### PR TITLE
[WIP] fp8 Scaled mm in cute

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -40,6 +40,10 @@ from typing import Any
 from typing import Callable
 from typing import cast
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from tabulate import tabulate
 import torch
 from torch.utils._pytree import tree_leaves
@@ -222,6 +226,16 @@ KERNEL_MAPPINGS: dict[str, tuple[str, ...]] = {
         "fp8_gemm_tritonbench",
         {
             "num_inputs": 10,  # fp8_gemm takes long time on Benchmark CI, so use fewer inputs instead.
+        },
+    ),
+    "scaled_mm": (
+        "examples.scaled_mm",
+        [
+            ("examples.scaled_mm", "scaled_mm_tritonbench"),
+            ("examples.scaled_mm", "scaled_mm_triton_backend_tritonbench"),
+        ],
+        {
+            "num_inputs": 4,
         },
     ),
     "flash_attention": (
@@ -724,6 +738,15 @@ KERNEL_METRIC_MAPPINGS: dict[str, dict[str, str]] = {
         "helion_fp8_gemm_tritonbench-accuracy": "helion_accuracy",
         "helion_fp8_gemm_tritonbench-latency": "helion_latency_ms",
     },
+    "scaled_mm": {
+        "torch_scaled_mm-latency": "baseline_latency_ms",
+        "helion_scaled_mm_tritonbench-speedup": "helion_speedup",
+        "helion_scaled_mm_tritonbench-accuracy": "helion_accuracy",
+        "helion_scaled_mm_tritonbench-latency": "helion_latency_ms",
+        "helion_scaled_mm_triton_backend_tritonbench-speedup": "helion_triton_speedup",
+        "helion_scaled_mm_triton_backend_tritonbench-accuracy": "helion_triton_accuracy",
+        "helion_scaled_mm_triton_backend_tritonbench-latency": "helion_triton_latency_ms",
+    },
     "low_mem_dropout": {
         "seeded_dropout-accuracy": "triton_accuracy",
         "seeded_dropout-speedup": "triton_speedup",
@@ -1200,6 +1223,11 @@ def run_kernel_variants(
 
     assert "--op" not in tritonbench_args
     tritonbench_args = ["--op", operator_name, *tritonbench_args]
+    if not tritonbench_module.startswith("tritonbench.") and not any(
+        arg == "--benchmark-name" or arg.startswith("--benchmark-name=")
+        for arg in tritonbench_args
+    ):
+        tritonbench_args.extend(["--benchmark-name", operator_name])
 
     # If kernel name ends with `-bwd`, then add --bwd flag
     if kernel_name.endswith("-bwd") and "--bwd" not in tritonbench_args:
@@ -1468,7 +1496,24 @@ def run_kernel_variants(
 
     with tempfile.NamedTemporaryFile(mode="w+t", suffix=".csv") as tmp:
         tritonbench_args.extend(["--output", tmp.name])
-        tritonbench_run(tritonbench_args)
+        if not tritonbench_module.startswith("tritonbench."):
+            # TritonBench only discovers operators in its own package tree.
+            from tritonbench.utils import run_utils
+
+            original_load_opbench_by_name = run_utils.load_opbench_by_name
+
+            def load_opbench_by_name(name: str) -> object:
+                if name == operator_name:
+                    return Operator
+                return original_load_opbench_by_name(name)
+
+            run_utils.load_opbench_by_name = load_opbench_by_name
+            try:
+                tritonbench_run(tritonbench_args)
+            finally:
+                run_utils.load_opbench_by_name = original_load_opbench_by_name
+        else:
+            tritonbench_run(tritonbench_args)
         tmp.seek(0)
         try:
             process_result(

--- a/examples/scaled_mm.py
+++ b/examples/scaled_mm.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from typing import Any
+from typing import Callable
+from typing import Generator
+import sys
+
+import torch
+
+import helion
+import helion.language as hl
+
+SHAPES = (
+    (64, 128, 64),
+    (128, 128, 128),
+    (128, 256, 256),
+    (256, 256, 256),
+    (512, 1024, 512),
+    (1024, 1024, 1024),
+    (2048, 2048, 1024),
+    (4096, 4096, 4096),
+    (8192, 8192, 8192),
+    (16384, 8192, 8192),
+    (16384, 16384, 16384),
+    (32768, 8192, 8192),
+    (32768, 16384, 8192),
+)
+
+try:
+    from tritonbench.utils.triton_op import BenchmarkOperator
+    from tritonbench.utils.triton_op import register_benchmark
+except ImportError:
+    BenchmarkOperator = object  # type: ignore[assignment,misc]
+    register_benchmark = None  # type: ignore[assignment]
+
+
+@helion.kernel(backend="cute")
+def scaled_mm_cute(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> torch.Tensor:
+    m, k = a.size()
+    _, n = b.size()
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=a.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(a[tile_m, tile_k], b[tile_k, tile_n], acc=acc)
+        acc = acc * scale_a[tile_m, :].to(torch.float32)
+        acc = acc * scale_b[:, tile_n].to(torch.float32)
+        out[tile_m, tile_n] = acc.to(torch.bfloat16)
+    return out
+
+
+@helion.kernel(backend="triton")
+def scaled_mm_triton(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> torch.Tensor:
+    m, k = a.size()
+    _, n = b.size()
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=a.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(a[tile_m, tile_k], b[tile_k, tile_n], acc=acc)
+        acc = acc * scale_a[tile_m, :].to(torch.float32)
+        acc = acc * scale_b[:, tile_n].to(torch.float32)
+        out[tile_m, tile_n] = acc.to(torch.bfloat16)
+    return out
+
+
+def _direct_config(m: int, k: int, n: int) -> helion.Config:
+    if (m, k, n) == (64, 128, 64):
+        return helion.Config(block_sizes=[64, 64, 64])
+    if (m, k, n) == (128, 128, 128):
+        return helion.Config(block_sizes=[128, 128, 64])
+    if (m, k, n) == (128, 256, 256):
+        return helion.Config(block_sizes=[64, 256, 64])
+    if (m, k, n) == (256, 256, 256):
+        return helion.Config(block_sizes=[64, 128, 64])
+    if (m, k, n) == (512, 1024, 512):
+        return helion.Config(block_sizes=[128, 128, 128])
+    if (m, k, n) == (1024, 1024, 1024):
+        return helion.Config(block_sizes=[128, 128, 128])
+    if (m, k, n) == (2048, 2048, 1024):
+        return helion.Config(block_sizes=[128, 128, 128])
+    if (m, k, n) == (4096, 4096, 4096):
+        return helion.Config(block_sizes=[128, 128, 128])
+    if (m, k, n) == (8192, 8192, 8192):
+        return helion.Config(block_sizes=[128, 128, 128])
+    if (m, k, n) == (16384, 8192, 8192):
+        return helion.Config(block_sizes=[128, 128, 128])
+    if (m, k, n) == (16384, 16384, 16384):
+        return helion.Config(block_sizes=[128, 128, 128])
+    if (m, k, n) == (32768, 8192, 8192):
+        return helion.Config(block_sizes=[128, 128, 128])
+    if (m, k, n) == (32768, 16384, 8192):
+        return helion.Config(block_sizes=[128, 128, 128])
+    return helion.Config(block_sizes=[64, 64, 64])
+
+
+def scaled_mm_tritonbench(
+    tb_op: object,
+    a: torch.Tensor,
+    b_helion: torch.Tensor,
+    b_torch: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> Callable[[], torch.Tensor]:
+    m, k = a.size()
+    _, n = b_helion.size()
+    bound = scaled_mm_cute.bind((a, b_helion, scale_a, scale_b))
+    compiled = bound.compile_config(_direct_config(m, k, n))
+    return lambda: compiled(a, b_helion, scale_a, scale_b)
+
+
+def scaled_mm_triton_backend_tritonbench(
+    tb_op: object,
+    a: torch.Tensor,
+    b_helion: torch.Tensor,
+    b_torch: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> Callable[[], torch.Tensor]:
+    bound = scaled_mm_triton.bind((a, b_helion, scale_a, scale_b))
+    config = bound.autotune((a, b_helion, scale_a, scale_b), force=False)
+    print(f"Helion Triton scaled_mm autotune config: {config}", file=sys.stderr)
+    compiled = bound.compile_config(config)
+    return lambda: compiled(a, b_helion, scale_a, scale_b)
+
+
+if register_benchmark is not None:
+
+    class Operator(BenchmarkOperator):  # type: ignore[misc,valid-type]
+        DEFAULT_METRICS = ["latency", "speedup", "accuracy"]
+        DEFAULT_PRECISION = "bypass"
+        FWD_ONLY = True
+
+        @register_benchmark(operator_name="scaled_mm", baseline=True)
+        def torch_scaled_mm(
+            self,
+            a: torch.Tensor,
+            b_helion: torch.Tensor,
+            b_torch: torch.Tensor,
+            scale_a: torch.Tensor,
+            scale_b: torch.Tensor,
+        ) -> Callable[[], torch.Tensor]:
+            return lambda: torch._scaled_mm(
+                a,
+                b_torch,
+                scale_a,
+                scale_b,
+                out_dtype=torch.bfloat16,
+            )
+
+        def get_input_iter(self) -> Generator[tuple[torch.Tensor, ...], None, None]:
+            for m, k, n in SHAPES:
+                torch.manual_seed(0)
+                a = torch.randn(m, k, device=self.device, dtype=torch.float32).to(
+                    torch.float8_e4m3fn
+                )
+                b_values = torch.randn(k, n, device=self.device, dtype=torch.float32)
+                b_helion = b_values.to(torch.float8_e4m3fn)
+                b_torch = b_values.to(torch.float8_e4m3fn).t().contiguous().t()
+                scale_a = (
+                    torch.rand(m, 1, device=self.device, dtype=torch.float32) * 0.25
+                    + 0.875
+                )
+                scale_b = (
+                    torch.rand(1, n, device=self.device, dtype=torch.float32) * 0.25
+                    + 0.875
+                )
+                yield a, b_helion, b_torch, scale_a, scale_b
+
+        def get_x_val(self, example_inputs: Any) -> tuple[int, int, int]:
+            a = example_inputs[0]
+            b = example_inputs[1]
+            m, k = a.size()
+            _, n = b.size()
+            return m, k, n

--- a/helion/_compiler/cute/aux_tensor.py
+++ b/helion/_compiler/cute/aux_tensor.py
@@ -74,8 +74,10 @@ class Tcgen05AuxTensorDescriptor:
       the producer-body codegen needs at MMA-codegen time (the TMA
       atom and SMEM ring are sized from these).
     - ``broadcast_axis``: ``None`` for the exact-shape rank-2 form
-      (``residual[tile_m, tile_n]``); ``1`` for the trailing-axis
-      rowvec broadcast form (``bias[tile_n]``). Matches the field on
+      (``residual[tile_m, tile_n]``); ``1`` for trailing-axis rowvec
+      broadcast (``bias[tile_n]`` or ``scale_b[:, tile_n]``); ``0``
+      for explicit leading-axis colvec broadcast
+      (``scale_a[tile_m, :]``). Matches the field on
       :class:`_AuxiliaryTensorStep` so the productive body uses the
       same axis convention as the existing per-thread splice.
     - ``store_value_node``: the FX node of the store value whose

--- a/helion/_compiler/cute/cute_epilogue.py
+++ b/helion/_compiler/cute/cute_epilogue.py
@@ -21,10 +21,11 @@ expression for two cases:
 - Auxiliary-tensor binary ops: same shape as above, but one or more
   steps are ``add/sub/mul/div`` with the chain carrier as one
   operand and a ``helion.language.load(aux_tensor, [...])``
-  call as the other. Two aux load shapes are accepted: the
-  exact-shape rank-2 form (``residual[tile_m, tile_n]``) and the
-  rank-1 trailing-axis (rowvec) broadcast form (``bias[tile_n]``).
-  See :class:`_AuxiliaryTensorStep` for the canonical contract.
+  call as the other. Accepted aux load shapes are exact-shape rank-2
+  (``residual[tile_m, tile_n]``), trailing-axis rowvec broadcast
+  (``bias[tile_n]`` or ``scale_b[:, tile_n]``), and explicit
+  leading-axis colvec broadcast (``scale_a[tile_m, :]``). See
+  :class:`_AuxiliaryTensorStep` for the canonical contract.
   Forms outside these two — 3-D underlying tensors with a static
   collapse, mismatched indices, leading-axis rank-1
   (``bias[tile_m]``), kwargs — are rejected to the loud-failure
@@ -125,17 +126,12 @@ class _AuxiliaryTensorStep:
     classify time).
 
     ``broadcast_axis`` is ``None`` when the aux tensor matches the
-    carrier rank exactly (``residual[tile_m, tile_n]``) or ``1`` for
-    a trailing-axis (rowvec) broadcast aux load (``bias[tile_n]``
-    with shape ``(N,)``). The leading-axis (colvec / M-axis) form is
-    not accepted: a bare rank-1 operand on the RHS aligns to the
-    *last* dimension under PyTorch broadcasting rules
-    (``acc + bias[tile_m]`` is either a shape error when BM ≠ BN
-    or a rowvec broadcast when BM == BN), so accepting the colvec
-    pattern would silently rewrite the user's broadcast direction.
-    Users wanting an explicit colvec broadcast must spell it out
-    with ``[:, None]`` / ``.unsqueeze(-1)``; that is a separate
-    pattern handler not yet wired up. The splice site
+    carrier rank exactly (``residual[tile_m, tile_n]``), ``1`` for
+    trailing-axis rowvec broadcast (``bias[tile_n]`` or
+    ``scale_b[:, tile_n]``), or ``0`` for explicit leading-axis
+    colvec broadcast (``scale_a[tile_m, :]``). Bare rank-1
+    ``scale_a[tile_m]`` remains rejected because PyTorch aligns it
+    to the last dimension, not to the M axis. The splice site
     (``memory_ops._codegen_cute_store_tcgen05_tile``) owns the
     canonical broadcast-view contract — it builds a 2-D logical
     view of the rank-1 tensor with stride 0 on the orthogonal axis

--- a/helion/_compiler/cute/cute_fx_walk.py
+++ b/helion/_compiler/cute/cute_fx_walk.py
@@ -191,18 +191,12 @@ def aux_tensor_load_kind(
       load's index list is exactly the carrier's tile-id symbol
       nodes in the same order. The splice site uses the existing
       partition_C → flat_divide → partition_D pipeline.
-    - ``("broadcast", 1)``: a rank-1 trailing-axis broadcast aux
-      load (``bias[tile_n]``). The underlying tensor's rank is 1,
-      the load result shape equals the carrier tile shape's
-      trailing entry, and the load's single index symbol is
-      exactly ``carrier_tile_index_nodes[1]``. Only the trailing
-      axis is supported because PyTorch broadcasting aligns a
-      rank-1 operand to the *last* dimension of a rank-2 LHS:
-      ``acc + bias[tile_m]`` is either a shape error (BM ≠ BN) or
-      rowvec broadcast against the trailing axis (BM == BN). A
-      user wanting M-axis (column-vector) broadcasting must write
-      it explicitly (``bias[tile_m][:, None]`` /
-      ``.unsqueeze(-1)``); that is a separate, deferred pattern.
+    - ``("broadcast", 1)``: a trailing-axis rowvec broadcast aux
+      load (``bias[tile_n]`` or ``scale_b[:, tile_n]``).
+    - ``("broadcast", 0)``: an explicit leading-axis colvec
+      broadcast aux load (``scale_a[tile_m, :]``). Bare rank-1
+      ``scale_a[tile_m]`` remains rejected because PyTorch aligns
+      rank-1 operands to the last dimension of a rank-2 carrier.
       See :class:`Tcgen05UnaryEpilogueChain` (``cute_epilogue.py``)
       for the splice-side broadcast-view contract.
 
@@ -305,25 +299,18 @@ def _matches_broadcast(
     carrier_tile_index_nodes: tuple[torch.fx.Node, ...] | None,
     carrier_global_shape: tuple[object, ...] | None,
 ) -> tuple[str, int] | None:
-    """Check whether a load matches the rank-1 trailing-axis
-    (rowvec) broadcast aux pattern, and return ``("broadcast", 1)``
-    on success.
+    """Check whether a load matches a supported broadcast aux pattern.
 
-    The classifier intentionally restricts to the trailing axis
-    only: a bare rank-1 operand on the RHS of a rank-2 carrier
-    aligns to the last dimension under PyTorch broadcasting rules,
-    so ``acc + bias[tile_m]`` is not a column-vector broadcast — it
-    is a shape error (BM ≠ BN) or trailing-axis broadcast (BM == BN).
-    Users wanting an explicit M-axis broadcast must write it
-    explicitly (``bias[tile_m][:, None]`` / ``.unsqueeze(-1)`` /
-    ``.expand(...)``); that is a separate pattern handler not yet
-    wired up.
+    Rank-1 loads are accepted only as trailing-axis rowvec
+    broadcasts, matching PyTorch's rank-1 broadcasting rules. The
+    explicit rank-2 scale forms used by rowwise scaled_mm are also
+    accepted: ``scale_a[tile_m, :]`` with shape ``(M, 1)`` returns
+    ``("broadcast", 0)``, and ``scale_b[:, tile_n]`` with shape
+    ``(1, N)`` returns ``("broadcast", 1)``.
 
-    The splice site emits ``cute.make_layout((m, n),
-    stride=(0, 1))`` with stride 1 hard-coded on the data axis,
-    which is correct only when the underlying rank-1 tensor is
-    contiguous (stride 1 on dim 0). Non-stride-1 broadcast aux
-    is rejected loudly.
+    The splice site emits a stride-0 logical 2-D view with stride 1
+    hard-coded on the data axis. Non-stride-1 broadcast aux tensors
+    are rejected loudly.
 
     When ``carrier_global_shape`` is provided, the rank-1 aux's
     extent must equal the output tensor's global size on the
@@ -335,8 +322,6 @@ def _matches_broadcast(
     to be divisible by the tile extent passes the tile check yet
     reads OOB at runtime.
     """
-    if len(aux_tensor_shape) != 1 or len(aux_shape) != 1 or len(index_list) != 1:
-        return None
     if carrier_tile_index_nodes is None:
         # Broadcast classification is gated on knowing the carrier's
         # tile-id symbols so we can pin which axis the load broadcasts
@@ -345,17 +330,31 @@ def _matches_broadcast(
         return None
     if len(carrier_tile_index_nodes) != 2:
         return None
-    load_idx = index_list[0]
-    if not isinstance(load_idx, torch.fx.Node):
-        return None
-    if aux_tensor_val.stride() != (1,):
-        return None
-    aux_extent = aux_shape[0]
-    # Trailing-axis (rowvec) broadcast only — see docstring.
-    axis = 1
-    if load_idx is not carrier_tile_index_nodes[axis]:
-        return None
-    if aux_extent != carrier_tile_shape[axis]:
+    if len(aux_tensor_shape) == 1 and len(aux_shape) == 1 and len(index_list) == 1:
+        load_idx = index_list[0]
+        if not isinstance(load_idx, torch.fx.Node):
+            return None
+        if aux_tensor_val.stride() != (1,):
+            return None
+        axis = 1
+        if load_idx is not carrier_tile_index_nodes[axis]:
+            return None
+        if aux_shape[0] != carrier_tile_shape[axis]:
+            return None
+        aux_global_extent = aux_tensor_shape[0]
+    elif len(aux_tensor_shape) == 2 and len(aux_shape) == 2 and len(index_list) == 2:
+        axis = _explicit_rank2_broadcast_axis(
+            aux_shape=aux_shape,
+            aux_tensor_shape=aux_tensor_shape,
+            aux_tensor_stride=aux_tensor_val.stride(),
+            index_list=index_list,
+            carrier_tile_shape=carrier_tile_shape,
+            carrier_tile_index_nodes=carrier_tile_index_nodes,
+        )
+        if axis is None:
+            return None
+        aux_global_extent = aux_tensor_shape[axis]
+    else:
         return None
     if carrier_global_shape is not None:
         if len(carrier_global_shape) != 2:
@@ -368,9 +367,38 @@ def _matches_broadcast(
         # aux smaller than the output axis whose length happens to
         # be divisible by the tile extent could pass classification
         # yet read OOB at runtime.
-        if aux_tensor_shape[0] != carrier_global_shape[axis]:
+        if aux_global_extent != carrier_global_shape[axis]:
             return None
     return ("broadcast", axis)
+
+
+def _explicit_rank2_broadcast_axis(
+    *,
+    aux_shape: tuple[object, ...],
+    aux_tensor_shape: tuple[object, ...],
+    aux_tensor_stride: tuple[int, ...],
+    index_list: Sequence[object],
+    carrier_tile_shape: tuple[object, ...],
+    carrier_tile_index_nodes: tuple[torch.fx.Node, ...],
+) -> int | None:
+    for axis in (0, 1):
+        broadcast_axis = 1 - axis
+        load_idx = index_list[axis]
+        broadcast_idx = index_list[broadcast_axis]
+        if not isinstance(load_idx, torch.fx.Node):
+            continue
+        if load_idx is not carrier_tile_index_nodes[axis]:
+            continue
+        if not (isinstance(broadcast_idx, slice) and broadcast_idx == slice(None)):
+            continue
+        if aux_shape[axis] != carrier_tile_shape[axis]:
+            continue
+        if aux_shape[broadcast_axis] != 1 or aux_tensor_shape[broadcast_axis] != 1:
+            continue
+        if aux_tensor_stride[axis] != 1:
+            continue
+        return axis
+    return None
 
 
 def _matches_exact(

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -368,7 +368,13 @@ def _has_mma_operands(lhs_node: Node, rhs_node: Node) -> bool:
         return False
     lhs_load, _, lhs_fake = lhs_info
     rhs_load, _, rhs_fake = rhs_info
-    supported = {torch.float16, torch.bfloat16, torch.float32}
+    supported = {
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+        torch.float8_e4m3fn,
+        torch.float8_e5m2,
+    }
     return (
         lhs_fake.dtype in supported
         and rhs_fake.dtype in supported
@@ -1569,6 +1575,8 @@ def _emit_mma_pipeline(
         torch.float16: "cutlass.Float16",
         torch.bfloat16: "cutlass.BFloat16",
         torch.float32: "cutlass.Float32",
+        torch.float8_e4m3fn: "cutlass.Float8E4M3FN",
+        torch.float8_e5m2: "cutlass.Float8E5M2",
     }
     input_dtype_str = _dtype_map[input_dtype]
     acc_dtype_str = "cutlass.Float32"
@@ -4277,7 +4285,10 @@ def _mma_impl_matches_problem_shape(
 ) -> bool:
     if mma_impl == "universal":
         return True
-    if input_dtype not in (torch.float16, torch.bfloat16) or bn < 8 or bn % 8 != 0:
+    fp8_dtype = input_dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+    if input_dtype not in (torch.float16, torch.bfloat16) and not fp8_dtype:
+        return False
+    if bn < 8 or bn % 8 != 0:
         return False
     if bn > 256 and (
         mma_impl != "tcgen05"
@@ -4294,13 +4305,10 @@ def _mma_impl_matches_problem_shape(
         # Warp MMA atom is fixed-K (16 elements per BF16/FP16 instruction).
         return bk == 16 and bm >= 16 and bm % 16 == 0 and bn == 8
     if mma_impl == "tcgen05":
-        # tcgen05 mma instruction K is 16 elements for BF16/FP16, but the
-        # tile's K can be any positive multiple of that (the inner cute.gemm
-        # loop just runs more instructions per K iteration). Larger tile_k
-        # roughly halves the per-K-iter overhead per doubling. Production
-        # remains capped at block_n=256 to keep AB SMEM staging budget sane;
-        # the explicit G4 proof key admits only the smallest 512-N candidate.
-        if bk < 16 or bk > 256 or bk % 16 != 0:
+        # tcgen05 mma instruction K: 16 for BF16/FP16, 32 for F8F6F4.
+        # Tile K must be a positive multiple of the instruction K.
+        k_stride = 32 if fp8_dtype else 16
+        if bk < k_stride or bk > 256 or bk % k_stride != 0:
             return False
         if bm in (64, 128):
             return True
@@ -4364,6 +4372,29 @@ def _choose_mma_impl(
     tcgen05_large_bn_proof = _tcgen05_large_bn_proof_enabled(config)
     env_choice = os.environ.get("HELION_CUTE_MMA_IMPL", "auto").strip().lower()
     support = get_cute_mma_support()
+    fp8_dtype = input_dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+    if fp8_dtype:
+        # fp8 tcgen05 is currently disabled at the routing layer because the
+        # fp8 cute codegen takes a different code path than f16/bf16: fp8 is
+        # excluded from the TMA load gate (see ``tcgen05_use_tma`` in
+        # ``_emit_mma_pipeline``), so the fp8 tcgen05 emission lacks the
+        # producer/consumer-staged accumulator pipeline that the validated
+        # f16/bf16 path relies on. Empirically this produces sparse output
+        # (CUTLASS-side gate bm>=128 and bm==64 both fail with different
+        # patterns). Until fp8 is plumbed through the TMA path and the t2r
+        # epilogue is validated for MmaF8F6F4Op, route fp8 to the universal
+        # MMA atom which is dense + correct on B200.
+        if env_choice == "tcgen05":
+            raise exc.BackendUnsupported(
+                "cute",
+                (
+                    "tcgen05 fp8 MMA is currently disabled: fp8 is excluded "
+                    "from the TMA producer/consumer staging path used by the "
+                    "validated f16/bf16 tcgen05 emission, and the non-TMA fp8 "
+                    "tcgen05 path produces sparse accumulator output."
+                ),
+            )
+        return "universal"
     if env_choice != "auto":
         if env_choice not in support.supported_impls:
             raise exc.BackendUnsupported(
@@ -4461,6 +4492,7 @@ def _tcgen05_tiled_mma_expr(
         cta_group_expr = "cute.nvgpu.tcgen05.CtaGroup.TWO"
     return (
         "cutlass.utils.blackwell_helpers.make_trivial_tiled_mma("
+        f"{input_dtype_str}, "
         f"{input_dtype_str}, "
         "cute.nvgpu.tcgen05.OperandMajorMode.K, "
         "cute.nvgpu.tcgen05.OperandMajorMode.MN, "

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -99,6 +99,19 @@ _TRACE_THROUGH_TARGETS = {
     # raw tensor data — tracing through permute would bypass the
     # data shuffle.  Permuted operands fall back to scalar codegen.
 }
+_STORE_DTYPE_TRACE_TARGETS = _TRACE_THROUGH_TARGETS | {
+    torch.ops.aten.relu.default,
+    torch.ops.aten.abs.default,
+    torch.ops.aten.neg.default,
+    torch.ops.aten.tanh.default,
+    torch.ops.aten.exp.default,
+    torch.ops.aten.log.default,
+    torch.ops.aten.sqrt.default,
+    torch.ops.aten.add.Tensor,
+    torch.ops.aten.mul.Tensor,
+    torch.ops.aten.sub.Tensor,
+    torch.ops.aten.div.Tensor,
+}
 
 # Register reallocation budget for tcgen05 warp-specialized kernels.
 # Producer warps (TMA loads, scheduler) only do address arithmetic and
@@ -1528,7 +1541,7 @@ def _trace_mma_to_store_dtype(
                 target is _tracing_ops._phi
                 or target is _tracing_ops._new_var
                 or target is operator.getitem
-                or target in _TRACE_THROUGH_TARGETS
+                or target in _STORE_DTYPE_TRACE_TARGETS
             ):
                 stack.append(user)
                 continue
@@ -4387,26 +4400,22 @@ def _choose_mma_impl(
     support = get_cute_mma_support()
     fp8_dtype = input_dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
     if fp8_dtype:
-        # fp8 tcgen05 is currently disabled at the routing layer because the
-        # fp8 cute codegen takes a different code path than f16/bf16: fp8 is
-        # excluded from the TMA load gate (see ``tcgen05_use_tma`` in
-        # ``_emit_mma_pipeline``), so the fp8 tcgen05 emission lacks the
-        # producer/consumer-staged accumulator pipeline that the validated
-        # f16/bf16 path relies on. Empirically this produces sparse output
-        # (CUTLASS-side gate bm>=128 and bm==64 both fail with different
-        # patterns). Until fp8 is plumbed through the TMA path and the t2r
-        # epilogue is validated for MmaF8F6F4Op, route fp8 to the universal
-        # MMA atom which is dense + correct on B200.
         if env_choice == "tcgen05":
-            raise exc.BackendUnsupported(
-                "cute",
-                (
-                    "tcgen05 fp8 MMA is currently disabled: fp8 is excluded "
-                    "from the TMA producer/consumer staging path used by the "
-                    "validated f16/bf16 tcgen05 emission, and the non-TMA fp8 "
-                    "tcgen05 path produces sparse accumulator output."
-                ),
-            )
+            if not support.tcgen05_f8f6f4:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "tcgen05 F8F6F4 MMA is not supported on this machine.",
+                )
+            if _mma_impl_matches_problem_shape(
+                "tcgen05",
+                input_dtype,
+                bm=bm,
+                bn=bn,
+                bk=bk,
+                tcgen05_cluster_m=tcgen05_cluster_m,
+                tcgen05_large_bn_proof=tcgen05_large_bn_proof,
+            ):
+                return "tcgen05"
         return "universal"
     if env_choice != "auto":
         if env_choice not in support.supported_impls:

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -1603,8 +1603,21 @@ def _emit_mma_pipeline(
     epi_elem_dtype_str = (
         _dtype_map[epi_elem_dtype] if epi_elem_dtype is not None else input_dtype_str
     )
+    # TMA producer/consumer staging is admissible for f16/bf16 and for fp8
+    # (e4m3fn / e5m2). fp8 needs the same staged accumulator pipeline f16/bf16
+    # uses; without it the t2r epilogue reads sparse TMEM output for
+    # MmaF8F6F4Op. The downstream byte-budget helpers (e.g.
+    # tcgen05_ab_smem_bytes_per_cta) already accept dtype_bytes and callers
+    # source it from ``lhs.dtype.itemsize`` so the 1-byte fp8 path computes
+    # correct SMEM budgets when this gate opens.
     tcgen05_use_tma = (
-        input_dtype in (torch.float16, torch.bfloat16)
+        input_dtype
+        in (
+            torch.float16,
+            torch.bfloat16,
+            torch.float8_e4m3fn,
+            torch.float8_e5m2,
+        )
         and lhs_fake.is_contiguous()
         and rhs_fake.is_contiguous()
     )

--- a/helion/_compiler/cute/mma_support.py
+++ b/helion/_compiler/cute/mma_support.py
@@ -17,9 +17,11 @@ class CuteMmaSupport:
     warp_f16bf16: bool
     warpgroup_f16bf16: bool
     tcgen05_f16bf16: bool
+    tcgen05_f8f6f4: bool = False
     warp_error: str | None = None
     warpgroup_error: str | None = None
     tcgen05_error: str | None = None
+    tcgen05_f8f6f4_error: str | None = None
 
     @property
     def supported_impls(self) -> tuple[str, ...]:
@@ -105,6 +107,28 @@ def _probe_tcgen05_f16bf16() -> tuple[bool, str | None]:
         return False, f"{type(exc).__name__}: {exc}"
 
 
+def _probe_tcgen05_f8f6f4() -> tuple[bool, str | None]:
+    # MmaF8F6F4Op is the canonical Blackwell fp8/fp6/fp4 atom. The older
+    # MmaFP8Op is deprecated in cutlass-dsl in favor of this one.
+    try:
+        import cutlass
+        from cutlass.cute.nvgpu import tcgen05
+
+        tcgen05.MmaF8F6F4Op(
+            cutlass.Float8E4M3FN,
+            cutlass.Float8E4M3FN,
+            cutlass.Float32,
+            (128, 8, 32),
+            tcgen05.CtaGroup.ONE,
+            tcgen05.OperandSource.SMEM,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.K,
+        )
+        return True, None
+    except Exception as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+
+
 def get_cute_mma_support() -> CuteMmaSupport:
     device = _current_cuda_device()
     if device is None:
@@ -116,9 +140,11 @@ def get_cute_mma_support() -> CuteMmaSupport:
             warp_f16bf16=False,
             warpgroup_f16bf16=False,
             tcgen05_f16bf16=False,
+            tcgen05_f8f6f4=False,
             warp_error="CUDA unavailable",
             warpgroup_error="CUDA unavailable",
             tcgen05_error="CUDA unavailable",
+            tcgen05_f8f6f4_error="CUDA unavailable",
         )
 
     device_name = torch.cuda.get_device_name(device)
@@ -130,6 +156,7 @@ def get_cute_mma_support() -> CuteMmaSupport:
     warp_ok, warp_error = _probe_warp_f16bf16()
     warpgroup_ok, warpgroup_error = _probe_warpgroup_f16bf16()
     tcgen05_ok, tcgen05_error = _probe_tcgen05_f16bf16()
+    tcgen05_f8_ok, tcgen05_f8_error = _probe_tcgen05_f8f6f4()
 
     return CuteMmaSupport(
         device_name=device_name,
@@ -139,9 +166,11 @@ def get_cute_mma_support() -> CuteMmaSupport:
         warp_f16bf16=warp_ok,
         warpgroup_f16bf16=warpgroup_ok,
         tcgen05_f16bf16=tcgen05_ok,
+        tcgen05_f8f6f4=tcgen05_f8_ok,
         warp_error=warp_error,
         warpgroup_error=warpgroup_error,
         tcgen05_error=tcgen05_error,
+        tcgen05_f8f6f4_error=tcgen05_f8_error,
     )
 
 

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -3557,7 +3557,12 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             aux_tensor_name = device_function.tensor_arg(desc.host_tensor_val).name
             aux_dtype_str = env_backend.dtype_str(desc.host_tensor_val.dtype)
             dtype_bits = desc.host_tensor_val.dtype.itemsize * 8
-            copy_bits = 128
+            # Broadcast aux views intentionally have a stride-0 axis.
+            # CuTe cannot vectorize a 128-bit GMEM copy over static
+            # stride-0 elements, so keep those producer copies scalar
+            # and let the cooperative tiling cover the expanded SMEM
+            # tile. Dense residual tiles keep the wider copy atom.
+            copy_bits = dtype_bits if desc.broadcast_axis is not None else 128
             num_copy_elems = max(1, copy_bits // dtype_bits)
             gmem_aux_view_var = device_function.new_var(
                 f"tcgen05_aux_gmem_view_{desc_idx}"
@@ -3585,10 +3590,9 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             smem_part_var = device_function.new_var(f"tcgen05_aux_smem_part_{desc_idx}")
             setup: list[ast.stmt] = []
             # Build the source 2-D GMEM tensor. Exact-shape rank-2
-            # aux passes through ``aux_tensor`` directly; rank-1
-            # trailing-axis broadcast aux builds a stride-0-on-M
-            # view with M-extent ``bm_per_cta`` and N-extent = the
-            # rank-1 size. Under cluster_m=2 ``use_2cta_instrs``
+            # aux passes through ``aux_tensor`` directly; broadcast
+            # aux builds a stride-0 view with stride 1 on the data
+            # axis. Under cluster_m=2 ``use_2cta_instrs``
             # the per-CTA aux tile is ``(bm/2, bn)``; the global M
             # tile coord directly indexes per-CTA M stripes (the
             # scheduler publishes 2 global tiles per cluster
@@ -3608,24 +3612,37 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                     ]
                 )
             else:
-                assert desc.broadcast_axis == 1, (
-                    "C-input warp aux producer expects "
-                    "broadcast_axis in {None, 1}; the chain "
-                    "analyzer rejects other forms"
+                data_axis = desc.broadcast_axis
+                assert data_axis in (0, 1)
+                m_extent = (
+                    int(desc.host_tensor_val.shape[0])
+                    if data_axis == 0
+                    else bm_per_cta
                 )
-                n_global = int(desc.host_tensor_val.shape[0])
+                n_extent = (
+                    int(desc.host_tensor_val.shape[1])
+                    if len(desc.host_tensor_val.shape) == 2
+                    else int(desc.host_tensor_val.shape[0])
+                )
+                if data_axis == 0:
+                    n_extent = bn
+                    view_stride = "(1, 0)"
+                    tile_coord = f"({tile_m_var}, cutlass.Int32(0))"
+                else:
+                    view_stride = "(0, 1)"
+                    tile_coord = f"(cutlass.Int32(0), {tile_n_var})"
                 setup.extend(
                     [
                         statement_from_string(
                             f"{gmem_aux_view_var} = cute.make_tensor("
                             f"{aux_tensor_name}.iterator, "
-                            f"cute.make_layout(({bm_per_cta}, {n_global}), "
-                            "stride=(0, 1)))"
+                            f"cute.make_layout(({m_extent}, {n_extent}), "
+                            f"stride={view_stride}))"
                         ),
                         statement_from_string(
                             f"{gmem_aux_tile_var} = cute.local_tile("
                             f"{gmem_aux_view_var}, ({bm_per_cta}, {bn}), "
-                            f"(cutlass.Int32(0), {tile_n_var}))"
+                            f"{tile_coord})"
                         ),
                     ]
                 )
@@ -3902,6 +3919,8 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             "min",
             "cutlass.BFloat16",
             "cutlass.Boolean",
+            "cutlass.Float8E4M3FN",
+            "cutlass.Float8E5M2",
             "cutlass.Float16",
             "cutlass.Float32",
             "cutlass.Int32",

--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -354,12 +354,15 @@ def default_cute_mma_support(
     supported_impls: tuple[str, ...] = ("universal", "warp", "tcgen05"),
     warp_f16bf16: bool = True,
     tcgen05_f16bf16: bool = True,
+    tcgen05_f8f6f4: bool = True,
 ) -> SimpleNamespace:
     """Return a ``get_cute_mma_support()`` mock with tcgen05-on defaults."""
     return SimpleNamespace(
         supported_impls=supported_impls,
         warp_f16bf16=warp_f16bf16,
         tcgen05_f16bf16=tcgen05_f16bf16,
+        tcgen05_f8f6f4=tcgen05_f8f6f4,
+        tcgen05_f8f6f4_error=None,
     )
 
 

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 from itertools import zip_longest
+import os
 from typing import TYPE_CHECKING
 
 import torch
@@ -289,6 +290,14 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
     static_m = static_problem_extent(m)
     static_n = static_problem_extent(n)
     static_k = static_problem_extent(k)
+    input_dtype = lhs.dtype
+    fp8_dtype = input_dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+    tcgen05_k_min = 32 if fp8_dtype else 16
+    fp8_tcgen05_forced = (
+        fp8_dtype
+        and os.environ.get("HELION_CUTE_MMA_IMPL", "auto").strip().lower()
+        == "tcgen05"
+    )
     env.config_spec.matmul_facts.append(
         MatmulFact(
             lhs_ndim=lhs.ndim,
@@ -307,14 +316,22 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
         env.backend_name == "cute"
         and lhs.ndim == 2
         and rhs.ndim == 2
-        and lhs.dtype in (torch.float16, torch.bfloat16)
-        and rhs.dtype == lhs.dtype
+        and input_dtype in (
+            torch.float16,
+            torch.bfloat16,
+            torch.float8_e4m3fn,
+            torch.float8_e5m2,
+        )
+        and rhs.dtype == input_dtype
         and static_m is not None
         and static_n is not None
         and static_k is not None
         and static_m >= 64
         and static_n >= 8
-        and static_k >= 16
+        and static_k >= tcgen05_k_min
+        # Keep fp8 tcgen05 behind an explicit routing choice until the
+        # rowwise scaled_mm path has broader correctness coverage.
+        and (not fp8_dtype or fp8_tcgen05_forced)
         # The tcgen05 direct-store epilogue's predicated SIMT path
         # CUDA-launch-fails for partial M tiles on B200. Gate the tcgen05
         # specialization on M being a clean multiple of the minimum tcgen05
@@ -324,7 +341,11 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
     ):
         from .._compiler.cute.mma_support import get_cute_mma_support
 
-        if get_cute_mma_support().tcgen05_f16bf16:
+        support = get_cute_mma_support()
+        tcgen05_supported = (
+            support.tcgen05_f8f6f4 if fp8_dtype else support.tcgen05_f16bf16
+        )
+        if tcgen05_supported:
 
             def pow2_floor_at_least(value: int, minimum: int) -> int:
                 return 1 << (max(minimum, value).bit_length() - 1)
@@ -336,7 +357,7 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
             # Larger tile_k packs more cute.gemm instructions per K loop
             # iteration on tcgen05 (mma instruction K is fixed at 16 for
             # BF16/FP16). Cap at 128 to keep AB SMEM staging budget sane.
-            max_tcgen05_k = min(128, pow2_floor_at_least(static_k, 16))
+            max_tcgen05_k = min(128, pow2_floor_at_least(static_k, tcgen05_k_min))
             max_search_m = min(max_tcgen05_m, pow2_floor_at_least(static_m, 64))
             max_search_n = max_tcgen05_n
             max_search_k = max_tcgen05_k
@@ -422,7 +443,7 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
                 if block_idx is None:
                     continue
                 if axis_name == "k":
-                    min_size = 16
+                    min_size = tcgen05_k_min
                 elif axis_name == "m":
                     min_size = 128 if max_tcgen05_m >= 256 else 64
                 else:

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -2000,30 +2000,18 @@ def _codegen_cute_store_tcgen05_tile(
                 # of the underlying 2-D tensor directly.
                 source_for_local_tile = rec.aux_tensor_name
             else:
-                # Rank-1 trailing-axis (rowvec) broadcast aux: build a
-                # 2-D logical view of the rank-1 underlying tensor with
-                # stride 0 on the leading (M) axis and stride 1 on the
-                # trailing (N) axis. Stride 0 on M causes every lane
-                # "owning" output ``(m, n)`` to read the same source
-                # element regardless of m, which is the rowvec
-                # broadcast semantic that matches PyTorch's
-                # ``acc + bias[tile_n]`` (rank-1 RHS aligns to the
-                # trailing axis). The view feeds the same
-                # ``partition_C → flat_divide → partition_D`` pipeline
-                # used by exact-shape aux. Mirrors Quack's
-                # ``RowVecLoad`` epilogue (``quack/quack/epi_ops.py``).
-                # Only the trailing axis (``broadcast_axis == 1``)
-                # form is accepted at classify time — see
-                # ``aux_tensor_load_kind`` /
-                # ``_AuxiliaryTensorStep.broadcast_axis`` for the
-                # rejection of the leading-axis form.
-                assert rec.broadcast_axis == 1
+                # Build a logical 2-D broadcast view for rank-1
+                # rowvec and explicit rank-2 scale forms. The data
+                # axis keeps stride 1; the orthogonal axis gets stride
+                # 0 so every output element in that row/column reads
+                # the same scale value.
                 assert rec.aux_view2d is not None
+                view_stride = "(1, 0)" if rec.broadcast_axis == 0 else "(0, 1)"
                 lines.append(
                     f"{rec.aux_view2d} = cute.make_tensor("
                     f"{rec.aux_tensor_name}.iterator, "
                     f"cute.make_layout(({m_size}, {n_size}), "
-                    f"stride=(0, 1)))"
+                    f"stride={view_stride}))"
                 )
                 source_for_local_tile = rec.aux_view2d
             lines.append(

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -1588,6 +1588,7 @@ def _append_cute_wrapper_plan(
             (
                 f"    {tiled_mma} = cutlass.utils.blackwell_helpers.make_trivial_tiled_mma("
                 f"{input_dtype}, "
+                f"{input_dtype}, "
                 "cute.nvgpu.tcgen05.OperandMajorMode.K, "
                 "cute.nvgpu.tcgen05.OperandMajorMode.MN, "
                 f"{acc_dtype}, "

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -1371,6 +1371,8 @@ def _torch_dtype_to_cutlass(dtype: torch.dtype) -> object:
         torch.float32: cutlass.Float32,
         torch.float64: cutlass.Float64,
         torch.bfloat16: cutlass.BFloat16,
+        torch.float8_e4m3fn: cutlass.Float8E4M3FN,
+        torch.float8_e5m2: cutlass.Float8E5M2,
         # CuTe does not support i1 global-memory tensors; torch.bool is stored
         # as one byte, so pass bool tensor pointers as uint8 and let load
         # lowering convert nonzero bytes back to cutlass.Boolean registers.

--- a/test/golden/tcgen05_role_local_monolithic_4096_bf16.py.expected
+++ b/test/golden/tcgen05_role_local_monolithic_4096_bf16.py.expected
@@ -31,7 +31,7 @@ def _helion_cute_matmul_role_local_monolithic_4096_bf16(x, y, out, tma_atom_a, t
     if tcgen05_exec_active or tcgen05_epi_active:
         cute.arch.setmaxregister_increase(256)
     mma_slice_tidx = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster()) % cutlass.Int32(2)
-    tiled_mma = cutlass.utils.blackwell_helpers.make_trivial_tiled_mma(cutlass.BFloat16, cute.nvgpu.tcgen05.OperandMajorMode.K, cute.nvgpu.tcgen05.OperandMajorMode.MN, cutlass.Float32, cute.nvgpu.tcgen05.CtaGroup.TWO, (256, 256), cute.nvgpu.tcgen05.OperandSource.SMEM)
+    tiled_mma = cutlass.utils.blackwell_helpers.make_trivial_tiled_mma(cutlass.BFloat16, cutlass.BFloat16, cute.nvgpu.tcgen05.OperandMajorMode.K, cute.nvgpu.tcgen05.OperandMajorMode.MN, cutlass.Float32, cute.nvgpu.tcgen05.CtaGroup.TWO, (256, 256), cute.nvgpu.tcgen05.OperandSource.SMEM)
     thr_mma = tiled_mma.get_slice(mma_slice_tidx)
     tcgen05_cluster_layout_vmnk = cute.tiled_divide(cute.make_layout((2, 1, 1)), (tiled_mma.thr_id.shape,))
     sA_layout = cutlass.utils.blackwell_helpers.make_smem_layout_a(tiled_mma, (256, 256, 128), cutlass.BFloat16, 2)

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 
 import pytest
 import torch
+from torch.testing._internal.common_utils import instantiate_parametrized_tests
+from torch.testing._internal.common_utils import parametrize
 
 import helion
 from helion import exc
@@ -539,6 +541,49 @@ def cute_matmul_fp8_dot_float32_out(
     return out
 
 
+@helion.kernel(backend="cute")
+def cute_matmul_rowwise_scaled_tcgen05(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    bias: torch.Tensor,
+) -> torch.Tensor:
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+        acc = acc * scale_a[tile_m, :].to(torch.float32)
+        acc = acc * scale_b[:, tile_n].to(torch.float32)
+        out[tile_m, tile_n] = (acc + bias[tile_n].to(torch.float32)).to(
+            torch.bfloat16
+        )
+    return out
+
+
+@helion.kernel(backend="cute")
+def cute_matmul_rowwise_scaled_no_bias_tcgen05(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> torch.Tensor:
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+        acc = acc * scale_a[tile_m, :].to(torch.float32)
+        acc = acc * scale_b[:, tile_n].to(torch.float32)
+        out[tile_m, tile_n] = acc.to(torch.bfloat16)
+    return out
+
+
 @helion.kernel(backend="cute", static_shapes=False)
 def cute_matmul_packed_rhs_bfloat16(
     a: torch.Tensor, b: torch.Tensor, c: torch.Tensor
@@ -1012,13 +1057,88 @@ class TestCuteBackend(TestCase):
         torch.testing.assert_close(out, args[0].float() @ args[1].float())
         self.assertNotIn("cute.nvgpu.tcgen05", code)
 
-    def test_choose_mma_impl_fp8_always_universal(self) -> None:
-        # fp8 currently routes to the universal MMA atom unconditionally
-        # because the fp8 cute tcgen05 path produces sparse accumulator
-        # output (the non-TMA emission lacks the producer/consumer staged
-        # pipeline used by f16/bf16 tcgen05). Explicit
-        # HELION_CUTE_MMA_IMPL=tcgen05 raises a clear error rather than
-        # silently misbehaving.
+    def test_matmul_rowwise_scaled_tcgen05_matches_reference(self) -> None:
+        support = get_cute_mma_support()
+        if not support.tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        args = (
+            torch.randn(128, 128, device=DEVICE, dtype=torch.bfloat16),
+            torch.randn(128, 128, device=DEVICE, dtype=torch.bfloat16),
+            torch.randn(128, 1, device=DEVICE, dtype=torch.float32),
+            torch.randn(1, 128, device=DEVICE, dtype=torch.float32),
+            torch.randn(128, device=DEVICE, dtype=torch.float32),
+        )
+        with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
+            code, out = code_and_output(
+                cute_matmul_rowwise_scaled_tcgen05,
+                args,
+                block_sizes=[128, 128, 32],
+            )
+        x, y, scale_a, scale_b, bias = args
+        expected = ((x.float() @ y.float()) * scale_a * scale_b + bias).to(
+            torch.bfloat16
+        )
+        torch.testing.assert_close(out, expected, atol=1e-1, rtol=1e-2)
+        self.assertIn("cute.nvgpu.tcgen05", code)
+        self.assertIn("stride=(1, 0)", code)
+        self.assertIn("stride=(0, 1)", code)
+
+    @parametrize(
+        "shape_config",
+        (
+            ((64, 128, 64), {"block_sizes": [64, 64, 32]}),
+            ((128, 128, 128), {"block_sizes": [128, 128, 32]}),
+            ((128, 256, 256), {"block_sizes": [128, 128, 64]}),
+            (
+                (256, 256, 256),
+                {
+                    "block_sizes": [256, 256, 128],
+                    "pid_type": "persistent_interleaved",
+                    "tcgen05_cluster_m": 2,
+                },
+            ),
+        ),
+    )
+    def test_matmul_fp8_rowwise_scaled_forced_tcgen05_matches_reference(
+        self, shape_config: tuple[tuple[int, int, int], dict[str, object]]
+    ) -> None:
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8f6f4:
+            self.skipTest("tcgen05 F8F6F4 MMA is not supported on this machine")
+
+        (m, k, n), config = shape_config
+        args = (
+            torch.randn(m, k, device=DEVICE, dtype=torch.float32).to(
+                torch.float8_e4m3fn
+            ),
+            torch.randn(k, n, device=DEVICE, dtype=torch.float32).to(
+                torch.float8_e4m3fn
+            ),
+            torch.randn(m, 1, device=DEVICE, dtype=torch.float32),
+            torch.randn(1, n, device=DEVICE, dtype=torch.float32),
+            torch.randn(n, device=DEVICE, dtype=torch.float32),
+        )
+        with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
+            code, out = code_and_output(
+                cute_matmul_rowwise_scaled_tcgen05,
+                args,
+                **config,
+            )
+        x, y, scale_a, scale_b, bias = args
+        expected = ((x.float() @ y.float()) * scale_a * scale_b + bias).to(
+            torch.bfloat16
+        )
+        torch.testing.assert_close(out, expected, atol=2.0, rtol=2e-1)
+        self.assertIn("cute.nvgpu.tcgen05", code)
+        self.assertIn("cutlass.Float8E4M3FN", code)
+        self.assertIn("cutlass.BFloat16", code)
+
+    def test_choose_mma_impl_fp8_auto_universal_forced_tcgen05(self) -> None:
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8f6f4:
+            self.skipTest("tcgen05 F8F6F4 MMA is not supported on this machine")
+
         from helion._compiler.cute.cute_mma import _choose_mma_impl
 
         for dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
@@ -1035,11 +1155,62 @@ class TestCuteBackend(TestCase):
             with patch.dict(
                 os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False
             ):
-                with self.assertRaisesRegex(
-                    exc.BackendUnsupported,
-                    "tcgen05 fp8 MMA is currently disabled",
-                ):
-                    _choose_mma_impl(dtype, bm=128, bn=16, bk=32)
+                self.assertEqual(
+                    _choose_mma_impl(dtype, bm=128, bn=16, bk=32),
+                    "tcgen05",
+                )
+
+    def test_matmul_fp8_rowwise_scaled_c_input_warp_matches_reference(self) -> None:
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8f6f4:
+            self.skipTest("tcgen05 F8F6F4 MMA is not supported on this machine")
+
+        args = (
+            torch.randn(256, 256, device=DEVICE, dtype=torch.float32).to(
+                torch.float8_e4m3fn
+            ),
+            torch.randn(256, 256, device=DEVICE, dtype=torch.float32).to(
+                torch.float8_e4m3fn
+            ),
+            torch.randn(256, 1, device=DEVICE, dtype=torch.float32),
+            torch.randn(1, 256, device=DEVICE, dtype=torch.float32),
+        )
+        config = {
+            "block_sizes": [256, 256, 128],
+            "l2_groupings": [1],
+            "num_warps": 4,
+            "num_sm_multiplier": 1,
+            "pid_type": "persistent_interleaved",
+            "tcgen05_cluster_m": 2,
+            "tcgen05_ab_stages": 2,
+            "tcgen05_acc_stages": 2,
+            "tcgen05_c_stages": 2,
+            "tcgen05_num_epi_warps": 4,
+            "tcgen05_strategy": "role_local_with_scheduler",
+            "tcgen05_warp_spec_scheduler_warps": 1,
+            "tcgen05_warp_spec_c_input_warps": 1,
+            "indexing": [
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "tensor_descriptor",
+            ],
+        }
+        with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
+            code, out = code_and_output(
+                cute_matmul_rowwise_scaled_no_bias_tcgen05,
+                args,
+                **config,
+            )
+        x, y, scale_a, scale_b = args
+        expected = ((x.float() @ y.float()) * scale_a * scale_b).to(torch.bfloat16)
+        torch.testing.assert_close(out, expected, atol=2.0, rtol=2e-1)
+        self.assertIn(
+            "tcgen05_aux_pipeline = cutlass.pipeline.PipelineAsync.create(",
+            code,
+        )
+        self.assertIn("tcgen05_c_input_warp_valid", code)
+        self.assertIn("num_bits_per_copy=32", code)
 
     def test_matmul_dot_out_dtype_falls_back_from_mma(self) -> None:
         args = (
@@ -1740,3 +1911,6 @@ class TestCuteBackend(TestCase):
         torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
         self.assertIn("block=(32, 32, 1)", code)
         self.assertIn("_cute_grouped_reduce_shared_two_stage", code)
+
+
+instantiate_parametrized_tests(TestCuteBackend)

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 
 import helion
+from helion import exc
 from helion._testing import DEVICE
 from helion._testing import HALF_DTYPE
 from helion._testing import TestCase
@@ -523,6 +524,21 @@ def cute_matmul_dot_out_dtype(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     return out
 
 
+@helion.kernel(backend="cute")
+def cute_matmul_fp8_dot_float32_out(
+    x: torch.Tensor, y: torch.Tensor
+) -> torch.Tensor:
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty([m, n], dtype=torch.float32, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+        out[tile_m, tile_n] = acc
+    return out
+
+
 @helion.kernel(backend="cute", static_shapes=False)
 def cute_matmul_packed_rhs_bfloat16(
     a: torch.Tensor, b: torch.Tensor, c: torch.Tensor
@@ -980,6 +996,50 @@ class TestCuteBackend(TestCase):
             code,
         )
         self.assertIn("cutlass.pipeline.NamedBarrier(barrier_id=1", code)
+
+    def test_matmul_fp8_dot_float32_out_matches_reference(self) -> None:
+        args = (
+            torch.randn(64, 32, device=DEVICE).to(torch.float8_e4m3fn),
+            torch.randn(32, 16, device=DEVICE).to(torch.float8_e4m3fn),
+        )
+        with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "auto"}, clear=False):
+            code, out = code_and_output(
+                cute_matmul_fp8_dot_float32_out,
+                args,
+                block_sizes=[64, 16, 32],
+                num_warps=4,
+            )
+        torch.testing.assert_close(out, args[0].float() @ args[1].float())
+        self.assertNotIn("cute.nvgpu.tcgen05", code)
+
+    def test_choose_mma_impl_fp8_always_universal(self) -> None:
+        # fp8 currently routes to the universal MMA atom unconditionally
+        # because the fp8 cute tcgen05 path produces sparse accumulator
+        # output (the non-TMA emission lacks the producer/consumer staged
+        # pipeline used by f16/bf16 tcgen05). Explicit
+        # HELION_CUTE_MMA_IMPL=tcgen05 raises a clear error rather than
+        # silently misbehaving.
+        from helion._compiler.cute.cute_mma import _choose_mma_impl
+
+        for dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+            with patch.dict(
+                os.environ, {"HELION_CUTE_MMA_IMPL": "auto"}, clear=False
+            ):
+                # Regardless of shape, auto picks universal for fp8.
+                for bm, bn, bk in ((64, 8, 32), (128, 16, 32), (256, 32, 32)):
+                    self.assertEqual(
+                        _choose_mma_impl(dtype, bm=bm, bn=bn, bk=bk),
+                        "universal",
+                        f"{dtype}: bm={bm},bn={bn} should pick universal",
+                    )
+            with patch.dict(
+                os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False
+            ):
+                with self.assertRaisesRegex(
+                    exc.BackendUnsupported,
+                    "tcgen05 fp8 MMA is currently disabled",
+                ):
+                    _choose_mma_impl(dtype, bm=128, bn=16, bk=32)
 
     def test_matmul_dot_out_dtype_falls_back_from_mma(self) -> None:
         args = (

--- a/test/test_cute_fp8_support.py
+++ b/test/test_cute_fp8_support.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from helion._compiler.cute.mma_support import CuteMmaSupport
+from helion._compiler.cute.mma_support import _probe_tcgen05_f8f6f4
+from helion._compiler.cute.mma_support import get_cute_mma_support
+from helion.runtime import _torch_dtype_to_cutlass
+
+
+def test_dtype_mapping_fp8() -> None:
+    cutlass = pytest.importorskip("cutlass")
+
+    assert _torch_dtype_to_cutlass(torch.float8_e4m3fn) is cutlass.Float8E4M3FN
+    assert _torch_dtype_to_cutlass(torch.float8_e5m2) is cutlass.Float8E5M2
+
+
+def test_dtype_mapping_existing_unchanged() -> None:
+    cutlass = pytest.importorskip("cutlass")
+
+    assert _torch_dtype_to_cutlass(torch.float16) is cutlass.Float16
+    assert _torch_dtype_to_cutlass(torch.bfloat16) is cutlass.BFloat16
+    assert _torch_dtype_to_cutlass(torch.float32) is cutlass.Float32
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="probe requires CUDA",
+)
+def test_tcgen05_f8f6f4_probe_on_b200() -> None:
+    cap = torch.cuda.get_device_capability(0)
+    ok, err = _probe_tcgen05_f8f6f4()
+    if cap >= (10, 0):
+        assert ok, f"expected fp8/f6/f4 MMA on capability {cap}, got error: {err}"
+        assert err is None
+    else:
+        # Older arches may or may not support the atom depending on cutlass-dsl
+        # backend; either way the probe must not raise.
+        assert isinstance(ok, bool)
+        if not ok:
+            assert isinstance(err, str) and err
+
+
+def test_capability_dataclass_no_cuda_fields() -> None:
+    # When CUDA is unavailable, all probe fields are False and error fields populated.
+    support = CuteMmaSupport(
+        device_name=None,
+        capability=None,
+        cutlass_arch=None,
+        universal=False,
+        warp_f16bf16=False,
+        warpgroup_f16bf16=False,
+        tcgen05_f16bf16=False,
+        tcgen05_f8f6f4=False,
+        warp_error="x",
+        warpgroup_error="x",
+        tcgen05_error="x",
+        tcgen05_f8f6f4_error="x",
+    )
+    assert support.tcgen05_f8f6f4 is False
+    assert support.tcgen05_f8f6f4_error == "x"
+    # supported_impls should not list tcgen05 if nothing under it is supported.
+    assert "tcgen05" not in support.supported_impls
+
+
+def test_supported_impls_does_not_list_tcgen05_when_only_fp8_supported() -> None:
+    # The generic "tcgen05" impl is the current f16/bf16 path. The fp8 probe is
+    # a separate capability bit until fp8 codegen consumes it directly.
+    support = CuteMmaSupport(
+        device_name="X",
+        capability=(10, 0),
+        cutlass_arch="SM_100",
+        universal=True,
+        warp_f16bf16=False,
+        warpgroup_f16bf16=False,
+        tcgen05_f16bf16=False,
+        tcgen05_f8f6f4=True,
+    )
+    assert "tcgen05" not in support.supported_impls
+
+
+def test_supported_impls_lists_tcgen05_when_f16bf16_supported() -> None:
+    support = CuteMmaSupport(
+        device_name="X",
+        capability=(10, 0),
+        cutlass_arch="SM_100",
+        universal=True,
+        warp_f16bf16=False,
+        warpgroup_f16bf16=False,
+        tcgen05_f16bf16=True,
+        tcgen05_f8f6f4=False,
+    )
+    assert "tcgen05" in support.supported_impls
+
+
+def test_probe_does_not_raise_when_cutlass_missing() -> None:
+    # If cutlass.cute.nvgpu.tcgen05 cannot be imported, the probe must return
+    # (False, error_str) rather than propagating.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("cutlass.cute.nvgpu") or name == "cutlass":
+            raise ImportError(f"simulated missing module: {name}")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=fake_import):
+        ok, err = _probe_tcgen05_f8f6f4()
+
+    assert ok is False
+    assert isinstance(err, str) and "ImportError" in err
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="aggregate probe requires CUDA",
+)
+def test_get_cute_mma_support_populates_fp8_field() -> None:
+    support = get_cute_mma_support()
+    cap = torch.cuda.get_device_capability(0)
+    # Field is always present (no AttributeError) on supported builds.
+    assert hasattr(support, "tcgen05_f8f6f4")
+    assert hasattr(support, "tcgen05_f8f6f4_error")
+    if cap >= (10, 0) and support.cutlass_arch is not None:
+        assert support.tcgen05_f8f6f4 is True

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -4797,6 +4797,60 @@ class TestCuteLowerings(unittest.TestCase):
         self.assertGreaterEqual(view_pos, 0)
         self.assertGreater(load_pos, view_pos)
 
+    def test_tcgen05_fused_rowwise_scale_codegen_marker(self) -> None:
+        """Explicit rowwise scaled_mm scales emit stride-0 views on the
+        non-data axis before the aux load pipeline:
+
+            scale_a[M, 1] -> stride=(1, 0)
+            scale_b[1, N] -> stride=(0, 1)
+        """
+
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_scales(
+            x: torch.Tensor,
+            y: torch.Tensor,
+            scale_a: torch.Tensor,
+            scale_b: torch.Tensor,
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                acc = acc * scale_a[tile_m, :].to(torch.float32)
+                acc = acc * scale_b[:, tile_n].to(torch.float32)
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        x = torch.randn(128, 128, dtype=torch.bfloat16, device=DEVICE)
+        y = torch.randn(128, 128, dtype=torch.bfloat16, device=DEVICE)
+        scale_a = torch.randn(128, 1, dtype=torch.float32, device=DEVICE)
+        scale_b = torch.randn(1, 128, dtype=torch.float32, device=DEVICE)
+        with patch_cute_mma_support():
+            bound = cute_matmul_scales.bind((x, y, scale_a, scale_b))
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            cfg = _make_tcgen05_persistent_config(
+                block_sizes=[128, 128, 32],
+                pid_type="persistent_interleaved",
+            )
+            bound.set_config(cfg)
+            code = bound.to_triton_code(cfg)
+        self.assertIn("tcgen05_aux_view2d_0", code)
+        self.assertIn("tcgen05_aux_view2d_1", code)
+        self.assertIn("stride=(1, 0)", code)
+        self.assertIn("stride=(0, 1)", code)
+        self.assertIn("tcgen05_aux_tile_0 = cute.local_tile(tcgen05_aux_view2d_0", code)
+        self.assertIn("tcgen05_aux_tile_1 = cute.local_tile(tcgen05_aux_view2d_1", code)
+        self.assertIn("tcgen05_aux_loaded_0", code)
+        self.assertIn("tcgen05_aux_loaded_1", code)
+
     def test_tcgen05_fused_bias_broadcast_rejects_non_contiguous(self) -> None:
         """Reject rank-1 broadcast aux loads whose underlying tensor
         is non-contiguous (stride != 1).
@@ -10972,6 +11026,60 @@ class TestCuteTcgen05AuxTensorWalker(unittest.TestCase):
         self.assertEqual(descriptor.host_tensor_val.shape, torch.Size([4096]))
         self.assertEqual(descriptor.host_tensor_val.dtype, torch.bfloat16)
 
+    def test_walker_discovers_explicit_rowwise_scale_aux(self) -> None:
+        """Rowwise scaled_mm scale loads register colvec and rowvec aux
+        descriptors:
+
+            scale_a[tile_m, :] -> (BM, 1), broadcast_axis == 0
+            scale_b[:, tile_n] -> (1, BN), broadcast_axis == 1
+        """
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_scales(
+            x: torch.Tensor,
+            y: torch.Tensor,
+            scale_a: torch.Tensor,
+            scale_b: torch.Tensor,
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                acc = acc * scale_a[tile_m, :].to(torch.float32)
+                acc = acc * scale_b[:, tile_n].to(torch.float32)
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 1], device=DEVICE, dtype=torch.float32),
+            torch.empty([1, 4096], device=DEVICE, dtype=torch.float32),
+        )
+        config = helion.Config(
+            block_sizes=[256, 256, 128],
+            l2_groupings=[1],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+        )
+        plans, _ = self._bind_and_capture_plans(cute_matmul_scales, args, config)
+        self.assertEqual(len(plans), 1, msg=f"plans={len(plans)}")
+        descriptors = plans[0].aux_tensor_descriptors
+        self.assertEqual(len(descriptors), 2, msg=f"descriptors={descriptors!r}")
+        self.assertEqual(descriptors[0].broadcast_axis, 0)
+        self.assertEqual(descriptors[0].host_tensor_val.shape, torch.Size([4096, 1]))
+        self.assertEqual(descriptors[0].host_tensor_val.dtype, torch.float32)
+        self.assertEqual(descriptors[1].broadcast_axis, 1)
+        self.assertEqual(descriptors[1].host_tensor_val.shape, torch.Size([1, 4096]))
+        self.assertEqual(descriptors[1].host_tensor_val.dtype, torch.float32)
+
     def test_walker_discovers_two_aux_steps_in_chain(self) -> None:
         """A chain with two aux operands (``acc + residual + bias``)
         registers two descriptors per matmul anchor — one per aux
@@ -13887,6 +13995,8 @@ class TestPersistentLoopSplitter(unittest.TestCase):
                     "    mask_2 = indices_2 < 16\n"
                     "    load = cutlass.BFloat16(0)"
                 ),
+                self._stmt("load_fp8 = cutlass.Float8E4M3FN(0)"),
+                self._stmt("load_fp8_e5m2 = cutlass.Float8E5M2(0)"),
             ],
         )
 

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -10034,6 +10034,29 @@ class TestCuteLowerings(unittest.TestCase):
                     ),
                     "universal",
                 )
+            with patch.dict(
+                "os.environ", {"HELION_CUTE_MMA_IMPL": "auto"}, clear=False
+            ):
+                # fp8 always routes to universal (fp8 tcgen05 is disabled).
+                for bm, bn, bk in (
+                    (64, 16, 32),
+                    (128, 16, 32),
+                    (256, 32, 32),
+                ):
+                    self.assertEqual(
+                        _choose_mma_impl(torch.float8_e4m3fn, bm=bm, bn=bn, bk=bk),
+                        "universal",
+                    )
+            with (
+                patch.dict(
+                    "os.environ", {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False
+                ),
+            ):
+                with self.assertRaisesRegex(
+                    exc.BackendUnsupported,
+                    "tcgen05 fp8 MMA is currently disabled",
+                ):
+                    _choose_mma_impl(torch.float8_e4m3fn, bm=128, bn=16, bk=32)
 
     def test_tcgen05_thread_counts_match_participants_and_cta(self) -> None:
         # ``_tcgen05_epi_warp_count`` takes a ``Tcgen05WarpSpec`` (G2-B);


### PR DESCRIPTION
# scaled_mm benchmark summary

Device: NVIDIA B200

Baseline: `torch._scaled_mm(a, b_torch, scale_a, scale_b, out_dtype=torch.bfloat16)`

Helion variants:

- CuTe: `@helion.kernel(backend="cute")`, `HELION_CUTE_MMA_IMPL=tcgen05`
- Triton: `@helion.kernel(backend="triton")`

The rows below were collected across several TritonBench invocations while
expanding the shape set, so treat small differences as benchmark noise. Accuracy
was `1` for every Helion result in these runs.

| Shape `(M, K, N)` | Torch `_scaled_mm` ms | Helion CuTe ms | CuTe / Torch | Helion Triton ms | Triton / Torch |
|---:|---:|---:|---:|---:|---:|
| `(64, 128, 64)` | 0.011104 | 0.123584 | 0.0899x | 0.008224 | 1.3502x |
| `(128, 128, 128)` | 0.011168 | 0.125536 | 0.0890x | 0.010240 | 1.0906x |
| `(128, 256, 256)` | 0.008224 | 0.121856 | 0.0675x | 0.012288 | 0.6693x |
| `(256, 256, 256)` | 0.008192 | 0.125280 | 0.0654x | 0.010240 | 0.8000x |
| `(512, 1024, 512)` | 0.010208 | 0.126112 | 0.0809x | 0.018432 | 0.5538x |
| `(1024, 1024, 1024)` | 0.010240 | 0.127008 | 0.0806x | 0.018432 | 0.5556x |
| `(2048, 2048, 1024)` | 0.012320 | 0.131168 | 0.0939x | 0.028672 | 0.4297x |
| `(4096, 4096, 4096)` | 0.065536 | 0.146432 | 0.4476x | 0.174080 | 0.3765x |
| `(8192, 8192, 8192)` | 0.671968 | 1.019968 | 0.6588x | 1.304736 | 0.5150x |
| `(16384, 8192, 8192)` | 1.366080 | 2.599872 | 0.5254x | 2.851616 | 0.4791x |
| `(16384, 16384, 16384)` | 6.197152 | 10.235936 | 0.6054x | 11.468672 | 0.5404x |
| `(32768, 8192, 8192)` | 3.120224 | 5.325824 | 0.5859x | 6.303776 | 0.4950x |
| `(32768, 16384, 8192)` | 6.748160 | 10.753920 | 0.6275x | 13.382656 | 0.5042x |

## Takeaways

- Helion Triton is best for the two smallest shapes tested, where it beats
  `torch._scaled_mm`.
- Helion CuTe has an approximately 0.12 ms fixed floor on small and mid-size
  shapes, so it is much slower there despite using the tcgen05 path.
- For large shapes, CuTe becomes the better Helion backend, but it remains
  slower than `torch._scaled_mm`. The best large-shape CuTe result here is
  about 0.66x of torch.
- Helion Triton avoids the CuTe fixed floor, but its generated kernel scales
  worse than CuTe on large GEMMs.

## Triton Autotune Results

This run kept the CuTe variant on the fixed direct configs and changed the
Helion Triton variant to call `bound.autotune(..., force=False)`.

Command:

```bash
HELION_CUTE_MMA_IMPL=tcgen05 HELION_AUTOTUNE_EFFORT=quick \
  uv run --no-sync python benchmarks/run.py \
  --kernel scaled_mm \
  --metrics latency,speedup,accuracy \
  --input-id 0 \
  --num-inputs 13 \
  --output agent_space/scaled_mm_triton_autotuned_all_results.json
```

CuTe autotune was attempted first on `(64, 128, 64)`, but it did not finish the
first generation after several minutes. I stopped that run and autotuned Triton
only.

| Shape `(M, K, N)` | Torch `_scaled_mm` ms | Fixed CuTe ms | Autotuned Triton ms | Autotuned Triton / Torch |
|---:|---:|---:|---:|---:|
| `(64, 128, 64)` | 0.011104 | 0.124576 | 0.006240 | 1.7795x |
| `(128, 128, 128)` | 0.011136 | 0.128544 | 0.006304 | 1.7665x |
| `(128, 256, 256)` | 0.008288 | 0.125536 | 0.006368 | 1.3015x |
| `(256, 256, 256)` | 0.008288 | 0.125440 | 0.008192 | 1.0117x |
| `(512, 1024, 512)` | 0.010240 | 0.129120 | 0.012288 | 0.8333x |
| `(1024, 1024, 1024)` | 0.010240 | 0.129760 | 0.012448 | 0.8226x |
| `(2048, 2048, 1024)` | 0.012448 | 0.130336 | 0.024640 | 0.5052x |
| `(4096, 4096, 4096)` | 0.064544 | 0.145440 | 0.125920 | 0.5126x |
| `(8192, 8192, 8192)` | 0.539712 | 1.036288 | 1.399808 | 0.3856x |
| `(16384, 8192, 8192)` | 1.474528 | 2.667424 | 2.827296 | 0.5215x |
| `(16384, 16384, 16384)` | 5.756960 | 10.235776 | 17.075136 | 0.3372x |
| `(32768, 8192, 8192)` | 3.554336 | 5.070752 | 4.426688 | 0.8029x |
| `(32768, 16384, 8192)` | 6.279104 | 10.670080 | 9.709632 | 0.6467x |

Autotuned Triton takeaways:

- Autotune makes Triton clearly faster than `torch._scaled_mm` for small shapes
  through `(256, 256, 256)`.
- For large square shapes, Triton autotune still lags both torch and fixed CuTe.
- For the tall large shapes, autotuned Triton beats fixed CuTe but remains slower
  than torch.
- Several candidate configs failed in the Triton compiler, mostly in
  warp-specialization or matmul-acceleration passes. Helion skipped those and
  continued tuning.

## Commands used

Small shapes:

```bash
HELION_CUTE_MMA_IMPL=tcgen05 uv run --no-sync python benchmarks/run.py \
  --kernel scaled_mm \
  --metrics latency,speedup,accuracy \
  --input-id 0 \
  --num-inputs 2 \
  --output agent_space/scaled_mm_triton_backend_smoke.json
```

Mid shapes:

```bash
HELION_CUTE_MMA_IMPL=tcgen05 uv run --no-sync python benchmarks/run.py \
  --kernel scaled_mm \
  --metrics latency,speedup,accuracy \
  --input-id 2 \
  --num-inputs 5 \
  --output agent_space/scaled_mm_triton_backend_mid_results.json
```

Large shapes:

```bash
HELION_CUTE_MMA_IMPL=tcgen05 uv run --no-sync python benchmarks/run.py \
  --kernel scaled_mm \
  --metrics latency,speedup,accuracy \
  --input-id 7 \
  --num-inputs 3 \
  --output agent_space/scaled_mm_triton_backend_large_results.json
```

Very large shapes:

```bash
HELION_CUTE_MMA_IMPL=tcgen05 uv run --no-sync python benchmarks/run.py \
  --kernel scaled_mm \
  --metrics latency,speedup,accuracy \
  --input-id 10 \
  --num-inputs 3 \
  --output agent_space/scaled_mm_very_large_results.json
```
