### PR TITLE
[Pallas] Replace FakeTensorMode wrap with device='meta' for output-only tensors

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -971,7 +971,6 @@ class PallasBackend(Backend):
             "_default_pallas_launcher": "from helion.runtime import default_pallas_launcher as _default_pallas_launcher",
             "_default_pallas_pipeline_launcher": "from helion.runtime import default_pallas_pipeline_launcher as _default_pallas_pipeline_launcher",
             "_default_pallas_fori_launcher": "from helion.runtime import default_pallas_fori_launcher as _default_pallas_fori_launcher",
-            "FakeTensorMode": "from torch._subclasses.fake_tensor import FakeTensorMode",
         }
 
     # Config keys that Pallas actually uses.  Everything else
@@ -1589,8 +1588,8 @@ class PallasBackend(Backend):
                     output_indices.append(i)
                     inplace_indices.append(i)
 
-        # Collect output-only tensor names for FakeTensorMode wrapping
-        # and launcher return capture in codegen.
+        # Collect output-only tensor names so codegen can retarget their
+        # allocations to ``device='meta'`` and capture the launcher return.
         output_only_set = set(output_indices) - set(inplace_indices)
         output_only_names: list[str] = []
         if sorted_args is not None:

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -731,15 +731,15 @@ def generate_ast(
             kernel_def = codegen.device_function.codegen_function_def()
             codegen.host_dead_code_elimination()
 
-            # Wrap output-only tensor allocations in FakeTensorMode()
-            # so they don't allocate real HBM. The launcher returns
-            # the real tensors, reassigning the variables.
+            # Retarget output-only tensor allocations to ``device='meta'`` so
+            # the factory call produces a zero-storage metadata-only tensor
+            # instead of allocating real HBM. The launcher reassigns the
+            # variable to the real result tensor.
             output_only_names = getattr(
                 CompileEnvironment.current().backend, "_output_only_names", []
             )
             if output_only_names:
                 oo_set = set(output_only_names)
-                new_stmts: list[ast.AST] = []
                 for stmt in codegen.host_statements:
                     if (
                         isinstance(stmt, ast.Assign)
@@ -747,16 +747,14 @@ def generate_ast(
                         and isinstance(stmt.targets[0], ast.Name)
                         and stmt.targets[0].id in oo_set
                         and not getattr(stmt, "_is_kernel_call", False)
+                        and isinstance(stmt.value, ast.Call)
                     ):
-                        with_stmt = statement_from_string(
-                            "with FakeTensorMode(allow_non_fake_inputs=True): pass"
-                        )
-                        assert isinstance(with_stmt, ast.With)
-                        with_stmt.body = [stmt]
-                        new_stmts.append(with_stmt)
-                    else:
-                        new_stmts.append(stmt)
-                codegen.host_statements = new_stmts
+                        call = stmt.value
+                        call.keywords = [
+                            kw for kw in call.keywords if kw.arg != "device"
+                        ] + [
+                            ast.keyword(arg="device", value=ast.Constant(value="meta"))
+                        ]
 
             # Inject RNG seed buffer creation if needed
             rng_statements = (

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -763,9 +763,15 @@ def _pallas_invoke_and_return(
                 # Interpret mode: pallas_call returns JAX arrays, convert to torch.
                 # On TPU, JaxCallable returns torch tensors directly.
                 out_tensor = cast("torch.Tensor", args[orig_pos])
+                # Output-only tensors are allocated with ``device='meta'`` to
+                # avoid HBM; fall back to the first real input's device in
+                # interpret mode so the converted tensor lands somewhere real.
+                device = out_tensor.device
+                if device.type == "meta" and tensor_arg_indices:
+                    device = cast("torch.Tensor", args[tensor_arg_indices[0]]).device
                 result = _jax_to_torch(
                     result,
-                    device=out_tensor.device,
+                    device=device,
                     dtype=out_tensor.dtype,
                 )
             output_only_results.append(result)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -918,8 +918,8 @@ class TestPallas(TestCase):
         # excluded from pallas_call inputs (no donation, no graph split).
         self.assertIn("_output_indices=[1]", code)
         self.assertIn("_inplace_indices=[]", code)
-        # Output-only allocation wrapped in FakeTensorMode (no real HBM).
-        self.assertIn("FakeTensorMode", code)
+        # Output-only allocation retargeted to device='meta' (no real HBM).
+        self.assertIn("device='meta'", code)
         # Launcher return captured into output variable.
         self.assertIn("out = _launcher(", code)
 
@@ -937,7 +937,7 @@ class TestPallas(TestCase):
         code, result = code_and_output(new_empty_relu, (x,), block_sizes=[1024])
         torch.testing.assert_close(result, torch.relu(x))
         self.assertIn("_inplace_indices=[]", code)
-        self.assertIn("FakeTensorMode", code)
+        self.assertIn("device='meta'", code)
         self.assertIn("out = _launcher(", code)
 
     def test_mixed_inplace_and_output_only(self) -> None:
@@ -963,7 +963,7 @@ class TestPallas(TestCase):
         # out is excluded from pallas_call inputs.
         self.assertIn("_output_indices=[0, 1]", code)
         self.assertIn("_inplace_indices=[0]", code)
-        self.assertIn("FakeTensorMode", code)
+        self.assertIn("device='meta'", code)
         self.assertIn("out = _launcher(", code)
 
     def test_empty_like_read_stays_inplace(self) -> None:
@@ -982,8 +982,8 @@ class TestPallas(TestCase):
         torch.testing.assert_close(result, x + 1.0)
         # out is read after write, so it must be in _inplace_indices
         self.assertIn("_inplace_indices=[1]", code)
-        # Not output-only, so no FakeTensorMode wrapping.
-        self.assertNotIn("FakeTensorMode", code)
+        # Not output-only, so no device='meta' retargeting.
+        self.assertNotIn("device='meta'", code)
 
     def test_int64_tensor_raises(self) -> None:
         """Passing int64 tensors to a Pallas kernel should raise TypeError."""
@@ -1013,7 +1013,7 @@ class TestPallas(TestCase):
         # Both outputs are output-only: 2 outputs, 0 aliases
         self.assertIn("_output_indices=[1, 2]", code)
         self.assertIn("_inplace_indices=[]", code)
-        self.assertIn("FakeTensorMode", code)
+        self.assertIn("device='meta'", code)
         self.assertIn("out1, out2 = _launcher(", code)
 
     def test_fori_loop_multidim(self) -> None:


### PR DESCRIPTION
## Summary

#2022 wrapped output-only tensor allocations in `with FakeTensorMode(allow_non_fake_inputs=True):` to skip HBM. Entering/exiting the context manager costs ~500µs per call on CI's pinned PyTorch nightly — negligible for large kernels but devastating for small ones.

The launcher only needs **shape and dtype** from the output-only tensor. Replacing the CM with a `device='meta'` kwarg on the factory call gives us the same zero-HBM property with zero per-call overhead.

### Before
```python
with FakeTensorMode(allow_non_fake_inputs=True):
    out = torch.empty_like(x)
out = _launcher(...)
```

### After
```python
out = torch.empty_like(x, device='meta')
out = _launcher(...)
```

## Benchmark results

Measured on the TPU nightly benchmark harness (#1913), small shapes where kernel device time is <0.3ms:

| Kernel | Shape | Before fix (#2022) | After fix (`device='meta'`) |
|---|---|---|---|
| exp | `[1024]` | 0.27x | **0.80x** |
| softmax_two_pass | `[1024,256]` | 0.25x | **0.82x** |
| low_mem_dropout | `[4096]` | 0.24x | **0.63x** |
| softmax | `[4096,2560]` | 0.30x | **0.93x** |
| layer_norm | `[2048,4096]` | 0.28x | **0.63x** |
| batch_softmax | `[16,512,1024]` | 0.17x | **0.77x** |
| welford | `[262144,1024]` | 0.89x | **1.12x** |
| bmm | `[16,512,768,1024]` | 0.47x | **0.89x** |

15/15 kernels pass; no functional regressions.

## Notes

- Interpret mode previously used `args[orig_pos].device` to convert JAX results back to torch. With a meta placeholder that would produce a `meta`-device tensor, so the launcher now falls back to the first real input tensor's device in that case.
- Keeps #2022's launcher-return-capture mechanism intact — necessary because meta tensors have no storage, so `set_()` is no longer an option.
- `@skipIfPallas` on the four `test_infer_fake_impl` tests stays: the skip is about outer-`FakeTensorMode` incompatibility with return capture, which is orthogonal to this change.