### PR TITLE
[Fix CI] Work around missing return type at end of function for Triton build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,8 @@ jobs:
           git clone https://github.com/triton-lang/triton.git
           cd triton/
           uv pip install -r python/requirements.txt
-          MAX_JOBS=$(nproc) TRITON_PARALLEL_LINK_JOBS=2 uv pip install .
+          CFLAGS="-Wno-error=return-type" CXXFLAGS="-Wno-error=return-type" MAX_JOBS=$(nproc) TRITON_PARALLEL_LINK_JOBS=2 uv pip install .
+          python -c "import triton; print(f'Triton version: {triton.__version__}')"
           cd /tmp/$USER
           rm -rf triton/
 


### PR DESCRIPTION
Triton build on CI is failing with:
```
2025-08-30T09:17:30.2519473Z       FAILED: [code=1]
2025-08-30T09:17:30.2519860Z       lib/Dialect/TritonNvidiaGPU/IR/CMakeFiles/TritonNvidiaGPUIR.dir/Ops.cpp.o
2025-08-30T09:17:30.2520314Z       /usr/bin/g++-13 -DGTEST_HAS_RTTI=0
2025-08-30T09:17:30.2520769Z       -I/tmp/triton/build/cmake.linux-x86_64-cpython-3.10/lib/Dialect/TritonNvidiaGPU/IR
2025-08-30T09:17:30.2521358Z       -I/tmp/triton/lib/Dialect/TritonNvidiaGPU/IR
2025-08-30T09:17:30.2521688Z       -I/tmp/triton/include -I/tmp/triton/.
2025-08-30T09:17:30.2522066Z       -I/github/home/.triton/llvm/llvm-064f02da-ubuntu-x64/include
2025-08-30T09:17:30.2522511Z       -I/tmp/triton/build/cmake.linux-x86_64-cpython-3.10/include
2025-08-30T09:17:30.2522894Z       -I/tmp/triton/third_party
2025-08-30T09:17:30.2523257Z       -I/tmp/triton/build/cmake.linux-x86_64-cpython-3.10/third_party
2025-08-30T09:17:30.2523696Z       -D__STDC_FORMAT_MACROS  -fPIC -std=gnu++17 -Werror
2025-08-30T09:17:30.2524095Z       -Wno-covered-switch-default -fvisibility=hidden -O2 -g
2025-08-30T09:17:30.2524539Z       -std=gnu++17  -fno-exceptions -funwind-tables -fno-rtti -MD -MT
2025-08-30T09:17:30.2525081Z       lib/Dialect/TritonNvidiaGPU/IR/CMakeFiles/TritonNvidiaGPUIR.dir/Ops.cpp.o
2025-08-30T09:17:30.2525508Z       -MF
2025-08-30T09:17:30.2525881Z       lib/Dialect/TritonNvidiaGPU/IR/CMakeFiles/TritonNvidiaGPUIR.dir/Ops.cpp.o.d
2025-08-30T09:17:30.2526331Z       -o
2025-08-30T09:17:30.2526684Z       lib/Dialect/TritonNvidiaGPU/IR/CMakeFiles/TritonNvidiaGPUIR.dir/Ops.cpp.o
2025-08-30T09:17:30.2527191Z       -c /tmp/triton/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
2025-08-30T09:17:30.2527584Z       /tmp/triton/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp:
2025-08-30T09:17:30.2528207Z       In function ‘std::string
2025-08-30T09:17:30.2528650Z       mlir::triton::nvidia_gpu::strMMADTypeKind({anonymous}::MMADTypeKind)’:
2025-08-30T09:17:30.2529194Z       /tmp/triton/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp:280:1: error: control
2025-08-30T09:17:30.2529685Z       reaches end of non-void function [-Werror=return-type]
2025-08-30T09:17:30.2530007Z         280 | }
2025-08-30T09:17:30.2530198Z             | ^
2025-08-30T09:17:30.2530395Z       At global scope:
2025-08-30T09:17:30.2530670Z       cc1plus: note: unrecognized command-line option
2025-08-30T09:17:30.2531548Z       ‘-Wno-covered-switch-default’ may have been intended to silence earlier
2025-08-30T09:17:30.2531979Z       diagnostics
2025-08-30T09:17:30.2532225Z       cc1plus: all warnings being treated as errors
```
Adding `-Wno-error=return-type` to work around now, and I also opened a PR to fix it properly at upstream Triton repo: https://github.com/triton-lang/triton/pull/8019. 