### PR TITLE
[autotuner] make initial-population benchmark phase budget-aware

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -267,6 +267,7 @@ class BaseSearch(BaseAutotuner):
             log=self.log,
             autotune_metrics=self._autotune_metrics,
         )
+        self.benchmark_provider.set_budget_exceeded_fn(self._autotune_budget_exceeded)
 
     def _autotune_budget_exceeded(self) -> bool:
         budget = self.settings.autotune_budget_seconds

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -250,6 +250,10 @@ def _unset_fn(*args: object) -> NoReturn:
     raise RuntimeError("Uninitialized function")
 
 
+def _never_exceeded() -> bool:
+    return False
+
+
 class BenchmarkProvider(abc.ABC):
     """Abstract interface for benchmarking kernel configurations.
 
@@ -267,9 +271,21 @@ class BenchmarkProvider(abc.ABC):
             provider.cleanup()
 
     ``BaseSearch`` manages this lifecycle automatically.
+
+    ``budget_exceeded_fn`` is the local wall-clock budget check that
+    ``BaseSearch._prepare`` installs via ``set_budget_exceeded_fn``.
+    Subclasses should not call this hook directly inside loops that
+    participate in distributed collectives; use a sync wrapper that
+    agrees the cutoff across the process group so peers do not deadlock
+    on an unmatched collective. Default no-op so providers built before
+    the search installs the hook stay unchanged.
     """
 
     mutated_arg_indices: Sequence[int]
+    # ``staticmethod`` prevents Python from binding the class-level
+    # default to ``self`` when an instance reads it before any caller
+    # has installed a real hook via ``set_budget_exceeded_fn``.
+    budget_exceeded_fn: Callable[[], bool] = staticmethod(_never_exceeded)
 
     @abc.abstractmethod
     def __init__(
@@ -283,6 +299,10 @@ class BenchmarkProvider(abc.ABC):
     ) -> None:
         """Initialize the provider with kernel context and benchmarking state."""
         ...
+
+    def set_budget_exceeded_fn(self, fn: Callable[[], bool]) -> None:
+        """Install the search's budget-check hook on this provider."""
+        self.budget_exceeded_fn = fn
 
     @abc.abstractmethod
     def benchmark(
@@ -355,6 +375,8 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         self._precompile_args_path: str | None = None
         self._precompile_result_counter: count[int] = count()
         self._benchmark_worker: BenchmarkWorker | None = None
+        # budget_exceeded_fn inherits the class-level _never_exceeded default
+        # until BaseSearch._prepare installs the search's real hook.
 
         # TODO(hinriksnaer): baseline computation is expensive (compiles and runs
         # the kernel). Currently safe because the provider is only constructed
@@ -666,19 +688,57 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             args_path=self._precompile_args_path,
         )
 
+    def _budget_exceeded_synced(self) -> bool:
+        """Return whether any rank reports the autotune budget exhausted.
+
+        The compile and benchmark loops below participate in distributed
+        collectives. The cutoff decision must be agreed across the
+        process group; otherwise one rank breaks early while peers keep
+        entering collectives and the group deadlocks. Single-process
+        autotune skips the all-gather because
+        ``all_gather_object`` returns ``[obj]`` when distributed is not
+        initialized.
+        """
+        local = self.budget_exceeded_fn()
+        return any(
+            all_gather_object(
+                local,
+                process_group_name=self.kernel.env.process_group_name,
+            )
+        )
+
     def benchmark(
         self,
         configs: list[Config],
         *,
         desc: str = "Benchmarking",
     ) -> list[BenchmarkResult]:
-        """Compile, precompile, validate, and time a batch of configs."""
+        """Compile, precompile, validate, and time a batch of configs.
+
+        When ``budget_exceeded_fn`` reports the autotune wall-clock
+        budget exhausted, the compile and benchmark loops short-circuit
+        and leave any not-yet-handled slots at the default
+        ``perf=inf, status="error"`` so the caller still receives one
+        ``BenchmarkResult`` per input config in positional order. The
+        cutoff is synchronized across the process group via
+        ``_budget_exceeded_synced``.
+
+        The precompile-phase wait (``PrecompileFuture.wait_for_all``)
+        is not budget-aware: once the compile loop has queued
+        precompile futures it drains all of them, so the effective
+        wall-clock may overrun the configured budget by up to
+        ``len(queued) * autotune_compile_timeout`` seconds. Backends
+        that disable ``autotune_precompile`` (e.g. cute) skip that
+        wait entirely.
+        """
         all_configs = configs
         compiled: dict[int, Callable[..., object]] = {}
         futures: list[PrecompileFuture] | None = None
 
         # Compilation phase
         for i, config in enumerate(all_configs):
