### PR TITLE
[Pallas] Fix emit_pipeline/fori_loop codegen when multiple inner loops tile the same dim

### DIFF
--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -324,12 +324,18 @@ def _pallas_tile_pattern_code(
 
     block_id = pattern.block_id
 
+    # Pipeline-tiled dims are already sliced by emit_pipeline / fori_loop's
+    # BlockSpec or DMA copy, so the body should use ``:`` regardless of
+    # whether the planner marked the dim as tileable.
+    # TODO(yifeixu): the long-term fix is making ``can_tile`` per-loop-scope
+    # instead of per-tensor-dim so the planner doesn't mark this dim
+    # untileable in pipeline mode in the first place.
+    if in_pipeline and block_id in pipeline_block_ids:
+        return ":"
+
     can_tile = _can_tile_dimension(state, tensor_dim)
     if not can_tile:
         return _pallas_ds_expr(state, block_id)
-
-    if in_pipeline and block_id in pipeline_block_ids:
-        return ":"
 
     loops = state.codegen.active_device_loops.get(block_id)
     if loops and any(

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -217,6 +217,23 @@ def pallas_inner_loop_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_two_pass_reduction(x: torch.Tensor) -> torch.Tensor:
+    """Two inner reduction loops over the same dim: reduce to a per-row mean,
+    then subtract it from each element.
+    """
+    m, n = x.size()
+    out = torch.empty_like(x)
+    for tile_m in hl.tile(m):
+        acc = torch.zeros_like(x[tile_m, 0], dtype=torch.float32)
+        for tile_n in hl.tile(n):
+            acc = acc + torch.sum(x[tile_m, tile_n], dim=-1)
+        mean = (acc / n)[:, None]
+        for tile_n in hl.tile(n):
+            out[tile_m, tile_n] = x[tile_m, tile_n] - mean.to(x.dtype)
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_add_3d(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     """Kernel with an outer grid loop and a 2D inner device loop."""
     b, m, n = x.size()
@@ -624,6 +641,34 @@ class TestPallas(TestCase):
         torch.testing.assert_close(result, args[0] + args[1])
         # out is output-only, excluded from pallas_call inputs
         self.assertIn("_inplace_indices=[]", code)
+
+    def test_two_pass_reduction_emit_pipeline(self) -> None:
+        """Two inner reduction loops over the same dim compile and run under
+        ``pallas_loop_type='emit_pipeline'``.
+        """
+        x = torch.randn(256, 128, device=DEVICE, dtype=torch.float32)
+        _code, result = code_and_output(
+            pallas_two_pass_reduction,
+            (x,),
+            block_sizes=[128, 128, 128],
+            pallas_loop_type="emit_pipeline",
+        )
+        expected = x - x.mean(dim=-1, keepdim=True)
+        torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
+
+    def test_two_pass_reduction_fori_loop(self) -> None:
+        """Two inner reduction loops over the same dim compile and run under
+        ``pallas_loop_type='fori_loop'``.
+        """
+        x = torch.randn(256, 128, device=DEVICE, dtype=torch.float32)
+        _code, result = code_and_output(
+            pallas_two_pass_reduction,
+            (x,),
+            block_sizes=[128, 128, 128],
+            pallas_loop_type="fori_loop",
+        )
+        expected = x - x.mean(dim=-1, keepdim=True)
+        torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
 
     def test_attention_default_fp32(self) -> None:
         """Test attention with default (for-loop) inner loop."""


### PR DESCRIPTION
## Symptom

A kernel with two inner reduction loops over the same dimension (welford pattern) fails codegen under `pallas_loop_type='emit_pipeline'` / `'fori_loop'` with `NameError: name 'offset_1' is not defined`. The `offset_N` name is only defined by the `default`-loop-type prologue (`for offset_N in range(...)`); in emit_pipeline / DMA fori_loop the body instead receives an already-sliced VMEM ref and there's no such prologue.

## Root cause and scoping

The planner tracks `can_tile` as a **per-tensor-dim** flag. Two `hl.tile(n)` loops over the same dim produce distinct block_ids, so `_disallow_tiling()` fires — one `pl.BlockSpec` can't express two tilings per dim. That's correct for `default` loop_type. In pipeline mode each inner `hl.tile` gets its **own** `emit_pipeline` call with its **own** BlockSpec, so the constraint doesn't apply. The right long-term fix is making `can_tile` per-loop-scope; this PR is a scoped patch at the codegen site: inside a pipeline body, return `:` for a `TilePattern` whose block_id belongs to an active pipeline.

Safe across all `can_tile=False` triggers for `TilePattern`:
- **Same dim, multiple block_ids** — the welford case, handled by per-pipeline BlockSpecs.
- **Block size misaligned for TPU** — Pallas rejects the outer BlockSpec itself at compile time, before the body's index matters.
- **DMA-less `fori_loop`** — excluded from the `in_pipeline` check, since its `offset_N` *is* defined (the fori iteration index); existing behavior preserved.

## Generated Pallas code (before vs after)

```python
def _helion_pallas_two_pass_reduction(x, out, scratch_0):
    acc = jnp.full([_BLOCK_SIZE_0], 0, jnp.float32)
    _outer_pid_0 = pl.program_id(0)
    scratch_0[...] = acc[...]

    def _pipeline_body(x_vmem):
        v_0_0 = scratch_0[...]
-       load = x_vmem[:, pl.ds(offset_1, _BLOCK_SIZE_1)]   # NameError: offset_1 undefined
+       load = x_vmem[:, :]                                # tile already sliced
        sum_1 = lax.convert_element_type(jnp.sum(load, axis=1), jnp.float32)
        scratch_0[...] = (v_0_0 + sum_1)[...]
    pltpu.emit_pipeline(_pipeline_body, grid=..., in_specs=[...])(x)
    acc = scratch_0[...]
    ...
    def _pipeline_body_1(x_vmem_1, out_vmem):
        mean_copy_0 = mean
-       load_1 = x_vmem_1[:, pl.ds(offset_2, _BLOCK_SIZE_2)]   # NameError: offset_2 undefined
+       load_1 = x_vmem_1[:, :]                                # tile already sliced
        out_vmem[:, :] = load_1 - mean_copy_0
    pltpu.emit_pipeline(_pipeline_body_1, grid=..., in_specs=[...], out_specs=[...])(x, out)
```
