### PR TITLE
Skip test_differential_evolution_search due to slowness

### DIFF
--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -282,6 +282,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         torch.testing.assert_close(fn(*args), args[0] @ args[1], rtol=1e-2, atol=1e-1)
 
     @skipIfRocm("too slow on rocm")
+    @skip("too slow")
     def test_differential_evolution_search(self):
         args = (
             torch.randn([512, 512], device=DEVICE),


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * __->__#968


--- --- ---

Skip test_differential_evolution_search due to slowness