### PR TITLE
# PR Summary: Support reductions under branch-by-grid control flow

### DIFF
--- a/helion/_compiler/roll_reduction.py
+++ b/helion/_compiler/roll_reduction.py
@@ -106,12 +106,19 @@ class ReductionRoller:
         if is_for_loop_target(node.target) or node.target is _if:
             if is_for_loop_target(node.target):
                 graph_id, *_ = node.args
+                assert isinstance(graph_id, int)
+                infos = [self.graph_id_to_info[graph_id]]
             else:
-                _, graph_id, _ = node.args
-            assert isinstance(graph_id, int)
-            info = self.graph_id_to_info[graph_id]
-            if info.used_rdim:
-                if not info.can_be_rolled_by_caller:
+                _, if_graph_id, else_graph_id, *_ = node.args
+                assert isinstance(if_graph_id, int)
+                assert isinstance(else_graph_id, int)
+                infos = [
+                    self.graph_id_to_info[if_graph_id],
+                    self.graph_id_to_info[else_graph_id],
+                ]
+            used_infos = [info for info in infos if info.used_rdim]
+            if used_infos:
+                if not all(info.can_be_rolled_by_caller for info in used_infos):
                     raise NotImplementedError("for loop with mixed reduction dim usage")
                 return True
             return False

--- a/test/test_control_flow.py
+++ b/test/test_control_flow.py
@@ -12,6 +12,7 @@ from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
+from helion._testing import skipIfCute
 from helion._testing import skipIfPallas
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
@@ -340,6 +341,97 @@ class TestControlFlow(RefEagerTestBase, TestCase):
         code, result = code_and_output(fn, (x, False))
         expected = (x.float() + x.float()).to(x.dtype)
         torch.testing.assert_close(result, expected)
