### PR TITLE
Enable User-Driven Early Termination and Caching in Autotuning

### DIFF
--- a/helion/autotuner/base_cache.py
+++ b/helion/autotuner/base_cache.py
@@ -18,7 +18,8 @@ from torch._inductor.codecache import torch_key
 
 from .. import exc
 from .._utils import counters
-from .base_search import BaseAutotuner, performance
+from .base_search import BaseAutotuner
+from .base_search import performance
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -173,7 +174,7 @@ class AutotuneCacheBase(BaseAutotuner, abc.ABC, metaclass=AutotuneCacheMeta):
 
     def _handle_early_termination(self) -> Config:
         try:
-            if not hasattr(self.autotuner, 'population'):
+            if not hasattr(self.autotuner, "population"):
                 raise AttributeError("No population available")
 
             # Only consider members that have been benchmarked (have perfs data)


### PR DESCRIPTION
Implements #1331

  ### Summary
  Adds support for gracefully terminating autotuning early (via `CTRL+C`) while saving the best configuration found so far. This allows users to stop autotuning when they see diminishing returns without losing progress.

  ### Implementation
  - Added `_handle_early_termination()` method to `AutotuneCacheBase` that extracts the best benchmarked config
  - Wrapped `autotuner.autotune()` calls in both code paths (skip_cache and normal) with `try/except KeyboardInterrupt`
  - Config is automatically saved to cache before exiting
  - Future runs will use the cached config, skipping autotuning entirely

  Users who want immediate termination can press `CTRL+C` twice or use `kill -9`.

  ### Discussion

Using `try` like this never feels elegant enough to me. I did consider making this cleaner with a decorator, but I'd rather keep things simple for now and get some feedback before overcomplicating this.

Are we good on `CTRL+C` invoking this or do we want to consider something else? I am also not sure if we should prompt the user for this or guard this behind a flag.
