### PR TITLE
[cutedsl] Drive matmul warp roles from generated warp-spec records

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -44,6 +44,7 @@ from .layout import MatmulExecutionKind
 from .layout import MatmulExecutionPlan
 from .matmul_utils import analyze_direct_grouped_n_loads
 from .mma_support import get_cute_mma_support
+from .strategies import warp_spec_from_config
 from .tcgen05_constants import TCGEN05_AB_CONSUMER_PHASE_MODE_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_AB_CONSUMER_PHASE_MODE_NORMAL
 from .tcgen05_constants import TCGEN05_AB_CONSUMER_PHASE_MODE_PHASE1
@@ -81,6 +82,7 @@ if TYPE_CHECKING:
     from ..device_function import DeviceFunction
     from ..generate_ast import GenerateAST
     from ..inductor_lowering import CodegenState
+    from .strategies import Tcgen05WarpSpec
 
 
 _TRACE_THROUGH_TARGETS = {
@@ -139,6 +141,23 @@ class _Tcgen05LayoutPlan:
     acc_producer_state: str
     acc_consumer_state: str
     epilogue_rest_mode: str
+
+
+@dataclass(frozen=True)
+class _Tcgen05SchedPipelinePlan:
+    """Generated CuTe variable names for the scheduler-broadcast pipeline.
+
+    Pure name container, mirroring ``_Tcgen05LayoutPlan``: each field
+    is the textual identifier of a value materialized in the kernel
+    prefix when ``_emit_sched_pipeline_setup`` runs.
+    """
+
+    barriers: str
+    producer_group: str
+    consumer_group: str
+    pipeline: str
+    producer_state: str
+    consumer_state: str
 
 
 class _ConfigLike(Protocol):
@@ -1903,25 +1922,37 @@ def _emit_mma_pipeline(
     tcgen05_c_stage_count_value = _tcgen05_config_int(
         df.config, "tcgen05_c_stages", _tcgen05_c_stage_count(bn)
     )
-    tcgen05_epi_warp_count_value = _tcgen05_epi_warp_count(
-        df.config, cta_thread_count=tcgen05_cta_thread_count
-    )
-    tcgen05_tmem_barrier_thread_count_value = _tcgen05_tmem_barrier_thread_count(
-        tcgen05_epi_warp_count_value
-    )
-    # Each CtaGroup.TWO CTA has its own epilogue warps consuming the
-    # distributed accumulator slot, so the acc empty barrier expects each
-    # CTA's epi warp leaders. The CtaGroup.ONE clustered fallback remains
-    # on the single-CTA count until it has separate runtime coverage.
-    tcgen05_acc_consumer_arrive_count_value = tcgen05_epi_warp_count_value * (
-        2 if tcgen05_is_two_cta else 1
-    )
     tcgen05_defer_pipeline_sync_arg = (
         ", defer_sync=True" if tcgen05_use_cluster_deferred_pipelines else ""
     )
     tcgen05_matmul_plan: CuteTcgen05MatmulPlan | None = None
     tcgen05_mma_owner_active: str | None = None
+    # Initialized inside the ``mma_impl == "tcgen05"`` branch so the
+    # non-tcgen05 path doesn't pay for warp-spec / barrier-count work
+    # it never uses; consumed only at later tcgen05-gated emission
+    # sites that share this `if mma_impl == "tcgen05":` predicate.
+    tcgen05_epi_warp_count_value = 0
+    tcgen05_tmem_barrier_thread_count_value = 0
+    tcgen05_acc_consumer_arrive_count_value = 0
     if mma_impl == "tcgen05":
+        # Use ``warp_spec.ab_load_warps`` so the strategy data model
+        # stays the source of truth for warp role IDs; ``epi_warps``
+        # flows the same way via ``_tcgen05_epi_warp_count`` below.
+        tcgen05_warp_spec = warp_spec_from_config(df.config)
+        tcgen05_epi_warp_count_value = _tcgen05_epi_warp_count(
+            tcgen05_warp_spec, cta_thread_count=tcgen05_cta_thread_count
+        )
+        tcgen05_tmem_barrier_thread_count_value = _tcgen05_tmem_barrier_thread_count(
+            tcgen05_epi_warp_count_value
+        )
+        # Each CtaGroup.TWO CTA has its own epilogue warps consuming
+        # the distributed accumulator slot, so the acc empty barrier
+        # expects each CTA's epi warp leaders. The CtaGroup.ONE
+        # clustered fallback remains on the single-CTA count until
+        # it has separate runtime coverage.
+        tcgen05_acc_consumer_arrive_count_value = tcgen05_epi_warp_count_value * (
+            2 if tcgen05_is_two_cta else 1
+        )
         tcgen05_matmul_plan = CuteTcgen05MatmulPlan(
             bm=bm,
             bn=bn,
@@ -1939,6 +1970,7 @@ def _emit_mma_pipeline(
             ab_stage_count=tcgen05_ab_stage_count_value,
             c_stage_count=tcgen05_c_stage_count_value,
             epi_warp_count=tcgen05_epi_warp_count_value,
+            ab_load_warp_count=tcgen05_warp_spec.ab_load_warps,
         )
         assert tcgen05_plan is not None
         tcgen05_mma_owner_active = _tcgen05_two_cta_owner_predicate(
@@ -3334,12 +3366,16 @@ def _tcgen05_use_2cta_instrs(*, bm: int, cluster_m: int) -> bool:
     return cluster_m == 2 and bm == TCGEN05_TWO_CTA_BLOCK_M
 
 
-def _tcgen05_epi_warp_count(config: object, *, cta_thread_count: int) -> int:
+def _tcgen05_epi_warp_count(
+    warp_spec: Tcgen05WarpSpec, *, cta_thread_count: int
+) -> int:
     """Pick the epilogue warp count for a tcgen05 matmul kernel.
 
-    Returns at most ``cta_thread_count // 32`` warps, capped by the
-    ``tcgen05_num_epi_warps`` autotune knob (default 4). The other roles
-    (one MMA exec warp + one A/B load warp) are added on top of this in
+    Returns at most ``cta_thread_count // 32`` warps, capped by
+    ``warp_spec.epi_warps`` (the strategy data model's source of
+    truth, sourced from the ``tcgen05_num_epi_warps`` autotune
+    knob, default 4). The other roles (one MMA exec warp + one A/B
+    load warp) are added on top of this in
     ``CuteTcgen05MatmulPlan.role_warp_count``.
 
     Today the only correct value for the SIMT-store epilogue is 4: the
@@ -3358,10 +3394,7 @@ def _tcgen05_epi_warp_count(config: object, *, cta_thread_count: int) -> int:
     the GMEM store. See ``cute_plan.md`` Section 2.
     """
     cta_warp_count = max(1, cta_thread_count // 32)
-    return min(
-        cta_warp_count,
-        max(1, _tcgen05_config_int(config, "tcgen05_num_epi_warps", 4)),
-    )
+    return min(cta_warp_count, max(1, warp_spec.epi_warps))
 
 
 def _mma_impl_matches_problem_shape(
@@ -3629,6 +3662,120 @@ def _make_tcgen05_layout_plan_setup(
         ),
         statement_from_string(
             f"{plan.epilogue_rest_mode} = cute.make_layout(1, stride=0)"
+        ),
+    ]
+
+
+def _new_tcgen05_sched_pipeline_plan(
+    df: DeviceFunction,
+) -> _Tcgen05SchedPipelinePlan:
+    """Allocate variable names for the scheduler-broadcast pipeline.
+
+    The ``tcgen05_sched_pipeline_*`` prefix family is shared with
+    the existing cluster_m=2 ONE-CTA bridge emission in
+    ``program_id._build_tcgen05_persistent_layout``: ``df.new_var``
+    appends an incrementing suffix so the two emissions cannot
+    actually collide, but a future cycle that consolidates the two
+    paths should drive both call sites through this allocator.
+    """
+    return _Tcgen05SchedPipelinePlan(
+        barriers=df.new_var("tcgen05_sched_pipeline_mbars"),
+        producer_group=df.new_var("tcgen05_sched_pipeline_producer_group"),
+        consumer_group=df.new_var("tcgen05_sched_pipeline_consumer_group"),
+        pipeline=df.new_var("tcgen05_sched_pipeline"),
+        producer_state=df.new_var("tcgen05_sched_pipeline_producer_state"),
+        consumer_state=df.new_var("tcgen05_sched_pipeline_consumer_state"),
+    )
+
+
+def _emit_sched_pipeline_setup(
+    plan: _Tcgen05SchedPipelinePlan,
+    *,
+    sched_stage_count: int,
+    consumer_arrive_count: int,
+    cluster_size: int,
+    defer_sync: bool,
+) -> list[ast.AST]:
+    """Emit the prefix statements that construct the sched pipeline.
+
+    Mirrors Quack's ``make_sched_pipeline`` in
+    ``quack/quack/gemm_sm100.py``. The cluster_m=2 ONE-CTA bridge
+    diagnostic in
+    ``program_id.Tcgen05PersistentProgramIDs._build_tcgen05_persistent_layout``
+    already inlines an equivalent emission for a different role
+    topology (peer-CTA work-tile publish via
+    ``_cute_store_shared_remote_x4``); G2-C should consider
+    consolidating that path onto this helper rather than carrying
+    two parallel emitters.
+
+    Parameters:
+
+    - ``consumer_arrive_count``: caller-supplied total number of
+      consumer arrivals per stage. Quack's ``make_sched_pipeline``
+      uses ``warps_per_cta * cluster_size`` *including* the
+      scheduler warp itself; the bridge diagnostic in
+      ``program_id.py`` uses ``cluster_m`` (one peer CTA per
+      arrival).
+    - ``cluster_size``: cluster-multicast factor. ``> 1`` causes
+      ``consumer_mask=cutlass.Int32(0)`` to be emitted, matching
+      the wrapping convention of the existing scheduler emission;
+      ``== 1`` omits the mask. Assumes the leader CTA sits at
+      cluster index 0 — the helper does not parameterize a
+      different leader.
+    - ``defer_sync``: emits ``defer_sync=True`` so the pipeline
+      participates in the cluster-wide deferred-init protocol
+      coordinated via ``pipeline_init_arrive`` /
+      ``pipeline_init_wait``. The caller threads
+      ``tcgen05_use_cluster_deferred_pipelines`` (see
+      ``cute_mma._codegen_cute_mma``) the same way the AB / acc
+      pipelines do via ``tcgen05_defer_pipeline_sync_arg``;
+      forgetting this on a clustered call site risks barrier-init
+      ordering hangs.
+
+    ``num_stages`` and ``make_pipeline_state`` count arguments are
+    bare ints (matching the existing AB / acc / c pipeline
+    emissions), but the SMEM mbar size and the consumer-arrive
+    count are wrapped in ``cutlass.Int32(...)`` literals (also
+    matching the existing emissions and the established pattern in
+    ``program_id.py``'s scheduler emission). No named compile-time
+    constants are materialized — same convention as
+    ``_make_tcgen05_layout_plan_setup``.
+    """
+    extra_args = ""
+    if cluster_size > 1:
+        extra_args += ", consumer_mask=cutlass.Int32(0)"
+    if defer_sync:
+        extra_args += ", defer_sync=True"
+    return [
+        statement_from_string(
+            f"{plan.barriers} = cute.arch.alloc_smem("
+            f"cutlass.Int64, cutlass.Int32({sched_stage_count * 2}))"
+        ),
+        statement_from_string(
+            f"{plan.producer_group} = "
+            "cutlass.pipeline.CooperativeGroup("
+            "cutlass.pipeline.Agent.Thread)"
+        ),
+        statement_from_string(
+            f"{plan.consumer_group} = "
+            "cutlass.pipeline.CooperativeGroup("
+            f"cutlass.pipeline.Agent.Thread, cutlass.Int32({consumer_arrive_count}))"
+        ),
+        statement_from_string(
+            f"{plan.pipeline} = cutlass.pipeline.PipelineAsync.create("
+            f"num_stages={sched_stage_count}, "
+            f"producer_group={plan.producer_group}, "
+            f"consumer_group={plan.consumer_group}, "
+            f"barrier_storage={plan.barriers}"
+            f"{extra_args})"
+        ),
+        statement_from_string(
+            f"{plan.producer_state} = cutlass.pipeline.make_pipeline_state("
+            f"cutlass.pipeline.PipelineUserType.Producer, {sched_stage_count})"
+        ),
+        statement_from_string(
+            f"{plan.consumer_state} = cutlass.pipeline.make_pipeline_state("
+            f"cutlass.pipeline.PipelineUserType.Consumer, {sched_stage_count})"
         ),
     ]
 

--- a/helion/_compiler/cute/strategies.py
+++ b/helion/_compiler/cute/strategies.py
@@ -17,6 +17,10 @@ from __future__ import annotations
 
 import dataclasses
 import enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 class Tcgen05Strategy(str, enum.Enum):
@@ -272,8 +276,12 @@ TCGEN05_WARP_SPEC_DEFAULTS_BY_KEY: dict[str, int] = {
 }
 
 
-def warp_spec_from_config(config: dict[str, object]) -> Tcgen05WarpSpec:
+def warp_spec_from_config(config: Mapping[str, object]) -> Tcgen05WarpSpec:
     """Read warp-spec fields out of a normalized config.
+
+    Accepts any ``Mapping[str, object]`` (e.g. ``dict`` or
+    ``helion.Config``) so the codegen path can pass ``df.config``
+    directly without unwrapping its inner dict.
 
     ``epi_warps`` is sourced from ``tcgen05_num_epi_warps`` — the
     existing single source of truth — so a user cannot simultaneously
@@ -302,7 +310,7 @@ def warp_spec_from_config(config: dict[str, object]) -> Tcgen05WarpSpec:
 
 
 def layout_overrides_from_config(
-    config: dict[str, object],
+    config: Mapping[str, object],
 ) -> Tcgen05LayoutOverrides:
     """Read layout-override fields out of a normalized config."""
 

--- a/test/golden/__init__.py
+++ b/test/golden/__init__.py
@@ -1,0 +1,13 @@
+"""Pinned golden files for CuTe codegen byte-identity tests.
+
+Each ``*.py.expected`` file in this directory is the captured
+``to_triton_code()`` output for a specific tcgen05 strategy /
+seed-config combination. The corresponding ``_*_kernel.py`` file
+hosts the matmul kernel definition at a stable file path so the
+embedded ``src[<file>:<line>]`` comments do not drift when the
+test file changes.
+
+See ``test_cute_lowerings.py``'s
+``test_tcgen05_role_local_monolithic_byte_identical_golden`` for
+the read site and update protocol (``EXPECTTEST_ACCEPT=1``).
+"""

--- a/test/golden/_tcgen05_role_local_monolithic_4096_bf16_kernel.py
+++ b/test/golden/_tcgen05_role_local_monolithic_4096_bf16_kernel.py
@@ -1,0 +1,37 @@
+"""Pinned matmul kernel for the byte-identity golden test.
+
+Hosts the kernel definition at a stable file path so the
+``src[<file>:<line>]`` comments embedded in the generated kernel
+do not drift when the test file changes. Pair file:
+``test/golden/tcgen05_role_local_monolithic_4096_bf16.py.expected``
+encodes ``bound.to_triton_code(seed_config)`` for the retained
+``ROLE_LOCAL_MONOLITHIC`` seed (cute_plan.md §10.1).
+
+Edits here change line numbers in the embedded ``src[...]:``
+comments and break byte-identity; the
+``test_tcgen05_role_local_monolithic_byte_identical_golden`` test
+catches the drift, so re-run with ``EXPECTTEST_ACCEPT=1`` after any
+intentional change here.
+"""
+
+from __future__ import annotations
+
+import torch
+
+import helion
+import helion.language as hl
+
+
+@helion.kernel(backend="cute")
+def cute_matmul_role_local_monolithic_4096_bf16(
+    x: torch.Tensor, y: torch.Tensor
+) -> torch.Tensor:
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+        out[tile_m, tile_n] = acc.to(x.dtype)
+    return out

--- a/test/golden/tcgen05_role_local_monolithic_4096_bf16.py.expected
+++ b/test/golden/tcgen05_role_local_monolithic_4096_bf16.py.expected
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import torch
+import helion
+import cutlass
+import cutlass.cute as cute
+from helion.runtime import default_cute_launcher as _default_cute_launcher
+
+_BLOCK_SIZE_0 = 256
+_BLOCK_SIZE_1 = 256
+_BLOCK_SIZE_2 = 128
+
+@cute.kernel
+def _helion_cute_matmul_role_local_monolithic_4096_bf16(x, y, out, tma_atom_a, tma_tensor_a, tma_atom_b, tma_tensor_b, tcgen05_tma_store_atom, tcgen05_tma_store_tensor):
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:32]: for tile_m, tile_n in hl.tile([m, n]):
+    num_blocks_0 = (4096 + _BLOCK_SIZE_0 - 1) // _BLOCK_SIZE_0
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:33]: acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+    acc = cutlass.Float32(0.0)
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:35]: acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+    tcgen05_warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    tcgen05_lane_idx = cute.arch.lane_idx()
+    mma_tidx = cutlass.Int32(cute.arch.thread_idx()[0]) + cutlass.Int32(cute.arch.thread_idx()[1]) * cutlass.Int32(32)
+    mma_copy_tidx = mma_tidx
+    mma_active = cutlass.Int32(cute.arch.thread_idx()[1]) < cutlass.Int32(2)
+    tcgen05_tma_warp = tcgen05_warp_idx == cutlass.Int32(5)
+    tcgen05_exec_active = tcgen05_warp_idx == cutlass.Int32(4)
+    tcgen05_epi_active = tcgen05_warp_idx < cutlass.Int32(4)
+    tcgen05_epi_tidx = tcgen05_lane_idx + tcgen05_warp_idx * cutlass.Int32(32) if tcgen05_epi_active else cutlass.Int32(0)
+    if not (tcgen05_exec_active or tcgen05_epi_active):
+        cute.arch.setmaxregister_decrease(120)
+    if tcgen05_exec_active or tcgen05_epi_active:
+        cute.arch.setmaxregister_increase(256)
+    mma_slice_tidx = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster()) % cutlass.Int32(2)
+    tiled_mma = cutlass.utils.blackwell_helpers.make_trivial_tiled_mma(cutlass.BFloat16, cute.nvgpu.tcgen05.OperandMajorMode.K, cute.nvgpu.tcgen05.OperandMajorMode.MN, cutlass.Float32, cute.nvgpu.tcgen05.CtaGroup.TWO, (256, 256), cute.nvgpu.tcgen05.OperandSource.SMEM)
+    thr_mma = tiled_mma.get_slice(mma_slice_tidx)
+    tcgen05_cluster_layout_vmnk = cute.tiled_divide(cute.make_layout((2, 1, 1)), (tiled_mma.thr_id.shape,))
+    sA_layout = cutlass.utils.blackwell_helpers.make_smem_layout_a(tiled_mma, (256, 256, 128), cutlass.BFloat16, 2)
+    sB_layout = cutlass.utils.blackwell_helpers.make_smem_layout_b(tiled_mma, (256, 256, 128), cutlass.BFloat16, 2)
+    tcgen05_c_layout = cutlass.utils.layout.LayoutEnum.ROW_MAJOR
+    tcgen05_epi_tile = cutlass.utils.blackwell_helpers.compute_epilogue_tile_shape((256, 256), False, tcgen05_c_layout, cutlass.Float32)
+    tcgen05_tmem_load_atom = cutlass.utils.blackwell_helpers.get_tmem_load_op((256, 256, 128), tcgen05_c_layout, cutlass.Float32, cutlass.Float32, tcgen05_epi_tile, True)
+    tcgen05_epilogue_rest_mode = cute.make_layout(1, stride=0)
+    acc_frag_base = tiled_mma.make_fragment_C(cute.append(tiled_mma.partition_shape_C((256, 256)), 2))
+    tcgen05_acc_tmem_cols = cutlass.utils.get_num_tmem_alloc_cols(acc_frag_base, arch='sm_100')
+    tcgen05_tmem_holding_buf = cute.arch.alloc_smem(cutlass.Int32, 1)
+    tcgen05_tmem_dealloc_mbar_ptr = cute.arch.alloc_smem(cutlass.Int64, 1)
+    tcgen05_tmem_alloc_barrier = cutlass.pipeline.NamedBarrier(barrier_id=1, num_threads=160)
+    tcgen05_tmem_allocator = cutlass.utils.TmemAllocator(tcgen05_tmem_holding_buf, barrier_for_retrieve=tcgen05_tmem_alloc_barrier, allocator_warp_id=0, is_two_cta=True, two_cta_tmem_dealloc_mbar_ptr=tcgen05_tmem_dealloc_mbar_ptr)
+    tcgen05_acc_pipeline_barriers = cute.arch.alloc_smem(cutlass.Int64, cutlass.Int32(4))
+    tcgen05_acc_pipeline_producer_group = cutlass.pipeline.CooperativeGroup(cutlass.pipeline.Agent.Thread)
+    tcgen05_acc_pipeline_consumer_group = cutlass.pipeline.CooperativeGroup(cutlass.pipeline.Agent.Thread, cutlass.Int32(8))
+    tcgen05_acc_pipeline = cutlass.pipeline.PipelineUmmaAsync.create(num_stages=2, producer_group=tcgen05_acc_pipeline_producer_group, consumer_group=tcgen05_acc_pipeline_consumer_group, barrier_storage=tcgen05_acc_pipeline_barriers, cta_layout_vmnk=tcgen05_cluster_layout_vmnk, defer_sync=True)
+    tcgen05_acc_producer_state = cutlass.pipeline.make_pipeline_state(cutlass.pipeline.PipelineUserType.Producer, 2)
+    tcgen05_acc_consumer_state = cutlass.pipeline.make_pipeline_state(cutlass.pipeline.PipelineUserType.Consumer, 2)
+    smem_a = cute.arch.alloc_smem(cutlass.BFloat16, cute.cosize(sA_layout.outer), alignment=128)
+    sA = cute.make_tensor(cute.recast_ptr(smem_a, sA_layout.inner, dtype=cutlass.BFloat16), sA_layout.outer)
+    smem_b = cute.arch.alloc_smem(cutlass.BFloat16, cute.cosize(sB_layout.outer), alignment=128)
+    sB = cute.make_tensor(cute.recast_ptr(smem_b, sB_layout.inner, dtype=cutlass.BFloat16), sB_layout.outer)
+    tcgen05_tCrA = tiled_mma.make_fragment_A(sA)
+    tcgen05_tCrB = tiled_mma.make_fragment_B(sB)
+    sA_tma_layout = cute.slice_(sA_layout, (None, None, None, 0))
+    sB_tma_layout = cute.slice_(sB_layout, (None, None, None, 0))
+    tma_thr_mma = tiled_mma.get_slice(mma_slice_tidx)
+    tma_a_cta_layout = cute.make_layout(cute.slice_(tcgen05_cluster_layout_vmnk, (0, 0, None, 0)).shape)
+    tma_b_cta_layout = cute.make_layout(cute.slice_(tcgen05_cluster_layout_vmnk, (0, None, 0, 0)).shape)
+    tcgen05_cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+    tcgen05_block_in_cluster_coord_vmnk = tcgen05_cluster_layout_vmnk.get_flat_coord(tcgen05_cta_rank_in_cluster)
+    tma_a_cta_coord = tcgen05_block_in_cluster_coord_vmnk[2]
+    tma_b_cta_coord = tcgen05_block_in_cluster_coord_vmnk[1]
+    tcgen05_a_mcast_mask = cute.nvgpu.cpasync.create_tma_multicast_mask(tcgen05_cluster_layout_vmnk, tcgen05_block_in_cluster_coord_vmnk, mcast_mode=2)
+    tcgen05_b_mcast_mask = cute.nvgpu.cpasync.create_tma_multicast_mask(tcgen05_cluster_layout_vmnk, tcgen05_block_in_cluster_coord_vmnk, mcast_mode=1)
+    tcgen05_ab_pipeline_mbars = cute.arch.alloc_smem(cutlass.Int64, cutlass.Int32(2))
+    tcgen05_ab_pipeline_producer_group = cutlass.pipeline.CooperativeGroup(cutlass.pipeline.Agent.Thread, 1)
+    tcgen05_ab_pipeline_consumer_group = cutlass.pipeline.CooperativeGroup(cutlass.pipeline.Agent.Thread, cutlass.Int32(1))
+    tcgen05_ab_pipeline_tx_count = (cute.size_in_bytes(cutlass.BFloat16, sA_tma_layout) + cute.size_in_bytes(cutlass.BFloat16, sB_tma_layout)) * cute.size(tiled_mma.thr_id.shape)
+    tcgen05_ab_pipeline = cutlass.pipeline.PipelineTmaUmma.create(num_stages=2, producer_group=tcgen05_ab_pipeline_producer_group, consumer_group=tcgen05_ab_pipeline_consumer_group, tx_count=tcgen05_ab_pipeline_tx_count, barrier_storage=tcgen05_ab_pipeline_mbars, cta_layout_vmnk=tcgen05_cluster_layout_vmnk, defer_sync=True)
+    tcgen05_ab_producer_state = cutlass.pipeline.make_pipeline_state(cutlass.pipeline.PipelineUserType.Producer, 2)
+    tcgen05_ab_consumer_state = cutlass.pipeline.make_pipeline_state(cutlass.pipeline.PipelineUserType.Consumer, 2)
+    cutlass.pipeline.pipeline_init_arrive(cluster_shape_mn=tcgen05_cluster_layout_vmnk, is_relaxed=True)
+    cutlass.pipeline.pipeline_init_wait(cluster_shape_mn=tcgen05_cluster_layout_vmnk)
+    if tcgen05_epi_active:
+        tcgen05_tmem_allocator.allocate(tcgen05_acc_tmem_cols)
+    tcgen05_exec_acc_tmem_ptr = cute.make_ptr(cutlass.Float32, 0, cute.AddressSpace.tmem, assumed_align=16)
+    tcgen05_epi_acc_tmem_ptr = cute.make_ptr(cutlass.Float32, 0, cute.AddressSpace.tmem, assumed_align=16)
+    if tcgen05_exec_active:
+        tcgen05_tmem_allocator.wait_for_alloc()
+        tcgen05_exec_acc_tmem_ptr = tcgen05_tmem_allocator.retrieve_ptr(cutlass.Float32)
+    if tcgen05_epi_active:
+        tcgen05_tmem_allocator.wait_for_alloc()
+        tcgen05_epi_acc_tmem_ptr = tcgen05_tmem_allocator.retrieve_ptr(cutlass.Float32)
+    tcgen05_exec_acc_frag_base = cute.make_tensor(tcgen05_exec_acc_tmem_ptr, acc_frag_base.layout)
+    tcgen05_epi_acc_frag_base = cute.make_tensor(tcgen05_epi_acc_tmem_ptr, acc_frag_base.layout)
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:36]: out[tile_m, tile_n] = acc.to(x.dtype)
+    tcgen05_epilog_sync_barrier = cutlass.pipeline.NamedBarrier(barrier_id=cutlass.Int32(2), num_threads=cutlass.Int32(128))
+    tcgen05_c_pipeline_producer_group = cutlass.pipeline.CooperativeGroup(cutlass.pipeline.Agent.Thread, cutlass.Int32(128))
+    tcgen05_c_pipeline = cutlass.pipeline.PipelineTmaStore.create(num_stages=2, producer_group=tcgen05_c_pipeline_producer_group)
+    tcgen05_kernel_desc = type('Tcgen05KernelDesc', (), {'cta_tile_shape_mnk': (256, 256, 128), 'c_layout': cutlass.utils.layout.LayoutEnum.ROW_MAJOR, 'c_dtype': cutlass.BFloat16, 'acc_dtype': cutlass.Float32, 'epilog_sync_bar_id': cutlass.Int32(2), 'epilogue_warp_id': (cutlass.Int32(0), cutlass.Int32(1), cutlass.Int32(2), cutlass.Int32(3)), 'num_c_stage': cutlass.Int32(2), 'use_2cta_instrs': True})()
+    tcgen05_store_epi_tile = cutlass.utils.blackwell_helpers.compute_epilogue_tile_shape((256, 256), False, cutlass.utils.layout.LayoutEnum.ROW_MAJOR, cutlass.BFloat16)
+    tcgen05_sD_layout = cutlass.utils.blackwell_helpers.make_smem_layout_epi(cutlass.BFloat16, cutlass.utils.layout.LayoutEnum.ROW_MAJOR, tcgen05_store_epi_tile, 2)
+    tcgen05_sD_ptr = cute.arch.alloc_smem(cutlass.BFloat16, cute.cosize(tcgen05_sD_layout.outer), alignment=1024)
+    tcgen05_sD = cute.make_tensor(cute.recast_ptr(tcgen05_sD_ptr, tcgen05_sD_layout.inner, dtype=cutlass.BFloat16), tcgen05_sD_layout.outer)
+    tcgen05_tAcc = cutlass.utils.gemm.sm100.transform_partitioned_tensor_layout(tcgen05_epi_acc_frag_base)
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:32]: for tile_m, tile_n in hl.tile([m, n]):
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:33]:     acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:34]:     for tile_k in hl.tile(k):
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:32-36]: ...
+    if cute.arch.make_warp_uniform(cute.arch.warp_idx()) == cutlass.Int32(5):
+        cute.arch.griddepcontrol_wait()
+        tcgen05_role_local_0_tile_sched_params = cutlass.utils.PersistentTileSchedulerParams(((4096 + _BLOCK_SIZE_0 - 1) // _BLOCK_SIZE_0 * 2, (4096 + _BLOCK_SIZE_1 - 1) // _BLOCK_SIZE_1, 1), (2, 1, 1))
+        tcgen05_role_local_0_tile_sched = cutlass.utils.StaticPersistentTileScheduler.create(tcgen05_role_local_0_tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim())
+        tcgen05_role_local_0_work_tile = tcgen05_role_local_0_tile_sched.initial_work_tile_info()
+        while tcgen05_role_local_0_work_tile.is_valid_tile:
+            virtual_pid = tcgen05_role_local_0_work_tile.tile_idx[0] // cutlass.Int32(2) + tcgen05_role_local_0_work_tile.tile_idx[1] * ((4096 + _BLOCK_SIZE_0 - 1) // _BLOCK_SIZE_0)
+            # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:32]: for tile_m, tile_n in hl.tile([m, n]):
+            pid_0 = virtual_pid % num_blocks_0
+            pid_1 = virtual_pid // num_blocks_0
+            offset_0 = pid_0 * _BLOCK_SIZE_0
+            offset_1 = pid_1 * _BLOCK_SIZE_1
+            # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:35]: acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+            gA_tma = cute.local_tile(tma_tensor_a, (256, 128), (offset_0 // cutlass.Int32(256), None))
+            gB_tma = cute.local_tile(tma_tensor_b, (256, 128), (offset_1 // cutlass.Int32(256), None))
+            gA_tma_part = tma_thr_mma.partition_A(gA_tma)
+            gB_tma_part = tma_thr_mma.partition_B(gB_tma)
+            tma_sA, tma_gA = cute.nvgpu.cpasync.tma_partition(tma_atom_a, tma_a_cta_coord, tma_a_cta_layout, cute.group_modes(sA, 0, cute.rank(sA) - 1), cute.group_modes(gA_tma_part, 0, cute.rank(gA_tma_part) - 1))
+            tma_sB, tma_gB = cute.nvgpu.cpasync.tma_partition(tma_atom_b, tma_b_cta_coord, tma_b_cta_layout, cute.group_modes(sB, 0, cute.rank(sB) - 1), cute.group_modes(gB_tma_part, 0, cute.rank(gB_tma_part) - 1))
+            tcgen05_tma_initial_full_tile = offset_0 + cutlass.Int32(256) <= cutlass.Int32(4096) and offset_1 + cutlass.Int32(256) <= cutlass.Int32(4096) and (cutlass.Int32(128) <= cutlass.Int32(4096))
+            if tcgen05_tma_initial_full_tile and tcgen05_tma_warp:
+                tcgen05_ab_pipeline.producer_acquire(tcgen05_ab_producer_state)
+                tcgen05_tma_barrier = tcgen05_ab_pipeline.producer_get_barrier(tcgen05_ab_producer_state)
+                cute.copy(tma_atom_a, tma_gA[None, cutlass.Int32(0)], tma_sA[None, tcgen05_ab_producer_state.index], tma_bar_ptr=tcgen05_tma_barrier, mcast_mask=tcgen05_a_mcast_mask)
+                cute.copy(tma_atom_b, tma_gB[None, cutlass.Int32(0)], tma_sB[None, tcgen05_ab_producer_state.index], tma_bar_ptr=tcgen05_tma_barrier, mcast_mask=tcgen05_b_mcast_mask)
+                tcgen05_ab_pipeline.producer_commit(tcgen05_ab_producer_state)
+                tcgen05_ab_producer_state.advance()
+            tcgen05_tma_initial_next_full_tile = offset_0 + cutlass.Int32(256) <= cutlass.Int32(4096) and offset_1 + cutlass.Int32(256) <= cutlass.Int32(4096) and (cutlass.Int32(256) <= cutlass.Int32(4096))
+            if tcgen05_tma_initial_full_tile and tcgen05_tma_initial_next_full_tile and tcgen05_tma_warp:
+                tcgen05_ab_pipeline.producer_acquire(tcgen05_ab_producer_state)
+                tcgen05_tma_barrier = tcgen05_ab_pipeline.producer_get_barrier(tcgen05_ab_producer_state)
+                cute.copy(tma_atom_a, tma_gA[None, cutlass.Int32(1)], tma_sA[None, tcgen05_ab_producer_state.index], tma_bar_ptr=tcgen05_tma_barrier, mcast_mask=tcgen05_a_mcast_mask)
+                cute.copy(tma_atom_b, tma_gB[None, cutlass.Int32(1)], tma_sB[None, tcgen05_ab_producer_state.index], tma_bar_ptr=tcgen05_tma_barrier, mcast_mask=tcgen05_b_mcast_mask)
+                tcgen05_ab_pipeline.producer_commit(tcgen05_ab_producer_state)
+                tcgen05_ab_producer_state.advance()
+            for offset_2 in range(cutlass.Int32(0), cutlass.Int32(4096), cutlass.Int32(_BLOCK_SIZE_2)):
+                tcgen05_tma_k_tile = offset_2 // cutlass.Int32(128)
+                tcgen05_tma_full_tile = offset_0 + cutlass.Int32(256) <= cutlass.Int32(4096) and offset_1 + cutlass.Int32(256) <= cutlass.Int32(4096) and (offset_2 + cutlass.Int32(128) <= cutlass.Int32(4096))
+                tcgen05_tma_next_full_tile = offset_0 + cutlass.Int32(256) <= cutlass.Int32(4096) and offset_1 + cutlass.Int32(256) <= cutlass.Int32(4096) and (offset_2 + cutlass.Int32(384) <= cutlass.Int32(4096))
+                tcgen05_ab_producer_try_token = cutlass.Boolean(0)
+                if tcgen05_tma_full_tile and tcgen05_tma_next_full_tile:
+                    tcgen05_ab_producer_try_token = tcgen05_ab_pipeline.producer_try_acquire(tcgen05_ab_producer_state)
+                    tcgen05_ab_pipeline.producer_acquire(tcgen05_ab_producer_state, tcgen05_ab_producer_try_token)
+                    tcgen05_tma_barrier = tcgen05_ab_pipeline.producer_get_barrier(tcgen05_ab_producer_state)
+                    cute.copy(tma_atom_a, tma_gA[None, tcgen05_tma_k_tile + cutlass.Int32(2)], tma_sA[None, tcgen05_ab_producer_state.index], tma_bar_ptr=tcgen05_tma_barrier, mcast_mask=tcgen05_a_mcast_mask)
+                    cute.copy(tma_atom_b, tma_gB[None, tcgen05_tma_k_tile + cutlass.Int32(2)], tma_sB[None, tcgen05_ab_producer_state.index], tma_bar_ptr=tcgen05_tma_barrier, mcast_mask=tcgen05_b_mcast_mask)
+                    tcgen05_ab_pipeline.producer_commit(tcgen05_ab_producer_state)
+                    tcgen05_ab_producer_state.advance()
+            # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:32]: for tile_m, tile_n in hl.tile([m, n]):
+            # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:33]:     acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+            # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:34]:     for tile_k in hl.tile(k):
+            # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:32-36]: ...
+            tcgen05_role_local_0_tile_sched.advance_to_next_work()
+            tcgen05_role_local_0_work_tile = tcgen05_role_local_0_tile_sched.get_current_work()
+    if cute.arch.make_warp_uniform(cute.arch.warp_idx()) == cutlass.Int32(4):
+        tcgen05_role_local_1_tile_sched_params = cutlass.utils.PersistentTileSchedulerParams(((4096 + _BLOCK_SIZE_0 - 1) // _BLOCK_SIZE_0 * 2, (4096 + _BLOCK_SIZE_1 - 1) // _BLOCK_SIZE_1, 1), (2, 1, 1))
+        tcgen05_role_local_1_tile_sched = cutlass.utils.StaticPersistentTileScheduler.create(tcgen05_role_local_1_tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim())
+        tcgen05_role_local_1_work_tile = tcgen05_role_local_1_tile_sched.initial_work_tile_info()
+        while tcgen05_role_local_1_work_tile.is_valid_tile:
+            virtual_pid = tcgen05_role_local_1_work_tile.tile_idx[0] // cutlass.Int32(2) + tcgen05_role_local_1_work_tile.tile_idx[1] * ((4096 + _BLOCK_SIZE_0 - 1) // _BLOCK_SIZE_0)
+            # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:32]: for tile_m, tile_n in hl.tile([m, n]):
+            pid_0 = virtual_pid % num_blocks_0
+            pid_1 = virtual_pid // num_blocks_0
+            offset_0 = pid_0 * _BLOCK_SIZE_0
+            offset_1 = pid_1 * _BLOCK_SIZE_1
+            # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:35]: acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+            acc_frag = tcgen05_exec_acc_frag_base[None, None, None, tcgen05_acc_producer_state.index]
+            tcgen05_ab_consumer_try_token = cutlass.Boolean(1)
+            if cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster()) == cutlass.Int32(0):
+                tcgen05_ab_consumer_try_token = tcgen05_ab_pipeline.consumer_try_wait(tcgen05_ab_consumer_state)
+            if tcgen05_exec_active and cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster()) == cutlass.Int32(0):
+                tcgen05_acc_pipeline.producer_acquire(tcgen05_acc_producer_state)
+            if tcgen05_exec_active and cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster()) == cutlass.Int32(0):
+                tiled_mma.set(cute.nvgpu.tcgen05.Field.ACCUMULATE, False)
+            for offset_2 in range(cutlass.Int32(0), cutlass.Int32(4096), cutlass.Int32(_BLOCK_SIZE_2)):
+                mma_stage = tcgen05_ab_consumer_state.index
+                sA_mma = sA[None, 0, 0, mma_stage]
+                sB_mma = sB[None, 0, 0, mma_stage]
+                tcgen05_tma_full_tile = offset_0 + cutlass.Int32(256) <= cutlass.Int32(4096) and offset_1 + cutlass.Int32(256) <= cutlass.Int32(4096) and (offset_2 + cutlass.Int32(128) <= cutlass.Int32(4096))
+                tcgen05_tma_next_consumer_tile = offset_2 + cutlass.Int32(256) <= cutlass.Int32(4096)
+                if tcgen05_tma_full_tile:
+                    if cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster()) == cutlass.Int32(0):
+                        tcgen05_ab_pipeline.consumer_wait(tcgen05_ab_consumer_state, tcgen05_ab_consumer_try_token)
+                if cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster()) == cutlass.Int32(0):
+                    cute.arch.fence_view_async_shared()
+                if cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster()) == cutlass.Int32(0):
+                    for _tcgen05_kblk_idx in range(cute.size(tcgen05_tCrA, mode=[2])):
+                        cute.gemm(tiled_mma, acc_frag, [tcgen05_tCrA[None, None, cutlass.Int32(_tcgen05_kblk_idx), mma_stage]], [tcgen05_tCrB[None, None, cutlass.Int32(_tcgen05_kblk_idx), mma_stage]], acc_frag)
+                        tiled_mma.set(cute.nvgpu.tcgen05.Field.ACCUMULATE, True)
+                if tcgen05_tma_full_tile:
+                    if cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster()) == cutlass.Int32(0):
+                        tcgen05_ab_pipeline.consumer_release(tcgen05_ab_consumer_state)
+                    tcgen05_ab_consumer_state.advance()
+                tcgen05_ab_consumer_try_token = cutlass.Boolean(1)
+                if tcgen05_tma_next_consumer_tile and cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster()) == cutlass.Int32(0):
+                    tcgen05_ab_consumer_try_token = tcgen05_ab_pipeline.consumer_try_wait(tcgen05_ab_consumer_state)
+            if tcgen05_exec_active and cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster()) == cutlass.Int32(0):
+                tcgen05_acc_pipeline.producer_commit(tcgen05_acc_producer_state)
+            tcgen05_acc_producer_state.advance()
+            # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:32]: for tile_m, tile_n in hl.tile([m, n]):
+            # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:33]:     acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+            # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:34]:     for tile_k in hl.tile(k):
+            # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:32-36]: ...
+            tcgen05_role_local_1_tile_sched.advance_to_next_work()
+            tcgen05_role_local_1_work_tile = tcgen05_role_local_1_tile_sched.get_current_work()
+    if cute.arch.make_warp_uniform(cute.arch.warp_idx()) < cutlass.Int32(4):
+        tcgen05_role_local_2_tile_sched_params = cutlass.utils.PersistentTileSchedulerParams(((4096 + _BLOCK_SIZE_0 - 1) // _BLOCK_SIZE_0 * 2, (4096 + _BLOCK_SIZE_1 - 1) // _BLOCK_SIZE_1, 1), (2, 1, 1))
+        tcgen05_role_local_2_tile_sched = cutlass.utils.StaticPersistentTileScheduler.create(tcgen05_role_local_2_tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim())
+        tcgen05_role_local_2_work_tile = tcgen05_role_local_2_tile_sched.initial_work_tile_info()
+        tcgen05_tma_store_role_tile = cutlass.Int32(0)
+        while tcgen05_role_local_2_work_tile.is_valid_tile:
+            virtual_pid = tcgen05_role_local_2_work_tile.tile_idx[0] // cutlass.Int32(2) + tcgen05_role_local_2_work_tile.tile_idx[1] * ((4096 + _BLOCK_SIZE_0 - 1) // _BLOCK_SIZE_0)
+            # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:32]: for tile_m, tile_n in hl.tile([m, n]):
+            pid_0 = virtual_pid % num_blocks_0
+            pid_1 = virtual_pid // num_blocks_0
+            offset_0 = pid_0 * _BLOCK_SIZE_0
+            offset_1 = pid_1 * _BLOCK_SIZE_1
+            # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:36]: out[tile_m, tile_n] = acc.to(x.dtype)
+            if True:
+                if tcgen05_epi_active and tcgen05_warp_idx == cutlass.Int32(0):
+                    tcgen05_c_pipeline.producer_acquire()
+                tcgen05_gC = cute.local_tile(tcgen05_tma_store_tensor, (256, 256), (offset_0 // cutlass.Int32(256), offset_1 // cutlass.Int32(256)))
+                tcgen05_tCgC_base = thr_mma.partition_C(tcgen05_gC)
+                tcgen05_tCgC = cutlass.utils.gemm.sm100.transform_partitioned_tensor_layout(tcgen05_tCgC_base)
+                tcgen05_tCgC_planned = cute.make_tensor(tcgen05_tCgC.iterator, cute.append(cute.append(cute.append(tcgen05_tCgC.layout, tcgen05_epilogue_rest_mode), tcgen05_epilogue_rest_mode), tcgen05_epilogue_rest_mode))
+                tcgen05_tiled_copy_t2r, tcgen05_tTR_tAcc_base, tcgen05_tTR_rAcc = cutlass.utils.gemm.sm100.epilogue_tmem_copy_and_partition(tcgen05_kernel_desc, tcgen05_epi_tidx, tcgen05_tAcc, tcgen05_tCgC_planned, tcgen05_store_epi_tile, True)
+                tcgen05_tTR_rD = cute.make_rmem_tensor(tcgen05_tTR_rAcc.shape, cutlass.BFloat16)
+                tcgen05_tiled_copy_r2s, tcgen05_tRS_rD, tcgen05_tRS_sD = cutlass.utils.gemm.sm100.epilogue_smem_copy_and_partition(tcgen05_kernel_desc, tcgen05_tiled_copy_t2r, tcgen05_tTR_rD, tcgen05_epi_tidx, tcgen05_sD)
+                tcgen05_tRS_rAcc = tcgen05_tiled_copy_r2s.retile(tcgen05_tTR_rAcc)
+                tcgen05_tCgC_epi = cute.flat_divide(tcgen05_tCgC_planned, tcgen05_store_epi_tile)
+                tcgen05_bSG_sD, tcgen05_bSG_gD_partitioned = cute.nvgpu.cpasync.tma_partition(tcgen05_tma_store_atom, 0, cute.make_layout(1), cute.group_modes(tcgen05_sD, 0, 2), cute.group_modes(tcgen05_tCgC_epi, 0, 2))
+                tcgen05_bSG_gD = tcgen05_bSG_gD_partitioned[None, None, None, cutlass.Int32(0), cutlass.Int32(0), cutlass.Int32(0)]
+                tcgen05_bSG_gD = cute.group_modes(tcgen05_bSG_gD, 1, cute.rank(tcgen05_bSG_gD))
+                tcgen05_tTR_tAcc_stage = tcgen05_tTR_tAcc_base[None, None, None, None, None, tcgen05_acc_consumer_state.index]
+                tcgen05_tTR_tAcc = cute.group_modes(tcgen05_tTR_tAcc_stage, 3, cute.rank(tcgen05_tTR_tAcc_stage))
+                tcgen05_subtile_count = cutlass.const_expr(cute.size(tcgen05_tTR_tAcc.shape, mode=[3]))
+                for _tcgen05_subtile in cutlass.range(tcgen05_subtile_count, unroll_full=True):
+                    if tcgen05_epi_active:
+                        if _tcgen05_subtile != 0 and tcgen05_warp_idx == cutlass.Int32(0):
+                            tcgen05_c_pipeline.producer_acquire()
+                        if _tcgen05_subtile == 0:
+                            tcgen05_acc_pipeline.consumer_wait(tcgen05_acc_consumer_state)
+                        tcgen05_tTR_tAcc_mn = tcgen05_tTR_tAcc[None, None, None, cutlass.Int32(_tcgen05_subtile)]
+                        cute.copy(tcgen05_tiled_copy_t2r, tcgen05_tTR_tAcc_mn, tcgen05_tTR_rAcc)
+                        tcgen05_acc_vec = tcgen05_tRS_rAcc.load().to(cutlass.BFloat16)
+                        if _tcgen05_subtile == tcgen05_subtile_count - 1:
+                            cute.arch.fence_view_async_tmem_load()
+                            with cute.arch.elect_one():
+                                tcgen05_acc_pipeline.consumer_release(tcgen05_acc_consumer_state)
+                        tcgen05_tRS_rD.store(tcgen05_acc_vec)
+                        tcgen05_epilog_sync_barrier.arrive_and_wait()
+                        tcgen05_c_buffer = (tcgen05_tma_store_role_tile * cutlass.Int32(tcgen05_subtile_count) + cutlass.Int32(_tcgen05_subtile)) % cutlass.Int32(2)
+                        cute.copy(tcgen05_tiled_copy_r2s, tcgen05_tRS_rD, tcgen05_tRS_sD[None, None, None, tcgen05_c_buffer])
+                        cute.arch.fence_view_async_shared()
+                        tcgen05_epilog_sync_barrier.arrive_and_wait()
+                        if tcgen05_warp_idx == cutlass.Int32(0):
+                            cute.copy(tcgen05_tma_store_atom, tcgen05_bSG_sD[None, tcgen05_c_buffer], tcgen05_bSG_gD[None, cutlass.Int32(_tcgen05_subtile)])
+                            tcgen05_c_pipeline.producer_commit()
+                if tcgen05_epi_active:
+                    tcgen05_acc_consumer_state.advance()
+            # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:32]: for tile_m, tile_n in hl.tile([m, n]):
+            # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:33]:     acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+            # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:34]:     for tile_k in hl.tile(k):
+            # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:32-36]: ...
+            tcgen05_tma_store_role_tile = tcgen05_tma_store_role_tile + cutlass.Int32(1)
+            tcgen05_role_local_2_tile_sched.advance_to_next_work()
+            tcgen05_role_local_2_work_tile = tcgen05_role_local_2_tile_sched.get_current_work()
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:36]: out[tile_m, tile_n] = acc.to(x.dtype)
+    if tcgen05_warp_idx == cutlass.Int32(0):
+        tcgen05_c_pipeline.producer_tail()
+    if tcgen05_tma_warp:
+        tcgen05_ab_pipeline.producer_tail(tcgen05_ab_producer_state)
+    if tcgen05_exec_active:
+        cute.arch.griddepcontrol_launch_dependents()
+    if tcgen05_exec_active:
+        tcgen05_tmem_alloc_barrier.arrive()
+    if tcgen05_exec_active:
+        tcgen05_acc_pipeline.producer_tail(tcgen05_acc_producer_state)
+    tcgen05_tmem_allocator = cutlass.utils.TmemAllocator(tcgen05_tmem_holding_buf, barrier_for_retrieve=tcgen05_tmem_alloc_barrier, allocator_warp_id=0, is_two_cta=True, two_cta_tmem_dealloc_mbar_ptr=tcgen05_tmem_dealloc_mbar_ptr, num_allocated_columns=tcgen05_acc_tmem_cols, initialize_mbarrier=False)
+    if tcgen05_epi_active:
+        tcgen05_tmem_allocator.relinquish_alloc_permit()
+    if tcgen05_epi_active:
+        tcgen05_tmem_alloc_barrier.arrive_and_wait()
+    if tcgen05_epi_active:
+        tcgen05_tmem_allocator.free(tcgen05_epi_acc_tmem_ptr)
+
+def cute_matmul_role_local_monolithic_4096_bf16(x: torch.Tensor, y: torch.Tensor, *, _launcher=_default_cute_launcher):
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:26]: def cute_matmul_role_local_monolithic_4096_bf16(
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:27]:     x: torch.Tensor, y: torch.Tensor
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:28]: ) -> torch.Tensor:
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:26-37]: ...
+    _helion_cute_matmul_role_local_monolithic_4096_bf16._helion_cute_cluster_shape = (2, 1, 1)
+    _helion_cute_matmul_role_local_monolithic_4096_bf16._helion_cute_wrapper_plans = [{'kind': 'tcgen05_ab_tma', 'bm': 256, 'bn': 256, 'bk': 128, 'cluster_m': 2, 'cluster_n': 1, 'ab_stage_count': 2, 'input_dtype': 'cutlass.BFloat16', 'acc_dtype': 'cutlass.Float32', 'kernel_args': ['tma_atom_a', 'tma_tensor_a', 'tma_atom_b', 'tma_tensor_b'], 'lhs_idx': 0, 'rhs_idx': 1}, {'kind': 'tcgen05_d_tma', 'bm': 256, 'bn': 256, 'c_stage_count': 2, 'output_dtype': 'cutlass.BFloat16', 'kernel_args': ['tcgen05_tma_store_atom', 'tcgen05_tma_store_tensor'], 'd_idx': 2}]
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:29]: m, k = x.size()
+    m, k = x.size()
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:30]: _, n = y.size()
+    _, n = y.size()
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:31]: out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+    out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:32]: for tile_m, tile_n in hl.tile([m, n]):
+    _NUM_SM = helion.runtime.get_num_sm(x.device)
+    _BLOCK_SIZE_0 = 256
+    _BLOCK_SIZE_1 = 256
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:32]: for tile_m, tile_n in hl.tile([m, n]):
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:33]:     acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:34]:     for tile_k in hl.tile(k):
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:32-36]: ...
+    _launcher(_helion_cute_matmul_role_local_monolithic_4096_bf16, (2, 1, min(((4096 + _BLOCK_SIZE_0 - 1) // _BLOCK_SIZE_0 * 2 + 2 - 1) // 2 * ((4096 + _BLOCK_SIZE_1 - 1) // _BLOCK_SIZE_1) * 1, max(1, _NUM_SM // 2))), x, y, out, block=(32, 6, 1))
+    # src[_tcgen05_role_local_monolithic_4096_bf16_kernel.py:37]: return out
+    return out

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import ast
 import contextlib
+import dataclasses
+import difflib
 import operator
+import os
+from pathlib import Path
 from types import SimpleNamespace
 import unittest
 from unittest.mock import patch
@@ -43,11 +47,13 @@ from helion._compiler.cute.cute_mma import _build_kloop_pipeline_release_if
 from helion._compiler.cute.cute_mma import _build_tcgen05_mma_accumulate_reset_stmt
 from helion._compiler.cute.cute_mma import _build_tcgen05_mma_issue_stmt
 from helion._compiler.cute.cute_mma import _choose_mma_impl
+from helion._compiler.cute.cute_mma import _emit_sched_pipeline_setup
 from helion._compiler.cute.cute_mma import _get_mma_k_loop_info
 from helion._compiler.cute.cute_mma import _InitialPrefetchTmaArgs
 from helion._compiler.cute.cute_mma import _make_tcgen05_layout_plan_setup
 from helion._compiler.cute.cute_mma import _mma_result_can_be_deferred
 from helion._compiler.cute.cute_mma import _new_tcgen05_layout_plan
+from helion._compiler.cute.cute_mma import _new_tcgen05_sched_pipeline_plan
 from helion._compiler.cute.cute_mma import _PerKiterTmaArgs
 from helion._compiler.cute.cute_mma import _tcgen05_ab_stage_count
 from helion._compiler.cute.cute_mma import _tcgen05_epi_warp_count
@@ -69,6 +75,8 @@ from helion._compiler.cute.matmul_utils import cute_resolve_active_block_id
 from helion._compiler.cute.matmul_utils import cute_resolve_active_matmul_k_block_id
 from helion._compiler.cute.matmul_utils import cute_static_k_invariant_extent
 from helion._compiler.cute.matmul_utils import cute_supports_scalar_matmul_fallback
+from helion._compiler.cute.strategies import ROLE_LOCAL_MONOLITHIC_DEFAULT_WARP_SPEC
+from helion._compiler.cute.strategies import Tcgen05WarpSpec
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_AB_CONSUMER_PHASE_MODE_CONFIG_KEY,
 )
@@ -142,6 +150,21 @@ from helion.language.memory_ops import _cute_index_exprs
 from helion.language.memory_ops import _maybe_codegen_cute_packed_affine_lhs_load
 from helion.language.memory_ops import load
 from helion.runtime import _append_cute_wrapper_plan
+
+# Golden file pinning the byte-identical generated CuTe for the
+# retained ROLE_LOCAL_MONOLITHIC seed (cute_plan.md §6.2 pin test #1
+# and §10.1 canonical benchmark seed). Lives at
+# ``test/golden/tcgen05_role_local_monolithic_4096_bf16.py.expected``.
+# The kernel definition is in
+# ``test/golden/_tcgen05_role_local_monolithic_4096_bf16_kernel.py``;
+# its file path appears in ``src[<file>:<line>]`` comments embedded
+# in the generated kernel, so both files must move together if
+# either is renamed.
+TCGEN05_ROLE_LOCAL_MONOLITHIC_GOLDEN_PATH = (
+    Path(__file__).parent
+    / "golden"
+    / "tcgen05_role_local_monolithic_4096_bf16.py.expected"
+)
 
 
 def _make_tcgen05_persistent_config(**overrides: object) -> helion.Config:
@@ -1334,6 +1357,317 @@ class TestCuteLowerings(unittest.TestCase):
                 code,
             )
             self.assertRegex(code, r"\(\s*1\s*,\s*1\s*,\s*min\s*\(")
+
+    def test_tcgen05_role_local_monolithic_byte_identical_golden(self) -> None:
+        """G2-B byte-identity pin (cute_plan.md §6.2 pin tests #1, #2).
+
+        The retained ``ROLE_LOCAL_MONOLITHIC`` seed (cute_plan.md
+        §10.1: 4096³ bf16, ``block_sizes=[256, 256, 128]``,
+        ``cluster_m=2``, ``pid_type=persistent_interleaved``,
+        ``ab/acc/c_stages=2/2/2``, ``num_epi_warps=4``) must
+        generate byte-identical CuTe across G2 refactors. The kernel
+        is hosted at a stable file path
+        (``test/golden/_tcgen05_role_local_monolithic_4096_bf16_kernel.py``)
+        so the embedded ``src[<file>:<line>]`` comments do not drift
+        when ``test_cute_lowerings.py`` itself changes.
+
+        Why a separate ``.py.expected`` file rather than
+        ``helion._testing.AssertExpectedJournal``: the journal stores
+        all expected outputs in one shared
+        ``test_cute_lowerings.expected`` file under
+        ``--- assertExpectedJournal(...)`` section markers, and
+        requires the test class to inherit from
+        ``helion._testing.TestCase``. ``TestCuteLowerings`` currently
+        inherits from ``unittest.TestCase`` (line 400 of this file) —
+        switching the base class would change setUp/tearDown
+        semantics for ~200 unrelated tests and is out of scope for
+        a byte-identity pin. A standalone 315-line ``.py.expected``
+        file is also more inspectable than a section inside the
+        shared journal. If a second golden test lands here, factor
+        the read/write/diff plumbing into a small helper alongside
+        the journal class in ``helion/_testing.py`` rather than
+        copy-pasting this block.
+
+        Update protocol: when an intentional codegen change makes
+        this test fail, regenerate the golden by setting
+        ``EXPECTTEST_ACCEPT=1`` (or by running
+        ``EXPECTTEST_ACCEPT=1 pytest -k
+        test_tcgen05_role_local_monolithic_byte_identical_golden``).
+        Reviewers diff the regenerated golden against the previous
+        version; only intentional codegen deltas should land.
+        """
+
+        from test.golden._tcgen05_role_local_monolithic_4096_bf16_kernel import (
+            cute_matmul_role_local_monolithic_4096_bf16,
+        )
+
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        seed_config = helion.Config(
+            block_sizes=[256, 256, 128],
+            l2_groupings=[1],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_role_local_monolithic_4096_bf16.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            actual = bound.to_triton_code(seed_config)
+
+        # Sanity: confirm the generated kernel is on the
+        # retained-seed tcgen05 path (a fallback path would diff
+        # against the golden but the ``make_trivial_tiled_mma`` /
+        # ``PipelineUmmaAsync`` markers below catch a regression to
+        # a non-tcgen05 fallback even before the golden compare
+        # runs, so the failure points at a real shape change rather
+        # than a host-detect regression).
+        self.assertIn("make_trivial_tiled_mma", actual)
+        self.assertIn("PipelineUmmaAsync.create", actual)
+        self.assertIn("PipelineTmaUmma.create", actual)
+        self.assertIn("PipelineTmaStore.create", actual)
+
+        # ``EXPECTTEST_ACCEPT=1`` is a *local-regeneration* hook
+        # (mirrors helion's ``AssertExpectedJournal`` machinery in
+        # ``helion/_testing.py``); CI runs the test without that
+        # env var so the golden file always exists and any drift
+        # fails. The "missing golden" path below also writes the
+        # file but fails the test so a bare ``pytest`` invocation
+        # in a fresh checkout produces a useful error rather than
+        # silently passing. Set ``EXPECTTEST_ACCEPT=1`` only when
+        # intentionally regenerating after a deliberate codegen
+        # change, and review the resulting diff in your PR.
+        accept = os.environ.get("EXPECTTEST_ACCEPT") == "1"
+        if accept or not TCGEN05_ROLE_LOCAL_MONOLITHIC_GOLDEN_PATH.exists():
+            TCGEN05_ROLE_LOCAL_MONOLITHIC_GOLDEN_PATH.parent.mkdir(
+                parents=True, exist_ok=True
+            )
+            TCGEN05_ROLE_LOCAL_MONOLITHIC_GOLDEN_PATH.write_text(actual)
+            if not accept:
+                self.fail(
+                    "golden file was missing; wrote initial version. "
+                    "Re-run the test to verify."
+                )
+            return
+        expected = TCGEN05_ROLE_LOCAL_MONOLITHIC_GOLDEN_PATH.read_text()
+        if actual != expected:
+            diff = "".join(
+                difflib.unified_diff(
+                    expected.splitlines(keepends=True),
+                    actual.splitlines(keepends=True),
+                    fromfile="golden",
+                    tofile="actual",
+                    n=3,
+                )
+            )
+            self.fail(
+                "Generated CuTe differs from the golden — "
+                "byte-identity for ROLE_LOCAL_MONOLITHIC seed broken. "
+                "If this is an intentional codegen change, regenerate "
+                "the golden via "
+                "EXPECTTEST_ACCEPT=1 pytest -k "
+                "test_tcgen05_role_local_monolithic_byte_identical_golden, "
+                "diff the regenerated file against the prior version, "
+                "and confirm every delta in your PR description.\n"
+                f"--- diff ---\n{diff}"
+            )
+
+    def test_tcgen05_codegen_consumes_warp_spec(self) -> None:
+        """G2-B data-flow pin: ``Tcgen05WarpSpec`` is consumed by
+        codegen as the source of truth for warp role IDs.
+
+        Two distinct call sites must route through the strategy
+        layer: ``_tcgen05_epi_warp_count`` (which now takes a
+        ``Tcgen05WarpSpec`` argument) and the ``CuteTcgen05MatmulPlan``
+        construction (which reads ``ab_load_warp_count`` from the
+        spec). Before G2-B both read ``tcgen05_num_epi_warps``
+        directly. The test pins both:
+
+        - ``warp_spec_from_config`` is invoked at least once during
+          ``to_triton_code``. Today it is invoked exactly once (item
+          4 of the G2-B review hoisted the build inside the
+          tcgen05 branch); the lower bound is kept loose so a
+          future cycle can route additional codegen sites through
+          the helper without a test-only edit.
+        - The constructed ``CuteTcgen05MatmulPlan`` carries
+          ``ab_load_warp_count`` and ``epi_warp_count`` derived from
+          the observed spec. A partial revert that hard-coded
+          either field would still pass the call-count check; this
+          object-shape pin catches that.
+
+        ``register_split`` is also asserted on the observed spec so
+        a drift in the (120, 256) decrease/increase pair is caught
+        as part of this test rather than waiting for the byte-
+        identity golden to flag it.
+        """
+
+        from test.golden._tcgen05_role_local_monolithic_4096_bf16_kernel import (
+            cute_matmul_role_local_monolithic_4096_bf16,
+        )
+
+        from helion._compiler.cute import cute_mma as cute_mma_module
+        from helion._compiler.cute import strategies as strategies_module
+        from helion._compiler.device_function import (
+            CuteTcgen05MatmulPlan as _CuteTcgen05MatmulPlan,
+        )
+
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        seed_config = helion.Config(
+            block_sizes=[256, 256, 128],
+            l2_groupings=[1],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+        )
+
+        original_warp_spec = strategies_module.warp_spec_from_config
+        observed_specs: list[Tcgen05WarpSpec] = []
+
+        def sniffing_warp_spec_from_config(config):  # type: ignore[no-untyped-def]
+            spec = original_warp_spec(config)
+            observed_specs.append(spec)
+            return spec
+
+        observed_plans: list[_CuteTcgen05MatmulPlan] = []
+
+        def sniffing_matmul_plan(*args, **kwargs):  # type: ignore[no-untyped-def]
+            plan = _CuteTcgen05MatmulPlan(*args, **kwargs)
+            observed_plans.append(plan)
+            return plan
+
+        with patch_cute_mma_support():
+            bound = cute_matmul_role_local_monolithic_4096_bf16.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            with (
+                patch.object(
+                    cute_mma_module,
+                    "warp_spec_from_config",
+                    sniffing_warp_spec_from_config,
+                ),
+                patch.object(
+                    cute_mma_module,
+                    "CuteTcgen05MatmulPlan",
+                    sniffing_matmul_plan,
+                ),
+            ):
+                bound.to_triton_code(seed_config)
+
+        # warp_spec_from_config is reached at least once. The hoist
+        # in item 4 of the G2-B review collapsed two reads into one,
+        # so today this is exactly 1 — keep the assertion loose so
+        # future per-strategy split work can add reads without a
+        # test-only edit.
+        self.assertGreaterEqual(
+            len(observed_specs), 1, msg=f"calls={len(observed_specs)}"
+        )
+        # Documented G2-A defaults for ROLE_LOCAL_MONOLITHIC:
+        # 1 ab_load + 1 mma + 4 epi + 0 epi_load + 0 scheduler = 6
+        # warps; register_split = (120, 256).
+        for spec in observed_specs:
+            self.assertEqual(spec.ab_load_warps, 1)
+            self.assertEqual(spec.mma_warps, 1)
+            self.assertEqual(spec.epi_warps, 4)
+            self.assertEqual(spec.epi_load_warps, 0)
+            self.assertEqual(spec.scheduler_warps, 0)
+            self.assertEqual(spec.total_warps, 6)
+            self.assertEqual(spec.register_split, (120, 256))
+        # The constructed matmul plan carries warp-role counts
+        # derived from the spec — a partial revert of the G2-B
+        # refactor that hard-coded ``ab_load_warp_count=1`` directly
+        # in the ``CuteTcgen05MatmulPlan(...)`` call would still
+        # pass the call-count check above, so pin the field
+        # directly on the observed plan object.
+        self.assertEqual(len(observed_plans), 1, msg=f"plans={len(observed_plans)}")
+        plan = observed_plans[0]
+        spec = observed_specs[0]
+        self.assertEqual(plan.ab_load_warp_count, spec.ab_load_warps)
+        # ``epi_warp_count`` is the cap-applied value (limited by
+        # ``cta_thread_count // 32``), but for the seed config the
+        # cap is loose and the spec's epi_warps flows through.
+        self.assertEqual(plan.epi_warp_count, spec.epi_warps)
+
+        # Strong dataflow pin: rerun codegen with a forced spec
+        # whose ``ab_load_warps`` differs from the autotune-pinned
+        # value (``1``). The plan's ``ab_load_warp_count`` must
+        # follow the forced spec, not the original config key. A
+        # partial revert that hard-coded ``ab_load_warp_count=1``
+        # in the ``CuteTcgen05MatmulPlan(...)`` call would fail this
+        # assertion (the plan would carry ``1`` while the forced
+        # spec carries the substituted value).
+        forced_spec = dataclasses.replace(
+            ROLE_LOCAL_MONOLITHIC_DEFAULT_WARP_SPEC, ab_load_warps=2
+        )
+        observed_plans.clear()
+
+        # Sentinel raised by the spy immediately after the plan is
+        # captured. Short-circuiting codegen here keeps the test
+        # focused on the dataflow check and avoids depending on
+        # whatever downstream emission would do with a non-default
+        # ``ab_load_warps`` (today: explode in epi-warp accounting).
+        # The sentinel is plain ``Exception`` and gets wrapped by
+        # ``inductor_lowering.run_node`` into ``InductorLoweringError``;
+        # we suppress *only* that specific helion exception type, so
+        # an unrelated failure (e.g. a future rename of
+        # ``warp_spec_from_config`` causing ``patch.object`` to
+        # raise ``AttributeError`` at context entry, or a real
+        # ``TypeError`` thrown elsewhere in ``to_triton_code``)
+        # still surfaces as a test failure pointing at the actual
+        # regression instead of being silently eaten.
+        class _CapturedPlan(Exception):
+            """Sentinel raised once the plan is captured."""
+
+        def short_circuiting_matmul_plan(*args, **kwargs):  # type: ignore[no-untyped-def]
+            plan = _CuteTcgen05MatmulPlan(*args, **kwargs)
+            observed_plans.append(plan)
+            raise _CapturedPlan
+
+        captured_plan_seen = False
+        with patch_cute_mma_support():
+            bound = cute_matmul_role_local_monolithic_4096_bf16.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            with (
+                patch.object(
+                    cute_mma_module,
+                    "warp_spec_from_config",
+                    lambda _config: forced_spec,
+                ),
+                patch.object(
+                    cute_mma_module,
+                    "CuteTcgen05MatmulPlan",
+                    short_circuiting_matmul_plan,
+                ),
+            ):
+                try:
+                    bound.to_triton_code(seed_config)
+                except exc.InductorLoweringError as wrapped:
+                    # Confirm the suppression was triggered by *our*
+                    # sentinel, not by some other codegen failure
+                    # that happens to surface as InductorLoweringError.
+                    chain: BaseException | None = wrapped
+                    while chain is not None:
+                        if isinstance(chain, _CapturedPlan):
+                            captured_plan_seen = True
+                            break
+                        chain = chain.__cause__ or chain.__context__
+                    if not captured_plan_seen:
+                        raise
+        self.assertTrue(
+            captured_plan_seen,
+            msg="forced-spec rerun did not raise the _CapturedPlan sentinel",
+        )
+        self.assertEqual(len(observed_plans), 1, msg="plan was never constructed")
+        self.assertEqual(observed_plans[0].ab_load_warp_count, 2)
 
     def test_tcgen05_persistent_kloop_producer_lifts_to_role_local_while(
         self,
@@ -6936,20 +7270,22 @@ class TestCuteLowerings(unittest.TestCase):
                 )
 
     def test_tcgen05_thread_counts_match_participants_and_cta(self) -> None:
+        # ``_tcgen05_epi_warp_count`` takes a ``Tcgen05WarpSpec`` (G2-B);
+        # build one from the documented monolithic defaults and only
+        # override ``epi_warps`` to exercise the cap behavior.
+        def _spec(epi_warps: int) -> Tcgen05WarpSpec:
+            return dataclasses.replace(
+                ROLE_LOCAL_MONOLITHIC_DEFAULT_WARP_SPEC, epi_warps=epi_warps
+            )
+
         self.assertEqual(_tcgen05_ab_stage_count(0), 1)
         self.assertEqual(_tcgen05_ab_stage_count(1), 1)
         self.assertEqual(_tcgen05_ab_stage_count(2), 2)
         self.assertEqual(_tcgen05_ab_stage_count(4), 2)
-        self.assertEqual(_tcgen05_epi_warp_count({}, cta_thread_count=32), 1)
-        self.assertEqual(_tcgen05_epi_warp_count({}, cta_thread_count=128), 4)
-        self.assertEqual(
-            _tcgen05_epi_warp_count({"tcgen05_num_epi_warps": 2}, cta_thread_count=256),
-            2,
-        )
-        self.assertEqual(
-            _tcgen05_epi_warp_count({"tcgen05_num_epi_warps": 8}, cta_thread_count=128),
-            4,
-        )
+        self.assertEqual(_tcgen05_epi_warp_count(_spec(4), cta_thread_count=32), 1)
+        self.assertEqual(_tcgen05_epi_warp_count(_spec(4), cta_thread_count=128), 4)
+        self.assertEqual(_tcgen05_epi_warp_count(_spec(2), cta_thread_count=256), 2)
+        self.assertEqual(_tcgen05_epi_warp_count(_spec(8), cta_thread_count=128), 4)
         self.assertEqual(_tcgen05_root_m_threads(64, 8), 64)
         self.assertEqual(_tcgen05_root_m_threads(64, 16), 32)
         self.assertEqual(_tcgen05_root_m_threads(128, 256), 32)
@@ -6998,6 +7334,123 @@ class TestCuteLowerings(unittest.TestCase):
             "tcgen05_epilogue_rest_mode_1 = cute.make_layout(1, stride=0)",
             emitted,
         )
+
+    def test_emit_sched_pipeline_setup_round_trips_pipeline_async(self) -> None:
+        """``_emit_sched_pipeline_setup`` emits the
+        ``cutlass.pipeline.PipelineAsync.create`` wrapper used to
+        broadcast tile coordinates from a scheduler warp to consumer
+        warps. Mirrors the shape of Quack's ``make_sched_pipeline``
+        and the existing inline scheduler emission in
+        ``program_id._build_tcgen05_persistent_layout``.
+
+        Three configurations are exercised:
+
+        - Single-CTA, no defer-sync: ``consumer_mask`` and
+          ``defer_sync`` are both omitted from the
+          ``PipelineAsync.create`` call.
+        - Cluster + defer-sync: both ``consumer_mask=cutlass.Int32(0)``
+          and ``defer_sync=True`` appear, matching the wrapping
+          convention of the existing scheduler emission.
+        - Same ``DeviceFunction`` reused: the suffix on the second
+          plan's ``new_var`` outputs advances to ``_2``, confirming
+          the helper does not memoize state on the device function.
+        """
+        df = _FakeDeviceFunction()
+        plan = _new_tcgen05_sched_pipeline_plan(df)
+        self.assertEqual(plan.barriers, "tcgen05_sched_pipeline_mbars_1")
+        self.assertEqual(plan.pipeline, "tcgen05_sched_pipeline_1")
+
+        stmts = _emit_sched_pipeline_setup(
+            plan,
+            sched_stage_count=2,
+            consumer_arrive_count=15,
+            cluster_size=1,
+            defer_sync=False,
+        )
+        emitted = "\n".join(ast.unparse(stmt) for stmt in stmts)
+
+        self.assertEqual(len(stmts), 6)
+        # mbar size is `2 * num_stages` Int64 slots, wrapped in
+        # cutlass.Int32(...) — matches the existing acc-pipeline
+        # barrier-storage shape and program_id.py's scheduler
+        # emission.
+        self.assertIn(
+            "tcgen05_sched_pipeline_mbars_1 = cute.arch.alloc_smem("
+            "cutlass.Int64, cutlass.Int32(4))",
+            emitted,
+        )
+        # Producer group: single thread, no count (consistent with
+        # the existing acc-pipeline producer group).
+        self.assertIn(
+            "tcgen05_sched_pipeline_producer_group_1 = "
+            "cutlass.pipeline.CooperativeGroup(cutlass.pipeline.Agent.Thread)",
+            emitted,
+        )
+        # Consumer group: caller-supplied arrive count wrapped in
+        # cutlass.Int32(...).
+        self.assertIn(
+            "tcgen05_sched_pipeline_consumer_group_1 = "
+            "cutlass.pipeline.CooperativeGroup("
+            "cutlass.pipeline.Agent.Thread, cutlass.Int32(15))",
+            emitted,
+        )
+        # PipelineAsync.create appears exactly once with neither
+        # consumer_mask nor defer_sync — single-CTA, eager-init
+        # path.
+        self.assertEqual(emitted.count("cutlass.pipeline.PipelineAsync.create"), 1)
+        self.assertIn(
+            "cutlass.pipeline.PipelineAsync.create(num_stages=2, "
+            "producer_group=tcgen05_sched_pipeline_producer_group_1, "
+            "consumer_group=tcgen05_sched_pipeline_consumer_group_1, "
+            "barrier_storage=tcgen05_sched_pipeline_mbars_1)",
+            emitted,
+        )
+        self.assertNotIn("consumer_mask", emitted)
+        self.assertNotIn("defer_sync", emitted)
+        # Producer / consumer pipeline-state initializers.
+        self.assertIn(
+            "tcgen05_sched_pipeline_producer_state_1 = "
+            "cutlass.pipeline.make_pipeline_state("
+            "cutlass.pipeline.PipelineUserType.Producer, 2)",
+            emitted,
+        )
+        self.assertIn(
+            "tcgen05_sched_pipeline_consumer_state_1 = "
+            "cutlass.pipeline.make_pipeline_state("
+            "cutlass.pipeline.PipelineUserType.Consumer, 2)",
+            emitted,
+        )
+
+        # Cluster + defer-sync path. Reuse the same DeviceFunction so
+        # the suffix on the second plan advances to ``_2`` —
+        # validates that ``_new_tcgen05_sched_pipeline_plan`` is a
+        # pure allocator with no memoization.
+        plan_cluster = _new_tcgen05_sched_pipeline_plan(df)
+        self.assertEqual(plan_cluster.barriers, "tcgen05_sched_pipeline_mbars_2")
+        self.assertEqual(plan_cluster.pipeline, "tcgen05_sched_pipeline_2")
+        cluster_stmts = _emit_sched_pipeline_setup(
+            plan_cluster,
+            sched_stage_count=2,
+            consumer_arrive_count=16,
+            cluster_size=2,
+            defer_sync=True,
+        )
+        cluster_emitted = "\n".join(ast.unparse(s) for s in cluster_stmts)
+        # PipelineAsync.create now carries both consumer_mask
+        # (wrapped via cutlass.Int32 to match the existing scheduler
+        # emission in program_id.py) and defer_sync=True so the
+        # pipeline participates in the cluster-wide deferred-init
+        # protocol.
+        self.assertIn(
+            "cutlass.pipeline.PipelineAsync.create(num_stages=2, "
+            "producer_group=tcgen05_sched_pipeline_producer_group_2, "
+            "consumer_group=tcgen05_sched_pipeline_consumer_group_2, "
+            "barrier_storage=tcgen05_sched_pipeline_mbars_2, "
+            "consumer_mask=cutlass.Int32(0), defer_sync=True)",
+            cluster_emitted,
+        )
+        self.assertIn("cutlass.Int32(16)", cluster_emitted)
+        self.assertEqual(len(cluster_stmts), 6)
 
     def test_tcgen05_codegen_emits_cluster_and_role_split_knobs(self) -> None:
         @helion.kernel(backend="cute")


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2391
 * #2390
 * #2389
 * #2388
 * #2387
 * #2386
 * #2385
 * #2384
 * #2383
 * #2382
 * __->__#2381
 * #2380


--- --- ---

### [cutedsl] Drive matmul warp roles from generated warp-spec records