### PR TITLE
Disable finishing rounds by default

### DIFF
--- a/helion/autotuner/effort_profile.py
+++ b/helion/autotuner/effort_profile.py
@@ -54,7 +54,7 @@ class AutotuneEffortProfile:
     lfbo_pattern_search: PatternSearchConfig | None
     differential_evolution: DifferentialEvolutionConfig | None
     random_search: RandomSearchConfig | None
-    finishing_rounds: int = 3
+    finishing_rounds: int = 0
     rebenchmark_threshold: float = 1.5
 
 
@@ -86,7 +86,7 @@ _PROFILES: dict[AutotuneEffort, AutotuneEffortProfile] = {
         random_search=RandomSearchConfig(
             count=100,
         ),
-        finishing_rounds=1,
+        finishing_rounds=0,
         rebenchmark_threshold=0.9,  # <1.0 effectively disables rebenchmarking
     ),
     "full": AutotuneEffortProfile(


### PR DESCRIPTION
The debug_oom branch showed that with the baseline, some benchmark ci runs fail on B200. This is due to shared memory issues based on the logs:
<img width="1723" height="537" alt="Screenshot 2026-02-20 at 11 41 33 AM" src="https://github.com/user-attachments/assets/6198527b-f441-4350-800d-7bbb7813b897" />

When finishing rounds is disabled, the benchmark CI looks more healthy and the issue goes away:
<img width="1722" height="729" alt="Screenshot 2026-02-20 at 11 42 40 AM" src="https://github.com/user-attachments/assets/4361895d-45a6-41ce-b83f-f174acc528b4" />
