### PR TITLE
[Autotuner] Adding LLM-guided search

### DIFF
--- a/helion/autotuner/__init__.py
+++ b/helion/autotuner/__init__.py
@@ -15,11 +15,13 @@ from .differential_evolution import (
 )
 from .effort_profile import AutotuneEffortProfile as AutotuneEffortProfile
 from .effort_profile import DifferentialEvolutionConfig as DifferentialEvolutionConfig
+from .effort_profile import LLMSearchConfig as LLMSearchConfig
 from .effort_profile import PatternSearchConfig as PatternSearchConfig
 from .effort_profile import RandomSearchConfig as RandomSearchConfig
 from .external import UserConfigSpec as UserConfigSpec
 from .external import autotune as autotune
 from .finite_search import FiniteSearch as FiniteSearch
+from .llm_search import LLMGuidedSearch as LLMGuidedSearch
 from .local_cache import LocalAutotuneCache as LocalAutotuneCache
 from .local_cache import StrictLocalAutotuneCache as StrictLocalAutotuneCache
 from .pattern_search import InitialPopulationStrategy as InitialPopulationStrategy
@@ -35,6 +37,7 @@ search_algorithms: dict[str, type[BaseSearch]] = {
     "DESurrogateHybrid": DESurrogateHybrid,
     "LFBOPatternSearch": LFBOPatternSearch,
     "LFBOTreeSearch": LFBOTreeSearch,
+    "LLMGuidedSearch": LLMGuidedSearch,
     "DifferentialEvolutionSearch": DifferentialEvolutionSearch,
     "FiniteSearch": FiniteSearch,
     "PatternSearch": PatternSearch,

--- a/helion/autotuner/effort_profile.py
+++ b/helion/autotuner/effort_profile.py
@@ -10,6 +10,7 @@ DEFAULT_LLM_MODEL = "gpt-5-2"
 DEFAULT_LLM_CONFIGS_PER_ROUND = 15
 DEFAULT_LLM_MAX_ROUNDS = 4
 DEFAULT_LLM_INITIAL_RANDOM_CONFIGS = 10
+DEFAULT_LLM_COMPILE_TIMEOUT_S: int | None = 15
 
 
 @dataclass(frozen=True)
@@ -44,6 +45,7 @@ class LLMSearchConfig:
     configs_per_round: int = DEFAULT_LLM_CONFIGS_PER_ROUND
     max_rounds: int = DEFAULT_LLM_MAX_ROUNDS
     initial_random_configs: int = DEFAULT_LLM_INITIAL_RANDOM_CONFIGS
+    compile_timeout_s: int | None = DEFAULT_LLM_COMPILE_TIMEOUT_S
 
 
 # Default values for each algorithm (single source of truth)

--- a/helion/autotuner/effort_profile.py
+++ b/helion/autotuner/effort_profile.py
@@ -6,6 +6,11 @@ from typing import Literal
 AutotuneEffort = Literal["none", "quick", "full"]
 InitialPopulation = Literal["from_random", "from_best_available"]
 
+DEFAULT_LLM_MODEL = "gpt-5-2"
+DEFAULT_LLM_CONFIGS_PER_ROUND = 15
+DEFAULT_LLM_MAX_ROUNDS = 4
+DEFAULT_LLM_INITIAL_RANDOM_CONFIGS = 10
+
 
 @dataclass(frozen=True)
 class PatternSearchConfig:
@@ -33,6 +38,14 @@ class RandomSearchConfig:
     count: int
 
 
+@dataclass(frozen=True)
+class LLMSearchConfig:
+    model: str = DEFAULT_LLM_MODEL
+    configs_per_round: int = DEFAULT_LLM_CONFIGS_PER_ROUND
+    max_rounds: int = DEFAULT_LLM_MAX_ROUNDS
+    initial_random_configs: int = DEFAULT_LLM_INITIAL_RANDOM_CONFIGS
+
+
 # Default values for each algorithm (single source of truth)
 PATTERN_SEARCH_DEFAULTS = PatternSearchConfig(
     initial_population=100,
@@ -49,6 +62,14 @@ RANDOM_SEARCH_DEFAULTS = RandomSearchConfig(
     count=1000,
 )
 
+# Full guided-search defaults used by direct LLMGuidedSearch construction.
+LLM_SEARCH_DEFAULTS = LLMSearchConfig()
+
+# Quick LLM preset used by the quick effort profile and the hybrid seed stage.
+QUICK_LLM_SEARCH_DEFAULTS = LLMSearchConfig(
+    max_rounds=1,
+)
+
 
 @dataclass(frozen=True)
 class AutotuneEffortProfile:
@@ -56,6 +77,7 @@ class AutotuneEffortProfile:
     lfbo_pattern_search: PatternSearchConfig | None
     differential_evolution: DifferentialEvolutionConfig | None
     random_search: RandomSearchConfig | None
+    llm_search: LLMSearchConfig | None = None
     finishing_rounds: int = 0
     rebenchmark_threshold: float = 1.5
 
@@ -91,6 +113,7 @@ _PROFILES: dict[AutotuneEffort, AutotuneEffortProfile] = {
         random_search=RandomSearchConfig(
             count=100,
         ),
+        llm_search=QUICK_LLM_SEARCH_DEFAULTS,
         finishing_rounds=0,
         rebenchmark_threshold=0.9,  # <1.0 effectively disables rebenchmarking
     ),
@@ -99,6 +122,7 @@ _PROFILES: dict[AutotuneEffort, AutotuneEffortProfile] = {
         lfbo_pattern_search=PATTERN_SEARCH_DEFAULTS,
         differential_evolution=DIFFERENTIAL_EVOLUTION_DEFAULTS,
         random_search=RANDOM_SEARCH_DEFAULTS,
+        llm_search=LLM_SEARCH_DEFAULTS,
     ),
 }
 

--- a/helion/autotuner/llm/__init__.py
+++ b/helion/autotuner/llm/__init__.py
@@ -1,0 +1,3 @@
+"""Support modules for Helion's LLM-backed autotuners."""
+
+from __future__ import annotations

--- a/helion/autotuner/llm/configs.py
+++ b/helion/autotuner/llm/configs.py
@@ -1,0 +1,161 @@
+"""Normalize and validate autotune configs proposed by the LLM."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import cast
+
+from .parsing import parse_jsonish
+
+if TYPE_CHECKING:
+    from ...runtime.config import Config
+    from ..config_fragment import ConfigSpecFragment
+    from ..config_spec import ConfigSpec
+    from ..logger import AutotuningLogger
+
+
+def is_positive_power_of_two_int(val: object) -> bool:
+    """Return whether `val` is a strictly positive power-of-two integer."""
+    return type(val) is int and val > 0 and (val & (val - 1)) == 0
+
+
+def _expected_json_array_length(field: object) -> int | None:
+    """Return the required JSON array length for fixed-length sequence fields."""
+    from ..block_id_sequence import BlockIdSequence
+    from ..config_fragment import ListOf
+
+    if isinstance(field, BlockIdSequence):
+        return len(field)
+    if isinstance(field, ListOf):
+        return field.length
+    return None
+
+
+def _validate_json_array_length(key: str, val: object, *, expected_len: int) -> None:
+    """Validate that a JSON value is a list with the expected fixed length."""
+    if not isinstance(val, list):
+        raise ValueError(
+            f"{key} must be a JSON array of length {expected_len}, got {val!r}"
+        )
+    if len(val) != expected_len:
+        raise ValueError(f"{key} must have length {expected_len}, got {len(val)}")
+
+
+def validate_sparse_config_shape(
+    raw: dict[str, object], *, config_spec: ConfigSpec
+) -> None:
+    """Reject common LLM shape/type mismatches instead of silently repairing them."""
+    flat_fields = config_spec._flat_fields()
+    for key, val in raw.items():
+        field = flat_fields.get(key)
+        if key == "num_warps" and not is_positive_power_of_two_int(val):
+            raise ValueError(
+                f"num_warps must be a positive power-of-two integer, got {val!r}"
+            )
+
+        if (expected_len := _expected_json_array_length(field)) is not None:
+            _validate_json_array_length(key, val, expected_len=expected_len)
+            continue
+
+        if field is not None and isinstance(val, list):
+            raise ValueError(f"{key} must be a scalar value, got {val!r}")
+
+
+def parse_response_configs(
+    response: str,
+    *,
+    config_spec: ConfigSpec,
+    default_config_dict: dict[str, object],
+    log: AutotuningLogger,
+) -> list[Config]:
+    """Parse, validate, normalize, and deduplicate configs from an LLM response."""
+    import helion
+
+    parsed = parse_jsonish(response)
+    raw_configs: object | None = None
+    if isinstance(parsed, dict):
+        raw_configs = parsed.get("configs")
+    elif isinstance(parsed, list):
+        raw_configs = parsed
+
+    if not isinstance(raw_configs, list):
+        log.warning("Failed to parse LLM response as a config list")
+        return []
+
+    configs: list[Config] = []
+    seen: set[str] = set()
+    for index, raw in enumerate(raw_configs):
+        if not isinstance(raw, dict):
+            log.debug(f"Skipping non-dict config at index {index}")
+            continue
+        try:
+            validate_sparse_config_shape(raw, config_spec=config_spec)
+            merged = dict(default_config_dict)
+            merged.update(raw)
+            config_spec.normalize(merged, _fix_invalid=True)
+            config = helion.Config(**cast("dict[str, Any]", merged))
+        except Exception as e:
+            log.debug(f"Skipping invalid config {index}: {e}")
+            continue
+
+        config_key = repr(config)
+        if config_key in seen:
+            continue
+        seen.add(config_key)
+        configs.append(config)
+
+    log(f"Parsed {len(configs)} valid configs from LLM response")
+    return configs
+
+
+def describe_config_space(config_spec: ConfigSpec) -> str:
+    """Build a human-readable description of the tunable config space."""
+    from ..block_id_sequence import BlockIdSequence
+    from ..config_fragment import ListOf
+
+    lines: list[str] = []
+    for key, field in config_spec._flat_fields().items():
+        if isinstance(field, BlockIdSequence):
+            items: list[str] = []
+            for item in field:
+                try:
+                    frag = item._fragment(config_spec)
+                except NotImplementedError:
+                    continue
+                items.append(describe_fragment(frag))
+            if not items:
+                continue
+            if len(items) == 1:
+                lines.append(f"  {key}: list of 1 x {items[0]}")
+            else:
+                lines.append(f"  {key}: [{', '.join(items)}]")
+        elif isinstance(field, ListOf):
+            lines.append(
+                f"  {key}: list of {field.length} x {describe_fragment(field.inner)}"
+            )
+        else:
+            lines.append(f"  {key}: {describe_fragment(field)}")
+    return "\n".join(lines)
+
+
+def describe_fragment(frag: ConfigSpecFragment) -> str:
+    """Generate a human-readable description of a config fragment."""
+    from ..config_fragment import BooleanFragment
+    from ..config_fragment import EnumFragment
+    from ..config_fragment import IntegerFragment
+    from ..config_fragment import PermutationFragment
+    from ..config_fragment import PowerOfTwoFragment
+
+    if isinstance(frag, PowerOfTwoFragment):
+        return f"power_of_2(min={frag.low}, max={frag.high}, default={frag.default()})"
+    if isinstance(frag, IntegerFragment):
+        return f"integer(min={frag.low}, max={frag.high}, default={frag.default()})"
+    if isinstance(frag, EnumFragment):
+        choices_str = ", ".join(repr(choice) for choice in frag.choices)
+        return f"enum({choices_str})"
+    if isinstance(frag, BooleanFragment):
+        return "boolean(default=False)"
+    if isinstance(frag, PermutationFragment):
+        return f"permutation(length={frag.length})"
+    return f"{type(frag).__name__}()"

--- a/helion/autotuner/llm/feedback.py
+++ b/helion/autotuner/llm/feedback.py
@@ -1,0 +1,219 @@
+"""Format benchmark results into compact feedback for LLM prompts."""
+
+from __future__ import annotations
+
+import collections
+import json
+import math
+import operator
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ...runtime.config import Config
+    from ..base_search import BenchmarkResult
+
+
+MAX_RESULTS_IN_PROMPT = 12
+MAX_ANCHORS_IN_PROMPT = 2
+MAX_CHANGED_FIELDS_PER_CONFIG = 6
+
+
+def format_config_for_prompt(cfg: Config | dict[str, object]) -> str:
+    """Serialize a config exactly as it should appear in prompt examples."""
+    return json.dumps(dict(cfg), sort_keys=True, separators=(",", ":"))
+
+
+def config_diff(
+    default_config_dict: dict[str, object], cfg: Config
+) -> dict[str, object]:
+    """Drop unchanged defaults so feedback focuses on meaningful tunables."""
+    config_dict = dict(cfg)
+    diff = {
+        key: value
+        for key, value in config_dict.items()
+        if key not in default_config_dict or value != default_config_dict[key]
+    }
+    if not diff:
+        return {"(default)": True}
+    return diff
+
+
+def format_config_diff(default_config_dict: dict[str, object], cfg: Config) -> str:
+    """Format only the changed fields as compact JSON."""
+    return json.dumps(config_diff(default_config_dict, cfg), sort_keys=True)
+
+
+def finite_results(results: list[BenchmarkResult]) -> list[tuple[Config, float]]:
+    """Return successful benchmark results sorted from fastest to slowest."""
+    return sorted(
+        [
+            (result.config, result.perf)
+            for result in results
+            if math.isfinite(result.perf)
+        ],
+        key=operator.itemgetter(1),
+    )
+
+
+def failed_benchmark_results(results: list[BenchmarkResult]) -> list[BenchmarkResult]:
+    """Return configs that failed or produced non-finite perf values."""
+    return [
+        result
+        for result in results
+        if result.status in {"error", "timeout", "peer_compilation_fail"}
+        or not math.isfinite(result.perf)
+    ]
+
+
+def format_results_for_llm(
+    results: list[BenchmarkResult],
+    default_config_dict: dict[str, object],
+    *,
+    limit: int = MAX_RESULTS_IN_PROMPT,
+) -> str:
+    """Format successful and failed benchmark results into a compact block."""
+    if not results:
+        return "No results yet."
+
+    sorted_results = finite_results(results)
+    failed_count = len(failed_benchmark_results(results))
+
+    lines: list[str] = []
+    for index, (cfg, perf) in enumerate(sorted_results[:limit], start=1):
+        lines.append(
+            f"  #{index}: {perf:.4f} ms — "
+            f"{format_config_diff(default_config_dict, cfg)}"
+        )
+    if failed_count > 0:
+        lines.append(f"  ({failed_count} configs failed to compile or had errors)")
+    return "\n".join(lines)
+
+
+def summarize_search_state_for_llm(
+    results: list[BenchmarkResult],
+    default_config_dict: dict[str, object],
+) -> str:
+    """Summarize the current best result, coverage, and failure counts."""
+    finite = finite_results(results)
+    if not finite:
+        return "  No successful configs yet."
+
+    best_cfg, best_perf = finite[0]
+    lines = [
+        (
+            f"  Best so far: {best_perf:.4f} ms — "
+            f"{format_config_diff(default_config_dict, best_cfg)}"
+        )
+    ]
+    if len(finite) >= 2 and finite[1][1] > 0:
+        gap_pct = ((finite[1][1] - best_perf) / finite[1][1]) * 100
+        lines.append(f"  Margin vs runner-up: {gap_pct:.1f}%")
+    failed_count = len(failed_benchmark_results(results))
+    if results:
+        lines.append(
+            f"  Search coverage: {len(finite)} successful / "
+            f"{len(results)} total configs"
+        )
+    if failed_count > 0:
+        lines.append(f"  Failed configs so far: {failed_count}")
+    return "\n".join(lines)
+
+
+def summarize_failed_configs_for_llm(
+    results: list[BenchmarkResult],
+    default_config_dict: dict[str, object],
+) -> str:
+    """Show a small sample of failed configs so the next round can avoid them."""
+    failed = failed_benchmark_results(results)
+    if not failed:
+        return "  No failed configs yet."
+
+    counts = collections.Counter(
+        "timeout" if result.status == "timeout" else "error" for result in failed
+    )
+    count_summary = ", ".join(
+        f"{label}={counts[label]}" for label in ("error", "timeout") if counts[label]
+    )
+    lines = [f"  Counts: {count_summary}"]
+
+    seen: set[str] = set()
+    for result in failed:
+        label = "timeout" if result.status == "timeout" else "error"
+        diff_text = format_config_diff(default_config_dict, result.config)
+        key = f"{label}:{diff_text}"
+        if key in seen:
+            continue
+        seen.add(key)
+        lines.append(f"  {label}: {diff_text}")
+        if len(lines) >= 5:
+            break
+    return "\n".join(lines)
+
+
+def summarize_anchor_configs_for_llm(
+    results: list[BenchmarkResult],
+    default_config_dict: dict[str, object],
+    *,
+    limit: int = MAX_ANCHORS_IN_PROMPT,
+) -> str:
+    """Show the strongest current configs that the next round should refine."""
+    finite = finite_results(results)
+    if not finite:
+        return "  No successful configs yet."
+
+    best_perf = finite[0][1]
+    lines: list[str] = []
+    for index, (cfg, perf) in enumerate(finite[:limit], start=1):
+        if index == 1 or best_perf <= 0:
+            delta = "best"
+        else:
+            gap_pct = ((perf - best_perf) / best_perf) * 100
+            delta = f"+{gap_pct:.1f}%"
+        lines.append(
+            f"  Anchor {index} ({delta}): {perf:.4f} ms — "
+            f"{format_config_diff(default_config_dict, cfg)}"
+        )
+    return "\n".join(lines)
+
+
+def analyze_top_configs(
+    results: list[BenchmarkResult],
+    default_config_dict: dict[str, object],
+) -> str:
+    """Highlight which field values repeat across the best configs so far."""
+    finite = finite_results(results)
+    if len(finite) < 3:
+        return "Not enough results for analysis yet."
+
+    top = [
+        {
+            key: value
+            for key, value in config_diff(default_config_dict, cfg).items()
+            if key != "(default)"
+        }
+        for cfg, _ in finite[:5]
+    ]
+    all_keys = sorted({key for cfg in top for key in cfg})
+    if not all_keys:
+        return "Top configs are all close to the default config."
+
+    lines: list[str] = []
+    for key in all_keys:
+        values = [cfg.get(key) for cfg in top if key in cfg]
+        if not values:
+            continue
+        encoded = [
+            json.dumps(value, sort_keys=True, separators=(",", ":")) for value in values
+        ]
+        counts = collections.Counter(encoded)
+        common = counts.most_common(2)
+        if len(common) == 1:
+            lines.append(f"  {key}: always {common[0][0]}")
+        elif common[0][1] >= 3:
+            lines.append(
+                f"  {key}: mostly {common[0][0]} (also {common[1][0]} x{common[1][1]})"
+            )
+        else:
+            summary = ", ".join(f"{value} x{count}" for value, count in common)
+            lines.append(f"  {key}: {summary}")
+    return "\n".join(lines) or "No clear patterns yet."

--- a/helion/autotuner/llm/parsing.py
+++ b/helion/autotuner/llm/parsing.py
@@ -1,0 +1,74 @@
+"""Extract JSON config payloads from raw LLM responses."""
+
+from __future__ import annotations
+
+import json
+import re
+
+
+def fix_python_json(text: str) -> str:
+    """Normalize Python literals in LLM output to valid JSON literals."""
+    text = re.sub(r"\bNone\b", "null", text)
+    text = re.sub(r"\bTrue\b", "true", text)
+    return re.sub(r"\bFalse\b", "false", text)
+
+
+def extract_balanced_block(text: str, opener: str, closer: str) -> str | None:
+    """Extract the first balanced JSON-like block, respecting quoted strings."""
+
+    start = text.find(opener)
+    while start != -1:
+        depth = 0
+        in_string = False
+        escaped = False
+        for index in range(start, len(text)):
+            char = text[index]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+                continue
+            if char == '"':
+                in_string = True
+                continue
+            if char == opener:
+                depth += 1
+            elif char == closer:
+                depth -= 1
+                if depth == 0:
+                    return text[start : index + 1]
+        start = text.find(opener, start + 1)
+    return None
+
+
+def iter_jsonish_candidates(text: str) -> list[str]:
+    """Yield likely JSON-ish substrings from raw LLM output."""
+
+    candidates: list[str] = []
+    stripped = text.strip()
+    if stripped:
+        candidates.append(stripped)
+    for match in re.finditer(
+        r"```(?:json|python)?\s*([\s\S]*?)```", text, re.IGNORECASE
+    ):
+        candidate = match.group(1).strip()
+        if candidate:
+            candidates.append(candidate)
+    for opener, closer in (("{", "}"), ("[", "]")):
+        if candidate := extract_balanced_block(text, opener, closer):
+            candidates.append(candidate.strip())
+    return list(dict.fromkeys(candidates))
+
+
+def parse_jsonish(text: str) -> object | None:
+    """Parse JSON output with light extraction from wrapped LLM responses."""
+
+    for candidate in iter_jsonish_candidates(fix_python_json(text)):
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+    return None

--- a/helion/autotuner/llm/prompting.py
+++ b/helion/autotuner/llm/prompting.py
@@ -25,71 +25,100 @@ SHAPE_RULE = (
     "array of the exact required length; if that length is unclear, omit the "
     "field."
 )
+_ADVANCED_TOGGLE_FIELDS = (
+    "range_warp_specializes",
+    "range_multi_buffers",
+    "range_flattens",
+)
+_INITIAL_STRATEGY_BASE_LINES = (
+    "First analyze the kernel source, input tensors, GPU hardware, and config space.",
+    "Cover 3 config families with a rough mix of about 40% near-default safe, 40% balanced throughput, and 20% aggressive configs, while keeping most candidates valid and compilable.",
+    "If the kernel structure is unclear, stay closer to default and avoid aggressive coupled changes.",
+    (
+        "Keep each config sparse: usually 2-6 changed fields, omit unchanged defaults, "
+        "and exceed 6 only when several coupled changes are needed for a distinct family."
+    ),
+    "Use block_sizes to define families: include at least 3 materially different tiling families instead of tiny perturbations of one tile.",
+    "Vary block_sizes coherently across dimensions rather than by arbitrary skew.",
+    SHAPE_RULE,
+    "Do not pretty-print or repeat unchanged defaults.",
+    "Avoid configs that simultaneously max out several aggressive knobs such as num_warps, num_stages, and maxnreg when present, unless strongly justified.",
+)
+_FAILURE_HEAVY_REFINEMENT_LINES = (
+    "Recent rounds had many failures. Use only the best 1-2 anchors.",
+    "At least 80% of configs should be 1-2 field mutations of those anchors.",
+    "Back off aggressive settings first: smaller num_stages/num_warps, pointer indexing, fewer advanced toggles.",
+)
+_DEFAULT_REFINEMENT_LINES = (
+    "About two thirds of configs should be 1-field mutations of Anchor 1.",
+    "Use most of the rest for 1-2 field mutations of Anchor 2.",
+    "Reserve at most a small minority for one clearly different family, not random noise.",
+)
+_SYSTEM_PROMPT = textwrap.dedent("""\
+    You are an expert GPU kernel autotuner for Helion/Triton kernels.
+
+    Use the provided Configuration Space and Default Configuration as the source of truth for:
+    - allowed field names and enum values
+    - which fields are scalar vs list-valued
+    - required list lengths
+    - valid ranges and defaults
+
+    Key knobs:
+    - block_sizes: per-dimension tile sizes. Good families usually change them coherently. For kernels with an inner or reduction dimension, very small values there are a separate aggressive family, not the default.
+    - num_warps: threads/32. 4-8 is typical; 16+ is mainly for clearly larger tiles.
+    - num_stages: pipeline depth. 2-4 is common for streaming loops; 1 is safer when unsure.
+    - pid_type: flat, persistent_blocked, and persistent_interleaved are distinct scheduling families when available.
+    - indexing: pointer and tensor_descriptor are distinct families.
+    - l2_groupings, maxnreg, num_sm_multiplier, and advanced range toggles are secondary knobs; change them selectively after choosing a coherent tiling family.
+
+    General heuristics:
+    - analyze the kernel source, input tensors, GPU hardware, and config space to infer likely optimization traits from the code itself and target hardware; if unsure, stay closer to default.
+    - block_sizes and num_warps should be powers of 2 when present.
+    - persistent pid_type is often worth trying when total tile count is comparable to or larger than SM count, and it may also be required for some kernels.
+    - tensor_descriptor is a distinct family from pointer indexing.
+    - higher num_stages and multi-buffering are more aggressive and should be used selectively.
+
+    Output contract:
+    - Return minified JSON on a single line. No markdown, code fences, comments, pretty-printing, or trailing commas.
+    - Emit exactly one top-level object: {"configs":[...]} and make every config unique.
+    - Do not use Python syntax or expressions such as single-quoted strings or list multiplication like ["pointer"] * 4.
+    - Only specify fields you want to change; unspecified = default.
+    - Use only field names and enum values that appear in the config space.
+    - For list-valued fields, emit an explicit JSON array with the exact required length shown in the config space.
+    - Never use a scalar as shorthand for a list-valued field, and never wrap scalar-valued fields in single-element lists.
+    - If you are unsure about a field's structure, required list length, or allowed values, omit that field instead of guessing.
+    - Use null not None, true/false not True/False.
+    - Return ONLY minified JSON: {"configs":[...]}""")
 
 
-def build_system_prompt() -> str:
-    """Return the global instruction block shared by every LLM request."""
-    return textwrap.dedent("""\
-        You are an expert GPU kernel autotuner for Helion/Triton kernels.
-
-        Use the provided Configuration Space and Default Configuration as the source of truth for:
-        - allowed field names and enum values
-        - which fields are scalar vs list-valued
-        - required list lengths
-        - valid ranges and defaults
-
-        Key knobs:
-        - block_sizes: per-dimension tile sizes. Good families usually change them coherently. For kernels with an inner or reduction dimension, very small values there are a separate aggressive family, not the default.
-        - num_warps: threads/32. 4-8 is typical; 16+ is mainly for clearly larger tiles.
-        - num_stages: pipeline depth. 2-4 is common for streaming loops; 1 is safer when unsure.
-        - pid_type: flat, persistent_blocked, and persistent_interleaved are distinct scheduling families when available.
-        - indexing: pointer and tensor_descriptor are distinct families.
-        - l2_groupings, maxnreg, num_sm_multiplier, and advanced range toggles are secondary knobs; change them selectively after choosing a coherent tiling family.
-
-        General heuristics:
-        - analyze the kernel source, input tensors, GPU hardware, and config space to infer likely optimization traits from the code itself and target hardware; if unsure, stay closer to default.
-        - block_sizes and num_warps should be powers of 2 when present.
-        - persistent pid_type is often worth trying when total tile count is comparable to or larger than SM count, and it may also be required for some kernels.
-        - tensor_descriptor is a distinct family from pointer indexing.
-        - higher num_stages and multi-buffering are more aggressive and should be used selectively.
-
-        Output contract:
-        - Return minified JSON on a single line. No markdown, code fences, comments, pretty-printing, or trailing commas.
-        - Emit exactly one top-level object: {"configs":[...]} and make every config unique.
-        - Do not use Python syntax or expressions such as single-quoted strings or list multiplication like ["pointer"] * 4.
-        - Only specify fields you want to change; unspecified = default.
-        - Use only field names and enum values that appear in the config space.
-        - For list-valued fields, emit an explicit JSON array with the exact required length shown in the config space.
-        - Never use a scalar as shorthand for a list-valued field, and never wrap scalar-valued fields in single-element lists.
-        - If you are unsure about a field's structure, required list length, or allowed values, omit that field instead of guessing.
-        - Use null not None, true/false not True/False.
-        - Return ONLY minified JSON: {"configs":[...]}""")
+def _section(title: str, body: str) -> str:
+    """Render a titled prompt section."""
+    return f"## {title}\n{body}"
 
 
-def build_initial_search_guidance(
+def _bullet_section(title: str, lines: Sequence[str]) -> str:
+    """Render a titled prompt section whose body is a bullet list."""
+    return _section(title, "\n".join(f"  - {line}" for line in lines))
+
+
+def _join_sections(*sections: str) -> str:
+    """Join non-empty prompt sections with a blank line."""
+    return "\n\n".join(section for section in sections if section)
+
+
+def _initial_strategy_lines(
     *,
     configs_per_round: int,
     compile_timeout_s: int | None,
     flat_fields: Mapping[str, object],
-) -> str:
-    """Build the search-strategy section of the initial prompt."""
+) -> list[str]:
+    """Build the bullet list used for the initial search-strategy section."""
     lines = [
         (
             f"Generate up to {configs_per_round} UNIQUE candidate configs. "
             "Fewer is better than invalid JSON."
         ),
-        "First analyze the kernel source, input tensors, GPU hardware, and config space.",
-        "Cover 3 config families with a rough mix of about 40% near-default safe, 40% balanced throughput, and 20% aggressive configs, while keeping most candidates valid and compilable.",
-        "If the kernel structure is unclear, stay closer to default and avoid aggressive coupled changes.",
-        (
-            "Keep each config sparse: usually 2-6 changed fields, omit unchanged defaults, "
-            "and exceed 6 only when several coupled changes are needed for a distinct family."
-        ),
-        "Use block_sizes to define families: include at least 3 materially different tiling families instead of tiny perturbations of one tile.",
-        "Vary block_sizes coherently across dimensions rather than by arbitrary skew.",
-        SHAPE_RULE,
-        "Do not pretty-print or repeat unchanged defaults.",
-        "Avoid configs that simultaneously max out several aggressive knobs such as num_warps, num_stages, and maxnreg when present, unless strongly justified.",
+        *_INITIAL_STRATEGY_BASE_LINES,
     ]
     if compile_timeout_s is not None:
         lines.append(
@@ -107,18 +136,62 @@ def build_initial_search_guidance(
         lines.append(
             "This is reduction-like: keep most configs conservative and avoid very large block_sizes or maxed num_warps/num_stages."
         )
-    if any(
-        name in flat_fields
-        for name in (
-            "range_warp_specializes",
-            "range_multi_buffers",
-            "range_flattens",
-        )
-    ):
+    if any(name in flat_fields for name in _ADVANCED_TOGGLE_FIELDS):
         lines.append(
             "Use advanced toggles like warp_specialize, multi_buffer, and flatten in only a minority of otherwise sane configs."
         )
-    return "## Search Strategy\n" + "\n".join(f"  - {line}" for line in lines)
+    return lines
+
+
+def _refinement_strategy_lines(
+    *,
+    compile_timeout_s: int | None,
+    failed_count: int,
+    total_count: int,
+) -> list[str]:
+    """Build the bullet list used for the refinement-step section."""
+    if total_count > 0 and failed_count * 3 >= total_count:
+        lines = list(_FAILURE_HEAVY_REFINEMENT_LINES)
+    else:
+        lines = list(_DEFAULT_REFINEMENT_LINES)
+    lines.append(
+        "Prefer edits with attributable effects: change block_sizes, num_warps, num_stages, pid_type, indexing, l2_groupings, or maxnreg instead of rewriting every field."
+    )
+    lines.append(
+        "Keep each config sparse: usually 1-4 changed fields, and no more than "
+        f"{MAX_CHANGED_FIELDS_PER_CONFIG} unless absolutely necessary."
+    )
+    lines.append(SHAPE_RULE)
+    if compile_timeout_s is not None:
+        lines.append(
+            f"Keep compile cost in mind: avoid candidates that are likely to exceed the {compile_timeout_s}s compile timeout."
+        )
+    lines.append(
+        "If unsure, return fewer valid configs instead of verbose or malformed JSON."
+    )
+    return lines
+
+
+def build_system_prompt() -> str:
+    """Return the global instruction block shared by every LLM request."""
+    return _SYSTEM_PROMPT
+
+
+def build_initial_search_guidance(
+    *,
+    configs_per_round: int,
+    compile_timeout_s: int | None,
+    flat_fields: Mapping[str, object],
+) -> str:
+    """Build the search-strategy section of the initial prompt."""
+    return _bullet_section(
+        "Search Strategy",
+        _initial_strategy_lines(
+            configs_per_round=configs_per_round,
+            compile_timeout_s=compile_timeout_s,
+            flat_fields=flat_fields,
+        ),
+    )
 
 
 def build_initial_prompt(
@@ -140,16 +213,20 @@ def build_initial_prompt(
         compile_timeout_s=compile_timeout_s,
         flat_fields=config_spec._flat_fields(),
     )
-    return (
-        f"{describe_kernel(kernel, args)}\n\n"
-        f"## Configuration Space\n{describe_config_space(config_spec)}\n\n"
-        f"## Default Configuration\n"
-        f"{format_config_for_prompt(default_config)}"
-        f"{workload_hints}\n\n"
-        f"{guidance}\n\n"
-        "## Task\n"
+    default_section = (
+        _section("Default Configuration", format_config_for_prompt(default_config))
+        + workload_hints
+    )
+    task_section = (
         "Suggest the first batch of configs. Include both near-default and exploratory candidates. "
         f"{RETURN_JSON_ONLY}"
+    )
+    return _join_sections(
+        describe_kernel(kernel, args),
+        _section("Configuration Space", describe_config_space(config_spec)),
+        default_section,
+        guidance,
+        _section("Task", task_section),
     )
 
 
@@ -166,42 +243,24 @@ def build_refinement_prompt(
     failed_patterns: str,
 ) -> str:
     """Build the refinement prompt sent after each benchmarking round."""
-    if total_count > 0 and failed_count * 3 >= total_count:
-        strategy_lines = [
-            "Recent rounds had many failures. Use only the best 1-2 anchors.",
-            "At least 80% of configs should be 1-2 field mutations of those anchors.",
-            "Back off aggressive settings first: smaller num_stages/num_warps, pointer indexing, fewer advanced toggles.",
-        ]
-    else:
-        strategy_lines = [
-            "About two thirds of configs should be 1-field mutations of Anchor 1.",
-            "Use most of the rest for 1-2 field mutations of Anchor 2.",
-            "Reserve at most a small minority for one clearly different family, not random noise.",
-        ]
-    strategy_lines.append(
-        "Prefer edits with attributable effects: change block_sizes, num_warps, num_stages, pid_type, indexing, l2_groupings, or maxnreg instead of rewriting every field."
-    )
-    strategy_lines.append(
-        "Keep each config sparse: usually 1-4 changed fields, and no more than "
-        f"{MAX_CHANGED_FIELDS_PER_CONFIG} unless absolutely necessary."
-    )
-    strategy_lines.append(SHAPE_RULE)
-    if compile_timeout_s is not None:
-        strategy_lines.append(
-            f"Keep compile cost in mind: avoid candidates that are likely to exceed the {compile_timeout_s}s compile timeout."
-        )
-    strategy_lines.append(
-        "If unsure, return fewer valid configs instead of verbose or malformed JSON."
-    )
-    return (
-        f"## Search State\n{search_state}\n\n"
-        f"## Anchor Configs\n{anchor_configs}\n\n"
-        f"## Results (best first)\n{results}\n\n"
-        f"## Top Config Patterns\n{top_patterns}\n\n"
-        f"## Failed Config Patterns\n{failed_patterns}\n\n"
-        "## Next Step\n" + "\n".join(f"  - {line}" for line in strategy_lines) + "\n\n"
-        "## Task\n"
+    task_section = (
         f"Suggest up to {configs_per_round} NEW UNIQUE configs around the anchors above. "
         "Avoid the failed patterns above and favor targeted edits with attributable effects. "
         f"{RETURN_JSON_ONLY}"
+    )
+    return _join_sections(
+        _section("Search State", search_state),
+        _section("Anchor Configs", anchor_configs),
+        _section("Results (best first)", results),
+        _section("Top Config Patterns", top_patterns),
+        _section("Failed Config Patterns", failed_patterns),
+        _bullet_section(
+            "Next Step",
+            _refinement_strategy_lines(
+                compile_timeout_s=compile_timeout_s,
+                failed_count=failed_count,
+                total_count=total_count,
+            ),
+        ),
+        _section("Task", task_section),
     )

--- a/helion/autotuner/llm/prompting.py
+++ b/helion/autotuner/llm/prompting.py
@@ -1,0 +1,207 @@
+"""Build prompts for the LLM-guided autotuner."""
+
+from __future__ import annotations
+
+import textwrap
+from typing import TYPE_CHECKING
+
+from .configs import describe_config_space
+from .feedback import MAX_CHANGED_FIELDS_PER_CONFIG
+from .feedback import format_config_for_prompt
+from .workload import compute_workload_hints
+from .workload import describe_kernel
+from .workload import detect_workload_traits
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from collections.abc import Sequence
+
+    from ..base_search import _AutotunableKernel
+    from ..config_spec import ConfigSpec
+
+RETURN_JSON_ONLY = 'Return minified JSON only: {"configs":[...]}'
+SHAPE_RULE = (
+    "Do not guess field structure: for list-valued fields, emit an explicit JSON "
+    "array of the exact required length; if that length is unclear, omit the "
+    "field."
+)
+
+
+def build_system_prompt() -> str:
+    """Return the global instruction block shared by every LLM request."""
+    return textwrap.dedent("""\
+        You are an expert GPU kernel autotuner for Helion/Triton kernels.
+
+        Use the provided Configuration Space and Default Configuration as the source of truth for:
+        - allowed field names and enum values
+        - which fields are scalar vs list-valued
+        - required list lengths
+        - valid ranges and defaults
+
+        Key knobs:
+        - block_sizes: per-dimension tile sizes. Good families usually change them coherently. For kernels with an inner or reduction dimension, very small values there are a separate aggressive family, not the default.
+        - num_warps: threads/32. 4-8 is typical; 16+ is mainly for clearly larger tiles.
+        - num_stages: pipeline depth. 2-4 is common for streaming loops; 1 is safer when unsure.
+        - pid_type: flat, persistent_blocked, and persistent_interleaved are distinct scheduling families when available.
+        - indexing: pointer and tensor_descriptor are distinct families.
+        - l2_groupings, maxnreg, num_sm_multiplier, and advanced range toggles are secondary knobs; change them selectively after choosing a coherent tiling family.
+
+        General heuristics:
+        - analyze the kernel source, input tensors, GPU hardware, and config space to infer likely optimization traits from the code itself and target hardware; if unsure, stay closer to default.
+        - block_sizes and num_warps should be powers of 2 when present.
+        - persistent pid_type is often worth trying when total tile count is comparable to or larger than SM count, and it may also be required for some kernels.
+        - tensor_descriptor is a distinct family from pointer indexing.
+        - higher num_stages and multi-buffering are more aggressive and should be used selectively.
+
+        Output contract:
+        - Return minified JSON on a single line. No markdown, code fences, comments, pretty-printing, or trailing commas.
+        - Emit exactly one top-level object: {"configs":[...]} and make every config unique.
+        - Do not use Python syntax or expressions such as single-quoted strings or list multiplication like ["pointer"] * 4.
+        - Only specify fields you want to change; unspecified = default.
+        - Use only field names and enum values that appear in the config space.
+        - For list-valued fields, emit an explicit JSON array with the exact required length shown in the config space.
+        - Never use a scalar as shorthand for a list-valued field, and never wrap scalar-valued fields in single-element lists.
+        - If you are unsure about a field's structure, required list length, or allowed values, omit that field instead of guessing.
+        - Use null not None, true/false not True/False.
+        - Return ONLY minified JSON: {"configs":[...]}""")
+
+
+def build_initial_search_guidance(
+    *,
+    configs_per_round: int,
+    compile_timeout_s: int | None,
+    flat_fields: Mapping[str, object],
+) -> str:
+    """Build the search-strategy section of the initial prompt."""
+    lines = [
+        (
+            f"Generate up to {configs_per_round} UNIQUE candidate configs. "
+            "Fewer is better than invalid JSON."
+        ),
+        "First analyze the kernel source, input tensors, GPU hardware, and config space.",
+        "Cover 3 config families with a rough mix of about 40% near-default safe, 40% balanced throughput, and 20% aggressive configs, while keeping most candidates valid and compilable.",
+        "If the kernel structure is unclear, stay closer to default and avoid aggressive coupled changes.",
+        (
+            "Keep each config sparse: usually 2-6 changed fields, omit unchanged defaults, "
+            "and exceed 6 only when several coupled changes are needed for a distinct family."
+        ),
+        "Use block_sizes to define families: include at least 3 materially different tiling families instead of tiny perturbations of one tile.",
+        "Vary block_sizes coherently across dimensions rather than by arbitrary skew.",
+        SHAPE_RULE,
+        "Do not pretty-print or repeat unchanged defaults.",
+        "Avoid configs that simultaneously max out several aggressive knobs such as num_warps, num_stages, and maxnreg when present, unless strongly justified.",
+    ]
+    if compile_timeout_s is not None:
+        lines.append(
+            f"Compile timeout is {compile_timeout_s}s, so avoid candidates that are likely to compile very slowly."
+        )
+    if "indexing" in flat_fields:
+        lines.append(
+            "If tensor_descriptor is available, treat it as a separate family: include a few configs using it, but keep some pure pointer configs too."
+        )
+    if "pid_type" in flat_fields:
+        lines.append(
+            "Include both flat and persistent scheduling families when plausible; do not put every config on the same pid_type."
+        )
+    if "reduction_loops" in flat_fields:
+        lines.append(
+            "This is reduction-like: keep most configs conservative and avoid very large block_sizes or maxed num_warps/num_stages."
+        )
+    if any(
+        name in flat_fields
+        for name in (
+            "range_warp_specializes",
+            "range_multi_buffers",
+            "range_flattens",
+        )
+    ):
+        lines.append(
+            "Use advanced toggles like warp_specialize, multi_buffer, and flatten in only a minority of otherwise sane configs."
+        )
+    return "## Search Strategy\n" + "\n".join(f"  - {line}" for line in lines)
+
+
+def build_initial_prompt(
+    *,
+    kernel: _AutotunableKernel,
+    args: Sequence[object],
+    config_spec: ConfigSpec,
+    configs_per_round: int,
+    compile_timeout_s: int | None,
+) -> str:
+    """Build the full initial user prompt sent to the LLM."""
+    default_config = config_spec.default_config()
+    workload_hints = compute_workload_hints(
+        args,
+        workload_traits=detect_workload_traits(kernel, config_spec=config_spec),
+    )
+    guidance = build_initial_search_guidance(
+        configs_per_round=configs_per_round,
+        compile_timeout_s=compile_timeout_s,
+        flat_fields=config_spec._flat_fields(),
+    )
+    return (
+        f"{describe_kernel(kernel, args)}\n\n"
+        f"## Configuration Space\n{describe_config_space(config_spec)}\n\n"
+        f"## Default Configuration\n"
+        f"{format_config_for_prompt(default_config)}"
+        f"{workload_hints}\n\n"
+        f"{guidance}\n\n"
+        "## Task\n"
+        "Suggest the first batch of configs. Include both near-default and exploratory candidates. "
+        f"{RETURN_JSON_ONLY}"
+    )
+
+
+def build_refinement_prompt(
+    *,
+    configs_per_round: int,
+    compile_timeout_s: int | None,
+    failed_count: int,
+    total_count: int,
+    search_state: str,
+    anchor_configs: str,
+    results: str,
+    top_patterns: str,
+    failed_patterns: str,
+) -> str:
+    """Build the refinement prompt sent after each benchmarking round."""
+    if total_count > 0 and failed_count * 3 >= total_count:
+        strategy_lines = [
+            "Recent rounds had many failures. Use only the best 1-2 anchors.",
+            "At least 80% of configs should be 1-2 field mutations of those anchors.",
+            "Back off aggressive settings first: smaller num_stages/num_warps, pointer indexing, fewer advanced toggles.",
+        ]
+    else:
+        strategy_lines = [
+            "About two thirds of configs should be 1-field mutations of Anchor 1.",
+            "Use most of the rest for 1-2 field mutations of Anchor 2.",
+            "Reserve at most a small minority for one clearly different family, not random noise.",
+        ]
+    strategy_lines.append(
+        "Prefer edits with attributable effects: change block_sizes, num_warps, num_stages, pid_type, indexing, l2_groupings, or maxnreg instead of rewriting every field."
+    )
+    strategy_lines.append(
+        "Keep each config sparse: usually 1-4 changed fields, and no more than "
+        f"{MAX_CHANGED_FIELDS_PER_CONFIG} unless absolutely necessary."
+    )
+    strategy_lines.append(SHAPE_RULE)
+    if compile_timeout_s is not None:
+        strategy_lines.append(
+            f"Keep compile cost in mind: avoid candidates that are likely to exceed the {compile_timeout_s}s compile timeout."
+        )
+    strategy_lines.append(
+        "If unsure, return fewer valid configs instead of verbose or malformed JSON."
+    )
+    return (
+        f"## Search State\n{search_state}\n\n"
+        f"## Anchor Configs\n{anchor_configs}\n\n"
+        f"## Results (best first)\n{results}\n\n"
+        f"## Top Config Patterns\n{top_patterns}\n\n"
+        f"## Failed Config Patterns\n{failed_patterns}\n\n"
+        "## Next Step\n" + "\n".join(f"  - {line}" for line in strategy_lines) + "\n\n"
+        "## Task\n"
+        f"Suggest up to {configs_per_round} NEW UNIQUE configs around the anchors above. "
+        "Avoid the failed patterns above and favor targeted edits with attributable effects. "
+        f"{RETURN_JSON_ONLY}"
+    )

--- a/helion/autotuner/llm/transport.py
+++ b/helion/autotuner/llm/transport.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import json
 import os
 import ssl
+from typing import TYPE_CHECKING
 from typing import Any
 from urllib import error as urllib_error
 from urllib import request as urllib_request
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 DEFAULT_REQUEST_TIMEOUT_S = 120.0
 # OpenAI Responses does not consume a temperature knob in our current request path,
@@ -128,6 +133,108 @@ def extract_anthropic_text(response: dict[str, object]) -> str:
     raise RuntimeError(f"Unexpected Anthropic payload: {response}")
 
 
+def _openai_payload(
+    model: str,
+    messages: list[dict[str, str]],
+    max_output_tokens: int,
+) -> dict[str, Any]:
+    """Build an OpenAI Responses request payload."""
+    system_prompt, input_messages = split_system_messages(messages)
+    payload: dict[str, Any] = {
+        "model": strip_provider_prefix(model),
+        "input": responses_input_from_messages(input_messages),
+        "max_output_tokens": max_output_tokens,
+    }
+    if system_prompt:
+        payload["instructions"] = system_prompt
+    return payload
+
+
+def _anthropic_payload(
+    model: str,
+    messages: list[dict[str, str]],
+    max_output_tokens: int,
+) -> dict[str, Any]:
+    """Build an Anthropic Messages request payload."""
+    system_prompt, input_messages = split_system_messages(messages)
+    payload: dict[str, Any] = {
+        "model": strip_provider_prefix(model),
+        "messages": anthropic_messages_from_history(input_messages),
+        "max_tokens": max_output_tokens,
+        "temperature": DEFAULT_ANTHROPIC_TEMPERATURE,
+    }
+    if system_prompt:
+        payload["system"] = system_prompt
+    return payload
+
+
+def _openai_headers(api_key: str) -> dict[str, str]:
+    """Build OpenAI-compatible auth headers."""
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+
+def _anthropic_headers(api_key: str) -> dict[str, str]:
+    """Build Anthropic Messages auth headers."""
+    return {
+        "content-type": "application/json",
+        "anthropic-version": "2023-06-01",
+        "x-api-key": api_key,
+    }
+
+
+@dataclass(frozen=True)
+class _ProviderConfig:
+    """Provider-specific transport configuration."""
+
+    endpoint: str
+    default_api_base: str
+    api_base_env_names: tuple[str, ...]
+    api_key_env_names: tuple[str, ...]
+    missing_api_key_error: str
+    build_payload: Callable[[str, list[dict[str, str]], int], dict[str, Any]]
+    build_headers: Callable[[str], dict[str, str]]
+    extract_text: Callable[[dict[str, object]], str]
+
+
+_PROVIDER_CONFIGS = {
+    "openai_responses": _ProviderConfig(
+        endpoint="responses",
+        default_api_base="https://api.openai.com",
+        api_base_env_names=("OPENAI_BASE_URL", "OPENAI_API_BASE"),
+        api_key_env_names=("OPENAI_API_KEY",),
+        missing_api_key_error=(
+            "OpenAI-compatible model requested but no api_key, HELION_LLM_API_KEY, "
+            "or OPENAI_API_KEY is set"
+        ),
+        build_payload=_openai_payload,
+        build_headers=_openai_headers,
+        extract_text=extract_openai_response_text,
+    ),
+    "anthropic": _ProviderConfig(
+        endpoint="messages",
+        default_api_base="https://api.anthropic.com",
+        api_base_env_names=("ANTHROPIC_BASE_URL",),
+        api_key_env_names=("ANTHROPIC_API_KEY",),
+        missing_api_key_error=(
+            "Anthropic model requested but no api_key, HELION_LLM_API_KEY, "
+            "or ANTHROPIC_API_KEY is set"
+        ),
+        build_payload=_anthropic_payload,
+        build_headers=_anthropic_headers,
+        extract_text=extract_anthropic_text,
+    ),
+}
+
+
+def _provider_config(provider: str) -> _ProviderConfig:
+    """Return the provider-specific transport configuration."""
+    normalized_provider = normalize_provider(provider)
+    return _PROVIDER_CONFIGS[normalized_provider]
+
+
 def _first_set_env(*names: str) -> str | None:
     """Return the first env var in the list that is present."""
     for name in names:
@@ -149,14 +256,8 @@ def _resolve_api_base(provider: str, api_base: str | None) -> str:
         return api_base
     if (generic_api_base := os.environ.get("HELION_LLM_API_BASE")) is not None:
         return generic_api_base
-    if provider == "openai_responses":
-        return (
-            os.environ.get("OPENAI_BASE_URL")
-            or os.environ.get("OPENAI_API_BASE")
-            or "https://api.openai.com"
-        )
-    assert provider == "anthropic"
-    return os.environ.get("ANTHROPIC_BASE_URL") or "https://api.anthropic.com"
+    config = _provider_config(provider)
+    return _first_set_env(*config.api_base_env_names) or config.default_api_base
 
 
 def _resolve_api_key(provider: str, api_key: str | None) -> str:
@@ -165,20 +266,10 @@ def _resolve_api_key(provider: str, api_key: str | None) -> str:
         return api_key
     if (generic_api_key := os.environ.get("HELION_LLM_API_KEY")) is not None:
         return generic_api_key
-    if provider == "openai_responses":
-        if (openai_api_key := os.environ.get("OPENAI_API_KEY")) is not None:
-            return openai_api_key
-        raise RuntimeError(
-            "OpenAI-compatible model requested but no api_key, HELION_LLM_API_KEY, "
-            "or OPENAI_API_KEY is set"
-        )
-    assert provider == "anthropic"
-    if (anthropic_api_key := os.environ.get("ANTHROPIC_API_KEY")) is not None:
-        return anthropic_api_key
-    raise RuntimeError(
-        "Anthropic model requested but no api_key, HELION_LLM_API_KEY, "
-        "or ANTHROPIC_API_KEY is set"
-    )
+    config = _provider_config(provider)
+    if resolved_api_key := _first_set_env(*config.api_key_env_names):
+        return resolved_api_key
+    raise RuntimeError(config.missing_api_key_error)
 
 
 def _resolve_v1_endpoint(api_base: str, endpoint: str) -> str:
@@ -217,44 +308,30 @@ def _build_provider_payload(
     max_output_tokens: int,
 ) -> dict[str, Any]:
     """Build the JSON request body for the selected provider."""
-    normalized_model = strip_provider_prefix(model)
-    system_prompt, input_messages = split_system_messages(messages)
-    if provider == "openai_responses":
-        payload: dict[str, Any] = {
-            "model": normalized_model,
-            "input": responses_input_from_messages(input_messages),
-            "max_output_tokens": max_output_tokens,
-        }
-        if system_prompt:
-            payload["instructions"] = system_prompt
-        return payload
-
-    assert provider == "anthropic"
-    payload = {
-        "model": normalized_model,
-        "messages": anthropic_messages_from_history(input_messages),
-        "max_tokens": max_output_tokens,
-        "temperature": DEFAULT_ANTHROPIC_TEMPERATURE,
-    }
-    if system_prompt:
-        payload["system"] = system_prompt
-    return payload
+    return _provider_config(provider).build_payload(model, messages, max_output_tokens)
 
 
 def _build_provider_headers(provider: str, api_key: str) -> dict[str, str]:
     """Build auth and content headers for the selected provider."""
-    if provider == "openai_responses":
-        return {
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-        }
+    return _provider_config(provider).build_headers(api_key)
 
-    assert provider == "anthropic"
-    return {
-        "content-type": "application/json",
-        "anthropic-version": "2023-06-01",
-        "x-api-key": api_key,
-    }
+
+def _load_json_response(
+    request: urllib_request.Request,
+    *,
+    request_timeout_s: float,
+    ssl_context: ssl.SSLContext | None,
+) -> object:
+    """Load one JSON response body, optionally using a custom SSL context."""
+    if ssl_context is None:
+        with urllib_request.urlopen(request, timeout=request_timeout_s) as response:
+            return json.load(response)
+    with urllib_request.urlopen(
+        request,
+        timeout=request_timeout_s,
+        context=ssl_context,
+    ) as response:
+        return json.load(response)
 
 
 def _post_json(
@@ -272,19 +349,11 @@ def _post_json(
         method="POST",
     )
     try:
-        if (ssl_context := _build_ssl_context()) is not None:
-            with urllib_request.urlopen(
-                request,
-                timeout=request_timeout_s,
-                context=ssl_context,
-            ) as response:
-                body = json.load(response)
-        else:
-            with urllib_request.urlopen(
-                request,
-                timeout=request_timeout_s,
-            ) as response:
-                body = json.load(response)
+        body = _load_json_response(
+            request,
+            request_timeout_s=request_timeout_s,
+            ssl_context=_build_ssl_context(),
+        )
     except urllib_error.HTTPError as e:
         body = e.read().decode("utf-8", errors="replace")
         raise RuntimeError(f"HTTP {e.code} from {url}: {body}") from e
@@ -307,20 +376,21 @@ def call_provider(
     request_timeout_s: float,
 ) -> str:
     """Resolve credentials, send one request, and extract text from the response."""
-    endpoint = "responses" if provider == "openai_responses" else "messages"
-    resolved_api_key = _resolve_api_key(provider, api_key)
+    normalized_provider = normalize_provider(provider)
+    config = _provider_config(normalized_provider)
+    resolved_api_key = _resolve_api_key(normalized_provider, api_key)
     response = _post_json(
-        _resolve_v1_endpoint(_resolve_api_base(provider, api_base), endpoint),
+        _resolve_v1_endpoint(
+            _resolve_api_base(normalized_provider, api_base),
+            config.endpoint,
+        ),
         _build_provider_payload(
-            provider,
+            normalized_provider,
             model=model,
             messages=messages,
             max_output_tokens=max_output_tokens,
         ),
-        _build_provider_headers(provider, resolved_api_key),
+        _build_provider_headers(normalized_provider, resolved_api_key),
         request_timeout_s=request_timeout_s,
     )
-    if provider == "openai_responses":
-        return extract_openai_response_text(response)
-    assert provider == "anthropic"
-    return extract_anthropic_text(response)
+    return config.extract_text(response)

--- a/helion/autotuner/llm/transport.py
+++ b/helion/autotuner/llm/transport.py
@@ -1,0 +1,326 @@
+"""Send direct HTTP requests to the configured LLM provider."""
+
+from __future__ import annotations
+
+import json
+import os
+import ssl
+from typing import Any
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+DEFAULT_REQUEST_TIMEOUT_S = 120.0
+# OpenAI Responses does not consume a temperature knob in our current request path,
+# so keep Anthropic's setting internal instead of exposing it on the search API.
+DEFAULT_ANTHROPIC_TEMPERATURE = 0.3
+
+_PROVIDER_ALIASES = {
+    "anthropic": "anthropic",
+    "openai": "openai_responses",
+    "openai_responses": "openai_responses",
+    "openai-responses": "openai_responses",
+}
+
+
+def normalize_provider(provider: str) -> str:
+    """Canonicalize user-facing provider names to internal transport IDs."""
+    normalized = provider.strip().lower()
+    if resolved := _PROVIDER_ALIASES.get(normalized):
+        return resolved
+    raise ValueError(
+        f"Unsupported LLM provider {provider!r}. "
+        "Valid providers are: anthropic, openai, openai_responses."
+    )
+
+
+def infer_provider(model: str, provider: str | None = None) -> str:
+    """Guess the transport from the model name unless the caller overrides it."""
+    if provider is not None:
+        return normalize_provider(provider)
+    normalized = model.lower()
+    if normalized.startswith(("claude", "anthropic/")):
+        return "anthropic"
+    if normalized.startswith(
+        ("gpt-", "chatgpt-", "codex", "o1", "o3", "o4", "openai/")
+    ):
+        return "openai_responses"
+    return "unsupported"
+
+
+def strip_provider_prefix(model: str) -> str:
+    """Remove a provider prefix before sending the model name to the API."""
+    for prefix in ("anthropic/", "openai/"):
+        if model.startswith(prefix):
+            return model.removeprefix(prefix)
+    return model
+
+
+def split_system_messages(
+    messages: list[dict[str, str]],
+) -> tuple[str, list[dict[str, str]]]:
+    """Hoist system prompts into the format expected by provider adapters."""
+    system_messages = [
+        message["content"] for message in messages if message["role"] == "system"
+    ]
+    non_system = [message for message in messages if message["role"] != "system"]
+    return "\n\n".join(system_messages), non_system
+
+
+def responses_input_from_messages(
+    messages: list[dict[str, str]],
+) -> list[dict[str, object]]:
+    """Convert chat history into the OpenAI Responses input schema."""
+    payload: list[dict[str, object]] = []
+    for message in messages:
+        role = "developer" if message["role"] == "system" else message["role"]
+        content_type = "output_text" if role == "assistant" else "input_text"
+        payload.append(
+            {
+                "role": role,
+                "content": [{"type": content_type, "text": message["content"]}],
+            }
+        )
+    return payload
+
+
+def anthropic_messages_from_history(
+    messages: list[dict[str, str]],
+) -> list[dict[str, str]]:
+    """Convert chat history into the Anthropic Messages schema."""
+    return [
+        {"role": message["role"], "content": message["content"]}
+        for message in messages
+        if message["role"] in {"user", "assistant"}
+    ]
+
+
+def _extract_text_content_items(content: object) -> list[str]:
+    """Collect plain-text content blocks from a provider response payload."""
+    if not isinstance(content, list):
+        return []
+    return [
+        item["text"]
+        for item in content
+        if isinstance(item, dict)
+        and item.get("type") in {"text", "output_text"}
+        and isinstance(item.get("text"), str)
+    ]
+
+
+def extract_openai_response_text(response: dict[str, object]) -> str:
+    """Extract concatenated text from an OpenAI Responses payload."""
+    output = response.get("output")
+    if isinstance(output, list):
+        texts: list[str] = []
+        for item in output:
+            if not isinstance(item, dict):
+                continue
+            texts.extend(_extract_text_content_items(item.get("content")))
+        if texts:
+            return "".join(texts)
+    raise RuntimeError(f"Unexpected OpenAI responses payload: {response}")
+
+
+def extract_anthropic_text(response: dict[str, object]) -> str:
+    """Extract concatenated text from an Anthropic Messages payload."""
+    if texts := _extract_text_content_items(response.get("content")):
+        return "".join(texts)
+    raise RuntimeError(f"Unexpected Anthropic payload: {response}")
+
+
+def _first_set_env(*names: str) -> str | None:
+    """Return the first env var in the list that is present."""
+    for name in names:
+        if (value := os.environ.get(name)) is not None:
+            return value
+    return None
+
+
+def _first_existing_path(*names: str) -> str | None:
+    """Return the first configured path that exists on disk."""
+    if (path := _first_set_env(*names)) is not None and os.path.exists(path):
+        return path
+    return None
+
+
+def _resolve_api_base(provider: str, api_base: str | None) -> str:
+    """Resolve the base URL from args, env vars, or provider defaults."""
+    if api_base is not None:
+        return api_base
+    if (generic_api_base := os.environ.get("HELION_LLM_API_BASE")) is not None:
+        return generic_api_base
+    if provider == "openai_responses":
+        return (
+            os.environ.get("OPENAI_BASE_URL")
+            or os.environ.get("OPENAI_API_BASE")
+            or "https://api.openai.com"
+        )
+    assert provider == "anthropic"
+    return os.environ.get("ANTHROPIC_BASE_URL") or "https://api.anthropic.com"
+
+
+def _resolve_api_key(provider: str, api_key: str | None) -> str:
+    """Resolve the API key from args, env vars, or provider defaults."""
+    if api_key is not None:
+        return api_key
+    if (generic_api_key := os.environ.get("HELION_LLM_API_KEY")) is not None:
+        return generic_api_key
+    if provider == "openai_responses":
+        if (openai_api_key := os.environ.get("OPENAI_API_KEY")) is not None:
+            return openai_api_key
+        raise RuntimeError(
+            "OpenAI-compatible model requested but no api_key, HELION_LLM_API_KEY, "
+            "or OPENAI_API_KEY is set"
+        )
+    assert provider == "anthropic"
+    if (anthropic_api_key := os.environ.get("ANTHROPIC_API_KEY")) is not None:
+        return anthropic_api_key
+    raise RuntimeError(
+        "Anthropic model requested but no api_key, HELION_LLM_API_KEY, "
+        "or ANTHROPIC_API_KEY is set"
+    )
+
+
+def _resolve_v1_endpoint(api_base: str, endpoint: str) -> str:
+    """Append the provider endpoint while tolerating bases that already include it."""
+    base = api_base.rstrip("/")
+    if base.endswith((f"/v1/{endpoint}", f"/{endpoint}")):
+        return base
+    if base.endswith("/v1"):
+        return f"{base}/{endpoint}"
+    return f"{base}/v1/{endpoint}"
+
+
+def _build_ssl_context() -> ssl.SSLContext | None:
+    """Build an optional SSL context for custom CA bundles or client certs."""
+    ca_bundle = _first_existing_path("HELION_LLM_CA_BUNDLE", "NODE_EXTRA_CA_CERTS")
+    cert = _first_existing_path("HELION_LLM_CLIENT_CERT")
+    if ca_bundle is None and cert is None:
+        return None
+
+    context = (
+        ssl.create_default_context(cafile=ca_bundle)
+        if ca_bundle is not None
+        else ssl.create_default_context()
+    )
+    if cert is not None:
+        key = _first_existing_path("HELION_LLM_CLIENT_KEY") or cert
+        context.load_cert_chain(certfile=cert, keyfile=key)
+    return context
+
+
+def _build_provider_payload(
+    provider: str,
+    *,
+    model: str,
+    messages: list[dict[str, str]],
+    max_output_tokens: int,
+) -> dict[str, Any]:
+    """Build the JSON request body for the selected provider."""
+    normalized_model = strip_provider_prefix(model)
+    system_prompt, input_messages = split_system_messages(messages)
+    if provider == "openai_responses":
+        payload: dict[str, Any] = {
+            "model": normalized_model,
+            "input": responses_input_from_messages(input_messages),
+            "max_output_tokens": max_output_tokens,
+        }
+        if system_prompt:
+            payload["instructions"] = system_prompt
+        return payload
+
+    assert provider == "anthropic"
+    payload = {
+        "model": normalized_model,
+        "messages": anthropic_messages_from_history(input_messages),
+        "max_tokens": max_output_tokens,
+        "temperature": DEFAULT_ANTHROPIC_TEMPERATURE,
+    }
+    if system_prompt:
+        payload["system"] = system_prompt
+    return payload
+
+
+def _build_provider_headers(provider: str, api_key: str) -> dict[str, str]:
+    """Build auth and content headers for the selected provider."""
+    if provider == "openai_responses":
+        return {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+    assert provider == "anthropic"
+    return {
+        "content-type": "application/json",
+        "anthropic-version": "2023-06-01",
+        "x-api-key": api_key,
+    }
+
+
+def _post_json(
+    url: str,
+    payload: dict[str, Any],
+    headers: dict[str, str],
+    *,
+    request_timeout_s: float,
+) -> dict[str, object]:
+    """Send one JSON POST and normalize HTTP and payload errors."""
+    request = urllib_request.Request(
+        url=url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        if (ssl_context := _build_ssl_context()) is not None:
+            with urllib_request.urlopen(
+                request,
+                timeout=request_timeout_s,
+                context=ssl_context,
+            ) as response:
+                body = json.load(response)
+        else:
+            with urllib_request.urlopen(
+                request,
+                timeout=request_timeout_s,
+            ) as response:
+                body = json.load(response)
+    except urllib_error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {e.code} from {url}: {body}") from e
+    except urllib_error.URLError as e:
+        raise RuntimeError(f"Request to {url} failed: {e.reason}") from e
+
+    if isinstance(body, dict):
+        return body
+    raise RuntimeError(f"Unexpected JSON payload from {url}: {type(body).__name__}")
+
+
+def call_provider(
+    provider: str,
+    *,
+    model: str,
+    api_base: str | None,
+    api_key: str | None,
+    messages: list[dict[str, str]],
+    max_output_tokens: int,
+    request_timeout_s: float,
+) -> str:
+    """Resolve credentials, send one request, and extract text from the response."""
+    endpoint = "responses" if provider == "openai_responses" else "messages"
+    resolved_api_key = _resolve_api_key(provider, api_key)
+    response = _post_json(
+        _resolve_v1_endpoint(_resolve_api_base(provider, api_base), endpoint),
+        _build_provider_payload(
+            provider,
+            model=model,
+            messages=messages,
+            max_output_tokens=max_output_tokens,
+        ),
+        _build_provider_headers(provider, resolved_api_key),
+        request_timeout_s=request_timeout_s,
+    )
+    if provider == "openai_responses":
+        return extract_openai_response_text(response)
+    assert provider == "anthropic"
+    return extract_anthropic_text(response)

--- a/helion/autotuner/llm/workload.py
+++ b/helion/autotuner/llm/workload.py
@@ -12,6 +12,7 @@ from ..._compat import get_device_name
 from ..._compat import num_compute_units
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from collections.abc import Sequence
 
     from ..base_search import _AutotunableKernel
@@ -33,56 +34,71 @@ REDUCTION_TARGET_NAMES = frozenset({"amax", "sum", "softmax", "logsumexp"})
 EXP_TARGET_NAMES = frozenset({"exp", "exp2"})
 
 
-def describe_kernel(kernel: _AutotunableKernel, args: Sequence[object]) -> str:
-    """Build a description of the kernel, its inputs, and the target GPU."""
-    parts: list[str] = []
-
+def _kernel_source_text(kernel: _AutotunableKernel) -> str:
+    """Extract the underlying kernel source when it is available."""
     try:
         inner_kernel = getattr(kernel, "kernel", None)
-        if inner_kernel is not None and hasattr(inner_kernel, "fn"):
-            raw_source = inspect.getsource(inner_kernel.fn)
-            source_lines = textwrap.dedent(raw_source).splitlines()
-            start_idx = 0
-            while start_idx < len(source_lines) and not source_lines[
-                start_idx
-            ].lstrip().startswith("def "):
-                start_idx += 1
-            kernel_source = "\n".join(source_lines[start_idx:])
-        else:
-            kernel_source = "# Source unavailable"
+        if inner_kernel is None or not hasattr(inner_kernel, "fn"):
+            return "# Source unavailable"
+        raw_source = inspect.getsource(inner_kernel.fn)
     except (OSError, TypeError):
-        kernel_source = "# Source unavailable"
+        return "# Source unavailable"
 
-    parts.append(f"## Kernel Source Code\n```python\n{kernel_source}\n```")
+    source_lines = textwrap.dedent(raw_source).splitlines()
+    start_idx = 0
+    while start_idx < len(source_lines) and not source_lines[
+        start_idx
+    ].lstrip().startswith("def "):
+        start_idx += 1
+    return "\n".join(source_lines[start_idx:])
 
-    tensor_info: list[str] = []
+
+def _tensor_args(args: Sequence[object]) -> list[torch.Tensor]:
+    """Return only the tensor-valued runtime arguments."""
+    return [arg for arg in args if isinstance(arg, torch.Tensor)]
+
+
+def _input_tensor_lines(args: Sequence[object]) -> list[str]:
+    """Render tensor argument shapes and dtypes for the prompt."""
+    lines: list[str] = []
     for index, arg in enumerate(args):
         if isinstance(arg, torch.Tensor):
-            tensor_info.append(
-                f"  arg[{index}]: shape={list(arg.shape)}, dtype={arg.dtype}"
-            )
-    if tensor_info:
-        parts.append("## Input Tensors\n" + "\n".join(tensor_info))
+            lines.append(f"  arg[{index}]: shape={list(arg.shape)}, dtype={arg.dtype}")
+    return lines
 
-    device = kernel.env.device
+
+def _gpu_hardware_lines(device: torch.device) -> list[str]:
+    """Render a short hardware summary for the prompt."""
     device_name = get_device_name(device) or str(device)
-    hw_lines = [
+    lines = [
         f"  Device: {device_name}",
         f"  Compute units (SMs): {num_compute_units()}",
     ]
-    if device.type == "cuda" and torch.cuda.is_available():
-        try:
-            props = torch.cuda.get_device_properties(device)
-            hw_lines.extend(
-                [
-                    f"  Total memory: {props.total_memory / (1024**3):.1f} GB",
-                    f"  Max threads per SM: {props.max_threads_per_multi_processor}",
-                ]
-            )
-        except Exception:
-            pass
-    parts.append("## GPU Hardware\n" + "\n".join(hw_lines))
+    if device.type != "cuda" or not torch.cuda.is_available():
+        return lines
+    try:
+        props = torch.cuda.get_device_properties(device)
+    except Exception:
+        return lines
+    lines.extend(
+        [
+            f"  Total memory: {props.total_memory / (1024**3):.1f} GB",
+            f"  Max threads per SM: {props.max_threads_per_multi_processor}",
+        ]
+    )
+    return lines
 
+
+def describe_kernel(kernel: _AutotunableKernel, args: Sequence[object]) -> str:
+    """Build a description of the kernel, its inputs, and the target GPU."""
+    parts = [f"## Kernel Source Code\n```python\n{_kernel_source_text(kernel)}\n```"]
+
+    if tensor_lines := _input_tensor_lines(args):
+        parts.append("## Input Tensors\n" + "\n".join(tensor_lines))
+
+    parts.append(
+        "## GPU Hardware\n" + "\n".join(_gpu_hardware_lines(kernel.env.device))
+    )
     return "\n\n".join(parts)
 
 
@@ -101,6 +117,19 @@ def _target_name_parts(target: object) -> frozenset[str]:
     return frozenset(parts)
 
 
+def _iter_call_targets(kernel: _AutotunableKernel) -> Iterator[object]:
+    """Yield traced call targets from compiler-generated FX graphs."""
+    host_function = getattr(kernel, "host_function", None)
+    device_ir = getattr(host_function, "device_ir", None)
+    for graph_info in getattr(device_ir, "graphs", ()):
+        graph = getattr(graph_info, "graph", None)
+        if not isinstance(graph, torch.fx.Graph):
+            continue
+        for node in graph.nodes:
+            if node.op == "call_function":
+                yield node.target
+
+
 def detect_workload_traits(
     kernel: _AutotunableKernel | None,
     *,
@@ -115,24 +144,16 @@ def detect_workload_traits(
     saw_reduction = bool(config_spec is not None and config_spec.reduction_loops)
     saw_exp = False
 
-    host_function = getattr(kernel, "host_function", None)
-    device_ir = getattr(host_function, "device_ir", None)
-    for graph_info in getattr(device_ir, "graphs", ()):
-        graph = getattr(graph_info, "graph", None)
-        if not isinstance(graph, torch.fx.Graph):
-            continue
-        for node in graph.nodes:
-            if node.op != "call_function":
-                continue
-            name_parts = _target_name_parts(node.target)
-            if node.target in MATMUL_TARGETS or name_parts & MATMUL_API_NAMES:
-                saw_matmul = True
-            if name_parts & BATCH_MATMUL_TARGET_NAMES:
-                saw_batched_matmul = True
-            if name_parts & REDUCTION_TARGET_NAMES:
-                saw_reduction = True
-            if name_parts & EXP_TARGET_NAMES:
-                saw_exp = True
+    for target in _iter_call_targets(kernel):
+        name_parts = _target_name_parts(target)
+        if target in MATMUL_TARGETS or name_parts & MATMUL_API_NAMES:
+            saw_matmul = True
+        if name_parts & BATCH_MATMUL_TARGET_NAMES:
+            saw_batched_matmul = True
+        if name_parts & REDUCTION_TARGET_NAMES:
+            saw_reduction = True
+        if name_parts & EXP_TARGET_NAMES:
+            saw_exp = True
 
     traits: set[str] = set()
     if saw_matmul:
@@ -144,114 +165,149 @@ def detect_workload_traits(
     return frozenset(traits)
 
 
-def compute_workload_hints(
-    args: Sequence[object], *, workload_traits: frozenset[str] = frozenset()
-) -> str:
-    """Analyze the kernel workload and produce optimization hints."""
+def _summary_hints(
+    tensors: Sequence[torch.Tensor],
+    *,
+    workload_traits: frozenset[str],
+) -> list[str]:
+    """Summarize input size and compiler-detected workload traits."""
     hints: list[str] = []
-    tensors = [arg for arg in args if isinstance(arg, torch.Tensor)]
     total_bytes = sum(tensor.numel() * tensor.element_size() for tensor in tensors)
     if total_bytes > 0:
         hints.append(f"Total input data: {total_bytes / (1024**2):.1f} MB")
     if workload_traits:
         hints.append("Compiler-detected traits: " + ", ".join(sorted(workload_traits)))
+    return hints
+
+
+def _attention_reduction_hints(tensors: Sequence[torch.Tensor]) -> list[str]:
+    """Suggest conservative but diverse starting families for attention-like kernels."""
+    hints = [
+        (
+            "Compiler detected matmul-family ops with reductions/"
+            "normalization; keep at least one attention/reduction-style "
+            "family with moderate streaming tiles, and reserve very "
+            "aggressive num_warps/num_stages or advanced toggles for a "
+            "minority of configs."
+        ),
+        (
+            "For this workload, distinct families can still stay near "
+            "moderate tiles: use scheduling or indexing changes to create "
+            "diversity too, instead of forcing every family to jump to a "
+            "much larger tile."
+        ),
+        (
+            "Keep most balanced configs on moderate warps and stages; "
+            "for attention-style streaming kernels, 4 warps is often the "
+            "balanced choice, while 8+ warps or 4+ stages are "
+            "exploratory unless tiles are clearly large and compile "
+            "cleanly."
+        ),
+        (
+            "Include at least one persistent scheduling family when "
+            "available for long streaming dimensions."
+        ),
+    ]
+    shapes = [list(tensor.shape) for tensor in tensors]
+    if len(tensors) < 3 or not all(len(shape) >= 2 for shape in shapes[:3]):
+        return hints
+
+    seq = shapes[0][-2]
+    head_dim = shapes[0][-1]
+    if not isinstance(seq, int) or not isinstance(head_dim, int):
+        return hints
+
+    mid_tile = min(seq, 64)
+    inner_tile = min(head_dim, 64)
+    hints.extend(
+        [
+            (
+                "Attention/reduction-style starting point: try a "
+                f"family near [1, {mid_tile}, {inner_tile}] if that matches the "
+                "config space."
+            ),
+            (
+                "Within that starting family, include a couple of "
+                "balanced variants that keep block_sizes fixed and "
+                "vary num_stages through 2-3 before moving to much "
+                "larger tiles or higher warps."
+            ),
+        ]
+    )
+    if inner_tile >= 32:
+        hints.append(
+            "A nearby family like "
+            f"[1, {mid_tile}, {max(16, inner_tile // 2)}] is already "
+            "distinct for this shape; prefer that kind of inner-tile "
+            "change before doubling the streaming tile, and keep tiles "
+            f"above {mid_tile} on the streaming axis to at most a "
+            "small minority."
+        )
+    return hints
+
+
+def _matmul_hints(
+    tensors: Sequence[torch.Tensor],
+    *,
+    workload_traits: frozenset[str],
+) -> list[str]:
+    """Suggest matmul-oriented starting tiles when the traced graph looks matmul-like."""
+    if "matmul" not in workload_traits:
+        return []
 
     shapes = [list(tensor.shape) for tensor in tensors]
     ndims = [len(shape) for shape in shapes]
     is_2d_compatible = len(tensors) >= 2 and all(dim == 2 for dim in ndims[:2])
-
-    if "attention_reduction" in workload_traits:
-        hints.extend(
-            [
-                (
-                    "Compiler detected matmul-family ops with reductions/"
-                    "normalization; keep at least one attention/reduction-style "
-                    "family with moderate streaming tiles, and reserve very "
-                    "aggressive num_warps/num_stages or advanced toggles for a "
-                    "minority of configs."
-                ),
-                (
-                    "For this workload, distinct families can still stay near "
-                    "moderate tiles: use scheduling or indexing changes to create "
-                    "diversity too, instead of forcing every family to jump to a "
-                    "much larger tile."
-                ),
-                (
-                    "Keep most balanced configs on moderate warps and stages; "
-                    "for attention-style streaming kernels, 4 warps is often the "
-                    "balanced choice, while 8+ warps or 4+ stages are "
-                    "exploratory unless tiles are clearly large and compile "
-                    "cleanly."
-                ),
-                (
-                    "Include at least one persistent scheduling family when "
-                    "available for long streaming dimensions."
-                ),
-            ]
-        )
-        if len(tensors) >= 3 and all(len(shape) >= 2 for shape in shapes[:3]):
-            seq = shapes[0][-2]
-            head_dim = shapes[0][-1]
-            if isinstance(seq, int) and isinstance(head_dim, int):
-                mid_tile = min(seq, 64)
-                inner_tile = min(head_dim, 64)
-                hints.extend(
-                    [
-                        (
-                            "Attention/reduction-style starting point: try a "
-                            "family near "
-                            f"[1, {mid_tile}, {inner_tile}] if that matches the "
-                            "config space."
-                        ),
-                        (
-                            "Within that starting family, include a couple of "
-                            "balanced variants that keep block_sizes fixed and "
-                            "vary num_stages through 2-3 before moving to much "
-                            "larger tiles or higher warps."
-                        ),
-                    ]
-                )
-                if inner_tile >= 32:
-                    hints.append(
-                        "A nearby family like "
-                        f"[1, {mid_tile}, {max(16, inner_tile // 2)}] is already "
-                        "distinct for this shape; prefer that kind of inner-tile "
-                        "change before doubling the streaming tile, and keep tiles "
-                        f"above {mid_tile} on the streaming axis to at most a "
-                        "small minority."
-                    )
-    elif "matmul" in workload_traits and not is_2d_compatible:
-        hints.append(
-            "Compiler detected matmul-family ops; keep at least one coherent "
-            "matmul-style tiling family in the search."
-        )
-
-    if "matmul" in workload_traits and is_2d_compatible:
-        m, k = shapes[0]
-        k2, n = shapes[1]
-        total_tiles_64 = (m // 64) * (n // 64)
-        hints.append(
-            f"Matmul-like: [{m}x{k}] @ [{k2}x{n}], ~{total_tiles_64} tiles at 64x64"
-        )
-        if total_tiles_64 > num_compute_units() * 4:
-            hints.append(
-                "Problem large enough for persistent kernels - "
-                "try pid_type='persistent_blocked' with l2_groupings=8-64"
+    if not is_2d_compatible:
+        if "attention_reduction" in workload_traits:
+            return []
+        return [
+            (
+                "Compiler detected matmul-family ops; keep at least one coherent "
+                "matmul-style tiling family in the search."
             )
-        hints.extend(
-            [
-                (
-                    f"Try block_sizes near [{min(m, 128)}, {min(n, 128)}, "
-                    f"{min(k, 64)}] as starting point"
-                ),
-                (
-                    "High-perf matmul tips: try asymmetric tiles like [64,128,64], "
-                    "num_stages=3-4, maxnreg=128 or 256, "
-                    "range_multi_buffers=[true,true] for double-buffering, "
-                    "load_eviction_policies with 'first' or 'last'"
-                ),
-            ]
+        ]
+
+    m, k = shapes[0]
+    k2, n = shapes[1]
+    total_tiles_64 = (m // 64) * (n // 64)
+    hints = [f"Matmul-like: [{m}x{k}] @ [{k2}x{n}], ~{total_tiles_64} tiles at 64x64"]
+    if total_tiles_64 > num_compute_units() * 4:
+        hints.append(
+            "Problem large enough for persistent kernels - "
+            "try pid_type='persistent_blocked' with l2_groupings=8-64"
         )
+    hints.extend(
+        [
+            (
+                f"Try block_sizes near [{min(m, 128)}, {min(n, 128)}, "
+                f"{min(k, 64)}] as starting point"
+            ),
+            (
+                "High-perf matmul tips: try asymmetric tiles like [64,128,64], "
+                "num_stages=3-4, maxnreg=128 or 256, "
+                "range_multi_buffers=[true,true] for double-buffering, "
+                "load_eviction_policies with 'first' or 'last'"
+            ),
+        ]
+    )
+    return hints
+
+
+def _format_workload_analysis(hints: list[str]) -> str:
+    """Render workload hints as an optional prompt section."""
     if not hints:
         return ""
     return "\n\n## Workload Analysis\n" + "\n".join(f"  {hint}" for hint in hints)
+
+
+def compute_workload_hints(
+    args: Sequence[object], *, workload_traits: frozenset[str] = frozenset()
+) -> str:
+    """Analyze the kernel workload and produce optimization hints."""
+    tensors = _tensor_args(args)
+    hints = _summary_hints(tensors, workload_traits=workload_traits)
+    if "attention_reduction" in workload_traits:
+        hints.extend(_attention_reduction_hints(tensors))
+    hints.extend(_matmul_hints(tensors, workload_traits=workload_traits))
+    return _format_workload_analysis(hints)

--- a/helion/autotuner/llm/workload.py
+++ b/helion/autotuner/llm/workload.py
@@ -1,0 +1,257 @@
+"""Infer workload traits and render kernel context for LLM prompts."""
+
+from __future__ import annotations
+
+import inspect
+import textwrap
+from typing import TYPE_CHECKING
+
+import torch
+
+from ..._compat import get_device_name
+from ..._compat import num_compute_units
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from ..base_search import _AutotunableKernel
+    from ..config_spec import ConfigSpec
+
+
+MATMUL_TARGETS = frozenset(
+    {
+        torch.matmul,
+        torch.ops.aten.mm.default,
+        torch.ops.aten.addmm.default,
+        torch.ops.aten.bmm.default,
+        torch.ops.aten.baddbmm.default,
+    }
+)
+MATMUL_API_NAMES = frozenset({"dot", "dot_scaled"})
+BATCH_MATMUL_TARGET_NAMES = frozenset({"bmm", "baddbmm"})
+REDUCTION_TARGET_NAMES = frozenset({"amax", "sum", "softmax", "logsumexp"})
+EXP_TARGET_NAMES = frozenset({"exp", "exp2"})
+
+
+def describe_kernel(kernel: _AutotunableKernel, args: Sequence[object]) -> str:
+    """Build a description of the kernel, its inputs, and the target GPU."""
+    parts: list[str] = []
+
+    try:
+        inner_kernel = getattr(kernel, "kernel", None)
+        if inner_kernel is not None and hasattr(inner_kernel, "fn"):
+            raw_source = inspect.getsource(inner_kernel.fn)
+            source_lines = textwrap.dedent(raw_source).splitlines()
+            start_idx = 0
+            while start_idx < len(source_lines) and not source_lines[
+                start_idx
+            ].lstrip().startswith("def "):
+                start_idx += 1
+            kernel_source = "\n".join(source_lines[start_idx:])
+        else:
+            kernel_source = "# Source unavailable"
+    except (OSError, TypeError):
+        kernel_source = "# Source unavailable"
+
+    parts.append(f"## Kernel Source Code\n```python\n{kernel_source}\n```")
+
+    tensor_info: list[str] = []
+    for index, arg in enumerate(args):
+        if isinstance(arg, torch.Tensor):
+            tensor_info.append(
+                f"  arg[{index}]: shape={list(arg.shape)}, dtype={arg.dtype}"
+            )
+    if tensor_info:
+        parts.append("## Input Tensors\n" + "\n".join(tensor_info))
+
+    device = kernel.env.device
+    device_name = get_device_name(device) or str(device)
+    hw_lines = [
+        f"  Device: {device_name}",
+        f"  Compute units (SMs): {num_compute_units()}",
+    ]
+    if device.type == "cuda" and torch.cuda.is_available():
+        try:
+            props = torch.cuda.get_device_properties(device)
+            hw_lines.extend(
+                [
+                    f"  Total memory: {props.total_memory / (1024**3):.1f} GB",
+                    f"  Max threads per SM: {props.max_threads_per_multi_processor}",
+                ]
+            )
+        except Exception:
+            pass
+    parts.append("## GPU Hardware\n" + "\n".join(hw_lines))
+
+    return "\n\n".join(parts)
+
+
+def _target_name_parts(target: object) -> frozenset[str]:
+    """Extract coarse name tokens for a traced call target."""
+    parts: set[str] = set()
+    for raw in (
+        getattr(target, "__name__", None),
+        getattr(target, "name", None),
+        str(target),
+    ):
+        if not isinstance(raw, str):
+            continue
+        parts.add(raw)
+        parts.update(piece for piece in raw.split(".") if piece)
+    return frozenset(parts)
+
+
+def detect_workload_traits(
+    kernel: _AutotunableKernel | None,
+    *,
+    config_spec: ConfigSpec | None = None,
+) -> frozenset[str]:
+    """Infer coarse workload traits from compiler-traced graphs."""
+    if kernel is None:
+        return frozenset()
+
+    saw_matmul = False
+    saw_batched_matmul = False
+    saw_reduction = bool(config_spec is not None and config_spec.reduction_loops)
+    saw_exp = False
+
+    host_function = getattr(kernel, "host_function", None)
+    device_ir = getattr(host_function, "device_ir", None)
+    for graph_info in getattr(device_ir, "graphs", ()):
+        graph = getattr(graph_info, "graph", None)
+        if not isinstance(graph, torch.fx.Graph):
+            continue
+        for node in graph.nodes:
+            if node.op != "call_function":
+                continue
+            name_parts = _target_name_parts(node.target)
+            if node.target in MATMUL_TARGETS or name_parts & MATMUL_API_NAMES:
+                saw_matmul = True
+            if name_parts & BATCH_MATMUL_TARGET_NAMES:
+                saw_batched_matmul = True
+            if name_parts & REDUCTION_TARGET_NAMES:
+                saw_reduction = True
+            if name_parts & EXP_TARGET_NAMES:
+                saw_exp = True
+
+    traits: set[str] = set()
+    if saw_matmul:
+        traits.add("matmul")
+    if saw_reduction:
+        traits.add("reduction")
+    if saw_matmul and saw_reduction and (saw_batched_matmul or saw_exp):
+        traits.add("attention_reduction")
+    return frozenset(traits)
+
+
+def compute_workload_hints(
+    args: Sequence[object], *, workload_traits: frozenset[str] = frozenset()
+) -> str:
+    """Analyze the kernel workload and produce optimization hints."""
+    hints: list[str] = []
+    tensors = [arg for arg in args if isinstance(arg, torch.Tensor)]
+    total_bytes = sum(tensor.numel() * tensor.element_size() for tensor in tensors)
+    if total_bytes > 0:
+        hints.append(f"Total input data: {total_bytes / (1024**2):.1f} MB")
+    if workload_traits:
+        hints.append("Compiler-detected traits: " + ", ".join(sorted(workload_traits)))
+
+    shapes = [list(tensor.shape) for tensor in tensors]
+    ndims = [len(shape) for shape in shapes]
+    is_2d_compatible = len(tensors) >= 2 and all(dim == 2 for dim in ndims[:2])
+
+    if "attention_reduction" in workload_traits:
+        hints.extend(
+            [
+                (
+                    "Compiler detected matmul-family ops with reductions/"
+                    "normalization; keep at least one attention/reduction-style "
+                    "family with moderate streaming tiles, and reserve very "
+                    "aggressive num_warps/num_stages or advanced toggles for a "
+                    "minority of configs."
+                ),
+                (
+                    "For this workload, distinct families can still stay near "
+                    "moderate tiles: use scheduling or indexing changes to create "
+                    "diversity too, instead of forcing every family to jump to a "
+                    "much larger tile."
+                ),
+                (
+                    "Keep most balanced configs on moderate warps and stages; "
+                    "for attention-style streaming kernels, 4 warps is often the "
+                    "balanced choice, while 8+ warps or 4+ stages are "
+                    "exploratory unless tiles are clearly large and compile "
+                    "cleanly."
+                ),
+                (
+                    "Include at least one persistent scheduling family when "
+                    "available for long streaming dimensions."
+                ),
+            ]
+        )
+        if len(tensors) >= 3 and all(len(shape) >= 2 for shape in shapes[:3]):
+            seq = shapes[0][-2]
+            head_dim = shapes[0][-1]
+            if isinstance(seq, int) and isinstance(head_dim, int):
+                mid_tile = min(seq, 64)
+                inner_tile = min(head_dim, 64)
+                hints.extend(
+                    [
+                        (
+                            "Attention/reduction-style starting point: try a "
+                            "family near "
+                            f"[1, {mid_tile}, {inner_tile}] if that matches the "
+                            "config space."
+                        ),
+                        (
+                            "Within that starting family, include a couple of "
+                            "balanced variants that keep block_sizes fixed and "
+                            "vary num_stages through 2-3 before moving to much "
+                            "larger tiles or higher warps."
+                        ),
+                    ]
+                )
+                if inner_tile >= 32:
+                    hints.append(
+                        "A nearby family like "
+                        f"[1, {mid_tile}, {max(16, inner_tile // 2)}] is already "
+                        "distinct for this shape; prefer that kind of inner-tile "
+                        "change before doubling the streaming tile, and keep tiles "
+                        f"above {mid_tile} on the streaming axis to at most a "
+                        "small minority."
+                    )
+    elif "matmul" in workload_traits and not is_2d_compatible:
+        hints.append(
+            "Compiler detected matmul-family ops; keep at least one coherent "
+            "matmul-style tiling family in the search."
+        )
+
+    if "matmul" in workload_traits and is_2d_compatible:
+        m, k = shapes[0]
+        k2, n = shapes[1]
+        total_tiles_64 = (m // 64) * (n // 64)
+        hints.append(
+            f"Matmul-like: [{m}x{k}] @ [{k2}x{n}], ~{total_tiles_64} tiles at 64x64"
+        )
+        if total_tiles_64 > num_compute_units() * 4:
+            hints.append(
+                "Problem large enough for persistent kernels - "
+                "try pid_type='persistent_blocked' with l2_groupings=8-64"
+            )
+        hints.extend(
+            [
+                (
+                    f"Try block_sizes near [{min(m, 128)}, {min(n, 128)}, "
+                    f"{min(k, 64)}] as starting point"
+                ),
+                (
+                    "High-perf matmul tips: try asymmetric tiles like [64,128,64], "
+                    "num_stages=3-4, maxnreg=128 or 256, "
+                    "range_multi_buffers=[true,true] for double-buffering, "
+                    "load_eviction_policies with 'first' or 'last'"
+                ),
+            ]
+        )
+    if not hints:
+        return ""
+    return "\n\n## Workload Analysis\n" + "\n".join(f"  {hint}" for hint in hints)

--- a/helion/autotuner/llm_search.py
+++ b/helion/autotuner/llm_search.py
@@ -18,8 +18,10 @@ High-level flow:
 6. The final returned config comes from the best rebenchmarked config,
    not from an unrechecked one-shot LLM suggestion.
 
-The implementation keeps prompt formatting, transport, and search orchestration
-separate:
+The implementation keeps config parsing, workload analysis, prompting,
+transport, and search orchestration separate:
+- `configs.py` parses and validates sparse configs from LLM responses.
+- `workload.py` analyzes the kernel and hardware for prompt context.
 - `feedback.py` summarizes benchmark results for prompts.
 - `prompting.py` builds the actual prompt text.
 - `transport.py` handles provider I/O.
@@ -29,6 +31,7 @@ separate:
 from __future__ import annotations
 
 import concurrent.futures
+import contextlib
 from dataclasses import dataclass
 import math
 import os
@@ -59,6 +62,7 @@ from .llm.transport import call_provider as _call_provider
 from .llm.transport import infer_provider as _infer_provider
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from collections.abc import Sequence
 
     from ..runtime.config import Config
@@ -98,6 +102,7 @@ def guided_search_kwargs_from_config(
                 "configs_per_round": config.configs_per_round,
                 "max_rounds": config.max_rounds,
                 "initial_random_configs": config.initial_random_configs,
+                "compile_timeout_s": config.compile_timeout_s,
             }
         )
 
@@ -105,6 +110,8 @@ def guided_search_kwargs_from_config(
         kwargs["provider"] = provider
     if (model := os.environ.get("HELION_LLM_MODEL")) is not None:
         kwargs["model"] = model
+    if (value := os.environ.get("HELION_LLM_COMPILE_TIMEOUT_S")) is not None:
+        kwargs["compile_timeout_s"] = int(value)
     return kwargs
 
 
@@ -151,6 +158,8 @@ class LLMGuidedSearch(PopulationBasedSearch):
         finishing_rounds: Number of finishing rounds to simplify the best config.
         api_base: Optional custom API base URL for the LLM provider.
         api_key: Optional API key. Defaults to the provider's env var (e.g. OPENAI_API_KEY).
+        compile_timeout_s: Optional compile-time cap applied only while the LLM
+            search benchmarks its exploratory configs.
     """
 
     def __init__(
@@ -168,6 +177,7 @@ class LLMGuidedSearch(PopulationBasedSearch):
         api_base: str | None = None,
         api_key: str | None = None,
         request_timeout_s: float = DEFAULT_REQUEST_TIMEOUT_S,
+        compile_timeout_s: int | None = None,
     ) -> None:
         super().__init__(kernel, args, finishing_rounds=finishing_rounds)
         if max_rounds < 1:
@@ -183,6 +193,7 @@ class LLMGuidedSearch(PopulationBasedSearch):
         self.api_base = api_base
         self.api_key = api_key
         self.request_timeout_s = request_timeout_s
+        self.compile_timeout_s = compile_timeout_s
 
         self._messages: list[dict[str, str]] = []
         self._all_benchmark_results: list[BenchmarkResult] = []
@@ -317,6 +328,26 @@ class LLMGuidedSearch(PopulationBasedSearch):
         )
 
     # ── Search loop ──────────────────────────────────────────────
