### PR TITLE
Add experimental FP8 random kernel (not working yet due to symm_mem)

### DIFF
--- a/examples/distributed/all_gather_matmul_fp8.py
+++ b/examples/distributed/all_gather_matmul_fp8.py
@@ -1,0 +1,184 @@
+# %%
+# FP8 All-Gather Matrix Multiplication Example
+# ===========================================
+# Same as all_gather_matmul.py but using FP8 inputs with FP32 accumulation and FP16 output
+
+# %%
+from __future__ import annotations
+
+import os
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+
+import helion
+from helion._testing import DEVICE
+import helion.language as hl
+
+# %%
+def copy_engine_all_gather_w_progress(
+    output: torch.Tensor,
+    inp: torch.Tensor,  # Must be symmetric tensor
+    progress: torch.Tensor,
+    splits_per_rank: int,
+    backend_stream: torch.cuda.Stream | None = None,
+) -> torch.cuda.Stream:
+    """
+    Performs an all-gather operation with progress tracking using symmetric memory.
+    Args:
+        output (torch.Tensor): The output tensor to store the gathered results.
+        inp (torch.Tensor): The input tensor to be gathered (must be a symmetric tensor).
+        progress (torch.Tensor): Tensor used to track progress of the operation.
+        splits_per_rank (int): Number of splits per rank.
+        backend_stream (torch.cuda.Stream, optional): CUDA stream for backend operations.
+    Returns:
+        torch.cuda.Stream: The CUDA stream used for the operation.
+    """
+    backend_stream = symm_mem._get_backend_stream(priority=-1)
+    assert inp.is_contiguous()
+    symm_mem_group = dist.group.WORLD
+    if symm_mem_group is None:
+        raise RuntimeError("No symmetric memory group available")
+    symm_mem_hdl = symm_mem.rendezvous(inp, group=symm_mem_group)
+    assert symm_mem_hdl is not None
+    rank = symm_mem_hdl.rank
+    world_size = symm_mem_hdl.world_size
+    assert inp.numel() % splits_per_rank == 0
+    assert progress.numel() >= world_size * splits_per_rank
+    output_shape = list(inp.shape)
+    output_shape[0] *= world_size
+    assert list(output.shape) == output_shape, (list(output.shape), output_shape)
+    chunks = output.chunk(world_size * splits_per_rank)
+    symm_mem_hdl.barrier()
+    backend_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(backend_stream):
+        for step in range(world_size):
+            src_rank = (rank + step + 1) % world_size
+            for split_id in range(splits_per_rank):
+                src_buf = symm_mem_hdl.get_buffer(
+                    src_rank, chunks[0].shape, inp.dtype, chunks[0].numel() * split_id
+                )
+                chunks[src_rank * splits_per_rank + split_id].copy_(src_buf)
+                symm_mem_hdl.stream_write_value32(
+                    progress,
+                    offset=src_rank * splits_per_rank + split_id,
+                    val=1,
+                )
+        symm_mem_hdl.barrier()
+    return backend_stream
+
+# %%
+@helion.kernel(
+    config=helion.Config(
+        block_sizes=[128, 256, 64],
+        num_warps=8,
+        num_stages=3,
+        indexing="block_ptr",
+    ),
+    static_shapes=True,
+)
+def helion_matmul_w_progress_fp8(
+    a: torch.Tensor,      # FP8 input
+    a_shared: torch.Tensor,  # FP8 gathered input
+    b: torch.Tensor,      # FP8 input
+    progress: torch.Tensor,
+    SPLITS_PER_RANK: int,
+    RANK: int,
+) -> torch.Tensor:
+    M, K = a.size()
+    K2, N = b.size()
+    assert K2 == K, f"size mismatch {K2} != {K}"
+    out = torch.empty(
+        [M, N], dtype=torch.promote_types(torch.float16, torch.float16), device=a.device
+    )
+    M_per_rank = a_shared.size(0)
+    for tile_m, tile_n in hl.tile([M, N]):
+        # Accumulate in FP32
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        hl.wait(
+            progress,
+            [
+                tile_m.begin // (M_per_rank // SPLITS_PER_RANK),
+            ],
+            signal=1,
+        )
+        for tile_k in hl.tile(K):
+            # Cast FP8 -> FP32 for accumulation
+            acc = torch.addmm(acc, a[tile_m, tile_k].to(torch.float32), b[tile_k, tile_n].to(torch.float32))
+        out[tile_m, tile_n] = acc.to(torch.float16)
+    return out
+
+# %%
+def helion_all_gather_matmul_fp8(
+    a_shared: torch.Tensor,
+    b: torch.Tensor,
+    a_out: torch.Tensor | None = None,
+    progress: torch.Tensor | None = None,
+    **kwargs: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    configs = {
+        "SPLITS_PER_RANK": kwargs.get("splits_per_rank", 1),
+    }
+    symm_mem_group = dist.group.WORLD
+    if symm_mem_group is None:
+        raise RuntimeError("No symmetric memory group available")
+    symm_mem_hdl = symm_mem.rendezvous(a_shared, group=symm_mem_group)
+    a_shape = list(a_shared.shape)
+    a_shape[0] *= symm_mem_hdl.world_size
+    configs["RANK"] = symm_mem_hdl.rank
+    configs["WORLD_SIZE"] = symm_mem_hdl.world_size
+    if a_out is None:
+        a_out = torch.empty(a_shape, dtype=a_shared.dtype, device=a_shared.device)
+    if progress is None:
+        progress = torch.zeros(
+            symm_mem_hdl.world_size * configs["SPLITS_PER_RANK"],
+            dtype=torch.uint32,
+            device=a_shared.device,
+        )
+    else:
+        progress.fill_(0) # Reset progress to 0.
+    backend_stream = copy_engine_all_gather_w_progress(
+        a_out, a_shared, progress, configs["SPLITS_PER_RANK"]
+    )
+    c = helion_matmul_w_progress_fp8(
+        a_out,
+        a_shared,
+        b,
+        progress,
+        SPLITS_PER_RANK=configs["SPLITS_PER_RANK"],
+        RANK=configs["RANK"],
+    )
+    torch.cuda.current_stream().wait_stream(backend_stream)
+    return a_out, c
+
+# %%
+def test_fp8(M: int, N: int, K: int, world_size: int, device: torch.device) -> None:
+    # Create FP8 symmetric input
+    a_shared = symm_mem.empty(
+        M // world_size, K, dtype=torch.float8_e4m3fn, device=device
+    ).normal_()
+    b = torch.randn((K, N), device=device, dtype=torch.float8_e4m3fn).T.contiguous().T
+    a_out, c = helion_all_gather_matmul_fp8(a_shared, b)
+    # Reference FP16 accumulation for correctness
+    golden_a = a_shared.to(torch.float32).clone()
+    golden_b = b.to(torch.float32).clone()
+    mm_golden = golden_a @ golden_b
+    # Convert Helion output to FP32 for comparison
+    torch.testing.assert_close(c.to(torch.float32), mm_golden, rtol=1e-1, atol=1e-1)
+
+# %%
+def main_fp8() -> None:
+    rank = int(os.environ["LOCAL_RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    torch.manual_seed(42 + rank)
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+    dist.init_process_group("nccl")
+    test_fp8(4096, 6656, 16384, world_size, device)
+    dist.destroy_process_group()
+
+# %%
+if __name__ == "__main__":
+    print("Running FP8 All-Gather MatMul Example")
+    assert DEVICE.type == "cuda", "Requires CUDA device"
+    main_fp8()

--- a/examples/distributed/all_gather_matmul_fp8.py
+++ b/examples/distributed/all_gather_matmul_fp8.py
@@ -1,3 +1,11 @@
+# %%
+# FP8 All-Gather Matrix Multiplication Example
+# ===========================================
+# Same as all_gather_matmul.py but using FP8 inputs with FP32 accumulation and FP16 output
+
+# %%
+from __future__ import annotations
+
 import os
 import torch
 import torch.distributed as dist
@@ -7,7 +15,60 @@ import helion
 from helion._testing import DEVICE
 import helion.language as hl
 
+# %%
+def copy_engine_all_gather_w_progress(
+    output: torch.Tensor,
+    inp: torch.Tensor,  # Must be symmetric tensor
+    progress: torch.Tensor,
+    splits_per_rank: int,
+    backend_stream: torch.cuda.Stream | None = None,
+) -> torch.cuda.Stream:
+    """
+    Performs an all-gather operation with progress tracking using symmetric memory.
+    Args:
+        output (torch.Tensor): The output tensor to store the gathered results.
+        inp (torch.Tensor): The input tensor to be gathered (must be a symmetric tensor).
+        progress (torch.Tensor): Tensor used to track progress of the operation.
+        splits_per_rank (int): Number of splits per rank.
+        backend_stream (torch.cuda.Stream, optional): CUDA stream for backend operations.
+    Returns:
+        torch.cuda.Stream: The CUDA stream used for the operation.
+    """
+    backend_stream = symm_mem._get_backend_stream(priority=-1)
+    assert inp.is_contiguous()
+    symm_mem_group = dist.group.WORLD
+    if symm_mem_group is None:
+        raise RuntimeError("No symmetric memory group available")
+    symm_mem_hdl = symm_mem.rendezvous(inp, group=symm_mem_group)
+    assert symm_mem_hdl is not None
+    rank = symm_mem_hdl.rank
+    world_size = symm_mem_hdl.world_size
+    assert inp.numel() % splits_per_rank == 0
+    assert progress.numel() >= world_size * splits_per_rank
+    output_shape = list(inp.shape)
+    output_shape[0] *= world_size
+    assert list(output.shape) == output_shape, (list(output.shape), output_shape)
+    chunks = output.chunk(world_size * splits_per_rank)
+    symm_mem_hdl.barrier()
+    backend_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(backend_stream):
+        for step in range(world_size):
+            src_rank = (rank + step + 1) % world_size
+            for split_id in range(splits_per_rank):
+                src_buf = symm_mem_hdl.get_buffer(
+                    src_rank, chunks[0].shape, inp.dtype, chunks[0].numel() * split_id
+                )
+                chunks[src_rank * splits_per_rank + split_id].copy_(src_buf)
+                # cuStreamWriteValue32 issues a system level fence before the write
+                symm_mem_hdl.stream_write_value32(
+                    progress,
+                    offset=src_rank * splits_per_rank + split_id,
+                    val=1,
+                )
+        symm_mem_hdl.barrier()
+    return backend_stream
 
+# %%
 @helion.kernel(
     config=helion.Config(
         block_sizes=[128, 256, 64],
@@ -29,29 +90,26 @@ def helion_matmul_w_progress_fp8(
     K2, N = b.size()
     assert K2 == K, f"size mismatch {K2} != {K}"
     out = torch.empty(
-        [M, N], dtype=torch.float16, device=a.device  # Output in FP16
+        [M, N], dtype=torch.promote_types(a.dtype, b.dtype), device=a.device
     )
     M_per_rank = a_shared.size(0)
     for tile_m, tile_n in hl.tile([M, N]):
-        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)  # Accumulate in FP32  
-        # hl.wait(
-        #     progress,
-        #     [
-        #         tile_m.begin // (M_per_rank // SPLITS_PER_RANK),
-        #     ],
-        #     signal=1,
-        # )
+        # Accumulate in FP32
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        hl.wait(
+            progress,
+            [
+                tile_m.begin // (M_per_rank // SPLITS_PER_RANK),
+            ],
+            signal=1,
+        )
         for tile_k in hl.tile(K):
-            # FP8 -> FP32 for accumulation
-            acc = torch.addmm(
-                acc,
-                a[tile_m, tile_k].to(torch.float32),
-                b[tile_k, tile_n].to(torch.float32),
-            )
-        out[tile_m, tile_n] = acc.to(torch.float16)  # FP16 output
+            # Cast FP8 -> FP32 for accumulation
+            acc = torch.addmm(acc, a[tile_m, tile_k].to(torch.float32), b[tile_k, tile_n].to(torch.float32))
+        out[tile_m, tile_n] = acc.to(torch.float16)
     return out
 
-
+# %%
 def helion_all_gather_matmul_fp8(
     a_shared: torch.Tensor,
     b: torch.Tensor,
@@ -59,102 +117,75 @@ def helion_all_gather_matmul_fp8(
     progress: torch.Tensor | None = None,
     **kwargs: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """
-    Combines all-gather and matrix multiplication for FP8 inputs.
-    """
     configs = {
         "SPLITS_PER_RANK": kwargs.get("splits_per_rank", 1),
     }
-    rank = dist.get_rank()
-    world_size = dist.get_world_size()
-
-    # Prepare progress tensor
+    symm_mem_group = dist.group.WORLD
+    if symm_mem_group is None:
+        raise RuntimeError("No symmetric memory group available")
+    symm_mem_hdl = symm_mem.rendezvous(a_shared, group=symm_mem_group)
+    a_shape = list(a_shared.shape)
+    a_shape[0] *= symm_mem_hdl.world_size
+    configs["RANK"] = symm_mem_hdl.rank
+    configs["WORLD_SIZE"] = symm_mem_hdl.world_size
+    if a_out is None:
+        a_out = torch.empty(a_shape, dtype=a_shared.dtype, device=a_shared.device)
     if progress is None:
         progress = torch.zeros(
-            world_size * configs["SPLITS_PER_RANK"],
+            symm_mem_hdl.world_size * configs["SPLITS_PER_RANK"],
             dtype=torch.uint32,
             device=a_shared.device,
         )
-
-    # Allocate a_out for gathered results
-    a_shape = list(a_shared.shape)
-    a_shape[0] *= world_size
-    if a_out is None:
-        a_out = torch.empty(a_shape, dtype=a_shared.dtype, device=a_shared.device)
-
-    # Perform all-gather
-    dist.all_gather(list(a_out.chunk(world_size, dim=0)), a_shared) #instead of symm_mem.rendezvous 
-
-    # Perform matrix multiplication with progress tracking
-    print("Helion kernel launch")
+    else:
+        progress.fill_(0) # Reset progress to 0.
+    backend_stream = copy_engine_all_gather_w_progress(
+        a_out, a_shared, progress, configs["SPLITS_PER_RANK"]
+    )
     c = helion_matmul_w_progress_fp8(
         a_out,
         a_shared,
         b,
         progress,
         SPLITS_PER_RANK=configs["SPLITS_PER_RANK"],
-        RANK=rank,
+        RANK=configs["RANK"],
     )
-    print("Helion Out kernel launch")
-
+    assert type(c) is torch.Tensor
+    torch.cuda.current_stream().wait_stream(backend_stream)
     return a_out, c
 
-
+# %%
 def test_fp8(M: int, N: int, K: int, world_size: int, device: torch.device) -> None:
-    """
-    Functional test for FP8 all-gather matrix multiplication.
-    """
-    torch.cuda.empty_cache()
 
-    # Input tensor, shared across ranks
     a_shared = symm_mem.empty(
         M // world_size, K, dtype=torch.float8_e4m3fn, device=device
     )
-    
-    # Randomly initialize a_shared in FP32 and cast to FP8
-    random_values = torch.randn(M // world_size, K, device=device, dtype=torch.float32)
-    a_shared.copy_(random_values.to(dtype=torch.float8_e4m3fn))
-
-    # Random matrix `b` in FP16 converted to FP8
-    b = torch.randn((K, N), device=DEVICE, dtype=torch.float16).to(torch.float8_e4m3fn)
-
-    print(f"[Rank {dist.get_rank()}] Initialized b matrix: {b.shape=}, {b.dtype=}")
-
-    # Call matrix multiplication with all-gather
+    b = torch.randn((K, N), device=DEVICE, dtype=torch.float16).T.contiguous().T.to(torch.float8_e4m3fn)
     a_out, c = helion_all_gather_matmul_fp8(a_shared, b)
-    print("helion_all_gather_matmul_fp8 out ")
-    # Generate FP16 reference results (golden)
+    golden_a = a_shared.clone()
+    dist_group = dist.group.WORLD
+    if dist_group is None:
+        raise RuntimeError("No distributed group available")
     golden_a = a_out.to(torch.float32).clone()
     golden_b = b.to(torch.float32).clone()
-    print("golden_a and golden_b created")
 
     mm_golden = golden_a @ golden_b
-    print("golden_a @ golden_b ")
 
     # Validate against the reference
     torch.testing.assert_close(c.to(torch.float32), mm_golden, rtol=1e-1, atol=1e-1)
 
-    print(f"[Rank {dist.get_rank()}] Matrix multiplication passed FP8 test!")
-
-
+# %%
 def main_fp8() -> None:
-    """
-    Main function for running FP8 distributed test.
-    """
     rank = int(os.environ["LOCAL_RANK"])
     world_size = int(os.environ["WORLD_SIZE"])
     torch.manual_seed(42 + rank)
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
     dist.init_process_group("nccl")
-    test_fp8(4096, 6656, 16384//2, world_size, device)
+    test_fp8(4096, 6656, 16384, world_size, device)
     dist.destroy_process_group()
 
-
+# %%
 if __name__ == "__main__":
-    """
-    Run the FP8 All-Gather MatMul Example.
-    """
     print("Running FP8 All-Gather MatMul Example")
     assert DEVICE.type == "cuda", "Requires CUDA device"
     main_fp8()

--- a/examples/distributed/all_gather_matmul_fp8.py
+++ b/examples/distributed/all_gather_matmul_fp8.py
@@ -1,11 +1,3 @@
-# %%
-# Distributed FP8 All-Gather Matrix Multiplication with FP32 Accumulation
-# =========================================================================
-# Demonstrates all-gather of BF16 shards across GPUs, FP8 matmul inputs, FP32 accumulation, and FP16 output.
-# Based on all_gather_matmul.py
-# %%
-from __future__ import annotations
-
 import os
 import torch
 import torch.distributed as dist
@@ -15,59 +7,7 @@ import helion
 from helion._testing import DEVICE
 import helion.language as hl
 
-# %%
-def copy_engine_all_gather_w_progress(
-    output: torch.Tensor,
-    inp: torch.Tensor,  # Must be symmetric tensor
-    progress: torch.Tensor,
-    splits_per_rank: int,
-    backend_stream: torch.cuda.Stream | None = None,
-) -> torch.cuda.Stream:
-    """
-    Performs an all-gather operation with progress tracking using symmetric memory.
-    Args:
-        output (torch.Tensor): The output tensor to store the gathered results.
-        inp (torch.Tensor): The input tensor to be gathered (must be a symmetric tensor).
-        progress (torch.Tensor): Tensor used to track progress of the operation.
-        splits_per_rank (int): Number of splits per rank.
-        backend_stream (torch.cuda.Stream, optional): CUDA stream for backend operations.
-    Returns:
-        torch.cuda.Stream: The CUDA stream used for the operation.
-    """
-    backend_stream = symm_mem._get_backend_stream(priority=-1)
-    assert inp.is_contiguous()
-    symm_mem_group = dist.group.WORLD
-    if symm_mem_group is None:
-        raise RuntimeError("No symmetric memory group available")
-    symm_mem_hdl = symm_mem.rendezvous(inp, group=symm_mem_group)
-    assert symm_mem_hdl is not None
-    rank = symm_mem_hdl.rank
-    world_size = symm_mem_hdl.world_size
-    assert inp.numel() % splits_per_rank == 0
-    assert progress.numel() >= world_size * splits_per_rank
-    output_shape = list(inp.shape)
-    output_shape[0] *= world_size
-    assert list(output.shape) == output_shape, (list(output.shape), output_shape)
-    chunks = output.chunk(world_size * splits_per_rank)
-    symm_mem_hdl.barrier()
-    backend_stream.wait_stream(torch.cuda.current_stream())
-    with torch.cuda.stream(backend_stream):
-        for step in range(world_size):
-            src_rank = (rank + step + 1) % world_size
-            for split_id in range(splits_per_rank):
-                src_buf = symm_mem_hdl.get_buffer(
-                    src_rank, chunks[0].shape, inp.dtype, chunks[0].numel() * split_id
-                )
-                chunks[src_rank * splits_per_rank + split_id].copy_(src_buf)
-                symm_mem_hdl.stream_write_value32(
-                    progress,
-                    offset=src_rank * splits_per_rank + split_id,
-                    val=1,
-                )
-        symm_mem_hdl.barrier()
-    return backend_stream
 
-# %%
 @helion.kernel(
     config=helion.Config(
         block_sizes=[128, 256, 64],
@@ -78,9 +18,9 @@ def copy_engine_all_gather_w_progress(
     static_shapes=True,
 )
 def helion_matmul_w_progress_fp8(
-    a: torch.Tensor,         # BF16 gathered input
-    a_shared: torch.Tensor,  # BF16 symmetric shard
-    b: torch.Tensor,         # FP8 input
+    a: torch.Tensor,      # FP8 input
+    a_shared: torch.Tensor,  # FP8 gathered input
+    b: torch.Tensor,      # FP8 input
     progress: torch.Tensor,
     SPLITS_PER_RANK: int,
     RANK: int,
@@ -88,39 +28,30 @@ def helion_matmul_w_progress_fp8(
     M, K = a.size()
     K2, N = b.size()
     assert K2 == K, f"size mismatch {K2} != {K}"
-
-    #out = torch.empty(
-    #    [M, N], dtype=torch.promote_types(a.dtype, b.dtype), device=a.device
-    #)
-    # using the torch.empty results in the error:
-    #[rank0]: RuntimeError: Promotion for Float8 Types is not supported, attempted to promote BFloat16 and Float8_e4m3fn
-
-    # the alternative is:
-    out = torch.empty((M, N), dtype=torch.float16, device=a.device)
-
+    out = torch.empty(
+        [M, N], dtype=torch.float16, device=a.device  # Output in FP16
+    )
     M_per_rank = a_shared.size(0)
     for tile_m, tile_n in hl.tile([M, N]):
-        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
-        hl.wait(
-            progress,
-            [
-                tile_m.begin // (M_per_rank // SPLITS_PER_RANK)
-            ],
-            signal=1,
-        )
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)  # Accumulate in FP32  
+        # hl.wait(
+        #     progress,
+        #     [
+        #         tile_m.begin // (M_per_rank // SPLITS_PER_RANK),
+        #     ],
+        #     signal=1,
+        # )
         for tile_k in hl.tile(K):
-            a_fp8 = a[tile_m, tile_k].to(torch.float8_e4m3fn) #Fake FP8 input BF16 → FP8) to simulate real FP8 input
-            b_fp8 = b[tile_k, tile_n]
-            #FP32 accumulate
+            # FP8 -> FP32 for accumulation
             acc = torch.addmm(
                 acc,
-                a_fp8.to(torch.float32),
-                b_fp8.to(torch.float32),
+                a[tile_m, tile_k].to(torch.float32),
+                b[tile_k, tile_n].to(torch.float32),
             )
-        out[tile_m, tile_n] = acc.to(torch.float16)
+        out[tile_m, tile_n] = acc.to(torch.float16)  # FP16 output
     return out
 
-# %%
+
 def helion_all_gather_matmul_fp8(
     a_shared: torch.Tensor,
     b: torch.Tensor,
@@ -128,80 +59,102 @@ def helion_all_gather_matmul_fp8(
     progress: torch.Tensor | None = None,
     **kwargs: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Combines all-gather and matrix multiplication for FP8 inputs.
+    """
     configs = {
         "SPLITS_PER_RANK": kwargs.get("splits_per_rank", 1),
     }
-    symm_mem_group = dist.group.WORLD
-    if symm_mem_group is None:
-        raise RuntimeError("No symmetric memory group available")
-    symm_mem_hdl = symm_mem.rendezvous(a_shared, group=symm_mem_group)
-    a_shape = list(a_shared.shape)
-    print("All-Gather MatMul FP8: a_shared shape:", a_shape)
-    a_shape[0] *= symm_mem_hdl.world_size
-    configs["RANK"] = symm_mem_hdl.rank
-    configs["WORLD_SIZE"] = symm_mem_hdl.world_size
-    if a_out is None:
-        a_out = torch.empty(a_shape, dtype=a_shared.dtype, device=a_shared.device)
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+
+    # Prepare progress tensor
     if progress is None:
         progress = torch.zeros(
-            symm_mem_hdl.world_size * configs["SPLITS_PER_RANK"],
+            world_size * configs["SPLITS_PER_RANK"],
             dtype=torch.uint32,
             device=a_shared.device,
         )
-    else:
-        progress.fill_(0) # Reset progress to 0.
-    backend_stream = copy_engine_all_gather_w_progress(
-        a_out, a_shared, progress, configs["SPLITS_PER_RANK"]
-    )
+
+    # Allocate a_out for gathered results
+    a_shape = list(a_shared.shape)
+    a_shape[0] *= world_size
+    if a_out is None:
+        a_out = torch.empty(a_shape, dtype=a_shared.dtype, device=a_shared.device)
+
+    # Perform all-gather
+    dist.all_gather(list(a_out.chunk(world_size, dim=0)), a_shared) #instead of symm_mem.rendezvous 
+
+    # Perform matrix multiplication with progress tracking
+    print("Helion kernel launch")
     c = helion_matmul_w_progress_fp8(
         a_out,
         a_shared,
         b,
         progress,
         SPLITS_PER_RANK=configs["SPLITS_PER_RANK"],
-        RANK=configs["RANK"],
+        RANK=rank,
     )
-    torch.cuda.current_stream().wait_stream(backend_stream)
+    print("Helion Out kernel launch")
+
     return a_out, c
 
-# %%
+
 def test_fp8(M: int, N: int, K: int, world_size: int, device: torch.device) -> None:
-    # Create BF16 Symmetric input
+    """
+    Functional test for FP8 all-gather matrix multiplication.
+    """
+    torch.cuda.empty_cache()
+
+    # Input tensor, shared across ranks
     a_shared = symm_mem.empty(
-        M // world_size, K, dtype=torch.bfloat16, device=device
-    ).normal_()
-
-    # FP8 weight
-    b = torch.randn((K, N), device=device, dtype=torch.bfloat16).T.contiguous().T.to(torch.float8_e4m3fn)
-
-    a_out, c = helion_all_gather_matmul_fp8(a_shared, b)
-
-    # Refermce FP16 accumulation for correctness
-    golden_a = a_out.to(torch.float8_e4m3fn).to(torch.float32)
-    golden_b = b.to(torch.float32)
-    mm_golden = golden_a @ golden_b
-
-
-    torch.testing.assert_close(
-        c.to(torch.float32),
-        mm_golden,
-        rtol=1e-1,
-        atol=1e-1,
+        M // world_size, K, dtype=torch.float8_e4m3fn, device=device
     )
+    
+    # Randomly initialize a_shared in FP32 and cast to FP8
+    random_values = torch.randn(M // world_size, K, device=device, dtype=torch.float32)
+    a_shared.copy_(random_values.to(dtype=torch.float8_e4m3fn))
 
-# %%
+    # Random matrix `b` in FP16 converted to FP8
+    b = torch.randn((K, N), device=DEVICE, dtype=torch.float16).to(torch.float8_e4m3fn)
+
+    print(f"[Rank {dist.get_rank()}] Initialized b matrix: {b.shape=}, {b.dtype=}")
+
+    # Call matrix multiplication with all-gather
+    a_out, c = helion_all_gather_matmul_fp8(a_shared, b)
+    print("helion_all_gather_matmul_fp8 out ")
+    # Generate FP16 reference results (golden)
+    golden_a = a_out.to(torch.float32).clone()
+    golden_b = b.to(torch.float32).clone()
+    print("golden_a and golden_b created")
+
+    mm_golden = golden_a @ golden_b
+    print("golden_a @ golden_b ")
+
+    # Validate against the reference
+    torch.testing.assert_close(c.to(torch.float32), mm_golden, rtol=1e-1, atol=1e-1)
+
+    print(f"[Rank {dist.get_rank()}] Matrix multiplication passed FP8 test!")
+
+
 def main_fp8() -> None:
+    """
+    Main function for running FP8 distributed test.
+    """
     rank = int(os.environ["LOCAL_RANK"])
     world_size = int(os.environ["WORLD_SIZE"])
     torch.manual_seed(42 + rank)
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
     dist.init_process_group("nccl")
-    test_fp8(4096, 6656, 16384, world_size, device)
+    test_fp8(4096, 6656, 16384//2, world_size, device)
     dist.destroy_process_group()
 
-# %%
+
 if __name__ == "__main__":
+    """
+    Run the FP8 All-Gather MatMul Example.
+    """
     print("Running FP8 All-Gather MatMul Example")
     assert DEVICE.type == "cuda", "Requires CUDA device"
     main_fp8()


### PR DESCRIPTION
**Goal**: Run FP8 all-gather + GEMM with helion for this [vLLM task
](https://github.com/vllm-project/vllm/issues/30896).


```
OMP_NUM_THREADS=1  python -m torch.distributed.run --standalone     --nproc-per-node 4     --rdzv-backend c10d --rdzv-endpoin
t localhost:0     --no_python python3 examples/distributed/all_gather_matmul_fp8.py
```

env:
torch                             2.10.0+cu128
torchaudio                        2.10.0+cu128
torchvision                       0.25.0+cu128

Next steps:
1. Identify the input/output contract of the vLLM kernel targeted for replacement.
2. Verify functional and layout alignment with the Helion kernel.
Future work:
-Benchmark performance via vLLM’s Helion integration.
