### PR TITLE
Seed tensor descriptor inner range autotune configs

### DIFF
--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 from .common import dedupe_configs
 from .cute import CuteTcgen05ClusterM2Heuristic
 from .triton import TritonSkinnyGemmHeuristic
+from .triton import TritonTensorDescriptorInnerRangeDefaultHeuristic
+from .triton import TritonTensorDescriptorInnerRangeInnerHeuristic
 
 if TYPE_CHECKING:
     from ...runtime.config import Config
@@ -16,7 +18,11 @@ if TYPE_CHECKING:
 # All active heuristics by backend
 HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
     "cute": (CuteTcgen05ClusterM2Heuristic,),
-    "triton": (TritonSkinnyGemmHeuristic,),
+    "triton": (
+        TritonSkinnyGemmHeuristic,
+        TritonTensorDescriptorInnerRangeDefaultHeuristic,
+        TritonTensorDescriptorInnerRangeInnerHeuristic,
+    ),
 }
 
 log: logging.Logger = logging.getLogger(__name__)

--- a/helion/_compiler/autotuner_heuristics/triton.py
+++ b/helion/_compiler/autotuner_heuristics/triton.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from typing import ClassVar
 
 from ...runtime.config import Config
 from .common import clamp_block_size_targets
@@ -76,3 +77,38 @@ class TritonSkinnyGemmHeuristic(AutotunerHeuristic):
         )
         assert block_sizes is not None
         return Config(block_sizes=block_sizes)
+
+
+class _TritonTensorDescriptorInnerRangeHeuristic(AutotunerHeuristic):
+    backend = "triton"
+    seed_index: ClassVar[int]
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        return (
+            env.config_spec.tensor_descriptor_inner_range_seed_configs_enabled
+            and env.config_spec._tensor_descriptor_inner_range_seed_structure_matches()
+        )
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        configs = env.config_spec._tensor_descriptor_inner_range_seed_configs()
+        if cls.seed_index >= len(configs):
+            return None
+        return configs[cls.seed_index]
+
+
+class TritonTensorDescriptorInnerRangeDefaultHeuristic(
+    _TritonTensorDescriptorInnerRangeHeuristic
+):
+    name = "triton_tensor_descriptor_inner_range_default"
+    seed_index = 0
+
+
+class TritonTensorDescriptorInnerRangeInnerHeuristic(
+    _TritonTensorDescriptorInnerRangeHeuristic
+):
+    name = "triton_tensor_descriptor_inner_range_inner"
+    seed_index = 1

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -2089,6 +2089,7 @@ def _register_load_store_tunables(
             EnumFragment(choices=env.config_spec.valid_indexing_types()),
             length=total_count,
         )
+    env.config_spec.maybe_enable_tensor_descriptor_inner_range_seed_configs()
 
 
 def _register_atomic_tunables(atomic_count: int) -> None:

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -460,6 +460,7 @@ class ConfigSpec:
         self.epilogue_subtile_k_hint: int = 0
         self.has_pallas_inner_loops: bool = False
         self.has_symbolic_or_data_dependent_bounds: bool = False
+        self.tensor_descriptor_inner_range_seed_configs_enabled: bool = False
         self.cute_tcgen05_search_enabled: bool = False
         # Post-compile bind-time flag: True when the host function's
         # FX graphs contain a tcgen05 matmul AND at least one
@@ -667,6 +668,15 @@ class ConfigSpec:
         # reopening the search choices.
         self.restrict_tcgen05_cluster_m_search((1, 2))
 
