### PR TITLE
Add HELION_AUTOTUNE_PRECOMPILE_REPS setting to run kernel multiple times during spawn precompile

### DIFF
--- a/helion/autotuner/precompile_future.py
+++ b/helion/autotuner/precompile_future.py
@@ -145,6 +145,7 @@ def _run_kernel_in_subprocess_spawn(
     args_path: str,
     result_path: str,
     decorator: str,
+    num_reps: int = 1,
 ) -> None:
     status = 0
     _cap: list[str] = [""]
@@ -154,7 +155,8 @@ def _run_kernel_in_subprocess_spawn(
         assert isinstance(args, (tuple, list))
         torch.accelerator.synchronize()
         with capture_output() as _cap:
-            fn(*args)
+            for _ in range(num_reps):
+                fn(*args)
         torch.accelerator.synchronize()
         _write_result_file(result_path, {"status": "ok"})
     except Exception as exc:
@@ -382,11 +384,12 @@ class PrecompileFuture:
                     "Failed to serialize compiled kernel for spawn precompile."
                     ' Set HELION_AUTOTUNE_PRECOMPILE="fork" to fall back to fork mode.'
                 ) from err
+            num_reps = search.settings.autotune_precompile_reps
             process = cast(
                 "mp.Process",
                 ctx.Process(
                     target=_run_kernel_in_subprocess_spawn,
-                    args=(fn_spec, args_path, result_path, decorator),
+                    args=(fn_spec, args_path, result_path, decorator, num_reps),
                 ),
             )
             process.daemon = True

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -403,6 +403,11 @@ class _Settings:
             "HELION_AUTOTUNE_PRECOMPILE_JOBS",
         )
     )
+    autotune_precompile_reps: int = dataclasses.field(
+        default_factory=functools.partial(
+            _env_get_int, "HELION_AUTOTUNE_PRECOMPILE_REPS", 1
+        )
+    )
     autotune_random_seed: int = dataclasses.field(
         default_factory=_get_autotune_random_seed
     )


### PR DESCRIPTION
Summary:
When using spawn precompile mode, a kernel may compile and run once
successfully but cause an illegal memory access (IMA) after repeated
execution during benchmarking. Since benchmarking runs in the main
process, this corrupts the GPU state and crashes the entire autotuning
session.

This adds a `autotune_precompile_reps` setting (env var
`HELION_AUTOTUNE_PRECOMPILE_REPS`, default 1) that controls how many
times the kernel is executed in the spawn subprocess during precompile.
Setting it to e.g. 10 helps catch IMAs that only manifest after
repeated runs, while keeping the failure isolated in the subprocess.

Differential Revision: D99175421


