### PR TITLE
[Autotuner] Long-lived worker pool for parallel precompile

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -39,9 +39,9 @@ jobs:
 
     env:
       HELION_AUTOTUNE_LOG_LEVEL: INFO
-      # Run autotune benchmarks in a subprocess so deadlocked kernels are
-      # SIGKILL'd at the per-config timeout instead of hanging the job.
-      HELION_AUTOTUNE_BENCHMARK_SUBPROCESS: "1"
+      # Perf CI measures the default fork precompile path unless a dispatch
+      # explicitly overrides it via env-vars, e.g. HELION_AUTOTUNE_PRECOMPILE=pool.
+      HELION_AUTOTUNE_PRECOMPILE: "fork"
 
     container:
       image: ${{ inputs.image }}

--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -145,8 +145,9 @@ def my_kernel(x: torch.Tensor) -> torch.Tensor:
    Select the autotuner precompile mode, which adds parallelism and
    checks for errors/timeouts. ``"fork"`` (default) is faster but does
    not include the error check run, ``"spawn"`` runs kernel warm-up in a
-   fresh process including running to check for errors, or None to
-   disables precompile checks altogether. Controlled by
+   fresh process including running to check for errors, ``"pool"`` uses
+   long-lived worker processes and implies subprocess benchmarking, or
+   None disables precompile checks altogether. Controlled by
    ``HELION_AUTOTUNE_PRECOMPILE``.
 
 .. autoattribute:: Settings.autotune_random_seed
@@ -313,8 +314,9 @@ Built-in values for ``HELION_AUTOTUNER`` include ``"LFBOTreeSearch"`` (default),
 | ``HELION_AUTOTUNE_COMPILE_TIMEOUT`` | ``autotune_compile_timeout`` | Maximum seconds to wait for Triton compilation during autotuning. |
 | ``HELION_AUTOTUNE_LOG_LEVEL`` | ``autotune_log_level`` | Adjust logging verbosity; accepts names like ``INFO`` or numeric levels. |
 | ``HELION_AUTOTUNE_LOG`` | ``autotune_log`` | Base filename for per-config CSV telemetry and mirrored autotune logs. |
-| ``HELION_AUTOTUNE_PRECOMPILE`` | ``autotune_precompile`` | Select the autotuner precompile mode (``"fork"`` (default), ``"spawn"``, or disable when empty). |
+| ``HELION_AUTOTUNE_PRECOMPILE`` | ``autotune_precompile`` | Select the autotuner precompile mode (``"fork"`` (default), ``"spawn"``, ``"pool"``, or disable when empty). |
 | ``HELION_AUTOTUNE_PRECOMPILE_JOBS`` | ``autotune_precompile_jobs`` | Cap the number of concurrent Triton precompile subprocesses. |
+| ``HELION_AUTOTUNE_PRECOMPILE_WORKERS_CAP`` | ``autotune_precompile_workers_cap`` | Cap the auto-decided worker-pool size. Default is ``32``. |
 | ``HELION_AUTOTUNE_RANDOM_SEED`` | ``autotune_random_seed`` | Seed used for randomized autotuning searches. |
 | ``HELION_AUTOTUNE_MAX_GENERATIONS`` | ``autotune_max_generations`` | Upper bound on generations for Pattern Search and Differential Evolution. |
 | ``HELION_AUTOTUNE_BUDGET_SECONDS`` | ``autotune_budget_seconds`` | Wall-clock budget for an autotune run. |

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -628,6 +628,7 @@ class PopulationBasedSearch(BaseSearch):
         super().__init__(kernel, args)
         self.finishing_rounds = finishing_rounds
         self.population: list[PopulationMember] = []
