### PR TITLE
Print Triton code when error for easier debugging

### DIFF
--- a/helion/autotuner/logger.py
+++ b/helion/autotuner/logger.py
@@ -14,6 +14,7 @@ from torch._inductor.runtime.triton_compat import PTXASError
 
 if TYPE_CHECKING:
     from ..runtime.config import Config
+    from ..runtime.kernel import BoundKernel
 
 
 class LambdaLogger:
@@ -92,12 +93,19 @@ def _maybe_call(fn: Callable[[], str] | str) -> str:
     return fn
 
 
-def format_triton_compile_failure(config: Config, err: BaseException) -> str:
+def format_triton_compile_failure(
+    config: Config, err: BaseException, bound_kernel: BoundKernel
+) -> str:
+    kernel_decorator = bound_kernel.format_kernel_decorator(
+        config, bound_kernel.settings
+    )
+    triton_code = bound_kernel.to_triton_code(config)
     return (
         "Triton compile failed. This likely indicates a bug in Triton. "
         "Skipping failing config.\n"
-        f"Config: {config!r}\n"
-        f"Error: {type(err).__name__}: {err}"
+        f"Config: {kernel_decorator}\n"
+        f"Error: {type(err).__name__}: {err}\n\n"
+        f"Generated Triton code:\n{triton_code}"
     )
 
 

--- a/helion/exc.py
+++ b/helion/exc.py
@@ -316,7 +316,7 @@ class TorchOpTracingError(_WrapException):
 
 
 class TritonError(BaseError):
-    message = "Error running generated Triton program:\n{1}\n{0}"
+    message = "Error running generated Triton program:\n{1}\n{0}\n\nGenerated Triton code:\n{2}"
 
 
 class BaseWarning(_FixedMessage):

--- a/helion/runtime/precompile_shim.py
+++ b/helion/runtime/precompile_shim.py
@@ -13,10 +13,13 @@ if TYPE_CHECKING:
     from triton.runtime.jit import JITFunction
 
     from .config import Config
+    from .kernel import BoundKernel
 
 
 def make_precompiler(
-    fn: JITFunction[object], config: Config
+    fn: JITFunction[object],
+    config: Config,
+    bound_kernel: BoundKernel,
 ) -> Callable[..., Callable[[], None]]:
     from triton.runtime.jit import find_paths_if
     from triton.runtime.jit import get_iterable_path
@@ -64,7 +67,10 @@ def make_precompiler(
             except Exception as e:
                 action = classify_triton_exception(e)
                 if action != "debug":
-                    print(format_triton_compile_failure(config, e), file=sys.stderr)
+                    print(
+                        format_triton_compile_failure(config, e, bound_kernel),
+                        file=sys.stderr,
+                    )
                 sys.exit(1)
 
         return finish_it


### PR DESCRIPTION
Some CUDA errors like https://github.com/pytorch/helion/issues/665 and https://github.com/pytorch/helion/issues/867 are hard to reproduce locally. With this PR, we can see the generated Triton kernel code on the failed CI job, to hopefully give us more hints for debugging.