### PR TITLE
[Interpret Mode] Fix `hl.store` automatic dtype conversion

### DIFF
--- a/helion/language/_decorators.py
+++ b/helion/language/_decorators.py
@@ -143,7 +143,8 @@ def api(
                 assert api._ref_fn is not None, (
                     f"{fn.__qualname__} does not have a ref mode implementation yet"
                 )
-                return api._ref_fn(*bound.arguments.values())
+                flat_args = api._prepare_args(*bound.arguments.values())
+                return api._ref_fn(*flat_args)
 
             flat_args = api._prepare_args(*bound.arguments.values())
             del args, kwargs

--- a/test/test_dot.py
+++ b/test/test_dot.py
@@ -142,6 +142,7 @@ def make_test_function(input_dtype, acc_dtype, static_shapes_option):
                     helion.exc.InternalError,
                     ValueError,
                     OSError,
+                    TypeError,
                 )
             ):
                 code, result = run_kernel()


### PR DESCRIPTION
[Interpret Mode] Fix `hl.store` automatic dtype conversion

Part of https://github.com/pytorch/helion/issues/521.