### PR TITLE
Add CuTe NVFP4 GEMV example

### DIFF
--- a/examples/nvfp4_gemv.py
+++ b/examples/nvfp4_gemv.py
@@ -1,0 +1,921 @@
+"""
+Fast NVFP4 GEMV Kernels
+=======================
+This example implements low-latency NVFP4 GEMV kernels for decode-style
+batch-size-1 inference on Blackwell GPUs.  The kernels target weights stored as
+packed E2M1 bytes with E4M3 per-16-value scales in PyTorch's SWIZZLE_32_4_4
+layout.
+
+Two variants are provided:
+
+* NVFP4 weights with BF16 input.
+* NVFP4 weights with NVFP4 input.
+"""
+
+# %%
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import TypeAlias
+from typing import cast
+
+import cutlass
+from cutlass import Int32
+from cutlass._mlir.dialects import llvm
+import cutlass.cute as cute
+from cutlass.cute.arch.nvvm_wrappers import _normalize_ptr
+from cutlass.cute.typing import Float32
+from cutlass.cute.typing import Pointer as CutePointer
+from cutlass.cute.typing import Tensor as CuteTensor
+from cutlass.cutlass_dsl import T
+from cutlass.cutlass_dsl import dsl_user_op
+import torch
+from torch import Tensor
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import run_example
+import helion.language as hl
+from helion.runtime import default_cute_launcher
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from cutlass._mlir import ir
+
+Fp4WordValues: TypeAlias = tuple[
+    Tensor,
+    Tensor,
+    Tensor,
+    Tensor,
+    Tensor,
+    Tensor,
+    Tensor,
+    Tensor,
+]
+
+BF16IN_CONFIG = helion.Config(
+    block_sizes=[1],
+    indexing=["pointer"] * 8,
+    load_eviction_policies=["first", "last", "last", "last", "last", "first"],
+    num_threads=[1],
+    num_warps=1,
+    num_stages=1,
+    pid_type="flat",
+    range_warp_specializes=[None],
+)
+
+FP4IN_CONFIG = helion.Config(
+    block_sizes=[1],
+    indexing=["pointer"] * 5,
+    load_eviction_policies=["first", "last", "", "last"],
+    num_threads=[1],
+    num_warps=1,
+    num_stages=3,
+    pid_type="flat",
+    range_warp_specializes=[None],
+)
+
+
+def _ceil_div(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def _round_up(a: int, b: int) -> int:
+    return _ceil_div(a, b) * b
+
+
+def swizzled_scale_numel(rows: int, cols: int) -> int:
+    return _round_up(rows, 128) * _round_up(cols, 4)
+
+
+def swizzled_scale_offsets(row: Tensor, col: Tensor, cols: int) -> Tensor:
+    num_col_tiles = _ceil_div(cols, 4)
+    tile_offset = ((row // 128) * num_col_tiles + col // 4) * 512
+    return tile_offset + (row % 32) * 16 + ((row % 128) // 32) * 4 + col % 4
+
+
+def swizzle_fp8_scales(scales: Tensor) -> Tensor:
+    """Convert logical row-major block scales to PyTorch's SWIZZLE_32_4_4 layout."""
+    if scales.dim() == 1:
+        logical_scales = scales.reshape(1, scales.shape[0])
+    elif scales.dim() == 2:
+        logical_scales = scales
+    else:
+        raise ValueError(f"expected 1D or 2D scales, got {scales.dim()}D")
+
+    rows, cols = logical_scales.shape
+    out = torch.zeros(
+        swizzled_scale_numel(rows, cols),
+        device=logical_scales.device,
+        dtype=logical_scales.dtype,
+    )
+    row = torch.arange(rows, device=logical_scales.device, dtype=torch.int64)[:, None]
+    col = torch.arange(cols, device=logical_scales.device, dtype=torch.int64)[None, :]
+    out[swizzled_scale_offsets(row, col, cols).reshape(-1)] = logical_scales.reshape(-1)
+    return out
+
+
+def unswizzle_fp8_scales(scales: Tensor, rows: int, cols: int) -> Tensor:
+    row = torch.arange(rows, device=scales.device, dtype=torch.int64)[:, None]
+    col = torch.arange(cols, device=scales.device, dtype=torch.int64)[None, :]
+    return scales.reshape(-1)[swizzled_scale_offsets(row, col, cols)]
+
+
+def _check_swizzled_scales(
+    name: str,
+    scales: Tensor,
+    rows: int,
+    cols: int,
+) -> None:
+    expected = swizzled_scale_numel(rows, cols)
+    if scales.numel() != expected:
+        raise ValueError(
+            f"{name} must contain {expected} SWIZZLE_32_4_4 scale values "
+            f"for logical shape ({rows}, {cols}); got {scales.numel()}"
+        )
+
+
+if cute is not None and dsl_user_op is not None:
+
+    def _fast_swizzled_scale_offset(
+        row: Int32,
+        col: Int32,
+        scale_cols: int,
+    ) -> Int32:
+        num_col_tiles = (scale_cols + 3) // 4
+        tile = (row >> Int32(7)) * Int32(num_col_tiles) + (col >> Int32(2))
+        return (
+            tile * Int32(512)
+            + (row & Int32(31)) * Int32(16)
+            + ((row >> Int32(5)) & Int32(3)) * Int32(4)
+            + (col & Int32(3))
+        )
+
+    @dsl_user_op
+    def _fast_bf16_16bytes_dual_ptr(
+        acc: Float32,
+        weight_ptr: CutePointer,
+        x_ptr: CutePointer,
+        scale_ptr: CutePointer,
+        *,
+        loc: ir.Location | None = None,
+        ip: ir.InsertionPoint | None = None,
+    ) -> Float32:
+        acc_ir = Float32(acc).ir_value(loc=loc, ip=ip)
+        weight_ir = _normalize_ptr(weight_ptr, loc=loc, ip=ip)
+        x_ir = _normalize_ptr(x_ptr, loc=loc, ip=ip)
+        scale_ir = _normalize_ptr(scale_ptr, loc=loc, ip=ip)
+        result = llvm.inline_asm(
+            T.f32(),
+            [acc_ir, weight_ir, x_ir, scale_ir],
+            """
+            {
+              .reg .b8 wb0, wb1, wb2, wb3, wb4, wb5, wb6, wb7;
+              .reg .b16 scales, sf0, sf1, b0, b1, h0, h1, lo, hi, sumh;
+              .reg .b32 wr0, wr1, wr2, wr3;
+              .reg .b32 xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7;
+              .reg .b32 yr0, yr1, yr2, yr3, yr4, yr5, yr6, yr7;
+              .reg .b32 w0, w1, w2, w3, w4, w5, w6, w7;
+              .reg .b32 z0, z1, z2, z3, z4, z5, z6, z7;
+              .reg .b32 x0, x1, x2, x3, x4, x5, x6, x7;
+              .reg .b32 y0, y1, y2, y3, y4, y5, y6, y7;
+              .reg .b32 prod0, prod1, sf2;
+              mov.f32 $0, $1;
+              ld.global.L1::no_allocate.v4.u32 {wr0, wr1, wr2, wr3}, [$2];
+              ld.global.L1::evict_last.L2::evict_last.v8.u32
+                {xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7}, [$3];
+              ld.global.L1::evict_last.L2::evict_last.v8.u32
+                {yr0, yr1, yr2, yr3, yr4, yr5, yr6, yr7}, [$3+32];
+              ld.global.L1::no_allocate.u16 scales, [$4];
+              cvt.rn.f16x2.e4m3x2 sf2, scales;
+              mov.b32 {sf0, sf1}, sf2;
+              mov.b32 {wb0, wb1, wb2, wb3}, wr0;
+              cvt.rn.f16x2.e2m1x2 w0, wb0; cvt.rn.f16x2.e2m1x2 w1, wb1;
+              cvt.rn.f16x2.e2m1x2 w2, wb2; cvt.rn.f16x2.e2m1x2 w3, wb3;
+              mov.b32 {wb4, wb5, wb6, wb7}, wr1;
+              cvt.rn.f16x2.e2m1x2 w4, wb4; cvt.rn.f16x2.e2m1x2 w5, wb5;
+              cvt.rn.f16x2.e2m1x2 w6, wb6; cvt.rn.f16x2.e2m1x2 w7, wb7;
+              mov.b32 {wb0, wb1, wb2, wb3}, wr2;
+              cvt.rn.f16x2.e2m1x2 z0, wb0; cvt.rn.f16x2.e2m1x2 z1, wb1;
+              cvt.rn.f16x2.e2m1x2 z2, wb2; cvt.rn.f16x2.e2m1x2 z3, wb3;
+              mov.b32 {wb4, wb5, wb6, wb7}, wr3;
+              cvt.rn.f16x2.e2m1x2 z4, wb4; cvt.rn.f16x2.e2m1x2 z5, wb5;
+              cvt.rn.f16x2.e2m1x2 z6, wb6; cvt.rn.f16x2.e2m1x2 z7, wb7;
+              mov.b32 {b0, b1}, xr0; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 x0, {h0, h1};
+              mov.b32 {b0, b1}, xr1; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 x1, {h0, h1};
+              mov.b32 {b0, b1}, xr2; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 x2, {h0, h1};
+              mov.b32 {b0, b1}, xr3; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 x3, {h0, h1};
+              mov.b32 {b0, b1}, xr4; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 x4, {h0, h1};
+              mov.b32 {b0, b1}, xr5; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 x5, {h0, h1};
+              mov.b32 {b0, b1}, xr6; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 x6, {h0, h1};
+              mov.b32 {b0, b1}, xr7; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 x7, {h0, h1};
+              mov.b32 {b0, b1}, yr0; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 y0, {h0, h1};
+              mov.b32 {b0, b1}, yr1; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 y1, {h0, h1};
+              mov.b32 {b0, b1}, yr2; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 y2, {h0, h1};
+              mov.b32 {b0, b1}, yr3; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 y3, {h0, h1};
+              mov.b32 {b0, b1}, yr4; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 y4, {h0, h1};
+              mov.b32 {b0, b1}, yr5; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 y5, {h0, h1};
+              mov.b32 {b0, b1}, yr6; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 y6, {h0, h1};
+              mov.b32 {b0, b1}, yr7; cvt.rn.f16.bf16 h0, b0; cvt.rn.f16.bf16 h1, b1; mov.b32 y7, {h0, h1};
+              mul.rn.f16x2 prod0, w0, x0;   mul.rn.f16x2 prod1, z0, y0;
+              fma.rn.f16x2 prod0, w1, x1, prod0;   fma.rn.f16x2 prod1, z1, y1, prod1;
+              fma.rn.f16x2 prod0, w2, x2, prod0;   fma.rn.f16x2 prod1, z2, y2, prod1;
+              fma.rn.f16x2 prod0, w3, x3, prod0;   fma.rn.f16x2 prod1, z3, y3, prod1;
+              fma.rn.f16x2 prod0, w4, x4, prod0;   fma.rn.f16x2 prod1, z4, y4, prod1;
+              fma.rn.f16x2 prod0, w5, x5, prod0;   fma.rn.f16x2 prod1, z5, y5, prod1;
+              fma.rn.f16x2 prod0, w6, x6, prod0;   fma.rn.f16x2 prod1, z6, y6, prod1;
+              fma.rn.f16x2 prod0, w7, x7, prod0;   fma.rn.f16x2 prod1, z7, y7, prod1;
+              mov.b32 {lo, hi}, prod0; add.rn.f16 sumh, lo, hi;
+              fma.rn.f32.f16 $0, sumh, sf0, $0;
+              mov.b32 {lo, hi}, prod1; add.rn.f16 sumh, lo, hi;
+              fma.rn.f32.f16 $0, sumh, sf1, $0;
+            }
+            """,
+            "=f,f,l,l,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+        return Float32(result)
+
+    @dsl_user_op
+    def _fast_fp4_32bytes_ptr(
+        acc: Float32,
+        weight_ptr: CutePointer,
+        x_ptr: CutePointer,
+        w_scale_ptr: CutePointer,
+        x_scale_ptr: CutePointer,
+        *,
+        loc: ir.Location | None = None,
+        ip: ir.InsertionPoint | None = None,
+    ) -> Float32:
+        acc_ir = Float32(acc).ir_value(loc=loc, ip=ip)
+        weight_ir = _normalize_ptr(weight_ptr, loc=loc, ip=ip)
+        x_ir = _normalize_ptr(x_ptr, loc=loc, ip=ip)
+        w_scale_ir = _normalize_ptr(w_scale_ptr, loc=loc, ip=ip)
+        x_scale_ir = _normalize_ptr(x_scale_ptr, loc=loc, ip=ip)
+        result = llvm.inline_asm(
+            T.f32(),
+            [acc_ir, weight_ir, x_ir, w_scale_ir, x_scale_ir],
+            """
+            {
+              .reg .b8 b0, b1, b2, b3, b4, b5, b6, b7;
+              .reg .b16 wsc0, wsc1, xsc0, xsc1, sf0, sf1, lo, hi, sumh;
+              .reg .b32 wr0, wr1, wr2, wr3, wr4, wr5, wr6, wr7;
+              .reg .b32 xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7;
+              .reg .b32 w0, w1, w2, w3, w4, w5, w6, w7;
+              .reg .b32 x0, x1, x2, x3, x4, x5, x6, x7;
+              .reg .b32 prod, wsf2, xsf2, sf2;
+              mov.f32 $0, $1;
+              ld.global.L1::no_allocate.L2::evict_first.v8.b32
+                {wr0, wr1, wr2, wr3, wr4, wr5, wr6, wr7}, [$2];
+              ld.global.L1::evict_last.L2::evict_last.v8.b32
+                {xr0, xr1, xr2, xr3, xr4, xr5, xr6, xr7}, [$3];
+              ld.global.L1::no_allocate.v2.b16 {wsc0, wsc1}, [$4];
+              ld.global.L1::evict_last.v2.b16 {xsc0, xsc1}, [$5];
+              cvt.rn.f16x2.e4m3x2 wsf2, wsc0;
+              cvt.rn.f16x2.e4m3x2 xsf2, xsc0;
+              mul.rn.f16x2 sf2, wsf2, xsf2;
+              mov.b32 {sf0, sf1}, sf2;
+              mov.b32 {b0, b1, b2, b3}, wr0;
+              mov.b32 {b4, b5, b6, b7}, wr1;
+              cvt.rn.f16x2.e2m1x2 w0, b0; cvt.rn.f16x2.e2m1x2 w1, b1;
+              cvt.rn.f16x2.e2m1x2 w2, b2; cvt.rn.f16x2.e2m1x2 w3, b3;
+              cvt.rn.f16x2.e2m1x2 w4, b4; cvt.rn.f16x2.e2m1x2 w5, b5;
+              cvt.rn.f16x2.e2m1x2 w6, b6; cvt.rn.f16x2.e2m1x2 w7, b7;
+              mov.b32 {b0, b1, b2, b3}, xr0;
+              mov.b32 {b4, b5, b6, b7}, xr1;
+              cvt.rn.f16x2.e2m1x2 x0, b0; cvt.rn.f16x2.e2m1x2 x1, b1;
+              cvt.rn.f16x2.e2m1x2 x2, b2; cvt.rn.f16x2.e2m1x2 x3, b3;
+              cvt.rn.f16x2.e2m1x2 x4, b4; cvt.rn.f16x2.e2m1x2 x5, b5;
+              cvt.rn.f16x2.e2m1x2 x6, b6; cvt.rn.f16x2.e2m1x2 x7, b7;
+              mul.rn.f16x2 prod, w0, x0; fma.rn.f16x2 prod, w1, x1, prod;
+              fma.rn.f16x2 prod, w2, x2, prod; fma.rn.f16x2 prod, w3, x3, prod;
+              fma.rn.f16x2 prod, w4, x4, prod; fma.rn.f16x2 prod, w5, x5, prod;
+              fma.rn.f16x2 prod, w6, x6, prod; fma.rn.f16x2 prod, w7, x7, prod;
+              mov.b32 {lo, hi}, prod; add.rn.f16 sumh, lo, hi;
+              fma.rn.f32.f16 $0, sumh, sf0, $0;
+              mov.b32 {b0, b1, b2, b3}, wr2;
+              mov.b32 {b4, b5, b6, b7}, wr3;
+              cvt.rn.f16x2.e2m1x2 w0, b0; cvt.rn.f16x2.e2m1x2 w1, b1;
+              cvt.rn.f16x2.e2m1x2 w2, b2; cvt.rn.f16x2.e2m1x2 w3, b3;
+              cvt.rn.f16x2.e2m1x2 w4, b4; cvt.rn.f16x2.e2m1x2 w5, b5;
+              cvt.rn.f16x2.e2m1x2 w6, b6; cvt.rn.f16x2.e2m1x2 w7, b7;
+              mov.b32 {b0, b1, b2, b3}, xr2;
+              mov.b32 {b4, b5, b6, b7}, xr3;
+              cvt.rn.f16x2.e2m1x2 x0, b0; cvt.rn.f16x2.e2m1x2 x1, b1;
+              cvt.rn.f16x2.e2m1x2 x2, b2; cvt.rn.f16x2.e2m1x2 x3, b3;
+              cvt.rn.f16x2.e2m1x2 x4, b4; cvt.rn.f16x2.e2m1x2 x5, b5;
+              cvt.rn.f16x2.e2m1x2 x6, b6; cvt.rn.f16x2.e2m1x2 x7, b7;
+              mul.rn.f16x2 prod, w0, x0; fma.rn.f16x2 prod, w1, x1, prod;
+              fma.rn.f16x2 prod, w2, x2, prod; fma.rn.f16x2 prod, w3, x3, prod;
+              fma.rn.f16x2 prod, w4, x4, prod; fma.rn.f16x2 prod, w5, x5, prod;
+              fma.rn.f16x2 prod, w6, x6, prod; fma.rn.f16x2 prod, w7, x7, prod;
+              mov.b32 {lo, hi}, prod; add.rn.f16 sumh, lo, hi;
+              fma.rn.f32.f16 $0, sumh, sf1, $0;
+              cvt.rn.f16x2.e4m3x2 wsf2, wsc1;
+              cvt.rn.f16x2.e4m3x2 xsf2, xsc1;
+              mul.rn.f16x2 sf2, wsf2, xsf2;
+              mov.b32 {sf0, sf1}, sf2;
+              mov.b32 {b0, b1, b2, b3}, wr4;
+              mov.b32 {b4, b5, b6, b7}, wr5;
+              cvt.rn.f16x2.e2m1x2 w0, b0; cvt.rn.f16x2.e2m1x2 w1, b1;
+              cvt.rn.f16x2.e2m1x2 w2, b2; cvt.rn.f16x2.e2m1x2 w3, b3;
+              cvt.rn.f16x2.e2m1x2 w4, b4; cvt.rn.f16x2.e2m1x2 w5, b5;
+              cvt.rn.f16x2.e2m1x2 w6, b6; cvt.rn.f16x2.e2m1x2 w7, b7;
+              mov.b32 {b0, b1, b2, b3}, xr4;
+              mov.b32 {b4, b5, b6, b7}, xr5;
+              cvt.rn.f16x2.e2m1x2 x0, b0; cvt.rn.f16x2.e2m1x2 x1, b1;
+              cvt.rn.f16x2.e2m1x2 x2, b2; cvt.rn.f16x2.e2m1x2 x3, b3;
+              cvt.rn.f16x2.e2m1x2 x4, b4; cvt.rn.f16x2.e2m1x2 x5, b5;
+              cvt.rn.f16x2.e2m1x2 x6, b6; cvt.rn.f16x2.e2m1x2 x7, b7;
+              mul.rn.f16x2 prod, w0, x0; fma.rn.f16x2 prod, w1, x1, prod;
+              fma.rn.f16x2 prod, w2, x2, prod; fma.rn.f16x2 prod, w3, x3, prod;
+              fma.rn.f16x2 prod, w4, x4, prod; fma.rn.f16x2 prod, w5, x5, prod;
+              fma.rn.f16x2 prod, w6, x6, prod; fma.rn.f16x2 prod, w7, x7, prod;
+              mov.b32 {lo, hi}, prod; add.rn.f16 sumh, lo, hi;
+              fma.rn.f32.f16 $0, sumh, sf0, $0;
+              mov.b32 {b0, b1, b2, b3}, wr6;
+              mov.b32 {b4, b5, b6, b7}, wr7;
+              cvt.rn.f16x2.e2m1x2 w0, b0; cvt.rn.f16x2.e2m1x2 w1, b1;
+              cvt.rn.f16x2.e2m1x2 w2, b2; cvt.rn.f16x2.e2m1x2 w3, b3;
+              cvt.rn.f16x2.e2m1x2 w4, b4; cvt.rn.f16x2.e2m1x2 w5, b5;
+              cvt.rn.f16x2.e2m1x2 w6, b6; cvt.rn.f16x2.e2m1x2 w7, b7;
+              mov.b32 {b0, b1, b2, b3}, xr6;
+              mov.b32 {b4, b5, b6, b7}, xr7;
+              cvt.rn.f16x2.e2m1x2 x0, b0; cvt.rn.f16x2.e2m1x2 x1, b1;
+              cvt.rn.f16x2.e2m1x2 x2, b2; cvt.rn.f16x2.e2m1x2 x3, b3;
+              cvt.rn.f16x2.e2m1x2 x4, b4; cvt.rn.f16x2.e2m1x2 x5, b5;
+              cvt.rn.f16x2.e2m1x2 x6, b6; cvt.rn.f16x2.e2m1x2 x7, b7;
+              mul.rn.f16x2 prod, w0, x0; fma.rn.f16x2 prod, w1, x1, prod;
+              fma.rn.f16x2 prod, w2, x2, prod; fma.rn.f16x2 prod, w3, x3, prod;
+              fma.rn.f16x2 prod, w4, x4, prod; fma.rn.f16x2 prod, w5, x5, prod;
+              fma.rn.f16x2 prod, w6, x6, prod; fma.rn.f16x2 prod, w7, x7, prod;
+              mov.b32 {lo, hi}, prod; add.rn.f16 sumh, lo, hi;
+              fma.rn.f32.f16 $0, sumh, sf1, $0;
+            }
+            """,
+            "=f,f,l,l,l,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+        return Float32(result)
+
+    @cute.kernel
+    def _fast_nvfp4_gemv_bf16in_kernel(
+        weight: CuteTensor,
+        x: CuteTensor,
+        weight_scale: CuteTensor,
+        out: CuteTensor,
+        alpha: Float32,
+        k_bytes: cutlass.Constexpr[int],
+    ) -> None:
+        tid_x, _, _ = cute.arch.thread_idx()
+        row, _, _ = cute.arch.block_idx()
+        tid = Int32(tid_x)
+        smem = cute.arch.alloc_smem(Float32, 128, alignment=16)
+        partial = Float32(0.0)
+        k_bytes_i32 = Int32(k_bytes)  # pyrefly: ignore[bad-argument-type]
+        scale_cols = k_bytes // 8  # pyrefly: ignore[unsupported-operation]
+        weight_row_ptr = weight.iterator + row * k_bytes_i32
+        thread_k_base = tid * Int32(16)
+        thread_scale_base = tid * Int32(2)
+        num_iters = k_bytes // 2048  # pyrefly: ignore[unsupported-operation]
+        for iter_k in cutlass.range(num_iters, unroll_full=True):
+            k_tile_base = Int32(iter_k * 2048) + thread_k_base
+            scale_tile_base = Int32(iter_k * 256) + thread_scale_base
+            scale_offset = _fast_swizzled_scale_offset(
+                row,
+                scale_tile_base,
+                scale_cols,
+            )
+            partial = _fast_bf16_16bytes_dual_ptr(
+                partial,
+                weight_row_ptr + k_tile_base,
+                x.iterator + k_tile_base * Int32(2),
+                weight_scale.iterator + scale_offset,
+            )
+        cute.arch.store(smem + tid, partial)
+        cute.arch.sync_threads()
+        block_val = Float32(0.0)
+        if tid < Int32(64):
+            block_val = partial + cute.arch.load(smem + tid + Int32(64), Float32)
+            cute.arch.store(smem + tid, block_val)
+        cute.arch.sync_threads()
+        if tid < Int32(32):
+            block_val += cute.arch.load(smem + tid + Int32(32), Float32)
+            block_val += cute.arch.shuffle_sync_down(block_val, 16)
+            block_val += cute.arch.shuffle_sync_down(block_val, 8)
+            block_val += cute.arch.shuffle_sync_down(block_val, 4)
+            block_val += cute.arch.shuffle_sync_down(block_val, 2)
+            block_val += cute.arch.shuffle_sync_down(block_val, 1)
+        if tid == Int32(0):
+            out[row] = (block_val * alpha).to(cutlass.BFloat16)
+
+    @cute.kernel
+    def _fast_nvfp4_gemv_fp4in_kernel(
+        weight: CuteTensor,
+        x: CuteTensor,
+        weight_scale: CuteTensor,
+        x_scale: CuteTensor,
+        out: CuteTensor,
+        alpha: Float32,
+        k_bytes: cutlass.Constexpr[int],
+    ) -> None:
+        tid_x, _, _ = cute.arch.thread_idx()
+        row, _, _ = cute.arch.block_idx()
+        tid = Int32(tid_x)
+        smem = cute.arch.alloc_smem(Float32, 2, alignment=16)
+        partial = Float32(0.0)
+        k_bytes_i32 = Int32(k_bytes)  # pyrefly: ignore[bad-argument-type]
+        scale_cols = k_bytes // 8  # pyrefly: ignore[unsupported-operation]
+        weight_row_ptr = weight.iterator + row * k_bytes_i32
+        thread_k_base = tid * Int32(32)
+        thread_scale_base = tid * Int32(4)
+        num_iters = k_bytes // 2048  # pyrefly: ignore[unsupported-operation]
+        for iter_k in cutlass.range(num_iters, unroll_full=True):
+            k_tile_base = Int32(iter_k * 2048) + thread_k_base
+            scale_tile_base = Int32(iter_k * 256) + thread_scale_base
+            scale_offset = _fast_swizzled_scale_offset(
+                row,
+                scale_tile_base,
+                scale_cols,
+            )
+            x_scale_offset = _fast_swizzled_scale_offset(
+                Int32(0),
+                scale_tile_base,
+                scale_cols,
+            )
+            partial = _fast_fp4_32bytes_ptr(
+                partial,
+                weight_row_ptr + k_tile_base,
+                x.iterator + k_tile_base,
+                weight_scale.iterator + scale_offset,
+                x_scale.iterator + x_scale_offset,
+            )
+        lane = tid & Int32(31)
+        warp_id = tid >> Int32(5)
+        warp_val = partial
+        warp_val += cute.arch.shuffle_sync_down(warp_val, 16)
+        warp_val += cute.arch.shuffle_sync_down(warp_val, 8)
+        warp_val += cute.arch.shuffle_sync_down(warp_val, 4)
+        warp_val += cute.arch.shuffle_sync_down(warp_val, 2)
+        warp_val += cute.arch.shuffle_sync_down(warp_val, 1)
+        if lane == Int32(0):
+            cute.arch.store(smem + warp_id, warp_val)
+        cute.arch.sync_threads()
+        block_val = Float32(0.0)
+        if tid < Int32(32):
+            if tid < Int32(2):
+                block_val = cute.arch.load(smem + tid, Float32)
+            block_val += cute.arch.shuffle_sync_down(block_val, 4)
+            block_val += cute.arch.shuffle_sync_down(block_val, 2)
+            block_val += cute.arch.shuffle_sync_down(block_val, 1)
+        if tid == Int32(0):
+            out[row] = (block_val * alpha).to(cutlass.BFloat16)
+
+else:
+    _fast_nvfp4_gemv_bf16in_kernel = None
+    _fast_nvfp4_gemv_fp4in_kernel = None
+
+
+def _can_use_fast_cute_path(*tensors: Tensor, k_bytes: int) -> bool:
+    return (
+        _fast_nvfp4_gemv_bf16in_kernel is not None
+        and k_bytes % 2048 == 0
+        and all(tensor.is_cuda and tensor.is_contiguous() for tensor in tensors)
+        and torch.cuda.get_device_capability(tensors[0].device) >= (10, 0)
+    )
+
+
+def _e4m3_byte_to_f32(scale_byte: Tensor) -> Tensor:
+    return hl.inline_asm_elementwise(
+        """
+        {
+          .reg .b16 sc, scale_lo, scale_hi;
+          .reg .b32 scale_h2;
+          mov.b32 {sc, _}, $1;
+          cvt.rn.f16x2.e4m3x2 scale_h2, sc;
+          mov.b32 {scale_lo, scale_hi}, scale_h2;
+          cvt.f32.f16 $0, scale_lo;
+        }
+        """,
+        "=f,r",
+        [scale_byte],
+        dtype=torch.float32,
+        is_pure=True,
+        pack=1,
+    )
+
+
+def _fp4_word_to_f32x8(word: Tensor) -> Fp4WordValues:
+    return cast(
+        "Fp4WordValues",
+        hl.inline_asm_elementwise(
+            """
+            {
+              .reg .b8 fp4_b0, fp4_b1, fp4_b2, fp4_b3;
+              .reg .b16 v0_lo, v0_hi, v1_lo, v1_hi;
+              .reg .b16 v2_lo, v2_hi, v3_lo, v3_hi;
+              .reg .b32 v0_h2, v1_h2, v2_h2, v3_h2;
+              mov.b32 {fp4_b0, fp4_b1, fp4_b2, fp4_b3}, $8;
+              cvt.rn.f16x2.e2m1x2 v0_h2, fp4_b0;
+              cvt.rn.f16x2.e2m1x2 v1_h2, fp4_b1;
+              cvt.rn.f16x2.e2m1x2 v2_h2, fp4_b2;
+              cvt.rn.f16x2.e2m1x2 v3_h2, fp4_b3;
+              mov.b32 {v0_lo, v0_hi}, v0_h2;
+              mov.b32 {v1_lo, v1_hi}, v1_h2;
+              mov.b32 {v2_lo, v2_hi}, v2_h2;
+              mov.b32 {v3_lo, v3_hi}, v3_h2;
+              cvt.f32.f16 $0, v0_lo;
+              cvt.f32.f16 $1, v0_hi;
+              cvt.f32.f16 $2, v1_lo;
+              cvt.f32.f16 $3, v1_hi;
+              cvt.f32.f16 $4, v2_lo;
+              cvt.f32.f16 $5, v2_hi;
+              cvt.f32.f16 $6, v3_lo;
+              cvt.f32.f16 $7, v3_hi;
+            }
+            """,
+            "=f,=f,=f,=f,=f,=f,=f,=f,r",
+            [word],
+            dtype=(
+                torch.float32,
+                torch.float32,
+                torch.float32,
+                torch.float32,
+                torch.float32,
+                torch.float32,
+                torch.float32,
+                torch.float32,
+            ),
+            is_pure=True,
+            pack=1,
+        ),
+    )
+
+
+def _fp4_bf16_word_contribution(
+    weight_word: Tensor,
+    x0: Tensor,
+    x1: Tensor,
+    x2: Tensor,
+    x3: Tensor,
+    x4: Tensor,
+    x5: Tensor,
+    x6: Tensor,
+    x7: Tensor,
+) -> Tensor:
+    w0, w1, w2, w3, w4, w5, w6, w7 = _fp4_word_to_f32x8(weight_word)
+    return (
+        w0 * x0.to(torch.float32)
+        + w1 * x1.to(torch.float32)
+        + w2 * x2.to(torch.float32)
+        + w3 * x3.to(torch.float32)
+        + w4 * x4.to(torch.float32)
+        + w5 * x5.to(torch.float32)
+        + w6 * x6.to(torch.float32)
+        + w7 * x7.to(torch.float32)
+    )
+
+
+def _fp4_word_pair_contribution(weight_word: Tensor, x_word: Tensor) -> Tensor:
+    w0, w1, w2, w3, w4, w5, w6, w7 = _fp4_word_to_f32x8(weight_word)
+    x0, x1, x2, x3, x4, x5, x6, x7 = _fp4_word_to_f32x8(x_word)
+    return w0 * x0 + w1 * x1 + w2 * x2 + w3 * x3 + w4 * x4 + w5 * x5 + w6 * x6 + w7 * x7
+
+
+@helion.kernel(static_shapes=True, config=BF16IN_CONFIG, backend="cute")
+def _nvfp4_gemv_bf16in_kernel(
+    weight_words: Tensor,
+    x_values: Tensor,
+    weight_scale_bytes: Tensor,
+    out: Tensor,
+    alpha: float = 1.0,
+) -> Tensor:
+    M, _K_units, _ = weight_words.shape
+    block_m = hl.register_block_size(1, 8)
+
+    for tile_m in hl.tile(M, block_size=block_m):
+        scale_j = hl.arange(_K_units)
+        acc = hl.zeros([tile_m], dtype=torch.float32)
+        contrib0 = _fp4_bf16_word_contribution(
+            weight_words[tile_m, :, 0],
+            x_values[:, 0],
+            x_values[:, 1],
+            x_values[:, 2],
+            x_values[:, 3],
+            x_values[:, 4],
+            x_values[:, 5],
+            x_values[:, 6],
+            x_values[:, 7],
+        )
+        contrib1 = _fp4_bf16_word_contribution(
+            weight_words[tile_m, :, 1],
+            x_values[:, 8],
+            x_values[:, 9],
+            x_values[:, 10],
+            x_values[:, 11],
+            x_values[:, 12],
+            x_values[:, 13],
+            x_values[:, 14],
+            x_values[:, 15],
+        )
+        scale_offsets = swizzled_scale_offsets(
+            tile_m.index[:, None],
+            scale_j[None, :],
+            _K_units,
+        )
+        scale = _e4m3_byte_to_f32(weight_scale_bytes[scale_offsets])
+        acc = acc + ((contrib0 + contrib1) * scale).sum(-1)
+        out[tile_m] = (acc * alpha).to(torch.bfloat16)
+    return out
+
+
+@helion.kernel(static_shapes=True, config=FP4IN_CONFIG, backend="cute")
+def _nvfp4_gemv_fp4in_kernel(
+    weight_words: Tensor,
+    x_words: Tensor,
+    weight_scale_bytes: Tensor,
+    x_scale_bytes: Tensor,
+    out: Tensor,
+    alpha: float = 1.0,
+) -> Tensor:
+    M, _K_units, _ = weight_words.shape
+    block_m = hl.register_block_size(1, 8)
+    scale_cols = _K_units * 2
+
+    for tile_m in hl.tile(M, block_size=block_m):
+        scale_j0 = hl.arange(_K_units) * 2
+        scale_j1 = scale_j0 + 1
+        acc = hl.zeros([tile_m], dtype=torch.float32)
+        contrib0 = _fp4_word_pair_contribution(
+            weight_words[tile_m, :, 0],
+            x_words[:, 0],
+        )
+        contrib0 = contrib0 + _fp4_word_pair_contribution(
+            weight_words[tile_m, :, 1],
+            x_words[:, 1],
+        )
+        contrib1 = _fp4_word_pair_contribution(
+            weight_words[tile_m, :, 2],
+            x_words[:, 2],
+        )
+        contrib1 = contrib1 + _fp4_word_pair_contribution(
+            weight_words[tile_m, :, 3],
+            x_words[:, 3],
+        )
+        weight_scale_offsets0 = swizzled_scale_offsets(
+            tile_m.index[:, None],
+            scale_j0[None, :],
+            scale_cols,
+        )
+        weight_scale_offsets1 = swizzled_scale_offsets(
+            tile_m.index[:, None],
+            scale_j1[None, :],
+            scale_cols,
+        )
+        x_scale_offsets0 = swizzled_scale_offsets(
+            scale_j0 * 0,
+            scale_j0,
+            scale_cols,
+        )
+        x_scale_offsets1 = swizzled_scale_offsets(
+            scale_j1 * 0,
+            scale_j1,
+            scale_cols,
+        )
+        scale0 = _e4m3_byte_to_f32(weight_scale_bytes[weight_scale_offsets0])
+        scale0 = scale0 * _e4m3_byte_to_f32(x_scale_bytes[x_scale_offsets0])
+        scale1 = _e4m3_byte_to_f32(weight_scale_bytes[weight_scale_offsets1])
+        scale1 = scale1 * _e4m3_byte_to_f32(x_scale_bytes[x_scale_offsets1])
+        acc = acc + (contrib0 * scale0 + contrib1 * scale1).sum(-1)
+        out[tile_m] = (acc * alpha).to(torch.bfloat16)
+    return out
+
+
+def nvfp4_gemv_bf16in(
+    weight_packed: Tensor,
+    x_bf16: Tensor,
+    weight_scale: Tensor,
+    alpha: float = 1.0,
+) -> Tensor:
+    """Compute ``weight_packed @ x_bf16`` for NVFP4 weights and BF16 input."""
+    scale_cols = weight_packed.shape[1] // 8
+    _check_swizzled_scales(
+        "weight_scale",
+        weight_scale,
+        weight_packed.shape[0],
+        scale_cols,
+    )
+    out = torch.empty(
+        weight_packed.shape[0], dtype=torch.bfloat16, device=weight_packed.device
+    )
+    if _can_use_fast_cute_path(
+        weight_packed,
+        x_bf16,
+        weight_scale,
+        k_bytes=weight_packed.shape[1],
+    ):
+        default_cute_launcher(
+            _fast_nvfp4_gemv_bf16in_kernel,
+            (weight_packed.shape[0],),
+            weight_packed,
+            x_bf16,
+            weight_scale.view(torch.uint8),
+            out,
+            alpha,
+            weight_packed.shape[1],
+            block=(128, 1, 1),
+        )
+        return out
+    return _nvfp4_gemv_bf16in_kernel(
+        weight_packed.view(torch.int32).view(
+            weight_packed.shape[0], weight_packed.shape[1] // 8, 2
+        ),
+        x_bf16.view(weight_packed.shape[1] // 8, 16),
+        weight_scale.reshape(-1).view(torch.int8),
+        out,
+        alpha,
+    )
+
+
+def nvfp4_gemv_fp4in(
+    weight_packed: Tensor,
+    x_packed: Tensor,
+    weight_scale: Tensor,
+    x_scale: Tensor,
+    alpha: float = 1.0,
+) -> Tensor:
+    """Compute ``weight_packed @ x_packed`` for NVFP4 weights and input."""
+    scale_cols = weight_packed.shape[1] // 8
+    _check_swizzled_scales(
+        "weight_scale",
+        weight_scale,
+        weight_packed.shape[0],
+        scale_cols,
+    )
+    _check_swizzled_scales("x_scale", x_scale, 1, scale_cols)
+    out = torch.empty(
+        weight_packed.shape[0], dtype=torch.bfloat16, device=weight_packed.device
+    )
+    if _can_use_fast_cute_path(
+        weight_packed,
+        x_packed,
+        weight_scale,
+        x_scale,
+        k_bytes=weight_packed.shape[1],
+    ):
+        default_cute_launcher(
+            _fast_nvfp4_gemv_fp4in_kernel,
+            (weight_packed.shape[0],),
+            weight_packed,
+            x_packed,
+            weight_scale.view(torch.uint8),
+            x_scale.view(torch.uint8),
+            out,
+            alpha,
+            weight_packed.shape[1],
+            block=(64, 1, 1),
+        )
+        return out
+    return _nvfp4_gemv_fp4in_kernel(
+        weight_packed.view(torch.int32).view(
+            weight_packed.shape[0], weight_packed.shape[1] // 16, 4
+        ),
+        x_packed.view(torch.int32).view(weight_packed.shape[1] // 16, 4),
+        weight_scale.reshape(-1).view(torch.int8),
+        x_scale.reshape(-1).view(torch.int8),
+        out,
+        alpha,
+    )
+
+
+def _dequant_e2m1(nibbles: Tensor) -> Tensor:
+    sign = ((nibbles >> 3) & 1).to(torch.float32)
+    u = (nibbles & 0x7).to(torch.float32)
+    abs_val = torch.where(
+        u < 4.0,
+        u * 0.5,
+        torch.where(u < 6.0, u - 2.0, u * 2.0 - 8.0),
+    )
+    return abs_val * (1.0 - 2.0 * sign)
+
+
+def reference_nvfp4_gemv_bf16in(
+    weight_packed: Tensor,
+    x_bf16: Tensor,
+    weight_scale: Tensor,
+    alpha: float = 1.0,
+) -> Tensor:
+    M, K_bytes = weight_packed.shape
+    weight = weight_packed.to(torch.int32)
+    weight_lo = _dequant_e2m1(weight & 0xF)
+    weight_hi = _dequant_e2m1((weight >> 4) & 0xF)
+    x = x_bf16.to(torch.float32).view(K_bytes, 2)
+    scale_cols = K_bytes // 8
+    scale_idx = torch.arange(K_bytes, device=weight_packed.device) // 8
+    row_idx = torch.arange(M, device=weight_packed.device)[:, None]
+    scale_offsets = swizzled_scale_offsets(row_idx, scale_idx[None, :], scale_cols)
+    scale = weight_scale.reshape(-1)[scale_offsets].to(torch.float32)
+    result = ((weight_lo * x[:, 0] + weight_hi * x[:, 1]) * scale).sum(-1)
+    return (result * alpha).to(torch.bfloat16).reshape(M)
+
+
+def reference_nvfp4_gemv_fp4in(
+    weight_packed: Tensor,
+    x_packed: Tensor,
+    weight_scale: Tensor,
+    x_scale: Tensor,
+    alpha: float = 1.0,
+) -> Tensor:
+    M, K_bytes = weight_packed.shape
+    weight = weight_packed.to(torch.int32)
+    x = x_packed.to(torch.int32)
+    weight_lo = _dequant_e2m1(weight & 0xF)
+    weight_hi = _dequant_e2m1((weight >> 4) & 0xF)
+    x_lo = _dequant_e2m1(x & 0xF)
+    x_hi = _dequant_e2m1((x >> 4) & 0xF)
+    scale_cols = K_bytes // 8
+    scale_idx = torch.arange(K_bytes, device=weight_packed.device) // 8
+    row_idx = torch.arange(M, device=weight_packed.device)[:, None]
+    weight_scale_offsets = swizzled_scale_offsets(
+        row_idx, scale_idx[None, :], scale_cols
+    )
+    x_scale_offsets = swizzled_scale_offsets(
+        torch.zeros_like(scale_idx),
+        scale_idx,
+        scale_cols,
+    )
+    scale = weight_scale.reshape(-1)[weight_scale_offsets].to(torch.float32)
+    scale = scale * x_scale.reshape(-1)[x_scale_offsets].to(torch.float32)
+    result = ((weight_lo * x_lo + weight_hi * x_hi) * scale).sum(-1)
+    return (result * alpha).to(torch.bfloat16).reshape(M)
+
+
+def make_fp8_scales(shape: tuple[int, ...], device: torch.device) -> Tensor:
+    logical_scales = (torch.rand(shape, device=device, dtype=torch.float32) + 0.5).to(
+        torch.float8_e4m3fn
+    )
+    return swizzle_fp8_scales(logical_scales)
+
+
+def check_bf16in(M: int, K_bytes: int) -> None:
+    weight = torch.randint(0, 256, (M, K_bytes), dtype=torch.uint8, device=DEVICE)
+    x = torch.randn(K_bytes * 2, dtype=torch.bfloat16, device=DEVICE)
+    weight_scale = make_fp8_scales((M, K_bytes // 8), DEVICE)
+    run_example(
+        nvfp4_gemv_bf16in,
+        reference_nvfp4_gemv_bf16in,
+        (weight, x, weight_scale),
+        atol=4.0,
+        rtol=2e-1,
+    )
+
+
+def check_fp4in(M: int, K_bytes: int) -> None:
+    weight = torch.randint(0, 256, (M, K_bytes), dtype=torch.uint8, device=DEVICE)
+    x = torch.randint(0, 256, (K_bytes,), dtype=torch.uint8, device=DEVICE)
+    weight_scale = make_fp8_scales((M, K_bytes // 8), DEVICE)
+    x_scale = make_fp8_scales((K_bytes // 8,), DEVICE)
+    run_example(
+        nvfp4_gemv_fp4in,
+        reference_nvfp4_gemv_fp4in,
+        (weight, x, weight_scale, x_scale),
+        atol=4.0,
+        rtol=2e-1,
+    )
+
+
+def nvfp4_gemv_bf16in_tritonbench(
+    tb_op: object,
+    weight_packed: Tensor,
+    x_bf16: Tensor,
+    weight_scale: Tensor,
+) -> Callable[[], Tensor]:
+    return lambda: nvfp4_gemv_bf16in(weight_packed, x_bf16, weight_scale)
+
+
+def nvfp4_gemv_fp4in_tritonbench(
+    tb_op: object,
+    weight_packed: Tensor,
+    x_packed: Tensor,
+    weight_scale: Tensor,
+    x_scale: Tensor,
+) -> Callable[[], Tensor]:
+    return lambda: nvfp4_gemv_fp4in(weight_packed, x_packed, weight_scale, x_scale)
+
+
+def main() -> None:
+    check_bf16in(64, 128)
+    check_fp4in(64, 128)
+
+
+if __name__ == "__main__":
+    main()

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -2651,6 +2651,7 @@ class CuteBackend(Backend):
             "_cute_grouped_reduce_warp": "from helion._compiler.cute.reduce_helpers import _cute_grouped_reduce_warp",
             "_cute_store_shared_remote_x4": "from helion._compiler.cute.cluster_helpers import store_shared_remote_x4 as _cute_store_shared_remote_x4",
             "_cute_issue_clc_query_nomulticast": "from helion._compiler.cute.clc_helpers import issue_clc_query_nomulticast as _cute_issue_clc_query_nomulticast",
+            "_cute_inline_asm_elementwise": "from helion._compiler.cute.inline_asm_helpers import inline_asm_elementwise as _cute_inline_asm_elementwise",
         }
 
     def program_id_expr(self, dim: int, *, index_dtype: str) -> str:

--- a/helion/_compiler/cute/inline_asm_helpers.py
+++ b/helion/_compiler/cute/inline_asm_helpers.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import cast
+
+from cutlass import Int32
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import dsl_user_op
+
+if TYPE_CHECKING:
+    from cutlass._mlir import ir
+
+
+@dsl_user_op
+def inline_asm_elementwise(
+    args: tuple[object, ...],
+    *,
+    asm: str = "",
+    constraints: str = "",
+    dtype: object = None,
+    is_pure: bool = True,
+    loc: ir.Location | None = None,
+    ip: ir.InsertionPoint | None = None,
+) -> object:
+    """CuTe scalar helper for ``hl.inline_asm_elementwise``.
+
+    Helion's CuTe SIMT lowering operates on one scalar per thread.  The public
+    API's tensor elementwise semantics are therefore implemented by calling this
+    helper once per generated scalar lane.
+    """
+
+    operands = []
+    for arg in args:
+        operand = cast("Any", arg).ir_value(loc=loc, ip=ip)
+        if str(operand.type) in {"i1", "i8", "i16"}:
+            operand = llvm.zext(Int32.mlir_type, operand, loc=loc, ip=ip)
+        operands.append(operand)
+    if isinstance(dtype, tuple):
+        result = llvm.inline_asm(
+            llvm.StructType.get_literal(  # pyrefly: ignore[missing-attribute]
+                [cast("Any", dt).mlir_type for dt in dtype]
+            ),
+            operands,
+            asm,
+            constraints,
+            has_side_effects=not is_pure,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+        return tuple(
+            cast("Any", dt)(
+                llvm.extractvalue(
+                    cast("Any", dt).mlir_type, result, [i], loc=loc, ip=ip
+                )
+            )
+            for i, dt in enumerate(dtype)
+        )
+    dtype = cast("Any", dtype)
+    return dtype(
+        llvm.inline_asm(
+            dtype.mlir_type,
+            operands,
+            asm,
+            constraints,
+            has_side_effects=not is_pure,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )

--- a/helion/language/inline_asm_ops.py
+++ b/helion/language/inline_asm_ops.py
@@ -205,3 +205,79 @@ def _(state: CodegenState) -> ast.AST | list[ast.AST]:
         ]
 
     return inline_asm_call
+
+
+@_decorators.codegen(inline_asm_elementwise, "cute")
+def _(state: CodegenState) -> ast.AST | list[ast.AST]:
+    asm_str = state.proxy_arg(0)
+    constraints_str = state.proxy_arg(1)
+    dtype = state.proxy_arg(3)
+    is_pure = state.proxy_arg(4)
+    pack = state.proxy_arg(5)
+
+    if pack != 1:
+        raise exc.BackendUnsupported(
+            "cute",
+            "hl.inline_asm_elementwise with pack != 1",
+        )
+
+    raw_args = state.ast_args[2]
+    if isinstance(raw_args, list):
+        args_ast = create(ast.Tuple, elts=raw_args, ctx=ast.Load())
+    elif isinstance(raw_args, tuple):
+        args_ast = create(ast.Tuple, elts=list(raw_args), ctx=ast.Load())
+    else:
+        args_ast = create(ast.Tuple, elts=[raw_args], ctx=ast.Load())
+
+    from .._compiler.compile_environment import CompileEnvironment
+
+    backend = CompileEnvironment.current().backend
+    if isinstance(dtype, (tuple, list)):
+        dtype_arg = create(
+            ast.Tuple,
+            elts=[
+                expr_from_string(backend.dtype_str(dt))
+                for dt in dtype
+                if isinstance(dt, torch.dtype)
+            ],
+            ctx=ast.Load(),
+        )
+        has_multiple_outputs = True
+    else:
+        dtype_arg = expr_from_string(
+            backend.dtype_str(dtype)
+            if isinstance(dtype, torch.dtype)
+            else "cutlass.Float32"
+        )
+        has_multiple_outputs = False
+
+    inline_asm_call = create(
+        ast.Call,
+        func=expr_from_string("_cute_inline_asm_elementwise"),
+        args=[args_ast],
+        keywords=[
+            create(ast.keyword, arg="asm", value=create(ast.Constant, value=asm_str)),
+            create(
+                ast.keyword,
+                arg="constraints",
+                value=create(ast.Constant, value=constraints_str),
+            ),
+            create(ast.keyword, arg="dtype", value=dtype_arg),
+            create(
+                ast.keyword,
+                arg="is_pure",
+                value=create(ast.Constant, value=is_pure),
+            ),
+        ],
+    )
+
+    if has_multiple_outputs:
+        assert isinstance(dtype, (tuple, list))
+        inline_asm_result = state.codegen.lift(
+            inline_asm_call, dce=True, prefix="inline_asm_result"
+        )
+        return [
+            expr_from_string(f"{inline_asm_result.id}[{i}]") for i in range(len(dtype))
+        ]
+
+    return inline_asm_call

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from contextlib import suppress
 import contextvars
+import importlib
 import inspect
 import linecache
 import os
@@ -1371,6 +1372,8 @@ def _torch_dtype_to_cutlass(dtype: torch.dtype) -> object:
         torch.float32: cutlass.Float32,
         torch.float64: cutlass.Float64,
         torch.bfloat16: cutlass.BFloat16,
+        torch.float8_e4m3fn: cutlass.Float8E4M3FN,
+        torch.float8_e5m2: cutlass.Float8E5M2,
         # CuTe does not support i1 global-memory tensors; torch.bool is stored
         # as one byte, so pass bool tensor pointers as uint8 and let load
         # lowering convert nonzero bytes back to cutlass.Boolean registers.
@@ -1695,6 +1698,7 @@ def _create_cute_wrapper(
     import cutlass
     import cutlass.cute as cute
 
+    cuda_driver = importlib.import_module("cuda.bindings.driver")
     kernel_name = getattr(cast("Any", cute_kernel), "__name__", "cute_kernel")
     kernel_tag = f"{kernel_name}_{id(cute_kernel):x}"
     func_name = f"_helion_cute_launch_{kernel_tag}"
@@ -1745,6 +1749,7 @@ def _create_cute_wrapper(
             "grid_x: cutlass.Int32",
             "grid_y: cutlass.Int32",
             "grid_z: cutlass.Int32",
+            "stream: CUstream",
         )
     )
     wrapper_plans = [
@@ -1771,7 +1776,7 @@ def _create_cute_wrapper(
             f"    _helion_cute_kernel_tag = {kernel_tag!r}",
             "    _kernel("
             + ", ".join(call_args)
-            + f").launch(grid=(grid_x, grid_y, grid_z){launch_suffix})",
+            + f").launch(grid=(grid_x, grid_y, grid_z){launch_suffix}, stream=stream)",
         )
     )
 
@@ -1786,6 +1791,7 @@ def _create_cute_wrapper(
     namespace: dict[str, Any] = {
         "cutlass": cutlass,
         "cute": cute,
+        "CUstream": cuda_driver.CUstream,
         "_kernel": cute_kernel,
     }
     filename = f"<helion_cute_launcher:{kernel_tag}:{schema_key!r}:{block!r}>"
@@ -1878,6 +1884,7 @@ def _build_cute_schema_and_args(
     _patch_cutlass_jit_shutdown_unload()
     import cutlass.cute as cute
     from cutlass.cute.runtime import make_ptr
+    import cutlass.torch as cutlass_torch
 
     _ensure_cute_dsl_arch_env(args)
     constexpr_flags = _cute_kernel_param_is_constexpr(cute_kernel)
@@ -1917,6 +1924,7 @@ def _build_cute_schema_and_args(
             launch_args.append(scalar_value)
 
     launch_args.extend(grid)
+    launch_args.append(cutlass_torch.current_stream())
     return tuple(schema), tuple(launch_args)
 
 

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1696,6 +1696,42 @@ class TestExamples(RefEagerTestBase, TestCase):
             atol=1.0,
         )
 
+    @onlyBackends(["cute"])
+    @skipIfNotCUDA()
+    @skipIfCudaCapabilityLessThan(
+        (10, 0), reason="NVFP4 conversion instructions require Blackwell"
+    )
+    @skipIfRefEager("inline asm codegen is not available in ref eager mode")
+    def test_nvfp4_gemv(self):
+        mod = import_path(EXAMPLES_DIR / "nvfp4_gemv.py")
+
+        M, K_bytes = 64, 128
+        weight = torch.randint(0, 256, (M, K_bytes), dtype=torch.uint8, device=DEVICE)
+        weight_scale = mod.make_fp8_scales((M, K_bytes // 8), DEVICE)
+
+        x_bf16 = torch.randn(K_bytes * 2, dtype=torch.bfloat16, device=DEVICE)
+        bf16_result = mod.nvfp4_gemv_bf16in(weight, x_bf16, weight_scale)
+        bf16_expected = mod.reference_nvfp4_gemv_bf16in(weight, x_bf16, weight_scale)
+        torch.testing.assert_close(
+            bf16_result,
+            bf16_expected,
+            atol=4.0,
+            rtol=2e-1,
+        )
+
+        x_packed = torch.randint(0, 256, (K_bytes,), dtype=torch.uint8, device=DEVICE)
+        x_scale = mod.make_fp8_scales((K_bytes // 8,), DEVICE)
+        fp4_result = mod.nvfp4_gemv_fp4in(weight, x_packed, weight_scale, x_scale)
+        fp4_expected = mod.reference_nvfp4_gemv_fp4in(
+            weight, x_packed, weight_scale, x_scale
+        )
+        torch.testing.assert_close(
+            fp4_result,
+            fp4_expected,
+            atol=4.0,
+            rtol=2e-1,
+        )
+
     @xfailIfPallas("JAX tracer error")
     @skipIfRefEager("hl.jagged_tile does not support ref mode yet")
     def test_jagged_sum(self):

--- a/test/test_inline_asm_elementwise.py
+++ b/test/test_inline_asm_elementwise.py
@@ -253,5 +253,89 @@ class TestInlineAsmElementwise(RefEagerTestDisabled, TestCase):
         code, result = code_and_output(kernel_basic, (x,))
 
 
+@onlyBackends(["cute"])
+class TestCuteInlineAsmElementwise(RefEagerTestDisabled, TestCase):
+    @pytest.mark.skipif(
+        DEVICE.type != "cuda", reason="inline_asm_elementwise is only supported on CUDA"
+    )
+    @skipIfRocm("only works on cuda")
+    @skipIfTileIR("TileIR does not support inline_asm_elementwise")
+    def test_inline_asm_simple(self):
+        @helion.kernel(autotune_effort="none")
+        def kernel_simple_asm(x: torch.Tensor) -> torch.Tensor:
+            result = torch.empty_like(x)
+            for tile in hl.tile(x.size(0), block_size=16):
+                result_val = hl.inline_asm_elementwise(
+                    "mov.u32 $0, $1;",
+                    "=r,r",
+                    [x[tile]],
+                    dtype=torch.int32,
+                    is_pure=True,
+                    pack=1,
+                )
+                result[tile] = result_val
+            return result
+
+        x = torch.randint(0, 100, [16], device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(kernel_simple_asm, (x,))
+        torch.testing.assert_close(result, x)
+        self.assertIn("_cute_inline_asm_elementwise", code)
+
+    @pytest.mark.skipif(
+        DEVICE.type != "cuda", reason="inline_asm_elementwise is only supported on CUDA"
+    )
+    @skipIfRocm("only works on cuda")
+    @skipIfTileIR("TileIR does not support inline_asm_elementwise")
+    def test_inline_asm_multiple_outputs(self):
+        @helion.kernel(autotune_effort="none")
+        def kernel_multiple_outputs(
+            a: torch.Tensor, b: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            result_c = torch.empty_like(a)
+            result_d = torch.empty_like(a)
+            for tile in hl.tile(a.size(0), block_size=16):
+                c_val, d_val = hl.inline_asm_elementwise(
+                    """
+                    sub.u32 $0, $2, $3;
+                    sub.u32 $1, $3, $2;
+                    """,
+                    "=r,=r,r,r",
+                    [a[tile], b[tile]],
+                    dtype=(torch.int32, torch.int32),
+                    is_pure=True,
+                    pack=1,
+                )
+                result_c[tile] = c_val
+                result_d[tile] = d_val
+            return result_c, result_d
+
+        shape = [16]
+        a = torch.randint(0, 2**16, shape, device=DEVICE, dtype=torch.int32)
+        b = torch.randint(0, 2**16, shape, device=DEVICE, dtype=torch.int32)
+        _code, (result_c, result_d) = code_and_output(kernel_multiple_outputs, (a, b))
+        torch.testing.assert_close(result_c, a - b)
+        torch.testing.assert_close(result_d, b - a)
+
+    def test_pack_error(self):
+        @helion.kernel(autotune_effort="none")
+        def kernel_packed_asm(x: torch.Tensor) -> torch.Tensor:
+            result = torch.empty_like(x)
+            for tile in hl.tile(x.size(0), block_size=16):
+                result_val = hl.inline_asm_elementwise(
+                    "mov.u32 $0, $1;",
+                    "=r,r",
+                    [x[tile]],
+                    dtype=torch.int32,
+                    is_pure=True,
+                    pack=2,
+                )
+                result[tile] = result_val
+            return result
+
+        x = torch.randint(0, 100, [16], device=DEVICE, dtype=torch.int32)
+        with self.assertRaises(helion.exc.BackendUnsupported):
+            code_and_output(kernel_packed_asm, (x,))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Stacked PRs:
 * #2437
 * __->__#2433


--- --- ---

### Add CuTe NVFP4 GEMV example


Add CuTe lowering support for hl.inline_asm_elementwise, including multiple scalar outputs, and use it for NVFP4 GEMV decode helpers. The fallback Helion kernels now generate the dot-product arithmetic while inline asm is limited to FP4/E4M3 decode operations.

Add a direct CuTe fast path for the two issue repro shapes and pass the current PyTorch CUDA stream into the CuTe launcher so CUDA graph benchmarks capture the launch correctly. Also map torch FP8 dtypes to Cutlass pointer types for launcher arguments.

Use PyTorch's SWIZZLE_32_4_4 layout for NVFP4 E4M3 per-16-value scales, matching the scaled_mm blockwise scale format.

Benchmark: [standalone repro with copied Helion kernels](https://gist.github.com/oulgen/e529d98c314e36662a18542633a06c62), NVIDIA B200, CUDA 12.9, SWIZZLE_32_4_4 scales, warmup=50, iters=500.

| case | input | shape | CUDA GEMV | Helion | Helion/CUDA |
| --- | --- | ---: | ---: | ---: | ---: |
| o | BF16 | 8192 x 8192 | 23.024 us | 17.339 us | 0.75x |
| down | FP4 | 8192 x 28672 | 43.583 us | 44.082 us | 1.01x |
