### PR TITLE
[Pallas] Don't record block_id in dim_map for hl.grid program_id dimensions

### DIFF
--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -226,8 +226,8 @@ def _pallas_index_str(
                         parts.append(expr)
                     else:
                         parts.append(":")
-            if isinstance(idx, torch.SymInt):
-                dim_map.setdefault(tensor_dim, block_id)
+                        if isinstance(idx, torch.SymInt):
+                            dim_map.setdefault(tensor_dim, block_id)
         elif isinstance(idx, int):
             parts.append(str(idx))
         elif isinstance(idx, torch.SymInt):

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -403,6 +403,15 @@ class TestExamples(RefEagerTestBase, TestCase):
             indexing="block_ptr",
         )
 
+    def test_softmax_default(self):
+        """Softmax without explicit config to exercise autotuner defaults."""
+        args = (torch.randn([4096, 2560], device=DEVICE, dtype=torch.float32),)
+        check_example(
+            "softmax",
+            args,
+            torch.nn.functional.softmax(*args, dim=1),
+        )
+
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
     @skipIfTileIR("TileIR does not support block_ptr indexing")
     def test_softmax_looped(self):
@@ -858,6 +867,16 @@ class TestExamples(RefEagerTestBase, TestCase):
             torch.sum(args[0], dim=-1),
             fn_name="sum_kernel",
             block_sizes=[8],
+        )
+
+    def test_sum_default(self):
+        """Sum without explicit config to exercise autotuner defaults."""
+        args = (torch.randn([5120, 2560], device=DEVICE, dtype=torch.float32),)
+        check_example(
+            "sum",
+            args,
+            torch.sum(args[0], dim=-1),
+            fn_name="sum_kernel",
         )
 
     def test_long_sum_manual(self):
@@ -2027,6 +2046,15 @@ class TestExamples(RefEagerTestBase, TestCase):
             args,
             torch.nn.functional.softmax(args[0], dim=-1),
             block_sizes=[8],
+        )
+
+    def test_batch_softmax_default(self):
+        """Batch softmax without explicit config to exercise autotuner defaults."""
+        args = (torch.randn([16, 512, 1024], device=DEVICE, dtype=torch.bfloat16),)
+        check_example(
+            "batch_softmax",
+            args,
+            torch.nn.functional.softmax(args[0], dim=-1),
         )
 
     @xfailIfCute(

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -403,15 +403,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             indexing="block_ptr",
         )
 
-    def test_softmax_default(self):
-        """Softmax without explicit config to exercise autotuner defaults."""
-        args = (torch.randn([4096, 2560], device=DEVICE, dtype=torch.float32),)
-        check_example(
-            "softmax",
-            args,
-            torch.nn.functional.softmax(*args, dim=1),
-        )
-
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
     @skipIfTileIR("TileIR does not support block_ptr indexing")
     def test_softmax_looped(self):
@@ -867,16 +858,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             torch.sum(args[0], dim=-1),
             fn_name="sum_kernel",
             block_sizes=[8],
-        )
-
-    def test_sum_default(self):
-        """Sum without explicit config to exercise autotuner defaults."""
-        args = (torch.randn([5120, 2560], device=DEVICE, dtype=torch.float32),)
-        check_example(
-            "sum",
-            args,
-            torch.sum(args[0], dim=-1),
-            fn_name="sum_kernel",
         )
 
     def test_long_sum_manual(self):
@@ -2046,15 +2027,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             args,
             torch.nn.functional.softmax(args[0], dim=-1),
             block_sizes=[8],
-        )
-
-    def test_batch_softmax_default(self):
-        """Batch softmax without explicit config to exercise autotuner defaults."""
-        args = (torch.randn([16, 512, 1024], device=DEVICE, dtype=torch.bfloat16),)
-        check_example(
-            "batch_softmax",
-            args,
-            torch.nn.functional.softmax(args[0], dim=-1),
         )
 
     @xfailIfCute(

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -120,7 +120,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         )
         torch.testing.assert_close(result, grid_2d_pytorch(args[0], args[1]))
 
-    @xfailIfPallas("2D nested grids not working correctly Pallas")
     def test_grid_2d_idx_nested(self):
         @helion.kernel(static_shapes=True)
         def grid_2d_idx_nested(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -615,9 +615,26 @@ class TestPallas(TestCase):
             return out
 
         x = torch.randn(128, device=DEVICE, dtype=torch.float32)
-        result = fn(x)
+        # Patch _no_tiling_block_spec_info to detect if the fallback is
+        # triggered.  hl.grid() dims use pl.program_id() and must NOT
+        # record a block_id in pallas_tensor_dim_block_ids — otherwise
+        # _compute_block_spec_info attempts tiling with bs=1, fails TPU
+        # alignment, and falls back here.
+        from unittest.mock import patch
+
+        from helion._compiler.backend import PallasBackend
+
+        with patch.object(
+            PallasBackend,
+            "_no_tiling_block_spec_info",
+            side_effect=AssertionError(
+                "hl.grid dims should not trigger _no_tiling_block_spec_info"
+            ),
+        ):
+            code, result = code_and_output(fn, (x,))
         expected = x + 0.5
         torch.testing.assert_close(result, expected)
+        self.assertIn("pl.program_id", code)
 
     def test_scalar_access_hl_grid_offset(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True, config=helion.Config())


### PR DESCRIPTION
## Background

While investigating when `_no_tiling_block_spec_info` (the fallback for untileable dims) actually gets triggered, we found that `hl.grid()` scalar accesses were incorrectly recording block_ids in `pallas_tensor_dim_block_ids`, causing the fallback to fire unnecessarily.

## Summary
- Fix `_pallas_index_str` to only record `dim_map` entries for dimensions that emit `:` (BlockSpec-tiled), not for `pl.program_id()` (scalar grid access) dimensions
- Previously, `hl.grid()` scalar accesses would record a block_id in `pallas_tensor_dim_block_ids`. `_compute_block_spec_info` would then see this block_id, look up its block size from the config (which is 1 for `hl.grid`), and fail the TPU alignment check (`1 % 128 != 0`), triggering the `_no_tiling_block_spec_info` fallback
- Add regression test that patches `_no_tiling_block_spec_info` to raise if called during `test_scalar_access_hl_grid`, ensuring this codepath is not triggered for `hl.grid()` dims