+
+    @contextlib.contextmanager
+    def _llm_search_settings_context(self) -> Iterator[None]:
+        """LLM proposals timed out more often per config, so fail them fast."""
+        if self.compile_timeout_s is None:
+            yield
+            return
+
+        original_compile_timeout = self.settings.autotune_compile_timeout
+        self.settings.autotune_compile_timeout = min(
+            original_compile_timeout,
+            self.compile_timeout_s,
+        )
+        self.log(
+            f"LLM compile timeout capped at {self.settings.autotune_compile_timeout}s"
+        )
+        try:
+            yield
+        finally:
+            self.settings.autotune_compile_timeout = original_compile_timeout
 
     def _config_key(self, cfg: Config) -> str:
         """Return the stable key used to dedupe configs across rounds."""
@@ -581,7 +612,8 @@ class LLMGuidedSearch(PopulationBasedSearch):
             f"max_rounds={self.max_rounds}"
         )
         try:
-            return self._autotune_inner()
+            with self._llm_search_settings_context():
+                return self._autotune_inner()
         finally:
             if (executor := getattr(self, "_llm_executor", None)) is not None:
                 executor.shutdown(wait=False, cancel_futures=True)
@@ -590,7 +622,6 @@ class LLMGuidedSearch(PopulationBasedSearch):
 
     def _autotune_inner(self) -> Config:
         """Run round 0 once, then iterate the synchronized refinement rounds."""
