### PR TITLE
[Pallas] Run each TPU benchmark shape in its own subprocess

### DIFF
--- a/.github/workflows/benchmark_tpu.yml
+++ b/.github/workflows/benchmark_tpu.yml
@@ -141,6 +141,7 @@ jobs:
             python benchmarks/run_tpu.py \
               "${KERNEL_FLAG[@]}" \
               --num-shapes 2 \
+              --subprocess-per-shape \
               --output "$TEST_REPORTS_DIR/helionbench.json"
 
           if [[ ! -s "$TEST_REPORTS_DIR/helionbench.json" ]]; then

--- a/benchmarks/run_tpu.py
+++ b/benchmarks/run_tpu.py
@@ -1249,7 +1249,7 @@ def _print_hbm_probe(label: str) -> None:
         import jax
 
         stats = jax.devices()[0].memory_stats()
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         print(f"  [hbm-probe@{label}] unavailable: {e}", file=sys.stderr)
         return
     in_use = stats.get("bytes_in_use", -1)
@@ -1298,7 +1298,7 @@ def run_kernel_inner(name: str) -> KernelResult:
         # fresh TPU device with no accumulated libtpu allocator state. The
         # child is invoked with --shape-index=N to restrict its work.
         if SHAPE_INDEX is not None:
-            if SHAPE_INDEX >= len(shapes):
+            if len(shapes) <= SHAPE_INDEX:
                 return KernelResult(
                     name=name,
                     passed=False,

--- a/benchmarks/run_tpu.py
+++ b/benchmarks/run_tpu.py
@@ -1166,6 +1166,11 @@ def _run_kernel_per_shape(name: str) -> KernelResult:
     all_passed = True
     accuracy_verified = True
     error_msg: str | None = None
+    # Safety cap: no kernel in KERNEL_MAPPINGS has > 8 shapes today. The
+    # cap protects against a child failing to even reach the shape-index
+    # bound check (e.g., env misconfig where shapes_fn itself crashes) —
+    # without it, parent would iterate forever.
+    MAX_SHAPES_PER_KERNEL = 20
     idx = 0
     while True:
         print(f"  [subprocess shape {idx}]", file=sys.stderr)
@@ -1179,9 +1184,16 @@ def _run_kernel_per_shape(name: str) -> KernelResult:
             all_passed = False
             if result.error and not error_msg:
                 error_msg = result.error
+            # If the child failed without producing any shape_results, the
+            # failure is at bootstrap (not in autotune); iterating further
+            # will hit the same error. Bail out.
+            if not result.shape_results:
+                break
         accuracy_verified = accuracy_verified and result.accuracy_verified
         idx += 1
         if NUM_SHAPES is not None and idx >= NUM_SHAPES:
+            break
+        if idx >= MAX_SHAPES_PER_KERNEL:
             break
     return KernelResult(
         name=name,

--- a/benchmarks/run_tpu.py
+++ b/benchmarks/run_tpu.py
@@ -1079,6 +1079,30 @@ def _kernel_shape_count(name: str) -> int | None:
     return len(shapes_fn(NUM_SHAPES))
 
 
+_LIBTPU_LOCKFILE = "/tmp/libtpu_lockfile"
+
+
+def _wait_for_tpu_release(timeout_s: float = 30.0, poll_s: float = 0.25) -> None:
+    """Block until the previous subprocess fully releases the TPU.
+
+    libtpu creates `/tmp/libtpu_lockfile` while a process holds the device.
+    When the process exits the file is removed, but the underlying
+    `/dev/vfio/<chip>` iommu group can stay busy for a moment longer.
+    Without this gate, the next subprocess hits `FAILED_PRECONDITION: open(
+    /dev/vfio/N): Device or resource busy`. Polls the lockfile + adds a
+    small slack to cover the OS-level iommu release. Times out silently —
+    the caller still tries to spawn and will get a clear error if the
+    device truly stays busy.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if not os.path.exists(_LIBTPU_LOCKFILE):
+            break
+        time.sleep(poll_s)
+    # Small slack after lockfile clears so vfio/iommu finishes teardown.
+    time.sleep(1.0)
+
+
 def _run_one_shape_via_subprocess(name: str, shape_index: int | None) -> KernelResult:
     """Spawn a child `run_tpu.py` invocation for one (kernel, shape) pair.
 
@@ -1087,12 +1111,20 @@ def _run_one_shape_via_subprocess(name: str, shape_index: int | None) -> KernelR
     (and to GH Actions). A non-zero exit code is folded into a FAIL result so a
     crashed shape doesn't abort the whole sweep.
     """
+    _wait_for_tpu_release()
     with tempfile.NamedTemporaryFile(
         prefix="run_tpu_result_", suffix=".json", delete=False, mode="w"
     ) as tmp:
         tmp_path = tmp.name
     try:
-        cmd = [sys.executable, __file__, "--kernel", name, "--intermediate-result", tmp_path]
+        cmd = [
+            sys.executable,
+            __file__,
+            "--kernel",
+            name,
+            "--intermediate-result",
+            tmp_path,
+        ]
         if NUM_SHAPES is not None:
             cmd += ["--num-shapes", str(NUM_SHAPES)]
         if shape_index is not None:

--- a/benchmarks/run_tpu.py
+++ b/benchmarks/run_tpu.py
@@ -1037,6 +1037,9 @@ class KernelResult:
     # was no real numerical check, so we drop helion_accuracy from the dashboard
     # JSON instead of falsely reporting 1.0.
     accuracy_verified: bool = True
+    # Set by the child when --shape-index walks past the end of shapes_fn's
+    # list, so the parent can stop iterating without parsing the error string.
+    shape_index_out_of_range: bool = False
 
 
 def import_example(module_file: str) -> types.ModuleType:
@@ -1129,7 +1132,27 @@ def _run_one_shape_via_subprocess(name: str, shape_index: int | None) -> KernelR
             cmd += ["--num-shapes", str(NUM_SHAPES)]
         if shape_index is not None:
             cmd += ["--shape-index", str(shape_index)]
-        proc = subprocess.run(cmd, env=os.environ.copy(), check=False)
+        # Parent-side hard cap. The child also installs SIGALRM at KERNEL_TIMEOUT;
+        # the extra slack covers child startup + autotune ramp-up + SIGALRM cleanup.
+        # If the child wedges before its own alarm fires (e.g., stuck on a TPU
+        # lockfile), this prevents the parent from hanging indefinitely.
+        subprocess_timeout = KERNEL_TIMEOUT + 120
+        try:
+            proc = subprocess.run(
+                cmd,
+                env=os.environ.copy(),
+                check=False,
+                timeout=subprocess_timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return KernelResult(
+                name=name,
+                passed=False,
+                error=(
+                    f"Subprocess exceeded parent timeout of {subprocess_timeout}s "
+                    f"(KERNEL_TIMEOUT={KERNEL_TIMEOUT}s + 120s slack)"
+                ),
+            )
         if proc.returncode != 0 or not os.path.exists(tmp_path):
             return KernelResult(
                 name=name,
@@ -1146,6 +1169,7 @@ def _run_one_shape_via_subprocess(name: str, shape_index: int | None) -> KernelR
             error=payload.get("error"),
             shape_results=shape_results,
             accuracy_verified=payload.get("accuracy_verified", True),
+            shape_index_out_of_range=payload.get("shape_index_out_of_range", False),
         )
     finally:
         if os.path.exists(tmp_path):
@@ -1156,7 +1180,7 @@ def _run_kernel_per_shape(name: str) -> KernelResult:
     """Orchestrate per-shape subprocesses for one kernel, merge into one result.
 
     Walks shape indices 0, 1, 2, ... by spawning one child per index. Stops
-    when a child returns an error matching ``--shape-index=N out of range``.
+    when a child sets ``shape_index_out_of_range=True`` in its KernelResult.
     Doing it this way avoids the parent calling ``shapes_fn`` (which would
     allocate `device=DEVICE` tensors and lock the TPU for the children).
     """
@@ -1175,7 +1199,7 @@ def _run_kernel_per_shape(name: str) -> KernelResult:
     while True:
         print(f"  [subprocess shape {idx}]", file=sys.stderr)
         result = _run_one_shape_via_subprocess(name, shape_index=idx)
-        if result.error and "out of range" in result.error:
+        if result.shape_index_out_of_range:
             # Sentinel: we've walked off the end of shapes_fn's list.
             break
         if result.shape_results:
@@ -1303,6 +1327,7 @@ def run_kernel_inner(name: str) -> KernelResult:
                     name=name,
                     passed=False,
                     error=f"--shape-index={SHAPE_INDEX} out of range (have {len(shapes)} shapes)",
+                    shape_index_out_of_range=True,
                 )
             shapes = [shapes[SHAPE_INDEX]]
         _print_hbm_probe("post-shape-alloc")

--- a/benchmarks/run_tpu.py
+++ b/benchmarks/run_tpu.py
@@ -1064,19 +1064,19 @@ def _alarm_handler(signum: int, frame: object) -> None:
     raise _KernelTimeout
 
 
-def _kernel_shape_count(name: str) -> int | None:
-    """Return the number of shapes for `name`, or None for baseline-less kernels.
+def _kernel_is_baseline_less(name: str) -> bool:
+    """Whether `name` runs via `mod.main()` instead of per-shape autotune.
 
-    Used by the subprocess-per-shape orchestrator to enumerate child invocations.
-    Calling the kernel's `shapes_fn` on the parent is safe — it allocates input
-    tensors but those get freed when this function returns.
+    Cheap to evaluate — only inspects KERNEL_MAPPINGS metadata, never calls
+    `shapes_fn`. The orchestrator must NOT call shapes_fn in the parent
+    because it allocates `device=DEVICE` tensors which forces PJRT to grab
+    the TPU lock — subsequent child subprocesses then fail with `open(
+    /dev/vfio/N): Device or resource busy`.
     """
     if name not in KERNEL_MAPPINGS:
-        return None
+        return False
     _, _, baseline_fn, shapes_fn, _ = KERNEL_MAPPINGS[name][:5]
-    if baseline_fn is None or shapes_fn is None:
-        return None
-    return len(shapes_fn(NUM_SHAPES))
+    return baseline_fn is None or shapes_fn is None
 
 
 _LIBTPU_LOCKFILE = "/tmp/libtpu_lockfile"
@@ -1153,20 +1153,26 @@ def _run_one_shape_via_subprocess(name: str, shape_index: int | None) -> KernelR
 
 
 def _run_kernel_per_shape(name: str) -> KernelResult:
-    """Orchestrate per-shape subprocesses for one kernel, merge into one result."""
-    shape_count = _kernel_shape_count(name)
-    if shape_count is None:
-        # Baseline-less kernel (uses mod.main()): a single subprocess covers it.
+    """Orchestrate per-shape subprocesses for one kernel, merge into one result.
+
+    Walks shape indices 0, 1, 2, ... by spawning one child per index. Stops
+    when a child returns an error matching ``--shape-index=N out of range``.
+    Doing it this way avoids the parent calling ``shapes_fn`` (which would
+    allocate `device=DEVICE` tensors and lock the TPU for the children).
+    """
+    if _kernel_is_baseline_less(name):
         return _run_one_shape_via_subprocess(name, shape_index=None)
     merged_shape_results: list[ShapeResult] = []
     all_passed = True
     accuracy_verified = True
     error_msg: str | None = None
-    for idx in range(shape_count):
-        print(
-            f"  [subprocess shape {idx + 1}/{shape_count}]", file=sys.stderr
-        )
+    idx = 0
+    while True:
+        print(f"  [subprocess shape {idx}]", file=sys.stderr)
         result = _run_one_shape_via_subprocess(name, shape_index=idx)
+        if result.error and "out of range" in result.error:
+            # Sentinel: we've walked off the end of shapes_fn's list.
+            break
         if result.shape_results:
             merged_shape_results.extend(result.shape_results)
         if not result.passed:
@@ -1174,6 +1180,9 @@ def _run_kernel_per_shape(name: str) -> KernelResult:
             if result.error and not error_msg:
                 error_msg = result.error
         accuracy_verified = accuracy_verified and result.accuracy_verified
+        idx += 1
+        if NUM_SHAPES is not None and idx >= NUM_SHAPES:
+            break
     return KernelResult(
         name=name,
         passed=all_passed,

--- a/benchmarks/run_tpu.py
+++ b/benchmarks/run_tpu.py
@@ -20,6 +20,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+from dataclasses import asdict
 from dataclasses import dataclass
 from dataclasses import field
 import functools
@@ -28,7 +29,9 @@ import json
 import os
 from pathlib import Path
 import signal
+import subprocess
 import sys
+import tempfile
 import time
 from typing import TYPE_CHECKING
 from typing import Any
@@ -1050,6 +1053,7 @@ def import_example(module_file: str) -> types.ModuleType:
 
 KERNEL_TIMEOUT = int(os.environ.get("HELION_BENCHMARK_KERNEL_TIMEOUT", "1200"))
 NUM_SHAPES: int | None = None  # Set from CLI; None means all shapes
+SHAPE_INDEX: int | None = None  # Set from CLI; restricts the kernel to one shape
 
 
 class _KernelTimeout(Exception):
@@ -1058,6 +1062,93 @@ class _KernelTimeout(Exception):
 
 def _alarm_handler(signum: int, frame: object) -> None:
     raise _KernelTimeout
+
+
+def _kernel_shape_count(name: str) -> int | None:
+    """Return the number of shapes for `name`, or None for baseline-less kernels.
+
+    Used by the subprocess-per-shape orchestrator to enumerate child invocations.
+    Calling the kernel's `shapes_fn` on the parent is safe — it allocates input
+    tensors but those get freed when this function returns.
+    """
+    if name not in KERNEL_MAPPINGS:
+        return None
+    _, _, baseline_fn, shapes_fn, _ = KERNEL_MAPPINGS[name][:5]
+    if baseline_fn is None or shapes_fn is None:
+        return None
+    return len(shapes_fn(NUM_SHAPES))
+
+
+def _run_one_shape_via_subprocess(name: str, shape_index: int | None) -> KernelResult:
+    """Spawn a child `run_tpu.py` invocation for one (kernel, shape) pair.
+
+    The child writes its KernelResult to a temp file via `--intermediate-result`.
+    stdout/stderr are inherited so autotune progress streams to the parent log
+    (and to GH Actions). A non-zero exit code is folded into a FAIL result so a
+    crashed shape doesn't abort the whole sweep.
+    """
+    with tempfile.NamedTemporaryFile(
+        prefix="run_tpu_result_", suffix=".json", delete=False, mode="w"
+    ) as tmp:
+        tmp_path = tmp.name
+    try:
+        cmd = [sys.executable, __file__, "--kernel", name, "--intermediate-result", tmp_path]
+        if NUM_SHAPES is not None:
+            cmd += ["--num-shapes", str(NUM_SHAPES)]
+        if shape_index is not None:
+            cmd += ["--shape-index", str(shape_index)]
+        proc = subprocess.run(cmd, env=os.environ.copy(), check=False)
+        if proc.returncode != 0 or not os.path.exists(tmp_path):
+            return KernelResult(
+                name=name,
+                passed=False,
+                error=f"Subprocess exited with code {proc.returncode}",
+            )
+        with open(tmp_path) as f:
+            payload = json.load(f)
+        shape_results = [ShapeResult(**sr) for sr in payload.get("shape_results", [])]
+        return KernelResult(
+            name=payload["name"],
+            passed=payload["passed"],
+            kernel_time_ms=payload.get("kernel_time_ms", 0.0),
+            error=payload.get("error"),
+            shape_results=shape_results,
+            accuracy_verified=payload.get("accuracy_verified", True),
+        )
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+def _run_kernel_per_shape(name: str) -> KernelResult:
+    """Orchestrate per-shape subprocesses for one kernel, merge into one result."""
+    shape_count = _kernel_shape_count(name)
+    if shape_count is None:
+        # Baseline-less kernel (uses mod.main()): a single subprocess covers it.
+        return _run_one_shape_via_subprocess(name, shape_index=None)
+    merged_shape_results: list[ShapeResult] = []
+    all_passed = True
+    accuracy_verified = True
+    error_msg: str | None = None
+    for idx in range(shape_count):
+        print(
+            f"  [subprocess shape {idx + 1}/{shape_count}]", file=sys.stderr
+        )
+        result = _run_one_shape_via_subprocess(name, shape_index=idx)
+        if result.shape_results:
+            merged_shape_results.extend(result.shape_results)
+        if not result.passed:
+            all_passed = False
+            if result.error and not error_msg:
+                error_msg = result.error
+        accuracy_verified = accuracy_verified and result.accuracy_verified
+    return KernelResult(
+        name=name,
+        passed=all_passed,
+        error=error_msg,
+        shape_results=merged_shape_results,
+        accuracy_verified=accuracy_verified,
+    )
 
 
 def run_kernel(name: str) -> KernelResult:
@@ -1119,6 +1210,18 @@ def run_kernel_inner(name: str) -> KernelResult:
         # shape on TPU first and only then drop the unused tail, which can
         # OOM during shape construction with --num-shapes 2.
         shapes = shapes_fn(NUM_SHAPES)
+        # In subprocess-per-shape mode, the parent process spawns one child
+        # per (kernel, shape_index) so each autotune session starts on a
+        # fresh TPU device with no accumulated libtpu allocator state. The
+        # child is invoked with --shape-index=N to restrict its work.
+        if SHAPE_INDEX is not None:
+            if SHAPE_INDEX >= len(shapes):
+                return KernelResult(
+                    name=name,
+                    passed=False,
+                    error=f"--shape-index={SHAPE_INDEX} out of range (have {len(shapes)} shapes)",
+                )
+            shapes = [shapes[SHAPE_INDEX]]
         all_passed = True
         shape_results: list[ShapeResult] = []
         accuracy_verified = max_mismatch_pct is None or max_mismatch_pct < 1.0
@@ -1380,10 +1483,38 @@ def main() -> None:
         action="store_true",
         help="List available kernel names and exit",
     )
+    parser.add_argument(
+        "--shape-index",
+        type=int,
+        default=None,
+        help=(
+            "Restrict the run to this single shape index. Combined with --kernel, "
+            "runs exactly one (kernel, shape) — used by --subprocess-per-shape."
+        ),
+    )
+    parser.add_argument(
+        "--subprocess-per-shape",
+        action="store_true",
+        help=(
+            "Spawn one subprocess per (kernel, shape). Each subprocess gets a "
+            "fresh TPU device, isolating libtpu allocator state across runs. "
+            "Adds ~30-60s per subprocess for Python/JAX/torch_tpu init."
+        ),
+    )
+    parser.add_argument(
+        "--intermediate-result",
+        type=str,
+        default=None,
+        help=(
+            "Write a single KernelResult as JSON to this path (used by the "
+            "subprocess child to communicate its result back to the parent)."
+        ),
+    )
     args = parser.parse_args()
 
-    global NUM_SHAPES
+    global NUM_SHAPES, SHAPE_INDEX
     NUM_SHAPES = args.num_shapes
+    SHAPE_INDEX = args.shape_index
 
     if args.list_kernels:
         for name in KERNEL_MAPPINGS:
@@ -1419,7 +1550,10 @@ def main() -> None:
         print(f"\n{'=' * 65}", file=sys.stderr)
         print(f"Kernel: {name}", file=sys.stderr)
         print(f"{'=' * 65}", file=sys.stderr)
-        result = run_kernel(name)
+        if args.subprocess_per_shape:
+            result = _run_kernel_per_shape(name)
+        else:
+            result = run_kernel(name)
         results.append(result)
 
         status = "PASS" if result.passed else "FAIL"
@@ -1493,6 +1627,19 @@ def main() -> None:
     if args.output:
         write_results_json(args.output, results)
         print(f"Results written to {args.output}", file=sys.stderr)
+
+    if args.intermediate_result:
+        # Child-mode handoff: serialize the (single) KernelResult so the parent
+        # subprocess-per-shape orchestrator can reconstruct it. Always exactly
+        # one result when this flag is set (parent passes --kernel=<one>).
+        if len(results) != 1:
+            print(
+                f"Warning: --intermediate-result expects 1 result, got {len(results)}",
+                file=sys.stderr,
+            )
+        if results:
+            with open(args.intermediate_result, "w") as f:
+                json.dump(asdict(results[0]), f)
 
 
 if __name__ == "__main__":

--- a/benchmarks/run_tpu.py
+++ b/benchmarks/run_tpu.py
@@ -1233,8 +1233,25 @@ def run_kernel(name: str) -> KernelResult:
         signal.signal(signal.SIGALRM, old_handler)
 
 
+def _print_hbm_probe(label: str) -> None:
+    """Diagnostic: print TPU HBM usage at named lifecycle points.
+
+    Compares shape 0 subprocess (cold device) vs shape N subprocess (post-
+    handoff). Cold subprocess should show min-HBM; if shape N>=1 sees higher
+    start-HBM, that's evidence of leaked device-side state across PjRtClient
+    teardown/restart.
+    """
+    try:
+        summary = torch.tpu._hbm_usage_summary()  # pyrefly: ignore[missing-attribute]
+    except (AttributeError, RuntimeError) as e:
+        print(f"  [hbm-probe@{label}] unavailable: {e}", file=sys.stderr)
+        return
+    print(f"  [hbm-probe@{label}] {summary}", file=sys.stderr)
+
+
 def run_kernel_inner(name: str) -> KernelResult:
     """Run a single kernel benchmark: accuracy check + timing vs baseline."""
+    _print_hbm_probe("run_kernel_inner-start")
     if name not in KERNEL_MAPPINGS:
         return KernelResult(name=name, passed=False, error=f"Unknown kernel: {name}")
 
@@ -1275,6 +1292,7 @@ def run_kernel_inner(name: str) -> KernelResult:
                     error=f"--shape-index={SHAPE_INDEX} out of range (have {len(shapes)} shapes)",
                 )
             shapes = [shapes[SHAPE_INDEX]]
+        _print_hbm_probe("post-shape-alloc")
         all_passed = True
         shape_results: list[ShapeResult] = []
         accuracy_verified = max_mismatch_pct is None or max_mismatch_pct < 1.0

--- a/benchmarks/run_tpu.py
+++ b/benchmarks/run_tpu.py
@@ -1240,13 +1240,26 @@ def _print_hbm_probe(label: str) -> None:
     handoff). Cold subprocess should show min-HBM; if shape N>=1 sees higher
     start-HBM, that's evidence of leaked device-side state across PjRtClient
     teardown/restart.