+        self._pool_final_rebenchmark_archive: dict[Config, PopulationMember] = {}
         self._best_available_seed_configs: list[Config] = []
         self.config_gen: ConfigGeneration = self.config_spec.create_config_generation(
             overrides=self.settings.autotune_config_overrides or None,
@@ -668,6 +669,134 @@ class PopulationBasedSearch(BaseSearch):
         """Replace the current best member in the population."""
         idx = min(range(len(self.population)), key=lambda i: self.population[i].perf)
         self.population[idx] = value
+
+    @staticmethod
+    def _first_finite_perf(member: PopulationMember) -> float:
+        for perf in member.perfs:
+            if math.isfinite(perf):
+                return perf
+        return inf
+
+    @staticmethod
+    def _median3(a: float, b: float, c: float) -> float:
+        return sorted((a, b, c))[1]
+
+    @staticmethod
+    def _pool_suspicious_rebenchmark_ratio() -> float:
+        value = os.getenv("HELION_AUTOTUNE_POOL_SUSPICIOUS_REBENCHMARK_RATIO")
+        if value is None or value.strip() == "":
+            return 0.85
+        return float(value)
+
+    @staticmethod
+    def _pool_final_rebenchmark_top_k() -> int:
+        value = os.getenv("HELION_AUTOTUNE_POOL_FINAL_REBENCHMARK_TOP_K")
+        if value is None or value.strip() == "":
+            return 8
+        return int(value)
+
+    def _pool_final_rebenchmark_archive_size(self) -> int:
+        top_k = self._pool_final_rebenchmark_top_k()
+        value = os.getenv("HELION_AUTOTUNE_POOL_FINAL_REBENCHMARK_ARCHIVE_SIZE")
+        if value is None or value.strip() == "":
+            return max(64, top_k * 4)
+        return max(top_k, int(value))
+
+    def _record_pool_final_rebenchmark_candidates(
+        self,
+        members: Sequence[PopulationMember],
+    ) -> None:
+        if self.settings.autotune_precompile != "pool":
+            return
+        archive_size = self._pool_final_rebenchmark_archive_size()
+        if archive_size <= 0:
+            return
+        for member in members:
+            raw_perf = self._first_finite_perf(member)
+            if not math.isfinite(raw_perf):
+                continue
+            prior = self._pool_final_rebenchmark_archive.get(member.config)
+            if prior is None or raw_perf < self._first_finite_perf(prior):
+                self._pool_final_rebenchmark_archive[member.config] = member
+        if len(self._pool_final_rebenchmark_archive) <= archive_size:
+            return
+        keep = sorted(
+            self._pool_final_rebenchmark_archive.values(),
+            key=self._first_finite_perf,
+        )[:archive_size]
+        self._pool_final_rebenchmark_archive = {
+            member.config: member for member in keep
+        }
+
+    def _confirm_suspicious_pool_rebenchmarks(
+        self,
+        members: list[PopulationMember],
+        timings: list[float],
+        *,
+        desc: str,
+    ) -> list[float]:
+        if self.settings.autotune_precompile != "pool":
+            return timings
+        ratio = self._pool_suspicious_rebenchmark_ratio()
+        if ratio <= 0:
+            return timings
+
+        suspicious: list[int] = []
+        for i, (member, timing) in enumerate(zip(members, timings, strict=True)):
+            raw_perf = self._first_finite_perf(member)
+            if not math.isfinite(raw_perf) or not math.isfinite(timing):
+                continue
+            if timing < ratio * raw_perf:
+                suspicious.append(i)
+        if not suspicious:
+            return timings
+
+        confirm_timings = self.benchmark_provider.confirm_rebenchmark(
+            [members[i].fn for i in suspicious],
+            desc=f"{desc}: confirming suspicious timings",
+        )
+        if confirm_timings is None:
+            return timings
+
+        timings = [*timings]
+        confirmed = 0
+        for i, confirm_timing in zip(suspicious, confirm_timings, strict=True):
+            raw_perf = self._first_finite_perf(members[i])
+            if math.isfinite(confirm_timing):
+                timings[i] = self._median3(raw_perf, timings[i], confirm_timing)
+                confirmed += 1
+            else:
+                timings[i] = raw_perf
+        self.log.debug(
+            f"{desc}: confirmed {confirmed}/{len(suspicious)} suspicious pool rebenchmark timing(s)"
+        )
+        return timings
+
+    def final_rebenchmark_top_k(self, fallback: PopulationMember) -> PopulationMember:
+        """Final pool-only verification over the best archived raw candidates."""
+        if self.settings.autotune_precompile != "pool":
+            return fallback
+        top_k = self._pool_final_rebenchmark_top_k()
+        if top_k <= 0:
+            return fallback
+
+        candidates_by_config = dict(self._pool_final_rebenchmark_archive)
+        candidates_by_config[fallback.config] = fallback
+        candidates = sorted(
+            candidates_by_config.values(),
+            key=lambda member: (self._first_finite_perf(member), member.perf),
+        )[:top_k]
+        if len(candidates) < 2:
+            return fallback
+
+        self.rebenchmark(
+            candidates, desc=f"Final pool verification top-{len(candidates)}"
+        )
+        best = min(candidates, key=performance)
+        self.log.debug(
+            f"Final pool verification selected {best.config!r} at {best.perf:.6f}ms"
+        )
+        return best
 
     def benchmark_flat(self, flat_values: FlatConfig) -> PopulationMember:
         """
@@ -838,6 +967,7 @@ class PopulationBasedSearch(BaseSearch):
             member.fn = result.fn
             member.status = result.status
             member.compile_time = result.compile_time
+        self._record_pool_final_rebenchmark_candidates(members)
         return members
 
     def compare(self, a: PopulationMember, b: PopulationMember) -> int:
@@ -892,29 +1022,45 @@ class PopulationBasedSearch(BaseSearch):
         repeat = min(1000, max(3, base_repeat))
         if (capstr := os.getenv("HELION_CAP_REBENCHMARK_REPEAT")) is not None:
             repeat = min(repeat, int(capstr))
-        if len(self.benchmark_provider.mutated_arg_indices) > 0:
-            bench_args = _clone_args(
-                self.args,
-                self.kernel.env.process_group_name,
-                idx_to_clone=self.benchmark_provider.mutated_arg_indices,
-            )
-        else:
-            bench_args = self.args
-        iterator = [functools.partial(m.fn, *bench_args) for m in members]
-        _backend = getattr(getattr(self, "config_spec", None), "backend", None)
-        _ib = (
-            _backend.get_interleaved_bench() if _backend is not None else None
-        ) or interleaved_bench
-        bench_fn: Callable[..., list[float]] = (
-            self.settings.autotune_benchmark_fn or _ib
+        provider_timings = self.benchmark_provider.rebenchmark(
+            [m.fn for m in members],
+            repeat=repeat,
+            desc=desc,
         )
-        if self.settings.autotune_progress_bar:
-            new_timings = bench_fn(iterator, repeat=repeat, desc=desc)
+        if provider_timings is None:
+            if len(self.benchmark_provider.mutated_arg_indices) > 0:
+                bench_args = _clone_args(
+                    self.args,
+                    self.kernel.env.process_group_name,
+                    idx_to_clone=self.benchmark_provider.mutated_arg_indices,
+                )
+            else:
+                bench_args = self.args
+            iterator = [functools.partial(m.fn, *bench_args) for m in members]
+            _backend = getattr(getattr(self, "config_spec", None), "backend", None)
+            _ib = (
+                _backend.get_interleaved_bench() if _backend is not None else None
+            ) or interleaved_bench
+            bench_fn: Callable[..., list[float]] = (
+                self.settings.autotune_benchmark_fn or _ib
+            )
+            if self.settings.autotune_progress_bar:
+                new_timings = bench_fn(iterator, repeat=repeat, desc=desc)
+            else:
+                new_timings = bench_fn(iterator, repeat=repeat)
+        elif not provider_timings:
+            return
         else:
-            new_timings = bench_fn(iterator, repeat=repeat)
+            new_timings = provider_timings
         new_timings = sync_object(
             new_timings, process_group_name=self.kernel.env.process_group_name
         )
+        if provider_timings is not None:
+            new_timings = self._confirm_suspicious_pool_rebenchmarks(
+                members,
+                list(new_timings),
+                desc=desc,
+            )
         for m, t in zip(members, new_timings, strict=True):
             m.perfs.append(t)
             if t < self.best_perf_so_far:

--- a/helion/autotuner/benchmark_job.py
+++ b/helion/autotuner/benchmark_job.py
@@ -1,27 +1,89 @@
-"""Picklable benchmark job executed inside a ``BenchmarkWorker``."""
+"""Picklable benchmark jobs executed inside a ``BenchmarkWorker``."""
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 import functools
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import cast
 
 import torch
 
 from .benchmarking import do_bench
+from .benchmarking import interleaved_bench
 from .precompile_future import _load_compiled_fn
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from collections.abc import Sequence
 
     from .precompile_future import SerializedCompiledFunction
 
 
-@functools.cache
+@functools.lru_cache(maxsize=2)
 def _load_args(path: str) -> Sequence[object]:
-    # Cached so re-spawning configs don't re-read the same args off disk.
-    return cast("Sequence[object]", torch.load(path))
+    """Load Helion-created benchmark args in a worker process.
+
+    The cache is intentionally tiny: process-level pools see multiple shapes,
+    but each worker should only retain the latest args. ``weights_only=False``
+    is required because kernel args can include callables such as epilogues.
+    """
+    return cast("Sequence[object]", torch.load(path, weights_only=False))
+
+
+@dataclasses.dataclass
+class PrecompileJob:
+    """Compile-only precompile in a worker. Runs host-side helion code with
+    an extract_launcher that raises before any kernel launch, then triggers
+    Triton's compile (CPU + ptxas, no kernel execution). The binary lands
+    in Triton's on-disk cache for the benchmark phase to reuse.
+
+    Mirrors fork-mode children, but inside a long-lived spawn worker so the
+    parent never touches CUDA during prep."""
+
+    fn_spec: SerializedCompiledFunction
+    args_path: str
+
+    def __call__(self) -> bool:
+        from ..runtime.precompile_shim import already_compiled
+        from ..runtime.precompile_shim import already_compiled_fail
+        from ..runtime.precompile_shim import make_precompiler
+        from .precompile_future import _ExtractedLaunchArgs
+
+        fn = _load_compiled_fn(self.fn_spec)
+        args = _load_args(self.args_path)
+
+        captured: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
+
+        def extract_launcher(
+            triton_kernel: object,
+            grid: tuple[int, ...],
+            *launch_args: object,
+            **launch_kwargs: object,
+        ) -> object:
+            captured.append((triton_kernel, launch_args, launch_kwargs))
+            raise _ExtractedLaunchArgs(triton_kernel, grid, launch_args, launch_kwargs)
+
+        with contextlib.suppress(_ExtractedLaunchArgs):
+            fn(*args, _launcher=extract_launcher)  # pyrefly: ignore[bad-argument-type]
+        if not captured:
+            # No kernel launch in host code -> nothing to compile.
+            return True
+
+        triton_fn, launch_args, launch_kwargs = captured[0]
+        precompiler = cast(
+            "Callable[..., bool]",
+            make_precompiler(cast("Any", triton_fn), None, None)(
+                *launch_args, **launch_kwargs
+            ),
+        )
+        if precompiler is already_compiled:
+            return True
+        if precompiler is already_compiled_fail:
+            return False
+        return precompiler(in_child_process=False)
 
 
 @dataclasses.dataclass
@@ -44,3 +106,20 @@ class BenchmarkJob:
                 rep=self.rep,
             ),
         )
+
+
+@dataclasses.dataclass
+class RebenchmarkJob:
+    """Run interleaved rebenchmarking in the same isolated worker path."""
+
+    fn_specs: list[SerializedCompiledFunction]
+    args_path: str
+    repeat: int
+
+    def __call__(self) -> list[float]:
+        args = _load_args(self.args_path)
+        fns: list[Callable[[], object]] = [
+            functools.partial(_load_compiled_fn(fn_spec), *args)
+            for fn_spec in self.fn_specs
+        ]
+        return interleaved_bench(fns, repeat=self.repeat)

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -16,6 +16,7 @@ from typing import Any
 from typing import Literal
 from typing import NamedTuple
 from typing import NoReturn
+from typing import TypeVar
 from typing import cast
 
 import torch
@@ -29,8 +30,12 @@ from ..runtime.precompile_shim import already_compiled
 from ..runtime.precompile_shim import already_compiled_fail
 from ..runtime.precompile_shim import make_precompiler
 from .benchmark_job import BenchmarkJob
+from .benchmark_job import PrecompileJob
+from .benchmark_job import RebenchmarkJob
 from .benchmark_worker import BenchmarkSubprocessError
 from .benchmark_worker import BenchmarkWorker
+from .benchmark_worker import BenchmarkWorkerPool
+from .benchmark_worker import get_or_create_pool
 from .benchmarking import do_bench
 from .benchmarking import synchronize_device
 from .logger import SUPPRESSED_TRITON_CODE_MSG
@@ -65,6 +70,7 @@ if TYPE_CHECKING:
     from .base_search import _AutotunableKernel
     from .logger import AutotuningLogger
     from .metrics import AutotuneMetrics
+    from .precompile_future import SerializedCompiledFunction
 
 
 _FP8_DTYPES = {
@@ -74,6 +80,8 @@ _FP8_DTYPES = {
     torch.float8_e5m2fnuz,
     torch.float8_e8m0fnu,
 }
+
+_T = TypeVar("_T")
 
 
 def _assert_close(actual: object, expected: object, atol: float, rtol: float) -> None:
@@ -301,6 +309,36 @@ class BenchmarkProvider(abc.ABC):
         """
         ...
 
+    def rebenchmark(
+        self,
+        fns: list[Callable[..., object]],
+        *,
+        repeat: int,
+        desc: str = "Rebenchmarking",
+    ) -> list[float] | None:
+        """Optionally rebenchmark compiled callables via the provider.
+
+        Returning ``None`` means the provider does not support the requested
+        rebenchmark shape and the caller should use its default path.
+        Returning a list gives one timing per callable; isolated failures should
+        be represented as ``inf`` timings.
+        """
+        return None
+
+    def confirm_rebenchmark(
+        self,
+        fns: list[Callable[..., object]],
+        *,
+        desc: str = "Confirming rebenchmark",
+    ) -> list[float] | None:
+        """Optionally re-time suspicious rebenchmark results via the provider.
+
+        Returning ``None`` means the provider does not support this confirmation
+        path. Returning a list gives one timing per callable; isolated failures
+        should be represented as ``inf`` timings.
+        """
+        return None
+
     @abc.abstractmethod
     def setup(self) -> None:
         """Prepare resources needed before benchmarking begins (e.g. tmpdir)."""
@@ -339,6 +377,9 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         self._precompile_args_path: str | None = None
         self._precompile_result_counter: count[int] = count()
         self._benchmark_worker: BenchmarkWorker | None = None
+        self._worker_pool: BenchmarkWorkerPool | None = None
+        self._serialized_fn_specs: dict[int, SerializedCompiledFunction | None] = {}
+        self._worker_precompile_worker_by_fn: dict[int, int] = {}
 
         # TODO(hinriksnaer): baseline computation is expensive (compiles and runs
         # the kernel). Currently safe because the provider is only constructed
@@ -541,13 +582,15 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         )
 
     def setup(self) -> None:
