### PR TITLE
[Pallas] Reject 64-bit input tensors and fix tiling ZeroDivisionError

### DIFF
--- a/examples/cross_entropy.py
+++ b/examples/cross_entropy.py
@@ -16,6 +16,7 @@ import torch
 
 import helion
 from helion._testing import DEVICE
+from helion._testing import LONG_INT_TYPE
 from helion._testing import run_example
 import helion.language as hl
 
@@ -91,7 +92,7 @@ def main() -> None:
     batch_size, seq_len, vocab_size = 8, 2048, 131072
     n = batch_size * seq_len
     logits = torch.randn(n, vocab_size, device=DEVICE, dtype=torch.float32)
-    labels = torch.randint(0, vocab_size, (n,), device=DEVICE, dtype=torch.long)
+    labels = torch.randint(0, vocab_size, (n,), device=DEVICE, dtype=LONG_INT_TYPE)
 
     run_example(
         cross_entropy,

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -896,6 +896,10 @@ _TORCH_TO_JAX_DTYPE: dict[str, str] = {
 }
 
 
+# TPU does not natively support 64-bit element types.
+_PALLAS_UNSUPPORTED_DTYPES = frozenset({torch.int64, torch.uint64, torch.float64})
+
+
 class PallasBackend(Backend):
     """Pallas (JAX) code generation backend for TPU."""
 
@@ -1177,6 +1181,10 @@ class PallasBackend(Backend):
             tensor_ndim (int): Amount of dimensions for the tensor.
             bitwidth (int): Bitwidth of tensor elements
         """
+        # Cap to 32: wider dtypes (e.g. float64, int64) would cause
+        # ZeroDivisionError in 32 // bitwidth.  64-bit types are rejected
+        # at runtime, so block spec computation uses 32-bit alignment.
+        bitwidth = min(bitwidth, 32)
         if dim_from_end == 0:  # Last dimension
             if tensor_ndim <= 1:
                 return 128 * (32 // bitwidth)

--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -248,6 +248,12 @@ if _get_backend() == "pallas":
 else:
     HALF_DTYPE = torch.float16
 
+# Long integer dtype: int32 on TPU (64-bit types not supported), int64 elsewhere
+if _get_backend() == "pallas":
+    LONG_INT_TYPE = torch.int32
+else:
+    LONG_INT_TYPE = torch.int64
+
 
 def get_nvidia_gpu_model() -> str:
     """

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -347,6 +347,18 @@ def _jax_placeholder_for_tensor(t: torch.Tensor) -> object:
     return jax.ShapeDtypeStruct(tuple(t.shape), jax_dtype)
 
 
+def _pallas_check_dtypes(args: tuple[object, ...]) -> None:
+    """Raise if any tensor arg uses a dtype unsupported on TPU."""
+    from .._compiler.backend import _PALLAS_UNSUPPORTED_DTYPES
+
+    for a in args:
+        if isinstance(a, torch.Tensor) and a.dtype in _PALLAS_UNSUPPORTED_DTYPES:
+            raise TypeError(
+                f"Pallas/TPU does not support {a.dtype} tensors. "
+                f"Cast to a 32-bit type before calling the kernel."
+            )
+
+
 def _pallas_prepare_args(
     args: tuple[object, ...],
     _output_indices: list[int],
@@ -591,6 +603,8 @@ def default_pallas_launcher(
     if _output_indices is None:
         _output_indices = []
 
+    _pallas_check_dtypes(args)
+
     cache = getattr(pallas_kernel, "_pallas_cache", None)
     if cache is not None and cache[0] == grid:
         _, jax_callable, tensor_arg_indices = cache
@@ -703,6 +717,8 @@ def default_pallas_pipeline_launcher(
         _output_indices = []
     if _scratch_shapes is None:
         _scratch_shapes = []
+
+    _pallas_check_dtypes(args)
 
     cache = getattr(pallas_kernel, "_pallas_pipeline_cache", None)
     if cache is not None and cache[0] == grid:
@@ -844,6 +860,8 @@ def default_pallas_fori_launcher(
         _output_indices = []
     if _scratch_shapes is None:
         _scratch_shapes = []
+
+    _pallas_check_dtypes(args)
 
     cache = getattr(pallas_kernel, "_pallas_fori_cache", None)
     if cache is not None and cache[0] == grid:

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -14,6 +14,7 @@ from helion import _compat
 from helion._testing import DEVICE
 from helion._testing import EXAMPLES_DIR
 from helion._testing import HALF_DTYPE
+from helion._testing import LONG_INT_TYPE
 from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import _get_backend
@@ -459,17 +460,17 @@ class TestExamples(RefEagerTestBase, TestCase):
             indexing="block_ptr",
         )
 
-    @xfailIfPallas("BlockSpec tiling failure")
+    @xfailIfPallas("missing BlockSpec for hl.load with computed indices")
     def test_cross_entropy(self):
         n, v = 128, 1000
-        args = (
-            torch.randn(n, v, device=DEVICE, dtype=torch.float32),
-            torch.randint(0, v, (n,), device=DEVICE, dtype=torch.long),
-        )
+        logits = torch.randn(n, v, device=DEVICE, dtype=torch.float32)
+        labels = torch.randint(0, v, (n,), device=DEVICE, dtype=LONG_INT_TYPE)
+        # PyTorch cross_entropy requires Long labels for the reference
+        expected = torch.nn.functional.cross_entropy(logits, labels.long())
         check_example(
             "cross_entropy",
-            args,
-            torch.nn.functional.cross_entropy(*args),
+            (logits, labels),
+            expected,
         )
 
     @xfailIfCute("CuTe Welford example still returns incorrect results")

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -787,6 +787,13 @@ class TestPallas(TestCase):
         # out is read after write, so it must be in _inplace_indices
         self.assertIn("_inplace_indices=[1]", code)
 
+    def test_int64_tensor_raises(self) -> None:
+        """Passing int64 tensors to a Pallas kernel should raise TypeError."""
+        x = torch.arange(256, device=DEVICE, dtype=torch.int64)
+        y = torch.arange(256, device=DEVICE, dtype=torch.int64)
+        with self.assertRaises(TypeError, msg="does not support"):
+            code_and_output(add_kernel, (x, y), block_size=128)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

TPU does not natively support 64-bit element types. This PR:

1. **Runtime** (`runtime/__init__.py`): `_pallas_check_dtypes` raises `TypeError` if any tensor arg uses int64, uint64, or float64. Runs before the cache check in all three launchers so it cannot be bypassed.

2. **Block spec tiling** (`backend.py`): Cap bitwidth to 32 in `_get_pallas_required_alignment` to prevent ZeroDivisionError when 64-bit dtypes appear at compile time (`128 * (32 // 64)` = 0).

3. **`LONG_INT_TYPE`** (`_testing.py`): New constant (int32 on Pallas, int64 elsewhere) for examples/tests that use long integers but don't need 64-bit range. Updated `cross_entropy` example and test to use it.

Note: internal dtype promotion (e.g. `torch.sum` on int32 → int64, `argmax` → int64) is handled by JAX, which silently narrows without `jax_enable_x64`.