### PR TITLE
[Autotune] Allow skipping Triton compilation error

### DIFF
--- a/helion/autotuner/logger.py
+++ b/helion/autotuner/logger.py
@@ -110,6 +110,7 @@ _EXPECTED_TRITON_ERRORS_RE: re.Pattern[str] = re.compile(
                 "[CUDA]: invalid argument",  # CUDA Error
                 "PassManager::run failed",  # Triton Error
                 "TServiceRouterException",  # Remote compile failed
+                "triton.compiler.errors.CompilationError",  # Triton CompilationError
             ],
         )
     )


### PR DESCRIPTION
Sometimes we do run into these errors and it's hard to proactively skip these configs (e.g. int4_gemm with small block sizes [1, 1, 16], but due to gemm block sizes being symbolic we couldn't apply padding to it. And then we will run into Triton compilation error due to dot size too small).