### PR TITLE
Fix shape inference for tile indexing on size-1 dimensions and use broadcast_to for block_ptr

### DIFF
--- a/test/test_associative_scan.expected
+++ b/test/test_associative_scan.expected
@@ -748,20 +748,22 @@ def add_combine_fn_0(param_0, param_1):
     return v_0
 
 @triton.jit
-def _helion_test_single_element(x, result):
+def _helion_test_single_element(x, result, _BLOCK_SIZE_0: tl.constexpr):
     # src[test_associative_scan.py:N]: row_data = x[i, :]
-    row_data = tl.load(x + tl.zeros([1, 1], tl.int32), None)
+    row_data = tl.load(x + tl.zeros([_BLOCK_SIZE_0, 1], tl.int32), None)
     # src[test_associative_scan.py:N]: result[i, :] = hl.associative_scan(add_combine_fn, row_data, dim=1)
     _associative_scan = tl.associative_scan(row_data, 1, add_combine_fn_0)
-    tl.store(result + tl.zeros([1, 1], tl.int32), tl.reshape(_associative_scan, []), None)
+    tl.store(result + tl.zeros([_BLOCK_SIZE_0, 1], tl.int32), tl.reshape(_associative_scan, []), None)
 
 def test_single_element(x: torch.Tensor, *, _launcher=_default_launcher):
     # src[test_associative_scan.py:N]: result = torch.empty_like(x)
     result = torch.empty_like(x)
+    # src[test_associative_scan.py:N]: row_data = x[i, :]
+    _BLOCK_SIZE_0 = 1
     # src[test_associative_scan.py:N]: for i in hl.tile(x.size(0)):
     # src[test_associative_scan.py:N]:     row_data = x[i, :]
     # src[test_associative_scan.py:N]:     result[i, :] = hl.associative_scan(add_combine_fn, row_data, dim=1)
-    _launcher(_helion_test_single_element, (1,), x, result, num_warps=4, num_stages=1)
+    _launcher(_helion_test_single_element, (1,), x, result, _BLOCK_SIZE_0, num_warps=4, num_stages=1)
     # src[test_associative_scan.py:N]: return result
     return result
 

