### PR TITLE
Limit A10G CI pytest workers to two

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -324,6 +324,12 @@ jobs:
             TEST_PATH="."
             EXTRA_FLAGS="--ignore=test/test_examples_dist.py"
           fi
+          # A10G runners expose one 22 GiB GPU. Four xdist workers can collectively
+          # exhaust VRAM with CUDA/Triton/Inductor state even when an individual test
+          # only needs a small allocation.
+          if [[ -n "$PARALLEL" && "${{ matrix.alias }}" == *a10g* ]]; then
+            PARALLEL="-n2"
+          fi
           # For distributed tests, fail if any test is skipped, failed, or has an error
           SKIP_CHECK=$([[ "${{ contains(matrix.alias, 'distributed') }}" == "true" ]] && echo "! grep -qE '(SKIPPED|FAILED|ERROR)'" || echo "cat > /dev/null")
           if [[ "${{ matrix.alias }}" == *xpu* ]]; then


### PR DESCRIPTION
fixes CI issue:
FAILED test/test_torch_compile.py::TestTorchCompile::test_prologue_epilogue_chained_ops_allow_torch_compile_fusion_False - torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 20.00 MiB. GPU 0 has a total capacity of 22.06 GiB of which 7.38 MiB is free. Process 1185 has 3.14 GiB memory in use. Process 1188 has 10.63 GiB memory in use. Including non-PyTorch memory, this process has 306.00 MiB memory in use. Process 1182 has 7.96 GiB memory in use. Of the allocated memory 483.00 KiB is allocated by PyTorch, and 1.53 MiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf)

From 
https://github.com/pytorch/helion/actions/runs/25942081303/job/76261905945?pr=2448#logs
