### PR TITLE
[CI] Fix B200 flaky test errors by deferring CUDA initialization to test execution time for pytest-xdist compatibility

### DIFF
--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -1496,15 +1496,15 @@ def _register_load_store_tunables(
 
     from ..autotuner.config_fragment import EnumFragment
     from ..autotuner.config_fragment import ListOf
-    from ..autotuner.config_spec import VALID_EVICTION_POLICIES
     from ..autotuner.config_spec import ConfigSpec
+    from ..autotuner.config_spec import get_valid_eviction_policies
 
     env = CompileEnvironment.current()
 
     # Register eviction policies only for loads without explicit eviction_policy
     if loads_without_eviction_policy > 0:
         env.config_spec.load_eviction_policies = ListOf(
-            EnumFragment(choices=VALID_EVICTION_POLICIES),
+            EnumFragment(choices=get_valid_eviction_policies()),
             length=loads_without_eviction_policy,
         )
         env.device_load_count = loads_without_eviction_policy

--- a/test/data/basic_kernels.py
+++ b/test/data/basic_kernels.py
@@ -54,8 +54,16 @@ def pointwise_device_loop(x: torch.Tensor) -> torch.Tensor:
     return out
 
 
-global_tensor = torch.randn([512], device=DEVICE)
+# Initialized lazily via _init_globals() to avoid CUDA init at import time,
+# which causes "CUDA unknown error" with pytest-xdist worker spawning.
+global_tensor = None
 global_float = 0.5
+
+
+def _init_globals():
+    global global_tensor
+    if global_tensor is None:
+        global_tensor = torch.randn([512], device=DEVICE)
 
 
 @helion.kernel

--- a/test/test_barrier.py
+++ b/test/test_barrier.py
@@ -8,6 +8,7 @@ from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import skipIfRefEager
+from helion._testing import skipIfTileIR
 import helion.exc as exc
 import helion.language as hl
 
@@ -77,6 +78,7 @@ def barrier_groups(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
 
 class TestBarrier(RefEagerTestBase, TestCase):
+    @skipIfTileIR("TileIR does not support barrier operations")
     def test_dep_across_barrier(self) -> None:
         x = torch.arange(8, device=DEVICE, dtype=torch.float32)
         code, out = code_and_output(
@@ -89,6 +91,7 @@ class TestBarrier(RefEagerTestBase, TestCase):
         torch.testing.assert_close(out, expected)
         self.assertExpectedJournal(code)
 
+    @skipIfTileIR("TileIR does not support barrier operations")
     def test_multiple_barriers(self) -> None:
         x = torch.arange(6, device=DEVICE, dtype=torch.float32)
         code, out = code_and_output(
@@ -101,6 +104,7 @@ class TestBarrier(RefEagerTestBase, TestCase):
         torch.testing.assert_close(out, expected)
         self.assertExpectedJournal(code)
 
+    @skipIfTileIR("TileIR does not support barrier operations")
     def test_multiple_loops_between_barriers(self) -> None:
         x = torch.arange(8, device=DEVICE, dtype=torch.float32)
         y = torch.arange(8, device=DEVICE, dtype=torch.float32) * 3
@@ -125,6 +129,7 @@ class TestBarrier(RefEagerTestBase, TestCase):
                 pid_type="flat",
             )
 
+    @skipIfTileIR("TileIR does not support barrier operations")
     def test_default_config_is_persistent(self) -> None:
         x = torch.arange(4, device=DEVICE, dtype=torch.float32)
         code, out = code_and_output(

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -17,6 +17,7 @@ from helion._testing import check_example
 from helion._testing import import_path
 from helion._testing import skipIfA10G
 from helion._testing import skipIfCpu
+from helion._testing import skipIfCudaCapabilityLessThan
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfRocm
 from helion._testing import skipIfTileIR
@@ -54,6 +55,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             )
         )
 
+    @skipIfTileIR("PassManager::run failed")
     @skipIfXPU("Split-K barrier not supported on XPU backend")
     def test_split_k_barrier(self):
         m, k, n = 64, 512, 64
@@ -73,6 +75,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             )
         )
 
