### PR TITLE
[autotuner] print path to generated Triton code after selection of kernel

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -694,9 +694,7 @@ class BaseSearch(BaseAutotuner):
             f"    {kernel_decorator}\n",
             level=logging.INFO + 5,
         )
-        self.log(
-            f"Code of selected kernel: {self.kernel.get_cached_path(best)}"
-        )
+        self.log(f"Code of selected kernel: {self.kernel.get_cached_path(best)}")
         self.kernel.maybe_log_repro(self.log.warning, self.args, best)
         if self.settings.print_output_code:
             triton_code = self.kernel.to_triton_code(best)

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -368,7 +368,7 @@ class BoundKernel(Generic[_R]):
         self._run: Callable[..., _R] | None = None
         self._config: Config | None = None
         self._compile_cache: dict[Config, CompiledConfig] = {}
-        self._cache_path_map: dict[Config, str] = {}
+        self._cache_path_map: dict[Config, str | None] = {}
         self.env = CompileEnvironment(
             _find_device(args),
             self.kernel.settings,


### PR DESCRIPTION
Rather small PR, but I found it really helpful for debugging, if I can directly look at the emitted Triton code and not need to copy prints from the log into a file again. 