### PR TITLE
Remove torch from toml

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,3 +12,4 @@ linkify-it-py
 sphinx-autobuild
 sphinxext-opengraph
 pillow
+torch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
-    "torch>=2.7.0",
     "typing_extensions>=4.0.0",
     "filecheck",
     "psutil"


### PR DESCRIPTION
Right now Helion doesn't seem to actually work with PyTorch stable and so having it in the toml is a footgun, even if you have torch nightly installed locally you'll downgrade. This seems unintended since in your `test.yml` file you explicitly install pytorch from a specific index and the main README mentions that you should be installing PyTorch nightlies