### PR TITLE
Properly generate floor division using // for constexpr

### DIFF
--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -884,32 +884,16 @@ class HelionTritonPrinter(TritonPrinter):
         # pyrefly: ignore [missing-attribute]
         return f"{self._print(expr.args[0])} + 0.0"
 
-    def _is_constexpr_arg(self, expr: sympy.Basic) -> bool:
-        """Check if this expression is a constexpr argument (autotune parameter).
-
-        Constexpr arguments are block sizes and other autotuned parameters that are
-        guaranteed to be positive integers and can be used in compile-time expressions
-        like TMA descriptor creation.
-
-        Returns:
-            True if expr is a Symbol that corresponds to a constexpr argument
-        """
-        if not isinstance(expr, sympy.Symbol):
-            return False
-        try:
-            device_fn = DeviceFunction.current()
-            return expr.name in device_fn._constexpr_args
-        except NoCurrentFunction:
-            return False
-
     def _print_FloorDiv(self, expr: sympy.Expr) -> str:
         lhs, rhs = expr.args
         # Only use // operator when:
-        # 1. RHS is a positive integer constant
+        # 1. RHS is an integer constant
         # 2. LHS is a constexpr argument (autotune parameter like block size)
         # This ensures TMA descriptors get compile-time constants while preserving
-        # correct floor division semantics for other cases
-        if isinstance(rhs, sympy.Integer) and rhs > 0 and self._is_constexpr_arg(lhs):
+        if (
+            isinstance(rhs, sympy.Integer)
+            and getattr(lhs, "name", None) in DeviceFunction.current()._constexpr_args
+        ):
             # pyrefly: ignore [missing-attribute]
             lhs_str = self._print(lhs)
             # pyrefly: ignore [missing-attribute]

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1112,6 +1112,41 @@ class TestHelionTritonPrinter(TestCase):
             self.assertNotIn("tl.full", result)
             self.assertAlmostEqual(float(result), val)
 
+    def test_print_FloorDiv_constexpr(self):
+        """Test that FloorDiv with constexpr LHS prints as // operator.
+
+        This is required for TMA tensor descriptors which need compile-time
+        constant block shapes. When the LHS is a constexpr argument (like a
+        block size), we must emit `lhs // rhs` instead of
+        `triton_helpers.div_floor_integer(lhs, rhs)` so Triton can evaluate
+        the expression at compile time.
+        """
+        from unittest.mock import Mock
+
+        import sympy
+        from torch.utils._sympy.functions import FloorDiv
+
+        from helion._compiler.device_function import DeviceFunction
+        from helion._compiler.device_function import HelionTritonPrinter
+
+        printer = HelionTritonPrinter()
+
+        # LHS is constexpr -> use //
+        mock_df = Mock(_constexpr_args={"_BLOCK_SIZE_0": None})
+        with patch.object(DeviceFunction, "current", return_value=mock_df):
+            block_size = sympy.Symbol("_BLOCK_SIZE_0", integer=True)
+            expr = FloorDiv(block_size, 2)
+            result = printer.doprint(expr)
+            self.assertEqual(result, "_BLOCK_SIZE_0 // 2")
+
+        # LHS is NOT constexpr -> fallback to triton_helpers
+        mock_df = Mock(_constexpr_args={})
+        with patch.object(DeviceFunction, "current", return_value=mock_df):
+            x = sympy.Symbol("x", integer=True)
+            expr = FloorDiv(x, 2)
+            result = printer.doprint(expr)
+            self.assertIn("div_floor_integer", result)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Previously, `triton.helpers.div_floor_integer` was generated for all floordivs. However, for constexpr, such as in the context of dividing block sizes, the normal // should be used. This PR fixes that case