### PR TITLE
[Pallas] Fix test_squeeze_slice_access to use code_and_output

### DIFF
--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1009,9 +1009,6 @@ class TestPallas(TestCase):
         self.assertIn("pl.ds(", code)
         torch.testing.assert_close(result, args[0] + args[1])
 
-    @xfailIfPallas(
-        "No config values to tune because all block sizes are fixed and Pallas no longer tunes reduction loops"
-    )
     def test_squeeze_slice_access(self) -> None:
         """Test for the [None, :] indexing pattern (subscript index for slice >= tensor_ndim)"""
 
@@ -1028,7 +1025,7 @@ class TestPallas(TestCase):
         M = 128
         x = torch.randn(N, device=DEVICE, dtype=torch.float32)
         y = torch.randn(M, device=DEVICE, dtype=torch.float32)
-        result = fn(x, y)
+        code, result = code_and_output(fn, (x, y))
         expected = (x[:, None] < y[None, :]).to(torch.float32)
         torch.testing.assert_close(result, expected)
 


### PR DESCRIPTION
## Summary
- Fix `test_squeeze_slice_access` which was calling the kernel directly (`fn(x, y)`), triggering autotuning with nothing to tune (all block sizes fixed, Pallas doesn't tune reduction loops)