### PR TITLE
[pallas-tpu] Fix BlockSpec regressions from codegen BlockSpecs PR

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1154,7 +1154,16 @@ class PallasBackend(Backend):
         self,
         sorted_args: list[Argument] | None,
         config: Config,
-    ) -> list[tuple[tuple[int | None, ...], tuple[int | None, ...]] | None] | None:
+    ) -> (
+        list[
+            tuple[
+                tuple[int | None, ...],
+                tuple[int | tuple[int, int, int] | None, ...],
+            ]
+            | None
+        ]
+        | None
+    ):
         """Compute per-tensor ``(block_shape, grid_dims)`` from codegen tiling info.
 
         Uses ``DeviceFunction.pallas_tensor_dim_block_ids`` (recorded during
@@ -1171,6 +1180,7 @@ class PallasBackend(Backend):
         from .device_function import TensorSizeArg
         from .device_function import TensorStrideArg
         from .host_function import HostFunction
+        from .program_id import FlatProgramIDs
 
         env = CompileEnvironment.current()
         device_fn = DeviceFunction.current()
@@ -1182,7 +1192,35 @@ class PallasBackend(Backend):
             flat_grid_block_ids.extend(block_ids)
         block_id_to_grid_dim = {bid: g for g, bid in enumerate(flat_grid_block_ids)}
 
-        result: list[tuple[tuple[int | None, ...], tuple[int | None, ...]] | None] = []
+        # FlatProgramIDs compresses all block_ids into a single 1D grid.
+        # Build a decomposition table so index_maps can recover per-block-id
+        # offsets via div/mod on the flat grid arg.
+        flat_decomp: dict[int, tuple[int, int, int]] | None = None
+        if isinstance(device_fn.pid, FlatProgramIDs) and len(flat_grid_block_ids) > 1:
+            import sympy
+
+            num_blocks_list: list[int] = []
+            for bid in flat_grid_block_ids:
+                bs = env.block_sizes[bid].from_config(config)
+                numel = env.block_sizes[bid].numel
+                if not isinstance(bs, int) or isinstance(numel, str):
+                    return None
+                try:
+                    numel_val = int(numel) if isinstance(numel, sympy.Expr) else numel
+                except (TypeError, ValueError):
+                    return None
+                num_blocks_list.append(-(-numel_val // bs))  # cdiv
+            # stride_i = product(num_blocks_j for j < i)
+            stride = 1
+            flat_decomp = {}
+            for i, bid in enumerate(flat_grid_block_ids):
+                flat_decomp[bid] = (0, stride, num_blocks_list[i])
+                stride *= num_blocks_list[i]
+
+        result: list[
+            tuple[tuple[int | None, ...], tuple[int | tuple[int, int, int] | None, ...]]
+            | None
+        ] = []
         for arg in sorted_args:
             if isinstance(arg, (SymbolArgument, TensorSizeArg, TensorStrideArg)):
                 result.append(None)  # scalars wrapped as 1-D tensors
@@ -1192,7 +1230,7 @@ class PallasBackend(Backend):
             tensor = arg.fake_value
             dim_block_ids = device_fn.pallas_tensor_dim_block_ids.get(id(tensor), {})
             block_shape: list[int | None] = []
-            grid_dims: list[int | None] = []
+            grid_dims: list[int | tuple[int, int, int] | None] = []
             for d in range(tensor.ndim):
                 bid = dim_block_ids.get(d)
                 if bid is not None and bid in block_id_to_grid_dim:
@@ -1213,7 +1251,10 @@ class PallasBackend(Backend):
                         ):
                             return None
                         block_shape.append(bs)
-                        grid_dims.append(block_id_to_grid_dim[bid])
+                        if flat_decomp is not None and bid in flat_decomp:
+                            grid_dims.append(flat_decomp[bid])
+                        else:
+                            grid_dims.append(block_id_to_grid_dim[bid])
                         continue
                 block_shape.append(None)
                 grid_dims.append(None)

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -130,7 +130,8 @@ def _pallas_make_block_spec(
     pl: object,
     jnp: object,
     tensor: torch.Tensor,
-    entry: tuple[tuple[int | None, ...], tuple[int | None, ...]] | None,
+    entry: tuple[tuple[int | None, ...], tuple[int | tuple[int, int, int] | None, ...]]
+    | None,
 ) -> object:
     """Build one ``pl.BlockSpec`` from compile-time ``(block_shape, grid_dims)``."""
     if entry is None:
@@ -149,22 +150,38 @@ def _pallas_make_block_spec(
         for d, bs in enumerate(block_shape_template)
     )
 
+    def _index_for_dim(
+        grid_args: tuple[object, ...],
+        g: int | tuple[int, int, int] | None,
+        jnp: object = jnp,
+    ) -> object:
+        if g is None:
+            return jnp.int32(0)  # pyrefly: ignore[missing-attribute]
+        if isinstance(g, tuple):
+            # Flat grid decomposition: (grid_dim, stride, num_blocks)
+            grid_dim, stride, num_blocks = g
+            val = grid_args[grid_dim]
+            if stride > 1:
+                val = val // stride  # type: ignore[operator]
+            val = val % num_blocks  # type: ignore[operator]
+            return jnp.int32(val)  # pyrefly: ignore[missing-attribute]
+        return jnp.int32(grid_args[g])  # pyrefly: ignore[missing-attribute]
+
     def index_map(
         *grid_args: object,
-        _grid_dims: tuple[int | None, ...] = grid_dims,
+        _grid_dims: tuple[int | tuple[int, int, int] | None, ...] = grid_dims,
     ) -> tuple[object, ...]:
-        return tuple(
-            jnp.int32(grid_args[g])  # pyrefly: ignore[missing-attribute]
-            if g is not None
-            else jnp.int32(0)  # pyrefly: ignore[missing-attribute]
-            for g in _grid_dims
-        )
+        return tuple(_index_for_dim(grid_args, g) for g in _grid_dims)
 
     return pl.BlockSpec(block_shape, index_map)  # type: ignore[union-attr]
 
 
 # Per-tensor block spec info: see ``_pallas_make_block_spec``.
-_BlockSpecInfo = list[tuple[tuple[int | None, ...], tuple[int | None, ...]] | None]
+# grid_dims entries are int (direct grid dim), tuple (flat decomposition),
+# or None (untiled dim).
+_BlockSpecInfo = list[
+    tuple[tuple[int | None, ...], tuple[int | tuple[int, int, int] | None, ...]] | None
+]
 
 
 def _pallas_build_block_specs(

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -649,6 +649,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             pid_type="xyz",
         )
 
+    @xfailIfPallas("jnp.dot does not perform batched matmul on 3D tensors")
     def test_attention_pointer(self):
         args = (
             torch.randn(1, 32, 512, 64, dtype=torch.float32, device=DEVICE),

--- a/test/test_rng.py
+++ b/test/test_rng.py
@@ -545,6 +545,7 @@ class TestRNG(RefEagerTestBase, TestCase):
         else:
             self.assertIn("tl.rand", code)
 
+    @xfailIfPallas("jnp.dot does not perform batched matmul on 3D tensors")
     def test_rand_like_nested_tiles_issue_1208(self):
         """Test torch.rand_like with nested tiles (regression test for issue #1208).
 

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -62,7 +62,6 @@ class TestViews(RefEagerTestBase, TestCase):
         )
 
     @skipIfRocm("too slow on rocm")
