### PR TITLE
Only include common outputs as outputs of traced if subgraph

### DIFF
--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -440,7 +440,19 @@ class IfGraphInfo(NodeArgsGraphInfo):
             body_stmts.append(ast.Pass())
         if len(orelse_stmts) == 0:
             orelse_stmts.append(ast.Pass())
-        return if_outputs + else_outputs
+
+        graph_info = state.get_graph(state.proxy_arg(1))
+        assert isinstance(graph_info, IfGraphInfo)
+
+        if_return_names, else_return_names = graph_info.get_branches_return_names(
+            state, if_outputs, else_outputs
+        )
+
+        return cast(
+            "list[object]",
+            [expr_from_string(n) for n in if_return_names]
+            + [expr_from_string(n) for n in else_return_names],
+        )
 
 
 @dataclasses.dataclass
@@ -1487,20 +1499,53 @@ class WalkDeviceAST(NodeVisitor):
             # pyrefly: ignore [bad-argument-type]
             *args_to_proxies(tracer, args),
         )
+
+        if_output_values = if_outputs.values
+        else_output_values = else_outputs.values
+
+        common_output_names = [n for n in if_output_values if n in else_output_values]
+        if_nonlocal_outputs_names = [
+            name
+            for name in if_output_values
+            if name not in common_output_names and name in self.scope
+        ]
+        else_nonlocal_output_names = [
+            name
+            for name in else_output_values
+            if name not in common_output_names and name in self.scope
+        ]
+
+        if_common_outputs = [if_output_values[name] for name in common_output_names]
+        if_nonlocal_outputs = [
+            if_output_values[name] for name in if_nonlocal_outputs_names
+        ]
+        if_unmodified_nonlocal_outputs = [
+            self.scope[name] for name in else_nonlocal_output_names
+        ]
+        else_common_outputs = [else_output_values[name] for name in common_output_names]
+        else_unmodified_nonlocal_outputs = [
+            self.scope[name] for name in if_nonlocal_outputs_names
+        ]
+        else_nonlocal_outputs = [
+            else_output_values[name] for name in else_nonlocal_output_names
+        ]
         proxy_tensor.track_tensor_tree(
-            if_outputs.get_tensor_args() + else_outputs.get_tensor_args(),
+            if_common_outputs
+            + if_nonlocal_outputs
+            + if_unmodified_nonlocal_outputs
+            + else_common_outputs
+            + else_unmodified_nonlocal_outputs
+            + else_nonlocal_outputs,
             proxy_out,
             constant=None,
             tracer=tracer,
         )
 
-        if_output_values = if_outputs.values
-        else_output_values = else_outputs.values
-        common_output_names = [n for n in if_output_values if n in else_output_values]
-
         # branches_outputs:  [(if_out_0, else_out_0), (if_out_1, else_out_1), ...]
         # where each output is either an index if the graph's output values,
-        # or a name of a nonlocal variable which the opposite branch writes to
+        # or a name of a nonlocal variable which the opposite branch writes to.
+        # Ordering: common -> if-only-nonlocal -> else-only-nonlocal,
+        # (i.e. same as ordering of values in track_tensor_tree above)
         if_graph.branches_outputs = []
 
         def get_output_idx(name: str, output_values: dict[str, object]) -> int:
@@ -1514,21 +1559,19 @@ class WalkDeviceAST(NodeVisitor):
             else_output_index = get_output_idx(name, else_output_values)
             if_graph.branches_outputs.append((if_output_index, else_output_index))
 
-        for name in if_output_values:
-            if name not in common_output_names and name in self.scope:
-                self.scope[name] = _tracing_ops._phi(
-                    self.scope[name], if_output_values[name]
-                )
-                if_output_index = get_output_idx(name, if_output_values)
-                if_graph.branches_outputs.append((if_output_index, name))
+        for name in if_nonlocal_outputs_names:
+            self.scope[name] = _tracing_ops._phi(
+                self.scope[name], if_output_values[name]
+            )
+            if_output_index = get_output_idx(name, if_output_values)
+            if_graph.branches_outputs.append((if_output_index, name))
 
-        for name in else_output_values:
-            if name not in common_output_names and name in self.scope:
-                self.scope[name] = _tracing_ops._phi(
-                    self.scope[name], else_output_values[name]
-                )
-                else_output_index = get_output_idx(name, else_output_values)
-                if_graph.branches_outputs.append((else_output_index, name))
+        for name in else_nonlocal_output_names:
+            self.scope[name] = _tracing_ops._phi(
+                self.scope[name], else_output_values[name]
+            )
+            else_output_index = get_output_idx(name, else_output_values)
+            if_graph.branches_outputs.append((name, else_output_index))
 
         return if_graph_idx
 

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -2402,7 +2402,14 @@ def _(state: CodegenState) -> list[object]:
     if_ast_node = create(ast.If, test=test, body=if_body_stmts, orelse=else_body_stmts)
     state.add_statement(if_ast_node)
 
