### PR TITLE
[Benchmark CI] Use equally-spaced-k mode to sample input shapes

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -787,6 +787,14 @@ def run_kernel_variants(
             file=sys.stderr,
         )
 
+    # Use equally-spaced-k input sample mode if not otherwise specified
+    if "--input-sample-mode" not in tritonbench_args:
+        tritonbench_args.extend(["--input-sample-mode", "equally-spaced-k"])
+        print(
+            f"Using input-sample-mode=equally-spaced-k for {operator_name}",
+            file=sys.stderr,
+        )
+
     # Parse known args and collect unknown ones for operator
     tb_args, unknown_args = tb_parser.parse_known_args(tritonbench_args)
 


### PR DESCRIPTION
Previously, we only run the first K input shapes (e.g. [1,2,3,4,5] out of 10), instead of sampling over the entire input shape space (e.g. [1,3,5,7,9] out of 10). This PR will ensure Benchmark CI runs shapes that roughly cover the full input shape space, to uncover any latent errors or bad perf.

This might move dashboard perf numbers since we are now running different shapes than before. I kicked off https://github.com/pytorch/helion/actions/runs/18384877445 to observe the influence on speedup numbers.