### PR TITLE
Enable tensor_descriptor for static_shapes = False

### DIFF
--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -48,6 +48,14 @@ log = logging.getLogger(__name__)
 TensorDescriptorLayoutSignature = tuple[int | None, tuple[bool, ...]]
 
 
+@dataclasses.dataclass
+class TensorDescriptorLayoutGuard:
+    ndim: int
+    element_size: int
+    memory_op_indices: set[int] = dataclasses.field(default_factory=set)
+    atomic_op_indices: set[int] = dataclasses.field(default_factory=set)
+
+
 def tensor_descriptor_layout_signature_from_strides(
     strides: typing.Sequence[int | torch.SymInt | sympy.Integer],
     element_size: int,
@@ -201,7 +209,9 @@ class CompileEnvironment:
         self.kernel_min_element_bits: int = 32  # smallest dtype bits across all tensors
         self.specialized_vars: set[sympy.Symbol] = set()
         self.specialized_strides: set[tuple[str, int]] = set()
-        self.tensor_descriptor_layout_guards: dict[str, tuple[int, int]] = {}
+        self.tensor_descriptor_layout_guards: dict[
+            str, TensorDescriptorLayoutGuard
+        ] = {}
         self.jagged_tile_parent_ids: dict[int, list[int]] = {}
         self.jagged_tile_mask_shapes: dict[int, list[torch.SymInt]] = {}
         self._symint_cache: dict[object, torch.SymInt] = {}
@@ -251,7 +261,11 @@ class CompileEnvironment:
         return expr
 
     def register_tensor_descriptor_layout_guard(
-        self, fake_tensor: torch.Tensor
+        self,
+        fake_tensor: torch.Tensor,
+        *,
+        memory_op_index: int | None = None,
+        atomic_op_index: int | None = None,
     ) -> None:
         """Specialize dynamic kernels on TD-relevant stride layout predicates."""
         if self.settings.static_shapes:
@@ -259,10 +273,17 @@ class CompileEnvironment:
         source = self.input_sources.get(fake_tensor)
         if not isinstance(source, LocalSource):
             return
-        self.tensor_descriptor_layout_guards[source.local_name] = (
-            fake_tensor.ndim,
-            fake_tensor.element_size(),
+        guard = self.tensor_descriptor_layout_guards.setdefault(
+            source.local_name,
+            TensorDescriptorLayoutGuard(
+                ndim=fake_tensor.ndim,
+                element_size=fake_tensor.element_size(),
+            ),
         )
+        if memory_op_index is not None:
+            guard.memory_op_indices.add(memory_op_index)
+        if atomic_op_index is not None:
+            guard.atomic_op_indices.add(atomic_op_index)
 
     def has_tensor_descriptor_layout_guard(self, fake_tensor: torch.Tensor) -> bool:
         if self.settings.static_shapes:

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -45,6 +45,44 @@ from .variable_origin import TensorSizeOrigin
 
 log = logging.getLogger(__name__)
 
+TensorDescriptorLayoutSignature = tuple[int | None, tuple[bool, ...]]
+
+
+def _default_tensor_descriptor_size_hint(n: int | torch.SymInt) -> int:
+    return int(n)
+
+
+def tensor_descriptor_layout_signature_from_strides(
+    strides: typing.Sequence[int | torch.SymInt | sympy.Integer],
+    element_size: int,
+    size_hint: typing.Callable[
+        [int | torch.SymInt], int
+    ] = _default_tensor_descriptor_size_hint,
+) -> TensorDescriptorLayoutSignature:
+    """Return the stride layout facts tensor descriptors depend on.
+
+    The signature intentionally records predicates rather than exact strides so
+    dynamic-shape kernels can share code across sizes that have the same tensor
+    descriptor eligibility.
+    """
+    stride_one_dim: int | None = None
+    has_multiple_stride_one_dims = False
+    aligned_dims = []
+    for dim, raw_stride in enumerate(strides):
+        if isinstance(raw_stride, sympy.Integer):
+            stride = int(raw_stride)
+        else:
+            stride = size_hint(raw_stride)
+        if stride == 1:
+            if stride_one_dim is None:
+                stride_one_dim = dim
+            else:
+                has_multiple_stride_one_dims = True
+        aligned_dims.append((stride * element_size) % 16 == 0)
+    if has_multiple_stride_one_dims:
+        stride_one_dim = None
+    return stride_one_dim, tuple(aligned_dims)
+
 
 def _make_numel_check(
     symbols: list[sympy.Basic], expr: sympy.Basic
@@ -163,6 +201,7 @@ class CompileEnvironment:
         self.kernel_min_element_bits: int = 32  # smallest dtype bits across all tensors
         self.specialized_vars: set[sympy.Symbol] = set()
         self.specialized_strides: set[tuple[str, int]] = set()
+        self.tensor_descriptor_layout_guards: dict[str, tuple[int, int]] = {}
         self.jagged_tile_parent_ids: dict[int, list[int]] = {}
         self.jagged_tile_mask_shapes: dict[int, list[torch.SymInt]] = {}
         self._symint_cache: dict[object, torch.SymInt] = {}
@@ -210,6 +249,51 @@ class CompileEnvironment:
             # pyrefly: ignore [bad-assignment]
             expr = expr.xreplace(subs)
         return expr
+
+    def register_tensor_descriptor_layout_guard(
+        self, fake_tensor: torch.Tensor
+    ) -> None:
+        """Specialize dynamic kernels on TD-relevant stride layout predicates."""
+        if self.settings.static_shapes:
+            return
+        source = self.input_sources.get(fake_tensor)
+        if not isinstance(source, LocalSource):
+            return
+        self.tensor_descriptor_layout_guards[source.local_name] = (
+            fake_tensor.ndim,
+            fake_tensor.element_size(),
+        )
+
+    def has_tensor_descriptor_layout_guard(self, fake_tensor: torch.Tensor) -> bool:
+        if self.settings.static_shapes:
+            return True
+        source = self.input_sources.get(fake_tensor)
+        return (
+            isinstance(source, LocalSource)
+            and source.local_name in self.tensor_descriptor_layout_guards
+        )
+
+    def tensor_descriptor_layout_signature(
+        self, fake_tensor: torch.Tensor
+    ) -> TensorDescriptorLayoutSignature | None:
+        has_symbolic_stride = False
+        for stride in fake_tensor.stride():
+            if isinstance(stride, int):
+                continue
+            expr = _to_sympy(stride)
+            expr = self.specialize_expr(self.shape_env.replace(expr))
+            if expr.free_symbols:
+                has_symbolic_stride = True
+                break
+        if has_symbolic_stride and not self.has_tensor_descriptor_layout_guard(
+            fake_tensor
+        ):
+            return None
+        return tensor_descriptor_layout_signature_from_strides(
+            fake_tensor.stride(),
+            fake_tensor.element_size(),
+            self.size_hint,
+        )
 
     def add_kernel_tensor_size(
         self,

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -48,16 +48,10 @@ log = logging.getLogger(__name__)
 TensorDescriptorLayoutSignature = tuple[int | None, tuple[bool, ...]]
 
 
-def _default_tensor_descriptor_size_hint(n: int | torch.SymInt) -> int:
-    return int(n)
-
-
 def tensor_descriptor_layout_signature_from_strides(
     strides: typing.Sequence[int | torch.SymInt | sympy.Integer],
     element_size: int,
-    size_hint: typing.Callable[
-        [int | torch.SymInt], int
-    ] = _default_tensor_descriptor_size_hint,
+    size_hint: typing.Callable[[int | torch.SymInt], int] | None = None,
 ) -> TensorDescriptorLayoutSignature:
     """Return the stride layout facts tensor descriptors depend on.
 
@@ -71,7 +65,13 @@ def tensor_descriptor_layout_signature_from_strides(
     for dim, raw_stride in enumerate(strides):
         if isinstance(raw_stride, sympy.Integer):
             stride = int(raw_stride)
+        elif isinstance(raw_stride, int):
+            stride = raw_stride
         else:
+            if size_hint is None:
+                raise TypeError(
+                    "symbolic tensor descriptor strides require an explicit size_hint"
+                )
             stride = size_hint(raw_stride)
         if stride == 1:
             if stride_one_dim is None:

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -1900,6 +1900,39 @@ def _register_atomic_tunables(atomic_count: int) -> None:
     )
 
 
+def _register_tensor_descriptor_layout_guards(device_ir: DeviceIR) -> None:
+    env = CompileEnvironment.current()
+    if env.settings.static_shapes:
+        return
+
+    from .._compat import supports_tensor_descriptor
+    from ..language import atomic_ops
+    from ..language import memory_ops
+
+    if not supports_tensor_descriptor():
+        return
+
+    atomic_targets = tuple(getattr(atomic_ops, name) for name in atomic_ops.__all__)
+
+    def tensor_arg_value(arg: object) -> object:
+        if isinstance(arg, torch.fx.Node):
+            return arg.meta.get("val")
+        return arg
+
+    for graph_info in device_ir.graphs:
+        for node in graph_info.graph.nodes:
+            if node.op != "call_function":
+                continue
+            if not (
+                node.target in (memory_ops.load, memory_ops.store)
+                or node.target in atomic_targets
+            ):
+                continue
+            tensor = tensor_arg_value(node.args[0])
+            if isinstance(tensor, torch.Tensor) and 2 <= tensor.ndim <= 5:
+                env.register_tensor_descriptor_layout_guard(tensor)
+
+
 def lower_to_device_ir(func: HostFunction) -> DeviceIR:
     device_ir = DeviceIR()
     with func, device_ir, compile_lock:
@@ -1992,6 +2025,7 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
             store_indices,
         )
         _register_atomic_tunables(_count_device_atomics(device_ir))
+        _register_tensor_descriptor_layout_guards(device_ir)
 
         return device_ir
 

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -1919,18 +1919,27 @@ def _register_tensor_descriptor_layout_guards(device_ir: DeviceIR) -> None:
             return arg.meta.get("val")
         return arg
 
+    memory_op_index = 0
+    atomic_op_index = 0
     for graph_info in device_ir.graphs:
         for node in graph_info.graph.nodes:
             if node.op != "call_function":
                 continue
-            if not (
-                node.target in (memory_ops.load, memory_ops.store)
-                or node.target in atomic_targets
-            ):
+            if node.target in (memory_ops.load, memory_ops.store):
+                tensor = tensor_arg_value(node.args[0])
+                if isinstance(tensor, torch.Tensor) and 2 <= tensor.ndim <= 5:
+                    env.register_tensor_descriptor_layout_guard(
+                        tensor, memory_op_index=memory_op_index
+                    )
+                memory_op_index += 1
                 continue
-            tensor = tensor_arg_value(node.args[0])
-            if isinstance(tensor, torch.Tensor) and 2 <= tensor.ndim <= 5:
-                env.register_tensor_descriptor_layout_guard(tensor)
+            if node.target in atomic_targets:
+                tensor = tensor_arg_value(node.args[0])
+                if isinstance(tensor, torch.Tensor) and 2 <= tensor.ndim <= 5:
+                    env.register_tensor_descriptor_layout_guard(
+                        tensor, atomic_op_index=atomic_op_index
+                    )
+                atomic_op_index += 1
 
 
 def lower_to_device_ir(func: HostFunction) -> DeviceIR:

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -463,38 +463,17 @@ class TensorDescriptorIndexingStrategy(IndexingStrategy):
         # descriptor so this dimension is last, but support checks are easier
         # to express in the original tensor dimension order.
         env = CompileEnvironment.current()
-        stride_one_dim = None
         element_size = fake_tensor.element_size()
-        for dim in range(fake_tensor.ndim):
-            raw_stride = fake_tensor.stride(dim)
-            if isinstance(raw_stride, (int, sympy.Integer)):
-                stride = raw_stride
-            else:
-                # Symbolic stride: size_hint gives the value from one concrete
-                # shape, but other shapes sharing this BoundKernel may have
-                # different alignment.  Only trust it for the stride==1 check;
-                # reject for the 16-byte alignment check since we cannot prove
-                # it holds for all shapes in the specialization bucket.
-                hint = env.size_hint(raw_stride)
-                if hint == 1:
-                    if stride_one_dim is not None:
-                        return False
-                    stride_one_dim = dim
-                    continue
-                return False
-            if stride == 1:
-                if stride_one_dim is not None:
-                    return False
-                stride_one_dim = dim
-            else:
-                # 3) All other dimensions should have 16-byte aligned strides
-                # so the descriptor remains valid for the whole tensor layout.
-                byte_stride = stride * element_size
-                if byte_stride % 16 != 0:
-                    return False
+        layout_signature = env.tensor_descriptor_layout_signature(fake_tensor)
+        if layout_signature is None:
+            return False
+        stride_one_dim, stride_aligned_dims = layout_signature
         if stride_one_dim is None:
             # There should be exactly one dimension with stride==1
             return False
+        for dim, is_aligned in enumerate(stride_aligned_dims):
+            if dim != stride_one_dim and not is_aligned:
+                return False
 
         def valid_block_size(
             block_size: int | torch.SymInt | None, stride: int | torch.SymInt, idx: int

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -890,7 +890,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             ) -> Hashable:
                 tensor = cast("torch.Tensor", args[_index])
                 if tensor.ndim != _ndim:
-                    return tensor.ndim
+                    return ("ndim", tensor.ndim)
                 return tensor_descriptor_layout_signature_from_strides(
                     tensor.stride(),
                     _element_size,

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -41,6 +41,9 @@ from .._compile_time import measure
 from .._compiler.ast_extension import unparse
 from .._compiler.backend import TritonBackend
 from .._compiler.compile_environment import CompileEnvironment
+from .._compiler.compile_environment import (
+    tensor_descriptor_layout_signature_from_strides,
+)
 from .._compiler.generate_ast import generate_ast
 from .._compiler.host_function import HostFunction
 from .._compiler.inductor_lowering_extra import patch_inductor_lowerings
@@ -818,7 +821,10 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         Returns:
             list[Callable[[Sequence[object]], Hashable]]: A list of functions that generate extra specialization keys.
         """
-        if not self.env.specialized_vars:
+        if (
+            not self.env.specialized_vars
+            and not self.env.tensor_descriptor_layout_guards
+        ):
             return []
 
         def make_extractor(v: Source) -> Callable[[Sequence[object]], Hashable]:
@@ -867,10 +873,30 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         arg_name_to_index: dict[str, int] = {
             n: i for i, n in enumerate(self.kernel.signature.parameters.keys())
         }
-        extractors = []
+        extractors: list[Callable[[Sequence[object]], Hashable]] = []
         for v in sorted(self.env.specialized_vars, key=lambda v: v.name):
             source = self.env.shape_env.var_to_sources[v][0]
             extractors.append(make_extractor(source))
+        for local_name, (ndim, element_size) in sorted(
+            self.env.tensor_descriptor_layout_guards.items()
+        ):
+            index = arg_name_to_index[local_name]
+
+            def td_layout_extractor(
+                args: Sequence[object],
+                _index: int = index,
+                _ndim: int = ndim,
+                _element_size: int = element_size,
+            ) -> Hashable:
+                tensor = cast("torch.Tensor", args[_index])
+                if tensor.ndim != _ndim:
+                    return tensor.ndim
+                return tensor_descriptor_layout_signature_from_strides(
+                    tensor.stride(),
+                    _element_size,
+                )
+
+            extractors.append(td_layout_extractor)
         return extractors
 
     def _user_provided_config(self) -> Config | None:

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -41,6 +41,7 @@ from .._compile_time import measure
 from .._compiler.ast_extension import unparse
 from .._compiler.backend import TritonBackend
 from .._compiler.compile_environment import CompileEnvironment
+from .._compiler.compile_environment import TensorDescriptorLayoutGuard
 from .._compiler.compile_environment import (
     tensor_descriptor_layout_signature_from_strides,
 )
@@ -73,6 +74,28 @@ if TYPE_CHECKING:
     ConfigLike = Config | dict[str, object]
 
 log: logging.Logger = logging.getLogger(__name__)
+
+
+def _indexing_config_uses_tensor_descriptor(indexing: object, index: int) -> bool:
+    if indexing == "tensor_descriptor":
+        return True
+    if isinstance(indexing, list):
+        return index < len(indexing) and indexing[index] == "tensor_descriptor"
+    return False
+
+
+def _td_layout_guard_active_for_config(
+    guard: TensorDescriptorLayoutGuard, config: Config
+) -> bool:
+    return any(
+        _indexing_config_uses_tensor_descriptor(config.indexing, index)
+        for index in guard.memory_op_indices
+    ) or any(
+        _indexing_config_uses_tensor_descriptor(config.atomic_indexing, index)
+        for index in guard.atomic_op_indices
+    )
+
+
 _R = TypeVar("_R")
 CompiledConfig = Callable[..., _R]
 
@@ -877,16 +900,21 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         for v in sorted(self.env.specialized_vars, key=lambda v: v.name):
             source = self.env.shape_env.var_to_sources[v][0]
             extractors.append(make_extractor(source))
-        for local_name, (ndim, element_size) in sorted(
+        implicit_config = self._fixed_config_for_td_layout_guards()
+        for local_name, guard in sorted(
             self.env.tensor_descriptor_layout_guards.items()
         ):
+            if implicit_config is not None and not _td_layout_guard_active_for_config(
+                guard, implicit_config
+            ):
+                continue
             index = arg_name_to_index[local_name]
 
             def td_layout_extractor(
                 args: Sequence[object],
                 _index: int = index,
-                _ndim: int = ndim,
-                _element_size: int = element_size,
+                _ndim: int = guard.ndim,
+                _element_size: int = guard.element_size,
             ) -> Hashable:
                 tensor = cast("torch.Tensor", args[_index])
                 if tensor.ndim != _ndim:
@@ -898,6 +926,20 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
 
             extractors.append(td_layout_extractor)
         return extractors
+
+    def _fixed_config_for_td_layout_guards(self) -> Config | None:
+        """Return the fixed config if TD layout guards can be filtered safely."""
+        if self._config is not None:
+            return self._config
+        if self.kernel.settings.autotune_effort == "none" and (
+            len(self.kernel.configs) == 0 or self.settings.force_autotune
+        ):
+            return self.config_spec.default_config()
+        if self.settings.force_autotune:
+            return None
+        if len(self.kernel.configs) == 1:
+            return self.kernel.configs[0]
+        return None
 
     def _user_provided_config(self) -> Config | None:
         """Return a config if the user explicitly provided one, else None.

--- a/test/test_atomic_ops.py
+++ b/test/test_atomic_ops.py
@@ -14,6 +14,7 @@ from helion._testing import onlyBackends
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfRocm
 from helion._testing import skipIfTileIR
+from helion._testing import skipUnlessTensorDescriptor
 from helion._testing import xfailIfPallas
 import helion.language as hl
 from helion.runtime.settings import _get_backend
@@ -687,6 +688,7 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
     @onlyBackends("triton")
     @skipIfRocm("Tensor descriptor not supported on ROCm")
     @skipIfTileIR("TileIR does not support descriptor atomics")
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_atomic_add_per_op_indexing(self):
         """Test per-op atomic_indexing list: first op pointer, second op tensor_descriptor."""
 
@@ -725,6 +727,7 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
     @onlyBackends("triton")
     @skipIfRocm("Tensor descriptor not supported on ROCm")
     @skipIfTileIR("TileIR does not support descriptor atomics")
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_atomic_ops_tensor_descriptor(self):
         """Test all TMA-supported atomic ops generate desc.atomic_{op} codegen."""
         M, N = 128, 64
@@ -801,6 +804,7 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
     @onlyBackends("triton")
     @skipIfRocm("Tensor descriptor not supported on ROCm")
     @skipIfTileIR("TileIR does not support descriptor atomics")
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_dynamic_atomic_add_tensor_descriptor(self):
         """Dynamic shape atomics should register TD layout guards."""
 
@@ -827,6 +831,7 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
     @onlyBackends("triton")
     @skipIfRocm("Tensor descriptor not supported on ROCm")
     @skipIfTileIR("TileIR does not support descriptor atomics")
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_atomic_td_scalar_symint(self):
         """Composite scalar SymInts should not prevent descriptor atomics."""
 

--- a/test/test_atomic_ops.py
+++ b/test/test_atomic_ops.py
@@ -801,6 +801,32 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
     @onlyBackends("triton")
     @skipIfRocm("Tensor descriptor not supported on ROCm")
     @skipIfTileIR("TileIR does not support descriptor atomics")
+    def test_dynamic_atomic_add_tensor_descriptor(self):
+        """Dynamic shape atomics should register TD layout guards."""
+
+        @helion.kernel(
+            config=helion.Config(
+                block_sizes=[64, 64],
+                indexing="tensor_descriptor",
+                atomic_indexing="tensor_descriptor",
+            ),
+            static_shapes=False,
+        )
+        def atomic_add_dynamic_td(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            for i, j in hl.tile([x.size(0), x.size(1)]):
+                hl.atomic_add(x, [i, j], y[i, j])
+            return x
+
+        x = torch.zeros(128, 64, device=DEVICE, dtype=torch.float32)
+        y = torch.ones(128, 64, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(atomic_add_dynamic_td, (x, y))
+        torch.testing.assert_close(result, torch.ones_like(x))
+        self.assertIn("x_desc.atomic_add(", code)
+        self.assertNotIn("tl.atomic_add(", code)
+
+    @onlyBackends("triton")
+    @skipIfRocm("Tensor descriptor not supported on ROCm")
+    @skipIfTileIR("TileIR does not support descriptor atomics")
     def test_atomic_td_scalar_symint(self):
         """Composite scalar SymInts should not prevent descriptor atomics."""
 

--- a/test/test_tensor_descriptor.py
+++ b/test/test_tensor_descriptor.py
@@ -921,7 +921,9 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
         self.assertNotIn(f"{name}_desc = {get_tensor_descriptor_fn_name()}", code)
 
     @skipUnlessTensorDescriptor("Tensor descriptor support is required")
-    @skipIfXPU("XPU tensor descriptor path has accuracy issue for scalar SymInt subscripts")
+    @skipIfXPU(
+        "XPU tensor descriptor path has accuracy issue for scalar SymInt subscripts"
+    )
     def test_scalar_symint_subscript_allowlist(self):
         """Known scalar SymInt expressions should still use tensor descriptors."""
 

--- a/test/test_tensor_descriptor.py
+++ b/test/test_tensor_descriptor.py
@@ -671,6 +671,13 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
                 False,
                 True,
             ),
+            (
+                "y_unaligned",
+                torch.randn([32, 64], device=DEVICE, dtype=HALF_DTYPE),
+                torch.randn([64, 31], device=DEVICE, dtype=HALF_DTYPE),
+                True,
+                False,
+            ),
         ]
 
         for static_shapes in (True, False):
@@ -693,6 +700,31 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
                     else:
                         self.assert_tensor_descriptor_not_used_for(code, "y")
                     self.assertIn("tl.dot", code)
+
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
+    def test_dynamic_shape_stride_zero_input(self):
+        """Expanded stride-0 dimensions should be TD-eligible with dynamic shapes."""
+
+        @helion.kernel(
+            static_shapes=False,
+            autotune_effort="none",
+            config=helion.Config(
+                block_sizes=[16, 16],
+                indexing=["tensor_descriptor", "pointer"],
+            ),
+        )
+        def copy_expanded(x: torch.Tensor) -> torch.Tensor:
+            result = torch.empty(x.size(), device=x.device, dtype=x.dtype)
+            for tile in hl.tile(x.size()):
+                result[tile] = x[tile]
+            return result
+
+        x = torch.randn([1, 64], device=DEVICE, dtype=HALF_DTYPE).expand(32, 64)
+        self.assertEqual(x.stride(), (0, 1))
+
+        code, result = code_and_output(copy_expanded, (x,))
+        torch.testing.assert_close(result, x)
+        self.assert_tensor_descriptor_used_for(code, "x")
 
     def assert_uses_tensor_descriptors(self, code: str) -> None:
         self.assertIn(get_tensor_descriptor_fn_name(), code)

--- a/test/test_tensor_descriptor.py
+++ b/test/test_tensor_descriptor.py
@@ -513,13 +513,82 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
 
         # D=1024 bf16: stride(0)=1024, byte_stride=2048, 16-byte aligned
         x_aligned = torch.randn(64, 1024, device=DEVICE, dtype=torch.bfloat16)
-        result_aligned = add_one(x_aligned)
+        code_aligned, result_aligned = code_and_output(add_one, (x_aligned,))
         torch.testing.assert_close(result_aligned, x_aligned + 1.0)
+        self.assertIn(f"x_desc = {get_tensor_descriptor_fn_name()}", code_aligned)
 
         # D=2047 bf16: stride(0)=2047, byte_stride=4094, NOT 16-byte aligned
         x_unaligned = torch.randn(64, 2047, device=DEVICE, dtype=torch.bfloat16)
-        result_unaligned = add_one(x_unaligned)
+        code_unaligned, result_unaligned = code_and_output(add_one, (x_unaligned,))
         torch.testing.assert_close(result_unaligned, x_unaligned + 1.0)
+        self.assertNotIn(f"x_desc = {get_tensor_descriptor_fn_name()}", code_unaligned)
+
+        @helion.kernel(
+            static_shapes=False,
+            autotune_effort="none",
+            config=helion.Config(
+                block_sizes=[32, 32],
+                indexing="tensor_descriptor",
+            ),
+        )
+        def add_one_reverse_order(x: torch.Tensor) -> torch.Tensor:
+            result = torch.zeros_like(x)
+            for tile in hl.tile(x.size()):
+                result[tile] = x[tile] + 1.0
+            return result
+
+        code_unaligned_first, result_unaligned_first = code_and_output(
+            add_one_reverse_order, (x_unaligned,)
+        )
+        torch.testing.assert_close(result_unaligned_first, x_unaligned + 1.0)
+        self.assertNotIn(
+            f"x_desc = {get_tensor_descriptor_fn_name()}", code_unaligned_first
+        )
+
+        code_aligned_second, result_aligned_second = code_and_output(
+            add_one_reverse_order, (x_aligned,)
+        )
+        torch.testing.assert_close(result_aligned_second, x_aligned + 1.0)
+        self.assertIn(
+            f"x_desc = {get_tensor_descriptor_fn_name()}", code_aligned_second
+        )
+
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
+    def test_dynamic_shape_stride_one_dim_guard(self):
+        """Changing stride-one dim within a shape bucket should recompile TD code."""
+
+        @helion.kernel(
+            static_shapes=False,
+            autotune_effort="none",
+            config=helion.Config(
+                block_sizes=[8, 8],
+                indexing=["tensor_descriptor", "pointer"],
+            ),
+        )
+        def copy_input(x: torch.Tensor) -> torch.Tensor:
+            result = torch.empty_like(x)
+            for tile in hl.tile(x.size()):
+                result[tile] = x[tile]
+            return result
+
+        x_contiguous = torch.randn([16, 8], device=DEVICE, dtype=torch.float32)
+        x_transposed = torch.randn([8, 16], device=DEVICE, dtype=torch.float32).t()
+        self.assertEqual(x_contiguous.stride(), (8, 1))
+        self.assertEqual(x_transposed.stride(), (1, 16))
+
+        code_contiguous, result_contiguous = code_and_output(
+            copy_input, (x_contiguous,)
+        )
+        torch.testing.assert_close(result_contiguous, x_contiguous)
+        self.assertIn(f"x_desc = {get_tensor_descriptor_fn_name()}", code_contiguous)
+        self.assertNotIn("tl.permute", code_contiguous)
+
+        code_transposed, result_transposed = code_and_output(
+            copy_input, (x_transposed,)
+        )
+        torch.testing.assert_close(result_transposed, x_transposed)
+        self.assertIn(f"x_desc = {get_tensor_descriptor_fn_name()}", code_transposed)
+        self.assertIn("tl.permute", code_transposed)
 
     def assert_uses_tensor_descriptors(self, code: str) -> None:
         self.assertIn(get_tensor_descriptor_fn_name(), code)

--- a/test/test_tensor_descriptor.py
+++ b/test/test_tensor_descriptor.py
@@ -631,8 +631,9 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
                 True,
             ),
         ]
+        static_shape_modes = (True, False)
 
-        for static_shapes in (True, False):
+        for static_shapes in static_shape_modes:
             matmul = self._make_td_matmul(static_shapes)
             for name, x, expect_permute in cases:
                 with self.subTest(static_shapes=static_shapes, layout=name):
@@ -643,8 +644,8 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
                         atol=1e-1,
                         rtol=1e-2,
                     )
-                    self.assertIn(f"x_desc = {get_tensor_descriptor_fn_name()}", code)
-                    self.assertIn(f"y_desc = {get_tensor_descriptor_fn_name()}", code)
+                    self.assert_tensor_descriptor_used_for(code, "x")
+                    self.assert_tensor_descriptor_used_for(code, "y")
                     self.assertIn("tl.dot", code)
                     if expect_permute:
                         self.assertIn("tl.permute", code)
@@ -655,55 +656,51 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
     def test_matmul_tensor_descriptor_mixed_fallback_static_and_dynamic(self):
         """Matmul should fall back per input when only one stride layout is valid."""
 
+        cases = [
+            (
+                "aligned",
+                torch.randn([32, 64], device=DEVICE, dtype=HALF_DTYPE),
+                torch.randn([64, 32], device=DEVICE, dtype=HALF_DTYPE),
+                True,
+                True,
+            ),
+            (
+                "x_unaligned",
+                torch.randn([32, 63], device=DEVICE, dtype=HALF_DTYPE),
+                torch.randn([63, 32], device=DEVICE, dtype=HALF_DTYPE),
+                False,
+                True,
+            ),
+        ]
+
         for static_shapes in (True, False):
             matmul = self._make_td_matmul(static_shapes)
-
-            x_aligned = torch.randn([32, 64], device=DEVICE, dtype=HALF_DTYPE)
-            y_aligned = torch.randn([64, 32], device=DEVICE, dtype=HALF_DTYPE)
-            with self.subTest(static_shapes=static_shapes, layout="aligned"):
-                code_aligned, result_aligned = code_and_output(
-                    matmul, (x_aligned, y_aligned)
-                )
-                torch.testing.assert_close(
-                    result_aligned,
-                    x_aligned @ y_aligned,
-                    atol=1e-1,
-                    rtol=1e-2,
-                )
-                self.assertIn(
-                    f"x_desc = {get_tensor_descriptor_fn_name()}", code_aligned
-                )
-                self.assertIn(
-                    f"y_desc = {get_tensor_descriptor_fn_name()}", code_aligned
-                )
-                self.assertIn("tl.dot", code_aligned)
-
-            # x.stride(0) == 63, so x's non-contiguous byte stride is not
-            # 16-byte aligned for 2-byte dtypes. y remains TD-eligible.
-            x_unaligned = torch.randn([32, 63], device=DEVICE, dtype=HALF_DTYPE)
-            y_still_aligned = torch.randn([63, 32], device=DEVICE, dtype=HALF_DTYPE)
-            with self.subTest(static_shapes=static_shapes, layout="x_unaligned"):
-                code_unaligned, result_unaligned = code_and_output(
-                    matmul, (x_unaligned, y_still_aligned)
-                )
-                torch.testing.assert_close(
-                    result_unaligned,
-                    x_unaligned @ y_still_aligned,
-                    atol=1e-1,
-                    rtol=1e-2,
-                )
-                self.assertNotIn(
-                    f"x_desc = {get_tensor_descriptor_fn_name()}", code_unaligned
-                )
-                self.assertIn(
-                    f"y_desc = {get_tensor_descriptor_fn_name()}", code_unaligned
-                )
-                self.assertIn("tl.dot", code_unaligned)
+            for name, x, y, expect_x_desc, expect_y_desc in cases:
+                with self.subTest(static_shapes=static_shapes, layout=name):
+                    code, result = code_and_output(matmul, (x, y))
+                    torch.testing.assert_close(
+                        result,
+                        x @ y,
+                        atol=1e-1,
+                        rtol=1e-2,
+                    )
+                    if expect_x_desc:
+                        self.assert_tensor_descriptor_used_for(code, "x")
+                    else:
+                        self.assert_tensor_descriptor_not_used_for(code, "x")
+                    if expect_y_desc:
+                        self.assert_tensor_descriptor_used_for(code, "y")
+                    else:
+                        self.assert_tensor_descriptor_not_used_for(code, "y")
+                    self.assertIn("tl.dot", code)
 
     def assert_uses_tensor_descriptors(self, code: str) -> None:
         self.assertIn(get_tensor_descriptor_fn_name(), code)
         self.assertNotIn("tl.load(", code)
         self.assertNotIn("tl.store(", code)
+
+    def assert_tensor_descriptor_used_for(self, code: str, name: str) -> None:
+        self.assertIn(f"{name}_desc = {get_tensor_descriptor_fn_name()}", code)
 
     def assert_tensor_descriptor_not_used_for(self, code: str, name: str) -> None:
         self.assertNotIn(f"{name}_desc = {get_tensor_descriptor_fn_name()}", code)
@@ -712,194 +709,263 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
     def test_scalar_symint_subscript_allowlist(self):
         """Known scalar SymInt expressions should still use tensor descriptors."""
 
-        @helion.kernel(
-            config=helion.Config(
-                block_sizes=[64],
-                indexing="tensor_descriptor",
-            ),
-            static_shapes=True,
-        )
-        def gather_rows(x: torch.Tensor, start: int) -> torch.Tensor:
-            _, n = x.size()
-            out = torch.empty([4, n], device=x.device, dtype=x.dtype)
-            for tile_n in hl.tile(n):
-                out[0, tile_n] = x[3, tile_n]
-                out[1, tile_n] = x[start, tile_n]
-                out[2, tile_n] = x[start + 3, tile_n]
-                out[3, tile_n] = x[start - start + 1, tile_n]
-            return out
-
-        @helion.kernel(
-            config=helion.Config(
-                block_sizes=[64],
-                indexing="tensor_descriptor",
-            ),
-            static_shapes=True,
-        )
-        def copy_offset_rows(x: torch.Tensor, start: int) -> torch.Tensor:
-            _, n = x.size()
-            rows = 4
-            out = torch.empty([rows, n], device=x.device, dtype=x.dtype)
-            for tile_b in hl.tile(rows, block_size=1):
+        def make_gather_rows(static_shapes: bool):
+            @helion.kernel(
+                config=helion.Config(
+                    block_sizes=[64],
+                    indexing="tensor_descriptor",
+                ),
+                static_shapes=static_shapes,
+            )
+            def gather_rows(x: torch.Tensor, start: int) -> torch.Tensor:
+                _, n = x.size()
+                out = torch.empty([4, n], device=x.device, dtype=x.dtype)
                 for tile_n in hl.tile(n):
-                    out[tile_b.begin, tile_n] = x[start + tile_b.begin, tile_n]
-            return out
+                    out[0, tile_n] = x[3, tile_n]
+                    out[1, tile_n] = x[start, tile_n]
+                    out[2, tile_n] = x[start + 3, tile_n]
+                    out[3, tile_n] = x[start - start + 1, tile_n]
+                return out
 
-        @helion.kernel(
-            config=helion.Config(
-                block_sizes=[64],
-                indexing="tensor_descriptor",
-            ),
-            static_shapes=True,
-        )
-        def copy_grid_rows(x: torch.Tensor) -> torch.Tensor:
-            _, n = x.size()
-            rows = 4
-            out = torch.empty([rows, n], device=x.device, dtype=x.dtype)
-            for row in hl.grid(rows):
-                for tile_n in hl.tile(n):
-                    out[row, tile_n] = x[row, tile_n]
-            return out
+            return gather_rows
 
-        @helion.kernel(
-            config=helion.Config(
-                block_sizes=[64, 64],
-                indexing="tensor_descriptor",
-            ),
-            static_shapes=True,
-        )
-        def scalar_noncontiguous_dims(x: torch.Tensor) -> torch.Tensor:
-            _, _, t, d = x.size()
-            out = torch.empty([t, d], device=x.device, dtype=x.dtype)
-            for tile_t, tile_d in hl.tile([t, d]):
-                out[tile_t, tile_d] = x[0, 0, tile_t, tile_d]
-            return out
+        def make_copy_offset_rows(static_shapes: bool):
+            @helion.kernel(
+                config=helion.Config(
+                    block_sizes=[64],
+                    indexing="tensor_descriptor",
+                ),
+                static_shapes=static_shapes,
+            )
+            def copy_offset_rows(x: torch.Tensor, start: int) -> torch.Tensor:
+                _, n = x.size()
+                rows = 4
+                out = torch.empty([rows, n], device=x.device, dtype=x.dtype)
+                for tile_b in hl.tile(rows, block_size=1):
+                    for tile_n in hl.tile(n):
+                        out[tile_b.begin, tile_n] = x[start + tile_b.begin, tile_n]
+                return out
+
+            return copy_offset_rows
+
+        def make_copy_grid_rows(static_shapes: bool):
+            @helion.kernel(
+                config=helion.Config(
+                    block_sizes=[64],
+                    indexing="tensor_descriptor",
+                ),
+                static_shapes=static_shapes,
+            )
+            def copy_grid_rows(x: torch.Tensor) -> torch.Tensor:
+                _, n = x.size()
+                rows = 4
+                out = torch.empty([rows, n], device=x.device, dtype=x.dtype)
+                for row in hl.grid(rows):
+                    for tile_n in hl.tile(n):
+                        out[row, tile_n] = x[row, tile_n]
+                return out
+
+            return copy_grid_rows
+
+        def make_scalar_noncontiguous_dims(static_shapes: bool):
+            @helion.kernel(
+                config=helion.Config(
+                    block_sizes=[64, 64],
+                    indexing="tensor_descriptor",
+                ),
+                static_shapes=static_shapes,
+            )
+            def scalar_noncontiguous_dims(x: torch.Tensor) -> torch.Tensor:
+                _, _, t, d = x.size()
+                out = torch.empty([t, d], device=x.device, dtype=x.dtype)
+                for tile_t, tile_d in hl.tile([t, d]):
+                    out[tile_t, tile_d] = x[0, 0, tile_t, tile_d]
+                return out
+
+            return scalar_noncontiguous_dims
 
         x = torch.randn(8, 128, device=DEVICE, dtype=torch.float32)
         x4d = torch.randn(2, 4, 128, 64, device=DEVICE, dtype=torch.float32)
 
-        code, result = code_and_output(gather_rows, (x, 2))
-        expected = torch.stack([x[3], x[2], x[5], x[1]])
-        torch.testing.assert_close(result, expected)
-        self.assert_uses_tensor_descriptors(code)
-
-        code, result = code_and_output(copy_offset_rows, (x, 2))
-        torch.testing.assert_close(result, x[2:6])
-        self.assert_uses_tensor_descriptors(code)
-
-        code, result = code_and_output(copy_grid_rows, (x,))
-        torch.testing.assert_close(result, x[:4])
-        self.assert_uses_tensor_descriptors(code)
-
-        code, result = code_and_output(scalar_noncontiguous_dims, (x4d,))
-        torch.testing.assert_close(result, x4d[0, 0])
-        self.assert_uses_tensor_descriptors(code)
+        for static_shapes in (True, False):
+            cases = [
+                (
+                    "gather_rows",
+                    make_gather_rows(static_shapes),
+                    (x, 2),
+                    torch.stack([x[3], x[2], x[5], x[1]]),
+                ),
+                (
+                    "copy_offset_rows",
+                    make_copy_offset_rows(static_shapes),
+                    (x, 2),
+                    x[2:6],
+                ),
+                (
+                    "copy_grid_rows",
+                    make_copy_grid_rows(static_shapes),
+                    (x,),
+                    x[:4],
+                ),
+                (
+                    "scalar_noncontiguous_dims",
+                    make_scalar_noncontiguous_dims(static_shapes),
+                    (x4d,),
+                    x4d[0, 0],
+                ),
+            ]
+            for name, kernel, args, expected in cases:
+                with self.subTest(static_shapes=static_shapes, case=name):
+                    code, result = code_and_output(kernel, args)
+                    torch.testing.assert_close(result, expected)
+                    self.assert_tensor_descriptor_used_for(code, "x")
 
     @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_scalar_symint_subscript_blocklist(self):
         """Unsafe scalar SymInt expressions should fall back for that tensor."""
 
-        @helion.kernel(
-            config=helion.Config(
-                block_sizes=[64],
-                indexing="tensor_descriptor",
-            ),
-            static_shapes=True,
-        )
-        def read_tile_end(x: torch.Tensor) -> torch.Tensor:
-            _, n = x.size()
-            rows = 4
-            out = torch.empty([rows, n], device=x.device, dtype=x.dtype)
-            for tile_b in hl.tile(rows, block_size=1):
-                for tile_n in hl.tile(n):
-                    out[tile_b.begin, tile_n] = x[tile_b.end, tile_n]
-            return out
+        def make_read_tile_end(static_shapes: bool):
+            @helion.kernel(
+                config=helion.Config(
+                    block_sizes=[64],
+                    indexing="tensor_descriptor",
+                ),
+                static_shapes=static_shapes,
+            )
+            def read_tile_end(x: torch.Tensor) -> torch.Tensor:
+                _, n = x.size()
+                rows = 4
+                out = torch.empty([rows, n], device=x.device, dtype=x.dtype)
+                for tile_b in hl.tile(rows, block_size=1):
+                    for tile_n in hl.tile(n):
+                        out[tile_b.begin, tile_n] = x[tile_b.end, tile_n]
+                return out
 
-        @helion.kernel(
-            config=helion.Config(
-                block_sizes=[64],
-                indexing="tensor_descriptor",
-            ),
-            static_shapes=True,
-        )
-        def read_tile_count(x: torch.Tensor) -> torch.Tensor:
-            _, n = x.size()
-            rows = 4
-            out = torch.empty([rows, n], device=x.device, dtype=x.dtype)
-            for tile_b in hl.tile(rows, block_size=1):
-                for tile_n in hl.tile(n):
-                    out[tile_b.begin, tile_n] = x[tile_b.count, tile_n]
-            return out
+            return read_tile_end
 
-        @helion.kernel(
-            config=helion.Config(
-                block_sizes=[64],
-                indexing="tensor_descriptor",
-            ),
-            static_shapes=True,
-        )
-        def read_tile_id(x: torch.Tensor) -> torch.Tensor:
-            _, n = x.size()
-            rows = 4
-            out = torch.empty([rows, n], device=x.device, dtype=x.dtype)
-            for tile_b in hl.tile(rows, block_size=1):
-                for tile_n in hl.tile(n):
-                    out[tile_b.begin, tile_n] = x[tile_b.id, tile_n]
-            return out
+        def make_read_tile_count(static_shapes: bool):
+            @helion.kernel(
+                config=helion.Config(
+                    block_sizes=[64],
+                    indexing="tensor_descriptor",
+                ),
+                static_shapes=static_shapes,
+            )
+            def read_tile_count(x: torch.Tensor) -> torch.Tensor:
+                _, n = x.size()
+                rows = 4
+                out = torch.empty([rows, n], device=x.device, dtype=x.dtype)
+                for tile_b in hl.tile(rows, block_size=1):
+                    for tile_n in hl.tile(n):
+                        out[tile_b.begin, tile_n] = x[tile_b.count, tile_n]
+                return out
 
-        @helion.kernel(
-            config=helion.Config(
-                block_sizes=[64, 64],
-                indexing="tensor_descriptor",
-            ),
-            static_shapes=True,
-        )
-        def read_indirect_rows(x: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
-            _, n = x.size()
-            rows = indices.size(0)
-            out = torch.empty([rows, n], device=x.device, dtype=x.dtype)
-            for tile_b, tile_n in hl.tile([rows, n]):
-                idx = indices[tile_b]
-                out[tile_b, tile_n] = x[idx, tile_n]
-            return out
+            return read_tile_count
 
-        @helion.kernel(
-            config=helion.Config(
-                block_sizes=[64],
-                indexing="tensor_descriptor",
-            ),
-            static_shapes=True,
-        )
-        def scalar_contiguous_dim(g: torch.Tensor) -> torch.Tensor:
-            _, t, _ = g.size()
-            out = torch.empty([t], device=g.device, dtype=g.dtype)
-            for tile_t in hl.tile(t):
-                out[tile_t] = g[0, tile_t, 0]
-            return out
+        def make_read_tile_id(static_shapes: bool):
+            @helion.kernel(
+                config=helion.Config(
+                    block_sizes=[64],
+                    indexing="tensor_descriptor",
+                ),
+                static_shapes=static_shapes,
+            )
+            def read_tile_id(x: torch.Tensor) -> torch.Tensor:
+                _, n = x.size()
+                rows = 4
+                out = torch.empty([rows, n], device=x.device, dtype=x.dtype)
+                for tile_b in hl.tile(rows, block_size=1):
+                    for tile_n in hl.tile(n):
+                        out[tile_b.begin, tile_n] = x[tile_b.id, tile_n]
+                return out
+
+            return read_tile_id
+
+        def make_read_indirect_rows(static_shapes: bool):
+            @helion.kernel(
+                config=helion.Config(
+                    block_sizes=[64, 64],
+                    indexing="tensor_descriptor",
+                ),
+                static_shapes=static_shapes,
+            )
+            def read_indirect_rows(
+                x: torch.Tensor, indices: torch.Tensor
+            ) -> torch.Tensor:
+                _, n = x.size()
+                rows = indices.size(0)
+                out = torch.empty([rows, n], device=x.device, dtype=x.dtype)
+                for tile_b, tile_n in hl.tile([rows, n]):
+                    idx = indices[tile_b]
+                    out[tile_b, tile_n] = x[idx, tile_n]
+                return out
+
+            return read_indirect_rows
+
+        def make_scalar_contiguous_dim(static_shapes: bool):
+            @helion.kernel(
+                config=helion.Config(
+                    block_sizes=[64],
+                    indexing="tensor_descriptor",
+                ),
+                static_shapes=static_shapes,
+            )
+            def scalar_contiguous_dim(g: torch.Tensor) -> torch.Tensor:
+                _, t, _ = g.size()
+                out = torch.empty([t], device=g.device, dtype=g.dtype)
+                for tile_t in hl.tile(t):
+                    out[tile_t] = g[0, tile_t, 0]
+                return out
+
+            return scalar_contiguous_dim
 
         x = torch.randn(8, 128, device=DEVICE, dtype=torch.float32)
         g = torch.randn(2, 128, 80, device=DEVICE, dtype=torch.float32)
-
-        code, result = code_and_output(read_tile_end, (x,))
-        torch.testing.assert_close(result, x[1:5])
-        self.assert_tensor_descriptor_not_used_for(code, "x")
-
-        code, result = code_and_output(read_tile_count, (x,))
-        torch.testing.assert_close(result, x[4].expand(4, 128))
-        self.assert_tensor_descriptor_not_used_for(code, "x")
-
-        code, result = code_and_output(read_tile_id, (x,))
-        torch.testing.assert_close(result, x[:4])
-        self.assert_tensor_descriptor_not_used_for(code, "x")
-
         indices = torch.tensor([3, 1, 4, 0], device=DEVICE, dtype=torch.int64)
-        code, result = code_and_output(read_indirect_rows, (x, indices))
-        torch.testing.assert_close(result, x[indices])
-        self.assert_tensor_descriptor_not_used_for(code, "x")
 
-        code, result = code_and_output(scalar_contiguous_dim, (g,))
-        torch.testing.assert_close(result, g[0, :, 0])
-        self.assert_tensor_descriptor_not_used_for(code, "g")
+        for static_shapes in (True, False):
+            cases = [
+                (
+                    "read_tile_end",
+                    make_read_tile_end(static_shapes),
+                    (x,),
+                    x[1:5],
+                    "x",
+                ),
+                (
+                    "read_tile_count",
+                    make_read_tile_count(static_shapes),
+                    (x,),
+                    x[4].expand(4, 128),
+                    "x",
+                ),
+                (
+                    "read_tile_id",
+                    make_read_tile_id(static_shapes),
+                    (x,),
+                    x[:4],
+                    "x",
+                ),
+                (
+                    "read_indirect_rows",
+                    make_read_indirect_rows(static_shapes),
+                    (x, indices),
+                    x[indices],
+                    "x",
+                ),
+                (
+                    "scalar_contiguous_dim",
+                    make_scalar_contiguous_dim(static_shapes),
+                    (g,),
+                    g[0, :, 0],
+                    "g",
+                ),
+            ]
+            for name, kernel, args, expected, tensor_name in cases:
+                with self.subTest(static_shapes=static_shapes, case=name):
+                    code, result = code_and_output(kernel, args)
+                    torch.testing.assert_close(result, expected)
+                    self.assert_tensor_descriptor_not_used_for(code, tensor_name)
 
 
 if __name__ == "__main__":

--- a/test/test_tensor_descriptor.py
+++ b/test/test_tensor_descriptor.py
@@ -17,6 +17,7 @@ from helion._testing import code_and_output
 from helion._testing import onlyBackends
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
+from helion._testing import skipIfXPU
 from helion._testing import skipUnlessTensorDescriptor
 import helion.language as hl
 
@@ -883,6 +884,7 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
                     self.assertIn("tl.dot", code)
 
     @skipUnlessTensorDescriptor("Tensor descriptor support is required")
+    @skipIfXPU("XPU tensor descriptor path has issue with stride-0 input")
     def test_dynamic_shape_stride_zero_input(self):
         """Expanded stride-0 dimensions should be TD-eligible with dynamic shapes."""
 
@@ -919,6 +921,7 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
         self.assertNotIn(f"{name}_desc = {get_tensor_descriptor_fn_name()}", code)
 
     @skipUnlessTensorDescriptor("Tensor descriptor support is required")
+    @skipIfXPU("XPU tensor descriptor path has accuracy issue for scalar SymInt subscripts")
     def test_scalar_symint_subscript_allowlist(self):
         """Known scalar SymInt expressions should still use tensor descriptors."""
 

--- a/test/test_tensor_descriptor.py
+++ b/test/test_tensor_descriptor.py
@@ -15,6 +15,7 @@ from helion._testing import TestCase
 from helion._testing import check_example
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
+from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
 from helion._testing import skipUnlessTensorDescriptor
 import helion.language as hl
@@ -589,6 +590,186 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result_transposed, x_transposed)
         self.assertIn(f"x_desc = {get_tensor_descriptor_fn_name()}", code_transposed)
         self.assertIn("tl.permute", code_transposed)
+
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
+    @skipIfRefEager("Test checks bound kernel specialization cache")
+    def test_dynamic_tensor_descriptor_reuses_specialization_across_batch_sizes(self):
+        """Changing only batch size should not trigger extra dynamic TD specializations."""
+
+        @helion.kernel(
+            static_shapes=False,
+            autotune_effort="none",
+            config=helion.Config(
+                block_sizes=[16, 16, 16],
+                indexing="tensor_descriptor",
+            ),
+        )
+        def linear(x: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
+            batch, k = x.size()
+            k2, n = w.size()
+            assert k == k2
+            out = torch.empty([batch, n], device=x.device, dtype=x.dtype)
+            for tile_b, tile_n in hl.tile([batch, n]):
+                acc = hl.zeros([tile_b, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_b, tile_k], w[tile_k, tile_n])
+                out[tile_b, tile_n] = acc.to(out.dtype)
+            return out
+
+        w = torch.randn([64, 64], device=DEVICE, dtype=HALF_DTYPE)
+        xs = [
+            torch.randn([32, 64], device=DEVICE, dtype=HALF_DTYPE),
+            torch.randn([64, 64], device=DEVICE, dtype=HALF_DTYPE),
+            torch.randn([128, 64], device=DEVICE, dtype=HALF_DTYPE),
+            torch.randn([32, 64], device=DEVICE, dtype=HALF_DTYPE),
+        ]
+
+        code, result = code_and_output(linear, (xs[0], w))
+        torch.testing.assert_close(result, xs[0] @ w, atol=1e-1, rtol=1e-2)
+        self.assert_tensor_descriptor_used_for(code, "x")
+        self.assert_tensor_descriptor_used_for(code, "w")
+        self.assertEqual(len(linear._bound_kernels), 1)
+
+        for x in xs[1:]:
+            result = linear(x, w)
+            torch.testing.assert_close(result, x @ w, atol=1e-1, rtol=1e-2)
+            self.assertEqual(len(linear._bound_kernels), 1)
+
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
+    @skipIfRefEager("Test checks bound kernel specialization cache")
+    def test_pointer_indexing_ignores_tensor_descriptor_layout_specialization(self):
+        """Pointer-only configs should not specialize on TD layout predicates."""
+
+        @helion.kernel(
+            static_shapes=False,
+            autotune_effort="none",
+            config=helion.Config(
+                block_sizes=[32, 32],
+                indexing="pointer",
+            ),
+        )
+        def copy_input(x: torch.Tensor) -> torch.Tensor:
+            result = torch.empty(x.size(), device=x.device, dtype=x.dtype)
+            for tile in hl.tile(x.size()):
+                result[tile] = x[tile]
+            return result
+
+        x_aligned = torch.randn([64, 1024], device=DEVICE, dtype=HALF_DTYPE)
+        x_unaligned = torch.randn([64, 1025], device=DEVICE, dtype=HALF_DTYPE)[:, :1024]
+        self.assertEqual(x_aligned.stride(), (1024, 1))
+        self.assertEqual(x_unaligned.stride(), (1025, 1))
+
+        code_aligned, result_aligned = code_and_output(copy_input, (x_aligned,))
+        torch.testing.assert_close(result_aligned, x_aligned)
+        self.assert_tensor_descriptor_not_used_for(code_aligned, "x")
+        bound_aligned = copy_input.bind((x_aligned,))
+        self.assertEqual(len(copy_input._bound_kernels), 1)
+
+        result_unaligned = copy_input(x_unaligned)
+        torch.testing.assert_close(result_unaligned, x_unaligned)
+        self.assertIs(bound_aligned, copy_input.bind((x_unaligned,)))
+        self.assertEqual(len(copy_input._bound_kernels), 1)
+
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
+    @skipIfRefEager("Test checks bound kernel specialization cache")
+    def test_mixed_indexing_only_specializes_tensor_descriptor_operands(self):
+        """Mixed configs should only guard tensors used by TD-indexed ops."""
+
+        @helion.kernel(
+            static_shapes=False,
+            autotune_effort="none",
+            config=helion.Config(
+                block_sizes=[32, 32],
+                indexing=["pointer", "tensor_descriptor", "pointer"],
+            ),
+        )
+        def add_inputs(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            result = torch.empty(x.size(), device=x.device, dtype=x.dtype)
+            for tile in hl.tile(x.size()):
+                result[tile] = x[tile] + y[tile]
+            return result
+
+        x_aligned = torch.randn([64, 1024], device=DEVICE, dtype=HALF_DTYPE)
+        x_unaligned = torch.randn([64, 1025], device=DEVICE, dtype=HALF_DTYPE)[:, :1024]
+        y_aligned = torch.randn([64, 1024], device=DEVICE, dtype=HALF_DTYPE)
+        y_unaligned = torch.randn([64, 1025], device=DEVICE, dtype=HALF_DTYPE)[:, :1024]
+        self.assertEqual(x_aligned.stride(), (1024, 1))
+        self.assertEqual(x_unaligned.stride(), (1025, 1))
+        self.assertEqual(y_aligned.stride(), (1024, 1))
+        self.assertEqual(y_unaligned.stride(), (1025, 1))
+
+        code_aligned, result_aligned = code_and_output(
+            add_inputs, (x_aligned, y_aligned)
+        )
+        torch.testing.assert_close(result_aligned, x_aligned + y_aligned)
+        self.assert_tensor_descriptor_not_used_for(code_aligned, "x")
+        self.assert_tensor_descriptor_used_for(code_aligned, "y")
+        bound_aligned = add_inputs.bind((x_aligned, y_aligned))
+        self.assertEqual(len(add_inputs._bound_kernels), 1)
+
+        result_x_unaligned = add_inputs(x_unaligned, y_aligned)
+        torch.testing.assert_close(result_x_unaligned, x_unaligned + y_aligned)
+        self.assertIs(bound_aligned, add_inputs.bind((x_unaligned, y_aligned)))
+        self.assertEqual(len(add_inputs._bound_kernels), 1)
+
+        code_y_unaligned, result_y_unaligned = code_and_output(
+            add_inputs, (x_aligned, y_unaligned)
+        )
+        torch.testing.assert_close(result_y_unaligned, x_aligned + y_unaligned)
+        self.assert_tensor_descriptor_not_used_for(code_y_unaligned, "y")
+        self.assertIsNot(bound_aligned, add_inputs.bind((x_aligned, y_unaligned)))
+        self.assertEqual(len(add_inputs._bound_kernels), 2)
+
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
+    @skipIfRefEager("Test checks bound kernel specialization cache")
+    def test_dynamic_shape_layout_signature_controls_specialization(self):
+        """Dynamic TD should specialize on layout predicates but reuse matching layouts."""
+
+        @helion.kernel(
+            static_shapes=False,
+            autotune_effort="none",
+            config=helion.Config(
+                block_sizes=[32, 32],
+                indexing=["tensor_descriptor", "pointer"],
+            ),
+        )
+        def copy_input(x: torch.Tensor) -> torch.Tensor:
+            result = torch.empty(x.size(), device=x.device, dtype=x.dtype)
+            for tile in hl.tile(x.size()):
+                result[tile] = x[tile]
+            return result
+
+        x_aligned = torch.randn([64, 1024], device=DEVICE, dtype=HALF_DTYPE)
+        x_aligned_2 = torch.randn([64, 1024], device=DEVICE, dtype=HALF_DTYPE)
+        x_unaligned = torch.randn([64, 1025], device=DEVICE, dtype=HALF_DTYPE)[:, :1024]
+        x_aligned_3 = torch.randn([64, 1024], device=DEVICE, dtype=HALF_DTYPE)
+
+        self.assertEqual(x_aligned.stride(), (1024, 1))
+        self.assertEqual(x_aligned_2.stride(), (1024, 1))
+        self.assertEqual(x_unaligned.stride(), (1025, 1))
+        self.assertEqual(x_aligned_3.stride(), (1024, 1))
+
+        code_aligned, result_aligned = code_and_output(copy_input, (x_aligned,))
+        torch.testing.assert_close(result_aligned, x_aligned)
+        self.assert_tensor_descriptor_used_for(code_aligned, "x")
+        bound_aligned = copy_input.bind((x_aligned,))
+        self.assertEqual(len(copy_input._bound_kernels), 1)
+
+        result_aligned_2 = copy_input(x_aligned_2)
+        torch.testing.assert_close(result_aligned_2, x_aligned_2)
+        self.assertIs(bound_aligned, copy_input.bind((x_aligned_2,)))
+        self.assertEqual(len(copy_input._bound_kernels), 1)
+
+        code_unaligned, result_unaligned = code_and_output(copy_input, (x_unaligned,))
+        torch.testing.assert_close(result_unaligned, x_unaligned)
+        self.assert_tensor_descriptor_not_used_for(code_unaligned, "x")
+        self.assertIsNot(bound_aligned, copy_input.bind((x_unaligned,)))
+        self.assertEqual(len(copy_input._bound_kernels), 2)
+
+        result_aligned_3 = copy_input(x_aligned_3)
+        torch.testing.assert_close(result_aligned_3, x_aligned_3)
+        self.assertIs(bound_aligned, copy_input.bind((x_aligned_3,)))
+        self.assertEqual(len(copy_input._bound_kernels), 2)
 
     @staticmethod
     def _make_td_matmul(static_shapes: bool):

--- a/test/test_tensor_descriptor.py
+++ b/test/test_tensor_descriptor.py
@@ -590,6 +590,116 @@ class TestTensorDescriptor(RefEagerTestBase, TestCase):
         self.assertIn(f"x_desc = {get_tensor_descriptor_fn_name()}", code_transposed)
         self.assertIn("tl.permute", code_transposed)
 
+    @staticmethod
+    def _make_td_matmul(static_shapes: bool):
+        @helion.kernel(
+            static_shapes=static_shapes,
+            autotune_effort="none",
+            config=helion.Config(
+                block_sizes=[16, 16, 16],
+                indexing="tensor_descriptor",
+            ),
+        )
+        def matmul(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            k2, n = y.size()
+            assert k == k2
+            out = torch.empty([m, n], device=x.device, dtype=x.dtype)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(out.dtype)
+            return out
+
+        return matmul
+
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
+    def test_matmul_tensor_descriptor_static_and_dynamic(self):
+        """Matmul should use TD loads and tl.dot in static and dynamic modes."""
+
+        y = torch.randn([64, 32], device=DEVICE, dtype=HALF_DTYPE)
+        cases = [
+            (
+                "contiguous",
+                torch.randn([32, 64], device=DEVICE, dtype=HALF_DTYPE),
+                False,
+            ),
+            (
+                "transposed",
+                torch.randn([64, 32], device=DEVICE, dtype=HALF_DTYPE).t(),
+                True,
+            ),
+        ]
+
+        for static_shapes in (True, False):
+            matmul = self._make_td_matmul(static_shapes)
+            for name, x, expect_permute in cases:
+                with self.subTest(static_shapes=static_shapes, layout=name):
+                    code, result = code_and_output(matmul, (x, y))
+                    torch.testing.assert_close(
+                        result,
+                        x @ y,
+                        atol=1e-1,
+                        rtol=1e-2,
+                    )
+                    self.assertIn(f"x_desc = {get_tensor_descriptor_fn_name()}", code)
+                    self.assertIn(f"y_desc = {get_tensor_descriptor_fn_name()}", code)
+                    self.assertIn("tl.dot", code)
+                    if expect_permute:
+                        self.assertIn("tl.permute", code)
+                    else:
+                        self.assertNotIn("tl.permute", code)
+
+    @skipUnlessTensorDescriptor("Tensor descriptor support is required")
+    def test_matmul_tensor_descriptor_mixed_fallback_static_and_dynamic(self):
+        """Matmul should fall back per input when only one stride layout is valid."""
+
+        for static_shapes in (True, False):
+            matmul = self._make_td_matmul(static_shapes)
+
+            x_aligned = torch.randn([32, 64], device=DEVICE, dtype=HALF_DTYPE)
+            y_aligned = torch.randn([64, 32], device=DEVICE, dtype=HALF_DTYPE)
+            with self.subTest(static_shapes=static_shapes, layout="aligned"):
+                code_aligned, result_aligned = code_and_output(
+                    matmul, (x_aligned, y_aligned)
+                )
+                torch.testing.assert_close(
+                    result_aligned,
+                    x_aligned @ y_aligned,
+                    atol=1e-1,
+                    rtol=1e-2,
+                )
+                self.assertIn(
+                    f"x_desc = {get_tensor_descriptor_fn_name()}", code_aligned
+                )
+                self.assertIn(
+                    f"y_desc = {get_tensor_descriptor_fn_name()}", code_aligned
+                )
+                self.assertIn("tl.dot", code_aligned)
+
+            # x.stride(0) == 63, so x's non-contiguous byte stride is not
+            # 16-byte aligned for 2-byte dtypes. y remains TD-eligible.
+            x_unaligned = torch.randn([32, 63], device=DEVICE, dtype=HALF_DTYPE)
+            y_still_aligned = torch.randn([63, 32], device=DEVICE, dtype=HALF_DTYPE)
+            with self.subTest(static_shapes=static_shapes, layout="x_unaligned"):
+                code_unaligned, result_unaligned = code_and_output(
+                    matmul, (x_unaligned, y_still_aligned)
+                )
+                torch.testing.assert_close(
+                    result_unaligned,
+                    x_unaligned @ y_still_aligned,
+                    atol=1e-1,
+                    rtol=1e-2,
+                )
+                self.assertNotIn(
+                    f"x_desc = {get_tensor_descriptor_fn_name()}", code_unaligned
+                )
+                self.assertIn(
+                    f"y_desc = {get_tensor_descriptor_fn_name()}", code_unaligned
+                )
+                self.assertIn("tl.dot", code_unaligned)
+
     def assert_uses_tensor_descriptors(self, code: str) -> None:
         self.assertIn(get_tensor_descriptor_fn_name(), code)
         self.assertNotIn("tl.load(", code)


### PR DESCRIPTION
This PR enables tensor descriptor / TMA indexing for `static_shapes=False`. Previously, dynamic-shape kernels generally could not use tensor descriptors because TD legality depends on stride layout facts that may be symbolic at  
compile time. In particular, TMA requires:                                                     
  - exactly one stride-1 dimension, and
  - all non-contiguous byte strides to be 16-byte aligned.
For dynamic shapes, `size_hint()` only tells us the current concrete value inside a dynamic-shape bucket. A later input in the same bucket may have a different stride layout, so using the hint alone would be unsafe.                                                                                          

This PR handles that by adding TD layout predicates to the runtime specialization key when needed. The layout signature records:
  - which dimension, if any, has `stride == 1`
  - which dimensions have 16-byte aligned byte strides

This is intentionally coarser than specializing on exact strides, so layouts that differ in exact stride values but have the same TD eligibility can still share compiled code. We are careful to only trigger recompilation if the config is indeed using tensor_descriptors.

This introduces a tradeoff:
1. We gain large performance improvements from TMA on B200, attaining parity with `static_shapes = True`
2. But we potentially reduce cache hits for dynamic shapes if stride-one dimension or the 16-byte stride-alignment predicates changes.

For example, these two tensors have the same logical shape but different TD eligibility:
  ```python
  x_aligned = torch.randn(64, 1024)             # stride (1024, 1), TD eligible
  x_unaligned = torch.randn(64, 1025)[:, :1024] # stride (1025, 1), TD ineligible
```
With dynamic TD enabled, these need different compiled variants. That may induce extra recompilation compared to pointer indexing, but it is necessary to avoid reusing TMA code for an input whose stride layout is not TMA-legal.

For standard dynamic-shape cases where only batch size or sequence length changes, this should not induce extra recompilation as long as the layout signature is unchanged.

For example, changing batch sizes still reuse the same TD layout specialization:
  ```python
  x1 = torch.randn(31, 64)  # stride (64, 1)
  x2 = torch.randn(22, 64)  # stride (64, 1)
```
For attention-style tensors, varying sequence length also keeps the same layout signature when the head dimension is fixed:
```python
q1 = torch.randn(3, 17, 32, 64)   # [batch, seq_len, heads, head_dim]
q2 = torch.randn(3, 113, 32, 64)  # [batch, seq_len, heads, head_dim]
```

Below are benchmarks for matmul and mamba2 chunk scan (single config) on B200
- For matmul, we see that with this PR we are able to overcome a **2x** latency regression bw static_shapes = False and  static_shapes = True. We now obtain parity.
- For mamba2 chunk scan, with this PR we are able to close much of the gap but not completely attain parity. This is because we don't yet do the enablement for compiler created tensors (follow up PR) so there is 1 tensor that still fallbacks to pointer.

  #### Matmul

  | static_shapes | Size | Pointer (main) | TD (main) | TD (this PR) | Speedup vs TD main | Speedup vs pointer |
  |---|---:|---:|---:|---:|---:|---:|
  | True | 2048 | 0.0519 ms | 0.0430 ms | 0.0430 ms | 1.00x | 1.21x |
  | True | 4096 | 0.3258 ms | 0.2590 ms | 0.2574 ms | 1.01x | 1.27x |
  | False | 2048 | 0.0825 ms | 0.0826 ms | 0.0433 ms | 1.91x | 1.91x |
  | False | 4096 | 0.5506 ms | 0.5503 ms | 0.2586 ms | 2.13x | 2.13x |

  #### Mamba2 chunk-state

  | static_shapes | Batch | Heads | SeqLen | Hdim | Dstate | Pointer (main) | TD (main) | TD (this PR) | Speedup vs TD main | Speedup vs pointer |
  |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
  | True | 2 | 80 | 2048 | 64 | 128 | 0.1124 ms | 0.0782 ms | 0.0782 ms | 1.00x | 1.44x |
  | True | 4 | 80 | 2048 | 64 | 128 | 0.2351 ms | 0.1449 ms | 0.1449 ms | 1.00x | 1.62x |
  | True | 8 | 80 | 4096 | 64 | 128 | 0.9146 ms | 0.5313 ms | 0.5315 ms | 1.00x | 1.72x |
  | False | 2 | 80 | 2048 | 64 | 128 | 0.1246 ms | 0.1241 ms | 0.0940 ms | 1.32x | 1.33x |
  | False | 4 | 80 | 2048 | 64 | 128 | 0.2501 ms | 0.2502 ms | 0.1759 ms | 1.42x | 1.42x |
  | False | 8 | 80 | 4096 | 64 | 128 | 0.9655 ms | 0.9655 ms | 0.6567 ms | 1.47x | 1.47x |