### PR TITLE
[Pallas] Narrow 64-bit input tensors to 32-bit at runtime

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -896,6 +896,18 @@ _TORCH_TO_JAX_DTYPE: dict[str, str] = {
 }
 
 
+# TPU does not natively support 64-bit element types; narrow to 32-bit.
+_PALLAS_DTYPE_NARROW: dict[torch.dtype, torch.dtype] = {
+    torch.int64: torch.int32,
+    torch.float64: torch.float32,
+}
+
+
+def pallas_narrow_dtype(dtype: torch.dtype) -> torch.dtype:
+    """Narrow 64-bit dtypes to 32-bit for TPU compatibility."""
+    return _PALLAS_DTYPE_NARROW.get(dtype, dtype)
+
+
 class PallasBackend(Backend):
     """Pallas (JAX) code generation backend for TPU."""
 
@@ -904,6 +916,7 @@ class PallasBackend(Backend):
         return "pallas"
 
     def dtype_str(self, dtype: torch.dtype) -> str:
+        dtype = pallas_narrow_dtype(dtype)
         key = str(dtype)
         if key not in _TORCH_TO_JAX_DTYPE:
             raise ValueError(f"Unsupported dtype for Pallas backend: {dtype}")

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1190,6 +1190,9 @@ class PallasBackend(Backend):
             tensor_ndim (int): Amount of dimensions for the tensor.
             bitwidth (int): Bitwidth of tensor elements
         """
+        # Cap to 32: wider dtypes (e.g. float64, int64) are narrowed to
+        # 32-bit at runtime since TPU does not natively support 64-bit types.
+        bitwidth = min(bitwidth, 32)
         if dim_from_end == 0:  # Last dimension
             if tensor_ndim <= 1:
                 return 128 * (32 // bitwidth)

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -347,6 +347,64 @@ def _jax_placeholder_for_tensor(t: torch.Tensor) -> object:
     return jax.ShapeDtypeStruct(tuple(t.shape), jax_dtype)
 
 
+def _pallas_cast_unsupported_dtypes(
+    args: tuple[object, ...],
+    _output_indices: list[int],
+) -> tuple[tuple[object, ...], dict[int, torch.Tensor]]:
+    """Narrow 64-bit tensors to 32-bit for TPU/XLA compatibility.
+
+    TPU does not natively support 64-bit element types.  This function
+    narrows int64→int32 and float64→float32 before tracing so that
+    placeholders, block specs, and input tensors are all 32-bit.
+    This is a lossy operation: int64 values outside the int32 range will
+    overflow, and float64 values lose precision.
+
+    Returns the (possibly modified) args tuple and a mapping from output
+    arg index to the *original* output tensor.  After the kernel finishes,
+    callers must copy results back from the narrowed tensor to the original
+    via ``_pallas_copy_back_outputs``.
+    """
+    import warnings
+
+    from .._compiler.backend import pallas_narrow_dtype
+
+    need_cast = any(
+        isinstance(a, torch.Tensor) and pallas_narrow_dtype(a.dtype) != a.dtype
+        for a in args
+    )
+
+    if not need_cast:
+        return args, {}
+
+    new_args = list(args)
+    output_originals: dict[int, torch.Tensor] = {}
+    output_set = set(_output_indices)
+    for i, a in enumerate(new_args):
+        if isinstance(a, torch.Tensor):
+            narrow = pallas_narrow_dtype(a.dtype)
+            if narrow != a.dtype:
+                warnings.warn(
+                    f"Pallas/TPU: narrowing {a.dtype} tensors to {narrow} "
+                    f"because TPU does not natively support 64-bit types. "
+                    f"This may cause overflow or precision loss.",
+                    stacklevel=3,
+                )
+                if i in output_set:
+                    output_originals[i] = a
+                new_args[i] = a.to(narrow)
+    return tuple(new_args), output_originals
+
+
+def _pallas_copy_back_outputs(
+    output_originals: dict[int, torch.Tensor],
+    args: tuple[object, ...],
+) -> None:
+    """Copy narrowed output tensors back to the original wide-dtype tensors."""
+    for i, orig in output_originals.items():
+        narrowed = cast("torch.Tensor", args[i])
+        orig.copy_(narrowed)
+
+
 def _pallas_prepare_args(
     args: tuple[object, ...],
     _output_indices: list[int],
@@ -591,6 +649,8 @@ def default_pallas_launcher(
     if _output_indices is None:
         _output_indices = []
 
+    args, output_originals = _pallas_cast_unsupported_dtypes(args, _output_indices)
+
     cache = getattr(pallas_kernel, "_pallas_cache", None)
     if cache is not None and cache[0] == grid:
         _, jax_callable, tensor_arg_indices = cache
@@ -681,6 +741,7 @@ def default_pallas_launcher(
         cast("torch.Tensor", args[i]).contiguous() for i in tensor_arg_indices
     ]
     jax_callable(*input_tensors)  # type: ignore[operator]
+    _pallas_copy_back_outputs(output_originals, args)
 
 
 def default_pallas_pipeline_launcher(
@@ -703,6 +764,8 @@ def default_pallas_pipeline_launcher(
         _output_indices = []
     if _scratch_shapes is None:
         _scratch_shapes = []
+
+    args, output_originals = _pallas_cast_unsupported_dtypes(args, _output_indices)
 
     cache = getattr(pallas_kernel, "_pallas_pipeline_cache", None)
     if cache is not None and cache[0] == grid:
@@ -821,6 +884,7 @@ def default_pallas_pipeline_launcher(
         cast("torch.Tensor", args[i]).contiguous() for i in tensor_arg_indices
     ]
     jax_callable(*input_tensors)  # type: ignore[operator]
+    _pallas_copy_back_outputs(output_originals, args)
 
 
 def default_pallas_fori_launcher(
@@ -844,6 +908,8 @@ def default_pallas_fori_launcher(
         _output_indices = []
     if _scratch_shapes is None:
         _scratch_shapes = []
+
+    args, output_originals = _pallas_cast_unsupported_dtypes(args, _output_indices)
 
     cache = getattr(pallas_kernel, "_pallas_fori_cache", None)
     if cache is not None and cache[0] == grid:
@@ -961,6 +1027,7 @@ def default_pallas_fori_launcher(
         cast("torch.Tensor", args[i]).contiguous() for i in tensor_arg_indices
     ]
     jax_callable(*input_tensors)  # type: ignore[operator]
+    _pallas_copy_back_outputs(output_originals, args)
 
 
 def _torch_to_jax(t: torch.Tensor) -> object:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -792,15 +792,41 @@ class TestPallas(TestCase):
 
         Uses a reduction kernel so the generated code includes
         convert_element_type and jnp.full with dtype arguments.
-        Only checks codegen, does not execute the kernel.
         """
