### PR TITLE
[CI] Fix missing setuptools

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           source .venv/bin/activate
           uv pip install -r requirements.txt
-          uv pip install pytest-timeout
+          uv pip install pytest-timeout setuptools
 
       - name: Run Tests
         run: |


### PR DESCRIPTION
CI error: https://github.com/pytorch/helion/actions/runs/17997155423/job/51198778661?pr=679
```
______________________ ERROR collecting test/test_misc.py ______________________
ImportError while importing test module '/__w/helion/helion/test/test_misc.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/github/home/.local/share/uv/python/cpython-3.10.18-linux-x86_64-gnu/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
test/test_misc.py:15: in <module>
    from torch.testing._internal.common_utils import instantiate_parametrized_tests
.venv/lib/python3.10/site-packages/torch/testing/_internal/common_utils.py:96: in <module>
    from torch.utils import cpp_extension
.venv/lib/python3.10/site-packages/torch/utils/cpp_extension.py:10: in <module>
    import setuptools
E   ModuleNotFoundError: No module named 'setuptools'
=========================== short test summary info ============================
ERROR test/test_misc.py
```