### PR TITLE
[Autotuner] Make the autotuner robust to `InvalidConfig`

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -806,10 +806,10 @@ class PopulationBasedSearch(BaseSearch):
         Returns:
             A list of population members with the benchmark results.
         """
-        result = [*map(self.make_unbenchmarked, to_check)]
+        result = [m for m in map(self.make_unbenchmarked, to_check) if m is not None]
         return self.parallel_benchmark_population(result)
 
-    def make_unbenchmarked(self, flat_values: FlatConfig) -> PopulationMember:
+    def make_unbenchmarked(self, flat_values: FlatConfig) -> PopulationMember | None:
         """
         Create a population member with unbenchmarked configuration.  You
         should pass the result of this to parallel_benchmark_population.
@@ -818,9 +818,13 @@ class PopulationBasedSearch(BaseSearch):
             flat_values: The flat configuration values.
 
         Returns:
-            A population member with undefined performance.
+            A population member with undefined performance, or None if the
+            configuration is invalid (e.g. all dimensions fissioned).
         """
-        config = self.config_gen.unflatten(flat_values)
+        try:
+            config = self.config_gen.unflatten(flat_values)
+        except exc.InvalidConfig:
+            return None
         return PopulationMember(_unset_fn, [], flat_values, config)
 
     def _get_current_hardware_and_specialization(
@@ -939,7 +943,13 @@ class PopulationBasedSearch(BaseSearch):
                 self.log.debug(
                     f"Cached config {i + 1} (transferred): {transferred_config}"
                 )
-            except (ValueError, TypeError, KeyError, AssertionError) as e:
+            except (
+                ValueError,
+                TypeError,
+                KeyError,
+                AssertionError,
+                exc.InvalidConfig,
+            ) as e:
                 self.log(f"Failed to transfer cached config {i + 1}: {e}")
                 continue
 
@@ -1113,8 +1123,8 @@ class PopulationBasedSearch(BaseSearch):
                     new_flat = [*current.flat_values]
                     new_flat[i] = default_flat[i]
                     candidate = self.make_unbenchmarked(new_flat)
-                    # Only add if this produces a different config
-                    if candidate.config != current.config:
+                    # Only add if valid and produces a different config
+                    if candidate is not None and candidate.config != current.config:
                         candidates.append(candidate)
 
             if len(candidates) <= 1:
@@ -1158,7 +1168,7 @@ class PopulationBasedSearch(BaseSearch):
                         if c.flat_values[i] != current.flat_values[i]:
                             combined_flat[i] = c.flat_values[i]
                 combined = self.make_unbenchmarked(combined_flat)
-                if combined.config != current.config:
+                if combined is not None and combined.config != current.config:
                     self.parallel_benchmark_population(
                         [combined],
                         desc=f"Finishing round {round_num}: combined",

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -819,7 +819,7 @@ class PopulationBasedSearch(BaseSearch):
 
         Returns:
             A population member with undefined performance, or None if the
-            configuration is invalid (e.g. all dimensions fissioned).
+            configuration is invalid.
         """
         try:
             config = self.config_gen.unflatten(flat_values)

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -800,14 +800,36 @@ class PopulationBasedSearch(BaseSearch):
         """
         Benchmark multiple flat configurations in parallel.
 
+        The returned list has the same length as ``to_check`` and preserves
+        positional correspondence.  Invalid configurations that cannot be
+        unflattened are represented as ``PopulationMember`` objects with
+        ``perf == inf`` and ``status == "error"`` (they are not benchmarked).
+
         Args:
             to_check: A list of flat configurations to benchmark.
 
         Returns:
-            A list of population members with the benchmark results.
+            A list of population members with the benchmark results, one per
+            entry in *to_check*.
         """
