### PR TITLE
[Autotuner] Confirm suspicious subprocess timings

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -56,6 +56,12 @@ if TYPE_CHECKING:
     from helion.autotuner.effort_profile import AutotuneEffortProfile
 
 
+# Use the standard do_bench effort for confirmation instead of the adaptive
+# rebenchmark repeat, which can amplify a single optimistic subprocess timing.
+_SUSPICIOUS_REBENCHMARK_WARMUP = 25
+_SUSPICIOUS_REBENCHMARK_REP = 100
+
+
 class _HasDeviceAndProcessGroupName(Protocol):
     device: torch.device
     process_group_name: str | None
@@ -955,6 +961,11 @@ class PopulationBasedSearch(BaseSearch):
             new_timings = bench_fn(iterator, repeat=repeat, desc=desc)
         else:
             new_timings = bench_fn(iterator, repeat=repeat)
+        new_timings = self._confirm_suspicious_rebenchmark_timings(
+            members,
+            new_timings,
+            desc=desc,
+        )
         new_timings = sync_object(
             new_timings, process_group_name=self.kernel.env.process_group_name
         )
@@ -962,6 +973,42 @@ class PopulationBasedSearch(BaseSearch):
             m.perfs.append(t)
             if t < self.best_perf_so_far:
                 self.best_perf_so_far = t
