### PR TITLE
[CI] Adjust atol for `test_dtype_cast_preserved_before_second_dot` test

### DIFF
--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -319,7 +319,7 @@ class TestMisc(RefEagerTestBase, TestCase):
         expected = p @ vf  # [M, H]
         expected = expected.to(out.dtype)
 
-        torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(out, expected, atol=0.2, rtol=1e-2)
 
     @skipIfRefEager("Config tests not applicable in ref eager mode")
     def test_config_flatten_issue(self):


### PR DESCRIPTION
Example error on A10G hardware: https://github.com/pytorch/helion/actions/runs/21857332318/job/63077197781?pr=1410
```
FAILED test/test_misc.py::TestMisc::test_dtype_cast_preserved_before_second_dot - AssertionError: Tensor-likes are not close!

Mismatched elements: 6 / 2048 (0.3%)
Greatest absolute difference: 0.125 at index (21, 11) (up to 0.01 allowed)
Greatest relative difference: 0.05615234375 at index (21, 48) (up to 0.01 allowed)
```