### PR TITLE
Add `HELION_AUTOTUNE_RANDOM_SEED` env var and `autotune_random_seed` setting

### DIFF
--- a/docs/api/autotuner.md
+++ b/docs/api/autotuner.md
@@ -45,3 +45,7 @@ The autotuner supports multiple search strategies:
 .. automodule:: helion.autotuner.finite_search
    :members:
 ```
+
+## Environment Variables
+
+- `HELION_AUTOTUNE_RANDOM_SEED`: Seed Python's random module before autotune; when unset, Helion seeds from the current time so runs remain non-deterministic by default. You can also set ``autotune_random_seed=...`` on ``@helion.kernel`` to control it per-kernel.

--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -130,6 +130,10 @@ with helion.set_default_settings(
 .. autoattribute:: Settings.autotune_precompile
 
    Whether to precompile kernels before autotuning. Default is ``True`` on non-Windows systems, ``False`` on Windows.
+
+.. autoattribute:: Settings.autotune_random_seed
+
+   Seed used for autotuner random number generation. Defaults to ``HELION_AUTOTUNE_RANDOM_SEED`` if set, otherwise a time-based value.
 ```
 
 ### Debugging and Development

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -11,6 +11,7 @@ import math
 from math import inf
 from multiprocessing import connection
 import os
+import random
 import sys
 import time
 from typing import TYPE_CHECKING
@@ -84,6 +85,7 @@ class BaseSearch(BaseAutotuner):
         self.args = args
         self.counters: collections.Counter[str] = collections.Counter()
         self.log = LambdaLogger(self.settings.autotune_log_level)
