### PR TITLE
New performance dashboard with GitHub Pages deployment

### DIFF
--- a/.github/dashboard/README.md
+++ b/.github/dashboard/README.md
@@ -1,0 +1,24 @@
+# Helion Benchmark Dashboard
+
+Interactive dashboard for visualizing Helion benchmark results across GPU platforms (H100, B200, MI325X, MI350X). Tracks kernel latency, speedup vs eager, compile time, and accuracy over time.
+
+## Generating dashboard data
+
+```bash
+python .github/dashboard/process_for_dashboard.py \
+    --cache-dir <path-to-benchmark-cache> \
+    --runs-meta <path-to-runs-meta.json> \
+    --output .github/dashboard/dashboard-data.json
+```
+
+- `--cache-dir`: directory containing per-run subdirectories with `helionbench.json` files
+- `--runs-meta`: JSON file with run metadata (run_id, sha, full_sha, date, branch)
+- `--existing-data`: (optional) previous `dashboard-data.json` for incremental updates
+
+## Viewing locally
+
+```bash
+cd .github/dashboard
+python -m http.server 8899
+# Open http://localhost:8899/index.html
+```

--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -1,0 +1,944 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Helion Benchmark Dashboard</title>
+<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg:#0d1117;--surface:#161b22;--border:#30363d;--text:#e6edf3;--text-dim:#8b949e;
+  --green:#3fb950;--red:#f85149;--blue:#58a6ff;--orange:#f0883e;--purple:#bc8cff;
+  --gray:#484f58;
+}
+body{background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;line-height:1.5;overflow-x:hidden}
+a{color:var(--blue);text-decoration:none}
+a:hover{text-decoration:underline}
+.header{background:var(--surface);border-bottom:1px solid var(--border);padding:16px 24px;display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:12px}
+.header-left{display:flex;align-items:center;gap:12px}
+.header h1{font-size:20px;font-weight:600;letter-spacing:-0.3px}
+.header .repo-link{font-size:13px;color:var(--text-dim)}
+.tabs{display:flex;gap:0;background:var(--surface);border-bottom:1px solid var(--border);padding:0 24px}
+.tab-btn{padding:10px 20px;font-size:14px;font-weight:500;color:var(--text-dim);background:none;border:none;border-bottom:2px solid transparent;cursor:pointer;transition:all .15s}
+.tab-btn:hover{color:var(--text)}
+.tab-btn.active{color:var(--text);border-bottom-color:var(--blue)}
+.tab-content{display:none;padding:24px}
+.tab-content.active{display:block}
+.status-row{display:flex;gap:12px;margin-bottom:20px;flex-wrap:wrap}
+.status-card{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:16px 20px;min-width:170px;flex:1}
+.status-card .label{font-size:12px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:4px}
+.status-card .value{font-size:22px;font-weight:700}
+.status-card .sub{font-size:12px;color:var(--text-dim);margin-top:2px}
+.status-card.clickable,.summary-card.clickable{cursor:pointer;transition:border-color .15s}
+.status-card.clickable:hover,.summary-card.clickable:hover{border-color:var(--blue)}
+.filter-bar{display:flex;gap:12px;margin-bottom:20px;align-items:center;flex-wrap:wrap}
+.filter-bar select,.filter-bar input{background:var(--surface);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:8px 12px;font-size:13px;outline:none}
+.filter-bar select:focus,.filter-bar input:focus{border-color:var(--blue)}
+.filter-bar input{min-width:220px}
+.platform-grid{display:grid;gap:12px 16px;overflow-x:auto;padding-bottom:8px}
+.platform-col-header{text-align:center;font-size:14px;font-weight:600;padding:10px 12px;border-radius:8px 8px 0 0;letter-spacing:0.3px}
+.kernel-card{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:14px 16px;margin-bottom:10px;cursor:pointer;transition:border-color .15s;position:relative;overflow:hidden}
+.kernel-card:hover{border-color:var(--blue)}
+.kernel-card.placeholder{opacity:0.25;cursor:default;pointer-events:none}
+.kernel-card .left-accent{position:absolute;left:0;top:0;bottom:0;width:3px}
+.kernel-card .kc-body{display:flex;gap:8px}
+.kernel-card .kc-left{flex:1;min-width:0}
+.kernel-card .kc-right{flex:1;min-width:0;display:flex;align-items:center}
+.kernel-card .kc-header{display:flex;align-items:center;gap:8px;margin-bottom:6px;flex-wrap:wrap}
+.kernel-card .kc-name{font-size:13px;font-weight:600;word-break:break-word}
+.kernel-card .kc-tag{font-size:10px;font-weight:600;padding:2px 6px;border-radius:4px;text-transform:uppercase;letter-spacing:0.3px}
+.kernel-card .kc-tag.improved{background:rgba(63,185,80,0.15);color:var(--green)}
+.kernel-card .kc-tag.regressed{background:rgba(248,81,73,0.15);color:var(--red)}
+.kernel-card .kc-row{display:flex;gap:6px;align-items:center;font-size:12px;margin-bottom:3px}
+.kernel-card .kc-row .kc-label{color:var(--text-dim)}
+.kernel-card .kc-row .kc-val{font-weight:600}
+.kernel-card .kc-delta{font-size:13px;margin-bottom:3px}
+.kernel-card .sparkline-container{height:60px}
+.kernel-card .sparkline-container svg{width:100%;height:100%}
+.kernel-card .accuracy-warn{font-size:11px;color:var(--orange);margin-top:4px}
+.modal-overlay{display:none;position:fixed;inset:0;background:rgba(0,0,0,0.65);z-index:1000;justify-content:center;align-items:flex-start;padding:40px 20px;overflow-y:auto}
+.modal-overlay.open{display:flex}
+.modal{background:var(--surface);border:1px solid var(--border);border-radius:12px;width:100%;max-width:1200px;padding:24px;position:relative}
+.modal-split{display:grid;grid-template-columns:1fr 1fr;gap:20px}
+@media(max-width:900px){.modal-split{grid-template-columns:1fr}}
+.modal-lhs{overflow-y:auto;max-height:70vh}
+.modal-rhs{overflow-y:auto;max-height:70vh}
+.modal-close{position:absolute;right:16px;top:16px;background:none;border:none;color:var(--text-dim);font-size:22px;cursor:pointer;padding:4px 8px;border-radius:4px}
+.modal-close:hover{color:var(--text);background:var(--border)}
+.modal h2{font-size:18px;font-weight:600;margin-bottom:4px}
+.modal .modal-sub{font-size:13px;color:var(--text-dim);margin-bottom:16px}
+.modal .chart-container{margin-bottom:20px;background:var(--bg);border-radius:8px;padding:12px}
+.modal .chart-container h3{font-size:14px;font-weight:600;margin-bottom:8px}
+.modal-note{font-size:12px;color:var(--text-dim);font-style:italic;margin-top:12px;padding-top:12px;border-top:1px solid var(--border)}
+.fail-list{list-style:none;padding:0}
+.fail-list li{padding:8px 12px;border-bottom:1px solid var(--border);font-size:13px;display:flex;gap:12px;flex-wrap:wrap}
+.fail-list li:last-child{border-bottom:none}
+.fail-list .fail-kernel{font-weight:600}
+.fail-list .fail-shapes{color:var(--text-dim);font-size:12px}
+.data-table{width:100%;border-collapse:collapse;font-size:13px;margin-top:12px}
+.data-table th{text-align:left;padding:8px 10px;border-bottom:2px solid var(--border);color:var(--text-dim);font-weight:600;font-size:12px;text-transform:uppercase;letter-spacing:0.3px;position:sticky;top:0;background:var(--surface);cursor:pointer;user-select:none;white-space:nowrap}
+.data-table th:hover{color:var(--text)}
+.data-table th.sort-asc::after{content:' ▲';font-size:9px}
+.data-table th.sort-desc::after{content:' ▼';font-size:9px}
+.data-table td{padding:8px 10px;border-bottom:1px solid var(--border)}
+.data-table tbody tr:hover{background:rgba(88,166,255,0.04)}
+.table-scroll{overflow-x:auto;max-height:600px;overflow-y:auto;border-radius:8px;border:1px solid var(--border);background:var(--surface)}
+.summary-row{display:flex;gap:12px;margin-bottom:20px;flex-wrap:wrap}
+.summary-card{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:16px 20px;flex:1;min-width:140px}
+.summary-card .sc-label{font-size:12px;color:var(--text-dim);margin-bottom:4px}
+.summary-card .sc-value{font-size:24px;font-weight:700}
+.summary-card .sc-sub{font-size:12px;color:var(--text-dim);margin-top:2px}
+.compare-selectors{display:flex;gap:16px;margin-bottom:20px;flex-wrap:wrap}
+.commit-box{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:16px;flex:1;min-width:280px}
+.commit-box h3{font-size:13px;font-weight:600;margin-bottom:10px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.5px}
+.commit-box select{width:100%;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:8px 12px;font-size:13px;margin-bottom:8px;outline:none}
+.commit-box select:focus{border-color:var(--blue)}
+.commit-box .run-link{font-size:12px;color:var(--text-dim)}
+.compare-card{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:14px 16px;margin-bottom:10px}
+.compare-card .cc-header{font-size:13px;font-weight:600;margin-bottom:8px;display:flex;align-items:center;gap:8px}
+.compare-card .cc-row{display:flex;justify-content:space-between;font-size:12px;padding:3px 0}
+.compare-card .cc-row .cc-label{color:var(--text-dim)}
+.compare-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:12px;margin-bottom:20px}
+.plat-badge{display:inline-block;font-size:10px;font-weight:600;padding:2px 8px;border-radius:4px;letter-spacing:0.3px;text-transform:uppercase}
+.delta-pos{color:var(--green)}.delta-neg{color:var(--red)}.delta-neutral{color:var(--text-dim)}
+@media(max-width:768px){
+  .platform-grid{flex-direction:column}
+  .status-row,.summary-row{flex-direction:column}
+  .compare-selectors{flex-direction:column}
+  .tab-content{padding:16px}
+}
+</style>
+</head>
+<body>
+<div class="header">
+  <div class="header-left">
+    <h1>Helion Benchmark Dashboard</h1>
+    <a class="repo-link" href="https://github.com/pytorch/helion" target="_blank">pytorch/helion</a>
+  </div>
+</div>
+<div class="tabs">
+  <button class="tab-btn active" data-tab="overview">Overview</button>
+  <button class="tab-btn" data-tab="speedup">Speedup</button>
+  <button class="tab-btn" data-tab="compare">Compare</button>
+</div>
+<div id="tab-overview" class="tab-content active"></div>
+<div id="tab-speedup" class="tab-content"></div>
+<div id="tab-compare" class="tab-content"></div>
+<div class="modal-overlay" id="modal-overlay">
+  <div class="modal" id="modal-content"></div>
+</div>
+<script>
+const REPO = 'pytorch/helion';
+let DATA = typeof EMBEDDED_DATA !== 'undefined' ? EMBEDDED_DATA : null;
+const PLAT_COLORS = { h100: '#3fb950', b200: '#58a6ff', mi325x: '#f0883e', mi350x: '#bc8cff' };
+const PLAT_NAMES = { h100: 'H100', b200: 'B200', mi325x: 'MI325X', mi350x: 'MI350X' };
+const plotlyDark = {
+  paper_bgcolor: '#0d1117', plot_bgcolor: '#0d1117',
+  font: { color: '#e6edf3', size: 11 },
+  margin: { l: 50, r: 20, t: 10, b: 110 },
+  xaxis: { gridcolor: '#30363d', tickangle: -40 },
+  yaxis: { gridcolor: '#30363d' }
+};
+function commitUrl(sha) { return `https://github.com/${REPO}/commit/${sha}`; }
+function runUrl(id) { return `https://github.com/${REPO}/actions/runs/${id}`; }
+function formatSpeedup(v) { return v != null ? v.toFixed(2) + 'x' : '--'; }
+function formatCompileTime(s) { return s != null ? s.toFixed(1) + 's' : '--'; }
+function formatDate(d) {
+  if (!d) return '--';
+  const dt = new Date(d);
+  const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  return months[dt.getMonth()] + ' ' + dt.getDate() + ', ' + String(dt.getHours()).padStart(2,'0') + ':' + String(dt.getMinutes()).padStart(2,'0');
+}
+function formatDelta(v, invert) {
+  if (v == null) return '<span class="delta-neutral">--</span>';
+  const positive = invert ? v < 0 : v > 0;
+  const negative = invert ? v > 0 : v < 0;
+  const cls = positive ? 'delta-pos' : negative ? 'delta-neg' : 'delta-neutral';
+  const sign = v > 0 ? '+' : '';
+  return `<span class="${cls}">${sign}${v.toFixed(1)}%</span>`;
+}
+function platColor(ps) { return PLAT_COLORS[ps] || '#8b949e'; }
+function platName(ps) { return PLAT_NAMES[ps] || ps.toUpperCase(); }
+function platBadge(ps) {
+  const c = platColor(ps);
+  return `<span class="plat-badge" style="background:${c}22;color:${c}">${platName(ps)}</span>`;
+}
+function escHtml(s) { return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+// -------- Helper: status card (overview row) --------
+function statusCard(label, value, sub, opts) {
+  opts = opts || {};
+  const cls = 'status-card' + (opts.clickable ? ' clickable' : '');
+  const id = opts.id ? ` id="${opts.id}"` : '';
+  const vStyle = opts.valueColor ? ` style="color:${opts.valueColor}"` : '';
+  const extra = opts.extraHtml || '';
+  return `<div class="${cls}"${id}><div class="label">${label}</div><div class="value"${vStyle}>${value}</div><div class="sub">${sub}</div>${extra}</div>`;
+}
+// -------- Helper: summary card (speedup / compare row) --------
+function summaryCard(label, value, sub, opts) {
+  opts = opts || {};
+  const cls = 'summary-card' + (opts.clickable ? ' clickable' : '');
+  const id = opts.id ? ` id="${opts.id}"` : '';
+  const vStyle = opts.valueColor ? ` style="color:${opts.valueColor}"` : '';
+  const subHtml = sub ? `<div class="sc-sub">${sub}</div>` : '';
+  return `<div class="${cls}"${id}><div class="sc-label">${label}</div><div class="sc-value"${vStyle}>${value}</div>${subHtml}</div>`;
+}
+// -------- Helper: modal header with close button --------
+function modalHeader(title, sub) {
+  let h = '<button class="modal-close" onclick="closeModal()">&times;</button>';
+  h += `<h2>${title}</h2>`;
+  if (sub) h += `<p class="modal-sub">${sub}</p>`;
+  return h;
+}
+// -------- Helper: build perf change table for improved/regressed modals --------
+function perfChangeTable(list, color, extraHeaders) {
+  const headers = extraHeaders
+    ? '<th>Kernel</th><th>Platform</th><th>Metric</th><th>Base</th><th>Target</th><th>Change</th>'
+    : '<th>Kernel</th><th>Platform</th><th>Metric</th><th>Value</th><th>Change</th>';
+  let html = `<div class="table-scroll"><table class="data-table"><thead><tr>${headers}</tr></thead><tbody>`;
+  list.forEach(item => {
+    const hasLat = extraHeaders ? item.latencyDelta != null : item.latency_delta_pct != null;
+    const metric = hasLat ? 'Latency' : 'Speedup';
+    const delta = hasLat
+      ? (extraHeaders ? item.latencyDelta : item.latency_delta_pct)
+      : (extraHeaders ? item.speedupDelta : item.speedup_delta_pct);
+    const deltaStr = delta != null ? (delta > 0 ? '+' : '') + delta.toFixed(1) + '%' : '?';
+    if (extraHeaders) {
+      const base = hasLat ? (item.baseLatency ? item.baseLatency.toFixed(2) + ' ms' : '--') : formatSpeedup(item.baseSpeedup);
+      const cmp = hasLat ? (item.cmpLatency ? item.cmpLatency.toFixed(2) + ' ms' : '--') : formatSpeedup(item.cmpSpeedup);
+      html += `<tr><td>${escHtml(item.kernel)}</td><td>${platBadge(item.platform_short)}</td>
+        <td>${metric}</td><td>${base}</td><td>${cmp}</td>
+        <td style="color:${color}">${deltaStr}</td></tr>`;
+    } else {
+      const value = hasLat
+        ? (item.helion_latency_avg_ms > 0 ? item.helion_latency_avg_ms.toFixed(2) + ' ms' : '--')
+        : formatSpeedup(item.helion_speedup_geomean);
+      html += `<tr><td>${escHtml(item.kernel)}</td><td>${platBadge(item.platform_short)}</td>
+        <td>${metric}</td><td style="color:${color}">${value}</td>
+        <td style="color:${color}">${deltaStr}</td></tr>`;
+    }
+  });
+  html += '</tbody></table></div>';
+  return html;
+}
+function makeSortable(table) {
+  const headers = table.querySelectorAll('th');
+  headers.forEach((th, colIdx) => {
+    th.addEventListener('click', () => {
+      const tbody = table.querySelector('tbody');
+      const rows = Array.from(tbody.querySelectorAll('tr'));
+      const isAsc = th.classList.contains('sort-asc');
+      headers.forEach(h => { h.classList.remove('sort-asc', 'sort-desc'); });
+      th.classList.add(isAsc ? 'sort-desc' : 'sort-asc');
+      const dir = isAsc ? -1 : 1;
+      rows.sort((a, b) => {
+        const aText = (a.cells[colIdx].textContent || '').trim();
+        const bText = (b.cells[colIdx].textContent || '').trim();
+        const aNum = parseFloat(aText.replace(/[^0-9.\-]/g, ''));
+        const bNum = parseFloat(bText.replace(/[^0-9.\-]/g, ''));
+        if (!isNaN(aNum) && !isNaN(bNum)) return (aNum - bNum) * dir;
+        if (aText === '--' && bText !== '--') return 1;
+        if (bText === '--' && aText !== '--') return -1;
+        return aText.localeCompare(bText) * dir;
+      });
+      rows.forEach(r => tbody.appendChild(r));
+    });
+  });
+}
+let kernelPlatMap = {};
+let _cmpImproved = [], _cmpRegressed = [];
+let activeFilters = { platform: 'all', search: '' };
+function buildMaps() {
+  if (!DATA) return;
+  DATA.summary.forEach(e => {
+    kernelPlatMap[e.kernel + '||' + e.platform_short] = e;
+  });
+}
+function getFiltered() {
+  const plats = activeFilters.platform === 'all' ? DATA.platform_shorts : [activeFilters.platform];
+  const search = activeFilters.search.toLowerCase();
+  let kernels = DATA.unique_kernels;
+  if (search) kernels = kernels.filter(k => k.toLowerCase().includes(search));
+  return { platforms: plats, kernels };
+}
+function getAccuracyFailures() {
+  const fails = [];
+  DATA.summary.forEach(e => {
+    if (e.accuracy_failures && e.accuracy_failures.length > 0) {
+      fails.push({ kernel: e.kernel, platform: platName(e.platform_short), platform_short: e.platform_short, shapes: e.accuracy_failures });
+    }
+  });
+  return fails;
+}
+function sparklineSvg(history, color) {
+  if (!history || history.length < 2) return '';
+  const vals = history.map(h => h.helion_speedup_geomean).filter(v => v != null);
+  if (vals.length < 2) return '';
+  const mn = Math.min(...vals), mx = Math.max(...vals);
+  const range = mx - mn || 1;
+  const w = 120, h = 28, pad = 2;
+  let pts = vals.map((v, i) => {
+    const x = pad + (i / (vals.length - 1)) * (w - 2*pad);
+    const y = h - pad - ((v - mn) / range) * (h - 2*pad);
+    return `${x},${y}`;
+  });
+  return `<svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="none"><polyline points="${pts.join(' ')}" fill="none" stroke="${color}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
+}
+// -------- Overview Tab --------
+function renderOverview() {
+  const lr = DATA.latest_run;
+  const st = DATA.stats;
+  const fails = getAccuracyFailures();
+  const failCount = st.accuracy_failures;
+  const ciPass = failCount === 0;
+  let html = '<div class="status-row">';
+  html += statusCard('Latest Commit',
+    `<a href="${commitUrl(lr.full_sha)}" target="_blank">${escHtml(lr.sha)}</a>`,
+    `${formatDate(lr.date)}`,
+    { extraHtml: `<div class="sub">Run <a href="${runUrl(lr.run_id)}" target="_blank">#${lr.run_id}</a></div>` });
+  html += statusCard('CI Status',
+    ciPass ? 'PASS' : failCount + ' FAIL',
+    ciPass ? 'All accuracy checks passed' : 'Click for details',
+    { id: 'ci-status-card', clickable: failCount > 0, valueColor: ciPass ? 'var(--green)' : 'var(--red)' });
+  html += statusCard('Improved Perf', st.improved_count,
+    st.improved_count > 0 ? 'Click for details' : 'kernels, &gt;10% threshold',
+    { id: 'improved-card', clickable: true, valueColor: 'var(--green)' });
+  html += statusCard('Regressed Perf', st.regressed_count,
+    st.regressed_count > 0 ? 'Click for details' : 'kernels, &gt;10% threshold',
+    { id: 'regressed-card', clickable: true, valueColor: st.regressed_count > 0 ? 'var(--red)' : 'var(--text-dim)' });
+  html += statusCard('Kernels', st.total_kernels, st.num_platforms + ' platforms');
+  html += '</div>';
+  html += '<div class="filter-bar">';
+  html += '<select id="ov-plat-filter"><option value="all">All Platforms</option>';
+  DATA.platform_shorts.forEach(p => { html += `<option value="${p}">${platName(p)}</option>`; });
+  html += '</select>';
+  html += '<input type="text" id="ov-search" placeholder="Search kernels...">';
+  html += '</div>';
+  html += '<div class="platform-grid" id="ov-grid"></div>';
+  document.getElementById('tab-overview').innerHTML = html;
+  document.getElementById('ov-plat-filter').addEventListener('change', e => { activeFilters.platform = e.target.value; renderOverviewGrid(); });
+  document.getElementById('ov-search').addEventListener('input', e => { activeFilters.search = e.target.value; renderOverviewGrid(); });
+  if (failCount > 0) {
+    document.getElementById('ci-status-card').addEventListener('click', () => showFailuresModal(fails));
+  }
+  const improved = DATA.summary.filter(s => s.status === 'improved');
+  const regressed = DATA.summary.filter(s => s.status === 'regressed');
+  document.getElementById('improved-card').addEventListener('click', () => {
+    let html = modalHeader(
+      improved.length === 0 ? 'Improved Perf' : `Improved Perf — ${improved.length} kernel(s)`,
+      improved.length === 0 ? 'No kernels improved &gt;10% vs previous run' : 'Kernels with &gt;10% improvement vs previous run (latency or speedup)');
+    if (improved.length > 0) html += perfChangeTable(improved, 'var(--green)', false);
+    openModal(html);
+  });
+  document.getElementById('regressed-card').addEventListener('click', () => {
+    let html = modalHeader(
+      regressed.length === 0 ? 'Regressed Perf' : `Regressed Perf — ${regressed.length} kernel(s)`,
+      regressed.length === 0 ? 'No kernels regressed &gt;10% vs previous run' : 'Kernels with &gt;10% regression vs previous run (latency or speedup)');
+    if (regressed.length > 0) html += perfChangeTable(regressed, 'var(--red)', false);
+    openModal(html);
+  });
+  renderOverviewGrid();
+}
+function renderOverviewGrid() {
+  const { platforms, kernels } = getFiltered();
+  const grid = document.getElementById('ov-grid');
+  let html = '';
+  grid.style.gridTemplateColumns = `repeat(${platforms.length}, 1fr)`;
+  platforms.forEach(ps => {
+    const color = platColor(ps);
+    html += `<div class="platform-col-header" style="background:${color}18;color:${color};border:1px solid ${color}44">${platName(ps)}</div>`;
+  });
+  kernels.forEach(k => {
+    platforms.forEach(ps => {
+      const color = platColor(ps);
+      const e = kernelPlatMap[k + '||' + ps];
+      if (!e) {
+        html += `<div class="kernel-card placeholder"><div class="left-accent" style="background:${color}"></div>`;
+        html += `<div class="kc-header"><span class="kc-name">${escHtml(k)}</span></div>`;
+        html += '<div class="kc-body"><div class="kc-left">';
+        html += '<div class="kc-row"><span class="kc-label">Latency</span><span class="kc-val">--</span></div>';
+        html += '<div class="kc-row"><span class="kc-label">Compile time</span><span class="kc-val">--</span></div>';
+        html += '<div class="kc-delta" style="color:var(--text-dim)">No data</div>';
+        html += '</div><div class="kc-right"></div></div></div>';
+      } else {
+        const latencyVal = e.helion_latency_avg_ms > 0 ? e.helion_latency_avg_ms.toFixed(2) + ' ms' : null;
+        html += `<div class="kernel-card" data-kernel="${escHtml(e.kernel)}" data-platform="${escHtml(e.platform_short)}" onclick="showDetailModal('${escHtml(e.kernel)}','${escHtml(e.platform_short)}')">`;
+        html += `<div class="left-accent" style="background:${color}"></div>`;
+        html += '<div class="kc-header">';
+        html += `<span class="kc-name">${escHtml(e.kernel)}</span>`;
+        if (e.status === 'improved') html += '<span class="kc-tag improved">improved perf</span>';
+        else if (e.status === 'regressed') html += '<span class="kc-tag regressed">regressed perf</span>';
+        html += '</div>';
+        html += '<div class="kc-body"><div class="kc-left">';
+        if (latencyVal) {
+          html += `<div class="kc-row"><span class="kc-label">Latency</span><span class="kc-val" style="color:${color}">${latencyVal}</span></div>`;
+        } else {
+          html += `<div class="kc-row"><span class="kc-label">Speedup</span><span class="kc-val" style="color:${color}">${formatSpeedup(e.helion_speedup_geomean)}</span></div>`;
+        }
+        html += `<div class="kc-row"><span class="kc-label">Compile time</span><span class="kc-val">${formatCompileTime(e.compile_time_avg_s)}</span></div>`;
+        if (latencyVal && e.latency_delta_pct != null) {
+          html += `<div class="kc-delta">Latency vs prev: ${formatDelta(e.latency_delta_pct, true)}</div>`;
+        } else {
+          html += `<div class="kc-delta">Speedup vs prev: ${formatDelta(e.speedup_delta_pct, false)}</div>`;
+        }
+        html += `<div class="kc-delta">Compile vs prev: ${formatDelta(e.compile_delta_pct, true)}</div>`;
+        if (e.accuracy_failures && e.accuracy_failures.length > 0) {
+          html += `<div class="accuracy-warn">${e.accuracy_failures.length} accuracy fail</div>`;
+        }
+        html += '</div>';
+        html += `<div class="kc-right"><div class="sparkline-container">${sparklineSvg(e.history, color)}</div></div>`;
+        html += '</div></div>';
+      }
+    });
+  });
+  grid.innerHTML = html;
+}
+// -------- Speedup Tab --------
+function renderSpeedupTrendChart() {
+  const el = document.getElementById('speedup-trend-chart');
+  if (!el) return;
+  const { platforms, kernels } = getFiltered();
+  const entries = [];
+  kernels.forEach(k => {
+    platforms.forEach(ps => {
+      const e = kernelPlatMap[k + '||' + ps];
+      if (e) entries.push(e);
+    });
+  });
+  const gm = arr => arr.length > 0 ? Math.exp(arr.reduce((s, v) => s + Math.log(v), 0) / arr.length) : 0;
+  const runs = DATA.runs;
+  const helionTrend = [], tcTrend = [], tritonTrend = [];
+  const xLabels = [];
+  runs.forEach(r => {
+    const hValsRun = [], tValsRun = [], rValsRun = [];
+    entries.forEach(e => {
+      const h = (e.history || []).find(x => x.run_id === r.run_id);
+      if (h) {
+        if (h.helion_speedup_geomean > 0) hValsRun.push(h.helion_speedup_geomean);
+        if (h.torch_compile_speedup_geomean > 0) tValsRun.push(h.torch_compile_speedup_geomean);
+        if (h.triton_speedup_geomean > 0) rValsRun.push(h.triton_speedup_geomean);
+      }
+    });
+    helionTrend.push(gm(hValsRun));
+    tcTrend.push(gm(tValsRun));
+    tritonTrend.push(gm(rValsRun));
+    xLabels.push(r.sha + '\n' + formatDate(r.date));
+  });
+  const traces = [
+    { x: xLabels, y: helionTrend, name: 'Helion', mode: 'lines+markers', line: { color: '#3fb950', width: 2 }, marker: { size: 6 } },
+    { x: xLabels, y: tcTrend, name: 'torch.compile', mode: 'lines+markers', line: { color: '#58a6ff', width: 2 }, marker: { size: 6 } },
+    { x: xLabels, y: tritonTrend, name: 'Triton', mode: 'lines+markers', line: { color: '#bc8cff', width: 2 }, marker: { size: 6 } },
+  ];
+  const allVals = [...helionTrend, ...tcTrend, ...tritonTrend].filter(v => v > 0);
+  const minY = allVals.length > 0 ? Math.min(...allVals) * 0.9 : 0;
+  const maxY = allVals.length > 0 ? Math.max(...allVals) * 1.1 : 2;
+  const shapes = (minY < 1 && maxY > 1) ? [{
+    type: 'line', x0: xLabels[0], x1: xLabels[xLabels.length - 1],
+    y0: 1, y1: 1, line: { color: '#f85149', width: 1, dash: 'dash' }
+  }] : [];
+  const layout = Object.assign({}, plotlyDark, {
+    xaxis: Object.assign({}, plotlyDark.xaxis, { tickangle: -40 }),
+    yaxis: Object.assign({}, plotlyDark.yaxis, { title: 'Geomean Speedup' }),
+    shapes: shapes,
+    legend: { font: { color: '#e6edf3', size: 11 }, bgcolor: 'rgba(0,0,0,0)' },
+    height: 300
+  });
+  Plotly.newPlot(el, traces, layout, { responsive: true, displayModeBar: false });
+}
+function renderSpeedup() {
+  const { platforms, kernels } = getFiltered();
+  const entries = [];
+  kernels.forEach(k => {
+    platforms.forEach(ps => {
+      const e = kernelPlatMap[k + '||' + ps];
+      if (e) entries.push(e);
+    });
+  });
+  const hVals = entries.map(e => e.helion_speedup_geomean).filter(v => v > 0);
+  const tVals = entries.map(e => e.torch_compile_speedup_geomean).filter(v => v > 0);
+  const rVals = entries.map(e => e.triton_speedup_geomean).filter(v => v > 0);
+  const gm = arr => arr.length > 0 ? Math.exp(arr.reduce((s, v) => s + Math.log(v), 0) / arr.length) : 0;
+  const helionGM = gm(hVals), tcGM = gm(tVals), tritonGM = gm(rVals);
+  const helionWins = entries.filter(e => e.helion_speedup_geomean > Math.max(e.torch_compile_speedup_geomean || 0, e.triton_speedup_geomean || 0)).length;
+  let html = '';
+  html += '<h2 style="margin-bottom:4px">Speedup vs Eager Execution</h2>';
+  html += '<p style="font-size:13px;color:var(--text-dim);margin-bottom:16px">Higher values = faster than PyTorch eager. Values &lt; 1.0 are slower than eager.</p>';
+  html += '<div class="filter-bar"><select id="sp-plat-filter"><option value="all">All Platforms</option>';
+  DATA.platform_shorts.forEach(p => { html += `<option value="${p}"${p === activeFilters.platform ? ' selected' : ''}>${platName(p)}</option>`; });
+  html += '</select></div>';
+  html += '<div class="summary-row">';
+  html += summaryCard('Helion Geomean', formatSpeedup(helionGM), null, { valueColor: 'var(--green)' });
+  html += summaryCard('torch.compile Geomean', formatSpeedup(tcGM), null, { valueColor: 'var(--blue)' });
+  html += summaryCard('Triton Geomean', formatSpeedup(tritonGM), null, { valueColor: 'var(--purple)' });
+  html += summaryCard('Helion Wins', helionWins, `of ${entries.length} kernel/platform combos`, { valueColor: 'var(--green)' });
+  html += '</div>';
+  // Speedup trend over time (Plotly)
+  const runs = DATA.runs;
+  if (runs.length >= 2) {
+    html += '<div style="background:var(--bg);border-radius:8px;padding:16px;margin-bottom:20px">';
+    html += '<div style="font-size:14px;font-weight:600;margin-bottom:8px">Geomean Speedup Over Time</div>';
+    html += '<div id="speedup-trend-chart" style="width:100%;height:300px"></div>';
+    html += '</div>';
+  }
+  entries.sort((a, b) => (b.helion_speedup_geomean || 0) - (a.helion_speedup_geomean || 0));
+  html += '<div class="table-scroll"><table class="data-table"><thead><tr><th>Kernel</th><th>Platform</th><th>Commit</th><th>Helion</th><th>torch.compile</th><th>Triton</th><th>Compile Time</th><th>Best</th></tr></thead><tbody>';
+  entries.forEach(e => {
+    const vals = [e.helion_speedup_geomean, e.torch_compile_speedup_geomean, e.triton_speedup_geomean];
+    const names = ['Helion', 'torch.compile', 'Triton'];
+    const colors = ['var(--green)', 'var(--blue)', 'var(--purple)'];
+    let bestIdx = 0;
+    vals.forEach((v, i) => { if ((v || 0) > (vals[bestIdx] || 0)) bestIdx = i; });
+    const latest = e.history && e.history.length > 0 ? e.history[e.history.length - 1] : null;
+    const commitLink = latest ? `<a href="${commitUrl(latest.full_sha)}" target="_blank" style="font-family:monospace;font-size:12px">${escHtml(latest.sha)}</a>` : '--';
+    html += `<tr>
+      <td>${escHtml(e.kernel)}</td>
+      <td>${platBadge(e.platform_short)}</td>
+      <td>${commitLink}</td>
+      <td style="color:var(--green)">${formatSpeedup(e.helion_speedup_geomean)}</td>
+      <td style="color:var(--blue)">${formatSpeedup(e.torch_compile_speedup_geomean)}</td>
+      <td style="color:var(--purple)">${formatSpeedup(e.triton_speedup_geomean)}</td>
+      <td>${formatCompileTime(e.compile_time_avg_s)}</td>
+      <td style="color:${colors[bestIdx]}">${names[bestIdx]}</td>
+    </tr>`;
+  });
+  html += '</tbody></table></div>';
+  document.getElementById('tab-speedup').innerHTML = html;
+  document.querySelectorAll('#tab-speedup .data-table').forEach(makeSortable);
+  document.getElementById('sp-plat-filter').addEventListener('change', e => {
+    activeFilters.platform = e.target.value;
+    renderSpeedup();
+    renderOverviewGrid();
+  });
+  if (runs.length >= 2) {
+    setTimeout(() => renderSpeedupTrendChart(), 50);
+  }
+}
+// -------- Compare Tab --------
+function renderCompare(baseRunIdOverride, cmpRunIdOverride) {
+  const runs = [...DATA.runs].sort((a, b) => new Date(b.date) - new Date(a.date));
+  const baseRunId = baseRunIdOverride || (runs[1] ? runs[1].run_id : runs[0].run_id);
+  const cmpRunId = cmpRunIdOverride || runs[0].run_id;
+  const baseRun = DATA.runs.find(r => r.run_id === baseRunId);
+  const cmpRun = DATA.runs.find(r => r.run_id === cmpRunId);
+  const { platforms, kernels } = getFiltered();
+  let improved = 0, regressed = 0, unchanged = 0;
+  const allDeltas = [];
+  const comparisons = [];
+  kernels.forEach(k => {
+    platforms.forEach(ps => {
+      const entry = kernelPlatMap[k + '||' + ps];
+      if (!entry || !entry.history) return;
+      const baseH = entry.history.find(h => h.run_id === baseRunId);
+      const cmpH = entry.history.find(h => h.run_id === cmpRunId);
+      if (!baseH && !cmpH) return;
+      const baseSpeedup = baseH ? baseH.helion_speedup_geomean : null;
+      const cmpSpeedup = cmpH ? cmpH.helion_speedup_geomean : null;
+      const baseCompile = baseH ? baseH.compile_time_avg_s : null;
+      const cmpCompile = cmpH ? cmpH.compile_time_avg_s : null;
+      const baseLatency = baseH ? baseH.helion_latency_avg_ms : null;
+      const cmpLatency = cmpH ? cmpH.helion_latency_avg_ms : null;
+      let speedupDelta = null;
+      if (baseSpeedup && cmpSpeedup && baseSpeedup > 0) {
+        speedupDelta = ((cmpSpeedup - baseSpeedup) / baseSpeedup) * 100;
+      }
+      let latencyDelta = null;
+      if (baseLatency && cmpLatency && baseLatency > 0 && cmpLatency > 0) {
+        latencyDelta = ((baseLatency - cmpLatency) / cmpLatency) * 100;
+      }
+      const perfDelta = latencyDelta != null ? latencyDelta : speedupDelta;
+      if (perfDelta != null) {
+        allDeltas.push(perfDelta);
+        if (perfDelta > 10) improved++;
+        else if (perfDelta < -10) regressed++;
+        else unchanged++;
+      } else {
+        unchanged++;
+      }
+      let compileDelta = null;
+      if (baseCompile && cmpCompile && baseCompile > 0) {
+        compileDelta = ((cmpCompile - baseCompile) / baseCompile) * 100;
+      }
+      comparisons.push({
+        kernel: k, platform_short: ps,
+        baseSpeedup, cmpSpeedup, speedupDelta,
+        baseLatency, cmpLatency, latencyDelta,
+        baseCompile, cmpCompile, compileDelta
+      });
+    });
+  });
+  let geomeanDelta = 0;
+  if (allDeltas.length > 0) {
+    const absDelta = allDeltas.map(d => Math.abs(d)).filter(d => d > 0);
+    if (absDelta.length > 0) {
+      const gmVal = Math.exp(absDelta.reduce((s, v) => s + Math.log(v), 0) / absDelta.length);
+      const positiveCount = allDeltas.filter(d => d > 0).length;
+      geomeanDelta = positiveCount >= allDeltas.length / 2 ? gmVal : -gmVal;
+    }
+  }
+  let html = '<h2 style="margin-bottom:16px">Compare Commits</h2>';
+  html += '<div class="compare-selectors">';
+  html += '<div class="commit-box"><h3>Base</h3>';
+  html += '<select id="cmp-base-branch"><option value="main">main</option></select>';
+  html += '<select id="cmp-base-commit">';
+  runs.forEach(r => { html += `<option value="${r.run_id}"${r.run_id === baseRunId ? ' selected' : ''}>${r.sha} (${formatDate(r.date)})</option>`; });
+  html += '</select>';
+  html += baseRun ? `<div class="run-link">Run: <a href="${runUrl(baseRun.run_id)}" target="_blank">#${baseRun.run_id}</a></div>` : '';
+  html += '</div>';
+  html += '<div class="commit-box"><h3>Target</h3>';
+  html += '<select id="cmp-compare-branch"><option value="main">main</option></select>';
+  html += '<select id="cmp-compare-commit">';
+  runs.forEach(r => { html += `<option value="${r.run_id}"${r.run_id === cmpRunId ? ' selected' : ''}>${r.sha} (${formatDate(r.date)})</option>`; });
+  html += '</select>';
+  html += cmpRun ? `<div class="run-link">Run: <a href="${runUrl(cmpRun.run_id)}" target="_blank">#${cmpRun.run_id}</a></div>` : '';
+  html += '</div></div>';
+  html += '<div class="filter-bar"><select id="cmp-plat-filter"><option value="all">All Platforms</option>';
+  DATA.platform_shorts.forEach(p => { html += `<option value="${p}"${p === activeFilters.platform ? ' selected' : ''}>${platName(p)}</option>`; });
+  html += '</select></div>';
+  const improvedList = comparisons.filter(c => {
+    const d = c.latencyDelta != null ? c.latencyDelta : c.speedupDelta;
+    return d != null && d > 10;
+  });
+  const regressedList = comparisons.filter(c => {
+    const d = c.latencyDelta != null ? c.latencyDelta : c.speedupDelta;
+    return d != null && d < -10;
+  });
+  _cmpImproved = improvedList;
+  _cmpRegressed = regressedList;
+  html += '<div class="summary-row">';
+  html += summaryCard('Improved Perf', improved, improved > 0 ? 'Click for details' : '&gt;10% threshold',
+    { id: 'cmp-improved-card', clickable: true, valueColor: 'var(--green)' });
+  html += summaryCard('Regressed Perf', regressed, regressed > 0 ? 'Click for details' : '&gt;10% threshold',
+    { id: 'cmp-regressed-card', clickable: true, valueColor: regressed > 0 ? 'var(--red)' : 'var(--text-dim)' });
+  html += summaryCard('Unchanged', unchanged);
+  html += summaryCard('Geomean Perf Delta', formatDelta(geomeanDelta, false));
+  html += '</div>';
+  const changedComparisons = comparisons.filter(c => {
+    const d = c.latencyDelta != null ? c.latencyDelta : c.speedupDelta;
+    return d != null && (d > 10 || d < -10);
+  });
+  if (changedComparisons.length > 0) {
+    html += `<div style="font-size:14px;font-weight:600;margin-bottom:8px">Changed Kernels (${changedComparisons.length})</div>`;
+    html += '<div class="compare-grid">';
+    changedComparisons.forEach(c => {
+      const color = platColor(c.platform_short);
+      const hasLat = c.baseLatency > 0 || c.cmpLatency > 0;
+      const fmtLat = v => v && v > 0 ? v.toFixed(2) + ' ms' : '--';
+      const perfD = hasLat ? c.latencyDelta : c.speedupDelta;
+      const isImproved = perfD != null && perfD > 10;
+      const borderColor = isImproved ? 'var(--green)' : 'var(--red)';
+      html += `<div class="compare-card" style="border-left:3px solid ${borderColor}">`;
+      html += `<div class="cc-header"><span style="color:${color}">${escHtml(c.kernel)}</span> ${platBadge(c.platform_short)} <span class="kc-tag ${isImproved ? 'improved' : 'regressed'}">${isImproved ? 'improved' : 'regressed'} perf</span></div>`;
+      if (hasLat) {
+        html += `<div class="cc-row"><span class="cc-label">Latency</span><span>${fmtLat(c.baseLatency)} → ${fmtLat(c.cmpLatency)} (${formatDelta(c.latencyDelta, true)})</span></div>`;
+      }
+      html += `<div class="cc-row"><span class="cc-label">Speedup</span><span>${formatSpeedup(c.baseSpeedup)} → ${formatSpeedup(c.cmpSpeedup)} (${formatDelta(c.speedupDelta, false)})</span></div>`;
+      html += `<div class="cc-row"><span class="cc-label">Compile</span><span>${formatCompileTime(c.baseCompile)} → ${formatCompileTime(c.cmpCompile)} (${formatDelta(c.compileDelta, true)})</span></div>`;
+      html += '</div>';
+    });
+    html += '</div>';
+  } else {
+    html += '<div style="padding:16px;background:var(--bg);border-radius:8px;margin-bottom:20px;text-align:center;color:var(--text-dim);font-size:13px">No kernels changed &gt;10% between selected commits</div>';
+  }
+  html += '<div style="font-size:14px;font-weight:600;margin-bottom:8px">All Kernels</div>';
+  html += '<div class="table-scroll"><table class="data-table"><thead><tr><th>Kernel</th><th>Platform</th><th>Base Latency</th><th>Target Latency</th><th>Latency Delta</th><th>Base Speedup</th><th>Target Speedup</th><th>Speedup Delta</th><th>Base Compile</th><th>Target Compile</th><th>Compile Delta</th></tr></thead><tbody>';
+  comparisons.forEach(c => {
+    const fmtLat = v => v && v > 0 ? v.toFixed(2) + ' ms' : '--';
+    html += `<tr>
+      <td>${escHtml(c.kernel)}</td>
+      <td>${platBadge(c.platform_short)}</td>
+      <td>${fmtLat(c.baseLatency)}</td>
+      <td>${fmtLat(c.cmpLatency)}</td>
+      <td>${formatDelta(c.latencyDelta, true)}</td>
+      <td>${formatSpeedup(c.baseSpeedup)}</td>
+      <td>${formatSpeedup(c.cmpSpeedup)}</td>
+      <td>${formatDelta(c.speedupDelta, false)}</td>
+      <td>${formatCompileTime(c.baseCompile)}</td>
+      <td>${formatCompileTime(c.cmpCompile)}</td>
+      <td>${formatDelta(c.compileDelta, true)}</td>
+    </tr>`;
+  });
+  html += '</tbody></table></div>';
+  document.getElementById('tab-compare').innerHTML = html;
+  document.querySelectorAll('#tab-compare .data-table').forEach(makeSortable);
+  document.getElementById('cmp-base-commit').addEventListener('change', () => {
+    renderCompare(document.getElementById('cmp-base-commit').value, document.getElementById('cmp-compare-commit').value);
+  });
+  document.getElementById('cmp-compare-commit').addEventListener('change', () => {
+    renderCompare(document.getElementById('cmp-base-commit').value, document.getElementById('cmp-compare-commit').value);
+  });
+  document.getElementById('cmp-plat-filter').addEventListener('change', e => {
+    activeFilters.platform = e.target.value;
+    renderCompare(baseRunId, cmpRunId);
+    renderOverviewGrid();
+  });
+  document.getElementById('cmp-improved-card').addEventListener('click', () => {
+    const list = _cmpImproved || [];
+    let mhtml = modalHeader(
+      list.length === 0 ? 'Improved Perf' : `Improved Perf — ${list.length} kernel(s)`,
+      list.length === 0 ? 'No kernels improved &gt;10% between selected commits' : 'Kernels with &gt;10% improvement between selected commits (latency or speedup)');
+    if (list.length > 0) mhtml += perfChangeTable(list, 'var(--green)', true);
+    openModal(mhtml);
+  });
+  document.getElementById('cmp-regressed-card').addEventListener('click', () => {
+    const list = _cmpRegressed || [];
+    let mhtml = modalHeader(
+      list.length === 0 ? 'Regressed Perf' : `Regressed Perf — ${list.length} kernel(s)`,
+      list.length === 0 ? 'No kernels regressed &gt;10% between selected commits' : 'Kernels with &gt;10% regression between selected commits (latency or speedup)');
+    if (list.length > 0) mhtml += perfChangeTable(list, 'var(--red)', true);
+    openModal(mhtml);
+  });
+}
+// -------- Modals --------
+function openModal(content) {
+  document.getElementById('modal-content').innerHTML = content;
+  document.getElementById('modal-overlay').classList.add('open');
+}
+function closeModal() {
+  const charts = document.querySelectorAll('#modal-content [id^="mc-"]');
+  charts.forEach(el => { try { Plotly.purge(el); } catch(e) {} });
+  document.getElementById('modal-overlay').classList.remove('open');
+}
+document.getElementById('modal-overlay').addEventListener('click', e => {
+  if (e.target === document.getElementById('modal-overlay')) closeModal();
+});
+document.addEventListener('keydown', e => { if (e.key === 'Escape') closeModal(); });
+function showFailuresModal(fails) {
+  let html = modalHeader('Accuracy Failures', 'Kernel/platform combinations with accuracy check failures');
+  html += '<ul class="fail-list">';
+  fails.forEach(f => {
+    html += `<li>
+      <span class="fail-kernel">${escHtml(f.kernel)}</span>
+      ${platBadge(f.platform_short)}
+      <span class="fail-shapes">Shapes: ${f.shapes.map(escHtml).join(', ')}</span>
+    </li>`;
+  });
+  html += '</ul>';
+  openModal(html);
+}
+function showDetailModal(kernel, platform_short) {
+  const e = kernelPlatMap[kernel + '||' + platform_short];
+  if (!e) return;
+  const color = platColor(platform_short);
+  let html = modalHeader(
+    `${escHtml(kernel)} ${platBadge(platform_short)}`,
+    `Speedup Geomean: ${formatSpeedup(e.helion_speedup_geomean)} | Compile: ${formatCompileTime(e.compile_time_avg_s)}${e.helion_latency_avg_ms > 0 ? ' | Latency: ' + e.helion_latency_avg_ms.toFixed(2) + ' ms' : ''}`);
+  html += '<div class="modal-split"><div class="modal-lhs">';
+  if (e.status !== 'unchanged') {
+    html += `<div style="margin-bottom:12px"><span class="kc-tag ${e.status}">${e.status} perf</span></div>`;
+  }
+  if (e.accuracy_failures && e.accuracy_failures.length > 0) {
+    html += `<div class="accuracy-warn" style="margin-bottom:12px">${e.accuracy_failures.length} accuracy failure(s): ${e.accuracy_failures.join(', ')}</div>`;
+  }
+  html += '<h3 style="font-size:13px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.3px;margin-bottom:8px">Run History</h3>';
+  html += '<div class="table-scroll" style="max-height:300px"><table class="data-table"><thead><tr><th>Commit</th><th>Date</th><th>Latency</th><th>Speedup</th><th>Compile</th></tr></thead><tbody>';
+  const hist = [...(e.history || [])].reverse();
+  hist.forEach((h, i) => {
+    let speedupDelta = '', latencyDelta = '';
+    if (i < hist.length - 1) {
+      const prev = hist[i + 1];
+      if (prev.helion_speedup_geomean && h.helion_speedup_geomean && prev.helion_speedup_geomean > 0) {
+        const d = ((h.helion_speedup_geomean - prev.helion_speedup_geomean) / prev.helion_speedup_geomean) * 100;
+        speedupDelta = ' ' + formatDelta(d, false);
+      }
+      if (prev.helion_latency_avg_ms > 0 && h.helion_latency_avg_ms > 0) {
+        const d = ((prev.helion_latency_avg_ms - h.helion_latency_avg_ms) / h.helion_latency_avg_ms) * 100;
+        latencyDelta = ' ' + formatDelta(d, true);
+      }
+    }
+    const latencyVal = h.helion_latency_avg_ms > 0 ? h.helion_latency_avg_ms.toFixed(2) + ' ms' : '--';
+    html += `<tr>
+      <td><a href="${commitUrl(h.full_sha)}" target="_blank" title="Run #${h.run_id}">${escHtml(h.sha)}</a></td>
+      <td style="font-size:11px">${formatDate(h.date)}</td>
+      <td>${latencyVal}${latencyDelta}</td>
+      <td>${formatSpeedup(h.helion_speedup_geomean)}${speedupDelta}</td>
+      <td>${formatCompileTime(h.compile_time_avg_s)}</td>
+    </tr>`;
+  });
+  html += '</tbody></table></div>';
+  html += '</div>'; // end modal-lhs
+  // RHS: Plotly charts
+  html += '<div class="modal-rhs">';
+  const histFwd = e.history || [];
+  if (histFwd.length >= 2) {
+    const hasLatency = histFwd.some(h => h.helion_latency_avg_ms > 0);
+    if (hasLatency) {
+      html += '<div class="chart-container"><h3>Latency Over Time</h3><div id="mc-latency" style="width:100%;height:220px"></div></div>';
+    } else {
+      html += '<div class="chart-container"><h3>Speedup Over Time</h3><div id="mc-speedup" style="width:100%;height:220px"></div></div>';
+    }
+    html += '<div class="chart-container"><h3>Compile Time Over Time</h3><div id="mc-compile" style="width:100%;height:220px"></div></div>';
+  }
+  const latest = histFwd.length > 0 ? histFwd[histFwd.length - 1] : null;
+  if (latest && latest.per_shape && latest.per_shape.shapes.length > 0) {
+    html += '<div class="chart-container"><h3>Per-Shape Speedup (Latest Run)</h3><div id="mc-bar-speedup" style="width:100%;height:260px"></div></div>';
+    const ps = latest.per_shape;
+    const hasCompileTimes = ps.compile_times && ps.compile_times.length > 0 && ps.compile_times.some(v => v > 0);
+    if (hasCompileTimes) {
+      html += '<div class="chart-container"><h3>Per-Shape Compile Time (Latest Run)</h3><div id="mc-bar-compile" style="width:100%;height:220px"></div></div>';
+    }
+  }
+  html += '</div></div>'; // end modal-rhs + modal-split
+  openModal(html);
+  // Render Plotly charts after modal is visible
+  setTimeout(() => {
+    const commitUrls = histFwd.map(h => commitUrl(h.full_sha));
+    const xLabels = histFwd.map(h => h.sha + '\n' + formatDate(h.date));
+    if (histFwd.length >= 2) {
+      const hasLatency = histFwd.some(h => h.helion_latency_avg_ms > 0);
+      if (hasLatency) {
+        const latVals = histFwd.map(h => h.helion_latency_avg_ms > 0 ? h.helion_latency_avg_ms : null);
+        const latTrace = {
+          x: xLabels, y: latVals,
+          mode: 'lines+markers', line: { color: color, width: 2 }, marker: { size: 6 },
+          text: histFwd.map(h => h.sha), customdata: commitUrls,
+          hovertemplate: '%{text}: %{y:.2f} ms<extra></extra>',
+          connectgaps: false
+        };
+        const latLayout = Object.assign({}, plotlyDark, {
+          height: 220,
+          xaxis: Object.assign({}, plotlyDark.xaxis, { tickangle: -40 }),
+          yaxis: Object.assign({}, plotlyDark.yaxis, { title: 'Latency (ms)' })
+        });
+        const latEl = document.getElementById('mc-latency');
+        if (latEl) {
+          Plotly.newPlot(latEl, [latTrace], latLayout, { responsive: true, displayModeBar: false });
+          latEl.on('plotly_click', function(data) {
+            if (data.points && data.points[0] && data.points[0].customdata) {
+              window.open(data.points[0].customdata, '_blank');
+            }
+          });
+        }
+      } else {
+        const spVals = histFwd.map(h => h.helion_speedup_geomean > 0 ? h.helion_speedup_geomean : null);
+        const spTrace = {
+          x: xLabels, y: spVals,
+          mode: 'lines+markers', line: { color: color, width: 2 }, marker: { size: 6 },
+          text: histFwd.map(h => h.sha), customdata: commitUrls,
+          hovertemplate: '%{text}: %{y:.2f}x<extra></extra>',
+          connectgaps: false
+        };
+        const spLayout = Object.assign({}, plotlyDark, {
+          height: 220,
+          xaxis: Object.assign({}, plotlyDark.xaxis, { tickangle: -40 }),
+          yaxis: Object.assign({}, plotlyDark.yaxis, { title: 'Speedup' })
+        });
+        const spEl = document.getElementById('mc-speedup');
+        if (spEl) {
+          Plotly.newPlot(spEl, [spTrace], spLayout, { responsive: true, displayModeBar: false });
+          spEl.on('plotly_click', function(data) {
+            if (data.points && data.points[0] && data.points[0].customdata) {
+              window.open(data.points[0].customdata, '_blank');
+            }
+          });
+        }
+      }
+      // Compile time over time
+      const ctVals = histFwd.map(h => h.compile_time_avg_s > 0 ? h.compile_time_avg_s : null);
+      const ctTrace = {
+        x: xLabels, y: ctVals,
+        mode: 'lines+markers', line: { color: '#f0883e', width: 2 }, marker: { size: 6 },
+        text: histFwd.map(h => h.sha), customdata: commitUrls,
+        hovertemplate: '%{text}: %{y:.1f}s<extra></extra>',
+        connectgaps: false
+      };
+      const ctLayout = Object.assign({}, plotlyDark, {
+        height: 220,
+        xaxis: Object.assign({}, plotlyDark.xaxis, { tickangle: -40 }),
+        yaxis: Object.assign({}, plotlyDark.yaxis, { title: 'Compile Time (s)' })
+      });
+      const ctEl = document.getElementById('mc-compile');
+      if (ctEl) {
+        Plotly.newPlot(ctEl, [ctTrace], ctLayout, { responsive: true, displayModeBar: false });
+      }
+    }
+    // Per-shape bar charts
+    if (latest && latest.per_shape && latest.per_shape.shapes.length > 0) {
+      const ps = latest.per_shape;
+      const shapes = ps.shapes.map(s => s.length > 25 ? s.slice(0, 25) + '...' : s);
+      // Grouped bar chart for speedup
+      const barTraces = [];
+      if (ps.helion_speedup && ps.helion_speedup.length > 0) {
+        barTraces.push({ x: shapes, y: ps.helion_speedup, name: 'Helion', type: 'bar', marker: { color: '#3fb950' } });
+      }
+      if (ps.torch_compile_speedup && ps.torch_compile_speedup.length > 0) {
+        barTraces.push({ x: shapes, y: ps.torch_compile_speedup, name: 'torch.compile', type: 'bar', marker: { color: '#58a6ff' } });
+      }
+      if (ps.triton_speedup && ps.triton_speedup.length > 0) {
+        barTraces.push({ x: shapes, y: ps.triton_speedup, name: 'Triton', type: 'bar', marker: { color: '#bc8cff' } });
+      }
+      if (barTraces.length > 0) {
+        const allBarVals = barTraces.flatMap(t => t.y).filter(v => v > 0);
+        const barMax = allBarVals.length > 0 ? Math.max(...allBarVals) * 1.1 : 2;
+        const barShapes = (barMax > 1) ? [{
+          type: 'line', x0: -0.5, x1: shapes.length - 0.5,
+          y0: 1, y1: 1, line: { color: '#f85149', width: 1, dash: 'dash' }
+        }] : [];
+        const barLayout = Object.assign({}, plotlyDark, {
+          height: 260, barmode: 'group',
+          xaxis: Object.assign({}, plotlyDark.xaxis, { tickangle: -45 }),
+          yaxis: Object.assign({}, plotlyDark.yaxis, { title: 'Speedup' }),
+          shapes: barShapes,
+          legend: { font: { color: '#e6edf3', size: 11 }, bgcolor: 'rgba(0,0,0,0)' }
+        });
+        const barEl = document.getElementById('mc-bar-speedup');
+        if (barEl) {
+          Plotly.newPlot(barEl, barTraces, barLayout, { responsive: true, displayModeBar: false });
+        }
+      }
+      // Per-shape compile time
+      const hasCompileTimes = ps.compile_times && ps.compile_times.length > 0 && ps.compile_times.some(v => v > 0);
+      if (hasCompileTimes) {
+        const compileBarTrace = {
+          x: shapes, y: ps.compile_times, type: 'bar',
+          marker: { color: '#f0883e' },
+          hovertemplate: '%{x}: %{y:.1f}s<extra></extra>'
+        };
+        const compileBarLayout = Object.assign({}, plotlyDark, {
+          height: 220,
+          xaxis: Object.assign({}, plotlyDark.xaxis, { tickangle: -45 }),
+          yaxis: Object.assign({}, plotlyDark.yaxis, { title: 'Compile Time (s)' }),
+          showlegend: false
+        });
+        const compileBarEl = document.getElementById('mc-bar-compile');
+        if (compileBarEl) {
+          Plotly.newPlot(compileBarEl, [compileBarTrace], compileBarLayout, { responsive: true, displayModeBar: false });
+        }
+      }
+    }
+  }, 50);
+}
+// -------- Tab Switching --------
+document.querySelectorAll('.tab-btn').forEach(btn => {
+  btn.addEventListener('click', () => {
+    document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+    document.querySelectorAll('.tab-content').forEach(t => t.classList.remove('active'));
+    btn.classList.add('active');
+    document.getElementById('tab-' + btn.dataset.tab).classList.add('active');
+    if (btn.dataset.tab === 'speedup') {
+      renderSpeedup();
+    } else if (btn.dataset.tab === 'compare') renderCompare();
+  });
+});
+// -------- Init --------
+function initDashboard() {
+  buildMaps();
+  renderOverview();
+  renderSpeedup();
+  renderCompare();
+}
+function init() {
+  if (DATA) { initDashboard(); return; }
+  fetch('dashboard-data.json')
+    .then(r => {
+      if (!r.ok) throw new Error('HTTP ' + r.status);
+      return r.json();
+    })
+    .then(json => { DATA = json; initDashboard(); })
+    .catch(() => {
+      document.getElementById('tab-overview').innerHTML = '<div style="padding:60px;text-align:center"><h2 style="color:var(--red);margin-bottom:12px">Data Not Loaded</h2><p style="color:var(--text-dim)">Could not load dashboard data. Place <code>dashboard-data.json</code> in the same directory and serve via HTTP.</p></div>';
+    });
+}
+init();
+</script>
+</body>
+</html>

--- a/.github/dashboard/process_for_dashboard.py
+++ b/.github/dashboard/process_for_dashboard.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Process Helion benchmark artifacts into dashboard-ready JSON.
+
+Reads helionbench.json files from benchmark CI artifacts, aggregates
+across runs, and outputs a single JSON file that the dashboard renders
+with no client-side computation needed. Supports incremental updates
+via --existing-data to avoid reprocessing old runs.
+
+Usage:
+    python process_for_dashboard.py \
+        --cache-dir /path/to/benchmark-cache \
+        --runs-meta /path/to/runs-meta.json \
+        --output /path/to/dashboard-data.json
+"""
+
+import argparse
+import datetime
+import glob
+import json
+import math
+import os
+import sys
+
+
+def geo_mean(values):
+    pos = [v for v in values if v and v > 0]
+    if not pos:
+        return 0.0
+    return math.exp(sum(math.log(v) for v in pos) / len(pos))
+
+
+def avg(values):
+    valid = [v for v in values if v is not None and not math.isnan(v)]
+    if not valid:
+        return 0.0
+    return sum(valid) / len(valid)
+
+
+def fmt_delta(curr, prev):
+    if not prev or prev == 0 or not curr:
+        return None
+    return round(((curr - prev) / prev) * 100, 2)
+
+
+def parse_run(run_dir):
+    """Parse all helionbench.json files in a run directory."""
+    kernels = []
+    for bench_dir in sorted(glob.glob(os.path.join(run_dir, "benchmark-results-*"))):
+        dirname = os.path.basename(bench_dir)
+        parts = dirname.replace("benchmark-results-", "").split("-", 1)
+        platform_short = parts[0] if parts else "unknown"
+        kernel_name = parts[1] if len(parts) > 1 else "unknown"
+
+        bench_file = os.path.join(bench_dir, "helionbench.json")
+        if not os.path.exists(bench_file):
+            continue
+
+        try:
+            with open(bench_file) as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        if not data:
+            continue
+
+        platform = data[0].get("benchmark", {}).get("extra_info", {}).get("device", platform_short)
+        if platform == platform_short and platform in ("b200", "h100", "mi325x", "mi350x"):
+            continue
+
+        # Use model name from JSON instead of directory name
+        actual_kernel = data[0].get("model", {}).get("name", kernel_name)
+
+        # Group records by model name (a single file may contain multiple kernels)
+        by_model = {}
+        for item in data:
+            model = item.get("model", {}).get("name", actual_kernel)
+            if model not in by_model:
+                by_model[model] = {"shapes": item.get("shape", []), "metrics": {}}
+            by_model[model]["metrics"][item["metric"]["name"]] = item["metric"]["benchmark_values"]
+
+        for model_name, model_data in by_model.items():
+            if not model_data["metrics"].get("helion_speedup"):
+                continue
+
+            kernels.append({
+                "kernel": model_name,
+                "platform": platform,
+                "platform_short": platform_short,
+                "shapes": model_data["shapes"],
+                "metrics": model_data["metrics"],
+            })
+
+    return kernels
+
+
+def build_dashboard_data(cache_dir, runs_meta, existing_data=None):
+    """Build the complete dashboard data structure.
+
+    For runs that have local artifacts (in cache_dir), parse them fresh.
+    For runs that only exist in existing_data, reuse the cached history.
+    """
+    RETENTION_DAYS = 90
+    cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=RETENTION_DAYS)
+    runs_meta_sorted = sorted(
+        [r for r in runs_meta if datetime.datetime.fromisoformat(r["date"].replace("Z", "+00:00")) >= cutoff],
+        key=lambda r: r["date"],
+    )
+    run_ids = [r["run_id"] for r in runs_meta_sorted]
+
+    # Build index of existing history keyed by kernel|platform -> run_id -> history entry
+    existing_history = {}
+    if existing_data and "summary" in existing_data:
+        for entry in existing_data["summary"]:
+            key = f"{entry['kernel']}|{entry['platform']}"
+            if key not in existing_history:
+                existing_history[key] = {}
+            for h in entry.get("history", []):
+                existing_history[key][h["run_id"]] = h
+
+    # Parse each run — use local artifacts if available, skip if not (will use existing history later)
+    runs = []
+    for meta in runs_meta_sorted:
+        run_dir = os.path.join(cache_dir, meta["run_id"])
+        if os.path.isdir(run_dir) and os.listdir(run_dir):
+            kernels = parse_run(run_dir)
+            runs.append({**meta, "kernel_count": len(kernels), "kernels": kernels})
+        else:
+            runs.append({**meta, "kernel_count": 0, "kernels": []})
+
+    # Build per-kernel history across runs
+    # For runs with local artifacts, compute fresh. For others, reuse existing history.
+    kernel_index = {}
+
+    # First pass: add history from freshly parsed runs
+    for run in runs:
+        for k in run["kernels"]:
+            key = f"{k['kernel']}|{k['platform']}"
+            if key not in kernel_index:
+                kernel_index[key] = {
+                    "kernel": k["kernel"],
+                    "platform": k["platform"],
+                    "platform_short": k["platform_short"],
+                    "shapes": k["shapes"],
+                    "history": [],
+                }
+            helion_speedup_gm = geo_mean(k["metrics"].get("helion_speedup", []))
+            triton_speedup_gm = geo_mean(k["metrics"].get("triton_speedup", []))
+            tc_speedup_gm = geo_mean(k["metrics"].get("torch_compile_speedup", []))
+            compile_time_avg = avg(k["metrics"].get("helion_compile_time_s", []))
+            helion_latency = k["metrics"].get("helion_latency_ms", [])
+            helion_latency_avg = avg([v for v in helion_latency if v]) if helion_latency else 0
+            kernel_index[key]["history"].append({
+                "run_id": run["run_id"],
+                "sha": run["sha"],
+                "full_sha": run["full_sha"],
+                "date": run["date"],
+                "branch": run.get("branch", "main"),
+                "helion_speedup_geomean": round(helion_speedup_gm, 4),
+                "triton_speedup_geomean": round(triton_speedup_gm, 4),
+                "torch_compile_speedup_geomean": round(tc_speedup_gm, 4),
+                "compile_time_avg_s": round(compile_time_avg, 2),
+                "helion_latency_avg_ms": round(helion_latency_avg, 4),
+                "per_shape": {
+                    "shapes": k["shapes"],
+                    "helion_speedup": k["metrics"].get("helion_speedup", []),
+                    "triton_speedup": k["metrics"].get("triton_speedup", []),
+                    "torch_compile_speedup": k["metrics"].get("torch_compile_speedup", []),
+                    "helion_accuracy": k["metrics"].get("helion_accuracy", []),
+                    "helion_compile_time_s": k["metrics"].get("helion_compile_time_s", []),
+                    "helion_latency_ms": k["metrics"].get("helion_latency_ms", []),
+                },
+            })
+
+    # Second pass: for runs without local artifacts, fill in from existing history
+    fresh_run_ids = {run["run_id"] for run in runs if run["kernels"]}
+    for run in runs:
+        if run["run_id"] in fresh_run_ids:
+            continue
+        for key, cached_runs in existing_history.items():
+            if run["run_id"] in cached_runs:
+                if key not in kernel_index:
+                    parts = key.split("|", 1)
+                    platform_short = ""
+                    for entry in (existing_data or {}).get("summary", []):
+                        if entry["kernel"] == parts[0] and entry["platform"] == (parts[1] if len(parts) > 1 else ""):
+                            platform_short = entry["platform_short"]
+                            break
+                    kernel_index[key] = {
+                        "kernel": parts[0],
+                        "platform": parts[1] if len(parts) > 1 else "unknown",
+                        "platform_short": platform_short,
+                        "shapes": [],
+                        "history": [],
+                    }
+                kernel_index[key]["history"].append(cached_runs[run["run_id"]])
+
+    # Sort each kernel's history by date
+    for entry in kernel_index.values():
+        entry["history"].sort(key=lambda h: h["date"])
+
+    # Build the final summary with deltas pre-computed
+    summary = []
+    for key, entry in sorted(kernel_index.items()):
+        history = entry["history"]
+        latest = None
+        prev = None
+        for h in reversed(history):
+            if h["helion_speedup_geomean"] > 0:
+                if latest is None:
+                    latest = h
+                elif prev is None:
+                    prev = h
+                    break
+
+        speedup_delta = fmt_delta(
+            latest["helion_speedup_geomean"],
+            prev["helion_speedup_geomean"]
+        ) if latest and prev else None
+
+        compile_delta = fmt_delta(
+            prev["compile_time_avg_s"],  # inverted: lower is better
+            latest["compile_time_avg_s"]
+        ) if latest and prev and latest["compile_time_avg_s"] > 0 else None
+
+        latency_delta = fmt_delta(
+            prev["helion_latency_avg_ms"],  # inverted: lower is better
+            latest["helion_latency_avg_ms"]
+        ) if latest and prev and latest["helion_latency_avg_ms"] > 0 else None
+
+        # Classification — prefer latency (lower is better), fall back to speedup
+        status = "unchanged"
+        if latency_delta is not None:
+            if latency_delta > 10:
+                status = "improved"
+            elif latency_delta < -10:
+                status = "regressed"
+        elif speedup_delta is not None:
+            if speedup_delta > 10:
+                status = "improved"
+            elif speedup_delta < -10:
+                status = "regressed"
+
+        # Accuracy check
+        acc_failures = []
+        if latest and latest["per_shape"]["helion_accuracy"]:
+            for i, a in enumerate(latest["per_shape"]["helion_accuracy"]):
+                if a < 1.0:
+                    shapes = latest["per_shape"]["shapes"]
+                    shape_name = shapes[i] if i < len(shapes) else f"shape #{i}"
+                    acc_failures.append(shape_name)
+
+        summary.append({
+            "kernel": entry["kernel"],
+            "platform": entry["platform"],
+            "platform_short": entry["platform_short"],
+            "status": status,
+            "accuracy_failures": acc_failures,
+            # Latest values
+            "helion_speedup_geomean": latest["helion_speedup_geomean"] if latest else 0,
+            "triton_speedup_geomean": latest["triton_speedup_geomean"] if latest else 0,
+            "torch_compile_speedup_geomean": latest["torch_compile_speedup_geomean"] if latest else 0,
+            "compile_time_avg_s": latest["compile_time_avg_s"] if latest else 0,
+            "helion_latency_avg_ms": latest["helion_latency_avg_ms"] if latest else 0,
+            # Deltas vs previous run
+            "speedup_delta_pct": speedup_delta,
+            "compile_delta_pct": compile_delta,
+            "latency_delta_pct": latency_delta,
+            # Full history for sparklines and detail views
+            "history": history,
+        })
+
+    # Compute overall stats
+    platforms = sorted(set(s["platform"] for s in summary))
+    platform_shorts = sorted(set(s["platform_short"] for s in summary))
+    unique_kernels = sorted(set(s["kernel"] for s in summary))
+
+    improved_count = sum(1 for s in summary if s["status"] == "improved")
+    regressed_count = sum(1 for s in summary if s["status"] == "regressed")
+    total_acc_failures = sum(len(s["accuracy_failures"]) for s in summary)
+
+    overall_helion_gm = geo_mean([s["helion_speedup_geomean"] for s in summary if s["helion_speedup_geomean"] > 0])
+    overall_triton_gm = geo_mean([s["triton_speedup_geomean"] for s in summary if s["triton_speedup_geomean"] > 0])
+    overall_tc_gm = geo_mean([s["torch_compile_speedup_geomean"] for s in summary if s["torch_compile_speedup_geomean"] > 0])
+    helion_wins = sum(1 for s in summary if s["helion_speedup_geomean"] > max(s["triton_speedup_geomean"], s["torch_compile_speedup_geomean"]))
+
+    latest_run = runs_meta_sorted[-1] if runs_meta_sorted else {}
+
+    return {
+        "generated_at": runs[-1]["date"] if runs else "",
+        "latest_run": latest_run,
+        "runs": [{k: v for k, v in r.items() if k != "kernels"} for r in runs],
+        "platforms": platforms,
+        "platform_shorts": platform_shorts,
+        "unique_kernels": unique_kernels,
+        "stats": {
+            "total_kernels": len(unique_kernels),
+            "total_combos": len(summary),
+            "num_platforms": len(platforms),
+            "improved_count": improved_count,
+            "regressed_count": regressed_count,
+            "unchanged_count": len(summary) - improved_count - regressed_count,
+            "accuracy_failures": total_acc_failures,
+            "helion_geomean": round(overall_helion_gm, 4),
+            "triton_geomean": round(overall_triton_gm, 4),
+            "torch_compile_geomean": round(overall_tc_gm, 4),
+            "helion_wins": helion_wins,
+        },
+        "summary": summary,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Process Helion benchmarks for dashboard")
+    parser.add_argument("--cache-dir", required=True, help="Directory containing run subdirectories")
+    parser.add_argument("--output", required=True, help="Output JSON file path")
+    parser.add_argument("--runs-meta", required=True, help="JSON file with run metadata (run_id, sha, date, branch)")
+    parser.add_argument("--existing-data", default=None, help="Previous dashboard-data.json to merge with (for incremental updates)")
+    args = parser.parse_args()
+
+    with open(args.runs_meta) as f:
+        runs_meta = json.load(f)
+
+    existing_data = None
+    if args.existing_data:
+        try:
+            with open(args.existing_data) as f:
+                existing_data = json.load(f)
+            print(f"Loaded existing data: {len(existing_data.get('runs', []))} runs")
+        except (json.JSONDecodeError, OSError, KeyError):
+            print("No valid existing data found, building from scratch")
+
+    data = build_dashboard_data(args.cache_dir, runs_meta, existing_data)
+
+    with open(args.output, "w") as f:
+        json.dump(data, f, indent=2)
+
+    stats = data["stats"]
+    print(f"Dashboard data written to {args.output}")
+    print(f"  {stats['total_combos']} kernel/platform combos across {stats['num_platforms']} platforms")
+    print(f"  {len(data['runs'])} runs")
+    print(f"  {stats['improved_count']} improved, {stats['regressed_count']} regressed, {stats['unchanged_count']} unchanged")
+    print(f"  Helion geomean: {stats['helion_geomean']}x, wins: {stats['helion_wins']}/{stats['total_combos']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -193,7 +193,7 @@ jobs:
             # Run again with cache and record results
             ${{ inputs.env-vars }} HELION_PRINT_OUTPUT_CODE=1 HELION_ASSERT_CACHE_HIT=1 python benchmarks/run.py \
                 --op $kernel \
-                --metrics speedup,accuracy \
+                --metrics speedup,accuracy,latency \
                 --measure-compile-time \
                 --latency-measure-mode triton_do_bench \
                 --cudagraph \

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -367,6 +367,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_add-accuracy": "torch_compile_accuracy",
         "helion_add-speedup": "helion_speedup",
         "helion_add-accuracy": "helion_accuracy",
+        "helion_add-latency": "helion_latency_ms",
     },
     "vector_exp": {
         "torch_exp": "baseline",
@@ -376,6 +377,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_exp-accuracy": "torch_compile_accuracy",
         "helion_exp_tritonbench-speedup": "helion_speedup",
         "helion_exp_tritonbench-accuracy": "helion_accuracy",
+        "helion_exp_tritonbench-latency": "helion_latency_ms",
     },
     "sum": {
         "torch_sum": "baseline",
@@ -385,6 +387,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_sum-accuracy": "torch_compile_accuracy",
         "helion_sum_tritonbench-speedup": "helion_speedup",
         "helion_sum_tritonbench-accuracy": "helion_accuracy",
+        "helion_sum_tritonbench-latency": "helion_latency_ms",
     },
     "layer_norm": {
         "torch_layer_norm": "baseline",
@@ -394,6 +397,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_layer_norm-accuracy": "torch_compile_accuracy",
         "helion_layer_norm_tritonbench-speedup": "helion_speedup",
         "helion_layer_norm_tritonbench-accuracy": "helion_accuracy",
+        "helion_layer_norm_tritonbench-latency": "helion_latency_ms",
     },
     "layer_norm-bwd": {
         "torch_layer_norm": "baseline",
@@ -403,6 +407,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_layer_norm-accuracy": "torch_compile_accuracy",
         "helion_layer_norm_tritonbench-speedup": "helion_speedup",
         "helion_layer_norm_tritonbench-accuracy": "helion_accuracy",
+        "helion_layer_norm_tritonbench-latency": "helion_latency_ms",
     },
     "softmax": {
         "naive_softmax": "baseline",
@@ -412,6 +417,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_softmax-accuracy": "torch_compile_accuracy",
         "helion_softmax_tritonbench-speedup": "helion_speedup",
         "helion_softmax_tritonbench-accuracy": "helion_accuracy",
+        "helion_softmax_tritonbench-latency": "helion_latency_ms",
     },
     "softmax-bwd": {
         "naive_softmax": "baseline",
@@ -421,6 +427,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_softmax-accuracy": "torch_compile_accuracy",
         "helion_softmax_tritonbench-speedup": "helion_speedup",
         "helion_softmax_tritonbench-accuracy": "helion_accuracy",
+        "helion_softmax_tritonbench-latency": "helion_latency_ms",
     },
     "rms_norm": {
         "llama_rms": "baseline",
@@ -430,6 +437,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_rms-accuracy": "torch_compile_accuracy",
         "helion_rms_norm_tritonbench-speedup": "helion_speedup",
         "helion_rms_norm_tritonbench-accuracy": "helion_accuracy",
+        "helion_rms_norm_tritonbench-latency": "helion_latency_ms",
     },
     "rms_norm-bwd": {
         "llama_rms": "baseline",
@@ -439,6 +447,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_rms-accuracy": "torch_compile_accuracy",
         "helion_rms_norm_tritonbench-speedup": "helion_speedup",
         "helion_rms_norm_tritonbench-accuracy": "helion_accuracy",
+        "helion_rms_norm_tritonbench-latency": "helion_latency_ms",
     },
     "cross_entropy": {
         "cross_entropy_loss": "baseline",
@@ -448,6 +457,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_cross_entropy_loss-accuracy": "torch_compile_accuracy",
         "helion_cross_entropy-speedup": "helion_speedup",
         "helion_cross_entropy-accuracy": "helion_accuracy",
+        "helion_cross_entropy-latency": "helion_latency_ms",
     },
     "geglu": {
         "torch_geglu": "baseline",
@@ -457,6 +467,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_geglu-accuracy": "torch_compile_accuracy",
         "helion_geglu_tritonbench-speedup": "helion_speedup",
         "helion_geglu_tritonbench-accuracy": "helion_accuracy",
+        "helion_geglu_tritonbench-latency": "helion_latency_ms",
     },
     "swiglu": {
         "torch_swiglu": "baseline",
@@ -466,6 +477,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_swiglu-accuracy": "torch_compile_accuracy",
         "helion_swiglu_tritonbench-speedup": "helion_speedup",
         "helion_swiglu_tritonbench-accuracy": "helion_accuracy",
+        "helion_swiglu_tritonbench-latency": "helion_latency_ms",
     },
     "swiglu-bwd": {
         "torch_swiglu": "baseline",
@@ -475,6 +487,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_swiglu-accuracy": "torch_compile_accuracy",
         "helion_swiglu_tritonbench-speedup": "helion_speedup",
         "helion_swiglu_tritonbench-accuracy": "helion_accuracy",
+        "helion_swiglu_tritonbench-latency": "helion_latency_ms",
     },
     "jsd": {
         "torch_jsd": "baseline",
@@ -484,6 +497,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_jsd-accuracy": "torch_compile_accuracy",
         "helion_jsd_tritonbench-speedup": "helion_speedup",
         "helion_jsd_tritonbench-accuracy": "helion_accuracy",
+        "helion_jsd_tritonbench-latency": "helion_latency_ms",
     },
     "welford": {
         "eager_layer_norm": "baseline",
@@ -493,6 +507,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_welford-accuracy": "torch_compile_accuracy",
         "helion_welford-speedup": "helion_speedup",
         "helion_welford-accuracy": "helion_accuracy",
+        "helion_welford-latency": "helion_latency_ms",
     },
     "kl_div": {
         "torch_kl_div": "baseline",
@@ -502,6 +517,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_kl_div-accuracy": "torch_compile_accuracy",
         "helion_kl_div_tritonbench-speedup": "helion_speedup",
         "helion_kl_div_tritonbench-accuracy": "helion_accuracy",
+        "helion_kl_div_tritonbench-latency": "helion_latency_ms",
     },
     "gather_gemv": {
         "eager_gather_gemv": "baseline",
@@ -511,6 +527,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_gather_gemv-accuracy": "torch_compile_accuracy",
         "helion_gather_gemv_tritonbench-speedup": "helion_speedup",
         "helion_gather_gemv_tritonbench-accuracy": "helion_accuracy",
+        "helion_gather_gemv_tritonbench-latency": "helion_latency_ms",
     },
     "int4_gemm": {
         "preprocessed_eager_int4_gemm": "baseline",
@@ -520,6 +537,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "preprocessed_torch_compile_int4_gemm-accuracy": "torch_compile_accuracy",
         "helion_int4_gemm_tritonbench-speedup": "helion_speedup",
         "helion_int4_gemm_tritonbench-accuracy": "helion_accuracy",
+        "helion_int4_gemm_tritonbench-latency": "helion_latency_ms",
     },
     "grouped_gemm": {
         "aten_grouped_mm": "baseline",
@@ -529,12 +547,14 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_grouped_gemm-accuracy": "torch_compile_accuracy",
         "helion_grouped_gemm_jagged_persistent_tritonbench-speedup": "helion_speedup",
         "helion_grouped_gemm_jagged_persistent_tritonbench-accuracy": "helion_accuracy",
+        "helion_grouped_gemm_jagged_persistent_tritonbench-latency": "helion_latency_ms",
     },
     "jagged_layer_norm": {
         "torch_compile_nested_tensor_integration-speedup": "torch_compile_speedup",
         "torch_compile_nested_tensor_integration-accuracy": "torch_compile_accuracy",
         "helion_jagged_layer_norm_tritonbench-speedup": "helion_speedup",
         "helion_jagged_layer_norm_tritonbench-accuracy": "helion_accuracy",
+        "helion_jagged_layer_norm_tritonbench-latency": "helion_latency_ms",
     },
     "jagged_sum": {
         "triton_jagged_sum_no_pad_simple_fused-speedup": "triton_speedup",
@@ -543,6 +563,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_nested_tensor_integration-accuracy": "torch_compile_accuracy",
         "helion_jagged_sum_tritonbench-speedup": "helion_speedup",
         "helion_jagged_sum_tritonbench-accuracy": "helion_accuracy",
+        "helion_jagged_sum_tritonbench-latency": "helion_latency_ms",
     },
     "addmm": {
         "aten_addmm": "baseline",
@@ -552,6 +573,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "pt2_addmm_maxautotune-accuracy": "torch_compile_accuracy",
         "helion_addmm_tritonbench-speedup": "helion_speedup",
         "helion_addmm_tritonbench-accuracy": "helion_accuracy",
+        "helion_addmm_tritonbench-latency": "helion_latency_ms",
     },
     "addmm-bwd": {
         "aten_addmm": "baseline",
@@ -561,6 +583,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "pt2_addmm_maxautotune-accuracy": "torch_compile_accuracy",
         "helion_addmm_tritonbench-speedup": "helion_speedup",
         "helion_addmm_tritonbench-accuracy": "helion_accuracy",
+        "helion_addmm_tritonbench-latency": "helion_latency_ms",
     },
     # "ragged_attention": {
     #     "triton_ragged_attention-speedup": "triton_speedup",
@@ -578,6 +601,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_embedding-accuracy": "torch_compile_accuracy",
         "helion_embedding_tritonbench-speedup": "helion_speedup",
         "helion_embedding_tritonbench-accuracy": "helion_accuracy",
+        "helion_embedding_tritonbench-latency": "helion_latency_ms",
     },
     "jagged_mean": {
         "torch_jagged_mean_torch_sum": "baseline",
@@ -587,6 +611,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_jagged_mean_torch_sum-accuracy": "torch_compile_accuracy",
         "helion_jagged_mean_tritonbench-speedup": "helion_speedup",
         "helion_jagged_mean_tritonbench-accuracy": "helion_accuracy",
+        "helion_jagged_mean_tritonbench-latency": "helion_latency_ms",
     },
     "flash_attention": {
         "aten": "baseline",
@@ -596,6 +621,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "flex_attention-accuracy": "torch_compile_accuracy",
         "helion_attention-speedup": "helion_speedup",
         "helion_attention-accuracy": "helion_accuracy",
+        "helion_attention-latency": "helion_latency_ms",
     },
     "fp8_attention": {
         "triton_flash_v2": "baseline",
@@ -603,6 +629,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "triton_flash_v2_ws-accuracy": "triton_accuracy",
         "helion_fp8_attention_tritonbench-speedup": "helion_speedup",
         "helion_fp8_attention_tritonbench-accuracy": "helion_accuracy",
+        "helion_fp8_attention_tritonbench-latency": "helion_latency_ms",
     },
     "jagged_softmax": {
         "torch_jagged_softmax_torch_sum": "baseline",
@@ -612,6 +639,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_jagged_softmax_torch_sum-accuracy": "torch_compile_accuracy",
         "helion_jagged_softmax_tritonbench-speedup": "helion_speedup",
         "helion_jagged_softmax_tritonbench-accuracy": "helion_accuracy",
+        "helion_jagged_softmax_tritonbench-latency": "helion_latency_ms",
     },
     "fused_linear_jsd": {
         "torch_lm_head_jsd": "baseline",
@@ -621,6 +649,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_fused_linear_jsd-accuracy": "torch_compile_accuracy",
         "helion_fused_linear_jsd_fwd_tritonbench-speedup": "helion_speedup",
         "helion_fused_linear_jsd_fwd_tritonbench-accuracy": "helion_accuracy",
+        "helion_fused_linear_jsd_fwd_tritonbench-latency": "helion_latency_ms",
     },
     "gemm": {
         "aten_matmul": "baseline",
@@ -630,6 +659,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "pt2_triton_matmul-accuracy": "torch_compile_accuracy",
         "helion_matmul_tritonbench-speedup": "helion_speedup",
         "helion_matmul_tritonbench-accuracy": "helion_accuracy",
+        "helion_matmul_tritonbench-latency": "helion_latency_ms",
     },
     "gemm-bwd": {
         "aten_matmul": "baseline",
@@ -639,6 +669,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "pt2_triton_matmul-accuracy": "torch_compile_accuracy",
         "helion_matmul_tritonbench-speedup": "helion_speedup",
         "helion_matmul_tritonbench-accuracy": "helion_accuracy",
+        "helion_matmul_tritonbench-latency": "helion_latency_ms",
     },
     "fp8_gemm": {
         "torch_fp8_gemm": "baseline",
@@ -648,6 +679,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         f"{'blackwell_pt2' if IS_B200 else 'pt2'}_fp8_gemm-accuracy": "torch_compile_accuracy",
         "helion_fp8_gemm_tritonbench-speedup": "helion_speedup",
         "helion_fp8_gemm_tritonbench-accuracy": "helion_accuracy",
+        "helion_fp8_gemm_tritonbench-latency": "helion_latency_ms",
     },
     "low_mem_dropout": {
         "seeded_dropout-accuracy": "triton_accuracy",
@@ -656,6 +688,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_dropout-speedup": "torch_compile_speedup",
         "helion_low_mem_dropout_tritonbench-accuracy": "helion_accuracy",
         "helion_low_mem_dropout_tritonbench-speedup": "helion_speedup",
+        "helion_low_mem_dropout_tritonbench-latency": "helion_latency_ms",
     },
     "bf16xint16_gemm": {
         "bf16xbf16": "baseline",
@@ -665,6 +698,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "torch_compile_bf16xbf16-accuracy": "torch_compile_accuracy",
         "helion_bf16xint16_gemm_tritonbench-speedup": "helion_speedup",
         "helion_bf16xint16_gemm_tritonbench-accuracy": "helion_accuracy",
+        "helion_bf16xint16_gemm_tritonbench-latency": "helion_latency_ms",
     },
     "blackwell_attentions": {
         "aten": "baseline",
@@ -674,6 +708,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "flex_attention-accuracy": "torch_compile_accuracy",
         "helion_blackwell_attention_tritonbench-speedup": "helion_speedup",
         "helion_blackwell_attention_tritonbench-accuracy": "helion_accuracy",
+        "helion_blackwell_attention_tritonbench-latency": "helion_latency_ms",
     },
     "mamba2_chunk_scan": {
         "eager": "baseline",
@@ -681,6 +716,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "compile_accuracy": "torch_compile_accuracy",
         "helion_mamba2_chunk_scan_kernel_speedup": "helion_speedup",
         "helion_mamba2_chunk_scan_kernel_accuracy": "helion_accuracy",
+        "helion_mamba2_chunk_scan_kernel_latency": "helion_latency_ms",
     },
     "mamba2_chunk_state": {
         "eager": "baseline",
@@ -688,6 +724,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "compile_accuracy": "torch_compile_accuracy",
         "helion_mamba2_chunk_state_kernel_speedup": "helion_speedup",
         "helion_mamba2_chunk_state_kernel_accuracy": "helion_accuracy",
+        "helion_mamba2_chunk_state_kernel_latency": "helion_latency_ms",
     },
     "gdn_fwd_h": {
         "eager": "baseline",
@@ -695,6 +732,7 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "compile_accuracy": "torch_compile_accuracy",
         "helion_gdn_fwd_h_speedup": "helion_speedup",
         "helion_gdn_fwd_h_accuracy": "helion_accuracy",
+        "helion_gdn_fwd_h_latency": "helion_latency_ms",
     },
 }
 


### PR DESCRIPTION
New perf dashboard that allows us to easily see CI failures, perf and compile time improvements/regressions and track them over time. With agents, it's easier to build our own dashboard and change it as we need, rather than relying on someone else. This will be using Github Pages and should be deployed at pytorch.github.io/helion/dashboard/ (same domain as our documentation). 

The improvements I wanted to make to the dashboard:
1. CI failures: Some kernels don't show up on the perf dashboard and it's hard to tell why (runners down? kernels themselves failing?). For Helion issues, we should detect them. Note it currently only detects failures from the nightly benchmarking runs - the unit test failures (whenever main fails) should be added here in the future.
2. If some kernels improved/regressed in perf (>10%), we should be able to detect them easily. 
3. In addition to speedup, we should be tracking kernel latency as the measure for Helion perf, as the baseline changes.  We want to track how perf and compile time change over time. 
4. Better intuitive visualization to be able to see things easier. 

The new dashboard looks like this with 3 tabs:
Overview tab give a high-level picture of CI failures, performance improvements/regressions, with a graph of how perf changed over time:
<img width="1663" height="799" alt="image" src="https://github.com/user-attachments/assets/4d6278ae-174a-4fc2-a2e9-e20a29c5d466" />
The boxes are clickable, so you can see more data. If you click on "REGRESSED PERF" 
<img width="1197" height="204" alt="image" src="https://github.com/user-attachments/assets/bc91bd5b-ae3c-4f56-8556-1a190918bf24" />
If you click on one of the kernels:
<img width="1196" height="718" alt="image" src="https://github.com/user-attachments/assets/770c5ca8-f6dc-4f66-90c7-06d36508d06c" />


Speedup tab showing current geomean speedups, how they changed over time, speedups of individual kernels and which case performs the best:
<img width="1665" height="796" alt="image" src="https://github.com/user-attachments/assets/ae9df799-81d3-4061-b838-57642f46b0cc" />
<img width="1633" height="573" alt="image" src="https://github.com/user-attachments/assets/4375b5d5-e93d-43d7-8321-8dc357850736" />

Compare tab allowing you to compare latency, speedup, compile time data from different branches/commits:
<img width="1665" height="796" alt="image" src="https://github.com/user-attachments/assets/52f7ba9f-33e2-4018-8ce2-23bcaecbd41a" />

In terms of implementation:
- Added interactive dashboard (index.html) to show CI and benchmarking data as shown in the screenshots below. 
- Added process_for_dashboard.py to aggregate benchmark artifacts into dashboard-ready JSON with incremental updates (only fetches new runs)

There's multiple ways to deploy this together with the docs build, which I will figure out if people like the new dashboard. 