### PR TITLE
Skip default config printing if in ref eager mode

### DIFF
--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -569,8 +569,12 @@ class BoundKernel(Generic[_R]):
             return configs[0]
         if len(configs) == 0 and self.kernel.settings.use_default_config:
             config = self.config_spec.default_config()
-            kernel_decorator = self.format_kernel_decorator(config, self.settings)
-            print(f"Using default config: {kernel_decorator}", file=sys.stderr)
+            if not is_ref_mode_enabled(self.kernel.settings):
+                kernel_decorator = self.format_kernel_decorator(config, self.settings)
+                print(
+                    f"Using default config: {kernel_decorator}",
+                    file=sys.stderr,
+                )
             return config
         return None
 


### PR DESCRIPTION
Since Helion kernel config doesn't actually apply in ref eager mode.