### PR TITLE
custom config filter

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -22,6 +22,7 @@ from typing import Literal
 from typing import NamedTuple
 from typing import NoReturn
 from typing import Protocol
+from typing import cast
 from unittest.mock import patch
 
 import torch
@@ -182,7 +183,7 @@ class BenchmarkResult(NamedTuple):
     config: Config
     fn: Callable[..., object]
     perf: float
-    status: Literal["ok", "error", "timeout", "peer_compilation_fail"]
+    status: Literal["ok", "error", "timeout", "peer_compilation_fail", "filtered"]
     compile_time: float | None
 
 
@@ -366,7 +367,11 @@ class BaseSearch(BaseAutotuner):
 
     # TODO(hinriksnaer): migrate _benchmark to BenchmarkProvider
     def _benchmark(
-        self, configs: list[Config], *, desc: str = "Benchmarking"
+        self,
+        configs: list[Config],
+        *,
+        desc: str = "Benchmarking",
+        _skip_filter: bool = False,
     ) -> list[BenchmarkResult]:
         """
         Internal benchmark implementation. Compiles in parallel and benchmarks configs.
@@ -379,6 +384,40 @@ class BaseSearch(BaseAutotuner):
             A list of BenchmarkResult entries containing the configuration, compiled
             callable, measured performance, status, and compilation time.
         """
+        config_filter = self.settings.autotune_config_filter
+        if config_filter is not None and not _skip_filter:
+            filtered_configs: list[Config | None] = [config_filter(c) for c in configs]
+            passing_indices = [
+                i for i, fc in enumerate(filtered_configs) if fc is not None
+            ]
+            passing_configs = cast(
+                "list[Config]",
+                [filtered_configs[i] for i in passing_indices],
+            )
+            inner_results = self._benchmark(
+                passing_configs, desc=desc, _skip_filter=True
+            )
+            inner_iter = iter(inner_results)
+            merged: list[BenchmarkResult] = []
+            passing_set = set(passing_indices)
+            for i, config in enumerate(configs):
+                if i in passing_set:
+                    merged.append(next(inner_iter))
+                else:
+                    self.log.debug(
+                        f"Config filtered out by autotune_config_filter: {config!r}"
+                    )
+                    merged.append(
+                        BenchmarkResult(
+                            config=config,
+                            fn=lambda *a, **kw: None,
+                            perf=inf,
+                            status="filtered",
+                            compile_time=None,
+                        )
+                    )
+            return merged
+
         all_configs = configs
         compiled: dict[int, Callable[..., object]] = {}
         futures: list[PrecompileFuture] | None = None
@@ -446,7 +485,9 @@ class BaseSearch(BaseAutotuner):
                 )
             else:
                 compile_time = None
-            status: Literal["ok", "error", "timeout", "peer_compilation_fail"]
+            status: Literal[
+                "ok", "error", "timeout", "peer_compilation_fail", "filtered"
+            ]
             if all(
                 all_gather_object(
                     is_working, process_group_name=self.kernel.env.process_group_name
@@ -648,9 +689,9 @@ class PopulationMember:
     perfs: list[float]
     flat_values: FlatConfig
     config: Config
-    status: Literal["ok", "error", "timeout", "peer_compilation_fail", "unknown"] = (
-        "unknown"
-    )
+    status: Literal[
+        "ok", "error", "timeout", "peer_compilation_fail", "filtered", "unknown"
+    ] = "unknown"
     compile_time: float | None = None
 
     @property

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -30,6 +30,7 @@ from .ref_mode import RefMode
 if TYPE_CHECKING:
     from ..autotuner.base_search import BaseAutotuner
     from ..autotuner.pattern_search import InitialPopulationStrategy
+    from .config import Config
     from .kernel import BoundKernel
 
     _T = TypeVar("_T")
@@ -507,6 +508,7 @@ class _Settings:
             _env_get_bool, "HELION_AUTOTUNE_WITH_TORCH_COMPILE_FUSION", False
         )
     )
+    autotune_config_filter: Callable[[Config], Config | None] | None = None
 
 
 class Settings(_Settings):
@@ -652,6 +654,14 @@ class Settings(_Settings):
             "If True, allow torch.compile to fuse this Helion kernel with surrounding Inductor ops "
             "(prologue/epilogue) when used inside torch.compile. Default False. "
             "Set HELION_TORCH_COMPILE_FUSION=1 to enable globally."
