### PR TITLE
[metal] Add hl.dot support for MPPGraph matmul

### DIFF
--- a/helion/_compiler/metal/metal_mma.py
+++ b/helion/_compiler/metal/metal_mma.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     import ast
 
     from ..aten_lowering import LoweringContext
+    from ..inductor_lowering import CodegenState
 
 
 # ---------------------------------------------------------------------------
@@ -175,8 +176,15 @@ def can_codegen_metal_mma_aten(node: Node, with_acc: bool) -> bool:
     )
 
 
+def can_codegen_metal_mma_dot(node: Node) -> bool:
+    """Return True when hl.dot can use Metal MMA."""
+    if not _is_mma_compatible(node, lhs_idx=0, rhs_idx=1, acc_idx=2):
+        return False
+    return _mma_result_can_be_deferred(node) and _mma_loop_is_exclusive(node)
+
+
 # ---------------------------------------------------------------------------
-# Entry point (called from aten_lowering.py)
+# Entry points (called from aten_lowering.py and matmul_ops.py)
 # ---------------------------------------------------------------------------
 
 
@@ -194,4 +202,19 @@ def codegen_metal_mma(
         "patterns must load canonical 2D A[M,K] and B[K,N] tiles, reduce "
         "over one K tile loop, optionally apply a fusible pointwise epilogue, "
         "and store C[M,N].",
+    )
+
+
+def codegen_metal_mma_dot(state: CodegenState) -> object | None:
+    """Reject MPP-compatible hl.dot outside an owning MPPGraph."""
+    if state.fx_node is None:
+        return None
+    if not can_codegen_metal_mma_dot(state.fx_node):
+        return None
+    raise exc.BackendUnsupported(
+        "metal",
+        "Metal MPP dot requires an owning MPPGraph. Supported dot patterns "
+        "must load canonical 2D A[M,K] and B[K,N] tiles, reduce over one K "
+        "tile loop, optionally apply a fusible pointwise epilogue, and store "
+        "C[M,N].",
     )

--- a/helion/_compiler/metal/mpp_graph_transform.py
+++ b/helion/_compiler/metal/mpp_graph_transform.py
@@ -66,6 +66,7 @@ from ..inductor_lowering import CodegenState
 from ..inductor_lowering import codegen_call_with_graph
 from .metal_mma import _MppKStep
 from .metal_mma import _MppSetup
+import helion.language as hl
 from helion.language import _decorators
 from helion.language import _tracing_ops
 from helion.language import memory_ops
@@ -551,6 +552,7 @@ def _mma_output_for_getitem(
 
 def _is_mpp_matmul_node(node: Node) -> bool:
     return node.op == "call_function" and node.target in {
+        hl.dot,
         torch.ops.aten.mm.default,
         torch.ops.aten.addmm.default,
     }

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -674,6 +674,16 @@ def _(state: CodegenState) -> object:
     )
 
 
+@_decorators.codegen(dot, "metal")
+def _(state: CodegenState) -> object:
+    from .._compiler.metal.metal_mma import codegen_metal_mma_dot
+
+    result = codegen_metal_mma_dot(state)
+    if result is not None:
+        return result
+    raise exc.BackendUnsupported("metal", "hl.dot not supported by MPP for this config")
+
+
 @_decorators.ref(dot)
 def _(
     mat1: torch.Tensor,

--- a/test/test_metal.py
+++ b/test/test_metal.py
@@ -1098,5 +1098,62 @@ class TestMetalMatmul(unittest.TestCase):
         self.assertNotIn("auto _C =", msl)
         self.assertNotIn("matmul2d<_desc", msl)
 
+    def test_matmul_via_hl_dot(self) -> None:
+        """``hl.dot`` reaches the same MPP MMA pipeline as ``torch.addmm``.
+
+        Exercises the ``hl.dot`` codegen path (``codegen_metal_mma_dot``)
+        which is structurally distinct from the aten addmm/mm path
+        (``codegen_metal_mma``) but reuses the same compatibility predicate
+        (``_is_mma_compatible`` with hl.dot operand layout) and lowers to
+        the same ``_metal_mpp_*`` pseudo-call sequence.
+        """
+        cfg = [helion.Config(block_sizes=[32, 32, 32], num_warps=4)]
+
+        @helion.kernel(backend="metal", configs=cfg)
+        def matmul_dot(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _k2, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        x = torch.randn(64, 64, device=DEVICE)
+        y = torch.randn(64, 64, device=DEVICE)
+        result = matmul_dot(x, y)
+        torch.testing.assert_close(result, torch.mm(x, y), atol=1e-4, rtol=1e-4)
+
+        msl = _get_msl(matmul_dot, (x, y))
+        self.assertIn("matmul2d", msl, "MPP matmul2d not found in MSL (hl.dot)")
+        self.assertIn("_op.run", msl, "MPP run call not found in MSL (hl.dot)")
+
+    def test_matmul_via_hl_dot_with_relu(self) -> None:
+        cfg = [helion.Config(block_sizes=[32, 32, 32], num_warps=4)]
+
+        @helion.kernel(backend="metal", configs=cfg)
+        def matmul_dot_relu(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _k2, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+                out[tile_m, tile_n] = acc.relu()
+            return out
+
+        x = torch.randn(64, 64, device=DEVICE)
+        y = torch.randn(64, 64, device=DEVICE)
+        result = matmul_dot_relu(x, y)
+        torch.testing.assert_close(result, torch.mm(x, y).relu(), atol=1e-4, rtol=1e-4)
+
+        msl = _get_msl(matmul_dot_relu, (x, y))
+        self.assertIn("matmul2d", msl, "MPP matmul2d not found in MSL (hl.dot)")
+        self.assertIn("_coop.begin()", msl, "Epilogue loop not found in MSL (hl.dot)")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Stacked PRs:
 * __->__#2473
 * #2472
 * #1855


--- --- ---

### [metal] Add hl.dot support for MPPGraph matmul


Route hl.dot on Metal through the same MPPGraph matmul path used by aten
matmul. The dot lowering reuses the MPP compatibility checks and rejects
unsupported shapes rather than falling into scalar lowering.

Add coverage for both plain hl.dot matmul and hl.dot followed by a fused
ReLU epilogue, so the final commit verifies that dot participates in the
same cooperative epilogue machinery as aten addmm/mm.
