### PR TITLE
CI: retry flaky CUDA compute check

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -1,5 +1,7 @@
 retryable_workflows:
   - "test"
+  - "Tests"
   - "benchmark"
+  - "Benchmark"
 retryable_step_names:
   - "CUDA Compute Check"

--- a/.github/scripts/cuda_compute_check.sh
+++ b/.github/scripts/cuda_compute_check.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${HELION_CUDA_CHECK_ATTEMPTS:=3}"
+: "${HELION_CUDA_CHECK_RETRY_DELAY_SECONDS:=20}"
+: "${HELION_CUDA_CHECK_FORCE_FAIL_ATTEMPTS:=0}"
+
+source .venv/bin/activate
+
+run_cuda_compute_check_attempt() {
+  local attempt="$1"
+
+  if ((attempt <= HELION_CUDA_CHECK_FORCE_FAIL_ATTEMPTS)); then
+    python - <<'PY'
+import warnings
+
+warnings.warn(
+    "CUDA initialization: CUDA unknown error - this may be due to an incorrectly "
+    "set up environment, e.g. changing env variable CUDA_VISIBLE_DEVICES after "
+    "program start. Setting the available devices to be zero."
+)
+raise AssertionError("FATAL: CUDA not available")
+PY
+  else
+    python - <<'PY'
+import torch
+
+assert torch.cuda.is_available(), "FATAL: CUDA not available"
+n = torch.cuda.device_count()
+assert n > 0, "FATAL: No CUDA devices found"
+print(f"CUDA devices: {n}")
+
+for i in range(n):
+    dev = torch.device("cuda", i)
+    a = torch.randn(256, 256, device=dev)
+    (a @ a).sum().item()
+    print(f"  Device {i} ({torch.cuda.get_device_name(i)}): OK")
+
+print(f"All {n} devices healthy")
+PY
+  fi
+}
+
+for ((attempt = 1; attempt <= HELION_CUDA_CHECK_ATTEMPTS; attempt++)); do
+  echo "::group::CUDA Compute Check attempt ${attempt}/${HELION_CUDA_CHECK_ATTEMPTS}"
+  if run_cuda_compute_check_attempt "${attempt}"; then
+    echo "::endgroup::"
+    exit 0
+  fi
+  echo "::endgroup::"
+
+  if command -v nvidia-smi >/dev/null 2>&1; then
+    echo "nvidia-smi -L after failed attempt ${attempt}:"
+    nvidia-smi -L || true
+  fi
+
+  if ((attempt < HELION_CUDA_CHECK_ATTEMPTS)); then
+    echo "Retrying CUDA Compute Check in ${HELION_CUDA_CHECK_RETRY_DELAY_SECONDS}s"
+    sleep "${HELION_CUDA_CHECK_RETRY_DELAY_SECONDS}"
+  fi
+done
+
+echo "CUDA Compute Check failed after ${HELION_CUDA_CHECK_ATTEMPTS} attempts" >&2
+if command -v nvidia-smi >/dev/null 2>&1; then
+  nvidia-smi || true
+fi
+exit 1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -106,23 +106,7 @@ jobs:
       - name: CUDA Compute Check
         if: startsWith(inputs.image, 'nvidia')
         run: |
-          source .venv/bin/activate
-          python -c "
-          import torch, sys
-
-          assert torch.cuda.is_available(), 'FATAL: CUDA not available'
-          n = torch.cuda.device_count()
-          assert n > 0, 'FATAL: No CUDA devices found'
-          print(f'CUDA devices: {n}')
-
-          for i in range(n):
-              dev = torch.device('cuda', i)
-              a = torch.randn(256, 256, device=dev)
-              b = (a @ a).sum().item()
-              print(f'  Device {i} ({torch.cuda.get_device_name(i)}): OK')
-
-          print(f'All {n} devices healthy')
-          "
+          bash .github/scripts/cuda_compute_check.sh
 
       - name: Install Benchmark Requirements
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,24 +220,11 @@ jobs:
 
       - name: CUDA Compute Check
         if: startsWith(matrix.image, 'nvidia')
+        env:
+          HELION_CUDA_CHECK_FORCE_FAIL_ATTEMPTS: ${{ matrix.alias == 'a10g' && matrix.python-version == '3.10' && matrix.backend == 'triton' && matrix.pytorch-version == 'pytorch-2.9' && '2' || '0' }}
+          HELION_CUDA_CHECK_RETRY_DELAY_SECONDS: ${{ matrix.alias == 'a10g' && matrix.python-version == '3.10' && matrix.backend == 'triton' && matrix.pytorch-version == 'pytorch-2.9' && '1' || '20' }}
         run: |
-          source .venv/bin/activate
-          python -c "
-          import torch, sys
-
-          assert torch.cuda.is_available(), 'FATAL: CUDA not available'
-          n = torch.cuda.device_count()
-          assert n > 0, 'FATAL: No CUDA devices found'
-          print(f'CUDA devices: {n}')
-
-          for i in range(n):
-              dev = torch.device('cuda', i)
-              a = torch.randn(256, 256, device=dev)
-              b = (a @ a).sum().item()
-              print(f'  Device {i} ({torch.cuda.get_device_name(i)}): OK')
-
-          print(f'All {n} devices healthy')
-          "
+          bash .github/scripts/cuda_compute_check.sh
 
       - name: Run Tests
         run: |


### PR DESCRIPTION
Current retry bot retries on a different machine. For some of the failures I've seen, the machine is not down. This retries multiple times on the same machine before retrying on a different machine. 
Not seeing B200 failures now, so will try this when we see B200 failures again. 