### PR TITLE
Add generic kernel config adapter

### DIFF
--- a/helion/autotuner/__init__.py
+++ b/helion/autotuner/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from .aot_cache import AOTAutotuneCache as AOTAutotuneCache
 from .config_fragment import BooleanFragment as BooleanFragment
 from .config_fragment import EnumFragment as EnumFragment
@@ -15,6 +17,8 @@ from .effort_profile import AutotuneEffortProfile as AutotuneEffortProfile
 from .effort_profile import DifferentialEvolutionConfig as DifferentialEvolutionConfig
 from .effort_profile import PatternSearchConfig as PatternSearchConfig
 from .effort_profile import RandomSearchConfig as RandomSearchConfig
+from .external import UserConfigSpec as UserConfigSpec
+from .external import autotune as autotune
 from .finite_search import FiniteSearch as FiniteSearch
 from .local_cache import LocalAutotuneCache as LocalAutotuneCache
 from .local_cache import StrictLocalAutotuneCache as StrictLocalAutotuneCache
@@ -23,7 +27,10 @@ from .pattern_search import PatternSearch as PatternSearch
 from .random_search import RandomSearch as RandomSearch
 from .surrogate_pattern_search import LFBOPatternSearch
 
-search_algorithms = {
+if TYPE_CHECKING:
+    from .base_search import BaseSearch
+
+search_algorithms: dict[str, type[BaseSearch]] = {
     "DESurrogateHybrid": DESurrogateHybrid,
     "LFBOPatternSearch": LFBOPatternSearch,
     "DifferentialEvolutionSearch": DifferentialEvolutionSearch,

--- a/helion/autotuner/aot_cache.py
+++ b/helion/autotuner/aot_cache.py
@@ -914,7 +914,7 @@ class AOTAutotuneCache(AutotuneCacheBase):
 
     def _get_cache_key(self) -> BoundKernelInMemoryCacheKey:
         """Return a cache key for compatibility."""
-        return self.autotuner.kernel.kernel._create_bound_kernel_cache_key(
+        return self.kernel.kernel._create_bound_kernel_cache_key(
             self.kernel,
             tuple(self.args),
             self.kernel.kernel.specialization_key(self.args),

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -31,7 +31,7 @@ from typing import Iterable
 from typing import Literal
 from typing import NamedTuple
 from typing import NoReturn
-from typing import Sequence
+from typing import Protocol
 from typing import cast
 from unittest.mock import patch
 import uuid
@@ -44,12 +44,9 @@ from torch.utils._pytree import tree_unflatten
 from triton.testing import do_bench
 
 from .. import exc
-from ..runtime.kernel import BoundKernel
 from ..runtime.precompile_shim import already_compiled
 from ..runtime.precompile_shim import make_precompiler
 from .benchmarking import interleaved_bench
-from .config_generation import ConfigGeneration
-from .config_generation import FlatConfig
 from .logger import SUPPRESSED_TRITON_CODE_MSG
 from .logger import AutotuneLogEntry
 from .logger import AutotuningLogger
@@ -59,6 +56,51 @@ from .logger import log_generated_triton_code_debug
 from .logger import match_unrecoverable_runtime_error
 from .progress_bar import iter_with_progress
 
+
+class _HasDevice(Protocol):
+    device: torch.device
+
+
+class _AutotunableKernel(Protocol):
+    @property
+    def config_spec(self) -> ConfigSpec: ...
+
+    @property
+    def settings(self) -> Settings: ...
+
+    @property  # pyrefly: ignore[bad-return]
+    def env(self) -> _HasDevice: ...
+
+    @property
+    def configs(self) -> Sequence[Config]: ...
+
+    def compile_config(
+        self,
+        config: Config | dict[str, object] | None = None,
+        *,
+        allow_print: bool = True,
+    ) -> Callable[..., object]: ...
+
+    def format_kernel_decorator(self, config: Config, settings: Settings) -> str: ...
+
+    def get_cached_path(self, config: Config | None = None) -> str | None: ...
+
+    def to_triton_code(
+        self,
+        config: Config | dict[str, object] | None = None,
+        *,
+        emit_repro_caller: bool = False,
+        output_origin_lines: bool | None = None,
+    ) -> str | None: ...
+
+    def maybe_log_repro(
+        self,
+        log_func: Callable[[str], None],
+        args: Sequence[object],
+        config: Config | None = None,
+    ) -> None: ...
+
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -67,6 +109,8 @@ if TYPE_CHECKING:
     from ..runtime.kernel import CompiledConfig
     from ..runtime.settings import Settings
     from . import ConfigSpec
+    from .config_generation import ConfigGeneration
+    from .config_generation import FlatConfig
 
 
 class BaseAutotuner(abc.ABC):
@@ -118,11 +162,11 @@ class BaseSearch(BaseAutotuner):
     search algorithms.
 
     Attributes:
-        kernel (BoundKernel): The kernel to be tuned.
-        settings (Settings): The settings associated with the kernel.
-        config_spec (ConfigSpec): The configuration specification for the kernel.
-        args (Sequence[object]): The arguments to be passed to the kernel.
-        counters (collections.Counter): A counter to track various metrics during the search.
+        kernel: The kernel to be tuned (any ``_AutotunableKernel``).
+        settings: The settings associated with the kernel.
+        config_spec: The configuration specification for the kernel.
+        args: The arguments to be passed to the kernel.
+        counters: A counter to track various metrics during the search.
     """
 
     _baseline_output: object
@@ -133,7 +177,7 @@ class BaseSearch(BaseAutotuner):
     _effective_atol: float
     _effective_rtol: float
 
-    def __init__(self, kernel: BoundKernel, args: Sequence[object]) -> None:
+    def __init__(self, kernel: _AutotunableKernel, args: Sequence[object]) -> None:
         """
         Initialize the BaseSearch object.
 
@@ -291,8 +335,7 @@ class BaseSearch(BaseAutotuner):
         if all_dtypes_are_fp8:
             # All dtypes are fp8 - use bitwise comparison
             # unless the user explicitly set either tolerance value (i.e., not None)
-            user_set_either = atol is not None or rtol is not None
-            if not user_set_either:
+            if atol is None and rtol is None:
                 self.log(
                     f"Detected fp8 dtype(s) in output: {dtypes}. "
                     "Using bitwise comparison (atol=0.0, rtol=0.0) for autotuning accuracy check."
@@ -770,11 +813,14 @@ class BaseSearch(BaseAutotuner):
             f"    {kernel_decorator}\n",
             level=logging.INFO + 5,
         )
-        self.log(f"Code of selected kernel: {self.kernel.get_cached_path(best)}")
+        cached_path = self.kernel.get_cached_path(best)
+        if cached_path is not None:
+            self.log(f"Code of selected kernel: {cached_path}")
         self.kernel.maybe_log_repro(self.log.warning, self.args, best)
         if self.settings.print_output_code:
             triton_code = self.kernel.to_triton_code(best)
-            print(triton_code, file=sys.stderr)
+            if triton_code is not None:
+                print(triton_code, file=sys.stderr)
         return best
 
     def _autotune(self) -> Config:
@@ -862,7 +908,7 @@ class PopulationBasedSearch(BaseSearch):
 
     def __init__(
         self,
-        kernel: BoundKernel,
+        kernel: _AutotunableKernel,
         args: Sequence[object],
     ) -> None:
         """
@@ -875,10 +921,8 @@ class PopulationBasedSearch(BaseSearch):
         super().__init__(kernel, args)
         self.population: list[PopulationMember] = []
         self._current_generation: int = 0
-        overrides = self.settings.autotune_config_overrides or None
-        self.config_gen: ConfigGeneration = ConfigGeneration(
-            self.config_spec,
-            overrides=overrides,
+        self.config_gen: ConfigGeneration = self.config_spec.create_config_generation(
+            overrides=self.settings.autotune_config_overrides or None,
         )
 
     @property
@@ -1008,12 +1052,12 @@ class PopulationBasedSearch(BaseSearch):
         )
         repeat = min(1000, max(3, base_repeat))
         iterator = [functools.partial(m.fn, *self.args) for m in members]
-        bench_fn = self.settings.autotune_benchmark_fn or interleaved_bench
+        bench_fn: Callable[..., list[float]] = (
+            self.settings.autotune_benchmark_fn or interleaved_bench
+        )
         if self.settings.autotune_progress_bar:
-            # pyrefly: ignore [bad-argument-type]
             new_timings = bench_fn(iterator, repeat=repeat, desc=desc)
         else:
-            # pyrefly: ignore [bad-argument-type]
             new_timings = bench_fn(iterator, repeat=repeat)
         for m, t in zip(members, new_timings, strict=True):
             m.perfs.append(t)
@@ -1253,8 +1297,7 @@ class PrecompileFuture:
 
         # Wait for at least one to finish or time out
         timeout = min([f.seconds_left() for f in running], default=0.0)
-        # pyrefly: ignore [missing-attribute]
-        handles = [f.process.sentinel for f in running]
+        handles = [f.process.sentinel for f in running if f.process is not None]
         if handles and timeout > 0:
             connection.wait(handles, timeout)
         remaining: list[PrecompileFuture] = []
@@ -1405,7 +1448,8 @@ class PrecompileFuture:
             return
         exc_obj = error.to_exception()
         classification = error.classification or classify_triton_exception(exc_obj)
-        if ignore_errors := self.search.settings.autotune_ignore_errors:
+        ignore_errors = self.search.settings.autotune_ignore_errors
+        if ignore_errors:
             classification = "debug"
         if classification == "raise":
             if raise_on_raise:
@@ -1450,7 +1494,6 @@ class PrecompileFuture:
             self.search.kernel.maybe_log_repro(
                 self.search.log.warning, self.search.args, self.config
             )
-        # pyrefly: ignore [unbound-name]
         elif not ignore_errors:
             self.search.log.debug(formatted)
             self.search.kernel.maybe_log_repro(
@@ -1538,7 +1581,7 @@ def _prepare_precompiler_for_fork(
     fn: CompiledConfig,
     args: Sequence[object],
     config: Config,
-    kernel: BoundKernel,
+    kernel: _AutotunableKernel,
     decorator: str,
     logger: AutotuningLogger,
 ) -> Callable[[], None] | None:
@@ -1551,15 +1594,14 @@ def _prepare_precompiler_for_fork(
         raise _ExtractedLaunchArgs(triton_kernel, grid, launch_args, launch_kwargs)
 
     try:
-        fn(*tuple(args), _launcher=extract_launcher)
+        fn(*args, _launcher=extract_launcher)
         raise RuntimeError("Expected _ExtractedLaunchArgs to be raised")
     except _ExtractedLaunchArgs as extracted:
-        precompiler_factory = make_precompiler(
+        precompiler = make_precompiler(
             cast("Any", extracted.kernel),
             config,
-            kernel,
-        )
-        precompiler = precompiler_factory(*extracted.args, **extracted.kwargs)
+            cast("BoundKernel", kernel),
+        )(*extracted.args, **extracted.kwargs)
         if precompiler is already_compiled:
             return None
         return precompiler
@@ -1582,7 +1624,7 @@ def _prepare_precompiler_for_fork(
 def _run_kernel_in_subprocess_fork(
     precompiler: Callable[[], None],
     config: Config,
-    kernel: BoundKernel,
+    kernel: _AutotunableKernel,
     result_path: str,
     decorator: str,
 ) -> None:

--- a/helion/autotuner/config_generation.py
+++ b/helion/autotuner/config_generation.py
@@ -57,9 +57,12 @@ class ConfigGeneration:
             if spec.category() == Category.BLOCK_SIZE
         ]
         self.num_warps_index: int = next(
-            i
-            for i, spec in enumerate(self.flat_spec)
-            if spec.category() == Category.NUM_WARPS
+            (
+                i
+                for i, spec in enumerate(self.flat_spec)
+                if spec.category() == Category.NUM_WARPS
+            ),
+            -1,
         )
         self.min_block_size: int = (
             max([spec.min_size for spec in config_spec.block_sizes])
@@ -115,6 +118,8 @@ class ConfigGeneration:
             flat_config: config to mutate in place
             max_elements_per_thread: maximum number of elements per thread
         """
+        if self.num_warps_index < 0 or not self.block_size_indices:
+            return
         num_threads = warps_to_threads(cast("int", flat_config[self.num_warps_index]))
         # Respect Triton's maximum tensor element limit
         triton_limit = TRITON_MAX_TENSOR_NUMEL

--- a/helion/autotuner/de_surrogate_hybrid.py
+++ b/helion/autotuner/de_surrogate_hybrid.py
@@ -36,7 +36,7 @@ from .effort_profile import DIFFERENTIAL_EVOLUTION_DEFAULTS
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from ..runtime.kernel import BoundKernel
+    from .base_search import _AutotunableKernel
     from .config_generation import Config
     from .config_generation import FlatConfig
     from .pattern_search import InitialPopulationStrategy
@@ -83,7 +83,7 @@ class DESurrogateHybrid(DifferentialEvolutionSearch):
 
     def __init__(
         self,
-        kernel: BoundKernel,
+        kernel: _AutotunableKernel,
         args: Sequence[object],
         population_size: int = 40,
         max_generations: int = 40,

--- a/helion/autotuner/differential_evolution.py
+++ b/helion/autotuner/differential_evolution.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import random
 from typing import TYPE_CHECKING
 
-from .base_search import FlatConfig
 from .base_search import PopulationBasedSearch
 from .base_search import PopulationMember
 from .base_search import performance
@@ -16,7 +15,8 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from ..runtime.config import Config
-    from ..runtime.kernel import BoundKernel
+    from .base_search import _AutotunableKernel
+    from .config_generation import FlatConfig
 
 
 class DifferentialEvolutionSearch(PopulationBasedSearch):
@@ -26,7 +26,7 @@ class DifferentialEvolutionSearch(PopulationBasedSearch):
 
     def __init__(
         self,
-        kernel: BoundKernel,
+        kernel: _AutotunableKernel,
         args: Sequence[object],
         population_size: int = DIFFERENTIAL_EVOLUTION_DEFAULTS.population_size,
         max_generations: int = DIFFERENTIAL_EVOLUTION_DEFAULTS.max_generations,

--- a/helion/autotuner/external.py
+++ b/helion/autotuner/external.py
@@ -1,0 +1,271 @@
+"""External autotuner API for non-Helion kernels."""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+from typing import TYPE_CHECKING
+from typing import Any
+
+import torch
+
+from helion.autotuner.base_search import _AutotunableKernel
+from helion.autotuner.config_spec import ConfigSpec
+from helion.runtime.config import Config
+from helion.runtime.settings import Settings
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Sequence
+
+    import helion
+    from helion.autotuner.config_fragment import ConfigSpecFragment
+
+
+class UserConfigSpec(ConfigSpec):
+    """A ConfigSpec that only includes user-defined tunables.
+
+    The base ConfigSpec.flat_config() always injects Triton/Helion-specific
+    tunables (num_warps, num_stages, pid_type, etc.) into the search space.
+    This subclass overrides flat_config to only emit the tunables the caller
+    defined, keeping the search space minimal and DSL-agnostic.
+    """
+
+    def flat_config(self, fn: Callable[[ConfigSpecFragment], object]) -> helion.Config:
+        return Config.from_dict(
+            {key: fn(fragment) for key, fragment in self.user_defined_tunables.items()}
+        )
+
+    def normalize(
+        self,
+        config: helion.Config | dict[str, object],
+        *,
+        _fix_invalid: bool = False,
+    ) -> None:
+        pass
+
+
+def create_user_config_spec(
+    tunables: dict[str, ConfigSpecFragment],
+) -> UserConfigSpec:
+    return UserConfigSpec(user_defined_tunables=dict(tunables))
+
+
+@dataclasses.dataclass
+class _FakeEnv:
+    device: torch.device
+
+
+class _ExternalKernelAdapter(_AutotunableKernel):
+    """Adapter making user-provided callables satisfy the ``_AutotunableKernel`` protocol.
+
+    Private for now; could be made public/subclassable once the interface
+    stabilises.  Subclassing would let DSL authors override the diagnostic
+    hooks: ``get_cached_path``, ``to_triton_code``, ``format_kernel_decorator``,
+    and ``maybe_log_repro``.
+    """
+
+    def __init__(
+        self,
+        config_spec: UserConfigSpec,
+        compile_fn: Callable[[Config], Callable[..., Any]],
+        args: Sequence[Any],
+        baseline_fn: Callable[..., Any] | None = None,
+        device: torch.device | None = None,
+        **settings_kwargs: object,
+    ) -> None:
+        self._config_spec = config_spec
+        self._configs: list[Config] = []
+        self._compile_fn = compile_fn
+        self._compile_cache: dict[Config, Callable[..., Any]] = {}
+
+        self._env = _FakeEnv(
+            device
+            or next(
+                (
+                    arg.device
+                    for arg in args
+                    if isinstance(arg, torch.Tensor) and arg.is_cuda
+                ),
+                torch.device("cuda"),
+            )
+        )
+        self._settings = Settings(**settings_kwargs)
+        if baseline_fn is not None:
+            self._settings.autotune_baseline_fn = baseline_fn
+        self._settings.autotune_precompile = None
+
+    @property
+    def config_spec(self) -> UserConfigSpec:
+        return self._config_spec
+
+    @property
+    def env(self) -> _FakeEnv:
+        return self._env
+
+    @property
+    def settings(self) -> Settings:
+        return self._settings
+
+    @property
+    def configs(self) -> list[Config]:
+        return self._configs
+
+    def compile_config(
+        self,
+        config: Config | dict[str, object] | None = None,
+        *,
+        allow_print: bool = True,
+    ) -> Callable[..., Any]:
+        if config is None:
+            config = self.config_spec.default_config()
+        if not isinstance(config, Config):
+            config = Config.from_dict(config)
+
+        if config not in self._compile_cache:
+            self._compile_cache[config] = self._compile_fn(config)
+        return self._compile_cache[config]
+
+    def format_kernel_decorator(self, config: Config, settings: Settings) -> str:
+        return f"config={config!r}"
+
+    def get_cached_path(self, config: Config | None = None) -> str | None:
+        return None
+
+    def to_triton_code(
+        self,
+        config: Config | dict[str, object] | None = None,
+        *,
+        emit_repro_caller: bool = False,
+        output_origin_lines: bool | None = None,
+    ) -> str | None:
+        return None
+
+    def maybe_log_repro(
+        self,
+        log_func: Callable[[str], None],
+        args: Sequence[object],
+        config: Config | None = None,
+    ) -> None:
+        pass
+
+
+SETTINGS_KWARGS = {
+    f.name for f in dataclasses.fields(Settings) if f.name.startswith("autotune_")
+}
+
+
+def _split_and_validate_kwargs(
+    search_cls: type[object],
+    kwargs: dict[str, object],
+) -> tuple[dict[str, object], dict[str, object]]:
+    """Split kwargs into Settings and search kwargs, then validate search keys.
+
+    Keys listed in ``SETTINGS_KWARGS`` are routed to ``Settings``. Remaining
+    keys are treated as algorithm kwargs and are validated against the selected
+    search class constructor.
+    """
+    settings_kw = {k: v for k, v in kwargs.items() if k in SETTINGS_KWARGS}
+    search_kw = {k: v for k, v in kwargs.items() if k not in SETTINGS_KWARGS}
+
+    signature = inspect.signature(search_cls.__init__)
+    search_params = {
+        name
+        for name, param in signature.parameters.items()
+        if name not in {"self", "kernel", "args"}
+        and param.kind
+        in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+    }
+    if not any(
+        param.kind == inspect.Parameter.VAR_KEYWORD
+        for param in signature.parameters.values()
+    ):
+        if unknown_search_keys := sorted(set(search_kw) - search_params):
+            raise ValueError(
+                f"Unknown search kwargs for algorithm {search_cls.__name__}: "
+                f"{unknown_search_keys}. Allowed search kwargs: "
+                f"{sorted(search_params)}. Allowed settings kwargs: "
+                f"{sorted(SETTINGS_KWARGS)}."
+            )
+
+    return settings_kw, search_kw
+
+
+def autotune(
+    tunables: dict[str, ConfigSpecFragment],
+    compile_fn: Callable[[Config], Callable[..., Any]],
+    args: Sequence[Any],
+    *,
+    baseline_fn: Callable[..., Any] | None = None,
+    algorithm: str = "PatternSearch",
+    device: torch.device | None = None,
+    **kwargs: object,
+) -> Config:
+    """Autotune a kernel using Helion's search algorithms.
+
+    Args:
+        tunables: Dict mapping parameter names to ConfigSpecFragment instances
+            that define the search space.
+        compile_fn: ``Config -> Callable``.  Given a config, return a callable
+            that runs the kernel.  The callable must accept ``*args``.
+        args: The arguments that will be passed to ``compile_fn(config)()``.
+        baseline_fn: Optional ``*args -> output``.  Reference implementation
+            for accuracy validation.  If not provided, the default config is
+            compiled and used as the baseline (same behavior as
+            ``@helion.kernel``).
+        algorithm: Name of the search algorithm.  One of ``"PatternSearch"``,
+            ``"LFBOPatternSearch"``, ``"DifferentialEvolutionSearch"``,
+            ``"DESurrogateHybrid"``, ``"RandomSearch"``, ``"FiniteSearch"``.
+        device: CUDA device.  Auto-detected from *args* if not given.
+        **kwargs: Split automatically -- keys in ``SETTINGS_KWARGS`` go to
+            ``Settings`` (e.g. ``autotune_accuracy_check``), everything else
+            goes to the search algorithm constructor (e.g.
+            ``max_generations``, ``initial_population``). Unknown search kwargs
+            raise ``ValueError`` with the allowed keys for the selected
+            algorithm.
+
+    Note:
+        External kernels are not compatible with autotune cache wrappers.
+
+    Returns:
+        The best ``Config`` found.
+
+    Example::
+
+        from helion.autotuner import PowerOfTwoFragment
+        from helion.autotuner import autotune
+
+        best = autotune(
+            tunables={"block": PowerOfTwoFragment(32, 512, 128)},
+            compile_fn=my_compile,
+            args=(input_tensor,),
+            algorithm="PatternSearch",
+            max_generations=5,
+        )
+    """
+    from helion.autotuner import search_algorithms
+
+    search_cls = search_algorithms.get(algorithm)
+    if search_cls is None:
+        raise ValueError(
+            f"Unknown algorithm {algorithm!r}."
+            f" Available: {list(search_algorithms.keys())}"
+        )
+
+    settings_kw, search_kw = _split_and_validate_kwargs(search_cls, kwargs)
+
+    return search_cls(
+        _ExternalKernelAdapter(
+            create_user_config_spec(tunables),
+            compile_fn,
+            args,
+            baseline_fn=baseline_fn,
+            device=device,
+            **settings_kw,
+        ),
+        args,
+        **search_kw,
+    ).autotune()

--- a/helion/autotuner/finite_search.py
+++ b/helion/autotuner/finite_search.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from ..runtime.config import Config
-    from ..runtime.kernel import BoundKernel
+    from .base_search import _AutotunableKernel
 
 
 class FiniteSearch(BaseSearch):
@@ -21,7 +21,7 @@ class FiniteSearch(BaseSearch):
 
     def __init__(
         self,
-        kernel: BoundKernel,
+        kernel: _AutotunableKernel,
         args: Sequence[object],
         configs: list[Config] | None = None,
     ) -> None:

--- a/helion/autotuner/logger.py
+++ b/helion/autotuner/logger.py
@@ -28,8 +28,8 @@ if TYPE_CHECKING:
     import io
 
     from ..runtime.config import Config
-    from ..runtime.kernel import BoundKernel
     from ..runtime.settings import Settings
+    from .base_search import _AutotunableKernel
 
 else:
     CsvWriter = Any  # type: ignore[assignment]
@@ -364,7 +364,7 @@ SUPPRESSED_TRITON_CODE_MSG = (
 
 def log_generated_triton_code_debug(
     logger: AutotuningLogger,
-    bound_kernel: BoundKernel,
+    kernel: _AutotunableKernel,
     config: Config,
     *,
     prefix: str | None = None,
@@ -374,29 +374,29 @@ def log_generated_triton_code_debug(
 
     Args:
         logger: Logger that should receive the message.
-        bound_kernel: Kernel whose Triton code should be logged.
+        kernel: Kernel whose Triton code should be logged.
         config: Config used to generate the Triton code.
         prefix: Optional prefix for the log message.
     """
-    message_prefix = prefix or "Generated Triton code:"
-    logger.debug(lambda: _format_triton_code(bound_kernel, config, message_prefix))
+    logger.debug(
+        lambda: _format_triton_code(kernel, config, prefix or "Generated Triton code:")
+    )
 
 
-def _format_triton_code(bound_kernel: BoundKernel, config: Config, prefix: str) -> str:
-    code = bound_kernel.to_triton_code(config)
+def _format_triton_code(kernel: _AutotunableKernel, config: Config, prefix: str) -> str:
+    code = kernel.to_triton_code(config)
+    if code is None:
+        return f"{prefix}\n<no source code available>"
     return f"{prefix}\n{code}"
 
 
 def format_triton_compile_failure(
-    config: Config, err: BaseException, bound_kernel: BoundKernel
+    config: Config, err: BaseException, kernel: _AutotunableKernel
 ) -> str:
-    kernel_decorator = bound_kernel.format_kernel_decorator(
-        config, bound_kernel.settings
-    )
     return (
         "Triton compile failed. This likely indicates a bug in Triton. "
         "Skipping failing config.\n"
-        f"Config: {kernel_decorator}\n"
+        f"Config: {kernel.format_kernel_decorator(config, kernel.settings)}\n"
         f"Error: {type(err).__name__}: {err}\n"
         f"{SUPPRESSED_TRITON_CODE_MSG}"
     )

--- a/helion/autotuner/pattern_search.py
+++ b/helion/autotuner/pattern_search.py
@@ -5,7 +5,6 @@ import math
 from typing import TYPE_CHECKING
 
 from .. import exc
-from .base_search import FlatConfig
 from .base_search import PopulationBasedSearch
 from .base_search import PopulationMember
 from .base_search import performance
@@ -16,7 +15,8 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from ..runtime.config import Config
-    from ..runtime.kernel import BoundKernel
+    from .base_search import _AutotunableKernel
+    from .config_generation import FlatConfig
 
 
 class InitialPopulationStrategy(enum.Enum):
@@ -34,7 +34,7 @@ class PatternSearch(PopulationBasedSearch):
 
     def __init__(
         self,
-        kernel: BoundKernel,
+        kernel: _AutotunableKernel,
         args: Sequence[object],
         *,
         initial_population: int = PATTERN_SEARCH_DEFAULTS.initial_population,

--- a/helion/autotuner/random_search.py
+++ b/helion/autotuner/random_search.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .config_generation import ConfigGeneration
 from .effort_profile import RANDOM_SEARCH_DEFAULTS
 from .finite_search import FiniteSearch
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from ..runtime.kernel import BoundKernel
+    from .base_search import _AutotunableKernel
 
 
 class RandomSearch(FiniteSearch):
@@ -23,22 +22,21 @@ class RandomSearch(FiniteSearch):
         FiniteSearch: A base class for finite configuration searches.
 
     Attributes:
-        kernel (BoundKernel): The kernel to be tuned.
-        args (Sequence[object]): The arguments to be passed to the kernel.
-        count (int): The number of random configurations to generate.
+        kernel: The kernel to be tuned (any ``_AutotunableKernel``).
+        args: The arguments to be passed to the kernel.
+        count: The number of random configurations to generate.
     """
 
     def __init__(
         self,
-        kernel: BoundKernel,
+        kernel: _AutotunableKernel,
         args: Sequence[object],
         count: int = RANDOM_SEARCH_DEFAULTS.count,
     ) -> None:
         super().__init__(
             kernel,
             args,
-            configs=ConfigGeneration(
-                kernel.config_spec,
+            configs=kernel.config_spec.create_config_generation(
                 overrides=kernel.settings.autotune_config_overrides or None,
             ).random_population(count),
         )

--- a/helion/autotuner/surrogate_pattern_search.py
+++ b/helion/autotuner/surrogate_pattern_search.py
@@ -6,7 +6,6 @@ import random
 from typing import TYPE_CHECKING
 
 from .. import exc
-from .base_search import FlatConfig
 from .base_search import PopulationMember
 from .base_search import performance
 from .config_fragment import PowerOfTwoFragment
@@ -19,7 +18,8 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from ..runtime.config import Config
-    from ..runtime.kernel import BoundKernel
+    from .base_search import _AutotunableKernel
+    from .config_generation import FlatConfig
 
 try:
     import numpy as np
@@ -98,7 +98,7 @@ class LFBOPatternSearch(PatternSearch):
 
     def __init__(
         self,
-        kernel: BoundKernel,
+        kernel: _AutotunableKernel,
         args: Sequence[object],
         *,
         initial_population: int = PATTERN_SEARCH_DEFAULTS.initial_population,
@@ -473,7 +473,7 @@ class LFBOPatternSearch(PatternSearch):
                     raise ValueError("BlockSize should be PowerOfTwoFragment")
 
             # 2. Sample the num_warps index and change it by at most radius
-            if self.config_gen.num_warps_index:
+            if self.config_gen.num_warps_index >= 0:
                 warp_idx = self.config_gen.num_warps_index
                 modified_indices.add(warp_idx)
 

--- a/helion/runtime/config.py
+++ b/helion/runtime/config.py
@@ -137,6 +137,13 @@ class Config(Mapping[str, object]):
         return json.dumps(self.config, indent=2)
 
     @classmethod
+    def from_dict(cls, config_dict: Mapping[str, object]) -> Config:
+        """Create a Config from a plain dictionary."""
+        obj = Config()
+        obj.config = dict(config_dict)
+        return obj
+
+    @classmethod
     def from_json(cls, json_str: str) -> Config:
         """Create a Config object from a JSON string."""
         config_dict = json.loads(json_str)

--- a/test/test_external_autotune.py
+++ b/test/test_external_autotune.py
@@ -1,0 +1,138 @@
+"""Tests for the external autotuner API (helion.autotuner.external.autotune).
+
+These tests use pure PyTorch -- no Helion DSL, no Triton, no CuTeDSL.
+They verify that the search algorithms work correctly with user-defined
+tunables and plain Python compile/baseline functions.
+"""
+
+from __future__ import annotations
+
+import operator
+from typing import TYPE_CHECKING
+
+import torch
+
+from helion._testing import DEVICE
+from helion._testing import TestCase
+from helion._testing import skipIfCpu
+from helion.autotuner import IntegerFragment
+from helion.autotuner import PowerOfTwoFragment
+from helion.autotuner.external import autotune
+
+if TYPE_CHECKING:
+    from helion.runtime.config import Config
+
+
+def _scaled_add_compile(config: Config):
+    scale = config["scale"]
+    return lambda a, b: a * scale + b
+
+
+@skipIfCpu("external autotuner requires GPU for benchmarking")
+class TestExternalAutotune(TestCase):
+    def test_basic_autotune(self):
+        a = torch.randn(1024, device=DEVICE)
+        b = torch.randn(1024, device=DEVICE)
+
+        best = autotune(
+            tunables={
+                "scale": IntegerFragment(1, 4, 2),
+                "tile": PowerOfTwoFragment(32, 256, 64),
+            },
+            compile_fn=_scaled_add_compile,
+            baseline_fn=lambda a, b: a * 2 + b,
+            args=(a, b),
+            algorithm="RandomSearch",
+            count=5,
+        )
+
+        assert "scale" in best
+        assert "tile" in best
+        assert isinstance(best["scale"], int)
+        assert isinstance(best["tile"], int)
+
+    def test_config_only_has_user_keys(self):
+        a = torch.randn(256, device=DEVICE)
+        b = torch.randn(256, device=DEVICE)
+
+        best = autotune(
+            tunables={
+                "tile": PowerOfTwoFragment(32, 256, 64),
+                "unroll": IntegerFragment(1, 4, 2),
+            },
+            compile_fn=lambda config: operator.add,
+            baseline_fn=operator.add,
+            args=(a, b),
+            algorithm="RandomSearch",
+            count=3,
+        )
+
+        config_keys = set(best.config.keys())
+        assert config_keys == {"tile", "unroll"}, (
+            f"Config should only have user keys, got {config_keys}"
+        )
+
+    def test_pattern_search(self):
+        a = torch.randn(512, device=DEVICE)
+        b = torch.randn(512, device=DEVICE)
+
+        best = autotune(
+            tunables={
+                "block": PowerOfTwoFragment(32, 256, 64),
+                "unroll": IntegerFragment(1, 4, 1),
+            },
+            compile_fn=lambda config: operator.add,
+            baseline_fn=operator.add,
+            args=(a, b),
+            algorithm="PatternSearch",
+            max_generations=2,
+            initial_population=5,
+        )
+
+        assert "block" in best
+        assert "unroll" in best
+
+    def test_invalid_algorithm_raises(self):
+        a = torch.randn(64, device=DEVICE)
+
+        with self.assertRaisesRegex(ValueError, "Unknown algorithm"):
+            autotune(
+                tunables={"x": IntegerFragment(1, 4, 2)},
+                compile_fn=lambda config: lambda a: a,
+                baseline_fn=lambda a: a,
+                args=(a,),
+                algorithm="DoesNotExist",
+            )
+
+    def test_unknown_search_kwarg_raises(self):
+        a = torch.randn(64, device=DEVICE)
+
+        with self.assertRaisesRegex(ValueError, "Unknown search kwargs"):
+            autotune(
+                tunables={"x": IntegerFragment(1, 4, 2)},
+                compile_fn=lambda config: lambda a: a,
+                baseline_fn=lambda a: a,
+                args=(a,),
+                algorithm="PatternSearch",
+                max_generation=2,
+            )
+
+    def test_no_baseline_fn(self):
+        a = torch.randn(256, device=DEVICE)
+        b = torch.randn(256, device=DEVICE)
+
+        best = autotune(
+            tunables={"scale": IntegerFragment(1, 4, 2)},
+            compile_fn=_scaled_add_compile,
+            args=(a, b),
+            algorithm="RandomSearch",
+            count=3,
+        )
+
+        assert "scale" in best
+
+
+if __name__ == "__main__":
+    from helion._testing import main
+
+    main()


### PR DESCRIPTION
Add generic kernel config adapter


## Summary

Right now there is a loose protocol for what Search methods interact with on `BoundKernel`, however this is pretty coupled to the existing Helion kernel.

This PR adds one new public interface in `helion/autotuner/generic.py`: a generic `autotune` function that closely mirrors the existing one. It allows autotuning generic "kernels" but really any GPU functions that accept a `ConfigFragment` search space to search over. The config space only contains user-defined tunables (no `num_warps`, `pid_type`, etc. injected), which is the role of `UserConfigSpec`. IMO I think this is super cool because it  opens up Helion's powerful autotuning infrastructure to other kernel DSLs.

I debated whether to change the `BaseSearch` interface to take a proper protocol rather than `BoundKernel`. However, `BoundKernel` is already very close to said protocol and the lightweight adapter approach doesn't lock in too hard just yet.


### Usage
```Py
"""CuTeDSL kernel autotuned with Helion's generic autotune API.

Compare with example_helion_autotune.py which uses the old adapter layer
(TunableKernel subclass, HelionAutotuner, KernelAdapter, etc.).

This version uses the upstream helion.autotuner.generic.autotune() function
directly -- just pass tunables, compile_fn, baseline_fn, and args.
"""

from operator import add

import torch

import cutlass
import cutlass.cute as cute
from cutlass.cute.runtime import from_dlpack

from helion.autotuner import PowerOfTwoFragment
from helion.autotuner.external import autotune
from helion.runtime.config import Config

from transformer_nuggets.cute.cache import compile_and_cache
from transformer_nuggets.cute.utils import (
    get_tensor_alignment,
)
from transformer_nuggets.cute.base import CuteOp
from transformer_nuggets.utils.benchmark import benchmark_cuda_function_in_microseconds


class ElementwiseAddOp(CuteOp[[torch.Tensor, torch.Tensor], torch.Tensor]):
    tunables = {
        "thr_m": PowerOfTwoFragment(4, 32, 8),
        "thr_n": PowerOfTwoFragment(8, 128, 32),
        "val_m": PowerOfTwoFragment(1, 16, 4),
        "val_n": PowerOfTwoFragment(1, 32, 8),
    }

    def __init__(self):
        super().__init__()
        self.op = add

    def compile(self, config: Config):
        thr_m, thr_n = config["thr_m"], config["thr_n"]
        val_m, val_n = config["val_m"], config["val_n"]

        def run(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
            M, N = a.shape
            tile_m = thr_m * val_m
            tile_n = thr_n * val_n
            if M % tile_m != 0 or N % tile_n != 0:
                raise ValueError(
                    f"Invalid tile for shape {M}x{N}: tile_m={tile_m}, tile_n={tile_n}"
                )
            if thr_m * thr_n > 1024:
                raise ValueError(f"Invalid thread block size: thr_m*thr_n={thr_m * thr_n}")
            c = torch.empty(M, N, device="cuda", dtype=a.dtype)
            mA = from_dlpack(a, assumed_align=get_tensor_alignment(a, dim=-1)).mark_layout_dynamic(
                leading_dim=1
            )
            mB = from_dlpack(b, assumed_align=get_tensor_alignment(b, dim=-1)).mark_layout_dynamic(
                leading_dim=1
            )
            mC = from_dlpack(c, assumed_align=get_tensor_alignment(c, dim=-1)).mark_layout_dynamic(
                leading_dim=1
            )

            dim_orders = tuple(reversed(a.dim_order()))
            cache_key = f"add_{thr_m}_{thr_n}_{val_m}_{val_n}_{dim_orders}"

            compile_and_cache(
                self,
                cache_key,
                self.op,
                mA,
                mB,
                mC,
                thr_m,
                thr_n,
                val_m,
                val_n,
                dim_orders,
            )(mA, mB, mC)
            return c

        return run

    def baseline(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
        return a + b

    def interface(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
        raise NotImplementedError

    @cute.kernel
    def kernel(
        self,
        op: cutlass.Constexpr,
        gA: cute.Tensor,
        gB: cute.Tensor,
        gC: cute.Tensor,
        tv_layout: cute.Layout,
    ):
        tidx, _, _ = cute.arch.thread_idx()
        bidx, _, _ = cute.arch.block_idx()

        blk_coord = ((None, None), bidx)
        blkA = gA[blk_coord]
        blkB = gB[blk_coord]
        blkC = gC[blk_coord]

        tidfrgA = cute.composition(blkA, tv_layout)
        tidfrgB = cute.composition(blkB, tv_layout)
        tidfrgC = cute.composition(blkC, tv_layout)

        thr_coord = (tidx, None)
        thrA = tidfrgA[thr_coord]
        thrB = tidfrgB[thr_coord]
        thrC = tidfrgC[thr_coord]

        thrC.store(op(thrA.load(), thrB.load()))

    @cute.jit
    def __call__(
        self,
        op: cutlass.Constexpr,
        mA: cute.Tensor,
        mB: cute.Tensor,
        mC: cute.Tensor,
        thr_m: cutlass.Constexpr,
        thr_n: cutlass.Constexpr,
        val_m: cutlass.Constexpr,
        val_n: cutlass.Constexpr,
        order: cutlass.Constexpr,
    ):
        thr_layout = cute.make_ordered_layout((thr_m, thr_n), order)
        val_layout = cute.make_ordered_layout((val_m, val_n), order)
        tiler_mn, tv_layout = cute.make_layout_tv(thr_layout, val_layout)

        gA = cute.zipped_divide(mA, tiler_mn)
        gB = cute.zipped_divide(mB, tiler_mn)
        gC = cute.zipped_divide(mC, tiler_mn)

        self.kernel(op, gA, gB, gC, tv_layout).launch(
            grid=[cute.size(gC, mode=[1]), 1, 1],
            block=[cute.size(tv_layout, mode=[0]), 1, 1],
        )


_op = ElementwiseAddOp()
_config_cache: dict[str, Config] = {}


def autotuned_add(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
    M, N = a.shape
    cache_key = f"add_{M}x{N}_{a.dtype}"

    if cache_key not in _config_cache:
        _config_cache[cache_key] = autotune(
            tunables=_op.tunables,
            compile_fn=_op.compile,
            baseline_fn=_op.baseline,
            args=(a, b),
            algorithm="LFBOPatternSearch",
            autotune_accuracy_check=True,
            autotune_ignore_errors=True,
        )
        print(f"Best config for {M}x{N}: {dict(_config_cache[cache_key])}")

    return _op.compile(_config_cache[cache_key])(a, b)


if __name__ == "__main__":
    from rich import print as rprint

    shapes = [(1024, 1024), (2048, 2048), (4096, 4096)]

    for M, N in shapes:
        print(f"\n--- {M} x {N} ---")
        a = torch.randn(M, N, device="cuda", dtype=torch.float16)
        b = torch.randn(M, N, device="cuda", dtype=torch.float16)

        out = autotuned_add(a, b)
        torch.testing.assert_close(out, a + b)

        time_torch = benchmark_cuda_function_in_microseconds(lambda: a + b)
        time_cute = benchmark_cuda_function_in_microseconds(lambda: autotuned_add(a, b))

        rprint(f"  PyTorch: {time_torch:.1f} us ({M * N * 3 * 2 / time_torch * 1e-3:.1f} GB/s)")
        rprint(f"  CuTeDSL: {time_cute:.1f} us ({M * N * 3 * 2 / time_cute * 1e-3:.1f} GB/s)")


```