### PR TITLE
Split the matmul_bwd into two separate matmul kernels to tune independently.

### DIFF
--- a/examples/matmul.py
+++ b/examples/matmul.py
@@ -16,7 +16,7 @@ import torch
 from torch import Tensor
 
 import helion
-from helion._compat import is_hip
+from helion._compat import split_matmul_bwd
 from helion._compat import use_tileir_tunables
 from helion._testing import DEVICE
 from helion._testing import HALF_DTYPE
@@ -214,12 +214,14 @@ class MatMulFunction(torch.autograd.Function):
     ) -> tuple[Tensor | None, Tensor | None]:
         """Backward pass for matrix multiplication.
 
-        On HIP/AMD, uses two separate matmul kernel calls so each is
-        independently autotuned with its own block sizes, num_warps, etc.
+        When split_matmul_bwd() is enabled (default on HIP/AMD; disable via
+        HELION_ROCM_SPLIT_MATMUL_BWD=0), uses two separate matmul kernel calls
+        so each is independently autotuned with its own block sizes,
+        num_warps, etc.
         """
         grad_out = grad_outputs[0]
         mat1, mat2 = ctx.saved_tensors
-        if is_hip():
+        if split_matmul_bwd():
             grad_mat1 = matmul(grad_out, mat2.t().contiguous())
             grad_mat2 = matmul(mat1.t().contiguous(), grad_out)
         else:

--- a/helion/_compat.py
+++ b/helion/_compat.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import functools
+import os
 import re
 from typing import TYPE_CHECKING
 from typing import Any
@@ -337,6 +338,20 @@ def min_dot_size(
 def is_hip() -> bool:
     """Check if the current device uses the HIP (AMD ROCm) backend."""
     return _is_hip()
+
+
+def split_matmul_bwd() -> bool:
+    """Whether to split matmul backward into two independent kernel calls.
+
+    Each call gets its own autotuning config, which can help on AMD/HIP.
+    Only applies on HIP; set HELION_ROCM_SPLIT_MATMUL_BWD=0 to disable.
+    """
+    if not is_hip():
+        return False
+    env = os.environ.get("HELION_ROCM_SPLIT_MATMUL_BWD")
+    if env is not None:
+        return env.strip() not in ("0", "false", "")
+    return True
 
 
 @functools.cache


### PR DESCRIPTION
This PR splits the matmul_bwd into two separate matmul kernels to tune independently. We observed that the matmuls when tuned independently had better performance compared to the fused matmul kernels in the examples currently.
We have only enabled this through an env variable and for HIP only.