### PR TITLE
settings: set appropriate dot_precision default

### DIFF
--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -18,6 +18,7 @@ import torch
 from torch._environment import is_fbcode
 
 from .. import exc
+from .._compat import supports_amd_cdna_tunables
 from ..autotuner.effort_profile import AutotuneEffort
 from ..autotuner.effort_profile import get_effort_profile
 from .ref_mode import RefMode
@@ -267,9 +268,12 @@ def _get_ref_mode() -> RefMode:
 def _get_dot_precision() -> DotPrecision:
     """
     Get the dot precision setting from TRITON_F32_DEFAULT environment variable.
-    Defaults to 'tf32', 'ieee' if rocm.
+    Defaults to 'tf32', 'ieee' if rocm and not CDNA.
     """
-    default_precision = "ieee" if torch.version.hip is not None else "tf32"
+    if torch.version.hip is not None:
+        default_precision = "tf32" if supports_amd_cdna_tunables() else "ieee"
+    else:
+        default_precision = "tf32"
 
     return _env_get_literal(
         "TRITON_F32_DEFAULT",

--- a/test/test_dot.py
+++ b/test/test_dot.py
@@ -3,15 +3,6 @@ from __future__ import annotations
 import contextlib
 import io
 import itertools
-import os
-
-_ORIG_TRITON_F32_DEFAULT = os.environ.get("TRITON_F32_DEFAULT")
-os.environ["TRITON_F32_DEFAULT"] = "tf32"
-
-# pyrefly: noqa: E402
-# ruff: noqa: E402
-# (We intentionally set the env var before importing triton helion for rocm test fail.)
-
 from typing import Callable
 import unittest
 
@@ -198,15 +189,6 @@ def make_test_function(input_dtype, acc_dtype, static_shapes_option):
 
 
 class TestDot(RefEagerTestBase, TestCase):
-    @classmethod
-    def tearDownClass(cls):
-        # Restore f32 for any subsequent tests
-        if _ORIG_TRITON_F32_DEFAULT is None:
-            os.environ.pop("TRITON_F32_DEFAULT", None)
-        else:
-            os.environ["TRITON_F32_DEFAULT"] = _ORIG_TRITON_F32_DEFAULT
-        super().tearDownClass()
-
     @skipIfRefEager("Codegen inspection not applicable in ref eager mode")
     def test_hl_dot_codegen_acc_differs_uses_addition(self):
         # Test case 1: fused accumulation (acc_dtype = float32, common dtype = bfloat16)


### PR DESCRIPTION
On AMD/ROCm (non-CDNA) systems, matmul kernels fail when TRITON_F32_DEFAULT is not explicitly set to ieee, as the default tf32 precision is not compatible with rocm (non-CDNA).

These changes :
  Modifies helion/runtime/settings.py to automatically detect the backend (using `torch.version.hip`) and set the appropriate default:
  - non-rocm or rocm-cdna: Default to tf32 (unchanged)
  - rocm non-cdna: Default to ieee