### PR TITLE
[CI] Relax tolerances in `test_hl_arange_non_power_of_2`

### DIFF
--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -200,8 +200,8 @@ class TestIndexing(RefEagerTestBase, TestCase):
         ref_grad_x = (dz @ y.to(torch.float32).t()).to(grad_x.dtype)
         ref_grad_y = (x.to(torch.float32).t() @ dz).to(grad_y.dtype)
 
-        torch.testing.assert_close(grad_x, ref_grad_x, rtol=1e-3, atol=3e-3)
-        torch.testing.assert_close(grad_y, ref_grad_y, rtol=1e-3, atol=4e-3)
+        torch.testing.assert_close(grad_x, ref_grad_x, rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(grad_y, ref_grad_y, rtol=1e-2, atol=1e-2)
         # TODO(oulgen): needs mindot size mocked
 
     def test_pairwise_add(self):


### PR DESCRIPTION
The fp16 matmul + layernorm backward with non-power-of-2 dimensions can produce numerical differences up to ~0.006, exceeding the previous atol of 0.003. Bump rtol and atol to 1e-2 for both grad_x and grad_y checks.

Example error: https://github.com/pytorch/helion/actions/runs/22791955482/job/66120349969?pr=1053
```
FAILED test/test_indexing.py::TestIndexing::test_hl_arange_non_power_of_2 - AssertionError: Tensor-likes are not close!

Mismatched elements: 1 / 15 (6.7%)
Greatest absolute difference: 0.00634765625 at index (3, 0) (up to 0.003 allowed)
Greatest relative difference: 0.006999969482421875 at index (3, 0) (up to 0.001 allowed)
```