### PR TITLE
Fix the issue that the XPU kernels cannot be cached well

### DIFF
--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -33,9 +33,17 @@ if TYPE_CHECKING:
     from .runtime.kernel import Kernel
 
 
-DEVICE = torch.device("cuda")
+DEVICE = torch.device("xpu") if torch.xpu.is_available() else torch.device("cuda")
 PROJECT_ROOT: Path = Path(__file__).parent.parent
 EXAMPLES_DIR: Path = PROJECT_ROOT / "examples"
+
+
+def is_cuda() -> bool:
+    """Return True if running on CUDA (NVIDIA GPU)."""
+    return (
+        triton.runtime.driver.active.get_current_target().backend == "cuda"  # pyright: ignore[reportAttributeAccessIssue,reportOptionalMemberAccess]
+        and DEVICE.type == "cuda"
+    )
 
 
 def skipIfRefEager(reason: str) -> Callable[[Callable], Callable]:
@@ -53,19 +61,22 @@ def skipIfRocm(reason: str) -> Callable[[Callable], Callable]:
     return unittest.skipIf(torch.version.hip is not None, reason)  # pyright: ignore[reportAttributeAccessIssue]
 
 
+def skipIfXPU(reason: str) -> Callable[[Callable], Callable]:
+    """Skip test if running with Intel XPU"""
+    return unittest.skipIf(torch.xpu.is_available(), reason)  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def skipIfNotCUDA() -> Callable[[Callable], Callable]:
+    """Skip test if not running on CUDA (NVIDIA GPU)."""
+    if not is_cuda():
+        return unittest.skip("Test skipped: CUDA (NVIDIA GPU) is not available.")
+
+
 def skipIfLowVRAM(
     reason: str = "Test requires high VRAM",
 ) -> Callable[[Callable], Callable]:
     """Skip test if HELION_DEV_LOW_VRAM=1 is set"""
     return unittest.skipIf(os.environ.get("HELION_DEV_LOW_VRAM", "0") == "1", reason)
-
-
-def is_cuda() -> bool:
-    """Return True if running on CUDA (NVIDIA GPU)."""
-    return (
-        triton.runtime.driver.active.get_current_target().backend == "cuda"  # pyright: ignore[reportAttributeAccessIssue,reportOptionalMemberAccess]
-        and DEVICE.type == "cuda"
-    )
 
 
 @contextlib.contextmanager

--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -68,8 +68,9 @@ def skipIfXPU(reason: str) -> Callable[[Callable], Callable]:
 
 def skipIfNotCUDA() -> Callable[[Callable], Callable]:
     """Skip test if not running on CUDA (NVIDIA GPU)."""
-    if not is_cuda():
-        return unittest.skip("Test skipped: CUDA (NVIDIA GPU) is not available.")
+    return unittest.skipIf(
+        not is_cuda(), "Test skipped: CUDA (NVIDIA GPU) is not available."
+    )
 
 
 def skipIfLowVRAM(

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -128,7 +128,7 @@ class BaseSearch(BaseAutotuner):
             baseline_output = self.kernel.compile_config(
                 baseline_config, allow_print=False
             )(*new_args)
-            torch.cuda.synchronize()
+            torch.accelerator.synchronize()
         except Exception as e:
             decorator = self.kernel.format_kernel_decorator(
                 baseline_config, self.settings


### PR DESCRIPTION
This PR intends to fix the issue that the produced kernels for XPU cannot be cached well under the Helion cache directory. 

Meanwhile, the PR changes the `DEVICE`  to `XPU` if `torch.xpu.is_available()` is `True` to pass the `test_cache.py`. Otherwise, an assertion error will be raised - `AssertionError: Torch not compiled with CUDA enabled`