### PR TITLE
Reduce some autotuner overhead without changing kernel behavior

### DIFF
--- a/helion/_compiler/tile_dispatch.py
+++ b/helion/_compiler/tile_dispatch.py
@@ -19,6 +19,7 @@ from .tile_strategy import DeviceLoopState
 from .tile_strategy import TileStrategy
 
 if TYPE_CHECKING:
+    from collections.abc import ItemsView
     from collections.abc import Sequence
 
     from .. import Config
@@ -26,6 +27,38 @@ if TYPE_CHECKING:
 
     SymIntLike = torch.SymInt | int
     ShapeLike = Sequence[SymIntLike]
+
+
+class BlockIDStrategyMapping:
+    def __init__(self) -> None:
+        self._block_id_to_strategy: dict[tuple[int, ...], TileStrategy] = {}
+        self._block_id_to_any_strategy: dict[int, TileStrategy] = {}
+
+    def __setitem__(self, block_ids: tuple[int, ...], strategy: TileStrategy) -> None:
+        self._block_id_to_strategy[block_ids] = strategy
+        for block_id in block_ids:
+            self._block_id_to_any_strategy.setdefault(block_id, strategy)
+
+    def __getitem__(self, block_ids: tuple[int, ...]) -> TileStrategy:
+        return self._block_id_to_strategy[block_ids]
+
+    def get(
+        self, block_ids: tuple[int, ...], default: TileStrategy | None = None
+    ) -> TileStrategy | None:
+        return self._block_id_to_strategy.get(block_ids, default)
+
+    def get_any(self, block_id: int) -> TileStrategy | None:
+        strategy = self._block_id_to_strategy.get((block_id,))
+        if strategy is None:
+            strategy = self._block_id_to_any_strategy.get(block_id)
+        return strategy
+
+    def items(self) -> ItemsView[tuple[int, ...], TileStrategy]:
+        return self._block_id_to_strategy.items()
+
+    def clear(self) -> None:
+        self._block_id_to_strategy.clear()
+        self._block_id_to_any_strategy.clear()
 
 
 class TileStrategyDispatch:
@@ -36,8 +69,7 @@ class TileStrategyDispatch:
     ) -> None:
         super().__init__()
         self.strategies: list[TileStrategy] = []
-        self.block_id_to_strategy: dict[tuple[int, ...], TileStrategy] = {}
-        self._block_id_to_any_strategy: dict[int, TileStrategy] = {}
+        self.block_id_to_strategy = BlockIDStrategyMapping()
         self._add_loop_strategies(fn, config)
         self._add_reduction_strategies(fn, config)
 
@@ -62,8 +94,6 @@ class TileStrategyDispatch:
     def _register_strategy(self, block_ids: list[int], strategy: TileStrategy) -> None:
         self.strategies.append(strategy)
         self.block_id_to_strategy[tuple(block_ids)] = strategy
-        for block_id in block_ids:
-            self._block_id_to_any_strategy.setdefault(block_id, strategy)
 
     def _add_reduction_strategies(self, fn: DeviceFunction, config: Config) -> None:
         env = CompileEnvironment.current()
@@ -125,7 +155,7 @@ class TileStrategyDispatch:
             else:
                 strategy = self.block_id_to_strategy.get((block_idx,))
                 if strategy is None:
-                    strategy = self._block_id_to_any_strategy.get(block_idx)
+                    strategy = self.block_id_to_strategy.get_any(block_idx)
                 if strategy is not None:
                     block_size = strategy.block_size_var(block_idx)
                 else:

--- a/helion/_compiler/tile_dispatch.py
+++ b/helion/_compiler/tile_dispatch.py
@@ -59,9 +59,7 @@ class TileStrategyDispatch:
         strategy = env.backend.create_loop_strategy(fn, block_ids, config)
         self._register_strategy(block_ids, strategy)
 
-    def _register_strategy(
-        self, block_ids: list[int], strategy: TileStrategy
-    ) -> None:
+    def _register_strategy(self, block_ids: list[int], strategy: TileStrategy) -> None:
         self.strategies.append(strategy)
         self.block_id_to_strategy[tuple(block_ids)] = strategy
         for block_id in block_ids:

--- a/helion/_compiler/tile_dispatch.py
+++ b/helion/_compiler/tile_dispatch.py
@@ -37,6 +37,7 @@ class TileStrategyDispatch:
         super().__init__()
         self.strategies: list[TileStrategy] = []
         self.block_id_to_strategy: dict[tuple[int, ...], TileStrategy] = {}
