### PR TITLE
[CI] Adjust atol for `squeeze_and_excitation_net_bwd` unit tests

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1701,11 +1701,11 @@ class TestExamples(RefEagerTestBase, TestCase):
                 block_sizes=[16, 16, 16],
                 num_warps=4,
                 num_stages=2,
+                atol=0.3,
             )
         )
 
     @skipIfA10G("failure on a10g")
-    @skipIfTileIR("precision differences with tileir")
     def test_squeeze_and_excitation_net_bwd_da(self):
         m, n, k = 256, 256, 256
         x = torch.randn([m, n], device=DEVICE, dtype=torch.float16)
@@ -1744,6 +1744,7 @@ class TestExamples(RefEagerTestBase, TestCase):
                 block_sizes=[16, 16, 16],
                 num_warps=4,
                 num_stages=2,
+                atol=0.3,
             )
         )
 
@@ -1787,6 +1788,7 @@ class TestExamples(RefEagerTestBase, TestCase):
                 block_sizes=[16, 16, 16],
                 num_warps=4,
                 num_stages=2,
+                atol=0.3,
             )
         )
 


### PR DESCRIPTION
These unit tests seem to have flaky numerical issues on TileIR backend.

Example job: https://github.com/pytorch/helion/actions/runs/21854561911/job/63068501646?pr=1408
```
FAILED test/test_examples.py::TestExamples::test_squeeze_and_excitation_net_bwd_db - AssertionError: Tensor-likes are not close!

Mismatched elements: 7 / 65536 (0.0%)
Greatest absolute difference: 0.265625 at index (205, 114) (up to 0.1 allowed)
Greatest relative difference: 83.67955017089844 at index (124, 114) (up to 0.01 allowed)
FAILED test/test_examples.py::TestExamples::test_squeeze_and_excitation_net_bwd_dx - AssertionError: Tensor-likes are not close!

Mismatched elements: 4 / 65536 (0.0%)
Greatest absolute difference: 0.265625 at index (123, 173) (up to 0.1 allowed)
Greatest relative difference: 0.04978355020284653 at index (123, 210) (up to 0.01 allowed)
```