+        ),
+        "autotune_config_filter": (
+            "Optional callable ``(config: Config) -> Config | None`` that the autotuner calls on every "
+            "candidate config before compiling or benchmarking it.  If the callable returns None, "
+            "the config is skipped entirely (no compilation, no benchmarking).  If it returns a Config "
+            "(which may be a modified copy of the original), that config is used for benchmarking. "
+            "Also filters the explicit ``configs=[...]`` list when one is provided. "
+            "Pass as @helion.kernel(..., autotune_config_filter=my_filter_fn)."
         ),
         "autotune_with_torch_compile_fusion": (
             "If True, autotuning benchmarks the fused kernel (with epilogue/prologue) "

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -2404,5 +2404,120 @@ class TestAutotuneCacheSelection(TestCase):
                     bound.settings.autotuner_fn(bound, args)
 
 
+@skipIfRefEager("Autotuning requires compilation, not supported in ref eager mode")
+@onlyBackends(["triton"])
+class TestConfigFilter(TestCase):
+    """Tests for the autotune_config_filter setting."""
+
+    def _make_kernel_and_args(self, **kernel_kwargs):
+        @helion.kernel(autotune_log_level=0, **kernel_kwargs)
+        def add(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(a)
+            for tile in hl.tile(out.size()):
+                out[tile] = a[tile] + b[tile]
+            return out
+
+        args = (
+            torch.randn([128], device=DEVICE),
+            torch.randn([128], device=DEVICE),
+        )
+        return add, args
+
+    def test_autotune_config_filter_skips_filtered_configs(self) -> None:
+        """Filtered configs produce status='filtered' and perf=inf."""
+        cfg1 = helion.Config(block_sizes=[16], num_warps=4)
+        cfg2 = helion.Config(block_sizes=[32], num_warps=4)
+        cfg3 = helion.Config(block_sizes=[64], num_warps=4)
+
+        filtered_out: list[helion.Config] = []
+
+        def my_filter(config: helion.Config) -> helion.Config | None:
+            if config.get("block_sizes") == [32]:
+                filtered_out.append(config)
+                return None
+            return config
+
+        add, args = self._make_kernel_and_args(
+            autotune_config_filter=my_filter, autotune_precompile=None
+        )
+        bound = add.bind(args)
+        search = FiniteSearch(bound, args, configs=[cfg1, cfg2, cfg3])
+        search._prepare()
+        results = search.benchmark_batch([cfg1, cfg2, cfg3])
+
+        # cfg2 should be filtered
+        self.assertEqual(len(filtered_out), 1)
+        self.assertEqual(filtered_out[0].get("block_sizes"), [32])
+
+        statuses = {tuple(r.config.get("block_sizes", [])): r.status for r in results}
+        self.assertEqual(statuses[(16,)], "ok")
+        self.assertEqual(statuses[(32,)], "filtered")
+        self.assertEqual(statuses[(64,)], "ok")
+
+        perfs = {tuple(r.config.get("block_sizes", [])): r.perf for r in results}
+        self.assertEqual(perfs[(32,)], float("inf"))
+
+    def test_autotune_config_filter_affects_autotune_winner(self) -> None:
+        """The autotuner never picks a filtered config as the winner."""
+        # cfg_fast would normally win (smallest block = least work per kernel launch
+        # in this trivial test), but we filter it out.
+        cfg_fast = helion.Config(block_sizes=[16], num_warps=4)
+        cfg_slow = helion.Config(block_sizes=[128], num_warps=4)
+
+        def reject_small_blocks(config: helion.Config) -> helion.Config | None:
+            return config if (config.get("block_sizes") or [0])[0] >= 64 else None
+
+        add, args = self._make_kernel_and_args(
+            autotune_config_filter=reject_small_blocks
+        )
+        bound = add.bind(args)
+        search = FiniteSearch(bound, args, configs=[cfg_fast, cfg_slow])
+        winner = search.autotune()
+        # cfg_fast is filtered out, so cfg_slow must win
+        self.assertEqual(winner.get("block_sizes"), [128])
+
+    def test_autotune_config_filter_none_is_noop(self) -> None:
+        """When autotune_config_filter=None (default), all configs are benchmarked normally."""
+        cfg1 = helion.Config(block_sizes=[16], num_warps=4)
+        cfg2 = helion.Config(block_sizes=[32], num_warps=4)
+
+        add, args = self._make_kernel_and_args(
+            autotune_precompile=None
+        )  # no autotune_config_filter
+        bound = add.bind(args)
+        search = FiniteSearch(bound, args, configs=[cfg1, cfg2])
+        search._prepare()
+        results = search.benchmark_batch([cfg1, cfg2])
+
+        for result in results:
+            self.assertNotEqual(result.status, "filtered")
+            self.assertFalse(math.isinf(result.perf))
+
+    def test_autotune_config_filter_can_override_config(self) -> None:
+        """autotune_config_filter can return a modified Config to override values before benchmarking."""
+        cfg1 = helion.Config(block_sizes=[16], num_warps=4)
+        cfg2 = helion.Config(block_sizes=[32], num_warps=4)
+
+        def override_num_warps(config: helion.Config) -> helion.Config | None:
+            # Override num_warps to 2 for all configs
+            return helion.Config.from_dict({**config.config, "num_warps": 2})
+
+        add, args = self._make_kernel_and_args(
+            autotune_config_filter=override_num_warps, autotune_precompile=None
+        )
+        bound = add.bind(args)
+        search = FiniteSearch(bound, args, configs=[cfg1, cfg2])
+        search._prepare()
+        results = search.benchmark_batch([cfg1, cfg2])
+
+        # All configs should run successfully (none filtered)
+        for result in results:
+            self.assertNotEqual(result.status, "filtered")
+            self.assertFalse(math.isinf(result.perf))
+        # The result configs should reflect the overridden values
+        self.assertEqual(results[0].config.get("num_warps"), 2)
+        self.assertEqual(results[1].config.get("num_warps"), 2)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
custom config filter

Motivations
1. user may want to be aggressively filter small block sizes for their kernel but don't want to make such call for all kernels
2. would be handy to do investigation like avoid TMA here https://github.com/pytorch/helion/issues/1846