### PR TITLE
[Benchmark CI] Set welford num_inputs to 6 to avoid timeout

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -279,6 +279,9 @@ KERNEL_MAPPINGS: dict[str, tuple[str, ...]] = {  # pyright: ignore[reportAssignm
         "tritonbench.operators.welford.operator",
         "examples.welford",
         "welford",
+        {
+            "num_inputs": 6,  # welford takes long time on Benchmark CI, so use fewer inputs instead.
+        },
     ),
     "gather_gemv": (
         "tritonbench.operators.gather_gemv.operator",


### PR DESCRIPTION
Example timeout: https://github.com/pytorch/helion/actions/runs/18833945626/job/53730637790