### PR TITLE
[Pallas] More robust analysis of tensors reads/writes via FX graph instead of AST, allowing more aggresive output_only optimizations

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1571,10 +1571,12 @@ class PallasBackend(Backend):
         # Determine which arg positions are outputs.  A tensor is an output if:
         #   1. It was created inside the function body (not in input_sources), OR
         #   2. It is a function parameter that is mutated in-place (e.g. x[tile] += ...)
-        from .ast_read_writes import ReadWrites
         from .compile_environment import CompileEnvironment
+        from .device_function import DeviceFunction
         from .device_function import TensorArg
         from .host_function import HostFunction
+
+        device_fn = DeviceFunction.current()
 
         def _empty_allocated_vars(body: list[ast.stmt]) -> set[str]:
             """Return names of variables allocated with torch.empty/empty_like/new_empty.
@@ -1605,38 +1607,22 @@ class PallasBackend(Backend):
         if sorted_args is not None:
             env = CompileEnvironment.current()
             host_fn = HostFunction.current()
-            mutated_params = set(ReadWrites.from_list(host_fn.body).inplace_writes) & {
-                a.arg for a in host_fn.args.args
-            }
+            read_names, write_names = device_fn.get_tensor_read_write_names()
+            mutated_params = write_names & {a.arg for a in host_fn.args.args}
             input_storages = {id(t.untyped_storage()) for t in env.input_sources}
-            # Collect reads from for-loop bodies only (kernel code), excluding
-            # host-level reads like ``return out``.
-            # Note: Python AST counts ``out[tile] = val`` as a Load of ``out``
-            # (the object must be loaded to index into it), but from Pallas's
-            # perspective this is a pure write — the tensor data is not read.
-            # Subtract such "false reads" by checking inplace_writes counts.
-            #
             # Only tensors allocated with torch.empty/empty_like/new_empty can be
             # output-only — their initial values are undefined, so it's safe
             # to use HBM BlockSpecs.  Tensors allocated with torch.zeros_like,
             # torch.full, etc. have meaningful initial values that must be
             # preserved via VMEM BlockSpecs.
             empty_vars = _empty_allocated_vars(host_fn.body)
-            kernel_reads: set[str] = set()
-            for stmt in host_fn.body:
-                if isinstance(stmt, ast.For):
-                    body_rw = ReadWrites.from_list(stmt.body)
-                    for name, read_count in body_rw.reads.items():
-                        iw_count = body_rw.inplace_writes.get(name, 0)
-                        if read_count > iw_count or name not in empty_vars:
-                            kernel_reads.add(name)
             for i, arg in enumerate(sorted_args):
                 if not isinstance(arg, TensorArg):
                     continue
                 if id(arg.fake_value.untyped_storage()) not in input_storages:
                     # Tensor created inside the function body (output)
                     output_indices.append(i)
-                    if arg.host_str() in kernel_reads:
+                    if arg.host_str() in read_names or arg.host_str() not in empty_vars:
                         # Also read by the kernel (e.g. broadcast result)
                         inplace_indices.append(i)
                 elif arg.host_str() in mutated_params:
@@ -1668,9 +1654,6 @@ class PallasBackend(Backend):
                 block_spec_info.append(None)  # RNG seed buffer is untiled
             launcher_args.append(f"_block_spec_info={block_spec_info!r}")
 
-        from .device_function import DeviceFunction
-
-        device_fn = DeviceFunction.current()
         from .device_function import PallasMemorySpace
 
         mem_space = device_fn.pallas_memory_space

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -939,6 +939,43 @@ class DeviceFunction:
             (), None, name_hint=name_hint, scratch_type="dma_semaphore"
         )
 
+    def get_tensor_read_write_names(self) -> tuple[set[str], set[str]]:
+        """Returns AST names of read and written tensors"""
+        from helion.language import atomic_ops
+        from helion.language import memory_ops
+
+        read_names: set[str] = set()
+        write_names: set[str] = set()
+        for graph in self.codegen.codegen_graphs:
+            for node in graph.graph.nodes:
+                if node.op != "call_function":
+                    continue
+
+                def _get_tensor_name(node: torch.fx.Node) -> str:
+                    tensor_arg = node.args[0]
+                    assert isinstance(tensor_arg, torch.fx.Node)
+                    tensor_val = tensor_arg.meta.get("val")
+                    assert isinstance(tensor_val, torch.Tensor)
+                    return self.tensor_arg(tensor_val).name
+
+                if node.target is memory_ops.load:
+                    read_names.add(_get_tensor_name(node))
+                elif node.target is memory_ops.store:
+                    write_names.add(_get_tensor_name(node))
+                elif node.target in (
+                    atomic_ops.atomic_add,
+                    atomic_ops.atomic_cas,
+                    atomic_ops.atomic_or,
+                    atomic_ops.atomic_xor,
+                    atomic_ops.atomic_xchg,
+                    atomic_ops.atomic_min,
+                    atomic_ops.atomic_max,
+                    atomic_ops.atomic_and,
+                ):
+                    read_names.add(_get_tensor_name(node))
+                    write_names.add(_get_tensor_name(node))
+        return read_names, write_names
+
     def __enter__(self) -> None:
         try:
             tls.functions.append(self)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -722,11 +722,17 @@ class TestPallas(TestCase):
         key = torch.randn(1, 4, 32, 64, dtype=torch.float32, device=DEVICE)
         val = torch.randn(1, 4, 32, 64, dtype=torch.float32, device=DEVICE)
         args = (query, key, val)
+
         _code, result = code_and_output(pallas_attention, args, block_sizes=[1, 32, 32])
         ref = torch.nn.functional.scaled_dot_product_attention(
             query.float().cpu(), key.float().cpu(), val.float().cpu()
         ).to(device=DEVICE)
         torch.testing.assert_close(result, ref, rtol=1e-2, atol=1e-2)
+
+        # test that we're not manually allocating and donating out tensor HBM,
+        # but are instead taking over tensor returned by torch_tpu JaxCallable
+        self.assertIn("out = torch.empty_like(q_view, device='meta')", _code)
+        self.assertIn("out = _launcher(", _code)
 
     def test_attention_emit_pipeline_correctness(self) -> None:
         """Test emit_pipeline attention with loop-carried state."""


### PR DESCRIPTION
Previously, we're using AST to analyze what are the read/write tensors in the kernel. This is often too conservative -- where tensors that are only written are marked as both read and write. This PR modifies this to do this analysis on the FX graph `memory_ops` level, which is a lot more accurate. This enables more kernels to go through the "output_only" optimizations in #1849 landed by @norx1991, including `attention.`.

With this PR, [this attention kernel](https://gist.github.com/AmesingFlank/80cc424005a7d13113ee814e07510207) increases from 195 TFLOPS to 201 TFLOPS.