### PR TITLE
[Benchmark CI] Print config that causes tritonbench accuracy check failure

### DIFF
--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -37,6 +37,7 @@ from .._compiler.output_header import assert_no_conflicts
 from .._compiler.output_header import get_needed_imports
 from .._compiler.variable_origin import ArgumentOrigin
 from .._logging import LazyString
+from .._utils import counters
 from ..language.constexpr import ConstExpr
 from .config import Config
 from .ref_mode import RefModeContext
@@ -616,6 +617,12 @@ class BoundKernel(Generic[_R]):
             else:
                 self.autotune(args)
             assert self._run is not None
+
+        assert self._config is not None
+        counters["best_config_decorator"][
+            self.format_kernel_decorator(self._config, self.settings)
+        ] = 1
+
         return self._run(*args)
 
 


### PR DESCRIPTION
This will help us debug the `layer_norm` accuracy check failure on Benchmark CI: https://github.com/pytorch/helion/actions/runs/18071440671/job/51421790150.