### PR TITLE
[language] Add hl.rand4x for 4-output Philox RNG

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -87,6 +87,7 @@ runtime
    full
    arange
    rand
+   rand4x
    randint
    subscript
    split

--- a/docs/api/language.md
+++ b/docs/api/language.md
@@ -220,6 +220,12 @@ def k(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 .. autofunction:: rand
 ```
 
+### rand4x()
+
+```{eval-rst}
+.. autofunction:: rand4x
+```
+
 ### randint()
 
 ```{eval-rst}

--- a/helion/_compiler/rng_utils.py
+++ b/helion/_compiler/rng_utils.py
@@ -118,6 +118,19 @@ def philox_rand_ref(
     return _uint32_to_uniform_float_ref(c0)
 
 
+def philox_rand4x_ref(
+    seed: int | torch.Tensor,
+    offset: int | torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    c0, c1, c2, c3 = philox_uint32_4_ref(seed, offset)
+    return (
+        _uint32_to_uniform_float_ref(c0),
+        _uint32_to_uniform_float_ref(c1),
+        _uint32_to_uniform_float_ref(c2),
+        _uint32_to_uniform_float_ref(c3),
+    )
+
+
 def philox_randint_ref(
     seed: int | torch.Tensor,
     offset: int | torch.Tensor,

--- a/helion/language/__init__.py
+++ b/helion/language/__init__.py
@@ -31,6 +31,7 @@ from .matmul_ops import dot_scaled as dot_scaled
 from .memory_ops import load as load
 from .memory_ops import store as store
 from .random_ops import rand as rand
+from .random_ops import rand4x as rand4x
 from .random_ops import randint as randint
 from .reduce_ops import reduce as reduce
 from .scan_ops import associative_scan as associative_scan

--- a/helion/language/random_ops.py
+++ b/helion/language/random_ops.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import operator
 from typing import TYPE_CHECKING
 from typing import cast
 
@@ -18,6 +19,7 @@ from .._compiler.rng_utils import PHILOX_ROUNDS
 from .._compiler.rng_utils import TWO_PI
 from .._compiler.rng_utils import UINT32_TO_UNIFORM_SCALE
 from .._compiler.rng_utils import codegen_rng_seed_expr
+from .._compiler.rng_utils import philox_rand4x_ref
 from .._compiler.rng_utils import philox_rand_ref
 from .._compiler.rng_utils import philox_randint_ref
 from ..exc import NotInsideKernel
@@ -33,7 +35,7 @@ if TYPE_CHECKING:
     from .._compiler.inductor_lowering import CodegenState
     from .tile_interface import TileInterface
 
-__all__ = ["rand", "randint"]
+__all__ = ["rand", "rand4x", "randint"]
 
 _ShapeDim = int | torch.SymInt
 _ArgDesc = tuple[bool, object]
@@ -333,6 +335,19 @@ def decompose_rand(
     return _philox_rand_from_seed_and_offset(seed, offsets)
 
 
+def decompose_rand4x(
+    seed: int | torch.SymInt | torch.Tensor,
+    offsets: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    c0, c1, c2, c3 = _philox_uint32x4(seed, offsets)
+    return (
+        _uint32_to_uniform_float(c0),
+        _uint32_to_uniform_float(c1),
+        _uint32_to_uniform_float(c2),
+        _uint32_to_uniform_float(c3),
+    )
+
+
 def decompose_randint(
     shape: list[int | torch.SymInt],
     *,
@@ -496,7 +511,7 @@ def _copy_rewrite_subgraph(
     *,
     before: Node,
     runtime_args: list[Node],
-) -> Node:
+) -> Node | tuple[Node, ...]:
     helper_placeholders = list(helper_graph.find_nodes(op="placeholder"))
     helper_getattrs = list(helper_graph.find_nodes(op="get_attr"))
     if helper_getattrs:
@@ -508,6 +523,9 @@ def _copy_rewrite_subgraph(
             helper_graph,
             dict(zip(helper_placeholders, runtime_args, strict=True)),
         )
+    if isinstance(copied, tuple):
+        assert all(isinstance(item, Node) for item in copied)
+        return cast("tuple[Node, ...]", copied)  # pyrefly: ignore[redundant-cast]
     assert isinstance(copied, Node)
     return copied
 
@@ -515,9 +533,9 @@ def _copy_rewrite_subgraph(
 def _trace_rewrite_subgraph(
     graph: torch.fx.Graph,
     node: Node,
-    helper: Callable[..., torch.Tensor],
+    helper: Callable[..., object],
     descriptors: list[_ArgDesc],
-) -> Node:
+) -> Node | tuple[Node, ...]:
     from .._compiler.device_ir import _make_fx
 
     runtime_args, example_args = _rewrite_runtime_args(descriptors)
@@ -583,6 +601,7 @@ def _resolve_offsets_desc(
 def _random_rewrite_nodes(graph: torch.fx.Graph) -> list[Node]:
     targets = (
         rand,
+        rand4x,
         randint,
         torch.ops.aten.rand.default,
         torch.ops.aten.randn.default,
@@ -625,6 +644,42 @@ def rewrite_implicit_random_ops(graph: torch.fx.Graph) -> None:
                 return decompose_rand(shape, seed=seed, offsets=offsets)
 
             replacement = _trace_rewrite_subgraph(graph, node, helper, descriptors)
+        elif node.target is rand4x:
+            descriptors: list[_ArgDesc] = []
+            seed_desc = _add_rewrite_desc(descriptors, node.args[0])
+            offsets_desc = _add_rewrite_desc(descriptors, node.args[1])
+
+            def helper(
+                *flat_args: object,
+                seed_desc: _ArgDesc = seed_desc,
+                offsets_desc: _ArgDesc = offsets_desc,
+            ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+                seed = _resolve_seed_desc(flat_args, seed_desc)
+                offsets = _resolve_offsets_desc(flat_args, offsets_desc)
+                assert offsets is not None
+                return decompose_rand4x(seed, offsets)
+
+            replacement_tuple = _trace_rewrite_subgraph(
+                graph, node, helper, descriptors
+            )
+            assert isinstance(replacement_tuple, tuple)
+            assert len(replacement_tuple) == 4
+            for user in list(node.users):
+                if (
+                    user.op == "call_function"
+                    and user.target is operator.getitem
+                    and len(user.args) == 2
+                ):
+                    idx = user.args[1]
+                    assert isinstance(idx, int) and 0 <= idx < 4
+                    user.replace_all_uses_with(replacement_tuple[idx])
+                    graph.erase_node(user)
+                else:
+                    raise NotImplementedError(
+                        f"unexpected non-getitem user of hl.rand4x: {user}"
+                    )
+            graph.erase_node(node)
+            continue
         elif node.target is randint:
             shape_arg = node.args[0]
             descriptors, shape_desc = _shape_rewrite_desc(shape_arg)
@@ -727,6 +782,7 @@ def rewrite_implicit_random_ops(graph: torch.fx.Graph) -> None:
         else:
             continue
 
+        assert isinstance(replacement, Node)
         node.replace_all_uses_with(replacement)
         graph.erase_node(node)
 
@@ -836,6 +892,91 @@ def _(
         return philox_rand_ref(seed, offsets).to(device=rng_device)
     processed_shape, offset = _ref_rng_shape_and_offset(shape, device=rng_device)
     return philox_rand_ref(seed, offset).reshape(processed_shape).to(device=rng_device)
+
+
+@_decorators.api(tiles_as_sizes=False)
+def rand4x(
+    seed: int | torch.Tensor,
+    offsets: torch.Tensor,
+    device: torch.device | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    hl.rand4x returns four independent uniform float32 tensors in ``[0, 1)``
+    per offset from a single Philox round (~4× cheaper than four separate
+    :func:`hl.rand` calls). Mirrors Triton's ``tl.rand4x``.
+
+    Args:
+        seed: A single element int64 tensor or int literal
+        offsets: Int64 offset tensor fed into the Philox RNG. The output
+            tensors have shape equal to ``offsets.shape``.
+        device: Device must match the current compile environment device
+
+    Returns:
+        tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        Four float32 tensors, each with shape ``offsets.shape`` and values in
+        [0, 1).
+
+    Examples:
+        Three sibling dropout masks per element with a single Philox call:
+
+        .. code-block:: python
+
+            @helion.kernel
+            def triple_dropout_kernel(x: torch.Tensor) -> torch.Tensor:
+                out = torch.empty_like(x)
+                (n,) = x.shape
+                for tile in hl.tile(n):
+                    base = hl.tile_index(tile).to(torch.int64)
+                    r0, r1, r2, _ = hl.rand4x(seed=42, offsets=base)
+                    keep = (r0 > 0.1) & (r1 > 0.2) & (r2 > 0.3)
+                    out[tile] = x[tile] * keep.to(x.dtype)
+                return out
+    """
+    raise NotInsideKernel
+
+
+@_decorators.register_fake(rand4x)
+def _rand4x_fake(
+    seed: int | torch.Tensor,
+    offsets: torch.Tensor,
+    device: torch.device | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    if not isinstance(offsets, torch.Tensor):
+        raise TypeError(
+            f"Expected torch.Tensor for offsets, got {type(offsets).__name__}"
+        )
+    env = CompileEnvironment.current()
+    rng_device = env.device if device is None else device
+    for _ in range(4):
+        env.add_kernel_tensor_size(offsets.shape)
+    return (
+        torch.empty([*offsets.shape], dtype=torch.float32, device=rng_device),
+        torch.empty([*offsets.shape], dtype=torch.float32, device=rng_device),
+        torch.empty([*offsets.shape], dtype=torch.float32, device=rng_device),
+        torch.empty([*offsets.shape], dtype=torch.float32, device=rng_device),
+    )
+
+
+@_decorators.get_masked_value(rand4x)
+def _(node: torch.fx.Node) -> float:
+    return 0
+
+
+@_decorators.ref(rand4x)
+def _(
+    seed: int | torch.Tensor,
+    offsets: torch.Tensor,
+    device: torch.device | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    env = CompileEnvironment.current()
+    rng_device = env.device if device is None else device
+    r0, r1, r2, r3 = philox_rand4x_ref(seed, offsets)
+    return (
+        r0.to(device=rng_device),
+        r1.to(device=rng_device),
+        r2.to(device=rng_device),
+        r3.to(device=rng_device),
+    )
 
 
 @_decorators.api(tiles_as_sizes=True)

--- a/test/test_random.py
+++ b/test/test_random.py
@@ -7,6 +7,7 @@ import unittest
 import torch
 
 import helion
+from helion._compiler.rng_utils import philox_rand4x_ref
 from helion._compiler.rng_utils import philox_rand_ref
 from helion._compiler.rng_utils import philox_randint_ref
 from helion._testing import DEVICE
@@ -140,6 +141,26 @@ if triton is not None and tl is not None:
         tl.store(out_ptr + idx, values, mask=mask)
 
     @triton.jit
+    def _triton_rand4x_from_offsets(
+        seed,
+        offsets_ptr,
+        out0_ptr,
+        out1_ptr,
+        out2_ptr,
+        out3_ptr,
+        n_elements,
+        BLOCK: tl.constexpr,
+    ):
+        idx = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+        mask = idx < n_elements
+        offsets = tl.load(offsets_ptr + idx, mask=mask, other=0)
+        r0, r1, r2, r3 = tl.rand4x(seed, offsets)
+        tl.store(out0_ptr + idx, r0, mask=mask)
+        tl.store(out1_ptr + idx, r1, mask=mask)
+        tl.store(out2_ptr + idx, r2, mask=mask)
+        tl.store(out3_ptr + idx, r3, mask=mask)
+
+    @triton.jit
     def _triton_randint_from_offsets(
         seed,
         offsets_ptr,
@@ -166,6 +187,26 @@ if triton is not None and tl is not None:
         )
         return out
 
+    def _triton_rand4x_reference(
+        seed: int, offsets: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        n = offsets.numel()
+        out0 = torch.empty(n, device=offsets.device, dtype=torch.float32)
+        out1 = torch.empty(n, device=offsets.device, dtype=torch.float32)
+        out2 = torch.empty(n, device=offsets.device, dtype=torch.float32)
+        out3 = torch.empty(n, device=offsets.device, dtype=torch.float32)
+        _triton_rand4x_from_offsets[(triton.cdiv(n, 256),)](
+            seed,
+            offsets,
+            out0,
+            out1,
+            out2,
+            out3,
+            n,
+            BLOCK=256,
+        )
+        return out0, out1, out2, out3
+
     def _triton_randint_reference(
         seed: int,
         offsets: torch.Tensor,
@@ -187,6 +228,11 @@ if triton is not None and tl is not None:
 else:
 
     def _triton_rand_reference(seed: int, offsets: torch.Tensor) -> torch.Tensor:
+        raise unittest.SkipTest("requires Triton")
+
+    def _triton_rand4x_reference(
+        seed: int, offsets: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         raise unittest.SkipTest("requires Triton")
 
     def _triton_randint_reference(
@@ -593,6 +639,39 @@ class TestRandom(RefEagerTestBase, TestCase):
         expected_b = _triton_rand_reference(seed, ref_offsets_b).reshape_as(x)
         _assert_bitwise_equal_float(self, a, expected_a)
         _assert_bitwise_equal_float(self, b, expected_b)
+
+    @skipIfRefEager("compile_config is not supported in ref eager mode")
+    def test_hl_rand4x_dropout_pattern(self):
+        """Generate three sibling dropout masks per element with a single rand4x call."""
+
+        @helion.kernel(static_shapes=False, autotune_effort="none")
+        def triple_dropout_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
+            m = x.size(0)
+            output = torch.zeros((3, m), device=x.device, dtype=x.dtype)
+            for tile_m in hl.tile(m):
+                idx = hl.tile_index(tile_m).to(torch.int64)
+                r0, r1, r2, _ = hl.rand4x(seed, idx)
+                output[0, tile_m] = (r0 > 0.1).to(x.dtype) * x[tile_m]
+                output[1, tile_m] = (r1 > 0.2).to(x.dtype) * x[tile_m]
+                output[2, tile_m] = (r2 > 0.3).to(x.dtype) * x[tile_m]
+            return output
+
+        x = torch.ones(256, device=DEVICE, dtype=torch.float32)
+        seed = 9999
+        code, compiled = _compile_once(
+            triple_dropout_kernel, (x, seed), block_sizes=[64]
+        )
+        out = compiled(x, seed)
+
+        ref_offsets = torch.arange(x.numel(), device=DEVICE, dtype=torch.int64)
+        r0, r1, r2, _ = _triton_rand4x_reference(seed, ref_offsets)
+        expected_0 = ((r0 > 0.1).to(x.dtype) * x).reshape(x.shape)
+        expected_1 = ((r1 > 0.2).to(x.dtype) * x).reshape(x.shape)
+        expected_2 = ((r2 > 0.3).to(x.dtype) * x).reshape(x.shape)
+        _assert_bitwise_equal_float(self, out[0], expected_0)
+        _assert_bitwise_equal_float(self, out[1], expected_1)
+        _assert_bitwise_equal_float(self, out[2], expected_2)
+        _assert_uses_philox(self, code)
 
     def test_hl_randint_1d(self):
         """Test hl.randint with 1D output."""
@@ -1115,6 +1194,80 @@ class TestRandomPhiloxParity(TestCase):
         )
         compiled_out = compiled(x, seed)
         ref_out = rand_offsets_kernel_ref(x, seed)
+        _assert_bitwise_equal_float(self, compiled_out, ref_out)
+
+    def test_hl_rand4x_matches_triton_reference(self):
+        @helion.kernel(static_shapes=False, autotune_effort="none")
+        def rand4x_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
+            (m,) = x.shape
+            out = torch.zeros((4, m), device=x.device, dtype=torch.float32)
+            for tile_m in hl.tile(m):
+                idx = hl.tile_index(tile_m).to(torch.int64)
+                r0, r1, r2, r3 = hl.rand4x(seed, idx)
+                out[0, tile_m] = r0
+                out[1, tile_m] = r1
+                out[2, tile_m] = r2
+                out[3, tile_m] = r3
+            return out
+
+        x = torch.empty(123, device=DEVICE, dtype=torch.float32)
+        seed = 271828
+        code, out = code_and_output(rand4x_kernel, (x, seed), block_sizes=[16])
+        offsets = torch.arange(x.numel(), device=DEVICE, dtype=torch.int64)
+        e0, e1, e2, e3 = _triton_rand4x_reference(seed, offsets)
+        _assert_bitwise_equal_float(self, out[0], e0.reshape_as(x))
+        _assert_bitwise_equal_float(self, out[1], e1.reshape_as(x))
+        _assert_bitwise_equal_float(self, out[2], e2.reshape_as(x))
+        _assert_bitwise_equal_float(self, out[3], e3.reshape_as(x))
+        _assert_uses_philox(self, code)
+
+    def test_hl_rand4x_ref_matches_triton(self):
+        seed = 54321
+        offsets = torch.arange(96, device=DEVICE, dtype=torch.int64) * 4
+        t0, t1, t2, t3 = _triton_rand4x_reference(seed, offsets)
+        r0, r1, r2, r3 = philox_rand4x_ref(seed, offsets)
+        _assert_bitwise_equal_float(self, t0, r0)
+        _assert_bitwise_equal_float(self, t1, r1)
+        _assert_bitwise_equal_float(self, t2, r2)
+        _assert_bitwise_equal_float(self, t3, r3)
+
+    @skipIfRefEager("compile_config is not supported in ref eager mode")
+    def test_hl_rand4x_ref_mode_matches_compiled(self):
+        @helion.kernel(static_shapes=False, autotune_effort="none")
+        def rand4x_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
+            (m,) = x.shape
+            out = torch.zeros((4, m), device=x.device, dtype=torch.float32)
+            for tile_m in hl.tile(m):
+                idx = hl.tile_index(tile_m).to(torch.int64)
+                r0, r1, r2, r3 = hl.rand4x(seed, idx)
+                out[0, tile_m] = r0
+                out[1, tile_m] = r1
+                out[2, tile_m] = r2
+                out[3, tile_m] = r3
+            return out
+
+        @helion.kernel(
+            static_shapes=False,
+            autotune_effort="none",
+            ref_mode=helion.RefMode.EAGER,
+        )
+        def rand4x_kernel_ref(x: torch.Tensor, seed: int) -> torch.Tensor:
+            (m,) = x.shape
+            out = torch.zeros((4, m), device=x.device, dtype=torch.float32)
+            for tile_m in hl.tile(m):
+                idx = hl.tile_index(tile_m).to(torch.int64)
+                r0, r1, r2, r3 = hl.rand4x(seed, idx)
+                out[0, tile_m] = r0
+                out[1, tile_m] = r1
+                out[2, tile_m] = r2
+                out[3, tile_m] = r3
+            return out
+
+        x = torch.empty(96, device=DEVICE, dtype=torch.float32)
+        seed = 999
+        _code, compiled = _compile_once(rand4x_kernel, (x, seed), block_sizes=[16])
+        compiled_out = compiled(x, seed)
+        ref_out = rand4x_kernel_ref(x, seed)
         _assert_bitwise_equal_float(self, compiled_out, ref_out)
 
 


### PR DESCRIPTION
[language] Add hl.rand4x for 4-output Philox RNG

Adds `hl.rand4x(seed, offsets, device=None) -> tuple[Tensor, Tensor, Tensor, Tensor]`, mirroring Triton's `tl.rand4x`. A single Philox round produces four independent `[0, 1)` float32 tensors ,~4× cheaper than four separate `hl.rand` calls when multiple sibling RNG streams are needed (e.g. packing several dropout masks per
element).

## Usage

```python
@helion.kernel
def triple_dropout_kernel(x: torch.Tensor, seed: int) -> torch.Tensor:
    out = torch.empty((3, x.size(0)), device=x.device, dtype=x.dtype)
    for tile in hl.tile(x.size(0)):
        idx = hl.tile_index(tile).to(torch.int64)
        r0, r1, r2, _ = hl.rand4x(seed, idx)
        out[0, tile] = (r0 > 0.1).to(x.dtype) * x[tile]
        out[1, tile] = (r1 > 0.2).to(x.dtype) * x[tile]
        out[2, tile] = (r2 > 0.3).to(x.dtype) * x[tile]
    return out
```
Fixes: #2147