### PR TITLE
[Cache] Fix backend_cache_key not written to .best_config after Config.minimize #1319

### DIFF
--- a/helion/autotuner/local_cache.py
+++ b/helion/autotuner/local_cache.py
@@ -145,6 +145,14 @@ class LocalAutotuneCache(AutotuneCacheBase):
         }
 
         backend_cache_key = self.kernel.backend_cache_key(config)
+        if backend_cache_key is None:
+            # Config may have been minimized (default values stripped),
+            # so it won't match the full config in _compile_cache.
+            # Expand it back by merging with defaults.
+            default = self.kernel.config_spec.default_config()
+            # pyrefly: ignore [bad-argument-type]
+            full_config = Config(**(default.config | config.config))
+            backend_cache_key = self.kernel.backend_cache_key(full_config)
         if backend_cache_key is not None:
             data["backend_cache_key"] = backend_cache_key
 


### PR DESCRIPTION
  ## Summary

  - `backend_cache_key` was not being written to the `.best_config` JSON file after autotuning because `Config.minimize()` (introduced in #1319) strips default values, producing a config that doesn't match the full config stored in `_compile_cache`
  - The existing tests didn't catch this because they call `backend_cache_key()` on the `BoundKernel` **after** `kernel(*args)` completes, at which point `set_config()` has already compiled the minimized config into `_compile_cache`. But `put()` is called **before** `set_config()`, when only full configs exist  in the cache
  - Fix: in `put()`, when the minimized config misses, expand it back to a full config by merging with defaults and retry the lookup
  - Added `test_backend_cache_key_written_to_cache_file` with a `MinimizingBasicSearch` that reproduces the real autotuner flow (compile with full config, return minimized config to `put()`)

  ## Test plan

  - [x] `test_backend_cache_key_written_to_cache_file` fails without fix, passes with fix