+            if self._budget_exceeded_synced():
+                break
             try:
                 compiled[i] = self.kernel.compile_config(config, allow_print=False)
             except Exception:
@@ -734,6 +794,8 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             enabled=self.settings.autotune_progress_bar,
         )
         for index, (fn, is_working, reason) in iterator:
+            if self._budget_exceeded_synced():
+                break
             config = configs[index]
             if futures is not None:
                 future = futures[index]

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -3295,6 +3295,169 @@ class TestAutotuneBudget(TestCase):
             "run_finishing_phase should stop when the autotune budget is exhausted",
         )
 
+    def test_prepare_wires_budget_hook_into_provider(self) -> None:
+        """``BaseSearch._prepare`` should install the budget-check hook on
+        the benchmark provider so the initial-population
+        compile/benchmark phase can short-circuit once the wall-clock
+        budget is exhausted.
+        """
+        settings = Settings(
+            autotune_budget_seconds=1,
+            autotune_log_level=logging.CRITICAL,
+        )
+        search = self._make_search(settings)
+        self.assertEqual(
+            search.benchmark_provider.budget_exceeded_fn,
+            search._autotune_budget_exceeded,
+        )
+
+    def _make_stub_provider(self):
+        """Construct a minimal ``LocalBenchmarkProvider`` for budget-loop
+        tests without standing up a real kernel/config_spec.
+        """
+        from helion.autotuner.benchmark_provider import LocalBenchmarkProvider
+
+        provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
+        provider.kernel = SimpleNamespace(
+            compile_config=lambda config, allow_print: lambda *a, **kw: None,
+            format_kernel_decorator=lambda config, s: "decorator",
+            env=SimpleNamespace(process_group_name=None),
+        )
+        provider.settings = Settings(autotune_log_level=logging.CRITICAL)
+        # Match the cute backend's path: CuteBackend.supports_precompile()
+        # is False, which clears autotune_precompile in autotune setup.
+        provider.settings.autotune_precompile = None
+        provider.config_spec = SimpleNamespace()
+        provider.args = ()
+        provider.log = AutotuningLogger(provider.settings)
+        provider._autotune_metrics = SimpleNamespace(
+            num_configs_tested=0,
+            num_compile_failures=0,
+            num_accuracy_failures=0,
+            num_generations=0,
+        )
+        provider.mutated_arg_indices = ()
+        provider._benchmark_worker = None
+        provider._precompile_args_path = None
+        provider._precompile_tmpdir = None
+        return provider
+
+    def test_benchmark_provider_short_circuits_compile_loop(self) -> None:
+        """``LocalBenchmarkProvider.benchmark`` must stop compiling
+        configs once ``budget_exceeded_fn`` returns ``True`` from inside
+        the compile loop, and still return one ``BenchmarkResult`` per
+        input config so callers receive a positionally-aligned list.
+        """
+        from helion.autotuner.benchmark_provider import BenchmarkResult
+        from helion.autotuner.benchmark_provider import LocalBenchmarkProvider
+
+        provider = self._make_stub_provider()
+
+        compiled_count = [0]
+        budget_calls = [0]
+
+        original_compile = provider.kernel.compile_config
+
+        def counting_compile(config, allow_print):
+            compiled_count[0] += 1
+            return original_compile(config, allow_print)
+
+        provider.kernel.compile_config = counting_compile
+
+        def budget_check():
+            budget_calls[0] += 1
+            return compiled_count[0] >= 2
+
+        provider.set_budget_exceeded_fn(budget_check)
+
+        from helion.runtime.config import Config
+
+        configs = [Config() for _ in range(5)]
+
+        with patch.object(
+            LocalBenchmarkProvider,
+            "_benchmark_function",
+            return_value=0.001,
+        ):
+            results = provider.benchmark(configs)
+
+        self.assertEqual(len(results), len(configs))
+        compiled_finite = sum(1 for r in results if math.isfinite(r.perf))
+        self.assertLessEqual(compiled_count[0], 2)
+        self.assertLessEqual(compiled_finite, compiled_count[0])
+        for r in results[compiled_count[0] :]:
+            self.assertEqual(r.status, "error")
+            self.assertEqual(r.perf, float("inf"))
+        for r in results:
+            self.assertIsInstance(r, BenchmarkResult)
+        # The hook must actually fire; without it the loop wouldn't break.
+        self.assertGreater(budget_calls[0], 0)
+
+    def test_benchmark_provider_short_circuits_benchmark_loop(self) -> None:
+        """If compilation finishes cleanly and the budget only fires
+        partway through the benchmark loop, remaining configs must be
+        left at the default ``perf=inf, status="error"`` slots while the
+        earlier benchmarked configs keep their measured perf.
+        """
+        from helion.autotuner.benchmark_provider import BenchmarkResult
+        from helion.autotuner.benchmark_provider import LocalBenchmarkProvider
+
+        provider = self._make_stub_provider()
+
+        # All compiles succeed; budget stays clear during compilation.
+        benchmark_count = [0]
+
+        def budget_check():
+            # Trip the budget after 2 benchmark calls.
+            return benchmark_count[0] >= 2
+
+        provider.set_budget_exceeded_fn(budget_check)
+
+        def counting_benchmark(self_, config, fn):
+            benchmark_count[0] += 1
+            return 0.001
+
+        from helion.runtime.config import Config
+
+        configs = [Config() for _ in range(5)]
+
+        with patch.object(
+            LocalBenchmarkProvider,
+            "_benchmark_function",
+            new=counting_benchmark,
+        ):
+            results = provider.benchmark(configs)
+
+        self.assertEqual(len(results), len(configs))
+        # At most 2 benchmarks ran (the loop checks before each call).
+        self.assertLessEqual(benchmark_count[0], 2)
+        # First few entries have finite measured perf.
+        finite_count = sum(1 for r in results if math.isfinite(r.perf))
+        self.assertEqual(finite_count, benchmark_count[0])
+        # The tail entries must be the inf/error defaults.
+        for r in results[benchmark_count[0] :]:
+            self.assertEqual(r.status, "error")
+            self.assertEqual(r.perf, float("inf"))
+        for r in results:
+            self.assertIsInstance(r, BenchmarkResult)
+
+    def test_benchmark_provider_default_hook_is_no_op(self) -> None:
+        """A provider that never had its hook installed must read the
+        class-level no-op default rather than raising ``AttributeError``
+        on the first ``budget_exceeded_fn()`` call.
+        """
+        from helion.autotuner.benchmark_provider import BenchmarkProvider
+        from helion.autotuner.benchmark_provider import LocalBenchmarkProvider
+        from helion.autotuner.benchmark_provider import _never_exceeded
+
+        # Class-level default lives on the abstract base so any subclass
+        # picks it up even if it forgets to call super().__init__.
+        self.assertIs(BenchmarkProvider.budget_exceeded_fn, _never_exceeded)
+        # Subclass instance with no __init__ work still resolves the
+        # default via class-level descriptor.
+        provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
+        self.assertFalse(provider.budget_exceeded_fn())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_llm_autotuner.py
+++ b/test/test_llm_autotuner.py
@@ -191,6 +191,9 @@ class TestLLMGuidedSearch(TestCase):
             def cleanup(self) -> None:
                 self.cleanup_called = True
 
