### PR TITLE
Skip "too many blocks in cooperative launch" error during autotuning

### DIFF
--- a/helion/autotuner/logger.py
+++ b/helion/autotuner/logger.py
@@ -416,6 +416,7 @@ _EXPECTED_TRITON_ERRORS_RE: re.Pattern[str] = re.compile(
                 "ZE_RESULT_ERROR_INVALID_KERNEL_NAME",  # Level Zero compile failed
                 "exceeds triton maximum tensor numel",  # needs smaller config
                 "Resource temporarily unavailable",  # LLVM Error
+                "too many blocks in cooperative launch",  # CUDA cooperative launch limit
             ],
         )
     )


### PR DESCRIPTION
This CUDA runtime error is config-dependent (block sizes exceeding the cooperative launch limit) and should be skipped like other expected Triton errors rather than crashing the autotuner.