### PR TITLE
Login to Docker from the workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,6 +35,9 @@ jobs:
     container:
       image: ${{ inputs.image }}
       options: ${{ inputs.container-options }}
+      credentials:
+        username: pytorchbot
+        password: ${{ secrets.DOCKER_HUB_READONLY_TOKEN }}
 
     runs-on: ${{ inputs.runner }}
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,9 @@ jobs:
     container:
       image: ${{ matrix.image }}
       options: ${{ matrix.container-options }}
+      credentials:
+        username: pytorchbot
+        password: ${{ secrets.DOCKER_HUB_READONLY_TOKEN }}
 
     runs-on: ${{ matrix.runner }}
 


### PR DESCRIPTION
Because Helion uses [GitHub container](https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/run-jobs-in-a-container) right at the beginning of the jobs, all my attempts to login to Docker on the runner side before the job were foiled.  Let's do this on the workflow instead.  This requires adding a secret on Helion, but it's ok as a read-only account to Docker.