### PR TITLE
[Pallas] Fix scalar .begin index not collapsing tensor dimensions

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1178,11 +1178,18 @@ class PallasBackend(Backend):
                                     tensor_ndim,
                                 )
 
-        for i, spec in enumerate(block_specs):
+        for spec in block_specs:
             if not isinstance(spec, BlockSizeSpec):
                 continue
             bid = spec.block_ids[0]
-            dfe = min_dim_from_end.get(bid, ndim - 1 - i)
+            dfe = min_dim_from_end.get(bid)
+            if dfe is None:
+                # No tensor dim mapping found — skip alignment
+                # constraints.  The fallback (ndim - 1 - i) assumes
+                # spec ordering matches tensor dim ordering which is
+                # not always true (e.g. hl.tile([M, N, B]) where B
+                # is the first tensor dim but last spec).
+                continue
             if dfe == 0:
                 tndim = min_tensor_ndim.get(bid, ndim)
                 alignment = tiling_1d if tndim <= 1 else 128

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -46,6 +46,7 @@ from .variable_origin import BlockSizeOrigin
 from .variable_origin import GridOrigin
 from .variable_origin import Origin
 from .variable_origin import TensorSizeOrigin
+from .variable_origin import TileBeginOrigin
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -813,8 +814,11 @@ class CompileEnvironment:
                 BlockSizeOrigin,
             ):
                 return origin_info.origin.block_id
-            if origin_info is not None and type(origin_info.origin) is GridOrigin:
-                return origin_info.origin.block_id
+            if origin_info is not None and type(origin_info.origin) in (
+                GridOrigin,
+                TileBeginOrigin,
+            ):
+                return origin_info.origin.block_id  # pyrefly: ignore[missing-attribute]
         return None
 
     def resolve_block_id(self, size: object) -> int | None:

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -207,6 +207,18 @@ def _pallas_index_str(
             out_pos += 1
             continue
         block_id = _resolve_block_id(env, idx, tensor, tensor_dim)
+        if block_id is not None and _is_scalar_tile_offset(idx):
+            # Scalar .begin index — emit literal 0 to collapse this
+            # dimension, mirroring Triton's scalar SymInt handling
+            # (indexing_strategy.py:1024-1033).  Record in dim_map so
+            # the BlockSpec tiles this dim (typically to size 1); the
+            # kernel receives a size-1 slice and index 0 eliminates it.
+            # Don't increment out_pos — the dim is collapsed from the
+            # output, so subsequent None positions stay correct.
+            parts.append("0")
+            dim_map.setdefault(tensor_dim, block_id)
+            tensor_dim += 1
+            continue
         if block_id is not None:
             is_device_loop = False
             if in_pipeline and block_id in pipeline_block_ids:
@@ -241,6 +253,24 @@ def _resolve_block_id(
     if isinstance(idx, slice) and idx == slice(None):
         return env.resolve_block_id(tensor.shape[pos])
     return None
+
+
+def _is_scalar_tile_offset(idx: object) -> bool:
+    """Return True if *idx* is a tile.begin scalar offset.
+
+    In Triton, scalar SymInts without BlockSizeOrigin eliminate the
+    dimension from the result.  Pallas needs the same behavior: emit
+    a scalar index to collapse the dim.
+    """
+    if not isinstance(idx, torch.SymInt):
+        return False
+    import sympy
+
+    expr = _symint_expr(idx)
+    if not isinstance(expr, sympy.Symbol):
+        return False
+    origin_info = HostFunction.current().expr_to_origin.get(expr)
+    return origin_info is not None and isinstance(origin_info.origin, TileBeginOrigin)
 
 
 def _pallas_ds_expr(state: CodegenState, block_id: int) -> str:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -548,6 +548,65 @@ class TestPallas(TestCase):
         expected = torch.nn.functional.softmax(x, dim=-1)
         torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
 
+    def test_scalar_index_transpose(self) -> None:
+        """Scalar .begin index should collapse the dimension.
+
+        In Triton, a scalar SymInt index (like tile.begin) eliminates
+        the dimension from the result. In Pallas, _pallas_index_str
+        emits ':' instead, keeping all dimensions. This causes .T to
+        fail because it gets a 3D tensor when the IR expects 2D.
+        """
+
+        @helion.kernel(
+            backend="pallas",
+            static_shapes=True,
+            config=helion.Config(block_sizes=[32, 32, 1]),
+        )
+        def scalar_index_transpose(x: torch.Tensor) -> torch.Tensor:
+            B, M, N = x.shape
+            out = torch.empty([B, N, M], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n, tile_b in hl.tile([M, N, B]):
+                # tile_b has block_size=1, so .begin is used as a scalar index
+                out[tile_b.begin, tile_n, tile_m] = x[tile_b.begin, tile_m, tile_n].T
+            return out
+
+        x = torch.randn(4, 64, 64, device=DEVICE, dtype=torch.float32)
+        _code, result = code_and_output(scalar_index_transpose, (x,))
+        expected = x.permute(0, 2, 1)
+        torch.testing.assert_close(result, expected)
+
+    def test_scalar_index_with_none(self) -> None:
+        """Scalar .begin + None indexing: out_pos must not count collapsed dims.
+
+        When .begin collapses a dim and None appears later in the same
+        subscript, the None position in the output must account for the
+        collapsed dim.  Without the fix, jnp.expand_dims uses the wrong
+        axis.
+        """
+
+        @helion.kernel(
+            backend="pallas",
+            static_shapes=True,
+            config=helion.Config(block_sizes=[32, 32, 1]),
+        )
+        def scalar_index_with_none(
+            x: torch.Tensor, scale: torch.Tensor
+        ) -> torch.Tensor:
+            B, M, N = x.shape
+            out = torch.empty([B, M, N], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n, tile_b in hl.tile([M, N, B]):
+                # .begin collapses B dim, then scale[None, :] broadcasts
+                out[tile_b.begin, tile_m, tile_n] = (
+                    x[tile_b.begin, tile_m, tile_n] * scale[None, tile_n]
+                )
+            return out
+
+        x = torch.randn(4, 64, 64, device=DEVICE, dtype=torch.float32)
+        scale = torch.randn(64, device=DEVICE, dtype=torch.float32)
+        _code, result = code_and_output(scalar_index_with_none, (x, scale))
+        expected = x * scale[None, None, :]
+        torch.testing.assert_close(result, expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- When a kernel uses `tile.begin` as a scalar index, the Pallas codegen emitted `:` keeping the dimension alive, causing rank mismatches with ops like `.T`
- Add `TileBeginOrigin` to `get_block_id`'s accepted types so `.begin` SymInts get a block_id
- Emit literal `0` for `.begin` indices in `_pallas_index_str` to collapse the dim, mirroring Triton's scalar SymInt handling
- Fix `adjust_block_size_constraints` fallback that incorrectly assumed spec ordering matches tensor dim ordering
- Skip `out_pos` increment for collapsed dims so `None` positions stay correct