### PR TITLE
[cutedsl] allocate c-input warp aux pipeline without producer barrier ops

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -167,6 +167,70 @@ class _Tcgen05LayoutPlan:
 
 
 @dataclass(frozen=True)
+class _Tcgen05AuxPerDescriptorRingNames:
+    """Generated CuTe variable names for one auxiliary-tensor SMEM ring.
+
+    One instance per :class:`Tcgen05AuxTensorDescriptor` registered on
+    the matmul plan when the productive-body gate fires
+    (``c_input_warp_count > 0`` AND non-empty
+    ``aux_tensor_descriptors``). Each ring has its own
+    ``make_smem_layout_epi``-based SMEM layout, ``alloc_smem`` ptr,
+    and ``make_tensor`` view; the producer body in
+    ``program_id._build_c_input_warp_role_local_while`` indexes the
+    ring by descriptor position, and cycle 3's consumer-side flip
+    in ``memory_ops._aux_subtile_load_source`` reads from the same
+    SMEM tensor in descriptor-list order.
+    """
+
+    smem_layout: str
+    smem_ptr: str
+    smem: str
+
+
+@dataclass(frozen=True)
+class _Tcgen05AuxPipelinePlan:
+    """Generated CuTe variable names for the C-input warp's
+    auxiliary-tensor SMEM-ring pipeline (``cute_plan.md`` §7.5.3.2).
+
+    Pure name container, mirroring ``_Tcgen05SchedPipelinePlan``.
+    Each field is the textual identifier of a value materialized in
+    the kernel prefix when ``_emit_tcgen05_aux_pipeline_setup``
+    runs. The pipeline is allocated only when the productive-body
+    gate fires (``c_input_warp_count > 0`` AND non-empty
+    ``aux_tensor_descriptors``).
+
+    ``rings`` carries the per-descriptor SMEM ring names in
+    descriptor-list order — the same order
+    ``CuteTcgen05MatmulPlan.aux_tensor_descriptors`` exposes them.
+    The producer body indexes by position; the consumer side
+    (cycle 3) consumes the same ordering.
+
+    Consumer cooperative group: **``epi_warp_count`` (per-warp,
+    NOT per-thread)**. Cycle 3's consumer-side flip in
+    ``memory_ops._aux_subtile_load_source`` will gate
+    ``consumer_release(c_pipeline_aux)`` on ``lane_idx() == 0``
+    (matching the sched-pipeline pattern from
+    ``_build_role_local_while_with_scheduler``), so the consumer
+    arrive count is per-warp. Setting per-thread would hang cycle
+    3 waiting for 31 missing per-warp arrivals per stage.
+    """
+
+    barriers: str
+    producer_group: str
+    consumer_group: str
+    pipeline: str
+    producer_state: str
+    # Pre-allocated for cycle 3: the consumer-side flip in
+    # ``memory_ops._aux_subtile_load_source`` will issue
+    # ``c_pipeline_aux.consumer_wait`` / ``consumer_release`` keyed
+    # off this state. Cycle 2a allocates the name + the
+    # ``make_pipeline_state(...)`` initializer so cycle 3 can wire
+    # it in place without revisiting the allocator.
+    consumer_state: str
+    rings: tuple[_Tcgen05AuxPerDescriptorRingNames, ...]
+
+
+@dataclass(frozen=True)
 class _Tcgen05SchedPipelinePlan:
     """Generated CuTe variable names for the scheduler-broadcast pipeline.
 
@@ -2780,6 +2844,56 @@ def _emit_mma_pipeline(
             # safe to emit at the kernel prefix.
             if tcgen05_matmul_plan.is_clc_persistent:
                 prefix.extend(_emit_clc_smem_setup(tcgen05_sched_plan))
+            # C-input warp aux SMEM ring + ``c_pipeline_aux``
+            # ``PipelineAsync`` (``cute_plan.md`` §7.5.3.2 cycle 2
+            # of the producer-body split). Fires only when the
+            # productive-body gate is open: ``c_input_warp_count > 0``
+            # AND a non-empty ``aux_tensor_descriptors`` tuple. The
+            # role-local while builder in
+            # ``program_id._build_c_input_warp_role_local_while``
+            # emits the per-descriptor producer body that issues
+            # ``producer_acquire`` → cooperative
+            # ``cute.copy(GMEM, SMEM_ring[stage])`` →
+            # ``producer_commit`` against the same plan; cycle 3 will
+            # flip the consumer-side splice in
+            # ``memory_ops._aux_subtile_load_source`` to read from
+            # the SMEM ring under ``consumer_wait`` /
+            # ``consumer_release`` gating. Gate-closed configs
+            # (``c_input_warps=0`` or no aux residual) skip this
+            # allocation entirely and preserve byte identity.
+            if (
+                tcgen05_matmul_plan.has_c_input_warp
+                and tcgen05_matmul_plan.aux_tensor_descriptors
+            ):
+                aux_descriptor_dtype_strs = tuple(
+                    env.backend.dtype_str(desc.host_tensor_val.dtype)
+                    for desc in tcgen05_matmul_plan.aux_tensor_descriptors
+                )
+                tcgen05_aux_plan = _new_tcgen05_aux_pipeline_plan(
+                    df,
+                    num_rings=len(tcgen05_matmul_plan.aux_tensor_descriptors),
+                )
+                df.register_cute_tcgen05_aux_pipeline_plan(tcgen05_aux_plan)
+                prefix.extend(
+                    _emit_tcgen05_aux_pipeline_setup(
+                        tcgen05_aux_plan,
+                        descriptor_dtype_strs=aux_descriptor_dtype_strs,
+                        epi_tile_var=tcgen05_plan.epi_tile,
+                        # Single C-input warp = 32 lanes (validator
+                        # pins ``c_input_warp_count`` to ``{0, 1}``
+                        # under WITH_SCHEDULER); all 32 lanes
+                        # participate in the producer-side
+                        # cooperative copy.
+                        c_input_warp_thread_count=(
+                            tcgen05_matmul_plan.c_input_warp_count * 32
+                        ),
+                        # Per-warp consumer arrive count for cycle
+                        # 3's lane-0-gated release — see the
+                        # emitter docstring.
+                        epi_warp_count=tcgen05_matmul_plan.epi_warp_count,
+                        defer_sync=tcgen05_use_cluster_deferred_pipelines,
+                    )
+                )
         if not tcgen05_use_tma:
             _emit_tcgen05_tmem_setup()
     else:
@@ -4515,6 +4629,155 @@ def _emit_sched_pipeline_setup(
             f"cutlass.pipeline.PipelineUserType.Consumer, {sched_stage_count})"
         ),
     ]
+
+
+#: Fixed stage count for the aux SMEM-ring pipeline (cycle 2 of the
+#: producer-body split, ``cute_plan.md`` §7.5.3.2). Matches the
+#: existing D-store ``c_pipeline`` 2-stage default. Future cycles
+#: may make this autotunable once the producer body lands.
+_TCGEN05_AUX_PIPELINE_STAGE_COUNT = 2
+
+
+def _new_tcgen05_aux_pipeline_plan(
+    df: DeviceFunction,
+    *,
+    num_rings: int,
+) -> _Tcgen05AuxPipelinePlan:
+    """Allocate variable names for the C-input warp's aux-tensor
+    SMEM-ring pipeline (``cute_plan.md`` §7.5.3.2).
+
+    ``num_rings`` is the number of aux-tensor descriptors registered
+    on the matmul plan; the producer body indexes the rings by
+    descriptor position, and cycle 3's consumer-side flip consumes
+    the same ordering.
+    """
+    assert num_rings >= 1, (
+        "aux pipeline plan requires at least one descriptor; the gate "
+        "in ``_codegen_cute_mma`` should not call this with an empty "
+        "descriptor tuple"
+    )
+    rings = tuple(
+        _Tcgen05AuxPerDescriptorRingNames(
+            smem_layout=df.new_var(f"tcgen05_aux_smem_layout_{idx}"),
+            smem_ptr=df.new_var(f"tcgen05_aux_smem_ptr_{idx}"),
+            smem=df.new_var(f"tcgen05_aux_smem_{idx}"),
+        )
+        for idx in range(num_rings)
+    )
+    return _Tcgen05AuxPipelinePlan(
+        barriers=df.new_var("tcgen05_aux_pipeline_mbars"),
+        producer_group=df.new_var("tcgen05_aux_pipeline_producer_group"),
+        consumer_group=df.new_var("tcgen05_aux_pipeline_consumer_group"),
+        pipeline=df.new_var("tcgen05_aux_pipeline"),
+        producer_state=df.new_var("tcgen05_aux_pipeline_producer_state"),
+        consumer_state=df.new_var("tcgen05_aux_pipeline_consumer_state"),
+        rings=rings,
+    )
+
+
+def _emit_tcgen05_aux_pipeline_setup(
+    plan: _Tcgen05AuxPipelinePlan,
+    *,
+    descriptor_dtype_strs: tuple[str, ...],
+    epi_tile_var: str,
+    c_input_warp_thread_count: int,
+    epi_warp_count: int,
+    defer_sync: bool,
+) -> list[ast.AST]:
+    """Emit the prefix statements that construct the aux SMEM rings
+    + ``c_pipeline_aux`` ``PipelineAsync`` for cycle 2 of the
+    producer-body split (``cute_plan.md`` §7.5.3.2).
+
+    Per descriptor, allocates a SMEM ring sized by
+    ``make_smem_layout_epi(<aux_dtype>, ROW_MAJOR, epi_tile,
+    _TCGEN05_AUX_PIPELINE_STAGE_COUNT)`` — the same staged-epilogue
+    layout the D-output uses. Cycle 3's consumer-side flip in
+    ``memory_ops._aux_subtile_load_source`` consumes the SMEM
+    tensor via the same ``partition_C → transform → flat_divide(epi_tile)
+    → partition_D`` pipeline the existing GMEM path already uses,
+    so the layout choice keeps cycle 3 a localized GMEM→SMEM
+    operand swap.
+
+    Pipeline parameters:
+
+    - ``producer_arrive_count = c_input_warp_thread_count`` (32 for
+      the single C-input warp). The producer body issues
+      ``producer_acquire`` / ``producer_commit`` per-thread, so
+      the cooperative-group arrive count is per-thread.
+    - ``consumer_arrive_count = epi_warp_count`` (per-warp, NOT
+      per-thread). Cycle 3's consumer-side flip will gate
+      ``consumer_release(c_pipeline_aux)`` on ``lane_idx() == 0``
+      (matching the sched-pipeline pattern from
+      ``_build_role_local_while_with_scheduler``). Setting
+      per-thread would hang cycle 3 waiting for 31 missing
+      per-warp arrivals per stage.
+    - ``defer_sync`` mirrors the AB / acc / sched pipelines'
+      cluster-deferred-init participation so the
+      ``pipeline_init_arrive`` / ``pipeline_init_wait`` rendezvous
+      spans every pipeline.
+    """
+    extra_args = ", defer_sync=True" if defer_sync else ""
+    stage_count = _TCGEN05_AUX_PIPELINE_STAGE_COUNT
+    lines: list[ast.AST] = []
+    for ring, dtype_str in zip(plan.rings, descriptor_dtype_strs, strict=True):
+        lines.extend(
+            [
+                statement_from_string(
+                    f"{ring.smem_layout} = "
+                    f"cutlass.utils.blackwell_helpers.make_smem_layout_epi("
+                    f"{dtype_str}, cutlass.utils.layout.LayoutEnum.ROW_MAJOR, "
+                    f"{epi_tile_var}, {stage_count})"
+                ),
+                statement_from_string(
+                    f"{ring.smem_ptr} = cute.arch.alloc_smem("
+                    f"{dtype_str}, cute.cosize({ring.smem_layout}.outer), "
+                    "alignment=1024)"
+                ),
+                statement_from_string(
+                    f"{ring.smem} = cute.make_tensor("
+                    f"cute.recast_ptr({ring.smem_ptr}, "
+                    f"{ring.smem_layout}.inner, dtype={dtype_str}), "
+                    f"{ring.smem_layout}.outer)"
+                ),
+            ]
+        )
+    lines.extend(
+        [
+            statement_from_string(
+                f"{plan.barriers} = cute.arch.alloc_smem("
+                f"cutlass.Int64, cutlass.Int32({stage_count * 2}))"
+            ),
+            statement_from_string(
+                f"{plan.producer_group} = "
+                "cutlass.pipeline.CooperativeGroup("
+                "cutlass.pipeline.Agent.Thread, "
+                f"cutlass.Int32({c_input_warp_thread_count}))"
+            ),
+            statement_from_string(
+                f"{plan.consumer_group} = "
+                "cutlass.pipeline.CooperativeGroup("
+                "cutlass.pipeline.Agent.Thread, "
+                f"cutlass.Int32({epi_warp_count}))"
+            ),
+            statement_from_string(
+                f"{plan.pipeline} = cutlass.pipeline.PipelineAsync.create("
+                f"num_stages={stage_count}, "
+                f"producer_group={plan.producer_group}, "
+                f"consumer_group={plan.consumer_group}, "
+                f"barrier_storage={plan.barriers}"
+                f"{extra_args})"
+            ),
+            statement_from_string(
+                f"{plan.producer_state} = cutlass.pipeline.make_pipeline_state("
+                f"cutlass.pipeline.PipelineUserType.Producer, {stage_count})"
+            ),
+            statement_from_string(
+                f"{plan.consumer_state} = cutlass.pipeline.make_pipeline_state("
+                f"cutlass.pipeline.PipelineUserType.Consumer, {stage_count})"
+            ),
+        ]
+    )
+    return lines
 
 
 def _tcgen05_epilogue_dest_expr(plan: _Tcgen05LayoutPlan, tensor: str) -> str:

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -640,6 +640,18 @@ class DeviceFunction:
         # consumer-side ``consumer_wait``/``consumer_release`` and the
         # scheduler-warp role-local while.
         self.cute_tcgen05_sched_pipeline_plan: object | None = None
+        # ``_Tcgen05AuxPipelinePlan`` for the C-input warp's
+        # auxiliary-tensor SMEM-ring pipeline (``cute_plan.md``
+        # §7.5.3.2 cycle 2). Set in ``_codegen_cute_mma`` when the
+        # productive-body gate fires (``c_input_warp_count > 0`` AND
+        # non-empty ``aux_tensor_descriptors``); ``program_id.py``
+        # reads it when emitting the C-input warp role-local while
+        # body (per-descriptor ``producer_acquire`` → cooperative
+        # ``cute.copy(GMEM, SMEM_ring[stage])`` → ``producer_commit``),
+        # and ``memory_ops._aux_subtile_load_source`` reads the
+        # per-descriptor SMEM ring when cycle 3's consumer flip
+        # lands.
+        self.cute_tcgen05_aux_pipeline_plan: object | None = None
         self._cute_tcgen05_per_tile_stmt_ids: set[int] = set()
         self._cute_tcgen05_post_loop_stmt_ids: set[int] = set()
         self._cute_tcgen05_tma_load_role_stmt_ids: set[int] = set()
@@ -850,6 +862,21 @@ class DeviceFunction:
         the scheduler-warp role-local while.
         """
         self.cute_tcgen05_sched_pipeline_plan = plan
