### PR TITLE
Hardcoding range_num_stages to 1 to fix illegal memory access.

### DIFF
--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -247,20 +247,12 @@ class TileStrategy:
                 range_num_stages = 0
             if range_unroll_factor > 0 and num_stages > 1:
                 range_unroll_factor = 0
-        elif (
-            range_num_stages > 1
-            and range_unroll_factor > 1
-        ):
+        elif range_num_stages > 1 and range_unroll_factor > 1:
             block_size_info = env.block_sizes[block_idx]
-            if (
-                block_size_info.size is not None
-                and block_size_info.numel.is_number
-            ):
+            if block_size_info.size is not None and block_size_info.numel.is_number:
                 # Static dimension: compute exact safe pipeline depth
                 loop_numel = int(block_size_info.numel)
-                block_size = int(
-                    block_size_info.from_config_assert(config)
-                )
+                block_size = int(block_size_info.from_config_assert(config))
                 step = range_unroll_factor * block_size
                 last_offset = ((loop_numel - 1) // block_size) * block_size
                 remainder = loop_numel - last_offset

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -250,19 +250,27 @@ class TileStrategy:
         elif (
             range_num_stages > 1
             and range_unroll_factor > 1
-            and env.block_sizes[block_idx].size
-            and env.block_sizes[block_idx].numel.is_number
         ):
-            # Unrolling can cause CUDA IMA with pipelining
-            # We want to ensure new step size + pipeline is within bounds
-            loop_numel = int(env.block_sizes[block_idx].numel)
-            block_size = int(env.block_sizes[block_idx].from_config_assert(config))
-            step = range_unroll_factor * block_size
-            last_offset = ((loop_numel - 1) // block_size) * block_size
-            remainder = loop_numel - last_offset
-            range_num_stages = min(
-                max(1, int(math.ceil(remainder / step))), range_num_stages
-            )
+            block_size_info = env.block_sizes[block_idx]
+            if (
+                block_size_info.size is not None
+                and block_size_info.numel.is_number
+            ):
+                # Static dimension: compute exact safe pipeline depth
+                loop_numel = int(block_size_info.numel)
+                block_size = int(
+                    block_size_info.from_config_assert(config)
+                )
+                step = range_unroll_factor * block_size
+                last_offset = ((loop_numel - 1) // block_size) * block_size
+                remainder = loop_numel - last_offset
+                range_num_stages = min(
+                    max(1, int(math.ceil(remainder / step))), range_num_stages
+                )
+            else:
+                # Data-dependent or unknown dimension: can't verify pipeline
+                # bounds statically, so disable pipelining to prevent OOB reads
+                range_num_stages = 1
 
         if range_unroll_factor > 0:
             kwargs.append(f"loop_unroll_factor={range_unroll_factor}")

--- a/test/test_persistent_kernels.py
+++ b/test/test_persistent_kernels.py
@@ -1058,7 +1058,9 @@ class TestPersistentKernels(RefEagerTestBase, TestCase):
 
         # Verify all options are present in the generated code
         self.assertIn("loop_unroll_factor=2", code_combined)
-        self.assertIn("num_stages=3", code_combined)
+        # num_stages is clamped to 1 for data-dependent dimensions when
+        # range_unroll_factor > 1 to prevent OOB software pipelining prefetches
+        self.assertIn("num_stages=1", code_combined)
         self.assertIn("disallow_acc_multi_buffer=False", code_combined)
         self.assertIn("flatten=False", code_combined)
 


### PR DESCRIPTION
This PR prevents illegal memory access by preventing prefetches when the loop dimension is not known at compile time. The compiler ended up prefetching beyond the bounds causing a memory fault on AMD GPUs