### PR TITLE
[Pallas] Fix codegen for slice indexing  when there are squeezed dimensions

### DIFF
--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -290,7 +290,7 @@ def _pallas_generated_index_code(
         )
 
     if isinstance(pattern, ArbitrarySlicePattern):
-        return _pallas_slice_code(idx, pattern, state, tensor, subscript_index)
+        return _pallas_slice_code(idx, pattern, state, tensor, tensor_dim)
 
     if isinstance(pattern, ArbitraryIndexPattern):
         if isinstance(idx, int):
@@ -387,7 +387,7 @@ def _pallas_slice_code(
     pattern: object,
     state: CodegenState,
     tensor: torch.Tensor,
-    subscript_index: int,
+    tensor_dim: int,
 ) -> str:
     from .._compiler.pallas.plan_tiling import ArbitrarySlicePattern
     from .._compiler.tile_strategy import DeviceLoopState
@@ -400,7 +400,7 @@ def _pallas_slice_code(
         )
 
     env = CompileEnvironment.current()
-    block_id = env.resolve_block_id(tensor.shape[subscript_index])
+    block_id = env.resolve_block_id(tensor.shape[tensor_dim])
     if block_id is not None:
         loops = state.codegen.active_device_loops.get(block_id)
         if loops and any(isinstance(loop, DeviceLoopState) for loop in loops):

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -841,6 +841,26 @@ class TestPallas(TestCase):
         self.assertGreaterEqual(code.count("jax.lax.fori_loop"), 2)
         torch.testing.assert_close(result, args[0] + args[1])
 
+    def test_squeeze_slice_access(self) -> None:
+        """Test for the [None, :] indexing pattern (subscript index for slice >= tensor_ndim)"""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            (N,) = x.shape
+            (M,) = y.shape
+            out = torch.empty((N, M), dtype=x.dtype)
+            for tile in hl.tile([N], block_size=[M]):
+                out[tile, :] = (x[tile][:, None] < y[None, :]).to(torch.float32)
+            return out
+
+        N = 1024
+        M = 128
+        x = torch.randn(N, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(M, device=DEVICE, dtype=torch.float32)
+        result = fn(x, y)
+        expected = (x[:, None] < y[None, :]).to(torch.float32)
+        torch.testing.assert_close(result, expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
[Pallas] Fix codegen for slice indexing  when there are squeezed dimensions

When there are squeezed dimensions (i.e. `None` subscripts), we will have `tensor_dim != subscript_idx`. The correct value for indexing into `tensor.shape` here is `tensor_dim` and not `subscript_idx`