### PR TITLE
Log generated triton code at the DEBUG level rather than INFO

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,6 +37,9 @@ jobs:
   benchmark:
     name: benchmark-${{ inputs.runtime-version }}-${{ inputs.kernels }}-py${{ inputs.python-version }}-${{ inputs.alias }}
 
+    env:
+      HELION_AUTOTUNE_LOG_LEVEL: DEBUG
+
     container:
       image: ${{ inputs.image }}
       options: ${{ inputs.container-options }}


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * __->__#986


--- --- ---

Log generated triton code at the DEBUG level rather than INFO

This was too noisy.