### PR TITLE
[benchmarks] change tritonbench path

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -1047,7 +1047,7 @@ def process_result(
     metrics = collections.defaultdict(list)
     for row in lines[1:]:
         row_data = row.strip().split(";")
-        if row_data[0] == "average":
+        if row_data[0] == "average" or len(row_data) == 1:
             continue
         for idx, (name, item) in enumerate(zip(names, row_data, strict=True)):
             if idx == 0:


### PR DESCRIPTION
We want to run helion benchmark when tritonbench is installed as a library, e.g. `pip install -e .` in tritonbench repo root.
In upstream, move `run()` in `run.py` to `tritonbench.utils.run_utils` so that it can be referred as a library. 

Upstream change: https://github.com/meta-pytorch/tritonbench/pull/568

I will submit another PR after the upstream change is merged to simplify this.