### PR TITLE
Improve autotuning log readability

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -1013,7 +1013,7 @@ def population_statistics(population: list[PopulationMember]) -> str:
             f"min={working[0].perf:.4f}",
             f"mid={working[len(working) // 2].perf:.4f}",
             f"max={working[-1].perf:.4f}",
-            f"best={pprint.pformat(dict(population[0].config), width=100, compact=True)}"
+            f"best={pprint.pformat(dict(population[0].config), width=100, compact=True)}",
         )
     )
     return "\n" + "\n".join(parts)


### PR DESCRIPTION
Small suggested change to make logs more human friendly

### Before
```
[43s] Generation 1 complete: error=25 ok=79 min=0.1161 mid=0.3548 max=3.5272 best=Config(block_sizes=[512, 32, 16], indexing=['tensor_descriptor', 'tensor_descriptor', 'pointer'], l2_groupings=[16], load_eviction_policies=['last', 'first'], loop_orders=[[1, 0]], num_stages=3, num_warps=4, pid_type='flat', range_flattens=[None, False], range_multi_buffers=[None, None], range_num_stages=[0, 0], range_unroll_factors=[0, 0], range_warp_specializes=[])
```
  ### After
```
[43s] Generation 1 complete:
error=25
ok=79
min=0.1161
mid=0.3548
max=3.5272
best={'block_sizes': [512, 32, 16],
   'indexing': ['tensor_descriptor', 'tensor_descriptor', 'pointer'],
   'l2_groupings': [16],
   'load_eviction_policies': ['last', 'first'],
   'loop_orders': [[1, 0]],
   'num_stages': 3,
   'num_warps': 4,
   'pid_type': 'flat',
   'range_flattens': [None, False],
   'range_multi_buffers': [None, None],
   'range_num_stages': [0, 0],
   'range_unroll_factors': [0, 0],
   'range_warp_specializes': []}
```
