### PR TITLE
[TPU][Pallas] Fix OOM on large reductions by delegating chunking to Mosaic

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -927,6 +927,9 @@ class PallasBackend(Backend):
     def name(self) -> str:
         return "pallas"
 
+    def max_reduction_threads(self) -> int | None:
+        return None
+
     def dtype_str(self, dtype: torch.dtype) -> str:
         key = str(dtype)
         if key not in _TORCH_TO_JAX_DTYPE:

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -979,7 +979,6 @@ class PallasBackend(Backend):
             "block_sizes",
             "loop_orders",
             "flatten_loops",
-            "reduction_loops",
             "pallas_loop_type",
         }
     )

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -640,12 +640,13 @@ class DeviceIR:
                 continue
             if used_graphs & graphs_with_rolled_rdim:
                 continue
-            env.config_spec.reduction_loops.append(
-                ReductionLoopSpec(
-                    block_id=rdim.block_id,
-                    size_hint=rdim.size_hint(),
+            if env.config_spec.backend_name != "pallas":
+                env.config_spec.reduction_loops.append(
+                    ReductionLoopSpec(
+                        block_id=rdim.block_id,
+                        size_hint=rdim.size_hint(),
+                    )
                 )
-            )
             graphs_with_rolled_rdim |= used_graphs
 
     def build_codegen_graphs(self, config: Config) -> list[GraphInfo]:

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -1126,9 +1126,6 @@ class ReductionLoopSpec(_PowerOfTwoBlockIdItem):
     def _flat_config(
         self, base: ConfigSpec, fn: Callable[[ConfigSpecFragment], object]
     ) -> int | None:
-        if base.backend_name == "pallas":
-            return None
-
         low = 8  # TODO(jansel): is smaller needed?
         high = next_power_of_2(max(low, self.size_hint))
         default = min(high, 4096)

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -1126,6 +1126,9 @@ class ReductionLoopSpec(_PowerOfTwoBlockIdItem):
     def _flat_config(
         self, base: ConfigSpec, fn: Callable[[ConfigSpecFragment], object]
     ) -> int | None:
+        if base.backend_name == "pallas":
+            return None
+
         low = 8  # TODO(jansel): is smaller needed?
         high = next_power_of_2(max(low, self.size_hint))
         default = min(high, 4096)

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1095,11 +1095,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             num_stages=3,
         )
 
-    @xfailIfPallas(
-        "Out-of-bounds slice when reduction_loops doesn't evenly divide the "
-        "reduction dimension (e.g. reduction_loops=32 on dim=48 generates "
-        "pl.ds(32, 32) which exceeds bounds)"
-    )
     def test_layernorm_reduction_not_divisible(self):
         """Reduction loop OOB when reduction_loops doesn't divide the reduction dim."""
         batch_size = 4
@@ -2164,7 +2159,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             fn_name="longsum",
         )
 
