### PR TITLE
Add H100 (sm90) pretuned heuristics and perf gates

### DIFF
--- a/pretuned_kernels/README.md
+++ b/pretuned_kernels/README.md
@@ -6,9 +6,11 @@ points for common kernel patterns while also being runnable examples for people
 who want to quickly try Helion.
 
 The checked-in heuristics let these kernels run immediately without online
-autotuning.  Treat the files as kernel recipes: copy the kernel and its local
-`_helion_aot_*` heuristic into your code, then retune when your target shapes or
-hardware differ materially from the included sweep.
+autotuning.  Heuristics ship for both NVIDIA H100 (`sm90`) and B200 (`sm100`);
+Helion picks the matching file at runtime.  Treat the files as kernel recipes:
+copy the kernel and its local `_helion_aot_*` heuristic into your code, then
+retune when your target shapes or hardware differ materially from the included
+sweep.
 
 Each kernel module has a `main()` that benchmarks against PyTorch eager.
 
@@ -19,13 +21,17 @@ pretuned_kernels/
 ├── README.md
 ├── vector_add/
 │   ├── vector_add.py                          # the kernel + main()
-│   └── _helion_aot_vector_add_cuda_sm100.py   # auto-loaded heuristic
+│   ├── _helion_aot_vector_add_cuda_sm100.py   # B200 heuristic
+│   └── _helion_aot_vector_add_cuda_sm90.py    # H100 heuristic
 ├── softmax/
 ├── layer_norm/
 ├── rms_norm/
 ├── cross_entropy/
 └── rope/
 ```
+
+Each kernel ships with one heuristic file per supported compute capability.
+At runtime Helion picks the file matching the current GPU.
 
 | Kernel | Shape sweep | PyTorch baseline |
 |---|---|---|

--- a/pretuned_kernels/cross_entropy/_helion_aot_cross_entropy_cuda_sm90.py
+++ b/pretuned_kernels/cross_entropy/_helion_aot_cross_entropy_cuda_sm90.py
@@ -1,0 +1,28 @@
+"""
+Auto-generated heuristic for kernel: cross_entropy
+Backend: decision_tree
+
+Provides:
+- key_cross_entropy(*args): Returns config index (cache key)
+- autotune_cross_entropy(*args): Returns config dict for the given arguments
+"""
+
+import torch
+
+
+def key_cross_entropy(*args) -> int:
+    """Select config index for the given arguments (also serves as cache key)."""
+    _arg0_dim1 = int(args[0].shape[1]) if len(args) > 0 and isinstance(args[0], torch.Tensor) and args[0].ndim > 1 else 0
+    if _arg0_dim1 <= 129280.0:
+        return 1
+    else:
+        return 0
+
+
+def autotune_cross_entropy(*args) -> dict:
+    """Select the optimal config for the given arguments."""
+    _C = [
+        {'block_sizes': [1], 'reduction_loops': [32768], 'range_unroll_factors': [0], 'range_warp_specializes': [], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['last', 'first', 'last', 'first', 'first'], 'num_warps': 32, 'num_stages': 1, 'indexing': ['pointer', 'tensor_descriptor', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'pointer'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['first', 'first', 'first', 'first', ''], 'num_warps': 16, 'num_stages': 1, 'indexing': ['pointer', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'pointer'], 'atomic_indexing': [], 'pid_type': 'flat'},
+    ]
+    return _C[key_cross_entropy(*args)]

--- a/pretuned_kernels/layer_norm/_helion_aot_layer_norm_cuda_sm90.py
+++ b/pretuned_kernels/layer_norm/_helion_aot_layer_norm_cuda_sm90.py
@@ -1,0 +1,40 @@
+"""
+Auto-generated heuristic for kernel: layer_norm
+Backend: decision_tree
+
+Provides:
+- key_layer_norm(*args): Returns config index (cache key)
+- autotune_layer_norm(*args): Returns config dict for the given arguments
+"""
+
+import torch
+
+
+def key_layer_norm(*args) -> int:
+    """Select config index for the given arguments (also serves as cache key)."""
+    _arg0_dim0 = int(args[0].shape[0]) if len(args) > 0 and isinstance(args[0], torch.Tensor) and args[0].ndim > 0 else 0
+    _arg0_dim1 = int(args[0].shape[1]) if len(args) > 0 and isinstance(args[0], torch.Tensor) and args[0].ndim > 1 else 0
+    if _arg0_dim1 <= 7168.0:
+        if _arg0_dim1 <= 1536.0:
+            return 3
+        else:
+            return 0
+    else:
+        if _arg0_dim0 <= 2048.0:
+            if _arg0_dim0 <= 1152.0:
+                return 2
+            else:
+                return 0
+        else:
+            return 1
+
+
+def autotune_layer_norm(*args) -> dict:
+    """Select the optimal config for the given arguments."""
+    _C = [
+        {'block_sizes': [1], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['first', '', 'last', 'last', '', 'last', '', ''], 'num_warps': 8, 'num_stages': 3, 'indexing': ['pointer', 'pointer', 'pointer', 'tensor_descriptor', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'pointer', 'pointer', 'pointer'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['', '', 'last', 'first', 'last', '', 'last', ''], 'num_warps': 16, 'num_stages': 4, 'indexing': ['pointer', 'tensor_descriptor', 'pointer', 'pointer', 'pointer', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'pointer'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1], 'reduction_loops': [8192], 'range_unroll_factors': [0], 'range_warp_specializes': [], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['last', '', 'first', '', '', '', 'first', ''], 'num_warps': 32, 'num_stages': 2, 'indexing': ['tensor_descriptor', 'pointer', 'tensor_descriptor', 'pointer', 'tensor_descriptor', 'pointer', 'tensor_descriptor', 'pointer', 'tensor_descriptor', 'pointer'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['first', '', '', 'first', 'last', 'first', 'first', ''], 'num_warps': 4, 'num_stages': 1, 'indexing': ['tensor_descriptor', 'pointer', 'pointer', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'pointer', 'tensor_descriptor', 'pointer', 'pointer'], 'atomic_indexing': [], 'pid_type': 'flat'},
+    ]
+    return _C[key_layer_norm(*args)]

--- a/pretuned_kernels/rms_norm/_helion_aot_rms_norm_cuda_sm90.py
+++ b/pretuned_kernels/rms_norm/_helion_aot_rms_norm_cuda_sm90.py
@@ -1,0 +1,42 @@
+"""
+Auto-generated heuristic for kernel: rms_norm
+Backend: decision_tree
+
+Provides:
+- key_rms_norm(*args): Returns config index (cache key)
+- autotune_rms_norm(*args): Returns config dict for the given arguments
+"""
+
+import torch
+
+
+def key_rms_norm(*args) -> int:
+    """Select config index for the given arguments (also serves as cache key)."""
+    _arg0_dim0 = int(args[0].shape[0]) if len(args) > 0 and isinstance(args[0], torch.Tensor) and args[0].ndim > 0 else 0
+    _arg0_dim1 = int(args[0].shape[1]) if len(args) > 0 and isinstance(args[0], torch.Tensor) and args[0].ndim > 1 else 0
+    if _arg0_dim1 <= 4096.0:
+        if _arg0_dim0 <= 16384.0:
+            if _arg0_dim1 <= 3584.0:
+                return 0
+            else:
+                if _arg0_dim0 <= 2048.0:
+                    return 1
+                else:
+                    return 0
+        else:
+            if _arg0_dim1 <= 384.0:
+                return 2
+            else:
+                return 0
+    else:
+        return 1
+
+
+def autotune_rms_norm(*args) -> dict:
+    """Select the optimal config for the given arguments."""
+    _C = [
+        {'block_sizes': [4], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['last', '', '', 'last', 'last'], 'num_warps': 8, 'num_stages': 5, 'indexing': ['pointer', 'pointer', 'pointer', 'tensor_descriptor', 'pointer', 'tensor_descriptor', 'pointer'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['', '', '', 'last', 'last'], 'num_warps': 16, 'num_stages': 1, 'indexing': ['pointer', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'pointer', 'pointer', 'pointer'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [16], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['', '', '', 'last', 'first'], 'num_warps': 4, 'num_stages': 2, 'indexing': ['pointer', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'pointer', 'pointer', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'flat'},
+    ]
+    return _C[key_rms_norm(*args)]

--- a/pretuned_kernels/softmax/_helion_aot_softmax_cuda_sm90.py
+++ b/pretuned_kernels/softmax/_helion_aot_softmax_cuda_sm90.py
@@ -1,0 +1,56 @@
+"""
+Auto-generated heuristic for kernel: softmax
+Backend: decision_tree
+
+Provides:
+- key_softmax(*args): Returns config index (cache key)
+- autotune_softmax(*args): Returns config dict for the given arguments
+"""
+
+import torch
+
+
+def key_softmax(*args) -> int:
+    """Select config index for the given arguments (also serves as cache key)."""
+    _arg0_dim1 = int(args[0].shape[1]) if len(args) > 0 and isinstance(args[0], torch.Tensor) and args[0].ndim > 1 else 0
+    if _arg0_dim1 <= 2048.0:
+        return 1
+    else:
+        if _arg0_dim1 <= 7552.0:
+            return 0
+        else:
+            if _arg0_dim1 <= 9984.0:
+                if _arg0_dim1 <= 8192.0:
+                    if _arg0_dim1 <= 7680.0:
+                        return 2
+                    else:
+                        return 0
+                else:
+                    if _arg0_dim1 <= 8960.0:
+                        if _arg0_dim1 <= 8832.0:
+                            return 2
+                        else:
+                            return 0
+                    else:
+                        return 2
+            else:
+                if _arg0_dim1 <= 12672.0:
+                    if _arg0_dim1 <= 11136.0:
+                        return 0
+                    else:
+                        if _arg0_dim1 <= 11264.0:
+                            return 2
+                        else:
+                            return 0
+                else:
+                    return 2
+
+
+def autotune_softmax(*args) -> dict:
+    """Select the optimal config for the given arguments."""
+    _C = [
+        {'block_sizes': [1], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['first', 'first', 'first', ''], 'num_warps': 8, 'num_stages': 2, 'indexing': ['tensor_descriptor', 'pointer', 'tensor_descriptor', 'tensor_descriptor', 'pointer', 'pointer'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [1], 'reduction_loops': [None], 'range_unroll_factors': [2], 'range_warp_specializes': [], 'range_num_stages': [4], 'range_multi_buffers': [True], 'range_flattens': [True], 'load_eviction_policies': ['last', 'first', 'first', 'last'], 'num_warps': 1, 'num_stages': 3, 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'pointer'], 'atomic_indexing': [], 'pid_type': 'persistent_interleaved', 'num_sm_multiplier': 32},
+        {'block_sizes': [1], 'reduction_loops': [None], 'range_unroll_factors': [0], 'range_warp_specializes': [], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['first', 'first', 'first', ''], 'num_warps': 16, 'num_stages': 2, 'indexing': ['pointer', 'tensor_descriptor', 'tensor_descriptor', 'pointer', 'tensor_descriptor', 'pointer'], 'atomic_indexing': [], 'pid_type': 'flat'},
+    ]
+    return _C[key_softmax(*args)]

--- a/pretuned_kernels/vector_add/_helion_aot_vector_add_cuda_sm90.py
+++ b/pretuned_kernels/vector_add/_helion_aot_vector_add_cuda_sm90.py
@@ -1,0 +1,31 @@
+"""
+Auto-generated heuristic for kernel: vector_add
+Backend: decision_tree
+
+Provides:
+- key_vector_add(*args): Returns config index (cache key)
+- autotune_vector_add(*args): Returns config dict for the given arguments
+"""
+
+import torch
+
+
+def key_vector_add(*args) -> int:
+    """Select config index for the given arguments (also serves as cache key)."""
+    _arg0_dim0 = int(args[0].shape[0]) if len(args) > 0 and isinstance(args[0], torch.Tensor) and args[0].ndim > 0 else 0
+    if _arg0_dim0 <= 4194304.0:
+        if _arg0_dim0 <= 1048576.0:
+            return 0
+        else:
+            return 1
+    else:
+        return 0
+
+
+def autotune_vector_add(*args) -> dict:
+    """Select the optimal config for the given arguments."""
+    _C = [
+        {'block_sizes': [256], 'range_unroll_factors': [0], 'range_warp_specializes': [], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['last', 'last'], 'num_warps': 1, 'num_stages': 7, 'indexing': ['pointer', 'tensor_descriptor', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'flat'},
+        {'block_sizes': [4096], 'range_unroll_factors': [0], 'range_warp_specializes': [], 'range_num_stages': [0], 'range_multi_buffers': [None], 'range_flattens': [None], 'load_eviction_policies': ['', 'last'], 'num_warps': 8, 'num_stages': 3, 'indexing': ['pointer', 'pointer', 'tensor_descriptor'], 'atomic_indexing': [], 'pid_type': 'flat'},
+    ]
+    return _C[key_vector_add(*args)]

--- a/test/test_pretuned_kernels.py
+++ b/test/test_pretuned_kernels.py
@@ -264,6 +264,12 @@ _EXPECTED_PERF: dict[str, dict[str, ExpectedPerf]] = {
             geomean=1.009,
             wins_slack=None,
         ),
+        "sm90": ExpectedPerf(
+            helion_wins=5,
+            total=10,
+            geomean=0.99,
+            wins_slack=None,
+        ),
     },
     "softmax": {
         "sm100": ExpectedPerf(
@@ -271,6 +277,12 @@ _EXPECTED_PERF: dict[str, dict[str, ExpectedPerf]] = {
             total=100,
             geomean=2.304,
             wins_slack=2,
+        ),
+        "sm90": ExpectedPerf(
+            helion_wins=97,
+            total=100,
+            geomean=1.78,
+            wins_slack=7,
         ),
     },
     "layer_norm": {
@@ -280,6 +292,12 @@ _EXPECTED_PERF: dict[str, dict[str, ExpectedPerf]] = {
             geomean=1.55,
             wins_slack=1,
         ),
+        "sm90": ExpectedPerf(
+            helion_wins=37,
+            total=38,
+            geomean=1.39,
+            wins_slack=2,
+        ),
     },
     "rms_norm": {
         "sm100": ExpectedPerf(
@@ -288,12 +306,24 @@ _EXPECTED_PERF: dict[str, dict[str, ExpectedPerf]] = {
             geomean=1.605,
             wins_slack=6,
         ),
+        "sm90": ExpectedPerf(
+            helion_wins=23,
+            total=30,
+            geomean=1.17,
+            wins_slack=5,
+        ),
     },
     "cross_entropy": {
         "sm100": ExpectedPerf(
             helion_wins=21,
             total=21,
             geomean=1.698,
+            wins_slack=1,
+        ),
+        "sm90": ExpectedPerf(
+            helion_wins=21,
+            total=21,
+            geomean=2.35,
             wins_slack=1,
         ),
     },


### PR DESCRIPTION
With the triton_do_not_specialize as opt in, we recover the perf for these pretuned kernels that use static_shapes=false (all AOT kernels).