+    @skipIfTileIR("PassManager::run failed")
     @skipIfRefEager("Test requires compiled kernel with specific config")
     def test_split_k_barrier_accuracy(self):
         """Test split_k_barrier with a shape that exposes accuracy issues.
@@ -251,10 +254,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             )
         )
 
-    @unittest.skipIf(
-        not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9,
-        "FP8 requires GPU with compute capability >= 9.0 (e.g., H100)",
-    )
+    @skipIfCudaCapabilityLessThan((9, 0), reason="FP8 requires CUDA capability >= 9.0")
     @skipIfRocm("failure on rocm")
     def test_fp8_gemm(self):
         # Create FP32 tensors and convert to FP8
@@ -923,10 +923,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             )
         )
 
-    @unittest.skipIf(
-        not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9,
-        "FP8 requires GPU with compute capability >= 9.0 (e.g., H100)",
-    )
+    @skipIfCudaCapabilityLessThan((9, 0), reason="FP8 requires CUDA capability >= 9.0")
     @skipIfRocm("failure on rocm")
     def test_fp8_attention(self):
         batch = 2
@@ -1678,6 +1675,7 @@ class TestExamples(RefEagerTestBase, TestCase):
         )
 
     @skipIfA10G("failure on a10g")
+    @skipIfTileIR("precision differences with tileir")
     def test_squeeze_and_excitation_net_bwd_da(self):
         m, n, k = 256, 256, 256
         x = torch.randn([m, n], device=DEVICE, dtype=torch.float16)

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -7,11 +7,11 @@ import torch
 
 import helion
 from helion import _compat
-from helion._compat import supports_tensor_descriptor
 from helion._testing import DEVICE
 from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import code_and_output
+from helion._testing import skipUnlessTensorDescriptor
 import helion.language as hl
 
 
@@ -34,9 +34,7 @@ def grid_2d_pytorch(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
 
 class TestGrid(RefEagerTestBase, TestCase):
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     @patch.object(_compat, "_min_dot_size", lambda *args: (16, 16, 16))
     def test_grid_1d(self):
         @helion.kernel(static_shapes=True)
@@ -81,9 +79,7 @@ class TestGrid(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, grid_1d_pytorch(args[0], args[1]))
         self.assertExpectedJournal(code)
 
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_grid_2d_idx_list(self):
         @helion.kernel(static_shapes=True)
         def grid_2d_idx_list(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -9,7 +9,6 @@ import torch
 import helion
 from helion import _compat
 from helion._compat import get_tensor_descriptor_fn_name
-from helion._compat import supports_tensor_descriptor
 from helion._compat import use_tileir_tunables
 from helion._testing import DEVICE
 from helion._testing import RefEagerTestBase
@@ -21,6 +20,7 @@ from helion._testing import skipIfNormalMode
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfRocm
 from helion._testing import skipIfTileIR
+from helion._testing import skipUnlessTensorDescriptor
 import helion.language as hl
 
 _LARGE_BF16_SHAPE = (51200, 51200)
@@ -224,9 +224,7 @@ class TestIndexing(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, x[:-1] + x[1:])
         self.assertExpectedJournal(code)
 
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_pairwise_add_commuted_and_multi_offset(self):
         @helion.kernel()
         def pairwise_add_variants(x: torch.Tensor) -> torch.Tensor:
@@ -925,7 +923,7 @@ class TestIndexing(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, expected)
         self.assertExpectedJournal(code)
 
-    @unittest.skipIf(not supports_tensor_descriptor(), "TensorDescriptor not supported")
+    @skipUnlessTensorDescriptor("TensorDescriptor not supported")
     @unittest.skipIf(
         get_tensor_descriptor_fn_name() == "tl._experimental_make_tensor_descriptor",
         "LLVM ERROR: Illegal shared layout",
@@ -1014,7 +1012,7 @@ class TestIndexing(RefEagerTestBase, TestCase):
         torch.testing.assert_close(out, query)
         self.assertExpectedJournal(code)
 
-    @unittest.skipIf(not supports_tensor_descriptor(), "TensorDescriptor not supported")
+    @skipUnlessTensorDescriptor("TensorDescriptor not supported")
     @unittest.skipIf(
         get_tensor_descriptor_fn_name() != "tl._experimental_make_tensor_descriptor",
         "Not using experimental tensor descriptor",
@@ -1035,7 +1033,7 @@ class TestIndexing(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, expected)
         self.assertExpectedJournal(code)
 
-    @unittest.skipIf(not supports_tensor_descriptor(), "TensorDescriptor not supported")
+    @skipUnlessTensorDescriptor("TensorDescriptor not supported")
     @unittest.skipIf(
         get_tensor_descriptor_fn_name() != "tl._experimental_make_tensor_descriptor",
         "Not using experimental tensor descriptor",
@@ -1589,7 +1587,7 @@ class TestIndexing(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, x[10:])
         self.assertExpectedJournal(code)
 
-    @unittest.skipIf(not supports_tensor_descriptor(), "TensorDescriptor not supported")
+    @skipUnlessTensorDescriptor("TensorDescriptor not supported")
     @skipIfTileIR(
         "TileIR does not support descriptor with index not multiple of tile size"
     )

--- a/test/test_int64_indexing.py
+++ b/test/test_int64_indexing.py
@@ -21,7 +21,6 @@ import torch
 
 import helion
 from helion import _compat
-from helion._compat import supports_tensor_descriptor
 from helion._testing import DEVICE
 from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
@@ -29,6 +28,7 @@ from helion._testing import code_and_output
 from helion._testing import skipIfCpu
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
+from helion._testing import skipUnlessTensorDescriptor
 import helion.language as hl
 
 
@@ -94,9 +94,7 @@ class TestInt64Indexing(RefEagerTestBase, TestCase):
         self.assertExpectedJournal(code)
 
     @skipIfRefEager("Test checks generated code")
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_int64_tensor_descriptor_falls_back_to_pointer(self):
         """Test that int64 index_dtype causes tensor_descriptor to fall back to pointer indexing.
 
