### PR TITLE
Print Helion kernel source line in symbolic shape debugging

### DIFF
--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -1,14 +1,61 @@
 from __future__ import annotations
 
+import inspect
+import logging
+import os
+from typing import Callable
 import unittest
 
 import torch
+import torch.fx.experimental._config as fx_config
 
 import helion
 from helion._testing import DEVICE
 from helion._testing import RefEagerTestDisabled
 from helion._testing import TestCase
 import helion.language as hl
+
+
+@helion.kernel(use_default_config=True)
+def logging_reduce_rows(x: torch.Tensor) -> torch.Tensor:
+    m, n = x.shape
+    n = hl.specialize(n)
+
+    m_block = hl.register_block_size(m)
+
+    result = torch.zeros(n, dtype=torch.float32, device=x.device)
+
+    for outer in hl.tile(m, block_size=m_block):
+        for inner in hl.tile(outer.begin, outer.end):
+            zero_idx = inner.begin - inner.begin
+            result[zero_idx] = result[zero_idx]
+    return result
+
+
+def _run_symbol_logging_example() -> None:
+    x = torch.randn((128, 5632), device=DEVICE, dtype=torch.float16)
+    logging_reduce_rows(x)
+
+
+def _run_with_symbol_logs(fn: Callable[[], None]) -> str:
+    logger = logging.getLogger("torch.fx.experimental.symbolic_shapes")
+    records: list[str] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:  # type: ignore[override]
+            records.append(record.getMessage())
+
+    handler = _Capture()
+    previous_level = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    try:
+        fn()
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous_level)
+
+    return "\n".join(records)
 
 
 class TestLogging(RefEagerTestDisabled, TestCase):
@@ -50,6 +97,68 @@ class TestLogging(RefEagerTestDisabled, TestCase):
         self.assertTrue(
             any("DEBUG:helion.runtime.kernel:Debug string:" in msg for msg in cm.output)
         )
+
+    def test_symbolic_shape_log_includes_kernel_source(self):
+        symbol_filter = ",".join(f"u{i}" for i in range(5))
+        file_path = os.path.abspath(__file__)
+        source_lines, start_line = inspect.getsourcelines(logging_reduce_rows.fn)
+
+        def get_line_no(snippet: str) -> int:
+            return start_line + next(
+                idx for idx, line in enumerate(source_lines) if snippet in line
+            )
+
+        line_for_block = get_line_no("m_block = hl.register_block_size(m)")
+        line_for_inner = get_line_no("for inner in hl.tile(outer.begin, outer.end):")
+        line_for_zero = get_line_no("zero_idx = inner.begin - inner.begin")
+
+        with fx_config.patch(extended_debug_create_symbol=symbol_filter):
+            output = _run_with_symbol_logs(_run_symbol_logging_example)
+
+        lines = output.splitlines()
+
+        self.assertTrue(output, msg="no logs captured for symbolic shapes")
+        self.assertIn("create_unbacked_symint", output)
+        self.assertIn("Helion kernel stack:", output)
+        self.assertTrue(
+            any(
+                f'  File "{file_path}", line {line_for_block}, in logging_reduce_rows'
+                in line
+                for line in lines
+            ),
+            msg="register_block_size location missing",
+        )
+        self.assertIn("    m_block = hl.register_block_size(m)", output)
+
+        def assert_symbol(symbol: str, lineno: int, snippet: str) -> None:
+            marker = f"create_unbacked_symint {symbol}"
+            for idx, line in enumerate(lines):
+                if marker in line:
+                    window = lines[idx : idx + 6]
+                    break
+            else:
+                self.fail(f"missing log for {symbol}")
+
+            expected_file_line = (
+                f'  File "{file_path}", line {lineno}, in logging_reduce_rows'
+            )
+            self.assertTrue(
+                any(expected_file_line in line for line in window),
+                msg=f"missing file info for {symbol}",
+            )
+            self.assertTrue(
+                any(snippet in line for line in window),
+                msg=f"missing source line for {symbol}",
+            )
+
+        for sym, line_no, snippet in [
+            ("u0", line_for_block, "m_block = hl.register_block_size(m)"),
+            ("u1", line_for_inner, "for inner in hl.tile(outer.begin, outer.end):"),
+            ("u2", line_for_inner, "for inner in hl.tile(outer.begin, outer.end):"),
+            ("u3", line_for_inner, "for inner in hl.tile(outer.begin, outer.end):"),
+            ("u4", line_for_zero, "zero_idx = inner.begin - inner.begin"),
+        ]:
+            assert_symbol(sym, line_no, snippet)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked PRs:
 * __->__#771


--- --- ---

### Print Helion kernel source line in symbolic shape debugging


With `TORCH_LOGS="+dynamic"`, now it prints:
```
I1001 20:49:16.995000 1208064 torch/fx/experimental/symbolic_shapes.py:4800] create_unbacked_symint u0 [-int_oo, int_oo]
I1001 20:49:16.995000 1208064 torch/fx/experimental/symbolic_shapes.py:4800] Helion kernel stack:
I1001 20:49:16.995000 1208064 torch/fx/experimental/symbolic_shapes.py:4800]   File "/home/willfeng/local/helion2/minimal_repro.py", line 10, in logging_reduce_rows
I1001 20:49:16.995000 1208064 torch/fx/experimental/symbolic_shapes.py:4800]     m_block = hl.register_block_size(m)
I1001 20:49:16.995000 1208064 torch/fx/experimental/symbolic_shapes.py:4800]               ^^^^^^^^^^^^^^^^^^^^^^^^^
```
which can be further traced with `TORCHDYNAMO_EXTENDED_DEBUG_CREATE_SYMBOL="u0"`
