### PR TITLE
[Benchmark CI] Use equally-spaced K input shapes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -140,6 +140,8 @@ jobs:
               --cudagraph \
               --only triton,liger,torch_compile,helion \
               --only-match-mode prefix-with-baseline \
+              --input-sample-mode equally-spaced-k \
+              --num-inputs 20 \
               --exit-on-exception
 
           # Relax the GPU
@@ -154,6 +156,8 @@ jobs:
               --only triton,liger,torch_compile,helion \
               --only-match-mode prefix-with-baseline \
               --output "$TEST_REPORTS_DIR/helionbench.json" \
+              --input-sample-mode equally-spaced-k \
+              --num-inputs 20 \
               --exit-on-exception
 
           if [[ ! -s "$TEST_REPORTS_DIR/helionbench.json" ]]; then

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -14,6 +14,9 @@ $ python benchmarks/run.py --metrics speedup,accuracy  # Runs all kernels
 
 # On GPU-1, run first 1/4 of inputs for all kernels and save results to CSV in the current directory
 $ CUDA_VISIBLE_DEVICES=1 python benchmarks/run.py --input-shard 1/4 --metrics accuracy,tflops,gbps,speedup --csv --output-dir ./
+
+# Equally-spaced-k mode: Select 5 equally spaced inputs from all available inputs
+$ python benchmarks/run.py --metrics speedup,accuracy --kernel softmax --input-sample-mode equally-spaced-k --num-inputs 5
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Select only 20 equally-spaced inputs from the total input space, to make Benchmark CI complete faster.

Dependent PR: https://github.com/meta-pytorch/tritonbench/pull/476.