### PR TITLE
[Pallas] Host-side padding for non-divisible pl.ds() dimensions

### DIFF
--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -938,6 +938,13 @@ def _pallas_dot(ctx: LoweringContext, node: Node, with_acc: bool) -> ast.AST:
     need_f32_acc = _needs_f32_accumulator(lhs_dtype, rhs_dtype)
     out_dtype = node.meta["val"].dtype if "val" in node.meta else None
 
+    # Record matmul K-dim for host-side padding.  This covers all loop types
+    # (default, fori_loop DMA, emit_pipeline) because it traces from the
+    # matmul operands back to the source load() tensors.
+    from ..language.memory_ops import _record_pad_info_from_matmul
+
+    _record_pad_info_from_matmul(lhs_node_arg, rhs_node_arg)
+
     return _emit_pallas_matmul(
         lhs,
         rhs,

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1558,6 +1558,104 @@ class PallasBackend(Backend):
             result.append((tuple(block_shape), tuple(grid_dims)))
         return result
 
+    def _compute_pad_info(
+        self,
+        sorted_args: list[Argument] | None,
+        config: Config,
+    ) -> list[tuple[int, int, int]] | None:
+        """Compute per-tensor padding for pl.ds() dims with non-divisible block sizes.
+
+        Merges two sources:
+        1. Codegen-level ``pallas_pad_info`` — dims that use pl.ds() in the kernel body
+        2. Matmul K ``pallas_matmul_k_block_ids`` — K-dims from matmul lowering
+
+        Returns ``[(arg_index, tensor_dim, pad_amount), ...]`` or ``None``.
+        """
+        if sorted_args is None:
+            return None
+
+        from .device_function import DeviceFunction
+
+        device_fn = DeviceFunction.current()
+        if not device_fn.pallas_pad_info and not device_fn.pallas_matmul_k_block_ids:
+            return None
+
+        result = self._collect_codegen_pad_dims(sorted_args, config)
+        result += self._collect_matmul_k_pad_dims(sorted_args, config, result)
+        return result or None
+
+    def _pad_amount_for_block(self, block_id: int, config: Config) -> int | None:
+        """Return the padding needed for a block_id, or None if divisible."""
+        from .compile_environment import CompileEnvironment
+
+        env = CompileEnvironment.current()
+        bsi = env.block_sizes[block_id]
+        bs = bsi.from_config(config)
+        if not isinstance(bs, int) or bs <= 1:
+            return None
+        try:
+            numel = int(bsi.numel)
+        except (TypeError, ValueError):
+            return None
+        pad = (-numel) % bs
+        return pad if pad > 0 else None
+
+    def _collect_codegen_pad_dims(
+        self,
+        sorted_args: list[Argument],
+        config: Config,
+    ) -> list[tuple[int, int, int]]:
+        """Collect padding from codegen-level pl.ds() tracking."""
+        from .device_function import DeviceFunction
+        from .device_function import TensorArg
+
+        device_fn = DeviceFunction.current()
+        result: list[tuple[int, int, int]] = []
+        for i, arg in enumerate(sorted_args):
+            if not isinstance(arg, TensorArg):
+                continue
+            dims_info = device_fn.pallas_pad_info.get(id(arg.fake_value))
+            if dims_info is not None:
+                for dim, block_id in dims_info.items():
+                    pad = self._pad_amount_for_block(block_id, config)
+                    if pad is not None:
+                        result.append((i, dim, pad))
+        return result
+
+    def _collect_matmul_k_pad_dims(
+        self,
+        sorted_args: list[Argument],
+        config: Config,
+        already_covered: list[tuple[int, int, int]],
+    ) -> list[tuple[int, int, int]]:
+        """Collect padding from matmul K block_ids (fori_loop DMA, emit_pipeline)."""
+        from .device_function import DeviceFunction
+        from .device_function import TensorArg
+
+        device_fn = DeviceFunction.current()
+        if not device_fn.pallas_matmul_k_block_ids:
+            return []
+
+        covered = {(arg_idx, dim) for arg_idx, dim, _ in already_covered}
+        result: list[tuple[int, int, int]] = []
+        for i, arg in enumerate(sorted_args):
+            if not isinstance(arg, TensorArg):
+                continue
+            dim_tilings = device_fn.pallas_tensor_dim_tilings.get(
+                id(arg.fake_value)
+            )
+            if dim_tilings is None:
+                continue
+            for d, dt in enumerate(dim_tilings):
+                if (i, d) in covered:
+                    continue
+                for bid in dt.block_ids:
+                    if bid in device_fn.pallas_matmul_k_block_ids:
+                        pad = self._pad_amount_for_block(bid, config)
+                        if pad is not None:
+                            result.append((i, d, pad))
+        return result
+
     def build_launcher_args(
         self,
         args: list[str],
@@ -1653,6 +1751,10 @@ class PallasBackend(Backend):
             if has_rng_ops:
                 block_spec_info.append(None)  # RNG seed buffer is untiled
             launcher_args.append(f"_block_spec_info={block_spec_info!r}")
+
+        pad_info = self._compute_pad_info(sorted_args, config)
+        if pad_info:
+            launcher_args.append(f"_ds_pad_dims={pad_info!r}")
 
         from .device_function import PallasMemorySpace
 

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -328,6 +328,13 @@ class DeviceFunction:
         # dict would then need to support multiple entries per tensor
         # or the tensor would get distinct arg IDs per memory space.
         self.pallas_memory_space: dict[int, PallasMemorySpace] = {}
+        # Pallas: id(fake_tensor) → {dim: block_id} for dims using pl.ds()
+        # that may need host-side padding when block size doesn't divide dim.
+        self.pallas_pad_info: dict[int, dict[int, int]] = {}
+        # Pallas: K block_ids from matmul ops — used to pad all tensors
+        # with those block_ids even when pl.ds() isn't in the kernel body
+        # (e.g., fori_loop DMA, emit_pipeline).
+        self.pallas_matmul_k_block_ids: set[int] = set()
 
     def allocate_store_index(self) -> int:
         """Bump store counters and return the indexing strategy slot."""

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -112,6 +112,33 @@ def _generated_index_code(
     pipeline_block_ids: set[int],
 ) -> str:
     """Generate index code based on the indexing pattern."""
+    result = _dispatch_index_code(
+        pattern, idx, state, tensor, subscript_index, tensor_dim,
+        in_pipeline, pipeline_block_ids,
+    )
+
+    # Record dims using pl.ds() for host-side padding of non-divisible blocks.
+    if "pl.ds" in result:
+        from helion.language.memory_ops import _record_pad_info
+
+        block_id = _get_pattern_block_id(pattern, tensor, tensor_dim)
+        assert block_id is not None
+        _record_pad_info(state, tensor, tensor_dim, block_id)
+
+    return result
+
+
+def _dispatch_index_code(
+    pattern: object,
+    idx: object,
+    state: CodegenState,
+    tensor: torch.Tensor,
+    subscript_index: int,
+    tensor_dim: int,
+    in_pipeline: bool,
+    pipeline_block_ids: set[int],
+) -> str:
+    """Dispatch to the pattern-specific index code generator."""
     from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
     from helion._compiler.pallas.plan_tiling import ArbitrarySlicePattern
     from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
@@ -144,6 +171,30 @@ def _generated_index_code(
         f"Pattern: {pattern}, idx: {idx}, subscript_index: {subscript_index}. "
         f"All indexing patterns should be handled by the tiling analysis system."
     )
+
+
+def _get_pattern_block_id(
+    pattern: object, tensor: torch.Tensor, tensor_dim: int
+) -> int | None:
+    """Extract the block_id from an indexing pattern, if any."""
+    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
+    from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
+    from helion._compiler.pallas.plan_tiling import TilePattern
+
+    if isinstance(
+        pattern,
+        (TilePattern, TileIndexWithOffsetPattern, TileBeginWithOffsetPattern),
+    ):
+        return pattern.block_id
+    from helion._compiler.pallas.plan_tiling import ArbitrarySlicePattern
+
+    if isinstance(pattern, ArbitrarySlicePattern):
+        from helion._compiler.compile_environment import CompileEnvironment
+
+        return CompileEnvironment.current().resolve_block_id(
+            tensor.shape[tensor_dim]
+        )
+    return None
 
 
 def _tile_pattern_code(

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -159,6 +159,43 @@ def _(state: CodegenState) -> ast.AST:
     raise NotImplementedError(f"Cannot store to type: {type(tensor)}")
 
 
+def _record_pad_info(
+    state: CodegenState,
+    tensor: torch.Tensor,
+    tensor_dim: int,
+    block_id: int,
+) -> None:
+    """Record that a tensor dimension uses pl.ds() and may need host-side padding."""
+    pad_info = state.device_function.pallas_pad_info
+    tensor_id = id(tensor)
+    if tensor_id not in pad_info:
+        pad_info[tensor_id] = {}
+    pad_info[tensor_id][tensor_dim] = block_id
+
+
+def _record_pad_info_from_matmul(
+    lhs_node: torch.fx.Node,
+    rhs_node: torch.fx.Node,
+) -> None:
+    """Record matmul K block_id for host-side padding.
+
+    Records the K block_id so that _compute_pad_info can pad all tensors
+    with that block_id on the K dimension.  This covers all Pallas loop
+    types including fori_loop DMA and emit_pipeline where the kernel body
+    doesn't go through the normal codegen pl.ds() path.
+    """
+    from .._compiler.compile_environment import CompileEnvironment
+    from .._compiler.device_function import DeviceFunction
+
+    env = CompileEnvironment.current()
+    device_fn = DeviceFunction.current()
+    lhs_val = lhs_node.meta["val"]
+    k_size = lhs_val.size(-1)
+    k_block_id = env.resolve_block_id(k_size)
+    if k_block_id is not None:
+        device_fn.pallas_matmul_k_block_ids.add(k_block_id)
+
+
 def _maybe_get_symbol_origin(idx: object) -> SymbolOrigin | None:
     if not isinstance(idx, torch.SymInt):
         return None

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -740,44 +740,104 @@ def _pallas_invoke_and_return(
     tensor_arg_indices: list[int],
     arg_to_tensor_pos: dict[int, int],
     _output_indices: list[int],
+    _ds_pad_dims: list[tuple[int, int, int]] | None = None,
+    _orig_output_tensors: dict[int, torch.Tensor] | None = None,
 ) -> object:
     """Run the JaxCallable and return output-only results.
 
     Output-only tensors (those not in ``arg_to_tensor_pos``) are not passed
     as pallas_call inputs, so the JaxCallable returns new buffers for them.
     Returns a single tensor, a tuple of tensors, or None.
+
+    When ``_ds_pad_dims`` is provided, also handles:
+    - Copying sliced results back into original (unpadded) in-place output tensors
+    - Slicing padded output-only result tensors back to original shapes
     """
     input_tensors = [
         cast("torch.Tensor", args[i]).contiguous() for i in tensor_arg_indices
     ]
     results = jax_callable(*input_tensors)  # type: ignore[operator]
-    if results is None:
-        return None
-    if not isinstance(results, (tuple, list)):
-        results = (results,)
-    output_only_results = []
-    for out_idx, orig_pos in enumerate(_output_indices):
-        if orig_pos not in arg_to_tensor_pos:
-            result = results[out_idx]
-            if not isinstance(result, torch.Tensor):
-                # Interpret mode: pallas_call returns JAX arrays, convert to torch.
-                # On TPU, JaxCallable returns torch tensors directly.
-                out_tensor = cast("torch.Tensor", args[orig_pos])
-                # Output-only tensors are allocated with ``device='meta'`` to
-                # avoid HBM; fall back to the first real input's device in
-                # interpret mode so the converted tensor lands somewhere real.
-                device = out_tensor.device
-                if device.type == "meta" and tensor_arg_indices:
-                    device = cast("torch.Tensor", args[tensor_arg_indices[0]]).device
-                result = _jax_to_torch(
-                    result,
-                    device=device,
-                    dtype=out_tensor.dtype,
-                )
-            output_only_results.append(result)
+
+    # Collect output-only results
+    output_only_results: list[object] = []
+    if results is not None:
+        if not isinstance(results, (tuple, list)):
+            results = (results,)
+        for out_idx, orig_pos in enumerate(_output_indices):
+            if orig_pos not in arg_to_tensor_pos:
+                result = results[out_idx]
+                if not isinstance(result, torch.Tensor):
+                    out_tensor = cast("torch.Tensor", args[orig_pos])
+                    device = out_tensor.device
+                    if device.type == "meta" and tensor_arg_indices:
+                        device = cast(
+                            "torch.Tensor", args[tensor_arg_indices[0]]
+                        ).device
+                    result = _jax_to_torch(
+                        result, device=device, dtype=out_tensor.dtype
+                    )
+                output_only_results.append(result)
+
+    # Handle padding copy-back and result slicing
+    if _ds_pad_dims:
+        # Copy sliced results back into original in-place output tensors
+        if _orig_output_tensors:
+            pad_by_arg: dict[int, list[tuple[int, int]]] = {}
+            for arg_idx, dim, pad_amount in _ds_pad_dims:
+                pad_by_arg.setdefault(arg_idx, []).append((dim, pad_amount))
+            for arg_idx, orig_tensor in _orig_output_tensors.items():
+                padded = cast("torch.Tensor", args[arg_idx])
+                slices = [slice(None)] * padded.ndim
+                for dim, _pad in pad_by_arg.get(arg_idx, []):
+                    slices[dim] = slice(None, orig_tensor.shape[dim])
+                orig_tensor.copy_(padded[tuple(slices)])
+
+        # Slice padded output-only results back to original shapes
+        if output_only_results:
+            pad_by_arg_: dict[int, list[tuple[int, int]]] = {}
+            for arg_idx, dim, pad_amount in _ds_pad_dims:
+                pad_by_arg_.setdefault(arg_idx, []).append((dim, pad_amount))
+            compacted_idx = 0
+            for orig_pos in _output_indices:
+                if orig_pos not in arg_to_tensor_pos:
+                    pads = pad_by_arg_.get(orig_pos)
+                    if pads and compacted_idx < len(output_only_results):
+                        t = output_only_results[compacted_idx]
+                        if isinstance(t, torch.Tensor):
+                            slices = [slice(None)] * t.ndim
+                            for dim, pad in pads:
+                                slices[dim] = slice(None, t.shape[dim] - pad)
+                            output_only_results[compacted_idx] = t[tuple(slices)]
+                    compacted_idx += 1
+
     if len(output_only_results) == 1:
         return output_only_results[0]
     return tuple(output_only_results) if output_only_results else None
+
+
+def _pallas_apply_ds_padding(
+    args: tuple[object, ...],
+    _output_indices: list[int],
+    _ds_pad_dims: list[tuple[int, int, int]],
+) -> tuple[tuple[object, ...], dict[int, torch.Tensor]]:
+    """Pad tensor args along non-divisible pl.ds() dimensions.
+
+    Returns the padded args tuple and a dict mapping output arg indices
+    to their original (unpadded) tensors for post-call copy-back.
+    """
+    args_list = list(args)
+    orig_output_tensors: dict[int, torch.Tensor] = {}
+    output_set = set(_output_indices)
+    for arg_idx, dim, pad_amount in _ds_pad_dims:
+        a = args_list[arg_idx]
+        if not isinstance(a, torch.Tensor):
+            continue
+        if arg_idx in output_set:
+            orig_output_tensors[arg_idx] = a
+        pad_widths = [0] * (2 * a.ndim)
+        pad_widths[2 * (a.ndim - 1 - dim) + 1] = pad_amount
+        args_list[arg_idx] = torch.nn.functional.pad(a, pad_widths)
+    return tuple(args_list), orig_output_tensors
 
 
 def default_pallas_launcher(
@@ -788,6 +848,7 @@ def default_pallas_launcher(
     _inplace_indices: list[int] | None = None,
     _block_spec_info: _BlockSpecInfo | None = None,
     _smem_arg_indices: list[int] | None = None,
+    _ds_pad_dims: list[tuple[int, int, int]] | None = None,
     **kwargs: object,
 ) -> object:
     """Default launcher for Pallas kernels on TPU (or CPU with interpret=True).
@@ -804,6 +865,12 @@ def default_pallas_launcher(
     """
     if _output_indices is None:
         _output_indices = []
+
+    _orig_output_tensors: dict[int, torch.Tensor] | None = None
+    if _ds_pad_dims:
+        args, _orig_output_tensors = _pallas_apply_ds_padding(
+            args, _output_indices, _ds_pad_dims
+        )
 
     _pallas_check_dtypes(args)
 
@@ -903,7 +970,8 @@ def default_pallas_launcher(
         )
 
     return _pallas_invoke_and_return(
-        jax_callable, args, tensor_arg_indices, arg_to_tensor_pos, _output_indices
+        jax_callable, args, tensor_arg_indices, arg_to_tensor_pos,
+        _output_indices, _ds_pad_dims, _orig_output_tensors,
     )
 
 
@@ -916,6 +984,7 @@ def default_pallas_pipeline_launcher(
     _block_spec_info: _BlockSpecInfo | None = None,
     _scratch_shapes: list[tuple[tuple[int, ...], str]] | None = None,
     _pipeline_arg_indices: list[int] | None = None,
+    _ds_pad_dims: list[tuple[int, int, int]] | None = None,
     **kwargs: object,
 ) -> object:
     """Launcher for Pallas kernels using PrefetchScalarGridSpec with scratch memory.
@@ -930,6 +999,12 @@ def default_pallas_pipeline_launcher(
         _scratch_shapes = []
 
     _pallas_check_dtypes(args)
+
+    _orig_output_tensors: dict[int, torch.Tensor] | None = None
+    if _ds_pad_dims:
+        args, _orig_output_tensors = _pallas_apply_ds_padding(
+            args, _output_indices, _ds_pad_dims
+        )
 
     cache = getattr(pallas_kernel, "_pallas_pipeline_cache", None)
     if cache is not None and cache[0] == grid:
@@ -1055,7 +1130,8 @@ def default_pallas_pipeline_launcher(
         )
 
     return _pallas_invoke_and_return(
-        jax_callable, args, tensor_arg_indices, arg_to_tensor_pos, _output_indices
+        jax_callable, args, tensor_arg_indices, arg_to_tensor_pos,
+        _output_indices, _ds_pad_dims, _orig_output_tensors,
     )
 
 
@@ -1067,6 +1143,7 @@ def default_pallas_fori_launcher(
     _inplace_indices: list[int] | None = None,
     _block_spec_info: _BlockSpecInfo | None = None,
     _scratch_shapes: list[tuple[tuple[int, ...], str | None, str]] | None = None,
+    _ds_pad_dims: list[tuple[int, int, int]] | None = None,
     **kwargs: object,
 ) -> object:
     """Launcher for Pallas kernels using fori_loop with manual DMA.
@@ -1083,6 +1160,12 @@ def default_pallas_fori_launcher(
         _scratch_shapes = []
 
     _pallas_check_dtypes(args)
+
+    _orig_output_tensors: dict[int, torch.Tensor] | None = None
+    if _ds_pad_dims:
+        args, _orig_output_tensors = _pallas_apply_ds_padding(
+            args, _output_indices, _ds_pad_dims
+        )
 
     cache = getattr(pallas_kernel, "_pallas_fori_cache", None)
     if cache is not None and cache[0] == grid:
@@ -1207,7 +1290,8 @@ def default_pallas_fori_launcher(
         )
 
     return _pallas_invoke_and_return(
-        jax_callable, args, tensor_arg_indices, arg_to_tensor_pos, _output_indices
+        jax_callable, args, tensor_arg_indices, arg_to_tensor_pos,
+        _output_indices, _ds_pad_dims, _orig_output_tensors,
     )
 
 

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -322,7 +322,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[16, 16, 16, 16],
         )
 
-    @xfailIfPallas("reduction tile K=256 doesn't evenly divide K=384")
     @xfailIfCute("CuTE IR build error with non-divisible K block sizes")
     def test_bmm_non_divisible_k(self):
         args = (
@@ -962,6 +961,17 @@ class TestExamples(RefEagerTestBase, TestCase):
             (x,),
             x.sum(-1),
             fn_name="longsum_manual",
+        )
+
+    def test_long_sum_manual_non_divisible(self):
+        """Reduction loop OOB when block_size doesn't divide the reduction dim."""
+        x = torch.randn([4, 50000], device=DEVICE, dtype=torch.float32)
+        check_example(
+            "long_sum",
+            (x,),
+            x.sum(-1),
+            fn_name="longsum_manual",
+            block_sizes=[32768, 1],
         )
 
     @xfailIfCute("CuTe jagged mean example still fails lowering/runtime")

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -587,9 +587,6 @@ class TestPallas(TestCase):
         expected = torch.bmm(a.float(), b.float()).to(torch.bfloat16)
         torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
 
-    @xfailIfPallas(
-        "reduction tile K=256 doesn't evenly divide K=384, last tile reads OOB"
-    )
     def test_bmm_fori_loop_non_divisible_k(self) -> None:
         """Test fori_loop bmm where BLOCK_K=256 doesn't evenly divide K=384."""
         a = torch.randn(4, 128, 384, device=DEVICE, dtype=torch.bfloat16)
@@ -603,9 +600,6 @@ class TestPallas(TestCase):
         expected = torch.bmm(a.float(), b.float()).to(torch.bfloat16)
         torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
 
-    @xfailIfPallas(
-        "reduction tile K=256 doesn't evenly divide K=384, last tile reads OOB"
-    )
     def test_bmm_emit_pipeline_non_divisible_k(self) -> None:
         """Test emit_pipeline bmm where BLOCK_K=256 doesn't evenly divide K=384."""
         a = torch.randn(4, 128, 384, device=DEVICE, dtype=torch.bfloat16)


### PR DESCRIPTION
## Summary
- When a tiled dimension's block size doesn't evenly divide the dimension, `pl.ds(offset, block_size)` goes out of bounds on the last iteration
- Fix by zero-padding tensors on the host before `pallas_call`, then slicing outputs back to original shapes
- This follows the standard Pallas convention used in reference TPU kernels (e.g. quantized_matmul, flash_attention)
- Two complementary detection mechanisms:
  1. **Codegen-level**: records at every `pl.ds()` site in the kernel body — covers default loop and non-DMA fori_loop
  2. **Matmul K block_id**: records K block_id from matmul lowering, pads all tensors with that block_id — covers fori_loop DMA and emit_pipeline
- Removes xfails from bmm non-divisible K tests added in #2031
- Adds `test_long_sum_manual_non_divisible` to verify non-matmul cases

### Example

For `bmm` with K=384, BLOCK_K=256 (384 % 256 ≠ 0), the launcher receives:

```python
_ds_pad_dims=[(0, 2, 128), (1, 1, 128)]
```

This pads A from `[4, 128, 384]` → `[4, 128, 512]` and B from `[4, 384, 128]` → `[4, 512, 128]` with zeros before `pallas_call`. The output is sliced back to the original shape after the call.