### PR TITLE
[Autotuner] Cap inner-tile block size by outer tile

### DIFF
--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -39,6 +39,7 @@ from .compile_environment import AutoSize
 from .compile_environment import CompileEnvironment
 from .compile_environment import FixedBlockSizeSource
 from .compile_environment import LoopSpecBlockSizeSource
+from .compile_environment import _symint_expr
 from .compile_environment import warning
 from .device_function import contains_only_block_size_symbols
 from .host_function import HostFunction
@@ -1119,6 +1120,64 @@ def _get_hint(numel: int | torch.SymInt | AutoSize | None) -> int:
     return CompileEnvironment.current().size_hint(numel)
 
 
+def _detect_outer_block_bound(
+    numel: torch.SymInt, env: CompileEnvironment
+) -> int | None:
+    """If ``numel`` equals ``tile.end - tile.begin`` for an outer tile, return
+    that tile's block_id.  Used to cap inner-tile block sizes to the enclosing
+    outer tile's extent (e.g. ``hl.tile(outer.begin, outer.end)``).
+    """
+    from .variable_origin import TileBeginOrigin
+    from .variable_origin import TileEndOrigin
+
+    # Direct match: numel is another block's var.
+    direct = env.get_block_id(numel)
+    if direct is not None:
+        return direct
+
+    expr = _symint_expr(numel)
+    if expr is None:
+        return None
+    host_fn = HostFunction.current()
+
+    # Walk the free symbols: expect exactly one TileBeginOrigin and one
+    # TileEndOrigin with the same block_id, then verify the expression is
+    # structurally the tile extent.
+    begin_bid: int | None = None
+    end_bid: int | None = None
+    begin_sym: sympy.Symbol | None = None
+    end_sym: sympy.Symbol | None = None
+    for sym in expr.free_symbols:
+        if not isinstance(sym, sympy.Symbol):
+            return None
+        symbol_origin = host_fn.expr_to_origin.get(sym)
+        if symbol_origin is None:
+            return None
+        origin = symbol_origin.origin
+        if isinstance(origin, TileBeginOrigin):
+            if begin_bid is not None:
+                return None
+            begin_bid = origin.block_id
+            begin_sym = sym
+        elif isinstance(origin, TileEndOrigin):
+            if end_bid is not None:
+                return None
+            end_bid = origin.block_id
+            end_sym = sym
+        else:
+            return None
+    if (
+        begin_bid is not None
+        and end_bid is not None
+        and begin_bid == end_bid
+        and begin_sym is not None
+        and end_sym is not None
+        and sympy.expand(expr - (end_sym - begin_sym)) == 0  # pyrefly: ignore[unsupported-operation]
+    ):
+        return begin_bid
+    return None
+
+
 class TileIndexType(TypeInfo):
     block_id: int
 
@@ -1150,10 +1209,26 @@ class TileIndexType(TypeInfo):
         env = CompileEnvironment.current()
         if block_size is None:
             block_id = env.allocate_block_size(numel, source=LoopSpecBlockSizeSource())
+            outer_max: int | None = None
+            bounded_by: int | None = None
+            if isinstance(numel, torch.SymInt):
+                maybe_bounded_by = _detect_outer_block_bound(numel, env)
+                if maybe_bounded_by is not None:
+                    try:
+                        outer_spec = env.config_spec.block_sizes.block_id_lookup(
+                            maybe_bounded_by
+                        )
+                    except KeyError:
+                        pass
+                    else:
+                        bounded_by = maybe_bounded_by
+                        outer_max = outer_spec.max_size
             env.config_spec.block_sizes.append(
                 BlockSizeSpec(
                     block_id=block_id,
                     size_hint=_get_hint(numel),
+                    max_size=outer_max,
+                    bounded_by_block_id=bounded_by,
                 )
             )
             if env.config_spec.supports_config_key("num_threads"):

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -1799,6 +1799,60 @@ class ConfigSpec:
             config[name] = mapping._normalize(
                 name, config.get(name, ()), flatten=flatten
             )
