### PR TITLE
[tileir] Add early error when HELION_BACKEND=tileir is set without ENABLE_TILE=1

### DIFF
--- a/helion/exc.py
+++ b/helion/exc.py
@@ -311,6 +311,14 @@ class IncompatibleInterpretModes(BaseError):
     message = "TRITON_INTERPRET=1 and HELION_INTERPRET=1 cannot be used together. Please use only one of these debug modes at a time."
 
 
+class MissingEnableTile(BaseError):
+    message = (
+        "HELION_BACKEND=tileir requires the Triton TileIR driver to be active. "
+        "Set ENABLE_TILE=1 before importing Triton:\n"
+        "  export ENABLE_TILE=1"
+    )
+
+
 class UndefinedVariable(BaseError):
     message = "{} is not defined."
 

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -618,6 +618,9 @@ class Settings(_Settings):
         # pyrefly: ignore [bad-argument-type]
         super().__init__(**settings)
 
+        if self.backend == "tileir" and os.environ.get("ENABLE_TILE", "0") != "1":
+            raise exc.MissingEnableTile
+
         self._check_ref_eager_mode_before_print_output_code()
 
     def to_dict(self) -> dict[str, object]:


### PR DESCRIPTION
## Summary                                                                                                                                                                             
  - while I was performing a couple of tests using the TileIR backend, I noticed that setting `HELION_BACKEND=tileir` without `ENABLE_TILE=1` leads to confusing failures. This adds an early validation in `Settings.__init__` that raises an error before anything else goes wrong.  

Added a couple of tests