### PR TITLE
[Docs] Update autotuner and TileIR backend documentation 

### DIFF
--- a/docs/api/autotuner.md
+++ b/docs/api/autotuner.md
@@ -39,6 +39,26 @@ The autotuner supports multiple search strategies:
 ```{eval-rst}
 .. automodule:: helion.autotuner.surrogate_pattern_search
    :members:
+   :exclude-members: LFBOTreeSearch
+```
+
+### LFBO Tree Search (Default)
+
+{py:class}`~helion.autotuner.surrogate_pattern_search.LFBOTreeSearch` is the default autotuner.
+It extends LFBO Pattern Search with tree-guided neighbor generation, using greedy decision tree
+traversal to focus search on parameters the surrogate model has identified as important.
+
+```{eval-rst}
+.. autoclass:: helion.autotuner.surrogate_pattern_search.LFBOTreeSearch
+   :members:
+   :show-inheritance:
+```
+
+### DE Surrogate Hybrid
+
+```{eval-rst}
+.. automodule:: helion.autotuner.de_surrogate_hybrid
+   :members:
 ```
 
 ### Differential Evolution

--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -196,11 +196,21 @@ def my_kernel(x: torch.Tensor) -> torch.Tensor:
    Select the autotuning effort preset. Available values:
 
    - ``"none"`` – skip autotuning and run the default configuration.
-   - ``"quick"`` – limited search for faster runs with decent performance.
-   - ``"full"`` – exhaustive autotuning (current default behavior).
+   - ``"quick"`` – limited search for faster runs with decent performance. Uses ``from_default`` initial population strategy.
+   - ``"full"`` – exhaustive autotuning (current default behavior). Uses ``from_random`` initial population strategy.
 
+   Each preset also sets a default initial population strategy (see :doc:`../deployment_autotuning` for details).
    Users can still override individual ``autotune_*`` settings; explicit values win over the preset. Controlled by ``HELION_AUTOTUNE_EFFORT``.
 
+.. autoattribute:: Settings.autotune_best_available_max_configs
+
+   Maximum number of cached configs to use when seeding the initial population with the ``from_best_available`` strategy.
+   Default is ``20``. Controlled by ``HELION_BEST_AVAILABLE_MAX_CONFIGS``.
+
+.. autoattribute:: Settings.autotune_best_available_max_cache_scan
+
+   Maximum number of cache files to scan when searching for matching configs in the ``from_best_available`` strategy.
+   Default is ``500``. Controlled by ``HELION_BEST_AVAILABLE_MAX_CACHE_SCAN``.
 
 ```
 
@@ -267,7 +277,7 @@ See :class:`helion.autotuner.LocalAutotuneCache` for details on cache keys and b
    Pass a replacement callable via ``@helion.kernel(..., autotune_benchmark_fn=...)`` at definition time.
 ```
 
-Built-in values for ``HELION_AUTOTUNER`` include ``"PatternSearch"``, ``"DifferentialEvolutionSearch"``, ``"FiniteSearch"``, and ``"RandomSearch"``.
+Built-in values for ``HELION_AUTOTUNER`` include ``"LFBOTreeSearch"`` (default), ``"LFBOPatternSearch"``, ``"DESurrogateHybrid"``, ``"PatternSearch"``, ``"DifferentialEvolutionSearch"``, ``"FiniteSearch"``, and ``"RandomSearch"``.
 
 ## Functions
 
@@ -296,6 +306,9 @@ Built-in values for ``HELION_AUTOTUNER`` include ``"PatternSearch"``, ``"Differe
 | ``HELION_AUTOTUNE_ACCURACY_CHECK`` | ``autotune_accuracy_check`` | Toggle baseline validation for candidate configs. |
 | ``HELION_AUTOTUNE_EFFORT`` | ``autotune_effort`` | Select autotuning preset (``"none"``, ``"quick"``, ``"full"``). |
 | ``HELION_AUTOTUNE_SEARCH_ACF`` | ``autotune_search_acf`` | Comma-separated list of PTXAS config file paths to search during autotuning. |
+| ``HELION_AUTOTUNER_INITIAL_POPULATION`` | (effort profile) | Override the initial population strategy (``"from_random"``, ``"from_default"``, ``"from_best_available"``). |
+| ``HELION_BEST_AVAILABLE_MAX_CONFIGS`` | ``autotune_best_available_max_configs`` | Maximum cached configs to seed when using ``from_best_available`` strategy. |
+| ``HELION_BEST_AVAILABLE_MAX_CACHE_SCAN`` | ``autotune_best_available_max_cache_scan`` | Maximum cache files to scan when using ``from_best_available`` strategy. |
 | ``HELION_REBENCHMARK_THRESHOLD`` | ``autotune_rebenchmark_threshold`` | Re-run configs whose performance is within a multiplier of the current best. |
 | ``HELION_AUTOTUNE_PROGRESS_BAR`` | ``autotune_progress_bar`` | Enable or disable the progress bar UI during autotuning. |
 | ``HELION_AUTOTUNE_IGNORE_ERRORS`` | ``autotune_ignore_errors`` | Continue autotuning even when recoverable runtime errors occur. |