-    @xfailIfPallas("view/reshape with tile variable size mismatch in pallas codegen")
     def test_softmax_view_reshape(self):
         @helion.kernel(config={"block_size": 1})
         def softmax(x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Summary

Fixes 3 TPU test regressions introduced by #1633 (codegen BlockSpecs), plus removes an xfail for a test that now passes.

- **`test_scalar_broadcast_2d`** (`IndexError: tuple index out of range`): `FlatProgramIDs` compresses multiple block_ids into a single 1D grid, but the generated `index_map` tried to access grid dimensions that don't exist. Fix: compute div/mod decomposition at compile time — each block_id gets `(grid_dim=0, stride, num_blocks)` so the runtime `index_map` recovers per-block-id offsets via `(flat_pid // stride) % num_blocks`.

- **`test_attention_pointer`**, **`test_rand_like_nested_tiles_issue_1208`** (`ValueError: Incompatible shapes for broadcasting`): Restore `@xfailIfPallas` — `jnp.dot` does not perform batched matmul on 3D tensors (produces 4D output). Will be resolved by #1647 which switches to `jnp.matmul`.

- **`test_softmax_view_reshape`** (`Failed: Unexpected success`): Remove xfail — now passes with codegen BlockSpecs from #1633.

## Test plan

- [x] `test_scalar_broadcast_2d` passes on TPU (was IndexError)
- [x] `test_attention_pointer` correctly xfails on TPU
- [x] `test_rand_like_nested_tiles_issue_1208` correctly xfails on TPU
- [x] `test_softmax_view_reshape` passes on TPU (xfail removed)
- [x] Full pallas test suite: 150 passed, 66 xfailed, 0 new regressions
- [x] ruff check + format clean
- [x] pyrefly clean (no new errors)