### PR TITLE
Use the fast launcher during autotuning

### DIFF
--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -749,6 +749,21 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                     self.kernel.format_kernel_decorator(config, self.settings),
                     exc_info=True,
                 )
+            else:
+                # G3: install the fast launcher (and after priming, the C
+                # ``CompiledLauncher`` if ``helion._C`` is available) on the
+                # compiled wrapper so every per-trial benchmark call uses
+                # it. Autotune args don't change shape or scalar value
+                # across calls within a trial, so the fast launcher's
+                # cached specialization is safe here. ``_install_fast_launcher``
+                # is a no-op if the kernel's backend isn't ``TritonBackend``
+                # (e.g. Pallas, Cute) or on any priming failure. Only
+                # installed when the kernel exposes the helper (i.e. is a
+                # ``BoundKernel``; external adapters in
+                # ``helion/autotuner/external.py`` skip this).
+                installer = getattr(self.kernel, "_install_fast_launcher", None)
+                if installer is not None:
+                    installer(compiled[i], config)
         fns = list(compiled.values())
         valid_indices = list(compiled.keys())
         configs = [all_configs[i] for i in valid_indices]

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -926,10 +926,12 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         closure (built once with this config's ``num_warps`` / ``num_stages``
         / etc. baked in), every direct call to ``compiled(*args)`` —
         including from ``BoundKernel.__call__`` on the steady-state hot
-        path — uses the fast launcher with no extra Python wrapping.
+        path AND every per-trial benchmark call from the autotune harness
+        in ``helion/autotuner/benchmark_provider.py`` — uses the fast
+        launcher with no extra Python wrapping.
 
-        The autotune trial harness and any external caller that explicitly
-        passes ``_launcher=`` (e.g. ``benchmarks/launch_overhead.py``)
+        The precompile path in ``helion/autotuner/precompile_future.py``
+        and any external caller that explicitly passes ``_launcher=``
         overrides the kwdefault automatically, so this is safe.
 
         Non-Triton backends and any priming failure cause the kwdefault to


### PR DESCRIPTION
Stacked PRs:
 * #2537
 * #2536
 * __->__#2535
 * #2534
 * #2533


--- --- ---

The autotuner picks the fastest config for a kernel by running each
candidate config thousands of times and timing it. Previously those
timing loops still went through the slow default launcher, so
per-trial wall time was dominated by Python overhead instead of GPU
work. That made autotune timings noisy and skewed toward configs
that happened to launch faster, not configs that ran faster on the
GPU.

We hot-swap the fast launcher onto each per-trial compiled wrapper
the moment it is compiled, so trial timings now reflect real GPU
work. The production kernel and the autotune trials share one
launch path.

Effect: a single autotune run that previously made ~12k
default_launcher calls now makes <=1; the rest go through the fast
launcher.