@@ -155,9 +153,7 @@ class TestInt64Indexing(RefEagerTestBase, TestCase):
         self.assertExpectedJournal(code)
 
     @skipIfRefEager("Test checks generated code")
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     @skipIfTileIR(
         "TileIR does not support descriptor with index not multiple of tile size"
     )
@@ -283,9 +279,7 @@ class TestInt64Indexing(RefEagerTestBase, TestCase):
         self.assertExpectedJournal(code)
 
     @skipIfRefEager("Test checks generated code")
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_int64_tensor_descriptor_with_reduction_falls_back(self):
         """Test int64 indexing with tensor_descriptor and reduction loops falls back to pointer."""
 
@@ -351,9 +345,7 @@ class TestInt64Indexing(RefEagerTestBase, TestCase):
         self.assertExpectedJournal(code)
 
     @skipIfRefEager("Test checks generated code")
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_int64_tensor_descriptor_matmul_falls_back(self):
         """Test int64 indexing with tensor_descriptor in a matmul pattern falls back to pointer."""
 

--- a/test/test_loops.py
+++ b/test/test_loops.py
@@ -16,6 +16,7 @@ from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import import_path
 from helion._testing import skipIfCpu
+from helion._testing import skipIfCudaCapabilityLessThan
 from helion._testing import skipIfLowVRAM
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
@@ -783,9 +784,8 @@ class TestLoops(RefEagerTestBase, TestCase):
         self.assertNotIn("loop_unroll_factor", code0)
         self.assertExpectedJournal(code2)
 
