### PR TITLE
[Autotuner] Fix crash when autotuner_min exceeds max_size

### DIFF
--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -857,6 +857,7 @@ class ConfigSpec:
             min_block = min(min_block, default)
             if min_block >= 2:
                 min_block = 1 << (min_block.bit_length() - 1)
+                min_block = min(min_block, spec.max_size)
                 spec.autotuner_min = assert_integer_power_of_two(
                     max(min_block, spec.autotuner_min)
                 )

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -2044,6 +2044,21 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             encoded = fragment.encode(value)
             self.assertEqual(len(encoded), dim)
 
+    def test_block_size_fragment_autotuner_min_clamp(self):
+        """random_config() must not crash when autotuner_min > max_size."""
+        from examples.attention import attention
+
+        q, k, v = [
+            torch.randn(4, 48, 128, 128, dtype=torch.bfloat16, device=DEVICE)
+            for _ in range(3)
+        ]
+        bound = attention.bind((q, k, v))
+        config_spec = bound.config_spec
+        config_spec.raise_grid_block_minimums()
+        gen = ConfigGeneration(config_spec)
+        config = gen.random_config()
+        self.assertEqual(config["block_sizes"][0], 1)
+
     def test_autotune_benchmark_fn(self) -> None:
         """Test that custom benchmark function is used during rebenchmarking."""
         # Track benchmark function calls


### PR DESCRIPTION
Fixes #2176

- `raise_grid_block_minimums()` can set `autotuner_min` above a block dimension's `max_size`, producing `BlockSizeFragment(low=2, high=1)` which crashes with `ValueError: empty range in randrange(1, 1)`
- Reproduces on attention with tritonbench shape `(4, 48, 128, 128)` where the batch block dim has `max_size=1` but `autotuner_min` gets raised to 2
- Fix: clamp `min_block` to `max_size` in `raise_grid_block_minimums()`

