### PR TITLE
ND jagged tile support 

### DIFF
--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -163,7 +163,7 @@ class CompileEnvironment:
         self.kernel_min_element_bits: int = 32  # smallest dtype bits across all tensors
         self.specialized_vars: set[sympy.Symbol] = set()
         self.specialized_strides: set[tuple[str, int]] = set()
-        self.jagged_tile_parent_id: dict[int, int] = {}
+        self.jagged_tile_parent_ids: dict[int, list[int]] = {}
         self.jagged_tile_mask_shapes: dict[int, list[torch.SymInt]] = {}
         self._symint_cache: dict[object, torch.SymInt] = {}
         self._foreign_symint_cache: dict[tuple[int, sympy.Expr], torch.SymInt] = {}
@@ -1020,11 +1020,11 @@ class CompileEnvironment:
             return candidate
         return block_id
 
-    def register_jagged_tile(self, block_id: int, parent_id: int) -> None:
-        self.jagged_tile_parent_id[block_id] = parent_id
+    def register_jagged_tile(self, block_id: int, parent_ids: list[int]) -> None:
+        self.jagged_tile_parent_ids[block_id] = parent_ids
 
     def is_jagged_tile(self, block_id: int) -> bool:
-        return block_id in self.jagged_tile_parent_id
+        return block_id in self.jagged_tile_parent_ids
 
 
 class NoCurrentEnvironment(RuntimeError):

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -1071,7 +1071,7 @@ class WalkDeviceAST(NodeVisitor):
                     step = [None] * len(iter_vars)
             else:
                 if isinstance(inner_type, JaggedTileIndexType):
-                    # hl.jagged_tile takes a 1D parent tensor, not a scalar bound.
+                    # hl.jagged_tile takes an N-D parent tensor, not a scalar bound.
                     assert isinstance(end, torch.Tensor)
                     jagged_parent = end
 
@@ -1079,7 +1079,9 @@ class WalkDeviceAST(NodeVisitor):
                     # _setup_mask uses that parent tensor to recover each lane's true end.
                     assert inputs.flat_values[0] is jagged_parent
 
-                    end = torch.amax(jagged_parent)
+                    # Flatten so the global max becomes a single-axis reduction —
+                    # Inductor only supports one reduction dim per buffer.
+                    end = torch.amax(jagged_parent.reshape(-1))
 
                 iter_vars = [inner_type]
                 begin = [0] if begin is None else [begin]

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -998,9 +998,15 @@ class SubscriptIndexing(NamedTuple):
                     and (mv := state.codegen.mask_var(bid))
                     and not _is_size_one(fake_value.size(len(index_values)))
                 ):
-                    new_masks.setdefault(
-                        f"({mv}){tile_strategy.expand_str(output_size, pos)}"
-                    )
+                    if env.is_jagged_tile(bid):
+                        mask_shape = env.jagged_tile_mask_shapes[bid]
+                        new_masks.setdefault(
+                            f"({mv}){tile_strategy.jagged_tile_expand_str(mask_shape, output_size)}"
+                        )
+                    else:
+                        new_masks.setdefault(
+                            f"({mv}){tile_strategy.expand_str(output_size, pos)}"
+                        )
             else:
                 # Multi-dim tensor with multiple non-trivial dims
                 # Still need expansion for trailing/leading slice dimensions

--- a/helion/_compiler/tile_dispatch.py
+++ b/helion/_compiler/tile_dispatch.py
@@ -414,6 +414,8 @@ class TileStrategyDispatch:
         Examples:
             (u0, u2) -> (u0, u2, u1) => "[:, :, None]"
             (u2, u0) -> (u0, u2, u1) => ".permute(1, 0)[:, :, None]"
