### PR TITLE
[Benchmark CI] Run fewer inputs for layer_norm-bwd to avoid job timeout

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -201,6 +201,9 @@ KERNEL_MAPPINGS: dict[str, tuple[str, ...]] = {  # pyright: ignore[reportAssignm
         "tritonbench.operators.layer_norm.operator",
         "examples.layer_norm",
         "layer_norm_tritonbench",
+        {
+            "num_inputs": 10,  # layer_norm-bwd takes long time on Benchmark CI, so use fewer inputs instead.
+        },
     ),
     "jagged_softmax": (
         "tritonbench.operators.jagged_softmax.operator",


### PR DESCRIPTION
Before this PR, it times out at 6 hours: https://github.com/pytorch/helion/actions/runs/18057174753/job/51388536865