### PR TITLE
[Pallas] Under interpret mode, Use float16 as HALF_DTYPE because bfloat16 is not supported on CPU

### DIFF
--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -243,7 +243,7 @@ else:
     DEVICE = torch.device("cuda")
 
 # Half-precision dtype: bfloat16 on TPU (float16 not supported), float16 elsewhere
-if _get_backend() == "pallas":
+if _get_backend() == "pallas" and not is_pallas_interpret():
     HALF_DTYPE = torch.bfloat16
 else:
     HALF_DTYPE = torch.float16


### PR DESCRIPTION
Stacked PRs:
 * #2051
 * __->__#2050


--- --- ---

[Pallas] Under interpret mode, Use float16 as HALF_DTYPE because bfloat16 is not supported on CPU