### PR TITLE
Print repro code on autotune success

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -669,6 +669,7 @@ class BaseSearch(BaseAutotuner):
             f"    {kernel_decorator}\n",
             level=logging.INFO + 5,
         )
+        self.kernel.maybe_log_repro(self.log.warning, self.args, best)
         if self.settings.print_output_code:
             triton_code = self.kernel.to_triton_code(best)
             print(triton_code, file=sys.stderr)


### PR DESCRIPTION
Getting the repro Helion kernel with example inputs is useful even when autotuning is successful (e.g. we can use that to debug autotune slowness for internal use cases).