+
+    def register_cute_tcgen05_aux_pipeline_plan(self, plan: object) -> None:
+        """Register the C-input warp's auxiliary-tensor SMEM-ring
+        ``PipelineAsync`` plan (``cute_plan.md`` §7.5.3.2 cycle 2).
+
+        Set by ``cute_mma._codegen_cute_mma`` when the productive-body
+        gate fires (``c_input_warp_count > 0`` AND non-empty
+        ``aux_tensor_descriptors``). ``program_id.py`` reads it when
+        emitting the C-input warp's role-local while body
+        (per-descriptor ``producer_acquire`` → cooperative
+        ``cute.copy(GMEM, SMEM_ring[stage])`` → ``producer_commit``),
+        and ``memory_ops._aux_subtile_load_source`` reads the
+        per-descriptor SMEM ring when cycle 3's consumer flip lands.
+        """
+        self.cute_tcgen05_aux_pipeline_plan = plan
 
     def register_cute_tcgen05_per_tile_stmts(self, stmts: list[ast.AST]) -> None:
         """Mark statements that depend on per-tile coordinates.

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -3231,8 +3231,7 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         layout: Tcgen05PersistentProgramIDs._Tcgen05PersistentLayout,
     ) -> ast.stmt:
         """Build the C-input warp's role-local while
