### PR TITLE
helion distributed kernel autotuning

### DIFF
--- a/examples/distributed/all_reduce.py
+++ b/examples/distributed/all_reduce.py
@@ -21,6 +21,8 @@ import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
 from torch.utils.cpp_extension import load_inline
 
+from examples.distributed.utils import symm_mem_sync
+
 import helion
 from helion._testing import DEVICE
 from helion._testing import run_example
@@ -91,11 +93,11 @@ def dev_array_to_tensor_short(
     static_shapes=True,
 )
 def one_shot_all_reduce_kernel(
-    signal_pad_addrs: torch.Tensor,
-    local_signal_pad: torch.Tensor,
+    signal_pad_ptrs_dev: torch.Tensor,
     a_shared: torch.Tensor,
     my_rank: hl.constexpr,
     group_name: hl.constexpr,
+    world_size: hl.constexpr,
 ) -> torch.Tensor:
     """
     Helion JIT-compiled kernel for one-shot all-reduce operation.
@@ -113,8 +115,6 @@ def one_shot_all_reduce_kernel(
     Returns:
         Tensor containing the all-reduced result (sum across all devices)
     """
-    _, world_size = local_signal_pad.size()
-    world_size = hl.specialize(world_size)
     out = torch.empty_like(a_shared)
     N = out.size(0)
     a_shared_tuple = torch.ops.symm_mem.get_remote_tensors(a_shared, group_name)
