### PR TITLE
Fix flaky distributed and torch.compile tests

### DIFF
--- a/test/test_examples_dist.py
+++ b/test/test_examples_dist.py
@@ -84,6 +84,7 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
             world_size=self.world_size,
             rank=self.rank,
             store=store,
+            device_id=self.device,
         )
         torch.distributed.distributed_c10d._set_pg_timeout(
             timedelta(seconds=60), dist.group.WORLD
@@ -156,10 +157,8 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
 
         mod = import_path(EXAMPLES_DIR / "distributed" / "all_reduce.py")
 
-        selected_backend = _set_preferred_symm_mem_backend(self.device)
+        _set_preferred_symm_mem_backend(self.device)
         group = dist.group.WORLD
-        if selected_backend == "NVSHMEM":
-            symm_mem.enable_symm_mem_for_group(group.group_name)
 
         N = 16384
         dtype = torch.bfloat16
@@ -213,10 +212,8 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
 
         mod = import_path(EXAMPLES_DIR / "distributed" / "allreduce_bias_rmsnorm.py")
 
-        selected_backend = _set_preferred_symm_mem_backend(self.device)
+        _set_preferred_symm_mem_backend(self.device)
         group = dist.group.WORLD
-        if selected_backend == "NVSHMEM":
-            symm_mem.enable_symm_mem_for_group(group.group_name)
 
         N, D = 128, 4096
         dtype = torch.float32
@@ -270,10 +267,8 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
 
         mod = import_path(EXAMPLES_DIR / "distributed" / "matmul_reduce_scatter.py")
 
-        selected_backend = _set_preferred_symm_mem_backend(self.device)
+        _set_preferred_symm_mem_backend(self.device)
         group = dist.group.WORLD
-        if selected_backend == "NVSHMEM":
-            symm_mem.enable_symm_mem_for_group(group.group_name)
 
         M, N, K = 512, 768, 1024
         dtype = torch.float32
@@ -321,10 +316,8 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
 
         mod = import_path(EXAMPLES_DIR / "distributed" / "matmul_reduce_scatter.py")
 
-        selected_backend = _set_preferred_symm_mem_backend(self.device)
+        _set_preferred_symm_mem_backend(self.device)
         group = dist.group.WORLD
-        if selected_backend == "NVSHMEM":
-            symm_mem.enable_symm_mem_for_group(group.group_name)
 
         M, N, K = 512, 768, 1024
         dtype = torch.float32

--- a/test/test_torch_compile.py
+++ b/test/test_torch_compile.py
@@ -4884,6 +4884,7 @@ class TestTorchCompile(RefEagerTestDisabled, TestCase):
         kernel.reset()
         torch._dynamo.reset()
 
+        torch.manual_seed(0)
         x = torch.randn(128, device=DEVICE, dtype=torch.float32)
         y = torch.randn(128, device=DEVICE, dtype=torch.float32)
 


### PR DESCRIPTION
For distributed test:
  - Raise per-test timeout to 180s via @pytest.mark.timeout
  - Pass device_id to init_process_group to address warning:   [rank0]:[W424 01:07:20.235214416 ProcessGroupNCCL.cpp:5325] Guessing device ID based on global rank. This can cause a hang 
  if rank to GPU mapping is heterogeneous. You can specify device_id in init_process_group() 
  - Drop the deprecated symm_mem.enable_symm_mem_for_group() calls to address warning:  /__w/helion/helion/test/test_examples_dist.py:153: FutureWarning: `enable_symm_mem_for_group` is deprecated. There is no   
  need to call this function anymore.                                                                                     
    symm_mem.enable_symm_mem_for_group(group.group_name) 
          
For torch.compile test:
  - Seed torch.randn with manual_seed(0)