### PR TITLE
[docs] Fix broken tutorials/ links in AOT autotuning doc

### DIFF
--- a/docs/aot_autotuning.md
+++ b/docs/aot_autotuning.md
@@ -10,8 +10,8 @@ The **AOT autotuning workflow** addresses both problems.  Offline, you
 sweep a kernel over a representative shape set, tune each shape, then
 distill the (shape → best-config) table into a small **decision-tree
 heuristic**.  At runtime, the heuristic picks a tuned config for the
-caller's shape in microseconds — no autotuner involved.  The tutorials
-under [`tutorials/`](https://github.com/pytorch/helion/tree/main/tutorials)
+caller's shape in microseconds — no autotuner involved.  The pretuned
+kernels under [`pretuned_kernels/`](https://github.com/pytorch/helion/tree/main/pretuned_kernels)
 ship pretuned heuristic files that demonstrate this end-to-end.
 
 This doc covers the user-facing API, the offline workflow, and how the
@@ -223,7 +223,7 @@ target.
 
    ```bash
    # Tutorial example: tune layer_norm on the current GPU.
-   python -m helion.experimental.aot_runner -- python tutorials/layer_norm/layer_norm.py
+   python -m helion.experimental.aot_runner -- python pretuned_kernels/layer_norm/layer_norm.py
 
    # User-authored kernel: same pattern.
    python -m helion.experimental.aot_runner -- python my_benchmark.py
@@ -235,7 +235,7 @@ target.
 
 4. **Locate the emitted heuristic file.**  See *Generated artifacts* —
    the heuristic file lands next to the kernel source (e.g.
-   `tutorials/layer_norm/_helion_aot_layer_norm_cuda_sm90.py`); the
+   `pretuned_kernels/layer_norm/_helion_aot_layer_norm_cuda_sm90.py`); the
    data dir holds disposable intermediates.
 
 5. **Commit the heuristic file.**  Keep the existing pretuned files
@@ -263,5 +263,5 @@ those bounds.
   runtime cache that consumes generated heuristics.
 - [`examples/aot_example.py`](https://github.com/pytorch/helion/blob/main/examples/aot_example.py)
   — runnable end-to-end example.
-- [`tutorials/`](https://github.com/pytorch/helion/tree/main/tutorials)
-  — pretuned tutorial kernels you can use as templates.
+- [`pretuned_kernels/`](https://github.com/pytorch/helion/tree/main/pretuned_kernels)
+  — pretuned kernels you can use as templates.

--- a/docs/deployment_autotuning.md
+++ b/docs/deployment_autotuning.md
@@ -457,6 +457,6 @@ See {doc}`aot_autotuning` for the
 `@helion.experimental.aot_kernel` decorator, the three-phase
 `collect → measure → evaluate` runner, the heuristic file format and
 generated artifacts, and the runtime compute-capability fallback rules.
-The pretuned [`tutorials/`](https://github.com/pytorch/helion/tree/main/tutorials)
-kernels use this workflow end-to-end and ship `sm100` heuristic files
+The [`pretuned_kernels/`](https://github.com/pytorch/helion/tree/main/pretuned_kernels)
+use this workflow end-to-end and ship `sm100` heuristic files
 that you can use as templates.


### PR DESCRIPTION
The AOT autotuning doc (#2274) links to `tutorials/`, but that directory was actually landed as `pretuned_kernels/` in #2209. The two PRs landed close together and the path drifted, breaking docs linkcheck on `main`:

```
(aot_autotuning: line 9) broken https://github.com/pytorch/helion/tree/main/tutorials - 404 Client Error: Not Found
```

Fix: update all four references in `docs/aot_autotuning.md` to point at `pretuned_kernels/`.