### PR TITLE
Add backend-agnostic lane loop APIs to tile strategies

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -307,6 +307,16 @@ class Backend(abc.ABC):
         """
         return self.next_power_of_2_host_expr(expr)
 
+    def lane_index_expr(
+        self, offset_var: str, elements_per_thread: int, *, axis: int
+    ) -> str:
+        """Thread index expression with elements-per-thread stride for lane loops."""
+        raise exc.BackendUnsupported(self.name, "lane index")
+
+    def lane_offset_expr(self, lane_var: str) -> str:
+        """Cast a lane variable for addition to an index expression."""
+        raise exc.BackendUnsupported(self.name, "lane offset")
+
     def reduction_combine_expr(
         self,
         reduction_type: str,
@@ -2258,6 +2268,14 @@ class CuteBackend(Backend):
     def grid_barrier_stmt(self, sem_arg: str) -> str | None:
         del sem_arg
         raise exc.BackendUnsupported(self.name, "hl.barrier()")
+
+    def lane_index_expr(
+        self, offset_var: str, elements_per_thread: int, *, axis: int
+    ) -> str:
+        return f"{offset_var} + cutlass.Int32(cute.arch.thread_idx()[{axis}]) * {elements_per_thread}"
+
+    def lane_offset_expr(self, lane_var: str) -> str:
+        return f"cutlass.Int32({lane_var})"
 
     def sympy_printer_expr(self, expr: sympy.Expr) -> str:
         from .device_function import cute_texpr

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -1999,16 +1999,16 @@ class CuteNDTileStrategy(NDTileStrategy):
             )
             axis = thread_axis_offset + thread_axis_map[block_idx]
             if uses_thread_axis:
-                idx_expr = f"{offset_var} + cutlass.Int32(cute.arch.thread_idx()[{axis}]) * {elements_per_thread}"
-                static_thread_extent = self._static_thread_extent_for_block(
-                    block_idx, block_size
+                idx_expr = env.backend.lane_index_expr(
+                    offset_var, elements_per_thread, axis=axis
                 )
-                if isinstance(static_thread_extent, int):
-                    tracker.record(block_idx, axis, static_thread_extent)
+                thread_extent = self._thread_extent_for_axis(block_idx, block_size)
+                if isinstance(thread_extent, int):
+                    tracker.record(block_idx, axis, thread_extent)
             else:
                 idx_expr = offset_var
             if lane_var := self._lane_var_by_block.get(block_idx):
-                idx_expr = f"{idx_expr} + cutlass.Int32({lane_var})"
+                idx_expr = f"{idx_expr} + {env.backend.lane_offset_expr(lane_var)}"
             lane_setup_statements.append(
                 statement_from_string(f"{index_var} = {idx_expr}")
             )
@@ -2158,16 +2158,16 @@ class CuteNDTileStrategy(NDTileStrategy):
             )
             axis = thread_axis_offset + thread_axis_map[block_idx]
             if uses_thread_axis:
-                idx_expr = f"{offset_var} + cutlass.Int32(cute.arch.thread_idx()[{axis}]) * {elements_per_thread}"
-                static_thread_extent = self._static_thread_extent_for_block(
-                    block_idx, block_size
+                idx_expr = env.backend.lane_index_expr(
+                    offset_var, elements_per_thread, axis=axis
                 )
-                if isinstance(static_thread_extent, int):
-                    tracker.record(block_idx, axis, static_thread_extent)
+                thread_extent = self._thread_extent_for_axis(block_idx, block_size)
+                if isinstance(thread_extent, int):
+                    tracker.record(block_idx, axis, thread_extent)
             else:
                 idx_expr = offset_var
             if lane_var := self._lane_var_by_block.get(block_idx):
-                idx_expr = f"{idx_expr} + cutlass.Int32({lane_var})"
+                idx_expr = f"{idx_expr} + {env.backend.lane_offset_expr(lane_var)}"
             index_setup.append(statement_from_string(f"{index_var} = {idx_expr}"))
             mask_statement = self._setup_mask(
                 state, block_idx, block_size, index_var, end
@@ -2276,7 +2276,7 @@ class CuteFlattenedTileStrategy(FlattenedTileStrategy):
 
         lane_setup_statements.append(
             statement_from_string(
-                f"{offsets_var} = {offsets_base_var} + cutlass.Int32({self._lane_var})"
+                f"{offsets_var} = {offsets_base_var} + {env.backend.lane_offset_expr(self._lane_var)}"
             )
         )
         for i, block_idx in enumerate(self._reorder(block_ids)):
@@ -2307,7 +2307,7 @@ class CuteFlattenedTileStrategy(FlattenedTileStrategy):
         pids.append(PIDInfo(pid_var, block_size_var, total_numel, self.block_ids[0]))
         axis = self._flat_thread_axis()
         state.add_statement(
-            f"{offsets_base_var} = ({pid_var}) * ({block_size_var}) + cutlass.Int32(cute.arch.thread_idx()[{axis}]) * {self._elements_per_thread}"
+            f"{offsets_base_var} = {env.backend.lane_index_expr(f'({pid_var}) * ({block_size_var})', self._elements_per_thread, axis=axis)}"
         )
         pids.codegen(state)
         if isinstance(state.device_function.pid, ForEachProgramID):
@@ -2349,7 +2349,7 @@ class CuteFlattenedTileStrategy(FlattenedTileStrategy):
 
         lane_setup_statements.append(
             statement_from_string(
-                f"{offsets_var} = {offsets_base_var} + cutlass.Int32({self._lane_var})"
+                f"{offsets_var} = {offsets_base_var} + {env.backend.lane_offset_expr(self._lane_var)}"
             )
         )
         for i, block_idx in enumerate(self._reorder(block_ids)):
@@ -2393,7 +2393,7 @@ class CuteFlattenedTileStrategy(FlattenedTileStrategy):
             body = [lane_for]
         body[:0] = [
             statement_from_string(
-                f"{offsets_base_var} = {lid} * ({block_size_var}) + cutlass.Int32(cute.arch.thread_idx()[{axis}]) * {self._elements_per_thread}"
+                f"{offsets_base_var} = {env.backend.lane_index_expr(f'{lid} * ({block_size_var})', self._elements_per_thread, axis=axis)}"
             )
         ]
         for_node = create(


### PR DESCRIPTION
Stacked PRs:
 * #1855
 * __->__#1798


--- --- ---

### Add backend-agnostic lane loop APIs to tile strategies


CuteNDTileStrategy and CuteFlattenedTileStrategy have lane loop
machinery (num_threads, _lane_var_by_block, _elements_per_thread)
that decouples block_size from thread count — when a tile has more
elements than threads, each thread iterates over multiple elements
via explicit for-loops ("lane loops").

Currently, the lane loop index expressions are hardcoded to CuTe:
  cutlass.Int32(cute.arch.thread_idx()[axis]) * elements_per_thread
  cutlass.Int32(lane_var)

This makes the Cute tile strategies unusable by other scalar-thread
backends. The Metal backend needs these strategies because Metal
shares CuTe's scalar-thread execution model: both dispatch one
element per thread for elementwise work, and both rely on cooperative
hardware primitives (simdgroup MPP / warpgroup MMA) for matmul where
the strategy must suppress per-thread index generation. The base
NDTileStrategy / FlattenedTileStrategy cannot express either pattern
— they target Triton/Pallas where each thread holds a *vector* of
elements via tl.arange / jnp.arange.

This commit extracts lane loop index generation into two Backend
hooks, and updates all 8 call sites in the Cute strategies:

  lane_index_expr(offset_var, elements_per_thread, axis=axis)
    CuTe: "offset + cutlass.Int32(cute.arch.thread_idx()[axis]) * ept"
    Metal (next commit): "offset + tid[axis] * ept"

  lane_offset_expr(lane_var)
    CuTe: "cutlass.Int32(lane_var)"
    Metal (next commit): "lane_var"  (no cast needed)

No behavioral change — CuTe produces identical expressions as before.
The next commit will add the Metal overrides and use these strategies
for Metal's threadgroup auto-capping.