+            (u0, u2) -> (1, u2)      => ""   (u0 absorbed by dst size-1 via
+                                              broadcast; no transform needed)
         """
         if not self.supports_index_rank_expansion():
             return ""
@@ -434,6 +436,15 @@ class TileStrategyDispatch:
                 if env.known_equal(src_dim, dst_dim):
                     match = dst_i
                     break
+            if match is None:
+                # Fallback: absorb unmatched src dim into a dst size-1 slot
+                # (Triton will broadcast the size-1 dim at load time).
+                for dst_i, dst_dim in enumerate(dst_shape):
+                    if dst_i in used_dst:
+                        continue
+                    if env.known_equal(dst_dim, 1):
+                        match = dst_i
+                        break
             assert match is not None, (
                 f"Cannot map src dim {src_dim} into dst shape {dst_shape} "
                 f"from src shape {src_shape}"

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -1701,14 +1701,18 @@ class NDTileStrategy(_BaseNDTileStrategy):
             jagged_tile_block_size = env.block_sizes[block_idx].var
             jagged_tile_parent_proxy = jagged_tile_parents_proxy[0]
             assert isinstance(jagged_tile_parent_proxy, torch.Tensor)
-            jagged_tile_parent_block_size = jagged_tile_parent_proxy.size(0)
-            assert isinstance(jagged_tile_parent_block_size, torch.SymInt)
+            parent_dims = list(jagged_tile_parent_proxy.size())
+            assert len(parent_dims) >= 1
+            assert all(isinstance(d, torch.SymInt) for d in parent_dims)
             env.jagged_tile_mask_shapes[block_idx] = [
-                jagged_tile_parent_block_size,
+                *parent_dims,
                 jagged_tile_block_size,
             ]
+            k = len(parent_dims)
+            child_expand = "[" + ", ".join(["None"] * k + [":"]) + "]"
+            parent_expand = "[" + ", ".join([":"] * k + ["None"]) + "]"
             return statement_from_string(
-                f"{mask_var} = ({index_var})[None,:] < {{parent}}[:,None]",
+                f"{mask_var} = ({index_var}){child_expand} < {{parent}}{parent_expand}",
                 parent=self._to_ast(jagged_tile_parent),
             )
 

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -1701,9 +1701,11 @@ class NDTileStrategy(_BaseNDTileStrategy):
             jagged_tile_block_size = env.block_sizes[block_idx].var
             jagged_tile_parent_proxy = jagged_tile_parents_proxy[0]
             assert isinstance(jagged_tile_parent_proxy, torch.Tensor)
-            parent_dims = list(jagged_tile_parent_proxy.size())
+            parent_dims: list[torch.SymInt] = []
+            for d in jagged_tile_parent_proxy.size():
+                assert isinstance(d, torch.SymInt)
+                parent_dims.append(d)
             assert len(parent_dims) >= 1
-            assert all(isinstance(d, torch.SymInt) for d in parent_dims)
             env.jagged_tile_mask_shapes[block_idx] = [
                 *parent_dims,
                 jagged_tile_block_size,

--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -1173,22 +1173,24 @@ class TileIndexType(TypeInfo):
 
 
 class JaggedTileIndexType(TileIndexType):
-    parent_block_id: int
+    parent_block_ids: list[int]
 
-    def __init__(self, origin: Origin, block_id: int, parent_block_id: int) -> None:
+    def __init__(
+        self, origin: Origin, block_id: int, parent_block_ids: list[int]
+    ) -> None:
         super().__init__(origin, block_id)
-        self.parent_block_id = parent_block_id
+        self.parent_block_ids = parent_block_ids
 
     def merge(self, other: TypeInfo, var_name: str | None = None) -> TypeInfo:
         if isinstance(other, JaggedTileIndexType):
             if (
                 self.block_id == other.block_id
-                and self.parent_block_id == other.parent_block_id
+                and self.parent_block_ids == other.parent_block_ids
             ):
                 return self
             raise exc.TypeInferenceError(
-                f"JaggedTileIndexType mismatch: block/parent {self.block_id}/{self.parent_block_id} "
-                f"vs {other.block_id}/{other.parent_block_id}"
+                f"JaggedTileIndexType mismatch: block/parents {self.block_id}/{self.parent_block_ids} "
+                f"vs {other.block_id}/{other.parent_block_ids}"
             )
         return super().merge(other, var_name=var_name)
 
@@ -1934,11 +1936,11 @@ class TypePropagation(ast.NodeVisitor):
                 shape_id = [
                     env.resolve_block_id(size) for size in list(rhs.fake_value.shape)
                 ]
-                jagged_tile_info = env.jagged_tile_parent_id
-                for jagged_tile_id, parent_block_id in jagged_tile_info.items():
+                jagged_tile_info = env.jagged_tile_parent_ids
+                for jagged_tile_id, parent_block_ids in jagged_tile_info.items():
                     include_jagged = jagged_tile_id in shape_id
-                    include_parent = parent_block_id in shape_id
-                    if include_jagged and not include_parent:
+                    include_parents = all(p in shape_id for p in parent_block_ids)
+                    if include_jagged and not include_parents:
                         raise exc.InvalidJaggedTileUsage(
                             f"jagged_tile alone cannot be used without its parent in assignment {lhs.id}"
                         )

--- a/helion/language/loops.py
+++ b/helion/language/loops.py
@@ -584,12 +584,12 @@ def jagged_tile(
     parent: object,
 ) -> Iterator[Tile]:
     """
