### PR TITLE
[Autotuner] Use chunked comparison in autotuner accuracy checks to reduce peak memory

### DIFF
--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -1608,6 +1608,65 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         expected = torch.full([128], 3.0, device=DEVICE)
         torch.testing.assert_close(out, expected)
 
+    @skipIfCpu("Requires CUDA memory tracking")
+    def test_chunked_allclose_memory(self):
+        """Test that autotuning accuracy checks use chunked comparison for large tensors."""
+        import helion.autotuner.base_search as _bs
+
+        numel = 2**26  # 64M float32 elements (~256 MB each)
+
+        config1 = helion.Config(block_sizes=[128], num_warps=4)
+        config2 = helion.Config(block_sizes=[256], num_warps=4)
+
+        @helion.kernel(configs=[config1, config2], autotune_log_level=0)
+        def vec_add(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(a)
+            for tile in hl.tile(a.size()):
+                out[tile] = a[tile] + b[tile]
+            return out
+
+        a = torch.randn(numel, device=DEVICE)
+        b = torch.randn(numel, device=DEVICE)
+
+        # Measure naive baseline: peak memory of torch.testing.assert_close
+        # on tensors of the same size
+        ref_a = torch.randn(numel, device=DEVICE)
+        ref_b = ref_a.clone()
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+        base_mem = torch.cuda.memory_allocated()
+        torch.testing.assert_close(ref_a, ref_b, atol=1e-2, rtol=1e-2)
+        naive_peak = torch.cuda.max_memory_allocated() - base_mem
+        del ref_a, ref_b
+
+        # Patch _assert_close to record peak memory delta during each call
+        real_assert_close = _bs._assert_close
+        peaks: list[int] = []
+
+        def measuring_assert_close(*args, **kwargs):
+            torch.cuda.reset_peak_memory_stats()
+            before = torch.cuda.memory_allocated()
+            real_assert_close(*args, **kwargs)
+            peak = torch.cuda.max_memory_allocated() - before
+            peaks.append(peak)
+
+        with patch.object(_bs, "_assert_close", measuring_assert_close):
+            out = vec_add(a, b)
+
+        # Accuracy check was called at least once
+        self.assertGreater(len(peaks), 0, "Expected _assert_close to be called")
+
+        # Every call's peak memory should be less than naive peak
+        for i, p in enumerate(peaks):
+            self.assertLess(
+                p,
+                naive_peak * 0.5,
+                f"Call {i}: peak {p} should be < 50% of naive {naive_peak}",
+            )
+
+        # Kernel result is correct
+        torch.testing.assert_close(out, a + b)
+
 
 @onlyBackends(["triton"])
 class TestAutotuneRandomSeed(RefEagerTestDisabled, TestCase):


### PR DESCRIPTION
For large tensors, `torch.testing.assert_close` allocates full-size temporaries. This adds `_chunked_assert_close` which processes tensors in chunks, capping peak memory regardless of tensor size. Small tensors skip the reshape and compare directly. Also adds tree structure mismatch detection with descriptive errors.

Part of https://github.com/pytorch/helion/issues/1335.