### PR TITLE
ci: Always auth for benchmarking workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -204,7 +204,6 @@ jobs:
           cat "$TEST_REPORTS_DIR/helionbench.json"
 
       - name: Authenticate with AWS
-        if: inputs.alias == 'b200'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_upload-benchmark-results


### PR DESCRIPTION
Should remove errors related to not being authed for uploading benchmarking results. ([example](https://github.com/pytorch/helion/actions/runs/18103935503/job/51513673651))

> [!NOTE]
> This might have some implications on uploading H100 results, which the conditional was trying to solve for initially I guess?