### PR TITLE
Add offsets kwarg to hl.rand for explicit Philox offsets

### DIFF
--- a/helion/language/random_ops.py
+++ b/helion/language/random_ops.py
@@ -325,10 +325,12 @@ def decompose_rand(
     shape: list[int | torch.SymInt],
     *,
     seed: int | torch.SymInt | torch.Tensor,
+    offsets: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    env = CompileEnvironment.current()
-    offset = _explicit_offset_from_shape(shape, device=env.device)
-    return _philox_rand_from_seed_and_offset(seed, offset)
+    if offsets is None:
+        env = CompileEnvironment.current()
+        offsets = _explicit_offset_from_shape(shape, device=env.device)
+    return _philox_rand_from_seed_and_offset(seed, offsets)
 
 
 def decompose_randint(
@@ -567,6 +569,17 @@ def _resolve_seed_desc(
     )
 
 
+def _resolve_offsets_desc(
+    flat_args: tuple[object, ...],
+    desc: _ArgDesc | None,
+) -> torch.Tensor | None:
+    if desc is None:
+        return None
+    value = _resolve_rewrite_arg(flat_args, desc)
+    assert isinstance(value, torch.Tensor)
+    return value
+
+
 def _random_rewrite_nodes(graph: torch.fx.Graph) -> list[Node]:
     targets = (
         rand,
@@ -593,15 +606,23 @@ def rewrite_implicit_random_ops(graph: torch.fx.Graph) -> None:
             shape_arg = node.args[0]
             descriptors, shape_desc = _shape_rewrite_desc(shape_arg)
             seed_desc = _add_rewrite_desc(descriptors, node.args[1])
+            offsets_arg = node.args[3]
+            offsets_desc: _ArgDesc | None = (
+                _add_rewrite_desc(descriptors, offsets_arg)
+                if offsets_arg is not None
+                else None
+            )
 
             def helper(
                 *flat_args: object,
                 shape_desc: tuple[_ArgDesc, ...] = tuple(shape_desc),
                 seed_desc: _ArgDesc = seed_desc,
+                offsets_desc: _ArgDesc | None = offsets_desc,
             ) -> torch.Tensor:
                 shape = [_resolve_shape_desc(flat_args, desc) for desc in shape_desc]
                 seed = _resolve_seed_desc(flat_args, seed_desc)
-                return decompose_rand(shape, seed=seed)
+                offsets = _resolve_offsets_desc(flat_args, offsets_desc)
+                return decompose_rand(shape, seed=seed, offsets=offsets)
 
             replacement = _trace_rewrite_subgraph(graph, node, helper, descriptors)
         elif node.target is randint:
@@ -715,17 +736,25 @@ def rand(
     shape: list[object],
     seed: int | torch.Tensor,
     device: torch.device | None = None,
+    offsets: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     hl.rand provides a Philox-based pseudorandom number generator (PRNG) that
     operates independently of PyTorch's global random seed. Instead, it
-    requires an explicit seed argument. Offsets are derived from the full
-    logical sizes of the tiles specified in the shape argument.
+    requires an explicit seed argument. By default, offsets are derived from
+    the full logical sizes of the tiles specified in the shape argument. An
+    explicit ``offsets`` tensor may be supplied to bypass the implicit offset
+    computation; the output will then have ``offsets.shape`` and ``shape`` is
+    ignored (an empty list ``[]`` is fine).
 
     Args:
-        shape: A list of sizes for the output tensor
+        shape: A list of sizes for the output tensor. Ignored when ``offsets``
+            is provided.
         seed: A single element int64 tensor or int literal
         device: Device must match the current compile environment device
+        offsets: Optional explicit int64 offset tensor fed directly into the
+            philox RNG. When provided, the output shape equals
+            ``offsets.shape``.
 
     Returns:
         torch.Tensor: A device tensor of float32 dtype filled with uniform
@@ -741,6 +770,20 @@ def rand(
                 for tile_m in hl.tile(m):
                     output[tile_m] = hl.rand([tile_m], seed=42)
                 return output
+
+        With explicit offsets (e.g. spaced out so sibling streams may use
+        offsets ``+1`` and ``+2``):
+
+        .. code-block:: python
+
+            @helion.kernel
+            def spaced_rand_kernel(x: torch.Tensor) -> torch.Tensor:
+                output = torch.zeros_like(x)
+                (m,) = x.shape
+                for tile_m in hl.tile(m):
+                    base = hl.arange(tile_m).to(torch.int64) * 3
+                    output[tile_m] = hl.rand([], seed=42, offsets=base)
+                return output
     """
     raise NotInsideKernel
 
@@ -750,15 +793,28 @@ def _rand_fake(
     shape: list[int | torch.SymInt],
     seed: int | torch.Tensor,
     device: torch.device | None = None,
+    offsets: torch.Tensor | None = None,
 ) -> torch.Tensor:
     if not isinstance(shape, (list, tuple)):
         raise TypeError(f"Expected list[SymInt], got {type(shape).__name__}")
     env = CompileEnvironment.current()
+    rng_device = env.device if device is None else device
+    if offsets is not None:
+        if not isinstance(offsets, torch.Tensor):
+            raise TypeError(
+                f"Expected torch.Tensor for offsets, got {type(offsets).__name__}"
+            )
+        env.add_kernel_tensor_size(offsets.shape)
+        return torch.empty(
+            [*offsets.shape],
+            dtype=torch.float32,
+            device=rng_device,
+        )
     env.add_kernel_tensor_size(shape)
     return torch.empty(
         [*shape],
         dtype=torch.float32,
-        device=env.device if device is None else device,
+        device=rng_device,
     )
 
 
@@ -772,9 +828,12 @@ def _(
     shape: list[int | RefTile],
     seed: int | torch.Tensor,
     device: torch.device | None = None,
+    offsets: torch.Tensor | None = None,
 ) -> torch.Tensor:
     env = CompileEnvironment.current()
     rng_device = env.device if device is None else device
+    if offsets is not None:
+        return philox_rand_ref(seed, offsets).to(device=rng_device)
     processed_shape, offset = _ref_rng_shape_and_offset(shape, device=rng_device)
     return philox_rand_ref(seed, offset).reshape(processed_shape).to(device=rng_device)
 

--- a/test/test_random.py
+++ b/test/test_random.py
@@ -532,6 +532,68 @@ class TestRandom(RefEagerTestBase, TestCase):
             msg="Persistent and rolled reductions should produce identical results",
         )
 
+    @skipIfRefEager("compile_config is not supported in ref eager mode")
+    def test_hl_rand_with_explicit_offsets(self):
+        @helion.kernel(static_shapes=False, autotune_effort="none")
+        def rand_explicit_offsets_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
+            output = torch.zeros_like(x)
+            (m,) = x.shape
+            for tile_m in hl.tile(m):
+                idx = hl.tile_index(tile_m).to(torch.int64)
+                offsets = idx * 3
+                output[tile_m] = hl.rand([], seed=seed, offsets=offsets)
+            return output
+
+        x = torch.empty(256, device=DEVICE, dtype=torch.float32)
+        seed = 31337
+        code, compiled = _compile_once(
+            rand_explicit_offsets_kernel, (x, seed), block_sizes=[64]
+        )
+        out = compiled(x, seed)
+
+        ref_offsets = torch.arange(x.numel(), device=DEVICE, dtype=torch.int64) * 3
+        expected = _triton_rand_reference(seed, ref_offsets).reshape_as(x)
+        _assert_bitwise_equal_float(self, out, expected)
+        _assert_uses_philox(self, code)
+
+    @skipIfRefEager("compile_config is not supported in ref eager mode")
+    def test_hl_rand_offsets_independence(self):
+        """Two hl.rand calls with different offset expressions are different but deterministic."""
+
+        @helion.kernel(static_shapes=False, autotune_effort="none")
+        def rand_two_streams_kernel(
+            x: torch.Tensor, seed: int
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            out_a = torch.zeros_like(x)
+            out_b = torch.zeros_like(x)
+            (m,) = x.shape
+            for tile_m in hl.tile(m):
+                idx = hl.tile_index(tile_m).to(torch.int64)
+                out_a[tile_m] = hl.rand([], seed=seed, offsets=idx * 3)
+                out_b[tile_m] = hl.rand([], seed=seed, offsets=idx * 3 + 1)
+            return out_a, out_b
+
+        x = torch.empty(128, device=DEVICE, dtype=torch.float32)
+        seed = 4242
+        _code, compiled = _compile_once(
+            rand_two_streams_kernel, (x, seed), block_sizes=[32]
+        )
+        a, b = compiled(x, seed)
+        self.assertFalse(
+            torch.allclose(a, b),
+            "Different offset expressions should produce different outputs",
+        )
+        a2, b2 = compiled(x, seed)
+        _assert_bitwise_equal_float(self, a, a2)
+        _assert_bitwise_equal_float(self, b, b2)
+
+        ref_offsets_a = torch.arange(x.numel(), device=DEVICE, dtype=torch.int64) * 3
+        ref_offsets_b = ref_offsets_a + 1
+        expected_a = _triton_rand_reference(seed, ref_offsets_a).reshape_as(x)
+        expected_b = _triton_rand_reference(seed, ref_offsets_b).reshape_as(x)
+        _assert_bitwise_equal_float(self, a, expected_a)
+        _assert_bitwise_equal_float(self, b, expected_b)
+
     def test_hl_randint_1d(self):
         """Test hl.randint with 1D output."""
 
@@ -1014,6 +1076,46 @@ class TestRandomPhiloxParity(TestCase):
         compiled_out = compiled(x, seed)
         ref_out = randint_outer_loop_kernel_ref(x, seed)
         self.assertTrue(torch.equal(compiled_out.cpu(), ref_out.cpu()))
+
+    def test_hl_rand_explicit_offsets_ref_matches_triton(self):
+        seed = 12321
+        offsets = torch.arange(64, device=DEVICE, dtype=torch.int64) * 5 + 7
+        triton_out = _triton_rand_reference(seed, offsets)
+        ref_out = philox_rand_ref(seed, offsets)
+        _assert_bitwise_equal_float(self, triton_out, ref_out)
+
+    @skipIfRefEager("compile_config is not supported in ref eager mode")
+    def test_hl_rand_with_offsets_ref_mode_matches_compiled(self):
+        @helion.kernel(static_shapes=False, autotune_effort="none")
+        def rand_offsets_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
+            out = torch.zeros_like(x)
+            (m,) = x.shape
+            for tile_m in hl.tile(m):
+                idx = hl.tile_index(tile_m).to(torch.int64)
+                out[tile_m] = hl.rand([], seed=seed, offsets=idx * 3)
+            return out
+
+        @helion.kernel(
+            static_shapes=False,
+            autotune_effort="none",
+            ref_mode=helion.RefMode.EAGER,
+        )
+        def rand_offsets_kernel_ref(x: torch.Tensor, seed: int) -> torch.Tensor:
+            out = torch.zeros_like(x)
+            (m,) = x.shape
+            for tile_m in hl.tile(m):
+                idx = hl.tile_index(tile_m).to(torch.int64)
+                out[tile_m] = hl.rand([], seed=seed, offsets=idx * 3)
+            return out
+
+        x = torch.empty(192, device=DEVICE, dtype=torch.float32)
+        seed = 161803
+        _code, compiled = _compile_once(
+            rand_offsets_kernel, (x, seed), block_sizes=[32]
+        )
+        compiled_out = compiled(x, seed)
+        ref_out = rand_offsets_kernel_ref(x, seed)
+        _assert_bitwise_equal_float(self, compiled_out, ref_out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds an optional `offsets=` keyword argument to `hl.rand` so users can supply
their own int64 offset tensor. This mirrors Triton's `tl.rand(seed, offsets=...)` and lets kernels
control the deterministic Philox stream.

When `offsets` is provided:
- `shape` is ignored (pass `[]`); the output shape is `offsets.shape`.
- The offsets tensor is fed directly into `_philox_rand_from_seed_and_offset`,
  bypassing `_explicit_offset_from_shape`.
- Numerical output is bitwise-identical to `tl.rand(seed, offsets)`.

Backwards-compatible: existing call sites `hl.rand(shape, seed=...)` are
unchanged.

Fixes: #2147