### PR TITLE
Reduce measure() overhead when compile-time tracking is disabled

### DIFF
--- a/helion/_compile_time.py
+++ b/helion/_compile_time.py
@@ -17,10 +17,7 @@ from typing import TypeVar
 
 _F = TypeVar("_F", bound=Callable[..., Any])
 
-
-def _is_enabled() -> bool:
-    """Check if compile time measurement is enabled via HELION_MEASURE_COMPILE_TIME=1."""
-    return os.environ.get("HELION_MEASURE_COMPILE_TIME", "0") == "1"
+_enabled: bool = os.environ.get("HELION_MEASURE_COMPILE_TIME", "0") == "1"
 
 
 class CompileTimeTracker:
@@ -48,13 +45,13 @@ class CompileTimeTracker:
             with cls._lock:
                 if cls._instance is None:
                     cls._instance = CompileTimeTracker()
-                    if _is_enabled():
+                    if _enabled:
                         atexit.register(cls._instance.print_report)
         return cls._instance
 
     def start(self, name: str) -> None:
         """Start timing a named section."""
-        if not _is_enabled():
+        if not _enabled:
             return
         tid = threading.get_ident()
         with self._timer_lock:
@@ -64,7 +61,7 @@ class CompileTimeTracker:
 
     def stop(self, name: str) -> float:
         """Stop timing a named section and return elapsed time."""
-        if not _is_enabled():
+        if not _enabled:
             return 0.0
         end_time = time.perf_counter()
         tid = threading.get_ident()
@@ -92,7 +89,7 @@ class CompileTimeTracker:
 
     def record(self, name: str, elapsed: float) -> None:
         """Directly record a timing measurement."""
-        if not _is_enabled():
+        if not _enabled:
             return
         with self._timer_lock:
             self._timings[name] += elapsed
@@ -225,23 +222,28 @@ def get_tracker() -> CompileTimeTracker:
     return CompileTimeTracker.instance()
 
 
-@contextlib.contextmanager
-def measure(name: str) -> Generator[None, None, None]:
-    """
-    Context manager to measure compilation time for a named section.
+_NOOP: contextlib.AbstractContextManager[None] = contextlib.nullcontext()
 
-    Usage:
-        with measure("phase_name"):
-            # code to measure
 
-    Only active when HELION_MEASURE_COMPILE_TIME=1 is set.
-    """
-    tracker = get_tracker()
-    tracker.start(name)
-    try:
-        yield
-    finally:
-        tracker.stop(name)
+class _MeasureContext:
+    __slots__ = ("_name", "_tracker")
+
+    def __init__(self, name: str, tracker: CompileTimeTracker) -> None:
+        self._name = name
+        self._tracker = tracker
+
+    def __enter__(self) -> None:
+        self._tracker.start(self._name)
+        return None
+
+    def __exit__(self, *args: object) -> None:
+        self._tracker.stop(self._name)
+
+
+def measure(name: str) -> contextlib.AbstractContextManager[None]:
+    if not _enabled:
+        return _NOOP
+    return _MeasureContext(name, get_tracker())
 
 
 def timed(name: str | None = None) -> Callable[[_F], _F]:
@@ -266,7 +268,7 @@ def timed(name: str | None = None) -> Callable[[_F], _F]:
 
         @functools.wraps(fn)
         def wrapper(*args: object, **kwargs: object) -> object:
-            if not _is_enabled():
+            if not _enabled:
                 return fn(*args, **kwargs)
             tracker = get_tracker()
             tracker.start(section_name)


### PR DESCRIPTION
Binding a kernel is on the hot path of calling a Helion op in Python, this PR removes 2 us of latency in each call.

- Replace the @contextmanager-based measure() with a cached nullcontext singleton when disabled, and a lightweight class (faster) when enabled.
- Also cache the HELION_MEASURE_COMPILE_TIME env var check at import time instead of checking env var repeatedly

Benchmark (1M iterations):
  Disabled path: 2.294 -> 0.192 us/call (~12x faster)
  Enabled path:  1.870 -> 1.252 us/call (~1.5x faster)