### PR TITLE
[Pallas] Add a helion setting for pallas interpret mode

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1216,11 +1216,11 @@ class PallasBackend(Backend):
         from .device_function import TensorStrideArg
 
         if isinstance(arg, (SymbolArgument, TensorSizeArg, TensorStrideArg)):
-            from ..runtime.settings import is_pallas_interpret
+            from .compile_environment import CompileEnvironment
 
             if tensor_host_args:
                 device_expr = f"{tensor_host_args[0]}.device"
-            elif is_pallas_interpret():
+            elif CompileEnvironment.current().settings.pallas_interpret:
                 device_expr = "'cpu'"
             else:
                 device_expr = "'tpu'"

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -542,6 +542,11 @@ class _Settings:
         )
     )
     autotune_config_filter: Callable[[Config], Config | None] | None = None
+    pallas_interpret: bool = dataclasses.field(
+        default_factory=functools.partial(
+            _env_get_bool, "HELION_PALLAS_INTERPRET", False
+        )
+    )
     triton_do_not_specialize: bool = dataclasses.field(
         default_factory=functools.partial(
             _env_get_bool, "HELION_TRITON_DO_NOT_SPECIALIZE", False
@@ -621,6 +626,10 @@ class Settings(_Settings):
             "If True, set the compile timeout threshold to be smaller for Triton compilation,"
             "based on a quantile of initial compile times (with a lower bound). Lower bound and quantile "
             "are set by the effort profile. Set HELION_AUTOTUNE_ADAPTIVE_TIMEOUT=0 to disable."
+        ),
+        "pallas_interpret": (
+            "If True, run Pallas kernels in interpret mode on CPU (no TPU needed). "
+            "Defaults to HELION_PALLAS_INTERPRET env var."
         ),
         "triton_do_not_specialize": (
             "If True, pass do_not_specialize for every dynamic size/stride/symbol "


### PR DESCRIPTION
Stacked PRs:
 * #2524
 * __->__#2522


--- --- ---

### [Pallas] Add a helion setting for pallas interpret mode


Pallas interpret mode (running Pallas kernels on CPU without TPU
hardware) was previously only controllable via the
HELION_PALLAS_INTERPRET=1 environment variable. This makes it
difficult for programmatic callers -- such as PyTorch Inductor's
Helion backend -- to enable interpret mode without manipulating
global process state.

This adds a `pallas_interpret` field to Settings so callers can pass
`Settings(backend="pallas", pallas_interpret=True)` directly in the
@helion.kernel decorator. The env var remains as the default factory
value for backwards compatibility.

Also updates PallasBackend.transform_host_arg to read the flag from
the CompileEnvironment's settings instance rather than the standalone
is_pallas_interpret() function, so compilation respects the
per-kernel setting.

Note: the runtime launcher paths (default_pallas_launcher, etc.)
still read the env var via is_pallas_interpret() since they don't
have access to the Settings instance. Threading the flag through the
launcher is left as a follow-up.

Authored by Claude.