-        """Prepare precompile tmpdir and args for spawn mode."""
+        """Prepare precompile tmpdir and args.
+
+        Worker processes are started from ``_worker_pool_precompile`` once the
+        batch size is known. That keeps ``PR_SET_PDEATHSIG`` anchored to the
+        main thread without spawning workers that cannot receive jobs.
+        """
         if self._precompile_tmpdir is None:
             self._precompile_tmpdir = tempfile.TemporaryDirectory()
-        if (
-            self.settings.autotune_precompile == "spawn"
-            or self._subprocess_benchmark_enabled()
-        ):
+        if self._needs_worker_args_file():
             args_path = os.path.join(self._precompile_tmpdir.name, "args.pt")
             torch.save(self.args, args_path)
             self._precompile_args_path = args_path
@@ -562,28 +605,125 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         )
 
     def cleanup(self) -> None:
-        """Release precompile tmpdir and related resources."""
+        """Release per-autotune resources. The process-level worker pool is
+        intentionally left alive so subsequent autotunes (e.g. iterating
+        input shapes within tritonbench) reuse the same workers."""
         if self._benchmark_worker is not None:
             self._benchmark_worker.shutdown()
             self._benchmark_worker = None
+        self._worker_pool = None  # release local handle; pool itself stays up
+        self._serialized_fn_specs.clear()
+        self._worker_precompile_worker_by_fn.clear()
         if self._precompile_tmpdir is not None:
             self._precompile_tmpdir.cleanup()
             self._precompile_tmpdir = None
         self._precompile_args_path = None
         self._precompile_result_counter = count()
 
-    def _subprocess_benchmark_enabled(self) -> bool:
-        """Subprocess benchmark path is opt-in and skipped for distributed /
-        mutated-arg kernels where the worker's simple job shape doesn't fit."""
-        if not self.settings.autotune_benchmark_subprocess:
-            return False
+    def _needs_worker_args_file(self) -> bool:
+        return (
+            self.settings.autotune_precompile in {"spawn", "pool"}
+            or self._subprocess_benchmark_enabled()
+        )
+
+    def _subprocess_benchmark_requested(self) -> bool:
+        return (
+            self.settings.autotune_benchmark_subprocess
+            or self.settings.autotune_precompile == "pool"
+        )
+
+    def _subprocess_benchmark_unsupported_reason(self) -> str | None:
         if dist.is_initialized():