+        self._block_id_to_any_strategy: dict[int, TileStrategy] = {}
         self._add_loop_strategies(fn, config)
         self._add_reduction_strategies(fn, config)
 
@@ -56,8 +57,15 @@ class TileStrategyDispatch:
     ) -> None:
         env = CompileEnvironment.current()
         strategy = env.backend.create_loop_strategy(fn, block_ids, config)
+        self._register_strategy(block_ids, strategy)
+
+    def _register_strategy(
+        self, block_ids: list[int], strategy: TileStrategy
+    ) -> None:
         self.strategies.append(strategy)
         self.block_id_to_strategy[tuple(block_ids)] = strategy
+        for block_id in block_ids:
+            self._block_id_to_any_strategy.setdefault(block_id, strategy)
 
     def _add_reduction_strategies(self, fn: DeviceFunction, config: Config) -> None:
         env = CompileEnvironment.current()
@@ -91,8 +99,7 @@ class TileStrategyDispatch:
                 strategy: TileStrategy = PersistentReductionStrategy(fn, block_id)
             else:
                 strategy = LoopedReductionStrategy(fn, block_id, reduction_loop)
-            self.strategies.append(strategy)
-            self.block_id_to_strategy[(block_id,)] = strategy
+            self._register_strategy([block_id], strategy)
 
     def codegen_grid(self, state: CodegenState, block_ids: list[int]) -> None:
         strategy = self.block_id_to_strategy[tuple(block_ids)]
@@ -120,10 +127,7 @@ class TileStrategyDispatch:
             else:
                 strategy = self.block_id_to_strategy.get((block_idx,))
                 if strategy is None:
-                    for candidate in self.strategies:
-                        if block_idx in candidate.block_ids:
-                            strategy = candidate
-                            break
+                    strategy = self._block_id_to_any_strategy.get(block_idx)
                 if strategy is not None:
                     block_size = strategy.block_size_var(block_idx)
                 else:

