### PR TITLE
Infer CuTe NVFP4 conversions from dtypes

### DIFF
--- a/examples/nvfp4_gemv.py
+++ b/examples/nvfp4_gemv.py
@@ -16,8 +16,6 @@ Two variants are provided:
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import TypeAlias
-from typing import cast
 
 import cutlass
 from cutlass import Int32
@@ -42,17 +40,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from cutlass._mlir import ir
-
-Fp4WordValues: TypeAlias = tuple[
-    Tensor,
-    Tensor,
-    Tensor,
-    Tensor,
-    Tensor,
-    Tensor,
-    Tensor,
-    Tensor,
-]
 
 BF16IN_CONFIG = helion.Config(
     block_sizes=[1],
@@ -494,208 +481,87 @@ def _can_use_fast_cute_path(*tensors: Tensor, k_bytes: int) -> bool:
     )
 
 
-def _e4m3_byte_to_f32(scale_byte: Tensor) -> Tensor:
-    return hl.inline_asm_elementwise(
-        """
-        {
-          .reg .b16 sc, scale_lo, scale_hi;
-          .reg .b32 scale_h2;
-          mov.b32 {sc, _}, $1;
-          cvt.rn.f16x2.e4m3x2 scale_h2, sc;
-          mov.b32 {scale_lo, scale_hi}, scale_h2;
-          cvt.f32.f16 $0, scale_lo;
-        }
-        """,
-        "=f,r",
-        [scale_byte],
-        dtype=torch.float32,
-        is_pure=True,
-        pack=1,
-    )
+def _as_fp4x2(tensor: Tensor) -> Tensor:
+    if tensor.dtype is torch.float4_e2m1fn_x2:
+        return tensor
+    if tensor.dtype is torch.uint8:
+        return tensor.view(torch.float4_e2m1fn_x2)
+    raise TypeError(f"expected uint8 or float4_e2m1fn_x2 tensor, got {tensor.dtype}")
 
 
-def _fp4_word_to_f32x8(word: Tensor) -> Fp4WordValues:
-    return cast(
-        "Fp4WordValues",
-        hl.inline_asm_elementwise(
-            """
-            {
-              .reg .b8 fp4_b0, fp4_b1, fp4_b2, fp4_b3;
-              .reg .b16 v0_lo, v0_hi, v1_lo, v1_hi;
-              .reg .b16 v2_lo, v2_hi, v3_lo, v3_hi;
-              .reg .b32 v0_h2, v1_h2, v2_h2, v3_h2;
-              mov.b32 {fp4_b0, fp4_b1, fp4_b2, fp4_b3}, $8;
-              cvt.rn.f16x2.e2m1x2 v0_h2, fp4_b0;
-              cvt.rn.f16x2.e2m1x2 v1_h2, fp4_b1;
-              cvt.rn.f16x2.e2m1x2 v2_h2, fp4_b2;
-              cvt.rn.f16x2.e2m1x2 v3_h2, fp4_b3;
-              mov.b32 {v0_lo, v0_hi}, v0_h2;
-              mov.b32 {v1_lo, v1_hi}, v1_h2;
-              mov.b32 {v2_lo, v2_hi}, v2_h2;
-              mov.b32 {v3_lo, v3_hi}, v3_h2;
-              cvt.f32.f16 $0, v0_lo;
-              cvt.f32.f16 $1, v0_hi;
-              cvt.f32.f16 $2, v1_lo;
-              cvt.f32.f16 $3, v1_hi;
-              cvt.f32.f16 $4, v2_lo;
-              cvt.f32.f16 $5, v2_hi;
-              cvt.f32.f16 $6, v3_lo;
-              cvt.f32.f16 $7, v3_hi;
-            }
-            """,
-            "=f,=f,=f,=f,=f,=f,=f,=f,r",
-            [word],
-            dtype=(
-                torch.float32,
-                torch.float32,
-                torch.float32,
-                torch.float32,
-                torch.float32,
-                torch.float32,
-                torch.float32,
-                torch.float32,
-            ),
-            is_pure=True,
-            pack=1,
-        ),
-    )
-
-
-def _fp4_bf16_word_contribution(
-    weight_word: Tensor,
-    x0: Tensor,
-    x1: Tensor,
-    x2: Tensor,
-    x3: Tensor,
-    x4: Tensor,
-    x5: Tensor,
-    x6: Tensor,
-    x7: Tensor,
-) -> Tensor:
-    w0, w1, w2, w3, w4, w5, w6, w7 = _fp4_word_to_f32x8(weight_word)
-    return (
-        w0 * x0.to(torch.float32)
-        + w1 * x1.to(torch.float32)
-        + w2 * x2.to(torch.float32)
-        + w3 * x3.to(torch.float32)
-        + w4 * x4.to(torch.float32)
-        + w5 * x5.to(torch.float32)
-        + w6 * x6.to(torch.float32)
-        + w7 * x7.to(torch.float32)
-    )
-
-
-def _fp4_word_pair_contribution(weight_word: Tensor, x_word: Tensor) -> Tensor:
-    w0, w1, w2, w3, w4, w5, w6, w7 = _fp4_word_to_f32x8(weight_word)
-    x0, x1, x2, x3, x4, x5, x6, x7 = _fp4_word_to_f32x8(x_word)
-    return w0 * x0 + w1 * x1 + w2 * x2 + w3 * x3 + w4 * x4 + w5 * x5 + w6 * x6 + w7 * x7
+def _fp4_storage(tensor: Tensor) -> Tensor:
+    if tensor.dtype is torch.float4_e2m1fn_x2:
+        return tensor.view(torch.uint8)
+    return tensor
 
 
 @helion.kernel(static_shapes=True, config=BF16IN_CONFIG, backend="cute")
 def _nvfp4_gemv_bf16in_kernel(
-    weight_words: Tensor,
+    weight_fp4x2: Tensor,
     x_values: Tensor,
-    weight_scale_bytes: Tensor,
+    weight_scale: Tensor,
     out: Tensor,
     alpha: float = 1.0,
 ) -> Tensor:
