### PR TITLE
Make _get_tile_with_offset_info accept a torch.fx.Node as arg, instead of the entire CodegenState

### DIFF
--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -77,7 +77,7 @@ def _get_padded_iota_original_length(
 
 
 def _get_tile_with_offset_info(
-    k: object, state: CodegenState, k_index: int
+    k: object, fx_node: torch.fx.Node | None, k_index: int
 ) -> TileWithOffsetInfo | None:
     """Check if the subscript at k_index has tile_with_offset metadata.
 
@@ -86,15 +86,15 @@ def _get_tile_with_offset_info(
         state: The codegen state containing the FX node
         k_index: The index of k in the subscript list
     """
-    if state.fx_node is None:
+    if fx_node is None:
         return None
 
     # Get the subscript list from the FX node's arguments
     # args[0] is the tensor, args[1] is the subscript list
-    if len(state.fx_node.args) < 2:
+    if len(fx_node.args) < 2:
         return None
 
-    subscript_arg = state.fx_node.args[1]
+    subscript_arg = fx_node.args[1]
     if not isinstance(subscript_arg, (list, tuple)):
         return None
 
@@ -249,7 +249,7 @@ class PointerIndexingStrategy(IndexingStrategy):
                 # Scalar int index - consumes tensor dim but adds scalar to pointer
                 tensor_dim += 1
             elif _get_tile_with_offset_info(
-                k, state, k_index
+                k, state.fx_node, k_index
             ) is not None or isinstance(k, torch.Tensor):
                 # Tensor index (tile.index + offset or regular tensor) - block index
                 if not env.known_equal(fake_tensor.size(tensor_dim), 1):
@@ -454,7 +454,9 @@ class TensorDescriptorIndexingStrategy(IndexingStrategy):
                 block_size = env.allocate_reduction_dimension(size).from_config(config)
                 if not valid_block_size(block_size, stride, i):
                     return False
-            elif (tile_info := _get_tile_with_offset_info(k, state, i)) is not None:
+            elif (
+                tile_info := _get_tile_with_offset_info(k, state.fx_node, i)
+            ) is not None:
                 # Tensor marked as tile.index + offset
                 block_size = (
                     tile_info.block_size
@@ -757,7 +759,9 @@ class SubscriptIndexing(NamedTuple):
                 input_size.popleft()
             elif (
                 state is not None
-                and (tile_info := _get_tile_with_offset_info(k, state, position))
+                and (
+                    tile_info := _get_tile_with_offset_info(k, state.fx_node, position)
+                )
                 is not None
             ):
                 # Tensor marked as tile.index + offset
@@ -956,7 +960,9 @@ class SubscriptIndexing(NamedTuple):
                 output_idx += 1
             elif isinstance(k, int):
                 index_values.append(repr(k))
-            elif (tile_info := _get_tile_with_offset_info(k, state, n)) is not None:
+            elif (
+                tile_info := _get_tile_with_offset_info(k, state.fx_node, n)
+            ) is not None:
                 # Tensor marked as tile.index + offset
                 block_id = _resolve_codegen_block_id(state, tile_info.block_id)
                 full_block_size = env.block_sizes[env.canonical_block_id(block_id)].var
@@ -1289,7 +1295,7 @@ class BlockedSubscriptIndexing:
             input_size = 1 if k is None else input_sizes.popleft()
             # Check for tile+offset tensor first before other checks
             if (
-                tile_info := _get_tile_with_offset_info(k, state, position)
+                tile_info := _get_tile_with_offset_info(k, state.fx_node, position)
             ) is not None:
                 # Tensor marked as tile.index + offset - treat like TileWithOffset
                 block_index = _resolve_codegen_block_id(state, tile_info.block_id)
@@ -1363,7 +1369,9 @@ class BlockedSubscriptIndexing:
             elif isinstance(k, int):
                 res.offsets.append(repr(k))
                 res.block_shape.append(1)
-            elif (tile_info := _get_tile_with_offset_info(k, state, n)) is not None:
+            elif (
+                tile_info := _get_tile_with_offset_info(k, state.fx_node, n)
+            ) is not None:
                 # Tensor marked as tile.index + offset
                 if fake_value.size(len(res.offsets)) != 1:
                     block_id = _resolve_codegen_block_id(state, tile_info.block_id)


### PR DESCRIPTION
Stacked PRs:
 * #2007
 * #2006
 * __->__#2005


--- --- ---

Make _get_tile_with_offset_info accept a torch.fx.Node as arg, instead of the entire CodegenState. This will be useful in #2007 