-        (``cute_plan.md`` §7.5.3.2 cycle 1 of the producer-body
-        split).
+        (``cute_plan.md`` §7.5.3.2 producer-body split).
 
         Active when the matmul plan has ``c_input_warp_count > 0``
         AND the forward FX walker discovered one or more
@@ -3240,15 +3239,30 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         in the scheduler-broadcast pipeline as a *consumer*: each
         iteration it consumer-waits on ``sched_pipeline``, reads
         the published per-tile coords from the SMEM mailbox, runs
-        its role body, then consumer-releases. Cycle 1's role body
-        is empty apart from the ``virtual_pid_var`` write — the
-        warp waits / releases each iteration to keep the
-        sched-pipeline arrive count balanced. Cycle 2 fills in the
-        producer-side aux GMEM→SMEM cooperative copy (allocates
-        SMEM ring + ``PipelineAsync.create`` for ``c_pipeline_aux``,
-        emits ``producer_acquire`` → ``cute.copy`` → ``producer_commit``
-        per descriptor); cycle 3 wires the consumer-side SMEM read
-        flip in ``memory_ops._aux_subtile_load_source``.
+        its role body, then consumer-releases.
+
+        Per-tile body (post-cycle-2a):
+
+        1. ``virtual_pid_var`` write (decomposed from
+           ``work_tile_smem`` coords). Cycle 2b will use this to
+           build the aux GMEM tile for the cooperative copy.
+        2. No producer-side barrier ops fire this cycle. Cycle 2b
+           lands the complete producer handshake — the
+           ``c_pipeline_aux.producer_acquire(producer_state)`` /
+           cooperative ``cute.copy(GMEM, SMEM)`` /
+           ``c_pipeline_aux.producer_commit(producer_state)`` /
+           ``producer_state`` advance — and cycle 3 wires the
+           consumer-side SMEM read flip
+           (``c_pipeline_aux.consumer_wait`` /
+           ``consumer_release``) in
+           ``memory_ops._aux_subtile_load_source``. The producer
+           and consumer barrier ops *must* land in the same cycle
+           or a partial-handshake deadlock results (an early-2a
+           variant of this builder emitted producer barriers
+           without consumer releases; with ``num_stages=2`` the
+           third ``producer_acquire`` blocks forever once a CTA
+           wraps the pipeline depth — see the deadlock-regression
+           pin in ``TestCuteTcgen05AuxPipelineCycle2a``).
 
         Mirrors the consumer-side pattern in
         ``_build_role_local_while_with_scheduler`` — both route
