### PR TITLE
Fix _benchmark dropping configs that fail compilation

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -380,27 +380,23 @@ class BaseSearch(BaseAutotuner):
             callable, measured performance, status, and compilation time.
         """
         all_configs = configs
-        fns: list[Callable[..., object]] = []
-        valid_configs: list[Config] = []
-        valid_indices: set[int] = set()
+        compiled: dict[int, Callable[..., object]] = {}
         futures: list[PrecompileFuture] | None = None
         for i, config in enumerate(all_configs):
             try:
-                fn = self.kernel.compile_config(config, allow_print=False)
+                compiled[i] = self.kernel.compile_config(config, allow_print=False)
             except Exception:
                 # If all configs failed, raise error
-                if not valid_configs and i == len(all_configs) - 1:
+                if not compiled and i == len(all_configs) - 1:
                     raise
                 self.log.warning(
                     "Skipping config that failed to compile: %s",
                     self.kernel.format_kernel_decorator(config, self.settings),
                     exc_info=True,
                 )
-                continue
-            fns.append(fn)
-            valid_configs.append(config)
-            valid_indices.add(i)
-        configs = valid_configs
+        fns = list(compiled.values())
+        valid_indices = list(compiled.keys())
+        configs = [all_configs[i] for i in valid_indices]
         if self.settings.autotune_precompile:
             futures = list(
                 starmap(
@@ -425,7 +421,12 @@ class BaseSearch(BaseAutotuner):
             is_workings = [True] * len(configs)
             precompile_status = ["ok"] * len(configs)
 
-        results: list[BenchmarkResult] = []
+        results: list[BenchmarkResult] = [
+            BenchmarkResult(
+                config=c, fn=_unset_fn, perf=inf, status="error", compile_time=None
+            )
+            for c in all_configs
+        ]
 
         # Render a progress bar only when the user requested it.
         iterator = iter_with_progress(
@@ -476,46 +477,25 @@ class BaseSearch(BaseAutotuner):
                         config=config,
                     )
                 )
-                results.append(
-                    BenchmarkResult(
-                        config=config,
-                        fn=fn,
-                        perf=perf,
-                        status=status,
-                        compile_time=compile_time,
-                    )
+                results[valid_indices[index]] = BenchmarkResult(
+                    config=config,
+                    fn=fn,
+                    perf=perf,
+                    status=status,
+                    compile_time=compile_time,
                 )
             else:
                 status = "timeout" if reason == "timeout" else "error"
                 if is_working:
                     status = "peer_compilation_fail"
-                results.append(
-                    BenchmarkResult(
-                        config=config,
-                        fn=fn,
-                        perf=inf,
-                        status=status,
-                        compile_time=compile_time,
-                    )
+                results[valid_indices[index]] = BenchmarkResult(
+                    config=config,
+                    fn=fn,
+                    perf=inf,
+                    status=status,
+                    compile_time=compile_time,
                 )
-        if len(valid_indices) == len(all_configs):
-            return results
-        full_results: list[BenchmarkResult] = []
-        valid_iter = iter(results)
-        for i, config in enumerate(all_configs):
-            if i in valid_indices:
-                full_results.append(next(valid_iter))
-            else:
-                full_results.append(
-                    BenchmarkResult(
-                        config=config,
-                        fn=_unset_fn,
-                        perf=inf,
-                        status="error",
-                        compile_time=None,
-                    )
-                )
-        return full_results
+        return results
 
     def benchmark_batch(
         self, configs: list[Config], *, desc: str = "Benchmarking"

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -382,7 +382,7 @@ class BaseSearch(BaseAutotuner):
         all_configs = configs
         fns: list[Callable[..., object]] = []
         valid_configs: list[Config] = []
-        valid_indices: list[int] = []
+        valid_indices: set[int] = set()
         futures: list[PrecompileFuture] | None = None
         for i, config in enumerate(all_configs):
             try:
@@ -399,7 +399,7 @@ class BaseSearch(BaseAutotuner):
                 continue
             fns.append(fn)
             valid_configs.append(config)
-            valid_indices.append(i)
+            valid_indices.add(i)
         configs = valid_configs
         if self.settings.autotune_precompile:
             futures = list(
@@ -502,9 +502,8 @@ class BaseSearch(BaseAutotuner):
             return results
         full_results: list[BenchmarkResult] = []
         valid_iter = iter(results)
-        valid_set = set(valid_indices)
         for i, config in enumerate(all_configs):
-            if i in valid_set:
+            if i in valid_indices:
                 full_results.append(next(valid_iter))
             else:
                 full_results.append(

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -379,15 +379,17 @@ class BaseSearch(BaseAutotuner):
             A list of BenchmarkResult entries containing the configuration, compiled
             callable, measured performance, status, and compilation time.
         """
