### PR TITLE
[CI] [XPU] Enable the tests for XPU

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -102,6 +102,17 @@
       "backend": "triton"
     },
     {
+      "runner": "linux.idc.xpu",
+      "python-version": "3.12",
+      "ref-eager": false,
+      "image": "intelgpu/ubuntu-24.04-lts2:2523.40",
+      "runtime-version": "xpu",
+      "container-options": "--group-add 109 --device=/dev/mem --device=/dev/dri",
+      "pytorch-version": "pytorch-nightly",
+      "alias": "xpu",
+      "backend": "triton"
+    },
+    {
       "runner": "linux.rocm.gpu.ecosystem.gfx950.1",
       "python-version": "3.12",
       "ref-eager": false,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,12 @@ jobs:
           echo "Detected ROCm image"
           rocminfo || echo "rocminfo not found"
 
+      - name: Run XPU command
+        if: startsWith(matrix.image, 'intel')
+        run: |
+          echo "Detected XPU image"
+          xpu-smi discovery || echo "xpu-smi not found"
+
       - name: Check out code
         uses: actions/checkout@v6
 
@@ -134,12 +140,14 @@ jobs:
           export CXX=clang++-20
           mkdir -p /tmp/$USER
           cd /tmp/$USER
-          uv pip uninstall triton pytorch-triton || true
+          uv pip uninstall triton pytorch-triton triton-xpu || true
           rm -rf triton/ || true
           if [[ "${{ matrix.backend }}" == "tileir" ]]; then
             git clone --recursive -b main https://github.com/triton-lang/Triton-to-tile-IR.git triton
             # Pin to last known-good commit before 13.2 syncup broke Atan2Op build
             git -C triton checkout 5d3ab8c13c
+          elif [[ "${{ matrix.alias }}" == *xpu* ]]; then
+            git clone https://github.com/intel/intel-xpu-backend-for-triton.git triton
           else
             git clone https://github.com/triton-lang/triton.git triton
             if [[ "${{ matrix.python-version }}" == "3.14" ]]; then
@@ -271,7 +279,10 @@ jobs:
           fi
           # For distributed tests, fail if any test is skipped, failed, or has an error
           SKIP_CHECK=$([[ "${{ contains(matrix.alias, 'distributed') }}" == "true" ]] && echo "! grep -qE '(SKIPPED|FAILED|ERROR)'" || echo "cat > /dev/null")
-          pytest $PARALLEL -rf --timeout=60 $EXTRA_FLAGS $TEST_PATH | tee >(eval $SKIP_CHECK)
+          if [[ "${{ matrix.alias }}" == *xpu* ]]; then
+            export TRITON_XPU_GEN_NATIVE_CODE=1
+          fi
+          pytest $PARALLEL -rf -v --timeout=60 $EXTRA_FLAGS $TEST_PATH | tee >(eval $SKIP_CHECK)
 
   test-notebooks:
     name: test-notebooks-cu128-py3.12-pytorch-2.9-a10g

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -1,3 +1,4 @@
 ND
 NotIn
 readd
+subtile

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -510,6 +510,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
     @patch.object(_compat, "_supports_maxnreg", lambda: True)
     @patch.object(loops, "_supports_warp_specialize", lambda: True)
     @skipIfRocm("config space differs on ROCm")
+    @skipIfXPU("maxnreg uses CUDA-specific register query")
     def test_config_fragment0(self):
         args = (
             torch.randn([512, 512], device=DEVICE),
@@ -529,6 +530,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
     @patch("torch.version.hip", None)
     @patch("torch.version.xpu", None)
     @skipIfRocm("config space differs on ROCm")
+    @skipIfXPU("maxnreg uses CUDA-specific register query")
     def test_config_fragment1(self):
         args = (
             torch.randn([8, 512, 512], device=DEVICE),
@@ -549,6 +551,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
     @patch("torch.version.xpu", None)
     @skipIfTileIR("tileir backend will ignore `warp specialization` hint")
     @skipIfRocm("config space differs on ROCm")
+    @skipIfXPU("maxnreg uses CUDA-specific register query")
     def test_config_warp_specialize_unroll(self):
         args = (
             torch.randn([8, 512, 512], device=DEVICE),
@@ -2083,6 +2086,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         expected = torch.full([128], 3.0, device=DEVICE)
         torch.testing.assert_close(out, expected)
 
+    @skipIfXPU("CUDA specific API used to check memory usage")
     def test_chunked_allclose_memory(self):
         """Test that autotuning accuracy checks use chunked comparison for large tensors."""
         import helion.autotuner.benchmark_provider as _bs

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -18,6 +18,7 @@ from helion import exc
 from helion._compiler.compile_environment import CompileEnvironment
 from helion._testing import TestCase
 from helion._testing import onlyBackends
+from helion._testing import skipIfXPU
 
 
 def _json_safe_values() -> st.SearchStrategy[Any]:
@@ -283,6 +284,7 @@ class TestSettingsEnv(TestCase):
             ("persistent_blocked", "persistent_interleaved"),
         )
 
+    @skipIfXPU("Uses torch.device('cuda') directly")
     def test_distributed_limits_pid_types_to_persistent(self) -> None:
         settings = helion.Settings()
         with (

--- a/test/test_dot.py
+++ b/test/test_dot.py
@@ -922,6 +922,7 @@ class TestDot(RefEagerTestBase, TestCase):
         """Test hl.dot with N=2 created through reshape."""
         self._test_reshape_n_2(lambda acc, a, b: hl.dot(a, b, acc=acc))
 
+    @skipIfXPU("Accuracy issue on XPU - small M dim tiles produce wrong results")
     def test_mm_small_m_dim(self):
         """Test torch.mm with M=2 smaller than the minimum of 16 for tl.dot."""
         # Allow slightly larger absolute error for torch.mm small-dim tiles
@@ -1000,6 +1001,7 @@ class TestDot(RefEagerTestBase, TestCase):
             lambda acc, a, b: acc + torch.mm(a, b), rtol=1e-2, atol=5e-2
         )
 
+    @skipIfXPU("Accuracy issue on XPU - small M dim tiles produce wrong results")
     def test_matmul_small_m_dim(self):
         """Test torch.matmul with M=2 smaller than the minimum of 16 for tl.dot."""
         # Allow slightly larger absolute error for small-dim tiles

--- a/test/test_epilogue_subtiling.py
+++ b/test/test_epilogue_subtiling.py
@@ -11,6 +11,7 @@ from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
 from helion._testing import skipIfRefEager
+from helion._testing import skipIfXPU
 from helion.autotuner.config_fragment import EnumFragment
 import helion.language as hl
 
@@ -177,6 +178,7 @@ class TestEpilogueSubtiling(TestCase):
         torch.testing.assert_close(out_none, out_s2, atol=1e-5, rtol=1e-5)
         torch.testing.assert_close(out_none, out_s4, atol=1e-5, rtol=1e-5)
 
+    @skipIfXPU("epilogue_subtile_autotune check uses CUDA device properties")
     def test_autotune_field_enabled_for_large_k(self):
         args = (
             torch.randn([128, 1024], device=DEVICE, dtype=torch.float32),
@@ -201,6 +203,7 @@ class TestEpilogueSubtiling(TestCase):
         fields = matmul_with_bias.bind(args).config_spec._flat_fields()
         self.assertNotIn("epilogue_subtile", fields)
 
+    @skipIfXPU("uses torch.cuda.get_device_capability() - Blackwell is CUDA-specific")
     def test_autotune_field_large_k_allows_s4_on_blackwell(self):
         args = (
             torch.randn([128, 16384], device=DEVICE, dtype=torch.float32),

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1816,6 +1816,7 @@ class TestExamples(RefEagerTestBase, TestCase):
     @xfailIfPallas("tensor accessed with conflicting tiling patterns")
     @skipIfA10G("failure on a10g")
     @skipIfTileIR("accuracy failure")
+    @skipIfXPU("ocloc compilation failure with 256-GRF kernel on XPU backend")
     def test_squeeze_and_excitation_net_bwd_da(self):
         m, n, k = 256, 256, 256
         x = torch.randn([m, n], device=DEVICE, dtype=HALF_DTYPE)
@@ -1859,6 +1860,7 @@ class TestExamples(RefEagerTestBase, TestCase):
     @xfailIfCute("CuTe squeeze-and-excitation backward still fails lowering/runtime")
     @skipIfA10G("failure on a10g")
     @skipIfTileIR("accuracy failure")
+    @skipIfXPU("ocloc compilation failure with 256-GRF kernel on XPU backend")
     def test_squeeze_and_excitation_net_bwd_db(self):
         m, n, k = 256, 256, 256
         x = torch.randn([m, n], device=DEVICE, dtype=HALF_DTYPE)

--- a/test/test_inline_asm_elementwise.py
+++ b/test/test_inline_asm_elementwise.py
@@ -13,6 +13,7 @@ from helion._testing import code_and_output
 from helion._testing import onlyBackends
 from helion._testing import skipIfRocm
 from helion._testing import skipIfTileIR
+from helion._testing import skipIfXPU
 import helion.language as hl
 
 
@@ -227,6 +228,7 @@ class TestInlineAsmElementwise(RefEagerTestDisabled, TestCase):
 
     @skipIfRocm("only works on cuda")
     @skipIfTileIR("TileIR does not support inline_asm_elementwise")
+    @skipIfXPU("PTX inline assembly (mov.u32) not supported on XPU backend")
     def test_inline_asm_basic_compilation(self):
         """Test that inline_asm_elementwise compiles without errors (no CUDA requirement)"""
 

--- a/test/test_loops.py
+++ b/test/test_loops.py
@@ -28,6 +28,7 @@ from helion._testing import skipIfNotTriton
 from helion._testing import skipIfPallas
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
+from helion._testing import skipIfXPU
 from helion._testing import xfailIfPallas
 import helion.language as hl
 
@@ -404,6 +405,7 @@ class TestLoops(RefEagerTestBase, TestCase):
             torch.testing.assert_close(result, expected)
 
     @xfailIfPallas("data-dependent bounds hit JAX tracing issues on pallas")
+    @skipIfXPU("worker crash on XPU")
     def test_data_dependent_bounds3(self):
         @helion.kernel()
         def fn(x: torch.Tensor, end0: torch.Tensor, end1: torch.Tensor) -> torch.Tensor:
@@ -1390,6 +1392,7 @@ class TestLoops(RefEagerTestBase, TestCase):
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
     @skipIfTileIR("tileir backend will ignore `range_unroll_factors` hint")
     @skipIfNotTriton("range loop hints are Triton-specific")
+    @skipIfXPU("Accuracy issue on XPU backend")
     def test_unroll_with_pipelining(self):
         @helion.kernel(static_shapes=True)
         def matmul(

--- a/test/test_rng.py
+++ b/test/test_rng.py
@@ -241,6 +241,7 @@ def _nested_broadcast_rand_expected_3d(
 class TestRNG(RefEagerTestBase, TestCase):
     @xfailIfPallas("implicit rand still hits TPU deferred buffer materialization")
     @skipIfRefEager("compile_config is not supported in ref eager mode")
+    @skipIfXPU("RNG tests timeout on XPU")
     def test_rand(self):
         """Test RNG seeding behavior, reproducibility, output range, and distribution."""
 
@@ -317,6 +318,7 @@ class TestRNG(RefEagerTestBase, TestCase):
         )
 
     @xfailIfPallas("3D aten rand has low uniqueness with fold_in offset collisions")
+    @skipIfXPU("RNG tests timeout on XPU")
     def test_rand_3d_tensor(self):
         """Test 3D RNG with tiled operations."""
 
@@ -544,6 +546,7 @@ class TestRNG(RefEagerTestBase, TestCase):
         _assert_uses_philox(self, _code1)
 
     @xfailIfPallas("implicit randn still hits TPU deferred buffer materialization")
+    @skipIfXPU("RNG tests timeout on XPU")
     def test_randn_different_seeds_tiled(self):
         """Test that different torch.manual_seed values produce different outputs for randn."""
 
@@ -572,6 +575,7 @@ class TestRNG(RefEagerTestBase, TestCase):
         self.assertFalse(torch.allclose(output1, output2))
 
     @xfailIfPallas("implicit randn still hits TPU deferred buffer materialization")
+    @skipIfXPU("RNG tests timeout on XPU")
     def test_randn_normal_distribution(self):
         """Test that torch.randn_like produces normal distribution (mean≈0, std≈1)."""
 
@@ -610,6 +614,7 @@ class TestRNG(RefEagerTestBase, TestCase):
         )
 
     @xfailIfPallas("3D implicit randn still hits TPU materialization failure")
+    @skipIfXPU("RNG tests timeout on XPU")
     def test_randn_3d_tensor(self):
         """Test 3D randn with tiled operations."""
 

--- a/test/test_torch_compile.py
+++ b/test/test_torch_compile.py
@@ -28,6 +28,7 @@ from helion._testing import TestCase
 from helion._testing import onlyBackends
 from helion._testing import skipIfRocm
 from helion._testing import skipIfTileIR
+from helion._testing import skipIfXPU
 import helion.language as hl
 
 
@@ -2583,6 +2584,7 @@ class TestTorchCompile(RefEagerTestDisabled, TestCase):
 
     @parametrize("allow_torch_compile_fusion", (True, False))
     @skipIfTileIR("torch.compile missing kernel metadata on tileir")
+    @skipIfXPU("kernel count mismatch on XPU")
     def test_clone_with_multiple_views_one_mutated(self, allow_torch_compile_fusion):
         """Test: clone with multiple views, only one is mutated.
 


### PR DESCRIPTION
Ported from #1327 

# CI Tests Related
- Add XPU runner config to matrix.json (linux.idc.xpu with Intel GPU image)
- Use parallell = 4 to accelerate CI process

# Temp Skips for XPU Only
- Add @skipIfXPU to tests that use CUDA-specific APIs (maxnreg register query)
- Add @skipIfXPU to test_unroll_with_pipelining (accuracy issue on XPU)
- Add @skipIfXPU to test_chunked_allclose_memory (CUDA memory API)