### PR TITLE
[Autotuner] LLM search: effort_level knob + Anthropic adaptive thinking + OpenAI xhigh

### DIFF
--- a/helion/autotuner/llm/transport.py
+++ b/helion/autotuner/llm/transport.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import json
 import os
+import re
 import ssl
 from typing import TYPE_CHECKING
 from typing import Any
@@ -18,6 +19,29 @@ DEFAULT_REQUEST_TIMEOUT_S = 120.0
 # OpenAI Responses does not consume a temperature knob in our current request path,
 # so keep Anthropic's setting internal instead of exposing it on the search API.
 DEFAULT_ANTHROPIC_TEMPERATURE = 0.3
+# Legacy `budget_tokens` presets (1024 = Anthropic's hard minimum). Newer models
+# self-pick via adaptive thinking — see `_supports_anthropic_adaptive`.
+_ANTHROPIC_THINKING_BUDGET_BY_EFFORT = {
+    "low": 1024,
+    "medium": 4096,
+    "high": 8192,
+    "max": 24000,
+}
+_VALID_EFFORT_LEVELS = frozenset({"none", "low", "medium", "high", "max"})
+# Per-family minimum (major, minor) for adaptive thinking. Required on Opus 4.7+
+# (manual budget_tokens returns HTTP 400). Below-minimum / unlisted → legacy path.
+_ANTHROPIC_ADAPTIVE_MIN_VERSIONS: dict[str, tuple[int, int]] = {
+    "opus": (4, 5),
+    "sonnet": (4, 6),
+}
+# Minor capped at 2 digits + non-digit lookahead so 8-digit date suffixes (e.g.
+# `claude-opus-4-20250514`) don't get mis-parsed as the minor version.
+_ANTHROPIC_MODEL_VERSION_RE = re.compile(
+    r"^claude-([a-z]+)-(\d+)(?:-(\d{1,2})(?=\D|$))?"
+)
+# Models that accept OpenAI's `xhigh` effort. Others reject it, so "max" only
+# maps to "xhigh" here; elsewhere "max" → "high".
+_OPENAI_XHIGH_MODELS = frozenset({"gpt-5.1-codex-max", "gpt-5.4", "gpt-5.5"})
 
 _PROVIDER_ALIASES = {
     "anthropic": "anthropic",
@@ -99,6 +123,61 @@ def anthropic_messages_from_history(
     ]
 
 
+def normalize_effort_level(effort_level: str | None) -> str | None:
+    """Normalize the optional model effort-level knob."""
+    from ...runtime.settings import _FALSE_LITERALS
+
+    if effort_level is None:
+        return None
+    normalized = effort_level.strip().lower()
+    if normalized in _FALSE_LITERALS:
+        return "none"
+    if normalized not in _VALID_EFFORT_LEVELS:
+        raise ValueError(
+            f"Unsupported LLM effort level {effort_level!r}. "
+            "Valid values are: none, low, medium, high, max."
+        )
+    return normalized
+
+
+def _openai_effort_level(effort_level: str | None, model: str) -> str | None:
+    normalized = normalize_effort_level(effort_level)
+    if normalized in {None, "none"}:
+        return None
+    if normalized == "max":
+        return (
+            "xhigh" if strip_provider_prefix(model) in _OPENAI_XHIGH_MODELS else "high"
+        )
+    return normalized
+
+
+def _anthropic_thinking_budget_tokens(effort_level: str | None) -> int | None:
+    normalized = normalize_effort_level(effort_level)
+    if normalized in {None, "none"}:
+        return None
+    return _ANTHROPIC_THINKING_BUDGET_BY_EFFORT[normalized]
+
+
+def _supports_anthropic_adaptive(model: str) -> bool:
+    match = _ANTHROPIC_MODEL_VERSION_RE.match(model.lower())
+    if match is None:
+        return False
+    family, major_str, minor_str = match.groups()
+    minimum = _ANTHROPIC_ADAPTIVE_MIN_VERSIONS.get(family)
+    if minimum is None:
+        return False
+    return (int(major_str), int(minor_str) if minor_str else 0) >= minimum
+
+
+def _anthropic_max_tokens(
+    max_output_tokens: int,
+    thinking_budget_tokens: int | None,
+) -> int:
+    if thinking_budget_tokens is None:
+        return max_output_tokens
+    return thinking_budget_tokens + max_output_tokens
+
+
 def _extract_text_content_items(content: object) -> list[str]:
     """Collect plain-text content blocks from a provider response payload."""
     if not isinstance(content, list):
@@ -137,6 +216,7 @@ def _openai_payload(
     model: str,
     messages: list[dict[str, str]],
     max_output_tokens: int,
+    effort_level: str | None,
 ) -> dict[str, Any]:
     """Build an OpenAI Responses request payload."""
     system_prompt, input_messages = split_system_messages(messages)
@@ -145,6 +225,8 @@ def _openai_payload(
         "input": responses_input_from_messages(input_messages),
         "max_output_tokens": max_output_tokens,
     }
+    if (effort := _openai_effort_level(effort_level, model)) is not None:
+        payload["reasoning"] = {"effort": effort}
     if system_prompt:
         payload["instructions"] = system_prompt
     return payload
@@ -154,17 +236,39 @@ def _anthropic_payload(
     model: str,
     messages: list[dict[str, str]],
     max_output_tokens: int,
+    effort_level: str | None,
 ) -> dict[str, Any]:
     """Build an Anthropic Messages request payload."""
     system_prompt, input_messages = split_system_messages(messages)
     normalized_model = strip_provider_prefix(model)
+    normalized_effort = normalize_effort_level(effort_level)
+    enable_thinking = normalized_effort not in {None, "none"}
+    use_adaptive = enable_thinking and _supports_anthropic_adaptive(normalized_model)
+    # Reserve max_tokens for both visible output AND thinking. Anthropic counts
+    # thinking tokens against `max_tokens`; without this, adaptive thinking can
+    # consume the entire budget on the encrypted CoT and produce no text.
+    thinking_token_budget = (
+        _anthropic_thinking_budget_tokens(effort_level) if enable_thinking else None
+    )
     payload: dict[str, Any] = {
         "model": normalized_model,
         "messages": anthropic_messages_from_history(input_messages),
-        "max_tokens": max_output_tokens,
+        "max_tokens": _anthropic_max_tokens(max_output_tokens, thinking_token_budget),
     }
-    # Claude Opus 4.7 returns HTTP 400 if `temperature` is present.
-    if not normalized_model.lower().startswith("claude-opus-4-7"):
+    if use_adaptive:
+        # Adaptive thinking lets the model self-pick its budget within Anthropic's
+        # cap for the chosen effort. Required on Opus 4.7 (manual budget_tokens 400s).
+        payload["thinking"] = {"type": "adaptive"}
+        payload["output_config"] = {"effort": normalized_effort}
+    elif thinking_token_budget is not None:
+        payload["thinking"] = {
+            "type": "enabled",
+            "budget_tokens": thinking_token_budget,
+        }
+    # Claude Opus 4.7 (and extended thinking) rejects `temperature`.
+    if not enable_thinking and not normalized_model.lower().startswith(
+        "claude-opus-4-7"
+    ):
         payload["temperature"] = DEFAULT_ANTHROPIC_TEMPERATURE
     if system_prompt:
         payload["system"] = system_prompt
@@ -197,7 +301,10 @@ class _ProviderConfig:
     api_base_env_names: tuple[str, ...]
     api_key_env_names: tuple[str, ...]
     missing_api_key_error: str
-    build_payload: Callable[[str, list[dict[str, str]], int], dict[str, Any]]
+    build_payload: Callable[
+        [str, list[dict[str, str]], int, str | None],
+        dict[str, Any],
+    ]
     build_headers: Callable[[str], dict[str, str]]
     extract_text: Callable[[dict[str, object]], str]
 
@@ -309,9 +416,15 @@ def _build_provider_payload(
     model: str,
     messages: list[dict[str, str]],
     max_output_tokens: int,
+    effort_level: str | None,
 ) -> dict[str, Any]:
     """Build the JSON request body for the selected provider."""
-    return _provider_config(provider).build_payload(model, messages, max_output_tokens)
+    return _provider_config(provider).build_payload(
+        model,
+        messages,
+        max_output_tokens,
+        effort_level,
+    )
 
 
 def _build_provider_headers(provider: str, api_key: str) -> dict[str, str]:
@@ -377,6 +490,7 @@ def call_provider(
     messages: list[dict[str, str]],
     max_output_tokens: int,
     request_timeout_s: float,
+    effort_level: str | None = None,
 ) -> str:
     """Resolve credentials, send one request, and extract text from the response."""
     normalized_provider = normalize_provider(provider)
@@ -392,6 +506,7 @@ def call_provider(
             model=model,
             messages=messages,
             max_output_tokens=max_output_tokens,
+            effort_level=effort_level,
         ),
         _build_provider_headers(normalized_provider, resolved_api_key),
         request_timeout_s=request_timeout_s,

--- a/helion/autotuner/llm_search.py
+++ b/helion/autotuner/llm_search.py
@@ -110,6 +110,8 @@ def guided_search_kwargs_from_config(
         kwargs["provider"] = provider
     if (model := os.environ.get("HELION_LLM_MODEL")) is not None:
         kwargs["model"] = model
+    if (effort_level := os.environ.get("HELION_LLM_EFFORT_LEVEL")) is not None:
+        kwargs["effort_level"] = effort_level
     if (value := os.environ.get("HELION_LLM_COMPILE_TIMEOUT_S")) is not None:
         kwargs["compile_timeout_s"] = int(value)
     return kwargs
@@ -160,6 +162,8 @@ class LLMGuidedSearch(PopulationBasedSearch):
         api_key: Optional API key. Defaults to the provider's env var (e.g. OPENAI_API_KEY).
         compile_timeout_s: Optional compile-time cap applied only while the LLM
             search benchmarks its exploratory configs.
+        effort_level: Optional provider-specific effort-level hint (none / low /
+            medium / high / max). Can also be set via HELION_LLM_EFFORT_LEVEL.
     """
 
     def __init__(
@@ -178,6 +182,7 @@ class LLMGuidedSearch(PopulationBasedSearch):
         api_key: str | None = None,
         request_timeout_s: float = DEFAULT_REQUEST_TIMEOUT_S,
         compile_timeout_s: int | None = None,
+        effort_level: str | None = None,
     ) -> None:
         super().__init__(kernel, args, finishing_rounds=finishing_rounds)
         if max_rounds < 1:
@@ -194,6 +199,7 @@ class LLMGuidedSearch(PopulationBasedSearch):
         self.api_key = api_key
         self.request_timeout_s = request_timeout_s
         self.compile_timeout_s = compile_timeout_s
+        self.effort_level = effort_level
 
         self._messages: list[dict[str, str]] = []
         self._all_benchmark_results: list[BenchmarkResult] = []
@@ -288,6 +294,7 @@ class LLMGuidedSearch(PopulationBasedSearch):
                 messages=messages,
                 max_output_tokens=self._max_output_tokens_for_request(),
                 request_timeout_s=self.request_timeout_s,
+                effort_level=self.effort_level,
             )
         except Exception as e:
             self.log.warning(f"LLM call failed: {type(e).__name__}: {e}")

--- a/helion/autotuner/llm_seeded_lfbo.py
+++ b/helion/autotuner/llm_seeded_lfbo.py
@@ -115,6 +115,7 @@ class LLMSeededSearch(BaseSearch):
         llm_api_base: str | None = None,
         llm_api_key: str | None = None,
         llm_request_timeout_s: float = DEFAULT_REQUEST_TIMEOUT_S,
+        llm_effort_level: str | None = None,
     ) -> None:
         super().__init__(kernel, args)
         if llm_max_rounds < 0:
@@ -140,6 +141,7 @@ class LLMSeededSearch(BaseSearch):
         self.llm_api_base = llm_api_base
         self.llm_api_key = llm_api_key
         self.llm_request_timeout_s = llm_request_timeout_s
+        self.llm_effort_level = llm_effort_level
 
         self.hybrid_stage_breakdown = None
 
@@ -199,6 +201,7 @@ class LLMSeededSearch(BaseSearch):
             api_base=self.llm_api_base,
             api_key=self.llm_api_key,
             request_timeout_s=self.llm_request_timeout_s,
+            effort_level=self.llm_effort_level,
         )
 
     def _second_stage_search_kwargs(self, *, seeded: bool) -> dict[str, object]:
@@ -412,6 +415,7 @@ class LLMSeededLFBOTreeSearch(LLMSeededSearch):
         llm_api_base: str | None = None,
         llm_api_key: str | None = None,
         llm_request_timeout_s: float = DEFAULT_REQUEST_TIMEOUT_S,
+        llm_effort_level: str | None = None,
     ) -> None:
         super().__init__(
             kernel,
@@ -428,4 +432,5 @@ class LLMSeededLFBOTreeSearch(LLMSeededSearch):
             llm_api_base=llm_api_base,
             llm_api_key=llm_api_key,
             llm_request_timeout_s=llm_request_timeout_s,
+            llm_effort_level=llm_effort_level,
         )

--- a/test/test_llm_autotuner.py
+++ b/test/test_llm_autotuner.py
@@ -46,10 +46,11 @@ class TestLLMGuidedSearch(TestCase):
         search.configs_per_round = 15
         search._llm_call_times = []
         search._benchmark_times = []
-        search.model = "gpt-5-2"
+        search.model = "gpt-5.5"
         search.api_base = None
         search.api_key = None
         search.request_timeout_s = 120.0
+        search.effort_level = None
 
         # Mock config_spec with a normalize that accepts anything.
         search.config_spec = SimpleNamespace(
@@ -397,16 +398,21 @@ class TestLLMTransport(TestCase):
         from helion.autotuner.llm.transport import extract_anthropic_text
         from helion.autotuner.llm.transport import extract_openai_response_text
         from helion.autotuner.llm.transport import infer_provider
+        from helion.autotuner.llm.transport import normalize_effort_level
         from helion.autotuner.llm.transport import responses_input_from_messages
         from helion.autotuner.llm.transport import split_system_messages
 
-        self.assertEqual(infer_provider("claude-haiku-4.5"), "anthropic")
-        self.assertEqual(infer_provider("gpt-5-2"), "openai_responses")
+        self.assertEqual(infer_provider("claude-opus-4-7"), "anthropic")
+        self.assertEqual(infer_provider("gpt-5.5"), "openai_responses")
         self.assertEqual(infer_provider("custom/model"), "unsupported")
         self.assertEqual(infer_provider("custom/model", "anthropic"), "anthropic")
         self.assertEqual(infer_provider("custom/model", "openai"), "openai_responses")
+        self.assertEqual(normalize_effort_level("MAX"), "max")
+        self.assertEqual(normalize_effort_level("off"), "none")
         with self.assertRaisesRegex(ValueError, "Unsupported LLM provider"):
-            infer_provider("gpt-5-2", "bogus")
+            infer_provider("gpt-5.5", "bogus")
+        with self.assertRaisesRegex(ValueError, "Unsupported LLM effort level"):
+            normalize_effort_level("bogus")
 
         self.assertEqual(
             _resolve_v1_endpoint("https://api.openai.com", "responses"),
@@ -496,7 +502,7 @@ class TestLLMTransport(TestCase):
                 "provider": "openai_responses",
                 "response_payload": self._response_payload("openai_responses"),
                 "expected_text": '{"configs": []}',
-                "model": "gpt-5-2",
+                "model": "gpt-5.5",
                 "api_base": "https://api.openai.com",
                 "expected_url": "https://api.openai.com/v1/responses",
                 "api_key": "openai-test-key",
@@ -518,7 +524,7 @@ class TestLLMTransport(TestCase):
                     "anthropic", '{"configs": [{"num_warps": 4}]}'
                 ),
                 "expected_text": '{"configs": [{"num_warps": 4}]}',
-                "model": "claude-3-5-haiku-latest",
+                "model": "claude-opus-4-7",
                 "api_base": "https://api.anthropic.com",
                 "expected_url": "https://api.anthropic.com/v1/messages",
                 "api_key": "anthropic-test-key",
@@ -576,6 +582,142 @@ class TestLLMTransport(TestCase):
                 self.assertEqual(captured["request_timeout_s"], 120.0)
                 case["request_assertions"](captured)
 
+    def test_supports_anthropic_adaptive_version_matrix(self):
+        """Adaptive-thinking detection follows per-family minimum versions."""
+        from helion.autotuner.llm.transport import _supports_anthropic_adaptive
+
+        cases = {
+            # Opus 4.5+ supports adaptive; 4.4 / 4.1 / 4 (no minor) do not.
+            "claude-opus-4-5": True,
+            "claude-opus-4-6": True,
+            "claude-opus-4-7": True,
+            "claude-opus-4-4": False,
+            "claude-opus-4-1": False,
+            "claude-opus-4": False,
+            # Sonnet only crosses the threshold at 4.6.
+            "claude-sonnet-4-6": True,
+            "claude-sonnet-4-5": False,
+            # Variants and date suffixes still match the family/version prefix.
+            "claude-opus-4-7[1m]": True,
+            "claude-opus-4-7-20260201": True,
+            # A bare date suffix (no minor) must not be parsed as minor=20250514.
+            "claude-opus-4-20250514": False,
+            # Future major / minor releases auto-recognized.
+            "claude-opus-5-0": True,
+            "claude-opus-4-99": True,
+            "claude-sonnet-5-0": True,
+            # Families without an adaptive entry stay on the legacy path.
+            "claude-haiku-4-5": False,
+            # Old-naming models (version before family) never match.
+            "claude-3-5-sonnet-20241022": False,
+            "claude-3-7-sonnet-20250219": False,
+            # Non-Anthropic / unknown model strings fall through.
+            "gpt-5.5": False,
+            "custom-model": False,
+        }
+        for model, expected in cases.items():
+            with self.subTest(model=model):
+                self.assertEqual(_supports_anthropic_adaptive(model), expected)
+
+    def test_transport_effort_level_payloads(self):
+        """Reasoning effort maps to provider-specific request payload fields."""
+        from helion.autotuner.llm.transport import call_provider
+
+        captured = {}
+        messages = [{"role": "user", "content": "suggest configs"}]
+
+        def fake_post_json(url, payload, headers, *, request_timeout_s):
+            del url, headers, request_timeout_s
+            captured["payload"] = payload
+            if "input" in payload:
+                return self._response_payload("openai_responses")
+            return self._response_payload("anthropic")
+
+        # gpt-5.5 supports the xhigh effort level, so the provider-neutral "max"
+        # maps directly to xhigh on the OpenAI side.
+        with patch(
+            "helion.autotuner.llm.transport._post_json",
+            side_effect=fake_post_json,
+        ):
+            call_provider(
+                "openai_responses",
+                model="gpt-5.5",
+                api_base="https://api.openai.com",
+                api_key="openai-test-key",
+                messages=messages,
+                max_output_tokens=512,
+                request_timeout_s=120.0,
+                effort_level="max",
+            )
+        self.assertEqual(captured["payload"]["reasoning"], {"effort": "xhigh"})
+
+        # Older OpenAI models without xhigh support fall back to "high" for the
+        # provider-neutral "max" knob.
+        captured.clear()
+        with patch(
+            "helion.autotuner.llm.transport._post_json",
+            side_effect=fake_post_json,
+        ):
+            call_provider(
+                "openai_responses",
+                model="gpt-5-2",
+                api_base="https://api.openai.com",
+                api_key="openai-test-key",
+                messages=messages,
+                max_output_tokens=512,
+                request_timeout_s=120.0,
+                effort_level="max",
+            )
+        self.assertEqual(captured["payload"]["reasoning"], {"effort": "high"})
+
+        # Modern Claude models (Opus 4.5+, Sonnet 4.6+) use adaptive thinking;
+        # the model self-picks its budget so no budget_tokens is sent. Required on
+        # Opus 4.7 where manual budget_tokens returns HTTP 400.
+        captured.clear()
+        with patch(
+            "helion.autotuner.llm.transport._post_json",
+            side_effect=fake_post_json,
+        ):
+            call_provider(
+                "anthropic",
+                model="claude-opus-4-7",
+                api_base="https://api.anthropic.com",
+                api_key="anthropic-test-key",
+                messages=messages,
+                max_output_tokens=512,
+                request_timeout_s=120.0,
+                effort_level="max",
+            )
+        self.assertEqual(captured["payload"]["thinking"], {"type": "adaptive"})
+        self.assertEqual(captured["payload"]["output_config"], {"effort": "max"})
+        # max_tokens reserves the adaptive thinking budget (24000) + visible output (512).
+        self.assertEqual(captured["payload"]["max_tokens"], 24512)
+        self.assertNotIn("temperature", captured["payload"])
+
+        # Legacy Claude models (Opus 4 / Sonnet 4.5 and earlier) still go through
+        # the manual budget_tokens path with the same low/medium/high/max table.
+        captured.clear()
+        with patch(
+            "helion.autotuner.llm.transport._post_json",
+            side_effect=fake_post_json,
+        ):
+            call_provider(
+                "anthropic",
+                model="claude-opus-4",
+                api_base="https://api.anthropic.com",
+                api_key="anthropic-test-key",
+                messages=messages,
+                max_output_tokens=512,
+                request_timeout_s=120.0,
+                effort_level="high",
+            )
+        self.assertEqual(
+            captured["payload"]["thinking"],
+            {"type": "enabled", "budget_tokens": 8192},
+        )
+        self.assertEqual(captured["payload"]["max_tokens"], 8704)
+        self.assertNotIn("output_config", captured["payload"])
+
 
 class TestLLMSeededLFBOTreeSearch(TestCase):
     """Tests for the two-stage LLM-seeded hybrid autotuner."""
@@ -615,6 +757,7 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
             {
                 "HELION_HYBRID_LLM_MAX_ROUNDS": "2",
                 "HELION_LLM_PROVIDER": "openai",
+                "HELION_LLM_EFFORT_LEVEL": "max",
             },
             clear=False,
         ):
@@ -623,9 +766,11 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
             )
         self.assertEqual(kwargs["llm_max_rounds"], 2)
         self.assertEqual(kwargs["llm_provider"], "openai")
+        self.assertEqual(kwargs["llm_effort_level"], "max")
 
         search = LLMSeededLFBOTreeSearch(kernel, (), **kwargs)
         self.assertEqual(search.llm_provider, "openai")
+        self.assertEqual(search.llm_effort_level, "max")
 
     def test_selected_by_env(self):
         """HELION_AUTOTUNER selects the hybrid autotuner and applies profile defaults."""


### PR DESCRIPTION
Stacked PRs:
 * #2465
 * #2451
 * #2448
 * #2450
 * __->__#2446


--- --- ---
### [Autotuner] LLM search: effort_level knob + Anthropic adaptive thinking + OpenAI xhigh

- Added "effort_level" knob (none/low/medium/high/max) on LLMGuidedSearch,
  LLMSeededSearch, LLMSeededLFBOTreeSearch. Env var: HELION_LLM_EFFORT_LEVEL.
- Anthropic: adaptive thinking token budget on
  Opus 4.5+/Sonnet 4.6+ (required on Opus 4.7); legacy budget_tokens on older models.
- OpenAI: max effort maps to xhigh on gpt-5.1-codex-max / gpt-5.4+, else high.

Results (B200, full effort, GPU 1, `HELION_LLM_MODEL=claude-opus-4-7
HELION_LLM_EFFORT_LEVEL=max HELION_LLM_FAST_MODE=1`):

| kernel     | wall time LFBO (s) | wall time LLM (s) | wall time ratio | helion LFBO (ms) | helion LLM (ms) | perf ratio |
| ---------- | ------------- | ------------ | ---------- | ---------------- | --------------- | ------------ |
| attention  |        251.9 |        114.6 |  **0.46×** |          0.0594 |          0.0548 |        0.92× |
| gdn_fwd_h  |        286.7 |        118.1 |  **0.41×** |          0.5910 |          0.6165 |        1.04× |
| layer_norm |       1358.3 |        723.7 |  **0.53×** |          0.0349 |          0.0389 |        1.11× |
| matmul     |        117.9 |         97.8 |  **0.83×** |          0.0154 |          0.0143 |        0.93× |
| rope       |         96.1 |         56.7 |  **0.59×** |          0.0497 |          0.0458 |        0.92× |
| softmax    |        573.3 |        162.8 |  **0.28×** |          0.0143 |          0.0165 |        1.15× |

Geomean wall time ratio: **0.49×**, geomean perf ratio: **1.01×**. Ratios are LLM/LFBO; `<1.0×` is the LLM-seeded win.
cc: @mengluy0125 