-    @unittest.skipIf(
-        DEVICE.type != "cuda" or torch.cuda.get_device_capability() < (12, 0),
-        "Warp specialization requires CUDA compute capability >= 12.0",
+    @skipIfCudaCapabilityLessThan(
+        (12, 0), reason="Warp specialization requires CUDA capability >= 12.0"
     )
     def test_range_warp_specialize(self):
         # Test configuration validation - that range_warp_specialize works

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -20,7 +20,6 @@ from torch.testing._internal.common_utils import parametrize
 
 import helion
 from helion import _compat
-from helion._compat import supports_tensor_descriptor
 from helion._testing import DEVICE
 from helion._testing import EXAMPLES_DIR
 from helion._testing import PROJECT_ROOT
@@ -32,6 +31,7 @@ from helion._testing import skipIfCpu
 from helion._testing import skipIfPyTorchBaseVerLessThan
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
+from helion._testing import skipUnlessTensorDescriptor
 import helion.language as hl
 
 
@@ -497,9 +497,7 @@ class TestMisc(RefEagerTestBase, TestCase):
         self.assertNotEqualCode(code_pointer, code_block)
         self.assertExpectedJournal(code_pointer + code_block)
 
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_tuple_literal_subscript_w_descriptor(self):
         @helion.kernel
         def tuple_literal_index_kernel(inp_tuple) -> torch.Tensor:

--- a/test/test_persistent_kernels.py
+++ b/test/test_persistent_kernels.py
@@ -6,14 +6,15 @@ import torch
 
 import helion
 from helion._compat import get_tensor_descriptor_fn_name
-from helion._compat import supports_tensor_descriptor
 from helion._testing import DEVICE
 from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import skipIfCpu
+from helion._testing import skipIfCudaCapabilityLessThan
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
+from helion._testing import skipUnlessTensorDescriptor
 import helion.language as hl
 
 
@@ -988,9 +989,7 @@ class TestPersistentKernels(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result[0], result_flat[0])
         torch.testing.assert_close(result[1], result_flat[1])
 
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptors not supported on this device"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptors not supported on this device")
     def test_persistent_kernels_with_tensor_descriptor_indexing(self):
         """Test persistent kernels with indexing='tensor_descriptor'."""
 
@@ -1108,9 +1107,8 @@ class TestPersistentKernels(RefEagerTestBase, TestCase):
         self.assertIn("disallow_acc_multi_buffer=False", code_combined)
         self.assertIn("flatten=False", code_combined)
 
-    @unittest.skipIf(
-        DEVICE.type != "cuda" or torch.cuda.get_device_capability() < (12, 0),
-        "Warp specialization requires CUDA compute capability >= 12.0",
+    @skipIfCudaCapabilityLessThan(
+        (12, 0), reason="Warp specialization requires CUDA capability >= 12.0"
     )
     def test_persistent_kernels_with_warp_specialize(self):
         """Test that range_warp_specialize works with persistent kernels."""

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -6,7 +6,6 @@ import unittest
 import torch
 
 import helion
-from helion._compat import supports_tensor_descriptor
 from helion._testing import DEVICE
 from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
@@ -14,6 +13,7 @@ from helion._testing import code_and_output
 from helion._testing import skipIfCpu
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
+from helion._testing import skipUnlessTensorDescriptor
 import helion.language as hl
 
 if TYPE_CHECKING:
@@ -124,9 +124,7 @@ class TestReductions(RefEagerTestBase, TestCase):
         torch.testing.assert_close(output, args[0].sum(-1), rtol=1e-04, atol=1e-04)
         self.assertExpectedJournal(code)
 
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_sum_keepdims(self):
         args = (torch.randn([512, 512], device=DEVICE),)
         code, output = code_and_output(
@@ -137,9 +135,7 @@ class TestReductions(RefEagerTestBase, TestCase):
         )
         self.assertExpectedJournal(code)
 
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_argmin_argmax(self):
         for fn in (torch.argmin, torch.argmax):
             args = (torch.randn([512, 512], device=DEVICE), fn, torch.int64)
@@ -149,9 +145,7 @@ class TestReductions(RefEagerTestBase, TestCase):
             torch.testing.assert_close(output, args[1](args[0], dim=-1))
         self.assertExpectedJournal(code)
 
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_reduction_functions(self):
         for reduction_loop in (None, 16):
             for block_size in (1, 16):
@@ -175,9 +169,7 @@ class TestReductions(RefEagerTestBase, TestCase):
                             output, fn(args[0], dim=-1), rtol=1e-3, atol=1e-3
                         )
 
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_mean(self):
         args = (torch.randn([512, 512], device=DEVICE), torch.mean, torch.float32)
         self.assertExpectedJournal(reduce_kernel.bind(args)._debug_str())
