### PR TITLE
[Pallas] Use torch.addmm in matmul_layernorm K-loop

### DIFF
--- a/examples/matmul_layernorm.py
+++ b/examples/matmul_layernorm.py
@@ -57,8 +57,7 @@ def matmul_layernorm(
     for tile_m in hl.tile(m):
         acc = hl.zeros([tile_m, n], dtype=torch.float32)
         for tile_k in hl.tile(k):
-            mm = torch.matmul(x[tile_m, tile_k], y[tile_k, :])
-            acc = acc + mm
+            acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, :])
         eps = 1e-5
         sum_vals = acc.sum(dim=-1, keepdim=True)
         mean = sum_vals / n

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -279,7 +279,7 @@ class TestExamples(RefEagerTestBase, TestCase):
         stay in fp32 to keep the layernorm output within tight tolerance;
         regressions here surface as out-of-tolerance results on bf16/fp16.
         """
-        m, k, n = 1024, 1024, 1024
+        m, k, n = 512, 1024, 256
         args = (
             torch.randn([m, k], device=DEVICE, dtype=HALF_DTYPE),
             torch.randn([k, n], device=DEVICE, dtype=HALF_DTYPE),
@@ -296,7 +296,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             "matmul_layernorm",
             args,
             expected,
-            block_sizes=[32, 256],
+            block_sizes=[16, 256],
             static_shapes=True,
             atol=1e-2,
             rtol=1e-2,

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -268,10 +268,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             static_shapes=True,
         )
 
-    @skipIfFn(
-        lambda: _get_backend() == "cute",
-        "CuTe matmul+layernorm example is unsupported and too expensive in-process",
-    )
+    @onlyBackends(["pallas"])
     def test_matmul_layernorm_half_dtype_multi_k_tile(self):
         """Guards K-loop accumulator precision when inputs are half-precision.
 
@@ -279,7 +276,7 @@ class TestExamples(RefEagerTestBase, TestCase):
         stay in fp32 to keep the layernorm output within tight tolerance;
         regressions here surface as out-of-tolerance results on bf16/fp16.
         """
-        m, k, n = 512, 1024, 256
+        m, k, n = 1024, 1024, 1024
         args = (
             torch.randn([m, k], device=DEVICE, dtype=HALF_DTYPE),
             torch.randn([k, n], device=DEVICE, dtype=HALF_DTYPE),
@@ -296,7 +293,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             "matmul_layernorm",
             args,
             expected,
-            block_sizes=[16, 256],
+            block_sizes=[32, 256],
             static_shapes=True,
             atol=1e-2,
             rtol=1e-2,

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -268,6 +268,40 @@ class TestExamples(RefEagerTestBase, TestCase):
             static_shapes=True,
         )
 
+    @skipIfFn(
+        lambda: _get_backend() == "cute",
+        "CuTe matmul+layernorm example is unsupported and too expensive in-process",
+    )
+    def test_matmul_layernorm_half_dtype_multi_k_tile(self):
+        """Guards K-loop accumulator precision when inputs are half-precision.
+
+        Across multiple K-tile iterations the partial-sum accumulator must
+        stay in fp32 to keep the layernorm output within tight tolerance;
+        regressions here surface as out-of-tolerance results on bf16/fp16.
+        """
+        m, k, n = 1024, 1024, 1024
+        args = (
+            torch.randn([m, k], device=DEVICE, dtype=HALF_DTYPE),
+            torch.randn([k, n], device=DEVICE, dtype=HALF_DTYPE),
+            torch.randn([n], device=DEVICE, dtype=HALF_DTYPE),
+            torch.randn([n], device=DEVICE, dtype=HALF_DTYPE),
+        )
+        expected = torch.nn.functional.layer_norm(
+            (args[0] @ args[1]).to(torch.float32),
+            normalized_shape=(n,),
+            weight=args[2].to(torch.float32),
+            bias=args[3].to(torch.float32),
+        ).to(HALF_DTYPE)
+        check_example(
+            "matmul_layernorm",
+            args,
+            expected,
+            block_sizes=[32, 256],
+            static_shapes=True,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
     def test_matmul_layernorm_small_shapes_compile_on_cute(self):
         if _get_backend() != "cute":
             self.skipTest("CuTe-specific compile coverage")


### PR DESCRIPTION
## Summary

Switch the K-loop accumulation in `examples/matmul_layernorm.py` from `mm = torch.matmul(x, y); acc = acc + mm` to `acc = torch.addmm(acc, x, y)`.

## Why

The unfused form traces as two FX nodes — `aten.mm.default` and `aten.add.Tensor` — handled by separate registered lowerings (`mm_lowering` and the generic add lowering in `aten_lowering.py`). On the Pallas backend this forces a precision-killing dtype round-trip per K iteration.

The Pallas matmul lowering uses `preferred_element_type=jnp.float32` so the TPU MXU accumulates in fp32 internally (the canonical pattern documented in the [JAX Pallas TPU matmul guide](https://docs.jax.dev/en/latest/pallas/tpu/matmul.html)). But because torch's type-promotion rule says `bf16 × bf16 → bf16`, the matmul FX node's `out_dtype` is bf16, and the codegen casts the matmul result back to bf16 to keep the JAX-level dtype consistent with the FX-level dtype. The next FX node (`acc + mm`) lowers as a separate JAX expression that upcasts back to fp32 to match the fp32 accumulator. So every K-tile pays:

```
fp32 (MXU output) → bf16 (cast-back) → fp32 (upcast for add)
```

The bf16 hop discards the fp32 partial-sum precision the MXU just produced, and with multiple K iterations the per-tile quantization error compounds.

`torch.addmm` traces as a single FX node (`aten.addmm.default`), which Pallas lowers via the `with_acc=True` path in `_pallas_dot` to one fused expression:

```
acc + jnp.matmul(lhs, rhs, preferred_element_type=jnp.float32)
```

This matches the pattern from the JAX Pallas docs: keep partial sums in fp32 across the K loop, downcast only at the final store. `examples/matmul.py` already uses this idiom; this PR makes `matmul_layernorm` consistent.

The existing `test_matmul_layernorm_static_shapes` uses fp32 inputs and so doesn't exercise the cast-back branch (it only triggers for `out_dtype.itemsize < 4`).
