### PR TITLE
Remove redundant `m_i` update in example attention kernel

### DIFF
--- a/examples/attention.py
+++ b/examples/attention.py
@@ -84,7 +84,6 @@ def attention(
             p = p.to(v.dtype)
             acc = torch.baddbmm(acc, p, v)
             m_i = m_ij
-        m_i += torch.log2(l_i)
         acc = acc / l_i[:, :, None]
         out[tile_b, tile_m, :] = acc.to(out.dtype)
     return out.view(q_in.size())

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -310,7 +310,6 @@ def pallas_attention(
             p = p.to(v.dtype)
             acc = torch.baddbmm(acc, p, v)
             m_i = m_ij
-        m_i += torch.log2(l_i)
         acc = acc / l_i[:, :, None]
         out[tile_b, tile_m, :] = acc.to(out.dtype)
     return out.view(q_in.size())


### PR DESCRIPTION
Stacked PRs:
 * #2157
 * __->__#2156


--- --- ---

This is dead-code, there is no need to update `m_i` at the end of the loop. This is probably copy-pasta remnants from other attention variants, e.g. [here](https://github.com/pytorch/helion/blob/attn_pre_scale/examples/blackwell_attention.py#L203-L206) 