### PR TITLE
[Autotuner] Enable autotuner seed configs

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -145,19 +145,20 @@ class _CodeSentinel:
 _CODE_SENTINEL = _CodeSentinel()
 
 
-def normalize_autotune_hints(settings: Settings) -> tuple[Config, ...]:
-    """Return user-provided autotune hints from settings as concrete Configs."""
+def normalize_autotune_seed_configs(settings: Settings) -> tuple[Config, ...]:
+    """Return user-provided autotune seed configs from settings as concrete Configs."""
     from ..runtime.config import Config
 
-    hints = settings.autotune_hints
-    if hints is None:
+    seed_configs = settings.autotune_seed_configs
+    if seed_configs is None:
         return ()
-    if isinstance(hints, Config):
-        return (hints,)
-    if isinstance(hints, dict):
-        return (Config.from_dict(hints),)
+    if isinstance(seed_configs, Config):
+        return (seed_configs,)
+    if isinstance(seed_configs, dict):
+        return (Config.from_dict(seed_configs),)
     return tuple(
-        Config.from_dict(hint) if isinstance(hint, dict) else hint for hint in hints
+        Config.from_dict(seed_config) if isinstance(seed_config, dict) else seed_config
+        for seed_config in seed_configs
     )
 
 
@@ -551,9 +552,9 @@ class BaseSearch(BaseAutotuner):
         """
         raise NotImplementedError
 
-    def _autotune_hint_configs(self) -> Sequence[Config]:
-        """Return user-provided autotune hints normalized from settings."""
-        return normalize_autotune_hints(self.settings)
+    def _autotune_seed_configs(self) -> Sequence[Config]:
+        """Return user-provided autotune seed configs normalized from settings."""
+        return normalize_autotune_seed_configs(self.settings)
 
     def set_generation(self, generation: int) -> None:
         self._autotune_metrics.num_generations = generation
@@ -785,17 +786,17 @@ class PopulationBasedSearch(BaseSearch):
         result: list[FlatConfig] = [default_flat]
         self.log("Starting with default config")
 
-        # User hints are explicit requests, so try them before compiler-owned
+        # User seed configs are explicit requests, so try them before compiler-owned
         # seeds and cached configs while still deduplicating normalized configs.
-        for flat, transferred_config in self.config_gen.hint_flat_config_pairs(
-            self._autotune_hint_configs(), self.log
+        for flat, transferred_config in self.config_gen.user_seed_flat_config_pairs(
+            self._autotune_seed_configs(), self.log
         ):
             if transferred_config not in seen:
                 seen.add(transferred_config)
                 result.append(flat)
 
         # Compiler-owned seeds come from ConfigSpec.autotune_seed_configs();
-        # they encode backend/compiler heuristics and complement user hints.
+        # they encode backend/compiler heuristics and complement user seed configs.
         for flat, transferred_config in self.config_gen.seed_flat_config_pairs():
             if transferred_config not in seen:
                 seen.add(transferred_config)

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -74,9 +74,6 @@ class _AutotunableKernel(Protocol):
     @property
     def configs(self) -> Sequence[Config]: ...
 
-    @property
-    def autotune_hints(self) -> Sequence[Config]: ...
-
     def compile_config(
         self,
         config: Config | dict[str, object] | None = None,
@@ -146,6 +143,22 @@ class _CodeSentinel:
 
 
 _CODE_SENTINEL = _CodeSentinel()
+
+
+def normalize_autotune_hints(settings: Settings) -> tuple[Config, ...]:
+    """Return autotune hints from settings as concrete Config objects."""
+    from ..runtime.config import Config
+
+    hints = settings.autotune_hints
+    if hints is None:
+        return ()
+    if isinstance(hints, Config):
+        return (hints,)
+    if isinstance(hints, dict):
+        return (Config.from_dict(hints),)
+    return tuple(
+        Config.from_dict(hint) if isinstance(hint, dict) else hint for hint in hints
+    )
 
 
 def _normalize_spec_key(key: object) -> object:
@@ -539,8 +552,8 @@ class BaseSearch(BaseAutotuner):
         raise NotImplementedError
 
     def _autotune_hint_configs(self) -> Sequence[Config]:
-        """Return user-provided autotune hints normalized by the kernel."""
-        return self.kernel.autotune_hints
+        """Return user-provided autotune hints normalized from settings."""
+        return normalize_autotune_hints(self.settings)
 
     def set_generation(self, generation: int) -> None:
         self._autotune_metrics.num_generations = generation

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -74,6 +74,9 @@ class _AutotunableKernel(Protocol):
     @property
     def configs(self) -> Sequence[Config]: ...
 
+    @property
+    def autotune_hints(self) -> Sequence[Config]: ...
+
     def compile_config(
         self,
         config: Config | dict[str, object] | None = None,
@@ -535,6 +538,10 @@ class BaseSearch(BaseAutotuner):
         """
         raise NotImplementedError
 
+    def _autotune_hint_configs(self) -> Sequence[Config]:
+        """Return user-provided autotune hints when the kernel supports them."""
+        return getattr(self.kernel, "autotune_hints", ())
+
     def set_generation(self, generation: int) -> None:
         self._autotune_metrics.num_generations = generation
 
@@ -764,6 +771,22 @@ class PopulationBasedSearch(BaseSearch):
         seen: set[Config] = {default_config}
         result: list[FlatConfig] = [default_flat]
         self.log("Starting with default config")
+
+        for i, config in enumerate(self._autotune_hint_configs()):
+            try:
+                flat = self.config_gen.flatten(config)
+                transferred_config = self.config_gen.unflatten(flat)
+                if transferred_config not in seen:
+                    seen.add(transferred_config)
+                    result.append(flat)
+            except (
+                ValueError,
+                TypeError,
+                KeyError,
+                AssertionError,
+                exc.InvalidConfig,
+            ) as e:
+                self.log(f"Failed to transfer autotune hint {i + 1}: {e}")
 
         for flat, transferred_config in self.config_gen.seed_flat_config_pairs():
             if transferred_config not in seen:

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -787,21 +787,12 @@ class PopulationBasedSearch(BaseSearch):
 
         # User hints are explicit requests, so try them before compiler-owned
         # seeds and cached configs while still deduplicating normalized configs.
