### PR TITLE
[Autotuner] Add `generation_ctx()` context manager for each autotuner generation

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -983,6 +983,18 @@ class BaseSearch(BaseAutotuner):
     def set_generation(self, generation: int) -> None:
         self._autotune_metrics.num_generations = generation
 
+    @contextlib.contextmanager
+    def generation_ctx(
+        self, generation: int
+    ) -> collections.abc.Generator[None, None, None]:
+        """Context manager wrapping each generation (including generation 0).
+
+        sync_seed() can be added here for distributed autotuning so that
+        all ranks generate the same configs each generation.
+        """
+        self.set_generation(generation)
+        yield
+
     def _finalize_autotune_metrics(self) -> None:
         self._autotune_metrics.best_perf_ms = (
             self.best_perf_so_far if math.isfinite(self.best_perf_so_far) else 0.0

--- a/helion/autotuner/de_surrogate_hybrid.py
+++ b/helion/autotuner/de_surrogate_hybrid.py
@@ -170,8 +170,8 @@ class DESurrogateHybrid(DifferentialEvolutionSearch):
 
         # Evolution loop
         for gen in range(2, self.max_generations + 1):
-            self.set_generation(gen)
-            self._evolve_generation(gen)
+            with self.generation_ctx(gen):
+                self._evolve_generation(gen)
 
             # Check for convergence
             if self.check_early_stopping():

--- a/helion/autotuner/differential_evolution.py
+++ b/helion/autotuner/differential_evolution.py
@@ -120,18 +120,19 @@ class DifferentialEvolutionSearch(PopulationBasedSearch):
 
     def initial_two_generations(self) -> None:
         # The initial population is 2x larger so we can throw out the slowest half and give the tuning process a head start
-        initial_population_name = self.initial_population_strategy.name
-        oversized_population = sorted(
-            self.parallel_benchmark_flat(
-                self._generate_initial_population_flat(),
-            ),
-            key=performance,
-        )
-        self.log(
-            f"Initial population (initial_population={initial_population_name}):",
-            lambda: population_statistics(oversized_population),
-        )
-        self.population = oversized_population[: self.population_size]
+        with self.generation_ctx(0):
+            initial_population_name = self.initial_population_strategy.name
+            oversized_population = sorted(
+                self.parallel_benchmark_flat(
+                    self._generate_initial_population_flat(),
+                ),
+                key=performance,
+            )
+            self.log(
+                f"Initial population (initial_population={initial_population_name}):",
+                lambda: population_statistics(oversized_population),
+            )
+            self.population = oversized_population[: self.population_size]
 
     def _benchmark_mutation_batch(
         self, indices: Sequence[int]
@@ -240,10 +241,12 @@ class DifferentialEvolutionSearch(PopulationBasedSearch):
             self.generations_without_improvement = 0
 
         for i in range(2, self.max_generations):
-            self.set_generation(i)
-            self.log(f"Generation {i} starting")
-            replaced = self.evolve_population()
-            self.log(f"Generation {i} complete: replaced={replaced}", self.statistics)
+            with self.generation_ctx(i):
+                self.log(f"Generation {i} starting")
+                replaced = self.evolve_population()
+                self.log(
+                    f"Generation {i} complete: replaced={replaced}", self.statistics
+                )
 
             # Check for convergence (only if early stopping enabled)
             if early_stopping_enabled and self.check_early_stopping():

--- a/helion/autotuner/pattern_search.py
+++ b/helion/autotuner/pattern_search.py
@@ -101,23 +101,28 @@ class PatternSearch(PopulationBasedSearch):
         )
         visited: set[Config] = set()
         self.population = []
-        for flat_config in self._generate_initial_population_flat():
-            member = self.make_unbenchmarked(flat_config)
-            if member.config not in visited:
-                visited.add(member.config)
-                self.population.append(member)
-        self.parallel_benchmark_population(self.population, desc="Initial population")
+        with self.generation_ctx(0):
+            for flat_config in self._generate_initial_population_flat():
+                member = self.make_unbenchmarked(flat_config)
+                if member.config not in visited:
+                    visited.add(member.config)
+                    self.population.append(member)
+            self.parallel_benchmark_population(
+                self.population, desc="Initial population"
+            )
 
-        # Compute adaptive compile timeout based on initial population compile times
-        self.set_adaptive_compile_timeout(
-            self.population,
-            min_seconds=self.compile_timeout_lower_bound,
-            quantile=self.compile_timeout_quantile,
-        )
+            # Compute adaptive compile timeout based on initial population compile times
+            self.set_adaptive_compile_timeout(
+                self.population,
+                min_seconds=self.compile_timeout_lower_bound,
+                quantile=self.compile_timeout_quantile,
+            )
 
-        # again with higher accuracy
-        self.rebenchmark_population(self.population, desc="Verifying initial results")
-        self.population.sort(key=performance)
+            # again with higher accuracy
+            self.rebenchmark_population(
+                self.population, desc="Verifying initial results"
+            )
+            self.population.sort(key=performance)
         starting_points = []
         for member in self.population[: self.copies]:
             if math.isfinite(member.perf):  # filter failed compiles
@@ -131,40 +136,41 @@ class PatternSearch(PopulationBasedSearch):
 
         search_copies = [self._pattern_search_from(m, visited) for m in starting_points]
         for generation in range(1, self.max_generations + 1):
-            prior_best = self.best
-            new_population = {id(prior_best): prior_best}
-            num_neighbors = 0
-            num_active = 0
-            for search_copy in search_copies:
-                added = next(search_copy, ())
-                if added:
-                    assert len(added) > 1
-                    num_active += 1
-                    num_neighbors += len(added) - 1
-                    for member in added:
-                        new_population[id(member)] = member
-            if num_active == 0:
-                break
+            with self.generation_ctx(generation):
+                prior_best = self.best
+                new_population = {id(prior_best): prior_best}
+                num_neighbors = 0
+                num_active = 0
+                for search_copy in search_copies:
+                    added = next(search_copy, ())
+                    if added:
+                        assert len(added) > 1
+                        num_active += 1
+                        num_neighbors += len(added) - 1
+                        for member in added:
+                            new_population[id(member)] = member
+                if num_active == 0:
+                    break
 
-            # Log generation header before compiling/benchmarking
-            self.log(
-                f"Generation {generation} starting: {num_neighbors} neighbors, {num_active} active search path(s)"
-            )
-
-            self.population = [*new_population.values()]
-            # compile any unbenchmarked members in parallel
-            unbenchmarked = [m for m in self.population if len(m.perfs) == 0]
-            if unbenchmarked:
-                self.set_generation(generation)
-                self.parallel_benchmark_population(
-                    unbenchmarked, desc=f"Generation {generation}:"
+                # Log generation header before compiling/benchmarking
+                self.log(
+                    f"Generation {generation} starting: {num_neighbors} neighbors, {num_active} active search path(s)"
                 )
-            # higher-accuracy rebenchmark
-            self.rebenchmark_population(
-                self.population, desc=f"Generation {generation}: verifying top configs"
-            )
-            # Log final statistics for this generation
-            self.log(f"Generation {generation} complete:", self.statistics)
+
+                self.population = [*new_population.values()]
+                # compile any unbenchmarked members in parallel
+                unbenchmarked = [m for m in self.population if len(m.perfs) == 0]
+                if unbenchmarked:
+                    self.parallel_benchmark_population(
+                        unbenchmarked, desc=f"Generation {generation}:"
+                    )
+                # higher-accuracy rebenchmark
+                self.rebenchmark_population(
+                    self.population,
+                    desc=f"Generation {generation}: verifying top configs",
+                )
+                # Log final statistics for this generation
+                self.log(f"Generation {generation} complete:", self.statistics)
 
         # Run finishing phase to simplify the best configuration
         best = self.run_finishing_phase(self.best, self.finishing_rounds)

--- a/helion/autotuner/surrogate_pattern_search.py
+++ b/helion/autotuner/surrogate_pattern_search.py
@@ -331,24 +331,28 @@ class LFBOPatternSearch(PatternSearch):
         )
         visited: set[Config] = set()
         self.population = []
-        for flat_config in self._generate_initial_population_flat():
-            member = self.make_unbenchmarked(flat_config)
-            if member.config not in visited:
-                visited.add(member.config)
-                self.population.append(member)
-        self.set_generation(0)
-        self.parallel_benchmark_population(self.population, desc="Initial population")
+        with self.generation_ctx(0):
+            for flat_config in self._generate_initial_population_flat():
+                member = self.make_unbenchmarked(flat_config)
+                if member.config not in visited:
+                    visited.add(member.config)
+                    self.population.append(member)
+            self.parallel_benchmark_population(
+                self.population, desc="Initial population"
+            )
 
-        # Compute adaptive compile timeout based on initial population compile times
-        self.set_adaptive_compile_timeout(
-            self.population,
-            min_seconds=self.compile_timeout_lower_bound,
-            quantile=self.compile_timeout_quantile,
-        )
+            # Compute adaptive compile timeout based on initial population compile times
+            self.set_adaptive_compile_timeout(
+                self.population,
+                min_seconds=self.compile_timeout_lower_bound,
+                quantile=self.compile_timeout_quantile,
+            )
 
-        # again with higher accuracy
-        self.rebenchmark_population(self.population, desc="Verifying initial results")
-        self.population.sort(key=performance)
+            # again with higher accuracy
+            self.rebenchmark_population(
+                self.population, desc="Verifying initial results"
+            )
+            self.population.sort(key=performance)
         starting_points = []
         for member in self.population[: self.copies]:
             if math.isfinite(member.perf):  # filter failed compiles
@@ -372,48 +376,51 @@ class LFBOPatternSearch(PatternSearch):
             self._pruned_pattern_search_from(m, visited) for m in starting_points
         ]
         for generation in range(1, self.max_generations + 1):