+        random.seed(self.settings.autotune_random_seed)
 
     def benchmark(self, config: Config) -> float:
         """
@@ -180,8 +182,9 @@ class BaseSearch(BaseAutotuner):
                 return PrecompileFuture.skip(self, config, True)
         except Exception:
             log.warning(
-                "Helion autotuner precompile error for config %r",
+                "Helion autotuner precompile error for config %r, settings %r",
                 config,
+                self.settings,
                 exc_info=True,
             )
             raise

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -432,8 +432,9 @@ class BoundKernel(Generic[_R]):
             module = PyCodeCache.load(triton_code)
         except Exception:
             log.warning(
-                "Helion compiler triton codegen error for config %r",
+                "Helion compiler triton codegen error for config %r, settings %r",
                 config,
+                self.settings,
                 exc_info=True,
             )
             raise

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 import threading
+import time
 from typing import TYPE_CHECKING
 from typing import Literal
 from typing import Protocol
@@ -68,6 +69,13 @@ def default_autotuner_fn(
     return LocalAutotuneCache(DifferentialEvolutionSearch(bound_kernel, args, **kwargs))  # pyright: ignore[reportArgumentType]
 
 
+def _get_autotune_random_seed() -> int:
+    value = os.environ.get("HELION_AUTOTUNE_RANDOM_SEED")
+    if value is not None:
+        return int(value)
+    return int(time.time() * 1000) % 2**32
+
+
 @dataclasses.dataclass
 class _Settings:
     # see __slots__ below for the doc strings that show up in help(Settings)
@@ -87,6 +95,9 @@ class _Settings:
     )
     autotune_precompile: bool = sys.platform != "win32"
     autotune_precompile_jobs: int | None = None
+    autotune_random_seed: int = dataclasses.field(
+        default_factory=_get_autotune_random_seed
+    )
     print_output_code: bool = os.environ.get("HELION_PRINT_OUTPUT_CODE", "0") == "1"
     force_autotune: bool = os.environ.get("HELION_FORCE_AUTOTUNE", "0") == "1"
     allow_warp_specialize: bool = (
@@ -115,6 +126,7 @@ class Settings(_Settings):
         "autotune_compile_timeout": "Timeout for Triton compilation in seconds used for autotuning. Default is 60 seconds.",
         "autotune_precompile": "If True, precompile the kernel before autotuning. Requires fork-safe environment.",
         "autotune_precompile_jobs": "Maximum concurrent Triton precompile processes, default to cpu count.",
+        "autotune_random_seed": "Seed used for autotuner random number generation. Defaults to HELION_AUTOTUNE_RANDOM_SEED or a time-based seed.",
         "print_output_code": "If True, print the output code of the kernel to stderr.",
         "force_autotune": "If True, force autotuning even if a config is provided.",
         "allow_warp_specialize": "If True, allow warp specialization for tl.range calls on CUDA devices.",

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 import os
 from pathlib import Path
 import random
@@ -27,6 +28,27 @@ datadir = Path(__file__).parent / "data"
 basic_kernels = import_path(datadir / "basic_kernels.py")
 examples_dir = Path(__file__).parent.parent / "examples"
 examples_matmul = import_path(examples_dir / "matmul.py").matmul
+
+
+@contextmanager
+def without_env_var(name: str):
+    sentinel = object()
+    previous = os.environ.pop(name, sentinel)
+    try:
+        yield
+    finally:
+        if previous is not sentinel:
+            os.environ[name] = previous
+
+
+class RecordingRandomSearch(RandomSearch):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.samples: list[float] = []
+
+    def _autotune(self):
+        self.samples.append(random.random())
+        return super()._autotune()
 
 
 class TestAutotuner(RefEagerTestDisabled, TestCase):
@@ -185,6 +207,76 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             ),
         ):
             add(*args)
+
+
+class TestAutotuneRandomSeed(TestCase):
+    def _autotune_and_record(self, **settings: object) -> float:
+        search_capture: dict[str, RecordingRandomSearch] = {}
+
+        def autotuner_factory(bound_kernel, args, **kwargs):
+            search = RecordingRandomSearch(bound_kernel, args, count=4, **kwargs)
+            search_capture["search"] = search
+            return search
+
+        kernel_settings = {
+            "autotuner_fn": autotuner_factory,
+        }
+        kernel_settings.update(settings)
+
+        @helion.kernel(**kernel_settings)
+        def add(a, b):
+            out = torch.empty_like(a)
+            for tile in hl.tile(out.size()):
+                out[tile] = a[tile] + b[tile]
+            return out
+
+        args = (
+            torch.randn([8, 32], device=DEVICE),
+            torch.randn([8, 32], device=DEVICE),
+        )
+        bound_kernel = add.bind(args)
+        bound_kernel.autotune(args)
+        torch.testing.assert_close(bound_kernel(*args), sum(args), rtol=1e-2, atol=1e-1)
+
+        search = search_capture["search"]
+        assert search.samples, (
+            "expected RecordingRandomSearch to record a random sample"
+        )
+        return search.samples[0]
+
+    def test_autotune_random_seed_from_env_var(self) -> None:
+        # same env var value -> same random sample
+        with patch.dict(
+            os.environ, {"HELION_AUTOTUNE_RANDOM_SEED": "4242"}, clear=False
+        ):
+            first = self._autotune_and_record()
+        with patch.dict(
+            os.environ, {"HELION_AUTOTUNE_RANDOM_SEED": "4242"}, clear=False
+        ):
+            second = self._autotune_and_record()
+        self.assertEqual(first, second)
+
+        # different env var values -> different random samples
+        with patch.dict(
+            os.environ, {"HELION_AUTOTUNE_RANDOM_SEED": "101"}, clear=False
+        ):
+            first = self._autotune_and_record()
+        with patch.dict(
+            os.environ, {"HELION_AUTOTUNE_RANDOM_SEED": "102"}, clear=False
+        ):
+            second = self._autotune_and_record()
+        self.assertNotEqual(first, second)
+
+    def test_autotune_random_seed_from_settings(self) -> None:
+        # same autotune_random_seed setting -> same random sample
+        first = self._autotune_and_record(autotune_random_seed=4242)
+        second = self._autotune_and_record(autotune_random_seed=4242)
+        self.assertEqual(first, second)
+
+        # different autotune_random_seed settings -> different random samples
+        first = self._autotune_and_record(autotune_random_seed=101)
+        second = self._autotune_and_record(autotune_random_seed=102)
+        self.assertNotEqual(first, second)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Errors like https://github.com/pytorch/helion/issues/634 is quite hard to deterministically reproduce (it repros but at different generations each time). Also in the future for user error reports on autotuning, including a deterministic seed helps with our repro as well.