### PR TITLE
[metal] Skip tests better to pass in internal CI

### DIFF
--- a/test/test_metal.py
+++ b/test/test_metal.py
@@ -3,15 +3,17 @@ from __future__ import annotations
 import sys
 import unittest
 
-if sys.platform != "darwin":
-    raise unittest.SkipTest("Metal tests require macOS")
-
-
 import torch
 
 import helion
-from helion._compiler.metal.metal_jit import _MetalKernel
 import helion.language as hl
+
+if sys.platform == "darwin":
+    from helion._compiler.metal.metal_jit import _MetalKernel
+
+_requires_darwin = unittest.skipIf(
+    sys.platform != "darwin", "Metal tests require macOS"
+)
 
 DEVICE = "mps"
 
@@ -215,6 +217,7 @@ def clamp_kernel(x: torch.Tensor, lo: float, hi: float) -> torch.Tensor:
 # ---------------------------------------------------------------------------
 
 
+@_requires_darwin
 class TestMetalCopy(unittest.TestCase):
     """Copy kernels that test load/store + masking."""
 
@@ -250,6 +253,7 @@ class TestMetalCopy(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
+@_requires_darwin
 class TestMetalBoundsMasking(unittest.TestCase):
     """Bounds masking tests using vector_add for both load and store paths."""
 
@@ -330,6 +334,7 @@ class TestMetalBoundsMasking(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
+@_requires_darwin
 class TestMetalArithmetic(unittest.TestCase):
     """Basic arithmetic elementwise kernels."""
 
@@ -363,6 +368,7 @@ class TestMetalArithmetic(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
+@_requires_darwin
 class TestMetalScalarArgs(unittest.TestCase):
     """Kernels that accept scalar (SymbolArgument) parameters."""
 
@@ -378,6 +384,7 @@ class TestMetalScalarArgs(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
+@_requires_darwin
 class TestMetalActivations(unittest.TestCase):
     """Activation function kernels."""
 
@@ -402,6 +409,7 @@ class TestMetalActivations(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
+@_requires_darwin
 class TestMetalMathOps(unittest.TestCase):
     """Math function kernels."""
 
@@ -438,6 +446,7 @@ class TestMetalMathOps(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
+@_requires_darwin
 class TestMetalDtypes(unittest.TestCase):
     """Elementwise ops across different dtypes."""
 


### PR DESCRIPTION
- Internal CI does not handle unittest raise unlike OSS CI.
- Add requires_darwin skip to individual test classes.

Testing: Verified that `buck2 test` now runs without error:

$ buck2 test fbcode//helion/test:metal -- --list-only ...
time elapsed: 2.0s
Tests finished: Pass 0. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0 NO TESTS RAN

$ buck2 test fbcode//helion/test:metal
...
Time elapsed: 39.6s
Tests finished: Pass 0. Fail 0. Timeout 0. Fatal 0. Skip 30. Omit 0. Infra Failure 0. Build failure 0

<!-- ps-id: 11246da2-aea1-496f-973d-6af65c743610 -->