### PR TITLE
Seeding the configs for aymmetric skinny matmuls

### DIFF
--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -399,6 +399,14 @@ class ConfigSpec:
         # no loud crash to alert a user who bypasses autotune via an
         # explicit config, so normalize() must reject the unsafe values.
         self._tcgen05_num_epi_warps_validation_choices: tuple[int, ...] | None = None
+        # Compiler-owned seed configs for severely imbalanced 2-D matmul shapes
+        # (max(M, N) >= 8 * min(M, N)).  Populated by helion.language.matmul_ops
+        # at compile time when static shapes are known and the backend is
+        # triton.  These seeds bias the autotuner's initial population
+        # toward small-tile configs that the random sampler is unlikely to
+        # discover on its own.  See https://github.com/pytorch/helion/pull/2276
+        # for the validation experiment by @ethche on H100 skinny GEMM.
+        self._imbalanced_matmul_seed_configs: list[helion.Config] = []
         self.store_indices: list[int] = []
         self.backend_tunable_fragments = self.backend.tunable_fragments()
         unknown_tunables = set(self.backend_tunable_fragments) - BACKEND_TUNABLE_KEYS
@@ -607,10 +615,25 @@ class ConfigSpec:
 
     def autotune_seed_configs(self) -> list[helion.Config]:
         """Return validated extra configs that should be benchmarked early."""
+        seeds: list[helion.Config] = []
         cluster_m2_seed = self._tcgen05_cluster_m2_seed_config()
-        if cluster_m2_seed is None:
-            return []
-        return [cluster_m2_seed]
+        if cluster_m2_seed is not None:
+            seeds.append(cluster_m2_seed)
+        seeds.extend(self._imbalanced_matmul_seed_configs)
+        return seeds
+
+    def register_imbalanced_matmul_seed(self, seed: helion.Config) -> bool:
+        """Register a deduped imbalanced-matmul seed.
+
+        Returns True if the seed was added, False if an equivalent seed was
+        already present (multiple matmul calls in one kernel sharing the same
+        imbalanced shape would otherwise over-bias the initial population).
+        """
+        for existing in self._imbalanced_matmul_seed_configs:
+            if existing.config == seed.config:
+                return False
+        self._imbalanced_matmul_seed_configs.append(seed)
+        return True
 
     def _fix_tcgen05_cluster_m2_search_config(self, config: dict[str, object]) -> None:
         """Canonicalize unvalidated search-only ``cluster_m=2`` products."""

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -31,6 +31,7 @@ from .._compiler.matmul_utils import _emit_pallas_matmul
 from .._compiler.matmul_utils import _emit_tl_dot_scaled
 from .._compiler.matmul_utils import _needs_f32_accumulator
 from .._compiler.matmul_utils import emit_tl_dot_with_padding
+from ..runtime.config import Config
 from . import _decorators
 
 if TYPE_CHECKING:
@@ -376,6 +377,90 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
             block_idx = env.get_block_id(batch_dim)
             if block_idx is not None:
                 env.block_sizes[block_idx].update_max_block(1)