+    def enable_tensor_descriptor_inner_range_seed_configs(self) -> None:
+        """Allow compiler-owned tensor-descriptor inner-range seed configs."""
+        self.tensor_descriptor_inner_range_seed_configs_enabled = True
+
+    def maybe_enable_tensor_descriptor_inner_range_seed_configs(self) -> None:
+        """Enable TD inner-range seeds only for the matching compiler structure."""
+        if self._tensor_descriptor_inner_range_seed_structure_matches():
+            self.enable_tensor_descriptor_inner_range_seed_configs()
+
     @staticmethod
     def _tcgen05_cluster_m2_bk_is_valid(
         bk: int, constraints: Tcgen05ClusterM2SearchConstraints
@@ -791,6 +801,115 @@ class ConfigSpec:
         if c_input_seed is not None:
             seeds.append(c_input_seed)
         return seeds
+
+    def _tensor_descriptor_inner_range_seed_configs(self) -> list[helion.Config]:
+        """Seed layer-norm-style inner range reductions with known fast TD configs."""
+        # The flag mirrors the tcgen05 opt-in style; rechecking the structure
+        # keeps the seed from surviving later ConfigSpec mutations.
+        if (
+            not self.tensor_descriptor_inner_range_seed_configs_enabled
+            or not self._tensor_descriptor_inner_range_seed_structure_matches()
+        ):
+            return []
+
+        default_warp_specializes: list[bool | None] | None = None
+        inner_warp_specializes: list[bool | None] | None = None
+        if len(self.range_warp_specialize) == 2:
+            default_warp_specializes = [None, None]
+            inner_warp_specializes = [None, False]
+
+        return [
+            helion.Config(
+                block_sizes=[32, 8],
+                indexing=[
+                    "tensor_descriptor",
+                    "pointer",
+                    "pointer",
+                    "tensor_descriptor",
+                    "pointer",
+                    "pointer",
+                    "tensor_descriptor",
+                    "tensor_descriptor",
+                ],
+                load_eviction_policies=["last", "last", "", "first", ""],
+                num_warps=4,
+                num_stages=3,
+                pid_type="flat",
+                range_flattens=[None, False],
+                range_multi_buffers=[None, None],
+                range_num_stages=[0, 4],
+                range_unroll_factors=[0, 0],
+                range_warp_specializes=default_warp_specializes,
+            ),
+            helion.Config(
+                block_sizes=[32, 8],
+                indexing=[
+                    "pointer",
+                    "pointer",
+                    "pointer",
+                    "tensor_descriptor",
+                    "pointer",
+                    "pointer",
+                    "tensor_descriptor",
+                    "tensor_descriptor",
+                ],
+                load_eviction_policies=["", "last", "last", "first", ""],
+                num_warps=4,
+                num_stages=6,
+                pid_type="flat",
+                range_flattens=[None, True],
+                range_multi_buffers=[None, False],
+                range_num_stages=[0, 4],
+                range_unroll_factors=[0, 0],
+                range_warp_specializes=inner_warp_specializes,
+            ),
+        ]
+
+    def _tensor_descriptor_inner_range_seed_structure_matches(self) -> bool:
+        if self.backend_name != "triton" or not supports_tensor_descriptor():
+            return False
+
+        has_warp_spec = len(self.range_warp_specialize) == 2
+        range_specs = (
+            self.range_num_stages,
+            self.range_unroll_factors,
+            self.range_multi_buffers,
+            self.range_flattens,
+        )
+        if has_warp_spec:
+            range_specs = (*range_specs, self.range_warp_specialize)
+        elif len(self.range_warp_specialize) != 0:
+            return False
+
+        if (
+            len(self.block_sizes) != 2
+            or any(len(specs) != 2 for specs in range_specs)
+            or self.indexing.length != 8
+            or self.load_eviction_policies.length != 5
+            or self.atomic_indexing.length != 0
+            or self.store_indices != [4, 6, 7]
+            or "flat" not in self.allowed_pid_types
+        ):
+            return False
+
+        # This matches the current layer_norm_bwd-style lowering: five
+        # tunable loads, three stores in the combined load/store indexing
+        # vector, and the same two single-block-id ranges as the tile axes.
+        block_id_layout = tuple(tuple(spec.block_ids) for spec in self.block_sizes)
+        if any(len(block_ids) != 1 for block_ids in block_id_layout):
+            return False
+        if block_id_layout != ((0,), (2,)):
+            return False
+        if any(
+            tuple(tuple(spec.block_ids) for spec in specs) != block_id_layout
+            for specs in range_specs
+        ):
+            return False
+
+        return all(
+            spec.min_size <= block_size <= spec.max_size
+            for block_size, spec in zip((32, 8), self.block_sizes, strict=True)
+        )
 
     def _fix_tcgen05_cluster_m2_search_config(self, config: dict[str, object]) -> None:
         """Canonicalize unvalidated search-only ``cluster_m=2`` products."""

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -29,6 +29,14 @@ import torch
 import helion
 from helion import _compat
 from helion import exc
+from helion._compiler.autotuner_heuristics import compiler_seed_configs
+from helion._compiler.autotuner_heuristics.triton import (
+    TritonTensorDescriptorInnerRangeDefaultHeuristic,
+)
+from helion._compiler.autotuner_heuristics.triton import (
+    TritonTensorDescriptorInnerRangeInnerHeuristic,
+)
+from helion._compiler.backend import TritonBackend
 from helion._compiler.tile_dispatch import BlockIDStrategyMapping
 from helion._compiler.tile_dispatch import TileStrategyDispatch
 from helion._testing import DEVICE
@@ -61,6 +69,13 @@ from helion.autotuner.config_fragment import NumThreadsFragment
 from helion.autotuner.config_fragment import PermutationFragment
 from helion.autotuner.config_fragment import PowerOfTwoFragment
 from helion.autotuner.config_generation import ConfigGeneration
+from helion.autotuner.config_spec import BlockSizeSpec
+from helion.autotuner.config_spec import ConfigSpec
+from helion.autotuner.config_spec import RangeFlattenSpec
+from helion.autotuner.config_spec import RangeMultiBufferSpec
+from helion.autotuner.config_spec import RangeNumStagesSpec
+from helion.autotuner.config_spec import RangeUnrollFactorSpec
+from helion.autotuner.config_spec import RangeWarpSpecializeSpec
 from helion.autotuner.effort_profile import get_effort_profile
 from helion.autotuner.finite_search import FiniteSearch
 from helion.autotuner.local_cache import LocalAutotuneCache
@@ -810,6 +825,159 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         # We expect all the unroll factors to be set to 0
         configs = ConfigGeneration(spec, overrides=overrides).random_population(10)
         self.assertExpectedJournal("\n".join(map(repr, configs)))
+
+    @patch.object(_compat, "_supports_tensor_descriptor", lambda: True)
+    @patch.object(loops, "_supports_warp_specialize", lambda: True)
+    @patch("torch.version.hip", None)
+    @patch("torch.version.xpu", None)
+    def test_tensor_descriptor_inner_range_seed_configs(self):
+        def compiler_seeds_for_spec(spec: ConfigSpec) -> list[helion.Config]:
+            env = SimpleNamespace(
+                backend_name="triton",
+                config_spec=spec,
+                settings=Settings(),
+            )
+            return compiler_seed_configs(env, Mock())
+
+        def make_spec(
+            *,
+            store_indices: list[int] | None = None,
+            atomic_count: int = 0,
+            warp_specialize: bool = True,
+        ) -> ConfigSpec:
+            spec = ConfigSpec(backend=TritonBackend())
+            spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=4096))
+            spec.block_sizes.append(BlockSizeSpec(block_id=2, size_hint=8192))
+            for block_id in (0, 2):
+                spec.range_unroll_factors.append(RangeUnrollFactorSpec([block_id]))
+                if warp_specialize:
+                    spec.range_warp_specialize.append(
+                        RangeWarpSpecializeSpec([block_id])
+                    )
+                spec.range_num_stages.append(RangeNumStagesSpec([block_id]))
+                spec.range_multi_buffers.append(RangeMultiBufferSpec([block_id]))
+                spec.range_flattens.append(RangeFlattenSpec([block_id]))
+            spec.indexing = ListOf(
+                EnumFragment(choices=spec.valid_indexing_types()),
+                length=8,
+            )
+            spec.load_eviction_policies = ListOf(
+                EnumFragment(choices=("", "first", "last")),
+                length=5,
+            )
+            spec.atomic_indexing = ListOf(
+                EnumFragment(choices=spec.valid_atomic_indexing_types()),
+                length=atomic_count,
+            )
+            spec.store_indices = [] if store_indices is None else store_indices
+            return spec
+
+        expected_seed_configs = [
+            {
+                "block_sizes": [32, 8],
+                "indexing": [
+                    "tensor_descriptor",
+                    "pointer",
+                    "pointer",
+                    "tensor_descriptor",
+                    "pointer",
+                    "pointer",
+                    "tensor_descriptor",
+                    "tensor_descriptor",
+                ],
+                "load_eviction_policies": ["last", "last", "", "first", ""],
+                "num_stages": 3,
+                "num_warps": 4,
+                "pid_type": "flat",
+                "range_flattens": [None, False],
+                "range_multi_buffers": [None, None],
+                "range_num_stages": [0, 4],
+                "range_unroll_factors": [0, 0],
+                "range_warp_specializes": [None, None],
+            },
+            {
+                "block_sizes": [32, 8],
+                "indexing": [
+                    "pointer",
+                    "pointer",
+                    "pointer",
+                    "tensor_descriptor",
+                    "pointer",
+                    "pointer",
+                    "tensor_descriptor",
+                    "tensor_descriptor",
+                ],
+                "load_eviction_policies": ["", "last", "last", "first", ""],
+                "num_stages": 6,
+                "num_warps": 4,
+                "pid_type": "flat",
+                "range_flattens": [None, True],
+                "range_multi_buffers": [None, False],
+                "range_num_stages": [0, 4],
+                "range_unroll_factors": [0, 0],
+                "range_warp_specializes": [None, False],
+            },
+        ]
+        expected_heuristics = [
+            TritonTensorDescriptorInnerRangeDefaultHeuristic.name,
+            TritonTensorDescriptorInnerRangeInnerHeuristic.name,
+        ]
+
+        spec = make_spec()
+
+        self.assertEqual(spec.autotune_seed_configs(), [])
+        self.assertFalse(spec.tensor_descriptor_inner_range_seed_configs_enabled)
+        mismatch_spec = make_spec(store_indices=[4, 6])
+        mismatch_spec.maybe_enable_tensor_descriptor_inner_range_seed_configs()
+        self.assertFalse(
+            mismatch_spec.tensor_descriptor_inner_range_seed_configs_enabled
+        )
+        self.assertEqual(compiler_seeds_for_spec(mismatch_spec), [])
+
+        atomic_spec = make_spec(store_indices=[4, 6, 7], atomic_count=1)
+        atomic_spec.maybe_enable_tensor_descriptor_inner_range_seed_configs()
+        self.assertFalse(atomic_spec.tensor_descriptor_inner_range_seed_configs_enabled)
+        self.assertEqual(compiler_seeds_for_spec(atomic_spec), [])
+
+        spec.store_indices = [4, 6, 7]
+        spec.maybe_enable_tensor_descriptor_inner_range_seed_configs()
+        self.assertTrue(spec.tensor_descriptor_inner_range_seed_configs_enabled)
+
+        seeds = compiler_seeds_for_spec(spec)
+        self.assertEqual(len(seeds), 2)
+        self.assertEqual([seed.config for seed in seeds], expected_seed_configs)
+        self.assertEqual(spec.autotuner_heuristics, expected_heuristics)
+
+        spec.compiler_seed_configs = seeds
+        gen = ConfigGeneration(spec)
+        normalized_seeds = [config for _flat, config in gen.seed_flat_config_pairs()]
+        configs = gen.random_population(3)
+        self.assertEqual(configs[1:], normalized_seeds)
+
+        no_warp_spec = make_spec(store_indices=[4, 6, 7], warp_specialize=False)
+        no_warp_spec.maybe_enable_tensor_descriptor_inner_range_seed_configs()
+        no_warp_seeds = compiler_seeds_for_spec(no_warp_spec)
+        self.assertEqual(len(no_warp_seeds), 2)
+        self.assertTrue(
+            all("range_warp_specializes" not in seed.config for seed in no_warp_seeds)
+        )
+
+        layer_norm = import_path(examples_dir / "layer_norm.py")
+        m, n = 4096, 1024
+        grad_out = torch.randn((m, n), device=DEVICE, dtype=torch.float16)
+        x = torch.randn((m, n), device=DEVICE, dtype=torch.float16)
+        mean = torch.randn((m,), device=DEVICE, dtype=torch.float32)
+        rstd = torch.randn((m,), device=DEVICE, dtype=torch.float32)
+        weight = torch.randn((n,), device=DEVICE, dtype=torch.float16)
+        bound = layer_norm.layer_norm_bwd.bind((grad_out, x, mean, rstd, weight))
+        self.assertTrue(
+            bound.config_spec.tensor_descriptor_inner_range_seed_configs_enabled
+        )
+        self.assertEqual(
+            [seed.config for seed in bound.config_spec.compiler_seed_configs],
+            expected_seed_configs,
+        )
+        self.assertEqual(bound.config_spec.autotuner_heuristics, expected_heuristics)
 
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: True)
     def test_config_generation_overrides(self):


### PR DESCRIPTION
Stacked PRs:
 * __->__#2471
 * #2427
 * #2394

--- --- ---
Seed tensor descriptor inner range autotune configs

from previous PR to this PR:
<img width="1861" height="727" alt="image" src="https://github.com/user-attachments/assets/fa772913-94c3-4d09-8417-d1d0354205f6" />

from main to this PR:
<img width="1856" height="728" alt="image" src="https://github.com/user-attachments/assets/c3a36d32-5da0-40df-be63-295db93063f1" />

