### PR TITLE
[Bechmarking] Default to benchmark subprocess

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -39,9 +39,6 @@ jobs:
 
     env:
       HELION_AUTOTUNE_LOG_LEVEL: INFO
-      # Run autotune benchmarks in a subprocess so deadlocked kernels are
-      # SIGKILL'd at the per-config timeout instead of hanging the job.
-      HELION_AUTOTUNE_BENCHMARK_SUBPROCESS: "1"
 
     container:
       image: ${{ inputs.image }}

--- a/helion/_compiler/_inductor/template_buffer.py
+++ b/helion/_compiler/_inductor/template_buffer.py
@@ -134,6 +134,9 @@ class _FusionAutotuneAdapter:
     def extra_cache_key(self) -> str:
         return self._fusion_context_hash
 
+    def supports_subprocess_benchmark(self) -> bool:
+        return False
+
 
 class HelionTemplateBuffer(TemplateBuffer):
     """Inductor template buffer for Helion kernel."""

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -125,6 +125,10 @@ class _AutotunableKernel(Protocol):
         """
         ...
 
+    def supports_subprocess_benchmark(self) -> bool:
+        """Whether autotuning may benchmark compiled configs in a subprocess."""
+        ...
+
     def is_cacheable(self) -> bool:
         """Whether this kernel supports the autotuning disk cache."""
         ...

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -581,6 +581,8 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             return False
         if len(self.mutated_arg_indices) > 0:
             return False
+        if not self.kernel.supports_subprocess_benchmark():
+            return False
         # Custom do_bench implementations are not shipped to the worker.
         _backend = getattr(self.config_spec, "backend", None)
         return not (_backend is not None and _backend.get_do_bench() is not None)

--- a/helion/autotuner/external.py
+++ b/helion/autotuner/external.py
@@ -183,6 +183,9 @@ class _ExternalKernelAdapter(_AutotunableKernel):
     def extra_cache_key(self) -> str:
         return ""
 
+    def supports_subprocess_benchmark(self) -> bool:
+        return True
+
     def is_cacheable(self) -> bool:
         return False
 

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -699,6 +699,9 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         """
         return ""
 
+    def supports_subprocess_benchmark(self) -> bool:
+        return True
+
     def is_cacheable(self) -> bool:
         return True
 

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -382,7 +382,7 @@ class _Settings:
     )
     autotune_benchmark_subprocess: bool = dataclasses.field(
         default_factory=functools.partial(
-            _env_get_bool, "HELION_AUTOTUNE_BENCHMARK_SUBPROCESS", False
+            _env_get_bool, "HELION_AUTOTUNE_BENCHMARK_SUBPROCESS", True
         )
     )
     autotune_benchmark_timeout: int = dataclasses.field(
@@ -575,7 +575,7 @@ class Settings(_Settings):
             "/tmp/run.csv and /tmp/run.log with per-config metrics and debug logs."
         ),
         "autotune_compile_timeout": "Timeout for Triton compilation in seconds used for autotuning. Default is 60 seconds.",
-        "autotune_benchmark_subprocess": "Run the autotune benchmark phase in a long-lived spawn subprocess so a hung/slow kernel can be killed without losing autotune progress. Opt-in via HELION_AUTOTUNE_BENCHMARK_SUBPROCESS=1. Default disabled.",
+        "autotune_benchmark_subprocess": "Run the autotune benchmark phase in a long-lived spawn subprocess so a hung/slow kernel can be killed without losing autotune progress. Enabled by default. Set HELION_AUTOTUNE_BENCHMARK_SUBPROCESS=0 to disable.",
         "autotune_benchmark_timeout": "Per-config wall-clock timeout in seconds for the subprocess benchmark phase. Only applies when autotune_benchmark_subprocess is enabled. Default 30 seconds.",
         "autotune_precompile": "Autotuner precompile mode: 'fork', 'spawn', or falsy/None to disable. Defaults to 'fork' on non-Windows platforms.",
         "autotune_precompile_jobs": "Maximum concurrent Triton precompile processes, default to cpu count.",

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -114,6 +114,7 @@ class TestAutotuneIgnoreErrors(TestCase):
             format_kernel_decorator=lambda config, s: "decorator",
             to_triton_code=lambda config: "code",
             maybe_log_repro=lambda log_func, args, config=None: None,
+            supports_subprocess_benchmark=lambda: False,
         )
         search.args = args
         search.log = AutotuningLogger(settings)
@@ -3027,6 +3028,7 @@ class TestAutotuneBudget(TestCase):
             format_kernel_decorator=lambda config, s: "decorator",
             to_triton_code=lambda config: "code",
             maybe_log_repro=lambda log_func, args, config=None: None,
+            supports_subprocess_benchmark=lambda: False,
         )
         search.args = ()
         search.log = AutotuningLogger(settings)

--- a/test/test_debug_utils.py
+++ b/test/test_debug_utils.py
@@ -165,6 +165,7 @@ class TestDebugUtils(RefEagerTestDisabled, TestCase):
                     helion.Config(block_sizes=[64], num_warps=8),
                 ],
                 autotune_precompile=False,
+                autotune_benchmark_subprocess=False,
             )
 
             torch.manual_seed(0)

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -71,6 +71,9 @@ class TestErrors(RefEagerTestDisabled, TestCase):
             ) -> str:
                 return ""
 
+            def supports_subprocess_benchmark(self) -> bool:
+                return False
+
             @property
             def env(self):
                 return _FakeEnv(device=DEVICE)
@@ -673,6 +676,9 @@ def _make_fake_kernel():
             output_origin_lines: bool | None = None,
         ) -> str:
             return ""
+
+        def supports_subprocess_benchmark(self) -> bool:
+            return False
 
         @property
         def env(self):


### PR DESCRIPTION
Turning on using a subprocess for benchmarking (https://github.com/pytorch/helion/pull/2111) by default. I've had this on on CI for about 2 weeks now and there hasn't been any issues, so it should be safe to turn on by default. This should get rid of most CUDA sticky errors, as the CUDA context is isolated to the subprocess, which will be killed/respawned if we run into an issue, rather than bringing down the entire process. We should be able to get rid of manual overrides like this from issue (https://github.com/pytorch/helion/issues/2044): https://github.com/pytorch/helion/blob/4292b2a0e2c6756fa0a0ef0b8679e92bd13559e0/helion/_compiler/tile_strategy.py#L272-L278

Benchmarking locally on B200 with HELION_AUTOTUNE_BENCHMARK_SUBPROCESS=1/0, there is no difference in compile time and perf. 
<img width="625" height="266" alt="image" src="https://github.com/user-attachments/assets/f5d29a18-dd4a-4984-bea6-e85084cc4636" />

Running on more shapes 3 times each shows the same conclusion:
<img width="807" height="522" alt="image" src="https://github.com/user-attachments/assets/7651abf7-72e8-4e83-97aa-9fb163b1b9c0" />