-    return if_outputs + else_outputs
+    if_return_names, else_return_names = graph_info.get_branches_return_names(
+        state, if_outputs, else_outputs
+    )
+    return cast(
+        "list[object]",
+        [expr_from_string(n) for n in if_return_names]
+        + [expr_from_string(n) for n in else_return_names],
+    )
 
 
 # Note we can't DCE phi nodes because there may be a loop carry dependency not captured in the outer graph

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1556,7 +1556,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             num_stages=3,
         )
 
-    @xfailIfPallas("InductorLoweringError")
     def test_jsd(self):
         args = (
             torch.randn([1024, 4096], device=DEVICE, dtype=torch.float32).log_softmax(

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -2610,6 +2610,85 @@ class TestPallas(TestCase):
             ref[i] = (x[s:e] @ y[s:e].T).sum()
         torch.testing.assert_close(result, ref, rtol=1e-2, atol=1e-2)
 
+    def test_if_branch_intermediate_outputs(self) -> None:
+        """Branch intermediates must survive in _if output list."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def if_with_intermediate(x: torch.Tensor, flag: float) -> torch.Tensor:
+            n, m = x.shape
+            block_n = hl.register_block_size(n)
+            block_m = hl.register_block_size(m)
+            out = torch.empty([n], device=x.device, dtype=torch.float32)
+            for tile_n in hl.tile(n, block_size=block_n):
+                acc = hl.zeros([tile_n, block_m], dtype=torch.float32)
+                for tile_m in hl.tile(m, block_size=block_m):
+                    v = x[tile_n, tile_m]
+                    if flag == 0.0:
+                        doubled = v * 2
+                        acc += doubled + 1
+                    else:
+                        acc += v
+                out[tile_n] = torch.sum(acc, dim=1)
+            return out
+
+        x = torch.randn(64, 64, device=DEVICE, dtype=torch.float32)
+
+        # else-branch
+        code, result = code_and_output(
+            if_with_intermediate,
+            (x, 0.5),
+            block_sizes=[1, 64],
+        )
+        self.assertIn("lax.cond", code)
+        torch.testing.assert_close(result, torch.sum(x, dim=1))
+
+        # if-branch
+        _, result = code_and_output(
+            if_with_intermediate,
+            (x, 0.0),
+            block_sizes=[1, 64],
+        )
+        torch.testing.assert_close(result, torch.sum(x * 2 + 1, dim=1))
+
+    def test_branch_nonlocal_write(self) -> None:
+        """Branch intermediates must survive in _if output list."""
+
+        @helion.kernel(backend="pallas", static_shapes=True, print_output_code=True)
+        def fn(x: torch.Tensor, flag: float, coeffs: torch.Tensor) -> torch.Tensor:
+            (n,) = x.shape
+            block_n = hl.register_block_size(n)
+            out = torch.empty([n], device=x.device, dtype=torch.float32)
+            for tile_n in hl.tile(n, block_size=block_n):
+                coeff_a = coeffs[0]
+                coeff_b = coeffs[1]
+                if flag == 1.0:
+                    coeff_a = coeffs[2]
+                    coeff_new = coeffs[3]
+                else:
+                    coeff_b = coeffs[4]
+                    coeff_new = coeffs[5]
+                out[tile_n] = x[tile_n] * coeff_a * coeff_b * coeff_new
+            return out
+
+        x = torch.ones(64, device=DEVICE, dtype=torch.float32)
+        coeffs = torch.arange(6, device=DEVICE, dtype=torch.float32)
+
+        # if-branch
+        code, result = code_and_output(
+            fn,
+            (x, 1.0, coeffs),
+            block_sizes=[64],
+        )
+        torch.testing.assert_close(result, x * coeffs[2] * coeffs[1] * coeffs[3])
+
+        # else-branch
+        code, result = code_and_output(
+            fn,
+            (x, 0.0, coeffs),
+            block_sizes=[64],
+        )
+        torch.testing.assert_close(result, x * coeffs[0] * coeffs[4] * coeffs[5])
+
 
 @skipUnlessPallas("JAX/Pallas TPU not available")
 class TestPallasIndirectGather(TestCase):


### PR DESCRIPTION
This is an alternative fix to #2399. 

Currently, the outputs of the traced `if` subgraph is "all outputs in if" + "all outputs in else". This is problematic because we also include local variables added in `if` but not in `else` (or vice versa). As an example, in the branch
```
                    if flag == 0.0:
                        doubled = v * 2
                        acc += doubled + 1
                    else:
                        acc += v
```
The existing logic would include the outputs `[double, acc (from if), acc (from else)]`.  This is problematic for backends that cannot directly use Python's if-else syntax, for example Pallas's `lax.cond` which requires explicitly managing control-flow carrying. 

This fix in this PR is to explicit set the output values if the if-subgraph to be `if_common_outputs + if_nonlocal_outputs + else_common_outputs + else_nonlocal_outputs`. In otherwise, we remove outputs that are local to only one of the branches, which cannot be safely referenced outside the branch anyways.

(this should've been done as part of #1935, but i missed it).

This fixes the `jsd` test on Pallas