### PR TITLE
[Internal CI] Use MTIA-aligned tensor shape in test_tile_single_element_list

### DIFF
--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -139,7 +139,7 @@ class TestErrors(RefEagerTestDisabled, TestCase):
                 out[tile] = x[tile, :].sum(1)
             return out
 
-        code, result = code_and_output(fn, (torch.randn(100, 100, device=DEVICE),))
+        code, result = code_and_output(fn, (torch.randn(128, 128, device=DEVICE),))
         self.assertIn("tl.load", code)
 
     def test_tile_invalid_range_unpack(self):


### PR DESCRIPTION
Change test tensor shape from (100, 100) to (128, 128) to satisfy MTIA hardware alignment/padding requirements. The test validates hl.tile([x]) codegen behavior which is shape-independent.