### PR TITLE
Handle XPU compilation error

### DIFF
--- a/helion/autotuner/logger.py
+++ b/helion/autotuner/logger.py
@@ -112,6 +112,7 @@ _EXPECTED_TRITON_ERRORS_RE: re.Pattern[str] = re.compile(
                 "TServiceRouterException",  # Remote compile failed
                 "triton.compiler.errors.CompilationError",  # Triton CompilationError
                 "out of resource: shared memory",  # Triton shared memory OOM
+                "ZE_RESULT_ERROR_INVALID_KERNEL_NAME",  # Level Zero compile failed
             ],
         )
     )


### PR DESCRIPTION
Adds expected Level Zero driver error that occurs for invalid kernel configurations using XPU backend.