### PR TITLE
[cutedsl] widen autotune surface for c_input warp on residual kernels

### DIFF
--- a/helion/_compiler/cute/aux_tensor.py
+++ b/helion/_compiler/cute/aux_tensor.py
@@ -29,12 +29,26 @@ from typing import TYPE_CHECKING
 
 import torch
 
+from ...language import matmul_ops
 from ...language import memory_ops
 from .cute_epilogue import _AuxiliaryTensorStep
 from .cute_epilogue import analyze_tcgen05_unary_epilogue_chain
 
 if TYPE_CHECKING:
     from ..generate_ast import GenerateAST
+    from ..host_function import HostFunction
+
+
+# Mirrors ``cute_mma._TRACE_THROUGH_TARGETS`` — the data-preserving
+# wrappers the MMA codegen walks through when resolving operand
+# loads (``_trace_to_load`` in ``cute_mma``). Duplicated here
+# rather than imported because ``cute_mma`` imports from this
+# module, creating a circular dependency. The single
+# ``convert_element_type`` target is the canonical operand-cast
+# wrapper Helion emits for ``lhs.to(dtype) @ rhs.to(dtype)``
+# patterns; keep this set in sync with ``cute_mma`` if either
+# side adds a new wrapper.
+_MMA_OPERAND_TRACE_THROUGH_TARGETS = (torch.ops.prims.convert_element_type.default,)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -281,3 +295,155 @@ def discover_tcgen05_aux_tensor_descriptors(
         for step in chain.auxiliary_tensor_steps:
             descriptors.append(_aux_descriptor_from_step(step, store_value))
     return tuple(descriptors)
+
+
+def host_function_has_tcgen05_aux_kernel_pattern(
+    host_function: HostFunction,
+) -> bool:
+    """Conservative pre-codegen detector for kernels whose tcgen05
+    matmul is followed by an aux-fused store
+    (``out[tile] = (acc + residual[tile]).to(...)`` and the
+    bias / rowvec variants — see :class:`_AuxiliaryTensorStep`
+    for the accepted forms).
+
+    Runs at autotune-surface configuration time (post-FX-graph
+    build, pre-autotune-sample) where the
+    :func:`discover_tcgen05_aux_tensor_descriptors` walker is
+    unavailable — that walker requires a populated
+    ``DeviceFunction.cute_tcgen05_matmul_fx_nodes`` set, which
+    is only registered at MMA-codegen time per config sample.
+    The aux pipeline only fires when the productive-body gate
+    sees aux descriptors, so the autotune surface only needs
+    to widen ``tcgen05_warp_spec_c_input_warps`` when this
+    detector returns True; otherwise the C-input warp is
+    inert and sampling ``c_input_warps=1`` would be a strict
+    resource cost for pure-matmul kernels (the inert warp
+    occupies an SM slot without delivering work).
+
+    Implementation: walk every FX graph in
+    ``host_function.device_ir.graphs`` and look for the
+    coarse pattern "the kernel has at least one MMA-anchor
+    call AND at least one ``memory_ops.load`` call whose
+    result is NOT used as one of the MMA operands". MMA
+    anchors include both the aten paths
+    (``aten.addmm`` / ``aten.baddbmm`` / ``aten.mm`` /
+    ``aten.bmm``) AND the ``hl.dot`` HOP — both ends up
+    in the tcgen05 MMA lowering, and the canonical Helion
+    residual kernel uses ``hl.dot``. Operand resolution
+    traces through the same ``convert_element_type``
+    wrappers the MMA codegen accepts
+    (``cute_mma._trace_to_load`` /
+    ``_TRACE_THROUGH_TARGETS``); without this trace,
+    kernels written as ``lhs.to(dtype) @ rhs.to(dtype)``
+    would have their operand loads classified as aux and
+    the detector would over-fire on pure matmul.
+
+    The detector is **conservative**: a false positive
+    only widens the autotune search by one enum value
+    (the productive-body safety gates handle the resulting
+    invalid combinations at codegen time and the
+    inert-body fallback handles invalid runs); a false
+    negative would miss the residual c_input=1 win. The
+    chain analyzer at codegen time
+    (``analyze_tcgen05_unary_epilogue_chain``) remains the
+    source of truth for which aux shapes are *accepted*
+    by the productive-body codegen; this detector
+    intentionally over-approximates so the autotune surface
+    admits the productive shape whenever any aux load is
+    plausibly involved.
+
+    Caught patterns include:
+
+    - exact-shape residual: ``out[tile] = (acc + residual[tile]).to(...)``
+    - rowvec broadcast: ``out[tile] = (acc + bias[tile_n]).to(...)``
+    - chained: ``(acc + residual)*bias``, ``relu(acc + residual)``, etc.
+    - any of the above using ``hl.dot(...)`` instead of
+      ``torch.addmm`` / ``torch.matmul``.
+    """
+    device_ir = host_function.device_ir
+    graphs = device_ir.graphs
+    if not graphs:
+        return False
+
+    # MMA anchor targets: both the aten paths and the
+    # ``hl.dot`` HOP (the canonical Helion API entrypoint —
+    # the FX target is the ``dot`` Python function from
+    # ``matmul_ops`` itself; see ``backend.py`` which
+    # identifies ``hl.dot`` via
+    # ``getattr(node.target, "__name__", "") == "dot"``).
+    mma_targets = (
+        torch.ops.aten.addmm.default,
+        torch.ops.aten.mm.default,
+        torch.ops.aten.bmm.default,
+        torch.ops.aten.baddbmm.default,
+        matmul_ops.dot,
+    )
+    has_mma = False
+    operand_load_nodes: set[torch.fx.Node] = set()
+    for graph_info in graphs:
+        for node in graph_info.graph.nodes:
+            if node.op != "call_function" or node.target not in mma_targets:
+                continue
+            has_mma = True
+            # ``aten.addmm`` / ``aten.baddbmm`` /
+            # ``aten.mm`` / ``aten.bmm``: lhs and rhs are
+            # the last two positional args.
+            # ``hl.dot(mat1, mat2, acc=..., out_dtype=...)``:
+            # mat1/mat2 are the first two positional args.
+            # Both layouts collapse to "the two MMA operand
+            # nodes are positional args 0/1 or N-2/N-1
+            # depending on whether an accumulator is the
+            # first arg" — pick by checking which of the
+            # first three positional args produced data
+            # tensors. Simpler heuristic: every positional
+            # arg that is an FX node and resolves through
+            # the operand-trace to a ``memory_ops.load`` is
+            # treated as a candidate MMA operand load.
+            for arg in node.args:
+                if isinstance(arg, torch.fx.Node):
+                    load_node = _trace_to_load_through_casts(arg)
+                    if load_node is not None:
+                        operand_load_nodes.add(load_node)
+    if not has_mma:
+        return False
+    # Second pass: any ``memory_ops.load`` call whose result
+    # is NOT a resolved MMA-operand load is treated as aux.
+    # Operand loads feed the dot directly (after optional
+    # casts); aux loads feed an arithmetic op that combines
+    # with the dot's result on the way to a store.
+    for graph_info in graphs:
+        for node in graph_info.graph.nodes:
+            if (
+                node.op == "call_function"
+                and node.target is memory_ops.load
+                and node not in operand_load_nodes
+            ):
+                return True
+    return False
+
+
+def _trace_to_load_through_casts(node: torch.fx.Node) -> torch.fx.Node | None:
+    """Walk backward from ``node`` through accepted operand-cast
+    wrappers to the underlying ``memory_ops.load``.
+
+    Mirrors ``cute_mma._trace_to_load`` for the operand-trace
+    contract: only data-preserving ops in
+    ``_MMA_OPERAND_TRACE_THROUGH_TARGETS`` are walked
+    through, matching the MMA codegen's own operand-resolution
+    behavior. Returns the resolved ``memory_ops.load`` node, or
+    ``None`` if a non-wrapper op (e.g. arithmetic) is
+    encountered before the load — in that case the operand is
+    not a pure load chain and we conservatively decline to
+    treat it as an MMA operand load.
+    """
+    cur = node
+    while cur.op == "call_function" and cur.target is not memory_ops.load:
+        if cur.target not in _MMA_OPERAND_TRACE_THROUGH_TARGETS:
+            return None
+        input_nodes = [a for a in cur.args if isinstance(a, torch.fx.Node)]
+        if len(input_nodes) != 1:
+            return None
+        cur = input_nodes[0]
+    if cur.op != "call_function" or cur.target is not memory_ops.load:
+        return None
+    return cur

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -457,6 +457,27 @@ class ConfigSpec:
         self.has_pallas_inner_loops: bool = False
         self.has_symbolic_or_data_dependent_bounds: bool = False
         self.cute_tcgen05_search_enabled: bool = False
+        # Post-compile bind-time flag: True when the host function's
+        # FX graphs contain a tcgen05 matmul AND at least one
+        # ``memory_ops.load`` whose target is not one of the
+        # matmul's operands (the productive C-input warp's
+        # trigger condition). Set by ``BoundKernel`` after
+        # ``KernelCompiler.compile`` via
+        # ``host_function_has_tcgen05_aux_kernel_pattern`` before
+        # any autotune sampling. Used by
+        # ``_tcgen05_strategy_autotune_fragments`` to widen the
+        # ``tcgen05_strategy`` and
+        # ``tcgen05_warp_spec_c_input_warps`` search surfaces to
+        # ``(MONOLITHIC, WITH_SCHEDULER)`` and ``(0, 1)``
+        # respectively when the productive C-input warp can be
+        # productive — pure-matmul kernels (no aux) keep the
+        # narrow ``(0,)`` autotune surface so the inert C-input
+        # warp is not sampled as a strict resource cost. The
+        # default ``False`` matches non-tcgen05 paths and bind
+        # contexts that have not run post-compile detection (the
+        # explicit-config validation surface accepts
+        # ``c_input_warps=1`` regardless of this flag).
+        self.cute_tcgen05_aux_kernel_detected: bool = False
         # Allowed values of tcgen05_cluster_m the autotuner is allowed to
         # *search* over. None means "use the default set defined by
         # _tcgen05_optional_fragments". This is consulted by _flat_fields()
@@ -649,6 +670,123 @@ class ConfigSpec:
         return constraints.static_k % bk == 0 and (
             constraints.static_k // bk <= constraints.max_k_tiles
         )
+
+    def _tcgen05_c_input_seed_config(self) -> helion.Config | None:
+        """Seed the canonical productive C-input warp config for aux kernels.
+
+        Cycle 2f finding: the autotune surface widening landed in cycle
+        2e admits ``c_input_warps=1`` but the random initial population
+        draw misses it on residual cells where the
+        ``WITH_SCHEDULER + scheduler_warps=1 + c_input_warps=1`` corner
+        is a small intersection of the search space (zero of 44 configs
+        sampled on 8192x4096x2048 quick-effort autotune). The forced
+        c_input=1 perf class wins by +33% there, so leaving the corner
+        un-seeded leaves the headline residual win unreachable through
+        normal autotune.
+
+        This seed mirrors ``_tcgen05_cluster_m2_seed_config`` (same
+        ``[256, 256, 128]`` tile, ``cluster_m=2``, ``persistent_interleaved``
+        pid order) but stamps the WITH_SCHEDULER strategy + the
+        ``c_input_warps=1`` productive body. ``ab_stages`` is held at 2
+        because the ``ab=3 + c_input=1`` combination is unconditionally
+        over the per-CTA SMEM budget on B200 (see
+        ``_fix_tcgen05_with_scheduler_search_config`` for the demotion
+        path and the MMA-codegen-time ``BackendUnsupported`` rejection).
+
+        Gated on ``cute_tcgen05_aux_kernel_detected`` so the seed only
+        fires for kernels whose post-compile FX scan identified an aux
+        load. Pure-matmul kernels keep the narrow autotune surface and
+        do not receive this seed — the inert C-input warp would occupy
+        an SM slot without delivering work and regress pure-matmul perf.
+
+        Returns ``None`` whenever the cluster_m=2 seed envelope is not
+        admitted (same structural checks: validated 3-block-size triple,
+        ``persistent_interleaved`` allowed, ``[256, 256, 128]`` falls
+        inside the block-size fragment ranges, and at least one bk in
+        the fragment range satisfies the cluster_m=2 K-tile cap).
+        """
+        if not self.cute_tcgen05_aux_kernel_detected:
+            return None
+        constraints = self._tcgen05_cluster_m2_search_constraints
+        if (
+            constraints is None
+            or TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types
+        ):
+            return None
+        if len(self.block_sizes) != 3:
+            return None
+
+        bm_fragment = cast("BlockSizeFragment", self.block_sizes[0]._fragment(self))
+        bn_fragment = cast("BlockSizeFragment", self.block_sizes[1]._fragment(self))
+        bk_fragment = cast("BlockSizeFragment", self.block_sizes[2]._fragment(self))
+        if not (
+            bm_fragment.low <= TCGEN05_TWO_CTA_BLOCK_M <= bm_fragment.high
+            and bn_fragment.low <= TCGEN05_TWO_CTA_BLOCK_N <= bn_fragment.high
+        ):
+            return None
+
+        bk = bk_fragment.high
+        while bk >= bk_fragment.low:
+            if self._tcgen05_cluster_m2_bk_is_valid(bk, constraints):
+                seed_config: dict[str, Any] = {
+                    "block_sizes": [
+                        TCGEN05_TWO_CTA_BLOCK_M,
+                        TCGEN05_TWO_CTA_BLOCK_N,
+                        bk,
+                    ],
+                    # ``l2_groupings=[1]`` (NOT the cluster_m2 seed's
+                    # ``TCGEN05_TWO_CTA_SEED_L2_GROUPING=4``). Direct
+                    # verification on 4096^3 and 8192x4096x2048 bf16
+                    # residual: ``c_input_warps=1 + cluster_m=2 +
+                    # l2_groupings=[g]`` produces ~60-69% mismatched
+                    # elements vs the eager reference for every g > 1
+                    # tested ({2, 4, 8}); only ``g=1`` is correct.
+                    # The matched-shape cycle 2c forced c_input=1
+                    # baselines (765 / 880 / 803 mom-median TFLOP/s)
+                    # all run at ``l2_groupings=[1]`` so the perf
+                    # class the seed targets is the
+                    # ``g=1``-validated one. The autotune-rejected
+                    # ``g=4`` seed observed in cycle 2g is the
+                    # same codegen bug surfaced at the canonical
+                    # config — a separate fix follow-up.
+                    "l2_groupings": [1],
+                    "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
+                    "tcgen05_cluster_m": 2,
+                    "tcgen05_num_epi_warps": 4,
+                    # The c_input productive body is unconditionally
+                    # paired with ``ab_stages=2``. The ``ab=3 +
+                    # c_input=1`` combo overshoots the 232 KB B200 SMEM
+                    # cap; ``_fix_tcgen05_with_scheduler_search_config``
+                    # also demotes search-time samples that carry both.
+                    "tcgen05_ab_stages": 2,
+                    TCGEN05_STRATEGY_CONFIG_KEY: (
+                        Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value
+                    ),
+                    TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY: 1,
+                    TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY: 1,
+                }
+                # Mirror the cluster_m2 seed: pure-matmul has exactly
+                # the A/B/C indexing slots, so stamp the validated
+                # tensor_descriptor triple. Fused epilogues add more
+                # memory ops, so leave those seeds to the spec default
+                # rather than constructing a partial list.
+                if self.indexing.length == 3:
+                    seed_config["indexing"] = [
+                        "tensor_descriptor",
+                        "tensor_descriptor",
+                        "tensor_descriptor",
+                    ]
+                return helion.Config(**seed_config)
+            bk //= 2
+        return None
+
+    def autotune_seed_configs(self) -> list[helion.Config]:
+        """Return validated extra configs that should be benchmarked early."""
+        seeds: list[helion.Config] = []
+        c_input_seed = self._tcgen05_c_input_seed_config()
+        if c_input_seed is not None:
+            seeds.append(c_input_seed)
+        return seeds
 
     def _fix_tcgen05_cluster_m2_search_config(self, config: dict[str, object]) -> None:
         """Canonicalize unvalidated search-only ``cluster_m=2`` products."""
@@ -848,6 +986,83 @@ class ConfigSpec:
             cluster_m=cluster_m,
         ):
             config["tcgen05_ab_stages"] = 2
