### PR TITLE
[Autotuner] Benchmark: LLM-seeded LFBO vs LFBO baseline (6 kernels)

### DIFF
--- a/benchmarks/llm_compare/README.md
+++ b/benchmarks/llm_compare/README.md
@@ -1,0 +1,47 @@
+# LFBO vs LLM-seeded LFBO comparison
+
+Head-to-head benchmark of `LFBOTreeSearch` against `LLMSeededLFBOTreeSearch`
+(Claude Opus 4.7 seed, `effort_level=max`, `fast_mode=1`) across a fixed set
+of example kernels at full autotune effort.
+
+## Running
+
+```bash
+HELION_LLM_API_KEY="$(your-key-source)" \
+python benchmarks/llm_compare/run_compare.py --gpu 0 --timeout 2400
+python benchmarks/llm_compare/summarize.py \
+    benchmarks/llm_compare/runs/<tag>/results.jsonl \
+    --out benchmarks/llm_compare/runs/<tag>/headtohead.md
+```
+
+The harness sets `HELION_SKIP_CACHE=1` per cell so neither autotuner can reuse
+the other's cached `best_config`. Other caches (inductor, Triton) are left
+alone so the run doesn't disturb concurrent helion jobs on the same host.
+
+## Results — 6 kernels on NVIDIA B200, full effort, single shot per cell
+
+| kernel     | wall LFBO (s) | wall LLM (s) | wall ratio  | helion LFBO (ms) | helion LLM (ms) | kernel ratio |
+| ---------- | ------------- | ------------ | ----------- | ---------------- | --------------- | ------------ |
+| attention  |        251.9 |        114.6 |  **0.46×**  |          0.0594  |         0.0548  |       0.92×  |
+| gdn_fwd_h  |        286.7 |        118.1 |  **0.41×**  |          0.5910  |         0.6165  |       1.04×  |
+| layer_norm |       1358.3 |        723.7 |  **0.53×**  |          0.0349  |         0.0389  |       1.11×  |
+| matmul     |        117.9 |         97.8 |  **0.83×**  |          0.0154  |         0.0143  |       0.93×  |
+| rope       |         96.1 |         56.7 |  **0.59×**  |          0.0497  |         0.0458  |       0.92×  |
+| softmax    |        573.3 |        162.8 |  **0.28×**  |          0.0143  |         0.0165  |       1.15×  |
+
+**Geomean compile wall-clock ratio (LLM / LFBO): 0.49×** — LLM-seeded is ~2×
+faster to autotune, on every kernel.
+
+**Geomean helion kernel-ms ratio (LLM / LFBO): 1.01×** — tuned-kernel quality
+is essentially tied (3 small wins, 3 small losses, within typical autotune
+noise).
+
+Ratios are LLM / LFBO; `<1.0×` means LLM-seeded wins.
+
+## Notes
+
+- `matmul` exits non-zero on both autotuners because of a pre-existing
+  `addmm`-lambda pickle bug in `examples/matmul.py`; the primary `matmul`
+  `run_example` runs and times correctly before the crash.
+- Single shot per cell, so ±10% on individual kernel-ms cells is plausible.
+  The wall-clock signal (geomean 0.49× across 6/6 kernels) is far above noise.

