### PR TITLE
[docs] Add dashboard link, LLM autotuner docs, remove past events

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 # Events
 
-- **April 7, 2026**: Helion General Availability Launch, [Helion 1.0: A High-Level DSL for Performance-Portable Kernels](https://pytorchconferenceeu2026.sched.com/event/2Himi/helion-10-a-high-level-dsl-for-performance-portable-kernels-oguz-ulgen-meta) @ PyTorch Conference Europe 2026, Paris, France
-- **April 7, 2026**: Meetup, [Meet the Developers of Helion](https://pytorchconferenceeu2026.sched.com/event/2HioG/meet-the-developers-of-helion) @ PyTorch Conference Europe 2026, Paris, France
 - **June 15, 2026**: Helion Tutorial, [Writing Performance-Portable Kernels Simplified with Helion](https://pldi26.sigplan.org/details/pldi-2026-tutorials/1/Writing-Performance-Portable-Kernels-Simplified-with-Helion) @ PLDI 2026, Boulder, CO
 
 # About

--- a/docs/api/autotuner.md
+++ b/docs/api/autotuner.md
@@ -54,6 +54,88 @@ traversal to focus search on parameters the surrogate model has identified as im
    :show-inheritance:
 ```
 
+### LLM-Guided Search
+
+{py:class}`~helion.autotuner.llm_search.LLMGuidedSearch` uses a large language model to
+iteratively propose kernel configurations. It sends the kernel source, config space, GPU
+hardware info, and benchmark results to the LLM, which suggests promising configurations
+across multiple refinement rounds.
+
+```{eval-rst}
+.. automodule:: helion.autotuner.llm_search
+   :members:
+```
+
+#### LLM Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `HELION_LLM_PROVIDER` | | LLM provider: `anthropic` or `openai` |
+| `HELION_LLM_MODEL` | | Model name (e.g. `claude-opus-4-7`, `gpt-4o`) |
+| `HELION_LLM_API_KEY` | | API key (falls back to `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`) |
+| `HELION_LLM_API_BASE` | | Custom API base URL |
+| `HELION_LLM_COMPILE_TIMEOUT_S` | `15` | Compile timeout (seconds) for LLM-proposed configs |
+| `HELION_LLM_CA_BUNDLE` | | Custom CA bundle path (for corporate proxies that do TLS inspection) |
+| `HELION_LLM_CLIENT_CERT` | | Client certificate path (for proxies requiring mutual TLS) |
+| `HELION_LLM_CLIENT_KEY` | | Client key path (for proxies requiring mutual TLS) |
+
+The proxy/TLS variables are only needed in corporate environments where a proxy intercepts
+HTTPS traffic. Most users connecting directly to the LLM API can ignore them.
+
+### LLM-Seeded Search (Hybrid)
+
+{py:class}`~helion.autotuner.llm_seeded_lfbo.LLMSeededSearch` is a two-stage hybrid approach:
+
+1. **Stage 1 (LLM)**: Run LLM-guided search for a configurable number of rounds to find good
+   initial configs.
+2. **Stage 2 (Surrogate)**: Run a non-LLM search algorithm (default: `LFBOTreeSearch`),
+   seeded with the best LLM config and trained on all LLM benchmark results.
+
+This combines the LLM's ability to make informed initial guesses with the surrogate model's
+efficient local search.
+
+{py:class}`~helion.autotuner.llm_seeded_lfbo.LLMSeededLFBOTreeSearch` is a convenience subclass
+that locks stage 2 to `LFBOTreeSearch`.
+
+```{eval-rst}
+.. automodule:: helion.autotuner.llm_seeded_lfbo
+   :members:
+```
+
+#### Hybrid Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `HELION_HYBRID_SECOND_STAGE_ALGORITHM` | `LFBOTreeSearch` | Override the second-stage search algorithm |
+| `HELION_HYBRID_LLM_MAX_ROUNDS` | *(effort-dependent)* | Override the number of LLM rounds in stage 1 |
+
+To use the LLM-guided autotuner, set the `HELION_AUTOTUNER` environment variable:
+
+```bash
+# Pure LLM-guided search
+export HELION_AUTOTUNER=LLMGuidedSearch
+
+# LLM-seeded hybrid (recommended)
+export HELION_AUTOTUNER=LLMSeededLFBOTreeSearch
+```
+
+#### Example: Using Claude as the LLM provider
+
+```bash
+export HELION_AUTOTUNER=LLMSeededLFBOTreeSearch
+export HELION_LLM_PROVIDER=anthropic
+export HELION_LLM_MODEL=claude-opus-4-7
+export HELION_LLM_API_KEY=your-key-here
+```
+
+Then run your kernel as usual — the autotuner will use Claude to propose initial configs
+before handing off to the surrogate-based search:
+
+```python
+out = matmul(torch.randn([2048, 2048], device="cuda"),
+             torch.randn([2048, 2048], device="cuda"))
+```
+
 ### DE Surrogate Hybrid
 
 ```{eval-rst}

--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -334,7 +334,7 @@ Built-in values for ``HELION_AUTOTUNER`` include ``"LFBOTreeSearch"`` (default),
 | ``HELION_ALLOW_WARP_SPECIALIZE`` | ``allow_warp_specialize`` | Permit warp-specialized code generation for ``tl.range``. |
 | ``HELION_DEBUG_DTYPE_ASSERTS`` | ``debug_dtype_asserts`` | Inject dtype assertions after each lowering step. |
 | ``HELION_INTERPRET`` | ``ref_mode`` | Run kernels through the reference interpreter when set to ``1`` (maps to ``RefMode.EAGER``). |
-| ``HELION_AUTOTUNER`` | ``default_autotuner_fn`` | Select which autotuner implementation to instantiate. Default is ``"LFBOTreeSearch"``. Other options: ``"LFBOPatternSearch"``, ``"DESurrogateHybrid"``, ``"PatternSearch"``, ``"DifferentialEvolutionSearch"``, ``"FiniteSearch"``, ``"RandomSearch"``. |
+| ``HELION_AUTOTUNER`` | ``default_autotuner_fn`` | Select which autotuner implementation to instantiate. Default is ``"LFBOTreeSearch"``. Other options: ``"LFBOPatternSearch"``, ``"DESurrogateHybrid"``, ``"PatternSearch"``, ``"DifferentialEvolutionSearch"``, ``"FiniteSearch"``, ``"RandomSearch"``, ``"LLMGuidedSearch"``, ``"LLMSeededSearch"``, ``"LLMSeededLFBOTreeSearch"``. See :doc:`autotuner` for LLM configuration. |
 | ``HELION_BACKEND`` | ``backend`` | Code generation backend (``"triton"`` (default), ``"pallas"``, ``"cute"``, ``"tileir"``). |
 
 ## See Also

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -178,6 +178,7 @@ html_sidebars = {
     "examples/index": [],
     "installation": [],
     "deployment_autotuning": [],
+    "tileir_backend": [],
     "events": [],
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ Tutorials <helion_tutorials>
 Deployment <deployment_autotuning>
 TileIR Backend <tileir_backend>
 events
+Dashboard <https://helionlang.com/dashboard/>
 ```
 
 **Helion** is a Python-embedded domain-specific language (DSL) for


### PR DESCRIPTION
- Add performance dashboard link to the docs navigation sidebar
- Document LLM-guided (`LLMGuidedSearch`) and LLM-seeded (`LLMSeededLFBOTreeSearch`) autotuner algorithms with env var reference tables and a Claude usage example
- Remove past PyTorch Conference Europe 2026 events from README