-        # Run round 0 once, then iterate the regular refinement rounds.
         self._initialize_prompt_state()
         state = _SearchLoopState(seen_config_keys=set())
         self._run_initial_round(state)

--- a/helion/autotuner/llm_search.py
+++ b/helion/autotuner/llm_search.py
@@ -1,0 +1,618 @@
+"""Search for autotune configs by iteratively querying an LLM.
+
+High-level flow:
+1. Initialize the prompt context from the kernel, config space, and default
+   config so the first LLM call sees both the workload description and the
+   available tuning knobs.
+2. Round 0 launches the first LLM call immediately, then benchmarks the
+   default config plus a few random seed configs while that request is in
+   flight.
+3. When the round-0 LLM response arrives, the search benchmarks its new unique
+   configs and folds those results into the running set of top configs.
+4. The top configs are then rebenchmarked before the next prompt is built, so each
+   later LLM round sees the latest stabilized timings instead of only one-shot
+   measurements.
+5. Later rounds repeat a synchronous cycle: build prompt from the latest
+   search state, query the LLM, benchmark new configs, then rebenchmark the
+   strongest configs.
+6. The final returned config comes from the best rebenchmarked config,
+   not from an unrechecked one-shot LLM suggestion.
+
+The implementation keeps prompt formatting, transport, and search orchestration
+separate:
+- `feedback.py` summarizes benchmark results for prompts.
+- `prompting.py` builds the actual prompt text.
+- `transport.py` handles provider I/O.
+- This file owns the round-by-round search state machine.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+from dataclasses import dataclass
+import math
+import os
+import time
+from typing import TYPE_CHECKING
+
+from .base_search import BenchmarkResult
+from .base_search import PopulationBasedSearch
+from .base_search import PopulationMember
+from .base_search import check_population_consistency
+from .effort_profile import DEFAULT_LLM_CONFIGS_PER_ROUND
+from .effort_profile import DEFAULT_LLM_INITIAL_RANDOM_CONFIGS
+from .effort_profile import DEFAULT_LLM_MAX_ROUNDS
+from .effort_profile import DEFAULT_LLM_MODEL
+from .llm.configs import parse_response_configs
+from .llm.feedback import analyze_top_configs
+from .llm.feedback import failed_benchmark_results
+from .llm.feedback import format_results_for_llm
+from .llm.feedback import summarize_anchor_configs_for_llm
+from .llm.feedback import summarize_failed_configs_for_llm
+from .llm.feedback import summarize_search_state_for_llm
+from .llm.prompting import build_initial_prompt
+from .llm.prompting import build_initial_search_guidance
+from .llm.prompting import build_refinement_prompt
+from .llm.prompting import build_system_prompt
+from .llm.transport import DEFAULT_REQUEST_TIMEOUT_S
+from .llm.transport import call_provider as _call_provider
+from .llm.transport import infer_provider as _infer_provider
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from ..runtime.config import Config
+    from ..runtime.settings import Settings
+    from .base_search import _AutotunableKernel
+    from .effort_profile import AutotuneEffortProfile
+    from .effort_profile import LLMSearchConfig
+
+# Keep system + initial prompt plus this many recent round-trip exchanges
+# to avoid exceeding LLM context limits on long sessions.
+_MAX_CONTEXT_ROUNDS = 3
+_EMPTY_LLM_RESPONSE = '{"configs": []}'
+_MAX_STAGNANT_ROUNDS = 2
+
+
+@dataclass
+class _SearchLoopState:
+    """Track dedupe and early-stop state across guided-search rounds."""
+
+    seen_config_keys: set[str]
+    prev_best_perf: float = math.inf
+    rounds_without_improvement: int = 0
+
+
+def guided_search_kwargs_from_config(
+    config: LLMSearchConfig | None,
+    settings: Settings,
+) -> dict[str, object]:
+    """Merge LLM config defaults with the supported HELION_LLM_* overrides."""
+    del settings
+    kwargs: dict[str, object] = {}
+
+    if config is not None:
+        kwargs.update(
+            {
+                "model": config.model,
+                "configs_per_round": config.configs_per_round,
+                "max_rounds": config.max_rounds,
+                "initial_random_configs": config.initial_random_configs,
+            }
+        )
+
+    if (provider := os.environ.get("HELION_LLM_PROVIDER")) is not None:
+        kwargs["provider"] = provider
+    if (model := os.environ.get("HELION_LLM_MODEL")) is not None:
+        kwargs["model"] = model
+    return kwargs
+
+
+def guided_search_kwargs_from_profile(
+    profile: AutotuneEffortProfile,
+    settings: Settings,
+) -> dict[str, object]:
+    """Merge effort-profile defaults with the supported HELION_LLM_* overrides."""
+    return guided_search_kwargs_from_config(profile.llm_search, settings)
+
+
+class LLMGuidedSearch(PopulationBasedSearch):
+    """
+    LLM-Guided autotuner that uses a language model to suggest kernel configurations.
+
+    Instead of random or evolutionary search, this strategy uses an LLM to propose
+    configurations based on:
+    - The kernel's source code and structure
+    - The configuration space (parameter types, ranges)
+    - GPU hardware information
+    - Benchmark results from previous rounds (iterative refinement)
+
+    The search overlaps only the initial round-0 request with seed
+    benchmarking. After that, refinement rounds are synchronous: each round
+    asks the LLM for a batch of configs, benchmarks them, rebenchmarks the
+    strongest configs, and only then builds the next prompt.
+
+    Common providers (OpenAI Responses, Anthropic Messages, and compatible
+    proxies) work via direct HTTP without extra dependencies.
+
+    Args:
+        kernel: The kernel to be autotuned.
+        args: Arguments passed to the kernel during benchmarking.
+        provider: Optional explicit provider override. Use this when a proxy
+            serves a model family behind a different API shape than its name
+            implies.
+        model: LLM model name (e.g. "gpt-5-2", "claude-haiku-4.5",
+            "claude-3-5-haiku-latest"). Can also be set via HELION_LLM_MODEL.
+        configs_per_round: Number of configs to request from the LLM per round.
+        max_rounds: Total number of LLM query rounds, including the initial
+            suggestion round. ``max_rounds=1`` means one LLM call total.
+        initial_random_configs: Number of random configs to add alongside LLM
+            suggestions in the first round, for diversity.
+        finishing_rounds: Number of finishing rounds to simplify the best config.
+        api_base: Optional custom API base URL for the LLM provider.
+        api_key: Optional API key. Defaults to the provider's env var (e.g. OPENAI_API_KEY).
+    """
+
+    def __init__(
+        self,
+        kernel: _AutotunableKernel,
+        args: Sequence[object],
+        *,
+        provider: str | None = None,
+        model: str = DEFAULT_LLM_MODEL,
+        configs_per_round: int = DEFAULT_LLM_CONFIGS_PER_ROUND,
+        max_rounds: int = DEFAULT_LLM_MAX_ROUNDS,
+        initial_random_configs: int = DEFAULT_LLM_INITIAL_RANDOM_CONFIGS,
+        finishing_rounds: int = 0,
+        min_improvement_delta: float = 0.005,
+        api_base: str | None = None,
+        api_key: str | None = None,
+        request_timeout_s: float = DEFAULT_REQUEST_TIMEOUT_S,
+    ) -> None:
+        super().__init__(kernel, args, finishing_rounds=finishing_rounds)
+        if max_rounds < 1:
+            raise ValueError("LLMGuidedSearch max_rounds must be >= 1")
+        self.provider = (
+            _infer_provider(model, provider) if provider is not None else None
+        )
+        self.model = model
+        self.configs_per_round = configs_per_round
+        self.max_rounds = max_rounds
+        self.initial_random_configs = initial_random_configs
+        self.min_improvement_delta = min_improvement_delta
+        self.api_base = api_base
+        self.api_key = api_key
+        self.request_timeout_s = request_timeout_s
+
+        self._messages: list[dict[str, str]] = []
+        self._all_benchmark_results: list[BenchmarkResult] = []
+        self._latest_results_by_config_key: dict[str, BenchmarkResult] = {}
+        self._llm_call_times: list[float] = []
+        self._benchmark_times: list[float] = []
+        self._llm_executor: concurrent.futures.ThreadPoolExecutor | None = None
+
+    @classmethod
+    def get_kwargs_from_profile(
+        cls, profile: AutotuneEffortProfile, settings: Settings
+    ) -> dict[str, object]:
+        """Merge shared search kwargs with LLM-specific profile settings."""
+        return {
+            **super().get_kwargs_from_profile(profile, settings),
+            **guided_search_kwargs_from_profile(profile, settings),
+        }
+
+    # ── Prompt building ─────────────────────────────────────────────
+
+    def _build_system_prompt(self) -> str:
+        """Return the fixed instruction block shared by every LLM request."""
+        return build_system_prompt()
+
+    def _build_initial_search_guidance(self) -> str:
+        """Describe the round-0 search strategy for this config space."""
+        return build_initial_search_guidance(
+            configs_per_round=self.configs_per_round,
+            compile_timeout_s=self.settings.autotune_compile_timeout,
+            flat_fields=self.config_spec._flat_fields(),
+        )
+
+    def _build_initial_prompt(self) -> str:
+        """Describe the kernel and ask the LLM for the first batch of configs."""
+        return build_initial_prompt(
+            kernel=self.kernel,
+            args=self.args,
+            config_spec=self.config_spec,
+            configs_per_round=self.configs_per_round,
+            compile_timeout_s=self.settings.autotune_compile_timeout,
+        )
+
+    def _build_refinement_prompt(self, round_num: int) -> str:
+        """Summarize search progress so the LLM can propose the next batch."""
+        del round_num
+        return build_refinement_prompt(
+            configs_per_round=self.configs_per_round,
+            compile_timeout_s=self.settings.autotune_compile_timeout,
+            failed_count=len(failed_benchmark_results(self._all_benchmark_results)),
+            total_count=len(self._all_benchmark_results),
+            search_state=summarize_search_state_for_llm(
+                self._all_benchmark_results,
+                self._default_config_dict,
+            ),
+            anchor_configs=summarize_anchor_configs_for_llm(
+                self._all_benchmark_results,
+                self._default_config_dict,
+            ),
+            results=format_results_for_llm(
+                self._all_benchmark_results,
+                self._default_config_dict,
+            ),
+            top_patterns=analyze_top_configs(
+                self._all_benchmark_results,
+                self._default_config_dict,
+            ),
+            failed_patterns=summarize_failed_configs_for_llm(
+                self._all_benchmark_results,
+                self._default_config_dict,
+            ),
+        )
+
+    # ── LLM transport ────────────────────────────────────────────
+
+    def _call_llm(self, messages: list[dict[str, str]]) -> str:
+        """Send one synchronous request to the configured provider and time it."""
+        t0 = time.perf_counter()
+        try:
+            provider = self.provider or _infer_provider(self.model)
+            if provider == "unsupported":
+                raise RuntimeError(
+                    f"Unsupported LLM provider for model={self.model!r}. "
+                    "Supported providers are Anthropic Messages and OpenAI "
+                    "Responses. Set HELION_LLM_PROVIDER to override the provider "
+                    "when using a proxy."
+                )
+            return _call_provider(
+                provider,
+                model=self.model,
+                api_base=self.api_base,
+                api_key=self.api_key,
+                messages=messages,
+                max_output_tokens=self._max_output_tokens_for_request(),
+                request_timeout_s=self.request_timeout_s,
+            )
+        except Exception as e:
+            self.log.warning(f"LLM call failed: {type(e).__name__}: {e}")
+            raise
+        finally:
+            self._llm_call_times.append(time.perf_counter() - t0)
+
+    def _call_llm_async(
+        self, messages: list[dict[str, str]]
+    ) -> concurrent.futures.Future[str]:
+        """Launch the round-0 LLM request so seed benchmarking can overlap it."""
+        # Round 0 is the only safe overlap point because the first prompt does not
+        # depend on benchmark feedback from earlier rounds.
+        if self._llm_executor is None:
+            self._llm_executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        return self._llm_executor.submit(self._call_llm, messages)
+
+    def _max_output_tokens_for_request(self) -> int:
+        """Choose a small response budget that scales with configs_per_round."""
+        return max(384, min(1536, 192 + self.configs_per_round * 56))
+
+    def _get_context_messages(self) -> list[dict[str, str]]:
+        """Keep the fixed prompt prefix plus only the most recent round history."""
+        prefix = self._messages[:2]
+        suffix = self._messages[2:]
+        max_suffix = _MAX_CONTEXT_ROUNDS * 2
+        if len(suffix) > max_suffix:
+            suffix = suffix[-max_suffix:]
+        return prefix + suffix
+
+    def _parse_configs(self, response: str) -> list[Config]:
+        """Parse and validate candidate configs from a raw LLM response."""
+        return parse_response_configs(
+            response,
+            config_spec=self.config_spec,
+            default_config_dict=self._default_config_dict,
+            log=self.log,
+        )
+
+    # ── Search loop ──────────────────────────────────────────────
+
+    def _config_key(self, cfg: Config) -> str:
+        """Return the stable key used to dedupe configs across rounds."""
+        # Use the normalized repr so identical configs collapse across round boundaries.
+        return repr(cfg)
+
+    def _initialize_prompt_state(self) -> None:
+        """Reset prompt state for a fresh guided-search run."""
+        # Start each run from the fixed system prompt and the initial request.
+        self._default_config_dict = dict(self.config_spec.default_config())
+        self._messages = [
+            {"role": "system", "content": self._build_system_prompt()},
+            {"role": "user", "content": self._build_initial_prompt()},
+        ]
+
+    def _build_seed_configs(self) -> list[Config]:
+        """Build the initial benchmark set: default plus a few random seeds."""
+        # Start from default and add only distinct random configs that unflatten cleanly.
+        seed_configs: list[Config] = [self.config_spec.default_config()]
+        seen_config_keys = {self._config_key(seed_configs[0])}
+        for flat in self.config_gen.random_population_flat(
+            self.initial_random_configs + 1
+        )[1:]:
+            try:
+                cfg = self.config_gen.unflatten(flat)
+            except Exception:
+                continue
+            key = self._config_key(cfg)
+            if key in seen_config_keys:
+                continue
+            seen_config_keys.add(key)
+            seed_configs.append(cfg)
+        return seed_configs
+
+    def _dedupe_new_configs(
+        self, configs: list[Config], seen_config_keys: set[str]
+    ) -> list[Config]:
+        """Filter out configs that have already been seen in earlier rounds."""
+        # Drop configs that were already benchmarked or queued in prior rounds.
+        new_configs: list[Config] = []
+        for cfg in configs:
+            key = self._config_key(cfg)
+            if key in seen_config_keys:
+                continue
+            seen_config_keys.add(key)
+            new_configs.append(cfg)
+        return new_configs
+
+    def _benchmark_and_ingest(
+        self,
+        configs: list[Config],
+        *,
+        generation: int,
+        desc: str,
+    ) -> None:
+        """Benchmark a batch of configs and fold the results into search state."""
+        # Benchmark one batch and feed the outcomes back into prompt and top-config state.
+        self.set_generation(generation)
+        bench_t0 = time.perf_counter()
+        results = self.benchmark_batch(configs, desc=desc)
+        self._benchmark_times.append(time.perf_counter() - bench_t0)
+        self._ingest_results(results)
+
+    def _ingest_results(self, results: list[BenchmarkResult]) -> None:
+        """Store raw results and keep a bounded set of top configs for rebenchmarking."""
+        # Retain full results for prompts while keeping only a small top-config set in memory.
+        self._store_latest_results(results)
+        self.population.extend(
+            PopulationMember(
+                fn=result.fn,
+                perfs=[result.perf],
+                flat_values=self.config_gen.flatten(result.config),
+                config=result.config,
+                status=result.status,
+                compile_time=result.compile_time,
+            )
+            for result in results
+        )
+        self._trim_population()
+
+    def _trim_population(self) -> None:
+        """Keep only the current top configs that future rebenchmarking needs."""
+        # Bound population size because rebenchmarking cost scales with how many
+        # top configs we keep.
+        max_population = self.configs_per_round * 2
+        if len(self.population) > max_population:
+            self.population.sort(key=lambda member: member.perf)
+            self.population = self.population[:max_population]
+
+    def _store_latest_results(self, results: list[BenchmarkResult]) -> None:
+        """Replace each config's prompt-facing result with its newest known timing."""
+        # Keep one latest result per config so later prompts can see rebenchmark updates.
+        for result in results:
+            self._latest_results_by_config_key[self._config_key(result.config)] = result
+        self._all_benchmark_results = list(self._latest_results_by_config_key.values())
+
+    def _result_from_population_member(
+        self, member: PopulationMember
+    ) -> BenchmarkResult:
+        """Convert one top config into a prompt-facing benchmark result."""
+        # Reuse the latest top-config timing so prompts reflect post-rebenchmark winners.
+        status = member.status
+        if status == "unknown":
+            status = "error"
+        return BenchmarkResult(
+            config=member.config,
+            fn=member.fn,
+            perf=member.perf,
+            status=status,
+            compile_time=member.compile_time,
+        )
+
+    def _refresh_prompt_results_from_population(self) -> None:
+        """Push rebenchmarked top-config timings back into the prompt-facing history."""
+        # Update only configs still in the top set; older off-top-set configs keep their
+        # latest one-shot results.
+        self._store_latest_results(
+            [self._result_from_population_member(member) for member in self.population]
+        )
+
+    def _build_llm_messages(self, prompt: str | None = None) -> list[dict[str, str]]:
+        """Build the message list for the next LLM request."""
+        # Start from the rolling context window and optionally append a fresh prompt.
+        messages = self._get_context_messages()
+        if prompt is not None:
+            messages = [*messages, {"role": "user", "content": prompt}]
+        return messages
+
+    def _wait_for_initial_llm_response(
+        self,
+        future: concurrent.futures.Future[str] | None,
+    ) -> str | None:
+        """Finish the overlapped round-0 LLM request after seed benchmarking."""
+        # Wait only after the seed batch so round 0 can hide some initial LLM latency.
+        if future is None:
+            return None
+        try:
+            return future.result(timeout=self.request_timeout_s)
+        except Exception:
+            self.log.warning(
+                "Round 0: initial LLM call failed, continuing with seed configs"
+            )
+            return None
+
+    def _finalize_round(self, round_num: int) -> None:
+        """Rebenchmark the current top configs and log the stabilized round summary."""
+        # Rebenchmark before the next prompt so prompts and stop checks use stable winners.
+        self.rebenchmark_population(desc=f"Round {round_num}: verifying top configs")
+        self._refresh_prompt_results_from_population()
+        check_population_consistency(
+            self.population,
+            process_group_name=self.kernel.env.process_group_name,
+        )
+        self.log(f"Round {round_num} complete:", self.statistics)
+
+    def _update_early_stop_state(self, state: _SearchLoopState) -> bool:
+        """Track weak-improvement rounds and decide whether to stop early."""
+        # Stop after repeated weak rounds so extra LLM calls do not just churn.
+        current_best = self.best.perf
+        if (
+            math.isfinite(current_best)
+            and math.isfinite(state.prev_best_perf)
+            and state.prev_best_perf > 0
+        ):
+            relative_improvement = (
+                state.prev_best_perf - current_best
+            ) / state.prev_best_perf
+            if relative_improvement < self.min_improvement_delta:
+                state.rounds_without_improvement += 1
+                if state.rounds_without_improvement >= _MAX_STAGNANT_ROUNDS:
+                    self.log(
+                        "Early stopping: no significant improvement "
+                        f"for {state.rounds_without_improvement} rounds"
+                    )
+                    return True
+            else:
+                state.rounds_without_improvement = 0
+        state.prev_best_perf = current_best
+        return False
+
+    def _run_initial_round(self, state: _SearchLoopState) -> None:
+        """Run round 0 by overlapping the initial LLM request with seed benchmarking."""
+        # Launch the first request before benchmarking because round 0 does not need
+        # any prior search feedback to build its prompt.
+        seed_configs = self._build_seed_configs()
+        state.seen_config_keys.update(self._config_key(cfg) for cfg in seed_configs)
+
+        self.log(
+            f"Round 0: starting initial LLM call while benchmarking "
+            f"{len(seed_configs)} seed configs (1 default + "
+            f"{max(0, len(seed_configs) - 1)} random)"
+        )
+
+        llm_future: concurrent.futures.Future[str] | None = None
+        try:
+            llm_future = self._call_llm_async(self._build_llm_messages())
+        except Exception:
+            self.log.warning(
+                "Round 0: could not start initial LLM call, continuing with seed configs"
+            )
+
+        if seed_configs:
+            self._benchmark_and_ingest(seed_configs, generation=0, desc="Round 0 seed")
+
+        llm_response = self._wait_for_initial_llm_response(llm_future)
+
+        llm_configs: list[Config] = []
+        if llm_response is not None:
+            self._messages.append({"role": "assistant", "content": llm_response})
+            llm_configs = self._parse_configs(llm_response)
+
+        round0_configs = self._dedupe_new_configs(llm_configs, state.seen_config_keys)
+        if round0_configs:
+            self.log(
+                f"Round 0: benchmarking {len(round0_configs)} new configs from the LLM"
+            )
+            self._benchmark_and_ingest(round0_configs, generation=0, desc="Round 0 LLM")
+        else:
+            self.log("Round 0: no new unique configs from the LLM")
+
+        self._finalize_round(0)
+        state.prev_best_perf = self.best.perf
+
+    def _run_refinement_round(self, round_num: int, state: _SearchLoopState) -> bool:
+        """Run one post-seed refinement round and report whether search should stop."""
+        # Build the next prompt from the stabilized prior round, then benchmark new configs.
+        prompt = self._build_refinement_prompt(round_num)
+        try:
+            llm_response = self._call_llm(self._build_llm_messages(prompt))
+        except Exception:
+            self.log.warning(
+                f"Round {round_num}: LLM call failed, generating no new configs instead"
+            )
+            llm_response = _EMPTY_LLM_RESPONSE
+
+        self._messages.append({"role": "user", "content": prompt})
+        self._messages.append({"role": "assistant", "content": llm_response})
+
+        new_configs = self._dedupe_new_configs(
+            self._parse_configs(llm_response),
+            state.seen_config_keys,
+        )
+        if not new_configs:
+            self.log(f"Round {round_num}: no new unique configs from LLM, stopping")
+            return True
+
+        self.log(f"Round {round_num}: benchmarking {len(new_configs)} new configs")
+        self._benchmark_and_ingest(
+            new_configs,
+            generation=round_num,
+            desc=f"Round {round_num}",
+        )
+
+        self._finalize_round(round_num)
+        return self._update_early_stop_state(state)
+
+    def _autotune(self) -> Config:
+        """Run the guided search and emit per-run timing logs."""
+        self.log(
+            f"Starting LLMGuidedSearch with model={self.model}, "
+            f"configs_per_round={self.configs_per_round}, "
+            f"max_rounds={self.max_rounds}"
+        )
+        try:
+            return self._autotune_inner()
+        finally:
+            if (executor := getattr(self, "_llm_executor", None)) is not None:
+                executor.shutdown(wait=False, cancel_futures=True)
+                self._llm_executor = None
+            self._log_search_stats()
+
+    def _autotune_inner(self) -> Config:
+        """Run round 0 once, then iterate the synchronized refinement rounds."""
+        # Run round 0 once, then iterate the regular refinement rounds.
+        self._initialize_prompt_state()
+        state = _SearchLoopState(seen_config_keys=set())
+        self._run_initial_round(state)
+
+        for round_num in range(1, self.max_rounds):
+            if self._run_refinement_round(round_num, state):
+                break
+
+        best = self.run_finishing_phase(self.best, self.finishing_rounds)
+        return best.config
+
+    def _log_search_stats(self) -> None:
+        """Report how much time went to LLM calls and benchmarking."""
+        if not self._llm_call_times:
+            return
+        avg_llm = sum(self._llm_call_times) / len(self._llm_call_times)
+        avg_bench = (
+            sum(self._benchmark_times) / len(self._benchmark_times)
+            if self._benchmark_times
+            else 0.0
+        )
+        self.log(
+            f"LLM search stats: avg LLM call={avg_llm:.1f}s, "
+            f"avg benchmark={avg_bench:.1f}s"
+        )

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -2526,5 +2526,603 @@ class TestConfigFilter(TestCase):
         self.assertEqual(results[1].config.get("num_warps"), 2)
 
 
