### PR TITLE
[Pallas] Adding a tunable pre_broadcast optimization pass for TPU scratch buffers, improving TPU attention perf

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1000,6 +1000,7 @@ class PallasBackend(Backend):
             "loop_orders",
             "flatten_loops",
             "pallas_loop_type",
+            "pallas_pre_broadcast",
         }
     )
 

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -106,6 +106,7 @@ _BASE_BACKEND_TUNABLE_KEYS: frozenset[str] = frozenset(
         "num_ctas",
         "occupancy",
         "pallas_loop_type",
+        "pallas_pre_broadcast",
     }
 )
 
@@ -126,6 +127,7 @@ BACKEND_TUNABLE_KEYS: frozenset[str] = _get_backend_tunable_keys()
 BACKEND_SPECIFIC_KEYS: frozenset[str] = BACKEND_TUNABLE_KEYS | {
     "num_threads",
     "pallas_loop_type",
+    "pallas_pre_broadcast",
 }
 VALID_KEYS: frozenset[str] = frozenset(
     [
@@ -150,6 +152,7 @@ VALID_KEYS: frozenset[str] = frozenset(
         "atomic_indexing",
         "load_eviction_policies",
         "pallas_loop_type",
+        "pallas_pre_broadcast",
         *BACKEND_TUNABLE_KEYS,
         "advanced_controls_file",
         "epilogue_subtile",

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import operator
 from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import cast
@@ -594,6 +595,629 @@ def _setup_inner_loop_masks(
     return needs_explicit
 
 
+PRE_BROADCAST_SIZE = 128
+
+
+def _apply_pre_broadcast_transform(
+    state: CodegenState,
+    graph: torch.fx.Graph,
+    carried: set[int],
+    proxy_args: list[object],
+    scratch_names: list[str],
+    args: list[ast.AST],
+    block_ids: list[int],
+    env: CompileEnvironment,
+) -> None:
+    """Shared pre-broadcast transform for emit_pipeline and fori_loop codegen.
+
+    On TPU, implicit broadcast an array of (block, 1) is significantly
+    slower than pre-expanding them to (block, 128) and using explicit
+    jnp.tile at the point of use. This is because TPU hardware can execute
+    element-wise ops on same-shaped tiles much more efficiently than ops that
+    require implicit broadcast across the trailing dimension.
+
+    This transform detects loop-carried scratch buffers that participate in
+    such broadcasts (via subscript[..., None] followed by an op with a
+    wider-dimensioned sibling), appends a trailing PRE_BROADCAST_SIZE (128)
+    dimension to their scratch shapes, and rewrites the FX graph so that:
+
+    - The subscript[..., None] unsqueezes become identity (the trailing dim
+      is already present in the scratch).
+    - A _pre_broadcast_tile op is inserted where the narrow (128-wide)
+      value needs to match a wider dimension (e.g. head_dim=256), generating
+      jnp.tile(tensor, block_size // 128) in the output code.
+    - Lower-rank values (e.g. reduction results) get an unsqueeze to [..., 1]
+      so JAX broadcasting against the [..., 128] scratch still works.
+
+    The transform is gated by the pallas_pre_broadcast config flag and only
+    applies when all broadcast target dimensions are multiples of 128.
+    """
+    candidates = _find_pre_broadcast_candidates(
+        graph, carried, proxy_args, env, state.config
+    )
+    if not candidates:
+        return
+    pre_broadcast_nodes = _compute_pre_broadcast_nodes(graph, candidates, proxy_args)
+    placeholders = list(graph.find_nodes(op="placeholder"))
+    for i, proxy in enumerate(proxy_args):
+        if (
+            i in carried
+            and isinstance(proxy, torch.Tensor)
+            and i < len(placeholders)
+            and placeholders[i].name in pre_broadcast_nodes
+            and i not in candidates
+        ):
+            candidates[i] = placeholders[i]
+    _apply_pre_broadcast_to_scratch(state, candidates, scratch_names, args)
+    _rewrite_outer_subscripts_for_pre_broadcast(state.fx_node, candidates, state.config)
+    _annotate_pre_broadcast(graph, pre_broadcast_nodes, block_ids, env, state.config)
+
+
+def _find_pre_broadcast_candidates(
+    graph: torch.fx.Graph,
+    carried: set[int],
+    proxy_args: list[object],
+    env: CompileEnvironment,
+    config: Config,
+) -> dict[int, torch.fx.Node]:
+    """Find loop-carried tensor args that are broadcast via subscript[..., None].
+
+    Returns a dict mapping carried arg index to the placeholder node.
+    """
+    from .view_ops import subscript as _subscript_op
+
+    placeholders = list(graph.find_nodes(op="placeholder"))
+    candidates: dict[int, torch.fx.Node] = {}
+    for i, proxy in enumerate(proxy_args):
+        if i not in carried:
+            continue
+        if not isinstance(proxy, torch.Tensor):
+            continue
+        if i >= len(placeholders):
+            continue
+        ph = placeholders[i]
+        if _placeholder_has_broadcast_usage(
+            ph, _subscript_op, len(proxy.shape), env, config
+        ):
+            candidates[i] = ph
+    return candidates
+
+
+def _dim_concrete_size(
+    dim: int | torch.SymInt,
+    env: CompileEnvironment,
+    config: Config,
+) -> int | None:
+    """Resolve a dimension size to a concrete int.
+
+    For SymInts that correspond to block size variables, reads the configured
+    block size via ``BlockSizeInfo.from_config``.
+    """
+    if isinstance(dim, int):
+        return dim
+    block_id = env.get_block_id(dim)
+    if block_id is not None and block_id < len(env.block_sizes):
+        val = env.block_sizes[block_id].from_config(config)
+        if isinstance(val, int):
+            return val
+    return None
+
+
+def _placeholder_has_broadcast_usage(
+    ph: torch.fx.Node,
+    subscript_op: object,
+    orig_rank: int,
+    env: CompileEnvironment,
+    config: Config,
+) -> bool:
+    """Check if placeholder feeds into subscript[..., None] that is then broadcast.
+
+    First finds unsqueeze nodes (subscript[..., None]) reachable from the
+    placeholder through same-rank ops.  Then checks whether any unsqueeze
+    result is consumed by an op whose sibling arg has a wider last dimension,
+    confirming an actual broadcast.  All broadcast target dimensions must be
+    multiples of PRE_BROADCAST_SIZE for the optimization to be valid.
+    """
+    unsqueeze_nodes: list[torch.fx.Node] = []
+    worklist = [ph]
+    visited: set[str] = set()
+    while worklist:
+        node = worklist.pop()
+        if node.name in visited:
+            continue
+        visited.add(node.name)
+        for user in node.users:
+            if user.op == "call_function" and user.target is subscript_op:
+                idx = user.args[1] if len(user.args) > 1 else None
+                if isinstance(idx, (list, tuple)) and len(idx) > 0 and idx[-1] is None:
+                    unsqueeze_nodes.append(user)
+            if user.op == "call_function":
+                user_val = user.meta.get("val", None)
+                if (
+                    isinstance(user_val, torch.Tensor)
+                    and len(user_val.shape) == orig_rank
+                ):
+                    worklist.append(user)
+
+    if not unsqueeze_nodes:
+        return False
+
+    found_broadcast = False
+    for unsq in unsqueeze_nodes:
+        for user in unsq.users:
+            if user.op != "call_function":
+                continue
+            for arg in user.args:
+                if not isinstance(arg, torch.fx.Node) or arg is unsq:
+                    continue
+                arg_val = arg.meta.get("val", None)
+                if not isinstance(arg_val, torch.Tensor) or len(arg_val.shape) < 1:
+                    continue
+                arg_last = arg_val.shape[-1]
+                if isinstance(arg_last, int) and arg_last == 1:
+                    continue
+                size = _dim_concrete_size(arg_last, env, config)
+                if size is not None and size % PRE_BROADCAST_SIZE != 0:
+                    return False
+                found_broadcast = True
+    return found_broadcast
+
+
+def _compute_pre_broadcast_nodes(
+    graph: torch.fx.Graph,
+    candidates: dict[int, torch.fx.Node],
+    proxy_args: list[object],
+) -> set[str]:
+    """Compute the set of FX node names whose runtime shape becomes [.., PRE_BROADCAST_SIZE].
+
+    Starts from candidate placeholders and propagates through _new_var copies,
+    subscript unsqueezes, and element-wise ops whose FX shape has the same rank
+    as the candidate (because at runtime the trailing PRE_BROADCAST_SIZE dimension
+    is carried along).
+    """
+    from collections import deque
+
+    from .view_ops import subscript as _subscript_op
+
+    pre_broadcast_nodes: set[str] = set()
+    placeholders = list(graph.find_nodes(op="placeholder"))
+
+    candidate_ranks: set[int] = set()
+    for arg_idx in candidates:
+        proxy = proxy_args[arg_idx]
+        if isinstance(proxy, torch.Tensor):
+            candidate_ranks.add(len(proxy.shape))
+
+    node_by_name: dict[str, torch.fx.Node] = {n.name: n for n in graph.nodes}
+
+    def _is_forward_candidate(node: torch.fx.Node) -> bool:
+        if node.name in pre_broadcast_nodes or node.op != "call_function":
+            return False
+        if node.target is _new_var and len(node.args) >= 1:
+            arg0 = node.args[0]
+            if isinstance(arg0, torch.fx.Node) and arg0.name in pre_broadcast_nodes:
+                return True
+        if node.target is _subscript_op and len(node.args) >= 2:
+            base = node.args[0]
+            idx = node.args[1]
+            if (
+                isinstance(base, torch.fx.Node)
+                and base.name in pre_broadcast_nodes
+                and isinstance(idx, (list, tuple))
+                and len(idx) > 0
+                and idx[-1] is None
+            ):
+                return True
+        val = node.meta.get("val", None)
+        if isinstance(val, torch.Tensor) and len(val.shape) in candidate_ranks:
+            for arg in node.args:
+                if isinstance(arg, torch.fx.Node) and arg.name in pre_broadcast_nodes:
+                    return True
+        return False
+
+    # Forward pass: propagate from candidate placeholders through users
+    worklist: deque[torch.fx.Node] = deque()
+    for arg_idx in candidates:
+        ph = placeholders[arg_idx]
+        pre_broadcast_nodes.add(ph.name)
+        worklist.append(ph)
+
+    while worklist:
+        node = worklist.popleft()
+        for user in node.users:
+            if _is_forward_candidate(user):
+                pre_broadcast_nodes.add(user.name)
+                worklist.append(user)
+
+    # Backward pass: propagate back through _new_var (loop-carried copies)
+    # to find placeholder sources that should also be pre-broadcast.
+    backward_worklist: deque[torch.fx.Node] = deque(
+        node_by_name[name]
+        for name in pre_broadcast_nodes
+        if node_by_name[name].op == "call_function"
+    )
+    while backward_worklist:
+        node = backward_worklist.popleft()
+        for arg in node.args:
+            if not isinstance(arg, torch.fx.Node) or arg.name in pre_broadcast_nodes:
+                continue
+            if arg.op != "call_function" or arg.target is not _new_var:
+                continue
+            a_val = arg.meta.get("val", None)
+            if (
+                not isinstance(a_val, torch.Tensor)
+                or len(a_val.shape) not in candidate_ranks
+            ):
+                continue
+            pre_broadcast_nodes.add(arg.name)
+            backward_worklist.append(arg)
+            # Follow _new_var chain to its placeholder source
+            src = arg.args[0]
+            if (
+                isinstance(src, torch.fx.Node)
+                and src.op == "placeholder"
+                and src.name not in pre_broadcast_nodes
+            ):
+                src_val = src.meta.get("val", None)
+                if (
+                    isinstance(src_val, torch.Tensor)
+                    and len(src_val.shape) in candidate_ranks
+                ):
+                    pre_broadcast_nodes.add(src.name)
+
+    return pre_broadcast_nodes
+
+
+def _apply_pre_broadcast_to_scratch(
+    state: CodegenState,
+    candidates: dict[int, torch.fx.Node],
+    scratch_names: list[str],
+    args: list[ast.AST],
+) -> set[str]:
+    """Modify scratch shapes for pre-broadcast candidates.
+
+    Appends PRE_BROADCAST_SIZE to the scratch shape (e.g. (a,b) → (a,b,128)).
+    For scratches NOT from hl.full/hl.zeros (where the init was already emitted
+    without the extra dim), rewrites the existing init statement to broadcast.
+    Returns the set of scratch names that were modified.
+    """
+    modified_scratches: set[str] = set()
+    for arg_idx in candidates:
+        sname = scratch_names[arg_idx]
+        if not sname:
+            continue
+        for sa in state.device_function._scratch_args:
+            if sa.name == sname:
+                sa.shape = (*sa.shape, PRE_BROADCAST_SIZE)
+                modified_scratches.add(sname)
+                # If scratch != arg, the init `scratch[...] = arg[...]` was
+                # emitted without the trailing dim. Rewrite it to broadcast.
+                arg_ast = args[arg_idx]
+                if isinstance(arg_ast, ast.Name) and arg_ast.id != sname:
+                    _rewrite_scratch_init_for_pre_broadcast(state, sname, arg_ast.id)
+                break
+    return modified_scratches
+
+
+def _rewrite_scratch_init_for_pre_broadcast(
+    state: CodegenState,
+    scratch_name: str,
+    arg_name: str,
+) -> None:
+    """Find and rewrite `scratch[...] = arg[...]` to broadcast the N-D arg to (N+1)-D."""
+    stmts = state.codegen.statements_stack[-1]
+    replacement = statement_from_string(
+        f"{scratch_name}[...] = jnp.broadcast_to("
+        f"{arg_name}[..., None], {scratch_name}.shape)"
+    )
+    for i, stmt in enumerate(stmts):
+        src = ast.unparse(stmt) if isinstance(stmt, ast.AST) else str(stmt)
+        if f"{scratch_name}[" in src and f"{arg_name}[" in src:
+            stmts[i] = replacement
+            return
+    stmts.append(replacement)
+
+
+def _rewrite_outer_subscripts_for_pre_broadcast(
+    for_loop_node: torch.fx.Node | None,
+    candidates: dict[int, torch.fx.Node],
+    config: object,
+) -> None:
+    """Rewrite outer-scope subscript[..., None] to identity for pre-broadcast results.
+
+    After pre-broadcast, loop-carried values read from scratch have an extra
+    trailing PRE_BROADCAST_SIZE dim. The outer graph's subscript(val, [..., None])
+    would add yet another dim. Instead, rewrite to identity slicing.
+    """
+    from torch._inductor.virtualized import V
+
+    from .._compiler.inductor_lowering import FakeGraphLowering
+    from .._compiler.inductor_lowering import compile_lock
+    from .._compiler.inductor_lowering import prepare_node_lowering
+    from .view_ops import subscript as _subscript_op
+
+    if for_loop_node is None:
+        return
+
+    # The _for_loop result is a tuple. Each result index i corresponds
+    # to proxy_args[i]. candidates maps arg index → inner placeholder.
+    # Track which result indices are pre-broadcast.
+    pre_broadcast_result_indices = set(candidates.keys())
+
+    # Find getitem nodes that extract pre-broadcast results
+    pre_broadcast_outer_nodes: set[str] = set()
+    for user in for_loop_node.users:
+        if user.op == "call_function" and user.target is operator.getitem:
+            idx = user.args[1]
+            if isinstance(idx, int) and idx in pre_broadcast_result_indices:
+                pre_broadcast_outer_nodes.add(user.name)
+                # Follow through _phi nodes
+                pre_broadcast_outer_nodes.update(
+                    phi_user.name for phi_user in user.users
+                )
+
+    # Rewrite subscript[:, :, None] → [:, :] for pre-broadcast outer nodes
+    reshaped: list[torch.fx.Node] = []
+    reshaped_bases: set[str] = set()
+    outer_graph = for_loop_node.graph
+    for node in outer_graph.nodes:
+        if node.op != "call_function" or node.target is not _subscript_op:
+            continue
+        base = node.args[0]
+        idx = node.args[1]
+        if (
+            isinstance(base, torch.fx.Node)
+            and base.name in pre_broadcast_outer_nodes
+            and isinstance(idx, (list, tuple))
+            and len(idx) > 0
+            and idx[-1] is None
+        ):
+            new_idx = [i for i in idx if i is not None]
+            node.args = (base, new_idx)
+            base_val = base.meta.get("val", None)
+            if isinstance(base_val, torch.Tensor):
+                if base.name not in reshaped_bases:
+                    new_val = base_val.new_empty([*base_val.shape, PRE_BROADCAST_SIZE])
+                    base.meta["val"] = new_val
+                    reshaped_bases.add(base.name)
+                    reshaped.append(base)
+                node.meta["val"] = base.meta["val"].new_empty(
+                    list(base.meta["val"].shape)
+                )
+                reshaped.append(node)
+
+    # Re-prepare lowerings for modified outer nodes
+    if reshaped:
+        with compile_lock:
+            graph_lowering = FakeGraphLowering()
+            with V.set_graph_handler(graph_lowering):
+                for node in reshaped:
+                    if node.op == "call_function":
+                        with node.meta["location"]:
+                            prepare_node_lowering(graph_lowering, node)
+
+
+def _annotate_pre_broadcast(
+    graph: torch.fx.Graph,
+    pre_broadcast_nodes: set[str],
+    inner_block_ids: list[int],
+    env: CompileEnvironment,
+    config: object,
+) -> None:
+    """FX graph rewrite for pre-broadcast optimization.
+
+    Appends PRE_BROADCAST_SIZE to pre-broadcast node meta shapes, rewrites
+    subscript unsqueezes to identity, inserts _pre_broadcast_tile for
+    wider-dim consumers, inserts unsqueezes for lower-rank non-pre-broadcast
+    values feeding pre-broadcast ops, and re-prepares lowerings for all
+    affected nodes.
+    """
+    from .view_ops import subscript as _subscript_op
+
+    new_nodes: list[torch.fx.Node] = []
+    reshaped_nodes: list[torch.fx.Node] = []
+
+    def _node_val(n: torch.fx.Node) -> torch.Tensor | None:
+        v = n.meta.get("val", None)
+        return v if isinstance(v, torch.Tensor) else None
+
+    # --- Step 1: append PRE_BROADCAST_SIZE to meta shapes for pre-broadcast nodes ---
+    # Skip nodes that already have PRE_BROADCAST_SIZE as last dim (subscript
+    # unsqueezes with shape [..., 1] will be handled in Step 2).
+    for node in graph.nodes:
+        if node.name not in pre_broadcast_nodes:
+            continue
+        val = _node_val(node)
+        if val is None:
+            continue
+        if isinstance(val.shape[-1], int) and val.shape[-1] == PRE_BROADCAST_SIZE:
+            continue
+        if isinstance(val.shape[-1], int) and val.shape[-1] == 1:
+            continue
+        new_val = val.new_empty([*val.shape, PRE_BROADCAST_SIZE])
+        node.meta["val"] = new_val
+        reshaped_nodes.append(node)
+
+    # --- Step 2: rewrite subscript(base, [:, :, None]) → subscript(base, [:, :]) ---
+    # The subscript was an unsqueeze from 2D→3D. Now the base is already 3D,
+    # so we change it to an identity slice. Also update the subscript's meta
+    # shape from [a,b,1] to [a,b,PRE_BROADCAST_SIZE] to match the base.
+    for node in list(graph.nodes):
+        if node.op != "call_function" or node.target is not _subscript_op:
+            continue
+        if node.name not in pre_broadcast_nodes:
+            continue
+        base = node.args[0]
+        idx = node.args[1]
+        if (
+            isinstance(base, torch.fx.Node)
+            and base.name in pre_broadcast_nodes
+            and isinstance(idx, (list, tuple))
+            and len(idx) > 0
+            and idx[-1] is None
+        ):
+            new_idx = [i for i in idx if i is not None]
+            node.args = (base, new_idx)
+            base_val = _node_val(base)
+            if base_val is not None:
+                node.meta["val"] = base_val.new_empty(list(base_val.shape))
+
+    # --- Step 3: insert _pre_broadcast_tile where pre-broadcast values feed wider-dim ops ---
+    for node in list(graph.nodes):
+        if node.op != "call_function" or node.name in pre_broadcast_nodes:
+            continue
+        node_val = _node_val(node)
+        if node_val is None or len(node_val.shape) < 2:
+            continue
+        last_dim = node_val.shape[-1]
+        last_dim_is_sym = isinstance(last_dim, torch.SymInt)
+        if not last_dim_is_sym and int(last_dim) <= PRE_BROADCAST_SIZE:
+            continue
+        args_list = list(node.args)
+        changed = False
+        for ai, arg in enumerate(args_list):
+            if not isinstance(arg, torch.fx.Node):
+                continue
+            if arg.name not in pre_broadcast_nodes:
+                continue
+            arg_val = _node_val(arg)
+            if arg_val is None:
+                continue
+            if not (
+                isinstance(arg_val.shape[-1], int)
+                and arg_val.shape[-1] == PRE_BROADCAST_SIZE
+            ):
+                continue
+            with graph.inserting_before(node):
+                tiled = graph.call_function(
+                    _pre_broadcast_tile,
+                    args=(arg, last_dim),
+                )
+            tiled.meta = {
+                **arg.meta,
+                "val": arg_val.new_empty([*arg_val.shape[:-1], last_dim]),
+            }
+            new_nodes.append(tiled)
+            args_list[ai] = tiled
+            changed = True
+        if changed:
+            node.args = tuple(args_list)
+
+    # --- Step 4: insert unsqueeze for lower-rank non-pre-broadcast values ---
+    # Reductions produce rank R-1. Pre-broadcast nodes now have rank R+1
+    # (with trailing 128). We unsqueeze to [..., 1] so JAX broadcast works:
+    # [..., 128] op [..., 1].
+    for node in list(graph.nodes):
+        if node.op != "call_function" or node.name in pre_broadcast_nodes:
+            continue
+        node_val = _node_val(node)
+        if node_val is None:
+            continue
+        node_rank = len(node_val.shape)
+        # Check if any pre-broadcast consumer/sibling has a higher rank
+        needs_unsqueeze = False
+        for u in node.users:
+            u_val = _node_val(u)
+            if (
+                u.name in pre_broadcast_nodes
+                and u_val is not None
+                and len(u_val.shape) > node_rank
+            ):
+                needs_unsqueeze = True
+                break
+            for ua in u.args:
+                if isinstance(ua, torch.fx.Node) and ua.name in pre_broadcast_nodes:
+                    ua_val = _node_val(ua)
+                    if ua_val is not None and len(ua_val.shape) > node_rank:
+                        needs_unsqueeze = True
+                        break
+            if needs_unsqueeze:
+                break
+        if not needs_unsqueeze:
+            continue
+        with graph.inserting_after(node):
+            unsq = graph.call_function(
+                torch.ops.aten.unsqueeze.default,
+                args=(node, node_rank),
+            )
+        unsq.meta = {**node.meta, "val": node_val.new_empty([*node_val.shape, 1])}
+        new_nodes.append(unsq)
+        for user in list(node.users):
+            if user is unsq:
+                continue
+            if user.name in pre_broadcast_nodes or any(
+                isinstance(ua, torch.fx.Node) and ua.name in pre_broadcast_nodes
+                for ua in user.args
+            ):
+                user.replace_input_with(node, unsq)
+
+    # --- Step 5: annotate all pre-broadcast nodes ---
+    for node in graph.nodes:
+        if node.name in pre_broadcast_nodes:
+            node.meta["pre_broadcast"] = True
+
+    # --- Step 6: re-prepare lowerings for all affected nodes ---
+    from torch._inductor.virtualized import V
+
+    from .._compiler.inductor_lowering import FakeGraphLowering
+    from .._compiler.inductor_lowering import compile_lock
+    from .._compiler.inductor_lowering import prepare_node_lowering
+
+    all_affected = new_nodes + reshaped_nodes
+    with compile_lock:
+        graph_lowering = FakeGraphLowering()
+        with V.set_graph_handler(graph_lowering):
+            for node in all_affected:
+                if hasattr(node, "_erased") and node._erased:
+                    continue
+                if node.op == "call_function":
+                    with node.meta["location"]:
+                        prepare_node_lowering(graph_lowering, node)
+
+
+@_decorators.api()
+def _pre_broadcast_tile(tensor: torch.Tensor, target_size: int) -> torch.Tensor:
+    """Tile a pre-broadcast tensor along its last dim to match target_size."""
+    raise AssertionError("this should never be called")
+
+
+@_decorators.register_fake(_pre_broadcast_tile)
+def _(tensor: torch.Tensor, target_size: int) -> torch.Tensor:
+    new_shape = [*tensor.shape[:-1], target_size]
+    return tensor.new_empty(new_shape)
+
+
+@_decorators.codegen(_pre_broadcast_tile, "pallas")
+def _(state: CodegenState) -> ast.AST:
+    tensor_ast = state.ast_arg(0)
+    target_size = state.proxy_arg(1)
+    if isinstance(target_size, torch.SymInt):
+        target_expr = state.sympy_expr(target_size._sympy_())
+        block_id = CompileEnvironment.current().get_block_id(target_size)
+        bs_var = (
+            state.device_function.block_size_var(block_id)
+            if block_id is not None
+            else None
+        )
+        if bs_var:
+            return expr_from_string(
+                f"jnp.tile({{tensor}}, {bs_var} // {PRE_BROADCAST_SIZE})",
+                tensor=tensor_ast,
+            )
+        return expr_from_string(
+            f"jnp.tile({{tensor}}, {target_expr} // {PRE_BROADCAST_SIZE})",
+            tensor=tensor_ast,
+        )
+    assert isinstance(target_size, int)
+    factor = target_size // PRE_BROADCAST_SIZE
+    if factor <= 1:
+        return tensor_ast
+    return expr_from_string(
+        f"jnp.tile({{tensor}}, {factor})",
+        tensor=tensor_ast,
+    )
+
+
 def _codegen_emit_pipeline(state: CodegenState) -> object:
     """Emit inner device loops using pltpu.emit_pipeline.
 
@@ -746,6 +1370,20 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     if has_loop_state:
         scratch_names, result_vars, carried = _setup_loop_carried_state(
             state, args, proxy_args, env
+        )
+
+    # --- Pre-broadcast transform: append PRE_BROADCAST_SIZE to scratch shapes
+    #     to avoid costly implicit broadcasts on TPU. ---
+    if state.config.get("pallas_pre_broadcast", False) and has_loop_state:
+        _apply_pre_broadcast_transform(
+            state,
+            graph_info.graph,
+            carried,
+            proxy_args,
+            scratch_names,
+            args,
+            block_ids,
+            env,
         )
 
     # Record which tensors are in the pipeline body (need HBM refs)
@@ -996,6 +1634,19 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     if has_loop_state:
         scratch_names, result_vars, carried = _setup_loop_carried_state(
             state, args, proxy_args, env
+        )
+
+    # --- Pre-broadcast transform (same as emit_pipeline) ---
+    if state.config.get("pallas_pre_broadcast", False) and has_loop_state:
+        _apply_pre_broadcast_transform(
+            state,
+            graph_info.graph,
+            carried,
+            proxy_args,
+            scratch_names,
+            args,
+            block_ids,
+            env,
         )
 
     # Collect all tensors: load-only first, then stored (which may also be read)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -317,6 +317,60 @@ def pallas_reduce_non_pow2(x: torch.Tensor) -> torch.Tensor:
     return out
 
 
+def _cumsum_broadcast_ref(
+    a: torch.Tensor, b: torch.Tensor, block_k: int = 128
+) -> torch.Tensor:
+    """Eager reference for cumsum_broadcast kernels.
+
+    running[b,m] accumulates row sums; acc[b,m,d] += running[:,:,None].
+    """
+    batch, m, k = a.shape
+    head_dim = b.shape[-1]
+    running = torch.zeros(batch, m, dtype=torch.float32, device=a.device)
+    acc = torch.zeros(batch, m, head_dim, dtype=torch.float32, device=a.device)
+    for kb in range(0, k, block_k):
+        chunk = a[:, :, kb : kb + block_k]
+        running = running + chunk.sum(-1).float()
+        acc = acc + running[:, :, None]
+    return acc.to(a.dtype)
+
+
+def _scaled_bmm_ref(
+    a: torch.Tensor, b: torch.Tensor, block_k: int = 128
+) -> torch.Tensor:
+    """Eager reference for scaled_bmm kernels.
+
+    m_i[b,m] accumulates row sums; acc[b,m,d] += m_i[:,:,None].
+    """
+    batch, m, k = a.shape
+    head_dim = b.shape[-1]
+    m_i = torch.zeros(batch, m, dtype=torch.float32, device=a.device)
+    acc = torch.zeros(batch, m, head_dim, dtype=torch.float32, device=a.device)
+    for kb in range(0, k, block_k):
+        chunk = a[:, :, kb : kb + block_k]
+        m_i = m_i + chunk.sum(-1).float()
+        acc = acc + m_i[:, :, None]
+    return acc.to(a.dtype)
+
+
+def _running_max_broadcast_ref(
+    a: torch.Tensor, b: torch.Tensor, block_k: int = 128
+) -> torch.Tensor:
+    """Eager reference for running_max_broadcast kernel.
+
+    scale[b,m] = running max of chunk row maxes; acc[b,m,d] += scale[:,:,None].
+    """
+    batch, m, k = a.shape
+    head_dim = b.shape[-1]
+    scale = torch.zeros(batch, m, dtype=torch.float32, device=a.device)
+    acc = torch.zeros(batch, m, head_dim, dtype=torch.float32, device=a.device)
+    for kb in range(0, k, block_k):
+        chunk = a[:, :, kb : kb + block_k]
+        scale = torch.maximum(scale, chunk.amax(-1).float())
+        acc = acc + scale[:, :, None]
+    return acc.to(a.dtype)
+
+
 @onlyBackends(["triton", "pallas"])
 @skipUnlessPallas("JAX/Pallas TPU not available")
 class TestPallas(TestCase):
@@ -735,15 +789,25 @@ class TestPallas(TestCase):
         self.assertIn("out = _launcher(", _code)
 
     def test_attention_emit_pipeline_correctness(self) -> None:
-        """Test emit_pipeline attention with loop-carried state."""
+        """Test emit_pipeline attention with loop-carried state and pre-broadcast."""
         query = torch.randn(2, 2, 128, 128, dtype=torch.float32, device=DEVICE)
         key = torch.randn(2, 2, 128, 128, dtype=torch.float32, device=DEVICE)
         val = torch.randn(2, 2, 128, 128, dtype=torch.float32, device=DEVICE)
-        _code, result = code_and_output(
+        code, result = code_and_output(
             pallas_attention,
             (query, key, val),
             block_sizes=[4, 128, 128],
             pallas_loop_type="emit_pipeline",
+            pallas_pre_broadcast=True,
+        )
+        # m_i and l_i last dim 128 is the pre-broadcast trailing dim;
+        # acc last dim 128 is head_dim (unchanged)
+        self.assertIn(
+            "_scratch_shapes=["
+            "((4, 128, 128), 'jnp.float32', 'vmem'), "
+            "((4, 128, 128), 'jnp.float32', 'vmem'), "
+            "((4, 128, 128), 'jnp.float32', 'vmem')]",
+            code,
         )
         ref = torch.nn.functional.scaled_dot_product_attention(
             query.float().cpu(), key.float().cpu(), val.float().cpu()
@@ -751,7 +815,7 @@ class TestPallas(TestCase):
         torch.testing.assert_close(result, ref, rtol=1e-2, atol=1e-2)
 
     def test_attention_fori_loop_correctness(self) -> None:
-        """Test fori_loop attention with loop-carried state."""
+        """Test fori_loop attention with loop-carried state and pre-broadcast."""
         query = torch.randn(2, 2, 128, 128, dtype=torch.float32, device=DEVICE)
         key = torch.randn(2, 2, 128, 128, dtype=torch.float32, device=DEVICE)
         val = torch.randn(2, 2, 128, 128, dtype=torch.float32, device=DEVICE)
@@ -761,9 +825,23 @@ class TestPallas(TestCase):
             args,
             block_sizes=[4, 128, 128],
             pallas_loop_type="fori_loop",
+            pallas_pre_broadcast=True,
         )
         self.assertIn("jax.lax.fori_loop", code)
         self.assertIn("pltpu.make_async_copy", code)
+        # m_i and l_i last dim 128 is the pre-broadcast trailing dim;
+        # acc last dim 128 is head_dim; extra entries are DMA buffers/semaphores
+        self.assertIn(
+            "_scratch_shapes=["
+            "((4, 128, 128), 'jnp.float32', 'vmem'), "
+            "((4, 128, 128), 'jnp.float32', 'vmem'), "
+            "((4, 128, 128), 'jnp.float32', 'vmem'), "
+            "((4, 128, 128), 'jnp.float32', 'vmem'), "
+            "((), None, 'dma_semaphore'), "
+            "((4, 128, 128), 'jnp.float32', 'vmem'), "
+            "((), None, 'dma_semaphore')]",
+            code,
+        )
         ref = torch.nn.functional.scaled_dot_product_attention(
             query.float().cpu(), key.float().cpu(), val.float().cpu()
         ).to(device=DEVICE)
@@ -773,19 +851,30 @@ class TestPallas(TestCase):
         """Test emit_pipeline with seq_kv not divisible by block_k.
 
         Uses _explicit_indices to pass iteration index into body for
-        proper mask computation on partial tiles.
+        proper mask computation on partial tiles.  Pre-broadcast still
+        applies since block_k=256 is a multiple of 128.
         """
         # seq=384, block_k=256 -> 2 tiles, last is partial (128/256)
         query = torch.randn(1, 2, 128, 128, dtype=torch.float32, device=DEVICE)
         key = torch.randn(1, 2, 384, 128, dtype=torch.float32, device=DEVICE)
         val = torch.randn(1, 2, 384, 128, dtype=torch.float32, device=DEVICE)
-        _code, result = code_and_output(
+        code, result = code_and_output(
             pallas_attention,
             (query, key, val),
             block_sizes=[2, 128, 256],
             pallas_loop_type="emit_pipeline",
+            pallas_pre_broadcast=True,
         )
-        self.assertIn("_explicit_indices=True", _code)
+        self.assertIn("_explicit_indices=True", code)
+        # m_i and l_i last dim 128 is the pre-broadcast trailing dim;
+        # acc last dim 128 is head_dim (unchanged)
+        self.assertIn(
+            "_scratch_shapes=["
+            "((2, 128, 128), 'jnp.float32', 'vmem'), "
+            "((2, 128, 128), 'jnp.float32', 'vmem'), "
+            "((2, 128, 128), 'jnp.float32', 'vmem')]",
+            code,
+        )
         ref = torch.nn.functional.scaled_dot_product_attention(
             query.float().cpu(), key.float().cpu(), val.float().cpu()
         ).to(device=DEVICE)
@@ -1369,6 +1458,368 @@ class TestPallas(TestCase):
         torch.testing.assert_close(
             result, expected.to(torch.bfloat16), rtol=1e-2, atol=1e-2
         )
+
+    def test_pre_broadcast_emit_pipeline_codegen(self) -> None:
+        """Pre-broadcast with emit_pipeline: scratch shapes get extra trailing dim."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def cumsum_broadcast(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            batch, m, k = a.size()
+            head_dim = hl.specialize(b.size(-1))
+            out = torch.empty([batch, m, head_dim], device=a.device, dtype=a.dtype)
+            for tile_b, tile_m in hl.tile([batch, m]):
+                running = hl.zeros([tile_b, tile_m], dtype=torch.float32)
+                acc = hl.zeros([tile_b, tile_m, head_dim], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    chunk = a[tile_b, tile_m, tile_k]
+                    running = running + torch.sum(chunk, -1)
+                    acc = acc + running[:, :, None]
+                out[tile_b, tile_m, :] = acc.to(out.dtype)
+            return out
+
+        a = torch.randn(2, 128, 256, device=DEVICE, dtype=torch.float32)
+        b = torch.randn(2, 256, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            cumsum_broadcast,
+            (a, b),
+            block_sizes=[2, 128, 128],
+            pallas_loop_type="emit_pipeline",
+            pallas_pre_broadcast=True,
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+        self.assertIn(
+            "_scratch_shapes=["
+            "((2, 128, 128), 'jnp.float32', 'vmem'), "
+            "((2, 128, 128), 'jnp.float32', 'vmem')]",
+            code,
+        )
+        ref = _cumsum_broadcast_ref(a, b, block_k=128)
+        torch.testing.assert_close(result, ref, rtol=1e-2, atol=1e-2)
+
+    def test_pre_broadcast_fori_loop_codegen(self) -> None:
+        """Pre-broadcast with fori_loop: same transform applies."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def cumsum_broadcast(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            batch, m, k = a.size()
+            head_dim = hl.specialize(b.size(-1))
+            out = torch.empty([batch, m, head_dim], device=a.device, dtype=a.dtype)
+            for tile_b, tile_m in hl.tile([batch, m]):
+                running = hl.zeros([tile_b, tile_m], dtype=torch.float32)
+                acc = hl.zeros([tile_b, tile_m, head_dim], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    chunk = a[tile_b, tile_m, tile_k]
+                    running = running + torch.sum(chunk, -1)
+                    acc = acc + running[:, :, None]
+                out[tile_b, tile_m, :] = acc.to(out.dtype)
+            return out
+
+        a = torch.randn(2, 128, 256, device=DEVICE, dtype=torch.float32)
+        b = torch.randn(2, 256, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            cumsum_broadcast,
+            (a, b),
+            block_sizes=[2, 128, 128],
+            pallas_loop_type="fori_loop",
+            pallas_pre_broadcast=True,
+        )
+        self.assertIn("jax.lax.fori_loop", code)
+        self.assertIn(
+            "_scratch_shapes=["
+            "((2, 128, 128), 'jnp.float32', 'vmem'), "
+            "((2, 128, 128), 'jnp.float32', 'vmem'), "
+            "((2, 128, 128), 'jnp.float32', 'vmem'), "
+            "((), None, 'dma_semaphore')]",
+            code,
+        )
+        ref = _cumsum_broadcast_ref(a, b, block_k=128)
+        torch.testing.assert_close(result, ref, rtol=1e-2, atol=1e-2)
+
+    def test_pre_broadcast_skipped_non_multiple_of_128(self) -> None:
+        """Pre-broadcast is skipped when broadcast dim is not a multiple of 128.
+
+        Uses head_dim=64 so the broadcast target has last dim 64.
+        Since 64 % 128 != 0, the transform is skipped.
+        """
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def cumsum_broadcast_d64(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            batch, m, k = a.size()
+            head_dim = hl.specialize(b.size(-1))
+            out = torch.empty([batch, m, head_dim], device=a.device, dtype=a.dtype)
+            for tile_b, tile_m in hl.tile([batch, m]):
+                running = hl.zeros([tile_b, tile_m], dtype=torch.float32)
+                acc = hl.zeros([tile_b, tile_m, head_dim], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    chunk = a[tile_b, tile_m, tile_k]
+                    running = running + torch.sum(chunk, -1)
+                    acc = acc + running[:, :, None]
+                out[tile_b, tile_m, :] = acc.to(out.dtype)
+            return out
+
+        a = torch.randn(2, 128, 256, device=DEVICE, dtype=torch.float32)
+        b = torch.randn(2, 256, 64, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            cumsum_broadcast_d64,
+            (a, b),
+            block_sizes=[2, 128, 128],
+            pallas_loop_type="emit_pipeline",
+            pallas_pre_broadcast=True,
+        )
+        self.assertNotIn("jnp.tile(", code)
+        self.assertIn(
+            "_scratch_shapes=["
+            "((2, 128), 'jnp.float32', 'vmem'), "
+            "((2, 128, 64), 'jnp.float32', 'vmem')]",
+            code,
+        )
+        ref = _cumsum_broadcast_ref(a, b, block_k=128)
+        torch.testing.assert_close(result, ref, rtol=1e-2, atol=1e-2)
+
+    def test_pre_broadcast_no_broadcast_no_transform(self) -> None:
+        """Pre-broadcast is a no-op when loop-carried state has no broadcast usage."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def accum_sum(x: torch.Tensor) -> torch.Tensor:
+            n, m = x.size()
+            out = torch.empty([n], device=x.device, dtype=x.dtype)
+            for tile_n in hl.tile(n):
+                acc = hl.zeros([tile_n], dtype=torch.float32)
+                for tile_m in hl.tile(m):
+                    acc = acc + torch.sum(x[tile_n, tile_m], -1)
+                out[tile_n] = acc.to(out.dtype)
+            return out
+
+        x = torch.randn(128, 256, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            accum_sum,
+            (x,),
+            block_sizes=[128, 128],
+            pallas_loop_type="emit_pipeline",
+            pallas_pre_broadcast=True,
+        )
+        self.assertNotIn("jnp.tile(", code)
+        self.assertIn(
+            "_scratch_shapes=[((128,), 'jnp.float32', 'vmem')]",
+            code,
+        )
+        ref = x.sum(-1)
+        torch.testing.assert_close(result, ref, rtol=1e-2, atol=1e-2)
+
+    def test_pre_broadcast_correctness_emit_pipeline(self) -> None:
+        """Pre-broadcast correctness with emit_pipeline using a bespoke kernel."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def scaled_bmm(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            batch, m, k = a.size()
+            _, _, n = b.size()
+            head_dim = hl.specialize(n)
+            out = torch.empty([batch, m, head_dim], device=a.device, dtype=a.dtype)
+            for tile_b, tile_m in hl.tile([batch, m]):
+                m_i = hl.zeros([tile_b, tile_m], dtype=torch.float32)
+                acc = hl.zeros([tile_b, tile_m, head_dim], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    chunk = a[tile_b, tile_m, tile_k]
+                    row_sum = torch.sum(chunk, -1)
+                    m_i = m_i + row_sum
+                    acc = acc + m_i[:, :, None]
+                out[tile_b, tile_m, :] = acc.to(out.dtype)
+            return out
+
+        a = torch.randn(2, 128, 256, device=DEVICE, dtype=torch.float32)
+        b = torch.randn(2, 256, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            scaled_bmm,
+            (a, b),
+            block_sizes=[2, 128, 128],
+            pallas_loop_type="emit_pipeline",
+            pallas_pre_broadcast=True,
+        )
+        self.assertIn(
+            "_scratch_shapes=["
+            "((2, 128, 128), 'jnp.float32', 'vmem'), "
+            "((2, 128, 128), 'jnp.float32', 'vmem')]",
+            code,
+        )
+        ref = _scaled_bmm_ref(a, b, block_k=128)
+        torch.testing.assert_close(result, ref, rtol=1e-2, atol=1e-2)
+
+    def test_pre_broadcast_correctness_fori_loop(self) -> None:
+        """Pre-broadcast correctness with fori_loop using a bespoke kernel."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def scaled_bmm(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            batch, m, k = a.size()
+            _, _, n = b.size()
+            head_dim = hl.specialize(n)
+            out = torch.empty([batch, m, head_dim], device=a.device, dtype=a.dtype)
+            for tile_b, tile_m in hl.tile([batch, m]):
+                m_i = hl.zeros([tile_b, tile_m], dtype=torch.float32)
+                acc = hl.zeros([tile_b, tile_m, head_dim], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    chunk = a[tile_b, tile_m, tile_k]
+                    row_sum = torch.sum(chunk, -1)
+                    m_i = m_i + row_sum
+                    acc = acc + m_i[:, :, None]
+                out[tile_b, tile_m, :] = acc.to(out.dtype)
+            return out
+
+        a = torch.randn(2, 128, 256, device=DEVICE, dtype=torch.float32)
+        b = torch.randn(2, 256, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            scaled_bmm,
+            (a, b),
+            block_sizes=[2, 128, 128],
+            pallas_loop_type="fori_loop",
+            pallas_pre_broadcast=True,
+        )
+        self.assertIn(
+            "_scratch_shapes=["
+            "((2, 128, 128), 'jnp.float32', 'vmem'), "
+            "((2, 128, 128), 'jnp.float32', 'vmem'), "
+            "((2, 128, 128), 'jnp.float32', 'vmem'), "
+            "((), None, 'dma_semaphore')]",
+            code,
+        )
+        ref = _scaled_bmm_ref(a, b, block_k=128)
+        torch.testing.assert_close(result, ref, rtol=1e-2, atol=1e-2)
+
+    def test_pre_broadcast_reduction_unsqueeze(self) -> None:
+        """Pre-broadcast inserts unsqueeze for reduction results feeding pre-broadcast ops.
+
+        The inner-loop reduction torch.amax(chunk, -1) produces a 2D result
+        that feeds into torch.maximum(scale, ...) where scale is a pre-broadcast
+        node (3D after transform).  Step 4 of _annotate_pre_broadcast must
+        unsqueeze the reduction result to [..., 1] so JAX broadcast works.
+        """
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def running_max_broadcast(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            batch, m, k = a.size()
+            head_dim = hl.specialize(b.size(-1))
+            out = torch.empty([batch, m, head_dim], device=a.device, dtype=a.dtype)
+            for tile_b, tile_m in hl.tile([batch, m]):
+                scale = hl.zeros([tile_b, tile_m], dtype=torch.float32)
+                acc = hl.zeros([tile_b, tile_m, head_dim], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    chunk = a[tile_b, tile_m, tile_k]
+                    row_max = torch.amax(chunk, -1)
+                    scale = torch.maximum(scale, row_max)
+                    acc = acc + scale[:, :, None]
+                out[tile_b, tile_m, :] = acc.to(out.dtype)
+            return out
+
+        a = torch.randn(2, 128, 256, device=DEVICE, dtype=torch.float32)
+        b = torch.randn(2, 256, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            running_max_broadcast,
+            (a, b),
+            block_sizes=[2, 128, 128],
+            pallas_loop_type="emit_pipeline",
+            pallas_pre_broadcast=True,
+        )
+        self.assertIn(
+            "_scratch_shapes=["
+            "((2, 128, 128), 'jnp.float32', 'vmem'), "
+            "((2, 128, 128), 'jnp.float32', 'vmem')]",
+            code,
+        )
+        self.assertIn("unsqueeze_default = row_max[:, :, None]", code)
+        ref = _running_max_broadcast_ref(a, b, block_k=128)
+        torch.testing.assert_close(result, ref, rtol=1e-2, atol=1e-2)
+
+    def test_pre_broadcast_dynamic_shapes(self) -> None:
+        """Pre-broadcast with static_shapes=False exercises the SymInt codegen path.
+
+        When head_dim is not specialized, the inner FX graph carries it as a
+        backed SymInt.  The _pre_broadcast_tile codegen must handle SymInt
+        target_size and emit a valid tile expression.
+        """
+
+        @helion.kernel(backend="pallas", static_shapes=False)
+        def cumsum_broadcast_dynamic(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            batch, m, k = a.size()
+            head_dim = b.size(-1)
+            out = torch.empty([batch, m, head_dim], device=a.device, dtype=a.dtype)
+            for tile_b, tile_m in hl.tile([batch, m]):
+                running = hl.zeros([tile_b, tile_m], dtype=torch.float32)
+                acc = hl.zeros([tile_b, tile_m, head_dim], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    chunk = a[tile_b, tile_m, tile_k]
+                    running = running + torch.sum(chunk, -1)
+                    acc = acc + running[:, :, None]
+                out[tile_b, tile_m, :] = acc.to(out.dtype)
+            return out
+
+        # head_dim=256 > PRE_BROADCAST_SIZE=128 and a multiple of it
+        a = torch.randn(2, 128, 256, device=DEVICE, dtype=torch.float32)
+        b = torch.randn(2, 256, 256, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            cumsum_broadcast_dynamic,
+            (a, b),
+            block_sizes=[2, 128, 128],
+            pallas_loop_type="emit_pipeline",
+            pallas_pre_broadcast=True,
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+        self.assertIn(
+            "_scratch_shapes=["
+            "((2, 128, 128), 'jnp.float32', 'vmem'), "
+            "((2, 128, 256), 'jnp.float32', 'vmem')]",
+            code,
+        )
+        ref = _cumsum_broadcast_ref(a, b, block_k=128)
+        torch.testing.assert_close(result, ref, rtol=1e-2, atol=1e-2)
+
+    def test_pre_broadcast_double_outer_use(self) -> None:
+        """Pre-broadcast value used twice via [:, :, None] in the outer scope.
+
+        Regression test: the outer rewrite must not append PRE_BROADCAST_SIZE
+        to the same base node twice when it has multiple subscript users.
+        """
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def double_use(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            batch, m, k = a.size()
+            head_dim = hl.specialize(b.size(-1))
+            out = torch.empty([batch, m, head_dim], device=a.device, dtype=a.dtype)
+            for tile_b, tile_m in hl.tile([batch, m]):
+                running = hl.zeros([tile_b, tile_m], dtype=torch.float32)
+                acc = hl.zeros([tile_b, tile_m, head_dim], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    chunk = a[tile_b, tile_m, tile_k]
+                    running = running + torch.sum(chunk, -1)
+                    acc = acc + running[:, :, None]
+                result = acc + running[:, :, None] * running[:, :, None]
+                out[tile_b, tile_m, :] = result.to(out.dtype)
+            return out
+
+        a = torch.randn(2, 128, 256, device=DEVICE, dtype=torch.float32)
+        b = torch.randn(2, 256, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            double_use,
+            (a, b),
+            block_sizes=[2, 128, 128],
+            pallas_loop_type="emit_pipeline",
+            pallas_pre_broadcast=True,
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+        self.assertIn(
+            "_scratch_shapes=["
+            "((2, 128, 128), 'jnp.float32', 'vmem'), "
+            "((2, 128, 128), 'jnp.float32', 'vmem')]",
+            code,
+        )
+        # Eager reference
+        block_k = 128
+        running = torch.zeros(2, 128, dtype=torch.float32, device=a.device)
+        acc_ref = torch.zeros(2, 128, 128, dtype=torch.float32, device=a.device)
+        for kb in range(0, 256, block_k):
+            chunk = a[:, :, kb : kb + block_k]
+            running = running + chunk.sum(-1).float()
+            acc_ref = acc_ref + running[:, :, None]
+        ref = (acc_ref + running[:, :, None] * running[:, :, None]).to(a.dtype)
+        torch.testing.assert_close(result, ref, rtol=1e-2, atol=1e-2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
On TPU, implicit broadcast an array of `(block, 1)` is significantly slower than pre-expanding them to `(block, 128)` and using explicit `jnp.tile` at the point of use. This [repro script](https://github.com/v0i0/Helion-Pallas-Kernels/blob/v0i0/attention-pallas-more/examples/broadcast_repro.py) is a demo of the perf benefit of pre-broadcasting. This PR adds an optional FX-graph-level optimization pass `pallas_pre_broadcast` that automatically applies this transform to Pallas codegen. 
                                                                                                                                   
### Motivating Example 
In attention kernels, 2D loop-carried state (`m_i` and `l_i`) is repeatedly broadcast against 3D accumulators via 
`[:, :, None]`. The implicit `(block, 1)` broadcast on TPU is costly. Pre-expanding the scratch buffer's trailing dimension to 128 and tiling at use sites eliminates this bottleneck. 

For [this attention example](https://gist.github.com/AmesingFlank/359e50a73bfe2c18292de8ff4be46962), this optimization increase perf from 201 TFLOPS to 254 TFLOPS
                                                                  
### Changes in this PR                                                                                                         
  1. Candidate detection (`_find_pre_broadcast_candidates`): Scans the FX graph for loop-carried tensors that feed into subscript `[..., None]` unsqueezes followed by ops that involve broadcasting.                                                         
  2. Node propagation (`_compute_pre_broadcast_nodes`): Propagates the pre-broadcast status through the graph to all nodes that operate on narrow (pre-broadcast) shapes.                                                                                  
  3. Scratch shape update (`_apply_pre_broadcast_to_scratch`): Appends a trailing PRE_BROADCAST_SIZE dimension to the identified scratch buffers.                                                                                                            
  4. Graph rewrite (`_annotate_pre_broadcast`): Rewrites the FX graph — unsqueezes become identity, and _pre_broadcast_tile calls are inserted where narrow values feed into wider-dimensioned operations (generating `jnp.tile(tensor, block_size // 128)` in the output).                                                                                                                         
  5. Outer graph fixup (`_rewrite_outer_subscripts_for_pre_broadcast`): Adjusts post-loop subscript operations that consumed the old narrow shape.
  6. The transform is shared between `emit_pipeline` and `fori_loop` codegen paths via `_apply_pre_broadcast_transform`.
  7. Config: Controlled by the new `pallas_pre_broadcast` tunable (default off).                                                             
                                                                                                                                   
  Test plan                           
  - `test/test_pallas.py`                                                           
    - 6 new test_pre_broadcast_* tests 
    - 3 attention tests updated to enable `pallas_pre_broadcast=True` with `_scratch_shapes` assertions that show that we are using broad-casted shapes