### PR TITLE
Fix local runs for test_triton_repro tests

### DIFF
--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -457,7 +457,10 @@ class TestMisc(RefEagerTestBase, TestCase):
                 capture_output=True,
                 text=True,
                 cwd=PROJECT_ROOT,
-                env={**os.environ, "PYTHONPATH": str(PROJECT_ROOT)},
+                env={
+                    **os.environ,
+                    "PYTHONPATH": f"{PROJECT_ROOT}{os.pathsep}{os.environ.get('PYTHONPATH', '')}",
+                },
             )
             self.assertEqual(result.returncode, 0, msg=f"stderr:\n{result.stderr}")
         self.assertExpectedJournal(code)
@@ -486,7 +489,10 @@ class TestMisc(RefEagerTestBase, TestCase):
                 capture_output=True,
                 text=True,
                 cwd=PROJECT_ROOT,
-                env={**os.environ, "PYTHONPATH": str(PROJECT_ROOT)},
+                env={
+                    **os.environ,
+                    "PYTHONPATH": f"{PROJECT_ROOT}{os.pathsep}{os.environ.get('PYTHONPATH', '')}",
+                },
             )
             self.assertEqual(
                 result.returncode, 0, msg=f"code:{code}\nstderr:\n{result.stderr}"


### PR DESCRIPTION
Before the fix, they fail with:
```
____________________________________________________________ TestMisc.test_triton_repro_custom_static_shapes_True _____________________________________________________________

self = <test.test_misc.TestMisc testMethod=test_triton_repro_custom_static_shapes_True>, static_shapes = True

    @skipIfRefEager("no code execution")
    @parametrize("static_shapes", (True, False))
    def test_triton_repro_custom(self, static_shapes):
        @helion.kernel(static_shapes=static_shapes)
        def kernel(t: torch.Tensor, i: int, s: str, b: bool, f: float) -> torch.Tensor:
            out = torch.empty_like(t)
            for tile in hl.tile(t.size()):
                if b and len(s) > 2:
                    out[tile] = t[tile] + i + f
            return out
    
        a = torch.randn(16, 1, device=DEVICE)
        bound_kernel = kernel.bind((a, 1, "foo", True, 1.2))
        code = bound_kernel.to_triton_code(
            config=bound_kernel.config_spec.default_config(), emit_repro_caller=True
        )
        with tempfile.TemporaryDirectory() as tmpdir:
            tmp = Path(tmpdir) / "test.py"
            tmp.write_text(code)
            result = subprocess.run(
                [sys.executable, str(tmp)],
                capture_output=True,
                text=True,
                cwd=PROJECT_ROOT,
                env={**os.environ, "PYTHONPATH": str(PROJECT_ROOT)},
            )
>           self.assertEqual(
                result.returncode, 0, msg=f"code:{code}\nstderr:\n{result.stderr}"
            )
E           AssertionError: 1 != 0 : code:from __future__ import annotations
E           
E           import torch
E           import triton
E           import triton.language as tl
E           from helion.runtime import default_launcher as _default_launcher
E           
E           @triton.jit
E           def _helion_kernel(t, out, b, i, f, _BLOCK_SIZE_0: tl.constexpr):
E               num_blocks_0 = tl.cdiv(16, _BLOCK_SIZE_0)
E               pid_0 = tl.program_id(0) % num_blocks_0
E               offset_0 = pid_0 * _BLOCK_SIZE_0
E               indices_0 = (offset_0 + tl.arange(0, _BLOCK_SIZE_0)).to(tl.int32)
E               _and = b and True
E               if _and:
E                   load = tl.load(t + indices_0[:, None] * 1, None)
E                   v_0 = i.to(tl.float32)
E                   v_1 = load + v_0
E                   v_2 = v_1 + f
E                   tl.store(out + indices_0[:, None] * 1, v_2, None)
E           
E           def kernel(t: torch.Tensor, i: int, s: str, b: bool, f: float, *, _launcher=_default_launcher):
E               out = torch.empty_like(t)
E               _BLOCK_SIZE_0 = 16
E               _launcher(_helion_kernel, (triton.cdiv(16, _BLOCK_SIZE_0) * 1,), t, out, b, i, f, _BLOCK_SIZE_0, num_warps=4, num_stages=3)
E               return out
E           
E           def call():
E               from torch._dynamo.testing import rand_strided
E               t = rand_strided(size=(16, 1), stride=(1, 1), dtype=torch.float32, device='cuda:0')
E               i = 8192
E               s = 'foo'
E               b = False
E               f = 1.1
E               kernel(t, i, s, b, f)
E           if __name__ == '__main__':
E               call()
E           stderr:
E           Traceback (most recent call last):
E             File "/tmp/tmpt_o3foqe/test.py", line 3, in <module>
E               import torch
E           ModuleNotFoundError: No module named 'torch'

test/test_misc.py:491: AssertionError
```