### PR TITLE
Benchmark: Reduce running Tritonbench for each kernel from twice to once. 

### DIFF
--- a/.github/dashboard/build_dashboard_data.py
+++ b/.github/dashboard/build_dashboard_data.py
@@ -159,7 +159,7 @@ def build_history_entry(run, metrics, shapes):
         "helion_speedup_geomean": round(geo_mean(metrics.get("helion_speedup", [])), 4),
         "triton_speedup_geomean": round(geo_mean(metrics.get("triton_speedup", [])), 4),
         "torch_compile_speedup_geomean": round(geo_mean(metrics.get("torch_compile_speedup", [])), 4),
-        "compile_time_avg_s": round(avg(metrics.get("helion_compile_time_s", [])), 2),
+        "compile_time_geomean_s": round(geo_mean(metrics.get("helion_compile_time_s", [])), 2),
         "helion_latency_avg_ms": round(avg(helion_lat), 4) if helion_lat else 0,
         "per_shape": {
             "shapes": shapes,
@@ -269,7 +269,7 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None):
                 break
 
         speedup_delta = fmt_delta(latest_data["helion_speedup_geomean"], prev_data["helion_speedup_geomean"]) if latest_data and prev_data else None
-        compile_delta = fmt_delta(prev_data["compile_time_avg_s"], latest_data["compile_time_avg_s"]) if latest_data and prev_data and latest_data["compile_time_avg_s"] > 0 else None
+        compile_delta = fmt_delta(prev_data["compile_time_geomean_s"], latest_data["compile_time_geomean_s"]) if latest_data and prev_data and latest_data["compile_time_geomean_s"] > 0 else None
         latency_delta = fmt_delta(prev_data["helion_latency_avg_ms"], latest_data["helion_latency_avg_ms"]) if latest_data and prev_data and latest_data["helion_latency_avg_ms"] > 0 else None
 
         classify_delta = latency_delta if latency_delta is not None else speedup_delta
@@ -312,7 +312,7 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None):
             "helion_speedup_geomean": latest_data["helion_speedup_geomean"] if latest_data else 0,
             "triton_speedup_geomean": latest_data["triton_speedup_geomean"] if latest_data else 0,
             "torch_compile_speedup_geomean": latest_data["torch_compile_speedup_geomean"] if latest_data else 0,
-            "compile_time_avg_s": latest_data["compile_time_avg_s"] if latest_data else 0,
+            "compile_time_geomean_s": latest_data["compile_time_geomean_s"] if latest_data else 0,
             "helion_latency_avg_ms": latest_data["helion_latency_avg_ms"] if latest_data else 0,
             "speedup_delta_pct": speedup_delta,
             "compile_delta_pct": compile_delta,

