### PR TITLE
Handle new return type of triton's JITFunction.create_binder().

### DIFF
--- a/helion/runtime/precompile_shim.py
+++ b/helion/runtime/precompile_shim.py
@@ -25,7 +25,7 @@ def make_precompiler(fn: JITFunction[object]) -> Callable[..., Callable[[], None
         kwargs["debug"] = (
             kwargs.get("debug", fn.debug) or os.environ.get("TRITON_DEBUG", "0") == "1"
         )
-        kernel_cache, target, backend, binder = fn.device_caches[device]
+        kernel_cache, _, target, backend, binder = fn.device_caches[device]
         bound_args, specialization, options = binder(*args, **kwargs)
         key = str(specialization) + str(options)
         kernel = kernel_cache.get(key, None)


### PR DESCRIPTION
See https://github.com/triton-lang/triton/commit/5fe73f068607586790a4284d68f0509fb510103d#diff-aa69de5c38e9973824602394a4bbe32f374bc506b444ec6825f499747b8180ea