--- a/helion/autotuner/heuristic_generator.py
+++ b/helion/autotuner/heuristic_generator.py
@@ -709,8 +709,7 @@ def _select_config_subset_single(
             scores = np.sum(slowdowns <= target.threshold, axis=0)
         elif target.goal_type == "geomean_slowdown":
             scores = (
-                np.exp(np.mean(np.log(slowdowns + 1e-10), axis=0))
-                <= target.threshold
+                np.exp(np.mean(np.log(slowdowns + 1e-10), axis=0)) <= target.threshold
             ).astype(np.int64)
         else:  # avg_slowdown
             scores = (np.mean(slowdowns, axis=0) <= target.threshold).astype(np.int64)

--- a/helion/autotuner/heuristic_generator.py
+++ b/helion/autotuner/heuristic_generator.py
@@ -684,9 +684,11 @@ def _select_config_subset_single(
 
     # Find the best timing for each shape (oracle performance)
     best_per_shape = np.min(data.timings, axis=1)
+    safe_best_per_shape = best_per_shape[:, None]
 
     # Track which shapes are satisfied
     selected_indices: list[int] = []
+    selected_mask = np.zeros(n_configs, dtype=bool)
     satisfied = np.zeros(n_shapes, dtype=bool)
 
     # Current best achievable timing with selected configs
@@ -696,36 +698,30 @@ def _select_config_subset_single(
         if satisfied.all():
             break
 
-        # Score each remaining config by how many unsatisfied shapes it helps
-        best_score = -1
-        best_config_idx = -1
-
-        for config_idx in range(n_configs):
-            if config_idx in selected_indices:
-                continue
-
-            # Compute new best if we add this config
-            new_best = np.minimum(current_best, data.timings[:, config_idx])
-            slowdowns = new_best / best_per_shape
-
-            if target.goal_type == "max_slowdown":
-                score = np.sum(slowdowns <= target.threshold)
-            elif target.goal_type == "geomean_slowdown":
-                score = np.sum(
-                    np.exp(np.mean(np.log(slowdowns + 1e-10))) <= target.threshold
-                )
-            else:  # avg_slowdown
-                score = np.sum(np.mean(slowdowns) <= target.threshold)
-
-            if score > best_score:
-                best_score = score
-                best_config_idx = config_idx
-
-        if best_config_idx == -1:
+        unselected_indices = np.flatnonzero(~selected_mask)
+        if len(unselected_indices) == 0:
             break
 
+        new_best = np.minimum(current_best[:, None], data.timings)
+        slowdowns = new_best / safe_best_per_shape
+
+        if target.goal_type == "max_slowdown":
+            scores = np.sum(slowdowns <= target.threshold, axis=0)
+        elif target.goal_type == "geomean_slowdown":
+            scores = (
+                np.exp(np.mean(np.log(slowdowns + 1e-10), axis=0))
+                <= target.threshold
+            ).astype(np.int64)
+        else:  # avg_slowdown
+            scores = (np.mean(slowdowns, axis=0) <= target.threshold).astype(np.int64)
+
+        # Preserve the original tie-breaking behavior by taking the first
+        # unselected config with the best score in index order.
+        best_local_idx = int(np.argmax(np.asarray(scores)[unselected_indices]))
+        best_config_idx = int(unselected_indices[best_local_idx])
         selected_indices.append(best_config_idx)
-        current_best = np.minimum(current_best, data.timings[:, best_config_idx])
+        selected_mask[best_config_idx] = True
+        current_best = new_best[:, best_config_idx]
 
         # Update satisfied
         slowdowns = current_best / best_per_shape

--- a/helion/autotuner/surrogate_pattern_search.py
+++ b/helion/autotuner/surrogate_pattern_search.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import operator
 import random
 from typing import TYPE_CHECKING
 
@@ -306,7 +307,7 @@ class LFBOPatternSearch(PatternSearch):
                 scores = [random.random() for _ in range(n_samples)]
             candidates_sorted = sorted(
                 zip(candidates, scores, strict=True),
-                key=lambda item: item[1],
+                key=operator.itemgetter(1),
             )[:n_selected]
             candidates_sorted = [member for member, _ in candidates_sorted]
         else:
@@ -323,8 +324,8 @@ class LFBOPatternSearch(PatternSearch):
 
             for _rank in range(n_selected):
                 if selected_indices:
-                    mean_similarities = (
-                        similarity_sums[remaining_indices] / len(selected_indices)
+                    mean_similarities = similarity_sums[remaining_indices] / len(
+                        selected_indices
                     )
                     proba_minus_similarity = (
                         proba[remaining_indices]

--- a/helion/autotuner/surrogate_pattern_search.py
+++ b/helion/autotuner/surrogate_pattern_search.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import math
-import operator
 import random
 from typing import TYPE_CHECKING
 
@@ -288,12 +287,16 @@ class LFBOPatternSearch(PatternSearch):
         Returns:
             List of the top n_sorted PopulationMember candidates, ordered by selection rank.
         """
+        if n_sorted <= 0 or not candidates:
+            return []
+
         # Score candidates
         candidate_X = np.array(
             [self.config_gen.encode_config(member.flat_values) for member in candidates]
         )
 
         n_samples = len(candidate_X)
+        n_selected = min(n_sorted, n_samples)
 
         # Get predicted probabilities (higher = more likely to be good)
         surrogate: RandomForestClassifier | None = self.surrogate
@@ -301,58 +304,54 @@ class LFBOPatternSearch(PatternSearch):
             # If surrogate is None, scores are random
             with sync_seed():
                 scores = [random.random() for _ in range(n_samples)]
+            candidates_sorted = sorted(
+                zip(candidates, scores, strict=True),
+                key=lambda item: item[1],
+            )[:n_selected]
+            candidates_sorted = [member for member, _ in candidates_sorted]
         else:
             proba = np.asarray(surrogate.predict_proba(candidate_X))[:, 1]
 
-            # Compute pairwise similarity matrix using decision path Jaccard
-            similarity_matrix = self.compute_leaf_similarity(surrogate, candidate_X)
-
-            # Sequential greedy selection with diversity penalty
-            selected_indices = []
+            # Track the cumulative similarity to already-selected points and update
+            # it incrementally. This preserves the original ranking while avoiding
+            # the dense n_samples x n_samples similarity matrix.
+            leaf_indices = surrogate.apply(candidate_X)
+            n_trees = leaf_indices.shape[1]
+            similarity_sums = np.zeros(n_samples)
             remaining_indices = list(range(n_samples))
-            scores = np.zeros(n_samples)
+            selected_indices: list[int] = []
 
-            for rank in range(n_samples):
-                if len(selected_indices) == 0:
-                    # First selection: just use probability
-                    proba_minus_similarity = proba[remaining_indices]
-                else:
-                    # Compute mean similarity to already selected points for each remaining point
-                    mean_similarties = np.zeros(len(remaining_indices))
-                    for i, idx in enumerate(remaining_indices):
-                        similarities_to_selected = similarity_matrix[
-                            idx, selected_indices
-                        ]
-                        mean_similarties[i] = np.mean(similarities_to_selected)
-
-                    # Score = probability - lambda * mean_similarity
+            for _rank in range(n_selected):
+                if selected_indices:
+                    mean_similarities = (
+                        similarity_sums[remaining_indices] / len(selected_indices)
+                    )
                     proba_minus_similarity = (
                         proba[remaining_indices]
-                        - self.similarity_penalty * mean_similarties
+                        - self.similarity_penalty * mean_similarities
                     )
+                else:
+                    proba_minus_similarity = proba[remaining_indices]
 
-                # Select the point with highest score
-                best_local_idx = np.argmax(proba_minus_similarity)
-                best_global_idx = remaining_indices[best_local_idx]
-
-                # Assign ranking score (lower rank = better)
-                scores[best_global_idx] = rank
-
-                # Update selected and remaining
+                best_local_idx = int(np.argmax(proba_minus_similarity))
+                best_global_idx = remaining_indices.pop(best_local_idx)
                 selected_indices.append(best_global_idx)
-                remaining_indices.remove(best_global_idx)
 
-        # sort candidates by score
-        candidates_sorted = sorted(
-            zip(candidates, scores, strict=True),
-            key=operator.itemgetter(1),
-        )[:n_sorted]
+                if len(selected_indices) == n_selected:
+                    break
+
+                same_leaf: np.ndarray = (
+                    leaf_indices == leaf_indices[best_global_idx : best_global_idx + 1]
+                )
+                similarity_sums += same_leaf.sum(axis=1) / n_trees
+
+            candidates_sorted = [candidates[idx] for idx in selected_indices]
 
         self.log.debug(
-            f"Scoring {len(candidate_X)} neighbors, selecting {(n_sorted / len(candidate_X)) * 100:.0f}% neighbors: {len(candidates_sorted)}"
+            f"Scoring {len(candidate_X)} neighbors, selecting {(n_selected / len(candidate_X)) * 100:.0f}% neighbors: {len(candidates_sorted)}"
         )
 
-        return [member for member, score in candidates_sorted]
+        return candidates_sorted
 
     def _autotune(self) -> Config:
         initial_population_name = self.initial_population_strategy.name

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -1059,7 +1059,10 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
 
         with patch(
             "helion._compiler.tile_dispatch.CompileEnvironment.current",
-            return_value=SimpleNamespace(get_block_id=lambda _shape: 3),
+            return_value=SimpleNamespace(
+                get_block_id=lambda _shape: 3,
+                resolve_block_id=lambda _shape: 3,
+            ),
         ):
             compacted = dispatch._compact_shape([object()])
 

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -15,6 +15,7 @@ import random
 import tempfile
 from types import SimpleNamespace
 from typing import Callable
+from typing import ClassVar
 from typing import Sequence
 import unittest
 from unittest import skip
@@ -27,6 +28,7 @@ import torch
 import helion
 from helion import _compat
 from helion import exc
+from helion._compiler.tile_dispatch import TileStrategyDispatch
 from helion._testing import DEVICE
 from helion._testing import RefEagerTestDisabled
 from helion._testing import TestCase
@@ -60,7 +62,6 @@ from helion.autotuner.logger import AutotuneLogEntry
 from helion.autotuner.logger import AutotuningLogger
 from helion.autotuner.metrics import AutotuneMetrics
 from helion.autotuner.random_search import RandomSearch
-from helion._compiler.tile_dispatch import TileStrategyDispatch
 import helion.language as hl
 from helion.language import loops
 from helion.runtime.settings import Settings
@@ -999,7 +1000,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
 
             ranked = sorted(
                 zip(candidates, scores, strict=True),
-                key=lambda item: item[1],
+                key=operator.itemgetter(1),
             )[:n_sorted]
             return [member for member, _ in ranked]
 
@@ -1025,9 +1026,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
                 5: [12, 22, 33, 43],
             },
         )
-        candidates = [
-            SimpleNamespace(name=f"c{i}", flat_values=[i]) for i in range(6)
-        ]
+        candidates = [SimpleNamespace(name=f"c{i}", flat_values=[i]) for i in range(6)]
 
         expected = legacy_select(search, candidates, 3)
 
@@ -1044,7 +1043,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         """Fallback block-id lookups should reuse the precomputed strategy cache."""
 
         class DummyStrategy:
-            block_ids = [3, 4]
+            block_ids: ClassVar[list[int]] = [3, 4]
 
             def block_size_var(self, block_idx: int) -> str:
                 return f"_BLOCK_{block_idx}"

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -20,6 +20,7 @@ import unittest
 from unittest import skip
 from unittest.mock import patch
 
+import numpy as np
 import pytest
 import torch
 
@@ -59,6 +60,7 @@ from helion.autotuner.logger import AutotuneLogEntry
 from helion.autotuner.logger import AutotuningLogger
 from helion.autotuner.metrics import AutotuneMetrics
 from helion.autotuner.random_search import RandomSearch
+from helion._compiler.tile_dispatch import TileStrategyDispatch
 import helion.language as hl
 from helion.language import loops
 from helion.runtime.settings import Settings
@@ -934,6 +936,136 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             self.assertIn(neighbor[3], ["a", "b", "c"])
             # Check boolean
             self.assertIn(neighbor[4], [True, False])
+
+    def test_lfbo_pattern_search_surrogate_select_matches_legacy_prefix(self):
+        """Top-k LFBO selection should match the legacy full-ranking implementation."""
+
+        class MockSurrogate:
+            def __init__(
+                self, proba_by_id: dict[int, float], leaf_by_id: dict[int, list[int]]
+            ) -> None:
+                self.proba_by_id = proba_by_id
+                self.leaf_by_id = leaf_by_id
+
+            def predict_proba(self, X):
+                ids = np.asarray(X)[:, 0].astype(int)
+                return np.array(
+                    [[1.0 - self.proba_by_id[i], self.proba_by_id[i]] for i in ids]
+                )
+
+            def apply(self, X):
+                ids = np.asarray(X)[:, 0].astype(int)
+                return np.array([self.leaf_by_id[i] for i in ids], dtype=int)
+
+        def legacy_select(
+            search: LFBOPatternSearch,
+            candidates: list[SimpleNamespace],
+            n_sorted: int,
+        ) -> list[SimpleNamespace]:
+            candidate_X = np.array(
+                [
+                    search.config_gen.encode_config(member.flat_values)
+                    for member in candidates
+                ]
+            )
+            proba = np.asarray(search.surrogate.predict_proba(candidate_X))[:, 1]
+            similarity_matrix = search.compute_leaf_similarity(
+                search.surrogate, candidate_X
+            )
+            selected_indices = []
+            remaining_indices = list(range(len(candidate_X)))
+            scores = np.zeros(len(candidate_X))
+
+            for rank in range(len(candidate_X)):
+                if selected_indices:
+                    mean_similarities = np.zeros(len(remaining_indices))
+                    for i, idx in enumerate(remaining_indices):
+                        similarities_to_selected = similarity_matrix[
+                            idx, selected_indices
+                        ]
+                        mean_similarities[i] = np.mean(similarities_to_selected)
+                    ranked_scores = (
+                        proba[remaining_indices]
+                        - search.similarity_penalty * mean_similarities
+                    )
+                else:
+                    ranked_scores = proba[remaining_indices]
+
+                best_local_idx = int(np.argmax(ranked_scores))
+                best_global_idx = remaining_indices[best_local_idx]
+                scores[best_global_idx] = rank
+                selected_indices.append(best_global_idx)
+                remaining_indices.remove(best_global_idx)
+
+            ranked = sorted(
+                zip(candidates, scores, strict=True),
+                key=lambda item: item[1],
+            )[:n_sorted]
+            return [member for member, _ in ranked]
+
+        search = LFBOPatternSearch.__new__(LFBOPatternSearch)
+        search.config_gen = SimpleNamespace(encode_config=lambda flat: [flat[0]])
+        search.similarity_penalty = 0.35
+        search.log = SimpleNamespace(debug=lambda *_args, **_kwargs: None)
+        search.surrogate = MockSurrogate(
+            proba_by_id={
+                0: 0.95,
+                1: 0.92,
+                2: 0.90,
+                3: 0.86,
+                4: 0.84,
+                5: 0.83,
+            },
+            leaf_by_id={
+                0: [10, 20, 30, 40],
+                1: [10, 20, 31, 41],
+                2: [11, 21, 32, 42],
+                3: [50, 60, 70, 80],
+                4: [50, 61, 71, 81],
+                5: [12, 22, 33, 43],
+            },
+        )
+        candidates = [
+            SimpleNamespace(name=f"c{i}", flat_values=[i]) for i in range(6)
+        ]
+
+        expected = legacy_select(search, candidates, 3)
+
+        with patch.object(
+            search,
+            "compute_leaf_similarity",
+            side_effect=AssertionError("dense similarity matrix should not be built"),
+        ):
+            actual = search._surrogate_select(candidates, 3)
+
+        self.assertEqual([c.name for c in actual], [c.name for c in expected])
+
+    def test_tile_strategy_dispatch_compact_shape_uses_cached_block_lookup(self):
+        """Fallback block-id lookups should reuse the precomputed strategy cache."""
+
+        class DummyStrategy:
+            block_ids = [3, 4]
+
+            def block_size_var(self, block_idx: int) -> str:
+                return f"_BLOCK_{block_idx}"
+
+            def compact_shape(self, shapes):
+                return shapes
+
+        dispatch = TileStrategyDispatch.__new__(TileStrategyDispatch)
+        dispatch.strategies = [DummyStrategy()]
+        dispatch.block_id_to_strategy = {}
+        dispatch._block_id_to_any_strategy = {3: dispatch.strategies[0]}
+
+        with patch(
+            "helion._compiler.tile_dispatch.CompileEnvironment.current",
+            return_value=SimpleNamespace(get_block_id=lambda _shape: 3),
+        ):
+            compacted = dispatch._compact_shape([object()])
+
+        self.assertEqual(len(compacted), 1)
+        self.assertEqual(compacted[0].size_str, "_BLOCK_3")
+        self.assertEqual(compacted[0].block_ids, [3])
 
     @skip("too slow")
     def test_lfbo_pattern_search(self):

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -28,6 +28,7 @@ import torch
 import helion
 from helion import _compat
 from helion import exc
+from helion._compiler.tile_dispatch import BlockIDStrategyMapping
 from helion._compiler.tile_dispatch import TileStrategyDispatch
 from helion._testing import DEVICE
 from helion._testing import RefEagerTestDisabled
@@ -1053,8 +1054,8 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
 
         dispatch = TileStrategyDispatch.__new__(TileStrategyDispatch)
         dispatch.strategies = [DummyStrategy()]
-        dispatch.block_id_to_strategy = {}
-        dispatch._block_id_to_any_strategy = {3: dispatch.strategies[0]}
+        dispatch.block_id_to_strategy = BlockIDStrategyMapping()
+        dispatch.block_id_to_strategy[(3, 4)] = dispatch.strategies[0]
 
         with patch(
             "helion._compiler.tile_dispatch.CompileEnvironment.current",


### PR DESCRIPTION
## Summary

This PR trims a few avoidable hot paths in the autotuner and compiler control flow while keeping kernel math and behavior the same.

Changes:
- Reworked LFBO candidate selection so it avoids the dense pairwise similarity matrix while preserving parity in the selected prefix.
- Vectorized AOT config-subset scoring and replaced repeated list membership checks with a boolean mask while preserving existing tie-break behavior.
- Added a cached block-id-to-strategy fallback in tile dispatch so `_compact_shape()` does not rescan all strategies on fallback lookups.
- Added regression coverage for LFBO selection parity and the tile-dispatch cache path.

Files in this PR:
- `helion/autotuner/surrogate_pattern_search.py`
- `helion/autotuner/heuristic_generator.py`
- `helion/_compiler/tile_dispatch.py`
- `test/test_autotuner.py`

## Why

The review turned up a few places where the control plane was doing more work than necessary:
- LFBO selection was paying dense `O(n^2)` similarity cost and extra ranking work.
- AOT config subset selection was rescanning the timing table in Python-heavy loops.
- Tile dispatch had a fallback path that could repeatedly scan all strategies.

These changes are meant to make those paths lighter without changing the underlying math or intended search behavior.

## Testing

Ran locally:
- `pytest test/test_autotuner.py -k "lfbo_pattern_search_surrogate_select_matches_legacy_prefix or tile_strategy_dispatch_compact_shape_uses_cached_block_lookup"`
- `pytest test/test_aot_autotuning.py -k "ConfigSubsetSelection or ConfigValidityPartitioning"`

GPU benchmarking was run separately on H200 hardware during validation. I am refreshing the comparison against the current upstream `main` after rebasing this branch onto `d2eb086` and can post the updated benchmark note directly in the PR thread.
