### PR TITLE
[Pallas] Fix fori_loop multi-dim inner loop index unflattening

### DIFF
--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -992,6 +992,46 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     loop_var = state.device_function.new_var("_j")
     body_stmts: list[ast.AST] = []
 
+    # Compute per-dimension index variables from the flat loop_var.
+    # When len(block_ids) > 1 the fori_loop iterates over the product of
+    # all tile counts, so we must unflatten into per-dim indices via divmod.
+    if len(block_ids) == 1:
+        dim_index_vars = [loop_var]
+    else:
+        dim_index_vars = [
+            state.device_function.new_var(f"_j_{i}") for i in range(len(block_ids))
+        ]
+        # Emit divmod decomposition: row-major order (last dim varies fastest)
+        remainder_var = loop_var
+        for i in range(len(block_ids)):
+            if i < len(block_ids) - 1:
+                # divisor = product of grid_parts[i+1:]
+                suffix = grid_parts[i + 1 :]
+                divisor = (
+                    suffix[0]
+                    if len(suffix) == 1
+                    else " * ".join(f"({p})" for p in suffix)
+                )
+                body_stmts.append(
+                    statement_from_string(
+                        f"{dim_index_vars[i]} = ({remainder_var}) // ({divisor})"
+                    )
+                )
+                if i < len(block_ids) - 2:
+                    new_remainder = state.device_function.new_var(f"_jr_{i}")
+                    body_stmts.append(
+                        statement_from_string(
+                            f"{new_remainder} = ({remainder_var}) % ({divisor})"
+                        )
+                    )
+                    remainder_var = new_remainder
+                else:
+                    body_stmts.append(
+                        statement_from_string(
+                            f"{dim_index_vars[i + 1]} = ({remainder_var}) % ({divisor})"
+                        )
+                    )
+
     # Build block_id_to_info
     block_id_to_info: dict[int, LoopDimInfo] = {}
     for block_id in block_ids:
@@ -1009,8 +1049,8 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         block_size_vars,
         env,
         body_stmts,
-        # fori_loop has direct access to the loop variable
-        offset_expr_fn=lambda i, bs: f"{loop_var} * {bs} + jnp.arange({bs})",
+        # fori_loop has direct access to the per-dimension loop variable
+        offset_expr_fn=lambda i, bs: f"{dim_index_vars[i]} * {bs} + jnp.arange({bs})",
     )
     # Create ForiLoopState
     fori_state = ForiLoopState(
@@ -1038,8 +1078,9 @@ def _codegen_fori_loop(state: CodegenState) -> object:
                 begin_expr = begin_exprs[bid_idx]
                 iter_step_expr = iter_step_exprs[bid_idx]
                 slice_size_expr = slice_size_exprs[bid_idx]
+                dim_var = dim_index_vars[bid_idx]
                 parts.append(
-                    f"pl.ds(({begin_expr}) + ({loop_var}) * ({iter_step_expr}), {slice_size_expr})"
+                    f"pl.ds(({begin_expr}) + ({dim_var}) * ({iter_step_expr}), {slice_size_expr})"
                 )
                 needs_slice = True
             elif bid is not None and bid not in block_ids:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -172,6 +172,20 @@ def pallas_inner_loop_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_2d_inner_loop_add(
+    x: torch.Tensor, y: torch.Tensor, out: torch.Tensor
+) -> torch.Tensor:
+    """Outer grid on batch, inner 2D fori_loop on (rows, cols)."""
+    batch, rows, cols = x.shape
+    for tile_b in hl.tile(batch):
+        for tile_r, tile_c in hl.tile([rows, cols]):
+            out[tile_b, tile_r, tile_c] = (
+                x[tile_b, tile_r, tile_c] + y[tile_b, tile_r, tile_c]
+            )
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_attention(
     q_in: torch.Tensor, k_in: torch.Tensor, v_in: torch.Tensor
 ) -> torch.Tensor:
@@ -450,6 +464,38 @@ class TestPallas(TestCase):
         self.assertIn("pltpu.make_async_copy", code)
         self.assertNotIn("pltpu.emit_pipeline", code)
         torch.testing.assert_close(result, args[0] + args[1])
+
+    def test_fori_loop_2d_inner(self) -> None:
+        """Test fori_loop with 2D inner loop correctly unflattens loop index."""
+        B, M, N = 2, 256, 256
+        x = torch.randn(B, M, N, device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn(B, M, N, device=DEVICE, dtype=torch.bfloat16)
+        out = torch.empty_like(x)
+        code, result = code_and_output(
+            pallas_2d_inner_loop_add,
+            (x, y, out),
+            block_sizes=[1, 128, 128],
+            pallas_loop_type="fori_loop",
+        )
+        self.assertIn("jax.lax.fori_loop", code)
+        # Per-dim index vars from divmod decomposition
+        self.assertIn("_j_0", code)
+        self.assertIn("_j_1", code)
+        torch.testing.assert_close(result, x + y, rtol=1e-2, atol=1e-2)
+
+    def test_fori_loop_2d_inner_asymmetric(self) -> None:
+        """Test fori_loop with asymmetric 2D inner loop (3x2 tiles)."""
+        B, M, N = 2, 384, 256
+        x = torch.randn(B, M, N, device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn(B, M, N, device=DEVICE, dtype=torch.bfloat16)
+        out = torch.empty_like(x)
+        _code, result = code_and_output(
+            pallas_2d_inner_loop_add,
+            (x, y, out),
+            block_sizes=[1, 128, 128],
+            pallas_loop_type="fori_loop",
+        )
+        torch.testing.assert_close(result, x + y, rtol=1e-2, atol=1e-2)
 
     def test_attention_default_fp32(self) -> None:
         """Test attention with default (for-loop) inner loop."""


### PR DESCRIPTION
Fix out-of-bounds DMA access when fori_loop iterates over multiple inner block dimensions

The flat `_j` loop variable was used directly for all dimensions' offsets; now we unflatten it into per-dimension indices (`_j_0`, `_j_1`, ...) via divmod decomposition