### PR TITLE
[Pallas] Tighten _pallas_build_pipeline_specs block_spec_info to non-Optional

### DIFF
--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -417,7 +417,7 @@ def _pallas_build_pipeline_specs(
     args: tuple[object, ...],
     tensor_arg_indices: list[int],
     output_indices: list[int],
-    block_spec_info: _BlockSpecInfo | None,
+    block_spec_info: _BlockSpecInfo,
     pipeline_arg_indices: list[int] | None,
     output_only_indices: list[int] | None = None,
     smem_arg_indices: list[int] | None = None,
@@ -430,9 +430,6 @@ def _pallas_build_pipeline_specs(
     group offset tables) are placed in SMEM so dynamic scalar reads don't
     require 128-lane alignment proofs against a small VMEM ref.
     """
-    assert block_spec_info is not None, (
-        "pipeline launchers require block_spec_info from codegen"
-    )
     pipeline_set = set(pipeline_arg_indices or [])
     smem_set = set(smem_arg_indices or [])
     all_positions = sorted(set(tensor_arg_indices) | set(output_only_indices or []))
@@ -1080,6 +1077,9 @@ def default_pallas_pipeline_launcher(
                     pltpu.VMEM(shape, jnp_dtype)  # pyrefly: ignore[bad-argument-type]
                 )
 
+        assert _block_spec_info is not None, (
+            "emit_pipeline launcher requires _block_spec_info from codegen"
+        )
         in_specs_list, out_specs = _pallas_build_pipeline_specs(
             pl,
             jnp,
@@ -1248,6 +1248,9 @@ def default_pallas_fori_launcher(
         # Build in_specs/out_specs: proper BlockSpecs for outer grid dims,
         # HBM refs for tensors used in the fori_loop body (DMA handles tiling).
         _fori_pipeline_indices = kwargs.get("_pipeline_arg_indices")
+        assert _block_spec_info is not None, (
+            "fori_loop launcher requires _block_spec_info from codegen"
+        )
         in_specs_list, out_specs = _pallas_build_pipeline_specs(
             pl,
             jnp,

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -420,26 +420,33 @@ def _pallas_build_pipeline_specs(
     block_spec_info: _BlockSpecInfo | None,
     pipeline_arg_indices: list[int] | None,
     output_only_indices: list[int] | None = None,
+    smem_arg_indices: list[int] | None = None,
 ) -> tuple[list[object], object]:
     """Build in/out specs for pipeline launchers.
 
     Pipeline-body tensors (listed in *pipeline_arg_indices*) get HBM refs.
     All other tensors get proper BlockSpecs for automatic VMEM prefetch.
+    Tensors in *smem_arg_indices* (only ever accessed by scalar index, e.g.
+    group offset tables) are placed in SMEM so dynamic scalar reads don't
+    require 128-lane alignment proofs against a small VMEM ref.
     """
+    assert block_spec_info is not None, (
+        "pipeline launchers require block_spec_info from codegen"
+    )
     pipeline_set = set(pipeline_arg_indices or [])
+    smem_set = set(smem_arg_indices or [])
     all_positions = sorted(set(tensor_arg_indices) | set(output_only_indices or []))
     arg_to_tpos = {orig: tpos for tpos, orig in enumerate(all_positions)}
 
     def _spec_for(idx: int) -> object:
         if idx in pipeline_set:
             return pl.BlockSpec(memory_space=pltpu.HBM)  # type: ignore[union-attr]
-        if block_spec_info is not None:
-            t = args[idx]
-            assert isinstance(t, torch.Tensor)
-            return _pallas_make_block_spec(
-                pl, jnp, pltpu, t, block_spec_info[arg_to_tpos[idx]]
-            )
-        return pl.BlockSpec(memory_space=pl.ANY)  # type: ignore[union-attr]
+        tpos = arg_to_tpos[idx]
+        t = args[idx]
+        assert isinstance(t, torch.Tensor)
+        return _pallas_make_block_spec(
+            pl, jnp, pltpu, t, block_spec_info[tpos], tpos in smem_set
+        )
 
     in_specs = [_spec_for(idx) for idx in tensor_arg_indices]
     out_specs_list = [_spec_for(idx) for idx in output_indices]
@@ -1016,6 +1023,7 @@ def default_pallas_pipeline_launcher(
     _scratch_shapes: list[tuple[tuple[int, ...], str]] | None = None,
     _pipeline_arg_indices: list[int] | None = None,
     _ds_pad_dims: list[tuple[int, int, int]] | None = None,
+    _smem_arg_indices: list[int] | None = None,
     **kwargs: object,
 ) -> object:
     """Launcher for Pallas kernels using PrefetchScalarGridSpec with scratch memory.
@@ -1083,6 +1091,7 @@ def default_pallas_pipeline_launcher(
             _block_spec_info,
             _pipeline_arg_indices,
             output_only_indices,
+            smem_arg_indices=_smem_arg_indices,
         )
 
         _pipeline_set = set(_pipeline_arg_indices or [])
@@ -1097,6 +1106,7 @@ def default_pallas_pipeline_launcher(
             arg_to_tensor_pos,
             n_extra_refs=len(scratch_shapes),
             skip_inplace_copy=_pipeline_set,
+            _smem_arg_indices=_smem_arg_indices,
         )
 
         out_shape_arg = out_shapes if len(out_shapes) > 1 else out_shapes[0]
@@ -1180,6 +1190,7 @@ def default_pallas_fori_launcher(
     _block_spec_info: _BlockSpecInfo | None = None,
     _scratch_shapes: list[tuple[tuple[int, ...], str | None, str]] | None = None,
     _ds_pad_dims: list[tuple[int, int, int]] | None = None,
+    _smem_arg_indices: list[int] | None = None,
     **kwargs: object,
 ) -> object:
     """Launcher for Pallas kernels using fori_loop with manual DMA.
@@ -1248,6 +1259,7 @@ def default_pallas_fori_launcher(
             _block_spec_info,
             _fori_pipeline_indices,  # type: ignore[arg-type]
             output_only_indices,
+            smem_arg_indices=_smem_arg_indices,
         )
 
         _fori_pipeline_set = set(_fori_pipeline_indices or [])  # type: ignore[arg-type]
@@ -1262,6 +1274,7 @@ def default_pallas_fori_launcher(
             arg_to_tensor_pos,
             n_extra_refs=len(scratch_shapes),
             skip_inplace_copy=_fori_pipeline_set,
+            _smem_arg_indices=_smem_arg_indices,
         )
 
         out_shape_arg = out_shapes if len(out_shapes) > 1 else out_shapes[0]

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -235,6 +235,22 @@ def pallas_two_pass_reduction(x: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_scalar_lookup_in_pipeline(
+    biases: torch.Tensor, x: torch.Tensor, out: torch.Tensor
+) -> torch.Tensor:
+    """Per-program scalar lookup from a small 1-D table combined with an
+    inner pipeline loop. Each of the ``G`` outer programs reads its own
+    ``biases[g]`` and broadcasts it across the inner pipeline body."""
+    G = biases.size(0)
+    M = x.size(0)
+    for g in hl.grid(G):
+        b = biases[g]
+        for tile_m in hl.tile(M):
+            out[tile_m] = x[tile_m] + b
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_inner_loop_add_with_scalar_access(
     x: torch.Tensor, y: torch.Tensor
 ) -> torch.Tensor:
@@ -705,6 +721,45 @@ class TestPallas(TestCase):
         torch.testing.assert_close(result, args[0] + args[1])
         # out is output-only, excluded from pallas_call inputs
         self.assertIn("_inplace_indices=[]", code)
+
+    def _check_scalar_lookup_in_pipeline(self, loop_type: str) -> None:
+        torch.manual_seed(0)
+        x = torch.randn(256, device=DEVICE, dtype=torch.float32)
+        # Run with several distinct bias vectors; each invocation's
+        # observable output is the last program's read of biases[-1], so a
+        # fresh value of biases[-1] per call exercises the dynamic SMEM
+        # load with different runtime values rather than a fixed offset.
+        for biases_list in (
+            [1.0, 2.0, 3.0, 4.0],
+            [-7.5, 11.0, 0.0, 1234.5],
+            [100.0, -50.0, 25.0, -12.5],
+        ):
+            biases = torch.tensor(biases_list, device=DEVICE, dtype=torch.float32)
+            out = torch.zeros_like(x)
+            _code, result = code_and_output(
+                pallas_scalar_lookup_in_pipeline,
+                (biases, x, out),
+                block_sizes=[64],
+                pallas_loop_type=loop_type,
+            )
+            torch.testing.assert_close(
+                result, x + biases[-1].item(), rtol=1e-5, atol=1e-5
+            )
+
+    def test_scalar_lookup_with_emit_pipeline(self) -> None:
+        """``hl.grid`` outer + scalar lookup ``biases[g]`` + inner pipeline body
+        runs end-to-end under ``pallas_loop_type='emit_pipeline'``.
+
+        The scalar load index is per-program runtime, so ``biases`` has to
+        live in SMEM — Mosaic rejects a dynamic vector load from a small
+        VMEM ref because dim 0 isn't provably aligned to 128 lanes.
+        """
+        self._check_scalar_lookup_in_pipeline("emit_pipeline")
+
+    def test_scalar_lookup_with_fori_loop(self) -> None:
+        """Same kernel as :meth:`test_scalar_lookup_with_emit_pipeline`
+        compiled under ``pallas_loop_type='fori_loop'``."""
+        self._check_scalar_lookup_in_pipeline("fori_loop")
 
     def test_two_pass_reduction_emit_pipeline(self) -> None:
         """Two inner reduction loops over the same dim compile and run under


### PR DESCRIPTION
## Summary

Stacks on #2143.

PR #2143 added a runtime assert inside `_pallas_build_pipeline_specs` to require `block_spec_info` to be non-`None`, but kept the parameter typed as `_BlockSpecInfo | None`. This PR tightens the helper signature to `_BlockSpecInfo` (non-Optional) and moves the runtime check up to each launcher's call site.

The launcher kwargs themselves keep `_block_spec_info: _BlockSpecInfo | None = None` because every other `_*` launcher kwarg follows the same default-`None` convention; making this one required would break that pattern (and risk older cached generated kernel files that don't pass it).

So: launcher kwargs stay convention-compliant, the internal helper has the strict contract it actually needs, and the soft-vs-strict boundary lives at one place — the launcher's call site.

## Test plan

CI already covered by #2143. Locally re-ran the full Pallas test sweep:
- `test_pallas.py`: 82 passed, 5 xfailed (no regression)
- `test_examples.py`: 50 passed, 9 skipped, 31 xfailed (no regression)
