### PR TITLE
[Pallas] Add pl.multiple_of alignment hint to pl.ds() offsets

### DIFF
--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -290,7 +290,65 @@ def _ds_expr(
         from helion.language.memory_ops import _record_pad_info
 
         _record_pad_info(state, tensor, tensor_dim, block_id)
+
+        # Skip when tile_offset is set (e.g. offset + 64) — the shift
+        # means the full expression may not be a multiple of block_size.
+        if not tile_offset:
+            alignment = _loop_offset_alignment(block_id, state)
+            if alignment is not None:
+                # Workaround for JAX <= 0.10.0 where AssumeMultipleOp
+                # short-circuits divisibility analysis (fixed in
+                # jax-ml/jax@33c38f50b): only apply when alignment meets
+                # Mosaic's requirement, otherwise the hint could replace
+                # a stronger proof Mosaic already has.
+                from helion._compiler.backend import PallasBackend
+                from helion._compiler.compile_environment import CompileEnvironment
+
+                backend = CompileEnvironment.current().backend
+                assert isinstance(backend, PallasBackend)
+                dim_from_end = tensor.ndim - 1 - tensor_dim
+                bitwidth = tensor.dtype.itemsize * 8
+                required = backend._get_pallas_required_alignment(
+                    dim_from_end, tensor.ndim, bitwidth
+                )
+                if alignment % required == 0:
+                    # e.g. pl.ds(pl.multiple_of(offset_3, _BLOCK_SIZE_3), _BLOCK_SIZE_3)
+                    offset = f"pl.multiple_of({offset}, {block_size})"
+
     return f"pl.ds({offset}, {block_size})"
+
+
+def _loop_offset_alignment(
+    block_id: int,
+    state: CodegenState,
+) -> int | None:
+    """Return the proven alignment of a loop's offset for *block_id*, or ``None``.
+
+    A loop with step ``block_size`` produces offsets ``begin + i * block_size``,
+    which are multiples of ``block_size`` iff ``begin`` is.  Returns
+    ``block_size`` (int) when provable, ``None`` otherwise.
+    """
+    import sympy
+
+    from helion._compiler.compile_environment import CompileEnvironment
+
+    env = CompileEnvironment.current()
+    bs_value = env.block_sizes[block_id].from_config(state.device_function.config)
+    if not isinstance(bs_value, int):
+        return None
+
+    # Check that the loop begins at a multiple of block_size.
+    loops = state.codegen.active_device_loops.get(block_id)
+    if loops:
+        info = loops[-1].block_id_to_info.get(block_id)
+        if info is not None and info.begin_expr is not None:
+            begin = info.begin_expr
+            if not isinstance(begin, (int, sympy.Integer)):
+                return None  # symbolic begin — can't prove alignment
+            if int(begin) % bs_value != 0:
+                return None
+
+    return bs_value
 
 
 def vmem_name(state: CodegenState, name: str) -> str:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -640,6 +640,8 @@ class TestPallas(TestCase):
         code, result = code_and_output(pallas_bmm, (a, b))
         expected = torch.bmm(a.float(), b.float()).to(torch.bfloat16)
         torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+        # Block sizes >= 128 should get the pl.multiple_of alignment hint
+        self.assertIn("pl.multiple_of(", code)
 
     def test_bmm_fori_loop_non_divisible_k(self) -> None:
         """Test fori_loop bmm where BLOCK_K=256 doesn't evenly divide K=384."""
@@ -992,6 +994,9 @@ class TestPallas(TestCase):
         code, result = code_and_output(chunked_add, (x,), block_sizes=[128])
         expected = x + 1.0
         torch.testing.assert_close(result, expected)
+        # tile_k.index + offset uses TileIndexWithOffsetPattern — the
+        # pl.multiple_of hint should NOT be applied to offset expressions
+        self.assertNotIn("pl.multiple_of(", code)
 
     def test_mixed_scalar_and_slice_access(self) -> None:
         """Tensor accessed both as scalar and slice should not be placed in SMEM.
@@ -1361,6 +1366,8 @@ class TestPallas(TestCase):
         self.assertIn("jax.lax.fori_loop", code)
         self.assertNotIn("pltpu.make_async_copy", code)
         self.assertIn("pl.ds(", code)
+        # Block size 64 < 128 alignment — hint should NOT be applied
+        self.assertNotIn("pl.multiple_of(", code)
         torch.testing.assert_close(result, args[0] + args[1])
 
     def test_fori_loop_no_dma_multidim_unaligned(self) -> None:


### PR DESCRIPTION
## Summary
- Tells Mosaic the `pl.ds()` offset is aligned to `block_size` via `pl.multiple_of`, enabling compiler optimizations
- Only applied to plain loop offsets (no tile_offset), which are genuinely multiples of block_size by loop construction. Offsets with constant shifts (e.g. `offset + 64` from tile-index-with-offset patterns) are excluded
- Additionally guarded to only apply when `block_size` meets Mosaic's alignment requirement for the dimension (128 for last dim, 8 for second-to-last), working around a bug in JAX <= 0.10.0 where `AssumeMultipleOp` short-circuits divisibility analysis (fixed in jax-ml/jax@33c38f50b). Once JAX is updated past that fix, this guard can be removed

### Benchmark (TPU v7)

Using `tpu_sync(r, wait=True)` for proper device synchronization.

**longsum_manual** (`[32, 65536]`, block_sizes `[32768, 1]`, float32):

| | Median (ms) | Mean (ms) |
|---|---|---|
| Without hint | 0.254 | 0.281 |
| With hint | 0.181 | 0.204 |
| **Speedup** | **~29%** | |

**BMM** (`[16, 512, 768] x [16, 768, 1024]`, block_sizes `[16, 128, 128, 256]`, bfloat16):

| | Median (ms) | Mean (ms) |
|---|---|---|
| Without hint | 0.288 | 0.300 |
| With hint | 0.299 | 0.320 |
| **Speedup** | **~0% (noise)** | |

The hint helps memory-bound kernels (longsum ~29% faster) but not compute-bound kernels (BMM no change).