### PR TITLE
Simplify CI: update PyTorch releases to 2.11, use bundled Triton

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -29,7 +29,7 @@
       "image": "nvidia/cuda:12.8.1-devel-ubuntu24.04",
       "runtime-version": "cu128",
       "container-options": "--gpus all",
-      "pytorch-version": "pytorch-2.9",
+      "pytorch-version": "pytorch-2.11",
       "alias": "a10g-dtype-asserts",
       "dtype-asserts": true,
       "expecttest-accept": true,
@@ -75,7 +75,7 @@
       "image": "nvidia/cuda:13.1.0-devel-ubuntu24.04",
       "runtime-version": "cu130",
       "container-options": "--gpus all",
-      "pytorch-version": "pytorch-2.9",
+      "pytorch-version": "pytorch-2.11",
       "alias": "b200",
       "backend": "triton"
     },
@@ -86,9 +86,11 @@
       "image": "nvidia/cuda:13.1.0-devel-ubuntu24.04",
       "runtime-version": "cu130",
       "container-options": "--gpus all",
-      "pytorch-version": "pytorch-2.9",
+      "pytorch-version": "pytorch-2.11",
       "alias": "b200",
-      "backend": "tileir"
+      "backend": "tileir",
+      "triton-repo": "https://github.com/triton-lang/Triton-to-tile-IR.git",
+      "triton-pin": "5d3ab8c13c"
     },
     {
       "runner": "linux.rocm.gpu.gfx942.1",

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Install PyTorch
         run: |
           source .venv/bin/activate
-          uv pip install -U "torch==2.10.*" --index-url https://download.pytorch.org/whl/${{ inputs.runtime-version }}
+          uv pip install -U "torch==2.11.*" --index-url https://download.pytorch.org/whl/${{ inputs.runtime-version }}
 
       - name: Install Helion
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,9 +107,10 @@ jobs:
       - name: Install PyTorch
         run: |
           source .venv/bin/activate
-          if [[ "${{ matrix.pytorch-version }}" == "pytorch-2.9" ]]; then
-            # Install stable 2.9 from test channel
-            uv pip install -U "torch==2.9.*" --index-url https://download.pytorch.org/whl/${{ matrix.runtime-version }}
+          if [[ "${{ matrix.pytorch-version }}" == pytorch-[0-9]* ]]; then
+            VERSION="${{ matrix.pytorch-version }}"
+            VERSION="${VERSION#pytorch-}"
+            uv pip install -U "torch==${VERSION}.*" --index-url https://download.pytorch.org/whl/${{ matrix.runtime-version }}
           elif [[ "${{ matrix.runtime-version }}" == "tpu" ]]; then
             # TPU: install CPU-only PyTorch nightly (torch_tpu provides TPU backend)
             uv pip install -U --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
@@ -122,33 +123,22 @@ jobs:
             uv pip install -U --pre torch --index-url https://download.pytorch.org/whl/nightly/${{ matrix.runtime-version }}
           fi
 
-      - name: Install Triton
-        if: matrix.backend == 'tileir' || (matrix.backend == 'triton' && steps.cache.outputs.cache-hit != 'true' && matrix.pytorch-version != 'pytorch-2.9')
+      - name: Install Triton from source
+        if: matrix.triton-pin != ''
         run: |
           set -x
           source .venv/bin/activate
           apt-get update
-          apt-get install -y git
-          apt-get install -y clang-20 clang++-20 zlib1g-dev
+          apt-get install -y git clang-20 clang++-20 zlib1g-dev
           export CC=clang-20
           export CXX=clang++-20
           mkdir -p /tmp/$USER
           cd /tmp/$USER
           uv pip uninstall triton pytorch-triton || true
           rm -rf triton/ || true
-          if [[ "${{ matrix.backend }}" == "tileir" ]]; then
-            git clone --recursive -b main https://github.com/triton-lang/Triton-to-tile-IR.git triton
-            # Pin to last known-good commit before 13.2 syncup broke Atan2Op build
-            git -C triton checkout 5d3ab8c13c
-          else
-            git clone https://github.com/triton-lang/triton.git triton
-            if [[ "${{ matrix.python-version }}" == "3.14" ]]; then
-              # Pin Python 3.14 nightly to known-good Triton revision until backend detection is fixed upstream.
-              git -C triton checkout 77a13369
-            else
-              git -C triton checkout 9844da95
-            fi
-          fi
+          REPO="${{ matrix.triton-repo || 'https://github.com/triton-lang/triton.git' }}"
+          git clone --recursive "$REPO" triton
+          git -C triton checkout ${{ matrix.triton-pin }}
           cd triton/
           uv pip install -r python/requirements.txt
           MAX_JOBS=$(nproc) TRITON_PARALLEL_LINK_JOBS=2 uv pip install .


### PR DESCRIPTION
- Update release configs from 2.9/2.10 to 2.11 (tests, benchmarks)
- Keep one 2.9 config (a10g py3.10) as min supported version check
- Use Triton bundled with PyTorch instead of building from source - should save CI time. 
- Enable Triton source builds by specifying triton-pin/triton-repo in matrix.json
- Only tileir still builds Triton from source (separate fork)