### PR TITLE
[Pallas] Route meta output-only tensors to CPU under interpret

### DIFF
--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -788,11 +788,11 @@ def _pallas_invoke_and_return(
                 # On TPU, JaxCallable returns torch tensors directly.
                 out_tensor = cast("torch.Tensor", args[orig_pos])
                 # Output-only tensors are allocated with ``device='meta'`` to
-                # avoid HBM; fall back to the first real input's device in
-                # interpret mode so the converted tensor lands somewhere real.
+                # avoid HBM; interpret mode runs on CPU so the converted
+                # tensor lands there.
                 device = out_tensor.device
-                if device.type == "meta" and tensor_arg_indices:
-                    device = cast("torch.Tensor", args[tensor_arg_indices[0]]).device
+                if device.type == "meta":
+                    device = torch.device("cpu")
                 result = _jax_to_torch(
                     result,
                     device=device,


### PR DESCRIPTION
The interpret-mode meta-fallback in `_pallas_invoke_and_return` only fired when `tensor_arg_indices` was non-empty:

```python
if device.type == "meta" and tensor_arg_indices:
    device = args[tensor_arg_indices[0]].device
```

That covers the common case where a kernel reads from some input tensor — interpret mode runs on CPU, the input lives on CPU, and the result lands on CPU.

It misses the edge case where the kernel writes only constants (e.g. `out = torch.empty_like(x); out[tile] = hl.full(...)`). Helion doesn't need to load `x` into pallas, so `tensor_arg_indices` is `[]`, the guard is falsy, and the meta `out` tensor flows out unchanged. Tests downstream then hit `assert_close` device mismatches.

Since this branch is interpret-only (it lives inside `if not isinstance(result, torch.Tensor):`, and only `_PallasInterpretCallable` returns JAX arrays), and interpret mode always runs on CPU, drop the input-chasing fallback and route meta outputs to `cpu` directly. Same answer for the common case, fixes the edge case.

Affects `test_store_slice_1d/2d/skips_pl_ds_dim` and `test_while_accumulates_tensor`, which use the constant-fill pattern.
