### PR TITLE
Removing MI325 runners from CI

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -93,17 +93,6 @@
       "triton-pin": "0d9283bf49"
     },
     {
-      "runner": "linux.rocm.gpu.gfx942.1",
-      "python-version": "3.12",
-      "ref-eager": false,
-      "image": "rocm/dev-ubuntu-24.04:7.0-complete",
-      "runtime-version": "rocm7.0",
-      "container-options": "--device=/dev/kfd --device=/dev/dri",
-      "pytorch-version": "pytorch-nightly",
-      "alias": "mi325x",
-      "backend": "triton"
-    },
-    {
       "runner": "linux.rocm.gpu.ecosystem.gfx950.1",
       "python-version": "3.12",
       "ref-eager": false,

--- a/.github/workflows/benchmark_dispatch.yml
+++ b/.github/workflows/benchmark_dispatch.yml
@@ -13,11 +13,6 @@ on:
         required: false
         type: boolean
         default: true
-      run_mi325x:
-        description: 'Run benchmark on MI325X'
-        required: false
-        type: boolean
-        default: false
       run_mi350x:
         description: 'Run benchmark on MI350X'
         required: false
@@ -90,33 +85,6 @@ jobs:
       runtime-version: cu130
       container-options: --gpus all
       alias: b200
-      kernels: ${{ matrix.kernels }}
-      env-vars: ${{ github.event.inputs.env_vars }}
-      custom-args: ${{ github.event.inputs.custom_args }}
-
-  gen-matrix-mi325x:
-    uses: ./.github/workflows/compute-benchmark-matrix.yml
-    if: ${{ github.event.inputs.run_mi325x == 'true' }}
-    with:
-      max-runners: 6
-      kernels: ${{ github.event.inputs.kernels }}
-
-  run-mi325x:
-    needs: gen-matrix-mi325x
-    uses: ./.github/workflows/benchmark.yml
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.gen-matrix-mi325x.outputs.matrix) }}
-    permissions:
-      id-token: write
-      contents: read
-    with:
-      runner: linux.rocm.gpu.gfx942.1
-      python-version: "3.12"
-      image: rocm/dev-ubuntu-24.04:7.1.1-complete
-      runtime-version: rocm7.1
-      container-options: --device=/dev/kfd --device=/dev/dri
-      alias: mi325x
       kernels: ${{ matrix.kernels }}
       env-vars: ${{ github.event.inputs.env_vars }}
       custom-args: ${{ github.event.inputs.custom_args }}

--- a/.github/workflows/benchmark_nightly.yml
+++ b/.github/workflows/benchmark_nightly.yml
@@ -25,7 +25,6 @@ jobs:
               inputs: {
                 run_h100: 'true',
                 run_b200: 'true',
-                run_mi325x: 'true',
                 run_mi350x: 'true'
               }
             })


### PR DESCRIPTION
This PR removes MI325 runners from the CI.
We recently added MI350 runners for Helion CI. There have been limited number of MI325 runners in the CI as such we were never able to get the full coverage with the nightlys. It is best that we run only on MI350 since that is the latest platform and we have enough MI350 runners to cover the nightlys.  
