### PR TITLE
Lower symbolic slices to hl.arange

### DIFF
--- a/test/test_indexing.expected
+++ b/test/test_indexing.expected
@@ -45,6 +45,33 @@ def arange_block_size_mul(x: torch.Tensor, *, _launcher=_default_launcher):
     _launcher(_helion_arange_block_size_mul, (triton.cdiv(64, _BLOCK_SIZE_0),), out, _BLOCK_SIZE_0, 2 * _BLOCK_SIZE_0, num_warps=4, num_stages=3)
     return out
 
+
+--- assertExpectedJournal(TestIndexing.test_slice_block_size_multiple)
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from helion.runtime import default_launcher as _default_launcher
+
+@triton.jit
+def _helion_arange_block_size_mul(ones, out, _BLOCK_SIZE_0: tl.constexpr, mul_1: tl.constexpr):
+    pid_0 = tl.program_id(0)
+    offset_0 = pid_0 * _BLOCK_SIZE_0
+    mul = 2 * offset_0
+    iota = mul + tl.arange(0, mul_1)
+    load = tl.load(ones + iota * 1, None)
+    iota_1 = mul + tl.arange(0, mul_1)
+    tl.store(out + iota_1 * 1, load, None)
+
+def arange_block_size_mul(x: torch.Tensor, *, _launcher=_default_launcher):
+    out = torch.zeros([x.size(0) * 2], dtype=torch.int32, device=x.device)
+    ones = torch.ones_like(out)
+    _BLOCK_SIZE_0 = 64
+    _launcher(_helion_arange_block_size_mul, (triton.cdiv(64, _BLOCK_SIZE_0),), ones, out, _BLOCK_SIZE_0, 2 * _BLOCK_SIZE_0, num_warps=4, num_stages=3)
+    return out
+
+
 --- assertExpectedJournal(TestIndexing.test_arange_three_args_step)
 from __future__ import annotations
 


### PR DESCRIPTION
With this PR, we are able to support slicing with multiples-of-block-size as slice length, by lowering the slice to `hl.arange` (Related PR: https://github.com/pytorch/helion/pull/509).

```python
indices_start = tile.begin * 2
indices_end = indices_start + tile.block_size * 2
out[indices_start:indices_end] = ones[indices_start:indices_end]
```

This is part of https://github.com/pytorch/helion/issues/508.