### PR TITLE
Reuse kernel output buffers instead of allocating fresh on every call

### DIFF
--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -888,8 +888,9 @@ def _rewrite_output_allocs_for_pool(host_statements: list[ast.AST]) -> None:
     allocating a fresh one each call.
 
     The rewrite swaps ``torch.empty(...)`` → ``_helion_output_alloc(...)``.
-    The runtime helper decides whether to pool on each call based on
-    ``HELION_OUTPUT_POOL`` and the per-call liveness signals.
+    The runtime helper pools by default and applies per-call liveness
+    signals (refcount, stream, CUDA-graph capture);
+    ``HELION_REUSE_OUTPUT_BUFFERS=0`` opts out.
 
     Implementation notes:
     - Only rewrites ``torch.empty(shape, dtype=..., device=...)`` (and the
@@ -983,10 +984,9 @@ def generate_ast(
             codegen.host_dead_code_elimination()
 
             # Route output-tensor allocations through
-            # ``_helion_output_alloc`` so the runtime can pool them.
-            # Initially opt-in via ``HELION_OUTPUT_POOL=1`` (default
-            # ``_helion_output_alloc`` semantics match ``torch.empty``);
-            # a follow-up patch will make safe pooling the default.
+            # ``_helion_output_alloc`` so the runtime pool can reuse
+            # buffers across calls; pooling is on by default and disabled
+            # by ``HELION_REUSE_OUTPUT_BUFFERS=0``.
             # Pallas/Cute backends manage outputs via launcher-return
             # plumbing and don't pass output buffers as launcher args, so
             # the rewrite naturally no-ops there (no matches). Restrict

--- a/helion/autotuner/benchmarking.py
+++ b/helion/autotuner/benchmarking.py
@@ -11,6 +11,7 @@ from typing import TypeVar
 
 import torch
 
+from ..runtime._output_pool import _pool_active
 from ..runtime.settings import _env_get_bool
 from ..runtime.settings import _get_backend
 from ..runtime.settings import is_pallas_interpret
@@ -120,19 +121,25 @@ def compute_repeat(
     di = runtime.driver.active.get_device_interface()  # type: ignore[attr-defined]
     cache = runtime.driver.active.get_empty_cache_for_benchmark()  # type: ignore[attr-defined]
 
-    # Warm the pipeline once before collecting timing samples.
-    fn()
-    di.synchronize()
-    benchmark_function = _maybe_cudagraph_replay(fn, default_enabled=default_cudagraph)
+    # Pool is on by default; the ``_pool_active()`` scope just clears
+    # cached buffers on exit so per-trial allocations don't leak across
+    # trial sets.
+    with _pool_active():
+        # Warm the pipeline once before collecting timing samples.
+        fn()
+        di.synchronize()
+        benchmark_function = _maybe_cudagraph_replay(
+            fn, default_enabled=default_cudagraph
+        )
 
-    start_event = di.Event(enable_timing=True)
-    end_event = di.Event(enable_timing=True)
-    start_event.record()
-    for _ in range(estimate_runs):
-        runtime.driver.active.clear_cache(cache)  # type: ignore[attr-defined]
-        benchmark_function()
-    end_event.record()
-    di.synchronize()
+        start_event = di.Event(enable_timing=True)
+        end_event = di.Event(enable_timing=True)
+        start_event.record()
+        for _ in range(estimate_runs):
+            runtime.driver.active.clear_cache(cache)  # type: ignore[attr-defined]
+            benchmark_function()
+        end_event.record()
+        di.synchronize()
 
     estimate_ms = start_event.elapsed_time(end_event) / max(estimate_runs, 1)
     if not math.isfinite(estimate_ms) or estimate_ms <= 0:
@@ -155,15 +162,16 @@ def compute_repeat_generic(
     Estimate how many repetitions are needed using wall-clock timing.
     Used for backends that don't have Triton's event-based timing (e.g., Pallas/TPU).
     """
-    # Warm the pipeline once before collecting timing samples.
-    out = fn()
-    synchronize_device(out)
-
-    start = time.perf_counter()
-    for _ in range(estimate_runs):
+    with _pool_active():
+        # Warm the pipeline once before collecting timing samples.
         out = fn()
-    synchronize_device(out)
-    end = time.perf_counter()
+        synchronize_device(out)
+
+        start = time.perf_counter()
+        for _ in range(estimate_runs):
+            out = fn()
+        synchronize_device(out)
+        end = time.perf_counter()
 
     estimate_ms = (end - start) * 1000 / max(estimate_runs, 1)
     if not math.isfinite(estimate_ms) or estimate_ms <= 0:
@@ -192,42 +200,45 @@ def interleaved_bench(
     """
     from triton import runtime
 
-    # warmup
-    for fn in fns:
-        fn()
-    clear_cache = functools.partial(
-        runtime.driver.active.clear_cache,  # type: ignore[attr-defined]
-        runtime.driver.active.get_empty_cache_for_benchmark(),  # type: ignore[attr-defined]
-    )
-    clear_cache()
-    di = runtime.driver.active.get_device_interface()  # type: ignore[attr-defined]
-    start_events = [
-        [di.Event(enable_timing=True) for _ in range(repeat)] for _ in range(len(fns))
-    ]
-    end_events = [
-        [di.Event(enable_timing=True) for _ in range(repeat)] for _ in range(len(fns))
-    ]
+    with _pool_active():
+        # warmup
+        for fn in fns:
+            fn()
+        clear_cache = functools.partial(
+            runtime.driver.active.clear_cache,  # type: ignore[attr-defined]
+            runtime.driver.active.get_empty_cache_for_benchmark(),  # type: ignore[attr-defined]
+        )
+        clear_cache()
+        di = runtime.driver.active.get_device_interface()  # type: ignore[attr-defined]
+        start_events = [
+            [di.Event(enable_timing=True) for _ in range(repeat)]
+            for _ in range(len(fns))
+        ]
+        end_events = [
+            [di.Event(enable_timing=True) for _ in range(repeat)]
+            for _ in range(len(fns))
+        ]
 
-    di.synchronize()
-    benchmark_functions = [
-        _maybe_cudagraph_replay(fn, default_enabled=default_cudagraph) for fn in fns
-    ]
+        di.synchronize()
+        benchmark_functions = [
+            _maybe_cudagraph_replay(fn, default_enabled=default_cudagraph) for fn in fns
+        ]
 
-    # When a description is supplied we show a progress bar so the user can
-    # track the repeated benchmarking loop.
-    iterator = iter_with_progress(
-        range(repeat),
-        total=repeat,
-        description=desc,
-        enabled=desc is not None,
-    )
-    for i in iterator:
-        for j in range(len(benchmark_functions)):
-            clear_cache()
-            start_events[j][i].record()
-            benchmark_functions[j]()
-            end_events[j][i].record()
-    di.synchronize()
+        # When a description is supplied we show a progress bar so the user
+        # can track the repeated benchmarking loop.
+        iterator = iter_with_progress(
+            range(repeat),
+            total=repeat,
+            description=desc,
+            enabled=desc is not None,
+        )
+        for i in iterator:
+            for j in range(len(benchmark_functions)):
+                clear_cache()
+                start_events[j][i].record()
+                benchmark_functions[j]()
+                end_events[j][i].record()
+        di.synchronize()
 
     return [
         statistics.median(
@@ -251,28 +262,29 @@ def interleaved_bench_generic(
     Benchmark multiple functions using wall-clock timing.
     Used for backends that don't have Triton's event-based timing (e.g., Pallas/TPU).
     """
-    # warmup
-    out: object = None
-    for fn in fns:
-        out = fn()
-    synchronize_device(out)
+    with _pool_active():
+        # warmup
+        out: object = None
+        for fn in fns:
+            out = fn()
+        synchronize_device(out)
 
-    all_times: list[list[float]] = [[] for _ in range(len(fns))]
+        all_times: list[list[float]] = [[] for _ in range(len(fns))]
 
-    iterator = iter_with_progress(
-        range(repeat),
-        total=repeat,
-        description=desc,
-        enabled=desc is not None,
-    )
-    for _i in iterator:
-        for j in range(len(fns)):
-            synchronize_device(out)
-            start = time.perf_counter()
-            out = fns[j]()
-            synchronize_device(out)
-            end = time.perf_counter()
-            all_times[j].append((end - start) * 1000)  # convert to ms
+        iterator = iter_with_progress(
+            range(repeat),
+            total=repeat,
+            description=desc,
+            enabled=desc is not None,
+        )
+        for _i in iterator:
+            for j in range(len(fns)):
+                synchronize_device(out)
+                start = time.perf_counter()
+                out = fns[j]()
+                synchronize_device(out)
+                end = time.perf_counter()
+                all_times[j].append((end - start) * 1000)  # convert to ms
 
     return [statistics.median(times) for times in all_times]
 
@@ -341,55 +353,57 @@ def do_bench(
 
     di = runtime.driver.active.get_device_interface()  # pyrefly: ignore
 
-    fn()
-    di.synchronize()
-    # Backward benchmarks mutate grad fields between iterations, so keep their
-    # existing launch path.
-    benchmark_function = (
-        fn
-        if grad_to_none is not None
-        else _maybe_cudagraph_replay(fn, default_enabled=default_cudagraph)
-    )
+    with _pool_active():
+        fn()
+        di.synchronize()
+        # Backward benchmarks mutate grad fields between iterations, so keep
+        # their existing launch path.
+        benchmark_function = (
+            fn
+            if grad_to_none is not None
+            else _maybe_cudagraph_replay(fn, default_enabled=default_cudagraph)
+        )
 
-    cache = runtime.driver.active.get_empty_cache_for_benchmark()  # pyrefly: ignore
+        cache = runtime.driver.active.get_empty_cache_for_benchmark()  # pyrefly: ignore
 
-    # Estimate the runtime of the function
-    start_event = di.Event(enable_timing=True)
-    end_event = di.Event(enable_timing=True)
-    start_event.record()
-    for _ in range(5):
-        runtime.driver.active.clear_cache(cache)  # pyrefly: ignore
-        benchmark_function()
-    end_event.record()
-    di.synchronize()
-    estimate_ms = sync_object(
-        start_event.elapsed_time(end_event) / 5, process_group_name=process_group_name
-    )
+        # Estimate the runtime of the function
+        start_event = di.Event(enable_timing=True)
+        end_event = di.Event(enable_timing=True)
+        start_event.record()
+        for _ in range(5):
+            runtime.driver.active.clear_cache(cache)  # pyrefly: ignore
+            benchmark_function()
+        end_event.record()
+        di.synchronize()
+        estimate_ms = sync_object(
+            start_event.elapsed_time(end_event) / 5,
+            process_group_name=process_group_name,
+        )
 
-    # compute number of warmup and repeat
-    n_warmup = max(1, int(warmup / estimate_ms))
-    n_repeat = max(1, int(rep / estimate_ms))
-    start_event = [di.Event(enable_timing=True) for i in range(n_repeat)]
-    end_event = [di.Event(enable_timing=True) for i in range(n_repeat)]
-    # Warm-up
-    for _ in range(n_warmup):
-        benchmark_function()
-    # Benchmark
-    for i in range(n_repeat):
-        # we don't want `fn` to accumulate gradient values
-        # if it contains a backward pass. So we clear the
-        # provided gradients
-        if grad_to_none is not None:
-            for x in grad_to_none:
-                x.grad = None
-        # we clear the L2 cache before each run
-        runtime.driver.active.clear_cache(cache)  # pyrefly: ignore
-        # record time of `fn`
-        start_event[i].record()
-        benchmark_function()
-        end_event[i].record()
-    # Record clocks
-    di.synchronize()
+        # compute number of warmup and repeat
+        n_warmup = max(1, int(warmup / estimate_ms))
+        n_repeat = max(1, int(rep / estimate_ms))
+        start_event = [di.Event(enable_timing=True) for i in range(n_repeat)]
+        end_event = [di.Event(enable_timing=True) for i in range(n_repeat)]
+        # Warm-up
+        for _ in range(n_warmup):
+            benchmark_function()
+        # Benchmark
+        for i in range(n_repeat):
+            # we don't want `fn` to accumulate gradient values
+            # if it contains a backward pass. So we clear the
+            # provided gradients
+            if grad_to_none is not None:
+                for x in grad_to_none:
+                    x.grad = None
+            # we clear the L2 cache before each run
+            runtime.driver.active.clear_cache(cache)  # pyrefly: ignore
+            # record time of `fn`
+            start_event[i].record()
+            benchmark_function()
+            end_event[i].record()
+        # Record clocks
+        di.synchronize()
     times = [s.elapsed_time(e) for s, e in zip(start_event, end_event, strict=True)]
     return _summarize_statistics(times, quantiles, return_mode)  # pyrefly: ignore
 
@@ -410,36 +424,37 @@ def do_bench_generic(
     """
     assert return_mode in ["min", "max", "mean", "median", "all"]
 
-    out = fn()
-    synchronize_device(out)
-
-    # Estimate the runtime of the function
-    synchronize_device(out)
-    start = time.perf_counter()
-    for _ in range(5):
-        out = fn()
-    synchronize_device(out)
-    end = time.perf_counter()
-    estimate_ms = sync_object(
-        (end - start) * 1000 / 5, process_group_name=process_group_name
-    )
-
-    # compute number of warmup and repeat
-    n_warmup = max(1, int(warmup / estimate_ms))
-    n_repeat = max(1, int(rep / estimate_ms))
-    # Warm-up
-    for _ in range(n_warmup):
-        fn()
-    # Benchmark
-    times: list[float] = []
-    for _i in range(n_repeat):
-        if grad_to_none is not None:
-            for x in grad_to_none:
-                x.grad = None
-        synchronize_device(out)
-        t0 = time.perf_counter()
+    with _pool_active():
         out = fn()
         synchronize_device(out)
-        t1 = time.perf_counter()
-        times.append((t1 - t0) * 1000)  # convert to ms
+
+        # Estimate the runtime of the function
+        synchronize_device(out)
+        start = time.perf_counter()
+        for _ in range(5):
+            out = fn()
+        synchronize_device(out)
+        end = time.perf_counter()
+        estimate_ms = sync_object(
+            (end - start) * 1000 / 5, process_group_name=process_group_name
+        )
+
+        # compute number of warmup and repeat
+        n_warmup = max(1, int(warmup / estimate_ms))
+        n_repeat = max(1, int(rep / estimate_ms))
+        # Warm-up
+        for _ in range(n_warmup):
+            fn()
+        # Benchmark
+        times: list[float] = []
+        for _i in range(n_repeat):
+            if grad_to_none is not None:
+                for x in grad_to_none:
+                    x.grad = None
+            synchronize_device(out)
+            t0 = time.perf_counter()
+            out = fn()
+            synchronize_device(out)
+            t1 = time.perf_counter()
+            times.append((t1 - t0) * 1000)  # convert to ms
     return _summarize_statistics_fallback(times, quantiles, return_mode)

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -17,6 +17,13 @@ from .. import _compat as _compat  # ensure Triton compatibility patches run
 from .. import exc
 from .._compiler.cute.strategies import tcgen05_smem_layout_expr
 from .._utils import triton_is_available
+from ._output_pool import _REUSE_OUTPUT_BUFFERS_ENV as _REUSE_OUTPUT_BUFFERS_ENV
+from ._output_pool import _output_pool_alloc as _output_pool_alloc
+from ._output_pool import _pool_active as _pool_active
+from ._output_pool import (
+    _reset_output_pool_user_opt_in_cache as _reset_output_pool_user_opt_in_cache,
+)
+from ._output_pool import output_pool_clear as output_pool_clear
 from .config import Config as Config
 from .kernel import Kernel as Kernel
 from .kernel import kernel as kernel
@@ -179,112 +186,6 @@ def default_launcher(
         if "Cannot make_shape_compatible: incompatible dimensions" in message:
             raise exc.ShapeMismatch("kernel operands", message) from error
         raise
-
-
-# -----------------------------------------------------------------------------
-# Output buffer pool (G4 round 2, env-gated)
-# -----------------------------------------------------------------------------
-#
-# When ``HELION_OUTPUT_POOL=1`` is set, the generated host wrapper's
-# ``torch.empty(...)``/``torch.zeros(...)`` calls that produce kernel-output
-# tensors are routed through ``_output_pool_alloc(...)``, which caches one
-# buffer per ``(dtype, shape, device)`` triple and returns the cached
-# buffer on subsequent calls.
-#
-# This is **unsafe** if the caller stores prior outputs (subsequent calls
-# would overwrite them). Because of that the default is OFF and the
-# wrapper falls back to ``torch.empty(...)`` semantics. Opt-in is for
-# benchmarks and tight steady-state loops only.
-#
-# Implementation note: the env var is read once on first use rather than
-# per call to keep the hot path branch-free after pooling kicks in.
-
-_OUTPUT_POOL_ENV = "HELION_OUTPUT_POOL"
-_output_pool_enabled: bool | None = None
-_output_pool_cache: dict[
-    tuple[torch.dtype, tuple[int, ...], torch.device], torch.Tensor
-] = {}
-
-
-def _output_pool_is_enabled() -> bool:
-    global _output_pool_enabled
-    if _output_pool_enabled is None:
-        _output_pool_enabled = os.environ.get(_OUTPUT_POOL_ENV, "").strip() not in (
-            "",
-            "0",
-            "false",
-            "False",
-        )
-    return _output_pool_enabled
-
-
-def _output_pool_alloc(
-    *shape_args: object,
-    dtype: torch.dtype | None = None,
-    device: torch.device | str | None = None,
-    **extra_kwargs: object,
-) -> torch.Tensor:
-    """Pooled replacement for ``torch.empty(*shape, dtype=..., device=...)``.
-
-    Matches ``torch.empty``'s overloaded shape signature: callers can pass
-    a single tuple/list ``([1024, 1024])`` or multiple positional dims
-    ``(M, N)``. Generated host wrappers emit whichever the user wrote, so
-    both shapes need to work transparently. ``dtype`` and ``device`` are
-    optional to mirror ``torch.empty``'s defaults; ``extra_kwargs`` is a
-    catch-all (e.g. ``pin_memory``) forwarded to ``torch.empty`` on the
-    miss path. Pooled buffers always carry the resolved ``dtype``/``device``
-    in their cache key, so the same call site with different dtypes gets
-    distinct cached buffers.
-
-    When ``HELION_OUTPUT_POOL=1`` is set, returns a cached buffer matching
-    the (dtype, shape, device) triple — allocating one only on the first
-    request for each unique triple. The cached buffer's contents are
-    undefined on entry (same contract as ``torch.empty``), and the kernel
-    is expected to fully write it before the caller reads.
-
-    When the env var is unset (default), behaves identically to
-    ``torch.empty(*shape, dtype=dtype, device=device)`` so existing
-    behavior is preserved.
-    """
-    if not _output_pool_is_enabled():
-        kwargs: dict[str, object] = dict(extra_kwargs)
-        if dtype is not None:
-            kwargs["dtype"] = dtype
-        if device is not None:
-            kwargs["device"] = device
-        return torch.empty(*shape_args, **kwargs)  # type: ignore[arg-type]
-    # Normalize ``shape_args`` → a flat tuple of ints (or a tuple containing
-    # one tuple/list/torch.Size that we flatten). Mirrors torch.empty's
-    # accepted overloads.
-    if len(shape_args) == 1 and isinstance(shape_args[0], (tuple, list, torch.Size)):
-        shape_t = tuple(shape_args[0])
-    else:
-        shape_t = tuple(shape_args)  # type: ignore[arg-type]
-    # Resolve defaults the same way torch.empty does so the cache key
-    # captures the actual realized dtype/device.
-    resolved_dtype = dtype if dtype is not None else torch.get_default_dtype()
-    resolved_device = device if device is not None else torch.tensor(0.0).device
-    if extra_kwargs:
-        # Uncommon: extra kwargs (e.g. ``layout``, ``pin_memory``) change
-        # storage characteristics, so don't pool — just delegate.
-        # pyrefly: ignore [no-matching-overload]
-        return torch.empty(
-            shape_t, dtype=resolved_dtype, device=resolved_device, **extra_kwargs
-        )
-    key = (resolved_dtype, shape_t, resolved_device)
-    # pyrefly: ignore [bad-argument-type]
-    buf = _output_pool_cache.get(key)
-    if buf is None:
-        # pyrefly: ignore [no-matching-overload]
-        buf = torch.empty(shape_t, dtype=resolved_dtype, device=resolved_device)
-        # pyrefly: ignore [unsupported-operation]
-        _output_pool_cache[key] = buf
-    return buf
-
-
-def output_pool_clear() -> None:
-    """Drop all pooled output buffers (for tests that need fresh storage)."""
-    _output_pool_cache.clear()
 
 
 class _FastLauncher:

--- a/helion/runtime/_output_pool.py
+++ b/helion/runtime/_output_pool.py
@@ -1,0 +1,297 @@
+"""Output buffer pool for kernel-output ``torch.empty`` allocations.
+
+The generated host wrapper's ``torch.empty(...)`` calls that produce
+kernel-output tensors are routed through ``_output_pool_alloc(...)``
+(see ``helion/_compiler/generate_ast.py``), which reuses buffers across
+calls to amortize the per-call ``cudaMalloc`` cost (~5 µs per launch on
+small kernels).
+
+Activation:
+
+* **Default (env unset).** Pooling is active for every kernel call. The
+  first time the pool actually reuses a buffer, a one-time INFO log line
+  describes what's pooled and how to opt out.
+* **``HELION_REUSE_OUTPUT_BUFFERS=0``** (or ``off``/``false``/``no``).
+  The pool is disabled — every call falls through to ``torch.empty``.
+  Use this if you keep raw ``data_ptr()`` to outputs across calls,
+  share a single ``Kernel`` across Python threads, or otherwise need
+  pre-pool semantics.
+* **``HELION_REUSE_OUTPUT_BUFFERS=debug``.** Pool active and every pool
+  decision (hit, refcount miss, capture bypass, fresh alloc) is logged
+  at INFO. Use this to diagnose suspected output corruption.
+
+When pooling is active, three signals guard against silent aliasing
+(they cover essentially all real usage):
+
+  1. Tensor reference count: a cached tensor has exactly 3 refs (dict
+     slot + the local variable holding the lookup result + the
+     ``sys.getrefcount`` arg) when no external code holds it. If the
+     refcount exceeds 3 — either because the user kept the previous
+     output, took a view (PyTorch view ops bump the parent's refcount
+     via ``_base`` for autograd version tracking), or autograd saved
+     it for backward — we allocate fresh instead.
+
+  2. CUDA stream tagging: the cache key includes the current CUDA
+     stream id. A buffer first produced on stream A is never returned
+     to a caller running on stream B, so cross-stream consumers don't
+     observe stale data.
+
+  3. CUDA graph capture: when ``torch.cuda.is_current_stream_capturing()``
+     is True, the pool is bypassed entirely (always ``torch.empty``).
+     CUDA graph buffer reuse is decided by the graph builder, not by
+     runtime liveness, so the pool would interfere otherwise.
+
+The ``_pool_active`` context manager no longer toggles activation — it
+exists purely as a clear-on-exit scope used by the autotuner so per-trial
+cached buffers don't leak past the trial boundary.
+
+Concurrency note: the safety guarantees here are per Python process
+(single-Python-thread), not thread-safe across multiple Python threads
+that share a Kernel. The refcount-based liveness check between the
+``dict.get`` and the ``return`` is not atomic across a thread switch.
+Real Helion workloads are GPU-driven on a single Python thread, so this
+matches existing usage; thread-sharing callers should opt out via
+``HELION_REUSE_OUTPUT_BUFFERS=0``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing_extensions import Self
+
+import torch
+
+log: logging.Logger = logging.getLogger(__name__)
+
+_REUSE_OUTPUT_BUFFERS_ENV = "HELION_REUSE_OUTPUT_BUFFERS"
+
+# Tri-state mode resolved from the env var on first hot-path call:
+# 0 = disabled (passthrough), 1 = enabled, 2 = enabled + debug logging.
+_MODE_DISABLED = 0
+_MODE_ENABLED = 1
+_MODE_DEBUG = 2
+_pool_mode: int | None = None
+
+# One-time INFO log fired the first time the pool returns a reused buffer.
+_pool_intro_logged = False
+
+# Bind the low-level C entry points once at import time so the hot path
+# avoids the Python wrapper layer. ``torch.cuda.current_stream(device)`` is
+# ~10× slower than ``torch._C._cuda_getCurrentStream(device_index)`` and
+# the public ``is_current_stream_capturing`` wrapper has a similar
+# overhead profile.
+_cuda_is_capturing = getattr(torch._C, "_cuda_isCurrentStreamCapturing", lambda: False)
+_cuda_get_current_stream = getattr(
+    torch._C, "_cuda_getCurrentStream", lambda _idx: (0, 0, 1)
+)
+
+# Cache keyed on (dtype, shape, device, stream_id). Values are strong
+# references to the cached tensor; the liveness check uses
+# ``sys.getrefcount`` to decide whether external code also holds the
+# tensor (in which case we allocate fresh instead of reusing).
+_output_pool_safe_cache: dict[
+    tuple[torch.dtype, tuple[int, ...], torch.device, int], torch.Tensor
+] = {}
+
+# ``sys.getrefcount(x)`` always counts the temporary binding it makes for
+# its argument, so a value held by exactly ``(dict slot, local var)``
+# reports a refcount of 3. Anything higher means external code holds it.
+_OUTPUT_POOL_BASELINE_REFCOUNT = 3
+
+
+class _pool_active:
+    """Clear-on-exit scope for the output pool.
+
+    Activation no longer depends on this scope (the pool is on by default
+    unless ``HELION_REUSE_OUTPUT_BUFFERS=0``). The autotuner still wraps
+    each trial in ``_pool_active()`` so cached buffers from per-trial
+    measurement don't leak across trial sets — entering is a no-op,
+    exiting drops the cache.
+    """
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        _output_pool_safe_cache.clear()
+
+
+def _resolve_pool_mode() -> int:
+    """Read ``HELION_REUSE_OUTPUT_BUFFERS`` once and cache the result."""
+    global _pool_mode
+    if _pool_mode is None:
+        raw = os.environ.get(_REUSE_OUTPUT_BUFFERS_ENV, "").strip().lower()
+        if raw in ("0", "off", "false", "no"):
+            _pool_mode = _MODE_DISABLED
+        elif raw == "debug":
+            _pool_mode = _MODE_DEBUG
+        else:
+            _pool_mode = _MODE_ENABLED
+    return _pool_mode
+
+
+def _maybe_log_pool_intro() -> None:
+    """Fire a one-time INFO line the first time the pool reuses a buffer."""
+    global _pool_intro_logged
+    if _pool_intro_logged:
+        return
+    _pool_intro_logged = True
+    log.info(
+        "Helion is reusing kernel-output buffers across calls to lower "
+        "launch overhead. Set HELION_REUSE_OUTPUT_BUFFERS=0 to disable "
+        "(needed if you hold raw .data_ptr() to outputs across calls or "
+        "share a Kernel across Python threads), or =debug to log each "
+        "pool decision."
+    )
+
+
+def _output_pool_alloc(
+    *shape_args: object,
+    dtype: torch.dtype | None = None,
+    device: torch.device | str | None = None,
+    **extra_kwargs: object,
+) -> torch.Tensor:
+    """Pooled replacement for ``torch.empty(*shape, dtype=..., device=...)``.
+
+    Matches ``torch.empty``'s overloaded shape signature: callers can pass
+    a single tuple/list ``([1024, 1024])`` or multiple positional dims
+    ``(M, N)``. Generated host wrappers emit whichever the user wrote, so
+    both shapes need to work transparently. ``dtype`` and ``device`` are
+    optional to mirror ``torch.empty``'s defaults; ``extra_kwargs`` is a
+    catch-all (e.g. ``pin_memory``) forwarded to ``torch.empty`` on the
+    miss path.
+
+    Pooling is on by default; ``HELION_REUSE_OUTPUT_BUFFERS=0`` disables
+    it (passthrough to ``torch.empty``) and ``=debug`` adds INFO logging
+    for every pool decision. See the module docstring for full details.
+    Returns a tensor whose contents are undefined (same contract as
+    ``torch.empty``); the kernel is expected to fully write it before the
+    caller reads.
+    """
+    mode = _resolve_pool_mode()
+    if mode == _MODE_DISABLED:
+        # Fast path: pool disabled. Pure passthrough to ``torch.empty`` so
+        # the user sees exact pre-pool semantics.
+        kwargs: dict[str, object] = dict(extra_kwargs)
+        if dtype is not None:
+            kwargs["dtype"] = dtype
+        if device is not None:
+            kwargs["device"] = device
+        return torch.empty(*shape_args, **kwargs)  # type: ignore[arg-type]
+    debug = mode == _MODE_DEBUG
+    # Normalize ``shape_args`` → a flat tuple of ints (or a tuple containing
+    # one tuple/list/torch.Size that we flatten). Mirrors torch.empty's
+    # accepted overloads.
+    if len(shape_args) == 1 and isinstance(shape_args[0], (tuple, list, torch.Size)):
+        shape_t = tuple(shape_args[0])
+    else:
+        shape_t = tuple(shape_args)  # type: ignore[arg-type]
+    # Resolve defaults the same way torch.empty does so the cache key
+    # captures the actual realized dtype/device. Use ``get_default_device``
+    # rather than ``torch.tensor(0.0).device`` so the device-defaulting
+    # branch (theoretical — generated wrappers always pass ``device=``)
+    # doesn't allocate a throwaway tensor per call.
+    resolved_dtype = dtype if dtype is not None else torch.get_default_dtype()
+    resolved_device = device if device is not None else torch.get_default_device()
+    if isinstance(resolved_device, str):
+        resolved_device = torch.device(resolved_device)
+    if extra_kwargs:
+        # Uncommon: extra kwargs (e.g. ``layout``, ``pin_memory``) change
+        # storage characteristics, so don't pool — just delegate.
+        if debug:
+            log.info(
+                "output pool: fresh alloc (extra kwargs %s) shape=%s dtype=%s device=%s",
+                sorted(extra_kwargs),
+                shape_t,
+                resolved_dtype,
+                resolved_device,
+            )
+        # pyrefly: ignore [no-matching-overload]
+        return torch.empty(
+            shape_t, dtype=resolved_dtype, device=resolved_device, **extra_kwargs
+        )
+    # Three guards: CG capture bypass, stream-keyed cache, refcount check.
+    if resolved_device.type == "cuda":
+        # Use the lowest-level C APIs available — the public Python
+        # wrappers (``torch.cuda.is_current_stream_capturing``,
+        # ``torch.cuda.current_stream``) are ~10× slower per call.
+        if _cuda_is_capturing():
+            # CUDA graph capture handles buffer reuse at graph-build time;
+            # the runtime pool must not interfere.
+            if debug:
+                log.info(
+                    "output pool: bypass (CUDA graph capture) shape=%s dtype=%s device=%s",
+                    shape_t,
+                    resolved_dtype,
+                    resolved_device,
+                )
+            # pyrefly: ignore [no-matching-overload]
+            return torch.empty(shape_t, dtype=resolved_dtype, device=resolved_device)
+        device_index = resolved_device.index
+        if device_index is None:
+            device_index = torch.cuda.current_device()
+        # ``_cuda_getCurrentStream`` returns ``(stream_id, device, raw_id)``;
+        # we use the first element as the stream tag.
+        stream_id = _cuda_get_current_stream(device_index)[0]
+    else:
+        # Non-CUDA devices: the stream concept doesn't apply, but we still
+        # want pooling per device. Use a constant stream tag.
+        stream_id = 0
+    key_safe = (resolved_dtype, shape_t, resolved_device, stream_id)
+    # pyrefly: ignore [bad-argument-type]
+    cached = _output_pool_safe_cache.get(key_safe)
+    if cached is not None:
+        # sys.getrefcount returns one more than the "real" count because
+        # of the temporary binding it creates for its argument. Our pool
+        # contributes (dict slot, ``cached`` local) → 2 + 1 (getrefcount
+        # arg) = 3 baseline. Anything higher means at least one external
+        # holder (direct ref, view via ``_base``, or autograd save).
+        if sys.getrefcount(cached) <= _OUTPUT_POOL_BASELINE_REFCOUNT:
+            if debug:
+                log.info(
+                    "output pool: hit shape=%s dtype=%s device=%s stream=%s",
+                    shape_t,
+                    resolved_dtype,
+                    resolved_device,
+                    stream_id,
+                )
+            else:
+                _maybe_log_pool_intro()
+            return cached
+        if debug:
+            log.info(
+                "output pool: refcount miss (external holder) shape=%s "
+                "dtype=%s device=%s stream=%s",
+                shape_t,
+                resolved_dtype,
+                resolved_device,
+                stream_id,
+            )
+    elif debug:
+        log.info(
+            "output pool: cold miss shape=%s dtype=%s device=%s stream=%s",
+            shape_t,
+            resolved_dtype,
+            resolved_device,
+            stream_id,
+        )
+    # pyrefly: ignore [no-matching-overload]
+    fresh = torch.empty(shape_t, dtype=resolved_dtype, device=resolved_device)
+    # pyrefly: ignore [unsupported-operation]
+    _output_pool_safe_cache[key_safe] = fresh
+    return fresh
+
+
+def output_pool_clear() -> None:
+    """Drop all pooled output buffers (for tests that need fresh storage)."""
+    _output_pool_safe_cache.clear()
+
+
+def _reset_output_pool_user_opt_in_cache() -> None:
+    """Reset the cached env-var lookup so tests can flip the mode mid-process."""
+    global _pool_mode, _pool_intro_logged
+    _pool_mode = None
+    _pool_intro_logged = False
+    output_pool_clear()

--- a/test/test_output_pool.py
+++ b/test/test_output_pool.py
@@ -1,0 +1,384 @@
+"""Tests for the output pool.
+
+The pool lives in ``helion/runtime/_output_pool.py`` and routes the
+generated host wrapper's ``torch.empty(...)`` calls through
+``_output_pool_alloc``.
+
+Activation:
+
+* Default (env unset): pool is active for every kernel call. The first
+  buffer reuse fires a one-time INFO log line.
+* ``HELION_REUSE_OUTPUT_BUFFERS=0`` (or ``off``/``false``/``no``): pool
+  is disabled (passthrough to ``torch.empty``).
+* ``HELION_REUSE_OUTPUT_BUFFERS=debug``: pool active with per-decision
+  INFO logging.
+
+When pooling is active, the cache is gated by three safety signals:
+tensor refcount (catches direct references, views via ``_base``, and
+autograd saves), CUDA stream tagging (cross-stream consumers don't see
+stale buffers), and CUDA-graph capture detection (capture bypasses the
+pool entirely).
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+from typing import Iterator
+
+import pytest
+import torch
+
+import helion
+from helion._testing import DEVICE
+import helion.language as hl
+import helion.runtime as helion_runtime
+from helion.runtime.settings import _get_backend
+
+# Output-pool tests genuinely require the Triton backend: the codegen
+# rewrite that routes ``torch.empty(...)`` through ``_helion_output_alloc``
+# (see ``helion/_compiler/generate_ast.py``) is restricted to
+# ``TritonBackend``. They would silently no-op the pool under
+# ``HELION_BACKEND=cute`` on a CUDA host.
+pytestmark = [
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA"),
+    pytest.mark.skipif(
+        _get_backend() != "triton",
+        reason="output pool codegen rewrite is Triton-backend only",
+    ),
+]
+
+
+@helion.kernel(static_shapes=True)
+def _pool_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    """Minimal add kernel used by the pool tests.
+
+    Goes through the generated host wrapper's ``torch.empty(...)`` (which
+    is rewritten to ``_helion_output_alloc``), so its output participates
+    in the pool exactly like ``examples/add.py``.
+    """
+    out = torch.empty(x.shape, dtype=x.dtype, device=x.device)
+    for tile in hl.tile(out.size()):
+        out[tile] = x[tile] + y[tile]
+    return out
+
+
+@pytest.fixture
+def reset_pool(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Reset the env-cached mode + drop buffers around each test.
+
+    The env var is read once and cached for the lifetime of the process,
+    so tests that flip it need a reset hook. ``monkeypatch`` also restores
+    the env var after the test.
+    """
+    helion_runtime._reset_output_pool_user_opt_in_cache()
+    yield
+    helion_runtime._reset_output_pool_user_opt_in_cache()
+
+
+def test_user_call_pools_by_default(
+    reset_pool: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default mode: a dropped output's buffer is reused by the next call."""
+    monkeypatch.delenv(helion_runtime._REUSE_OUTPUT_BUFFERS_ENV, raising=False)
+    helion_runtime._reset_output_pool_user_opt_in_cache()
+    x = torch.randn(256, 256, device=DEVICE, dtype=torch.float32)
+    y = torch.randn(256, 256, device=DEVICE, dtype=torch.float32)
+
+    # Warmup so the kernel itself is JIT'd.
+    out = _pool_add(x, y)
+    torch.testing.assert_close(out, x + y)
+    del out
+    gc.collect()
+
+    out1 = _pool_add(x, y)
+    p1 = out1.data_ptr()
+    del out1
+    gc.collect()
+
+    out2 = _pool_add(x, y)
+    p2 = out2.data_ptr()
+    assert p1 == p2, (
+        "Default mode: dropping the previous output should let the next "
+        f"call reuse its buffer (got {p1=} vs {p2=})."
+    )
+
+
+def test_opt_out_env_disables_pool(
+    reset_pool: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``HELION_REUSE_OUTPUT_BUFFERS=0`` falls back to fresh allocations."""
+    monkeypatch.setenv(helion_runtime._REUSE_OUTPUT_BUFFERS_ENV, "0")
+    helion_runtime._reset_output_pool_user_opt_in_cache()
+    x = torch.randn(256, 256, device=DEVICE, dtype=torch.float32)
+    y = torch.randn(256, 256, device=DEVICE, dtype=torch.float32)
+
+    # Warmup so we don't measure first-time JIT.
+    out = _pool_add(x, y)
+    del out
+    gc.collect()
+
+    out1 = _pool_add(x, y)
+    p1 = out1.data_ptr()
+    del out1
+    gc.collect()
+
+    out2 = _pool_add(x, y)
+    p2 = out2.data_ptr()
+    # Without the pool, dropping the previous tensor doesn't guarantee the
+    # CUDA caching allocator hands the same address back: assert that the
+    # passthrough doesn't go through the pool by verifying the cache stays
+    # empty (the pool would have populated it).
+    from helion.runtime._output_pool import _output_pool_safe_cache
+
+    assert not _output_pool_safe_cache, (
+        "With HELION_REUSE_OUTPUT_BUFFERS=0 the pool must be inactive; "
+        f"found {len(_output_pool_safe_cache)} cached entries instead."
+    )
+    # Also sanity-check that p1/p2 don't both come from a Helion pool slot
+    # (they may still match by chance via PyTorch's own caching allocator,
+    # which is fine — the pool itself is what we're testing).
+    assert isinstance(p1, int) and isinstance(p2, int)
+
+
+def test_pool_active_scope_clears_on_exit(
+    reset_pool: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_pool_active()`` drops cached buffers when the scope exits."""
+    monkeypatch.delenv(helion_runtime._REUSE_OUTPUT_BUFFERS_ENV, raising=False)
+    helion_runtime._reset_output_pool_user_opt_in_cache()
+    x = torch.randn(256, 256, device=DEVICE, dtype=torch.float32)
+    y = torch.randn(256, 256, device=DEVICE, dtype=torch.float32)
+
+    # Warmup outside the scope.
+    out = _pool_add(x, y)
+    del out
+    gc.collect()
+
+    from helion.runtime._output_pool import _output_pool_safe_cache
+
+    with helion_runtime._pool_active():
+        out1 = _pool_add(x, y)
+        del out1
+        gc.collect()
+        assert _output_pool_safe_cache, (
+            "Inside _pool_active() the pool should still cache buffers."
+        )
+
+    assert not _output_pool_safe_cache, (
+        "_pool_active.__exit__ must clear the cache so cross-scope state "
+        "doesn't leak; found leftover entries."
+    )
+
+
+def test_pool_view_keeps_storage_alive(
+    reset_pool: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A surviving view of the previous output forces a fresh allocation."""
+    monkeypatch.delenv(helion_runtime._REUSE_OUTPUT_BUFFERS_ENV, raising=False)
+    helion_runtime._reset_output_pool_user_opt_in_cache()
+    x = torch.randn(256, 256, device=DEVICE, dtype=torch.float32)
+    y = torch.randn(256, 256, device=DEVICE, dtype=torch.float32)
+
+    # Warmup: get the pool entry seeded.
+    out = _pool_add(x, y)
+    del out
+    gc.collect()
+
+    out1 = _pool_add(x, y)
+    p1 = out1.data_ptr()
+    view = out1[:128]  # holds out1 alive via _base + storage via view
+    del out1
+    gc.collect()
+
+    out2 = _pool_add(x, y)
+    p2 = out2.data_ptr()
+    assert p1 != p2, (
+        "View kept storage alive, so the pool must allocate a fresh buffer "
+        f"(got {p1=} vs {p2=})."
+    )
+    # Sanity: the view still sees the original buffer's data.
+    assert view.data_ptr() == p1
+
+
+def test_pool_autograd_retain_alloc_fresh(
+    reset_pool: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An autograd graph that saves the output keeps the pool from reusing it.
+
+    ``_pool_add`` itself doesn't track gradients (Helion outputs are leaf
+    tensors), so we emulate the "autograd retains" case by saving the
+    tensor inside a custom autograd graph via ``ctx.save_for_backward``.
+    """
+    monkeypatch.delenv(helion_runtime._REUSE_OUTPUT_BUFFERS_ENV, raising=False)
+    helion_runtime._reset_output_pool_user_opt_in_cache()
+    x = torch.randn(256, 256, device=DEVICE, dtype=torch.float32)
+    y = torch.randn(256, 256, device=DEVICE, dtype=torch.float32)
+
+    # Warmup.
+    out = _pool_add(x, y)
+    del out
+    gc.collect()
+
+    class Retain(torch.autograd.Function):
+        @staticmethod
+        def forward(
+            ctx: object, kept: torch.Tensor, gate: torch.Tensor
+        ) -> torch.Tensor:
+            ctx.save_for_backward(kept)  # type: ignore[attr-defined]
+            return gate.clone()
+
+        @staticmethod
+        def backward(ctx: object, grad: torch.Tensor) -> tuple[None, torch.Tensor]:
+            (kept,) = ctx.saved_tensors  # type: ignore[attr-defined]
+            return None, grad + kept.mean()
+
+    out1 = _pool_add(x, y)
+    p1 = out1.data_ptr()
+    gate = torch.zeros(1, device=DEVICE, requires_grad=True)
+    # The Retain.forward call saves out1 in the autograd graph.
+    graph_out = Retain.apply(out1, gate)
+    del out1  # caller drops their explicit ref; autograd still holds it
+    gc.collect()
+
+    out2 = _pool_add(x, y)
+    p2 = out2.data_ptr()
+    assert p1 != p2, (
+        "Autograd retained the previous output via save_for_backward, so "
+        f"the pool must allocate fresh (got {p1=} vs {p2=})."
+    )
+    # Trigger the backward path so the kept reference is exercised.
+    assert graph_out is not None
+
+
+def test_pool_cuda_graph_bypass(
+    reset_pool: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """During CUDA graph capture, the pool must bypass (never reuse)."""
+    monkeypatch.delenv(helion_runtime._REUSE_OUTPUT_BUFFERS_ENV, raising=False)
+    helion_runtime._reset_output_pool_user_opt_in_cache()
+    x = torch.randn(256, 256, device=DEVICE, dtype=torch.float32)
+    y = torch.randn(256, 256, device=DEVICE, dtype=torch.float32)
+    # Warmup outside the graph.
+    out = _pool_add(x, y)
+    torch.cuda.synchronize()
+    del out
+    gc.collect()
+
+    # Capture: the kernel runs once inside the graph context. We don't
+    # assert the data_ptr inside capture (CG semantics own that), only
+    # that the captured graph replays correctly without aliasing.
+    side_stream = torch.cuda.Stream()
+    with torch.cuda.stream(side_stream):
+        _pool_add(x, y)
+    torch.cuda.current_stream().wait_stream(side_stream)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    static_out: torch.Tensor | None = None
+    with torch.cuda.graph(graph):
+        static_out = _pool_add(x, y)
+    assert static_out is not None
+    torch.cuda.synchronize()
+
+    # Replay: should reproduce the original result.
+    graph.replay()
+    torch.cuda.synchronize()
+    expected = x + y
+    torch.testing.assert_close(static_out, expected)
+
+
+def test_pool_cross_stream_no_reuse(
+    reset_pool: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When pooling is active, the pool is stream-keyed — switching streams allocates fresh."""
+    monkeypatch.delenv(helion_runtime._REUSE_OUTPUT_BUFFERS_ENV, raising=False)
+    helion_runtime._reset_output_pool_user_opt_in_cache()
+    x = torch.randn(256, 256, device=DEVICE, dtype=torch.float32)
+    y = torch.randn(256, 256, device=DEVICE, dtype=torch.float32)
+
+    # Warmup on the default stream.
+    out = _pool_add(x, y)
+    del out
+    gc.collect()
+
+    stream_a = torch.cuda.Stream()
+    stream_b = torch.cuda.Stream()
+
+    with torch.cuda.stream(stream_a):
+        out_a = _pool_add(x, y)
+        ptr_a = out_a.data_ptr()
+        del out_a
+        gc.collect()
+    stream_a.synchronize()
+
+    with torch.cuda.stream(stream_b):
+        out_b = _pool_add(x, y)
+        ptr_b = out_b.data_ptr()
+    stream_b.synchronize()
+
+    assert ptr_a != ptr_b, (
+        "Cross-stream consumer: the pool must not return a buffer first "
+        f"allocated on stream A to a caller on stream B (got {ptr_a=} vs {ptr_b=})."
+    )
+
+
+def test_pool_debug_mode_logs_decisions(
+    reset_pool: None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``=debug`` mode emits an INFO line for each pool decision."""
+    monkeypatch.setenv(helion_runtime._REUSE_OUTPUT_BUFFERS_ENV, "debug")
+    helion_runtime._reset_output_pool_user_opt_in_cache()
+    x = torch.randn(256, 256, device=DEVICE, dtype=torch.float32)
+    y = torch.randn(256, 256, device=DEVICE, dtype=torch.float32)
+
+    # Warmup outside caplog so JIT noise stays out.
+    out = _pool_add(x, y)
+    del out
+    gc.collect()
+
+    with caplog.at_level(logging.INFO, logger="helion.runtime._output_pool"):
+        out1 = _pool_add(x, y)
+        del out1
+        gc.collect()
+        _pool_add(x, y)
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("output pool" in m for m in messages), (
+        f"Expected at least one 'output pool: ...' log line in debug mode, "
+        f"got: {messages!r}"
+    )
+
+
+def test_pool_intro_logs_once(
+    reset_pool: None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Default mode logs a one-time INFO line the first time the pool reuses."""
+    monkeypatch.delenv(helion_runtime._REUSE_OUTPUT_BUFFERS_ENV, raising=False)
+    helion_runtime._reset_output_pool_user_opt_in_cache()
+    x = torch.randn(256, 256, device=DEVICE, dtype=torch.float32)
+    y = torch.randn(256, 256, device=DEVICE, dtype=torch.float32)
+
+    # Warmup so the cache has a seeded entry to reuse.
+    out = _pool_add(x, y)
+    del out
+    gc.collect()
+
+    with caplog.at_level(logging.INFO, logger="helion.runtime._output_pool"):
+        # Two reuse calls; intro log should fire exactly once total.
+        out1 = _pool_add(x, y)
+        del out1
+        gc.collect()
+        out2 = _pool_add(x, y)
+        del out2
+        gc.collect()
+
+    intro_records = [r for r in caplog.records if "Helion is reusing" in r.getMessage()]
+    assert len(intro_records) == 1, (
+        f"Intro log should fire exactly once, got {len(intro_records)} "
+        f"records: {[r.getMessage() for r in intro_records]!r}"
+    )


### PR DESCRIPTION
Stacked PRs:
 * #2537
 * __->__#2536
 * #2535
 * #2534
 * #2533


--- --- ---

Every kernel call needs an output tensor to write into, which used
to mean a fresh torch.empty() each time -- about 5 microseconds of
CUDA allocator work per call. On small kernels that is most of the
remaining overhead. But blindly reusing buffers is dangerous: if a
caller is still holding the previous output, reusing its memory
would silently corrupt their data.

Keep a small cache of recently returned output tensors and hand the
same buffer back on the next call -- but only when it is safe. We
detect "safe" with three signals:
  1. Is the buffer still alive somewhere else? (refcount check
     catches direct references, views, and saved-for-backward.)
  2. Was it created on a different CUDA stream? (cache key includes
     the stream id.)
  3. Are we currently capturing a CUDA graph? (the graph builder
     owns buffer reuse during capture; we step aside.)

If any of those signals fire, we allocate fresh.

User-facing controls via HELION_REUSE_OUTPUT_BUFFERS:
  - unset (default): pool active, safety guards on. A one-time
    INFO log line tells you the pool is on the first time a buffer
    is reused, so if anything looks corrupted you know what to
    turn off.
  - =0 (or off/false/no): pool disabled, every call is torch.empty.
    Use this if you keep raw .data_ptr() to outputs across calls,
    share a single Kernel across Python threads, or otherwise need
    pre-pool semantics.
  - =debug: pool active and every decision (hit / refcount miss /
    capture bypass / cold miss / fresh-due-to-extra-kwargs) is
    logged at INFO. Use this to diagnose suspected output
    corruption.

Perf (1024x1024 bf16 add microbench, CUDA graphs off):
  Pre-launcher baseline:                      34.5 us / call
  Previous patch:                             18.2 us / call
  This patch (default):                       11.6 us / call  (-36% vs prev)
  This patch (HELION_REUSE_OUTPUT_BUFFERS=0): 17.9 us / call  (matches pre-pool)

Hot-path overhead measured at ~1 us / call after this change,
dominated by the unavoidable torch._C._cuda_* CUDA-context calls.

Replaces per-call torch.empty in the generated host wrapper with a
refcount-aware buffer cache (helion/runtime/_output_pool.py).

The three safety signals in detail:
  1. Tensor reference count: sys.getrefcount(cached) <= 3 means no
     external code holds the buffer (direct refs, PyTorch views via
     _base, and autograd save_for_backward all bump the count);
     otherwise allocate fresh.
  2. Stream-tagged cache key: (dtype, shape, device, stream_id), so
     a buffer first allocated on stream A is never returned to a
     consumer on stream B.
  3. CUDA-graph capture bypass: torch._C._cuda_isCurrentStreamCapturing()
     short-circuits the pool during capture; CG owns those buffers.

_pool_active() is retained as a clear-on-exit scope only: activation
is no longer gated on it, but the autotuner still wraps trial timing
in it so cached buffers from one trial set don't leak into the next.

Direct torch._C._cuda_* bindings used on the hot path (~10x faster
than the public Python wrappers).
