### PR TITLE
Adjust rtol/atol for test_sum_keepdims

### DIFF
--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -91,7 +91,7 @@ def sum_kernel(x: torch.Tensor):
         code, output = code_and_output(
             sum_kernel_keepdims, args, block_size=16, indexing="block_ptr"
         )
-        torch.testing.assert_close(output, args[0].sum(0, keepdim=True))
+        torch.testing.assert_close(output, args[0].sum(0, keepdim=True), rtol=2e-05, atol=1e-05)
         self.assertExpectedInline(
             code,
             """\


### PR DESCRIPTION
`test_sum_keepdims` seems to fail the accuracy check occasionally:
```
======================================================================
FAIL: test_sum_keepdims (test_reductions.TestReductions.test_sum_keepdims)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/pytorch-labs/helion/test/test_reductions.py", line 97, in test_sum_keepdims
    torch.testing.assert_close(output, args[0].sum(0, keepdim=True))
  File "/opt/conda/envs/venv/lib/python3.12/site-packages/torch/testing/_comparison.py", line 1587, in assert_close
    raise error_metas[0].to_error(msg)
AssertionError: Tensor-likes are not close!

Mismatched elements: 1 / 512 (0.2%)
Greatest absolute difference: 1.33514404296875e-05 at index (0, 407) (up to 1e-05 allowed)
Greatest relative difference: 7.88162651588209e-06 at index (0, 407) (up to 1.3e-06 allowed)
```

This PR slightly increases the tolerance to make the test more consistently pass the accuracy check.