+
+    # Seed the autotuner with a balanced-tile config for severely imbalanced
+    # 2-D matmul shapes (M, N grid is skinny, ratio >= 8x). This biases the
+    # initial population toward small-tile configs that the random sampler is
+    # unlikely to discover on its own, without restricting the search space.
+    # See pytorch/helion#2102 for the cap-based approach this replaces, and
+    # https://github.com/pytorch/helion/pull/2276 for @ethche's validation
+    # experiment on H100 Triton skinny GEMM.
+    #
+    # Triton-only for now: the CuTe/tcgen05 path enforces m_min >= 64 (and 128
+    # when M >= 256), which would silently drop the target=64 seed for the
+    # common B200 shapes; CuTe needs its own seed family before opting in.
+    if (
+        env.backend_name == "triton"
+        and lhs.ndim == 2
+        and rhs.ndim == 2
+        and static_m is not None
+        and static_n is not None
+        and static_k is not None
+        and max(static_m, static_n) >= 8 * min(static_m, static_n)
+    ):
+        seed = _make_imbalanced_matmul_seed(env, m, n, k, static_m, static_n, static_k)
+        if seed is not None:
+            env.config_spec.register_imbalanced_matmul_seed(seed)
+
+
+# Balanced-tile family for imbalanced 2-D matmul.  See
+# https://github.com/pytorch/helion/pull/2276 for the H100 validation
+# experiment that motivated these targets.  Each axis of the seed is
+# shape-clamped to the static dim and respects the per-axis floor
+# (min_size, autotuner_min); these are the *targets* before clamping.
+_IMBALANCED_MATMUL_SEED_TARGETS: tuple[int, int, int] = (64, 64, 256)
+
+
+def _make_imbalanced_matmul_seed(
+    env: CompileEnvironment,
+    m: int | torch.SymInt,
+    n: int | torch.SymInt,
+    k: int | torch.SymInt,
+    static_m: int,
+    static_n: int,
+    static_k: int,
+) -> Config | None:
+    """Build a [block_m, block_n, block_k] seed Config for an imbalanced matmul.
+
+    Targets ``_IMBALANCED_MATMUL_SEED_TARGETS`` (the [64, 64, 256] family
+    motivated by @ethche's experiment in
+    https://github.com/pytorch/helion/pull/2276), but adapts each block to
+    the static dim and respects the per-axis floor (``min_size``,
+    ``autotuner_min``) so the seed survives normalization.  Returns None if
+    any axis cannot satisfy its constraints (in which case the seed would be
+    silently dropped anyway).
+
+    Only ``block_sizes`` is pinned; ``num_warps``, ``num_stages``, ``pid_type``
+    and other tunables fall back to the autotuner's defaults so the seed is a
+    soft hint rather than a fully-specified config.
+    """
+    targets = (
+        (m, static_m, _IMBALANCED_MATMUL_SEED_TARGETS[0]),
+        (n, static_n, _IMBALANCED_MATMUL_SEED_TARGETS[1]),
+        (k, static_k, _IMBALANCED_MATMUL_SEED_TARGETS[2]),
+    )
+    block_sizes: list[int] = []
+    for shape, static_dim, target in targets:
+        block_idx = env.get_block_id(shape)
+        if block_idx is None:
+            return None
+        try:
+            bspec = env.config_spec.block_sizes.block_id_lookup(block_idx)
+        except KeyError:
+            return None
+        # Largest power-of-two <= min(target, static_dim)
+        candidate = min(target, static_dim)
+        if candidate < 1:
+            return None
+        candidate = 1 << (candidate.bit_length() - 1)
+        # Respect floor: skip the seed entirely if the target falls below
+        # any pre-existing minimum (e.g. tcgen05 m_min = 64/128).
+        floor = max(bspec.min_size, bspec.autotuner_min)
+        if candidate < floor:
+            return None
+        candidate = min(candidate, bspec.max_size)
+        block_sizes.append(candidate)
+    return Config(block_sizes=block_sizes)
 
 
 @_decorators.register_fake(dot)

--- a/test/test_best_available.py
+++ b/test/test_best_available.py
@@ -30,6 +30,7 @@ from helion.autotuner.local_cache import LocalAutotuneCache
 from helion.autotuner.local_cache import SavedBestConfig
 from helion.autotuner.local_cache import iter_cache_entries
 from helion.autotuner.pattern_search import InitialPopulationStrategy
+from helion.language.matmul_ops import _make_imbalanced_matmul_seed
 from helion.runtime.config import Config
 from helion.runtime.settings import Settings
 from helion.runtime.settings import _get_initial_population_strategy
@@ -1139,6 +1140,115 @@ class TestGenerateBestAvailablePopulation(unittest.TestCase):
         )
 
         self.assertEqual(len(result), 2)  # 1 default + 1 good cached
