### PR TITLE
bump pytorch to 2.10 in benchmark nightly to unblock grouped_gemm tritonbench

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Install PyTorch
         run: |
           source .venv/bin/activate
-          uv pip install -U "torch==2.9.*" --index-url https://download.pytorch.org/whl/${{ inputs.runtime-version }}
+          uv pip install -U "torch==2.10.*" --index-url https://download.pytorch.org/whl/${{ inputs.runtime-version }}
 
       - name: Install Helion
         run: |


### PR DESCRIPTION
hopefully the last benchmark nightly failure reason
