### PR TITLE
[Pallas] Enable se_block tests on TPU + simplify skipIfCudaCapabilityLessThan

### DIFF
--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -451,11 +451,16 @@ def skipIfNotCUDA() -> Callable[[Callable], Callable]:
 def skipIfCudaCapabilityLessThan(
     min_capability: tuple[int, int], *, reason: str | None = None
 ) -> Callable[[Callable], Callable]:
-    """Skip test if not running on CUDA or capability is less than min_capability."""
+    """Skip test if running on CUDA with capability less than min_capability.
+
+    Pass-through on non-CUDA backends. Combine with `skipIfNotCUDA()` (or
+    `skipIfPallas`/`skipIfXPU`/etc.) at the call site if the test also
+    requires a specific platform.
+    """
 
     def cond() -> bool:
         if not is_cuda():
-            return True
+            return False
         return torch.cuda.get_device_capability() < min_capability
 
     # Defers check to test execution time to avoid CUDA init during pytest-xdist collection.

--- a/test/test_dot_scaled.py
+++ b/test/test_dot_scaled.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import os
 import sys
+from typing import TYPE_CHECKING
 import unittest
 
 import torch
@@ -14,14 +15,22 @@ from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
 from helion._testing import skipIfCudaCapabilityLessThan
+from helion._testing import skipIfNotCUDA
 from helion._testing import skipIfRefEager
 import helion.language as hl
 from helion.runtime.settings import _get_backend
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
 # tl.dot_scaled requires SM 10.0+ (B200 / compute capability 10.0)
-requires_sm100 = skipIfCudaCapabilityLessThan(
-    (10, 0), reason="tl.dot_scaled requires CUDA capability >= 10.0 (B200+)"
-)
+def requires_sm100(fn: Callable) -> Callable:
+    return skipIfNotCUDA()(
+        skipIfCudaCapabilityLessThan(
+            (10, 0), reason="tl.dot_scaled requires CUDA capability >= 10.0 (B200+)"
+        )(fn)
+    )
 
 
 @functools.lru_cache(maxsize=1)

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -21,12 +21,12 @@ from helion._testing import _get_backend
 from helion._testing import check_example
 from helion._testing import get_nvidia_gpu_model
 from helion._testing import import_path
-from helion._testing import is_cuda
 from helion._testing import onlyBackends
 from helion._testing import skipIfA10G
 from helion._testing import skipIfCudaCapabilityLessThan
 from helion._testing import skipIfCudaSharedMemoryLessThan
 from helion._testing import skipIfFn
+from helion._testing import skipIfNotCUDA
 from helion._testing import skipIfPallas
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfRocm
@@ -339,6 +339,7 @@ class TestExamples(RefEagerTestBase, TestCase):
     @skipIfFn(
         lambda: _get_backend() == "cute", "CuTe FP8 GEMM example is not supported yet"
     )
+    @skipIfNotCUDA()
     @skipIfCudaCapabilityLessThan((9, 0), reason="FP8 requires CUDA capability >= 9.0")
     def test_fp8_gemm(self):
         # Create FP32 tensors and convert to FP8
@@ -1069,6 +1070,7 @@ class TestExamples(RefEagerTestBase, TestCase):
         lambda: _get_backend() == "cute",
         "CuTe FP8 attention destabilizes later cute tests when it fails in-process",
     )
+    @skipIfNotCUDA()
     @skipIfCudaCapabilityLessThan((9, 0), reason="FP8 requires CUDA capability >= 9.0")
     def test_fp8_attention(self):
         batch = 2
@@ -2348,10 +2350,7 @@ class TestExamples(RefEagerTestBase, TestCase):
 
     @skipIfRocm("failure on rocm")
     @skipIfA10G("failure on a10g")
-    @skipIfFn(
-        lambda: is_cuda() and torch.cuda.get_device_capability() < (9, 0),
-        reason="se_block CUDA path requires H100+",
-    )
+    @skipIfCudaCapabilityLessThan((9, 0), reason="se_block CUDA path requires H100+")
     def test_se_block_fwd(self):
         m, n = 128, 128
         x = torch.randn([m, n], device=DEVICE, dtype=torch.bfloat16)
