### PR TITLE
fix shape bug in lfbo pattern search

### DIFF
--- a/helion/autotuner/surrogate_pattern_search.py
+++ b/helion/autotuner/surrogate_pattern_search.py
@@ -99,7 +99,7 @@ class LFBOPatternSearch(PatternSearch):
         frac_selected: float = 0.10,
         num_neighbors: int = 300,
         radius: int = 2,
-        quantile: float = 0.3,
+        quantile: float = 0.2,
         patience: int = 1,
     ) -> None:
         if not HAS_ML_DEPS:


### PR DESCRIPTION
After running some additional benchmarks, I realized that for some kernels, there are many configs that give identical performance (e.g. for rms_norm). Originally, LFBO Pattern Search construct training labels by classifying which configs have performance **strictly** better than quantile(perfs, 0.3). Since this comparison is strict, in cases where the performance of the top 30% of configs is identical, then all the labels are zero. Training with these labels doesn't throw an error but instead when we call predict_proba, this returns all a 1D tensor of all zeros instead of a 2d tensor of probabilities for each class.

Now this is fixed by constructing labels with a non-strict comparison. We also explicitly deal with the case where all the labels are identical by arbitrarily flipping the first one.