### PR TITLE
Fix tensor descriptor silent fallback for scalar SymInt subscripts

### DIFF
--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -24,6 +24,7 @@ from .host_function import HostFunction
 from .tile_strategy import DeviceLoopState
 from .utils import compute_slice_size
 from .variable_origin import BlockSizeOrigin
+from .variable_origin import GridOrigin
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -507,9 +508,8 @@ class TensorDescriptorIndexingStrategy(IndexingStrategy):
                     ].from_config(config)
                     if not valid_block_size(block_size, stride, i):
                         return False
-                # Non-BlockSizeOrigin SymInt is a scalar index
-                # (block_shape=1 in BlockedSubscriptIndexing.create),
-                # same as int — no valid_block_size check needed.
+                elif not (origin and isinstance(origin.origin, GridOrigin)):
+                    return False
 
         return True
 

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -138,6 +138,8 @@ def _scalar_symint_can_codegen_as_scalar(k: torch.SymInt) -> bool:
 
     expr_to_origin = HostFunction.current().expr_to_origin
     for symbol in expr.free_symbols:
+        if not isinstance(symbol, sympy.Symbol):
+            return False
         # Every symbol must be known to DeviceFunction.sympy_expr(), otherwise
         # tensor descriptor lowering would fail when printing the scalar offset.
         origin_info = expr_to_origin.get(symbol)

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -25,6 +25,7 @@ from .tile_strategy import DeviceLoopState
 from .utils import compute_slice_size
 from .variable_origin import BlockSizeOrigin
 from .variable_origin import GridOrigin
+from .variable_origin import TileBeginOrigin
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -124,6 +125,32 @@ def _resolve_codegen_block_id(state: CodegenState, block_id: int) -> int:
     env = CompileEnvironment.current()
     graph = state.fx_node.graph if state.fx_node is not None else None
     return env.resolve_codegen_block_id(block_id, state.codegen, graph)
+
+
+def _scalar_symint_can_codegen_as_scalar(k: torch.SymInt) -> bool:
+    expr = _symint_expr(k)
+    if not isinstance(expr, sympy.Expr):
+        return False
+    if not expr.free_symbols:
+        return True
+
+    expr_to_origin = HostFunction.current().expr_to_origin
+    for symbol in expr.free_symbols:
+        origin_info = expr_to_origin.get(symbol)
+        if origin_info is None:
+            return False
+
+        origin = origin_info.origin
+        if isinstance(origin, BlockSizeOrigin):
+            return False
+        if isinstance(origin, GridOrigin):
+            if type(origin) is GridOrigin or isinstance(origin, TileBeginOrigin):
+                continue
+            return False
+        if not origin.is_host():
+            return False
+
+    return True
 
 
 def _has_active_codegen_block(state: CodegenState, block_idx: int) -> bool:
@@ -503,12 +530,12 @@ class TensorDescriptorIndexingStrategy(IndexingStrategy):
                 if isinstance(symbol, sympy.Symbol):
                     origin = HostFunction.current().expr_to_origin.get(symbol)
                 if origin and isinstance(origin.origin, BlockSizeOrigin):
-                    block_size = env.block_sizes[
-                        origin.origin.block_id
-                    ].from_config(config)
+                    block_size = env.block_sizes[origin.origin.block_id].from_config(
+                        config
+                    )
                     if not valid_block_size(block_size, stride, i):
                         return False
-                elif not (origin and isinstance(origin.origin, GridOrigin)):
+                elif not _scalar_symint_can_codegen_as_scalar(k):
                     return False
 
         return True

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -131,24 +131,35 @@ def _scalar_symint_can_codegen_as_scalar(k: torch.SymInt) -> bool:
     expr = _symint_expr(k)
     if not isinstance(expr, sympy.Expr):
         return False
+
+    # Constants, including SymInts simplified to constants, are scalar offsets.
     if not expr.free_symbols:
         return True
 
     expr_to_origin = HostFunction.current().expr_to_origin
     for symbol in expr.free_symbols:
+        # Every symbol must be known to DeviceFunction.sympy_expr(), otherwise
+        # tensor descriptor lowering would fail when printing the scalar offset.
         origin_info = expr_to_origin.get(symbol)
         if origin_info is None:
             return False
 
         origin = origin_info.origin
+        # BlockSizeOrigin represents a descriptor block extent, not a scalar
+        # offset. Those symbols must use the block-size validation path above.
         if isinstance(origin, BlockSizeOrigin):
             return False
         if isinstance(origin, GridOrigin):
-            # Exact GridOrigin is used for hl.grid() variables and already
-            # represents the loop offset; subclasses may need different math.
+            # Exact GridOrigin (hl.grid()) and TileBeginOrigin (tile.begin)
+            # already represent the loop offset. Other GridOrigin subclasses
+            # such as tile.end/count/id need different math, so fall back.
             if type(origin) is GridOrigin or isinstance(origin, TileBeginOrigin):
                 continue
             return False
+
+        # Host-derived values (scalar args, tensor sizes, attributes/items) can
+        # be lifted as scalar arguments. Device-derived values are not uniform
+        # descriptor offsets.
         if not origin.is_host():
             return False
 

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -144,6 +144,8 @@ def _scalar_symint_can_codegen_as_scalar(k: torch.SymInt) -> bool:
         if isinstance(origin, BlockSizeOrigin):
             return False
         if isinstance(origin, GridOrigin):
