### PR TITLE
[xpu] Disable proton build for XPU

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -98,7 +98,7 @@
       "ref-eager": false,
       "image": "intelgpu/ubuntu-24.04-lts2:2523.40",
       "runtime-version": "xpu",
-      "container-options": "--group-add 109 --device=/dev/mem --device=/dev/dri",
+      "container-options": "--group-add 109 --device=/dev/mem --device=/dev/dri -e ZE_AFFINITY_MASK",
       "pytorch-version": "pytorch-nightly",
       "alias": "xpu",
       "backend": "triton",

--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -93,6 +93,19 @@
       "triton-pin": "0d9283bf49"
     },
     {
+      "runner": "linux.idc.xpu",
+      "python-version": "3.12",
+      "ref-eager": false,
+      "image": "intelgpu/ubuntu-24.04-lts2:2523.40",
+      "runtime-version": "xpu",
+      "container-options": "--group-add 109 --device=/dev/mem --device=/dev/dri",
+      "pytorch-version": "pytorch-nightly",
+      "alias": "xpu",
+      "backend": "triton",
+      "triton-repo": "https://github.com/intel/intel-xpu-backend-for-triton.git",
+      "triton-pin": "8997b14d4d6580c401c842ea4fded92cdf7adaa8"
+    },
+    {
       "runner": "linux.rocm.gpu.ecosystem.gfx950.1",
       "python-version": "3.12",
       "ref-eager": false,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,7 +154,10 @@ jobs:
           git -C triton checkout ${{ matrix.triton-pin }}
           cd triton/
           uv pip install -r python/requirements.txt
-          MAX_JOBS=$(nproc) TRITON_PARALLEL_LINK_JOBS=2 uv pip install .
+          # Disable proton on XPU: proton's NVIDIA sources (CuptiApi.cpp, NvtxApi.cpp)
+          # require CUDA headers that are not present on Intel XPU runners.
+          TRITON_BUILD_PROTON=${{ startsWith(matrix.image, 'intel') && 'OFF' || 'ON' }}
+          MAX_JOBS=$(nproc) TRITON_PARALLEL_LINK_JOBS=2 TRITON_BUILD_PROTON=$TRITON_BUILD_PROTON uv pip install .
           cd /tmp/$USER
           rm -rf triton/
           python -c "import triton; print(f'Triton version: {triton.__version__}')"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,8 +156,10 @@ jobs:
           uv pip install -r python/requirements.txt
           # Disable proton on XPU: proton's NVIDIA sources (CuptiApi.cpp, NvtxApi.cpp)
           # require CUDA headers that are not present on Intel XPU runners.
-          TRITON_BUILD_PROTON=${{ startsWith(matrix.image, 'intel') && 'OFF' || 'ON' }}
-          MAX_JOBS=$(nproc) TRITON_PARALLEL_LINK_JOBS=2 TRITON_BUILD_PROTON=$TRITON_BUILD_PROTON uv pip install .
+          if [ "${{ matrix.alias }}" = "xpu" ]; then
+            export TRITON_BUILD_PROTON=OFF
+          fi
+          MAX_JOBS=$(nproc) TRITON_PARALLEL_LINK_JOBS=2 uv pip install .
           cd /tmp/$USER
           rm -rf triton/
           python -c "import triton; print(f'Triton version: {triton.__version__}')"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,7 +156,7 @@ jobs:
           uv pip install -r python/requirements.txt
           # Disable proton on XPU: proton's NVIDIA sources (CuptiApi.cpp, NvtxApi.cpp)
           # require CUDA headers that are not present on Intel XPU runners.
-          if [ "${{ matrix.alias }}" = "xpu" ]; then
+          if [ "${{ matrix.alias }}" == "xpu" ]; then
             export TRITON_BUILD_PROTON=OFF
           fi
           MAX_JOBS=$(nproc) TRITON_PARALLEL_LINK_JOBS=2 uv pip install .


### PR DESCRIPTION
This is to fix the issue in #2270 
The proton build will be by default disabled for all triton xpu build