### PR TITLE
[Pallas] Validate pallas_loop_type

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1581,7 +1581,14 @@ class PallasBackend(Backend):
 
     def build_launcher_name(self, config: Config) -> str:
         """Return the launcher name to use based on ``pallas_loop_type``."""
+        from ..autotuner.config_spec import VALID_PALLAS_LOOP_TYPES
+
         pallas_loop_type = config.get("pallas_loop_type", "default")
+        if pallas_loop_type not in VALID_PALLAS_LOOP_TYPES:
+            raise ValueError(
+                f"Invalid pallas_loop_type {pallas_loop_type!r}. "
+                f"Expected one of {VALID_PALLAS_LOOP_TYPES}."
+            )
         if pallas_loop_type == "emit_pipeline":
             return "_default_pallas_pipeline_launcher"
         if pallas_loop_type == "fori_loop":
@@ -1591,13 +1598,13 @@ class PallasBackend(Backend):
     def get_launcher_name(self) -> str:
         """Return the launcher name based on the current config."""
         from .device_function import DeviceFunction
+        from .device_function import NoCurrentFunction
 
         try:
             device_fn = DeviceFunction.current()
-            config = device_fn.config
-            return self.build_launcher_name(config)
-        except Exception:
+        except NoCurrentFunction:
             return self.default_launcher_name
+        return self.build_launcher_name(device_fn.config)
 
     def pre_codegen(
         self,

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -507,6 +507,20 @@ class TestPallas(TestCase):
         self.assertNotIn("pltpu.emit_pipeline", code)
         torch.testing.assert_close(result, args[0] + args[1])
 
+    def test_invalid_pallas_loop_type_raises(self) -> None:
+        """Invalid pallas_loop_type values must raise instead of silently falling back."""
+        args = (
+            torch.randn(64, 128, device=DEVICE, dtype=torch.float32),
+            torch.randn(64, 128, device=DEVICE, dtype=torch.float32),
+        )
+        with self.assertRaisesRegex(ValueError, "Invalid pallas_loop_type 'pipeline'"):
+            code_and_output(
+                pallas_inner_loop_add,
+                args,
+                block_sizes=[8, 128],
+                pallas_loop_type="pipeline",
+            )
+
     def test_attention_default_fp32(self) -> None:
         """Test attention with default (for-loop) inner loop."""
         query = torch.randn(1, 4, 32, 64, dtype=torch.float32, device=DEVICE)


### PR DESCRIPTION
The silent fallback hid typos and stale configs (e.g. `pallas_loop_type='pipeline'` instead of `'emit_pipeline'`) by quietly running the default launcher.