### PR TITLE
[Autotuner] Apply numel constraints on search neighbors

### DIFF
--- a/helion/autotuner/pattern_search.py
+++ b/helion/autotuner/pattern_search.py
@@ -257,6 +257,13 @@ class PatternSearch(PopulationBasedSearch):
             return neighbors[: self.num_neighbors_cap]
         return neighbors
 
+    def _apply_numel_constraints(self, neighbors: list[FlatConfig]) -> list[FlatConfig]:
+        """Shrink each neighbor in place to satisfy tensor numel constraints."""
+        if self.config_gen.config_spec.tensor_numel_constraints:
+            for n in neighbors:
+                self.config_gen._shrink_for_numel_constraints(n)
+        return neighbors
+
     def _generate_neighbors(self, base: FlatConfig) -> list[FlatConfig]:
         """
         Generate neighboring configurations by changing one or two parameters at a time.
@@ -295,4 +302,4 @@ class PatternSearch(PopulationBasedSearch):
                         new_flat[second] = second_value
                         neighbors.append(new_flat)
 
-        return self.shrink_neighbors(neighbors)
+        return self.shrink_neighbors(self._apply_numel_constraints(neighbors))

--- a/helion/autotuner/surrogate_pattern_search.py
+++ b/helion/autotuner/surrogate_pattern_search.py
@@ -541,7 +541,7 @@ class LFBOPatternSearch(PatternSearch):
             if new_flat != base:
                 neighbors.append(new_flat)
 
-        return self.shrink_neighbors(neighbors)
+        return self.shrink_neighbors(self._apply_numel_constraints(neighbors))
 
     def _pruned_pattern_search_from(
         self,
@@ -838,4 +838,4 @@ class LFBOTreeSearch(LFBOPatternSearch):
             if current_flat != base_list:
                 all_results.append(list(current_flat))
 
-        return all_results
+        return self._apply_numel_constraints(all_results)

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -948,6 +948,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             ],
             block_size_indices=[0, 1],
             overridden_flat_indices={1},  # freeze block_size[1]
+            config_spec=SimpleNamespace(tensor_numel_constraints=[]),
         )
         search.num_neighbors_cap = -1
 
@@ -1018,6 +1019,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             block_size_indices=[0, 1],
             num_warps_index=2,
             overridden_flat_indices={1, 2},  # freeze block_size[1] and num_warps
+            config_spec=SimpleNamespace(tensor_numel_constraints=[]),
         )
         search.num_neighbors_cap = -1
 


### PR DESCRIPTION
Follow-up to #1839.                                                                                                                                                   
                                         
  ## Summary                                                                                                                                                            
                                                                                                                                                                        
  #1839 enforced numel constraints on `default_config()` / `random_flat()` / `shrink_config()` but deferred search neighbors. This PR closes that gap in   `PatternSearch`, `LFBOPatternSearch`, and `LFBOTreeSearch`.
                                                                                                                                                                        
  ## Motivation                                             

  On `scaled_mm_blockwise` (tight constraint `16384 * block_m * block_k <= 1M`), **11% of neighbors violate constraints** and waste autotune time on failed compiles. On `bmm` (loose constraints), 0% violate and the shrink is a no-op.
                                                                                                                                                                        
  ## What it does                                           

  Adds `PatternSearch._apply_numel_constraints` that shrinks each neighbor in place via the existing `_shrink_for_numel_constraints`, called from all three   `_generate_neighbors` overrides.
                                                                                                                                                                        
  ## Performance                                            

  A/B autotune on `bmm` (n=7): median 10.48s -> 10.99s (+4.9%, within +- 1s noise). Microbenchmark: ~8μs per neighbor, ~11ms per 1400-neighbor autotune (~0.01%).          
   
  ## Test                                                                                                                                                               
                                                            
  Existing `test/test_tensor_numel_constraints.py` coverage should be sufficient. updated two `test_autotuner.py` mocks to include `config_spec.tensor_numel_constraints=[]`.