### PR TITLE
[Pallas] Emit offset/indices at inner-loop body prologue

### DIFF
--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -561,9 +561,11 @@ def _emit_inner_loop_offset_indices(
     strategy: object,
     block_ids: list[int],
     block_size_vars: list[str],
+    begin_exprs: list[str],
+    iter_step_exprs: list[str],
+    loop_index_exprs: list[str],
     env: CompileEnvironment,
     body_stmts: list[ast.AST],
-    offset_expr_fn: Callable[[int, str], str],
 ) -> None:
     """Emit ``offset_<bid> = …`` and ``indices_<bid> = …`` at the inner-loop
     body prologue, using the canonical names from ``strategy``.
@@ -575,9 +577,10 @@ def _emit_inner_loop_offset_indices(
     ``dce=True``, so unused emissions are pruned downstream.
 
     Args:
-        offset_expr_fn: Given ``(block_id_index, block_size_var)``, returns a
-            string expression for the absolute start of the current iteration
-            (e.g. ``"(begin) + _j * (step)"``).
+        loop_index_exprs: Per-block-id expression for the inner-loop iteration
+            index (``_pipeline_indices[i]`` for emit_pipeline; the fori_loop
+            variable like ``_j`` for fori_loop).  Combined with ``begin_exprs``
+            and ``iter_step_exprs`` to form the absolute start of the tile.
     """
     for i, bid in enumerate(block_ids):
         offset_name = strategy.offset_var(bid)  # type: ignore[attr-defined]
