### PR TITLE
Gracefully handle the error, "failed to translate module to LLVM IR"

### DIFF
--- a/helion/autotuner/logger.py
+++ b/helion/autotuner/logger.py
@@ -456,6 +456,7 @@ _EXPECTED_TRITON_ERRORS_RE: re.Pattern[str] = re.compile(
                 "out of resource: shared memory",  # Triton shared memory OOM
                 "ZE_RESULT_ERROR_INVALID_KERNEL_NAME",  # Level Zero compile failed
                 "exceeds triton maximum tensor numel",  # needs smaller config
+                "failed to translate module to LLVM IR",  # Triton LLVM lowering failure
                 "Resource temporarily unavailable",  # LLVM Error
                 "too many blocks in cooperative launch",  # CUDA cooperative launch limit
                 "too many resources requested for launch",  # Triton resource error

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -143,6 +143,23 @@ class TestAutotuneIgnoreErrors(TestCase):
 
         assert "HELION_AUTOTUNE_IGNORE_ERRORS" in str(err.value)
 
+    def test_llvm_translation_failure_skips_config(self):
+        settings = Settings(
+            autotune_ignore_errors=False,
+            autotune_log_level=logging.CRITICAL,
+        )
+        search = self._make_search(settings)
+
+        def bad_fn(*_args):
+            raise RuntimeError("failed to translate module to LLVM IR")
+
+        with patch("torch.accelerator.synchronize", autospec=True) as sync:
+            sync.return_value = None
+            result = search.benchmark_function("cfg", bad_fn)
+
+        self.assertEqual(result, float("inf"))
+        self.assertEqual(search._autotune_metrics.num_compile_failures, 1)
+
     def test_ignore_errors_skips_logging_and_raise(self):
         settings = Settings(
             autotune_ignore_errors=True,


### PR DESCRIPTION
This PR makes the autotuner gracefully handle the "failed to translate module to LLVM IR" error instead of crashing.