+            def set_budget_exceeded_fn(self, fn) -> None:
+                pass
+
         args = (
             torch.randn([128, 128], device=DEVICE, dtype=torch.float16),
             torch.randn([128, 128], device=DEVICE, dtype=torch.float16),
@@ -661,6 +664,9 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
             def __init__(self, **kwargs) -> None:
                 self.kwargs = kwargs
 
+            def set_budget_exceeded_fn(self, fn) -> None:
+                pass
+
         class FakeLLMSearch:
             def __init__(self, kernel, args, **kwargs) -> None:
                 self.kernel = kernel
@@ -791,6 +797,9 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
             def cleanup(self) -> None:
                 self.cleanup_called = True
 
+            def set_budget_exceeded_fn(self, fn) -> None:
+                pass
+
         class FakeLLMSearch:
             def __init__(self, kernel, args, **kwargs) -> None:
                 self.kernel = kernel
@@ -896,6 +905,9 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
         class FakeBenchmarkProvider:
             def __init__(self, **kwargs) -> None:
                 self.kwargs = kwargs
+
+            def set_budget_exceeded_fn(self, fn) -> None:
+                pass
 
         class FailIfLLMConstructed:
             def __init__(self, *args, **kwargs) -> None:


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2411
 * #2410
 * #2409
 * #2408
 * #2407
 * #2406
 * #2405
 * #2404
 * __->__#2403
 * #2402
 * #2401
 * #2400


--- --- ---

[autotuner] make initial-population benchmark phase budget-aware