### PR TITLE
Fixing the stale global memory read for AMD GPUs.

### DIFF
--- a/helion/_compiler/ast_read_writes.py
+++ b/helion/_compiler/ast_read_writes.py
@@ -78,6 +78,18 @@ class ReadWrites(typing.NamedTuple):
             visitor.visit(node)
         return visitor.rw
 
+    def read_and_write_name_frozensets(self) -> tuple[frozenset[str], frozenset[str]]:
+        """Pair of (read names, write names) for inter-loop / barrier metadata.
+
+        ``_ReadWriteVisitor.visit_Subscript`` and ``visit_Call`` already
+        increment ``writes`` for both Store-context subscripts and atomic
+        first-args, so ``inplace_writes`` is a strict subset of ``writes``
+        today and adding it explicitly would be redundant.
+        """
+        reads = frozenset(self.reads.keys())
+        writes = frozenset(self.writes.keys())
+        return reads, writes
+
     @staticmethod
     def from_ast(node: ast.AST) -> ReadWrites:
         """

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -298,6 +298,16 @@ class NodeArgsGraphInfo(GraphInfo):
 @dataclasses.dataclass
 class ForLoopGraphInfo(NodeArgsGraphInfo):
     block_ids: list[int]
+    # Host AST read/write names for this device loop body (siblings only; see
+    # ``_ReadWriteVisitor.visit_For`` in ast_read_writes.py).  Used to insert
+    # ``tl.debug_barrier()`` between loops when there is a global RAW dep.
+    host_loop_reads: frozenset[str] = dataclasses.field(default_factory=frozenset)
+    host_loop_writes: frozenset[str] = dataclasses.field(default_factory=frozenset)
+    # Precomputed by GenerateAST._compute_inter_loop_barriers: True iff a
+    # tl.debug_barrier() must be emitted immediately before this for-loop's
+    # outer prefix to make global writes from the previous sibling for-loop
+    # in this scope visible.  Not copied across graph copies; recomputed.
+    needs_barrier_before: bool = False
 
     @property
     def name(self) -> str:
@@ -307,6 +317,10 @@ class ForLoopGraphInfo(NodeArgsGraphInfo):
         return {
             **super().kwargs(),
             "block_ids": [*self.block_ids],
+            "host_loop_reads": self.host_loop_reads,
+            "host_loop_writes": self.host_loop_writes,
+            # ``needs_barrier_before`` is excluded -- recomputed by GenerateAST
+            # per codegen run.
         }
 
     def codegen(self, state: CodegenState) -> list[object]:
@@ -316,7 +330,8 @@ class ForLoopGraphInfo(NodeArgsGraphInfo):
         with state.codegen.add_device_loop(
             state.device_function.tile_strategy.codegen_device_loop(
                 state, self.block_ids
-            )
+            ),
+            needs_barrier_before=self.needs_barrier_before,
         ):
             return codegen_call_with_graph(
                 state.codegen,
@@ -529,6 +544,111 @@ class KernelPhase:
     )
 
 
+def _tensor_to_inter_loop_rw_name(host: HostFunction, t: torch.Tensor) -> str | None:
+    o = host.tensor_to_origin.get(t)
+    if o is None:
+        return None
+    return o.root_rw_name()
+
+
+def _fx_trace_tensor_arg_rw_names(
+    host: HostFunction, arg: object, seen: set[int] | None = None
+) -> list[str]:
+    """Map a load/store tensor FX arg to the list of host variable names it
+    aliases.  Returns an empty list when the arg cannot be resolved to any
+    host name (e.g. a purely device-internal temporary)."""
+    from ..language import _tracing_ops
+
+    if seen is None:
+        seen = set()
+    if isinstance(arg, tuple):
+        out: list[str] = []
+        for a in arg:
+            out.extend(_fx_trace_tensor_arg_rw_names(host, a, seen))
+        return out
+    if not isinstance(arg, torch.fx.Node):
+        return []
+    nid = id(arg)
+    if nid in seen:
+        return []
+    seen.add(nid)
+    val = arg.meta.get("val")
+    if isinstance(val, torch.Tensor):
+        n = _tensor_to_inter_loop_rw_name(host, val)
+        if n is not None:
+            return [n]
+    if arg.op == "call_function" and arg.target is _tracing_ops._host_tensor:
+        val = arg.meta.get("val")
+        if isinstance(val, torch.Tensor):
+            n = _tensor_to_inter_loop_rw_name(host, val)
+            if n is not None:
+                return [n]
+        return []
+    out2: list[str] = []
+    for a in arg.args:
+        out2.extend(_fx_trace_tensor_arg_rw_names(host, a, seen))
+    return out2
+
+
+def _reduction_fx_inter_loop_rw_names(
+    graph: torch.fx.Graph,
+    host: HostFunction,
+) -> tuple[frozenset[str], frozenset[str]]:
+    """Infer host buffer names read/written in a rolled reduction FX subgraph.
+
+    Walks every hl.load / hl.store / atomic_* node in ``graph`` and resolves
+    its tensor argument back to host-named buffers via
+    :func:`_fx_trace_tensor_arg_rw_names`.  Buffers that don't resolve to a
+    host name are device-internal temporaries and don't participate in
+    cross-wavefront global coherence, so they're correctly excluded from the
+    returned sets.
+    """
+    from ..language import atomic_add
+    from ..language import atomic_and
+    from ..language import atomic_cas
+    from ..language import atomic_max
+    from ..language import atomic_min
+    from ..language import atomic_or
+    from ..language import atomic_xchg
+    from ..language import atomic_xor
+    from ..language import memory_ops
+
+    atomic_funcs = frozenset(
+        {
+            atomic_add,
+            atomic_and,
+            atomic_cas,
+            atomic_max,
+            atomic_min,
+            atomic_or,
+            atomic_xchg,
+            atomic_xor,
+        }
+    )
+    reads: set[str] = set()
+    writes: set[str] = set()
+
+    for node in graph.find_nodes(
+        op="call_function", target=memory_ops.load, sort=False
+    ):
+        reads.update(_fx_trace_tensor_arg_rw_names(host, node.args[0]))
+
+    for node in graph.find_nodes(
+        op="call_function", target=memory_ops.store, sort=False
+    ):
+        writes.update(_fx_trace_tensor_arg_rw_names(host, node.args[0]))
+
+    for atomic_target in atomic_funcs:
+        for node in graph.find_nodes(
+            op="call_function", target=atomic_target, sort=False
+        ):
+            nms = _fx_trace_tensor_arg_rw_names(host, node.args[0])
+            reads.update(nms)
+            writes.update(nms)
+
+    return frozenset(reads), frozenset(writes)
+
+
 class DeviceIR:
     def __init__(self) -> None:
         super().__init__()
@@ -563,11 +683,14 @@ class DeviceIR:
         block_index: int,
         node_args: list[torch.fx.Node],
     ) -> int:
+        reads, writes = _reduction_fx_inter_loop_rw_names(graph, HostFunction.current())
         return self.add_graph(
             graph,
             graph_info_cls=ReductionLoopGraphInfo,
             block_ids=[block_index],
             node_args=node_args,
+            host_loop_reads=reads,
+            host_loop_writes=writes,
         )
 
     def add_root_graph(self, graph: torch.fx.Graph) -> None:
@@ -1111,11 +1234,14 @@ class WalkDeviceAST(NodeVisitor):
                 assert isinstance(var, (TileIndexType, GridIndexType))
                 block_ids.append(var.block_id)
 
+            host_reads, host_writes = rw.read_and_write_name_frozensets()
             graph_idx, outputs = self._trace_graph(
                 inputs,
                 build_subgraph,
                 graph_info_cls=ForLoopGraphInfo,
                 block_ids=block_ids,
+                host_loop_reads=host_reads,
+                host_loop_writes=host_writes,
             )
             step_list = step if isinstance(step, list) else None
             if step_list is None or all(s is None for s in step_list):

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -99,6 +99,10 @@ class GenerateAST(NodeVisitor, CodegenInterface):
         )
         CodegenInterface.__init__(self, self.device_function)
 
+        # Decide once which sibling for-loops need a tl.debug_barrier()
+        # to make global writes visible to subsequent reads.
+        self._compute_inter_loop_barriers()
+
     def get_graph(self, graph_id: int) -> GraphInfo:
         return self.codegen_graphs[graph_id]
 
@@ -116,6 +120,93 @@ class GenerateAST(NodeVisitor, CodegenInterface):
     def _phase_checker(self, root_id: int) -> LoopDependencyChecker:
         phase_idx = self.host_function.device_ir.phase_for_root(root_id)
         return self.host_function.device_ir.phases[phase_idx].loop_dependency_checker
+
+    def _compute_inter_loop_barriers(self) -> None:
+        """Walk every codegen graph; for each pair of consecutive sibling
+        ``_for_loop`` / ``_for_loop_step`` nodes, set ``needs_barrier_before``
+        on the second loop's ``ForLoopGraphInfo`` when there is a global RAW
+        dependency.
+
+        TileIR shares Triton surface syntax but ``tl.debug_barrier()`` lowers
+        to ``ttg.barrier`` which the TileIR pass pipeline does not legalize,
+        so the analysis is a no-op there.
+        """
+        from ..language._tracing_ops import _for_loop
+        from ..language._tracing_ops import _for_loop_step
+        from .device_ir import ForLoopGraphInfo
+        from .loop_dependency_checker import (
+            needs_inter_loop_debug_barrier_for_global_raw,
+        )
+
+        env = CompileEnvironment.current()
+        if env.codegen_name != "triton" or env.backend.name == "tileir":
+            return
+
+        for graph_info in self.codegen_graphs:
+            # Pending writes accumulate across ALL prior sibling for-loops
+            # since the last emitted barrier.  When a barrier is inserted
+            # before a loop, it flushes all earlier writes, so the pending set
+            # is reset and only writes from loops AFTER the barrier need to be
+            # tracked for subsequent siblings.
+            pending_global_writes: set[str] = set()
+            for node in graph_info.graph.nodes:
+                if node.op != "call_function":
+                    continue
+                if node.target not in (_for_loop, _for_loop_step):
+                    continue
+                cur_id = node.args[0]
+                assert isinstance(cur_id, int)
+                cur_info = self.codegen_graphs[cur_id]
+                if not isinstance(cur_info, ForLoopGraphInfo):
+                    continue
+                need_barrier = needs_inter_loop_debug_barrier_for_global_raw(
+                    pending_global_writes,
+                    cur_info.host_loop_reads,
+                    global_barrier_tensor_names=self._triton_global_barrier_tensor_names,
+                )
+                cur_info.needs_barrier_before = need_barrier
+                if need_barrier:
+                    # Barrier flushes everything written before it.
+                    pending_global_writes = set()
+                # Accumulate the current loop's writes for future siblings.
+                pending_global_writes |= self._triton_global_barrier_tensor_names(
+                    cur_info.host_loop_writes
+                )
+
+    def _triton_global_barrier_tensor_names(self, names: frozenset[str]) -> set[str]:
+        """Names that may participate in cross-wavefront global (HBM) coherence.
+
+        Triton-specific: the Pallas SMEM filter is intentionally omitted here
+        because the only caller (``_compute_inter_loop_barriers``) gates on
+        Triton codegen.  The ``triton_`` prefix and the assertion below encode
+        that precondition so a future non-Triton caller fails loudly rather
+        than silently mis-classifying SMEM-only tensors as needing a global
+        barrier.
+        """
+        from .type_propagation import StackTensorType
+        from .type_propagation import TensorType
+
+        env = CompileEnvironment.current()
+        assert env.codegen_name == "triton" and env.backend.name != "tileir", (
+            "_triton_global_barrier_tensor_names called outside Triton codegen"
+        )
+
+        out: set[str] = set()
+        scratch_names = {s.name for s in self.device_function._scratch_args}
+        local_types = self.host_function.local_types
+        for name in names:
+            if name in scratch_names:
+                continue
+            if local_types is None:
+                out.add(name)
+                continue
+            ti = local_types.get(name)
+            if ti is None:
+                out.add(name)
+                continue
+            if isinstance(ti, (TensorType, StackTensorType)):
+                out.add(name)
+        return out
 
     def add_statement(self, stmt: ast.AST | str | None) -> None:
         if stmt is None:
@@ -300,7 +391,12 @@ class GenerateAST(NodeVisitor, CodegenInterface):
             self.host_statements = prior
 
     @contextlib.contextmanager
-    def add_device_loop(self, device_loop: DeviceLoopState) -> Iterator[None]:
+    def add_device_loop(
+        self,
+        device_loop: DeviceLoopState,
+        *,
+        needs_barrier_before: bool = False,
+    ) -> Iterator[None]:
         with self.set_statements(device_loop.inner_statements):
             for idx in device_loop.block_ids:
                 active_loops = self.active_device_loops[idx]
@@ -314,6 +410,8 @@ class GenerateAST(NodeVisitor, CodegenInterface):
             finally:
                 for idx in device_loop.block_ids:
                     self.active_device_loops[idx].pop()
+        if needs_barrier_before:
+            self.add_statement(statement_from_string("tl.debug_barrier()"))
         self.statements_stack[-1].extend(device_loop.outer_prefix)
         self.add_statement(device_loop.for_node)
         self.statements_stack[-1].extend(device_loop.outer_suffix)
@@ -478,7 +576,6 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                             ) from None
                         bound = fn._signature.bind(*args, **kwargs)
                         bound.apply_defaults()
-
                         from .inductor_lowering import CodegenState
 
                         state = CodegenState(

--- a/helion/_compiler/host_function.py
+++ b/helion/_compiler/host_function.py
@@ -128,6 +128,7 @@ class HostFunction:
         self.location = location
         self.compiler_state: CompilerState = CompilerState()
         self._device_ir: DeviceIR | None = None
+        self.local_types: dict[str, TypeInfo] | None = None
 
     # Backward-compatible accessors
 
@@ -251,6 +252,7 @@ class HostFunction:
         return seed_slot
 
     def set_local_types(self, local_types: dict[str, TypeInfo]) -> None:
+        self.local_types = local_types
         for name, type_info in local_types.items():
             type_info.populate_symbol_origins(NameOrigin(name, self))
 

--- a/helion/_compiler/loop_dependency_checker.py
+++ b/helion/_compiler/loop_dependency_checker.py
@@ -8,6 +8,23 @@ from .ast_read_writes import ReadWrites
 
 if TYPE_CHECKING:
     import ast
+    from collections.abc import Callable
+
+
+def needs_inter_loop_debug_barrier_for_global_raw(
+    prev_global_writes: set[str],
+    host_loop_reads: frozenset[str],
+    *,
+    global_barrier_tensor_names: Callable[[frozenset[str]], set[str]],
+) -> bool:
+    """Whether to emit ``tl.debug_barrier()`` before the next sequential device loop.
+
+    Returns True when the union of host-named global writes accumulated from
+    all prior siblings (since the last emitted barrier) intersects the current
+    loop's host-named read set.
+    """
+    cur_global_reads = global_barrier_tensor_names(host_loop_reads)
+    return bool(prev_global_writes & cur_global_reads)
 
 
 class LoopDependencyChecker:

--- a/helion/_compiler/variable_origin.py
+++ b/helion/_compiler/variable_origin.py
@@ -123,6 +123,14 @@ class Origin:
         """Convert to a PyTorch source object."""
         raise NotImplementedError(type(self).__name__)
 
+    def root_rw_name(self) -> str | None:
+        """Host buffer name for inter-loop RAW tracking, after unwrapping wrappers.
+
+        Returns ``None`` when this origin is not rooted in a named host binding
+        (e.g. device temporaries, block sizes).
+        """
+        return None
+
 
 @dataclasses.dataclass
 class HostOrigin(Origin):
@@ -143,6 +151,9 @@ class NameOrigin(HostOrigin):
         return self.name
 
     def suggest_var_name(self) -> str:
+        return self.name
+
+    def root_rw_name(self) -> str | None:
         return self.name
 
 
@@ -175,6 +186,9 @@ class WrappedOrigin(Origin):
 
     def depth(self) -> int:
         return 1 + self.value.depth()
+
+    def root_rw_name(self) -> str | None:
+        return self.value.root_rw_name()
 
 
 @dataclasses.dataclass

--- a/test/test_barrier.py
+++ b/test/test_barrier.py
@@ -262,12 +262,20 @@ class TestBarrier(RefEagerTestBase, TestCase):
             backend_name="triton",
         )
 
+        # The fake roller adds an empty subgraph (only an output node), so the
+        # FX walker in _reduction_fx_inter_loop_rw_names never dereferences the
+        # HostFunction; we just need HostFunction.current() not to raise.
+        fake_host = SimpleNamespace()
         with (
             patch(
                 "helion._compiler.device_ir.CompileEnvironment.current",
                 return_value=fake_env,
             ),
             patch("helion._compiler.device_ir.ReductionRoller", _FakeReductionRoller),
+            patch(
+                "helion._compiler.device_ir.HostFunction.current",
+                return_value=fake_host,
+            ),
         ):
             device_ir.register_rollable_reductions()
 

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1835,7 +1835,6 @@ class TestExamples(RefEagerTestBase, TestCase):
     @xfailIfCute(
         "CuTe squeeze-and-excitation forward still exceeds thread-block limits"
     )
-    @skipIfRocm("Triton ROCm store-forwarding bug: stale global memory reads")
     @skipIfCudaSharedMemoryLessThan(
         131072, reason="block sizes exceed device shared memory limit"
     )

--- a/test/test_loops.py
+++ b/test/test_loops.py
@@ -22,6 +22,7 @@ from helion._testing import code_and_output
 from helion._testing import import_path
 from helion._testing import onlyBackends
 from helion._testing import skipIfCudaCapabilityLessThan
+from helion._testing import skipIfCudaSharedMemoryLessThan
 from helion._testing import skipIfFn
 from helion._testing import skipIfLowVRAM
 from helion._testing import skipIfNotCUDA
@@ -1456,6 +1457,125 @@ class TestLoops(RefEagerTestBase, TestCase):
 
         x = torch.randn(128, 1024, dtype=torch.float32, device=DEVICE)
         torch.testing.assert_close(fn(x), x)
+
+    @skipIfNotTriton(
+        "tl.debug_barrier() is only emitted in Triton device codegen (not Pallas/JAX)"
+    )
+    @skipIfCudaSharedMemoryLessThan(
+        131072, reason="block sizes exceed device shared memory limit"
+    )
+    def test_sequential_loops_global_memory_barrier(self):
+        """Sequential device loops that store then load the same global buffer
+        need tl.debug_barrier() between the sibling loops so all warps see
+        prior stores (Triton; portable across ROCm and num_warps)."""
+
+        @helion.kernel(autotune_effort="none")
+        def two_phase_kernel(
+            x: torch.Tensor, a: torch.Tensor, b: torch.Tensor
+        ) -> torch.Tensor:
+            m, n = x.size()
+            k = a.size(1)
+            c = torch.empty([m, k], dtype=x.dtype, device=x.device)
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m in hl.tile(m):
+                for tile_k in hl.tile(k):
+                    c[tile_m, tile_k] = torch.relu(x[tile_m, :] @ a[:, tile_k])
+                for tile_n in hl.tile(n):
+                    acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                    for tile_k in hl.tile(k):
+                        acc = torch.addmm(acc, c[tile_m, tile_k], b[tile_k, tile_n])
+                    out[tile_m, tile_n] = acc
+            return out
+
+        torch.manual_seed(42)
+        m, n, k = 128, 128, 128
+        x = torch.randn([m, n], device=DEVICE, dtype=torch.float32)
+        a = torch.randn([n, k], device=DEVICE, dtype=torch.float32)
+        b = torch.randn([k, n], device=DEVICE, dtype=torch.float32)
+
+        expected = torch.relu(x @ a) @ b
+
+        for num_warps in (2, 4):
+            code, result = code_and_output(
+                two_phase_kernel,
+                (x, a, b),
+                block_sizes=[128, 128, 128, 128],
+                num_warps=num_warps,
+                num_stages=2,
+            )
+            torch.testing.assert_close(result, expected, atol=0.15, rtol=0.01)
+            self.assertIn("tl.debug_barrier()", code)
+
+    @skipIfRefEager("reduction rolling is a codegen-time transformation")
+    @skipIfNotTriton("rolled reduction loops are Triton codegen-specific")
+    def test_reduction_loop_rolling_emits_inner_for_loop(self):
+        """With ``reduction_loop`` set, the per-tile reduction is rolled into
+        an explicit inner Triton for-loop over chunks of the reduction dim.
+
+        This replaces an earlier, brittle test that reached into
+        ``bound.host_function.device_ir.build_codegen_graphs`` and asserted on
+        ``ReductionLoopGraphInfo`` directly.  Asserting on the generated code
+        verifies the same end-to-end behavior (rolling actually happens) without
+        coupling to compiler internals.
+        """
+
+        @helion.kernel(autotune_effort="none")
+        def reduction_roll_kernel(x: torch.Tensor) -> torch.Tensor:
+            n, _m = x.size()
+            out = torch.empty([n], dtype=x.dtype, device=x.device)
+            for tile_n in hl.tile(n):
+                out[tile_n] = x[tile_n, :].sum(-1)
+            return out
+
+        x = torch.randn(64, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            reduction_roll_kernel,
+            (x,),
+            block_size=8,
+            reduction_loop=32,
+        )
+        # Rolled reductions emit an inner ``for r0_<n> in tl.range(...)`` loop
+        # walking chunks of the reduction dim; the un-rolled path computes the
+        # whole reduction with a single ``tl.sum`` and has no such for-loop.
+        self.assertRegex(
+            code,
+            r"for\s+\w+\s+in\s+tl\.range\(",
+            msg="expected an inner reduction for-loop in the generated Triton code",
+        )
+        torch.testing.assert_close(result, x.sum(-1), rtol=1e-4, atol=1e-4)
+
+    @skipIfNotTriton(
+        "tl.debug_barrier() is Triton codegen-specific; "
+        "the negative assertion is trivially true on non-Triton backends"
+    )
+    @skipIfCudaSharedMemoryLessThan(
+        65536, reason="block sizes exceed device shared memory limit"
+    )
+    def test_sequential_loops_no_barrier_without_cross_loop_raw(self):
+        """Independent sequential device loops should not get an inter-loop barrier."""
+
+        @helion.kernel(autotune_effort="none")
+        def independent_loops(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.shape
+            out1 = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            out2 = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m in hl.tile(m):
+                for tile_n in hl.tile(n):
+                    out1[tile_m, tile_n] = x[tile_m, tile_n] * 2
+                for tile_n in hl.tile(n):
+                    out2[tile_m, tile_n] = x[tile_m, tile_n] + 1
+            return out2
+
+        x = torch.randn(64, 64, dtype=torch.float32, device=DEVICE)
+        code, result = code_and_output(
+            independent_loops,
+            (x,),
+            block_sizes=[64, 64, 64],
+            num_warps=4,
+            num_stages=1,
+        )
+        torch.testing.assert_close(result, x + 1)
+        self.assertNotIn("tl.debug_barrier()", code)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
On AMD devices with num_warps >= 4, sequential device loops need an explicit workgroup barrier so that global memory stores from all wavefronts in the first loop are visible to loads in the second loop.
NVIDIA GPUs provide implicit L1 cache coherence within a CTA so no barrier is needed. On AMD with fewer wavefronts the hardware coherence within a single CU is sufficient.