### PR TITLE
Dashboard: don't flag manual-only kernels as infra_missing

### DIFF
--- a/.github/dashboard/build_dashboard_data.py
+++ b/.github/dashboard/build_dashboard_data.py
@@ -328,8 +328,11 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None, active_platfo
 
         acc_failures = []
         run_failures = []
-        # Kernel absent from the global latest nightly run → likely CI infra issue.
-        infra_missing = bool(latest_nightly_run_id) and (not latest_main or latest_main["run_id"] != latest_nightly_run_id)
+        # Kernel had nightly history but is absent from the global latest
+        # nightly run → likely CI infra issue. Kernels that have never had a
+        # nightly entry (e.g., only seen via manual workflow_dispatch or
+        # ad-hoc full-coverage runs) are not flagged.
+        infra_missing = bool(latest_nightly_run_id) and latest_main is not None and latest_main["run_id"] != latest_nightly_run_id
         if not infra_missing and latest_main:
             latest_ps = latest_main.get("per_shape") or {}
             shapes = latest_ps.get("shapes", [])


### PR DESCRIPTION
## Summary

The dashboard's `infra_missing` classifier was firing for kernels that have **no nightly history at all** — typically kernels seen only via manual `workflow_dispatch` runs or ad-hoc full-coverage sweeps. They'd render with the red "shapes failed / didn't run" overlay on the Overview/Speedup tabs even though they were never part of the nightly subset to begin with.

Concretely, on the live dashboard ([helionlang.com/dashboard](https://helionlang.com/dashboard/)) every non-slim TPU kernel currently shows infra_missing = true with `last_seen_date = None`:

```
add                            infra_missing=True last_seen=None
batch_softmax                  infra_missing=True last_seen=None
broadcast_matmul               infra_missing=True last_seen=None
embedding                      infra_missing=True last_seen=None
exp                            infra_missing=True last_seen=None
geglu                          infra_missing=True last_seen=None
... (16 total)
```

These entries come from manual full-coverage sweeps via `yifeixu/tpu-bench-full` (PR #2322), which intentionally tracks 25 kernels — a superset of the nightly's 9. They should appear on the Compare tab only, not as Overview-level CI failures.

## Root cause

`build_dashboard_data.py:332`:

```python
infra_missing = bool(latest_nightly_run_id) and (not latest_main or latest_main["run_id"] != latest_nightly_run_id)
```

The `not latest_main` clause treats "kernel has never had a nightly entry" identically to "kernel had a nightly entry but missed the latest run". Those are different cases — only the second is genuinely an infra issue.

## Fix

Add `latest_main is not None` to the conjunction:

```python
infra_missing = (
    bool(latest_nightly_run_id)
    and latest_main is not None
    and latest_main["run_id"] != latest_nightly_run_id
)
```

| Case | Before | After |
|---|---|---|
| Kernel in latest nightly | False ✓ | False ✓ |
| Kernel had prior nightly history but absent from latest nightly (real infra issue) | True ✓ | True ✓ — preserved |
| Kernel has never had a nightly entry (manual-dispatch only) | True ❌ | False ✓ |

Real infra-issue detection (a slim kernel crashes hard enough to emit no JSON in the latest nightly) is preserved: that case has `latest_main` from a prior nightly with a different `run_id`, which still triggers `infra_missing=True`.

## Relation to PR #2363

#2363 (just merged) fixed two adjacent bugs in the same area: `is_nightly` mistagging when a cron run is re-run by `pytorch-bot[bot]`, and side-branch nightlies leaking into the Overview. This PR is complementary — it fixes the `infra_missing` line itself, which #2363 didn't touch.
