### PR TITLE
[CI] Skip TestBreakpoint in ref-eager CI job

### DIFF
--- a/test/test_breakpoint.py
+++ b/test/test_breakpoint.py
@@ -14,6 +14,7 @@ import triton.runtime.interpreter as triton_interpreter
 import helion
 from helion import exc
 from helion._testing import DEVICE
+from helion._testing import RefEagerTestDisabled
 from helion._testing import TestCase
 import helion.language as hl
 
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
     from helion.runtime.kernel import Kernel
 
 
-class TestBreakpoint(TestCase):
+class TestBreakpoint(RefEagerTestDisabled, TestCase):
     @staticmethod
     @contextmanager
     def _auto_resume_breakpoint() -> None:


### PR DESCRIPTION
Some tests in `TestBreakpoint` test suite sometimes fail in ref-eager CI job: https://github.com/pytorch/helion/actions/runs/19441539802/job/55625828680?pr=1136. Since we already run `TestBreakpoint` in normal CI jobs, I believe we can skip it in ref-eager CI job to avoid the error.