### PR TITLE
Adjust tolerance for test_rms_norm_bwd_dx

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -413,8 +413,8 @@ class TestExamples(RefEagerTestBase, TestCase):
                 block_size=32,
                 num_warps=4,
                 num_stages=3,
-                rtol=1e-3,
-                atol=1e-3,
+                rtol=2e-3,
+                atol=5e-3,
             )
         )
 


### PR DESCRIPTION
Recently I have seen this mismatch error on CI:
```
FAILED test/test_examples.py::TestExamples::test_rms_norm_bwd_dx - AssertionError: Tensor-likes are not close!

Mismatched elements: 1 / 2048 (0.0%)
Greatest absolute difference: 0.00146484375 at index (29, 19) (up to 0.001 allowed)
Greatest relative difference: 0.004338394850492477 at index (29, 19) (up to 0.001 allowed)
```
e.g. https://github.com/pytorch/helion/actions/runs/17841339611/job/50731357865?pr=620