### PR TITLE
[Helion + torch.compile] Temporarily skip torch.compile fusion test cases to wait for cross-repo changes

### DIFF
--- a/test/test_torch_compile.py
+++ b/test/test_torch_compile.py
@@ -360,10 +360,9 @@ class TestTorchCompile(RefEagerTestDisabled, TestCase):
         compare_fn=None,
     ):
         """Run torch.compile test comparing eager vs compiled execution."""
-        # Skip fusion tests on PyTorch < 2.11
+        # Skip fusion tests
         if allow_torch_compile_fusion:
-            if not requires_torch_version("2.11"):
-                self.skipTest("torch.compile fusion requires PyTorch >= 2.11")
+            self.skipTest("torch.compile fusion tests are currently skipped")
 
         # Reset specific kernels and configure fusion setting via env var
         if allow_torch_compile_fusion:


### PR DESCRIPTION
There is a pending PyTorch-side change which would break all fusion=True test cases. I plan to disable these tests first, then land the PyTorch changes, then re-enable these tests in another PR.