+
+    @skipIfPallas("Pallas gather supports only dim-0 indirect indexing")
+    @skipIfCute("Cute requires hl.arange() to use an active tile/reduction axis")
+    def test_grid_if_reduction_rolling_branch_graph_ids(self):
+        """Test for reductions under branch-by-grid control flow.
+
+        Reduction rolling must inspect both _if branch graph ids. The _if node
+        also carries branch args, so unpacking the old 3-arg form misses this
+        case before codegen.
+        """
+
+        # This branch-by-grid pattern is used by the fused kernel work in
+        # https://github.com/vllm-project/vllm/pull/38595.
+        @helion.kernel(static_shapes=False)
+        def fn(
+            a: torch.Tensor,
+            b: torch.Tensor,
+            c: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            t = a.size(0)
+            ha = hl.specialize(a.shape[1])
+            hc = hl.specialize(c.shape[1])
+            hmax = hl.specialize(max(a.shape[1], c.shape[1]))
+            da = hl.specialize(a.shape[2])
+            db = hl.specialize(b.shape[2])
+            dc = hl.specialize(c.shape[2])
+
+            out_a = torch.empty_like(a, dtype=torch.float32)
+            out_b = torch.empty_like(b, dtype=torch.float32)
+            out_c = torch.empty_like(c, dtype=torch.float32)
+
+            for pid, tile_t, tile_h in hl.grid([3, t, hmax]):
+                if pid == 0:
+                    if tile_h < ha:
+                        a_offsets = hl.arange(0, da)
+                        a_vals = a[tile_t, tile_h, a_offsets].to(torch.float32)
+                        a_scale = torch.rsqrt(
+                            torch.sum(a_vals * a_vals, dim=-1) / da + 1.0e-6
+                        )
+                        out_a[tile_t, tile_h, a_offsets] = a_vals * a_scale
+                elif pid == 1:
+                    if tile_h < ha:
+                        b_offsets = hl.arange(0, db)
+                        b_vals = b[tile_t, tile_h, b_offsets].to(torch.float32)
+                        b_scale = torch.amax(torch.abs(b_vals), dim=-1)
+                        out_b[tile_t, tile_h, b_offsets] = b_vals / b_scale
+                elif pid == 2:
+                    if tile_h < hc:
+                        c_offsets = hl.arange(0, dc)
+                        c_vals = c[tile_t, tile_h, c_offsets].to(torch.float32)
+                        out_c[tile_t, tile_h, c_offsets] = c_vals + 1.0
+            return out_a, out_b, out_c
+
+        t, ha, hc = 4, 8, 12
+        da, db, dc = 32, 64, 16
+        a = torch.randn(t, ha, da, device=DEVICE, dtype=torch.bfloat16)
+        b = torch.randn(t, ha, db, device=DEVICE, dtype=torch.bfloat16)
+        c = torch.randn(t, hc, dc, device=DEVICE, dtype=torch.bfloat16)
+
+        code, result = code_and_output(fn, (a, b, c))
+        a_ref = a.float()
+        a_scale = torch.rsqrt(
+            torch.sum(a_ref * a_ref, dim=-1, keepdim=True) / da + 1.0e-6
+        )
+        b_ref = b.float()
+        b_scale = torch.amax(torch.abs(b_ref), dim=-1, keepdim=True)
+        expected = (a_ref * a_scale, b_ref / b_scale, c.float() + 1.0)
+        for actual, expected_tensor in zip(result, expected, strict=True):
+            torch.testing.assert_close(
+                actual, expected_tensor, rtol=1.0e-2, atol=1.0e-2
+            )
+
+    # TODO(shangdiy): This currently fails after reduction rolling because
+    # keepdim=True lowers through a scalar reshape that Triton rejects with:
+    # "'dtype' object has no attribute 'numel'".
+    # def test_grid_if_reduction_keepdim_true_xfail(self):
+    #     @helion.kernel(static_shapes=False)
+    #     def fn(x: torch.Tensor) -> torch.Tensor:
+    #         out = torch.empty_like(x, dtype=torch.float32)
+    #         n = x.size(0)
+    #         d = hl.specialize(x.shape[1])
+    #         for pid, row in hl.grid([2, n]):
+    #             if pid == 0:
+    #                 offsets = hl.arange(0, d)
+    #                 vals = x[row, offsets].to(torch.float32)
+    #                 scale = torch.sum(vals * vals, dim=-1, keepdim=True)
+    #                 out[row, offsets] = vals / scale
+    #         return out
+    #
+    #     x = torch.randn(4, 32, device=DEVICE, dtype=torch.bfloat16)
+    #     code_and_output(fn, (x,))
 
     @skipIfPallas("tensor gather indexing not supported on Pallas")
     def test_optional_tensor_is_none_constexpr(self):


### PR DESCRIPTION
Stacked PRs:
 * #2481
 * __->__#2480


--- --- ---

### # PR Summary: Support reductions under branch-by-grid control flow


## Summary

This change fixes reduction rolling for Helion kernels that use `hl.grid(...)`
with device-side branch dispatch, where different grid `pid` branches perform
different work and some branches contain reductions.

The issue was that reduction rolling treated `_if` nodes as the older 3-argument
form. Current `_if` nodes carry both branch graph IDs plus branch argument lists,
so the roller needs to inspect both branch graphs when deciding whether an `_if`
uses the reduction dimension.

This pattern is used by fused kernel work in vLLM:
https://github.com/vllm-project/vllm/pull/38595

## Test Coverage

Added `test_grid_if_reduction_rolling_branch_graph_ids` in
`test/test_control_flow.py`.

The test covers:

- `hl.grid([3, ...])` branch-by-pid style control flow.
- Distinct branch-local tensor shapes.
- Reductions inside multiple branches.
- Correct output against PyTorch reference results.

## Known Follow-up

`keepdim=True` reductions under this same branch-by-grid pattern still hit a
separate Triton lowering issue:

```text
'dtype' object has no attribute 'numel'
```

The test file includes a commented xfail scaffold documenting that follow-up.

## Benchmarking

Mini repro benchmark code reference: `P2341009212`.

vLLM `fused_q` benchmark code reference: `P2341069714`.

Benchmark environment: local CUDA host with NVIDIA B200 GPU, using the
`pytorch-3.12` conda environment.

Mini repro results with CUDA graph timing:

```text
split Helion matches Triton output A
split Helion matches Triton output B
split Helion matches Triton output C
triton one-launch graph ms: 0.002780
helion split graph ms:     0.006243
single Helion branch-by-grid without reductions compiled: [(8, 16, 64), (8, 16, 128), (8, 32, 32)]
single Helion matches Triton output A
single Helion matches Triton output B
single Helion matches Triton output C
helion single-branch graph ms: 0.002844
```

vLLM `fused_q` single-kernel Helion results with `HELION_AUTOTUNE_EFFORT=quick`
and `HELION_FORCE_AUTOTUNE=1`:

```text
tokens,correctness,triton_graph_ms,helion_graph_ms,helion_graph/triton_graph
1,OK,0.004920,0.004109,0.835
2,OK,0.004436,0.004135,0.932
4,OK,0.006036,0.004129,0.684
8,OK,0.006193,0.006167,0.996
16,OK,0.010272,0.008227,0.801
32,OK,0.016445,0.014389,0.875
64,OK,0.028702,0.028704,1.000
128,OK,0.053349,0.053269,0.998
256,OK,0.104455,0.102467,0.981
512,OK,0.204902,0.202901,0.990
1024,OK,0.405684,0.403686,0.995
```

For `T=1024`, quick autotune searched 49 configs and selected:

```text
@helion.kernel(
    config=helion.Config(
        atomic_indexing=[],
        block_sizes=[],
        indexing=[
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
            'pointer',
        ],
        l2_groupings=[1],
        load_eviction_policies=[
            '',
            '',
            '',
            '',
            '',
            '',
            '',
            'last',
            '',
            'last',
            'last',
            '',
            '',
            '',
            '',
            '',
            '',
        ],
        loop_orders=[[2, 0, 1]],
        num_stages=4,
        num_warps=1,
        pid_type='flat',
        range_flattens=[None],
        range_multi_buffers=[None],
        range_num_stages=[],
        range_unroll_factors=[0],
        range_warp_specializes=[None],
    ),
    static_shapes=False,
)
```

The single branch-by-grid Helion kernel used a cached autotuned config:

```text
@helion.kernel(
    config=helion.Config(
        atomic_indexing=[],
        block_sizes=[],
        indexing=[
            'pointer',
            'pointer',
            'tensor_descriptor',
            'tensor_descriptor',
            'pointer',
            'pointer',
        ],
        l2_groupings=[4],
        load_eviction_policies=['first', 'first', 'first'],
        loop_orders=[[0, 2, 1]],
        num_stages=1,
        num_warps=2,
        pid_type='flat',
        range_flattens=[None],
        range_multi_buffers=[None],
        range_num_stages=[0],
        range_unroll_factors=[0],
        range_warp_specializes=[None],
    ),
    static_shapes=False,
)
```

The no-reduction branch-by-grid compile check used this cached config:

```text
@helion.kernel(
    config=helion.Config(
        atomic_indexing=[],
        block_sizes=[],
        indexing=['pointer', 'pointer', 'pointer', 'pointer', 'pointer', 'pointer'],
        l2_groupings=[1],
        load_eviction_policies=['', '', ''],
        loop_orders=[[0, 1, 2]],
        num_stages=1,
        num_warps=4,
        pid_type='flat',
        range_flattens=[None],
        range_multi_buffers=[None],
        range_num_stages=[0],
        range_unroll_factors=[0],
        range_warp_specializes=[None],
    ),
    static_shapes=False,
)
```

## Verification

```bash
CUDA_VISIBLE_DEVICES=0 TORCH_NATIVE_SKIP_VERSION_CHECK=1 HELION_AUTOTUNE_EFFORT=none \
  conda run -n pytorch-3.12 python -m pytest /home/shangdiy/helion/test/test_control_flow.py -q
```

Result:

```text
13 passed
```