+
+        # Clamp inner block sizes that are bounded by an outer block
+        # (e.g. ``hl.tile(outer.begin, outer.end)``): at this point the
+        # outer's concrete block size for this config is known, and the
+        # inner extent can never exceed it.
+        block_sizes_list = config.get("block_sizes")
+        if isinstance(block_sizes_list, list):
+            changed = False
+            new_block_sizes = list(block_sizes_list)
+            for i, spec in enumerate(self.block_sizes):
+                bb = spec.bounded_by_block_id
+                if (
+                    bb is None
+                    or i >= len(new_block_sizes)
+                    or new_block_sizes[i] is None
+                ):
+                    continue
+                try:
+                    outer_index = self.block_sizes.block_id_to_index(bb)
+                except KeyError:
+                    continue
+                outer_val = (
+                    new_block_sizes[outer_index]
+                    if outer_index < len(new_block_sizes)
+                    else None
+                )
+                if (
+                    isinstance(outer_val, int)
+                    and isinstance(new_block_sizes[i], int)
+                    and new_block_sizes[i] > outer_val
+                ):
+                    new_block_sizes[i] = outer_val
+                    changed = True
+            if changed:
+                config["block_sizes"] = new_block_sizes
+                num_threads = config.get("num_threads")
+                if isinstance(num_threads, list):
+                    new_num_threads = list(num_threads)
+                    for i, (block_size, num_thread) in enumerate(
+                        zip(new_block_sizes, new_num_threads, strict=False)
+                    ):
+                        if (
+                            type(block_size) is not int
+                            or type(num_thread) is not int
+                            or num_thread <= 0
+                        ):
+                            continue
+                        if num_thread > block_size:
+                            num_thread = 1 << (max(block_size, 1).bit_length() - 1)
+                        while num_thread > 1 and block_size % num_thread != 0:
+                            num_thread //= 2
+                        new_num_threads[i] = max(num_thread, 1)
+                    config["num_threads"] = new_num_threads
+
         if self.supports_config_key("num_threads"):
             num_threads = cast("list[int]", config.get("num_threads", []))
             if all(value == 0 for value in num_threads):
@@ -2855,6 +2909,7 @@ class BlockSizeSpec(_PowerOfTwoBlockIdItem):
         size_hint: int,
         min_size: int = 1,
         max_size: int | None = None,
+        bounded_by_block_id: int | None = None,
     ) -> None:
         super().__init__([block_id])
         self.size_hint = size_hint
@@ -2872,6 +2927,8 @@ class BlockSizeSpec(_PowerOfTwoBlockIdItem):
         self.max_size: int = (
             next_power_of_2(bounded_hint) if max_size is None else max_size
         )
+        # Outer block_id whose tile extent caps this block's size in normalize().
+        self.bounded_by_block_id: int | None = bounded_by_block_id
         if self.max_size < self.min_size:
             self.max_size = self.min_size
         assert self.min_size <= self.max_size
@@ -2883,6 +2940,7 @@ class BlockSizeSpec(_PowerOfTwoBlockIdItem):
             ("size_hint", None),
             ("min_size", 1),
             ("max_size", next_power_of_2(self.size_hint)),
