### PR TITLE
[Pallas] Add a `plan_tiling` pre_codegen pass to make more consistent tiling and indexing decisions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,6 +207,9 @@ jobs:
           export SITE_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
           bazel build -c opt //ci/wheel:torch_tpu_wheel --config=helion_public_caching_readwrite --define WHEEL_VERSION=0.1.0 --define TORCH_SOURCE=local --action_env=PYTHONPATH=$TORCH_SOURCE:$SITE_PACKAGES --action_env=JAX_PLATFORMS=cpu
           uv pip install bazel-bin/ci/wheel/*.whl
+          # torch_tpu wheel is pinned to libtpu 0.0.38, but helion requires 0.0.40 to work
+          # we can remove this step as soon as torch_tpu updates its libtpu pin
+          uv pip install libtpu==0.0.40
           cd -
           rm -rf /tmp/torch_tpu
           # Verify

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1311,8 +1311,8 @@ class PallasBackend(Backend):
     ):
         """Compute per-tensor ``(block_shape, grid_dims)`` from codegen tiling info.
 
-        Uses ``DeviceFunction.pallas_tensor_dim_block_ids`` (recorded during
-        load/store codegen from SymInt subscripts) for an unambiguous
+        Uses ``DeviceFunction.pallas_tensor_dim_tilings`` (recorded during
+        ``plan_tiling`` from SymInt subscripts) for an unambiguous
         dim → block_id mapping.
         """
         if sorted_args is None:
@@ -1383,11 +1383,21 @@ class PallasBackend(Backend):
             if not isinstance(arg, TensorArg) or arg.fake_value.ndim == 0:
                 continue
             tensor = arg.fake_value
-            dim_block_ids = device_fn.pallas_tensor_dim_block_ids.get(id(tensor), {})
+            dim_tilings = device_fn.pallas_tensor_dim_tilings.get(id(tensor))
+            if dim_tilings is None:
+                # this means this tensor isn't accessed at all in the kernel
+                result.append(None)
+                return None
             block_shape: list[int | None] = []
             grid_dims: list[int | tuple[int, int, int] | None] = []
             for d in range(tensor.ndim):
-                bid = dim_block_ids.get(d)
+                dim_tiling = dim_tilings[d]
+                if not dim_tiling.can_tile or len(dim_tiling.block_ids) == 0:
+                    block_shape.append(None)
+                    grid_dims.append(None)
+                    continue
+                assert len(dim_tiling.block_ids) == 1
+                bid = dim_tiling.block_ids[0]
                 if bid is not None and bid in known_block_ids:
                     bs = env.block_sizes[bid].from_config(config)
                     if isinstance(bs, int):
@@ -1599,6 +1609,16 @@ class PallasBackend(Backend):
             return self.build_launcher_name(config)
         except Exception:
             return self.default_launcher_name
+
+    def pre_codegen(
+        self,
+        graphs: list[GraphInfo],
+        config: Config,
+        tile_strategy: TileStrategyDispatch,
+    ) -> None:
+        from .pallas.plan_tiling import plan_tiling
+
+        plan_tiling(graphs, config, tile_strategy)
 
 
 def _detect_mma_loop(

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
     from .generate_ast import GenerateAST
     from .indexing_strategy import IndexingStrategy
     from .program_id import ProgramIDs
+    from helion._compiler.pallas.plan_tiling import DimensionTiling
 
     _P = TypeVar("_P", bound="TensorPropertyArg")
 
@@ -318,8 +319,8 @@ class DeviceFunction:
         self.epilogue_subtile_store_indices: dict[str, int] = {}
         self.rng_seed_buffer_param_name = None
 
-        # Pallas: id(fake_tensor) → {dim: block_id}, recorded during codegen
-        self.pallas_tensor_dim_block_ids: dict[int, dict[int, int]] = {}
+        # Pallas: id(fake_tensor) → [DimensionTiling], recorded during `plan_tiling`
+        self.pallas_tensor_dim_tilings: dict[int, list[DimensionTiling]] = {}
         # Pallas: set of id(fake_tensor) for tensors accessed in pipeline body
         self.pallas_pipeline_tensor_ids: set[int] = set()
         # TODO(dunfanlu): consider duplicating and aliasing arguments if a tensor needs to be accessed via both VMEM and SMEM?

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -710,12 +710,13 @@ def generate_ast(
             load_transform=load_transform,
             extra_params=extra_params,
         )
-        CompileEnvironment.current().backend.pre_codegen(
-            graphs=codegen.codegen_graphs,
-            config=config,
-            tile_strategy=codegen.device_function.tile_strategy,
-        )
         with codegen.device_function:
+            CompileEnvironment.current().backend.pre_codegen(
+                graphs=codegen.codegen_graphs,
+                config=config,
+                tile_strategy=codegen.device_function.tile_strategy,
+            )
+
             for stmt in func.body:
                 codegen.add_statement(codegen.visit(stmt))
             kernel_def = codegen.device_function.codegen_function_def()

--- a/helion/_compiler/pallas/__init__.py
+++ b/helion/_compiler/pallas/__init__.py
@@ -1,0 +1,3 @@
+"""Pallas backend analysis passes."""
+
+from __future__ import annotations

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -1,0 +1,383 @@
+"""Tiling analysis pass for the Pallas backend.
+
+Analyzes indexing expressions to determine which tensor dimensions can be tiled.
+Sets 'dim_tilings' metadata on tensors based on indexing constraints.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from typing import TYPE_CHECKING
+
+import sympy
+import torch
+
+if TYPE_CHECKING:
+    from ...runtime.config import Config
+    from ..compile_environment import CompileEnvironment
+    from ..device_ir import GraphInfo
+    from ..host_function import SymbolOrigin
+    from ..tile_dispatch import TileStrategyDispatch
+
+
+@dataclass
+class IndexingPattern:
+    """Base class for indexing patterns detected during tiling analysis."""
+
+
+@dataclass
+class TilePattern(IndexingPattern):
+    """Vanilla tile pattern - translates to ':' when tiled."""
+
+    block_id: int
+
+
+@dataclass
+class TileIndexWithOffsetPattern(IndexingPattern):
+    """Tile index with offset - no tiling allowed."""
+
+    block_id: int
+    offset: int | torch.SymInt | object
+
+
+@dataclass
+class TileBeginWithOffsetPattern(IndexingPattern):
+    """Tile begin with offset - allow/disallow tiling based on bounds."""
+
+    block_id: int
+    offset: int | torch.SymInt | object
+
+
+@dataclass
+class ArbitrarySlicePattern(IndexingPattern):
+    slice: slice
+
+
+@dataclass
+class ArbitraryIndexPattern(IndexingPattern):
+    index: int | torch.SymInt | object | None
+
+
+@dataclass
+class NonePattern(IndexingPattern):
+    """None index pattern (broadcasting dimension) - allow tiling."""
+
+
+@dataclass
+class DimensionTiling:
+    """Tiling decision for a specific dimension of a tensor
+
+    can_tile: whether or not we can tile this dimension
+    block_ids: which which block_ids we are indexing this dimension (there can be multiple, in which case we mustn't tile)
+    """
+
+    can_tile: bool = True
+    block_ids: list[int] = field(default_factory=list)
+
+
+def plan_tiling(
+    graphs: list[GraphInfo],
+    config: Config,
+    tile_strategy: TileStrategyDispatch,
+) -> None:
+    for graph_info in graphs:
+        _analyze_indexing_expressions(graph_info, config)
+
+
+def _analyze_indexing_expressions(graph_info: GraphInfo, config: Config) -> None:
+    from ...language import atomic_ops
+    from ...language import memory_ops
+
+    for node in graph_info.graph.nodes:
+        if node.op != "call_function":
+            continue
+        if node.target in (
+            memory_ops.load,
+            memory_ops.store,
+            atomic_ops.atomic_add,
+            atomic_ops.atomic_cas,
+            atomic_ops.atomic_or,
+            atomic_ops.atomic_xor,
+            atomic_ops.atomic_xchg,
+            atomic_ops.atomic_min,
+            atomic_ops.atomic_max,
+            atomic_ops.atomic_and,
+        ):
+            _analyze_indexing(node, config)
+
+
+def _analyze_indexing(node: torch.fx.Node, config: Config) -> None:
+    tensor_arg = node.args[0]
+    subscript = node.args[1]
+
+    assert isinstance(subscript, (list, tuple))
+    assert isinstance(tensor_arg, torch.fx.Node)
+    tensor_val = tensor_arg.meta.get("val")
+    assert isinstance(tensor_val, torch.Tensor)
+
+    from helion._compiler.device_function import DeviceFunction
+
+    device_fn = DeviceFunction.current()
+    if id(tensor_val) not in device_fn.pallas_tensor_dim_tilings:
+        device_fn.pallas_tensor_dim_tilings[id(tensor_val)] = [
+            DimensionTiling() for _ in range(tensor_val.ndim)
+        ]
+    dim_tilings = device_fn.pallas_tensor_dim_tilings[id(tensor_val)]
+
+    # Store indexing patterns directly on the memory operation node
+    indexing_patterns = _analyze_subscript_patterns(
+        tensor_val, list(subscript), dim_tilings, node, config
+    )
+    node.meta["indexing_patterns"] = indexing_patterns
+
+
+def _analyze_subscript_patterns(
+    tensor: torch.Tensor,
+    subscript: list[object],
+    dim_tilings: list[DimensionTiling],
+    node: torch.fx.Node,
+    config: Config,
+) -> list[IndexingPattern]:
+    """Analyze subscript patterns and create indexing pattern metadata."""
+    from ..compile_environment import CompileEnvironment
+
+    env = CompileEnvironment.current()
+    patterns: list[IndexingPattern] = []
+    tensor_dim = 0  # Track which tensor dimension we're indexing
+
+    for i, idx in enumerate(subscript):
+        if idx is None:
+            # None adds an unsqueezed dimension but doesn't consume a tensor dimension
+            patterns.append(NonePattern())
+            continue
+
+        if tensor_dim >= tensor.ndim:
+            raise AssertionError(
+                f"Indexing {tensor_dim}th dim but tensor only has {tensor.ndim} dims"
+            )
+
+        # Detect different indexing patterns
+        pattern = _detect_indexing_pattern(idx, tensor, tensor_dim, node, i, env)
+        patterns.append(pattern)
+
+        # Update dim_tilings based on the detected pattern
+        _update_tiling_decision(tensor, pattern, tensor_dim, dim_tilings, env, config)
+
+        tensor_dim += 1
+
+    return patterns
+
+
+def _detect_indexing_pattern(
+    idx: object,
+    tensor: torch.Tensor,
+    tensor_dim: int,
+    node: torch.fx.Node,
+    subscript_index: int,
+    env: CompileEnvironment,
+) -> IndexingPattern:
+    """Detect the specific indexing pattern for a subscript element."""
+    from ..indexing_strategy import _get_tile_with_offset_info
+    from ..variable_origin import GridOrigin
+
+    if isinstance(idx, torch.fx.Node):
+        idx_val = idx.meta.get("val")
+        if isinstance(idx_val, torch.SymInt):
+            block_id = env.get_block_id(idx_val)
+            if block_id is not None:
+                symbol_origin = _maybe_get_symbol_origin(idx_val)
+                is_hl_grid = symbol_origin is not None and isinstance(
+                    symbol_origin.origin, GridOrigin
+                )
+                if not is_hl_grid:
+                    return TilePattern(block_id=block_id)
+
+        tile_with_offset = _get_tile_with_offset_info(idx_val, node, subscript_index)
+        if tile_with_offset is not None:
+            return TileIndexWithOffsetPattern(
+                block_id=tile_with_offset.block_id, offset=tile_with_offset.offset
+            )
+
+        # Check for TileBeginWithOffset pattern (t.begin, t.end-1)
+        tile_begin_with_offset = _maybe_get_tile_begin_with_offset_info(idx_val)
+        if tile_begin_with_offset is not None:
+            return TileBeginWithOffsetPattern(
+                block_id=tile_begin_with_offset.block_id,
+                offset=tile_begin_with_offset.offset,
+            )
+
+    if isinstance(idx, slice):
+        if idx != slice(None):
+            raise AssertionError(
+                f"Arbitrary slice expr {slice} not supported in Pallas backend yet"
+            )
+        return ArbitrarySlicePattern(idx)
+
+    if isinstance(idx, (int, torch.SymInt)):
+        return ArbitraryIndexPattern(idx)
+
+    raise AssertionError(f"Unrecognized indexing pattern for pallas backend {idx}")
+
+
+def _update_tiling_decision(
+    tensor: torch.Tensor,
+    pattern: IndexingPattern,
+    tensor_dim: int,
+    dim_tilings: list[DimensionTiling],
+    env: CompileEnvironment,
+    config: Config,
+) -> None:
+    """Update tiling decision based on the detected indexing pattern."""
+
+    curr_dim_tiling = dim_tilings[tensor_dim]
+
+    def _disallow_tiling() -> None:
+        curr_dim_tiling.can_tile = False
+
+    def _try_set_tiling_block_id(new_block_id: int) -> None:
+        if new_block_id not in curr_dim_tiling.block_ids:
+            curr_dim_tiling.block_ids.append(new_block_id)
+            if len(curr_dim_tiling.block_ids) > 1:
+                # we already need to tile this dim using a different block_id
+                # so fallback to no-tiling so that we can access using both tiles
+                _disallow_tiling()
+
+    if isinstance(pattern, TilePattern):
+        _try_set_tiling_block_id(pattern.block_id)
+
+    elif isinstance(pattern, TileIndexWithOffsetPattern):
+        _disallow_tiling()
+
+    elif isinstance(pattern, TileBeginWithOffsetPattern):
+        _try_set_tiling_block_id(pattern.block_id)
+        # check bounds
+        if not isinstance(pattern.offset, int) or pattern.offset < 0:
+            _disallow_tiling()
+        else:
+            block_size = env.block_sizes[pattern.block_id].from_config(config)
+            if isinstance(block_size, int) and pattern.offset >= block_size:
+                _disallow_tiling()
+
+    elif isinstance(pattern, ArbitrarySlicePattern):
+        if pattern.slice != slice(None):
+            # fow now we only support the `[:]` slice pattern
+            _disallow_tiling()
+
+    elif isinstance(pattern, ArbitraryIndexPattern):
+        _disallow_tiling()
+
+    elif isinstance(pattern, NonePattern):
+        pass
+
+    if isinstance(pattern, (TilePattern, TileBeginWithOffsetPattern)):
+        block_size = env.block_sizes[pattern.block_id].from_config(config)
+        if isinstance(block_size, int):
+            from ..compile_environment import CompileEnvironment
+
+            backend = CompileEnvironment.current().backend
+            from helion._compiler.backend import PallasBackend
+
+            assert isinstance(backend, PallasBackend)
+
+            dim_from_end = tensor.ndim - tensor_dim - 1
+            bitwidth = tensor.dtype.itemsize * 8
+            required_alignment = backend._get_pallas_required_alignment(
+                dim_from_end, tensor.ndim, bitwidth
+            )
+
+            if (
+                block_size < tensor.shape[tensor_dim]
+                and block_size % required_alignment != 0
+            ):
+                _disallow_tiling()
+
+
+# Helper functions moved from memory_ops.py
+def _maybe_get_symbol_origin(idx: object) -> SymbolOrigin | None:
+    """Get symbol origin for a subscript element."""
+    from ..compile_environment import _symint_expr
+    from ..host_function import HostFunction
+
+    if not isinstance(idx, torch.SymInt):
+        return None
+    expr = _symint_expr(idx)
+    if expr is None:
+        return None
+    return HostFunction.current().expr_to_origin.get(expr)
+
+
+def _maybe_get_tile_begin_with_offset_info(
+    idx: object,
+) -> TileBeginWithOffsetPattern | None:
+    """Extended version that allows out-of-bounds and symbolic offsets."""
+    from ..compile_environment import CompileEnvironment
+    from ..compile_environment import _symint_expr
+    from ..host_function import HostFunction
+    from ..host_function import SymbolOrigin
+    from ..variable_origin import GridOrigin
+    from ..variable_origin import TileBeginOrigin
+    from ..variable_origin import TileEndOrigin
+
+    idx_symbol_origin = _maybe_get_symbol_origin(idx)
+    if isinstance(idx_symbol_origin, SymbolOrigin):
+        if isinstance(idx_symbol_origin.origin, TileBeginOrigin):
+            return TileBeginWithOffsetPattern(
+                block_id=idx_symbol_origin.origin.block_id, offset=0
+            )
+        if isinstance(idx_symbol_origin.origin, GridOrigin) and not isinstance(
+            idx_symbol_origin.origin, TileEndOrigin
+        ):
+            return TileBeginWithOffsetPattern(
+                block_id=idx_symbol_origin.origin.block_id, offset=0
+            )
+
+    if not isinstance(idx, torch.SymInt):
+        return None
+    expr = _symint_expr(idx)
+    if not isinstance(expr, sympy.Expr):
+        return None
+
+    args = expr.args
+    origin: TileBeginOrigin | TileEndOrigin | GridOrigin | None = None
+    offset = 0
+
+    for arg in args:
+        assert isinstance(arg, sympy.Expr)
+        if (
+            symbol_origin := HostFunction.current().expr_to_origin.get(arg)
+        ) is not None:
+            if isinstance(
+                symbol_origin.origin, (GridOrigin, TileBeginOrigin, TileEndOrigin)
+            ):
+                if origin is not None:
+                    # Multiple tile offset expressions - result is out of current tile
+                    return None
+                origin = symbol_origin.origin
+            else:
+                return None
+        elif arg.is_constant():
+            evalf_result = arg.evalf()
+            f_value = float(evalf_result)  # type: ignore[arg-type]
+            if not f_value.is_integer():
+                return None
+            offset += int(f_value)
+        else:
+            offset = torch.SymInt(arg)
+            break
+
+    env = CompileEnvironment.current()
+    if origin is None:
+        return None
+
+    block_id = origin.block_id
+
+    if isinstance(origin, TileEndOrigin):
+        block_size = env.block_sizes[block_id].size
+        if isinstance(block_size, int) and isinstance(offset, int):
+            offset = block_size + offset  # Starting from end
+        else:
+            # For non-integer block sizes or offsets, fall back to symbolic offset
+            offset = torch.SymInt(f"{block_size} + {offset}")  # type: ignore[arg-type]
+
+    return TileBeginWithOffsetPattern(block_id=block_id, offset=offset)

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -25,7 +25,10 @@ from .stack_tensor import StackTensor
 if TYPE_CHECKING:
     from .._compiler.inductor_lowering import CodegenState
     from .._compiler.tile_strategy import LoopDimInfo
-    from helion._compiler.type_propagation import SymbolOrigin
+
+from .._compiler.host_function import SymbolOrigin
+
+# TileBeginWithOffset removed - using TileBeginWithOffsetPattern instead
 
 __all__ = ["load", "store"]
 
@@ -155,6 +158,23 @@ def _(state: CodegenState) -> ast.AST:
     raise NotImplementedError(f"Cannot store to type: {type(tensor)}")
 
 
+def _can_tile_dimension(state: CodegenState, tensor_dim: int) -> bool:
+    assert state.fx_node is not None
+    tensor_arg_node = state.fx_node.args[0]  # 0th argument to load/store is the tensor
+    assert isinstance(tensor_arg_node, torch.fx.Node)
+
+    tensor_val = tensor_arg_node.meta.get("val")
+    assert isinstance(tensor_val, torch.Tensor)
+
+    dim_tilings = state.device_function.pallas_tensor_dim_tilings.get(id(tensor_val))
+    assert isinstance(dim_tilings, list)
+    assert tensor_dim < len(dim_tilings)
+    from helion._compiler.pallas.plan_tiling import DimensionTiling
+
+    assert isinstance(dim_tilings[tensor_dim], DimensionTiling)
+    return dim_tilings[tensor_dim].can_tile
+
+
 def _pallas_index_str(
     state: CodegenState,
     subscript: list[object] | tuple[object, ...],
@@ -174,11 +194,8 @@ def _pallas_index_str(
     Also returns positions of ``None`` indices so the caller can apply
     ``jnp.expand_dims`` after loading.
     """
-    from .._compiler.tile_strategy import DeviceLoopState
     from .._compiler.tile_strategy import EmitPipelineLoopState
     from .._compiler.tile_strategy import ForiLoopState
-
-    env = CompileEnvironment.current()
 
     if not subscript:
         return "...", []
@@ -192,53 +209,27 @@ def _pallas_index_str(
                 in_pipeline = True
                 pipeline_block_ids.update(loop.block_ids)
 
-    # Record grid-level dim→block_id for block spec generation.
-    dim_map = state.device_function.pallas_tensor_dim_block_ids.setdefault(
-        id(tensor), {}
-    )
+    # Use pre-computed indexing patterns from plan_tiling analysis
+    indexing_patterns = _pallas_get_indexing_patterns(state, tensor)
 
-    # Build parts, using pl.ds() only for looped reduction dims.
+    # Build parts using the pre-computed patterns
     parts: list[str] = []
     none_dims: list[int] = []
     out_pos = 0
-    tensor_dim = 0  # tracks which tensor dimension we're at (skips None)
-    for i, idx in enumerate(subscript):
+    tensor_dim = 0
+
+    for i, (idx, pattern) in enumerate(zip(subscript, indexing_patterns, strict=True)):
         if idx is None:
             none_dims.append(out_pos)
             out_pos += 1
             continue
-        block_id = _resolve_block_id(env, idx, tensor, tensor_dim)
-        if block_id is not None:
-            if in_pipeline and block_id in pipeline_block_ids:
-                parts.append(":")
-            else:
-                loops = state.codegen.active_device_loops.get(block_id)
-                if loops and any(isinstance(loop, DeviceLoopState) for loop in loops):
-                    symbol_origin = _maybe_get_symbol_origin(idx)
-                    if symbol_origin and isinstance(symbol_origin.origin, GridOrigin):
-                        parts.append(state.codegen.offset_var(block_id))
-                    else:
-                        parts.append(_pallas_ds_expr(state, block_id))
-                else:
-                    maybe_grid_axis_idx = _maybe_get_hl_grid_axis_pid(idx)
-                    if maybe_grid_axis_idx is not None:
-                        expr = f"pl.program_id({maybe_grid_axis_idx})"
-                        parts.append(expr)
-                    else:
-                        parts.append(":")
-            if isinstance(idx, torch.SymInt):
-                dim_map.setdefault(tensor_dim, block_id)
-        elif isinstance(idx, int):
-            parts.append(str(idx))
-        elif isinstance(idx, torch.SymInt):
-            ast_subscripts = state.ast_args[1]
-            assert isinstance(ast_subscripts, list)
-            ast_idx = ast_subscripts[i]
-            assert isinstance(ast_idx, ast.AST)
-            name = state.codegen.lift(ast_idx, dce=True, prefix="index")
-            parts.append(name.id)
-        else:
-            parts.append(":")
+
+        # Generate code based on the pattern type
+        index_code = _pallas_generated_index_code(
+            pattern, idx, state, tensor, i, tensor_dim, in_pipeline, pipeline_block_ids
+        )
+        parts.append(index_code)
+
         out_pos += 1
         tensor_dim += 1
 
@@ -258,36 +249,165 @@ def _maybe_get_symbol_origin(idx: object) -> SymbolOrigin | None:
     return HostFunction.current().expr_to_origin.get(expr)
 
 
-# returns pid for an idx (used in a index_expr) that comes from a hl.grid
-def _maybe_get_hl_grid_axis_pid(idx: object) -> int | None:
-    symbol_origin = _maybe_get_symbol_origin(idx)
-    if symbol_origin is None:
-        return None
-    if not isinstance(symbol_origin.origin, GridOrigin):
-        return None
-    block_id = symbol_origin.origin.block_id
-    from .._compiler.device_function import DeviceFunction
-
-    device_fn = DeviceFunction.current()
-    if device_fn.pid is not None:
-        for i, pid in enumerate(device_fn.pid.pid_info):
-            if pid.block_id == block_id:
-                return i
-    return None
+def _pallas_get_indexing_patterns(
+    state: CodegenState, tensor: torch.Tensor
+) -> list[object]:
+    assert state.fx_node is not None
+    assert hasattr(state.fx_node, "meta")
+    patterns = state.fx_node.meta.get("indexing_patterns")
+    assert patterns is not None, f"No indexing patterns found for node {state.fx_node}"
+    return patterns
 
 
-def _resolve_block_id(
-    env: CompileEnvironment,
+def _pallas_generated_index_code(
+    pattern: object,
     idx: object,
+    state: CodegenState,
     tensor: torch.Tensor,
-    pos: int,
-) -> int | None:
-    """Resolve a subscript element to its block_id, if any."""
-    if isinstance(idx, torch.SymInt):
-        return env.get_block_id(idx)
-    if isinstance(idx, slice) and idx == slice(None):
-        return env.resolve_block_id(tensor.shape[pos])
-    return None
+    subscript_index: int,
+    tensor_dim: int,
+    in_pipeline: bool,
+    pipeline_block_ids: set[int],
+) -> str:
+    """Generate index code based on the indexing pattern."""
+    from .._compiler.pallas.plan_tiling import ArbitraryIndexPattern
+    from .._compiler.pallas.plan_tiling import ArbitrarySlicePattern
+    from .._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
+    from .._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
+    from .._compiler.pallas.plan_tiling import TilePattern
+
+    if isinstance(pattern, TilePattern):
+        return _pallas_tile_pattern_code(
+            pattern, idx, state, tensor_dim, in_pipeline, pipeline_block_ids
+        )
+
+    if isinstance(pattern, TileIndexWithOffsetPattern):
+        return _pallas_tile_index_with_offset_pattern_code(pattern, state)
+
+    if isinstance(pattern, TileBeginWithOffsetPattern):
+        return _pallas_tile_begin_with_offset_pattern_code(
+            pattern, state, subscript_index, tensor_dim
+        )
+
+    if isinstance(pattern, ArbitrarySlicePattern):
+        return _pallas_slice_code(idx, pattern, state, tensor, subscript_index)
+
+    if isinstance(pattern, ArbitraryIndexPattern):
+        if isinstance(idx, int):
+            return str(idx)
+        return _pallas_index_expr_from_ast(state, subscript_index)
+
+    raise RuntimeError(
+        f"Unhandled indexing pattern type: {type(pattern).__name__}. "
+        f"Pattern: {pattern}, idx: {idx}, subscript_index: {subscript_index}. "
+        f"All indexing patterns should be handled by the tiling analysis system."
+    )
+
+
+def _pallas_tile_pattern_code(
+    pattern: object,
+    idx: object,
+    state: CodegenState,
+    tensor_dim: int,
+    in_pipeline: bool,
+    pipeline_block_ids: set[int],
+) -> str:
+    from .._compiler.pallas.plan_tiling import TilePattern
+    from .._compiler.tile_strategy import DeviceLoopState
+
+    assert isinstance(pattern, TilePattern)
+
+    block_id = pattern.block_id
+
+    can_tile = _can_tile_dimension(state, tensor_dim)
+    if not can_tile:
+        return _pallas_ds_expr(state, block_id)
+
+    if in_pipeline and block_id in pipeline_block_ids:
+        return ":"
+
+    loops = state.codegen.active_device_loops.get(block_id)
+    if loops and any(isinstance(loop, DeviceLoopState) for loop in loops):
+        return _pallas_ds_expr(state, block_id)
+    return ":"
+
+
+def _pallas_tile_index_with_offset_pattern_code(
+    pattern: object,
+    state: CodegenState,
+) -> str:
+    from .._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
+
+    assert isinstance(pattern, TileIndexWithOffsetPattern)
+
+    block_id = pattern.block_id
+    offset_str = f"{pattern.offset}"
+    return _pallas_ds_expr(state, block_id, offset_str)
+
+
+def _pallas_tile_begin_with_offset_pattern_code(
+    pattern: object,
+    state: CodegenState,
+    subscript_index: int,
+    tensor_dim: int,
+) -> str:
+    from .._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
+    from .._compiler.tile_strategy import DeviceLoopState
+
+    assert isinstance(pattern, TileBeginWithOffsetPattern)
+
+    can_tile = _can_tile_dimension(state, tensor_dim)
+
+    if not can_tile:
+        return _pallas_index_expr_from_ast(state, subscript_index)
+
+    assert isinstance(pattern.offset, int)
+
+    loops = state.codegen.active_device_loops.get(pattern.block_id)
+    if loops and any(isinstance(loop, DeviceLoopState) for loop in loops):
+        offset = state.codegen.offset_var(pattern.block_id)
+        if pattern.offset != 0:
+            offset = f"{offset} + {pattern.offset}"
+        return offset
+
+    return f"{pattern.offset}"
+
+
+def _pallas_index_expr_from_ast(state: CodegenState, subscript_index: int) -> str:
+    ast_subscripts = state.ast_args[1]
+    assert isinstance(ast_subscripts, list)
+    ast_idx = ast_subscripts[subscript_index]
+    assert isinstance(ast_idx, ast.AST)
+    name = state.codegen.lift(ast_idx, dce=True, prefix="index")
+    return name.id
+
+
+def _pallas_slice_code(
+    idx: object,
+    pattern: object,
+    state: CodegenState,
+    tensor: torch.Tensor,
+    subscript_index: int,
+) -> str:
+    from .._compiler.pallas.plan_tiling import ArbitrarySlicePattern
+    from .._compiler.tile_strategy import DeviceLoopState
+
+    assert isinstance(pattern, ArbitrarySlicePattern)
+
+    if idx != slice(None):
+        raise AssertionError(
+            f"Arbitrary slice expr {slice} not supported in Pallas backend yet"
+        )
+
+    env = CompileEnvironment.current()
+    block_id = env.resolve_block_id(tensor.shape[subscript_index])
+    if block_id is not None:
+        loops = state.codegen.active_device_loops.get(block_id)
+        if loops and any(isinstance(loop, DeviceLoopState) for loop in loops):
+            if block_id is not None:
+                return _pallas_ds_expr(state, block_id)
+
+    return ":"
 
 
 def _pallas_ds_expr(state: CodegenState, block_id: int, tile_offset: str = "") -> str:

--- a/test/test_atomic_ops.py
+++ b/test/test_atomic_ops.py
@@ -265,6 +265,7 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, expected)
 
     @xfailIfCute("cute: hl.arange atomic scatter requires an active non-reduction axis")
+    @xfailIfPallas("Integer indexing not supported on Pallas")
     def test_atomic_add_1d_tensor(self):
         M, N = 32, 64
         x = torch.randn(M, N, device=DEVICE, dtype=torch.float32)

--- a/test/test_broadcasting.py
+++ b/test/test_broadcasting.py
@@ -52,19 +52,23 @@ class TestBroadcasting(RefEagerTestBase, TestCase):
         args = [torch.randn(512, 512, device=DEVICE), torch.randn(512, device=DEVICE)]
         assert not broadcast_fn.bind(args).config_spec.flatten_loops
 
+    @xfailIfPallas("[16, 8] isn't a valid tiling for this kernel in Pallas")
     def test_broadcast1(self):
         _check_broadcast_fn(
             block_sizes=[16, 8],
         )
 
+    @xfailIfPallas("[16, 8] isn't a valid tiling for this kernel in Pallas")
     def test_broadcast2(self):
         _check_broadcast_fn(block_size=[16, 8], loop_order=(1, 0))
 
+    @xfailIfPallas("[64, 1] isn't a valid tiling for this kernel in Pallas")
     def test_broadcast3(self):
         _check_broadcast_fn(
             block_sizes=[64, 1],
         )
 
+    @xfailIfPallas("[1, 64] isn't a valid tiling for this kernel in Pallas")
     def test_broadcast4(self):
         _check_broadcast_fn(
             block_sizes=[1, 64],
@@ -72,9 +76,18 @@ class TestBroadcasting(RefEagerTestBase, TestCase):
 
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
     @skipIfTileIR("TileIR does not support block_ptr indexing")
+    @xfailIfPallas("[32, 32] isn't a valid tiling for this kernel in Pallas")
     def test_broadcast5(self):
         code = _check_broadcast_fn(
             block_sizes=[32, 32],
+            indexing="block_ptr",
+        )
+        if _get_backend() == "triton":
+            self.assertIn("tl.make_block_ptr", code)
+
+    def test_broadcast6(self):
+        code = _check_broadcast_fn(
+            block_sizes=[128, 128],
             indexing="block_ptr",
         )
         if _get_backend() == "triton":

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -120,7 +120,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         )
         torch.testing.assert_close(result, grid_2d_pytorch(args[0], args[1]))
 
-    @xfailIfPallas("2D nested grids not working correctly Pallas")
     def test_grid_2d_idx_nested(self):
         @helion.kernel(static_shapes=True)
         def grid_2d_idx_nested(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
@@ -153,7 +152,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(grid_2d_idx_nested, args)
         torch.testing.assert_close(result, grid_2d_pytorch(args[0], args[1]))
 
-    @xfailIfPallas("Grid begin/end not working on Pallas")
     def test_grid_begin_end(self):
         @helion.kernel(autotune_effort="none")
         def grid_begin_end(x: torch.Tensor) -> torch.Tensor:
@@ -216,7 +214,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(grid_end_step_kwarg, (x,))
         torch.testing.assert_close(result, grid_end_step_kwarg_pytorch(x))
 
-    @xfailIfPallas("Grid begin/end not working on Pallas")
     def test_grid_multidim_begin_end(self):
         @helion.kernel(autotune_effort="none")
         def grid_multidim_begin_end(x: torch.Tensor) -> torch.Tensor:

--- a/test/test_loops.py
+++ b/test/test_loops.py
@@ -307,6 +307,7 @@ class TestLoops(RefEagerTestBase, TestCase):
             result, functools.reduce(torch.matmul, args), atol=1e-1, rtol=1e-2
         )
 
+    @skipIfPallas("Requires int indexing which is unavailable on TPUs")
     def test_use_block_size_var_without_hl_tile(self):
         """Test that block size var can be used without hl.tile()."""
 

--- a/test/test_random.py
+++ b/test/test_random.py
@@ -314,7 +314,6 @@ class TestRandom(RefEagerTestBase, TestCase):
         self.assertTrue(torch.all(output >= 0.0), "All values should be >= 0")
         self.assertTrue(torch.all(output < 1.0), "All values should be < 1")
 
-    @xfailIfPallas("3D hl.rand lowering hits TPU Mosaic unsupported shape cast")
     @skipIfRefEager("compile_config is not supported in ref eager mode")
     def test_hl_rand_3d(self):
         @helion.kernel(static_shapes=False, autotune_effort="none")
@@ -435,9 +434,6 @@ class TestRandom(RefEagerTestBase, TestCase):
             0.7 < q3_val < 0.8, f"Third quartile {q3_val:.3f} should be around 0.75"
         )
 
-    @xfailIfPallas(
-        "specialized non-tiled hl.rand hits TPU Mosaic unsupported shape cast"
-    )
     def test_hl_rand_non_tiled_dimensions(self):
         @helion.kernel(static_shapes=False)
         def rand_kernel_partial_tile(x: torch.Tensor, seed: int) -> torch.Tensor:
@@ -464,7 +460,6 @@ class TestRandom(RefEagerTestBase, TestCase):
         torch.testing.assert_close(output, output2, msg="it should deterministic")
 
     @skipIfMTIA("Skip on MTIA due to unaligned address crash")
-    @xfailIfPallas("reordered tile dims cause BlockSpec axis mismatch")
     def test_hl_rand_mixed_argument_order(self):
         @helion.kernel(static_shapes=False)
         def rand_kernel_normal_order(x: torch.Tensor, seed: int) -> torch.Tensor:


### PR DESCRIPTION
Introduces a new plan_tiling pre-codegen IR analyshttps://github.com/pytorch/helion/pull/2007/changesis pass for the Pallas backend that makes tiling and indexing decisions upfront, before any code generation occurs. This fixes a general classes of issues where we fail (or fall-back to no-tiling at all) when multiple indexing expressions on the same tensor dimension requires different tiling. 

## Main Changes

* `helion/_compiler/pallas/plan_tiling.py` (new file)
   A new pre-codegen analysis pass that walks the FX IR graph and inspects all load/store nodes (including all atomic ops). It produces two pieces of metadata:
  - `DimensionTiling(can_tile: bool, block_ids: set[int])`:   For each dimension in each tensor, whether or not we can tile it, and with which `block_id`.   Here, `block_ids` is the set of blocks for which we do tiled accesses on this dimension. We can tile this dimension only if this set has size 1
  - `indexing_patterns`: For each subscript dimension, what type of indexing is it doing. Currently we recognize and handle a few different patterns `Tile/TileIndexWithOffset/TileBeginWithOffset/None/ArbitrarySlice/ArbitracyIndex`. Each pattern has different implications to the `DimensionTiling` of the accessed dimension. 

* `helion/language/memory_ops.py`
   During codegen, we fetch the `DimensionTiling` and `indexing_patterns` metadata which we collected during the `plan_tiling` pass, and use them directly to generate code. For example, when we see a `TilePattern` where `can_tile == True`, we just generate `:`, other wise we generate `pl.ds(offset, BLOCK_SIZE)`
                             
                                                                                                                                        
## Tests Fixed                                                                                                                                                                                                         
  - test_grid_2d_idx_nested, test_grid_begin_end, test_grid_multidim_begin_end 
  - test_hl_rand_3d, test_hl_rand_non_tiled_dimensions, test_hl_rand_mixed_argument_order 
  
Added xfails for a few tests that were only "accidentally" working, e.g. `test_atomic_add_1d_tensor` which requires integer indexing, we are passing it because we use `:` which happens to be correct because the indices were an `arange`