### PR TITLE
[Autotuner] Move benchmarking implementation into BenchmarkProvider

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -5,7 +5,6 @@ import collections
 import contextlib
 import dataclasses
 import functools
-from itertools import starmap
 import logging
 import math
 from math import inf
@@ -19,8 +18,6 @@ import types
 from typing import TYPE_CHECKING
 from typing import Callable
 from typing import Literal
-from typing import NamedTuple
-from typing import NoReturn
 from typing import Protocol
 from typing import cast
 from unittest.mock import patch
@@ -33,15 +30,15 @@ from .. import exc
 from .._compat import extract_device
 from .._compat import get_device_name
 from .benchmark_provider import BenchmarkProvider
+from .benchmark_provider import BenchmarkResult
 from .benchmark_provider import LocalBenchmarkProvider
 from .benchmark_provider import _clone_args
+from .benchmark_provider import _unset_fn
 from .benchmarking import interleaved_bench
-from .logger import AutotuneLogEntry
 from .logger import AutotuningLogger
 from .metrics import AutotuneMetrics
 from .metrics import _run_post_autotune_hooks
 from .precompile_future import PrecompileFuture as PrecompileFuture
-from .progress_bar import iter_with_progress
 from helion._dist_utils import all_gather_object
 from helion._dist_utils import is_master_rank
 from helion._dist_utils import sync_object
@@ -50,7 +47,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from ..runtime.config import Config
-    from ..runtime.kernel import CompiledConfig
     from ..runtime.settings import Settings
     from . import ConfigSpec
     from .config_generation import ConfigGeneration
@@ -133,10 +129,6 @@ class _AutotunableKernel(Protocol):
         ...
 
 
-def _unset_fn(*args: object) -> NoReturn:
-    raise RuntimeError("Uninitialized function")
-
-
 _CODE_OBJECT_RE = re.compile(r"<code object .+?, line \d+>")
 
 
@@ -175,16 +167,6 @@ class BaseAutotuner(abc.ABC):
     @abc.abstractmethod
     def autotune(self, *, skip_cache: bool = False) -> Config:
         raise NotImplementedError
-
-
-class BenchmarkResult(NamedTuple):
-    """Result tuple returned by parallel_benchmark."""
-
-    config: Config
-    fn: Callable[..., object]
-    perf: float
-    status: Literal["ok", "error", "timeout", "peer_compilation_fail", "filtered"]
-    compile_time: float | None
 
 
 class BaseSearch(BaseAutotuner):
@@ -266,7 +248,6 @@ class BaseSearch(BaseAutotuner):
 
         return kwargs
 
-    # TODO(hinriksnaer): migrate set_adaptive_compile_timeout to BenchmarkProvider as post_initial_benchmark
     def set_adaptive_compile_timeout(
         self,
         members: list[PopulationMember],
@@ -322,92 +303,53 @@ class BaseSearch(BaseAutotuner):
             f"bounds=[{min_seconds}s, {original_timeout}s])"
         )
 
