### PR TITLE
[Autotuner] Skip `temperature` for claude-opus-4-7 (HTTP 400)

### DIFF
--- a/helion/autotuner/llm/transport.py
+++ b/helion/autotuner/llm/transport.py
@@ -157,12 +157,15 @@ def _anthropic_payload(
 ) -> dict[str, Any]:
     """Build an Anthropic Messages request payload."""
     system_prompt, input_messages = split_system_messages(messages)
+    normalized_model = strip_provider_prefix(model)
     payload: dict[str, Any] = {
-        "model": strip_provider_prefix(model),
+        "model": normalized_model,
         "messages": anthropic_messages_from_history(input_messages),
         "max_tokens": max_output_tokens,
-        "temperature": DEFAULT_ANTHROPIC_TEMPERATURE,
     }
+    # Claude Opus 4.7 returns HTTP 400 if `temperature` is present.
+    if not normalized_model.lower().startswith("claude-opus-4-7"):
+        payload["temperature"] = DEFAULT_ANTHROPIC_TEMPERATURE
     if system_prompt:
         payload["system"] = system_prompt
     return payload


### PR DESCRIPTION
Stacked PRs:
 * #2090
 * __->__#2089


--- --- ---

Opus 4.7 does not support the temperature API. 
Benchmarking on H100: 
<img width="933" height="297" alt="image" src="https://github.com/user-attachments/assets/5b1b4a33-f155-46fe-9ccf-0015ebafba30" />

LLM full autotuning (upto 4 rounds of prompts) vs LLM seeded LFBO full autotuning vs LFBO full. 

LLM full: matches LFBO on 6/7 kernels in 9.9% of the tune time (≈10× speedup). cross_entropy is the outlier. Early-stopped at 2 rounds with a bad config.                                                           
                                                                                                                                                                                                                        
Hybrid: matches LFBO on 7/7 kernels in 34.4% of the tune time (≈3× speedup). 

