### PR TITLE
[Pallas] Add epilogue_subtiling to TPU benchmark sweep

### DIFF
--- a/benchmarks/run_tpu.py
+++ b/benchmarks/run_tpu.py
@@ -731,6 +731,37 @@ def _grpo_loss_shapes(
     return out
 
 
+def _epilogue_subtiling_residual_gelu_baseline(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    bias: torch.Tensor,
+    residual: torch.Tensor,
+) -> torch.Tensor:
+    # PyTorch reference matching matmul_bias_residual_gelu_cast.
+    acc = x.float() @ w.float()
+    return torch.nn.functional.gelu(
+        acc * 1.25 + residual.float() * 0.5 + bias.float()
+    ).to(x.dtype)
+
+
+def _epilogue_subtiling_shapes(
+    num_shapes: int | None = None,
+) -> list[tuple[str, tuple[Any, ...]]]:
+    # (m, k, n) — matmul shape. Test uses 8192³; smaller shapes here keep
+    # autotune time tractable in the sweep.
+    configs = [(2048, 2048, 2048), (4096, 4096, 4096)]
+    if num_shapes is not None:
+        configs = configs[:num_shapes]
+    out: list[tuple[str, tuple[Any, ...]]] = []
+    for m, k, n in configs:
+        x = torch.randn(m, k, device=DEVICE, dtype=torch.bfloat16)
+        w = torch.randn(k, n, device=DEVICE, dtype=torch.bfloat16)
+        bias = torch.randn(n, device=DEVICE, dtype=torch.bfloat16)
+        residual = torch.randn(m, n, device=DEVICE, dtype=torch.bfloat16)
+        out.append((f"[{m},{k},{n}]", (x, w, bias, residual)))
+    return out
+
+
 # Kernel mappings for TPU/Pallas benchmarks.
 # Format: kernel_name -> (module_file, kernel_fn_name, baseline_fn, shapes_fn,
 #                         max_mismatch_pct)
@@ -928,6 +959,13 @@ KERNEL_MAPPINGS: dict[str, KernelMapping] = {
         "helion_grpo_loss",
         _grpo_loss_baseline,
         _grpo_loss_shapes,
+        None,
+    ),
+    "epilogue_subtiling": (
+        "epilogue_subtiling",
+        "matmul_bias_residual_gelu_cast",
+        _epilogue_subtiling_residual_gelu_baseline,
+        _epilogue_subtiling_shapes,
         None,
     ),
 }

--- a/examples/epilogue_subtiling.py
+++ b/examples/epilogue_subtiling.py
@@ -40,7 +40,7 @@ def matmul_bias_residual_gelu_cast(
 ) -> torch.Tensor:
     m, k = x.size()
     _, n = w.size()
-    out = torch.empty([m, n], dtype=HALF_DTYPE, device=x.device)
+    out = torch.empty([m, n], dtype=x.dtype, device=x.device)
 
     for tile_m, tile_n in hl.tile([m, n]):
         acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
@@ -51,7 +51,7 @@ def matmul_bias_residual_gelu_cast(
         val = val + residual[tile_m, tile_n].to(torch.float32) * 0.5
         val = val + bias[tile_n]
         val = torch.nn.functional.gelu(val)
-        out[tile_m, tile_n] = val.to(HALF_DTYPE)
+        out[tile_m, tile_n] = val.to(x.dtype)
 
     return out
 
@@ -72,8 +72,8 @@ def matmul_bias_gelu_aux(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     m, k = x.size()
     _, n = w.size()
-    out = torch.empty([m, n], dtype=HALF_DTYPE, device=x.device)
-    aux = torch.empty([m, n], dtype=HALF_DTYPE, device=x.device)
+    out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+    aux = torch.empty([m, n], dtype=x.dtype, device=x.device)
 
     for tile_m, tile_n in hl.tile([m, n]):
         acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
@@ -82,8 +82,8 @@ def matmul_bias_gelu_aux(
 
         pre = acc * 1.25
         pre = pre + bias[tile_n]
-        aux[tile_m, tile_n] = pre.to(HALF_DTYPE)
-        out[tile_m, tile_n] = torch.nn.functional.gelu(pre).to(HALF_DTYPE)
+        aux[tile_m, tile_n] = pre.to(x.dtype)
+        out[tile_m, tile_n] = torch.nn.functional.gelu(pre).to(x.dtype)
 
     return out, aux
 


### PR DESCRIPTION
## Summary
- Wires `examples/epilogue_subtiling.py`'s `matmul_bias_residual_gelu_cast` into `benchmarks/run_tpu.py::KERNEL_MAPPINGS` so it runs in the full-coverage TPU sweep.
- Replaces `HALF_DTYPE` references inside the kernel bodies with `x.dtype`. `HALF_DTYPE` is still imported and used at the call site (in `check()` / `main()`).

## Why drop `HALF_DTYPE` *inside* the kernel
`HALF_DTYPE` is a module-level constant in `helion._testing` (`bf16` on TPU, `fp16` elsewhere). When it's referenced *inside* a Helion kernel body, Helion's compiler walks the AST, sees the name, and does `sys.modules[kernel_fn.__module__]` to resolve it. That lookup fails when the benchmark harness imports the example via `importlib.util.spec_from_file_location` (the loader doesn't register the module in `sys.modules`). Other examples that use `HALF_DTYPE` only at the call site (`attention.py`, `bmm.py`, `broadcast_matmul.py`, …) don't hit this. Using `x.dtype` inside the kernel keeps the kernel backend-portable (matches input dtype, bf16 on TPU and fp16 on CUDA) without the global-lookup gotcha.

## Autotune results (TPUv7, full effort)

| Shape | Helion (ms) | Torch (ms) | Helion speedup | torch.compile speedup |
|---|---:|---:|---:|---:|
| [2048, 2048, 2048] | 0.2572 | 0.5278 | **2.05x** | 1.95x |
| [4096, 4096, 4096] | 0.4413 | 0.8677 | **1.97x** | 1.85x |