@@ -3257,17 +3271,17 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         scope so the two consumer-role builders share one source
         of truth for the wait/release shape.
 
-        The ``virtual_pid_var`` write is *load-bearing for cycle 2*:
-        the producer body's aux GMEM tile is built by decomposing
-        the linear pid into ``(tile_m, tile_n)`` (same decomposition
-        the existing consumer roles already perform). Emitting it
-        in cycle 1 establishes the producer body's entry point so
-        the cycle-2 landing site can drop the per-descriptor
-        ``producer_acquire`` / ``cute.copy`` / ``producer_commit``
-        sequence in directly after this statement without a
-        structural rewrite. Cycle 2 also lifts the producer-arrive
-        contract on the C-input warp's lane-0 gate; the wait/release
-        shape stays unchanged.
+        Cycle 2a (this slice): the data-model + SMEM ring +
+        ``c_pipeline_aux`` ``PipelineAsync.create`` +
+        producer/consumer ``make_pipeline_state`` lands in
+        ``cute_mma._codegen_cute_mma``; the producer body does NOT
+        fire any barrier ops. The pipeline storage exists but the
+        producer/consumer handshake is dormant until cycle 2b
+        lands the producer ops + cooperative copy and cycle 3
+        lands the consumer-side flip. The pre-allocated
+        ``producer_state`` / ``consumer_state`` are unused this
+        cycle but reserved so cycle 2b / cycle 3 can wire them in
+        place without revisiting the allocator.
         """
         plan = self._tcgen05_plan()
         assert plan is not None and plan.has_c_input_warp, (
@@ -3282,6 +3296,23 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         sched_pipeline = sched_pipeline_plan.pipeline  # type: ignore[attr-defined]
         sched_consumer_state = (
             sched_pipeline_plan.consumer_state  # type: ignore[attr-defined]
+        )
+        # Aux pipeline plan (cycle 2a). The matmul-plan gate that
+        # admits this builder also fires the pipeline allocation
+        # in ``cute_mma._codegen_cute_mma``, so a non-None plan
+        # is the invariant we rely on once the gate is open.
+        # ``producer_state`` / ``consumer_state`` are reserved by
+        # the allocator but unused this cycle — cycle 2b wires the
+        # producer side and cycle 3 wires the consumer side. We
+        # keep the assert so a future gate-skew between
+        # ``has_c_input_warp + aux_tensor_descriptors`` and the
+        # cute_mma allocator fires here rather than producing a
+        # half-allocated kernel.
+        aux_pipeline_plan = device_function.cute_tcgen05_aux_pipeline_plan
+        assert aux_pipeline_plan is not None, (
+            "C-input role-local while requires a registered "
+            "aux pipeline plan; was register_cute_tcgen05_aux_pipeline_plan "
+            "called by _codegen_cute_mma?"
         )
 
         valid_var = device_function.new_var("tcgen05_c_input_warp_valid")
@@ -3311,14 +3342,18 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                 sched_consumer_state=sched_consumer_state,
             )
 
+        # Cycle 2a producer body: NO barrier ops. The aux pipeline
+        # storage is allocated up front but the
+        # ``producer_acquire`` / ``producer_commit`` handshake
+        # lands in cycle 2b paired with the cooperative
+        # GMEM→SMEM copy and the cycle-3 consumer side. Wiring
+        # producer barriers here without a matching consumer
+        # release would deadlock after ``num_stages`` iterations
+        # per CTA (the third ``producer_acquire`` blocks waiting
+        # for an empty-mbar arrival the consumer never issues).
         prelude: list[ast.stmt] = []
         prelude.extend(_consumer_wait_block())
         per_tile_body: list[ast.stmt] = [
-            # Load-bearing for cycle 2: the producer body
-            # (``producer_acquire`` → cooperative GMEM→SMEM
-            # ``cute.copy`` → ``producer_commit`` per descriptor)
-            # will land immediately after this line, using
-            # ``virtual_pid_var`` to decompose the aux tile coords.
             statement_from_string(f"{self.virtual_pid_var} = {linear_pid_expr}"),
         ]
         per_tile_body.extend(_consumer_release_block())
@@ -3656,16 +3691,21 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             )
         # ``c_input_warp_count > 0`` AND a non-empty
         # ``aux_tensor_descriptors`` adds a fifth role-local while for
-        # the C-input warp (``cute_plan.md`` §7.5.3.2 cycle 1 of the
-        # producer-body split). Cycle 1's role body is empty (just
-        # the consumer_wait / valid-read / release machinery so the
-        # warp participates as a sched-pipeline consumer); cycles 2
-        # and 3 fill in the producer GMEM→SMEM copy and the
-        # consumer-side SMEM read flip. Gating on the descriptors
-        # being non-empty preserves byte identity for every
-        # ``c_input_warps=0`` config (today's default) and for
-        # ``c_input_warps=1`` configs that don't have a residual
-        # epilogue (the walker returns an empty tuple in that case).
+        # the C-input warp (``cute_plan.md`` §7.5.3.2 producer-body
+        # split). Post-cycle-2a the role body has the
+        # consumer_wait / valid-read / release machinery so the
+        # warp participates as a sched-pipeline consumer and
+        # publishes ``virtual_pid_var`` for cycle 2b. The aux
+        # pipeline storage (SMEM ring + ``c_pipeline_aux``) is
+        # allocated alongside but the
+        # producer/consumer barrier handshake stays dormant until
+        # cycle 2b (producer side + cooperative copy) and cycle 3
+        # (consumer-side SMEM read flip) land together. Gating on
+        # the descriptors being non-empty preserves byte identity
+        # for every ``c_input_warps=0`` config (today's default)
+        # and for ``c_input_warps=1`` configs that don't have a
+        # residual epilogue (the walker returns an empty tuple in
+        # that case).
         plan = self._tcgen05_plan()
         if plan is not None and plan.has_c_input_warp and plan.aux_tensor_descriptors:
             role_local_whiles.append(

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -11174,31 +11174,34 @@ class TestCuteTcgen05AuxTensorWalker(unittest.TestCase):
 
 
 @onlyBackends(["cute"])
-class TestCuteTcgen05AuxPipelineCycle1(unittest.TestCase):
-    """Pin cycle 1 of the C-input warp producer-body split
-    (``cute_plan.md`` §7.5.3.2): the empty C-input warp role-local
-    while emitted by ``program_id._build_c_input_warp_role_local_while``
-    plus the conditional sched-pipeline arrive-count revert.
+class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
+    """Pin cycle 2a of the C-input warp producer-body split
+    (``cute_plan.md`` §7.5.3.2): SMEM aux ring + ``c_pipeline_aux``
+    ``PipelineAsync`` allocation at MMA-codegen time, plus the
+    C-input warp role-local while body that consumer-waits on the
+    sched_pipeline and publishes ``virtual_pid_var`` for cycle 2b.
+    No producer/consumer barrier ops fire on ``c_pipeline_aux``
+    this cycle — the producer side (``producer_acquire`` +
+    cooperative ``cute.copy(GMEM, SMEM)`` + ``producer_commit``)
+    lands in cycle 2b paired with the consumer-side flip in
+    cycle 3. Wiring producer barriers here without a matching
+    consumer release would deadlock once a CTA wraps the
+    pipeline depth — the
+    ``test_aux_pipeline_no_producer_barrier_ops_emitted`` pin
+    below guards against that regression.
 
     Gate: fires only when ``c_input_warp_count > 0`` AND the
     aux-tensor identity walker discovered one or more descriptors
     on the matmul plan. For every other config the role-local
-    while is omitted and the codegen is byte-identical to the
-    pre-cycle-1 baseline.
+    while is omitted, the SMEM ring + pipeline allocation skip,
+    and the codegen is byte-identical to the pre-cycle-1
+    baseline.
 
-    Cycle 1 emits the role-local while with the linear-pid write
-    as the only per-tile body statement (load-bearing entry point
-    for cycle 2's producer body). The SMEM aux ring +
-    ``c_pipeline_aux`` ``PipelineAsync`` allocation land in cycle
-    2 alongside the ``producer_acquire`` / ``cute.copy`` /
-    ``producer_commit`` body — bundling them together (rather
-    than allocating empty barriers in cycle 1) avoids the
-    cluster-init overhead and ~16 KB SMEM-per-descriptor cost
-    that would otherwise push c_input_warps=1 configs near the
-    228 KB B200 SMEM cap on the canonical 256×256×128 ab=3
-    layout. The runtime-correctness pin below confirms the role-local
-    while + arrive-count change compose without deadlock or
-    wrong-output on a small canonical-fast-config residual kernel.
+    The runtime-correctness pin below confirms the SMEM ring +
+    pipeline + role-local while compose without deadlock or
+    wrong-output on a small canonical-fast-config residual kernel
+    — the consumer still reads from GMEM and the producer side
+    is dormant, so output equivalence is preserved.
     """
 
     def _residual_kernel(self):  # type: ignore[no-untyped-def]
