### PR TITLE
Add XPU support for RNG operations

### DIFF
--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -81,7 +81,7 @@ class GenerateAST(NodeVisitor, CodegenInterface):
 
         # Create host-side seed buffer with the required number of seeds
         seed_buffer_stmt = statement_from_string(
-            f"_rng_seed_buffer = inductor_prims.seeds({self.device_function.rng_seed_count}, torch.device('cuda'))"
+            f"_rng_seed_buffer = inductor_prims.seeds({self.device_function.rng_seed_count}, torch.accelerator.current_accelerator())"
         )
 
         return [import_stmt, seed_buffer_stmt]

--- a/test/test_rng.expected
+++ b/test/test_rng.expected
@@ -37,7 +37,7 @@ def _helion_multiple_rng_ops_kernel(rand1, rand2, uniform, normal, randn_a, rand
 
 def multiple_rng_ops_kernel(x: torch.Tensor, *, _launcher=_default_launcher):
     from torch._inductor import inductor_prims
-    _rng_seed_buffer = inductor_prims.seeds(7, torch.device('cuda'))
+    _rng_seed_buffer = inductor_prims.seeds(7, torch.accelerator.current_accelerator())
     rand1 = torch.zeros_like(x)
     rand2 = torch.zeros_like(x)
     uniform = torch.zeros_like(x)


### PR DESCRIPTION
Currently, the RNG operations in Helion only support `CUDA` as the device name is hard-coded as `cuda` to produce the RNG seed buffer. This PR intends to generalize the code by replacing `torch.device('cuda')` with `torch.accelerator.current_accelerator()`.