### PR TITLE
Include index_dtype in the printed decorator snippet 

### DIFF
--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -452,7 +452,13 @@ class BoundKernel(Generic[_R]):
 
     def format_kernel_decorator(self, config: Config, settings: Settings) -> str:
         """Return the @helion.kernel decorator snippet capturing configs and settings that influence Triton code generation."""
-        return f"@helion.kernel(config={config.__repr__()}, static_shapes={settings.static_shapes})"
+        parts = [
+            f"config={config.__repr__()}",
+            f"static_shapes={settings.static_shapes}",
+        ]
+        if settings.index_dtype is not None:
+            parts.append(f"index_dtype={settings.index_dtype}")
+        return f"@helion.kernel({', '.join(parts)})"
 
     def to_triton_code(
         self,

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -255,5 +255,17 @@ class TestSettingsEnv(TestCase):
         )
 
 
+class TestFormatKernelDecorator(TestCase):
+    def test_format_kernel_decorator_includes_index_dtype(self) -> None:
+        """Test that format_kernel_decorator includes index_dtype when set."""
+        config = helion.Config(block_sizes=[8], num_warps=4)
+        settings = helion.Settings(index_dtype=torch.int64)
+        from helion.runtime.kernel import BoundKernel
+
+        decorator = BoundKernel.format_kernel_decorator(None, config, settings)  # type: ignore[arg-type]
+
+        self.assertIn("index_dtype=torch.int64", decorator)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes https://github.com/pytorch/helion/issues/1205