### PR TITLE
[Pallas] Skip fp32 fallback for unary transcendentals on TPU

### DIFF
--- a/helion/_compiler/inductor_lowering_extra.py
+++ b/helion/_compiler/inductor_lowering_extra.py
@@ -77,7 +77,11 @@ def patch_inductor_lowerings() -> Generator[None, Any, Any]:
         # /tl_math bf16 limitations. Mosaic on TPU handles bf16
         # transcendentals natively, so installing the fallback there
         # would only double per-element VMEM working-set.
-        if CompileEnvironment.current().backend_name != "pallas":
+        is_pallas = (
+            CompileEnvironment.has_current()
+            and CompileEnvironment.current().backend_name == "pallas"
+        )
+        if not is_pallas:
             # pyrefly: ignore [implicit-import]
             torch._inductor.lowering.lowerings.update(fp32_fallback_dispatch)
         yield

--- a/helion/_compiler/inductor_lowering_extra.py
+++ b/helion/_compiler/inductor_lowering_extra.py
@@ -47,9 +47,13 @@ FP32_FALLBACK_OPS_UNARY = [
     torch.ops.aten.exp.default,
 ]
 
-# Register fp32 fallback lowerings for ops that don't support fp16/bfloat16
+# Register fp32 fallback lowerings in a separate dict so that
+# `patch_inductor_lowerings` can skip them on backends (Pallas) where
+# Mosaic handles bf16 transcendentals natively and the round-trip would
+# only double per-element VMEM working-set.
+fp32_fallback_dispatch: dict[Callable[..., Any] | str, Callable[..., Any]] = {}
 for op in FP32_FALLBACK_OPS_UNARY:
-    inductor_lowering_dispatch[op] = create_fp16_to_fp32_unary_fallback_lowering(
+    fp32_fallback_dispatch[op] = create_fp16_to_fp32_unary_fallback_lowering(
         original_lowerings[op]
     )
 
@@ -62,11 +66,20 @@ def patch_inductor_lowerings() -> Generator[None, Any, Any]:
     affecting the global state, especially in cases where Helion
     is missing support for a specific lowering.
     """
+    from .compile_environment import CompileEnvironment
+
     # pyrefly: ignore [implicit-import]
     original_lowerings = torch._inductor.lowering.lowerings.copy()
     try:
         # pyrefly: ignore [implicit-import]
         torch._inductor.lowering.lowerings.update(inductor_lowering_dispatch)
+        # The fp32 round-trip is a Triton/CUDA workaround for libdevice
+        # /tl_math bf16 limitations. Mosaic on TPU handles bf16
+        # transcendentals natively, so installing the fallback there
+        # would only double per-element VMEM working-set.
+        if CompileEnvironment.current().backend_name != "pallas":
+            # pyrefly: ignore [implicit-import]
+            torch._inductor.lowering.lowerings.update(fp32_fallback_dispatch)
         yield
     finally:
         # pyrefly: ignore [implicit-import]


### PR DESCRIPTION
## Summary

`create_fp16_to_fp32_unary_fallback_lowering` in `helion/_compiler/inductor_lowering_extra.py` wraps nine unary transcendentals (`rsqrt`, `sqrt`, `sin`, `cos`, `log`, `tanh`, `log1p`, `expm1`, `exp`) so that bf16/fp16 inputs are promoted to fp32, the op runs in fp32, and the result is cast back. The rationale (per the comment on `FP32_FALLBACK_OPS_UNARY`) is *"libdevice/tl_math limitations"* — Triton/CUDA's device-math libraries have limited bf16 transcendental support.

Mosaic on TPU lowers these ops directly to TPU vector ALUs that handle bf16 natively, so the fp32 round-trip is unnecessary AND harmful: it doubles per-element VMEM working-set, which forces the autotuner into smaller block sizes (which then run more sequential outer iterations).

This PR splits the fp32-fallback registrations into a separate `fp32_fallback_dispatch` dict and skips installing them on the Pallas backend at `patch_inductor_lowerings` time. The Triton/CUDA path is untouched. Other Helion lowerings registered in the same file (`var_`, `var_mean_`) continue to apply on every backend.

## Measured impact

A geglu-style elementwise kernel with bf16 inputs at shape `[16, 8192, 8192]`, both measurements at the same `block_size=2097152`:

| Variant | Time |
|---|---|
| **Helion (before this PR)** — `bf16 → fp32 → tanh → bf16` cast pair around `torch.tanh` | 13.92 ms |
| **Helion (after this PR)** — direct `jnp.tanh(bf16)`, no cast pair | **7.93 ms** |

Other transcendental-using kernels in the TPU benchmark (`exp`, `softmax`, `rms_norm`) verified equivalent or slightly better than before — `rms_norm [8192, 8192]` improved from 1.34× → 1.71× vs lazy torch.

## Test plan

- [x] Verified codegen for geglu no longer contains the `lax.convert_element_type → jnp.tanh → lax.convert_element_type` round-trip
