### PR TITLE
[Benchmark CI] Set log level to INFO to reduce log volume

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,7 +38,7 @@ jobs:
     name: benchmark-${{ inputs.runtime-version }}-${{ inputs.kernels }}-py${{ inputs.python-version }}-${{ inputs.alias }}
 
     env:
-      HELION_AUTOTUNE_LOG_LEVEL: DEBUG
+      HELION_AUTOTUNE_LOG_LEVEL: INFO
 
     container:
       image: ${{ inputs.image }}


### PR DESCRIPTION
Logs for some kernels are so long that the Github Actions raw log file fails to generate (e.g. https://github.com/pytorch/helion/actions/runs/21451888026/job/61782518137). This PR will reduce the log volume.