### PR TITLE
[Pallas] Don't pipeline tensors read or written outside the inner loop

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -2269,21 +2269,11 @@ def _loop_contains_atomic(
     fn: DeviceFunction,
     block_ids: list[int],
 ) -> bool:
-    from ..language import atomic_ops
     from ..language._decorators import is_api_func
+    from ..language.atomic_ops import ATOMIC_OPS as atomic_targets
     from .device_ir import RootGraphInfo
     from .host_function import HostFunction
 
-    atomic_targets = {
-        atomic_ops.atomic_add,
-        atomic_ops.atomic_and,
-        atomic_ops.atomic_cas,
-        atomic_ops.atomic_max,
-        atomic_ops.atomic_min,
-        atomic_ops.atomic_or,
-        atomic_ops.atomic_xchg,
-        atomic_ops.atomic_xor,
-    }
     device_ir = HostFunction.current().device_ir
     graph_by_id = {
         graph_info.graph_id: graph_info

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -1249,8 +1249,8 @@ class DeviceFunction:
 
     def get_tensor_read_write_names(self) -> tuple[set[str], set[str]]:
         """Returns AST names of read and written tensors"""
-        from helion.language import atomic_ops
         from helion.language import memory_ops
+        from helion.language.atomic_ops import ATOMIC_OPS
 
         read_names: set[str] = set()
         write_names: set[str] = set()
@@ -1270,16 +1270,7 @@ class DeviceFunction:
                     read_names.add(_get_tensor_name(node))
                 elif node.target is memory_ops.store:
                     write_names.add(_get_tensor_name(node))
-                elif node.target in (
-                    atomic_ops.atomic_add,
-                    atomic_ops.atomic_cas,
-                    atomic_ops.atomic_or,
-                    atomic_ops.atomic_xor,
-                    atomic_ops.atomic_xchg,
-                    atomic_ops.atomic_min,
-                    atomic_ops.atomic_max,
-                    atomic_ops.atomic_and,
-                ):
+                elif node.target in ATOMIC_OPS:
                     read_names.add(_get_tensor_name(node))
                     write_names.add(_get_tensor_name(node))
         return read_names, write_names

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -99,24 +99,14 @@ def plan_tiling(
 
 
 def _analyze_indexing_expressions(graph_info: GraphInfo, config: Config) -> None:
-    from ...language import atomic_ops
     from ...language import memory_ops
+    from ...language.atomic_ops import ATOMIC_OPS
 
+    indexing_targets = ATOMIC_OPS | {memory_ops.load, memory_ops.store}
     for node in graph_info.graph.nodes:
         if node.op != "call_function":
             continue
-        if node.target in (
-            memory_ops.load,
-            memory_ops.store,
-            atomic_ops.atomic_add,
-            atomic_ops.atomic_cas,
-            atomic_ops.atomic_or,
-            atomic_ops.atomic_xor,
-            atomic_ops.atomic_xchg,
-            atomic_ops.atomic_min,
-            atomic_ops.atomic_max,
-            atomic_ops.atomic_and,
-        ):
+        if node.target in indexing_targets:
             _analyze_indexing(node, config)
 
 

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -1840,8 +1840,11 @@ def _classify_pipelined_tensors(
     Tensors that fail any check stay on their outer BlockSpec and are
     closure-read from the body.
     """
+    from .atomic_ops import ATOMIC_OPS
     from .memory_ops import load as _load_op
     from .memory_ops import store as _store_op
+
+    outer_access_targets = ATOMIC_OPS | {_load_op, _store_op}
 
     all_tensor_info: list[tuple[torch.Tensor, list[object], str]] = []
     for key, (fake, _tensor_node, sub_meta) in loaded_tensors.items():
@@ -1856,14 +1859,16 @@ def _classify_pipelined_tensors(
     inner_block_id_set = set(block_ids)
     grid_block_id_set = {bid for ids in device_ir.grid_block_ids for bid in ids}
 
-    # Walk all root graphs (outer pallas_call body) for load/store nodes.
-    # Anything indexed there is read/written outside the inner loop and
-    # must stay on the outer BlockSpec.
+    # Walk all root graphs (outer pallas_call body) for load/store/atomic
+    # nodes.  Pallas lowers atomics as load-compute-store on the same ref,
+    # so an outer-scope atomic on T is also an outer-scope memory access
+    # that breaks pipelining (HBM ref can't be pl.ds'd outside the inner
+    # emit_pipeline / fori_loop body).
     outer_access_tensor_ids: set[int] = set()
     for root_id in device_ir.root_ids:
         root_graph = device_ir.graphs[root_id].graph
         for node in root_graph.nodes:
-            if node.op != "call_function" or node.target not in (_load_op, _store_op):
+            if node.op != "call_function" or node.target not in outer_access_targets:
                 continue
             tensor_node = node.args[0]
             if not isinstance(tensor_node, torch.fx.Node):

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -1825,12 +1825,15 @@ def _classify_pipelined_tensors(
 
     * Its inner-block ``vmem_shape`` passes ``_check_dma_alignment`` -- a TPU
       DMA hardware constraint.
-    * No dim is shared between an *inner-loop* block_id and an *outer*
+    * No dim is shared between the *current inner loop* and an *outer/grid*
       block_id.  When a dim is indexed by both (e.g. the kernel reads
       ``T[tile_m, tile_n]`` at outer scope and ``T[tile_m, tile_k]`` inside
       the inner loop), the kernel needs outer ``pl.ds`` slicing for that
       dim, which only works when the tensor stays on its outer BlockSpec.
       HBM refs (the pipelined path) can't be sliced directly with ``pl.ds``.
+      Sibling inner-loop block_ids (other emit_pipeline / fori_loop bodies
+      under the same outer grid) don't trigger this -- they don't put the
+      shared dim on the outer BlockSpec.
 
     Tensors that fail either check stay on their outer BlockSpec and are
     closure-read from the body.
@@ -1845,6 +1848,9 @@ def _classify_pipelined_tensors(
         all_tensor_info, block_ids, slice_size_exprs, env, state
     )
     inner_block_id_set = set(block_ids)
+    grid_block_id_set = {
+        bid for ids in HostFunction.current().device_ir.grid_block_ids for bid in ids
+    }
     dim_tilings_map = state.device_function.pallas_tensor_dim_tilings
     pipelined_ids: set[int] = set()
     for (fake, _sub_meta, _direction), vmem_shape in zip(
@@ -1854,8 +1860,8 @@ def _classify_pipelined_tensors(
             continue
         dim_tilings = dim_tilings_map.get(id(fake))
         if dim_tilings is not None and any(
-            len(d.block_ids) > 1
-            and any(bid not in inner_block_id_set for bid in d.block_ids)
+            any(bid in inner_block_id_set for bid in d.block_ids)
+            and any(bid in grid_block_id_set for bid in d.block_ids)
             for d in dim_tilings
         ):
             continue

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -1825,17 +1825,14 @@ def _classify_pipelined_tensors(
 
     * Its inner-block ``vmem_shape`` passes ``_check_dma_alignment`` -- a TPU
       DMA hardware constraint.
-    * The tensor is not also accessed at outer scope (i.e. in a root graph,
+    * It is not also accessed at outer scope (i.e. in a root graph,
       between/before/after inner loops).  Pipelining replaces the tensor's
       outer BlockSpec with ``pltpu.HBM`` so the inner loop's BlockSpec can
-      handle slicing; reads at outer scope would then have to ``pl.ds`` an
-      HBM ref, which isn't supported.
-    * No dim is shared between the *current inner loop* and an *outer/grid*
-      block_id.  Catches in-loop conflicting accesses (e.g. transposed
-      indexing) where a single inner BlockSpec can't serve both.  Sibling
-      inner-loop block_ids (other emit_pipeline / fori_loop bodies under
-      the same outer grid) don't trigger this -- they don't put the shared
-      dim on the outer BlockSpec.
+      handle slicing; reads/writes at outer scope would then have to
+      ``pl.ds`` an HBM ref, which Pallas rejects with "Loads are only
+      allowed on VMEM and SMEM references."  Pallas lowers atomics as
+      load-compute-store on the same ref, so outer-scope atomics count as
+      memory accesses too.
 
     Tensors that fail any check stay on their outer BlockSpec and are
     closure-read from the body.
@@ -1856,14 +1853,10 @@ def _classify_pipelined_tensors(
         all_tensor_info, block_ids, slice_size_exprs, env, state
     )
     device_ir = HostFunction.current().device_ir
-    inner_block_id_set = set(block_ids)
-    grid_block_id_set = {bid for ids in device_ir.grid_block_ids for bid in ids}
 
     # Walk all root graphs (outer pallas_call body) for load/store/atomic
-    # nodes.  Pallas lowers atomics as load-compute-store on the same ref,
-    # so an outer-scope atomic on T is also an outer-scope memory access
-    # that breaks pipelining (HBM ref can't be pl.ds'd outside the inner
-    # emit_pipeline / fori_loop body).
+    # nodes; any tensor accessed there is read/written outside the inner
+    # loop and must keep its outer BlockSpec.
     outer_access_tensor_ids: set[int] = set()
     for root_id in device_ir.root_ids:
         root_graph = device_ir.graphs[root_id].graph
@@ -1877,7 +1870,6 @@ def _classify_pipelined_tensors(
             if isinstance(val, torch.Tensor):
                 outer_access_tensor_ids.add(id(val))
 
-    dim_tilings_map = state.device_function.pallas_tensor_dim_tilings
     pipelined_ids: set[int] = set()
     for (fake, _sub_meta, _direction), vmem_shape in zip(
         all_tensor_info, vmem_shapes, strict=True
@@ -1885,13 +1877,6 @@ def _classify_pipelined_tensors(
         if not _check_dma_alignment(vmem_shape):
             continue
         if id(fake) in outer_access_tensor_ids:
-            continue
-        dim_tilings = dim_tilings_map.get(id(fake))
-        if dim_tilings is not None and any(
-            any(bid in inner_block_id_set for bid in d.block_ids)
-            and any(bid in grid_block_id_set for bid in d.block_ids)
-            for d in dim_tilings
-        ):
             continue
         pipelined_ids.add(id(fake))
     return all_tensor_info, vmem_shapes, pipelined_ids

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -1825,19 +1825,24 @@ def _classify_pipelined_tensors(
 
     * Its inner-block ``vmem_shape`` passes ``_check_dma_alignment`` -- a TPU
       DMA hardware constraint.
+    * The tensor is not also accessed at outer scope (i.e. in a root graph,
+      between/before/after inner loops).  Pipelining replaces the tensor's
+      outer BlockSpec with ``pltpu.HBM`` so the inner loop's BlockSpec can
+      handle slicing; reads at outer scope would then have to ``pl.ds`` an
+      HBM ref, which isn't supported.
     * No dim is shared between the *current inner loop* and an *outer/grid*
-      block_id.  When a dim is indexed by both (e.g. the kernel reads
-      ``T[tile_m, tile_n]`` at outer scope and ``T[tile_m, tile_k]`` inside
-      the inner loop), the kernel needs outer ``pl.ds`` slicing for that
-      dim, which only works when the tensor stays on its outer BlockSpec.
-      HBM refs (the pipelined path) can't be sliced directly with ``pl.ds``.
-      Sibling inner-loop block_ids (other emit_pipeline / fori_loop bodies
-      under the same outer grid) don't trigger this -- they don't put the
-      shared dim on the outer BlockSpec.
+      block_id.  Catches in-loop conflicting accesses (e.g. transposed
+      indexing) where a single inner BlockSpec can't serve both.  Sibling
+      inner-loop block_ids (other emit_pipeline / fori_loop bodies under
+      the same outer grid) don't trigger this -- they don't put the shared
+      dim on the outer BlockSpec.
 
-    Tensors that fail either check stay on their outer BlockSpec and are
+    Tensors that fail any check stay on their outer BlockSpec and are
     closure-read from the body.
     """
+    from .memory_ops import load as _load_op
+    from .memory_ops import store as _store_op
+
     all_tensor_info: list[tuple[torch.Tensor, list[object], str]] = []
     for key, (fake, _tensor_node, sub_meta) in loaded_tensors.items():
         if key not in stored_tensors:
@@ -1847,16 +1852,34 @@ def _classify_pipelined_tensors(
     vmem_shapes = _compute_vmem_shapes(
         all_tensor_info, block_ids, slice_size_exprs, env, state
     )
+    device_ir = HostFunction.current().device_ir
     inner_block_id_set = set(block_ids)
-    grid_block_id_set = {
-        bid for ids in HostFunction.current().device_ir.grid_block_ids for bid in ids
-    }
+    grid_block_id_set = {bid for ids in device_ir.grid_block_ids for bid in ids}
+
+    # Walk all root graphs (outer pallas_call body) for load/store nodes.
+    # Anything indexed there is read/written outside the inner loop and
+    # must stay on the outer BlockSpec.
+    outer_access_tensor_ids: set[int] = set()
+    for root_id in device_ir.root_ids:
+        root_graph = device_ir.graphs[root_id].graph
+        for node in root_graph.nodes:
+            if node.op != "call_function" or node.target not in (_load_op, _store_op):
+                continue
+            tensor_node = node.args[0]
+            if not isinstance(tensor_node, torch.fx.Node):
+                continue
+            val = tensor_node.meta.get("val")
+            if isinstance(val, torch.Tensor):
+                outer_access_tensor_ids.add(id(val))
+
     dim_tilings_map = state.device_function.pallas_tensor_dim_tilings
     pipelined_ids: set[int] = set()
     for (fake, _sub_meta, _direction), vmem_shape in zip(
         all_tensor_info, vmem_shapes, strict=True
     ):
         if not _check_dma_alignment(vmem_shape):
+            continue
+        if id(fake) in outer_access_tensor_ids:
             continue
         dim_tilings = dim_tilings_map.get(id(fake))
         if dim_tilings is not None and any(

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -1430,10 +1430,10 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         state, block_ids, block_size_vars
     )
 
-    # Aligned tensors flow through emit_pipeline's per-iter Buffered
-    # BlockSpec; unaligned ones stay on the outer pallas_call BlockSpec
+    # Pipelined tensors flow through emit_pipeline's per-iter Buffered
+    # BlockSpec; the rest stay on the outer pallas_call BlockSpec
     # (escape clause `bs == as`) and are closure-read from the body.
-    all_tensor_info, _vmem_shapes, aligned_tensor_ids = _classify_pipelined_tensors(
+    all_tensor_info, _vmem_shapes, pipelined_tensor_ids = _classify_pipelined_tensors(
         loaded_tensors, stored_tensors, block_ids, slice_size_exprs, env, state
     )
 
@@ -1578,16 +1578,16 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     from .._compiler.device_function import PallasMemorySpace
 
     for fake, _tensor_node, _sub_meta in loaded_tensors.values():
-        if id(fake) in aligned_tensor_ids:
+        if id(fake) in pipelined_tensor_ids:
             state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
     for fake, _tensor_node, _sub_meta in stored_tensors.values():
-        if id(fake) in aligned_tensor_ids:
+        if id(fake) in pipelined_tensor_ids:
             state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
 
     for key, (fake, _tensor_node, sub_meta) in loaded_tensors.items():
         if key in stored_tensors:
             continue  # Handle as output instead
-        if id(fake) not in aligned_tensor_ids:
+        if id(fake) not in pipelined_tensor_ids:
             continue
         hbm_name = state.device_function.tensor_arg(fake).name
         vmem_name = state.device_function.new_var(
@@ -1599,7 +1599,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         pipeline_in_args.append(hbm_name)
 
     for fake, _tensor_node, sub_meta in stored_tensors.values():
-        if id(fake) not in aligned_tensor_ids:
+        if id(fake) not in pipelined_tensor_ids:
             continue
         hbm_name = state.device_function.tensor_arg(fake).name
         vmem_name = state.device_function.new_var(
@@ -1657,7 +1657,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     # sliced via pl.ds against a VMEM ref whose extent is the whole
     # outer-block window.  Pipelined tensors ignore these offsets and
     # use the ``:`` full-slice inside their VMEM scratches.
-    any_non_pipelined = len(aligned_tensor_ids) < len(all_tensor_info)
+    any_non_pipelined = len(pipelined_tensor_ids) < len(all_tensor_info)
     if any_non_pipelined:
         _needs_explicit_indices = True
         for i, bid in enumerate(block_ids):
@@ -1818,12 +1818,22 @@ def _classify_pipelined_tensors(
 ) -> tuple[
     list[tuple[torch.Tensor, list[object], str]], list[tuple[int, ...]], set[int]
 ]:
-    """Build (all_tensor_info, vmem_shapes, aligned_ids) for an inner loop.
+    """Build (all_tensor_info, vmem_shapes, pipelined_ids) for an inner loop.
 
-    Tensors whose ``vmem_shape`` passes ``_check_dma_alignment`` are eligible
-    for the inner-DMA path (HBM ref + small VMEM scratch in fori_loop, or
-    ``pl.Buffered`` BlockSpec in emit_pipeline); the rest stay on their
-    outer ``pallas_call`` BlockSpec and are closure-read from the body.
+    A tensor is eligible for the inner-DMA path (HBM ref + small VMEM scratch
+    in fori_loop, or ``pl.Buffered`` BlockSpec in emit_pipeline) when:
+
+    * Its inner-block ``vmem_shape`` passes ``_check_dma_alignment`` -- a TPU
+      DMA hardware constraint.
+    * No dim is shared between an *inner-loop* block_id and an *outer*
+      block_id.  When a dim is indexed by both (e.g. the kernel reads
+      ``T[tile_m, tile_n]`` at outer scope and ``T[tile_m, tile_k]`` inside
+      the inner loop), the kernel needs outer ``pl.ds`` slicing for that
+      dim, which only works when the tensor stays on its outer BlockSpec.
+      HBM refs (the pipelined path) can't be sliced directly with ``pl.ds``.
+
+    Tensors that fail either check stay on their outer BlockSpec and are
+    closure-read from the body.
     """
     all_tensor_info: list[tuple[torch.Tensor, list[object], str]] = []
     for key, (fake, _tensor_node, sub_meta) in loaded_tensors.items():
@@ -1834,14 +1844,23 @@ def _classify_pipelined_tensors(
     vmem_shapes = _compute_vmem_shapes(
         all_tensor_info, block_ids, slice_size_exprs, env, state
     )
-    aligned_ids = {
-        id(fake)
-        for (fake, _sub_meta, _direction), vmem_shape in zip(
-            all_tensor_info, vmem_shapes, strict=True
-        )
-        if _check_dma_alignment(vmem_shape)
-    }
-    return all_tensor_info, vmem_shapes, aligned_ids
+    inner_block_id_set = set(block_ids)
+    dim_tilings_map = state.device_function.pallas_tensor_dim_tilings
+    pipelined_ids: set[int] = set()
+    for (fake, _sub_meta, _direction), vmem_shape in zip(
+        all_tensor_info, vmem_shapes, strict=True
+    ):
+        if not _check_dma_alignment(vmem_shape):
+            continue
+        dim_tilings = dim_tilings_map.get(id(fake))
+        if dim_tilings is not None and any(
+            len(d.block_ids) > 1
+            and any(bid not in inner_block_id_set for bid in d.block_ids)
+            for d in dim_tilings
+        ):
+            continue
+        pipelined_ids.add(id(fake))
+    return all_tensor_info, vmem_shapes, pipelined_ids
 
 
 def _codegen_fori_loop(state: CodegenState) -> object:
@@ -1902,13 +1921,13 @@ def _codegen_fori_loop(state: CodegenState) -> object:
             env,
         )
 
-    # Aligned tensors get HBM refs (no outer BlockSpec) + VMEM scratch +
-    # semaphore; unaligned tensors keep their outer BlockSpec and are
-    # accessed via pl.ds() in the body.  Mixing both paths inside a single
-    # fori_loop avoids forcing every tensor onto the non-DMA path when a
-    # lone unaligned tensor is present (which would load full outer-block
+    # Pipelined tensors get HBM refs (no outer BlockSpec) + VMEM scratch +
+    # semaphore; the rest keep their outer BlockSpec and are accessed via
+    # pl.ds() in the body.  Mixing both paths inside a single fori_loop
+    # avoids forcing every tensor onto the non-DMA path when a lone
+    # non-pipelined tensor is present (which would load full outer-block
     # tiles into VMEM and may OOM at large shapes).
-    all_tensor_info, vmem_shapes, aligned_tensor_ids = _classify_pipelined_tensors(
+    all_tensor_info, vmem_shapes, pipelined_tensor_ids = _classify_pipelined_tensors(
         loaded_tensors, stored_tensors, block_ids, slice_size_exprs, env, state
     )
 
@@ -1919,7 +1938,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     for (fake, _sub_meta, _direction), vmem_shape in zip(
         all_tensor_info, vmem_shapes, strict=True
     ):
-        if id(fake) not in aligned_tensor_ids:
+        if id(fake) not in pipelined_tensor_ids:
             continue
         state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
         hbm_name = state.device_function.tensor_arg(fake).name

--- a/helion/language/atomic_ops.py
+++ b/helion/language/atomic_ops.py
@@ -1660,3 +1660,17 @@ def _(state: CodegenState) -> ast.AST:
         )
     )
     return expr_from_string(prev_var)
+
+
+ATOMIC_OPS: frozenset[Callable[..., object]] = frozenset(
+    {
+        atomic_add,
+        atomic_and,
+        atomic_cas,
+        atomic_max,
+        atomic_min,
+        atomic_or,
+        atomic_xchg,
+        atomic_xor,
+    }
+)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1738,6 +1738,47 @@ class TestPallas(TestCase):
         self.assertIn("pl.ds(", code)
         torch.testing.assert_close(result, x * r)
 
+    def test_emit_pipeline_no_pipeline_outer_inner_shared_dim(self) -> None:
+        """Don't pipeline a tensor whose dim is shared between outer and inner tiles.
+
+        Regression test: when a kernel reads a tensor at outer scope using
+        an outer block_id (e.g. ``T[tile_m, tile_n]``) and *also* inside an
+        inner emit_pipeline using a different inner block_id on the same
+        dim (e.g. ``T[tile_m, tile_k]``), the kernel needs outer ``pl.ds``
+        slicing for the shared dim.  Pipelining the tensor turns it into
+        an HBM ref, which can't be sliced with ``pl.ds`` -- emit_pipeline
+        then either crashes (HBM read not allowed) or generates the wrong
+        offset.  The classifier must keep such tensors on the outer
+        BlockSpec (no ``_pipeline_arg_indices`` entry).
+        """
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.shape
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = x[tile_m, tile_n].to(torch.float32)  # outer-scope use of n
+                # inner emit_pipeline shares x's n dim with the outer tile
+                # via a different block_id -> x's n dim has both
+                # tile_n_bid (outer) and tile_k_bid (inner).
+                for tile_k in hl.tile(n):
+                    acc += x[tile_m, tile_k].to(torch.float32).sum(dim=-1, keepdim=True)
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        x = torch.randn(128, 128, device=DEVICE, dtype=torch.float32)
+        code, _result = code_and_output(
+            fn,
+            (x,),
+            block_sizes=[32, 128, 128],
+            pallas_loop_type="emit_pipeline",
+        )
+        # x's n dim is shared (tile_n outer, tile_k inner), so x must NOT
+        # be pipelined.  The body should use ``pl.ds`` on x at outer scope
+        # rather than emit a pipeline arg for it.
+        self.assertIn("pltpu.emit_pipeline", code)
+        self.assertNotIn("_pipeline_arg_indices=[0", code)
+
     def test_fori_loop_per_tensor_dma_mixed(self) -> None:
         """A fori_loop body can mix DMA-aligned and DMA-unaligned tensors.
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1783,44 +1783,48 @@ class TestPallas(TestCase):
                 self.assertNotIn("_pipeline_arg_indices=[0", code)
                 torch.testing.assert_close(result, expected)
 
-    def test_no_pipeline_outer_redundant_read(self) -> None:
-        """Don't pipeline a tensor read at both outer scope and inner scope
-        with the same outer-grid index (no inner block_id on its dims).
+    def test_no_pipeline_outer_summary_read(self) -> None:
+        """Don't pipeline a tensor that's read at outer scope as a per-row
+        summary, even when no inner block_id appears alongside an outer/grid
+        block_id on any dim of the tensor.
 
-        Regression test for the case where the outer read uses some grid
-        block_id (e.g. ``T[tile_m, :]``) and inner code redundantly re-reads
-        T using the same grid block_id, with no inner block_id contributing
-        to T's dim_tilings.  Pipelining would replace T's outer BlockSpec
-        with HBM, and the outer-scope ``pl.load`` then fails with
-        "Loads are only allowed on VMEM and SMEM references."
+        Outer scope reads ``T[tile_m, :]`` to compute a per-row summary;
+        inner loop reads ``T[tile_m, tile_k]`` for per-tile work.  Pipelining
+        T would replace its outer BlockSpec with HBM, and the outer-scope
+        ``T[tile_m, :]`` load then fails with ``"Loads are only allowed on
+        VMEM and SMEM references."``.  Companion to
+        ``test_no_pipeline_outer_inner_shared_dim`` -- both exercise the
+        outer-scope-access exclusion in ``_classify_pipelined_tensors`` but
+        through different access patterns (this one uses ``:`` on the inner
+        loop's dim; the other uses an outer-grid block_id on it).
         """
 
-        @helion.kernel(
-            backend="pallas",
-            static_shapes=True,
-            config=helion.Config(
-                block_sizes=[128, 128, 128],
-                loop_orders=[[0, 1]],
-                pallas_loop_type="emit_pipeline",
-            ),
-        )
+        @helion.kernel(backend="pallas", static_shapes=True)
         def fn(T: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
             m, n = x.shape
             out = torch.empty_like(x)
-            for tile_m, tile_n in hl.tile([m, n]):
-                outer_sum = T[tile_m, :].to(torch.float32).sum(dim=-1, keepdim=True)
-                for _tile_k in hl.tile(n):
-                    inner_sum = T[tile_m, :].to(torch.float32).sum(dim=-1, keepdim=True)
-                    out[tile_m, tile_n] = (
-                        x[tile_m, tile_n].to(torch.float32) + outer_sum + inner_sum
-                    ).to(x.dtype)
+            aux = torch.empty([m], dtype=x.dtype, device=x.device)
+            for tile_m in hl.tile(m):
+                # outer-scope read of T -- a per-row summary
+                aux[tile_m] = T[tile_m, :].sum(dim=-1)
+                for tile_k in hl.tile(n):
+                    # inner-scope read of T -- per-tile elementwise work
+                    out[tile_m, tile_k] = T[tile_m, tile_k] * x[tile_m, tile_k]
             return out
 
         T = torch.randn(128, 128, device=DEVICE, dtype=torch.float32)
         x = torch.randn(128, 128, device=DEVICE, dtype=torch.float32)
-        result = fn(T, x)
-        expected = (x.float() + 2 * T.float().sum(dim=1, keepdim=True)).to(x.dtype)
-        torch.testing.assert_close(result, expected, rtol=1e-3, atol=1e-3)
+        code, result = code_and_output(
+            fn,
+            (T, x),
+            block_sizes=[128, 128],
+            pallas_loop_type="emit_pipeline",
+        )
+        # T (arg index 0) must NOT be pipelined — its outer-scope load
+        # would otherwise hit HBM after the BlockSpec is replaced.
+        self.assertIn("pltpu.emit_pipeline", code)
+        self.assertNotIn("_pipeline_arg_indices=[0", code)
+        torch.testing.assert_close(result, T * x, rtol=1e-3, atol=1e-3)
 
     def test_fori_loop_per_tensor_dma_mixed(self) -> None:
         """A fori_loop body can mix DMA-aligned and DMA-unaligned tensors.

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1738,18 +1738,18 @@ class TestPallas(TestCase):
         self.assertIn("pl.ds(", code)
         torch.testing.assert_close(result, x * r)
 
-    def test_emit_pipeline_no_pipeline_outer_inner_shared_dim(self) -> None:
+    def test_no_pipeline_outer_inner_shared_dim(self) -> None:
         """Don't pipeline a tensor whose dim is shared between outer and inner tiles.
 
         Regression test: when a kernel reads a tensor at outer scope using
         an outer block_id (e.g. ``T[tile_m, tile_n]``) and *also* inside an
-        inner emit_pipeline using a different inner block_id on the same
-        dim (e.g. ``T[tile_m, tile_k]``), the kernel needs outer ``pl.ds``
-        slicing for the shared dim.  Pipelining the tensor turns it into
-        an HBM ref, which can't be sliced with ``pl.ds`` -- emit_pipeline
-        then either crashes (HBM read not allowed) or generates the wrong
-        offset.  The classifier must keep such tensors on the outer
-        BlockSpec (no ``_pipeline_arg_indices`` entry).
+        inner emit_pipeline / fori_loop using a different inner block_id on
+        the same dim (e.g. ``T[tile_m, tile_k]``), the kernel needs outer
+        ``pl.ds`` slicing for the shared dim.  Pipelining the tensor turns
+        it into an HBM ref, which can't be sliced with ``pl.ds`` -- the
+        body then either crashes or generates the wrong offset.  The
+        classifier (shared between both inner-loop codegens) must keep
+        such tensors on the outer BlockSpec.
         """
 
         @helion.kernel(backend="pallas", static_shapes=True)
@@ -1758,28 +1758,30 @@ class TestPallas(TestCase):
             out = torch.empty_like(x)
             for tile_m, tile_n in hl.tile([m, n]):
                 acc = x[tile_m, tile_n].to(torch.float32)  # outer-scope use of n
-                # inner emit_pipeline shares x's n dim with the outer tile
-                # via a different block_id -> x's n dim has both
-                # tile_n_bid (outer) and tile_k_bid (inner).
+                # inner loop shares x's n dim with the outer tile via a
+                # different block_id -> x's n dim has both tile_n_bid
+                # (outer) and tile_k_bid (inner).
                 for tile_k in hl.tile(n):
                     acc += x[tile_m, tile_k].to(torch.float32).sum(dim=-1, keepdim=True)
                 out[tile_m, tile_n] = acc.to(x.dtype)
             return out
 
         x = torch.randn(128, 128, device=DEVICE, dtype=torch.float32)
-        code, result = code_and_output(
-            fn,
-            (x,),
-            block_sizes=[32, 128, 128],
-            pallas_loop_type="emit_pipeline",
-        )
-        # x's n dim is shared (tile_n outer, tile_k inner), so x must NOT
-        # be pipelined.  The body should use ``pl.ds`` on x at outer scope
-        # rather than emit a pipeline arg for it.
-        self.assertIn("pltpu.emit_pipeline", code)
-        self.assertNotIn("_pipeline_arg_indices=[0", code)
         expected = x + x.sum(dim=1, keepdim=True)
-        torch.testing.assert_close(result, expected)
+        for loop_type, loop_marker in (
+            ("emit_pipeline", "pltpu.emit_pipeline"),
+            ("fori_loop", "jax.lax.fori_loop"),
+        ):
+            with self.subTest(pallas_loop_type=loop_type):
+                code, result = code_and_output(
+                    fn,
+                    (x,),
+                    block_sizes=[32, 128, 128],
+                    pallas_loop_type=loop_type,
+                )
+                self.assertIn(loop_marker, code)
+                self.assertNotIn("_pipeline_arg_indices=[0", code)
+                torch.testing.assert_close(result, expected)
 
     def test_fori_loop_per_tensor_dma_mixed(self) -> None:
         """A fori_loop body can mix DMA-aligned and DMA-unaligned tensors.

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1767,7 +1767,7 @@ class TestPallas(TestCase):
             return out
 
         x = torch.randn(128, 128, device=DEVICE, dtype=torch.float32)
-        code, _result = code_and_output(
+        code, result = code_and_output(
             fn,
             (x,),
             block_sizes=[32, 128, 128],
@@ -1778,6 +1778,8 @@ class TestPallas(TestCase):
         # rather than emit a pipeline arg for it.
         self.assertIn("pltpu.emit_pipeline", code)
         self.assertNotIn("_pipeline_arg_indices=[0", code)
+        expected = x + x.sum(dim=1, keepdim=True)
+        torch.testing.assert_close(result, expected)
 
     def test_fori_loop_per_tensor_dma_mixed(self) -> None:
         """A fori_loop body can mix DMA-aligned and DMA-unaligned tensors.

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1783,6 +1783,45 @@ class TestPallas(TestCase):
                 self.assertNotIn("_pipeline_arg_indices=[0", code)
                 torch.testing.assert_close(result, expected)
 
+    def test_no_pipeline_outer_redundant_read(self) -> None:
+        """Don't pipeline a tensor read at both outer scope and inner scope
+        with the same outer-grid index (no inner block_id on its dims).
+
+        Regression test for the case where the outer read uses some grid
+        block_id (e.g. ``T[tile_m, :]``) and inner code redundantly re-reads
+        T using the same grid block_id, with no inner block_id contributing
+        to T's dim_tilings.  Pipelining would replace T's outer BlockSpec
+        with HBM, and the outer-scope ``pl.load`` then fails with
+        "Loads are only allowed on VMEM and SMEM references."
+        """
+
+        @helion.kernel(
+            backend="pallas",
+            static_shapes=True,
+            config=helion.Config(
+                block_sizes=[128, 128, 128],
+                loop_orders=[[0, 1]],
+                pallas_loop_type="emit_pipeline",
+            ),
+        )
+        def fn(T: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+            m, n = x.shape
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile([m, n]):
+                outer_sum = T[tile_m, :].to(torch.float32).sum(dim=-1, keepdim=True)
+                for _tile_k in hl.tile(n):
+                    inner_sum = T[tile_m, :].to(torch.float32).sum(dim=-1, keepdim=True)
+                    out[tile_m, tile_n] = (
+                        x[tile_m, tile_n].to(torch.float32) + outer_sum + inner_sum
+                    ).to(x.dtype)
+            return out
+
+        T = torch.randn(128, 128, device=DEVICE, dtype=torch.float32)
+        x = torch.randn(128, 128, device=DEVICE, dtype=torch.float32)
+        result = fn(T, x)
+        expected = (x.float() + 2 * T.float().sum(dim=1, keepdim=True)).to(x.dtype)
+        torch.testing.assert_close(result, expected, rtol=1e-3, atol=1e-3)
+
     def test_fori_loop_per_tensor_dma_mixed(self) -> None:
         """A fori_loop body can mix DMA-aligned and DMA-unaligned tensors.
 


### PR DESCRIPTION
## Summary

A tensor pipelined via #2093's per-tensor decision becomes an HBM ref at the outer pallas_call boundary — its outer BlockSpec is replaced with `pl.BlockSpec(memory_space=pltpu.HBM)`. Reads/writes at outer scope (i.e. in the root graph, between/before/after inner loops) then have to `pl.ds` an HBM ref, which Pallas rejects with `"Loads are only allowed on VMEM and SMEM references."` — or, in some shapes, generates the wrong offset and crashes at swap-check with a shape mismatch.

Surfaces in `examples/se_block.py`'s `se_block_bwd_dx` (covered by `test/test_examples.py::TestExamples::test_se_block_bwd_dx`):

```python
for tile_m, tile_n in hl.tile([m, n]):
    acc = ... grad_out[tile_m, tile_n] ...        # outer scope read of grad_out
    for tile_k in hl.tile(n):
        ... grad_out[tile_m, tile_k] ...           # inner scope read of grad_out
```

Today this is masked because the kernel runs on `unroll` by default; running it with `pallas_loop_type="emit_pipeline"` exposes it. This fix removes one of the bugs gating that test from passing under the flipped default — additional pending fixes are still needed for the test to pass end-to-end.

## Fix

The question we want to answer is direct: *"is T accessed in the outer scope?"* The most principled way to check is to look at the outer scope's memory ops directly. In `_classify_pipelined_tensors`, walk every root graph for `load` / `store` / atomic ops; any tensor whose first arg's `meta["val"]` shows up there is read/written outside the inner loop and must keep its outer BlockSpec — exclude it from pipelining.

Atomics count: Pallas lowers `atomic_add` / `atomic_cas` / etc. as load-compute-store on the same ref, so an outer-scope atomic on `T` breaks pipelining the same way a plain load/store does. The 8-tuple of atomic targets, previously duplicated in three other call sites, is consolidated into `helion.language.atomic_ops.ATOMIC_OPS`.

## Why not dim_tilings?

An earlier iteration of this PR used a `dim_tilings`-based gate: exclude when some dim of T has both a *current-inner* block_id and an *outer/grid* block_id. That works for the original bug pattern above (dim 1 of `grad_out` ends up with `tile_n` (grid) + `tile_k` (inner)), but it's a *block_id pattern* check — one step removed from the actual question we're trying to answer. It infers "outer scope accessed T" from the shape of T's index expressions, which is necessary-not-sufficient: there are kernels where T is accessed outside the inner loop but no dim ends up with the (grid + current-inner) pair.

Concrete repro (added as `test_no_pipeline_outer_summary_read`):

```python
for tile_m in hl.tile(m):                         # grid block_id: tile_m
    aux[tile_m] = T[tile_m, :].sum(dim=-1)        # outer scope: dim 0 ← tile_m, dim 1 ← `:` (no block_id)
    for tile_k in hl.tile(n):                      # current inner: tile_k
        out[tile_m, tile_k] = T[tile_m, tile_k] * x[tile_m, tile_k]
                                                   # inner: dim 0 ← tile_m, dim 1 ← tile_k
```

`T`'s `dim_tilings` here is dim 0 = `[tile_m]` and dim 1 = `[tile_k]`. The outer `T[tile_m, :]` uses a `:` slice on dim 1, which contributes *nothing* to dim_tilings, so dim 1 ends up with only the current-inner `tile_k` — no grid block_id alongside. The `dim_tilings` "current-inner ∩ grid" gate doesn't fire. But T is still loaded at outer scope, so pipelining T (replacing its outer BlockSpec with HBM) makes the outer `T[tile_m, :]` crash with `"Loads are only allowed on VMEM and SMEM references."`. The FX-graph approach catches this directly: it asks the question we actually care about — *is there a memory op for T in the outer scope?* — without going through block_ids as a proxy. (Verified on TPU: the test passes with the FX-graph gate; with FX-graph disabled and dim_tilings re-added, the kernel raises that exact error.)

The FX-graph gate also strictly subsumes `dim_tilings` for the original bug pattern: outer reads of `grad_out[tile_m, tile_n]` already produce a load node in the root graph, so the gate fires there too. Verified empirically — full Pallas test suite (`test_pallas.py` + `test_examples.py`) passes with the FX-graph gate alone.

## Regression tests

* **`test_no_pipeline_outer_inner_shared_dim`** — the original `grad_out`-style bug, exercised under both `pallas_loop_type="emit_pipeline"` and `"fori_loop"` (one `subTest` each, since `_classify_pipelined_tensors` is shared). Verified on TPU: both subTests fail on main with `ValueError: Invalid shape for swap. Ref shape: (32, 128). Expected shape: (32, 128). Value shape: (128, 128).` and pass with this fix.
* **`test_no_pipeline_outer_summary_read`** — the realistic case dim_tilings would have missed: outer scope precomputes a per-row summary via `T[tile_m, :].sum(...)` (`:` contributes nothing to dim_tilings), inner loop does element-wise per-tile work via `T[tile_m, tile_k]` (only the current-inner block_id on dim 1, no grid id alongside). Without the FX-graph gate, T gets pipelined and the outer `T[tile_m, :]` raises `"Loads are only allowed on VMEM and SMEM references."`.

Sibling-inner-loop coverage: `test_two_pass_reduction_emit_pipeline` / `_fori_loop` confirm the gate doesn't over-fire — two `hl.tile(n)` reductions under one outer grid still pipeline `x` and `out` (verified `_pipeline_arg_indices=[0, 1]` in generated code).
