### PR TITLE
Fill uninitialized memory with NaN during autotuner accuracy checks

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -28,6 +28,7 @@ import types
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
+from typing import Generator
 from typing import Iterable
 from typing import Literal
 from typing import NamedTuple
@@ -181,7 +182,29 @@ _FP8_DTYPES = {
 }
 
 
-def _assert_close(actual: object, expected: object, atol: float, rtol: float) -> None:
+@contextlib.contextmanager
+def _fill_uninitialized_memory() -> Generator[None, None, None]:
+    """Enable deterministic filling of torch.empty during accuracy checks.
+
+    Uses PyTorch's built-in mechanism to fill uninitialized memory with NaN
+    (float) or max value (int), ensuring unwritten memory locations produce
+    consistent values between baseline and candidate kernel runs.
+    """
+    old_det = torch.are_deterministic_algorithms_enabled()
+    old_warn = torch.is_deterministic_algorithms_warn_only_enabled()
+    try:
+        torch.use_deterministic_algorithms(True, warn_only=True)
+        yield
+    finally:
+        if old_det:
+            torch.use_deterministic_algorithms(old_det, warn_only=old_warn)
+        else:
+            torch.use_deterministic_algorithms(False)
+
+
+def _assert_close(
+    actual: object, expected: object, atol: float, rtol: float, equal_nan: bool = False
+) -> None:
     """Like torch.testing.assert_close but handles fp8 and uses chunked comparison for large tensors."""
 
     def convert(t: torch.Tensor) -> torch.Tensor:
@@ -203,9 +226,9 @@ def _assert_close(actual: object, expected: object, atol: float, rtol: float) ->
 
     for a, e in zip(actual_flat, expected_flat, strict=True):
         if isinstance(a, torch.Tensor):
-            _chunked_assert_close(a, e, atol=atol, rtol=rtol)
+            _chunked_assert_close(a, e, atol=atol, rtol=rtol, equal_nan=equal_nan)
         else:
