### PR TITLE
Fixes in helion puzzles 

### DIFF
--- a/docs/helion_puzzles.rst
+++ b/docs/helion_puzzles.rst
@@ -468,8 +468,8 @@ A batched 2D convolution.
 .. code-block:: python
 
     def conv2d_spec(x: Float32[Tensor, "4 8 8"], k: Float32[Tensor, "4 4"]) -> Float32[Tensor, "4 8 8"]:
-        z = torch.zeros(4, 8, 8).to(x.device)
-        x = torch.nn.functional.pad(x, (0, 4, 0, 4, 0, 0), value=0.0).to(x.device)
+        z = torch.zeros(4, 8, 8, device=x.device)
+        x = torch.nn.functional.pad(x, (0, 4, 0, 4, 0, 0), value=0.0)
         for i in range(8):
             for j in range(8):
                 z[:, i, j] = (k[None, :, :] * x[:, i: i+4, j: j + 4]).sum(1).sum(1)


### PR DESCRIPTION
1. Fixes in the softmax operation (max is not supported)
2. For the convolution kernel, I fixed the shape and devices issue, but the result does not match with `conv2d_spec`