### PR TITLE
Attention Perf: Transpose blocked K right before QK instead of pre-transposing before the kernel

### DIFF
--- a/examples/attention.py
+++ b/examples/attention.py
@@ -61,7 +61,7 @@ def attention(
     assert head_dim == k_in.size(-1) == v_in.size(-1)
     q_view = q_in.reshape([-1, m_dim, head_dim])
     v_view = v_in.reshape([-1, n_dim, head_dim])
-    k_view = k_in.reshape([-1, n_dim, head_dim]).transpose(1, 2)
+    k_view = k_in.reshape([-1, n_dim, head_dim])
     out = torch.empty_like(q_view)
     sm_scale = 1.0 / math.sqrt(head_dim)
     qk_scale = sm_scale * 1.44269504  # 1/log(2)
@@ -73,10 +73,10 @@ def attention(
         for tile_n in hl.tile(v_view.size(1)):
             # scaling Q in-loop on-demand reduces spillage, faster than keeping pre-scaled Q
             q_scaled = q * qk_scale
-            k = k_view[tile_b, :, tile_n]
+            k = k_view[tile_b, tile_n, :]
             # Keep scores in fp32 to match SDPA tolerances on bf16/fp16 inputs.
             # same as hl.dot(q, k, out_dtype=torch.float32)
-            qk = torch.bmm(q_scaled, k, torch.float32)
+            qk = torch.bmm(q_scaled, k.transpose(1, 2), torch.float32)
             m_ij = torch.maximum(m_i, torch.amax(qk, -1))
             qk = qk - m_ij[:, :, None]
             p = torch.exp2(qk)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -306,7 +306,7 @@ def pallas_attention(
     head_dim = hl.specialize(q_in.size(-1))
     assert head_dim == k_in.size(-1) == v_in.size(-1)
     q_view = q_in.reshape([-1, m_dim, head_dim])
-    k_view = k_in.reshape([-1, n_dim, head_dim]).transpose(1, 2)
+    k_view = k_in.reshape([-1, n_dim, head_dim])
     v_view = v_in.reshape([-1, n_dim, head_dim])
     out = torch.empty_like(q_view)
     sm_scale = 1.0 / math.sqrt(head_dim)
@@ -319,9 +319,10 @@ def pallas_attention(
         for tile_n in hl.tile(v_view.size(1)):
             # scaling Q in-loop on-demand reduces spillage, faster than keeping pre-scaled Q
             q_scaled = q * qk_scale
-            k = k_view[tile_b, :, tile_n]
+            k = k_view[tile_b, tile_n, :]
+            # Keep scores in fp32 to match SDPA tolerances on bf16/fp16 inputs.
             # same as hl.dot(q, k, out_dtype=torch.float32)
-            qk = torch.bmm(q_scaled, k, torch.float32)
+            qk = torch.bmm(q_scaled, k.transpose(1, 2), torch.float32)
             m_ij = torch.maximum(m_i, torch.amax(qk, -1))
             qk = qk - m_ij[:, :, None]
             p = torch.exp2(qk)
@@ -1059,7 +1060,7 @@ class TestPallas(TestCase):
             "((4, 128, 128), 'jnp.float32', 'vmem'), "
             "((4, 128, 128), 'jnp.float32', 'vmem'), "
             "((4, 128, 256), 'jnp.float32', 'vmem'), "
-            "((4, 256, 128), 'jnp.float32', 'vmem'), "
+            "((4, 128, 256), 'jnp.float32', 'vmem'), "
             "((), None, 'dma_semaphore'), "
             "((4, 128, 256), 'jnp.float32', 'vmem'), "
             "((), None, 'dma_semaphore')]",


### PR DESCRIPTION
Optimization found by claude, by comparing the current Helion kernel with [this reference impl](https://github.com/cota/Helion-Pallas-Kernels/blob/6fc7cadb720710f3e3ea2a91dd5c20e31848760b/examples/attention.py)

Previously, The Helion-generated kernel reshapes and transposes K before the kernel: `k_view = k_in.reshape([-1, n_dim, head_dim]).transpose(0, 2, 1)` producing shape `[B*H, D, S]`. And then during matmul (`jax.dot_general`) it then uses a standard contraction `dimension_numbers=(((2,), (1,)), ((0,), (0,)))`.

This causes sub-optimal DMA patterns because the transposed K layout in HBM has non-contiguous memory access for the pipeline's sequential block reads along the sequence dimension.

The PR modifies the kernel by keeping K contiguous, and only transposes right before the matmul. On top of the previous PR (#2373) this improves the TFLOPs from 633 to 652