### PR TITLE
Disable rope-bwd from nightly perf CI for now

### DIFF
--- a/.github/workflows/benchmark_dispatch.yml
+++ b/.github/workflows/benchmark_dispatch.yml
@@ -34,7 +34,12 @@ on:
         type: string
         # Ordered to balance B200 runtime under compute-benchmark-matrix's
         # round-robin sharding with max-runners=13.
-        default: "flash_attention,gdn_fwd_h,cross_entropy,grouped_gemm,gemm,welford,layer_norm-bwd,int4_gemm,softmax,layer_norm,mamba2_chunk_state,rms_norm-bwd,rope,rope-bwd,jsd,mamba2_chunk_scan,kl_div,rms_norm"
+        # rope-bwd temporarily removed: autotune trips Triton's
+        # LinearLayout::reshapeOuts assertion on H100/B200/MI350X and aborts
+        # the parent process, producing Shape Failures for every shape. Re-add
+        # once #2531 (compile-phase subprocess isolation) lands or the upstream
+        # Triton bug is fixed. Forward `rope` stays in the list.
+        default: "flash_attention,gdn_fwd_h,cross_entropy,grouped_gemm,gemm,welford,layer_norm-bwd,int4_gemm,softmax,layer_norm,mamba2_chunk_state,rms_norm-bwd,rope,jsd,mamba2_chunk_scan,kl_div,rms_norm"
       kernels_tpu:
         description: 'Comma-separated list of kernels to benchmark on TPU (examples-based; disjoint from `kernels`). Default is the dashboard-tracked subset; pass an explicit list, or `all` to run every kernel registered in benchmarks/run_tpu.py::KERNEL_MAPPINGS.'
         required: false


### PR DESCRIPTION
rope-bwd autotune trips Triton's LinearLayout::reshapeOuts assertion on H100, B200, and MI350X. The C++ abort kills the parent autotune process before any other config can be tried, so every rope-bwd shape is reported as a Shape Failure on the perf-CI dashboard.

Drop rope-bwd from the workflow default until #2531 (compile-phase subprocess isolation) lands or the upstream Triton bug is fixed. Forward rope stays in the list.