### PR TITLE
[Pallas] Fix multi-dim padding overwriting original tensor reference

### DIFF
--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -850,7 +850,7 @@ def _pallas_apply_ds_padding(
         pad_amount = (-a.shape[dim]) % block_size
         if pad_amount == 0:
             continue
-        if arg_idx in output_set:
+        if arg_idx in output_set and arg_idx not in orig_output_tensors:
             orig_output_tensors[arg_idx] = a
         # F.pad takes (last_dim_left, last_dim_right, ..., first_dim_left, first_dim_right).
         # To right-pad dimension `dim`, set index 2*(ndim-1-dim) + 1.

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1314,6 +1314,25 @@ class TestPallas(TestCase):
         self.assertGreaterEqual(code.count("jax.lax.fori_loop"), 2)
         torch.testing.assert_close(result, args[0] + args[1])
 
+    def test_default_loop_multidim_non_divisible(self) -> None:
+        """Default loop with 2D inner loop where both dims are non-divisible.
+
+        Regression test: when an output tensor is padded on multiple dims,
+        _pallas_apply_ds_padding must save the original tensor reference
+        only once (on the first dim), not overwrite it with the partially-
+        padded tensor on subsequent dims.
+        """
+        args = (
+            torch.randn(4, 70, 130, device=DEVICE, dtype=torch.float32),
+            torch.randn(4, 70, 130, device=DEVICE, dtype=torch.float32),
+        )
+        code, result = code_and_output(
+            pallas_add_3d,
+            args,
+            block_sizes=[1, 8, 128],
+        )
+        torch.testing.assert_close(result, args[0] + args[1])
+
     def test_fori_loop_multidim_partial_tile(self) -> None:
         """Test fori_loop with a 2D inner loop and a partial tail tile."""
         args = (


### PR DESCRIPTION
## Summary
When a tensor is padded on multiple dimensions, `_pallas_apply_ds_padding` overwrites `orig_output_tensors[arg_idx]` on each dim, saving the partially-padded tensor instead of the true original. This causes incorrect slice-back shapes.

Fix: only save the original on the first dim encountered (`arg_idx not in orig_output_tensors`).

Adds `test_default_loop_multidim_non_divisible` which uses `pallas_add_3d` with a 2D inner loop where both dims are non-divisible (70 % 8 ≠ 0, 130 % 128 ≠ 0). Without the fix, the output has shape `[4, 72, 130]` instead of `[4, 70, 130]`.