### PR TITLE
[Autotuner] LLM search: Anthropic Opus 4.6/4.7 fast mode

### DIFF
--- a/helion/autotuner/llm/transport.py
+++ b/helion/autotuner/llm/transport.py
@@ -217,8 +217,10 @@ def _openai_payload(
     messages: list[dict[str, str]],
     max_output_tokens: int,
     effort_level: str | None,
+    fast_mode: bool,
 ) -> dict[str, Any]:
     """Build an OpenAI Responses request payload."""
+    # fast_mode is Anthropic-only; the kwarg is accepted for dispatch parity.
     system_prompt, input_messages = split_system_messages(messages)
     payload: dict[str, Any] = {
         "model": strip_provider_prefix(model),
@@ -237,11 +239,14 @@ def _anthropic_payload(
     messages: list[dict[str, str]],
     max_output_tokens: int,
     effort_level: str | None,
+    fast_mode: bool,
 ) -> dict[str, Any]:
     """Build an Anthropic Messages request payload."""
     system_prompt, input_messages = split_system_messages(messages)
     normalized_model = strip_provider_prefix(model)
-    normalized_effort = normalize_effort_level(effort_level)
+    # Fast mode (Opus 4.6/4.7) is a non-thinking inference path, so it overrides
+    # any effort_level setting rather than failing the request.
+    normalized_effort = None if fast_mode else normalize_effort_level(effort_level)
     enable_thinking = normalized_effort not in {None, "none"}
     use_adaptive = enable_thinking and _supports_anthropic_adaptive(normalized_model)
     legacy_budget_tokens = (
@@ -254,7 +259,9 @@ def _anthropic_payload(
         "messages": anthropic_messages_from_history(input_messages),
         "max_tokens": _anthropic_max_tokens(max_output_tokens, legacy_budget_tokens),
     }
-    if use_adaptive:
+    if fast_mode:
+        payload["speed"] = "fast"
+    elif use_adaptive:
         # Adaptive thinking lets the model self-pick its budget within Anthropic's
         # cap for the chosen effort. Required on Opus 4.7 (manual budget_tokens 400s).
         payload["thinking"] = {"type": "adaptive"}
@@ -264,9 +271,12 @@ def _anthropic_payload(
             "type": "enabled",
             "budget_tokens": legacy_budget_tokens,
         }
-    # Claude Opus 4.7 (and extended thinking) rejects `temperature`.
-    if not enable_thinking and not normalized_model.lower().startswith(
-        "claude-opus-4-7"
+    # Claude Opus 4.7 (and fast mode on any Opus, and extended thinking) rejects
+    # `temperature`.
+    if (
+        not enable_thinking
+        and not fast_mode
+        and not normalized_model.lower().startswith("claude-opus-4-7")
     ):
         payload["temperature"] = DEFAULT_ANTHROPIC_TEMPERATURE
     if system_prompt:
@@ -274,21 +284,27 @@ def _anthropic_payload(
     return payload
 
 
-def _openai_headers(api_key: str) -> dict[str, str]:
+def _openai_headers(api_key: str, fast_mode: bool) -> dict[str, str]:
     """Build OpenAI-compatible auth headers."""
+    # fast_mode is Anthropic-only; the kwarg is accepted for dispatch parity.
     return {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
     }
 
 
-def _anthropic_headers(api_key: str) -> dict[str, str]:
+def _anthropic_headers(api_key: str, fast_mode: bool) -> dict[str, str]:
     """Build Anthropic Messages auth headers."""
-    return {
+    headers = {
         "content-type": "application/json",
         "anthropic-version": "2023-06-01",
         "x-api-key": api_key,
     }
+    if fast_mode:
+        # Opus 4.6/4.7 fast-mode beta. Direct Anthropic API only — Vertex strips
+        # this header. Paired with the `speed: "fast"` body field in _anthropic_payload.
+        headers["anthropic-beta"] = "fast-mode-2026-02-01"
+    return headers
 
 
 @dataclass(frozen=True)
@@ -301,10 +317,10 @@ class _ProviderConfig:
     api_key_env_names: tuple[str, ...]
     missing_api_key_error: str
     build_payload: Callable[
-        [str, list[dict[str, str]], int, str | None],
+        [str, list[dict[str, str]], int, str | None, bool],
         dict[str, Any],
     ]
-    build_headers: Callable[[str], dict[str, str]]
+    build_headers: Callable[[str, bool], dict[str, str]]
     extract_text: Callable[[dict[str, object]], str]
 
 
@@ -416,6 +432,7 @@ def _build_provider_payload(
     messages: list[dict[str, str]],
     max_output_tokens: int,
     effort_level: str | None,
+    fast_mode: bool,
 ) -> dict[str, Any]:
     """Build the JSON request body for the selected provider."""
     return _provider_config(provider).build_payload(
@@ -423,12 +440,15 @@ def _build_provider_payload(
         messages,
         max_output_tokens,
         effort_level,
+        fast_mode,
     )
 
 
-def _build_provider_headers(provider: str, api_key: str) -> dict[str, str]:
+def _build_provider_headers(
+    provider: str, api_key: str, fast_mode: bool
+) -> dict[str, str]:
     """Build auth and content headers for the selected provider."""
-    return _provider_config(provider).build_headers(api_key)
+    return _provider_config(provider).build_headers(api_key, fast_mode)
 
 
 def _load_json_response(
@@ -490,6 +510,7 @@ def call_provider(
     max_output_tokens: int,
     request_timeout_s: float,
     effort_level: str | None = None,
+    fast_mode: bool = False,
 ) -> str:
     """Resolve credentials, send one request, and extract text from the response."""
     normalized_provider = normalize_provider(provider)
@@ -506,8 +527,9 @@ def call_provider(
             messages=messages,
             max_output_tokens=max_output_tokens,
             effort_level=effort_level,
+            fast_mode=fast_mode,
         ),
-        _build_provider_headers(normalized_provider, resolved_api_key),
+        _build_provider_headers(normalized_provider, resolved_api_key, fast_mode),
         request_timeout_s=request_timeout_s,
     )
     return config.extract_text(response)

--- a/helion/autotuner/llm/transport.py
+++ b/helion/autotuner/llm/transport.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import json
 import os
+import re
 import ssl
 from typing import TYPE_CHECKING
 from typing import Any
@@ -18,6 +19,29 @@ DEFAULT_REQUEST_TIMEOUT_S = 120.0
 # OpenAI Responses does not consume a temperature knob in our current request path,
 # so keep Anthropic's setting internal instead of exposing it on the search API.
 DEFAULT_ANTHROPIC_TEMPERATURE = 0.3
+# Legacy `budget_tokens` presets (1024 = Anthropic's hard minimum). Newer models
+# self-pick via adaptive thinking — see `_supports_anthropic_adaptive`.
+_ANTHROPIC_THINKING_BUDGET_BY_EFFORT = {
+    "low": 1024,
+    "medium": 4096,
+    "high": 8192,
+    "max": 24000,
+}
+_VALID_EFFORT_LEVELS = frozenset({"none", "low", "medium", "high", "max"})
+# Per-family minimum (major, minor) for adaptive thinking. Required on Opus 4.7+
+# (manual budget_tokens returns HTTP 400). Below-minimum / unlisted → legacy path.
+_ANTHROPIC_ADAPTIVE_MIN_VERSIONS: dict[str, tuple[int, int]] = {
+    "opus": (4, 5),
+    "sonnet": (4, 6),
+}
+# Minor capped at 2 digits + non-digit lookahead so 8-digit date suffixes (e.g.
+# `claude-opus-4-20250514`) don't get mis-parsed as the minor version.
+_ANTHROPIC_MODEL_VERSION_RE = re.compile(
+    r"^claude-([a-z]+)-(\d+)(?:-(\d{1,2})(?=\D|$))?"
+)
+# Models that accept OpenAI's `xhigh` effort. Others reject it, so "max" only
+# maps to "xhigh" here; elsewhere "max" → "high".
+_OPENAI_XHIGH_MODELS = frozenset({"gpt-5.1-codex-max", "gpt-5.4", "gpt-5.5"})
 
 _PROVIDER_ALIASES = {
     "anthropic": "anthropic",
@@ -99,6 +123,61 @@ def anthropic_messages_from_history(
     ]
 
 
+def normalize_effort_level(effort_level: str | None) -> str | None:
+    """Normalize the optional model effort-level knob."""
+    from ...runtime.settings import _FALSE_LITERALS
+
+    if effort_level is None:
+        return None
+    normalized = effort_level.strip().lower()
+    if normalized in _FALSE_LITERALS:
+        return "none"
+    if normalized not in _VALID_EFFORT_LEVELS:
+        raise ValueError(
+            f"Unsupported LLM effort level {effort_level!r}. "
+            "Valid values are: none, low, medium, high, max."
+        )
+    return normalized
+
+
+def _openai_effort_level(effort_level: str | None, model: str) -> str | None:
+    normalized = normalize_effort_level(effort_level)
+    if normalized in {None, "none"}:
+        return None
+    if normalized == "max":
+        return (
+            "xhigh" if strip_provider_prefix(model) in _OPENAI_XHIGH_MODELS else "high"
+        )
+    return normalized
+
+
+def _anthropic_thinking_budget_tokens(effort_level: str | None) -> int | None:
+    normalized = normalize_effort_level(effort_level)
+    if normalized in {None, "none"}:
+        return None
+    return _ANTHROPIC_THINKING_BUDGET_BY_EFFORT[normalized]
+
+
+def _supports_anthropic_adaptive(model: str) -> bool:
+    match = _ANTHROPIC_MODEL_VERSION_RE.match(model.lower())
+    if match is None:
+        return False
+    family, major_str, minor_str = match.groups()
+    minimum = _ANTHROPIC_ADAPTIVE_MIN_VERSIONS.get(family)
+    if minimum is None:
+        return False
+    return (int(major_str), int(minor_str) if minor_str else 0) >= minimum
+
+
+def _anthropic_max_tokens(
+    max_output_tokens: int,
+    thinking_budget_tokens: int | None,
+) -> int:
+    if thinking_budget_tokens is None:
+        return max_output_tokens
+    return thinking_budget_tokens + max_output_tokens
+
+
 def _extract_text_content_items(content: object) -> list[str]:
     """Collect plain-text content blocks from a provider response payload."""
     if not isinstance(content, list):
@@ -137,6 +216,7 @@ def _openai_payload(
     model: str,
     messages: list[dict[str, str]],
     max_output_tokens: int,
+    effort_level: str | None,
 ) -> dict[str, Any]:
     """Build an OpenAI Responses request payload."""
     system_prompt, input_messages = split_system_messages(messages)
@@ -145,6 +225,8 @@ def _openai_payload(
         "input": responses_input_from_messages(input_messages),
         "max_output_tokens": max_output_tokens,
     }
+    if (effort := _openai_effort_level(effort_level, model)) is not None:
+        payload["reasoning"] = {"effort": effort}
     if system_prompt:
         payload["instructions"] = system_prompt
     return payload
@@ -154,17 +236,38 @@ def _anthropic_payload(
     model: str,
     messages: list[dict[str, str]],
     max_output_tokens: int,
+    effort_level: str | None,
 ) -> dict[str, Any]:
     """Build an Anthropic Messages request payload."""
     system_prompt, input_messages = split_system_messages(messages)
     normalized_model = strip_provider_prefix(model)
+    normalized_effort = normalize_effort_level(effort_level)
+    enable_thinking = normalized_effort not in {None, "none"}
+    use_adaptive = enable_thinking and _supports_anthropic_adaptive(normalized_model)
+    legacy_budget_tokens = (
+        _anthropic_thinking_budget_tokens(effort_level)
+        if enable_thinking and not use_adaptive
+        else None
+    )
     payload: dict[str, Any] = {
         "model": normalized_model,
         "messages": anthropic_messages_from_history(input_messages),
-        "max_tokens": max_output_tokens,
+        "max_tokens": _anthropic_max_tokens(max_output_tokens, legacy_budget_tokens),
     }
-    # Claude Opus 4.7 returns HTTP 400 if `temperature` is present.
-    if not normalized_model.lower().startswith("claude-opus-4-7"):
+    if use_adaptive:
+        # Adaptive thinking lets the model self-pick its budget within Anthropic's
+        # cap for the chosen effort. Required on Opus 4.7 (manual budget_tokens 400s).
+        payload["thinking"] = {"type": "adaptive"}
+        payload["output_config"] = {"effort": normalized_effort}
+    elif legacy_budget_tokens is not None:
+        payload["thinking"] = {
+            "type": "enabled",
+            "budget_tokens": legacy_budget_tokens,
+        }
+    # Claude Opus 4.7 (and extended thinking) rejects `temperature`.
+    if not enable_thinking and not normalized_model.lower().startswith(
+        "claude-opus-4-7"
+    ):
         payload["temperature"] = DEFAULT_ANTHROPIC_TEMPERATURE
     if system_prompt:
         payload["system"] = system_prompt
@@ -197,7 +300,10 @@ class _ProviderConfig:
     api_base_env_names: tuple[str, ...]
     api_key_env_names: tuple[str, ...]
     missing_api_key_error: str
-    build_payload: Callable[[str, list[dict[str, str]], int], dict[str, Any]]
+    build_payload: Callable[
+        [str, list[dict[str, str]], int, str | None],
+        dict[str, Any],
+    ]
     build_headers: Callable[[str], dict[str, str]]
     extract_text: Callable[[dict[str, object]], str]
 
@@ -309,9 +415,15 @@ def _build_provider_payload(
     model: str,
     messages: list[dict[str, str]],
     max_output_tokens: int,
+    effort_level: str | None,
 ) -> dict[str, Any]:
     """Build the JSON request body for the selected provider."""
-    return _provider_config(provider).build_payload(model, messages, max_output_tokens)
+    return _provider_config(provider).build_payload(
+        model,
+        messages,
+        max_output_tokens,
+        effort_level,
+    )
 
 
 def _build_provider_headers(provider: str, api_key: str) -> dict[str, str]:
@@ -377,6 +489,7 @@ def call_provider(
     messages: list[dict[str, str]],
     max_output_tokens: int,
     request_timeout_s: float,
+    effort_level: str | None = None,
 ) -> str:
     """Resolve credentials, send one request, and extract text from the response."""
     normalized_provider = normalize_provider(provider)
@@ -392,6 +505,7 @@ def call_provider(
             model=model,
             messages=messages,
             max_output_tokens=max_output_tokens,
+            effort_level=effort_level,
         ),
         _build_provider_headers(normalized_provider, resolved_api_key),
         request_timeout_s=request_timeout_s,

--- a/helion/autotuner/llm_search.py
+++ b/helion/autotuner/llm_search.py
@@ -112,6 +112,10 @@ def guided_search_kwargs_from_config(
         kwargs["model"] = model
     if (effort_level := os.environ.get("HELION_LLM_EFFORT_LEVEL")) is not None:
         kwargs["effort_level"] = effort_level
+    if os.environ.get("HELION_LLM_FAST_MODE") is not None:
+        from ..runtime.settings import _env_get_bool
+
+        kwargs["fast_mode"] = _env_get_bool("HELION_LLM_FAST_MODE", False)
     if (value := os.environ.get("HELION_LLM_COMPILE_TIMEOUT_S")) is not None:
         kwargs["compile_timeout_s"] = int(value)
     return kwargs
@@ -164,6 +168,9 @@ class LLMGuidedSearch(PopulationBasedSearch):
             search benchmarks its exploratory configs.
         effort_level: Optional provider-specific effort-level hint (none / low /
             medium / high / max). Can also be set via HELION_LLM_EFFORT_LEVEL.
+        fast_mode: Opt into Anthropic Opus 4.6/4.7 fast mode (faster output
+            tokens, no extended thinking). Ignored by non-Anthropic providers.
+            Can also be set via HELION_LLM_FAST_MODE.
     """
 
     def __init__(
@@ -183,6 +190,7 @@ class LLMGuidedSearch(PopulationBasedSearch):
         request_timeout_s: float = DEFAULT_REQUEST_TIMEOUT_S,
         compile_timeout_s: int | None = None,
         effort_level: str | None = None,
+        fast_mode: bool = False,
     ) -> None:
         super().__init__(kernel, args, finishing_rounds=finishing_rounds)
         if max_rounds < 1:
@@ -200,6 +208,7 @@ class LLMGuidedSearch(PopulationBasedSearch):
         self.request_timeout_s = request_timeout_s
         self.compile_timeout_s = compile_timeout_s
         self.effort_level = effort_level
+        self.fast_mode = fast_mode
 
         self._messages: list[dict[str, str]] = []
         self._all_benchmark_results: list[BenchmarkResult] = []
@@ -295,6 +304,7 @@ class LLMGuidedSearch(PopulationBasedSearch):
                 max_output_tokens=self._max_output_tokens_for_request(),
                 request_timeout_s=self.request_timeout_s,
                 effort_level=self.effort_level,
+                fast_mode=self.fast_mode,
             )
         except Exception as e:
             self.log.warning(f"LLM call failed: {type(e).__name__}: {e}")

--- a/helion/autotuner/llm_search.py
+++ b/helion/autotuner/llm_search.py
@@ -110,6 +110,8 @@ def guided_search_kwargs_from_config(
         kwargs["provider"] = provider
     if (model := os.environ.get("HELION_LLM_MODEL")) is not None:
         kwargs["model"] = model
+    if (effort_level := os.environ.get("HELION_LLM_EFFORT_LEVEL")) is not None:
+        kwargs["effort_level"] = effort_level
     if (value := os.environ.get("HELION_LLM_COMPILE_TIMEOUT_S")) is not None:
         kwargs["compile_timeout_s"] = int(value)
     return kwargs
@@ -160,6 +162,8 @@ class LLMGuidedSearch(PopulationBasedSearch):
         api_key: Optional API key. Defaults to the provider's env var (e.g. OPENAI_API_KEY).
         compile_timeout_s: Optional compile-time cap applied only while the LLM
             search benchmarks its exploratory configs.
+        effort_level: Optional provider-specific effort-level hint (none / low /
+            medium / high / max). Can also be set via HELION_LLM_EFFORT_LEVEL.
     """
 
     def __init__(
@@ -178,6 +182,7 @@ class LLMGuidedSearch(PopulationBasedSearch):
         api_key: str | None = None,
         request_timeout_s: float = DEFAULT_REQUEST_TIMEOUT_S,
         compile_timeout_s: int | None = None,
+        effort_level: str | None = None,
     ) -> None:
         super().__init__(kernel, args, finishing_rounds=finishing_rounds)
         if max_rounds < 1:
@@ -194,6 +199,7 @@ class LLMGuidedSearch(PopulationBasedSearch):
         self.api_key = api_key
         self.request_timeout_s = request_timeout_s
         self.compile_timeout_s = compile_timeout_s
+        self.effort_level = effort_level
 
         self._messages: list[dict[str, str]] = []
         self._all_benchmark_results: list[BenchmarkResult] = []
@@ -288,6 +294,7 @@ class LLMGuidedSearch(PopulationBasedSearch):
                 messages=messages,
                 max_output_tokens=self._max_output_tokens_for_request(),
                 request_timeout_s=self.request_timeout_s,
+                effort_level=self.effort_level,
             )
         except Exception as e:
             self.log.warning(f"LLM call failed: {type(e).__name__}: {e}")

--- a/helion/autotuner/llm_seeded_lfbo.py
+++ b/helion/autotuner/llm_seeded_lfbo.py
@@ -116,6 +116,7 @@ class LLMSeededSearch(BaseSearch):
         llm_api_key: str | None = None,
         llm_request_timeout_s: float = DEFAULT_REQUEST_TIMEOUT_S,
         llm_effort_level: str | None = None,
+        llm_fast_mode: bool = False,
     ) -> None:
         super().__init__(kernel, args)
         if llm_max_rounds < 0:
@@ -142,6 +143,7 @@ class LLMSeededSearch(BaseSearch):
         self.llm_api_key = llm_api_key
         self.llm_request_timeout_s = llm_request_timeout_s
         self.llm_effort_level = llm_effort_level
+        self.llm_fast_mode = llm_fast_mode
 
         self.hybrid_stage_breakdown = None
 
@@ -202,6 +204,7 @@ class LLMSeededSearch(BaseSearch):
             api_key=self.llm_api_key,
             request_timeout_s=self.llm_request_timeout_s,
             effort_level=self.llm_effort_level,
+            fast_mode=self.llm_fast_mode,
         )
 
     def _second_stage_search_kwargs(self, *, seeded: bool) -> dict[str, object]:
@@ -416,6 +419,7 @@ class LLMSeededLFBOTreeSearch(LLMSeededSearch):
         llm_api_key: str | None = None,
         llm_request_timeout_s: float = DEFAULT_REQUEST_TIMEOUT_S,
         llm_effort_level: str | None = None,
+        llm_fast_mode: bool = False,
     ) -> None:
         super().__init__(
             kernel,
@@ -433,4 +437,5 @@ class LLMSeededLFBOTreeSearch(LLMSeededSearch):
             llm_api_key=llm_api_key,
             llm_request_timeout_s=llm_request_timeout_s,
             llm_effort_level=llm_effort_level,
+            llm_fast_mode=llm_fast_mode,
         )

--- a/helion/autotuner/llm_seeded_lfbo.py
+++ b/helion/autotuner/llm_seeded_lfbo.py
@@ -115,6 +115,7 @@ class LLMSeededSearch(BaseSearch):
         llm_api_base: str | None = None,
         llm_api_key: str | None = None,
         llm_request_timeout_s: float = DEFAULT_REQUEST_TIMEOUT_S,
+        llm_effort_level: str | None = None,
     ) -> None:
         super().__init__(kernel, args)
         if llm_max_rounds < 0:
@@ -140,6 +141,7 @@ class LLMSeededSearch(BaseSearch):
         self.llm_api_base = llm_api_base
         self.llm_api_key = llm_api_key
         self.llm_request_timeout_s = llm_request_timeout_s
+        self.llm_effort_level = llm_effort_level
 
         self.hybrid_stage_breakdown = None
 
@@ -199,6 +201,7 @@ class LLMSeededSearch(BaseSearch):
             api_base=self.llm_api_base,
             api_key=self.llm_api_key,
             request_timeout_s=self.llm_request_timeout_s,
+            effort_level=self.llm_effort_level,
         )
 
     def _second_stage_search_kwargs(self, *, seeded: bool) -> dict[str, object]:
@@ -412,6 +415,7 @@ class LLMSeededLFBOTreeSearch(LLMSeededSearch):
         llm_api_base: str | None = None,
         llm_api_key: str | None = None,
         llm_request_timeout_s: float = DEFAULT_REQUEST_TIMEOUT_S,
+        llm_effort_level: str | None = None,
     ) -> None:
         super().__init__(
             kernel,
@@ -428,4 +432,5 @@ class LLMSeededLFBOTreeSearch(LLMSeededSearch):
             llm_api_base=llm_api_base,
             llm_api_key=llm_api_key,
             llm_request_timeout_s=llm_request_timeout_s,
+            llm_effort_level=llm_effort_level,
         )

--- a/test/test_llm_autotuner.py
+++ b/test/test_llm_autotuner.py
@@ -51,6 +51,7 @@ class TestLLMGuidedSearch(TestCase):
         search.api_key = None
         search.request_timeout_s = 120.0
         search.effort_level = None
+        search.fast_mode = False
 
         # Mock config_spec with a normalize that accepts anything.
         search.config_spec = SimpleNamespace(
@@ -717,6 +718,63 @@ class TestLLMTransport(TestCase):
         self.assertEqual(captured["payload"]["max_tokens"], 8704)
         self.assertNotIn("output_config", captured["payload"])
 
+    def test_transport_fast_mode_payload_and_headers(self):
+        """Anthropic fast mode sets the beta header, speed body field, and disables thinking."""
+        from helion.autotuner.llm.transport import call_provider
+
+        captured = {}
+        messages = [{"role": "user", "content": "suggest configs"}]
+
+        def fake_post_json(url, payload, headers, *, request_timeout_s):
+            del url, request_timeout_s
+            captured["payload"] = payload
+            captured["headers"] = headers
+            if "input" in payload:
+                return self._response_payload("openai_responses")
+            return self._response_payload("anthropic")
+
+        # Anthropic fast mode: beta header + speed=fast, and effort_level=max
+        # is overridden to a non-thinking payload.
+        with patch(
+            "helion.autotuner.llm.transport._post_json",
+            side_effect=fake_post_json,
+        ):
+            call_provider(
+                "anthropic",
+                model="claude-opus-4-7",
+                api_base="https://api.anthropic.com",
+                api_key="anthropic-test-key",
+                messages=messages,
+                max_output_tokens=512,
+                request_timeout_s=120.0,
+                effort_level="max",
+                fast_mode=True,
+            )
+        self.assertEqual(captured["headers"]["anthropic-beta"], "fast-mode-2026-02-01")
+        self.assertEqual(captured["payload"]["speed"], "fast")
+        self.assertNotIn("thinking", captured["payload"])
+        self.assertNotIn("temperature", captured["payload"])
+        self.assertEqual(captured["payload"]["max_tokens"], 512)
+
+        # OpenAI: fast_mode is accepted but is a no-op (no beta header, no speed field).
+        captured.clear()
+        with patch(
+            "helion.autotuner.llm.transport._post_json",
+            side_effect=fake_post_json,
+        ):
+            call_provider(
+                "openai_responses",
+                model="gpt-5.5",
+                api_base="https://api.openai.com",
+                api_key="openai-test-key",
+                messages=messages,
+                max_output_tokens=512,
+                request_timeout_s=120.0,
+                fast_mode=True,
+            )
+        self.assertNotIn("anthropic-beta", captured["headers"])
+        self.assertNotIn("speed", captured["payload"])
+
 
 class TestLLMSeededLFBOTreeSearch(TestCase):
     """Tests for the two-stage LLM-seeded hybrid autotuner."""
@@ -757,6 +815,7 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
                 "HELION_HYBRID_LLM_MAX_ROUNDS": "2",
                 "HELION_LLM_PROVIDER": "openai",
                 "HELION_LLM_EFFORT_LEVEL": "max",
+                "HELION_LLM_FAST_MODE": "1",
             },
             clear=False,
         ):