-    Iterate over a jagged inner dimension using a 1D parent tensor of per-lane ends.
+    Iterate over a jagged inner dimension using an N-D parent tensor of per-lane ends.
 
     ``jagged_tile`` is the jagged counterpart to :func:`~helion.language.tile`.
-    Instead of taking a scalar upper bound, it takes a 1D tensor from the enclosing
-    parent tile context. Each element of ``parent`` gives the true end of the jagged
-    child loop for the corresponding parent lane.
+    Instead of taking a scalar upper bound, it takes a tensor whose every axis comes
+    from an enclosing parent tile context. Each element of ``parent`` gives the true
+    end of the jagged child loop for the corresponding parent lane.
 
     Conceptually, Helion lowers:
 
@@ -612,8 +612,9 @@ def jagged_tile(
     loop and manually constructing masks.
 
     Args:
-        parent: 1D tensor in the parent tile context. ``parent[i]`` is the true end
-                of the jagged child loop for parent lane ``i``.
+        parent: N-D tensor whose every axis is an enclosing tile axis. ``parent[i, ...]``
+                is the true end of the jagged child loop for that combination of parent
+                lanes. The 1-D case is the common scalar-of-rows pattern.
 
     Returns:
         Iterator[Tile]: Iterator over tile objects for the jagged child dimension
@@ -628,11 +629,11 @@ def jagged_tile(
                 x: torch.Tensor, row_lengths: torch.Tensor
             ) -> torch.Tensor:
                 b = row_lengths.size(0)
-                max_len = row_lengths.amax()
                 out = torch.zeros([b], dtype=x.dtype, device=x.device)
 
                 for tile_b in hl.tile(b):
                     lengths = row_lengths[tile_b]
+                    max_len = lengths.amax()
                     acc = hl.zeros([tile_b], dtype=x.dtype)
 
                     for tile_k in hl.tile(max_len):
@@ -696,7 +697,8 @@ def jagged_tile(
     Note:
         ``jagged_tile`` currently has a few important restrictions:
 
-        * The input must be a 1D tensor. Scalars and higher-rank tensors are not allowed.
+        * The input must be a tensor of rank >= 1. Scalars are not allowed, and every
+          axis of the parent tensor must come from an enclosing tile context.
         * ``jagged_tile`` cannot be used as the outermost loop of a kernel.
         * A jagged child tile must be indexed together with its parent axes. For example,
           ``x[tile_k]`` is invalid if ``tile_k`` comes from ``hl.jagged_tile(lengths)``
@@ -719,17 +721,18 @@ def _(
         raise exc.LoopFunctionNotInFor("jagged_tile")
 
     env = CompileEnvironment.current()
-    parent_block_id: int = -1
-    if isinstance(parent, TensorType) and parent.fake_value.ndim == 1:
-        bid = env.get_block_id(parent.fake_value.size(0))
-        if not isinstance(bid, int):
-            raise exc.InvalidJaggedTileUsage(
-                "hl.jagged_tile cannot be outermost loop or get host tensor as a parent"
-            )
-        parent_block_id = bid
+    parent_block_ids: list[int] = []
+    if isinstance(parent, TensorType) and parent.fake_value.ndim >= 1:
+        for dim_size in parent.fake_value.shape:
+            bid = env.get_block_id(dim_size)
+            if not isinstance(bid, int):
+                raise exc.InvalidJaggedTileUsage(
+                    "hl.jagged_tile cannot be outermost loop or get host tensor as a parent"
+                )
+            parent_block_ids.append(bid)
     else:
         raise exc.InvalidJaggedTileUsage(
-            "hl.jagged_tile currently only accepts 1d tensor as an argument"
+            "hl.jagged_tile only accepts a tensor with rank >= 1 as an argument"
         )
     proxy_parent = _to_proxy(parent)
     if not isinstance(proxy_parent, torch.Tensor):
@@ -740,8 +743,8 @@ def _(
         raise exc.TileOfTile
 
     base = TileIndexType.allocate(None, origin)
-    result = JaggedTileIndexType(origin, base.block_id, parent_block_id)
-    env.register_jagged_tile(base.block_id, parent_block_id)
+    result = JaggedTileIndexType(origin, base.block_id, parent_block_ids)
+    env.register_jagged_tile(base.block_id, parent_block_ids)
 
     _add_config_choices(
         [result.block_id],

--- a/test/test_jagged_tile.py
+++ b/test/test_jagged_tile.py
@@ -318,6 +318,83 @@ class TestJaggedTile(RefEagerTestDisabled, TestCase):
         )
         torch.testing.assert_close(result, ref(x, lengths))
 
+    def test_jagged_tile_tensor_index_parent_blocksize_1(self):
+        # Regression: jagged_tile with parent block_size=1 exercises
+        # jagged_tile_expand_str on a (P_b, P_k) mask against a (1, P_k)-style
+        # output, which is where the size-1 dst fallback becomes relevant.
+        @helion.kernel(config={"block_sizes": [1, 4]})
+        def jagged_row_sum(
+            x_data: torch.Tensor, x_offsets: torch.Tensor
+        ) -> torch.Tensor:
+            b = x_offsets.size(0) - 1
+            out = torch.zeros([b], dtype=x_data.dtype, device=x_data.device)
+            for tile_b in hl.tile(b):
+                starts = x_offsets[tile_b]
+                ends = x_offsets[tile_b.index + 1]
+                nnz = ends - starts
+                acc = hl.zeros([tile_b], dtype=x_data.dtype)
+                for tile_k in hl.jagged_tile(nnz):
+                    idx = starts[:, None] + tile_k.index[None, :]
+                    acc += x_data[idx].sum(dim=1)
+                out[tile_b] = acc
+            return out
+
+        offsets = torch.tensor([0, 3, 4, 8, 10], device=DEVICE, dtype=torch.long)
+        x = torch.randn(int(offsets[-1].item()), device=DEVICE, dtype=torch.float32)
+
+        def ref(x_data: torch.Tensor, x_offsets: torch.Tensor) -> torch.Tensor:
+            b = x_offsets.numel() - 1
+            out = torch.zeros([b], dtype=x_data.dtype, device=x_data.device)
+            for i in range(b):
+                s = int(x_offsets[i].item())
+                e = int(x_offsets[i + 1].item())
+                out[i] = x_data[s:e].sum()
+            return out
+
+        _, result = code_and_output(jagged_row_sum, (x, offsets))
+        torch.testing.assert_close(result, ref(x, offsets))
+
+    def test_jagged_tile_tensor_index_2d_parent_blocksize_1(self):
+        # Regression: 2-D parent with block_sizes=[1, 1, 4] routes a 3-D jagged
+        # mask through the handle_broadcast_tensor + jagged_tile_expand_str
+        # pipeline. Verifies the dispatch path on an ND parent shape.
+        @helion.kernel(config={"block_sizes": [1, 1, 4]})
+        def jagged_tile_2d_parent(
+            x_data: torch.Tensor, offsets: torch.Tensor
+        ) -> torch.Tensor:
+            b1, b2 = offsets.size(0) - 1, offsets.size(1)
+            out = torch.zeros([b1, b2], dtype=x_data.dtype, device=x_data.device)
+            for tile_b1, tile_b2 in hl.tile([b1, b2]):
+                starts = offsets[tile_b1, tile_b2]
+                ends = offsets[tile_b1.index + 1, tile_b2]
+                nnz = ends - starts
+                acc = hl.zeros([tile_b1, tile_b2], dtype=x_data.dtype)
+                for tile_k in hl.jagged_tile(nnz):
+                    idx = starts[:, :, None] + tile_k.index[None, None, :]
+                    acc += x_data[idx].sum(dim=2)
+                out[tile_b1, tile_b2] = acc
+            return out
+
+        offsets = torch.tensor(
+            [[0, 0], [3, 2], [4, 5], [8, 7]], device=DEVICE, dtype=torch.long
+        )
+        total = int(offsets[-1].max().item()) + 4
+        x = torch.randn(total, device=DEVICE, dtype=torch.float32)
+
+        def ref(x_data: torch.Tensor, off: torch.Tensor) -> torch.Tensor:
+            b1 = off.size(0) - 1
+            b2 = off.size(1)
+            out = torch.zeros((b1, b2), dtype=x_data.dtype, device=x_data.device)
+            for i in range(b1):
+                for j in range(b2):
+                    s = int(off[i, j].item())
+                    e = int(off[i + 1, j].item())
+                    out[i, j] = x_data[s:e].sum()
+            return out
+
+        _, result = code_and_output(jagged_tile_2d_parent, (x, offsets))
+        torch.testing.assert_close(result, ref(x, offsets))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_jagged_tile.py
+++ b/test/test_jagged_tile.py
@@ -284,6 +284,40 @@ class TestJaggedTile(RefEagerTestDisabled, TestCase):
         with self.assertRaises(helion.exc.InvalidJaggedTileUsage):
             code_and_output(dense_add_bad_jagged_tile, (x, y))
 
+    def test_jagged_tile_2d_parent(self):
+        @helion.kernel(autotune_effort="none")
+        def jagged_tile_2d_parent(
+            x: torch.Tensor, lengths: torch.Tensor
+        ) -> torch.Tensor:
+            b1, b2 = lengths.size()
+            out = torch.zeros([b1, b2], dtype=x.dtype, device=x.device)
+            for tile_b1, tile_b2 in hl.tile([b1, b2]):
+                row_lengths = lengths[tile_b1, tile_b2]
+                acc = hl.zeros([tile_b1, tile_b2], dtype=x.dtype)
+                for tile_k in hl.jagged_tile(row_lengths):
+                    acc += x[tile_b1, tile_b2, tile_k].sum(dim=2)
+                out[tile_b1, tile_b2] = acc
+            return out
+
+        lengths = torch.tensor([[3, 1], [2, 4]], device=DEVICE, dtype=torch.long)
+        max_k = 5
+        x = torch.randn(2, 2, max_k, device=DEVICE, dtype=torch.float32)
+
+        def ref(x_data: torch.Tensor, row_lengths: torch.Tensor) -> torch.Tensor:
+            b1, b2 = row_lengths.size()
+            out = torch.zeros((b1, b2), dtype=x_data.dtype, device=x_data.device)
+            for i in range(b1):
+                for j in range(b2):
+                    L = int(row_lengths[i, j].item())
+                    out[i, j] = x_data[i, j, :L].sum()
+            return out
+
+        code, result = code_and_output(jagged_tile_2d_parent, (x, lengths))
+        self.assertIn(
+            "mask_2 = indices_2[None, None, :] < row_lengths[:, :, None]", code
+        )
+        torch.testing.assert_close(result, ref(x, lengths))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
  Until now `hl.jagged_tile` only accepted a 1-D parent — one tile axis carrying the ragged lengths. This PR lifts
  that restriction so the jagged tile's length can be any N-D tensor:

```python
for tile_b1, tile_b2 in hl.tile([b1, b2]):
    row_lengths = lengths[tile_b1, tile_b2]   # 2-D parent
    for tile_k in hl.jagged_tile(row_lengths):
        acc += x[tile_b1, tile_b2, tile_k].sum(dim=2)
```

  What changed

  - JaggedTileIndexType now carries a list of parent block ids.
  - Mask generalizes to ND parent dims: (idx)[None,...,None,:] < parent[:,...,:,None].
  - Loop-bound lowering uses `amax(parent.reshape(-1))` to get the global maximum of ND parent since Inductor only supports a single reduction dim.
  - Docstring updated to say "support N-D parent tensor".