-    M, _K_units, _ = weight_words.shape
+    M, K_groups, _ = weight_fp4x2.shape
     block_m = hl.register_block_size(1, 8)
 
     for tile_m in hl.tile(M, block_size=block_m):
-        scale_j = hl.arange(_K_units)
+        scale_j = hl.arange(K_groups)
         acc = hl.zeros([tile_m], dtype=torch.float32)
-        contrib0 = _fp4_bf16_word_contribution(
-            weight_words[tile_m, :, 0],
-            x_values[:, 0],
-            x_values[:, 1],
-            x_values[:, 2],
-            x_values[:, 3],
-            x_values[:, 4],
-            x_values[:, 5],
-            x_values[:, 6],
-            x_values[:, 7],
-        )
-        contrib1 = _fp4_bf16_word_contribution(
-            weight_words[tile_m, :, 1],
-            x_values[:, 8],
-            x_values[:, 9],
-            x_values[:, 10],
-            x_values[:, 11],
-            x_values[:, 12],
-            x_values[:, 13],
-            x_values[:, 14],
-            x_values[:, 15],
-        )
+        contrib = hl.zeros([tile_m, K_groups], dtype=torch.float32)
+        for byte in hl.static_range(8):
+            weight_lo, weight_hi = hl.float4_e2m1fn_x2_to_float32(
+                weight_fp4x2[tile_m, :, byte]
+            )
+            contrib = contrib + weight_lo * x_values[:, byte * 2].to(torch.float32)
+            contrib = contrib + weight_hi * x_values[:, byte * 2 + 1].to(torch.float32)
         scale_offsets = swizzled_scale_offsets(
             tile_m.index[:, None],
             scale_j[None, :],
-            _K_units,
+            K_groups,
         )
-        scale = _e4m3_byte_to_f32(weight_scale_bytes[scale_offsets])
-        acc = acc + ((contrib0 + contrib1) * scale).sum(-1)
+        scale = weight_scale[scale_offsets].to(torch.float32)
+        acc = acc + (contrib * scale).sum(-1)
         out[tile_m] = (acc * alpha).to(torch.bfloat16)
     return out
 
 
 @helion.kernel(static_shapes=True, config=FP4IN_CONFIG, backend="cute")
 def _nvfp4_gemv_fp4in_kernel(
-    weight_words: Tensor,
-    x_words: Tensor,
-    weight_scale_bytes: Tensor,
-    x_scale_bytes: Tensor,
+    weight_fp4x2: Tensor,
+    x_fp4x2: Tensor,
+    weight_scale: Tensor,
+    x_scale: Tensor,
     out: Tensor,
     alpha: float = 1.0,
 ) -> Tensor:
-    M, _K_units, _ = weight_words.shape
+    M, K_groups, _ = weight_fp4x2.shape
     block_m = hl.register_block_size(1, 8)
-    scale_cols = _K_units * 2
 
     for tile_m in hl.tile(M, block_size=block_m):
-        scale_j0 = hl.arange(_K_units) * 2
-        scale_j1 = scale_j0 + 1
+        scale_j = hl.arange(K_groups)
         acc = hl.zeros([tile_m], dtype=torch.float32)
