### PR TITLE
[Pallas] Apply tile masks at load time to zero out-of-bounds data

### DIFF
--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -35,12 +35,100 @@ def load_expr(
             return emit_gather(state, pattern.plan, name)
 
     idx_str, none_dims = index_str(state, subscript, tensor)
-    result = expr_from_string(f"{name}[{idx_str}]")
+    mask_expr = _load_mask_expr(state, subscript, tensor)
+    if mask_expr is not None:
+        result = expr_from_string(f"{name}[{idx_str}] * ({mask_expr})")
+    else:
+        result = expr_from_string(f"{name}[{idx_str}]")
     for dim in none_dims:
         result = expr_from_string(
             f"jnp.expand_dims({{result}}, axis={dim})", result=result
         )
     return result
+
+
+def _load_mask_expr(
+    state: CodegenState,
+    subscript: list[object],
+    tensor: torch.Tensor,
+) -> str | None:
+    """Build a mask expression for a Pallas load to zero out-of-bounds data.
+
+    Iterates over the indexing patterns for this load.  For each TilePattern
+    whose loop range does not match the tensor's dimension size (e.g.
+    data-dependent bounds, constexpr sub-ranges), generates a mask term so
+    that out-of-tile positions are zeroed.
+
+    Only applies to dimensions that are ds-padded (the ref is padded to a
+    multiple of block_size).  Grid/tile dimensions where BlockSpecs size the
+    ref to the actual remainder are not masked — a block-sized mask would
+    cause a shape mismatch against the smaller ref.
+    """
+    from helion._compiler.compile_environment import CompileEnvironment
+    from helion._compiler.pallas.plan_tiling import TilePattern
+
+    assert state.fx_node is not None
+    output_val = state.fx_node.meta.get("val")
+    if not isinstance(output_val, torch.Tensor):
+        return None
+
+    indexing_patterns = _get_indexing_patterns(state, tensor)
+    env = CompileEnvironment.current()
+    output_sizes = [*output_val.size()]
+    mask_exprs: list[str] = []
+    dtype_str: str | None = None
+    out_dim = 0
+    tensor_dim = 0
+
+    for idx, pattern in zip(subscript, indexing_patterns, strict=True):
+        if idx is None:
+            out_dim += 1
+            continue
+
+        if isinstance(pattern, TilePattern):
+            block_id = pattern.block_id
+            if _tile_needs_mask(state, block_id, tensor, tensor_dim):
+                mask_var = state.codegen.mask_var(block_id)
+                if mask_var is not None:
+                    if dtype_str is None:
+                        dtype_str = env.backend.dtype_str(tensor.dtype)
+                    expand = state.tile_strategy.expand_str(output_sizes, out_dim)
+                    expr = f"({mask_var}.astype({dtype_str}){expand})"
+                    mask_exprs.append(expr)
+
+        # TODO(dunfanlu): Do other patterns beside TilePattern require masking?
+
+        out_dim += 1
+        tensor_dim += 1
+
+    if not mask_exprs:
+        return None
+    return "*".join(mask_exprs)
+
+
+def _tile_needs_mask(
+    state: CodegenState,
+    block_id: int,
+    tensor: torch.Tensor,
+    tensor_dim: int,
+) -> bool:
+    """Return True when a TilePattern dimension needs load-time masking.
+
+    A mask is needed when the tile loop's iteration range does not cover the
+    full tensor dimension — i.e. the loop end differs from the tensor's
+    symbolic size at *tensor_dim*.  This includes data-dependent bounds and
+    constexpr sub-ranges.
+    """
+    loops = state.codegen.active_device_loops.get(block_id)
+    if not loops:
+        return False
+    info = loops[-1].block_id_to_info.get(block_id)
+    if info is None:
+        return False
+    dim_size = tensor.shape[tensor_dim]
+    if not info.is_end_matching(dim_size):
+        return True
+    return info.begin_expr is not None and info.begin_expr != 0
 
 
 def _can_tile_dimension(state: CodegenState, tensor_dim: int) -> bool:

--- a/test/test_loops.py
+++ b/test/test_loops.py
@@ -382,7 +382,6 @@ class TestLoops(RefEagerTestBase, TestCase):
         code, result = code_and_output(fn, args, block_sizes=[32, 32])
         torch.testing.assert_close(result, args[0][:, : args[1][0].item()].sum(-1))
 
-    @xfailIfPallas("uses block_ptr indexing not supported on pallas")
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
     @skipIfTileIR("TileIR does not support block_ptr indexing")
     def test_data_dependent_bounds2(self):

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -2061,6 +2061,51 @@ class TestPallas(TestCase):
         _code2, result2 = code_and_output(sum_with_dynamic_offset, (data, offsets))
         torch.testing.assert_close(result2, ref, rtol=1e-3, atol=1e-3)
 
+    def test_jagged_sum_3d(self) -> None:
+        """3D jagged sum with load-time masking for out-of-bounds data."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def jagged_sum_3d(
+            x_data: torch.Tensor, x_offsets: torch.Tensor
+        ) -> torch.Tensor:
+            num_rows = x_offsets.size(0) - 1
+            out = torch.zeros([num_rows], dtype=x_data.dtype, device=x_data.device)
+            for seq_index in hl.grid(num_rows):
+                start = x_offsets[seq_index]
+                end = x_offsets[seq_index + 1]
+                row_sums = hl.zeros([1], dtype=x_data.dtype)
+                for tile in hl.tile(start, end):
+                    vals = x_data[tile, :, :]
+                    row_sums = row_sums + vals.sum(dim=0).sum(dim=0).sum(
+                        dim=0
+                    ).unsqueeze(0)
+                out[seq_index] = row_sums.squeeze(0)
+            return out
+
+        num_segments, A, B, max_seqlen = 8, 8, 256, 64
+        seq_lengths = torch.randint(
+            1, max_seqlen + 1, (num_segments,), dtype=torch.int32
+        )
+        x_offsets = torch.cat(
+            [
+                torch.zeros(1, dtype=torch.int32),
+                torch.cumsum(seq_lengths, dim=0).to(torch.int32),
+            ]
+        ).to(DEVICE)
+        N = int(x_offsets[-1])
+        x_data = torch.randn(N, A, B, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            jagged_sum_3d,
+            (x_data, x_offsets),
+        )
+        ref = torch.stack(
+            [
+                x_data[x_offsets[i] : x_offsets[i + 1], :, :].sum()
+                for i in range(num_segments)
+            ]
+        )
+        torch.testing.assert_close(result, ref, rtol=1e-3, atol=1e-3)
+
 
 @skipUnlessPallas("JAX/Pallas TPU not available")
 class TestPallasIndirectGather(TestCase):


### PR DESCRIPTION
Stacked PRs:
 * #2223
 * #2218
 * #2217
 * #2216
 * #2215
 * __->__#2214


--- --- ---

### [Pallas] Apply tile masks at load time to zero out-of-bounds data


Consider this jagged-sum kernel where each segment has a different
length:

    for seq_index in hl.grid(num_rows):
        start = x_offsets[seq_index]
        end = x_offsets[seq_index + 1]
        row_sums = hl.zeros([1], dtype=x_data.dtype)
        for tile in hl.tile(start, end):
            vals = x_data[tile, :, :]
            row_sums += vals.sum()

If segment 0 has length 35, `hl.tile(0, 35)` with block_size=64
iterates once over tile range [0, 64).  The host pads `x_data` along
dim 0 so the Pallas ref has at least 64 rows, but rows 35-63 contain
the next segment's data (or padding garbage).  Without masking, those
29 stale rows are included in the reduction, silently producing wrong
results.

Unlike Triton's `tl.load(mask=, other=0)`, Pallas loads via
`ref[pl.ds()]` return raw memory with no built-in masking.  Fix this
by generating `ref[idx] * mask.astype(dtype)` directly in load
codegen so loaded data is zeroed for out-of-tile positions.

Masking is driven by the indexing patterns: for each TilePattern
dimension, we check whether the loop's iteration range matches the
tensor's symbolic size.  If not (data-dependent bounds, constexpr
sub-ranges, non-zero begin), a mask is applied.  Grid/tile dimensions
where BlockSpecs size the ref to the actual remainder are not masked —
a block-sized mask would cause a shape mismatch against the smaller
ref.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
