### PR TITLE
[Pallas] Add xfail tests for bmm non-divisible reduction

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -303,6 +303,19 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[16, 16, 16, 16],
         )
 
+    @xfailIfPallas("reduction tile K=256 doesn't evenly divide K=384")
+    def test_bmm_non_divisible_k(self):
+        args = (
+            torch.randn([4, 128, 384], device=DEVICE, dtype=HALF_DTYPE),
+            torch.randn([4, 384, 128], device=DEVICE, dtype=HALF_DTYPE),
+        )
+        check_example(
+            "bmm",
+            args,
+            torch.bmm(args[0], args[1]),
+            block_sizes=[4, 128, 128, 256],
+        )
+
     @skipIfFn(
         lambda: _get_backend() == "cute", "CuTe FP8 GEMM example is not supported yet"
     )

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -556,6 +556,38 @@ class TestPallas(TestCase):
         expected = torch.bmm(a.float(), b.float()).to(torch.bfloat16)
         torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
 
+    @xfailIfPallas(
+        "reduction tile K=256 doesn't evenly divide K=384, last tile reads OOB"
+    )
+    def test_bmm_fori_loop_non_divisible_k(self) -> None:
+        """Test fori_loop bmm where BLOCK_K=256 doesn't evenly divide K=384."""
+        a = torch.randn(4, 128, 384, device=DEVICE, dtype=torch.bfloat16)
+        b = torch.randn(4, 384, 128, device=DEVICE, dtype=torch.bfloat16)
+        _code, result = code_and_output(
+            pallas_bmm,
+            (a, b),
+            block_sizes=[4, 128, 128, 256],
+            pallas_loop_type="fori_loop",
+        )
+        expected = torch.bmm(a.float(), b.float()).to(torch.bfloat16)
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+
+    @xfailIfPallas(
+        "reduction tile K=256 doesn't evenly divide K=384, last tile reads OOB"
+    )
+    def test_bmm_emit_pipeline_non_divisible_k(self) -> None:
+        """Test emit_pipeline bmm where BLOCK_K=256 doesn't evenly divide K=384."""
+        a = torch.randn(4, 128, 384, device=DEVICE, dtype=torch.bfloat16)
+        b = torch.randn(4, 384, 128, device=DEVICE, dtype=torch.bfloat16)
+        _code, result = code_and_output(
+            pallas_bmm,
+            (a, b),
+            block_sizes=[4, 128, 128, 256],
+            pallas_loop_type="emit_pipeline",
+        )
+        expected = torch.bmm(a.float(), b.float()).to(torch.bfloat16)
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+
     def test_emit_pipeline_codegen(self) -> None:
         """Test that pallas_loop_type='emit_pipeline' generates correct emit_pipeline code."""
         args = (


### PR DESCRIPTION
## Summary

Add three xfail tests documenting that bmm produces wrong results when `BLOCK_K` doesn't evenly divide `K` (e.g. `K=384, BLOCK_K=256`).

Tests use small shapes (`[4, 128, 384] @ [4, 384, 128]`) with `BLOCK_K=256` (`384 % 256 != 0`).

### Root cause

The last reduction tile reads past the end of the tensor. With `K=384, BLOCK_K=256`: `ceil(384 / 256) = 2` iterations, last reads `K[256:512]` — OOB by 128 elements.

All three Pallas loop types are affected:
- **default**: Crashes with `Out of bound slice: start=256, size=256, stride=1, dim=384`
- **fori_loop**: Silently produces garbage (max_diff=inf)
- **emit_pipeline**: Silently produces garbage (max_diff=inf)

Note: the attention kernel handles non-divisible reduction correctly using `_explicit_indices=True` and element-wise masking (tested in `test_attention_emit_pipeline_non_divisible`). A similar approach may be taken.

### Impact

Discovered via a test autotuning run where **48 of 215** autotuned bmm configs and **35 of 123** broadcast_matmul configs failed accuracy checks.