### PR TITLE
[Autotune] Skip Triton shared memory OOM

### DIFF
--- a/helion/autotuner/logger.py
+++ b/helion/autotuner/logger.py
@@ -111,6 +111,7 @@ _EXPECTED_TRITON_ERRORS_RE: re.Pattern[str] = re.compile(
                 "PassManager::run failed",  # Triton Error
                 "TServiceRouterException",  # Remote compile failed
                 "triton.compiler.errors.CompilationError",  # Triton CompilationError
+                "out of resource: shared memory",  # Triton shared memory OOM
             ],
         )
     )


### PR DESCRIPTION
I believe this error can happen for some configs, and it's recoverable.

Fixes https://github.com/pytorch/helion/issues/470.