### PR TITLE
Avoid setting default `--input-sample-mode` to `equally-spaced-k`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -150,6 +150,7 @@ jobs:
                 --only $IMPLS \
                 --only-match-mode prefix-with-baseline \
                 --baseline $BASELINE \
+                --input-sample-mode equally-spaced-k \
                 --keep-going
 
             # Relax the GPU
@@ -164,6 +165,7 @@ jobs:
                 --only $IMPLS \
                 --only-match-mode prefix-with-baseline \
                 --baseline $BASELINE \
+                --input-sample-mode equally-spaced-k \
                 --output "$TEST_REPORTS_DIR/helionbench.json" \
                 --append-to-output \
                 --keep-going

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -814,14 +814,6 @@ def run_kernel_variants(
             file=sys.stderr,
         )
 
-    # Use equally-spaced-k input sample mode if not otherwise specified
-    if "--input-sample-mode" not in tritonbench_args:
-        tritonbench_args.extend(["--input-sample-mode", "equally-spaced-k"])
-        print(
-            f"Using input-sample-mode=equally-spaced-k for {operator_name}",
-            file=sys.stderr,
-        )
-
     # Parse known args and collect unknown ones for operator
     tb_args, unknown_args = tb_parser.parse_known_args(tritonbench_args)
 


### PR DESCRIPTION
... to prevent behavior divergence from TritonBench run.py. Instead explicitly set `equally-spaced-k` in benchmark.yml.