### PR TITLE
Limit rebench to 1000 iterations

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -552,7 +552,7 @@ class PopulationBasedSearch(BaseSearch):
         """
         if len(members) < 2:
             return
-        repeat = max(3, int(200 / self.best_perf_so_far))
+        repeat = min(1000, max(3, int(200 / self.best_perf_so_far)))
         iterator = [functools.partial(m.fn, *self.args) for m in members]
         if self.settings.autotune_progress_bar:
             new_timings = interleaved_bench(iterator, repeat=repeat, desc=desc)


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #800
 * #799
 * #788
 * __->__#789


--- --- ---

Limit rebench to 1000 iterations

For ulta-tiny sizes we would do 10k+ iterations, which is slow.