### PR TITLE
Fix PointwiseLowering rank mismatch for size-1 reductions

### DIFF
--- a/test/test_reductions.expected
+++ b/test/test_reductions.expected
@@ -790,6 +790,92 @@ def layer_norm_reduction(x: torch.Tensor, weight: torch.Tensor, bias: torch.Tens
     # src[test_reductions.py:N]: return out
     return out
 
+--- assertExpectedJournal(TestReductions.test_size1_reduction_keepdim_sum)
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from helion.runtime import default_launcher as _default_launcher
+
+@triton.jit
+def _helion_keepdim_sum(x, out, out_stride_0, x_stride_0, x_stride_1, T, D, _BLOCK_SIZE_0: tl.constexpr, _BLOCK_SIZE_1: tl.constexpr):
+    # src[test_reductions.py:N]: for tile_t, tile_d in hl.tile([T, D]):
+    num_blocks_0 = tl.cdiv(T, _BLOCK_SIZE_0)
+    pid_0 = tl.program_id(0) % num_blocks_0
+    pid_1 = tl.program_id(0) // num_blocks_0
+    offset_0 = pid_0 * _BLOCK_SIZE_0
+    indices_0 = (offset_0 + tl.arange(0, _BLOCK_SIZE_0)).to(tl.int32)
+    mask_0 = indices_0 < T
+    offset_1 = pid_1 * _BLOCK_SIZE_1
+    indices_1 = (offset_1 + tl.arange(0, _BLOCK_SIZE_1)).to(tl.int32)
+    mask_1 = indices_1 < D
+    # src[test_reductions.py:N]: val = x[tile_t, tile_d].float()  # [T_tile, D_tile]
+    load = tl.load(x + (indices_0[:, None] * x_stride_0 + indices_1[None, :] * x_stride_1), mask_0[:, None] & mask_1[None, :], other=0)
+    v_0 = tl.cast(load, tl.float32)
+    # src[test_reductions.py:N]: partial = val.sum(0, keepdim=True)  # [1, D_tile]
+    partial = tl.cast(tl.reshape(tl.sum(v_0, 0), [1, _BLOCK_SIZE_1]), tl.float32)
+    # src[test_reductions.py:N]: result = partial.sum(0)  # should be [D_tile]
+    result = tl.reshape(partial, [_BLOCK_SIZE_1])
+    # src[test_reductions.py:N]: hl.store(out, [tile_d.index], result)
+    tl.store(out + indices_1 * out_stride_0, result, mask_1)
+
+def keepdim_sum(x: torch.Tensor, *, _launcher=_default_launcher):
+    # src[test_reductions.py:N]: T, D = x.shape
+    T, D = x.shape
+    # src[test_reductions.py:N]: out = torch.empty(D, dtype=torch.float32, device=x.device)
+    out = torch.empty(D, dtype=torch.float32, device=x.device)
+    # src[test_reductions.py:N]: for tile_t, tile_d in hl.tile([T, D]):
+    _BLOCK_SIZE_0 = 32
+    _BLOCK_SIZE_1 = 128
+    # src[test_reductions.py:N]: for tile_t, tile_d in hl.tile([T, D]):
+    # src[test_reductions.py:N]:     val = x[tile_t, tile_d].float()  # [T_tile, D_tile]
+    # src[test_reductions.py:N]:     partial = val.sum(0, keepdim=True)  # [1, D_tile]
+    # src[test_reductions.py:N-N]: ...
+    _launcher(_helion_keepdim_sum, (triton.cdiv(T, _BLOCK_SIZE_0) * triton.cdiv(D, _BLOCK_SIZE_1),), x, out, out.stride(0), x.stride(0), x.stride(1), T, D, _BLOCK_SIZE_0, _BLOCK_SIZE_1, num_warps=4, num_stages=1)
+    # src[test_reductions.py:N]: return out
+    return out
+
+--- assertExpectedJournal(TestReductions.test_size1_reduction_unsqueeze_sum)
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from helion.runtime import default_launcher as _default_launcher
+
+@triton.jit
+def _helion_unsqueeze_sum(x, out, out_stride_0, x_stride_0, D, _BLOCK_SIZE_0: tl.constexpr):
+    # src[test_reductions.py:N]: for (tile_d,) in hl.tile([D]):
+    pid_0 = tl.program_id(0)
+    offset_0 = pid_0 * _BLOCK_SIZE_0
+    indices_0 = (offset_0 + tl.arange(0, _BLOCK_SIZE_0)).to(tl.int32)
+    mask_0 = indices_0 < D
+    # src[test_reductions.py:N]: val = x[tile_d].float()  # [D_tile]
+    load = tl.load(x + indices_0 * x_stride_0, mask_0, other=0)
+    v_0 = tl.cast(load, tl.float32)
+    # src[test_reductions.py:N]: val2 = val.unsqueeze(0)  # [1, D_tile]
+    val2 = v_0[None, :]
+    # src[test_reductions.py:N]: reduced = val2.sum(0)  # should be [D_tile]
+    reduced = tl.reshape(val2, [_BLOCK_SIZE_0])
+    # src[test_reductions.py:N]: hl.store(out, [tile_d.index], reduced)
+    tl.store(out + indices_0 * out_stride_0, reduced, mask_0)
+
+def unsqueeze_sum(x: torch.Tensor, *, _launcher=_default_launcher):
+    # src[test_reductions.py:N]: (D,) = x.shape
+    D, = x.shape
+    # src[test_reductions.py:N]: out = torch.empty(D, dtype=torch.float32, device=x.device)
+    out = torch.empty(D, dtype=torch.float32, device=x.device)
+    # src[test_reductions.py:N]: for (tile_d,) in hl.tile([D]):
+    _BLOCK_SIZE_0 = 128
+    # src[test_reductions.py:N]: for (tile_d,) in hl.tile([D]):
+    # src[test_reductions.py:N]:     val = x[tile_d].float()  # [D_tile]
+    # src[test_reductions.py:N]:     val2 = val.unsqueeze(0)  # [1, D_tile]
+    # src[test_reductions.py:N-N]: ...
+    _launcher(_helion_unsqueeze_sum, (triton.cdiv(D, _BLOCK_SIZE_0),), x, out, out.stride(0), x.stride(0), D, _BLOCK_SIZE_0, num_warps=4, num_stages=1)
+    # src[test_reductions.py:N]: return out
+    return out
+
 --- assertExpectedJournal(TestReductions.test_sum)
 from __future__ import annotations
 


### PR DESCRIPTION
When Inductor converts a size-1 reduction to a Pointwise op, the buffer has fewer ranges than the inputs, causing a shape mismatch in the generated Triton code. Add a reshape in PointwiseLowering to match the expected output shape. Add two regression tests that trigger this via unsqueeze+sum and keepdim+sum patterns.

Fixes https://github.com/pytorch/helion/issues/1423.