### PR TITLE
[cache] Wire from_best_available / from_cache to RemoteCacheBackend

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -576,7 +576,17 @@ class BaseSearch(BaseAutotuner):
 
         # Over-fetch 2x to absorb filtered / duplicate entries.
         remaining = max_configs - len(matching)
-        for raw in backend.list(max_results=remaining * 2):
+        try:
+            # Materialize eagerly so any backend failure surfaces here, not
+            # mid-iteration when partial results are already in `matching`.
+            raw_entries = list(backend.list(max_results=remaining * 2))
+        except Exception:
+            self.log.warning(
+                "Remote cache list failed, using local matches only", exc_info=True
+            )
+            return matching
+
+        for raw in raw_entries:
             try:
                 entry = parse_cache_entry(raw)
             except ValueError:

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -513,7 +513,12 @@ class BaseSearch(BaseAutotuner):
         return hardware, specialization_key
 
     def _find_similar_cached_configs(self, max_configs: int) -> list[SavedBestConfig]:
-        """Return cached configs matching hardware, specialization_key, and config_spec_hash; empty if cache is skipped."""
+        """Return cached configs matching hardware, specialization_key, and config_spec_hash; empty if cache is skipped.
+
+        Scans the local cache first; if more configs are needed and a remote
+        backend is configured, queries it via ``RemoteCacheBackend.list()``
+        and merges the results, deduplicating against local entries.
+        """
         from .base_cache import should_skip_cache
 
         if self._skip_cache or should_skip_cache():
@@ -521,6 +526,8 @@ class BaseSearch(BaseAutotuner):
 
         from .local_cache import get_helion_cache_dir
         from .local_cache import iter_cache_entries
+        from .local_cache import parse_cache_entry
+        from .remote_cache import _load_remote_backend_if_configured
 
         current_hardware, current_spec_key = (
             self._get_current_hardware_and_specialization()
@@ -532,22 +539,50 @@ class BaseSearch(BaseAutotuner):
             advanced_controls_files=self.settings.autotune_search_acf or None
         )
 
+        def is_compatible(entry: SavedBestConfig) -> bool:
+            return (
+                entry.flat_config is not None
+                and entry.hardware == current_hardware
+                and _normalize_spec_key_str(entry.specialization_key)
+                == current_spec_key
+                and entry.config_spec_hash == current_fingerprint_hash
+            )
+
         matching: list[SavedBestConfig] = []
+        seen: set[str] = set()
+
+        def consider(entry: SavedBestConfig) -> bool:
+            """Return True once we have enough matches to stop scanning."""
+            if not is_compatible(entry):
+                return False
+            assert entry.flat_config is not None  # narrowed by is_compatible
+            # flat_config may contain nested lists (unhashable); key by repr.
+            dedup_key = repr(entry.flat_config)
+            if dedup_key in seen:
+                return False
+            matching.append(entry)
+            seen.add(dedup_key)
+            return len(matching) >= max_configs
+
         for entry in iter_cache_entries(
             get_helion_cache_dir(),
             max_scan=self.settings.autotune_best_available_max_cache_scan,
         ):
-            if entry.hardware != current_hardware:
+            if consider(entry):
+                return matching
+
+        backend = _load_remote_backend_if_configured()
+        if backend is None:
+            return matching
+
+        # Over-fetch 2x to absorb filtered / duplicate entries.
+        remaining = max_configs - len(matching)
+        for raw in backend.list(max_results=remaining * 2):
+            try:
+                entry = parse_cache_entry(raw)
+            except ValueError:
                 continue
-            if _normalize_spec_key_str(entry.specialization_key) != current_spec_key:
-                continue
-            # Skip entries without a matching structural fingerprint or flat_config.
-            if entry.config_spec_hash != current_fingerprint_hash:
-                continue
-            if entry.flat_config is None:
-                continue
-            matching.append(entry)
-            if len(matching) >= max_configs:
+            if consider(entry):
                 break
 
         return matching

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -555,8 +555,7 @@ class BaseSearch(BaseAutotuner):
             """Return True once we have enough matches to stop scanning."""
             if not is_compatible(entry):
                 return False
-            assert entry.flat_config is not None  # narrowed by is_compatible
-            # flat_config may contain nested lists (unhashable); key by repr.
+            assert entry.flat_config is not None
             dedup_key = repr(entry.flat_config)
             if dedup_key in seen:
                 return False

