### PR TITLE
[TPU][Pallas] Add lower bound analytical VMEM estimation and OOM guard for Pallas launchers

### DIFF
--- a/helion/autotuner/logger.py
+++ b/helion/autotuner/logger.py
@@ -461,6 +461,7 @@ _EXPECTED_TRITON_ERRORS_RE: re.Pattern[str] = re.compile(
                 "too many blocks in cooperative launch",  # CUDA cooperative launch limit
                 "too many resources requested for launch",  # Triton resource error
                 "CUDA error: out of memory",  # CUDA runtime OOM during kernel execution
+                "Ran out of memory in memory space vmem",  # TPU VMEM OOM (caught by Helion or XLA)
             ],
         )
     )

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -231,6 +231,118 @@ def _pallas_make_block_spec(
     return pl.BlockSpec(block_shape, index_map, memory_space=memory_space)  # type: ignore[union-attr]
 
 
+_CACHED_VMEM_LIMIT_BYTES: int | None = None
+
+
+def _get_vmem_limit_bytes(pltpu: object) -> int:
+    """Safely retrieves the TPU VMEM capacity without crashing on hardware locks."""
+    global _CACHED_VMEM_LIMIT_BYTES
+    if _CACHED_VMEM_LIMIT_BYTES is not None:
+        return _CACHED_VMEM_LIMIT_BYTES
+
+    try:
+        get_tpu_info = pltpu.get_tpu_info
+        _CACHED_VMEM_LIMIT_BYTES = get_tpu_info().vmem_capacity_bytes
+    except Exception:
+        # Fallback if JAX fails to acquire the TPU backend lock (e.g., in a precompile fork).
+        # Default to 16MB (safe baseline for v4 and v5e per-core VMEM).
+        _CACHED_VMEM_LIMIT_BYTES = 16 * 1024 * 1024
+
+    return _CACHED_VMEM_LIMIT_BYTES
+
+
+def _estimate_pallas_vmem_bytes(
+    pl: object,
+    pltpu: object,
+    in_specs: list[object] | None,
+    out_specs: list[object] | object | None,
+    scratch_shapes: list[object] | list[Any] | None,
+    args: tuple[object, ...],
+    tensor_arg_indices: list[int],
+    output_indices: list[int],
+    pallas_aliases: dict[int, int] | None,
+) -> int:
+    """Estimates the VMEM required by the Pallas kernel."""
+    total_bytes = 0
+    in_spec_bytes = [0] * len(tensor_arg_indices)
+    out_spec_bytes = [0] * len(output_indices)
+
+    def _bytes_per_element(t: object) -> int:
+        import torch
+
+        if isinstance(t, torch.Tensor):
+            return t.element_size()
+
+        dtype = getattr(t, "dtype", None)
+        if dtype is not None:
+            # Works for torch.dtype and np.dtype/jnp.dtype
+            itemsize = getattr(dtype, "itemsize", None)
+            if itemsize is not None:
+                return itemsize
+
+        return 4
+
+    if in_specs:
+        for i, idx in enumerate(tensor_arg_indices):
+            spec = in_specs[i]
+            # pl.BlockSpec will have block_shape and memory_space.
+            # HBM is pl.ANY. We only count VMEM (which is not pl.ANY).
+            if spec is not None and getattr(spec, "memory_space", None) is not getattr(
+                pl, "ANY", None
+            ):
+                block_shape = getattr(spec, "block_shape", None)
+                if block_shape is not None:
+                    numel = 1
+                    for d in block_shape:
+                        numel *= int(d)
+                    in_spec_bytes[i] = numel * _bytes_per_element(args[idx])
+
+    if out_specs:
+        out_specs_list = (
+            out_specs if isinstance(out_specs, (list, tuple)) else [out_specs]
+        )
+        for i, idx in enumerate(output_indices):
+            if i < len(out_specs_list):
+                spec = out_specs_list[i]
+                if spec is not None and getattr(
+                    spec, "memory_space", None
+                ) is not getattr(pl, "ANY", None):
+                    block_shape = getattr(spec, "block_shape", None)
+                    if block_shape is not None:
+                        numel = 1
+                        for d in block_shape:
+                            numel *= int(d)
+                        out_spec_bytes[i] = numel * _bytes_per_element(args[idx])
+
+    pallas_aliases = pallas_aliases or {}
+    aliased_out_positions = set()
+    for in_pos, out_pos in pallas_aliases.items():
+        aliased_out_positions.add(out_pos)
+        if in_pos < len(in_spec_bytes) and out_pos < len(out_spec_bytes):
+            in_spec_bytes[in_pos] = max(in_spec_bytes[in_pos], out_spec_bytes[out_pos])
+
+    for out_pos in aliased_out_positions:
+        if out_pos < len(out_spec_bytes):
+            out_spec_bytes[out_pos] = 0
+
+    # Pallas pipelines and default launchers natively double buffer their BlockSpecs.
+    multiplier = 2
+    total_bytes += sum(in_spec_bytes) * multiplier
+    total_bytes += sum(out_spec_bytes) * multiplier
+
+    if scratch_shapes:
+        for scratch in scratch_shapes:
+            if type(scratch).__name__ == "VMEM":
+                numel = 1
+                shape = getattr(scratch, "shape", ())
+                for d in shape:
+                    numel *= int(d)
+                dtype_size = getattr(getattr(scratch, "dtype", None), "itemsize", 4)
+                total_bytes += numel * dtype_size
+
+    return total_bytes
+
+
 # Per-tensor block spec info: see ``_pallas_make_block_spec``.
 # grid_dims entries are int (direct grid dim), tuple (flat decomposition),
 # or None (untiled dim).
@@ -680,6 +792,24 @@ def default_pallas_launcher(
             for out_idx, orig_pos in enumerate(_output_indices)
         }
 
+        estimated_vmem = _estimate_pallas_vmem_bytes(
+            pl,
+            pltpu,
+            in_specs,
+            out_specs,
+            None,
+            args,
+            tensor_arg_indices,
+            _output_indices,
+            pallas_aliases,
+        )
+        vmem_limit_bytes = _get_vmem_limit_bytes(pltpu)
+        if estimated_vmem > vmem_limit_bytes:
+            raise RuntimeError(
+                f"XLA:TPU compile permanent error. Ran out of memory in memory space vmem. "
+                f"Estimated {estimated_vmem / 1e6:.2f}MB exceeds {vmem_limit_bytes / 1e6:.2f}MB vmem capacity."
+            )
+
         pallas_call_kwargs: dict[str, object] = {
             "out_shape": out_shape_arg,
             "input_output_aliases": pallas_aliases,
@@ -811,6 +941,24 @@ def default_pallas_pipeline_launcher(
             scratch_shapes=scratch_shapes,
             grid=grid,
         )
+
+        estimated_vmem = _estimate_pallas_vmem_bytes(
+            pl,
+            pltpu,
+            in_specs_list,
+            out_specs,
+            scratch_shapes,
+            args,
+            tensor_arg_indices,
+            _output_indices,
+            pallas_aliases,
+        )
+        vmem_limit_bytes = _get_vmem_limit_bytes(pltpu)
+        if estimated_vmem > vmem_limit_bytes:
+            raise RuntimeError(
+                f"XLA:TPU compile permanent error. Ran out of memory in memory space vmem. "
+                f"Estimated {estimated_vmem / 1e6:.2f}MB exceeds {vmem_limit_bytes / 1e6:.2f}MB vmem capacity."
+            )
 
         pallas_call_kwargs: dict[str, object] = {
             "out_shape": out_shape_arg,
@@ -944,6 +1092,24 @@ def default_pallas_fori_launcher(
             scratch_shapes=scratch_shapes,
             grid=grid,
         )
+
+        estimated_vmem = _estimate_pallas_vmem_bytes(
+            pl,
+            pltpu,
+            in_specs_list,
+            out_specs,
+            scratch_shapes,
+            args,
+            tensor_arg_indices,
+            _output_indices,
+            pallas_aliases,
+        )
+        vmem_limit_bytes = _get_vmem_limit_bytes(pltpu)
+        if estimated_vmem > vmem_limit_bytes:
+            raise RuntimeError(
+                f"XLA:TPU compile permanent error. Ran out of memory in memory space vmem. "
+                f"Estimated {estimated_vmem / 1e6:.2f}MB exceeds {vmem_limit_bytes / 1e6:.2f}MB vmem capacity."
+            )
 
         pallas_call_kwargs: dict[str, object] = {
             "out_shape": out_shape_arg,

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -241,7 +241,7 @@ def _get_vmem_limit_bytes(pltpu: object) -> int:
         return _CACHED_VMEM_LIMIT_BYTES
 
     try:
-        get_tpu_info = pltpu.get_tpu_info
+        get_tpu_info = pltpu.get_tpu_info  # pyrefly: ignore[missing-attribute]
         _CACHED_VMEM_LIMIT_BYTES = get_tpu_info().vmem_capacity_bytes
     except Exception:
         # Fallback if JAX fails to acquire the TPU backend lock (e.g., in a precompile fork).

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -244,6 +244,49 @@ def pallas_reduce_non_pow2(x: torch.Tensor) -> torch.Tensor:
 @onlyBackends(["triton", "pallas"])
 @skipUnlessPallas("JAX/Pallas TPU not available")
 class TestPallas(TestCase):
+    def test_estimate_pallas_vmem_bytes(self) -> None:
+        """VMEM OOM: Tests that block sizes and dtypes (fp32, bf16) are correctly estimated."""
+
+        # Test 1: float32 (4 bytes per element)
+        # 3 tensors * 2048 * 4096 * 4 bytes * 2 (multiplier) = ~201.3MB (OOM)
+        args_f32 = (
+            torch.randn(2048, 4096, device=DEVICE, dtype=torch.float32),
+            torch.randn(2048, 4096, device=DEVICE, dtype=torch.float32),
+        )
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"Ran out of memory in memory space vmem.*Estimated [0-9.]+MB exceeds",
+        ):
+            code_and_output(pallas_add_2d, args_f32, block_sizes=[2048, 4096])
+
+        # Test 2: bfloat16 (2 bytes per element)
+        # 3 tensors * 1024 * 4096 * 2 bytes * 2 (multiplier) = ~50.3MB (Passes safely under 64MB)
+        args_bf16 = (
+            torch.randn(1024, 4096, device=DEVICE, dtype=torch.bfloat16),
+            torch.randn(1024, 4096, device=DEVICE, dtype=torch.bfloat16),
+        )
+        try:
+            code_and_output(pallas_add_2d, args_bf16, block_sizes=[1024, 4096])
+        except Exception as e:
+            if "Ran out of memory in memory space vmem" in str(e):
+                self.fail(f"bfloat16 incorrectly threw VMEM OOM: {e}")
+
+        # Test 3: float8_e4m3fn (1 byte per element)
+        # 3 tensors * 4096 * 8192 * 1 byte * 2 (multiplier) = ~201.3MB (OOM)
+        args_fp8 = (
+            torch.randn(4096, 8192, device=DEVICE, dtype=torch.float32).to(
+                torch.float8_e4m3fn
+            ),
+            torch.randn(4096, 8192, device=DEVICE, dtype=torch.float32).to(
+                torch.float8_e4m3fn
+            ),
+        )
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"Ran out of memory in memory space vmem.*Estimated [0-9.]+MB exceeds",
+        ):
+            code_and_output(pallas_add_2d, args_fp8, block_sizes=[4096, 8192])
+
     def test_add_1d(self) -> None:
         args = (torch.randn(1024, device=DEVICE), torch.randn(1024, device=DEVICE))
         code, result = code_and_output(add_kernel, args, block_size=256)


### PR DESCRIPTION
During autotuning, exploring configurations with block sizes that are too large for TPU VMEM wastes significant time. Sending these impossible configs to XLA incurs heavy compilation overhead before inevitably failing with an OOM. 

This PR speeds up tuning by catching these impossible configurations instantly in Python before invoking pallas_call and XLA:
- Calculates the theoretical VMEM footprint (accounting for dtypes, scratch shapes, and pipeline double-buffering) and compares it to the actual hardware limit
- If the config is too large, it immediately raises a RuntimeError("Ran out of memory in memory space vmem..."), skipping the slow XLA compilation step entirely.
- Added this OOM string to `_EXPECTED_TRITON_ERRORS_RE` so the tuner recognizes it as a standard config failure, allowing it to gracefully scale down block sizes instead of crashing.