### PR TITLE
make sure persistent setup code uses index type for total pids

### DIFF
--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -613,7 +613,12 @@ class PersistentProgramIDs(ProgramIDs):
 
     def _persistent_setup_statements(self, total_pids_expr: str) -> list[ast.stmt]:
         """Generate the preamble statements for persistent kernel setup."""
-        backend = CompileEnvironment.current().backend
+        env = CompileEnvironment.current()
+        backend = env.backend
+        # Cast total_pids to match the index type so all persistent scheduling
+        # variables (start_pid, end_pid, etc.) have consistent types.
+        if env.index_dtype != torch.int32:
+            total_pids_expr = backend.cast_expr(total_pids_expr, env.index_type())
         stmts: list[ast.stmt] = [
             statement_from_string(f"{self.total_pids_var} = {total_pids_expr}"),
         ]


### PR DESCRIPTION
this fixes one of our benchmark nightly failures
