### PR TITLE
[cute] add fp8 dtypes to _torch_dtype_to_cutlass mapping

### DIFF
--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -1371,6 +1371,8 @@ def _torch_dtype_to_cutlass(dtype: torch.dtype) -> object:
         torch.float32: cutlass.Float32,
         torch.float64: cutlass.Float64,
         torch.bfloat16: cutlass.BFloat16,
+        torch.float8_e4m3fn: cutlass.Float8E4M3FN,
+        torch.float8_e5m2: cutlass.Float8E5M2,
         # CuTe does not support i1 global-memory tensors; torch.bool is stored
         # as one byte, so pass bool tensor pointers as uint8 and let load
         # lowering convert nonzero bytes back to cutlass.Boolean registers.

--- a/test/test_cute_dtype_mapping.py
+++ b/test/test_cute_dtype_mapping.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from helion.runtime import _torch_dtype_to_cutlass
+
+cutlass = pytest.importorskip("cutlass")
+
+
+def test_fp16_bf16_fp32_unchanged() -> None:
+    assert _torch_dtype_to_cutlass(torch.float16) is cutlass.Float16
+    assert _torch_dtype_to_cutlass(torch.bfloat16) is cutlass.BFloat16
+    assert _torch_dtype_to_cutlass(torch.float32) is cutlass.Float32
+
+
+def test_fp8_e4m3fn_maps_to_cutlass() -> None:
+    assert _torch_dtype_to_cutlass(torch.float8_e4m3fn) is cutlass.Float8E4M3FN
+
+
+def test_fp8_e5m2_maps_to_cutlass() -> None:
+    assert _torch_dtype_to_cutlass(torch.float8_e5m2) is cutlass.Float8E5M2


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2422

Allow fp8 tensors (torch.float8_e4m3fn, torch.float8_e5m2) to flow through
the cute-backend kernel binding layer. Before this change, passing fp8
tensors to a helion.kernel(backend='cute') call would hit BackendUnsupported
at type-mapping time, before any MMA/codegen could be attempted.

This is pure plumbing — no MMA, lowering, or codegen behavior changes. fp8
kernels will still fail downstream until follow-up PRs wire fp8 through
mma_support and cute_mma codegen. The point of this PR is to move the
failure boundary forward so the next PR can be reviewed in isolation.

Authored with Claude.