### PR TITLE
Fix IndexError in `Kernel.bind()` when `hl.specialize` references a default argument

### DIFF
--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -218,18 +218,17 @@ class Kernel(Generic[_R]):
                 raise TypeError(
                     f"Too many arguments passed to the kernel, expected: {self._num_params} got: {len(args)}."
                 )
+            # Normalize first so all downstream code (specialization_key,
+            # cache key extractors, BoundKernel) sees full-length args
+            # with defaults applied.
+            args = self.normalize_args(*args)
             signature = self.specialization_key(args)
             cache_key = self._get_bound_kernel_cache_key(args, signature)
             bound_kernel = (
                 None if cache_key is None else self._bound_kernels.get(cache_key, None)
             )
             if bound_kernel is None:
-                normalized_args: tuple[object, ...] = self.normalize_args(*args)
-                if len(normalized_args) != len(args):
-                    # we had default args that needed to be applied
-                    bound_kernel = self.bind(normalized_args)
-                else:
-                    bound_kernel = BoundKernel(self, args)
+                bound_kernel = BoundKernel(self, args)
                 if cache_key is None:
                     cache_key = self._create_bound_kernel_cache_key(
                         bound_kernel, args, signature

--- a/test/test_specialize.py
+++ b/test/test_specialize.py
@@ -401,6 +401,37 @@ class TestSpecialize(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result1, x_a + stride0_a)
         torch.testing.assert_close(result2, x_b + stride0_b)
 
+    def test_specialize_default_arg(self):
+        """bind() with short args must not crash when hl.specialize
+        references a parameter with a default value.
+
+        When called without the default arg (e.g., fn(x)), normalize_args
+        fills in the default.  Before the fix, _specialize_extra extractors
+        (which reference the default arg's index) were applied to the SHORT
+        args tuple, causing IndexError.
+        """
+
+        @helion.kernel(static_shapes=False, autotune_effort="none")
+        def fn(
+            x: torch.Tensor,
+            repeat: int = 2,
+        ) -> torch.Tensor:
+            m = x.size(0)
+            r = hl.specialize(repeat)
+            out = x.new_empty([m])
+            for tile in hl.tile(m):
+                out[tile] = x[tile, :].sum(-1) * r
+            return out
+
+        x = torch.randn(8, 32, device=DEVICE, dtype=torch.float32)
+        # Call with only x — relies on default repeat=2.
+        code, result = code_and_output(fn, (x,))
+        torch.testing.assert_close(result, x.sum(-1) * 2, rtol=1e-4, atol=1e-4)
+        # bind() with short args resolves to same BoundKernel as explicit repeat=2.
+        self.assertTrueIfInNormalMode(fn.bind((x,)) is fn.bind((x, 2)))
+        # Different repeat value → different BoundKernel.
+        self.assertTrueIfInNormalMode(fn.bind((x,)) is not fn.bind((x, 3)))
+
     def test_specialize_stride_tuple(self):
         """Test that hl.specialize works with tuple of strides."""
 


### PR DESCRIPTION
When a kernel parameter has a default value and hl.specialize is called on it, _specialize_extra extractors reference that parameter's index in the full args tuple. If bind() is called with short args (omitting the default), the extractors would crash with IndexError when applied to the short tuple.

Fix: normalize args (apply defaults) at the top of bind(), before computing specialization keys or cache keys, so all downstream code always sees full-length args.