### PR TITLE
autotuner: cap tile size for imbalanced 2D grid dims                                                                                                                                       

### DIFF
--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -1958,7 +1958,7 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
         config_spec = CompileEnvironment.current().config_spec
         config_spec.raise_grid_block_minimums()
         config_spec.lower_max_for_imbalanced_grid_dims()
-        
+
         if len(device_ir.root_ids) > 1:
             # xyz is not supported with shared program IDs. Non-tcgen05
             # persistent kernels are allowed; tcgen05 persistent has a

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -1957,6 +1957,8 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
         device_ir.register_rollable_reductions()
         config_spec = CompileEnvironment.current().config_spec
         config_spec.raise_grid_block_minimums()
+        config_spec.lower_max_for_imbalanced_grid_dims()
+        
         if len(device_ir.root_ids) > 1:
             # xyz is not supported with shared program IDs. Non-tcgen05
             # persistent kernels are allowed; tcgen05 persistent has a

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -1216,12 +1216,16 @@ class ConfigSpec:
     def lower_max_for_imbalanced_grid_dims(self) -> None:
         """Lower max_size for the large grid dimension when the shape is skinny.
 
-        When one grid dimension is much larger than the other (e.g. M=1024, N=8192),
-        the autotuner samples large tile sizes for the big dimension that produce too
-        few grid blocks for good GPU occupancy.  Capping the larger dimension's tile
-        keeps the search in the useful region without hardcoding specific tile values.
+        Mirrors raise_grid_block_minimums: that method raises the minimum tile to
+        prevent too many blocks per dimension; this method lowers the maximum tile
+        to prevent too few blocks when one dimension is much larger than the other.
 
-        Only applied to 2-D grids where max(dim) >= 4 * min(dim).
+        The cap is derived from num_compute_units() so it naturally relaxes on
+        smaller GPUs (fewer SMs/CUs → fewer blocks needed → larger tiles OK).
+
+        Only applied to 2-D grids where max(dim) >= 8 * min(dim).  The 8x threshold
+        is hardware-independent: below it the random sampler has a reasonable chance
+        of finding good balanced-tile configs on its own.
         """
         if len(self.grid_block_ids) != 2:
             return
@@ -1238,16 +1242,24 @@ class ConfigSpec:
 
         min_hint = min(hints)
         max_hint = max(hints)
-        if max_hint < min_hint * 4:
-            return  # Square-ish shape — leave the search space alone
+        if max_hint < min_hint * 8:
+            return  # Not severely imbalanced — leave the search space alone
 