@@ -195,9 +187,7 @@ class TestReductions(RefEagerTestBase, TestCase):
         torch.testing.assert_close(output, args[0].sum(-1), rtol=1e-04, atol=1e-04)
         self.assertExpectedJournal(code)
 
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_argmin_argmax_looped(self):
         for fn in (torch.argmin, torch.argmax):
             args = (torch.randn([512, 512], device=DEVICE), fn, torch.int64)
@@ -408,9 +398,7 @@ class TestReductions(RefEagerTestBase, TestCase):
             # Verify result maintains bfloat16 dtype
             self.assertEqual(result_bf16.dtype, torch.bfloat16)
 
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_layer_norm_nonpow2_reduction(self):
         """Test layer norm with non-power-of-2 reduction dimension (1536)."""
 

--- a/test/test_tensor_descriptor.py
+++ b/test/test_tensor_descriptor.py
@@ -7,7 +7,6 @@ import torch
 
 import helion
 from helion._compat import get_tensor_descriptor_fn_name
-from helion._compat import supports_tensor_descriptor
 from helion._compat import use_tileir_tunables
 from helion._testing import DEVICE
 from helion._testing import RefEagerTestBase
@@ -15,13 +14,12 @@ from helion._testing import TestCase
 from helion._testing import check_example
 from helion._testing import code_and_output
 from helion._testing import skipIfTileIR
+from helion._testing import skipUnlessTensorDescriptor
 import helion.language as hl
 
 
 class TestTensorDescriptor(RefEagerTestBase, TestCase):
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_permutation_when_stride_one_not_last(self):
         """Test that permutation is applied when stride==1 is not the last dimension."""
 
@@ -58,9 +56,7 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
         # The tensor descriptor should be created with permuted dimensions
         # (sizes and strides should be reordered so stride==1 dim is last)
 
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_no_permutation_when_stride_one_already_last(self):
         """Test that no permutation is applied when stride==1 is already last."""
 
@@ -94,9 +90,7 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
         # Should not contain permute calls since no permutation needed
         self.assertNotIn("tl.permute", code)
 
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_3d_tensor_permutation(self):
         """Test permutation with 3D tensor where stride==1 is in middle."""
 
@@ -129,9 +123,7 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
         self.assertIn(get_tensor_descriptor_fn_name(), code)
         self.assertIn("tl.permute", code)
 
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_matrix_transpose_case(self):
         """Test a common case: transposed matrix operations."""
 
@@ -165,9 +157,7 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
         self.assertIn(get_tensor_descriptor_fn_name(), code)
         self.assertIn("tl.permute", code)
 
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_permutation_with_different_block_sizes(self):
         """Test that permutation works correctly with different block sizes."""
 
@@ -201,9 +191,7 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
         # The block sizes should also be permuted in the tensor descriptor
         # This is important for correctness
 
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     @skipIfTileIR("tileir backend will ignore `range_num_stages` hints")
     def test_multistage_range_tensor_descriptor(self):
         @helion.kernel(
@@ -319,9 +307,7 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
         # range_num_stages=4 is clamped to 0, so doesn't show up as num_stages in the tl.range call
         self.assertEqual(len(range_stage_values), 0)
 
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_tiny_matmul_tile_fallback(self) -> None:
         """Tensor descriptor indexing should be rejected when the tile is too small."""
 
@@ -384,9 +370,7 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result_large, expected, atol=1e-2, rtol=1e-2)
         self.assertIn(get_tensor_descriptor_fn_name(), code_large)
 
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_store_operation_permutation(self):
         """Test that store operations also handle permutation correctly."""
 
