### PR TITLE
Adding new setting, autotune_max_generations, that allows user to set the maximum number of generations for autotuning

### DIFF
--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -137,7 +137,7 @@ with helion.set_default_settings(
 
 .. autoattribute:: Settings.autotune_max_generations
 
-   Override the maximum number of generations for Pattern Search and Differential Evolution Search autotuning algorithms with HELION_AUTOTUNE_MAX_GENERATIONS=N or @helion.kernel(autotune_max_generations=N).
+   Override the default number of generations set for Pattern Search and Differential Evolution Search autotuning algorithms with HELION_AUTOTUNE_MAX_GENERATIONS=N or @helion.kernel(autotune_max_generations=N).
 
    Lower values result in faster autotuning but may find less optimal configurations.
 ```

--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -137,8 +137,8 @@ with helion.set_default_settings(
 
 .. autoattribute:: Settings.autotune_max_generations
 
-   Maximum number of generations for population-based autotuning algorithms (PatternSearch and DifferentialEvolutionSearch). Default is ``40``. Controlled by ``HELION_AUTOTUNE_MAX_GENERATIONS``.
-
+   Override the maximum number of generations for Pattern Search and Differential Evolution Search autotuning algorithms with HELION_AUTOTUNE_MAX_GENERATIONS=N or @helion.kernel(autotune_max_generations=N).
+   
    Lower values result in faster autotuning but may find less optimal configurations.
 ```
 

--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -138,7 +138,7 @@ with helion.set_default_settings(
 .. autoattribute:: Settings.autotune_max_generations
 
    Override the maximum number of generations for Pattern Search and Differential Evolution Search autotuning algorithms with HELION_AUTOTUNE_MAX_GENERATIONS=N or @helion.kernel(autotune_max_generations=N).
-   
+
    Lower values result in faster autotuning but may find less optimal configurations.
 ```
 

--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -134,6 +134,12 @@ with helion.set_default_settings(
 .. autoattribute:: Settings.autotune_random_seed
 
    Seed used for autotuner random number generation. Defaults to ``HELION_AUTOTUNE_RANDOM_SEED`` if set, otherwise a time-based value.
+
+.. autoattribute:: Settings.autotune_max_generations
+
+   Maximum number of generations for population-based autotuning algorithms (PatternSearch and DifferentialEvolutionSearch). Default is ``40``. Controlled by ``HELION_AUTOTUNE_MAX_GENERATIONS``.
+
+   Lower values result in faster autotuning but may find less optimal configurations.
 ```
 
 ### Debugging and Development

--- a/helion/autotuner/differential_evolution.py
+++ b/helion/autotuner/differential_evolution.py
@@ -27,7 +27,7 @@ class DifferentialEvolutionSearch(PopulationBasedSearch):
         kernel: BoundKernel,
         args: Sequence[object],
         population_size: int = 40,
-        num_generations: int = 40,
+        max_generations: int = 40,
         crossover_rate: float = 0.8,
         immediate_update: bool | None = None,
     ) -> None:
@@ -35,7 +35,7 @@ class DifferentialEvolutionSearch(PopulationBasedSearch):
         if immediate_update is None:
             immediate_update = not kernel.settings.autotune_precompile
         self.population_size = population_size
-        self.num_generations = num_generations
+        self.max_generations = max_generations
         self.crossover_rate = crossover_rate
         self.immediate_update = immediate_update
 
@@ -90,11 +90,11 @@ class DifferentialEvolutionSearch(PopulationBasedSearch):
         self.log(
             lambda: (
                 f"Starting DifferentialEvolutionSearch with population={self.population_size}, "
-                f"generations={self.num_generations}, crossover_rate={self.crossover_rate}"
+                f"generations={self.max_generations}, crossover_rate={self.crossover_rate}"
             )
         )
         self.initial_two_generations()
-        for i in range(2, self.num_generations):
+        for i in range(2, self.max_generations):
             replaced = self.evolve_population()
             self.log(f"Generation {i}: replaced={replaced}", self.statistics)
         self.rebenchmark_population()

--- a/helion/autotuner/differential_evolution.py
+++ b/helion/autotuner/differential_evolution.py
@@ -34,9 +34,6 @@ class DifferentialEvolutionSearch(PopulationBasedSearch):
         super().__init__(kernel, args)
         if immediate_update is None:
             immediate_update = not kernel.settings.autotune_precompile
-        max_generations_override = kernel.settings.autotune_max_generations
-        if max_generations_override is not None:
-            max_generations = max_generations_override
         self.population_size = population_size
         self.max_generations = max_generations
         self.crossover_rate = crossover_rate

--- a/helion/autotuner/differential_evolution.py
+++ b/helion/autotuner/differential_evolution.py
@@ -34,6 +34,9 @@ class DifferentialEvolutionSearch(PopulationBasedSearch):
         super().__init__(kernel, args)
         if immediate_update is None:
             immediate_update = not kernel.settings.autotune_precompile
+        max_generations_override = kernel.settings.autotune_max_generations
+        if max_generations_override is not None:
+            max_generations = max_generations_override
         self.population_size = population_size
         self.max_generations = max_generations
         self.crossover_rate = crossover_rate

--- a/helion/autotuner/pattern_search.py
+++ b/helion/autotuner/pattern_search.py
@@ -40,9 +40,6 @@ class PatternSearch(PopulationBasedSearch):
             max_generations: The maximum number of generations to run.
         """
         super().__init__(kernel, args)
-        max_generations_override = kernel.settings.autotune_max_generations
-        if max_generations_override is not None:
-            max_generations = max_generations_override
         self.initial_population = initial_population
         self.copies = copies
         self.max_generations = max_generations

--- a/helion/autotuner/pattern_search.py
+++ b/helion/autotuner/pattern_search.py
@@ -40,6 +40,9 @@ class PatternSearch(PopulationBasedSearch):
             max_generations: The maximum number of generations to run.
         """
         super().__init__(kernel, args)
+        max_generations_override = kernel.settings.autotune_max_generations
+        if max_generations_override is not None:
+            max_generations = max_generations_override
         self.initial_population = initial_population
         self.copies = copies
         self.max_generations = max_generations

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -74,6 +74,13 @@ def default_autotuner_fn(
             f"{', '.join(search_algorithms.keys())}"
         )
 
+    # Use autotune_max_generations from settings if kwarg is not explicitly provided
+    if autotuner_name in ("PatternSearch", "DifferentialEvolutionSearch"):
+        if bound_kernel.settings.autotune_max_generations is not None:
+            kwargs.setdefault(
+                "max_generations", bound_kernel.settings.autotune_max_generations
+            )
+
     return LocalAutotuneCache(autotuner_cls(bound_kernel, args, **kwargs))  # pyright: ignore[reportArgumentType]
 
 

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -90,6 +90,7 @@ def _get_autotune_max_generations() -> int | None:
         return int(value)
     return None
 
+
 @dataclasses.dataclass
 class _Settings:
     # see __slots__ below for the doc strings that show up in help(Settings)

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -63,9 +63,7 @@ def set_default_settings(settings: Settings) -> AbstractContextManager[None, Non
 def default_autotuner_fn(
     bound_kernel: BoundKernel, args: Sequence[object], **kwargs: object
 ) -> BaseAutotuner:
-    from ..autotuner import DifferentialEvolutionSearch
     from ..autotuner import LocalAutotuneCache
-    from ..autotuner import PatternSearch
     from ..autotuner import search_algorithms
 
     autotuner_name = os.environ.get("HELION_AUTOTUNER", "PatternSearch")
@@ -77,7 +75,7 @@ def default_autotuner_fn(
         )
 
     # Pass max_generations from settings only for autotuners that support it
-    if autotuner_cls in (PatternSearch, DifferentialEvolutionSearch):
+    if autotuner_name in ("PatternSearch", "DifferentialEvolutionSearch"):
         if "max_generations" not in kwargs:
             kwargs["max_generations"] = bound_kernel.settings.autotune_max_generations
 

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -15,7 +15,6 @@ import pytest
 import torch
 
 import helion
-import helion.autotuner as autotuner_module
 from helion import _compat
 from helion._testing import DEVICE
 from helion._testing import RefEagerTestDisabled
@@ -384,21 +383,16 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
 
         bound_kernel = add.bind(args)
 
-        search = PatternSearch(
-            bound_kernel,
-            args,
-            max_generations=10
+        search = PatternSearch(bound_kernel, args, max_generations=10)
+
+        self.assertEqual(
+            bound_kernel.settings.autotune_max_generations, search.max_generations
         )
 
-        self.assertEqual(bound_kernel.settings.autotune_max_generations, search.max_generations)
-
-        evo_search = DifferentialEvolutionSearch(
-            bound_kernel,
-            args,
-            max_generations=10
+        evo_search = DifferentialEvolutionSearch(bound_kernel, args, max_generations=10)
+        self.assertEqual(
+            bound_kernel.settings.autotune_max_generations, evo_search.max_generations
         )
-        self.assertEqual(bound_kernel.settings.autotune_max_generations, evo_search.max_generations)
-
 
     def test_use_default_config(self):
         @helion.kernel(use_default_config=True)


### PR DESCRIPTION
The maximum number of generations was hardcoded to 100 for pattern search and to 40 for differential evolution search.
This autotune_max_generations setting (HELION_AUTOTUNE_MAX_GENERATIONS env variable) allows users to override the default max, which is now set to 40 by default for both search algorithms.
This setting can be applied to either the pattern search or the differential evolution search algorithms.
