### PR TITLE
Allow direct running of add.py example

### DIFF
--- a/examples/add.py
+++ b/examples/add.py
@@ -20,3 +20,21 @@ def add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     for tile in hl.tile(out.size()):
         out[tile] = x[tile] + y[tile]
     return out
+
+
+def check(m: int, n: int) -> None:
+    from triton.testing import do_bench
+
+    x = torch.randn([m, n], device="cuda", dtype=torch.float16)
+    y = torch.randn([m, n], device="cuda", dtype=torch.float16)
+    result = add(x, y)
+    torch.testing.assert_close(result, x + y, rtol=1e-2, atol=1e-1)
+    sec = do_bench(lambda: add(x, y))
+    baseline_sec = do_bench(lambda: torch.add(x, y))
+    print(
+        f"Helion time: {sec:.4f}s, torch time: {baseline_sec:.4f}, speedup: {baseline_sec / sec:.2f}x"
+    )
+
+
+if __name__ == "__main__":
+    check(1024, 1024)


### PR DESCRIPTION
Make `python examples/add.py` work.