### PR TITLE
[Pallas] Fix DMA scratch buffer offset bug in nested fori_loop codegen

### DIFF
--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -294,7 +294,7 @@ def _tile_pattern_code(
     # TODO(yifeixu): the long-term fix is making ``can_tile`` per-loop-scope
     # instead of per-tensor-dim so the planner doesn't mark this dim
     # untileable in pipeline mode in the first place.
-    if in_pipeline and block_id in pipeline_block_ids:
+    if in_pipeline:
         return ":"
 
     can_tile = _can_tile_dimension(state, tensor_dim)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -2061,6 +2061,52 @@ class TestPallas(TestCase):
         _code2, result2 = code_and_output(sum_with_dynamic_offset, (data, offsets))
         torch.testing.assert_close(result2, ref, rtol=1e-3, atol=1e-3)
 
+    def test_dma_buffer_offset_nested_tile(self) -> None:
+        """Inner loop reading outer-tiled tensor must use ':' not absolute offset."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def outer_in_inner(
+            x: torch.Tensor, y: torch.Tensor, offsets: torch.Tensor
+        ) -> torch.Tensor:
+            A = hl.specialize(x.size(1))
+            B = hl.specialize(x.size(2))
+            num_segs = offsets.size(0) - 1
+            out = torch.zeros([num_segs, A, B], dtype=x.dtype, device=x.device)
+            for seg in hl.grid(num_segs):
+                start = offsets[seg]
+                end = offsets[seg + 1]
+                for tile_i in hl.tile(start, end):
+                    for tile_j in hl.tile(start, end):
+                        out[seg, :, :] = (
+                            out[seg, :, :]
+                            + x[tile_i, :, :].sum(dim=0)
+                            + y[tile_j, :, :].sum(dim=0)
+                        )
+            return out
+
+        N, A, B = 128, 8, 256
+        x = torch.randn(N, A, B, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(N, A, B, device=DEVICE, dtype=torch.float32)
+        offsets = torch.tensor([0, 64, 128], device=DEVICE, dtype=torch.int32)
+
+        _code, result = code_and_output(
+            outer_in_inner,
+            (x, y, offsets),
+            block_sizes=[32, 32],
+            pallas_loop_type="fori_loop",
+        )
+
+        block = 32
+        ref = torch.zeros(offsets.size(0) - 1, A, B, device=DEVICE, dtype=x.dtype)
+        for seg in range(offsets.size(0) - 1):
+            s, e = int(offsets[seg]), int(offsets[seg + 1])
+            for i in range(0, e - s, block):
+                for j in range(0, e - s, block):
+                    ref[seg] += x[s + i : s + i + block].sum(dim=0) + y[
+                        s + j : s + j + block
+                    ].sum(dim=0)
+        torch.testing.assert_close(result, ref, rtol=1e-3, atol=1e-3)
+
     def test_jagged_sum_3d(self) -> None:
         """3D jagged sum with load-time masking for out-of-bounds data."""
 


### PR DESCRIPTION
Stacked PRs:
 * #2223
 * #2218
 * #2216
 * #2215
 * __->__#2217


--- --- ---

### [Pallas] Fix DMA scratch buffer offset bug in nested fori_loop codegen


When a tensor is DMA'd inside an inner fori_loop, _build_hbm_dma_slice
correctly slices ALL tiled dimensions (both the inner loop's block_ids
and outer loop/grid dims). The VMEM scratch buffer therefore has every
dimension already at tile size.

However, _tile_pattern_code only returned ":" for dimensions whose
block_id was in the inner loop's pipeline_block_ids set. Dimensions
tiled by an outer loop fell through to _ds_expr(), which applied the
outer loop's global offset on the small scratch buffer — an
out-of-bounds access when the offset was non-zero.

Fix: when in_pipeline is True (tensor is DMA'd), return ":" for ALL
TilePattern dimensions unconditionally.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