+
+    def _confirm_suspicious_rebenchmark_timings(
+        self,
+        members: list[PopulationMember],
+        timings: list[float],
+        *,
+        desc: str,
+    ) -> list[float]:
+        ratio = self.settings.get_suspicious_rebenchmark_ratio()
+        if ratio is None or ratio <= 0:
+            return timings
+
+        suspicious = [
+            i
+            for i, (member, timing) in enumerate(zip(members, timings, strict=True))
+            if math.isfinite(timing)
+            and math.isfinite(member.perf)
+            and timing < ratio * member.perf
+        ]
+        if not suspicious:
+            return timings
+
+        confirmed = self.benchmark_provider.benchmark_isolated(
+            [members[i].fn for i in suspicious],
+            warmup=_SUSPICIOUS_REBENCHMARK_WARMUP,
+            rep=_SUSPICIOUS_REBENCHMARK_REP,
+            desc=f"{desc}: confirming suspicious timings",
+        )
+        if confirmed is None:
+            return timings
+
+        updated = list(timings)
+        for i, timing in zip(suspicious, confirmed, strict=True):
+            if timing is not None:
+                updated[i] = timing
+        return updated
 
     def rebenchmark_population(
         self,

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -301,6 +301,22 @@ class BenchmarkProvider(abc.ABC):
         """
         ...
 
+    def benchmark_isolated(
+        self,
+        fns: list[Callable[..., object]],
+        *,
+        warmup: int,
+        rep: int,
+        desc: str = "Benchmarking",
+    ) -> list[float | None] | None:
+        """Benchmark already-validated functions in an isolated subprocess.
+
+        Return ``None`` when the provider cannot support the isolated path or
+        per-function ``None`` when a timing could not be confirmed and callers
+        should keep the prior timing for that function.
+        """
+        return None
+
     @abc.abstractmethod
     def setup(self) -> None:
         """Prepare resources needed before benchmarking begins (e.g. tmpdir)."""
@@ -985,26 +1001,10 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         we classified and handled, or ``None`` if the subprocess path cannot
         handle this config and the caller should fall back to in-process.
         """
-        if self._precompile_args_path is None:
-            return None
         try:
-            fn_spec = _serialize_compiled_fn(fn)
-        except RuntimeError:
-            return None
-
-        if self._benchmark_worker is None:
-            self._benchmark_worker = BenchmarkWorker(device=None)
-
-        job = BenchmarkJob(
-            fn_spec=fn_spec,
-            args_path=self._precompile_args_path,
-            warmup=1,
-            rep=50,
-        )
-        timeout = float(self.settings.autotune_benchmark_timeout)
-
-        try:
-            latency = self._benchmark_worker.run(job, timeout=timeout)
+            latency = self._run_subprocess_benchmark_job(fn, warmup=1, rep=50)
+            if latency is None:
+                return None
         except BenchmarkSubprocessError as e:
             # Timeout or unexpected worker exit; skip config and continue.
             self.log.warning(f"Benchmark subprocess failed for {config!r}: {e}")
@@ -1046,3 +1046,71 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                 return inf
 
         return float(latency)
+
+    def _run_subprocess_benchmark_job(
+        self,
+        fn: CompiledConfig,
+        *,
+        warmup: int,
+        rep: int,
+    ) -> float | None:
+        if self._precompile_args_path is None:
+            return None
+        try:
+            fn_spec = _serialize_compiled_fn(fn)
+        except RuntimeError:
+            return None
+
+        if self._benchmark_worker is None:
+            self._benchmark_worker = BenchmarkWorker(device=None)
+
+        job = BenchmarkJob(
+            fn_spec=fn_spec,
+            args_path=self._precompile_args_path,
+            warmup=warmup,
+            rep=rep,
+        )
+        return float(
+            self._benchmark_worker.run(
+                job,
+                timeout=float(self.settings.autotune_benchmark_timeout),
+            )
+        )
+
+    def benchmark_isolated(
+        self,
+        fns: list[Callable[..., object]],
+        *,
+        warmup: int,
+        rep: int,
+        desc: str = "Benchmarking",
+    ) -> list[float | None] | None:
+        if not self._subprocess_benchmark_enabled():
+            return None
+        if self.settings.autotune_benchmark_fn is not None:
+            return None
+
+        timings: list[float | None] = []
+        for fn in fns:
+            try:
+                timing = self._run_subprocess_benchmark_job(
+                    cast("CompiledConfig", fn),
+                    warmup=warmup,
+                    rep=rep,
+                )
+            except BenchmarkSubprocessError as e:
+                self.log.warning(f"{desc} subprocess failed: {e}")
+                timing = None
+            except Exception as e:
+                e.__traceback__ = None
+                if match_unrecoverable_runtime_error(e):
+                    self.log.warning(f"{desc} sticky CUDA error skipped: {e}")
+                    # The confirmation re-ran a previously accepted candidate in
+                    # an isolated worker; a sticky CUDA error means that config is
+                    # still unsafe, so remove it from contention.
+                    timing = inf
+                else:
+                    self.log.debug(f"{desc} subprocess raised: {type(e).__name__}: {e}")
+                    timing = None
+            timings.append(None if timing is None else float(timing))
+        return timings

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -423,6 +423,12 @@ class _Settings:
             "HELION_REBENCHMARK_THRESHOLD",
         )
     )
