### PR TITLE
[Pallas] Make Pallas interpret mode honor TPU constraints

### DIFF
--- a/helion/_compat.py
+++ b/helion/_compat.py
@@ -245,7 +245,11 @@ if triton_is_available():
     def _min_dot_size(
         device: torch.device, lhs: torch.dtype, rhs: torch.dtype
     ) -> tuple[int, int, int]:
-        if device.type == "tpu":
+        # Helion's Pallas backend always targets TPU's Mosaic MXU, even in
+        # interpret mode where the actual device is "cpu".
+        from .runtime.settings import _get_backend
+
+        if _get_backend() == "pallas":
             # TPU Mosaic MXU tile: (8, 128) sublane × lane.
             # pl.dot(lhs[M,K], rhs[K,N]) needs M>=8, K>=128, N>=128.
             return (8, 128, 128)
@@ -328,7 +332,9 @@ else:
     def _min_dot_size(  # type: ignore[misc]
         device: torch.device, lhs: torch.dtype, rhs: torch.dtype
     ) -> tuple[int, int, int]:
-        if device.type == "tpu":
+        from .runtime.settings import _get_backend
+
+        if _get_backend() == "pallas":
             return (8, 128, 128)
         return (16, 16, 16)
 

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -248,6 +248,20 @@ def _get_vmem_limit_bytes(pltpu: object) -> int:
     if _CACHED_VMEM_LIMIT_BYTES is not None:
         return _CACHED_VMEM_LIMIT_BYTES
 
+    # In interpret mode there is no real TPU; query the synthetic TPU info
+    # registered by ``_ensure_cpu_tpu_info`` so the budget matches what real
+    # TPU 7X reports rather than falling back to the conservative 16MB default.
+    from .settings import is_pallas_interpret
+
+    if is_pallas_interpret():
+        try:
+            from jax._src.pallas.mosaic.tpu_info import registry
+
+            _CACHED_VMEM_LIMIT_BYTES = registry["cpu"]().vmem_capacity_bytes
+            return _CACHED_VMEM_LIMIT_BYTES
+        except (ImportError, KeyError, AttributeError):
+            pass
+
     try:
         get_tpu_info = pltpu.get_tpu_info  # pyrefly: ignore[missing-attribute]
         _CACHED_VMEM_LIMIT_BYTES = get_tpu_info().vmem_capacity_bytes


### PR DESCRIPTION
Align two interpret-mode fallbacks with what TPU actually does, so Helion's Pallas interpret path is a faithful proxy for real TPU.

- `helion/_compat.py` — `_min_dot_size` now returns the TPU MXU constraints `(8, 128, 128)` whenever the helion backend is pallas, regardless of `device.type`. Previously it keyed on `device.type == "tpu"`, so interpret-mode runs on cpu got the generic `(16, 16, 16)` default and matmul block-size minimums diverged from TPU.
- `helion/runtime/__init__.py` — `_get_vmem_limit_bytes` now consults the synthetic CPU `TpuInfo` entry registered by `_ensure_cpu_tpu_info` when running in interpret mode. Previously `pltpu.get_tpu_info()` raised without libtpu and the generic `except` branch handed back a conservative 16 MiB — the TPU 7X synthetic entry actually reports 64 MiB, matching real TPU 7X. The synthetic info is hardcoded JAX spec data, so it works on CI runners without libtpu installed.
