### PR TITLE
Fix error when operating on host values from `torch.cuda.get_device_properties()`

### DIFF
--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -31,11 +31,13 @@ from .ast_read_writes import dead_assignment_elimination
 from .compile_environment import CompileEnvironment
 from .host_function import HostFunction
 from .host_function import NoCurrentFunction
+from .host_function import _resolve_sym
 from .output_header import reserved_names
 from .source_location import SyntheticLocation
 from .variable_origin import BlockSizeOrigin
 from .variable_origin import GridOrigin
 from .variable_origin import Origin
+from .variable_origin import SourceOrigin
 from .variable_origin import TensorSizeOrigin
 
 if TYPE_CHECKING:
@@ -423,7 +425,26 @@ class DeviceFunction:
             return self.expr_to_var_info[expr].name
         expr_to_origin = HostFunction.current().expr_to_origin
         if expr in expr_to_origin:
-            return self._lift_sympy_arg(expr)
+            origin = expr_to_origin[expr].origin
+            if not issubclass(origin.base_type(), SourceOrigin):
+                return env.backend.sympy_printer_expr(
+                    sympy.Symbol(self._lift_sympy_arg(expr), integer=True)
+                )
+        # Substitute compound sub-expressions that have a known name.
+        # E.g. expr_to_origin maps 4*u0 -> "num_workers"; substituting
+        # absorbs u0 so it doesn't need individual resolution.
+        original_symbols = expr.free_symbols
+        for compound, sym_origin in expr_to_origin.items():
+            if (
+                not isinstance(compound, sympy.Symbol)
+                and compound.free_symbols.issubset(expr.free_symbols)
+                and not issubclass(sym_origin.origin.base_type(), SourceOrigin)
+            ):
+                expr = expr.subs(
+                    compound,
+                    sympy.Symbol(self._lift_sympy_arg(compound), integer=True),
+                )
+        # Replace remaining individual symbols with their codegen names.
         replacements = {}
         for sym in sorted(expr.free_symbols, key=lambda x: x.name):
             assert isinstance(sym, sympy.Symbol)
@@ -431,10 +452,9 @@ class DeviceFunction:
                 replacements[sym] = sympy.Symbol(
                     self.expr_to_var_info[sym].name, integer=True
                 )
