### PR TITLE
Fix hardcoded CUDA device in jagged_dense_bmm example

### DIFF
--- a/examples/jagged_dense_bmm.py
+++ b/examples/jagged_dense_bmm.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import torch
 
 import helion
+from helion._testing import DEVICE
 from helion._testing import run_example
 import helion.language as hl
 
@@ -126,26 +127,22 @@ def random_input(
     max_seq_len: int = 3,
     dtype: torch.dtype = torch.float32,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    lengths = torch.randint(
-        max_seq_len + 1, size=(batch_size,), device=torch.device("cuda")
-    )
-    seq_offsets = torch.zeros(
-        (batch_size + 1,), dtype=torch.int64, device=torch.device("cuda")
-    )
+    lengths = torch.randint(max_seq_len + 1, size=(batch_size,), device=DEVICE)
+    seq_offsets = torch.zeros((batch_size + 1,), dtype=torch.int64, device=DEVICE)
     seq_offsets[1:] = torch.cumsum(lengths, dim=0)
     jagged_size = int(seq_offsets[-1].item())
     jagged = (
-        torch.empty((jagged_size, D), dtype=dtype, device=torch.device("cuda"))
+        torch.empty((jagged_size, D), dtype=dtype, device=DEVICE)
         .uniform_(-1.0, 1.0)
         .requires_grad_()
     )
     dense = (
-        torch.empty((batch_size, D, K), dtype=dtype, device=torch.device("cuda"))
+        torch.empty((batch_size, D, K), dtype=dtype, device=DEVICE)
         .uniform_(-1.0, 1.0)
         .requires_grad_()
     )
     bias = (
-        torch.empty((batch_size, K), dtype=dtype, device=torch.device("cuda"))
+        torch.empty((batch_size, K), dtype=dtype, device=DEVICE)
         .uniform_(-1.0, 1.0)
         .requires_grad_()
     )

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -885,7 +885,7 @@ class TestExamples(RefEagerTestBase, TestCase):
         )
 
     @xfailIfCute("CuTe jagged dense bmm example still returns incorrect results")
-    @xfailIfPallas("tensor-derived if-predicates not supported")
+    @xfailIfPallas("Pallas rejects int64 inputs (jagged offsets)")
     @skipIfXPU("Jagged tensor operations not fully supported on XPU")
     @skipIfRefEager("hl.jagged_tile does not support ref mode yet")
     def test_jagged_dense_bmm(self):


### PR DESCRIPTION
## Summary

`examples/jagged_dense_bmm.py`'s `random_input()` helper hardcoded `device=torch.device("cuda")` in five places, which made the example unusable on TPU (and other non-CUDA backends) before the kernel even ran. Swap those sites to the auto-detected `DEVICE` from `helion._testing`.

`test_jagged_dense_bmm` still xfails on Pallas, but the reason is now the downstream int64-offset issue (same cluster as the other jagged tests) rather than the CUDA setup error.

## Verified on TPU

- Before the fix: test aborted with `Torch not compiled with CUDA enabled` (from `random_input`).
- After the fix: the test reaches the Pallas backend and xfails with `Pallas/TPU does not support torch.int64 tensors` — the expected cluster failure.