@@ -122,48 +122,25 @@ def one_shot_all_reduce_kernel(
     for tile_n in hl.tile(N):
         # Sync all devices through signal_pad to make sure
         # all previous writes to the shared tensor are visible
-        ptr_tile = signal_pad_addrs[:]
-        stack_signalpad = hl.stacktensor_like(local_signal_pad, ptr_tile)
-        hl.signal(
-            stack_signalpad,
-            [tile_n.id, my_rank],
-            signal=1,
-            wait_for=0,
-            scope="sys",
-            hasPreviousMemAccess=False,
+        hl.triton_kernel(
+            symm_mem_sync,
+            args=(signal_pad_ptrs_dev, None, my_rank, world_size, False, True),
+            output_like=None,
         )
 
-        for world in hl.tile(world_size, block_size=world_size):
-            hl.wait(
-                local_signal_pad,
-                [tile_n.id, world],
-                signal=1,
-                update=0,
-                scope="sys",
-            )
-
-        acc = hl.zeros([tile_n], dtype=a_shared.dtype, device=local_signal_pad.device)
+        acc = hl.zeros([tile_n], dtype=a_shared.dtype, device=a_shared.device)
 
         for a in a_shared_tuple:
             acc += a[tile_n]
 
         out[tile_n] = acc
 
-        # Sync all devices through signal_pad to make sure our writes to shared
-        # tensor are visible to subsequent kernels.
-        hl.signal(
-            stack_signalpad, [tile_n.id, my_rank], signal=1, wait_for=0, scope="sys"
+        hl.triton_kernel(
+            symm_mem_sync,
+            args=(signal_pad_ptrs_dev, None, my_rank, world_size, True, False),
+            output_like=None,
         )
 
-        for world in hl.tile(world_size, block_size=world_size):
-            hl.wait(
-                local_signal_pad,
-                [tile_n.id, world],
-                signal=1,
-                update=0,
-                scope="sys",
-                hasSubsequentMemAccess=False,
-            )
     return out
 
 
@@ -188,23 +165,12 @@ def helion_one_shot_all_reduce(a_shared: torch.Tensor) -> torch.Tensor:
     group_name = dist.group.WORLD.group_name
     symm_mem_hdl = symm_mem.rendezvous(a_shared, group_name)
 
-    local_signal_pad = symm_mem_hdl.get_signal_pad(
-        symm_mem_hdl.rank, dtype=torch.int32
-    ).view(-1, symm_mem_hdl.world_size)
-
-    signal_pad_addrs = dev_array_to_tensor_short(
-        symm_mem_hdl.signal_pad_ptrs_dev,
-        (symm_mem_hdl.world_size,),
-        dtype=torch.uint64,
-        device=a_shared.device,
-    )
-
     return one_shot_all_reduce_kernel(
-        signal_pad_addrs,
-        local_signal_pad,
+        symm_mem_hdl.signal_pad_ptrs_dev,
         a_shared,
         my_rank=symm_mem_hdl.rank,
         group_name=group_name,
+        world_size=symm_mem_hdl.world_size,
     )
 
 

--- a/examples/distributed/matmul_reduce_scatter.py
+++ b/examples/distributed/matmul_reduce_scatter.py
@@ -76,7 +76,7 @@ def matmul_reduce_scatter_kernel(
             symm_mem_sync,
             args=(
                 signal_pad_ptrs,
-                tile_m.id * 1000 + tile_n.id,
+                None,
                 RANK,
                 WORLD_SIZE,
                 True,
@@ -102,7 +102,7 @@ def matmul_reduce_scatter_kernel(
             symm_mem_sync,
             args=(
                 signal_pad_ptrs,
-                tile_m.id * 1000 + tile_n.id + 10000,
+                None,
                 RANK,
                 WORLD_SIZE,
                 True,

--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -30,8 +30,10 @@ from ._compat import requires_torch_version
 from ._compat import supports_amd_cdna_tunables
 from ._compat import supports_tensor_descriptor
 from ._utils import counters
+from ._utils import is_master_rank
 from .autotuner.benchmarking import sync_object as sync_object
 from .runtime.settings import _get_backend
+from helion.autotuner.base_search import _clone_args
 
 if _get_backend() == "pallas":
     from .autotuner.benchmarking import compute_repeat_generic as compute_repeat
@@ -932,6 +934,7 @@ def run_example(
     rtol: float = 1e-2,
     atol: float = 1e-1,
     bwd: bool = False,
+    trace_path: str | None = None,
 ) -> None:
     """Run complete example: correctness check + benchmark.
 
@@ -944,6 +947,7 @@ def run_example(
         rtol: Relative tolerance for correctness check (default: 1e-2)
         atol: Absolute tolerance for correctness check (default: 1e-1)
         bwd: Whether to also test backward pass (default: False)
+        trace_path: if not None, do profiling and save trace to this path
     """
     try:
         torch.backends.cuda.matmul.fp32_precision = "tf32"
@@ -965,9 +969,7 @@ def run_example(
         if name != first_baseline_name:
             print(f"Testing {name} correctness...", file=sys.stderr)
             # Clone args to avoid buffer donation issues (e.g., Pallas/TPU)
-            cloned_args = tuple(
-                a.clone() if isinstance(a, torch.Tensor) else a for a in args
-            )
+            cloned_args = _clone_args(args)
             result = func(*cloned_args).clone()
             torch.testing.assert_close(
                 result.to(torch.float32),
@@ -1052,7 +1054,7 @@ def run_example(
                     t.grad = None
 
     # Benchmark all functions — clone args to avoid buffer donation issues
-    cloned_args = tuple(a.clone() if isinstance(a, torch.Tensor) else a for a in args)
+    cloned_args = _clone_args(args)
     all_benchmarks = {**kernels, **baselines}
     bench_fns = [functools.partial(fn, *cloned_args) for fn in all_benchmarks.values()]
     repeat = compute_repeat(bench_fns[0])
@@ -1065,11 +1067,23 @@ def run_example(
         repeat = sync_object(repeat)
 
     # pyrefly: ignore [bad-argument-type]
-    timings = interleaved_bench(bench_fns, repeat=repeat, desc="Benchmarking")
+    profile_context = contextlib.nullcontext()
+    if trace_path is not None and is_master_rank():
+        profile_context = torch.profiler.profile()
+
+    with profile_context:
+        # pyrefly: ignore[bad-argument-type]
+        timings = interleaved_bench(bench_fns, repeat=repeat, desc="Benchmarking")
+
+    if trace_path is not None and is_master_rank():
+        print(f"Write profile to {trace_path}")
+        # pyrefly: ignore[missing-attribute]
+        profile_context.export_chrome_trace(trace_path)
+
     all_times = dict(zip(all_benchmarks.keys(), timings, strict=True))
     best_baseline_time = min(all_times[name] for name in baselines)
 
-    if not dist.is_initialized() or dist.get_rank() == 0:
+    if is_master_rank():
         # Print results (on rank 0)
         print(f"\n{'=' * 65}\nBenchmark Results\n{'=' * 65}", file=sys.stderr)
         print(
@@ -1418,7 +1432,11 @@ class TestCase(unittest.TestCase):
 
         from torch._inductor.utils import fresh_cache
 
-        self._test_stack.enter_context(fresh_cache())
+        self._test_stack.enter_context(
+            fresh_cache(
+                delete=os.getenv("HELION_DELETE_CACHE_AFTER_TEST", "1") == "1",
+            )
+        )
 
         counters.clear()
 

--- a/helion/_utils.py
+++ b/helion/_utils.py
@@ -4,13 +4,19 @@ import collections
 import contextlib
 from dataclasses import dataclass
 import functools
+import os
 import random
 from typing import Generator
 from typing import Sequence
 from typing import TypeVar
 
 import torch
+from torch import Tensor
 import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+
+import helion
+from helion import exc
 
 counters: collections.defaultdict[str, collections.Counter[str]] = (
     collections.defaultdict(collections.Counter)
@@ -98,6 +104,64 @@ def convert_tile_indices_to_slices(index: object) -> object:
     return _extract_slice(index)
 
 
+def is_master_rank() -> bool:
+    """
+    Either return True for rank 0 in a distributed workload or
+    always return true for non-distributed workload.
+    """
+    return not dist.is_initialized() or dist.get_rank() == 0
+
+
+def is_symm_mem_tensor(t: Tensor) -> bool:
+    if not isinstance(t, Tensor) or not dist.is_initialized():
+        return False
+
+    # TODO(shunting): support group other than WORLD?
+    try:
+        assert dist.group.WORLD is not None
+        return symm_mem.rendezvous(t, group=dist.group.WORLD.group_name) is not None
+    except RuntimeError:
+        # PyTorch right now throws a RuntimeError if the tensor passed
+        # to rendezvious is not from symm-mem
+        return False
+
+
+def get_signal_pad_ptrs_dev(t: Tensor) -> int:
+    assert dist.group.WORLD is not None
+    hdl = symm_mem.rendezvous(t, group=dist.group.WORLD.group_name)
+    return hdl.signal_pad_ptrs_dev
+
+
+def check_config_consistancy(config: helion.Config, print_config: bool = False) -> None:
+    """
+    Check the consistency of configs across ranks.
+    """
+    if (
+        os.getenv("HELION_DIST_CHECK_CONFIG_CONSISTANCY") != "1"
+        or not dist.is_initialized()
+    ):
+        return
+
+    all_configs = [None] * dist.get_world_size()
+    dist.all_gather_object(all_configs, config)
+    if dist.get_rank() == 0:
+        # do the check on rank 0
+        if all_configs != all_configs[:1] * len(all_configs):
+            if print_config:
+                for idx, c in enumerate(all_configs):
+                    print("FAIL", idx, c)
+            raise exc.InconsistantConfigsAcrossRanks
+        if print_config:
+            for idx, c in enumerate(all_configs):
+                print("PASS", idx, c)
+
+
+def print_with_rank(*args: object, **kwargs: object) -> None:
+    if dist.is_initialized():
+        print(f"Rank{dist.get_rank()}: ", end="")
+    print(*args, **kwargs)  # pyrefly: ignore[no-matching-overload]
+
+
 @dataclass
 class SeedEnsemble:
     torch_seed: int
@@ -161,3 +225,11 @@ def all_gather_object(obj: T) -> list[T]:
     object_list = [None] * dist.get_world_size()
     dist.all_gather_object(object_list, obj)
     return object_list  # pyrefly: ignore
+
+
+def autotune_for_distributed_kernel() -> bool:
+    """
+    Remove this once these issues regarding distributed kernels are fixed:
+    - https://github.com/pytorch/helion/issues/1642
+    """
+    return os.getenv("HELION_AUTOTUNE_FOR_DISTRIBUTED_KERNEL") == "1"

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -39,6 +39,7 @@ import uuid
 
 import torch
 import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
 from torch.utils._pytree import tree_flatten
 from torch.utils._pytree import tree_map_only
 from torch.utils._pytree import tree_unflatten
@@ -47,6 +48,7 @@ from .. import exc
 from .._compat import extract_device
 from .._compat import get_device_name
 from ..runtime.precompile_shim import already_compiled
+from ..runtime.precompile_shim import already_compiled_fail
 from ..runtime.precompile_shim import make_precompiler
 from .benchmarking import do_bench
 from .benchmarking import interleaved_bench
@@ -65,6 +67,9 @@ from .metrics import AutotuneMetrics
 from .metrics import _run_post_autotune_hooks
 from .progress_bar import iter_with_progress
 from helion._utils import all_gather_object
+from helion._utils import get_signal_pad_ptrs_dev
+from helion._utils import is_master_rank
+from helion._utils import is_symm_mem_tensor
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -170,8 +175,22 @@ class BenchmarkResult(NamedTuple):
     config: Config
     fn: Callable[..., object]
     perf: float
-    status: Literal["ok", "error", "timeout"]
+    status: Literal["ok", "error", "timeout", "peer_compilation_fail"]
     compile_time: float | None
+
+
+def _clone_symm_mem_tensor(t: torch.Tensor) -> torch.Tensor:
+    assert t.is_contiguous(), "Only support cloning contiguous symm mem tensor for now"
+    new_tensor = symm_mem.empty(
+        *t.shape,
+        dtype=t.dtype,
+        device=t.device,
+    )
+    new_tensor.copy_(t)
+    # rendezvous so we don't count the time in benchmarking
+    assert dist.group.WORLD is not None
+    symm_mem.rendezvous(new_tensor, dist.group.WORLD.group_name)
+    return new_tensor
 
 
 _FP8_DTYPES = {
@@ -206,6 +225,11 @@ def _assert_close(actual: object, expected: object, atol: float, rtol: float) ->
     for a, e in zip(actual_flat, expected_flat, strict=True):
         if isinstance(a, torch.Tensor):
             _chunked_assert_close(a, e, atol=atol, rtol=rtol)
+        elif isinstance(a, str):
+            if not isinstance(e, str):
+                raise AssertionError(f"Type mismatch {a} vs {e}")
+            if a != e:
+                raise AssertionError(f"string mismatch {a} vs {e}")
         else:
             torch.testing.assert_close(a, e, atol=atol, rtol=rtol)
 
@@ -243,16 +267,30 @@ def _clone_args(
       idx_to_clone. If idx_to_clone is None, clone all tensors.
     """
 
+    def _should_clone(idx: int) -> bool:
+        return idx_to_clone is None or idx in idx_to_clone
+
     args_flat, tree_spec = tree_flatten(args)
-    tensor_idx = 0
+    old_arg_to_new_arg = {}
+
     for i, arg in enumerate(args_flat):
+        if _should_clone(i) and is_symm_mem_tensor(arg):
+            new_arg = _clone_symm_mem_tensor(arg)
+            old_arg_to_new_arg[get_signal_pad_ptrs_dev(arg)] = get_signal_pad_ptrs_dev(
+                new_arg
+            )
+            old_arg_to_new_arg[arg] = new_arg  # pyrefly: ignore[unsupported-operation]
+
+    for i, arg in enumerate(args_flat):
+        if arg in old_arg_to_new_arg:
+            args_flat[i] = old_arg_to_new_arg[arg]
+            continue
         if not isinstance(arg, torch.Tensor):
             continue
-        if idx_to_clone is None or tensor_idx in idx_to_clone:
+        if _should_clone(i):
             clone = arg.detach().clone()
             clone.requires_grad_(arg.requires_grad)
             args_flat[i] = clone
-        tensor_idx += 1
 
     return tree_unflatten(args_flat, tree_spec)
 
@@ -515,6 +553,7 @@ class BaseSearch(BaseAutotuner):
     def _validate_against_baseline(
         self, config: Config, output: object, args: Sequence[object]
     ) -> bool:
+
         try:
             custom_check = self.settings.autotune_baseline_accuracy_check_fn
             if custom_check is not None:
@@ -528,13 +567,18 @@ class BaseSearch(BaseAutotuner):
                     atol=self._effective_atol,
                     rtol=self._effective_rtol,
                 )
-                if len(self._mutated_arg_indices) > 0:
-                    _assert_close(
-                        args,
-                        self._baseline_post_args,
-                        atol=self._effective_atol,
-                        rtol=self._effective_rtol,
-                    )
+                if os.getenv("CHECK_INPUT_ACCURACY", "1") == "1":
+                    if len(self._mutated_arg_indices) > 0:
+                        # For distributed kernel, group_name may also be a argument.
+                        # torch.testing.assert_close does not handle str argument.
+                        # Filter needed.
+                        assert self._baseline_post_args is not None
+                        _assert_close(
+                            args,
+                            self._baseline_post_args,
+                            atol=self._effective_atol,
+                            rtol=self._effective_rtol,
+                        )
         except AssertionError as e:
             if not self.settings.autotune_ignore_errors:
                 self.log.warning(
@@ -618,14 +662,24 @@ class BaseSearch(BaseAutotuner):
             self.log.debug(lambda: f"Running {config} at {datetime.datetime.now()}")
             t0 = time.perf_counter()
             torch.accelerator.synchronize()
+
             with _capture_ctx as _captured_output:
                 output = fn(*working_args)  # make sure the kernel is compiled
+
             torch.accelerator.synchronize()
-            if (
-                self.settings.autotune_accuracy_check
-                and not self._validate_against_baseline(config, output, working_args)
-            ):
+
+            pass_accuracy_check = (
+                not self.settings.autotune_accuracy_check
+                or self._validate_against_baseline(config, output, working_args)
+            )
+            if not pass_accuracy_check:
                 self._autotune_metrics.num_accuracy_failures += 1
+            if not all(all_gather_object(pass_accuracy_check)):
+                # for distributed kernels like matmul-reduce-scatter, different ranks compute
+                # a different chunk. It's possible that some ranks pass the accuracy check while
+                # others don't. Skip the config if any rank fails the accuracy check.
+                # Without this synchronization, some ranks go on to call the benchmark function
+                # while other ranks return immediately, this will cause stuck jobs!
                 return inf
 
             t1 = time.perf_counter()
@@ -642,6 +696,7 @@ class BaseSearch(BaseAutotuner):
             res = sync_object(res)
             t2 = time.perf_counter()
             assert isinstance(res, float)
+
             self.log.debug(
                 lambda: f"result: {res:.4f}ms (took {t1 - t0:.1f}s + {t2 - t1:.1f}s)",
             )
@@ -903,8 +958,8 @@ class BaseSearch(BaseAutotuner):
                 )
             else:
                 compile_time = None
-            status: Literal["ok", "error", "timeout"]
-            if is_working:
+            status: Literal["ok", "error", "timeout", "peer_compilation_fail"]
+            if all(all_gather_object(is_working)):
                 # Log started before benchmarking to help identify hangs
                 self.log.record_autotune_entry(
                     AutotuneLogEntry(
@@ -939,6 +994,8 @@ class BaseSearch(BaseAutotuner):
                 )
             else:
                 status = "timeout" if reason == "timeout" else "error"
+                if is_working:
+                    status = "peer_compilation_fail"
                 results.append(
                     BenchmarkResult(
                         config=config,
@@ -988,6 +1045,7 @@ class BaseSearch(BaseAutotuner):
                 self._finalize_autotune_metrics()
         end = time.perf_counter()
         kernel_decorator = self.kernel.format_kernel_decorator(best, self.settings)
+
         self.log(
             f"Autotuning complete in {end - start:.1f}s after searching {self._autotune_metrics.num_configs_tested} configs.\n"
             "One can hardcode the best config and skip autotuning with:\n"
@@ -995,7 +1053,7 @@ class BaseSearch(BaseAutotuner):
             level=logging.INFO + 5,
         )
         cached_path = self.kernel.get_cached_path(best)
-        if cached_path is not None:
+        if cached_path is not None and is_master_rank():
             self.log(f"Code of selected kernel: {cached_path}")
         self.kernel.maybe_log_repro(self.log.warning, self.args, best)
         if self.settings.print_output_code:
@@ -1076,7 +1134,9 @@ class PopulationMember:
     perfs: list[float]
     flat_values: FlatConfig
     config: Config
-    status: Literal["ok", "error", "timeout", "unknown"] = "unknown"
+    status: Literal["ok", "error", "timeout", "peer_compilation_fail", "unknown"] = (
+        "unknown"
+    )
     compile_time: float | None = None
 
     @property
@@ -1399,6 +1459,8 @@ class PopulationBasedSearch(BaseSearch):
             else 1000
         )
         repeat = min(1000, max(3, base_repeat))
+        if (capstr := os.getenv("HELION_CAP_REBENCHMARK_REPEAT")) is not None:
+            repeat = min(repeat, int(capstr))
         if len(self._mutated_arg_indices) > 0:
             bench_args = _clone_args(self.args, idx_to_clone=self._mutated_arg_indices)
         else:
@@ -2076,9 +2138,11 @@ def _triton_compile(
             config,
             cast("BoundKernel", kernel),
         )(*extracted.args, **extracted.kwargs)
-        if precompiler is not already_compiled:
-            return precompiler(False)  # pyrefly: ignore[bad-argument-count]
-        return True
+        if precompiler is already_compiled:
+            return True
+        if precompiler is already_compiled_fail:
+            return False
+        return precompiler(False)  # pyrefly: ignore[bad-argument-count]
     except Exception:
         return False
 

--- a/helion/autotuner/config_generation.py
+++ b/helion/autotuner/config_generation.py
@@ -12,6 +12,7 @@ from .._compat import warps_to_threads
 from .config_fragment import Category
 from .config_fragment import ConfigSpecFragment
 from .config_fragment import PowerOfTwoFragment
+from helion._utils import sync_seed
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -193,9 +194,10 @@ class ConfigGeneration:
         Returns:
             A random flat configuration.
         """
-        config = [spec.random() for spec in self.flat_spec]
-        self.shrink_config(config, PowerOfTwoFragment(1, 2048, 32).random())
-        return config
+        with sync_seed():
+            config = [spec.random() for spec in self.flat_spec]
+            self.shrink_config(config, PowerOfTwoFragment(1, 2048, 32).random())
+            return config
 
     def random_config(self) -> Config:
         return self.unflatten(self.random_flat())

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -8,6 +8,7 @@ from typing import Any
 from typing import cast
 
 from torch._inductor.runtime.runtime_utils import next_power_of_2
+import torch.distributed as dist
 
 from .._compat import supports_amd_cdna_tunables
 from .._compat import supports_maxnreg
@@ -27,6 +28,7 @@ from .config_fragment import PermutationFragment
 from .config_fragment import PowerOfTwoFragment
 from .config_fragment import assert_integer_power_of_two
 import helion
+from helion._utils import autotune_for_distributed_kernel
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -717,8 +719,16 @@ class BlockSizeSpec(_PowerOfTwoBlockIdItem):
     ) -> None:
         super().__init__([block_id])
         self.size_hint = size_hint
+
+        # TODO(shunting): it's a bit conservative since not every block is split
+        # for different ranks.
+        bounded_hint = size_hint
+        if dist.is_initialized():
+            world_size = dist.get_world_size()
+            bounded_hint = bounded_hint // world_size
+
+        bounded_hint = max(bounded_hint, 1)
         self.min_size: int = min_size
-        bounded_hint = max(size_hint, 1)
         self.max_size: int = (
             next_power_of_2(bounded_hint) if max_size is None else max_size
         )
@@ -842,6 +852,9 @@ class ReductionLoopSpec(_PowerOfTwoBlockIdItem):
                 default = min(default, base.max_reduction_threads)
         value = fn(BlockSizeFragment(low, high, default))
         assert isinstance(value, int)
+        if autotune_for_distributed_kernel():
+            # workaround https://github.com/pytorch/helion/issues/1642
+            return None
 
         if not (low <= value <= high):
             raise InvalidConfig(

--- a/helion/autotuner/de_surrogate_hybrid.py
+++ b/helion/autotuner/de_surrogate_hybrid.py
@@ -32,6 +32,7 @@ from typing import Any
 
 from .differential_evolution import DifferentialEvolutionSearch
 from .effort_profile import DIFFERENTIAL_EVOLUTION_DEFAULTS
+from helion._utils import sync_seed
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -234,59 +235,61 @@ class DESurrogateHybrid(DifferentialEvolutionSearch):
 
     def _generate_de_candidates(self, n_candidates: int) -> list[FlatConfig]:
         """Generate candidates using standard DE mutation/crossover."""
-        candidates = []
+        with sync_seed():
+            candidates = []
 
-        for _ in range(n_candidates):
-            # Select four distinct individuals: x (base), and a, b, c for mutation
-            x, a, b, c = random.sample(self.population, 4)
+            for _ in range(n_candidates):
+                # Select four distinct individuals: x (base), and a, b, c for mutation
+                x, a, b, c = random.sample(self.population, 4)
 
-            # Differential mutation: x + F(a - b + c)
-            trial = self.config_gen.differential_mutation(
-                x.flat_values,
-                a.flat_values,
-                b.flat_values,
-                c.flat_values,
-                crossover_rate=self.crossover_rate,
-            )
+                # Differential mutation: x + F(a - b + c)
+                trial = self.config_gen.differential_mutation(
+                    x.flat_values,
+                    a.flat_values,
+                    b.flat_values,
+                    c.flat_values,
+                    crossover_rate=self.crossover_rate,
+                )
 
-            candidates.append(trial)
+                candidates.append(trial)
 
-        return candidates
+            return candidates
 
     def _fit_surrogate(self) -> None:
         """Fit Random Forest surrogate model on all observations."""
         if len(self.all_observations) < 10:
             return  # Need minimum data
 
-        # Encode configs to numeric arrays
-        X = []
-        y = []
+        with sync_seed():
+            # Encode configs to numeric arrays
+            X = []
+            y = []
 
-        for config, perf in self.all_observations:
-            try:
-                encoded = self.config_gen.encode_config(config)
-                X.append(encoded)
-                y.append(perf)
-            except Exception:
-                continue
+            for config, perf in self.all_observations:
+                try:
+                    encoded = self.config_gen.encode_config(config)
+                    X.append(encoded)
+                    y.append(perf)
+                except Exception:
+                    continue
 
-        if len(X) < 10:
-            return
+            if len(X) < 10:
+                return
 
-        X_array = np.array(X)  # type: ignore[union-attr]
-        y_array = np.array(y)  # type: ignore[union-attr]
+            X_array = np.array(X)  # type: ignore[union-attr]
+            y_array = np.array(y)  # type: ignore[union-attr]
 
-        # Fit Random Forest
-        surrogate = RandomForestRegressor(  # type: ignore[misc]
-            n_estimators=self.n_estimators,
-            max_depth=15,
-            min_samples_split=5,
-            min_samples_leaf=2,
-            random_state=42,
-            n_jobs=-1,
-        )
-        surrogate.fit(X_array, y_array)
-        self.surrogate = surrogate
+            # Fit Random Forest
+            surrogate = RandomForestRegressor(  # type: ignore[misc]
+                n_estimators=self.n_estimators,
+                max_depth=15,
+                min_samples_split=5,
+                min_samples_leaf=2,
+                random_state=42,
+                n_jobs=-1,
+            )
+            surrogate.fit(X_array, y_array)
+            self.surrogate = surrogate
 
     def _surrogate_select(
         self, candidates: list[FlatConfig], n_select: int
@@ -303,7 +306,8 @@ class DESurrogateHybrid(DifferentialEvolutionSearch):
         """
         if self.surrogate is None:
             # Fallback: random selection
-            return random.sample(candidates, min(n_select, len(candidates)))
+            with sync_seed():
+                return random.sample(candidates, min(n_select, len(candidates)))
 
         # Predict performance for all candidates
         predictions = []

--- a/helion/autotuner/differential_evolution.py
+++ b/helion/autotuner/differential_evolution.py
@@ -9,6 +9,7 @@ from .base_search import performance
 from .base_search import population_statistics
 from .effort_profile import DIFFERENTIAL_EVOLUTION_DEFAULTS
 from .pattern_search import InitialPopulationStrategy
+from helion._utils import sync_seed
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -81,18 +82,19 @@ class DifferentialEvolutionSearch(PopulationBasedSearch):
         self.generations_without_improvement = 0
 
     def mutate(self, x_index: int) -> FlatConfig:
-        a, b, c, *_ = [
-            self.population[p]
-            for p in random.sample(range(len(self.population)), 4)
-            if p != x_index
-        ]
-        return self.config_gen.differential_mutation(
-            self.population[x_index].flat_values,
-            a.flat_values,
-            b.flat_values,
-            c.flat_values,
-            self.crossover_rate,
-        )
+        with sync_seed():
+            a, b, c, *_ = [
+                self.population[p]
+                for p in random.sample(range(len(self.population)), 4)
+                if p != x_index
+            ]
+            return self.config_gen.differential_mutation(
+                self.population[x_index].flat_values,
+                a.flat_values,
+                b.flat_values,
+                c.flat_values,
+                self.crossover_rate,
+            )
 
     def _generate_initial_population_flat(self) -> list[FlatConfig]:
         """

--- a/helion/autotuner/logger.py
+++ b/helion/autotuner/logger.py
@@ -27,6 +27,8 @@ from typing_extensions import Self
 from torch._inductor.runtime.triton_compat import OutOfResources
 from torch._inductor.runtime.triton_compat import PTXASError
 
+from helion._utils import is_master_rank
+
 if TYPE_CHECKING:
     from _csv import _writer as CsvWriter
     import io
@@ -176,7 +178,7 @@ class AutotuningLogger:
             exc_info: Optional exception info forwarded to ``logging.Logger``.
             stacklevel: Optional stack level forwarded to ``logging.Logger``.
         """
-        if level >= self.level:
+        if level >= self.level and is_master_rank():
             message = " ".join(map(_maybe_call, msg))
             if stacklevel is not None:
                 if exc_info is not None:

--- a/helion/autotuner/pattern_search.py
+++ b/helion/autotuner/pattern_search.py
@@ -35,6 +35,8 @@ class InitialPopulationStrategy(enum.Enum):
 class PatternSearch(PopulationBasedSearch):
     """Search that explores single-parameter perturbations around the current best."""
 
+    num_neighbors_cap: int = -1
+
     def __init__(
         self,
         kernel: _AutotunableKernel,
@@ -218,6 +220,11 @@ class PatternSearch(PopulationBasedSearch):
             and abs(best.perf / current.perf - 1.0) < self.min_improvement_delta
         )
 
+    def shrink_neighbors(self, neighbors: list[FlatConfig]) -> list[FlatConfig]:
+        if self.num_neighbors_cap > 0:
+            return neighbors[: self.num_neighbors_cap]
+        return neighbors
+
     def _generate_neighbors(self, base: FlatConfig) -> list[FlatConfig]:
         """
         Generate neighboring configurations by changing one or two parameters at a time.
@@ -253,4 +260,4 @@ class PatternSearch(PopulationBasedSearch):
                         new_flat[second] = second_value
                         neighbors.append(new_flat)
 
-        return neighbors
+        return self.shrink_neighbors(neighbors)

--- a/helion/autotuner/progress_bar.py
+++ b/helion/autotuner/progress_bar.py
@@ -18,6 +18,8 @@ from rich.progress import TextColumn
 from rich.text import Text
 import torch
 
+from helion._utils import is_master_rank
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from collections.abc import Iterator
@@ -54,7 +56,7 @@ def iter_with_progress(
         When ``False`` the iterable is returned unchanged so there is zero
         overhead; when ``True`` a Rich progress bar is rendered.
     """
-    if (not enabled) or torch._utils_internal.is_fb_unit_test():
+    if (not enabled) or torch._utils_internal.is_fb_unit_test() or not is_master_rank():
         yield from iterable
         return
 

--- a/helion/autotuner/surrogate_pattern_search.py
+++ b/helion/autotuner/surrogate_pattern_search.py
@@ -12,6 +12,7 @@ from .base_search import performance
 from .effort_profile import PATTERN_SEARCH_DEFAULTS
 from .pattern_search import InitialPopulationStrategy
 from .pattern_search import PatternSearch
+from helion._utils import sync_seed
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -268,7 +269,8 @@ class LFBOPatternSearch(PatternSearch):
         surrogate: RandomForestClassifier | None = self.surrogate
         if surrogate is None:
             # If surrogate is None, scores are random
-            scores = [random.random() for _ in range(n_samples)]
+            with sync_seed():
+                scores = [random.random() for _ in range(n_samples)]
         else:
             proba = np.asarray(surrogate.predict_proba(candidate_X))[:, 1]
 
@@ -371,8 +373,10 @@ class LFBOPatternSearch(PatternSearch):
         self._fit_surrogate()
 
         search_copies = [
-            self._pruned_pattern_search_from(m, visited) for m in starting_points
+            self._pruned_pattern_search_from(idx, m, visited)
+            for idx, m in enumerate(starting_points)
         ]
+
         for generation in range(1, self.max_generations + 1):
             prior_best = self.best
             new_population = {id(prior_best): prior_best}
@@ -387,6 +391,9 @@ class LFBOPatternSearch(PatternSearch):
                     for member in added:
                         new_population[id(member)] = member
             if num_active == 0:
+                self.log(
+                    f"Autotuning stop at generation {generation} because of no active search path"
+                )
                 break
 
             # Log generation header before compiling/benchmarking
@@ -409,13 +416,16 @@ class LFBOPatternSearch(PatternSearch):
             # Log final statistics for this generation
             self.log(f"Generation {generation} complete:", self.statistics)
 
-            # Update training data
-            for member in self.population:
-                self.train_x.append(self.config_gen.encode_config(member.flat_values))
-                self.train_y.append(member.perf)
-
-            # Fit model
-            self._fit_surrogate()
+            # no need to retrain the model for the last generation
+            if generation != self.max_generations:
+                # Update training data
+                for member in self.population:
+                    self.train_x.append(
+                        self.config_gen.encode_config(member.flat_values)
+                    )
+                    self.train_y.append(member.perf)
+                # Fit model
+                self._fit_surrogate()
 
         # Run finishing phase to simplify the best configuration
         best = self.run_finishing_phase(self.best, self.finishing_rounds)
@@ -494,10 +504,11 @@ class LFBOPatternSearch(PatternSearch):
             if new_flat != base:
                 neighbors.append(new_flat)
 
-        return neighbors
+        return self.shrink_neighbors(neighbors)
 
     def _pruned_pattern_search_from(
         self,
+        copy_idx: int,
         current: PopulationMember,
         visited: set[Config],
     ) -> Iterator[list[PopulationMember]]:
@@ -520,7 +531,8 @@ class LFBOPatternSearch(PatternSearch):
         patience = self.patience
         for _ in range(self.max_generations):
             candidates: list[PopulationMember] = [current]
-            all_neighbors = self._generate_neighbors(current.flat_values)
+            with sync_seed():
+                all_neighbors = self._generate_neighbors(current.flat_values)
             for flat_config in all_neighbors:
                 new_member = self.make_unbenchmarked(flat_config)
                 if new_member.config not in visited:
@@ -532,6 +544,7 @@ class LFBOPatternSearch(PatternSearch):
             candidates = self._surrogate_select(candidates, n_sorted)
 
             if len(candidates) <= 1:
+                self.log(f"Copy {copy_idx} finish because of no candidates")
                 return  # no new candidates, stop searching
             yield candidates  # yield new population to benchmark in parallel
             best = min(candidates, key=performance)
@@ -539,6 +552,7 @@ class LFBOPatternSearch(PatternSearch):
                 if patience > 0:
                     patience -= 1
                 else:
+                    self.log(f"Copy {copy_idx} finish because of no improvement")
                     return
             current = best
 

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -47,6 +47,7 @@ from .._compiler.output_header import assert_no_conflicts
 from .._compiler.output_header import get_needed_imports
 from .._compiler.variable_origin import ArgumentOrigin
 from .._logging import LazyString
+from .._utils import check_config_consistancy as dist_check_config_consistancy
 from .._utils import counters
 from ..autotuner.base_search import _AutotunableKernel
 from ..language.constexpr import ConstExpr
@@ -559,6 +560,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                 # pyrefly: ignore [bad-argument-type]
                 **config
             )
+        dist_check_config_consistancy(config)
         if (rv := self._compile_cache.get(config)) is not None:
             return rv
         if (

--- a/helion/runtime/precompile_shim.py
+++ b/helion/runtime/precompile_shim.py
@@ -13,10 +13,23 @@ from ..autotuner.logger import format_triton_compile_failure
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from triton.compiler.compiler import CompiledKernel
     from triton.runtime.jit import JITFunction
 
     from .config import Config
     from .kernel import BoundKernel
+
+
+def _set_helion_compilation_success(kernel: CompiledKernel, status: bool) -> None:
+    """
+    Instead of always assuming cached kernel being properly compiled,
+    attach a flag to indicate if there is any compilation failure.
+    """
+    kernel._helion_compilation_success = status  # pyrefly: ignore[missing-attribute]
+
+
+def _get_helion_compilation_success(kernel: CompiledKernel) -> bool:
+    return getattr(kernel, "_helion_compilation_success", True)
 
 
 def make_precompiler(
@@ -42,7 +55,11 @@ def make_precompiler(
         key = str(specialization) + str(options)
         kernel = kernel_cache.get(key, None)
         if kernel is not None:
-            return already_compiled  # cache hit
+            return (
+                already_compiled
+                if _get_helion_compilation_success(kernel)
+                else already_compiled_fail
+            )  # cache hit
 
         options = backend.parse_options(kwargs)
         sigkeys = [x.name for x in fn.params]
@@ -71,10 +88,12 @@ def make_precompiler(
             src = fn.ASTSource(fn, signature, constexprs, attrs)
             # here we update the cache so if this is called in the parent we skip a extra compile
 
+            compiled_kernel = None
             try:
                 kernel_cache[key] = compiled_kernel = fn.compile(
                     src, target=target, options=options.__dict__
                 )
+                _set_helion_compilation_success(compiled_kernel, True)
                 if not in_child_process:
                     compiled_kernel._init_handles()
             except Exception as e:
@@ -84,6 +103,8 @@ def make_precompiler(
                         format_triton_compile_failure(config, e, bound_kernel),
                         file=sys.stderr,
                     )
+                if compiled_kernel is not None:
+                    _set_helion_compilation_success(compiled_kernel, False)
                 if in_child_process:
                     sys.exit(1)
                 return False
@@ -96,3 +117,7 @@ def make_precompiler(
 
 def already_compiled() -> bool:
     return True
+
+
+def already_compiled_fail() -> bool:
+    return False

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -259,6 +259,7 @@ def default_autotuner_fn(
 ) -> BaseAutotuner:
     from ..autotuner import cache_classes
     from ..autotuner import search_algorithms
+    from ..autotuner.pattern_search import PatternSearch
 
     autotuner_name = _env_get_str("HELION_AUTOTUNER", "LFBOTreeSearch")
     autotuner_cls = search_algorithms.get(autotuner_name)
@@ -349,6 +350,12 @@ def default_autotuner_fn(
     if hasattr(autotuner, "finishing_rounds"):
         # pyrefly: ignore[missing-attribute]
         autotuner.finishing_rounds = finishing_rounds
+
+    if isinstance(autotuner, PatternSearch):
+        # pyrefly: ignore[missing-attribute]
+        autotuner.num_neighbors_cap = _env_get_int(
+            "HELION_CAP_AUTOTUNE_NUM_NEIGHBORS", -1
+        )
     return cache_cls(autotuner)
 
 

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -1,24 +1,109 @@
 from __future__ import annotations
 
+import contextlib
 from datetime import timedelta
+import os
+import unittest
 
 import torch
 from torch import Tensor
+from torch._C._distributed_c10d import _SymmetricMemory
 import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
 from torch.testing._internal.common_distributed import MultiProcessTestCase
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_utils import instantiate_parametrized_tests
+from torch.testing._internal.common_utils import parametrize
 from torch.testing._internal.common_utils import run_tests
 
+import helion
+from helion._testing import EXAMPLES_DIR
 from helion._testing import TestCase
+from helion._testing import import_path
 from helion._testing import onlyBackends
 from helion._testing import skipIfRocm
 from helion._testing import skipIfXPU
 from helion._utils import all_gather_object
 from helion._utils import sync_seed
+from helion.autotuner import search_algorithms
+from helion.autotuner.effort_profile import _PROFILES
+from helion.autotuner.effort_profile import AutotuneEffortProfile
+from helion.autotuner.effort_profile import DifferentialEvolutionConfig
+from helion.autotuner.effort_profile import PatternSearchConfig
+from helion.autotuner.effort_profile import RandomSearchConfig
+import helion.language as hl
+
+autotuner_names = ["fixed", *search_algorithms]
+
+
+def one_shot_allreduce_kernel(
+    a_shared: torch.Tensor,
+    my_rank: hl.constexpr,
+    group_name: hl.constexpr,
+    WORLD_SIZE: hl.constexpr,
+) -> torch.Tensor:
+    out = torch.empty_like(a_shared)
+    N = out.size(0)
+    a_shared_tuple = torch.ops.symm_mem.get_remote_tensors(a_shared, group_name)
+
+    for tile_n in hl.tile(N):
+        acc = hl.zeros([tile_n], dtype=a_shared.dtype, device=a_shared.device)
+
+        for a in a_shared_tuple:
+            acc += a[tile_n]
+
+        out[tile_n] = acc
+    return out
+
+
+# make it easy to use a 'smaller' profile than 'quick' in unit test
+pattern_search_config = PatternSearchConfig(
+    initial_population=6,
+    copies=2,
+    max_generations=3,
+)
+
+differential_evolution_config = DifferentialEvolutionConfig(
+    population_size=10,
+    max_generations=5,
+)
+
+random_search_config = RandomSearchConfig(
+    count=20,
+)
+
+profile = AutotuneEffortProfile(
+    pattern_search=pattern_search_config,
+    lfbo_pattern_search=pattern_search_config,
+    differential_evolution=differential_evolution_config,
+    random_search=random_search_config,
+)
 
 
 @onlyBackends(["triton"])
+@instantiate_parametrized_tests
 class TestDistributed(TestCase, MultiProcessTestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls._class_stack = contextlib.ExitStack()
+        cls._class_stack.enter_context(
+            unittest.mock.patch.dict(
+                os.environ,
+                {
+                    "HELION_DIST_CHECK_CONFIG_CONSISTANCY": "1",
+                    "HELION_CAP_AUTOTUNE_NUM_NEIGHBORS": "50",
+                    "HELION_CAP_REBENCHMARK_REPEAT": "50",
+                    "HELION_AUTOTUNE_FOR_DISTRIBUTED_KERNEL": "1",
+                },
+            )
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._class_stack.close()
+        super().tearDownClass()
+
     def setUp(self) -> None:
         super().setUp()
         self._spawn_processes()
@@ -31,13 +116,20 @@ class TestDistributed(TestCase, MultiProcessTestCase):
 
     @property
     def world_size(self) -> int:
-        return 4
+        return int(os.getenv("TEST_WORLD_SIZE", "4"))
 
     @property
     def device(self) -> torch.device:
         return torch.device(f"cuda:{self.rank}")
 
     def _init_process(self):
+        self._exit_stack = contextlib.ExitStack()
+        self._exit_stack.enter_context(
+            unittest.mock.patch.dict(
+                _PROFILES,
+                {"full": profile},
+            )
+        )
         torch.cuda.set_device(self.device)
         store = dist.FileStore(self.file_name, self.world_size)
         dist.init_process_group(
@@ -45,6 +137,7 @@ class TestDistributed(TestCase, MultiProcessTestCase):
             world_size=self.world_size,
             rank=self.rank,
             store=store,
+            device_id=self.rank,
         )
         torch.distributed.distributed_c10d._set_pg_timeout(
             timedelta(seconds=60), dist.group.WORLD
@@ -52,6 +145,7 @@ class TestDistributed(TestCase, MultiProcessTestCase):
         torch.manual_seed(42 + self.rank)
 
     def _cleanup_process(self):
+        self._exit_stack.close()
         torch.cuda.synchronize()
         dist.barrier()
         dist.destroy_process_group()
@@ -83,6 +177,239 @@ class TestDistributed(TestCase, MultiProcessTestCase):
         self.assertFalse(_all_eq(xlist))
 
         self._cleanup_process()
+
+    @skipIfRocm("Distributed example requires CUDA/NCCL")
+    @skipIfXPU("Distributed operations require CCL, not yet fully integrated")
+    @skip_if_lt_x_gpu(4)
+    @parametrize("autotuner", autotuner_names)
+    def test_allreduce(self, autotuner):
+        self._init_process()
+        if autotuner == "fixed":
+            kernel = helion.kernel(
+                config=helion.Config(
+                    block_sizes=[8192],
+                    num_warps=32,
+                ),
+                ignore_warnings=[helion.exc.TensorOperationInWrapper],
+            )(one_shot_allreduce_kernel)
+            context = contextlib.nullcontext()
+        elif autotuner == "FiniteSearch":
+            kernel = helion.kernel(
+                configs=[
+                    helion.Config(block_sizes=[8192], num_warps=16),
+                    helion.Config(block_sizes=[4096], num_warps=16),
+                ],
+                ignore_warnings=[helion.exc.TensorOperationInWrapper],
+            )(one_shot_allreduce_kernel)
+            context = unittest.mock.patch.dict(
+                os.environ, {"HELION_AUTOTUNER": autotuner}
+            )
+        else:
+            kernel = helion.kernel(
+                one_shot_allreduce_kernel,
+                ignore_warnings=[helion.exc.TensorOperationInWrapper],
+            )
+            context = unittest.mock.patch.dict(
+                os.environ, {"HELION_AUTOTUNER": autotuner}
+            )
+
+        with context:
+            self.do_test_allreduce(kernel)
+
+        self._cleanup_process()
+
+    def do_test_allreduce(self, kernel):
+        group = dist.group.WORLD
+
+        N = 16384
+        dtype = torch.bfloat16
+
+        a_shared = symm_mem.empty(N, dtype=dtype, device=self.device).normal_()
+
+        symm_mem_hdl = symm_mem.rendezvous(a_shared, group=group)
+
+        result = kernel(
+            a_shared,
+            symm_mem_hdl.rank,
+            group.group_name,
+            symm_mem_hdl.world_size,
+        )
+
+        torch.cuda.synchronize()
+
+        expected = torch.empty_like(result).copy_(a_shared)
+        dist.all_reduce(expected, op=dist.ReduceOp.SUM)
+
+        torch.testing.assert_close(result, expected, rtol=1e-1, atol=1e-1)
+
+    @skipIfRocm("Distributed example requires CUDA/NCCL")
+    @skipIfXPU("Distributed operations require CCL, not yet fully integrated")
+    @skip_if_lt_x_gpu(4)
+    @parametrize(
+        "kernel_name",
+        (
+            "one_shot_allreduce_bias_rmsnorm_kernel",
+            "two_shot_allreduce_bias_rmsnorm_kernel",
+        ),
+    )
+    @parametrize("autotuner", autotuner_names)
+    def test_allreduce_bias_rmsnorm(self, kernel_name, autotuner):
+        """
+        There is a similar test in test/test_examples_dist.py.
+        The current test focus more on autotuning functionality.
+        """
+        self._init_process()
+        mod = import_path(EXAMPLES_DIR / "distributed" / "allreduce_bias_rmsnorm.py")
+
+        kernel = getattr(mod, kernel_name).fn
+        if autotuner == "fixed":
+            fixed_config = helion.Config(
+                block_sizes=[8],
+                num_warps=8,
+            )
+
+            kernel = helion.kernel(
+                config=fixed_config,
+                ignore_warnings=[helion.exc.TensorOperationInWrapper],
+            )(kernel)
+            context = contextlib.nullcontext()
+        elif autotuner == "FiniteSearch":
+            kernel = helion.kernel(
+                configs=[
+                    helion.Config(block_sizes=[8], num_warps=8),
+                    helion.Config(block_sizes=[8], num_warps=4),
+                ],
+                ignore_warnings=[helion.exc.TensorOperationInWrapper],
+            )(kernel)
+            context = unittest.mock.patch.dict(
+                os.environ, {"HELION_AUTOTUNER": autotuner}
+            )
+        else:
+            kernel = helion.kernel(
+                kernel, ignore_warnings=[helion.exc.TensorOperationInWrapper]
+            )
+            context = unittest.mock.patch.dict(
+                os.environ, {"HELION_AUTOTUNER": autotuner}
+            )
+
+        with context:
+            self.do_test_allreduce_bias_rmsnorm(
+                kernel, mod.reference_allreduce_bias_rmsnorm
+            )
+
+        self._cleanup_process()
+
+    def do_test_allreduce_bias_rmsnorm(self, kernel, ref_kernel):
+        N, D = 128, 4096
+        eps = 1e-5
+        x = torch.randn(N, D, device=self.device)
+        symm_mem_buffer = symm_mem.empty(N, D, device=self.device)
+        symm_mem_hdl = symm_mem.rendezvous(symm_mem_buffer, dist.group.WORLD.group_name)
+        torch.manual_seed(42)
+        bias = torch.randn(D, device=self.device)
+        weight = torch.randn(D, device=self.device)
+
+        result = kernel(
+            symm_mem_buffer,
+            x,
+            bias,
+            weight,
+            symm_mem_hdl.signal_pad_ptrs_dev,
+            eps,
+            symm_mem_hdl.rank,
+            symm_mem_hdl.world_size,
+            dist.group.WORLD.group_name,
+        )
+
+        expected = ref_kernel(x, bias, weight)
+        torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
+
+    @skipIfRocm("Distributed example requires CUDA/NCCL")
+    @skipIfXPU("Distributed operations require CCL, not yet fully integrated")
+    @skip_if_lt_x_gpu(4)
+    @parametrize("autotuner", autotuner_names)
+    def test_matmul_reduce_scatter(self, autotuner):
+        self._init_process()
+
+        mod = import_path(EXAMPLES_DIR / "distributed" / "matmul_reduce_scatter.py")
+
+        kernel = mod.matmul_reduce_scatter_kernel.fn
+        _SymmetricMemory.signal_pad_size = 1024 * 1024 * 16
+        if autotuner == "fixed":
+            # small block on purpose to test large grid
+            fixed_config = helion.Config(
+                block_sizes=[2, 2, 32],
+                num_warps=8,
+                num_stages=3,
+                indexing="block_ptr",
+            )
+
+            kernel = helion.kernel(
+                config=fixed_config,
+                ignore_warnings=[helion.exc.TensorOperationInWrapper],
+            )(kernel)
+            context = contextlib.nullcontext()
+        elif autotuner == "FiniteSearch":
+            kernel = helion.kernel(
+                configs=[
+                    helion.Config(
+                        block_sizes=[64, 64, 32],
+                        num_warps=8,
+                        num_stages=3,
+                        indexing="block_ptr",
+                    ),
+                    helion.Config(
+                        block_sizes=[64, 64, 32],
+                        num_warps=4,
+                        num_stages=3,
+                        indexing="block_ptr",
+                    ),
+                ],
+                ignore_warnings=[helion.exc.TensorOperationInWrapper],
+            )(kernel)
+            context = unittest.mock.patch.dict(
+                os.environ, {"HELION_AUTOTUNER": autotuner}
+            )
+        else:
+            kernel = helion.kernel(
+                kernel, ignore_warnings=[helion.exc.TensorOperationInWrapper]
+            )
+            context = unittest.mock.patch.dict(
+                os.environ, {"HELION_AUTOTUNER": autotuner}
+            )
+
+        with context:
+            self.do_test_matmul_reduce_scatter(
+                kernel, mod.reference_matmul_reduce_scatter
+            )
+        self._cleanup_process()
+
+    def do_test_matmul_reduce_scatter(self, kernel, ref_kernel):
+        M, N, K = 512, 768, 1024
+
+        torch.manual_seed(42 + self.rank)
+        a = torch.randn(M, K, device=self.device)
+
+        # Weight matrix is the same across all ranks
+        torch.manual_seed(42)
+        b = torch.randn(K, N, device=self.device)
+
+        symm_mem_buffer = symm_mem.empty(M, N, device=self.device)
+        symm_mem_hdl = symm_mem.rendezvous(symm_mem_buffer, dist.group.WORLD.group_name)
+
+        result = kernel(
+            a,
+            b,
+            symm_mem_buffer,
+            symm_mem_hdl.signal_pad_ptrs_dev,
+            symm_mem_hdl.rank,  # RANK constexpr
+            symm_mem_hdl.world_size,  # WORLD_SIZE constexpr
+            dist.group.WORLD.group_name,  # GROUP_NAME constexpr
+        )
+
+        expected = ref_kernel(a, b)
+
+        torch.testing.assert_close(result, expected, rtol=1e-1, atol=1e-1)
 
 
 if __name__ == "__main__":

--- a/test/test_examples_dist.py
+++ b/test/test_examples_dist.py
@@ -160,24 +160,15 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
         ).normal_()
 
         symm_mem_hdl = symm_mem.rendezvous(a_shared, group=group)
-        local_signal_pad = symm_mem_hdl.get_signal_pad(
-            symm_mem_hdl.rank, dtype=torch.int32
-        ).view(-1, symm_mem_hdl.world_size)
-        signal_pad_addrs = mod.dev_array_to_tensor_short(
-            symm_mem_hdl.signal_pad_ptrs_dev,
-            (symm_mem_hdl.world_size,),
-            dtype=torch.uint64,
-            device=a_shared.device,
-        )
 
         _, result = code_and_output(
             mod.one_shot_all_reduce_kernel,
             (
-                signal_pad_addrs,
-                local_signal_pad,
+                symm_mem_hdl.signal_pad_ptrs_dev,
                 a_shared,
                 symm_mem_hdl.rank,
                 group.group_name,
+                symm_mem_hdl.world_size,
             ),
         )
 
@@ -230,7 +221,7 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
         symm_mem_hdl = symm_mem.rendezvous(symm_mem_buffer, group.group_name)
 
         _, result = code_and_output(
-            mod.one_shot_allreduce_bias_rmsnorm_kernel,
+            getattr(mod, kernel_name),
             (
                 symm_mem_buffer,
                 x,


### PR DESCRIPTION
Stacked PRs:
 * #1800
 * #1799
 * #1797
 * #1770
 * #1791
 * #1772
 * #1771
 * #1753
 * #1750
 * __->__#1532


--- --- ---

The major work to make Helion autotuners supporting distributed kernels is to synchronize properly for different ranks. There are multiple reasons that ranks can go out of sync
- Helion uses its own interleaved_bench to bench multiple kernels or triton's do_bench to bench a single kernel. Both benchmarking functions will decide the number of times to run the kernel based on a time budget and an estimation of a single run of the kernel. The estimation is based on runtime data and can vary across different GPUs. This causes different GPUs to run the kernel different number of times and causes a stuck job.
- Inconsistent accuracy failure. Even for distributed kernels, different rank may compute different results (e.g. reduce_scatter). Some rank may fail the accuracy check while others don't. Without proper sync, the job will get stuck since the former will return early while the latter go on to do the benchmarking
- Inconsistent build timeout. Similar to the inconsistent accuracy failure, if some rank has build timeout while others don't, we need do proper synchronization
- Randomness. Helion autotuner leverages randomness in multiple places. E.g., we initialize a random population to explore; we may randomly update candidates to generate new candidates; we use RandomForest to predict benchmarking results. These all require  syncing random seeds across ranks.  We definitely don't want different GPUs benchmarking different configs at the same time.

Besides synchronization across ranks. There are other special handling for distributed kernels
- Symmetric memory tensors leverage signal pads to synchronize across GPUs. Signal pads size restricts the grid size. We need make sure we don't autotune with excess grid size
- Some Helion kernels (e.g. the example matmul_reduce_scatter.py in Helion repo) have implicit block size requirements. When block size is too large, some rank may fail the accuracy check (can be tricky, see https://github.com/issues/created?issue=pytorch%7Chelion%7C1676 ) while other ranks may have illegal memory access. The current solution is to cap all block-size with 'size // WORLD_SIZE'. But we can be more specific to apply the cap only to the block-size that needs it.