### PR TITLE
[Pallas] Add Pallas interpret CI job (revival of #1938)

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -153,7 +153,7 @@
       "runner": "linux.2xlarge",
       "python-version": "3.12",
       "ref-eager": false,
-      "image": "",
+      "image": "ubuntu:24.04",
       "runtime-version": "cpu",
       "container-options": "",
       "pytorch-version": "pytorch-nightly",

--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -148,6 +148,17 @@
       "pytorch-version": "pytorch-2.9",
       "alias": "m2-metal",
       "backend": "metal"
+    },
+    {
+      "runner": "linux.2xlarge",
+      "python-version": "3.12",
+      "ref-eager": false,
+      "image": "",
+      "runtime-version": "cpu",
+      "container-options": "",
+      "pytorch-version": "pytorch-nightly",
+      "alias": "pallas-interpret",
+      "backend": "pallas"
     }
   ]
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,6 +229,12 @@ jobs:
           # Verify
           python -c "from torch_tpu import api; print(f'TPU device: {api.tpu_device()}')"
 
+      - name: Install Pallas interpret dependencies
+        if: matrix.alias == 'pallas-interpret'
+        run: |
+          source .venv/bin/activate
+          uv pip install 'jax==0.10.0' 'jaxlib==0.10.0' 'absl-py'
+
       - name: Install CUTLASS CuTe DSL
         if: matrix.backend == 'cute'
         run: |
@@ -310,6 +316,7 @@ jobs:
           if [[ "${{ matrix.expecttest-accept }}" == "true" ]]; then export EXPECTTEST_ACCEPT=1; fi
           if [[ "${{ matrix.ref-eager }}" == "true" ]]; then export HELION_INTERPRET=1; fi
           if [[ "${{ matrix.backend }}" == "tileir" ]]; then export ENABLE_TILE=1; fi
+          if [[ "${{ matrix.alias }}" == "pallas-interpret" ]]; then export HELION_PALLAS_INTERPRET=1; fi
           export HELION_BACKEND=${{ matrix.backend }}
           # Disable TorchTPU build cache to prevent running out of disk space.
           export TORCH_TPU_INTERNAL_TIER2_COMPILATION_CACHE=disabled
@@ -319,7 +326,7 @@ jobs:
           if [[ "${{ contains(matrix.alias, 'distributed') }}" == "true" ]]; then
             TEST_PATH="test/test_examples_dist.py"
             EXTRA_FLAGS="-rs"
-          elif [[ "${{ matrix.alias }}" == "tpu" || "$HELION_BACKEND" == "metal" ]]; then
+          elif [[ "${{ matrix.alias }}" == "tpu" || "${{ matrix.alias }}" == "pallas-interpret" || "$HELION_BACKEND" == "metal" ]]; then
             TEST_PATH="."
             EXTRA_FLAGS="--ignore=test/test_examples_dist.py"
             PARALLEL=""

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -345,7 +345,13 @@ jobs:
           if [[ "${{ matrix.alias }}" == *xpu* ]]; then
             export TRITON_XPU_GEN_NATIVE_CODE=1
           fi
-          pytest $PARALLEL -rf --timeout=60 --reruns=2 --timeout-method=thread $EXTRA_FLAGS $TEST_PATH | tee >(eval $SKIP_CHECK)
+          # Pallas interpret runs on CPU (no parallelism) and is much slower
+          # than TPU/Triton — bump the per-test timeout accordingly.
+          TIMEOUT=60
+          if [[ "${{ matrix.alias }}" == "pallas-interpret" ]]; then
+            TIMEOUT=300
+          fi
+          pytest $PARALLEL -rf --timeout=$TIMEOUT --reruns=2 --timeout-method=thread $EXTRA_FLAGS $TEST_PATH | tee >(eval $SKIP_CHECK)
 
   test-notebooks:
     name: test-notebooks-cu128-py3.12-pytorch-2.9-a10g

