### PR TITLE
[Benchmark CI] Run one kernel per gpu to maximize successful kernel reporting

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,8 +29,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4]
-        num_shards: [5]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        num_shards: [10]
 
     container:
       image: ${{ inputs.image }}


### PR DESCRIPTION
Since we need to report perf very soon, I will make this change to maximize # kernels that has successful reporting.