### PR TITLE
[CI] Fix NCCL error in distributed CI

### DIFF
--- a/test/test_examples_dist.py
+++ b/test/test_examples_dist.py
@@ -30,6 +30,8 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
         "NVSHMEM_SYMMETRIC_SIZE": "4G",
         # Disable NVLink Switch features (not available on AWS H100 instances)
         "NVSHMEM_DISABLE_NVLS": "1",
+        # Disable NCCL's NVLS (NVLink SHARP) multicast which requires NVSwitch/Fabric Manager
+        "NCCL_NVLS_ENABLE": "0",
     }
 
     @classmethod


### PR DESCRIPTION
Example error:
https://github.com/pytorch/helion/actions/runs/21776627150/job/62834170258?pr=1395
```
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939] Caught exception: 
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939] Traceback (most recent call last):
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939]   File "/__w/helion/helion/.venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py", line 929, in run_test
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939]     getattr(self, test_name)()
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939]   File "/__w/helion/helion/.venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py", line 776, in wrapper
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939]     fn()
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939]   File "/__w/helion/helion/.venv/lib/python3.12/site-packages/torch/testing/_internal/common_utils.py", line 3364, in wrapper
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939]     method(*args, **kwargs)
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939]   File "/__w/helion/helion/.venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py", line 227, in wrapper
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939]     return func(*args, **kwargs)
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939]            ^^^^^^^^^^^^^^^^^^^^^
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939]   File "/__w/helion/helion/test/test_examples_dist.py", line 142, in test_all_gather_matmul
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939]     self._cleanup_process()
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939]   File "/__w/helion/helion/test/test_examples_dist.py", line 79, in _cleanup_process
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939]     dist.barrier()
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939]   File "/__w/helion/helion/.venv/lib/python3.12/site-packages/torch/distributed/c10d_logger.py", line 83, in wrapper
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939]     return func(*args, **kwargs)
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939]            ^^^^^^^^^^^^^^^^^^^^^
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939]   File "/__w/helion/helion/.venv/lib/python3.12/site-packages/torch/distributed/distributed_c10d.py", line 4971, in barrier
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939]     work = group.barrier(opts=opts)
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939]            ^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939] torch.distributed.DistBackendError: NCCL error in: /pytorch/torch/csrc/distributed/c10d/NCCLUtils.cpp:93, unhandled cuda error (run with NCCL_DEBUG=INFO for details), NCCL version 2.29.3
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939] ncclUnhandledCudaError: Call to CUDA function failed.
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939] Last error:
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939] Failed to bind NVLink SHARP (NVLS) Multicast memory of size 2097152 : CUDA error 401 'the operation cannot be performed in the present state'.
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939] This is usually caused by a system or configuration error in the Fabric Manager or NVSwitches.
[rank1]:E0207 07:54:31.862000 4712 .venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py:939] Disable NVLS (NCCL_NVLS_ENABLE=0) if you wish to avoid this error in the future.
```