### PR TITLE
[WIP][xpu][fix] Change min_dot_size call due to Triton API Change

### DIFF
--- a/helion/_compat.py
+++ b/helion/_compat.py
@@ -255,11 +255,13 @@ def _min_dot_size(
         # pyrefly: ignore [missing-import]
         try:
             # Support New triton API which put the min_dot_size in XPUBackend class
-            from triton.backends.intel.compiler import XPUBackend
+            from triton.backends.intel.compiler import (
+                XPUBackend,  # pyrefly: ignore [missing-import]
+            )
 
             min_dot_size_xpu = XPUBackend.min_dot_size
         except Exception:
-            from triton.backends.intel.compiler import (
+            from triton.backends.intel.compiler import (  # pyrefly: ignore [missing-import]
                 min_dot_size as min_dot_size_xpu,  # type: ignore[no-redef]
             )
 


### PR DESCRIPTION
This PR is to align with the XPU Triton recently change. Now the `min_dot_size()` call is not exposed directly and wrapped in `XPUBackend` class according to https://github.com/intel/intel-xpu-backend-for-triton/pull/5329.

cc: @EikanWang 