### PR TITLE
Fix test broken by #2033: use env.backend_name

### DIFF
--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -640,7 +640,7 @@ class DeviceIR:
                 continue
             if used_graphs & graphs_with_rolled_rdim:
                 continue
-            if env.config_spec.backend_name != "pallas":
+            if env.backend_name != "pallas":
                 env.config_spec.reduction_loops.append(
                     ReductionLoopSpec(
                         block_id=rdim.block_id,

--- a/test/test_barrier.py
+++ b/test/test_barrier.py
@@ -259,6 +259,7 @@ class TestBarrier(RefEagerTestBase, TestCase):
         fake_env = SimpleNamespace(
             block_sizes=[_FakeRDim()],
             config_spec=SimpleNamespace(reduction_loops=[]),
+            backend_name="triton",
         )
 
         with (


### PR DESCRIPTION
## Summary
- Use `env.backend_name` instead of `env.config_spec.backend_name` in `register_rollable_reductions`, matching the standard pattern used everywhere else in the codebase
- Fixes `test_register_rollable_reductions_does_not_mutate_graphs` which broke across all CI jobs after #2033 landed