### PR TITLE
[generate_ast] providing AST args, and fall back to `api._codegen` when output is a tuple

### DIFF
--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -331,8 +331,9 @@ class GenerateAST(NodeVisitor, CodegenInterface):
             return api._codegen(  # pyright: ignore[reportReturnType]
                 CodegenState(
                     self,
-                    ast_args=[*ast_params.arguments.values()],
+                    None,
                     proxy_args=[*proxy_params.arguments.values()],
+                    ast_args=[*ast_params.arguments.values()],
                 )
             )
         return self.generic_visit(node)

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -289,18 +289,14 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                     block_info.from_config(self.device_function.config)
                 )
             )
-        elif (
-            isinstance(type_info, SequenceType)
-            and all(isinstance(x, TileIndexType) for x in type_info.unpack())
+        elif isinstance(type_info, SequenceType) and all(
+            isinstance(x, TileIndexType) for x in type_info.unpack()
         ):
             values = type_info.unpack()
             block_infos = [env.block_sizes[x.block_id] for x in values]  # pyright: ignore[reportAttributeAccessIssue]
             return expr_from_string(
                 self.host_function.literal_expr(
-                    [
-                        x.from_config(self.device_function.config)
-                        for x in block_infos
-                    ]
+                    [x.from_config(self.device_function.config) for x in block_infos]
                 )
             )
         elif (


### PR DESCRIPTION
This PR addresses two main points:
1. Piping AST arguments into `._codegen`
2. When the host-side function returns a sequence-like output but is not `TileIndexType`, correctly fallback to using `api._codegen`

Side note, I’m not entirely sure how to handle default AST arguments. For now, I’m just using `ast_params.apply_defaults()`, but I’m unsure if that’s the best way.