### PR TITLE
[Interpret Mode] Support custom block size

### DIFF
--- a/helion/language/tile_ops.py
+++ b/helion/language/tile_ops.py
@@ -259,5 +259,4 @@ def _(state: CodegenState) -> ast.AST:
 
 @_decorators.ref(tile_id)
 def _(tile: RefTile) -> int:
-    # ID is always 0 since we always have one tile per dim in ref mode
-    return 0
+    return tile._slice.start // tile._block_size


### PR DESCRIPTION
Several customers have found interpret mode very useful for debugging, and they want to use interpret mode on Helion kernel with custom block sizes, despite it being slow.

Fixes https://github.com/pytorch/helion/issues/1183.

cc. @Chillee