### PR TITLE
[Pallas] Process tensor access within external lambdas when adjusting block size constraints

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -184,6 +184,14 @@ class Backend(abc.ABC):
     def supports_block_ptr_indexing(self) -> bool:
         return True
 
+    def process_fake_tensor_load(
+        self,
+        tensor: torch.Tensor,
+        index: list[object],
+    ) -> None:
+        """Called during `type_propagation` when processing a `load` memory op on fake tensors"""
+        return
+
     def adjust_block_size_constraints(
         self,
         block_specs: list[object],
@@ -1218,6 +1226,17 @@ class PallasBackend(Backend):
             return 8
         return 1  # No requirements for other dimensions
 
+    fake_tensor_loads: list[tuple[torch.Tensor, list[object]]]
+
+    def process_fake_tensor_load(
+        self,
+        tensor: torch.Tensor,
+        index: list[object],
+    ) -> None:
+        if not hasattr(self, "fake_tensor_loads"):
+            self.fake_tensor_loads = []
+        self.fake_tensor_loads.append((tensor, index))
+
     def adjust_block_size_constraints(
         self,
         block_specs: list[object],
@@ -1240,7 +1259,10 @@ class PallasBackend(Backend):
         ``min(block_size, tensor_dim)`` which equals the full array
         dimension -- always valid per TPU rules.
         """
+        from ..autotuner.config_spec import BlockSizeSpec
         from .ast_extension import ExtendedAST
+        from .compile_environment import BlockSizeInfo
+        from helion._compiler.compile_environment import _to_sympy
         from helion._compiler.host_function import HostFunction
         from helion._compiler.type_propagation import SequenceType
         from helion._compiler.type_propagation import TensorType
@@ -1253,6 +1275,7 @@ class PallasBackend(Backend):
                 super().__init__()
                 self.backend = backend
                 self.required_alignments: dict[int, int] = {}
+                self.update_requirements_from_fake_tensor_loads()
 
             def visit_Subscript(self, node: ast.Subscript) -> None:
                 assert isinstance(node, ExtendedAST)
@@ -1312,14 +1335,37 @@ class PallasBackend(Backend):
                         self.required_alignments[bid], required_alignment
                     )
 
+            def update_requirements_from_fake_tensor_loads(self) -> None:
+                # When tensors are indexed within external lambdas called by the kernel,
+                # they generate fake loads, which we don't pickup during AST walk.
+                if not hasattr(self.backend, "fake_tensor_loads"):
+                    return
+                if block_sizes is None:
+                    return
+                for info in block_sizes:
+                    if not isinstance(info, BlockSizeInfo):
+                        continue
+                    for tensor, subscripts in self.backend.fake_tensor_loads:
+                        for dim, subscript in enumerate(subscripts):
+                            if isinstance(subscript, torch.SymInt) and info.dim_matches(
+                                _to_sympy(subscript)
+                            ):
+                                dim_from_end = tensor.ndim - 1 - dim
+                                bitwidth = tensor.dtype.itemsize * 8
+                                required_alignment = (
+                                    self.backend._get_pallas_required_alignment(
+                                        dim_from_end, tensor.ndim, bitwidth
+                                    )
+                                )
+                                self.maybe_update_required_alignment(
+                                    info.block_id, required_alignment
+                                )
+
         analyzer = TensorTiledAccessAnalyzer(self)
         for stmt in host_func.body:
             analyzer.visit(stmt)
 
         from torch._inductor.runtime.runtime_utils import next_power_of_2
-
-        from ..autotuner.config_spec import BlockSizeSpec
-        from .compile_environment import BlockSizeInfo
 
         if block_sizes is not None and kernel_tensor_sizes is not None:
             for shape in kernel_tensor_sizes:

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -1405,6 +1405,7 @@ def _(
     if isinstance(tensor, torch.Tensor):
         target_shape = SubscriptIndexing.compute_shape(tensor, index)
         env = CompileEnvironment.current()
+        env.backend.process_fake_tensor_load(tensor, index)
         return env.new_index_result(tensor, target_shape)
     if isinstance(tensor, tuple):
         tensor_like, dev_ptrs = tensor

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from typing import Callable
 import unittest
 
 import torch
@@ -1143,6 +1144,36 @@ class TestPallas(TestCase):
         code, result = code_and_output(fn, (x, y))
         expected = (x[:, None] < y[None, :]).to(torch.float32)
         torch.testing.assert_close(result, expected)
+
+    def test_matmul_1d_bias_closure(self) -> None:
+        """Verifies that ops in a closure also constrain the chosen block size."""
+
+        @helion.kernel(backend="pallas")
+        def matmul_custom(
+            x: torch.Tensor, y: torch.Tensor, epilogue: Callable
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], device=x.device, dtype=x.dtype)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = epilogue(acc, (tile_m, tile_n))
+            return out
+
+        x = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        bias = torch.randn(1024, device=DEVICE, dtype=torch.bfloat16)
+
+        code, result = code_and_output(
+            matmul_custom, (x, y, lambda acc, tile: acc + bias[tile[1]])
+        )
+
+        expected = x.float() @ y.float() + bias.float()
+        torch.testing.assert_close(
+            result, expected.to(torch.bfloat16), rtol=1e-2, atol=1e-2
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When a kernel calls external lambdas which accesses tensors (which we do in the `matmul` example), we need to adjust block sizes based on tensor accesses within the lambda. However, those accesses are not visible via the AST, so the AST-analysis-based adjustment from #2051 isn't enough. This PR handles this by looking into `load` memory ops on fake tensors, which is processed during `type_propogation` when we call the lambda via fake tensor valuesl.


cc @cota, as discussed offline, this is a safer version of #2070 which doesn't break existing tests fixed by #2051.