### PR TITLE
[DO NOT MERGE] [Pallas] Manual full-coverage TPU benchmark trigger

### DIFF
--- a/.github/workflows/benchmark_tpu_full.yml
+++ b/.github/workflows/benchmark_tpu_full.yml
@@ -36,6 +36,6 @@ jobs:
                 run_b200: 'false',
                 run_mi350x: 'false',
                 run_tpu: 'true',
-                kernels_tpu: 'exp,add,softmax_two_pass,welford,attention,bmm,matmul,matmul_layernorm,cross_entropy,embedding,broadcast_matmul,geglu,low_mem_dropout,swiglu,batch_softmax,sum,rms_norm,layer_norm,softmax,long_sum_naive,long_sum_loop,long_sum_manual,se_block,squeeze_and_excitation_net,rms_norm_bwd',
+                kernels_tpu: 'exp,add,softmax_two_pass,welford,flash_attention,bmm,gemm,matmul_layernorm,cross_entropy,embedding,broadcast_matmul,geglu,low_mem_dropout,swiglu,batch_softmax,sum,rms_norm,layer_norm,softmax,long_sum_naive,long_sum_loop,long_sum_manual,se_block,squeeze_and_excitation_net,rms_norm-bwd',
               },
             })

--- a/.github/workflows/benchmark_tpu_full.yml
+++ b/.github/workflows/benchmark_tpu_full.yml
@@ -36,6 +36,6 @@ jobs:
                 run_b200: 'false',
                 run_mi350x: 'false',
                 run_tpu: 'true',
-                kernels_tpu: 'exp,add,softmax_two_pass,welford,flash_attention,bmm,gemm,matmul_layernorm,cross_entropy,embedding,broadcast_matmul,geglu,low_mem_dropout,swiglu,batch_softmax,sum,rms_norm,layer_norm,softmax,long_sum_naive,long_sum_loop,long_sum_manual,se_block,squeeze_and_excitation_net,rms_norm-bwd',
+                kernels_tpu: 'exp,add,softmax_two_pass,welford,flash_attention,bmm,gemm,matmul_layernorm,cross_entropy,embedding,broadcast_matmul,geglu,low_mem_dropout,swiglu,batch_softmax,sum,rms_norm,layer_norm,softmax,long_sum_naive,long_sum_loop,long_sum_manual,se_block,squeeze_and_excitation_net,rms_norm-bwd,fused_linear_jsd,grpo_loss',
               },
             })

--- a/.github/workflows/benchmark_tpu_full.yml
+++ b/.github/workflows/benchmark_tpu_full.yml
@@ -1,0 +1,41 @@
+name: Benchmark TPU (Full Pallas Coverage)
+
+# Manual-only trigger that fans Benchmark Dispatch out across every TPU
+# example currently registered in benchmarks/run_tpu.py. Useful for
+# end-to-end Pallas-backend smoke testing; NOT part of the nightly
+# dashboard signal (which intentionally tracks a slimmer kernel set).
+#
+# Usage:
+#   gh workflow run benchmark_tpu_full.yml -R pytorch/helion -r yifeixu/tpu-bench-full
+#
+# Or trigger from the Actions UI: select this workflow, pick the
+# yifeixu/tpu-bench-full branch, click "Run workflow".
+
+on:
+  workflow_dispatch:
+
+jobs:
+  dispatch-benchmark:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Dispatch benchmark_dispatch workflow (TPU, full kernel list)
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'benchmark_dispatch.yml',
+              ref: context.ref.replace('refs/heads/', ''),
+              inputs: {
+                run_h100: 'false',
+                run_b200: 'false',
+                run_mi350x: 'false',
+                run_tpu: 'true',
+                kernels_tpu: 'exp,add,softmax_two_pass,welford,attention,bmm,matmul,matmul_layernorm,cross_entropy,embedding,broadcast_matmul,geglu,low_mem_dropout,swiglu,batch_softmax,sum,rms_norm,layer_norm,softmax,long_sum_naive,long_sum_loop,long_sum_manual,se_block,squeeze_and_excitation_net,rms_norm_bwd',
+              },
+            })


### PR DESCRIPTION
## Summary

**Not for merge.** Permanent feature branch carrying `.github/workflows/benchmark_tpu_full.yml` — a manual-only `workflow_dispatch` workflow that fires `Benchmark Dispatch` with `run_tpu=true` and **every kernel** registered in `benchmarks/run_tpu.py`'s `KERNEL_MAPPINGS`.

The dashboard nightly tracks a slim 9-kernel subset: `flash_attention,bmm,gemm,welford,softmax,layer_norm,rms_norm,rms_norm-bwd,cross_entropy`. This branch is the opt-in escape hatch for full Pallas-backend coverage when verifying a backend change end-to-end across every example.

## How to trigger

Rebase the branch on whatever main commit you want to benchmark, then:

```bash
gh workflow run benchmark_tpu_full.yml \
  -R pytorch/helion \
  -r yifeixu/tpu-bench-full
```

Or via the Actions UI: select **Benchmark TPU (Full Pallas Coverage)**, pick `yifeixu/tpu-bench-full` as the ref, click "Run workflow". The wrapper hardcodes the kernel list (`benchmark_tpu_full.yml`), then dispatches `Benchmark Dispatch` with only the `run-tpu` job populated (GPU jobs `if`-gated off).

## Why a separate branch (and not landed)

- Keeps the public nightly dashboard signal focused (cross-platform comparable kernels + flagship TPU workloads only).
- Doesn't bloat `benchmark_dispatch.yml` with a `kernels_tpu_preset` choice input.
- Living off-main avoids spending CI minutes on a workflow only used ad-hoc.
