### PR TITLE
[Pallas] Treat tile.id subscripts as untileable scalar indices

### DIFF
--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -314,7 +314,12 @@ def _maybe_get_symbol_origin(idx: object) -> SymbolOrigin | None:
 def _maybe_get_tile_begin_with_offset_info(
     idx: object,
 ) -> TileBeginWithOffsetPattern | None:
-    """Extended version that allows out-of-bounds and symbolic offsets."""
+    """Extended version that allows out-of-bounds and symbolic offsets.
+
+    Matches expressions that resolve to a tile's start offset within the
+    full loop extent (e.g. ``tile.begin``, ``tile.end - 1``, or affine
+    combinations of those with integer constants).
+    """
     from ..compile_environment import CompileEnvironment
     from ..compile_environment import _symint_expr
     from ..host_function import HostFunction
@@ -322,6 +327,7 @@ def _maybe_get_tile_begin_with_offset_info(
     from ..variable_origin import GridOrigin
     from ..variable_origin import TileBeginOrigin
     from ..variable_origin import TileEndOrigin
+    from ..variable_origin import TileIdOrigin
 
     idx_symbol_origin = _maybe_get_symbol_origin(idx)
     if isinstance(idx_symbol_origin, SymbolOrigin):
@@ -330,7 +336,7 @@ def _maybe_get_tile_begin_with_offset_info(
                 block_id=idx_symbol_origin.origin.block_id, offset=0
             )
         if isinstance(idx_symbol_origin.origin, GridOrigin) and not isinstance(
-            idx_symbol_origin.origin, TileEndOrigin
+            idx_symbol_origin.origin, (TileEndOrigin, TileIdOrigin)
         ):
             return TileBeginWithOffsetPattern(
                 block_id=idx_symbol_origin.origin.block_id, offset=0

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1125,6 +1125,43 @@ class TestPallas(TestCase):
         self.assertIn("pl.ds(", code)
         torch.testing.assert_close(result, args[0] + args[1])
 
+    def test_tile_id_per_block_accumulator(self) -> None:
+        """Writing to ``out[tile.id, :]`` stores one row per outer grid iter.
+
+        This is the multi-block partial-reduction pattern used e.g. in
+        ``rms_norm_bwd``: each outer grid iter computes a per-block
+        accumulator and writes it into its own row of a ``[num_blocks, N]``
+        output tensor, which the host then sums across ``dim=0``.
+
+        Each grid iter ``i`` must land in row ``i``, so the kernel must
+        correctly interpret the scalar ``tile.id`` index against a tensor
+        whose outer dim has extent ``num_blocks`` (not ``M``).
+        """
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def per_block_reduction(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.shape
+            m_block = hl.register_block_size(x.size(0))
+            out = x.new_empty(
+                [(x.size(0) + m_block - 1) // m_block, n], dtype=torch.float32
+            )
+            for mb_cta in hl.tile(m, block_size=m_block):
+                acc = x.new_zeros([n], dtype=torch.float32)
+                for mb in hl.tile(mb_cta.begin, mb_cta.end):
+                    acc += x[mb, :].to(torch.float32).sum(0)
+                out[mb_cta.id, :] = acc
+            return out
+
+        x = torch.randn(64, 128, device=DEVICE, dtype=torch.float32)
+        _code, result = code_and_output(
+            per_block_reduction,
+            (x,),
+            block_sizes=[8, 8],
+            pallas_loop_type="fori_loop",
+        )
+        ref = x.view(8, 8, 128).sum(1)
+        torch.testing.assert_close(result, ref, rtol=1e-3, atol=1e-3)
+
     def test_squeeze_slice_access(self) -> None:
         """Test for the [None, :] indexing pattern (subscript index for slice >= tensor_ndim)"""
 


### PR DESCRIPTION
## Summary

- `_maybe_get_tile_begin_with_offset_info` previously classified any `GridOrigin`-derived subscript (other than `TileEndOrigin`) as `TileBeginWithOffsetPattern`.  `TileIdOrigin` falls in that bucket but has different semantics: `tile.id` is a scalar enumerating grid iterations, not a position within the loop extent.
- Downstream, `_compute_block_spec_info` then assigned such dims the outer block_size with `grid_dim=0`, striding `pid * block_size` across a tensor whose dim has extent `ceil(numel / block_size)` — out of bounds for `pid ≥ num_blocks / block_size`.
- Narrow the helper to also exclude `TileIdOrigin` so tile-id subscripts fall through to `ArbitraryIndexPattern`, leaving the dim untiled at the BlockSpec level and using the raw tile-id expression at the subscript site.

### Generated code before vs. after

For `out[mb_cta.id, :] = acc` inside an outer `hl.tile` loop where `out.shape = [num_blocks, N]`:

**Before (buggy):**
```python
out[0, :] = acc
# _block_spec_info for out: ((8, None), (0, None))
```

**After (this PR):**
```python
tile_id = offset_0 // _BLOCK_SIZE_0
out[tile_id, :] = acc
# _block_spec_info for out: ((None, None), (None, None))
```
