### PR TITLE
Update num_warps and num_stages range for AMD

### DIFF
--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -431,8 +431,12 @@ class ConfigSpec:
             "range_multi_buffers": self.range_multi_buffers._flat_config(self, fn),
             "range_flattens": self.range_flattens._flat_config(self, fn),
             "static_ranges": self.static_ranges._flat_config(self, fn),
-            "num_warps": fn(NumWarpsFragment(1, 32, DEFAULT_NUM_WARPS)),
-            "num_stages": fn(IntegerFragment(1, 8, DEFAULT_NUM_STAGES)),
+            "num_warps": fn(NumWarpsFragment(1, 32, DEFAULT_NUM_WARPS))
+            if not supports_amd_cdna_tunables()
+            else fn(NumWarpsFragment(1, 16, DEFAULT_NUM_WARPS)),
+            "num_stages": fn(IntegerFragment(1, 8, DEFAULT_NUM_STAGES))
+            if not supports_amd_cdna_tunables()
+            else fn(IntegerFragment(1, 4, DEFAULT_NUM_STAGES)),
             "indexing": fn(self.indexing),
             "pid_type": fn(EnumFragment(self.allowed_pid_types)),
             "num_sm_multiplier": fn(


### PR DESCRIPTION
Summary:
- **num_warps**: AMD has 1024 threads and 64-thread wavefronts (i.e. warps), hence the max num_warps should be 16 instead of 32 for NVIDIA.

- **num_stages**: In practice, num_stages is up to 4 otherwise hip will OOM.

So, update these numbers to reduce OutOfResources errors when doing autotune search and reduce compile time.

Differential Revision: D91915719


