### PR TITLE
[Pallas] Add larger shapes for attention and matmul_layernorm benchmarks

### DIFF
--- a/benchmarks/run_tpu.py
+++ b/benchmarks/run_tpu.py
@@ -156,15 +156,10 @@ def _attention_shapes(
     num_shapes: int | None = None,
 ) -> list[tuple[str, tuple[Any, ...]]]:
     # First entry matches examples/attention.py main() so --num-shapes 1 gives
-    # the canonical example config.
-    # First entry mirrors examples/attention.py main(); second is the
-    # reviewer's flagship shape — much larger seq_len + head_dim so the
-    # bench exercises real LM-scale attention.
-    # 2nd shape doubles seq_len. Tried (4,32,4096,128) and (8,32,8192,128)
-    # but the autotuner default OOMs at d=128 + larger seq before the search
-    # can compute its baseline. (2,32,2048,64) is the largest that fits.
+    # the canonical example config.  Second is an LM-scale flagship shape.
     configs = [
         (2, 32, 1024, 64),
+        (8, 32, 8192, 256),
         (2, 32, 2048, 64),
         (1, 4, 512, 64),
         (1, 4, 1024, 64),
@@ -242,9 +237,7 @@ def _matmul_layernorm_shapes(
 ) -> list[tuple[str, tuple[Any, ...]]]:
     # Use larger, regular shapes than examples/matmul_layernorm.py main()
     # (which uses small/odd n=200,400 to dodge an unrelated power-of-2 bug).
-    # (4096,4096,4096) hit "Default config failed while computing baseline"
-    # — autotuner default OOMs before search starts.
-    configs = [(1024, 1024, 1024), (2048, 2048, 2048)]
+    configs = [(1024, 1024, 1024), (4096, 4096, 4096), (2048, 2048, 2048)]
     if num_shapes is not None:
         configs = configs[:num_shapes]
     return [


### PR DESCRIPTION
## Summary

The `unroll` default has been replaced by `emit_pipeline` (#2321), which means the autotuner's `BenchmarkProvider._compute_baseline()` no longer OOMs on shapes that overshoot the unroll path's VMEM budget. Drop the comments in `run_tpu.py` that described the old failure mode and add the previously-blocked larger shapes back to the benchmark configs:

* **`_attention_shapes`**: add `(8, 32, 8192, 256)` as slot 1 (canonical at slot 0). Verified on TPU — full LFBO autotune completes in ~24 min, best config is `block_sizes=[2, 512, 2048]`, `loop_orders=[[0, 1]]`, `pallas_loop_type='unroll'`, `pallas_pre_broadcast=True`, hitting **23.98 ms ≈ 733 TFLOPs**.
* **`_matmul_layernorm_shapes`**: add `(4096, 4096, 4096)` as slot 1. Verified on TPU — full LFBO autotune completes in ~1.5 min, best config `block_sizes=[1024, 512]`, `pallas_loop_type='emit_pipeline'`, `pallas_pre_broadcast=True`, hitting 0.45 ms ≈ ~305 TFLOPs.
