### PR TITLE
[Pallas] Exclude output-only tensors from Pallas pallas_call inputs to improve performance

### DIFF
--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -361,47 +361,45 @@ def _pallas_build_block_specs(
     output_indices: list[int],
     block_spec_info: _BlockSpecInfo | None = None,
     _smem_arg_indices: list[int] | None = None,
-    _output_only_set: set[int] | None = None,
+    output_only_indices: list[int] | None = None,
 ) -> tuple[list[object] | None, object | None]:
     """Build ``in_specs`` and ``out_specs`` for ``pl.pallas_call``.
 
-    Output-only tensors (in ``_output_only_set``) get HBM in_specs
-    to avoid VMEM pressure while keeping VMEM out_specs for writes.
+    ``block_spec_info`` is indexed by position among *all* tensor args.
+    ``output_only_indices`` lists tensor positions excluded from
+    ``tensor_arg_indices``; they are merged back to compute the mapping.
     """
     if block_spec_info is None or len(grid) == 0:
         return None, None
 
-    output_only_set = _output_only_set or set()
+    all_positions = sorted(set(tensor_arg_indices) | set(output_only_indices or []))
+    all_arg_to_tensor_pos = {orig: tpos for tpos, orig in enumerate(all_positions)}
 
     in_specs = []
-    for tensor_pos, idx in enumerate(tensor_arg_indices):
+    for idx in tensor_arg_indices:
         t = args[idx]
         assert isinstance(t, torch.Tensor)