-        result = [m for m in map(self.make_unbenchmarked, to_check) if m is not None]
-        return self.parallel_benchmark_population(result)
+        from ..runtime.config import Config
+
+        valid: list[PopulationMember] = []
+        result: list[PopulationMember] = []
+        for flat in to_check:
+            m = self.make_unbenchmarked(flat)
+            if m is not None:
+                valid.append(m)
+                result.append(m)
+            else:
+                result.append(
+                    PopulationMember(
+                        _unset_fn, [float("inf")], flat, Config(), status="error"
+                    )
+                )
+
+        self.parallel_benchmark_population(valid)
+        return result
 
     def make_unbenchmarked(self, flat_values: FlatConfig) -> PopulationMember | None:
         """

--- a/helion/autotuner/config_generation.py
+++ b/helion/autotuner/config_generation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import copy
 import functools
 import itertools
@@ -9,6 +10,7 @@ from typing import TYPE_CHECKING
 from typing import cast
 
 from .._compat import warps_to_threads
+from ..exc import InvalidConfig
 from .config_fragment import Category
 from .config_fragment import ConfigSpecFragment
 from .config_fragment import PowerOfTwoFragment
@@ -236,13 +238,32 @@ class ConfigGeneration:
             return config
 
     def random_config(self) -> Config:
-        return self.unflatten(self.random_flat())
+        for _ in range(64):
+            try:
+                return self.unflatten(self.random_flat())
+            except InvalidConfig:
+                continue
+        raise InvalidConfig(
+            "failed to generate a valid random config after 64 attempts"
+        )
 
     def random_population_flat(self, n: int) -> list[FlatConfig]:
         return [self.default_flat(), *[self.random_flat() for _ in range(n - 1)]]
 
     def random_population(self, n: int) -> list[Config]:
-        return [*map(self.unflatten, self.random_population_flat(n))]
+        result: list[Config] = []
+        attempts = 0
+        for flat in self.random_population_flat(n):
+            try:
+                result.append(self.unflatten(flat))
+            except InvalidConfig:
+                attempts += 1
+        # Retry to fill the population to the requested size
+        while len(result) < n and attempts < 64:
+            with contextlib.suppress(InvalidConfig):
+                result.append(self.unflatten(self.random_flat()))
+            attempts += 1
+        return result
 
     def differential_mutation(
         self,

--- a/helion/autotuner/config_generation.py
+++ b/helion/autotuner/config_generation.py
@@ -238,13 +238,17 @@ class ConfigGeneration:
             return config
 
     def random_config(self) -> Config:
+        errors: dict[str, int] = {}
         for _ in range(64):
             try:
                 return self.unflatten(self.random_flat())
-            except InvalidConfig:
+            except InvalidConfig as e:
+                msg = str(e)
+                errors[msg] = errors.get(msg, 0) + 1
                 continue
+        summary = "; ".join(f"{msg} (x{n})" for msg, n in errors.items())
         raise InvalidConfig(
-            "failed to generate a valid random config after 64 attempts"
+            f"failed to generate a valid random config after 64 attempts: {summary}"
         )
 
     def random_population_flat(self, n: int) -> list[FlatConfig]:

--- a/helion/autotuner/pattern_search.py
+++ b/helion/autotuner/pattern_search.py
@@ -137,7 +137,7 @@ class PatternSearch(PopulationBasedSearch):
         self.population = []
         for flat_config in self._generate_initial_population_flat():
             member = self.make_unbenchmarked(flat_config)
-            if member.config not in visited:
+            if member is not None and member.config not in visited:
                 visited.add(member.config)
                 self.population.append(member)
         self.parallel_benchmark_population(self.population, desc="Initial population")
@@ -217,7 +217,7 @@ class PatternSearch(PopulationBasedSearch):
             candidates = [current]
             for flat_config in self._generate_neighbors(current.flat_values):
                 new_member = self.make_unbenchmarked(flat_config)
-                if new_member.config not in visited:
+                if new_member is not None and new_member.config not in visited:
                     visited.add(new_member.config)
                     candidates.append(new_member)
             if len(candidates) <= 1:

--- a/helion/autotuner/surrogate_pattern_search.py
+++ b/helion/autotuner/surrogate_pattern_search.py
@@ -366,7 +366,7 @@ class LFBOPatternSearch(PatternSearch):
         self.population = []
         for flat_config in self._generate_initial_population_flat():
             member = self.make_unbenchmarked(flat_config)
-            if member.config not in visited:
+            if member is not None and member.config not in visited:
                 visited.add(member.config)
                 self.population.append(member)
         self.set_generation(0)
@@ -572,7 +572,7 @@ class LFBOPatternSearch(PatternSearch):
                 all_neighbors = self._generate_neighbors(current.flat_values)
             for flat_config in all_neighbors:
                 new_member = self.make_unbenchmarked(flat_config)
-                if new_member.config not in visited:
+                if new_member is not None and new_member.config not in visited:
                     candidates.append(new_member)
                     visited.add(new_member.config)
 

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import unittest
 from unittest import mock
 
@@ -15,6 +16,7 @@ from helion.autotuner.base_search import PopulationBasedSearch
 from helion.autotuner.base_search import PopulationMember
 from helion.autotuner.differential_evolution import DifferentialEvolutionSearch
 from helion.autotuner.external import _FakeEnv
+from helion.exc import InvalidConfig
 import helion.language as hl
 
 
@@ -634,6 +636,245 @@ class TestErrors(RefEagerTestDisabled, TestCase):
             r"Device loop is empty after dead-code elimination",
         ):
             code_and_output(empty_kernel, (torch.randn(4, 4, device=DEVICE),))
+
+
+def _make_fake_kernel():
+    """Create a minimal fake kernel for autotuner unit tests."""
+
+    class FakeKernel:
+        def __init__(self) -> None:
+            self.settings = helion.Settings(
+                autotune_accuracy_check=False,
+                autotune_precompile=False,
+                autotune_log_level=0,
+            )
+            from helion._compiler.backend import TritonBackend
+            from helion.autotuner.config_spec import ConfigSpec
+
+            self.config_spec = ConfigSpec(backend=TritonBackend())
+            self.configs: list[helion.Config] = []
+
+        def compile_config(self, config: helion.Config, allow_print: bool = False):
+            return lambda *args: None
+
+        def format_kernel_decorator(
+            self, config: helion.Config, settings: helion.Settings
+        ) -> str:
+            return "@helion.kernel(...)"
+
+        def to_triton_code(
+            self,
+            config: helion.Config,
+            *,
+            emit_repro_caller: bool = False,
+            output_origin_lines: bool | None = None,
+        ) -> str:
+            return ""
+
+        @property
+        def env(self):
+            return _FakeEnv(device=DEVICE)
+
+    return FakeKernel()
+
+
+@onlyBackends(["triton"])
+class TestInvalidConfig(RefEagerTestDisabled, TestCase):
+    """Tests for autotuner robustness to InvalidConfig exceptions."""
+
+    def test_make_unbenchmarked_returns_none_on_invalid(self):
+        """make_unbenchmarked returns None when unflatten raises InvalidConfig."""
+        fake_kernel = _make_fake_kernel()
+        search = DifferentialEvolutionSearch(fake_kernel, args=())
+        original_unflatten = search.config_gen.unflatten
+
+        def always_invalid(flat_values):
+            raise InvalidConfig("test: forced invalid")
+
+        with mock.patch.object(search.config_gen, "unflatten", always_invalid):
+            result = search.make_unbenchmarked(search.config_gen.default_flat())
+        self.assertIsNone(result)
+
+        # Confirm it still works for valid configs
+        result = search.make_unbenchmarked(search.config_gen.default_flat())
+        self.assertIsNotNone(result)
+        self.assertEqual(
+            result.config, original_unflatten(search.config_gen.default_flat())
+        )
+
+    def test_parallel_benchmark_flat_preserves_length(self):
+        """parallel_benchmark_flat returns same-length list with inf-perf error
+        members for invalid configs."""
+        fake_kernel = _make_fake_kernel()
+        search = DifferentialEvolutionSearch(fake_kernel, args=())
+
+        default_flat = search.config_gen.default_flat()
+        # Build 5 copies of the default flat config
+        to_check = [list(default_flat) for _ in range(5)]
+
+        # Make positions 1 and 3 invalid
+        invalid_indices = {1, 3}
+        original_unflatten = search.config_gen.unflatten
+        call_count = 0
+
+        def selective_unflatten(flat_values):
+            nonlocal call_count
+            idx = call_count
+            call_count += 1
+            if idx in invalid_indices:
+                raise InvalidConfig("test: forced invalid")
+            return original_unflatten(flat_values)
+
+        def fake_benchmark_population(members, *, desc="Benchmarking"):
+            for m in members:
+                m.perfs.append(1.0)
+                m.fn = lambda *args: None
+                m.status = "ok"
+            return members
+
+        with (
+            mock.patch.object(search.config_gen, "unflatten", selective_unflatten),
+            mock.patch.object(
+                search, "parallel_benchmark_population", fake_benchmark_population
+            ),
+        ):
+            result = search.parallel_benchmark_flat(to_check)
+
+        self.assertEqual(len(result), len(to_check))
+        for i, member in enumerate(result):
+            if i in invalid_indices:
+                self.assertTrue(
+                    math.isinf(member.perf), f"index {i} should have inf perf"
+                )
+                self.assertEqual(member.status, "error")
+            else:
+                self.assertAlmostEqual(member.perf, 1.0)
+                self.assertEqual(member.status, "ok")
+
+    def test_random_config_retries_on_invalid(self):
+        """random_config retries up to 64 times, then raises with summary."""
+        fake_kernel = _make_fake_kernel()
+        search = DifferentialEvolutionSearch(fake_kernel, args=())
+        gen = search.config_gen
+
+        # Fail 5 times then succeed
+        call_count = 0
+        original_unflatten = gen.unflatten
+
+        def fail_then_succeed(flat_values):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 5:
+                raise InvalidConfig("test: forced invalid")
+            return original_unflatten(flat_values)
+
+        with mock.patch.object(gen, "unflatten", fail_then_succeed):
+            config = gen.random_config()
+        self.assertIsNotNone(config)
+        self.assertEqual(call_count, 6)  # 5 failures + 1 success
+
+        # Always fail — should raise after 64 attempts
+        with (
+            mock.patch.object(
+                gen, "unflatten", side_effect=InvalidConfig("always bad")
+            ),
+            self.assertRaisesRegex(InvalidConfig, r"failed to generate.*64 attempts"),
+        ):
+            gen.random_config()
+
+    def test_random_population_fills_despite_invalid(self):
+        """random_population gracefully skips invalid configs and retries."""
+        fake_kernel = _make_fake_kernel()
+        search = DifferentialEvolutionSearch(fake_kernel, args=())
+        gen = search.config_gen
+
+        # Fail every other call
+        call_count = 0
+        original_unflatten = gen.unflatten
+
+        def intermittent_fail(flat_values):
+            nonlocal call_count
+            call_count += 1
+            if call_count % 2 == 0:
+                raise InvalidConfig("test: forced invalid")
+            return original_unflatten(flat_values)
+
+        with mock.patch.object(gen, "unflatten", intermittent_fail):
+            result = gen.random_population(5)
+
+        # Should still get 5 configs (retries fill the gaps)
+        self.assertEqual(len(result), 5)
+
+        # When all fail, should return fewer than requested (graceful degradation)
+        with mock.patch.object(
+            gen, "unflatten", side_effect=InvalidConfig("always bad")
+        ):
+            result = gen.random_population(5)
+        self.assertEqual(len(result), 0)
+
+    def test_pattern_search_skips_invalid_neighbors(self):
+        """Pattern search skips None members from make_unbenchmarked without crashing."""
+        from helion.autotuner.pattern_search import PatternSearch
+
+        fake_kernel = _make_fake_kernel()
+        search = PatternSearch(fake_kernel, args=())
+
+        # Build a small valid initial population
+        default_flat = search.config_gen.default_flat()
+        default_config = search.config_gen.unflatten(default_flat)
+        initial_member = PopulationMember(
+            lambda *args: None, [1.0], default_flat, default_config, status="ok"
+        )
+
+        # make_unbenchmarked returns None for all neighbors
+        original_make = search.make_unbenchmarked
+
+        def make_only_default(flat_values):
+            if flat_values == default_flat:
+                return original_make(flat_values)
+            return None
+
+        def fake_benchmark_population(members, *, desc="Benchmarking"):
+            for m in members:
+                if not m.perfs:
+                    m.perfs.append(1.0)
+                m.fn = lambda *args: None
+                m.status = "ok"
+            return members
+
+        with (
+            mock.patch.object(search, "make_unbenchmarked", make_only_default),
+            mock.patch.object(
+                search, "parallel_benchmark_population", fake_benchmark_population
+            ),
+            mock.patch.object(
+                search, "rebenchmark_population", lambda self, *a, **kw: None
+            ),
+            mock.patch.object(search, "rebenchmark", lambda *a, **kw: None),
+        ):
+            # Manually run the initial population phase
+            visited: set[helion.Config] = set()
+            search.population = []
+            for flat_config in search._generate_initial_population_flat():
+                member = search.make_unbenchmarked(flat_config)
+                if member is not None and member.config not in visited:
+                    visited.add(member.config)
+                    search.population.append(member)
+            fake_benchmark_population(search.population)
+
+            # All population members should be valid
+            for m in search.population:
+                self.assertIsNotNone(m.config)
+                self.assertTrue(math.isfinite(m.perf))
+
+            # Run one generation of pattern search from the default member
+            gen_iter = search._pattern_search_from(initial_member, visited)
+            candidates = next(gen_iter, None)
+            if candidates is not None:
+                # Only the starting member should be in candidates
+                # (all neighbors returned None)
+                self.assertEqual(len(candidates), 1)
+                self.assertEqual(candidates[0], initial_member)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The increasing number of features the autotuner can search through increase also the share or potential invalid configurations. Consequently, I think the current approach with `normalize(_fix_invalid=True)` becomes unfeasible. 

Hence, I propose to make the autotuner robust to `IvalidConfig` raised during `normalize()`, so that cross-parameter constraints (e.g. all-dims-folded in upcoming grid folding #1767 ) can reject invalid configs instead of silently mutating them (which increases the search space significantly and unnecessarily). 

### Test plan

- [x] Pattern search autotuner tests pass (test_autotuner.py -k test_pattern_search)
- [x] Crosscheck with e.g. #1767 (exercises _fix_invalid=False path)
- [x] Lint clean (./lint.sh)