@@ -421,9 +405,7 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
         self.assertIn(get_tensor_descriptor_fn_name(), code)
         self.assertIn("tl.permute", code)
 
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_attention_tensor_descriptor(self):
         args = (
             torch.randn(2, 32, 1024, 64, dtype=torch.float16, device=DEVICE),
@@ -440,9 +422,7 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
             )
         )
 
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_attention_td_dynamic(self):
         args = (
             torch.randn(1, 32, 512, 64, dtype=torch.float32, device=DEVICE),
@@ -460,9 +440,7 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
             )
         )
 
-    @unittest.skipUnless(
-        supports_tensor_descriptor(), "Tensor descriptor support is required"
-    )
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_minimum_16_byte_block_size_fallback(self):
         """Test that tensor descriptor falls back when block size is too small."""
 

--- a/test/test_triton_kernel.py
+++ b/test/test_triton_kernel.py
@@ -9,6 +9,7 @@ from helion._testing import DEVICE
 from helion._testing import RefEagerTestDisabled
 from helion._testing import TestCase
 from helion._testing import code_and_output
+from helion._testing import skipIfTileIR
 import helion.language as hl
 
 # Global constant used by triton kernel
@@ -205,6 +206,7 @@ class TestTritonKernel(RefEagerTestDisabled, TestCase):
         torch.testing.assert_close(result, x * 2.0 + 1.0)
         self.assertExpectedJournal(code)
 
+    @skipIfTileIR("TileIR does not support barrier operations")
     def test_triton_kernel_output_like_none(self) -> None:
         """Test that triton_kernel with output_like=None emits the call."""
 


### PR DESCRIPTION
Avoid "CUDA unknown error" when pytest-xdist workers simultaneously initialize CUDA during test collection by deferring all CUDA initialization from module import / decoration time to test execution time.

Original error on CI:
https://github.com/pytorch/helion/actions/runs/21770595700/job/62817086189
```
2026-02-07T00:38:10.3453259Z ___________________ ERROR collecting test/test_autotuner.py ____________________
2026-02-07T00:38:10.3455784Z test/test_autotuner.py:64: in <module>
2026-02-07T00:38:10.3456079Z     basic_kernels = import_path(datadir / "basic_kernels.py")
2026-02-07T00:38:10.3456347Z                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-02-07T00:38:10.3456577Z helion/_testing.py:579: in import_path
2026-02-07T00:38:10.3456826Z     spec.loader.exec_module(module)
2026-02-07T00:38:10.3457076Z <frozen importlib._bootstrap_external>:999: in exec_module
2026-02-07T00:38:10.3457313Z     ???
2026-02-07T00:38:10.3457517Z <frozen importlib._bootstrap>:488: in _call_with_frames_removed
2026-02-07T00:38:10.3457750Z     ???
2026-02-07T00:38:10.3457908Z test/data/basic_kernels.py:57: in <module>
2026-02-07T00:38:10.3458146Z     global_tensor = torch.randn([512], device=DEVICE)
2026-02-07T00:38:10.3458375Z                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-02-07T00:38:10.3458674Z .venv/lib/python3.12/site-packages/torch/cuda/__init__.py:410: in _lazy_init
2026-02-07T00:38:10.3458978Z     torch._C._cuda_init()
2026-02-07T00:38:10.3459536Z E   RuntimeError: CUDA unknown error - this may be due to an incorrectly set up environment, e.g. changing env variable CUDA_VISIBLE_DEVICES after program start. Setting the available devices to be zero.
```