### PR TITLE
settings: normalize HELION_AUTOTUNER parsing

### DIFF
--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -133,17 +133,9 @@ def _env_get_literal(
     )
 
 
-def _env_get_str(
-    var_name: str,
-    default: str,
-    *,
-    empty: Literal["default", "keep"] = "default",
-) -> str:
+def _env_get_str(var_name: str, default: str) -> str:
     value = os.environ.get(var_name)
-    if value is None:
-        return default
-    value = value.strip()
-    if value == "" and empty == "default":
+    if value is None or (value := value.strip()) == "":
         return default
     return value
 
@@ -245,7 +237,7 @@ def default_autotuner_fn(
     from ..autotuner import cache_classes
     from ..autotuner import search_algorithms
 
-    autotuner_name = _env_get_str("HELION_AUTOTUNER", "LFBOPatternSearch", empty="keep")
+    autotuner_name = _env_get_str("HELION_AUTOTUNER", "LFBOPatternSearch")
     autotuner_cls = search_algorithms.get(autotuner_name)
     if autotuner_cls is None:
         raise ValueError(


### PR DESCRIPTION
Switch HELION_AUTOTUNER parsing to _env_get_str(...) so whitespace is trimmed