### PR TITLE
[Pallas] Thread pallas_interpret through runtime launchers

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1897,6 +1897,9 @@ class PallasBackend(Backend):
                         f"_pipeline_arg_indices={pipeline_arg_indices!r}"
                     )
 
+        if CompileEnvironment.current().settings.pallas_interpret:
+            launcher_args.append("_pallas_interpret=True")
+
         return launcher_args
 
     def build_launcher_name(self, config: Config) -> str:

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -502,6 +502,7 @@ def _pallas_prepare_args(
     args: tuple[object, ...],
     _output_indices: list[int],
     _inplace_indices: list[int] | None = None,
+    _pallas_interpret: bool | None = None,
 ) -> tuple[
     list[int],
     list[int],
@@ -525,7 +526,10 @@ def _pallas_prepare_args(
     """
     from .settings import is_pallas_interpret
 
-    if is_pallas_interpret():
+    interpret = (
+        _pallas_interpret if _pallas_interpret is not None else is_pallas_interpret()
+    )
+    if interpret:
         placeholder_fn = _jax_placeholder_for_tensor
     else:
         from torch_tpu._internal.pallas.pallas import (  # pyrefly: ignore[missing-import]
@@ -631,6 +635,7 @@ def _pallas_build_callable(
     cache_attr: str,
     call_aliases: dict[int, int],
     trace_key_suffix: str = "",
+    pallas_interpret: bool | None = None,
 ) -> object:
     """Build a ``JaxCallable``, cache it on the kernel, and return it.
 
@@ -655,7 +660,7 @@ def _pallas_build_callable(
         )
         return callable_obj
 
-    if _pallas_interpret_flag():
+    if _pallas_interpret_flag(pallas_interpret):
         return _make_interpret_callable()
 
     import jax
@@ -722,15 +727,22 @@ class _PallasInterpretCallable:
         return tuple(jax_results)
 
 
-def _pallas_interpret_flag() -> bool:
-    """Return True if ``HELION_PALLAS_INTERPRET=1`` is set.
+def _pallas_interpret_flag(override: bool | None = None) -> bool:
+    """Return True if Pallas interpret mode is active.
+
+    When *override* is True, interpret mode is forced on regardless of the
+    environment variable.  When *override* is None (the default), falls back
+    to ``HELION_PALLAS_INTERPRET=1``.
 
     As a side effect, registers a synthetic CPU TpuInfo entry so that
     ``emit_pipeline`` / ``fori_loop`` interpret paths don't fail.
     """
-    from .settings import is_pallas_interpret
+    if override is not None:
+        result = override
+    else:
+        from .settings import is_pallas_interpret
 
-    result = is_pallas_interpret()
+        result = is_pallas_interpret()
     if result:
         _ensure_cpu_tpu_info()
     return result
@@ -888,6 +900,7 @@ def default_pallas_launcher(
     _block_spec_info: _BlockSpecInfo | None = None,
     _smem_arg_indices: list[int] | None = None,
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
+    _pallas_interpret: bool | None = None,
     **kwargs: object,
 ) -> object:
     """Default launcher for Pallas kernels on TPU (or CPU with interpret=True).
@@ -930,7 +943,9 @@ def default_pallas_launcher(
             inplace_positions,
             out_shapes,
             pallas_aliases,
-        ) = _pallas_prepare_args(args, _output_indices, _inplace_indices)
+        ) = _pallas_prepare_args(
+            args, _output_indices, _inplace_indices, _pallas_interpret
+        )
 
         in_specs, out_specs = _pallas_build_block_specs(
             pl,
@@ -981,7 +996,7 @@ def default_pallas_launcher(
             "out_shape": out_shape_arg,
             "grid": grid,
         }
-        if _pallas_interpret_flag():
+        if _pallas_interpret_flag(_pallas_interpret):
             pallas_call_kwargs["interpret"] = True
         if in_specs is not None:
             pallas_call_kwargs["in_specs"] = in_specs
@@ -1001,6 +1016,7 @@ def default_pallas_launcher(
             tensor_arg_indices,
             cache_attr="_pallas_cache",
             call_aliases=pallas_aliases,
+            pallas_interpret=_pallas_interpret,
         )
 
     return _pallas_invoke_and_return(
@@ -1025,6 +1041,7 @@ def default_pallas_pipeline_launcher(
     _pipeline_arg_indices: list[int] | None = None,
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _smem_arg_indices: list[int] | None = None,
+    _pallas_interpret: bool | None = None,
     **kwargs: object,
 ) -> object:
     """Launcher for Pallas kernels using PrefetchScalarGridSpec with scratch memory.
@@ -1063,7 +1080,9 @@ def default_pallas_pipeline_launcher(
             inplace_positions,
             out_shapes,
             pallas_aliases,
-        ) = _pallas_prepare_args(args, _output_indices, _inplace_indices)
+        ) = _pallas_prepare_args(
+            args, _output_indices, _inplace_indices, _pallas_interpret
+        )
 
         # Build scratch shapes for VMEM
         _jnp_dtype_map = _pallas_jnp_dtype_map()
@@ -1149,7 +1168,7 @@ def default_pallas_pipeline_launcher(
                 dimension_semantics=tuple("parallel" for _ in grid),
             ),
         }
-        if _pallas_interpret_flag():
+        if _pallas_interpret_flag(_pallas_interpret):
             pallas_call_kwargs["interpret"] = True
 
         jit_fn = pl.pallas_call(
@@ -1167,6 +1186,7 @@ def default_pallas_pipeline_launcher(
             cache_attr="_pallas_pipeline_cache",
             call_aliases=pallas_aliases,
             trace_key_suffix="_pipeline",
+            pallas_interpret=_pallas_interpret,
         )
 
     return _pallas_invoke_and_return(
@@ -1190,6 +1210,7 @@ def default_pallas_fori_launcher(
     _scratch_shapes: list[tuple[tuple[int, ...], str | None, str]] | None = None,
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _smem_arg_indices: list[int] | None = None,
+    _pallas_interpret: bool | None = None,
     **kwargs: object,
 ) -> object:
     """Launcher for Pallas kernels using fori_loop with manual DMA.
@@ -1230,7 +1251,9 @@ def default_pallas_fori_launcher(
             inplace_positions,
             out_shapes,
             pallas_aliases,
-        ) = _pallas_prepare_args(args, _output_indices, _inplace_indices)
+        ) = _pallas_prepare_args(
+            args, _output_indices, _inplace_indices, _pallas_interpret
+        )
 
         # Build scratch shapes: VMEM buffers + DMA semaphores
         _jnp_dtype_map = _pallas_jnp_dtype_map()
@@ -1315,7 +1338,7 @@ def default_pallas_fori_launcher(
                 dimension_semantics=tuple("parallel" for _ in grid),
             ),
         }
-        if _pallas_interpret_flag():
+        if _pallas_interpret_flag(_pallas_interpret):
             pallas_call_kwargs["interpret"] = True
 
         jit_fn = pl.pallas_call(
@@ -1333,6 +1356,7 @@ def default_pallas_fori_launcher(
             cache_attr="_pallas_fori_cache",
             call_aliases=pallas_aliases,
             trace_key_suffix="_fori",
+            pallas_interpret=_pallas_interpret,
         )
 
     return _pallas_invoke_and_return(


### PR DESCRIPTION
Stacked PRs:
 * __->__#2523
 * #2522


--- --- ---

### [Pallas] Thread pallas_interpret through runtime launchers


The previous commit added `pallas_interpret` to Settings but only the
compilation step respected it -- the runtime launchers still required
the HELION_PALLAS_INTERPRET env var because they didn't receive the
flag from the compiled kernel.

This threads the flag end-to-end:

1. PallasBackend.build_launcher_args() embeds `_pallas_interpret=True`
   in the generated launcher call when settings.pallas_interpret is set
   at compile time.

2. All three Pallas launchers (default, pipeline, fori) accept the new
   `_pallas_interpret` kwarg and forward it to `_pallas_prepare_args`
   and `_pallas_interpret_flag`.

3. `_pallas_interpret_flag(override)` accepts an explicit override;
   when None, falls back to the env var as before.

This means `Settings(backend="pallas", pallas_interpret=True)` is now
sufficient to run in interpret mode without any environment variable.
The env var remains as a fallback for backwards compatibility.

Compatible with PR #2491 (Pallas interpret CI job) which modifies
`_torch_to_jax`/`_jax_to_torch` and adds a `_get_vmem_limit_bytes`
interpret-mode path -- those changes touch different sections and use
`_pallas_interpret_flag()` without arguments, which still works since
the override parameter defaults to None.

Authored by Claude.