### PR TITLE
Add warning to discourage use of `acc += lhs @ rhs` pattern

### DIFF
--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -350,6 +350,10 @@ Warnings can be suppressed by including them in the `ignore_warnings` setting:
 
    Warns when operations return tensors on wrong device.
 
+.. autoclass:: TiledKMatmulAccumulationWarning
+
+   Warns when ``acc += lhs @ rhs`` pattern is used inside tiled device loops.
+
 ```
 
 ### Warning Suppression

--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -1646,6 +1646,32 @@ class TypePropagation(ast.NodeVisitor):
         super().generic_visit(node)
         raise exc.UnsupportedPythonType(f"ast.{node.__class__.__name__}")
 
+    @staticmethod
+    def _contains_matmul(node: ast.AST | None) -> bool:
+        if node is None:
+            return False
+
+        matmul_functions = ["torch.matmul", "torch.mm", "torch.bmm", "hl.dot"]
+
+        for sub_node in ast.walk(node):
+            # Check for @ operator
+            if isinstance(sub_node, ast.BinOp) and isinstance(sub_node.op, ast.MatMult):
+                return True
+
+            # Check for function calls
+            if not isinstance(sub_node, ast.Call):
+                continue
+
+            func = sub_node.func
+
+            # Check for matmul function calls
+            if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+                qualified_name = f"{func.value.id}.{func.attr}"
+                if qualified_name in matmul_functions:
+                    return True
+
+        return False
+
     def _bool_op(self, op: ast.boolop, left: TypeInfo, right: TypeInfo) -> TypeInfo:
         try:
             val = left.truth_value()
@@ -2094,6 +2120,12 @@ class TypePropagation(ast.NodeVisitor):
 
     def visit_AugAssign(self, node: ast.AugAssign) -> TypeInfo:
         assert isinstance(node.target, ExtendedAST)
+        if (
+            self.device_loop_depth > 0
+            and isinstance(node.op, ast.Add)
+            and self._contains_matmul(node.value)
+        ):
+            warning(exc.TiledKMatmulAccumulationWarning)
         try:
             type_info = self.visit(
                 create(

--- a/helion/exc.py
+++ b/helion/exc.py
@@ -414,6 +414,22 @@ class BlockSizeIgnoredInInterpretMode(BaseWarning):
     message = "block_size is specified to be {0}, but in interpret mode, the full dimension size is always used."
 
 
+class TiledKMatmulAccumulationWarning(BaseWarning):
+    message = (
+        "Detected one of the following usage patterns inside a Helion device loop:\n"
+        "- `acc += lhs @ rhs`\n"
+        "- `acc += torch.matmul(lhs, rhs)`\n"
+        "- `acc += torch.mm(lhs, rhs)`\n"
+        "- `acc += torch.bmm(lhs, rhs)`\n"
+        "- `acc += hl.dot(lhs, rhs)`\n"
+        "For accurate numerics, please use one of:\n"
+        "- `torch.addmm(acc, ...)`\n"
+        "- `torch.baddbmm(acc, ...)`\n"
+        "- `hl.dot(acc=...)`\n"
+        "to accumulate across tiled-K iterations of a matmul operation."
+    )
+
+
 class AutotuningDisallowedInEnvironment(BaseError):
     message = "Autotuning is disabled {0}, please provide a config to @helion.kernel via the config= argument."
 


### PR DESCRIPTION
Part of https://github.com/pytorch/helion/issues/1109.