### PR TITLE
Remove PyTorch requirement from deps so that it is easier to install arbitrary version of pytorch

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,3 +12,4 @@ linkify-it-py
 sphinx-autobuild
 sphinxext-opengraph
 pillow
+torch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
-    "torch>=2.7.0",
     "typing_extensions>=4.0.0",
     "filecheck",
     "psutil",


### PR DESCRIPTION
Fixes #863

Essentially the idea here is that pip install helion should not forcefully bring pytorch, and instead folks should install their own desired pytorch version.