--- a/test/test_examples.expected
+++ b/test/test_examples.expected
@@ -6913,7 +6913,7 @@ def _helion_matmul(x, y, epilogue_closure_0, out, _BLOCK_SIZE_0: tl.constexpr, _
         load_1 = tl.load(tl.make_block_ptr(y, [1024, 1024], [1024, 1], [offset_2, offset_1], [_BLOCK_SIZE_2, _BLOCK_SIZE_1], [1, 0]), boundary_check=[0, 1], padding_option='zero')
         acc = tl.dot(tl.cast(load, tl.float16), tl.cast(load_1, tl.float16), acc=acc_copy_0, input_precision='tf32', out_dtype=tl.float32)
     # src[matmul.py:N]: out[tile_m, tile_n] = epilogue(acc, (tile_m, tile_n))
-    load_2 = tl.load(tl.make_block_ptr(epilogue_closure_0, [1, 1024], [1024, 1], [0, offset_1], [1, _BLOCK_SIZE_1], [1, 0]), boundary_check=[1], padding_option='zero')
+    load_2 = tl.broadcast_to(tl.load(tl.make_block_ptr(epilogue_closure_0, [1, 1024], [1024, 1], [0, offset_1], [1, _BLOCK_SIZE_1], [1, 0]), boundary_check=[1], padding_option='zero'), [_BLOCK_SIZE_0, _BLOCK_SIZE_1])
     v_0 = tl.cast(load_2, tl.float32)
     v_1 = acc + v_0
     v_2 = tl.full([], 0, tl.int32)

--- a/test/test_indexing.expected
+++ b/test/test_indexing.expected
@@ -121,12 +121,12 @@ def _helion_broadcast_add_3d(x, bias1, bias2, out, _BLOCK_SIZE_0: tl.constexpr, 
     # src[test_indexing.py:N]: x[tile_l, tile_m, tile_n]
     load = tl.load(tl.make_block_ptr(x, [16, 24, 32], [768, 32, 1], [offset_0, offset_1, offset_2], [_BLOCK_SIZE_0, _BLOCK_SIZE_1, _BLOCK_SIZE_2], [2, 1, 0]), boundary_check=[0, 1, 2], padding_option='zero')
     # src[test_indexing.py:N]: + bias1[tile_l, tile_m, tile_n]
-    load_1 = tl.load(tl.make_block_ptr(bias1, [1, 24, 32], [768, 32, 1], [0, offset_1, offset_2], [1, _BLOCK_SIZE_1, _BLOCK_SIZE_2], [2, 1, 0]), boundary_check=[1, 2], padding_option='zero')
+    load_1 = tl.broadcast_to(tl.load(tl.make_block_ptr(bias1, [1, 24, 32], [768, 32, 1], [0, offset_1, offset_2], [1, _BLOCK_SIZE_1, _BLOCK_SIZE_2], [2, 1, 0]), boundary_check=[1, 2], padding_option='zero'), [_BLOCK_SIZE_0, _BLOCK_SIZE_1, _BLOCK_SIZE_2])
     # src[test_indexing.py:N]: x[tile_l, tile_m, tile_n]
     # src[test_indexing.py:N]: + bias1[tile_l, tile_m, tile_n]
     v_0 = load + load_1
     # src[test_indexing.py:N]: + bias2[tile_l, tile_m, tile_n]
-    load_2 = tl.load(tl.make_block_ptr(bias2, [16, 1, 32], [32, 32, 1], [offset_0, 0, offset_2], [_BLOCK_SIZE_0, 1, _BLOCK_SIZE_2], [2, 1, 0]), boundary_check=[0, 2], padding_option='zero')
+    load_2 = tl.broadcast_to(tl.load(tl.make_block_ptr(bias2, [16, 1, 32], [32, 32, 1], [offset_0, 0, offset_2], [_BLOCK_SIZE_0, 1, _BLOCK_SIZE_2], [2, 1, 0]), boundary_check=[0, 2], padding_option='zero'), [_BLOCK_SIZE_0, _BLOCK_SIZE_1, _BLOCK_SIZE_2])
     # src[test_indexing.py:N]: x[tile_l, tile_m, tile_n]
     # src[test_indexing.py:N]: + bias1[tile_l, tile_m, tile_n]
     # src[test_indexing.py:N]: + bias2[tile_l, tile_m, tile_n]
@@ -252,12 +252,12 @@ def _helion_broadcast_add_3d(x, bias1, bias2, out, _BLOCK_SIZE_0: tl.constexpr, 
     # src[test_indexing.py:N]: x[tile_l, tile_m, tile_n]
     load = x_desc.load([offset_0, offset_1, offset_2])
     # src[test_indexing.py:N]: + bias1[tile_l, tile_m, tile_n]
-    load_1 = bias1_desc.load([0, offset_1, offset_2])
+    load_1 = tl.broadcast_to(bias1_desc.load([0, offset_1, offset_2]), [_BLOCK_SIZE_0, _BLOCK_SIZE_1, _BLOCK_SIZE_2])
     # src[test_indexing.py:N]: x[tile_l, tile_m, tile_n]
     # src[test_indexing.py:N]: + bias1[tile_l, tile_m, tile_n]
     v_0 = load + load_1
     # src[test_indexing.py:N]: + bias2[tile_l, tile_m, tile_n]
-    load_2 = bias2_desc.load([offset_0, 0, offset_2])
+    load_2 = tl.broadcast_to(bias2_desc.load([offset_0, 0, offset_2]), [_BLOCK_SIZE_0, _BLOCK_SIZE_1, _BLOCK_SIZE_2])
     # src[test_indexing.py:N]: x[tile_l, tile_m, tile_n]
     # src[test_indexing.py:N]: + bias1[tile_l, tile_m, tile_n]
     # src[test_indexing.py:N]: + bias2[tile_l, tile_m, tile_n]
@@ -869,7 +869,7 @@ from torch._inductor.runtime.triton_helpers import math as tl_math
 from helion.runtime import default_launcher as _default_launcher
 
 @triton.jit
-def _helion_kernel_with_mixed_store(x_data, out, scales, _BLOCK_SIZE_0: tl.constexpr, _BLOCK_SIZE_2: tl.constexpr):
+def _helion_kernel_with_mixed_store(x_data, out, scales, _BLOCK_SIZE_0: tl.constexpr, _BLOCK_SIZE_2: tl.constexpr, _BLOCK_SIZE_1: tl.constexpr):
     # src[test_indexing.py:N]: for m_tile, n_tile in hl.tile([m, n], block_size=[None, n_block]):
     num_blocks_0 = 1
     pid_1 = tl.program_id(0) // num_blocks_0
@@ -887,7 +887,7 @@ def _helion_kernel_with_mixed_store(x_data, out, scales, _BLOCK_SIZE_0: tl.const
         x_block = tl.load(x_data + indices_2[None, :] * 1, mask_2[None, :], other=0)
         # src[test_indexing.py:N]: row_max = x_block.abs().amax(dim=1)
         v_0 = tl_math.abs(x_block)
-        _mask_to = tl.where(tl.broadcast_to(mask_2[None, :], [1, _BLOCK_SIZE_2]), v_0, tl.full([], float('-inf'), tl.float32))
+        _mask_to = tl.where(tl.broadcast_to(mask_2[None, :], [_BLOCK_SIZE_1, _BLOCK_SIZE_2]), v_0, tl.full([], float('-inf'), tl.float32))
         row_max = tl.cast(tl.max(_mask_to, 1), tl.float32)
         # src[test_indexing.py:N]: row_value = row_max.to(torch.uint8)
         v_1 = tl.cast(row_max, tl.uint8)
@@ -918,11 +918,13 @@ def kernel_with_mixed_store(x_data: torch.Tensor, BLOCK_SIZE: hl.constexpr, *, _
     # src[test_indexing.py:N]: ):
     # src[test_indexing.py:N-N]: ...
     _BLOCK_SIZE_2 = 32
+    # src[test_indexing.py:N]: x_block = x_data[m_tile, n_tile_local]
+    _BLOCK_SIZE_1 = 1
     # src[test_indexing.py:N]: for m_tile, n_tile in hl.tile([m, n], block_size=[None, n_block]):
     # src[test_indexing.py:N]:     for n_tile_local in hl.tile(
     # src[test_indexing.py:N]:         n_tile.begin, n_tile.end, block_size=BLOCK_SIZE
     # src[test_indexing.py:N-N]: ...
-    _launcher(_helion_kernel_with_mixed_store, (1 * triton.cdiv(64, _BLOCK_SIZE_0),), x_data, out, scales, _BLOCK_SIZE_0, _BLOCK_SIZE_2, num_warps=4, num_stages=1)
+    _launcher(_helion_kernel_with_mixed_store, (1 * triton.cdiv(64, _BLOCK_SIZE_0),), x_data, out, scales, _BLOCK_SIZE_0, _BLOCK_SIZE_2, _BLOCK_SIZE_1, num_warps=4, num_stages=1)
     # src[test_indexing.py:N]: return out, scales
     return (out, scales)
 
@@ -1391,6 +1393,39 @@ def many_loads_kernel(a: torch.Tensor, *, _launcher=_default_launcher):
     _launcher(_helion_many_loads_kernel, (triton.cdiv(64, _BLOCK_SIZE_0) * triton.cdiv(64, _BLOCK_SIZE_1),), a, out, _BLOCK_SIZE_0, _BLOCK_SIZE_1, num_warps=4, num_stages=1)
     # src[test_indexing.py:N]: return out
     return out
+
+--- assertExpectedJournal(TestIndexing.test_size1_dimension_tile_reshape)
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from helion.runtime import default_launcher as _default_launcher
+
+@triton.jit
+def _helion_size1_reshape_kernel(x, out, _BLOCK_SIZE_1: tl.constexpr, _BLOCK_SIZE_0: tl.constexpr):
+    # src[test_indexing.py:N]: for tile_1, tile_2 in hl.tile([x.size(0), x.size(1)]):
+    num_blocks_0 = 1
+    pid_1 = tl.program_id(0) // num_blocks_0
+    offset_1 = pid_1 * _BLOCK_SIZE_1
+    indices_1 = (offset_1 + tl.arange(0, _BLOCK_SIZE_1)).to(tl.int32)
+    # src[test_indexing.py:N]: block = x[tile_1, tile_2]
+    block = tl.load(x + indices_1[None, :] * 1, None)
+    # src[test_indexing.py:N]: block_reshape = block.reshape([tile_1, tile_2])
+    block_reshape = tl.reshape(block, [_BLOCK_SIZE_0, _BLOCK_SIZE_1])
+    # src[test_indexing.py:N]: out[tile_1, tile_2] = block_reshape
+    tl.store(out + indices_1[None, :] * 1, block_reshape, None)
+
+def size1_reshape_kernel(x: torch.Tensor, out: torch.Tensor, *, _launcher=_default_launcher):
+    # src[test_indexing.py:N]: for tile_1, tile_2 in hl.tile([x.size(0), x.size(1)]):
+    _BLOCK_SIZE_1 = 16
+    # src[test_indexing.py:N]: block = x[tile_1, tile_2]
+    _BLOCK_SIZE_0 = 1
+    # src[test_indexing.py:N]: for tile_1, tile_2 in hl.tile([x.size(0), x.size(1)]):
+    # src[test_indexing.py:N]:     block = x[tile_1, tile_2]
+    # src[test_indexing.py:N]:     # This reshape would fail before the fix when x.size(0) == 1
+    # src[test_indexing.py:N-N]: ...
+    _launcher(_helion_size1_reshape_kernel, (1 * triton.cdiv(16, _BLOCK_SIZE_1),), x, out, _BLOCK_SIZE_1, _BLOCK_SIZE_0, num_warps=4, num_stages=1)
 
 --- assertExpectedJournal(TestIndexing.test_slice_block_size_multiple)
 from __future__ import annotations

--- a/test/test_reduce.expected
+++ b/test/test_reduce.expected
@@ -190,7 +190,7 @@ def add_combine_fn_0(param_0, param_1):
     return v_0
 
 @triton.jit
-def _helion_test_reduce_codegen_kernel(x, result, _RDIM_SIZE_1: tl.constexpr):
+def _helion_test_reduce_codegen_kernel(x, result, _RDIM_SIZE_1: tl.constexpr, _BLOCK_SIZE_0: tl.constexpr):
     # src[test_reduce.py:N]: for i in hl.tile(x.size(0)):
     indices_1 = tl.arange(0, _RDIM_SIZE_1).to(tl.int32)
     mask_1 = indices_1 < 3
@@ -198,17 +198,19 @@ def _helion_test_reduce_codegen_kernel(x, result, _RDIM_SIZE_1: tl.constexpr):
     row_data = tl.load(x + indices_1[None, :] * 1, mask_1[None, :], other=0)
     # src[test_reduce.py:N]: result[i] = hl.reduce(add_combine_fn, row_data, dim=1)
     _reduce = tl.reduce(row_data, 1, add_combine_fn_0)
-    tl.store(result + tl.zeros([1], tl.int32), tl.reshape(_reduce, []), None)
+    tl.store(result + tl.zeros([_BLOCK_SIZE_0], tl.int32), tl.reshape(_reduce, []), None)
 
 def test_reduce_codegen_kernel(x: torch.Tensor, *, _launcher=_default_launcher):
     # src[test_reduce.py:N]: result = torch.empty([x.size(0)], dtype=x.dtype, device=x.device)
     result = torch.empty([x.size(0)], dtype=x.dtype, device=x.device)
     # src[test_reduce.py:N]: for i in hl.tile(x.size(0)):
     _RDIM_SIZE_1 = 4
+    # src[test_reduce.py:N]: row_data = x[i, :]
+    _BLOCK_SIZE_0 = 1
     # src[test_reduce.py:N]: for i in hl.tile(x.size(0)):
     # src[test_reduce.py:N]:     row_data = x[i, :]
     # src[test_reduce.py:N]:     result[i] = hl.reduce(add_combine_fn, row_data, dim=1)
-    _launcher(_helion_test_reduce_codegen_kernel, (1,), x, result, _RDIM_SIZE_1, num_warps=4, num_stages=1)
+    _launcher(_helion_test_reduce_codegen_kernel, (1,), x, result, _RDIM_SIZE_1, _BLOCK_SIZE_0, num_warps=4, num_stages=1)
     # src[test_reduce.py:N]: return result
     return result
 


### PR DESCRIPTION
Stacked PRs:
 * #1300
 * __->__#1299


--- --- ---

### Fix shape inference for tile indexing on size-1 dimensions and use broadcast_to for block_ptr


Fixes #1275
