### PR TITLE
[Benchmark CI] Set atol and rtol to 1e-2

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -158,6 +158,8 @@ jobs:
                 --only $IMPLS \
                 --only-match-mode prefix-with-baseline \
                 --baseline $BASELINE \
+                --atol 1e-2 \
+                --rtol 1e-2 \
                 --input-sample-mode equally-spaced-k \
                 --keep-going \
                 ${{ inputs.custom-args }}
@@ -174,6 +176,8 @@ jobs:
                 --only $IMPLS \
                 --only-match-mode prefix-with-baseline \
                 --baseline $BASELINE \
+                --atol 1e-2 \
+                --rtol 1e-2 \
                 --input-sample-mode equally-spaced-k \
                 --output "$TEST_REPORTS_DIR/helionbench.json" \
                 --append-to-output \


### PR DESCRIPTION
... to match Helion autotuner setting.

Accompanying PR: https://github.com/meta-pytorch/tritonbench/pull/569