+class TestLLMGuidedSearch(TestCase):
+    """Tests for LLMGuidedSearch config parsing and utility methods."""
+
+    @classmethod
+    def _make_mock_search(cls, **overrides):
+        """Create a minimal LLMGuidedSearch-like object for testing internal methods."""
+        from helion.autotuner.llm_search import LLMGuidedSearch
+
+        search = LLMGuidedSearch.__new__(LLMGuidedSearch)
+        search.settings = Settings()
+        search.log = AutotuningLogger(search.settings)
+        search._messages = []
+        search._all_benchmark_results = []
+        search._latest_results_by_config_key = {}
+        search.configs_per_round = 15
+        search._llm_call_times = []
+        search._benchmark_times = []
+        search.model = "gpt-5-2"
+        search.api_base = None
+        search.api_key = None
+        search.request_timeout_s = 120.0
+
+        # Mock config_spec with a normalize that accepts anything
+        search.config_spec = SimpleNamespace(
+            normalize=lambda raw, _fix_invalid=False: None,
+            default_config=lambda: helion.Config(block_sizes=[64]),
+            _flat_fields=dict,
+        )
+        search._default_config_dict = dict(search.config_spec.default_config())
+        for name, value in overrides.items():
+            setattr(search, name, value)
+        return search
+
+    def test_parse_configs_accepts_common_llm_outputs(self):
+        """LLM config parsing accepts the response shapes we expect to see in practice."""
+        import json
+
+        from helion.autotuner.llm_search import LLMGuidedSearch
+
+        # Critical subflow: accept the response wrappers and cleanup patterns
+        # we expect from real LLM/provider output while deduplicating configs.
+        cases = [
+            (
+                "structured",
+                json.dumps(
+                    {"configs": [{"block_sizes": [64]}, {"block_sizes": [128]}]}
+                ),
+                2,
+            ),
+            (
+                "python-literals",
+                '{"configs": [{"block_sizes": [64], "maxnreg": None, "flag": True}]}',
+                1,
+            ),
+            (
+                "deduplicates",
+                json.dumps({"configs": [{"block_sizes": [64]}, {"block_sizes": [64]}]}),
+                1,
+            ),
+            ("malformed", "not json at all", 0),
+        ]
+
+        for name, response, expected in cases:
+            with self.subTest(name=name):
+                search = self._make_mock_search()
+                configs = LLMGuidedSearch._parse_configs(search, response)
+                self.assertEqual(len(configs), expected)
+
+    def test_parse_configs_rejects_shape_guesses(self):
+        """LLM config parsing rejects guessed scalar/list shapes instead of repairing them."""
+        from helion.autotuner.llm_search import LLMGuidedSearch
+
+        # Critical subflow: reject scalar-vs-list shape guesses so invalid
+        # LLM output cannot silently morph into a different config.
+        search = self._make_mock_search(
+            config_spec=SimpleNamespace(
+                normalize=lambda raw, _fix_invalid=False: None,
+                default_config=lambda: helion.Config(block_sizes=[64, 64], num_warps=4),
+                _flat_fields=lambda: {
+                    "block_sizes": ListOf(IntegerFragment(1, 256, 64), length=2),
+                    "num_stages": IntegerFragment(1, 8, 2),
+                    "num_warps": PowerOfTwoFragment(1, 32, 4),
+                },
+            ),
+        )
+        search._default_config_dict = dict(search.config_spec.default_config())
+
+        cases = [
+            ("non-power-of-two num_warps", '{"configs": [{"num_warps": 6}]}', 0),
+            ("scalar block_sizes", '{"configs": [{"block_sizes": 64}]}', 0),
+            ("list scalar field", '{"configs": [{"num_stages": [2]}]}', 0),
+            (
+                "well-shaped config",
+                '{"configs": [{"block_sizes": [64, 128], "num_warps": 8, "num_stages": 2}]}',
+                1,
+            ),
+        ]
+
+        for name, response, expected in cases:
+            with self.subTest(name=name):
+                configs = LLMGuidedSearch._parse_configs(search, response)
+                self.assertEqual(len(configs), expected)
+
+    def test_context_window_keeps_prefix_and_recent_history(self):
+        """Prompt context always keeps the fixed prefix and trims only old round history."""
+        from helion.autotuner.llm_search import _MAX_CONTEXT_ROUNDS
+        from helion.autotuner.llm_search import LLMGuidedSearch
+
+        # Critical subflow: keep the fixed prompt prefix intact while trimming
+        # only stale round history from the rolling conversation window.
+        for short_history in (False, True):
+            with self.subTest(short_history=short_history):
+                search = self._make_mock_search()
+                search._messages = [
+                    {"role": "system", "content": "system"},
+                    {"role": "user", "content": "initial"},
+                ]
+                if short_history:
+                    search._messages.append(
+                        {"role": "assistant", "content": "response"}
+                    )
+                    expected_len = 3
+                else:
+                    for i in range(10):
+                        search._messages.append(
+                            {"role": "user", "content": f"round {i}"}
+                        )
+                        search._messages.append(
+                            {"role": "assistant", "content": f"resp {i}"}
+                        )
+                    expected_len = 2 + _MAX_CONTEXT_ROUNDS * 2
+
+                context = LLMGuidedSearch._get_context_messages(search)
+                self.assertEqual(context[0]["content"], "system")
+                self.assertEqual(context[1]["content"], "initial")
+                self.assertEqual(len(context), expected_len)
+
+    def test_profile_kwargs_defaults_and_supported_env_overrides(self):
+        """Profile kwargs use the supported env overrides and ignore unsupported ones."""
+        from helion.autotuner.llm_search import LLMGuidedSearch
+
+        # Critical subflow: profile resolution should honor supported env
+        # overrides without letting deprecated knobs leak into runtime kwargs.
+        kwargs = LLMGuidedSearch.get_kwargs_from_profile(
+            get_effort_profile("full"), Settings()
+        )
+        self.assertEqual(kwargs["model"], "gpt-5-2")
+        self.assertEqual(kwargs["configs_per_round"], 15)
+        self.assertEqual(kwargs["max_rounds"], 4)
+        self.assertEqual(kwargs["initial_random_configs"], 10)
+        self.assertNotIn("compile_timeout_s", kwargs)
+
+        quick_kwargs = LLMGuidedSearch.get_kwargs_from_profile(
+            get_effort_profile("quick"), Settings()
+        )
+        self.assertEqual(quick_kwargs["max_rounds"], 1)
+        self.assertEqual(quick_kwargs["initial_random_configs"], 10)
+
+        with patch.dict(
+            os.environ,
+            {
+                "HELION_LLM_PROVIDER": "openai",
+                "HELION_LLM_MODEL": "gpt-4.1-mini",
+                "HELION_LLM_COMPILE_TIMEOUT_S": "21",
+                "HELION_LLM_INITIAL_RANDOM_CONFIGS": "99",
+                "HELION_LLM_TEMPERATURE": "0.9",
+                "HELION_LLM_MAX_OUTPUT_TOKENS": "9999",
+            },
+            clear=False,
+        ):
+            kwargs = LLMGuidedSearch.get_kwargs_from_profile(
+                get_effort_profile("full"), Settings()
+            )
+        self.assertEqual(kwargs["provider"], "openai")
+        self.assertEqual(kwargs["model"], "gpt-4.1-mini")
+        self.assertEqual(kwargs["initial_random_configs"], 10)
+        self.assertNotIn("compile_timeout_s", kwargs)
+        self.assertNotIn("temperature", kwargs)
+        self.assertNotIn("max_output_tokens", kwargs)
+
+    @onlyBackends(["triton"])
+    def test_autotune_runs_full_llm_guided_loop_with_mocked_provider(self):
+        """LLM-guided search runs the public round loop with mocked LLM and benchmark backends."""
+        import concurrent.futures
+        import json
+
+        from helion.autotuner.base_search import BenchmarkResult
+        from helion.autotuner.llm_search import LLMGuidedSearch
+
+        # End-to-end LLM flow: run the public autotune entrypoint with the
+        # real round orchestration, while mocking only provider I/O and timing.
+        class FakeBenchmarkProvider:
+            def __init__(
+                self,
+                *,
+                kernel,
+                settings,
+                config_spec,
+                args,
+                log,
+                autotune_metrics,
+            ) -> None:
+                del kernel, settings, config_spec, args, log, autotune_metrics
+                self.mutated_arg_indices: list[int] = []
+                self.setup_called = False
+                self.cleanup_called = False
+
+            def setup(self) -> None:
+                self.setup_called = True
+
+            def cleanup(self) -> None:
+                self.cleanup_called = True
+
+        args = (
+            torch.randn([128, 128], device=DEVICE, dtype=torch.float16),
+            torch.randn([128, 128], device=DEVICE, dtype=torch.float16),
+        )
+        bound = _get_examples_matmul().bind(args)
+        default_config = bound.config_spec.default_config()
+        search = LLMGuidedSearch(
+            bound,
+            args,
+            configs_per_round=2,
+            max_rounds=3,
+            initial_random_configs=0,
+        )
+        search._benchmark_provider_cls = FakeBenchmarkProvider
+        search._default_config_dict = dict(default_config)
+
+        def sparse_config(cfg: helion.Config) -> dict[str, object]:
+            return {
+                key: value
+                for key, value in dict(cfg).items()
+                if key not in default_config or value != default_config[key]
+            }
+
+        def collect_candidate_configs(count: int) -> list[helion.Config]:
+            candidates: list[helion.Config] = []
+            seen = {repr(default_config)}
+            raw_candidates = [
+                {"num_warps": 8},
+                {"num_stages": 2},
+                {"pid_type": "xyz"},
+                {"num_warps": 8, "num_stages": 2},
+                {"num_warps": 8, "pid_type": "xyz"},
+            ]
+            for raw in raw_candidates:
+                parsed = search._parse_configs(json.dumps({"configs": [raw]}))
+                if not parsed:
+                    continue
+                candidate = parsed[0]
+                key = repr(candidate)
+                if key in seen:
+                    continue
+                seen.add(key)
+                candidates.append(candidate)
+                if len(candidates) == count:
+                    return candidates
+            raise AssertionError(
+                f"Could not find {count} valid non-default configs for matmul"
+            )
+
+        round0_cfg, round1_cfg = collect_candidate_configs(2)
+        default_key = repr(default_config)
+        round0_key = repr(round0_cfg)
+        round1_key = repr(round1_cfg)
+        round0_sparse = sparse_config(round0_cfg)
+        round1_sparse = sparse_config(round1_cfg)
+
+        llm_requests: list[list[dict[str, str]]] = []
+        benchmark_batches: list[tuple[str, list[dict[str, object]]]] = []
+        rebenchmark_descs: list[str] = []
+        async_request_count = 0
+        sync_request_count = 0
+        llm_responses = iter(
+            [
+                json.dumps({"configs": [{}, round0_sparse]}),
+                json.dumps({"configs": [round0_sparse, round1_sparse]}),
+                json.dumps({"configs": [round1_sparse]}),
+            ]
+        )
+        perf_by_key = {
+            default_key: 10.0,
+            round0_key: 5.0,
+            round1_key: 3.0,
+        }
+        rebench_perf_by_key = {
+            default_key: 9.5,
+            round0_key: 4.5,
+            round1_key: 2.5,
+        }
+
+        def fake_call_llm_async(
+            self, messages: list[dict[str, str]]
+        ) -> concurrent.futures.Future[str]:
+            del self
+            nonlocal async_request_count
+            async_request_count += 1
+            llm_requests.append([dict(message) for message in messages])
+            future: concurrent.futures.Future[str] = concurrent.futures.Future()
+            future.set_result(next(llm_responses))
+            return future
+
+        def fake_call_llm(self, messages: list[dict[str, str]]) -> str:
+            del self
+            nonlocal sync_request_count
+            sync_request_count += 1
+            llm_requests.append([dict(message) for message in messages])
+            return next(llm_responses)
+
+        def fake_benchmark_batch(
+            self, configs: list[helion.Config], *, desc: str = "Benchmarking"
+        ) -> list[BenchmarkResult]:
+            batch_keys = [repr(config) for config in configs]
+            benchmark_batches.append(
+                (desc, [sparse_config(config) for config in configs])
+            )
+
+            results: list[BenchmarkResult] = []
+            for config, key in zip(configs, batch_keys, strict=True):
+                perf = perf_by_key[key]
+                self.best_perf_so_far = min(self.best_perf_so_far, perf)
+                self._autotune_metrics.num_configs_tested += 1
+                results.append(
+                    BenchmarkResult(
+                        config=config,
+                        fn=lambda: None,
+                        perf=perf,
+                        status="ok",
+                        compile_time=0.01,
+                    )
+                )
+            return results
+
+        def fake_rebenchmark_population(self, members=None, *, desc="Rebenchmarking"):
+            del members
+            rebenchmark_descs.append(desc)
+            for member in self.population:
+                member.perfs.append(rebench_perf_by_key[repr(member.config)])
+
+        with (
+            patch.object(
+                LLMGuidedSearch,
+                "_call_llm_async",
+                autospec=True,
+                side_effect=fake_call_llm_async,
+            ),
+            patch.object(
+                LLMGuidedSearch,
+                "_call_llm",
+                autospec=True,
+                side_effect=fake_call_llm,
+            ),
+            patch.object(
+                LLMGuidedSearch,
+                "benchmark_batch",
+                autospec=True,
+                side_effect=fake_benchmark_batch,
+            ),
+            patch.object(
+                LLMGuidedSearch,
+                "rebenchmark_population",
+                autospec=True,
+                side_effect=fake_rebenchmark_population,
+            ),
+        ):
+            best = search.autotune(skip_cache=True)
+
+        self.assertEqual(dict(best), dict(round1_cfg))
+        self.assertTrue(search.benchmark_provider.setup_called)
+        self.assertTrue(search.benchmark_provider.cleanup_called)
+        self.assertEqual(len(llm_requests), 3)
+        self.assertEqual(async_request_count, 1)
+        self.assertEqual(sync_request_count, 2)
+        self.assertEqual([len(messages) for messages in llm_requests], [2, 4, 6])
+        self.assertIn("4.5000 ms", llm_requests[1][-1]["content"])
+        self.assertIn("2.5000 ms", llm_requests[2][-1]["content"])
+        self.assertEqual(
+            [desc for desc, _ in benchmark_batches],
+            ["Round 0 seed", "Round 0 LLM", "Round 1"],
+        )
+        self.assertEqual(benchmark_batches[0][1], [sparse_config(default_config)])
+        self.assertEqual(benchmark_batches[1][1], [round0_sparse])
+        self.assertEqual(benchmark_batches[2][1], [round1_sparse])
+        self.assertEqual(
+            rebenchmark_descs,
+            ["Round 0: verifying top configs", "Round 1: verifying top configs"],
+        )
+        self.assertEqual(search._autotune_metrics.num_configs_tested, 3)
+        self.assertEqual(len(search._all_benchmark_results), 3)
+        self.assertEqual(len(search.population), 3)
+        self.assertEqual(search.best.perf, 2.5)
+        self.assertEqual(dict(best), dict(round1_cfg))
+        self.assertEqual(dict(search.best.config), dict(round1_cfg))
+
+
+class TestLLMTransport(TestCase):
+    """Tests for provider selection and HTTP payload translation."""
+
+    @staticmethod
+    def _response_payload(
+        provider: str, text: str = '{"configs": []}'
+    ) -> dict[str, object]:
+        if provider == "openai_responses":
+            return {"output": [{"content": [{"type": "text", "text": text}]}]}
+        return {"content": [{"type": "text", "text": text}]}
+
+    def test_transport_helpers_and_http_request_shapes(self):
+        """Provider helpers build the expected request/response shapes for each backend."""
+        from helion.autotuner.llm.transport import _resolve_api_base
+        from helion.autotuner.llm.transport import _resolve_api_key
+        from helion.autotuner.llm.transport import _resolve_v1_endpoint
+        from helion.autotuner.llm.transport import call_provider
+        from helion.autotuner.llm.transport import extract_anthropic_text
+        from helion.autotuner.llm.transport import extract_openai_response_text
+        from helion.autotuner.llm.transport import infer_provider
+        from helion.autotuner.llm.transport import responses_input_from_messages
+        from helion.autotuner.llm.transport import split_system_messages
+
+        # Critical subflow: transport must normalize provider selection,
+        # request payloads, and response parsing across supported backends.
+        self.assertEqual(infer_provider("claude-haiku-4.5"), "anthropic")
+        self.assertEqual(infer_provider("gpt-5-2"), "openai_responses")
+        self.assertEqual(infer_provider("custom/model"), "unsupported")
+        self.assertEqual(infer_provider("custom/model", "anthropic"), "anthropic")
+        self.assertEqual(infer_provider("custom/model", "openai"), "openai_responses")
+        with self.assertRaisesRegex(ValueError, "Unsupported LLM provider"):
+            infer_provider("gpt-5-2", "bogus")
+
+        self.assertEqual(
+            _resolve_v1_endpoint("https://api.openai.com", "responses"),
+            "https://api.openai.com/v1/responses",
+        )
+        self.assertEqual(
+            _resolve_v1_endpoint("https://api.openai.com/v1", "responses"),
+            "https://api.openai.com/v1/responses",
+        )
+        self.assertEqual(
+            _resolve_v1_endpoint("https://proxy.example/v1/messages", "messages"),
+            "https://proxy.example/v1/messages",
+        )
+        self.assertEqual(
+            _resolve_api_base("openai_responses", "https://explicit.example/v1"),
+            "https://explicit.example/v1",
+        )
+        self.assertEqual(
+            _resolve_api_key("openai_responses", "explicit-key"), "explicit-key"
+        )
+
+        system, history = split_system_messages(
+            [
+                {"role": "system", "content": "tune kernels"},
+                {"role": "user", "content": "suggest configs"},
+                {"role": "assistant", "content": '{"configs": []}'},
+            ]
+        )
+        self.assertEqual(system, "tune kernels")
+        self.assertEqual(
+            [message["role"] for message in history], ["user", "assistant"]
+        )
+
+        payload = responses_input_from_messages(
+            [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "world"},
+            ]
+        )
+        self.assertEqual(
+            payload[0]["content"], [{"type": "input_text", "text": "hello"}]
+        )
+        self.assertEqual(
+            payload[1]["content"], [{"type": "output_text", "text": "world"}]
+        )
+        self.assertEqual(
+            extract_openai_response_text(
+                {
+                    "output": [
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": '{"configs": []}'}],
+                        }
+                    ]
+                }
+            ),
+            '{"configs": []}',
+        )
+        self.assertEqual(
+            extract_anthropic_text(
+                {
+                    "content": [
+                        {"type": "text", "text": '{"configs": [{"num_warps": 4}]}'}
+                    ]
+                }
+            ),
+            '{"configs": [{"num_warps": 4}]}',
+        )
+
+        captured = {}
+        messages = [
+            {"role": "system", "content": "tune kernels"},
+            {"role": "user", "content": "suggest configs"},
+            {"role": "assistant", "content": '{"configs": []}'},
+        ]
+
+        def fake_post_json(url, payload, headers, *, request_timeout_s):
+            captured["url"] = url
+            captured["payload"] = payload
+            captured["headers"] = headers
+            captured["request_timeout_s"] = request_timeout_s
+
+        cases = [
+            {
+                "name": "openai",
+                "provider": "openai_responses",
+                "response_payload": self._response_payload("openai_responses"),
+                "expected_text": '{"configs": []}',
+                "model": "gpt-5-2",
+                "api_base": "https://api.openai.com",
+                "expected_url": "https://api.openai.com/v1/responses",
+                "api_key": "openai-test-key",
+                "request_assertions": lambda captured: (
+                    self.assertEqual(
+                        captured["headers"]["Authorization"],
+                        "Bearer openai-test-key",
+                    ),
+                    self.assertEqual(
+                        captured["payload"]["instructions"], "tune kernels"
+                    ),
+                    self.assertEqual(captured["payload"]["input"][0]["role"], "user"),
+                ),
+            },
+            {
+                "name": "anthropic",
+                "provider": "anthropic",
+                "response_payload": self._response_payload(
+                    "anthropic", '{"configs": [{"num_warps": 4}]}'
+                ),
+                "expected_text": '{"configs": [{"num_warps": 4}]}',
+                "model": "claude-3-5-haiku-latest",
+                "api_base": "https://api.anthropic.com",
+                "expected_url": "https://api.anthropic.com/v1/messages",
+                "api_key": "anthropic-test-key",
+                "request_assertions": lambda captured: (
+                    self.assertEqual(
+                        captured["headers"]["x-api-key"],
+                        "anthropic-test-key",
+                    ),
+                    self.assertEqual(captured["payload"]["system"], "tune kernels"),
+                    self.assertEqual(
+                        captured["payload"]["messages"][0]["role"], "user"
+                    ),
+                ),
+            },
+        ]
+
+        for case in cases:
+            with self.subTest(name=case["name"]):
+                captured.clear()
+
+                def fake_post_json_with_response(
+                    url,
+                    payload,
+                    headers,
+                    *,
+                    request_timeout_s,
+                    response_payload=case["response_payload"],
+                ):
+                    fake_post_json(
+                        url,
+                        payload,
+                        headers,
+                        request_timeout_s=request_timeout_s,
+                    )
+                    return response_payload
+
+                with (
+                    patch.dict(os.environ, {}, clear=True),
+                    patch(
+                        "helion.autotuner.llm.transport._post_json",
+                        side_effect=fake_post_json_with_response,
+                    ),
+                ):
+                    response = call_provider(
+                        case["provider"],
+                        model=case["model"],
+                        api_base=case["api_base"],
+                        api_key=case["api_key"],
+                        messages=messages,
+                        max_output_tokens=512,
+                        request_timeout_s=120.0,
+                    )
+                self.assertEqual(response, case["expected_text"])
+                self.assertEqual(captured["url"], case["expected_url"])
+                self.assertEqual(captured["request_timeout_s"], 120.0)
+                case["request_assertions"](captured)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -2676,7 +2676,7 @@ class TestLLMGuidedSearch(TestCase):
         self.assertEqual(kwargs["configs_per_round"], 15)
         self.assertEqual(kwargs["max_rounds"], 4)
         self.assertEqual(kwargs["initial_random_configs"], 10)