@@ -11264,12 +11267,15 @@ class TestCuteTcgen05AuxPipelineCycle1(unittest.TestCase):
         consumer-waits on the sched_pipeline every iteration so
         the warp participates in the sched-pipeline arrive count.
 
-        Cycle 1's body has the consumer wait/release machinery +
-        the linear-pid expression (load-bearing entry point for
-        cycle 2's producer body). The SMEM aux ring +
-        ``c_pipeline_aux`` allocation arrive in cycle 2, so this
-        cycle's codegen does not yet contain ``producer_acquire``
-        or ``producer_commit`` on any aux pipeline.
+        Cycle 2a's body has the consumer wait/release machinery
+        and the linear-pid expression (consumed by cycle 2b's
+        cooperative GMEM→SMEM copy). The producer-side handshake
+        on ``c_pipeline_aux`` (``producer_acquire`` / cooperative
+        ``cute.copy`` / ``producer_commit``) lands in cycle 2b
+        paired with the cycle-3 consumer-side flip — see
+        ``test_aux_pipeline_no_producer_barrier_ops_emitted``
+        for the deadlock-regression pin that guards against
+        landing producer barriers without consumer releases.
         """
         kernel = self._residual_kernel()
         args = (
@@ -11294,12 +11300,10 @@ class TestCuteTcgen05AuxPipelineCycle1(unittest.TestCase):
             f"cutlass.Int32({expected_warp_id})",
             code,
         )
-        # The SMEM aux ring + c_pipeline_aux land in cycle 2;
-        # cycle 1's codegen does not emit any aux-pipeline
-        # allocation. Pin the absence so a future leak from cycle
-        # 2 lands intentionally.
-        self.assertNotIn("tcgen05_aux_pipeline", code)
-        self.assertNotIn("tcgen05_aux_smem_layout_", code)
+        # Cycle 2a does NOT yet emit a cooperative GMEM→SMEM
+        # ``cute.copy`` between any acquire/commit pair. Pin the
+        # absence so cycle 2b lands intentionally.
+        self.assertNotIn("cute.autovec_copy", code)
         # Sched-pipeline arrive count under the productive-body
         # gate includes the C-input warp: 4 epi + 1 mma + 1
         # ab_load + 1 c_input = 7 consumers.
@@ -11318,13 +11322,87 @@ class TestCuteTcgen05AuxPipelineCycle1(unittest.TestCase):
             code,
         )
 
+    def test_aux_pipeline_smem_ring_allocation_codegen(self) -> None:
+        """The aux SMEM ring + ``c_pipeline_aux`` materialize when
+        the productive-body gate fires (``c_input_warp_count > 0``
+        AND non-empty ``aux_tensor_descriptors``).
+
+        Pin the SMEM layout helper name (``make_smem_layout_epi``),
+        the per-descriptor SMEM ring variable names, the
+        producer cooperative group size (per-thread = 32 lanes,
+        matching the C-input warp's 32 threads), the consumer
+        cooperative group size (per-warp = ``epi_warp_count``,
+        NOT per-thread, so cycle 3's lane-0-gated
+        ``consumer_release`` does not hang on missing per-warp
+        arrivals), and the ``defer_sync=True`` flag (so the
+        cluster-deferred-init protocol coordinates with the
+        AB / acc / sched pipelines).
+        """
+        kernel = self._residual_kernel()
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        config = self._canonical_c_input_config()
+        with patch_cute_mma_support():
+            bound = kernel.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code = bound.to_triton_code(config)
+
+        # Per-descriptor SMEM ring vars (one descriptor for the
+        # canonical exact-shape residual aux). Layout helper +
+        # alloc_smem + make_tensor view.
+        self.assertIn("tcgen05_aux_smem_layout_0", code)
+        self.assertIn("tcgen05_aux_smem_ptr_0", code)
+        self.assertIn("tcgen05_aux_smem_0", code)
+        self.assertIn("cutlass.utils.blackwell_helpers.make_smem_layout_epi(", code)
+        # ``c_pipeline_aux`` ``PipelineAsync.create`` site.
+        self.assertIn("tcgen05_aux_pipeline_mbars", code)
+        self.assertIn(
+            "tcgen05_aux_pipeline = cutlass.pipeline.PipelineAsync.create(",
+            code,
+        )
+        # Producer cooperative group: 32 lanes (single C-input
+        # warp).
+        self.assertIn(
+            "tcgen05_aux_pipeline_producer_group = "
+            "cutlass.pipeline.CooperativeGroup("
+            "cutlass.pipeline.Agent.Thread, cutlass.Int32(32))",
+            code,
+        )
+        # Consumer cooperative group: per-warp (epi_warp_count,
+        # NOT epi_warp_count * 32). Cycle 3's lane-0-gated
+        # ``consumer_release`` arrives once per warp.
+        cfg = config.config
+        expected_consumer = int(cfg.get("tcgen05_num_epi_warps", 4))
+        self.assertIn(
+            "tcgen05_aux_pipeline_consumer_group = "
+            "cutlass.pipeline.CooperativeGroup("
+            "cutlass.pipeline.Agent.Thread, "
+            f"cutlass.Int32({expected_consumer}))",
+            code,
+        )
+        # Cluster-deferred-init participation: ``defer_sync=True``
+        # on the ``c_pipeline_aux`` create site (matches AB /
+        # acc / sched pipelines under the cluster envelope).
+        aux_create_idx = code.find(
+            "tcgen05_aux_pipeline = cutlass.pipeline.PipelineAsync.create("
+        )
+        self.assertGreater(aux_create_idx, -1)
+        aux_create_end = code.find(")", aux_create_idx)
+        aux_create_call = code[aux_create_idx:aux_create_end]
+        self.assertIn("defer_sync=True", aux_create_call)
+
     def test_c_input_role_local_while_not_emitted_without_residual(self) -> None:
         """``c_input_warps=1`` without any aux residual leaves the
         productive-body gate closed: the walker returns an empty
-        descriptor tuple and the C-input warp role-local while is
-        not emitted. The C-input warp falls back to the
-        inert-padding slot the foundation cycle established and
-        the sched-pipeline arrive-count subtraction compensates.
+        descriptor tuple, the C-input warp role-local while is
+        not emitted, AND the SMEM aux ring + ``c_pipeline_aux``
+        allocation skip (cycle 2a fires both together). The
+        C-input warp falls back to the inert-padding slot the
+        foundation cycle established and the sched-pipeline
+        arrive-count subtraction compensates.
         """
 
         @helion.kernel(backend="cute")
@@ -11353,6 +11431,12 @@ class TestCuteTcgen05AuxPipelineCycle1(unittest.TestCase):
         # the warp inert and falls back to the
         # consumer-arrive-count subtraction.
         self.assertNotIn("tcgen05_c_input_warp_valid", code)
+        # Gate-closed: SMEM ring + pipeline allocation skipped.
+        # Pin the absence of the aux pipeline variable names so
+        # a future leak that allocates dead barriers without a
+        # production caller lands intentionally.
+        self.assertNotIn("tcgen05_aux_pipeline", code)
+        self.assertNotIn("tcgen05_aux_smem_layout_", code)
         # Sched-pipeline arrive count subtracts the inert C-input
         # warp: 4 epi + 1 mma + 1 ab_load = 6 consumers (matches
         # the foundation-cycle pin).
@@ -11368,13 +11452,19 @@ class TestCuteTcgen05AuxPipelineCycle1(unittest.TestCase):
         and produces output within bf16 tolerance of the eager
         reference under the cluster_m=2 canonical fast config.
 
-        Cycle 1's consumer side still reads from GMEM, so this is
-        not a perf test — it confirms the C-input warp role-local
-        while + sched-pipeline consumer arrive-count change
-        compose without deadlock or wrong-output. The 1024^3 size
-        keeps the test under the typical per-test wall-clock
-        budget while still exercising ~16 tile iterations under
-        the persistent grid.
+        Cycle 2a's consumer side still reads from GMEM (the
+        cooperative GMEM→SMEM copy is cycle 2b; the consumer
+        flip is cycle 3) and the producer side is dormant
+        (no ``producer_acquire`` / ``producer_commit`` fire on
+        ``c_pipeline_aux``), so this is not a perf test — it
+        confirms the SMEM aux ring + ``c_pipeline_aux`` +
+        role-local while compose without wrong-output. The
+        1024^3 size keeps the test under the typical per-test
+        wall-clock budget while still exercising ~16 tile
+        iterations under the persistent grid; the multi-tile
+        deadlock-regression pin lives in
+        ``test_aux_pipeline_no_producer_barrier_ops_emitted``
+        + the 4096^3 runtime cross-check below.
         """
         from helion._compiler.cute.mma_support import get_cute_mma_support
 
@@ -11393,6 +11483,118 @@ class TestCuteTcgen05AuxPipelineCycle1(unittest.TestCase):
         out = bound(x, y, residual)
         expected = (x @ y + residual).to(x.dtype)
         torch.testing.assert_close(out, expected, atol=2e-1, rtol=1e-2)
+
+    def test_aux_pipeline_no_producer_barrier_ops_emitted(self) -> None:
+        """Deadlock-regression pin: cycle 2a must NOT emit any
+        ``c_pipeline_aux.producer_acquire`` / ``producer_commit``
+        calls.
+
+        An early-2a variant of the role-local-while builder
+        emitted producer barrier-arrival framing every iteration
+        in the hope of "keeping the per-stage phases balanced".
+        That's a deadlock — the consumer-side flip lands in
+        cycle 3, so cycle 2a has *no consumer that ever
+        releases* the aux pipeline. With
+        ``_TCGEN05_AUX_PIPELINE_STAGE_COUNT = 2``, the first two
+        ``producer_acquire`` calls drain the pre-signaled empty
+        barriers; the third blocks forever. The runtime path
+        only stalls if a CTA wraps the pipeline depth (more than
+        ``num_stages`` tile iterations per CTA), which the
+        1024^3 + 256x256 + persistent-blocked grid can miss when
+        the tile count (~16) is smaller than the SM count
+        (~148). Pin codegen-level absence so the regression
+        catches without needing a worst-case shape.
+
+        Once cycle 2b lands the matching producer ops + cycle 3
+        the consumer side, this pin moves to the cycle-2b suite
+        with the inverse assertions (``assertIn`` on the
+        producer ops).
+        """
+        kernel = self._residual_kernel()
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        config = self._canonical_c_input_config()
+        with patch_cute_mma_support():
+            bound = kernel.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code = bound.to_triton_code(config)
+
+        self.assertNotIn("tcgen05_aux_pipeline.producer_acquire(", code)
+        self.assertNotIn("tcgen05_aux_pipeline.producer_commit(", code)
+        # The aux pipeline state itself is allocated (cycle 2a
+        # data-model + ``make_pipeline_state`` initializer); only
+        # the in-loop barrier ops are forbidden. Pin the
+        # allocator to make the negative pins meaningful — a
+        # future regression that *also* drops the allocator
+        # should fail one of the sibling positive pins, not just
+        # silently nullify both negative pins here.
+        self.assertIn("tcgen05_aux_pipeline_producer_state", code)
+        self.assertIn(
+            "tcgen05_aux_pipeline = cutlass.pipeline.PipelineAsync.create(",
+            code,
+        )
+
+    def test_aux_pipeline_smem_budget_canonical_ab_stages_3(self) -> None:
+        """Compile-only SMEM-budget pin for the canonical
+        cluster_m=2 ``tcgen05_ab_stages=3`` config.
+
+        B200 caps per-CTA SMEM at 228 KB. The canonical
+        cluster_m=2 [256,256,128] config with ``ab_stages=3``
+        already consumes ~220 KB; cycle 2a's aux SMEM ring adds
+        ~16 KB per descriptor (256x128 bf16 with
+        ``num_stages=2``). Compiling this config must not raise
+        a ptxas SMEM-over-budget error — if cycle 2a's
+        allocator ever inflates the per-descriptor footprint
+        (e.g. by raising ``num_stages`` or widening the epi tile
+        beyond the staged-D layout), the validator pass should
+        reject the config at autotune time rather than letting
+        ptxas crash. This pin guards the happy path.
+
+        Cycle 2b's cooperative copy + cycle 3's consumer flip
+        do NOT increase per-stage SMEM (they consume the same
+        ring), so this is the right cycle to land the
+        compile-only budget pin.
+        """
+        kernel = self._residual_kernel()
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        config = helion.Config(
+            block_sizes=[256, 256, 128],
+            l2_groupings=[1],
+            num_warps=4,
+            num_sm_multiplier=1,
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_ab_stages=3,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+            tcgen05_strategy="role_local_with_scheduler",
+            tcgen05_warp_spec_scheduler_warps=1,
+            tcgen05_warp_spec_c_input_warps=1,
+            indexing=[
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "tensor_descriptor",
+            ],
+        )
+        with patch_cute_mma_support():
+            bound = kernel.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code = bound.to_triton_code(config)
+        # Sanity check: the cycle 2a aux pipeline + canonical
+        # ab_stages=3 both made it into the kernel.
+        self.assertIn(
+            "tcgen05_aux_pipeline = cutlass.pipeline.PipelineAsync.create(",
+            code,
+        )
+        self.assertIn("num_stages=3", code)
 
 
 @onlyBackends(["cute"])


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2411
 * #2410
 * #2409
 * __->__#2408
 * #2407
 * #2406
 * #2405
 * #2404
 * #2403
 * #2402
 * #2401
 * #2400


--- --- ---

[cutedsl] allocate c-input warp aux pipeline without producer barrier ops