### PR TITLE
[Reland] Login to Docker from the workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,6 +35,9 @@ jobs:
     container:
       image: ${{ inputs.image }}
       options: ${{ inputs.container-options }}
+      credentials:
+        username: pytorchbot
+        password: ${{ secrets.DOCKER_HUB_READONLY_TOKEN }}
 
     runs-on: ${{ inputs.runner }}
     permissions:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,6 +24,8 @@ on:
 
 jobs:
   benchmark:
+    # Won't work when the secret is empty on DGX B200 runners
+    if: ${{ !contains(matrix.runner, 'b200') || secrets.DOCKER_HUB_READONLY_TOKEN != '' }}
     name: benchmark-${{ inputs.runtime-version }}-py${{ inputs.python-version }}-${{ inputs.alias }}
 
     strategy:
@@ -37,7 +39,7 @@ jobs:
       options: ${{ inputs.container-options }}
       credentials:
         username: pytorchbot
-        password: ${{ secrets.DOCKER_HUB_READONLY_TOKEN }}
+        password: ${{ secrets.DOCKER_HUB_READONLY_TOKEN || '' }}
 
     runs-on: ${{ inputs.runner }}
     permissions:

--- a/.github/workflows/benchmark_dispatch.yml
+++ b/.github/workflows/benchmark_dispatch.yml
@@ -30,6 +30,7 @@ jobs:
       runtime-version: cu129
       container-options: --gpus all
       alias: h100
+    secrets: inherit
 
   run-b200:
     if: ${{ github.event.inputs.run_b200 == 'true' || github.event_name == 'schedule' }}
@@ -44,3 +45,4 @@ jobs:
       runtime-version: cu129
       container-options: --gpus all
       alias: b200
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,9 @@ jobs:
     container:
       image: ${{ matrix.image }}
       options: ${{ matrix.container-options }}
+      credentials:
+        username: pytorchbot
+        password: ${{ secrets.DOCKER_HUB_READONLY_TOKEN }}
 
     runs-on: ${{ matrix.runner }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
   test:
+    # Won't work when the secret is empty on DGX B200 runners
+    if: ${{ !contains(matrix.runner, 'b200') || secrets.DOCKER_HUB_READONLY_TOKEN != '' }}
     needs: load-matrix
 
     strategy:
@@ -40,7 +42,7 @@ jobs:
       options: ${{ matrix.container-options }}
       credentials:
         username: pytorchbot
-        password: ${{ secrets.DOCKER_HUB_READONLY_TOKEN }}
+        password: ${{ secrets.DOCKER_HUB_READONLY_TOKEN || '' }}
 
     runs-on: ${{ matrix.runner }}
 


### PR DESCRIPTION
Reland https://github.com/pytorch/helion/pull/601 with a couple of additional safe guards:
- Only run the test and benchmark workflows on b200 when the secret is not empty
- Use `secrets: inherit` in .github/workflows/benchmark_dispatch.yml to allow it to pass secret to .github/workflows/benchmark.yml

### Testing

This is a forked PR from https://github.com/huydhn/helion, so it doesn't have access to the secret