--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -208,6 +208,8 @@ class _OutputCapture:
 
 def is_cuda() -> bool:
     """Return True if running on CUDA (NVIDIA GPU)."""
+    if _get_backend() == "pallas":
+        return False
     return _get_triton_backend() == "cuda" and torch.cuda.is_available()
 
 
@@ -301,8 +303,15 @@ def skipIfPallas(reason: str) -> Callable[[Callable], Callable]:
 
 
 def xfailIfPallas(reason: str) -> Callable[[Callable], Callable]:
-    """Mark test as expected failure if running with pallas"""
+    """Mark test as expected failure if running with pallas (TPU or interpret mode)"""
     return xfailIfFn(lambda: _get_backend() == "pallas", reason)
+
+
+def xfailIfPallasInterpret(reason: str) -> Callable[[Callable], Callable]:
+    """Mark test as expected failure only in Pallas interpret mode (passes on real TPU)."""
+    return xfailIfFn(
+        lambda: _get_backend() == "pallas" and is_pallas_interpret(), reason
+    )
 
 
 def skipUnlessAMDCDNA(reason: str) -> Callable[[Callable], Callable]:
@@ -410,7 +419,7 @@ def onlyBackends(
 def skipUnlessTensorDescriptor(reason: str) -> Callable[[Callable], Callable]:
     """Skip test unless tensor descriptors are supported."""
     # Defers check to test execution time to avoid CUDA init during pytest-xdist collection.
-    return skipIfFn(lambda: not supports_tensor_descriptor(), reason)
+    return skipIfFn(lambda: not is_cuda() or not supports_tensor_descriptor(), reason)
 
 
 def skipUnlessTf32Supported(

--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -307,9 +307,16 @@ def xfailIfPallas(reason: str) -> Callable[[Callable], Callable]:
     return xfailIfFn(lambda: _get_backend() == "pallas", reason)
 
 
-def xfailIfPallasInterpret(reason: str) -> Callable[[Callable], Callable]:
-    """Mark test as expected failure only in Pallas interpret mode (passes on real TPU)."""
+def xfailIfPallasTpu(reason: str) -> Callable[[Callable], Callable]:
+    """Mark test as expected failure only on real Pallas TPU (passes in interpret mode)."""
     return xfailIfFn(
+        lambda: _get_backend() == "pallas" and not is_pallas_interpret(), reason
+    )
+
+
+def skipIfPallasInterpret(reason: str) -> Callable[[Callable], Callable]:
+    """Skip test in Pallas interpret mode (e.g. tests of TPU-only behavior)."""
+    return skipIfFn(
         lambda: _get_backend() == "pallas" and is_pallas_interpret(), reason
     )
 

--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -314,6 +314,13 @@ def xfailIfPallasTpu(reason: str) -> Callable[[Callable], Callable]:
     )
 
 
+def xfailIfPallasInterpret(reason: str) -> Callable[[Callable], Callable]:
+    """Mark test as expected failure only in Pallas interpret mode (passes on real TPU)."""
+    return xfailIfFn(
+        lambda: _get_backend() == "pallas" and is_pallas_interpret(), reason
+    )
+
+
 def skipIfPallasInterpret(reason: str) -> Callable[[Callable], Callable]:
     """Skip test in Pallas interpret mode (e.g. tests of TPU-only behavior)."""
     return skipIfFn(

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -1385,20 +1385,17 @@ def default_pallas_fori_launcher(
 
 
 def _torch_to_jax(t: torch.Tensor) -> object:
-    """Convert a torch.Tensor to a JAX array via numpy (for interpret mode on CPU)."""
+    """Convert a torch.Tensor to a JAX array via DLPack (for interpret mode on CPU)."""
     import jax.numpy as jnp
-    import numpy as np
 
-    return jnp.array(np.asarray(t.detach().cpu()))
+    return jnp.from_dlpack(t.detach().cpu())
 
 
 def _jax_to_torch(
     arr: object, *, device: torch.device, dtype: torch.dtype
 ) -> torch.Tensor:
-    """Convert a JAX array back to a torch.Tensor via numpy (for interpret mode on CPU)."""
-    import numpy as np
-
-    return torch.from_numpy(np.asarray(arr)).to(dtype=dtype, device=device)
+    """Convert a JAX array back to a torch.Tensor via DLPack (for interpret mode on CPU)."""
+    return torch.from_dlpack(arr).to(dtype=dtype, device=device)
 
 
 def _torch_dtype_to_cutlass(dtype: torch.dtype) -> object:

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -36,6 +36,7 @@ from helion._testing import skipIfTileIR
 from helion._testing import skipIfXPU
 from helion._testing import xfailIfCute
 from helion._testing import xfailIfPallas
+from helion._testing import xfailIfPallasTpu
 from helion.runtime.config import Config
 from helion.runtime.ref_mode import is_ref_mode_enabled
 
@@ -2298,7 +2299,7 @@ class TestExamples(RefEagerTestBase, TestCase):
         )
 
     @xfailIfCute("CuTe GDN forward example still fails CUTLASS DSL codegen")
-    @xfailIfPallas("operation not supported on TPU")
+    @xfailIfPallasTpu("operation not supported on TPU")
     def test_gdn_fwd_h(self):
         """Test gated delta net forward h kernel."""
         batch = 2

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -36,6 +36,7 @@ from helion._testing import skipIfTileIR
 from helion._testing import skipIfXPU
 from helion._testing import xfailIfCute
 from helion._testing import xfailIfPallas
+from helion._testing import xfailIfPallasInterpret
 from helion._testing import xfailIfPallasTpu
 from helion.runtime.config import Config
 from helion.runtime.ref_mode import is_ref_mode_enabled
@@ -1557,6 +1558,9 @@ class TestExamples(RefEagerTestBase, TestCase):
             num_stages=3,
         )
 
+    @xfailIfPallasInterpret(
+        "JAX interpret cannot trace dynamic shapes (TypeError: JitTracer ~int32[])"
+    )
     def test_jsd(self):
         args = (
             torch.randn([1024, 4096], device=DEVICE, dtype=torch.float32).log_softmax(
@@ -1582,6 +1586,9 @@ class TestExamples(RefEagerTestBase, TestCase):
             num_stages=3,
         )
 
+    @xfailIfPallasInterpret(
+        "JAX interpret cannot trace dynamic shapes (TypeError: JitTracer ~int32[])"
+    )
     def test_kl_div(self):
         if _get_backend() == "cute" and "B200" in get_nvidia_gpu_model():
             pytest.xfail("CuTe KL-div example still launches out of resources on B200")
@@ -1937,6 +1944,7 @@ class TestExamples(RefEagerTestBase, TestCase):
         131072, reason="block sizes exceed device shared memory limit"
     )
     @skipIfXPU("Squeeze-and-excitation network not supported on XPU")
+    @xfailIfPallasInterpret("numerical mismatch in JAX interpret mode")
     def test_squeeze_and_excitation_net_fwd(self):
         m, n, k = 128, 128, 128
         x = torch.randn([m, n], device=DEVICE, dtype=torch.float32)
@@ -2404,7 +2412,7 @@ class TestExamples(RefEagerTestBase, TestCase):
         lambda: _get_backend() == "cute",
         "CuTe Mamba2 chunk-state destabilizes later cute tests when it fails in-process",
     )
