### PR TITLE
Add extra line before repro log; update repro log tests

### DIFF
--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -737,7 +737,7 @@ class BoundKernel(Generic[_R]):
             output_lines.extend(["", "helion_repro_caller()"])
 
         output_lines.append("# === END HELION KERNEL REPRO ===")
-        repro_text = "\n".join(output_lines)
+        repro_text = "\n" + "\n".join(output_lines)
         log_func(repro_text)
 
 

--- a/test/test_debug_utils.expected
+++ b/test/test_debug_utils.expected
@@ -23,3 +23,75 @@ def helion_repro_caller():
 
 helion_repro_caller()
 # === END HELION KERNEL REPRO ===
+
+--- assertExpectedJournal(TestDebugUtils.test_print_repro_on_autotune_error)
+# === HELION KERNEL REPRO ===
+import helion
+import helion.language as hl
+import torch
+from torch._dynamo.testing import rand_strided
+
+@helion.kernel(config=helion.Config(block_sizes=[64], indexing=['pointer', 'pointer'], load_eviction_policies=[''], num_stages=1, num_warps=8, pid_type='flat', range_flattens=[None], range_multi_buffers=[None], range_num_stages=[0], range_unroll_factors=[0], range_warp_specializes=[]), static_shapes=True)
+def kernel(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    n = x.shape[0]
+    for tile_n in hl.tile([n]):
+        out[tile_n] = x[tile_n] + 1
+    return out
+
+def helion_repro_caller():
+    torch.manual_seed(0)
+    x = rand_strided((128,), (1,), dtype=torch.float32, device=DEVICE)
+    return kernel(x)
+
+helion_repro_caller()
+# === END HELION KERNEL REPRO ===
+
+--- assertExpectedJournal(TestDebugUtils.test_print_repro_on_device_ir_lowering_error)
+# === HELION KERNEL REPRO ===
+import helion
+import helion.language as hl
+import torch
+from torch._dynamo.testing import rand_strided
+
+@helion.kernel(config=helion.Config(block_sizes=[32], indexing=[], load_eviction_policies=[], num_stages=1, num_warps=4, pid_type='flat', range_flattens=[None], range_multi_buffers=[None], range_num_stages=[0], range_unroll_factors=[0], range_warp_specializes=[]), static_shapes=True)
+def kernel_with_compile_error(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    n = x.shape[0]
+    for tile_n in hl.tile([n]):
+        # Using torch.nonzero inside device loop causes compilation error
+        # because it produces data-dependent output shape
+        torch.nonzero(x[tile_n])
+        out[tile_n] = x[tile_n]
+    return out
+
+def helion_repro_caller():
+    torch.manual_seed(0)
+    x = rand_strided((128,), (1,), dtype=torch.float32, device=DEVICE)
+    return kernel_with_compile_error(x)
+
+helion_repro_caller()
+# === END HELION KERNEL REPRO ===
+
+--- assertExpectedJournal(TestDebugUtils.test_print_repro_on_triton_codegen_error)
+# === HELION KERNEL REPRO ===
+import helion
+import helion.language as hl
+import torch
+from torch._dynamo.testing import rand_strided
+
+@helion.kernel(config=helion.Config(block_sizes=[32], indexing=['pointer', 'pointer'], load_eviction_policies=[''], num_stages=1, num_warps=4, pid_type='flat', range_flattens=[None], range_multi_buffers=[None], range_num_stages=[0], range_unroll_factors=[0], range_warp_specializes=[]), static_shapes=True)
+def kernel_with_triton_error(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    n = x.shape[0]
+    for tile_n in hl.tile([n]):
+        out[tile_n] = x[tile_n] + 1
+    return out
+
+def helion_repro_caller():
+    torch.manual_seed(0)
+    x = rand_strided((128,), (1,), dtype=torch.float32, device=DEVICE)
+    return kernel_with_triton_error(x)
+
+helion_repro_caller()
+# === END HELION KERNEL REPRO ===


### PR DESCRIPTION
In the log, sometimes the first line of the repro script `# === HELION KERNEL REPRO ===` is in the same line with some prefix, like:
```
WARNING:helion.runtime.kernel:# === HELION KERNEL REPRO ===
import helion
import helion.language as hl
import torch
from torch._dynamo.testing import rand_strided
...
```
which requires work from the user to remove the prefix to make the script runnable (e.g.  https://github.com/pytorch/helion/issues/1081). This PR logs a new line before logging the repro script, so that it's easier to copy-paste a working repro script.