### PR TITLE
[fix] Incorrect shape inference for tile indexing on size-1 dimension

### DIFF
--- a/test/test_associative_scan.expected
+++ b/test/test_associative_scan.expected
@@ -748,20 +748,22 @@ def add_combine_fn_0(param_0, param_1):
     return v_0
 
 @triton.jit
-def _helion_test_single_element(x, result):
+def _helion_test_single_element(x, result, _BLOCK_SIZE_0: tl.constexpr):
     # src[test_associative_scan.py:N]: row_data = x[i, :]
-    row_data = tl.load(x + tl.zeros([1, 1], tl.int32), None)
+    row_data = tl.load(x + tl.zeros([_BLOCK_SIZE_0, 1], tl.int32), None)
     # src[test_associative_scan.py:N]: result[i, :] = hl.associative_scan(add_combine_fn, row_data, dim=1)
     _associative_scan = tl.associative_scan(row_data, 1, add_combine_fn_0)
-    tl.store(result + tl.zeros([1, 1], tl.int32), tl.reshape(_associative_scan, []), None)
+    tl.store(result + tl.zeros([_BLOCK_SIZE_0, 1], tl.int32), tl.reshape(_associative_scan, []), None)
 
 def test_single_element(x: torch.Tensor, *, _launcher=_default_launcher):
     # src[test_associative_scan.py:N]: result = torch.empty_like(x)
     result = torch.empty_like(x)
+    # src[test_associative_scan.py:N]: row_data = x[i, :]
+    _BLOCK_SIZE_0 = 1
     # src[test_associative_scan.py:N]: for i in hl.tile(x.size(0)):
     # src[test_associative_scan.py:N]:     row_data = x[i, :]
     # src[test_associative_scan.py:N]:     result[i, :] = hl.associative_scan(add_combine_fn, row_data, dim=1)
-    _launcher(_helion_test_single_element, (1,), x, result, num_warps=4, num_stages=1)
+    _launcher(_helion_test_single_element, (1,), x, result, _BLOCK_SIZE_0, num_warps=4, num_stages=1)
     # src[test_associative_scan.py:N]: return result
     return result
 