-        for i, config in enumerate(self._autotune_hint_configs()):
-            try:
-                flat = self.config_gen.flatten(config)
-                transferred_config = self.config_gen.unflatten(flat)
-                if transferred_config not in seen:
-                    seen.add(transferred_config)
-                    result.append(flat)
-            except (
-                ValueError,
-                TypeError,
-                KeyError,
-                AssertionError,
-                exc.InvalidConfig,
-            ) as e:
-                self.log(f"Failed to transfer autotune hint {i + 1}: {e}")
+        for flat, transferred_config in self.config_gen.hint_flat_config_pairs(
+            self._autotune_hint_configs(), self.log
+        ):
+            if transferred_config not in seen:
+                seen.add(transferred_config)
+                result.append(flat)
 
         # Compiler-owned seeds come from ConfigSpec.autotune_seed_configs();
         # they encode backend/compiler heuristics and complement user hints.

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -539,8 +539,8 @@ class BaseSearch(BaseAutotuner):
         raise NotImplementedError
 
     def _autotune_hint_configs(self) -> Sequence[Config]:
-        """Return user-provided autotune hints when the kernel supports them."""
-        return getattr(self.kernel, "autotune_hints", ())
+        """Return user-provided autotune hints normalized by the kernel."""
+        return self.kernel.autotune_hints
 
     def set_generation(self, generation: int) -> None:
         self._autotune_metrics.num_generations = generation

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -146,7 +146,7 @@ _CODE_SENTINEL = _CodeSentinel()
 
 
 def normalize_autotune_hints(settings: Settings) -> tuple[Config, ...]:
-    """Return autotune hints from settings as concrete Config objects."""
+    """Return user-provided autotune hints from settings as concrete Configs."""
     from ..runtime.config import Config
 
     hints = settings.autotune_hints
@@ -785,6 +785,8 @@ class PopulationBasedSearch(BaseSearch):
         result: list[FlatConfig] = [default_flat]
         self.log("Starting with default config")
 
+        # User hints are explicit requests, so try them before compiler-owned
+        # seeds and cached configs while still deduplicating normalized configs.
         for i, config in enumerate(self._autotune_hint_configs()):
             try:
                 flat = self.config_gen.flatten(config)
@@ -801,6 +803,8 @@ class PopulationBasedSearch(BaseSearch):
             ) as e:
                 self.log(f"Failed to transfer autotune hint {i + 1}: {e}")
 
+        # Compiler-owned seeds come from ConfigSpec.autotune_seed_configs();
+        # they encode backend/compiler heuristics and complement user hints.
         for flat, transferred_config in self.config_gen.seed_flat_config_pairs():
             if transferred_config not in seen:
                 seen.add(transferred_config)

--- a/helion/autotuner/config_generation.py
+++ b/helion/autotuner/config_generation.py
@@ -444,6 +444,9 @@ class ConfigGeneration:
         result = [default_flat]
         seen = {self.unflatten([*default_flat])}
 
+        # Initial population order is default -> user hints -> compiler seeds
+        # -> random.  This preserves hint priority without dropping built-in
+        # backend/compiler seeds from ConfigSpec.autotune_seed_configs().
         for i, config in enumerate(config_hints):
             try:
                 flat = self.flatten(config)

--- a/helion/autotuner/config_generation.py
+++ b/helion/autotuner/config_generation.py
@@ -403,6 +403,34 @@ class ConfigGeneration:
             result.append((flat, normalized))
         return result
 
