### PR TITLE
[Autotuner] Fix default block sizes hanging for high-dimensional kernels with reduction

### DIFF
--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -613,6 +613,13 @@ class BlockSizeSpec(_PowerOfTwoBlockIdItem):
         )
         if total_ndim <= 2 and reduction_numel <= 128:
             default = 32
+        elif total_ndim >= 3 and reduction_numel > 1:
+            # With 3+ tiled dimensions and a non-trivial reduction/full-slice
+            # dimension, the total tensor numel (default^total_ndim *
+            # reduction_numel) grows quickly and can cause Triton JIT
+            # compilation to hang.  Using 8 keeps this manageable:
+            # e.g. 8^3 * 256 = 131K.
+            default = 8
         elif reduction_numel <= 256:
             default = 16
         else:


### PR DESCRIPTION
When a kernel tiles over 3+ dimensions and also accesses a non-tiled (reduction/full-slice) dimension, the old default block size of 16 caused Triton JIT compilation to hang (e.g. 16^3 * 128 = 524K elements per block). Add a new heuristic in BlockSizeSpec._fragment() that picks default=8 for this case, keeping the total manageable (8^3 * 128 = 65K). Add a regression test based on the original merge_attention_fwd repro with non-contiguous tensor layout.

Fixes https://github.com/pytorch/helion/issues/1354.