### PR TITLE
Fix strided slice support for static slices (e.g., buf[::2])

### DIFF
--- a/helion/_compiler/utils.py
+++ b/helion/_compiler/utils.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch
+
+
+def compute_slice_size(
+    slice_obj: slice, original_size: int | torch.SymInt
+) -> int | torch.SymInt:
+    """
+    Compute the size of a slice operation.
+
+    Args:
+        slice_obj: The slice object with start, stop, and step attributes
+        original_size: The size of the dimension being sliced
+
+    Returns:
+        The size of the resulting sliced dimension
+    """
+    if slice_obj.step is not None and slice_obj.step != 1:
+        # Calculate size based on step
+        start = slice_obj.start if slice_obj.start is not None else 0
+        stop = slice_obj.stop if slice_obj.stop is not None else original_size
+        step = slice_obj.step
+        return (stop - start + step - 1) // step
+    # Full slice or slice without step
+    return original_size

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -689,7 +689,6 @@ class TestIndexing(RefEagerTestBase, TestCase):
         torch.testing.assert_close(src_result, expected_src)
         torch.testing.assert_close(dst_result, expected_dst)
 
-    @skipIfNormalMode("InternalError: AssertionError")
     def test_strided_slice(self):
         """Test both setter from scalar and getter for strided slices [::2] and [1::3]"""
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#426
 * #425
 * #424


--- --- ---

### Fix strided slice support for static slices (e.g., buf[::2])