+            # Exact GridOrigin is used for hl.grid() variables and already
+            # represents the loop offset; subclasses may need different math.
             if type(origin) is GridOrigin or isinstance(origin, TileBeginOrigin):
                 continue
             return False

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -497,12 +497,19 @@ class TensorDescriptorIndexingStrategy(IndexingStrategy):
                 if not valid_block_size(block_size, stride, i):
                     return False
             elif isinstance(k, torch.SymInt):
-                block_id = env.get_block_id(k)
-                if block_id is None:
-                    return False
-                block_size = env.block_sizes[block_id].from_config(config)
-                if not valid_block_size(block_size, stride, i):
-                    return False
+                symbol = _symint_expr(k)
+                origin = None
+                if isinstance(symbol, sympy.Symbol):
+                    origin = HostFunction.current().expr_to_origin.get(symbol)
+                if origin and isinstance(origin.origin, BlockSizeOrigin):
+                    block_size = env.block_sizes[
+                        origin.origin.block_id
+                    ].from_config(config)
+                    if not valid_block_size(block_size, stride, i):
+                        return False
+                # Non-BlockSizeOrigin SymInt is a scalar index
+                # (block_shape=1 in BlockedSubscriptIndexing.create),
+                # same as int — no valid_block_size check needed.
 
         return True
 

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -461,7 +461,7 @@ class TensorDescriptorIndexingStrategy(IndexingStrategy):
 
         # 2) Exactly 1 dimension should have stride==1
         env = CompileEnvironment.current()
-        stride_one_count = 0
+        stride_one_dim = None
         element_size = fake_tensor.element_size()
         for dim in range(fake_tensor.ndim):
             raw_stride = fake_tensor.stride(dim)
@@ -475,17 +475,21 @@ class TensorDescriptorIndexingStrategy(IndexingStrategy):
                 # it holds for all shapes in the specialization bucket.
                 hint = env.size_hint(raw_stride)
                 if hint == 1:
-                    stride_one_count += 1
+                    if stride_one_dim is not None:
+                        return False
+                    stride_one_dim = dim
                     continue
                 return False
             if stride == 1:
-                stride_one_count += 1
+                if stride_one_dim is not None:
+                    return False
+                stride_one_dim = dim
             else:
                 # 3) All other dimensions should have 16-byte aligned strides
                 byte_stride = stride * element_size
                 if byte_stride % 16 != 0:
                     return False
-        if stride_one_count != 1:
+        if stride_one_dim is None:
             # There should be exactly one dimension with stride==1
             return False
 
@@ -512,7 +516,9 @@ class TensorDescriptorIndexingStrategy(IndexingStrategy):
             # generated stores stay aligned and avoid misaligned-address errors.
             return block_size * element_size >= 16
 
-        # 4) Check minimum 16 bytes in each dimension
+        # 4) Validate subscript forms and collect the block_shape that will be
+        # passed to tl.make_tensor_descriptor.
+        descriptor_block_shape: list[int | torch.SymInt] = []
         sizes = fake_tensor.size()
         strides = fake_tensor.stride()
         size_stride = collections.deque(zip(sizes, strides, strict=True))
@@ -521,11 +527,14 @@ class TensorDescriptorIndexingStrategy(IndexingStrategy):
             if k is None:
                 continue
             size, stride = size_stride.popleft()
-            if isinstance(k, slice):
+            if isinstance(k, int):
+                descriptor_block_shape.append(1)
+            elif isinstance(k, slice):
                 # Slices with steps are not supported in tensor descriptor mode
                 if k.step is not None and k.step != 1:
                     return False
                 block_size = env.allocate_reduction_dimension(size).from_config(config)
+                descriptor_block_shape.append(block_size)
                 if not valid_block_size(block_size, stride, i):
                     return False
             elif (
@@ -537,6 +546,7 @@ class TensorDescriptorIndexingStrategy(IndexingStrategy):
                     if tile_info.block_size is not None
                     else env.block_sizes[tile_info.block_id].from_config(config)
                 )
+                descriptor_block_shape.append(block_size)
                 if not valid_block_size(block_size, stride, i):
                     return False
             elif isinstance(k, torch.SymInt):
@@ -548,12 +558,21 @@ class TensorDescriptorIndexingStrategy(IndexingStrategy):
                     block_size = env.block_sizes[origin.origin.block_id].from_config(
                         config
                     )
+                    descriptor_block_shape.append(block_size)
                     if not valid_block_size(block_size, stride, i):
                         return False
-                elif not _scalar_symint_can_codegen_as_scalar(k):
-                    return False
+                else:
+                    descriptor_block_shape.append(1)
+                    if not _scalar_symint_can_codegen_as_scalar(k):
+                        return False
 
