### PR TITLE
Log autotune random seed for easier repro

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -88,7 +88,9 @@ class BaseSearch(BaseAutotuner):
         self.args: Sequence[object] = args
         self.counters: collections.Counter[str] = collections.Counter()
         self.log = LambdaLogger(self.settings.autotune_log_level)
-        random.seed(self.settings.autotune_random_seed)
+        seed = self.settings.autotune_random_seed
+        random.seed(seed)
+        self.log(f"Autotune random seed: {seed}")
         self._original_args: Sequence[object] = self._clone_args(self.args)
         (
             self._baseline_output,


### PR DESCRIPTION
This has been helpful for reproing the "misaligned address" error in matmul https://github.com/pytorch/helion/pull/654#issuecomment-3325201565.