### PR TITLE
[CI] Fix flaky OOM error for `test_int32_offset_out_of_range_error` on H100

### DIFF
--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -524,6 +524,8 @@ class TestIndexing(RefEagerTestBase, TestCase):
                     f"index_dtype is {index_dtype}",
                 ):
                     code_and_output(kernel, (x, y))
+                del x, y
+                torch.cuda.empty_cache()
                 torch.accelerator.synchronize()
                 return
 
@@ -533,6 +535,8 @@ class TestIndexing(RefEagerTestBase, TestCase):
             checker("tl.int64", code)
             torch.accelerator.synchronize()
             ref_out = torch.add(x, y)
+            del x, y
+            torch.cuda.empty_cache()
             torch.accelerator.synchronize()
             torch.testing.assert_close(out, ref_out, rtol=1e-2, atol=1e-2)
 


### PR DESCRIPTION
Example error: https://github.com/pytorch/helion/actions/runs/21885615149/job/63179607004?pr=1417
```
=================================== FAILURES ===================================
______________ TestIndexing.test_int32_offset_out_of_range_error _______________
[gw1] linux -- Python 3.12.12 /__w/helion/helion/.venv/bin/python3

self = TensorLikePair(
    id=(),
    actual=tensor([[-1.1719,  0.8438,  0.2930,  ..., -2.7188,  1.0234, -1.3125],
        [-....01,
    equal_nan=False,
    check_device=True,
    check_dtype=True,
    check_layout=True,
    check_stride=False,
)

    def compare(self) -> None:
        actual, expected = self.actual, self.expected
    
        self._compare_attributes(actual, expected)
        if any(input.device.type == "meta" for input in (actual, expected)):
            return
    
        actual, expected = self._equalize_attributes(actual, expected)
>       self._compare_values(actual, expected)

.venv/lib/python3.12/site-packages/torch/testing/_comparison.py:747: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
.venv/lib/python3.12/site-packages/torch/testing/_comparison.py:905: in _compare_values
    compare_fn(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = TensorLikePair(
    id=(),
    actual=tensor([[-1.1719,  0.8438,  0.2930,  ..., -2.7188,  1.0234, -1.3125],
        [-....01,
    equal_nan=False,
    check_device=True,
    check_dtype=True,
    check_layout=True,
    check_stride=False,
)
actual = tensor([[-1.1719,  0.8438,  0.2930,  ..., -2.7188,  1.0234, -1.3125],
        [-0.3984, -1.1250,  0.5234,  ...,  0.722...],
        [ 0.5117, -0.2461,  2.4219,  ...,  0.8008, -0.1328, -2.2500]],
       device='cuda:0', dtype=torch.bfloat16)
expected = tensor([[-1.1719,  0.8438,  0.2930,  ..., -2.7188,  1.0234, -1.3125],
        [-0.3984, -1.1250,  0.5234,  ...,  0.722...],
        [ 0.5117, -0.2461,  2.4219,  ...,  0.8008, -0.1328, -2.2500]],
       device='cuda:0', dtype=torch.bfloat16)

    def _compare_regular_values_close(
        self,
        actual: torch.Tensor,
        expected: torch.Tensor,
        *,
        rtol: float,
        atol: float,
        equal_nan: bool,
        identifier: Optional[Union[str, Callable[[str], str]]] = None,
    ) -> None:
        """Checks if the values of two tensors are close up to a desired tolerance."""
>       matches = torch.isclose(
            actual, expected, rtol=rtol, atol=atol, equal_nan=equal_nan
        )
E       torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 2.44 GiB. GPU 0 has a total capacity of 79.18 GiB of which 1.71 GiB is free. Process 3632 has 1.72 GiB memory in use. Including non-PyTorch memory, this process has 39.98 GiB memory in use. Process 3638 has 24.71 GiB memory in use. Process 3641 has 11.03 GiB memory in use. Of the allocated memory 39.09 GiB is allocated by PyTorch, and 225.95 MiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf)
```