### PR TITLE
Attention Perf: Multiply Q in-loop to avoid memory spillage

### DIFF
--- a/examples/attention.py
+++ b/examples/attention.py
@@ -69,12 +69,14 @@ def attention(
         m_i = hl.full([tile_b, tile_m], float("-inf"), dtype=torch.float32)
         l_i = torch.full_like(m_i, 1.0)
         acc = hl.zeros([tile_b, tile_m, head_dim], dtype=torch.float32)
-        q = q_view[tile_b, tile_m, :] * qk_scale
+        q = q_view[tile_b, tile_m, :]
         for tile_n in hl.tile(v_view.size(1)):
+            # scaling Q in-loop on-demand reduces spillage, faster than keeping pre-scaled Q
+            q_scaled = q * qk_scale
             k = k_view[tile_b, :, tile_n]
             # Keep scores in fp32 to match SDPA tolerances on bf16/fp16 inputs.
             # same as hl.dot(q, k, out_dtype=torch.float32)
-            qk = torch.bmm(q, k, torch.float32)
+            qk = torch.bmm(q_scaled, k, torch.float32)
             m_ij = torch.maximum(m_i, torch.amax(qk, -1))
             qk = qk - m_ij[:, :, None]
             p = torch.exp2(qk)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -315,11 +315,13 @@ def pallas_attention(
         m_i = hl.full([tile_b, tile_m], float("-inf"), dtype=torch.float32)
         l_i = torch.full_like(m_i, 1.0)
         acc = hl.zeros([tile_b, tile_m, head_dim], dtype=torch.float32)
-        q = q_view[tile_b, tile_m, :] * qk_scale
+        q = q_view[tile_b, tile_m, :]
         for tile_n in hl.tile(v_view.size(1)):
+            # scaling Q in-loop on-demand reduces spillage, faster than keeping pre-scaled Q
+            q_scaled = q * qk_scale
             k = k_view[tile_b, :, tile_n]
             # same as hl.dot(q, k, out_dtype=torch.float32)
-            qk = torch.bmm(q, k, torch.float32)
+            qk = torch.bmm(q_scaled, k, torch.float32)
             m_ij = torch.maximum(m_i, torch.amax(qk, -1))
             qk = qk - m_ij[:, :, None]
             p = torch.exp2(qk)


### PR DESCRIPTION
Stacked PRs:
 * #2374
 * __->__#2373


--- --- ---

Optimization found by claude, by comparing the current Helion kernel with [this reference impl](https://github.com/cota/Helion-Pallas-Kernels/blob/6fc7cadb720710f3e3ea2a91dd5c20e31848760b/examples/attention.py)

Previously, the Helion attention kernel pre-multiplies `Q` with `q_scale` before the device loop. While this is less work for the VALU, this requires more registers to store the scaled Q which ends up causing the kernel to spend more time moving data.

On TPU, this change improves TFLOPs from 622 TFLOPs to 633 TFLOPs.  (optimal block sizes changes from [2, 2048, 1024] to `[1, 8192, 256]` for emit_pipeline)