### PR TITLE
[Pallas] Refactor memory space tracking into PallasMemorySpace enum

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1671,14 +1671,18 @@ class PallasBackend(Backend):
         from .device_function import DeviceFunction
 
         device_fn = DeviceFunction.current()
-        smem_ids = device_fn.pallas_smem_tensor_ids
-        if smem_ids and sorted_args is not None:
+        from .device_function import PallasMemorySpace
+
+        mem_space = device_fn.pallas_memory_space
+        if sorted_args is not None:
             smem_arg_indices = [
                 i
                 for i, arg in enumerate(sorted_args)
-                if isinstance(arg, TensorArg) and id(arg.fake_value) in smem_ids
+                if isinstance(arg, TensorArg)
+                and mem_space.get(id(arg.fake_value)) == PallasMemorySpace.SMEM
             ]
-            launcher_args.append(f"_smem_arg_indices={smem_arg_indices!r}")
+            if smem_arg_indices:
+                launcher_args.append(f"_smem_arg_indices={smem_arg_indices!r}")
 
         # Pass scratch shapes for pipeline/fori_loop launcher
         pallas_loop_type = config.get("pallas_loop_type", "default")
@@ -1698,14 +1702,17 @@ class PallasBackend(Backend):
             # tensors (need HBM refs); all others get proper BlockSpecs.
             from .device_function import TensorArg
 
-            pipeline_ids = device_fn.pallas_pipeline_tensor_ids
-            if pipeline_ids and sorted_args is not None:
+            if sorted_args is not None:
                 pipeline_arg_indices = [
                     i
                     for i, arg in enumerate(sorted_args)
-                    if isinstance(arg, TensorArg) and id(arg.fake_value) in pipeline_ids
+                    if isinstance(arg, TensorArg)
+                    and mem_space.get(id(arg.fake_value)) == PallasMemorySpace.HBM
                 ]
-                launcher_args.append(f"_pipeline_arg_indices={pipeline_arg_indices!r}")
+                if pipeline_arg_indices:
+                    launcher_args.append(
+                        f"_pipeline_arg_indices={pipeline_arg_indices!r}"
+                    )
 
         return launcher_args
 

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -4,6 +4,7 @@ import ast
 from collections import defaultdict
 import contextlib
 import dataclasses
+import enum
 import itertools
 import math
 import threading
@@ -231,6 +232,14 @@ def _is_literal_constexpr(arg: ConstExprArg) -> bool:
         return False
 
 
+class PallasMemorySpace(enum.Enum):
+    """TPU memory space for Pallas tensors."""
+
+    HBM = "hbm"  # Pipeline body tensors (DMA)
+    SMEM = "smem"  # Scalar-only access
+    VMEM = "vmem"  # Vector/slice access (default)
+
+
 class DeviceFunction:
     def __init__(
         self,
@@ -310,11 +319,15 @@ class DeviceFunction:
 
         # Pallas: id(fake_tensor) → [DimensionTiling], recorded during `plan_tiling`
         self.pallas_tensor_dim_tilings: dict[int, list[DimensionTiling]] = {}
-        # Pallas: set of id(fake_tensor) for tensors accessed in pipeline body
-        self.pallas_pipeline_tensor_ids: set[int] = set()
-        # TODO(dunfanlu): consider duplicating and aliasing arguments if a tensor needs to be accessed via both VMEM and SMEM?
-        # Pallas: set of id(fake_tensor) for tensors requiring scalar accessing (SMEM)
-        self.pallas_smem_tensor_ids: set[int] = set()
+        # Pallas: id(fake_tensor) → memory space, determined during
+        # tracing (HBM for pipeline) and codegen (SMEM for scalar access).
+        # NOTE: Currently each tensor can only have one memory space.
+        # If a tensor needs both SMEM (scalar access) and VMEM (slice
+        # access), it will need tensor duplication — passing the same
+        # data as two separate args in different memory spaces. This
+        # dict would then need to support multiple entries per tensor
+        # or the tensor would get distinct arg IDs per memory space.
+        self.pallas_memory_space: dict[int, PallasMemorySpace] = {}
 
     def allocate_store_index(self) -> int:
         """Bump store counters and return the indexing strategy slot."""

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -749,10 +749,12 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         )
 
     # Record which tensors are in the pipeline body (need HBM refs)
+    from .._compiler.device_function import PallasMemorySpace
+
     for fake, _tensor_node, _sub_meta in loaded_tensors.values():
-        state.device_function.pallas_pipeline_tensor_ids.add(id(fake))
+        state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
     for fake, _tensor_node, _sub_meta in stored_tensors.values():
-        state.device_function.pallas_pipeline_tensor_ids.add(id(fake))
+        state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
 
     # Process loaded tensors (inputs to pipeline)
     for key, (fake, _tensor_node, sub_meta) in loaded_tensors.items():
