### PR TITLE
[AMD ROCm] Use AMD Triton backend for min_dot_size instead of NVIDIA

### DIFF
--- a/helion/_compat.py
+++ b/helion/_compat.py
@@ -268,18 +268,23 @@ if triton_is_available():
             return tuple(int(v) for v in dot_size_val)
 
         if device.type == "cuda":
-            from triton.backends.nvidia.compiler import (
-                min_dot_size as min_dot_size_cuda,
-            )
-
             props = DeviceProperties.create(device)
-            return min_dot_size_cuda(
-                GPUTarget(
-                    backend=props.type,
-                    arch=props.cc,
-                    warp_size=props.warp_size or 32,
+            target = GPUTarget(
+                backend=props.type,
+                arch=props.cc,
+                warp_size=props.warp_size or 32,
+            )
+            if is_hip():
+                from triton.backends.amd.compiler import get_min_dot_size
+
+                get_min_size = get_min_dot_size(target)
+            else:
+                from triton.backends.nvidia.compiler import (
+                    min_dot_size as min_dot_size_cuda,
                 )
-            )(torch_dtype_to_tl(lhs), torch_dtype_to_tl(rhs))
+
+                get_min_size = min_dot_size_cuda(target)
+            return get_min_size(torch_dtype_to_tl(lhs), torch_dtype_to_tl(rhs))
 
         return (16, 16, 16)
 


### PR DESCRIPTION
- On ROCm, `device.type == "cuda"` is True, so `_min_dot_size()` was calling `triton.backends.nvidia.compiler.min_dot_size` with a HIP GPUTarget. This returned incorrect K-dimension minimums (16 instead of 1 for fp16), forcing unnecessary tile padding on AMD GPUs.
- Route HIP devices to `triton.backends.amd.compiler.get_min_dot_size` instead.
- Benchmarks on MI300X show **23-31% speedup on small-K matmuls** (K=4, K=8) where the old path wasted compute padding tiles to K=16.

| Shape | Old (K padded to 16) | New | Speedup |
|-------|---------------------|---------------|---------|
| (16384, 4, 16384) | 0.188 ms | 0.143 ms | **1.31x** |
| (16384, 8, 16384) | 0.191 ms | 0.155 ms | **1.23x** |