### PR TITLE
[cutedsl] emit c-input warp role-local while for residual scheduling

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -2715,18 +2715,39 @@ def _emit_mma_pipeline(
             # barrier.
             tcgen05_sched_cluster_size = tcgen05_cluster_m * tcgen05_cluster_n
             # Consumer arrive count excludes the scheduler warp (the
-            # producer of this pipeline) AND the C-input warp
-            # (``cute_plan.md`` §7.5.3.2): the C-input warp body is
-            # inert today and does not call ``consumer_arrive`` on
-            # the scheduler broadcast pipeline, so counting it would
-            # leave ``producer_commit`` blocked on a missing arrival.
-            # With ``c_input_warp_count=0`` (the default) the
-            # subtraction is a no-op and the byte-identity path is
-            # preserved exactly.
+            # producer of this pipeline). The C-input warp's
+            # participation depends on whether the productive-body
+            # gate fires (``has_c_input_warp AND
+            # aux_tensor_descriptors``):
+            #
+            # - Gate fires: the C-input role-local while emitted by
+            #   ``program_id._build_c_input_warp_role_local_while``
+            #   consumer-waits on the sched_pipeline every iteration
+            #   (``cute_plan.md`` §7.5.3.2 cycle 1: empty body, but
+            #   the wait/release runs to receive the per-tile work
+            #   coords for cycles 2/3). Include the C-input warp in
+            #   the arrive count.
+            #
+            # - Gate does not fire (``c_input_warps=1`` without an
+            #   aux residual, or ``c_input_warps=0``): the C-input
+            #   warp body is fully inert and never calls
+            #   ``consumer_arrive`` on the sched_pipeline. Subtract
+            #   ``c_input_warp_count`` so ``producer_commit`` is not
+            #   blocked on a missing arrival.
+            #
+            # With ``c_input_warps=0`` the subtraction is a no-op
+            # and the byte-identity path is preserved exactly.
+            c_input_is_sched_consumer = tcgen05_matmul_plan.has_c_input_warp and bool(
+                tcgen05_matmul_plan.aux_tensor_descriptors
+            )
             tcgen05_sched_consumer_role_count = (
                 tcgen05_matmul_plan.role_warp_count
                 - tcgen05_matmul_plan.scheduler_warp_count
-                - tcgen05_matmul_plan.c_input_warp_count
+                - (
+                    0
+                    if c_input_is_sched_consumer
+                    else tcgen05_matmul_plan.c_input_warp_count
+                )
             )
             if tcgen05_matmul_plan.is_clc_persistent and tcgen05_sched_cluster_size > 1:
                 tcgen05_sched_consumer_arrive_count = (

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -317,12 +317,27 @@ class CuteTcgen05MatmulPlan:
     # previously the inert padding slot (sitting after the scheduler
     # warp in the launched-CTA layout). ``launched_warp_count`` stays
     # at 8 either way because ``role_warp_count`` (8 with the slot
-    # lifted) already matches the warpgroup-aligned envelope. The
-    # codegen body of the C-input warp is inert today — it does not
-    # arrive on the scheduler broadcast pipeline, so the consumer
-    # arrive count in ``cute_mma._codegen_cute_mma`` subtracts
-    # ``c_input_warp_count`` to compensate. MONOLITHIC keeps this at
-    # 0 by validator; only WITH_SCHEDULER hosts the slot.
+    # lifted) already matches the warpgroup-aligned envelope.
+    #
+    # The C-input warp's sched-pipeline participation depends on
+    # whether the productive-body gate fires (``c_input_warp_count
+    # > 0`` AND non-empty ``aux_tensor_descriptors``):
+    #
+    # - Gate fires: ``program_id._build_c_input_warp_role_local_while``
+    #   emits a consumer-side role-local while that calls
+    #   ``consumer_wait`` / ``consumer_release`` on the
+    #   sched_pipeline every iteration. The sched-pipeline consumer
+    #   arrive count in ``cute_mma._codegen_cute_mma`` includes the
+    #   C-input warp.
+    #
+    # - Gate closed (no aux residual, or ``c_input_warps=0``): the
+    #   C-input warp body is fully inert and never calls
+    #   ``consumer_arrive`` on the sched_pipeline. The arrive count
+    #   subtracts ``c_input_warp_count`` to compensate so
+    #   ``producer_commit`` does not block on a missing arrival.
+    #
+    # MONOLITHIC keeps this at 0 by validator; only WITH_SCHEDULER
+    # hosts the slot.
     c_input_warp_count: int = 0
     # ``persistence_model`` selects the persistence axis of the
     # generated kernel. ``STATIC_PERSISTENT`` (default) keeps the
@@ -434,6 +449,24 @@ class CuteTcgen05MatmulPlan:
         if self.has_scheduler_warp:
             return self.scheduler_warp_id
         return self.tma_warp_id
+
+    @property
+    def has_c_input_warp(self) -> bool:
+        return self.c_input_warp_count > 0
+
+    @property
+    def c_input_warp_id(self) -> int:
+        # Dedicated C-input warp sits after the scheduler warp. The
+        # validator rejects ``c_input_warps>0`` under ``MONOLITHIC``
+        # (which has no scheduler warp), so the read implies
+        # ``has_scheduler_warp`` in practice; callers must guard on
+        # ``has_c_input_warp`` before reading. Consumed by the C-input
+        # role-local while builder in ``program_id.py`` to gate the
+        # producer body on the matching warp predicate.
+        assert self.has_c_input_warp, (
+            "c_input_warp_id is only valid when c_input_warp_count > 0"
+        )
+        return self.scheduler_warp_id + self.scheduler_warp_count
 
     @property
     def role_warp_count(self) -> int:

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -46,6 +46,83 @@ def _stmt_name_uses(stmt: ast.AST) -> tuple[set[str], set[str]]:
     return reads, writes
 
 
+def _build_sched_pipeline_consumer_wait_block(
+    *,
+    sched_pipeline: str,
+    sched_consumer_state: str,
+    work_tile_smem: str,
+    valid_var: str,
+) -> list[ast.stmt]:
+    """Emit the consumer-side wait block for the ``ROLE_LOCAL_WITH_SCHEDULER``
+    sched_pipeline: ``consumer_wait`` → ``fence_view_async_shared``
+    → ``sync_warp`` → read the work-tile valid flag.
+
+    Shared between ``_build_role_local_while_with_scheduler`` (the
+    TMA-load / MMA-exec / epi consumer roles) and
+    ``_build_c_input_warp_role_local_while`` (the C-input warp role
+    introduced in ``cute_plan.md`` §7.5.3.2's producer-body split).
+    Each call site supplies a fresh ``valid_var`` so the per-role
+    valid flag has its own SMEM name; the other three arguments
+    are pipeline-level and identical across roles.
+
+    ``mbarrier.wait`` PTX stalls the issuing thread until the phase
+    flips, so all 32 threads in the warp can call ``consumer_wait``
+    safely (no lane-0 gate needed). The async-shared fence
+    serializes the scheduler-warp's SMEM writes against the
+    consumer's proxy view of SMEM, and ``sync_warp`` keeps the warp
+    lanes consistent before they read the valid flag from SMEM.
+
+    Each call returns *fresh* AST nodes — caller-supplied factory
+    pattern (insertion-point-specific copies of the same shape)
+    so downstream AST passes are not corrupted by sharing nodes
+    across multiple parents.
+    """
+    return [
+        statement_from_string(
+            f"{sched_pipeline}.consumer_wait({sched_consumer_state})"
+        ),
+        statement_from_string("cute.arch.fence_view_async_shared()"),
+        statement_from_string("cute.arch.sync_warp()"),
+        statement_from_string(
+            f"{valid_var} = {work_tile_smem}[cutlass.Int32(3)] != cutlass.Int32(0)"
+        ),
+    ]
+
+
+def _build_sched_pipeline_consumer_release_block(
+    *,
+    sched_pipeline: str,
+    sched_consumer_state: str,
+) -> list[ast.stmt]:
+    """Emit the consumer-side release block for the
+    ``ROLE_LOCAL_WITH_SCHEDULER`` sched_pipeline: lane-0-gated
+    ``consumer_release`` → ``advance_state`` → ``sync_warp``.
+
+    Companion to ``_build_sched_pipeline_consumer_wait_block``.
+    ``consumer_release`` is gated on ``lane_idx == 0`` because the
+    per-CTA sched-pipeline empty barrier is initialized with one
+    arrival per consumer *warp* (not per-thread) — see
+    ``cute_mma._codegen_cute_mma``'s
+    ``consumer_mask_to_leader=False`` branch. The ``sync_warp``
+    after the advance keeps the warp lanes' view of the
+    register-resident consumer state consistent.
+    """
+    return [
+        create(
+            ast.If,
+            test=expr_from_string("cute.arch.lane_idx() == cutlass.Int32(0)"),
+            body=[
+                statement_from_string(
+                    f"{sched_pipeline}.consumer_release({sched_consumer_state})"
+                ),
+            ],
+            orelse=[],
+        ),
+        statement_from_string(emit_pipeline_advance(sched_consumer_state)),
+        statement_from_string("cute.arch.sync_warp()"),
+    ]
+
+
 if TYPE_CHECKING:
     import sympy
 
@@ -1174,6 +1251,29 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             "== cutlass.Int32(plan.scheduler_warp_id)".replace(
                 "plan.scheduler_warp_id", str(plan.scheduler_warp_id)
             )
+        )
+
+    def _tcgen05_c_input_role_predicate(self) -> str:
+        """Boolean expression that gates the C-input warp's role block.
+
+        Active when the matmul plan has ``c_input_warp_count > 0``
+        (``cute_plan.md`` §7.5.3.2). The C-input warp sits at warp
+        id ``scheduler_warp_id + scheduler_warp_count`` — directly
+        after the scheduler warp in the launched-CTA layout. Cycle 1
+        of the producer-body split: the role-local while body is
+        empty (consumer side still reads from GMEM in
+        ``memory_ops._aux_subtile_load_source``); cycle 2 fills in
+        the producer GMEM→SMEM cooperative copy, cycle 3 the
+        consumer-side SMEM read flip.
+        """
+        plan = self._tcgen05_plan()
+        assert plan is not None and plan.has_c_input_warp, (
+            "tcgen05 C-input role predicate requires a matmul plan "
+            "with has_c_input_warp=True"
+        )
+        return (
+            "cute.arch.make_warp_uniform(cute.arch.warp_idx()) "
+            f"== cutlass.Int32({plan.c_input_warp_id})"
         )
 
     def _split_tcgen05_invariant_setup(
@@ -2397,60 +2497,26 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         linear_pid_expr = self._tcgen05_linear_virtual_pid_from_coords_expr(coord_terms)
 
         # ``PipelineAsync.consumer_wait`` and ``consumer_release``
-        # call into ``mbarrier`` ops that are *per-thread*: every
-        # thread that runs them counts as an arrival on the barrier.
-        # The per-CTA topology used by ``ROLE_LOCAL_WITH_SCHEDULER``
-        # initializes the empty barrier with one arrival per consumer
-        # *warp* (no ``× cluster_size`` multiplier — see
-        # ``cute_mma._codegen_cute_mma`` ``consumer_mask_to_leader``
-        # branch), so we must gate ``consumer_release`` on a single
-        # thread per warp (lane 0). The other 31 lanes synchronize
-        # via ``sync_warp`` after. Same for ``consumer_wait`` —
-        # gating it on lane 0 alone would leave the other 31 lanes
-        # racing ahead, but ``mbarrier.wait`` PTX is documented to
-        # stall the issuing thread until the phase flips, so all 32
-        # threads can call it; the ``sync_warp`` after the read of
-        # SMEM keeps the warp lanes consistent.
-        #
-        # Mirrors the consumer pattern in
-        # ``_build_tcgen05_persistent_prelude`` for the
-        # cluster_m=2 ONE-CTA bridge (work_tile_consume_stmts +
-        # work_tile_release_stmts gated on consumer_leader_var).
-        # Build the wait/release blocks via factories per insertion
-        # point so each prelude/body/sentinel site gets fresh AST
-        # nodes — sharing nodes across multiple parents corrupts
-        # downstream AST passes.
+        # use the shared sched-pipeline factories at module scope —
+        # see ``_build_sched_pipeline_consumer_wait_block`` and
+        # ``_build_sched_pipeline_consumer_release_block`` for the
+        # per-thread vs per-warp arrival count rationale. The
+        # closures here just thread the per-role variables (the
+        # role's ``valid_var`` plus the shared pipeline/state) into
+        # fresh AST nodes per insertion point.
         def _consumer_wait_block() -> list[ast.stmt]:
-            return [
-                statement_from_string(
-                    f"{sched_pipeline}.consumer_wait({sched_consumer_state})"
-                ),
-                # async-shared fence: ensures the scheduler-warp's
-                # SMEM writes are visible in the consumer's proxy
-                # view before reading the work-tile mailbox.
-                statement_from_string("cute.arch.fence_view_async_shared()"),
-                statement_from_string("cute.arch.sync_warp()"),
-                statement_from_string(
-                    f"{valid_var} = "
-                    f"{layout.work_tile_smem}[cutlass.Int32(3)] != cutlass.Int32(0)"
-                ),
-            ]
+            return _build_sched_pipeline_consumer_wait_block(
+                sched_pipeline=sched_pipeline,
+                sched_consumer_state=sched_consumer_state,
+                work_tile_smem=layout.work_tile_smem,
+                valid_var=valid_var,
+            )
 
         def _consumer_release_block() -> list[ast.stmt]:
-            return [
-                create(
-                    ast.If,
-                    test=expr_from_string("cute.arch.lane_idx() == cutlass.Int32(0)"),
-                    body=[
-                        statement_from_string(
-                            f"{sched_pipeline}.consumer_release({sched_consumer_state})"
-                        ),
-                    ],
-                    orelse=[],
-                ),
-                statement_from_string(emit_pipeline_advance(sched_consumer_state)),
-                statement_from_string("cute.arch.sync_warp()"),
-            ]
+            return _build_sched_pipeline_consumer_release_block(
+                sched_pipeline=sched_pipeline,
+                sched_consumer_state=sched_consumer_state,
+            )
 
         # Initial wait + valid-flag read happens in the prelude so the
         # ``while`` test can be a simple condition (CuTe DSL forbids
@@ -3159,6 +3225,121 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             orelse=[],
         )
 
+    def _build_c_input_warp_role_local_while(
+        self,
+        device_function: DeviceFunction,
+        layout: Tcgen05PersistentProgramIDs._Tcgen05PersistentLayout,
+    ) -> ast.stmt:
+        """Build the C-input warp's role-local while
+        (``cute_plan.md`` §7.5.3.2 cycle 1 of the producer-body
+        split).
+
+        Active when the matmul plan has ``c_input_warp_count > 0``
+        AND the forward FX walker discovered one or more
+        auxiliary-tensor descriptors. The C-input warp participates
+        in the scheduler-broadcast pipeline as a *consumer*: each
+        iteration it consumer-waits on ``sched_pipeline``, reads
+        the published per-tile coords from the SMEM mailbox, runs
+        its role body, then consumer-releases. Cycle 1's role body
+        is empty apart from the ``virtual_pid_var`` write — the
+        warp waits / releases each iteration to keep the
+        sched-pipeline arrive count balanced. Cycle 2 fills in the
+        producer-side aux GMEM→SMEM cooperative copy (allocates
+        SMEM ring + ``PipelineAsync.create`` for ``c_pipeline_aux``,
+        emits ``producer_acquire`` → ``cute.copy`` → ``producer_commit``
+        per descriptor); cycle 3 wires the consumer-side SMEM read
+        flip in ``memory_ops._aux_subtile_load_source``.
+
+        Mirrors the consumer-side pattern in
+        ``_build_role_local_while_with_scheduler`` — both route
+        through ``_build_sched_pipeline_consumer_wait_block`` and
+        ``_build_sched_pipeline_consumer_release_block`` at module
+        scope so the two consumer-role builders share one source
+        of truth for the wait/release shape.
+
+        The ``virtual_pid_var`` write is *load-bearing for cycle 2*:
+        the producer body's aux GMEM tile is built by decomposing
+        the linear pid into ``(tile_m, tile_n)`` (same decomposition
+        the existing consumer roles already perform). Emitting it
+        in cycle 1 establishes the producer body's entry point so
+        the cycle-2 landing site can drop the per-descriptor
+        ``producer_acquire`` / ``cute.copy`` / ``producer_commit``
+        sequence in directly after this statement without a
+        structural rewrite. Cycle 2 also lifts the producer-arrive
+        contract on the C-input warp's lane-0 gate; the wait/release
+        shape stays unchanged.
+        """
+        plan = self._tcgen05_plan()
+        assert plan is not None and plan.has_c_input_warp, (
+            "C-input role-local while requires a matmul plan with has_c_input_warp=True"
+        )
+        sched_pipeline_plan = self._tcgen05_sched_pipeline_plan()
+        assert sched_pipeline_plan is not None, (
+            "C-input role-local while requires a registered "
+            "sched_pipeline plan; was register_cute_tcgen05_sched_pipeline_plan "
+            "called by _codegen_cute_mma?"
+        )
+        sched_pipeline = sched_pipeline_plan.pipeline  # type: ignore[attr-defined]
+        sched_consumer_state = (
+            sched_pipeline_plan.consumer_state  # type: ignore[attr-defined]
+        )
+
+        valid_var = device_function.new_var("tcgen05_c_input_warp_valid")
+
+        coord_terms = [
+            f"{layout.work_tile_smem}[cutlass.Int32({i})]"
+            for i in range(len(self.pid_info))
+        ]
+        linear_pid_expr = self._tcgen05_linear_virtual_pid_from_coords_expr(coord_terms)
+
+        # Factories mirror the consumer-side pattern in
+        # ``_build_role_local_while_with_scheduler`` — both go
+        # through the shared module-scope helpers
+        # (``_build_sched_pipeline_consumer_{wait,release}_block``)
+        # so the wait/release shape has one source of truth.
+        def _consumer_wait_block() -> list[ast.stmt]:
+            return _build_sched_pipeline_consumer_wait_block(
+                sched_pipeline=sched_pipeline,
+                sched_consumer_state=sched_consumer_state,
+                work_tile_smem=layout.work_tile_smem,
+                valid_var=valid_var,
+            )
+
+        def _consumer_release_block() -> list[ast.stmt]:
+            return _build_sched_pipeline_consumer_release_block(
+                sched_pipeline=sched_pipeline,
+                sched_consumer_state=sched_consumer_state,
+            )
+
+        prelude: list[ast.stmt] = []
+        prelude.extend(_consumer_wait_block())
+        per_tile_body: list[ast.stmt] = [
+            # Load-bearing for cycle 2: the producer body
+            # (``producer_acquire`` → cooperative GMEM→SMEM
+            # ``cute.copy`` → ``producer_commit`` per descriptor)
+            # will land immediately after this line, using
+            # ``virtual_pid_var`` to decompose the aux tile coords.
+            statement_from_string(f"{self.virtual_pid_var} = {linear_pid_expr}"),
+        ]
+        per_tile_body.extend(_consumer_release_block())
+        per_tile_body.extend(_consumer_wait_block())
+        prelude.append(
+            create(
+                ast.While,
+                test=expr_from_string(valid_var),
+                body=per_tile_body,
+                orelse=[],
+            )
+        )
+        prelude.extend(_consumer_release_block())
+
+        return create(
+            ast.If,
+            test=expr_from_string(self._tcgen05_c_input_role_predicate()),
+            body=prelude,
+            orelse=[],
+        )
+
     def _role_local_dependency_stmts(
         self, shared_body: list[ast.stmt], role_stmts: list[ast.stmt]
     ) -> list[ast.stmt]:
@@ -3472,6 +3653,23 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         if self._tcgen05_has_scheduler_warp():
             role_local_whiles.append(
                 self._build_scheduler_warp_role_local_while(device_function, layout)
+            )
+        # ``c_input_warp_count > 0`` AND a non-empty
+        # ``aux_tensor_descriptors`` adds a fifth role-local while for
+        # the C-input warp (``cute_plan.md`` §7.5.3.2 cycle 1 of the
+        # producer-body split). Cycle 1's role body is empty (just
+        # the consumer_wait / valid-read / release machinery so the
+        # warp participates as a sched-pipeline consumer); cycles 2
+        # and 3 fill in the producer GMEM→SMEM copy and the
+        # consumer-side SMEM read flip. Gating on the descriptors
+        # being non-empty preserves byte identity for every
+        # ``c_input_warps=0`` config (today's default) and for
+        # ``c_input_warps=1`` configs that don't have a residual
+        # epilogue (the walker returns an empty tuple in that case).
+        plan = self._tcgen05_plan()
+        if plan is not None and plan.has_c_input_warp and plan.aux_tensor_descriptors:
+            role_local_whiles.append(
+                self._build_c_input_warp_role_local_while(device_function, layout)
             )
         return role_local_whiles, shared_tile_body
 

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -11174,6 +11174,228 @@ class TestCuteTcgen05AuxTensorWalker(unittest.TestCase):
 
 
 @onlyBackends(["cute"])
+class TestCuteTcgen05AuxPipelineCycle1(unittest.TestCase):
+    """Pin cycle 1 of the C-input warp producer-body split
+    (``cute_plan.md`` §7.5.3.2): the empty C-input warp role-local
+    while emitted by ``program_id._build_c_input_warp_role_local_while``
+    plus the conditional sched-pipeline arrive-count revert.
+
+    Gate: fires only when ``c_input_warp_count > 0`` AND the
+    aux-tensor identity walker discovered one or more descriptors
+    on the matmul plan. For every other config the role-local
+    while is omitted and the codegen is byte-identical to the
+    pre-cycle-1 baseline.
+
+    Cycle 1 emits the role-local while with the linear-pid write
+    as the only per-tile body statement (load-bearing entry point
+    for cycle 2's producer body). The SMEM aux ring +
+    ``c_pipeline_aux`` ``PipelineAsync`` allocation land in cycle
+    2 alongside the ``producer_acquire`` / ``cute.copy`` /
+    ``producer_commit`` body — bundling them together (rather
+    than allocating empty barriers in cycle 1) avoids the
+    cluster-init overhead and ~16 KB SMEM-per-descriptor cost
+    that would otherwise push c_input_warps=1 configs near the
+    228 KB B200 SMEM cap on the canonical 256×256×128 ab=3
+    layout. The runtime-correctness pin below confirms the role-local
+    while + arrive-count change compose without deadlock or
+    wrong-output on a small canonical-fast-config residual kernel.
+    """
+
+    def _residual_kernel(self):  # type: ignore[no-untyped-def]
+        @helion.kernel(backend="cute")
+        def cute_matmul_residual_c_input(
+            x: torch.Tensor, y: torch.Tensor, residual: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = (acc + residual[tile_m, tile_n]).to(x.dtype)
+            return out
+
+        return cute_matmul_residual_c_input
+
+    def _canonical_c_input_config(self) -> helion.Config:
+        return helion.Config(
+            block_sizes=[256, 256, 128],
+            l2_groupings=[1],
+            num_warps=4,
+            num_sm_multiplier=1,
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+            tcgen05_strategy="role_local_with_scheduler",
+            tcgen05_warp_spec_scheduler_warps=1,
+            tcgen05_warp_spec_c_input_warps=1,
+            indexing=[
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "tensor_descriptor",
+            ],
+        )
+
+    def _expected_c_input_warp_id(self, config: helion.Config) -> int:
+        """Compute the expected ``c_input_warp_id`` from the config
+        rather than hardcoding a numeric literal. The id sits after
+        the scheduler warp: 4 epi + 1 exec + 1 ab_load +
+        scheduler_warp_count = 7 under the canonical cluster_m=2
+        config (scheduler_warp_count=1). Computing it here keeps
+        the assertion tied to the matmul-plan accounting so a
+        future role-layout change (e.g. wider mma_warps) updates
+        the test alongside the plan.
+        """
+        cfg = config.config
+        epi = int(cfg.get("tcgen05_num_epi_warps", 4))
+        mma = int(cfg.get("tcgen05_warp_spec_mma_warps", 1))
+        ab_load = int(cfg.get("tcgen05_warp_spec_ab_load_warps", 1))
+        scheduler = int(cfg.get("tcgen05_warp_spec_scheduler_warps", 1))
+        return epi + mma + ab_load + scheduler
+
+    def test_c_input_role_local_while_emits_with_sched_pipeline_wait(self) -> None:
+        """The C-input warp's role-local while is emitted under
+        the productive-body gate, gated on the C-input warp
+        predicate (``warp_idx == c_input_warp_id``), and the body
+        consumer-waits on the sched_pipeline every iteration so
+        the warp participates in the sched-pipeline arrive count.
+
+        Cycle 1's body has the consumer wait/release machinery +
+        the linear-pid expression (load-bearing entry point for
+        cycle 2's producer body). The SMEM aux ring +
+        ``c_pipeline_aux`` allocation arrive in cycle 2, so this
+        cycle's codegen does not yet contain ``producer_acquire``
+        or ``producer_commit`` on any aux pipeline.
+        """
+        kernel = self._residual_kernel()
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        config = self._canonical_c_input_config()
+        with patch_cute_mma_support():
+            bound = kernel.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code = bound.to_triton_code(config)
+
+        # The C-input warp role-local while emits its own valid
+        # flag and gates on ``warp_idx == c_input_warp_id``. The
+        # id sits at scheduler_warp_id + scheduler_warp_count —
+        # computed from the config rather than hardcoded.
+        self.assertIn("tcgen05_c_input_warp_valid", code)
+        expected_warp_id = self._expected_c_input_warp_id(config)
+        self.assertIn(
+            "cute.arch.make_warp_uniform(cute.arch.warp_idx()) == "
+            f"cutlass.Int32({expected_warp_id})",
+            code,
+        )
+        # The SMEM aux ring + c_pipeline_aux land in cycle 2;
+        # cycle 1's codegen does not emit any aux-pipeline
+        # allocation. Pin the absence so a future leak from cycle
+        # 2 lands intentionally.
+        self.assertNotIn("tcgen05_aux_pipeline", code)
+        self.assertNotIn("tcgen05_aux_smem_layout_", code)
+        # Sched-pipeline arrive count under the productive-body
+        # gate includes the C-input warp: 4 epi + 1 mma + 1
+        # ab_load + 1 c_input = 7 consumers.
+        cfg = config.config
+        expected_arrive = (
+            int(cfg.get("tcgen05_num_epi_warps", 4))
+            + int(cfg.get("tcgen05_warp_spec_mma_warps", 1))
+            + int(cfg.get("tcgen05_warp_spec_ab_load_warps", 1))
+            + int(cfg.get("tcgen05_warp_spec_c_input_warps", 1))
+        )
+        self.assertIn(
+            "tcgen05_sched_pipeline_consumer_group = "
+            "cutlass.pipeline.CooperativeGroup("
+            "cutlass.pipeline.Agent.Thread, "
+            f"cutlass.Int32({expected_arrive}))",
+            code,
+        )
+
+    def test_c_input_role_local_while_not_emitted_without_residual(self) -> None:
+        """``c_input_warps=1`` without any aux residual leaves the
+        productive-body gate closed: the walker returns an empty
+        descriptor tuple and the C-input warp role-local while is
+        not emitted. The C-input warp falls back to the
+        inert-padding slot the foundation cycle established and
+        the sched-pipeline arrive-count subtraction compensates.
+        """
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_pure_c_input(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        config = self._canonical_c_input_config()
+        with patch_cute_mma_support():
+            bound = cute_matmul_pure_c_input.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code = bound.to_triton_code(config)
+
+        # No C-input role-local while: the gate-closed path keeps
+        # the warp inert and falls back to the
+        # consumer-arrive-count subtraction.
+        self.assertNotIn("tcgen05_c_input_warp_valid", code)
+        # Sched-pipeline arrive count subtracts the inert C-input
+        # warp: 4 epi + 1 mma + 1 ab_load = 6 consumers (matches
+        # the foundation-cycle pin).
+        self.assertIn(
+            "tcgen05_sched_pipeline_consumer_group = "
+            "cutlass.pipeline.CooperativeGroup("
+            "cutlass.pipeline.Agent.Thread, cutlass.Int32(6))",
+            code,
+        )
+
+    def test_residual_c_input_runtime_correctness(self) -> None:
+        """The c_input=1 + residual lowering compiles, launches,
+        and produces output within bf16 tolerance of the eager
+        reference under the cluster_m=2 canonical fast config.
+
+        Cycle 1's consumer side still reads from GMEM, so this is
+        not a perf test — it confirms the C-input warp role-local
+        while + sched-pipeline consumer arrive-count change
+        compose without deadlock or wrong-output. The 1024^3 size
+        keeps the test under the typical per-test wall-clock
+        budget while still exercising ~16 tile iterations under
+        the persistent grid.
+        """
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = torch.randn(1024, 1024, dtype=torch.bfloat16, device=DEVICE)
+        y = torch.randn(1024, 1024, dtype=torch.bfloat16, device=DEVICE)
+        residual = torch.randn(1024, 1024, dtype=torch.bfloat16, device=DEVICE)
+        kernel = self._residual_kernel()
+        config = self._canonical_c_input_config()
+        bound = kernel.bind((x, y, residual))
+        bound.env.config_spec.cute_tcgen05_search_enabled = True
+        bound.set_config(config)
+        out = bound(x, y, residual)
+        expected = (x @ y + residual).to(x.dtype)
+        torch.testing.assert_close(out, expected, atol=2e-1, rtol=1e-2)
+
+
+@onlyBackends(["cute"])
 class TestCuteDslCompat(unittest.TestCase):
     def test_umma_async_tail_workaround_preserves_leader_cta_guard(self) -> None:
         from helion._compiler.cute import cutedsl_compat


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2411
 * #2410
 * #2409
 * #2408
 * __->__#2407
 * #2406
 * #2405
 * #2404
 * #2403
 * #2402
 * #2401
 * #2400


--- --- ---

[cutedsl] emit c-input warp role-local while for residual scheduling