@@ -310,7 +323,8 @@ Built-in values for ``HELION_AUTOTUNER`` include ``"PatternSearch"``, ``"Differe
 | ``HELION_ALLOW_WARP_SPECIALIZE`` | ``allow_warp_specialize`` | Permit warp-specialized code generation for ``tl.range``. |
 | ``HELION_DEBUG_DTYPE_ASSERTS`` | ``debug_dtype_asserts`` | Inject dtype assertions after each lowering step. |
 | ``HELION_INTERPRET`` | ``ref_mode`` | Run kernels through the reference interpreter when set to ``1`` (maps to ``RefMode.EAGER``). |
-| ``HELION_AUTOTUNER`` | ``default_autotuner_fn`` | Select which autotuner implementation to instantiate (``"PatternSearch"``, ``"DifferentialEvolutionSearch"``, ``"FiniteSearch"``, ``"RandomSearch"``). |
+| ``HELION_AUTOTUNER`` | ``default_autotuner_fn`` | Select which autotuner implementation to instantiate. Default is ``"LFBOTreeSearch"``. Other options: ``"LFBOPatternSearch"``, ``"DESurrogateHybrid"``, ``"PatternSearch"``, ``"DifferentialEvolutionSearch"``, ``"FiniteSearch"``, ``"RandomSearch"``. |
+| ``HELION_BACKEND`` | ``backend`` | Code generation backend (``"triton"`` (default), ``"pallas"``, ``"cute"``, ``"tileir"``). |
 
 ## See Also
 

--- a/docs/deployment_autotuning.md
+++ b/docs/deployment_autotuning.md
@@ -75,14 +75,14 @@ for tag, args in datasets.items():
 ### Direct Control Over Autotuners
 
 When you need more control, construct autotuners
-manually. {py:class}`~helion.autotuner.pattern_search.PatternSearch` is the default
+manually. {py:class}`~helion.autotuner.surrogate_pattern_search.LFBOTreeSearch` is the default
 autotuner:
 
 ```python
-from helion.autotuner import PatternSearch
+from helion.autotuner import LFBOTreeSearch
 
 bound = my_kernel.bind(example_inputs)
-tuner = PatternSearch(
+tuner = LFBOTreeSearch(
     bound,
     example_inputs,
     # Double the defaults to explore more candidates:
@@ -103,6 +103,85 @@ tuning time versus coverage, or try different search algorithms.
 - Tuning runs can be seeded with `HELION_AUTOTUNE_RANDOM_SEED` if you
 need more reproducibility; see {doc}`api/settings`.  Note this only
 affects which configs are tried, not the timing results.
+
+## Effort Profiles and Initial Population Strategies
+
+### Autotuning Effort
+
+The `autotune_effort` setting controls how much work the autotuner does.
+Each effort level configures the search algorithm with a different budget
+and a default **initial population strategy** that determines how the
+starting configs are generated:
+
+| Effort | Initial Population Strategy | Use Case |
+|--------|---------------------------|----------|
+| `"none"` | N/A (no autotuning) | Development iteration — uses the default config only |
+| `"quick"` | `from_default` | Fast development tuning — starts from the default config and perturbs around it |
+| `"full"` | `from_random` | Production tuning — explores the full search space randomly |
+
+Set the effort via the decorator or an environment variable:
+
+```python
+@helion.kernel(autotune_effort="quick")
+def my_kernel(x: torch.Tensor) -> torch.Tensor:
+    ...
+```
+
+```bash
+export HELION_AUTOTUNE_EFFORT=quick
+```
+
+The `"quick"` preset is a practical middle ground: it seeds the initial
+population with a single configuration (the default) and runs a short
+search that perturbs around that starting point.  A typical `quick` run
+finishes in seconds (e.g. ~3s / ~32 configs for a simple kernel),
+compared to `"full"` which generates a large random initial population
+and runs many more generations (often ~10 minutes).
+
+### Initial Population Strategies
+
+The initial population strategy determines how the autotuner generates
+its starting set of configurations before beginning the search:
+
+- **`from_random`** (default for `"full"`): Generates a fully random
+  initial population, maximizing diversity in the search space.
+
+- **`from_default`** (default for `"quick"`): Seeds the initial
+  population with only the default configuration. The search algorithm
+  then perturbs around this single starting point, converging faster but
+  exploring a narrower region of the search space.
+
+- **`from_best_available`**: Seeds the initial population with the
+  default configuration plus the best configs from previous autotuning
+  runs found in the local cache.  This strategy is useful when:
+
+  - You are **iterating on a kernel** and want to warm-start from what
+    previously worked rather than searching from scratch.
+  - You are **tuning across similar problem sizes** on the same
+    hardware — configs that worked for one size are often good starting
+    points for another.
+  - You want **incremental improvement** over multiple tuning sessions
+    without repeating work already done.
+
+  The strategy matches cached configs by hardware, specialization key,
+  and structural fingerprint, so it only reuses results that are
+  structurally compatible with the current kernel.
+
+Override the default strategy for any effort level with the
+`HELION_AUTOTUNER_INITIAL_POPULATION` environment variable:
+
+```bash
+# Use from_best_available with the full search budget
+export HELION_AUTOTUNE_EFFORT=full
+export HELION_AUTOTUNER_INITIAL_POPULATION=from_best_available
+```
+
+Related settings for `from_best_available` (see {doc}`api/settings`):
+
+| Setting | Environment Variable | Default | Description |
+|---------|---------------------|---------|-------------|
+| `autotune_best_available_max_configs` | `HELION_BEST_AVAILABLE_MAX_CONFIGS` | 20 | Maximum cached configs to seed |
+| `autotune_best_available_max_cache_scan` | `HELION_BEST_AVAILABLE_MAX_CACHE_SCAN` | 500 | Maximum cache files to scan |
 
 ## Deploy a Single Config
 

--- a/docs/tileir_backend.md
+++ b/docs/tileir_backend.md
@@ -10,10 +10,11 @@ To use the TileIR backend, you need:
 
 1. **Compatible Hardware**: A GPU with compute capability 10.x or 12.x (Blackwell)
 2. **Triton-to-tile-IR Backend**: The [Triton-to-tile-IR backend](https://github.com/triton-lang/Triton-to-tile-IR) must be installed
-3. **Environment Variable**: Set `ENABLE_TILE=1` to enable TileIR support
+3. **Environment Variables**: Set `ENABLE_TILE=1` to enable the Triton TileIR driver and `HELION_BACKEND=tileir` to select the TileIR backend
 
 ```bash
 export ENABLE_TILE=1
