### PR TITLE
Use site-package for torch in pyre_configuration

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -12,7 +12,7 @@
   ],
   "python_version": "3.9",
   "search_path": [
-      "../pytorch",
+      {"site-package": "torch"},
       {"site-package": "sympy"},
       {"site-package": "triton"}
   ],


### PR DESCRIPTION
The old version required PyTorch to be installed locally.  This make it work if you `pip install torch` or `python setup.py install` torch.

Annoyingly, it doesn't work with `python setup.py develop` torch -- can't figure out a pyre config that works with both, but this is a better default.