### PR TITLE
Add static_shapes="none" mode to disable 0/1 shape specialization

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -1204,7 +1204,7 @@ def run_kernel_variants(
                             # Only force full autotuning if no configs are provided
                             if not attr.configs:
                                 attr.settings.force_autotune = True
-                            attr.settings.static_shapes = True
+                            attr.settings.static_shapes = "all"
 
                 if isinstance(kfunc, Kernel):
                     # Helion kernel - we call it in a lambda to delay execution until measurement

--- a/examples/welford.py
+++ b/examples/welford.py
@@ -49,7 +49,8 @@ def welford(
 
         for tile_n in hl.tile(n):
             chunk = x[tile_m, tile_n]
-            Tn = chunk.size(-1)
+            # Use tile.end - tile.begin to get actual tile size (handles partial tiles)
+            Tn = tile_n.end - tile_n.begin
             sum_x = torch.sum(chunk, dim=-1)
             sum_x2 = torch.sum(chunk * chunk, dim=-1)
             mean_c = sum_x / Tn

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -130,9 +130,9 @@ class CompileEnvironment:
                 f"The '{settings.backend}' backend is experimental and may have limited functionality.",
             )
         self.shape_env = ShapeEnv(
-            specialize_zero_one=True,
+            specialize_zero_one=(settings.static_shapes != "none"),
             duck_shape=False,
-            assume_static_by_default=settings.static_shapes,
+            assume_static_by_default=(settings.static_shapes == "all"),
         )
         # TODO(jansel): check for guards in the shapeenv
         self.fake_mode = FakeTensorMode(shape_env=self.shape_env)
@@ -293,13 +293,12 @@ class CompileEnvironment:
             source=ReductionLoopBlockSizeSource(
                 sum([int(bs.reduction) for bs in self.block_sizes])
             ),
-            # When size==0, next_power_of_2(size_hint(0)) == 1, and a hint of 1
-            # causes Inductor to see reduction_numel==1 and skip the reduction
-            # instead of generating a masked reduction that yields the identity value.
-            # Use hint=2 in that case so the reduction is preserved.
-            hint=2
-            if (size == 0 and next_power_of_2(self.size_hint(size)) == 1)
-            else next_power_of_2(self.size_hint(size)),
+            # When next_power_of_2(hint) == 1 (e.g. size==0 or symbolic size
+            # with hint 1), Inductor sees reduction_numel==1 and converts the
+            # reduction to a Pointwise op, eliminating the reduction loop.
+            # Use hint=2 so the full reduction is preserved; at runtime the
+            # wrapper passes the actual next_power_of_2(size) as a constexpr.
+            hint=max(2, next_power_of_2(self.size_hint(size))),
             reuse_var=reuse_var,
         )
         return self.block_sizes[rdim_idx]
@@ -320,6 +319,10 @@ class CompileEnvironment:
 
             shape_env_var_hints(self.shape_env)[sym._sympy_()] = sympy.Integer(hint)
         assert isinstance(sym._sympy_(), sympy.Symbol)
+        # Mark block vars as size-like so ShapeEnv won't 0/1-specialize them.
+        # With the symbol in size_like, _set_replacement checks size-oblivious
+        # bounds [2, int_oo] and rejects replacements with 0 or 1.
+        self.shape_env._constrain_range_for_size(sym._sympy_())
         self.debug_shape_renames[sym._sympy_()] = sympy.Symbol(debug_name, integer=True)
         return sym
 
@@ -534,7 +537,7 @@ class CompileEnvironment:
     def _to_fake_tensor(self, tensor: torch.Tensor, source: Source) -> torch.Tensor:
         assert CompileEnvironment.current() is self
         assert not self.fake_mode.is_our_fake(tensor)
