### PR TITLE
[TPU][Pallas] Enable TPU support and fix benchmarking for AOT compilation example

### DIFF
--- a/examples/aot_compile_example.py
+++ b/examples/aot_compile_example.py
@@ -64,8 +64,8 @@ def benchmark_add_2d() -> None:
     print(f"{'Shape':>16} {'Time (ms)':>12} {'GB/s':>10}")
     print("-" * 40)
     for m, n in shapes:
-        x = torch.randn(m, n, device=DEVICE, dtype=torch.float16)
-        y = torch.randn(m, n, device=DEVICE, dtype=torch.float16)
+        x = torch.randn(m, n, device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn(m, n, device=DEVICE, dtype=torch.bfloat16)
         add_2d(x, y)  # warmup
         time_ms = do_bench(lambda x=x, y=y: add_2d(x, y))
         assert isinstance(time_ms, float)

--- a/examples/aot_compile_example.py
+++ b/examples/aot_compile_example.py
@@ -30,9 +30,9 @@ import argparse
 import os
 
 import torch
-from triton.testing import do_bench
 
 from helion._testing import DEVICE
+from helion._testing import do_bench
 import helion.experimental
 import helion.language as hl
 

--- a/examples/aot_compile_example.py
+++ b/examples/aot_compile_example.py
@@ -27,6 +27,7 @@ The standalone file is a drop-in replacement::
 from __future__ import annotations
 
 import argparse
+from functools import partial
 import os
 
 import torch
@@ -67,7 +68,7 @@ def benchmark_add_2d() -> None:
         x = torch.randn(m, n, device=DEVICE, dtype=torch.bfloat16)
         y = torch.randn(m, n, device=DEVICE, dtype=torch.bfloat16)
         add_2d(x, y)  # warmup
-        time_ms = do_bench(lambda x=x, y=y: add_2d(x, y))
+        time_ms = do_bench(partial(add_2d, x, y))
         assert isinstance(time_ms, float)
         total_bytes = x.numel() * x.element_size() * 3  # 2 reads + 1 write
         gbps = total_bytes / time_ms * 1e-6

--- a/helion/autotuner/aot_cache.py
+++ b/helion/autotuner/aot_cache.py
@@ -177,8 +177,24 @@ def get_hardware_info(device: torch.device | None = None) -> HardwareInfo:
                 compute_capability=props.gcnArchName,
             )
 
+    # TPU / Pallas path
+    try:
+        import jax
+
+        tpu_devices = [d for d in jax.devices() if d.platform == "tpu"]
+        if tpu_devices:
+            first_tpu = tpu_devices[0]
+            return HardwareInfo(
+                device_kind="tpu",
+                hardware_name=first_tpu.device_kind,
+                runtime_version=jax.__version__,
+                compute_capability=first_tpu.device_kind,
+            )
+    except ImportError:
+        pass
+
     raise RuntimeError(
-        "No supported GPU device found. Helion requires CUDA, ROCm, or XPU."
+        "No supported GPU or TPU device found. Helion requires CUDA, ROCm, XPU, or TPU."
     )
 
 


### PR DESCRIPTION
This PR enables the AOT compilation example (aot_compile_example.py) to compile and benchmark successfully on TPU environments.

Changes included:

- Hardware Detection: Updated `get_hardware_info` in `helion/autotuner/aot_cache.py` to detect TPUs via JAX, preventing it from incorrectly raising a "No supported GPU device found" error on TPU machines.
- Cross-Platform dtype (`bfloat16`): Switched the default `dtype` in `examples/aot_compile_example.py` from `torch.float16` to `torch.bfloat16`. The TPU Vector ALU requires `bfloat16` for native packing and math (forcing `float16` resulted in an Invalid vector type for load error during Mosaic compilation). Modern NVIDIA (Ampere+) and AMD (MI200+) GPUs also natively support and heavily optimize for `bfloat16`. This brings `aot_compile_example.py` in line with established conventions across the repository, as many modern kernels already default to `bfloat16` (e.g., `jagged_hstu_attn.py`, `grpo_loss.py`, `add.py`).
- Benchmarking Fix: Replaced the Triton-specific `do_bench` import with the backend-agnostic `do_bench` wrapper from `helion._testing` to allow the timing loop to succeed natively on TPUs where NVIDIA/AMD Triton drivers are unavailable.

After this PR:
```
[37s] Code of selected kernel: /tmp/torchinductor_ymu_google_com/s2/cs2h2blqaamu3hmsjsztt23ssqlsla5z46xkyha3dv3cs22fuqxr.py
    (4096, 4096)       0.3014     334.01
```