### PR TITLE
Speed up Helion kernel launches by avoiding repeated Python work

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -970,7 +970,17 @@ class TritonBackend(Backend):
             f"tl.full([{', '.join(shape_dims)}], {value_expr}, {self.dtype_str(dtype)})"
         )
 
-    def launcher_keyword_args(self, config: Config, *, has_barrier: bool) -> list[str]:
+    def launcher_runtime_kwargs(
+        self, config: Config, *, has_barrier: bool
+    ) -> dict[str, object]:
+        """Return the launcher kwargs as a ``dict`` of runtime values.
+
+        Used by both :meth:`launcher_keyword_args` (which formats the dict
+        as source strings for codegen) and
+        :func:`helion.runtime.build_fast_launcher` (which bakes the dict
+        into a closure at :meth:`BoundKernel.set_config` time so the hot
+        launch path doesn't have to allocate a per-call kwargs dict).
+        """
         from .._compat import supports_maxnreg
 
         # Workaround for triton bug: warp_specialize requires at least 4 warps
@@ -979,31 +989,45 @@ class TritonBackend(Backend):
         if any(config.range_warp_specializes):
             num_warps = max(4, num_warps)
 
-        args = [
-            f"num_warps={num_warps}",
-            f"num_stages={config.num_stages}",
-            *(["launch_cooperative_grid=True"] if has_barrier else []),
-        ] + [
-            f"{x.removeprefix('_triton_config_')}={config[x]}"
-            for x in config
-            if x.startswith("_triton_config_")
-        ]
+        kwargs: dict[str, object] = {
+            "num_warps": num_warps,
+            "num_stages": config.num_stages,
+        }
+        if has_barrier:
+            kwargs["launch_cooperative_grid"] = True
+        for x in config:
+            if x.startswith("_triton_config_"):
+                kwargs[x.removeprefix("_triton_config_")] = config[x]
 
         from ..autotuner.config_spec import _get_backend_tunable_keys
 
         for key in _get_backend_tunable_keys():
             if key in config:
-                args.append(f"{key}={config[key]!r}")
+                kwargs[key] = config[key]
 
         if "maxnreg" in config and config["maxnreg"] is not None and supports_maxnreg():
-            args.append(f"maxnreg={config['maxnreg']}")
+            kwargs["maxnreg"] = config["maxnreg"]
 
         advanced_controls_file = config.advanced_controls_file
         if advanced_controls_file:
-            ptx_option = f"--apply-controls {advanced_controls_file}"
-            args.append(f"ptx_options={ptx_option!r}")
+            kwargs["ptx_options"] = f"--apply-controls {advanced_controls_file}"
 