-        return True
+        if len(descriptor_block_shape) != fake_tensor.ndim:
+            return False
+        return valid_block_size(
+            descriptor_block_shape[stride_one_dim],
+            fake_tensor.stride(stride_one_dim),
+            stride_one_dim,
+        )
 
     def codegen_load(
         self,

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -459,7 +459,9 @@ class TensorDescriptorIndexingStrategy(IndexingStrategy):
         if not (2 <= fake_tensor.ndim <= 5):
             return False
 
-        # 2) Exactly 1 dimension should have stride==1
+        # 2) Exactly one dimension must be contiguous. Triton may permute the
+        # descriptor so this dimension is last, but support checks are easier
+        # to express in the original tensor dimension order.
         env = CompileEnvironment.current()
         stride_one_dim = None
         element_size = fake_tensor.element_size()
@@ -486,6 +488,7 @@ class TensorDescriptorIndexingStrategy(IndexingStrategy):
                 stride_one_dim = dim
             else:
                 # 3) All other dimensions should have 16-byte aligned strides
+                # so the descriptor remains valid for the whole tensor layout.
                 byte_stride = stride * element_size
                 if byte_stride % 16 != 0:
                     return False
@@ -516,8 +519,10 @@ class TensorDescriptorIndexingStrategy(IndexingStrategy):
             # generated stores stay aligned and avoid misaligned-address errors.
             return block_size * element_size >= 16
 
-        # 4) Validate subscript forms and collect the block_shape that will be
-        # passed to tl.make_tensor_descriptor.
+        # 4) Validate subscript forms and collect the descriptor block_shape in
+        # tensor-dimension order. Scalar indices become block_shape=1, which is
+        # fine for batch/head dimensions but invalid if it lands on the
+        # contiguous dimension checked below.
         descriptor_block_shape: list[int | torch.SymInt] = []
         sizes = fake_tensor.size()
         strides = fake_tensor.stride()
@@ -528,15 +533,18 @@ class TensorDescriptorIndexingStrategy(IndexingStrategy):
                 continue
             size, stride = size_stride.popleft()
             if isinstance(k, int):
+                # Python integer indexing collapses this tensor dimension to a
+                # scalar offset, so the descriptor block in that dimension is 1.
                 descriptor_block_shape.append(1)
             elif isinstance(k, slice):
                 # Slices with steps are not supported in tensor descriptor mode
                 if k.step is not None and k.step != 1:
                     return False
                 block_size = env.allocate_reduction_dimension(size).from_config(config)
-                descriptor_block_shape.append(block_size)
                 if not valid_block_size(block_size, stride, i):
                     return False
+                assert isinstance(block_size, int)
+                descriptor_block_shape.append(block_size)
             elif (
                 tile_info := _get_tile_with_offset_info(k, state.fx_node, i)
             ) is not None:
@@ -546,9 +554,10 @@ class TensorDescriptorIndexingStrategy(IndexingStrategy):
                     if tile_info.block_size is not None
                     else env.block_sizes[tile_info.block_id].from_config(config)
                 )
-                descriptor_block_shape.append(block_size)
                 if not valid_block_size(block_size, stride, i):
                     return False
+                assert isinstance(block_size, int)
+                descriptor_block_shape.append(block_size)
             elif isinstance(k, torch.SymInt):
                 symbol = _symint_expr(k)
                 origin = None
@@ -558,16 +567,25 @@ class TensorDescriptorIndexingStrategy(IndexingStrategy):
                     block_size = env.block_sizes[origin.origin.block_id].from_config(
                         config
                     )
-                    descriptor_block_shape.append(block_size)
                     if not valid_block_size(block_size, stride, i):
                         return False
+                    assert isinstance(block_size, int)
+                    descriptor_block_shape.append(block_size)
                 else:
+                    # Lowerable scalar SymInt offsets also collapse the tensor
+                    # dimension to block_shape=1. The final stride-one check
+                    # below decides whether that scalar dimension is legal for
+                    # tensor descriptors.
                     descriptor_block_shape.append(1)
                     if not _scalar_symint_can_codegen_as_scalar(k):
                         return False
 
         if len(descriptor_block_shape) != fake_tensor.ndim:
             return False
+        # Triton requires the descriptor's contiguous dimension to cover at
+        # least 16 bytes. This catches cases like g[batch, tile_t, head], where
+        # scalar head indexing would emit block_shape=[1, block_t, 1] and the
+        # stride-one dimension would move only one element.
         return valid_block_size(
             descriptor_block_shape[stride_one_dim],
             fake_tensor.stride(stride_one_dim),

--- a/test/test_atomic_ops.py
+++ b/test/test_atomic_ops.py
@@ -798,7 +798,6 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
             self.assertIn("tl.atomic_xchg", code)
             self.assertNotIn("desc.atomic_xchg", code)
 
-
     @onlyBackends("triton")
     @skipIfRocm("Tensor descriptor not supported on ROCm")
     @skipIfTileIR("TileIR does not support descriptor atomics")
@@ -813,13 +812,15 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
             ),
             static_shapes=True,
         )
-        def batched_atomic_add(
-            x: torch.Tensor, y: torch.Tensor
-        ) -> torch.Tensor:
+        def batched_atomic_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
             B, M, N = x.size()
             for tile_b in hl.tile(B, block_size=1):
                 for tile_m, tile_n in hl.tile([M, N]):
