### PR TITLE
Suggest use of `@helion.kernel(index_dtype=torch.int64)` if index offset is out of bound for int32

### DIFF
--- a/helion/exc.py
+++ b/helion/exc.py
@@ -107,6 +107,13 @@ class InvalidIndexingType(BaseError):
     message = "Expected tile/int/None/tensor/etc in tensor[...], got {0!s}."
 
 
+class IndexOffsetOutOfRangeForInt32(BaseError):
+    message = (
+        "Kernel index_dtype is {0}, but tensor indexing offsets exceed the int32 range. "
+        "Use @helion.kernel(index_dtype=torch.int64) to enable larger offsets."
+    )
+
+
 class DataDependentOutputShapeNotSupported(BaseError):
     message = (
         "{op_desc} is not supported in Helion device loops because it produces "


### PR DESCRIPTION
Fixes https://github.com/pytorch/helion/issues/686.