### PR TITLE
Skip tensor_descriptor and eviction policy for AMD

### DIFF
--- a/helion/_compat.py
+++ b/helion/_compat.py
@@ -200,6 +200,10 @@ def supports_tensor_descriptor() -> bool:
 
 @functools.cache
 def _supports_tensor_descriptor() -> bool:
+    # AMD ROCm does not support tensor_descriptor
+    if torch.version.hip is not None:
+        return False
+
     def _cuda_tensor_desc_available() -> bool:
         if not torch.cuda.is_available():
             return False

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -73,8 +73,12 @@ DEFAULT_NUM_SM_MULTIPLIER = 1
 # Lower values allow higher occupancy but may hurt performance for register-heavy kernels
 VALID_MAXNREG = (None, 32, 64, 128, 256)
 DEFAULT_MAXNREG = None
-# For tileir backend, eviction policies will be discarded.
-VALID_EVICTION_POLICIES = ("", "first", "last") if not use_tileir_tunables() else ("",)
+# For tileir backend or AMD ROCM, eviction policies are not supported.
+VALID_EVICTION_POLICIES = (
+    ("", "first", "last")
+    if not use_tileir_tunables() and not supports_amd_cdna_tunables()
+    else ("",)
+)
 VALID_WAVES_PER_EU = (1, 2, 3, 4)
 VALID_MATRIX_INSTR_NONKDIM = (0, 16, 32)
 

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -463,6 +463,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
     @patch.object(loops, "_supports_warp_specialize", lambda: True)
     @patch("torch.version.hip", None)
     @patch("torch.version.xpu", None)
+    @skipIfRocm("should skip on rocm")
     def test_config_fragment1(self):
         args = (
             torch.randn([8, 512, 512], device=DEVICE),
@@ -482,6 +483,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
     @patch("torch.version.hip", None)
     @patch("torch.version.xpu", None)
     @skipIfTileIR("tileir backend will ignore `warp specialization` hint")
+    @skipIfRocm("should skip on rocm")
     def test_config_warp_specialize_unroll(self):
         args = (
             torch.randn([8, 512, 512], device=DEVICE),

--- a/test/test_eviction_policy.py
+++ b/test/test_eviction_policy.py
@@ -16,6 +16,7 @@ from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import skipIfRefEager
+from helion._testing import skipIfRocm
 from helion._testing import skipIfTileIR
 import helion.language as hl
 
@@ -72,6 +73,7 @@ class TestEvictionPolicy(RefEagerTestBase, TestCase):
 
     @skipIfRefEager("Config spec inspection not applicable in ref eager mode")
     @skipIfTileIR("tileir backend will ignore `eviction_policy` hint")
+    @skipIfRocm("ROCm does not support eviction policy")
     def test_autotune_eviction_policy_registered(self):
         """Test that eviction policy tunable is automatically registered for loads in device loops."""
 


### PR DESCRIPTION
Summary:
The Helion autotuner incorrectly includes tensor_descriptor as a valid indexing strategy for AMD GPUs, thus it can generate incompatible configs for MI350X.

full error log: P2142502073

Differential Revision: D91366006


