### PR TITLE
[Pallas] Render outer_prefix for emit_pipeline and fori_loop scopes

### DIFF
--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -438,6 +438,10 @@ class GenerateAST(NodeVisitor, CodegenInterface):
             finally:
                 for idx in pipeline_state.block_ids:
                     self.active_device_loops[idx].pop()
+        # Flush any symnode bindings hoisted into the loop's outer_prefix
+        # (via lift_symnode) into the parent scope, so they precede the
+        # function def + pipeline call the caller is about to add.
+        self.statements_stack[-1].extend(pipeline_state.outer_prefix)
 
     @contextlib.contextmanager
     def add_fori_loop(self, fori_state: ForiLoopState) -> Iterator[None]:
@@ -459,6 +463,7 @@ class GenerateAST(NodeVisitor, CodegenInterface):
             finally:
                 for idx in fori_state.block_ids:
                     self.active_device_loops[idx].pop()
+        self.statements_stack[-1].extend(fori_state.outer_prefix)
 
     def set_active_loops(self, device_grid: DeviceLoopOrGridState) -> None:
         if isinstance(device_grid, DeviceGridState):

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1212,6 +1212,26 @@ class TestPallas(TestCase):
         ).to(device=DEVICE)
         torch.testing.assert_close(result, ref, rtol=1e-2, atol=1e-2)
 
+    def test_symnode_index_in_emit_pipeline_body(self) -> None:
+        """A SymInt expression derived from an outer tile index
+        (e.g. ``tile_h.begin // 2``, as in GQA's
+        ``h_idx // num_groups``) must be usable as an index inside an
+        inner ``hl.tile`` loop on the Pallas backend.
+        """
+
+        @helion.kernel(static_shapes=True)
+        def k(x: torch.Tensor) -> torch.Tensor:
+            H, N = x.size()
+            out = torch.empty_like(x)
+            for tile_h in hl.tile(H, block_size=1):
+                h_kv = tile_h.begin // 2
+                for tile_n in hl.tile(N):
+                    out[tile_h.begin, tile_n] = x[h_kv, tile_n]
+            return out
+
+        x = torch.randn(4, 8, dtype=torch.float32, device=DEVICE)
+        code_and_output(k, (x,))
+
     def test_emit_pipeline_loop_order(self) -> None:
         """Test emit_pipeline with loop_order reordering.
 


### PR DESCRIPTION
## Summary

- A binding hoisted into `EmitPipelineLoopState.outer_prefix` / `ForiLoopState.outer_prefix` (via `lift_symnode`) was silently dropped because neither `add_emit_pipeline_loop` nor `add_fori_loop` extended the parent statements with the loop's `outer_prefix` on context exit, unlike `add_device_loop`.
- A GQA-style `key[b, h_idx // num_groups, tile_n, :]` lift produced `symnode_0 = h_idx // num_groups` bound only in the (unrendered) `outer_prefix`; the inner `_pipeline_body` then referenced an undefined `symnode_0` and raised `NameError` at execution.

## Fix

Flush each loop kind's `outer_prefix` into the parent scope right where `add_device_loop` already does for `DeviceLoopState`. Resulting parent body for the emit_pipeline case becomes:

```
symnode_N = <expr>
def _pipeline_body(...): ... key[..., symnode_N, ...]
pltpu.emit_pipeline(_pipeline_body, ...)()
```

so the body fn closes over the binding instead of seeing it as undefined.

The same idiom appears in `examples/flex_attention.py` (`h_kv_idx = h_idx // num_groups` → `key[..., h_kv_idx, ...]`); that example is currently `@skipIfPallas`, which is why this codegen path went untested.

## Regression test

`test/test_pallas.py::TestPallas::test_symnode_index_in_emit_pipeline_body` — verified to fail on `main` with `NameError: name 'symnode_0' is not defined`.