-    @xfailIfPallas(
+    @xfailIfPallasTpu(
         "dA_cumsum has mixed scalar+slice access (VMEM), but Mosaic requires 32-bit for VMEM scalar extracts"
     )
     def test_mamba2_chunk_state(self):

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -16,6 +16,8 @@ from helion._testing import skipIfMetal
 from helion._testing import skipIfXPU
 from helion._testing import skipUnlessTensorDescriptor
 from helion._testing import xfailIfPallas
+from helion._testing import xfailIfPallasInterpret
+from helion._testing import xfailIfPallasTpu
 import helion.language as hl
 
 
@@ -166,6 +168,7 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(grid_2d_idx_nested, args)
         torch.testing.assert_close(result, grid_2d_pytorch(args[0], args[1]))
 
+    @xfailIfPallasInterpret("numerical mismatch in JAX interpret mode")
     def test_grid_begin_end(self):
         @helion.kernel(autotune_effort="none")
         def grid_begin_end(x: torch.Tensor) -> torch.Tensor:
@@ -228,6 +231,7 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(grid_end_step_kwarg, (x,))
         torch.testing.assert_close(result, grid_end_step_kwarg_pytorch(x))
 
+    @xfailIfPallasInterpret("numerical mismatch in JAX interpret mode")
     def test_grid_multidim_begin_end(self):
         @helion.kernel(autotune_effort="none")
         def grid_multidim_begin_end(x: torch.Tensor) -> torch.Tensor:
@@ -275,7 +279,7 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(grid_multidim_begin_end_step, (x,))
         torch.testing.assert_close(result, grid_multidim_begin_end_step_pytorch(x))
 
-    @xfailIfPallas("Tile begin/end not working on Pallas")
+    @xfailIfPallasTpu("Tile begin/end not working on Pallas TPU")
     def test_tile_begin_end(self):
         @helion.kernel(autotune_effort="none")
         def tile_begin_end(x: torch.Tensor) -> torch.Tensor:

--- a/test/test_loops.py
+++ b/test/test_loops.py
@@ -32,6 +32,8 @@ from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
 from helion._testing import skipIfXPU
 from helion._testing import xfailIfPallas
+from helion._testing import xfailIfPallasInterpret
+from helion._testing import xfailIfPallasTpu
 import helion.language as hl
 
 datadir = Path(__file__).parent / "data"
@@ -218,7 +220,7 @@ class TestLoops(RefEagerTestBase, TestCase):
         )
         torch.testing.assert_close(result, torch.sin(args[0]))
 
