### PR TITLE
Raise error when autotune_with_torch_compile_fusion is set without torch_compile_fusion

### DIFF
--- a/helion/exc.py
+++ b/helion/exc.py
@@ -313,8 +313,7 @@ class IncompatibleInterpretModes(BaseError):
 class FusionAutotuneRequiresTorchCompileFusion(BaseError):
     location_suffix = ""
     message = (
-        "autotune_with_torch_compile_fusion=True requires torch_compile_fusion=True. "
-        "Either enable torch_compile_fusion or disable autotune_with_torch_compile_fusion."
+        "autotune_with_torch_compile_fusion=True requires torch_compile_fusion=True."
     )
 
 

--- a/helion/exc.py
+++ b/helion/exc.py
@@ -310,6 +310,14 @@ class IncompatibleInterpretModes(BaseError):
     message = "TRITON_INTERPRET=1 and HELION_INTERPRET=1 cannot be used together. Please use only one of these debug modes at a time."
 
 
+class FusionAutotuneRequiresTorchCompileFusion(BaseError):
+    location_suffix = ""
+    message = (
+        "autotune_with_torch_compile_fusion=True requires torch_compile_fusion=True. "
+        "Either enable torch_compile_fusion or disable autotune_with_torch_compile_fusion."
+    )
+
+
 class MissingEnableTile(BaseError):
     message = (
         "HELION_BACKEND=tileir requires the Triton TileIR driver to be active. "

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -681,6 +681,9 @@ class Settings(_Settings):
         if self.backend == "tileir" and os.environ.get("ENABLE_TILE", "0") != "1":
             raise exc.MissingEnableTile
 
+        if self.autotune_with_torch_compile_fusion and not self.torch_compile_fusion:
+            raise exc.FusionAutotuneRequiresTorchCompileFusion
+
         self._check_ref_eager_mode_before_print_output_code()
 
     def to_dict(self) -> dict[str, object]:


### PR DESCRIPTION
## Summary
- Previously, setting `autotune_with_torch_compile_fusion=True` without `torch_compile_fusion=True` was silently ignored.
- Now it raises `FusionAutotuneRequiresTorchCompileFusion` at `Settings` construction time with a clear error message.

## Test plan
- [ ] Verify `Settings(autotune_with_torch_compile_fusion=True)` raises the error
- [ ] Verify `Settings(autotune_with_torch_compile_fusion=True, torch_compile_fusion=True)` works fine
- [ ] Existing tests pass