### PR TITLE
Add to_code() as backend-agnostic alias for to_triton_code()

### DIFF
--- a/helion/_compile_time.py
+++ b/helion/_compile_time.py
@@ -109,15 +109,15 @@ class CompileTimeTracker:
             "HostFunction.lower_to_device_ir",
         ],
         "BoundKernel.set_config": [
-            "BoundKernel.to_triton_code",
+            "BoundKernel.to_code",
             "BoundKernel.PyCodeCache.load",
         ],
-        "BoundKernel.to_triton_code": [
+        "BoundKernel.to_code": [
             "BoundKernel.generate_ast",
             "BoundKernel.unparse",
         ],
         "BoundKernel.autotune": [
-            "BoundKernel.to_triton_code",
+            "BoundKernel.to_code",
             "BoundKernel.PyCodeCache.load",
         ],
     }

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -520,7 +520,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             parts.append(f"index_dtype={settings.index_dtype}")
         return f"@helion.kernel({', '.join(parts)})"
 
-    def to_triton_code(
+    def to_code(
         self,
         config: ConfigLike | None = None,
         *,
@@ -528,18 +528,18 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         output_origin_lines: bool | None = None,
     ) -> str:
         """
-        Generate Triton code for the kernel based on the given configuration.
+        Generate backend-specific code for the kernel based on the given configuration.
 
         Args:
             config: The configuration to use for code generation.
-            emit_repro_caller: Emits a main function to call the triton kernel with example inputs.
+            emit_repro_caller: Emits a main function to call the kernel with example inputs.
 
         Returns:
-            str: The generated Triton code as a string.
+            str: The generated code as a string.
         """
         if config is None:
             config = self._require_implicit_config()
-        with self.env, measure("BoundKernel.to_triton_code"):
+        with self.env, measure("BoundKernel.to_code"):
             if not isinstance(config, Config):
                 # pyrefly: ignore [bad-argument-type]
                 config = Config(**config)
@@ -577,6 +577,20 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                 if imports:
                     return f"from __future__ import annotations\n\n{imports}\n\n{body}"
                 return f"from __future__ import annotations\n\n{body}"
+
+    def to_triton_code(
+        self,
+        config: ConfigLike | None = None,
+        *,
+        emit_repro_caller: bool = False,
+        output_origin_lines: bool | None = None,
+    ) -> str:
+        """Backward-compatible alias for :meth:`to_code`."""
+        return self.to_code(
+            config,
+            emit_repro_caller=emit_repro_caller,
+            output_origin_lines=output_origin_lines,
+        )
 
     def compile_config(
         self, config: ConfigLike | None = None, *, allow_print: bool = True

--- a/test/test_metal.py
+++ b/test/test_metal.py
@@ -27,7 +27,7 @@ def _get_msl(kernel: helion.Kernel, args: tuple[object, ...]) -> str:
     """
     from torch._inductor.codecache import PyCodeCache
 
-    code = kernel.bind(args).to_triton_code()
+    code = kernel.bind(args).to_code()
     module = PyCodeCache.load(code)
     # Call the host function by name
     host_fn = getattr(module, kernel.fn.__name__)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -353,7 +353,7 @@ class TestPallas(TestCase):
         from helion.runtime.config import Config
 
         bound = pallas_tile_begin_end.bind((x,))
-        code = bound.to_triton_code(Config(block_size=256))
+        code = bound.to_code(Config(block_size=256))
         self.assertIn("pl.program_id", code)
 
     def test_dynamic_scalar_no_recompile(self) -> None:


### PR DESCRIPTION
## Summary
- Add `to_code()` as the primary method name for generating backend-specific code, since `to_triton_code()` is a legacy name from when Triton was the only backend.
- `to_triton_code` is kept as a backward-compatible delegating method.
- Update Pallas and Metal test files to use the new name.

Long-term, all internal callers will be migrated to `to_code()` and `to_triton_code()` will be deprecated.

Note: a simple class attribute alias (`to_triton_code = to_code`) would be preferred, but pyrefly doesn't propagate the explicit `-> str` return type annotation through the assignment — it uses its own inferred type (`str | None`) instead, causing spurious errors at every call site. A delegating method avoids this.