### PR TITLE
removed stale comments

### DIFF
--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -1968,7 +1968,6 @@ class TypePropagation(ast.NodeVisitor):
             # pyrefly: ignore [not-iterable]
             for elt in lhs:
                 if isinstance(elt, ast.Starred):
-                    # TODO(jansel): need to test this
                     assert not used_star, "multiple `*` in assignment"
                     used_star = True
                     # pyrefly: ignore [bad-argument-type]
@@ -2179,7 +2178,6 @@ class TypePropagation(ast.NodeVisitor):
         return result
 
     def visit_Call(self, node: ast.Call) -> TypeInfo:
-        # TODO(jansel): test handling if *args and **kwargs
         func = self.visit(node.func)
 
         # Check for calling a Helion kernel from within another Helion kernel


### PR DESCRIPTION
Two TODOs in `type_propagation.py` claim missing tests, but both are covered by `test_all_ast_nodes` via `test/data/all_ast_nodes.py` (starred assignments at lines 89-93, `*args`/`**kwargs` calls at lines 66-67).