-        return args
+        return kwargs
+
+    def launcher_keyword_args(self, config: Config, *, has_barrier: bool) -> list[str]:
+        from ..autotuner.config_spec import _get_backend_tunable_keys
+
+        backend_tunable_keys = _get_backend_tunable_keys()
+        kwargs = self.launcher_runtime_kwargs(config, has_barrier=has_barrier)
+        # Backend tunable keys (typically strings) and ptx_options use repr;
+        # everything else (num_warps, num_stages, ints, bools) renders plain.
+        out: list[str] = []
+        for k, v in kwargs.items():
+            if k in backend_tunable_keys or k == "ptx_options":
+                out.append(f"{k}={v!r}")
+            else:
+                out.append(f"{k}={v}")
+        return out
 
     def grid_barrier_stmt(self, sem_arg: str) -> str:
         return f"triton_helpers.x_grid_barrier({sem_arg})"

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -181,6 +181,308 @@ def default_launcher(
         raise
 
 
+class _FastLauncher:
+    """Fast launcher that bypasses Triton's ``JITFunction.run`` Python frame.
+
+    On the first call this lazily JIT-compiles the underlying Triton kernel
+    (via ``triton_kernel.run(..., warmup=True)``), captures the resulting
+    ``CompiledKernel``, its packed metadata, the launch-hook callables, the
+    active driver/device, and the binder. Subsequent calls dispatch straight
+    into the C launcher Triton generates, skipping ``JITFunction.run``'s
+    cache lookup, ``compute_cache_key`` call, and per-call kwargs dict
+    construction.
+
+    The closure bakes in ``num_warps`` / ``num_stages`` /
+    ``launch_cooperative_grid`` / ``ptx_options`` so no per-call dict is
+    allocated on the hot path; it also caches a precomputed ``run_kwargs``
+    dict to pass to the binder on each call so that path stays Python-cheap
+    too.
+
+    If anything goes wrong while priming (e.g. an unsupported Triton
+    version, an alternative backend that doesn't expose
+    ``CompiledKernel.run``), the launcher transparently falls back to
+    :func:`default_launcher` so the kernel still runs.
+    """
+
+    __slots__ = (
+        "_active_driver",
+        "_binder",
+        "_bind_skip_safe",
+        "_compiled_kernel",
+        "_compiled_run",
+        "_device",
+        "_get_current_stream",
+        "_kernel_launch_metadata",
+        "_launch_cooperative_grid",
+        "_launch_enter_hook",
+        "_launch_exit_hook",
+        "_num_warps",
+        "_num_stages",
+        "_packed_metadata",
+        "_primed",
+        "_ptx_options",
+        "_run_kwargs",
+        "_triton_function",
+    )
+
+    def __init__(
+        self,
+        *,
+        num_warps: int,
+        num_stages: int,
+        launch_cooperative_grid: bool = False,
+        ptx_options: str | None = None,
+        extra_kwargs: dict | None = None,
+    ) -> None:
+        self._num_warps = num_warps
+        self._num_stages = num_stages
+        self._launch_cooperative_grid = launch_cooperative_grid
+        self._ptx_options = ptx_options
+        # Pre-built kwargs dict for the priming warmup AND the fallback path
+        # AND every binder() invocation. Stored once so the hot path doesn't
+        # have to build a fresh kwargs dict per launch.
+        run_kwargs: dict = {
+            "num_warps": num_warps,
+            "num_stages": num_stages,
+            "launch_cooperative_grid": launch_cooperative_grid,
+        }
+        if extra_kwargs:
+            run_kwargs.update(extra_kwargs)
+        if ptx_options is not None:
+            run_kwargs["ptx_options"] = ptx_options
+        self._run_kwargs = run_kwargs
+
+        # Lazy fields, set by _prime() on the first call.
+        self._primed = False
+        self._compiled_kernel: object = None
+        self._compiled_run: Callable[..., object] | None = None
+        self._triton_function: object = None
+        self._packed_metadata: object = None
+        self._kernel_launch_metadata: Callable[..., object] | None = None
+        self._launch_enter_hook: object = None
+        self._launch_exit_hook: object = None
+        self._active_driver: object = None
+        self._device: object = None
+        self._get_current_stream: Callable[[object], object] | None = None
+        self._binder: Callable[..., tuple] | None = None
+        # True if priming proved that ``bound_args.values() == args`` for
+        # this kernel — i.e. all kernel parameters map 1:1 onto positional
+        # args, so the per-call binder invocation can be skipped entirely.
+        # This holds for typical Helion kernels because Helion inlines
+        # constexpr block-sizes as module-level constants rather than
+        # passing them as Triton parameters.
+        self._bind_skip_safe = False
+
+    def _prime(
+        self, triton_kernel: object, grid: tuple[int, ...], args: tuple[object, ...]
+    ) -> None:
+        """Capture the cached ``CompiledKernel`` and dispatch state.
+
+        Called once on the first invocation. After this returns
+        successfully, :meth:`__call__` dispatches via
+        :attr:`_compiled_run` (the C launcher Triton's ``make_launcher``
+        emits). On any failure we set ``_primed=True`` with
+        ``_compiled_run=None`` so subsequent calls fall through to
+        :func:`default_launcher`.
+        """
+        self._primed = True
+        try:
+            import triton
+            from triton.runtime.driver import driver
+        except ImportError:
+            self._compiled_run = None
+            return
+
+        try:
+            warmup_kwargs = {**self._run_kwargs, "grid": grid, "warmup": True}
+            # pyrefly: ignore[missing-attribute]
+            compiled_kernel = triton_kernel.run(*args, **warmup_kwargs)
+            if compiled_kernel is None:
+                self._compiled_run = None
+                return
+
+            active_driver = driver.active
+            # pyrefly: ignore[missing-attribute]
+            device = active_driver.get_current_device()
+            # device_caches[device] = (kernel_cache, kernel_key_cache,
+            #                          target, backend, binder)
+            # pyrefly: ignore[missing-attribute]
+            device_cache = triton_kernel.device_caches[device]
+            binder = device_cache[4]
+
+            # Probe: do bound_args.values() == args? If yes, skip the
+            # binder on every hot call (saves a generated dynamic_func
+            # invocation + N native_specialize_impl C calls per launch).
+            try:
+                bound_args, _spec, _opts = binder(*args, **self._run_kwargs)
+                bound_values = tuple(bound_args.values())
+                self._bind_skip_safe = len(bound_values) == len(args) and all(
+                    b is a for b, a in zip(bound_values, args, strict=True)
+                )
+            except Exception:
+                self._bind_skip_safe = False
+
+            launch_enter_hook = triton.knobs.runtime.launch_enter_hook
+            launch_exit_hook = triton.knobs.runtime.launch_exit_hook
+
+            self._compiled_kernel = compiled_kernel
+            self._compiled_run = compiled_kernel.run
+            self._triton_function = compiled_kernel.function
+            self._packed_metadata = compiled_kernel.packed_metadata
+            self._kernel_launch_metadata = compiled_kernel.launch_metadata
+            self._launch_enter_hook = launch_enter_hook
+            self._launch_exit_hook = launch_exit_hook
+            self._active_driver = active_driver
+            self._device = device
+            # Cache the bound-method to avoid attribute lookup per call.
+            # pyrefly: ignore[missing-attribute]
+            self._get_current_stream = active_driver.get_current_stream
+            self._binder = binder
+            # We don't precompute a ``launch_metadata_skip`` flag here
+            # because a profiler may attach (adding hooks) later in the
+            # process. The hot path checks ``launch_enter_hook`` /
+            # ``launch_exit_hook`` activity per call instead — cheap
+            # because both are HookChain objects whose ``calls`` list
+            # check is a constant-time identity comparison.
+        except Exception:
+            # Any priming failure → leave _compiled_run None so the
+            # __call__ path falls back to default_launcher.
+            self._compiled_run = None
+
+    def __call__(
+        self,
+        triton_kernel: object,
+        grid: tuple[int, ...],
+        *args: object,
+        # Spell out the kwargs the generated wrapper always passes so
+        # CPython binds them positionally into local slots rather than
+        # packing them into a per-call **kwargs dict. The closure already
+        # has the runtime values baked in; these parameter names exist
+        # solely to absorb the wrapper's keyword arguments cheaply, and
+        # are otherwise unused.
+        num_warps: int | None = None,
+        num_stages: int | None = None,
+        launch_cooperative_grid: bool = False,
+        **kwargs: object,
+    ) -> object:
+        # Under torch.compile / Dynamo tracing, defer to ``default_launcher``
+        # which routes through ``triton_kernel.run`` and is captured by
+        # Dynamo's ``triton_kernel_wrapper_mutation`` HOP handler.
+        #
+        # The fast path calls ``_cuda_getCurrentRawStream`` directly. Dynamo
+        # has that symbol in its in-graph allowlist
+        # (``torch_c_binding_in_graph_functions``), so tracing it produces a
+        # graph node whose example_value is ``int``, which trips Dynamo's
+        # "torch.* op returned non-Tensor" check and aborts the trace.
+        #
+        # On PyTorch builds where Helion's own HOP is registered (see
+        # ``supports_torch_compile_fusion`` in ``helion/_compat.py``), the
+        # kernel call is intercepted at the ``HelionKernelVariable`` level
+        # and ``_FastLauncher.__call__`` is never reached during tracing —
+        # this guard is a no-op on those builds. It only fires on
+        # builds/configs where the HOP isn't available (e.g. PyTorch < 2.11
+        # or XPU) and Dynamo falls through to trace the launcher.
+        if torch.compiler.is_compiling():
+            return default_launcher(
+                triton_kernel,
+                grid,
+                *args,
+                **self._run_kwargs,
+            )
+
+        if not self._primed:
+            self._prime(triton_kernel, grid, args)
+
+        compiled_run = self._compiled_run
+        if compiled_run is None:
+            # Fall back to Triton's Python launcher. Forward the full
+            # ``_run_kwargs`` mapping so any backend tunable / ``maxnreg`` /
+            # ``_triton_config_*`` keys baked in at ``build_fast_launcher``
+            # time also reach ``default_launcher`` — keeping behavior
+            # consistent with the captured config when priming fails.
+            return default_launcher(
+                triton_kernel,
+                grid,
+                *args,
+                **self._run_kwargs,
+            )
+
+        # Hot path — no dict allocation, no Python-level Triton run frame.
+        try:
+            if self._bind_skip_safe:
+                # Skip the binder: for typical Helion kernels (where
+                # constexprs are inlined as module-level constants),
+                # ``bound_args.values() == args``. Priming validated this.
+                kernel_args = args
+            else:
+                # pyrefly: ignore[not-callable]
+                bound_args, _spec, _opts = self._binder(*args, **self._run_kwargs)
+                kernel_args = tuple(bound_args.values())
+
+            grid_size = len(grid)
+            grid_0 = grid[0]
+            grid_1 = grid[1] if grid_size > 1 else 1
+            grid_2 = grid[2] if grid_size > 2 else 1
+            # pyrefly: ignore[not-callable]
+            stream = self._get_current_stream(self._device)
+            # Skip ``launch_metadata`` when no profiler hooks are active.
+            # Probe identity / calls list directly: older Triton uses
+            # ``None``, newer Triton uses ``HookChain`` (no ``__bool__``).
+            enter_hook = self._launch_enter_hook
+            exit_hook = self._launch_exit_hook
+            if (enter_hook is None or getattr(enter_hook, "calls", None) == []) and (
+                exit_hook is None or getattr(exit_hook, "calls", None) == []
+            ):
+                launch_metadata = None
+            else:
+                # pyrefly: ignore[not-callable]
+                launch_metadata = self._kernel_launch_metadata(
+                    grid, stream, *kernel_args
+                )
+            return compiled_run(
+                grid_0,
+                grid_1,
+                grid_2,
+                stream,
+                self._triton_function,
+                self._packed_metadata,
+                launch_metadata,
+                self._launch_enter_hook,
+                self._launch_exit_hook,
+                *kernel_args,
+            )
+        except Exception as error:
+            message = str(error)
+            if "Cannot make_shape_compatible: incompatible dimensions" in message:
+                raise exc.ShapeMismatch("kernel operands", message) from error
+            raise
+
+
+def build_fast_launcher(
+    *,
+    num_warps: int,
+    num_stages: int,
+    launch_cooperative_grid: bool = False,
+    ptx_options: str | None = None,
+    extra_kwargs: dict | None = None,
+) -> _FastLauncher:
+    """Build a :class:`_FastLauncher` closure with config baked in.
+
+    Invoked from :meth:`BoundKernel.set_config` after the generated Triton
+    kernel is compiled. The returned object's ``__call__`` signature
+    matches :func:`default_launcher`, so the generated wrapper can use it
+    as a drop-in replacement (threaded through as ``_launcher=`` by the
+    bound-kernel-level wrapper installed in ``set_config``).
+    """
+    return _FastLauncher(
+        num_warps=num_warps,
+        num_stages=num_stages,
+        launch_cooperative_grid=launch_cooperative_grid,
+        ptx_options=ptx_options,
+        extra_kwargs=extra_kwargs,
+    )
+
+
 def _pallas_make_block_spec(
     pl: object,
     jnp: object,

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -863,11 +863,76 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             config: The configuration to set.
         """
         config = self._normalize_config(config)
-        self._run = self.compile_config(config)
+        compiled = self.compile_config(config)
+        self._install_fast_launcher(compiled, config)
+        self._run = compiled
         self._config = config
         counters["best_config_decorator"][
             self.format_kernel_decorator(config, self.settings)
         ] = 1
+
+    def _install_fast_launcher(
+        self,
+        compiled: CompiledConfig,
+        config: Config,
+    ) -> None:
+        """Re-point ``compiled``'s ``_launcher`` kwarg default at a fast closure.
+
+        The generated host wrapper declares
+        ``def add(x, y, *, _launcher=_default_launcher)``; Python stores the
+        ``_default_launcher`` value in ``compiled.__kwdefaults__``. By
+        overwriting that entry with a :class:`helion.runtime._FastLauncher`
+        closure (built once with this config's ``num_warps`` / ``num_stages``
+        / etc. baked in), every direct call to ``compiled(*args)`` —
+        including from ``BoundKernel.__call__`` on the steady-state hot
+        path — uses the fast launcher with no extra Python wrapping.
+
+        The autotune trial harness and any external caller that explicitly
+        passes ``_launcher=`` (e.g. ``benchmarks/launch_overhead.py``)
+        overrides the kwdefault automatically, so this is safe.
+
+        Non-Triton backends and any priming failure cause the kwdefault to
+        be left at :func:`default_launcher`.
+        """
+        from . import build_fast_launcher
+
+        backend = self.env.backend
+        if not isinstance(backend, TritonBackend):
+            return
+        kwdefaults = getattr(compiled, "__kwdefaults__", None)
+        if not kwdefaults or "_launcher" not in kwdefaults:
+            # No ``_launcher`` kwonly default — nothing to wire up.
+            # (Should not happen for Helion-compiled Triton kernels.)
+            return
+
+        try:
+            kwargs = backend.launcher_runtime_kwargs(
+                config, has_barrier=self._env.has_barrier
+            )
+        except Exception:
+            log.debug(
+                "FastLauncher disabled: backend.launcher_runtime_kwargs raised",
+                exc_info=True,
+            )
+            return
+
+        num_warps = cast("int", kwargs.pop("num_warps"))
+        num_stages = cast("int", kwargs.pop("num_stages"))
+        launch_cooperative_grid = cast(
+            "bool", kwargs.pop("launch_cooperative_grid", False)
+        )
+        ptx_options = cast("str | None", kwargs.pop("ptx_options", None))
+        # Anything left in kwargs (backend tunable keys, maxnreg,
+        # _triton_config_*) is forwarded as ``extra_kwargs`` to be baked
+        # into the closure.
+        fast_launcher = build_fast_launcher(
+            num_warps=num_warps,
+            num_stages=num_stages,
+            launch_cooperative_grid=launch_cooperative_grid,
+            ptx_options=ptx_options,
+            extra_kwargs=kwargs or None,
+        )
+        kwdefaults["_launcher"] = fast_launcher
 
     def _specialize_extra(self) -> list[Callable[[Sequence[object]], Hashable]]:
         """


### PR DESCRIPTION

Modified from the stack at https://github.com/pytorch/helion/pull/2533.

Every time you call a Helion kernel, the GPU compiler underneath
(Triton) redoes a bunch of bookkeeping it does not actually need to
repeat: rebinding arguments, recomputing cache keys, dictionary
lookups. On small kernels, this Python work dominates total
wall-clock time per call.

We do the bookkeeping once on the first call, cache the result, and
on every later call jump straight into Triton's C launcher.

End-to-end validation on H100 via TritonBench:

  HELION_AUTOTUNE_EFFORT=none python benchmarks/run.py \
      --kernel <name> --metrics walltime,accuracy --num-inputs 5

  (--metrics walltime is required; the default --metrics latency uses
  CUDA events and excludes Python-side launch overhead.)

vector_add (--only helion_add, no baseline):

  x_val    before (us)   after (us)   delta (us)
   4096         22.61        18.26       -4.35
   8192         22.43        17.99       -4.44
  16384         22.82        18.17       -4.65
  32768         22.89        18.15       -4.74
  65536         22.87        18.03       -4.84
    avg         22.72        18.12       -4.60

rms_norm (with llama_rms baseline; accuracy=1 means match):

  (M, H)          before (us)   after (us)   delta (us)   accuracy
  (2048, 1024)          34.95        26.28        -8.67          1
  (2048, 2048)          34.35        26.45        -7.90          1
  (2048, 4096)          36.27        27.93        -8.34          1
  (2048, 8192)          82.31        82.31         0.00          1
  (2048, 16384)        182.97       183.51        +0.54          1

The improvement is a fixed per-call cost removed; it dominates on
small kernels and is amortized away at larger shapes. Numerics are
unchanged (accuracy stays at 1 vs the llama_rms baseline).

The rms_norm wins (~8 us) are larger than vector_add's (~4.6 us)
because rms_norm passes more arguments (weight tensor + epsilon
scalar), which means more bind/cache-key work that the fast launcher
now skips.


For reference, autotuned Helion vs Triton/torch baselines at the
smallest vector_add shape (HELION_AUTOTUNE_EFFORT default, not
"none"):

  python benchmarks/run.py --kernel vector_add \
      --metrics walltime,accuracy --num-inputs 1 \
      --only helion_add,triton_add,torch_add

  impl                     walltime (us)   accuracy
  torch_add (eager)                 4.66   (baseline)
  triton_add                                9.50          1
  helion_add (autotuned)           18.10          1

This PR removes the per-call Python work in the Triton launcher.
The remaining ~8.6 us gap between helion_add and triton_add is
Helion-over-Triton framing in Kernel.__call__ itself, which will be
addressed in later PRs.
Additionally, fall back to the default Triton launcher under
torch.compile / Dynamo tracing on PyTorch builds where Helion's HOP
isn't registered (supports_torch_compile_fusion() is False). The
fast launcher's direct _cuda_getCurrentRawStream call returns int
and trips Dynamo's "torch.* op returned non-Tensor" check; on builds
where the HOP intercepts the call earlier, this guard is a no-op.