-        if idx in output_only_set:
-            in_specs.append(pl.BlockSpec(memory_space=pl.ANY))  # type: ignore[union-attr]
-        else:
-            should_use_smem = tensor_pos in (_smem_arg_indices or [])
-            in_specs.append(
-                _pallas_make_block_spec(
-                    pl, jnp, pltpu, t, block_spec_info[tensor_pos], should_use_smem
-                )
+        tensor_pos = all_arg_to_tensor_pos[idx]
+        should_use_smem = tensor_pos in (_smem_arg_indices or [])
+        in_specs.append(
+            _pallas_make_block_spec(
+                pl, jnp, pltpu, t, block_spec_info[tensor_pos], should_use_smem
             )
+        )
 
-    arg_to_tensor_pos = {orig: tpos for tpos, orig in enumerate(tensor_arg_indices)}
     out_specs_list = []
     for idx in output_indices:
         t = args[idx]
         assert isinstance(t, torch.Tensor)
-        # Output-only tensors keep VMEM out_specs so the kernel can write
-        # to them; only their in_specs use HBM to avoid VMEM pressure.
-        should_use_smem = arg_to_tensor_pos[idx] in (_smem_arg_indices or [])
+        tensor_pos = all_arg_to_tensor_pos[idx]
+        should_use_smem = tensor_pos in (_smem_arg_indices or [])
         out_specs_list.append(
             _pallas_make_block_spec(
                 pl,
                 jnp,
                 pltpu,
                 t,
-                block_spec_info[arg_to_tensor_pos[idx]],
+                block_spec_info[tensor_pos],
                 should_use_smem,
             )
         )
@@ -420,6 +418,7 @@ def _pallas_build_pipeline_specs(
     output_indices: list[int],
     block_spec_info: _BlockSpecInfo | None,
     pipeline_arg_indices: list[int] | None,
+    output_only_indices: list[int] | None = None,
 ) -> tuple[list[object], object]:
     """Build in/out specs for pipeline launchers.
 
@@ -427,7 +426,8 @@ def _pallas_build_pipeline_specs(
     All other tensors get proper BlockSpecs for automatic VMEM prefetch.
     """
     pipeline_set = set(pipeline_arg_indices or [])
-    arg_to_tpos = {orig: tpos for tpos, orig in enumerate(tensor_arg_indices)}
+    all_positions = sorted(set(tensor_arg_indices) | set(output_only_indices or []))
+    arg_to_tpos = {orig: tpos for tpos, orig in enumerate(all_positions)}
 
     def _spec_for(idx: int) -> object:
         if idx in pipeline_set:
@@ -489,25 +489,24 @@ def _pallas_check_dtypes(args: tuple[object, ...]) -> None:
 def _pallas_prepare_args(
     args: tuple[object, ...],
     _output_indices: list[int],
+    _inplace_indices: list[int] | None = None,
 ) -> tuple[
-    set[int],
+    list[int],
     list[int],
     dict[int, object],
     int,
     dict[int, int],
-    list[object],
     set[int],
     tuple[object, ...],
 ]:
     """Extract and organize tensor/non-tensor args for Pallas launchers.
 
     Returns a tuple of:
-    - output_set: set of output arg positions
-    - tensor_arg_indices: positions of tensor args
+    - tensor_arg_indices: positions of tensor args passed as pallas_call inputs
+    - output_only_indices: positions of output-only tensors (excluded from inputs)
     - non_tensor_args: mapping of non-tensor arg positions to values
-    - n_tensor_inputs: count of tensor args
+    - n_tensor_inputs: count of tensor inputs (excl. output-only)
     - arg_to_tensor_pos: mapping from original position to tensor-only position
-    - outputs: list of output tensors
     - inplace_positions: positions that are both input and output
     - out_shapes: JAX placeholders for output shapes
     """
@@ -523,25 +522,29 @@ def _pallas_prepare_args(
         placeholder_fn = jax_placeholder
 
     output_set = set(_output_indices)
-    tensor_arg_indices = [
+    inplace_set = set(_inplace_indices) if _inplace_indices is not None else output_set
+    output_only = output_set - inplace_set
+
+    all_tensor_positions = [
         i for i in range(len(args)) if isinstance(args[i], torch.Tensor)
     ]
+    output_only_indices = [i for i in all_tensor_positions if i in output_only]
+    tensor_arg_indices = [i for i in all_tensor_positions if i not in output_only]
+
     non_tensor_args: dict[int, object] = {
         i: args[i] for i in range(len(args)) if not isinstance(args[i], torch.Tensor)
     }
     n_tensor_inputs = len(tensor_arg_indices)
     arg_to_tensor_pos = {orig: tpos for tpos, orig in enumerate(tensor_arg_indices)}
-    outputs = [args[i] for i in _output_indices]
     inplace_positions = output_set & set(tensor_arg_indices)
-    out_shapes = tuple(placeholder_fn(out) for out in outputs)  # type: ignore[arg-type]
+    out_shapes = tuple(placeholder_fn(args[i]) for i in _output_indices)  # type: ignore[arg-type]
 
     return (
-        output_set,
         tensor_arg_indices,
+        output_only_indices,
         non_tensor_args,
         n_tensor_inputs,
         arg_to_tensor_pos,
-        outputs,
         inplace_positions,
         out_shapes,
     )
@@ -568,10 +571,9 @@ def _pallas_make_reordered_kernel(
     reordered args.
 
     *skip_inplace_copy* is a set of original-arg positions for which the
-    initial ``out_ref[...] = in_ref[...]`` copy should be skipped.  This is
-    needed for outputs backed by HBM refs (``pl.ANY``) where direct
-    load/store is not allowed.  Outputs with VMEM BlockSpecs still get the
-    copy so that ``input_output_aliases`` correctly preloads their contents.
+    initial ``out_ref[...] = in_ref[...]`` copy should be skipped.  Used by
+    pipeline/fori launchers for pipeline-body tensors backed by HBM refs
+    where direct load/store is not allowed.
     """
     _skip_copy = skip_inplace_copy or set()
 
@@ -617,11 +619,19 @@ def _pallas_build_callable(
     """
 
     def _make_interpret_callable() -> _PallasInterpretCallable:
-        output_tensor_positions = [
-            arg_to_tensor_pos[orig_pos] for orig_pos in _output_indices
+        # Map (out_idx in _output_indices) -> tensor_pos for inplace outputs.
+        # out_idx must match jax_results ordering (all outputs), not filtered.
+        inplace_output_mapping = [
+            (out_idx, arg_to_tensor_pos[orig_pos])
+            for out_idx, orig_pos in enumerate(_output_indices)
+            if orig_pos in arg_to_tensor_pos
         ]
-        callable_obj = _PallasInterpretCallable(jit_fn, output_tensor_positions)
-        setattr(pallas_kernel, cache_attr, (grid, callable_obj, tensor_arg_indices))
+        callable_obj = _PallasInterpretCallable(jit_fn, inplace_output_mapping)
+        setattr(
+            pallas_kernel,
+            cache_attr,
+            (grid, callable_obj, tensor_arg_indices, arg_to_tensor_pos),
+        )
         return callable_obj
 
     if _pallas_interpret_flag():
@@ -636,7 +646,8 @@ def _pallas_build_callable(
 
     call_aliases: dict[int, int] = {}
     for out_idx, orig_pos in enumerate(_output_indices):
-        call_aliases[arg_to_tensor_pos[orig_pos]] = out_idx
+        if orig_pos in arg_to_tensor_pos:
+            call_aliases[arg_to_tensor_pos[orig_pos]] = out_idx
 
     jax_callable = JaxCallable(
         name=kernel_name,
@@ -644,38 +655,54 @@ def _pallas_build_callable(
         trace_key=f"{kernel_name}_{id(pallas_kernel)}_{grid}{trace_key_suffix}",
         input_output_aliases=call_aliases,
     )
-    setattr(pallas_kernel, cache_attr, (grid, jax_callable, tensor_arg_indices))
+    setattr(
+        pallas_kernel,
+        cache_attr,
+        (grid, jax_callable, tensor_arg_indices, arg_to_tensor_pos),
+    )
     return jax_callable
 
 
 class _PallasInterpretCallable:
     """Thin wrapper that converts torch tensors <-> JAX arrays for interpret mode.
 
-    ``pallas_call`` with ``input_output_aliases`` returns new JAX arrays for the
-    outputs.  This wrapper copies those results back into the original torch
-    output tensors (identified by ``output_tensor_positions``).
+    In interpret mode, ``pallas_call`` runs on CPU and returns JAX arrays.
+    This wrapper:
+    1. Converts input torch tensors to JAX arrays
+    2. Runs the pallas_call function
+    3. For inplace outputs (donated tensors): copies JAX results back into
+       the original torch tensors via ``copy_()``
+    4. Returns raw JAX results so ``_pallas_invoke_and_copy_back`` can
+       handle output-only tensors (which are not in the input list)
+
+    ``inplace_output_mapping`` maps each inplace output to its JAX result:
+    a list of ``(out_idx, tensor_pos)`` where ``out_idx`` indexes into
+    ``jax_results`` and ``tensor_pos`` indexes into ``input_tensors``.
     """
 
     def __init__(
         self,
         jit_fn: object,
-        output_tensor_positions: list[int],
+        inplace_output_mapping: list[tuple[int, int]],
     ) -> None:
         self._jit_fn = jit_fn
-        self._output_tensor_positions = output_tensor_positions
+        self._inplace_output_mapping = inplace_output_mapping
 
-    def __call__(self, *input_tensors: torch.Tensor) -> None:
+    def __call__(self, *input_tensors: torch.Tensor) -> tuple[object, ...]:
         jax_inputs = [_torch_to_jax(t) for t in input_tensors]
         jax_results = self._jit_fn(*jax_inputs)  # type: ignore[operator]
         if not isinstance(jax_results, (tuple, list)):
             jax_results = (jax_results,)
-        # Write results back into the original output tensors.
-        for out_idx, tensor_pos in enumerate(self._output_tensor_positions):
+        # Write inplace results back into the original output tensors.
+        for out_idx, tensor_pos in self._inplace_output_mapping:
             out_tensor = input_tensors[tensor_pos]
             result_data = _jax_to_torch(
                 jax_results[out_idx], device=out_tensor.device, dtype=out_tensor.dtype
             )
             out_tensor.copy_(result_data)
+        # Return JAX results so output-only tensors can be handled
+        # by _pallas_invoke_and_copy_back.
+        return tuple(jax_results)
 
 
 def _pallas_interpret_flag() -> bool:
@@ -706,6 +733,43 @@ def _ensure_cpu_tpu_info() -> None:
         registry["cpu"] = lambda: _get_tpu_info_impl(ChipVersion.TPU_7X, 1)
 
 
+def _pallas_invoke_and_copy_back(
+    jax_callable: object,
+    args: tuple[object, ...],
+    tensor_arg_indices: list[int],
+    arg_to_tensor_pos: dict[int, int],
+    _output_indices: list[int],
+) -> None:
+    """Run the JaxCallable and handle output-only results.
+
+    Output-only tensors (those not in ``arg_to_tensor_pos``) are not passed
+    as pallas_call inputs, so the JaxCallable returns them.
+    """
+    input_tensors = [
+        cast("torch.Tensor", args[i]).contiguous() for i in tensor_arg_indices
+    ]
+    results = jax_callable(*input_tensors)  # type: ignore[operator]
+    if results is None:
+        return
+    if not isinstance(results, (tuple, list)):
+        results = (results,)
+    for out_idx, orig_pos in enumerate(_output_indices):
+        if orig_pos not in arg_to_tensor_pos:
+            out_tensor = cast("torch.Tensor", args[orig_pos])
+            result = results[out_idx]
+            if not isinstance(result, torch.Tensor):
+                # Interpret mode: pallas_call returns JAX arrays, convert to torch.
+                # On TPU, JaxCallable returns torch tensors directly.
+                result = _jax_to_torch(
+                    result,
+                    device=out_tensor.device,
+                    dtype=out_tensor.dtype,
+                )
+            # Swap the pre-allocated tensor's storage with the result
+            # (zero-copy) instead of copying data.
+            out_tensor.set_(result)  # pyrefly: ignore[no-matching-overload]
+
+
 def default_pallas_launcher(
     pallas_kernel: object,
     grid: tuple[int, ...],
@@ -725,7 +789,8 @@ def default_pallas_launcher(
     buffers (zero-copy on TPU).
 
     Output-only tensors (in ``_output_indices`` but not in ``_inplace_indices``)
-    get HBM in_specs to avoid VMEM pressure while still being donated.
+    are excluded from pallas_call inputs to save VMEM.  Their results are
+    returned as torch tensors.
     """
     if _output_indices is None:
         _output_indices = []
@@ -734,30 +799,21 @@ def default_pallas_launcher(
 
     cache = getattr(pallas_kernel, "_pallas_cache", None)
     if cache is not None and cache[0] == grid:
-        _, jax_callable, tensor_arg_indices = cache
+        _, jax_callable, tensor_arg_indices, arg_to_tensor_pos = cache
     else:
         from jax.experimental import pallas as pl
         from jax.experimental.pallas import tpu as pltpu
         import jax.numpy as jnp
 
         (
-            output_set,
             tensor_arg_indices,
+            output_only_indices,
             non_tensor_args,
             n_tensor_inputs,
             arg_to_tensor_pos,
-            outputs,
             inplace_positions,
             out_shapes,
-        ) = _pallas_prepare_args(args, _output_indices)
-
-        # Derive output-only set: outputs not in _inplace_indices.
-        inplace_set = (
-            set(_inplace_indices)
-            if _inplace_indices is not None
-            else set(_output_indices)
-        )
-        output_only_set = set(_output_indices) - inplace_set
+        ) = _pallas_prepare_args(args, _output_indices, _inplace_indices)
 
         in_specs, out_specs = _pallas_build_block_specs(
             pl,
@@ -769,7 +825,7 @@ def default_pallas_launcher(
             _output_indices,
             _block_spec_info,
             _smem_arg_indices,
-            output_only_set,
+            output_only_indices,
         )
 
         reordered_kernel = _pallas_make_reordered_kernel(
@@ -782,7 +838,6 @@ def default_pallas_launcher(
             inplace_positions,
             arg_to_tensor_pos,
             _smem_arg_indices=_smem_arg_indices,
-            skip_inplace_copy=output_only_set,
         )
 
         out_shape_arg = out_shapes if len(out_shapes) > 1 else out_shapes[0]
@@ -790,6 +845,7 @@ def default_pallas_launcher(
         pallas_aliases = {
             arg_to_tensor_pos[orig_pos]: out_idx
             for out_idx, orig_pos in enumerate(_output_indices)
+            if orig_pos in arg_to_tensor_pos
         }
 
         estimated_vmem = _estimate_pallas_vmem_bytes(
@@ -836,10 +892,9 @@ def default_pallas_launcher(
             cache_attr="_pallas_cache",
         )
 
-    input_tensors = [
-        cast("torch.Tensor", args[i]).contiguous() for i in tensor_arg_indices
-    ]
-    jax_callable(*input_tensors)  # type: ignore[operator]
+    _pallas_invoke_and_copy_back(
+        jax_callable, args, tensor_arg_indices, arg_to_tensor_pos, _output_indices
+    )
 
 
 def default_pallas_pipeline_launcher(
@@ -847,6 +902,7 @@ def default_pallas_pipeline_launcher(
     grid: tuple[int, ...],
     *args: object,
     _output_indices: list[int] | None = None,
+    _inplace_indices: list[int] | None = None,
     _block_spec_info: _BlockSpecInfo | None = None,
     _scratch_shapes: list[tuple[tuple[int, ...], str]] | None = None,
     _pipeline_arg_indices: list[int] | None = None,
@@ -867,22 +923,21 @@ def default_pallas_pipeline_launcher(
 
     cache = getattr(pallas_kernel, "_pallas_pipeline_cache", None)
     if cache is not None and cache[0] == grid:
-        _, jax_callable, tensor_arg_indices = cache
+        _, jax_callable, tensor_arg_indices, arg_to_tensor_pos = cache
     else:
         from jax.experimental import pallas as pl
         from jax.experimental.pallas import tpu as pltpu
         import jax.numpy as jnp
 
         (
-            output_set,
             tensor_arg_indices,
+            output_only_indices,
             non_tensor_args,
             n_tensor_inputs,
             arg_to_tensor_pos,
-            outputs,
             inplace_positions,
             out_shapes,
-        ) = _pallas_prepare_args(args, _output_indices)
+        ) = _pallas_prepare_args(args, _output_indices, _inplace_indices)
 
         # Build scratch shapes for VMEM
         _jnp_dtype_map = _pallas_jnp_dtype_map()
@@ -911,6 +966,7 @@ def default_pallas_pipeline_launcher(
             _output_indices,
             _block_spec_info,
             _pipeline_arg_indices,
+            output_only_indices,
         )
 
         _pipeline_set = set(_pipeline_arg_indices or [])
@@ -932,6 +988,7 @@ def default_pallas_pipeline_launcher(
         pallas_aliases = {
             arg_to_tensor_pos[orig_pos]: out_idx
             for out_idx, orig_pos in enumerate(_output_indices)
+            if orig_pos in arg_to_tensor_pos
         }
 
         grid_spec = pltpu.PrefetchScalarGridSpec(
@@ -987,10 +1044,9 @@ def default_pallas_pipeline_launcher(
             trace_key_suffix="_pipeline",
         )
 
-    input_tensors = [
-        cast("torch.Tensor", args[i]).contiguous() for i in tensor_arg_indices
-    ]
-    jax_callable(*input_tensors)  # type: ignore[operator]
+    _pallas_invoke_and_copy_back(
+        jax_callable, args, tensor_arg_indices, arg_to_tensor_pos, _output_indices
+    )
 
 
 def default_pallas_fori_launcher(
@@ -998,6 +1054,7 @@ def default_pallas_fori_launcher(
     grid: tuple[int, ...],
     *args: object,
     _output_indices: list[int] | None = None,
+    _inplace_indices: list[int] | None = None,
     _block_spec_info: _BlockSpecInfo | None = None,
     _scratch_shapes: list[tuple[tuple[int, ...], str | None, str]] | None = None,
     **kwargs: object,
@@ -1019,22 +1076,21 @@ def default_pallas_fori_launcher(
 
     cache = getattr(pallas_kernel, "_pallas_fori_cache", None)
     if cache is not None and cache[0] == grid:
-        _, jax_callable, tensor_arg_indices = cache
+        _, jax_callable, tensor_arg_indices, arg_to_tensor_pos = cache
     else:
         from jax.experimental import pallas as pl
         from jax.experimental.pallas import tpu as pltpu
         import jax.numpy as jnp
 
         (
-            output_set,
             tensor_arg_indices,
+            output_only_indices,
             non_tensor_args,
             n_tensor_inputs,
             arg_to_tensor_pos,
-            outputs,
             inplace_positions,
             out_shapes,
-        ) = _pallas_prepare_args(args, _output_indices)
+        ) = _pallas_prepare_args(args, _output_indices, _inplace_indices)
 
         # Build scratch shapes: VMEM buffers + DMA semaphores
         _jnp_dtype_map = _pallas_jnp_dtype_map()
@@ -1062,6 +1118,7 @@ def default_pallas_fori_launcher(
             _output_indices,
             _block_spec_info,
             _fori_pipeline_indices,  # type: ignore[arg-type]
+            output_only_indices,
         )
 
         _fori_pipeline_set = set(_fori_pipeline_indices or [])  # type: ignore[arg-type]
@@ -1083,6 +1140,7 @@ def default_pallas_fori_launcher(
         pallas_aliases = {
             arg_to_tensor_pos[orig_pos]: out_idx
             for out_idx, orig_pos in enumerate(_output_indices)
+            if orig_pos in arg_to_tensor_pos
         }
 
         grid_spec = pltpu.PrefetchScalarGridSpec(
@@ -1138,10 +1196,9 @@ def default_pallas_fori_launcher(
             trace_key_suffix="_fori",
         )
 
-    input_tensors = [
-        cast("torch.Tensor", args[i]).contiguous() for i in tensor_arg_indices
-    ]
-    jax_callable(*input_tensors)  # type: ignore[operator]
+    _pallas_invoke_and_copy_back(
+        jax_callable, args, tensor_arg_indices, arg_to_tensor_pos, _output_indices
+    )
 
 
 def _torch_to_jax(t: torch.Tensor) -> object:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -571,6 +571,8 @@ class TestPallas(TestCase):
         self.assertIn("pltpu.emit_pipeline", code)
         self.assertIn("pl.BlockSpec", code)
         torch.testing.assert_close(result, args[0] + args[1])
+        # out is output-only, excluded from pallas_call inputs
+        self.assertIn("_inplace_indices=[]", code)
 
     def test_fori_loop_codegen(self) -> None:
         """Test that pallas_loop_type='fori_loop' generates correct fori_loop code."""
@@ -588,6 +590,8 @@ class TestPallas(TestCase):
         self.assertIn("pltpu.make_async_copy", code)
         self.assertNotIn("pltpu.emit_pipeline", code)
         torch.testing.assert_close(result, args[0] + args[1])
+        # out is output-only, excluded from pallas_call inputs
+        self.assertIn("_inplace_indices=[]", code)
 
     def test_attention_default_fp32(self) -> None:
         """Test attention with default (for-loop) inner loop."""
@@ -869,10 +873,19 @@ class TestPallas(TestCase):
         torch.testing.assert_close(result, expected)
 
     def test_output_only_not_inplace(self) -> None:
-        """Output-only tensors should not appear in _inplace_indices."""
+        """Output-only tensors should not appear in _inplace_indices.
+
+        When _output_indices has more entries than _inplace_indices, the
+        extra outputs are excluded from pallas_call inputs and
+        input_output_aliases, eliminating the OpSplitMode::kSplitBoth
+        graph split in torch_tpu.
+        """
         x = torch.randn(1024, device=DEVICE, dtype=torch.float32)
         code, result = code_and_output(pallas_relu, (x,), block_sizes=[1024])
         torch.testing.assert_close(result, torch.relu(x))
+        # out is in _output_indices but not _inplace_indices, so it's
+        # excluded from pallas_call inputs (no donation, no graph split).
+        self.assertIn("_output_indices=[1]", code)
         self.assertIn("_inplace_indices=[]", code)
 
     def test_new_empty_output_only(self) -> None:
@@ -909,7 +922,9 @@ class TestPallas(TestCase):
         expected_out = (x + 1.0) * 2.0
         code, result = code_and_output(inplace_and_output, (x,), block_sizes=[1024])
         torch.testing.assert_close(result, expected_out)
-        # x is inplace-mutated (index 0), out is output-only (not in inplace)
+        # 2 outputs (x and out), but only x is aliased (inplace).
+        # out is excluded from pallas_call inputs.
+        self.assertIn("_output_indices=[0, 1]", code)
         self.assertIn("_inplace_indices=[0]", code)
 
     def test_empty_like_read_stays_inplace(self) -> None:
@@ -935,6 +950,28 @@ class TestPallas(TestCase):
         y = torch.arange(256, device=DEVICE, dtype=torch.int64)
         with self.assertRaises(TypeError, msg="does not support"):
             code_and_output(add_kernel, (x, y), block_size=128)
+
+    def test_multiple_output_only(self) -> None:
+        """Kernel returning two output-only tensors."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def two_outputs(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+            out1 = torch.empty_like(x)
+            out2 = torch.empty_like(x)
+            for tile in hl.tile(x.size()):
+                out1[tile] = x[tile] + 1.0
+                out2[tile] = x[tile] * 2.0
+            return out1, out2
+
+        x = torch.randn(1024, device=DEVICE, dtype=torch.float32)
+        code, (result1, result2) = code_and_output(
+            two_outputs, (x,), block_sizes=[1024]
+        )
+        torch.testing.assert_close(result1, x + 1.0)
+        torch.testing.assert_close(result2, x * 2.0)
+        # Both outputs are output-only: 2 outputs, 0 aliases
+        self.assertIn("_output_indices=[1, 2]", code)
+        self.assertIn("_inplace_indices=[]", code)
 
     def test_fori_loop_multidim(self) -> None:
         """Test fori_loop with a 2D inner loop (nested iteration)."""


### PR DESCRIPTION
## Summary

When a Helion kernel allocates an output tensor that is only written to (never read), e.g.:
```python
out = torch.empty_like(x)
for tile in hl.tile(x.size()):
    out[tile] = torch.exp(x[tile])
return out
```

the Pallas backend previously passed `out` as both a pallas_call input (for donation via `input_output_aliases`) and output. This triggered `OpSplitMode::kSplitBoth` in torch_tpu ([pallas_py.cc:110](https://github.com/google-pytorch/torch_tpu/blob/1ab227b4/torch_tpu/_internal/pallas/pallas_py.cc#L110)), which splits the XLA graph before and after the custom kernel. This forced the `torch.empty_like()` allocation — which would normally be elided or fused by XLA — to materialize as a separate device op (`empty.1` broadcast), adding ~127us overhead per kernel call at large tensor sizes.

### Root cause investigation

We investigated the `empty.1` overhead by isolating each factor:

1. **`kSplitBoth` alone doesn't insert `empty.1`**: Passing a pre-existing tensor with `input_output_aliases` (without allocating a new one per call) shows no `empty.1` in xprof traces — `kSplitBoth` just splits the graph.

2. **`torch.empty()` alone doesn't create a device op**: Without aliasing, `torch.empty()` is either fused away or never materialized on device — no `empty.1` appears.

3. **`torch.empty()` + `kSplitBoth` together create `empty.1`**: When `torch.empty()` is called per iteration AND `input_output_aliases` is non-empty, `kSplitBoth` forces the graph to materialize before the kernel, which forces the `empty()` to execute as a separate `empty.1` broadcast op on the device.

The overhead scales linearly with tensor size: ~3us at 4MB, ~127us at 400MB.

### Fix

This PR excludes output-only tensors from pallas_call inputs entirely. Since output-only tensors are never read by the kernel, they don't need to be donated — pallas_call returns new buffers for them, and `set_()` swaps the pre-allocated tensor's storage with the result (zero-copy).

With no output-only tensors in inputs, `input_output_aliases` becomes empty, `kSplitBoth` is not triggered, and the `torch.empty_like()` allocation is never forced to materialize on device.

Builds on #1984 which already eliminated VMEM pressure for output-only tensors via HBM `in_specs`. This PR goes further by removing them from inputs entirely.

## Benchmark Results

`exp_fwd` kernel on TPU v7, N=104,857,600. See #1773 for benchmark methodology.

| Implementation | Wall (ms) | Throughput (ms) | Device (ms, xprof) |
|---|---|---|---|
| torch.exp | 0.508 | 0.281 | 0.259 |
| helion exp_fwd (g=50) | 0.507 | 0.293 | 0.260 |
| jax.numpy.exp | 0.445 | 0.274 | 0.263 |
| pallas exp jax (g=50) | 0.453 | 0.271 | 0.260 |
| pallas exp torch_tpu (g=50) | 0.523 | 0.280 | 0.260 |

Device time for helion `exp_fwd` is **0.260 ms** — no `empty.1` broadcast op. Matches native `torch.exp` (0.259 ms) and pure JAX Pallas (0.260 ms).

Benchmark script: https://gist.github.com/norx1991/091794b532b2a86650befc449f868c68