### PR TITLE
[Pallas] Fix TPU min_dot_size for matmul autotuning

### DIFF
--- a/helion/_compat.py
+++ b/helion/_compat.py
@@ -245,11 +245,12 @@ if triton_is_available():
     def _min_dot_size(
         device: torch.device, lhs: torch.dtype, rhs: torch.dtype
     ) -> tuple[int, int, int]:
-        if device.type not in ["cuda", "xpu"]:
-            # TODO(jansel): support other hardware backends properly besides CUDA and XPU
-            return (16, 16, 16)
+        if device.type == "tpu":
+            # TPU Mosaic MXU tile: (8, 128) sublane × lane.
+            # pl.dot(lhs[M,K], rhs[K,N]) needs M>=8, K>=128, N>=128.
+            return (8, 128, 128)
 
-        if torch.xpu.is_available():
+        if device.type == "xpu" and torch.xpu.is_available():
             # pyrefly: ignore [missing-import]
             from triton.backends.intel.compiler import min_dot_size as min_dot_size_xpu
 
@@ -266,16 +267,21 @@ if triton_is_available():
             # pyrefly: ignore [bad-return]
             return tuple(int(v) for v in dot_size_val)
 
-        from triton.backends.nvidia.compiler import min_dot_size as min_dot_size_cuda
-
-        props = DeviceProperties.create(device)
-        return min_dot_size_cuda(
-            GPUTarget(
-                backend=props.type,
-                arch=props.cc,
-                warp_size=props.warp_size or 32,
+        if device.type == "cuda":
+            from triton.backends.nvidia.compiler import (
+                min_dot_size as min_dot_size_cuda,
             )
-        )(torch_dtype_to_tl(lhs), torch_dtype_to_tl(rhs))
+
+            props = DeviceProperties.create(device)
+            return min_dot_size_cuda(
+                GPUTarget(
+                    backend=props.type,
+                    arch=props.cc,
+                    warp_size=props.warp_size or 32,
+                )
+            )(torch_dtype_to_tl(lhs), torch_dtype_to_tl(rhs))
+
+        return (16, 16, 16)
 
     @functools.cache
     def use_tileir_tunables() -> bool:
@@ -317,6 +323,8 @@ else:
     def _min_dot_size(  # type: ignore[misc]
         device: torch.device, lhs: torch.dtype, rhs: torch.dtype
     ) -> tuple[int, int, int]:
+        if device.type == "tpu":
+            return (8, 128, 128)
         return (16, 16, 16)
 
     def use_tileir_tunables() -> bool:  # type: ignore[misc]

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -219,6 +219,17 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
     for shape, min_size in ((m, a), (n, b), (k, c)):
         block_idx = env.get_block_id(shape)
         if block_idx is not None:
+            # On Pallas, clamp min to the tensor dimension so we don't
+            # force blocks larger than the tensor (Pallas BlockSpecs can't
+            # handle that, unlike Triton which masks out-of-bounds accesses).
+            # The dot-level padding in matmul_utils.py will pad the smaller
+            # tile up to min_dot_size at codegen time.
+            if env.backend_name == "pallas":
+                try:
+                    bspec = env.config_spec.block_sizes.block_id_lookup(block_idx)
+                    min_size = min(min_size, bspec.size_hint)
+                except KeyError:
+                    pass
             env.block_sizes[block_idx].update_min_block(min_size, allow_flattened=True)
 
     # Triton only supports 2D dot operations.  When the operands are 3D

--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -17,6 +17,20 @@ from helion._testing import skipIfMTIA
 import helion.language as hl
 
 
+@helion.kernel
+def _matmul_kernel(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    m, k = x.size()
+    k2, n = y.size()
+    assert k == k2
+    out = torch.empty([m, n], dtype=torch.float32, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc += torch.matmul(x[tile_m, tile_k], y[tile_k, tile_n])
+        out[tile_m, tile_n] = acc
+    return out
+
+
 @onlyBackends(["triton", "cute"])
 class TestDotRequirements(RefEagerTestDisabled, TestCase):
     @patch.object(_compat, "_min_dot_size", lambda *args: (2, 8, 16))
@@ -44,26 +58,28 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
 
     @patch.object(_compat, "_min_dot_size", lambda *args: (2, 8, 16))
     def test_matmul_sets_min_size(self) -> None:
-        @helion.kernel
-        def k_small(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-            m, k = x.size()
-            k2, n = y.size()
-            assert k == k2
-            out = torch.empty([m, n], dtype=torch.float32, device=x.device)
-            for tile_m, tile_n in hl.tile([m, n]):
-                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
-                for tile_k in hl.tile(k):
-                    acc += torch.matmul(x[tile_m, tile_k], y[tile_k, tile_n])
-                out[tile_m, tile_n] = acc
-            return out
-
         m, k, n = 32, 4, 16
         args = (
             torch.randn([m, k], device=DEVICE, dtype=HALF_DTYPE),
             torch.randn([k, n], device=DEVICE, dtype=HALF_DTYPE),
         )
-        spec = k_small.bind(args).config_spec
+        spec = _matmul_kernel.bind(args).config_spec
         self.assertEqual([x.min_size for x in spec.block_sizes], [2, 8, 16])
+
+    def test_matmul_smaller_than_min_dot_size(self) -> None:
+        """Test matmul where K and N are smaller than min_dot_size (16 on CUDA).
+
+        If update_min_block() promotes block sizes beyond the tensor dimensions,
+        this will fail with shape mismatches.
+        """
+        m, k, n = 32, 8, 8
+        args = (
+            torch.randn([m, k], device=DEVICE, dtype=HALF_DTYPE),
+            torch.randn([k, n], device=DEVICE, dtype=HALF_DTYPE),
+        )
+        _, result = code_and_output(_matmul_kernel, args, block_sizes=[32, 8, 8])
+        ref = args[0].float() @ args[1].float()
+        torch.testing.assert_close(result, ref, atol=1e-1, rtol=1e-2)
 
     @skipIfMTIA("MTIA backend does not support 3D dot reshape patterns")
     def test_bmm_constrains_batch_block_to_one(self) -> None:
@@ -121,6 +137,18 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         )
         expected = torch.bmm(args[0], args[1])
         torch.testing.assert_close(result, expected, atol=1e-1, rtol=1e-2)
+
+
+@onlyBackends(["pallas"])
+class TestDotRequirementsPallas(RefEagerTestDisabled, TestCase):
+    def test_tpu_min_dot_size_constrains_matmul(self) -> None:
+        """Verify that TPU min_dot_size (8, 128, 128) is applied to matmul block sizes."""
+        args = (
+            torch.randn([1024, 1024], device=DEVICE, dtype=torch.float32),
+            torch.randn([1024, 1024], device=DEVICE, dtype=torch.float32),
+        )
+        spec = _matmul_kernel.bind(args).config_spec
+        self.assertEqual([x.min_size for x in spec.block_sizes], [8, 128, 128])
 
 
 if __name__ == "__main__":

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -108,6 +108,18 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[128, 128, 128],
         )
 
+    def test_matmul_default(self):
+        """Matmul without explicit block_sizes to exercise autotuner defaults."""
+        args = (
+            torch.randn([1024, 1024], device=DEVICE, dtype=torch.float32),
+            torch.randn([1024, 1024], device=DEVICE, dtype=torch.float32),
+        )
+        check_example(
+            "matmul",
+            args,
+            args[0] @ args[1],
+        )
+
     @xfailIfCute("CuTe barrier-based split-K example is still unsupported")
     @xfailIfPallas("missing barrier implementation")
     @skipIfTileIR("PassManager::run failed")

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -258,7 +258,6 @@ class TestViews(RefEagerTestBase, TestCase):
         expected = input_tensor * scale_tensor[0]
         torch.testing.assert_close(result, expected)
 
-    @xfailIfPallas("torch.addmm not supported on pallas")
     def test_reshape_input_types(self):
         @helion.kernel(static_shapes=True)
         def reshape_reduction_dim(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Summary
- Re-land #1731 (reverted in #1740 due to `test_loops.py` crash, which no longer reproduces on the current codebase)
- Set TPU `_min_dot_size` to `(8, 128, 128)` matching the Mosaic MXU tile dimensions (`M>=8, K>=128, N>=128`)
- Restructure device-type checks in `_min_dot_size` to be explicit (`tpu`, `xpu`, `cuda`) instead of fallback-based
- Add `test_matmul_default` to exercise autotuned matmul without hardcoded `block_sizes`
- Clamp `min_dot_size` to tensor dimensions on Pallas backend to prevent blocks exceeding tensor size
- Add `test_matmul_smaller_than_min_dot_size` to verify matmul works when dimensions are smaller than `min_dot_size`
- Add direct regression test verifying `config_spec` min_size constraints are `[8, 128, 128]` on TPU
- Remove `xfail` for `test_reshape_input_types` on Pallas (unblocked by the clamping fix)

## Why correct `min_dot_size` matters for matmul autotuning performance

`_min_dot_size` feeds into `default_config()`, which generates the initial configuration that the autotuner uses as its starting point. It also constrains the autotuner search space via `update_min_block()` in `matmul_ops.py`. With the wrong default `(16, 16, 16)`, the autotuner explores configs with K=16 or N=16 tiles that get zero-padded up to 128 before `pl.dot`, wasting autotuning time on suboptimal candidates.

With `(8, 128, 128)`, the search space is pruned upfront so every trial uses MXU-compatible tiles, improving both autotuning speed and the quality of the resulting configs.

## Clamping for small tensors

When a tensor dimension is smaller than `min_dot_size` (e.g., a 16x16 matmul with min N=128), `update_min_block()` would force the block size to 128 — larger than the tensor. Triton handles this via automatic out-of-bounds masking, but Pallas BlockSpecs can't. The fix clamps `min_size` to `size_hint` (the tensor dimension) on the Pallas backend, letting the dot-level padding in `matmul_utils.py` handle the MXU requirement at codegen time instead.