### PR TITLE
memory_ops: register tensor shape on fake loads

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1332,6 +1332,23 @@ class PallasBackend(Backend):
                         # https://github.com/jax-ml/jax/issues/36970
                         analyzer.maybe_update_required_alignment(bid, 2)
 
+                # Update alignment from 'shape'; it's possible that the AST visitor
+                # would otherwise not be able to see this shape, for example when it
+                # comes from a lambda.
+                tensor_ndim = len(shape)
+                for d, dim_expr in enumerate(shape):
+                    for info in block_sizes:
+                        if not isinstance(info, BlockSizeInfo):
+                            continue
+                        if info.dim_matches(dim_expr):
+                            dim_from_end = tensor_ndim - 1 - d
+                            required_alignment = self._get_pallas_required_alignment(
+                                dim_from_end, tensor_ndim, min_element_bits
+                            )
+                            analyzer.maybe_update_required_alignment(
+                                info.block_id, required_alignment
+                            )
+
         for spec in block_specs:
             if not isinstance(spec, BlockSizeSpec):
                 continue

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -1405,6 +1405,7 @@ def _(
     if isinstance(tensor, torch.Tensor):
         target_shape = SubscriptIndexing.compute_shape(tensor, index)
         env = CompileEnvironment.current()
+        env.add_kernel_tensor_size(target_shape, tensor.dtype)
         return env.new_index_result(tensor, target_shape)
     if isinstance(tensor, tuple):
         tensor_like, dev_ptrs = tensor

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from typing import Callable
 import unittest
 
 import torch
@@ -540,6 +541,36 @@ class TestPallas(TestCase):
         torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
         # The bias block_spec_info must have None for dim 0 (not a grid index).
         self.assertIn("(None, 1)", code)
+
+    def test_matmul_1d_bias_closure(self) -> None:
+        """Verifies that ops in a closure also constrain the chosen block size."""
+
+        @helion.kernel(backend="pallas")
+        def matmul_custom(
+            x: torch.Tensor, y: torch.Tensor, epilogue: Callable
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], device=x.device, dtype=x.dtype)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = epilogue(acc, (tile_m, tile_n))
+            return out
+
+        x = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        bias = torch.randn(1024, device=DEVICE, dtype=torch.bfloat16)
+
+        code, result = code_and_output(
+            matmul_custom, (x, y, lambda acc, tile: acc + bias[tile[1]])
+        )
+
+        expected = x.float() @ y.float() + bias.float()
+        torch.testing.assert_close(
+            result, expected.to(torch.bfloat16), rtol=1e-2, atol=1e-2
+        )
 
     def test_bmm(self) -> None:
         """Test BMM with default config — exercises size_matches fix.


### PR DESCRIPTION
So that intermediate tensors in lambda's can constrain the chosen block sizes. This fixes a compiler error in Pallas, where the 1D bias of a matmul is not taken into account when it comes in a lambda, leading to a chosen block size that is incompatible with an innermost dimension (see the added test). With this fix, all the matmul examples can run.

Alternatives considered:
- Capturing the shape in TensorType.__init__ is not an option, since intermediates inside a lambda don't go through it.
- We could inspect the __closure__ of lambda's and register all the captures, but that might be overly constraining since not all captures might end up being used.