### PR TITLE
Increasing Mi325 runners for nightlys

### DIFF
--- a/.github/workflows/benchmark_dispatch.yml
+++ b/.github/workflows/benchmark_dispatch.yml
@@ -93,7 +93,7 @@ jobs:
     uses: ./.github/workflows/compute-benchmark-matrix.yml
     if: ${{ github.event.inputs.run_mi325x == 'true' }}
     with:
-      max-runners: 6
+      max-runners: 13
       kernels: ${{ github.event.inputs.kernels }}
 
   run-mi325x:


### PR DESCRIPTION
This PR increases the benchmark nightly MI325 runners from 6 to 13 to let the benchmark runs complete and not timeout.