### PR TITLE
Add a C extension so launches skip more Python frames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *.a
 *.bak
 benchmarks/tritonbench
+# scikit-build-core CMake build directory
+/build/
 *.bzl
 .build-wheels
 .cache
@@ -112,3 +114,5 @@ cute_sweep_results.jsonl
 # Per-user Claude Code settings; ``.claude/skills/`` is tracked but
 # this file lives alongside it and is per-session local state.
 .claude/settings.local.json
+# Per-session lock files written by Claude Code's scheduled-task hook.
+.claude/*.lock

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.20)
+project(helion_c CXX)
+
+# Helion's C extension layer (see helion/_C/_helion_c.cpp and helion/_C.py).
+#
+# Built into ``helion._C_ext`` (the actual extension module) and re-exported
+# from the pure-Python shim ``helion/_C.py`` as ``helion._C`` so callers
+# match the public API (`from helion._C import tensor_key`).
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
+
+# Use scikit-build-core's Python_add_library helper. It creates a shared
+# library with the right Python prefix/suffix per platform/Python version
+# and links against the appropriate Python runtime.
+Python_add_library(_C_ext MODULE WITH_SOABI
+  helion/_C/_helion_c.cpp
+)
+
+# Disable expensive default warnings; we'll restrict to a small surface area
+# and rely on PR review for code quality. Add ``-fvisibility=hidden`` so
+# only ``PyInit__C_ext`` is exported.
+target_compile_options(_C_ext PRIVATE -O2 -Wall -fvisibility=hidden)
+
+# scikit-build-core installs whatever we tell it to into the wheel.
+# Put the .so next to ``helion/_C.py`` so the shim's relative import
+# (``from ._C_ext import ...``) resolves.
+install(TARGETS _C_ext LIBRARY DESTINATION helion)

--- a/helion/_C.py
+++ b/helion/_C.py
@@ -1,0 +1,47 @@
+"""Thin Python shim re-exporting Helion's C extension.
+
+The C sources live under ``helion/_C/`` (see ``CMakeLists.txt``) and are
+compiled into ``helion._C_ext`` so the directory and module names don't
+collide on the filesystem. This shim lets callers ``import helion._C``
+and use the public surface (`tensor_key`, `CompiledLauncher`) directly.
+
+Falls back to a sentinel ``available = False`` when the extension didn't
+build (e.g. PyTorch-on-MTIA, debug build), so the pure-Python
+``_FastLauncher`` stays usable as the fallback.
+"""
+
+from __future__ import annotations
+
+try:
+    # pyrefly: ignore [missing-import]  # built by CMake at install time
+    from ._C_ext import CompiledLauncher
+
+    # pyrefly: ignore [missing-import]  # built by CMake at install time
+    from ._C_ext import tensor_key
+
+    available: bool = True
+except ImportError:  # pragma: no cover - exercised only when build is missing
+    available = False
+
+    def tensor_key(_tensor: object) -> None:  # type: ignore[misc]
+        """Stub matching the C signature; always returns ``None``.
+
+        ``None`` is the documented sentinel telling the caller to fall
+        back to the Python implementation (used for SymInts, etc.), so
+        having the stub always return it is equivalent to "C ext not
+        installed".
+        """
+        return None
+
+    class CompiledLauncher:  # type: ignore[no-redef]
+        """Stub raising on construction. Used only as a type marker."""
+
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            raise RuntimeError(
+                "helion._C is unavailable in this build; the C extension "
+                "didn't compile. Falling back to the pure-Python "
+                "_FastLauncher."
+            )
+
+
+__all__ = ["CompiledLauncher", "available", "tensor_key"]

--- a/helion/_C/_helion_c.cpp
+++ b/helion/_C/_helion_c.cpp
@@ -1,0 +1,736 @@
+// Helion C extension: bind cache + CompiledLauncher.
+//
+// Two primary consumers:
+//
+//   1. ``helion._C.tensor_key(tensor)`` — drop-in C replacement for the
+//      hot ``_tensor_key`` Python function called once per tensor arg per
+//      ``Kernel.__call__`` from inside ``_base_specialization_key``.
+//      Returns the same shape of Python tuple, but avoids a fistful of
+//      Python frames per invocation. Plumbed in behind ``HELION_C_BIND``
+//      (default on when the .so is present).
+//
+//   2. ``helion._C.CompiledLauncher`` — a Python type whose instances
+//      hold ``(compiled_run, function, packed_metadata, hooks, device,
+//      stream getter, binder, run_kwargs)`` and expose a single
+//      ``launch(grid_0, grid_1, grid_2, *args)`` Python method that
+//      issues the kernel through Triton's own C launcher with as little
+//      Python work as possible. Used by :class:`helion.runtime._FastLauncher`
+//      to dispatch the hot path without the per-call Python frame.
+//
+// The extension is loaded lazily; if any part of import fails (e.g. on
+// MTIA / debug builds), the pure-Python ``_FastLauncher`` continues to
+// work as a fallback.
+
+// Limited API is convenient but we intentionally don't enable it because
+// CPython 3.10's limited API doesn't expose tuple internals we'd want
+// for the bind cache fast path. Use the regular CPython API.
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <structmember.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace {
+
+// -----------------------------------------------------------------------------
+// Bind cache helpers
+// -----------------------------------------------------------------------------
+//
+// ``tensor_key(tensor)`` mirrors the static-shape branch of
+// ``helion.runtime.kernel._tensor_key`` exactly:
+//   ``(dtype, hashable_dims(size), hashable_dims(stride), static_indices)``.
+//
+// ``hashable_dims`` for non-SymInt ints is just the int itself (we leave
+// the SymInt branch in Python because it touches torch.SymInt internals
+// that aren't trivially reachable from C). Likewise the bucketed
+// (non-static_shapes) branch and the int64 indexing probe stay in
+// Python — they are taken on a far colder path.
+
+// Cached references resolved on first use. We hold strong refs that
+// outlive the module. Lifetime matches the interpreter — there is no
+// module finalizer (``m_free``) registered, so these are intentionally
+// leaked at process shutdown.
+static PyObject *g_torch_Tensor = nullptr;
+static PyObject *g_empty_frozenset = nullptr;
+static PyObject *g_static_indices_attr = nullptr;
+static PyObject *g_frozenset_type = nullptr;
+
+static int resolve_torch_tensor() {
+  if (g_torch_Tensor != nullptr) {
+    return 0;
+  }
+  PyObject *torch_mod = PyImport_ImportModule("torch");
+  if (torch_mod == nullptr) {
+    return -1;
+  }
+  PyObject *tensor_cls = PyObject_GetAttrString(torch_mod, "Tensor");
+  Py_DECREF(torch_mod);
+  if (tensor_cls == nullptr) {
+    return -1;
+  }
+  g_torch_Tensor = tensor_cls; // keep strong ref
+  return 0;
+}
+
+static int ensure_static_cache() {
+  if (g_empty_frozenset == nullptr) {
+    g_empty_frozenset = PyFrozenSet_New(nullptr);
+    if (g_empty_frozenset == nullptr) {
+      return -1;
+    }
+  }
+  if (g_static_indices_attr == nullptr) {
+    g_static_indices_attr = PyUnicode_InternFromString("_dynamo_static_indices");
+    if (g_static_indices_attr == nullptr) {
+      return -1;
+    }
+  }
+  if (g_frozenset_type == nullptr) {
+    g_frozenset_type = reinterpret_cast<PyObject *>(&PyFrozenSet_Type);
+    Py_INCREF(g_frozenset_type);
+  }
+  return 0;
+}
+
+// Build the Python tuple ``hashable_dims(dims)``. For non-SymInt
+// integral dims this is just a tuple of those ints. If a SymInt is
+// encountered we bail out to ``nullptr`` and the caller falls back to
+// the Python implementation (which knows how to hash the SymInt).
+static PyObject *hashable_dims_from_sizes(const int64_t *dims, Py_ssize_t n) {
+  PyObject *out = PyTuple_New(n);
+  if (out == nullptr) {
+    return nullptr;
+  }
+  for (Py_ssize_t i = 0; i < n; ++i) {
+    PyObject *v = PyLong_FromLongLong(static_cast<long long>(dims[i]));
+    if (v == nullptr) {
+      Py_DECREF(out);
+      return nullptr;
+    }
+    PyTuple_SET_ITEM(out, i, v); // steals ref
+  }
+  return out;
+}
+
+// Public ``helion._C.tensor_key(tensor) -> tuple | None``.
+//
+// Always uses the static_shapes branch — that's the only one that
+// matters for the hot path (``examples/add.py``). The dynamic-shape
+// and bucketed branches stay in Python and are taken on far colder
+// paths via the ``_tensor_key`` Python fallback. Returns ``None`` to
+// tell the caller to take the Python path (e.g. SymInt sizes, or any
+// input that isn't a ``torch.Tensor``).
+static PyObject *helion_c_tensor_key(PyObject *self, PyObject *const *args,
+                                     Py_ssize_t nargs, PyObject *kwnames) {
+  if (resolve_torch_tensor() < 0) {
+    return nullptr;
+  }
+  if (ensure_static_cache() < 0) {
+    return nullptr;
+  }
+  if (nargs != 1) {
+    PyErr_SetString(PyExc_TypeError,
+                    "tensor_key() requires exactly one positional argument");
+    return nullptr;
+  }
+  PyObject *tensor = args[0];
+  // Quick type check via fast path. ``PyObject_IsInstance`` is cheap and
+  // accepts subclasses (e.g. torch.nn.Parameter, FakeTensor).
+  int is_tensor = PyObject_IsInstance(tensor, g_torch_Tensor);
+  if (is_tensor < 0) {
+    return nullptr;
+  }
+  if (is_tensor == 0) {
+    Py_RETURN_NONE; // signal caller to take the Python path
+  }
+
+  // Pull dtype as an opaque object (compared via ``is`` / ``==``).
+  PyObject *dtype = PyObject_GetAttrString(tensor, "dtype");
+  if (dtype == nullptr) {
+    return nullptr;
+  }
+
+  // Sizes + strides as Python tuples of ints. For most tensors these
+  // are 1–4 element tuples; we go through the public ``.size()`` /
+  // ``.stride()`` methods to avoid touching at::Tensor internals.
+  PyObject *size_seq = PyObject_CallMethod(tensor, "size", nullptr);
+  if (size_seq == nullptr) {
+    Py_DECREF(dtype);
+    return nullptr;
+  }
+  PyObject *stride_seq = PyObject_CallMethod(tensor, "stride", nullptr);
+  if (stride_seq == nullptr) {
+    Py_DECREF(dtype);
+    Py_DECREF(size_seq);
+    return nullptr;
+  }
+
+  // Detect SymInts cheaply: ``size()`` returns ``torch.Size`` (a tuple
+  // subclass) — fast-path the all-int case via PyLong_Check on each
+  // element. Any non-PyLong → return None and let Python handle it.
+  PyObject *size_fast = PySequence_Fast(size_seq, "size() must be a sequence");
+  if (size_fast == nullptr) {
+    Py_DECREF(dtype);
+    Py_DECREF(size_seq);
+    Py_DECREF(stride_seq);
+    return nullptr;
+  }
+  Py_ssize_t ndim = PySequence_Fast_GET_SIZE(size_fast);
+  PyObject **size_items = PySequence_Fast_ITEMS(size_fast);
+  int64_t stack_sizes[8];
+  int64_t *sizes_buf = ndim <= 8 ? stack_sizes : new int64_t[ndim];
+  for (Py_ssize_t i = 0; i < ndim; ++i) {
+    if (!PyLong_CheckExact(size_items[i])) {
+      // SymInt or some other unusual object — bail to Python.
+      if (sizes_buf != stack_sizes) delete[] sizes_buf;
+      Py_DECREF(size_fast);
+      Py_DECREF(dtype);
+      Py_DECREF(size_seq);
+      Py_DECREF(stride_seq);
+      Py_RETURN_NONE;
+    }
+    sizes_buf[i] = PyLong_AsLongLong(size_items[i]);
+    if (sizes_buf[i] == -1 && PyErr_Occurred()) {
+      if (sizes_buf != stack_sizes) delete[] sizes_buf;
+      Py_DECREF(size_fast);
+      Py_DECREF(dtype);
+      Py_DECREF(size_seq);
+      Py_DECREF(stride_seq);
+      return nullptr;
+    }
+  }
+  Py_DECREF(size_fast);
+
+  PyObject *stride_fast =
+      PySequence_Fast(stride_seq, "stride() must be a sequence");
+  if (stride_fast == nullptr) {
+    if (sizes_buf != stack_sizes) delete[] sizes_buf;
+    Py_DECREF(dtype);
+    Py_DECREF(size_seq);
+    Py_DECREF(stride_seq);
+    return nullptr;
+  }
+  Py_ssize_t sndim = PySequence_Fast_GET_SIZE(stride_fast);
+  PyObject **stride_items = PySequence_Fast_ITEMS(stride_fast);
+  int64_t stack_strides[8];
+  int64_t *strides_buf =
+      sndim <= 8 ? stack_strides : new int64_t[sndim];
+  for (Py_ssize_t i = 0; i < sndim; ++i) {
+    if (!PyLong_CheckExact(stride_items[i])) {
+      if (sizes_buf != stack_sizes) delete[] sizes_buf;
+      if (strides_buf != stack_strides) delete[] strides_buf;
+      Py_DECREF(stride_fast);
+      Py_DECREF(dtype);
+      Py_DECREF(size_seq);
+      Py_DECREF(stride_seq);
+      Py_RETURN_NONE;
+    }
+    strides_buf[i] = PyLong_AsLongLong(stride_items[i]);
+    if (strides_buf[i] == -1 && PyErr_Occurred()) {
+      if (sizes_buf != stack_sizes) delete[] sizes_buf;
+      if (strides_buf != stack_strides) delete[] strides_buf;
+      Py_DECREF(stride_fast);
+      Py_DECREF(dtype);
+      Py_DECREF(size_seq);
+      Py_DECREF(stride_seq);
+      return nullptr;
+    }
+  }
+  Py_DECREF(stride_fast);
+  Py_DECREF(size_seq);
+  Py_DECREF(stride_seq);
+
+  PyObject *sizes_tuple = hashable_dims_from_sizes(sizes_buf, ndim);
+  PyObject *strides_tuple = hashable_dims_from_sizes(strides_buf, sndim);
+  if (sizes_buf != stack_sizes) delete[] sizes_buf;
+  if (strides_buf != stack_strides) delete[] strides_buf;
+  if (sizes_tuple == nullptr || strides_tuple == nullptr) {
+    Py_DECREF(dtype);
+    Py_XDECREF(sizes_tuple);
+    Py_XDECREF(strides_tuple);
+    return nullptr;
+  }
+
+  // static_indices: ``frozenset(getattr(t, '_dynamo_static_indices', ()))``.
+  // The vast majority of tensors don't have that attr; check via
+  // GetAttr-without-error for speed (PyObject_GetAttr would raise).
+  PyObject *static_indices_obj = nullptr;
+  if (PyObject_HasAttr(tensor, g_static_indices_attr)) {
+    PyObject *raw = PyObject_GetAttr(tensor, g_static_indices_attr);
+    if (raw == nullptr) {
+      Py_DECREF(dtype);
+      Py_DECREF(sizes_tuple);
+      Py_DECREF(strides_tuple);
+      return nullptr;
+    }
+    static_indices_obj = PyFrozenSet_New(raw);
+    Py_DECREF(raw);
+    if (static_indices_obj == nullptr) {
+      Py_DECREF(dtype);
+      Py_DECREF(sizes_tuple);
+      Py_DECREF(strides_tuple);
+      return nullptr;
+    }
+  } else {
+    Py_INCREF(g_empty_frozenset);
+    static_indices_obj = g_empty_frozenset;
+  }
+
+  PyObject *out = PyTuple_New(4);
+  if (out == nullptr) {
+    Py_DECREF(dtype);
+    Py_DECREF(sizes_tuple);
+    Py_DECREF(strides_tuple);
+    Py_DECREF(static_indices_obj);
+    return nullptr;
+  }
+  PyTuple_SET_ITEM(out, 0, dtype);
+  PyTuple_SET_ITEM(out, 1, sizes_tuple);
+  PyTuple_SET_ITEM(out, 2, strides_tuple);
+  PyTuple_SET_ITEM(out, 3, static_indices_obj);
+  (void)kwnames;
+  (void)self;
+  return out;
+}
+
+// -----------------------------------------------------------------------------
+// CompiledLauncher
+// -----------------------------------------------------------------------------
+//
+// Holds all the per-config state captured from Triton at warmup time
+// (CompiledKernel, packed metadata, hooks, ...). Its ``launch(grid_0,
+// grid_1, grid_2, *args)`` method dispatches into Triton's own C
+// launcher (``compiled_kernel.run``) with no Python wrapper frames
+// between us and it.
+
+typedef struct {
+  PyObject_HEAD
+  PyObject *compiled_run;        // bound method: compiled_kernel.run
+  PyObject *triton_function;     // compiled_kernel.function
+  PyObject *packed_metadata;     // compiled_kernel.packed_metadata
+  PyObject *kernel_launch_metadata; // compiled_kernel.launch_metadata (callable)
+  PyObject *launch_enter_hook;   // triton.knobs.runtime.launch_enter_hook (object)
+  PyObject *launch_exit_hook;    // triton.knobs.runtime.launch_exit_hook (object)
+  PyObject *get_current_stream;  // active_driver.get_current_stream (bound method)
+  PyObject *device;              // device handle
+  PyObject *binder;              // device_cache[4] (or None if skip)
+  PyObject *run_kwargs;          // pre-built dict {num_warps, num_stages, ...}
+  int bind_skip_safe;            // 0 / 1
+} CompiledLauncherObject;
+
+static int CompiledLauncher_init(CompiledLauncherObject *self, PyObject *args,
+                                 PyObject *kwds) {
+  static const char *kwlist[] = {"compiled_run",
+                                 "triton_function",
+                                 "packed_metadata",
+                                 "kernel_launch_metadata",
+                                 "launch_enter_hook",
+                                 "launch_exit_hook",
+                                 "get_current_stream",
+                                 "device",
+                                 "binder",
+                                 "run_kwargs",
+                                 "bind_skip_safe",
+                                 nullptr};
+  PyObject *compiled_run, *triton_function, *packed_metadata;
+  PyObject *kernel_launch_metadata, *launch_enter_hook, *launch_exit_hook;
+  PyObject *get_current_stream, *device, *binder, *run_kwargs;
+  int bind_skip_safe;
+  if (!PyArg_ParseTupleAndKeywords(
+          args, kwds, "OOOOOOOOOOp",
+          // Cast away const for the legacy keyword-list signature.
+          const_cast<char **>(kwlist), &compiled_run, &triton_function,
+          &packed_metadata, &kernel_launch_metadata, &launch_enter_hook,
+          &launch_exit_hook, &get_current_stream, &device, &binder,
+          &run_kwargs, &bind_skip_safe)) {
+    return -1;
+  }
+  Py_INCREF(compiled_run);
+  Py_INCREF(triton_function);
+  Py_INCREF(packed_metadata);
+  Py_INCREF(kernel_launch_metadata);
+  Py_INCREF(launch_enter_hook);
+  Py_INCREF(launch_exit_hook);
+  Py_INCREF(get_current_stream);
+  Py_INCREF(device);
+  Py_INCREF(binder);
+  Py_INCREF(run_kwargs);
+  self->compiled_run = compiled_run;
+  self->triton_function = triton_function;
+  self->packed_metadata = packed_metadata;
+  self->kernel_launch_metadata = kernel_launch_metadata;
+  self->launch_enter_hook = launch_enter_hook;
+  self->launch_exit_hook = launch_exit_hook;
+  self->get_current_stream = get_current_stream;
+  self->device = device;
+  self->binder = binder;
+  self->run_kwargs = run_kwargs;
+  self->bind_skip_safe = bind_skip_safe ? 1 : 0;
+  return 0;
+}
+
+static void CompiledLauncher_dealloc(CompiledLauncherObject *self) {
+  Py_XDECREF(self->compiled_run);
+  Py_XDECREF(self->triton_function);
+  Py_XDECREF(self->packed_metadata);
+  Py_XDECREF(self->kernel_launch_metadata);
+  Py_XDECREF(self->launch_enter_hook);
+  Py_XDECREF(self->launch_exit_hook);
+  Py_XDECREF(self->get_current_stream);
+  Py_XDECREF(self->device);
+  Py_XDECREF(self->binder);
+  Py_XDECREF(self->run_kwargs);
+  Py_TYPE(self)->tp_free(reinterpret_cast<PyObject *>(self));
+}
+
+// Determine whether either hook has any active subscribers. Newer
+// Triton wraps these in a ``HookChain`` whose ``.calls`` attribute is a
+// list (empty means no subscribers); older Triton just uses ``None`` /
+// callable. Matches the Python ``_FastLauncher`` check.
+static int hooks_inactive(PyObject *enter_hook, PyObject *exit_hook) {
+  // Returns 1 if both hooks are inactive (so we can skip launch_metadata).
+  // Returns 0 if either has work to do.
+  static PyObject *calls_attr = nullptr;
+  if (calls_attr == nullptr) {
+    calls_attr = PyUnicode_InternFromString("calls");
+    if (calls_attr == nullptr) {
+      // Defer to the slow path; can't decide.
+      PyErr_Clear();
+      return 0;
+    }
+  }
+  for (int i = 0; i < 2; ++i) {
+    PyObject *hook = (i == 0) ? enter_hook : exit_hook;
+    if (hook == Py_None) {
+      continue;
+    }
+    if (!PyObject_HasAttr(hook, calls_attr)) {
+      return 0; // Treat as active (older Triton style).
+    }
+    PyObject *calls = PyObject_GetAttr(hook, calls_attr);
+    if (calls == nullptr) {
+      PyErr_Clear();
+      return 0;
+    }
+    int empty = 0;
+    if (PyList_Check(calls)) {
+      empty = (PyList_GET_SIZE(calls) == 0);
+    } else {
+      Py_ssize_t sz = PyObject_Size(calls);
+      empty = (sz == 0);
+      if (sz < 0) PyErr_Clear();
+    }
+    Py_DECREF(calls);
+    if (!empty) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+// Shared core of the CompiledLauncher dispatch. Both the explicit
+// ``.launch(...)`` method and the ``tp_call`` slot funnel through here.
+// ``grid_0/1/2`` are the unpacked grid dims; ``kernel_args``/``kernel_nargs``
+// is the kernel argument array (already grid-stripped).
+static PyObject *CompiledLauncher_dispatch(CompiledLauncherObject *self,
+                                           PyObject *grid_0, PyObject *grid_1,
+                                           PyObject *grid_2,
+                                           PyObject *const *kernel_args,
+                                           Py_ssize_t kernel_nargs) {
+  // Resolve binder result: either pass kernel_args through, or call
+  // the binder to canonicalize. Storage for the bound-args tuple lives
+  // for the duration of this call.
+  PyObject *bound_tuple_owner = nullptr;
+  PyObject *const *final_kernel_args = kernel_args;
+  Py_ssize_t final_kernel_nargs = kernel_nargs;
+
+  if (!self->bind_skip_safe && self->binder != Py_None) {
+    PyObject *binder_args = PyTuple_New(kernel_nargs);
+    if (binder_args == nullptr) {
+      return nullptr;
+    }
+    for (Py_ssize_t i = 0; i < kernel_nargs; ++i) {
+      Py_INCREF(kernel_args[i]);
+      PyTuple_SET_ITEM(binder_args, i, kernel_args[i]);
+    }
+    PyObject *binder_result =
+        PyObject_Call(self->binder, binder_args, self->run_kwargs);
+    Py_DECREF(binder_args);
+    if (binder_result == nullptr) {
+      return nullptr;
+    }
+    if (!PyTuple_Check(binder_result) || PyTuple_GET_SIZE(binder_result) < 1) {
+      Py_DECREF(binder_result);
+      PyErr_SetString(PyExc_RuntimeError, "binder returned unexpected shape");
+      return nullptr;
+    }
+    PyObject *bound_args_dict = PyTuple_GET_ITEM(binder_result, 0);
+    PyObject *values_iter = PyObject_CallMethod(bound_args_dict, "values", nullptr);
+    Py_DECREF(binder_result);
+    if (values_iter == nullptr) {
+      return nullptr;
+    }
+    // tuple(values()) → store and use its PySequence_Fast_ITEMS.
+    bound_tuple_owner = PySequence_Tuple(values_iter);
+    Py_DECREF(values_iter);
+    if (bound_tuple_owner == nullptr) {
+      return nullptr;
+    }
+    final_kernel_args =
+        reinterpret_cast<PyObject *const *>(PySequence_Fast_ITEMS(bound_tuple_owner));
+    final_kernel_nargs = PyTuple_GET_SIZE(bound_tuple_owner);
+  }
+
+  // stream = self._get_current_stream(self._device)
+  PyObject *stream = PyObject_CallOneArg(self->get_current_stream, self->device);
+  if (stream == nullptr) {
+    Py_XDECREF(bound_tuple_owner);
+    return nullptr;
+  }
+
+  // launch_metadata: only compute if hooks are active.
+  PyObject *launch_metadata;
+  if (hooks_inactive(self->launch_enter_hook, self->launch_exit_hook)) {
+    Py_INCREF(Py_None);
+    launch_metadata = Py_None;
+  } else {
+    // grid_tuple = (grid_0, grid_1, grid_2)
+    PyObject *grid_tuple = PyTuple_Pack(3, grid_0, grid_1, grid_2);
+    if (grid_tuple == nullptr) {
+      Py_DECREF(stream);
+      Py_XDECREF(bound_tuple_owner);
+      return nullptr;
+    }
+    // metadata_args = (grid_tuple, stream, *kernel_args)
+    Py_ssize_t md_nargs = 2 + final_kernel_nargs;
+    PyObject *md_call_args = PyTuple_New(md_nargs);
+    if (md_call_args == nullptr) {
+      Py_DECREF(grid_tuple);
+      Py_DECREF(stream);
+      Py_XDECREF(bound_tuple_owner);
+      return nullptr;
+    }
+    PyTuple_SET_ITEM(md_call_args, 0, grid_tuple);
+    Py_INCREF(stream);
+    PyTuple_SET_ITEM(md_call_args, 1, stream);
+    for (Py_ssize_t i = 0; i < final_kernel_nargs; ++i) {
+      Py_INCREF(final_kernel_args[i]);
+      PyTuple_SET_ITEM(md_call_args, 2 + i, final_kernel_args[i]);
+    }
+    launch_metadata = PyObject_Call(self->kernel_launch_metadata,
+                                    md_call_args, nullptr);
+    Py_DECREF(md_call_args);
+    if (launch_metadata == nullptr) {
+      Py_DECREF(stream);
+      Py_XDECREF(bound_tuple_owner);
+      return nullptr;
+    }
+  }
+
+  // compiled_run(grid_0, grid_1, grid_2, stream, function,
+  //              packed_metadata, launch_metadata,
+  //              enter_hook, exit_hook, *kernel_args)
+  Py_ssize_t total_args = 9 + final_kernel_nargs;
+  PyObject *call_args = PyTuple_New(total_args);
+  if (call_args == nullptr) {
+    Py_DECREF(stream);
+    Py_DECREF(launch_metadata);
+    Py_XDECREF(bound_tuple_owner);
+    return nullptr;
+  }
+  Py_INCREF(grid_0); PyTuple_SET_ITEM(call_args, 0, grid_0);
+  Py_INCREF(grid_1); PyTuple_SET_ITEM(call_args, 1, grid_1);
+  Py_INCREF(grid_2); PyTuple_SET_ITEM(call_args, 2, grid_2);
+  // stream (steal)
+  PyTuple_SET_ITEM(call_args, 3, stream);
+  Py_INCREF(self->triton_function);
+  PyTuple_SET_ITEM(call_args, 4, self->triton_function);
+  Py_INCREF(self->packed_metadata);
+  PyTuple_SET_ITEM(call_args, 5, self->packed_metadata);
+  // launch_metadata (steal)
+  PyTuple_SET_ITEM(call_args, 6, launch_metadata);
+  Py_INCREF(self->launch_enter_hook);
+  PyTuple_SET_ITEM(call_args, 7, self->launch_enter_hook);
+  Py_INCREF(self->launch_exit_hook);
+  PyTuple_SET_ITEM(call_args, 8, self->launch_exit_hook);
+  for (Py_ssize_t i = 0; i < final_kernel_nargs; ++i) {
+    Py_INCREF(final_kernel_args[i]);
+    PyTuple_SET_ITEM(call_args, 9 + i, final_kernel_args[i]);
+  }
+
+  PyObject *result = PyObject_Call(self->compiled_run, call_args, nullptr);
+  Py_DECREF(call_args);
+  Py_XDECREF(bound_tuple_owner);
+  return result;
+}
+
+// CompiledLauncher.launch(grid_0, grid_1, grid_2, *args) → object
+//
+// METH_FASTCALL: args is a contiguous PyObject* array. The first three
+// are grid coordinates (raw Python ints); the rest pass through to the
+// binder (if active) and the Triton C launcher.
+static PyObject *CompiledLauncher_launch(CompiledLauncherObject *self,
+                                         PyObject *const *args,
+                                         Py_ssize_t nargs) {
+  if (nargs < 3) {
+    PyErr_SetString(
+        PyExc_TypeError,
+        "CompiledLauncher.launch requires at least grid_0, grid_1, grid_2");
+    return nullptr;
+  }
+  return CompiledLauncher_dispatch(self, args[0], args[1], args[2],
+                                   args + 3, nargs - 3);
+}
+
+// CompiledLauncher.__call__(triton_kernel, grid_tuple, *args, **kwargs)
+//
+// Implements ``tp_call`` so a ``CompiledLauncher`` instance can be
+// installed directly as a generated wrapper's ``_launcher=`` default —
+// eliminating the ``_FastLauncher.__call__`` Python frame on the hot
+// path. The wrapper's call site looks like::
+//
+//     _launcher(_helion_add, ((N + B - 1) // B,), x, y, out,
+//               num_warps=2, num_stages=5)
+//
+// The triton_kernel positional arg is already baked into ``self->compiled_run``,
+// so we ignore it. The grid is a tuple like ``(grid_0,)`` (or up to 3 elems);
+// the kwargs are already baked into ``self->run_kwargs`` so we ignore them too.
+static PyObject *CompiledLauncher_call(CompiledLauncherObject *self,
+                                       PyObject *args, PyObject *kwargs) {
+  (void)kwargs;
+  Py_ssize_t nargs = PyTuple_GET_SIZE(args);
+  if (nargs < 2) {
+    PyErr_SetString(PyExc_TypeError,
+                    "CompiledLauncher() requires at least (triton_kernel, grid)");
+    return nullptr;
+  }
+  // args[0] is the triton_kernel function — already baked in, ignored.
+  PyObject *grid = PyTuple_GET_ITEM(args, 1);
+  if (!PyTuple_Check(grid)) {
+    PyErr_SetString(PyExc_TypeError,
+                    "CompiledLauncher() grid argument must be a tuple");
+    return nullptr;
+  }
+  Py_ssize_t grid_len = PyTuple_GET_SIZE(grid);
+  PyObject *grid_0 = (grid_len > 0) ? PyTuple_GET_ITEM(grid, 0) : nullptr;
+  PyObject *grid_1 = (grid_len > 1) ? PyTuple_GET_ITEM(grid, 1) : nullptr;
+  PyObject *grid_2 = (grid_len > 2) ? PyTuple_GET_ITEM(grid, 2) : nullptr;
+  static PyObject *g_one = nullptr;
+  if (g_one == nullptr) {
+    g_one = PyLong_FromLong(1);
+    if (g_one == nullptr) return nullptr;
+  }
+  if (grid_0 == nullptr) {
+    PyErr_SetString(PyExc_TypeError,
+                    "CompiledLauncher() grid tuple must have ≥ 1 element");
+    return nullptr;
+  }
+  if (grid_1 == nullptr) grid_1 = g_one;
+  if (grid_2 == nullptr) grid_2 = g_one;
+
+  // Kernel args: positional args[2:] of the call tuple. We need a
+  // pointer to the contiguous storage; PyTuple_GET_ITEM(args, i) gives
+  // us indexed access, and the underlying storage is contiguous, so we
+  // can hand its pointer (offset by 2) to the dispatch helper directly.
+  PyObject *const *kernel_args = nullptr;
+  Py_ssize_t kernel_nargs = nargs - 2;
+  if (kernel_nargs > 0) {
+    kernel_args = &PyTuple_GET_ITEM(args, 2);
+  }
+  return CompiledLauncher_dispatch(self, grid_0, grid_1, grid_2, kernel_args,
+                                   kernel_nargs);
+}
+
+static PyMethodDef CompiledLauncher_methods[] = {
+    {"launch", reinterpret_cast<PyCFunction>(CompiledLauncher_launch),
+     METH_FASTCALL,
+     "Issue the kernel via Triton's C launcher. Args: (grid_0, grid_1, grid_2, *kernel_args)."},
+    {nullptr, nullptr, 0, nullptr},
+};
+
+static PyTypeObject CompiledLauncher_Type = {
+    PyVarObject_HEAD_INIT(nullptr, 0)
+    "helion._C_ext.CompiledLauncher",              // tp_name
+    sizeof(CompiledLauncherObject),                // tp_basicsize
+    0,                                             // tp_itemsize
+    reinterpret_cast<destructor>(CompiledLauncher_dealloc), // tp_dealloc
+    0,                                             // tp_vectorcall_offset
+    nullptr,                                       // tp_getattr
+    nullptr,                                       // tp_setattr
+    nullptr,                                       // tp_as_async
+    nullptr,                                       // tp_repr
+    nullptr,                                       // tp_as_number
+    nullptr,                                       // tp_as_sequence
+    nullptr,                                       // tp_as_mapping
+    nullptr,                                       // tp_hash
+    reinterpret_cast<ternaryfunc>(CompiledLauncher_call), // tp_call
+    nullptr,                                       // tp_str
+    nullptr,                                       // tp_getattro
+    nullptr,                                       // tp_setattro
+    nullptr,                                       // tp_as_buffer
+    Py_TPFLAGS_DEFAULT,                            // tp_flags
+    "Helion C launcher (config + compiled kernel state).", // tp_doc
+    nullptr,                                       // tp_traverse
+    nullptr,                                       // tp_clear
+    nullptr,                                       // tp_richcompare
+    0,                                             // tp_weaklistoffset
+    nullptr,                                       // tp_iter
+    nullptr,                                       // tp_iternext
+    CompiledLauncher_methods,                      // tp_methods
+    nullptr,                                       // tp_members
+    nullptr,                                       // tp_getset
+    nullptr,                                       // tp_base
+    nullptr,                                       // tp_dict
+    nullptr,                                       // tp_descr_get
+    nullptr,                                       // tp_descr_set
+    0,                                             // tp_dictoffset
+    reinterpret_cast<initproc>(CompiledLauncher_init), // tp_init
+    nullptr,                                       // tp_alloc
+    PyType_GenericNew,                             // tp_new
+};
+
+static PyMethodDef HelionCMethods[] = {
+    {"tensor_key",
+     reinterpret_cast<PyCFunction>(helion_c_tensor_key),
+     METH_FASTCALL | METH_KEYWORDS,
+     "Return ``(dtype, sizes_tuple, strides_tuple, static_indices_frozenset)`` "
+     "for a tensor, or ``None`` if the caller should fall back to the Python "
+     "implementation (e.g. SymInt sizes)."},
+    {nullptr, nullptr, 0, nullptr},
+};
+
+static struct PyModuleDef helion_c_module = {
+    PyModuleDef_HEAD_INIT,
+    "helion._C_ext",
+    "Helion's compiled-kernel hot path: bind cache and CompiledLauncher.",
+    -1,
+    HelionCMethods,
+    nullptr,
+    nullptr,
+    nullptr,
+    nullptr,
+};
+
+} // anonymous namespace
+
+PyMODINIT_FUNC PyInit__C_ext(void) {
+  PyObject *module = PyModule_Create(&helion_c_module);
+  if (module == nullptr) {
+    return nullptr;
+  }
+  if (PyType_Ready(&CompiledLauncher_Type) < 0) {
+    Py_DECREF(module);
+    return nullptr;
+  }
+  Py_INCREF(&CompiledLauncher_Type);
+  if (PyModule_AddObject(module, "CompiledLauncher",
+                         reinterpret_cast<PyObject *>(&CompiledLauncher_Type)) <
+      0) {
+    Py_DECREF(&CompiledLauncher_Type);
+    Py_DECREF(module);
+    return nullptr;
+  }
+  return module;
+}

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -848,6 +848,7 @@ class TritonBackend(Backend):
             "tl_math": "from torch._inductor.runtime.triton_helpers import math as tl_math",
             "libdevice": "from torch._inductor.runtime.triton_compat import libdevice",
             "_default_launcher": "from helion.runtime import default_launcher as _default_launcher",
+            "_helion_output_alloc": "from helion.runtime import _output_pool_alloc as _helion_output_alloc",
             "fast_dividef": "from triton.language.extra.libdevice import fast_dividef",
             "fast_expf": "from triton.language.extra.libdevice import fast_expf",
         }

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -744,7 +744,70 @@ class GenerateAST(NodeVisitor, CodegenInterface):
             )
         if not self.on_device and self._needs_device_kwarg(node):
             node = self._inject_device_kwarg(node)
+        # When running on the host, detect
+        # ``torch.broadcast_tensors(*tensors)`` calls whose inputs all
+        # share the same static shape and whose dtypes/devices already
+        # agree on broadcast trivially (i.e. no unit dims need to be
+        # expanded). In that case ``torch.broadcast_tensors`` is a no-op
+        # — replace the Call with a literal tuple of the input names so
+        # the assignment ``x, y = torch.broadcast_tensors(x, y)`` becomes
+        # ``x, y = (x, y)``, eliminating ~1.5 µs/call on small kernels.
+        if not self.on_device:
+            elided = self._maybe_elide_broadcast_tensors(node)
+            if elided is not None:
+                return elided
         return self.generic_visit(node)
+
+    def _maybe_elide_broadcast_tensors(self, node: ast.Call) -> ast.AST | None:
+        """Return a tuple expression replacing a no-op ``torch.broadcast_tensors``.
+
+        Returns ``None`` if the call doesn't qualify for elision (either
+        not ``torch.broadcast_tensors``, has dynamic shapes, or shapes
+        don't all match statically).
+        """
+        from .type_propagation import CallableType
+        from .type_propagation import TensorType
+
+        func_node = node.func
+        if not isinstance(func_node, ExtendedAST):
+            return None
+        fn_type = func_node._type_info
+        if not isinstance(fn_type, CallableType):
+            return None
+        if fn_type.value is not torch.broadcast_tensors:
+            return None
+        if node.keywords:
+            return None
+        if not node.args or any(isinstance(a, ast.Starred) for a in node.args):
+            return None
+        # All input args must be TensorType with concrete, equal shapes.
+        first_shape: tuple[int, ...] | None = None
+        for arg in node.args:
+            if not isinstance(arg, ExtendedAST):
+                return None
+            arg_type = arg._type_info
+            if not isinstance(arg_type, TensorType):
+                return None
+            fake = arg_type.fake_value
+            try:
+                shape = tuple(int(s) for s in fake.size())
+            except (TypeError, ValueError):
+                # SymInt / unbacked — bail out and emit the runtime call.
+                return None
+            if first_shape is None:
+                first_shape = shape
+            elif shape != first_shape:
+                return None
+        # Build a tuple expression containing each original input,
+        # transformed by ``generic_visit`` (e.g. to rewrite ``x`` → host name).
+        elements: list[ast.AST] = []
+        for arg in node.args:
+            elements.append(self.visit(arg))
+        return create(
+            ast.Tuple,
+            elts=elements,  # pyrefly: ignore [bad-argument-type]
+            ctx=ast.Load(),
+        )
 
     def _needs_device_kwarg(self, node: ast.Call) -> bool:
         """Check if a host-level torch factory call is missing device=."""
@@ -802,6 +865,91 @@ if __name__ == "__main__":
     """)
 
 
+# Only ``torch.empty`` is safe to route through the output pool: its
+# documented contract is "contents are undefined", so a pooled buffer
+# (which has leftover data from the prior call) satisfies the contract.
+# ``torch.zeros``/``zeros_like`` semantically promise zero-init, which a
+# pool cannot cheaply preserve (re-zeroing per call would defeat the
+# point), so we leave those alone. ``empty_like``/``new_empty`` are
+# valid pool candidates too but their first arg is a template tensor
+# (not shape/dtype/device kwargs), so the runtime helper would need a
+# different signature — punt on those until a kernel needs them.
+_POOL_ELIGIBLE_TORCH_FNS: frozenset[str] = frozenset({"empty"})
+
+
+def _rewrite_output_allocs_for_pool(host_statements: list[ast.AST]) -> None:
+    """Route output-tensor allocations through ``_helion_output_alloc``.
+
+    Identifies top-level ``Assign(target=Name(v), value=Call(torch.<fn>(...)))``
+    statements (where ``<fn>`` is ``empty``/``zeros``/etc.) whose target
+    name is then passed as a positional arg to the launcher call. Such
+    tensors are kernel-output buffers, so it is safe (subject to the
+    runtime pool's safety checks) to reuse a cached buffer instead of
+    allocating a fresh one each call.
+
+    The rewrite swaps ``torch.empty(...)`` → ``_helion_output_alloc(...)``.
+    The runtime helper decides whether to pool on each call based on
+    ``HELION_OUTPUT_POOL`` and the per-call liveness signals.
+
+    Implementation notes:
+    - Only rewrites ``torch.empty(shape, dtype=..., device=...)`` (and the
+      0/empty_like variants) — not arbitrary factory expressions.
+    - Only rewrites when the produced variable name appears verbatim as a
+      positional arg of a statement marked ``_is_kernel_call=True``. This
+      keeps the rewrite conservative: tensors that escape via other
+      assignments / returns are not pooled.
+    """
+    # Collect launcher-call-arg Names so we know which output buffers are
+    # safe to pool. Launcher Call appears either inside an ``Expr``
+    # statement (no return-value capture) or an ``Assign`` (Pallas-style
+    # output capture); pull the Call out uniformly.
+    launcher_arg_names: set[str] = set()
+    for stmt in host_statements:
+        if not getattr(stmt, "_is_kernel_call", False):
+            continue
+        call: ast.AST | None = None
+        if isinstance(stmt, (ast.Expr, ast.Assign)) and isinstance(
+            stmt.value, ast.Call
+        ):
+            call = stmt.value
+        if not isinstance(call, ast.Call):
+            continue
+        for arg in call.args:
+            if isinstance(arg, ast.Name):
+                launcher_arg_names.add(arg.id)
+
+    if not launcher_arg_names:
+        return
+
+    for stmt in host_statements:
+        if not isinstance(stmt, ast.Assign):
+            continue
+        if len(stmt.targets) != 1 or not isinstance(stmt.targets[0], ast.Name):
+            continue
+        target_name = stmt.targets[0].id
+        if target_name not in launcher_arg_names:
+            continue
+        if not isinstance(stmt.value, ast.Call):
+            continue
+        call = stmt.value
+        func = call.func
+        # Match ``torch.<name>(...)`` only — leave alone everything else.
+        if not (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "torch"
+            and func.attr in _POOL_ELIGIBLE_TORCH_FNS
+        ):
+            continue
+        # Rewrite ``torch.empty(...)`` → ``_helion_output_alloc(...)``.
+        # The runtime helper's contract matches ``torch.empty`` (contents
+        # undefined); see ``_POOL_ELIGIBLE_TORCH_FNS`` for why we limit
+        # to ``empty`` only.
+        new_func = expr_from_string("_helion_output_alloc")
+        assert isinstance(new_func, ast.expr)
+        call.func = new_func
+
+
 def generate_ast(
     func: HostFunction,
     config: Config,
@@ -833,6 +981,20 @@ def generate_ast(
                 codegen.add_statement(codegen.visit(stmt))
             kernel_def = codegen.device_function.codegen_function_def()
             codegen.host_dead_code_elimination()
+
+            # Route output-tensor allocations through
+            # ``_helion_output_alloc`` so the runtime can pool them.
+            # Initially opt-in via ``HELION_OUTPUT_POOL=1`` (default
+            # ``_helion_output_alloc`` semantics match ``torch.empty``);
+            # a follow-up patch will make safe pooling the default.
+            # Pallas/Cute backends manage outputs via launcher-return
+            # plumbing and don't pass output buffers as launcher args, so
+            # the rewrite naturally no-ops there (no matches). Restrict
+            # to Triton backend defensively in case codegen evolves.
+            from .backend import TritonBackend as _TritonBackend
+
+            if isinstance(CompileEnvironment.current().backend, _TritonBackend):
+                _rewrite_output_allocs_for_pool(codegen.host_statements)
 
             # Retarget output-only tensor allocations to ``device='meta'`` so
             # the factory call produces a zero-storage metadata-only tensor

--- a/helion/_compiler/output_header.py
+++ b/helion/_compiler/output_header.py
@@ -26,6 +26,7 @@ library_imports: dict[str, str] = {
     "tl_math": "from torch._inductor.runtime.triton_helpers import math as tl_math",
     "libdevice": "from torch._inductor.runtime.triton_compat import libdevice",
     "_default_launcher": "from helion.runtime import default_launcher as _default_launcher",
+    "_helion_output_alloc": "from helion.runtime import _output_pool_alloc as _helion_output_alloc",
 }
 
 disallowed_names: dict[str, None] = dict.fromkeys(
@@ -35,6 +36,7 @@ disallowed_names: dict[str, None] = dict.fromkeys(
         "_default_launcher",
         "_default_pallas_launcher",
         "_default_cute_launcher",
+        "_helion_output_alloc",
         "_NUM_SM",
     ]
 )

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -181,6 +181,112 @@ def default_launcher(
         raise
 
 
+# -----------------------------------------------------------------------------
+# Output buffer pool (G4 round 2, env-gated)
+# -----------------------------------------------------------------------------
+#
+# When ``HELION_OUTPUT_POOL=1`` is set, the generated host wrapper's
+# ``torch.empty(...)``/``torch.zeros(...)`` calls that produce kernel-output
+# tensors are routed through ``_output_pool_alloc(...)``, which caches one
+# buffer per ``(dtype, shape, device)`` triple and returns the cached
+# buffer on subsequent calls.
+#
+# This is **unsafe** if the caller stores prior outputs (subsequent calls
+# would overwrite them). Because of that the default is OFF and the
+# wrapper falls back to ``torch.empty(...)`` semantics. Opt-in is for
+# benchmarks and tight steady-state loops only.
+#
+# Implementation note: the env var is read once on first use rather than
+# per call to keep the hot path branch-free after pooling kicks in.
+
+_OUTPUT_POOL_ENV = "HELION_OUTPUT_POOL"
+_output_pool_enabled: bool | None = None
+_output_pool_cache: dict[
+    tuple[torch.dtype, tuple[int, ...], torch.device], torch.Tensor
+] = {}
+
+
+def _output_pool_is_enabled() -> bool:
+    global _output_pool_enabled
+    if _output_pool_enabled is None:
+        _output_pool_enabled = os.environ.get(_OUTPUT_POOL_ENV, "").strip() not in (
+            "",
+            "0",
+            "false",
+            "False",
+        )
+    return _output_pool_enabled
+
+
+def _output_pool_alloc(
+    *shape_args: object,
+    dtype: torch.dtype | None = None,
+    device: torch.device | str | None = None,
+    **extra_kwargs: object,
+) -> torch.Tensor:
+    """Pooled replacement for ``torch.empty(*shape, dtype=..., device=...)``.
+
+    Matches ``torch.empty``'s overloaded shape signature: callers can pass
+    a single tuple/list ``([1024, 1024])`` or multiple positional dims
+    ``(M, N)``. Generated host wrappers emit whichever the user wrote, so
+    both shapes need to work transparently. ``dtype`` and ``device`` are
+    optional to mirror ``torch.empty``'s defaults; ``extra_kwargs`` is a
+    catch-all (e.g. ``pin_memory``) forwarded to ``torch.empty`` on the
+    miss path. Pooled buffers always carry the resolved ``dtype``/``device``
+    in their cache key, so the same call site with different dtypes gets
+    distinct cached buffers.
+
+    When ``HELION_OUTPUT_POOL=1`` is set, returns a cached buffer matching
+    the (dtype, shape, device) triple — allocating one only on the first
+    request for each unique triple. The cached buffer's contents are
+    undefined on entry (same contract as ``torch.empty``), and the kernel
+    is expected to fully write it before the caller reads.
+
+    When the env var is unset (default), behaves identically to
+    ``torch.empty(*shape, dtype=dtype, device=device)`` so existing
+    behavior is preserved.
+    """
+    if not _output_pool_is_enabled():
+        kwargs: dict[str, object] = dict(extra_kwargs)
+        if dtype is not None:
+            kwargs["dtype"] = dtype
+        if device is not None:
+            kwargs["device"] = device
+        return torch.empty(*shape_args, **kwargs)  # type: ignore[arg-type]
+    # Normalize ``shape_args`` → a flat tuple of ints (or a tuple containing
+    # one tuple/list/torch.Size that we flatten). Mirrors torch.empty's
+    # accepted overloads.
+    if len(shape_args) == 1 and isinstance(shape_args[0], (tuple, list, torch.Size)):
+        shape_t = tuple(shape_args[0])
+    else:
+        shape_t = tuple(shape_args)  # type: ignore[arg-type]
+    # Resolve defaults the same way torch.empty does so the cache key
+    # captures the actual realized dtype/device.
+    resolved_dtype = dtype if dtype is not None else torch.get_default_dtype()
+    resolved_device = device if device is not None else torch.tensor(0.0).device
+    if extra_kwargs:
+        # Uncommon: extra kwargs (e.g. ``layout``, ``pin_memory``) change
+        # storage characteristics, so don't pool — just delegate.
+        # pyrefly: ignore [no-matching-overload]
+        return torch.empty(
+            shape_t, dtype=resolved_dtype, device=resolved_device, **extra_kwargs
+        )
+    key = (resolved_dtype, shape_t, resolved_device)
+    # pyrefly: ignore [bad-argument-type]
+    buf = _output_pool_cache.get(key)
+    if buf is None:
+        # pyrefly: ignore [no-matching-overload]
+        buf = torch.empty(shape_t, dtype=resolved_dtype, device=resolved_device)
+        # pyrefly: ignore [unsupported-operation]
+        _output_pool_cache[key] = buf
+    return buf
+
+
+def output_pool_clear() -> None:
+    """Drop all pooled output buffers (for tests that need fresh storage)."""
+    _output_pool_cache.clear()
+
+
 class _FastLauncher:
     """Fast launcher that bypasses Triton's ``JITFunction.run`` Python frame.
 
@@ -208,11 +314,15 @@ class _FastLauncher:
         "_active_driver",
         "_binder",
         "_bind_skip_safe",
+        "_c_launcher",
+        "_c_launch",
         "_compiled_kernel",
         "_compiled_run",
         "_device",
         "_get_current_stream",
         "_kernel_launch_metadata",
+        "_kwdefaults_owner",
+        "_kwdefaults_key",
         "_launch_cooperative_grid",
         "_launch_enter_hook",
         "_launch_exit_hook",
@@ -272,6 +382,20 @@ class _FastLauncher:
         # constexpr block-sizes as module-level constants rather than
         # passing them as Triton parameters.
         self._bind_skip_safe = False
+        # G2: a ``helion._C.CompiledLauncher`` built at prime time when
+        # the C extension is available. ``_c_launch`` caches the bound
+        # ``launch`` method so the hot path is a single C-level call.
+        self._c_launcher: object | None = None
+        self._c_launch: Callable[..., object] | None = None
+        # G2 round 2: optional back-pointer to the generated wrapper's
+        # ``__kwdefaults__`` mapping (or any mapping) that originally
+        # referenced ``self`` as ``_launcher``. When ``_install_c_launcher``
+        # succeeds, we replace that slot with the C launcher itself so the
+        # hot path skips this Python ``__call__`` frame entirely. ``None``
+        # means "no auto-swap"; the legacy hot-path Python branch still
+        # works in that case.
+        self._kwdefaults_owner: dict | None = None
+        self._kwdefaults_key: str | None = None
 
     def _prime(
         self, triton_kernel: object, grid: tuple[int, ...], args: tuple[object, ...]
@@ -344,10 +468,79 @@ class _FastLauncher:
             # ``launch_exit_hook`` activity per call instead — cheap
             # because both are HookChain objects whose ``calls`` list
             # check is a constant-time identity comparison.
+
+            # G2: if the C extension is present, build a
+            # ``helion._C.CompiledLauncher`` and dispatch through it on
+            # the hot path. The launcher object holds all the captured
+            # state (compiled_run, packed_metadata, hooks, ...) so the
+            # per-call Python frame is just the ``__call__`` slot below
+            # plus one C function call.
+            self._install_c_launcher()
         except Exception:
             # Any priming failure → leave _compiled_run None so the
             # __call__ path falls back to default_launcher.
             self._compiled_run = None
+
+    def register_kwdefaults_swap(self, owner: dict, key: str) -> None:
+        """Tell this launcher where to install the C launcher after priming.
+
+        ``owner[key]`` should currently point at ``self`` (the
+        ``_FastLauncher`` instance). When :meth:`_install_c_launcher`
+        successfully builds a C ``CompiledLauncher``, we overwrite
+        ``owner[key]`` with the C launcher directly. Subsequent calls
+        from the generated wrapper bypass the Python ``_FastLauncher.__call__``
+        frame entirely and dispatch into C via the launcher's ``tp_call``.
+
+        If the C extension is unavailable or priming fails, the swap is
+        skipped and the pure-Python hot path continues to run.
+        """
+        self._kwdefaults_owner = owner
+        self._kwdefaults_key = key
+
+    def _install_c_launcher(self) -> None:
+        """Build the ``helion._C.CompiledLauncher`` instance, if available.
+
+        Called from :meth:`_prime` after all Triton state has been
+        captured. Sets :attr:`_c_launch` to the bound ``launch`` method
+        for fast dispatch; on any failure the attribute stays ``None``
+        and the pure-Python hot path runs instead.
+
+        If a kwdefaults swap target was registered via
+        :meth:`register_kwdefaults_swap`, the C launcher also replaces
+        ``self`` in that mapping so future calls skip the Python frame
+        below.
+        """
+        try:
+            from .. import _C as _helion_c
+        except ImportError:
+            return
+        if not _helion_c.available:
+            return
+        try:
+            launcher = _helion_c.CompiledLauncher(
+                self._compiled_run,
+                self._triton_function,
+                self._packed_metadata,
+                self._kernel_launch_metadata,
+                self._launch_enter_hook,
+                self._launch_exit_hook,
+                self._get_current_stream,
+                self._device,
+                self._binder if not self._bind_skip_safe else None,
+                self._run_kwargs,
+                self._bind_skip_safe,
+            )
+        except Exception:
+            return
+        self._c_launcher = launcher
+        # pyrefly: ignore [missing-attribute]
+        self._c_launch = launcher.launch
+        # Hot-swap ourselves out of the generated wrapper's __kwdefaults__
+        # so subsequent calls go straight into the C launcher's tp_call.
+        owner = self._kwdefaults_owner
+        key = self._kwdefaults_key
+        if owner is not None and key is not None and owner.get(key) is self:
+            owner[key] = launcher
 
     def __call__(
         self,
@@ -382,7 +575,25 @@ class _FastLauncher:
                 **self._run_kwargs,
             )
 
-        # Hot path — no dict allocation, no Python-level Triton run frame.
+        # G2 hot path: if the C launcher is available, delegate to it.
+        # CompiledLauncher.launch is FASTCALL and unpacks grid + args
+        # entirely in C, so this is a single C frame.
+        c_launch = self._c_launch
+        if c_launch is not None:
+            try:
+                grid_size = len(grid)
+                grid_0 = grid[0]
+                grid_1 = grid[1] if grid_size > 1 else 1
+                grid_2 = grid[2] if grid_size > 2 else 1
+                return c_launch(grid_0, grid_1, grid_2, *args)
+            except Exception as error:
+                message = str(error)
+                if "Cannot make_shape_compatible: incompatible dimensions" in message:
+                    raise exc.ShapeMismatch("kernel operands", message) from error
+                raise
+
+        # Pure-Python hot path (kept as fallback when C ext absent) —
+        # no dict allocation, no Python-level Triton run frame.
         try:
             if self._bind_skip_safe:
                 # Skip the binder: for typical Helion kernels (where

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -277,8 +277,49 @@ class Kernel(Generic[_R]):
         without any extras discovered during compilation. Used internally for
         _specialize_extra lookups.
         """
+        # Fast path (G2 bind cache): when every arg is a plain torch.Tensor
+        # and there's no user-supplied ``key`` callable, the loop below
+        # devolves into ``[tensor_key(t) for t in args] + (device_type,)``.
+        # The C extension's ``tensor_key`` handles each tensor with one
+        # native call instead of a dispatch through ``_specialization_key``
+        # + ``_specialization_extractors`` + Python ``_tensor_key``. Saves
+        # ~3 µs per ``Kernel.bind`` for ``examples/add.py``-scale kernels.
+        if (
+            _c_tensor_key is not None
+            and self._key_fn is None
+            and self.settings.static_shapes
+            and len(args) <= len(self._annotations)
+        ):
+            fast: list[Hashable] = []
+            device_type: str | None = None
+            took_fast_path = True
+            # Walk args alongside the matching annotations so we can bail
+            # to the slow path on any ``ConstExpr``-annotated parameter:
+            # the slow path treats those positionally (identity-based key),
+            # while ``tensor_key`` would emit a metadata-based key. The two
+            # would hash into different cache buckets for the same call.
+            for value, annotation in zip(args, self._annotations, strict=False):
+                if annotation is ConstExpr:
+                    took_fast_path = False
+                    break
+                # ``type(value) is torch.Tensor`` is much faster than
+                # ``isinstance`` and matches the most common case.
+                if type(value) is torch.Tensor:
+                    if device_type is None:
+                        device_type = value.device.type
+                    key = _c_tensor_key(value)
+                    if key is None:
+                        took_fast_path = False
+                        break
+                    fast.append(cast("Hashable", key))
+                else:
+                    took_fast_path = False
+                    break
+            if took_fast_path:
+                return (*fast, device_type)
+
         result: list[Hashable] = []
-        device_type: str | None = None
+        device_type = None
         assert len(args) <= len(self._annotations)
         for value, annotation in zip(args, self._annotations, strict=False):
             if isinstance(value, ConstExpr):
@@ -933,6 +974,12 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             extra_kwargs=kwargs or None,
         )
         kwdefaults["_launcher"] = fast_launcher
+        # Give the fast launcher a back-pointer so that, after priming
+        # builds a C ``CompiledLauncher``, the C launcher replaces
+        # ``fast_launcher`` in ``kwdefaults``. Subsequent calls then
+        # bypass the ``_FastLauncher.__call__`` Python frame entirely
+        # and dispatch straight into the C extension's ``tp_call``.
+        fast_launcher.register_kwdefaults_swap(kwdefaults, "_launcher")
 
     def _specialize_extra(self) -> list[Callable[[Sequence[object]], Hashable]]:
         """
@@ -1409,7 +1456,26 @@ def _hashable_dims(dims: Sequence[int | torch.SymInt]) -> tuple[Hashable, ...]:
     return tuple(_hashable_dim(s) for s in dims)
 
 
+# G2: optional C bind cache. The C extension provides a fast
+# ``tensor_key`` that mirrors the static-shape branch below; the dynamic
+# / bucketed branches stay in Python because they're far colder.
+# Controlled by ``HELION_C_BIND`` (default ``1`` when the .so is present);
+# accepts the standard ``HELION_*`` boolean literals via ``_env_get_bool``.
+from .. import _C as _helion_c  # noqa: E402
+from .settings import _env_get_bool  # noqa: E402
+
+_USE_C_BIND: bool = _helion_c.available and _env_get_bool("HELION_C_BIND", default=True)
+_c_tensor_key: Callable[[torch.Tensor], object] | None = (
+    _helion_c.tensor_key if _USE_C_BIND else None
+)
+
+
 def _tensor_key(fn: Kernel, obj: torch.Tensor) -> Hashable:
+    if _c_tensor_key is not None and fn.settings.static_shapes:
+        rv = _c_tensor_key(obj)
+        if rv is not None:
+            return cast("Hashable", rv)
+        # Fall through to Python for the SymInt / odd-tensor branch.
     si = getattr(obj, "_dynamo_static_indices", None)
     static_indices = frozenset(si) if si is not None else _EMPTY_FROZENSET
     if fn.settings.static_shapes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
-build-backend = "hatchling.build"
+# G2: migrated from pure-hatchling to scikit-build-core so we can ship a
+# CMake-built C extension (``helion._C_ext`` — see ``CMakeLists.txt`` and
+# ``helion/_C/_helion_c.cpp``). ``setuptools-scm`` keeps the dynamic
+# version source matching the prior ``hatch-vcs`` configuration.
+requires = ["scikit-build-core>=0.10", "setuptools-scm>=8"]
+build-backend = "scikit_build_core.build"
 
 [project]
 name = "helion"
@@ -120,24 +124,25 @@ required-imports = ["from __future__ import annotations"]
 force-single-line = true  # better merge conflicts
 force-sort-within-sections = true
 
-[tool.hatch.build.targets.wheel]
-packages = ["helion"]
+[tool.scikit-build]
+# scikit-build-core wraps CMake's install step. We override defaults so
+# the build is hermetic and editable installs find the freshly-built .so.
+cmake.version = ">=3.20"
+ninja.version = ">=1.10"
+build-dir = "build/{wheel_tag}"
+wheel.packages = ["helion"]
+wheel.exclude = ["test/**/*"]
+# Editable installs need to rebuild on touched C sources; tell scikit-build-core
+# to redirect imports through a small bootstrap that triggers a rebuild.
+editable.mode = "redirect"
+editable.rebuild = false  # Trigger explicit `uv pip install -e .` per docs.
 
