### PR TITLE
[Examples] rope: print benchmark table via run_example

### DIFF
--- a/examples/rope.py
+++ b/examples/rope.py
@@ -16,6 +16,7 @@ import torch
 import helion
 from helion._testing import DEVICE
 from helion._testing import HALF_DTYPE
+from helion._testing import run_example
 import helion.language as hl
 
 
@@ -255,9 +256,10 @@ def main() -> None:
     angles = torch.randn([batch, seq_len, head_dim], device=DEVICE, dtype=HALF_DTYPE)
     cos = torch.cos(angles)
     sin = torch.sin(angles)
-    torch.testing.assert_close(
-        rope(q, k, cos, sin),
-        rope_pytorch(q, k, cos, sin),
+    run_example(
+        rope,  # pyrefly: ignore [bad-argument-type]
+        rope_pytorch,  # pyrefly: ignore [bad-argument-type]
+        (q, k, cos, sin),
         atol=1e-2,
         rtol=1e-2,
     )


### PR DESCRIPTION
Stacked PRs:
 * #2465
 * __->__#2464
 * #2448
 * #2450
 * #2446


--- --- ---

### [Examples] rope: print benchmark table via run_example


Replaces the bare `torch.testing.assert_close` in `examples/rope.py:main` with
`run_example(rope, rope_pytorch, …, atol=1e-2, rtol=1e-2)` so the example
prints a helion-vs-baseline timing table, matching the rest of the examples
suite. `run_example` performs the same `torch.testing.assert_close` internally,
so correctness coverage is unchanged (explicit `atol=1e-2, rtol=1e-2` to
preserve the original tolerances).

Useful when benchmarking the LLM-seeded autotuner vs the plain LFBO baseline
across this example: with the prior stack on B200 (full effort, single shot,
`HELION_LLM_MODEL=claude-opus-4-7 HELION_LLM_EFFORT_LEVEL=max HELION_LLM_FAST_MODE=1`),
the head-to-head on 6 example kernels was:

| kernel     | wall LFBO (s) | wall LLM (s) | wall ratio | helion LFBO (ms) | helion LLM (ms) | kernel ratio |
| ---------- | ------------- | ------------ | ---------- | ---------------- | --------------- | ------------ |
| attention  |        251.9 |         74.5 |  **0.30×** |          0.0594 |          0.0604 |        1.02× |
| gdn_fwd_h  |        286.7 |         93.8 |  **0.33×** |          0.5910 |          0.5970 |        1.01× |
| layer_norm |       1358.3 |        742.9 |  **0.55×** |          0.0349 |          0.0369 |        1.06× |
| matmul     |        117.9 |         57.0 |  **0.48×** |          0.0154 |          0.0144 |        0.94× |
| rope       |         96.1 |         63.9 |  **0.67×** |          0.0497 |          0.0458 |        0.92× |
| softmax    |        573.3 |        176.8 |  **0.31×** |          0.0143 |          0.0205 |        1.43× |

Geomean wall: **0.42×**, geomean helion-ms: **1.05×**.