--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -386,7 +386,7 @@ function renderOverviewGrid() {
         html += '</div>';
         html += '<div class="kc-body"><div class="kc-left">';
         html += `<div class="kc-row"><span class="kc-label">Latency</span><span class="kc-val" style="color:${color}">${e.helion_latency_avg_ms.toFixed(2)} ms</span></div>`;
-        html += `<div class="kc-row"><span class="kc-label">Compile time</span><span class="kc-val">${formatCompileTime(e.compile_time_avg_s)}</span></div>`;
+        html += `<div class="kc-row"><span class="kc-label">Compile time</span><span class="kc-val">${formatCompileTime(e.compile_time_geomean_s)}</span></div>`;
         html += `<div class="kc-delta">Latency vs prev: ${formatDelta(e.latency_delta_pct, true)}</div>`;
         html += `<div class="kc-delta">Compile time vs prev: ${formatDelta(e.compile_delta_pct, true)}</div>`;
         html += '</div>';
@@ -524,7 +524,7 @@ function renderSpeedup() {
       <td style="color:var(--green)">${formatSpeedup(e.helion_speedup_geomean)}</td>
       <td style="color:var(--blue)">${formatSpeedup(e.torch_compile_speedup_geomean)}</td>
       <td style="color:var(--purple)">${formatSpeedup(e.triton_speedup_geomean)}</td>
-      <td>${formatCompileTime(e.compile_time_avg_s)}</td>
+      <td>${formatCompileTime(e.compile_time_geomean_s)}</td>
       <td style="color:${colors[bestIdx]}">${names[bestIdx]}</td>
     </tr>`;
   });
@@ -570,8 +570,8 @@ function renderCompare(baseRunIdOverride, cmpRunIdOverride, baseBranchOverride, 
       if (!baseH && !cmpH) return;
       const baseSpeedup = baseH ? baseH.helion_speedup_geomean : null;
       const cmpSpeedup = cmpH ? cmpH.helion_speedup_geomean : null;
-      const baseCompile = baseH ? baseH.compile_time_avg_s : null;
-      const cmpCompile = cmpH ? cmpH.compile_time_avg_s : null;
+      const baseCompile = baseH ? baseH.compile_time_geomean_s : null;
+      const cmpCompile = cmpH ? cmpH.compile_time_geomean_s : null;
       const baseLatency = baseH ? baseH.helion_latency_avg_ms : null;
       const cmpLatency = cmpH ? cmpH.helion_latency_avg_ms : null;
       let speedupDelta = null;
@@ -778,7 +778,7 @@ function showDetailModal(kernel, platform_short) {
   const color = platColor(platform_short);
   let html = modalHeader(
     `${escHtml(kernel)} ${platBadge(platform_short)}`,
-    `Latency: ${e.helion_latency_avg_ms.toFixed(2)} ms | Speedup: ${formatSpeedup(e.helion_speedup_geomean)} | Compile Time: ${formatCompileTime(e.compile_time_avg_s)}`);
+    `Latency: ${e.helion_latency_avg_ms.toFixed(2)} ms | Speedup: ${formatSpeedup(e.helion_speedup_geomean)} | Compile Time: ${formatCompileTime(e.compile_time_geomean_s)}`);
   html += '<div class="modal-split"><div class="modal-lhs">';
   if (e.status !== 'unchanged') {
     html += `<div style="margin-bottom:12px"><span class="kc-tag ${e.status}">${e.status} perf</span></div>`;
@@ -814,7 +814,7 @@ function showDetailModal(kernel, platform_short) {
       <td style="font-size:11px">${formatDate(h.date)}</td>
       <td>${h.helion_latency_avg_ms.toFixed(2)} ms${latencyDelta}</td>
       <td>${formatSpeedup(h.helion_speedup_geomean)}${speedupDelta}</td>
-      <td>${formatCompileTime(h.compile_time_avg_s)}</td>
+      <td>${formatCompileTime(h.compile_time_geomean_s)}</td>
     </tr>`;
   });
   html += '</tbody></table></div>';
@@ -884,7 +884,7 @@ function showDetailModal(kernel, platform_short) {
         spEl.on('plotly_click', clickHandler);
       }
       // Compile time over time
-      const ctVals = histFwd.map(h => h.compile_time_avg_s > 0 ? h.compile_time_avg_s : null);
+      const ctVals = histFwd.map(h => h.compile_time_geomean_s > 0 ? h.compile_time_geomean_s : null);
       const ctTrace = {
         x: xLabels, y: ctVals,
         mode: 'lines+markers', line: { color: '#f0883e', width: 2 }, marker: { size: 6 },

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -172,26 +172,9 @@ jobs:
             echo "Using baseline: $BASELINE"
             echo "Available implementations for $kernel: $IMPLS"
 
-            # Do autotuning but do not record the results
-            ${{ inputs.env-vars }} python benchmarks/run.py \
-                --op $kernel \
-                --metrics speedup,accuracy \
-                --latency-measure-mode triton_do_bench \
-                --cudagraph \
-                --only $IMPLS \
-                --only-match-mode prefix-with-baseline \
-                --baseline $BASELINE \
-                --atol 1e-2 \
-                --rtol 1e-2 \
-                --input-sample-mode equally-spaced-k \
-                --keep-going \
-                ${{ inputs.custom-args }}
-
-            # Relax the GPU
-            sleep 2m
-
-            # Run again with cache and record results
-            ${{ inputs.env-vars }} HELION_PRINT_OUTPUT_CODE=1 HELION_ASSERT_CACHE_HIT=1 python benchmarks/run.py \
+            # Single pass: autotune search + codegen + compilation happen inline,
+            # so --measure-compile-time reports end-to-end user-visible compile time.
+            ${{ inputs.env-vars }} HELION_PRINT_OUTPUT_CODE=1 python benchmarks/run.py \
                 --op $kernel \
                 --metrics speedup,accuracy,latency \
                 --measure-compile-time \


### PR DESCRIPTION
Many kernels timeout on nightly perf CI. 
Change compile time measurement from avg to geomean