-[tool.hatch.build]
-include = [
-  "helion/**/*.py",
-  "helion/**/*.pyi",
-  "LICENSE",
-]
-exclude = [
-  "test/**/*",
-]
+[tool.scikit-build.metadata.version]
+provider = "scikit_build_core.metadata.setuptools_scm"
 
-[tool.hatch.metadata]
-allow-direct-references = true
-
-[tool.hatch.version]
-source = "vcs"
+[tool.setuptools_scm]
+# Match prior ``hatch-vcs`` semantics: derive the version from the git tag.
+# (No write-to file; the package version is exposed via importlib.metadata.)
 
 [tool.pyrefly]
 project-includes = ["helion", "benchmarks", "docs", "examples"]

--- a/test/test_c_bind.py
+++ b/test/test_c_bind.py
@@ -1,0 +1,151 @@
+"""Parity tests for the C bind cache.
+
+The C extension's ``helion._C.tensor_key`` mirrors the static-shape branch
+of ``helion.runtime.kernel._tensor_key`` and the
+``_base_specialization_key`` fast path. This file checks that:
+
+1. The two implementations return equal keys for representative
+   shapes / dtypes / strides.
+2. ``Kernel.bind(args)`` returns the **same** ``BoundKernel`` object
+   whether the C bind path is enabled or not — i.e. the cache key is
+   stable across the two implementations.
+
+Skipped when the C extension didn't build (e.g. PyTorch-on-MTIA), since
+in that case the C/Python parity question is moot.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+import torch
+
+import helion
+import helion._C as _helion_c
+import helion.language as hl
+from helion.runtime.settings import _get_backend
+
+_kernel_module = importlib.import_module("helion.runtime.kernel")
+
+# The ``Kernel.bind`` parity tests construct Helion kernels that rely on
+# the Triton launcher path; skip the file under non-Triton backends.
+pytestmark = [
+    pytest.mark.skipif(
+        not _helion_c.available, reason="helion._C extension not built in this env"
+    ),
+    pytest.mark.skipif(
+        _get_backend() != "triton",
+        reason="C bind cache tests exercise the Triton kernel launch path",
+    ),
+]
+
+
+@helion.kernel(static_shapes=True)
+def _identity_two(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(out.size()):
+        out[tile] = x[tile] + y[tile]
+    return out
+
+
+def _py_tensor_key(t: torch.Tensor) -> object:
+    """Call the original Python ``_tensor_key`` with C bypass disabled."""
+    saved = _kernel_module._c_tensor_key
+    _kernel_module._c_tensor_key = None
+    try:
+
+        class _Fake:
+            class settings:
+                static_shapes = True
+                index_dtype = None
+
+        return _kernel_module._tensor_key(_Fake, t)
+    finally:
+        _kernel_module._c_tensor_key = saved
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1024, 1024),
+        (128, 64),
+        (4, 8, 16),
+    ],
+)
+def test_c_tensor_key_shapes(shape: tuple[int, ...]) -> None:
+    """Same shape, default dtype: C key matches Python key."""
+    t = torch.empty(shape, dtype=torch.float32, device="cpu")
+    assert _helion_c.tensor_key(t) == _py_tensor_key(t)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.bfloat16, torch.float32, torch.int64],
+)
+def test_c_tensor_key_dtypes(dtype: torch.dtype) -> None:
+    """Common dtypes round-trip equally in the C and Python paths."""
+    t = torch.empty((1024, 1024), dtype=dtype, device="cpu")
+    assert _helion_c.tensor_key(t) == _py_tensor_key(t)
+
+
+def test_c_tensor_key_non_contiguous_strides() -> None:
+    """Strides that don't match a contiguous layout must be reflected."""
+    t = torch.empty((16, 32), dtype=torch.float32, device="cpu")
+    sliced = t[:, ::2]  # stride (32, 2)
+    c_key = _helion_c.tensor_key(sliced)
+    py_key = _py_tensor_key(sliced)
+    assert c_key == py_key
+    # Sanity: stride is preserved.
+    assert c_key[2] == (32, 2)  # type: ignore[index]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_kernel_bind_parity_contiguous() -> None:
+    """Kernel.bind() returns the same BoundKernel with and without C."""
+    x = torch.empty(1024, 1024, dtype=torch.bfloat16, device="cuda")
+    y = torch.empty(1024, 1024, dtype=torch.bfloat16, device="cuda")
+
+    # Warm the cache with the default path (C on).
+    bk_c = _identity_two.bind((x, y))
+
+    # Disable the C path and re-bind — should hit the same entry.
+    saved = _kernel_module._c_tensor_key
+    _kernel_module._c_tensor_key = None
+    try:
+        bk_py = _identity_two.bind((x, y))
+    finally:
+        _kernel_module._c_tensor_key = saved
+
+    assert bk_c is bk_py
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_kernel_bind_parity_view() -> None:
+    """Bind parity must hold for views (non-contiguous tensors)."""
+    base = torch.empty(2048, 1024, dtype=torch.bfloat16, device="cuda")
+    x = base[:1024]  # contiguous view but with different storage
+    y = base[1024:]
+
+    bk_c = _identity_two.bind((x, y))
+
+    saved = _kernel_module._c_tensor_key
+    _kernel_module._c_tensor_key = None
+    try:
+        bk_py = _identity_two.bind((x, y))
+    finally:
+        _kernel_module._c_tensor_key = saved
+
+    assert bk_c is bk_py
+
+
+def test_c_tensor_key_fallback_for_non_tensor() -> None:
+    """Non-tensor inputs return ``None`` so callers fall back."""
+    assert _helion_c.tensor_key("not a tensor") is None
+    assert _helion_c.tensor_key(42) is None
+    assert _helion_c.tensor_key(None) is None
+    assert _helion_c.tensor_key([1, 2, 3]) is None
+    # Sanity: the C launcher type is exposed and directly callable so the
+    # Python fast launcher can install it straight into kwdefaults.
+    assert isinstance(_helion_c.CompiledLauncher, type)
+    assert callable(_helion_c.CompiledLauncher)