+
+    def _fix_tcgen05_with_scheduler_search_config(
+        self, config: dict[str, object]
+    ) -> None:
+        """Pair WITH_SCHEDULER-only knobs and demote the
+        ``ab=3 + c_input_warps=1`` SMEM-over-budget combo.
+
+        Two adjustments tied to the aux-kernel-detected
+        autotune-surface widening (see
+        ``cute_tcgen05_aux_kernel_detected`` for the gate):
+
+        1. ``scheduler_warps`` and ``c_input_warps`` are gated by
+           ``tcgen05_strategy``: under ``ROLE_LOCAL_MONOLITHIC``
+           both must be 0 (the 6-warp role-local shape has no
+           slot for a scheduler or c_input warp); under
+           ``ROLE_LOCAL_WITH_SCHEDULER`` ``scheduler_warps`` must
+           be 1 (the strategy's definition). The cross-fragment
+           validator
+           (``validate_tcgen05_strategy_invariants``) rejects
+           mismatched pairs at codegen time; this fixup demotes
+           the mismatched samples before they reach codegen so
+           autotune does not spend cycles on doomed compiles.
+        2. The MMA-codegen-time rejection in
+           ``cute_mma._emit_mma_pipeline`` raises
+           ``BackendUnsupported`` for
+           ``ab_stages=3 + c_input_warps=1 + non-empty
+           single-store aux`` (the aux SMEM ring + AB pipeline
+           overshoot the 232 KB B200 SMEM cap by 30+ KB at every
+           validated tile shape). The autotuner would otherwise
+           sample this combo, hit the raise, and waste a
+           compile slot per sample. Demote
+           ``c_input_warps=1`` to ``c_input_warps=0`` when the
+           sample carries ``ab_stages=3`` so the sample still
+           produces a legal kernel (autotune compares
+           ``ab=3 + c_input=0`` against ``ab=2 + c_input=1``
+           via separate samples rather than the rejected combo).
+
+        Runs only when the aux-kernel-detected widening is
+        active (``cute_tcgen05_aux_kernel_detected`` is True
+        AND ``cute_tcgen05_search_enabled`` is True). For
+        non-aux kernels the autotune surface only samples
+        ``MONOLITHIC + scheduler_warps=0 + c_input_warps=0``
+        so the fixup is a no-op.
+        """
+        if not (
+            self.cute_tcgen05_search_enabled and self.cute_tcgen05_aux_kernel_detected
+        ):
+            return
+        strategy = config.get(TCGEN05_STRATEGY_CONFIG_KEY)
+        scheduler_warps = config.get(TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY)
+        c_input_warps = config.get(TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY)
+        ab_stages = config.get("tcgen05_ab_stages")
+        # Pair scheduler_warps + c_input_warps with strategy. The
+        # cross-fragment validator's rules:
+        # - MONOLITHIC: scheduler_warps must be 0, c_input_warps
+        #   must be 0.
+        # - WITH_SCHEDULER: scheduler_warps must be 1,
+        #   c_input_warps in {0, 1}.
+        if strategy == Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value:
+            if scheduler_warps != 0:
+                config[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY] = 0
+            if c_input_warps != 0:
+                config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY] = 0
+        elif strategy == Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value:
+            if scheduler_warps != 1:
+                config[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY] = 1
+            # ``c_input_warps`` is allowed at ``{0, 1}`` —
+            # leave the sampled value unless the
+            # ``ab=3 + c_input=1`` SMEM-budget rejection
+            # below forces demotion.
+        # SMEM-budget demotion: ``ab=3 + c_input=1`` is
+        # unconditionally over-budget (see
+        # ``cute_mma._emit_mma_pipeline`` rejection). Demote
+        # c_input_warps to 0 so the sample still produces a
+        # legal kernel.
+        if ab_stages == 3 and config.get(TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY) == 1:
+            config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY] = 0
 
     def _fix_tcgen05_cluster_m1_persistent_search_config(
         self, config: dict[str, object]
@@ -1140,20 +1355,52 @@ class ConfigSpec:
         the existing ``tcgen05_num_epi_warps`` field. See
         ``warp_spec_from_config`` for the read site.
         """
+        # When the bind-time detector identified the kernel as
+        # tcgen05-matmul-with-aux (a residual / bias-residual /
+        # chained-residual epilogue), widen the strategy +
+        # scheduler_warps + c_input_warps fragments so autotune
+        # can discover the productive C-input warp
+        # configuration. Detection runs post-compile in
+        # ``BoundKernel`` via
+        # ``host_function_has_tcgen05_aux_kernel_pattern``. For
+        # pure-matmul kernels the flag stays False and the
+        # surface remains narrowed to
+        # ``MONOLITHIC + c_input_warps=0`` so autotune cannot
+        # pick the strictly-worse
+        # ``WITH_SCHEDULER + c_input_warps=1`` shape on a
+        # kernel where the C-input warp would be inert (the
+        # inert warp occupies an SM slot without delivering
+        # work).
+        if self.cute_tcgen05_aux_kernel_detected:
+            strategy_choices: tuple[str, ...] = (
+                Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
+                Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value,
+            )
+            # WITH_SCHEDULER requires exactly one scheduler
+            # warp; MONOLITHIC has none. The cross-fragment
+            # invariant validator
+            # (``validate_tcgen05_strategy_invariants``) rejects
+            # mismatched pairs at codegen time, and
+            # ``_fix_tcgen05_with_scheduler_search_config``
+            # pairs the values so autotune samples only valid
+            # combinations.
+            scheduler_warps_choices: tuple[int, ...] = (0, 1)
+            c_input_warps_choices: tuple[int, ...] = (0, 1)
+        else:
+            strategy_choices = (Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,)
+            scheduler_warps_choices = (0,)
+            c_input_warps_choices = (0,)
         return {
-            # ``ROLE_LOCAL_WITH_SCHEDULER`` is implemented and runs
-            # correctly on cluster_m=1 (validated by direct user
-            # config). The autotune surface stays narrowed to
-            # ``ROLE_LOCAL_MONOLITHIC`` until the cluster_m=2 path
-            # is also stable so autotune can't pick a hanging
-            # configuration mid-search. The validation surface
-            # accepts both strategies (see
+            # ``ROLE_LOCAL_WITH_SCHEDULER`` is implemented and
+            # runs correctly on cluster_m=1 / cluster_m=2. The
+            # autotune surface broadens when the bind-time
+            # detector identified an aux kernel (see
+            # ``cute_tcgen05_aux_kernel_detected`` above). The
+            # validation surface accepts both strategies (see
             # ``_tcgen05_strategy_validation_fragments``) so an
             # explicit ``helion.Config(tcgen05_strategy=...)``
             # round-trips through normalize.
-            TCGEN05_STRATEGY_CONFIG_KEY: EnumFragment(
-                (Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,)
-            ),
+            TCGEN05_STRATEGY_CONFIG_KEY: EnumFragment(strategy_choices),
             TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: EnumFragment(
                 (Tcgen05LayoutStrategy.DEFAULT.value,)
             ),
@@ -1165,18 +1412,29 @@ class ConfigSpec:
             # the value the implemented strategies use.
             TCGEN05_WARP_SPEC_AB_LOAD_WARPS_KEY: EnumFragment((1,)),
             TCGEN05_WARP_SPEC_EPI_LOAD_WARPS_KEY: EnumFragment((0,)),
-            # ``scheduler_warps``: matches the autotune-surface
-            # narrowing of ``tcgen05_strategy`` above. Under
-            # MONOLITHIC, scheduler_warps must be 0; the validator
-            # rejects 1 with a MONOLITHIC strategy.
-            TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY: EnumFragment((0,)),
-            # ``c_input_warps``: G3.1-C step-2 (``cute_plan.md``
-            # §7.5.3.2) lifts this to ``{0, 1}`` under
-            # ``ROLE_LOCAL_WITH_SCHEDULER`` once the dedicated TMA
-            # producer + SMEM ring + role-local while loop land. The
-            # autotune surface stays narrowed to ``(0,)`` until
-            # cycle 34 perf-validates the productive C-input warp.
-            TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY: EnumFragment((0,)),
+            # ``scheduler_warps``: tracked with ``tcgen05_strategy``
+            # — must be 0 under MONOLITHIC and 1 under
+            # WITH_SCHEDULER. The cross-fragment validator
+            # rejects mismatched pairs; the
+            # ``_fix_tcgen05_with_scheduler_search_config`` fixup
+            # below pairs the values so autotune samples the
+            # valid (strategy, scheduler_warps) combinations.
+            TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY: EnumFragment(
+                scheduler_warps_choices
+            ),
+            # ``c_input_warps``: widening routed through the
+            # per-bind ``cute_tcgen05_aux_kernel_detected``
+            # flag so the autotune surface only samples
+            # ``c_input_warps=1`` when the kernel actually
+            # has an aux load. Under MONOLITHIC the
+            # cross-fragment validator forces
+            # ``c_input_warps=0`` (the MONOLITHIC 6-warp
+            # shape has no slot for the c_input warp); the
+            # ``_fix_tcgen05_with_scheduler_search_config``
+            # fixup demotes ``c_input_warps=1`` under
+            # MONOLITHIC samples so autotune does not spend
+            # cycles on the cross-fragment-rejected combo.
+            TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY: EnumFragment(c_input_warps_choices),
             # Register split is currently fixed at the role-local
             # MONOLITHIC values. G2-E may broaden.
             TCGEN05_WARP_SPEC_REGISTER_DECREASE_KEY: EnumFragment(
@@ -1966,6 +2224,16 @@ class ConfigSpec:
             # Run after the cluster_m fixups so the SMEM budget check
             # sees the post-projection ``cluster_m`` and ``block_sizes``.
             self._fix_tcgen05_ab_stages_three_search_config(config)
+            # Pair WITH_SCHEDULER-only knobs (strategy /
+            # scheduler_warps / c_input_warps) and demote the
+            # ``ab=3 + c_input=1`` SMEM-over-budget combo. Run
+            # AFTER the ab_stages_three fixup so the final
+            # ``ab_stages`` is what the c_input_warps demotion
+            # check sees: if ab_stages got demoted from 3 to 2
+            # above, c_input=1 is once again legal under
+            # WITH_SCHEDULER and the demotion below does not
+            # fire.
+            self._fix_tcgen05_with_scheduler_search_config(config)
 
         # Strategy data-model fragments (G2-A). Each per-fragment
         # validator runs first (type/range checks); cross-fragment

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -496,6 +496,31 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                     self.env, self.host_function.device_ir
                 )
 
+                # Post-compile FX-graph scan to detect kernels
+                # whose tcgen05 matmul is followed by an
+                # aux-fused store
+                # (``out[tile] = (acc + residual[tile]).to(...)``
+                # and variants — see
+                # ``host_function_has_tcgen05_aux_kernel_pattern``
+                # for the accepted shapes). When detected, the
+                # autotune surface widens to admit
+                # ``tcgen05_strategy=ROLE_LOCAL_WITH_SCHEDULER``
+                # + ``tcgen05_warp_spec_c_input_warps=1`` so the
+                # productive C-input warp lift is reachable from
+                # the normal autotune path. For pure-matmul
+                # kernels the detector returns False and the
+                # autotune surface keeps the narrow
+                # ``MONOLITHIC + c_input_warps=0`` shape so
+                # autotune cannot sample the strictly-worse
+                # inert C-input warp configuration.
+                from .._compiler.cute.aux_tensor import (
+                    host_function_has_tcgen05_aux_kernel_pattern,
+                )
+
+                self.env.config_spec.cute_tcgen05_aux_kernel_detected = (
+                    host_function_has_tcgen05_aux_kernel_pattern(self.host_function)
+                )
+
     def _apply_mark_static(self, args: tuple[object, ...]) -> None:
         """
         Apply torch._dynamo.mark_static() markings from input tensors.

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -12008,6 +12008,406 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
             code,
         )
 
