### PR TITLE
[Autotuner] Adjust memory_per_job safety factor to 3 to alleviate OOM issue on Benchmark CI

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -183,7 +183,7 @@ class BaseSearch(BaseAutotuner):
         memory_per_job = _estimate_tree_bytes(self.args) + _estimate_tree_bytes(
             self._baseline_output
         )
-        memory_per_job *= 2  # safety factor
+        memory_per_job *= 3  # safety factor
         if memory_per_job <= 0:
             return jobs
 


### PR DESCRIPTION
Alternatively we could also expose this as an env var and set custom value only on Benchmark CI jobs.