### PR TITLE
[Helion + torch.compile] Support calling torch.compile on Helion kernel without eager warmup run

### DIFF
--- a/helion/_compiler/_inductor/template_buffer.py
+++ b/helion/_compiler/_inductor/template_buffer.py
@@ -123,7 +123,9 @@ class HelionTemplateBuffer(TritonTemplateBuffer):
             return PartialRender("", {})
         # Ensure config is available (triggers autotuning if needed)
         if self._autotune_args:
-            self._bound_kernel.ensure_config_exists(self._autotune_args)
+            self._bound_kernel.ensure_config_exists(
+                self._autotune_args  # pyrefly: ignore [bad-argument-type]
+            )
         cfg = self._bound_kernel._config
         assert cfg is not None, "Config should be set after ensure_config_exists"
         host_fn = self._helion_kernel.name

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -355,6 +355,7 @@ class Kernel(Generic[_R]):
 
 
 class BoundKernel(_AutotunableKernel, Generic[_R]):
+    @torch._dynamo.disable
     def __init__(
         self,
         kernel: Kernel[_R],
@@ -758,6 +759,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             raise RuntimeError("no config provided and no implicit config available")
         return config
 
+    @torch._dynamo.disable
     def ensure_config_exists(self, args: Sequence[object]) -> None:
         """
         Ensure a config is available, triggering autotuning if needed.
@@ -805,7 +807,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             return self.run_ref(*args)
 
         if self._run is None:
-            self.ensure_config_exists(args)
+            self.ensure_config_exists(args)  # pyrefly: ignore [bad-argument-type]
             assert self._run is not None
 
         assert self._config is not None


### PR DESCRIPTION
It's common for users to run Helion kernel within torch.compile region without doing an eager run of the Helion kernel first (e.g. https://github.com/pytorch/ao/pull/3880). This PR removes the limitation and adds support for that use case.