--- a/helion/autotuner/local_cache.py
+++ b/helion/autotuner/local_cache.py
@@ -101,6 +101,7 @@ def iter_cache_entries(
     files.sort(key=lambda p: p.stat().st_mtime, reverse=True)
 
     for p in itertools.islice(files, max_scan):
+        # parse_cache_entry consolidates KeyError/TypeError/JSONDecodeError into ValueError.
         try:
             yield parse_cache_entry(p.read_text())
         except (OSError, ValueError) as e:

--- a/helion/autotuner/local_cache.py
+++ b/helion/autotuner/local_cache.py
@@ -60,6 +60,33 @@ class SavedBestConfig:
         return list(self.flat_config)
 
 
+def parse_cache_entry(raw: str) -> SavedBestConfig:
+    """Parse a serialized .best_config JSON string into a SavedBestConfig.
+
+    Raises:
+        ValueError: if the payload is malformed or missing required fields.
+    """
+    try:
+        data = json.loads(raw)
+        fields = data["key"]["fields"]
+        raw_flat = data.get("flat_config")
+        if isinstance(raw_flat, str):
+            flat_config: tuple[object, ...] | None = tuple(json.loads(raw_flat))
+        elif raw_flat is not None:
+            flat_config = tuple(raw_flat)
+        else:
+            flat_config = None
+        return SavedBestConfig(
+            hardware=fields.get("hardware", ""),
+            specialization_key=fields.get("specialization_key", ""),
+            config=Config.from_json(data["config"]),
+            config_spec_hash=fields.get("config_spec_hash", ""),
+            flat_config=flat_config,
+        )
+    except (KeyError, TypeError, json.JSONDecodeError) as e:
+        raise ValueError(f"malformed cache entry: {e}") from e
+
+
 def iter_cache_entries(
     cache_path: Path, *, max_scan: int | None = None
 ) -> Iterator[SavedBestConfig]:
@@ -75,25 +102,9 @@ def iter_cache_entries(
 
     for p in itertools.islice(files, max_scan):
         try:
-            data = json.loads(p.read_text())
-            fields = data["key"]["fields"]
-            raw_flat = data.get("flat_config")
-            if isinstance(raw_flat, str):
-                flat_config: tuple[object, ...] | None = tuple(json.loads(raw_flat))
-            elif raw_flat is not None:
-                flat_config = tuple(raw_flat)
-            else:
-                flat_config = None
-            yield SavedBestConfig(
-                hardware=fields.get("hardware", ""),
-                specialization_key=fields.get("specialization_key", ""),
-                config=Config.from_json(data["config"]),
-                config_spec_hash=fields.get("config_spec_hash", ""),
-                flat_config=flat_config,
-            )
-        except (OSError, KeyError, ValueError, TypeError) as e:
+            yield parse_cache_entry(p.read_text())
+        except (OSError, ValueError) as e:
             log.warning("Skipping corrupt cache file %s: %s", p.name, e)
-            continue
 
 
 class LocalAutotuneCache(AutotuneCacheBase):

--- a/helion/autotuner/remote_cache.py
+++ b/helion/autotuner/remote_cache.py
@@ -12,6 +12,8 @@ from .local_cache import LocalAutotuneCache
 from .local_cache import StrictLocalAutotuneCache
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from .base_search import BaseSearch
 
 log: logging.Logger = logging.getLogger(__name__)
@@ -34,6 +36,10 @@ class RemoteCacheBackend(abc.ABC):
     def put(self, key: str, data: str) -> None:
         """Store a JSON string under *key*."""
 
+    def list(self, max_results: int | None = None) -> Iterable[str]:
+        """Yield cached JSON entries, newest first. Empty by default; override to enable warm-start from remote."""
+        return ()
+
 
 _ENV_VAR = "HELION_REMOTE_CACHE_BACKEND"
 
@@ -54,6 +60,13 @@ def _load_remote_backend() -> RemoteCacheBackend:
             f"{_ENV_VAR} must point to a RemoteCacheBackend subclass, got {cls!r}"
         )
     return cls()
+
+
+def _load_remote_backend_if_configured() -> RemoteCacheBackend | None:
+    """Return the remote backend if HELION_REMOTE_CACHE_BACKEND is set, else None."""
+    if not os.environ.get(_ENV_VAR):
+        return None
+    return _load_remote_backend()
 
 
 def _remote_get(backend: RemoteCacheBackend, cache_hash: str) -> str | None:
@@ -95,9 +108,13 @@ class RemoteAutotuneCache(LocalAutotuneCache):
 
     def put(self, config: Config) -> None:
         super().put(config)
-        cache_hash = self.key.stable_hash()
-        data = json.dumps({"config": config.to_json()})
-        _remote_put(self._backend, cache_hash, data)
+        # Ship the exact bytes super().put() just atomically wrote, so the
+        # remote payload mirrors the on-disk shape without re-serialising.
+        _remote_put(
+            self._backend,
+            self.key.stable_hash(),
+            self._get_local_cache_path().read_text(),
+        )
 
     def _get_cache_info_message(self) -> str:
         base = super()._get_cache_info_message()
@@ -123,9 +140,12 @@ class StrictRemoteAutotuneCache(StrictLocalAutotuneCache):
 
     def put(self, config: Config) -> None:
         super().put(config)
-        cache_hash = self.key.stable_hash()
-        data = json.dumps({"config": config.to_json()})
-        _remote_put(self._backend, cache_hash, data)
+        # Ship the exact bytes super().put() just atomically wrote.
+        _remote_put(
+            self._backend,
+            self.key.stable_hash(),
+            self._get_local_cache_path().read_text(),
+        )
 
     def _get_cache_info_message(self) -> str:
         base = super()._get_cache_info_message()

--- a/helion/autotuner/remote_cache.py
+++ b/helion/autotuner/remote_cache.py
@@ -37,7 +37,7 @@ class RemoteCacheBackend(abc.ABC):
         """Store a JSON string under *key*."""
 
     def list(self, max_results: int | None = None) -> Iterable[str]:
-        """Yield cached JSON entries, newest first. Empty by default; override to enable warm-start from remote."""
+        """Return cached JSON entries, newest first. Empty by default; override to enable warm-start from remote."""
         return ()
 
 

--- a/test/test_best_available.py
+++ b/test/test_best_available.py
@@ -640,6 +640,247 @@ class TestCacheMatching(unittest.TestCase):
             self.assertEqual(entries[0].config.config["block_sizes"], [64, 128])
 
 
+def _make_entry_json(
+    hardware: str,
+    spec_key: str,
+    config_dict: dict[str, object],
+    config_spec_hash: str,
+    flat_config: list[object],
+) -> str:
+    """Build a .best_config JSON string matching the on-disk format."""
+    return json.dumps(
+        {
+            "key": {
+                "fields": {
+                    "hardware": hardware,
+                    "specialization_key": spec_key,
+                    "config_spec_hash": config_spec_hash,
+                }
+            },
+            "config": json.dumps(config_dict),
+            "flat_config": json.dumps(flat_config),
+        }
+    )
+
+
+class TestRemoteCacheMerging(unittest.TestCase):
+    """Tests for _find_similar_cached_configs merging remote entries via RemoteCacheBackend.list()."""
+
+    def _make_mock_search(self, hardware: str, spec_key: str, fp_hash: str):
+        mock_search = MagicMock()
+        mock_search._skip_cache = False
+        mock_search.settings = MagicMock()
+        mock_search.settings.autotune_best_available_max_cache_scan = 500
+        mock_search.settings.autotune_search_acf = None
+        mock_search._get_current_hardware_and_specialization = MagicMock(
+            return_value=(hardware, spec_key)
+        )
+        mock_search.config_spec = MagicMock()
+        mock_search.config_spec.structural_fingerprint_hash = MagicMock(
+            return_value=fp_hash
+        )
+        return mock_search
+
+    def test_remote_entries_returned_when_local_empty(self):
+        """When local has no matches, remote entries seed warm-start."""
+        from helion.autotuner.remote_cache import RemoteCacheBackend
+
+        fp_hash = "abc123"
+        hardware = "NVIDIA GeForce RTX 4090"
+        spec_key = "('tensor_spec',)"
+
+        class StubBackend(RemoteCacheBackend):
+            def get(self, key):
+                return None
+
+            def put(self, key, data):
+                pass
+
+            def list(self, max_results=None):
+                return [
+                    _make_entry_json(
+                        hardware, spec_key, {"block_sizes": [64]}, fp_hash, [64]
+                    )
+                ]
+
+        with (
+            tempfile.TemporaryDirectory() as cache_dir,
+            patch(
+                "helion.autotuner.local_cache.get_helion_cache_dir",
+                return_value=Path(cache_dir),
+            ),
+            patch(
+                "helion.autotuner.remote_cache._load_remote_backend_if_configured",
+                return_value=StubBackend(),
+            ),
+        ):
+            entries = PopulationBasedSearch._find_similar_cached_configs(
+                self._make_mock_search(hardware, spec_key, fp_hash), max_configs=10
+            )
+
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].config.config["block_sizes"], [64])
+
+    def test_remote_dedups_against_local(self):
+        """Remote entries duplicating a local match (including nested lists in flat_config) are dropped."""
+        from helion.autotuner.remote_cache import RemoteCacheBackend
+
+        fp_hash = "abc123"
+        hardware = "NVIDIA GeForce RTX 4090"
+        spec_key = "('tensor_spec',)"
+
+        # Nested list inside flat_config — common shape for block_sizes etc.
+        # The dedup machinery must not crash with "unhashable type: 'list'".
+        flat_a = [[16, 32], 4]
+        flat_b = [[64, 128], 8]
+
+        class StubBackend(RemoteCacheBackend):
+            def get(self, key):
+                return None
+
+            def put(self, key, data):
+                pass
+
+            def list(self, max_results=None):
+                return [
+                    _make_entry_json(
+                        hardware, spec_key, {"block_sizes": [16, 32]}, fp_hash, flat_a
+                    ),
+                    _make_entry_json(
+                        hardware, spec_key, {"block_sizes": [64, 128]}, fp_hash, flat_b
+                    ),
+                ]
+
+        with tempfile.TemporaryDirectory() as cache_dir:
+            # Local entry matches flat_a — remote duplicate must be skipped.
+            data = {
+                "key": {
+                    "fields": {
+                        "hardware": hardware,
+                        "specialization_key": spec_key,
+                        "config_spec_hash": fp_hash,
+                    }
+                },
+                "config": json.dumps({"block_sizes": [16, 32]}),
+                "flat_config": json.dumps(flat_a),
+            }
+            with open(os.path.join(cache_dir, "local.best_config"), "w") as f:
+                json.dump(data, f)
+
+            with (
+                patch(
+                    "helion.autotuner.local_cache.get_helion_cache_dir",
+                    return_value=Path(cache_dir),
+                ),
+                patch(
+                    "helion.autotuner.remote_cache._load_remote_backend_if_configured",
+                    return_value=StubBackend(),
+                ),
+            ):
+                entries = PopulationBasedSearch._find_similar_cached_configs(
+                    self._make_mock_search(hardware, spec_key, fp_hash),
+                    max_configs=10,
+                )
+
+        flats = [e.flat_config for e in entries]
+        # Local entry (a) appears first; remote (a) is deduped; remote (b) is kept.
+        self.assertEqual(flats, [([16, 32], 4), ([64, 128], 8)])
+
+    def test_remote_entries_filtered_by_hardware(self):
+        """Remote entries with non-matching hardware are skipped."""
+        from helion.autotuner.remote_cache import RemoteCacheBackend
+
+        fp_hash = "abc123"
+
+        class StubBackend(RemoteCacheBackend):
+            def get(self, key):
+                return None
+
+            def put(self, key, data):
+                pass
+
+            def list(self, max_results=None):
+                return [
+                    _make_entry_json(
+                        "NVIDIA A100", "('s',)", {"block_sizes": [128]}, fp_hash, [128]
+                    ),
+                ]
+
+        with (
+            tempfile.TemporaryDirectory() as cache_dir,
+            patch(
+                "helion.autotuner.local_cache.get_helion_cache_dir",
+                return_value=Path(cache_dir),
+            ),
+            patch(
+                "helion.autotuner.remote_cache._load_remote_backend_if_configured",
+                return_value=StubBackend(),
+            ),
+        ):
+            entries = PopulationBasedSearch._find_similar_cached_configs(
+                self._make_mock_search("NVIDIA GeForce RTX 4090", "('s',)", fp_hash),
+                max_configs=10,
+            )
+
+        self.assertEqual(entries, [])
+
+    def test_remote_malformed_entries_skipped(self):
+        """Malformed remote entries are silently skipped, valid ones still returned."""
+        from helion.autotuner.remote_cache import RemoteCacheBackend
+
+        fp_hash = "abc123"
+        hardware = "NVIDIA GeForce RTX 4090"
+        spec_key = "('s',)"
+
+        class StubBackend(RemoteCacheBackend):
+            def get(self, key):
+                return None
+
+            def put(self, key, data):
+                pass
+
+            def list(self, max_results=None):
+                return [
+                    "not valid json",
+                    json.dumps({"config": "minimal payload, missing key.fields"}),
+                    _make_entry_json(
+                        hardware, spec_key, {"block_sizes": [16]}, fp_hash, [16]
+                    ),
+                ]
+
+        with (
+            tempfile.TemporaryDirectory() as cache_dir,
+            patch(
+                "helion.autotuner.local_cache.get_helion_cache_dir",
+                return_value=Path(cache_dir),
+            ),
+            patch(
+                "helion.autotuner.remote_cache._load_remote_backend_if_configured",
+                return_value=StubBackend(),
+            ),
+        ):
+            entries = PopulationBasedSearch._find_similar_cached_configs(
+                self._make_mock_search(hardware, spec_key, fp_hash), max_configs=10
+            )
+
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].config.config["block_sizes"], [16])
+
+    def test_default_list_returns_empty(self):
+        """Backends that don't override list() use the empty default — no errors, no entries."""
+        from helion.autotuner.remote_cache import RemoteCacheBackend
+
+        class MinimalBackend(RemoteCacheBackend):
+            def get(self, key):
+                return None
+
+            def put(self, key, data):
+                pass
+
+        # The default impl returns an empty tuple; just verify the contract holds.
+        self.assertEqual(list(MinimalBackend().list()), [])
+
+
 class TestIterCacheEntries(unittest.TestCase):
     """Tests for the iter_cache_entries() module-level API in local_cache."""
 

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -767,6 +767,29 @@ class TestRemoteCache(RefEagerTestDisabled, TestCase):
         kernel(*args_a)
         self.assertEqual(counters["autotune"]["cache_hit"], 2)
 
