### PR TITLE
[compile] Add `pre_codegen` hook to Backend ABC

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
     from ..runtime.kernel import BoundKernel
     from .device_function import Argument
     from .device_function import DeviceFunction
+    from .device_ir import GraphInfo
+    from .tile_dispatch import TileStrategyDispatch
     from .tile_strategy import TileStrategy
 
     InductorOpOverrides = OpsHandler[Any]
@@ -413,6 +415,18 @@ class Backend(abc.ABC):
 
     def launcher_keyword_args(self, config: Config, *, has_barrier: bool) -> list[str]:
         return []
+
+    def pre_codegen(
+        self,
+        graphs: list[GraphInfo],
+        config: Config,
+        tile_strategy: TileStrategyDispatch,
+    ) -> None:
+        """Run backend-specific passes after tiling is finalized, before codegen.
+
+        Backends can override this to analyze or transform the graphs.
+        """
+        return None
 
     def transform_host_arg(
         self,
@@ -1862,6 +1876,16 @@ class CuteBackend(Backend):
     @property
     def name(self) -> str:
         return "cute"
+
+    def pre_codegen(
+        self,
+        graphs: list[GraphInfo],
+        config: Config,
+        tile_strategy: TileStrategyDispatch,
+    ) -> None:
+        from .cute.layout_propagation import plan_layouts
+
+        plan_layouts(graphs, config, tile_strategy)
 
     def supports_config_key(self, key: str) -> bool:
         if key == "num_threads":

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -96,15 +96,6 @@ class GenerateAST(NodeVisitor, CodegenInterface):
         )
         CodegenInterface.__init__(self, self.device_function)
 
-        # Run CuTe layout planning after tile strategies are created, so
-        # layout rules can query actual thread counts from strategies.
-        if CompileEnvironment.current().backend.name == "cute":
-            from .cute.layout_propagation import plan_layouts
-
-            plan_layouts(
-                self.codegen_graphs, config, self.device_function.tile_strategy
-            )
-
     def get_graph(self, graph_id: int) -> GraphInfo:
         return self.codegen_graphs[graph_id]
 
@@ -718,6 +709,11 @@ def generate_ast(
             store_transform=store_transform,
             load_transform=load_transform,
             extra_params=extra_params,
+        )
+        CompileEnvironment.current().backend.pre_codegen(
+            graphs=codegen.codegen_graphs,
+            config=config,
+            tile_strategy=codegen.device_function.tile_strategy,
         )
         with codegen.device_function:
             for stmt in func.body:


### PR DESCRIPTION
The CuTe backend needs to run layout propagation after tiling is finalized but before code generation begins. This was previously handled by a hardcoded `if backend.name == "cute"` check inside `GenerateAST.__init__`.

This PR adds `pre_codegen` as a method on the `Backend` ABC, giving any backend a hook to run passes at this pipeline stage. The call is moved out of the constructor and into the `generate_ast()` function, making the pipeline step explicit at the call site.