### PR TITLE
[Benchmarking] Disable cudagraph for layer_norm-bwd / rms_norm-bwd

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -181,6 +181,11 @@ KERNEL_MAPPINGS: dict[str, tuple[str, ...]] = {
         "rms_norm_tritonbench",
         {
             "num_inputs": 5,  # rms_norm-bwd has 6 inputs total but last input raises Triton OOM at default config: https://github.com/pytorch/helion/issues/711
+            # tritonbench's torch_compile_rms_norm recompiles during CUDA graph
+            # capture for backward, producing "capturing stream has unjoined work"
+            # which poisons the CUDA context and OOMs other impls. Same workaround
+            # as grouped_gemm (PR #1662).
+            "remove_flags": ["--cudagraph"],
         },
     ),
     "sum": ("tritonbench.operators.sum.operator", "examples.sum", "sum_tritonbench"),
@@ -242,6 +247,11 @@ KERNEL_MAPPINGS: dict[str, tuple[str, ...]] = {
         "layer_norm_tritonbench",
         {
             "num_inputs": 10,  # layer_norm-bwd takes long time on Benchmark CI, so use fewer inputs instead.
+            # tritonbench's torch_compile_layer_norm recompiles during CUDA graph
+            # capture for backward, producing "capturing stream has unjoined work"
+            # which poisons the CUDA context and OOMs other impls. Same workaround
+            # as grouped_gemm (PR #1662).
+            "remove_flags": ["--cudagraph"],
         },
     ),
     "jagged_softmax": (


### PR DESCRIPTION
[Benchmarking] Disable cudagraph for layer_norm-bwd / rms_norm-bwd

tritonbench's torch_compile_*_norm recompiles Triton kernels during CUDA
graph capture for the backward pass. The recompile triggers "capturing
stream has unjoined work", which poisons the GPU's CUDA context for the
remainder of the bench harness and causes liger and Helion to fail with
downstream CUDA OOM.

Same workaround that PR #1662 applied to grouped_gemm; extending it to
the two backward kernels currently surfacing the same error in nightly
B200/H100/MI350X runs.

Trade-off: absolute Helion latencies for these kernels read ~10-25%
higher because per-launch CPU overhead is no longer amortized into a
graph. Speedup ratios vs the torch baseline stay close to truth since
all impls are measured the same way.