-        contrib0 = _fp4_word_pair_contribution(
-            weight_words[tile_m, :, 0],
-            x_words[:, 0],
-        )
-        contrib0 = contrib0 + _fp4_word_pair_contribution(
-            weight_words[tile_m, :, 1],
-            x_words[:, 1],
-        )
-        contrib1 = _fp4_word_pair_contribution(
-            weight_words[tile_m, :, 2],
-            x_words[:, 2],
-        )
-        contrib1 = contrib1 + _fp4_word_pair_contribution(
-            weight_words[tile_m, :, 3],
-            x_words[:, 3],
-        )
-        weight_scale_offsets0 = swizzled_scale_offsets(
+        contrib = hl.zeros([tile_m, K_groups], dtype=torch.float32)
+        for byte in hl.static_range(8):
+            weight_lo, weight_hi = hl.float4_e2m1fn_x2_to_float32(
+                weight_fp4x2[tile_m, :, byte]
+            )
+            x_lo, x_hi = hl.float4_e2m1fn_x2_to_float32(x_fp4x2[:, byte])
+            contrib = contrib + weight_lo * x_lo + weight_hi * x_hi
+        weight_scale_offsets = swizzled_scale_offsets(
             tile_m.index[:, None],
-            scale_j0[None, :],
-            scale_cols,
+            scale_j[None, :],
+            K_groups,
         )
-        weight_scale_offsets1 = swizzled_scale_offsets(
-            tile_m.index[:, None],
-            scale_j1[None, :],
-            scale_cols,
+        x_scale_offsets = swizzled_scale_offsets(
+            scale_j * 0,
+            scale_j,
+            K_groups,
         )
-        x_scale_offsets0 = swizzled_scale_offsets(
-            scale_j0 * 0,
-            scale_j0,
-            scale_cols,
-        )
-        x_scale_offsets1 = swizzled_scale_offsets(
-            scale_j1 * 0,
-            scale_j1,
-            scale_cols,
-        )
-        scale0 = _e4m3_byte_to_f32(weight_scale_bytes[weight_scale_offsets0])
-        scale0 = scale0 * _e4m3_byte_to_f32(x_scale_bytes[x_scale_offsets0])
-        scale1 = _e4m3_byte_to_f32(weight_scale_bytes[weight_scale_offsets1])
-        scale1 = scale1 * _e4m3_byte_to_f32(x_scale_bytes[x_scale_offsets1])
-        acc = acc + (contrib0 * scale0 + contrib1 * scale1).sum(-1)
+        scale = weight_scale[weight_scale_offsets].to(torch.float32)
+        scale = scale * x_scale[x_scale_offsets].to(torch.float32)
+        acc = acc + (contrib * scale).sum(-1)
         out[tile_m] = (acc * alpha).to(torch.bfloat16)
     return out
 
@@ -707,40 +573,40 @@ def nvfp4_gemv_bf16in(
     alpha: float = 1.0,
 ) -> Tensor:
     """Compute ``weight_packed @ x_bf16`` for NVFP4 weights and BF16 input."""
-    scale_cols = weight_packed.shape[1] // 8
+    weight_fp4x2 = _as_fp4x2(weight_packed)
+    weight_bytes = weight_fp4x2.view(torch.uint8)
+    scale_cols = weight_bytes.shape[1] // 8
     _check_swizzled_scales(
         "weight_scale",
         weight_scale,
-        weight_packed.shape[0],
+        weight_bytes.shape[0],
         scale_cols,
     )
     out = torch.empty(
-        weight_packed.shape[0], dtype=torch.bfloat16, device=weight_packed.device
+        weight_bytes.shape[0], dtype=torch.bfloat16, device=weight_bytes.device
     )
     if _can_use_fast_cute_path(
-        weight_packed,
+        weight_bytes,
         x_bf16,
         weight_scale,
-        k_bytes=weight_packed.shape[1],
+        k_bytes=weight_bytes.shape[1],
     ):
         default_cute_launcher(
             _fast_nvfp4_gemv_bf16in_kernel,
-            (weight_packed.shape[0],),
-            weight_packed,
+            (weight_bytes.shape[0],),
+            weight_bytes,
             x_bf16,
             weight_scale.view(torch.uint8),
             out,
             alpha,
-            weight_packed.shape[1],
+            weight_bytes.shape[1],
             block=(128, 1, 1),
         )
         return out
     return _nvfp4_gemv_bf16in_kernel(
-        weight_packed.view(torch.int32).view(
-            weight_packed.shape[0], weight_packed.shape[1] // 8, 2
-        ),
-        x_bf16.view(weight_packed.shape[1] // 8, 16),
-        weight_scale.reshape(-1).view(torch.int8),
+        weight_fp4x2.view(weight_bytes.shape[0], weight_bytes.shape[1] // 8, 8),
+        x_bf16.view(weight_bytes.shape[1] // 8, 16),
+        weight_scale.reshape(-1),
         out,
         alpha,
     )
@@ -754,44 +620,46 @@ def nvfp4_gemv_fp4in(
     alpha: float = 1.0,
 ) -> Tensor:
     """Compute ``weight_packed @ x_packed`` for NVFP4 weights and input."""
-    scale_cols = weight_packed.shape[1] // 8
+    weight_fp4x2 = _as_fp4x2(weight_packed)
+    x_fp4x2 = _as_fp4x2(x_packed)
+    weight_bytes = weight_fp4x2.view(torch.uint8)
+    x_bytes = x_fp4x2.view(torch.uint8)
+    scale_cols = weight_bytes.shape[1] // 8
     _check_swizzled_scales(
         "weight_scale",
         weight_scale,
-        weight_packed.shape[0],
+        weight_bytes.shape[0],
         scale_cols,
     )
     _check_swizzled_scales("x_scale", x_scale, 1, scale_cols)
     out = torch.empty(
-        weight_packed.shape[0], dtype=torch.bfloat16, device=weight_packed.device
+        weight_bytes.shape[0], dtype=torch.bfloat16, device=weight_bytes.device
     )
     if _can_use_fast_cute_path(
-        weight_packed,
-        x_packed,
+        weight_bytes,
+        x_bytes,
         weight_scale,
         x_scale,
-        k_bytes=weight_packed.shape[1],
+        k_bytes=weight_bytes.shape[1],
     ):
         default_cute_launcher(
             _fast_nvfp4_gemv_fp4in_kernel,
-            (weight_packed.shape[0],),
-            weight_packed,
-            x_packed,
+            (weight_bytes.shape[0],),
+            weight_bytes,
+            x_bytes,
             weight_scale.view(torch.uint8),
             x_scale.view(torch.uint8),
             out,
             alpha,
-            weight_packed.shape[1],
+            weight_bytes.shape[1],
             block=(64, 1, 1),
         )
         return out
     return _nvfp4_gemv_fp4in_kernel(
-        weight_packed.view(torch.int32).view(
-            weight_packed.shape[0], weight_packed.shape[1] // 16, 4
-        ),
-        x_packed.view(torch.int32).view(weight_packed.shape[1] // 16, 4),
-        weight_scale.reshape(-1).view(torch.int8),
-        x_scale.reshape(-1).view(torch.int8),
+        weight_fp4x2.view(weight_bytes.shape[0], weight_bytes.shape[1] // 8, 8),
+        x_fp4x2.view(weight_bytes.shape[1] // 8, 8),
+        weight_scale.reshape(-1),
+        x_scale.reshape(-1),
         out,
         alpha,
     )
@@ -814,14 +682,15 @@ def reference_nvfp4_gemv_bf16in(
     weight_scale: Tensor,
     alpha: float = 1.0,
 ) -> Tensor:
-    M, K_bytes = weight_packed.shape
-    weight = weight_packed.to(torch.int32)
+    weight_storage = _fp4_storage(weight_packed)
+    M, K_bytes = weight_storage.shape
+    weight = weight_storage.to(torch.int32)
     weight_lo = _dequant_e2m1(weight & 0xF)
     weight_hi = _dequant_e2m1((weight >> 4) & 0xF)
     x = x_bf16.to(torch.float32).view(K_bytes, 2)
     scale_cols = K_bytes // 8
-    scale_idx = torch.arange(K_bytes, device=weight_packed.device) // 8
-    row_idx = torch.arange(M, device=weight_packed.device)[:, None]
+    scale_idx = torch.arange(K_bytes, device=weight_storage.device) // 8
+    row_idx = torch.arange(M, device=weight_storage.device)[:, None]
     scale_offsets = swizzled_scale_offsets(row_idx, scale_idx[None, :], scale_cols)
     scale = weight_scale.reshape(-1)[scale_offsets].to(torch.float32)
     result = ((weight_lo * x[:, 0] + weight_hi * x[:, 1]) * scale).sum(-1)
@@ -835,16 +704,18 @@ def reference_nvfp4_gemv_fp4in(
     x_scale: Tensor,
     alpha: float = 1.0,
 ) -> Tensor:
-    M, K_bytes = weight_packed.shape
-    weight = weight_packed.to(torch.int32)
-    x = x_packed.to(torch.int32)
+    weight_storage = _fp4_storage(weight_packed)
+    x_storage = _fp4_storage(x_packed)
+    M, K_bytes = weight_storage.shape
+    weight = weight_storage.to(torch.int32)
+    x = x_storage.to(torch.int32)
     weight_lo = _dequant_e2m1(weight & 0xF)
     weight_hi = _dequant_e2m1((weight >> 4) & 0xF)
     x_lo = _dequant_e2m1(x & 0xF)
     x_hi = _dequant_e2m1((x >> 4) & 0xF)
     scale_cols = K_bytes // 8
-    scale_idx = torch.arange(K_bytes, device=weight_packed.device) // 8
-    row_idx = torch.arange(M, device=weight_packed.device)[:, None]
+    scale_idx = torch.arange(K_bytes, device=weight_storage.device) // 8
+    row_idx = torch.arange(M, device=weight_storage.device)[:, None]
     weight_scale_offsets = swizzled_scale_offsets(
         row_idx, scale_idx[None, :], scale_cols
     )
@@ -867,7 +738,9 @@ def make_fp8_scales(shape: tuple[int, ...], device: torch.device) -> Tensor:
 
 
 def check_bf16in(M: int, K_bytes: int) -> None:
-    weight = torch.randint(0, 256, (M, K_bytes), dtype=torch.uint8, device=DEVICE)
+    weight = torch.randint(0, 256, (M, K_bytes), dtype=torch.uint8, device=DEVICE).view(
+        torch.float4_e2m1fn_x2
+    )
     x = torch.randn(K_bytes * 2, dtype=torch.bfloat16, device=DEVICE)
     weight_scale = make_fp8_scales((M, K_bytes // 8), DEVICE)
     run_example(
@@ -880,8 +753,12 @@ def check_bf16in(M: int, K_bytes: int) -> None:
 
 
 def check_fp4in(M: int, K_bytes: int) -> None:
-    weight = torch.randint(0, 256, (M, K_bytes), dtype=torch.uint8, device=DEVICE)
-    x = torch.randint(0, 256, (K_bytes,), dtype=torch.uint8, device=DEVICE)
+    weight = torch.randint(0, 256, (M, K_bytes), dtype=torch.uint8, device=DEVICE).view(
+        torch.float4_e2m1fn_x2
+    )
+    x = torch.randint(0, 256, (K_bytes,), dtype=torch.uint8, device=DEVICE).view(
+        torch.float4_e2m1fn_x2
+    )
     weight_scale = make_fp8_scales((M, K_bytes // 8), DEVICE)
     x_scale = make_fp8_scales((K_bytes // 8,), DEVICE)
     run_example(

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -2560,6 +2560,11 @@ class CuteBackend(Backend):
             inductor_dtype := CuteDSLOpOverrides.TORCH_TO_CUTE_DTYPE.get(dtype)
         ) is not None:
             return inductor_dtype
+        if dtype is torch.float4_e2m1fn_x2:
+            # PyTorch's shell dtype stores two E2M1 values in one byte.  CuTe
+            # does not support scalar dereference for its 4-bit type yet, so
+            # SIMT scalar loads treat the tensor as raw byte storage.
+            return "cutlass.Uint8"
         if dtype is torch.uint64:
             return "cutlass.Int64"
 
@@ -2652,6 +2657,8 @@ class CuteBackend(Backend):
             "_cute_store_shared_remote_x4": "from helion._compiler.cute.cluster_helpers import store_shared_remote_x4 as _cute_store_shared_remote_x4",
             "_cute_issue_clc_query_nomulticast": "from helion._compiler.cute.clc_helpers import issue_clc_query_nomulticast as _cute_issue_clc_query_nomulticast",
             "_cute_inline_asm_elementwise": "from helion._compiler.cute.inline_asm_helpers import inline_asm_elementwise as _cute_inline_asm_elementwise",
+            "_cute_fp8e4m3fn_to_float32": "from helion._compiler.cute.quantized_helpers import fp8e4m3fn_to_float32 as _cute_fp8e4m3fn_to_float32",
+            "_cute_float4_e2m1fn_x2_to_float32": "from helion._compiler.cute.quantized_helpers import float4_e2m1fn_x2_to_float32 as _cute_float4_e2m1fn_x2_to_float32",
         }
 
     def program_id_expr(self, dim: int, *, index_dtype: str) -> str:

--- a/helion/_compiler/cute/quantized_helpers.py
+++ b/helion/_compiler/cute/quantized_helpers.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import cast
+
+from cutlass import Float32
+from cutlass import Int8
+from cutlass import Int16
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import dsl_user_op
+
+if TYPE_CHECKING:
+    from cutlass._mlir import ir
+
+
+def _as_i16(
+    value: object,
+    *,
+    loc: ir.Location | None,
+    ip: ir.InsertionPoint | None,
+) -> ir.Value:
+    raw_value = getattr(value, "value", None)
+    if hasattr(raw_value, "type"):
+        ir_value = cast("Any", raw_value)
+    else:
+        ir_value = cast("Any", value).ir_value(loc=loc, ip=ip)
+    ir_type = str(cast("Any", ir_value).type)
+    if ir_type == "i8":
+        return llvm.zext(Int16.mlir_type, ir_value, loc=loc, ip=ip)
+    if ir_type.startswith("f8"):
+        as_i8 = llvm.bitcast(Int8.mlir_type, ir_value, loc=loc, ip=ip)
+        return llvm.zext(Int16.mlir_type, as_i8, loc=loc, ip=ip)
+    if ir_type == "i16":
+        return ir_value
+    raise TypeError(f"unsupported quantized scalar type: {ir_type}")
+
+
+@dsl_user_op
+def fp8e4m3fn_to_float32(
+    value: object,
+    *,
+    loc: ir.Location | None = None,
+    ip: ir.InsertionPoint | None = None,
+) -> Float32:
+    value_i16 = _as_i16(value, loc=loc, ip=ip)
+    result = llvm.inline_asm(
+        Float32.mlir_type,
+        [value_i16],
+        """
+        {
+          .reg .b16 scale_lo, scale_hi;
+          .reg .b32 scale_h2;
+          cvt.rn.f16x2.e4m3x2 scale_h2, $1;
+          mov.b32 {scale_lo, scale_hi}, scale_h2;
+          cvt.f32.f16 $0, scale_lo;
+        }
+        """,
+        "=f,h",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return Float32(result)
+
+
+@dsl_user_op
+def float4_e2m1fn_x2_to_float32(
+    value: object,
+    *,
+    loc: ir.Location | None = None,
+    ip: ir.InsertionPoint | None = None,
+) -> tuple[Float32, Float32]:
+    value_i16 = _as_i16(value, loc=loc, ip=ip)
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal(  # pyrefly: ignore[missing-attribute]
+            [Float32.mlir_type, Float32.mlir_type]
+        ),
+        [value_i16],
+        """
+        {
+          .reg .b8 v;
+          .reg .b16 v_lo, v_hi;
+          .reg .b32 v_h2;
+          mov.b16 {v, _}, $2;
+          cvt.rn.f16x2.e2m1x2 v_h2, v;
+          mov.b32 {v_lo, v_hi}, v_h2;
+          cvt.f32.f16 $0, v_lo;
+          cvt.f32.f16 $1, v_hi;
+        }
+        """,
+        "=f,=f,h",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        Float32(llvm.extractvalue(Float32.mlir_type, result, [0], loc=loc, ip=ip)),
+        Float32(llvm.extractvalue(Float32.mlir_type, result, [1], loc=loc, ip=ip)),
+    )

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -1043,6 +1043,16 @@ class GenerateASTFromInductor(DefaultHandler):
         device context during compute-type selection, and to guarantee a visible
         cast in generated code that matches PyTorch's dtype semantics.
         """
+        if (
+            CompileEnvironment.current().backend.name == "cute"
+            and src_dtype is torch.float8_e4m3fn
+            and dtype is torch.float32
+        ):
+            cast_expr = expr_from_string(
+                "_cute_fp8e4m3fn_to_float32({x})",
+                x=self._to_ast(x),
+            )
+            return self._lift(cast_expr)
         cast_expr = self._create_cast_expr(x, dtype)
         return self._lift(cast_expr)
 

--- a/helion/language/__init__.py
+++ b/helion/language/__init__.py
@@ -30,6 +30,7 @@ from .matmul_ops import dot as dot
 from .matmul_ops import dot_scaled as dot_scaled
 from .memory_ops import load as load
 from .memory_ops import store as store
+from .quantized_ops import float4_e2m1fn_x2_to_float32 as float4_e2m1fn_x2_to_float32
 from .random_ops import rand as rand
 from .random_ops import rand4x as rand4x
 from .random_ops import randint as randint

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -808,9 +808,24 @@ def _cute_scalar_pointer_expr(tensor_name: str, index_exprs: list[str]) -> str:
     return f"({tensor_name}.iterator + {offset})"
 
 
-def _cute_scalar_load_expr(tensor_name: str, index_exprs: list[str]) -> str:
+def _cute_scalar_storage_dtype(dtype: torch.dtype) -> str:
+    if dtype in (torch.float4_e2m1fn_x2, torch.float8_e4m3fn):
+        return "cutlass.Uint8"
+    return CompileEnvironment.current().backend.dtype_str(dtype)
+
+
+def _cute_scalar_load_expr(
+    tensor_name: str,
+    index_exprs: list[str],
+    dtype: torch.dtype,
+) -> str:
     if "None" in index_exprs:
         return f"{tensor_name}[{', '.join(index_exprs)}]"
+    if dtype in (torch.float4_e2m1fn_x2, torch.float8_e4m3fn):
+        return (
+            f"cute.arch.load({_cute_scalar_pointer_expr(tensor_name, index_exprs)}, "
+            "cutlass.Uint8)"
+        )
     return f"{_cute_scalar_pointer_expr(tensor_name, index_exprs)}.load()"
 
 
@@ -4467,10 +4482,10 @@ def _(state: CodegenState) -> object:
         return packed_rhs_load
 
     if _is_cute_affine_range_load_for_store(state, subscript, ast_subscript):
-        zero = CompileEnvironment.current().backend.dtype_str(tensor.dtype)
+        zero = _cute_scalar_storage_dtype(tensor.dtype)
         return expr_from_string(f"{zero}(0)")
     if _is_cute_strided_slice_load_for_store(state, tensor, subscript):
-        zero = CompileEnvironment.current().backend.dtype_str(tensor.dtype)
+        zero = _cute_scalar_storage_dtype(tensor.dtype)
         return expr_from_string(f"{zero}(0)")
 
     tensor_name = state.device_function.tensor_arg(tensor).name
@@ -4482,7 +4497,7 @@ def _(state: CodegenState) -> object:
         inactive_slice_expr="None",
         inactive_singleton_slice_expr="0",
     )
-    load_expr = _cute_scalar_load_expr(tensor_name, index_exprs)
+    load_expr = _cute_scalar_load_expr(tensor_name, index_exprs, tensor.dtype)
     mask_expr = _cute_combined_mask(
         state,
         subscript,
@@ -4517,7 +4532,7 @@ def _(state: CodegenState) -> object:
             expr=expr_from_string(
                 load_expr
                 if mask_expr is None
-                else f"({load_expr} if {mask_expr} else {CompileEnvironment.current().backend.dtype_str(tensor.dtype)}(0))"
+                else f"({load_expr} if {mask_expr} else {_cute_scalar_storage_dtype(tensor.dtype)}(0))"
             ),
             tensor_name=tensor_name,
             index_exprs=tuple(index_exprs),
@@ -4529,7 +4544,7 @@ def _(state: CodegenState) -> object:
         return sortable_load.expr
     if mask_expr is None:
         return expr_from_string(load_expr)
-    zero = CompileEnvironment.current().backend.dtype_str(tensor.dtype)
+    zero = _cute_scalar_storage_dtype(tensor.dtype)
     return expr_from_string(f"({load_expr} if {mask_expr} else {zero}(0))")
 
 

--- a/helion/language/quantized_ops.py
+++ b/helion/language/quantized_ops.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from .. import exc
+from .._compiler.ast_extension import expr_from_string
+from . import _decorators
+
+if TYPE_CHECKING:
+    import ast
+
+    from .._compiler.inductor_lowering import CodegenState
+
+__all__ = ["float4_e2m1fn_x2_to_float32"]
+
+
+@_decorators.api(is_device_only=True)
+def float4_e2m1fn_x2_to_float32(
+    value: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Unpack a ``torch.float4_e2m1fn_x2`` scalar tensor into FP32 lanes."""
+    raise exc.NotInsideKernel
+
+
+@_decorators.register_fake(float4_e2m1fn_x2_to_float32)
+def _(value: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    if value.dtype is not torch.float4_e2m1fn_x2:
+        raise exc.InvalidAPIUsage(
+            "hl.float4_e2m1fn_x2_to_float32 expects a "
+            f"torch.float4_e2m1fn_x2 tensor, got {value.dtype}"
+        )
+    return (
+        torch.empty(value.shape, dtype=torch.float32, device=value.device),
+        torch.empty(value.shape, dtype=torch.float32, device=value.device),
+    )
+
+
+@_decorators.codegen(float4_e2m1fn_x2_to_float32, "cute")
+def _(state: CodegenState) -> list[ast.AST]:
+    call = expr_from_string(
+        "_cute_float4_e2m1fn_x2_to_float32({value})",
+        value=state.ast_arg(0),
+    )
+    result = state.codegen.lift(call, dce=True, prefix="fp4_pair")
+    return [
+        expr_from_string(f"{result.id}[0]"),
+        expr_from_string(f"{result.id}[1]"),
+    ]

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -1374,6 +1374,7 @@ def _torch_dtype_to_cutlass(dtype: torch.dtype) -> object:
         torch.bfloat16: cutlass.BFloat16,
         torch.float8_e4m3fn: cutlass.Float8E4M3FN,
         torch.float8_e5m2: cutlass.Float8E5M2,
+        torch.float4_e2m1fn_x2: cutlass.Uint8,
         # CuTe does not support i1 global-memory tensors; torch.bool is stored
         # as one byte, so pass bool tensor pointers as uint8 and let load
         # lowering convert nonzero bytes back to cutlass.Boolean registers.

--- a/test/test_quantized_ops.py
+++ b/test/test_quantized_ops.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import RefEagerTestDisabled
+from helion._testing import TestCase
+from helion._testing import code_and_output
+from helion._testing import onlyBackends
+from helion._testing import skipIfCudaCapabilityLessThan
+from helion._testing import skipIfNotCUDA
+import helion.language as hl
+
+
+def _dequant_e2m1(nibbles: torch.Tensor) -> torch.Tensor:
+    sign = ((nibbles >> 3) & 1).to(torch.float32)
+    u = (nibbles & 0x7).to(torch.float32)
+    abs_val = torch.where(
+        u < 4.0,
+        u * 0.5,
+        torch.where(u < 6.0, u - 2.0, u * 2.0 - 8.0),
+    )
+    return abs_val * (1.0 - 2.0 * sign)
+
+
+@onlyBackends(["cute"])
+class TestCuteQuantizedOps(RefEagerTestDisabled, TestCase):
+    @skipIfNotCUDA()
+    @skipIfCudaCapabilityLessThan(
+        (10, 0), reason="FP4/FP8 conversion instructions require Blackwell"
+    )
+    def test_fp8_e4m3fn_to_float32(self):
+        @helion.kernel(autotune_effort="none")
+        def fp8_to_f32(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty(x.shape, dtype=torch.float32, device=x.device)
+            for tile in hl.tile(x.size(0), block_size=16):
+                out[tile] = x[tile].to(torch.float32)
+            return out
+
+        x = (torch.rand((16,), device=DEVICE, dtype=torch.float32) + 0.5).to(
+            torch.float8_e4m3fn
+        )
+        code, result = code_and_output(fp8_to_f32, (x,))
+        torch.testing.assert_close(result, x.to(torch.float32))
+        self.assertIn("_cute_fp8e4m3fn_to_float32", code)
+
+    @skipIfNotCUDA()
+    @skipIfCudaCapabilityLessThan(
+        (10, 0), reason="FP4/FP8 conversion instructions require Blackwell"
+    )
+    def test_float4_e2m1fn_x2_to_float32(self):
+        @helion.kernel(autotune_effort="none")
+        def fp4_to_f32_pair(
+            x: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            lo = torch.empty(x.shape, dtype=torch.float32, device=x.device)
+            hi = torch.empty(x.shape, dtype=torch.float32, device=x.device)
+            for tile in hl.tile(x.size(0), block_size=16):
+                lo_value, hi_value = hl.float4_e2m1fn_x2_to_float32(x[tile])
+                lo[tile] = lo_value
+                hi[tile] = hi_value
+            return lo, hi
+
+        raw = torch.tensor(
+            [
+                0x10,
+                0x21,
+                0x32,
+                0x43,
+                0x54,
+                0x65,
+                0x76,
+                0x87,
+                0x98,
+                0xA9,
+                0xBA,
+                0xCB,
+                0xDC,
+                0xED,
+                0xFE,
+                0xFF,
+            ],
+            dtype=torch.uint8,
+            device=DEVICE,
+        )
+        code, (lo, hi) = code_and_output(
+            fp4_to_f32_pair,
+            (raw.view(torch.float4_e2m1fn_x2),),
+        )
+        raw_i32 = raw.to(torch.int32)
+        torch.testing.assert_close(lo, _dequant_e2m1(raw_i32 & 0xF))
+        torch.testing.assert_close(hi, _dequant_e2m1((raw_i32 >> 4) & 0xF))
+        self.assertIn("_cute_float4_e2m1fn_x2_to_float32", code)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

Add CuTe quantized scalar helpers so FP8 E4M3 scale loads lower through tensor.to(torch.float32), and add a dtype-driven hl.float4_e2m1fn_x2_to_float32 unpack op for PyTorch's packed FP4 shell dtype. CuTe scalar loads for FP4x2 and FP8 now read byte storage directly before conversion, avoiding the unsupported scalar FP4 dereference path and FP8 fpext lowering.

Update the NVFP4 GEMV fallback kernels to operate on torch.float4_e2m1fn_x2 tensors and generated arithmetic instead of handwritten conversion asm. The fused direct CuTe fast path remains unchanged for the large benchmark shapes.

Benchmark: CUDA baseline from [standalone repro with copied CUDA GEMV](https://gist.github.com/oulgen/e529d98c314e36662a18542633a06c62), NVIDIA B200, CUDA 12.9, SWIZZLE_32_4_4 scales, warmup=50, iters=500. Helion numbers use the current examples/nvfp4_gemv.py kernels.

| case | input | shape | CUDA GEMV | Helion | Helion/CUDA |
| --- | --- | ---: | ---: | ---: | ---: |
| o | BF16 | 8192 x 8192 | 23.024 us | 17.338 us | 0.75x |
| down | FP4 | 8192 x 28672 | 43.532 us | 43.861 us | 1.01x |
