### PR TITLE
[Pallas] Use jax_export_ignore_forward_compatibility=True when exporting JaxCallable, improving attention perf

### DIFF
--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -657,7 +657,7 @@ def _pallas_build_callable(
     for out_idx, orig_pos in enumerate(_output_indices):
         if orig_pos in arg_to_tensor_pos:
             call_aliases[arg_to_tensor_pos[orig_pos]] = out_idx
-
+    jax.config.update("jax_export_ignore_forward_compatibility", True)
     jax_callable = JaxCallable(
         name=kernel_name,
         jit_fn=jax.jit(jit_fn),


### PR DESCRIPTION

The Helion Pallas launcher uses `jax.export.export()` to serialize the
Pallas kernel into a StableHLO module that `torch_tpu` can execute.
However, `jax.export` forces `forward_compatible=True` in the Mosaic
lowering context. This triggers conservative lowering rules that
decompose efficient ops into less efficient equivalents.

The primary offender is `exp2`. In the Pallas Mosaic lowering:

    @register_lowering_rule(lax.exp2_p, ensure_mlir_values=False)
    def _exp2_lowering_rule(ctx, x, accuracy):
        if ctx.forward_compatible or ctx.is_cloud_tpu_older_than(2025, 7, 26):
            return lower_fun(
                lambda x: jnp.exp(jnp.astype(np.log(2), x.dtype) * x), ...)
        return mlir_math.exp2(x)

With forward_compatible=True, `jnp.exp2(x)` lowers to `exp(ln2 * x)`
instead of the native `math.exp2` MLIR op. The TPU XLA compiler then
decomposes `exp(y)` into `pow2(y / ln2)`, producing:

    vmul.f32 %input, 0.6931472    ; x * ln(2) — from Mosaic lowering
    vmul.f32 %result, 1.442695    ; y * 1/ln(2) — from XLA exp decomposition
    vpow.pop %final              ; 2^z

Instead of the optimal single instruction:

    vpow.pop %input              ; 2^x directly

For a FlashAttention kernel (B=8, H=32, S=8192, D=256), which calls
exp2 for both the softmax numerator and the online-softmax rescaling,
this results in 9,216 extra vmul.f32 instructions per pipeline iteration
(4,608 × ln2 + 4,608 × 1/ln2), totalling ~4.7M wasted dynamic bundles
across the full grid.

LLO profile comparison (same kernel, same shapes):

    Path            Static bundles  Dynamic bundles  MXU slot fill
    ─────────────   ──────────────  ───────────────  ─────────────
    torch_tpu/helion     16,594       8,515,465         47.4%
    pure JAX pallas      14,373       7,373,871         54.1%

After this fix (both paths produce identical LLO):

    torch_tpu/helion     14,373       7,373,871         54.1%

Wall-clock improvement: 536 → 604 TFLOPS (+13%) for the attention kernel at (https://gist.github.com/AmesingFlank/6afdfba6f6384c7b55ce6d24e846d248)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>