### PR TITLE
[Pallas] Make test_tensor_access_tile_index_offset more meaningful and reveal codegen issue in Pallas backend

### DIFF
--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -679,37 +679,41 @@ class TestPallas(TestCase):
         expected = x + 0.5
         torch.testing.assert_close(result, expected)
 
+    @xfailIfPallas("Pallas backend not correctly handling tile index with offset")
     def test_tensor_access_tile_index_offset(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
-        def fn(x: torch.Tensor) -> torch.Tensor:
+        def fn(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
             (n,) = x.size()
             out = torch.zeros(n, device=DEVICE, dtype=torch.float32)
             for tile in hl.tile(n // 2):
                 out[tile] = x[tile]
-                out[tile.index + n // 2] = x[tile.index + n // 2]
+                out[tile.index + n // 2] = y[tile.index + n // 2]
             return out
 
         x = torch.randn(128, device=DEVICE, dtype=torch.float32)
-        result = fn(x)
-        torch.testing.assert_close(result, x)
+        y = torch.randn(128, device=DEVICE, dtype=torch.float32)
+        result = fn(x, y)
+        torch.testing.assert_close(result, torch.concat((x[:64], y[64:])))
 
+    @xfailIfPallas("Pallas backend not correctly handling tile index with offset")
     def test_tensor_access_tile_index_offset_2d(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
-        def fn(x: torch.Tensor) -> torch.Tensor:
+        def fn(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
             (n, m) = x.size()
             out = torch.zeros(x.size(), device=DEVICE, dtype=torch.float32)
             for tile1, tile2 in hl.tile([n // 2, m // 2]):
                 out[tile1, tile2] = x[tile1, tile2]
-                out[tile1.index + n // 2, tile2] = x[tile1.index + n // 2, tile2]
+                out[tile1.index + n // 2, tile2] = y[tile1.index + n // 2, tile2]
                 out[tile1, tile2 + m // 2] = x[tile1, tile2 + m // 2]
-                out[tile1.index + n // 2, tile2 + m // 2] = x[
+                out[tile1.index + n // 2, tile2 + m // 2] = y[
                     tile1.index + n // 2, tile2 + m // 2
                 ]
             return out
 
         x = torch.randn(128, 128, device=DEVICE, dtype=torch.float32)
-        _, result = code_and_output(fn, (x,), block_size=[128, 128])
-        torch.testing.assert_close(result, x)
+        y = torch.randn(128, 128, device=DEVICE, dtype=torch.float32)
+        _, result = code_and_output(fn, (x, y), block_size=[128, 128])
+        torch.testing.assert_close(result, torch.concat((x[:64, :], y[64:, :])))
 
     def test_tensor_access_tile_id(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True, config=helion.Config())


### PR DESCRIPTION
Stacked PRs:
 * #2007
 * __->__#2006


--- --- ---

[Pallas] Make test_tensor_access_tile_index_offset more meaningful and reveal codegen issue in Pallas backend

For the existing test, we're generating the following pallas code:
```py
def _helion_fn(x, out):
    # src[tpu_tensor_access_tile_index_offset.py:18]: for tile in hl.tile(n // 2):
    pid_0 = pl.program_id(0)
    offset_0 = pid_0 * _BLOCK_SIZE_0
    indices_0 = offset_0 + jnp.arange(0, _BLOCK_SIZE_0, dtype=jnp.int32)
    # src[tpu_tensor_access_tile_index_offset.py:19]: out[tile] = x[tile]
    load = x[:]
    out[:] = load
    # src[tpu_tensor_access_tile_index_offset.py:20]: out[tile.index + n // 2] = x[tile.index + n // 2]
    v_0 = jnp.array(64, dtype=jnp.int32)
    v_1 = indices_0 + v_0
    load_1 = x[:]
    v_2 = jnp.array(64, dtype=jnp.int32)
    v_3 = indices_0 + v_2
    out[:] = load_1

def fn(x: torch.Tensor, *, _launcher=_default_pallas_launcher):
    # src[tpu_tensor_access_tile_index_offset.py:16]: (n,) = x.size()
    n, = x.size()
    # src[tpu_tensor_access_tile_index_offset.py:17]: out = torch.zeros(n, device=DEVICE, dtype=torch.float32)
    out = torch.zeros(n, device=_source_module.DEVICE, dtype=torch.float32)
    # src[tpu_tensor_access_tile_index_offset.py:18]: for tile in hl.tile(n // 2):
    _BLOCK_SIZE_0 = 64
    # src[tpu_tensor_access_tile_index_offset.py:18]: for tile in hl.tile(n // 2):
    # src[tpu_tensor_access_tile_index_offset.py:19]:     out[tile] = x[tile]
    # src[tpu_tensor_access_tile_index_offset.py:20]:     out[tile.index + n // 2] = x[tile.index + n // 2]
    _launcher(_helion_fn, ((64 + _BLOCK_SIZE_0 - 1) // _BLOCK_SIZE_0,), x, out, _output_indices=[1], _inplace_indices=[1], _block_spec_info=[((None,), (None,)), ((None,), (None,))])
    # src[tpu_tensor_access_tile_index_offset.py:21]: return out
    return out
```

This is not really correct, we're not really generating the `index+offset` expr, but the test happened to pass because the test case is too simple and we're using values from `x` in both halves. This PR updates this test to reveal the codegen bug in Pallas.