### PR TITLE
Enable pytorch retryBot for flaky CI retries

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -1,0 +1,3 @@
+retryable_workflows:
+  - Tests
+  - Benchmark


### PR DESCRIPTION
## Summary
- Adds `.github/pytorch-probot.yml` to enable the pytorch retryBot on this repo
- Configures automatic retries for flaky failures (e.g. B200 flakes) in `Tests` and `Benchmark` workflows
- `Benchmark` substring-matches `Benchmark Dispatch` and `Benchmark Nightly` as well

## Test plan
- Verify the retryBot picks up the config on the next flaky workflow failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)