### PR TITLE
Fix unit test breakage due to upstream change

### DIFF
--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -50,15 +50,24 @@ tls: _TLS = typing.cast("_TLS", threading.local())
 class HelionKernelSource(EphemeralSource):
     """Ephemeral source that formats as a kernel file location."""
 
+    class _CompatSourceName(str):
+        """String that is also callable (for torch<=2.9 which calls `source.name()`)."""
+
+        __slots__ = ()
+
+        def __call__(self) -> str:
+            return self
+
     def __init__(self, location: SourceLocation) -> None:
         super().__init__()
         self.location = location
 
+    @property
     def name(self) -> str:  # type: ignore[override]
         formatted = self.location.format().rstrip("\n")
         if not formatted:
             return ""
-        return "\nHelion kernel stack:\n" + formatted
+        return self._CompatSourceName("\nHelion kernel stack:\n" + formatted)
 
 
 def _current_symbol_source() -> EphemeralSource | None:


### PR DESCRIPTION
Example: https://github.com/pytorch/helion/actions/runs/19994201311/job/57339374560?pr=1210

`test/test_logging.py::TestLogging::test_symbolic_shape_log_includes_kernel_source - AssertionError: 'Helion kernel stack:' not found`

