### PR TITLE
Fix no libdw.so issue on AMD CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,12 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v5
 
+      - name: Install system dependencies
+        run: |
+          set -eux
+          apt-get update
+          apt-get install -y libdw1
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:


### PR DESCRIPTION
Error (https://github.com/pytorch/helion/actions/runs/19197929602/job/54881647027?pr=1106):
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/__w/helion/helion/helion/__init__.py", line 6, in <module>
    from . import _compat as _compat_module  # noqa: F401  # side-effect import
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/helion/helion/helion/_compat.py", line 9, in <module>
    import torch
  File "/__w/helion/helion/.venv/lib/python3.12/site-packages/torch/__init__.py", line 433, in <module>
    from torch._C import *  # noqa: F403
    ^^^^^^^^^^^^^^^^^^^^^^
ImportError: libdw.so.1: cannot open shared object file: No such file or directory
```