### PR TITLE
[Pallas] Lower hl.zeros / hl.full to plain jnp.full

### DIFF
--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -519,21 +519,13 @@ def _setup_loop_carried_state(
             continue
         if isinstance(proxy, torch.Tensor):
             assert isinstance(arg_ast, ast.Name)
-            # Reuse existing scratch if the init value is already in one
-            # (e.g. from hl.full / hl.zeros). Otherwise allocate new.
-            existing = any(
-                s.name == arg_ast.id for s in state.device_function._scratch_args
+            shape = _resolve_shape(proxy, env, state.config)
+            dtype = proxy.dtype
+            scratch_name = state.device_function.register_scratch(
+                shape, dtype, name_hint=f"scratch_{i}"
             )
-            if existing:
-                scratch_name = arg_ast.id
-            else:
-                shape = _resolve_shape(proxy, env, state.config)
-                dtype = proxy.dtype
-                scratch_name = state.device_function.register_scratch(
-                    shape, dtype, name_hint=f"scratch_{i}"
-                )
-                # Initialize scratch with the arg value.
-                state.add_statement(_scratch_write_stmt(state, scratch_name, arg_ast))
+            # Initialize scratch with the arg value.
+            state.add_statement(_scratch_write_stmt(state, scratch_name, arg_ast))
             scratch_names.append(scratch_name)
 
             # Result will be read after loop

--- a/helion/language/creation_ops.py
+++ b/helion/language/creation_ops.py
@@ -153,52 +153,18 @@ def _full_codegen(state: CodegenState) -> ast.AST:
 def _full_codegen_pallas(state: CodegenState) -> ast.AST:
     """Pallas codegen for hl.full / hl.zeros.
 
-    When ``pallas_loop_type`` is ``"emit_pipeline"`` or ``"fori_loop"``,
-    device tensors created at grid scope
-    (before any pipeline loop) are registered as scratch memory. The
-    scratch ref is initialized in the kernel and later captured by the
-    pipeline body closure.
+    Always lowers to a plain ``jnp.full`` bound to a fresh local, regardless
+    of pallas_loop_type.  The previous emit_pipeline/fori_loop path returned
+    a bare scratch ref AST, which broke any downstream arithmetic on the
+    result outside the inner loop -- e.g. ``acc = hl.zeros(...); acc += x``
+    emitted ``scratch + x`` and JAX raised
+    ``'AbstractRef' object has no attribute '_add'`` at trace time
+    (``Refs`` don't support arithmetic; only ``ref[...]`` reads).
+
+    When the result is loop-carried, ``_setup_loop_carried_state`` allocates
+    a scratch buffer at the loop boundary and copies the init value in --
+    no scratch needed at the ``hl.zeros`` site itself.
     """
-    from .._compiler.ast_extension import statement_from_string
-
-    config = state.config
-    pallas_loop_type = config.get("pallas_loop_type", "unroll")
-
-    if pallas_loop_type in ("emit_pipeline", "fori_loop"):
-        fake_value = state.fake_value
-        assert isinstance(fake_value, torch.Tensor)
-        env = CompileEnvironment.current()
-        # Resolve symbolic tile sizes to concrete block sizes from config
-        resolved_shape: list[int] = []
-        for s in fake_value.size():
-            bid = env.resolve_block_id(s)
-            if bid is not None:
-                bs = env.block_sizes[bid].from_config(config)
-                assert isinstance(bs, int)
-                resolved_shape.append(bs)
-            else:
-                resolved_shape.append(int(s))
-        shape = tuple(resolved_shape)
-        dtype = fake_value.dtype
-
-        # Register as scratch memory
-        scratch_name = state.device_function.register_scratch(shape, dtype)
-
-        # Emit initialization: scratch_ref[...] = jnp.full(scratch_ref.shape, value, dtype)
-        proxy_value = state.proxy_arg(1)
-        if isinstance(proxy_value, (int, float, bool)):
-            value_str = state.device_function.literal_expr(proxy_value)
-        else:
-            value_str = str(proxy_value)
-        jnp_dtype = CompileEnvironment.current().backend.dtype_str(dtype)
-        state.add_statement(
-            statement_from_string(
-                f"{scratch_name}[...] = jnp.full({scratch_name}.shape, {value_str}, {jnp_dtype})"
-            )
-        )
-        return expr_from_string(scratch_name)
-
-    # Fall through to common codegen
     return full._codegen["common"](state)  # pyrefly: ignore[missing-attribute]
 
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -873,6 +873,45 @@ class TestPallas(TestCase):
         self.assertIn("out = torch.empty_like(q_view, device='meta')", _code)
         self.assertIn("out = _launcher(", _code)
 
+    def test_hl_zeros_outer_arithmetic_emit_pipeline(self) -> None:
+        """``hl.zeros`` results must support arithmetic at outer (non-inner-loop) scope.
+
+        Regression test: ``acc = hl.zeros(...); acc += x`` written before an
+        inner emit_pipeline / fori_loop must work.  Previously, the Pallas
+        codegen for hl.zeros returned a bare VMEM scratch ref, so the outer
+        ``acc + x`` emitted ``scratch + x`` and JAX raised
+        ``'AbstractRef' object has no attribute '_add'`` at trace time.
+        Inner-loop bodies dodged the issue via ``_remap_args_to_scratch``;
+        outer scope had no equivalent remap.
+        """
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def kernel(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.shape
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(m):
+                acc = hl.zeros([tile_m, n], dtype=torch.float32)
+                # Outer-scope arithmetic on the hl.zeros result with a
+                # scalar.  Previously, this emitted ``scratch + 1.0`` and
+                # JAX raised the AbstractRef ``_add`` error.
+                acc += 1.0
+                # Inner emit_pipeline forces the previously-buggy scratch
+                # path inside ``hl.zeros`` codegen.
+                for tile_k in hl.tile(n):
+                    acc += x[tile_m, tile_k].to(torch.float32).sum(dim=-1, keepdim=True)
+                out[tile_m, :] = acc.to(x.dtype)
+            return out
+
+        x = torch.randn(128, 128, device=DEVICE, dtype=torch.float32)
+        _code, result = code_and_output(
+            kernel,
+            (x,),
+            block_sizes=[32, 128],
+            pallas_loop_type="emit_pipeline",
+        )
+        ref = 1.0 + x.sum(dim=-1, keepdim=True).expand(-1, 128)
+        torch.testing.assert_close(result, ref, rtol=1e-3, atol=1e-3)
+
     def test_attention_emit_pipeline_correctness(self) -> None:
         """Test emit_pipeline attention with loop-carried state and pre-broadcast."""
         query = torch.randn(2, 2, 128, 128, dtype=torch.float32, device=DEVICE)


### PR DESCRIPTION
## Summary

Previously, `_full_codegen_pallas` returned a bare VMEM scratch ref AST when `pallas_loop_type` was `emit_pipeline` or `fori_loop`. That broke any downstream arithmetic on the result *outside* an inner loop:

```python
acc = hl.zeros([m, n], dtype=torch.float32)
acc += x[...]   # emits ``scratch + x``, raises
                # AttributeError: 'AbstractRef' has no attribute '_add'
```

Inner-loop bodies dodged the issue via `_remap_args_to_scratch` (which rewrites scratch refs to `scratch[...]` reads); outer scope had no equivalent remap.

Surfaces in real kernels — e.g. `examples/se_block.py`'s `se_block_bwd_dx` (covered by `test/test_examples.py::TestExamples::test_se_block_bwd_dx`) does the outer arithmetic pattern:

```python
acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
acc += 2.0 * grad_out[tile_m, tile_n] * s[tile_m, tile_n]   # outer scope, BUG
for tile_k in hl.tile(n):
    acc += grad_to_w @ w[tile_n, tile_k].T
```

Today this is masked because the kernel runs on `unroll` by default; flipping the default to `emit_pipeline` exposes it. With this fix, `test_se_block_bwd_dx` no longer hits the AbstractRef error (a separate shape-mismatch bug in the same test is fixed by #2284).

## Fix

Always lower `hl.full` / `hl.zeros` to a plain `jnp.full` bound to a fresh local, regardless of loop type. Downstream arithmetic gets a real tensor value. When the result is loop-carried, `_setup_loop_carried_state` allocates a scratch buffer at the loop boundary as before — no scratch is needed at the `hl.zeros` site itself.

### What happens in each case

**Not loop-carried** — the `jnp.full(...)` value is used directly as a regular JAX tensor. No scratch buffer involved at all. Same behavior as the common (non-Pallas) `_full_codegen` codepath.

**Loop-carried** — `_setup_loop_carried_state` allocates a scratch buffer at the loop boundary, emits `scratch_X[...] = init_value[...]` to seed it, and the inner loop iterates writing back to `scratch_X`. After the loop, `_read_final_loop_state` reads back the final value.

## Cleanup: drop now-dead `_setup_loop_carried_state` branch

Before this PR, when `hl.zeros` registered a scratch ref upfront, two systems wanted scratch for the same logical buffer:

1. `hl.zeros` → `register_scratch` → returned ref AST (e.g. `scratch_0`).
2. `_setup_loop_carried_state` → also allocates a scratch when a loop carries the value.

To avoid a double allocation, `_setup_loop_carried_state` had a "reuse existing scratch" branch (`if any(s.name == arg_ast.id for s in _scratch_args): scratch_name = arg_ast.id`). It only fired when (1) had run for the same FX node.

After this PR, (1) no longer registers a scratch — it returns a `jnp.full` value bound to a fresh local. `arg_ast.id` is that local's name, never matches `_scratch_args`. The reuse branch is unreachable, so dropped (kept the `else` body inline). Net behavior: exactly one scratch per loop-carried tensor, allocated by (2). For well-behaved kernels (`hl.zeros` followed straight by a loop with no outer arithmetic on the result) the count is unchanged (the old reuse branch was achieving the same with extra plumbing). The buggy outer-arithmetic case used to allocate two (init scratch + loop scratch via the missed-reuse path) and now allocates one — though that path was broken anyway pre-fix.

## Regression test

`test_hl_zeros_outer_arithmetic_emit_pipeline` exercises the outer-scope-arithmetic pattern directly under `pallas_loop_type="emit_pipeline"` (so it fails on `main` without depending on the default flip). Verified on TPU to fail on main with `AttributeError: 'AbstractRef' has no attribute '_add'` and pass with this fix.