-    @xfailIfPallas("JAX tracer error with dynamic shapes")
     def test_long_sum_looped(self):
         args = (torch.randn([4, 130000], device=DEVICE, dtype=torch.float32),)
         check_example(

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -457,7 +457,9 @@ class TestPallas(TestCase):
 
     def test_sum_reduce_middle(self) -> None:
         x = torch.randn(4, 64, 32, device=DEVICE, dtype=torch.float32)
-        code, result = code_and_output(pallas_sum_reduce_middle, (x,), block_sizes=[2, 16])
+        code, result = code_and_output(
+            pallas_sum_reduce_middle, (x,), block_sizes=[2, 16]
+        )
         self.assertIn("jnp.sum", code)
         torch.testing.assert_close(result, x.sum(1), rtol=1e-4, atol=1e-4)
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1009,6 +1009,9 @@ class TestPallas(TestCase):
         self.assertIn("pl.ds(", code)
         torch.testing.assert_close(result, args[0] + args[1])
 
+    @xfailIfPallas(
+        "No config values to tune because all block sizes are fixed and Pallas no longer tunes reduction loops"
+    )
     def test_squeeze_slice_access(self) -> None:
         """Test for the [None, :] indexing pattern (subscript index for slice >= tensor_ndim)"""
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -120,6 +120,33 @@ def pallas_sum_reduction(x: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_sum_reduce_dim0(x: torch.Tensor) -> torch.Tensor:
+    _n, m = x.size()
+    out = torch.empty([m], dtype=x.dtype, device=x.device)
+    for tile_m in hl.tile(m):
+        out[tile_m] = x[:, tile_m].sum(0)
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_sum_reduce_middle(x: torch.Tensor) -> torch.Tensor:
+    b, _n, m = x.size()
+    out = torch.empty([b, m], dtype=x.dtype, device=x.device)
+    for tile_b, tile_m in hl.tile([b, m]):
+        out[tile_b, tile_m] = x[tile_b, :, tile_m].sum(1)
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_sum_reduce_multiple(x: torch.Tensor) -> torch.Tensor:
+    b, _n, _m = x.size()
+    out = torch.empty([b], dtype=x.dtype, device=x.device)
+    for tile_b in hl.tile(b):
+        out[tile_b] = x[tile_b, :, :].sum([0, 1])
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_max_reduction(x: torch.Tensor) -> torch.Tensor:
     n, _m = x.size()
     out = torch.empty([n], dtype=x.dtype, device=x.device)
@@ -403,6 +430,23 @@ class TestPallas(TestCase):
         code, result = code_and_output(pallas_sum_reduction, (x,), block_size=1)
         self.assertIn("jnp.sum", code)
         torch.testing.assert_close(result, x.sum(-1), rtol=1e-3, atol=1e-3)
+
+    def test_sum_reduce_dim0(self) -> None:
+        x = torch.randn(64, 32, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(pallas_sum_reduce_dim0, (x,), block_size=16)
+        self.assertIn("jnp.sum", code)
+        torch.testing.assert_close(result, x.sum(0), rtol=1e-4, atol=1e-4)
+
+    def test_sum_reduce_middle(self) -> None:
+        x = torch.randn(4, 64, 32, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(pallas_sum_reduce_middle, (x,), block_sizes=[2, 16])
+        self.assertIn("jnp.sum", code)
+        torch.testing.assert_close(result, x.sum(1), rtol=1e-4, atol=1e-4)
+
+    def test_sum_reduce_multiple(self) -> None:
+        x = torch.randn(4, 32, 64, device=DEVICE, dtype=torch.float32)
+        with self.assertRaises(NotImplementedError):
+            code_and_output(pallas_sum_reduce_multiple, (x,), block_size=2)
 
     def test_max_reduction(self) -> None:
         x = torch.randn(32, 64, device=DEVICE, dtype=torch.float32)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -156,6 +156,24 @@ def pallas_max_reduction(x: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_min_reduction(x: torch.Tensor) -> torch.Tensor:
+    n, _m = x.size()
+    out = torch.empty([n], dtype=x.dtype, device=x.device)
+    for tile_n in hl.tile(n):
+        out[tile_n] = torch.amin(x[tile_n, :], dim=-1)
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_argmin_reduction(x: torch.Tensor) -> torch.Tensor:
+    n, _m = x.size()
+    out = torch.empty([n], dtype=torch.int32, device=x.device)
+    for tile_n in hl.tile(n):
+        out[tile_n] = torch.argmin(x[tile_n, :], dim=-1).to(torch.int32)
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_tile_begin_end(x: torch.Tensor) -> torch.Tensor:
     out = torch.empty_like(x)
     for tile in hl.tile(x.size(0)):
@@ -453,6 +471,18 @@ class TestPallas(TestCase):
         code, result = code_and_output(pallas_max_reduction, (x,), block_size=16)
         self.assertIn("jnp.max", code)
         torch.testing.assert_close(result, torch.amax(x, dim=-1), rtol=1e-4, atol=1e-4)
+
+    def test_min_reduction(self) -> None:
+        x = torch.randn(32, 64, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(pallas_min_reduction, (x,), block_size=16)
+        self.assertIn("jnp.min", code)
+        torch.testing.assert_close(result, torch.amin(x, dim=-1), rtol=1e-4, atol=1e-4)
+
+    def test_argmin_reduction(self) -> None:
+        x = torch.randn(32, 64, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(pallas_argmin_reduction, (x,), block_size=16)
+        self.assertIn("jnp.argmin", code)
+        torch.testing.assert_close(result, torch.argmin(x, dim=-1).to(torch.int32))
 
     def test_tile_begin_end(self) -> None:
         x = torch.randn(1024, device=DEVICE, dtype=torch.float32)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -398,6 +398,12 @@ class TestPallas(TestCase):
         self.assertIn("jnp.sum", code)
         torch.testing.assert_close(result, x.sum(-1), rtol=1e-4, atol=1e-4)
 
+    def test_sum_reduction_large(self) -> None:
+        x = torch.randn(8, 16384, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(pallas_sum_reduction, (x,), block_size=1)
+        self.assertIn("jnp.sum", code)
+        torch.testing.assert_close(result, x.sum(-1), rtol=1e-3, atol=1e-3)
+
     def test_max_reduction(self) -> None:
         x = torch.randn(32, 64, device=DEVICE, dtype=torch.float32)
         code, result = code_and_output(pallas_max_reduction, (x,), block_size=16)

--- a/test/test_random.py
+++ b/test/test_random.py
@@ -17,7 +17,6 @@ from helion._testing import onlyBackends
 from helion._testing import skipIfMTIA
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfRocm
-from helion._testing import xfailIfPallas
 import helion.language as hl
 from helion.runtime.config import Config
 from helion.runtime.ref_mode import is_ref_mode_enabled

--- a/test/test_random.py
+++ b/test/test_random.py
@@ -498,7 +498,6 @@ class TestRandom(RefEagerTestBase, TestCase):
             msg="Mixed tile argument order should produce identical results",
         )
 
-    @xfailIfPallas("rolled reductions not supported for pallas rand")
     @skipIfRocm("ROCm Triton worker crashes on rand with rolled reductions")
     def test_hl_rand_rolled_reductions(self):
         @helion.kernel(static_shapes=False)


### PR DESCRIPTION
Previously, Helion's autotuner would enforce a warp-size cap (e.g., 4096 elements) via reduction_loops, prompting `LoopedReductionStrategy` to emit an explicit for loop that chunked the reduction dimension. While this is necessary for Triton, jnp.sum handles this natively, more akin to the `PersistentReductionStrategy` even for large reduction dimensions.

This update introduces a cleaner integration:
- `PallasBackend.max_reduction_threads()` now returns `None` to lift artificial warp-size ceilings.
- `ReductionLoopSpec._flat_config()` enforces a `None` loop strategy for the pallas backend.

`examples/sum.py` now produces:
```
Benchmarking 100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 401/401 1414.5 configs/s

=================================================================
Benchmark Results
=================================================================
Implementation       Time (ms)    Speedup        
-----------------------------------------------------------------
helion               0.3706       0.88x          
torch                0.3265       1.00x (ref)    
=================================================================
```