### PR TITLE
[autotuner] Work around Triton two-dot shared-memory IMA on H100

### DIFF
--- a/helion/_compat.py
+++ b/helion/_compat.py
@@ -335,6 +335,15 @@ def min_dot_size(
     return _min_dot_size(device, lhs, rhs)
 
 
+@functools.cache
+def is_sm90() -> bool:
+    """Return True if the current CUDA device is H100 (sm_90)."""
+    if not torch.cuda.is_available():
+        return False
+    major, minor = torch.cuda.get_device_capability(torch.cuda.current_device())
+    return major == 9 and minor == 0
+
+
 def is_hip() -> bool:
     """Check if the current device uses the HIP (AMD ROCm) backend."""
     return _is_hip()

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -160,6 +160,7 @@ class CompileEnvironment:
         self.jagged_tile_parent_id: dict[int, int] = {}
         self.jagged_tile_mask_shapes: dict[int, list[torch.SymInt]] = {}
         self._symint_cache: dict[object, torch.SymInt] = {}
+        self._dot_k_block_ids: list[int] = []
         self._foreign_symint_cache: dict[tuple[int, sympy.Expr], torch.SymInt] = {}
         self.device_load_count = (
             0  # Track number of loads in all device code for eviction policy tuning

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -900,8 +900,11 @@ class BlockSizeSpec(_PowerOfTwoBlockIdItem):
 
     def _normalize(self, name: str, value: object) -> int | None:
         result = super()._normalize(name, value)
-        if isinstance(result, int) and result < self.min_size:
-            result = self.min_size
+        if isinstance(result, int):
+            if result < self.min_size:
+                result = self.min_size
+            elif result > self.max_size:
+                result = self.max_size
         return result
 
     def update_min(self, value: int) -> None:

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -8,6 +8,7 @@ import torch
 from torch._subclasses.fake_tensor import FakeTensor
 
 from .. import exc
+from .._compat import is_sm90
 from .._compat import min_dot_size
 from .._compiler.compile_environment import CompileEnvironment
 from .._compiler.compile_environment import format_shape
@@ -196,6 +197,31 @@ def _(
     return (mat1, mat2, acc, out_dtype)
 
 
+def _apply_two_dot_k_constraint(env: CompileEnvironment, k_block_idx: int) -> None:
+    """Skip K_bs in {16, 32} for two-dot kernels on H100.
+
+    Triton has a shared-memory bug on H100 (sm_90) when 2+ tl.dot ops
+    coexist in a kernel: K block sizes of 16 and 32 cause IMA or silent
+    data corruption.  K_bs=8 and K_bs>=64 are safe.
+
+    If K >= 64, set min to 64 (skip 16/32, keep 64+).
+    If K < 64, set max to 8 (only safe option).
+    """
+    spec = env.config_spec
+    try:
+        block_spec = spec.block_sizes.block_id_lookup(k_block_idx)
+    except KeyError:
+        return
+    if block_spec.size_hint >= 64:
+        block_spec.update_min(64)
+    else:
+        # K_bs=8 is the only safe option below 64; override min_dot_size
+        # which may have already set min_size=16.
+        block_spec.min_size = min(block_spec.min_size, 8)
+        block_spec.autotuner_min = min(block_spec.autotuner_min, 8)
+        block_spec.update_max(8)
+
+
 def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
     """Update config-spec min/max sizes for a dot/matmul.
 
@@ -218,6 +244,19 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
         block_idx = env.get_block_id(shape)
         if block_idx is not None:
             env.block_sizes[block_idx].update_min_block(min_size, allow_flattened=True)
+
+    # Track K block_ids for the two-dot IMA workaround.
+    k_block_idx = env.get_block_id(k)
+    if k_block_idx is not None:
+        env._dot_k_block_ids.append(k_block_idx)
+
+    # Triton has a shared-memory bug on H100 (sm_90) when 2+ tl.dot ops
+    # coexist in a kernel: K block sizes of 16 and 32 cause IMA or silent
+    # corruption.  K_bs=8 and K_bs>=64 are safe.
+    # See sweep_two_dot_ima.py for empirical data.
+    if len(env._dot_k_block_ids) >= 2 and is_sm90():
+        for k_id in env._dot_k_block_ids:
+            _apply_two_dot_k_constraint(env, k_id)
 
     # Triton only supports 2D dot operations.  When the operands are 3D
     # (batched matmul), constrain the batch dimension block size to 1 so

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -2003,6 +2003,107 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
 
 
 @onlyBackends(["triton"])
+class TestTritonIMA(RefEagerTestDisabled, TestCase):
+    def test_two_dot_batch_loop_ima(self):
+        """Test workaround for Triton shared-memory IMA with two tl.dot ops.
+
+        Triton has a shared-memory bug on H100 (sm_90) when 2+ tl.dot ops
+        coexist in a kernel with a batch loop: K block sizes of 16 or 32
+        cause IMA or silent corruption.  K_bs=8 and K_bs>=64 are safe.
+
+        The workaround in enforce_dot_requirements() detects the two-dot
+        pattern and constrains K block sizes to skip the broken range.
+        """
+
+        @helion.kernel(static_shapes=True)
+        def two_dot_bwd(
+            x: torch.Tensor,
+            A: torch.Tensor,
+            B: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            Batch, N, M = x.size()
+            K = A.size(0)
+            out1 = torch.empty((Batch, N, K), device=x.device, dtype=x.dtype)
+            out2 = torch.empty((Batch, M, K), device=x.device, dtype=x.dtype)
+            for tile_b in hl.tile(Batch, block_size=1):
+                # dot 1: x[N,M] @ A[K,M].T -> out1[N,K]
+                for tile_n, tile_k in hl.tile([N, K]):
+                    acc = hl.zeros([tile_n, tile_k], dtype=torch.float32)
+                    for tile_m in hl.tile(M):
+                        acc = torch.addmm(
+                            acc,
+                            x[tile_b.begin, tile_n, tile_m],
+                            A[tile_k, tile_m].t(),
+                        )
+                    out1[tile_b.begin, tile_n, tile_k] = acc.to(x.dtype)
+                # dot 2: x[N,M].T @ B[N,K] -> out2[M,K]
+                for tile_m2, tile_k2 in hl.tile([M, K]):
+                    acc2 = hl.zeros([tile_m2, tile_k2], dtype=torch.float32)
+                    for tile_n2 in hl.tile(N):
+                        acc2 = torch.addmm(
+                            acc2,
+                            x[tile_b.begin, tile_n2, tile_m2].t(),
+                            B[tile_n2, tile_k2],
+                        )
+                    out2[tile_b.begin, tile_m2, tile_k2] = acc2.to(x.dtype)
+            return out1, out2
+
+        K, N, M = 48, 192, 128
+        x = torch.randn(2, N, M, device=DEVICE, dtype=torch.bfloat16)
+        A = torch.randn(K, M, device=DEVICE, dtype=torch.bfloat16)
+        B = torch.randn(N, K, device=DEVICE, dtype=torch.bfloat16)
+        args = (x, A, B)
+
+        # block_sizes: [N, K(dot1), M(dot1-red), M(dot2), K(dot2), N(dot2-red)]
+        # good_config: K_bs=8 avoids the Triton shared-memory bug.
+        good_config = helion.Config(
+            block_sizes=[64, 8, 64, 64, 8, 64],
+            indexing="pointer",
+            num_stages=1,
+            num_warps=4,
+        )
+        # bad_config: K_bs=16 would trigger IMA on H100 without the
+        # workaround.  The constraint caps K_bs to 8 on sm_90, so
+        # this config becomes equivalent to good_config.
+        bad_config = helion.Config(
+            block_sizes=[64, 16, 64, 64, 16, 64],
+            indexing="pointer",
+            num_stages=1,
+            num_warps=4,
+        )
+
+        bound = two_dot_bwd.bind(args)
+        search = FiniteSearch(bound, args, configs=[good_config, bad_config])
+        winner = search.autotune()
+
+        # On H100 (sm_90), K_bs should be capped to 8 (not 16 or 32).
+        # On other GPUs the constraint is not applied.
+        if _compat.is_sm90():
+            k_bs_values = [winner.block_sizes[1], winner.block_sizes[4]]
+            for k_bs in k_bs_values:
+                self.assertTrue(
+                    k_bs <= 8 or k_bs >= 64,
+                    f"K_bs={k_bs} is in the broken range [16, 32]",
+                )
+
+        compiled = bound.compile_config(winner)
+        out1, out2 = compiled(*args)
+        self.assertTrue(torch.isfinite(out1).all())
+        self.assertTrue(torch.isfinite(out2).all())
+
+        # Verify correctness against PyTorch reference
+        ref_out1 = torch.bmm(
+            x.float(), A.float().t().unsqueeze(0).expand(2, -1, -1)
+        ).to(x.dtype)
+        ref_out2 = torch.bmm(
+            x.float().transpose(-2, -1),
+            B.float().unsqueeze(0).expand(2, -1, -1),
+        ).to(x.dtype)
+        torch.testing.assert_close(out1, ref_out1, atol=1e-1, rtol=1e-1)
+        torch.testing.assert_close(out2, ref_out2, atol=1e-1, rtol=1e-1)
+
+
+@onlyBackends(["triton"])
 class TestAutotuneRandomSeed(RefEagerTestDisabled, TestCase):
     def _autotune_and_record(self, **settings: object) -> float:
         search_capture: dict[str, RecordingRandomSearch] = {}


### PR DESCRIPTION
## Summary
- Triton has a shared-memory bug on H100 (sm_90) when 2+ `tl.dot` ops coexist in a kernel: block sizes of 16 and 32 cause IMA or silent data corruption. Block sizes of 8 and >=64 are safe. B200 (sm_100) is not affected.
- Adds a workaround in `enforce_dot_requirements()` that detects the two-dot pattern and constrains dot dimension block sizes to skip the broken {16, 32} range on H100.
- Also fixes `BlockSizeSpec._normalize()` to enforce `max_size` clamping so user-specified configs respect the constraint.

## Test plan
- [x] `TestTritonIMA::test_two_dot_batch_loop_ima` passes with workaround, fails with IMA without it
- [x] Full `test/test_autotuner.py` suite passes (56 passed, 4 skipped)
- [x] Verified B200 is unaffected via `sweep_two_dot_ima.py`