### PR TITLE
[Benchmarking/CI] Prevent hangs in benchmark phase via subprocess + per-config run timeout

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -39,6 +39,9 @@ jobs:
 
     env:
       HELION_AUTOTUNE_LOG_LEVEL: INFO
+      # Run autotune benchmarks in a subprocess so deadlocked kernels are
+      # SIGKILL'd at the per-config timeout instead of hanging the job.
+      HELION_AUTOTUNE_BENCHMARK_SUBPROCESS: "1"
 
     container:
       image: ${{ inputs.image }}

--- a/helion/autotuner/benchmark_job.py
+++ b/helion/autotuner/benchmark_job.py
@@ -1,0 +1,46 @@
+"""Picklable benchmark job executed inside a ``BenchmarkWorker``."""
+
+from __future__ import annotations
+
+import dataclasses
+import functools
+from typing import TYPE_CHECKING
+from typing import cast
+
+import torch
+
+from .benchmarking import do_bench
+from .precompile_future import _load_compiled_fn
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from .precompile_future import SerializedCompiledFunction
+
+
+@functools.cache
+def _load_args(path: str) -> Sequence[object]:
+    # Cached so re-spawning configs don't re-read the same args off disk.
+    return cast("Sequence[object]", torch.load(path))
+
+
+@dataclasses.dataclass
+class BenchmarkJob:
+    fn_spec: SerializedCompiledFunction
+    args_path: str
+    warmup: int = 1
+    rep: int = 50
+
+    def __call__(self) -> float:
+        fn = _load_compiled_fn(self.fn_spec)
+        args = _load_args(self.args_path)
+        # return_mode="median" guarantees a float return (not the tuple variant).
+        return cast(
+            "float",
+            do_bench(
+                functools.partial(fn, *args),
+                return_mode="median",
+                warmup=self.warmup,
+                rep=self.rep,
+            ),
+        )

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -28,6 +28,9 @@ from .. import exc
 from ..runtime.precompile_shim import already_compiled
 from ..runtime.precompile_shim import already_compiled_fail
 from ..runtime.precompile_shim import make_precompiler
+from .benchmark_job import BenchmarkJob
+from .benchmark_worker import BenchmarkSubprocessError
+from .benchmark_worker import BenchmarkWorker
 from .benchmarking import do_bench
 from .benchmarking import synchronize_device
 from .logger import SUPPRESSED_TRITON_CODE_MSG
@@ -42,6 +45,7 @@ from .logger import maybe_dump_triton_failure
 from .precompile_future import PrecompileContext
 from .precompile_future import PrecompileFuture
 from .precompile_future import _ExtractedLaunchArgs
+from .precompile_future import _serialize_compiled_fn
 from .progress_bar import iter_with_progress
 from helion._dist_utils import _clone_symm_mem_tensor
 from helion._dist_utils import all_gather_object
@@ -334,6 +338,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         self._precompile_tmpdir: tempfile.TemporaryDirectory[str] | None = None
         self._precompile_args_path: str | None = None
         self._precompile_result_counter: count[int] = count()
+        self._benchmark_worker: BenchmarkWorker | None = None
 
         # TODO(hinriksnaer): baseline computation is expensive (compiles and runs
         # the kernel). Currently safe because the provider is only constructed
@@ -539,7 +544,10 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         """Prepare precompile tmpdir and args for spawn mode."""
         if self._precompile_tmpdir is None:
             self._precompile_tmpdir = tempfile.TemporaryDirectory()
-        if self.settings.autotune_precompile == "spawn":
+        if (
+            self.settings.autotune_precompile == "spawn"
+            or self._subprocess_benchmark_enabled()
+        ):
             args_path = os.path.join(self._precompile_tmpdir.name, "args.pt")
             torch.save(self.args, args_path)
             self._precompile_args_path = args_path
@@ -555,11 +563,27 @@ class LocalBenchmarkProvider(BenchmarkProvider):
 
     def cleanup(self) -> None:
         """Release precompile tmpdir and related resources."""
+        if self._benchmark_worker is not None:
+            self._benchmark_worker.shutdown()
+            self._benchmark_worker = None
         if self._precompile_tmpdir is not None:
             self._precompile_tmpdir.cleanup()
             self._precompile_tmpdir = None
         self._precompile_args_path = None
         self._precompile_result_counter = count()
