### PR TITLE
Print warning if block_size is specified in interpret mode.

### DIFF
--- a/helion/exc.py
+++ b/helion/exc.py
@@ -335,6 +335,10 @@ class WrongDevice(BaseWarning):
     message = "Operation {0} returned a tensor on {1} device, but the kernel is on {2} device."
 
 
+class BlockSizeIgnoredInInterpretMode(BaseWarning):
+    message = "block_size is specified to be {0}, but in interpret mode, the full dimension size is always used."
+
+
 class AutotuningDisallowedInEnvironment(BaseError):
     message = "Autotuning is disabled {0}, please provide a config to @helion.kernel via the config= argument."
 

--- a/helion/language/loops.py
+++ b/helion/language/loops.py
@@ -23,6 +23,7 @@ from .._compiler.ast_extension import ExtendedAST
 from .._compiler.ast_extension import LoopType
 from .._compiler.ast_extension import expr_from_string
 from .._compiler.compile_environment import CompileEnvironment
+from .._compiler.compile_environment import warning
 from .._compiler.type_propagation import GridIndexType
 from .._compiler.type_propagation import IterType
 from .._compiler.type_propagation import LiteralType
@@ -496,6 +497,10 @@ def _(
     end_or_none: int | torch.Tensor | list[int | torch.Tensor] | None = None,
     block_size: int | torch.Tensor | list[int | torch.Tensor] | None = None,
 ) -> Iterator[RefTile | tuple[RefTile, ...]]:
+    # Issue warning if block_size is specified in interpret mode
+    if block_size is not None:
+        warning(exc.BlockSizeIgnoredInInterpretMode(block_size))
+
     # Step 1: Normalize begin and end values
     begin, end = _normalize_begin_end_ref(begin_or_end, end_or_none)
 


### PR DESCRIPTION
Warns users when they specify block_size parameters to hl.tile() in interpret mode, since the block_size is ignored and full dimension size is always used in interpret mode.
Added a testcase to check that a warning is printed when block_size is specified in interpret mode.

Addresses issue: https://github.com/pytorch/helion/issues/466