+
+
+class TestImbalancedMatmulSeed(unittest.TestCase):
+    """Tests for the imbalanced 2-D matmul seed-config heuristic.
+
+    The heuristic lives in ``helion.language.matmul_ops`` and registers a
+    shape-aware ``[<=64, <=64, <=256]`` seed on
+    ``ConfigSpec._imbalanced_matmul_seed_configs`` whenever a 2-D matmul has
+    static M/N with ``max(M, N) >= 8 * min(M, N)`` on the triton backend.
+    ``ConfigSpec.autotune_seed_configs()`` then surfaces those seeds to the
+    autotuner's initial population.
+    """
+
+    def _make_spec_with_block_sizes(self, m_max=8192, n_max=8192, k_max=8192):
+        spec = ConfigSpec(backend=TritonBackend())
+        spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=m_max))
+        spec.block_sizes.append(BlockSizeSpec(block_id=1, size_hint=n_max))
+        spec.block_sizes.append(BlockSizeSpec(block_id=2, size_hint=k_max))
+        return spec
+
+    def test_seed_field_default_empty(self):
+        """A fresh ConfigSpec has no imbalanced-matmul seeds."""
+        spec = ConfigSpec(backend=TritonBackend())
+        self.assertEqual(spec._imbalanced_matmul_seed_configs, [])
+
+    def test_autotune_seed_configs_surfaces_registered_seeds(self):
+        """Registered seeds flow through ``autotune_seed_configs()``."""
+        spec = self._make_spec_with_block_sizes()
+        seed = Config(block_sizes=[64, 64, 256])
+        spec._imbalanced_matmul_seed_configs.append(seed)
+        out = spec.autotune_seed_configs()
+        self.assertIn(seed, out)
+
+    def test_autotune_seed_configs_empty_when_no_seeds_registered(self):
+        """Default ``autotune_seed_configs()`` returns an empty list when no
+        cluster_m2 seed and no imbalanced-matmul seed is registered."""
+        spec = self._make_spec_with_block_sizes()
+        self.assertEqual(spec.autotune_seed_configs(), [])
+
+    def test_helper_skinny_n_returns_target_blocks(self):
+        """Skinny-N (M=1024, N=8192, K=4096): seed picks targets [64, 64, 256]."""
+        spec = self._make_spec_with_block_sizes(m_max=1024, n_max=8192, k_max=4096)
+        env = MagicMock()
+        env.config_spec = spec
+        env.get_block_id.side_effect = [0, 1, 2]
+        seed = _make_imbalanced_matmul_seed(env, "m", "n", "k", 1024, 8192, 4096)
+        self.assertIsNotNone(seed)
+        self.assertEqual(seed.config["block_sizes"], [64, 64, 256])
+
+    def test_helper_skinny_m_returns_target_blocks(self):
+        """Skinny-M (M=8192, N=1024, K=4096): symmetric, same target blocks."""
+        spec = self._make_spec_with_block_sizes(m_max=8192, n_max=1024, k_max=4096)
+        env = MagicMock()
+        env.config_spec = spec
+        env.get_block_id.side_effect = [0, 1, 2]
+        seed = _make_imbalanced_matmul_seed(env, "m", "n", "k", 8192, 1024, 4096)
+        self.assertIsNotNone(seed)
+        self.assertEqual(seed.config["block_sizes"], [64, 64, 256])
+
+    def test_helper_caps_at_static_dim(self):
+        """Very-skinny (M=16, N=8192, K=128): blocks cap at static dim."""
+        spec = self._make_spec_with_block_sizes(m_max=16, n_max=8192, k_max=128)
+        env = MagicMock()
+        env.config_spec = spec
+        env.get_block_id.side_effect = [0, 1, 2]
+        seed = _make_imbalanced_matmul_seed(env, "m", "n", "k", 16, 8192, 128)
+        self.assertIsNotNone(seed)
+        # block_m clamped to static_m=16, block_k clamped to static_k=128
+        self.assertEqual(seed.config["block_sizes"], [16, 64, 128])
+
+    def test_helper_returns_none_when_floor_violated(self):
+        """If autotuner_min on M is raised above target=64, seed is dropped."""
+        spec = self._make_spec_with_block_sizes(m_max=1024, n_max=8192, k_max=4096)
+        spec.block_sizes.block_id_lookup(0).autotuner_min = 256
+        env = MagicMock()
+        env.config_spec = spec
+        env.get_block_id.side_effect = [0, 1, 2]
+        seed = _make_imbalanced_matmul_seed(env, "m", "n", "k", 1024, 8192, 4096)
+        self.assertIsNone(seed)
+
+    def test_helper_returns_none_when_block_id_missing(self):
+        """If a shape's block_id is unresolvable, seed is dropped."""
+        spec = self._make_spec_with_block_sizes()
+        env = MagicMock()
+        env.config_spec = spec
+        env.get_block_id.return_value = None
+        seed = _make_imbalanced_matmul_seed(env, "m", "n", "k", 1024, 8192, 4096)
+        self.assertIsNone(seed)
+
+    def test_register_dedupes_identical_seeds(self):
+        """register_imbalanced_matmul_seed() deduplicates equivalent seeds.
+
+        Multiple matmul calls in one kernel with the same imbalanced shape
+        should not over-bias the initial population by registering duplicates.
+        Calls the production API directly so removing the dedup guard would
+        fail this test.
+        """
+        spec = self._make_spec_with_block_sizes()
+        first = Config(block_sizes=[64, 64, 256])
+        second = Config(block_sizes=[64, 64, 256])  # equivalent to first
+        third = Config(block_sizes=[32, 64, 256])  # different -> should add
+        self.assertTrue(spec.register_imbalanced_matmul_seed(first))
+        self.assertFalse(spec.register_imbalanced_matmul_seed(second))
+        self.assertTrue(spec.register_imbalanced_matmul_seed(third))
+        self.assertEqual(len(spec._imbalanced_matmul_seed_configs), 2)
+        self.assertEqual(
+            [c.config["block_sizes"] for c in spec.autotune_seed_configs()],
+            [[64, 64, 256], [32, 64, 256]],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a replacement for this [PR ](https://github.com/pytorch/helion/pull/2102) which I created. 
## Summary                                                
                                                                                                                     
  Adds a compiler-owned seed config for severely imbalanced 2-D matmul shapes (`max(M, N) >= 8 * min(M, N)`). When the trigger fires, a shape-aware `[<=64, <=64, <=256]` block-sizes Config is registered via `ConfigSpec.register_imbalanced_matmul_seed()` and surfaced through the existing `autotune_seed_configs()` mechanism added in #2250 / #2276.                                               
                                                                                                                     
  This is a soft hint — the autotuner explores around the seed but the search space is not restricted. Kernels for which the seed is sub-optimal remain free to find better configs.                                                                                       
                                                                                                                     
  ## Background                                                                                                      
                                                                                                                     
  Helion's random sampler has roughly a 1% probability of picking a small-tile config (e.g., `[64, 64, 256]`) on skinny GEMM shapes such as M=1024, N=8192. With ~100 initial samples the surrogate model rarely sees a winning point and steers toward large tiles that win on average across balanced shapes. This produced large gaps vs torch_compile / aten on the worst skinny matmul shapes.                                                                                        
                                                                                                                     
  #2102 (closed) approached the same problem by hard-capping the `max_size` of the larger grid dim. Per @ethche's suggestion in                                                     
  [#2102 (comment)](https://github.com/pytorch/helion/pull/2102#issuecomment-4390481054)  and [#2276](https://github.com/pytorch/helion/pull/2276), seeding the initial population is strictly less invasive: zero downside on shapes where the heuristic is sub-optimal, and direct access to the validated tile family on the shapes where it helps.                           