### PR TITLE
Fix allow_tf32 warning

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -13,8 +13,8 @@ from helion._testing import check_example
 from helion._testing import import_path
 from helion._testing import skipIfRefEager
 
-torch.backends.cuda.matmul.allow_tf32 = True
-torch.backends.cudnn.allow_tf32 = True
+torch.backends.cuda.matmul.fp32_precision = "tf32"
+torch.backends.cudnn.conv.fp32_precision = "tf32"
 
 
 class TestExamples(RefEagerTestBase, TestCase):

--- a/test/test_matmul.py
+++ b/test/test_matmul.py
@@ -15,8 +15,8 @@ from helion._testing import code_and_output
 from helion._testing import import_path
 import helion.language as hl
 
-torch.backends.cuda.matmul.allow_tf32 = True
-torch.backends.cudnn.allow_tf32 = True
+torch.backends.cuda.matmul.fp32_precision = "tf32"
+torch.backends.cudnn.conv.fp32_precision = "tf32"
 examples_dir = Path(__file__).parent.parent / "examples"
 examples_matmul = import_path(examples_dir / "matmul.py").matmul
 


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #415
 * #414
 * __->__#413
 * #412
 * #411


--- --- ---

Fix allow_tf32 warning:

```
UserWarning: Please use the new API settings to control TF32 behavior, such as torch.backends.cudnn.conv.fp32_precision = 'tf32' or torch.backends.cuda.matmul.fp32_precision = 'ieee'. Old settings, e.g, torch.backends.cuda.matmul.allow_tf32 = True, torch.backends.cudnn.allow_tf32 = True, allowTF32CuDNN() and allowTF32CuBLAS() will be deprecated after Pytorch 2.9. Please see https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices (Triggered internally at /home/jansel/pytorch/aten/src/ATen/Context.cpp:80.)
```