### PR TITLE
[reland without ghstack] handle PTXASError

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 from typing import NamedTuple
 
 from torch._inductor.runtime.triton_compat import OutOfResources
+from torch._inductor.runtime.triton_compat import PTXASError
 import torch.multiprocessing as mp
 from triton.testing import do_bench
 
@@ -113,6 +114,8 @@ class BaseSearch:
             return res
         except OutOfResources:
             self.log.debug("Benchmarking failed: OutOfResources")
+        except PTXASError:
+            self.log.warning(f"PTXASError compiling config: {config}")
         except Exception as e:
             if not _expected_errors_regexp.search(str(e)):
                 raise exc.TritonError(f"{type(e).__qualname__}: {e}", config) from e

--- a/helion/runtime/precompile_shim.py
+++ b/helion/runtime/precompile_shim.py
@@ -50,8 +50,15 @@ def make_precompiler(fn: JITFunction[object]) -> Callable[..., Callable[[], None
             # pyre-ignore[16]
             src = fn.ASTSource(fn, signature, constexprs, attrs)
             # here we update the cache so if this is called in the parent we skip a extra compile
-            # pyre-ignore[16]
-            kernel_cache[key] = fn.compile(src, target=target, options=options.__dict__)
+            from triton.runtime.errors import PTXASError
+
+            try:
+                # pyre-ignore[16]
+                kernel_cache[key] = fn.compile(
+                    src, target=target, options=options.__dict__
+                )
+            except PTXASError:
+                return
 
         return finish_it
 


### PR DESCRIPTION
Copy of #71 without ghstack, since it doesn't work with new branch protection rules.