-        self.assertNotIn("compile_timeout_s", kwargs)
+        self.assertEqual(kwargs["compile_timeout_s"], 15)
 
         quick_kwargs = LLMGuidedSearch.get_kwargs_from_profile(
             get_effort_profile("quick"), Settings()
@@ -2702,7 +2702,7 @@ class TestLLMGuidedSearch(TestCase):
         self.assertEqual(kwargs["provider"], "openai")
         self.assertEqual(kwargs["model"], "gpt-4.1-mini")
         self.assertEqual(kwargs["initial_random_configs"], 10)
-        self.assertNotIn("compile_timeout_s", kwargs)
+        self.assertEqual(kwargs["compile_timeout_s"], 21)
         self.assertNotIn("temperature", kwargs)
         self.assertNotIn("max_output_tokens", kwargs)
 


### PR DESCRIPTION
Stacked PRs:
 * #2004
 * __->__#2003

--- --- ---
### [Autotuner] Adding LLM-guided search

Prompting an LLM (GPT-5.2) to get the configs:
<img width="1418" height="142" alt="image" src="https://github.com/user-attachments/assets/42708d34-4c40-40d7-a2df-1887edf93976" />

Rn indicates the number of rounds of LLM prompts. 
Rn_speedup indicates the speedup of nth round of LLM vs LFBO full autotuning. 
Rn_time/LFBO compares the wall clock time it takes to finish the nth round of LLM vs LFBO full autotuning. 

For simple kernels (matmul, rms_norm), LLM is able to one shot the config with on par perf as LFBO full autotuning at a fraction (10s, 10-20%) of LFBO full autotuning time. 
For 4th round, most kernels get pretty close in perf. 4 LLM rounds take 20-30% of LFBO full autotuning time. 
There are cases where perf does not improve after more LLM rounds. 

Opus 4.6 results - rms_norm 1.57x speedup @ 32% tuning time. 
<img width="713" height="140" alt="image" src="https://github.com/user-attachments/assets/009555d4-7ffb-4602-9cc2-0e24f8e9b014" />

### High-level flow:
1. Initialize the prompt context from the kernel, config space, and default
   config so the first LLM call sees both the workload description and the
   available tuning knobs.
2. Round 0 launches the first LLM call immediately, then benchmarks the
   default config plus a few random seed configs while that request is in
   flight.
3. When the round-0 LLM response arrives, the search benchmarks its new unique
   configs and folds those results into the running set of top configs.
4. The top configs are then rebenchmarked before the next prompt is built, so each
   later LLM round sees the latest stabilized timings instead of only one-shot
   measurements.
5. Later rounds repeat a synchronous cycle: build prompt from the latest
   search state, query the LLM, benchmark new configs, then rebenchmark the
   strongest configs.
6. The final returned config comes from the best rebenchmarked config. The search can early-stop after 2 consecutive rounds without a meaningful improvement. 

### How to run it:
Specify the autotuner, model, and API keys:
 export HELION_AUTOTUNER=LLMGuidedSearch/LLMSeededLFBOTreeSearch (next PR)
 export HELION_LLM_MODEL=gpt-5-2/claude-...
 export OPENAI_API_KEY=... or export ANTHROPIC_API_KEY=...
 
If not using the API KEYs directly (devservers), you need to use:
  export HELION_LLM_API_BASE=...
  export HELION_LLM_CA_BUNDLE=...
  export HELION_LLM_CLIENT_CERT=...
  export HELION_LLM_CLIENT_KEY=...
