### PR TITLE
Use args provided to BoundKernel for autotune and caching

### DIFF
--- a/helion/autotuner/base_cache.py
+++ b/helion/autotuner/base_cache.py
@@ -8,7 +8,6 @@ import logging
 import os
 from typing import TYPE_CHECKING
 from typing import Hashable
-from typing import Sequence
 
 from torch._inductor.codecache import build_code_hash
 from torch._inductor.codecache import torch_key
@@ -114,12 +113,9 @@ class AutotuneCacheBase(abc.ABC):
     provide implementations for get and put methods.
     """
 
-    def __init__(
-        self, kernel: BoundKernel, args: Sequence[object], autotuner: BaseSearch
-    ) -> None:
+    def __init__(self, kernel: BoundKernel, autotuner: BaseSearch) -> None:
         self.autotuner = autotuner
         self.kernel = kernel
-        self.args = args
 
     @abc.abstractmethod
     def get(self) -> Config | None:

--- a/helion/autotuner/differential_evolution.py
+++ b/helion/autotuner/differential_evolution.py
@@ -11,7 +11,6 @@ from .base_search import population_statistics
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from collections.abc import Sequence
 
     from ..runtime.config import Config
     from ..runtime.kernel import BoundKernel
@@ -25,13 +24,12 @@ class DifferentialEvolutionSearch(PopulationBasedSearch):
     def __init__(
         self,
         kernel: BoundKernel,
-        args: Sequence[object],
         population_size: int = 40,
         num_generations: int = 20,
         crossover_rate: float = 0.8,
         immediate_update: bool | None = None,
     ) -> None:
-        super().__init__(kernel, args)
+        super().__init__(kernel)
         if immediate_update is None:
             immediate_update = not kernel.settings.autotune_precompile
         self.population_size = population_size

--- a/helion/autotuner/finite_search.py
+++ b/helion/autotuner/finite_search.py
@@ -6,8 +6,6 @@ from .. import exc
 from .base_search import BaseSearch
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
     from ..runtime.config import Config
     from ..runtime.kernel import BoundKernel
 
@@ -22,10 +20,9 @@ class FiniteSearch(BaseSearch):
     def __init__(
         self,
         kernel: BoundKernel,
-        args: Sequence[object],
         configs: list[Config] | None = None,
     ) -> None:
-        super().__init__(kernel, args)
+        super().__init__(kernel)
         self.configs: list[Config] = [*(configs or ())]
         if len(self.configs) == 0 and self.kernel.configs:
             self.configs.extend(self.kernel.configs)

--- a/helion/autotuner/local_cache.py
+++ b/helion/autotuner/local_cache.py
@@ -7,7 +7,6 @@ import os
 from pathlib import Path
 import textwrap
 from typing import TYPE_CHECKING
-from typing import Sequence
 
 import torch
 from torch._inductor.runtime.cache_dir_utils import (
@@ -38,17 +37,15 @@ class LocalAutotuneCache(AutotuneCacheBase):
     PyTorch. Use StrictLocalAutotuneCache to consider these properties.
     """
 
-    def __init__(
-        self, kernel: BoundKernel, args: Sequence[object], autotuner: BaseSearch
-    ) -> None:
-        super().__init__(kernel, args, autotuner)
+    def __init__(self, kernel: BoundKernel, autotuner: BaseSearch) -> None:
+        super().__init__(kernel, autotuner)
         self.key = self._generate_key()
 
     def _generate_key(self) -> LooseAutotuneCacheKey:
         in_memory_cache_key = self.kernel.kernel._create_bound_kernel_cache_key(
             self.kernel,
-            tuple(self.args),
-            self.kernel.kernel.specialization_key(self.args),
+            tuple(self.kernel.args),
+            self.kernel.kernel.specialization_key(self.kernel.args),
         )
         kernel_source = textwrap.dedent(inspect.getsource(self.kernel.kernel.fn))
         kernel_source_hash = hashlib.sha256(kernel_source.encode("utf-8")).hexdigest()
