### PR TITLE
[cutedsl] Enable cluster_n=2 under role-local scheduler

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -2605,11 +2605,26 @@ def _emit_mma_pipeline(
             # empty mbar (mirrors Quack's ``make_sched_pipeline`` for
             # ``cluster_size > 1``). For cluster_size == 1 the two
             # topologies degenerate to the same per-CTA shape.
-            if tcgen05_matmul_plan.is_clc_persistent and tcgen05_cluster_m > 1:
+            # ``cluster_size`` is the full cluster envelope
+            # (``cluster_m * cluster_n``) so the cluster-wide arrive
+            # count under cluster_n=2 spans the full 4-CTA cluster
+            # AND the deferred-init protocol participates in the same
+            # cluster-wide barrier init as the AB / acc pipelines.
+            # For cluster_n=2 under ``ROLE_LOCAL_WITH_SCHEDULER`` the
+            # per-CTA-local scheduler topology is preserved (each CTA
+            # in the 4-CTA cluster runs its own scheduler that
+            # publishes locally and consumers release locally — see
+            # the ``consumer_mask_to_leader=False`` branch below);
+            # only the deferred-init participation needs the full
+            # cluster envelope so every CTA in the cluster contributes
+            # its arrival to the cluster-wide ``pipeline_init``
+            # barrier.
+            tcgen05_sched_cluster_size = tcgen05_cluster_m * tcgen05_cluster_n
+            if tcgen05_matmul_plan.is_clc_persistent and tcgen05_sched_cluster_size > 1:
                 tcgen05_sched_consumer_arrive_count = (
                     tcgen05_matmul_plan.role_warp_count
                     - tcgen05_matmul_plan.scheduler_warp_count
-                ) * tcgen05_cluster_m
+                ) * tcgen05_sched_cluster_size
                 tcgen05_sched_consumer_mask_to_leader = True
             else:
                 tcgen05_sched_consumer_arrive_count = (
@@ -2622,7 +2637,7 @@ def _emit_mma_pipeline(
                     tcgen05_sched_plan,
                     sched_stage_count=tcgen05_matmul_plan.sched_stage_count,
                     consumer_arrive_count=tcgen05_sched_consumer_arrive_count,
-                    cluster_size=tcgen05_cluster_m,
+                    cluster_size=tcgen05_sched_cluster_size,
                     defer_sync=tcgen05_use_cluster_deferred_pipelines,
                     consumer_mask_to_leader=tcgen05_sched_consumer_mask_to_leader,
                     # One leader thread (lane 0 of the scheduler

--- a/helion/_compiler/cute/strategies.py
+++ b/helion/_compiler/cute/strategies.py
@@ -39,18 +39,23 @@ class Tcgen05Strategy(str, enum.Enum):
       dedicated scheduler warp that publishes ``(virtual_pid,
       tile_coord_mnkl, is_valid)`` into a per-CTA SMEM mailbox via
       a ``PipelineAsync``. The C-input epilogue-load warp Quack
-      uses (Quack's 8th warp) is not present because Helion does
-      not yet have C-input fusion;
-      ``CuteTcgen05MatmulPlan.launched_warp_count`` rounds to 8
-      launched warps (one inert padding warp) so warpgroup
-      ``setmaxregister`` semantics are uniform. Validated at
-      ``cluster_m`` ∈ {1, 2}: each CTA in the cluster runs its
-      own scheduler that publishes locally and each CTA's
-      consumers release locally (no peer-CTA broadcast). Both
-      CTAs converge on the same cluster-level virtual_pid because
-      the consumer ``virtual_pid = work_tile_smem[0] // cluster_m
-      + ...`` formula collapses the per-CTA ``cta_id_in_cluster``
-      offset.
+      uses (Quack's 8th warp) is not present in cycle 33 because
+      Helion does not yet have a productive C-input warp (cycle
+      34 widens ``Tcgen05WarpSpec.c_input_warps`` to 1 to occupy
+      the slot); ``CuteTcgen05MatmulPlan.launched_warp_count``
+      rounds to 8 launched warps (one inert padding warp) so
+      warpgroup ``setmaxregister`` semantics are uniform.
+      Validated at ``cluster_m`` ∈ {1, 2} and ``cluster_n``
+      ∈ {1, 2}: each CTA in the cluster runs its own scheduler
+      that publishes locally and each CTA's consumers release
+      locally (no peer-CTA broadcast). Both CTAs converge on the
+      same cluster-level virtual_pid because the consumer
+      ``virtual_pid = work_tile_smem[0] // cluster_m + ...``
+      formula collapses the per-CTA ``cta_id_in_cluster`` offset.
+      cycle 33 lifted the cluster_n=2 restriction by widening the
+      sched_pipeline ``cluster_size`` argument to the full
+      ``cluster_m * cluster_n`` envelope so the deferred-init
+      protocol participates in the cluster-wide barrier-init.
     """
 
     ROLE_LOCAL_MONOLITHIC = "role_local_monolithic"
@@ -118,6 +123,14 @@ ROLE_LOCAL_MONOLITHIC_MMA_WARPS = 1
 ROLE_LOCAL_MONOLITHIC_EPI_WARPS = 4
 ROLE_LOCAL_MONOLITHIC_EPI_LOAD_WARPS = 0
 ROLE_LOCAL_MONOLITHIC_SCHEDULER_WARPS = 0
+# ``c_input_warps`` slot for the dedicated C-input / auxiliary-tensor warp
+# that drives a TMA-loaded SMEM-ring producer pipeline (G3.1-C step-2 in
+# ``cute_plan.md`` §7.5.3.2). Default 0 keeps the historical inert-padding
+# behavior under ``ROLE_LOCAL_WITH_SCHEDULER``; the validator allows the
+# value 1 only under ``ROLE_LOCAL_WITH_SCHEDULER`` once the TMA producer +
+# SMEM ring + role-local while loop land. The autotune surface stays
+# narrowed to 0 until perf is characterized.
+ROLE_LOCAL_MONOLITHIC_C_INPUT_WARPS = 0
 # Today's role-local lowering uses a (decrease, increase) register split of
 # (120, 256). The decrease side runs on TMA-load + scheduler warps; the
 # increase side runs on MMA-exec + epilogue + epilogue-load warps.
@@ -148,6 +161,18 @@ class Tcgen05WarpSpec:
     - ``scheduler_warps``: 0 in ``ROLE_LOCAL_MONOLITHIC`` (each role
       runs its own scheduler), 1 in ``ROLE_LOCAL_WITH_SCHEDULER``
       (dedicated scheduler warp drives a broadcasting pipeline).
+    - ``c_input_warps``: dedicated C-input warp count. Currently
+      narrowed to ``{0}`` for both strategies (the data-model slot
+      is plumbed through normalize / round-trip but the validator
+      rejects nonzero); cycle 34 widens
+      ``ROLE_LOCAL_WITH_SCHEDULER`` to ``{0, 1}`` once the dedicated
+      TMA producer + SMEM ring + role-local while loop land
+      (``cute_plan.md`` §7.5.3.2). Setting this to 1 is intended
+      to convert the 8-warp shape's currently-inert padding warp
+      under ``ROLE_LOCAL_WITH_SCHEDULER`` into a productive
+      C-input TMA producer; ``ROLE_LOCAL_MONOLITHIC`` has no such
+      warp slot to occupy. The autotune surface stays narrowed to
+      0 until cycle 34 perf-validates the productive C-input warp.
     - ``register_split``: ``(decrease, increase)`` ``setmaxregister``
       counts. The current 6-warp shape uses ``(120, 256)``. Each
       entry's range is enforced by its per-field fragment in
@@ -163,6 +188,12 @@ class Tcgen05WarpSpec:
     epi_load_warps: int
     scheduler_warps: int
     register_split: tuple[int, int]
+    # ``c_input_warps`` is keyword-only (via ``KW_ONLY``) so adding
+    # the field after ``register_split`` doesn't shift positional
+    # constructors that existing callers rely on; the validator and
+    # lowering use the field name, not position.
+    _: dataclasses.KW_ONLY
+    c_input_warps: int = 0
 
     @property
     def total_warps(self) -> int:
@@ -172,6 +203,7 @@ class Tcgen05WarpSpec:
             + self.epi_warps
             + self.epi_load_warps
             + self.scheduler_warps
+            + self.c_input_warps
         )
 
 
@@ -185,6 +217,7 @@ ROLE_LOCAL_MONOLITHIC_DEFAULT_WARP_SPEC = Tcgen05WarpSpec(
     epi_load_warps=ROLE_LOCAL_MONOLITHIC_EPI_LOAD_WARPS,
     scheduler_warps=ROLE_LOCAL_MONOLITHIC_SCHEDULER_WARPS,
     register_split=ROLE_LOCAL_MONOLITHIC_REGISTER_SPLIT,
+    c_input_warps=ROLE_LOCAL_MONOLITHIC_C_INPUT_WARPS,
 )
 
 
@@ -238,6 +271,11 @@ TCGEN05_WARP_SPEC_AB_LOAD_WARPS_KEY = "tcgen05_warp_spec_ab_load_warps"
 TCGEN05_WARP_SPEC_MMA_WARPS_KEY = "tcgen05_warp_spec_mma_warps"
 TCGEN05_WARP_SPEC_EPI_LOAD_WARPS_KEY = "tcgen05_warp_spec_epi_load_warps"
 TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY = "tcgen05_warp_spec_scheduler_warps"
+# ``c_input_warps``: dedicated C-input / auxiliary-tensor warp count.
+# G3.1-C step-2 in ``cute_plan.md`` §7.5.3.2; today narrowed to 0 in
+# the autotune surface, validated to ``{0, 1}`` only under
+# ``ROLE_LOCAL_WITH_SCHEDULER`` in the user-config validation surface.
+TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY = "tcgen05_warp_spec_c_input_warps"
 # Register-split is exposed as two scalar keys (decrease, increase)
 # rather than a tuple value because flat config values are scalars.
 TCGEN05_WARP_SPEC_REGISTER_DECREASE_KEY = "tcgen05_warp_spec_register_decrease"
@@ -253,6 +291,7 @@ TCGEN05_WARP_SPEC_KEYS: tuple[str, ...] = (
     TCGEN05_WARP_SPEC_MMA_WARPS_KEY,
     TCGEN05_WARP_SPEC_EPI_LOAD_WARPS_KEY,
     TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY,
+    TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY,
     TCGEN05_WARP_SPEC_REGISTER_DECREASE_KEY,
     TCGEN05_WARP_SPEC_REGISTER_INCREASE_KEY,
 )
@@ -293,6 +332,7 @@ TCGEN05_WARP_SPEC_DEFAULTS_BY_KEY: dict[str, int] = {
     TCGEN05_WARP_SPEC_MMA_WARPS_KEY: ROLE_LOCAL_MONOLITHIC_MMA_WARPS,
     TCGEN05_WARP_SPEC_EPI_LOAD_WARPS_KEY: ROLE_LOCAL_MONOLITHIC_EPI_LOAD_WARPS,
     TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY: ROLE_LOCAL_MONOLITHIC_SCHEDULER_WARPS,
+    TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY: ROLE_LOCAL_MONOLITHIC_C_INPUT_WARPS,
     TCGEN05_WARP_SPEC_REGISTER_DECREASE_KEY: ROLE_LOCAL_MONOLITHIC_REGISTER_SPLIT[0],
     TCGEN05_WARP_SPEC_REGISTER_INCREASE_KEY: ROLE_LOCAL_MONOLITHIC_REGISTER_SPLIT[1],
 }
@@ -328,6 +368,13 @@ def warp_spec_from_config(config: Mapping[str, object]) -> Tcgen05WarpSpec:
             _as_int(config[TCGEN05_WARP_SPEC_REGISTER_DECREASE_KEY]),
             _as_int(config[TCGEN05_WARP_SPEC_REGISTER_INCREASE_KEY]),
         ),
+        # ``c_input_warps`` was added in cycle 33 as the foundation
+        # for G3.1-C step-2 (``cute_plan.md`` §7.5.3.2). The
+        # validator below restricts its accept set per-strategy; the
+        # default is 0 so configs serialized before cycle 33 (which
+        # never carry the key) round-trip via ``ConfigSpec.normalize``
+        # picking up ``ROLE_LOCAL_MONOLITHIC_C_INPUT_WARPS``.
+        c_input_warps=_as_int(config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY]),
     )
 
 
@@ -469,6 +516,24 @@ _STRATEGY_REQUIRED_SCHEDULER_WARPS: dict[Tcgen05Strategy, int] = {
     Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER: 1,
 }
 
+# Strategy-conditional ``c_input_warps`` accept set. Per ``cute_plan.md``
+# §7.5.3.2, only ``ROLE_LOCAL_WITH_SCHEDULER`` can host a productive
+# C-input warp (the inert padding warp under the WITH_SCHEDULER 8-warp
+# shape becomes the C-input TMA producer). ``ROLE_LOCAL_MONOLITHIC``
+# has no such warp slot — its 6-warp shape is fully populated by the
+# TMA-load + MMA-exec + 4 epi warps. Values outside the per-strategy
+# accept set are rejected so user configs cannot reach an unsupported
+# combination silently. cycle 33: validator accepts ``{0}`` for both
+# strategies; cycle 34 widens ``ROLE_LOCAL_WITH_SCHEDULER`` to ``{0, 1}``
+# once the dedicated TMA producer + SMEM ring + role-local while
+# loop land. This staging keeps the data-model slot stable for
+# config serialization round-trips while keeping user configs from
+# reaching a not-yet-implemented codegen path.
+_STRATEGY_SUPPORTED_C_INPUT_WARPS: dict[Tcgen05Strategy, frozenset[int]] = {
+    Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC: frozenset({0}),
+    Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER: frozenset({0}),
+}
+
 # When the strategy demands warpgroup-aligned splits (every 4 warps
 # == one warpgroup, ``setmaxregister`` is warpgroup-uniform), the
 # total warp count must be a multiple of 4. ``ROLE_LOCAL_MONOLITHIC``
@@ -501,15 +566,44 @@ _STRATEGY_SUPPORTED_CLUSTER_M: dict[Tcgen05Strategy, frozenset[int]] = {
     Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER: frozenset({1, 2}),
 }
 
-# Strategy-conditional cluster_n capability. cluster_n=2 is only validated
-# for ``ROLE_LOCAL_MONOLITHIC`` today (the Quack-canonical 4-CTA cluster
-# is the perf target for G2; ``ROLE_LOCAL_WITH_SCHEDULER`` would also
-# require fixing the broadcast topology for cluster_n>1, which is out
-# of scope for cycle 27). Set outside the supported set is rejected so
-# user configs cannot reach an untested cluster shape.
+# Strategy-conditional cluster_n capability. cluster_n=2 is now validated
+# under both ``ROLE_LOCAL_MONOLITHIC`` (the existing Quack-canonical 4-CTA
+# cluster path) and ``ROLE_LOCAL_WITH_SCHEDULER`` (cycle 33: the precursor
+# for G3.1-C step-2's productive C-input warp). The WITH_SCHEDULER
+# scheduler topology is "every CTA in the cluster runs its own scheduler
+# that publishes locally" (see ``cute_mma._codegen_cute_mma`` ``consumer
+# _mask_to_leader=False`` branch); generalizing to cluster_n=2 keeps the
+# per-CTA-local pattern with the cluster_size at the sched_pipeline level
+# updated to ``cluster_m * cluster_n`` so the deferred-pipeline cluster-
+# barrier sync still spans the full V=2 cluster_n=2 4-CTA cluster envelope.
+# Setting outside the supported set is rejected so user configs cannot
+# reach an untested cluster shape.
 _STRATEGY_SUPPORTED_CLUSTER_N: dict[Tcgen05Strategy, frozenset[int]] = {
     Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC: frozenset({1, 2}),
-    Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER: frozenset({1}),
+    Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER: frozenset({1, 2}),
+}
+
+# (strategy, persistence_model)-conditional cluster_n accept set. Used to
+# reject combinations where the (strategy, persistence) pair has a
+# cluster-broadcast topology that has not been generalized to cluster_n>1.
+# Today's only entry: ``CLC_PERSISTENT`` under ``ROLE_LOCAL_WITH_SCHEDULER``
+# is cluster_m-only — the CLC scheduler-warp body iterates lanes
+# ``< cluster_m`` to publish to peer CTAs (see ``program_id.py``
+# ``_build_scheduler_warp_role_local_while_clc``); cluster_n>1 CTAs would
+# never receive the CLC mailbox publish and would hang on the
+# ``producer_acquire`` wait. Generalizing the CLC broadcast to cluster_n>1
+# is out of scope for cycle 33 (deferred to a future cycle alongside the
+# ``cluster_n>1`` C-input pipeline work). When a (strategy, persistence)
+# pair appears here, it overrides the per-strategy
+# ``_STRATEGY_SUPPORTED_CLUSTER_N`` entry; missing entries fall back to
+# the per-strategy capability.
+_STRATEGY_PERSISTENCE_SUPPORTED_CLUSTER_N: dict[
+    tuple[Tcgen05Strategy, Tcgen05PersistenceModel], frozenset[int]
+] = {
+    (
+        Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER,
+        Tcgen05PersistenceModel.CLC_PERSISTENT,
+    ): frozenset({1}),
 }
 
 
@@ -624,6 +718,19 @@ def validate_tcgen05_strategy_invariants(
             f"{warp_spec.scheduler_warps}"
         )
 
+    # ``c_input_warps`` accept set is per-strategy; today narrows
+    # both strategies to ``{0}`` until the dedicated TMA producer +
+    # SMEM ring + role-local while loop lands. The data-model slot
+    # is plumbed through normalize / round-trip paths so the
+    # accept set can widen without further config-shape churn.
+    supported_c_input = _STRATEGY_SUPPORTED_C_INPUT_WARPS.get(strategy, frozenset())
+    if supported_c_input and warp_spec.c_input_warps not in supported_c_input:
+        errors.append(
+            f"tcgen05 strategy {strategy.value!r} only accepts "
+            f"c_input_warps in {sorted(supported_c_input)!r}; got "
+            f"c_input_warps={warp_spec.c_input_warps}"
+        )
+
     # ``epi_warps`` is intentionally NOT checked here — its accept-
     # set is owned by ``tcgen05_num_epi_warps`` validation
     # (``restrict_tcgen05_num_epi_warps_validation``) so there is one
@@ -674,6 +781,25 @@ def validate_tcgen05_strategy_invariants(
             f"tcgen05_cluster_n={cluster_n} requires tcgen05_cluster_m=2 "
             f"with use_2cta=True (the validated 4-CTA cluster envelope; "
             f"cute_plan.md §6.12); got tcgen05_cluster_m={cluster_m}"
+        )
+
+    # (strategy, persistence_model) paired cluster_n accept set.
+    # Some persistence models have cluster-broadcast topology that
+    # has not been generalized to cluster_n>1; they must reject
+    # cluster_n>1 even when the per-strategy capability allows it.
+    # See ``_STRATEGY_PERSISTENCE_SUPPORTED_CLUSTER_N`` for the rationale.
+    paired_supported_cluster_n = _STRATEGY_PERSISTENCE_SUPPORTED_CLUSTER_N.get(
+        (strategy, persistence_model)
+    )
+    if (
+        paired_supported_cluster_n is not None
+        and cluster_n not in paired_supported_cluster_n
+    ):
+        errors.append(
+            f"tcgen05 strategy {strategy.value!r} with persistence model "
+            f"{persistence_model.value!r} only runs correctly at "
+            f"tcgen05_cluster_n in {sorted(paired_supported_cluster_n)!r}; "
+            f"got tcgen05_cluster_n={cluster_n}"
         )
 
     # Layout overrides may only carry concrete values under the

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -29,6 +29,7 @@ from .._compiler.cute.strategies import TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY
 from .._compiler.cute.strategies import TCGEN05_STRATEGY_CONFIG_KEY
 from .._compiler.cute.strategies import TCGEN05_STRATEGY_CONFIG_KEYS
 from .._compiler.cute.strategies import TCGEN05_WARP_SPEC_AB_LOAD_WARPS_KEY
+from .._compiler.cute.strategies import TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY
 from .._compiler.cute.strategies import TCGEN05_WARP_SPEC_DEFAULTS_BY_KEY
 from .._compiler.cute.strategies import TCGEN05_WARP_SPEC_EPI_LOAD_WARPS_KEY
 from .._compiler.cute.strategies import TCGEN05_WARP_SPEC_MMA_WARPS_KEY
@@ -933,6 +934,13 @@ class ConfigSpec:
             # MONOLITHIC, scheduler_warps must be 0; the validator
             # rejects 1 with a MONOLITHIC strategy.
             TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY: EnumFragment((0,)),
+            # ``c_input_warps``: G3.1-C step-2 (``cute_plan.md``
+            # §7.5.3.2) lifts this to ``{0, 1}`` under
+            # ``ROLE_LOCAL_WITH_SCHEDULER`` once the dedicated TMA
+            # producer + SMEM ring + role-local while loop land. The
+            # autotune surface stays narrowed to ``(0,)`` until
+            # cycle 34 perf-validates the productive C-input warp.
+            TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY: EnumFragment((0,)),
             # Register split is currently fixed at the role-local
             # MONOLITHIC values. G2-E may broaden.
             TCGEN05_WARP_SPEC_REGISTER_DECREASE_KEY: EnumFragment(
@@ -1000,6 +1008,17 @@ class ConfigSpec:
             )
         )
         fragments[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY] = EnumFragment((0, 1))
+        # ``c_input_warps`` validation surface: accept ``{0, 1}`` so
+        # explicit user configs can opt in to the productive C-input
+        # warp slot via ``helion.Config(tcgen05_warp_spec_c_input_warps=1)``.
+        # The cross-fragment validator
+        # (``validate_tcgen05_strategy_invariants``) further narrows
+        # the value per-strategy: today both strategies reject nonzero
+        # until the dedicated TMA producer + SMEM ring + role-local
+        # while loop land; the accept set widens to ``{0, 1}`` for
+        # ``ROLE_LOCAL_WITH_SCHEDULER`` once that codegen path lands
+        # (``cute_plan.md`` §7.5.3.2).
+        fragments[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY] = EnumFragment((0, 1))
         return fragments
 
     @staticmethod

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -1783,6 +1783,102 @@ class TestCuteLowerings(unittest.TestCase):
             code,
         )
 
+    def test_tcgen05_with_scheduler_cluster_n2_codegen(
+        self,
+    ) -> None:
+        """G3.1-C step-2 precursor (cute_plan.md §7.5.3.2, cycle 33).
+
+        ``ROLE_LOCAL_WITH_SCHEDULER`` + ``cluster_n=2`` is now a
+        validated codegen path: the strategy validator's per-strategy
+        ``cluster_n`` accept set widens to ``{1, 2}`` so the
+        Quack-canonical ``(cluster_m=2, cluster_n=2, 1)`` 4-CTA
+        cluster is reachable from explicit user configs. The
+        per-CTA-local scheduler topology stays the same shape as
+        cluster_m=2 (every CTA in the cluster runs its own scheduler
+        publishing locally; consumers release locally) so the
+        ``consumer_mask=cutlass.Int32(0)`` literal must NOT appear,
+        matching the cluster_m=2 codegen pin in
+        ``test_tcgen05_with_scheduler_cluster_m2_per_cta_topology_codegen``.
+
+        The cluster envelope ``cluster_m * cluster_n = 4`` participates
+        in the deferred-init protocol (``defer_sync=True`` still
+        emitted), and the cluster_layout shape pins to ``(2, 2, 1)``.
+        """
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_with_scheduler_c2_n2(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        config = helion.Config(
+            block_sizes=[256, 256, 128],
+            l2_groupings=[1],
+            num_warps=4,
+            num_sm_multiplier=1,
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=2,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+            tcgen05_strategy="role_local_with_scheduler",
+            tcgen05_warp_spec_scheduler_warps=1,
+            indexing=[
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "tensor_descriptor",
+            ],
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_with_scheduler_c2_n2.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code = bound.to_triton_code(config)
+
+        # Cluster shape is (2, 2, 1) — the canonical 4-CTA cluster.
+        self.assertIn("cute.make_layout((2, 2, 1))", code)
+        # Per-CTA scheduler topology preserved at cluster_n=2: no
+        # consumer_mask=Int32(0) literal (which would route every
+        # CTA's release to the cluster leader and starve non-leaders).
+        self.assertNotIn("consumer_mask=cutlass.Int32(0)", code)
+        sched_create_idx = code.find("tcgen05_sched_pipeline = ")
+        self.assertGreater(
+            sched_create_idx,
+            -1,
+            msg="WITH_SCHEDULER + cluster_n=2 kernel did not emit a "
+            "sched_pipeline.create",
+        )
+        sched_create_end = code.find(")", sched_create_idx)
+        sched_create_call = code[sched_create_idx:sched_create_end]
+        self.assertNotIn("consumer_mask", sched_create_call)
+        # ``defer_sync=True`` still appears so the sched_pipeline
+        # init coordinates with the AB / acc / c pipelines under the
+        # cluster-deferred protocol; the cluster envelope is now 4
+        # (cluster_m * cluster_n).
+        self.assertIn("defer_sync=True", sched_create_call)
+        # Per-CTA consumer arrive count = role_warps - scheduler_warps
+        # = 1 + 1 + 4 + 0 = 6 (unchanged from cluster_n=1: each CTA
+        # in the cluster still runs its own scheduler).
+        self.assertIn(
+            "tcgen05_sched_pipeline_consumer_group = "
+            "cutlass.pipeline.CooperativeGroup("
+            "cutlass.pipeline.Agent.Thread, cutlass.Int32(6))",
+            code,
+        )
+
     def test_tcgen05_clc_persistent_codegen(self) -> None:
         """G2-H CLC scheduler-warp body codegen pin (cute_plan.md).
 

--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -1216,6 +1216,12 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         self.assertNotIn("tcgen05_warp_spec_epi_warps", default_cfg.config)
         self.assertEqual(default_cfg.config["tcgen05_warp_spec_epi_load_warps"], 0)
         self.assertEqual(default_cfg.config["tcgen05_warp_spec_scheduler_warps"], 0)
+        # ``c_input_warps`` was added in cycle 33 as the foundation for
+        # G3.1-C step-2 (``cute_plan.md`` §7.5.3.2). Default is 0 so
+        # serialized configs round-trip cleanly; the value 1 will be
+        # accepted under ``ROLE_LOCAL_WITH_SCHEDULER`` once cycle 34
+        # lands the dedicated TMA producer + SMEM ring.
+        self.assertEqual(default_cfg.config["tcgen05_warp_spec_c_input_warps"], 0)
         self.assertEqual(default_cfg.config["tcgen05_warp_spec_register_decrease"], 120)
         self.assertEqual(default_cfg.config["tcgen05_warp_spec_register_increase"], 256)
         for key in (
@@ -1505,16 +1511,17 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
 
     @onlyBackends(["cute"])
     def test_cute_tcgen05_strategy_invariants_cluster_n(self) -> None:
-        """G2 cluster_n=2 validator coverage (cute_plan.md §6.12.7).
+        """G2 cluster_n=2 validator coverage (cute_plan.md §6.12.7,
+        cycle 33 widening for ``ROLE_LOCAL_WITH_SCHEDULER``).
 
-        ``cluster_n=2`` only runs under ``ROLE_LOCAL_MONOLITHIC`` with
-        ``cluster_m=2`` (the validated 4-CTA cluster envelope). The
-        validator rejects:
+        ``cluster_n=2`` requires the 4-CTA V=2 cluster (``cluster_m=2``
+        with ``use_2cta=True``). The validator now accepts cluster_n=2
+        under both ``ROLE_LOCAL_MONOLITHIC`` and
+        ``ROLE_LOCAL_WITH_SCHEDULER`` (cycle 33 lifted the
+        WITH_SCHEDULER restriction so the cluster_n=2 lever exposes
+        the G3.1-C step-2 productive C-input warp opportunity); it
+        still rejects:
           - ``cluster_n=2`` with ``cluster_m=1`` (V=1 has no 4-CTA path)
-          - ``cluster_n=2`` under ``ROLE_LOCAL_WITH_SCHEDULER`` (the
-            scheduler-broadcast topology is not validated for cluster_n>1)
-        and accepts ``cluster_n=2`` under ``ROLE_LOCAL_MONOLITHIC`` +
-        ``cluster_m=2``.
         """
         # Positive control: cluster_n=2 + ROLE_LOCAL_MONOLITHIC + cluster_m=2.
         errors = validate_tcgen05_strategy_invariants(
@@ -1546,8 +1553,11 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
             msg=str(errors),
         )
 
-        # cluster_n=2 under ROLE_LOCAL_WITH_SCHEDULER: rejected
-        # (scheduler-broadcast topology is not validated for cluster_n>1).
+        # cluster_n=2 under ROLE_LOCAL_WITH_SCHEDULER: ACCEPTED
+        # in cycle 33 (the scheduler-broadcast topology generalizes
+        # to cluster_n=2 with the per-CTA-local pattern preserved
+        # and the cluster envelope ``cluster_m * cluster_n`` wired
+        # through the deferred-init protocol).
         with_sched = dataclasses.replace(
             ROLE_LOCAL_MONOLITHIC_DEFAULT_WARP_SPEC, scheduler_warps=1
         )
@@ -1561,8 +1571,176 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
             cluster_m=2,
             cluster_n=2,
         )
+        self.assertEqual(errors, [], msg=str(errors))
+
+        # cluster_n=2 with cluster_m=1 still rejected under
+        # ROLE_LOCAL_WITH_SCHEDULER (V=1 has no 4-CTA path).
+        errors = validate_tcgen05_strategy_invariants(
+            strategy=Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER,
+            persistence_model=Tcgen05PersistenceModel.STATIC_PERSISTENT,
+            layout_strategy=Tcgen05LayoutStrategy.DEFAULT,
+            warp_spec=with_sched,
+            layout_overrides=Tcgen05LayoutOverrides(),
+            pid_type="persistent_blocked",
+            cluster_m=1,
+            cluster_n=2,
+        )
         self.assertTrue(
-            any("tcgen05_cluster_n in [1]" in e for e in errors),
+            any("requires tcgen05_cluster_m=2" in e for e in errors),
+            msg=str(errors),
+        )
+
+    @onlyBackends(["cute"])
+    def test_cute_tcgen05_strategy_invariants_c_input_warps(self) -> None:
+        """G3.1-C step-2 (cute_plan.md §7.5.3.2) data-model entrance:
+        ``c_input_warps`` is plumbed through the dataclass + validator,
+        and cycle 33's narrowing rejects nonzero for both strategies
+        until cycle 34 lands the dedicated TMA producer + SMEM ring.
+
+        - Positive control: ``c_input_warps=0`` accepted under both
+          ``ROLE_LOCAL_MONOLITHIC`` and ``ROLE_LOCAL_WITH_SCHEDULER``
+          (the field is plumbed through normalize / round-trip and
+          defaults to 0 for legacy configs).
+        - Negative control: ``c_input_warps=1`` is rejected under
+          both strategies in cycle 33; cycle 34 widens the
+          ``ROLE_LOCAL_WITH_SCHEDULER`` accept set to ``{0, 1}`` once
+          the productive C-input warp implementation lands.
+        """
+        # Positive control: c_input_warps=0 under MONOLITHIC.
+        errors = validate_tcgen05_strategy_invariants(
+            strategy=Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC,
+            persistence_model=Tcgen05PersistenceModel.STATIC_PERSISTENT,
+            layout_strategy=Tcgen05LayoutStrategy.DEFAULT,
+            warp_spec=ROLE_LOCAL_MONOLITHIC_DEFAULT_WARP_SPEC,
+            layout_overrides=Tcgen05LayoutOverrides(),
+            pid_type="persistent_blocked",
+            cluster_m=1,
+        )
+        self.assertEqual(errors, [], msg=str(errors))
+
+        # Positive control: c_input_warps=0 under WITH_SCHEDULER.
+        with_sched = dataclasses.replace(
+            ROLE_LOCAL_MONOLITHIC_DEFAULT_WARP_SPEC, scheduler_warps=1
+        )
+        errors = validate_tcgen05_strategy_invariants(
+            strategy=Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER,
+            persistence_model=Tcgen05PersistenceModel.STATIC_PERSISTENT,
+            layout_strategy=Tcgen05LayoutStrategy.DEFAULT,
+            warp_spec=with_sched,
+            layout_overrides=Tcgen05LayoutOverrides(),
+            pid_type="persistent_blocked",
+            cluster_m=1,
+        )
+        self.assertEqual(errors, [], msg=str(errors))
+
+        # Negative control: c_input_warps=1 under MONOLITHIC.
+        c_input_monolithic = dataclasses.replace(
+            ROLE_LOCAL_MONOLITHIC_DEFAULT_WARP_SPEC, c_input_warps=1
+        )
+        errors = validate_tcgen05_strategy_invariants(
+            strategy=Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC,
+            persistence_model=Tcgen05PersistenceModel.STATIC_PERSISTENT,
+            layout_strategy=Tcgen05LayoutStrategy.DEFAULT,
+            warp_spec=c_input_monolithic,
+            layout_overrides=Tcgen05LayoutOverrides(),
+            pid_type="persistent_blocked",
+            cluster_m=1,
+        )
+        self.assertTrue(
+            any("c_input_warps in [0]" in e for e in errors),
+            msg=str(errors),
+        )
+
+        # Negative control: c_input_warps=1 under WITH_SCHEDULER
+        # (cycle 33). Cycle 34 widens this accept set to ``{0, 1}``.
+        c_input_with_sched = dataclasses.replace(with_sched, c_input_warps=1)
+        errors = validate_tcgen05_strategy_invariants(
+            strategy=Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER,
+            persistence_model=Tcgen05PersistenceModel.STATIC_PERSISTENT,
+            layout_strategy=Tcgen05LayoutStrategy.DEFAULT,
+            warp_spec=c_input_with_sched,
+            layout_overrides=Tcgen05LayoutOverrides(),
+            pid_type="persistent_blocked",
+            cluster_m=1,
+        )
+        self.assertTrue(
+            any("c_input_warps in [0]" in e for e in errors),
+            msg=str(errors),
+        )
+
+        # The dataclass total_warps reflects the c_input_warps slot
+        # so a future cycle-34 lift to c_input_warps=1 transparently
+        # adjusts the warp count without further data-model churn.
+        self.assertEqual(c_input_with_sched.total_warps, 8)
+
+    @onlyBackends(["cute"])
+    def test_cute_tcgen05_strategy_invariants_clc_persistent_cluster_n(
+        self,
+    ) -> None:
+        """``CLC_PERSISTENT`` + ``cluster_n>1`` is rejected.
+
+        The CLC scheduler-warp body in
+        ``program_id._build_scheduler_warp_role_local_while_clc``
+        publishes the work tile to peer CTAs by iterating lanes
+        ``< cluster_m``; cluster_n>1 CTAs would never receive the
+        CLC mailbox publish and would hang at ``producer_acquire``.
+        The paired ``(strategy, persistence_model)`` invariant
+        rejects this combination at validate time so the runtime
+        path is unreachable.
+        """
+        with_sched = dataclasses.replace(
+            ROLE_LOCAL_MONOLITHIC_DEFAULT_WARP_SPEC, scheduler_warps=1
+        )
+
+        # Positive control: CLC + cluster_n=1 still accepts.
+        errors = validate_tcgen05_strategy_invariants(
+            strategy=Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER,
+            persistence_model=Tcgen05PersistenceModel.CLC_PERSISTENT,
+            layout_strategy=Tcgen05LayoutStrategy.DEFAULT,
+            warp_spec=with_sched,
+            layout_overrides=Tcgen05LayoutOverrides(),
+            pid_type="persistent_blocked",
+            cluster_m=2,
+            cluster_n=1,
+            arch_major=10,
+        )
+        self.assertEqual(errors, [], msg=str(errors))
+
+        # Positive control: STATIC_PERSISTENT + cluster_n=2 accepts
+        # (the static path's per-CTA-local scheduler topology
+        # generalizes to cluster_n=2).
+        errors = validate_tcgen05_strategy_invariants(
+            strategy=Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER,
+            persistence_model=Tcgen05PersistenceModel.STATIC_PERSISTENT,
+            layout_strategy=Tcgen05LayoutStrategy.DEFAULT,
+            warp_spec=with_sched,
+            layout_overrides=Tcgen05LayoutOverrides(),
+            pid_type="persistent_blocked",
+            cluster_m=2,
+            cluster_n=2,
+            arch_major=10,
+        )
+        self.assertEqual(errors, [], msg=str(errors))
+
+        # Negative control: CLC + cluster_n=2 rejected. The CLC
+        # broadcast is cluster_m-only; second-N-lane CTAs never
+        # receive the mailbox publish.
+        errors = validate_tcgen05_strategy_invariants(
+            strategy=Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER,
+            persistence_model=Tcgen05PersistenceModel.CLC_PERSISTENT,
+            layout_strategy=Tcgen05LayoutStrategy.DEFAULT,
+            warp_spec=with_sched,
+            layout_overrides=Tcgen05LayoutOverrides(),
+            pid_type="persistent_blocked",
+            cluster_m=2,
+            cluster_n=2,
+            arch_major=10,
+        )
+        self.assertTrue(
+            any(
+                "clc_persistent" in e and "tcgen05_cluster_n in [1]" in e
+                for e in errors
+            ),
             msg=str(errors),
         )
 


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2391
 * #2390
 * #2389
 * __->__#2388
 * #2387
 * #2386
 * #2385
 * #2384
 * #2383
 * #2382
 * #2381
 * #2380


--- --- ---

### [cutedsl] Enable cluster_n=2 under role-local scheduler