### PR TITLE
[Docs] Put API Reference on the docs earlier

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,10 +7,10 @@
 
 installation
 Examples <./examples/index>
+api/index
 Puzzles <helion_puzzles>
 Deployment <deployment_autotuning>
 TileIR Backend <tileir_backend>
-api/index
 events
 
 ```


### PR DESCRIPTION
On a 16 inch laptop, API reference no longer fits the main page. This seems important to display.

Before:
<img width="1507" height="189" alt="image" src="https://github.com/user-attachments/assets/30f3b5b8-ab54-4029-b23c-a33304ce0e55" />
