### PR TITLE
Improve CuTe RMS norm reduction path

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -190,6 +190,10 @@ class Backend(abc.ABC):
         """Maximum threads for a single warp-level reduction, or None if unlimited."""
         return None
 
+    def max_reduction_loop(self) -> int | None:
+        """Maximum user-visible loop chunk for a rolled reduction."""
+        return self.max_reduction_threads()
+
     def adjust_reduction_thread_count(
         self, requested: int, existing_strategies: list[TileStrategy]
     ) -> int:
@@ -2815,7 +2819,15 @@ class CuteBackend(Backend):
         return f"({tensor_name})[{index_expr}]"
 
     def max_reduction_threads(self) -> int | None:
-        return 32
+        return 1024
+
+    def max_reduction_loop(self) -> int | None:
+        from .reduction_strategy import cute_looped_reduction_block_size
+
+        max_threads = self.max_reduction_threads()
+        if max_threads is None:
+            return None
+        return cute_looped_reduction_block_size(2**31 - 1, max_threads)
 
     def adjust_reduction_thread_count(
         self, requested: int, existing_strategies: list[TileStrategy]

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -1078,6 +1078,10 @@ class GenerateASTFromInductor(DefaultHandler):
         return self._lift(result)
 
     def rsqrt(self, x: object) -> str:  # type: ignore[override]
+        if CompileEnvironment.current().backend.name == "cute":
+            return self._lift(
+                expr_from_string("cute.math.rsqrt({x})", x=self._to_ast(x))
+            )
         try:
             return self._default("rsqrt", (x,), {})
         except NotImplementedError:

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -91,6 +91,19 @@ def _cute_reduction_smem_bytes(num_elements: int, dtype: torch.dtype) -> int:
     return num_elements * torch.empty((), dtype=dtype).element_size()
 
 
+_CUTE_LOOPED_REDUCTION_MAX_ELEMENTS_PER_THREAD = 256
+_CUTE_WARP_REDUCTION_THREADS = 32
+
+
+def cute_looped_reduction_block_size(size_hint: int, max_threads: int) -> int:
+    """Pick the default CuTe loop chunk for reductions wider than one warp."""
+    return min(size_hint, max_threads * _CUTE_LOOPED_REDUCTION_MAX_ELEMENTS_PER_THREAD)
+
+
+def cute_live_reduction_threads(max_threads: int) -> int:
+    return min(max_threads, _CUTE_WARP_REDUCTION_THREADS)
+
+
 class ReductionStrategy(TileStrategy):
     def __init__(
         self,
@@ -395,6 +408,8 @@ class PersistentReductionStrategy(ReductionStrategy):
         # Compute thread count for warp-level reductions
         max_threads = env.backend.max_reduction_threads()
         if max_threads is not None:
+            if env.backend.name == "cute":
+                max_threads = cute_live_reduction_threads(max_threads)
             if isinstance(numel, (int, sympy.Integer)):
                 size_hint = int(numel)
             elif isinstance(numel, sympy.Expr):
@@ -572,7 +587,39 @@ class LoopedReductionStrategy(ReductionStrategy):
         block_size: int,
     ) -> None:
         env = CompileEnvironment.current()
-        if env.known_multiple(env.block_sizes[block_index].numel, block_size):
+        assert block_size > 1
+        # Compute thread count for warp-level reductions
+        max_threads = env.backend.max_reduction_threads()
+        if max_threads is not None:
+            thread_count = next_power_of_2(min(block_size, max_threads))
+        else:
+            thread_count = 0
+        tile_dispatch = getattr(fn, "tile_strategy", None)
+        if tile_dispatch is not None:
+            thread_count = env.backend.adjust_reduction_thread_count(
+                thread_count, tile_dispatch.strategies
+            )
+        self._thread_count = thread_count
+        self.block_size = block_size
+        self._loop_block_size = block_size
+        self._cute_reduction_lane_var: str | None = None
+        self._cute_reduction_lane_extent = 1
+        if (
+            env.backend.name == "cute"
+            and thread_count > 0
+            and block_size > thread_count
+        ):
+            self._cute_reduction_lane_extent = (
+                block_size + thread_count - 1
+            ) // thread_count
+            self._loop_block_size = thread_count * self._cute_reduction_lane_extent
+            self._cute_reduction_lane_var = fn.new_var(
+                f"reduction_lane_{block_index}",
+                dce=False,
+            )
+        if env.known_multiple(
+            env.block_sizes[block_index].numel, self._loop_block_size
+        ):
             mask_var: str | None = None
         else:
             mask_var = fn.new_var(f"mask_{block_index}", dce=True)
@@ -584,27 +631,92 @@ class LoopedReductionStrategy(ReductionStrategy):
         )
         self.offset_vars[block_index] = fn.new_var(f"roffset_{block_index}", dce=True)
         self.index_vars[block_index] = fn.new_var(f"rindex_{block_index}", dce=True)
