### PR TITLE
[Pallas] correct RNG seed buffer argument ordering in launcher

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1857,11 +1857,12 @@ class PallasBackend(Backend):
                     output_only_names.append(arg.host_str())
         self._output_only_names = output_only_names
 
-        launcher_args = [*args, f"_output_indices={output_indices}"]
-        launcher_args.append(f"_inplace_indices={inplace_indices}")
-
+        launcher_args = [*args]
         if has_rng_ops:
-            launcher_args.insert(-1, "_rng_seed_buffer")
+            launcher_args.append("_rng_seed_buffer")
+        launcher_args.extend(
+            [f"_output_indices={output_indices}", f"_inplace_indices={inplace_indices}"]
+        )
 
         block_spec_info = self._compute_block_spec_info(sorted_args, config)
         if block_spec_info is not None:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -444,6 +444,16 @@ def pallas_chunked_add(x: torch.Tensor) -> torch.Tensor:
     return out
 
 
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_rand_add(x: torch.Tensor, seed: int) -> torch.Tensor:
+    """Kernel that uses hl.rand to generate random values and add them to x."""
+    out = torch.empty_like(x)
+    (m,) = x.size()
+    for tile_m in hl.tile(m):
+        out[tile_m] = x[tile_m] + hl.rand([tile_m], seed=seed)
+    return out
+
+
 @onlyBackends(["triton", "pallas"])
 @skipUnlessPallas("JAX/Pallas TPU not available")
 class TestPallas(TestCase):
@@ -2775,6 +2785,30 @@ class TestPallas(TestCase):
             block_sizes=[64],
         )
         torch.testing.assert_close(result, x * coeffs[0] * coeffs[4] * coeffs[5])
+
+    def test_rand_add(self) -> None:
+        """Test kernel using hl.rand (RNG ops) passes _rng_seed_buffer correctly.
+
+        Regression test: the Pallas launcher previously inserted _rng_seed_buffer
+        at position -1 (before _inplace_indices), which put it between
+        _output_indices and _inplace_indices. The fix places _rng_seed_buffer
+        before both _output_indices and _inplace_indices so the Pallas runtime
+        receives arguments in the correct order.
+        """
+        x = torch.randn(1024, device=DEVICE, dtype=torch.float32)
+        _, result = code_and_output(
+            pallas_rand_add,
+            (x, 42),
+            block_sizes=[1024],
+        )
+        # Verify shape and dtype are correct
+        self.assertEqual(result.shape, x.shape)
+        self.assertEqual(result.dtype, x.dtype)
+        # The result should differ from x (random values added)
+        self.assertFalse(torch.allclose(result, x))
+        # All added random values should be in [0, 1), so result >= x and < x + 1
+        self.assertTrue(torch.all(result >= x))
+        self.assertTrue(torch.all(result < x + 1.0))
 
 
 @skipUnlessPallas("JAX/Pallas TPU not available")


### PR DESCRIPTION

The Pallas backend's build_launcher_args method had a bug in how it
positioned _rng_seed_buffer relative to _output_indices and
_inplace_indices in the generated launcher call.

Previously, the code used insert(-1, "_rng_seed_buffer") which placed
the RNG seed buffer between _output_indices and _inplace_indices
keyword arguments. This resulted in a positional argument appearing
after a keyword argument in the generated Python code, which could
cause the Pallas runtime to receive arguments in the wrong order on
TPU and lead to failures when kernels use random operations.

The fix reorders the argument construction to append _rng_seed_buffer
(when present) immediately after the tensor positional args and before
any keyword-style arguments (_output_indices, _inplace_indices). This
ensures the generated launcher call has all positional arguments before
keyword arguments, matching the expected calling convention.

Includes a regression test (test_rand_add) that exercises a Pallas
kernel using hl.rand and verifies correct execution and argument
ordering in the generated code.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