-    @xfailIfPallas("uses Triton-specific config options (block_ptr, pid_type)")
+    @xfailIfPallasTpu("uses Triton-specific config options (block_ptr, pid_type)")
     def test_flattened_tile_with_unit_axis(self):
         @helion.kernel(
             config=helion.Config(
@@ -251,7 +253,7 @@ class TestLoops(RefEagerTestBase, TestCase):
 
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
     @skipIfTileIR("TileIR does not support block_ptr indexing")
-    @xfailIfPallas(
+    @xfailIfPallasTpu(
         "emit_pipeline + block_ptr indexing fails Mosaic alignment proof "
         "on the trailing 16-block dim (E2003)"
     )
@@ -290,6 +292,7 @@ class TestLoops(RefEagerTestBase, TestCase):
         )
         torch.testing.assert_close(result, torch.sin(args[0]))
 
+    @xfailIfPallasInterpret("numerical mismatch in JAX interpret mode")
     def test_three_level_matmul(self):
         @helion.kernel(static_shapes=True)
         def matmul(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
@@ -1296,6 +1299,10 @@ class TestLoops(RefEagerTestBase, TestCase):
         expected = x + fill_value[0]
         torch.testing.assert_close(result, expected)
 
+    @xfailIfPallasInterpret(
+        "JAX MLIR translation rule for primitive 'program_id' is not implemented "
+        "for the CPU platform"
+    )
     def test_nested_loop_accumulator(self):
         """Test variable scoping with nested loops and accumulator pattern."""
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1179,9 +1179,6 @@ class TestPallas(TestCase):
         ref = ref_outer_chain_scale(a, b)
         torch.testing.assert_close(result, ref, rtol=1e-2, atol=1e-2)
 
-    @xfailIfPallasInterpret(
-        "JAX interpret mode cannot discharge dynamic_slice with traced sizes",
-    )
     def test_attention_emit_pipeline_non_divisible(self) -> None:
         """Test emit_pipeline with seq_kv not divisible by block_k.
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -13,6 +13,8 @@ from helion._testing import code_and_output
 from helion._testing import onlyBackends
 from helion._testing import skipUnlessPallas
 from helion._testing import xfailIfPallas
+from helion._testing import xfailIfPallasInterpret
+from helion._testing import xfailIfPallasTpu
 import helion.language as hl
 
 
@@ -470,7 +472,12 @@ class TestPallas(TestCase):
             if "Ran out of memory in memory space vmem" in str(e):
                 self.fail(f"bfloat16 incorrectly threw VMEM OOM: {e}")
 
-        # Test 3: float8_e4m3fn (1 byte per element)
+    @xfailIfPallasInterpret(
+        "torch.float8_e4m3fn has no JAX dtype mapping in interpret mode; "
+        "conversion errors before the VMEM check fires"
+    )
+    def test_estimate_pallas_vmem_bytes_fp8(self) -> None:
+        """VMEM OOM at fp8 (1 byte/element)."""
         # 3 tensors * 4096 * 8192 * 1 byte * 2 (multiplier) = ~201.3MB (OOM)
         args_fp8 = (
             torch.randn(4096, 8192, device=DEVICE, dtype=torch.float32).to(
@@ -1299,6 +1306,7 @@ class TestPallas(TestCase):
         result = fn(x)
         torch.testing.assert_close(result, x)
 
+    @xfailIfPallasInterpret("numerical mismatch in JAX interpret mode")
     def test_scalar_access_2D_constexpr(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True, config=helion.Config())
         def fn(x: torch.Tensor) -> torch.Tensor:
@@ -1340,6 +1348,7 @@ class TestPallas(TestCase):
         expected = x.permute(0, 2, 1)
         torch.testing.assert_close(result, expected)
 
+    @xfailIfPallasInterpret("numerical mismatch in JAX interpret mode")
     def test_tile_index_with_symbolic_offset(self) -> None:
         """tile.index + tile.begin * constant should codegen valid variable names.
 
@@ -1361,6 +1370,7 @@ class TestPallas(TestCase):
         # pl.multiple_of hint should NOT be applied to offset expressions
         self.assertNotIn("pl.multiple_of(", code)
 
+    @xfailIfPallasInterpret("numerical mismatch in JAX interpret mode")
     def test_tile_index_with_symbolic_offset_emit_pipeline(self) -> None:
         """Same kernel under pallas_loop_type='emit_pipeline'.
 
@@ -1425,7 +1435,7 @@ class TestPallas(TestCase):
         expected = x + x[:, -1:]
         torch.testing.assert_close(result, expected)
 
-    @xfailIfPallas(
+    @xfailIfPallasTpu(
         "Mixed scalar write + slice needs tensor duplication into SMEM and VMEM"
     )
     def test_mixed_scalar_write_and_slice_access(self) -> None:
@@ -1518,7 +1528,7 @@ class TestPallas(TestCase):
         expected = x + 0.5
         torch.testing.assert_close(result, expected)
 
-    @xfailIfPallas("Pallas backend not correctly handling tile index with offset")
+    @xfailIfPallasTpu("Pallas TPU not correctly handling tile index with offset")
     def test_tensor_access_tile_index_offset(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def fn(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
@@ -1854,6 +1864,9 @@ class TestPallas(TestCase):
         ref = x.view(8, 8, 384).sum(1)
         torch.testing.assert_close(result, ref, rtol=1e-3, atol=1e-3)
 
+    @xfailIfPallasInterpret(
+        "JAX interpret cannot trace dynamic shapes (TypeError: JitTracer ~int32[])"
+    )
     def test_emit_pipeline_per_tensor_pipelined_mixed(self) -> None:
         """An emit_pipeline body can mix pipelined and non-pipelined tensors.
 
@@ -2502,6 +2515,7 @@ class TestPallas(TestCase):
         )
         torch.testing.assert_close(result, ref, rtol=1e-3, atol=1e-3)
 
+    @xfailIfPallasInterpret("numerical mismatch in JAX interpret mode")
     def test_dma_buffer_offset_nested_tile(self) -> None:
         """Inner loop reading outer-tiled tensor must use ':' not absolute offset."""
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1179,6 +1179,9 @@ class TestPallas(TestCase):
         ref = ref_outer_chain_scale(a, b)
         torch.testing.assert_close(result, ref, rtol=1e-2, atol=1e-2)
 
+    @xfailIfPallasInterpret(
+        "JAX interpret mode cannot discharge dynamic_slice with traced sizes",
+    )
     def test_attention_emit_pipeline_non_divisible(self) -> None:
         """Test emit_pipeline with seq_kv not divisible by block_k.
 

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -21,6 +21,7 @@ from helion._testing import skipIfTileIR
 from helion._testing import skipUnlessTensorDescriptor
 from helion._testing import xfailIfCute
 from helion._testing import xfailIfPallas
+from helion._testing import xfailIfPallasTpu
 import helion.language as hl
 
 if TYPE_CHECKING:
@@ -452,7 +453,7 @@ class TestReductions(RefEagerTestBase, TestCase):
         )
         torch.testing.assert_close(result1, result2, rtol=1e-3, atol=1e-3)
 
-    @xfailIfPallas("fp16/bf16 1D tensors hit TPU Mosaic sublane alignment error")
+    @xfailIfPallasTpu("fp16/bf16 1D tensors hit TPU Mosaic sublane alignment error")
     @skipIfTileIR("TileIR does not support log1p")
     def test_fp16_math_ops_fp32_fallback(self):
         """Test that mathematical ops with fp16/bfloat16 inputs now work via fp32 fallback."""

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -20,7 +20,6 @@ from helion._testing import skipIfRocm
 from helion._testing import skipIfTileIR
 from helion._testing import skipUnlessTensorDescriptor
 from helion._testing import xfailIfCute
-from helion._testing import xfailIfPallas
 from helion._testing import xfailIfPallasTpu
 import helion.language as hl
 


### PR DESCRIPTION
Adds a CPU-runner CI matrix entry (`pallas-interpret`) that runs the Helion test suite under the Pallas backend in JAX interpret mode (`HELION_PALLAS_INTERPRET=1`), so Pallas-backend changes can be exercised in CI without the self-hosted TPU runner.

- New matrix entry on `linux.2xlarge` inside a `ubuntu:24.04` container, with `jax==0.10.0` / `jaxlib==0.10.0` installed via pip (matching the TPU job's pin).
- Workflow gating: installs JAX only when `alias == 'pallas-interpret'`, exports `HELION_PALLAS_INTERPRET=1`, and routes to the same `TEST_PATH=.` / single-process branch the `tpu` and `metal` aliases use. Per-test timeout is bumped to 300s since interpret runs on CPU.
- `is_cuda()` early-returns `False` when the backend is `pallas` — fixes the latent issue where a Pallas job on a host with CUDA visible would have trusted `torch.cuda.is_available()`.
- `skipUnlessTensorDescriptor` gains a `not is_cuda()` guard so it short-circuits on Pallas before calling CUDA-only `supports_tensor_descriptor()`.
- `_torch_to_jax` / `_jax_to_torch` switch from a numpy round-trip to DLPack zero-copy.
- New `xfailIfPallasTpu(reason)`, `xfailIfPallasInterpret(reason)`, and `skipIfPallasInterpret(reason)` decorators for asymmetric cases. A handful of existing `xfailIfPallas` markers are retagged to `xfailIfPallasTpu` for tests that pass on interpret, and a small set of genuinely interpret-only failures get `xfailIfPallasInterpret` markers (JAX tracer limitations, MLIR `program_id` on CPU, etc.).

Credit: revives #1938 (@v0i0).
