### PR TITLE
Fix lerp decomp in _make_fx for PyTorch nightly

### DIFF
--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -199,7 +199,7 @@ def _make_fx(fn: Callable[..., object], *args: object) -> torch.fx.Graph:
         ),
     ):
         current_location().set_fx_location()
-        return proxy_tensor.make_fx(fn, decomposition_table=select_decomp_table())(
+        return proxy_tensor.make_fx(fn, decomposition_table=_get_custom_decomp_table())(
             *args
         ).graph
 

--- a/test/test_broadcasting.py
+++ b/test/test_broadcasting.py
@@ -149,9 +149,6 @@ class TestBroadcasting(RefEagerTestBase, TestCase):
         code, out = code_and_output(fn, args)
         torch.testing.assert_close(out, expected)
 
-    @xfailIfCute(
-        "torch.lerp scalar lowering emits an undefined mlir_math symbol in CuTe codegen"
-    )
     def test_lerp_scalar_weight(self):
         # Repro for https://github.com/pytorch/helion/issues/448
         # Using torch.lerp with a Python scalar weight should not crash.


### PR DESCRIPTION
## Summary
- The previous lerp fix (#1652) only added the custom `lerp.Scalar` decomposition to `_get_custom_decomp_table()`, used by `_trace_graph()` for subgraph tracing. But `_make_fx()` (root-level tracing) was still using `select_decomp_table()` directly, so `torch.lerp` with a scalar weight still hit inductor's `_lerp_scalar` which guards on `weight >= 0.5`, crashing with `GuardOnDataDependentSymNode` on PyTorch nightly.
- Removes the now-unnecessary `@xfailIfCute` on `test_lerp_scalar_weight` — the custom decomposition decomposes lerp before it reaches CuTe codegen, avoiding the `mlir_math` symbol issue.

## Test plan
- [x] Reproduced failure on PyTorch nightly (`2.12.0.dev20260311+cu128`) without fix
- [x] Verified fix resolves the failure on nightly
- [x] `test/test_broadcasting.py` — all 10 tests pass
- [x] Lint clean (`./lint.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)