+
+    Uses ``jax.devices()[0].memory_stats()`` because torch.tpu's
+    ``_hbm_usage_summary`` only reports CompilationCache HBM, not total
+    user-allocated HBM.
     """
     try:
-        summary = torch.tpu._hbm_usage_summary()  # pyrefly: ignore[missing-attribute]
-    except (AttributeError, RuntimeError) as e:
+        import jax
+
+        stats = jax.devices()[0].memory_stats()
+    except Exception as e:  # noqa: BLE001
         print(f"  [hbm-probe@{label}] unavailable: {e}", file=sys.stderr)
         return
-    print(f"  [hbm-probe@{label}] {summary}", file=sys.stderr)
+    in_use = stats.get("bytes_in_use", -1)
+    peak = stats.get("peak_bytes_in_use", -1)
+    largest_free = stats.get("largest_free_block_bytes", -1)
+    print(
+        f"  [hbm-probe@{label}] in_use={in_use:_} peak={peak:_} "
+        f"largest_free_block={largest_free:_} num_allocs={stats.get('num_allocs', -1)}",
+        file=sys.stderr,
+    )
 
 
 def run_kernel_inner(name: str) -> KernelResult:

--- a/benchmarks/run_tpu.py
+++ b/benchmarks/run_tpu.py
@@ -1257,38 +1257,8 @@ def run_kernel(name: str) -> KernelResult:
         signal.signal(signal.SIGALRM, old_handler)
 
 
-def _print_hbm_probe(label: str) -> None:
-    """Diagnostic: print TPU HBM usage at named lifecycle points.
-
-    Compares shape 0 subprocess (cold device) vs shape N subprocess (post-
-    handoff). Cold subprocess should show min-HBM; if shape N>=1 sees higher
-    start-HBM, that's evidence of leaked device-side state across PjRtClient
-    teardown/restart.
-
-    Uses ``jax.devices()[0].memory_stats()`` because torch.tpu's
-    ``_hbm_usage_summary`` only reports CompilationCache HBM, not total
-    user-allocated HBM.
-    """
-    try:
-        import jax
-
-        stats = jax.devices()[0].memory_stats()
-    except Exception as e:
-        print(f"  [hbm-probe@{label}] unavailable: {e}", file=sys.stderr)
-        return
-    in_use = stats.get("bytes_in_use", -1)
-    peak = stats.get("peak_bytes_in_use", -1)
-    largest_free = stats.get("largest_free_block_bytes", -1)
-    print(
-        f"  [hbm-probe@{label}] in_use={in_use:_} peak={peak:_} "
-        f"largest_free_block={largest_free:_} num_allocs={stats.get('num_allocs', -1)}",
-        file=sys.stderr,
-    )
-
-
 def run_kernel_inner(name: str) -> KernelResult:
     """Run a single kernel benchmark: accuracy check + timing vs baseline."""
-    _print_hbm_probe("run_kernel_inner-start")
     if name not in KERNEL_MAPPINGS:
         return KernelResult(name=name, passed=False, error=f"Unknown kernel: {name}")
 
@@ -1330,7 +1300,6 @@ def run_kernel_inner(name: str) -> KernelResult:
                     shape_index_out_of_range=True,
                 )
             shapes = [shapes[SHAPE_INDEX]]
-        _print_hbm_probe("post-shape-alloc")
         all_passed = True
         shape_results: list[ShapeResult] = []
         accuracy_verified = max_mismatch_pct is None or max_mismatch_pct < 1.0


### PR DESCRIPTION
## Summary

Adds a `--subprocess-per-shape` mode to `benchmarks/run_tpu.py` and wires it into the TPU benchmark CI. Each `(kernel, shape)` pair now runs in a fresh Python subprocess, so every autotune session starts with an uninitialized TPU device — no carryover of libtpu allocator state, JAX HLO/Mosaic caches, or `torch_tpu` compile caches from previously-benchmarked kernels.

## Why

Same-process sweeps accumulate device-side state across kernels over ~2 hours. The prior runs showed `rms_norm-bwd[8192,8192]` OOMing on a 257 MB `masked_select` scratch when only ~97 MB was free in HBM bank 0, then downstream kernels cascading into "Default config failed" because the OOMed state poisoned the rest of the sweep. Process-level isolation is the cleanest way to guarantee a clean device for each autotune.

## What we tried first (and why it wasn't enough)

The OOM that motivated this work is `rms_norm-bwd[8192,8192]` failing on a 257 MB `masked_select` scratch when only ~97 MB was free in HBM bank 0 — but the kernel only allocated ~150 MB of its own, so something between the start of the sweep and `rms_norm-bwd` had retained the rest. Several lighter-weight mitigations were tried on top of the same-process runner before falling back to process isolation:

### 1. Reorder `rms_norm-bwd` last in `KERNEL_MAPPINGS` (landed as 618dad03)
Hypothesis: if `rms_norm-bwd` is the OOM canary, run it after everything else so any failure only affects itself. Worked for that one kernel — it still OOMed but no longer cascaded into the kernels after it. But it doesn't generalize: any *new* high-pressure kernel would need its own reorder, and shapes that grow over time will re-trigger the problem. Also doesn't reclaim memory, just isolates the blast radius.

### 2. Per-shape tensor-ref release in `run_kernel_inner` (landed as 618dad03)
Hypothesis: shapes within a kernel hold Python refs to allocated tensors longer than necessary. Drop them between shapes inside the same process. Reduced peak Python-visible tensor memory and helped some marginal cases. But `jax.devices()[0].memory_stats()` showed libtpu's *reserved* allocator pool kept growing across shapes regardless — the heap was fragmented, not just full. The Python ref-drop returns memory to the libtpu allocator's free list but doesn't return it to the OS or compact the heap, so subsequent shapes with mismatched alignment still hit `RESOURCE_EXHAUSTED`.

### 3. Per-candidate GC in the autotuner (landed as 43be16bb, reverted in 7b65b489)
Hypothesis: autotune accumulates compiled XLA executables across candidates; force `gc.collect()` every N candidates to clear stale references. Measured no HBM headroom recovery before vs after the GC — confirming the leak is in libtpu/PJRT state (cached HLO modules, compiled `PjRtLoadedExecutable`s, allocator-reserved blocks), not Python heap objects. Reverted to keep autotune fast.

### 4. Release device caches between shapes via private torch_tpu API (landed as faef79dc)
Hypothesis: explicitly call into `torch_tpu` to drop the per-device compile cache and allocator pool between shapes. Worked but uses a non-public `torch_tpu` cache-clear hook, and only addresses the torch_tpu side — not the JAX/Pallas side of the cache state.

### Why subprocess isolation is the right answer

Each of the in-process attempts addressed one piece of the cumulative state (Python refs, autotune cache, torch_tpu cache) but none can drop libtpu's process-level allocator reservations or JAX's compile cache without re-initializing PJRT — and re-initializing PJRT mid-process is what causes `Device or resource busy` errors. The only reliable way to get a "clean" device today is `fork()`/`exec()`: a new PID gets a new libtpu state, a new PJRT client, and a new allocator. The trade-off is ~30-60s cold-start per shape, which is a one-time cost per shape (not per autotune candidate) and turned out to be cheaper than the engineering needed to plumb cache-clear paths through three layers.

## What changes

Parent / child split inside `run_tpu.py`:

- Parent walks `(kernel, shape_index)` pairs and spawns a child per pair: `python run_tpu.py --kernel <name> --shape-index <N> --intermediate-result <tmp.json>`. Child's stdout/stderr inherit, so autotune progress still streams to the CI log.
- The parent never calls `shapes_fn()` — doing so would force PJRT to initialize on the parent and the next child would hit `Device or resource busy`. Instead it walks `shape_index = 0, 1, 2, ...` and stops when the child sets a typed `KernelResult.shape_index_out_of_range=True` field on its result.
- Each child writes a single-shape `KernelResult` JSON; the parent merges them into the same summary table the same-process path emits.
- A short wait on the TPU lockfile between spawns lets the OS finish releasing the device. A bounded retry on bootstrap failures keeps a flaky cold-start from hanging the sweep.
- Parent-side `subprocess.run(..., timeout=KERNEL_TIMEOUT + 120)` so a child wedged before its own SIGALRM fires (e.g., stuck on the TPU lockfile or in pre-helion startup) gets killed and the sweep keeps making progress.

## Results

Comprehensive sweep on `kernels_tpu=all`, `autotune_effort=full` ([run 26549626274](https://github.com/pytorch/helion/actions/runs/26549626274), 2h 32m):

- **27/29 kernels PASS** (54/57 row-shapes) — up from 21/29 in the prior same-process sweep ([run 26485039794](https://github.com/pytorch/helion/actions/runs/26485039794), 2026-05-26, 1h 57m).
- **9 row-shapes recovered** that previously OOM'd or failed:
  - `swiglu[16,16384,4096]`
  - `rms_norm-bwd[8192,8192]` (the original masked_select OOM)
  - `kl_div[2048,32000]`
  - `fused_linear_jsd[1024,4096]` and `[4096,4096]`
  - `grpo_loss[4,512,2048]` and `[4,1024,32000]`
  - `epilogue_subtiling[2048,2048,2048]` and `[4096,4096,4096]`
- **No regressions** in previously-passing kernels. Speedup deltas are within ±0.2x noise across the board.
- **Cost**: +~35 min wallclock vs same-process baseline (subprocess cold-start, most visible in `welford[524288,512]` autotune 603s → 1443s).
- **Win tally** (Helion 9 · torch.compile 26 · lazy torch 19) is consistent with prior weeks; the shift toward torch.compile is because the recovered rows (jsd / grpo_loss / epilogue_subtiling) all favor torch.compile's full-graph fusion.

Still failing in `--subprocess-per-shape` mode (default-config failures, *not* HBM-pressure related — these need kernel-level fixes):
- `se_block[8192,8192]`
- `squeeze_and_excitation_net[1024,1024,1024]`
- `squeeze_and_excitation_net[4096,4096,4096]`

## Cost

~30-60s startup per subprocess (Python import + TPU init). For the 29-kernel × 2-shape sweep that's roughly +30-60 min wallclock on top of autotune time, in exchange for isolation.
