### PR TITLE
[Pallas] jsd if output arity fix

### DIFF
--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -2276,18 +2276,27 @@ def _(state: CodegenState) -> list[object]:
         graph_info.if_arg_names[i]: if_args[i].id for i in range(len(if_args))
     } | {graph_info.else_arg_names[i]: else_args[i].id for i in range(len(else_args))}
 
-    if_return_names = [
-        cast("ast.Name", if_outputs[o]).id
-        if isinstance(o, int)
-        else arg_node_name_to_ast_name[o]
-        for (o, _) in graph_info.branches_outputs
-    ]
-    else_return_names = [
-        cast("ast.Name", else_outputs[o]).id
-        if isinstance(o, int)
-        else arg_node_name_to_ast_name[o]
-        for (_, o) in graph_info.branches_outputs
-    ]
+    if_return_names: list[str] = []
+    else_return_names: list[str] = []
+    output_aliases: dict[int, str] = {}
+    else_output_offset = len(if_outputs)
+    for if_entry, else_entry in graph_info.branches_outputs:
+        if_name = (
+            cast("ast.Name", if_outputs[if_entry]).id
+            if isinstance(if_entry, int)
+            else arg_node_name_to_ast_name[if_entry]
+        )
+        else_name = (
+            cast("ast.Name", else_outputs[else_entry]).id
+            if isinstance(else_entry, int)
+            else arg_node_name_to_ast_name[else_entry]
+        )
+        if_return_names.append(if_name)
+        else_return_names.append(else_name)
+        if isinstance(if_entry, int):
+            output_aliases[if_entry] = if_name
+        if isinstance(else_entry, int):
+            output_aliases[else_output_offset + else_entry] = if_name
 
     if_arg_ids = {arg.id for arg in if_args}
     union_args = if_args + [a for a in else_args if a.id not in if_arg_ids]
@@ -2340,10 +2349,13 @@ def _(state: CodegenState) -> list[object]:
             )
         )
 
+    outputs = [*if_outputs, *else_outputs]
     return cast(
         "list[object]",
-        [expr_from_string(n) for n in if_return_names]
-        + [expr_from_string(n) for n in else_return_names],
+        [
+            expr_from_string(output_aliases[i]) if i in output_aliases else output
+            for i, output in enumerate(outputs)
+        ],
     )
 
 

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -2278,6 +2278,10 @@ def _(state: CodegenState) -> list[object]:
 
     if_return_names: list[str] = []
     else_return_names: list[str] = []
+    # _if was traced as returning if_outputs + else_outputs, so surviving
+    # getitem nodes still index into that original full layout after DCE.
+    # Pallas lowers only phi values through lax.cond, so place each cond
+    # result back at the original if/else output indices it represents.
     output_aliases: dict[int, str] = {}
     else_output_offset = len(if_outputs)
     for if_entry, else_entry in graph_info.branches_outputs:

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1556,7 +1556,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             num_stages=3,
         )
 
-    @xfailIfPallas("InductorLoweringError")
     def test_jsd(self):
         args = (
             torch.randn([1024, 4096], device=DEVICE, dtype=torch.float32).log_softmax(

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -579,6 +579,48 @@ class TestPallas(TestCase):
         torch.testing.assert_close(x, x_copy)
         torch.testing.assert_close(y, y_copy)
 
+    def test_if_branch_intermediate_outputs(self) -> None:
+        """Branch intermediates must survive in _if output list."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def if_with_intermediate(
+            x: torch.Tensor, flag: float
+        ) -> torch.Tensor:
+            n, m = x.shape
+            block_n = hl.register_block_size(n)
+            block_m = hl.register_block_size(m)
+            out = torch.empty([n], device=x.device, dtype=torch.float32)
+            for tile_n in hl.tile(n, block_size=block_n):
+                acc = hl.zeros([tile_n, block_m], dtype=torch.float32)
+                for tile_m in hl.tile(m, block_size=block_m):
+                    v = x[tile_n, tile_m]
+                    if flag == 0.0:
+                        doubled = v * 2
+                        acc += doubled + 1
+                    else:
+                        acc += v
+                out[tile_n] = torch.sum(acc, dim=1)
+            return out
+
+        x = torch.randn(64, 64, device=DEVICE, dtype=torch.float32)
+
+        # else-branch
+        code, result = code_and_output(
+            if_with_intermediate,
+            (x, 0.5),
+            block_sizes=[1, 64],
+        )
+        self.assertIn("lax.cond", code)
+        torch.testing.assert_close(result, torch.sum(x, dim=1))
+
+        # if-branch
+        _, result = code_and_output(
+            if_with_intermediate,
+            (x, 0.0),
+            block_sizes=[1, 64],
+        )
+        torch.testing.assert_close(result, torch.sum(x * 2 + 1, dim=1))
+
     def test_add_2d(self) -> None:
         args = (
             torch.randn(64, 512, device=DEVICE, dtype=torch.float32),

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -583,9 +583,7 @@ class TestPallas(TestCase):
         """Branch intermediates must survive in _if output list."""
 
         @helion.kernel(backend="pallas", static_shapes=True)
-        def if_with_intermediate(
-            x: torch.Tensor, flag: float
-        ) -> torch.Tensor:
+        def if_with_intermediate(x: torch.Tensor, flag: float) -> torch.Tensor:
             n, m = x.shape
             block_n = hl.register_block_size(n)
             block_m = hl.register_block_size(m)


### PR DESCRIPTION
This PR is based onto https://github.com/pytorch/helion/pull/2398

Fix Pallas `_if` output index alignment when branches create local tensor temporaries.

Branch tracing currently registers `_if` as returning the full flattened branch output layout:
`if_outputs + else_outputs`

Because branch tracing uses `_collect_outputs(..., include_new=True)`, that full layout can include branch-local temporaries that are not semantically live after the `if`. For example:
```
    if flag == 0.0:
        doubled = v * 2
        acc += doubled + 1
    else:
        acc += v
```
This can trace `_if` with a layout like:
```
    [doubled, acc_if, acc_else]
```
The `doubled` getitem is dead and can be removed by DCE, but DCE does not renumber the surviving getitems for the phi'd `acc` value. Those getitems still refer to their original full-layout indices.

Pallas codegen previously returned only the compact `lax.cond` phi outputs. In the example above, it returned a two-element list for the merged `acc` values, while surviving getitems still expected the original slots 1 and 2 from the three-element traced layout. That could make a surviving getitem read the wrong slot or index past the end of the returned list.

Return a full-length list aligned with the original traced `_if` layout, and map each live phi slot back to the outer variable bound by the `lax.cond` assignment. Branch-local temporary slots remain in the returned list only to preserve indexing; their getitems are dead.
