### PR TITLE
[Pallas] Use dot_general instead of matmul for Pallas codegen

### DIFF
--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -989,15 +989,7 @@ def codegen_baddbmm(ctx: LoweringContext, node: Node) -> ast.AST:
 
 
 def _pallas_dot(ctx: LoweringContext, node: Node, with_acc: bool) -> ast.AST:
-    """Generate jnp.matmul for Pallas backend.
-
-    Uses ``jnp.matmul`` instead of ``jnp.dot`` for correct batch matmul
-    semantics (``jnp.dot`` on 3D tensors produces 4D output).
-
-    When either operand is sub-32-bit (bf16, f16, fp8, int8), we pass
-    ``preferred_element_type=jnp.float32`` so TPU uses a 32-bit accumulator.
-    If the FX-level output dtype is narrower than f32 we cast back afterwards.
-    """
+    """Generate jnp.dot_general for Pallas backend."""
     if with_acc:
         acc_node_arg, lhs_node_arg, rhs_node_arg = node.args[:3]
         acc, lhs, rhs = map_arg(node.args, lambda arg: _env_arg(ctx, arg))
@@ -1015,6 +1007,7 @@ def _pallas_dot(ctx: LoweringContext, node: Node, with_acc: bool) -> ast.AST:
     assert isinstance(rhs_node_arg, Node)
     lhs_dtype = lhs_node_arg.meta["val"].dtype
     rhs_dtype = rhs_node_arg.meta["val"].dtype
+    lhs_ndim = lhs_node_arg.meta["val"].ndim
     need_f32_acc = _needs_f32_accumulator(lhs_dtype, rhs_dtype)
     out_dtype = node.meta["val"].dtype if "val" in node.meta else None
 
@@ -1024,6 +1017,7 @@ def _pallas_dot(ctx: LoweringContext, node: Node, with_acc: bool) -> ast.AST:
         acc=acc if with_acc else None,
         need_f32_acc=need_f32_acc,
         out_dtype=out_dtype,
+        lhs_ndim=lhs_ndim,
     )
 
 

--- a/helion/_compiler/matmul_utils.py
+++ b/helion/_compiler/matmul_utils.py
@@ -138,15 +138,16 @@ def _emit_pallas_matmul(
     acc: ast.AST | None = None,
     need_f32_acc: bool = False,
     out_dtype: torch.dtype | None = None,
+    lhs_ndim: int = 2,
 ) -> ast.AST:
-    """Build a ``jnp.matmul`` AST node for the Pallas backend.
+    """Build a ``lax.dot_general`` AST node for the Pallas backend.
 
     Parameters
     ----------
     lhs, rhs:
         AST nodes for the left / right operands.
     acc:
-        Optional AST node for the accumulator (``acc + matmul(...)``).
+        Optional AST node for the accumulator (``acc + dot_general(...)``).
     need_f32_acc:
         When True, emit ``preferred_element_type=jnp.float32`` and, if
         *out_dtype* is narrower than f32, append a
@@ -154,15 +155,28 @@ def _emit_pallas_matmul(
     out_dtype:
         Desired output dtype.  Only used when *need_f32_acc* is True to
         decide whether a cast-back is required.
+    lhs_ndim:
+        Number of dimensions in the left operand (2 for mm, 3 for bmm).
     """
+    if lhs_ndim == 3:
+        dim_numbers = "(((2,), (1,)), ((0,), (0,)))"
+    elif lhs_ndim == 2:
+        dim_numbers = "(((1,), (0,)), ((), ()))"
+    else:
+        raise ValueError(f"lhs_ndim must be 2 or 3, got {lhs_ndim}")
+
     if need_f32_acc:
         dot_expr = expr_from_string(
-            "jnp.matmul({lhs}, {rhs}, preferred_element_type=jnp.float32)",
+            f"lax.dot_general({{lhs}}, {{rhs}}, dimension_numbers={dim_numbers}, preferred_element_type=jnp.float32)",
             lhs=lhs,
             rhs=rhs,
         )
     else:
-        dot_expr = expr_from_string("jnp.matmul({lhs}, {rhs})", lhs=lhs, rhs=rhs)
+        dot_expr = expr_from_string(
+            f"lax.dot_general({{lhs}}, {{rhs}}, dimension_numbers={dim_numbers})",
+            lhs=lhs,
+            rhs=rhs,
+        )
 
     if acc is not None:
         dot_expr = expr_from_string("{acc} + {dot}", acc=acc, dot=dot_expr)

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -370,7 +370,7 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
     # Triton only supports 2D dot operations.  When the operands are 3D
     # (batched matmul), constrain the batch dimension block size to 1 so
     # the codegen can squeeze it away before emitting tl.dot.
-    # Pallas uses jnp.matmul which handles batched matmul natively.
+    # Pallas uses jnp.dot_general which handles batched matmul natively.
     if len(lshape) == 3 and env.backend_name != "pallas":
         for batch_dim in (lshape[0], rshape[0]):
             block_idx = env.get_block_id(batch_dim)
@@ -605,6 +605,7 @@ def _(state: CodegenState) -> object:
         acc=acc,
         need_f32_acc=need_f32_acc,
         out_dtype=out_dtype,
+        lhs_ndim=lhs_proxy.ndim,
     )
 
 


### PR DESCRIPTION
[Pallas] Use dot_general instead of matmul for Pallas codegen

@thcmbs Noticed a bug in Mosaic compiler, where `jnp.matmul` for shapes like `(1, 8192, 128)` inserts a transpose to `(8192, 1, 128)` before applying the matmul, which hurts perf on TPU. We confirmed that using dot_general avoids this issue.

With this kernel (https://gist.github.com/AmesingFlank/04291a7c248f9eba002d6b69aad1ba3e), this PR boosts perf from 110 TFLOPs to 260 TFLOPs.

Related Jax fix: https://github.com/jax-ml/jax/pull/37383,