-        self.block_size = block_size
-        assert block_size > 1
-        # Compute thread count for warp-level reductions
-        max_threads = env.backend.max_reduction_threads()
-        if max_threads is not None:
-            self._thread_count = next_power_of_2(min(block_size, max_threads))
-        else:
-            self._thread_count = 0
-        tile_dispatch = getattr(fn, "tile_strategy", None)
-        if tile_dispatch is not None:
-            self._thread_count = env.backend.adjust_reduction_thread_count(
-                self._thread_count, tile_dispatch.strategies
-            )
-            self.block_size = (
-                min(self.block_size, self._thread_count)
-                if self._thread_count > 1
-                else self.block_size
-            )
 
     def _reduction_thread_count(self) -> int:
         return self._thread_count
+
+    def _active_thread_axis_sizes(
+        self, state: CodegenState, device_loop: DeviceLoopState
+    ) -> dict[int, int]:
+        axis_sizes: dict[int, int] = {}
+        seen: set[int] = set()
+        for loops in state.codegen.active_device_loops.values():
+            for loop_state in loops:
+                if not isinstance(loop_state, (DeviceLoopState, DeviceGridState)):
+                    continue
+                key = id(loop_state)
+                if key in seen:
+                    continue
+                seen.add(key)
+                for axis, size in loop_state.thread_axis_sizes.items():
+                    axis_sizes[axis] = max(axis_sizes.get(axis, 1), size)
+        current_grid = state.codegen.current_grid_state
+        if isinstance(current_grid, DeviceGridState):
+            for axis, size in current_grid.thread_axis_sizes.items():
+                axis_sizes[axis] = max(axis_sizes.get(axis, 1), size)
+        for axis, size in device_loop.thread_axis_sizes.items():
+            axis_sizes[axis] = max(axis_sizes.get(axis, 1), size)
+        return axis_sizes
+
+    def _cute_cross_warp_reduction_expr(
+        self,
+        state: CodegenState,
+        device_loop: DeviceLoopState,
+        input_name: str,
+        reduction_type: str,
+        default_value: float | bool,
+        dtype: torch.dtype,
+    ) -> str | None:
+        env = CompileEnvironment.current()
+        backend = env.backend
+        if (
+            backend.name != "cute"
+            or self._thread_count <= 32
+            or backend.is_indexed_reduction(reduction_type)
+        ):
+            return None
+
+        axis_sizes = self._active_thread_axis_sizes(state, device_loop)
+        reduction_axis = self._get_thread_axis()
+        axis_sizes[reduction_axis] = max(
+            axis_sizes.get(reduction_axis, 1), self._thread_count
+        )
+        num_threads = 1
+        for size in axis_sizes.values():
+            num_threads *= size
+        group_span = self._thread_count
+        if num_threads % group_span != 0:
+            return None
+        lane_expr = backend.thread_linear_index_expr(axis_sizes)
+        if lane_expr is None:
+            return None
+
+        identity_expr = backend.cast_expr(
+            constant_repr(default_value), _dtype_str(dtype)
+        )
+        group_count = num_threads // group_span
+        lane_var = self.fn.new_var("looped_reduce_lane", dce=True)
+        lane_in_group_var = self.fn.new_var("looped_reduce_lane_in_group", dce=True)
+        lane_mod_pre_var = self.fn.new_var("looped_reduce_lane_mod_pre", dce=True)
+        result_var = self.fn.new_var("looped_reduce_result", dce=True)
+        device_loop.outer_suffix.append(
+            statement_from_string(f"{lane_var} = {lane_expr}")
+        )
+        device_loop.outer_suffix.append(
+            statement_from_string(f"{lane_in_group_var} = ({lane_var}) % {group_span}")
+        )
+        device_loop.outer_suffix.append(
+            statement_from_string(f"{lane_mod_pre_var} = ({lane_in_group_var}) % 1")
+        )
+        device_loop.outer_suffix.append(
+            statement_from_string(
+                f"{result_var} = _cute_grouped_reduce_shared_two_stage("
+                f"{input_name}, {reduction_type!r}, {identity_expr}, "
+                f"{lane_var}, {lane_in_group_var}, {lane_mod_pre_var}, "
+                f"pre=1, group_span={group_span}, group_count={group_count})"
+            )
+        )
+        return result_var
 
     def codegen_device_loop(self, state: CodegenState) -> DeviceLoopState:
         env = CompileEnvironment.current()
