### PR TITLE
Set HELION_DEV_LOW_VRAM=1 on a10g CI machines

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,4 +131,5 @@ jobs:
           if [[ "${{ matrix.dtype-asserts }}" == "true" ]]; then export HELION_DEBUG_DTYPE_ASSERTS=1; fi
           if [[ "${{ matrix.expecttest-accept }}" == "true" ]]; then export EXPECTTEST_ACCEPT=1; fi
           if [[ "${{ matrix.ref-eager }}" == "true" ]]; then export HELION_INTERPRET=1; fi
+          if [[ "${{ matrix.alias }}" == *"a10g"* ]]; then export HELION_DEV_LOW_VRAM=1; fi
           pytest --timeout=60


### PR DESCRIPTION
Would like to use `skipIfLowVRAM` to gate high-VRAM unit tests (like `test_int32_offset_out_of_range_error` being added in https://github.com/pytorch/helion/pull/850), which is currently failing on a10g CI machines due to OOM.