-                    hl.atomic_add(x, [tile_b.begin, tile_m, tile_n], y[tile_b.begin, tile_m, tile_n])
+                    hl.atomic_add(
+                        x,
+                        [tile_b.begin, tile_m, tile_n],
+                        y[tile_b.begin, tile_m, tile_n],
+                    )
             return x
 
         x = torch.zeros(4, 64, 64, device=DEVICE, dtype=torch.float32)

--- a/test/test_atomic_ops.py
+++ b/test/test_atomic_ops.py
@@ -802,7 +802,7 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
     @skipIfRocm("Tensor descriptor not supported on ROCm")
     @skipIfTileIR("TileIR does not support descriptor atomics")
     def test_atomic_td_scalar_symint(self):
-        """tile.begin in atomic subscript should not prevent descriptor atomics."""
+        """Composite scalar SymInts should not prevent descriptor atomics."""
 
         @helion.kernel(
             config=helion.Config(
@@ -812,21 +812,26 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
             ),
             static_shapes=True,
         )
-        def batched_atomic_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        def batched_atomic_add(
+            x: torch.Tensor, y: torch.Tensor, start: int
+        ) -> torch.Tensor:
             B, M, N = x.size()
-            for tile_b in hl.tile(B, block_size=1):
+            for tile_b in hl.tile(B - start, block_size=1):
                 for tile_m, tile_n in hl.tile([M, N]):
+                    batch = start + tile_b.begin
                     hl.atomic_add(
                         x,
-                        [tile_b.begin, tile_m, tile_n],
-                        y[tile_b.begin, tile_m, tile_n],
+                        [batch, tile_m, tile_n],
+                        y[batch, tile_m, tile_n],
                     )
             return x
 
         x = torch.zeros(4, 64, 64, device=DEVICE, dtype=torch.float32)
         y = torch.ones(4, 64, 64, device=DEVICE, dtype=torch.float32)
-        code, result = code_and_output(batched_atomic_add, (x, y))
-        torch.testing.assert_close(result, y)
+        code, result = code_and_output(batched_atomic_add, (x, y, 1))
+        expected = torch.zeros_like(x)
+        expected[1:] = 1
+        torch.testing.assert_close(result, expected)
         self.assertIn("desc.atomic_add(", code)
         self.assertNotIn("tl.atomic_add(", code)
 

--- a/test/test_atomic_ops.py
+++ b/test/test_atomic_ops.py
@@ -799,5 +799,36 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
             self.assertNotIn("desc.atomic_xchg", code)
 
 