+    def test_remote_put_payload_is_parseable(self):
+        """Bytes RemoteAutotuneCache.put sends are parseable by parse_cache_entry.
+
+        Guards against drift between LocalAutotuneCache.put's on-disk shape and
+        the format that warm-start consumers (_find_similar_cached_configs) expect.
+        """
+        from helion.autotuner.local_cache import parse_cache_entry
+
+        backend = InMemoryBackend()
+        kernel, args_a, _result_a, _args_b, _result_b = KERNELS["add"]()
+
+        kernel.reset()
+        kernel.settings.autotuner_fn = self._make_remote_cache_fn(backend)
+        kernel(*args_a)
+
+        self.assertEqual(len(backend.store), 1)
+        (raw,) = backend.store.values()
+        entry = parse_cache_entry(raw)
+        self.assertNotEqual(entry.hardware, "")
+        self.assertNotEqual(entry.specialization_key, "")
+        self.assertNotEqual(entry.config_spec_hash, "")
+        self.assertIsNotNone(entry.flat_config)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
  - `RemoteAutotuneCache.put` now ships the full local payload (key fields + flat_config) so warm-start consumers have the fields they need to filter.
  - Add optional `list()` to `RemoteCacheBackend` (empty default; backends override to enable warm-start enrichment).
  - `_find_similar_cached_configs` scans local first, then remote, dedup by flat_config. Benefits both `from_best_available` and `helion.from_cache` for FiniteSearch.
  - Extract `parse_cache_entry` as shared parser for `.best_config` files and remote payloads.

With both `HELION_REMOTE_CACHE_BACKEND` and `HELION_AUTOTUNE_CACHE=RemoteAutotuneCache` set, every new winning config is written to the remote backend and is then available to other machines' warm-start lookups.

  ## Test plan
  - [x] Multi-process end-to-end test: Worker A populates the remote via `RemoteAutotuneCache`; Worker B (separate process, empty local cache) discovers the entry via `_find_similar_cached_configs`