--- a/benchmarks/llm_compare/run_compare.py
+++ b/benchmarks/llm_compare/run_compare.py
@@ -1,0 +1,316 @@
+"""Compare LFBOTreeSearch vs LLMSeededLFBOTreeSearch across a fixed kernel set.
+
+Runs each (autotuner, kernel) cell sequentially on a single GPU, captures
+end-to-end wall-clock and the helion-vs-baseline timings printed by each
+example's `run_example` call, then writes a results table.
+
+Usage:
+    python benchmarks/llm_compare/run_compare.py [--gpu 0] [--timeout 2400]
+                                                 [--out-tag mytag]
+
+Set HELION_LLM_API_KEY (e.g. from a key helper) before invocation when the
+LLM-seeded cell needs it. The harness sets HELION_SKIP_CACHE=1 per cell so
+neither autotuner reuses the other's cached best_config.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import dataclasses
+import datetime as dt
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import time
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+CONDA_PY = sys.executable
+
+KERNELS = [
+    "attention",
+    "matmul",
+    "softmax",
+    "gdn_fwd_h",
+    "layer_norm",
+    "rope",
+]
+
+AUTOTUNERS = [
+    {
+        "label": "LFBO",
+        "autotuner": "LFBOTreeSearch",
+        "llm": False,
+    },
+    {
+        "label": "LLMSeededLFBO_opus47_max_fast",
+        "autotuner": "LLMSeededLFBOTreeSearch",
+        "llm": True,
+        "llm_env": {
+            "HELION_LLM_PROVIDER": "anthropic",
+            "HELION_LLM_MODEL": "claude-opus-4-7",
+            "HELION_LLM_EFFORT_LEVEL": "max",
+            "HELION_LLM_FAST_MODE": "1",
+        },
+    },
+]
+
+
+BENCH_RE = re.compile(
+    r"^(?P<impl>\S+)\s+(?P<ms>\d+\.\d+)\s+(?P<speedup>\S+)",
+    re.MULTILINE,
+)
+
+
+@dataclasses.dataclass
+class CellResult:
+    autotuner_label: str
+    kernel: str
+    wall_clock_s: float
+    exit_code: int
+    helion_timings: dict[str, float]
+    baseline_timings: dict[str, float]
+    error: str | None
+
+
+def parse_bench_blocks(stderr_text: str) -> tuple[dict[str, float], dict[str, float]]:
+    """Extract helion-vs-baseline ms timings from `run_example` output."""
+    baseline_names = {"torch", "ref", "flex", "compiled", "torch_compile", "eager"}
+    helion: dict[str, float] = {}
+    baselines: dict[str, float] = {}
+    for match in BENCH_RE.finditer(stderr_text):
+        impl = match.group("impl")
+        ms = float(match.group("ms"))
+        speedup = match.group("speedup")
+        if speedup.endswith("(ref)") or impl in baseline_names:
+            baselines.setdefault(impl, ms)
+        else:
+            helion.setdefault(impl, ms)
+    return helion, baselines
+
+
+def run_cell(
+    *,
+    kernel: str,
+    autotuner_cfg: dict[str, object],
+    gpu: int,
+    timeout_s: int,
+    out_dir: Path,
+) -> CellResult:
+    label = str(autotuner_cfg["label"])
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = str(gpu)
+    env["PYTHONPATH"] = f"{REPO_ROOT}:" + env.get("PYTHONPATH", "")
+    env["HELION_AUTOTUNE_EFFORT"] = "full"
+    env["HELION_AUTOTUNER"] = str(autotuner_cfg["autotuner"])
+    env["HELION_AUTOTUNE_LOG_LEVEL"] = "INFO"
+    # HELION_SKIP_CACHE=1 disables read+write of the best_config cache and the
+    # FROM_BEST_AVAILABLE disk-cache scan in stage 2 of LFBO. In-memory
+    # LLM->LFBO seed handoff is unaffected. This is the only knob we need for
+    # fair cross-cell comparison; we leave inductor/triton caches alone so we
+    # don't touch shared state owned by other processes on this machine.
+    env["HELION_SKIP_CACHE"] = "1"
+
+    if autotuner_cfg.get("llm"):
+        for key, value in autotuner_cfg.get("llm_env", {}).items():
+            env[key] = str(value)
+        if not env.get("HELION_LLM_API_KEY"):
+            return CellResult(
+                autotuner_label=label,
+                kernel=kernel,
+                wall_clock_s=0.0,
+                exit_code=-1,
+                helion_timings={},
+                baseline_timings={},
+                error="HELION_LLM_API_KEY not set; required for LLM-seeded cells",
+            )
+
+    log_path = out_dir / "logs" / f"{label}_{kernel}.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [CONDA_PY, str(REPO_ROOT / "examples" / f"{kernel}.py")]
+    t0 = time.perf_counter()
+    try:
+        result = subprocess.run(
+            cmd,
+            env=env,
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+        wall = time.perf_counter() - t0
+        log_path.write_text(
+            f"=== cmd: {' '.join(cmd)}\n"
+            f"=== exit: {result.returncode}\n"
+            f"=== wall_s: {wall:.2f}\n"
+            f"=== stdout ===\n{result.stdout}\n"
+            f"=== stderr ===\n{result.stderr}\n"
+        )
+        helion, baselines = parse_bench_blocks(result.stderr)
+        return CellResult(
+            autotuner_label=label,
+            kernel=kernel,
+            wall_clock_s=wall,
+            exit_code=result.returncode,
+            helion_timings=helion,
+            baseline_timings=baselines,
+            error=None
+            if result.returncode == 0
+            else f"nonzero exit {result.returncode}",
+        )
+    except subprocess.TimeoutExpired:
+        wall = time.perf_counter() - t0
+        log_path.write_text(f"TIMEOUT after {wall:.2f}s (limit={timeout_s}s)\n")
+        return CellResult(
+            autotuner_label=label,
+            kernel=kernel,
+            wall_clock_s=wall,
+            exit_code=-1,
+            helion_timings={},
+            baseline_timings={},
+            error=f"timeout after {timeout_s}s",
+        )
+
+
+def write_outputs(out_dir: Path, results: list[CellResult]) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with (out_dir / "results.jsonl").open("w") as f:
+        for r in results:
+            f.write(json.dumps(dataclasses.asdict(r)) + "\n")
+    with (out_dir / "results.csv").open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            [
+                "autotuner",
+                "kernel",
+                "wall_clock_s",
+                "exit_code",
+                "helion_impl",
+                "helion_ms",
+                "error",
+            ]
+        )
+        for r in results:
+            if r.helion_timings:
+                for impl, ms in r.helion_timings.items():
+                    writer.writerow(
+                        [
+                            r.autotuner_label,
+                            r.kernel,
+                            f"{r.wall_clock_s:.2f}",
+                            r.exit_code,
+                            impl,
+                            f"{ms:.4f}",
+                            r.error or "",
+                        ]
+                    )
+            else:
+                writer.writerow(
+                    [
+                        r.autotuner_label,
+                        r.kernel,
+                        f"{r.wall_clock_s:.2f}",
+                        r.exit_code,
+                        "",
+                        "",
+                        r.error or "no helion timings parsed",
+                    ]
+                )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gpu", type=int, default=0)
+    parser.add_argument(
+        "--timeout", type=int, default=2400, help="Per-cell timeout in seconds"
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=REPO_ROOT / "benchmarks" / "llm_compare" / "runs",
+        help="Parent directory for run output",
+    )
+    parser.add_argument(
+        "--out-tag",
+        default=dt.datetime.now().strftime("%Y%m%d_%H%M%S"),
+        help="Subdirectory name under --out-dir",
+    )
+    parser.add_argument(
+        "--kernels",
+        default=",".join(KERNELS),
+        help="Comma-separated kernel list (override for partial runs)",
+    )
+    parser.add_argument(
+        "--autotuners",
+        default=",".join(str(a["label"]) for a in AUTOTUNERS),
+        help="Comma-separated autotuner labels (override for partial runs)",
+    )
+    args = parser.parse_args()
+
+    kernels = [k for k in args.kernels.split(",") if k]
+    chosen_autotuners = [
+        a for a in AUTOTUNERS if str(a["label"]) in args.autotuners.split(",")
+    ]
+
+    out_dir = args.out_dir / args.out_tag
+    out_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Output dir: {out_dir}", file=sys.stderr)
+
+    (out_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "gpu": args.gpu,
+                "timeout_s": args.timeout,
+                "kernels": kernels,
+                "autotuners": [a["label"] for a in chosen_autotuners],
+                "started": dt.datetime.now().isoformat(timespec="seconds"),
+            },
+            indent=2,
+        )
+    )
+
+    results: list[CellResult] = []
+    total = len(kernels) * len(chosen_autotuners)
+    cell_idx = 0
+    overall_t0 = time.perf_counter()
+    for autotuner_cfg in chosen_autotuners:
+        label = str(autotuner_cfg["label"])
+        for kernel in kernels:
+            cell_idx += 1
+            print(
+                f"[{cell_idx}/{total}] {label} / {kernel} starting "
+                f"(elapsed total {time.perf_counter() - overall_t0:.0f}s)",
+                file=sys.stderr,
+                flush=True,
+            )
+            r = run_cell(
+                kernel=kernel,
+                autotuner_cfg=autotuner_cfg,
+                gpu=args.gpu,
+                timeout_s=args.timeout,
+                out_dir=out_dir,
+            )
+            results.append(r)
+            write_outputs(out_dir, results)  # checkpoint after each cell
+            print(
+                f"[{cell_idx}/{total}] {label} / {kernel} done in "
+                f"{r.wall_clock_s:.1f}s exit={r.exit_code} "
+                f"helion_impls={list(r.helion_timings)} err={r.error}",
+                file=sys.stderr,
+                flush=True,
+            )
+
+    print(f"\nWrote: {out_dir / 'results.csv'}", file=sys.stderr)
+    print(f"Wrote: {out_dir / 'results.jsonl'}", file=sys.stderr)
+    print(
+        f"Run `python benchmarks/llm_compare/summarize.py "
+        f"{out_dir / 'results.jsonl'}` for a head-to-head table.",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/llm_compare/summarize.py
+++ b/benchmarks/llm_compare/summarize.py
@@ -1,0 +1,146 @@
+"""Focused head-to-head: LFBO vs LLMSeededLFBO.
+
+Reads results.jsonl produced by run_compare.py and writes a comparison table
+of compile wall-clock and the resulting helion kernel ms — no torch / flex /
+ref baselines, no speedup-vs-baseline numbers.
+
+Usage:
+    python benchmarks/llm_compare/summarize.py <results.jsonl> [--out report.md]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+import statistics
+import sys
+
+LFBO_LABEL = "LFBO"
+LLM_LABEL_PREFIX = "LLMSeededLFBO"
+
+
+def load(jsonl_path: Path) -> list[dict]:
+    rows: list[dict] = []
+    for line in jsonl_path.read_text().splitlines():
+        if line.strip():
+            rows.append(json.loads(line))
+    return rows
+
+
+def best_helion_ms(record: dict) -> float | None:
+    timings = record.get("helion_timings") or {}
+    if not timings:
+        return None
+    return min(timings.values())
+
+
+def ratio(numerator: float | None, denominator: float | None) -> float | None:
+    if numerator is None or denominator is None or denominator <= 0:
+        return None
+    return numerator / denominator
+
+
+def geomean(values: list[float]) -> float | None:
+    finite = [v for v in values if v is not None and v > 0 and math.isfinite(v)]
+    if not finite:
+        return None
+    return math.exp(statistics.fmean(math.log(v) for v in finite))
+
+
+def fmt_s(value: float | None) -> str:
+    return f"{value:.1f}" if value is not None else "-"
+
+
+def fmt_ms(value: float | None) -> str:
+    return f"{value:.4f}" if value is not None else "-"
+
+
+def fmt_x(value: float | None) -> str:
+    return f"{value:.2f}×" if value is not None else "-"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "results", type=Path, help="path to results.jsonl from run_compare.py"
+    )
+    parser.add_argument(
+        "--out", type=Path, default=None, help="optional path to write the .md report"
+    )
+    args = parser.parse_args()
+
+    rows = load(args.results)
+    by_kernel: dict[str, dict[str, dict]] = {}
+    for r in rows:
+        label = r["autotuner_label"]
+        bucket = LFBO_LABEL if label == LFBO_LABEL else LLM_LABEL_PREFIX
+        by_kernel.setdefault(r["kernel"], {})[bucket] = r
+
+    lines: list[str] = [
+        "# LFBO vs LLM-seeded LFBO\n",
+        (
+            "Compile wall-clock = end-to-end subprocess time (Python startup + module "
+            "load + autotune + correctness/benchmark). Helion ms = min helion impl time "
+            "from the example's `run_example` table.\n"
+        ),
+        (
+            "Ratios are LLM / LFBO: <1.0× means LLM-seeded is **faster** "
+            "(less compile time, or faster tuned kernel).\n"
+        ),
+        "## Per-kernel comparison\n",
+        (
+            "| kernel | wall LFBO (s) | wall LLM (s) | wall ratio | "
+            "helion LFBO (ms) | helion LLM (ms) | kernel ratio | LFBO exit | LLM exit |"
+        ),
+        "|" + "|".join(["---"] * 9) + "|",
+    ]
+
+    wall_ratios: list[float] = []
+    kernel_ratios: list[float] = []
+    for kernel in sorted(by_kernel):
+        cells = by_kernel[kernel]
+        lfbo = cells.get(LFBO_LABEL)
+        llm = cells.get(LLM_LABEL_PREFIX)
+        wall_lfbo = lfbo.get("wall_clock_s") if lfbo else None
+        wall_llm = llm.get("wall_clock_s") if llm else None
+        wall_r = ratio(wall_llm, wall_lfbo)
+        ms_lfbo = best_helion_ms(lfbo) if lfbo else None
+        ms_llm = best_helion_ms(llm) if llm else None
+        ms_r = ratio(ms_llm, ms_lfbo)
+        if wall_r is not None:
+            wall_ratios.append(wall_r)
+        if ms_r is not None:
+            kernel_ratios.append(ms_r)
+        lines.append(
+            f"| {kernel} | {fmt_s(wall_lfbo)} | {fmt_s(wall_llm)} | "
+            f"{fmt_x(wall_r)} | {fmt_ms(ms_lfbo)} | {fmt_ms(ms_llm)} | "
+            f"{fmt_x(ms_r)} | "
+            f"{lfbo['exit_code'] if lfbo else '-'} | "
+            f"{llm['exit_code'] if llm else '-'} |"
+        )
+
+    lines.extend(
+        [
+            "\n## Aggregates (geomean of available ratios)\n",
+            (
+                f"- **Compile wall-clock ratio (LLM/LFBO)**: "
+                f"{fmt_x(geomean(wall_ratios))}  ({len(wall_ratios)} kernels)"
+            ),
+            (
+                f"- **Helion kernel ms ratio (LLM/LFBO)**: "
+                f"{fmt_x(geomean(kernel_ratios))}  ({len(kernel_ratios)} kernels)"
+            ),
+        ]
+    )
+
+    text = "\n".join(lines) + "\n"
+    print(text)
+    if args.out:
+        args.out.write_text(text)
+        print(f"Wrote: {args.out}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rope.py
+++ b/examples/rope.py
@@ -16,6 +16,7 @@ import torch
 import helion
 from helion._testing import DEVICE
 from helion._testing import HALF_DTYPE
+from helion._testing import run_example
 import helion.language as hl
 
 
@@ -255,12 +256,7 @@ def main() -> None:
     angles = torch.randn([batch, seq_len, head_dim], device=DEVICE, dtype=HALF_DTYPE)
     cos = torch.cos(angles)
     sin = torch.sin(angles)
-    torch.testing.assert_close(
-        rope(q, k, cos, sin),
-        rope_pytorch(q, k, cos, sin),
-        atol=1e-2,
-        rtol=1e-2,
-    )
+    run_example(rope, rope_pytorch, (q, k, cos, sin))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked PRs:
 * __->__#2449
 * #2448
 * #2450
 * #2446


--- --- ---

### [Autotuner] Benchmark: LLM-seeded LFBO vs LFBO baseline (6 kernels)


- Adds `benchmarks/llm_compare/` (harness, summarize, README).
- `examples/rope.py`: add missing `run_example` call so rope prints a benchmark table.

Results (B200, full effort, GPU 1, `HELION_LLM_MODEL=claude-opus-4-7
HELION_LLM_EFFORT_LEVEL=max HELION_LLM_FAST_MODE=1`):

| kernel     | wall LFBO (s) | wall LLM (s) | wall ratio | helion LFBO (ms) | helion LLM (ms) | kernel ratio |
| ---------- | ------------- | ------------ | ---------- | ---------------- | --------------- | ------------ |
| attention  |        251.9 |        114.6 |  **0.46×** |          0.0594 |          0.0548 |        0.92× |
| gdn_fwd_h  |        286.7 |        118.1 |  **0.41×** |          0.5910 |          0.6165 |        1.04× |
| layer_norm |       1358.3 |        723.7 |  **0.53×** |          0.0349 |          0.0389 |        1.11× |
| matmul     |        117.9 |         97.8 |  **0.83×** |          0.0154 |          0.0143 |        0.93× |
| rope       |         96.1 |         56.7 |  **0.59×** |          0.0497 |          0.0458 |        0.92× |
| softmax    |        573.3 |        162.8 |  **0.28×** |          0.0143 |          0.0165 |        1.15× |

Geomean wall: **0.49×**, geomean helion-ms: **1.01×**. Ratios are LLM/LFBO;
`<1.0×` is the LLM-seeded win.
