### PR TITLE
[Benchmark CI] Allow specifying custom args to benchmark runner via UI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,6 +28,10 @@ on:
         required: false
         type: string
         default: ""
+      custom-args:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   benchmark:
@@ -155,7 +159,8 @@ jobs:
                 --only-match-mode prefix-with-baseline \
                 --baseline $BASELINE \
                 --input-sample-mode equally-spaced-k \
-                --keep-going
+                --keep-going \
+                ${{ inputs.custom-args }}
 
             # Relax the GPU
             sleep 2m
@@ -172,7 +177,8 @@ jobs:
                 --input-sample-mode equally-spaced-k \
                 --output "$TEST_REPORTS_DIR/helionbench.json" \
                 --append-to-output \
-                --keep-going
+                --keep-going \
+                ${{ inputs.custom-args }}
 
             echo "✅ Completed benchmark for kernel: $kernel"
           done

--- a/.github/workflows/benchmark_dispatch.yml
+++ b/.github/workflows/benchmark_dispatch.yml
@@ -28,6 +28,11 @@ on:
         required: false
         type: string
         default: ""
+      custom_args:
+        description: 'Custom arguments to append to benchmark commands'
+        required: false
+        type: string
+        default: ""
 
 jobs:
   gen-matrix-h100:
@@ -55,6 +60,7 @@ jobs:
       alias: h100
       kernels: ${{ matrix.kernels }}
       env-vars: ${{ github.event.inputs.env_vars }}
+      custom-args: ${{ github.event.inputs.custom_args }}
 
   gen-matrix-b200:
     uses: ./.github/workflows/compute-benchmark-matrix.yml
@@ -81,6 +87,7 @@ jobs:
       alias: b200
       kernels: ${{ matrix.kernels }}
       env-vars: ${{ github.event.inputs.env_vars }}
+      custom-args: ${{ github.event.inputs.custom_args }}
 
   gen-matrix-mi325x:
     uses: ./.github/workflows/compute-benchmark-matrix.yml
@@ -107,3 +114,4 @@ jobs:
       alias: mi325x
       kernels: ${{ matrix.kernels }}
       env-vars: ${{ github.event.inputs.env_vars }}
+      custom-args: ${{ github.event.inputs.custom_args }}


### PR DESCRIPTION
This will be convenient for specifying or overwriting args, e.g.:
Run a specific input id:
`--input-id X --num-inputs 1`
Run first K inputs:
`--num-inputs K --input-sample-mode first-k`