### PR TITLE
TPU CI: Restore to using latest nightly pytorch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,10 +123,7 @@ jobs:
             uv pip install -U "torch==${VERSION}.*" --index-url https://download.pytorch.org/whl/${{ matrix.runtime-version }}
           elif [[ "${{ matrix.runtime-version }}" == "tpu" ]]; then
             # TPU: install CPU-only PyTorch nightly (torch_tpu provides TPU backend)
-            # TODO: we should be using nightly pytorch, but currently this is failing when used with our pinned torch_tpu
-            # uv pip install -U --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
-            # so for now, just install the last nightly pytorch which we know works with our pinned torch_tpu
-            uv pip install -U --pre "torch==2.13.0.dev20260502" --index-url https://download.pytorch.org/whl/nightly/cpu
+            uv pip install -U --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
           else
             # Default to nightly
             if [[ "${{ matrix.runtime-version }}" == "cu128" ]]; then


### PR DESCRIPTION
TPU CI: Restore to using latest nightly pytorch

In #2298 we started using a pinned pytorch nightly from 2026 May 2nd in order to unblock TPU CI. But now that in #2316 we are using a new torch_tpu version, we can try to restore to using latest nightly pytorch