@@ -2374,10 +2373,7 @@ class TestExamples(RefEagerTestBase, TestCase):
 
     @skipIfRocm("failure on rocm")
     @skipIfA10G("failure on a10g")
-    @skipIfFn(
-        lambda: is_cuda() and torch.cuda.get_device_capability() < (9, 0),
-        reason="se_block CUDA path requires H100+",
-    )
+    @skipIfCudaCapabilityLessThan((9, 0), reason="se_block CUDA path requires H100+")
     def test_se_block_bwd_dx(self):
         m, n = 128, 128
         x = torch.randn([m, n], device=DEVICE, dtype=HALF_DTYPE, requires_grad=True)
@@ -2407,10 +2403,7 @@ class TestExamples(RefEagerTestBase, TestCase):
 
     @skipIfRocm("failure on rocm")
     @skipIfA10G("failure on a10g")
-    @skipIfFn(
-        lambda: is_cuda() and torch.cuda.get_device_capability() < (9, 0),
-        reason="se_block CUDA path requires H100+",
-    )
+    @skipIfCudaCapabilityLessThan((9, 0), reason="se_block CUDA path requires H100+")
     def test_se_block_bwd_dw(self):
         m, n = 128, 128
         x = torch.randn([m, n], device=DEVICE, dtype=HALF_DTYPE, requires_grad=True)

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -21,6 +21,7 @@ from helion._testing import _get_backend
 from helion._testing import check_example
 from helion._testing import get_nvidia_gpu_model
 from helion._testing import import_path
+from helion._testing import is_cuda
 from helion._testing import onlyBackends
 from helion._testing import skipIfA10G
 from helion._testing import skipIfCudaCapabilityLessThan
@@ -2347,7 +2348,10 @@ class TestExamples(RefEagerTestBase, TestCase):
 
     @skipIfRocm("failure on rocm")
     @skipIfA10G("failure on a10g")
-    @skipIfCudaCapabilityLessThan((9, 0), reason="se_block requires H100+")
+    @skipIfFn(
+        lambda: is_cuda() and torch.cuda.get_device_capability() < (9, 0),
+        reason="se_block CUDA path requires H100+",
+    )
     def test_se_block_fwd(self):
         m, n = 128, 128
         x = torch.randn([m, n], device=DEVICE, dtype=torch.bfloat16)
@@ -2370,12 +2374,15 @@ class TestExamples(RefEagerTestBase, TestCase):
 
     @skipIfRocm("failure on rocm")
     @skipIfA10G("failure on a10g")
-    @skipIfCudaCapabilityLessThan((9, 0), reason="se_block requires H100+")
+    @skipIfFn(
+        lambda: is_cuda() and torch.cuda.get_device_capability() < (9, 0),
+        reason="se_block CUDA path requires H100+",
+    )
     def test_se_block_bwd_dx(self):
         m, n = 128, 128
-        x = torch.randn([m, n], device=DEVICE, dtype=torch.float16, requires_grad=True)
-        w = torch.randn([n, n], device=DEVICE, dtype=torch.float16, requires_grad=True)
-        grad_out = torch.randn([m, n], device=DEVICE, dtype=torch.float16)
+        x = torch.randn([m, n], device=DEVICE, dtype=HALF_DTYPE, requires_grad=True)
+        w = torch.randn([n, n], device=DEVICE, dtype=HALF_DTYPE, requires_grad=True)
+        grad_out = torch.randn([m, n], device=DEVICE, dtype=HALF_DTYPE)
 
         # Compute expected gradients with PyTorch
         x_torch = x.detach().clone().requires_grad_(True)
@@ -2400,12 +2407,15 @@ class TestExamples(RefEagerTestBase, TestCase):
 
     @skipIfRocm("failure on rocm")
     @skipIfA10G("failure on a10g")