-            prior_best = self.best
-            new_population = {id(prior_best): prior_best}
-            num_neighbors = 0
-            num_active = 0
-            for search_copy in search_copies:
-                added = next(search_copy, ())
-                if added:
-                    assert len(added) > 1
-                    num_active += 1
-                    num_neighbors += len(added) - 1
-                    for member in added:
-                        new_population[id(member)] = member
-            if num_active == 0:
-                break
+            with self.generation_ctx(generation):
+                prior_best = self.best
+                new_population = {id(prior_best): prior_best}
+                num_neighbors = 0
+                num_active = 0
+                for search_copy in search_copies:
+                    added = next(search_copy, ())
+                    if added:
+                        assert len(added) > 1
+                        num_active += 1
+                        num_neighbors += len(added) - 1
+                        for member in added:
+                            new_population[id(member)] = member
+                if num_active == 0:
+                    break
 
-            # Log generation header before compiling/benchmarking
-            self.log(
-                f"Generation {generation} starting: {num_neighbors} neighbors, {num_active} active search path(s)"
-            )
-
-            self.population = [*new_population.values()]
-            # compile any unbenchmarked members in parallel
-            unbenchmarked = [m for m in self.population if len(m.perfs) == 0]
-            if unbenchmarked:
-                self.set_generation(generation)
-                self.parallel_benchmark_population(
-                    unbenchmarked, desc=f"Generation {generation}:"
+                # Log generation header before compiling/benchmarking
+                self.log(
+                    f"Generation {generation} starting: {num_neighbors} neighbors, {num_active} active search path(s)"
                 )
-            # higher-accuracy rebenchmark
-            self.rebenchmark_population(
-                self.population, desc=f"Generation {generation}: verifying top configs"
-            )
-            # Log final statistics for this generation
-            self.log(f"Generation {generation} complete:", self.statistics)
 
-            # Update training data
-            for member in self.population:
-                self.train_x.append(self.config_gen.encode_config(member.flat_values))
-                self.train_y.append(member.perf)
+                self.population = [*new_population.values()]
+                # compile any unbenchmarked members in parallel
+                unbenchmarked = [m for m in self.population if len(m.perfs) == 0]
+                if unbenchmarked:
+                    self.parallel_benchmark_population(
+                        unbenchmarked, desc=f"Generation {generation}:"
+                    )
+                # higher-accuracy rebenchmark
+                self.rebenchmark_population(
+                    self.population,
+                    desc=f"Generation {generation}: verifying top configs",
+                )
+                # Log final statistics for this generation
+                self.log(f"Generation {generation} complete:", self.statistics)
 
-            # Fit model
-            self._fit_surrogate()
+                # Update training data
+                for member in self.population:
+                    self.train_x.append(
+                        self.config_gen.encode_config(member.flat_values)
+                    )
+                    self.train_y.append(member.perf)
+
+                # Fit model
+                self._fit_surrogate()
 
         # Run finishing phase to simplify the best configuration
         best = self.run_finishing_phase(self.best, self.finishing_rounds)


### PR DESCRIPTION
## Summary

- Add a `generation_ctx()` context manager to `PopulationBasedSearch` that wraps every autotuner generation (including generation 0 for initial population)
- Provides a clean point to add `sync_seed()` for distributed autotuning — instead of wrapping each individual `random` call site, a future change can add it once inside `generation_ctx()`
- All four autotuner algorithms updated: `PatternSearch`, `LFBOPatternSearch`, `DifferentialEvolutionSearch`, `DESurrogateHybrid`

## Test plan

- [x] `pytest test/test_autotuner.py -x -vv -s` — all 48 tests pass