### PR TITLE
[Pallas] Accept kernels_tpu='all' for full-coverage TPU bench

### DIFF
--- a/.github/workflows/benchmark_dispatch.yml
+++ b/.github/workflows/benchmark_dispatch.yml
@@ -31,7 +31,7 @@ on:
         # round-robin sharding with max-runners=13.
         default: "flash_attention,gdn_fwd_h,cross_entropy,grouped_gemm,gemm,welford,layer_norm-bwd,int4_gemm,softmax,layer_norm,mamba2_chunk_state,rms_norm-bwd,rope,rope-bwd,jsd,mamba2_chunk_scan,kl_div,rms_norm"
       kernels_tpu:
-        description: 'Comma-separated list of kernels to benchmark on TPU (examples-based; disjoint from `kernels`). Default is the dashboard-tracked subset; pass an explicit list for ad-hoc full-coverage runs.'
+        description: 'Comma-separated list of kernels to benchmark on TPU (examples-based; disjoint from `kernels`). Default is the dashboard-tracked subset; pass an explicit list, or `all` to run every kernel registered in benchmarks/run_tpu.py::KERNEL_MAPPINGS.'
         required: false
         type: string
         default: "flash_attention,bmm,gemm,welford,softmax,layer_norm,rms_norm,rms_norm-bwd,cross_entropy"

--- a/.github/workflows/benchmark_tpu.yml
+++ b/.github/workflows/benchmark_tpu.yml
@@ -116,9 +116,17 @@ jobs:
           mkdir -p "$TEST_REPORTS_DIR"
 
           KERNELS="${{ inputs.kernels }}"
+          # "all" (or empty) -> let run_tpu.py default to every kernel in
+          # KERNEL_MAPPINGS. Single source of truth for the full kernel set
+          # lives in the Python dict; YAML doesn't need to mirror it.
+          if [[ "$KERNELS" == "all" || -z "$KERNELS" ]]; then
+            KERNEL_FLAG=()
+          else
+            KERNEL_FLAG=(--kernel "$KERNELS")
+          fi
           echo "=========================================="
           echo "TPU Benchmark"
-          echo "Kernels: $KERNELS"
+          echo "Kernels: ${KERNELS:-all}"
           echo "=========================================="
 
           # Single combined pass — same shape as benchmarks/run.py for GPU.
@@ -127,7 +135,7 @@ jobs:
           # warmup so post-autotune latency measurements are stable.
           HELION_PRINT_OUTPUT_CODE=1 HELION_MEASURE_COMPILE_TIME=1 \
             python benchmarks/run_tpu.py \
-              --kernel "$KERNELS" \
+              "${KERNEL_FLAG[@]}" \
               --num-shapes 2 \
               --output "$TEST_REPORTS_DIR/helionbench.json"
 


### PR DESCRIPTION
## Summary
Adds a magic `kernels_tpu=all` value to `benchmark_dispatch.yml` that runs every kernel registered in `benchmarks/run_tpu.py::KERNEL_MAPPINGS`. Replaces the off-main `yifeixu/tpu-bench-full` workflow wrapper (PR #2322), which hardcoded the kernel list in YAML and drifted from `KERNEL_MAPPINGS` as new kernels were added.

`run_tpu.py` already picks every kernel in `KERNEL_MAPPINGS` when called without `--kernel`. The change just wires that path through `benchmark_tpu.yml`: when `kernels_tpu == "all"` (or empty), drop the `--kernel` flag and let the Python defaulter handle it. The Python dict becomes the single source of truth — adding a new kernel auto-includes it in the full sweep.

## Trigger a full sweep

```bash
gh workflow run benchmark_dispatch.yml -R pytorch/helion \
  -f run_tpu=true -f run_h100=false -f run_b200=false -f run_mi350x=false \
  -f kernels_tpu=all
```

Or via the Actions UI: set the `kernels_tpu` input textbox to `all`.