### PR TITLE
Cleanup the tests skips on ROCM.

### DIFF
--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -451,7 +451,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
     @patch.object(_compat, "_min_dot_size", lambda *args: (16, 16, 16))
     @patch.object(_compat, "_supports_maxnreg", lambda: True)
     @patch.object(loops, "_supports_warp_specialize", lambda: True)
-    @skipIfRocm("failure on rocm")
+    @skipIfRocm("config space differs on ROCm")
     def test_config_fragment0(self):
         args = (
             torch.randn([512, 512], device=DEVICE),
@@ -470,7 +470,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
     @patch.object(loops, "_supports_warp_specialize", lambda: True)
     @patch("torch.version.hip", None)
     @patch("torch.version.xpu", None)
-    @skipIfRocm("should skip on rocm")
+    @skipIfRocm("config space differs on ROCm")
     def test_config_fragment1(self):
         args = (
             torch.randn([8, 512, 512], device=DEVICE),
@@ -490,7 +490,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
     @patch("torch.version.hip", None)
     @patch("torch.version.xpu", None)
     @skipIfTileIR("tileir backend will ignore `warp specialization` hint")
-    @skipIfRocm("should skip on rocm")
+    @skipIfRocm("config space differs on ROCm")
     def test_config_warp_specialize_unroll(self):
         args = (
             torch.randn([8, 512, 512], device=DEVICE),

--- a/test/test_register_tunable.py
+++ b/test/test_register_tunable.py
@@ -13,7 +13,6 @@ from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
-from helion._testing import skipIfRocm
 from helion._testing import skipIfSharedMemoryLessThan
 from helion._testing import xfailIfCute
 from helion.autotuner import EnumFragment

--- a/test/test_register_tunable.py
+++ b/test/test_register_tunable.py
@@ -114,7 +114,6 @@ class TestRegisterTunable(RefEagerTestBase, TestCase):
     @skipIfSharedMemoryLessThan(
         86016, reason="num_stages=8 requires 86016 bytes of shared memory"
     )
-    @skipIfRocm("failure on rocm")
     @xfailIfCute(
         "cute: split-k matmul register_tunable path exceeds CuTe thread-block "
         "layout limits and scalar float16 atomic_add is not supported"


### PR DESCRIPTION
This PR removes the skip which is based on the shared_memory_size and not for all rocm devices.
This also cleans up the skip description.