### PR TITLE
DEBUG: grouped_gemm and gemm errors on benchmark CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -120,7 +120,7 @@ jobs:
 
           source .venv/bin/activate
 
-          KERNELS=("softmax" "jsd" "welford" "kl_div" "layer_norm" "layer_norm-bwd" "rms_norm" "rms_norm-bwd" "cross_entropy" "flash_attention" "gemm" "grouped_gemm")
+          KERNELS=("gemm" "grouped_gemm")
           NUMSHARDS=${{ inputs.num-shards }}
           SHARD=${{ inputs.shard }}
 
@@ -147,6 +147,7 @@ jobs:
             KERNEL_INFO=$(python benchmarks/run.py --list-impls-for-benchmark-ci --op $kernel | grep "^$kernel:")
             IMPLS=$(echo "$KERNEL_INFO" | sed -n 's/.*impls=\([^ ]*\).*/\1/p')
             BASELINE=$(echo "$KERNEL_INFO" | sed -n 's/.*baseline=\([^ ]*\).*/\1/p')
+            LATENCY_MODE=$(echo "$KERNEL_INFO" | sed -n 's/.*latency_measure_mode=\([^ ]*\).*/\1/p')
 
             if [[ -z "$IMPLS" ]]; then
               echo "Warning: No implementations found for kernel $kernel, skipping..."
@@ -156,15 +157,23 @@ jobs:
               echo "Warning: No baseline found for kernel $kernel, skipping..."
               continue
             fi
+            if [[ -z "$LATENCY_MODE" ]]; then
+              LATENCY_MODE="triton_do_bench"
+            fi
             echo "Using baseline: $BASELINE"
             echo "Available implementations for $kernel: $IMPLS"
+            echo "Latency measure mode for $kernel: $LATENCY_MODE"
+
+            LATENCY_MODE_ARGS=(--latency-measure-mode triton_do_bench --cudagraph)
+            if [[ "$LATENCY_MODE" == "profiler" ]]; then
+              LATENCY_MODE_ARGS=(--latency-measure-mode profiler)
+            fi
 
             # Do autotuning but do not record the results
-            python benchmarks/run.py \
+            CUDA_LAUNCH_BLOCKING=1 python benchmarks/run.py \
                 --op $kernel \
                 --metrics speedup,accuracy \
-                --latency-measure-mode triton_do_bench \
-                --cudagraph \
+                "${LATENCY_MODE_ARGS[@]}" \
                 --only $IMPLS \
                 --only-match-mode prefix-with-baseline \
                 --baseline $BASELINE \
@@ -174,11 +183,10 @@ jobs:
             sleep 2m
 
             # Run again with cache and record results
-            python benchmarks/run.py \
+            CUDA_LAUNCH_BLOCKING=1 python benchmarks/run.py \
                 --op $kernel \
                 --metrics speedup,accuracy \
-                --latency-measure-mode triton_do_bench \
-                --cudagraph \
+                "${LATENCY_MODE_ARGS[@]}" \
                 --only $IMPLS \
                 --only-match-mode prefix-with-baseline \
                 --baseline $BASELINE \

--- a/.github/workflows/benchmark_dispatch.yml
+++ b/.github/workflows/benchmark_dispatch.yml
@@ -26,7 +26,7 @@ jobs:
     if: ${{ github.event.inputs.run_h100 == 'true' || github.event_name == 'schedule' }}
     uses: ./.github/workflows/compute-benchmark-matrix.yml
     with:
-      max-runners: 12
+      max-runners: 2
 
   run-h100:
     needs: gen-matrix-h100
@@ -51,7 +51,7 @@ jobs:
     uses: ./.github/workflows/compute-benchmark-matrix.yml
     if: ${{ github.event.inputs.run_b200 == 'true' || github.event_name == 'schedule' }}
     with:
-      max-runners: 12
+      max-runners: 2
 
   run-b200:
     needs: gen-matrix-b200

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -446,6 +446,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_grouped_gemm-accuracy": "torch_compile_accuracy",
         "helion_grouped_gemm_jagged_persistent_tritonbench-speedup": "helion_speedup",
         "helion_grouped_gemm_jagged_persistent_tritonbench-accuracy": "helion_accuracy",
+        "latency_measure_mode": "profiler",
     },
     "jagged_layer_norm": {
         "torch_compile_nested_tensor_integration-speedup": "torch_compile_speedup",
@@ -1166,8 +1167,11 @@ def main() -> None:
 
             implementations = sorted(implementations)
             assert implementations, f"No implementations found for kernel: {kernel}"
+            latency_mode = KERNEL_METRIC_MAPPINGS[kernel].get(
+                "latency_measure_mode", "triton_do_bench"
+            )
             print(
-                f"{kernel}: impls={','.join(implementations)} baseline={baseline_impl}"
+                f"{kernel}: impls={','.join(implementations)} baseline={baseline_impl} latency_measure_mode={latency_mode}"
             )
         sys.exit(0)
 

--- a/examples/grouped_gemm.py
+++ b/examples/grouped_gemm.py
@@ -108,7 +108,7 @@ def grouped_gemm_jagged(
 
 
 # %%
-@helion.kernel(static_shapes=False)
+@helion.kernel(static_shapes=False, autotune_precompile=False)
 def grouped_gemm_jagged_persistent(
     A_packed: torch.Tensor,  # [total_M, K]
     B: torch.Tensor,  # [K, N]

--- a/examples/matmul.py
+++ b/examples/matmul.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 @helion.kernel(
     # static_shapes=True gives a performance boost for matmuls
     static_shapes=True,
+    autotune_precompile=False,
 )
 def matmul(
     x: Tensor,

--- a/helion/autotuner/logger.py
+++ b/helion/autotuner/logger.py
@@ -105,7 +105,6 @@ def format_triton_compile_failure(
         "Skipping failing config.\n"
         f"Config: {kernel_decorator}\n"
         f"Error: {type(err).__name__}: {err}\n\n"
-        f"Generated Triton code:\n{triton_code}"
     )
 
 


### PR DESCRIPTION
A few findings so far:
1. Many backends for grouped_gemm doesn't support cudagraph due to either tensor creation in input preprocessing, or some implementation specific issue. So for grouped_gemm, we will try to use `--latency-measure-mode profiler` to work around cudagraph issue.
2. grouped_gemm input preprocessing should be included in the timed region.
3. gemm backends name matching needs to be fixed.