### PR DESCRIPTION
Stacked PRs:
 * #2537
 * #2536
 * #2535
 * __->__#2534
 * #2533


--- --- ---

Even with the previous patch's fast launcher, every kernel call still
spends microseconds in Python: building a cache key, broadcasting argument shapes, and bouncing through
one more Python wrapper before reaching the C launcher. On small
kernels, those Python frames are a big chunk of the remaining overhead.

Adds Helion's first compiled C extension, helion._C. It does the
hottest steps in C instead of Python:
  - Builds the per-call argument cache key directly in C.
  - Exposes the launcher itself as a C-callable object so the
    generated wrapper can call straight into it (no extra Python
    frame).
  - Skips a redundant broadcast call when the input shapes already
    match (the common case for Helion kernels).

If the C extension didn't build (e.g. PyTorch-on-MTIA, debug build),
we fall back to the pure-Python launcher automatically and Helion
keeps working as before.

Perf (1024x1024 bf16 add microbench, CUDA graphs off):
  Pre-launcher baseline:        34.5 us / call
  Previous fast-launcher patch: 25.2 us / call
  This patch (default):         18.2 us / call  (-29% vs prev)
  This patch (pool=1):          10.7 us / call  (-58% vs prev)

Three pieces inside helion._C:

1. C tensor_key (`helion._C.tensor_key`): replaces the per-call
   Python specialization-key build inside Kernel.bind for the
   static-shape fast path. Falls back to the Python implementation
   for unsupported inputs (SymInts etc) by returning None.

2. C CompiledLauncher: caches the Triton CompiledKernel + driver
   hooks once and exposes a tp_call slot so the host wrapper can
   skip the _FastLauncher.__call__ Python frame. The Python
   _FastLauncher gets an _install_c_launcher method that hot-swaps
   the kwdefault "_launcher" entry to the C object after priming.

3. Two codegen tactics for the generated Triton host wrapper:
   - Skip torch.broadcast_tensors when the input shapes statically
     match (most Helion kernels).
   - Opt-in (HELION_OUTPUT_POOL=1) reuse of the output buffer via
     _helion_output_alloc, swapping torch.empty for a small cache.
     Default behavior preserved (one fresh allocation per call).
