### PR TITLE
Do not benchmark twice

### DIFF
--- a/helion/autotuner/differential_evolution.py
+++ b/helion/autotuner/differential_evolution.py
@@ -81,7 +81,6 @@ class DifferentialEvolutionSearch(PopulationBasedSearch):
     def evolve_population(self) -> int:
         replaced = 0
         for i, candidate in self.iter_candidates():
-            candidate = self.benchmark_flat(self.mutate(i))
             if candidate.perf < self.population[i].perf:
                 self.population[i] = candidate
                 replaced += 1


### PR DESCRIPTION
Stacked PRs:
 * __->__#583


--- --- ---

### Do not benchmark twice


currently we end up compiling the same kernel 4 times i think. 1
precompile and 1 cached compile during iter_candidates and another set
of these again in benchmark_flat.