### PR TITLE
[Pallas] Host-side padding for non-divisible pl.ds() dimensions

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1558,6 +1558,46 @@ class PallasBackend(Backend):
             result.append((tuple(block_shape), tuple(grid_dims)))
         return result
 
+    def _compute_pad_info(
+        self,
+        sorted_args: list[Argument] | None,
+        config: Config,
+    ) -> list[tuple[int, int, int]] | None:
+        """Identify pl.ds() dims that may need padding and their block sizes.
+
+        Uses ``pallas_pad_info`` recorded during codegen to identify which
+        tensor dimensions use ``pl.ds()`` slicing.
+
+        Returns ``[(arg_index, tensor_dim, block_size), ...]`` or ``None``.
+        The launcher computes the actual pad amount at runtime as
+        ``(-tensor.shape[dim]) % block_size``.
+        """
+        if sorted_args is None:
+            return None
+
+        from .compile_environment import CompileEnvironment
+        from .device_function import DeviceFunction
+        from .device_function import TensorArg
+
+        env = CompileEnvironment.current()
+        device_fn = DeviceFunction.current()
+        if not device_fn.pallas_pad_info:
+            return None
+
+        result: list[tuple[int, int, int]] = []
+        for i, arg in enumerate(sorted_args):
+            if not isinstance(arg, TensorArg):
+                continue
+            dims_info = device_fn.pallas_pad_info.get(id(arg.fake_value))
+            if dims_info is not None:
+                for dim, block_id in dims_info.items():
+                    bsi = env.block_sizes[block_id]
+                    bs = bsi.from_config(config)
+                    if isinstance(bs, int) and bs > 1:
+                        result.append((i, dim, bs))
+
+        return result or None
+
     def build_launcher_args(
         self,
         args: list[str],
@@ -1653,6 +1693,10 @@ class PallasBackend(Backend):
             if has_rng_ops:
                 block_spec_info.append(None)  # RNG seed buffer is untiled
             launcher_args.append(f"_block_spec_info={block_spec_info!r}")
+
+        pad_info = self._compute_pad_info(sorted_args, config)
+        if pad_info:
+            launcher_args.append(f"_ds_pad_dims={pad_info!r}")
 
         from .device_function import PallasMemorySpace
 

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -328,6 +328,9 @@ class DeviceFunction:
         # dict would then need to support multiple entries per tensor
         # or the tensor would get distinct arg IDs per memory space.
         self.pallas_memory_space: dict[int, PallasMemorySpace] = {}
+        # Pallas: id(fake_tensor) → {dim: block_id} for dims using pl.ds()
+        # that may need host-side padding when block size doesn't divide dim.
+        self.pallas_pad_info: dict[int, dict[int, int]] = {}
 
     def allocate_store_index(self) -> int:
         """Bump store counters and return the indexing strategy slot."""

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -120,11 +120,11 @@ def _generated_index_code(
 
     if isinstance(pattern, TilePattern):
         return _tile_pattern_code(
-            pattern, idx, state, tensor_dim, in_pipeline, pipeline_block_ids
+            pattern, idx, state, tensor, tensor_dim, in_pipeline, pipeline_block_ids
         )
 
     if isinstance(pattern, TileIndexWithOffsetPattern):
-        return _tile_index_with_offset_pattern_code(pattern, state)
+        return _tile_index_with_offset_pattern_code(pattern, state, tensor, tensor_dim)
 
     if isinstance(pattern, TileBeginWithOffsetPattern):
         return _tile_begin_with_offset_pattern_code(
@@ -150,6 +150,7 @@ def _tile_pattern_code(
     pattern: object,
     idx: object,
     state: CodegenState,
+    tensor: torch.Tensor,
     tensor_dim: int,
     in_pipeline: bool,
     pipeline_block_ids: set[int],
@@ -173,7 +174,7 @@ def _tile_pattern_code(
 
     can_tile = _can_tile_dimension(state, tensor_dim)
     if not can_tile:
-        return _ds_expr(state, block_id)
+        return _ds_expr(state, block_id, tensor=tensor, tensor_dim=tensor_dim)
 
     loops = state.codegen.active_device_loops.get(block_id)
     if loops and any(
@@ -181,13 +182,15 @@ def _tile_pattern_code(
         or (isinstance(loop, ForiLoopState) and not loop.use_dma)
         for loop in loops
     ):
-        return _ds_expr(state, block_id)
+        return _ds_expr(state, block_id, tensor=tensor, tensor_dim=tensor_dim)
     return ":"
 
 
 def _tile_index_with_offset_pattern_code(
     pattern: object,
     state: CodegenState,
+    tensor: torch.Tensor,
+    tensor_dim: int,
 ) -> str:
     from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
 
@@ -195,7 +198,7 @@ def _tile_index_with_offset_pattern_code(
 
     block_id = pattern.block_id
     offset_str = state.device_function.literal_expr(pattern.offset)
-    return _ds_expr(state, block_id, offset_str)
+    return _ds_expr(state, block_id, offset_str, tensor=tensor, tensor_dim=tensor_dim)
 
 
 def _tile_begin_with_offset_pattern_code(
@@ -259,19 +262,34 @@ def _slice_code(
         loops = state.codegen.active_device_loops.get(block_id)
         if loops and any(isinstance(loop, DeviceLoopState) for loop in loops):
             if block_id is not None:
-                return _ds_expr(state, block_id)
+                return _ds_expr(state, block_id, tensor=tensor, tensor_dim=tensor_dim)
 
     return ":"
 
 
-def _ds_expr(state: CodegenState, block_id: int, tile_offset: str = "") -> str:
-    """Return a ``pl.ds(offset, block_size)`` expression for *block_id*, offset by *tile_offset*"""
+def _ds_expr(
+    state: CodegenState,
+    block_id: int,
+    tile_offset: str = "",
+    *,
+    tensor: torch.Tensor | None = None,
+    tensor_dim: int | None = None,
+) -> str:
+    """Return a ``pl.ds(offset, block_size)`` expression for *block_id*, offset by *tile_offset*.
+
+    When *tensor* and *tensor_dim* are provided, records the dimension in
+    ``pallas_pad_info`` so the launcher can zero-pad non-divisible dims.
+    """
     offset = state.codegen.offset_var(block_id)
     if tile_offset:
         offset = f"{offset} + {tile_offset}"
     block_size = state.device_function.block_size_var(block_id)
     if block_size is None:
         return ":"
+    if tensor is not None and tensor_dim is not None:
+        from helion.language.memory_ops import _record_pad_info
+
+        _record_pad_info(state, tensor, tensor_dim, block_id)
     return f"pl.ds({offset}, {block_size})"
 
 

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -159,6 +159,25 @@ def _(state: CodegenState) -> ast.AST:
     raise NotImplementedError(f"Cannot store to type: {type(tensor)}")
 
 
+def _record_pad_info(
+    state: CodegenState,
+    tensor: torch.Tensor,
+    tensor_dim: int,
+    block_id: int,
+) -> None:
+    """Record that a tensor dimension uses pl.ds() and may need host-side padding.
+
+    Note: stores one block_id per (tensor, dim).  If two inner loops tile the
+    same dim with different block_ids, the last one wins.  This is fine when
+    both loops use the same block size (the common case).
+    """
+    pad_info = state.device_function.pallas_pad_info
+    tensor_id = id(tensor)
+    if tensor_id not in pad_info:
+        pad_info[tensor_id] = {}
+    pad_info[tensor_id][tensor_dim] = block_id
+
+
 def _maybe_get_symbol_origin(idx: object) -> SymbolOrigin | None:
     if not isinstance(idx, torch.SymInt):
         return None

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -740,12 +740,18 @@ def _pallas_invoke_and_return(
     tensor_arg_indices: list[int],
     arg_to_tensor_pos: dict[int, int],
     _output_indices: list[int],
+    _ds_pad_dims: list[tuple[int, int, int]] | None = None,
+    _orig_output_tensors: dict[int, torch.Tensor] | None = None,
 ) -> object:
     """Run the JaxCallable and return output-only results.
 
     Output-only tensors (those not in ``arg_to_tensor_pos``) are not passed
     as pallas_call inputs, so the JaxCallable returns new buffers for them.
     Returns a single tensor, a tuple of tensors, or None.
+
+    When ``_ds_pad_dims`` is provided, also handles:
+    - Copying sliced results back into original (unpadded) in-place output tensors
+    - Slicing padded output-only result tensors back to original shapes
     """
     input_tensors = [
         cast("torch.Tensor", args[i]).contiguous() for i in tensor_arg_indices
@@ -775,9 +781,83 @@ def _pallas_invoke_and_return(
                     dtype=out_tensor.dtype,
                 )
             output_only_results.append(result)
+
+    # Handle padding copy-back and result slicing
+    if _ds_pad_dims and _orig_output_tensors:
+        # _ds_pad_dims contains (arg_idx, dim, block_size).
+        # Build a map from arg_idx → [(dim, ...)] for padded output args.
+        padded_dims_by_arg: dict[int, list[int]] = {}
+        for arg_idx, dim, _bs in _ds_pad_dims:
+            if arg_idx in _orig_output_tensors:
+                padded_dims_by_arg.setdefault(arg_idx, []).append(dim)
+
+        # Copy sliced results back into original in-place output tensors
+        for arg_idx, orig_tensor in _orig_output_tensors.items():
+            dims = padded_dims_by_arg.get(arg_idx)
+            if not dims:
+                continue
+            padded = cast("torch.Tensor", args[arg_idx])
+            slices = [slice(None)] * padded.ndim
+            for dim in dims:
+                slices[dim] = slice(None, orig_tensor.shape[dim])
+            orig_tensor.copy_(padded[tuple(slices)])
+
+        # Slice padded output-only results back to original shapes
+        if output_only_results:
+            compacted_idx = 0
+            for orig_pos in _output_indices:
+                if orig_pos not in arg_to_tensor_pos:
+                    orig = _orig_output_tensors.get(orig_pos)
+                    dims = padded_dims_by_arg.get(orig_pos)
+                    if (
+                        orig is not None
+                        and dims
+                        and compacted_idx < len(output_only_results)
+                    ):
+                        t = output_only_results[compacted_idx]
+                        if isinstance(t, torch.Tensor):
+                            slices = [slice(None)] * t.ndim
+                            for dim in dims:
+                                slices[dim] = slice(None, orig.shape[dim])
+                            output_only_results[compacted_idx] = t[tuple(slices)]
+                    compacted_idx += 1
+
     if len(output_only_results) == 1:
         return output_only_results[0]
     return tuple(output_only_results) if output_only_results else None
+
+
+def _pallas_apply_ds_padding(
+    args: tuple[object, ...],
+    _output_indices: list[int],
+    _ds_pad_dims: list[tuple[int, int, int]],
+) -> tuple[tuple[object, ...], dict[int, torch.Tensor]]:
+    """Pad tensor args along non-divisible pl.ds() dimensions.
+
+    ``_ds_pad_dims`` contains ``(arg_index, dim, block_size)`` tuples.
+    The pad amount is computed at runtime as ``(-tensor.shape[dim]) % block_size``.
+
+    Returns the padded args tuple and a dict mapping output arg indices
+    to their original (unpadded) tensors for post-call copy-back.
+    """
+    args_list = list(args)
+    orig_output_tensors: dict[int, torch.Tensor] = {}
+    output_set = set(_output_indices)
+    for arg_idx, dim, block_size in _ds_pad_dims:
+        a = args_list[arg_idx]
+        if not isinstance(a, torch.Tensor):
+            continue
+        pad_amount = (-a.shape[dim]) % block_size
+        if pad_amount == 0:
+            continue
+        if arg_idx in output_set:
+            orig_output_tensors[arg_idx] = a
+        # F.pad takes (last_dim_left, last_dim_right, ..., first_dim_left, first_dim_right).
+        # To right-pad dimension `dim`, set index 2*(ndim-1-dim) + 1.
+        pad_widths = [0] * (2 * a.ndim)
+        pad_widths[2 * (a.ndim - 1 - dim) + 1] = pad_amount
+        args_list[arg_idx] = torch.nn.functional.pad(a, pad_widths)
+    return tuple(args_list), orig_output_tensors
 
 
 def default_pallas_launcher(
@@ -788,6 +868,7 @@ def default_pallas_launcher(
     _inplace_indices: list[int] | None = None,
     _block_spec_info: _BlockSpecInfo | None = None,
     _smem_arg_indices: list[int] | None = None,
+    _ds_pad_dims: list[tuple[int, int, int]] | None = None,
     **kwargs: object,
 ) -> object:
     """Default launcher for Pallas kernels on TPU (or CPU with interpret=True).
@@ -804,6 +885,12 @@ def default_pallas_launcher(
     """
     if _output_indices is None:
         _output_indices = []
+
+    _orig_output_tensors: dict[int, torch.Tensor] | None = None
+    if _ds_pad_dims:
+        args, _orig_output_tensors = _pallas_apply_ds_padding(
+            args, _output_indices, _ds_pad_dims
+        )
 
     _pallas_check_dtypes(args)
 
@@ -903,7 +990,13 @@ def default_pallas_launcher(
         )
 
     return _pallas_invoke_and_return(
-        jax_callable, args, tensor_arg_indices, arg_to_tensor_pos, _output_indices
+        jax_callable,
+        args,
+        tensor_arg_indices,
+        arg_to_tensor_pos,
+        _output_indices,
+        _ds_pad_dims,
+        _orig_output_tensors,
     )
 
 
@@ -916,6 +1009,7 @@ def default_pallas_pipeline_launcher(
     _block_spec_info: _BlockSpecInfo | None = None,
     _scratch_shapes: list[tuple[tuple[int, ...], str]] | None = None,
     _pipeline_arg_indices: list[int] | None = None,
+    _ds_pad_dims: list[tuple[int, int, int]] | None = None,
     **kwargs: object,
 ) -> object:
     """Launcher for Pallas kernels using PrefetchScalarGridSpec with scratch memory.
@@ -928,6 +1022,12 @@ def default_pallas_pipeline_launcher(
         _output_indices = []
     if _scratch_shapes is None:
         _scratch_shapes = []
+
+    _orig_output_tensors: dict[int, torch.Tensor] | None = None
+    if _ds_pad_dims:
+        args, _orig_output_tensors = _pallas_apply_ds_padding(
+            args, _output_indices, _ds_pad_dims
+        )
 
     _pallas_check_dtypes(args)
 
@@ -1055,7 +1155,13 @@ def default_pallas_pipeline_launcher(
         )
 
     return _pallas_invoke_and_return(
-        jax_callable, args, tensor_arg_indices, arg_to_tensor_pos, _output_indices
+        jax_callable,
+        args,
+        tensor_arg_indices,
+        arg_to_tensor_pos,
+        _output_indices,
+        _ds_pad_dims,
+        _orig_output_tensors,
     )
 
 
@@ -1067,6 +1173,7 @@ def default_pallas_fori_launcher(
     _inplace_indices: list[int] | None = None,
     _block_spec_info: _BlockSpecInfo | None = None,
     _scratch_shapes: list[tuple[tuple[int, ...], str | None, str]] | None = None,
+    _ds_pad_dims: list[tuple[int, int, int]] | None = None,
     **kwargs: object,
 ) -> object:
     """Launcher for Pallas kernels using fori_loop with manual DMA.
@@ -1081,6 +1188,12 @@ def default_pallas_fori_launcher(
         _output_indices = []
     if _scratch_shapes is None:
         _scratch_shapes = []
+
+    _orig_output_tensors: dict[int, torch.Tensor] | None = None
+    if _ds_pad_dims:
+        args, _orig_output_tensors = _pallas_apply_ds_padding(
+            args, _output_indices, _ds_pad_dims
+        )
 
     _pallas_check_dtypes(args)
 
@@ -1207,7 +1320,13 @@ def default_pallas_fori_launcher(
         )
 
     return _pallas_invoke_and_return(
-        jax_callable, args, tensor_arg_indices, arg_to_tensor_pos, _output_indices
+        jax_callable,
+        args,
+        tensor_arg_indices,
+        arg_to_tensor_pos,
+        _output_indices,
+        _ds_pad_dims,
+        _orig_output_tensors,
     )
 
 

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -322,7 +322,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[16, 16, 16, 16],
         )
 
-    @xfailIfPallas("reduction tile K=256 doesn't evenly divide K=384")
     @xfailIfCute("CuTE IR build error with non-divisible K block sizes")
     def test_bmm_non_divisible_k(self):
         args = (
@@ -963,6 +962,33 @@ class TestExamples(RefEagerTestBase, TestCase):
             x.sum(-1),
             fn_name="longsum_manual",
         )
+
+    def test_long_sum_manual_non_divisible(self):
+        """Reduction loop OOB when block_size doesn't divide the reduction dim."""
+        x = torch.randn([4, 50000], device=DEVICE, dtype=torch.float32)
+        check_example(
+            "long_sum",
+            (x,),
+            x.sum(-1),
+            fn_name="longsum_manual",
+            block_sizes=[32768, 1],
+        )
+
+    def test_long_sum_manual_non_divisible_dynamic(self):
+        """longsum_manual uses dynamic shapes (static_shapes=False by default).
+
+        Calling with two different non-divisible N values exercises the
+        runtime pad computation: (-x.shape[1]) % block_size.
+        """
+        for n in [50000, 40000]:
+            x = torch.randn([4, n], device=DEVICE, dtype=torch.float32)
+            check_example(
+                "long_sum",
+                (x,),
+                x.sum(-1),
+                fn_name="longsum_manual",
+                block_sizes=[32768, 1],
+            )
 
     @xfailIfCute("CuTe jagged mean example still fails lowering/runtime")
     @xfailIfPallas("JAX tracer error with dynamic shapes")

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -964,21 +964,11 @@ class TestExamples(RefEagerTestBase, TestCase):
         )
 
     def test_long_sum_manual_non_divisible(self):
-        """Reduction loop OOB when block_size doesn't divide the reduction dim."""
-        x = torch.randn([4, 50000], device=DEVICE, dtype=torch.float32)
-        check_example(
-            "long_sum",
-            (x,),
-            x.sum(-1),
-            fn_name="longsum_manual",
-            block_sizes=[32768, 1],
-        )
+        """Reduction loop OOB when block_size doesn't divide the reduction dim.
 
-    def test_long_sum_manual_non_divisible_dynamic(self):
-        """longsum_manual uses dynamic shapes (static_shapes=False by default).
-
-        Calling with two different non-divisible N values exercises the
-        runtime pad computation: (-x.shape[1]) % block_size.
+        longsum_manual uses dynamic shapes (static_shapes=False by default).
+        Two different non-divisible N values exercise the runtime pad
+        computation with different pad amounts.
         """
         for n in [50000, 40000]:
             x = torch.randn([4, n], device=DEVICE, dtype=torch.float32)


### PR DESCRIPTION
## Summary
- When a tiled dimension's block size doesn't evenly divide the dimension, `pl.ds(offset, block_size)` goes out of bounds on the last iteration
- Fix by zero-padding tensors on the host before `pallas_call`, then slicing outputs back — following the standard Pallas convention used in reference TPU kernels (e.g. quantized_matmul, flash_attention in msl-tpu-kernel)
- Note: Pallas BlockSpecs handle partial grid tiles automatically (padding with unspecified values, discarding OOB on output — see [JAX docs](https://docs.jax.dev/en/latest/pallas/grid_blockspec.html#partial-blocks)). But `pl.ds()` slicing in inner loops has no such handling and simply crashes on OOB
- Records `(tensor, dim, block_id)` at each `pl.ds()` codegen site (in `_ds_expr`), covering default loop and non-DMA fori_loop
- Compile time emits `(arg_idx, dim, block_size)` tuples; the launcher computes pad amounts at runtime as `(-tensor.shape[dim]) % block_size`, supporting both static and dynamic shapes
- Follow-up #2105 extends to fori_loop DMA and emit_pipeline via matmul K block_id tracking
- Related to #2085 which takes a similar approach; this PR additionally handles output tensor slicing and avoids the `pl.multiple_of` alignment issue

### Example

For `longsum_manual` with N=50000, block_size=32768 (50000 % 32768 ≠ 0), the generated code passes `(arg_index, dim, block_size)` to the launcher:

```python
# arg 0 = x, dim 1 = N, block_size = 32768
_ds_pad_dims=[(0, 1, 32768)]
```

At runtime, the launcher computes `(-x.shape[1]) % 32768 = 15536` and pads x from `[4, 50000]` → `[4, 65536]` with zeros before `pallas_call`.

Builds on xfail tests from #2031.