### PR TITLE
Print error message for torch.chunk / torch.unbind to redirect users to hl.split

### DIFF
--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -773,6 +773,10 @@ class CallableType(LiteralType):
     ) -> TypeInfo | None:
         if self.value in (torch.nonzero, torch.Tensor.nonzero) and origin.is_device():
             raise exc.DataDependentOutputShapeNotSupported(op_desc="torch.nonzero")
+        if self.value in (torch.chunk, torch.Tensor.chunk) and origin.is_device():
+            raise exc.UnsupportedSplitOperation(op="torch.chunk")
+        if self.value in (torch.unbind, torch.Tensor.unbind) and origin.is_device():
+            raise exc.UnsupportedSplitOperation(op="torch.unbind")
         if is_api_func(fn := self.value):
             if fn._is_device_only and origin.is_host():
                 raise exc.DeviceAPIOnHost(fn.__qualname__)

--- a/helion/exc.py
+++ b/helion/exc.py
@@ -114,6 +114,14 @@ class DataDependentOutputShapeNotSupported(BaseError):
     )
 
 
+class UnsupportedSplitOperation(BaseError):
+    message = (
+        "{op} is not supported in Helion device loops. "
+        "For splitting the last dimension with size 2, use hl.split(). "
+        "For other splitting operations, consider reshaping or using other hl.* operations."
+    )
+
+
 class RequiresTensorInAssignment(BaseError):
     message = "Expected tensor in right-hand side of assignment, got {0!s}."
 


### PR DESCRIPTION
Related to https://github.com/pytorch/helion/issues/901.