### PR TITLE
[Autotuner] Better error message for default config error

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -193,6 +193,8 @@ class BaseSearch(BaseAutotuner):
                     "Default config failed while computing baseline.\n"
                     f"Default config: {decorator}\n"
                     f"{SUPPRESSED_TRITON_CODE_MSG}\n"
+                    "To work around this error, you could set `@helion.kernel(autotune_baseline_fn=...)` "
+                    "to provide a custom baseline function (e.g. PyTorch eager implementation of your kernel)."
                 ) from e
 
         original_args_flat, _ = tree_flatten(self._original_args)


### PR DESCRIPTION
In general we can't guarantee that the default config can always run for all kernels (e.g. https://github.com/pytorch/helion/issues/1064). As a fallback solution, I think we should advise user to pass in `autotune_baseline_fn=...` when default config fails, so that they can at least get past default config and start autotuning.