### PR TITLE
[cutedsl] fix c_input warp aux tile coords for cluster + l2_groupings

### DIFF
--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -3229,6 +3229,8 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         self,
         device_function: DeviceFunction,
         layout: Tcgen05PersistentProgramIDs._Tcgen05PersistentLayout,
+        *,
+        shared_body_extracted: list[ast.stmt] | None = None,
     ) -> ast.stmt:
         """Build the C-input warp's role-local while
         (``cute_plan.md`` §7.5.3.2 producer-body split).
@@ -3360,18 +3362,135 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         bm_per_cta = bm // cluster_m if is_two_cta else bm
         tile_m_var = device_function.new_var("tcgen05_aux_tile_m")
         tile_n_var = device_function.new_var("tcgen05_aux_tile_n")
-        m_coord_raw = f"{layout.work_tile_smem}[cutlass.Int32(0)]"
-        n_coord_raw = f"{layout.work_tile_smem}[cutlass.Int32(1)]"
-        # Per-CTA M tile coord: under 2cta the global M-coord
-        # already indexes into per-CTA M stripes (the scheduler
-        # publishes global M tiles, two per cluster step). Use the
-        # global coord directly; the local_tile shape ``bm_per_cta``
-        # handles the per-CTA slicing.
-        if is_two_cta:
-            tile_m_expr = m_coord_raw
+        # Bring the L2-grouping PID-decomposition chain (the
+        # ``inner_2d_pid`` → ``pid_0`` / ``pid_1`` →
+        # ``tile_offset_0`` / ``tile_offset_1`` line) into this
+        # role-local while body so the producer's per-CTA aux
+        # GMEM tile aligns with the consumer's post-L2-remap
+        # logical tile coords. Without it the producer would
+        # build its per-CTA aux GMEM tile from the raw
+        # ``work_tile_smem`` coords (which equal the consumer's
+        # only under ``l2_groupings=[1]``); under
+        # ``l2_groupings=[g>1]`` the consumer's post-L2-remap
+        # ``pid_0`` / ``pid_1`` no longer equal ``work_tile_smem[0,1]``
+        # and the producer fetches a misaligned aux tile.
+        # ``_role_local_dependency_stmts`` walks the shared body
+        # backward from a synthetic read of ``tile_offset_0`` /
+        # ``tile_offset_1`` and returns the smallest set of
+        # statements that define them. The walker is the same
+        # one the consumer role-local whiles use; this keeps the
+        # producer and consumer in lockstep on whatever the
+        # L2-grouping decomposition emits.
+        #
+        # ``tile_offset_0`` / ``tile_offset_1`` are emitted
+        # unconditionally by the standard ``NDTileStrategy``
+        # decomposition (see ``tile_strategy.py:_strategy_codegen``
+        # — ``tile_offset_<i> = pid_<i> * BS`` is part of every
+        # tile body). They are therefore always present in
+        # ``shared_body_extracted`` for any real kernel binding,
+        # regardless of whether ``L2GroupingProgramIDs.codegen``
+        # wraps the strategy (l2_grp=[g>1]) or not (l2_grp=[1]
+        # passes the names through directly with the identity
+        # remap). The branch on ``has_post_l2_coords`` below is
+        # purely defensive — it preserves the pre-cycle-2i
+        # ``work_tile_smem`` fallback for the hypothetical case
+        # where a future strategy emits the role-local while
+        # without these names, so the cycle 2b correctness
+        # baseline at ``l2_grp=[1]`` cannot regress silently.
+        synthetic_reads_for_l2 = [
+            statement_from_string(
+                "_tcgen05_aux_l2_anchor = tile_offset_0 + tile_offset_1"
+            )
+        ]
+        l2_dependency_stmts: list[ast.stmt] = []
+        if shared_body_extracted is not None:
+            l2_dependency_stmts = self._role_local_dependency_stmts(
+                shared_body_extracted, synthetic_reads_for_l2
+            )
+        l2_dependency_writes: set[str] = set()
+        for stmt in l2_dependency_stmts:
+            _, writes = _stmt_name_uses(stmt)
+            l2_dependency_writes.update(writes)
+        has_post_l2_coords = (
+            "tile_offset_0" in l2_dependency_writes
+            and "tile_offset_1" in l2_dependency_writes
+        )
+        # ``peer_m`` is this CTA's rank along the M axis of the
+        # cluster: ``block_idx_in_cluster() % cluster_m``. The
+        # modulo is load-bearing for ``cluster_n > 1`` — for
+        # ``cluster_m=2 + cluster_n=2 + use_2cta=True`` (a
+        # validated 4-CTA cluster shape, see
+        # ``cute_mma.py:_TCGEN05_V_LEADER_PREDICATE``) ranks
+        # {0, 1, 2, 3} have M peer ranks {0, 1, 0, 1}, NOT
+        # the raw rank-in-cluster. Mirrors the scheduler's
+        # per-CTA publish at the ``_cute_store_shared_remote_x4``
+        # call sites (``program_id.py`` lines 1979 and 2954)
+        # which use the same modulo on the lane-idx form.
+        peer_m_expr = (
+            f"(cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster()) "
+            f"% cutlass.Int32({cluster_m}))"
+        )
+        if has_post_l2_coords:
+            # Post-L2 path. ``tile_offset_0 // bm`` is the
+            # post-L2-remap logical M tile index (== ``pid_0``
+            # in the decomposition emitted right above this
+            # body); ``tile_offset_1 // bn`` is ``pid_1``.
+            #
+            # Note that under ``cluster_n=1 + l2_groupings=[1]``
+            # the post-L2 expression ``pid_0 * cluster_m +
+            # peer_m`` is numerically equal to the pre-cycle-2i
+            # ``work_tile_smem[0]`` because (a) the L2 remap is
+            # identity and (b) the scheduler publishes
+            # ``tile_idx[0] + peer_m = pid_0 * cluster_m +
+            # peer_m`` into each CTA's slot. Outside that
+            # narrow case the two forms diverge: under
+            # ``l2_grp=[g>1]`` because L2 remap is non-identity,
+            # and under ``cluster_n=2`` because the raw
+            # rank-in-cluster ≠ peer_m.
+            m_source = f"(tile_offset_0 // cutlass.Int32({bm}))"
+            n_source = f"(tile_offset_1 // cutlass.Int32({bn}))"
+            if is_two_cta:
+                tile_m_expr = (
+                    f"({m_source}) * cutlass.Int32({cluster_m}) + {peer_m_expr}"
+                )
+            elif self._tcgen05_uses_cluster_m2_one_cta_role_local_bridge():
+                # Bridge: cluster has ``cluster_m`` CTAs each
+                # handling its own logical M tile (no V-pair
+                # striping); add peer_m to step from the
+                # cluster-leader CTA's logical tile to this
+                # CTA's. Bridge requires ``cluster_n=1`` (see
+                # ``cute_mma._tcgen05_cluster_m2_one_cta_role_local_bridge``)
+                # so ``peer_m == block_idx_in_cluster()``; using
+                # ``peer_m`` form keeps the expression
+                # robust if that constraint widens later.
+                tile_m_expr = f"({m_source}) + {peer_m_expr}"
+            else:
+                tile_m_expr = m_source
+            tile_n_expr = n_source
         else:
-            tile_m_expr = self._tcgen05_logical_m_coord_expr(m_coord_raw)
-        tile_n_expr = n_coord_raw
+            # Pre-cycle-2i raw scheduler coords. Unreachable in
+            # production today: ``tile_offset_0`` /
+            # ``tile_offset_1`` are emitted unconditionally by
+            # the standard ``NDTileStrategy`` decomposition,
+            # which runs for every real kernel binding
+            # regardless of ``l2_groupings``. Purely defensive —
+            # preserves the pre-cycle-2i correctness baseline
+            # if a future strategy emits the role-local while
+            # without those names. Under ``is_two_cta`` the
+            # scheduler-published ``work_tile_smem[0]`` already
+            # carries the per-CTA peer_m baked in (the
+            # scheduler publish is
+            # ``tile_idx[0] + peer_m`` per CTA); under non-2cta
+            # ``_tcgen05_logical_m_coord_expr`` adds the bridge
+            # adjustment when applicable. So no extra peer_m
+            # is applied here.
+            m_source = f"{layout.work_tile_smem}[cutlass.Int32(0)]"
+            n_source = f"{layout.work_tile_smem}[cutlass.Int32(1)]"
+            if is_two_cta:
+                tile_m_expr = m_source
+            else:
+                tile_m_expr = self._tcgen05_logical_m_coord_expr(m_source)
+            tile_n_expr = n_source
 
         # Cooperative-copy thread layout. Single C-input warp has
         # 32 lanes; lay them out row-major as (M_threads, N_threads)
@@ -3701,6 +3820,13 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         per_tile_body: list[ast.stmt] = [
             statement_from_string(f"{self.virtual_pid_var} = {linear_pid_expr}"),
         ]
+        # Emit the L2-grouping decomposition chain right after
+        # ``virtual_pid`` is bound, so ``_aux_copy_lines()`` can
+        # reference the post-L2 ``tile_offset_0`` / ``tile_offset_1``
+        # names. Mirrors the consumer role-local while body's
+        # placement of ``dependency_stmts`` (see
+        # ``_build_role_local_while_with_scheduler``).
+        per_tile_body.extend(l2_dependency_stmts)
         per_tile_body.extend(_aux_copy_lines())
         per_tile_body.extend(_sched_consumer_release_block())
         per_tile_body.extend(_sched_consumer_wait_block())
@@ -4068,7 +4194,23 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             and len({d.store_value_node for d in plan.aux_tensor_descriptors}) <= 1
         ):
             role_local_whiles.append(
-                self._build_c_input_warp_role_local_while(device_function, layout)
+                self._build_c_input_warp_role_local_while(
+                    device_function,
+                    layout,
+                    # ``shared_body_extracted`` carries the post-PID-
+                    # decomposition statements (incl. the L2-grouping
+                    # ``pid_0`` / ``pid_1`` / ``tile_offset_0`` /
+                    # ``tile_offset_1`` chain). The C-input producer
+                    # body needs the same chain so its per-CTA aux
+                    # GMEM tile coords match the consumer's
+                    # post-L2-remapped tile coords — without this
+                    # the producer fetches a misaligned aux tile
+                    # under ``l2_groupings=[g>1]`` and the residual
+                    # add reads wrong rows / columns of the
+                    # auxiliary tensor (cycle 2i: 60-69% mismatched
+                    # elements vs eager).
+                    shared_body_extracted=partition.shared_body_extracted,
+                )
             )
         return role_local_whiles, shared_tile_body
 

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -11611,6 +11611,222 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         expected = (x @ y + residual).to(x.dtype)
         torch.testing.assert_close(out, expected, atol=2e-1, rtol=1e-2)
 
+    def test_aux_pipeline_runtime_correctness_with_l2_groupings(self) -> None:
+        """Cycle 2i fix: the C-input producer body must apply the
+        same L2-grouping decomposition as the consumer roles, so
+        the producer's per-CTA aux GMEM tile is aligned with the
+        consumer's post-L2-remapped tile coords.
+
+        Pre-cycle-2i, the producer's
+        ``cute.local_tile(host_aux, (bm_per_cta, bn),
+        (work_tile_smem[0], work_tile_smem[1]))`` used the raw
+        scheduler-published coords (NOT remapped by
+        ``L2GroupingProgramIDs``). The consumer's matmul +
+        aux-add machinery used the post-L2 ``pid_0`` / ``pid_1``
+        (via ``tile_offset_0`` / ``tile_offset_1``). Under
+        ``l2_groupings=[g]`` with ``g > 1`` the two diverged
+        and the residual epilogue read from the wrong rows /
+        columns of the auxiliary tensor — direct verification
+        on 4096^3 bf16 residual at
+        ``cluster_m=2 + c_input_warps=1 + ab_stages=2``
+        produced 60-69% mismatched elements vs eager for every
+        ``g in {2, 4, 8}`` tested; only ``g=1`` was correct.
+
+        The cycle 2i fix passes ``shared_body_extracted`` to
+        ``_build_c_input_warp_role_local_while`` and calls
+        ``_role_local_dependency_stmts`` with a synthetic read of
+        ``tile_offset_0`` / ``tile_offset_1`` so the L2-grouping
+        chain is re-emitted in the producer body. The producer
+        then derives its per-CTA M tile coord from the post-L2
+        logical M tile index plus ``peer_m =
+        block_idx_in_cluster() %% cluster_m`` (mirroring the
+        scheduler's per-CTA publish at
+        ``program_id.py:1979 / 2954``).
+
+        The ``cluster_n=2`` arm of the sweep is the autoreview
+        P1 follow-up: a 4-CTA cluster
+        (``cluster_m=2 + cluster_n=2 + use_2cta=True``) has
+        ranks {0, 1, 2, 3} with M peer ranks {0, 1, 0, 1}, so
+        the producer's per-CTA M coord must use the
+        ``rank %% cluster_m`` modulo form rather than the raw
+        rank (which would emit ``pid_m * 2 + 2/3`` for ranks
+        2/3 and produce wrong output on the cluster_n=2 path
+        that was otherwise validated by the cute_mma V-leader
+        logic).
+
+        Pin: ``c_input_warps=1 + cluster_m=2 + ab_stages=2``
+        runs correctness-clean across the sweep
+        ``l2_groupings ∈ {1, 2, 4, 8} × cluster_n ∈ {1, 2}``.
+        The non-trivial ``g`` values are the load-bearing
+        regression for the original cycle 2i fix; the
+        ``cluster_n=2`` values are the load-bearing
+        regression for the autoreview P1 fix.
+        """
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = torch.randn(4096, 4096, dtype=torch.bfloat16, device=DEVICE)
+        y = torch.randn(4096, 4096, dtype=torch.bfloat16, device=DEVICE)
+        residual = torch.randn(4096, 4096, dtype=torch.bfloat16, device=DEVICE)
+        expected = (x @ y + residual).to(x.dtype)
+        kernel = self._residual_kernel()
+        # Bind once — args don't change across the sweep, only
+        # the config. ``set_config`` swaps the config without
+        # re-tracing the fx graph.
+        bound = kernel.bind((x, y, residual))
+        bound.env.config_spec.cute_tcgen05_search_enabled = True
+        # Sweep covers both cluster_n=1 (2-CTA cluster, the
+        # cycle 2b validated baseline shape) and cluster_n=2
+        # (4-CTA cluster, validated by cute_mma.py's V-leader
+        # logic; ranks {0,1,2,3} have M peer ranks {0,1,0,1},
+        # so the producer's per-CTA M tile coord must use
+        # ``peer_m = block_idx_in_cluster() %% cluster_m``
+        # rather than the raw rank — see the P1 autoreview
+        # fix in cycle 2i). ``g > 1`` is the load-bearing
+        # regression for the original cycle 2i fix; ``g=1``
+        # is included to keep the cycle 2b correctness
+        # baseline pinned.
+        sweep_configs: list[tuple[int, int]] = [
+            (l2_grouping, cluster_n)
+            for cluster_n in (1, 2)
+            for l2_grouping in (1, 2, 4, 8)
+        ]
+        for l2_grouping, cluster_n in sweep_configs:
+            config = helion.Config(
+                block_sizes=[256, 256, 128],
+                l2_groupings=[l2_grouping],
+                num_warps=4,
+                num_sm_multiplier=1,
+                pid_type="persistent_interleaved",
+                tcgen05_cluster_m=2,
+                tcgen05_cluster_n=cluster_n,
+                tcgen05_ab_stages=2,
+                tcgen05_acc_stages=2,
+                tcgen05_c_stages=2,
+                tcgen05_num_epi_warps=4,
+                tcgen05_strategy="role_local_with_scheduler",
+                tcgen05_warp_spec_scheduler_warps=1,
+                tcgen05_warp_spec_c_input_warps=1,
+                indexing=[
+                    "tensor_descriptor",
+                    "tensor_descriptor",
+                    "tensor_descriptor",
+                ],
+            )
+            bound.set_config(config)
+            out = bound(x, y, residual)
+            torch.testing.assert_close(
+                out,
+                expected,
+                atol=2e-1,
+                rtol=1e-2,
+                msg=(
+                    f"residual c_input=1 cluster_m=2 cluster_n={cluster_n} "
+                    f"l2_groupings=[{l2_grouping}] output mismatch"
+                ),
+            )
+
+    def test_aux_pipeline_producer_post_l2_tile_coords_emitted(self) -> None:
+        """Cycle 2i codegen pin: the C-input producer body emits
+        the L2-grouping decomposition chain (``inner_2d_pid`` /
+        ``pid_0`` / ``pid_1`` / ``tile_offset_0`` /
+        ``tile_offset_1``) and derives its per-CTA aux tile
+        coords from the post-L2 ``tile_offset_0/1 // bm/bn``
+        plus ``block_idx_in_cluster()`` under ``is_two_cta``.
+
+        This pin guards against a regression that drops the
+        ``shared_body_extracted`` plumb to
+        ``_build_c_input_warp_role_local_while`` or stops
+        invoking ``_role_local_dependency_stmts`` for the
+        producer. Without those, the producer falls back to
+        the raw ``work_tile_smem`` coords and the
+        ``l2_groupings=[g>1]`` correctness pin above breaks.
+        """
+        kernel = self._residual_kernel()
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        config = helion.Config(
+            block_sizes=[256, 256, 128],
+            l2_groupings=[4],
+            num_warps=4,
+            num_sm_multiplier=1,
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+            tcgen05_strategy="role_local_with_scheduler",
+            tcgen05_warp_spec_scheduler_warps=1,
+            tcgen05_warp_spec_c_input_warps=1,
+            indexing=[
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "tensor_descriptor",
+            ],
+        )
+        with patch_cute_mma_support():
+            bound = kernel.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code = bound.to_triton_code(config)
+
+        # The producer body re-emits the L2-grouping
+        # decomposition chain. ``tile_offset_0`` and
+        # ``tile_offset_1`` must both appear inside the
+        # producer body (they are scope-local to each
+        # role-local while; the consumer roles re-emit them
+        # too).
+        c_input_marker = "while tcgen05_c_input_warp_valid:"
+        assert c_input_marker in code, (
+            "expected the C-input producer while loop in codegen"
+        )
+        producer_body = code.split(c_input_marker, 1)[1]
+        # The dependency walker brings in ``inner_2d_pid``,
+        # ``group_id``, ``first_pid_m``, ``group_size_m``,
+        # ``pid_0``, ``pid_1``, ``tile_offset_0``,
+        # ``tile_offset_1``.
+        for name in (
+            "inner_2d_pid",
+            "group_id",
+            "first_pid_m",
+            "group_size_m",
+            "pid_0",
+            "pid_1",
+            "tile_offset_0",
+            "tile_offset_1",
+        ):
+            self.assertIn(
+                f"{name} = ",
+                producer_body,
+                f"expected L2-grouping decomposition var {name!r} "
+                f"defined inside the C-input producer body",
+            )
+        # The producer's per-CTA aux M tile coord must derive
+        # from post-L2 ``tile_offset_0 // bm * cluster_m`` plus
+        # ``peer_m = block_idx_in_cluster() %% cluster_m``
+        # under is_two_cta. ``bm=256`` for this config;
+        # ``cluster_m=2``. The modulo form is load-bearing for
+        # ``cluster_n=2`` (autoreview P1 fix; see the runtime
+        # correctness sweep above). Python's expression
+        # rendering strips redundant outer parens, so the
+        # match below is on the canonical post-rendering form.
+        self.assertIn(
+            "tcgen05_aux_tile_m = tile_offset_0 // cutlass.Int32(256) "
+            "* cutlass.Int32(2) + cute.arch.make_warp_uniform"
+            "(cute.arch.block_idx_in_cluster()) % cutlass.Int32(2)",
+            producer_body,
+        )
+        self.assertIn(
+            "tcgen05_aux_tile_n = tile_offset_1 // cutlass.Int32(256)",
+            producer_body,
+        )
+
     def test_aux_pipeline_producer_advance_indent_fallback_path(self) -> None:
         """Producer-body indent regression for the fallback
         ``emit_pipeline_advance`` path: when


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * __->__#2411
 * #2410
 * #2409
 * #2408
 * #2407
 * #2406
 * #2405
 * #2404
 * #2403
 * #2402
 * #2401
 * #2400


--- --- ---

[cutedsl] fix c_input warp aux tile coords for cluster + l2_groupings