+    def test_aux_autotune_surface_widens_for_residual_kernel(self) -> None:
+        """Autotune-surface routing pin (residual case).
+
+        The productive C-input warp is reachable from the
+        normal Helion autotune path when the bound kernel's
+        FX graphs contain a tcgen05 matmul AND at least one
+        ``memory_ops.load`` whose target isn't one of the
+        matmul operands (the residual / bias / chained
+        residual_relu pattern). Pin:
+          - ``cute_tcgen05_aux_kernel_detected`` is True after
+            bind.
+          - ``tcgen05_strategy`` autotune fragment widens to
+            ``(MONOLITHIC, WITH_SCHEDULER)``.
+          - ``tcgen05_warp_spec_scheduler_warps`` widens to
+            ``(0, 1)`` so it can be paired with the strategy.
+          - ``tcgen05_warp_spec_c_input_warps`` widens to
+            ``(0, 1)``.
+        """
+        from helion._compiler.cute.strategies import Tcgen05Strategy
+
+        kernel = self._residual_kernel()
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        with patch_cute_mma_support():
+            bound = kernel.bind(args)
+        self.assertTrue(bound.env.config_spec.cute_tcgen05_aux_kernel_detected)
+        frags = bound.env.config_spec._tcgen05_strategy_autotune_fragments()
+        self.assertEqual(
+            frags["tcgen05_strategy"].choices,
+            (
+                Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
+                Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value,
+            ),
+        )
+        self.assertEqual(frags["tcgen05_warp_spec_scheduler_warps"].choices, (0, 1))
+        self.assertEqual(frags["tcgen05_warp_spec_c_input_warps"].choices, (0, 1))
+
+    def test_aux_autotune_surface_stays_narrow_for_pure_matmul(self) -> None:
+        """Autotune-surface routing pin (pure-matmul case).
+
+        Pure-matmul kernels (no aux load) keep the narrow
+        autotune surface so autotune cannot sample the
+        strictly-worse inert C-input warp configuration —
+        the inert warp regresses pure-matmul perf because it
+        takes up an SM slot without delivering work.
+
+        Pin:
+          - ``cute_tcgen05_aux_kernel_detected`` is False
+            after bind.
+          - ``tcgen05_strategy`` stays at MONOLITHIC only.
+          - ``tcgen05_warp_spec_scheduler_warps`` stays at 0
+            only.
+          - ``tcgen05_warp_spec_c_input_warps`` stays at 0
+            only.
+        """
+        from helion._compiler.cute.strategies import Tcgen05Strategy
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_pure(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_pure.bind(args)
+        self.assertFalse(bound.env.config_spec.cute_tcgen05_aux_kernel_detected)
+        frags = bound.env.config_spec._tcgen05_strategy_autotune_fragments()
+        self.assertEqual(
+            frags["tcgen05_strategy"].choices,
+            (Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,),
+        )
+        self.assertEqual(frags["tcgen05_warp_spec_scheduler_warps"].choices, (0,))
+        self.assertEqual(frags["tcgen05_warp_spec_c_input_warps"].choices, (0,))
+
+    def test_aux_autotune_surface_does_not_narrow_for_multistore_fanout(
+        self,
+    ) -> None:
+        """Autotune-surface routing pin (multi-store fan-out
+        case).
+
+        Multi-store fan-out kernels (one matmul → two distinct
+        stores with different aux operands) carry aux loads,
+        so the bind-time detector flags them as aux kernels
+        and the autotune surface widens (does NOT narrow to
+        the pure-matmul ``(0,)`` shape). Compile-time the
+        productive-body safety gate then suppresses the
+        productive body (per
+        ``test_aux_pipeline_multi_store_fanout_gate_closes``)
+        and falls back to GMEM aux reads — so sampling
+        ``c_input_warps=1`` is a wasted compile slot but does
+        not deadlock. The detector intentionally does NOT
+        distinguish fan-out from single-store (the productive
+        body's own safety gate is the authoritative check),
+        so the autotune surface still admits
+        ``c_input_warps=1`` here. This is a documented over-
+        approximation: a follow-up could prune the fan-out
+        case at autotune-surface time, but the safety gate at
+        codegen already prevents the over-budget compile.
+        """
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_residual_fanout(
+            x: torch.Tensor,
+            y: torch.Tensor,
+            residual_a: torch.Tensor,
+            residual_b: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            m, k = x.size()
+            _, n = y.size()
+            out_a = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            out_b = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out_a[tile_m, tile_n] = (acc + residual_a[tile_m, tile_n]).to(x.dtype)
+                out_b[tile_m, tile_n] = (acc + residual_b[tile_m, tile_n]).to(x.dtype)
+            return out_a, out_b
+
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_residual_fanout.bind(args)
+        # Detector is intentionally coarse and DOES flag
+        # fan-out as aux (it has aux loads). The
+        # productive-body safety gate at codegen suppresses
+        # the productive body for fan-out specifically.
+        self.assertTrue(bound.env.config_spec.cute_tcgen05_aux_kernel_detected)
+
+    def test_aux_autotune_fixup_demotes_ab3_c_input1(self) -> None:
+        """Search-time fixup pin: a sampled
+        ``ab_stages=3 + c_input_warps=1`` combination under
+        WITH_SCHEDULER is demoted to ``c_input_warps=0`` by
+        ``_fix_tcgen05_with_scheduler_search_config`` so the
+        autotuner doesn't waste a compile on a sample that
+        would hit the MMA-codegen-time SMEM-budget
+        ``BackendUnsupported`` rejection.
+
+        Note: a config carrying ``ab_stages=3 +
+        c_input_warps=1`` is normally unreachable through
+        normalize because the autotune-surface fragment
+        widening + cross-fragment validator interaction
+        produces only valid combinations. This test exercises
+        the fixup directly to confirm the safety net is in
+        place if a future surface change exposes the combo.
+        """
+        from helion._compiler.cute.strategies import Tcgen05Strategy
+
+        kernel = self._residual_kernel()
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        with patch_cute_mma_support():
+            bound = kernel.bind(args)
+        # Manually craft the over-budget combo.
+        config_dict: dict[str, object] = {
+            "tcgen05_strategy": Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value,
+            "tcgen05_warp_spec_scheduler_warps": 1,
+            "tcgen05_warp_spec_c_input_warps": 1,
+            "tcgen05_ab_stages": 3,
+        }
+        bound.env.config_spec._fix_tcgen05_with_scheduler_search_config(config_dict)
+        # Fixup demoted c_input_warps to 0; ab_stages=3 stays.
+        self.assertEqual(config_dict["tcgen05_warp_spec_c_input_warps"], 0)
+        self.assertEqual(config_dict["tcgen05_ab_stages"], 3)
+
+    def test_aux_autotune_surface_widens_for_hldot_residual_kernel(self) -> None:
+        """Detector recognizes ``hl.dot`` MMA anchors in
+        addition to the aten paths.
+
+        The canonical Helion API for matmul is ``hl.dot``;
+        kernels written with it lower through
+        ``codegen_cute_mma_dot`` to the tcgen05 MMA path the
+        same way ``torch.addmm`` / ``torch.matmul`` do. Without
+        treating ``hl.dot`` as an MMA anchor, the detector
+        would flag ``hl.dot`` + residual kernels as non-MMA
+        (no matched anchor in any graph) and the autotune
+        surface would never widen — the headline residual
+        c_input_warps=1 win would silently not apply to
+        ``hl.dot`` kernels.
+
+        Pin: a residual kernel written with ``hl.dot`` sets the
+        detector flag True and the three fragments widen,
+        matching the ``torch.addmm`` path.
+        """
+        from helion._compiler.cute.strategies import Tcgen05Strategy
+
+        @helion.kernel(backend="cute")
+        def hldot_residual(
+            x: torch.Tensor, y: torch.Tensor, residual: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+                out[tile_m, tile_n] = (acc + residual[tile_m, tile_n]).to(x.dtype)
+            return out
+
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        with patch_cute_mma_support():
+            bound = hldot_residual.bind(args)
+        self.assertTrue(bound.env.config_spec.cute_tcgen05_aux_kernel_detected)
+        frags = bound.env.config_spec._tcgen05_strategy_autotune_fragments()
+        self.assertEqual(
+            frags["tcgen05_strategy"].choices,
+            (
+                Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
+                Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value,
+            ),
+        )
+        self.assertEqual(frags["tcgen05_warp_spec_c_input_warps"].choices, (0, 1))
+
+    def test_aux_autotune_surface_stays_narrow_for_wrapped_cast_pure_matmul(
+        self,
+    ) -> None:
+        """Operand-cast wrappers (``lhs.to(dtype) @ rhs.to(dtype)``)
+        are traced through to the underlying ``memory_ops.load``
+        nodes so the detector classifies them as MMA-operand
+        loads, not aux loads.
+
+        Without operand-trace, the detector's "every
+        ``memory_ops.load`` that isn't the exact node arg of
+        the MMA call is aux" rule misclassifies the underlying
+        load behind a ``convert_element_type`` wrapper as aux
+        and the autotune surface widens on a kernel where no
+        true aux load exists — autotune then samples the
+        strictly-worse inert C-input warp on pure matmul.
+
+        Pin: a pure matmul with explicit operand casts (fp32
+        operand tensors cast to bf16 before the dot) keeps
+        the detector flag False — the cast wrapper is walked
+        through to the underlying load via
+        ``_trace_to_load_through_casts`` and the load is
+        classified as an MMA operand, not an aux load.
+        """
+        from helion._compiler.cute.strategies import Tcgen05Strategy
+
+        @helion.kernel(backend="cute")
+        def matmul_wrapped_cast_pure(
+            x_fp32: torch.Tensor, y_fp32: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x_fp32.size()
+            _, n = y_fp32.size()
+            out = torch.empty([m, n], dtype=torch.bfloat16, device=x_fp32.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    x_tile = x_fp32[tile_m, tile_k].to(torch.bfloat16)
+                    y_tile = y_fp32[tile_k, tile_n].to(torch.bfloat16)
+                    acc = torch.addmm(acc, x_tile, y_tile)
+                out[tile_m, tile_n] = acc.to(torch.bfloat16)
+            return out
+
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.float32),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.float32),
+        )
+        with patch_cute_mma_support():
+            bound = matmul_wrapped_cast_pure.bind(args)
+        self.assertFalse(bound.env.config_spec.cute_tcgen05_aux_kernel_detected)
+        frags = bound.env.config_spec._tcgen05_strategy_autotune_fragments()
+        self.assertEqual(
+            frags["tcgen05_strategy"].choices,
+            (Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,),
+        )
+        self.assertEqual(frags["tcgen05_warp_spec_c_input_warps"].choices, (0,))
+
+    def test_aux_autotune_seeds_c_input_config_for_residual_kernel(self) -> None:
+        """Autotune seed pin (residual case).
+
+        Cycle 2f finding: quick-effort autotune missed
+        ``c_input_warps=1`` entirely on residual cells (zero of
+        44 configs sampled on 8192x4096x2048) because the
+        ``WITH_SCHEDULER + scheduler_warps=1 + c_input_warps=1``
+        corner is a small intersection of the search space. The
+        cycle 2g fix is to seed the canonical productive C-input
+        warp config directly into the autotuner's initial
+        population for aux-detected kernels.
+
+        Pin: an aux-detected residual kernel's
+        ``autotune_seed_configs()`` list contains a config with
+        the productive C-input warp shape:
+            - ``tcgen05_strategy = ROLE_LOCAL_WITH_SCHEDULER``
+            - ``tcgen05_warp_spec_scheduler_warps = 1``
+            - ``tcgen05_warp_spec_c_input_warps = 1``
+            - ``tcgen05_ab_stages = 2``
+            - ``block_sizes = [256, 256, 128]``
+            - ``tcgen05_cluster_m = 2``
+            - ``pid_type = persistent_interleaved``
+        """
+        from helion._compiler.cute.strategies import Tcgen05Strategy
+
+        kernel = self._residual_kernel()
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        with patch_cute_mma_support():
+            bound = kernel.bind(args)
+        seeds = bound.env.config_spec.autotune_seed_configs()
+        c_input_seeds = [
+            s for s in seeds if s.config.get("tcgen05_warp_spec_c_input_warps") == 1
+        ]
+        self.assertEqual(
+            len(c_input_seeds),
+            1,
+            f"expected exactly one c_input=1 seed, got {len(c_input_seeds)} "
+            f"out of {len(seeds)} seeds: {[s.config for s in seeds]}",
+        )
+        seed = c_input_seeds[0].config
+        self.assertEqual(
+            seed["tcgen05_strategy"],
+            Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value,
+        )
+        self.assertEqual(seed["tcgen05_warp_spec_scheduler_warps"], 1)
+        self.assertEqual(seed["tcgen05_warp_spec_c_input_warps"], 1)
+        self.assertEqual(seed["tcgen05_ab_stages"], 2)
+        self.assertEqual(seed["block_sizes"][0], 256)
+        self.assertEqual(seed["block_sizes"][1], 256)
+        self.assertEqual(seed["tcgen05_cluster_m"], 2)
+        self.assertEqual(seed["pid_type"], "persistent_interleaved")
+        # Pin ``l2_groupings=[1]``: direct verification on 4096^3
+        # and 8192x4096x2048 shows ``c_input_warps=1 +
+        # cluster_m=2 + l2_groupings=[g]`` produces 60-69%
+        # mismatched elements for every ``g > 1``. The matched
+        # cycle 2c forced c_input=1 baselines all run at
+        # ``g=1``. The cluster_m2 seed's
+        # ``TCGEN05_TWO_CTA_SEED_L2_GROUPING=4`` is intentionally
+        # NOT mirrored here (would defeat the purpose of the
+        # seed by producing wrong output).
+        self.assertEqual(seed["l2_groupings"], [1])
+
+    def test_aux_autotune_seeds_omit_c_input_config_for_pure_matmul(self) -> None:
+        """Autotune seed pin (pure-matmul case).
+
+        Pure-matmul kernels (detector flag False) do NOT receive
+        the c_input=1 seed. Seeding the inert C-input warp on a
+        pure-matmul kernel would waste a compile slot on a
+        config the autotune-surface widening explicitly avoids
+        (the inert warp occupies an SM slot without delivering
+        work).
+        """
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_pure(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_pure.bind(args)
+        self.assertFalse(bound.env.config_spec.cute_tcgen05_aux_kernel_detected)
+        seeds = bound.env.config_spec.autotune_seed_configs()
+        c_input_seeds = [
+            s for s in seeds if s.config.get("tcgen05_warp_spec_c_input_warps") == 1
+        ]
+        self.assertEqual(
+            len(c_input_seeds),
+            0,
+            f"pure matmul must not get a c_input=1 seed; got "
+            f"{[s.config for s in c_input_seeds]}",
+        )
+
 
 @onlyBackends(["cute"])
 class TestCuteDslCompat(unittest.TestCase):


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2411
 * __->__#2410
 * #2409
 * #2408
 * #2407
 * #2406
 * #2405
 * #2404
 * #2403
 * #2402
 * #2401
 * #2400


--- --- ---

[cutedsl] widen autotune surface for c_input warp on residual kernels