+    @onlyBackends("triton")
+    @skipIfRocm("Tensor descriptor not supported on ROCm")
+    @skipIfTileIR("TileIR does not support descriptor atomics")
+    def test_atomic_td_scalar_symint(self):
+        """tile.begin in atomic subscript should not prevent descriptor atomics."""
+
+        @helion.kernel(
+            config=helion.Config(
+                block_sizes=[64, 64],
+                indexing="tensor_descriptor",
+                atomic_indexing="tensor_descriptor",
+            ),
+            static_shapes=True,
+        )
+        def batched_atomic_add(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            B, M, N = x.size()
+            for tile_b in hl.tile(B, block_size=1):
+                for tile_m, tile_n in hl.tile([M, N]):
+                    hl.atomic_add(x, [tile_b.begin, tile_m, tile_n], y[tile_b.begin, tile_m, tile_n])
+            return x
+
+        x = torch.zeros(4, 64, 64, device=DEVICE, dtype=torch.float32)
+        y = torch.ones(4, 64, 64, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(batched_atomic_add, (x, y))
+        torch.testing.assert_close(result, y)
+        self.assertIn("desc.atomic_add(", code)
+        self.assertNotIn("tl.atomic_add(", code)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -118,7 +118,7 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(
             grid_2d_idx_list,
             args,
-            block_sizes=[64, 32, 16],
+            block_sizes=[64, 16, 16],
             indexing="tensor_descriptor",
         )
         torch.testing.assert_close(result, grid_2d_pytorch(args[0], args[1]))

--- a/test/test_tensor_descriptor.py
+++ b/test/test_tensor_descriptor.py
@@ -509,37 +509,16 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
         result_unaligned = add_one(x_unaligned)
         torch.testing.assert_close(result_unaligned, x_unaligned + 1.0)
 
-    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
-    def test_scalar_symint_subscript(self):
-        """tile.begin (a SymInt without BlockSizeOrigin) should not prevent
-        tensor descriptor indexing.  Before the fix, is_supported() rejected
-        these and silently fell back to pointer indexing."""
-
-        @helion.kernel(
-            config=helion.Config(
-                block_sizes=[64],
-                indexing="tensor_descriptor",
-            ),
-            static_shapes=True,
-        )
-        def batched_add(x: torch.Tensor) -> torch.Tensor:
-            B, N = x.size()
-            out = torch.empty_like(x)
-            for tile_b in hl.tile(B, block_size=1):
-                for tile_n in hl.tile(N):
-                    out[tile_b.begin, tile_n] = x[tile_b.begin, tile_n] + 1.0
-            return out
-
-        x = torch.randn(4, 128, device=DEVICE, dtype=torch.float32)
-        code, result = code_and_output(batched_add, (x,))
-        torch.testing.assert_close(result, x + 1.0)
-
+    def assert_uses_tensor_descriptors(self, code: str) -> None:
         self.assertIn(get_tensor_descriptor_fn_name(), code)
         self.assertNotIn("tl.load(", code)
         self.assertNotIn("tl.store(", code)
 
+    def assert_tensor_descriptor_not_used_for(self, code: str, name: str) -> None:
+        self.assertNotIn(f"{name}_desc = {get_tensor_descriptor_fn_name()}", code)
+
     @skipUnlessTensorDescriptor("Tensor descriptor support is required")
-    def test_composite_scalar_symint_subscript(self):
+    def test_scalar_symint_subscript_allowlist(self):
         """Known scalar SymInt expressions should still use tensor descriptors."""
 
         @helion.kernel(
@@ -551,24 +530,13 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
         )
         def gather_rows(x: torch.Tensor, start: int) -> torch.Tensor:
             _, n = x.size()
-            out = torch.empty([2, n], device=x.device, dtype=x.dtype)
+            out = torch.empty([4, n], device=x.device, dtype=x.dtype)
             for tile_n in hl.tile(n):
-                out[0, tile_n] = x[start + 3, tile_n]
-                out[1, tile_n] = x[start - start + 1, tile_n]
+                out[0, tile_n] = x[3, tile_n]
+                out[1, tile_n] = x[start, tile_n]
+                out[2, tile_n] = x[start + 3, tile_n]
+                out[3, tile_n] = x[start - start + 1, tile_n]
             return out
-
-        x = torch.randn(8, 128, device=DEVICE, dtype=torch.float32)
-        code, result = code_and_output(gather_rows, (x, 2))
-        expected = torch.stack([x[5], x[1]])
-        torch.testing.assert_close(result, expected)
-
-        self.assertIn(get_tensor_descriptor_fn_name(), code)
-        self.assertNotIn("tl.load(", code)
-        self.assertNotIn("tl.store(", code)
-
-    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
-    def test_composite_tile_begin_scalar_symint_subscript(self):
-        """Scalar expressions composed with tile.begin are descriptor-safe."""
 
         @helion.kernel(
             config=helion.Config(
@@ -586,13 +554,123 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
                     out[tile_b.begin, tile_n] = x[start + tile_b.begin, tile_n]
             return out
 
+        @helion.kernel(
+            config=helion.Config(
+                block_sizes=[64],
+                indexing="tensor_descriptor",
+            ),
+            static_shapes=True,
+        )
+        def copy_grid_rows(x: torch.Tensor) -> torch.Tensor:
+            _, n = x.size()
+            rows = 4
+            out = torch.empty([rows, n], device=x.device, dtype=x.dtype)
+            for row in hl.grid(rows):
+                for tile_n in hl.tile(n):
+                    out[row, tile_n] = x[row, tile_n]
+            return out
+
         x = torch.randn(8, 128, device=DEVICE, dtype=torch.float32)
+
+        code, result = code_and_output(gather_rows, (x, 2))
+        expected = torch.stack([x[3], x[2], x[5], x[1]])
+        torch.testing.assert_close(result, expected)
+        self.assert_uses_tensor_descriptors(code)
+
         code, result = code_and_output(copy_offset_rows, (x, 2))
         torch.testing.assert_close(result, x[2:6])
+        self.assert_uses_tensor_descriptors(code)
 
-        self.assertIn(get_tensor_descriptor_fn_name(), code)
-        self.assertNotIn("tl.load(", code)
-        self.assertNotIn("tl.store(", code)
+        code, result = code_and_output(copy_grid_rows, (x,))
+        torch.testing.assert_close(result, x[:4])
+        self.assert_uses_tensor_descriptors(code)
+
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
+    def test_scalar_symint_subscript_blocklist(self):
+        """Unsafe scalar SymInt expressions should fall back for that tensor."""
+
+        @helion.kernel(
+            config=helion.Config(
+                block_sizes=[64],
+                indexing="tensor_descriptor",
+            ),
+            static_shapes=True,
+        )
+        def read_tile_end(x: torch.Tensor) -> torch.Tensor:
+            _, n = x.size()
+            rows = 4
+            out = torch.empty([rows, n], device=x.device, dtype=x.dtype)
+            for tile_b in hl.tile(rows, block_size=1):
+                for tile_n in hl.tile(n):
+                    out[tile_b.begin, tile_n] = x[tile_b.end, tile_n]
+            return out
+
+        @helion.kernel(
+            config=helion.Config(
+                block_sizes=[64],
+                indexing="tensor_descriptor",
+            ),
+            static_shapes=True,
+        )
+        def read_tile_count(x: torch.Tensor) -> torch.Tensor:
+            _, n = x.size()
+            rows = 4
+            out = torch.empty([rows, n], device=x.device, dtype=x.dtype)
+            for tile_b in hl.tile(rows, block_size=1):
+                for tile_n in hl.tile(n):
+                    out[tile_b.begin, tile_n] = x[tile_b.count, tile_n]
+            return out
+
+        @helion.kernel(
+            config=helion.Config(
+                block_sizes=[64],
+                indexing="tensor_descriptor",
+            ),
+            static_shapes=True,
+        )
+        def read_tile_id(x: torch.Tensor) -> torch.Tensor:
+            _, n = x.size()
+            rows = 4
+            out = torch.empty([rows, n], device=x.device, dtype=x.dtype)
+            for tile_b in hl.tile(rows, block_size=1):
+                for tile_n in hl.tile(n):
+                    out[tile_b.begin, tile_n] = x[tile_b.id, tile_n]
+            return out
+
+        @helion.kernel(
+            config=helion.Config(
+                block_sizes=[64, 64],
+                indexing="tensor_descriptor",
+            ),
+            static_shapes=True,
+        )
+        def read_indirect_rows(x: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
+            _, n = x.size()
+            rows = indices.size(0)
+            out = torch.empty([rows, n], device=x.device, dtype=x.dtype)
+            for tile_b, tile_n in hl.tile([rows, n]):
+                idx = indices[tile_b]
+                out[tile_b, tile_n] = x[idx, tile_n]
+            return out
+
+        x = torch.randn(8, 128, device=DEVICE, dtype=torch.float32)
+
+        code, result = code_and_output(read_tile_end, (x,))
+        torch.testing.assert_close(result, x[1:5])
+        self.assert_tensor_descriptor_not_used_for(code, "x")
+
+        code, result = code_and_output(read_tile_count, (x,))
+        torch.testing.assert_close(result, x[4].expand(4, 128))
+        self.assert_tensor_descriptor_not_used_for(code, "x")
+
+        code, result = code_and_output(read_tile_id, (x,))
+        torch.testing.assert_close(result, x[:4])
+        self.assert_tensor_descriptor_not_used_for(code, "x")
+
+        indices = torch.tensor([3, 1, 4, 0], device=DEVICE, dtype=torch.int64)
+        code, result = code_and_output(read_indirect_rows, (x, indices))
+        torch.testing.assert_close(result, x[indices])
+        self.assert_tensor_descriptor_not_used_for(code, "x")
 
 
 if __name__ == "__main__":

--- a/test/test_tensor_descriptor.py
+++ b/test/test_tensor_descriptor.py
@@ -510,5 +510,35 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result_unaligned, x_unaligned + 1.0)
 
 
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
+    def test_scalar_symint_subscript(self):
+        """tile.begin (a SymInt without BlockSizeOrigin) should not prevent
+        tensor descriptor indexing.  Before the fix, is_supported() rejected
+        these and silently fell back to pointer indexing."""
+
+        @helion.kernel(
+            config=helion.Config(
+                block_sizes=[64],
+                indexing="tensor_descriptor",
+            ),
+            static_shapes=True,
+        )
+        def batched_add(x: torch.Tensor) -> torch.Tensor:
+            B, N = x.size()
+            out = torch.empty_like(x)
+            for tile_b in hl.tile(B, block_size=1):
+                for tile_n in hl.tile(N):
+                    out[tile_b.begin, tile_n] = x[tile_b.begin, tile_n] + 1.0
+            return out
+
+        x = torch.randn(4, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(batched_add, (x,))
+        torch.testing.assert_close(result, x + 1.0)
+
+        self.assertIn(get_tensor_descriptor_fn_name(), code)
+        self.assertNotIn("tl.load(", code)
+        self.assertNotIn("tl.store(", code)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_tensor_descriptor.py
+++ b/test/test_tensor_descriptor.py
@@ -474,6 +474,18 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
         expected = x + 1.0
         torch.testing.assert_close(result, expected)
 
+        # Repeat with a 2-byte dtype to ensure the byte-size check scales with
+        # dtype, not just element count. block_size=4 gives 4 * 2 = 8 bytes.
+        x_half = torch.randn([8, 16], device=DEVICE, dtype=HALF_DTYPE)
+        code_half, result_half = code_and_output(
+            kernel_small_block,
+            (x_half,),
+            indexing="tensor_descriptor",
+            block_sizes=[4, 4],
+        )
+        self.assertNotIn(get_tensor_descriptor_fn_name(), code_half)
+        torch.testing.assert_close(result_half, x_half + 1.0)
+
     @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_dynamic_shape_stride_alignment(self):
         """Test that aligned and unaligned strides produce correct results with dynamic shapes.
@@ -570,7 +582,22 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
                     out[row, tile_n] = x[row, tile_n]
             return out
 
+        @helion.kernel(
+            config=helion.Config(
+                block_sizes=[64, 64],
+                indexing="tensor_descriptor",
+            ),
+            static_shapes=True,
+        )
+        def scalar_noncontiguous_dims(x: torch.Tensor) -> torch.Tensor:
+            _, _, t, d = x.size()
+            out = torch.empty([t, d], device=x.device, dtype=x.dtype)
+            for tile_t, tile_d in hl.tile([t, d]):
+                out[tile_t, tile_d] = x[0, 0, tile_t, tile_d]
+            return out
+
         x = torch.randn(8, 128, device=DEVICE, dtype=torch.float32)
+        x4d = torch.randn(2, 4, 128, 64, device=DEVICE, dtype=torch.float32)
 
         code, result = code_and_output(gather_rows, (x, 2))
         expected = torch.stack([x[3], x[2], x[5], x[1]])
@@ -583,6 +610,10 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
 
         code, result = code_and_output(copy_grid_rows, (x,))
         torch.testing.assert_close(result, x[:4])
+        self.assert_uses_tensor_descriptors(code)
+
+        code, result = code_and_output(scalar_noncontiguous_dims, (x4d,))
+        torch.testing.assert_close(result, x4d[0, 0])
         self.assert_uses_tensor_descriptors(code)
 
     @skipUnlessTensorDescriptor("Tensor descriptor support is required")
@@ -653,7 +684,22 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
                 out[tile_b, tile_n] = x[idx, tile_n]
             return out
 
+        @helion.kernel(
+            config=helion.Config(
+                block_sizes=[64],
+                indexing="tensor_descriptor",
+            ),
+            static_shapes=True,
+        )
+        def scalar_contiguous_dim(g: torch.Tensor) -> torch.Tensor:
+            _, t, _ = g.size()
+            out = torch.empty([t], device=g.device, dtype=g.dtype)
+            for tile_t in hl.tile(t):
+                out[tile_t] = g[0, tile_t, 0]
+            return out
+
         x = torch.randn(8, 128, device=DEVICE, dtype=torch.float32)
+        g = torch.randn(2, 128, 80, device=DEVICE, dtype=torch.float32)
 
         code, result = code_and_output(read_tile_end, (x,))
         torch.testing.assert_close(result, x[1:5])
@@ -671,6 +717,10 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
         code, result = code_and_output(read_indirect_rows, (x, indices))
         torch.testing.assert_close(result, x[indices])
         self.assert_tensor_descriptor_not_used_for(code, "x")
+
+        code, result = code_and_output(scalar_contiguous_dim, (g,))
+        torch.testing.assert_close(result, g[0, :, 0])
+        self.assert_tensor_descriptor_not_used_for(code, "g")
 
 
 if __name__ == "__main__":

--- a/test/test_tensor_descriptor.py
+++ b/test/test_tensor_descriptor.py
@@ -509,7 +509,6 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
         result_unaligned = add_one(x_unaligned)
         torch.testing.assert_close(result_unaligned, x_unaligned + 1.0)
 
-
     @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_scalar_symint_subscript(self):
         """tile.begin (a SymInt without BlockSizeOrigin) should not prevent
@@ -534,6 +533,62 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
         x = torch.randn(4, 128, device=DEVICE, dtype=torch.float32)
         code, result = code_and_output(batched_add, (x,))
         torch.testing.assert_close(result, x + 1.0)
+
+        self.assertIn(get_tensor_descriptor_fn_name(), code)
+        self.assertNotIn("tl.load(", code)
+        self.assertNotIn("tl.store(", code)
+
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
+    def test_composite_scalar_symint_subscript(self):
+        """Known scalar SymInt expressions should still use tensor descriptors."""
+
+        @helion.kernel(
+            config=helion.Config(
+                block_sizes=[64],
+                indexing="tensor_descriptor",
+            ),
+            static_shapes=True,
+        )
+        def gather_rows(x: torch.Tensor, start: int) -> torch.Tensor:
+            _, n = x.size()
+            out = torch.empty([2, n], device=x.device, dtype=x.dtype)
+            for tile_n in hl.tile(n):
+                out[0, tile_n] = x[start + 3, tile_n]
+                out[1, tile_n] = x[start - start + 1, tile_n]
+            return out
+
+        x = torch.randn(8, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(gather_rows, (x, 2))
+        expected = torch.stack([x[5], x[1]])
+        torch.testing.assert_close(result, expected)
+
+        self.assertIn(get_tensor_descriptor_fn_name(), code)
+        self.assertNotIn("tl.load(", code)
+        self.assertNotIn("tl.store(", code)
+
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
+    def test_composite_tile_begin_scalar_symint_subscript(self):
+        """Scalar expressions composed with tile.begin are descriptor-safe."""
+
+        @helion.kernel(
+            config=helion.Config(
+                block_sizes=[64],
+                indexing="tensor_descriptor",
+            ),
+            static_shapes=True,
+        )
+        def copy_offset_rows(x: torch.Tensor, start: int) -> torch.Tensor:
+            _, n = x.size()
+            rows = 4
+            out = torch.empty([rows, n], device=x.device, dtype=x.dtype)
+            for tile_b in hl.tile(rows, block_size=1):
+                for tile_n in hl.tile(n):
+                    out[tile_b.begin, tile_n] = x[start + tile_b.begin, tile_n]
+            return out
+
+        x = torch.randn(8, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(copy_offset_rows, (x, 2))
+        torch.testing.assert_close(result, x[2:6])
 
         self.assertIn(get_tensor_descriptor_fn_name(), code)
         self.assertNotIn("tl.load(", code)


### PR DESCRIPTION
`TensorDescriptorIndexingStrategy.is_supported()` rejected scalar SymInt subscript elements (tile.begin, tile.index, range loop variables) that lack BlockSizeOrigin, silently falling back to pointer indexing even when indexing="tensor_descriptor" was configured.

TensorDescriptorIndexingStrategy.is_supported() still treats BlockSizeOrigin SymInts as block dimensions. Those go through the existing block-size path: resolve the configured block size and validate descriptor constraints such as static integer block size and minimum 16-byte transfer size. 

We will now enable tensor_descriptor for the following patterns:

  | Pattern | Example | Why allowed | Descriptor behavior |
  |---|---|---|---|
  | Plain Python int | x[3, tile_n] | Handled before SymInt; always a scalar offset. | block_shape=1 for that dim |
  | Symbol-free SymInt | x[start - start + 1, tile_n] | SymPy expression has no free symbols after simplification. | Scalar descriptor offset |
  | Host scalar arg | x[start, tile_n] | start has host origin and can be lowered as a kernel scalar arg. | Scalar descriptor offset |
  | Host scalar expression | x[start + 3, tile_n] | All free symbols have host origins. | Scalar descriptor offset |
  | Exact GridOrigin | x[grid_i, tile_n] from hl.grid() style symbols | Exact GridOrigin already represents loop offset. | Scalar descriptor offset |
  | tile.begin | x[tile_b.begin, tile_n] | TileBeginOrigin means loop offset. | Scalar descriptor offset |
  | Composite with tile.begin | x[start + tile_b.begin, tile_n] | All symbols are lowerable, and tile.begin is semantically offset-like. | Scalar descriptor offset |
  | Tiled dim | x[tile_m, tile_n] | BlockSizeOrigin path validates descriptor block sizes. | Tiled descriptor dim |
  | Tile plus offset | x[tile_n + start_N, :] | _get_tile_with_offset_info() handles tile-index-plus-offset metadata. | Tiled descriptor dim with offset  |

Blocked Patterns

  | Pattern | Example | Why blocked | Result |
  |---|---|---|---|
  | Unknown SymInt symbol | x[unknown_sym, tile_n] | No expr_to_origin metadata, so codegen cannot reliably lower it. | Pointer fallback |
| Scalar on contiguous/stride-1 dim with too few bytes | g[0, tile_t, 0] for row-major [B, T, H] | Final descriptor block_shape=[1, block_t, 1]; stride-1 dim block is 1 * itemsize < 16. | Pointer fallback |
  | Block size used as scalar | x[tile.block_size, tile_n] | BlockSizeOrigin is an extent, not a scalar offset; scalar path would skip block validation.  | Pointer fallback unless handled by block path |
  | tile.end scalar | x[tile_b.end, tile_n] | Current generic GridOrigin lowering would emit offset_var, which is wrong for tile.end. | Pointer fallback  |
  | tile.count scalar | x[tile_b.count, tile_n] | Needs cdiv(end - begin, block_size), not raw offset. | Pointer fallback |
  | tile.id scalar | x[tile_b.id, tile_n] | Needs offset // block_size, not raw offset. | Pointer fallback |
  | Device/non-host symbolic origin | x[device_expr, tile_n] | Not known to be scalar-lowerable as a descriptor offset. | Pointer fallback |
  | Tensor-valued index | x[idx, tile_d] where idx = indices[tile_o] | Per-element indirect indexing, not a uniform scalar offset. | Pointer fallback |

NOTE: We have a stride-1 check, which finds the tensor dimension that is contiguous in memory, then validates the descriptor block size Helion will emit for that exact dimension. Scalar subscripts produce block_shape=1, which is fine for non-contiguous batch/head dimensions but invalid if the scalar lands on the contiguous dimension because Triton requires at least a 16-byte contiguous descriptor block. This makes g[0, tile_t, 0] fall back while preserving TD for patterns like x[0, 0, tile_t, tile_d].

BMM example: https://gist.github.com/ethche/36355c12674edd62b43a90bf8720d045

We see that on main, it falls back to indexing = 'pointer'. With the fix, tensor_descriptor is correctly enabled:

  Shape                  | Pointer  | TD (main) | TD (fix) | Speedup
  -----------------------|----------|-----------|----------|--------
  B=8,  M=K=N=256        | 0.053ms  | 0.053ms   | 0.025ms  | 2.17x
  B=8,  M=K=N=512        | 0.275ms  | 0.275ms   | 0.078ms  | 3.54x
  B=16, M=K=N=256        | 0.054ms  | 0.053ms   | 0.025ms  | 2.16x
  B=16, M=K=N=512        | 0.276ms  | 0.276ms   | 0.080ms  | 3.47x
  B=32, M=K=N=256        | 0.054ms  | 0.054ms   | 0.025ms  | 2.14x
  B=32, M=K=N=512        | 0.277ms  | 0.277ms   | 0.080ms  | 3.45x

Mamba example: https://gist.github.com/ethche/a37c40c45258b557b8baacc22994194b

  | batch | heads | seqlen | hdim | dstate | Pointer | TD (main) | TD (fix) | Speedup |                                                                 
  |-------|-------|--------|------|--------|---------|-----------|----------|---------|                                                                 
  | 2     | 80    | 2048   | 64   | 128    | 0.112ms | 0.112ms   | 0.077ms  | 1.44x   |                                                                 
  | 4     | 80    | 2048   | 64   | 128    | 0.237ms | 0.237ms   | 0.142ms  | 1.67x   |                                                                 
  | 8     | 80    | 4096   | 64   | 128    | 0.922ms | 0.921ms   | 0.519ms  | 1.77x   |   

@mengluy0125 This may help for bmm style kernels