@@ -56,7 +53,7 @@ class LocalAutotuneCache(AutotuneCacheBase):
         hardware = None
         runtime_name = None
 
-        for arg in self.args:
+        for arg in self.kernel.args:
             if isinstance(arg, torch.Tensor):
                 device_properties = torch.cuda.get_device_properties(arg.device)
                 if torch.version.cuda is not None:  # pyright: ignore[reportAttributeAccessIssue]

--- a/helion/autotuner/random_search.py
+++ b/helion/autotuner/random_search.py
@@ -6,8 +6,6 @@ from .config_generation import ConfigGeneration
 from .finite_search import FiniteSearch
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
     from ..runtime.kernel import BoundKernel
 
 
@@ -23,18 +21,15 @@ class RandomSearch(FiniteSearch):
 
     Attributes:
         kernel (BoundKernel): The kernel to be tuned.
-        args (Sequence[object]): The arguments to be passed to the kernel.
         count (int): The number of random configurations to generate.
     """
 
     def __init__(
         self,
         kernel: BoundKernel,
-        args: Sequence[object],
         count: int = 1000,
     ) -> None:
         super().__init__(
             kernel,
-            args,
             configs=ConfigGeneration(kernel.config_spec).random_population(count),
         )

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -127,7 +127,7 @@ class TestAutotuner(TestCase):
             torch.randn([512, 512], device=DEVICE),
         )
         bound_kernel = examples_matmul.bind(args)
-        best = RandomSearch(bound_kernel, args, 5).autotune()
+        best = RandomSearch(bound_kernel, 5).autotune()
         fn = bound_kernel.compile_config(best)
         torch.testing.assert_close(fn(*args), args[0] @ args[1], rtol=1e-2, atol=1e-1)
 
@@ -138,7 +138,7 @@ class TestAutotuner(TestCase):
         )
         bound_kernel = examples_matmul.bind(args)
         best = DifferentialEvolutionSearch(
-            bound_kernel, args, 5, num_generations=3
+            bound_kernel, 5, num_generations=3
         ).autotune()
         fn = bound_kernel.compile_config(best)
         torch.testing.assert_close(fn(*args), args[0] @ args[1], rtol=1e-2, atol=1e-1)

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -28,10 +28,9 @@ class TestCache(TestCase):
         b = torch.randn(16, device=DEVICE, dtype=torch.float16)
         args_b = (b, b)
 
-        # TODO(oulgen): Using a custom autotuner is very verbose, requires passing args 3 times etc
         bound_kernel = basic_kernels.add.bind(args_a)
         config = StrictLocalAutotuneCache(
-            bound_kernel, args_a, BasicSearch(bound_kernel, args_a)
+            bound_kernel, BasicSearch(bound_kernel)
         ).autotune()
         bound_kernel.set_config(config)
         result = bound_kernel(*args_a)
@@ -45,7 +44,7 @@ class TestCache(TestCase):
 
         bound_kernel = basic_kernels.add.bind(args_a)
         config = StrictLocalAutotuneCache(
-            bound_kernel, args_a, BasicSearch(bound_kernel, args_a)
+            bound_kernel, BasicSearch(bound_kernel)
         ).autotune()
         bound_kernel.set_config(config)
         result = bound_kernel(*args_a)
@@ -59,7 +58,7 @@ class TestCache(TestCase):
 
         bound_kernel = basic_kernels.add.bind(args_b)
         config = StrictLocalAutotuneCache(
-            bound_kernel, args_b, BasicSearch(bound_kernel, args_b)
+            bound_kernel, BasicSearch(bound_kernel)
         ).autotune()
         bound_kernel.set_config(config)
         result = bound_kernel(*args_b)


### PR DESCRIPTION
Stacked PRs:
 * #389
 * #388
 * __->__#387


--- --- ---

### Use args provided to BoundKernel for autotune and caching


BoundKernel is already created via binding a Kernel with argument. We
can just reuse those instead of passing them again and again to autotune
and caching.
