### PR TITLE
Remove cache around set_triton_allocator

### DIFF
--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextvars
-import functools
 from typing import TYPE_CHECKING
 
 import torch
@@ -21,7 +20,6 @@ def _alloc_fn(size: int, alignment: int, stream: int | None) -> torch.Tensor:
     return torch.empty(size, device="cuda", dtype=torch.int8)
 
 
-@functools.cache
 def set_triton_allocator() -> None:
     try:
         from triton import set_allocator


### PR DESCRIPTION
Stacked PRs:
 * __->__#912


--- --- ---

### Remove cache around set_triton_allocator


In FBCode autotuning tensor_descriptors results in allocator not set exception,
even though set_triton_allocator is in the source code. I'm guessing
there's some bad interaction with RE but cant exactly pinpoint.