### PR TITLE
[Pallas] Add kl_div to TPU benchmark sweep and dashboard

### DIFF
--- a/.github/workflows/benchmark_dispatch.yml
+++ b/.github/workflows/benchmark_dispatch.yml
@@ -39,7 +39,7 @@ on:
         description: 'Comma-separated list of kernels to benchmark on TPU (examples-based; disjoint from `kernels`). Default is the dashboard-tracked subset; pass an explicit list, or `all` to run every kernel registered in benchmarks/run_tpu.py::KERNEL_MAPPINGS.'
         required: false
         type: string
-        default: "flash_attention,bmm,gemm,welford,softmax,layer_norm,rms_norm,rms_norm-bwd,cross_entropy"
+        default: "flash_attention,bmm,gemm,welford,softmax,layer_norm,rms_norm,rms_norm-bwd,cross_entropy,kl_div"
       kernels_cute:
         description: 'Comma-separated list of kernels to benchmark on B200 with HELION_BACKEND=cute. Defaults to the CuTe-capable TritonBench subset.'
         required: false

--- a/benchmarks/run_tpu.py
+++ b/benchmarks/run_tpu.py
@@ -762,6 +762,32 @@ def _epilogue_subtiling_shapes(
     return out
 
 
+def _kl_div_baseline(y_pred: torch.Tensor, y_true: torch.Tensor) -> torch.Tensor:
+    # Mirrors test_kl_div: y_pred is in log-space, y_true is probabilities,
+    # reduction is batchmean.
+    return torch.nn.functional.kl_div(
+        y_pred, y_true, reduction="batchmean", log_target=False
+    )
+
+
+def _kl_div_shapes(
+    num_shapes: int | None = None,
+) -> list[tuple[str, tuple[Any, ...]]]:
+    # (BT, V) — matches the test's canonical shape; second is a larger
+    # LLM-style vocab.
+    configs = [(1024, 4096), (2048, 32000)]
+    if num_shapes is not None:
+        configs = configs[:num_shapes]
+    out: list[tuple[str, tuple[Any, ...]]] = []
+    for bt, v in configs:
+        y_pred = torch.randn(bt, v, device=DEVICE, dtype=torch.float32).log_softmax(
+            dim=-1
+        )
+        y_true = torch.randn(bt, v, device=DEVICE, dtype=torch.float32).softmax(dim=-1)
+        out.append((f"[{bt},{v}]", (y_pred, y_true)))
+    return out
+
+
 # Kernel mappings for TPU/Pallas benchmarks.
 # Format: kernel_name -> (module_file, kernel_fn_name, baseline_fn, shapes_fn,
 #                         max_mismatch_pct)
@@ -942,6 +968,13 @@ KERNEL_MAPPINGS: dict[str, KernelMapping] = {
         "squeeze_and_excitation_net_fwd",
         _squeeze_and_excitation_net_baseline,
         _squeeze_and_excitation_net_shapes,
+        None,
+    ),
+    "kl_div": (
+        "kl_div",
+        "kl_div_forward",
+        _kl_div_baseline,
+        _kl_div_shapes,
         None,
     ),
     # Use the JSD-only inner kernel (test-covered on Pallas). The example's


### PR DESCRIPTION
## Summary
- Wires `kl_div` into `benchmarks/run_tpu.py::KERNEL_MAPPINGS` (test-covered on Pallas since PR #2398).
- Adds `kl_div` to the slim TPU subset that the nightly dashboard tracks, so it now appears on the dashboard side-by-side with the existing GPU bar.

## Autotune results (TPUv7, full effort)

| Shape | Helion (ms) | Torch (ms) | Helion speedup | torch.compile speedup |
|---|---:|---:|---:|---:|
| [1024, 4096] | 0.5128 | 0.3255 | **0.63x** | 1.32x |
| [2048, 32000] | 0.6964 | 0.9499 | **1.36x** | 2.03x |

Small shape: Helion slower than eager torch. Large-vocab shape: Helion beats eager torch (1.36x), torch.compile wins overall (2.03x).