-        if self.settings.static_shapes:
+        if self.settings.static_shapes == "all":
             result = torch.empty_strided(
                 tensor.size(),
                 tensor.stride(),
@@ -545,6 +548,18 @@ class CompileEnvironment:
             result = self.fake_mode.fake_tensor_converter.from_real_tensor(
                 self.fake_mode, tensor, shape_env=self.shape_env, source=source
             )
+            # Mark input symbols as size-like to prevent 0/1 specialization.
+            # Without this, operations like .view(-1) during type propagation
+            # trigger _set_replacement(s, 1) which bakes concrete shapes into
+            # the generated kernel and breaks reuse across the bucket.
+            for s in (*result.size(), *result.stride()):
+                if isinstance(s, torch.SymInt):
+                    sym = s._sympy_()
+                    if (
+                        isinstance(sym, sympy.Symbol)
+                        and sym not in self.specialized_vars
+                    ):
+                        self.shape_env._constrain_range_for_size(sym)
         self.input_sources[result] = source
         if isinstance(source, LocalSource):
             for i, s in enumerate(result.size()):
@@ -577,13 +592,28 @@ class CompileEnvironment:
         if isinstance(a, torch.SymInt) or isinstance(b, torch.SymInt):
             sa = a._sympy_() if isinstance(a, torch.SymInt) else a
             sb = b._sympy_() if isinstance(b, torch.SymInt) else b
+            # Resolve hl.specialize'd vars to their concrete values so
+            # equality checks don't depend on ShapeEnv replacements/axioms.
+            if isinstance(sa, sympy.Expr):
+                sa = self.specialize_expr(sa)
+            if isinstance(sb, sympy.Expr):
+                sb = self.specialize_expr(sb)
             if sa == sb:
                 return True
+            # After specialize_expr, remaining free symbols are
+            # non-specialized.  In "none" mode, don't let
+            # _maybe_evaluate_static prove them equal via axioms that
+            # guard evaluation may have created (e.g. Eq(s, 1)).
+            if self.settings.static_shapes == "none":
+                return False
             res = self.shape_env._maybe_evaluate_static(sympy.Eq(sa, sb))
             if res is None:
                 return False
             return bool(res)
         return a == b
+
+    def _is_size_one(self, size: int | torch.SymInt) -> bool:
+        return self.known_equal(size, 1)
 
     def known_multiple(self, a: sympy.Expr, b: int | torch.SymInt) -> bool:
         if isinstance(a, (int, sympy.Integer)) and isinstance(b, int):
@@ -660,6 +690,11 @@ class CompileEnvironment:
             The block ID if the size corresponds to a registered block size, None otherwise.
         """
         if isinstance(size, torch.SymInt):
+            # Identity check handles block vars whose sympy expr is a concrete
+            # Integer (e.g. in static_shapes="none" mode).
+            for bs in self.block_sizes:
+                if bs.var is size:
+                    return bs.block_id
             return self.get_block_id(size._sympy_())
         if isinstance(size, sympy.Symbol):
             from .host_function import HostFunction
@@ -717,6 +752,7 @@ class BlockSizeInfo:
     reduction: bool
     block_size_source: BlockSizeSource
     debug_names: set[str] = dataclasses.field(default_factory=set)
+    min_dot_size: int = 0
 
     def add_debug_name(self, name: str) -> None:
         if not name:
@@ -816,7 +852,7 @@ class LoopSpecBlockSizeSource(BlockSizeSource):
     def from_config(self, config: Config, block_size_info: BlockSizeInfo) -> int:
         env = CompileEnvironment.current()
         size = block_size_info.size
-        if isinstance(size, (int, torch.SymInt)) and env.known_equal(size, 1):
+        if isinstance(size, (int, torch.SymInt)) and env._is_size_one(size):
             return 1
         index = env.config_spec.block_sizes.block_id_to_index(block_size_info.block_id)
         return config.block_sizes[index]

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -281,7 +281,7 @@ class DeviceFunction:
         self.dce_vars: list[str] = []
         self.block_size_var_cache: dict[tuple[int, ...], str] = {}
         self.expr_to_var_info: dict[sympy.Expr, VarInfo] = {}
-        self.deferred_rdim_defs: list[tuple[str, sympy.Expr]] = []
+        self.deferred_rdim_defs: list[tuple[str, sympy.Expr, int]] = []
 
         from .helper_function import HelperFunctionManager
 
@@ -643,7 +643,7 @@ class DeviceFunction:
         ):
             return StaticShape(int(v))
         if isinstance(v, int):
-            if env.settings.static_shapes:
+            if env.settings.static_shapes == "all":
                 return StaticShape(v)
         return self._tensor_property(TensorStrideArg, fake_value, dim, "stride")
 
@@ -812,12 +812,15 @@ class DeviceFunction:
 
     def flush_deferred_rdim_defs(self, codegen: GenerateAST) -> None:
         """Add all deferred RDIM definitions to host statements."""
-        backend = CompileEnvironment.current().backend
-        for var_name, expr in self.deferred_rdim_defs:
+        env = CompileEnvironment.current()
+        backend = env.backend
+        for var_name, expr, block_id in self.deferred_rdim_defs:
             expr_str = HostFunction.current().sympy_expr(expr)
-            stmt = statement_from_string(
-                f"{var_name} = {backend.next_power_of_2_host_expr(expr_str)}"
-            )
+            inner = backend.next_power_of_2_host_expr(expr_str)
+            min_rdim = env.block_sizes[block_id].min_dot_size
+            if min_rdim > 0:
+                inner = f"max({min_rdim}, {inner})"
+            stmt = statement_from_string(f"{var_name} = {inner}")
             codegen.host_statements.append(stmt)
         self.deferred_rdim_defs.clear()
 

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -19,9 +19,11 @@ from .compile_environment import CompileEnvironment
 from .device_function import DeviceFunction
 from .dtype_utils import cast_ast
 from .host_function import HostFunction
+from .tile_strategy import DeviceLoopOrGridState
 from .tile_strategy import DeviceLoopState
 from .utils import compute_slice_size
 from .variable_origin import BlockSizeOrigin
+from .variable_origin import GridOrigin
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -32,6 +34,52 @@ if TYPE_CHECKING:
 
     SymIntLike = torch.SymInt | int
     ShapeLike = Sequence[SymIntLike]
+
+
+def _is_grid_origin(sym: torch.SymInt) -> bool:
+    """Return True if `sym` is a grid index (from hl.grid), not a tile index."""
+    origin_info = HostFunction.current().expr_to_origin.get(sym._sympy_())
+    return origin_info is not None and isinstance(origin_info.origin, GridOrigin)
+
+
+def _needs_runtime_broadcast(
+    size: int | torch.SymInt,
+    env: CompileEnvironment,
+) -> bool:
+    """True when a dim may be 1 at runtime but is not specialized.
+
+    In "none" mode, size-1 dims are not specialized at compile time, so
+    the compiler cannot rely on compile-time broadcast.  Returns False
+    for concrete ints, non-"none" modes, or dims pinned by
+    hl.specialize().
+    """
+    return (
+        isinstance(size, torch.SymInt)
+        and env.settings.static_shapes == "none"
+        and not isinstance(env.specialize_expr(size._sympy_()), sympy.Integer)
+    )
+
+
+def _block_ptr_may_need_broadcast(
+    size: int | torch.SymInt,
+    env: CompileEnvironment,
+    loop_state: object,
+    block_index: int,
+) -> bool:
+    """Check if a block_ptr dim might need broadcasting in "none" mode.
+
+    block_ptr zero-pads out-of-bounds elements instead of broadcasting,
+    so we must fall back to pointer indexing when a dim could be 1 at
+    runtime.  If the dim's sympy expression matches the tile loop bound,
+    the dim equals the tile range and cannot be a broadcast dim.
+    """
+    if not _needs_runtime_broadcast(size, env):
+        return False
+    if not isinstance(loop_state, DeviceLoopOrGridState):
+        return False
+    assert isinstance(size, torch.SymInt)
+    end_expr = loop_state.block_id_to_info[block_index].end_expr
+    return size._sympy_() != end_expr
 
 
 def _get_padded_iota_original_length(
@@ -214,7 +262,7 @@ class PointerIndexingStrategy(IndexingStrategy):
                 k, state, k_index
             ) is not None or isinstance(k, torch.Tensor):
                 # Tensor index (tile.index + offset or regular tensor) - block index
-                if not env.known_equal(fake_tensor.size(tensor_dim), 1):
+                if not env._is_size_one(fake_tensor.size(tensor_dim)):
                     pointer_has_block_dims = True
                 tensor_dim += 1
                 k_index += 1
@@ -226,7 +274,7 @@ class PointerIndexingStrategy(IndexingStrategy):
                     origin = HostFunction.current().expr_to_origin.get(symbol)
                 if origin and isinstance(origin.origin, BlockSizeOrigin):
                     # Block index
-                    if not env.known_equal(fake_tensor.size(tensor_dim), 1):
+                    if not env._is_size_one(fake_tensor.size(tensor_dim)):
                         pointer_has_block_dims = True
                 # Both block and scalar SymInt consume a tensor dimension
                 tensor_dim += 1
@@ -235,8 +283,8 @@ class PointerIndexingStrategy(IndexingStrategy):
                 # Slice - adds block dimension if slice_size > 1
                 size = fake_tensor.size(tensor_dim)
                 slice_size = compute_slice_size(k, size)
-                if not env.known_equal(slice_size, 1):
-                    if not env.known_equal(fake_tensor.size(tensor_dim), 1):
+                if not env._is_size_one(slice_size):
+                    if not env._is_size_one(fake_tensor.size(tensor_dim)):
                         pointer_has_block_dims = True
                 tensor_dim += 1
                 k_index += 1
@@ -703,21 +751,19 @@ class SubscriptIndexing(NamedTuple):
                 k_index += 1
             elif isinstance(k, torch.SymInt):
                 input_size.popleft()
-                symbol = k._sympy_()
-                if isinstance(symbol, sympy.Symbol):
-                    origin = HostFunction.current().expr_to_origin.get(symbol)
-                    if origin and isinstance(origin.origin, BlockSizeOrigin):
-                        # Always use block size for consistency with type propagation.
-                        # This ensures shapes match what _device_indexing_size computes.
-                        output_size.append(k)
-                # Note: if not BlockSizeOrigin, this is a scalar index that eliminates the dim
+                block_id = env.get_block_id(k)
+                # Grid indices (from hl.grid) are scalar selectors that
+                # consume a dimension, like plain integer indices.
+                # Only tile/block indices add a dimension to the output.
+                if block_id is not None and not _is_grid_origin(k):
+                    output_size.append(k)
                 k_index += 1
             elif isinstance(k, slice):
                 size = input_size.popleft()
                 # Handle slices with steps
                 slice_size = compute_slice_size(k, size)
 
-                if slice_size != 1:
+                if not env._is_size_one(slice_size):
                     rdim = env.allocate_reduction_dimension(slice_size)
                     output_size.append(rdim.var)
                 else:
@@ -797,9 +843,6 @@ class SubscriptIndexing(NamedTuple):
         if dtype == "tl.int32" and SubscriptIndexing._needs_int64(fake_value):
             raise exc.IndexOffsetOutOfRangeForInt32(env.index_dtype)
 
-        def _is_size_one(size: int | torch.SymInt) -> bool:
-            return env.known_equal(size, 1)
-
         k_index = 0
 
         def handle_broadcast_tensor(
@@ -848,7 +891,7 @@ class SubscriptIndexing(NamedTuple):
                     pos < len(output_size)
                     and (bid := env.get_block_id(output_size[pos])) is not None
                     and (mv := state.codegen.mask_var(bid))
-                    and not _is_size_one(fake_value.size(len(index_values)))
+                    and not env._is_size_one(fake_value.size(len(index_values)))
                 ):
                     new_masks.setdefault(
                         f"({mv}){tile_strategy.expand_str(output_size, pos)}"
@@ -866,7 +909,7 @@ class SubscriptIndexing(NamedTuple):
                             p < len(output_size)
                             and (bid := env.get_block_id(output_size[p])) is not None
                             and (mv := state.codegen.mask_var(bid))
-                            and not _is_size_one(fake_value.size(len(index_values)))
+                            and not env._is_size_one(fake_value.size(len(index_values)))
                         ):
                             new_masks.setdefault(
                                 f"({mv}){tile_strategy.expand_str(output_size, p)}"
@@ -896,33 +939,33 @@ class SubscriptIndexing(NamedTuple):
                 i = len(index_values)
                 index_values.append(f"(({index_var}) + {offset_expr}){expand}")
                 # Use the same mask as the underlying tile
-                if (mask := state.codegen.mask_var(block_id)) and not _is_size_one(
+                if (mask := state.codegen.mask_var(block_id)) and not env._is_size_one(
                     fake_value.size(i)
                 ):
                     mask_values.setdefault(f"({mask}){expand}")
                 # Track if this dimension needs broadcasting (tensor size is 1 but output has block_size)
-                if _is_size_one(fake_value.size(i)) and not _is_size_one(
+                if env._is_size_one(fake_value.size(i)) and not env._is_size_one(
                     output_size[output_idx]
                 ):
                     size1_broadcast_dims.append((output_idx, output_size[output_idx]))
                 output_idx += 1
                 k_index += 1
             elif isinstance(k, torch.SymInt):
-                symbol = k._sympy_()
-                origin = None
-                if isinstance(symbol, sympy.Symbol):
-                    origin = HostFunction.current().expr_to_origin.get(symbol)
-                if origin and isinstance(origin.origin, BlockSizeOrigin):
-                    index_var = state.codegen.index_var(origin.origin.block_id)
+                block_id = env.get_block_id(k)
+                # Grid indices (from hl.grid) are scalar selectors that
+                # consume a dimension, like plain integer indices.
+                # Only tile/block indices add a dimension to the output.
+                if block_id is not None and not _is_grid_origin(k):
+                    index_var = state.codegen.index_var(block_id)
                     expand = tile_strategy.expand_str(output_size, output_idx)
                     i = len(index_values)
                     index_values.append(f"({index_var}){expand}")
                     if (
-                        mask := state.codegen.mask_var(origin.origin.block_id)
-                    ) and not _is_size_one(fake_value.size(i)):
+                        mask := state.codegen.mask_var(block_id)
+                    ) and not env._is_size_one(fake_value.size(i)):
                         mask_values.setdefault(f"({mask}){expand}")
                     # Track if this dimension needs broadcasting
-                    if _is_size_one(fake_value.size(i)) and not _is_size_one(
+                    if env._is_size_one(fake_value.size(i)) and not env._is_size_one(
                         output_size[output_idx]
                     ):
                         size1_broadcast_dims.append(
@@ -931,7 +974,7 @@ class SubscriptIndexing(NamedTuple):
                     output_idx += 1
                     k_index += 1
                 else:
-                    # When the index is a scalar (no BlockSizeOrigin), the corresponding dim is eliminated.
+                    # Scalar index (no block_id, or grid origin): dim is eliminated.
                     val = state.device_function.literal_expr(k)
                     index_values.append(f"({val})")
             elif isinstance(k, slice):
@@ -945,7 +988,7 @@ class SubscriptIndexing(NamedTuple):
                     step = k.step
                     slice_size = compute_slice_size(k, size)
 
-                    if slice_size != 1:
+                    if not env._is_size_one(slice_size):
                         rdim = env.allocate_reduction_dimension(slice_size)
                         block_idx = rdim.block_id
                         index_var = state.codegen.index_var(block_idx)
@@ -959,7 +1002,7 @@ class SubscriptIndexing(NamedTuple):
                         index_values.append(f"{start}{expand}")
                 else:
                     # Full slice or slice without step
-                    if not _is_size_one(size):
+                    if not env._is_size_one(size):
                         rdim = env.allocate_reduction_dimension(size)
                         block_idx = rdim.block_id
                         index_var = state.codegen.index_var(block_idx)
@@ -1000,7 +1043,7 @@ class SubscriptIndexing(NamedTuple):
                 )
                 if mask_block_id is not None:
                     mask_var = state.codegen.mask_var(mask_block_id)
-                    if mask_var and not _is_size_one(
+                    if mask_var and not env._is_size_one(
                         fake_value.size(len(index_values) - 1)
                     ):
                         mask_values.setdefault(f"({mask_var}){expand}")
@@ -1013,9 +1056,13 @@ class SubscriptIndexing(NamedTuple):
         assert len(index_values) == fake_value.ndim
         index_expr = []
         for i, idx in enumerate(index_values):
-            if not _is_size_one(fake_value.size(i)):
+            if not env._is_size_one(fake_value.size(i)):
                 stride = state.device_function.tensor_stride(fake_value, i).name
-                index_expr.append(f"{idx} * {stride}")
+                if _needs_runtime_broadcast(fake_value.size(i), env):
+                    size_name = state.device_function.tensor_size(fake_value, i).name
+                    index_expr.append(f"{idx} * ({stride} * ({size_name} != 1))")
+                else:
+                    index_expr.append(f"{idx} * {stride}")
         if not index_expr:
             shape_str = tile_strategy.shape_str(output_size)
             index_expr.append(f"tl.zeros({shape_str}, {dtype})")
@@ -1122,7 +1169,7 @@ class BlockedSubscriptIndexing:
             self.block_shape, self.reshaped_size, strict=True
         ):
             # If block_shape has 1 but target has a larger value, need broadcast
-            if env.known_equal(block_dim, 1) and not env.known_equal(target_dim, 1):
+            if env._is_size_one(block_dim) and not env._is_size_one(target_dim):
                 return True
         return False
 
@@ -1180,6 +1227,10 @@ class BlockedSubscriptIndexing:
                         assert state.fx_node is not None
                         if "masked_value" in state.fx_node.meta:
                             return False
+                if _block_ptr_may_need_broadcast(
+                    input_size, env, loop_state, block_index
+                ):
+                    return False
                 k_index += 1
             elif isinstance(k, torch.SymInt):
                 symbol = k._sympy_()
@@ -1207,6 +1258,10 @@ class BlockedSubscriptIndexing:
                                 # TODO(jansel): in this case we should be able to lower to block_ptr+tl.where
                                 # see test/test_loops.py::TestLoops::test_data_dependent_bounds2
                                 return False
+                    if _block_ptr_may_need_broadcast(
+                        input_size, env, loop_state, block_index
+                    ):
+                        return False
                 k_index += 1
             elif isinstance(k, torch.Tensor):
                 # indirect loads don't work with block_ptr
@@ -1243,7 +1298,7 @@ class BlockedSubscriptIndexing:
                 tile_info := _get_tile_with_offset_info(k, state, k_index)
             ) is not None:
                 # Tensor marked as tile.index + offset
-                if fake_value.size(len(res.offsets)) != 1:
+                if not env._is_size_one(fake_value.size(len(res.offsets))):
                     block_id, offset = tile_info
                     offset_var = state.codegen.offset_var(block_id)
                     offset_expr = state.device_function.literal_expr(offset)
@@ -1257,7 +1312,7 @@ class BlockedSubscriptIndexing:
                 symbol = k._sympy_()
                 origin = HostFunction.current().expr_to_origin.get(symbol)
                 if origin and isinstance(origin.origin, BlockSizeOrigin):
-                    if fake_value.size(len(res.offsets)) != 1:
+                    if not env._is_size_one(fake_value.size(len(res.offsets))):
                         res.offsets.append(
                             state.codegen.offset_var(origin.origin.block_id)
                         )
@@ -1278,7 +1333,7 @@ class BlockedSubscriptIndexing:
                         f"Strided slices not supported in block_ptr mode: {k}"
                     )
                 # Full slice or slice without step
-                if size != 1:
+                if not env._is_size_one(size):
                     rdim = env.allocate_reduction_dimension(size)
                     res.offsets.append(state.codegen.offset_var(rdim.block_id))
                     res.block_shape.append(rdim.var)

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -978,9 +978,12 @@ class GenerateASTFromInductor(DefaultHandler):
 
         # If the lifted symbol refers to a `tl.constexpr` kernel
         # argument (for example a tile/block size constant such as
-        # `_BLOCK_SIZE_1`) the resulting value is not a tensor and
-        # does not need casting.
+        # `_BLOCK_SIZE_1`) or a scalar kernel argument (such as a
+        # size or stride parameter), the resulting value is not a
+        # tensor and does not need casting.
         if name in self.cg.device_function._constexpr_args:
+            return name
+        if any(arg.name == name for arg in self.cg.device_function._expr_args.values()):
             return name
 
         return self._lift(self._create_cast_expr(expr_from_string(name), dtype))

--- a/helion/_compiler/matmul_utils.py
+++ b/helion/_compiler/matmul_utils.py
@@ -146,6 +146,14 @@ def _resolve_dim_size(
     if not isinstance(v, (torch.SymInt, sympy.Expr)):
         return v
 
+    # In "none" mode, don't resolve via config lookup.  Block sizes for
+    # full-dimension reductions are runtime constexprs (e.g.
+    # ``triton.next_power_of_2(n)``) that vary per invocation.  Resolving
+    # them to the config value (which reflects only the *first* invocation)
+    # would generate shape-specific padding code that can't be reused.
+    if env.settings.static_shapes == "none":
+        return v
+
     device_fn = DeviceFunction.current()
     cfg = device_fn.config
     block_idx = env.get_block_id(v)
@@ -292,6 +300,23 @@ def emit_tl_dot_with_padding(
         dim_value = dims[d]
         pad_needed[d] = dim_value is not None and dim_value < min_sizes[d]
     need_padding = any(pad_needed.values())
+
+    # In "none" mode, symbolic dimensions skip padding (their runtime value
+    # varies).  Instead, register the minimum size requirement so the wrapper
+    # can emit ``max(min, next_power_of_2(…))`` for the corresponding
+    # constexpr.  This ensures tl.dot gets operands that meet hardware
+    # minimums without baking shape-specific reshapes into the kernel.
+    #
+    # Register by block_id so that flush_deferred_rdim_defs can match
+    # the RDIM's numel to the correct block, even though tensor shapes
+    # use block variables while RDIM numels use original size expressions.
+    if env.settings.static_shapes == "none":
+        for dim_val, min_size in [(m, min_m), (n, min_n), (k, min_k)]:
+            if not isinstance(dim_val, int) and min_size > 1:
+                block_id = env.get_block_id(dim_val)
+                if block_id is not None:
+                    bs = env.block_sizes[block_id]
+                    bs.min_dot_size = max(bs.min_dot_size, min_size)
 
     if not need_padding:
         result = _emit_tl_dot(

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -247,10 +247,16 @@ class PersistentReductionStrategy(ReductionStrategy):
             else:
                 # Check for block size dependencies
                 block_mapping, _ = find_block_size_symbols(numel)
-                if block_mapping:
-                    # Defer issuing statement until block sizes are known
+                if block_mapping or env.settings.static_shapes == "none":
+                    # Defer so flush_deferred_rdim_defs can apply the
+                    # min_dot_size clamp after all block sizes are resolved.
+                    # In "none" mode the reduction dim is always symbolic
+                    # (even when concretely 1), so we must also defer here
+                    # to avoid emitting the statement before
+                    # emit_tl_dot_with_padding has registered its min-size
+                    # requirement.
                     state.device_function.deferred_rdim_defs.append(
-                        (block_size_var, numel)
+                        (block_size_var, numel, block_idx)
                     )
                 else:
                     # No dependencies - issue statement immediately

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -1027,7 +1027,9 @@ class _BaseNDTileStrategy(BlockSizeTileStrategy):
 
     def _to_ast(self, x: object, to_dtype: str | None = None) -> ast.AST:
         if isinstance(x, ast.AST):
-            if to_dtype:
+            # Casting is only valid for Triton tensor expressions
+            # Skip casting for simple names/constants representing host scalar args
+            if to_dtype and not isinstance(x, (ast.Name, ast.Constant)):
                 cast_expr = CompileEnvironment.current().backend.ast_to_dtype_expr(
                     "{value}", to_dtype
                 )

--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -488,7 +488,7 @@ class TensorType(TypeInfo):
 
                 if self.origin.is_device():
                     output_sizes.append(output_size)
-                elif output_size != 1:
+                elif not CompileEnvironment.current()._is_size_one(output_size):
                     # If all symbols in output_size are block size symbols, we reuse them
                     if isinstance(output_size, torch.SymInt):
                         expr = output_size._sympy_()

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 BackendLiteral = Literal["triton", "pallas", "cute", "tileir"]
 DotPrecision = Literal["tf32", "tf32x3", "ieee"]
 PrecompileMode = Literal["spawn", "fork"] | None
+StaticShapes = Literal["all", "ones", "none"]
 _TRUE_LITERALS = frozenset({"1", "true", "yes", "on"})
 _FALSE_LITERALS = frozenset({"0", "false", "no", "off"})
 
@@ -339,6 +340,40 @@ def _get_autotune_random_seed() -> int:
     return int(time.time() * 1000) % 2**32
 
 
+def normalize_static_shapes(value: bool | str) -> StaticShapes:
+    """
+    Normalize static_shapes value to the string literal type.
+    Converts bool to string for backward compatibility: True -> "all", False -> "ones".
+    Also handles bool-ish strings like "1", "true", "yes", "on", "0", "false", "no", "off".
+    """
+    if value is True:
+        return "all"
+    if value is False:
+        return "ones"
+    if isinstance(value, str):
+        lowered = value.lower()
+        if lowered in ("all", "ones", "none"):
+            return lowered
+        if lowered in _TRUE_LITERALS:
+            return "all"
+        if lowered in _FALSE_LITERALS:
+            return "ones"
+    raise ValueError(
+        f"static_shapes must be one of 'all', 'ones', 'none', True, or False, got {value!r}"
+    )
+
+
+def _get_static_shapes() -> StaticShapes:
+    """
+    Get the static_shapes setting from HELION_STATIC_SHAPES environment variable.
+    Default is "all" (fully static shapes).
+    """
+    value = os.environ.get("HELION_STATIC_SHAPES")
+    if value is None or (value := value.strip()) == "":
+        return "all"
+    return normalize_static_shapes(value)
+
+
 def _get_ref_mode() -> RefMode:
     interpret = _env_get_bool("HELION_INTERPRET", False)
     triton_interpret = os.environ.get("TRITON_INTERPRET") == "1"
@@ -388,9 +423,7 @@ class _Settings:
         default_factory=_get_index_dtype
     )
     dot_precision: DotPrecision = dataclasses.field(default_factory=_get_dot_precision)
-    static_shapes: bool = dataclasses.field(
-        default_factory=functools.partial(_env_get_bool, "HELION_STATIC_SHAPES", True)
-    )
+    static_shapes: StaticShapes = dataclasses.field(default_factory=_get_static_shapes)
     persistent_reserved_sms: int = dataclasses.field(
         default_factory=functools.partial(
             _env_get_int,
@@ -552,8 +585,12 @@ class Settings(_Settings):
         ),
         "dot_precision": "Precision for dot products, see `triton.language.dot`. Can be 'tf32', 'tf32x3', or 'ieee'.",
         "static_shapes": (
-            "If True, use static shapes for all tensors. This is a performance optimization. "
-            "Set HELION_STATIC_SHAPES=0 to disable."
+            "Shape specialization mode. "
+            "'all' (default): fully static shapes, specialize on exact tensor dimensions. "
+            "'ones': dynamic shapes, specialize on 0 and 1 sized dimensions. "
+            "'none': dynamic shapes, specialize only on 0 sized dimensions. "
+            "Accepts bool for backward compat: True='all', False='ones'. "
+            "Set via HELION_STATIC_SHAPES=all|ones|none|0|1."
         ),
         "persistent_reserved_sms": (
             "Number of streaming multiprocessors to reserve when launching persistent kernels. "
@@ -656,6 +693,16 @@ class Settings(_Settings):
             raise exc.MissingEnableTile
 
         self._check_ref_eager_mode_before_print_output_code()
+
+    def __setattr__(self, name: str, value: object) -> None:
+        """
+        Override setattr to auto-normalize static_shapes on assignment.
+        This ensures that direct assignments like `settings.static_shapes = False`
+        are properly normalized to the string literal type.
+        """
+        if name == "static_shapes":
+            value = normalize_static_shapes(value)  # type: ignore[arg-type]
+        super().__setattr__(name, value)
 
     def to_dict(self) -> dict[str, object]:
         """

--- a/test/test_debug_utils.expected
+++ b/test/test_debug_utils.expected
@@ -8,7 +8,7 @@ import helion.language as hl
 import torch
 from torch._dynamo.testing import rand_strided
 
-@helion.kernel(config=helion.Config(block_sizes=[32], num_warps=4), static_shapes=True)
+@helion.kernel(config=helion.Config(block_sizes=[32], num_warps=4), static_shapes='all')
 def kernel(x: torch.Tensor) -> torch.Tensor:
     out = torch.empty_like(x)
     n = x.shape[0]
@@ -31,7 +31,7 @@ import helion.language as hl
 import torch
 from torch._dynamo.testing import rand_strided
 
-@helion.kernel(config=helion.Config(block_sizes=[64], num_warps=8), static_shapes=True)
+@helion.kernel(config=helion.Config(block_sizes=[64], num_warps=8), static_shapes='all')
 def kernel(x: torch.Tensor) -> torch.Tensor:
     out = torch.empty_like(x)
     n = x.shape[0]
@@ -54,7 +54,7 @@ import helion.language as hl
 import torch
 from torch._dynamo.testing import rand_strided
 
-@helion.kernel(config=helion.Config(block_sizes=[32], indexing=[], load_eviction_policies=[], num_stages=1, num_warps=4, pid_type='flat', range_flattens=[None], range_multi_buffers=[None], range_num_stages=[0], range_unroll_factors=[0], range_warp_specializes=[]), static_shapes=True)
+@helion.kernel(config=helion.Config(block_sizes=[32], indexing=[], load_eviction_policies=[], num_stages=1, num_warps=4, pid_type='flat', range_flattens=[None], range_multi_buffers=[None], range_num_stages=[0], range_unroll_factors=[0], range_warp_specializes=[]), static_shapes='all')
 def kernel_with_compile_error(x: torch.Tensor) -> torch.Tensor:
     out = torch.empty_like(x)
     n = x.shape[0]
@@ -80,7 +80,7 @@ import helion.language as hl
 import torch
 from torch._dynamo.testing import rand_strided
 
-@helion.kernel(config=helion.Config(block_sizes=[32], num_warps=4), static_shapes=True)
+@helion.kernel(config=helion.Config(block_sizes=[32], num_warps=4), static_shapes='all')
 def kernel_with_triton_error(x: torch.Tensor) -> torch.Tensor:
     out = torch.empty_like(x)
     n = x.shape[0]

--- a/test/test_debug_utils.expected_tileir
+++ b/test/test_debug_utils.expected_tileir
@@ -8,7 +8,7 @@ import helion.language as hl
 import torch
 from torch._dynamo.testing import rand_strided
 
-@helion.kernel(config=helion.Config(block_sizes=[32], num_warps=4), static_shapes=True)
+@helion.kernel(config=helion.Config(block_sizes=[32], num_warps=4), static_shapes='all')
 def kernel(x: torch.Tensor) -> torch.Tensor:
     out = torch.empty_like(x)
     n = x.shape[0]
@@ -31,7 +31,7 @@ import helion.language as hl
 import torch
 from torch._dynamo.testing import rand_strided
 
-@helion.kernel(config=helion.Config(block_sizes=[64], num_warps=8), static_shapes=True)
+@helion.kernel(config=helion.Config(block_sizes=[64], num_warps=8), static_shapes='all')
 def kernel(x: torch.Tensor) -> torch.Tensor:
     out = torch.empty_like(x)
     n = x.shape[0]
@@ -54,7 +54,7 @@ import helion.language as hl
 import torch
 from torch._dynamo.testing import rand_strided
 
-@helion.kernel(config=helion.Config(block_sizes=[32], indexing=[], load_eviction_policies=[], num_stages=1, num_warps=4, pid_type='flat', range_flattens=[], range_multi_buffers=[], range_num_stages=[], range_unroll_factors=[], range_warp_specializes=[]), static_shapes=True)
+@helion.kernel(config=helion.Config(block_sizes=[32], indexing=[], load_eviction_policies=[], num_stages=1, num_warps=4, pid_type='flat', range_flattens=[], range_multi_buffers=[], range_num_stages=[], range_unroll_factors=[], range_warp_specializes=[]), static_shapes='all')
 def kernel_with_compile_error(x: torch.Tensor) -> torch.Tensor:
     out = torch.empty_like(x)
     n = x.shape[0]
@@ -80,7 +80,7 @@ import helion.language as hl
 import torch
 from torch._dynamo.testing import rand_strided
 
-@helion.kernel(config=helion.Config(block_sizes=[32], num_warps=4), static_shapes=True)
+@helion.kernel(config=helion.Config(block_sizes=[32], num_warps=4), static_shapes='all')
 def kernel_with_triton_error(x: torch.Tensor) -> torch.Tensor:
     out = torch.empty_like(x)
     n = x.shape[0]

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -2454,42 +2454,43 @@ class TestIndexing(RefEagerTestBase, TestCase):
         missing masking in the generated code.
         """
 
-        @helion.kernel(autotune_effort="none", static_shapes=False)
-        def jagged_iota(out_offsets):
-            n = out_offsets.size(0) - 1
-            out = torch.zeros(out_offsets[n].item(), device=out_offsets.device)
-            for tile_n in hl.tile(n):
-                s = out_offsets[tile_n]
-                e = out_offsets[tile_n + 1]
-                lens = e - s
-                max_len = lens.amax()
-
-                for tile_l in hl.tile(max_len):
-                    idx = tile_l.index[None, :] + s[:, None]
-                    mask = tile_l.index[None, :] < lens[:, None]
-                    hl.store(out, [idx], idx, extra_mask=mask)
-            return out
-
         offsets = torch.tensor([0, 2, 3, 5, 7], device=DEVICE)
 
-        # n=0: offsets[:1] has shape (1,). static_shapes=False still
-        # specializes on 0/1 which creates a specialized kernel for dim=1
-        # (bucket (1,) vs (2,) for dim>=2).
-        result = jagged_iota(offsets[:1].clone())
-        torch.testing.assert_close(
-            result, torch.arange(0, dtype=torch.float32, device=DEVICE)
-        )
-        self.assertEqual(len(jagged_iota._bound_kernels), 1)
+        # Expected bound kernels after each call with shapes (1,), (2,), (4,), (5,):
+        #   "all":  each exact shape gets its own kernel → 1, 2, 3, 4
+        #   "ones": dim=1 specialized separately, dim>=2 shared → 1, 2, 2, 2
+        #   "none": dim=1 lumped with dim>=2 (no 0/1 specialization) → 1, 1, 1, 1
+        expected_kernels = {
+            "all": [1, 2, 3, 4],
+            "ones": [1, 2, 2, 2],
+            "none": [1, 1, 1, 1],
+        }
 
-        # n=1: offsets[:2] has shape (2,), which buckets to (2,) — a new
-        # dynamic kernel is compiled, giving 2 bound kernels total.
-        for n in [1, 3, len(offsets) - 1]:
-            result = jagged_iota(offsets[: n + 1].clone())
-            total = offsets[n].item()
-            expected = torch.arange(total, dtype=torch.float32, device=DEVICE)
-            torch.testing.assert_close(result, expected)
-            # First iteration (n=1) compiles a second kernel; rest reuse it.
-            self.assertEqual(len(jagged_iota._bound_kernels), 2)
+        for mode, expected in expected_kernels.items():
+            with self.subTest(static_shapes=mode):
+
+                @helion.kernel(autotune_effort="none", static_shapes=mode)
+                def jagged_iota(out_offsets):
+                    n = out_offsets.size(0) - 1
+                    out = torch.zeros(out_offsets[n].item(), device=out_offsets.device)
+                    for tile_n in hl.tile(n):
+                        s = out_offsets[tile_n]
+                        e = out_offsets[tile_n + 1]
+                        lens = e - s
+                        max_len = lens.amax()
+
+                        for tile_l in hl.tile(max_len):
+                            idx = tile_l.index[None, :] + s[:, None]
+                            mask = tile_l.index[None, :] < lens[:, None]
+                            hl.store(out, [idx], idx, extra_mask=mask)
+                    return out
+
+                for i, n in enumerate([0, 1, 3, len(offsets) - 1]):
+                    result = jagged_iota(offsets[: n + 1].clone())
+                    total = offsets[n].item()
+                    exp = torch.arange(total, dtype=torch.float32, device=DEVICE)
+                    torch.testing.assert_close(result, exp)
+                    self.assertEqual(len(jagged_iota._bound_kernels), expected[i])
 
     def test_scalar_tensor_index_with_grid(self):
         """Index a tensor with a 0-dim scalar tensor from a grid load."""

--- a/test/test_loops.py
+++ b/test/test_loops.py
@@ -845,11 +845,11 @@ class TestLoops(RefEagerTestBase, TestCase):
         self.assertNotEqualCode(code0, code3)
         # Check that range_num_stages parameter appears in tl.range call
         self.assertNotIn(
-            "tl.range(0, tl.cast(x_size_1, tl.int32), _BLOCK_SIZE_1, num_stages=",
+            "tl.range(0, x_size_1, _BLOCK_SIZE_1, num_stages=",
             code0,
         )
         self.assertIn(
-            "tl.range(0, tl.cast(x_size_1, tl.int32), _BLOCK_SIZE_1, num_stages=3)",
+            "tl.range(0, x_size_1, _BLOCK_SIZE_1, num_stages=3)",
             code3,
         )
 

--- a/test/test_matmul.py
+++ b/test/test_matmul.py
@@ -20,23 +20,6 @@ from helion._testing import skipIfTileIR
 from helion._testing import skipUnlessTensorDescriptor
 import helion.language as hl
 
-_orig_matmul_fp32_precision: str = "none"
-_orig_cudnn_fp32_precision: str = "none"
-
-
-def setUpModule() -> None:
-    global _orig_matmul_fp32_precision, _orig_cudnn_fp32_precision
-    _orig_matmul_fp32_precision = torch.backends.cuda.matmul.fp32_precision
-    _orig_cudnn_fp32_precision = torch.backends.cudnn.conv.fp32_precision
-    torch.backends.cuda.matmul.fp32_precision = "tf32"
-    torch.backends.cudnn.conv.fp32_precision = "tf32"
-
-
-def tearDownModule() -> None:
-    torch.backends.cuda.matmul.fp32_precision = _orig_matmul_fp32_precision
-    torch.backends.cudnn.conv.fp32_precision = _orig_cudnn_fp32_precision
-
-
 examples_dir = Path(__file__).parent.parent / "examples"
 
 
@@ -93,6 +76,12 @@ def matmul_static_shapes(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
 @onlyBackends(["triton"])
 class TestMatmul(RefEagerTestBase, TestCase):
+    def setUp(self):
+        super().setUp()
+        for obj in (torch.backends.cuda.matmul, torch.backends.cudnn.conv):
+            self.addCleanup(setattr, obj, "fp32_precision", obj.fp32_precision)
+            obj.fp32_precision = "tf32"
+
     def test_matmul0(self):
         args = (
             torch.randn([128, 128], device=DEVICE, dtype=torch.float32),

--- a/test/test_shape_bucketing.py
+++ b/test/test_shape_bucketing.py
@@ -1,0 +1,1133 @@
+from __future__ import annotations
+
+import re
+import unittest
+from unittest.mock import patch
+
+import torch
+from torch.testing._internal.common_utils import instantiate_parametrized_tests
+from torch.testing._internal.common_utils import parametrize
+
+import helion
+from helion import _compat
+from helion._testing import DEVICE
+from helion._testing import RefEagerTestBase
+from helion._testing import TestCase
+from helion._testing import skipIfNotCUDA
+from helion._testing import skipIfRefEager
+from helion._testing import skipIfTileIR
+import helion.language as hl
+from helion.runtime.config import Config
+from helion.runtime.kernel import kernel
+from helion.runtime.settings import Settings
+
+
+def pointwise_add_kernel(x: torch.Tensor) -> torch.Tensor:
+    """Simple pointwise kernel: out = x + 1.0"""
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size()):
+        out[tile] = x[tile] + 1.0
+    return out
+
+
+def reduction_sum_kernel(x: torch.Tensor) -> torch.Tensor:
+    """Reduction kernel: sum along last dimension."""
+    out = x.new_empty([x.size(0)])
+    for tile in hl.tile(x.size(0)):
+        out[tile] = x[tile, :].sum(-1)
+    return out
+
+
+def softmax_two_pass_kernel(x: torch.Tensor) -> torch.Tensor:
+    """Numerically optimized softmax in two passes - from examples/softmax.py.
+
+    This kernel has nested hl.tile loops and reduces over the inner dimension.
+    """
+    m, n = x.size()
+    out = torch.empty_like(x)
+    block_size_m = hl.register_block_size(m)
+    block_size_n = hl.register_block_size(n)
+    for tile_m in hl.tile(m, block_size=block_size_m):
+        mi = hl.full([tile_m], float("-inf"), dtype=torch.float32)
+        di = hl.zeros([tile_m], dtype=torch.float32)
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            local_amax = torch.amax(values, dim=1)
+            mi_next = torch.maximum(mi, local_amax)
+            di = di * torch.exp(mi - mi_next) + torch.exp(
+                values - mi_next[:, None]
+            ).sum(dim=1)
+            mi = mi_next
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            out[tile_m, tile_n] = torch.exp(values - mi[:, None]) / di[:, None]
+    return out
+
+
+def nested_tile_kernel(x: torch.Tensor) -> torch.Tensor:
+    """Nested tile kernel with registered block sizes."""
+    m, n = x.size()
+    out = torch.empty_like(x)
+    block_size_m = hl.register_block_size(m)
+    block_size_n = hl.register_block_size(n)
+    for tile_m in hl.tile(m, block_size=block_size_m):
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            out[tile_m, tile_n] = x[tile_m, tile_n] + 1.0
+    return out
+
+
+class TestShapeBucketing(RefEagerTestBase, TestCase):
+    maxDiff = 16384
+
+    def _make_kernel(self, fn, mode, **kwargs):
+        """Create a kernel with the given static_shapes mode and autotune disabled."""
+        return kernel(
+            fn, settings=Settings(static_shapes=mode, autotune_effort="none"), **kwargs
+        )
+
+    def _check_bucketing(
+        self,
+        kernel_fn,
+        ref_fn,
+        shape1,
+        shape2,
+        same_in_ones,
+        *,
+        rtol=1e-4,
+        atol=1e-4,
+        modes=("none", "ones", "all"),
+        **kernel_kwargs,
+    ):
+        """Check correctness, bucket identity, and cross-size reuse for two shapes."""
+        for mode in modes:
+            with self.subTest(mode=mode):
+                k = self._make_kernel(kernel_fn, mode, **kernel_kwargs)
+                x1 = torch.randn(*shape1, device=DEVICE, dtype=torch.float32)
+                r1 = k(x1)
+                torch.testing.assert_close(r1, ref_fn(x1), rtol=rtol, atol=atol)
+                x2 = torch.randn(*shape2, device=DEVICE, dtype=torch.float32)
+                r2 = k(x2)
+                torch.testing.assert_close(r2, ref_fn(x2), rtol=rtol, atol=atol)
+                bound1 = k.bind((x1,))
+                bound2 = k.bind((x2,))
+                if mode == "none":
+                    self.assertIs(bound1, bound2)
+                    self.assertEqual(len(k._bound_kernels), 1)
+                elif mode == "ones":
+                    if same_in_ones:
+                        self.assertIs(bound1, bound2)
+                        self.assertEqual(len(k._bound_kernels), 1)
+                    else:
+                        self.assertIsNot(bound1, bound2)
+                        self.assertEqual(len(k._bound_kernels), 2)
+                else:
+                    assert mode == "all"
+                    self.assertIsNot(bound1, bound2)
+
+    @skipIfRefEager("code generation not relevant in ref eager mode")
+    @skipIfNotCUDA()
+    def test_pointwise_size1_bucketing_across_modes(self) -> None:
+        """Test pointwise kernel with all modes and shape variations."""
+
+        def ref(x):
+            return x + 1.0
+
+        # (desc, shape1, shape2, same_in_ones)
+        shape_list = [
+            ("dim0=1", (1, 16), (4, 16), False),  # 1->4 changes 1-ness
+            ("dim1=1", (16, 1), (16, 8), False),  # 1->8 changes 1-ness
+            ("both=1", (1, 1), (4, 8), False),  # both 1s -> no 1s
+            ("no_1s", (2, 16), (8, 32), True),  # both ≥2 in all dims
+            ("same_1_in_dim0", (1, 16), (1, 32), True),  # same 1-ness pattern
+            ("dim0=2_dim1=1", (2, 1), (2, 8), False),  # boundary: size==bucket
+            ("shape2_dim1_1", (4, 16), (4, 1), False),  # shape2 has 1-dim
+            # 3D tensors with mixed size-1 dimensions
+            ("3d_outer_inner_1", (1, 32, 1), (4, 32, 8), False),
+            ("3d_middle_1", (4, 1, 8), (4, 16, 8), False),
+            ("3d_all_1", (1, 1, 1), (4, 8, 16), False),
+            ("3d_no_1s", (4, 8, 16), (2, 3, 5), True),
+            ("3d_shape2_middle_1", (4, 16, 8), (4, 1, 8), False),
+        ]
+        for desc, shape1, shape2, same_in_ones in shape_list:
+            with self.subTest(shapes=desc):
+                self._check_bucketing(
+                    pointwise_add_kernel, ref, shape1, shape2, same_in_ones
+                )
+
+        # Incremental bucket growth: same-1-ness shapes share one bucket,
+        # then a different-1-ness shape creates a second bucket.
+        with self.subTest(case="ones_mode_incremental_bucket_growth"):
+            k = self._make_kernel(pointwise_add_kernel, "ones")
+            # Three shapes with dim0=1 → all share one bucket
+            for shape in [(1, 16), (1, 32), (1, 3)]:
+                x = torch.randn(*shape, device=DEVICE, dtype=torch.float32)
+                torch.testing.assert_close(k(x), ref(x), rtol=1e-4, atol=1e-4)
+            self.assertEqual(len(k._bound_kernels), 1)
+            # Different 1-ness pattern → second bucket
+            x = torch.randn(4, 16, device=DEVICE, dtype=torch.float32)
+            torch.testing.assert_close(k(x), ref(x), rtol=1e-4, atol=1e-4)
+            self.assertEqual(len(k._bound_kernels), 2)
+
+    @skipIfRefEager("code generation not relevant in ref eager mode")
+    @skipIfNotCUDA()
+    def test_reduction_size1_bucketing_across_modes(self) -> None:
+        """Test reduction kernel with all modes and shape variations."""
+
+        def ref(x):
+            return x.sum(-1)
+
+        # (desc, shape1, shape2, same_in_ones)
+        shape_list = [
+            ("dim0=1", (1, 64), (4, 64), False),  # 1->4 changes 1-ness
+            ("dim0=2", (2, 64), (8, 64), True),  # 2->8, both non-1
+            ("rdim1", (32, 1), (32, 64), False),  # was test_reduction_rdim1
+            (
+                "rdim_varies",
+                (32, 16),
+                (32, 64),
+                True,
+            ),  # was test_reduction_varying_nonzero_rdim
+            ("both_1", (1, 1), (4, 32), False),  # was test_reduction_both_dims_1
+        ]
+        for desc, shape1, shape2, same_in_ones in shape_list:
+            with self.subTest(shapes=desc):
+                self._check_bucketing(
+                    reduction_sum_kernel, ref, shape1, shape2, same_in_ones
+                )
+
+    @skipIfRefEager("code generation not relevant in ref eager mode")
+    @skipIfNotCUDA()
+    @parametrize("mode", ("none", "ones", "all"))
+    def test_stride_specialization(self, mode: str) -> None:
+        """Test stride handling across all bucketing modes.
+
+        In 'ones'/'none' modes, strides are NOT in the cache key — a kernel
+        compiled for contiguous input must still be correct for transposed input.
+        In 'all' mode, strides ARE in the cache key — contiguous vs transposed
+        same-shape tensors produce different specialization keys.
+        """
+
+        def ref(x):
+            return x + 1.0
+
+        if mode in ("ones", "none"):
+            # Pointwise: correctness with different strides
+            k = self._make_kernel(pointwise_add_kernel, mode)
+            x1 = torch.randn(32, 64, device=DEVICE, dtype=torch.float32)
+            result1 = k(x1)
+            torch.testing.assert_close(result1, ref(x1), rtol=1e-4, atol=1e-4)
+
+            x2 = torch.randn(64, 32, device=DEVICE, dtype=torch.float32).T
+            self.assertEqual(x2.shape, (32, 64))
+            self.assertFalse(x2.is_contiguous())
+            result2 = k(x2)
+            torch.testing.assert_close(result2, ref(x2), rtol=1e-4, atol=1e-4)
+
+            # Strides are NOT in the cache key — same key for contig vs transposed
+            key_contig = k.specialization_key([x1])
+            key_transposed = k.specialization_key([x2])
+            self.assertEqual(key_contig, key_transposed)
+
+            # Reduction: correctness with different strides
+            k = self._make_kernel(reduction_sum_kernel, mode)
+            x1 = torch.randn(8, 64, device=DEVICE, dtype=torch.float32)
+            result1 = k(x1)
+            torch.testing.assert_close(result1, x1.sum(-1), rtol=1e-4, atol=1e-4)
+
+            x2 = torch.randn(64, 8, device=DEVICE, dtype=torch.float32).T
+            self.assertEqual(x2.shape, (8, 64))
+            self.assertFalse(x2.is_contiguous())
+            result2 = k(x2)
+            torch.testing.assert_close(result2, x2.sum(-1), rtol=1e-4, atol=1e-4)
+
+            key_contig = k.specialization_key([x1])
+            key_transposed = k.specialization_key([x2])
+            self.assertEqual(key_contig, key_transposed)
+        else:
+            assert mode == "all"
+
+            def dummy(x: torch.Tensor) -> torch.Tensor:
+                return x
+
+            k = kernel(
+                dummy, settings=Settings(static_shapes="all", autotune_effort="none")
+            )
+            t_contig = torch.randn(32, 64, device=DEVICE, dtype=torch.float32)
+            t_transposed = torch.randn(64, 32, device=DEVICE, dtype=torch.float32).T
+            self.assertEqual(t_transposed.shape, (32, 64))
+
+            key_contig = k.specialization_key([t_contig])
+            key_transposed = k.specialization_key([t_transposed])
+            self.assertNotEqual(key_contig, key_transposed)
+
+            # Same shape + same strides → same key
+            t_contig2 = torch.randn(32, 64, device=DEVICE, dtype=torch.float32)
+            self.assertEqual(key_contig, k.specialization_key([t_contig2]))
+
+    @skipIfRefEager("code generation not relevant in ref eager mode")
+    @skipIfNotCUDA()
+    @parametrize("mode", ("none", "ones", "all"))
+    def test_mark_static_dims_force_recompilation_on_change(self, mode: str) -> None:
+        """Test mark_static: single dim, multiple dims, and size-1 dims."""
+
+        def ref(x):
+            return x + 1.0
+
+        # Single dim mark_static: changing marked dim → cache miss
+        k = self._make_kernel(pointwise_add_kernel, mode)
+        x1 = torch.randn(96, 32, device=DEVICE, dtype=torch.float32)
+        torch._dynamo.mark_static(x1, 0)
+        result1 = k(x1)
+        torch.testing.assert_close(result1, ref(x1), rtol=1e-4, atol=1e-4)
+        bound1 = k.bind((x1,))
+
+        x2 = torch.randn(128, 32, device=DEVICE, dtype=torch.float32)
+        torch._dynamo.mark_static(x2, 0)
+        result2 = k(x2)
+        torch.testing.assert_close(result2, ref(x2), rtol=1e-4, atol=1e-4)
+        self.assertIsNot(bound1, k.bind((x2,)))
+
+        # In dynamic modes, changing non-marked dim → cache hit
+        if mode in ("ones", "none"):
+            x3 = torch.randn(96, 48, device=DEVICE, dtype=torch.float32)
+            torch._dynamo.mark_static(x3, 0)
+            result3 = k(x3)
+            torch.testing.assert_close(result3, ref(x3), rtol=1e-4, atol=1e-4)
+            self.assertIs(bound1, k.bind((x3,)))
+
+        # Remaining sub-cases only apply to dynamic modes
+        if mode == "all":
+            return
+
+        # Multiple dims marked static: changing either dim → cache miss
+        k = self._make_kernel(pointwise_add_kernel, mode)
+        x1 = torch.randn(48, 64, device=DEVICE, dtype=torch.float32)
+        torch._dynamo.mark_static(x1, 0)
+        torch._dynamo.mark_static(x1, 1)
+        result1 = k(x1)
+        torch.testing.assert_close(result1, ref(x1), rtol=1e-4, atol=1e-4)
+        bound1 = k.bind((x1,))
+
+        x2 = torch.randn(96, 64, device=DEVICE, dtype=torch.float32)
+        torch._dynamo.mark_static(x2, 0)
+        torch._dynamo.mark_static(x2, 1)
+        result2 = k(x2)
+        torch.testing.assert_close(result2, ref(x2), rtol=1e-4, atol=1e-4)
+        self.assertIsNot(bound1, k.bind((x2,)))
+
+        x3 = torch.randn(48, 128, device=DEVICE, dtype=torch.float32)
+        torch._dynamo.mark_static(x3, 0)
+        torch._dynamo.mark_static(x3, 1)
+        result3 = k(x3)
+        torch.testing.assert_close(result3, ref(x3), rtol=1e-4, atol=1e-4)
+        self.assertIsNot(bound1, k.bind((x3,)))
+
+        # Size-1 dim with mark_static: different marked value → different BoundKernel
+        k = self._make_kernel(pointwise_add_kernel, mode)
+        x1 = torch.randn(1, 32, device=DEVICE, dtype=torch.float32)
+        torch._dynamo.mark_static(x1, 0)
+        result1 = k(x1)
+        torch.testing.assert_close(result1, ref(x1), rtol=1e-4, atol=1e-4)
+        bound1 = k.bind((x1,))
+
+        x2 = torch.randn(4, 32, device=DEVICE, dtype=torch.float32)
+        torch._dynamo.mark_static(x2, 0)
+        result2 = k(x2)
+        torch.testing.assert_close(result2, ref(x2), rtol=1e-4, atol=1e-4)
+        self.assertIsNot(bound1, k.bind((x2,)))
+
+        # static_indices changes the specialization key:
+        # marked vs unmarked should produce different keys even with same shapes
+        k = self._make_kernel(pointwise_add_kernel, mode)
+        x_marked = torch.randn(32, 64, device=DEVICE, dtype=torch.float32)
+        torch._dynamo.mark_static(x_marked, 0)
+        x_unmarked = torch.randn(32, 64, device=DEVICE, dtype=torch.float32)
+        key_marked = k.specialization_key([x_marked])
+        key_unmarked = k.specialization_key([x_unmarked])
+        self.assertNotEqual(key_marked, key_unmarked)
+
+    @skipIfRefEager("code generation not relevant in ref eager mode")
+    @skipIfNotCUDA()
+    @parametrize("mode", ("none", "ones", "all"))
+    def test_zero_size_dims(self, mode: str) -> None:
+        """Test zero-size dimensions work correctly with all bucketing modes."""
+
+        def ref(x):
+            return x + 1.0
+
+        # Correctness: zero-size dims produce empty but correct results
+        # NOTE: reduction with zero-size reduction dim (e.g. [4, 0]) is not
+        # tested because Triton's tl.arange(0, 0) is unsupported.
+        for shape in [(0, 32), (0, 0)]:
+            with self.subTest(case="correctness", shape=shape):
+                k = self._make_kernel(pointwise_add_kernel, mode)
+                x = torch.randn(*shape, device=DEVICE, dtype=torch.float32)
+                result = k(x)
+                self.assertEqual(result.shape, shape)
+                torch.testing.assert_close(result, ref(x), rtol=1e-4, atol=1e-4)
+
+        # Reuse: two zero-first-dim shapes with different second dims
+        # should map to the same bucket in "none" and "ones" modes.
+        if mode in ("none", "ones"):
+            k = self._make_kernel(pointwise_add_kernel, mode)
+            xa = torch.randn(0, 16, device=DEVICE, dtype=torch.float32)
+            k(xa)
+            xb = torch.randn(0, 32, device=DEVICE, dtype=torch.float32)
+            k(xb)
+            self.assertIs(k.bind((xa,)), k.bind((xb,)))
+
+        # Specialization key: zero-size dim produces distinct key from non-zero dims
+        k = self._make_kernel(pointwise_add_kernel, mode)
+        x_zero = torch.randn(0, 32, device=DEVICE, dtype=torch.float32)
+        x_nonzero = torch.randn(4, 32, device=DEVICE, dtype=torch.float32)
+        key_zero = k.specialization_key([x_zero])
+        key_nonzero = k.specialization_key([x_nonzero])
+        self.assertNotEqual(key_zero, key_nonzero)
+
+        # Identity: zero-size shapes must not share BoundKernels
+        for shape_a, shape_b in [((0, 32), (4, 32)), ((0, 0), (0, 32))]:
+            with self.subTest(case="identity", shapes=(shape_a, shape_b)):
+                k = self._make_kernel(pointwise_add_kernel, mode)
+                xa = torch.randn(*shape_a, device=DEVICE, dtype=torch.float32)
+                k(xa)
+                bound_a = k.bind((xa,))
+
+                xb = torch.randn(*shape_b, device=DEVICE, dtype=torch.float32)
+                k(xb)
+                bound_b = k.bind((xb,))
+                self.assertIsNot(bound_a, bound_b)
+
+    @skipIfRefEager("code generation not relevant in ref eager mode")
+    @skipIfNotCUDA()
+    def test_softmax_two_pass_with_size1_inner_dim(self) -> None:
+        """Test softmax two-pass kernel with size-1 dimensions."""
+
+        def ref(x):
+            return torch.softmax(x, dim=-1)
+
+        shape_list = [
+            ("n=1", (32, 1), (32, 64), False),
+            ("both=1", (1, 1), (4, 6), False),
+        ]
+        for desc, shape1, shape2, same_in_ones in shape_list:
+            with self.subTest(shapes=desc):
+                self._check_bucketing(
+                    softmax_two_pass_kernel,
+                    ref,
+                    shape1,
+                    shape2,
+                    same_in_ones,
+                    rtol=1e-3,
+                    atol=1e-3,
+                )
+
+    @skipIfRefEager("code generation not relevant in ref eager mode")
+    @skipIfNotCUDA()
+    def test_view_flatten_none_mode_with_unit_dim(self) -> None:
+        """Test .view(-1) works with static_shapes='none' when n=1."""
+
+        def cross_entropy(
+            logits: torch.Tensor,
+            labels: torch.Tensor,
+        ) -> torch.Tensor:
+            n, v = logits.shape
+            losses = torch.zeros([n], dtype=logits.dtype, device=logits.device)
+            logits_flat = logits.view(-1)
+            for tile_n in hl.tile(n):
+                labels_tile = labels[tile_n]
+                base_indices_tile = tile_n.index * v
+                flat_indices = base_indices_tile + labels_tile
+                logits_at_target = hl.load(logits_flat, [flat_indices])
+                logits_rows = logits[tile_n, :]
+                max_logits = torch.amax(logits_rows, dim=-1, keepdim=True)
+                shifted = logits_rows - max_logits
+                exp_shifted = torch.exp(shifted)
+                sum_exp = torch.sum(exp_shifted, dim=-1, keepdim=True)
+                log_sum_exp = max_logits.squeeze(-1) + torch.log(sum_exp.squeeze(-1))
+                losses[tile_n] = log_sum_exp - logits_at_target
+            return losses.mean()
+
+        k = kernel(
+            cross_entropy,
+            settings=Settings(
+                static_shapes="none",
+                autotune_effort="none",
+                ignore_warnings=[helion.exc.TensorOperationInWrapper],
+            ),
+        )
+
+        m, n = 32, 1
+        logits = torch.randn(m, n, device=DEVICE, dtype=torch.float32)
+        labels = torch.randint(0, n, (m,), device=DEVICE, dtype=torch.long)
+
+        result = k(logits, labels)
+        expected = torch.nn.functional.cross_entropy(logits, labels)
+
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+
+    @skipIfRefEager("code generation not relevant in ref eager mode")
+    @skipIfNotCUDA()
+    def test_nested_tile_with_size1_dims(self) -> None:
+        """Test nested tile kernel with size-1 dimensions and none-mode reuse."""
+
+        def ref(x):
+            return x + 1.0
+
+        shape_list = [
+            ("m=1", (1, 64), (32, 64), False),
+            ("n=1", (32, 1), (32, 64), False),
+            ("both=1", (1, 1), (32, 64), False),
+        ]
+        for desc, shape1, shape2, same_in_ones in shape_list:
+            with self.subTest(shapes=desc):
+                self._check_bucketing(
+                    nested_tile_kernel,
+                    ref,
+                    shape1,
+                    shape2,
+                    same_in_ones,
+                    rtol=1e-5,
+                    atol=1e-5,
+                    config=Config(block_sizes=[32, 32]),
+                )
+
+    @skipIfRefEager("code generation not relevant in ref eager mode")
+    @skipIfNotCUDA()
+    @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
+    @skipIfTileIR("TileIR does not support block_ptr indexing")
+    def test_block_ptr_reduction_none_mode_size1(self) -> None:
+        """Test block_ptr + reduction + none mode with size-1 reduction dim."""
+        self._check_bucketing(
+            reduction_sum_kernel,
+            lambda x: x.sum(-1),
+            (32, 1),
+            (32, 64),
+            False,
+            modes=("none",),
+            config=Config(block_sizes=[32], indexing="block_ptr"),
+        )
+
+    @skipIfRefEager("code generation not relevant in ref eager mode")
+    @skipIfNotCUDA()
+    def test_none_mode_size1_broadcast(self) -> None:
+        """Test 'none' mode broadcast: bias is (1, n) but indexed with tiles from (m, n).
+
+        In 'none' mode, size-1 dims are not specialized, so the compiler
+        doesn't know at compile time that bias.size(0) == 1 and can't
+        generate static broadcast code. The generated kernel must still
+        produce correct results via runtime stride-based broadcasting.
+        """
+
+        def add_bias(x: torch.Tensor, bias: torch.Tensor, out: torch.Tensor) -> None:
+            m, n = x.size()
+            block_m = hl.register_block_size(m)
+            block_n = hl.register_block_size(n)
+            for tile_m in hl.tile(m, block_size=block_m):
+                for tile_n in hl.tile(n, block_size=block_n):
+                    out[tile_m, tile_n] = x[tile_m, tile_n] + bias[tile_m, tile_n]
+
+        # First verify it works in "ones" mode (where broadcast is generated)
+        k_ones = self._make_kernel(
+            add_bias, "ones", config=Config(block_sizes=[32, 32])
+        )
+        x = torch.randn(4, 8, device=DEVICE, dtype=torch.float32)
+        bias = torch.randn(1, 8, device=DEVICE, dtype=torch.float32)
+        out_ones = torch.empty_like(x)
+        k_ones(x, bias, out_ones)
+        expected = x + bias  # PyTorch broadcasts bias (1, 8) to (4, 8)
+        torch.testing.assert_close(out_ones, expected, rtol=1e-4, atol=1e-4)
+
+        # Now test "none" mode — the broadcast code path is NOT taken,
+        # so the bias load might not correctly broadcast the size-1 dim.
+        k_none = self._make_kernel(
+            add_bias, "none", config=Config(block_sizes=[32, 32])
+        )
+        out_none = torch.empty_like(x)
+        k_none(x, bias, out_none)
+        torch.testing.assert_close(out_none, expected, rtol=1e-4, atol=1e-4)
+
+        # In "none" mode, different non-zero shapes share the same specialization key.
+        key_x = k_none.specialization_key([x, bias, out_none])
+        bias_full = torch.randn(4, 8, device=DEVICE, dtype=torch.float32)
+        out_full = torch.empty_like(x)
+        key_full = k_none.specialization_key([x, bias_full, out_full])
+        self.assertEqual(key_x, key_full)
+
+    @skipIfRefEager("code generation not relevant in ref eager mode")
+    @skipIfNotCUDA()
+    @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
+    @skipIfTileIR("TileIR does not support block_ptr indexing")
+    def test_block_ptr_broadcast_none_mode(self) -> None:
+        """Test block_ptr indexing with broadcast in 'none' mode.
+
+        In block_ptr mode, BlockedSubscriptIndexing uses tl.make_block_ptr which
+        handles out-of-bounds via boundary_check (zero-padding). For a (1, n) tensor
+        with block_shape (tile_m, tile_n), rows beyond the first are padded with 0
+        instead of being broadcast from row 0. This tests whether the result is correct.
+
+        Also tests reuse: compile with no broadcast first, reuse with broadcast.
+        """
+
+        def add_bias(x: torch.Tensor, bias: torch.Tensor, out: torch.Tensor) -> None:
+            m, n = x.size()
+            block_m = hl.register_block_size(m)
+            block_n = hl.register_block_size(n)
+            for tile_m in hl.tile(m, block_size=block_m):
+                for tile_n in hl.tile(n, block_size=block_n):
+                    out[tile_m, tile_n] = x[tile_m, tile_n] + bias[tile_m, tile_n]
+
+        k = self._make_kernel(
+            add_bias, "none", config=Config(block_sizes=[32, 32], indexing="block_ptr")
+        )
+
+        # First call: broadcast (bias has size-1 dim 0)
+        with self.subTest(case="broadcast"):
+            x = torch.randn(4, 8, device=DEVICE, dtype=torch.float32)
+            bias = torch.randn(1, 8, device=DEVICE, dtype=torch.float32)
+            out = torch.empty_like(x)
+            k(x, bias, out)
+            expected = x + bias  # PyTorch broadcasts bias (1, 8) to (4, 8)
+            torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+
+        # Second call: no broadcast then broadcast (reuse test)
+        with self.subTest(case="reuse"):
+            k2 = self._make_kernel(
+                add_bias,
+                "none",
+                config=Config(block_sizes=[32, 32], indexing="block_ptr"),
+            )
+            # First call: no broadcast (bias same shape as x)
+            x1 = torch.randn(4, 8, device=DEVICE, dtype=torch.float32)
+            bias1 = torch.randn(4, 8, device=DEVICE, dtype=torch.float32)
+            out1 = torch.empty_like(x1)
+            k2(x1, bias1, out1)
+            torch.testing.assert_close(out1, x1 + bias1, rtol=1e-4, atol=1e-4)
+
+            # Second call: broadcast needed (bias has size-1 dim 0)
+            x2 = torch.randn(4, 8, device=DEVICE, dtype=torch.float32)
+            bias2 = torch.randn(1, 8, device=DEVICE, dtype=torch.float32)
+            out2 = torch.empty_like(x2)
+            k2(x2, bias2, out2)
+            torch.testing.assert_close(out2, x2 + bias2, rtol=1e-4, atol=1e-4)
+
+    @skipIfRefEager("specialization keys not relevant in ref eager mode")
+    def test_backward_compat_bool_to_string_modes(self) -> None:
+        """Test backward compatibility: True maps to 'all', False maps to 'ones'."""
+        t1 = torch.empty(1, 3)
+        t2 = torch.empty(2, 3)
+        t3 = torch.empty(3, 3)
+
+        def dummy(x: torch.Tensor) -> torch.Tensor:
+            return x
+
+        # True -> 'all' mode: verify normalization and behavior
+        settings_all = Settings(static_shapes=True, autotune_effort="none")
+        self.assertEqual(settings_all.static_shapes, "all")  # normalized to string
+        k_all = kernel(dummy, settings=settings_all)
+        key_all_2 = k_all.specialization_key([t2])
+        key_all_3 = k_all.specialization_key([t3])
+        self.assertNotEqual(key_all_2, key_all_3)  # each exact size is distinct
+
+        # False -> 'ones' mode: verify normalization and behavior
+        settings_ones = Settings(static_shapes=False, autotune_effort="none")
+        self.assertEqual(settings_ones.static_shapes, "ones")  # normalized to string
+        k_ones = kernel(dummy, settings=settings_ones)
+        key_ones_1 = k_ones.specialization_key([t1])
+        key_ones_2 = k_ones.specialization_key([t2])
+        key_ones_3 = k_ones.specialization_key([t3])
+        self.assertNotEqual(key_ones_1, key_ones_2)  # 1 is distinct from >=2
+        self.assertEqual(key_ones_2, key_ones_3)  # but 2 and 3 are same
+
+
+instantiate_parametrized_tests(TestShapeBucketing)
+
+
+# Shape variations to test 1-ness: (description, m, n)
+ALL_SHAPES = [
+    ("dim0=1", 1, 64),
+    ("dim1=1", 32, 1),
+    ("both=1", 1, 1),
+    ("normal", 32, 64),
+]
+
+# Each example config: (example_name, fn_name, input_fn, ref_fn, shape_list)
+# input_fn: callable(m, n) -> tuple of args (m, n are dimensions)
+# ref_fn: callable(*args) -> expected output
+# shape_list: list of (description, m, n) tuples to test
+EXAMPLE_CONFIGS_WITH_SHAPES: list[
+    tuple[str, str | None, object, object, list[tuple[str, int, int]]]
+] = [
+    # Simple pointwise operations - support all shapes
+    (
+        "add",
+        None,
+        lambda m, n: (
+            torch.randn(m, n, device=DEVICE, dtype=torch.float32),
+            torch.randn(m, n, device=DEVICE, dtype=torch.float32),
+        ),
+        lambda x, y: torch.add(x, y),
+        ALL_SHAPES,
+    ),
+    (
+        "exp",
+        "exp_fwd",
+        lambda m, n: (torch.randn(m, n, device=DEVICE, dtype=torch.float32),),
+        lambda x: torch.exp(x),
+        ALL_SHAPES,
+    ),
+    # Reduction operations - test all shapes including n=1 edge case
+    (
+        "sum",
+        "sum_kernel",
+        lambda m, n: (torch.randn(m, n, device=DEVICE, dtype=torch.float32),),
+        lambda x: x.sum(-1),
+        ALL_SHAPES,
+    ),
+    (
+        "softmax",
+        "softmax_two_pass",
+        lambda m, n: (torch.randn(m, n, device=DEVICE, dtype=torch.float32),),
+        lambda x: torch.nn.functional.softmax(x, dim=-1),
+        ALL_SHAPES,
+    ),
+    (
+        "cross_entropy",
+        "cross_entropy",
+        lambda m, n: (
+            torch.randn(m, n, device=DEVICE, dtype=torch.float32),
+            torch.randint(0, n, (m,), device=DEVICE, dtype=torch.long),
+        ),
+        lambda logits, labels: torch.nn.functional.cross_entropy(logits, labels),
+        ALL_SHAPES,
+    ),
+    # Normalization operations
+    (
+        "rms_norm",
+        "rms_norm_fwd",
+        lambda m, n: (
+            torch.randn(m, n, device=DEVICE, dtype=torch.float32),
+            torch.randn(n, device=DEVICE, dtype=torch.float32),
+            1e-5,
+        ),
+        lambda x, w, eps: torch.nn.functional.rms_norm(x, (x.shape[-1],), w, eps),
+        ALL_SHAPES,
+    ),
+    # Embedding lookup - support all shapes
+    (
+        "embedding",
+        "embedding",
+        lambda m, n: (
+            torch.randint(0, 128, (m, n), device=DEVICE, dtype=torch.int32),
+            torch.randn(128, 64, device=DEVICE, dtype=torch.float32),
+        ),
+        lambda x, w: torch.nn.functional.embedding(x.long(), w),
+        ALL_SHAPES,
+    ),
+    # Concatenation - support all shapes
+    (
+        "concatenate",
+        "concat2d_dim1",
+        lambda m, n: (
+            torch.randn(m, n, device=DEVICE, dtype=torch.float32),
+            torch.randn(m, n + 8, device=DEVICE, dtype=torch.float32),
+        ),
+        lambda x, y: torch.cat([x, y], dim=1),
+        ALL_SHAPES,
+    ),
+    # GEGLU activation
+    (
+        "geglu",
+        "geglu",
+        lambda m, n: (
+            torch.randn(m, n, device=DEVICE, dtype=torch.float32),
+            torch.randn(m, n, device=DEVICE, dtype=torch.float32),
+        ),
+        lambda x1, x2: torch.nn.functional.gelu(x1, approximate="tanh") * x2,
+        ALL_SHAPES,
+    ),
+    # SwiGLU activation
+    (
+        "swiglu",
+        "swiglu_fwd",
+        lambda m, n: (
+            torch.randn(m, n, device=DEVICE, dtype=torch.float32),
+            torch.randn(m, n, device=DEVICE, dtype=torch.float32),
+        ),
+        lambda x1, x2: torch.nn.functional.silu(x1) * x2,
+        ALL_SHAPES,
+    ),
+    # Additional softmax variants - test all shapes
+    (
+        "softmax",
+        "softmax",  # Simple wrapper around torch.nn.functional.softmax
+        lambda m, n: (torch.randn(m, n, device=DEVICE, dtype=torch.float32),),
+        lambda x: torch.nn.functional.softmax(x, dim=-1),
+        ALL_SHAPES,
+    ),
+    (
+        "softmax",
+        "softmax_decomposed",  # Decomposed softmax with explicit max, exp, normalize
+        lambda m, n: (torch.randn(m, n, device=DEVICE, dtype=torch.float32),),
+        lambda x: torch.nn.functional.softmax(x, dim=-1),
+        ALL_SHAPES,
+    ),
+    # Long sum - reduction along last dimension
+    (
+        "long_sum",
+        "longsum",
+        lambda m, n: (torch.randn(m, n, device=DEVICE, dtype=torch.float32),),
+        lambda x: x.sum(-1),
+        ALL_SHAPES,
+    ),
+    # Welford layer norm - uses Welford's algorithm for mean/variance
+    (
+        "welford",
+        "welford",
+        lambda m, n: (
+            torch.randn(n, device=DEVICE, dtype=torch.float32),  # weight
+            torch.randn(n, device=DEVICE, dtype=torch.float32),  # bias
+            torch.randn(m, n, device=DEVICE, dtype=torch.float32),  # x
+            1e-5,  # eps
+        ),
+        lambda w, b, x, eps: torch.nn.functional.layer_norm(
+            x, (x.shape[-1],), w, b, eps
+        ),
+        ALL_SHAPES,
+    ),
+    # Long sum variants - reduction along last dimension with different implementations
+    (
+        "long_sum",
+        "longsum_w_red_loop",
+        lambda m, n: (torch.randn(m, n, device=DEVICE, dtype=torch.float32),),
+        lambda x: x.sum(-1),
+        ALL_SHAPES,
+    ),
+    (
+        "long_sum",
+        "longsum_manual",
+        lambda m, n: (torch.randn(m, n, device=DEVICE, dtype=torch.float32),),
+        lambda x: x.sum(-1),
+        ALL_SHAPES,
+    ),
+    # Layer norm forward - normalization over the last dimension
+    (
+        "layer_norm",
+        "layer_norm_fwd",
+        lambda m, n: (
+            torch.randn(m, n, device=DEVICE, dtype=torch.float32),  # x
+            [n],  # normalized_shape
+            torch.randn(n, device=DEVICE, dtype=torch.float32),  # weight
+            torch.randn(n, device=DEVICE, dtype=torch.float32),  # bias
+            1e-5,  # eps
+        ),
+        lambda x, ns, w, b, eps: torch.nn.functional.layer_norm(x, ns, w, b, eps),
+        ALL_SHAPES,
+    ),
+    # Matrix multiplication - with k dimension fixed
+    (
+        "matmul",
+        "matmul",
+        lambda m, n: (
+            torch.randn(m, 64, device=DEVICE, dtype=torch.float32),  # x: [m, k]
+            torch.randn(64, n, device=DEVICE, dtype=torch.float32),  # y: [k, n]
+        ),
+        lambda x, y: torch.matmul(x, y),
+        ALL_SHAPES,
+    ),
+    # Matrix multiplication with split-K - higher parallelism for large K
+    (
+        "matmul_split_k",
+        "matmul_split_k",
+        lambda m, n: (
+            torch.randn(m, 128, device=DEVICE, dtype=torch.float32),  # x: [m, k]
+            torch.randn(128, n, device=DEVICE, dtype=torch.float32),  # y: [k, n]
+        ),
+        lambda x, y: torch.matmul(x, y),
+        ALL_SHAPES,
+    ),
+    # Fused matmul + layer norm - with k dimension fixed
+    (
+        "matmul_layernorm",
+        "matmul_layernorm",
+        lambda m, n: (
+            torch.randn(m, 64, device=DEVICE, dtype=torch.float32),  # x: [m, k]
+            torch.randn(64, n, device=DEVICE, dtype=torch.float32),  # y: [k, n]
+            torch.randn(n, device=DEVICE, dtype=torch.float32),  # weight: [n]
+            torch.randn(n, device=DEVICE, dtype=torch.float32),  # bias: [n]
+        ),
+        lambda x, y, w, b: torch.nn.functional.layer_norm(
+            torch.matmul(x, y), [y.size(1)], w, b
+        ),
+        ALL_SHAPES,
+    ),
+    # Squeeze and excitation network forward - with k dimension fixed
+    (
+        "squeeze_and_excitation_net",
+        "squeeze_and_excitation_net_fwd",
+        lambda m, n: (
+            torch.randn(m, n, device=DEVICE, dtype=torch.float32),  # x: [m, n]
+            torch.randn(n, 32, device=DEVICE, dtype=torch.float32),  # a: [n, k]
+            torch.randn(32, n, device=DEVICE, dtype=torch.float32),  # b: [k, n]
+        ),
+        lambda x, a, b: torch.mul(x, torch.sigmoid(torch.relu(x @ a) @ b)),
+        ALL_SHAPES,
+    ),
+    # Attention - complex indexing with batch/head dims
+    (
+        "attention",
+        "attention",
+        lambda m, n: (
+            torch.randn(1, 1, m, 64, device=DEVICE, dtype=torch.float32),
+            torch.randn(1, 1, n, 64, device=DEVICE, dtype=torch.float32),
+            torch.randn(1, 1, n, 64, device=DEVICE, dtype=torch.float32),
+        ),
+        lambda q, k, v: torch.nn.functional.scaled_dot_product_attention(q, k, v),
+        ALL_SHAPES,
+    ),
+    # KL divergence forward - with specific settings
+    (
+        "kl_div",
+        "kl_div_forward",
+        lambda m, n: (
+            torch.randn(m, n, device=DEVICE, dtype=torch.float32).log_softmax(
+                dim=-1
+            ),  # y_pred
+            torch.randn(m, n, device=DEVICE, dtype=torch.float32).softmax(
+                dim=-1
+            ),  # y_true
+            False,  # log_target
+            "batchmean",  # reduction
+            1e-10,  # eps
+        ),
+        lambda y_pred, y_true, log_target, reduction, eps: torch.nn.functional.kl_div(
+            y_pred, y_true, reduction=reduction, log_target=log_target
+        ),
+        ALL_SHAPES,
+    ),
+]
+
+# Examples where "none" mode reuse across shapes is known to fail.
+# These kernels call hl.specialize() on shape-derived values (e.g.
+# `hl.specialize(n)` in matmul_layernorm for the layer-norm normalized_shape,
+# or head_dim in attention), which bakes compile-time constants into the
+# generated Triton code.  When a second call arrives with different concrete
+# shapes, the specialization key changes (because the specialized variable
+# has a new value), so the kernel gets a new BoundKernel instead of reusing
+# the first one — even though all *non-specialized* shape components match.
+_NONE_MODE_REUSE_SKIP: set[tuple[str, str | None]] = {
+    ("matmul_layernorm", "matmul_layernorm"),
+    ("attention", "attention"),
+}
+
+STATIC_SHAPES_MODES = ["none", "ones", "all"]
+
+# Examples that use tl.dot and need IEEE precision for tight tolerances.
+_EXAMPLES_WITH_TL_DOT = {
+    "matmul",
+    "matmul_split_k",
+    "matmul_layernorm",
+    "squeeze_and_excitation_net",
+    "attention",
+}
+
+# Build a lookup table keyed by unique example identifier (fn_name or
+# example_name) so we can parametrize test methods by string key.
+_EXAMPLE_CONFIGS_BY_KEY: dict[
+    str, tuple[str, str | None, object, object, list[tuple[str, int, int]]]
+] = {}
+for _cfg in EXAMPLE_CONFIGS_WITH_SHAPES:
+    _key = _cfg[1] or _cfg[0]
+    assert _key not in _EXAMPLE_CONFIGS_BY_KEY, f"duplicate example key: {_key}"
+    _EXAMPLE_CONFIGS_BY_KEY[_key] = _cfg
+
+_EXAMPLE_KEYS = tuple(_EXAMPLE_CONFIGS_BY_KEY.keys())
+
+
+class TestExampleStaticShapes(RefEagerTestBase, TestCase):
+    maxDiff = 16384
+
+    @skipIfRefEager("code generation not relevant in ref eager mode")
+    @skipIfNotCUDA()
+    @parametrize("mode", ("none", "ones", "all"))
+    @parametrize("example_key", _EXAMPLE_KEYS)
+    def test_example_kernel_across_shape_modes(
+        self, mode: str, example_key: str
+    ) -> None:
+        """Test one example with one static_shapes mode across shape variations."""
+        import sys
+
+        from helion._testing import EXAMPLES_DIR
+        from helion._testing import import_path
+
+        example_name, fn_name, input_fn, ref_fn, shapes = _EXAMPLE_CONFIGS_BY_KEY[
+            example_key
+        ]
+        for shape_desc, m, n in shapes:
+            with self.subTest(shape=shape_desc):
+                self._check_example(
+                    example_name,
+                    fn_name,
+                    input_fn,
+                    ref_fn,
+                    mode,
+                    m,
+                    n,
+                    import_path,
+                    EXAMPLES_DIR,
+                    sys,
+                )
+
+    def _check_example(
+        self,
+        example_name: str,
+        fn_name: str | None,
+        input_fn: object,
+        ref_fn: object,
+        mode: str,
+        m: int,
+        n: int,
+        import_path: object,
+        examples_dir: object,
+        sys: object,
+    ) -> None:
+        # Force fresh module import to prevent state leakage between subtests,
+        # since import_path caches modules in sys.modules.
+        module_cache_key = f"helion._testing.{example_name}"
+        sys.modules.pop(module_cache_key, None)
+        mod = import_path(examples_dir / f"{example_name}.py")
+        kernel_fn = getattr(mod, fn_name or example_name)
+
+        # Clear any hardcoded configs and cached bound kernels from the kernel
+        kernel_fn.configs = []
+        kernel_fn._bound_kernels = {}
+
+        # Set the static_shapes mode and disable autotuning for faster tests
+        kernel_fn.settings.static_shapes = mode
+        kernel_fn.settings.autotune_effort = "none"
+
+        if example_name in _EXAMPLES_WITH_TL_DOT:
+            kernel_fn.settings.dot_precision = "ieee"
+
+        # Create test inputs with the specified shapes and run
+        args = input_fn(m, n)
+        result = kernel_fn(*args)
+
+        # Compare with reference
+        expected = ref_fn(*args)
+        if isinstance(result, tuple) and not isinstance(expected, tuple):
+            result = result[0]
+
+        torch.testing.assert_close(
+            result,
+            expected,
+            rtol=1e-4,
+            atol=1e-4,
+        )
+
+        # Code-generation verification: in "all" mode, no symbolic size vars
+        # (like x_size_0, logits_size_1) should appear in the generated code.
+        # The pattern _size_\d avoids false positives from block_size_n.
+        bound_check = kernel_fn.bind(args)
+        if mode == "all":
+            code = bound_check.to_triton_code()
+            self.assertNotRegex(
+                code,
+                r"_size_\d",
+                f"'all' mode should not have symbolic size vars for "
+                f"{example_name}/{fn_name}",
+            )
+            # "all" mode: strides are hardcoded, no dynamic stride params
+            self.assertNotRegex(
+                code,
+                r"\w+_stride_\d",
+                f"'all' mode should not have symbolic stride vars for "
+                f"{example_name}/{fn_name}",
+            )
+
+        # Code-generation verification for "ones" mode: strides should be
+        # passed dynamically when all dimensions > 1 (just like "none" mode).
+        if mode == "ones" and m > 1 and n > 1:
+            code = bound_check.to_triton_code()
+            stride_params = set(re.findall(r"(\w+)\.stride\(", code))
+            multi_dim_tensor_count = sum(
+                1 for a in args if isinstance(a, torch.Tensor) and a.dim() > 1
+            )
+            min_stride_params = max(1, multi_dim_tensor_count)
+            self.assertGreaterEqual(
+                len(stride_params),
+                min_stride_params,
+                f"'ones' mode should pass dynamic strides for at least "
+                f"{min_stride_params} multi-dim tensor(s) in "
+                f"{example_name}/{fn_name}, but only found .stride() calls "
+                f"for {len(stride_params)} parameters: {stride_params}",
+            )
+
+        # Code-generation verification for "none" mode: verify the generated
+        # code is shape-agnostic by checking that tensor strides are passed
+        # dynamically (via .stride() calls in the wrapper).
+        if mode == "none":
+            code = bound_check.to_triton_code()
+            stride_params = set(re.findall(r"(\w+)\.stride\(", code))
+            # 1D contiguous tensors have trivially known stride (1,) and
+            # may not require .stride() calls, so count only multi-dim tensors.
+            multi_dim_tensor_count = sum(
+                1 for a in args if isinstance(a, torch.Tensor) and a.dim() > 1
+            )
+            min_stride_params = max(1, multi_dim_tensor_count)
+            self.assertGreaterEqual(
+                len(stride_params),
+                min_stride_params,
+                f"'none' mode should pass dynamic strides for at least "
+                f"{min_stride_params} multi-dim tensor(s) in "
+                f"{example_name}/{fn_name}, but only found .stride() calls "
+                f"for {len(stride_params)} parameters: {stride_params}",
+            )
+
+        # Verify shape-agnosticism in "none" mode: different non-zero shapes
+        # must produce the same specialization key (tensor bucketing).
+        if mode == "none":
+            args2 = input_fn(m + 3, n + 5)
+            key1 = kernel_fn.specialization_key(args)
+            key2 = kernel_fn.specialization_key(args2)
+            self.assertEqual(
+                key1,
+                key2,
+                f"In 'none' mode, shapes ({m},{n}) and ({m + 3},{n + 5}) "
+                f"produced different specialization keys for "
+                f"{example_name}/{fn_name}",
+            )
+            if (example_name, fn_name) not in _NONE_MODE_REUSE_SKIP:
+                # Verify correctness of reuse
+                result2 = kernel_fn(*args2)
+                expected2 = ref_fn(*args2)
+                if isinstance(result2, tuple) and not isinstance(expected2, tuple):
+                    result2 = result2[0]
+                torch.testing.assert_close(
+                    result2,
+                    expected2,
+                    rtol=1e-4,
+                    atol=1e-4,
+                )
+                # When bound kernels differ, it must be because
+                # hl.specialize() variables took different concrete values.
+                bound1 = kernel_fn.bind(args)
+                bound2 = kernel_fn.bind(args2)
+                if bound1 is not bound2:
+                    self.assertTrue(
+                        bound1.env.specialized_vars,
+                        f"In 'none' mode with no specialized vars, expected "
+                        f"same bound kernel for shapes ({m},{n}) and "
+                        f"({m + 3},{n + 5}) for {example_name}/{fn_name}",
+                    )
+
+        # Remove the module from sys.modules to prevent test contamination:
+        # the modified settings (static_shapes, autotune_effort, etc.) would
+        # leak into later tests that import the same example module.
+        sys.modules.pop(module_cache_key, None)
+
+
+instantiate_parametrized_tests(TestExampleStaticShapes)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Resolves #934 

Converts `static_shapes` from a boolean to a tri-state enum (`"all"` / `"ones"` / `"none"`) to give users granular control over shape specialization, reducing kernel recompilation churn for dynamic-shape workloads while preserving correctness.

- **`"all"`** (default, equivalent to old `True`): Fully static — specialize on exact tensor dimensions and strides. No kernel reuse across different shapes.
- **`"ones"`** (equivalent to old `False`): Dynamic shapes, but specialize on 0 and 1-sized dimensions. Kernels are reused across shapes that differ only in dimensions ≥ 2.
- **`"none"`** (new): Dynamic shapes, specialize only on 0-sized dimensions. Size-1 dimensions are treated the same as any other non-zero size, maximizing kernel reuse.

Backward compatible: `True`/`False` are automatically normalized to `"all"`/`"ones"`. Configurable via `Settings(static_shapes=...)` or `HELION_STATIC_SHAPES` env var.