### PR TITLE
[Autotuner] Run CUDA synchronize before / after candidate func call, to surface CUDA errors sooner

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -207,7 +207,9 @@ class BaseSearch(BaseAutotuner):
             t0 = time.perf_counter()
             if self._kernel_mutates_args:
                 self.args = self._clone_args(self._original_args)
+            torch.accelerator.synchronize()
             output = fn(*self.args)  # make sure the kernel is compiled
+            torch.accelerator.synchronize()
             if (
                 self.settings.autotune_accuracy_check
                 and not self._validate_against_baseline(config, output, self.args)


### PR DESCRIPTION
Try to make it easier to debug CUDA errors like https://github.com/pytorch/helion/issues/665 and https://github.com/pytorch/helion/issues/867.