### PR TITLE
[DO NOT MERGE] Test about XPU CI

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -102,6 +102,17 @@
       "backend": "triton"
     },
     {
+      "runner": "linux.idc.xpu",
+      "python-version": "3.12",
+      "ref-eager": false,
+      "image": "intelgpu/ubuntu-24.04-lts2:2523.40",
+      "runtime-version": "xpu",
+      "container-options": "--group-add 109 --device=/dev/mem --device=/dev/dri",
+      "pytorch-version": "pytorch-nightly",
+      "alias": "xpu",
+      "backend": "triton"
+    },
+    {
       "runner": "linux.google.tpuv7x.1",
       "python-version": "3.12",
       "ref-eager": false,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -260,7 +260,7 @@ jobs:
           export HELION_BACKEND=${{ matrix.backend }}
           # -rf: print failed tests
           # --timeout: max allowed time for each test
-          PARALLEL=""
+          PARALLEL="-n4"
           if [[ "${{ contains(matrix.alias, 'distributed') }}" == "true" ]]; then
             TEST_PATH="test/test_examples_dist.py"
             EXTRA_FLAGS="-rs"
@@ -280,6 +280,7 @@ jobs:
             TIMEOUT=360
             export TRITON_XPU_GEN_NATIVE_CODE=1
             export HELION_DELETE_CACHE_AFTER_TEST=0
+            export HELION_STATIC_LAUNCHER=1
           fi
           pytest $PARALLEL -rf --timeout=$TIMEOUT $EXTRA_FLAGS $TEST_PATH | tee >(eval $SKIP_CHECK)
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,12 @@ jobs:
           echo "Detected ROCm image"
           rocminfo || echo "rocminfo not found"
 
+      - name: Run XPU command
+        if: startsWith(matrix.image, 'intel')
+        run: |
+          echo "Detected XPU image"
+          xpu-smi discovery || echo "xpu-smi not found"
+
       - name: Check out code
         uses: actions/checkout@v6
 
@@ -134,10 +140,12 @@ jobs:
           export CXX=clang++-20
           mkdir -p /tmp/$USER
           cd /tmp/$USER
-          uv pip uninstall triton pytorch-triton || true
+          uv pip uninstall triton pytorch-triton triton-xpu || true
           rm -rf triton/ || true
           if [[ "${{ matrix.backend }}" == "tileir" ]]; then
             git clone --recursive -b main https://github.com/triton-lang/Triton-to-tile-IR.git triton
+          elif [[ "${{ matrix.alias }}" == *xpu* ]]; then
+            git clone https://github.com/intel/intel-xpu-backend-for-triton.git triton
           else
             git clone https://github.com/triton-lang/triton.git triton
             if [[ "${{ matrix.python-version }}" == "3.14" ]]; then
@@ -266,7 +274,14 @@ jobs:
           fi
           # For distributed tests, fail if any test is skipped, failed, or has an error
           SKIP_CHECK=$([[ "${{ contains(matrix.alias, 'distributed') }}" == "true" ]] && echo "! grep -qE '(SKIPPED|FAILED|ERROR)'" || echo "cat > /dev/null")
-          pytest $PARALLEL -rf --timeout=60 $EXTRA_FLAGS $TEST_PATH | tee >(eval $SKIP_CHECK)
+          TIMEOUT=60
+          if [[ "${{ matrix.alias }}" == *xpu* ]]; then
+            # TEST_PATH="test/test_atomic_ops.py test/test_barrier.py test/test_broadcasting.py test/test_control_flow.py test/test_dot.py test/test_indexing.py test/test_matmul.py test/test_loops.py test/test_reductions.py test/test_triton_kernel.py"
+            TIMEOUT=360
+            export TRITON_XPU_GEN_NATIVE_CODE=1
+            export HELION_DELETE_CACHE_AFTER_TEST=0
+          fi
+          pytest $PARALLEL -rf --timeout=$TIMEOUT $EXTRA_FLAGS $TEST_PATH | tee >(eval $SKIP_CHECK)
 
   test-notebooks:
     name: test-notebooks-cu128-py3.12-pytorch-2.9-a10g

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -260,7 +260,7 @@ jobs:
           export HELION_BACKEND=${{ matrix.backend }}
           # -rf: print failed tests
           # --timeout: max allowed time for each test
-          PARALLEL="-n4"
+          PARALLEL=""
           if [[ "${{ contains(matrix.alias, 'distributed') }}" == "true" ]]; then
             TEST_PATH="test/test_examples_dist.py"
             EXTRA_FLAGS="-rs"

--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -1444,11 +1444,11 @@ class TestCase(unittest.TestCase):
 
         from torch._inductor.utils import fresh_cache
 
-        self._test_stack.enter_context(
-            fresh_cache(
-                delete=os.getenv("HELION_DELETE_CACHE_AFTER_TEST", "1") == "1",
-            )
-        )
+        # self._test_stack.enter_context(
+        #     fresh_cache(
+        #         delete=os.getenv("HELION_DELETE_CACHE_AFTER_TEST", "1") == "1",
+        #     )
+        # )
 
         counters.clear()
 

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -16,6 +16,9 @@ from .._utils import triton_is_available
 from .config import Config as Config
 from .kernel import Kernel as Kernel
 from .kernel import kernel as kernel
+from .static_launcher import _STATIC_LAUNCHER_DEVICES
+from .static_launcher import _check_static_launcher_available
+from .static_launcher import _static_launch
 
 _CUTLASS_SHUTDOWN_PATCHED = False
 
@@ -151,7 +154,25 @@ def default_launcher(
     **kwargs: dict,
 ) -> object:
     """Default launcher function that executes the kernel immediately."""
-    # For both CUDA and MTIA, use the same kernel execution
+    device_type = next(
+        (a.device.type for a in args if isinstance(a, torch.Tensor)), None
+    )
+    # Use static launcher when available (bypasses per-kernel C++ compilation)
+    if (
+        not launch_cooperative_grid
+        and device_type in _STATIC_LAUNCHER_DEVICES
+        and _check_static_launcher_available()
+    ):
+        assert device_type is not None
+        return _static_launch(
+            triton_kernel,
+            grid,
+            args,
+            device_type,
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+    # Standard path for other backends, cooperative grid, or when static launcher unavailable
     run_kwargs: dict = {
         "grid": grid,
         "warmup": False,

--- a/helion/runtime/static_launcher.py
+++ b/helion/runtime/static_launcher.py
@@ -1,0 +1,97 @@
+"""Static launcher support for Helion kernels.
+
+On first call, compiles via Triton (warmup only) and wraps the compiled binary
+with PyTorch's StaticallyLaunchedTritonKernel. All launches (including the
+first) go through the static C++ path, bypassing Triton's Python runtime.
+Supports CUDA, ROCm, and XPU via PyTorch's StaticallyLaunchedTritonKernel.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+from typing import Any
+
+import torch
+
+from .._utils import triton_is_available
+
+if triton_is_available():
+    import triton
+
+
+@functools.cache
+def _check_static_launcher_available() -> bool:
+    if os.environ.get("HELION_STATIC_LAUNCHER", "1") == "0":
+        return False
+    try:
+        # Could use the `torch._inductor.config` directly in the test, 
+        # which is controlled by the PyTorch's behavior.
+        return torch._inductor.config.use_static_triton_launcher
+    except AttributeError:
+        return False
+
+
+# Device types that support static launching
+_STATIC_LAUNCHER_DEVICES = {"cuda", "xpu"}
+
+_BIN_EXTS = {".cubin", ".hsaco", ".zebin"}
+
+_STATIC_LAUNCHER_ATTR = "_helion_static_launcher"
+
+
+def _static_launch(
+    triton_kernel: Any,
+    grid: tuple[int, ...],
+    args: tuple[object, ...],
+    device_type: str,
+    *,
+    num_warps: int,
+    num_stages: int,
+    launch_cooperative_grid: bool = False,
+    **kwargs: object,
+) -> None:
+    """Launch via PyTorch's static C++ launcher, compiling on first call."""
+    from torch._inductor.runtime.static_triton_launcher import (
+        statically_launched_kernel_by_device,
+    )
+
+    entry = getattr(triton_kernel, _STATIC_LAUNCHER_ATTR, None)
+
+    if entry is None:
+        # First call: compile only (warmup=True), then wrap with static launcher.
+        compiled_kernel = triton_kernel.run(
+            *args,
+            grid=grid,
+            warmup=True,
+            num_warps=num_warps,
+            num_stages=num_stages,
+            generate_native_code=True,
+            launch_cooperative_grid=launch_cooperative_grid,
+            **kwargs,
+        )
+        # StaticallyLaunchedTritonKernel.__init__ reads _cubin_path.
+        # Triton stores binary paths in metadata_group, so bridge the gap.
+        for fname, fpath in compiled_kernel.metadata_group.items():
+            if any(fname.endswith(ext) for ext in _BIN_EXTS):
+                compiled_kernel._cubin_path = fpath
+                break
+        static = statically_launched_kernel_by_device(compiled_kernel, device_type)
+        # static.run() expects only non-constexpr args, so build a mask.
+        n_args = len(static.arg_names)
+        const_set = set(static.full_constexprs)
+        keep_mask = [i not in const_set for i in range(n_args)]
+        device = triton.runtime.driver.active.get_current_device()
+        static.load_kernel(device)
+        setattr(triton_kernel, _STATIC_LAUNCHER_ATTR, (static, keep_mask))
+    else:
+        static, keep_mask = entry
+
+    # All launches go through the static C++ path.
+    gx = grid[0] if len(grid) > 0 else 1
+    gy = grid[1] if len(grid) > 1 else 1
+    gz = grid[2] if len(grid) > 2 else 1
+    device = triton.runtime.driver.active.get_current_device()
+    stream = triton.runtime.driver.active.get_current_stream(device)
+    filtered = tuple(a for a, keep in zip(args, keep_mask, strict=True) if keep)
+    static.run(gx, gy, gz, stream, *filtered)

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -1809,6 +1809,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         expected = torch.full([128], 3.0, device=DEVICE)
         torch.testing.assert_close(out, expected)
 
+    @skipIfXPU("CUDA specific API used to check memory usage")
     def test_chunked_allclose_memory(self):
         """Test that autotuning accuracy checks use chunked comparison for large tensors."""
         import helion.autotuner.base_search as _bs

--- a/test/test_loops.py
+++ b/test/test_loops.py
@@ -28,6 +28,7 @@ from helion._testing import skipIfNotTriton
 from helion._testing import skipIfPallas
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
+from helion._testing import skipIfXPU
 from helion._testing import xfailIfPallas
 import helion.language as hl
 
@@ -1391,6 +1392,7 @@ class TestLoops(RefEagerTestBase, TestCase):
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
     @skipIfTileIR("tileir backend will ignore `range_unroll_factors` hint")
     @skipIfNotTriton("range loop hints are Triton-specific")
+    @skipIfXPU("Accuracy issue on XPU backend")
     def test_unroll_with_pipelining(self):
         @helion.kernel(static_shapes=True)
         def matmul(

--- a/test/test_static_launcher.py
+++ b/test/test_static_launcher.py
@@ -62,6 +62,9 @@ class TestStaticLauncher(TestCase):
             return launcher
 
         with mock.patch(
+            "helion.runtime.static_launcher._STATIC_LAUNCHER_ATTR",
+            "_helion_static_launcher_test",
+        ), mock.patch(
             "torch._inductor.runtime.static_triton_launcher.statically_launched_kernel_by_device",
             side_effect=tracking_factory,
         ):

--- a/test/test_static_launcher.py
+++ b/test/test_static_launcher.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import TestCase
+import helion.language as hl
+from helion.runtime import _check_static_launcher_available
+
+
+def _make_add_kernel():
+    @helion.kernel(static_shapes=True, autotune_effort="none")
+    def add_kernel(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        x, y = torch.broadcast_tensors(x, y)
+        out = torch.empty_like(x)
+        for tile in hl.tile(out.size()):
+            out[tile] = x[tile] + y[tile]
+        return out
+
+    return add_kernel
+
+
+@unittest.skipUnless(
+    _check_static_launcher_available(),
+    "static launcher not available (missing torch._inductor.runtime.static_triton_launcher)",
+)
+class TestStaticLauncher(TestCase):
+    def test_basic(self):
+        """Verify the static launcher produces correct results."""
+        add_kernel = _make_add_kernel()
+        x = torch.randn(1024, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(1024, device=DEVICE, dtype=torch.float32)
+        torch.testing.assert_close(add_kernel(x, y), x + y)
+        # Second call exercises the cached hot path
+        x2 = torch.randn(1024, device=DEVICE, dtype=torch.float32)
+        y2 = torch.randn(1024, device=DEVICE, dtype=torch.float32)
+        torch.testing.assert_close(add_kernel(x2, y2), x2 + y2)
+
+    def test_static_launch_is_called(self):
+        """Verify the static launcher (not Triton's default) is used."""
+        from torch._inductor.runtime.static_triton_launcher import (
+            StaticallyLaunchedTritonKernel,
+        )
+        from torch._inductor.runtime.static_triton_launcher import (
+            statically_launched_kernel_by_device,
+        )
+
+        add_kernel = _make_add_kernel()
+        x = torch.randn(1024, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(1024, device=DEVICE, dtype=torch.float32)
+
+        created_launchers = []
+        original = statically_launched_kernel_by_device
+
+        def tracking_factory(*args, **kwargs):
+            launcher = original(*args, **kwargs)
+            created_launchers.append(launcher)
+            return launcher
+
+        with mock.patch(
+            "torch._inductor.runtime.static_triton_launcher.statically_launched_kernel_by_device",
+            side_effect=tracking_factory,
+        ):
+            # First call creates the static launcher
+            result1 = add_kernel(x, y)
+            torch.testing.assert_close(result1, x + y)
+            self.assertEqual(len(created_launchers), 1)
+            self.assertIsInstance(created_launchers[0], StaticallyLaunchedTritonKernel)
+
+            # Second call reuses it (no new launcher created)
+            x2 = torch.randn(1024, device=DEVICE, dtype=torch.float32)
+            y2 = torch.randn(1024, device=DEVICE, dtype=torch.float32)
+            result2 = add_kernel(x2, y2)
+            torch.testing.assert_close(result2, x2 + y2)
+            self.assertEqual(len(created_launchers), 1)
+
+    def test_disable_static_launcher(self):
+        """Verify that _static_launch is NOT called when disabled via env var."""
+        add_kernel = _make_add_kernel()
+        x = torch.randn(1024, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(1024, device=DEVICE, dtype=torch.float32)
+        with mock.patch.dict("os.environ", {"HELION_STATIC_LAUNCHER": "0"}):
+            # Clear the cached result so the env var takes effect
+            _check_static_launcher_available.cache_clear()
+            try:
+                with mock.patch("helion.runtime._static_launch") as mocked:
+                    result = add_kernel(x, y)
+                    mocked.assert_not_called()
+                torch.testing.assert_close(result, x + y)
+            finally:
+                _check_static_launcher_available.cache_clear()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This ported from #1327 and #1893 , It does the following:
1. Enable static launcher to reduce overhead
2. Use HELION_DELETE_CACHE_AFTER_TEST for xpu to reduce recompilation