--- a/test/test_indexing.expected
+++ b/test/test_indexing.expected
@@ -428,6 +428,43 @@ def scatter_kernel(dy: torch.Tensor, indices: torch.Tensor, input_shape: list[in
     # src[test_indexing.py:N]: return dx.view(input_shape)
     return dx.view(input_shape)
 
+--- assertExpectedJournal(TestIndexing.test_indexing_on_size1_tensor_with_size1_tile)
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from helion.runtime import default_launcher as _default_launcher
+
+@triton.jit
+def _helion_kernel_with_reshape_on_size1_tensor(x, out, _BLOCK_SIZE_1: tl.constexpr, _BLOCK_SIZE_0: tl.constexpr):
+    # src[test_indexing.py:N]: for tile_1, tile_2 in hl.tile(
+    # src[test_indexing.py:N]:     [x.size(0), x.size(1)],
+    # src[test_indexing.py:N]: ):
+    num_blocks_0 = 1
+    pid_1 = tl.program_id(0) // num_blocks_0
+    offset_1 = pid_1 * _BLOCK_SIZE_1
+    indices_1 = (offset_1 + tl.arange(0, _BLOCK_SIZE_1)).to(tl.int32)
+    # src[test_indexing.py:N]: block = x[tile_1, tile_2]
+    block = tl.load(x + indices_1[None, :] * 1, None)
+    # src[test_indexing.py:N]: block_reshape = block.reshape([tile_1, tile_2])
+    block_reshape = tl.reshape(block, [_BLOCK_SIZE_0, _BLOCK_SIZE_1])
+    # src[test_indexing.py:N]: out[tile_1, tile_2] = block_reshape
+    tl.store(out + indices_1[None, :] * 1, block_reshape, None)
+
+def kernel_with_reshape_on_size1_tensor(x: torch.Tensor, out: torch.Tensor, *, _launcher=_default_launcher):
+    # src[test_indexing.py:N]: for tile_1, tile_2 in hl.tile(
+    # src[test_indexing.py:N]:     [x.size(0), x.size(1)],
+    # src[test_indexing.py:N]: ):
+    _BLOCK_SIZE_1 = 16
+    # src[test_indexing.py:N]: block = x[tile_1, tile_2]
+    _BLOCK_SIZE_0 = 1
+    # src[test_indexing.py:N]: for tile_1, tile_2 in hl.tile(
+    # src[test_indexing.py:N]:     [x.size(0), x.size(1)],
+    # src[test_indexing.py:N]: ):
+    # src[test_indexing.py:N-N]: ...
+    _launcher(_helion_kernel_with_reshape_on_size1_tensor, (1 * triton.cdiv(16, _BLOCK_SIZE_1),), x, out, _BLOCK_SIZE_1, _BLOCK_SIZE_0, num_warps=4, num_stages=1)
+
 --- assertExpectedJournal(TestIndexing.test_indirect_indexing_2d_direct_gather)
 from __future__ import annotations
 
@@ -869,7 +906,7 @@ from torch._inductor.runtime.triton_helpers import math as tl_math
 from helion.runtime import default_launcher as _default_launcher
 
 @triton.jit
-def _helion_kernel_with_mixed_store(x_data, out, scales, _BLOCK_SIZE_0: tl.constexpr, _BLOCK_SIZE_2: tl.constexpr):
+def _helion_kernel_with_mixed_store(x_data, out, scales, _BLOCK_SIZE_0: tl.constexpr, _BLOCK_SIZE_2: tl.constexpr, _BLOCK_SIZE_1: tl.constexpr):
     # src[test_indexing.py:N]: for m_tile, n_tile in hl.tile([m, n], block_size=[None, n_block]):
     num_blocks_0 = 1
     pid_1 = tl.program_id(0) // num_blocks_0
@@ -887,7 +924,7 @@ def _helion_kernel_with_mixed_store(x_data, out, scales, _BLOCK_SIZE_0: tl.const
         x_block = tl.load(x_data + indices_2[None, :] * 1, mask_2[None, :], other=0)
         # src[test_indexing.py:N]: row_max = x_block.abs().amax(dim=1)
         v_0 = tl_math.abs(x_block)
-        _mask_to = tl.where(tl.broadcast_to(mask_2[None, :], [1, _BLOCK_SIZE_2]), v_0, tl.full([], float('-inf'), tl.float32))
+        _mask_to = tl.where(tl.broadcast_to(mask_2[None, :], [_BLOCK_SIZE_1, _BLOCK_SIZE_2]), v_0, tl.full([], float('-inf'), tl.float32))
         row_max = tl.cast(tl.max(_mask_to, 1), tl.float32)
         # src[test_indexing.py:N]: row_value = row_max.to(torch.uint8)
         v_1 = tl.cast(row_max, tl.uint8)
@@ -918,11 +955,13 @@ def kernel_with_mixed_store(x_data: torch.Tensor, BLOCK_SIZE: hl.constexpr, *, _
     # src[test_indexing.py:N]: ):
     # src[test_indexing.py:N-N]: ...
     _BLOCK_SIZE_2 = 32
+    # src[test_indexing.py:N]: x_block = x_data[m_tile, n_tile_local]
+    _BLOCK_SIZE_1 = 1
     # src[test_indexing.py:N]: for m_tile, n_tile in hl.tile([m, n], block_size=[None, n_block]):
     # src[test_indexing.py:N]:     for n_tile_local in hl.tile(
     # src[test_indexing.py:N]:         n_tile.begin, n_tile.end, block_size=BLOCK_SIZE
     # src[test_indexing.py:N-N]: ...
-    _launcher(_helion_kernel_with_mixed_store, (1 * triton.cdiv(64, _BLOCK_SIZE_0),), x_data, out, scales, _BLOCK_SIZE_0, _BLOCK_SIZE_2, num_warps=4, num_stages=1)
+    _launcher(_helion_kernel_with_mixed_store, (1 * triton.cdiv(64, _BLOCK_SIZE_0),), x_data, out, scales, _BLOCK_SIZE_0, _BLOCK_SIZE_2, _BLOCK_SIZE_1, num_warps=4, num_stages=1)
     # src[test_indexing.py:N]: return out, scales
     return (out, scales)
 

--- a/test/test_reduce.expected
+++ b/test/test_reduce.expected
@@ -190,7 +190,7 @@ def add_combine_fn_0(param_0, param_1):
     return v_0
 
 @triton.jit
-def _helion_test_reduce_codegen_kernel(x, result, _RDIM_SIZE_1: tl.constexpr):
+def _helion_test_reduce_codegen_kernel(x, result, _RDIM_SIZE_1: tl.constexpr, _BLOCK_SIZE_0: tl.constexpr):
     # src[test_reduce.py:N]: for i in hl.tile(x.size(0)):
     indices_1 = tl.arange(0, _RDIM_SIZE_1).to(tl.int32)
     mask_1 = indices_1 < 3
@@ -198,17 +198,19 @@ def _helion_test_reduce_codegen_kernel(x, result, _RDIM_SIZE_1: tl.constexpr):
     row_data = tl.load(x + indices_1[None, :] * 1, mask_1[None, :], other=0)
     # src[test_reduce.py:N]: result[i] = hl.reduce(add_combine_fn, row_data, dim=1)
     _reduce = tl.reduce(row_data, 1, add_combine_fn_0)
-    tl.store(result + tl.zeros([1], tl.int32), tl.reshape(_reduce, []), None)
+    tl.store(result + tl.zeros([_BLOCK_SIZE_0], tl.int32), tl.reshape(_reduce, []), None)
 
 def test_reduce_codegen_kernel(x: torch.Tensor, *, _launcher=_default_launcher):
     # src[test_reduce.py:N]: result = torch.empty([x.size(0)], dtype=x.dtype, device=x.device)
     result = torch.empty([x.size(0)], dtype=x.dtype, device=x.device)
     # src[test_reduce.py:N]: for i in hl.tile(x.size(0)):
     _RDIM_SIZE_1 = 4
+    # src[test_reduce.py:N]: row_data = x[i, :]
+    _BLOCK_SIZE_0 = 1
     # src[test_reduce.py:N]: for i in hl.tile(x.size(0)):
     # src[test_reduce.py:N]:     row_data = x[i, :]
     # src[test_reduce.py:N]:     result[i] = hl.reduce(add_combine_fn, row_data, dim=1)
-    _launcher(_helion_test_reduce_codegen_kernel, (1,), x, result, _RDIM_SIZE_1, num_warps=4, num_stages=1)
+    _launcher(_helion_test_reduce_codegen_kernel, (1,), x, result, _RDIM_SIZE_1, _BLOCK_SIZE_0, num_warps=4, num_stages=1)
     # src[test_reduce.py:N]: return result
     return result
 


### PR DESCRIPTION
Fixes #1275

For more details on the issue, see https://github.com/pytorch/helion/issues/1275.

This commit adopts **option 2** proposed from #1275. Both options will address the shape mismatch issue when the tile symbolic size is known at compile time. For the following case, 
```
config = helion.Config(
    block_sizes=[1],
)

@helion.kernel(
    config=config,
    autotune_effort="none",
    static_shapes=False,                                                                                                
)
def test_helion_kernel(
    query: Tensor,
    query_start_lens: Tensor,
    num_seqs,
    output: Tensor
):
    q_size_1 = hl.specialize(query.size(1))

    for seq_tile in hl.tile(num_seqs, block_size=1):
        seq_idx = seq_tile.begin
        query_start = query_start_lens[seq_idx]
        query_end = query_start_lens[seq_idx + 1]

        for tile_q in hl.tile(
            query_start,
            query_end
        ):
            q = query[tile_q, :]
            q = q.reshape([tile_q.block_size, q_size_1])
            output[tile_q, :] = q

def main() -> None:
    torch.set_default_device("cuda")
    query = torch.randn(1, 16, dtype=torch.bfloat16)
    query_start_lens = torch.tensor([0, 1], dtype=torch.int32)
    num_seqs = 1
    out = torch.empty_like(query)
    test_helion_kernel(query, query_start_lens, num_seqs, out)
```
will still trigger the same error during device IR generation if going with option 1. This is because ```tile_q``` size is unknown at compile time, so the solution from option 1 will not cover this case.  


Added a new test case to cover the bug and all existing unit tests passed
```
pytest test/
```
Note that the test case to cover the block_ptr indexing issue mentioned in #1275 is covered by an [existing unit test](https://github.com/pytorch/helion/blob/main/test/test_examples.py#L268) already.