### PR TITLE
[Examples] rope: print benchmark table via run_example

### DIFF
--- a/examples/rope.py
+++ b/examples/rope.py
@@ -16,6 +16,7 @@ import torch
 import helion
 from helion._testing import DEVICE
 from helion._testing import HALF_DTYPE
+from helion._testing import run_example
 import helion.language as hl
 
 
@@ -255,9 +256,10 @@ def main() -> None:
     angles = torch.randn([batch, seq_len, head_dim], device=DEVICE, dtype=HALF_DTYPE)
     cos = torch.cos(angles)
     sin = torch.sin(angles)
-    torch.testing.assert_close(
-        rope(q, k, cos, sin),
-        rope_pytorch(q, k, cos, sin),
+    run_example(
+        rope,  # pyrefly: ignore [bad-argument-type]
+        rope_pytorch,  # pyrefly: ignore [bad-argument-type]
+        (q, k, cos, sin),
         atol=1e-2,
         rtol=1e-2,
     )


### PR DESCRIPTION
Stacked PRs:
 * #2465
 * __->__#2451
 * #2448
 * #2450
 * #2446


--- --- ---

### [Examples] rope: print benchmark table via run_example


Replaces the bare torch.testing.assert_close with run_example(rope, rope_pytorch, …, atol=1e-2, rtol=1e-2) so the example prints a helion-vs-baseline timing table, matching the rest of the examples suite.