### PR TITLE
[Bug][Autotuner] Autotuner failed to clone mutated input arg

### DIFF
--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -373,11 +373,12 @@ class LocalBenchmarkProvider(BenchmarkProvider):
 
         original_args_flat, _ = tree_flatten(self.args)
         new_args_flat, _ = tree_flatten(new_args)
-        mutated_tensor_idxs = []
+        mutated_arg_idxs = []
         # we should only count tensors, since they won't be bound or removed
-        tensor_idx = 0
+        arg_idx = 0
         for old, new in zip(original_args_flat, new_args_flat, strict=False):
             if not (isinstance(old, torch.Tensor) and isinstance(new, torch.Tensor)):
+                arg_idx += 1
                 continue
             try:
                 equal = torch.equal(new, old)
@@ -387,14 +388,14 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                 # assume the argument was not mutated.
                 equal = True
             if not equal:
-                mutated_tensor_idxs.append(tensor_idx)
-            tensor_idx += 1
+                mutated_arg_idxs.append(arg_idx)
+            arg_idx += 1
         baseline_post_args = _clone_args(
             new_args,
             self.kernel.env.process_group_name,
-            idx_to_clone=mutated_tensor_idxs,
+            idx_to_clone=mutated_arg_idxs,
         )
-        return baseline_output, mutated_tensor_idxs, baseline_post_args
+        return baseline_output, mutated_arg_idxs, baseline_post_args
 
     def _compute_effective_tolerances(self) -> tuple[float, float]:
         """

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -1996,16 +1996,19 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         def nested_in_place_add(
             a: Sequence[torch.Tensor],
             b: Sequence[torch.Tensor],
+            epsilon: float,
             out: Sequence[torch.Tensor],
         ):
             for tile in hl.tile(out[0].size()):
-                out[0][tile] += a[0][tile] + b[0][tile]
+                out[0][tile] += a[0][tile] + b[0][tile] + epsilon
             for tile in hl.tile(out[1].size()):
-                out[1][tile] += a[1][tile] + b[1][tile]
+                out[1][tile] += a[1][tile] + b[1][tile] + epsilon
 
+        epsilon = 1e-6
         args = (
             [torch.ones([128], device=DEVICE), torch.ones([128], device=DEVICE)],
             [torch.ones([128], device=DEVICE), torch.ones([128], device=DEVICE)],
+            epsilon,
             [torch.zeros([128], device=DEVICE), torch.zeros([128], device=DEVICE)],
         )
 
@@ -2015,10 +2018,10 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         # test that we overwrite c only once and the arguments are correctly
         #  cloned for each autotune run
         ref_out = [
-            torch.full([128], 2.0, device=DEVICE),
-            torch.full([128], 2.0, device=DEVICE),
+            torch.full([128], 2.0, device=DEVICE) + epsilon,
+            torch.full([128], 2.0, device=DEVICE) + epsilon,
         ]
-        torch.testing.assert_close(args[2], ref_out)
+        torch.testing.assert_close(args[3], ref_out)
 
     def test_only_mutated_tensors_cloned_during_benchmark(self) -> None:
         """
@@ -2032,13 +2035,15 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         def inplace_add(
             a: torch.Tensor,
             b: torch.Tensor,
+            epsilon: float,
             out: torch.Tensor,
         ):
             for tile in hl.tile(out.size()):
-                out[tile] += a[tile] + b[tile]
+                out[tile] += a[tile] + b[tile] + epsilon
 
         a = torch.full([128], 1.0, device=DEVICE)
         b = torch.full([128], 2.0, device=DEVICE)
+        epsilon = 1e-6
         out = torch.zeros([128], device=DEVICE)
 
         # Track clones separately for mutated vs non-mutated tensors
@@ -2060,7 +2065,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             return result
 
         with patch.object(torch.Tensor, "clone", tracking_clone):
-            inplace_add(a, b, out)
+            inplace_add(a, b, epsilon, out)
 
         # Mutated tensor (out) should be cloned during baseline AND benchmarking:
         #   _compute_baseline: 1 + baseline_post_args: 1
@@ -2080,7 +2085,7 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             f"Only mutated tensors should be cloned during benchmarking.",
         )
 
-        expected = torch.full([128], 3.0, device=DEVICE)
+        expected = torch.full([128], 3.0, device=DEVICE) + epsilon
         torch.testing.assert_close(out, expected)
 
     def test_chunked_allclose_memory(self):


### PR DESCRIPTION
### Issue
Currently, Autotuner [_compute_baseline](https://github.com/pytorch/helion/blob/8110bb1974c6dd4e65fdd2caff2764dbe4ea537e/helion/autotuner/benchmark_provider.py#L314-L318) returns mutated tensor indices instead of mutated arg indices. Take the update unit test kernel for example
```
        def nested_in_place_add(
            a: Sequence[torch.Tensor],
            b: Sequence[torch.Tensor],
            epsilon: float,
            out: Sequence[torch.Tensor],
        ):
            for tile in hl.tile(out[0].size()):
                out[0][tile] += a[0][tile] + b[0][tile] + epsilon
            for tile in hl.tile(out[1].size()):
                out[1][tile] += a[1][tile] + b[1][tile] + epsilon
```
```out``` arg will be mutated. For this kernel, current [_compute_baseline](https://github.com/pytorch/helion/blob/8110bb1974c6dd4e65fdd2caff2764dbe4ea537e/helion/autotuner/benchmark_provider.py#L314-L318) returns ```[2]``` since ```epsilon``` is not tensor and index counter increment is [skipped](https://github.com/pytorch/helion/blob/8110bb1974c6dd4e65fdd2caff2764dbe4ea537e/helion/autotuner/benchmark_provider.py#L380-L381).

However, Autotuner [_clone_args](https://github.com/pytorch/helion/blob/8110bb1974c6dd4e65fdd2caff2764dbe4ea537e/helion/autotuner/benchmark_provider.py#L128) method clone mutating args based on the arg index not tensor index. In this case, arg ```epsilon``` is cloned during benchmarking instead of arg ```out```. This causes most of samples failing baseline validation since arg ```out``` used for each config benchmarking is different.

This issue was introduced in v1.0.0. The bug is identified when observing regression after switching to helion 1.0.0 for autotuning a [kernel](https://github.com/xiaohongchen1991/vllm/blob/828538a206ef4b02b528aeb8a1471bf047dee644/vllm/kernels/helion/ops/rms_norm_dynamic_per_token_quant.py#L128-L136) I am working on. 

### Fix
This commit updates [_compute_baseline](https://github.com/pytorch/helion/blob/8110bb1974c6dd4e65fdd2caff2764dbe4ea537e/helion/autotuner/benchmark_provider.py#L314-L318) to return mutated arg indices instead of tensor indicies.

Also updated unit tests to cover this bug.

### Testing
```
pytest test/

=============================== 1354 passed, 313 skipped, 146 warnings in 539.11s (0:08:59) ===============================


```
