### PR TITLE
[Pallas] Rename pallas_loop_type "default" to "unroll"

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1716,7 +1716,7 @@ class PallasBackend(Backend):
                 launcher_args.append(f"_smem_arg_indices={smem_arg_indices!r}")
 
         # Pass scratch shapes for pipeline/fori_loop launcher
-        pallas_loop_type = config.get("pallas_loop_type", "default")
+        pallas_loop_type = config.get("pallas_loop_type", "unroll")
         if pallas_loop_type in ("emit_pipeline", "fori_loop"):
             scratch_shapes = [
                 (
@@ -1751,7 +1751,7 @@ class PallasBackend(Backend):
         """Return the launcher name to use based on ``pallas_loop_type``."""
         from ..autotuner.config_spec import VALID_PALLAS_LOOP_TYPES
 
-        pallas_loop_type = config.get("pallas_loop_type", "default")
+        pallas_loop_type = config.get("pallas_loop_type", "unroll")
         if pallas_loop_type not in VALID_PALLAS_LOOP_TYPES:
             raise ValueError(
                 f"Invalid pallas_loop_type {pallas_loop_type!r}. "

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -158,7 +158,7 @@ VALID_KEYS: frozenset[str] = frozenset(
         "epilogue_subtile",
     ]
 )
-VALID_PALLAS_LOOP_TYPES = ("default", "emit_pipeline", "fori_loop")
+VALID_PALLAS_LOOP_TYPES = ("unroll", "emit_pipeline", "fori_loop")
 VALID_PID_TYPES = ("flat", "xyz", "persistent_blocked", "persistent_interleaved")
 MIN_NUM_SM_MULTIPLIER = 1
 MAX_NUM_SM_MULTIPLIER = 128
@@ -543,7 +543,7 @@ class ConfigSpec:
             config.setdefault(key, fragment.default())
         if self.has_pallas_inner_loops:
             if self.has_pallas_symbolic_bounds:
-                # "default" uses Python range() which can't handle traced bounds.
+                # "unroll" uses Python range() which can't handle traced bounds.
                 # Between the remaining options, prefer "fori_loop": it handles
                 # both DMA-aligned and unaligned inner blocks, while
                 # "emit_pipeline" fails on unaligned dims.
@@ -889,7 +889,7 @@ class ConfigSpec:
         if self.has_pallas_inner_loops:
             choices = VALID_PALLAS_LOOP_TYPES
             if self.has_pallas_symbolic_bounds:
-                # Exclude "default" (uses Python range(), can't handle traced
+                # Exclude "unroll" (uses Python range(), can't handle traced
                 # bounds) and put "fori_loop" first: it handles both DMA-aligned
                 # and unaligned inner blocks, while "emit_pipeline" fails on
                 # unaligned dims.

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -238,12 +238,12 @@ def _(state: CodegenState) -> object:
     Otherwise falls through to the common ``ForLoopGraphInfo.codegen`` path.
     """
     config = state.config
-    pallas_loop_type = config.get("pallas_loop_type", "default")
+    pallas_loop_type = config.get("pallas_loop_type", "unroll")
     if pallas_loop_type == "emit_pipeline":
         return _codegen_emit_pipeline(state)
     if pallas_loop_type == "fori_loop":
         return _codegen_fori_loop(state)
-    # default: fall through to common codegen path
+    # unroll: fall through to common codegen path
     # pyrefly: ignore[bad-return]
     return state.get_graph(state.proxy_arg(0)).codegen(state)
 
@@ -252,7 +252,7 @@ def _(state: CodegenState) -> object:
 def _(state: CodegenState) -> None:
     """Emit inner stepped device loops for Pallas/TPU."""
     config = state.config
-    pallas_loop_type = config.get("pallas_loop_type", "default")
+    pallas_loop_type = config.get("pallas_loop_type", "unroll")
     if pallas_loop_type == "emit_pipeline":
         _codegen_emit_pipeline(state)
         return None

--- a/helion/language/creation_ops.py
+++ b/helion/language/creation_ops.py
@@ -162,7 +162,7 @@ def _full_codegen_pallas(state: CodegenState) -> ast.AST:
     from .._compiler.ast_extension import statement_from_string
 
     config = state.config
-    pallas_loop_type = config.get("pallas_loop_type", "default")
+    pallas_loop_type = config.get("pallas_loop_type", "unroll")
 
     if pallas_loop_type in ("emit_pipeline", "fori_loop"):
         fake_value = state.fake_value

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -821,8 +821,8 @@ class TestPallas(TestCase):
                 pallas_loop_type="pipeline",
             )
 
-    def test_attention_default_fp32(self) -> None:
-        """Test attention with default (for-loop) inner loop."""
+    def test_attention_unroll_fp32(self) -> None:
+        """Test attention with unroll (for-loop) inner loop."""
         query = torch.randn(1, 4, 32, 64, dtype=torch.float32, device=DEVICE)
         key = torch.randn(1, 4, 32, 64, dtype=torch.float32, device=DEVICE)
         val = torch.randn(1, 4, 32, 64, dtype=torch.float32, device=DEVICE)
@@ -1368,8 +1368,8 @@ class TestPallas(TestCase):
         self.assertGreaterEqual(code.count("jax.lax.fori_loop"), 2)
         torch.testing.assert_close(result, args[0] + args[1])
 
-    def test_default_loop_multidim_non_divisible(self) -> None:
-        """Default loop with 2D inner loop where both dims are non-divisible.
+    def test_unroll_loop_multidim_non_divisible(self) -> None:
+        """Unroll loop with 2D inner loop where both dims are non-divisible.
 
         Regression test: when an output tensor is padded on multiple dims,
         _pallas_apply_ds_padding must save the original tensor reference


### PR DESCRIPTION
## Summary

Pure rename of the `pallas_loop_type` value `"default"` → `"unroll"`. The old name was misleading: `"default"` referred specifically to the Python-`range()` unroll path, not "the default loop type" — `set_default` is already symbolic-bounds-aware and picks `"fori_loop"` for kernels that can't use `range()`. Calling the value `"unroll"` makes the name describe the behavior.

`VALID_PALLAS_LOOP_TYPES` keeps `"unroll"` at index 0, so `set_default`'s actual selection and the autotune-search starting point are unchanged. This is a no-op behavior-wise.

## Follow-ups (not this PR)

A future PR can flip the default to `"emit_pipeline"` once the codegen has a `has_pallas_dma_unaligned` signal (TODO at `config_spec.py:896`) so `set_default` can fall back to `"unroll"` / `"fori_loop"` for kernels emit_pipeline can't compile. That work should sit on top of #2093, which makes both inner-loop constructs tolerant of unaligned tensors via per-tensor pipelining.
