### PR TITLE
[Pallas] Extend padding to fori_loop DMA and emit_pipeline via _record_pad_info

### DIFF
--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -1307,6 +1307,9 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                 begin_expr = begin_exprs[bid_idx]
                 iter_step_expr = iter_step_exprs[bid_idx]
                 block_shape_parts.append(slice_size_expr)
+                from .memory_ops import _record_pad_info
+
+                _record_pad_info(state, fake, dim_idx, bid)
                 if begin_expr == "0" and iter_step_expr == slice_size_expr:
                     lambda_parts.append(lambda_params[bid_idx])
                 else:
@@ -1763,6 +1766,9 @@ def _codegen_fori_loop(state: CodegenState) -> object:
                     f"pl.ds(({begin_expr}) + ({dim_idx_expr}) * ({iter_step_expr}), {slice_size_expr})"
                 )
                 needs_slice = True
+                from .memory_ops import _record_pad_info
+
+                _record_pad_info(state, fake, dim_idx, bid)
             elif bid is not None and bid not in block_ids:
                 # Outer grid dim: use grid offset
                 grid_loops = state.codegen.active_device_loops.get(bid)

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -791,8 +791,12 @@ def _pallas_invoke_and_return(
             if arg_idx in _orig_output_tensors:
                 padded_dims_by_arg.setdefault(arg_idx, []).append(dim)
 
-        # Copy sliced results back into original in-place output tensors
+        # Copy sliced results back into original in-place output tensors.
+        # Skip output-only tensors (not in arg_to_tensor_pos) — their
+        # results come from output_only_results, not from args.
         for arg_idx, orig_tensor in _orig_output_tensors.items():
+            if arg_idx not in arg_to_tensor_pos:
+                continue
             dims = padded_dims_by_arg.get(arg_idx)
             if not dims:
                 continue

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -641,9 +641,6 @@ class TestPallas(TestCase):
         expected = torch.bmm(a.float(), b.float()).to(torch.bfloat16)
         torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
 
-    @xfailIfPallas(
-        "reduction tile K=256 doesn't evenly divide K=384, last tile reads OOB"
-    )
     def test_bmm_fori_loop_non_divisible_k(self) -> None:
         """Test fori_loop bmm where BLOCK_K=256 doesn't evenly divide K=384."""
         a = torch.randn(4, 128, 384, device=DEVICE, dtype=torch.bfloat16)
@@ -657,9 +654,6 @@ class TestPallas(TestCase):
         expected = torch.bmm(a.float(), b.float()).to(torch.bfloat16)
         torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
 
-    @xfailIfPallas(
-        "reduction tile K=256 doesn't evenly divide K=384, last tile reads OOB"
-    )
     def test_bmm_emit_pipeline_non_divisible_k(self) -> None:
         """Test emit_pipeline bmm where BLOCK_K=256 doesn't evenly divide K=384."""
         a = torch.randn(4, 128, 384, device=DEVICE, dtype=torch.bfloat16)


### PR DESCRIPTION
## Summary
- #2104 records padding info at `_ds_expr` codegen sites, covering default loop and non-DMA fori_loop
- This PR extends coverage to fori_loop DMA and emit_pipeline by recording `_record_pad_info` directly at the tiling generation sites:
  - `_build_hbm_dma_slice` in `_tracing_ops.py` for fori_loop DMA `pl.ds()` slices
  - `_make_block_spec` in `_tracing_ops.py` for emit_pipeline BlockSpec tiling
- Also fixes output-only tensor copy-back: skips tensors not in `arg_to_tensor_pos` since their results come from `output_only_results`, not from `args`

### Design
All padding detection now happens uniformly at the tiling generation site — no matmul-specific fallback or block_id matching needed. This is possible because the multi-dim padding bug (fixed in #2120) was the root cause of earlier failures with this approach.

Stacked on #2120 → #2104.