### PR TITLE
[Pallas] Fix failing scratch shapes asserts due to land-time race when #2278 caused scratch shapes to be re-ordered

### DIFF
--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1027,8 +1027,8 @@ class TestPallas(TestCase):
         self.assertIn(
             "_scratch_shapes=["
             "((4, 128, 128), 'jnp.float32', 'vmem'), "
-            "((4, 128, 256), 'jnp.float32', 'vmem'), "
-            "((4, 128, 128), 'jnp.float32', 'vmem')]",
+            "((4, 128, 128), 'jnp.float32', 'vmem'), "
+            "((4, 128, 256), 'jnp.float32', 'vmem')]",
             code,
         )
         self.assertIn("jnp.tile(", code)
@@ -1056,8 +1056,8 @@ class TestPallas(TestCase):
         self.assertIn(
             "_scratch_shapes=["
             "((4, 128, 128), 'jnp.float32', 'vmem'), "
-            "((4, 128, 256), 'jnp.float32', 'vmem'), "
             "((4, 128, 128), 'jnp.float32', 'vmem'), "
+            "((4, 128, 256), 'jnp.float32', 'vmem'), "
             "((4, 256, 128), 'jnp.float32', 'vmem'), "
             "((), None, 'dma_semaphore'), "
             "((4, 128, 256), 'jnp.float32', 'vmem'), "


### PR DESCRIPTION

The PRs #2278 and #2223 had a land-time race. #2223 introduced new
scratch shape asserts, while #2278 caused scratch shapes to be
re-ordered. No real breakage, but the asserted shapes needs to be
re-ordered.