-    def create_precompile_future(
-        self, config: Config, fn: CompiledConfig
-    ) -> PrecompileFuture:
-        """
-        Create a subprocess that will precompile the kernel to detect hangs
-        during compilation.  The subprocess is not started until the returned
-        future is called or started explicitly.
-
-        Args:
-            config: The config that generated fn.
-            fn: The function to be precompiled.
-
-        Returns:
-            A ``PrecompileFuture`` that resolves to True on success or False on
-            failure/timeout when called.
-        """
-        # TODO(hinriksnaer): migrate create_precompile_future to BenchmarkProvider
-        bp = self.benchmark_provider
-        assert isinstance(bp, LocalBenchmarkProvider)
-        ctx = bp._precompile_context()
-        if not self.settings.autotune_precompile:
-            return PrecompileFuture.skip(ctx, config, True)
-        mode = self.settings.autotune_precompile
-        if mode not in {"fork", "spawn"}:
-            raise exc.InvalidAPIUsage("autotune_precompile must be 'fork' or 'spawn'")
-        if len(bp.mutated_arg_indices) > 0:
-            args = _clone_args(
-                self.args,
-                self.kernel.env.process_group_name,
-                idx_to_clone=bp.mutated_arg_indices,
-            )
-        else:
-            args = self.args
-
-        return PrecompileFuture.create(
-            ctx=ctx,
-            config=config,
-            fn=fn,
-            args=args,
-            result_path=bp._next_precompile_result_path(),
-            args_path=bp._precompile_args_path,
+    def _apply_config_filter(
+        self, configs: list[Config]
+    ) -> tuple[list[Config], list[int]]:
+        """Apply the user-provided config filter, returning passing configs and their indices."""
+        config_filter = self.settings.autotune_config_filter
+        if config_filter is None:
+            return configs, list(range(len(configs)))
+        filtered: list[Config | None] = [config_filter(c) for c in configs]
+        passing_indices = [i for i, fc in enumerate(filtered) if fc is not None]
+        passing_configs = cast(
+            "list[Config]",
+            [filtered[i] for i in passing_indices],
         )
+        return passing_configs, passing_indices
 
-    # TODO(hinriksnaer): migrate _benchmark to BenchmarkProvider
-    def _benchmark(
-        self,
-        configs: list[Config],
-        *,
-        desc: str = "Benchmarking",
-        _skip_filter: bool = False,
+    def benchmark_batch(
+        self, configs: list[Config], *, desc: str = "Benchmarking"
     ) -> list[BenchmarkResult]:
-        """
-        Internal benchmark implementation. Compiles in parallel and benchmarks configs.
+        """Compile and benchmark a batch of configurations.
+
+        Applies the config filter, delegates to the provider, and tracks
+        best performance.
 
         Args:
             configs: A list of configurations to benchmark.
             desc: Description for the progress bar.
 
         Returns:
-            A list of BenchmarkResult entries containing the configuration, compiled
-            callable, measured performance, status, and compilation time.
+            A list of BenchmarkResult entries, one per input config.
         """
-        config_filter = self.settings.autotune_config_filter
-        if config_filter is not None and not _skip_filter:
-            filtered_configs: list[Config | None] = [config_filter(c) for c in configs]
-            passing_indices = [
-                i for i, fc in enumerate(filtered_configs) if fc is not None
-            ]
-            passing_configs = cast(
-                "list[Config]",
-                [filtered_configs[i] for i in passing_indices],
-            )
-            inner_results = self._benchmark(
-                passing_configs, desc=desc, _skip_filter=True
-            )
+        passing_configs, passing_indices = self._apply_config_filter(configs)
+        inner_results = self.benchmark_provider.benchmark(passing_configs, desc=desc)
+
+        if len(passing_indices) == len(configs):
+            results = inner_results
+        else:
             inner_iter = iter(inner_results)
-            merged: list[BenchmarkResult] = []
             passing_set = set(passing_indices)
+            results = []
             for i, config in enumerate(configs):
                 if i in passing_set:
-                    merged.append(next(inner_iter))
+                    results.append(next(inner_iter))
                 else:
                     self.log.debug(
                         f"Config filtered out by autotune_config_filter: {config!r}"
                     )
-                    merged.append(
+                    results.append(
                         BenchmarkResult(
                             config=config,
                             fn=lambda *a, **kw: None,
@@ -416,146 +358,12 @@ class BaseSearch(BaseAutotuner):
                             compile_time=None,
                         )
                     )
-            return merged
 
-        all_configs = configs
-        compiled: dict[int, Callable[..., object]] = {}
-        futures: list[PrecompileFuture] | None = None
-        for i, config in enumerate(all_configs):
-            try:
-                compiled[i] = self.kernel.compile_config(config, allow_print=False)
-            except Exception:
-                # If all configs failed, raise error
-                if not compiled and i == len(all_configs) - 1:
-                    raise
-                self.log.warning(
-                    "Skipping config that failed to compile: %s",
-                    self.kernel.format_kernel_decorator(config, self.settings),
-                    exc_info=True,
-                )
-        fns = list(compiled.values())
-        valid_indices = list(compiled.keys())
-        configs = [all_configs[i] for i in valid_indices]
-        if self.settings.autotune_precompile:
-            futures = list(
-                starmap(
-                    self.create_precompile_future,
-                    zip(configs, fns, strict=True),
-                )
-            )
-            precompile_desc = (
-                f"{desc} precompiling" if self.settings.autotune_progress_bar else None
-            )
-            is_workings = PrecompileFuture.wait_for_all(futures, desc=precompile_desc)
-            precompile_status: list[Literal["ok", "error", "timeout"]] = []
-            for future, ok in zip(futures, is_workings, strict=True):
-                reason = future.failure_reason
-                if ok:
-                    precompile_status.append("ok")
-                elif reason == "timeout":
-                    precompile_status.append("timeout")
-                else:
-                    precompile_status.append("error")
-        else:
-            is_workings = [True] * len(configs)
-            precompile_status = ["ok"] * len(configs)
+        for r in results:
+            if r.perf < self.best_perf_so_far:
+                self.best_perf_so_far = r.perf
 
-        results: list[BenchmarkResult] = [
-            BenchmarkResult(
-                config=c, fn=_unset_fn, perf=inf, status="error", compile_time=None
-            )
-            for c in all_configs
-        ]
-
-        # Render a progress bar only when the user requested it.
-        iterator = iter_with_progress(
-            enumerate(zip(fns, is_workings, precompile_status, strict=True)),
-            total=len(configs),
-            description=f"{desc} exploring neighbors",
-            enabled=self.settings.autotune_progress_bar,
-        )
-        for index, (fn, is_working, reason) in iterator:
-            config = configs[index]
-            if futures is not None:
-                future = futures[index]
-                compile_time = (
-                    future.elapsed
-                    if future.process is not None and future.started
-                    else None
-                )
-            else:
-                compile_time = None
-            status: Literal[
-                "ok", "error", "timeout", "peer_compilation_fail", "filtered"
-            ]
-            if all(
-                all_gather_object(
-                    is_working, process_group_name=self.kernel.env.process_group_name
-                )
-            ):
-                # Log started before benchmarking to help identify hangs
-                self.log.record_autotune_entry(
-                    AutotuneLogEntry(
-                        generation=self._autotune_metrics.num_generations,
-                        status="started",
-                        perf_ms=None,
-                        compile_time=compile_time,
-                        config=config,
-                    )
-                )
-                # benchmark one-by-one to avoid noisy results
-                perf = self.benchmark_provider.benchmark_function(config, fn)
-                if perf < self.best_perf_so_far:
-                    self.best_perf_so_far = perf
-                status = "ok" if math.isfinite(perf) else "error"
-                # Log completion after benchmarking
-                self.log.record_autotune_entry(
-                    AutotuneLogEntry(
-                        generation=self._autotune_metrics.num_generations,
-                        status=status,
-                        perf_ms=perf if math.isfinite(perf) else None,
-                        compile_time=compile_time,
-                        config=config,
-                    )
-                )
-                results[valid_indices[index]] = BenchmarkResult(
-                    config=config,
-                    fn=fn,
-                    perf=perf,
-                    status=status,
-                    compile_time=compile_time,
-                )
-            else:
-                status = "timeout" if reason == "timeout" else "error"
-                if is_working:
-                    status = "peer_compilation_fail"
-                results[valid_indices[index]] = BenchmarkResult(
-                    config=config,
-                    fn=fn,
-                    perf=inf,
-                    status=status,
-                    compile_time=compile_time,
-                )
         return results
-
-    def benchmark_batch(
-        self, configs: list[Config], *, desc: str = "Benchmarking"
-    ) -> list[BenchmarkResult]:
-        """
-        Compile and benchmark a batch of configurations.
-
-        This is the primary entry point for benchmarking. It compiles and
-        benchmarks the given configs, then updates search-level metrics
-        (configs tested, failures, best performance).
-
-        Args:
-            configs: A list of configurations to benchmark.
-            desc: Description for the progress bar.
-
-        Returns:
-            A list of BenchmarkResult entries.
-        """
-        return self._benchmark(configs, desc=desc)
 
     def benchmark(self, config: Config) -> BenchmarkResult:
         """Compile and benchmark a single configuration.
@@ -791,10 +599,10 @@ class PopulationBasedSearch(BaseSearch):
         """
         config = self.config_gen.unflatten(flat_values)
         member = PopulationMember(_unset_fn, [], flat_values, config)
-        self.parallel_benchmark_population([member], desc="Benchmarking")
+        self.benchmark_population([member], desc="Benchmarking")
         return member
 
-    def parallel_benchmark_flat(
+    def benchmark_flat_batch(
         self, to_check: list[FlatConfig]
     ) -> list[PopulationMember]:
         """
@@ -807,12 +615,12 @@ class PopulationBasedSearch(BaseSearch):
             A list of population members with the benchmark results.
         """
         result = [*map(self.make_unbenchmarked, to_check)]
-        return self.parallel_benchmark_population(result)
+        return self.benchmark_population(result)
 
     def make_unbenchmarked(self, flat_values: FlatConfig) -> PopulationMember:
         """
         Create a population member with unbenchmarked configuration.  You
-        should pass the result of this to parallel_benchmark_population.
+        should pass the result of this to benchmark_population.
 
         Args:
             flat_values: The flat configuration values.
@@ -952,7 +760,7 @@ class PopulationBasedSearch(BaseSearch):
 
         return result
 
-    def parallel_benchmark_population(
+    def benchmark_population(
         self, members: list[PopulationMember], *, desc: str = "Benchmarking"
     ) -> list[PopulationMember]:
         """
@@ -1125,7 +933,7 @@ class PopulationBasedSearch(BaseSearch):
             unbenchmarked = [m for m in candidates if len(m.perfs) == 0]
             if unbenchmarked:
                 self.set_generation(self._autotune_metrics.num_generations + 1)
-                self.parallel_benchmark_population(
+                self.benchmark_population(
                     unbenchmarked, desc=f"Finishing round {round_num}"
                 )
 
@@ -1159,7 +967,7 @@ class PopulationBasedSearch(BaseSearch):
                             combined_flat[i] = c.flat_values[i]
                 combined = self.make_unbenchmarked(combined_flat)
                 if combined.config != current.config:
-                    self.parallel_benchmark_population(
+                    self.benchmark_population(
                         [combined],
                         desc=f"Finishing round {round_num}: combined",
                     )

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -5,12 +5,16 @@ import contextlib
 import datetime
 import functools
 from itertools import count
+from itertools import starmap
+import math
 from math import inf
 import os
 import tempfile
 import time
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Literal
+from typing import NamedTuple
 from typing import NoReturn
 from typing import cast
 
@@ -27,6 +31,7 @@ from ..runtime.precompile_shim import make_precompiler
 from .benchmarking import do_bench
 from .benchmarking import synchronize_device
 from .logger import SUPPRESSED_TRITON_CODE_MSG
+from .logger import AutotuneLogEntry
 from .logger import _get_failure_dump_dir
 from .logger import capture_output
 from .logger import classify_triton_exception
@@ -35,7 +40,9 @@ from .logger import log_generated_triton_code_debug
 from .logger import match_unrecoverable_runtime_error
 from .logger import maybe_dump_triton_failure
 from .precompile_future import PrecompileContext
+from .precompile_future import PrecompileFuture
 from .precompile_future import _ExtractedLaunchArgs
+from .progress_bar import iter_with_progress
 from helion._dist_utils import _clone_symm_mem_tensor
 from helion._dist_utils import all_gather_object
 from helion._dist_utils import get_signal_pad_ptrs_dev
@@ -43,6 +50,7 @@ from helion._dist_utils import is_symm_mem_tensor
 from helion._dist_utils import sync_object
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from collections.abc import Sequence
 
     from ..runtime.config import Config
@@ -53,11 +61,6 @@ if TYPE_CHECKING:
     from .base_search import _AutotunableKernel
     from .logger import AutotuningLogger
     from .metrics import AutotuneMetrics
-
-
-# TODO(hinriksnaer): benchmark_function mixes benchmarking with accuracy validation
-# (_validate_against_baseline, _compute_baseline, _assert_close) and arg management
-# (_clone_args, mutated_arg_indices). Worth decoupling these concerns.
 
 
 _FP8_DTYPES = {
@@ -229,6 +232,20 @@ def _triton_compile(
         return False
 
 
+class BenchmarkResult(NamedTuple):
+    """Result of benchmarking a single configuration."""
+
+    config: Config
+    fn: Callable[..., object]
+    perf: float
+    status: Literal["ok", "error", "timeout", "peer_compilation_fail", "filtered"]
+    compile_time: float | None
+
+
+def _unset_fn(*args: object) -> NoReturn:
+    raise RuntimeError("Uninitialized function")
+
+
 class BenchmarkProvider(abc.ABC):
     """Abstract interface for benchmarking kernel configurations.
 
@@ -241,11 +258,11 @@ class BenchmarkProvider(abc.ABC):
         provider = LocalBenchmarkProvider(...)
         provider.setup()
         try:
-            provider.benchmark_function(config, fn)
+            provider.benchmark(configs)
         finally:
             provider.cleanup()
 
-    ``BaseSearch.autotune()`` manages this lifecycle automatically.
+    ``BaseSearch`` manages this lifecycle automatically.
     """
 
     mutated_arg_indices: Sequence[int]
@@ -264,8 +281,20 @@ class BenchmarkProvider(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def benchmark_function(self, config: Config, fn: CompiledConfig) -> float:
-        """Benchmark a single compiled function.  Returns time in ms or inf."""
+    def benchmark(
+        self,
+        configs: list[Config],
+        *,
+        desc: str = "Benchmarking",
+    ) -> list[BenchmarkResult]:
+        """Compile, precompile, validate, and time a batch of configs.
+
+        Handles the full benchmark flow: compilation, optional subprocess
+        precompilation, accuracy validation, timing, error classification,
+        and progress reporting.
+
+        Returns one ``BenchmarkResult`` per input config, in the same order.
+        """
         ...
 
     @abc.abstractmethod
@@ -567,7 +596,161 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             return False
         return True
 
-    def benchmark_function(self, config: Config, fn: CompiledConfig) -> float:
+    def _create_precompile_future(
+        self, config: Config, fn: CompiledConfig
+    ) -> PrecompileFuture:
+        """Create a subprocess to precompile the kernel and detect hangs."""
+        ctx = self._precompile_context()
+        if not self.settings.autotune_precompile:
+            return PrecompileFuture.skip(ctx, config, True)
+        mode = self.settings.autotune_precompile
+        if mode not in {"fork", "spawn"}:
+            raise exc.InvalidAPIUsage("autotune_precompile must be 'fork' or 'spawn'")
+        if len(self.mutated_arg_indices) > 0:
+            args = _clone_args(
+                self.args,
+                self.kernel.env.process_group_name,
+                idx_to_clone=self.mutated_arg_indices,
+            )
+        else:
+            args = self.args
+        return PrecompileFuture.create(
+            ctx=ctx,
+            config=config,
+            fn=fn,
+            args=args,
+            result_path=self._next_precompile_result_path(),
+            args_path=self._precompile_args_path,
+        )
+
+    def benchmark(
+        self,
+        configs: list[Config],
+        *,
+        desc: str = "Benchmarking",
+    ) -> list[BenchmarkResult]:
+        """Compile, precompile, validate, and time a batch of configs."""
+        all_configs = configs
+        compiled: dict[int, Callable[..., object]] = {}
+        futures: list[PrecompileFuture] | None = None
+
+        # Compilation phase
+        for i, config in enumerate(all_configs):
+            try:
+                compiled[i] = self.kernel.compile_config(config, allow_print=False)
+            except Exception:
+                if not compiled and i == len(all_configs) - 1:
+                    raise
+                self.log.warning(
+                    "Skipping config that failed to compile: %s",
+                    self.kernel.format_kernel_decorator(config, self.settings),
+                    exc_info=True,
+                )
+        fns = list(compiled.values())
+        valid_indices = list(compiled.keys())
+        configs = [all_configs[i] for i in valid_indices]
+
+        # Precompile phase
+        if self.settings.autotune_precompile:
+            futures = list(
+                starmap(
+                    self._create_precompile_future,
+                    zip(configs, fns, strict=True),
+                )
+            )
+            precompile_desc = (
+                f"{desc} precompiling" if self.settings.autotune_progress_bar else None
+            )
+            is_workings = PrecompileFuture.wait_for_all(futures, desc=precompile_desc)
+            precompile_status: list[Literal["ok", "error", "timeout"]] = []
+            for future, ok in zip(futures, is_workings, strict=True):
+                reason = future.failure_reason
+                if ok:
+                    precompile_status.append("ok")
+                elif reason == "timeout":
+                    precompile_status.append("timeout")
+                else:
+                    precompile_status.append("error")
+        else:
+            is_workings = [True] * len(configs)
+            precompile_status = ["ok"] * len(configs)
+
+        # Initialize results with defaults
+        results: list[BenchmarkResult] = [
+            BenchmarkResult(
+                config=c, fn=_unset_fn, perf=inf, status="error", compile_time=None
+            )
+            for c in all_configs
+        ]
+
+        # Benchmark loop with progress reporting
+        iterator = iter_with_progress(
+            enumerate(zip(fns, is_workings, precompile_status, strict=True)),
+            total=len(configs),
+            description=f"{desc} exploring neighbors",
+            enabled=self.settings.autotune_progress_bar,
+        )
+        for index, (fn, is_working, reason) in iterator:
+            config = configs[index]
+            if futures is not None:
+                future = futures[index]
+                compile_time = (
+                    future.elapsed
+                    if future.process is not None and future.started
+                    else None
+                )
+            else:
+                compile_time = None
+            status: Literal[
+                "ok", "error", "timeout", "peer_compilation_fail", "filtered"
+            ]
+            if all(
+                all_gather_object(
+                    is_working,
+                    process_group_name=self.kernel.env.process_group_name,
+                )
+            ):
+                self.log.record_autotune_entry(
+                    AutotuneLogEntry(
+                        generation=self._autotune_metrics.num_generations,
+                        status="started",
+                        perf_ms=None,
+                        compile_time=compile_time,
+                        config=config,
+                    )
+                )
+                perf = self._benchmark_function(config, fn)
+                status = "ok" if math.isfinite(perf) else "error"
+                self.log.record_autotune_entry(
+                    AutotuneLogEntry(
+                        generation=self._autotune_metrics.num_generations,
+                        status=status,
+                        perf_ms=perf if math.isfinite(perf) else None,
+                        compile_time=compile_time,
+                        config=config,
+                    )
+                )
+                results[valid_indices[index]] = BenchmarkResult(
+                    config=config,
+                    fn=fn,
+                    perf=perf,
+                    status=status,
+                    compile_time=compile_time,
+                )
+            else:
+                status = "timeout" if reason == "timeout" else "error"
+                if is_working:
+                    status = "peer_compilation_fail"
+                results[valid_indices[index]] = BenchmarkResult(
+                    config=config,
+                    fn=fn,
+                    perf=inf,
+                    status=status,
+                    compile_time=compile_time,
+                )
+        return results
+
+    def _benchmark_function(self, config: Config, fn: CompiledConfig) -> float:
         """Benchmark a single compiled function.  Returns time in ms or inf."""
         self._autotune_metrics.num_configs_tested += 1
         self.log.debug(lambda: f"Running benchmark for {config!r}")

--- a/helion/autotuner/de_surrogate_hybrid.py
+++ b/helion/autotuner/de_surrogate_hybrid.py
@@ -215,7 +215,7 @@ class DESurrogateHybrid(DifferentialEvolutionSearch):
             selected_candidates = self._generate_de_candidates(self.population_size)
 
         # Evaluate selected candidates
-        new_members = self.parallel_benchmark_flat(selected_candidates)
+        new_members = self.benchmark_flat_batch(selected_candidates)
 
         # Track observations
         for member in new_members:

--- a/helion/autotuner/differential_evolution.py
+++ b/helion/autotuner/differential_evolution.py
@@ -150,7 +150,7 @@ class DifferentialEvolutionSearch(PopulationBasedSearch):
         # The initial population is 2x larger so we can throw out the slowest half and give the tuning process a head start
         initial_population_name = self.initial_population_strategy.name
         oversized_population = sorted(
-            self.parallel_benchmark_flat(
+            self.benchmark_flat_batch(
                 self._generate_initial_population_flat(),
             ),
             key=performance,
@@ -167,7 +167,7 @@ class DifferentialEvolutionSearch(PopulationBasedSearch):
         if not indices:
             return []
         flat_configs = [self.mutate(i) for i in indices]
-        return self.parallel_benchmark_flat(flat_configs)
+        return self.benchmark_flat_batch(flat_configs)
 
     def iter_candidates(self) -> Iterator[tuple[int, PopulationMember]]:
         if self.immediate_update:

--- a/helion/autotuner/pattern_search.py
+++ b/helion/autotuner/pattern_search.py
@@ -140,7 +140,7 @@ class PatternSearch(PopulationBasedSearch):
             if member.config not in visited:
                 visited.add(member.config)
                 self.population.append(member)
-        self.parallel_benchmark_population(self.population, desc="Initial population")
+        self.benchmark_population(self.population, desc="Initial population")
 
         # Compute adaptive compile timeout based on initial population compile times
         self.set_adaptive_compile_timeout(
@@ -190,7 +190,7 @@ class PatternSearch(PopulationBasedSearch):
             unbenchmarked = [m for m in self.population if len(m.perfs) == 0]
             if unbenchmarked:
                 self.set_generation(generation)
-                self.parallel_benchmark_population(
+                self.benchmark_population(
                     unbenchmarked, desc=f"Generation {generation}:"
                 )
             # higher-accuracy rebenchmark

--- a/helion/autotuner/surrogate_pattern_search.py
+++ b/helion/autotuner/surrogate_pattern_search.py
@@ -370,7 +370,7 @@ class LFBOPatternSearch(PatternSearch):
                 visited.add(member.config)
                 self.population.append(member)
         self.set_generation(0)
-        self.parallel_benchmark_population(self.population, desc="Initial population")
+        self.benchmark_population(self.population, desc="Initial population")
 
         # Compute adaptive compile timeout based on initial population compile times
         self.set_adaptive_compile_timeout(
@@ -438,7 +438,7 @@ class LFBOPatternSearch(PatternSearch):
             unbenchmarked = [m for m in self.population if len(m.perfs) == 0]
             if unbenchmarked:
                 self.set_generation(generation)
-                self.parallel_benchmark_population(
+                self.benchmark_population(
                     unbenchmarked, desc=f"Generation {generation}:"
                 )
             # higher-accuracy rebenchmark

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -143,7 +143,7 @@ class TestAutotuneIgnoreErrors(TestCase):
         with patch("torch.accelerator.synchronize", autospec=True) as sync:
             sync.return_value = None
             with pytest.raises(exc.TritonError) as err:
-                search.benchmark_provider.benchmark_function("cfg", bad_fn)
+                search.benchmark_provider._benchmark_function("cfg", bad_fn)
 
         assert "HELION_AUTOTUNE_IGNORE_ERRORS" in str(err.value)
 
@@ -159,7 +159,7 @@ class TestAutotuneIgnoreErrors(TestCase):
 
         with patch("torch.accelerator.synchronize", autospec=True) as sync:
             sync.return_value = None
-            result = search.benchmark_provider.benchmark_function("cfg", bad_fn)
+            result = search.benchmark_provider._benchmark_function("cfg", bad_fn)
 
         self.assertEqual(result, float("inf"))
         self.assertEqual(search._autotune_metrics.num_compile_failures, 1)
@@ -177,7 +177,7 @@ class TestAutotuneIgnoreErrors(TestCase):
         with patch("torch.accelerator.synchronize", autospec=True) as sync:
             sync.return_value = None
             with patch.object(search.log, "warning") as warn:
-                result = search.benchmark_provider.benchmark_function("cfg", bad_fn)
+                result = search.benchmark_provider._benchmark_function("cfg", bad_fn)
 
         self.assertEqual(result, float("inf"))
         warn.assert_not_called()
@@ -202,7 +202,7 @@ class TestAutotuneIgnoreErrors(TestCase):
         ):
             sync.return_value = None
             with pytest.raises(exc.TritonError) as err:
-                search.benchmark_provider.benchmark_function("cfg", bad_fn)
+                search.benchmark_provider._benchmark_function("cfg", bad_fn)
 
         # Verify the traceback was cleared
         assert err.value.__cause__.__traceback__ is None
@@ -231,7 +231,7 @@ class TestAutotuneIgnoreErrors(TestCase):
         ):
             sync.return_value = None
             with pytest.raises(exc.TritonError) as err:
-                search.benchmark_provider.benchmark_function("cfg", bad_fn)
+                search.benchmark_provider._benchmark_function("cfg", bad_fn)
 
         # Verify the traceback was cleared
         assert err.value.__cause__.__traceback__ is None
@@ -242,7 +242,7 @@ class TestAutotuneIgnoreErrors(TestCase):
         assert type(err.value.__cause__).__name__ == "RuntimeError"
 
     def test_benchmark_results_aligned_when_compile_fails(self):
-        """_benchmark must return one result per input config even when some
+        """benchmark_batch must return one result per input config even when some
         fail to compile."""
         settings = Settings(
             autotune_precompile=None,
@@ -266,11 +266,11 @@ class TestAutotuneIgnoreErrors(TestCase):
             patch.object(search.kernel, "compile_config", side_effect=fail_second),
             patch.object(
                 search.benchmark_provider,
-                "benchmark_function",
+                "_benchmark_function",
                 return_value=1.0,
             ),
         ):
-            results = search._benchmark(configs, desc="test")
+            results = search.benchmark_batch(configs, desc="test")
 
         self.assertEqual(len(results), 3)
         self.assertEqual(results[0].perf, 1.0)
@@ -419,7 +419,9 @@ class TestAutotuneIgnoreErrors(TestCase):
             ),
             patch("torch.cuda._lazy_init", side_effect=fake_lazy_init),
         ):
-            future = search.create_precompile_future("cfg", fake_compiled_fn)
+            future = search.benchmark_provider._create_precompile_future(
+                "cfg", fake_compiled_fn
+            )
             self.assertTrue(future())
 
         self.assertEqual(set(lazy_calls), {parent_pid})
@@ -1261,8 +1263,8 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
                 search._prepare()
                 if mode == "fork":
                     start_cm = patch.object(
-                        search,
-                        "create_precompile_future",
+                        search.benchmark_provider,
+                        "_create_precompile_future",
                         side_effect=lambda config, fn: (
                             base_search_module.PrecompileFuture.skip(
                                 search.benchmark_provider._precompile_context(),
@@ -1345,8 +1347,8 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
                 search._prepare()
                 if mode == "fork":
                     start_cm = patch.object(
-                        search,
-                        "create_precompile_future",
+                        search.benchmark_provider,
+                        "_create_precompile_future",
                         side_effect=lambda config, fn: (
                             base_search_module.PrecompileFuture.skip(
                                 search.benchmark_provider._precompile_context(),
@@ -1473,8 +1475,8 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             )
             search._prepare()
             with patch.object(
-                search,
-                "create_precompile_future",
+                search.benchmark_provider,
+                "_create_precompile_future",
                 side_effect=lambda config, fn: base_search_module.PrecompileFuture.skip(
                     search.benchmark_provider._precompile_context(), config, True
                 ),
@@ -2202,8 +2204,8 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             search._prepare()
 
             with patch.object(
-                search,
-                "create_precompile_future",
+                search.benchmark_provider,
+                "_create_precompile_future",
                 side_effect=lambda config, fn: base_search_module.PrecompileFuture.skip(
                     search.benchmark_provider._precompile_context(), config, True
                 ),

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -92,7 +92,7 @@ class TestErrors(RefEagerTestDisabled, TestCase):
 
         with (
             mock.patch.object(
-                PopulationBasedSearch, "parallel_benchmark_flat", fake_parallel
+                PopulationBasedSearch, "benchmark_flat_batch", fake_parallel
             ),
             self.assertRaises(helion.exc.NoConfigFound),
         ):


### PR DESCRIPTION
`LocalBenchmarkProvider` should now include the remaining implementation detail for benchmarking and compilation that was previously found inside `base_search.py`. Also dropped the `parallel_benchmark...` prefix now that search is no longer responsible for that implementation detail.

Rebenchmarking still remains on BaseSearch since it uses a different, more specialized strategy (interleaved timing of already-compiled functions). 