### PR TITLE
[Pallas] Thread pallas_interpret through runtime launchers

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1897,6 +1897,9 @@ class PallasBackend(Backend):
                         f"_pipeline_arg_indices={pipeline_arg_indices!r}"
                     )
 
+        if CompileEnvironment.current().settings.pallas_interpret:
+            launcher_args.append("_pallas_interpret=True")
+
         return launcher_args
 
     def build_launcher_name(self, config: Config) -> str:

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -502,6 +502,8 @@ def _pallas_prepare_args(
     args: tuple[object, ...],
     _output_indices: list[int],
     _inplace_indices: list[int] | None = None,
+    *,
+    interpret: bool = False,
 ) -> tuple[
     list[int],
     list[int],
@@ -523,9 +525,7 @@ def _pallas_prepare_args(
     - inplace_positions: positions that are both input and output
     - out_shapes: JAX placeholders for output shapes
     """
-    from .settings import is_pallas_interpret
-
-    if is_pallas_interpret():
+    if interpret:
         placeholder_fn = _jax_placeholder_for_tensor
     else:
         from torch_tpu._internal.pallas.pallas import (  # pyrefly: ignore[missing-import]
@@ -631,6 +631,8 @@ def _pallas_build_callable(
     cache_attr: str,
     call_aliases: dict[int, int],
     trace_key_suffix: str = "",
+    *,
+    interpret: bool = False,
 ) -> object:
     """Build a ``JaxCallable``, cache it on the kernel, and return it.
 
@@ -655,7 +657,7 @@ def _pallas_build_callable(
         )
         return callable_obj
 
-    if _pallas_interpret_flag():
+    if interpret:
         return _make_interpret_callable()
 
     import jax
@@ -720,20 +722,6 @@ class _PallasInterpretCallable:
         # Return JAX results so output-only tensors can be handled
         # by _pallas_invoke_and_return.
         return tuple(jax_results)
-
-
-def _pallas_interpret_flag() -> bool:
-    """Return True if ``HELION_PALLAS_INTERPRET=1`` is set.
-
-    As a side effect, registers a synthetic CPU TpuInfo entry so that
-    ``emit_pipeline`` / ``fori_loop`` interpret paths don't fail.
-    """
-    from .settings import is_pallas_interpret
-
-    result = is_pallas_interpret()
-    if result:
-        _ensure_cpu_tpu_info()
-    return result
 
 
 def _ensure_cpu_tpu_info() -> None:
@@ -888,6 +876,7 @@ def default_pallas_launcher(
     _block_spec_info: _BlockSpecInfo | None = None,
     _smem_arg_indices: list[int] | None = None,
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
+    _pallas_interpret: bool | None = None,
     **kwargs: object,
 ) -> object:
     """Default launcher for Pallas kernels on TPU (or CPU with interpret=True).
@@ -902,6 +891,14 @@ def default_pallas_launcher(
     are excluded from pallas_call inputs to save VMEM.  Their results are
     returned as torch tensors.
     """
+    from .settings import is_pallas_interpret
+
+    interpret = (
+        _pallas_interpret if _pallas_interpret is not None else is_pallas_interpret()
+    )
+    if interpret:
+        _ensure_cpu_tpu_info()
+
     if _output_indices is None:
         _output_indices = []
 
@@ -930,7 +927,9 @@ def default_pallas_launcher(
             inplace_positions,
             out_shapes,
             pallas_aliases,
-        ) = _pallas_prepare_args(args, _output_indices, _inplace_indices)
+        ) = _pallas_prepare_args(
+            args, _output_indices, _inplace_indices, interpret=interpret
+        )
 
         in_specs, out_specs = _pallas_build_block_specs(
             pl,
@@ -981,7 +980,7 @@ def default_pallas_launcher(
             "out_shape": out_shape_arg,
             "grid": grid,
         }
-        if _pallas_interpret_flag():
+        if interpret:
             pallas_call_kwargs["interpret"] = True
         if in_specs is not None:
             pallas_call_kwargs["in_specs"] = in_specs
@@ -1001,6 +1000,7 @@ def default_pallas_launcher(
             tensor_arg_indices,
             cache_attr="_pallas_cache",
             call_aliases=pallas_aliases,
+            interpret=interpret,
         )
 
     return _pallas_invoke_and_return(
@@ -1025,6 +1025,7 @@ def default_pallas_pipeline_launcher(
     _pipeline_arg_indices: list[int] | None = None,
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _smem_arg_indices: list[int] | None = None,
+    _pallas_interpret: bool | None = None,
     **kwargs: object,
 ) -> object:
     """Launcher for Pallas kernels using PrefetchScalarGridSpec with scratch memory.
@@ -1033,6 +1034,14 @@ def default_pallas_pipeline_launcher(
     (listed in ``_pipeline_arg_indices``) use HBM refs; all other tensors
     get proper BlockSpecs for automatic VMEM prefetch.
     """
+    from .settings import is_pallas_interpret
+
+    interpret = (
+        _pallas_interpret if _pallas_interpret is not None else is_pallas_interpret()
+    )
+    if interpret:
+        _ensure_cpu_tpu_info()
+
     if _output_indices is None:
         _output_indices = []
     if _scratch_shapes is None:
@@ -1063,7 +1072,9 @@ def default_pallas_pipeline_launcher(
             inplace_positions,
             out_shapes,
             pallas_aliases,
-        ) = _pallas_prepare_args(args, _output_indices, _inplace_indices)
+        ) = _pallas_prepare_args(
+            args, _output_indices, _inplace_indices, interpret=interpret
+        )
 
         # Build scratch shapes for VMEM
         _jnp_dtype_map = _pallas_jnp_dtype_map()
@@ -1149,7 +1160,7 @@ def default_pallas_pipeline_launcher(
                 dimension_semantics=tuple("parallel" for _ in grid),
             ),
         }
-        if _pallas_interpret_flag():
+        if interpret:
             pallas_call_kwargs["interpret"] = True
 
         jit_fn = pl.pallas_call(
@@ -1167,6 +1178,7 @@ def default_pallas_pipeline_launcher(
             cache_attr="_pallas_pipeline_cache",
             call_aliases=pallas_aliases,
             trace_key_suffix="_pipeline",
+            interpret=interpret,
         )
 
     return _pallas_invoke_and_return(
@@ -1190,6 +1202,7 @@ def default_pallas_fori_launcher(
     _scratch_shapes: list[tuple[tuple[int, ...], str | None, str]] | None = None,
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _smem_arg_indices: list[int] | None = None,
+    _pallas_interpret: bool | None = None,
     **kwargs: object,
 ) -> object:
     """Launcher for Pallas kernels using fori_loop with manual DMA.
@@ -1200,6 +1213,14 @@ def default_pallas_fori_launcher(
     The kernel uses ``jax.lax.fori_loop`` with ``pltpu.make_async_copy``
     internally for DMA control.
     """
+    from .settings import is_pallas_interpret
+
+    interpret = (
+        _pallas_interpret if _pallas_interpret is not None else is_pallas_interpret()
+    )
+    if interpret:
+        _ensure_cpu_tpu_info()
+
     if _output_indices is None:
         _output_indices = []
     if _scratch_shapes is None:
@@ -1230,7 +1251,9 @@ def default_pallas_fori_launcher(
             inplace_positions,
             out_shapes,
             pallas_aliases,
-        ) = _pallas_prepare_args(args, _output_indices, _inplace_indices)
+        ) = _pallas_prepare_args(
+            args, _output_indices, _inplace_indices, interpret=interpret
+        )
 
         # Build scratch shapes: VMEM buffers + DMA semaphores
         _jnp_dtype_map = _pallas_jnp_dtype_map()
@@ -1315,7 +1338,7 @@ def default_pallas_fori_launcher(
                 dimension_semantics=tuple("parallel" for _ in grid),
             ),
         }
-        if _pallas_interpret_flag():
+        if interpret:
             pallas_call_kwargs["interpret"] = True
 
         jit_fn = pl.pallas_call(
@@ -1333,6 +1356,7 @@ def default_pallas_fori_launcher(
             cache_attr="_pallas_fori_cache",
             call_aliases=pallas_aliases,
             trace_key_suffix="_fori",
+            interpret=interpret,
         )
 
     return _pallas_invoke_and_return(

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -338,7 +338,15 @@ def _get_backend() -> str:
 
 
 def is_pallas_interpret() -> bool:
-    """Return True if HELION_PALLAS_INTERPRET=1 is set."""
+    """Return True if pallas_interpret is enabled.
+
+    Checks the active CompileEnvironment first (if one exists),
+    then falls back to the HELION_PALLAS_INTERPRET env var.
+    """
+    from helion._compiler.compile_environment import CompileEnvironment
+
+    if CompileEnvironment.has_current():
+        return CompileEnvironment.current().settings.pallas_interpret
     return _env_get_bool("HELION_PALLAS_INTERPRET", False)
 
 


### PR DESCRIPTION

The previous commit added `pallas_interpret` to Settings but only the
compilation step respected it -- the runtime launchers still required
the HELION_PALLAS_INTERPRET env var because they didn't receive the
flag from the compiled kernel.

This threads the flag end-to-end:

1. PallasBackend.build_launcher_args() embeds `_pallas_interpret=True`
   in the generated launcher call when settings.pallas_interpret is set
   at compile time.

2. Each launcher resolves interpret mode once at the top:
       interpret = _pallas_interpret if _pallas_interpret is not None
                   else is_pallas_interpret()
   If interpret mode is active, `_ensure_cpu_tpu_info()` is called
   explicitly to register the synthetic TpuInfo for CPU execution.

3. The resolved bool is passed to `_pallas_prepare_args` and
   `_pallas_build_callable` as a keyword-only `interpret` parameter,
   replacing the previous pattern of calling `_pallas_interpret_flag()`
   deep inside each helper.

4. `is_pallas_interpret()` now checks the active CompileEnvironment's
   settings first, falling back to the env var when no environment is
   active (e.g., at test module import time). This ensures code that
   queries interpret mode during compilation/autotuning sees the
   Settings value, not just the env var.

This means `Settings(backend="pallas", pallas_interpret=True)` is now
sufficient to run in interpret mode without any environment variable.
The env var remains as a fallback for backwards compatibility.

Compatible with PR #2491 (Pallas interpret CI job) which uses
`is_pallas_interpret()` in `_get_vmem_limit_bytes`, test decorators,
and benchmarking sync logic -- all of which now correctly respect the
Settings flag when a CompileEnvironment is active.

Authored by Claude.