-            else:
-                assert sym in expr_to_origin, f"no origin found for {sym.name}"
-                replacements[sym] = sympy.Symbol(
-                    self._lift_sympy_arg(sym), integer=True
+            elif sym in original_symbols:
+                replacements[sym] = _resolve_sym(
+                    sym, expr_to_origin, lambda e, o: self._lift_sympy_arg(e)
                 )
         # pyrefly: ignore [bad-argument-type]
         return env.backend.sympy_printer_expr(expr.xreplace(replacements))

--- a/helion/_compiler/host_function.py
+++ b/helion/_compiler/host_function.py
@@ -32,8 +32,10 @@ from .variable_origin import AttributeOrigin
 from .variable_origin import GlobalOrigin
 from .variable_origin import NameOrigin
 from .variable_origin import Origin
+from .variable_origin import SourceOrigin
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     import types
 
     from .type_propagation import TypeInfo
@@ -224,12 +226,15 @@ class HostFunction:
         if not expr.free_symbols:
             return pexpr(expr)
         if expr in self.expr_to_origin:
-            return self.expr_to_origin[expr].origin.host_str()
+            origin = self.expr_to_origin[expr].origin
+            if not issubclass(origin.base_type(), SourceOrigin):
+                return pexpr(sympy.Symbol(origin.host_str(), integer=True))
         replacements = {}
         for sym in sorted(expr.free_symbols, key=lambda x: x.name):
             assert isinstance(sym, sympy.Symbol)
-            origin = self.expr_to_origin[sym].origin
-            replacements[sym] = sympy.Symbol(origin.host_str(), integer=True)
+            replacements[sym] = _resolve_sym(
+                sym, self.expr_to_origin, lambda e, o: o.host_str()
+            )
         # pyrefly: ignore [bad-argument-type]
         return pexpr(expr.xreplace(replacements))
 
@@ -363,6 +368,36 @@ class HostFunction:
             return tls.functions[-1]
         except (AttributeError, IndexError):
             raise NoCurrentFunction from None
+
+
+def _resolve_sym(
+    sym: sympy.Symbol,
+    expr_to_origin: dict[sympy.Expr, SymbolOrigin],
+    get_name: Callable[[sympy.Expr, Origin], str],
+) -> sympy.Expr:
+    """Resolve a symbol to a named sympy expression.
+
+    For non-SourceOrigin symbols, returns Symbol(get_name(sym, origin)).
+    For SourceOrigin symbols, derives from compound expressions
+    (e.g., if 4*u0 -> "num_workers", resolves u0 to num_workers // 4).
+    """
+    if sym in expr_to_origin:
+        origin = expr_to_origin[sym].origin
+        if not issubclass(origin.base_type(), SourceOrigin):
+            return sympy.Symbol(get_name(sym, origin), integer=True)
+    # SourceOrigin or missing: derive from compound expression
+    for compound, sym_origin in expr_to_origin.items():
+        if isinstance(compound, sympy.Symbol) or sym not in compound.free_symbols:
+            continue
+        origin = sym_origin.origin
+        if issubclass(origin.base_type(), SourceOrigin):
+            continue
+        ratio = sympy.cancel(compound / sym)
+        if ratio.is_number and ratio.is_integer and int(ratio) > 0:
+            r = int(ratio)
+            named = sympy.Symbol(get_name(compound, origin), integer=True)
+            return named if r == 1 else named // r
+    raise AssertionError(f"cannot resolve symbol {sym}")
 
 
 class NoCurrentFunction(RuntimeError):

--- a/test/test_type_propagation.expected
+++ b/test/test_type_propagation.expected
@@ -862,6 +862,716 @@ def root_graph_2():
     _for_loop = helion_language__tracing_ops__for_loop(1, [0], [128], []);  _for_loop = None
     return None
 
+--- assertExpectedJournal(TestTypePropagation.test_device_properties_arithmetic)
+def fn(x: torch.Tensor, weight: torch.Tensor):
+    m, n = 
+    # Call: SequenceType((LiteralType(1000), LiteralType(1024))) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: TensorAttributeType AttributeOrigin(value=ArgumentOrigin(name='x'), key='size')
+    # Name: TensorType([1000, 1024], torch.float32) ArgumentOrigin(name='x')
+x.size()
+    n = 
+    # Call: LiteralType(1024) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: CallableType(specialize) AttributeOrigin(value=GlobalOrigin(name='hl'), key='specialize')
+    # Name: PythonModuleType(helion.language) GlobalOrigin(name='hl')
+hl.specialize(
+    # Name: LiteralType(1024) GetItemOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key=1)
+n)
+    out = 
+    # Call: TensorType([1000, 1024], torch.float32) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: CallableType(_VariableFunctionsClass.empty_like) AttributeOrigin(value=GlobalOrigin(name='torch'), key='empty_like')
+    # Name: PythonModuleType(torch) GlobalOrigin(name='torch')
+torch.empty_like(
+    # Name: TensorType([1000, 1024], torch.float32) ArgumentOrigin(name='x')
+x)
+    m_block = 
+    # Call: BlockSizeType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: CallableType(register_block_size) AttributeOrigin(value=GlobalOrigin(name='hl'), key='register_block_size')
+    # Name: PythonModuleType(helion.language) GlobalOrigin(name='hl')
+hl.register_block_size(
+    # Name: LiteralType(1000) GetItemOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key=0)
+m)
+    n_block = 
+    # Call: BlockSizeType(1) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: CallableType(register_block_size) AttributeOrigin(value=GlobalOrigin(name='hl'), key='register_block_size')
+    # Name: PythonModuleType(helion.language) GlobalOrigin(name='hl')
+hl.register_block_size(
+    # Name: LiteralType(1024) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n)
+    m_count = 
+    # BinOp: SymIntType(((u0 + 999)//u0)) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # BinOp: SymIntType(u0 + 999) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+(
+    # BinOp: SymIntType(u0 + 1000) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Name: LiteralType(1000) GetItemOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key=0)
+m + 
+    # Name: BlockSizeType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+m_block - 
+    # Constant: LiteralType(1) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+1) // 
+    # Name: BlockSizeType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+m_block
+    n_count = 
+    # BinOp: SymIntType(((u1 + 1023)//u1)) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # BinOp: SymIntType(u1 + 1023) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+(
+    # BinOp: SymIntType(u1 + 1024) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Name: LiteralType(1024) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n + 
+    # Name: BlockSizeType(1) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n_block - 
+    # Constant: LiteralType(1) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+1) // 
+    # Name: BlockSizeType(1) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n_block
+    num_workers = 
+    # Attribute: SymIntType(u2) AttributeOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='multi_processor_count')
+    # Call: ClassType({'multi_processor_count': SymIntType(u2)}) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: CallableType(get_device_properties) AttributeOrigin(value=AttributeOrigin(value=GlobalOrigin(name='torch'), key='cuda'), key='get_device_properties')
+    # Attribute: PythonModuleType(torch.cuda) AttributeOrigin(value=GlobalOrigin(name='torch'), key='cuda')
+    # Name: PythonModuleType(torch) GlobalOrigin(name='torch')
+torch.cuda.get_device_properties(
+    # Attribute: LiteralType(device=DEVICE) AttributeOrigin(value=ArgumentOrigin(name='x'), key='device')
+    # Name: TensorType([1000, 1024], torch.float32) ArgumentOrigin(name='x')
+x.device).multi_processor_count
+    num_workers = 
+    # BinOp: SymIntType(4*u2) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # BinOp: SymIntType(3*u2) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # BinOp: SymIntType(2*u2) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Name: SymIntType(u2) AttributeOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='multi_processor_count')
+num_workers + 
+    # Name: SymIntType(u2) AttributeOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='multi_processor_count')
+num_workers + 
+    # Name: SymIntType(u2) AttributeOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='multi_processor_count')
+num_workers + 
+    # Name: SymIntType(u2) AttributeOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='multi_processor_count')
+num_workers
+    total_work = 
+    # BinOp: SymIntType((((u0 + 999)//u0))*(((u1 + 1023)//u1))) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Name: SymIntType(((u0 + 999)//u0)) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+m_count * 
+    # Name: SymIntType(((u1 + 1023)//u1)) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n_count
+    work_per_worker = 
+    # BinOp: SymIntType(((4*u2 + (((u0 + 999)//u0))*(((u1 + 1023)//u1)) - 1)//(4*u2))) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # BinOp: SymIntType(4*u2 + (((u0 + 999)//u0))*(((u1 + 1023)//u1)) - 1) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+(
+    # BinOp: SymIntType(4*u2 + (((u0 + 999)//u0))*(((u1 + 1023)//u1))) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Name: SymIntType((((u0 + 999)//u0))*(((u1 + 1023)//u1))) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+total_work + 
+    # Name: SymIntType(4*u2) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+num_workers - 
+    # Constant: LiteralType(1) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+1) // 
+    # Name: SymIntType(4*u2) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+num_workers
+    # For: loop_type=GRID
+
+    for worker_id in 
+    # Call: IterType(GridIndexType(2)) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: CallableType(grid) AttributeOrigin(value=GlobalOrigin(name='hl'), key='grid')
+    # Name: PythonModuleType(helion.language) GlobalOrigin(name='hl')
+hl.grid(
+    # Name: SymIntType(4*u2) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+num_workers):
+        # For: loop_type=DEVICE
+
+        for work_item in 
+        # Call: IterType(GridIndexType(3)) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+        # Attribute: CallableType(grid) AttributeOrigin(value=GlobalOrigin(name='hl'), key='grid')
+        # Name: PythonModuleType(helion.language) GlobalOrigin(name='hl')
+hl.grid(
+        # Name: SymIntType(((4*u2 + (((u0 + 999)//u0))*(((u1 + 1023)//u1)) - 1)//(4*u2))) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_per_worker):
+            work_n = 
+            # BinOp: SymIntType(PythonMod(4*u2*u6 + u4, ((u1 + 1023)//u1))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # BinOp: SymIntType(4*u2*u6 + u4) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+(
+            # Name: GridIndexType(2) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+worker_id + 
+            # BinOp: SymIntType(4*u2*u6) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Name: SymIntType(4*u2) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+num_workers * 
+            # Name: GridIndexType(3) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_item) % 
+            # Name: SymIntType(((u1 + 1023)//u1)) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n_count
+            work_m = 
+            # BinOp: SymIntType(((4*u2*u6 + u4)//(((u1 + 1023)//u1)))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # BinOp: SymIntType(4*u2*u6 + u4) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+(
+            # Name: GridIndexType(2) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+worker_id + 
+            # BinOp: SymIntType(4*u2*u6) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Name: SymIntType(4*u2) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+num_workers * 
+            # Name: GridIndexType(3) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_item) // 
+            # Name: SymIntType(((u1 + 1023)//u1)) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n_count
+            work_n_start = 
+            # BinOp: SymIntType(u1*(PythonMod(4*u2*u6 + u4, ((u1 + 1023)//u1)))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Name: SymIntType(PythonMod(4*u2*u6 + u4, ((u1 + 1023)//u1))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_n * 
+            # Name: BlockSizeType(1) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n_block
+            work_n_end = 
+            # Call: SymIntType(Min(1024, u1*(PythonMod(4*u2*u6 + u4, ((u1 + 1023)//u1))) + u1)) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Name: CallableType(min) BuiltinOrigin(name='min')
+min(
+            # BinOp: SymIntType(u1*(PythonMod(4*u2*u6 + u4, ((u1 + 1023)//u1))) + u1) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Name: SymIntType(u1*(PythonMod(4*u2*u6 + u4, ((u1 + 1023)//u1)))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_n_start + 
+            # Name: BlockSizeType(1) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n_block, 
+            # Name: LiteralType(1024) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n)
+            work_m_start = 
+            # BinOp: SymIntType(u0*(((4*u2*u6 + u4)//(((u1 + 1023)//u1))))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Name: SymIntType(((4*u2*u6 + u4)//(((u1 + 1023)//u1)))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_m * 
+            # Name: BlockSizeType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+m_block
+            work_m_end = 
+            # Call: SymIntType(Min(1000, u0*(((4*u2*u6 + u4)//(((u1 + 1023)//u1)))) + u0)) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Name: CallableType(min) BuiltinOrigin(name='min')
+min(
+            # BinOp: SymIntType(u0*(((4*u2*u6 + u4)//(((u1 + 1023)//u1)))) + u0) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Name: SymIntType(u0*(((4*u2*u6 + u4)//(((u1 + 1023)//u1))))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_m_start + 
+            # Name: BlockSizeType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+m_block, 
+            # Name: LiteralType(1000) GetItemOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key=0)
+m)
+            # For: loop_type=DEVICE
+
+            for tile_n, tile_m in 
+            # Call: IterType(SequenceType((TileIndexType(1), TileIndexType(0)))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Attribute: CallableType(tile) AttributeOrigin(value=GlobalOrigin(name='hl'), key='tile')
+            # Name: PythonModuleType(helion.language) GlobalOrigin(name='hl')
+hl.tile(
+            # List: SequenceType([SymIntType(u1*(PythonMod(4*u2*u6 + u4, ((u1 + 1023)//u1)))), SymIntType(u0*(((4*u2*u6 + u4)//(((u1 + 1023)//u1)))))]) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+[
+            # Name: SymIntType(u1*(PythonMod(4*u2*u6 + u4, ((u1 + 1023)//u1)))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_n_start, 
+            # Name: SymIntType(u0*(((4*u2*u6 + u4)//(((u1 + 1023)//u1))))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_m_start], 
+            # List: SequenceType([SymIntType(Min(1024, u1*(PythonMod(4*u2*u6 + u4, ((u1 + 1023)//u1))) + u1)), SymIntType(Min(1000, u0*(((4*u2*u6 + u4)//(((u1 + 1023)//u1)))) + u0))]) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+[
+            # Name: SymIntType(Min(1024, u1*(PythonMod(4*u2*u6 + u4, ((u1 + 1023)//u1))) + u1)) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_n_end, 
+            # Name: SymIntType(Min(1000, u0*(((4*u2*u6 + u4)//(((u1 + 1023)//u1)))) + u0)) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_m_end], block_size=
+            # List: SequenceType([BlockSizeType(1), BlockSizeType(0)]) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+[
+            # Name: BlockSizeType(1) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n_block, 
+            # Name: BlockSizeType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+m_block]):
+                x_tile = 
+                # Call: TensorType([block_size_0, block_size_1], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+                # Attribute: TensorAttributeType AttributeOrigin(value=DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='to')
+                # Subscript: TensorType([block_size_0, block_size_1], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+                # Name: TensorType([1000, 1024], torch.float32) ArgumentOrigin(name='x')
+x[
+                # Name: TileIndexType(0) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+tile_m, 
+                # Name: TileIndexType(1) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+tile_n].to(
+                # Attribute: LiteralType(torch.float32) AttributeOrigin(value=GlobalOrigin(name='torch'), key='float32')
+                # Name: PythonModuleType(torch) GlobalOrigin(name='torch')
+torch.float32)
+                
+                # Subscript: TensorType([block_size_0, block_size_1], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+                # Name: TensorType([1000, 1024], torch.float32) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+out[
+                # Name: TileIndexType(0) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+tile_m, 
+                # Name: TileIndexType(1) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+tile_n] = 
+                # Call: TensorType([block_size_0, block_size_1], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+                # Attribute: TensorAttributeType AttributeOrigin(value=DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='to')
+                # Name: TensorType([block_size_0, block_size_1], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+x_tile.to(
+                # Attribute: LiteralType(torch.float32) AttributeOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='dtype')
+                # Name: TensorType([1000, 1024], torch.float32) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+out.dtype)
+    return 
+    # Name: TensorType([1000, 1024], torch.float32) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+out
+
+def for_loop_0():
+    # File: .../test_type_propagation.py:N in fn, code: x_tile = x[tile_m, tile_n].to(torch.float32)
+    x: "f32[1000, 1024]" = helion_language__tracing_ops__host_tensor('x')
+    block_size_0: "Sym(u0)" = helion_language__tracing_ops__get_symnode('block_size_0')
+    block_size_1: "Sym(u1)" = helion_language__tracing_ops__get_symnode('block_size_1')
+    x_tile: "f32[u0, u1]" = helion_language_memory_ops_load(x, [block_size_0, block_size_1], None, None);  x = None
+
+    # File: .../test_type_propagation.py:N in fn, code: out[tile_m, tile_n] = x_tile.to(out.dtype)
+    out: "f32[1000, 1024]" = helion_language__tracing_ops__host_tensor('out')
+    store = helion_language_memory_ops_store(out, [block_size_0, block_size_1], x_tile, None);  out = block_size_0 = block_size_1 = x_tile = store = None
+    return []
+
+def for_loop_1():
+    # File: .../test_type_propagation.py:N in fn, code: work_n = (worker_id + num_workers * work_item) % n_count
+    symnode: "Sym(4*u2)" = helion_language__tracing_ops__get_symnode('4*u2')
+    u6: "Sym(u6)" = helion_language__tracing_ops__get_symnode('u6')
+    mul: "Sym(4*u2*u6)" = symnode * u6;  symnode = u6 = None
+    u4: "Sym(u4)" = helion_language__tracing_ops__get_symnode('u4')
+    add: "Sym(4*u2*u6 + u4)" = u4 + mul;  u4 = mul = None
+    symnode_1: "Sym(((u1 + 1023)//u1))" = helion_language__tracing_ops__get_symnode('((block_size_1 + 1023)//block_size_1)')
+    mod: "Sym(PythonMod(4*u2*u6 + u4, ((u1 + 1023)//u1)))" = add % symnode_1
+
+    # File: .../test_type_propagation.py:N in fn, code: work_m = (worker_id + num_workers * work_item) // n_count
+    floordiv: "Sym(((4*u2*u6 + u4)//(((u1 + 1023)//u1))))" = add // symnode_1;  add = symnode_1 = None
+
+    # File: .../test_type_propagation.py:N in fn, code: work_n_start = work_n * n_block
+    block_size_1: "Sym(u1)" = helion_language__tracing_ops__get_symnode('block_size_1')
+    mul_2: "Sym(u1*(PythonMod(4*u2*u6 + u4, ((u1 + 1023)//u1))))" = mod * block_size_1;  mod = block_size_1 = None
+
+    # File: .../test_type_propagation.py:N in fn, code: work_m_start = work_m * m_block
+    block_size_0: "Sym(u0)" = helion_language__tracing_ops__get_symnode('block_size_0')
+    mul_3: "Sym(u0*(((4*u2*u6 + u4)//(((u1 + 1023)//u1)))))" = floordiv * block_size_0;  floordiv = block_size_0 = None
+
+    # File: .../test_type_propagation.py:N in fn, code: for tile_n, tile_m in hl.tile(
+    symnode_2: "Sym(Min(1024, u1*(PythonMod(4*u2*u6 + u4, ((u1 + 1023)//u1))) + u1))" = helion_language__tracing_ops__get_symnode('Min(1024, block_size_1*(PythonMod(4*u2*u6 + u4, ((block_size_1 + 1023)//block_size_1))) + block_size_1)')
+    symnode_3: "Sym(Min(1000, u0*(((4*u2*u6 + u4)//(((u1 + 1023)//u1)))) + u0))" = helion_language__tracing_ops__get_symnode('Min(1000, block_size_0*(((4*u2*u6 + u4)//(((block_size_1 + 1023)//block_size_1)))) + block_size_0)')
+    _for_loop = helion_language__tracing_ops__for_loop(0, [mul_2, mul_3], [symnode_2, symnode_3], []);  mul_2 = mul_3 = symnode_2 = symnode_3 = _for_loop = None
+    return []
+
+def root_graph_2():
+    # File: .../test_type_propagation.py:N in fn, code: for work_item in hl.grid(work_per_worker):
+    symnode: "Sym(((4*u2 + (((u0 + 999)//u0))*(((u1 + 1023)//u1)) - 1)//(4*u2)))" = helion_language__tracing_ops__get_symnode('((4*u2 + (((block_size_0 + 999)//block_size_0))*(((block_size_1 + 1023)//block_size_1)) - 1)//(4*u2))')
+    _for_loop = helion_language__tracing_ops__for_loop(1, [0], [symnode], []);  symnode = _for_loop = None
+    return None
+
+--- assertExpectedJournal(TestTypePropagation.test_device_properties_division)
+def fn(x: torch.Tensor):
+    n, = 
+    # Call: SequenceType((LiteralType(1024), )) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: TensorAttributeType AttributeOrigin(value=ArgumentOrigin(name='x'), key='size')
+    # Name: TensorType([1024], torch.float32) ArgumentOrigin(name='x')
+x.size()
+    out = 
+    # Call: TensorType([1024], torch.float32) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: CallableType(_VariableFunctionsClass.empty_like) AttributeOrigin(value=GlobalOrigin(name='torch'), key='empty_like')
+    # Name: PythonModuleType(torch) GlobalOrigin(name='torch')
+torch.empty_like(
+    # Name: TensorType([1024], torch.float32) ArgumentOrigin(name='x')
+x)
+    num_workers = 
+    # Attribute: SymIntType(u0) AttributeOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='multi_processor_count')
+    # Call: ClassType({'multi_processor_count': SymIntType(u0)}) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: CallableType(get_device_properties) AttributeOrigin(value=AttributeOrigin(value=GlobalOrigin(name='torch'), key='cuda'), key='get_device_properties')
+    # Attribute: PythonModuleType(torch.cuda) AttributeOrigin(value=GlobalOrigin(name='torch'), key='cuda')
+    # Name: PythonModuleType(torch) GlobalOrigin(name='torch')
+torch.cuda.get_device_properties(
+    # Attribute: LiteralType(device=DEVICE) AttributeOrigin(value=ArgumentOrigin(name='x'), key='device')
+    # Name: TensorType([1024], torch.float32) ArgumentOrigin(name='x')
+x.device).multi_processor_count
+    num_workers = 
+    # BinOp: SymIntType(2*u0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Name: SymIntType(u0) AttributeOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='multi_processor_count')
+num_workers + 
+    # Name: SymIntType(u0) AttributeOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='multi_processor_count')
+num_workers
+    # For: loop_type=GRID
+
+    for tile in 
+    # Call: IterType(TileIndexType(0)) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: CallableType(tile) AttributeOrigin(value=GlobalOrigin(name='hl'), key='tile')
+    # Name: PythonModuleType(helion.language) GlobalOrigin(name='hl')
+hl.tile(
+    # Name: LiteralType(1024) GetItemOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key=0)
+n):
+        
+        # Subscript: TensorType([block_size_0], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+        # Name: TensorType([1024], torch.float32) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+out[
+        # Name: TileIndexType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+tile] = 
+        # BinOp: TensorType([block_size_0], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+        # Subscript: TensorType([block_size_0], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+        # Name: TensorType([1024], torch.float32) ArgumentOrigin(name='x')
+x[
+        # Name: TileIndexType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+tile] + 
+        # BinOp: SymIntType(u0) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+        # Name: SymIntType(2*u0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+num_workers // 
+        # Constant: LiteralType(2) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+2
+    return 
+    # Name: TensorType([1024], torch.float32) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+out
+
+def root_graph_0():
+    # File: .../test_type_propagation.py:N in fn, code: out[tile] = x[tile] + (num_workers // 2)
+    x: "f32[1024]" = helion_language__tracing_ops__host_tensor('x')
+    block_size_0: "Sym(u1)" = helion_language__tracing_ops__get_symnode('block_size_0')
+    load: "f32[u1]" = helion_language_memory_ops_load(x, [block_size_0], None, None);  x = None
+    symnode: "Sym(2*u0)" = helion_language__tracing_ops__get_symnode('2*u0')
+    floordiv: "Sym(u0)" = symnode // 2;  symnode = None
+    add: "f32[u1]" = torch.ops.aten.add.Tensor(load, floordiv);  load = floordiv = None
+    out: "f32[1024]" = helion_language__tracing_ops__host_tensor('out')
+    store = helion_language_memory_ops_store(out, [block_size_0], add, None);  out = block_size_0 = add = store = None
+    return None
+
+--- assertExpectedJournal(TestTypePropagation.test_device_properties_division_as_grid)
+def fn(x: torch.Tensor):
+    n, = 
+    # Call: SequenceType((LiteralType(1024), )) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: TensorAttributeType AttributeOrigin(value=ArgumentOrigin(name='x'), key='size')
+    # Name: TensorType([1024], torch.float32) ArgumentOrigin(name='x')
+x.size()
+    out = 
+    # Call: TensorType([1024], torch.float32) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: CallableType(_VariableFunctionsClass.zeros_like) AttributeOrigin(value=GlobalOrigin(name='torch'), key='zeros_like')
+    # Name: PythonModuleType(torch) GlobalOrigin(name='torch')
+torch.zeros_like(
+    # Name: TensorType([1024], torch.float32) ArgumentOrigin(name='x')
+x)
+    num_workers = 
+    # Attribute: SymIntType(u0) AttributeOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='multi_processor_count')
+    # Call: ClassType({'multi_processor_count': SymIntType(u0)}) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: CallableType(get_device_properties) AttributeOrigin(value=AttributeOrigin(value=GlobalOrigin(name='torch'), key='cuda'), key='get_device_properties')
+    # Attribute: PythonModuleType(torch.cuda) AttributeOrigin(value=GlobalOrigin(name='torch'), key='cuda')
+    # Name: PythonModuleType(torch) GlobalOrigin(name='torch')
+torch.cuda.get_device_properties(
+    # Attribute: LiteralType(device=DEVICE) AttributeOrigin(value=ArgumentOrigin(name='x'), key='device')
+    # Name: TensorType([1024], torch.float32) ArgumentOrigin(name='x')
+x.device).multi_processor_count
+    num_workers = 
+    # BinOp: SymIntType(2*u0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Name: SymIntType(u0) AttributeOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='multi_processor_count')
+num_workers + 
+    # Name: SymIntType(u0) AttributeOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='multi_processor_count')
+num_workers
+    # For: loop_type=GRID
+
+    for worker_id in 
+    # Call: IterType(GridIndexType(0)) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: CallableType(grid) AttributeOrigin(value=GlobalOrigin(name='hl'), key='grid')
+    # Name: PythonModuleType(helion.language) GlobalOrigin(name='hl')
+hl.grid(
+    # BinOp: SymIntType(u0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Name: SymIntType(2*u0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+num_workers // 
+    # Constant: LiteralType(2) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+2):
+        # For: loop_type=DEVICE
+
+        for tile in 
+        # Call: IterType(TileIndexType(1)) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+        # Attribute: CallableType(tile) AttributeOrigin(value=GlobalOrigin(name='hl'), key='tile')
+        # Name: PythonModuleType(helion.language) GlobalOrigin(name='hl')
+hl.tile(
+        # Name: LiteralType(1024) GetItemOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key=0)
+n):
+            
+            # Subscript: TensorType([block_size_1], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Name: TensorType([1024], torch.float32) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+out[
+            # Name: TileIndexType(1) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+tile] = 
+            # Subscript: TensorType([block_size_1], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Name: TensorType([1024], torch.float32) ArgumentOrigin(name='x')
+x[
+            # Name: TileIndexType(1) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+tile]
+    return 
+    # Name: TensorType([1024], torch.float32) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+out
+
+def for_loop_0():
+    # File: .../test_type_propagation.py:N in fn, code: out[tile] = x[tile]
+    x: "f32[1024]" = helion_language__tracing_ops__host_tensor('x')
+    block_size_1: "Sym(u3)" = helion_language__tracing_ops__get_symnode('block_size_1')
+    load: "f32[u3]" = helion_language_memory_ops_load(x, [block_size_1], None, None);  x = None
+    out: "f32[1024]" = helion_language__tracing_ops__host_tensor('out')
+    store = helion_language_memory_ops_store(out, [block_size_1], load, None);  out = block_size_1 = load = store = None
+    return []
+
+def root_graph_1():
+    # File: .../test_type_propagation.py:N in fn, code: for tile in hl.tile(n):
+    _for_loop = helion_language__tracing_ops__for_loop(0, [0], [1024], []);  _for_loop = None
+    return None
+
+--- assertExpectedJournal(TestTypePropagation.test_device_properties_doubled)
+def fn(x: torch.Tensor, weight: torch.Tensor):
+    m, n = 
+    # Call: SequenceType((LiteralType(1000), LiteralType(1024))) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: TensorAttributeType AttributeOrigin(value=ArgumentOrigin(name='x'), key='size')
+    # Name: TensorType([1000, 1024], torch.float32) ArgumentOrigin(name='x')
+x.size()
+    n = 
+    # Call: LiteralType(1024) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: CallableType(specialize) AttributeOrigin(value=GlobalOrigin(name='hl'), key='specialize')
+    # Name: PythonModuleType(helion.language) GlobalOrigin(name='hl')
+hl.specialize(
+    # Name: LiteralType(1024) GetItemOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key=1)
+n)
+    out = 
+    # Call: TensorType([1000, 1024], torch.float32) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: CallableType(_VariableFunctionsClass.empty_like) AttributeOrigin(value=GlobalOrigin(name='torch'), key='empty_like')
+    # Name: PythonModuleType(torch) GlobalOrigin(name='torch')
+torch.empty_like(
+    # Name: TensorType([1000, 1024], torch.float32) ArgumentOrigin(name='x')
+x)
+    m_block = 
+    # Call: BlockSizeType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: CallableType(register_block_size) AttributeOrigin(value=GlobalOrigin(name='hl'), key='register_block_size')
+    # Name: PythonModuleType(helion.language) GlobalOrigin(name='hl')
+hl.register_block_size(
+    # Name: LiteralType(1000) GetItemOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key=0)
+m)
+    n_block = 
+    # Call: BlockSizeType(1) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: CallableType(register_block_size) AttributeOrigin(value=GlobalOrigin(name='hl'), key='register_block_size')
+    # Name: PythonModuleType(helion.language) GlobalOrigin(name='hl')
+hl.register_block_size(
+    # Name: LiteralType(1024) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n)
+    m_count = 
+    # BinOp: SymIntType(((u0 + 999)//u0)) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # BinOp: SymIntType(u0 + 999) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+(
+    # BinOp: SymIntType(u0 + 1000) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Name: LiteralType(1000) GetItemOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key=0)
+m + 
+    # Name: BlockSizeType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+m_block - 
+    # Constant: LiteralType(1) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+1) // 
+    # Name: BlockSizeType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+m_block
+    n_count = 
+    # BinOp: SymIntType(((u1 + 1023)//u1)) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # BinOp: SymIntType(u1 + 1023) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+(
+    # BinOp: SymIntType(u1 + 1024) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Name: LiteralType(1024) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n + 
+    # Name: BlockSizeType(1) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n_block - 
+    # Constant: LiteralType(1) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+1) // 
+    # Name: BlockSizeType(1) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n_block
+    num_workers = 
+    # Attribute: SymIntType(u2) AttributeOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='multi_processor_count')
+    # Call: ClassType({'multi_processor_count': SymIntType(u2)}) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: CallableType(get_device_properties) AttributeOrigin(value=AttributeOrigin(value=GlobalOrigin(name='torch'), key='cuda'), key='get_device_properties')
+    # Attribute: PythonModuleType(torch.cuda) AttributeOrigin(value=GlobalOrigin(name='torch'), key='cuda')
+    # Name: PythonModuleType(torch) GlobalOrigin(name='torch')
+torch.cuda.get_device_properties(
+    # Attribute: LiteralType(device=DEVICE) AttributeOrigin(value=ArgumentOrigin(name='x'), key='device')
+    # Name: TensorType([1000, 1024], torch.float32) ArgumentOrigin(name='x')
+x.device).multi_processor_count
+    num_workers = 
+    # BinOp: SymIntType(2*u2) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Name: SymIntType(u2) AttributeOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='multi_processor_count')
+num_workers + 
+    # Name: SymIntType(u2) AttributeOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='multi_processor_count')
+num_workers
+    total_work = 
+    # BinOp: SymIntType((((u0 + 999)//u0))*(((u1 + 1023)//u1))) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Name: SymIntType(((u0 + 999)//u0)) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+m_count * 
+    # Name: SymIntType(((u1 + 1023)//u1)) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n_count
+    work_per_worker = 
+    # BinOp: SymIntType(((2*u2 + (((u0 + 999)//u0))*(((u1 + 1023)//u1)) - 1)//(2*u2))) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # BinOp: SymIntType(2*u2 + (((u0 + 999)//u0))*(((u1 + 1023)//u1)) - 1) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+(
+    # BinOp: SymIntType(2*u2 + (((u0 + 999)//u0))*(((u1 + 1023)//u1))) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Name: SymIntType((((u0 + 999)//u0))*(((u1 + 1023)//u1))) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+total_work + 
+    # Name: SymIntType(2*u2) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+num_workers - 
+    # Constant: LiteralType(1) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+1) // 
+    # Name: SymIntType(2*u2) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+num_workers
+    # For: loop_type=GRID
+
+    for worker_id in 
+    # Call: IterType(GridIndexType(2)) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: CallableType(grid) AttributeOrigin(value=GlobalOrigin(name='hl'), key='grid')
+    # Name: PythonModuleType(helion.language) GlobalOrigin(name='hl')
+hl.grid(
+    # Name: SymIntType(2*u2) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+num_workers):
+        # For: loop_type=DEVICE
+
+        for work_item in 
+        # Call: IterType(GridIndexType(3)) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+        # Attribute: CallableType(grid) AttributeOrigin(value=GlobalOrigin(name='hl'), key='grid')
+        # Name: PythonModuleType(helion.language) GlobalOrigin(name='hl')
+hl.grid(
+        # Name: SymIntType(((2*u2 + (((u0 + 999)//u0))*(((u1 + 1023)//u1)) - 1)//(2*u2))) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_per_worker):
+            work_n = 
+            # BinOp: SymIntType(PythonMod(2*u2*u6 + u4, ((u1 + 1023)//u1))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # BinOp: SymIntType(2*u2*u6 + u4) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+(
+            # Name: GridIndexType(2) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+worker_id + 
+            # BinOp: SymIntType(2*u2*u6) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Name: SymIntType(2*u2) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+num_workers * 
+            # Name: GridIndexType(3) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_item) % 
+            # Name: SymIntType(((u1 + 1023)//u1)) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n_count
+            work_m = 
+            # BinOp: SymIntType(((2*u2*u6 + u4)//(((u1 + 1023)//u1)))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # BinOp: SymIntType(2*u2*u6 + u4) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+(
+            # Name: GridIndexType(2) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+worker_id + 
+            # BinOp: SymIntType(2*u2*u6) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Name: SymIntType(2*u2) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+num_workers * 
+            # Name: GridIndexType(3) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_item) // 
+            # Name: SymIntType(((u1 + 1023)//u1)) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n_count
+            work_n_start = 
+            # BinOp: SymIntType(u1*(PythonMod(2*u2*u6 + u4, ((u1 + 1023)//u1)))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Name: SymIntType(PythonMod(2*u2*u6 + u4, ((u1 + 1023)//u1))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_n * 
+            # Name: BlockSizeType(1) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n_block
+            work_n_end = 
+            # Call: SymIntType(Min(1024, u1*(PythonMod(2*u2*u6 + u4, ((u1 + 1023)//u1))) + u1)) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Name: CallableType(min) BuiltinOrigin(name='min')
+min(
+            # BinOp: SymIntType(u1*(PythonMod(2*u2*u6 + u4, ((u1 + 1023)//u1))) + u1) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Name: SymIntType(u1*(PythonMod(2*u2*u6 + u4, ((u1 + 1023)//u1)))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_n_start + 
+            # Name: BlockSizeType(1) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n_block, 
+            # Name: LiteralType(1024) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n)
+            work_m_start = 
+            # BinOp: SymIntType(u0*(((2*u2*u6 + u4)//(((u1 + 1023)//u1))))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Name: SymIntType(((2*u2*u6 + u4)//(((u1 + 1023)//u1)))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_m * 
+            # Name: BlockSizeType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+m_block
+            work_m_end = 
+            # Call: SymIntType(Min(1000, u0*(((2*u2*u6 + u4)//(((u1 + 1023)//u1)))) + u0)) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Name: CallableType(min) BuiltinOrigin(name='min')
+min(
+            # BinOp: SymIntType(u0*(((2*u2*u6 + u4)//(((u1 + 1023)//u1)))) + u0) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Name: SymIntType(u0*(((2*u2*u6 + u4)//(((u1 + 1023)//u1))))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_m_start + 
+            # Name: BlockSizeType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+m_block, 
+            # Name: LiteralType(1000) GetItemOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key=0)
+m)
+            # For: loop_type=DEVICE
+
+            for tile_n, tile_m in 
+            # Call: IterType(SequenceType((TileIndexType(1), TileIndexType(0)))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Attribute: CallableType(tile) AttributeOrigin(value=GlobalOrigin(name='hl'), key='tile')
+            # Name: PythonModuleType(helion.language) GlobalOrigin(name='hl')
+hl.tile(
+            # List: SequenceType([SymIntType(u1*(PythonMod(2*u2*u6 + u4, ((u1 + 1023)//u1)))), SymIntType(u0*(((2*u2*u6 + u4)//(((u1 + 1023)//u1)))))]) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+[
+            # Name: SymIntType(u1*(PythonMod(2*u2*u6 + u4, ((u1 + 1023)//u1)))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_n_start, 
+            # Name: SymIntType(u0*(((2*u2*u6 + u4)//(((u1 + 1023)//u1))))) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_m_start], 
+            # List: SequenceType([SymIntType(Min(1024, u1*(PythonMod(2*u2*u6 + u4, ((u1 + 1023)//u1))) + u1)), SymIntType(Min(1000, u0*(((2*u2*u6 + u4)//(((u1 + 1023)//u1)))) + u0))]) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+[
+            # Name: SymIntType(Min(1024, u1*(PythonMod(2*u2*u6 + u4, ((u1 + 1023)//u1))) + u1)) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_n_end, 
+            # Name: SymIntType(Min(1000, u0*(((2*u2*u6 + u4)//(((u1 + 1023)//u1)))) + u0)) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+work_m_end], block_size=
+            # List: SequenceType([BlockSizeType(1), BlockSizeType(0)]) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+[
+            # Name: BlockSizeType(1) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+n_block, 
+            # Name: BlockSizeType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+m_block]):
+                x_tile = 
+                # Call: TensorType([block_size_0, block_size_1], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+                # Attribute: TensorAttributeType AttributeOrigin(value=DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='to')
+                # Subscript: TensorType([block_size_0, block_size_1], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+                # Name: TensorType([1000, 1024], torch.float32) ArgumentOrigin(name='x')
+x[
+                # Name: TileIndexType(0) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+tile_m, 
+                # Name: TileIndexType(1) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+tile_n].to(
+                # Attribute: LiteralType(torch.float32) AttributeOrigin(value=GlobalOrigin(name='torch'), key='float32')
+                # Name: PythonModuleType(torch) GlobalOrigin(name='torch')
+torch.float32)
+                
+                # Subscript: TensorType([block_size_0, block_size_1], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+                # Name: TensorType([1000, 1024], torch.float32) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+out[
+                # Name: TileIndexType(0) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+tile_m, 
+                # Name: TileIndexType(1) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+tile_n] = 
+                # Call: TensorType([block_size_0, block_size_1], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+                # Attribute: TensorAttributeType AttributeOrigin(value=DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='to')
+                # Name: TensorType([block_size_0, block_size_1], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+x_tile.to(
+                # Attribute: LiteralType(torch.float32) AttributeOrigin(value=SourceOrigin(location=<SourceLocation test_type_propagation.py:N>), key='dtype')
+                # Name: TensorType([1000, 1024], torch.float32) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+out.dtype)
+    return 
+    # Name: TensorType([1000, 1024], torch.float32) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+out
+
+def for_loop_0():
+    # File: .../test_type_propagation.py:N in fn, code: x_tile = x[tile_m, tile_n].to(torch.float32)
+    x: "f32[1000, 1024]" = helion_language__tracing_ops__host_tensor('x')
+    block_size_0: "Sym(u0)" = helion_language__tracing_ops__get_symnode('block_size_0')
+    block_size_1: "Sym(u1)" = helion_language__tracing_ops__get_symnode('block_size_1')
+    x_tile: "f32[u0, u1]" = helion_language_memory_ops_load(x, [block_size_0, block_size_1], None, None);  x = None
+
+    # File: .../test_type_propagation.py:N in fn, code: out[tile_m, tile_n] = x_tile.to(out.dtype)
+    out: "f32[1000, 1024]" = helion_language__tracing_ops__host_tensor('out')
+    store = helion_language_memory_ops_store(out, [block_size_0, block_size_1], x_tile, None);  out = block_size_0 = block_size_1 = x_tile = store = None
+    return []
+
+def for_loop_1():
+    # File: .../test_type_propagation.py:N in fn, code: work_n = (worker_id + num_workers * work_item) % n_count
+    symnode: "Sym(2*u2)" = helion_language__tracing_ops__get_symnode('2*u2')
+    u6: "Sym(u6)" = helion_language__tracing_ops__get_symnode('u6')
+    mul: "Sym(2*u2*u6)" = symnode * u6;  symnode = u6 = None
+    u4: "Sym(u4)" = helion_language__tracing_ops__get_symnode('u4')
+    add: "Sym(2*u2*u6 + u4)" = u4 + mul;  u4 = mul = None
+    symnode_1: "Sym(((u1 + 1023)//u1))" = helion_language__tracing_ops__get_symnode('((block_size_1 + 1023)//block_size_1)')
+    mod: "Sym(PythonMod(2*u2*u6 + u4, ((u1 + 1023)//u1)))" = add % symnode_1
+
+    # File: .../test_type_propagation.py:N in fn, code: work_m = (worker_id + num_workers * work_item) // n_count
+    floordiv: "Sym(((2*u2*u6 + u4)//(((u1 + 1023)//u1))))" = add // symnode_1;  add = symnode_1 = None
+
+    # File: .../test_type_propagation.py:N in fn, code: work_n_start = work_n * n_block
+    block_size_1: "Sym(u1)" = helion_language__tracing_ops__get_symnode('block_size_1')
+    mul_2: "Sym(u1*(PythonMod(2*u2*u6 + u4, ((u1 + 1023)//u1))))" = mod * block_size_1;  mod = block_size_1 = None
+
+    # File: .../test_type_propagation.py:N in fn, code: work_m_start = work_m * m_block
+    block_size_0: "Sym(u0)" = helion_language__tracing_ops__get_symnode('block_size_0')
+    mul_3: "Sym(u0*(((2*u2*u6 + u4)//(((u1 + 1023)//u1)))))" = floordiv * block_size_0;  floordiv = block_size_0 = None
+
+    # File: .../test_type_propagation.py:N in fn, code: for tile_n, tile_m in hl.tile(
+    symnode_2: "Sym(Min(1024, u1*(PythonMod(2*u2*u6 + u4, ((u1 + 1023)//u1))) + u1))" = helion_language__tracing_ops__get_symnode('Min(1024, block_size_1*(PythonMod(2*u2*u6 + u4, ((block_size_1 + 1023)//block_size_1))) + block_size_1)')
+    symnode_3: "Sym(Min(1000, u0*(((2*u2*u6 + u4)//(((u1 + 1023)//u1)))) + u0))" = helion_language__tracing_ops__get_symnode('Min(1000, block_size_0*(((2*u2*u6 + u4)//(((block_size_1 + 1023)//block_size_1)))) + block_size_0)')
+    _for_loop = helion_language__tracing_ops__for_loop(0, [mul_2, mul_3], [symnode_2, symnode_3], []);  mul_2 = mul_3 = symnode_2 = symnode_3 = _for_loop = None
+    return []
+
+def root_graph_2():
+    # File: .../test_type_propagation.py:N in fn, code: for work_item in hl.grid(work_per_worker):
+    symnode: "Sym(((2*u2 + (((u0 + 999)//u0))*(((u1 + 1023)//u1)) - 1)//(2*u2)))" = helion_language__tracing_ops__get_symnode('((2*u2 + (((block_size_0 + 999)//block_size_0))*(((block_size_1 + 1023)//block_size_1)) - 1)//(2*u2))')
+    _for_loop = helion_language__tracing_ops__for_loop(1, [0], [symnode], []);  symnode = _for_loop = None
+    return None
+
 --- assertExpectedJournal(TestTypePropagation.test_hl_full_usage)
 def hl_full_usage(x: torch.Tensor):
     out = 
@@ -1010,6 +1720,110 @@ def root_graph_0():
     # File: .../basic_kernels.py:N in hl_zeros_usage, code: out[tile] = tmp
     out: "i32[512, 512]" = helion_language__tracing_ops__host_tensor('out')
     store = helion_language_memory_ops_store(out, [block_size_0, block_size_1], tmp_2, None);  out = block_size_0 = block_size_1 = tmp_2 = store = None
+    return None
+
+--- assertExpectedJournal(TestTypePropagation.test_list_iteration)
+def kernel_list_iteration(tensor_list: list[torch.Tensor]):
+    M, = 
+    # Attribute: SequenceType((LiteralType(16), )) AttributeOrigin(value=GetItemOrigin(value=ArgumentOrigin(name='tensor_list'), key=0), key='shape')
+    # Subscript: TensorType([16], torch.float32) GetItemOrigin(value=ArgumentOrigin(name='tensor_list'), key=0)
+    # Name: SequenceType([TensorType([16], torch.float32), TensorType([16], torch.float32), TensorType([16], torch.float32), TensorType([16], torch.float32)]) ArgumentOrigin(name='tensor_list')
+tensor_list[
+    # Constant: LiteralType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+0].shape
+    result = 
+    # Call: TensorType([16], torch.float32) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: CallableType(_VariableFunctionsClass.zeros_like) AttributeOrigin(value=GlobalOrigin(name='torch'), key='zeros_like')
+    # Name: PythonModuleType(torch) GlobalOrigin(name='torch')
+torch.zeros_like(
+    # Subscript: TensorType([16], torch.float32) GetItemOrigin(value=ArgumentOrigin(name='tensor_list'), key=0)
+    # Name: SequenceType([TensorType([16], torch.float32), TensorType([16], torch.float32), TensorType([16], torch.float32), TensorType([16], torch.float32)]) ArgumentOrigin(name='tensor_list')
+tensor_list[
+    # Constant: LiteralType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+0])
+    # For: loop_type=GRID
+
+    for tile_m in 
+    # Call: IterType(TileIndexType(0)) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+    # Attribute: CallableType(tile) AttributeOrigin(value=GlobalOrigin(name='hl'), key='tile')
+    # Name: PythonModuleType(helion.language) GlobalOrigin(name='hl')
+hl.tile(
+    # Name: LiteralType(16) GetItemOrigin(value=AttributeOrigin(value=GetItemOrigin(value=ArgumentOrigin(name='tensor_list'), key=0), key='shape'), key=0)
+M):
+        acc = 
+        # Call: TensorType([block_size_0], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+        # Attribute: CallableType(zeros) AttributeOrigin(value=GlobalOrigin(name='hl'), key='zeros')
+        # Name: PythonModuleType(helion.language) GlobalOrigin(name='hl')
+hl.zeros(
+        # List: SequenceType([TileIndexType(0)]) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+[
+        # Name: TileIndexType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+tile_m], dtype=
+        # Attribute: LiteralType(torch.float32) AttributeOrigin(value=GlobalOrigin(name='torch'), key='float32')
+        # Name: PythonModuleType(torch) GlobalOrigin(name='torch')
+torch.float32)
+        # For: loop_type=DEVICE
+
+        for tensor in 
+        # Name: SequenceType([TensorType([16], torch.float32), TensorType([16], torch.float32), TensorType([16], torch.float32), TensorType([16], torch.float32)]) ArgumentOrigin(name='tensor_list')
+tensor_list:
+            acc = 
+            # BinOp: TensorType([block_size_0], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Name: TensorType([block_size_0], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+acc + 
+            # Subscript: TensorType([block_size_0], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+            # Name: TensorType([16], torch.float32) GetItemOrigin(value=ArgumentOrigin(name='tensor_list'), key=3)
+tensor[
+            # Name: TileIndexType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+tile_m]
+        
+        # Subscript: TensorType([block_size_0], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+        # Name: TensorType([16], torch.float32) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+result[
+        # Name: TileIndexType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+tile_m] = 
+        # Name: TensorType([block_size_0], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+acc
+    return 
+    # Name: TensorType([16], torch.float32) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
+result
+
+def root_graph_0():
+    # File: .../test_type_propagation.py:N in kernel_list_iteration, code: acc = hl.zeros([tile_m], dtype=torch.float32)
+    block_size_0: "Sym(u0)" = helion_language__tracing_ops__get_symnode('block_size_0')
+    acc: "f32[u0]" = helion_language_creation_ops_full([block_size_0], 0.0, torch.float32, None)
+
+    # File: .../test_type_propagation.py:N in kernel_list_iteration, code: for tensor in tensor_list:
+    tensor_list_item_0: "f32[16]" = helion_language__tracing_ops__host_tensor('tensor_list[0]')
+
+    # File: .../test_type_propagation.py:N in kernel_list_iteration, code: acc = acc + tensor[tile_m]
+    load: "f32[u0]" = helion_language_memory_ops_load(tensor_list_item_0, [block_size_0], None, None);  tensor_list_item_0 = None
+    acc_1: "f32[u0]" = torch.ops.aten.add.Tensor(acc, load);  acc = load = None
+
+    # File: .../test_type_propagation.py:N in kernel_list_iteration, code: for tensor in tensor_list:
+    tensor_list_item_1: "f32[16]" = helion_language__tracing_ops__host_tensor('tensor_list[1]')
+
+    # File: .../test_type_propagation.py:N in kernel_list_iteration, code: acc = acc + tensor[tile_m]
+    load_1: "f32[u0]" = helion_language_memory_ops_load(tensor_list_item_1, [block_size_0], None, None);  tensor_list_item_1 = None
+    acc_2: "f32[u0]" = torch.ops.aten.add.Tensor(acc_1, load_1);  acc_1 = load_1 = None
+
+    # File: .../test_type_propagation.py:N in kernel_list_iteration, code: for tensor in tensor_list:
+    tensor_list_item_2: "f32[16]" = helion_language__tracing_ops__host_tensor('tensor_list[2]')
+
+    # File: .../test_type_propagation.py:N in kernel_list_iteration, code: acc = acc + tensor[tile_m]
+    load_2: "f32[u0]" = helion_language_memory_ops_load(tensor_list_item_2, [block_size_0], None, None);  tensor_list_item_2 = None
+    acc_3: "f32[u0]" = torch.ops.aten.add.Tensor(acc_2, load_2);  acc_2 = load_2 = None
+
+    # File: .../test_type_propagation.py:N in kernel_list_iteration, code: for tensor in tensor_list:
+    tensor_list_item_3: "f32[16]" = helion_language__tracing_ops__host_tensor('tensor_list[3]')
+
+    # File: .../test_type_propagation.py:N in kernel_list_iteration, code: acc = acc + tensor[tile_m]
+    load_3: "f32[u0]" = helion_language_memory_ops_load(tensor_list_item_3, [block_size_0], None, None);  tensor_list_item_3 = None
+    acc_4: "f32[u0]" = torch.ops.aten.add.Tensor(acc_3, load_3);  acc_3 = load_3 = None
+
+    # File: .../test_type_propagation.py:N in kernel_list_iteration, code: result[tile_m] = acc
+    result: "f32[16]" = helion_language__tracing_ops__host_tensor('result')
+    store = helion_language_memory_ops_store(result, [block_size_0], acc_4, None);  result = block_size_0 = acc_4 = store = None
     return None
 
 --- assertExpectedJournal(TestTypePropagation.test_matmul)
@@ -1371,108 +2185,4 @@ def root_graph_0():
     convert_element_type: "i32[u0]" = torch.ops.prims.convert_element_type.default(sigmoid, torch.int32);  sigmoid = None
     out: "i32[1024]" = helion_language__tracing_ops__host_tensor('out')
     store = helion_language_memory_ops_store(out, [block_size_0], convert_element_type, None);  out = block_size_0 = convert_element_type = store = None
-    return None
-
---- assertExpectedJournal(TestTypePropagation.test_list_iteration)
-def kernel_list_iteration(tensor_list: list[torch.Tensor]):
-    M, = 
-    # Attribute: SequenceType((LiteralType(16), )) AttributeOrigin(value=GetItemOrigin(value=ArgumentOrigin(name='tensor_list'), key=0), key='shape')
-    # Subscript: TensorType([16], torch.float32) GetItemOrigin(value=ArgumentOrigin(name='tensor_list'), key=0)
-    # Name: SequenceType([TensorType([16], torch.float32), TensorType([16], torch.float32), TensorType([16], torch.float32), TensorType([16], torch.float32)]) ArgumentOrigin(name='tensor_list')
-tensor_list[
-    # Constant: LiteralType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
-0].shape
-    result = 
-    # Call: TensorType([16], torch.float32) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
-    # Attribute: CallableType(_VariableFunctionsClass.zeros_like) AttributeOrigin(value=GlobalOrigin(name='torch'), key='zeros_like')
-    # Name: PythonModuleType(torch) GlobalOrigin(name='torch')
-torch.zeros_like(
-    # Subscript: TensorType([16], torch.float32) GetItemOrigin(value=ArgumentOrigin(name='tensor_list'), key=0)
-    # Name: SequenceType([TensorType([16], torch.float32), TensorType([16], torch.float32), TensorType([16], torch.float32), TensorType([16], torch.float32)]) ArgumentOrigin(name='tensor_list')
-tensor_list[
-    # Constant: LiteralType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
-0])
-    # For: loop_type=GRID
-
-    for tile_m in 
-    # Call: IterType(TileIndexType(0)) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
-    # Attribute: CallableType(tile) AttributeOrigin(value=GlobalOrigin(name='hl'), key='tile')
-    # Name: PythonModuleType(helion.language) GlobalOrigin(name='hl')
-hl.tile(
-    # Name: LiteralType(16) GetItemOrigin(value=AttributeOrigin(value=GetItemOrigin(value=ArgumentOrigin(name='tensor_list'), key=0), key='shape'), key=0)
-M):
-        acc = 
-        # Call: TensorType([block_size_0], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
-        # Attribute: CallableType(zeros) AttributeOrigin(value=GlobalOrigin(name='hl'), key='zeros')
-        # Name: PythonModuleType(helion.language) GlobalOrigin(name='hl')
-hl.zeros(
-        # List: SequenceType([TileIndexType(0)]) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
-[
-        # Name: TileIndexType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
-tile_m], dtype=
-        # Attribute: LiteralType(torch.float32) AttributeOrigin(value=GlobalOrigin(name='torch'), key='float32')
-        # Name: PythonModuleType(torch) GlobalOrigin(name='torch')
-torch.float32)
-        # For: loop_type=DEVICE
-
-        for tensor in 
-        # Name: SequenceType([TensorType([16], torch.float32), TensorType([16], torch.float32), TensorType([16], torch.float32), TensorType([16], torch.float32)]) ArgumentOrigin(name='tensor_list')
-tensor_list:
-            acc = 
-            # BinOp: TensorType([block_size_0], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
-            # Name: TensorType([block_size_0], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
-acc + 
-            # Subscript: TensorType([block_size_0], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
-            # Name: TensorType([16], torch.float32) GetItemOrigin(value=ArgumentOrigin(name='tensor_list'), key=3)
-tensor[
-            # Name: TileIndexType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
-tile_m]
-        
-        # Subscript: TensorType([block_size_0], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
-        # Name: TensorType([16], torch.float32) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
-result[
-        # Name: TileIndexType(0) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
-tile_m] = 
-        # Name: TensorType([block_size_0], torch.float32) DeviceOrigin(location=<SourceLocation test_type_propagation.py:N>)
-acc
-    return 
-    # Name: TensorType([16], torch.float32) SourceOrigin(location=<SourceLocation test_type_propagation.py:N>)
-result
-
-def root_graph_0():
-    # File: .../test_type_propagation.py:N in kernel_list_iteration, code: acc = hl.zeros([tile_m], dtype=torch.float32)
-    block_size_0: "Sym(u0)" = helion_language__tracing_ops__get_symnode('block_size_0')
-    acc: "f32[u0]" = helion_language_creation_ops_full([block_size_0], 0.0, torch.float32, None)
-
-    # File: .../test_type_propagation.py:N in kernel_list_iteration, code: for tensor in tensor_list:
-    tensor_list_item_0: "f32[16]" = helion_language__tracing_ops__host_tensor('tensor_list[0]')
-
-    # File: .../test_type_propagation.py:N in kernel_list_iteration, code: acc = acc + tensor[tile_m]
-    load: "f32[u0]" = helion_language_memory_ops_load(tensor_list_item_0, [block_size_0], None, None);  tensor_list_item_0 = None
-    acc_1: "f32[u0]" = torch.ops.aten.add.Tensor(acc, load);  acc = load = None
-
-    # File: .../test_type_propagation.py:N in kernel_list_iteration, code: for tensor in tensor_list:
-    tensor_list_item_1: "f32[16]" = helion_language__tracing_ops__host_tensor('tensor_list[1]')
-
-    # File: .../test_type_propagation.py:N in kernel_list_iteration, code: acc = acc + tensor[tile_m]
-    load_1: "f32[u0]" = helion_language_memory_ops_load(tensor_list_item_1, [block_size_0], None, None);  tensor_list_item_1 = None
-    acc_2: "f32[u0]" = torch.ops.aten.add.Tensor(acc_1, load_1);  acc_1 = load_1 = None
-
-    # File: .../test_type_propagation.py:N in kernel_list_iteration, code: for tensor in tensor_list:
-    tensor_list_item_2: "f32[16]" = helion_language__tracing_ops__host_tensor('tensor_list[2]')
-
-    # File: .../test_type_propagation.py:N in kernel_list_iteration, code: acc = acc + tensor[tile_m]
-    load_2: "f32[u0]" = helion_language_memory_ops_load(tensor_list_item_2, [block_size_0], None, None);  tensor_list_item_2 = None
-    acc_3: "f32[u0]" = torch.ops.aten.add.Tensor(acc_2, load_2);  acc_2 = load_2 = None
-
-    # File: .../test_type_propagation.py:N in kernel_list_iteration, code: for tensor in tensor_list:
-    tensor_list_item_3: "f32[16]" = helion_language__tracing_ops__host_tensor('tensor_list[3]')
-
-    # File: .../test_type_propagation.py:N in kernel_list_iteration, code: acc = acc + tensor[tile_m]
-    load_3: "f32[u0]" = helion_language_memory_ops_load(tensor_list_item_3, [block_size_0], None, None);  tensor_list_item_3 = None
-    acc_4: "f32[u0]" = torch.ops.aten.add.Tensor(acc_3, load_3);  acc_3 = load_3 = None
-
-    # File: .../test_type_propagation.py:N in kernel_list_iteration, code: result[tile_m] = acc
-    result: "f32[16]" = helion_language__tracing_ops__host_tensor('result')
-    store = helion_language_memory_ops_store(result, [block_size_0], acc_4, None);  result = block_size_0 = acc_4 = store = None
     return None

--- a/test/test_type_propagation.py
+++ b/test/test_type_propagation.py
@@ -11,8 +11,10 @@ from helion import exc
 from helion._testing import DEVICE
 from helion._testing import RefEagerTestDisabled
 from helion._testing import TestCase
+from helion._testing import code_and_output
 from helion._testing import import_path
 from helion._testing import onlyBackends
+from helion._testing import skipIfRefEager
 from helion._testing import skipIfXPU
 import helion.language as hl
 
@@ -134,9 +136,172 @@ class TestTypePropagation(RefEagerTestDisabled, TestCase):
         x = torch.ones([16], device="cuda")  # @ignore-device-lint
         with self.assertRaisesRegex(
             exc.TypeInferenceError,
-            r"Attribute 'total_memory' is not supported on .*test_type_propagation.py",
+            r"Attribute 'total_memory' is not supported on",
         ):
             type_propagation_report(use_unsupported_property, x)
+
+    @skipIfXPU("CUDA-only")
+    @skipIfRefEager("Config tests not applicable in ref eager mode")
+    def test_device_properties_arithmetic(self):
+        """Regression test for https://github.com/pytorch/helion/issues/778:
+        'error when operating on python int' when doing math on a value from
+        torch.cuda.get_device_properties().
+
+        The crash requires: (1) multi_processor_count assigned then used in
+        arithmetic that produces a compound sympy expression (e.g. 4*u0),
+        and (2) that expression multiplied with another symbol in device code
+        so sympy decomposes back to the original free symbol u0 whose
+        expr_to_origin still points at SourceOrigin.
+        """
+
+        @helion.kernel(config=helion.Config(block_sizes=[1, 8192]))
+        def fn(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            n = hl.specialize(n)
+            out = torch.empty_like(x)
+            m_block = hl.register_block_size(m)
+            n_block = hl.register_block_size(n)
+            m_count = (m + m_block - 1) // m_block
+            n_count = (n + n_block - 1) // n_block
+            num_workers = torch.cuda.get_device_properties(
+                x.device
+            ).multi_processor_count
+            num_workers = num_workers + num_workers + num_workers + num_workers
+            total_work = m_count * n_count
+            work_per_worker = (total_work + num_workers - 1) // num_workers
+            for worker_id in hl.grid(num_workers):
+                for work_item in hl.grid(work_per_worker):
+                    work_n = (worker_id + num_workers * work_item) % n_count
+                    work_m = (worker_id + num_workers * work_item) // n_count
+                    work_n_start = work_n * n_block
+                    work_n_end = min(work_n_start + n_block, n)
+                    work_m_start = work_m * m_block
+                    work_m_end = min(work_m_start + m_block, m)
+                    for tile_n, tile_m in hl.tile(
+                        [work_n_start, work_m_start],
+                        [work_n_end, work_m_end],
+                        block_size=[n_block, m_block],
+                    ):
+                        x_tile = x[tile_m, tile_n].to(torch.float32)
+                        out[tile_m, tile_n] = x_tile.to(out.dtype)
+            return out
+
+        x = torch.randn(1000, 1024, device=DEVICE)
+        w = torch.randn(1024, device=DEVICE)
+        output = type_propagation_report(fn, x, w)
+        self.assertExpectedJournal(output)
+        code, result = code_and_output(fn, (x, w))
+        torch.testing.assert_close(result, x)
+        self.assertIn("num_workers", code)
+        # The Triton kernel should receive num_workers as a parameter,
+        # not repeat the get_device_properties() call in device code.
+        kernel_code = code.split("@triton.jit")[1].split("\ndef ")[0]
+        self.assertNotIn("get_device_properties", kernel_code)
+
+    @skipIfXPU("CUDA-only")
+    @skipIfRefEager("Config tests not applicable in ref eager mode")
+    def test_device_properties_doubled(self):
+        """Variant of test_device_properties_arithmetic using 2*u0 instead of 4*u0."""
+
+        @helion.kernel(config=helion.Config(block_sizes=[1, 8192]))
+        def fn(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            n = hl.specialize(n)
+            out = torch.empty_like(x)
+            m_block = hl.register_block_size(m)
+            n_block = hl.register_block_size(n)
+            m_count = (m + m_block - 1) // m_block
+            n_count = (n + n_block - 1) // n_block
+            num_workers = torch.cuda.get_device_properties(
+                x.device
+            ).multi_processor_count
+            num_workers = num_workers + num_workers
+            total_work = m_count * n_count
+            work_per_worker = (total_work + num_workers - 1) // num_workers
+            for worker_id in hl.grid(num_workers):
+                for work_item in hl.grid(work_per_worker):
+                    work_n = (worker_id + num_workers * work_item) % n_count
+                    work_m = (worker_id + num_workers * work_item) // n_count
+                    work_n_start = work_n * n_block
+                    work_n_end = min(work_n_start + n_block, n)
+                    work_m_start = work_m * m_block
+                    work_m_end = min(work_m_start + m_block, m)
+                    for tile_n, tile_m in hl.tile(
+                        [work_n_start, work_m_start],
+                        [work_n_end, work_m_end],
+                        block_size=[n_block, m_block],
+                    ):
+                        x_tile = x[tile_m, tile_n].to(torch.float32)
+                        out[tile_m, tile_n] = x_tile.to(out.dtype)
+            return out
+
+        x = torch.randn(1000, 1024, device=DEVICE)
+        w = torch.randn(1024, device=DEVICE)
+        output = type_propagation_report(fn, x, w)
+        self.assertExpectedJournal(output)
+        code, result = code_and_output(fn, (x, w))
+        torch.testing.assert_close(result, x)
+        self.assertIn("num_workers", code)
+        kernel_code = code.split("@triton.jit")[1].split("\ndef ")[0]
+        self.assertNotIn("get_device_properties", kernel_code)
+
+    @skipIfXPU("CUDA-only")
+    @skipIfRefEager("Config tests not applicable in ref eager mode")
+    def test_device_properties_division(self):
+        """Device-code division that strips the compound factor, leaving bare u0.
+
+        num_workers = sm_count + sm_count  (= 2*u0, overwrites sm_count)
+        In device code: num_workers // 2  simplifies to u0, which has no
+        named variable and only a SourceOrigin.
+        """
+
+        @helion.kernel(config=helion.Config(block_sizes=[128]))
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            (n,) = x.size()
+            out = torch.empty_like(x)
+            num_workers = torch.cuda.get_device_properties(
+                x.device
+            ).multi_processor_count
+            # Overwrite so u0 has no named variable at grid boundary
+            num_workers = num_workers + num_workers  # 2*u0
+            for tile in hl.tile(n):
+                # num_workers // 2 simplifies to bare u0 in sympy,
+                # exercising _resolve_via_compound in codegen
+                out[tile] = x[tile] + (num_workers // 2)
+            return out
+
+        x = torch.randn(1024, device="cuda")  # @ignore-device-lint
+        output = type_propagation_report(fn, x)
+        self.assertExpectedJournal(output)
+        sm_count = torch.cuda.get_device_properties(x.device).multi_processor_count
+        code, result = code_and_output(fn, (x,))
+        torch.testing.assert_close(result, x + sm_count)
+        self.assertIn("num_workers", code)
+
+    @skipIfXPU("CUDA-only")
+    @skipIfRefEager("Config tests not applicable in ref eager mode")
+    def test_device_properties_division_as_grid(self):
+        """Bare u0 used as hl.grid size (host-side HostFunction.sympy_expr)."""
+
+        @helion.kernel(config=helion.Config(block_sizes=[128]))
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            (n,) = x.size()
+            out = torch.zeros_like(x)
+            num_workers = torch.cuda.get_device_properties(
+                x.device
+            ).multi_processor_count
+            num_workers = num_workers + num_workers  # 2*u0 (overwrites)
+            # num_workers // 2 = u0 used as grid size
+            for worker_id in hl.grid(num_workers // 2):
+                for tile in hl.tile(n):
+                    out[tile] = x[tile]
+            return out
+
+        x = torch.randn(1024, device="cuda")  # @ignore-device-lint
+        output = type_propagation_report(fn, x)
+        self.assertExpectedJournal(output)
+        code, result = code_and_output(fn, (x,))
+        torch.testing.assert_close(result, x)
 
     def test_and_between_optional_tensors(self):
         @helion.kernel()


### PR DESCRIPTION
SourceOrigin is a fallback origin without host_str(), so calling host_str() on values derived from get_device_properties() crashed when generating host code. This PR introduces CallOrigin that composes the function's origin with its argument origins to reconstruct call expressions like `torch.cuda.get_device_properties(x.device)`.

Fixes https://github.com/pytorch/helion/issues/778