### PR TITLE
[Benchmark CI] Print input shapes and surface problematic Helion config

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -32,6 +32,8 @@ from .logger import LambdaLogger
 from .logger import classify_triton_exception
 from .logger import format_triton_compile_failure
 
+log = logging.getLogger(__name__)
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -176,6 +178,13 @@ class BaseSearch(BaseAutotuner):
             precompiler = make_precompiler(e.kernel, config)(*e.args, **e.kwargs)
             if precompiler is already_compiled:
                 return PrecompileFuture.skip(self, config, True)
+        except Exception:
+            log.warning(
+                "Helion autotuner precompile error for config %r",
+                config,
+                exc_info=True,
+            )
+            raise
         process: mp.Process = ctx.Process(target=precompiler)  # pyright: ignore[reportAssignmentType]
         return PrecompileFuture(
             search=self,

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -425,10 +425,18 @@ class BoundKernel(Generic[_R]):
             )
         if (rv := self._compile_cache.get(config)) is not None:
             return rv
-        triton_code = self.to_triton_code(
-            config, emit_repro_caller=self.settings.print_output_code
-        )
-        module = PyCodeCache.load(triton_code)
+        try:
+            triton_code = self.to_triton_code(
+                config, emit_repro_caller=self.settings.print_output_code
+            )
+            module = PyCodeCache.load(triton_code)
+        except Exception:
+            log.warning(
+                "Helion compiler triton codegen error for config %r",
+                config,
+                exc_info=True,
+            )
+            raise
         if allow_print:
             log.info("Output code: \n%s", triton_code)
             log.info("Output code written to: %s", module.__file__)


### PR DESCRIPTION
Trying to use this debugging util to find out which shapes + config causes error in benchmark CI.