### PR TITLE
Make Triton do_not_specialize opt-in

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -800,9 +800,18 @@ class TritonBackend(Backend):
         return "triton.jit"
 
     def function_decorator_for_args(self, args: Sequence[Argument]) -> str:
+        from .compile_environment import CompileEnvironment
         from .device_function import SymbolArgument
         from .device_function import TensorSizeArg
         from .device_function import TensorStrideArg
+
+        # Default to Triton's own behavior: let Triton specialize on values and
+        # alignment.  This enables vectorized loads (constexpr 1 for inner
+        # strides, divisibility-by-16 hint for sizes) at the cost of an
+        # occasional Triton recompile when a value crosses a specialization
+        # boundary (e.g. size 1 -> 2, alignment changes).
+        if not CompileEnvironment.current().settings.triton_do_not_specialize:
+            return self.function_decorator
 
         do_not_specialize = [
             arg.name

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -538,6 +538,11 @@ class _Settings:
         )
     )
     autotune_config_filter: Callable[[Config], Config | None] | None = None
+    triton_do_not_specialize: bool = dataclasses.field(
+        default_factory=functools.partial(
+            _env_get_bool, "HELION_TRITON_DO_NOT_SPECIALIZE", False
+        )
+    )
 
 
 class Settings(_Settings):
@@ -612,6 +617,15 @@ class Settings(_Settings):
             "If True, set the compile timeout threshold to be smaller for Triton compilation,"
             "based on a quantile of initial compile times (with a lower bound). Lower bound and quantile "
             "are set by the effort profile. Set HELION_AUTOTUNE_ADAPTIVE_TIMEOUT=0 to disable."
+        ),
+        "triton_do_not_specialize": (
+            "If True, pass do_not_specialize for every dynamic size/stride/symbol "
+            "arg so a single Triton binary handles any value, avoiding Triton-level "
+            "recompiles when shapes cross 0/1 or alignment boundaries. Disables "
+            "Triton's value/alignment specializations and can significantly slow "
+            "memory-bound kernels (vectorized loads rely on inner stride being "
+            "specialized to constexpr 1). Only takes effect when static_shapes=False. "
+            "Set HELION_TRITON_DO_NOT_SPECIALIZE=1 to enable globally."
         ),
         "print_output_code": "If True, print the output code of the kernel to stderr.",
         "print_repro": "If True, print Helion kernel code, config, and caller code to stderr as a standalone repro script.",

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -2670,8 +2670,12 @@ class TestIndexing(RefEagerTestBase, TestCase):
 
     @onlyBackends(["triton"])
     @skipIfRefEager("Test checks generated Triton code")
-    def test_dynamic_size_args_do_not_specialize_in_triton(self):
-        @helion.kernel(autotune_effort="none", static_shapes=False)
+    def test_triton_do_not_specialize_emits_do_not_specialize(self):
+        @helion.kernel(
+            autotune_effort="none",
+            static_shapes=False,
+            triton_do_not_specialize=True,
+        )
         def add_one(x: torch.Tensor) -> torch.Tensor:
             out = torch.empty_like(x)
             for tile in hl.tile(x.size(0)):
@@ -2686,6 +2690,30 @@ class TestIndexing(RefEagerTestBase, TestCase):
         self.assertIn("do_not_specialize=", code)
         self.assertIn("do_not_specialize_on_alignment=", code)
         y = torch.randn([2], device=DEVICE)
+        torch.testing.assert_close(add_one(y), y + 1)
+        self.assertEqual(len(add_one._bound_kernels), 1)
+
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Test checks generated Triton code")
+    def test_dynamic_size_args_match_triton_default(self):
+        """Without triton_do_not_specialize, Helion follows Triton's own default
+        and emits a plain @triton.jit so value/alignment specialization is
+        preserved (which is what enables vectorized loads)."""
+
+        @helion.kernel(autotune_effort="none", static_shapes=False)
+        def add_one(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] + 1
+            return out
+
+        x = torch.randn([1024], device=DEVICE)
+        code, result = code_and_output(add_one, (x,), block_size=16)
+        torch.testing.assert_close(result, x + 1)
+        self.assertNotIn("do_not_specialize=", code)
+        self.assertNotIn("do_not_specialize_on_alignment=", code)
+        # Helion still buckets sizes so a single BoundKernel handles every shape.
+        y = torch.randn([2048], device=DEVICE)
         torch.testing.assert_close(add_one(y), y + 1)
         self.assertEqual(len(add_one._bound_kernels), 1)
 


### PR DESCRIPTION
Make Triton's do_not_specialize / do_not_specialize_on_alignment flags opt-in via a new prevent_triton_recompile setting (@helion.kernel(prevent_triton_recompile=True), which defaults to False. This default matches Triton behavior. The core parts of #2353 are unchanged.

The previous default disables Triton's value/alignment specialization, which disables vectorized loads. On H100, with static_shapes=False, this makes perf worse by roughly 50% on some memory-bound kernels. Eager speedup comparison with the new defaults:

| Kernel | before | after |
|---|---|---|
| layer_norm | 0.72x | 1.42x |
| rms_norm | 0.84x | 1.31x |
| softmax | 1.07x | 1.71x |
| cross_entropy | 2.39x | 2.39x |
| vector_add | 0.97x | 0.99x |

Users who want the recompile-prevention from #1539 can opt in via prevent_triton_recompile=True/HELION_PREVENT_TRITON_RECOMPILE=1.