+    def hint_flat_config_pairs(
+        self,
+        config_hints: Sequence[Config],
+        log_func: Callable[[str], None] | None = None,
+    ) -> list[tuple[FlatConfig, Config]]:
+        """Return user-provided hints as flat and normalized configs."""
+        result: list[tuple[FlatConfig, Config]] = []
+        seen: set[Config] = set()
+        for i, config in enumerate(config_hints):
+            try:
+                flat = self.flatten(config)
+                normalized = self.unflatten(flat)
+            except (
+                InvalidConfig,
+                ValueError,
+                TypeError,
+                KeyError,
+                AssertionError,
+            ) as e:
+                if log_func is not None:
+                    log_func(f"Failed to transfer autotune hint {i + 1}: {e}")
+                continue
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            result.append((flat, normalized))
+        return result
+
     def random_flat(self) -> FlatConfig:
         """
         Generate a random flat configuration.
@@ -442,36 +470,20 @@ class ConfigGeneration:
             return [self.default_flat()]
         default_flat = self.default_flat()
         result = [default_flat]
-        seen = {self.unflatten([*default_flat])}
 
         # Initial population order is default -> user hints -> compiler seeds
         # -> random.  This preserves hint priority without dropping built-in
         # backend/compiler seeds from ConfigSpec.autotune_seed_configs().
-        for i, config in enumerate(config_hints):
-            try:
-                flat = self.flatten(config)
-                transferred_config = self.unflatten(flat)
-            except (
-                InvalidConfig,
-                ValueError,
-                TypeError,
-                KeyError,
-                AssertionError,
-            ) as e:
-                if log_func is not None:
-                    log_func(f"Failed to transfer autotune hint {i + 1}: {e}")
+        for flat, _config in self.hint_flat_config_pairs(config_hints, log_func):
+            if any(flat == existing for existing in result):
                 continue
-            if transferred_config in seen:
-                continue
-            seen.add(transferred_config)
             result.append(flat)
             if len(result) >= n:
                 return result[:n]
 
-        for flat, transferred_config in self.seed_flat_config_pairs():
-            if transferred_config in seen:
+        for flat, _config in self.seed_flat_config_pairs():
+            if any(flat == existing for existing in result):
                 continue
-            seen.add(transferred_config)
             result.append(flat)
             if len(result) >= n:
                 return result[:n]

--- a/helion/autotuner/config_generation.py
+++ b/helion/autotuner/config_generation.py
@@ -7,6 +7,7 @@ import itertools
 import operator
 import random
 from typing import TYPE_CHECKING
+from typing import Callable
 from typing import cast
 
 from .._compat import warps_to_threads
@@ -20,6 +21,7 @@ from helion._dist_utils import sync_seed
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+    from collections.abc import Sequence
 
     from .. import Config
     from . import ConfigSpec
@@ -429,26 +431,63 @@ class ConfigGeneration:
             f"failed to generate a valid random config after 64 attempts: {summary}"
         )
 
-    def random_population_flat(self, n: int) -> list[FlatConfig]:
+    def random_population_flat(
+        self,
+        n: int,
+        *,
+        config_hints: Sequence[Config] = (),
+        log_func: Callable[[str], None] | None = None,
+    ) -> list[FlatConfig]:
         if n <= 0:
             return [self.default_flat()]
         default_flat = self.default_flat()
         result = [default_flat]
-        if len(result) >= n:
-            return result[:n]
-        for flat, _config in self.seed_flat_config_pairs():
-            if any(flat == existing for existing in result):
+        seen = {self.unflatten([*default_flat])}
+
+        for i, config in enumerate(config_hints):
+            try:
+                flat = self.flatten(config)
+                transferred_config = self.unflatten(flat)
+            except (
+                InvalidConfig,
+                ValueError,
+                TypeError,
+                KeyError,
+                AssertionError,
+            ) as e:
+                if log_func is not None:
+                    log_func(f"Failed to transfer autotune hint {i + 1}: {e}")
                 continue
+            if transferred_config in seen:
+                continue
+            seen.add(transferred_config)
             result.append(flat)
             if len(result) >= n:
                 return result[:n]
+
+        for flat, transferred_config in self.seed_flat_config_pairs():
+            if transferred_config in seen:
+                continue
+            seen.add(transferred_config)
+            result.append(flat)
+            if len(result) >= n:
+                return result[:n]
+
         result.extend(self.random_flat() for _ in range(n - len(result)))
         return result
 
-    def random_population(self, n: int) -> list[Config]:
+    def random_population(
+        self,
+        n: int,
+        *,
+        config_hints: Sequence[Config] = (),
+        log_func: Callable[[str], None] | None = None,
+    ) -> list[Config]:
         result: list[Config] = []
         attempts = 0
-        for flat in self.random_population_flat(n):
+        for flat in self.random_population_flat(
+            n, config_hints=config_hints, log_func=log_func
+        ):
             try:
                 result.append(self.unflatten(flat))
             except InvalidConfig:

--- a/helion/autotuner/config_generation.py
+++ b/helion/autotuner/config_generation.py
@@ -403,15 +403,15 @@ class ConfigGeneration:
             result.append((flat, normalized))
         return result
 
-    def hint_flat_config_pairs(
+    def user_seed_flat_config_pairs(
         self,
-        config_hints: Sequence[Config],
+        user_seed_configs: Sequence[Config],
         log_func: Callable[[str], None] | None = None,
     ) -> list[tuple[FlatConfig, Config]]:
-        """Return user-provided hints as flat and normalized configs."""
+        """Return user-provided seed configs as flat and normalized configs."""
         result: list[tuple[FlatConfig, Config]] = []
         seen: set[Config] = set()
-        for i, config in enumerate(config_hints):
+        for i, config in enumerate(user_seed_configs):
             try:
                 flat = self.flatten(config)
                 normalized = self.unflatten(flat)
@@ -423,7 +423,7 @@ class ConfigGeneration:
                 AssertionError,
             ) as e:
                 if log_func is not None:
-                    log_func(f"Failed to transfer autotune hint {i + 1}: {e}")
+                    log_func(f"Failed to transfer autotune seed config {i + 1}: {e}")
                 continue
             if normalized in seen:
                 continue
@@ -463,7 +463,7 @@ class ConfigGeneration:
         self,
         n: int,
         *,
-        config_hints: Sequence[Config] = (),
+        user_seed_configs: Sequence[Config] = (),
         log_func: Callable[[str], None] | None = None,
     ) -> list[FlatConfig]:
         if n <= 0:
@@ -471,10 +471,12 @@ class ConfigGeneration:
         default_flat = self.default_flat()
         result = [default_flat]
 
-        # Initial population order is default -> user hints -> compiler seeds
-        # -> random.  This preserves hint priority without dropping built-in
+        # Initial population order is default -> user seed configs -> compiler seeds
+        # -> random.  This preserves user seed priority without dropping built-in
         # backend/compiler seeds from ConfigSpec.autotune_seed_configs().
-        for flat, _config in self.hint_flat_config_pairs(config_hints, log_func):
+        for flat, _config in self.user_seed_flat_config_pairs(
+            user_seed_configs, log_func
+        ):
             if any(flat == existing for existing in result):
                 continue
             result.append(flat)
@@ -495,13 +497,13 @@ class ConfigGeneration:
         self,
         n: int,
         *,
-        config_hints: Sequence[Config] = (),
+        user_seed_configs: Sequence[Config] = (),
         log_func: Callable[[str], None] | None = None,
     ) -> list[Config]:
         result: list[Config] = []
         attempts = 0
         for flat in self.random_population_flat(
-            n, config_hints=config_hints, log_func=log_func
+            n, user_seed_configs=user_seed_configs, log_func=log_func
         ):
             try:
                 result.append(self.unflatten(flat))

--- a/helion/autotuner/differential_evolution.py
+++ b/helion/autotuner/differential_evolution.py
@@ -144,7 +144,11 @@ class DifferentialEvolutionSearch(PopulationBasedSearch):
                 return pop[:target]
             return pop
 
-        return self.config_gen.random_population_flat(self.population_size * 2)
+        return self.config_gen.random_population_flat(
+            self.population_size * 2,
+            config_hints=self._autotune_hint_configs(),
+            log_func=self.log,
+        )
 
     def initial_two_generations(self) -> None:
         # The initial population is 2x larger so we can throw out the slowest half and give the tuning process a head start

--- a/helion/autotuner/differential_evolution.py
+++ b/helion/autotuner/differential_evolution.py
@@ -146,7 +146,7 @@ class DifferentialEvolutionSearch(PopulationBasedSearch):
 
         return self.config_gen.random_population_flat(
             self.population_size * 2,
-            config_hints=self._autotune_hint_configs(),
+            user_seed_configs=self._autotune_seed_configs(),
             log_func=self.log,
         )
 

--- a/helion/autotuner/external.py
+++ b/helion/autotuner/external.py
@@ -134,19 +134,6 @@ class _ExternalKernelAdapter(_AutotunableKernel):
     def configs(self) -> list[Config]:
         return self._configs
 
-    @property
-    def autotune_hints(self) -> list[Config]:
-        hints = self.settings.autotune_hints
-        if hints is None:
-            return []
-        if isinstance(hints, Config):
-            return [hints]
-        if isinstance(hints, dict):
-            return [Config.from_dict(hints)]
-        return [
-            Config.from_dict(hint) if isinstance(hint, dict) else hint for hint in hints
-        ]
-
     def compile_config(
         self,
         config: Config | dict[str, object] | None = None,

--- a/helion/autotuner/external.py
+++ b/helion/autotuner/external.py
@@ -136,7 +136,16 @@ class _ExternalKernelAdapter(_AutotunableKernel):
 
     @property
     def autotune_hints(self) -> list[Config]:
-        return []
+        hints = self.settings.autotune_hints
+        if hints is None:
+            return []
+        if isinstance(hints, Config):
+            return [hints]
+        if isinstance(hints, dict):
+            return [Config.from_dict(hints)]
+        return [
+            Config.from_dict(hint) if isinstance(hint, dict) else hint for hint in hints
+        ]
 
     def compile_config(
         self,

--- a/helion/autotuner/external.py
+++ b/helion/autotuner/external.py
@@ -134,6 +134,10 @@ class _ExternalKernelAdapter(_AutotunableKernel):
     def configs(self) -> list[Config]:
         return self._configs
 
+    @property
+    def autotune_hints(self) -> list[Config]:
+        return []
+
     def compile_config(
         self,
         config: Config | dict[str, object] | None = None,

--- a/helion/autotuner/pattern_search.py
+++ b/helion/autotuner/pattern_search.py
@@ -128,7 +128,7 @@ class PatternSearch(PopulationBasedSearch):
             return pop
         return self.config_gen.random_population_flat(
             self.initial_population,
-            config_hints=self._autotune_hint_configs(),
+            user_seed_configs=self._autotune_seed_configs(),
             log_func=self.log,
         )
 

--- a/helion/autotuner/pattern_search.py
+++ b/helion/autotuner/pattern_search.py
@@ -126,7 +126,11 @@ class PatternSearch(PopulationBasedSearch):
                 n_random = max(0, self.initial_population - len(pop))
                 pop.extend(self.config_gen.random_flat() for _ in range(n_random))
             return pop
-        return self.config_gen.random_population_flat(self.initial_population)
+        return self.config_gen.random_population_flat(
+            self.initial_population,
+            config_hints=self._autotune_hint_configs(),
+            log_func=self.log,
+        )
 
     def _autotune(self) -> Config:
         initial_population_name = self.initial_population_strategy.name

--- a/helion/autotuner/random_search.py
+++ b/helion/autotuner/random_search.py
@@ -44,7 +44,7 @@ class RandomSearch(FiniteSearch):
                 process_group_name=kernel.env.process_group_name,
             ).random_population(
                 count,
-                config_hints=getattr(kernel, "autotune_hints", ()),
+                config_hints=kernel.autotune_hints,
             ),
         )
 

--- a/helion/autotuner/random_search.py
+++ b/helion/autotuner/random_search.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from .base_search import normalize_autotune_hints
 from .effort_profile import RANDOM_SEARCH_DEFAULTS
 from .finite_search import FiniteSearch
 
@@ -44,7 +45,7 @@ class RandomSearch(FiniteSearch):
                 process_group_name=kernel.env.process_group_name,
             ).random_population(
                 count,
-                config_hints=kernel.autotune_hints,
+                config_hints=normalize_autotune_hints(kernel.settings),
             ),
         )
 

--- a/helion/autotuner/random_search.py
+++ b/helion/autotuner/random_search.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .base_search import normalize_autotune_hints
+from .base_search import normalize_autotune_seed_configs
 from .effort_profile import RANDOM_SEARCH_DEFAULTS
 from .finite_search import FiniteSearch
 
@@ -45,7 +45,7 @@ class RandomSearch(FiniteSearch):
                 process_group_name=kernel.env.process_group_name,
             ).random_population(
                 count,
-                config_hints=normalize_autotune_hints(kernel.settings),
+                user_seed_configs=normalize_autotune_seed_configs(kernel.settings),
             ),
         )
 

--- a/helion/autotuner/random_search.py
+++ b/helion/autotuner/random_search.py
@@ -42,7 +42,10 @@ class RandomSearch(FiniteSearch):
                 overrides=kernel.settings.autotune_config_overrides or None,
                 advanced_controls_files=kernel.settings.autotune_search_acf or None,
                 process_group_name=kernel.env.process_group_name,
-            ).random_population(count),
+            ).random_population(
+                count,
+                config_hints=getattr(kernel, "autotune_hints", ()),
+            ),
         )
 
     @classmethod

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -116,6 +116,7 @@ class Kernel(Generic[_R]):
         fn: Callable[..., _R],
         *,
         configs: Sequence[ConfigLike] | None = None,
+        autotune_hints: Sequence[ConfigLike] | None = None,
         settings: Settings | None,
         key: Callable[..., Hashable] | None = None,
     ) -> None:
@@ -125,6 +126,8 @@ class Kernel(Generic[_R]):
         Args:
             fn: The function to be compiled as a Helion kernel.
             configs: A list of configurations to use for the kernel.
+            autotune_hints: A list of configurations to seed the autotuner's
+                initial population without restricting the search.
             settings: The settings to be used by the Kernel. If None, a new `Settings()` instance is created.
             key: Optional callable that returns an extra hashable component for specialization.
         """