-            torch.testing.assert_close(a, e, atol=atol, rtol=rtol)
+            torch.testing.assert_close(a, e, atol=atol, rtol=rtol, equal_nan=equal_nan)
 
 
 def _chunked_assert_close(
@@ -214,6 +237,7 @@ def _chunked_assert_close(
     atol: float,
     rtol: float,
     chunk_size: int = 2**22,  # ~4M elements per chunk
+    equal_nan: bool = False,
 ) -> None:
     """Memory-efficient assert_close for large tensors.
 
@@ -222,14 +246,18 @@ def _chunked_assert_close(
     each chunk so error messages retain full detail.
     """
     if actual.numel() <= chunk_size:
-        torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+        torch.testing.assert_close(
+            actual, expected, atol=atol, rtol=rtol, equal_nan=equal_nan
+        )
         return
     a_flat = actual.reshape(-1)
     e_flat = expected.reshape(-1)
     for i in range(0, a_flat.numel(), chunk_size):
         a_chunk = a_flat[i : i + chunk_size]
         e_chunk = e_flat[i : i + chunk_size]
-        torch.testing.assert_close(a_chunk, e_chunk, atol=atol, rtol=rtol)
+        torch.testing.assert_close(
+            a_chunk, e_chunk, atol=atol, rtol=rtol, equal_nan=equal_nan
+        )
 
 
 def _clone_args(
@@ -351,44 +379,53 @@ class BaseSearch(BaseAutotuner):
         - If settings.autotune_baseline_fn is provided, use that custom function
         - Otherwise, run the kernel with the default config
         """
-        new_args = _clone_args(self.args)
+        fill_ctx = (
+            _fill_uninitialized_memory()
+            if self.settings.autotune_fill_uninitialized_memory
+            else contextlib.nullcontext()
+        )
 
-        # Use custom baseline function if provided
-        if self.settings.autotune_baseline_fn is not None:
-            try:
-                baseline_output = self.settings.autotune_baseline_fn(*new_args)
-                torch.accelerator.synchronize()
-            except Exception as e:
-                raise exc.AutotuneError(
-                    "Custom baseline function failed while computing baseline.\n"
-                    f"Baseline function: {self.settings.autotune_baseline_fn}\n"
-                ) from e
-        else:
-            # Use default config
-            baseline_config = self.config_spec.default_config()
-            try:
-                baseline_output = self.kernel.compile_config(
-                    baseline_config, allow_print=False
-                )(*new_args)
-                torch.accelerator.synchronize()
-            except Exception as e:
-                decorator = self.kernel.format_kernel_decorator(
-                    baseline_config, self.settings
-                )
-                log_generated_triton_code_debug(
-                    self.log,
-                    self.kernel,
-                    baseline_config,
-                    prefix=f"Generated Triton code for {decorator}:",
-                )
-                self.kernel.maybe_log_repro(self.log.error, new_args, baseline_config)
-                raise exc.InvalidConfig(
-                    "Default config failed while computing baseline.\n"
-                    f"Default config: {decorator}\n"
-                    f"{SUPPRESSED_TRITON_CODE_MSG}\n"
-                    "To work around this error, you could set `@helion.kernel(autotune_baseline_fn=...)` "
-                    "to provide a custom baseline function (e.g. PyTorch eager implementation of your kernel)."
-                ) from e
+        with fill_ctx:
+            new_args = _clone_args(self.args)
+
+            # Use custom baseline function if provided
+            if self.settings.autotune_baseline_fn is not None:
+                try:
+                    baseline_output = self.settings.autotune_baseline_fn(*new_args)
+                    torch.accelerator.synchronize()
+                except Exception as e:
+                    raise exc.AutotuneError(
+                        "Custom baseline function failed while computing baseline.\n"
+                        f"Baseline function: {self.settings.autotune_baseline_fn}\n"
+                    ) from e
+            else:
+                # Use default config
+                baseline_config = self.config_spec.default_config()
+                try:
+                    baseline_output = self.kernel.compile_config(
+                        baseline_config, allow_print=False
+                    )(*new_args)
+                    torch.accelerator.synchronize()
+                except Exception as e:
+                    decorator = self.kernel.format_kernel_decorator(
+                        baseline_config, self.settings
+                    )
+                    log_generated_triton_code_debug(
+                        self.log,
+                        self.kernel,
+                        baseline_config,
+                        prefix=f"Generated Triton code for {decorator}:",
+                    )
+                    self.kernel.maybe_log_repro(
+                        self.log.error, new_args, baseline_config
+                    )
+                    raise exc.InvalidConfig(
+                        "Default config failed while computing baseline.\n"
+                        f"Default config: {decorator}\n"
+                        f"{SUPPRESSED_TRITON_CODE_MSG}\n"
+                        "To work around this error, you could set `@helion.kernel(autotune_baseline_fn=...)` "
+                        "to provide a custom baseline function (e.g. PyTorch eager implementation of your kernel)."
+                    ) from e
 
         original_args_flat, _ = tree_flatten(self.args)
         new_args_flat, _ = tree_flatten(new_args)
@@ -506,12 +543,14 @@ class BaseSearch(BaseAutotuner):
     def _validate_against_baseline(
         self, config: Config, output: object, args: Sequence[object]
     ) -> bool:
+        equal_nan = self.settings.autotune_fill_uninitialized_memory
         try:
             _assert_close(
                 output,
                 self._baseline_output,
                 atol=self._effective_atol,
                 rtol=self._effective_rtol,
+                equal_nan=equal_nan,
             )
             if len(self._mutated_arg_indices) > 0:
                 _assert_close(
@@ -519,6 +558,7 @@ class BaseSearch(BaseAutotuner):
                     self._baseline_post_args,
                     atol=self._effective_atol,
                     rtol=self._effective_rtol,
+                    equal_nan=equal_nan,
                 )
         except AssertionError as e:
             if not self.settings.autotune_ignore_errors:
@@ -576,9 +616,15 @@ class BaseSearch(BaseAutotuner):
             else:
                 working_args = self.args
             torch.accelerator.synchronize()
-            with _capture_ctx as _captured_output:
-                output = fn(*working_args)  # make sure the kernel is compiled
-            torch.accelerator.synchronize()
+            fill_ctx = (
+                _fill_uninitialized_memory()
+                if self.settings.autotune_fill_uninitialized_memory
+                else contextlib.nullcontext()
+            )
+            with fill_ctx:
+                with _capture_ctx as _captured_output:
+                    output = fn(*working_args)  # make sure the kernel is compiled
+                torch.accelerator.synchronize()
             if (
                 self.settings.autotune_accuracy_check
                 and not self._validate_against_baseline(config, output, working_args)

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -432,6 +432,11 @@ class _Settings:
             _env_get_bool, "HELION_AUTOTUNE_ACCURACY_CHECK", True
         )
     )
+    autotune_fill_uninitialized_memory: bool = dataclasses.field(
+        default_factory=functools.partial(
+            _env_get_bool, "HELION_AUTOTUNE_FILL_UNINITIALIZED_MEMORY", True
+        )
+    )
     autotune_rebenchmark_threshold: float | None = dataclasses.field(
         default_factory=functools.partial(
             _env_get_optional_float,
@@ -564,6 +569,12 @@ class Settings(_Settings):
         "autotune_precompile_jobs": "Maximum concurrent Triton precompile processes, default to cpu count.",
         "autotune_random_seed": "Seed used for autotuner random number generation. Defaults to HELION_AUTOTUNE_RANDOM_SEED or a time-based seed.",
         "autotune_accuracy_check": "If True, validate candidate configs against the baseline kernel output before accepting them during autotuning.",
+        "autotune_fill_uninitialized_memory": (
+            "If True, fill tensors allocated by torch.empty with NaN (float) or max value (int) "
+            "during autotuning accuracy checks. This prevents false accuracy failures when kernels "
+            "intentionally leave some output addresses unwritten. "
+            "Set HELION_AUTOTUNE_FILL_UNINITIALIZED_MEMORY=0 to disable."
+        ),
         "autotune_rebenchmark_threshold": "If a config is within threshold*best_perf, re-benchmark it to avoid outliers. Defaults to effort profile value. Set HELION_REBENCHMARK_THRESHOLD to override.",
         "autotune_progress_bar": "If True, show progress bar during autotuning. Default is True. Set HELION_AUTOTUNE_PROGRESS_BAR=0 to disable.",
         "autotune_max_generations": "Override the maximum number of generations for Pattern Search and Differential Evolution Search autotuning algorithms with HELION_AUTOTUNE_MAX_GENERATIONS=N or @helion.kernel(autotune_max_generations=N).",

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -1222,6 +1222,45 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
                 self.assertIn(winner, (cfg1, cfg2))
                 self.assertEqual(search._autotune_metrics.num_accuracy_failures, 0)
 
+    def test_fill_uninitialized_memory_setting(self) -> None:
+        """Test that autotune_fill_uninitialized_memory setting exists and defaults to True."""
+        s = Settings()
+        self.assertTrue(s.autotune_fill_uninitialized_memory)
+
+        s2 = Settings(autotune_fill_uninitialized_memory=False)
+        self.assertFalse(s2.autotune_fill_uninitialized_memory)
+
+    @skipIfCpu("fails on Triton CPU backend")
+    def test_fill_uninitialized_memory_partial_write(self) -> None:
+        """Test that fill_uninitialized_memory prevents false accuracy failures
+        for kernels that leave some output memory unwritten via masked stores."""
+        config1 = helion.Config(block_sizes=[16], num_warps=4)
+        config2 = helion.Config(block_sizes=[32], num_warps=4)
+
+        @helion.kernel(configs=[config1, config2], autotune_log_level=0)
+        def masked_write(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(out.size(0)):
+                hl.store(out, [tile], x[tile] * 2, extra_mask=(tile.index % 2) == 0)
+            return out
+
+        x = torch.randn([64], device=DEVICE)
+
+        # With fill_uninitialized_memory=True (default), accuracy check should pass
+        # because both baseline and candidate runs fill torch.empty with NaN,
+        # and equal_nan=True means the unwritten NaN positions match.
+        bound = masked_write.bind((x,))
+        bound.settings.autotune_precompile = None
+        self.assertTrue(bound.settings.autotune_fill_uninitialized_memory)
+        search = FiniteSearch(bound, (x,), configs=[config1, config2])
+        search._prepare()
+        _, time_val = search.benchmark(config1)
+        self.assertFalse(
+            math.isinf(time_val),
+            "Accuracy check should pass with fill_uninitialized_memory=True",
+        )
+        self.assertEqual(search._autotune_metrics.num_accuracy_failures, 0)
+
     @skipIfCpu("fails on Triton CPU backend")
     @skipIfCudaCapabilityLessThan((9, 0), reason="FP8 requires CUDA capability >= 9.0")
     def test_autotune_fp8_automatic_tolerance(self) -> None:


### PR DESCRIPTION
This PR addresses the issue https://github.com/pytorch/helion/issues/1334

**Problem:** During autotuning, Helion compares each candidate config's output against a baseline to verify correctness. When a kernel uses torch.empty() for its output tensor and intentionally leaves some addresses unwritten (e.g., masked stores with extra_mask), the unwritten positions contain arbitrary garbage that differs between the baseline and candidate runs. This causes the accuracy check to reject valid configs as incorrect, even though the kernel is working as intended.

**Solution:** Add an `autotune_fill_uninitialized_memory` setting (default True, env var `HELION_AUTOTUNE_FILL_UNINITIALIZED_MEMORY`). When enabled, both baseline and candidate kernel executions run inside a context that enables `torch.use_deterministic_algorithms(True, warn_only=True)`, which causes `torch.empty()` to fill tensors with deterministic values (NaN for floats, max value for integers) instead of garbage. The subsequent accuracy comparison passes `equal_nan=True` to `torch.testing.assert_close`, so the NaN-filled unwritten positions are treated as equal between the two runs.