### PR TITLE
Avoid skipping CUDA errors that crashes the CUDA context

### DIFF
--- a/helion/autotuner/logger.py
+++ b/helion/autotuner/logger.py
@@ -108,8 +108,6 @@ _EXPECTED_TRITON_ERRORS_RE: re.Pattern[str] = re.compile(
             re.escape,
             [
                 "[CUDA]: invalid argument",  # CUDA Error
-                "misaligned address",  # CUDA Error
-                "illegal memory access",  # CUDA Error
                 "PassManager::run failed",  # Triton Error
                 "TServiceRouterException",  # Remote compile failed
             ],


### PR DESCRIPTION
We actually want the CUDA-context-crashing errors to bubble up and terminates the autotuning process, to be able to identify them more easily (and also the CUDA context is already crashed at that point so future CUDA launches won't be working anyways). This would help surface errors like https://github.com/pytorch/helion/issues/634.