### PR TITLE
Fallback handling for streams without fileno and Rich LiveError in progress bar

### DIFF
--- a/helion/autotuner/logger.py
+++ b/helion/autotuner/logger.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import csv
 import hashlib
+import io
 import itertools
 import logging
 import math
@@ -20,6 +21,7 @@ from typing import Callable
 from typing import Iterator
 from typing import Literal
 from typing import NamedTuple
+from typing import Protocol
 from typing import TypeAlias
 from typing import TypeVar
 from typing_extensions import Self
@@ -29,7 +31,6 @@ from torch._inductor.runtime.triton_compat import PTXASError
 
 if TYPE_CHECKING:
     from _csv import _writer as CsvWriter
-    import io
 
     from ..runtime.config import Config
     from ..runtime.settings import Settings
@@ -55,6 +56,10 @@ class _ElapsedFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:  # type: ignore[override]
         elapsed = self._elapsed_fn()
         return f"[{elapsed}s] {record.getMessage()}"
+
+
+class _SupportsFileno(Protocol):
+    def fileno(self) -> int: ...
 
 
 class AutotuningLogger:
@@ -520,6 +525,16 @@ def _stable_hash(content: str) -> str:
     return hashlib.sha256(normalized.encode()).hexdigest()[:16]
 
 
+def _safe_fileno(stream: io.TextIOBase | _SupportsFileno | None) -> int | None:
+    """Return ``stream.fileno()`` when supported, otherwise ``None``."""
+    try:
+        if stream is None:
+            return None
+        return stream.fileno()
+    except (AttributeError, io.UnsupportedOperation, OSError, ValueError):
+        return None
+
+
 @contextlib.contextmanager
 def capture_output() -> Iterator[list[str]]:
     """
@@ -538,8 +553,26 @@ def capture_output() -> Iterator[list[str]]:
     sys.stdout.flush()
     sys.stderr.flush()
 
-    stdout_fd = sys.stdout.fileno()
-    stderr_fd = sys.stderr.fileno()
+    stdout_fd = _safe_fileno(sys.stdout)
+    stderr_fd = _safe_fileno(sys.stderr)
+
+    if stdout_fd is None:
+        stdout_fd = _safe_fileno(sys.__stdout__)
+    if stderr_fd is None:
+        stderr_fd = _safe_fileno(sys.__stderr__)
+
+    if stdout_fd is None or stderr_fd is None:
+        # Jupyter/IPython streams may not expose fileno(); fall back to
+        # Python-level capture so compilation can proceed in notebooks.
+        capture_stream = io.StringIO()
+        with (
+            contextlib.redirect_stdout(capture_stream),
+            contextlib.redirect_stderr(capture_stream),
+        ):
+            yield result
+        result[0] = capture_stream.getvalue()
+        return
+
     saved_stdout_fd = os.dup(stdout_fd)
     saved_stderr_fd = os.dup(stderr_fd)
     tmp_fd, tmp_path = tempfile.mkstemp()

--- a/helion/autotuner/progress_bar.py
+++ b/helion/autotuner/progress_bar.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import TypeVar
 
+from rich.errors import LiveError
 from rich.progress import BarColumn
 from rich.progress import MofNCompleteColumn
 from rich.progress import Progress
 from rich.progress import ProgressColumn
 from rich.progress import TextColumn
+from rich.progress import track
 from rich.text import Text
 import torch
 
@@ -61,11 +63,17 @@ def iter_with_progress(
     if description is None:
         description = "Progress"
 
-    with Progress(
-        TextColumn("[progress.description]{task.description}"),
-        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
-        BarColumn(bar_width=None, complete_style="yellow", finished_style="green"),
-        MofNCompleteColumn(),
-        SpeedColumn(),
-    ) as progress:
-        yield from progress.track(iterable, total=total, description=description)
+    try:
+        with Progress(
+            TextColumn("[progress.description]{task.description}"),
+            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+            BarColumn(bar_width=None, complete_style="yellow", finished_style="green"),
+            MofNCompleteColumn(),
+            SpeedColumn(),
+        ) as progress:
+            yield from progress.track(iterable, total=total, description=description)
+    except LiveError:
+        # Rich only supports one active Live display. In notebook-style
+        # environments another display may already be running, so degrade to a
+        # disabled tracker and continue autotuning without rendering the bar.
+        yield from track(iterable, total=total, description=description, disable=True)

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from contextlib import ExitStack
 from contextlib import contextmanager
 from contextlib import nullcontext
 import csv
+import io
 from itertools import count
 import logging
 import math
@@ -21,6 +23,7 @@ from unittest import skip
 from unittest.mock import patch
 
 import pytest
+from rich.errors import LiveError
 import torch
 
 import helion
@@ -56,7 +59,9 @@ from helion.autotuner.local_cache import LocalAutotuneCache
 from helion.autotuner.local_cache import StrictLocalAutotuneCache
 from helion.autotuner.logger import AutotuneLogEntry
 from helion.autotuner.logger import AutotuningLogger
+from helion.autotuner.logger import capture_output
 from helion.autotuner.metrics import AutotuneMetrics
+from helion.autotuner.progress_bar import iter_with_progress
 from helion.autotuner.random_search import RandomSearch
 import helion.language as hl
 from helion.language import loops
@@ -218,6 +223,56 @@ class TestAutotuneIgnoreErrors(TestCase):
         assert str(original_exception) == "original error in except block"
         # Verify we can still get the error type and message
         assert type(err.value.__cause__).__name__ == "RuntimeError"
+
+
+class _NoFilenoStream:
+    def write(self, _s: str) -> int:
+        return 0
+
+    def flush(self) -> None:
+        return
+
+    def fileno(self) -> int:
+        raise io.UnsupportedOperation("no fileno")
+
+
+class TestAutotunerNotebookCompatibility(TestCase):
+    def test_capture_output_without_fileno(self):
+        fake_stdout = _NoFilenoStream()
+        fake_stderr = _NoFilenoStream()
+
+        with ExitStack() as stack:
+            stack.enter_context(patch("sys.stdout", fake_stdout))
+            stack.enter_context(patch("sys.stderr", fake_stderr))
+            stack.enter_context(patch("sys.__stdout__", fake_stdout))
+            stack.enter_context(patch("sys.__stderr__", fake_stderr))
+            output = stack.enter_context(capture_output())
+            print("hello from notebook-like stream")
+
+        self.assertIn("hello from notebook-like stream", output[0])
+
+    def test_iter_with_progress_handles_live_error(self):
+        class _BoomProgress:
+            def __init__(self, *_args, **_kwargs):
+                return
+
+            def __enter__(self):
+                raise LiveError("Only one live display may be active at once")
+
+            def __exit__(self, *_args):
+                return False
+
+        with (
+            patch("helion.autotuner.progress_bar.Progress", _BoomProgress),
+            patch(
+                "helion.autotuner.progress_bar.track",
+                side_effect=lambda iterable, **_kwargs: iter(iterable),
+            ) as track_mock,
+        ):
+            values = list(iter_with_progress(range(3), total=3, enabled=True))
+
+        self.assertEqual(values, [0, 1, 2])
+        track_mock.assert_called_once()
 
     def test_autotune_log_sink_writes_csv_and_log(self):
         tmpdir = tempfile.TemporaryDirectory()


### PR DESCRIPTION
### Motivation

- Ensure autotuner output capture works in environments (e.g. Jupyter/IPython) where `sys.stdout`/`sys.stderr` do not expose a file descriptor, and prevent Rich live-display conflicts from crashing progress rendering.

### Description

- Add a helper ` _safe_fileno` to probe `fileno()` safely and use it in `capture_output` to detect streams without a real FD. 
- Update `capture_output` to fall back to a Python-level `io.StringIO` capture when `fileno()` is not available, and try `sys.__stdout__`/`sys.__stderr__` before falling back; preserve previous FD-based behavior when available.
- Catch `rich.errors.LiveError` in `iter_with_progress` and fall back to `rich.progress.track(..., disable=True)` so progress iteration still proceeds when a live display is already active.
- Add tests in `test/test_autotuner.py` to exercise notebook-like streams without `fileno()` and to verify the `LiveError` fallback for `iter_with_progress`.

### Testing

- Ran the new unit tests in `test/test_autotuner.py` including `TestAutotunerNotebookCompatibility::test_capture_output_without_fileno` and `TestAutotunerNotebookCompatibility::test_iter_with_progress_handles_live_error`, and they passed.
- Ran existing autotuner tests that exercise `capture_output` and `iter_with_progress`, and they passed under the CI-local test run.