-            return False
-        if len(self.mutated_arg_indices) > 0:
-            return False
-        # Custom do_bench implementations are not shipped to the worker.
-        _backend = getattr(self.config_spec, "backend", None)
-        return not (_backend is not None and _backend.get_do_bench() is not None)
+            return "distributed autotune"
+        if self.mutated_arg_indices:
+            return "mutated-argument kernels"
+        if self.config_spec.backend is not None:
+            if self.config_spec.backend.get_do_bench() is not None:
+                return "custom do_bench backends"
+        return None
+
+    def _subprocess_benchmark_enabled(self) -> bool:
+        """Subprocess benchmarking is opt-in, except explicit pool mode.
+
+        Pool mode always benchmarks in the same worker that precompiled the
+        config. Unsupported requests return ``False`` so explicit pool mode can
+        fail early with a specific reason.
+        """
+        return (
+            self._subprocess_benchmark_requested()
+            and self._subprocess_benchmark_unsupported_reason() is None
+        )
+
+    def _pool_mode_unavailable_reason(self) -> str | None:
+        reason = self._subprocess_benchmark_unsupported_reason()
+        if reason is not None:
+            return f"autotune_precompile='pool' does not support {reason}"
+        if self.settings.autotune_precompile_workers < 0:
+            return (
+                "autotune_precompile='pool' is disabled by "
+                "autotune_precompile_workers < 0"
+            )
+        if self._precompile_args_path is None:
+            return "autotune_precompile='pool' requires serialized autotune args"
+        if self._pool_size() < 1:
+            return "autotune_precompile='pool' requires at least one worker"
+        return None
+
+    def _pool_size(self) -> int:
+        """Resolve the effective pool size. ``autotune_precompile_workers > 0``
+        is honored verbatim. Auto-decide starts from ``autotune_precompile_jobs``
+        (or CPU count), then applies the optional worker cap and memory cap.
+        ``cpu_cap`` is ``cpu_count`` divided by ``PYTEST_XDIST_WORKER_COUNT``
+        when running under xdist."""
+        explicit = self.settings.autotune_precompile_workers
+        if explicit > 0:
+            return explicit
+        cpu_cap = self._jobs
+        xdist_count = int(os.environ.get("PYTEST_XDIST_WORKER_COUNT", "1"))
+        if xdist_count > 1:
+            cpu_cap = max(1, cpu_cap // xdist_count)
+        workers_cap = self.settings.autotune_precompile_workers_cap
+        if workers_cap > 0:
+            cpu_cap = min(cpu_cap, workers_cap)
+        device = self.kernel.env.device
+        if device.type != "cuda":
+            return cpu_cap
+        args_bytes = _estimate_tree_bytes(self.args)
+        # Each worker keeps one CUDA copy of args plus ~1 GiB of Triton
+        # compile scratch. The args cache is bounded in the worker process.
+        per_worker_bytes = args_bytes + 1 * 1024**3
+        if per_worker_bytes <= 0:
+            return cpu_cap
+        available_memory, _ = torch.cuda.mem_get_info(device)
+        memory_cap = max(1, int(available_memory * 0.9) // per_worker_bytes)
+        return min(cpu_cap, memory_cap)
+
+    def _ensure_worker_pool(self) -> BenchmarkWorkerPool:
+        if self._worker_pool is None:
+            # Process-level pool: spawn cost amortized across all autotune
+            # calls in this process, not paid per input shape.
+            self._worker_pool = get_or_create_pool(self._pool_size())
+        return self._worker_pool
+
+    def _serialize_fn_for_worker(
+        self, fn: CompiledConfig
+    ) -> SerializedCompiledFunction | None:
+        key = id(fn)
+        if key not in self._serialized_fn_specs:
+            try:
+                self._serialized_fn_specs[key] = _serialize_compiled_fn(fn)
+            except RuntimeError:
+                self._serialized_fn_specs[key] = None
+        return self._serialized_fn_specs[key]
+
+    def _run_subprocess_job(
+        self, job: Callable[[], _T], timeout: float, *, worker_index: int = 0
+    ) -> _T:
+        if self._worker_pool is not None:
+            return self._worker_pool.run_on(worker_index, job, timeout=timeout)
+        if self._benchmark_worker is None:
+            self._benchmark_worker = BenchmarkWorker(device=None)
+        return self._benchmark_worker.run(job, timeout=timeout)
 
     def _validate_against_baseline(
         self, config: Config, output: object, args: Sequence[object]
@@ -629,8 +769,15 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         if not self.settings.autotune_precompile:
             return PrecompileFuture.skip(ctx, config, True)
         mode = self.settings.autotune_precompile
+        if mode == "pool":
+            raise exc.InvalidAPIUsage(
+                "autotune_precompile='pool' is handled by the worker pool and "
+                "should not create per-config precompile futures"
+            )
         if mode not in {"fork", "spawn"}:
-            raise exc.InvalidAPIUsage("autotune_precompile must be 'fork' or 'spawn'")
+            raise exc.InvalidAPIUsage(
+                "autotune_precompile must be 'fork', 'spawn', or 'pool'"
+            )
         if len(self.mutated_arg_indices) > 0:
             args = _clone_args(
                 self.args,
@@ -676,7 +823,19 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         configs = [all_configs[i] for i in valid_indices]
 
         # Precompile phase
-        if self.settings.autotune_precompile:
+        precompile_status: list[Literal["ok", "error", "timeout"]] = []
+        compile_times: list[float | None] = [None] * len(configs)
+        if self.settings.autotune_precompile == "pool":
+            if (reason := self._pool_mode_unavailable_reason()) is not None:
+                raise exc.InvalidAPIUsage(reason)
+            precompile_desc = (
+                f"{desc} precompiling" if self.settings.autotune_progress_bar else None
+            )
+            is_workings, precompile_status, compile_times = (
+                self._worker_pool_precompile(configs, fns, precompile_desc)
+            )
+            futures = None
+        elif self.settings.autotune_precompile:
             futures = list(
                 starmap(
                     self._create_precompile_future,
@@ -687,7 +846,6 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                 f"{desc} precompiling" if self.settings.autotune_progress_bar else None
             )
             is_workings = PrecompileFuture.wait_for_all(futures, desc=precompile_desc)
-            precompile_status: list[Literal["ok", "error", "timeout"]] = []
             for future, ok in zip(futures, is_workings, strict=True):
                 reason = future.failure_reason
                 if ok:
@@ -697,6 +855,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                 else:
                     precompile_status.append("error")
         else:
+            futures = None
             is_workings = [True] * len(configs)
             precompile_status = ["ok"] * len(configs)
 
@@ -725,7 +884,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                     else None
                 )
             else:
-                compile_time = None
+                compile_time = compile_times[index]
             status: Literal[
                 "ok", "error", "timeout", "peer_compilation_fail", "filtered"
             ]
@@ -954,6 +1113,83 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             self._autotune_metrics.num_compile_failures += 1
             return inf
 
+    def _worker_pool_precompile(
+        self,
+        configs: list[Config],
+        fns: list[CompiledConfig],
+        desc: str | None,
+    ) -> tuple[
+        list[bool],
+        list[Literal["ok", "error", "timeout"]],
+        list[float | None],
+    ]:
+        """Compile each config in the long-lived worker pool. Returns
+        ``(is_workings, statuses, compile_times)`` aligned with ``configs``."""
+        assert self._precompile_args_path is not None
+        args_path = self._precompile_args_path
+        timeout = float(self.settings.autotune_compile_timeout)
+
+        # Build PrecompileJobs; serialization failures count as compile failures.
+        jobs: list[PrecompileJob | None] = []
+        for fn in fns:
+            fn_spec = self._serialize_fn_for_worker(fn)
+            if fn_spec is not None:
+                jobs.append(
+                    PrecompileJob(
+                        fn_spec=fn_spec,
+                        args_path=args_path,
+                    )
+                )
+            else:
+                jobs.append(None)
+
+        live_idxs = [i for i, j in enumerate(jobs) if j is not None]
+        live_jobs = cast("list[Callable[[], object]]", [jobs[i] for i in live_idxs])
+        pool = self._ensure_worker_pool()
+        # Spawn from the main thread so PR_SET_PDEATHSIG anchors here, but
+        # only start workers that can receive work in this batch.
+        pool.start_all(limit=len(live_jobs))
+        live_results = pool.map_jobs(live_jobs, timeout=timeout)
+
+        is_workings = [False] * len(configs)
+        statuses: list[Literal["ok", "error", "timeout"]] = ["error"] * len(configs)
+        compile_times: list[float | None] = [None] * len(configs)
+        for idx, job in enumerate(jobs):
+            if job is None:
+                self.log.debug(
+                    f"Precompile worker could not serialize {configs[idx]!r}"
+                )
+                self._autotune_metrics.num_compile_failures += 1
+        for idx, result in zip(live_idxs, live_results, strict=True):
+            compile_times[idx] = result.elapsed
+            job_result = result.result
+            if isinstance(job_result, BaseException):
+                statuses[idx] = (
+                    "timeout"
+                    if isinstance(job_result, BenchmarkSubprocessError)
+                    and "timeout" in str(job_result).lower()
+                    else "error"
+                )
+                self.log.debug(
+                    f"Precompile worker failed for {configs[idx]!r}: "
+                    f"{type(job_result).__name__}: {job_result}"
+                )
+                self._autotune_metrics.num_compile_failures += 1
+            elif job_result is True:
+                is_workings[idx] = True
+                statuses[idx] = "ok"
+                self._worker_precompile_worker_by_fn[id(fns[idx])] = result.worker_index
+            else:
+                self.log.debug(
+                    f"Precompile worker returned failure for {configs[idx]!r}: "
+                    f"{job_result!r}"
+                )
+                self._autotune_metrics.num_compile_failures += 1
+
+        if desc:
+            self.log(f"{desc} 100% via worker pool ({len(live_idxs)} configs)")
+        return is_workings, statuses, compile_times
+
     def _benchmark_function_subprocess(
         self, config: Config, fn: CompiledConfig
     ) -> float | None:
@@ -964,13 +1200,9 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         """
         if self._precompile_args_path is None:
             return None
-        try:
-            fn_spec = _serialize_compiled_fn(fn)
-        except RuntimeError:
+        fn_spec = self._serialize_fn_for_worker(fn)
+        if fn_spec is None:
             return None
-
-        if self._benchmark_worker is None:
-            self._benchmark_worker = BenchmarkWorker(device=None)
 
         job = BenchmarkJob(
             fn_spec=fn_spec,
@@ -979,14 +1211,20 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             rep=50,
         )
         timeout = float(self.settings.autotune_benchmark_timeout)
+        worker_index = self._worker_precompile_worker_by_fn.get(id(fn), 0)
 
         try:
-            latency = self._benchmark_worker.run(job, timeout=timeout)
+            latency = self._run_subprocess_job(
+                job,
+                timeout,
+                worker_index=worker_index,
+            )
         except BenchmarkSubprocessError as e:
             # Timeout or unexpected worker exit; skip config and continue.
             self.log.warning(f"Benchmark subprocess failed for {config!r}: {e}")
             self._autotune_metrics.num_compile_failures += 1
             return inf
+
         except Exception as e:
             e.__traceback__ = None
             if match_unrecoverable_runtime_error(e):
@@ -1023,3 +1261,113 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                 return inf
 
         return float(latency)
+
+    def rebenchmark(
+        self,
+        fns: list[Callable[..., object]],
+        *,
+        repeat: int,
+        desc: str = "Rebenchmarking",
+    ) -> list[float] | None:
+        """Run the top-config rebenchmark pass inside a benchmark worker.
+
+        This preserves full-effort rebenchmarking while keeping CUDA execution
+        out of the autotune parent process when subprocess benchmarking is
+        enabled. If the subprocess path cannot support the request, return
+        ``None`` so ``BaseSearch`` can use the standard in-process path.
+        """
+        if not self._subprocess_benchmark_enabled():
+            return None
+        if self.settings.autotune_benchmark_fn is not None:
+            return None
+        if self._precompile_args_path is None:
+            return None
+
+        fn_specs: list[SerializedCompiledFunction] = []
+        for fn in fns:
+            fn_spec = self._serialize_fn_for_worker(cast("CompiledConfig", fn))
+            if fn_spec is None:
+                return None
+            fn_specs.append(fn_spec)
+        if not fn_specs:
+            return []
+
+        job = RebenchmarkJob(
+            fn_specs=fn_specs,
+            args_path=self._precompile_args_path,
+            repeat=repeat,
+        )
+        timeout = float(self.settings.autotune_benchmark_timeout) * max(
+            1, len(fn_specs)
+        )
+
+        try:
+            worker_index = self._worker_precompile_worker_by_fn.get(id(fns[0]), 0)
+            return self._run_subprocess_job(job, timeout, worker_index=worker_index)
+        except BenchmarkSubprocessError as e:
+            self.log.warning(f"{desc} subprocess failed: {e}")
+        except Exception as e:
+            e.__traceback__ = None
+            if match_unrecoverable_runtime_error(e):
+                self.log.warning(f"{desc} sticky CUDA error skipped: {e}")
+            else:
+                self.log.debug(f"{desc} subprocess raised: {type(e).__name__}: {e}")
+        self._autotune_metrics.num_compile_failures += len(fn_specs)
+        return [inf] * len(fn_specs)
+
+    def confirm_rebenchmark(
+        self,
+        fns: list[Callable[..., object]],
+        *,
+        desc: str = "Confirming rebenchmark",
+    ) -> list[float] | None:
+        """Confirm suspicious pool rebenchmark timings with single-config jobs.
+
+        The normal worker rebenchmark uses an interleaved group timing.  If that
+        produces an implausibly fast value, re-run only the suspicious callable
+        through the same per-config worker benchmark path used for raw timings.
+        """
+        if self.settings.autotune_precompile != "pool":
+            return None
+        if not self._subprocess_benchmark_enabled():
+            return None
+        if self.settings.autotune_benchmark_fn is not None:
+            return None
+        if self._precompile_args_path is None:
+            return None
+
+        timings: list[float] = []
+        timeout = float(self.settings.autotune_benchmark_timeout)
+        for fn in fns:
+            fn_spec = self._serialize_fn_for_worker(cast("CompiledConfig", fn))
+            if fn_spec is None:
+                timings.append(inf)
+                continue
+            job = BenchmarkJob(
+                fn_spec=fn_spec,
+                args_path=self._precompile_args_path,
+                warmup=1,
+                rep=50,
+            )
+            worker_index = self._worker_precompile_worker_by_fn.get(id(fn), 0)
+            try:
+                timing = self._run_subprocess_job(
+                    job,
+                    timeout,
+                    worker_index=worker_index,
+                )
+            except BenchmarkSubprocessError as e:
+                self.log.warning(f"{desc} subprocess failed: {e}")
+                self._autotune_metrics.num_compile_failures += 1
+                timings.append(inf)
+            except Exception as e:
+                e.__traceback__ = None
+                if match_unrecoverable_runtime_error(e):
+                    self.log.warning(f"{desc} sticky CUDA error skipped: {e}")
+                else:
+                    self.log.debug(f"{desc} subprocess raised: {type(e).__name__}: {e}")
+                self._autotune_metrics.num_compile_failures += 1
+                timings.append(inf)
+            else:
+                timings.append(float(timing))
+        return timings

--- a/helion/autotuner/benchmark_worker.py
+++ b/helion/autotuner/benchmark_worker.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+import atexit
 import contextlib
 import ctypes
 import ctypes.util
 import multiprocessing as mp
 import os
+import queue
 import signal
 import sys
+import threading
+import time
 from typing import TYPE_CHECKING
 from typing import Callable
+from typing import NamedTuple
 from typing import TypeVar
 
 from .logger import _UNRECOVERABLE_RUNTIME_ERROR_RE
@@ -21,6 +26,12 @@ if TYPE_CHECKING:
 _T = TypeVar("_T")
 
 
+class WorkerPoolResult(NamedTuple):
+    worker_index: int
+    elapsed: float
+    result: object
+
+
 def _set_pdeathsig() -> None:
     """SIGTERM the child if the parent dies (Linux only, best-effort)."""
     if sys.platform != "linux":
@@ -29,6 +40,14 @@ def _set_pdeathsig() -> None:
         libc = ctypes.CDLL(ctypes.util.find_library("c") or "libc.so.6", use_errno=True)
         PR_SET_PDEATHSIG = 1
         libc.prctl(PR_SET_PDEATHSIG, signal.SIGTERM, 0, 0, 0)
+
+
+def _get_worker_context() -> mp.context.BaseContext:
+    """Return the multiprocessing context used to spawn pool/benchmark
+    workers. Always ``spawn`` -- ``forkserver`` is not viable because
+    PyTorch refuses CUDA re-init in any process forked from one where
+    torch was imported (which the forkserver inherits transitively)."""
+    return mp.get_context("spawn")
 
 
 def _worker_loop(connection: Connection, device: int | None) -> None:
@@ -123,9 +142,11 @@ class BenchmarkWorker:
         self._kill()
 
     def _start(self) -> None:
-        context = mp.get_context("spawn")
+        context = _get_worker_context()
         parent_connection, child_connection = context.Pipe(duplex=True)
-        process = context.Process(
+        # ``Process`` is on every concrete ``BaseContext`` subclass at runtime
+        # but isn't typed on the ``BaseContext`` ABC.
+        process = context.Process(  # pyrefly: ignore[missing-attribute]
             target=_worker_loop,
             args=(child_connection, self.device),
             daemon=True,
@@ -146,3 +167,131 @@ class BenchmarkWorker:
                 connection.close()
         self._process = None
         self._parent_connection = None
+
+
+class BenchmarkWorkerPool:
+    """Pool of long-lived ``BenchmarkWorker`` processes."""
+
+    def __init__(self, num_workers: int) -> None:
+        if num_workers < 1:
+            raise ValueError(f"num_workers must be >= 1, got {num_workers}")
+        self.workers = [BenchmarkWorker(device=None) for _ in range(num_workers)]
+
+    @property
+    def num_workers(self) -> int:
+        return len(self.workers)
+
+    def run_on(self, worker_index: int, job: Callable[[], _T], timeout: float) -> _T:
+        return self.workers[worker_index % self.num_workers].run(job, timeout=timeout)
+
+    def map_jobs(
+        self, jobs: list[Callable[[], object]], timeout: float
+    ) -> list[WorkerPoolResult]:
+        """Work-steal across workers and return one result per input job."""
+        if not jobs:
+            return []
+        active_workers = min(self.num_workers, len(jobs))
+        results: list[WorkerPoolResult | None] = [None] * len(jobs)
+        q: queue.Queue[int] = queue.Queue()
+        for i in range(len(jobs)):
+            q.put(i)
+
+        def steal(worker_idx: int) -> None:
+            worker = self.workers[worker_idx]
+            while True:
+                try:
+                    i = q.get_nowait()
+                except queue.Empty:
+                    return
+                start = time.perf_counter()
+                result = _run_capture(worker, jobs[i], timeout)
+                results[i] = WorkerPoolResult(
+                    worker_index=worker_idx,
+                    elapsed=time.perf_counter() - start,
+                    result=result,
+                )
+
+        _run_in_parallel(steal, active_workers)
+        final_results: list[WorkerPoolResult] = []
+        for result in results:
+            assert result is not None
+            final_results.append(result)
+        return final_results
+
+    def start_all(self, limit: int | None = None) -> None:
+        """Eagerly start worker processes from the calling thread.
+
+        Workers install ``PR_SET_PDEATHSIG`` (Linux) which anchors to the
+        thread that spawned them; once that thread terminates, the OS sends
+        SIGTERM to the worker. Pinning the spawn to the main thread before
+        the first worker-pool phase keeps workers alive for the rest of the
+        process."""
+        if limit is None:
+            limit = self.num_workers
+        for worker in self.workers[:limit]:
+            if not worker.alive():
+                worker._start()
+
+    def shutdown(self) -> None:
+        for w in self.workers:
+            with contextlib.suppress(Exception):
+                w.shutdown()
+
+
+def _run_capture(
+    worker: BenchmarkWorker, job: Callable[[], object], timeout: float
+) -> object:
+    try:
+        return worker.run(job, timeout=timeout)
+    except BaseException as e:
+        e.__traceback__ = None
+        return e
+
+
+def _run_in_parallel(target: Callable[[int], None], n: int) -> None:
+    if n == 1:
+        target(0)
+        return
+    threads = [
+        threading.Thread(target=target, args=(i,), daemon=True) for i in range(n)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+
+_global_pool: BenchmarkWorkerPool | None = None
+_global_pool_lock = threading.Lock()
+_global_pool_shutdown_registered = False
+
+
+def get_or_create_pool(num_workers: int) -> BenchmarkWorkerPool:
+    """Return the process-level worker pool, creating it on first use.
+
+    Reused across all autotune calls in the same Python process so pool
+    cold-start (spawn N interpreters + ``import torch``) is paid once per
+    process, not once per ``kernel.autotune()`` call. If a later autotune
+    needs a different ``num_workers``, the pool is replaced (rare on a
+    single-kernel CI process).
+    """
+    global _global_pool, _global_pool_shutdown_registered
+    with _global_pool_lock:
+        if _global_pool is not None and _global_pool.num_workers == num_workers:
+            return _global_pool
+        if _global_pool is not None:
+            _global_pool.shutdown()
+        _global_pool = BenchmarkWorkerPool(num_workers=num_workers)
+        if not _global_pool_shutdown_registered:
+            atexit.register(_shutdown_global_pool)
+            _global_pool_shutdown_registered = True
+    return _global_pool
+
+
+def _shutdown_global_pool() -> None:
+    global _global_pool
+    with _global_pool_lock:
+        if _global_pool is not None:
+            with contextlib.suppress(Exception):
+                _global_pool.shutdown()
+            _global_pool = None

--- a/helion/autotuner/de_surrogate_hybrid.py
+++ b/helion/autotuner/de_surrogate_hybrid.py
@@ -185,7 +185,7 @@ class DESurrogateHybrid(DifferentialEvolutionSearch):
 
         self.rebenchmark_population()
 
-        best = self.best
+        best = self.final_rebenchmark_top_k(self.best)
         self.log("=" * 70)
         self.log(f"✓ Best configuration: {best.perf:.4f} ms")
         self.log(f"Total evaluations: {len(self.all_observations)}")

--- a/helion/autotuner/differential_evolution.py
+++ b/helion/autotuner/differential_evolution.py
@@ -277,6 +277,7 @@ class DifferentialEvolutionSearch(PopulationBasedSearch):
 
         self.rebenchmark_population()
 
-        # Run finishing phase to simplify the best configuration
+        # Run final pool verification before simplifying the best configuration.
+        self.best = self.final_rebenchmark_top_k(self.best)
         self.best = self.run_finishing_phase(self.best, self.finishing_rounds)
         return self.best.config

--- a/helion/autotuner/llm_search.py
+++ b/helion/autotuner/llm_search.py
@@ -415,7 +415,7 @@ class LLMGuidedSearch(PopulationBasedSearch):
         """Store raw results and keep a bounded set of top configs for rebenchmarking."""
         # Retain full results for prompts while keeping only a small top-config set in memory.
         self._store_latest_results(results)
-        self.population.extend(
+        new_members = [
             PopulationMember(
                 fn=result.fn,
                 perfs=[result.perf],
@@ -425,7 +425,9 @@ class LLMGuidedSearch(PopulationBasedSearch):
                 compile_time=result.compile_time,
             )
             for result in results
-        )
+        ]
+        self.population.extend(new_members)
+        self._record_pool_final_rebenchmark_candidates(new_members)
         self._trim_population()
 
     def _trim_population(self) -> None:
@@ -630,7 +632,8 @@ class LLMGuidedSearch(PopulationBasedSearch):
             if self._run_refinement_round(round_num, state):
                 break
 
-        best = self.run_finishing_phase(self.best, self.finishing_rounds)
+        best = self.final_rebenchmark_top_k(self.best)
+        best = self.run_finishing_phase(best, self.finishing_rounds)
         return best.config
 
     def _log_search_stats(self) -> None:

--- a/helion/autotuner/pattern_search.py
+++ b/helion/autotuner/pattern_search.py
@@ -200,8 +200,9 @@ class PatternSearch(PopulationBasedSearch):
             # Log final statistics for this generation
             self.log(f"Generation {generation} complete:", self.statistics)
 
-        # Run finishing phase to simplify the best configuration
-        best = self.run_finishing_phase(self.best, self.finishing_rounds)
+        # Run final pool verification before simplifying the best configuration.
+        best = self.final_rebenchmark_top_k(self.best)
+        best = self.run_finishing_phase(best, self.finishing_rounds)
         return best.config
 
     def _pattern_search_from(

--- a/helion/autotuner/precompile_future.py
+++ b/helion/autotuner/precompile_future.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import collections
 import contextlib
 import dataclasses
+import functools
+import hashlib
 import inspect
 import multiprocessing as mp
 from multiprocessing import connection
@@ -20,7 +22,6 @@ from typing import Iterable
 from typing import Literal
 from typing import NoReturn
 from typing import cast
-import uuid
 
 import torch
 
@@ -144,20 +145,46 @@ def _serialize_compiled_fn(fn: CompiledConfig) -> SerializedCompiledFunction:
 
 
 def _load_compiled_fn(fn_spec: SerializedCompiledFunction) -> CompiledConfig:
-    module_name = f"_helion_autotune_subprocess_{uuid.uuid4().hex}"
-    module = types.ModuleType(module_name)
-    module.__file__ = fn_spec.filename or "<helion-autotune-subprocess>"
-    module.__loader__ = None
-    module.__package__ = None
-    sys.modules[module_name] = module
-    exec(
-        compile(fn_spec.source_code, module.__file__, "exec"),
-        module.__dict__,
+    return _load_compiled_fn_cached(
+        fn_spec.function_name,
+        fn_spec.source_code,
+        fn_spec.filename,
+        fn_spec.module_name,
     )
-    fn = getattr(module, fn_spec.function_name, None)
+
+
+@functools.lru_cache(maxsize=256)
+def _load_compiled_fn_cached(
+    function_name: str,
+    source_code: str,
+    filename: str | None,
+    source_module_name: str | None,
+) -> CompiledConfig:
+    digest = hashlib.sha256()
+    digest.update(function_name.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update((filename or "").encode("utf-8"))
+    digest.update(b"\0")
+    digest.update((source_module_name or "").encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(source_code.encode("utf-8"))
+    module_name = f"_helion_autotune_subprocess_{digest.hexdigest()}"
+    if module_name in sys.modules:
+        module = sys.modules[module_name]
+    else:
+        module = types.ModuleType(module_name)
+        module.__file__ = filename or "<helion-autotune-subprocess>"
+        module.__loader__ = None
+        module.__package__ = None
+        sys.modules[module_name] = module
+        exec(
+            compile(source_code, module.__file__, "exec"),
+            module.__dict__,
+        )
+    fn = getattr(module, function_name, None)
     if fn is None:
         raise RuntimeError(
-            f"Unable to locate compiled kernel '{fn_spec.function_name}' in generated module"
+            f"Unable to locate compiled kernel '{function_name}' in generated module"
         )
     return fn
 
@@ -172,7 +199,10 @@ def _run_kernel_in_subprocess_spawn(
     _cap: list[str] = [""]
     try:
         fn = _load_compiled_fn(fn_spec)
-        args = torch.load(args_path)
+        # The args file is created by the current autotune run in a private
+        # TemporaryDirectory. It may legitimately contain callable kernel args
+        # such as matmul epilogues, which PyTorch's weights_only loader rejects.
+        args = torch.load(args_path, weights_only=False)
         assert isinstance(args, (tuple, list))
         synchronize_device(None)
         with capture_output() as _cap:
@@ -394,6 +424,10 @@ class PrecompileFuture:
         mode = ctx.settings.autotune_precompile
         decorator = ctx.kernel.format_kernel_decorator(config, ctx.settings)
 
+        if mode == "pool":
+            raise exc.InvalidAPIUsage(
+                "autotune_precompile='pool' is handled by the benchmark worker pool"
+            )
         if mode == "spawn":
             mp_ctx = mp.get_context("spawn")
             assert args_path is not None

--- a/helion/autotuner/surrogate_pattern_search.py
+++ b/helion/autotuner/surrogate_pattern_search.py
@@ -482,7 +482,8 @@ class LFBOPatternSearch(PatternSearch):
                 self._fit_surrogate()
 
         # Run finishing phase to simplify the best configuration
-        best = self.run_finishing_phase(self.best, self.finishing_rounds)
+        best = self.final_rebenchmark_top_k(self.best)
+        best = self.run_finishing_phase(best, self.finishing_rounds)
         return best.config
 
     def _generate_neighbors(self, base: FlatConfig) -> list[FlatConfig]:

--- a/helion/runtime/precompile_shim.py
+++ b/helion/runtime/precompile_shim.py
@@ -34,9 +34,12 @@ def _get_helion_compilation_success(kernel: CompiledKernel) -> bool:
 
 def make_precompiler(
     fn: JITFunction[object],
-    config: Config,
-    bound_kernel: BoundKernel,
+    config: Config | None,
+    bound_kernel: BoundKernel | None,
 ) -> Callable[..., Callable[[], bool]]:
+    """``bound_kernel``/``config`` may be ``None`` when invoked from a
+    subprocess that has only the Triton fn + launch args (e.g. the pool
+    worker); their only use here is error formatting."""
     from .kernel import _find_device
 
     def _make_precompiler(*args: object, **kwargs: object) -> Callable[[], bool]:
@@ -50,9 +53,14 @@ def make_precompiler(
         kwargs["debug"] = (
             kwargs.get("debug", fn.debug) or os.environ.get("TRITON_DEBUG", "0") == "1"
         )
-        kernel_cache, *_, target, backend, binder = fn.device_caches[device]
+        kernel_cache, *cache_parts, target, backend, binder = fn.device_caches[device]
         bound_args, specialization, options = binder(*args, **kwargs)
-        key = str(specialization) + str(options)
+        if cache_parts:
+            from triton.runtime.jit import compute_cache_key
+
+            key = compute_cache_key(cache_parts[0], specialization, options)
+        else:
+            key = str(specialization) + str(options)
         kernel = kernel_cache.get(key, None)
         if kernel is not None:
             return (
@@ -98,7 +106,11 @@ def make_precompiler(
                     compiled_kernel._init_handles()
             except Exception as e:
                 action = classify_triton_exception(e)
-                if action != "debug":
+                if (
+                    action != "debug"
+                    and bound_kernel is not None
+                    and config is not None
+                ):
                     print(
                         format_triton_compile_failure(config, e, bound_kernel),
                         file=sys.stderr,

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
 
 
 DotPrecision = Literal["tf32", "tf32x3", "ieee"]
-PrecompileMode = Literal["spawn", "fork"] | None
+PrecompileMode = Literal["spawn", "fork", "pool"] | None
 _TRUE_LITERALS = frozenset({"1", "true", "yes", "on"})
 _FALSE_LITERALS = frozenset({"0", "false", "no", "off"})
 
@@ -397,9 +397,20 @@ class _Settings:
             mapping={
                 "spawn": "spawn",
                 "fork": "fork",
+                "pool": "pool",
                 "": None,
                 "0": None,
             },
+        )
+    )
+    autotune_precompile_workers: int = dataclasses.field(
+        default_factory=functools.partial(
+            _env_get_int, "HELION_AUTOTUNE_PRECOMPILE_WORKERS", 0
+        )
+    )
+    autotune_precompile_workers_cap: int = dataclasses.field(
+        default_factory=functools.partial(
+            _env_get_int, "HELION_AUTOTUNE_PRECOMPILE_WORKERS_CAP", 32
         )
     )
     autotune_precompile_jobs: int | None = dataclasses.field(
@@ -573,10 +584,12 @@ class Settings(_Settings):
             "/tmp/run.csv and /tmp/run.log with per-config metrics and debug logs."
         ),
         "autotune_compile_timeout": "Timeout for Triton compilation in seconds used for autotuning. Default is 60 seconds.",
-        "autotune_benchmark_subprocess": "Run the autotune benchmark phase in a long-lived spawn subprocess so a hung/slow kernel can be killed without losing autotune progress. Opt-in via HELION_AUTOTUNE_BENCHMARK_SUBPROCESS=1. Default disabled.",
-        "autotune_benchmark_timeout": "Per-config wall-clock timeout in seconds for the subprocess benchmark phase. Only applies when autotune_benchmark_subprocess is enabled. Default 30 seconds.",
-        "autotune_precompile": "Autotuner precompile mode: 'fork', 'spawn', or falsy/None to disable. Defaults to 'fork' on non-Windows platforms.",
+        "autotune_benchmark_subprocess": "Run the autotune benchmark phase in a long-lived spawn subprocess so a hung/slow kernel can be killed without losing autotune progress. Opt-in via HELION_AUTOTUNE_BENCHMARK_SUBPROCESS=1, or enabled implicitly by HELION_AUTOTUNE_PRECOMPILE=pool. Default disabled.",
+        "autotune_benchmark_timeout": "Per-config wall-clock timeout in seconds for the subprocess benchmark phase. Applies when autotune_benchmark_subprocess is enabled or autotune_precompile='pool'. Default 30 seconds.",
+        "autotune_precompile": "Autotuner precompile mode: 'fork', 'spawn', 'pool', or falsy/None to disable. 'pool' uses long-lived spawn workers and implies subprocess benchmarking. Defaults to 'fork' on non-Windows platforms.",
         "autotune_precompile_jobs": "Maximum concurrent Triton precompile processes, default to cpu count.",
+        "autotune_precompile_workers": "Worker-pool precompile size used when autotune_precompile='pool'. 0 (default) auto-decides from GPU memory + cpu count. >0 sets an explicit count. <0 disables the pool path. Set HELION_AUTOTUNE_PRECOMPILE_WORKERS=N to override.",
+        "autotune_precompile_workers_cap": "Upper bound on the auto-decided worker-pool size when autotune_precompile_workers=0 (auto-decide). Defaults to 32. Override via HELION_AUTOTUNE_PRECOMPILE_WORKERS_CAP=N. Has no effect when autotune_precompile_workers is set to a positive value (explicit count) or a negative value (pool disabled).",
         "autotune_random_seed": "Seed used for autotuner random number generation. Defaults to HELION_AUTOTUNE_RANDOM_SEED or a time-based seed.",
         "autotune_accuracy_check": "If True, validate candidate configs against the baseline kernel output before accepting them during autotuning.",
         "autotune_rebenchmark_threshold": "If a config is within threshold*best_perf, re-benchmark it to avoid outliers. Defaults to effort profile value. Set HELION_REBENCHMARK_THRESHOLD to override.",

--- a/test/test_benchmark_worker.py
+++ b/test/test_benchmark_worker.py
@@ -8,8 +8,12 @@ import os
 from pathlib import Path
 import random
 import signal
+import tempfile
 import time
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
+from typing import Any
+from typing import cast
 import unittest
 from unittest.mock import patch
 
@@ -20,14 +24,24 @@ from helion._testing import RefEagerTestDisabled
 from helion._testing import import_path
 from helion._testing import onlyBackends
 from helion._testing import skipIfXPU
+from helion.autotuner.base_search import PopulationBasedSearch
+from helion.autotuner.base_search import PopulationMember
+from helion.autotuner.benchmark_job import BenchmarkJob
+from helion.autotuner.benchmark_job import RebenchmarkJob
+from helion.autotuner.benchmark_job import _load_args
 from helion.autotuner.benchmark_provider import LocalBenchmarkProvider
 from helion.autotuner.benchmark_worker import BenchmarkTimeout
 from helion.autotuner.benchmark_worker import BenchmarkWorker
 from helion.autotuner.benchmark_worker import BenchmarkWorkerDied
+from helion.autotuner.benchmark_worker import BenchmarkWorkerPool
+from helion.autotuner.benchmark_worker import WorkerPoolResult
+from helion.autotuner.effort_profile import get_effort_profile
+from helion.autotuner.precompile_future import SerializedCompiledFunction
 from helion.autotuner.random_search import RandomSearch
+from helion.runtime.config import Config
+from helion.runtime.settings import Settings
 
 if TYPE_CHECKING:
-    from helion.runtime.config import Config
     from helion.runtime.kernel import CompiledConfig
 
 
@@ -67,8 +81,13 @@ class _ReturnValue:
         return self.value
 
 
+def _callable_kernel_arg(value: object) -> object:
+    return value
+
+
 class TestBenchmarkWorkerFailureModes(unittest.TestCase):
     def test_timeout_kills_worker(self) -> None:
+        # A timed-out job should kill the worker and the next job should respawn it.
         worker = BenchmarkWorker()
         try:
             t0 = time.time()
@@ -82,8 +101,7 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
             worker.shutdown()
 
     def test_sticky_error_kills_worker(self) -> None:
-        # Errors matching _UNRECOVERABLE_RUNTIME_ERROR_RE force the worker
-        # to be killed so the next call spawns a fresh CUDA context.
+        # Sticky CUDA-style errors should kill the worker before the next job.
         worker = BenchmarkWorker()
         try:
             with self.assertRaises(RuntimeError) as ctx:
@@ -95,6 +113,7 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
             worker.shutdown()
 
     def test_worker_crash_raises_died(self) -> None:
+        # A worker process crash should surface as BenchmarkWorkerDied.
         worker = BenchmarkWorker()
         try:
             with self.assertRaises(BenchmarkWorkerDied):
@@ -103,6 +122,315 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
         finally:
             worker.shutdown()
 
+    def test_pool_map_reports_worker_and_elapsed(self) -> None:
+        # Pool precompile mapping should preserve result order and report timing metadata.
+        pool = BenchmarkWorkerPool(2)
+        try:
+            results = pool.map_jobs(
+                [_ReturnValue("a"), _ReturnValue("b")],
+                timeout=30.0,
+            )
+        finally:
+            pool.shutdown()
+
+        self.assertEqual([r.result for r in results], ["a", "b"])
+        self.assertTrue(all(0 <= r.worker_index < 2 for r in results))
+        self.assertTrue(all(r.elapsed >= 0 for r in results))
+
+
+class TestWorkerPoolPrecompile(unittest.TestCase):
+    def test_worker_arg_loading_allows_callable_kernel_args(self) -> None:
+        # Worker arg loading must allow trusted callable args such as matmul epilogues.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = str(Path(tmpdir) / "args.pt")
+            torch.save((_callable_kernel_arg,), path)
+            _load_args.cache_clear()
+            try:
+                loaded = _load_args(path)
+            finally:
+                _load_args.cache_clear()
+
+        self.assertIs(loaded[0], _callable_kernel_arg)
+
+    def test_subprocess_benchmark_keeps_effort_rebenchmark_threshold(self) -> None:
+        # Subprocess benchmarking should not weaken full-effort rebenchmarking.
+        settings = Settings(
+            autotune_effort="full",
+            autotune_benchmark_subprocess=True,
+        )
+
+        self.assertEqual(
+            settings.get_rebenchmark_threshold(),
+            get_effort_profile("full").rebenchmark_threshold,
+        )
+
+    def test_explicit_rebenchmark_threshold_overrides_subprocess_default(self) -> None:
+        # Explicit rebenchmark thresholds should still override profile defaults.
+        settings = Settings(
+            autotune_effort="full",
+            autotune_benchmark_subprocess=True,
+            autotune_rebenchmark_threshold=1.25,
+        )
+
+        self.assertEqual(settings.get_rebenchmark_threshold(), 1.25)
+
+    def test_pool_mode_env_value_is_supported(self) -> None:
+        # HELION_AUTOTUNE_PRECOMPILE=pool should parse into the pool mode.
+        with patch.dict(os.environ, {"HELION_AUTOTUNE_PRECOMPILE": "pool"}):
+            self.assertEqual(Settings().autotune_precompile, "pool")
+
+    def test_pool_auto_worker_cap_defaults_to_32(self) -> None:
+        # Auto-sized pools should default to a 32-worker cap.
+        with patch.dict(os.environ, {"HELION_AUTOTUNE_PRECOMPILE_WORKERS_CAP": ""}):
+            self.assertEqual(Settings().autotune_precompile_workers_cap, 32)
+
+    def test_pool_mode_implies_subprocess_benchmark(self) -> None:
+        # Pool mode should benchmark in workers even without the subprocess env flag.
+        provider = cast("Any", LocalBenchmarkProvider.__new__(LocalBenchmarkProvider))
+        provider.settings = Settings(
+            autotune_precompile="pool",
+            autotune_benchmark_subprocess=False,
+        )
+        provider.config_spec = SimpleNamespace(backend=None)
+        provider.mutated_arg_indices = []
+
+        self.assertTrue(provider._subprocess_benchmark_enabled())
+
+    def test_pool_mode_reports_disabled_worker_reason(self) -> None:
+        # Explicitly disabled pool workers should fail with an actionable reason.
+        provider = cast("Any", LocalBenchmarkProvider.__new__(LocalBenchmarkProvider))
+        provider.settings = Settings(
+            autotune_precompile="pool",
+            autotune_precompile_workers=-1,
+        )
+        provider.config_spec = SimpleNamespace(backend=None)
+        provider.mutated_arg_indices = []
+        provider._precompile_args_path = "args.pt"
+        provider._pool_size = lambda: 1
+
+        reason = provider._pool_mode_unavailable_reason()
+        self.assertIsNotNone(reason)
+        assert reason is not None
+        self.assertIn("disabled", reason)
+
+    def test_rebenchmark_uses_worker_pool(self) -> None:
+        # Full-effort rebenchmarking should run on the worker that precompiled the config.
+        class FakePool:
+            def __init__(self) -> None:
+                self.worker_index: int | None = None
+                self.job: object | None = None
+                self.timeout: float | None = None
+
+            def run_on(
+                self,
+                worker_index: int,
+                job: object,
+                timeout: float,
+            ) -> list[float]:
+                self.worker_index = worker_index
+                self.job = job
+                self.timeout = timeout
+                return [1.0, 2.0]
+
+        class FakeLog:
+            def warning(self, *_args: object, **_kwargs: object) -> None:
+                pass
+
+            def debug(self, *_args: object, **_kwargs: object) -> None:
+                pass
+
+        def fake_fn() -> None:
+            pass
+
+        pool = FakePool()
+        provider = cast("Any", LocalBenchmarkProvider.__new__(LocalBenchmarkProvider))
+        provider.settings = Settings(
+            autotune_benchmark_subprocess=True,
+            autotune_benchmark_timeout=10,
+        )
+        provider.config_spec = SimpleNamespace(backend=None)
+        provider.mutated_arg_indices = []
+        provider._precompile_args_path = "args.pt"
+        provider._worker_pool = pool
+        provider._benchmark_worker = None
+        provider._worker_precompile_worker_by_fn = {id(fake_fn): 3}
+        provider._autotune_metrics = SimpleNamespace(num_compile_failures=0)
+        provider.log = FakeLog()
+        provider._serialize_fn_for_worker = lambda _fn: SerializedCompiledFunction(
+            function_name="fake_fn",
+            source_code="def fake_fn(): pass",
+            filename=None,
+            module_name=None,
+        )
+
+        result = provider.rebenchmark([fake_fn, fake_fn], repeat=7, desc="verify")
+
+        self.assertEqual(result, [1.0, 2.0])
+        self.assertEqual(pool.worker_index, 3)
+        self.assertIsInstance(pool.job, RebenchmarkJob)
+        assert isinstance(pool.job, RebenchmarkJob)
+        self.assertEqual(pool.job.repeat, 7)
+        self.assertEqual(len(pool.job.fn_specs), 2)
+        self.assertEqual(pool.timeout, 20.0)
+
+    def test_confirm_rebenchmark_uses_single_config_jobs(self) -> None:
+        # Suspicious pool rebenchmarks should be confirmed with per-config benchmark jobs.
+        class FakePool:
+            def __init__(self) -> None:
+                self.worker_index: int | None = None
+                self.job: object | None = None
+                self.timeout: float | None = None
+
+            def run_on(
+                self,
+                worker_index: int,
+                job: object,
+                timeout: float,
+            ) -> float:
+                self.worker_index = worker_index
+                self.job = job
+                self.timeout = timeout
+                return 0.25
+
+        class FakeLog:
+            def warning(self, *_args: object, **_kwargs: object) -> None:
+                pass
+
+            def debug(self, *_args: object, **_kwargs: object) -> None:
+                pass
+
+        def fake_fn() -> None:
+            pass
+
+        pool = FakePool()
+        provider = cast("Any", LocalBenchmarkProvider.__new__(LocalBenchmarkProvider))
+        provider.settings = Settings(
+            autotune_precompile="pool",
+            autotune_benchmark_timeout=10,
+        )
+        provider.config_spec = SimpleNamespace(backend=None)
+        provider.mutated_arg_indices = []
+        provider._precompile_args_path = "args.pt"
+        provider._worker_pool = pool
+        provider._benchmark_worker = None
+        provider._worker_precompile_worker_by_fn = {id(fake_fn): 5}
+        provider._autotune_metrics = SimpleNamespace(num_compile_failures=0)
+        provider.log = FakeLog()
+        provider._serialize_fn_for_worker = lambda _fn: SerializedCompiledFunction(
+            function_name="fake_fn",
+            source_code="def fake_fn(): pass",
+            filename=None,
+            module_name=None,
+        )
+
+        result = provider.confirm_rebenchmark([fake_fn], desc="confirm")
+
+        self.assertEqual(result, [0.25])
+        self.assertEqual(pool.worker_index, 5)
+        self.assertIsInstance(pool.job, BenchmarkJob)
+        self.assertEqual(pool.timeout, 10.0)
+
+    def test_pool_rebenchmark_confirms_suspicious_fast_timing(self) -> None:
+        # A too-fast worker rebenchmark should need one confirming benchmark before winning.
+        class FakeProvider:
+            def __init__(self) -> None:
+                self.confirmed_fns: list[object] | None = None
+
+            def rebenchmark(
+                self,
+                fns: list[object],
+                *,
+                repeat: int,
+                desc: str,
+            ) -> list[float]:
+                return [0.50, 0.80]
+
+            def confirm_rebenchmark(
+                self,
+                fns: list[object],
+                *,
+                desc: str,
+            ) -> list[float]:
+                self.confirmed_fns = fns
+                return [0.95]
+
+        class FakeLog:
+            def debug(self, *_args: object, **_kwargs: object) -> None:
+                pass
+
+        def fn_a() -> None:
+            pass
+
+        def fn_b() -> None:
+            pass
+
+        provider = FakeProvider()
+        search = cast("Any", PopulationBasedSearch.__new__(PopulationBasedSearch))
+        search.settings = Settings(autotune_precompile="pool")
+        search.kernel = SimpleNamespace(env=SimpleNamespace(process_group_name=None))
+        search.best_perf_so_far = 1.0
+        search.benchmark_provider = provider
+        search.log = FakeLog()
+        members = [
+            PopulationMember(fn=fn_a, perfs=[1.00], flat_values=[], config=Config()),
+            PopulationMember(fn=fn_b, perfs=[0.90], flat_values=[], config=Config()),
+        ]
+
+        search.rebenchmark(members, desc="verify")
+
+        self.assertEqual(provider.confirmed_fns, [fn_a])
+        self.assertEqual(members[0].perfs[-1], 0.95)
+        self.assertEqual(members[1].perfs[-1], 0.80)
+
+    def test_false_precompile_result_is_failure(self) -> None:
+        # A worker precompile returning False should count as a real compile failure.
+        class FakePool:
+            def start_all(self, limit: int | None = None) -> None:
+                self.limit = limit
+
+            def map_jobs(
+                self,
+                jobs: list[object],
+                timeout: float,
+            ) -> list[WorkerPoolResult]:
+                return [
+                    WorkerPoolResult(worker_index=0, elapsed=0.25, result=False)
+                    for _ in jobs
+                ]
+
+        class FakeLog:
+            def debug(self, *_args: object, **_kwargs: object) -> None:
+                pass
+
+        def fake_fn() -> None:
+            pass
+
+        provider = cast("Any", LocalBenchmarkProvider.__new__(LocalBenchmarkProvider))
+        provider._precompile_args_path = "args.pt"
+        provider.settings = Settings(autotune_compile_timeout=1)
+        provider._autotune_metrics = SimpleNamespace(num_compile_failures=0)
+        provider.log = FakeLog()
+        provider._worker_precompile_worker_by_fn = {}
+        provider._ensure_worker_pool = lambda: FakePool()
+        provider._serialize_fn_for_worker = lambda _fn: SerializedCompiledFunction(
+            function_name="fake_fn",
+            source_code="def fake_fn(): pass",
+            filename=None,
+            module_name=None,
+        )
+
+        is_workings, statuses, compile_times = provider._worker_pool_precompile(
+            [Config()],
+            [fake_fn],
+            desc=None,
+        )
+
+        self.assertEqual(is_workings, [False])
+        self.assertEqual(statuses, ["error"])
+        self.assertEqual(compile_times, [0.25])
+        self.assertEqual(provider._autotune_metrics.num_compile_failures, 1)
+        self.assertEqual(provider._worker_precompile_worker_by_fn, {})
+
 
 # Subprocess benchmarking depends on Backend.supports_precompile(); only the
 # Triton backend supports it (Pallas/CuTe return False).
@@ -110,6 +438,7 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
 class TestSubprocessBenchmarkIntegration(RefEagerTestDisabled, unittest.TestCase):
     @skipIfXPU("matmul config space includes maxnreg, unsupported on XPU")
     def test_autotune_with_subprocess_bench(self) -> None:
+        # Subprocess benchmarking should support a small end-to-end autotune run.
         if not torch.cuda.is_available():
             self.skipTest("requires CUDA")
 
@@ -130,6 +459,7 @@ class TestSubprocessBenchmarkIntegration(RefEagerTestDisabled, unittest.TestCase
 
     @skipIfXPU("matmul config space includes maxnreg, unsupported on XPU")
     def test_autotune_continues_when_subprocess_reports_inf(self) -> None:
+        # A subset of failed subprocess benchmarks should not abort the search.
         # Patches _benchmark_function_subprocess to return inf for a
         # fraction of configs, simulating BenchmarkTimeout / worker death;
         # autotune must still pick a best config from the rest.


### PR DESCRIPTION
This should fix bringing down the entire process from CUDA sticky errors.
On par with fork in terms of performance as well as total compile time, 2X faster than spawn.
<img width="1129" height="131" alt="image" src="https://github.com/user-attachments/assets/1d7ea476-52f5-4a43-99b0-2fbe09442d3b" />
<img width="636" height="281" alt="image" src="https://github.com/user-attachments/assets/8c830da4-f848-44a8-ac92-49ac0bbcedf0" />


CI shows "pool" is basically a win or on par with "fork" for compile time and perf. 
<img width="1703" height="543" alt="image" src="https://github.com/user-attachments/assets/11f6d159-3d2d-4f0c-aaec-f563595a827a" />
<img width="1620" height="497" alt="image" src="https://github.com/user-attachments/assets/e3a13318-9013-454d-a82e-d1ea21703901" />


