### PR TITLE
[Pallas] Skip trivial reduction mask when RDIM size equals actual dim

### DIFF
--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -13,7 +13,6 @@ from torch._inductor.runtime.runtime_utils import next_power_of_2
 from torch._prims_common import get_computation_dtype
 
 from .._compat import shape_env_size_hint
-from ..autotuner.config_fragment import integer_power_of_two
 from .ast_extension import create
 from .ast_extension import expr_from_string
 from .ast_extension import statement_from_string
@@ -339,10 +338,18 @@ class PersistentReductionStrategy(ReductionStrategy):
 
         env = CompileEnvironment.current()
         numel = env.block_sizes[block_index].numel
-        if isinstance(numel, (int, sympy.Integer)) and integer_power_of_two(int(numel)):
-            mask_var: str | None = None
-        else:
-            mask_var = fn.new_var(f"mask_{block_index}", dce=True)
+        # Skip the mask when RDIM_SIZE == numel (no padding needed).
+        # This is true when numel is a power of 2 (Triton doesn't round),
+        # or when the backend uses exact RDIM sizes (e.g., Pallas).
+        needs_mask = True
+        # Guard numel > 0: on PyTorch 2.9, next_power_of_2(0) returns 0
+        # (the n <= 0 guard was added later), so static_rdim_size(0) == 0
+        # would incorrectly skip the mask for zero-size reductions.
+        if isinstance(numel, (int, sympy.Integer)) and int(numel) > 0:
+            needs_mask = env.backend.static_rdim_size(int(numel)) != int(numel)
+        mask_var: str | None = (
+            fn.new_var(f"mask_{block_index}", dce=True) if needs_mask else None
+        )
         super().__init__(
             fn=fn,
             block_index=block_index,


### PR DESCRIPTION
## Summary
- When the Pallas backend sets `RDIM_SIZE` equal to the actual dimension size (no rounding), the reduction mask is always true and can be skipped entirely
- Previously, the mask was only skipped for power-of-2 dimensions — this worked for Triton (which rounds RDIM up to the next power of 2), but Pallas uses exact RDIM sizes, so the mask was never needed yet always generated for non-power-of-2 dims
- This change generalizes the check by comparing `backend.static_rdim_size(numel)` against `numel`, which naturally handles both backends
- Guards `numel > 0` to preserve correct behavior for zero-size reductions (`static_rdim_size(0)` returns 1 via `next_power_of_2`, which would incorrectly skip the mask)

**Before** (unnecessary mask for Pallas on non-power-of-2 dim like 1000):
```python
def _helion_pallas_reduce_non_pow2(x, out, _RDIM_SIZE_1: int):
    indices_1 = jnp.arange(0, _RDIM_SIZE_1, dtype=jnp.int32)
    mask_1 = indices_1 < 1000
    row = x[:, :]
    _mask_to = jnp.where(jnp.broadcast_to(mask_1[None, :], ...),
                         row, jnp.full([], float('-inf'), jnp.float32))
    max_val = ...jnp.max(_mask_to, axis=1)...
    v_1 = jnp.exp(v_0)
    _mask_to_1 = jnp.where(jnp.broadcast_to(mask_1[None, :], ...),
                           v_1, jnp.full([], 0, jnp.float32))
    sum_1 = ...jnp.sum(_mask_to_1, axis=1)...
```

**After** (no mask — clean and correct):
```python
def _helion_pallas_reduce_non_pow2(x, out):
    row = x[:, :]
    max_val = ...jnp.max(row, axis=1)...
    v_1 = jnp.exp(v_0)
    sum_1 = ...jnp.sum(v_1, axis=1)...
```