### PR TITLE
Increase default num_generations to 40

### DIFF
--- a/helion/autotuner/differential_evolution.py
+++ b/helion/autotuner/differential_evolution.py
@@ -27,7 +27,7 @@ class DifferentialEvolutionSearch(PopulationBasedSearch):
         kernel: BoundKernel,
         args: Sequence[object],
         population_size: int = 40,
-        num_generations: int = 20,
+        num_generations: int = 40,
         crossover_rate: float = 0.8,
         immediate_update: bool | None = None,
     ) -> None:


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #696
 * __->__#677
 * #654


--- --- ---

### Increase default num_generations to 40

I've been seeing improvements in generation 35 for more complex kernels.