### PR TITLE
Auto-shrink autotune_precompile_jobs based on free memory

### DIFF
--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -139,6 +139,8 @@ with helion.set_default_settings(
 .. autoattribute:: Settings.autotune_precompile_jobs
 
    Cap the number of concurrent Triton precompile subprocesses. ``None`` (default) uses the machine CPU count.
+   Controlled by ``HELION_AUTOTUNE_PRECOMPILE_JOBS``.
+   When using ``"spawn"`` precompile mode, Helion may automatically lower this cap if free GPU memory is limited.
 
 .. autoattribute:: Settings.autotune_max_generations
 

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -145,6 +145,16 @@ def _get_autotune_precompile() -> str | None:
     )
 
 
+def _get_autotune_precompile_jobs() -> int | None:
+    value = os.environ.get("HELION_AUTOTUNE_PRECOMPILE_JOBS")
+    if value is None or value.strip() == "":
+        return None
+    jobs = int(value)
+    if jobs <= 0:
+        raise ValueError("HELION_AUTOTUNE_PRECOMPILE_JOBS must be a positive integer")
+    return jobs
+
+
 @dataclasses.dataclass
 class _Settings:
     # see __slots__ below for the doc strings that show up in help(Settings)
@@ -164,7 +174,9 @@ class _Settings:
     autotune_precompile: str | None = dataclasses.field(
         default_factory=_get_autotune_precompile
     )
-    autotune_precompile_jobs: int | None = None
+    autotune_precompile_jobs: int | None = dataclasses.field(
+        default_factory=_get_autotune_precompile_jobs
+    )
     autotune_random_seed: int = dataclasses.field(
         default_factory=_get_autotune_random_seed
     )


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #793
 * #941
 * #932
 * #930
 * __->__#940
 * #914


--- --- ---

Auto-shrink autotune_precompile_jobs based on free memory

I was hitting out of memory errors due to too many worker jobs.