### PR TITLE
[Pallas] Support tile.index broadcast indexing in load codegen

### DIFF
--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -1541,6 +1541,7 @@ class DeviceFunction:
     def get_tensor_read_write_names(self) -> tuple[set[str], set[str]]:
         """Returns AST names of read and written tensors"""
         from helion.language import memory_ops
+        from helion.language import tile_index
         from helion.language.atomic_ops import ATOMIC_OPS
 
         read_names: set[str] = set()
@@ -1550,20 +1551,35 @@ class DeviceFunction:
                 if node.op != "call_function":
                     continue
 
-                def _get_tensor_name(node: torch.fx.Node) -> str:
+                def _get_tensor_name(node: torch.fx.Node) -> str | None:
                     tensor_arg = node.args[0]
                     assert isinstance(tensor_arg, torch.fx.Node)
+                    # tile.index loads operate on a synthesized FakeTensor
+                    # that is not registered in ``tensor_to_origin``; they
+                    # are materialized inline by the load codegen rather
+                    # than referencing a kernel-arg tensor.
+                    if (
+                        tensor_arg.op == "call_function"
+                        and tensor_arg.target == tile_index
+                    ):
+                        return None
                     tensor_val = tensor_arg.meta.get("val")
                     assert isinstance(tensor_val, torch.Tensor)
                     return self.tensor_arg(tensor_val).name
 
                 if node.target is memory_ops.load:
-                    read_names.add(_get_tensor_name(node))
+                    name = _get_tensor_name(node)
+                    if name is not None:
+                        read_names.add(name)
                 elif node.target is memory_ops.store:
-                    write_names.add(_get_tensor_name(node))
+                    name = _get_tensor_name(node)
+                    if name is not None:
+                        write_names.add(name)
                 elif node.target in ATOMIC_OPS:
