### PR TITLE
[CI] Fix debug_str() to be compatible with latest PyTorch nightly

### DIFF
--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -300,7 +300,8 @@ class DeviceIR:
 
     def debug_str(self) -> str:
         result = str(self)
-        return re.sub(r"(# File:\s+).*/([^/:]+:\d+)", r"\1.../\2", result)
+        # Normalize indentation to 4 spaces to handle both PyTorch 2.9 and nightly formatting
+        return re.sub(r" *(# File:\s+).*/([^/:]+:\d+)", r"    \1.../\2", result)
 
     def add_graph(
         self,


### PR DESCRIPTION
PyTorch PR that changed stacktrace summary formatting: https://github.com/pytorch/pytorch/pull/165397.

Example failing CI job: https://github.com/pytorch/helion/actions/runs/18923691664/job/54025942215?pr=1049

```
  def root_graph_0():
-    # File: .../basic_kernels.py:21 in torch_ops_pointwise, code: out[tile] = torch.sigmoid(torch.add(torch.sin(x[tile]), torch.cos(y[tile])))
+     # File: .../basic_kernels.py:21 in torch_ops_pointwise, code: out[tile] = torch.sigmoid(torch.add(torch.sin(x[tile]), torch.cos(y[tile])))
? +
      x: "i32[1024]" = helion_language__tracing_ops__host_tensor('x')
      block_size_0: "Sym(u0)" = helion_language__tracing_ops__get_symnode('block_size_0')
      load: "i32[u0]" = helion_language_memory_ops_load(x, [block_size_0], None, None);  x = None
      sin: "f32[u0]" = torch.ops.aten.sin.default(load);  load = None
      y: "i32[1024]" = helion_language__tracing_ops__host_tensor('y')
      load_1: "i32[u0]" = helion_language_memory_ops_load(y, [block_size_0], None, None);  y = None
      cos: "f32[u0]" = torch.ops.aten.cos.default(load_1);  load_1 = None
      add: "f32[u0]" = torch.ops.aten.add.Tensor(sin, cos);  sin = cos = None
      sigmoid: "f32[u0]" = torch.ops.aten.sigmoid.default(add);  add = None
      convert_element_type: "i32[u0]" = torch.ops.prims.convert_element_type.default(sigmoid, torch.int32);  sigmoid = None
      out: "i32[1024]" = helion_language__tracing_ops__host_tensor('out')
      store = helion_language_memory_ops_store(out, [block_size_0], convert_element_type, None);  out = block_size_0 = convert_element_type = store = None
      return None
```