### PR TITLE
[cutedsl] widen c_input_warps and loop_orders autotune surface

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -2293,6 +2293,12 @@ def _emit_mma_pipeline(
             ab_load_warp_count=tcgen05_warp_spec.ab_load_warps,
             scheduler_warp_count=tcgen05_warp_spec.scheduler_warps,
             sched_stage_count=tcgen05_sched_stage_count_value,
+            # ``c_input_warp_count`` plumbs the warp-spec slot
+            # through the matmul plan (``cute_plan.md`` §7.5.3.2).
+            # Validator restricts the value to ``{0, 1}`` under
+            # WITH_SCHEDULER and ``{0}`` under MONOLITHIC; codegen
+            # body for the C-input warp is inert today.
+            c_input_warp_count=tcgen05_warp_spec.c_input_warps,
             persistence_model=tcgen05_persistence_model_str,
             cluster_n=tcgen05_cluster_n,
             l2_swizzle_size=tcgen05_l2_swizzle_size_value,
@@ -2681,17 +2687,27 @@ def _emit_mma_pipeline(
             # its arrival to the cluster-wide ``pipeline_init``
             # barrier.
             tcgen05_sched_cluster_size = tcgen05_cluster_m * tcgen05_cluster_n
+            # Consumer arrive count excludes the scheduler warp (the
+            # producer of this pipeline) AND the C-input warp
+            # (``cute_plan.md`` §7.5.3.2): the C-input warp body is
+            # inert today and does not call ``consumer_arrive`` on
+            # the scheduler broadcast pipeline, so counting it would
+            # leave ``producer_commit`` blocked on a missing arrival.
+            # With ``c_input_warp_count=0`` (the default) the
+            # subtraction is a no-op and the byte-identity path is
+            # preserved exactly.
+            tcgen05_sched_consumer_role_count = (
+                tcgen05_matmul_plan.role_warp_count
+                - tcgen05_matmul_plan.scheduler_warp_count
+                - tcgen05_matmul_plan.c_input_warp_count
+            )
             if tcgen05_matmul_plan.is_clc_persistent and tcgen05_sched_cluster_size > 1:
                 tcgen05_sched_consumer_arrive_count = (
-                    tcgen05_matmul_plan.role_warp_count
-                    - tcgen05_matmul_plan.scheduler_warp_count
-                ) * tcgen05_sched_cluster_size
+                    tcgen05_sched_consumer_role_count * tcgen05_sched_cluster_size
+                )
                 tcgen05_sched_consumer_mask_to_leader = True
             else:
-                tcgen05_sched_consumer_arrive_count = (
-                    tcgen05_matmul_plan.role_warp_count
-                    - tcgen05_matmul_plan.scheduler_warp_count
-                )
+                tcgen05_sched_consumer_arrive_count = tcgen05_sched_consumer_role_count
                 tcgen05_sched_consumer_mask_to_leader = False
             prefix.extend(
                 _emit_sched_pipeline_setup(

--- a/helion/_compiler/cute/strategies.py
+++ b/helion/_compiler/cute/strategies.py
@@ -35,16 +35,23 @@ class Tcgen05Strategy(str, enum.Enum):
       6 specialized warps (1 TMA-load + 1 MMA-exec + 4 epilogue).
       Each role-local ``while`` loop carries its own
       ``StaticPersistentTileScheduler``.
-    - ``ROLE_LOCAL_WITH_SCHEDULER``. 7 specialized warps: adds a
-      dedicated scheduler warp that publishes ``(virtual_pid,
-      tile_coord_mnkl, is_valid)`` into a per-CTA SMEM mailbox via
-      a ``PipelineAsync``. The C-input epilogue-load warp Quack
-      uses (Quack's 8th warp) is not present in cycle 33 because
-      Helion does not yet have a productive C-input warp (cycle
-      34 widens ``Tcgen05WarpSpec.c_input_warps`` to 1 to occupy
-      the slot); ``CuteTcgen05MatmulPlan.launched_warp_count``
-      rounds to 8 launched warps (one inert padding warp) so
-      warpgroup ``setmaxregister`` semantics are uniform.
+    - ``ROLE_LOCAL_WITH_SCHEDULER``. 7 specialized warps by default
+      (4 epi + 1 exec + 1 ab_load + 1 sched), or 8 specialized warps
+      when ``Tcgen05WarpSpec.c_input_warps=1`` lifts the optional
+      C-input slot. Adds a dedicated scheduler warp that publishes
+      ``(virtual_pid, tile_coord_mnkl, is_valid)`` into a per-CTA
+      SMEM mailbox via a ``PipelineAsync``. The C-input
+      epilogue-load warp Quack uses (Quack's 8th warp) became
+      reachable in cycle 34 (G3.1 first slice, ``cute_plan.md``
+      §7.5.3.2) — the validator now admits
+      ``Tcgen05WarpSpec.c_input_warps=1`` so an explicit
+      ``helion.Config(tcgen05_warp_spec_c_input_warps=1)``
+      round-trips end-to-end; the codegen body stays inert in
+      cycle 34 (the slot occupies what was previously the inert
+      padding warp, so ``launched_warp_count`` is 8 either way and
+      warpgroup ``setmaxregister`` semantics are uniform). The
+      productive TMA-prefetch body that turns the slot into a
+      C-input producer lands in a follow-up cycle.
       Validated at ``cluster_m`` ∈ {1, 2} and ``cluster_n``
       ∈ {1, 2}: each CTA in the cluster runs its own scheduler
       that publishes locally and each CTA's consumers release
@@ -124,12 +131,16 @@ ROLE_LOCAL_MONOLITHIC_EPI_WARPS = 4
 ROLE_LOCAL_MONOLITHIC_EPI_LOAD_WARPS = 0
 ROLE_LOCAL_MONOLITHIC_SCHEDULER_WARPS = 0
 # ``c_input_warps`` slot for the dedicated C-input / auxiliary-tensor warp
-# that drives a TMA-loaded SMEM-ring producer pipeline (G3.1-C step-2 in
-# ``cute_plan.md`` §7.5.3.2). Default 0 keeps the historical inert-padding
-# behavior under ``ROLE_LOCAL_WITH_SCHEDULER``; the validator allows the
-# value 1 only under ``ROLE_LOCAL_WITH_SCHEDULER`` once the TMA producer +
-# SMEM ring + role-local while loop land. The autotune surface stays
-# narrowed to 0 until perf is characterized.
+# that will eventually drive a TMA-loaded SMEM-ring producer pipeline
+# (G3.1-C step-2 in ``cute_plan.md`` §7.5.3.2). Default 0 keeps the
+# historical inert-padding behavior under ``ROLE_LOCAL_WITH_SCHEDULER``.
+# Cycle 34 (G3.1 first slice) widens the validator to accept the value 1
+# under ``ROLE_LOCAL_WITH_SCHEDULER`` so the foundation lift is reachable;
+# the codegen body remains inert (the warp occupies the slot that was
+# previously the inert padding under the 7-role-warp / 8-launched shape,
+# so launched-warp accounting is unchanged). The autotune surface stays
+# narrowed to 0 until the productive TMA producer body lands and perf
+# is characterized.
 ROLE_LOCAL_MONOLITHIC_C_INPUT_WARPS = 0
 # Today's role-local lowering uses a (decrease, increase) register split of
 # (120, 256). The decrease side runs on TMA-load + scheduler warps; the
@@ -161,18 +172,25 @@ class Tcgen05WarpSpec:
     - ``scheduler_warps``: 0 in ``ROLE_LOCAL_MONOLITHIC`` (each role
       runs its own scheduler), 1 in ``ROLE_LOCAL_WITH_SCHEDULER``
       (dedicated scheduler warp drives a broadcasting pipeline).
-    - ``c_input_warps``: dedicated C-input warp count. Currently
-      narrowed to ``{0}`` for both strategies (the data-model slot
-      is plumbed through normalize / round-trip but the validator
-      rejects nonzero); cycle 34 widens
-      ``ROLE_LOCAL_WITH_SCHEDULER`` to ``{0, 1}`` once the dedicated
-      TMA producer + SMEM ring + role-local while loop land
-      (``cute_plan.md`` §7.5.3.2). Setting this to 1 is intended
-      to convert the 8-warp shape's currently-inert padding warp
-      under ``ROLE_LOCAL_WITH_SCHEDULER`` into a productive
-      C-input TMA producer; ``ROLE_LOCAL_MONOLITHIC`` has no such
-      warp slot to occupy. The autotune surface stays narrowed to
-      0 until cycle 34 perf-validates the productive C-input warp.
+    - ``c_input_warps``: dedicated C-input warp count. Cycle 34
+      (G3.1 first slice, ``cute_plan.md`` §7.5.3.2) widens the
+      validator's per-strategy accept set so
+      ``ROLE_LOCAL_WITH_SCHEDULER`` admits ``{0, 1}`` — an explicit
+      ``helion.Config(tcgen05_warp_spec_c_input_warps=1)`` now
+      round-trips end-to-end and the launched-CTA warp accounting
+      recognizes the slot. ``ROLE_LOCAL_MONOLITHIC`` stays at
+      ``{0}`` (no such warp slot in the 6-warp shape).
+      Setting this to 1 under ``WITH_SCHEDULER`` reuses what was
+      previously the inert padding warp: with the 4 epi + 1 exec
+      + 1 ab_load + 1 sched + 1 c_input layout, ``role_warp_count``
+      equals 8 and ``launched_warp_count`` (warpgroup-aligned)
+      stays at 8 — no extra warp is launched. The codegen body of
+      the C-input warp remains inert in cycle 34 (a no-op slot);
+      the productive TMA-prefetch body is deferred. The autotune
+      surface stays narrowed to ``0`` in
+      ``_tcgen05_strategy_autotune_fragments`` until the productive
+      body lands and perf is characterized; only the user-config
+      validation surface accepts ``{0, 1}``.
     - ``register_split``: ``(decrease, increase)`` ``setmaxregister``
       counts. The current 6-warp shape uses ``(120, 256)``. Each
       entry's range is enforced by its per-field fragment in
@@ -728,15 +746,26 @@ _STRATEGY_REQUIRED_SCHEDULER_WARPS: dict[Tcgen05Strategy, int] = {
 # has no such warp slot — its 6-warp shape is fully populated by the
 # TMA-load + MMA-exec + 4 epi warps. Values outside the per-strategy
 # accept set are rejected so user configs cannot reach an unsupported
-# combination silently. cycle 33: validator accepts ``{0}`` for both
-# strategies; cycle 34 widens ``ROLE_LOCAL_WITH_SCHEDULER`` to ``{0, 1}``
-# once the dedicated TMA producer + SMEM ring + role-local while
-# loop land. This staging keeps the data-model slot stable for
-# config serialization round-trips while keeping user configs from
-# reaching a not-yet-implemented codegen path.
+# combination silently.
+#
+# Cycle 33: validator accepted ``{0}`` for both strategies (data-model
+# slot only). Cycle 34 (G3.1 first slice, ``cute_plan.md`` §7.5.3.2):
+# widens ``ROLE_LOCAL_WITH_SCHEDULER`` to ``{0, 1}`` so explicit
+# ``helion.Config(tcgen05_warp_spec_c_input_warps=1)`` round-trips
+# end-to-end and the launched-warp accounting recognizes the slot.
+# The codegen body of the C-input warp remains inert in cycle 34 —
+# the warp occupies what was previously the inert padding slot
+# (``launched_warp_count`` stays at 8 under WITH_SCHEDULER because
+# ``role_warp_count`` now equals 8 = 4 epi + 1 exec + 1 ab_load +
+# 1 sched + 1 c_input, exactly matching the warpgroup-aligned launch
+# envelope). Producer-side TMA prefetch body is deferred to a
+# follow-up cycle. The autotune surface stays narrowed to ``(0,)``
+# in ``_tcgen05_strategy_autotune_fragments`` until the productive
+# body lands and perf is characterized; only the user-config
+# validation surface accepts ``(0, 1)``.
 _STRATEGY_SUPPORTED_C_INPUT_WARPS: dict[Tcgen05Strategy, frozenset[int]] = {
     Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC: frozenset({0}),
-    Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER: frozenset({0}),
+    Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER: frozenset({0, 1}),
 }
 
 # When the strategy demands warpgroup-aligned splits (every 4 warps

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -267,8 +267,13 @@ class CuteTcgen05MatmulPlan:
     when set to 1, the scheduler warp owns a centralized
     ``StaticPersistentTileScheduler`` and broadcasts work-tile
     metadata through ``cute_tcgen05_sched_pipeline_plan`` to the
-    consumer warps. The epi-load warp slot Quack uses for C input
-    is not yet present in Helion (no C-input fusion).
+    consumer warps. The C-input epi-load warp slot Quack uses for
+    C input became reachable in cycle 34 (G3.1 first slice,
+    ``cute_plan.md`` §7.5.3.2) via ``c_input_warp_count`` — when
+    set to 1 under WITH_SCHEDULER the role-warp layout grows to
+    8 role warps that exactly matches the warpgroup-aligned launch
+    envelope (no inert padding). The C-input warp body is inert
+    in cycle 34; the productive TMA-prefetch body is deferred.
     """
 
     bm: int
@@ -303,6 +308,21 @@ class CuteTcgen05MatmulPlan:
     # in ``cute_mma._codegen_cute_mma`` for why Helion does not
     # mirror Quack's depth-2.
     sched_stage_count: int = 0
+    # ``c_input_warp_count`` is the dedicated C-input / auxiliary-tensor
+    # warp count for the role-local layout (``cute_plan.md`` §7.5.3.2).
+    # Default 0 keeps the historical ``WITH_SCHEDULER`` 7-role-warp +
+    # 1-inert-padding layout. The validator accepts the value 1 under
+    # WITH_SCHEDULER — the C-input warp then occupies what was
+    # previously the inert padding slot (sitting after the scheduler
+    # warp in the launched-CTA layout). ``launched_warp_count`` stays
+    # at 8 either way because ``role_warp_count`` (8 with the slot
+    # lifted) already matches the warpgroup-aligned envelope. The
+    # codegen body of the C-input warp is inert today — it does not
+    # arrive on the scheduler broadcast pipeline, so the consumer
+    # arrive count in ``cute_mma._codegen_cute_mma`` subtracts
+    # ``c_input_warp_count`` to compensate. MONOLITHIC keeps this at
+    # 0 by validator; only WITH_SCHEDULER hosts the slot.
+    c_input_warp_count: int = 0
     # ``persistence_model`` selects the persistence axis of the
     # generated kernel. ``STATIC_PERSISTENT`` (default) keeps the
     # existing ``StaticPersistentTileScheduler`` path. ``CLC_PERSISTENT``
@@ -388,16 +408,23 @@ class CuteTcgen05MatmulPlan:
             + 1
             + self.ab_load_warp_count
             + self.scheduler_warp_count
+            + self.c_input_warp_count
         )
 
     @property
     def launched_warp_count(self) -> int:
         # ``setmaxregister`` is warpgroup-uniform on sm_100a (all 4
         # warps of a warpgroup must request the same register
-        # budget). For ``WITH_SCHEDULER`` the 7 role warps split as
-        # 4 epi (consumers) + 3 producer warps; padding to 8
-        # launched warps moves the partial producer warpgroup back
-        # to a clean 4-warp warpgroup that uniformly decreases.
+        # budget). For ``WITH_SCHEDULER`` with the default
+        # ``c_input_warp_count=0`` the 7 role warps split as 4 epi
+        # (consumers) + 3 producer warps; padding to 8 launched
+        # warps moves the partial producer warpgroup back to a
+        # clean 4-warp warpgroup that uniformly decreases. With
+        # ``c_input_warp_count=1`` the 8 role warps already match
+        # the warpgroup-aligned launch envelope so no padding is
+        # needed — the launched-warp count stays at 8 and the
+        # C-input warp simply occupies what was previously the
+        # inert padding slot.
         # ``MONOLITHIC`` keeps 6 launched warps because byte-identity
         # against the recorded golden is load-bearing and the
         # 6-warp shape happens to work in practice (mma+tma alone

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -1245,14 +1245,18 @@ class ConfigSpec:
         )
         fragments[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY] = EnumFragment((0, 1))
         # ``c_input_warps`` validation surface: accept ``{0, 1}`` so
-        # explicit user configs can opt in to the productive C-input
-        # warp slot via ``helion.Config(tcgen05_warp_spec_c_input_warps=1)``.
+        # explicit user configs can opt in to the C-input warp slot
+        # via ``helion.Config(tcgen05_warp_spec_c_input_warps=1)``.
         # The cross-fragment validator
         # (``validate_tcgen05_strategy_invariants``) further narrows
-        # the value per-strategy: today both strategies reject nonzero
-        # until the dedicated TMA producer + SMEM ring + role-local
-        # while loop land; the accept set widens to ``{0, 1}`` for
-        # ``ROLE_LOCAL_WITH_SCHEDULER`` once that codegen path lands
+        # the value per-strategy: ``ROLE_LOCAL_MONOLITHIC`` rejects
+        # nonzero (its 6-warp shape has no slot for an 8th role
+        # warp); ``ROLE_LOCAL_WITH_SCHEDULER`` accepts ``{0, 1}``,
+        # with the value 1 occupying the slot that was previously
+        # the inert padding warp. The codegen body of the C-input
+        # warp is inert today (no role-local while loop consumes
+        # it); the productive TMA producer body that actually
+        # overlaps the aux load with mainloop work is a follow-up
         # (``cute_plan.md`` §7.5.3.2).
         fragments[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY] = EnumFragment((0, 1))
         return fragments
@@ -2343,6 +2347,22 @@ class ConfigSpec:
                     fields["indexing"] = self.indexing
             elif self.supports_config_key("num_threads"):
                 fields["num_threads"] = self.num_threads
+                # Universal pid emission honors ``loop_orders`` (the
+                # launch grid swaps which tile axis is outer), and the
+                # better order is shape-dependent. Expose only on the
+                # non-tcgen05 branch — the tcgen05 persistent
+                # scheduler relies on a fixed
+                # ``pid_info[0]=M, pid_info[1]=N`` mapping for
+                # ``cluster_m`` / virtual-PID logic, so sampling
+                # ``loop_orders=[[1, 0]]`` there would steer cluster
+                # logic onto the wrong axis. Measured evidence for
+                # the non-tcgen05 widening lives in ``cute_plan.md``
+                # §7.0 "Recent landed work".
+                if (
+                    self.supports_config_key("loop_orders")
+                    and len(self.loop_orders) > 0
+                ):
+                    fields["loop_orders"] = self.loop_orders
             if self.epilogue_subtile_autotune_choices is not None:
                 fields["epilogue_subtile"] = EnumFragment(
                     choices=self.epilogue_subtile_autotune_choices

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -2631,7 +2631,12 @@ class TestCuteAutotuner(TestCase):
         flat_keys = {
             key for key, _count, _is_sequence in gen.config_spec.flat_key_layout()
         }
-        self.assertEqual(flat_keys, {"block_sizes", "num_threads"})
+        # ``loop_orders`` is exposed for the cute non-tcgen05 search
+        # surface (audited fp32 1024^3 matmul finds ~3x bench-time wins
+        # from ``[[1, 0]]`` over the default ``[[0, 1]]`` — see
+        # ``cute_plan.md`` §7.0). The set still excludes Triton-style
+        # knobs that the cute path does not consume.
+        self.assertEqual(flat_keys, {"block_sizes", "num_threads", "loop_orders"})
 
         repaired = gen.unflatten(
             gen.flatten(helion.Config(block_sizes=[16, 64], num_threads=[128, 128]))
@@ -2642,7 +2647,9 @@ class TestCuteAutotuner(TestCase):
         configs = [gen.random_config() for _ in range(20)]
         self.assertTrue(any(config.num_threads for config in configs))
         for config in configs:
-            self.assertLessEqual(set(config.config), {"block_sizes", "num_threads"})
+            self.assertLessEqual(
+                set(config.config), {"block_sizes", "num_threads", "loop_orders"}
+            )
             self.assertNotIn("persistent", config.pid_type)
             explicit_threads = [nt for nt in config.num_threads if nt > 0]
             if explicit_threads:
@@ -2655,6 +2662,41 @@ class TestCuteAutotuner(TestCase):
                 if num_threads > 0:
                     self.assertLessEqual(num_threads, block_size)
                     self.assertEqual(block_size % num_threads, 0)
+        # Deterministic round-trip pins the widened surface: a config
+        # explicitly built with ``loop_orders=[[1, 0]]`` must survive
+        # flatten/unflatten unchanged (otherwise the autotuner cannot
+        # actually explore the alternate order).
+        round_tripped = gen.unflatten(
+            gen.flatten(
+                helion.Config(
+                    block_sizes=[16, 64],
+                    num_threads=[16, 64],
+                    loop_orders=[[1, 0]],
+                )
+            )
+        )
+        self.assertEqual(round_tripped.loop_orders, [[1, 0]])
+
+    def test_cute_tcgen05_search_surface_excludes_loop_orders(self) -> None:
+        """tcgen05 persistent scheduler relies on a fixed
+        ``pid_info[0]=M, pid_info[1]=N`` mapping (``cluster_m`` and
+        virtual-PID logic). Sampling ``loop_orders=[[1, 0]]`` for a
+        tcgen05 config would steer cluster logic onto the wrong axis.
+        The cute non-tcgen05 widening must not leak into the tcgen05
+        branch.
+        """
+        bound = _get_examples_matmul().bind(
+            (
+                torch.randn([1024, 1024], device=DEVICE, dtype=torch.bfloat16),
+                torch.randn([1024, 1024], device=DEVICE, dtype=torch.bfloat16),
+            )
+        )
+        # Confirm we are on the tcgen05 search branch.
+        self.assertTrue(bound.config_spec.cute_tcgen05_search_enabled)
+        flat_keys = {
+            key for key, _count, _is_sequence in bound.config_spec.flat_key_layout()
+        }
+        self.assertNotIn("loop_orders", flat_keys)
 
 
 @onlyBackends(["triton"])

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -2254,6 +2254,186 @@ class TestCuteLowerings(unittest.TestCase):
             code,
         )
 
+    def test_tcgen05_with_scheduler_c_input_warp_inert_codegen(
+        self,
+    ) -> None:
+        """``cute_plan.md`` §7.5.3.2 data-model lift codegen pin.
+
+        The validator under ``ROLE_LOCAL_WITH_SCHEDULER`` accepts
+        ``tcgen05_warp_spec_c_input_warps=1``. The C-input warp body
+        is inert today (no role-local while loop consumes it); the
+        slot occupies what was previously the inert padding warp
+        under the 7-role-warp / 8-launched layout. The
+        scheduler-pipeline consumer-arrive count subtracts
+        ``c_input_warp_count`` so ``producer_commit`` is not blocked
+        on a missing arrival.
+
+        Pin:
+
+        - The sched_pipeline consumer arrive count stays at 6 (4 epi
+          + 1 mma + 1 ab_load = 6 consumer warps; the C-input warp
+          is excluded so the count is identical to the
+          ``c_input_warps=0`` baseline).
+        - The cluster_layout pin (2, 1, 1) for cluster_m=2 is
+          preserved so the launch envelope shape is unchanged.
+        - The kernel emits the tcgen05 codegen markers
+          (``cute.nvgpu.tcgen05`` operand-mode + ``PipelineTmaUmma``)
+          so the path is exercised end-to-end on the role-local
+          tcgen05 lowering, not the universal lane-loop fallback.
+        """
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_with_scheduler_c_input(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        # Use the cluster_m=2 path because it is the persistent-grid
+        # shape that the existing WITH_SCHEDULER codegen pins (see
+        # ``test_tcgen05_with_scheduler_cluster_m2_per_cta_topology_codegen``)
+        # use to reach the role-local tcgen05 lowering deterministically.
+        config = helion.Config(
+            block_sizes=[256, 256, 128],
+            l2_groupings=[1],
+            num_warps=4,
+            num_sm_multiplier=1,
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+            tcgen05_strategy="role_local_with_scheduler",
+            tcgen05_warp_spec_scheduler_warps=1,
+            tcgen05_warp_spec_c_input_warps=1,
+            indexing=[
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "tensor_descriptor",
+            ],
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_with_scheduler_c_input.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code = bound.to_triton_code(config)
+
+        # Sched_pipeline consumer arrive count excludes the C-input
+        # warp: 4 epi + 1 mma + 1 ab_load = 6 (same as c_input=0).
+        # If the subtraction in
+        # ``cute_mma._codegen_cute_mma`` were missing, the count would
+        # become 7 (counting the inert C-input warp as a consumer)
+        # and ``producer_commit`` would block forever on the missing
+        # arrival.
+        self.assertIn(
+            "tcgen05_sched_pipeline_consumer_group = "
+            "cutlass.pipeline.CooperativeGroup("
+            "cutlass.pipeline.Agent.Thread, cutlass.Int32(6))",
+            code,
+        )
+        # Negative pin: a count of 7 (or higher) must not appear on
+        # the sched_pipeline consumer group; that would indicate the
+        # C-input subtraction was missed.
+        self.assertNotIn(
+            "tcgen05_sched_pipeline_consumer_group = "
+            "cutlass.pipeline.CooperativeGroup("
+            "cutlass.pipeline.Agent.Thread, cutlass.Int32(7))",
+            code,
+        )
+        # The role-local TMA producer path is exercised: these
+        # strings appear only when the lowering reaches the tcgen05
+        # codegen (they do not appear in the universal lane-loop
+        # fallback).
+        self.assertIn("tcgen05_sched_pipeline = ", code)
+        # Cluster_layout pin for cluster_m=2 / cluster_n=1: shape
+        # (2, 1, 1). Preserved by the C-input lift (launched-warp
+        # envelope is unchanged: 8 warps either way).
+        self.assertIn("cute.make_layout((2, 1, 1))", code)
+        # tcgen05 codegen marker: the operand-mode reference appears
+        # only when the lowering selects the tcgen05 path (the
+        # universal lane-loop fallback uses scalar ops, no tcgen05
+        # symbols).
+        self.assertIn("cute.nvgpu.tcgen05.OperandMajorMode", code)
+        # PipelineTmaUmma marker: pins the role-local TMA + UMMA
+        # pipeline pairing, present only on the tcgen05 path.
+        self.assertIn("PipelineTmaUmma", code)
+
+    def test_tcgen05_with_scheduler_c_input_warp_inert_runtime_correctness(
+        self,
+    ) -> None:
+        """Runtime-correctness companion to
+        ``test_tcgen05_with_scheduler_c_input_warp_inert_codegen``.
+
+        Asserts: the matmul kernel under
+        ``tcgen05_warp_spec_c_input_warps=1`` (with
+        ``ROLE_LOCAL_WITH_SCHEDULER`` + the cluster_m=2 canonical
+        fast config) launches and produces output within bf16
+        tolerance of the eager reference.
+        """
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_with_scheduler_c_input_rt(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        # Canonical fast config family; the cluster_m=2 path is what
+        # the matched WITH_SCHEDULER runtime tests use, scaled down
+        # to 1024^3 so the kernel exercises ~32 tile launches under
+        # the persistent grid without spending full 4096-shape time.
+        torch.manual_seed(0)
+        x = torch.randn(1024, 1024, dtype=torch.bfloat16, device=DEVICE)
+        y = torch.randn(1024, 1024, dtype=torch.bfloat16, device=DEVICE)
+        config = helion.Config(
+            block_sizes=[256, 256, 128],
+            l2_groupings=[1],
+            num_warps=4,
+            num_sm_multiplier=1,
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+            tcgen05_strategy="role_local_with_scheduler",
+            tcgen05_warp_spec_scheduler_warps=1,
+            tcgen05_warp_spec_c_input_warps=1,
+            indexing=[
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "tensor_descriptor",
+            ],
+        )
+        bound = cute_matmul_with_scheduler_c_input_rt.bind((x, y))
+        bound.env.config_spec.cute_tcgen05_search_enabled = True
+        bound.set_config(config)
+        out = bound(x, y)
+        expected = (x @ y).to(x.dtype)
+        torch.testing.assert_close(out, expected, atol=2e-1, rtol=1e-2)
+
     def test_tcgen05_clc_persistent_codegen(self) -> None:
         """G2-H CLC scheduler-warp body codegen pin (cute_plan.md).
 

--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -1702,11 +1702,13 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         self.assertNotIn("tcgen05_warp_spec_epi_warps", default_cfg.config)
         self.assertEqual(default_cfg.config["tcgen05_warp_spec_epi_load_warps"], 0)
         self.assertEqual(default_cfg.config["tcgen05_warp_spec_scheduler_warps"], 0)
-        # ``c_input_warps`` was added in cycle 33 as the foundation for
-        # G3.1-C step-2 (``cute_plan.md`` §7.5.3.2). Default is 0 so
-        # serialized configs round-trip cleanly; the value 1 will be
-        # accepted under ``ROLE_LOCAL_WITH_SCHEDULER`` once cycle 34
-        # lands the dedicated TMA producer + SMEM ring.
+        # ``c_input_warps`` is the dedicated C-input / auxiliary-tensor
+        # warp slot (``cute_plan.md`` §7.5.3.2). Default is 0 so
+        # serialized configs round-trip cleanly; the validator widens
+        # the accept set to ``{0, 1}`` under ``ROLE_LOCAL_WITH_SCHEDULER``
+        # (inert-body slot) and stays at ``{0}`` under
+        # ``ROLE_LOCAL_MONOLITHIC``. The productive TMA producer body
+        # is a follow-up.
         self.assertEqual(default_cfg.config["tcgen05_warp_spec_c_input_warps"], 0)
         self.assertEqual(default_cfg.config["tcgen05_warp_spec_register_decrease"], 120)
         self.assertEqual(default_cfg.config["tcgen05_warp_spec_register_increase"], 256)
@@ -1884,6 +1886,36 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         spec.normalize(cfg)
         self.assertEqual(cfg.config["tcgen05_strategy"], "role_local_monolithic")
 
+        # G3.1 first slice (``cute_plan.md`` §7.5.3.2, cycle 34):
+        # ``tcgen05_warp_spec_c_input_warps=1`` under WITH_SCHEDULER
+        # round-trips end-to-end. The validator's accept set now
+        # admits the value; the codegen body stays inert until the
+        # productive TMA producer body lands.
+        c_input_cfg = helion.Config(
+            **base,
+            tcgen05_num_epi_warps=4,
+            tcgen05_strategy="role_local_with_scheduler",
+            tcgen05_warp_spec_scheduler_warps=1,
+            tcgen05_warp_spec_c_input_warps=1,
+        )
+        spec.normalize(c_input_cfg)
+        self.assertEqual(
+            c_input_cfg.config["tcgen05_strategy"], "role_local_with_scheduler"
+        )
+        self.assertEqual(c_input_cfg.config["tcgen05_warp_spec_c_input_warps"], 1)
+
+        # MONOLITHIC + c_input_warps=1 is still rejected (no slot in
+        # the 6-warp shape for an 8th role warp). Pin the negative
+        # path so the per-strategy gate cannot drift.
+        with self.assertRaises(InvalidConfig):
+            spec.normalize(
+                helion.Config(
+                    **base,
+                    tcgen05_strategy="role_local_monolithic",
+                    tcgen05_warp_spec_c_input_warps=1,
+                )
+            )
+
     @onlyBackends(["cute"])
     def test_cute_tcgen05_strategy_invariants_helper_unit(self) -> None:
         """``validate_tcgen05_strategy_invariants`` covers the
@@ -1896,9 +1928,11 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         The earlier warpgroup-alignment requirement on
         ``ROLE_LOCAL_WITH_SCHEDULER`` was relaxed once the initial
         7-warp implementation landed (1 ab_load + 1 mma + 4 epi + 1
-        scheduler = 7). The eventual 8-warp variant with a C-input
-        epi-load warp will re-introduce the alignment requirement
-        when register-split tuning becomes warpgroup-uniform.
+        scheduler = 7). Cycle 34's c_input lift makes the 8-warp
+        variant reachable end-to-end (8 role warps exactly match
+        the launched envelope, no padding); the alignment branch
+        stays dead-code-tested via patching since neither variant
+        triggers it organically today.
         """
         # scheduler_warps=0 under WITH_SCHEDULER is rejected (the
         # strategy demands one scheduler warp).
@@ -2078,19 +2112,24 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
 
     @onlyBackends(["cute"])
     def test_cute_tcgen05_strategy_invariants_c_input_warps(self) -> None:
-        """G3.1-C step-2 (cute_plan.md §7.5.3.2) data-model entrance:
+        """G3.1 first slice (cute_plan.md §7.5.3.2) data-model lift:
         ``c_input_warps`` is plumbed through the dataclass + validator,
-        and cycle 33's narrowing rejects nonzero for both strategies
-        until cycle 34 lands the dedicated TMA producer + SMEM ring.
+        and cycle 34 widens the ``ROLE_LOCAL_WITH_SCHEDULER`` accept
+        set to ``{0, 1}`` so explicit user configs can opt in to the
+        productive C-input warp slot. The codegen body remains inert
+        in cycle 34; the productive TMA producer body lands in a
+        follow-up cycle.
 
         - Positive control: ``c_input_warps=0`` accepted under both
           ``ROLE_LOCAL_MONOLITHIC`` and ``ROLE_LOCAL_WITH_SCHEDULER``
           (the field is plumbed through normalize / round-trip and
           defaults to 0 for legacy configs).
-        - Negative control: ``c_input_warps=1`` is rejected under
-          both strategies in cycle 33; cycle 34 widens the
-          ``ROLE_LOCAL_WITH_SCHEDULER`` accept set to ``{0, 1}`` once
-          the productive C-input warp implementation lands.
+        - Positive control (cycle 34): ``c_input_warps=1`` accepted
+          under ``ROLE_LOCAL_WITH_SCHEDULER`` — the slot occupies
+          what was previously the inert padding warp.
+        - Negative control: ``c_input_warps=1`` rejected under
+          ``ROLE_LOCAL_MONOLITHIC`` (the 6-warp shape has no slot
+          for an 8th role warp).
         """
         # Positive control: c_input_warps=0 under MONOLITHIC.
         errors = validate_tcgen05_strategy_invariants(
@@ -2137,8 +2176,11 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
             msg=str(errors),
         )
 
-        # Negative control: c_input_warps=1 under WITH_SCHEDULER
-        # (cycle 33). Cycle 34 widens this accept set to ``{0, 1}``.
+        # Positive control: c_input_warps=1 accepted under
+        # WITH_SCHEDULER. The slot is reachable end-to-end and the
+        # launched-warp accounting recognizes it (see the matching
+        # matmul-plan accounting test below); the codegen body
+        # stays inert until the productive TMA producer body lands.
         c_input_with_sched = dataclasses.replace(with_sched, c_input_warps=1)
         errors = validate_tcgen05_strategy_invariants(
             strategy=Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER,
@@ -2149,15 +2191,76 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
             pid_type="persistent_blocked",
             cluster_m=1,
         )
-        self.assertTrue(
-            any("c_input_warps in [0]" in e for e in errors),
-            msg=str(errors),
-        )
+        self.assertEqual(errors, [], msg=str(errors))
 
-        # The dataclass total_warps reflects the c_input_warps slot
-        # so a future cycle-34 lift to c_input_warps=1 transparently
-        # adjusts the warp count without further data-model churn.
+        # The dataclass total_warps reflects the c_input_warps slot:
+        # 4 epi + 1 mma + 1 ab_load + 1 sched + 1 c_input = 8.
         self.assertEqual(c_input_with_sched.total_warps, 8)
+
+    @onlyBackends(["cute"])
+    def test_cute_tcgen05_matmul_plan_c_input_warp_accounting(self) -> None:
+        """``CuteTcgen05MatmulPlan`` carries ``c_input_warp_count``
+        and the launched-warp accounting is invariant under the
+        c_input lift because the slot occupies what was previously
+        the inert padding warp under ``ROLE_LOCAL_WITH_SCHEDULER``
+        (``cute_plan.md`` §7.5.3.2):
+
+        - ``c_input_warp_count=0``: 7 role warps, 8 launched (1 pad).
+        - ``c_input_warp_count=1``: 8 role warps, 8 launched (0 pad).
+
+        Existing role warp ids (``exec_warp_id``, ``tma_warp_id``,
+        ``scheduler_warp_id``) are unaffected by the lift — codegen
+        sites that gate on those ids stay byte-identical.
+        """
+        from helion._compiler.device_function import CuteTcgen05MatmulPlan
+
+        base_kwargs: dict[str, object] = {
+            "bm": 256,
+            "bn": 256,
+            "bk": 128,
+            "k_tile_count": 32,
+            "cluster_m": 1,
+            "is_two_cta": False,
+            "uses_role_local_persistent_body": True,
+            "uses_cluster_m2_one_cta_role_local_bridge": False,
+            "cta_thread_count": 256,
+            "physical_m_threads": 128,
+            "acc_stage_count": 2,
+            "ab_stage_count": 2,
+            "c_stage_count": 2,
+            "epi_warp_count": 4,
+            "ab_load_warp_count": 1,
+            "scheduler_warp_count": 1,
+            "sched_stage_count": 1,
+        }
+
+        # c_input_warp_count=0 baseline: 7 role warps, 8 launched
+        # (one inert padding warp).
+        plan_c0 = CuteTcgen05MatmulPlan(**base_kwargs)
+        self.assertEqual(plan_c0.c_input_warp_count, 0)
+        self.assertEqual(plan_c0.role_warp_count, 7)
+        self.assertEqual(plan_c0.launched_warp_count, 8)
+        # All existing role warp ids stay pinned regardless of the
+        # c_input lift below.
+        self.assertEqual(plan_c0.exec_warp_id, 4)
+        self.assertEqual(plan_c0.tma_warp_id, 5)
+        self.assertEqual(plan_c0.scheduler_warp_id, 6)
+        self.assertEqual(plan_c0.persistent_scheduler_owner_warp_id, 6)
+
+        # c_input_warp_count=1 lift: 8 role warps, 8 launched (no
+        # padding).
+        plan_c1 = CuteTcgen05MatmulPlan(**base_kwargs, c_input_warp_count=1)
+        self.assertEqual(plan_c1.c_input_warp_count, 1)
+        self.assertEqual(plan_c1.role_warp_count, 8)
+        self.assertEqual(plan_c1.launched_warp_count, 8)
+        # Existing role warp ids are unaffected by the lift.
+        self.assertEqual(plan_c1.exec_warp_id, 4)
+        self.assertEqual(plan_c1.tma_warp_id, 5)
+        self.assertEqual(plan_c1.scheduler_warp_id, 6)
+        self.assertEqual(plan_c1.persistent_scheduler_owner_warp_id, 6)
+        # Block shape is invariant in both cases (256 mma threads
+        # × 8 launched warps × 1 = the same launch envelope).
+        self.assertEqual(plan_c0.block_shape, plan_c1.block_shape)
 
     @onlyBackends(["cute"])
     def test_cute_tcgen05_strategy_invariants_clc_persistent_cluster_n(


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2411
 * #2410
 * #2409
 * #2408
 * #2407
 * #2406
 * __->__#2405
 * #2404
 * #2403
 * #2402
 * #2401
 * #2400


--- --- ---

[cutedsl] widen c_input_warps and loop_orders autotune surface