### PR TITLE
sync seeds across ranks

### DIFF
--- a/helion/_utils.py
+++ b/helion/_utils.py
@@ -1,12 +1,22 @@
 from __future__ import annotations
 
 import collections
+import contextlib
+from dataclasses import dataclass
 import functools
+import random
+from typing import Generator
 from typing import Sequence
+from typing import TypeVar
+
+import torch
+import torch.distributed as dist
 
 counters: collections.defaultdict[str, collections.Counter[str]] = (
     collections.defaultdict(collections.Counter)
 )
+
+T = TypeVar("T")
 
 
 def cdiv(a: int, b: int) -> int:
@@ -86,3 +96,68 @@ def convert_tile_indices_to_slices(index: object) -> object:
     if isinstance(index, tuple):
         return tuple(_extract_slice(idx) for idx in index)
     return _extract_slice(index)
+
+
+@dataclass
+class SeedEnsemble:
+    torch_seed: int
+    py_random_seed: int
+
+    @staticmethod
+    def get_seeds() -> SeedEnsemble:
+        """
+        There is no way to get current seed in PyTorch. We can only get
+        the initial seed.
+
+        This method instead re-initialize the seed by incrementing the
+        initial seed by 1
+        """
+        seed = torch.initial_seed()
+        return SeedEnsemble(
+            seed + 1,
+            seed + 1,
+        )
+
+    @staticmethod
+    def set_seeds(seeds: SeedEnsemble) -> None:
+        torch.manual_seed(seeds.torch_seed)
+        random.seed(seeds.py_random_seed)
+
+    @classmethod
+    def update_seeds_with_rank(cls) -> None:
+        seed = torch.initial_seed() + 1 + dist.get_rank()
+        cls.set_seeds(SeedEnsemble(seed, seed))
+
+
+@contextlib.contextmanager
+def sync_seed(need_diverse_seeds_after: bool = True) -> Generator[None, None, None]:
+    """
+    Sync seeds across ranks.
+
+    If need_diverse_seeds_after is True, we make sure different
+    ranks have different seeds after the call. This ensures different
+    rank can generate independent random tensors.
+    """
+    if not dist.is_initialized():
+        yield
+        return
+
+    from helion._testing import sync_object
+
+    seeds = sync_object(SeedEnsemble.get_seeds())
+
+    try:
+        SeedEnsemble.set_seeds(seeds)
+        yield
+    finally:
+        if need_diverse_seeds_after:
+            SeedEnsemble.update_seeds_with_rank()
+
+
+def all_gather_object(obj: T) -> list[T]:
+    if not dist.is_initialized():
+        return [obj]
+
+    object_list = [None] * dist.get_world_size()
+    dist.all_gather_object(object_list, obj)
+    return object_list  # pyrefly: ignore

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+import torch
+from torch import Tensor
+import torch.distributed as dist
+from torch.testing._internal.common_distributed import MultiProcessTestCase
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_utils import run_tests
+
+from helion._testing import TestCase
+from helion._testing import onlyBackends
+from helion._testing import skipIfRocm
+from helion._testing import skipIfXPU
+from helion._utils import all_gather_object
+from helion._utils import sync_seed
+
+
+@onlyBackends(["triton"])
+class TestDistributed(TestCase, MultiProcessTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._spawn_processes()
+
+    def tearDown(self) -> None:
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+        super().tearDown()
+
+    @property
+    def world_size(self) -> int:
+        return 4
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device(f"cuda:{self.rank}")
+
+    def _init_process(self):
+        torch.cuda.set_device(self.device)
+        store = dist.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            backend="nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+        )
+        torch.distributed.distributed_c10d._set_pg_timeout(
+            timedelta(seconds=60), dist.group.WORLD
+        )
+        torch.manual_seed(42 + self.rank)
+
+    def _cleanup_process(self):
+        torch.cuda.synchronize()
+        dist.barrier()
+        dist.destroy_process_group()
+
+    @skipIfRocm("Distributed example requires CUDA/NCCL")
+    @skipIfXPU("Distributed operations require CCL, not yet fully integrated")
+    @skip_if_lt_x_gpu(4)
+    def test_sync_seed(self):
+        def _all_eq(xlist: list[Tensor]) -> bool:
+            assert len(xlist) > 1
+            lhs = xlist[0]
+            return all(torch.allclose(lhs.cpu(), rhs.cpu()) for rhs in xlist[1:])
+
+        self._init_process()
+        torch.manual_seed(42 + self.rank)
+
+        x = torch.randn(1024, device=self.device)
+        xlist = all_gather_object(x)
+
+        self.assertFalse(_all_eq(xlist))
+
+        with sync_seed():
+            x = torch.randn(1024, device=self.device)
+        xlist = all_gather_object(x)
+        self.assertTrue(_all_eq(xlist))
+
+        x = torch.randn(1024, device=self.device)
+        xlist = all_gather_object(x)
+        self.assertFalse(_all_eq(xlist))
+
+        self._cleanup_process()
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
Stacked PRs:
 * #1532
 * __->__#1555


--- --- ---

### sync seeds across ranks


To autotune for distributed kernels, we need an API to sync seeds acrss
ranks since AutoTuner has the following random behaviors
- generate initial population randomly
- make random perturbation to generate new configs
- etc.

Full test is done in next PR on the stack.
