### PR TITLE
[Pallas] Fix SMEM/VMEM conflict for tensors with mixed access patterns

### DIFF
--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -90,20 +90,6 @@ def index_str(
         out_pos += 1
         tensor_dim += 1
 
-    from helion._compiler.device_function import PallasMemorySpace
-
-    requires_smem_access = all(":" not in p and "pl.ds" not in p for p in parts)
-    if requires_smem_access:
-        # Don't override HBM — pipeline tensors keep their memory space
-        tid = id(tensor)
-        if (
-            state.codegen.device_function.pallas_memory_space.get(tid)
-            != PallasMemorySpace.HBM
-        ):
-            state.codegen.device_function.pallas_memory_space[tid] = (
-                PallasMemorySpace.SMEM
-            )
-
     return ", ".join(parts), none_dims
 
 

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -131,6 +131,37 @@ def _analyze_indexing(node: torch.fx.Node, config: Config) -> None:
     )
     node.meta["indexing_patterns"] = indexing_patterns
 
+    # Track SMEM eligibility (simplified — does not distinguish read vs write):
+    #   SMEM: only scalar access.  VMEM: vector/slice + scalar reads.
+    # A fully correct policy would check read vs write per access:
+    #   - Scalar read-only tensors could stay in VMEM (no SMEM needed)
+    #   - Scalar write requires SMEM
+    #   - Mixed scalar-write + slice needs tensor duplication (unsupported)
+    # For now we conservatively put all-scalar tensors in SMEM and
+    # mixed tensors in VMEM. This is correct for the common cases
+    # (scalar-only → SMEM, mixed scalar-read + slice → VMEM) but
+    # over-allocates SMEM for scalar-read-only tensors.
+    from ..device_function import PallasMemorySpace
+
+    is_all_scalar = all(
+        isinstance(p, (ArbitraryIndexPattern, TileBeginWithOffsetPattern, NonePattern))
+        for p in indexing_patterns
+    )
+    tid = id(tensor_val)
+    current = device_fn.pallas_memory_space.get(tid)
+    if is_all_scalar:
+        # Only mark for SMEM if not already assigned to VMEM or HBM
+        if current is None:
+            device_fn.pallas_memory_space[tid] = PallasMemorySpace.SMEM
+    else:
+        # Override SMEM → VMEM: this is intentional. When a tensor has
+        # both scalar and slice accesses, we keep it in VMEM because
+        # scalar *reads* work from VMEM (only scalar writes require
+        # SMEM). We optimistically assume the scalar access is a read.
+        # Don't override HBM (pipeline tensors).
+        if current != PallasMemorySpace.HBM:
+            device_fn.pallas_memory_space[tid] = PallasMemorySpace.VMEM
+
 
 def _analyze_subscript_patterns(
     tensor: torch.Tensor,

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -2236,7 +2236,9 @@ class TestExamples(RefEagerTestBase, TestCase):
         lambda: _get_backend() == "cute",
         "CuTe Mamba2 chunk-state destabilizes later cute tests when it fails in-process",
     )
