### PR TITLE
[Fix upcoming CI error] Set current node in inductor lowering

### DIFF
--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -177,7 +177,7 @@ def prepare_node_lowering(
     prior_buffers = len(graph_lowering.buffers)
     input_names: list[str] = []
     with inductor_config.patch(INDUCTOR_PATCH):
-        with node.meta["location"]:
+        with node.meta["location"], graph_lowering.set_current_node(node):
             try:
                 result = graph_lowering.call_function(
                     node.target,  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
PyTorch upstream has another change https://github.com/pytorch/pytorch/pull/166339 that will break Helion unit tests, and it already shows up on internal diff train jobs (https://www.internalfb.com/intern/testinfra/diagnostics/8725724585228463.281475193251408.1761797259/). This PR fixes it.