### PR TITLE
[CI] Set UV_LINK_MODE=copy to fix broken binary permissions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -39,6 +39,8 @@ jobs:
 
     env:
       HELION_AUTOTUNE_LOG_LEVEL: INFO
+      # uv 0.10.5+ reflinks on Linux break execute permissions on installed binaries
+      UV_LINK_MODE: copy
 
     container:
       image: ${{ inputs.image }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,9 @@ jobs:
 
     runs-on: ${{ matrix.runner }}
 
+    env:
+      # uv 0.10.5+ reflinks on Linux break execute permissions on installed binaries
+      UV_LINK_MODE: copy
 
     defaults:
       run:
@@ -251,6 +254,10 @@ jobs:
       options: --gpus all
 
     runs-on: linux.g5.4xlarge.nvidia.gpu
+
+    env:
+      # uv 0.10.5+ reflinks on Linux break execute permissions on installed binaries
+      UV_LINK_MODE: copy
 
     defaults:
       run:


### PR DESCRIPTION
uv 0.10.5 introduced reflinks by default on Linux which breaks execute permissions on all binaries installed via pip (cmake, ptxas, etc.), affecting both Triton builds and runtime.

Set UV_LINK_MODE=copy to force regular file copies which preserve permissions.