-    @xfailIfPallas("SMEM load lowering: Can only load scalars from SMEM")
+    @xfailIfPallas(
+        "dA_cumsum has mixed scalar+slice access (VMEM), but Mosaic requires 32-bit for VMEM scalar extracts"
+    )
     def test_mamba2_chunk_state(self):
         batch, nheads, ngroups, seqlen, chunk_size, headdim, dstate = (
             2,

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -910,6 +910,68 @@ class TestPallas(TestCase):
         expected = x + 1.0
         torch.testing.assert_close(result, expected)
 
+    def test_mixed_scalar_and_slice_access(self) -> None:
+        """Tensor accessed both as scalar and slice should not be placed in SMEM.
+
+        When a tensor has one access that is all-scalar (e.g. x[i, j, k])
+        and another that uses a slice (e.g. x[i, j, tile]), placing it in
+        SMEM causes 'Can only load scalars from SMEM' at runtime. The tensor
+        must stay in VMEM to support both access patterns.
+        """
+
+        @helion.kernel(
+            backend="pallas",
+            static_shapes=True,
+        )
+        def mixed_access(x: torch.Tensor) -> torch.Tensor:
+            B, N = x.shape
+            out = torch.empty_like(x)
+            for tile_b, tile_n in hl.tile([B, N], block_size=[1, None]):
+                # scalar access: x[tile_b.begin, N-1]
+                last_val = x[tile_b.begin, N - 1]
+                # slice access: x[tile_b.begin, tile_n]
+                out[tile_b.begin, tile_n] = x[tile_b.begin, tile_n] + last_val
+            return out
+
+        x = torch.randn(4, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(mixed_access, (x,), block_sizes=[128])
+        # x has mixed access (scalar + slice), so it must stay in VMEM
+        self.assertNotIn("_smem_arg_indices", code)
+        expected = x + x[:, -1:]
+        torch.testing.assert_close(result, expected)
+
+    @xfailIfPallas(
+        "Mixed scalar write + slice needs tensor duplication into SMEM and VMEM"
+    )
+    def test_mixed_scalar_write_and_slice_access(self) -> None:
+        """Tensor with both scalar write and slice access is unsupported.
+
+        SMEM only supports scalar access; VMEM doesn't support scalar writes.
+        A tensor that needs both would require duplication into SMEM (for the
+        scalar write) and VMEM (for the slice access), which is not yet
+        implemented.
+        """
+
+        @helion.kernel(
+            backend="pallas",
+            static_shapes=True,
+        )
+        def mixed_write(x: torch.Tensor) -> torch.Tensor:
+            B, N = x.shape
+            out = torch.empty_like(x)
+            for tile_b, tile_n in hl.tile([B, N], block_size=[1, None]):
+                # slice read
+                out[tile_b.begin, tile_n] = x[tile_b.begin, tile_n]
+                # scalar write to same tensor
+                out[tile_b.begin, N - 1] = x[tile_b.begin, 0]
+            return out
+
+        x = torch.randn(4, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(mixed_write, (x,), block_sizes=[128])
+        expected = x.clone()
+        expected[:, -1] = x[:, 0]
+        torch.testing.assert_close(result, expected)
+
     def test_scalar_access_hl_grid(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True, config=helion.Config())
         def fn(x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Summary
- Fix tensors with mixed scalar + slice access being incorrectly placed in SMEM
- Move SMEM eligibility tracking from codegen (memory_ops.py) to plan_tiling, where all accesses are analyzed upfront — no ordering issues
- Add regression tests (verified on TPU):
  - `test_mixed_scalar_and_slice_access` — passes
  - `test_mixed_scalar_write_and_slice_access` — xfail (documents unsupported case)
- Update `test_mamba2_chunk_state` xfail reason

## Pallas SMEM/VMEM rules (discovered during investigation)

| Access type | VMEM | SMEM |
|---|---|---|
| Scalar read | works | works |
| Scalar write | fails | works |
| Vector/slice read | works | fails |
| Vector/slice write | works | fails |

Key implications:
- **Scalar-only tensor** → SMEM (needs scalar writes)
- **Slice-only tensor** → VMEM (needs vector access)
- **Mixed scalar read + slice** → VMEM (scalar reads work from VMEM)
- **Mixed scalar write + slice** → unsupported (would need tensor duplication into both SMEM and VMEM)

The previous code marked a tensor for SMEM during codegen whenever *any single access* was all-scalar. If a later access needed a slice, the tensor was already in SMEM and would fail with `ValueError: Can only load scalars from SMEM`.

This PR moves the decision to `plan_tiling` which sees all accesses before codegen. A tensor is only placed in SMEM if ALL accesses are scalar; if any access uses a slice, it stays in VMEM.

Found while investigating `mamba2_chunk_state` example on Pallas. Stacked on #2072.