### PR TITLE
[Autotuner] Handle PyTorch CUDA OOM as a skippable error instead of aborting autotuning

### DIFF
--- a/helion/autotuner/logger.py
+++ b/helion/autotuner/logger.py
@@ -27,6 +27,7 @@ from typing_extensions import Self
 
 from torch._inductor.runtime.triton_compat import OutOfResources
 from torch._inductor.runtime.triton_compat import PTXASError
+from torch.cuda import OutOfMemoryError as CudaOOMError
 
 from helion._dist_utils import is_master_rank
 
@@ -461,6 +462,7 @@ _EXPECTED_TRITON_ERRORS_RE: re.Pattern[str] = re.compile(
                 "too many blocks in cooperative launch",  # CUDA cooperative launch limit
                 "too many resources requested for launch",  # Triton resource error
                 "CUDA error: out of memory",  # CUDA runtime OOM during kernel execution
+                "CUDA out of memory",  # PyTorch torch.cuda.OutOfMemoryError
                 "Ran out of memory in memory space vmem",  # TPU VMEM OOM (caught by Helion or XLA)
             ],
         )
@@ -497,7 +499,7 @@ def classify_triton_exception(err: BaseException) -> Literal["raise", "warn", "d
       - "debug": benign/expected error; caller can log at debug level
     """
     # Known exception types first
-    if isinstance(err, OutOfResources):
+    if isinstance(err, (OutOfResources, CudaOOMError)):
         return "debug"
     # Different PTXASError classes may be raised from different modules; match by name as well
     if isinstance(err, PTXASError) or err.__class__.__name__ == "PTXASError":

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -164,6 +164,23 @@ class TestAutotuneIgnoreErrors(TestCase):
         self.assertEqual(result, float("inf"))
         self.assertEqual(search._autotune_metrics.num_compile_failures, 1)
 
+    def test_cuda_oom_skips_config(self):
+        settings = Settings(
+            autotune_ignore_errors=False,
+            autotune_log_level=logging.CRITICAL,
+        )
+        search = self._make_search(settings)
+
+        def bad_fn(*_args):
+            raise torch.cuda.OutOfMemoryError("CUDA out of memory")
+
+        with patch("torch.accelerator.synchronize", autospec=True) as sync:
+            sync.return_value = None
+            result = search.benchmark_provider._benchmark_function("cfg", bad_fn)
+
+        self.assertEqual(result, float("inf"))
+        self.assertEqual(search._autotune_metrics.num_compile_failures, 1)
+
     def test_ignore_errors_skips_logging_and_raise(self):
         settings = Settings(
             autotune_ignore_errors=True,


### PR DESCRIPTION
  ## Summary
  - `torch.cuda.OutOfMemoryError` was not handled by `classify_triton_exception`, causing OOM during benchmarking to abort the entire
  autotuning run instead of skipping the config.
  - Add `isinstance` check for `torch.cuda.OutOfMemoryError` alongside the existing `OutOfResources` check.
  - Add `"CUDA out of memory"` regex pattern to cover the PyTorch OOM message string (complements the existing `"CUDA error: out of memory"`
  for CUDA runtime OOM).

  ## Test plan
  - `test_cuda_oom_skips_config` — verifies that `torch.cuda.OutOfMemoryError` during benchmarking returns `inf` (skip) instead of raising.