### PR TITLE
Add torch.library.custom_op compatibility to @helion.kernel

### DIFF
--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -152,6 +152,16 @@ class Kernel(Generic[_R]):
             else:
                 self._annotations.append(ann)
 
+        # Expose function attributes for compatibility with torch.library.custom_op
+        # These are set as instance attributes to allow the Kernel to be used
+        # as if it were a regular function for introspection purposes
+        functools.update_wrapper(self, fn)
+        # Manually add function-specific attributes not copied by update_wrapper
+        self.__globals__ = fn.__globals__
+        self.__code__ = fn.__code__
+        self.__defaults__ = fn.__defaults__
+        self.__kwdefaults__ = fn.__kwdefaults__
+
     def _get_bound_kernel_cache_key(
         self, args: tuple[object, ...], signature: tuple[Hashable, ...]
     ) -> BoundKernelInMemoryCacheKey | None:

--- a/test/test_custom_op.py
+++ b/test/test_custom_op.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import RefEagerTestBase
+from helion._testing import TestCase
+import helion.language as hl
+
+
+class TestCustomOp(RefEagerTestBase, TestCase):
+    def test_custom_op(self):
+        """Test directly registering a helion kernel as PyTorch custom op"""
+
+        @torch.library.custom_op("testlib::sub_one", mutates_args=())
+        @helion.kernel(autotune_effort="none")
+        def sub_one(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size()):
+                out[tile] = x[tile] - 1.0
+            return out
+
+        @sub_one.register_fake
+        def _(x: torch.Tensor) -> torch.Tensor:
+            return torch.empty_like(x)
+
+        x = torch.randn([64, 64], device=DEVICE)
+        expected = x - 1.0
+
+        # Test calling via torch.ops.testlib.sub_one (registry access)
+        result_registry = torch.ops.testlib.sub_one(x)
+        torch.testing.assert_close(result_registry, expected)
+
+        # Verify the direct call also works (backwards compatibility)
+        result_direct = sub_one(x)
+        torch.testing.assert_close(result_direct, expected)


### PR DESCRIPTION
Enable @helion.kernel decorated functions to be wrapped with @torch.library.custom_op() by exposing necessary function attributes for PyTorch's custom op registration.

Changes:
- Add functools.update_wrapper() call in Kernel.__init__ to copy standard function attributes
- Manually set a set of dunder attributes required by torch.library.infer_schema()

This allows Helion kernels to be registered as PyTorch custom ops:
```
    @torch.library.custom_op("mylib::kernel", mutates_args=())
    @helion.kernel()
    def my_kernel(x: torch.Tensor) -> torch.Tensor:
        ...

    # Call via PyTorch's op registry
    result = torch.ops.mylib.kernel(x)
```