-    @skipIfCudaCapabilityLessThan((9, 0), reason="se_block requires H100+")
+    @skipIfFn(
+        lambda: is_cuda() and torch.cuda.get_device_capability() < (9, 0),
+        reason="se_block CUDA path requires H100+",
+    )
     def test_se_block_bwd_dw(self):
         m, n = 128, 128
-        x = torch.randn([m, n], device=DEVICE, dtype=torch.float16, requires_grad=True)
-        w = torch.randn([n, n], device=DEVICE, dtype=torch.float16, requires_grad=True)
-        grad_out = torch.randn([m, n], device=DEVICE, dtype=torch.float16)
+        x = torch.randn([m, n], device=DEVICE, dtype=HALF_DTYPE, requires_grad=True)
+        w = torch.randn([n, n], device=DEVICE, dtype=HALF_DTYPE, requires_grad=True)
+        grad_out = torch.randn([m, n], device=DEVICE, dtype=HALF_DTYPE)
 
         # Compute expected gradients with PyTorch
         x_torch = x.detach().clone().requires_grad_(True)

--- a/test/test_loops.py
+++ b/test/test_loops.py
@@ -24,6 +24,7 @@ from helion._testing import onlyBackends
 from helion._testing import skipIfCudaCapabilityLessThan
 from helion._testing import skipIfFn
 from helion._testing import skipIfLowVRAM
+from helion._testing import skipIfNotCUDA
 from helion._testing import skipIfNotTriton
 from helion._testing import skipIfPallas
 from helion._testing import skipIfRefEager
@@ -847,6 +848,7 @@ class TestLoops(RefEagerTestBase, TestCase):
         self.assertNotEqualCode(code0, code2)
         self.assertNotIn("loop_unroll_factor", code0)
 
+    @skipIfNotCUDA()
     @skipIfCudaCapabilityLessThan(
         (12, 0), reason="Warp specialization requires CUDA capability >= 12.0"
     )

--- a/test/test_persistent_kernels.py
+++ b/test/test_persistent_kernels.py
@@ -12,6 +12,7 @@ from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
 from helion._testing import skipIfCudaCapabilityLessThan
+from helion._testing import skipIfNotCUDA
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
 from helion._testing import skipUnlessTensorDescriptor
@@ -1062,6 +1063,7 @@ class TestPersistentKernels(RefEagerTestBase, TestCase):
         self.assertIn("disallow_acc_multi_buffer=False", code_combined)
         self.assertIn("flatten=False", code_combined)
 
+    @skipIfNotCUDA()
     @skipIfCudaCapabilityLessThan(
         (12, 0), reason="Warp specialization requires CUDA capability >= 12.0"
     )


### PR DESCRIPTION
## Summary

### 1. Enable se_block tests on TPU

The three `se_block` tests in `test_examples.py` were gated to H100+ via `skipIfCudaCapabilityLessThan((9, 0))`. That helper short-circuits on non-CUDA, so it also skipped them on TPU.

- The fwd kernel (already bf16) works on TPU as-is.
- The bwd kernels were written with `float16`, which hits a Mosaic compile bug on the packed-layout tiled load:

  ```
  Invalid vector type for load
  memref<128x128xf16, #tpu.tiled<(8,128)(2,1)...>> -> vector<8x128x2xf16>
  ```

  The same kernels with `bfloat16` compile and pass, so it's an f16-specific Mosaic issue, not the access pattern. bf16 is the standard 16-bit dtype on TPU.

Switch the bwd tests to `HALF_DTYPE` from `helion._testing` (bfloat16 on Pallas, float16 elsewhere) so TPU uses bf16 while GPU keeps f16 coverage.

### 2. Make `skipIfCudaCapabilityLessThan` a pure capability filter

The helper previously conflated "must be on CUDA" with "must have cap >= X" — skipping on any non-CUDA backend regardless of the capability argument. Change it to pass through on non-CUDA so the decorator means just what its name says. Callers that genuinely require CUDA add `@skipIfNotCUDA()` explicitly.