-                    read_names.add(_get_tensor_name(node))
-                    write_names.add(_get_tensor_name(node))
+                    name = _get_tensor_name(node)
+                    if name is not None:
+                        read_names.add(name)
+                        write_names.add(name)
         return read_names, write_names
 
     def __enter__(self) -> None:

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -4268,6 +4268,46 @@ def _(
     raise NotImplementedError(f"Unsupported tensor type: {type(tensor)}")
 
 
+def _maybe_materialize_tile_index_load(
+    state: CodegenState,
+    tensor: torch.Tensor,
+    subscript: list[object] | tuple[object, ...],
+) -> ast.AST | None:
+    """If this load is on a ``tile.index`` value (e.g. ``tile_m.index[:, None]``),
+    emit the inline ``indices_<bid>[<sub>]`` expression and return it.
+    Returns ``None`` otherwise.
+
+    ``tile.index`` tensors are synthesized inside the kernel — they aren't
+    registered in ``tensor_to_origin`` — so the regular load path's
+    ``tensor_arg`` lookup would ``KeyError``.  Supported subscript entries
+    are ``None`` (new axis) and ``slice(None)`` (full slice).
+    """
+    from ..language import tile_index
+
+    tensor_node = state.fx_node.args[0] if state.fx_node is not None else None
+    if not (
+        isinstance(tensor_node, torch.fx.Node)
+        and tensor_node.op == "call_function"
+        and tensor_node.target == tile_index
+    ):
+        return None
+
+    env = CompileEnvironment.current()
+    block_id = env.get_block_id(tensor.size(0))
+    assert block_id is not None
+    base_var = state.codegen.index_var(block_id)
+
+    parts = []
+    for idx in subscript:
+        if idx is None:
+            parts.append("None")
+        elif idx == slice(None):
+            parts.append(":")
+        else:
+            raise AssertionError(f"Unexpected index type in tile_index load: {idx}")
+    return expr_from_string(f"{base_var}[{', '.join(parts)}]")
+
+
 @_decorators.codegen(load, "triton")
 def _(state: CodegenState) -> ast.AST:
     tensor = state.proxy_arg(0)
@@ -4295,33 +4335,9 @@ def _(state: CodegenState) -> ast.AST:
         eviction_policy = ast.Constant(value=eviction_policy)
 
     if isinstance(tensor, torch.Tensor):
-        # If tile_index(...) is being broadcast-only indexed
-        from ..language import tile_index
-
-        tensor_node = state.fx_node.args[0] if state.fx_node is not None else None
-        if (
-            isinstance(tensor_node, torch.fx.Node)
-            and tensor_node.op == "call_function"
-            and tensor_node.target == tile_index
-        ):
-            # tile.index tensors are not real memory accesses; materialize the
-            # block index variable with the requested broadcast/reshape.
-            env = CompileEnvironment.current()
-            block_id = env.get_block_id(tensor.size(0))
-            assert block_id is not None
-            base_var = state.codegen.index_var(block_id)
-
-            parts = []
-            for idx in subscript:
-                if idx is None:
-                    parts.append("None")
-                elif idx == slice(None):
-                    parts.append(":")
-                else:
-                    raise AssertionError(
-                        f"Unexpected index type in tile_index load: {idx}"
-                    )
-            return expr_from_string(f"{base_var}[{', '.join(parts)}]")
+        tile_index_result = _maybe_materialize_tile_index_load(state, tensor, subscript)
+        if tile_index_result is not None:
+            return tile_index_result
 
         # Use the shared memory op index for indexing strategy
         indexing_idx = device_fn.device_memory_op_index
@@ -4362,6 +4378,11 @@ def _(state: CodegenState) -> ast.AST:
     subscript = state.proxy_arg(1)
     assert isinstance(tensor, torch.Tensor)
     assert isinstance(subscript, (list, tuple))
+
+    tile_index_result = _maybe_materialize_tile_index_load(state, tensor, subscript)
+    if tile_index_result is not None:
+        return tile_index_result
+
     return pallas_codegen.load_expr(state, list(subscript), tensor)
 
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1232,6 +1232,30 @@ class TestPallas(TestCase):
         x = torch.randn(4, 8, dtype=torch.float32, device=DEVICE)
         code_and_output(k, (x,))
 
+    def test_tile_index_broadcast_mask(self) -> None:
+        """Two 1D ``tile.index`` tensors must broadcast into a 2D mask via
+        ``[:, None]`` / ``[None, :]`` indexing — the natural PyTorch idiom
+        for causal / sliding-window mask construction.
+        """
+
+        @helion.kernel(static_shapes=True)
+        def k(x: torch.Tensor) -> torch.Tensor:
+            M, N = x.size()
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(M):
+                for tile_n in hl.tile(N):
+                    mask = tile_m.index[:, None] >= tile_n.index[None, :]
+                    out[tile_m, tile_n] = torch.where(
+                        mask, x[tile_m, tile_n], torch.zeros_like(x[tile_m, tile_n])
+                    )
+            return out
+
+        x = torch.randn(8, 8, dtype=torch.float32, device=DEVICE)
+        _, result = code_and_output(k, (x,))
+        idx = torch.arange(8, device=DEVICE)
+        ref = torch.where(idx[:, None] >= idx[None, :], x, torch.zeros_like(x))
+        torch.testing.assert_close(result, ref)
+
     def test_emit_pipeline_loop_order(self) -> None:
         """Test emit_pipeline with loop_order reordering.
 


### PR DESCRIPTION
## Summary

`tile_m.index[:, None] >= tile_n.index[None, :]` — the natural PyTorch idiom for causal / sliding-window / local-attention mask construction — raised `KeyError: FakeTensor(..., size=(u0,), dtype=torch.int32)` on the Pallas backend. Triton already handled this via a `tile_index` short-circuit in its `load` codegen that materializes the block-index variable directly (`indices_<bid>`); Pallas was just delegating to the regular load path, which calls `tensor_arg` on the synthesized `tile_index` FakeTensor (never registered in `tensor_to_origin`).

## Fix

Extract the existing Triton short-circuit into a shared helper, `_maybe_materialize_tile_index_load`, and call it from both the Triton and Pallas `@codegen(load, …)` handlers. For loads whose first arg is a `tile_index` call, the helper emits `indices_<bid>[<subscript>]` directly instead of going through `load_expr` / `tensor_arg`. The `indices_<bid>` binding is already emitted at the emit_pipeline / fori_loop body prologue (`_emit_inner_loop_index_setup`), so this just consumes a variable that's already in scope.

Also teach `DeviceFunction.get_tensor_read_write_names` to skip `tile_index`-rooted loads — those don't reference any kernel-arg tensor (they're materialized inline) and hit the same `tensor_arg` `KeyError` otherwise.

The `.unsqueeze(d)` form already worked. This change closes the gap so the more common numpy-style `[:, None]` / `[None, :]` broadcast also compiles, matching Triton behavior.

## Regression test

`test/test_pallas.py::TestPallas::test_tile_index_broadcast_mask` — exercises `tile_m.index[:, None] >= tile_n.index[None, :]` and validates the output against a PyTorch reference. Verified to fail on `main` with `KeyError` at compile time.
