### PR TITLE
[Autotuner] LLM search: fail loudly + mTLS gateway compatibility

### DIFF
--- a/helion/autotuner/llm/transport.py
+++ b/helion/autotuner/llm/transport.py
@@ -409,8 +409,17 @@ def _resolve_v1_endpoint(api_base: str, endpoint: str) -> str:
 
 def _build_ssl_context() -> ssl.SSLContext | None:
     """Build an optional SSL context for custom CA bundles or client certs."""
-    ca_bundle = _first_existing_path("HELION_LLM_CA_BUNDLE", "NODE_EXTRA_CA_CERTS")
-    cert = _first_existing_path("HELION_LLM_CLIENT_CERT")
+    ca_bundle = _first_existing_path(
+        "HELION_LLM_CA_BUNDLE", "NODE_EXTRA_CA_CERTS", "CURL_CA_BUNDLE"
+    )
+    # Fall back to common mTLS client-cert env conventions used by HTTPS gateways
+    # (in addition to helion's own knob) so requests work out-of-the-box when an
+    # identity is already configured by another tool.
+    cert = _first_existing_path(
+        "HELION_LLM_CLIENT_CERT",
+        "CLAUDE_CODE_CLIENT_CERT",
+        "THRIFT_TLS_CL_CERT_PATH",
+    )
     if ca_bundle is None and cert is None:
         return None
 
@@ -420,7 +429,14 @@ def _build_ssl_context() -> ssl.SSLContext | None:
         else ssl.create_default_context()
     )
     if cert is not None:
-        key = _first_existing_path("HELION_LLM_CLIENT_KEY") or cert
+        key = (
+            _first_existing_path(
+                "HELION_LLM_CLIENT_KEY",
+                "CLAUDE_CODE_CLIENT_KEY",
+                "THRIFT_TLS_CL_KEY_PATH",
+            )
+            or cert
+        )
         context.load_cert_chain(certfile=cert, keyfile=key)
     return context
 

--- a/helion/autotuner/llm_search.py
+++ b/helion/autotuner/llm_search.py
@@ -74,7 +74,6 @@ if TYPE_CHECKING:
 # Keep system + initial prompt plus this many recent round-trip exchanges
 # to avoid exceeding LLM context limits on long sessions.
 _MAX_CONTEXT_ROUNDS = 3
-_EMPTY_LLM_RESPONSE = '{"configs": []}'
 _MAX_STAGNANT_ROUNDS = 2
 
 
@@ -501,13 +500,10 @@ class LLMGuidedSearch(PopulationBasedSearch):
         # Wait only after the seed batch so round 0 can hide some initial LLM latency.
         if future is None:
             return None
-        try:
-            return future.result(timeout=self.request_timeout_s)
-        except Exception:
-            self.log.warning(
-                "Round 0: initial LLM call failed, continuing with seed configs"
-            )
-            return None
+        # LLM failures are intentionally fatal: silently falling back to plain
+        # LFBO when the user opted into the LLM autotuner masks real config or
+        # connectivity bugs (e.g. wrong API key, missing mTLS cert).
+        return future.result(timeout=self.request_timeout_s)
 
     def _finalize_round(self, round_num: int) -> None:
         """Rebenchmark the current top configs and log the stabilized round summary."""
@@ -558,13 +554,9 @@ class LLMGuidedSearch(PopulationBasedSearch):
             f"{max(0, len(seed_configs) - 1)} random)"
         )
 
-        llm_future: concurrent.futures.Future[str] | None = None
-        try:
-            llm_future = self._call_llm_async(self._build_llm_messages())
-        except Exception:
-            self.log.warning(
-                "Round 0: could not start initial LLM call, continuing with seed configs"
-            )
+        # Failure to dispatch the initial LLM request is fatal (see
+        # _wait_for_initial_llm_response for the rationale).
+        llm_future = self._call_llm_async(self._build_llm_messages())
 
         if seed_configs:
             self._benchmark_and_ingest(seed_configs, generation=0, desc="Round 0 seed")
@@ -592,13 +584,8 @@ class LLMGuidedSearch(PopulationBasedSearch):
         """Run one post-seed refinement round and report whether search should stop."""
         # Build the next prompt from the stabilized prior round, then benchmark new configs.
         prompt = self._build_refinement_prompt(round_num)
-        try:
-            llm_response = self._call_llm(self._build_llm_messages(prompt))
-        except Exception:
-            self.log.warning(
-                f"Round {round_num}: LLM call failed, generating no new configs instead"
-            )
-            llm_response = _EMPTY_LLM_RESPONSE
+        # LLM failures are intentionally fatal (see _wait_for_initial_llm_response).
+        llm_response = self._call_llm(self._build_llm_messages(prompt))
 
         self._messages.append({"role": "user", "content": prompt})
         self._messages.append({"role": "assistant", "content": llm_response})

--- a/test/test_llm_autotuner.py
+++ b/test/test_llm_autotuner.py
@@ -378,6 +378,16 @@ class TestLLMGuidedSearch(TestCase):
         self.assertEqual(dict(best), dict(round1_cfg))
         self.assertEqual(dict(search.best.config), dict(round1_cfg))
 
+    def test_initial_llm_response_propagates_failure(self):
+        """Round 0 LLM future failures are not silently swallowed."""
+        import concurrent.futures
+
+        search = self._make_mock_search()
+        future: concurrent.futures.Future[str] = concurrent.futures.Future()
+        future.set_exception(RuntimeError("simulated provider 401"))
+        with self.assertRaisesRegex(RuntimeError, "simulated provider 401"):
+            search._wait_for_initial_llm_response(future)
+
 
 class TestLLMTransport(TestCase):
     """Tests for provider selection and HTTP payload translation."""


### PR DESCRIPTION
Stacked PRs:
 * #2465
 * #2451
 * __->__#2448
 * #2450
 * #2446


--- --- ---

### [Autotuner] LLM search: fail loudly + mTLS gateway compatibility


- No more silent fallback to no-seed LFBO when LLM hybrid cannot connect.
- To connect more easily from dev servers, _build_ssl_context picks up CURL_CA_BUNDLE and falls back to common mTLS client-cert envs (CLAUDE_CODE_CLIENT_CERT/KEY, THRIFT_TLS_CL_CERT_PATH/KEY_PATH).

