### PR TITLE
sync bench/rebench result across ranks

### DIFF
--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -13,9 +13,11 @@ from pathlib import Path
 import re
 import sys
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import Callable
 from typing import Generator
 from typing import Sequence
+from typing import TypeVar
 import unittest
 
 import pytest
@@ -39,6 +41,8 @@ if TYPE_CHECKING:
     import types
 
     from .runtime.kernel import Kernel
+
+T = TypeVar("T")
 
 
 def _strip_launcher_args(value: str) -> str:
@@ -834,14 +838,96 @@ def code_and_output(
     return code, result
 
 
-def sync_repeat(repeat: int) -> int:
+def sync_object(obj: T) -> T:
     r"""
     Synchronize the number of repeations across all ranks.
     """
-    object_list = [repeat]
+    if not dist.is_initialized():
+        return obj
+
+    object_list = [obj]
     # use the value from rank 0
     dist.broadcast_object_list(object_list, 0)
     return object_list[0]
+
+
+# This function is copied from triton._testing.do_bench with modification
+# to make sure different ranks run the benchmark for the same number
+# of times.
+def do_bench(
+    fn: Callable[[], Any],
+    warmup: int = 25,
+    rep: int = 100,
+    grad_to_none: torch.Tensor | None = None,
+    quantiles: list[float] | None = None,
+    return_mode: str = "mean",
+) -> float | tuple[float, ...]:
+    """
+    Benchmark the runtime of the provided function. By default, return the median runtime of :code:`fn` along with
+    the 20-th and 80-th performance percentile.
+
+    :param fn: Function to benchmark
+    :type fn: Callable
+    :param warmup: Warmup time (in ms)
+    :type warmup: int
+    :param rep: Repetition time (in ms)
+    :type rep: int
+    :param grad_to_none: Reset the gradient of the provided tensor to None
+    :type grad_to_none: torch.tensor, optional
+    :param quantiles: Performance percentile to return in addition to the median.
+    :type quantiles: list[float], optional
+    :param return_mode: The statistical measure to return. Options are "min", "max", "mean", "median", or "all". Default is "mean".
+    :type return_mode: str
+    """
+    from triton import runtime
+    from triton.testing import _summarize_statistics
+
+    assert return_mode in ["min", "max", "mean", "median", "all"]
+
+    di = runtime.driver.active.get_device_interface()  # pyrefly: ignore
+
+    fn()
+    di.synchronize()
+
+    cache = runtime.driver.active.get_empty_cache_for_benchmark()  # pyrefly: ignore
+
+    # Estimate the runtime of the function
+    start_event = di.Event(enable_timing=True)
+    end_event = di.Event(enable_timing=True)
+    start_event.record()
+    for _ in range(5):
+        runtime.driver.active.clear_cache(cache)  # pyrefly: ignore
+        fn()
+    end_event.record()
+    di.synchronize()
+    estimate_ms = sync_object(start_event.elapsed_time(end_event) / 5)
+
+    # compute number of warmup and repeat
+    n_warmup = max(1, int(warmup / estimate_ms))
+    n_repeat = max(1, int(rep / estimate_ms))
+    start_event = [di.Event(enable_timing=True) for i in range(n_repeat)]
+    end_event = [di.Event(enable_timing=True) for i in range(n_repeat)]
+    # Warm-up
+    for _ in range(n_warmup):
+        fn()
+    # Benchmark
+    for i in range(n_repeat):
+        # we don't want `fn` to accumulate gradient values
+        # if it contains a backward pass. So we clear the
+        # provided gradients
+        if grad_to_none is not None:
+            for x in grad_to_none:
+                x.grad = None
+        # we clear the L2 cache before each run
+        runtime.driver.active.clear_cache(cache)  # pyrefly: ignore
+        # record time of `fn`
+        start_event[i].record()
+        fn()
+        end_event[i].record()
+    # Record clocks
+    di.synchronize()
+    times = [s.elapsed_time(e) for s, e in zip(start_event, end_event, strict=True)]
+    return _summarize_statistics(times, quantiles, return_mode)  # pyrefly: ignore
 
 
 def run_example(
@@ -977,7 +1063,7 @@ def run_example(
     # Running different number of times on different ranks may cause
     # stuck processes.
     if dist.is_initialized():
-        repeat = sync_repeat(repeat)
+        repeat = sync_object(repeat)
 
     # pyrefly: ignore [bad-argument-type]
     timings = interleaved_bench(bench_fns, repeat=repeat, desc="Benchmarking")

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -60,6 +60,8 @@ from .logger import maybe_dump_triton_failure
 from .metrics import AutotuneMetrics
 from .metrics import _run_post_autotune_hooks
 from .progress_bar import iter_with_progress
+from helion._testing import do_bench
+from helion._testing import sync_object
 
 
 class _HasDevice(Protocol):
@@ -540,7 +542,6 @@ class BaseSearch(BaseAutotuner):
             ):
                 self._autotune_metrics.num_accuracy_failures += 1
                 return inf
-            from triton.testing import do_bench
 
             t1 = time.perf_counter()
             res = do_bench(
@@ -549,6 +550,7 @@ class BaseSearch(BaseAutotuner):
                 warmup=1,  # we are already warmed up above
                 rep=50,
             )
+            res = sync_object(res)
             t2 = time.perf_counter()
             assert isinstance(res, float)
             self.log.debug(
@@ -1155,6 +1157,7 @@ class PopulationBasedSearch(BaseSearch):
             new_timings = bench_fn(iterator, repeat=repeat, desc=desc)
         else:
             new_timings = bench_fn(iterator, repeat=repeat)
+        new_timings = sync_object(new_timings)
         for m, t in zip(members, new_timings, strict=True):
             m.perfs.append(t)
             if t < self.best_perf_so_far:


### PR DESCRIPTION
Stacked PRs:
 * #1532
 * #1555
 * __->__#1542


--- --- ---

### sync bench/rebench result across ranks


1. For helion benchmark/rebenchmark result, we need sync them across
   ranks
2. Helion calls triton do_bench, which decides the number of calls based
   on benchmarking result. The PR makes a copy of that function and sync
   across ranks to make sure different ranks makes the same decision.
