### PR TITLE
[Pallas] Make pallas_pre_broadcast a tunable autotune fragment

### DIFF
--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -1344,6 +1344,8 @@ class ConfigSpec:
                 # is set, to avoid wasted autotuning effort. See PR #1969 review discussion.
                 choices = ("fori_loop", "emit_pipeline")
             fields["pallas_loop_type"] = EnumFragment(choices=choices)
+            if self.supports_config_key("pallas_pre_broadcast"):
+                fields["pallas_pre_broadcast"] = BooleanFragment()
         # Only include maxnreg on CUDA devices (not supported on AMD and Intel GPU)
         if self.supports_config_key("maxnreg") and supports_maxnreg():
             fields["maxnreg"] = EnumFragment(VALID_MAXNREG)


### PR DESCRIPTION
## Summary

`pallas_pre_broadcast` (introduced in #2103) is listed in `VALID_KEYS` and `BACKEND_TUNABLE_KEYS`, and the Pallas backend opts in via `_PALLAS_SUPPORTED_KEYS` — so it's a respected config option when set manually. But `ConfigSpec._flat_fields()` never registers a fragment for it, so it doesn't appear in the autotuner's search space. The autotuner can't toggle it on/off during search; it only takes effect when manually pinned in `helion.Config(...)`.

This PR adds a `BooleanFragment` registration next to the existing `pallas_loop_type` block so the search includes both `False` / `True` for kernels with Pallas inner loops.

## Why this matters

The transform's win is shape- and config-dependent — it helps the broadcast-against-3D-accumulator pattern in attention by pre-tiling the trailing dim. The optimal `pallas_pre_broadcast` value depends on the chosen block sizes and loop type. Leaving it out of search means the autotuner systematically misses configs that need this knob to be the optimum.

Verified the fragment shows up at autotune-bind time on `examples/attention.py`:

```text
Total tunable fields: 5
  block_sizes: BlockIdSequence
  flatten_loops: BlockIdSequence
  loop_orders: BlockIdSequence
  pallas_loop_type: EnumFragment
  pallas_pre_broadcast: BooleanFragment
```
