### PR TITLE
[Pallas] Add FP8 dtype mappings to torch-to-JAX table

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1045,6 +1045,11 @@ _TORCH_TO_JAX_DTYPE: dict[str, str] = {
     "torch.bool": "jnp.bool_",
     "torch.complex64": "jnp.complex64",
     "torch.complex128": "jnp.complex128",
+    "torch.float8_e4m3fn": "jnp.float8_e4m3fn",
+    "torch.float8_e4m3fnuz": "jnp.float8_e4m3fnuz",
+    "torch.float8_e5m2": "jnp.float8_e5m2",
+    "torch.float8_e5m2fnuz": "jnp.float8_e5m2fnuz",
+    "torch.float8_e8m0fnu": "jnp.float8_e8m0fnu",
 }
 
 


### PR DESCRIPTION
The Pallas backend dtype table was missing all float8 types, causing KeyError when compiling kernels that use FP8 tensors.