### PR TITLE
[metal] Add DeviceIR MPPGraph lowering for aten matmul

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -139,13 +139,13 @@
       "backend": "cute"
     },
     {
-      "runner": "macos-26-xlarge",
+      "runner": "macos-m2-26",
       "python-version": "3.12",
       "ref-eager": false,
       "image": "",
       "runtime-version": "cpu",
       "container-options": "",
-      "pytorch-version": "pytorch-2.9",
+      "pytorch-version": "pytorch-nightly",
       "alias": "m2-metal",
       "backend": "metal"
     },

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -2032,6 +2032,13 @@ def _detect_mma_loop(
     return False
 
 
+def _largest_divisor_at_most(size: int, limit: int) -> int:
+    for divisor in range(limit, 0, -1):
+        if size % divisor == 0:
+            return divisor
+    return 1
+
+
 def _detect_specialized_mma_loop(
     fn: DeviceFunction,
     block_ids: list[int],
@@ -2074,13 +2081,6 @@ def _detect_specialized_mma_loop(
         root_thread_auto.append(threads == 0)
 
     if functools.reduce(operator.mul, root_thread_counts, 1) > 1024:
-
-        def _largest_divisor_at_most(size: int, limit: int) -> int:
-            for divisor in range(limit, 0, -1):
-                if size % divisor == 0:
-                    return divisor
-            return 1
-
         for idx in sorted(
             (i for i, is_auto in enumerate(root_thread_auto) if is_auto),
             reverse=True,
@@ -3603,12 +3603,6 @@ class CuteBackend(Backend):
         # dimensions to 1 thread to avoid budget overflow.
         from .cute.thread_budget import MAX_THREADS_PER_BLOCK
 
-        def _largest_divisor_at_most(size: int, limit: int) -> int:
-            for divisor in range(limit, 0, -1):
-                if size % divisor == 0:
-                    return divisor
-            return 1
-
         def _shrink_auto_thread_counts(
             nd_block_size: Sequence[object], thread_limit: int
         ) -> int:
@@ -4107,5 +4101,95 @@ class MetalBackend(Backend):
         Metal inherits this behavior for now; users hitting the error
         should pick a smaller ``block_sizes`` value.
         """
+        config = self._config_with_mpp_thread_budget(fn, block_ids, config)
         # pyrefly: ignore[bad-argument-type]
         return CuteBackend.create_loop_strategy(self, fn, block_ids, config)
+
+    def _config_with_mpp_thread_budget(
+        self, fn: DeviceFunction, block_ids: list[int], config: Config
+    ) -> Config:
+        """Reserve root-grid thread budget for MPPGraph cooperative work.
+
+        MPP matmul and ordinary scalar Metal code run inside one Metal
+        threadgroup.  MPP needs ``num_warps * 32`` threads participating on
+        ``tid[0]`` for its cooperative operation, while scalar code in the
+        surrounding root graph may still use ``tid[0]``, ``tid[1]``, and
+        ``tid[2]`` for normal tile indexing.  This method keeps the root graph
+        scalar-lowered, but caps auto ``num_threads`` on later root-grid axes
+        so the combined threadgroup stays within Metal's 1024-thread limit.
+        """
+        if not any(
+            type(graph_info).__name__ == "MPPGraphInfo"
+            for graph_info in fn.codegen.codegen_graphs
+        ):
+            return config
+
+        from .host_function import HostFunction
+
+        device_ir = HostFunction.current().device_ir
+        # Only adjust the loop strategy for the root grid.  MPPGraphInfo emits
+        # the cooperative K-loop internally; nested/device loops should keep
+        # their normal Metal/CuTe strategy.
+        if not device_ir.grid_block_ids or block_ids != device_ir.grid_block_ids[0]:
+            return config
+        if len(block_ids) < 2:
+            return config
+
+        from ..runtime.config import Config
+        from .compile_environment import CompileEnvironment
+        from .cute.thread_budget import MAX_THREADS_PER_BLOCK
+
+        env = CompileEnvironment.current()
+        num_threads = list(config.num_threads)
+        if len(num_threads) < len(env.config_spec.num_threads):
+            num_threads.extend(
+                [0] * (len(env.config_spec.num_threads) - len(num_threads))
+            )
+
+        first_block_id = block_ids[0]
+        first_axis_size = env.block_sizes[first_block_id].from_config(config)
+        if not isinstance(first_axis_size, int):
+            return config
+        first_axis_configured = int(
+            env.config_spec.num_threads.config_get(
+                config.num_threads, first_block_id, 0
+            )
+        )
+        first_axis_threads = (
+            first_axis_configured if first_axis_configured > 0 else first_axis_size
+        )
+
+        # MPP's execution_simdgroups<N> uses N simdgroups, and each Metal
+        # simdgroup has 32 threads.  tid[0] must be large enough for both
+        # MPP's cooperative operation and any scalar indexing on the first
+        # root axis.
+        mpp_threads = config.num_warps * 32
+        used_threads = max(mpp_threads, first_axis_threads)
+        changed = False
+
+        # Walk the remaining axes in launch order.  Explicit num_threads
+        # consume budget as-is; auto axes are reduced to the largest divisor
+        # that keeps the total threadgroup size under Metal's limit.
+        for block_id in block_ids[1:]:
+            configured = int(
+                env.config_spec.num_threads.config_get(config.num_threads, block_id, 0)
+            )
+            if configured > 0:
+                used_threads *= configured
+                continue
+
+            axis_size = env.block_sizes[block_id].from_config(config)
+            if not isinstance(axis_size, int):
+                continue
+
+            budget = max(1, MAX_THREADS_PER_BLOCK // max(1, used_threads))
+            chosen = _largest_divisor_at_most(axis_size, budget)
+            config_index = env.config_spec.num_threads.block_id_to_index(block_id)
+            if num_threads[config_index] != chosen:
+                num_threads[config_index] = chosen
+                changed = True
+            used_threads *= chosen
+
+        if not changed:
+            return config
+        return Config.from_dict({**config.config, "num_threads": num_threads})

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -927,6 +927,10 @@ class DeviceIR:
         temp.graphs = [g.copy() for g in self.graphs]
         temp._apply_rolling(config)
         temp._apply_epilogue_subtiling(config)
+        if CompileEnvironment.current().backend_name == "metal":
+            from .metal.mpp_graph_transform import rewrite_mpp_graphs
+
+            rewrite_mpp_graphs(temp)
         return temp.graphs
 
     def _apply_rolling(self, config: Config) -> None:

--- a/helion/_compiler/metal/metal_jit.py
+++ b/helion/_compiler/metal/metal_jit.py
@@ -30,6 +30,8 @@ from typing import TYPE_CHECKING
 
 import torch
 
+from ... import exc
+from .msl_ast_walker import EmitState
 from .msl_ast_walker import _emit_stmts
 
 if TYPE_CHECKING:
@@ -48,6 +50,7 @@ class _MetalKernel:
         self._fn = fn
         self._name = fn.__name__
         self.msl_source: str | None = None
+        self.required_threads_per_threadgroup: tuple[int, int, int] | None = None
 
     def __call__(self, *args: object) -> tuple[object, str]:
         """Return (compiled_lib, kernel_name) for the launcher.
@@ -71,6 +74,7 @@ class _MetalKernel:
             param_names=param_names,
             args=args,
             fn_globals=self._fn.__globals__,
+            required_threads_per_threadgroup=self.required_threads_per_threadgroup,
         )
 
         # Compile MSL to a Metal shader library
@@ -84,6 +88,7 @@ def _generate_msl(
     param_names: list[str],
     args: tuple[object, ...],
     fn_globals: dict[str, object],
+    required_threads_per_threadgroup: tuple[int, int, int] | None = None,
 ) -> str:
     """Generate complete MSL source from Python AST body and actual args.
 
@@ -97,8 +102,29 @@ def _generate_msl(
         "#include <c10/metal/utils.h>",
         "#include <c10/metal/special_math.h>",
         "using namespace metal;",
-        "",
     ]
+    if _uses_mpp_markers(body_stmts):
+        _raise_if_mpp_unsupported_device()
+        msl_parts.extend(
+            [
+                "#if !__has_include(<metal_tensor>)",
+                '#error "Helion Metal MPP lowering requires <metal_tensor>"',
+                "#endif",
+                (
+                    "#if !__has_include("
+                    "<MetalPerformancePrimitives/MPPTensorOpsMatMul2d.h>)"
+                ),
+                (
+                    '#error "Helion Metal MPP lowering requires '
+                    '<MetalPerformancePrimitives/MPPTensorOpsMatMul2d.h>"'
+                ),
+                "#endif",
+                "#include <metal_tensor>",
+                "#include <MetalPerformancePrimitives/MPPTensorOpsMatMul2d.h>",
+                "using namespace mpp::tensor_ops;",
+            ]
+        )
+    msl_parts.append("")
 
     params: list[str] = []
     scalar_preamble: list[str] = []
@@ -125,7 +151,15 @@ def _generate_msl(
     )
 
     sig = ",\n    ".join(params)
-    msl_parts.append(f"kernel void {kernel_name}(\n    {sig}\n) {{")
+    required_threads_attr = ""
+    if required_threads_per_threadgroup is not None:
+        tx, ty, tz = required_threads_per_threadgroup
+        required_threads_attr = (
+            f"[[required_threads_per_threadgroup({tx}, {ty}, {tz})]] "
+        )
+    msl_parts.append(
+        f"{required_threads_attr}kernel void {kernel_name}(\n    {sig}\n) {{"
+    )
     msl_parts.extend(scalar_preamble)
 
     # Declare _BLOCK_SIZE_* constants from module globals
@@ -137,8 +171,30 @@ def _generate_msl(
     for name in sorted(block_sizes):
         msl_parts.append(f"    constexpr int {name} = {block_sizes[name]};")
 
-    declared: set[str] = set(block_sizes)
-    _emit_stmts(body_stmts, msl_parts, indent=4, declared=declared)
+    state = EmitState(declared=set(block_sizes))
+
+    _emit_stmts(body_stmts, msl_parts, indent=4, state=state)
 
     msl_parts.append("}")
     return "\n".join(msl_parts)
+
+
+def _uses_mpp_markers(body_stmts: list[ast.stmt]) -> bool:
+    for node in ast.walk(ast.Module(body=body_stmts, type_ignores=[])):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id.startswith("_metal_mpp_"):
+            return True
+    return False
+
+
+def _raise_if_mpp_unsupported_device() -> None:
+    device_name = torch._C._mps_get_name()  # type: ignore[attr-defined]
+    if "paravirtual" in device_name.lower():
+        raise exc.BackendUnsupported(
+            "metal",
+            "MPP matmul lowering is not supported on Apple paravirtual MPS "
+            "devices; use a physical Apple GPU such as a self-hosted M-series "
+            "runner",
+        )

--- a/helion/_compiler/metal/metal_launcher.py
+++ b/helion/_compiler/metal/metal_launcher.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Any
+from typing import cast
+
+
+def set_required_threads_per_threadgroup(
+    metal_kernel: object,
+    group_size: tuple[int, int, int],
+) -> None:
+    cast("Any", metal_kernel).required_threads_per_threadgroup = group_size

--- a/helion/_compiler/metal/mpp_graph_codegen.py
+++ b/helion/_compiler/metal/mpp_graph_codegen.py
@@ -1,0 +1,388 @@
+"""Codegen support for DeviceIR MPPGraph nodes."""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+from typing import TYPE_CHECKING
+
+import torch
+
+from ... import exc
+from ..ast_extension import create
+from ..ast_extension import expr_from_string
+from ..ast_extension import statement_from_string
+from ..compile_environment import CompileEnvironment
+from ..device_ir import NodeArgsGraphInfo
+from ..inductor_lowering import CodegenState
+from ..inductor_lowering import codegen_call_with_graph
+from helion.language import _decorators
+
+if TYPE_CHECKING:
+    from ..generate_ast import GenerateAST
+
+
+@dataclasses.dataclass(frozen=True)
+class MPPSetupParams:
+    """Arguments for ``_metal_mpp_setup(...)`` consumed by the MSL walker.
+
+    Field order is mirrored by ``msl_ast_walker._extract_mpp_setup_params``.
+    """
+
+    lhs: str
+    rhs: str
+    M: int
+    N: int
+    K: int
+    TILE_M: int
+    TILE_N: int
+    TILE_K: int
+    NUM_SG: int
+    in_dtype: str
+    acc_dtype: str
+    bias: str | None
+    bias_dtype: str | None
+    fx_name: str | None
+
+    def __str__(self) -> str:
+        return (
+            f'_metal_mpp_setup("{self.lhs}", "{self.rhs}", '
+            f"{self.M}, {self.N}, {self.K}, "
+            f"{self.TILE_M}, {self.TILE_N}, {self.TILE_K}, {self.NUM_SG}, "
+            f'"{self.in_dtype}", "{self.acc_dtype}", '
+            f'"{self.bias or ""}", "{self.bias_dtype or ""}", '
+            f'"{self.fx_name or ""}")'
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class _MppKStep:
+    """``_metal_mpp_k_step(setup_var, k_offset)`` payload."""
+
+    setup_var: str
+    k_offset: str
+
+    def __str__(self) -> str:
+        return f"_metal_mpp_k_step({self.setup_var}, {self.k_offset})"
+
+
+@_decorators.api()
+def _mpp_graph(
+    graph_id: int,
+    begin: list[object],
+    end: list[object],
+    args: list[object],
+) -> list[object]:
+    """DeviceIR marker for a Metal MPP-owned graph."""
+    raise AssertionError("this should never be called")
+
+
+@_decorators.codegen(_mpp_graph, "common")
+def _(state: CodegenState) -> list[object] | None:
+    """Dispatch the synthetic marker to its owning MPPGraphInfo."""
+    graph_info = state.get_graph(state.proxy_arg(0))
+    return graph_info.codegen(state)
+
+
+@dataclasses.dataclass(frozen=True)
+class _GridAxisInfo:
+    block_id: int
+    offset_var: str
+    block_size: int | None
+
+
+def _resolve_grid_mn_axes(
+    codegen: GenerateAST,
+    env: CompileEnvironment,
+    m_size: int | torch.SymInt,
+    n_size: int | torch.SymInt,
+) -> tuple[_GridAxisInfo, _GridAxisInfo] | None:
+    """Resolve the root grid axes that correspond to matmul M and N."""
+    grid_state = codegen.current_grid_state
+    if grid_state is None:
+        return None
+
+    m_axis: _GridAxisInfo | None = None
+    n_axis: _GridAxisInfo | None = None
+    for block_id in grid_state.block_ids:
+        block_size_info = env.block_sizes[block_id]
+        size = block_size_info.size
+        if not isinstance(size, (int, torch.SymInt)):
+            continue
+        block_size = block_size_info.from_config(codegen.device_function.config)
+        axis = _GridAxisInfo(
+            block_id=block_id,
+            offset_var=grid_state.strategy.offset_var(block_id),
+            block_size=int(block_size) if isinstance(block_size, int) else None,
+        )
+        if m_axis is None and env.known_equal(size, m_size):
+            m_axis = axis
+        elif n_axis is None and env.known_equal(size, n_size):
+            n_axis = axis
+    if m_axis is None or n_axis is None:
+        return None
+    return m_axis, n_axis
+
+
+@dataclasses.dataclass
+class MPPGraphInfo(NodeArgsGraphInfo):
+    """GraphInfo for a Metal MPP matmul region."""
+
+    k_block_id: int
+    begin: list[object]
+    end: list[object]
+    result_name: str
+    lhs_tensor: torch.Tensor | None = None
+    rhs_tensor: torch.Tensor | None = None
+    bias_tensor: torch.Tensor | None = None
+    acc_dtype: torch.dtype | None = None
+    out_tensor: torch.Tensor | None = None
+    out_dtype: torch.dtype | None = None
+    needs_store_barrier: bool = False
+
+    @property
+    def name(self) -> str:
+        """Return the synthetic graph name used in generated comments."""
+        return f"mpp_graph_{self.graph_id}"
+
+    def kwargs(self) -> dict[str, object]:
+        """Serialize fields needed when cloning this graph info."""
+        return {
+            **super().kwargs(),
+            "k_block_id": self.k_block_id,
+            "begin": self.begin,
+            "end": self.end,
+            "result_name": self.result_name,
+            "lhs_tensor": self.lhs_tensor,
+            "rhs_tensor": self.rhs_tensor,
+            "bias_tensor": self.bias_tensor,
+            "acc_dtype": self.acc_dtype,
+            "out_tensor": self.out_tensor,
+            "out_dtype": self.out_dtype,
+            "needs_store_barrier": self.needs_store_barrier,
+        }
+
+    def codegen(self, state: CodegenState) -> list[object]:
+        """Emit the MPP region outside scalar lane loops when needed."""
+        grid_state = state.codegen.current_grid_state
+        if grid_state is not None and grid_state.has_lane_loops():
+            # GenerateAST wraps scalar root statements in per-lane loops for
+            # oversized tile axes.  MPP is already cooperative across the whole
+            # threadgroup, so it must run once in the root prefix.
+            mpp_body: list[ast.AST] = []
+            with state.codegen.set_statements(mpp_body):
+                self._codegen(state, emit_store_barrier=False)
+            grid_state.outer_prefix.extend(mpp_body)
+            if self.needs_store_barrier:
+                grid_state.outer_prefix.append(_mpp_threadgroup_barrier_stmt())
+            return []
+        return self._codegen(state, emit_store_barrier=True)
+
+    def _codegen(
+        self, state: CodegenState, *, emit_store_barrier: bool
+    ) -> list[object]:
+        """Emit setup, K-loop, optional epilogue, and cooperative store."""
+        args = state.ast_args[3]
+        assert isinstance(args, list)
+        assert all(isinstance(x, ast.AST) for x in args)
+
+        codegen = state.codegen
+
+        # 1. Declare the MPP tensors/cooperative accumulator and run the
+        # reduction loop over the original K tile range.
+        setup_var = self._emit_setup_and_k_loop(state)
+
+        # 2. Lower the optional epilogue graph with the cooperative tensor as
+        # its input.  codegen_call_with_graph interprets the copied FX graph and
+        # emits normal Helion AST statements into epilogue_body, returning the
+        # graph output expression.
+        epilogue_body: list[ast.AST] = []
+        with codegen.set_statements(epilogue_body):
+            outputs = codegen_call_with_graph(
+                codegen,
+                self.graph,
+                [expr_from_string(self.result_name)],
+                copy_named_args=False,
+            )
+        assert len(outputs) == 1
+        output = outputs[0]
+        assert isinstance(output, ast.expr)
+        if not (isinstance(output, ast.Name) and output.id == self.result_name):
+            # A transformed output must be written back into the cooperative
+            # tensor element before the final MPP store.
+            epilogue_body.append(
+                create(
+                    ast.Expr,
+                    value=create(
+                        ast.Call,
+                        func=create(ast.Name, id="_coop_writeback", ctx=ast.Load()),
+                        args=[output],
+                        keywords=[],
+                    ),
+                )
+            )
+        if epilogue_body:
+            # 3. Apply the epilogue once per cooperative tensor element.
+            codegen.add_statement(
+                create(
+                    ast.For,
+                    target=create(ast.Name, id="_it", ctx=ast.Store()),
+                    iter=create(
+                        ast.Call,
+                        func=create(ast.Name, id="_coop_iter", ctx=ast.Load()),
+                        args=[expr_from_string(setup_var)],
+                        keywords=[],
+                    ),
+                    body=epilogue_body,
+                    orelse=[],
+                )
+            )
+
+        assert self.out_tensor is not None
+        assert self.out_dtype is not None
+        from ..backend import MetalBackend
+
+        # 4. Store the cooperative tensor to HBM.
+        out_name = codegen.device_function.tensor_arg(self.out_tensor).name
+        codegen.device_function.placeholder_args.add(out_name)
+        out_dtype = MetalBackend._get_dtype_to_metal()[self.out_dtype]
+        codegen.add_statement(
+            statement_from_string(
+                f'_metal_mpp_coop_store({setup_var}, "{out_name}", "{out_dtype}")'
+            )
+        )
+        if emit_store_barrier and self.needs_store_barrier:
+            # Inline MPP emission needs to emit its own barrier.  When MPP is
+            # hoisted to the root prefix, codegen() appends the barrier after
+            # extending that prefix so scalar reloads see the cooperative store.
+            codegen.add_statement(_mpp_threadgroup_barrier_stmt())
+        return []
+
+    def _emit_setup_and_k_loop(self, state: CodegenState) -> str:
+        """Emit MPP setup plus the K-loop and return the setup variable name."""
+        assert self.lhs_tensor is not None
+        assert self.rhs_tensor is not None
+
+        codegen = state.codegen
+        df = codegen.device_function
+        env = CompileEnvironment.current()
+
+        from ..backend import MetalBackend
+
+        dtype_map = MetalBackend._get_dtype_to_metal()
+        if self.lhs_tensor.dtype not in dtype_map:
+            raise exc.BackendUnsupported(
+                "metal",
+                f"unsupported input dtype for MPP matmul: {self.lhs_tensor.dtype}",
+            )
+        acc_dtype = self.acc_dtype
+        if acc_dtype not in dtype_map:
+            raise exc.BackendUnsupported(
+                "metal",
+                f"unsupported accumulator dtype for MPP matmul: {acc_dtype}",
+            )
+        assert acc_dtype is not None
+        if self.out_dtype is not None and acc_dtype != self.out_dtype:
+            raise exc.BackendUnsupported(
+                "metal",
+                "MPP cooperative store requires accumulator dtype to match output "
+                f"dtype; got accumulator {acc_dtype} and output {self.out_dtype}",
+            )
+        assert self.lhs_tensor.ndim == 2 and self.rhs_tensor.ndim == 2
+        assert self.lhs_tensor.dtype == self.rhs_tensor.dtype
+
+        axes = _resolve_grid_mn_axes(
+            codegen,
+            env,
+            self.lhs_tensor.shape[0],
+            self.rhs_tensor.shape[1],
+        )
+        if axes is None:
+            raise exc.BackendUnsupported("metal", "unable to resolve MPP M/N axes")
+        m_axis, n_axis = axes
+        if m_axis.block_size is None or n_axis.block_size is None:
+            raise exc.BackendUnsupported("metal", "dynamic MPP M/N block size")
+
+        bk = env.block_sizes[self.k_block_id].from_config(df.config)
+        if not isinstance(bk, int):
+            raise exc.BackendUnsupported("metal", "dynamic MPP K block size")
+
+        num_sg = df.config.num_warps if df.config.num_warps is not None else 4
+        codegen.max_thread_block_dims[0] = max(
+            codegen.max_thread_block_dims[0], num_sg * 32
+        )
+
+        lhs_arg_name = df.tensor_arg(self.lhs_tensor).name
+        rhs_arg_name = df.tensor_arg(self.rhs_tensor).name
+        df.placeholder_args.add(lhs_arg_name)
+        df.placeholder_args.add(rhs_arg_name)
+
+        acc_arg_name = ""
+        acc_metal_dtype = ""
+        if self.bias_tensor is not None:
+            acc_arg_name = df.tensor_arg(self.bias_tensor).name
+            df.placeholder_args.add(acc_arg_name)
+            acc_metal_dtype = dtype_map.get(self.bias_tensor.dtype, "")
+
+        setup = MPPSetupParams(
+            lhs=lhs_arg_name,
+            rhs=rhs_arg_name,
+            M=int(env.size_hint(self.lhs_tensor.shape[0])),
+            N=int(env.size_hint(self.rhs_tensor.shape[1])),
+            K=int(env.size_hint(self.lhs_tensor.shape[1])),
+            TILE_M=m_axis.block_size,
+            TILE_N=n_axis.block_size,
+            TILE_K=bk,
+            NUM_SG=num_sg,
+            in_dtype=dtype_map[self.lhs_tensor.dtype],
+            acc_dtype=dtype_map[acc_dtype],
+            bias=acc_arg_name or None,
+            bias_dtype=acc_metal_dtype or None,
+            fx_name=self.result_name,
+        )
+        setup_var = df.new_var("_mpp_setup")
+        codegen.add_statement(statement_from_string(f"{setup_var} = {setup}"))
+        k_offset_var = df.new_var(f"offset_{self.k_block_id}")
+        body = [
+            statement_from_string(
+                str(_MppKStep(setup_var=setup_var, k_offset=k_offset_var))
+            )
+        ]
+        loop = create(
+            ast.For,
+            target=create(ast.Name, id=k_offset_var, ctx=ast.Store()),
+            iter=create(
+                ast.Call,
+                func=create(
+                    ast.Attribute,
+                    value=create(ast.Name, id="tl", ctx=ast.Load()),
+                    attr="range",
+                    ctx=ast.Load(),
+                ),
+                args=[
+                    _bound_expr(self.begin, 0),
+                    _bound_expr(self.end, 0),
+                    create(ast.Constant, value=bk),
+                ],
+                keywords=[],
+            ),
+            body=body,
+            orelse=[],
+        )
+        codegen.add_statement(loop)
+        return setup_var
+
+
+def _bound_expr(bounds: object, index: int) -> ast.expr:
+    """Return one loop bound as a Python AST expression."""
+    assert isinstance(bounds, list)
+    bound = bounds[index]
+    if isinstance(bound, ast.expr):
+        return bound
+    assert isinstance(bound, int)
+    return create(ast.Constant, value=bound)
+
+
+def _mpp_threadgroup_barrier_stmt() -> ast.stmt:
+    """Return the pseudo-call statement for an MPP/scalar memory barrier."""
+    return statement_from_string("_metal_mpp_threadgroup_barrier()")

--- a/helion/_compiler/metal/mpp_graph_transform.py
+++ b/helion/_compiler/metal/mpp_graph_transform.py
@@ -1,0 +1,675 @@
+"""DeviceIR rewrite for Metal MPP matmul lowering.
+
+The pass replaces an eligible K-loop matmul result and optional post-K epilogue
+with an ``MPPGraphInfo`` region.  That synthetic graph owns cooperative MPP
+setup, K iteration, epilogue, and store; the surrounding root graph stays on the
+normal scalar Metal lowering path.
+
+Recognition is conservative: the K-loop must return a supported 2D matmul
+accumulator, the root graph must have a single owner chain from
+``getitem -> _phi`` to one store, and A/B/output views must match the canonical
+matmul tile.  Non-fusible same-shape scalar postprocessing is handled by first
+materializing the MPP result, then reloading it in scalar code.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import operator
+
+import torch
+from torch.fx import Graph
+from torch.fx.node import Node
+from torch.fx.node import map_arg
+
+from ..cute.cute_mma import _trace_to_load_tensor
+from ..device_ir import DeviceIR
+from ..device_ir import ForLoopGraphInfo
+from ..device_ir import RootGraphInfo
+from ..inductor_lowering import APIFuncLowering
+from .mpp_graph_codegen import MPPGraphInfo
+from .mpp_graph_codegen import _mpp_graph
+import helion.language as hl
+from helion.language import _tracing_ops
+from helion.language import memory_ops
+
+
+@dataclasses.dataclass(frozen=True)
+class _MPPLoadView:
+    """Tensor plus 2D indices used by an MPP operand load."""
+
+    tensor: torch.Tensor
+    indices: tuple[object, object]
+
+
+@dataclasses.dataclass(frozen=True)
+class _MPPStoreView:
+    """Tensor plus 2D indices used by the MPP output store."""
+
+    tensor: torch.Tensor
+    indices: tuple[object, object]
+
+
+@dataclasses.dataclass(frozen=True)
+class _Candidate:
+    """Matched root/K-loop slice that can become one MPPGraphInfo.
+
+    ``mpp_output_node`` is the value produced by cooperative MPP lowering.
+    ``reload_value_node`` is set only for materialized scalar continuation,
+    where root scalar code reloads the MPP result from the final store target.
+    """
+
+    for_loop_node: Node
+    getitem_node: Node
+    phi_node: Node
+    k_loop_info: ForLoopGraphInfo
+    mma_node: Node
+    lhs_view: _MPPLoadView
+    rhs_view: _MPPLoadView
+    bias_view: _MPPLoadView | None
+    acc_dtype: torch.dtype
+    store_view: _MPPStoreView
+    mpp_output_node: Node
+    reload_value_node: Node | None
+    epilogue_nodes: tuple[Node, ...]
+    store_node: Node
+
+
+def rewrite_mpp_graphs(device_ir: DeviceIR) -> None:
+    """Rewrite eligible root/K-loop matmul pairs into ``MPPGraphInfo``.
+
+    The pass scans only root graphs.  For each root ``_for_loop`` call, it
+    checks whether one returned value is a completed K reduction whose loop
+    body returns a supported matmul accumulator.  The root use must be
+    single-owner: ``getitem -> _phi -> optional epilogue -> store``.  This
+    ownership check is what lets the rewrite remove the original K-loop result
+    from the root graph and replace it with a synthetic ``_mpp_graph`` call
+    without duplicating stores or losing side effects.
+
+    The produced ``MPPGraphInfo`` owns code generation for the cooperative
+    region.  The root graph remains responsible for any scalar continuation
+    that the transform deliberately leaves outside the cooperative region.
+    Unsupported or ambiguous shapes return no candidate and leave the graph
+    unchanged.
+    """
+    for graph_info in list(device_ir.graphs):
+        if not isinstance(graph_info, RootGraphInfo):
+            continue
+        for candidate in _find_root_candidates(device_ir, graph_info):
+            mpp_graph_id = _append_mpp_graph(device_ir, candidate)
+            _rewrite_root_for_mpp_graph(graph_info, candidate, mpp_graph_id)
+
+
+def _find_root_candidates(
+    device_ir: DeviceIR, root_info: RootGraphInfo
+) -> list[_Candidate]:
+    """Find root/K-loop slices that can be replaced by an MPPGraph."""
+    candidates: list[_Candidate] = []
+    for node in root_info.graph.nodes:
+        if not _is_for_loop_call(node):
+            continue
+        k_loop_info = _for_loop_graph_info(device_ir, node)
+        if k_loop_info is None:
+            continue
+        for getitem_node in _getitem_users(node):
+            mma_node = _mma_output_for_getitem(k_loop_info, getitem_node)
+            if mma_node is None:
+                continue
+            phi_node = _single_phi_user(getitem_node)
+            if phi_node is None:
+                continue
+            candidate = _classify_phi_users(
+                for_loop_node=node,
+                getitem_node=getitem_node,
+                phi_node=phi_node,
+                k_loop_info=k_loop_info,
+                mma_node=mma_node,
+            )
+            if candidate is not None:
+                candidates.append(candidate)
+    return candidates
+
+
+def _is_for_loop_call(node: Node) -> bool:
+    """Return whether *node* calls a DeviceIR for-loop graph."""
+    return (
+        node.op == "call_function"
+        and _tracing_ops.is_for_loop_target(node.target)
+        and bool(node.args)
+        and isinstance(node.args[0], int)
+    )
+
+
+def _for_loop_graph_info(device_ir: DeviceIR, node: Node) -> ForLoopGraphInfo | None:
+    """Return the ForLoopGraphInfo referenced by a for-loop call node."""
+    graph_id = node.args[0]
+    assert isinstance(graph_id, int)
+    if not (0 <= graph_id < len(device_ir.graphs)):
+        return None
+    graph_info = device_ir.graphs[graph_id]
+    if not isinstance(graph_info, ForLoopGraphInfo):
+        return None
+    return graph_info
+
+
+def _getitem_users(for_loop_node: Node) -> list[Node]:
+    """Return direct ``operator.getitem`` users of a for-loop result."""
+    return [
+        user
+        for user in for_loop_node.users
+        if user.op == "call_function" and user.target is operator.getitem
+    ]
+
+
+def _mma_output_for_getitem(
+    k_loop_info: ForLoopGraphInfo, getitem_node: Node
+) -> Node | None:
+    """Return the K-loop output selected by *getitem_node* if it is matmul."""
+    if len(getitem_node.args) < 2 or not isinstance(getitem_node.args[1], int):
+        return None
+    output_idx = getitem_node.args[1]
+    output_nodes = list(k_loop_info.graph.find_nodes(op="output"))
+    if len(output_nodes) != 1:
+        return None
+    output_value = output_nodes[0].args[0]
+    if not isinstance(output_value, (tuple, list)):
+        return None
+    if not (0 <= output_idx < len(output_value)):
+        return None
+    candidate = output_value[output_idx]
+    if not isinstance(candidate, Node) or not _is_matmul_node(candidate):
+        return None
+    return candidate
+
+
+def _is_matmul_node(node: Node) -> bool:
+    """Return whether *node* is a matmul op supported by MPPGraph matching."""
+    return node.op == "call_function" and node.target in {
+        hl.dot,
+        torch.ops.aten.mm.default,
+        torch.ops.aten.addmm.default,
+    }
+
+
+def _is_phi_node(node: Node, value: Node) -> bool:
+    """Return whether *node* is a phi that selects *value*."""
+    return (
+        node.op == "call_function"
+        and node.target is _tracing_ops._phi
+        and len(node.args) >= 2
+        and node.args[1] is value
+    )
+
+
+def _single_phi_user(getitem_node: Node) -> Node | None:
+    """Return the unique root phi that consumes a K-loop getitem result."""
+    phi_users = [
+        user for user in getitem_node.users if _is_phi_node(user, getitem_node)
+    ]
+    if len(phi_users) != 1:
+        return None
+    return phi_users[0]
+
+
+def _classify_phi_users(
+    *,
+    for_loop_node: Node,
+    getitem_node: Node,
+    phi_node: Node,
+    k_loop_info: ForLoopGraphInfo,
+    mma_node: Node,
+) -> _Candidate | None:
+    """Classify the post-K path as fused epilogue or materialized scalar use."""
+    operand_info = _mpp_operand_views(mma_node)
+    if operand_info is None:
+        return None
+    lhs_view, rhs_view, bias_view, acc_dtype = operand_info
+    epilogue_nodes: list[Node] = []
+    cur = phi_node
+    visited: set[Node] = set()
+    # Walk the single-owner post-K value chain:
+    # phi -> optional cooperative epilogue nodes -> store.  The first
+    # non-fusible op switches to the materialized scalar continuation path.
+    while True:
+        if cur in visited or len(cur.users) != 1:
+            return None
+        visited.add(cur)
+        (user,) = cur.users
+        if _is_store_of_value(user, cur):
+            store_view = _validated_mpp_store_view(
+                user,
+                lhs_view=lhs_view,
+                rhs_view=rhs_view,
+                mpp_output_node=cur,
+                acc_dtype=acc_dtype,
+            )
+            if store_view is None:
+                return None
+            return _Candidate(
+                for_loop_node=for_loop_node,
+                getitem_node=getitem_node,
+                phi_node=phi_node,
+                k_loop_info=k_loop_info,
+                mma_node=mma_node,
+                lhs_view=lhs_view,
+                rhs_view=rhs_view,
+                bias_view=bias_view,
+                acc_dtype=acc_dtype,
+                store_view=store_view,
+                mpp_output_node=cur,
+                reload_value_node=None,
+                epilogue_nodes=tuple(epilogue_nodes),
+                store_node=user,
+            )
+        if not _is_coop_fusible_epilogue_node(user, cur):
+            materialized = _find_materialized_scalar_store(
+                start_node=user,
+                lhs_view=lhs_view,
+                rhs_view=rhs_view,
+                mpp_output_node=cur,
+                acc_dtype=acc_dtype,
+            )
+            if materialized is None:
+                return None
+            store_node, store_view = materialized
+            return _Candidate(
+                for_loop_node=for_loop_node,
+                getitem_node=getitem_node,
+                phi_node=phi_node,
+                k_loop_info=k_loop_info,
+                mma_node=mma_node,
+                lhs_view=lhs_view,
+                rhs_view=rhs_view,
+                bias_view=bias_view,
+                acc_dtype=acc_dtype,
+                store_view=store_view,
+                mpp_output_node=cur,
+                reload_value_node=cur,
+                epilogue_nodes=tuple(epilogue_nodes),
+                store_node=store_node,
+            )
+        epilogue_nodes.append(user)
+        cur = user
+
+
+def _is_store_of_value(node: Node, value: Node) -> bool:
+    """Return whether *node* stores exactly *value*."""
+    return (
+        node.op == "call_function"
+        and node.target is memory_ops.store
+        and len(node.args) >= 3
+        and node.args[2] is value
+    )
+
+
+def _find_materialized_scalar_store(
+    *,
+    start_node: Node,
+    lhs_view: _MPPLoadView,
+    rhs_view: _MPPLoadView,
+    mpp_output_node: Node,
+    acc_dtype: torch.dtype,
+) -> tuple[Node, _MPPStoreView] | None:
+    """Find a scalar continuation store after materializing an MPP result."""
+    cur = start_node
+    visited: set[Node] = set()
+    while True:
+        if cur in visited:
+            return None
+        visited.add(cur)
+        if (
+            cur.op == "call_function"
+            and cur.target is memory_ops.store
+            and len(cur.args) >= 3
+        ):
+            store_view = _validated_mpp_store_view(
+                cur,
+                lhs_view=lhs_view,
+                rhs_view=rhs_view,
+                mpp_output_node=mpp_output_node,
+                acc_dtype=acc_dtype,
+            )
+            if store_view is None:
+                return None
+            return cur, store_view
+        if len(cur.users) != 1:
+            return None
+        (cur,) = cur.users
+
+
+def _mpp_operand_views(
+    mma_node: Node,
+) -> tuple[_MPPLoadView, _MPPLoadView, _MPPLoadView | None, torch.dtype] | None:
+    """Extract validated A/B/bias views and accumulator dtype from matmul."""
+    lhs_idx = 1 if mma_node.target is torch.ops.aten.addmm.default else 0
+    rhs_idx = 2 if mma_node.target is torch.ops.aten.addmm.default else 1
+    acc_idx = 0 if mma_node.target is torch.ops.aten.addmm.default else None
+    if len(mma_node.args) <= max(lhs_idx, rhs_idx):
+        return None
+    lhs_node = mma_node.args[lhs_idx]
+    rhs_node = mma_node.args[rhs_idx]
+    if not isinstance(lhs_node, Node) or not isinstance(rhs_node, Node):
+        return None
+    lhs_view = _trace_to_load_view(lhs_node)
+    rhs_view = _trace_to_load_view(rhs_node)
+    if lhs_view is None or rhs_view is None:
+        return None
+    if lhs_view.tensor.ndim != 2 or rhs_view.tensor.ndim != 2:
+        return None
+    if lhs_view.tensor.dtype != rhs_view.tensor.dtype:
+        return None
+    acc_dtype = _tensor_dtype_from_meta(mma_node)
+    if acc_dtype is None:
+        return None
+    bias_view = None
+    if acc_idx is not None and len(mma_node.args) > acc_idx:
+        acc_node = mma_node.args[acc_idx]
+        if isinstance(acc_node, Node):
+            bias_view = _trace_to_load_view(acc_node)
+    return lhs_view, rhs_view, bias_view, acc_dtype
+
+
+def _trace_to_load_view(node: Node) -> _MPPLoadView | None:
+    """Trace a value back to the 2D tensor load that produced it."""
+    load_info = _trace_to_load_tensor(node)
+    if load_info is None:
+        return None
+    load_node, _, tensor = load_info
+    if len(load_node.args) < 2:
+        return None
+    indices = _as_2d_indices(load_node.args[1])
+    if indices is None:
+        return None
+    return _MPPLoadView(tensor=tensor, indices=indices)
+
+
+def _tensor_dtype_from_meta(node: Node) -> torch.dtype | None:
+    """Return the tensor dtype recorded in FX metadata, if present."""
+    value = node.meta.get("val")
+    if isinstance(value, torch.Tensor):
+        return value.dtype
+    return None
+
+
+def _as_2d_indices(indices: object) -> tuple[object, object] | None:
+    """Normalize an index object to two dimensions."""
+    if not isinstance(indices, (list, tuple)) or len(indices) != 2:
+        return None
+    return indices[0], indices[1]
+
+
+def _validated_mpp_store_view(
+    store_node: Node,
+    *,
+    lhs_view: _MPPLoadView,
+    rhs_view: _MPPLoadView,
+    mpp_output_node: Node,
+    acc_dtype: torch.dtype,
+) -> _MPPStoreView | None:
+    """Return the store view if it can receive the materialized MPP result."""
+    store_view = _store_output_view(store_node)
+    if store_view is None:
+        return None
+    if not _can_store_mpp_output(
+        lhs_view, rhs_view, mpp_output_node, store_view, acc_dtype
+    ):
+        return None
+    return store_view
+
+
+def _is_canonical_mpp_view(
+    lhs_view: _MPPLoadView,
+    rhs_view: _MPPLoadView,
+    store_view: _MPPStoreView,
+) -> bool:
+    """Return whether A/B/output views match canonical matmul layout."""
+    if not (
+        _same_dim(lhs_view.tensor.shape[0], store_view.tensor.shape[0])
+        and _same_dim(rhs_view.tensor.shape[1], store_view.tensor.shape[1])
+        and _same_dim(lhs_view.tensor.shape[1], rhs_view.tensor.shape[0])
+    ):
+        return False
+    lhs_m, lhs_k = lhs_view.indices
+    rhs_k, rhs_n = rhs_view.indices
+    out_m, out_n = store_view.indices
+    # Shape checks prove the tensor extents match.  Integer index checks prove
+    # the matched tile axes are wired as A[M,K], B[K,N], C[M,N].
+    if not all(
+        isinstance(index, int) for index in (lhs_m, lhs_k, rhs_k, rhs_n, out_m, out_n)
+    ):
+        return True
+    return lhs_m == out_m and rhs_n == out_n and lhs_k == rhs_k
+
+
+def _can_store_mpp_output(
+    lhs_view: _MPPLoadView,
+    rhs_view: _MPPLoadView,
+    mpp_output_node: Node,
+    store_view: _MPPStoreView,
+    acc_dtype: torch.dtype,
+) -> bool:
+    """Validate that an MPP result can be stored through *store_view*."""
+    expected_dtype = store_view.tensor.dtype
+    value = mpp_output_node.meta.get("val")
+    if not isinstance(value, torch.Tensor):
+        return acc_dtype == expected_dtype and _is_canonical_mpp_view(
+            lhs_view, rhs_view, store_view
+        )
+    # Dtype changes must be explicit epilogue cast nodes before the final store;
+    # MPP cooperative store does not perform an implicit output cast here.
+    if value.dtype != expected_dtype or value.ndim != store_view.tensor.ndim:
+        return False
+    return _is_canonical_mpp_view(lhs_view, rhs_view, store_view)
+
+
+def _same_dim(lhs: int | torch.SymInt, rhs: int | torch.SymInt) -> bool:
+    """Best-effort dimension equality for symbolic and concrete dims."""
+    try:
+        return bool(lhs == rhs)
+    except TypeError:
+        return False
+
+
+def _is_coop_fusible_epilogue_node(node: Node, input_node: Node) -> bool:
+    """Return whether *node* is a single-input cooperative epilogue op."""
+    if node.op != "call_function" or not _is_coop_fusible_epilogue_target(node.target):
+        return False
+    return all(user_input is input_node for user_input in node.all_input_nodes)
+
+
+def _is_coop_fusible_epilogue_target(target: object) -> bool:
+    """Return whether *target* is in the current cooperative epilogue allowlist."""
+    return target in {
+        torch.ops.aten.relu.default,
+        torch.ops.aten.sigmoid.default,
+        torch.ops.aten.exp.default,
+        torch.ops.aten.neg.default,
+        torch.ops.aten.add.Tensor,
+        torch.ops.aten.mul.Tensor,
+        torch.ops.aten.sub.Tensor,
+        torch.ops.aten.div.Tensor,
+        torch.ops.prims.convert_element_type.default,
+    }
+
+
+def _append_mpp_graph(device_ir: DeviceIR, candidate: _Candidate) -> int:
+    """Append an MPPGraphInfo for *candidate* and return its graph id."""
+    # The K-loop itself is not copied.  MPPGraphInfo records its bounds and
+    # operands, then emits the MPP setup and K-step loop directly during codegen.
+    new_graph = Graph()
+    acc = new_graph.placeholder(candidate.mma_node.name)
+    acc.meta.update(candidate.mma_node.meta)
+    env: dict[Node, Node] = {candidate.phi_node: acc}
+
+    # Only the post-K cooperative epilogue remains as FX.  The original phi is
+    # replaced by a placeholder representing the completed MPP accumulator.
+    for node in candidate.epilogue_nodes:
+        _copy_node_recursive(node, new_graph, env)
+    new_graph.output((env[candidate.mpp_output_node],))
+
+    begin = candidate.for_loop_node.args[1]
+    end = candidate.for_loop_node.args[2]
+    assert isinstance(begin, list)
+    assert isinstance(end, list)
+
+    graph_id = len(device_ir.graphs)
+    device_ir.graphs.append(
+        MPPGraphInfo(
+            graph_id=graph_id,
+            graph=new_graph,
+            node_args=[*candidate.k_loop_info.node_args],
+            k_block_id=candidate.k_loop_info.block_ids[0],
+            begin=[*begin],
+            end=[*end],
+            result_name=candidate.mma_node.name,
+            lhs_tensor=candidate.lhs_view.tensor,
+            rhs_tensor=candidate.rhs_view.tensor,
+            bias_tensor=(
+                candidate.bias_view.tensor if candidate.bias_view is not None else None
+            ),
+            acc_dtype=candidate.acc_dtype,
+            out_tensor=candidate.store_view.tensor,
+            out_dtype=candidate.store_view.tensor.dtype,
+            needs_store_barrier=candidate.reload_value_node is not None,
+        )
+    )
+    return graph_id
+
+
+def _store_output_view(store_node: Node | None) -> _MPPStoreView | None:
+    """Extract the output tensor and 2D indices from a store node."""
+    if store_node is None or len(store_node.args) < 2:
+        return None
+    out_arg = store_node.args[0]
+    if not isinstance(out_arg, Node):
+        return None
+    fake = out_arg.meta.get("val")
+    if not isinstance(fake, torch.Tensor):
+        return None
+    if fake.ndim != 2:
+        return None
+    indices = _as_2d_indices(store_node.args[1])
+    if indices is None:
+        return None
+    return _MPPStoreView(
+        tensor=fake,
+        indices=indices,
+    )
+
+
+def _copy_node_recursive(node: Node, new_graph: Graph, env: dict[Node, Node]) -> Node:
+    """Copy *node* and its uncopied inputs into *new_graph*."""
+    if node in env:
+        return env[node]
+    for input_node in node.all_input_nodes:
+        if input_node not in env:
+            _copy_node_recursive(input_node, new_graph, env)
+    new_node = new_graph.node_copy(node, lambda n: env[n])
+    env[node] = new_node
+    return new_node
+
+
+def _rewrite_root_for_mpp_graph(
+    root_info: RootGraphInfo,
+    candidate: _Candidate,
+    mpp_graph_id: int,
+) -> None:
+    """Replace the consumed root slice with a synthetic ``_mpp_graph`` call."""
+    consumed = {
+        candidate.for_loop_node,
+        candidate.getitem_node,
+        candidate.phi_node,
+        *candidate.epilogue_nodes,
+    }
+    if candidate.reload_value_node is None:
+        consumed.add(candidate.store_node)
+    old_graph = root_info.graph
+    new_graph = Graph()
+    env: dict[Node, Node] = {}
+    inserted = False
+
+    def load_arg(n: Node) -> Node:
+        return env[n]
+
+    def ensure_arg(arg: Node) -> Node:
+        if arg in env:
+            return env[arg]
+        for input_node in arg.all_input_nodes:
+            if input_node not in env:
+                ensure_arg(input_node)
+        new_node = new_graph.node_copy(arg, load_arg)
+        env[arg] = new_node
+        return new_node
+
+    for node in old_graph.nodes:
+        if node is candidate.for_loop_node:
+            mpp_node = new_graph.call_function(
+                _mpp_graph,
+                args=(
+                    mpp_graph_id,
+                    node.args[1],
+                    node.args[2],
+                    [],
+                ),
+            )
+            _prepare_inserted_mpp_node(mpp_node)
+            env[node] = mpp_node
+            if candidate.reload_value_node is not None:
+                load_node = new_graph.call_function(
+                    memory_ops.load,
+                    args=(
+                        map_arg(candidate.store_node.args[0], ensure_arg),
+                        map_arg(candidate.store_node.args[1], ensure_arg),
+                        None,
+                        None,
+                    ),
+                )
+                _prepare_inserted_reload_node(
+                    load_node,
+                    candidate.reload_value_node,
+                    fallback_node=candidate.mma_node,
+                )
+                env[candidate.reload_value_node] = load_node
+            inserted = True
+            continue
+        if node in consumed:
+            continue
+        if _is_dead_after_mpp_rewrite(node, consumed):
+            continue
+        if node.op == "output":
+            new_graph.output(map_arg(node.args[0], load_arg))
+            continue
+        if node in env:
+            continue
+        new_node = new_graph.node_copy(node, load_arg)
+        env[node] = new_node
+
+    assert inserted, "expected to insert _mpp_graph marker"
+    root_info.graph = new_graph
+
+
+def _is_dead_after_mpp_rewrite(node: Node, consumed: set[Node]) -> bool:
+    """Return whether a pure node is only used by nodes consumed by rewrite."""
+    return (
+        node.op not in {"placeholder", "output"}
+        and bool(node.users)
+        and not node.is_impure()
+        and all(user in consumed for user in node.users)
+    )
+
+
+def _prepare_inserted_mpp_node(node: Node) -> None:
+    """Attach lowering metadata to an inserted ``_mpp_graph`` node."""
+    node.meta["lowering"] = APIFuncLowering(_mpp_graph)
+    node.meta["location"] = contextlib.nullcontext()
+    node.meta["val"] = []
+
+
+def _prepare_inserted_reload_node(
+    node: Node, value_node: Node, *, fallback_node: Node
+) -> None:
+    """Attach lowering metadata to a reload inserted after materialization."""
+    node.meta["lowering"] = APIFuncLowering(memory_ops.load)
+    node.meta["location"] = contextlib.nullcontext()
+    node.meta["val"] = value_node.meta.get("val", fallback_node.meta["val"])

--- a/helion/_compiler/metal/msl_ast_walker.py
+++ b/helion/_compiler/metal/msl_ast_walker.py
@@ -21,8 +21,26 @@ Handles:
 from __future__ import annotations
 
 import ast
+import dataclasses
 
 from ... import exc
+from .mpp_graph_codegen import MPPSetupParams
+
+
+@dataclasses.dataclass
+class EmitState:
+    """Mutable state passed through ``_emit_stmts`` calls.
+
+    Tracks declared variable names (to avoid duplicate ``auto`` declarations)
+    and MPP matmul setup parameters (keyed by setup variable name).
+
+    MPPGraph lowering emits explicit ``_coop_iter`` loops. The walker derives
+    the MMA-result substitution from the setup marker's ``fx_name``.
+    """
+
+    declared: set[str] = dataclasses.field(default_factory=set)
+    mpp_setups: dict[str, MPPSetupParams] = dataclasses.field(default_factory=dict)
+
 
 # ---------------------------------------------------------------------------
 # Statement emitter (handles Assign, Expr, If, For, and tl.store calls)
@@ -76,12 +94,17 @@ def _emit_stmts(
     stmts: list[ast.stmt],
     parts: list[str],
     indent: int,
-    declared: set[str],
+    state: EmitState,
+    subs: dict[str, str] | None = None,
 ) -> None:
     """Emit a list of AST statements as MSL lines into *parts*.
 
-    *declared* tracks variable names that have already been declared in the
-    current or an enclosing scope so that reassignments do not repeat ``auto``.
+    *subs* is an optional substitution dict applied when converting
+    expressions to MSL (e.g. ``{"acc": "(*_it)"}`` inside the coop
+    iteration loop).  It's set by the ``_coop_iter`` branch of
+    :func:`_emit_for` and propagated downward through nested control flow.
+
+    This function does pure text emission.
     """
     pad = " " * indent
     for stmt in stmts:
@@ -93,30 +116,85 @@ def _emit_stmts(
                     "metal",
                     f"assignment target type: {type(target).__name__}",
                 )
-            val_msl = _ast_expr_to_msl(value)
-            if target.id in declared:
+            # Check for _metal_mpp_setup assignment
+            if (
+                isinstance(value, ast.Call)
+                and isinstance(value.func, ast.Name)
+                and value.func.id == "_metal_mpp_setup"
+            ):
+                params = _extract_mpp_setup_params(value)
+                state.mpp_setups[target.id] = params
+                _emit_mpp_setup(target.id, params, parts, indent=indent)
+                state.declared.add(target.id)
+                continue
+            val_msl = _ast_expr_to_msl(value, subs=subs)
+            if target.id in state.declared:
                 parts.append(f"{pad}{target.id} = {val_msl};")
             else:
                 parts.append(f"{pad}auto {target.id} = {val_msl};")
-                declared.add(target.id)
+                state.declared.add(target.id)
         elif isinstance(stmt, ast.Expr):
             call = stmt.value
             # tl.store(ptr + offset, val, mask) → if (mask) { *(ptr+offset) = val; }
             if _is_tl_store_call(call):
                 assert isinstance(call, ast.Call)
                 _emit_tl_store(call, parts, indent=indent)
+            elif _is_call_to(call, "_metal_mpp_k_step"):
+                assert isinstance(call, ast.Call)
+                setup_arg = call.args[0]
+                assert isinstance(setup_arg, ast.Name)
+                k_offset_expr = _ast_expr_to_msl(call.args[1])
+                _emit_mpp_k_step(setup_arg.id, k_offset_expr, parts, indent=indent)
+            elif _is_call_to(call, "_metal_mpp_coop_store"):
+                # Three positional args: setup_var (Name), out_name (str),
+                # out_dtype (str).
+                assert isinstance(call, ast.Call)
+                setup_arg, out_name_node, out_dtype_node = call.args
+                assert isinstance(setup_arg, ast.Name)
+                _emit_mpp_coop_store(
+                    setup_arg.id,
+                    _ast_str_value(out_name_node),
+                    _ast_str_value(out_dtype_node),
+                    parts,
+                    indent,
+                )
+            elif _is_call_to(call, "_metal_mpp_threadgroup_barrier"):
+                parts.append(f"{pad}threadgroup_barrier(mem_flags::mem_device);")
+            elif _is_call_to(call, "_coop_writeback"):
+                # The argument is a plain local variable name — subs do NOT
+                # apply (we want the local value, not a recursive *_it lookup).
+                assert isinstance(call, ast.Call)
+                writeback_expr = _ast_expr_to_msl(call.args[0])
+                parts.append(f"{pad}*_it = {writeback_expr};")
             else:
-                parts.append(f"{pad}{_ast_expr_to_msl(call)};")
+                parts.append(f"{pad}{_ast_expr_to_msl(call, subs=subs)};")
         elif isinstance(stmt, ast.If):
-            test_msl = _ast_expr_to_msl(stmt.test)
+            test_msl = _ast_expr_to_msl(stmt.test, subs=subs)
             parts.append(f"{pad}if ({test_msl}) {{")
-            _emit_stmts(stmt.body, parts, indent=indent + 4, declared=declared)
+            _emit_stmts(stmt.body, parts, indent=indent + 4, state=state, subs=subs)
             if stmt.orelse:
                 parts.append(f"{pad}}} else {{")
-                _emit_stmts(stmt.orelse, parts, indent=indent + 4, declared=declared)
+                _emit_stmts(
+                    stmt.orelse, parts, indent=indent + 4, state=state, subs=subs
+                )
             parts.append(f"{pad}}}")
         elif isinstance(stmt, ast.For):
-            _emit_for(stmt, parts, indent=indent, declared=declared)
+            _emit_for(stmt, parts, indent=indent, state=state, subs=subs)
+        elif isinstance(stmt, ast.AugAssign):
+            target_msl = _ast_expr_to_msl(stmt.target, subs=subs)
+            val_msl = _ast_expr_to_msl(stmt.value, subs=subs)
+            op_map: dict[type[ast.operator], str] = {
+                ast.Add: "+=",
+                ast.Sub: "-=",
+                ast.Mult: "*=",
+                ast.Div: "/=",
+            }
+            op_str = op_map.get(type(stmt.op))
+            if op_str is None:
+                raise exc.BackendUnsupported(
+                    "metal", f"augmented assign op: {type(stmt.op).__name__}"
+                )
+            parts.append(f"{pad}{target_msl} {op_str} {val_msl};")
         else:
             raise exc.BackendUnsupported(
                 "metal",
@@ -128,15 +206,43 @@ def _emit_for(
     stmt: ast.For,
     parts: list[str],
     indent: int,
-    declared: set[str],
+    state: EmitState,
+    subs: dict[str, str] | None = None,
 ) -> None:
-    """Emit MSL for a ``for var in range(...)`` or ``for var in tl.range(...)`` loop.
+    """Emit MSL for a for-loop.  Supports three iterator shapes:
 
-    Both ``range`` and ``tl.range`` accept 1-3 positional args
-    (end), (start, end), or (start, end, step) and produce a
-    C-style ``for (int var = start; var < end; var += step)`` loop.
+    - ``range(...)`` / ``tl.range(...)`` → C-style ``for (int v = ..; ...)``
+    - ``_coop_iter(setup_var)``
+      → MPP cooperative_tensor iteration ``for (auto _it = _coop.begin();
+      _it != _coop.end(); _it++)`` with the plan's substitution dict
+      activated for the body.
     """
     pad = " " * indent
+    it = stmt.iter
+    if not isinstance(it, ast.Call):
+        raise exc.BackendUnsupported("metal", f"for loop iter: {ast.unparse(it)}")
+
+    # --- MPP cooperative iterator (synthesized by the pass) ---
+    func = it.func
+    if isinstance(func, ast.Name) and func.id == "_coop_iter":
+        assert len(it.args) == 1 and isinstance(it.args[0], ast.Name), (
+            "_coop_iter takes exactly one setup-var argument"
+        )
+        setup_name = it.args[0].id
+        setup = state.mpp_setups[setup_name]
+        coop_subs = {setup.fx_name: "(*_it)"} if setup.fx_name else {}
+        coop = _scoped_mpp_name(setup_name, "_coop")
+        parts.extend(
+            (
+                f"{pad}// Epilogue: element-wise ops on cooperative_tensor",
+                f"{pad}for (auto _it = {coop}.begin(); _it != {coop}.end(); _it++) {{",
+            )
+        )
+        _emit_stmts(stmt.body, parts, indent=indent + 4, state=state, subs=coop_subs)
+        parts.append(f"{pad}}}")
+        return
+
+    # --- Regular range / tl.range ---
     assert isinstance(stmt.target, ast.Name)
     loop_var = stmt.target.id
 
@@ -160,24 +266,24 @@ def _emit_for(
         raise exc.BackendUnsupported("metal", f"for loop iter: {ast.unparse(it)}")
     args = it.args
     if len(args) == 1:
-        end = _ast_expr_to_msl(args[0])
+        end = _ast_expr_to_msl(args[0], subs=subs)
     elif len(args) == 2:
-        start = _ast_expr_to_msl(args[0])
-        end = _ast_expr_to_msl(args[1])
+        start = _ast_expr_to_msl(args[0], subs=subs)
+        end = _ast_expr_to_msl(args[1], subs=subs)
     elif len(args) >= 3:
-        start = _ast_expr_to_msl(args[0])
-        end = _ast_expr_to_msl(args[1])
-        step = _ast_expr_to_msl(args[2])
+        start = _ast_expr_to_msl(args[0], subs=subs)
+        end = _ast_expr_to_msl(args[1], subs=subs)
+        step = _ast_expr_to_msl(args[2], subs=subs)
 
     parts.append(
         f"{pad}for (int {loop_var} = {start}; {loop_var} < {end}; {loop_var} += {step}) {{"
     )
-    declared.add(loop_var)
-    _emit_stmts(stmt.body, parts, indent=indent + 4, declared=declared)
+    state.declared.add(loop_var)
+    _emit_stmts(stmt.body, parts, indent=indent + 4, state=state, subs=subs)
     parts.append(f"{pad}}}")
 
 
-def _ptr_access_expr(ptr_node: ast.AST) -> str:
+def _ptr_access_expr(ptr_node: ast.AST, subs: dict[str, str] | None = None) -> str:
     """Convert a pointer expression to an MSL memory access.
 
     Recognizes ``buf + offset`` and emits ``buf[offset]``
@@ -186,9 +292,252 @@ def _ptr_access_expr(ptr_node: ast.AST) -> str:
     if isinstance(ptr_node, ast.BinOp) and isinstance(ptr_node.op, ast.Add):
         base = ptr_node.left
         if isinstance(base, ast.Name):
-            offset = _ast_expr_to_msl(ptr_node.right)
+            offset = _ast_expr_to_msl(ptr_node.right, subs=subs)
             return f"{base.id}[{offset}]"
-    return f"*({_ast_expr_to_msl(ptr_node)})"
+    return f"*({_ast_expr_to_msl(ptr_node, subs=subs)})"
+
+
+# ---------------------------------------------------------------------------
+# MPP matmul2d emission helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_call_to(node: ast.AST, name: str) -> bool:
+    """Return True if *node* is a ``name(...)`` call."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == name
+    )
+
+
+def _scoped_mpp_name(setup_name: str, suffix: str) -> str:
+    """Return an MSL identifier scoped by the setup variable name."""
+    return f"{setup_name}{suffix}"
+
+
+def _ast_str_value(node: ast.AST) -> str:
+    """Extract string constant from AST node."""
+    assert isinstance(node, ast.Constant) and isinstance(node.value, str)
+    return node.value
+
+
+def _ast_int_value(node: ast.AST) -> int:
+    """Extract integer constant from AST node."""
+    assert isinstance(node, ast.Constant) and isinstance(node.value, int)
+    return node.value
+
+
+def _extract_mpp_setup_params(node: ast.Call) -> MPPSetupParams:
+    """Extract parameters from ``_metal_mpp_setup(...)`` call.
+
+    Positional args (in order):
+      0: lhs tensor name,  1: rhs tensor name,
+      2-4: M, N, K,        5-7: TILE_M, TILE_N, TILE_K,
+      8: NUM_SG,           9: in_dtype,       10: acc_dtype,
+      11: bias tensor name (or ""),  12: bias metal dtype (or ""),
+      13: FX node name of the MMA op (or "").
+
+    Output tensor name and dtype are deliberately carried by the explicit
+    ``_metal_mpp_coop_store(setup, out_name, out_dtype)`` marker instead of
+    this setup marker.  The setup creates the operand tensors, operator, and
+    cooperative accumulator before the epilogue runs; the final output view is
+    determined by the root ``memory_ops.store`` that the MPPGraph rewrite
+    consumes.  Keeping the store target on the store marker makes that
+    ownership explicit and avoids assuming at setup time that every MPPGraph
+    will store to the same destination shape/dtype path.
+    """
+    args = node.args
+    assert len(args) == 14, (
+        f"_metal_mpp_setup expects 14 positional args, got {len(args)}"
+    )
+    return MPPSetupParams(
+        lhs=_ast_str_value(args[0]),
+        rhs=_ast_str_value(args[1]),
+        M=_ast_int_value(args[2]),
+        N=_ast_int_value(args[3]),
+        K=_ast_int_value(args[4]),
+        TILE_M=_ast_int_value(args[5]),
+        TILE_N=_ast_int_value(args[6]),
+        TILE_K=_ast_int_value(args[7]),
+        NUM_SG=_ast_int_value(args[8]),
+        in_dtype=_ast_str_value(args[9]),
+        acc_dtype=_ast_str_value(args[10]),
+        bias=_ast_str_value(args[11]) or None,
+        bias_dtype=_ast_str_value(args[12]) or None,
+        fx_name=_ast_str_value(args[13]) or None,
+    )
+
+
+def _emit_mpp_setup(
+    setup_name: str,
+    params: MPPSetupParams,
+    parts: list[str],
+    indent: int,
+) -> None:
+    """Emit MPP matmul2d setup MSL.
+
+    Declares the input tensor handles (``_A`` / ``_B``), the
+    ``matmul2d_descriptor`` and operator, the threadgroup-id → tile
+    decomposition, the operand slices, and the cooperative_tensor
+    accumulator.  The output tensor handle (``_C``) is declared by
+    :func:`_emit_mpp_coop_store` because its name and dtype are sourced
+    from the trailing ``tl.store(out_ptr, ...)`` rather than the setup.
+    """
+    pad = " " * indent
+    M_var = _scoped_mpp_name(setup_name, "_M")
+    N_var = _scoped_mpp_name(setup_name, "_N")
+    K_var = _scoped_mpp_name(setup_name, "_K")
+    TILE_M_var = _scoped_mpp_name(setup_name, "_TILE_M")
+    TILE_N_var = _scoped_mpp_name(setup_name, "_TILE_N")
+    TILE_K_var = _scoped_mpp_name(setup_name, "_TILE_K")
+    NUM_SG_var = _scoped_mpp_name(setup_name, "_NUM_SG")
+    A_var = _scoped_mpp_name(setup_name, "_A")
+    B_var = _scoped_mpp_name(setup_name, "_B")
+    D_var = _scoped_mpp_name(setup_name, "_D")
+    Ds_var = _scoped_mpp_name(setup_name, "_Ds")
+    desc_var = _scoped_mpp_name(setup_name, "_desc")
+    op_var = _scoped_mpp_name(setup_name, "_op")
+    gm_var = _scoped_mpp_name(setup_name, "_gm")
+    flat_id_var = _scoped_mpp_name(setup_name, "_flat_id")
+    ty_var = _scoped_mpp_name(setup_name, "_ty")
+    tx_var = _scoped_mpp_name(setup_name, "_tx")
+    As_var = _scoped_mpp_name(setup_name, "_As")
+    Bs_var = _scoped_mpp_name(setup_name, "_Bs")
+    coop_var = _scoped_mpp_name(setup_name, "_coop")
+
+    needs_k_loop = params.TILE_K < params.K
+    # When bias is provided, always use multiply_accumulate so
+    # _op.run accumulates onto the pre-loaded bias values.
+    mm_mode = "multiply_accumulate" if needs_k_loop or params.bias else "multiply"
+
+    parts.extend(
+        [
+            f"{pad}// MPP matmul2d setup",
+            f"{pad}constexpr int {M_var} = {params.M};",
+            f"{pad}constexpr int {N_var} = {params.N};",
+            f"{pad}constexpr int {K_var} = {params.K};",
+            f"{pad}constexpr int {TILE_M_var} = {params.TILE_M};",
+            f"{pad}constexpr int {TILE_N_var} = {params.TILE_N};",
+            f"{pad}constexpr int {TILE_K_var} = {params.TILE_K};",
+            f"{pad}constexpr int {NUM_SG_var} = {params.NUM_SG};",
+            "",
+            f"{pad}auto {A_var} = tensor<device {params.in_dtype}, dextents<int32_t, 2>, tensor_inline>(",
+            f"{pad}    {params.lhs}, dextents<int32_t, 2>({K_var}, {M_var}));",
+            f"{pad}auto {B_var} = tensor<device {params.in_dtype}, dextents<int32_t, 2>, tensor_inline>(",
+            f"{pad}    {params.rhs}, dextents<int32_t, 2>({N_var}, {K_var}));",
+            "",
+            f"{pad}constexpr auto {desc_var} = matmul2d_descriptor(",
+            f"{pad}    {TILE_M_var}, {TILE_N_var}, {TILE_K_var},",
+            f"{pad}    false, false, false, matmul2d_descriptor::mode::{mm_mode});",
+            f"{pad}matmul2d<{desc_var}, execution_simdgroups<{NUM_SG_var}>> {op_var};",
+            "",
+            f"{pad}// Decompose flat threadgroup ID into 2D tile indices",
+            f"{pad}uint {gm_var} = ({M_var} + {TILE_M_var} - 1) / {TILE_M_var};",
+            f"{pad}uint {flat_id_var} = tgid[0];",
+            f"{pad}uint {ty_var} = {flat_id_var} % {gm_var};",
+            f"{pad}uint {tx_var} = {flat_id_var} / {gm_var};",
+            "",
+            # The setup slices only define the cooperative_tensor type.  Keep
+            # their extents static so MPP can allocate the cooperative tile
+            # without falling back to deferred dynamic storage.
+            f"{pad}auto {As_var} = {A_var}.slice<{params.TILE_K}, {params.TILE_M}>(",
+            f"{pad}    0, {ty_var} * {TILE_M_var});",
+            f"{pad}auto {Bs_var} = {B_var}.slice<{params.TILE_N}, {params.TILE_K}>(",
+            f"{pad}    {tx_var} * {TILE_N_var}, 0);",
+            "",
+            f"{pad}auto {coop_var} = {op_var}.get_destination_cooperative_tensor<",
+            f"{pad}    decltype({As_var}), decltype({Bs_var}), {params.acc_dtype}>();",
+        ]
+    )
+    if params.bias:
+        # For addmm (C = A*B + bias): load the bias tensor into the
+        # cooperative_tensor BEFORE the K-loop.  Since _op.run uses
+        # multiply_accumulate mode (C += A*B), the bias values serve as
+        # the initial accumulator and the final result is bias + A*B.
+        bias_dtype = params.bias_dtype
+        assert bias_dtype, "bias_dtype must be populated when bias is provided"
+        parts.extend(
+            [
+                f"{pad}auto {D_var} = tensor<device {bias_dtype}, dextents<int32_t, 2>, tensor_inline>(",
+                f"{pad}    {params.bias}, dextents<int32_t, 2>({N_var}, {M_var}));",
+                f"{pad}auto {Ds_var} = {D_var}.slice({tx_var} * {TILE_N_var}, {ty_var} * {TILE_M_var});",
+                f"{pad}{coop_var}.load({Ds_var});",
+            ]
+        )
+    elif needs_k_loop:
+        # multiply_accumulate mode (used when needs_k_loop) accumulates
+        # onto _coop's existing values, so zero-init is required.
+        parts.extend(
+            [
+                f"{pad}for (auto _it = {coop_var}.begin(); _it != {coop_var}.end(); _it++)",
+                f"{pad}    *_it = ({params.acc_dtype})(0);",
+            ]
+        )
+
+
+def _emit_mpp_k_step(
+    setup_name: str,
+    k_offset_expr: str,
+    parts: list[str],
+    indent: int,
+) -> None:
+    """Emit MPP K-tile step MSL."""
+    pad = " " * indent
+    A_var = _scoped_mpp_name(setup_name, "_A")
+    B_var = _scoped_mpp_name(setup_name, "_B")
+    Ak_var = _scoped_mpp_name(setup_name, "_Ak")
+    Bk_var = _scoped_mpp_name(setup_name, "_Bk")
+    TILE_M_var = _scoped_mpp_name(setup_name, "_TILE_M")
+    TILE_N_var = _scoped_mpp_name(setup_name, "_TILE_N")
+    ty_var = _scoped_mpp_name(setup_name, "_ty")
+    tx_var = _scoped_mpp_name(setup_name, "_tx")
+    op_var = _scoped_mpp_name(setup_name, "_op")
+    coop_var = _scoped_mpp_name(setup_name, "_coop")
+    parts.extend(
+        [
+            f"{pad}auto {Ak_var} = {A_var}.slice({k_offset_expr}, {ty_var} * {TILE_M_var});",
+            f"{pad}auto {Bk_var} = {B_var}.slice({tx_var} * {TILE_N_var}, {k_offset_expr});",
+            f"{pad}{op_var}.run({Ak_var}, {Bk_var}, {coop_var});",
+        ]
+    )
+
+
+def _emit_mpp_coop_store(
+    setup_name: str,
+    out_name: str,
+    out_dtype: str,
+    parts: list[str],
+    indent: int,
+) -> None:
+    """Emit the cooperative_tensor → device memory store.
+
+    Declares the output tensor handle (``_C``) inline using *out_name* /
+    *out_dtype* from the explicit MPPGraph store marker and emits
+    ``_coop.store(_Cs)``.
+
+    The accumulator dtype is set in :func:`_emit_mpp_setup`; MPP handles the
+    cooperative_tensor-to-output conversion during ``store`` for supported
+    dtype combinations.
+    """
+    pad = " " * indent
+    C_var = _scoped_mpp_name(setup_name, "_C")
+    Cs_var = _scoped_mpp_name(setup_name, "_Cs")
+    M_var = _scoped_mpp_name(setup_name, "_M")
+    N_var = _scoped_mpp_name(setup_name, "_N")
+    TILE_M_var = _scoped_mpp_name(setup_name, "_TILE_M")
+    TILE_N_var = _scoped_mpp_name(setup_name, "_TILE_N")
+    ty_var = _scoped_mpp_name(setup_name, "_ty")
+    tx_var = _scoped_mpp_name(setup_name, "_tx")
+    coop_var = _scoped_mpp_name(setup_name, "_coop")
+    parts.extend(
+        [
+            f"{pad}auto {C_var} = tensor<device {out_dtype}, dextents<int32_t, 2>, tensor_inline>(",
+            f"{pad}    {out_name}, dextents<int32_t, 2>({N_var}, {M_var}));",
+            f"{pad}auto {Cs_var} = {C_var}.slice({tx_var} * {TILE_N_var}, {ty_var} * {TILE_M_var});",
+            f"{pad}{coop_var}.store({Cs_var});",
+        ]
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -196,9 +545,20 @@ def _ptr_access_expr(ptr_node: ast.AST) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _ast_expr_to_msl(node: ast.AST) -> str:
-    """Recursively convert an AST expression node to MSL C++ string."""
+def _ast_expr_to_msl(
+    node: ast.AST,
+    *,
+    subs: dict[str, str] | None = None,
+) -> str:
+    """Recursively convert an AST expression node to MSL C++ string.
+
+    *subs*: optional substitution dict mapping variable names to replacement
+    strings.  Used by the epilogue loop to replace MMA result variables with
+    ``(*_it)``.  Propagated through all recursive calls.
+    """
     if isinstance(node, ast.Name):
+        if subs and node.id in subs:
+            return subs[node.id]
         return node.id
 
     if isinstance(node, ast.Constant):
@@ -215,7 +575,7 @@ def _ast_expr_to_msl(node: ast.AST) -> str:
         )
 
     if isinstance(node, ast.UnaryOp):
-        operand = _ast_expr_to_msl(node.operand)
+        operand = _ast_expr_to_msl(node.operand, subs=subs)
         if isinstance(node.op, ast.USub):
             return f"(-{operand})"
         if isinstance(node.op, ast.Not):
@@ -225,8 +585,8 @@ def _ast_expr_to_msl(node: ast.AST) -> str:
         raise exc.BackendUnsupported("metal", f"unary op: {type(node.op).__name__}")
 
     if isinstance(node, ast.BinOp):
-        left = _ast_expr_to_msl(node.left)
-        right = _ast_expr_to_msl(node.right)
+        left = _ast_expr_to_msl(node.left, subs=subs)
+        right = _ast_expr_to_msl(node.right, subs=subs)
         op = node.op
         if isinstance(op, ast.Mult):
             if isinstance(node.right, ast.Constant) and node.right.value == 1:
@@ -269,7 +629,7 @@ def _ast_expr_to_msl(node: ast.AST) -> str:
             op_str = " || "
         else:
             raise exc.BackendUnsupported("metal", f"bool op: {type(node.op).__name__}")
-        parts = [_ast_expr_to_msl(v) for v in node.values]
+        parts = [_ast_expr_to_msl(v, subs=subs) for v in node.values]
         return f"({op_str.join(parts)})"
 
     if isinstance(node, ast.Compare):
@@ -289,16 +649,18 @@ def _ast_expr_to_msl(node: ast.AST) -> str:
             elif isinstance(type_node, ast.Call) and isinstance(
                 type_node.func, ast.Name
             ):
-                # decltype(expr) → decltype(expr)
                 fn = type_node.func.id
-                args_msl = [_ast_expr_to_msl(a) for a in type_node.args]
+                # decltype(expr) → decltype(expr)
+                args_msl = [_ast_expr_to_msl(a, subs=subs) for a in type_node.args]
                 metal_type = f"{fn}({', '.join(args_msl)})"
+                if metal_type == "decltype((*_it))":
+                    metal_type = "decltype(+(*_it))"
             else:
-                metal_type = _ast_expr_to_msl(type_node)
-            inner = _ast_expr_to_msl(node.comparators[1])
+                metal_type = _ast_expr_to_msl(type_node, subs=subs)
+            inner = _ast_expr_to_msl(node.comparators[1], subs=subs)
             return f"static_cast<{metal_type}>({inner})"
 
-        left = _ast_expr_to_msl(node.left)
+        left = _ast_expr_to_msl(node.left, subs=subs)
         parts = [left]
         for op, comp in zip(node.ops, node.comparators, strict=True):
             if isinstance(op, ast.Eq):
@@ -317,37 +679,37 @@ def _ast_expr_to_msl(node: ast.AST) -> str:
                 raise exc.BackendUnsupported(
                     "metal", f"comparison op: {type(op).__name__}"
                 )
-            parts.append(_ast_expr_to_msl(comp))
+            parts.append(_ast_expr_to_msl(comp, subs=subs))
         return f"({' '.join(parts)})"
 
     if isinstance(node, ast.IfExp):
-        test = _ast_expr_to_msl(node.test)
-        body = _ast_expr_to_msl(node.body)
-        orelse = _ast_expr_to_msl(node.orelse)
+        test = _ast_expr_to_msl(node.test, subs=subs)
+        body = _ast_expr_to_msl(node.body, subs=subs)
+        orelse = _ast_expr_to_msl(node.orelse, subs=subs)
         return f"({test} ? {body} : {orelse})"
 
     if isinstance(node, ast.Call):
-        return _ast_call_to_msl(node)
+        return _ast_call_to_msl(node, subs=subs)
 
     if isinstance(node, ast.Subscript):
-        return _ast_subscript_to_msl(node)
+        return _ast_subscript_to_msl(node, subs=subs)
 
     if isinstance(node, ast.Attribute):
-        value = _ast_expr_to_msl(node.value)
         # C++ namespace access: metal.precise.sin → metal::precise::sin
         # The :: was replaced with . before Python AST parsing; restore it here.
+        value = _ast_expr_to_msl(node.value, subs=subs)
         sep = "::" if _is_cpp_namespace_root(node) else "."
         return f"{value}{sep}{node.attr}"
 
     raise exc.BackendUnsupported("metal", f"AST expression type: {type(node).__name__}")
 
 
-def _ast_call_to_msl(node: ast.AST) -> str:
-    """Convert an AST Call node to MSL.
+def _ast_call_to_msl(node: ast.AST, subs: dict[str, str] | None = None) -> str:
+    """Convert an AST Call node to MSL with optional variable substitutions.
 
-    Handles:
-    - ``tl.load`` — from PointerIndexingStrategy
-    - Generic function call fallback — main handler for MetalOverrides expressions
+    Handles tl.load specifically; everything else falls through to a
+    generic ``func(args, ...)`` emit (the path used by MetalOverrides
+    expressions like ``c10.metal.max`` and ``metal.precise.sin``).
     """
     assert isinstance(node, ast.Call)
     func = node.func
@@ -359,20 +721,19 @@ def _ast_call_to_msl(node: ast.AST) -> str:
         and func.value.id == "tl"
         and func.attr == "load"
     ):
-        access = _ptr_access_expr(node.args[0])
+        access = _ptr_access_expr(node.args[0], subs=subs)
         if len(node.args) >= 2:
-            # Check if mask is None (no masking)
             mask_node = node.args[1]
             if isinstance(mask_node, ast.Constant) and mask_node.value is None:
                 return access
-            mask = _ast_expr_to_msl(mask_node)
+            mask = _ast_expr_to_msl(mask_node, subs=subs)
             other = None
             if len(node.args) >= 3:
-                other = _ast_expr_to_msl(node.args[2])
+                other = _ast_expr_to_msl(node.args[2], subs=subs)
             else:
                 for kw in node.keywords:
                     if kw.arg == "other":
-                        other = _ast_expr_to_msl(kw.value)
+                        other = _ast_expr_to_msl(kw.value, subs=subs)
                         break
             if other is None:
                 raise exc.BackendUnsupported(
@@ -382,8 +743,8 @@ def _ast_call_to_msl(node: ast.AST) -> str:
         return access
 
     # Generic function call (main path for MetalOverrides expressions)
-    func_msl = _ast_expr_to_msl(func)
-    args_msl = [_ast_expr_to_msl(a) for a in node.args]
+    func_msl = _ast_expr_to_msl(func, subs=subs)
+    args_msl = [_ast_expr_to_msl(a, subs=subs) for a in node.args]
     return f"{func_msl}({', '.join(args_msl)})"
 
 
@@ -402,12 +763,12 @@ def _is_cpp_namespace_root(node: ast.Attribute) -> bool:
     return isinstance(node.value, ast.Name) and node.value.id in _CPP_NAMESPACE_ROOTS
 
 
-def _ast_subscript_to_msl(node: ast.AST) -> str:
+def _ast_subscript_to_msl(node: ast.AST, subs: dict[str, str] | None = None) -> str:
     """Convert an AST Subscript node to MSL.
 
     Only simple index subscripts (e.g. ``tgid[0]``) are supported.
     """
     assert isinstance(node, ast.Subscript)
-    buf_name = _ast_expr_to_msl(node.value)
-    idx = _ast_expr_to_msl(node.slice)
+    buf_name = _ast_expr_to_msl(node.value, subs=subs)
+    idx = _ast_expr_to_msl(node.slice, subs=subs)
     return f"{buf_name}[{idx}]"

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -2885,6 +2885,9 @@ def default_metal_launcher(
             "metal", f"unexpected launcher kwargs: {sorted(kwargs)}"
         )
 
+    from .._compiler.metal.metal_launcher import set_required_threads_per_threadgroup
+
+    set_required_threads_per_threadgroup(metal_kernel, _block_dims)
     lib, kernel_name = metal_kernel(*args)  # type: ignore[operator]
 
     tensor_args = [a for a in args if isinstance(a, torch.Tensor)]

--- a/test/test_metal.py
+++ b/test/test_metal.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import sys
 import unittest
+from unittest.mock import patch
 
 import pytest
 import torch
 
 import helion
+from helion import exc
 import helion.language as hl
 
 if sys.platform == "darwin":
@@ -365,6 +367,13 @@ class TestMetalBoundsMasking(unittest.TestCase):
         self.assertIn("x[", msl, "array subscript load not found in generated MSL")
         self.assertIn("out[", msl, "array subscript store not found in generated MSL")
 
+    def test_scalar_codegen_does_not_include_mpp(self) -> None:
+        x = torch.randn(1024, device=DEVICE)
+        msl = _get_msl(copy_kernel, (x,))
+        self.assertNotIn("<metal_tensor>", msl)
+        self.assertNotIn("MetalPerformancePrimitives", msl)
+        self.assertNotIn("mpp::tensor_ops", msl)
+
     def test_vector_add_non_aligned(self) -> None:
         """vector_add with non-aligned size exercises mask on both load and store."""
         x = torch.randn(1000, device=DEVICE)
@@ -642,6 +651,534 @@ class TestMetalLargeBlock(unittest.TestCase):
             (buf_out[n:] == sentinel).all(),
             "OOB store detected in vector_add sentinel region",
         )
+
+
+# ---------------------------------------------------------------------------
+# Kernel definitions – matmul
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_MATMUL_CONFIG = [helion.Config(block_sizes=[32, 32, 32], num_warps=4)]
+
+
+@helion.kernel(backend="metal", configs=_DEFAULT_MATMUL_CONFIG)
+def matmul_kernel(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    m, k = x.size()
+    _k2, n = y.size()
+    out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+        out[tile_m, tile_n] = acc.to(x.dtype)
+    return out
+
+
+def _make_matmul_kernel(
+    block_sizes: list[int], num_warps: int = 4
+) -> helion.Kernel[torch.Tensor]:
+    cfg = [helion.Config(block_sizes=block_sizes, num_warps=num_warps)]
+
+    @helion.kernel(backend="metal", configs=cfg)
+    def _matmul(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        m, k = x.size()
+        _k2, n = y.size()
+        out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+        for tile_m, tile_n in hl.tile([m, n]):
+            acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+            for tile_k in hl.tile(k):
+                acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+            out[tile_m, tile_n] = acc.to(x.dtype)
+        return out
+
+    return _matmul
+
+
+# ---------------------------------------------------------------------------
+# Tests – matmul
+# ---------------------------------------------------------------------------
+
+
+@_requires_darwin
+class TestMetalMatmul(unittest.TestCase):
+    """Matmul kernels using MPP matmul2d through the standard pipeline."""
+
+    def test_mpp_rejects_paravirtual_mps_device(self) -> None:
+        from helion._compiler.metal.metal_jit import _raise_if_mpp_unsupported_device
+
+        with (
+            patch.object(
+                torch._C,
+                "_mps_get_name",
+                return_value="Apple Paravirtual device",
+            ),
+            self.assertRaisesRegex(exc.BackendUnsupported, "paravirtual MPS"),
+        ):
+            _raise_if_mpp_unsupported_device()
+
+    def test_matmul_basic(self) -> None:
+        """Square matmul: 64x64 @ 64x64."""
+        x = torch.randn(64, 64, device=DEVICE)
+        y = torch.randn(64, 64, device=DEVICE)
+        result = matmul_kernel(x, y)
+        expected = torch.mm(x, y)
+        torch.testing.assert_close(result, expected, atol=1e-4, rtol=1e-4)
+
+    def test_matmul_non_square(self) -> None:
+        """Non-square matmul: 128x64 @ 64x256."""
+        kernel = _make_matmul_kernel([32, 64, 32])
+        x = torch.randn(128, 64, device=DEVICE)
+        y = torch.randn(64, 256, device=DEVICE)
+        result = kernel(x, y)
+        expected = torch.mm(x, y)
+        torch.testing.assert_close(result, expected, atol=1e-4, rtol=1e-4)
+
+    def test_matmul_k_loop(self) -> None:
+        """K > TILE_K forces multiple K-loop iterations: 128x512 @ 512x128."""
+        x = torch.randn(128, 512, device=DEVICE)
+        y = torch.randn(512, 128, device=DEVICE)
+        result = matmul_kernel(x, y)
+        expected = torch.mm(x, y)
+        torch.testing.assert_close(result, expected, atol=1e-2, rtol=1e-2)
+
+    def test_matmul_large_square(self) -> None:
+        """Larger square matmul: 256x256 @ 256x256."""
+        kernel = _make_matmul_kernel([64, 64, 64])
+        x = torch.randn(256, 256, device=DEVICE)
+        y = torch.randn(256, 256, device=DEVICE)
+        result = kernel(x, y)
+        expected = torch.mm(x, y)
+        torch.testing.assert_close(result, expected, atol=1e-2, rtol=1e-2)
+
+    def test_matmul_tall_skinny(self) -> None:
+        """Tall-skinny: 512x32 @ 32x64."""
+        kernel = _make_matmul_kernel([32, 32, 32])
+        x = torch.randn(512, 32, device=DEVICE)
+        y = torch.randn(32, 64, device=DEVICE)
+        result = kernel(x, y)
+        expected = torch.mm(x, y)
+        torch.testing.assert_close(result, expected, atol=1e-4, rtol=1e-4)
+
+    def test_matmul_non_divisible_tiles(self) -> None:
+        kernel = _make_matmul_kernel([32, 32, 32])
+        for m, k, n in [(70, 64, 64), (64, 70, 64), (64, 64, 70), (71, 65, 73)]:
+            with self.subTest(shape=(m, k, n)):
+                x = torch.randn(m, k, device=DEVICE)
+                y = torch.randn(k, n, device=DEVICE)
+                result = kernel(x, y)
+                expected = torch.mm(x, y)
+                torch.testing.assert_close(result, expected, atol=1e-4, rtol=1e-4)
+
+    def test_matmul_float16(self) -> None:
+        """Float16 inputs with float32 accumulation cannot directly store fp16."""
+        x = torch.randn(64, 64, device=DEVICE, dtype=torch.float16)
+        y = torch.randn(64, 64, device=DEVICE, dtype=torch.float16)
+        with self.assertRaisesRegex(
+            exc.BackendUnsupported,
+            "requires accumulator dtype to match output dtype",
+        ):
+            matmul_kernel(x, y)
+
+    def test_matmul_float16_float32_output(self) -> None:
+        cfg = [helion.Config(block_sizes=[32, 32, 32], num_warps=4)]
+
+        @helion.kernel(backend="metal", configs=cfg)
+        def matmul_fp32_out(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _k2, n = y.size()
+            out = torch.empty([m, n], dtype=torch.float32, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc
+            return out
+
+        x = torch.randn(64, 64, device=DEVICE, dtype=torch.float16)
+        y = torch.randn(64, 64, device=DEVICE, dtype=torch.float16)
+        result = matmul_fp32_out(x, y)
+        expected = torch.mm(x.float(), y.float())
+        torch.testing.assert_close(result, expected, atol=1e-2, rtol=1e-2)
+
+        msl = _get_msl(matmul_fp32_out, (x, y))
+        self.assertIn("decltype(_mpp_setup_As), decltype(_mpp_setup_Bs), float", msl)
+        self.assertIn("tensor<device half", msl)
+
+    def test_matmul_bfloat16(self) -> None:
+        """Bfloat16 inputs with float32 accumulation cannot directly store bf16."""
+        x = torch.randn(64, 64, device=DEVICE, dtype=torch.bfloat16)
+        y = torch.randn(64, 64, device=DEVICE, dtype=torch.bfloat16)
+        with self.assertRaisesRegex(
+            exc.BackendUnsupported,
+            "requires accumulator dtype to match output dtype",
+        ):
+            matmul_kernel(x, y)
+
+    def test_matmul_codegen_has_mpp(self) -> None:
+        """Generated MSL must contain MPP matmul2d constructs."""
+        x = torch.randn(64, 64, device=DEVICE)
+        y = torch.randn(64, 64, device=DEVICE)
+        msl = _get_msl(matmul_kernel, (x, y))
+        self.assertIn(
+            "[[required_threads_per_threadgroup(128, 8, 1)]] kernel void",
+            msl,
+        )
+        self.assertIn("matmul2d", msl, "MPP matmul2d not found in MSL")
+        self.assertIn("_op.run", msl, "MPP run call not found in MSL")
+        self.assertNotIn("auto acc = float(0.0)", msl)
+
+    def test_matmul_with_relu(self) -> None:
+        """Matmul with ReLU epilogue fusion."""
+        cfg = [helion.Config(block_sizes=[32, 32, 32], num_warps=4)]
+
+        @helion.kernel(backend="metal", configs=cfg)
+        def matmul_relu(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _k2, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.relu()
+            return out
+
+        x = torch.randn(64, 64, device=DEVICE) * 0.05
+        y = torch.randn(64, 64, device=DEVICE) * 0.05
+        result = matmul_relu(x, y)
+        expected = torch.mm(x, y).relu()
+        torch.testing.assert_close(result, expected, atol=1e-4, rtol=1e-4)
+
+    def test_matmul_supported_epilogues(self) -> None:
+        cfg = [helion.Config(block_sizes=[32, 32, 32], num_warps=4)]
+
+        @helion.kernel(backend="metal", configs=cfg)
+        def matmul_sigmoid(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _k2, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = torch.sigmoid(acc)
+            return out
+
+        @helion.kernel(backend="metal", configs=cfg)
+        def matmul_exp(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _k2, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = torch.exp(acc)
+            return out
+
+        @helion.kernel(backend="metal", configs=cfg)
+        def matmul_neg(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _k2, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = -acc
+            return out
+
+        @helion.kernel(backend="metal", configs=cfg)
+        def matmul_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _k2, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc + 1.25
+            return out
+
+        @helion.kernel(backend="metal", configs=cfg)
+        def matmul_sub(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _k2, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc - 0.5
+            return out
+
+        @helion.kernel(backend="metal", configs=cfg)
+        def matmul_mul(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _k2, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc * 0.25
+            return out
+
+        @helion.kernel(backend="metal", configs=cfg)
+        def matmul_div(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _k2, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc / 2.0
+            return out
+
+        @helion.kernel(backend="metal", configs=cfg)
+        def matmul_chain(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _k2, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = torch.sigmoid(acc.relu() * 0.5 + 1.0)
+            return out
+
+        def apply_expected(kind: str, value: torch.Tensor) -> torch.Tensor:
+            if kind == "sigmoid":
+                return torch.sigmoid(value)
+            if kind == "exp":
+                return torch.exp(value)
+            if kind == "neg":
+                return -value
+            if kind == "add":
+                return value + 1.25
+            if kind == "sub":
+                return value - 0.5
+            if kind == "mul":
+                return value * 0.25
+            if kind == "div":
+                return value / 2.0
+            if kind == "chain":
+                return torch.sigmoid(value.relu() * 0.5 + 1.0)
+            raise AssertionError(f"unknown epilogue: {kind}")
+
+        x = torch.randn(64, 64, device=DEVICE)
+        y = torch.randn(64, 64, device=DEVICE)
+        mm = torch.mm(x, y)
+        kernels = {
+            "sigmoid": matmul_sigmoid,
+            "exp": matmul_exp,
+            "neg": matmul_neg,
+            "add": matmul_add,
+            "sub": matmul_sub,
+            "mul": matmul_mul,
+            "div": matmul_div,
+            "chain": matmul_chain,
+        }
+        for kind, kernel in kernels.items():
+            with self.subTest(kind=kind):
+                result = kernel(x, y)
+                expected = apply_expected(kind, mm)
+                torch.testing.assert_close(result, expected, atol=1e-4, rtol=1e-4)
+                msl = _get_msl(kernel, (x, y))
+                self.assertIn("_coop.begin()", msl)
+                self.assertIn("_coop.store", msl)
+
+    def test_matmul_aux_tensor_epilogue_materializes(self) -> None:
+        cfg = [helion.Config(block_sizes=[32, 32, 32], num_warps=4)]
+
+        @helion.kernel(backend="metal", configs=cfg)
+        def matmul_add_aux(
+            x: torch.Tensor,
+            y: torch.Tensor,
+            z: torch.Tensor,
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _k2, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc + z[tile_m, tile_n]
+            return out
+
+        x = torch.randn(64, 64, device=DEVICE) * 0.05
+        y = torch.randn(64, 64, device=DEVICE) * 0.05
+        z = torch.randn(64, 64, device=DEVICE)
+        result = matmul_add_aux(x, y, z)
+        expected = torch.mm(x, y) + z
+        torch.testing.assert_close(result, expected, atol=1e-4, rtol=1e-4)
+
+        msl = _get_msl(matmul_add_aux, (x, y, z))
+        self.assertIn("matmul2d", msl)
+        self.assertIn("_coop.store", msl)
+        self.assertIn("threadgroup_barrier(mem_flags::mem_device)", msl)
+        self.assertNotIn("_coop_writeback", msl)
+
+    def test_matmul_epilogue_codegen(self) -> None:
+        """ReLU epilogue must appear inside cooperative_tensor iteration."""
+        cfg = [helion.Config(block_sizes=[32, 32, 32], num_warps=4)]
+
+        @helion.kernel(backend="metal", configs=cfg)
+        def matmul_relu(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _k2, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.relu()
+            return out
+
+        x = torch.randn(64, 64, device=DEVICE)
+        y = torch.randn(64, 64, device=DEVICE)
+        msl = _get_msl(matmul_relu, (x, y))
+        self.assertIn("_coop.begin()", msl, "Epilogue loop not found in MSL")
+        self.assertIn("_coop.store", msl, "Cooperative store not found in MSL")
+        self.assertNotIn("auto acc = float(0.0)", msl)
+
+    def test_mpp_graph_followed_by_scalar_outer_work(self) -> None:
+        """MPPGraph lowering must not consume later scalar work in the root graph."""
+        cfg = [helion.Config(block_sizes=[32, 32, 32], num_warps=4)]
+
+        @helion.kernel(backend="metal", configs=cfg)
+        def matmul_then_scalar(
+            x: torch.Tensor,
+            y: torch.Tensor,
+            z: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            m, k = x.size()
+            _k2, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            side = torch.empty([m, n], dtype=z.dtype, device=z.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+                side[tile_m, tile_n] = z[tile_m, tile_n] + 1.0
+            return out, side
+
+        x = torch.randn(64, 64, device=DEVICE)
+        y = torch.randn(64, 64, device=DEVICE)
+        z = torch.randn(64, 64, device=DEVICE)
+        code = matmul_then_scalar.bind((x, y, z)).to_code()
+        self.assertIn("_block_dims=(128, 8, 1)", code)
+
+        out, side = matmul_then_scalar(x, y, z)
+        torch.testing.assert_close(out, torch.mm(x, y), atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(side, z + 1.0)
+
+        msl = _get_msl(matmul_then_scalar, (x, y, z))
+        self.assertIn("matmul2d", msl)
+        self.assertIn("_coop.store", msl)
+        self.assertLess(msl.index("_coop.store"), msl.index("side["))
+        self.assertNotIn("if ((tid[1] == 0))", msl)
+        self.assertIn("z[", msl)
+        self.assertIn("tid[1]", msl)
+
+    def test_mpp_setup_marker_rejects_stale_arity(self) -> None:
+        import ast as pyast
+
+        from helion._compiler.metal.msl_ast_walker import _extract_mpp_setup_params
+
+        expr = pyast.parse(
+            '_metal_mpp_setup("x", "y", 64, 64, 64, 32, 32, 32, 4, '
+            '"float", "float", "", "", "acc", "out", "float")'
+        )
+        stmt = expr.body[0]
+        self.assertIsInstance(stmt, pyast.Expr)
+        call = stmt.value
+        self.assertIsInstance(call, pyast.Call)
+        with self.assertRaisesRegex(AssertionError, "expects 14 positional args"):
+            _extract_mpp_setup_params(call)
+
+    def test_mpp_emission_scopes_symbols_by_setup_name(self) -> None:
+        import ast as pyast
+
+        from helion._compiler.metal.msl_ast_walker import EmitState
+        from helion._compiler.metal.msl_ast_walker import _emit_stmts
+
+        code = (
+            '_mpp_setup = _metal_mpp_setup("x", "y", 64, 64, 64, 32, 32, 32, 4, '
+            '"float", "float", "", "", "acc")\n'
+            "_metal_mpp_k_step(_mpp_setup, 0)\n"
+            '_metal_mpp_coop_store(_mpp_setup, "out0", "float")\n'
+            '_mpp_setup_1 = _metal_mpp_setup("a", "b", 64, 64, 64, 32, 32, 32, 4, '
+            '"float", "float", "", "", "acc_1")\n'
+            "_metal_mpp_k_step(_mpp_setup_1, 0)\n"
+            '_metal_mpp_coop_store(_mpp_setup_1, "out1", "float")\n'
+        )
+        state = EmitState()
+        parts: list[str] = []
+        _emit_stmts(pyast.parse(code).body, parts, indent=4, state=state)
+        msl = "\n".join(parts)
+
+        self.assertIn("_mpp_setup_A", msl)
+        self.assertIn("_mpp_setup_1_A", msl)
+        self.assertIn("_mpp_setup_C", msl)
+        self.assertIn("_mpp_setup_1_C", msl)
+        self.assertIn("_mpp_setup_op.run", msl)
+        self.assertIn("_mpp_setup_1_op.run", msl)
+        self.assertNotIn("auto _A =", msl)
+        self.assertNotIn("auto _C =", msl)
+        self.assertNotIn("matmul2d<_desc", msl)
+
+    def test_matmul_via_hl_dot(self) -> None:
+        """``hl.dot`` reaches the same MPPGraph pipeline as ``torch.addmm``."""
+        cfg = [helion.Config(block_sizes=[32, 32, 32], num_warps=4)]
+
+        @helion.kernel(backend="metal", configs=cfg)
+        def matmul_dot(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _k2, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        x = torch.randn(64, 64, device=DEVICE)
+        y = torch.randn(64, 64, device=DEVICE)
+        result = matmul_dot(x, y)
+        torch.testing.assert_close(result, torch.mm(x, y), atol=1e-4, rtol=1e-4)
+
+        msl = _get_msl(matmul_dot, (x, y))
+        self.assertIn("matmul2d", msl, "MPP matmul2d not found in MSL (hl.dot)")
+        self.assertIn("_op.run", msl, "MPP run call not found in MSL (hl.dot)")
+
+    def test_matmul_via_hl_dot_with_relu(self) -> None:
+        cfg = [helion.Config(block_sizes=[32, 32, 32], num_warps=4)]
+
+        @helion.kernel(backend="metal", configs=cfg)
+        def matmul_dot_relu(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _k2, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+                out[tile_m, tile_n] = acc.relu()
+            return out
+
+        x = torch.randn(64, 64, device=DEVICE)
+        y = torch.randn(64, 64, device=DEVICE)
+        result = matmul_dot_relu(x, y)
+        torch.testing.assert_close(result, torch.mm(x, y).relu(), atol=1e-4, rtol=1e-4)
+
+        msl = _get_msl(matmul_dot_relu, (x, y))
+        self.assertIn("matmul2d", msl, "MPP matmul2d not found in MSL (hl.dot)")
+        self.assertIn("_coop.begin()", msl, "Epilogue loop not found in MSL (hl.dot)")
 
 
 if __name__ == "__main__":

--- a/test/test_metal_mpp_graph_transform.py
+++ b/test/test_metal_mpp_graph_transform.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import operator
+import unittest
+
+import torch
+from torch.fx import Graph
+
+from helion._compiler.device_ir import DeviceIR
+from helion._compiler.device_ir import ForLoopGraphInfo
+from helion._compiler.device_ir import RootGraphInfo
+from helion._compiler.metal.mpp_graph_codegen import MPPGraphInfo
+from helion._compiler.metal.mpp_graph_codegen import _mpp_graph
+from helion._compiler.metal.mpp_graph_transform import rewrite_mpp_graphs
+from helion.language import _tracing_ops
+from helion.language import memory_ops
+
+
+def _target_names(graph: Graph) -> list[str]:
+    names: list[str] = []
+    for node in graph.nodes:
+        if node.op != "call_function":
+            continue
+        target = node.target
+        names.append(getattr(target, "__name__", str(target)))
+    return names
+
+
+class TestMetalMPPGraphTransform(unittest.TestCase):
+    def _build_matmul_ir(
+        self,
+        *,
+        epilogue: str | None,
+        extra_phi_user: bool = False,
+        lhs_indices: tuple[int, int] = (0, 1),
+        rhs_indices: tuple[int, int] = (1, 2),
+        store_indices: tuple[int, int] = (0, 2),
+    ) -> DeviceIR:
+        body_graph = Graph()
+        lhs = body_graph.placeholder("lhs")
+        lhs.meta["val"] = torch.empty(4, 64, dtype=torch.float32)
+        rhs = body_graph.placeholder("rhs")
+        rhs.meta["val"] = torch.empty(64, 4, dtype=torch.float32)
+        lhs_load = body_graph.call_function(
+            memory_ops.load, args=(lhs, list(lhs_indices), None, None)
+        )
+        lhs_load.meta["val"] = torch.empty(4, 64, dtype=torch.float32)
+        rhs_load = body_graph.call_function(
+            memory_ops.load, args=(rhs, list(rhs_indices), None, None)
+        )
+        rhs_load.meta["val"] = torch.empty(64, 4, dtype=torch.float32)
+        acc = body_graph.placeholder("acc")
+        acc.meta["val"] = torch.empty(4, 4, dtype=torch.float32)
+        mma = body_graph.call_function(
+            torch.ops.aten.addmm.default, args=(acc, lhs_load, rhs_load)
+        )
+        mma.meta["val"] = torch.empty(4, 4, dtype=torch.float32)
+        body_graph.output((mma,))
+
+        root_graph = Graph()
+        acc_init = root_graph.call_function(_tracing_ops._new_var, args=())
+        for_loop = root_graph.call_function(
+            _tracing_ops._for_loop,
+            args=(0, [0], [64], [acc_init]),
+        )
+        getitem = root_graph.call_function(operator.getitem, args=(for_loop, 0))
+        phi = root_graph.call_function(_tracing_ops._phi, args=(acc_init, getitem))
+
+        value = phi
+        if epilogue == "relu":
+            value = root_graph.call_function(torch.ops.aten.relu.default, args=(value,))
+        elif epilogue == "cast":
+            value = root_graph.call_function(
+                torch.ops.prims.convert_element_type.default,
+                args=(value, torch.float16),
+            )
+            value.meta["val"] = torch.empty(4, 4, dtype=torch.float16)
+        elif epilogue == "sum":
+            value = root_graph.call_function(
+                torch.ops.aten.sum.dim_IntList,
+                args=(value, [0], False),
+            )
+            value.meta["val"] = torch.empty(4, dtype=torch.float32)
+        elif epilogue == "aux_add":
+            aux = root_graph.call_function(_tracing_ops._new_var, args=())
+            aux.meta["val"] = torch.empty(4, 4, dtype=torch.float32)
+            aux_load = root_graph.call_function(
+                memory_ops.load, args=(aux, list(store_indices), None, None)
+            )
+            aux_load.meta["val"] = torch.empty(4, 4, dtype=torch.float32)
+            value = root_graph.call_function(
+                torch.ops.aten.add.Tensor, args=(value, aux_load)
+            )
+            value.meta["val"] = torch.empty(4, 4, dtype=torch.float32)
+        elif epilogue is not None:
+            raise AssertionError(f"unknown epilogue: {epilogue}")
+
+        if extra_phi_user:
+            root_graph.call_function(torch.ops.aten.neg.default, args=(phi,))
+
+        out_shape = tuple(value.meta.get("val", torch.empty(4, 4)).shape)
+        out_dtype = value.meta.get("val", torch.empty(4, 4)).dtype
+        if epilogue == "sum":
+            actual_store_indices = [store_indices[0]]
+        else:
+            actual_store_indices = list(store_indices)
+
+        out = root_graph.call_function(_tracing_ops._new_var, args=())
+        out.meta["val"] = torch.empty(*out_shape, dtype=out_dtype)
+        root_graph.call_function(
+            memory_ops.store, args=(out, actual_store_indices, value, None)
+        )
+        root_graph.output(())
+
+        device_ir = DeviceIR()
+        device_ir.graphs = [
+            ForLoopGraphInfo(
+                graph_id=0,
+                graph=body_graph,
+                node_args=[acc_init],
+                block_ids=[2],
+            ),
+            RootGraphInfo(graph_id=1, graph=root_graph, phase_index=0),
+        ]
+        device_ir.root_ids = [1]
+        return device_ir
+
+    def test_direct_store_becomes_fused_mpp_graph(self) -> None:
+        device_ir = self._build_matmul_ir(epilogue=None)
+
+        rewrite_mpp_graphs(device_ir)
+        self.assertEqual(len(device_ir.graphs), 3)
+
+        root = device_ir.graphs[1]
+        assert isinstance(root, RootGraphInfo)
+        root_targets = _target_names(root.graph)
+        self.assertIn("_mpp_graph", root_targets)
+        self.assertNotIn("_for_loop", root_targets)
+        self.assertNotIn("_phi", root_targets)
+        self.assertNotIn("store", root_targets)
+
+        mpp_graph = device_ir.graphs[2]
+        assert isinstance(mpp_graph, MPPGraphInfo)
+        self.assertEqual(mpp_graph.result_name, "addmm_default")
+        self.assertEqual(mpp_graph.k_block_id, 2)
+        self.assertEqual(mpp_graph.begin, [0])
+        self.assertEqual(mpp_graph.end, [64])
+        self.assertIsNotNone(mpp_graph.lhs_tensor)
+        self.assertIsNotNone(mpp_graph.rhs_tensor)
+        self.assertEqual(mpp_graph.acc_dtype, torch.float32)
+        self.assertEqual(_target_names(mpp_graph.graph), [])
+        self.assertIsNotNone(mpp_graph.out_dtype)
+
+    def test_pointwise_epilogue_moves_into_fused_mpp_graph(self) -> None:
+        device_ir = self._build_matmul_ir(epilogue="relu")
+
+        rewrite_mpp_graphs(device_ir)
+        self.assertEqual(len(device_ir.graphs), 3)
+
+        root = device_ir.graphs[1]
+        assert isinstance(root, RootGraphInfo)
+        self.assertNotIn("relu.default", _target_names(root.graph))
+        self.assertNotIn("store", _target_names(root.graph))
+
+        mpp_graph = device_ir.graphs[2]
+        assert isinstance(mpp_graph, MPPGraphInfo)
+        self.assertIn("relu.default", _target_names(mpp_graph.graph))
+        self.assertNotIn("store", _target_names(mpp_graph.graph))
+        self.assertIsNotNone(mpp_graph.out_dtype)
+
+    def test_nonfusible_epilogue_is_not_rewritten(self) -> None:
+        device_ir = self._build_matmul_ir(epilogue="sum")
+
+        rewrite_mpp_graphs(device_ir)
+        root = device_ir.graphs[1]
+        assert isinstance(root, RootGraphInfo)
+        root_targets = _target_names(root.graph)
+        self.assertIn("_for_loop", root_targets)
+        self.assertIn("_phi", root_targets)
+        self.assertIn("sum.dim_IntList", root_targets)
+        self.assertIn("store", root_targets)
+        self.assertEqual(len(device_ir.graphs), 2)
+
+    def test_same_shape_nonfusible_epilogue_materializes_mpp_result(self) -> None:
+        device_ir = self._build_matmul_ir(epilogue="aux_add")
+
+        rewrite_mpp_graphs(device_ir)
+        self.assertEqual(len(device_ir.graphs), 3)
+        root = device_ir.graphs[1]
+        assert isinstance(root, RootGraphInfo)
+        root_targets = _target_names(root.graph)
+        self.assertIn("_mpp_graph", root_targets)
+        self.assertIn("load", root_targets)
+        self.assertIn("add.Tensor", root_targets)
+        self.assertIn("store", root_targets)
+        self.assertNotIn("_for_loop", root_targets)
+        self.assertNotIn("_phi", root_targets)
+
+        mpp_graph = device_ir.graphs[2]
+        assert isinstance(mpp_graph, MPPGraphInfo)
+        self.assertEqual(_target_names(mpp_graph.graph), [])
+        self.assertTrue(mpp_graph.needs_store_barrier)
+
+    def test_dtype_cast_epilogue_moves_into_fused_mpp_graph(self) -> None:
+        device_ir = self._build_matmul_ir(epilogue="cast")
+
+        rewrite_mpp_graphs(device_ir)
+        self.assertEqual(len(device_ir.graphs), 3)
+        mpp_graph = device_ir.graphs[2]
+        assert isinstance(mpp_graph, MPPGraphInfo)
+        self.assertIn("convert_element_type.default", _target_names(mpp_graph.graph))
+
+    def test_phi_fanout_is_not_rewritten(self) -> None:
+        device_ir = self._build_matmul_ir(epilogue="relu", extra_phi_user=True)
+
+        rewrite_mpp_graphs(device_ir)
+        root = device_ir.graphs[1]
+        assert isinstance(root, RootGraphInfo)
+        self.assertIn("_for_loop", _target_names(root.graph))
+        self.assertNotIn("_mpp_graph", _target_names(root.graph))
+
+    def test_noncanonical_load_store_indices_are_not_rewritten(self) -> None:
+        device_ir = self._build_matmul_ir(
+            epilogue=None,
+            rhs_indices=(2, 1),
+            store_indices=(0, 2),
+        )
+
+        rewrite_mpp_graphs(device_ir)
+        root = device_ir.graphs[1]
+        assert isinstance(root, RootGraphInfo)
+        self.assertIn("_for_loop", _target_names(root.graph))
+        self.assertNotIn("_mpp_graph", _target_names(root.graph))
+
+    def test_mpp_marker_preserves_loop_args(self) -> None:
+        device_ir = self._build_matmul_ir(epilogue="relu")
+
+        rewrite_mpp_graphs(device_ir)
+
+        root = device_ir.graphs[1]
+        assert isinstance(root, RootGraphInfo)
+        mpp_nodes = [
+            node
+            for node in root.graph.nodes
+            if node.op == "call_function" and node.target is _mpp_graph
+        ]
+        self.assertEqual(len(mpp_nodes), 1)
+        self.assertEqual(mpp_nodes[0].args[0], 2)
+        self.assertIsInstance(mpp_nodes[0].args[1], list)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

Introduce the Metal MPPGraph lowering path for aten matmul patterns.
Eligible DeviceIR shapes are rewritten into an explicit _mpp_graph marker
and an MPPGraphInfo object that owns the K-loop metadata, operand tensors,
optional cooperative epilogue graph, and final output store.

MPPGraphInfo emits the MPP setup, K-step loop, cooperative epilogue, and
cooperative store directly. This avoids the previous AST-shape recovery
model: there is no trailing-store scan, no _metal_mpp_store marker, and no
side table keyed by matmul node name.

The MSL walker now lowers explicit MPP markers into setup-scoped
matmul2d symbols so multiple MPP regions can coexist. Metal aten matmul
codegen is kept as a compatibility guard: if an MPP-compatible matmul
reaches scalar codegen without an owning MPPGraph, it reports unsupported
instead of emitting a stale partial pipeline.

The transform tests cover direct stores, fusible epilogues, dtype casts,
and conservative rejection cases such as non-fusible reductions and phi
fanout.

For more detailed design, pl refer to https://gist.github.com/aditvenk/24137992bbf69c60621fc423eebe7ffe
