### PR TITLE
[HostFunction] Extract `_parse_source` from `Hostfunction.__init__`

### DIFF
--- a/helion/_compiler/host_function.py
+++ b/helion/_compiler/host_function.py
@@ -73,6 +73,27 @@ class SymbolOrigin(NamedTuple):
 
 
 class HostFunction:
+    """Parsed and lowered representation of a @helion.kernel function.
+
+    Constructed once per specialization during BoundKernel initialization.
+    Parses kernel source into an ExtendedAST, then runs config-independent
+    frontend passes to produce a DeviceIR:
+
+      1. Static loop unrolling (pure AST rewrite)
+      2. Type propagation (annotates AST, builds origin tracking
+         and config spec)
+      3. Config spec finalization
+      4. Device IR lowering (traces annotated AST into FX graphs)
+
+    These passes share mutable state across this object and
+    CompileEnvironment; the config spec in particular accumulates
+    contributions from passes 2-4.
+
+    The DeviceIR is later consumed by generate_ast() once per Config
+    to produce backend-specific output code. Accessed by compiler
+    passes via HostFunction.current() (thread-local stack).
+    """
+
     def __init__(
         self,
         fn: types.FunctionType,

--- a/helion/_compiler/host_function.py
+++ b/helion/_compiler/host_function.py
@@ -95,28 +95,18 @@ class HostFunction:
                 source_indented = inspect.getsource(fn)
                 source = textwrap.dedent(source_indented)
                 self.column_offset: int = source_indented.index(source[0])
-                root = ast.parse(source)
-                assert isinstance(root, ast.Module)
-                function_defs = [
-                    stmt for stmt in root.body if isinstance(stmt, ast.FunctionDef)
-                ]
-                assert len(function_defs) == 1, (
-                    f"expected one function definition in parsed source, got "
-                    f"{[type(stmt).__name__ for stmt in root.body]}"
+
+                self.params: inspect.BoundArguments = inspect.signature(fn).bind(
+                    *fake_args
                 )
-                (root,) = function_defs
-                root = ast_extension.convert(root)
-                assert isinstance(root, ast.FunctionDef)
-                assert isinstance(root, ast_extension.ExtendedAST)
-                self.location = root._location
+                self.params.apply_defaults()
+
+                root: ast.FunctionDef = HostFunction._parse_source(source)
                 self.name: str = root.name
                 self.args: ast.arguments = root.args
                 self.body: list[ast.stmt] = root.body
-
-                self.params = inspect.signature(fn).bind(*fake_args)
-                self.params.apply_defaults()
-
-                HostFunction.validate_ast(root)
+                assert isinstance(root, ast_extension.ExtendedAST)
+                self.location = root._location
 
             from .device_ir import lower_to_device_ir
             from .static_loop_unroller import unroll_static_loops
@@ -153,6 +143,24 @@ class HostFunction:
         if torch.autograd.profiler._is_profiler_enabled:
             return env.shape_env.suppress_guards()
         return contextlib.nullcontext()
+
+    @staticmethod
+    def _parse_source(source: str) -> ast.FunctionDef:
+        """Parse dedented source into a validated ExtendedAST FunctionDef."""
+        root = ast.parse(source)
+        assert isinstance(root, ast.Module)
+        function_defs = [
+            stmt for stmt in root.body if isinstance(stmt, ast.FunctionDef)
+        ]
+        assert len(function_defs) == 1, (
+            f"expected one function definition in parsed source, got "
+            f"{[type(stmt).__name__ for stmt in root.body]}"
+        )
+        (root,) = function_defs
+        root = ast_extension.convert(root)
+        assert isinstance(root, ast.FunctionDef)
+        HostFunction.validate_ast(root)
+        return root
 
     @staticmethod
     def validate_ast(root: ast.FunctionDef) -> None:


### PR DESCRIPTION
Extracts the AST parsing logic from `HostFunction.__init__` into a dedicated static method, similar to `validate_ast`. This declutters the constructor so that attribute initialization is clearly separated from source parsing.