### PR TITLE
Skip O(N^2) argsort in `torch.sort` lowering when `indices` is unused

### DIFF
--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -703,6 +703,13 @@ def codegen_sort(ctx: LoweringContext, node: Node) -> object:
         )
     )
 
+    # Skip O(N^2) argsort when indices are not used downstream
+    indices_used = any(
+        user.target is getitem and user.args[1] == 1 for user in node.users
+    )
+    if not indices_used:
+        return (expr_from_string(sorted_vals), None)
+
     # For indices, compute argsort using ranking:
     # For each element x[..., i], its rank is count of elements strictly less (or greater for descending)
     # plus count of equal elements with smaller index (for stability).

--- a/test/test_misc.expected
+++ b/test/test_misc.expected
@@ -443,6 +443,42 @@ def sort_kernel(x: torch.Tensor, *, _launcher=_default_launcher):
     # src[test_misc.py:N]: return out_vals, out_indices
     return (out_vals, out_indices)
 
+--- assertExpectedJournal(TestMisc.test_torch_sort_skips_argsort_when_indices_unused)
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from helion.runtime import default_launcher as _default_launcher
+
+@triton.jit
+def _helion_sort_values_only_kernel(x, out, _BLOCK_SIZE_0: tl.constexpr, _RDIM_SIZE_1: tl.constexpr):
+    # src[test_misc.py:N]: for tile_m in hl.tile(m):
+    pid_0 = tl.program_id(0)
+    offset_0 = pid_0 * _BLOCK_SIZE_0
+    indices_0 = (offset_0 + tl.arange(0, _BLOCK_SIZE_0)).to(tl.int32)
+    indices_1 = tl.arange(0, _RDIM_SIZE_1).to(tl.int32)
+    # src[test_misc.py:N]: vals, _indices = torch.sort(x[tile_m, :], dim=-1, descending=True)
+    load = tl.load(x + (indices_0[:, None] * 16 + indices_1[None, :] * 1), None)
+    sorted_vals = tl.sort(load, descending=True)
+    # src[test_misc.py:N]: out[tile_m, :] = vals
+    tl.store(out + (indices_0[:, None] * 16 + indices_1[None, :] * 1), sorted_vals, None)
+
+def sort_values_only_kernel(x: torch.Tensor, *, _launcher=_default_launcher):
+    # src[test_misc.py:N]: m, n = x.shape
+    m, n = x.shape
+    # src[test_misc.py:N]: out = torch.empty_like(x)
+    out = torch.empty_like(x)
+    # src[test_misc.py:N]: for tile_m in hl.tile(m):
+    _BLOCK_SIZE_0 = 4
+    _RDIM_SIZE_1 = 16
+    # src[test_misc.py:N]: for tile_m in hl.tile(m):
+    # src[test_misc.py:N]:     vals, _indices = torch.sort(x[tile_m, :], dim=-1, descending=True)
+    # src[test_misc.py:N]:     out[tile_m, :] = vals
+    _launcher(_helion_sort_values_only_kernel, (triton.cdiv(4, _BLOCK_SIZE_0),), x, out, _BLOCK_SIZE_0, _RDIM_SIZE_1, num_warps=4, num_stages=1)
+    # src[test_misc.py:N]: return out
+    return out
+
 --- assertExpectedJournal(TestMisc.test_torch_sort_then_cumsum)
 from __future__ import annotations
 
@@ -471,9 +507,6 @@ def _helion_sort_cumsum_kernel(x, result, _BLOCK_SIZE_0: tl.constexpr, _RDIM_SIZ
     # src[test_misc.py:N]: vals, indices = torch.sort(x[tile_m, :], dim=-1, descending=True)
     load = tl.load(x + (indices_0[:, None] * 16 + indices_1[None, :] * 1), None)
     sorted_vals = tl.sort(load, descending=True)
-    idx = tl.arange(0, 16)
-    rank = tl.sum(tl.where(load[:, None, :] > load[:, :, None], 1, 0), axis=2) + tl.sum(tl.where((load[:, None, :] == load[:, :, None]) & (idx[None, None, :] < idx[None, :, None]), 1, 0), axis=2)
-    sorted_indices = tl.sum(tl.where(rank[:, :, None] == idx[None, None, :], idx[None, :, None], 0), axis=1)
     # src[test_misc.py:N]: cumsum = torch.cumsum(vals, dim=-1)
     cumsum = tl.associative_scan(sorted_vals, -1, add_0)
     # src[test_misc.py:N]: result[tile_m, :] = cumsum

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -814,6 +814,55 @@ class TestMisc(RefEagerTestBase, TestCase):
         self.assertIn("tl.associative_scan", code)
         self.assertExpectedJournal(code)
 
+    def test_torch_sort_skips_argsort_when_indices_unused(self):
+        """Test that sort skips O(N^2) argsort when indices are not used.
+
+        When only values from torch.sort() are used, the compiler should
+        skip generating the rank-based argsort code (which creates
+        O(N^2) intermediate tensors and would exceed Triton's 1M element limit
+        for large N).
+        """
+
+        @helion.kernel()
+        def sort_values_only_kernel(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.shape
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(m):
+                vals, _indices = torch.sort(x[tile_m, :], dim=-1, descending=True)
+                out[tile_m, :] = vals
+            return out
+
+        x = torch.randn(4, 16, device=DEVICE)
+        code, result = code_and_output(sort_values_only_kernel, (x,))
+
+        ref_vals, _ = torch.sort(x, dim=-1, descending=True)
+        torch.testing.assert_close(result, ref_vals)
+        self.assertIn("tl.sort", code)
+        # Argsort rank computation should NOT be present
+        self.assertNotIn("tl.sum(tl.where(", code)
+        self.assertExpectedJournal(code)
+
+        # Contrast: when indices ARE used, argsort code must be generated
+        @helion.kernel()
+        def sort_with_indices_kernel(
+            x: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            m, n = x.shape
+            out_vals = torch.empty_like(x)
+            out_idx = torch.empty(m, n, dtype=torch.int64, device=x.device)
+            for tile_m in hl.tile(m):
+                vals, indices = torch.sort(x[tile_m, :], dim=-1, descending=True)
+                out_vals[tile_m, :] = vals
+                out_idx[tile_m, :] = indices
+            return out_vals, out_idx
+
+        code2, (vals2, idx2) = code_and_output(sort_with_indices_kernel, (x,))
+        ref_vals2, ref_idx2 = torch.sort(x, dim=-1, descending=True)
+        torch.testing.assert_close(vals2, ref_vals2)
+        torch.testing.assert_close(idx2, ref_idx2)
+        # Argsort rank computation SHOULD be present when indices are used
+        self.assertIn("tl.sum(tl.where(", code2)
+
     def test_torch_topk_in_kernel(self):
         """Test that torch.topk works inside Helion kernels.
 


### PR DESCRIPTION
`torch.sort()` returns `(values, indices)` tuple. When only `values` from `torch.sort()` output is used downstream (and `indices` is unused), This PR skips generating the rank-based argsort code which creates O(N^2) intermediate tensors.

This is done by checking if any user of the sort node accesses index 1 (the `indices` output) via `getitem`; if not, return early with None for `indices`.