### PR TITLE
[Autotuner] LLM prompt: diversify num_stages/num_warps in seed batch

### DIFF
--- a/helion/autotuner/llm/prompting.py
+++ b/helion/autotuner/llm/prompting.py
@@ -134,12 +134,15 @@ def _initial_strategy_lines(
         )
     if "reduction_loops" in flat_fields:
         lines.append(
-            "This is reduction-like: keep most configs conservative and avoid very large block_sizes or maxed num_warps/num_stages."
+            "This is reduction-like: span the space — include conservative configs (small blocks, num_stages=1-2) AND aggressive configs (large blocks up to the reduction dim, num_stages=4-8 with deep range_num_stages pipelining). Memory-bound reductions on modern accelerators often prefer the aggressive end."
         )
     if any(name in flat_fields for name in _ADVANCED_TOGGLE_FIELDS):
         lines.append(
             "Use advanced toggles like warp_specialize, multi_buffer, and flatten in only a minority of otherwise sane configs."
         )
+    lines.append(
+        "Explicitly diversify num_stages and num_warps across the batch: don't cluster all suggestions at num_stages=1; include several with num_stages in {2, 4, 8} so LFBO refinement has aggressive seeds to anchor on."
+    )
     return lines
 
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#2465
 * #2451
 * #2448
 * #2450
 * #2446


--- --- ---

### [Autotuner] LLM prompt: diversify num_stages/num_warps in seed batch


Two prompt additions in `helion/autotuner/llm/prompting.py`:

- Reduction-kernel guidance now spans the space (conservative AND aggressive
  configs with `num_stages=4-8` and large blocks up to the reduction dim),
  instead of "keep most configs conservative". The prior wording actively
  biased the LLM away from the aggressive optimum that LFBO reaches on its
  own (e.g., softmax_fwd_bwd picks `num_stages=8` with `block_sizes[-1]`
  equal to the reduction dim).
- Batch-level diversity: every initial batch now explicitly requires
  several configs with `num_stages` in {2, 4, 8} so LFBO refinement has
  aggressive anchors to climb from.

A/B at effort=none across 6 example kernels (single-shot on B200,
`HELION_LLM_MODEL=claude-opus-4-7 HELION_LLM_FAST_MODE=1`):

| kernel     | wall NEW (s) | wall OLD (s) | wall ratio | helion NEW (ms) | helion OLD (ms) | kernel ratio |
| ---------- | -----------: | -----------: | ---------: | --------------: | --------------: | -----------: |
| attention  |        86.85 |       107.96 |  **0.80x** |          0.0520 |          0.0532 |        0.98x |
| gdn_fwd_h  |       104.71 |        97.32 |      1.08x |          0.5940 |          0.5899 |        1.01x |
| layer_norm |       632.30 |       839.34 |  **0.75x** |          0.0378 |          0.0369 |        1.02x |
| matmul (*) |        58.68 |        57.49 |      1.02x |          0.0144 |          0.0134 |        1.07x |
| rope       |        59.56 |       101.11 |  **0.59x** |          0.0448 |          0.0456 |        0.98x |
| softmax    |       157.09 |       140.23 |      1.12x |          0.0205 |          0.0226 |    **0.91x** |

Geomean wall: **0.87x**. Geomean helion-ms (excl. matmul): **0.98x**.

(*) matmul exited 1 in both cells (same failure on both branches; unrelated
    to prompt content).