@@ -141,6 +144,11 @@ class Kernel(Generic[_R]):
             # pyrefly: ignore [bad-argument-type]
             Config(**c) if isinstance(c, dict) else c
             for c in configs or []
+        ]
+        self.autotune_hints: list[Config] = [
+            # pyrefly: ignore [bad-argument-type]
+            Config(**c) if isinstance(c, dict) else c
+            for c in autotune_hints or []
         ]
         self._bound_kernels: dict[BoundKernelInMemoryCacheKey, BoundKernel] = {}
         self._specialize_extra: dict[
@@ -507,6 +515,11 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
     def configs(self) -> list[Config]:
         """Return the kernel's configured configs (alias for `self.kernel.configs`)."""
         return self.kernel.configs
+
+    @property
+    def autotune_hints(self) -> list[Config]:
+        """Return configs that seed autotuning without constraining the search."""
+        return self.kernel.autotune_hints
 
     def _normalize_config(self, config: ConfigLike) -> Config:
         if isinstance(config, Config):
@@ -1108,6 +1121,7 @@ def kernel(
     *,
     config: ConfigLike | None = None,
     configs: Sequence[ConfigLike] | None = None,
+    autotune_hints: ConfigLike | Sequence[ConfigLike] | None = None,
     key: Callable[..., Hashable] | None = None,
     **settings: object,
 ) -> Kernel[_R]: ...
@@ -1119,6 +1133,7 @@ def kernel(
     *,
     config: ConfigLike | None = None,
     configs: Sequence[ConfigLike] | None = None,
+    autotune_hints: ConfigLike | Sequence[ConfigLike] | None = None,
     key: Callable[..., Hashable] | None = None,
     **settings: object,
 ) -> _KernelDecorator: ...
@@ -1129,6 +1144,7 @@ def kernel(
     *,
     config: ConfigLike | None = None,
     configs: Sequence[ConfigLike] | None = None,
+    autotune_hints: ConfigLike | Sequence[ConfigLike] | None = None,
     key: Callable[..., Hashable] | None = None,
     **settings: object,
 ) -> Kernel[_R] | _KernelDecorator:
@@ -1142,6 +1158,8 @@ def kernel(
         configs: A list of configurations to use for the kernel. Can only specify
             one of config or configs. Refer to the ``helion.Config`` class for
             details.
+        autotune_hints: A single configuration or list of configurations to include
+            in the autotuner's initial population without restricting the search.
         key: Optional callable returning a hashable that augments the specialization key.
         settings: Keyword arguments representing settings for the Kernel.
             Can also use settings=Settings(...) to pass a Settings object
@@ -1160,6 +1178,12 @@ def kernel(
         configs = [config]
     elif configs is None:
         configs = []
+    if autotune_hints is None:
+        normalized_autotune_hints = []
+    elif isinstance(autotune_hints, (Config, dict)):
+        normalized_autotune_hints = [autotune_hints]
+    else:
+        normalized_autotune_hints = list(autotune_hints)
 
     if settings_obj := settings.get("settings"):
         assert len(settings) == 1, "settings must be the only keyword argument"
@@ -1169,9 +1193,19 @@ def kernel(
 
     if fn is None:
         return functools.partial(
-            kernel, configs=configs, settings=settings_obj, key=key
+            kernel,
+            configs=configs,
+            autotune_hints=normalized_autotune_hints,
+            settings=settings_obj,
+            key=key,
         )
-    return Kernel(fn, configs=configs, settings=settings_obj, key=key)
+    return Kernel(
+        fn,
+        configs=configs,
+        autotune_hints=normalized_autotune_hints,
+        settings=settings_obj,
+        key=key,
+    )
 
 
 def _hashable_dim(s: int | torch.SymInt) -> Hashable:

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -142,22 +142,6 @@ class Kernel(Generic[_R]):
             Config(**config) if isinstance(config, dict) else config
             for config in configs or []
         ]
-        autotune_hints = self.settings.autotune_hints
-        if autotune_hints is None:
-            self.autotune_hints = []
-        elif isinstance(autotune_hints, (Config, dict)):
-            self.autotune_hints = [
-                # pyrefly: ignore [bad-argument-type]
-                Config(**autotune_hints)
-                if isinstance(autotune_hints, dict)
-                else autotune_hints
-            ]
-        else:
-            self.autotune_hints = [
-                # pyrefly: ignore [bad-argument-type]
-                Config(**config) if isinstance(config, dict) else config
-                for config in autotune_hints
-            ]
         self._bound_kernels: dict[BoundKernelInMemoryCacheKey, BoundKernel] = {}
         self._specialize_extra: dict[
             Hashable, list[Callable[[Sequence[object]], Hashable]]
@@ -523,11 +507,6 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
     def configs(self) -> list[Config]:
         """Return the kernel's configured configs (alias for `self.kernel.configs`)."""
         return self.kernel.configs
-
-    @property
-    def autotune_hints(self) -> list[Config]:
-        """Return configs that seed autotuning without constraining the search."""
-        return self.kernel.autotune_hints
 
     def _normalize_config(self, config: ConfigLike) -> Config:
         if isinstance(config, Config):

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -116,7 +116,6 @@ class Kernel(Generic[_R]):
         fn: Callable[..., _R],
         *,
         configs: Sequence[ConfigLike] | None = None,
-        autotune_hints: Sequence[ConfigLike] | None = None,
         settings: Settings | None,
         key: Callable[..., Hashable] | None = None,
     ) -> None:
@@ -126,8 +125,6 @@ class Kernel(Generic[_R]):
         Args:
             fn: The function to be compiled as a Helion kernel.
             configs: A list of configurations to use for the kernel.
-            autotune_hints: A list of configurations to seed the autotuner's
-                initial population without restricting the search.
             settings: The settings to be used by the Kernel. If None, a new `Settings()` instance is created.
             key: Optional callable that returns an extra hashable component for specialization.
         """
@@ -142,14 +139,25 @@ class Kernel(Generic[_R]):
         self._key_fn: Callable[..., Hashable] | None = key
         self.configs: list[Config] = [
             # pyrefly: ignore [bad-argument-type]
-            Config(**c) if isinstance(c, dict) else c
-            for c in configs or []
+            Config(**config) if isinstance(config, dict) else config
+            for config in configs or []
         ]
-        self.autotune_hints: list[Config] = [
-            # pyrefly: ignore [bad-argument-type]
-            Config(**c) if isinstance(c, dict) else c
-            for c in autotune_hints or []
-        ]
+        autotune_hints = self.settings.autotune_hints
+        if autotune_hints is None:
+            self.autotune_hints = []
+        elif isinstance(autotune_hints, (Config, dict)):
+            self.autotune_hints = [
+                # pyrefly: ignore [bad-argument-type]
+                Config(**autotune_hints)
+                if isinstance(autotune_hints, dict)
+                else autotune_hints
+            ]
+        else:
+            self.autotune_hints = [
+                # pyrefly: ignore [bad-argument-type]
+                Config(**config) if isinstance(config, dict) else config
+                for config in autotune_hints
+            ]
         self._bound_kernels: dict[BoundKernelInMemoryCacheKey, BoundKernel] = {}
         self._specialize_extra: dict[
             Hashable, list[Callable[[Sequence[object]], Hashable]]
@@ -1121,7 +1129,6 @@ def kernel(
     *,
     config: ConfigLike | None = None,
     configs: Sequence[ConfigLike] | None = None,
-    autotune_hints: ConfigLike | Sequence[ConfigLike] | None = None,
     key: Callable[..., Hashable] | None = None,
     **settings: object,
 ) -> Kernel[_R]: ...
@@ -1133,7 +1140,6 @@ def kernel(
     *,
     config: ConfigLike | None = None,
     configs: Sequence[ConfigLike] | None = None,
-    autotune_hints: ConfigLike | Sequence[ConfigLike] | None = None,
     key: Callable[..., Hashable] | None = None,
     **settings: object,
 ) -> _KernelDecorator: ...
@@ -1144,7 +1150,6 @@ def kernel(
     *,
     config: ConfigLike | None = None,
     configs: Sequence[ConfigLike] | None = None,
-    autotune_hints: ConfigLike | Sequence[ConfigLike] | None = None,
     key: Callable[..., Hashable] | None = None,
     **settings: object,
 ) -> Kernel[_R] | _KernelDecorator:
@@ -1158,8 +1163,6 @@ def kernel(
         configs: A list of configurations to use for the kernel. Can only specify
             one of config or configs. Refer to the ``helion.Config`` class for
             details.
-        autotune_hints: A single configuration or list of configurations to include
-            in the autotuner's initial population without restricting the search.
         key: Optional callable returning a hashable that augments the specialization key.
         settings: Keyword arguments representing settings for the Kernel.
             Can also use settings=Settings(...) to pass a Settings object
@@ -1178,12 +1181,6 @@ def kernel(
         configs = [config]
     elif configs is None:
         configs = []
-    if autotune_hints is None:
-        normalized_autotune_hints = []
-    elif isinstance(autotune_hints, (Config, dict)):
-        normalized_autotune_hints = [autotune_hints]
-    else:
-        normalized_autotune_hints = list(autotune_hints)
 
     if settings_obj := settings.get("settings"):
         assert len(settings) == 1, "settings must be the only keyword argument"
@@ -1195,14 +1192,12 @@ def kernel(
         return functools.partial(
             kernel,
             configs=configs,
-            autotune_hints=normalized_autotune_hints,
             settings=settings_obj,
             key=key,
         )
     return Kernel(
         fn,
         configs=configs,
-        autotune_hints=normalized_autotune_hints,
         settings=settings_obj,
         key=key,
     )

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from .kernel import BoundKernel
 
     _T = TypeVar("_T")
+    ConfigLike = Config | dict[str, object]
 
     class AutotunerFunction(Protocol):
         def __call__(
@@ -473,6 +474,7 @@ class _Settings:
     autotune_config_overrides: dict[str, object] = dataclasses.field(
         default_factory=_get_autotune_config_overrides
     )
+    autotune_hints: ConfigLike | Sequence[ConfigLike] | None = None
     autotune_effort: AutotuneEffort = dataclasses.field(
         default_factory=functools.partial(
             _env_get_literal,
@@ -614,6 +616,10 @@ class Settings(_Settings):
         "autotune_config_overrides": (
             "Dictionary of config key/value pairs forced during autotuning. "
             "Accepts HELION_AUTOTUNE_CONFIG_OVERRIDES='{\"num_warps\":4}'."
+        ),
+        "autotune_hints": (
+            "A Config or sequence of Configs to seed the autotuner initial population "
+            "without constraining the search space."
         ),
         "allow_warp_specialize": "If True, allow warp specialization for tl.range calls on CUDA devices.",
         "debug_dtype_asserts": "If True, emit tl.static_assert checks for dtype after each device node.",

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -474,7 +474,7 @@ class _Settings:
     autotune_config_overrides: dict[str, object] = dataclasses.field(
         default_factory=_get_autotune_config_overrides
     )
-    autotune_hints: ConfigLike | Sequence[ConfigLike] | None = None
+    autotune_seed_configs: ConfigLike | Sequence[ConfigLike] | None = None
     autotune_effort: AutotuneEffort = dataclasses.field(
         default_factory=functools.partial(
             _env_get_literal,
@@ -617,7 +617,7 @@ class Settings(_Settings):
             "Dictionary of config key/value pairs forced during autotuning. "
             "Accepts HELION_AUTOTUNE_CONFIG_OVERRIDES='{\"num_warps\":4}'."
         ),
-        "autotune_hints": (
+        "autotune_seed_configs": (
             "A Config or sequence of Configs to seed the autotuner initial population "
             "without constraining the search space."
         ),

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -65,6 +65,7 @@ from helion.autotuner.local_cache import LocalAutotuneCache
 from helion.autotuner.local_cache import StrictLocalAutotuneCache
 from helion.autotuner.logger import AutotuneLogEntry
 from helion.autotuner.logger import AutotuningLogger
+from helion.autotuner.pattern_search import InitialPopulationStrategy
 from helion.autotuner.random_search import RandomSearch
 import helion.language as hl
 from helion.language import loops
@@ -2653,6 +2654,78 @@ class TestAutotuneCacheSelection(TestCase):
                     ValueError, "Unknown HELION_AUTOTUNE_CACHE"
                 ):
                     bound.settings.autotuner_fn(bound, args)
+
+
+@onlyBackends(["triton"])
+class TestAutotuneHints(TestCase):
+    """Tests for seeding initial autotune populations with user hints."""
+
+    def _make_kernel_and_args(self, **kernel_kwargs):
+        @helion.kernel(autotune_log_level=0, **kernel_kwargs)
+        def add(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(a)
+            for tile in hl.tile(out.size()):
+                out[tile] = a[tile] + b[tile]
+            return out
+
+        args = (
+            torch.randn([128], device=DEVICE),
+            torch.randn([128], device=DEVICE),
+        )
+        return add, args
+
+    def _population_configs(self, search: PatternSearch) -> list[helion.Config]:
+        return [
+            search.config_gen.unflatten(flat)
+            for flat in search._generate_initial_population_flat()
+        ]
+
+    def test_decorator_accepts_single_hint(self) -> None:
+        hint = helion.Config(block_sizes=[16], num_warps=8)
+        add, _args = self._make_kernel_and_args(autotune_hints=hint)
+
+        self.assertEqual(add.autotune_hints, [hint])
+        self.assertEqual(add.configs, [])
+
+    def test_random_initial_population_includes_hints(self) -> None:
+        hint = helion.Config(block_sizes=[16], num_warps=8)
+        add, args = self._make_kernel_and_args(autotune_hints=[hint])
+        bound = add.bind(args)
+        search = PatternSearch(bound, args, initial_population=3)
+
+        configs = self._population_configs(search)
+
+        self.assertGreaterEqual(len(configs), 3)
+        self.assertEqual(configs[1].num_warps, 8)
+
+    def test_best_available_initial_population_includes_hints(self) -> None:
+        hint = helion.Config(block_sizes=[16], num_warps=8)
+        add, args = self._make_kernel_and_args(autotune_hints=[hint])
+        bound = add.bind(args)
+        search = PatternSearch(
+            bound,
+            args,
+            initial_population_strategy=InitialPopulationStrategy.FROM_BEST_AVAILABLE,
+        )
+
+        with patch.object(BaseSearch, "_find_similar_cached_configs", return_value=[]):
+            configs = self._population_configs(search)
+
+        self.assertGreaterEqual(len(configs), 2)
+        self.assertEqual(configs[1].num_warps, 8)
+
+    def test_random_initial_population_logs_invalid_hints(self) -> None:
+        hint = helion.Config.from_dict({"block_sizes": ["bad"]})
+        add, args = self._make_kernel_and_args(autotune_hints=[hint])
+        bound = add.bind(args)
+        search = PatternSearch(bound, args, initial_population=3)
+        search.log = Mock()
+
+        configs = self._population_configs(search)
+
+        self.assertGreaterEqual(len(configs), 3)
+        search.log.assert_called_once()
+        self.assertIn("Failed to transfer autotune hint 1", search.log.call_args[0][0])
 
 
 @skipIfRefEager("Autotuning requires compilation, not supported in ref eager mode")

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -2688,7 +2688,7 @@ class TestAutotuneHints(TestCase):
         self.assertEqual(add.configs, [])
 
     def test_random_initial_population_includes_hints(self) -> None:
-        hint = helion.Config(block_sizes=[16], num_warps=8)
+        hint = helion.Config(block_sizes=[1])
         add, args = self._make_kernel_and_args(autotune_hints=[hint])
         bound = add.bind(args)
         search = PatternSearch(bound, args, initial_population=3)
@@ -2696,10 +2696,10 @@ class TestAutotuneHints(TestCase):
         configs = self._population_configs(search)
 
         self.assertGreaterEqual(len(configs), 3)
-        self.assertEqual(configs[1].num_warps, 8)
+        self.assertEqual(configs[1].block_sizes, [1])
 
     def test_best_available_initial_population_includes_hints(self) -> None:
-        hint = helion.Config(block_sizes=[16], num_warps=8)
+        hint = helion.Config(block_sizes=[1])
         add, args = self._make_kernel_and_args(autotune_hints=[hint])
         bound = add.bind(args)
         search = PatternSearch(
@@ -2712,7 +2712,7 @@ class TestAutotuneHints(TestCase):
             configs = self._population_configs(search)
 
         self.assertGreaterEqual(len(configs), 2)
-        self.assertEqual(configs[1].num_warps, 8)
+        self.assertEqual(configs[1].block_sizes, [1])
 
     def test_random_initial_population_logs_invalid_hints(self) -> None:
         hint = helion.Config.from_dict({"block_sizes": ["bad"]})

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -2684,7 +2684,7 @@ class TestAutotuneHints(TestCase):
         hint = helion.Config(block_sizes=[16], num_warps=8)
         add, _args = self._make_kernel_and_args(autotune_hints=hint)
 
-        self.assertEqual(add.autotune_hints, [hint])
+        self.assertEqual(add.settings.autotune_hints, hint)
         self.assertEqual(add.configs, [])
 
     def test_random_initial_population_includes_hints(self) -> None:

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -2688,7 +2688,7 @@ class TestAutotuneHints(TestCase):
         self.assertEqual(add.configs, [])
 
     def test_random_initial_population_includes_hints(self) -> None:
-        hint = helion.Config(block_sizes=[1])
+        hint = helion.Config(num_warps=8)
         add, args = self._make_kernel_and_args(autotune_hints=[hint])
         bound = add.bind(args)
         search = PatternSearch(bound, args, initial_population=3)
@@ -2696,10 +2696,10 @@ class TestAutotuneHints(TestCase):
         configs = self._population_configs(search)
 
         self.assertGreaterEqual(len(configs), 3)
-        self.assertEqual(configs[1].block_sizes, [1])
+        self.assertTrue(any(config.num_warps == 8 for config in configs))
 
     def test_best_available_initial_population_includes_hints(self) -> None:
-        hint = helion.Config(block_sizes=[1])
+        hint = helion.Config(num_warps=8)
         add, args = self._make_kernel_and_args(autotune_hints=[hint])
         bound = add.bind(args)
         search = PatternSearch(
@@ -2712,7 +2712,7 @@ class TestAutotuneHints(TestCase):
             configs = self._population_configs(search)
 
         self.assertGreaterEqual(len(configs), 2)
-        self.assertEqual(configs[1].block_sizes, [1])
+        self.assertTrue(any(config.num_warps == 8 for config in configs))
 
     def test_random_initial_population_logs_invalid_hints(self) -> None:
         hint = helion.Config.from_dict({"block_sizes": ["bad"]})

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -2657,8 +2657,8 @@ class TestAutotuneCacheSelection(TestCase):
 
 
 @onlyBackends(["triton"])
-class TestAutotuneHints(TestCase):
-    """Tests for seeding initial autotune populations with user hints."""
+class TestAutotuneSeedConfigs(TestCase):
+    """Tests for seeding initial autotune populations with user configs."""
 
     def _make_kernel_and_args(self, **kernel_kwargs):
         @helion.kernel(autotune_log_level=0, **kernel_kwargs)
@@ -2680,16 +2680,16 @@ class TestAutotuneHints(TestCase):
             for flat in search._generate_initial_population_flat()
         ]
 
-    def test_decorator_accepts_single_hint(self) -> None:
-        hint = helion.Config(block_sizes=[16], num_warps=8)
-        add, _args = self._make_kernel_and_args(autotune_hints=hint)
+    def test_decorator_accepts_single_seed_config(self) -> None:
+        seed_config = helion.Config(block_sizes=[16], num_warps=8)
+        add, _args = self._make_kernel_and_args(autotune_seed_configs=seed_config)
 
-        self.assertEqual(add.settings.autotune_hints, hint)
+        self.assertEqual(add.settings.autotune_seed_configs, seed_config)
         self.assertEqual(add.configs, [])
 
-    def test_random_initial_population_includes_hints(self) -> None:
-        hint = helion.Config(num_warps=8)
-        add, args = self._make_kernel_and_args(autotune_hints=[hint])
+    def test_random_initial_population_includes_seed_configs(self) -> None:
+        seed_config = helion.Config(num_warps=8)
+        add, args = self._make_kernel_and_args(autotune_seed_configs=[seed_config])
         bound = add.bind(args)
         search = PatternSearch(bound, args, initial_population=3)
 
@@ -2698,9 +2698,9 @@ class TestAutotuneHints(TestCase):
         self.assertGreaterEqual(len(configs), 3)
         self.assertTrue(any(config.num_warps == 8 for config in configs))
 
-    def test_best_available_initial_population_includes_hints(self) -> None:
-        hint = helion.Config(num_warps=8)
-        add, args = self._make_kernel_and_args(autotune_hints=[hint])
+    def test_best_available_initial_population_includes_seed_configs(self) -> None:
+        seed_config = helion.Config(num_warps=8)
+        add, args = self._make_kernel_and_args(autotune_seed_configs=[seed_config])
         bound = add.bind(args)
         search = PatternSearch(
             bound,
@@ -2714,9 +2714,9 @@ class TestAutotuneHints(TestCase):
         self.assertGreaterEqual(len(configs), 2)
         self.assertTrue(any(config.num_warps == 8 for config in configs))
 
-    def test_random_initial_population_logs_invalid_hints(self) -> None:
-        hint = helion.Config.from_dict({"block_sizes": ["bad"]})
-        add, args = self._make_kernel_and_args(autotune_hints=[hint])
+    def test_random_initial_population_logs_invalid_seed_configs(self) -> None:
+        seed_config = helion.Config.from_dict({"block_sizes": ["bad"]})
+        add, args = self._make_kernel_and_args(autotune_seed_configs=[seed_config])
         bound = add.bind(args)
         search = PatternSearch(bound, args, initial_population=3)
         search.log = Mock()
@@ -2725,7 +2725,9 @@ class TestAutotuneHints(TestCase):
 
         self.assertGreaterEqual(len(configs), 3)
         search.log.assert_called_once()
-        self.assertIn("Failed to transfer autotune hint 1", search.log.call_args[0][0])
+        self.assertIn(
+            "Failed to transfer autotune seed config 1", search.log.call_args[0][0]
+        )
 
 
 @skipIfRefEager("Autotuning requires compilation, not supported in ref eager mode")


### PR DESCRIPTION
Users typically have a good sense of what configs will work for their kernel (e.g. #2102 and #1857). This can help narrow down the search space, improving autotuner performance and wall-clock. However, some of these heuristics are kernel-specific and may be detrimental in some cases. Encoding these heuristics as constraints on the search space may be undesireable.

It's worth noting that while restricting the search space can encourage the autotuner to explore more efficiently, it is not the only or even most efficient way of doing so. The default autotuner `LFBOTreeSearch`, as well as other variants like `LFBOPatternSearch`, `PatternSearch` or `DifferentialEvolution` are fundamentally _adaptive_, and automatically tailor more exploration around the best performing configs. 

This means that a more effective way to guide the autotuner is simply to _drop hints_: include specific configs into the original initial population. If the hints are effective, the autotuner will explore more in that direction. If they end up being bad, then the autotuner can just ignore and continue its exploration. The strong performance of LLM seeding for `LFBOTreeSearch` introduced in #2004 shows that well-designed hints can greatly speed up autotuning.

This PR introduces a new field in the kernel decorator called `autotune_hints = Config | List[Config] | None`. Example usage is:
```
@helion.kernel(
        static_shapes=True,
        autotune_hints=[Config(block_sizes = [64, 64, 128], num_warps = 8), Config(block_sizes = [32, 32, 128])]
)
```
The functionality is essentially identical to `configs` but does not restrict search space. Instead it just adds additional configs to the initial population.

For the example in #2102, for skinny gemm (M = 1024, N = 8192), we see improvements from inserting the hint from that PR: `Config(block_sizes = [64, 64, 256])` using autotune effort = quick

script: https://gist.github.com/ethche/11f96e5954afee5ffa02e5f9d0859a25

| Case | Hint | Selected block sizes | Other selected settings | Autotune duration | Post-run median | Speedup |
  |---|---:|---|---|---:|---:|---:|
  | no_hints | No | [64, 64, 256] | num_warps=4, num_stages=3, pid_type='flat' | 86.448s | 1.363 ms | 1.00x |
  | with_hints | Yes | [8, 256, 64] | num_warps=4, num_stages=4, pid_type='persistent_interleaved', indexing[0]='tensor_descriptor', maxnreg=256 | 60.049s | 1.006 ms | 1.355x |

It's interesting that in this run, the best config found from the no-hint run actually obtained the block sizes specified in the hint. We see that including the hint accelerates this process.