+
+    def _subprocess_benchmark_enabled(self) -> bool:
+        """Subprocess benchmark path is opt-in and skipped for distributed /
+        mutated-arg kernels where the worker's simple job shape doesn't fit."""
+        if not self.settings.autotune_benchmark_subprocess:
+            return False
+        if dist.is_initialized():
+            return False
+        if len(self.mutated_arg_indices) > 0:
+            return False
+        # Custom do_bench implementations are not shipped to the worker.
+        _backend = getattr(self.config_spec, "backend", None)
+        return not (_backend is not None and _backend.get_do_bench() is not None)
 
     def _validate_against_baseline(
         self, config: Config, output: object, args: Sequence[object]
@@ -755,6 +779,14 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         """Benchmark a single compiled function.  Returns time in ms or inf."""
         self._autotune_metrics.num_configs_tested += 1
         self.log.debug(lambda: f"Running benchmark for {config!r}")
+
+        if self._subprocess_benchmark_enabled():
+            result = self._benchmark_function_subprocess(config, fn)
+            if result is not None:
+                return result
+            # None means the subprocess path could not handle this config
+            # (e.g., serialization failed); fall through to in-process.
+
         _captured_output: list[str] = [""]
         _capture_ctx = (
             capture_output()
@@ -921,3 +953,73 @@ class LocalBenchmarkProvider(BenchmarkProvider):
 
             self._autotune_metrics.num_compile_failures += 1
             return inf
+
+    def _benchmark_function_subprocess(
+        self, config: Config, fn: CompiledConfig
+    ) -> float | None:
+        """Benchmark ``fn`` in a long-lived spawn subprocess with a per-call
+        timeout. Returns the measured latency in ms, ``inf`` for a failure
+        we classified and handled, or ``None`` if the subprocess path cannot
+        handle this config and the caller should fall back to in-process.
+        """
+        if self._precompile_args_path is None:
+            return None
+        try:
+            fn_spec = _serialize_compiled_fn(fn)
+        except RuntimeError:
+            return None
+
+        if self._benchmark_worker is None:
+            self._benchmark_worker = BenchmarkWorker(device=None)
+
+        job = BenchmarkJob(
+            fn_spec=fn_spec,
+            args_path=self._precompile_args_path,
+            warmup=1,
+            rep=50,
+        )
+        timeout = float(self.settings.autotune_benchmark_timeout)
+
+        try:
+            latency = self._benchmark_worker.run(job, timeout=timeout)
+        except BenchmarkSubprocessError as e:
+            # Timeout or unexpected worker exit; skip config and continue.
+            self.log.warning(f"Benchmark subprocess failed for {config!r}: {e}")
+            self._autotune_metrics.num_compile_failures += 1
+            return inf
+        except Exception as e:
+            e.__traceback__ = None
+            if match_unrecoverable_runtime_error(e):
+                # Subprocess already killed itself via BenchmarkWorker's sticky
+                # check; surface to the caller the same way the in-process
+                # path does so autotuning aborts.
+                self.kernel.maybe_log_repro(self.log.error, self.args, config)
+                raise exc.TritonUnrecoverableRuntimeError(
+                    reason=str(e),
+                    decorator=self.kernel.format_kernel_decorator(
+                        config, self.settings
+                    ),
+                    error=f"{type(e).__qualname__}: {e}",
+                ) from e
+            self.log.debug(
+                f"Benchmark subprocess raised for {config!r}: {type(e).__name__}: {e}"
+            )
+            self._autotune_metrics.num_compile_failures += 1
+            return inf
+
+        # Kernel is known-safe; accuracy check launches in-process without hang risk.
+        if self.settings.autotune_accuracy_check:
+            try:
+                output = fn(*self.args)
+                synchronize_device(output)
+                if not self._validate_against_baseline(config, output, self.args):
+                    self._autotune_metrics.num_accuracy_failures += 1
+                    return inf
+            except Exception as e:
+                self.log.debug(
+                    f"Accuracy check raised for {config!r}: {type(e).__name__}: {e}"
+                )
+                self._autotune_metrics.num_compile_failures += 1
+                return inf
+
+        return float(latency)

--- a/helion/autotuner/benchmark_worker.py
+++ b/helion/autotuner/benchmark_worker.py
@@ -1,0 +1,148 @@
+"""Long-lived spawn subprocess for executing autotune benchmark jobs."""
+
+from __future__ import annotations
+
+import contextlib
+import ctypes
+import ctypes.util
+import multiprocessing as mp
+import os
+import signal
+import sys
+from typing import TYPE_CHECKING
+from typing import Callable
+from typing import TypeVar
+
+from .logger import _UNRECOVERABLE_RUNTIME_ERROR_RE
+
+if TYPE_CHECKING:
+    from multiprocessing.connection import Connection
+
+_T = TypeVar("_T")
+
+
+def _set_pdeathsig() -> None:
+    """SIGTERM the child if the parent dies (Linux only, best-effort)."""
+    if sys.platform != "linux":
+        return
+    with contextlib.suppress(Exception):
+        libc = ctypes.CDLL(ctypes.util.find_library("c") or "libc.so.6", use_errno=True)
+        PR_SET_PDEATHSIG = 1
+        libc.prctl(PR_SET_PDEATHSIG, signal.SIGTERM, 0, 0, 0)
+
+
+def _worker_loop(connection: Connection, device: int | None) -> None:
+    _set_pdeathsig()
+    if device is not None:
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(device)
+
+    while True:
+        try:
+            job = connection.recv()
+        except EOFError:
+            return
+        if job is None:
+            return
+        try:
+            result: object = job()
+        except BaseException as e:
+            # Tracebacks pin the job's locals (tensors); strip before pickle.
+            e.__traceback__ = None
+            result = e
+        try:
+            connection.send(result)
+        except BrokenPipeError:
+            return
+
+
+class BenchmarkSubprocessError(Exception):
+    """Worker-subprocess failure, distinct from exceptions raised by the
+    user job (which are re-raised verbatim)."""
+
+
+class BenchmarkTimeout(BenchmarkSubprocessError):
+    pass
+
+
+class BenchmarkWorkerDied(BenchmarkSubprocessError):
+    pass
+
+
+class BenchmarkWorker:
+    """Single spawn subprocess. Lazily started on first ``run()``;
+    respawned after timeout, sticky CUDA error, or unexpected exit."""
+
+    def __init__(self, device: int | None = None) -> None:
+        self.device = device
+        self._process: mp.process.BaseProcess | None = None
+        self._parent_connection: Connection | None = None
+
+    def alive(self) -> bool:
+        return self._process is not None and self._process.is_alive()
+
+    def run(self, job: Callable[[], _T], timeout: float) -> _T:
+        """Execute ``job`` in the worker.
+
+        Raises ``BenchmarkTimeout`` if the job exceeds ``timeout`` seconds,
+        ``BenchmarkWorkerDied`` if the worker crashed, or whatever exception
+        the job raised. Sticky CUDA errors additionally kill the worker so
+        the next call respawns it.
+        """
+        if not self.alive():
+            self._start()
+        connection = self._parent_connection
+        assert connection is not None
+        try:
+            connection.send(job)
+        except (BrokenPipeError, OSError) as e:
+            self._kill()
+            raise BenchmarkWorkerDied("failed to send job to worker") from e
+
+        if not connection.poll(timeout):
+            self._kill()
+            raise BenchmarkTimeout(f"benchmark timeout after {timeout:.1f}s")
+
+        try:
+            result = connection.recv()
+        except EOFError as e:
+            self._kill()
+            raise BenchmarkWorkerDied("worker pipe closed before sending result") from e
+
+        if isinstance(result, BaseException):
+            if _UNRECOVERABLE_RUNTIME_ERROR_RE.search(str(result)):
+                self._kill()
+            raise result
+        return result  # type: ignore[return-value]
+
+    def shutdown(self) -> None:
+        process, connection = self._process, self._parent_connection
+        if process is not None and process.is_alive() and connection is not None:
+            with contextlib.suppress(Exception):
+                connection.send(None)
+                process.join(timeout=5)
+        self._kill()
+
+    def _start(self) -> None:
+        context = mp.get_context("spawn")
+        parent_connection, child_connection = context.Pipe(duplex=True)
+        process = context.Process(
+            target=_worker_loop,
+            args=(child_connection, self.device),
+            daemon=True,
+        )
+        process.start()
+        child_connection.close()
+        self._process = process
+        self._parent_connection = parent_connection
+
+    def _kill(self) -> None:
+        process, connection = self._process, self._parent_connection
+        if process is not None and process.is_alive():
+            with contextlib.suppress(Exception):
+                process.kill()
+                process.join(timeout=5)
+        if connection is not None:
+            with contextlib.suppress(Exception):
+                connection.close()
+        self._process = None
+        self._parent_connection = None

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -379,6 +379,16 @@ class _Settings:
             _env_get_int, "HELION_AUTOTUNE_COMPILE_TIMEOUT", 60
         )
     )
