### PR TITLE
Bump pyrefly to 0.42.1 and remove 'sed' workaround.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,6 +46,4 @@ jobs:
       - name: Run pre-commit
         run: |
           source .venv/bin/activate
-          # TODO(rchen152): Delete this when warnings do not cause failures
-          sed -i '/search-path/d' pyproject.toml
           pre-commit run --all-files

--- a/lint.sh
+++ b/lint.sh
@@ -9,7 +9,7 @@ fi
 if [ "$ACTION" = "install" ];
 then
     set -ex
-    pip install ruff==0.14.2 pyrefly==0.42.0
+    pip install ruff==0.14.2 pyrefly==0.42.1
     exit 0
 fi
 


### PR DESCRIPTION
Bumps pyrefly version to 0.42.1, which includes a fix for a bug where pyrefly exited with the wrong return code. This lets us remove a 'sed' workaround for the bug.