+        all_configs = configs
         fns: list[Callable[..., object]] = []
         valid_configs: list[Config] = []
+        valid_indices: list[int] = []
         futures: list[PrecompileFuture] | None = None
-        for i, config in enumerate(configs):
+        for i, config in enumerate(all_configs):
             try:
                 fn = self.kernel.compile_config(config, allow_print=False)
             except Exception:
                 # If all configs failed, raise error
-                if not valid_configs and i == len(configs) - 1:
+                if not valid_configs and i == len(all_configs) - 1:
                     raise
                 self.log.warning(
                     "Skipping config that failed to compile: %s",
@@ -397,6 +399,7 @@ class BaseSearch(BaseAutotuner):
                 continue
             fns.append(fn)
             valid_configs.append(config)
+            valid_indices.append(i)
         configs = valid_configs
         if self.settings.autotune_precompile:
             futures = list(
@@ -495,7 +498,25 @@ class BaseSearch(BaseAutotuner):
                         compile_time=compile_time,
                     )
                 )
-        return results
+        if len(valid_indices) == len(all_configs):
+            return results
+        full_results: list[BenchmarkResult] = []
+        valid_iter = iter(results)
+        valid_set = set(valid_indices)
+        for i, config in enumerate(all_configs):
+            if i in valid_set:
+                full_results.append(next(valid_iter))
+            else:
+                full_results.append(
+                    BenchmarkResult(
+                        config=config,
+                        fn=_unset_fn,
+                        perf=inf,
+                        status="error",
+                        compile_time=None,
+                    )
+                )
+        return full_results
 
     def benchmark_batch(
         self, configs: list[Config], *, desc: str = "Benchmarking"

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -239,7 +239,7 @@ class TestAutotuneIgnoreErrors(TestCase):
 
     def test_benchmark_results_aligned_when_compile_fails(self):
         """_benchmark must return one result per input config even when some
-        fail to compile (regression test for #1673 misalignment)."""
+        fail to compile."""
         settings = Settings(
             autotune_precompile=None,
             autotune_log_level=logging.CRITICAL,

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -692,6 +692,50 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         # should allow autotuning to succeed.
         torch.testing.assert_close(add(*args), sum(args))
 
+    def test_benchmark_results_aligned_when_compile_fails(self):
+        """_benchmark must return one result per input config even when some
+        fail to compile, otherwise parallel_benchmark_population crashes
+        with an assertion on result/member alignment."""
+
+        @helion.kernel(static_shapes=True)
+        def add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(out.size()):
+                out[tile] = x[tile] + y[tile]
+            return out
+
+        a = torch.randn([64, 64], device=DEVICE)
+        b = torch.randn([64, 64], device=DEVICE)
+        bound = add.bind((a, b))
+        good_config = bound.config_spec.default_config()
+
+        call_count = 0
+        original_compile = bound.compile_config
+
+        def fail_second(config, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise RuntimeError("simulated compile failure")
+            return original_compile(config, **kwargs)
+
+        search = FiniteSearch(
+            bound, (a, b), configs=[good_config, good_config, good_config]
+        )
+        search.settings.autotune_precompile = None
+        search._prepare()
+
+        with patch.object(bound, "compile_config", side_effect=fail_second):
+            results = search._benchmark(
+                [good_config, good_config, good_config], desc="test"
+            )
+
+        self.assertEqual(len(results), 3)
+        self.assertTrue(math.isfinite(results[0].perf))
+        self.assertEqual(results[1].perf, float("inf"))
+        self.assertEqual(results[1].status, "error")
+        self.assertTrue(math.isfinite(results[2].perf))
+
     @skipIfXPU("maxnreg parameter not supported on XPU backend")
     def test_random_search(self):
         args = (

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -237,6 +237,43 @@ class TestAutotuneIgnoreErrors(TestCase):
         # Verify we can still get the error type and message
         assert type(err.value.__cause__).__name__ == "RuntimeError"
 
+    def test_benchmark_results_aligned_when_compile_fails(self):
+        """_benchmark must return one result per input config even when some
+        fail to compile (regression test for #1673 misalignment)."""
+        settings = Settings(
+            autotune_precompile=None,
+            autotune_log_level=logging.CRITICAL,
+        )
+        search = self._make_search(settings)
+
+        call_count = 0
+
+        def fail_second(config, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise RuntimeError("simulated compile failure")
+            return lambda *a, **kw: None
+
+        search.kernel.compile_config = None
+        search.kernel.env = SimpleNamespace(process_group_name=None)
+        configs = ["cfg_a", "cfg_b", "cfg_c"]
+        with (
+            patch.object(search.kernel, "compile_config", side_effect=fail_second),
+            patch.object(
+                search.benchmark_provider,
+                "benchmark_function",
+                return_value=1.0,
+            ),
+        ):
+            results = search._benchmark(configs, desc="test")
+
+        self.assertEqual(len(results), 3)
+        self.assertEqual(results[0].perf, 1.0)
+        self.assertEqual(results[1].perf, float("inf"))
+        self.assertEqual(results[1].status, "error")
+        self.assertEqual(results[2].perf, 1.0)
+
     def test_autotune_log_sink_writes_csv_and_log(self):
         tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(tmpdir.cleanup)
@@ -691,50 +728,6 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         # 3D input and should fail to compile. The surrounding good configs
         # should allow autotuning to succeed.
         torch.testing.assert_close(add(*args), sum(args))
-
-    def test_benchmark_results_aligned_when_compile_fails(self):
-        """_benchmark must return one result per input config even when some
-        fail to compile, otherwise parallel_benchmark_population crashes
-        with an assertion on result/member alignment."""
-
-        @helion.kernel(static_shapes=True)
-        def add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-            out = torch.empty_like(x)
-            for tile in hl.tile(out.size()):
-                out[tile] = x[tile] + y[tile]
-            return out
-
-        a = torch.randn([64, 64], device=DEVICE)
-        b = torch.randn([64, 64], device=DEVICE)
-        bound = add.bind((a, b))
-        good_config = bound.config_spec.default_config()
-
-        call_count = 0
-        original_compile = bound.compile_config
-
-        def fail_second(config, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 2:
-                raise RuntimeError("simulated compile failure")
-            return original_compile(config, **kwargs)
-
-        search = FiniteSearch(
-            bound, (a, b), configs=[good_config, good_config, good_config]
-        )
-        search.settings.autotune_precompile = None
-        search._prepare()
-
-        with patch.object(bound, "compile_config", side_effect=fail_second):
-            results = search._benchmark(
-                [good_config, good_config, good_config], desc="test"
-            )
-
-        self.assertEqual(len(results), 3)
-        self.assertTrue(math.isfinite(results[0].perf))
-        self.assertEqual(results[1].perf, float("inf"))
-        self.assertEqual(results[1].status, "error")
-        self.assertTrue(math.isfinite(results[2].perf))
 
     @skipIfXPU("maxnreg parameter not supported on XPU backend")
     def test_random_search(self):


### PR DESCRIPTION
## Summary                                                                                                                                                                                              
  - `_benchmark` skips configs that fail `compile_config` but didn't emit a placeholder result, making the results list shorter than the input                                                            
  - `parallel_benchmark_population` zips members against results 1:1 and the misaligned pairing hits `assert result.config is member.config`    
  - Track valid indices during compilation, splice `inf`-perf placeholders for failed configs at the end  


```
Helion compiler triton codegen error for @helion.kernel(config=helion.Config(block_sizes=[16, 8], epilogue_subtile=2, flatten_loops=[True], indexing=['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], l2_groupings=[64], load_eviction_policies=['', 'first'], loop_orders=[[0, 1]], num_sm_multiplier=128, num_stages=7, num_warps=16, pid_type='persistent_blocked', range_flattens=[False], range_multi_buffers=[False], range_unroll_factors=[3], range_warp_specializes=[None]), static_shapes=True)
Traceback (most recent call last):
  File "/home/asangior/redhat/helion/helion/_compiler/inductor_lowering.py", line 1258, in run_node
    result = lowering.codegen(self, n)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/asangior/redhat/helion/helion/_compiler/inductor_lowering.py", line 915, in codegen
    return codegen_fn(
           ^^^^^^^^^^^
  File "/home/asangior/redhat/helion/helion/language/memory_ops.py", line 141, in _
    return strategy.codegen_store(state, tensor, [*subscript], value, extra_mask)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/asangior/redhat/helion/helion/_compiler/indexing_strategy.py", line 525, in codegen_store
    return PointerIndexingStrategy().codegen_store(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/asangior/redhat/helion/helion/_compiler/indexing_strategy.py", line 230, in codegen_store
    indexing = SubscriptIndexing.create(state, fake_tensor, subscript, extra_mask)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/asangior/redhat/helion/helion/_compiler/indexing_strategy.py", line 1141, in create
    per_dim = SubscriptIndexing.compute_per_dim_indexing(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/asangior/redhat/helion/helion/_compiler/indexing_strategy.py", line 968, in compute_per_dim_indexing
    base_offset = state.codegen.offset_var(block_id)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/asangior/redhat/helion/helion/_compiler/generate_ast.py", line 113, in offset_var
    return self.active_device_loops[block_idx][-1].strategy.offset_var(block_idx)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/asangior/redhat/helion/helion/_compiler/tile_strategy.py", line 737, in offset_var
    raise NotImplementedError("offset_var not used in FlattenedTileStrategy")
NotImplementedError: offset_var not used in FlattenedTileStrategy

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/asangior/redhat/helion/helion/runtime/kernel.py", line 619, in compile_config
    triton_code = self.to_triton_code(
                  ^^^^^^^^^^^^^^^^^^^^
  File "/home/asangior/redhat/helion/helion/runtime/kernel.py", line 555, in to_triton_code
    root = generate_ast(self.host_function, config, emit_repro_caller)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/asangior/redhat/helion/helion/_compiler/generate_ast.py", line 725, in generate_ast
    codegen.add_statement(codegen.visit(stmt))
                          ^^^^^^^^^^^^^^^^^^^
  File "/home/asangior/redhat/helion/helion/_compiler/ast_extension.py", line 284, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/home/asangior/redhat/helion/helion/_compiler/generate_ast.py", line 509, in visit_For
    codegen_call_with_graph(self, root, [])
  File "/home/asangior/redhat/helion/helion/_compiler/inductor_lowering.py", line 1340, in codegen_call_with_graph
    return GraphInterpreter(graph, cg).run(*new_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/asangior/redhat/venv-uv-helion-upstream/lib/python3.12/site-packages/torch/fx/interpreter.py", line 200, in run
    self.env[node] = self.run_node(node)
                     ^^^^^^^^^^^^^^^^^^^
  File "/home/asangior/redhat/helion/helion/_compiler/inductor_lowering.py", line 1307, in run_node
    raise InductorLoweringError(
helion.exc.InductorLoweringError: Error in codegen for node store_1 (<function store at 0x7f561194ce00>): offset_var not used in FlattenedTileStrategy
While processing:
  File "/home/asangior/redhat/helion/examples/add.py", line 50, in add
    out[tile] = x[tile] + y[tile]


While executing %store_1 : [num_users=0] = call_function[target=helion.language.memory_ops.store](args = (%out, [%block_size_0, %add_1], %add_tensor, None), kwargs = {})
Original traceback:
  File "/home/asangior/redhat/helion/examples/add.py", line 50, in add
    out[tile] = x[tile] + y[tile]

Use tlparse to see full graph. (https://github.com/pytorch/tlparse?tab=readme-ov-file#tlparse-parse-structured-pt2-logs)
[0s] Skipping config that failed to compile: %s @helion.kernel(config=helion.Config(block_sizes=[16, 8], epilogue_subtile=2, flatten_loops=[True], indexing=['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], l2_groupings=[64], load_eviction_policies=['', 'first'], loop_orders=[[0, 1]], num_sm_multiplier=128, num_stages=7, num_warps=16, pid_type='persistent_blocked', range_flattens=[False], range_multi_buffers=[False], range_unroll_factors=[3], range_warp_specializes=[None]), static_shapes=True)
Initial population precompiling 100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 99/99 62.7 configs/s
Initial population exploring neighbors 100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 99/99 17.6 configs/s
Traceback (most recent call last):
  File "/home/asangior/redhat/helion/examples/add.py", line 87, in <module>
    main()
  File "/home/asangior/redhat/helion/examples/add.py", line 83, in main
    check(1024, 1024)
  File "/home/asangior/redhat/helion/examples/add.py", line 70, in check
    run_example(add, torch.add, (x, y))
  File "/home/asangior/redhat/helion/helion/_testing.py", line 1048, in run_example
    result = func(*cloned_args).clone()
             ^^^^^^^^^^^^^^^^^^
  File "/home/asangior/redhat/helion/helion/runtime/kernel.py", line 370, in __call__
    return self.bind(args)(*args)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/asangior/redhat/helion/helion/runtime/kernel.py", line 956, in __call__
    self.ensure_config_exists(args)
  File "/home/asangior/redhat/helion/helion/runtime/kernel.py", line 924, in ensure_config_exists
    self.autotune(args, force=False)
  File "/home/asangior/redhat/helion/helion/runtime/kernel.py", line 776, in autotune
    config = self.env.backend.autotune(self, args, force=force, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/asangior/redhat/helion/helion/_compiler/backend.py", line 534, in autotune
    ).autotune(skip_cache=force)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/asangior/redhat/helion/helion/autotuner/base_cache.py", line 266, in autotune
    config = self.autotuner.autotune()
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/asangior/redhat/helion/helion/autotuner/base_search.py", line 1099, in autotune
    best = self._autotune()
           ^^^^^^^^^^^^^^^^
  File "/home/asangior/redhat/helion/helion/autotuner/surrogate_pattern_search.py", line 373, in _autotune
    self.parallel_benchmark_population(self.population, desc="Initial population")
  File "/home/asangior/redhat/helion/helion/autotuner/base_search.py", line 1477, in parallel_benchmark_population
    assert result.config is member.config
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```