### PR TITLE
Enable >32-thread persistent reduction on CuTe for RMS norm perf

### DIFF
--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -825,6 +825,43 @@ class DeviceIR:
                 )
             graphs_with_rolled_rdim |= used_graphs
 
+        # Track which rdims appear as the reduction axis of an indexed
+        # reduction (argmin/argmax). On CuTe these can only be combined
+        # via cute.arch.warp_reduction (32 threads max), so the autotuner
+        # must keep their persistent thread count and looped chunk size
+        # within a single warp.
+        if env.backend_name == "cute":
+            indexed_blocks: set[int] = set()
+            indexed_targets = {
+                torch.ops.aten.argmin.default,
+                torch.ops.aten.argmax.default,
+            }
+            for graph_info in self.graphs[:num_original_graphs]:
+                for node in graph_info.graph.nodes:
+                    if getattr(node, "target", None) not in indexed_targets:
+                        continue
+                    args = node.args or ()
+                    if not args:
+                        continue
+                    val = getattr(args[0], "meta", {}).get("val")
+                    if val is None:
+                        continue
+                    dim_arg = args[1] if len(args) >= 2 else -1
+                    dim_indices = (
+                        [int(cast("int", d)) for d in dim_arg]
+                        if isinstance(dim_arg, list)
+                        else [int(cast("int", dim_arg))]
+                    )
+                    for dim_idx in dim_indices:
+                        if dim_idx < 0:
+                            dim_idx += val.ndim
+                        if 0 <= dim_idx < val.ndim:
+                            reduce_dim = val.size(dim_idx)
+                            block_id = env.resolve_block_id(reduce_dim)
+                            if block_id is not None:
+                                indexed_blocks.add(block_id)
+            env.config_spec.cute_indexed_reduction_block_ids = indexed_blocks
+
     def build_codegen_graphs(self, config: Config) -> list[GraphInfo]:
         """Build and return graph copies with reduction rolling and epilogue subtiling applied.
 

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -101,7 +101,26 @@ def cute_looped_reduction_block_size(size_hint: int, max_threads: int) -> int:
 
 
 def cute_live_reduction_threads(max_threads: int) -> int:
-    return min(max_threads, _CUTE_WARP_REDUCTION_THREADS)
+    # Persistent reductions on CuTe can recruit threads beyond a single warp
+    # (cross-warp combining uses _cute_grouped_reduce_shared_two_stage). The
+    # autotuner / config_spec keeps the size_hint <= max_threads case here so
+    # no synthetic lane wrap is required.
+    return max_threads
+
+
+def _block_has_indexed_reduction(fn: DeviceFunction, block_index: int) -> bool:
+    """Return True when ``block_index`` is the reduction axis of any
+    argmin/argmax in the device IR.
+
+    Populated by :meth:`DeviceIR.register_rollable_reductions` so this is
+    just a set lookup on ConfigSpec.
+
+    Used to cap CuTe reduction strategies' thread_count at the warp width
+    when an indexed reduction is present — CuTe argreduce uses
+    cute.arch.warp_reduction which is only correct for threads_in_group<=32.
+    """
+    env = CompileEnvironment.current()
+    return block_index in env.config_spec.cute_indexed_reduction_block_ids
 
 
 class ReductionStrategy(TileStrategy):
@@ -410,6 +429,13 @@ class PersistentReductionStrategy(ReductionStrategy):
         if max_threads is not None:
             if env.backend.name == "cute":
                 max_threads = cute_live_reduction_threads(max_threads)
+                # Indexed reductions (argmin/argmax) on CuTe only have a
+                # warp-level reduction primitive that takes
+                # ``threads_in_group <= 32``. Cap the persistent thread
+                # count to the warp size so the emitted
+                # ``cute.arch.warp_reduction`` is correct.
+                if _block_has_indexed_reduction(fn, block_index):
+                    max_threads = min(max_threads, _CUTE_WARP_REDUCTION_THREADS)
             if isinstance(numel, (int, sympy.Integer)):
                 size_hint = int(numel)
             elif isinstance(numel, sympy.Expr):
@@ -550,6 +576,75 @@ class PersistentReductionStrategy(ReductionStrategy):
             )
         )
 
+    def _cute_cross_warp_reduction_expr(
+        self,
+        state: CodegenState,
+        input_name: str,
+        reduction_type: str,
+        default_value: float | bool,
+        dtype: torch.dtype,
+    ) -> str | None:
+        env = CompileEnvironment.current()
+        backend = env.backend
+        if (
+            backend.name != "cute"
+            or self._thread_count <= 32
+            or self._synthetic_cute_lane_var is not None
+            or backend.is_indexed_reduction(reduction_type)
+        ):
+            return None
+
+        current_grid = state.codegen.current_grid_state
+        axis_sizes: dict[int, int] = {}
+        if isinstance(current_grid, DeviceGridState):
+            for axis, size in current_grid.thread_axis_sizes.items():
+                axis_sizes[axis] = max(axis_sizes.get(axis, 1), size)
+        reduction_axis = self._get_thread_axis()
+        axis_sizes[reduction_axis] = max(
+            axis_sizes.get(reduction_axis, 1), self._thread_count
+        )
+
+        num_threads = 1
+        for size in axis_sizes.values():
+            num_threads *= size
+        group_span = self._thread_count
+        if num_threads % group_span != 0:
+            return None
+        # The two-stage shared-memory reduction assumes its ``lane_var`` is
+        # the linear thread index across ALL of the launch block's threads.
+        # If ``axis_sizes`` only covers a subset of the planned block dims
+        # (e.g. an inner reduction strategy contributes another thread axis
+        # that hasn't been entered yet), the emitted reduction would race
+        # across the missing axis. Bail out and fall back to the warp-level
+        # path in that case.
+        planned_dims = self._planned_thread_dims()
+        planned_block_threads = planned_dims[0] * planned_dims[1] * planned_dims[2]
+        if num_threads != planned_block_threads:
+            return None
+
+        lane_expr = backend.thread_linear_index_expr(axis_sizes)
+        if lane_expr is None:
+            return None
+
+        identity_expr = backend.cast_expr(
+            constant_repr(default_value), _dtype_str(dtype)
+        )
+        group_count = num_threads // group_span
+        lane_var = self.fn.new_var("persistent_reduce_lane", dce=True)
+        lane_in_group_var = self.fn.new_var("persistent_reduce_lane_in_group", dce=True)
+        lane_mod_pre_var = self.fn.new_var("persistent_reduce_lane_mod_pre", dce=True)
+        result_var = self.fn.new_var("persistent_reduce_result", dce=True)
+        state.add_statement(f"{lane_var} = {lane_expr}")
+        state.add_statement(f"{lane_in_group_var} = ({lane_var}) % {group_span}")
+        state.add_statement(f"{lane_mod_pre_var} = ({lane_in_group_var}) % 1")
+        state.add_statement(
+            f"{result_var} = _cute_grouped_reduce_shared_two_stage("
+            f"{input_name}, {reduction_type!r}, {identity_expr}, "
+            f"{lane_var}, {lane_in_group_var}, {lane_mod_pre_var}, "
+            f"pre=1, group_span={group_span}, group_count={group_count})"
+        )
+        return result_var
+
     def codegen_reduction(
         self,
         state: CodegenState,
@@ -569,13 +664,24 @@ class PersistentReductionStrategy(ReductionStrategy):
             return expr_from_string(
                 backend.full_expr(shape_dims, constant_repr(default), fake_output.dtype)
             )
-        expr = self.call_reduction_function(
-            input_name,
-            reduction_type,
-            dim,
-            fake_input,
-            fake_output,
-        )
+        acc_dtype = get_computation_dtype(fake_input.dtype)
+        default = ir.Reduction.default_accumulator(reduction_type, acc_dtype)
+        if isinstance(default, (float, int, bool)):
+            cross_warp = self._cute_cross_warp_reduction_expr(
+                state, input_name, reduction_type, default, acc_dtype
+            )
+        else:
+            cross_warp = None
+        if cross_warp is not None:
+            expr = cross_warp
+        else:
+            expr = self.call_reduction_function(
+                input_name,
+                reduction_type,
+                dim,
+                fake_input,
+                fake_output,
+            )
         return expr_from_string(self.maybe_reshape(expr, dim, fake_input, fake_output))
 
 
@@ -591,6 +697,14 @@ class LoopedReductionStrategy(ReductionStrategy):
         # Compute thread count for warp-level reductions
         max_threads = env.backend.max_reduction_threads()
         if max_threads is not None:
+            # CuTe argreduce uses cute.arch.warp_reduction which is only
+            # correct for threads_in_group<=32. Cap to warp size whenever
+            # the rolled reduction will fold an indexed reduction over this
+            # block.
+            if env.backend.name == "cute" and _block_has_indexed_reduction(
+                fn, block_index
+            ):
+                max_threads = min(max_threads, _CUTE_WARP_REDUCTION_THREADS)
             thread_count = next_power_of_2(min(block_size, max_threads))
         else:
             thread_count = 0
@@ -686,6 +800,17 @@ class LoopedReductionStrategy(ReductionStrategy):
             num_threads *= size
         group_span = self._thread_count
         if num_threads % group_span != 0:
+            return None
+        # The two-stage shared-memory reduction assumes its ``lane_var`` is
+        # the linear thread index across ALL of the launch block's threads.
+        # If ``axis_sizes`` only covers a subset of the planned block dims
+        # (e.g. an inner reduction strategy contributes another thread axis
+        # that hasn't been entered yet), the emitted reduction would race
+        # across the missing axis. Bail out and fall back to the warp-level
+        # path in that case.
+        planned_dims = self._planned_thread_dims()
+        planned_block_threads = planned_dims[0] * planned_dims[1] * planned_dims[2]
+        if num_threads != planned_block_threads:
             return None
         lane_expr = backend.thread_linear_index_expr(axis_sizes)
         if lane_expr is None:

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -414,8 +414,7 @@ class ConfigSpec:
         self.max_reduction_threads = backend.max_reduction_threads()
         self.max_reduction_loop = backend.max_reduction_loop()
         self.reduction_loop_force_threshold = self.max_reduction_threads
-        if self.backend_name == "cute" and self.max_reduction_threads is not None:
-            self.reduction_loop_force_threshold = min(self.max_reduction_threads, 32)
+        self.cute_indexed_reduction_block_ids: set[int] = set()
         self.user_defined_tunables = (
             {} if user_defined_tunables is None else dict(user_defined_tunables)
         )
@@ -1823,15 +1822,76 @@ class ConfigSpec:
                 for i, spec in enumerate(self.reduction_loops):
                     if i >= len(new_loops):
                         break
-                    if new_loops[i] is None and spec.size_hint > force_threshold:
-                        new_loops[i] = min(spec.size_hint, force_threshold)
+                    # Indexed reductions (argmin/argmax) on CuTe must keep
+                    # the persistent thread count or rolled chunk within a
+                    # single warp, since cute.arch.warp_reduction only
+                    # supports threads_in_group<=32.
+                    block_threshold = force_threshold
+                    if (
+                        self.backend_name == "cute"
+                        and spec.block_id in self.cute_indexed_reduction_block_ids
+                    ):
+                        block_threshold = min(block_threshold, 32)
+                    if new_loops[i] is None and spec.size_hint > block_threshold:
+                        new_loops[i] = min(spec.size_hint, block_threshold)
                         changed = True
                     elif (
                         new_loops[i] is not None
                         and max_loop is not None
-                        and new_loops[i] > max_loop
+                        and (
+                            new_loops[i] > max_loop
+                            or (
+                                self.backend_name == "cute"
+                                and spec.block_id
+                                in self.cute_indexed_reduction_block_ids
+                                and new_loops[i] > 32
+                            )
+                        )
                     ):
-                        new_loops[i] = max_loop
+                        new_loops[i] = min(
+                            new_loops[i] if max_loop is None else max_loop,
+                            block_threshold,
+                        )
+                        changed = True
+                if changed:
+                    config["reduction_loops"] = new_loops
+
+        # CuTe-specific: persistent reduction whose thread count is shrunk
+        # below the reduction extent by adjust_reduction_thread_count would
+        # wrap the kernel body in a synthetic lane loop. The lane loop
+        # carries the body-level reduction's accumulator across iterations,
+        # so the reduction result would only reflect the last lane iter.
+        # Force a looped reduction whenever the available reduction threads
+        # (max_reduction_threads // product_of_non_reduction_thread_axes)
+        # cannot cover the full reduction extent.
+        if (
+            self.backend_name == "cute"
+            and self.max_reduction_threads is not None
+            and self.reduction_loops
+        ):
+            nt_list = cast("list[int]", config.get("num_threads", []) or [])
+            bs_list = cast("list[int]", config.get("block_sizes", []) or [])
+            other_threads = 1
+            for i, _ in enumerate(self.num_threads):
+                nt = nt_list[i] if i < len(nt_list) else 0
+                if not isinstance(nt, int) or nt <= 0:
+                    bs = bs_list[i] if i < len(bs_list) else 1
+                    nt = bs if isinstance(bs, int) and bs > 1 else 1
+                if nt > 1:
+                    other_threads *= nt
+            available = max(1, self.max_reduction_threads // other_threads)
+            reduction_loops = config.get("reduction_loops", [])
+            if isinstance(reduction_loops, list):
+                new_loops = list(reduction_loops)
+                changed = False
+                for i, spec in enumerate(self.reduction_loops):
+                    if i >= len(new_loops):
+                        break
+                    if new_loops[i] is None and spec.size_hint > available:
+                        chunk = min(spec.size_hint, max(available, 1))
+                        if self.max_reduction_loop is not None:
+                            chunk = min(chunk, self.max_reduction_loop)
+                        new_loops[i] = chunk
                         changed = True
                 if changed:
                     config["reduction_loops"] = new_loops

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -1964,22 +1964,33 @@ def _build_cute_schema_and_args(
     return tuple(schema), tuple(launch_args)
 
 
+_CUTE_DSL_ARCH_CACHE: dict[int, str] = {}
+
+
 def _ensure_cute_dsl_arch_env(args: tuple[object, ...]) -> None:
     tensor_args = [arg for arg in args if isinstance(arg, torch.Tensor)]
     if tensor_args:
         device = tensor_args[0].device
         if device.type != "cuda":
             return
-        with torch.cuda.device(device):
-            major, minor = torch.cuda.get_device_capability(device)
+        device_index = device.index if device.index is not None else 0
     elif not torch.cuda.is_available():
         return
     else:
-        major, minor = torch.cuda.get_device_capability()
-    # CUTLASS DSL distinguishes post-Hopper arch variants such as sm_90a/sm_100a,
-    # while torch.cuda.get_device_capability() only returns major/minor.
-    suffix = "a" if major >= 9 else ""
-    desired = f"sm_{major}{minor}{suffix}"
+        device_index = torch.cuda.current_device()
+    desired = _CUTE_DSL_ARCH_CACHE.get(device_index)
+    if desired is None:
+        if tensor_args:
+            with torch.cuda.device(tensor_args[0].device):
+                major, minor = torch.cuda.get_device_capability(tensor_args[0].device)
+        else:
+            major, minor = torch.cuda.get_device_capability()
+        # CUTLASS DSL distinguishes post-Hopper arch variants such as
+        # sm_90a/sm_100a, while torch.cuda.get_device_capability() only
+        # returns major/minor.
+        suffix = "a" if major >= 9 else ""
+        desired = f"sm_{major}{minor}{suffix}"
+        _CUTE_DSL_ARCH_CACHE[device_index] = desired
     if os.environ.get("CUTE_DSL_ARCH") != desired:
         os.environ["CUTE_DSL_ARCH"] = desired
 

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1244,12 +1244,13 @@ class TestIndexing(RefEagerTestBase, TestCase):
         torch.testing.assert_close(dst_result, expected_dst)
 
         if _get_backend() == "cute":
-            # Regression: the scalar store `dst[:, :] = 1.0` must be wrapped
-            # in the reduction loop alongside the matching load, so the slice
-            # resolves to the rdim index (`rindex_*`) and each iteration
-            # writes the full slice. Without that wrapping, the slice would
-            # bind to the grid index and only one element per block would be
-            # written, racing with the subsequent load.
+            # Regression: the scalar store `dst[:, :] = 1.0` must vary across
+            # the slice's second dim. Either a lane loop variable
+            # (`rindex_*`) or a per-thread index derived from
+            # `cute.arch.thread_idx` (`indices_*`) is correct. What is NOT
+            # correct is binding the slice to a constant or grid-only PID,
+            # which would only write one element per block and race with the
+            # subsequent load.
             store_line = next(
                 (
                     line
@@ -1259,7 +1260,13 @@ class TestIndexing(RefEagerTestBase, TestCase):
                 None,
             )
             self.assertIsNotNone(store_line)
-            self.assertIn("rindex_", store_line)
+            assert "rindex_" in store_line or "indices_" in store_line, store_line
+            # Guard against the original race condition where the second-dim
+            # index resolved to a constant.
+            self.assertNotIn(
+                "cutlass.Int32(0) * cutlass.Int32(dst.layout.stride[1])",
+                store_line,
+            )
 
     def test_1d_index(self):
         """Test both setter from scalar and getter for [i]"""


### PR DESCRIPTION
Stacked PRs:
 * #2549
 * #2548
 * #2547
 * #2546
 * #2545
 * #2544
 * #2543
 * #2542
 * __->__#2541


--- --- ---

### Enable >32-thread persistent reduction on CuTe for RMS norm perf


Lift CuTe's persistent reduction 32-thread cap and route reductions
wider than a warp through _cute_grouped_reduce_shared_two_stage.

Helion CuTe RMS norm vs ATen on B200 (M=2048):
- N=1024:  0.27x -> 0.32x
- N=2048:  0.38x -> 0.43x
- N=4096:  0.58x -> 0.65x
- N=8192:  1.02x -> 1.13x
- N=16384: 0.96x -> 2.25x
- N=32768: 0.91x -> 3.01x
- average: 0.69x -> 1.30x
