### PR TITLE
[Pallas] Per-tensor pipelining decision in fori_loop and emit_pipeline

### DIFF
--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -85,15 +85,19 @@ def index_str(
     if not subscript:
         return "...", []
 
-    # Check if we're inside an emit_pipeline or fori_loop with DMA.
-    # When fori_loop runs without DMA (use_dma=False), its block_ids
-    # are NOT treated as pipeline dims — they get pl.ds() slicing instead.
+    # Check if we're inside an emit_pipeline or fori_loop that pipelines
+    # this specific tensor.  Both loop types take a per-tensor decision:
+    # only tensors present in the loop's _tensor_to_dma_scratch mapping were
+    # routed through the inner DMA / Buffered BlockSpec.  Others stay on
+    # their outer BlockSpec and fall through to pl.ds().
+    tensor_name = state.codegen.device_function.tensor_arg(tensor).name
     in_pipeline = False
     pipeline_block_ids: set[int] = set()
     for loops in state.codegen.active_device_loops.values():
         for loop in loops:
-            if isinstance(loop, EmitPipelineLoopState) or (
-                isinstance(loop, ForiLoopState) and loop.use_dma
+            if (
+                isinstance(loop, (EmitPipelineLoopState, ForiLoopState))
+                and tensor_name in loop._tensor_to_dma_scratch
             ):
                 in_pipeline = True
                 pipeline_block_ids.update(loop.block_ids)
@@ -189,6 +193,7 @@ def _tile_pattern_code(
 ) -> str:
     from helion._compiler.pallas.plan_tiling import TilePattern
     from helion._compiler.tile_strategy import DeviceLoopState
+    from helion._compiler.tile_strategy import EmitPipelineLoopState
     from helion._compiler.tile_strategy import ForiLoopState
 
     assert isinstance(pattern, TilePattern)
@@ -208,10 +213,12 @@ def _tile_pattern_code(
     if not can_tile:
         return _ds_expr(state, block_id, tensor=tensor, tensor_dim=tensor_dim)
 
+    # Non-pipelined inner-loop tensors: a pipeline/fori loop exists over
+    # this block_id but this specific tensor was left on its outer
+    # BlockSpec, so the kernel must slice it in VMEM with pl.ds().
     loops = state.codegen.active_device_loops.get(block_id)
     if loops and any(
-        isinstance(loop, DeviceLoopState)
-        or (isinstance(loop, ForiLoopState) and not loop.use_dma)
+        isinstance(loop, (DeviceLoopState, EmitPipelineLoopState, ForiLoopState))
         for loop in loops
     ):
         return _ds_expr(state, block_id, tensor=tensor, tensor_dim=tensor_dim)
@@ -293,8 +300,7 @@ def _slice_code(
     if block_id is not None:
         loops = state.codegen.active_device_loops.get(block_id)
         if loops and any(isinstance(loop, DeviceLoopState) for loop in loops):
-            if block_id is not None:
-                return _ds_expr(state, block_id, tensor=tensor, tensor_dim=tensor_dim)
+            return _ds_expr(state, block_id, tensor=tensor, tensor_dim=tensor_dim)
 
     return ":"
 
@@ -391,7 +397,7 @@ def vmem_name(state: CodegenState, name: str) -> str:
     for loops in state.codegen.active_device_loops.values():
         for loop in loops:
             if isinstance(loop, (EmitPipelineLoopState, ForiLoopState)):
-                mapping = getattr(loop, "_tensor_to_vmem", None)
+                mapping = getattr(loop, "_tensor_to_dma_scratch", None)
                 if mapping and name in mapping:
                     return mapping[name]
     return name

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -132,24 +132,25 @@ class EmitPipelineLoopState(DeviceLoopOrGridState):
     pipeline_call: ast.AST | None = None
     outer_prefix: list[ast.AST] = dataclasses.field(default_factory=list)
     outer_suffix: list[ast.AST] = dataclasses.field(default_factory=list)
+    _tensor_to_dma_scratch: dict[str, str] = dataclasses.field(default_factory=dict)
 
 
 @dataclasses.dataclass
 class ForiLoopState(DeviceLoopOrGridState):
     """State for fori_loop-based loops on TPU (Pallas backend).
 
-    Uses jax.lax.fori_loop with pltpu.make_async_copy for manual DMA control.
-    When ``use_dma=False``, skips DMA and accesses HBM refs directly via
-    ``pl.ds`` slicing (used when inner block shapes violate TPU DMA alignment).
+    Uses jax.lax.fori_loop with pltpu.make_async_copy for tensors whose
+    inner-block shape passes ``_check_dma_alignment``; tensors that fail
+    are kept on their outer BlockSpec and accessed via ``pl.ds`` from the
+    body.  Per-tensor pipelining membership lives in ``_tensor_to_dma_scratch``.
     """
 
     body_fn_name: str
     loop_var_name: str  # The fori_loop index variable (e.g., "_j")
-    use_dma: bool = True
     inner_statements: list[ast.AST] = dataclasses.field(default_factory=list)
     outer_prefix: list[ast.AST] = dataclasses.field(default_factory=list)
     outer_suffix: list[ast.AST] = dataclasses.field(default_factory=list)
-    _tensor_to_vmem: dict[str, str] = dataclasses.field(default_factory=dict)
+    _tensor_to_dma_scratch: dict[str, str] = dataclasses.field(default_factory=dict)
     _tensor_to_sem: dict[str, str] = dataclasses.field(default_factory=dict)
 
 

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -1298,6 +1298,13 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         state, block_ids, block_size_vars
     )
 
+    # Aligned tensors flow through emit_pipeline's per-iter Buffered
+    # BlockSpec; unaligned ones stay on the outer pallas_call BlockSpec
+    # (escape clause `bs == as`) and are closure-read from the body.
+    all_tensor_info, _vmem_shapes, aligned_tensor_ids = _classify_pipelined_tensors(
+        loaded_tensors, stored_tensors, block_ids, slice_size_exprs, env, state
+    )
+
     # Build in_specs and out_specs
     in_tensors: list[tuple[torch.Tensor, str]] = []
     out_tensors: list[tuple[torch.Tensor, str]] = []
@@ -1433,18 +1440,20 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
             env,
         )
 
-    # Record which tensors are in the pipeline body (need HBM refs)
     from .._compiler.device_function import PallasMemorySpace
 
     for fake, _tensor_node, _sub_meta in loaded_tensors.values():
-        state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
+        if id(fake) in aligned_tensor_ids:
+            state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
     for fake, _tensor_node, _sub_meta in stored_tensors.values():
-        state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
+        if id(fake) in aligned_tensor_ids:
+            state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
 
-    # Process loaded tensors (inputs to pipeline)
     for key, (fake, _tensor_node, sub_meta) in loaded_tensors.items():
         if key in stored_tensors:
             continue  # Handle as output instead
+        if id(fake) not in aligned_tensor_ids:
+            continue
         hbm_name = state.device_function.tensor_arg(fake).name
         vmem_name = state.device_function.new_var(
             hbm_name.replace("_hbm", "") + "_vmem"
@@ -1452,11 +1461,11 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         in_tensors.append((fake, hbm_name))
         in_specs.append(_make_block_spec(fake, sub_meta))
         body_params.append(vmem_name)
-        # Pass full HBM ref -- BlockSpec lambda handles outer grid indexing
         pipeline_in_args.append(hbm_name)
 
-    # Process stored tensors (outputs of pipeline, may also be read)
     for fake, _tensor_node, sub_meta in stored_tensors.values():
+        if id(fake) not in aligned_tensor_ids:
+            continue
         hbm_name = state.device_function.tensor_arg(fake).name
         vmem_name = state.device_function.new_var(
             hbm_name.replace("_hbm", "") + "_vmem"
@@ -1464,7 +1473,6 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         out_tensors.append((fake, hbm_name))
         out_specs.append(_make_block_spec(fake, sub_meta))
         body_params.append(vmem_name)
-        # Pass full HBM ref -- BlockSpec lambda handles outer grid indexing
         pipeline_out_args.append(hbm_name)
 
     # Build the body function
@@ -1505,14 +1513,32 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
             f"_pipeline_indices[{i}] * {bs} + jnp.arange({bs})"
         ),
     )
-    # Build tensor_to_vmem mapping
-    tensor_to_vmem: dict[str, str] = {}
+
+    # Emit absolute offset assignments inside the pipeline body so any
+    # non-pipelined tensors (those left on their outer BlockSpec) can be
+    # sliced via pl.ds against a VMEM ref whose extent is the whole
+    # outer-block window.  Pipelined tensors ignore these offsets and
+    # use the ``:`` full-slice inside their VMEM scratches.
+    any_non_pipelined = len(aligned_tensor_ids) < len(all_tensor_info)
+    if any_non_pipelined:
+        _needs_explicit_indices = True
+        for i, bid in enumerate(block_ids):
+            offset_name = strategy.offset_var(bid)
+            body_stmts.append(
+                statement_from_string(
+                    f"{offset_name} = ({begin_exprs[i]}) + "
+                    f"(_pipeline_indices[{i}]) * ({iter_step_exprs[i]})"
+                )
+            )
+
+    # Build tensor_to_dma_scratch mapping
+    tensor_to_dma_scratch: dict[str, str] = {}
     idx = 0
     for _fake, hbm_name in in_tensors:
-        tensor_to_vmem[hbm_name] = body_params[idx]
+        tensor_to_dma_scratch[hbm_name] = body_params[idx]
         idx += 1
     for _fake, hbm_name in out_tensors:
-        tensor_to_vmem[hbm_name] = body_params[idx]
+        tensor_to_dma_scratch[hbm_name] = body_params[idx]
         idx += 1
 
     # Create the pipeline loop state
@@ -1521,8 +1547,8 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         block_id_to_info=block_id_to_info,
         body_fn_name=body_fn_name,
         inner_statements=body_stmts,
+        _tensor_to_dma_scratch=tensor_to_dma_scratch,
     )
-    pipeline_state._tensor_to_vmem = tensor_to_vmem  # type: ignore[attr-defined]
 
     # For loop-carried state, remap args to scratch reads inside the body
     body_args = (
@@ -1642,6 +1668,42 @@ def _compute_vmem_shapes(
     return vmem_shapes
 
 
+def _classify_pipelined_tensors(
+    loaded_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
+    stored_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
+    block_ids: list[int],
+    slice_size_exprs: list[str],
+    env: CompileEnvironment,
+    state: CodegenState,
+) -> tuple[
+    list[tuple[torch.Tensor, list[object], str]], list[tuple[int, ...]], set[int]
+]:
+    """Build (all_tensor_info, vmem_shapes, aligned_ids) for an inner loop.
+
+    Tensors whose ``vmem_shape`` passes ``_check_dma_alignment`` are eligible
+    for the inner-DMA path (HBM ref + small VMEM scratch in fori_loop, or
+    ``pl.Buffered`` BlockSpec in emit_pipeline); the rest stay on their
+    outer ``pallas_call`` BlockSpec and are closure-read from the body.
+    """
+    all_tensor_info: list[tuple[torch.Tensor, list[object], str]] = []
+    for key, (fake, _tensor_node, sub_meta) in loaded_tensors.items():
+        if key not in stored_tensors:
+            all_tensor_info.append((fake, sub_meta, "load"))
+    for fake, _tensor_node, sub_meta in stored_tensors.values():
+        all_tensor_info.append((fake, sub_meta, "store"))
+    vmem_shapes = _compute_vmem_shapes(
+        all_tensor_info, block_ids, slice_size_exprs, env, state
+    )
+    aligned_ids = {
+        id(fake)
+        for (fake, _sub_meta, _direction), vmem_shape in zip(
+            all_tensor_info, vmem_shapes, strict=True
+        )
+        if _check_dma_alignment(vmem_shape)
+    }
+    return all_tensor_info, vmem_shapes, aligned_ids
+
+
 def _codegen_fori_loop(state: CodegenState) -> object:
     """Emit inner device loops using jax.lax.fori_loop.
 
@@ -1700,47 +1762,37 @@ def _codegen_fori_loop(state: CodegenState) -> object:
             env,
         )
 
-    # Collect all tensors: load-only first, then stored (which may also be read)
-    all_tensor_info: list[tuple[torch.Tensor, list[object], str]] = []
-    for key, (fake, _tensor_node, sub_meta) in loaded_tensors.items():
-        if key not in stored_tensors:
-            all_tensor_info.append((fake, sub_meta, "load"))
-    for fake, _tensor_node, sub_meta in stored_tensors.values():
-        all_tensor_info.append((fake, sub_meta, "store"))
-
-    # Compute VMEM shapes and check DMA alignment
-    vmem_shapes = _compute_vmem_shapes(
-        all_tensor_info, block_ids, slice_size_exprs, env, state
+    # Aligned tensors get HBM refs (no outer BlockSpec) + VMEM scratch +
+    # semaphore; unaligned tensors keep their outer BlockSpec and are
+    # accessed via pl.ds() in the body.  Mixing both paths inside a single
+    # fori_loop avoids forcing every tensor onto the non-DMA path when a
+    # lone unaligned tensor is present (which would load full outer-block
+    # tiles into VMEM and may OOM at large shapes).
+    all_tensor_info, vmem_shapes, aligned_tensor_ids = _classify_pipelined_tensors(
+        loaded_tensors, stored_tensors, block_ids, slice_size_exprs, env, state
     )
-    use_dma = all(_check_dma_alignment(shape) for shape in vmem_shapes)
 
-    # With DMA: tensors need HBM refs (no outer BlockSpec) because DMA
-    # handles all slicing, and we register VMEM scratch buffers +
-    # semaphores for each tensor.  Without DMA: outer BlockSpecs handle
-    # outer dims and inner dims use pl.ds(), so neither is needed.
-    tensor_to_vmem: dict[str, str] = {}
+    from .._compiler.device_function import PallasMemorySpace
+
+    tensor_to_dma_scratch: dict[str, str] = {}
     tensor_to_sem: dict[str, str] = {}
-    if use_dma:
-        from .._compiler.device_function import PallasMemorySpace
-
-        for fake, _tensor_node, _sub_meta in loaded_tensors.values():
-            state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
-        for fake, _tensor_node, _sub_meta in stored_tensors.values():
-            state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
-        for (fake, _sub_meta, _direction), vmem_shape in zip(
-            all_tensor_info, vmem_shapes, strict=True
-        ):
-            hbm_name = state.device_function.tensor_arg(fake).name
-            vmem_name = state.device_function.register_scratch(
-                vmem_shape,
-                fake.dtype,
-                name_hint=hbm_name.replace("_hbm", "") + "_buf",
-            )
-            sem_name = state.device_function.register_dma_semaphore(
-                name_hint=hbm_name.replace("_hbm", "") + "_sem",
-            )
-            tensor_to_vmem[hbm_name] = vmem_name
-            tensor_to_sem[hbm_name] = sem_name
+    for (fake, _sub_meta, _direction), vmem_shape in zip(
+        all_tensor_info, vmem_shapes, strict=True
+    ):
+        if id(fake) not in aligned_tensor_ids:
+            continue
+        state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
+        hbm_name = state.device_function.tensor_arg(fake).name
+        vmem_name = state.device_function.register_scratch(
+            vmem_shape,
+            fake.dtype,
+            name_hint=hbm_name.replace("_hbm", "") + "_buf",
+        )
+        sem_name = state.device_function.register_dma_semaphore(
+            name_hint=hbm_name.replace("_hbm", "") + "_sem",
+        )
+        tensor_to_dma_scratch[hbm_name] = vmem_name
+        tensor_to_sem[hbm_name] = sem_name
 
     # Build the body function
     body_stmts: list[ast.AST] = []
@@ -1800,9 +1852,8 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         block_id_to_info=block_id_to_info,
         body_fn_name="_fori_body_0",
         loop_var_name=loop_vars[0],
-        use_dma=use_dma,
         inner_statements=body_stmts,
-        _tensor_to_vmem=tensor_to_vmem,
+        _tensor_to_dma_scratch=tensor_to_dma_scratch,
         _tensor_to_sem=tensor_to_sem,
     )
 
@@ -1857,53 +1908,59 @@ def _codegen_fori_loop(state: CodegenState) -> object:
 
     # Generate body code within the fori_loop context
     with state.codegen.add_fori_loop(fori_state):
-        if use_dma:
-            # Emit DMA read copies at start of body
-            for fake, _tensor_node, sub_meta in loaded_tensors.values():
-                hbm_name = state.device_function.tensor_arg(fake).name
-                vmem_name = tensor_to_vmem[hbm_name]
-                sem_name = tensor_to_sem[hbm_name]
-                src_slice = _build_hbm_dma_slice(fake, hbm_name, sub_meta)
-                copy_var = state.device_function.new_var("_copy")
+        # Non-DMA tensors keep their outer BlockSpec (whole-shape VMEM ref)
+        # and need an absolute offset for ``pl.ds()`` indexing in the body.
+        # DMA copies build their own absolute slice via _build_hbm_dma_slice,
+        # so this offset is dead when every tensor is DMA'd.
+        if len(tensor_to_dma_scratch) < len(all_tensor_info):
+            for i, bid in enumerate(block_ids):
+                offset_name = strategy.offset_var(bid)
                 state.codegen.add_statement(
                     statement_from_string(
-                        f"{copy_var} = pltpu.make_async_copy({src_slice}, {vmem_name}, {sem_name})"
+                        f"{offset_name} = ({begin_exprs[i]}) + ({dim_idx_exprs[i]}) * ({iter_step_exprs[i]})"
                     )
                 )
-                state.codegen.add_statement(
-                    statement_from_string(f"{copy_var}.start()")
-                )
-                state.codegen.add_statement(statement_from_string(f"{copy_var}.wait()"))
 
-        # Codegen the user's body (loads/stores remapped via _tensor_to_vmem
-        # when using DMA, or accessing HBM refs directly when not)
+        for fake, _tensor_node, sub_meta in loaded_tensors.values():
+            hbm_name = state.device_function.tensor_arg(fake).name
+            if hbm_name not in tensor_to_dma_scratch:
+                continue
+            vmem_name = tensor_to_dma_scratch[hbm_name]
+            sem_name = tensor_to_sem[hbm_name]
+            src_slice = _build_hbm_dma_slice(fake, hbm_name, sub_meta)
+            copy_var = state.device_function.new_var("_copy")
+            state.codegen.add_statement(
+                statement_from_string(
+                    f"{copy_var} = pltpu.make_async_copy({src_slice}, {vmem_name}, {sem_name})"
+                )
+            )
+            state.codegen.add_statement(statement_from_string(f"{copy_var}.start()"))
+            state.codegen.add_statement(statement_from_string(f"{copy_var}.wait()"))
+
         graph_results = codegen_call_with_graph(
             state.codegen, graph_info.graph, body_args
         )
 
-        # Write updated loop-carried values back to scratch
         if has_loop_state:
             _write_back_loop_carried(state, scratch_names, carried, graph_results)
 
-        if use_dma:
-            # Emit DMA write copies at end of body for stored tensors
-            for fake, _tensor_node, sub_meta in stored_tensors.values():
-                hbm_name = state.device_function.tensor_arg(fake).name
-                vmem_name = tensor_to_vmem[hbm_name]
-                sem_name = tensor_to_sem[hbm_name]
-                dst_slice = _build_hbm_dma_slice(fake, hbm_name, sub_meta)
-                copy_out_var = state.device_function.new_var("_copy_out")
-                state.codegen.add_statement(
-                    statement_from_string(
-                        f"{copy_out_var} = pltpu.make_async_copy({vmem_name}, {dst_slice}, {sem_name})"
-                    )
+        for fake, _tensor_node, sub_meta in stored_tensors.values():
+            hbm_name = state.device_function.tensor_arg(fake).name
+            if hbm_name not in tensor_to_dma_scratch:
+                continue
+            vmem_name = tensor_to_dma_scratch[hbm_name]
+            sem_name = tensor_to_sem[hbm_name]
+            dst_slice = _build_hbm_dma_slice(fake, hbm_name, sub_meta)
+            copy_out_var = state.device_function.new_var("_copy_out")
+            state.codegen.add_statement(
+                statement_from_string(
+                    f"{copy_out_var} = pltpu.make_async_copy({vmem_name}, {dst_slice}, {sem_name})"
                 )
-                state.codegen.add_statement(
-                    statement_from_string(f"{copy_out_var}.start()")
-                )
-                state.codegen.add_statement(
-                    statement_from_string(f"{copy_out_var}.wait()")
-                )
+            )
+            state.codegen.add_statement(
+                statement_from_string(f"{copy_out_var}.start()")
+            )
+            state.codegen.add_statement(statement_from_string(f"{copy_out_var}.wait()"))
 
     # Emit nested fori_loop calls — one per dimension.
     # Build inside-out: innermost function wraps body_stmts, each outer

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -698,7 +698,7 @@ class TestExamples(RefEagerTestBase, TestCase):
     @xfailIfCute("CuTe RMSNorm backward example still returns incorrect results")
     def test_rms_norm_bwd(self):
         """Test backward pass for rms norm weight gradient."""
-        batch_size, dim = 32, 64
+        batch_size, dim = 2048, 2048
         x = torch.randn([batch_size, dim], device=DEVICE, dtype=torch.float32)
         weight = torch.randn(
             [dim], device=DEVICE, dtype=torch.float32, requires_grad=True

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -316,6 +316,21 @@ def pallas_attention(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_row_scale_mul(x: torch.Tensor, r: torch.Tensor) -> torch.Tensor:
+    """Elementwise multiply ``x [M, N]`` by per-row scale ``r [M, 1]``.
+
+    Iterates rows with a two-level tiling: an outer CTA tile and an inner
+    ``hl.tile(begin, end)`` that becomes the per-Pallas-loop-type body.
+    """
+    m, _ = x.shape
+    out = torch.empty_like(x)
+    for mb_cta in hl.tile(m, block_size=8):
+        for mb in hl.tile(mb_cta.begin, mb_cta.end):
+            out[mb, :] = x[mb, :] * r[mb, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_reduce_non_pow2(x: torch.Tensor) -> torch.Tensor:
     """Softmax over a non-power-of-2 reduction dim.
 
@@ -1520,6 +1535,45 @@ class TestPallas(TestCase):
         )
         ref = x.view(8, 8, 128).sum(1)
         torch.testing.assert_close(result, ref, rtol=1e-3, atol=1e-3)
+
+    def test_emit_pipeline_per_tensor_pipelined_mixed(self) -> None:
+        """An emit_pipeline body can mix pipelined and non-pipelined tensors.
+
+        Aligned tensors pass through ``pltpu.emit_pipeline``'s ``pl.Buffered``
+        BlockSpecs, while unaligned ones stay on the outer pallas_call
+        BlockSpec and are closure-read from the body via ``pl.ds``.
+        """
+        x = torch.randn(64, 128, device=DEVICE, dtype=torch.float32)
+        r = torch.randn(64, 1, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_row_scale_mul,
+            (x, r),
+            block_sizes=[8],
+            pallas_loop_type="emit_pipeline",
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+        self.assertIn("pl.ds(", code)
+        torch.testing.assert_close(result, x * r)
+
+    def test_fori_loop_per_tensor_dma_mixed(self) -> None:
+        """A fori_loop body can mix DMA-aligned and DMA-unaligned tensors.
+
+        Aligned tensors take ``pltpu.make_async_copy`` scratch buffers; the
+        unaligned tensor stays in its outer BlockSpec VMEM ref and is read
+        via ``pl.ds``.
+        """
+        x = torch.randn(64, 128, device=DEVICE, dtype=torch.float32)
+        r = torch.randn(64, 1, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_row_scale_mul,
+            (x, r),
+            block_sizes=[8],
+            pallas_loop_type="fori_loop",
+        )
+        self.assertIn("pltpu.make_async_copy", code)
+        self.assertIn("pl.ds(", code)
+        self.assertIn("_pipeline_arg_indices=", code)
+        torch.testing.assert_close(result, x * r)
 
     def test_squeeze_slice_access(self) -> None:
         """Test for the [None, :] indexing pattern (subscript index for slice >= tensor_ndim)"""


### PR DESCRIPTION
## Summary

A single unaligned inner-loop tensor (e.g. `[M, 1]`) previously forced every other inner-loop tensor in the same construct onto a fallback that doesn't scale:

- In **fori_loop**: the fallback gave every tensor a full-shape outer BlockSpec, which overwhelms VMEM at large shapes.
- In **emit_pipeline**: the unaligned tensor's per-iter `pl.BlockSpec((k, 1), pipeline_mode=pl.Buffered(...))` fails Mosaic's strict inner-DMA alignment check and the whole pipeline fails to compile.

This PR makes the pipelining decision per-tensor in both constructs:

- Aligned tensors get HBM refs at the `pallas_call` layer + small inner-block VMEM scratches (the existing DMA / `pl.Buffered` path).
- Unaligned tensors are left off the inner construct's argument list.  They keep the outer BlockSpec — at **whole-tensor** size, where the `bs == as` escape clause satisfies Pallas's outer alignment rule — and the kernel body **closes over** the resulting VMEM ref and slices it with `pl.ds`.

The whole-tensor outer BlockSpec + body-side `pl.ds` is the substantive new behavior; the rest is the refactor that turns a single boolean `use_dma` into a per-tensor classification.

### Motivating example: `rms_norm_bwd`

`rms_norm_bwd` is a fori_loop kernel that takes a wide `[M, N]` input and a row-scale companion `rstd: [M]`. The companion's inner-block slice `[BLOCK_M]` fails `_check_dma_alignment` (e.g. `BLOCK_M=32 % 128 != 0`).

- **Before:** the lone unaligned `rstd` forced `x`, `grad_out`, `grad_x` onto the non-DMA fallback. At `M=N=2048`, Helion's VMEM estimate exceeded the budget (101 MiB > 67 MiB) and the kernel failed to compile.
- **After:** `rstd` is closure-read from the outer `pallas_call` VMEM ref (8 KiB whole-tensor). The wide tensors keep the inner-DMA path and stay sized to the inner block. The kernel compiles and runs.

### Helion-side kernel pattern

```python
@helion.kernel(backend="pallas")
def kernel(x: torch.Tensor, r: torch.Tensor) -> torch.Tensor:
    # x: [M, N] aligned (DMA path)
    # r: [M, 1] unaligned -> closure path
    out = torch.empty_like(x)
    m_block = hl.register_block_size(x.size(0))
    for mb_cta in hl.tile(x.size(0), block_size=m_block):
        for mb in hl.tile(mb_cta.begin, mb_cta.end):
            out[mb, :] = x[mb, :] * r[mb, :]
    return out
```

Generated code (fori_loop loop_type, abbreviated):

```python
# x and out: HBM refs, DMA-copied into inner-block scratch
_copy_x = pltpu.make_async_copy(x.at[pl.ds(off + _j * 32, 32), :], x_buf, x_sem)
...
# r: stays on outer pallas_call BlockSpec at whole-tensor shape [M, 1] (escape clause).
# The pipeline body does NOT receive r as an argument; the body closes over r_vmem
# from the outer scope and slices it with pl.ds() per iteration.
load_r = r_vmem[pl.ds(off + _j * 32, 32), :]
```

The same routing applies to `pltpu.emit_pipeline`: aligned tensors appear in `in_specs`; unaligned ones are read from closure inside the body.
