### PR TITLE
Fix attention benchmark accuracy

### DIFF
--- a/examples/attention.py
+++ b/examples/attention.py
@@ -72,7 +72,8 @@ def attention(
         q = q_view[tile_b, tile_m, :] * qk_scale
         for tile_n in hl.tile(v_view.size(1)):
             k = k_view[tile_b, :, tile_n]
-            qk = torch.bmm(q, k)
+            # Keep scores in fp32 to match SDPA tolerances on bf16/fp16 inputs.
+            qk = hl.dot(q, k, out_dtype=torch.float32)
             m_ij = torch.maximum(m_i, torch.amax(qk, -1))
             qk = qk - m_ij[:, :, None]
             p = torch.exp2(qk)

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -581,7 +581,17 @@ def _(
         )
     else:
         # For non-FP8 tensors, use regular matmul
-        result = torch.mm(mat1, mat2, out_dtype=resolved_out_dtype)
+        if mat1.ndim == 3 or mat2.ndim == 3:
+            mat1_batched = mat1 if mat1.ndim == 3 else mat1.unsqueeze(0)
+            mat2_batched = mat2 if mat2.ndim == 3 else mat2.unsqueeze(0)
+            batch = max(mat1_batched.shape[0], mat2_batched.shape[0])
+            result = torch.bmm(
+                mat1_batched.expand(batch, -1, -1),
+                mat2_batched.expand(batch, -1, -1),
+                out_dtype=resolved_out_dtype,
+            )
+        else:
+            result = torch.mm(mat1, mat2, out_dtype=resolved_out_dtype)
 
     if acc is not None:
         return acc + result

--- a/test/test_dot.py
+++ b/test/test_dot.py
@@ -336,6 +336,32 @@ class TestDot(RefEagerTestBase, TestCase):
         expected = torch.bmm(A, B).to(result.dtype) * 2
         torch.testing.assert_close(result, expected, atol=1e-2, rtol=1e-2)
 
+    @skipIfNotTriton("3D hl.dot regression targets Triton and ref eager")
+    def test_hl_dot_3d_out_dtype(self):
+        @helion.kernel(
+            config=helion.Config(block_sizes=[1, 16, 16]),
+            static_shapes=True,
+            dot_precision=get_test_dot_precision(),
+        )
+        def bmm(A: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
+            b, m, k = A.size()
+            _, _, n = B.size()
+            out = torch.empty([b, m, n], device=A.device, dtype=torch.float32)
+            for tile_b, tile_m, tile_n in hl.tile([b, m, n]):
+                out[tile_b, tile_m, tile_n] = hl.dot(
+                    A[tile_b, tile_m, :],
+                    B[tile_b, :, tile_n],
+                    out_dtype=torch.float32,
+                )
+            return out
+
+        A = torch.randn([2, 32, 24], device=DEVICE, dtype=torch.bfloat16)
+        B = torch.randn([2, 24, 16], device=DEVICE, dtype=torch.bfloat16)
+
+        _, result = code_and_output(bmm, (A, B))
+        expected = torch.bmm(A, B, out_dtype=torch.float32)
+        torch.testing.assert_close(result, expected, atol=1e-2, rtol=1e-2)
+
     def _assert_warning_in_stderr(
         self, kernel, args, expected_result, warning_str, *, atol=1e-2, rtol=1e-2
     ):


### PR DESCRIPTION
Fix attention benchmark accuracy on CI with hl.dot by keeping output in fp32. We do the same in blackwell_attention: https://github.com/pytorch/helion/blob/97acc41612fd7754bf6f5a69d8e60968d67a1a4c/examples/blackwell_attention.py#L159 
Fix interpret mode also.  