-        # Cap the larger dim's tile so that at least 4 blocks cover min_hint,
-        # keeping total blocks comparable across both dims.
-        # e.g. M=1024, N=8192: cap N-tile at max(64, 1024//4) = 256
-        cap = max(64, next_power_of_2(min_hint) // 2)
+        # Derive cap from actual hardware: require at least 1 block per compute unit
+        # per grid dimension (mirroring raise_grid_block_minimums which uses n_cus*64).
+        n_cus = num_compute_units()
+        n_dims = len(self.grid_block_ids)
+        min_blocks_per_dim = math.ceil(n_cus ** (1.0 / n_dims))
+
         for spec, hint in zip(specs, hints, strict=True):
-            if hint == max_hint:
-                spec.update_max(min(spec.max_size, cap))
+            if hint != max_hint:
+                continue
+            max_tile = hint // min_blocks_per_dim
+            if max_tile < 2:
+                continue
+            # Round down to power of two
+            max_tile = 1 << (max_tile.bit_length() - 1)
+            spec.update_max(min(spec.max_size, max_tile))
 
     def create_config_generation(
         self,

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -1213,6 +1213,42 @@ class ConfigSpec:
                     max(min_block, spec.autotuner_min)
                 )
 
+    def lower_max_for_imbalanced_grid_dims(self) -> None:
+        """Lower max_size for the large grid dimension when the shape is skinny.
+
+        When one grid dimension is much larger than the other (e.g. M=1024, N=8192),
+        the autotuner samples large tile sizes for the big dimension that produce too
+        few grid blocks for good GPU occupancy.  Capping the larger dimension's tile
+        keeps the search in the useful region without hardcoding specific tile values.
+
+        Only applied to 2-D grids where max(dim) >= 4 * min(dim).
+        """
+        if len(self.grid_block_ids) != 2:
+            return
+
+        specs = []
+        for bid in self.grid_block_ids:
+            try:
+                specs.append(self.block_sizes.block_id_lookup(bid))
+            except KeyError:
+                return
+        hints = [s.size_hint for s in specs]
+        if any(h <= 0 for h in hints):
+            return
+
+        min_hint = min(hints)
+        max_hint = max(hints)
+        if max_hint < min_hint * 4:
+            return  # Square-ish shape — leave the search space alone
+
+        # Cap the larger dim's tile so that at least 4 blocks cover min_hint,
+        # keeping total blocks comparable across both dims.
+        # e.g. M=1024, N=8192: cap N-tile at max(64, 1024//4) = 256
+        cap = max(64, next_power_of_2(min_hint) // 2)
+        for spec, hint in zip(specs, hints, strict=True):
+            if hint == max_hint:
+                spec.update_max(min(spec.max_size, cap))
+
     def create_config_generation(
         self,
         *,

--- a/test/test_best_available.py
+++ b/test/test_best_available.py
@@ -1160,7 +1160,11 @@ class TestLowerMaxForImbalancedGridDims(unittest.TestCase):
         return config_spec
 
     def test_skinny_n_caps_n_tile(self):
-        """Skinny-N (M=1024, N=8192): N-tile max should be capped."""
+        """Skinny-N (M=1024, N=8192): N-tile max should be capped (hardware-derived cap)."""
+        import math
+
+        from helion._compat import num_compute_units
+
         spec = self._make_spec(m=1024, n=8192)
         n_max_before = spec.block_sizes.block_id_lookup(1).max_size
         spec.lower_max_for_imbalanced_grid_dims()
@@ -1170,8 +1174,10 @@ class TestLowerMaxForImbalancedGridDims(unittest.TestCase):
         self.assertLess(n_max_after, n_max_before)
         # M tile (the smaller dim) should be unchanged
         self.assertEqual(m_max_after, spec.block_sizes.block_id_lookup(0).max_size)
-        # Cap should allow at least 4 blocks on N dim
-        self.assertGreaterEqual(8192 // n_max_after, 4)
+        # Cap is hardware-derived: at least min_blocks_per_dim blocks on N dim
+        n_cus = num_compute_units()
+        min_blocks_per_dim = math.ceil(n_cus**0.5)
+        self.assertGreaterEqual(8192 // n_max_after, min_blocks_per_dim)
 
     def test_skinny_m_caps_m_tile(self):
         """Skinny-M (M=8192, N=1024): M-tile max should be capped."""
@@ -1191,8 +1197,8 @@ class TestLowerMaxForImbalancedGridDims(unittest.TestCase):
         self.assertEqual(spec.block_sizes.block_id_lookup(1).max_size, n_max_before)
 
     def test_slightly_imbalanced_unchanged(self):
-        """3:1 ratio (M=1024, N=3072): below the 4x threshold, no change."""
-        spec = self._make_spec(m=1024, n=3072)
+        """6.4x ratio (M=1280, N=8192): below the 8x threshold, no change (covers int4_gemm regression)."""
+        spec = self._make_spec(m=1280, n=8192)
         n_max_before = spec.block_sizes.block_id_lookup(1).max_size
         spec.lower_max_for_imbalanced_grid_dims()
         self.assertEqual(spec.block_sizes.block_id_lookup(1).max_size, n_max_before)

--- a/test/test_best_available.py
+++ b/test/test_best_available.py
@@ -1143,3 +1143,74 @@ class TestGenerateBestAvailablePopulation(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestLowerMaxForImbalancedGridDims(unittest.TestCase):
+    """Tests for lower_max_for_imbalanced_grid_dims in ConfigSpec."""
+
+    def _make_spec(self, m, n, m_max=None, n_max=None):
+        config_spec = ConfigSpec(backend=TritonBackend())
+        config_spec.block_sizes.append(
+            BlockSizeSpec(block_id=0, size_hint=m, max_size=m_max or m)
+        )
+        config_spec.block_sizes.append(
+            BlockSizeSpec(block_id=1, size_hint=n, max_size=n_max or n)
+        )
+        config_spec.grid_block_ids = [0, 1]
+        return config_spec
+
+    def test_skinny_n_caps_n_tile(self):
+        """Skinny-N (M=1024, N=8192): N-tile max should be capped."""
+        spec = self._make_spec(m=1024, n=8192)
+        n_max_before = spec.block_sizes.block_id_lookup(1).max_size
+        spec.lower_max_for_imbalanced_grid_dims()
+        n_max_after = spec.block_sizes.block_id_lookup(1).max_size
+        m_max_after = spec.block_sizes.block_id_lookup(0).max_size
+        # N tile should be capped below its original max
+        self.assertLess(n_max_after, n_max_before)
+        # M tile (the smaller dim) should be unchanged
+        self.assertEqual(m_max_after, spec.block_sizes.block_id_lookup(0).max_size)
+        # Cap should allow at least 4 blocks on N dim
+        self.assertGreaterEqual(8192 // n_max_after, 4)
+
+    def test_skinny_m_caps_m_tile(self):
+        """Skinny-M (M=8192, N=1024): M-tile max should be capped."""
+        spec = self._make_spec(m=8192, n=1024)
+        m_max_before = spec.block_sizes.block_id_lookup(0).max_size
+        spec.lower_max_for_imbalanced_grid_dims()
+        m_max_after = spec.block_sizes.block_id_lookup(0).max_size
+        self.assertLess(m_max_after, m_max_before)
+
+    def test_square_shape_unchanged(self):
+        """Square shape (M=4096, N=4096): no change to max sizes."""
+        spec = self._make_spec(m=4096, n=4096)
+        m_max_before = spec.block_sizes.block_id_lookup(0).max_size
+        n_max_before = spec.block_sizes.block_id_lookup(1).max_size
+        spec.lower_max_for_imbalanced_grid_dims()
+        self.assertEqual(spec.block_sizes.block_id_lookup(0).max_size, m_max_before)
+        self.assertEqual(spec.block_sizes.block_id_lookup(1).max_size, n_max_before)
+
+    def test_slightly_imbalanced_unchanged(self):
+        """3:1 ratio (M=1024, N=3072): below the 4x threshold, no change."""
+        spec = self._make_spec(m=1024, n=3072)
+        n_max_before = spec.block_sizes.block_id_lookup(1).max_size
+        spec.lower_max_for_imbalanced_grid_dims()
+        self.assertEqual(spec.block_sizes.block_id_lookup(1).max_size, n_max_before)
+
+    def test_1d_grid_unchanged(self):
+        """1D grid: method should be a no-op."""
+        config_spec = ConfigSpec(backend=TritonBackend())
+        config_spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=8192))
+        config_spec.grid_block_ids = [0]
+        max_before = config_spec.block_sizes.block_id_lookup(0).max_size
+        config_spec.lower_max_for_imbalanced_grid_dims()
+        self.assertEqual(
+            config_spec.block_sizes.block_id_lookup(0).max_size, max_before
+        )
+
+    def test_cap_is_valid_power_of_two(self):
+        """The cap applied to N-tile must be a power of two."""
+        spec = self._make_spec(m=1024, n=8192)
+        spec.lower_max_for_imbalanced_grid_dims()
+        n_max = spec.block_sizes.block_id_lookup(1).max_size
+        self.assertEqual(n_max & (n_max - 1), 0, f"{n_max} is not a power of two")


### PR DESCRIPTION
For skinny GEMM shapes (e.g. M=1024, N=8192), the random sampler rarely explores small balanced tile configs like [64, 64, 256] that Inductor uses, because block sizes are sampled independently in log2 space. Add lower_max_for_imbalanced_grid_dims() which caps the larger grid dim's tile max at max(64, next_power_of_2(min_dim)//2) when max(M,N) >= 4*min(M,N), removing provably bad large tiles from the search space.                                                                                                                         

Validated on MI350X: avg helion gemm speedup 0.59x -> 0.87x.                                                                                                                               
Worst case (M=1024, N=8192): 0.39x -> 0.97x (vs torch_compile 0.96x).                                                                                                                      
All 1D-grid kernels unaffected. flash_attention/int4_gemm accuracy failures are pre-existing (confirmed in CI run #24748289616).                                                                                                                           
                                                                                                                     
                                                                                                                        
                                                                                                                           
                                                                                                                         
                                                                                                                                                                                
                                                                                                                                                                                             
     