+export HELION_BACKEND=tileir
 ```
 
 ## CUDA Tile IR Specific Configuration Parameters
@@ -157,7 +158,7 @@ Kernels using these operations should not be compiled with the TileIR backend.
 | Feature | TileIR Backend | Standard Backend |
 |---------|---------------|------------------|
 | **Hardware** | SM100/SM120 (compute capability 10.x, 12.x) | All CUDA GPUs |
-| **Environment** | `ENABLE_TILE=1` required | No special env var |
+| **Environment** | `ENABLE_TILE=1` and `HELION_BACKEND=tileir` required | No special env var |
 | **num_ctas** | ✅ Supported | ❌ Not available |
 | **occupancy** | ✅ Supported | ❌ Not available |
 | **Indexing: pointer** | ✅ Supported | ✅ Supported |


### PR DESCRIPTION
## Summary

  I initially wanted to document the `FROM_BEST_AVAILABLE` initial population strategy, but while working on it I noticed several other gaps and inaccuracies in the docs, so I fixed those too. Co-authored with Claude Sonnet.

  Changes:
  - **TileIR backend**: Added missing `HELION_BACKEND=tileir` env var to requirements (docs only mentioned `ENABLE_TILE=1`, but both are required)
  - **Effort profiles**: Added new section documenting `none`/`quick`/`full` effort levels and their default initial population
  strategies (`from_default` for quick, `from_random` for full)
  - **`FROM_BEST_AVAILABLE`**: Documented the strategy, when to use it, related env vars and settings
  - **Default autotuner**: Fixed references from `PatternSearch` to `LFBOTreeSearch` (the actual default since it changed)
  - **Missing algorithms**: Added `LFBOTreeSearch`, `LFBOPatternSearch`, and `DESurrogateHybrid` to autotuner API docs and settings env var reference
  - **Missing env vars**: Added `HELION_BACKEND`, `HELION_AUTOTUNER_INITIAL_POPULATION`, `HELION_BEST_AVAILABLE_MAX_CONFIGS`,
  `HELION_BEST_AVAILABLE_MAX_CACHE_SCAN` to the settings reference table

  ## Test plan

  - [x] `make html` builds successfully
  - [x] `make linkcheck` passes with no broken links

  🤖 Co-authored with [Claude Sonnet](https://claude.ai)
