### PR TITLE
Exclude block_ptr / tensor_descriptor from autotuner search space when index_dtype is int64

### DIFF
--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -140,6 +140,7 @@ class CompileEnvironment:
         self.debug_shape_renames: dict[sympy.Expr, sympy.Expr] = {}
         self.config_spec = ConfigSpec(
             backend=self.backend,
+            index_dtype=self.index_dtype,
         )
         self.kernel_tensor_sizes: dict[tuple[sympy.Expr, ...], int] = (
             collections.Counter()

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
 
+import torch
 from torch._inductor.runtime.runtime_utils import next_power_of_2
 
 from .._compat import supports_amd_cdna_tunables
@@ -97,10 +98,12 @@ class ConfigSpec:
         self,
         *,
         backend: Backend,
+        index_dtype: torch.dtype | None = None,
         user_defined_tunables: Mapping[str, ConfigSpecFragment] | None = None,
     ) -> None:
         self.backend = backend
         self.backend_name = backend.name
+        self.index_dtype = index_dtype
         self.max_reduction_threads = backend.max_reduction_threads()
         self.user_defined_tunables = (
             {} if user_defined_tunables is None else dict(user_defined_tunables)
@@ -145,6 +148,11 @@ class ConfigSpec:
             )
 
     def valid_indexing_types(self) -> tuple[IndexingLiteral, ...]:
+        # block_ptr/tensor_descriptor fall back to pointer at codegen time
+        # when index_dtype is int64 (see BlockedSubscriptIndexing.is_supported),
+        # so exclude them from autotuning to avoid exploring duplicate configs.
+        if self.index_dtype == torch.int64:
+            return ("pointer",)
         if supports_tensor_descriptor():
             return ("pointer", "tensor_descriptor")
         if not self.backend.supports_block_ptr_indexing():


### PR DESCRIPTION
When index_dtype is int64, `block_ptr` and `tensor_descriptor` indexing strategies fall back to pointer at codegen time (see BlockedSubscriptIndexing.is_supported). Exclude them from the autotuner's search space to avoid exploring duplicate configs that all produce identical pointer-based code.

Part of https://github.com/pytorch/helion/issues/1335.