### PR TITLE
[Benchmark] Add try-catch for tritonbench import path

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -477,7 +477,10 @@ def run_kernel_variants(
             ["--input-id", str(start_idx), "--num-inputs", str(shard_size)]
         )
 
-    from tritonbench.run import run as tritonbench_run
+    try:
+        from tritonbench.run import run as tritonbench_run
+    except ImportError:
+        from pytorch.tritonbench.run import run as tritonbench_run
 
     tritonbench_run(tritonbench_args)
 


### PR DESCRIPTION
The tritonbench runner in fbcode has a weird `pytorch.` path prefix and it's difficult to remove it due to existing usage within fbcode. So we add a try-catch to handle this in `benchmarks/run.py`.