### PR TITLE
Fix `torch.cumsum` overwriting its input when used in Helion kernel

### DIFF
--- a/test/test_associative_scan.expected
+++ b/test/test_associative_scan.expected
@@ -1086,7 +1086,7 @@ def _helion_test_multi_kernel(x, sum_result, max_result, _RDIM_SIZE_1: tl.conste
     _associative_scan = tl.associative_scan(row_data, 1, add_combine_fn_0)
     tl.store(sum_result + tl.broadcast_to(indices_1[None, :] * 1, [_BLOCK_SIZE_0, _RDIM_SIZE_1]), _associative_scan, None)
     # src[test_associative_scan.py:N]: max_result[i, :] = hl.associative_scan(max_combine_fn, row_data, dim=1)
-    _associative_scan_1 = tl.associative_scan(_associative_scan, 1, max_combine_fn_1)
+    _associative_scan_1 = tl.associative_scan(row_data, 1, max_combine_fn_1)
     tl.store(max_result + tl.broadcast_to(indices_1[None, :] * 1, [_BLOCK_SIZE_0, _RDIM_SIZE_1]), _associative_scan_1, None)
 
 def test_multi_kernel(x: torch.Tensor, *, _launcher=_default_launcher):
@@ -1839,7 +1839,7 @@ def _helion_test_mixed_kernel(x, sum_result, prod_result, _RDIM_SIZE_1: tl.const
     _associative_scan = tl.associative_scan(row_data, 1, add_0)
     tl.store(sum_result + tl.broadcast_to(indices_1[None, :] * 1, [_BLOCK_SIZE_0, _RDIM_SIZE_1]), _associative_scan, None)
     # src[test_associative_scan.py:N]: prod_result[i, :] = torch.cumprod(row_data, dim=1)
-    _associative_scan_1 = tl.associative_scan(_associative_scan, 1, mul_1)
+    _associative_scan_1 = tl.associative_scan(row_data, 1, mul_1)
     tl.store(prod_result + tl.broadcast_to(indices_1[None, :] * 1, [_BLOCK_SIZE_0, _RDIM_SIZE_1]), _associative_scan_1, None)
 
 def test_mixed_kernel(x: torch.Tensor, *, _launcher=_default_launcher):

--- a/test/test_misc.expected
+++ b/test/test_misc.expected
@@ -66,6 +66,55 @@ def helion_min_kernel(x_c, *, _launcher=_default_launcher):
     # src[test_misc.py:N]: return out
     return out
 
+--- assertExpectedJournal(TestMisc.test_cumsum_does_not_alias_input)
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from helion.runtime import default_launcher as _default_launcher
+
+@triton.jit
+def add_0(param_0, param_1):
+    # src[test_misc.py:N]: cumsum = torch.cumsum(row, dim=-1)
+    v_0 = param_0 + param_1
+    # src[test_misc.py:N]: def exclusive_cumsum_kernel(x: torch.Tensor) -> torch.Tensor:
+    # src[test_misc.py:N]:     m, n = x.shape
+    # src[test_misc.py:N]:     result = torch.empty_like(x)
+    # src[test_misc.py:N-N]: ...
+    return v_0
+
+@triton.jit
+def _helion_exclusive_cumsum_kernel(x, result, _BLOCK_SIZE_0: tl.constexpr, _RDIM_SIZE_1: tl.constexpr):
+    # src[test_misc.py:N]: for tile_m in hl.tile(m):
+    pid_0 = tl.program_id(0)
+    offset_0 = pid_0 * _BLOCK_SIZE_0
+    indices_0 = (offset_0 + tl.arange(0, _BLOCK_SIZE_0)).to(tl.int32)
+    indices_1 = tl.arange(0, _RDIM_SIZE_1).to(tl.int32)
+    # src[test_misc.py:N]: row = x[tile_m, :]
+    row = tl.load(x + (indices_0[:, None] * 16 + indices_1[None, :] * 1), None)
+    # src[test_misc.py:N]: cumsum = torch.cumsum(row, dim=-1)
+    cumsum = tl.associative_scan(row, -1, add_0)
+    # src[test_misc.py:N]: result[tile_m, :] = cumsum - row
+    v_0 = cumsum - row
+    tl.store(result + (indices_0[:, None] * 16 + indices_1[None, :] * 1), v_0, None)
+
+def exclusive_cumsum_kernel(x: torch.Tensor, *, _launcher=_default_launcher):
+    # src[test_misc.py:N]: m, n = x.shape
+    m, n = x.shape
+    # src[test_misc.py:N]: result = torch.empty_like(x)
+    result = torch.empty_like(x)
+    # src[test_misc.py:N]: for tile_m in hl.tile(m):
+    _BLOCK_SIZE_0 = 4
+    _RDIM_SIZE_1 = 16
+    # src[test_misc.py:N]: for tile_m in hl.tile(m):
+    # src[test_misc.py:N]:     row = x[tile_m, :]
+    # src[test_misc.py:N]:     cumsum = torch.cumsum(row, dim=-1)
+    # src[test_misc.py:N-N]: ...
+    _launcher(_helion_exclusive_cumsum_kernel, (triton.cdiv(4, _BLOCK_SIZE_0),), x, result, _BLOCK_SIZE_0, _RDIM_SIZE_1, num_warps=4, num_stages=1)
+    # src[test_misc.py:N]: return result
+    return result
+
 --- assertExpectedJournal(TestMisc.test_inputs)
 from __future__ import annotations
 

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -863,6 +863,32 @@ class TestMisc(RefEagerTestBase, TestCase):
         # Argsort rank computation SHOULD be present when indices are used
         self.assertIn("tl.sum(tl.where(", code2)
 
+    def test_cumsum_does_not_alias_input(self):
+        """Regression test: torch.cumsum output must not alias its input.
+
+        tl.associative_scan modifies its input in-place, so the tracing
+        logic must allocate a distinct output tensor to avoid corrupting
+        the input when it is reused after the cumsum.
+        """
+
+        @helion.kernel(autotune_effort="none")
+        def exclusive_cumsum_kernel(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.shape
+            result = torch.empty_like(x)
+            for tile_m in hl.tile(m):
+                row = x[tile_m, :]
+                cumsum = torch.cumsum(row, dim=-1)
+                # row should still hold original values, not cumsum
+                result[tile_m, :] = cumsum - row
+            return result
+
+        x = torch.randn(4, 16, device=DEVICE)
+        code, result = code_and_output(exclusive_cumsum_kernel, (x,))
+
+        ref = torch.cumsum(x, dim=-1) - x
+        torch.testing.assert_close(result, ref)
+        self.assertExpectedJournal(code)
+
     def test_torch_topk_in_kernel(self):
         """Test that torch.topk works inside Helion kernels.
 


### PR DESCRIPTION
Helion compiles `torch.cumsum` to `tl.associative_scan` which modifies its input in-place. The tracing logic was aliasing the input and output tensors, so if the original input was used after the cumsum, it would silently contain the cumsum result instead of the original values.

Fix by allocating distinct output tensors during tracing so codegen emits separate variables for the input and the scan result.