### PR TITLE
[dashboard] Trigger docs-deploy explicitly from benchmark dispatch

### DIFF
--- a/.github/workflows/benchmark_dispatch.yml
+++ b/.github/workflows/benchmark_dispatch.yml
@@ -120,6 +120,8 @@ jobs:
     if: always()
     needs: [run-b200, run-h100, run-mi350x]
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - name: Trigger docs deploy
         uses: actions/github-script@v9

--- a/.github/workflows/benchmark_dispatch.yml
+++ b/.github/workflows/benchmark_dispatch.yml
@@ -115,3 +115,20 @@ jobs:
       kernels: ${{ matrix.kernels }}
       env-vars: ${{ github.event.inputs.env_vars }}
       custom-args: ${{ github.event.inputs.custom_args }}
+
+  trigger-docs-deploy:
+    if: always()
+    needs: [run-b200, run-h100, run-mi350x]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger docs deploy
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'docs-deploy.yml',
+              ref: 'main'
+            })

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Benchmark Dispatch"]
-    types: [completed]
 
 permissions:
   contents: read


### PR DESCRIPTION
Replace workflow_run trigger in docs-deploy.yml with an explicit trigger-docs-deploy job in benchmark_dispatch.yml. pytorch-bot auto-retries failed nightly benchmarks, but GitHub Actions re-runs don't fire, causing the dashboard to miss updates.
The explicit dispatch fires on every benchmark completion (first run, re-run, manual, nightly).
manaul trigger on docs-deploy.yml is preserved for doc-only changes.