### PR TITLE
Temporarily disable XPU CI

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -93,19 +93,6 @@
       "triton-pin": "0d9283bf49"
     },
     {
-      "runner": "linux.idc.xpu",
-      "python-version": "3.12",
-      "ref-eager": false,
-      "image": "intelgpu/ubuntu-24.04-lts2:2523.40",
-      "runtime-version": "xpu",
-      "container-options": "--group-add 109 --device=/dev/mem --device=/dev/dri",
-      "pytorch-version": "pytorch-nightly",
-      "alias": "xpu",
-      "backend": "triton",
-      "triton-repo": "https://github.com/intel/intel-xpu-backend-for-triton.git",
-      "triton-pin": "8997b14d4d6580c401c842ea4fded92cdf7adaa8"
-    },
-    {
       "runner": "linux.rocm.gpu.ecosystem.gfx950.1",
       "python-version": "3.12",
       "ref-eager": false,


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2269
 * __->__#2270


--- --- ---

Temporarily disable XPU CI

Remove the `xpu` entry from `.github/matrix.json`. The Triton-from-source
build fails with `fatal error: 'crt/host_defines.h' file not found` while
compiling proton's `CuptiApi.cpp` / `NvtxApi.cpp` on a subset of the XPU
runner fleet (`dut7363`, `dut7366`); other runners (`dut7360`, `dut7900`)
build the same Triton pin successfully, so the failure is a runner
environment regression — proton's build pulls in NVIDIA CUPTI headers
that aren't on the affected hosts. Disabling until the fleet is fixed
or the Triton build is configured to skip proton on XPU.