@@ -1017,10 +1019,12 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     tensor_to_vmem: dict[str, str] = {}
     tensor_to_sem: dict[str, str] = {}
     if use_dma:
+        from .._compiler.device_function import PallasMemorySpace
+
         for fake, _tensor_node, _sub_meta in loaded_tensors.values():
-            state.device_function.pallas_pipeline_tensor_ids.add(id(fake))
+            state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
         for fake, _tensor_node, _sub_meta in stored_tensors.values():
-            state.device_function.pallas_pipeline_tensor_ids.add(id(fake))
+            state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
         for (fake, _sub_meta, _direction), vmem_shape in zip(
             all_tensor_info, vmem_shapes, strict=True
         ):

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -237,9 +237,19 @@ def _pallas_index_str(
         out_pos += 1
         tensor_dim += 1
 
-    requries_smem_access = all(":" not in p and "pl.ds" not in p for p in parts)
-    if requries_smem_access:
-        state.codegen.device_function.pallas_smem_tensor_ids.add(id(tensor))
+    from .._compiler.device_function import PallasMemorySpace
+
+    requires_smem_access = all(":" not in p and "pl.ds" not in p for p in parts)
+    if requires_smem_access:
+        # Don't override HBM — pipeline tensors keep their memory space
+        tid = id(tensor)
+        if (
+            state.codegen.device_function.pallas_memory_space.get(tid)
+            != PallasMemorySpace.HBM
+        ):
+            state.codegen.device_function.pallas_memory_space[tid] = (
+                PallasMemorySpace.SMEM
+            )
 
     return ", ".join(parts), none_dims
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -235,6 +235,19 @@ def pallas_two_pass_reduction(x: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_inner_loop_add_with_scalar_access(
+    x: torch.Tensor, y: torch.Tensor
+) -> torch.Tensor:
+    """Kernel that mixes pipeline-tiled and scalar reads of the same tensor."""
+    m, n = x.size()
+    out = torch.empty_like(x)
+    for tile_m in hl.tile(m):
+        for tile_n in hl.tile(n):
+            out[tile_m, tile_n] = x[tile_m, tile_n] + y[tile_m, tile_n] + x[0, 0]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_add_3d(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     """Kernel with an outer grid loop and a 2D inner device loop."""
     b, m, n = x.size()
@@ -670,6 +683,24 @@ class TestPallas(TestCase):
         )
         expected = x - x.mean(dim=-1, keepdim=True)
         torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
+
+    @xfailIfPallas("Pipeline + scalar access codegen not yet supported")
+    def test_pipeline_tensor_with_scalar_access(self) -> None:
+        """A pipeline tensor with scalar access should keep HBM, not be overridden to SMEM."""
+        args = (
+            torch.randn(64, 128, device=DEVICE, dtype=torch.float32),
+            torch.randn(64, 128, device=DEVICE, dtype=torch.float32),
+        )
+        expected = args[0] + args[1] + args[0][0, 0]
+        code, result = code_and_output(
+            pallas_inner_loop_add_with_scalar_access,
+            args,
+            block_sizes=[8, 128],
+            pallas_loop_type="emit_pipeline",
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+        self.assertIn("_pipeline_arg_indices=", code)
+        torch.testing.assert_close(result, expected)
 
     def test_attention_default_fp32(self) -> None:
         """Test attention with default (for-loop) inner loop."""


### PR DESCRIPTION
## Summary
- Replace separate `pallas_pipeline_tensor_ids` set and `pallas_smem_tensor_ids` set with a single `pallas_memory_space` dict mapping tensor IDs to `PallasMemorySpace` enum values (HBM, SMEM, VMEM)
- Add guard to prevent SMEM from overriding HBM for pipeline tensors
- Add xfail test `test_pipeline_tensor_with_scalar_access` documenting a pre-existing limitation: mixing pipeline-tiled and scalar access to the same tensor fails with `NameError` in codegen (not caused by this refactor)

## Motivation
On TPU, tensors can live in three memory spaces (HBM, SMEM, VMEM), but these were tracked with two independent sets that couldn't represent the full picture:
- `pallas_pipeline_tensor_ids` (set) — HBM tensors for DMA pipeline
- `pallas_smem_tensor_ids` (set) — SMEM tensors for scalar access
- VMEM was implicit (anything not in the other two sets)

This made it hard to reason about conflicts (e.g., a tensor needing both SMEM and VMEM) since there was no single source of truth. With two sets, a tensor could appear in both sets simultaneously, silently producing conflicting launcher args. A unified dict with an enum makes the memory space decision explicit — each tensor has exactly one memory space.

This also simplifies #2069 (SMEM/VMEM conflict fix): instead of adding a third set and doing set subtraction at launch time, #2069 can just write `VMEM` to the same dict when a non-scalar access is found.