### PR TITLE
[tutorials] pretuned Helion examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,8 @@ venv
 *.zip
 .helion_aot
 _helion_aot_*.py
+# Tutorials ship pretuned heuristic files alongside the kernel source.
+!tutorials/*/_helion_aot_*.py
 pytorch
 .logs/
 quack

--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -211,6 +211,7 @@ def is_cuda() -> bool:
 
 PROJECT_ROOT: Path = Path(__file__).parent.parent
 EXAMPLES_DIR: Path = PROJECT_ROOT / "examples"
+PRETUNED_KERNELS_DIR: Path = PROJECT_ROOT / "pretuned_kernels"
 DEVICE = None
 
 

--- a/pretuned_kernels/README.md
+++ b/pretuned_kernels/README.md
@@ -1,0 +1,74 @@
+# Helion Pretuned Kernels
+
+This directory contains pretuned Helion kernels, benchmark shape sweeps, and
+checked-in AOT heuristic files.  They are meant to be useful copy/paste starting
+points for common kernel patterns while also being runnable examples for people
+who want to quickly try Helion.
+
+The checked-in `sm100` heuristics are pretuned on NVIDIA B200 so these kernels
+can run immediately without online autotuning.  Treat the files as kernel
+recipes: copy the kernel and its local `_helion_aot_*` heuristic into your code,
+then retune when your target shapes or hardware differ materially from the
+included sweep.
+
+Each kernel module has a `main()` that benchmarks against PyTorch eager.
+
+## File structure
+
+```
+pretuned_kernels/
+├── README.md
+├── vector_add/
+│   ├── vector_add.py                          # the kernel + main()
+│   └── _helion_aot_vector_add_cuda_sm100.py   # auto-loaded heuristic
+├── softmax/
+├── layer_norm/
+├── rms_norm/
+└── cross_entropy/
+```
+
+| Kernel | Shape sweep | PyTorch baseline |
+|---|---|---|
+| `vector_add` | `2**i for i in range(19, 29)` | `x + y` |
+| `softmax` | Triton tutorial `M=4096, N=128*i for i in range(2, 100)` + realistic long-context shapes | `F.softmax` |
+| `layer_norm` | Triton tutorial `M=4096, N=512*i for i in range(2, 32)` + realistic hidden-size shapes | `F.layer_norm` |
+| `rms_norm` | TritonBench `(M=2048, H)` default + NPOT shapes + realistic LLM hidden-size and production-style shapes | `F.rms_norm` |
+| `cross_entropy` | TritonBench/Liger token-vocab sweep + realistic LLM vocabulary shapes | `F.cross_entropy` |
+
+## Scope
+
+Use this directory as a collection of pretuned kernels and runnable examples.
+For production code, copy the relevant kernel pattern into the application.  If
+the shapes or target hardware differ from the included sweep, generate and
+commit an AOT heuristic for the application's target shapes and hardware.
+
+For AOT pretuned kernels, Helion's runtime looks for
+`_helion_aot_<kernel>_cuda_sm<NN>.py` next to the kernel source file.  Helion
+looks for AOT heuristic files for the current compute capability first, then
+falls back to older compatible CUDA/ROCm capabilities.  For example, on
+`sm120`, if no `sm120` heuristic exists, an `sm100` heuristic file can be used.
+
+## Running benchmarks
+
+Each kernel module has a `main()` that benchmarks the Helion kernel against
+PyTorch eager across the included shape set:
+
+```bash
+cd pretuned_kernels/softmax
+python softmax.py
+```
+
+## Adding a heuristic for new hardware
+
+These kernels ship pretuned heuristics for `sm100` (B200).  To add another GPU,
+run the AOT autotune workflow on that hardware against the kernel — the runner
+emits a new
+`_helion_aot_<kernel>_<device>_<cc>.py` next to the kernel source, which
+you commit alongside the existing one(s).  Helion picks the right one at
+runtime based on the running GPU's compute capability (with fallback to
+older compatible capabilities, e.g. `sm120` → `sm100`).
+
+See [`docs/aot_autotuning.md`](../docs/aot_autotuning.md) for the
+end-to-end workflow, runner CLI, generated artifacts, and runtime
+fallback rules — including a worked "Pretuning a kernel for new
+hardware" walkthrough.

--- a/pretuned_kernels/cross_entropy/_helion_aot_cross_entropy_cuda_sm100.py
+++ b/pretuned_kernels/cross_entropy/_helion_aot_cross_entropy_cuda_sm100.py
@@ -1,0 +1,68 @@
+"""
+Auto-generated heuristic for kernel: cross_entropy
+Backend: decision_tree
+
+Provides:
+- key_cross_entropy(*args): Returns config index (cache key)
+- autotune_cross_entropy(*args): Returns config dict for the given arguments
+"""
+
+import torch
+
+
+def key_cross_entropy(*args) -> int:
+    """Select config index for the given arguments (also serves as cache key)."""
+    _arg0_dim0 = int(args[0].shape[0]) if len(args) > 0 and isinstance(args[0], torch.Tensor) and args[0].ndim > 0 else 0
+    _arg0_dim1 = int(args[0].shape[1]) if len(args) > 0 and isinstance(args[0], torch.Tensor) and args[0].ndim > 1 else 0
+    _arg0_numel = int(args[0].numel()) if len(args) > 0 and isinstance(args[0], torch.Tensor) else 0
+    if _arg0_numel <= 262144000.0:
+        if _arg0_dim0 <= 1024.0:
+            return 6
+        else:
+            return 2
+    else:
+        if _arg0_dim1 <= 151936.0:
+            if _arg0_dim1 <= 128256.0:
+                if _arg0_dim0 <= 2048.0:
+                    return 1
+                else:
+                    if _arg0_numel <= 2097152000.0:
+                        if _arg0_dim1 <= 128000.0:
+                            return 0
+                        else:
+                            return 4
+                    else:
+                        return 0
+            else:
+                if _arg0_dim1 <= 129280.0:
+                    if _arg0_dim0 <= 2048.0:
+                        return 1
+                    else:
+                        if _arg0_dim0 <= 4096.0:
+                            return 0
+                        else:
+                            return 1
+                else:
+                    return 1
+        else:
+            if _arg0_dim0 <= 4096.0:
+                if _arg0_dim1 <= 152064.0:
+                    return 3
+                else:
+                    return 5
+            else:
+                return 0
+
+
+def autotune_cross_entropy(*args) -> dict:
+    """Select the optimal config for the given arguments."""
+    _C = [
+        {'block_sizes': [1], 'reduction_loops': [256], 'range_unroll_factors': [1], 'range_warp_specializes': [False], 'range_num_stages': [0], 'range_multi_buffers': [False], 'range_flattens': [None], 'load_eviction_policies': ['', '', 'last', '', 'first'], 'num_warps': 4, 'num_stages': 3, 'indexing': ['pointer', 'pointer', 'tensor_descriptor', 'pointer', 'pointer', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'persistent_interleaved', 'num_sm_multiplier': 128},
+        {'block_sizes': [1], 'reduction_loops': [8192], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['', 'first', 'last', 'first', 'first'], 'num_warps': 8, 'num_stages': 2, 'indexing': ['pointer', 'tensor_descriptor', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['', '', 'first', '', ''], 'num_warps': 16, 'num_stages': 8, 'indexing': ['pointer', 'tensor_descriptor', 'pointer', 'pointer', 'tensor_descriptor', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1], 'reduction_loops': [512], 'range_unroll_factors': [2], 'range_warp_specializes': [False], 'range_num_stages': [4], 'range_multi_buffers': [True], 'range_flattens': [False], 'load_eviction_policies': ['', '', '', 'first', 'last'], 'num_warps': 8, 'num_stages': 1, 'indexing': ['pointer', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'persistent_blocked', 'num_sm_multiplier': 32, 'maxnreg': 64},
+        {'block_sizes': [1], 'reduction_loops': [256], 'range_unroll_factors': [4], 'range_warp_specializes': [False], 'range_num_stages': [0], 'range_multi_buffers': [True], 'range_flattens': [True], 'load_eviction_policies': ['first', '', '', 'first', 'last'], 'num_warps': 4, 'num_stages': 2, 'indexing': ['pointer', 'pointer', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'persistent_interleaved', 'num_sm_multiplier': 128, 'maxnreg': 32},
+        {'block_sizes': [1], 'reduction_loops': [1024], 'range_unroll_factors': [4], 'range_warp_specializes': [False], 'range_num_stages': [2], 'range_multi_buffers': [False], 'range_flattens': [None], 'load_eviction_policies': ['first', '', 'last', '', ''], 'num_warps': 16, 'num_stages': 6, 'indexing': ['pointer', 'tensor_descriptor', 'tensor_descriptor', 'pointer', 'tensor_descriptor', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'persistent_interleaved', 'num_sm_multiplier': 16, 'maxnreg': 32},
+        {'block_sizes': [1], 'reduction_loops': [2048], 'range_unroll_factors': [4], 'range_warp_specializes': [False], 'range_num_stages': [3], 'range_multi_buffers': [False], 'range_flattens': [False], 'load_eviction_policies': ['first', 'first', 'first', '', 'first'], 'num_warps': 32, 'num_stages': 7, 'indexing': ['tensor_descriptor', 'pointer', 'tensor_descriptor', 'pointer', 'tensor_descriptor', 'pointer'], 'atomic_indexing': [], 'pid_type': 'persistent_interleaved', 'num_sm_multiplier': 32},
+    ]
+    return _C[key_cross_entropy(*args)]

--- a/pretuned_kernels/cross_entropy/cross_entropy.py
+++ b/pretuned_kernels/cross_entropy/cross_entropy.py
@@ -1,0 +1,128 @@
+"""Cross entropy loss for token classification."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn.functional as F
+import triton.testing as tt
+
+import helion
+import helion.experimental
+import helion.language as hl
+
+
+@helion.experimental.aot_kernel(
+    static_shapes=True,
+    ignore_warnings=[helion.exc.TensorOperationInWrapper],
+)
+def cross_entropy(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+) -> torch.Tensor:
+    n, v = logits.shape
+    losses = torch.empty([n], dtype=logits.dtype, device=logits.device)
+    logits_flat = logits.view(-1)
+
+    for tile_n in hl.tile(n):
+        labels_tile = labels[tile_n]
+        base_indices_tile = tile_n.index * v
+        flat_indices = base_indices_tile + labels_tile
+        logits_at_target = hl.load(logits_flat, [flat_indices])
+
+        logits_rows = logits[tile_n, :]
+        max_logits = torch.amax(logits_rows, dim=-1, keepdim=True)
+        shifted = logits_rows - max_logits
+        exp_shifted = torch.exp(shifted)
+        sum_exp = torch.sum(exp_shifted, dim=-1, keepdim=True)
+        log_sum_exp = max_logits.squeeze(-1) + torch.log(sum_exp.squeeze(-1))
+
+        losses[tile_n] = log_sum_exp - logits_at_target
+
+    return losses.mean()
+
+
+def main() -> None:
+    tritonbench_shapes = [
+        (2048, 32000),
+        (4096, 32000),
+        (8192, 32000),
+        (8192, 128000),
+        (16384, 128000),
+        (32768, 128000),
+    ]
+    realistic_shapes = [
+        (2048, 128256),
+        (4096, 128256),
+        (8192, 128256),
+        (16384, 128256),
+        (2048, 129280),
+        (4096, 129280),
+        (8192, 129280),
+        (2048, 151936),
+        (4096, 151936),
+        (8192, 151936),
+        (2048, 152064),
+        (4096, 152064),
+        (8192, 152064),
+        (1024, 256000),
+        (2048, 256000),
+    ]
+    shapes = list(dict.fromkeys(tritonbench_shapes + realistic_shapes))
+
+    print(f"GPU: {torch.cuda.get_device_name()}")
+    print(
+        f"{'tokens':>8s}  {'vocab':>8s}  {'helion (ms)':>12s}  "
+        f"{'torch (ms)':>12s}  {'speedup':>8s}"
+    )
+    print("-" * 67)
+
+    speedups: list[float] = []
+    helion_wins = 0
+    best_speedup = 0.0
+    best_shape = (0, 0)
+    for tokens, vocab in shapes:
+        logits = torch.randn([tokens, vocab], device="cuda", dtype=torch.bfloat16)
+        labels = torch.randint(0, vocab, [tokens], device="cuda", dtype=torch.int64)
+        cross_entropy(logits, labels)  # warmup
+        ms_helion = tt.do_bench(
+            lambda logits=logits, labels=labels: cross_entropy(logits, labels),
+            warmup=25,
+            rep=100,
+            return_mode="median",
+        )
+        ms_torch = tt.do_bench(
+            lambda logits=logits, labels=labels: F.cross_entropy(logits, labels),
+            warmup=25,
+            rep=100,
+            return_mode="median",
+        )
+        speedup = ms_torch / ms_helion if ms_helion > 0 else float("nan")
+        speedups.append(speedup)
+        if speedup > 1.0:
+            helion_wins += 1
+        if speedup > best_speedup:
+            best_speedup = speedup
+            best_shape = (tokens, vocab)
+        print(
+            f"{tokens:>8d}  {vocab:>8d}  {ms_helion:>12.4f}  "
+            f"{ms_torch:>12.4f}  {speedup:>7.2f}x"
+        )
+
+    geomean = math.exp(
+        sum(math.log(s) for s in speedups if s > 0) / max(len(speedups), 1)
+    )
+    print(
+        f"\nHelion faster on {helion_wins}/{len(shapes)} shapes; "
+        f"geomean speedup {geomean:.3f}x; "
+        f"best speedup {best_speedup:.2f}x at (tokens, vocab)={best_shape}."
+    )
+    print(
+        f"SUMMARY: helion_wins={helion_wins} total={len(shapes)} "
+        f"geomean={geomean:.4f} best_speedup={best_speedup:.4f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pretuned_kernels/layer_norm/_helion_aot_layer_norm_cuda_sm100.py
+++ b/pretuned_kernels/layer_norm/_helion_aot_layer_norm_cuda_sm100.py
@@ -1,0 +1,58 @@
+"""
+Auto-generated heuristic for kernel: layer_norm
+Backend: decision_tree
+
+Provides:
+- key_layer_norm(*args): Returns config index (cache key)
+- autotune_layer_norm(*args): Returns config dict for the given arguments
+"""
+
+import torch
+
+
+def key_layer_norm(*args) -> int:
+    """Select config index for the given arguments (also serves as cache key)."""
+    _arg0_dim0 = int(args[0].shape[0]) if len(args) > 0 and isinstance(args[0], torch.Tensor) and args[0].ndim > 0 else 0
+    _arg0_dim1 = int(args[0].shape[1]) if len(args) > 0 and isinstance(args[0], torch.Tensor) and args[0].ndim > 1 else 0
+    if _arg0_dim1 <= 8192.0:
+        if _arg0_dim1 <= 5632.0:
+            if _arg0_dim1 <= 4096.0:
+                if _arg0_dim1 <= 2560.0:
+                    return 2
+                else:
+                    if _arg0_dim1 <= 3072.0:
+                        return 6
+                    else:
+                        if _arg0_dim0 <= 2048.0:
+                            return 1
+                        else:
+                            return 2
+            else:
+                if _arg0_dim0 <= 4096.0:
+                    return 6
+                else:
+                    return 3
+        else:
+            return 1
+    else:
+        if _arg0_dim1 <= 14336.0:
+            return 0
+        else:
+            if _arg0_dim0 <= 1152.0:
+                return 4
+            else:
+                return 5
+
+
+def autotune_layer_norm(*args) -> dict:
+    """Select the optimal config for the given arguments."""
+    _C = [
+        {'block_sizes': [1], 'reduction_loops': [2048], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['last', '', 'first', '', '', 'last', '', 'last'], 'num_warps': 8, 'num_stages': 4, 'indexing': ['tensor_descriptor', 'pointer', 'pointer', 'tensor_descriptor', 'pointer', 'tensor_descriptor', 'pointer', 'pointer', 'tensor_descriptor', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['first', 'last', 'last', 'last', 'first', 'last', 'first', 'first'], 'num_warps': 8, 'num_stages': 2, 'indexing': ['tensor_descriptor', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'pointer', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [2], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['first', '', 'last', '', 'last', 'last', 'first', ''], 'num_warps': 4, 'num_stages': 4, 'indexing': ['pointer', 'pointer', 'pointer', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'pointer', 'pointer', 'pointer', 'pointer'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1], 'reduction_loops': [1024], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['', '', 'first', '', '', '', '', ''], 'num_warps': 4, 'num_stages': 1, 'indexing': ['pointer', 'tensor_descriptor', 'pointer', 'pointer', 'pointer', 'pointer', 'pointer', 'pointer', 'pointer', 'pointer'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1], 'reduction_loops': [4096], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['last', '', 'first', '', '', 'last', '', ''], 'num_warps': 16, 'num_stages': 2, 'indexing': ['pointer', 'tensor_descriptor', 'pointer', 'pointer', 'pointer', 'tensor_descriptor', 'pointer', 'pointer', 'pointer', 'pointer'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['first', 'last', 'last', '', '', 'last', 'last', 'last'], 'num_warps': 16, 'num_stages': 2, 'indexing': ['pointer', 'pointer', 'pointer', 'pointer', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'pointer', 'pointer', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1], 'reduction_loops': [1024], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['', 'last', 'first', '', 'last', 'first', 'last', 'last'], 'num_warps': 1, 'num_stages': 2, 'indexing': ['pointer', 'tensor_descriptor', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'pointer', 'pointer', 'pointer', 'tensor_descriptor', 'pointer'], 'atomic_indexing': [], 'pid_type': 'flat'},
+    ]
+    return _C[key_layer_norm(*args)]

--- a/pretuned_kernels/layer_norm/layer_norm.py
+++ b/pretuned_kernels/layer_norm/layer_norm.py
@@ -1,0 +1,103 @@
+"""Layer normalization (forward only)."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn.functional as F
+import triton.testing as tt
+
+import helion.experimental
+import helion.language as hl
+
+
+@helion.experimental.aot_kernel()
+def layer_norm(
+    x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor
+) -> torch.Tensor:
+    m, n = x.size()
+    out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+    for tile_m in hl.tile(m):
+        acc = x[tile_m, :].to(torch.float32)
+        mean_val = torch.sum(acc, dim=-1) / n
+        centered = acc - mean_val[:, None]
+        var_val = torch.sum(centered * centered, dim=-1) / n
+        rstd_val = torch.rsqrt(var_val + 1e-5)
+        out[tile_m, :] = (
+            centered * rstd_val[:, None] * weight[:].to(torch.float32)
+            + bias[:].to(torch.float32)
+        ).to(x.dtype)
+    return out
+
+
+def main() -> None:
+    triton_tutorial_shapes = [(4096, 512 * i) for i in range(2, 32)]
+    realistic_shapes = [
+        (2048, 3584),
+        (8192, 4096),
+        (8192, 5120),
+        (8192, 7168),
+        (2048, 8192),
+        (4096, 16384),
+        (1024, 36864),
+        (1152, 36864),
+    ]
+    shapes = list(dict.fromkeys(triton_tutorial_shapes + realistic_shapes))
+
+    print(f"GPU: {torch.cuda.get_device_name()}")
+    print(
+        f"{'M':>5s}  {'N':>6s}  {'helion (us)':>12s}  "
+        f"{'torch (us)':>12s}  {'speedup':>8s}"
+    )
+    print("-" * 60)
+
+    speedups: list[float] = []
+    helion_wins = 0
+    best_speedup = 0.0
+    best_shape = (0, 0)
+    for M, N in shapes:
+        x = torch.randn([M, N], device="cuda", dtype=torch.float16)
+        w = torch.randn([N], device="cuda", dtype=torch.float16)
+        b = torch.randn([N], device="cuda", dtype=torch.float16)
+        layer_norm(x, w, b)  # warmup
+        ms_helion = tt.do_bench(
+            lambda x=x, w=w, b=b: layer_norm(x, w, b),
+            warmup=50,
+            rep=200,
+            return_mode="median",
+        )
+        ms_torch = tt.do_bench(
+            lambda x=x, N=N, w=w, b=b: F.layer_norm(x, [N], w, b, eps=1e-5),
+            warmup=50,
+            rep=200,
+            return_mode="median",
+        )
+        speedup = ms_torch / ms_helion if ms_helion > 0 else float("nan")
+        speedups.append(speedup)
+        if speedup > 1.0:
+            helion_wins += 1
+        if speedup > best_speedup:
+            best_speedup = speedup
+            best_shape = (M, N)
+        print(
+            f"{M:>5d}  {N:>6d}  {ms_helion * 1000:>12.2f}  "
+            f"{ms_torch * 1000:>12.2f}  {speedup:>7.2f}x"
+        )
+
+    geomean = math.exp(
+        sum(math.log(s) for s in speedups if s > 0) / max(len(speedups), 1)
+    )
+    print(
+        f"\nHelion faster on {helion_wins}/{len(shapes)} shapes; "
+        f"geomean speedup {geomean:.3f}x; "
+        f"best speedup {best_speedup:.2f}x at (M, N)={best_shape}."
+    )
+    print(
+        f"SUMMARY: helion_wins={helion_wins} total={len(shapes)} "
+        f"geomean={geomean:.4f} best_speedup={best_speedup:.4f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pretuned_kernels/rms_norm/_helion_aot_rms_norm_cuda_sm100.py
+++ b/pretuned_kernels/rms_norm/_helion_aot_rms_norm_cuda_sm100.py
@@ -1,0 +1,64 @@
+"""
+Auto-generated heuristic for kernel: rms_norm
+Backend: decision_tree
+
+Provides:
+- key_rms_norm(*args): Returns config index (cache key)
+- autotune_rms_norm(*args): Returns config dict for the given arguments
+"""
+
+import torch
+
+
+def key_rms_norm(*args) -> int:
+    """Select config index for the given arguments (also serves as cache key)."""
+    _arg0_dim0 = int(args[0].shape[0]) if len(args) > 0 and isinstance(args[0], torch.Tensor) and args[0].ndim > 0 else 0
+    _arg0_dim1 = int(args[0].shape[1]) if len(args) > 0 and isinstance(args[0], torch.Tensor) and args[0].ndim > 1 else 0
+    if _arg0_dim1 <= 3072.0:
+        if _arg0_dim0 <= 2048.0:
+            if _arg0_dim1 <= 2047.0:
+                if _arg0_dim1 <= 96.0:
+                    if _arg0_dim1 <= 48.0:
+                        return 0
+                    else:
+                        return 2
+                else:
+                    return 0
+            else:
+                if _arg0_dim1 <= 2048.0:
+                    return 3
+                else:
+                    return 0
+        else:
+            return 2
+    else:
+        if _arg0_dim1 <= 6144.0:
+            if _arg0_dim0 <= 2048.0:
+                return 3
+            else:
+                if _arg0_dim1 <= 4096.0:
+                    return 5
+                else:
+                    return 1
+        else:
+            if _arg0_dim1 <= 8192.0:
+                return 1
+            else:
+                if _arg0_dim0 <= 2048.0:
+                    return 4
+                else:
+                    return 6
+
+
+def autotune_rms_norm(*args) -> dict:
+    """Select the optimal config for the given arguments."""
+    _C = [
+        {'block_sizes': [2], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['last', 'first', 'first', '', ''], 'num_warps': 4, 'num_stages': 6, 'indexing': ['pointer', 'pointer', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'pointer', 'pointer'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['first', 'last', 'last', '', 'last'], 'num_warps': 16, 'num_stages': 4, 'indexing': ['pointer', 'tensor_descriptor', 'pointer', 'pointer', 'pointer', 'pointer', 'pointer'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [4], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['first', 'last', '', 'first', ''], 'num_warps': 2, 'num_stages': 3, 'indexing': ['pointer', 'tensor_descriptor', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [2], 'reduction_loops': [2048], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['last', 'first', 'last', 'first', 'first'], 'num_warps': 2, 'num_stages': 1, 'indexing': ['tensor_descriptor', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'pointer', 'tensor_descriptor', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1], 'reduction_loops': [8192], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['', 'first', 'last', '', ''], 'num_warps': 8, 'num_stages': 3, 'indexing': ['pointer', 'tensor_descriptor', 'pointer', 'pointer', 'pointer', 'tensor_descriptor', 'pointer'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['', 'last', 'last', 'first', ''], 'num_warps': 8, 'num_stages': 2, 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'pointer', 'pointer', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1], 'reduction_loops': [2048], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['', 'first', 'last', 'first', 'last'], 'num_warps': 8, 'num_stages': 8, 'indexing': ['pointer', 'pointer', 'pointer', 'tensor_descriptor', 'pointer', 'tensor_descriptor', 'pointer'], 'atomic_indexing': [], 'pid_type': 'flat'},
+    ]
+    return _C[key_rms_norm(*args)]

--- a/pretuned_kernels/rms_norm/rms_norm.py
+++ b/pretuned_kernels/rms_norm/rms_norm.py
@@ -1,0 +1,130 @@
+"""Root mean square normalization (forward only)."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn.functional as F
+import triton.testing as tt
+
+import helion.experimental
+import helion.language as hl
+
+
+@helion.experimental.aot_kernel()
+def rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float = 1e-5) -> torch.Tensor:
+    m, n = x.size()
+    out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+    for tile_m in hl.tile(m):
+        acc = x[tile_m, :].to(torch.float32)
+        variance = torch.mean(acc * acc, dim=-1)
+        inv_rms = torch.rsqrt(variance + eps)
+        out[tile_m, :] = (acc * inv_rms[:, None] * weight[:].to(torch.float32)).to(
+            x.dtype
+        )
+    return out
+
+
+def _rms_norm_torch(
+    x: torch.Tensor, weight: torch.Tensor, eps: float = 1e-5
+) -> torch.Tensor:
+    return F.rms_norm(x, [x.size(1)], weight, eps=eps)
+
+
+def main() -> None:
+    tritonbench_shapes = [
+        (2048, 1024),
+        (2048, 2048),
+        (2048, 4096),
+        (2048, 8192),
+        (2048, 16384),
+        (2048, 32768),
+    ]
+    tritonbench_npot_shapes = [
+        (2048, 48),
+        (2048, 96),
+        (2048, 127),
+        (2048, 768),
+        (2048, 1023),
+        (2048, 1536),
+        (2048, 2047),
+        (2048, 3072),
+        (2048, 5120),
+        (2048, 6144),
+    ]
+    realistic_shapes = [
+        (4096, 3584),
+        (4096, 4096),
+        (4096, 5120),
+        (4096, 7168),
+        (4096, 8192),
+        (4096, 12288),
+        (8192, 4096),
+        (8192, 8192),
+        (16384, 4096),
+        (16384, 8192),
+        (145956, 384),
+        (380668, 512),
+        (589824, 256),
+        (1179648, 256),
+    ]
+    shapes = list(
+        dict.fromkeys(tritonbench_shapes + tritonbench_npot_shapes + realistic_shapes)
+    )
+
+    print(f"GPU: {torch.cuda.get_device_name()}")
+    print(
+        f"{'M':>8s}  {'N':>6s}  {'helion (us)':>12s}  "
+        f"{'torch (us)':>12s}  {'speedup':>8s}"
+    )
+    print("-" * 63)
+
+    speedups: list[float] = []
+    helion_wins = 0
+    best_speedup = 0.0
+    best_shape = (0, 0)
+    for M, N in shapes:
+        x = torch.randn([M, N], device="cuda", dtype=torch.bfloat16)
+        weight = torch.randn([N], device="cuda", dtype=torch.bfloat16)
+        rms_norm(x, weight)  # warmup
+        ms_helion = tt.do_bench(
+            lambda x=x, weight=weight: rms_norm(x, weight),
+            warmup=25,
+            rep=100,
+            return_mode="median",
+        )
+        ms_torch = tt.do_bench(
+            lambda x=x, weight=weight: _rms_norm_torch(x, weight),
+            warmup=25,
+            rep=100,
+            return_mode="median",
+        )
+        speedup = ms_torch / ms_helion if ms_helion > 0 else float("nan")
+        speedups.append(speedup)
+        if speedup > 1.0:
+            helion_wins += 1
+        if speedup > best_speedup:
+            best_speedup = speedup
+            best_shape = (M, N)
+        print(
+            f"{M:>8d}  {N:>6d}  {ms_helion * 1000:>12.2f}  "
+            f"{ms_torch * 1000:>12.2f}  {speedup:>7.2f}x"
+        )
+
+    geomean = math.exp(
+        sum(math.log(s) for s in speedups if s > 0) / max(len(speedups), 1)
+    )
+    print(
+        f"\nHelion faster on {helion_wins}/{len(shapes)} shapes; "
+        f"geomean speedup {geomean:.3f}x; "
+        f"best speedup {best_speedup:.2f}x at (M, N)={best_shape}."
+    )
+    print(
+        f"SUMMARY: helion_wins={helion_wins} total={len(shapes)} "
+        f"geomean={geomean:.4f} best_speedup={best_speedup:.4f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pretuned_kernels/softmax/_helion_aot_softmax_cuda_sm100.py
+++ b/pretuned_kernels/softmax/_helion_aot_softmax_cuda_sm100.py
@@ -1,0 +1,47 @@
+"""
+Auto-generated heuristic for kernel: softmax
+Backend: decision_tree
+
+Provides:
+- key_softmax(*args): Returns config index (cache key)
+- autotune_softmax(*args): Returns config dict for the given arguments
+"""
+
+import torch
+
+
+def key_softmax(*args) -> int:
+    """Select config index for the given arguments (also serves as cache key)."""
+    _arg0_dim0 = int(args[0].shape[0]) if len(args) > 0 and isinstance(args[0], torch.Tensor) and args[0].ndim > 0 else 0
+    _arg0_dim1 = int(args[0].shape[1]) if len(args) > 0 and isinstance(args[0], torch.Tensor) and args[0].ndim > 1 else 0
+    if _arg0_dim1 <= 4096.0:
+        if _arg0_dim1 <= 1024.0:
+            if _arg0_dim1 <= 512.0:
+                if _arg0_dim1 <= 256.0:
+                    return 3
+                else:
+                    if _arg0_dim1 <= 384.0:
+                        return 1
+                    else:
+                        return 3
+            else:
+                return 2
+        else:
+            return 1
+    else:
+        if _arg0_dim0 <= 2048.0:
+            return 4
+        else:
+            return 0
+
+
+def autotune_softmax(*args) -> dict:
+    """Select the optimal config for the given arguments."""
+    _C = [
+        {'block_sizes': [1], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['', '', 'last', 'first'], 'num_warps': 8, 'num_stages': 8, 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'pointer', 'pointer', 'tensor_descriptor', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['last', '', '', 'first'], 'num_warps': 4, 'num_stages': 1, 'indexing': ['pointer', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['last', 'first', 'last', ''], 'num_warps': 2, 'num_stages': 4, 'indexing': ['pointer', 'tensor_descriptor', 'tensor_descriptor', 'pointer', 'tensor_descriptor', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [4], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['', '', '', 'last'], 'num_warps': 4, 'num_stages': 7, 'indexing': ['pointer', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'pointer', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['', 'first', 'first', 'first'], 'num_warps': 32, 'num_stages': 6, 'indexing': ['pointer', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'pointer', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'flat'},
+    ]
+    return _C[key_softmax(*args)]

--- a/pretuned_kernels/softmax/softmax.py
+++ b/pretuned_kernels/softmax/softmax.py
@@ -1,0 +1,85 @@
+"""Row-wise softmax."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn.functional as F
+import triton.testing as tt
+
+import helion.experimental
+import helion.language as hl
+
+
+@helion.experimental.aot_kernel()
+def softmax(x: torch.Tensor) -> torch.Tensor:
+    m, _n = x.size()
+    out = torch.empty_like(x)
+    for tile_m in hl.tile(m):
+        out[tile_m, :] = torch.nn.functional.softmax(x[tile_m, :], dim=1)
+    return out
+
+
+def main() -> None:
+    triton_tutorial_shapes = [(4096, 128 * i) for i in range(2, 100)]
+    realistic_shapes = [
+        (4096, 16384),
+        (2048, 32768),
+    ]
+    shapes = list(dict.fromkeys(triton_tutorial_shapes + realistic_shapes))
+
+    print(f"GPU: {torch.cuda.get_device_name()}")
+    print(
+        f"{'M':>5s}  {'N':>6s}  {'helion (us)':>12s}  "
+        f"{'torch (us)':>12s}  {'speedup':>8s}"
+    )
+    print("-" * 60)
+
+    speedups: list[float] = []
+    helion_wins = 0
+    best_speedup = 0.0
+    best_shape = (0, 0)
+    for M, N in shapes:
+        x = torch.randn([M, N], device="cuda", dtype=torch.float16)
+        softmax(x)  # warmup
+        ms_helion = tt.do_bench(
+            lambda x=x: softmax(x),
+            warmup=50,
+            rep=200,
+            return_mode="median",
+        )
+        ms_torch = tt.do_bench(
+            lambda x=x: F.softmax(x, dim=1),
+            warmup=50,
+            rep=200,
+            return_mode="median",
+        )
+        speedup = ms_torch / ms_helion if ms_helion > 0 else float("nan")
+        speedups.append(speedup)
+        if speedup > 1.0:
+            helion_wins += 1
+        if speedup > best_speedup:
+            best_speedup = speedup
+            best_shape = (M, N)
+        print(
+            f"{M:>5d}  {N:>6d}  {ms_helion * 1000:>12.2f}  "
+            f"{ms_torch * 1000:>12.2f}  {speedup:>7.2f}x"
+        )
+
+    geomean = math.exp(
+        sum(math.log(s) for s in speedups if s > 0) / max(len(speedups), 1)
+    )
+    print(
+        f"\nHelion faster on {helion_wins}/{len(shapes)} shapes; "
+        f"geomean speedup {geomean:.3f}x; "
+        f"best speedup {best_speedup:.2f}x at (M, N)={best_shape}."
+    )
+    print(
+        f"SUMMARY: helion_wins={helion_wins} total={len(shapes)} "
+        f"geomean={geomean:.4f} best_speedup={best_speedup:.4f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pretuned_kernels/vector_add/_helion_aot_vector_add_cuda_sm100.py
+++ b/pretuned_kernels/vector_add/_helion_aot_vector_add_cuda_sm100.py
@@ -1,0 +1,66 @@
+"""
+Auto-generated heuristic for kernel: vector_add
+Backend: decision_tree
+
+Provides:
+- key_vector_add(*args): Returns config index (cache key)
+- autotune_vector_add(*args): Returns config dict for the given arguments
+"""
+
+import torch
+
+
+def key_vector_add(*args) -> int:
+    """Select config index for the given arguments (also serves as cache key)."""
+    _arg0_dim0 = int(args[0].shape[0]) if len(args) > 0 and isinstance(args[0], torch.Tensor) and args[0].ndim > 0 else 0
+    if _arg0_dim0 <= 1048576.0:
+        if _arg0_dim0 <= 8192.0:
+            return 0
+        else:
+            if _arg0_dim0 <= 32768.0:
+                if _arg0_dim0 <= 16384.0:
+                    return 1
+                else:
+                    return 2
+            else:
+                if _arg0_dim0 <= 131072.0:
+                    return 0
+                else:
+                    if _arg0_dim0 <= 262144.0:
+                        return 1
+                    else:
+                        if _arg0_dim0 <= 524288.0:
+                            return 0
+                        else:
+                            return 1
+    else:
+        if _arg0_dim0 <= 67108864.0:
+            if _arg0_dim0 <= 8388608.0:
+                if _arg0_dim0 <= 4194304.0:
+                    return 2
+                else:
+                    return 3
+            else:
+                return 2
+        else:
+            if _arg0_dim0 <= 536870912.0:
+                if _arg0_dim0 <= 134217728.0:
+                    return 1
+                else:
+                    return 0
+            else:
+                if _arg0_dim0 <= 1073741824.0:
+                    return 3
+                else:
+                    return 1
+
+
+def autotune_vector_add(*args) -> dict:
+    """Select the optimal config for the given arguments."""
+    _C = [
+        {'block_sizes': [1024], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['', ''], 'num_warps': 8, 'num_stages': 4, 'indexing': ['pointer', 'tensor_descriptor', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [512], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['last', 'last'], 'num_warps': 4, 'num_stages': 8, 'indexing': ['tensor_descriptor', 'pointer', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [512], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['first', ''], 'num_warps': 4, 'num_stages': 7, 'indexing': ['pointer', 'tensor_descriptor', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1024], 'range_unroll_factors': [0], 'range_warp_specializes': [None], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['', ''], 'num_warps': 1, 'num_stages': 3, 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'flat'},
+    ]
+    return _C[key_vector_add(*args)]

--- a/pretuned_kernels/vector_add/vector_add.py
+++ b/pretuned_kernels/vector_add/vector_add.py
@@ -1,0 +1,81 @@
+"""Element-wise vector addition."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import triton.testing as tt
+
+import helion.experimental
+import helion.language as hl
+
+
+@helion.experimental.aot_kernel()
+def vector_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size(0)):
+        out[tile] = x[tile] + y[tile]
+    return out
+
+
+def main() -> None:
+    shapes = [2**i for i in range(19, 29)]
+
+    print(f"GPU: {torch.cuda.get_device_name()}")
+    print(
+        f"{'N':>10s}  {'helion (us)':>12s}  {'torch (us)':>12s}  "
+        f"{'speedup':>8s}  {'winner':>8s}"
+    )
+    print("-" * 60)
+
+    speedups: list[float] = []
+    helion_wins = 0
+    best_speedup = 0.0
+    best_n = 0
+    for n in shapes:
+        x = torch.randn(n, device="cuda", dtype=torch.float32)
+        y = torch.randn(n, device="cuda", dtype=torch.float32)
+        vector_add(x, y)  # warmup
+        ms_helion = tt.do_bench(
+            lambda x=x, y=y: vector_add(x, y),
+            warmup=50,
+            rep=200,
+            return_mode="median",
+        )
+        ms_torch = tt.do_bench(
+            lambda x=x, y=y: x + y,
+            warmup=50,
+            rep=200,
+            return_mode="median",
+        )
+        speedup = ms_torch / ms_helion if ms_helion > 0 else float("nan")
+        speedups.append(speedup)
+        winner = "helion" if speedup > 1.0 else "torch" if speedup < 1.0 else "tie"
+        if speedup > 1.0:
+            helion_wins += 1
+        if speedup > best_speedup:
+            best_speedup = speedup
+            best_n = n
+        print(
+            f"{n:>10d}  {ms_helion * 1000:>12.2f}  "
+            f"{ms_torch * 1000:>12.2f}  {speedup:>7.3f}x  {winner:>8s}"
+        )
+
+    geomean = math.exp(
+        sum(math.log(s) for s in speedups if s > 0) / max(len(speedups), 1)
+    )
+    print(
+        f"\nHelion faster on {helion_wins}/{len(shapes)} shapes; "
+        f"geomean speedup {geomean:.3f}x; "
+        f"best speedup {best_speedup:.2f}x at N={best_n}."
+    )
+    # Machine-parseable summary line consumed by test/test_pretuned_kernels.py.
+    print(
+        f"SUMMARY: helion_wins={helion_wins} total={len(shapes)} "
+        f"geomean={geomean:.4f} best_speedup={best_speedup:.4f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,8 @@ Issues = "https://github.com/pytorch/helion/issues"
 target-version = "py310"
 line-length = 88
 src = ["helion"]
+extend-exclude = ["**/_helion_aot_*.py"]
+force-exclude = true
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/test/test_pretuned_kernels.py
+++ b/test/test_pretuned_kernels.py
@@ -1,0 +1,276 @@
+"""Correctness and perf tests for kernels under ``pretuned_kernels/``.
+
+Correctness runs on every CUDA / ROCm runner; perf gating runs only on
+sm100 (B200), where the checked-in heuristics apply.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import re
+import sys
+import unittest
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from helion._testing import DEVICE
+from helion._testing import PRETUNED_KERNELS_DIR
+from helion._testing import TestCase
+from helion._testing import is_cuda
+from helion._testing import onlyBackends
+from helion._testing import skipIfRefEager
+
+
+def _on_sm100() -> bool:
+    return is_cuda() and torch.cuda.get_device_capability() == (10, 0)
+
+
+def _import_pretuned_kernel_module(name):
+    # Private module name avoids clashing with ``examples/<name>.py``.
+    module_name = f"_helion_pretuned_kernels_test.{name}"
+    if module_name not in sys.modules:
+        file_path = PRETUNED_KERNELS_DIR / name / f"{name}.py"
+        spec = importlib.util.spec_from_file_location(module_name, file_path)
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        sys.modules[module_name] = module
+    return sys.modules[module_name]
+
+
+_SUMMARY_RE = re.compile(
+    r"^SUMMARY:\s+helion_wins=(?P<wins>\d+)\s+total=(?P<total>\d+)\s+"
+    r"geomean=(?P<geomean>[\d.]+)\s+best_speedup=(?P<best>[\d.]+)\s*$",
+    re.MULTILINE,
+)
+
+
+def _run_pretuned_kernel_main_and_parse_summary(name):
+    module = _import_pretuned_kernel_module(name)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        module.main()
+    output = buf.getvalue()
+    # Relay output so CI logs show the per-shape table on failure.
+    print(output)
+    match = _SUMMARY_RE.search(output)
+    if match is None:
+        raise AssertionError(
+            f"Could not find SUMMARY line in pretuned kernel output for {name}.\n"
+            f"Output was:\n{output}"
+        )
+    return {
+        "helion_wins": int(match["wins"]),
+        "total": int(match["total"]),
+        "geomean": float(match["geomean"]),
+        "best_speedup": float(match["best"]),
+    }
+
+
+_CORRECTNESS_SHAPES = {
+    "vector_add": [2**20],
+    "softmax": [(4096, 1024)],
+    "layer_norm": [(4096, 1024)],
+    "rms_norm": [(2048, 4096)],
+    "cross_entropy": [(4096, 32000)],
+}
+
+
+def _make_vector_add_inputs(shape):
+    n = shape
+    x = torch.randn(n, device=DEVICE, dtype=torch.float32)
+    y = torch.randn(n, device=DEVICE, dtype=torch.float32)
+    return (x, y), lambda: x + y
+
+
+def _make_softmax_inputs(shape):
+    m, n = shape
+    x = torch.randn(m, n, device=DEVICE, dtype=torch.float16)
+    return (x,), lambda: F.softmax(x, dim=1)
+
+
+def _make_layer_norm_inputs(shape):
+    m, n = shape
+    x = torch.randn(m, n, device=DEVICE, dtype=torch.float16)
+    w = torch.randn(n, device=DEVICE, dtype=torch.float16)
+    b = torch.randn(n, device=DEVICE, dtype=torch.float16)
+    return (x, w, b), lambda: F.layer_norm(x, [n], w, b, eps=1e-5)
+
+
+def _make_rms_norm_inputs(shape):
+    m, n = shape
+    x = torch.randn(m, n, device=DEVICE, dtype=torch.bfloat16)
+    w = torch.randn(n, device=DEVICE, dtype=torch.bfloat16)
+    return (x, w), lambda: F.rms_norm(x, [n], w, eps=1e-5)
+
+
+def _make_cross_entropy_inputs(shape):
+    tokens, vocab = shape
+    logits = torch.randn(tokens, vocab, device=DEVICE, dtype=torch.bfloat16)
+    labels = torch.randint(0, vocab, (tokens,), device=DEVICE, dtype=torch.int64)
+    return (logits, labels), lambda: F.cross_entropy(logits, labels)
+
+
+_INPUT_BUILDERS = {
+    "vector_add": _make_vector_add_inputs,
+    "softmax": _make_softmax_inputs,
+    "layer_norm": _make_layer_norm_inputs,
+    "rms_norm": _make_rms_norm_inputs,
+    "cross_entropy": _make_cross_entropy_inputs,
+}
+
+# (atol, rtol) per kernel. Norm/softmax need looser tolerances than
+# vector_add because reductions accumulate fp32 and round back to fp16/bf16.
+_TOLERANCES = {
+    "vector_add": (1e-5, 1e-5),
+    "softmax": (1e-3, 1e-3),
+    "layer_norm": (1e-2, 1e-2),
+    "rms_norm": (1e-2, 1e-2),
+    "cross_entropy": (1e-2, 1e-2),
+}
+
+# Sampled on B200 with the checked-in heuristic. ``wins_slack`` lets that
+# many near-noise-band shapes flip without failing; ``None`` disables the
+# wins gate (vector_add: all wins sit within do_bench noise).
+_EXPECTED_PERF: dict[str, dict[str, float | int | None]] = {
+    "vector_add": {
+        "helion_wins": 5,
+        "total": 10,
+        "geomean": 1.009,
+        "wins_slack": None,
+    },
+    "softmax": {
+        "helion_wins": 100,
+        "total": 100,
+        "geomean": 2.304,
+        "wins_slack": 2,
+    },
+    "layer_norm": {
+        "helion_wins": 38,
+        "total": 38,
+        "geomean": 1.784,
+        "wins_slack": 1,
+    },
+    "rms_norm": {
+        "helion_wins": 30,
+        "total": 30,
+        "geomean": 1.605,
+        "wins_slack": 2,
+    },
+    "cross_entropy": {
+        "helion_wins": 21,
+        "total": 21,
+        "geomean": 1.698,
+        "wins_slack": 1,
+    },
+}
+
+# Geomean must stay within this fraction below expected. Catches regressions
+# only; speedups going up is fine.
+_GEOMEAN_NOISE_BAND = 0.10
+
+
+@onlyBackends(["triton"])
+@skipIfRefEager("Pretuned kernels use AOT; ref-eager bypasses heuristic logic.")
+class TestPretunedKernelsCorrectness(TestCase):
+    """Numerical correctness vs. PyTorch eager."""
+
+    def _run_correctness(self, name: str) -> None:
+        if not is_cuda():
+            self.skipTest("Pretuned kernels require CUDA / ROCm.")
+        module = _import_pretuned_kernel_module(name)
+        kernel = getattr(module, name)
+        builder = _INPUT_BUILDERS[name]
+        atol, rtol = _TOLERANCES[name]
+        for shape in _CORRECTNESS_SHAPES[name]:
+            with self.subTest(shape=shape):
+                args, ref_fn = builder(shape)
+                actual = kernel(*args)
+                expected = ref_fn()
+                torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+
+    def test_vector_add(self):
+        self._run_correctness("vector_add")
+
+    def test_softmax(self):
+        self._run_correctness("softmax")
+
+    def test_layer_norm(self):
+        self._run_correctness("layer_norm")
+
+    def test_rms_norm(self):
+        self._run_correctness("rms_norm")
+
+    def test_cross_entropy(self):
+        self._run_correctness("cross_entropy")
+
+
+@onlyBackends(["triton"])
+@skipIfRefEager("Pretuned kernels use AOT; ref-eager bypasses heuristic logic.")
+class TestPretunedKernelsPerformance(TestCase):
+    """Run each kernel's main() and gate on parsed wins / geomean (sm100 only)."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        if not _on_sm100():
+            raise unittest.SkipTest(
+                "Pretuned kernel heuristics target sm100; perf gating runs on B200."
+            )
+
+    def _run_pretuned_kernel_perf(self, name: str) -> None:
+        expected = _EXPECTED_PERF[name]
+        actual = _run_pretuned_kernel_main_and_parse_summary(name)
+        self.assertEqual(
+            actual["total"],
+            expected["total"],
+            f"{name}: shape sweep size changed "
+            f"({actual['total']} vs expected {expected['total']}); "
+            f"update _EXPECTED_PERF if intentional.",
+        )
+        wins_slack = expected["wins_slack"]
+        if wins_slack is not None:
+            wins_floor = max(0, int(expected["helion_wins"]) - int(wins_slack))
+            self.assertGreaterEqual(
+                actual["helion_wins"],
+                wins_floor,
+                f"{name}: Helion wins {actual['helion_wins']}/{actual['total']} "
+                f"shapes, below floor {wins_floor} "
+                f"(expected ~{expected['helion_wins']}, slack {wins_slack}).",
+            )
+        geomean_floor = expected["geomean"] * (1 - _GEOMEAN_NOISE_BAND)
+        self.assertGreaterEqual(
+            actual["geomean"],
+            geomean_floor,
+            f"{name}: geomean {actual['geomean']:.3f}x below floor "
+            f"{geomean_floor:.3f}x "
+            f"(expected ~{expected['geomean']:.3f}x, "
+            f"noise band {_GEOMEAN_NOISE_BAND:.0%}).",
+        )
+
+    def test_vector_add(self):
+        self._run_pretuned_kernel_perf("vector_add")
+
+    # softmax/layer_norm sweep enough shapes to need >60s under xdist contention.
+    @pytest.mark.timeout(120)
+    def test_softmax(self):
+        self._run_pretuned_kernel_perf("softmax")
+
+    @pytest.mark.timeout(120)
+    def test_layer_norm(self):
+        self._run_pretuned_kernel_perf("layer_norm")
+
+    def test_rms_norm(self):
+        self._run_pretuned_kernel_perf("rms_norm")
+
+    def test_cross_entropy(self):
+        self._run_pretuned_kernel_perf("cross_entropy")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Pretuned (on B200) Helion examples that can just be used right away, without autotuning. Following the style of Triton tutorials (https://triton-lang.org/main/getting-started/tutorials/). Included the same shapes + additional shapes found from OSS models. Currently including kernels that show speedups vs eager. Matmul/attention kernels show slowdowns, should put those up when CuteDSL backend is ready. 
Running layer_norm shows the following output: 
<img width="434" height="581" alt="image" src="https://github.com/user-attachments/assets/4b220b9b-d764-48f1-bf63-c9498eddf313" />