-        from helion.runtime.config import Config
-
         x = torch.randint(0, 100, [32, 64], device=DEVICE, dtype=torch.int64)
-        bound = pallas_sum_reduction.bind((x,))
-        config = Config(block_sizes=[16])
-        code = bound.to_triton_code(config)
+        code, result = code_and_output(pallas_sum_reduction, (x,), block_size=16)
         self.assertNotIn("jnp.int64", code)
+        expected = x.sum(-1)
+        torch.testing.assert_close(result, expected)
+
+    def test_int64_1d_tensor(self) -> None:
+        """int64 tensors are narrowed to int32 before tracing/execution."""
+        x = torch.arange(256, device=DEVICE, dtype=torch.int64)
+        y = torch.arange(256, device=DEVICE, dtype=torch.int64)
+        code, result = code_and_output(add_kernel, (x, y), block_size=64)
+        expected = x + y
+        torch.testing.assert_close(result, expected)
+
+    def test_float64_1d_tensor(self) -> None:
+        """float64 tensors are narrowed to float32 before tracing/execution."""
+        x = torch.randn(256, device=DEVICE, dtype=torch.float64)
+        y = torch.randn(256, device=DEVICE, dtype=torch.float64)
+        code, result = code_and_output(add_kernel, (x, y), block_size=128)
+        expected = x + y
+        torch.testing.assert_close(result, expected, rtol=1e-5, atol=1e-5)
+
+    def test_int64_inplace(self) -> None:
+        """Inplace mutation of int64 tensors must work with dtype narrowing.
+
+        The tensor is both input and output, so the cast creates an int32
+        copy, the kernel mutates it, and the copy-back restores the original.
+        """
+        x = torch.arange(256, device=DEVICE, dtype=torch.int64)
+        y = torch.ones(256, device=DEVICE, dtype=torch.int64)
+        expected = x + y
+        code, result = code_and_output(pallas_inplace_add, (x, y), block_size=256)
+        # x should be mutated in place with correct dtype
+        torch.testing.assert_close(x, expected)
 
 
 if __name__ == "__main__":

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -787,6 +787,21 @@ class TestPallas(TestCase):
         # out is read after write, so it must be in _inplace_indices
         self.assertIn("_inplace_indices=[1]", code)
 
+    def test_int64_codegen_no_64bit_types(self) -> None:
+        """Codegen must not emit 64-bit JAX types (TPU rejects them).
+
+        Uses a reduction kernel so the generated code includes
+        convert_element_type and jnp.full with dtype arguments.
+        Only checks codegen, does not execute the kernel.
+        """
+        from helion.runtime.config import Config
+
+        x = torch.randint(0, 100, [32, 64], device=DEVICE, dtype=torch.int64)
+        bound = pallas_sum_reduction.bind((x,))
+        config = Config(block_sizes=[16])
+        code = bound.to_triton_code(config)
+        self.assertNotIn("jnp.int64", code)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

TPU does not natively support 64-bit element types. This PR narrows int64→int32 and float64→float32 in launcher args before tracing, so placeholders, block specs, and input tensors all use 32-bit types consistently. Output tensors are copied back to the original 64-bit tensors after the kernel completes.

**Note:** This is a lossy workaround — int64 values outside int32 range will overflow, and float64 values lose precision. A `UserWarning` is emitted when narrowing occurs.

Depends on #1950.

### Changes

1. **Runtime cast** (`runtime/__init__.py`): `_pallas_cast_unsupported_dtypes` narrows 64-bit tensors before `_pallas_prepare_args`. `_pallas_copy_back_outputs` copies results back afterward. Applied to all 3 launchers.

2. **Block spec tiling** (`backend.py`): Cap bitwidth to 32 in `_get_pallas_required_alignment` since wider dtypes are narrowed at runtime.

### Affected examples

These examples pass int64 tensors (labels, offsets) directly to `@helion.kernel` functions:

`cross_entropy`, `jagged_dense_add`, `jagged_dense_bmm`, `jagged_layer_norm`, `jagged_mean`, `jagged_softmax`, `jagged_sum`