@@ -616,19 +728,35 @@ class LoopedReductionStrategy(ReductionStrategy):
         assert block_size_var is not None
         if state.device_function.constexpr_arg(block_size_var):
             state.codegen.host_statements.append(
-                statement_from_string(f"{block_size_var} = {self.block_size!r}")
+                statement_from_string(f"{block_size_var} = {self._loop_block_size!r}")
             )
-        body: list[ast.AST] = [
+        inner_body: list[ast.AST] = [
             statement_from_string(
                 f"{index_var} = {offset_var} + {self._index_init_expr(f'({block_size_var})', env.index_type(), block_index)}"
             ),
         ]
+        reduction_lane_var = self._cute_reduction_lane_var
+        if reduction_lane_var is not None:
+            inner_body[0] = statement_from_string(
+                f"{index_var} = {offset_var} + {self._index_init_expr(f'({block_size_var})', env.index_type(), block_index)} + cutlass.Int32({reduction_lane_var}) * {self._thread_count}"
+            )
         if (mask_var := self._mask_var) is not None:
-            body.append(
+            inner_body.append(
                 statement_from_string(
                     f"{mask_var} = {index_var} < {state.sympy_expr(numel)}"
                 )
             )
+        body = inner_body
+        if reduction_lane_var is not None:
+            from .tile_strategy import _create_lane_loop
+
+            body = [
+                _create_lane_loop(
+                    reduction_lane_var,
+                    self._cute_reduction_lane_extent,
+                    inner_body,
+                )
+            ]
 
         for_node = create(
             ast.For,
@@ -659,7 +787,7 @@ class LoopedReductionStrategy(ReductionStrategy):
         return DeviceLoopState(
             self,
             for_node=for_node,
-            inner_statements=body,
+            inner_statements=inner_body,
             block_id_to_info=block_id_to_info,
             thread_axis_sizes=tracker.sizes,
             block_thread_axes=tracker.block_axes,
@@ -696,8 +824,19 @@ class LoopedReductionStrategy(ReductionStrategy):
                     reduction_type, acc, input_name, acc_dtype
                 )
                 state.add_statement(f"{acc} = {combine_expr}")
-                expr = self.call_reduction_function(
-                    acc, reduction_type, dim, fake_input, fake_output
+                expr = self._cute_cross_warp_reduction_expr(
+                    state,
+                    device_loop,
+                    acc,
+                    reduction_type,
+                    default,
+                    acc_dtype,
+                ) or self.call_reduction_function(
+                    acc,
+                    reduction_type,
+                    dim,
+                    fake_input,
+                    fake_output,
                 )
             else:
                 acc_index = self.fn.new_var(f"{state.fx_node.name}_acc_index", dce=True)

--- a/helion/_compiler/tile_dispatch.py
+++ b/helion/_compiler/tile_dispatch.py
@@ -14,6 +14,7 @@ from .device_ir import ReductionLoopGraphInfo
 from .device_ir import RootGraphInfo
 from .host_function import HostFunction
 from .reduction_strategy import ReductionStrategy
+from .reduction_strategy import cute_looped_reduction_block_size
 from .tile_strategy import CompactedShape
 from .tile_strategy import DeviceLoopState
 from .tile_strategy import TileStrategy
@@ -124,10 +125,14 @@ class TileStrategyDispatch:
                     size_hint = env.size_hint(numel)
                 if reduction_loop is None:
                     if size_hint > max_threads:
-                        # Too many elements for a single warp; force looped
-                        reduction_loop = max_threads
-                elif reduction_loop > max_threads:
-                    reduction_loop = max_threads
+                        # Too many elements for a single warp; force a looped
+                        # reduction. CuTe can cover a wider chunk with either
+                        # more live lanes or per-thread scalar lanes.
+                        reduction_loop = (
+                            cute_looped_reduction_block_size(size_hint, max_threads)
+                            if env.backend.name == "cute"
+                            else max_threads
+                        )
             strategy = env.backend.create_reduction_strategy(
                 fn, block_id, reduction_loop
             )

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -412,6 +412,10 @@ class ConfigSpec:
         self.backend = backend
         self.backend_name = backend.name
         self.max_reduction_threads = backend.max_reduction_threads()
+        self.max_reduction_loop = backend.max_reduction_loop()
+        self.reduction_loop_force_threshold = self.max_reduction_threads
+        if self.backend_name == "cute" and self.max_reduction_threads is not None:
+            self.reduction_loop_force_threshold = min(self.max_reduction_threads, 32)
         self.user_defined_tunables = (
             {} if user_defined_tunables is None else dict(user_defined_tunables)
         )
@@ -1806,20 +1810,28 @@ class ConfigSpec:
         else:
             config.pop("num_threads", None)
 
-        # Cap reduction loops at the backend's max reduction thread count
+        # Cap reduction loops at the backend's max loop chunk, while using the
+        # live reduction thread threshold to decide when a persistent reduction
+        # must be rolled.
         if self.max_reduction_threads is not None and self.reduction_loops:
-            max_threads = self.max_reduction_threads
+            force_threshold = self.reduction_loop_force_threshold
+            max_loop = self.max_reduction_loop
             reduction_loops = config.get("reduction_loops", [])
-            if isinstance(reduction_loops, list):
+            if force_threshold is not None and isinstance(reduction_loops, list):
                 new_loops = list(reduction_loops)
                 changed = False
                 for i, spec in enumerate(self.reduction_loops):
                     if i >= len(new_loops):
                         break
-                    if (new_loops[i] is None and spec.size_hint > max_threads) or (
-                        new_loops[i] is not None and new_loops[i] > max_threads
+                    if new_loops[i] is None and spec.size_hint > force_threshold:
+                        new_loops[i] = min(spec.size_hint, force_threshold)
+                        changed = True
+                    elif (
+                        new_loops[i] is not None
+                        and max_loop is not None
+                        and new_loops[i] > max_loop
                     ):
-                        new_loops[i] = max_threads
+                        new_loops[i] = max_loop
                         changed = True
                 if changed:
                     config["reduction_loops"] = new_loops
@@ -2987,11 +2999,12 @@ class ReductionLoopSpec(_PowerOfTwoBlockIdItem):
         low = 8  # TODO(jansel): is smaller needed?
         high = next_power_of_2(max(low, self.size_hint))
         default = min(high, 4096)
-        # Cap default at the backend's max reduction threads so that
+        # Cap default at the backend's max reduction loop so that
         # large reductions default to looped rather than persistent.
-        if base.max_reduction_threads is not None:
-            if self.size_hint > base.max_reduction_threads:
-                default = min(default, base.max_reduction_threads)
+        if base.max_reduction_loop is not None:
+            force_threshold = base.reduction_loop_force_threshold
+            if force_threshold is not None and self.size_hint > force_threshold:
+                default = min(default, base.max_reduction_loop)
         return BlockSizeFragment(low, high, default)
 
     def _flat_config(

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -148,6 +148,21 @@ def cute_row_centered(x: torch.Tensor) -> torch.Tensor:
     return out
 
 
+@helion.kernel(backend="cute", autotune_effort="none")
+def cute_rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    n, m = x.size()
+    out = torch.empty_like(x)
+    hl.specialize(m)
+    for tile_n in hl.tile(n):
+        vals = x[tile_n, :].to(torch.float32)
+        mean_sq = torch.mean(vals * vals, dim=-1)
+        inv_rms = torch.rsqrt(mean_sq + eps)
+        out[tile_n, :] = (vals * inv_rms[:, None] * weight[:].to(torch.float32)).to(
+            x.dtype
+        )
+    return out
+
+
 @helion.kernel(backend="cute")
 def cute_row_max(x: torch.Tensor) -> torch.Tensor:
     n, m = x.size()
@@ -652,6 +667,19 @@ class TestCuteBackend(TestCase):
         expected = torch.sigmoid(torch.sin(torch.relu(x * y)))
         torch.testing.assert_close(out, expected, rtol=1e-5, atol=1e-5)
 
+    def test_rms_norm_uses_native_rsqrt(self) -> None:
+        x = torch.randn(8, 32, device=DEVICE, dtype=torch.float32)
+        weight = torch.randn(32, device=DEVICE, dtype=torch.float32)
+        eps = 1e-5
+        code, out = code_and_output(cute_rms_norm, (x, weight, eps), block_size=4)
+        x_sq = x * x
+        inv_rms = torch.rsqrt(x_sq.mean(dim=-1) + eps)
+        expected = x * inv_rms[:, None] * weight
+        torch.testing.assert_close(out, expected, rtol=1e-5, atol=1e-5)
+        self.assertIn("cute.math.rsqrt", code)
+        self.assertNotIn("cute.math.sqrt", code)
+        self.assertNotRegex(code, r"1\.0\s*/\s*v_\d+")
+
     def test_scalar_args_int_and_float(self) -> None:
         args = (
             torch.randn(65, 23, device=DEVICE, dtype=torch.float32),
@@ -798,6 +826,23 @@ class TestCuteBackend(TestCase):
         (x,) = args
         torch.testing.assert_close(out, x.sum(-1), rtol=1e-4, atol=1e-4)
         self.assertIn("for lane_", code)
+
+    def test_looped_reduction_uses_per_thread_lanes(self) -> None:
+        args = (torch.randn(16, 4096, device=DEVICE, dtype=torch.float32),)
+        code, out = code_and_output(
+            cute_row_sum,
+            args,
+            block_sizes=[1],
+            reduction_loop=2048,
+            num_warps=4,
+        )
+        (x,) = args
+        torch.testing.assert_close(out, x.sum(-1), rtol=1e-4, atol=1e-4)
+        self.assertIn("_REDUCTION_BLOCK_1 = 2048", code)
+        self.assertIn("for reduction_lane_1 in range(2)", code)
+        self.assertIn("_cute_grouped_reduce_shared_two_stage", code)
+        self.assertIn("group_span=1024", code)
+        self.assertIn("block=(1024, 1, 1)", code)
 
     def test_strided_threaded_block_reduction(self) -> None:
         args = (torch.randn(4, 16, device=DEVICE, dtype=torch.float32),)


### PR DESCRIPTION
Stacked PRs:
 * #2545
 * #2544
 * #2543
 * #2542
 * #2541
 * __->__#2540


--- --- ---

### Improve CuTe RMS norm reduction path


- lower CuTe rsqrt to cute.math.rsqrt
- allow looped CuTe reductions to use wider chunks with safe shared cross-warp reduction
- preserve one-warp behavior for small reductions
