### PR TITLE
[Fix CI] Convert tiles to sizes for all torch.* functions

### DIFF
--- a/helion/language/tile_proxy.py
+++ b/helion/language/tile_proxy.py
@@ -79,6 +79,15 @@ class Tile(TileInterface, torch.Tensor):
             index_calls.count += 1
         if func is torch.Tensor.__format__:
             return repr(args[0])
+
+        # For any other torch.* function or torch.Tensor.* method, convert tiles to sizes
+        is_torch_func = getattr(func, "__module__", "") == "torch"
+        is_tensor_method = hasattr(torch.Tensor, getattr(func, "__name__", ""))
+        if is_torch_func or is_tensor_method:
+            new_args = cls._tiles_to_sizes(args)
+            new_kwargs = cls._tiles_to_sizes(kwargs) if kwargs else {}
+            return func(*new_args, **new_kwargs)
+
         raise exc.IncorrectTileUsage(func)
 
     @staticmethod


### PR DESCRIPTION
After PyTorch upstream PR https://github.com/pytorch/pytorch/pull/160256, Helion CI is failing with errors like:
```
FAILED test/test_views.py::TestViews::test_softmax_view_reshape - helion.exc.IncorrectTileUsage: Tiles can only be used in tensor indexing (`x[tile]`) or in `hl.*` ops (e.g. `hl.zeros(tile)`), used in <method 'view' of 'torch._C.TensorBase' objects>
While processing:
  File "/__w/helion/helion/test/test_views.py", line 45, in softmax
    amax = torch.amax(values, dim=1).view(tile_n, 1)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
This PR fixes it.