+    autotune_suspicious_rebenchmark_ratio: float | None = dataclasses.field(
+        default_factory=functools.partial(
+            _env_get_optional_float,
+            "HELION_AUTOTUNE_SUSPICIOUS_REBENCHMARK_RATIO",
+        )
+    )
     autotune_search_acf: list[str] = dataclasses.field(
         default_factory=functools.partial(
             _env_get_str_list, "HELION_AUTOTUNE_SEARCH_ACF"
@@ -582,6 +588,7 @@ class Settings(_Settings):
         "autotune_random_seed": "Seed used for autotuner random number generation. Defaults to HELION_AUTOTUNE_RANDOM_SEED or a time-based seed.",
         "autotune_accuracy_check": "If True, validate candidate configs against the baseline kernel output before accepting them during autotuning.",
         "autotune_rebenchmark_threshold": "If a config is within threshold*best_perf, re-benchmark it to avoid outliers. Defaults to effort profile value. Set HELION_REBENCHMARK_THRESHOLD to override.",
+        "autotune_suspicious_rebenchmark_ratio": "When subprocess benchmarking is enabled, recheck rebenchmark timings below ratio*previous_timing before accepting them. Defaults to 0.9. Set HELION_AUTOTUNE_SUSPICIOUS_REBENCHMARK_RATIO=0 to disable.",
         "autotune_search_acf": "List of PTXAS Advanced Controls Files (ACFs) to search during autotuning. ACFs are highly specialized configurations for specific hardware and use cases; when autotuning with ACFs, default -O3 is always considered. Empty list disables.",
         "autotune_progress_bar": "If True, show progress bar during autotuning. Default is True. Set HELION_AUTOTUNE_PROGRESS_BAR=0 to disable.",
         "autotune_max_generations": "Override the maximum number of generations for Pattern Search and Differential Evolution Search autotuning algorithms with HELION_AUTOTUNE_MAX_GENERATIONS=N or @helion.kernel(autotune_max_generations=N).",
@@ -762,6 +769,13 @@ class Settings(_Settings):
             return self.autotune_rebenchmark_threshold
 
         return get_effort_profile(self.autotune_effort).rebenchmark_threshold
+
+    def get_suspicious_rebenchmark_ratio(self) -> float | None:
+        if self.autotune_suspicious_rebenchmark_ratio is not None:
+            return self.autotune_suspicious_rebenchmark_ratio
+        if self.autotune_benchmark_subprocess:
+            return 0.9
+        return None
 
     def _check_ref_eager_mode_before_print_output_code(self) -> None:
         """

--- a/test/test_benchmark_worker.py
+++ b/test/test_benchmark_worker.py
@@ -9,7 +9,10 @@ from pathlib import Path
 import random
 import signal
 import time
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
+from typing import Any
+from typing import cast
 import unittest
 from unittest.mock import patch
 
@@ -20,14 +23,17 @@ from helion._testing import RefEagerTestDisabled
 from helion._testing import import_path
 from helion._testing import onlyBackends
 from helion._testing import skipIfXPU
+from helion.autotuner.base_search import PopulationBasedSearch
+from helion.autotuner.base_search import PopulationMember
 from helion.autotuner.benchmark_provider import LocalBenchmarkProvider
 from helion.autotuner.benchmark_worker import BenchmarkTimeout
 from helion.autotuner.benchmark_worker import BenchmarkWorker
 from helion.autotuner.benchmark_worker import BenchmarkWorkerDied
 from helion.autotuner.random_search import RandomSearch
+from helion.runtime.config import Config
+from helion.runtime.settings import Settings
 
 if TYPE_CHECKING:
-    from helion.runtime.config import Config
     from helion.runtime.kernel import CompiledConfig
 
 
@@ -102,6 +108,114 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
             self.assertFalse(worker.alive())
         finally:
             worker.shutdown()
+
+
+class TestSuspiciousRebenchmark(unittest.TestCase):
+    def test_subprocess_benchmark_defaults_suspicious_rebenchmark_ratio(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HELION_AUTOTUNE_SUSPICIOUS_REBENCHMARK_RATIO", None)
+            self.assertEqual(
+                Settings(
+                    autotune_benchmark_subprocess=True
+                ).get_suspicious_rebenchmark_ratio(),
+                0.9,
+            )
+            self.assertIsNone(
+                Settings(
+                    autotune_benchmark_subprocess=False
+                ).get_suspicious_rebenchmark_ratio()
+            )
+        self.assertEqual(
+            Settings(
+                autotune_benchmark_subprocess=True,
+                autotune_suspicious_rebenchmark_ratio=0.75,
+            ).get_suspicious_rebenchmark_ratio(),
+            0.75,
+        )
+
+    def test_confirm_suspicious_rebenchmark_timings(self) -> None:
+        class FakeProvider:
+            def __init__(self) -> None:
+                self.confirm_fns: list[object] | None = None
+                self.confirm_warmup: int | None = None
+                self.confirm_rep: int | None = None
+
+            def benchmark_isolated(
+                self,
+                fns: list[object],
+                *,
+                warmup: int,
+                rep: int,
+                desc: str,
+            ) -> list[float | None]:
+                self.confirm_fns = fns
+                self.confirm_warmup = warmup
+                self.confirm_rep = rep
+                return [0.92]
+
+        def fn_a() -> None:
+            pass
+
+        def fn_b() -> None:
+            pass
+
+        provider = FakeProvider()
+        search = SimpleNamespace(
+            settings=Settings(autotune_benchmark_subprocess=True),
+            benchmark_provider=provider,
+        )
+        members = [
+            PopulationMember(fn=fn_a, perfs=[1.00], flat_values=[], config=Config()),
+            PopulationMember(fn=fn_b, perfs=[1.00], flat_values=[], config=Config()),
+        ]
+
+        timings = PopulationBasedSearch._confirm_suspicious_rebenchmark_timings(
+            cast("Any", search),
+            members,
+            [0.70, 0.95],
+            desc="verify",
+        )
+
+        self.assertEqual(provider.confirm_fns, [fn_a])
+        self.assertEqual(provider.confirm_warmup, 25)
+        self.assertEqual(provider.confirm_rep, 100)
+        self.assertEqual(timings, [0.92, 0.95])
+
+    def test_confirm_suspicious_rebenchmark_keeps_unconfirmed_timings(self) -> None:
+        class FakeProvider:
+            def benchmark_isolated(
+                self,
+                fns: list[object],
+                *,
+                warmup: int,
+                rep: int,
+                desc: str,
+            ) -> list[float | None]:
+                return [0.92, None]
+
+        def fn_a() -> None:
+            pass
+
+        def fn_b() -> None:
+            pass
+
+        search = SimpleNamespace(
+            settings=Settings(autotune_benchmark_subprocess=True),
+            benchmark_provider=FakeProvider(),
+        )
+        members = [
+            PopulationMember(fn=fn_a, perfs=[1.00], flat_values=[], config=Config()),
+            PopulationMember(fn=fn_b, perfs=[1.00], flat_values=[], config=Config()),
+        ]
+
+        timings = PopulationBasedSearch._confirm_suspicious_rebenchmark_timings(
+            cast("Any", search),
+            members,
+            [0.70, 0.80],
+            desc="verify",
+        )
+
+        self.assertEqual(timings, [0.92, 0.80])
 
 
 # Subprocess benchmarking depends on Backend.supports_precompile(); only the


### PR DESCRIPTION
Benchmarking is noisy. Sometimes we see a big variance between initial benchmarking and rebench. This can lead to autotuner exploring different paths. Empirically, I've seen it goes to paths which leads to exploring more configs, leading to higher compile times, or lands on sub par perf. 
This feature is intended to filter optimistic timing outliers that can make autotuning select a config that only looked best due to benchmark noise. if a rebenchmark result is much faster than the config's prior timing, we confirm that result with an isolated benchmark before accepting it. 

Benchmarking on H100, this improves geomean compile time by 16% and perf by 7%.
<img width="927" height="236" alt="image" src="https://github.com/user-attachments/assets/f49665d6-2d03-4099-b567-2a722d5f6dfc" />
Running on more shapes (3 times each) confirm the results above. For shape 3 and 4, I've logged how many times suspicious rebenchmark actually fires (hundreds of times) and whether it is actually helpful for overall compile time (yes):
<img width="1263" height="453" alt="image" src="https://github.com/user-attachments/assets/715cea1c-afaa-4591-b9fd-7f88622ba1ae" />


B200 did not change materially.
<img width="910" height="157" alt="image" src="https://github.com/user-attachments/assets/52893b32-fc36-4ab2-9250-54811b50360c" />

similar results on CI for H100:
<img width="1667" height="589" alt="image" src="https://github.com/user-attachments/assets/888d39b0-f92f-4b69-a7f4-9d2c4c54d451" />

CI for B200:
<img width="1674" height="588" alt="image" src="https://github.com/user-attachments/assets/201d7f0a-96d6-4d4f-9d22-805c39e70d3f" />


