### PR TITLE
use non-interleaved benchmarking for all-reduce-rmsnorm

### DIFF
--- a/examples/distributed/allreduce_bias_rmsnorm.py
+++ b/examples/distributed/allreduce_bias_rmsnorm.py
@@ -361,6 +361,7 @@ def test(N: int, D: int, device: torch.device, dtype: torch.dtype) -> None:
         args,
         rtol=1e-4,
         atol=1e-4,
+        interleaved=False,
     )
 
     if os.getenv("DO_PROFILE") == "1":

--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -46,6 +46,8 @@ else:
     from .autotuner.benchmarking import do_bench as do_bench
     from .autotuner.benchmarking import interleaved_bench
 
+import typing
+
 from .runtime.config import Config
 from .runtime.ref_mode import is_ref_mode_enabled
 from .runtime.settings import RefMode
@@ -1026,6 +1028,7 @@ def run_example(
     bwd: bool = False,
     trace_path: str | None = None,
     process_group_name: str | None = None,
+    interleaved: bool = True,
 ) -> None:
     """Run complete example: correctness check + benchmark.
 
@@ -1180,8 +1183,17 @@ def run_example(
         profile_context = torch.profiler.profile()
 
     with profile_context:
-        # pyrefly: ignore[bad-argument-type]
-        timings = interleaved_bench(bench_fns, repeat=repeat, desc="Benchmarking")
+        if interleaved:
+            # pyrefly: ignore[bad-argument-type]
+            timings = interleaved_bench(bench_fns, repeat=repeat, desc="Benchmarking")
+        else:
+            timings = typing.cast(
+                "list[float]",
+                [
+                    do_bench(bench_fn, process_group_name=process_group_name)
+                    for bench_fn in bench_fns
+                ],
+            )
 
     if trace_path is not None and is_master_rank():
         print(f"Write profile to {trace_path}")


### PR DESCRIPTION
use non-interleaved benchmarking for all-reduce-rmsnorm

Interleaved benchmarking introduces interference btw the benchmarking result of different kernels for allreduce-rmsnorm.

With interleaved benchmarking:
- only benchmark two-shot (time KERNEL_FILTER=two_shot torchrun --nproc-per-node=8 examples/distributed/allreduce_bias_rmsnorm.py)

```
=================================================================
Benchmark Results
=================================================================
Implementation       Time (ms)    Speedup
-----------------------------------------------------------------
helion_two_shot      0.1198       0.83x
torch                0.0989       1.00x (ref)
=================================================================
```

The kernel has <1 speedup.

- benchmark all
```
=================================================================
Benchmark Results
=================================================================
Implementation       Time (ms)    Speedup
-----------------------------------------------------------------
flashinfer           0.0481       1.63x
helion_one_shot      0.2272       0.35x
helion_two_shot      0.0449       1.75x
torch                0.0787       1.00x (ref)
=================================================================
```

The two-shot kernel has >1 speedup.


With isolated (non-interleaved) benchmarking:
- only benchmark two-shot

```
=================================================================
Benchmark Results
=================================================================
Implementation       Time (ms)    Speedup
-----------------------------------------------------------------
helion_two_shot      0.0687       1.63x
torch                0.1116       1.00x (ref)
=================================================================
```

- benchmark all

```
=================================================================
Benchmark Results
=================================================================
Implementation       Time (ms)    Speedup
-----------------------------------------------------------------
flashinfer           0.0471       2.50x
helion_one_shot      0.1899       0.62x
helion_two_shot      0.0658       1.79x
torch                0.1176       1.00x (ref)
=================================================================
```

The benchmarking results are much more consistent compared to interleaved benchmarking