### PR TITLE
[Autotuner] Raise default min_improvement_delta to 0.003

### DIFF
--- a/helion/autotuner/pattern_search.py
+++ b/helion/autotuner/pattern_search.py
@@ -42,7 +42,7 @@ class PatternSearch(PopulationBasedSearch):
         initial_population: int = PATTERN_SEARCH_DEFAULTS.initial_population,
         copies: int = PATTERN_SEARCH_DEFAULTS.copies,
         max_generations: int = PATTERN_SEARCH_DEFAULTS.max_generations,
-        min_improvement_delta: float = 0.001,
+        min_improvement_delta: float = 0.003,
         initial_population_strategy: InitialPopulationStrategy | None = None,
         best_available_pad_random: bool = PATTERN_SEARCH_DEFAULTS.best_available_pad_random,
         num_neighbors_cap: int = -1,
@@ -92,6 +92,7 @@ class PatternSearch(PopulationBasedSearch):
     def get_kwargs_from_profile(
         cls, profile: AutotuneEffortProfile, settings: Settings
     ) -> dict[str, object]:
+        from ..runtime.settings import _env_get_float
         from ..runtime.settings import _env_get_int
         from ..runtime.settings import _get_initial_population_strategy
 
@@ -107,6 +108,9 @@ class PatternSearch(PopulationBasedSearch):
             "initial_population_strategy": strategy,
             "best_available_pad_random": profile.pattern_search.best_available_pad_random,
             "num_neighbors_cap": _env_get_int("HELION_CAP_AUTOTUNE_NUM_NEIGHBORS", -1),
+            "min_improvement_delta": _env_get_float(
+                "HELION_AUTOTUNE_MIN_IMPROVEMENT_DELTA", 0.003
+            ),
             **super().get_kwargs_from_profile(profile, settings),
         }
 

--- a/helion/autotuner/surrogate_pattern_search.py
+++ b/helion/autotuner/surrogate_pattern_search.py
@@ -110,7 +110,7 @@ class LFBOPatternSearch(PatternSearch):
         initial_population: int = PATTERN_SEARCH_DEFAULTS.initial_population,
         copies: int = PATTERN_SEARCH_DEFAULTS.copies,
         max_generations: int = PATTERN_SEARCH_DEFAULTS.max_generations,
-        min_improvement_delta: float = 0.001,
+        min_improvement_delta: float = 0.003,
         frac_selected: float = 0.10,
         num_neighbors: int = 300,
         radius: int = 2,
@@ -162,6 +162,7 @@ class LFBOPatternSearch(PatternSearch):
     def get_kwargs_from_profile(
         cls, profile: AutotuneEffortProfile, settings: Settings
     ) -> dict[str, object]:
+        from ..runtime.settings import _env_get_float
         from ..runtime.settings import _get_initial_population_strategy
 
         assert profile.lfbo_pattern_search is not None
@@ -175,6 +176,9 @@ class LFBOPatternSearch(PatternSearch):
             "max_generations": profile.lfbo_pattern_search.max_generations,
             "initial_population_strategy": strategy,
             "best_available_pad_random": profile.lfbo_pattern_search.best_available_pad_random,
+            "min_improvement_delta": _env_get_float(
+                "HELION_AUTOTUNE_MIN_IMPROVEMENT_DELTA", 0.003
+            ),
             **PopulationBasedSearch.get_kwargs_from_profile(profile, settings),
         }
 
@@ -704,7 +708,7 @@ class LFBOTreeSearch(LFBOPatternSearch):
         initial_population: int = PATTERN_SEARCH_DEFAULTS.initial_population,
         copies: int = PATTERN_SEARCH_DEFAULTS.copies,
         max_generations: int = PATTERN_SEARCH_DEFAULTS.max_generations,
-        min_improvement_delta: float = 0.001,
+        min_improvement_delta: float = 0.003,
         quantile: float = 0.1,
         patience: int = 1,
         similarity_penalty: float = 1.0,

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -105,6 +105,11 @@ def _env_get_optional_float(var_name: str) -> float | None:
         raise ValueError(f"{var_name} must be a float, got {value!r}") from err
 
 
+def _env_get_float(var_name: str, default: float) -> float:
+    result = _env_get_optional_float(var_name)
+    return default if result is None else result
+
+
 def _env_get_bool(var_name: str, default: bool) -> bool:
     value = os.environ.get(var_name)
     if value is None or (value := value.strip()) == "":


### PR DESCRIPTION
We've been seeing that autotuner typically converges in earlier rounds so we could exit earlier. Putting up a draft PR so I can benchmark on CI. Local testing shows that there's negligible cost to performance with shorter end-to-end compile times. 

Running autotuning 3 times locally on H100, looks like there is a 2% perf degradation for LFBO but not for hybrid. This is when min_improvement_delta as 0.003 and 0.005. Hybrid with 0.005 actually yieids very good results. 
<img width="1533" height="270" alt="image" src="https://github.com/user-attachments/assets/75635ecd-fca6-457d-930f-31cc611104fb" />

<img width="1574" height="609" alt="image" src="https://github.com/user-attachments/assets/fdc9e98c-7aeb-40f3-a112-dd99e7bb8c5e" />
