### PR TITLE
[Pallas] Tighten _check_dma_alignment + make "unroll" tests explicit

### DIFF
--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -1533,8 +1533,8 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     return None
 
 
-def _check_dma_alignment(vmem_shapes: list[tuple[int, ...]]) -> bool:
-    """Check if all VMEM buffer shapes satisfy TPU DMA alignment.
+def _check_dma_alignment(vmem_shape: tuple[int, ...]) -> bool:
+    """Check if a VMEM buffer shape satisfies TPU DMA alignment.
 
     DMA requires last dim % 128 == 0 and second-to-last dim % 8 == 0
     for 2D+ tensors. Note that these rules are currently optimized for
@@ -1546,15 +1546,10 @@ def _check_dma_alignment(vmem_shapes: list[tuple[int, ...]]) -> bool:
     emit_pipeline/fori_loop inner DMA does NOT have a ``block == tensor_dim``
     exception.
     """
-    for shape in vmem_shapes:
-        if len(shape) >= 2:
-            if shape[-1] % 128 != 0:
-                return False
-            if shape[-2] % 8 != 0:
-                return False
-        elif len(shape) == 1:
-            if shape[0] % 128 != 0:
-                return False
+    if len(vmem_shape) >= 2:
+        return vmem_shape[-1] % 128 == 0 and vmem_shape[-2] % 8 == 0
+    if len(vmem_shape) == 1:
+        return vmem_shape[0] % 128 == 0
     return True
 
 
@@ -1665,7 +1660,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     vmem_shapes = _compute_vmem_shapes(
         all_tensor_info, block_ids, slice_size_exprs, env, state
     )
-    use_dma = _check_dma_alignment(vmem_shapes)
+    use_dma = all(_check_dma_alignment(shape) for shape in vmem_shapes)
 
     # With DMA: tensors need HBM refs (no outer BlockSpec) because DMA
     # handles all slicing, and we register VMEM scratch buffers +

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -827,7 +827,12 @@ class TestPallas(TestCase):
         val = torch.randn(1, 4, 32, 64, dtype=torch.float32, device=DEVICE)
         args = (query, key, val)
 
-        _code, result = code_and_output(pallas_attention, args, block_sizes=[1, 32, 32])
+        _code, result = code_and_output(
+            pallas_attention,
+            args,
+            block_sizes=[1, 32, 32],
+            pallas_loop_type="unroll",
+        )
         ref = torch.nn.functional.scaled_dot_product_attention(
             query.float().cpu(), key.float().cpu(), val.float().cpu()
         ).to(device=DEVICE)
@@ -1383,6 +1388,7 @@ class TestPallas(TestCase):
             pallas_add_3d,
             args,
             block_sizes=[1, 8, 128],
+            pallas_loop_type="unroll",
         )
         torch.testing.assert_close(result, args[0] + args[1])
 


### PR DESCRIPTION
## Summary

Two small cleanups in service of eventually flipping the Pallas inner-loop default to `emit_pipeline`:

1. **`_check_dma_alignment` becomes per-shape.** Its only caller now invokes the predicate via `all(_check_dma_alignment(s) for s in vmem_shapes)`, which reads more clearly than the previous list-folding behavior buried inside the function. Behavior unchanged — observed `use_dma` is the same boolean for the same input.

2. **`test_attention_unroll_fp32` and `test_unroll_loop_multidim_non_divisible` pass `pallas_loop_type="unroll"` explicitly.** Both have "unroll" in their name and docstring but never requested it; they were silently relying on `unroll` being whatever `set_default` happens to pick. Make the contract explicit so the tests still exercise the unroll path if `set_default`'s choice ever changes.
