### PR TITLE
Pin pyrefly to 0.44.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install lint dependencies
         run: |
           source .venv/bin/activate
-          uv pip install pyrefly
+          uv pip install pyrefly==0.44.0
           uv pip install .'[dev]'
 
       - name: Run pre-commit


### PR DESCRIPTION
Latest pyrefly (0.46.1) fails on helion with https://github.com/pytorch/helion/actions/runs/20492124762/job/58985109210