### PR TITLE
[Autotuner] Catch expected errors during fork precompiler setup instead of aborting

### DIFF
--- a/helion/autotuner/logger.py
+++ b/helion/autotuner/logger.py
@@ -463,6 +463,7 @@ _EXPECTED_TRITON_ERRORS_RE: re.Pattern[str] = re.compile(
                 "too many resources requested for launch",  # Triton resource error
                 "CUDA error: out of memory",  # CUDA runtime OOM during kernel execution
                 "CUDA out of memory",  # PyTorch torch.cuda.OutOfMemoryError
+                "[CUDA]: out of memory",  # Triton CUDA OOM
                 "Ran out of memory in memory space vmem",  # TPU VMEM OOM (caught by Helion or XLA)
             ],
         )

--- a/helion/autotuner/logger.py
+++ b/helion/autotuner/logger.py
@@ -27,6 +27,7 @@ from typing_extensions import Self
 
 from torch._inductor.runtime.triton_compat import OutOfResources
 from torch._inductor.runtime.triton_compat import PTXASError
+from torch.cuda import OutOfMemoryError as CudaOOMError
 
 from helion._dist_utils import is_master_rank
 
@@ -461,6 +462,7 @@ _EXPECTED_TRITON_ERRORS_RE: re.Pattern[str] = re.compile(
                 "too many blocks in cooperative launch",  # CUDA cooperative launch limit
                 "too many resources requested for launch",  # Triton resource error
                 "CUDA error: out of memory",  # CUDA runtime OOM during kernel execution
+                "CUDA out of memory",  # PyTorch torch.cuda.OutOfMemoryError
                 "Ran out of memory in memory space vmem",  # TPU VMEM OOM (caught by Helion or XLA)
             ],
         )