+            ("bounded_by_block_id", None),
         ):
             value = getattr(self, field)
             if value != default:

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -407,6 +407,136 @@ class TestSettingsEnv(TestCase):
         # max_size should be bounded by size_hint // world_size = 256, not 1024
         self.assertLessEqual(spec.max_size, size_hint // world_size)
 
+    def test_bounded_inner_block_size_clamped_to_outer_value(self) -> None:
+        from helion._compiler.backend import TritonBackend
+        from helion.autotuner.config_spec import BlockSizeSpec
+        from helion.autotuner.config_spec import ConfigSpec
+
+        # Use Triton only as a concrete backend; this normalize behavior is
+        # backend-agnostic.
+        spec = ConfigSpec(backend=TritonBackend())
+        spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=1024))
+        spec.block_sizes.append(
+            BlockSizeSpec(block_id=1, size_hint=1024, bounded_by_block_id=0)
+        )
+
+        config = {"block_sizes": [64, 256]}
+        spec.normalize(config)
+
+        self.assertEqual(config["block_sizes"][:2], [64, 64])
+
+    def test_bounded_inner_block_size_keeps_valid_inner_value(self) -> None:
+        from helion._compiler.backend import TritonBackend
+        from helion.autotuner.config_spec import BlockSizeSpec
+        from helion.autotuner.config_spec import ConfigSpec
+
+        spec = ConfigSpec(backend=TritonBackend())
+        spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=1024))
+        spec.block_sizes.append(
+            BlockSizeSpec(block_id=1, size_hint=1024, bounded_by_block_id=0)
+        )
+
+        config = {"block_sizes": [256, 64]}
+        spec.normalize(config)
+
+        self.assertEqual(config["block_sizes"][:2], [256, 64])
+
+    def test_bounded_inner_block_size_clamps_multi_level_nesting(self) -> None:
+        from helion._compiler.backend import TritonBackend
+        from helion.autotuner.config_spec import BlockSizeSpec
+        from helion.autotuner.config_spec import ConfigSpec
+
+        spec = ConfigSpec(backend=TritonBackend())
+        spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=1024))
+        spec.block_sizes.append(
+            BlockSizeSpec(block_id=1, size_hint=1024, bounded_by_block_id=0)
+        )
+        spec.block_sizes.append(
+            BlockSizeSpec(block_id=2, size_hint=1024, bounded_by_block_id=1)
+        )
+
+        config = {"block_sizes": [64, 256, 512]}
+        spec.normalize(config)
+
+        self.assertEqual(config["block_sizes"][:3], [64, 64, 64])
+
+    def test_bounded_inner_block_size_repairs_cute_num_threads(self) -> None:
+        from helion._compiler.backend import CuteBackend
+        from helion.autotuner.config_spec import BlockSizeSpec
+        from helion.autotuner.config_spec import ConfigSpec
+        from helion.autotuner.config_spec import NumThreadsSpec
+
+        spec = ConfigSpec(backend=CuteBackend())
+        spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=1024))
+        spec.block_sizes.append(
+            BlockSizeSpec(block_id=1, size_hint=1024, bounded_by_block_id=0)
+        )
+        spec.num_threads.append(NumThreadsSpec(block_id=0, size_hint=1024))
+        spec.num_threads.append(NumThreadsSpec(block_id=1, size_hint=1024))
+
+        config = {"block_sizes": [64, 256], "num_threads": [64, 256]}
+        spec.normalize(config)
+
+        self.assertEqual(config["block_sizes"][:2], [64, 64])
+        self.assertEqual(config["num_threads"][:2], [64, 64])
+
+    def test_detect_outer_block_bound_requires_end_minus_begin(self) -> None:
+        from types import SimpleNamespace
+
+        import sympy
+
+        from helion._compiler.host_function import SymbolOrigin
+        from helion._compiler.type_propagation import _detect_outer_block_bound
+        from helion._compiler.variable_origin import TileBeginOrigin
+        from helion._compiler.variable_origin import TileEndOrigin
+
+        begin = sympy.Symbol("begin")
+        end = sympy.Symbol("end")
+        fake_host = SimpleNamespace(
+            expr_to_origin={
+                begin: SymbolOrigin(TileBeginOrigin(3)),
+                end: SymbolOrigin(TileEndOrigin(3)),
+            }
+        )
+        fake_env = SimpleNamespace(get_block_id=lambda _numel: None)
+
+        with (
+            patch(
+                "helion._compiler.type_propagation.HostFunction.current",
+                return_value=fake_host,
+            ),
+            patch(
+                "helion._compiler.type_propagation._symint_expr",
+                side_effect=lambda expr: expr,
+            ),
+        ):
+            self.assertEqual(_detect_outer_block_bound(end - begin, fake_env), 3)
+            self.assertIsNone(_detect_outer_block_bound(begin + end, fake_env))
+
+    def test_detect_outer_block_bound_accepts_direct_block_size(self) -> None:
+        from types import SimpleNamespace
+
+        from helion._compiler.type_propagation import _detect_outer_block_bound
+
+        numel = object()
+        fake_env = SimpleNamespace(
+            get_block_id=lambda value: 5 if value is numel else None
+        )
+
+        with patch(
+            "helion._compiler.type_propagation._symint_expr",
+            side_effect=AssertionError("_symint_expr should not be called"),
+        ):
+            self.assertEqual(_detect_outer_block_bound(numel, fake_env), 5)
+
+    def test_bounded_block_size_repr_includes_bound(self) -> None:
+        from helion.autotuner.config_spec import BlockSizeSpec
+
+        self.assertIn(
+            "bounded_by_block_id=7",
+            repr(BlockSizeSpec(block_id=1, size_hint=64, bounded_by_block_id=7)),
+        )
+
     def test_autotune_search_acf_env_var_strips_whitespace(self) -> None:
         with patch.dict(
             os.environ,


### PR DESCRIPTION

Based on Yifei's work:
- 0dc3f4a2 ([Autotuner] Cap inner-tile block_size by outer-tile block_size)
- branch: upstream/yifeixu/helion-inner-block-cap

----

When an inner hl.tile iterates over an outer tile range, the inner block cannot be larger than the outer block for that config. Record the outer block bound and clamp invalid inner block sizes during normalization.
