### PR TITLE
Disable autotuner progress bar in fbcode unit test

### DIFF
--- a/helion/autotuner/progress_bar.py
+++ b/helion/autotuner/progress_bar.py
@@ -16,6 +16,7 @@ from rich.progress import Progress
 from rich.progress import ProgressColumn
 from rich.progress import TextColumn
 from rich.text import Text
+import torch
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -53,7 +54,7 @@ def iter_with_progress(
         When ``False`` the iterable is returned unchanged so there is zero
         overhead; when ``True`` a Rich progress bar is rendered.
     """
-    if not enabled:
+    if (not enabled) or torch._utils_internal.is_fb_unit_test():  # pyright: ignore[reportAttributeAccessIssue]
         yield from iterable
         return
 


### PR DESCRIPTION
Autotuner's progress bar doesn't work well in fbcode unit test environment and throws `rich.errors.LiveError: Only one live display may be active at once` error: [P2010469080](https://www.internalfb.com/phabricator/paste/view/P2010469080). Since having progress bar in fbcode unit test is not that meaningful, in this PR we skip the progress bar in that environment instead.