### PR TITLE
[Autotuner] Seed LFBO surrogate with stage-1 LLM benchmarks in hybrid search

### DIFF
--- a/helion/autotuner/llm_seeded_lfbo.py
+++ b/helion/autotuner/llm_seeded_lfbo.py
@@ -234,12 +234,27 @@ class LLMSeededSearch(BaseSearch):
         self,
         second_stage_search: BaseSearch,
         llm_seed_config: Config,
+        llm_search: LLMGuidedSearch | None = None,
     ) -> None:
-        """Pass the best LLM config into searches that expose the seed hook."""
+        """Pass the best LLM config into searches that expose the seed hook.
+
+        For LFBO stage 2, also seed the surrogate's training set so LFBO
+        learns from the LLM's exploration, not just the single best config.
+        """
         if not self._second_stage_supports_best_available_handoff:
             return
         seeded_search = cast("PopulationBasedSearch", second_stage_search)
         seeded_search.set_best_available_seed_configs([llm_seed_config])
+
+        from .surrogate_pattern_search import LFBOPatternSearch
+
+        if llm_search is not None and isinstance(seeded_search, LFBOPatternSearch):
+            results = llm_search._all_benchmark_results
+            seeded_search.seed_training_data(results)
+            self.log(
+                f"Seeded LFBO surrogate with {len(results)} (config, perf) pairs "
+                "from the LLM stage."
+            )
 
     @staticmethod
     def _finite_perf(search: BaseSearch | None) -> float | None:
@@ -269,6 +284,7 @@ class LLMSeededSearch(BaseSearch):
     def _run_second_stage(
         self,
         llm_seed_config: Config | None,
+        llm_search: LLMGuidedSearch | None = None,
     ) -> tuple[BaseSearch, Config, float]:
         """Run stage 2, optionally seeded from the stage-1 best config."""
         seeded = llm_seed_config is not None
@@ -282,7 +298,9 @@ class LLMSeededSearch(BaseSearch):
         )
         second_stage_search = self._make_second_stage_search(seeded=seeded)
         if llm_seed_config is not None:
-            self._inject_seed_into_second_stage(second_stage_search, llm_seed_config)
+            self._inject_seed_into_second_stage(
+                second_stage_search, llm_seed_config, llm_search
+            )
         second_stage_start = time.perf_counter()
         best_config = second_stage_search.autotune()
         second_stage_wall_time = time.perf_counter() - second_stage_start
@@ -348,7 +366,7 @@ class LLMSeededSearch(BaseSearch):
         llm_search, llm_seed_config, llm_wall_time = self._run_llm_seed_stage()
         # Stage 2: run the configured follow-up search, seeded when stage 1 found a config.
         second_stage_search, best_config, second_stage_wall_time = (
-            self._run_second_stage(llm_seed_config)
+            self._run_second_stage(llm_seed_config, llm_search)
         )
 
         self._finalize_stage_metrics(

--- a/helion/autotuner/surrogate_pattern_search.py
+++ b/helion/autotuner/surrogate_pattern_search.py
@@ -6,6 +6,7 @@ import random
 from typing import TYPE_CHECKING
 
 from .. import exc
+from .base_search import BenchmarkResult
 from .base_search import PopulationBasedSearch
 from .base_search import PopulationMember
 from .base_search import check_population_consistency
@@ -176,6 +177,27 @@ class LFBOPatternSearch(PatternSearch):
             "best_available_pad_random": profile.lfbo_pattern_search.best_available_pad_random,
             **PopulationBasedSearch.get_kwargs_from_profile(profile, settings),
         }
+
+    def seed_training_data(
+        self,
+        results: Sequence[BenchmarkResult],
+    ) -> None:
+        """Pre-populate the surrogate's training set with externally-benchmarked configs.
+
+        Useful when an outer loop (e.g. a hybrid LLM+LFBO search) has already
+        benchmarked configs and wants the LFBO surrogate to learn from them
+        rather than starting from scratch. Failed configs (perf=inf) are
+        kept since the surrogate's binary classifier learns from negatives too.
+        """
+        for result in results:
+            try:
+                flat_values = self.config_gen.flatten(result.config)
+                encoded = self.config_gen.encode_config(flat_values)
+            except Exception as e:
+                self.log.debug(f"seed_training_data: skipping config: {e}")
+                continue
+            self.train_x.append(encoded)
+            self.train_y.append(result.perf)
 
     def _fit_surrogate(self) -> None:
         train_x = np.array(self.train_x)


### PR DESCRIPTION
Discussed with @ethche on how the LLM could be used better with the LFBO search. In the "hybrid" search, previously I did 1 round of LLM prompt, benchmarked to find the single best config, then fed that to LFBO as the seed. Now, I feed all of LLM stage 1's benchmark results into LFBO's surrogate model, so LFBO's                                                        classifier learns from the LLM's exploration instead of from a single seed. I see significant improvements in end-to-end compile times with the same kernel perf:
<img width="1416" height="305" alt="image" src="https://github.com/user-attachments/assets/7eadc757-9648-4ea7-ac8b-1fb18b29355f" />

baseline is LFBO (ms = perf, s = end-to-end compile time), Hybrid base is the previous single seed method, Hybrid new is the current PR. Hybrid Base perf is LFBO_ms/Hybrid Base_ms, Hybrid New perf is LFBO_ms/Hybrid New_ms. 

Hybrid New is 5.7X faster in geomean compile time than LFBO, 1.8X faster than Hybrid Base. I'm using Opus 4.7 for both Hybrids, benchmarking on H100.