### PR TITLE
Add setup for Helion to compile on MTIA with basic test

### DIFF
--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import contextvars
 import os
-from typing import TYPE_CHECKING
 
 import torch
+import triton
 
 from .. import _compat as _compat  # ensure Triton compatibility patches run
 from .config import Config as Config
@@ -14,12 +14,14 @@ from .triton_helpers import triton_send_signal as triton_send_signal
 from .triton_helpers import triton_wait_multiple_signal as triton_wait_multiple_signal
 from .triton_helpers import triton_wait_signal as triton_wait_signal
 
-if TYPE_CHECKING:
-    import triton
-
 
 def _alloc_fn(size: int, alignment: int, stream: int | None) -> torch.Tensor:
-    return torch.empty(size, device="cuda", dtype=torch.int8)
+    # Dynamically get device from Triton backend
+    current_target = triton.runtime.driver.active.get_current_target()
+    if current_target is None:
+        raise RuntimeError("No active Triton target available")
+    backend = current_target.backend
+    return torch.empty(size, device=backend, dtype=torch.int8)
 
 
 def set_triton_allocator() -> None:
@@ -51,8 +53,13 @@ def get_num_sm(device: torch.device, *, reserved_sms: int = 0) -> int:
         Grid size to use for a persistent kernel on the device after accounting
         for any reserved SMs. Always at least 1.
     """
-    assert device.type in ["cuda", "xpu", "cpu"], "TODO: implement for other devices"
     available_sms: int
+    assert device.type in [
+        "cuda",
+        "xpu",
+        "cpu",
+        "mtia",
+    ], "TODO: implement for other devices"
     if device.type == "cpu":
         try:
             num_threads = int(torch.get_num_threads())
@@ -66,8 +73,19 @@ def get_num_sm(device: torch.device, *, reserved_sms: int = 0) -> int:
     # TODO(EikanWang): gpu_subslice_count is an out-of-date term. we change update it to XeCore number.
     elif device.type == "xpu":
         available_sms = torch.xpu.get_device_properties(device.index).gpu_subslice_count
+    elif device.type == "mtia":
+        device_props = torch.mtia.get_device_properties(device.index)
+        if "maxGridHeight" in device_props and "maxGridWidth" in device_props:
+            available_sms = device_props["maxGridHeight"] * device_props["maxGridWidth"]
+        else:
+            raise RuntimeError(
+                f"Unable to determine SM count for MTIA device. "
+                f"Available properties: {list(device_props.keys())}"
+            )
     else:
-        raise AssertionError("TODO: implement for other devices")
+        raise NotImplementedError(
+            f"get_num_sm not implemented for device type: {device.type}"
+        )
 
     if reserved_sms <= 0:
         return available_sms
@@ -83,6 +101,7 @@ def default_launcher(
     **kwargs: dict,
 ) -> object:
     """Default launcher function that executes the kernel immediately."""
+    # For both CUDA and MTIA, use the same kernel execution
     return triton_kernel.run(
         *args,
         grid=grid,

--- a/test/test_constexpr.py
+++ b/test/test_constexpr.py
@@ -10,6 +10,7 @@ from helion._testing import DEVICE
 from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import code_and_output
+from helion._testing import skipIfMTIA
 from helion._testing import skipIfRefEager
 import helion.language as hl
 
@@ -95,6 +96,7 @@ class TestConstExpr(RefEagerTestBase, TestCase):
         self.assertExpectedJournal(code)
 
     @skipIfRefEager("Triton codegen does not work in ref eager mode")
+    @skipIfMTIA('Not supported on MTIA. Error: "Expected IntList but got GenericList"')
     def test_block_size_constexpr_assignment_in_host_code(self) -> None:
         @helion.kernel(
             config=helion.Config(


### PR DESCRIPTION
Enable Helion with MTIA for the first time. This is very basic setup to just make showcase it working.

We init mtia device through init_mtia_device() and depends on triton.runtime.driver.active.get_current_target().backend to choose which Triton backend to load.