@@ -588,7 +591,8 @@ def _emit_inner_loop_offset_indices(
         body_stmts.extend(
             [
                 statement_from_string(
-                    f"{offset_name} = {offset_expr_fn(i, block_size_vars[i])}"
+                    f"{offset_name} = ({begin_exprs[i]}) + "
+                    f"({loop_index_exprs[i]}) * ({iter_step_exprs[i]})"
                 ),
                 statement_from_string(f"{index_name} = {idx_expr}"),
             ]
@@ -1482,11 +1486,11 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         strategy,
         block_ids,
         block_size_vars,
+        begin_exprs,
+        iter_step_exprs,
+        [f"_pipeline_indices[{i}]" for i in range(len(block_ids))],
         env,
         body_stmts,
-        offset_expr_fn=lambda i, bs: (
-            f"({begin_exprs[i]}) + _pipeline_indices[{i}] * ({iter_step_exprs[i]})"
-        ),
     )
     # Set up mask variables for inner-loop block_ids (non-divisible bounds).
     _setup_inner_loop_masks(
@@ -1771,11 +1775,11 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         strategy,
         block_ids,
         block_size_vars,
+        begin_exprs,
+        iter_step_exprs,
+        dim_idx_exprs,
         env,
         body_stmts,
-        offset_expr_fn=lambda i, bs: (
-            f"({begin_exprs[i]}) + ({dim_idx_exprs[i]}) * ({iter_step_exprs[i]})"
-        ),
     )
     # Set up mask variables for inner-loop block_ids (non-divisible bounds).
     _setup_inner_loop_masks(

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -1445,16 +1445,16 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     for i, bid in enumerate(block_ids):
         offset_name = strategy.offset_var(bid)
         index_name = strategy.index_var(bid)
+        idx_expr = env.backend.loop_index_expr(
+            offset_name, block_size_vars[i], env.index_type(), axis=0
+        )
         body_stmts.extend(
             [
                 statement_from_string(
                     f"{offset_name} = ({begin_exprs[i]}) + "
                     f"_pipeline_indices[{i}] * ({iter_step_exprs[i]})"
                 ),
-                statement_from_string(
-                    f"{index_name} = {offset_name} + "
-                    f"jnp.arange({block_size_vars[i]}, dtype=jnp.int32)"
-                ),
+                statement_from_string(f"{index_name} = {idx_expr}"),
             ]
         )
     # Set up mask variables for inner-loop block_ids (non-divisible bounds).

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -556,6 +556,45 @@ def _read_final_loop_state(
     return final_results
 
 
+def _emit_inner_loop_offset_indices(
+    state: CodegenState,
+    strategy: object,
+    block_ids: list[int],
+    block_size_vars: list[str],
+    env: CompileEnvironment,
+    body_stmts: list[ast.AST],
+    offset_expr_fn: Callable[[int, str], str],
+) -> None:
+    """Emit ``offset_<bid> = …`` and ``indices_<bid> = …`` at the inner-loop
+    body prologue, using the canonical names from ``strategy``.
+
+    Used by ``_codegen_emit_pipeline`` and ``_codegen_fori_loop`` so kernel
+    code that references ``tile.index`` (lowered to ``indices_<bid>``) or
+    ``pl.ds`` offsets (``offset_<bid>``) sees defined symbols regardless of
+    whether the inner block is divisible.  Both vars are allocated
+    ``dce=True``, so unused emissions are pruned downstream.
+
+    Args:
+        offset_expr_fn: Given ``(block_id_index, block_size_var)``, returns a
+            string expression for the absolute start of the current iteration
+            (e.g. ``"(begin) + _j * (step)"``).
+    """
+    for i, bid in enumerate(block_ids):
+        offset_name = strategy.offset_var(bid)  # type: ignore[attr-defined]
+        index_name = strategy.index_var(bid)  # type: ignore[attr-defined]
+        idx_expr = env.backend.loop_index_expr(
+            offset_name, block_size_vars[i], env.index_type(), axis=0
+        )
+        body_stmts.extend(
+            [
+                statement_from_string(
+                    f"{offset_name} = {offset_expr_fn(i, block_size_vars[i])}"
+                ),
+                statement_from_string(f"{index_name} = {idx_expr}"),
+            ]
+        )
+
+
 def _setup_inner_loop_masks(
     state: CodegenState,
     strategy: object,
@@ -1437,26 +1476,19 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         )
 
     strategy = _find_strategy(state, block_ids)
-    # Emit offset_<bid>/indices_<bid> at the body prologue so kernel code
-    # that references tile.index (lowered to indices_<bid>) or pl.ds
-    # offsets (offset_<bid>) sees defined symbols.  Both vars are allocated
-    # dce=True, so unused emissions are pruned downstream.
+    # Emit offset_<bid>/indices_<bid> at the body prologue.
     _needs_explicit_indices = True
-    for i, bid in enumerate(block_ids):
-        offset_name = strategy.offset_var(bid)
-        index_name = strategy.index_var(bid)
-        idx_expr = env.backend.loop_index_expr(
-            offset_name, block_size_vars[i], env.index_type(), axis=0
-        )
-        body_stmts.extend(
-            [
-                statement_from_string(
-                    f"{offset_name} = ({begin_exprs[i]}) + "
-                    f"_pipeline_indices[{i}] * ({iter_step_exprs[i]})"
-                ),
-                statement_from_string(f"{index_name} = {idx_expr}"),
-            ]
-        )
+    _emit_inner_loop_offset_indices(
+        state,
+        strategy,
+        block_ids,
+        block_size_vars,
+        env,
+        body_stmts,
+        offset_expr_fn=lambda i, bs: (
+            f"({begin_exprs[i]}) + _pipeline_indices[{i}] * ({iter_step_exprs[i]})"
+        ),
+    )
     # Set up mask variables for inner-loop block_ids (non-divisible bounds).
     _setup_inner_loop_masks(
         state,
@@ -1737,7 +1769,19 @@ def _codegen_fori_loop(state: CodegenState) -> object:
             end_expr=env.block_sizes[block_id].numel,
         )
 
-    # Set up mask variables for inner-loop block_ids
+    # Emit offset_<bid>/indices_<bid> at the body prologue.
+    _emit_inner_loop_offset_indices(
+        state,
+        strategy,
+        block_ids,
+        block_size_vars,
+        env,
+        body_stmts,
+        offset_expr_fn=lambda i, bs: (
+            f"({begin_exprs[i]}) + ({dim_idx_exprs[i]}) * ({iter_step_exprs[i]})"
+        ),
+    )
+    # Set up mask variables for inner-loop block_ids (non-divisible bounds).
     _setup_inner_loop_masks(
         state,
         strategy,
@@ -1830,15 +1874,6 @@ def _codegen_fori_loop(state: CodegenState) -> object:
                     statement_from_string(f"{copy_var}.start()")
                 )
                 state.codegen.add_statement(statement_from_string(f"{copy_var}.wait()"))
-        else:
-            # No DMA: emit offset assignments so pl.ds() indexing works
-            for i, bid in enumerate(block_ids):
-                offset_name = strategy.offset_var(bid)
-                state.codegen.add_statement(
-                    statement_from_string(
-                        f"{offset_name} = ({begin_exprs[i]}) + ({dim_idx_exprs[i]}) * ({iter_step_exprs[i]})"
-                    )
-                )
 
         # Codegen the user's body (loads/stores remapped via _tensor_to_vmem
         # when using DMA, or accessing HBM refs directly when not)

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -1477,7 +1477,6 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
 
     strategy = _find_strategy(state, block_ids)
     # Emit offset_<bid>/indices_<bid> at the body prologue.
-    _needs_explicit_indices = True
     _emit_inner_loop_offset_indices(
         state,
         strategy,
@@ -1539,11 +1538,9 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
             _write_back_loop_carried(state, scratch_names, carried, graph_results)
 
     all_body_params = body_params
-    if _needs_explicit_indices:
-        # emit_pipeline passes indices as a single tuple argument
-        fn_args = "_pipeline_indices, " + ", ".join(all_body_params)
-    else:
-        fn_args = ", ".join(all_body_params)
+    # emit_pipeline passes indices as a single tuple argument; the prologue
+    # always references _pipeline_indices, so the body always takes it.
+    fn_args = "_pipeline_indices, " + ", ".join(all_body_params)
     fn_def = statement_from_string(f"def {body_fn_name}({fn_args}): pass")
     assert isinstance(fn_def, ast.FunctionDef)
     fn_def.body = body_stmts or [ast.Pass()]  # pyrefly: ignore[bad-assignment]
@@ -1558,8 +1555,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         spec_parts.append(f"in_specs=[{in_specs_str}]")
     if out_specs:
         spec_parts.append(f"out_specs=[{out_specs_str}]")
-    if _needs_explicit_indices:
-        spec_parts.append("_explicit_indices=True")
+    spec_parts.append("_explicit_indices=True")
     specs_str = ", ".join(spec_parts)
 
     all_pipeline_args = pipeline_in_args + pipeline_out_args

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -1437,8 +1437,28 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         )
 
     strategy = _find_strategy(state, block_ids)
-    # Set up mask variables for inner-loop block_ids.
-    _needs_explicit_indices = _setup_inner_loop_masks(
+    # Emit offset_<bid>/indices_<bid> at the body prologue so kernel code
+    # that references tile.index (lowered to indices_<bid>) or pl.ds
+    # offsets (offset_<bid>) sees defined symbols.  Both vars are allocated
+    # dce=True, so unused emissions are pruned downstream.
+    _needs_explicit_indices = True
+    for i, bid in enumerate(block_ids):
+        offset_name = strategy.offset_var(bid)
+        index_name = strategy.index_var(bid)
+        body_stmts.extend(
+            [
+                statement_from_string(
+                    f"{offset_name} = ({begin_exprs[i]}) + "
+                    f"_pipeline_indices[{i}] * ({iter_step_exprs[i]})"
+                ),
+                statement_from_string(
+                    f"{index_name} = {offset_name} + "
+                    f"jnp.arange({block_size_vars[i]}, dtype=jnp.int32)"
+                ),
+            ]
+        )
+    # Set up mask variables for inner-loop block_ids (non-divisible bounds).
+    _setup_inner_loop_masks(
         state,
         strategy,
         block_ids,

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -386,6 +386,21 @@ def _running_max_broadcast_ref(
     return acc.to(a.dtype)
 
 
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_chunked_add(x: torch.Tensor) -> torch.Tensor:
+    """Iterates over chunks of rows; uses tile_k.index + tile_chunk.begin * chunk_size
+    to compute the global row index (TileIndexWithOffsetPattern)."""
+    nrows, ncols = x.shape
+    chunk_size = 64
+    nchunks = nrows // chunk_size
+    out = torch.empty_like(x)
+    for tile_col, tile_chunk in hl.tile([ncols, nchunks], block_size=[None, 1]):
+        for tile_k in hl.tile(chunk_size, block_size=64):
+            row = tile_k.index + tile_chunk.begin * chunk_size
+            out[row, tile_col] = x[row, tile_col] + 1.0
+    return out
+
+
 @onlyBackends(["triton", "pallas"])
 @skipUnlessPallas("JAX/Pallas TPU not available")
 class TestPallas(TestCase):
@@ -1031,31 +1046,31 @@ class TestPallas(TestCase):
         within each chunk uses tile_k.index + tile_chunk.begin * chunk_size
         to compute the global row index.
         """
-
-        @helion.kernel(
-            backend="pallas",
-            static_shapes=True,
-        )
-        def chunked_add(x: torch.Tensor) -> torch.Tensor:
-            nrows, ncols = x.shape
-            chunk_size = 64
-            nchunks = nrows // chunk_size
-            out = torch.empty_like(x)
-            for tile_col, tile_chunk in hl.tile([ncols, nchunks], block_size=[None, 1]):
-                for tile_k in hl.tile(chunk_size, block_size=64):
-                    # global_row = local_row_within_chunk + chunk_start
-                    row = tile_k.index + tile_chunk.begin * chunk_size
-                    out[row, tile_col] = x[row, tile_col] + 1.0
-            return out
-
         # 4 chunks of 64 rows, 128 columns
         x = torch.randn(256, 128, device=DEVICE, dtype=torch.float32)
-        code, result = code_and_output(chunked_add, (x,), block_sizes=[128])
+        code, result = code_and_output(pallas_chunked_add, (x,), block_sizes=[128])
         expected = x + 1.0
         torch.testing.assert_close(result, expected)
         # tile_k.index + offset uses TileIndexWithOffsetPattern — the
         # pl.multiple_of hint should NOT be applied to offset expressions
         self.assertNotIn("pl.multiple_of(", code)
+
+    def test_tile_index_with_symbolic_offset_emit_pipeline(self) -> None:
+        """Same kernel under pallas_loop_type='emit_pipeline'.
+
+        emit_pipeline must emit offset_<bid>/indices_<bid> in the body
+        prologue so kernel code that references tile.index sees defined
+        symbols.  Without the prologue emission, the body raises
+        ``NameError: name 'indices_2' is not defined`` at trace time.
+        """
+        x = torch.randn(256, 128, device=DEVICE, dtype=torch.float32)
+        _code, result = code_and_output(
+            pallas_chunked_add,
+            (x,),
+            block_sizes=[128],
+            pallas_loop_type="emit_pipeline",
+        )
+        torch.testing.assert_close(result, x + 1.0)
 
     def test_mixed_scalar_and_slice_access(self) -> None:
         """Tensor accessed both as scalar and slice should not be placed in SMEM.

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1072,6 +1072,23 @@ class TestPallas(TestCase):
         )
         torch.testing.assert_close(result, x + 1.0)
 
+    def test_tile_index_with_symbolic_offset_fori_loop(self) -> None:
+        """Same kernel under pallas_loop_type='fori_loop'.
+
+        fori_loop has the same prologue gap as emit_pipeline: without
+        unconditional offset_<bid>/indices_<bid> emission, kernels that
+        reference tile.index inside a divisible inner loop raise
+        ``NameError: name 'indices_2' is not defined`` at trace time.
+        """
+        x = torch.randn(256, 128, device=DEVICE, dtype=torch.float32)
+        _code, result = code_and_output(
+            pallas_chunked_add,
+            (x,),
+            block_sizes=[128],
+            pallas_loop_type="fori_loop",
+        )
+        torch.testing.assert_close(result, x + 1.0)
+
     def test_mixed_scalar_and_slice_access(self) -> None:
         """Tensor accessed both as scalar and slice should not be placed in SMEM.
 


### PR DESCRIPTION
## Summary

When kernel code references `tile.index` (lowered to `indices_<bid>`) or `offset_<bid>` for `pl.ds`-style slicing, the inner-loop body must declare those vars at its prologue. Previously, only `_setup_inner_loop_masks` emitted them — and only when the inner block was **non-divisible** (mask required). For divisible inner blocks where user code still referenced `tile.index`, the body referenced `indices_<bid>` without ever defining it, raising `NameError: name 'indices_<n>' is not defined` at trace time.

The unroll path doesn't hit this because its enclosing for-loop construct emits these unconditionally at the top of every iteration's body (`tile_strategy.py:1664`). Both `emit_pipeline` and `fori_loop` had the same gap.

### Fix

Add `_emit_inner_loop_offset_indices` and call from both `_codegen_emit_pipeline` and `_codegen_fori_loop` body prologues:

```python
offset_<bid> = (begin) + <pipeline_iter_var> * (step)
indices_<bid> = offset_<bid> + jnp.arange(block_size, dtype=jnp.int32)
```

The indices expression goes through `env.backend.loop_index_expr(...)` for parity with the unroll path. Both vars are allocated `dce=True`, so unused emissions are pruned downstream — no codegen bloat for kernels that don't reference them.

Also drops the now-redundant offset-only emission inside `_codegen_fori_loop`'s `use_dma=False` branch (the prologue covers both DMA paths) and the `_needs_explicit_indices` flag (always `True` after the prologue is emitted unconditionally).

### Regression tests

Existing `test_tile_index_with_symbolic_offset` exercised the kernel pattern only through the implicit unroll default. Extracted the inline `chunked_add` kernel to a module-level `pallas_chunked_add` helper and added two parallel tests:

- `test_tile_index_with_symbolic_offset_emit_pipeline` — explicit `pallas_loop_type="emit_pipeline"`
- `test_tile_index_with_symbolic_offset_fori_loop` — explicit `pallas_loop_type="fori_loop"`

Verified on TPU that both new tests fail on `main` with `NameError: name 'indices_2' is not defined` and pass with this fix.