+    autotune_benchmark_subprocess: bool = dataclasses.field(
+        default_factory=functools.partial(
+            _env_get_bool, "HELION_AUTOTUNE_BENCHMARK_SUBPROCESS", False
+        )
+    )
+    autotune_benchmark_timeout: int = dataclasses.field(
+        default_factory=functools.partial(
+            _env_get_int, "HELION_AUTOTUNE_BENCHMARK_TIMEOUT", 30
+        )
+    )
     autotune_precompile: PrecompileMode = dataclasses.field(
         default_factory=functools.partial(
             _env_get_literal,
@@ -557,6 +567,8 @@ class Settings(_Settings):
             "/tmp/run.csv and /tmp/run.log with per-config metrics and debug logs."
         ),
         "autotune_compile_timeout": "Timeout for Triton compilation in seconds used for autotuning. Default is 60 seconds.",
+        "autotune_benchmark_subprocess": "Run the autotune benchmark phase in a long-lived spawn subprocess so a hung/slow kernel can be killed without losing autotune progress. Opt-in via HELION_AUTOTUNE_BENCHMARK_SUBPROCESS=1. Default disabled.",
+        "autotune_benchmark_timeout": "Per-config wall-clock timeout in seconds for the subprocess benchmark phase. Only applies when autotune_benchmark_subprocess is enabled. Default 30 seconds.",
         "autotune_precompile": "Autotuner precompile mode: 'fork', 'spawn', or falsy/None to disable. Defaults to 'fork' on non-Windows platforms.",
         "autotune_precompile_jobs": "Maximum concurrent Triton precompile processes, default to cpu count.",
         "autotune_random_seed": "Seed used for autotuner random number generation. Defaults to HELION_AUTOTUNE_RANDOM_SEED or a time-based seed.",

--- a/test/test_benchmark_worker.py
+++ b/test/test_benchmark_worker.py
@@ -1,0 +1,175 @@
+"""Tests for the subprocess benchmark path used to hang-protect autotune."""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+import os
+from pathlib import Path
+import random
+import signal
+import time
+from typing import TYPE_CHECKING
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from helion._testing import DEVICE
+from helion._testing import RefEagerTestDisabled
+from helion._testing import import_path
+from helion._testing import skipIfXPU
+from helion.autotuner.benchmark_provider import LocalBenchmarkProvider
+from helion.autotuner.benchmark_worker import BenchmarkTimeout
+from helion.autotuner.benchmark_worker import BenchmarkWorker
+from helion.autotuner.benchmark_worker import BenchmarkWorkerDied
+from helion.autotuner.random_search import RandomSearch
+
+if TYPE_CHECKING:
+    from helion.runtime.config import Config
+    from helion.runtime.kernel import CompiledConfig
+
+
+# Job callables: must be at module level so multiprocessing.spawn can
+# re-import them in the child.
+
+
+@dataclasses.dataclass
+class _Sleep:
+    seconds: float
+
+    def __call__(self) -> float:
+        time.sleep(self.seconds)
+        return self.seconds
+
+
+@dataclasses.dataclass
+class _RaiseRuntimeError:
+    message: str
+
+    def __call__(self) -> object:
+        raise RuntimeError(self.message)
+
+
+@dataclasses.dataclass
+class _Crash:
+    def __call__(self) -> object:
+        os.kill(os.getpid(), signal.SIGKILL)
+        return None
+
+
+@dataclasses.dataclass
+class _ReturnValue:
+    value: object
+
+    def __call__(self) -> object:
+        return self.value
+
+
+class TestBenchmarkWorkerFailureModes(unittest.TestCase):
+    def test_timeout_kills_worker(self) -> None:
+        worker = BenchmarkWorker()
+        try:
+            t0 = time.time()
+            with self.assertRaises(BenchmarkTimeout):
+                worker.run(_Sleep(60), timeout=0.5)
+            self.assertLess(time.time() - t0, 15.0)
+            self.assertFalse(worker.alive())
+            # Next call respawns.
+            self.assertEqual(worker.run(_ReturnValue(7), timeout=30.0), 7)
+        finally:
+            worker.shutdown()
+
+    def test_sticky_error_kills_worker(self) -> None:
+        # Errors matching _UNRECOVERABLE_RUNTIME_ERROR_RE force the worker
+        # to be killed so the next call spawns a fresh CUDA context.
+        worker = BenchmarkWorker()
+        try:
+            with self.assertRaises(RuntimeError) as ctx:
+                worker.run(_RaiseRuntimeError("illegal memory access"), timeout=30.0)
+            self.assertIn("illegal memory access", str(ctx.exception))
+            self.assertFalse(worker.alive())
+            self.assertEqual(worker.run(_ReturnValue(42), timeout=30.0), 42)
+        finally:
+            worker.shutdown()
+
+    def test_worker_crash_raises_died(self) -> None:
+        worker = BenchmarkWorker()
+        try:
+            with self.assertRaises(BenchmarkWorkerDied):
+                worker.run(_Crash(), timeout=30.0)
+            self.assertFalse(worker.alive())
+        finally:
+            worker.shutdown()
+
+
+class TestSubprocessBenchmarkIntegration(RefEagerTestDisabled, unittest.TestCase):
+    @skipIfXPU("matmul config space includes maxnreg, unsupported on XPU")
+    def test_autotune_with_subprocess_bench(self) -> None:
+        if not torch.cuda.is_available():
+            self.skipTest("requires CUDA")
+
+        examples_dir = Path(__file__).parent.parent / "examples"
+        matmul = import_path(examples_dir / "matmul.py").matmul
+
+        args = (
+            torch.randn([512, 512], device=DEVICE),
+            torch.randn([512, 512], device=DEVICE),
+        )
+        bound_kernel = matmul.bind(args)
+        bound_kernel.settings.autotune_benchmark_subprocess = True
+        bound_kernel.settings.autotune_benchmark_timeout = 60
+        bound_kernel.settings.autotune_precompile = None
+
+        random.seed(123)
+        RandomSearch(bound_kernel, args, 20).autotune()
+
+    @skipIfXPU("matmul config space includes maxnreg, unsupported on XPU")
+    def test_autotune_continues_when_subprocess_reports_inf(self) -> None:
+        # Patches _benchmark_function_subprocess to return inf for a
+        # fraction of configs, simulating BenchmarkTimeout / worker death;
+        # autotune must still pick a best config from the rest.
+        if not torch.cuda.is_available():
+            self.skipTest("requires CUDA")
+
+        original = LocalBenchmarkProvider._benchmark_function_subprocess
+        call_count = [0, 0]  # [total, simulated_failures]
+
+        def maybe_fail(
+            self: LocalBenchmarkProvider,
+            config: Config,
+            fn: CompiledConfig,
+        ) -> float | None:
+            call_count[0] += 1
+            if call_count[0] % 3 == 0:
+                call_count[1] += 1
+                self._autotune_metrics.num_compile_failures += 1
+                return math.inf
+            return original(self, config, fn)
+
+        examples_dir = Path(__file__).parent.parent / "examples"
+        matmul = import_path(examples_dir / "matmul.py").matmul
+
+        args = (
+            torch.randn([512, 512], device=DEVICE),
+            torch.randn([512, 512], device=DEVICE),
+        )
+        bound_kernel = matmul.bind(args)
+        bound_kernel.settings.autotune_benchmark_subprocess = True
+        bound_kernel.settings.autotune_benchmark_timeout = 60
+        bound_kernel.settings.autotune_precompile = None
+
+        random.seed(123)
+        with patch.object(
+            LocalBenchmarkProvider,
+            "_benchmark_function_subprocess",
+            maybe_fail,
+        ):
+            RandomSearch(bound_kernel, args, 20).autotune()
+
+        self.assertGreaterEqual(call_count[0], 6)
+        self.assertGreaterEqual(call_count[1], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Benchmarking can sometimes block forever, hanging CI until the 6 hour timeout. Recent CI runs:
    - https://github.com/pytorch/helion/actions/runs/24825340776/job/72659739888                                             
    - https://github.com/pytorch/helion/actions/runs/24880446409/job/72847236216                                             
                                                                                                                             
Run benchmark call in a long-lived spawn subprocess (BenchWorker).        
The parent SIGKILLs and respawns the worker on per-config run timeout, sticky CUDA errors, or unexpected exit. The config is marked inf and the search continues.                                                                
                                                                                                                             
Opt-in via `HELION_AUTOTUNE_BENCH_SUBPROCESS=1` (default off); 
only on in benchmark CI workflow for now. Timeout is set via `HELION_AUTOTUNE_BENCH_TIMEOUT`, defaults to 30s. Falls back to in-process for distributed kernels, mutated-arg kernels, and custom-do_bench backends.                                    