### PR TITLE
Fix tf32 warning

### DIFF
--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -429,7 +429,8 @@ def run_example(
         rtol: Relative tolerance for correctness check (default: 1e-2)
         atol: Absolute tolerance for correctness check (default: 1e-1)
     """
-    torch.set_float32_matmul_precision("high")
+    torch.backends.cuda.matmul.fp32_precision = "tf32"
+    torch.backends.cudnn.conv.fp32_precision = "tf32"  # type: ignore[reportAttributeAccessIssue]
 
     # Normalize to dict format
     kernels = kernel_fn if isinstance(kernel_fn, dict) else {kernel_name: kernel_fn}


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #595
 * __->__#592


--- --- ---

Fix tf32 warning

```
UserWarning: Please use the new API settings to control TF32 behavior, such as
▌torch.backends.cudnn.conv.fp32_precision = 'tf32' or torch.backends.cuda.matmul.fp32_precision = 'ieee'. Old settings, e.g,
▌torch.backends.cuda.matmul.allow_tf32 = True, torch.backends.cudnn.allow_tf32 = True, allowTF32CuDNN() and allowTF32CuBLAS()
▌will be deprecated after Pytorch 2.9.
```