### PR TITLE
[AMD ROCM] matrix_instr_nonkdim restricted to 16

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -620,7 +620,7 @@ class TritonBackend(Backend):
         if is_hip():
             fragments["waves_per_eu"] = EnumFragment(choices=(1, 2, 3, 4))
             if supports_amd_cdna_tunables():
-                fragments["matrix_instr_nonkdim"] = EnumFragment(choices=(0, 16, 32))
+                fragments["matrix_instr_nonkdim"] = EnumFragment(choices=(0, 16))
 
         if supports_mtia_tunables():
             fragments.update(get_mtia_tunable_fragments())


### PR DESCRIPTION
Restricting matrix_instr_nonkdim to avoid catastrophic errors while benchmarking.