### PR TITLE
Update Discourse link to point to Helion category

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,7 +121,7 @@ html_theme_options = {
         },
         {
             "name": "Discourse",
-            "url": "https://dev-discuss.pytorch.org/",
+            "url": "https://dev-discuss.pytorch.org/c/helion/",
             "icon": "fa-brands fa-discourse",
         },
         {


### PR DESCRIPTION
We now have a Helion category on PyTorch dev discuss: https://dev-discuss.pytorch.org/c/helion/