@@ -766,10 +825,12 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
         self.assertEqual(kwargs["llm_max_rounds"], 2)
         self.assertEqual(kwargs["llm_provider"], "openai")
         self.assertEqual(kwargs["llm_effort_level"], "max")
+        self.assertTrue(kwargs["llm_fast_mode"])
 
         search = LLMSeededLFBOTreeSearch(kernel, (), **kwargs)
         self.assertEqual(search.llm_provider, "openai")
         self.assertEqual(search.llm_effort_level, "max")
+        self.assertTrue(search.llm_fast_mode)
 
     def test_selected_by_env(self):
         """HELION_AUTOTUNER selects the hybrid autotuner and applies profile defaults."""

--- a/test/test_llm_autotuner.py
+++ b/test/test_llm_autotuner.py
@@ -46,10 +46,11 @@ class TestLLMGuidedSearch(TestCase):
         search.configs_per_round = 15
         search._llm_call_times = []
         search._benchmark_times = []
-        search.model = "gpt-5-2"
+        search.model = "gpt-5.5"
         search.api_base = None
         search.api_key = None
         search.request_timeout_s = 120.0
+        search.effort_level = None
 
         # Mock config_spec with a normalize that accepts anything.
         search.config_spec = SimpleNamespace(
@@ -397,16 +398,21 @@ class TestLLMTransport(TestCase):
         from helion.autotuner.llm.transport import extract_anthropic_text
         from helion.autotuner.llm.transport import extract_openai_response_text
         from helion.autotuner.llm.transport import infer_provider
+        from helion.autotuner.llm.transport import normalize_effort_level
         from helion.autotuner.llm.transport import responses_input_from_messages
         from helion.autotuner.llm.transport import split_system_messages
 
-        self.assertEqual(infer_provider("claude-haiku-4.5"), "anthropic")
-        self.assertEqual(infer_provider("gpt-5-2"), "openai_responses")
+        self.assertEqual(infer_provider("claude-opus-4-7"), "anthropic")
+        self.assertEqual(infer_provider("gpt-5.5"), "openai_responses")
         self.assertEqual(infer_provider("custom/model"), "unsupported")
         self.assertEqual(infer_provider("custom/model", "anthropic"), "anthropic")
         self.assertEqual(infer_provider("custom/model", "openai"), "openai_responses")
+        self.assertEqual(normalize_effort_level("MAX"), "max")
+        self.assertEqual(normalize_effort_level("off"), "none")
         with self.assertRaisesRegex(ValueError, "Unsupported LLM provider"):
-            infer_provider("gpt-5-2", "bogus")
+            infer_provider("gpt-5.5", "bogus")
+        with self.assertRaisesRegex(ValueError, "Unsupported LLM effort level"):
+            normalize_effort_level("bogus")
 
         self.assertEqual(
             _resolve_v1_endpoint("https://api.openai.com", "responses"),
@@ -496,7 +502,7 @@ class TestLLMTransport(TestCase):
                 "provider": "openai_responses",
                 "response_payload": self._response_payload("openai_responses"),
                 "expected_text": '{"configs": []}',
-                "model": "gpt-5-2",
+                "model": "gpt-5.5",
                 "api_base": "https://api.openai.com",
                 "expected_url": "https://api.openai.com/v1/responses",
                 "api_key": "openai-test-key",
@@ -518,7 +524,7 @@ class TestLLMTransport(TestCase):
                     "anthropic", '{"configs": [{"num_warps": 4}]}'
                 ),
                 "expected_text": '{"configs": [{"num_warps": 4}]}',
-                "model": "claude-3-5-haiku-latest",
+                "model": "claude-opus-4-7",
                 "api_base": "https://api.anthropic.com",
                 "expected_url": "https://api.anthropic.com/v1/messages",
                 "api_key": "anthropic-test-key",
@@ -576,6 +582,141 @@ class TestLLMTransport(TestCase):
                 self.assertEqual(captured["request_timeout_s"], 120.0)
                 case["request_assertions"](captured)
 
+    def test_supports_anthropic_adaptive_version_matrix(self):
+        """Adaptive-thinking detection follows per-family minimum versions."""
+        from helion.autotuner.llm.transport import _supports_anthropic_adaptive
+
+        cases = {
+            # Opus 4.5+ supports adaptive; 4.4 / 4.1 / 4 (no minor) do not.
+            "claude-opus-4-5": True,
+            "claude-opus-4-6": True,
+            "claude-opus-4-7": True,
+            "claude-opus-4-4": False,
+            "claude-opus-4-1": False,
+            "claude-opus-4": False,
+            # Sonnet only crosses the threshold at 4.6.
+            "claude-sonnet-4-6": True,
+            "claude-sonnet-4-5": False,
+            # Variants and date suffixes still match the family/version prefix.
+            "claude-opus-4-7[1m]": True,
+            "claude-opus-4-7-20260201": True,
+            # A bare date suffix (no minor) must not be parsed as minor=20250514.
+            "claude-opus-4-20250514": False,
+            # Future major / minor releases auto-recognized.
+            "claude-opus-5-0": True,
+            "claude-opus-4-99": True,
+            "claude-sonnet-5-0": True,
+            # Families without an adaptive entry stay on the legacy path.
+            "claude-haiku-4-5": False,
+            # Old-naming models (version before family) never match.
+            "claude-3-5-sonnet-20241022": False,
+            "claude-3-7-sonnet-20250219": False,
+            # Non-Anthropic / unknown model strings fall through.
+            "gpt-5.5": False,
+            "custom-model": False,
+        }
+        for model, expected in cases.items():
+            with self.subTest(model=model):
+                self.assertEqual(_supports_anthropic_adaptive(model), expected)
+
+    def test_transport_effort_level_payloads(self):
+        """Reasoning effort maps to provider-specific request payload fields."""
+        from helion.autotuner.llm.transport import call_provider
+
+        captured = {}
+        messages = [{"role": "user", "content": "suggest configs"}]
+
+        def fake_post_json(url, payload, headers, *, request_timeout_s):
+            del url, headers, request_timeout_s
+            captured["payload"] = payload
+            if "input" in payload:
+                return self._response_payload("openai_responses")
+            return self._response_payload("anthropic")
+
+        # gpt-5.5 supports the xhigh effort level, so the provider-neutral "max"
+        # maps directly to xhigh on the OpenAI side.
+        with patch(
+            "helion.autotuner.llm.transport._post_json",
+            side_effect=fake_post_json,
+        ):
+            call_provider(
+                "openai_responses",
+                model="gpt-5.5",
+                api_base="https://api.openai.com",
+                api_key="openai-test-key",
+                messages=messages,
+                max_output_tokens=512,
+                request_timeout_s=120.0,
+                effort_level="max",
+            )
+        self.assertEqual(captured["payload"]["reasoning"], {"effort": "xhigh"})
+
+        # Older OpenAI models without xhigh support fall back to "high" for the
+        # provider-neutral "max" knob.
+        captured.clear()
+        with patch(
+            "helion.autotuner.llm.transport._post_json",
+            side_effect=fake_post_json,
+        ):
+            call_provider(
+                "openai_responses",
+                model="gpt-5-2",
+                api_base="https://api.openai.com",
+                api_key="openai-test-key",
+                messages=messages,
+                max_output_tokens=512,
+                request_timeout_s=120.0,
+                effort_level="max",
+            )
+        self.assertEqual(captured["payload"]["reasoning"], {"effort": "high"})
+
+        # Modern Claude models (Opus 4.5+, Sonnet 4.6+) use adaptive thinking;
+        # the model self-picks its budget so no budget_tokens is sent. Required on
+        # Opus 4.7 where manual budget_tokens returns HTTP 400.
+        captured.clear()
+        with patch(
+            "helion.autotuner.llm.transport._post_json",
+            side_effect=fake_post_json,
+        ):
+            call_provider(
+                "anthropic",
+                model="claude-opus-4-7",
+                api_base="https://api.anthropic.com",
+                api_key="anthropic-test-key",
+                messages=messages,
+                max_output_tokens=512,
+                request_timeout_s=120.0,
+                effort_level="max",
+            )
+        self.assertEqual(captured["payload"]["thinking"], {"type": "adaptive"})
+        self.assertEqual(captured["payload"]["output_config"], {"effort": "max"})
+        self.assertEqual(captured["payload"]["max_tokens"], 512)
+        self.assertNotIn("temperature", captured["payload"])
+
+        # Legacy Claude models (Opus 4 / Sonnet 4.5 and earlier) still go through
+        # the manual budget_tokens path with the same low/medium/high/max table.
+        captured.clear()
+        with patch(
+            "helion.autotuner.llm.transport._post_json",
+            side_effect=fake_post_json,
+        ):
+            call_provider(
+                "anthropic",
+                model="claude-opus-4",
+                api_base="https://api.anthropic.com",
+                api_key="anthropic-test-key",
+                messages=messages,
+                max_output_tokens=512,
+                request_timeout_s=120.0,
+                effort_level="high",
+            )
+        self.assertEqual(
+            captured["payload"]["thinking"],
+            {"type": "enabled", "budget_tokens": 8192},
+        )
+        self.assertEqual(captured["payload"]["max_tokens"], 8704)
+        self.assertNotIn("output_config", captured["payload"])
+
 
 class TestLLMSeededLFBOTreeSearch(TestCase):
     """Tests for the two-stage LLM-seeded hybrid autotuner."""
@@ -615,6 +756,7 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
             {
                 "HELION_HYBRID_LLM_MAX_ROUNDS": "2",
                 "HELION_LLM_PROVIDER": "openai",
+                "HELION_LLM_EFFORT_LEVEL": "max",
             },
             clear=False,
         ):
@@ -623,9 +765,11 @@ class TestLLMSeededLFBOTreeSearch(TestCase):
             )
         self.assertEqual(kwargs["llm_max_rounds"], 2)
         self.assertEqual(kwargs["llm_provider"], "openai")
+        self.assertEqual(kwargs["llm_effort_level"], "max")
 
         search = LLMSeededLFBOTreeSearch(kernel, (), **kwargs)
         self.assertEqual(search.llm_provider, "openai")
+        self.assertEqual(search.llm_effort_level, "max")
 
     def test_selected_by_env(self):
         """HELION_AUTOTUNER selects the hybrid autotuner and applies profile defaults."""


### PR DESCRIPTION
Stacked PRs:
 * #2449
 * #2448
 * __->__#2447
 * #2446


--- --- ---

### [Autotuner] LLM search: Anthropic Opus 4.6/4.7 fast mode


- `anthropic-beta: fast-mode-2026-02-01` header + top-level `speed: "fast"` body field.
- `fast_mode` kwarg + `HELION_LLM_FAST_MODE` env var.
- Overrides extended thinking when on. Direct Anthropic API only (Vertex strips the beta).