### PR TITLE
[Easy][Benchmark CI] Exit job on any exception, for easier error catching

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -137,6 +137,7 @@ jobs:
               --kernel $KERNEL_LIST \
               --metrics speedup,accuracy \
               --latency-measure-mode profiler \
+              --exit-on-exception
 
           # Relax the GPU
           sleep 5m
@@ -146,7 +147,8 @@ jobs:
               --kernel $KERNEL_LIST \
               --metrics speedup,accuracy \
               --latency-measure-mode profiler \
-              --output "$TEST_REPORTS_DIR/helionbench.json"
+              --output "$TEST_REPORTS_DIR/helionbench.json" \
+              --exit-on-exception
 
           if [[ ! -s "$TEST_REPORTS_DIR/helionbench.json" ]]; then
             echo "❌ helionbench.json is missing or empty"


### PR DESCRIPTION
Currently tritonbench swallows all exceptions and proceeds to the next input shape, which makes legitimate exceptions hard to find in the log. With this PR, it will now exit the benchmark CI job on any exception.