@@ -497,7 +499,7 @@ def classify_triton_exception(err: BaseException) -> Literal["raise", "warn", "d
       - "debug": benign/expected error; caller can log at debug level
     """
     # Known exception types first
-    if isinstance(err, OutOfResources):
+    if isinstance(err, (OutOfResources, CudaOOMError)):
         return "debug"
     # Different PTXASError classes may be raised from different modules; match by name as well
     if isinstance(err, PTXASError) or err.__class__.__name__ == "PTXASError":

--- a/helion/autotuner/precompile_future.py
+++ b/helion/autotuner/precompile_future.py
@@ -33,6 +33,7 @@ from .logger import capture_output
 from .logger import classify_triton_exception
 from .logger import format_triton_compile_failure
 from .logger import log_generated_triton_code_debug
+from .logger import match_unrecoverable_runtime_error
 from .logger import maybe_dump_triton_failure
 from .progress_bar import iter_with_progress
 
@@ -412,9 +413,18 @@ class PrecompileFuture:
             )
             process.daemon = True
         else:
-            precompiler = _prepare_precompiler_for_fork(
-                fn, args, config, ctx.kernel, decorator, ctx.log
-            )
+            try:
+                precompiler = _prepare_precompiler_for_fork(
+                    fn, args, config, ctx.kernel, decorator, ctx.log
+                )
+            except Exception as e:
+                e.__traceback__ = None
+                if match_unrecoverable_runtime_error(e):
+                    raise
+                action = classify_triton_exception(e)
+                if action == "raise" and not ctx.settings.autotune_ignore_errors:
+                    raise
+                return PrecompileFuture.skip(ctx, config, False)
             if precompiler is None:
                 return PrecompileFuture.skip(ctx, config, True)
             mp_ctx = mp.get_context("fork")

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -164,6 +164,23 @@ class TestAutotuneIgnoreErrors(TestCase):
         self.assertEqual(result, float("inf"))
         self.assertEqual(search._autotune_metrics.num_compile_failures, 1)
 
+    def test_cuda_oom_skips_config(self):
+        settings = Settings(
+            autotune_ignore_errors=False,
+            autotune_log_level=logging.CRITICAL,
+        )
+        search = self._make_search(settings)
+
+        def bad_fn(*_args):
+            raise torch.cuda.OutOfMemoryError("CUDA out of memory")
+
+        with patch("torch.accelerator.synchronize", autospec=True) as sync:
+            sync.return_value = None
+            result = search.benchmark_provider._benchmark_function("cfg", bad_fn)
+
+        self.assertEqual(result, float("inf"))
+        self.assertEqual(search._autotune_metrics.num_compile_failures, 1)
+
     def test_ignore_errors_skips_logging_and_raise(self):
         settings = Settings(
             autotune_ignore_errors=True,

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -443,6 +443,98 @@ class TestAutotuneIgnoreErrors(TestCase):
 
         self.assertEqual(set(lazy_calls), {parent_pid})
 
+    @pytest.mark.skipif(
+        "fork" not in mp.get_all_start_methods(),
+        reason="fork start method is unavailable on this platform",
+    )
+    def test_fork_precompile_expected_errors_skip_config(self):
+        from torch._inductor.runtime.triton_compat import OutOfResources
+
+        expected_errors = [
+            torch.cuda.OutOfMemoryError("CUDA out of memory"),
+            OutOfResources(128, 64, "shared memory"),
+            RuntimeError("out of resource: shared memory"),
+            RuntimeError("too many resources requested for launch"),
+            RuntimeError("CUDA error: out of memory"),
+            RuntimeError("failed to translate module to LLVM IR"),
+        ]
+        for err in expected_errors:
+            with self.subTest(error=type(err).__name__, msg=str(err)):
+                settings = Settings(
+                    autotune_precompile="fork",
+                    autotune_ignore_errors=False,
+                    autotune_log_level=logging.CRITICAL,
+                )
+                search = self._make_search(settings, args=("arg0",))
+
+                def fake_compiled_fn(
+                    *fn_args: object, _launcher: Callable[..., object]
+                ) -> None:
+                    _launcher("fake_kernel", (1,), *fn_args)
+
+                with patch(
+                    "helion.autotuner.precompile_future._prepare_precompiler_for_fork",
+                    side_effect=err,
+                ):
+                    future = search.benchmark_provider._create_precompile_future(
+                        "cfg", fake_compiled_fn
+                    )
+
+                self.assertFalse(future.ok)
+
+    @pytest.mark.skipif(
+        "fork" not in mp.get_all_start_methods(),
+        reason="fork start method is unavailable on this platform",
+    )
+    def test_fork_precompile_illegal_memory_access_raises(self):
+        settings = Settings(
+            autotune_precompile="fork",
+            autotune_ignore_errors=True,
+            autotune_log_level=logging.CRITICAL,
+        )
+        search = self._make_search(settings, args=("arg0",))
+
+        def fake_compiled_fn(
+            *fn_args: object, _launcher: Callable[..., object]
+        ) -> None:
+            _launcher("fake_kernel", (1,), *fn_args)
+
+        with (
+            patch(
+                "helion.autotuner.precompile_future._prepare_precompiler_for_fork",
+                side_effect=RuntimeError("an illegal memory access was encountered"),
+            ),
+            pytest.raises(RuntimeError, match="illegal memory access"),
+        ):
+            search.benchmark_provider._create_precompile_future("cfg", fake_compiled_fn)
+
+    @pytest.mark.skipif(
+        "fork" not in mp.get_all_start_methods(),
+        reason="fork start method is unavailable on this platform",
+    )
+    def test_fork_precompile_unexpected_error_skipped_with_ignore_errors(self):
+        settings = Settings(
+            autotune_precompile="fork",
+            autotune_ignore_errors=True,
+            autotune_log_level=logging.CRITICAL,
+        )
+        search = self._make_search(settings, args=("arg0",))
+
+        def fake_compiled_fn(
+            *fn_args: object, _launcher: Callable[..., object]
+        ) -> None:
+            _launcher("fake_kernel", (1,), *fn_args)
+
+        with patch(
+            "helion.autotuner.precompile_future._prepare_precompiler_for_fork",
+            side_effect=RuntimeError("something unexpected"),
+        ):
+            future = search.benchmark_provider._create_precompile_future(
+                "cfg", fake_compiled_fn
+            )
+
+        self.assertFalse(future.ok)
+
     def _run_autotuner_and_check_logging(
         self, search_factory: Callable[[object, tuple[object, ...]], BaseSearch]
     ) -> None:

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -164,23 +164,6 @@ class TestAutotuneIgnoreErrors(TestCase):
         self.assertEqual(result, float("inf"))
         self.assertEqual(search._autotune_metrics.num_compile_failures, 1)
 
-    def test_cuda_oom_skips_config(self):
-        settings = Settings(
-            autotune_ignore_errors=False,
-            autotune_log_level=logging.CRITICAL,
-        )
-        search = self._make_search(settings)
-
-        def bad_fn(*_args):
-            raise torch.cuda.OutOfMemoryError("CUDA out of memory")
-
-        with patch("torch.accelerator.synchronize", autospec=True) as sync:
-            sync.return_value = None
-            result = search.benchmark_provider._benchmark_function("cfg", bad_fn)
-
-        self.assertEqual(result, float("inf"))
-        self.assertEqual(search._autotune_metrics.num_compile_failures, 1)
-
     def test_ignore_errors_skips_logging_and_raise(self):
         settings = Settings(
             autotune_ignore_errors=True,
@@ -456,6 +439,7 @@ class TestAutotuneIgnoreErrors(TestCase):
             RuntimeError("out of resource: shared memory"),
             RuntimeError("too many resources requested for launch"),
             RuntimeError("CUDA error: out of memory"),
+            RuntimeError("[CUDA]: out of memory"),
             RuntimeError("failed to translate module to LLVM IR"),
         ]
         for err in expected_errors:


### PR DESCRIPTION
## Summary
`_prepare_precompiler_for_fork` runs in the parent process before forking, but exceptions from it were not caught in `PrecompileFuture.create`. 

This meant errors like OOM during fork precompiler setup, e.g. `torch.cuda.OutOfMemoryError`, would crash the entire autotuning run even if `HELION_AUTOTUNE_IGNORE_ERRORS=1`.

This PR applies the same classify-and-skip logic already used in the benchmark path (`_benchmark_function`):
    - **Expected errors** (OOM, OutOfResources, shared memory, LLVM translation, etc.) → skip the config
    - **Unrecoverable errors** (illegal memory access) → always raise, GPU context is corrupted
    - **Unexpected errors** → raise unless `autotune_ignore_errors` is set

  ## Tests
  - `test_fork_precompile_expected_errors_skip_config` — loops over OOM, OutOfResources, and string-matched expected errors; all return skip futures
  - `test_fork_precompile_illegal_memory_access_raises` — unrecoverable error raises even with `ignore_errors=True`
  - `test_fork_precompile_unexpected_error_skipped_with_ignore_errors` — unknown error skipped when `ignore_errors=True`
