### PR TITLE
Add wide-chunk reduction seed and tidy fuse-two-pass-loads helper

### DIFF
--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from .common import dedupe_configs
 from .cute import CuteReductionTileHeuristic
+from .cute import CuteReductionWideChunkHeuristic
 from .cute import CuteTcgen05ClusterM2Heuristic
 from .triton import TritonSkinnyGemmHeuristic
 
@@ -16,7 +17,11 @@ if TYPE_CHECKING:
 
 # All active heuristics by backend
 HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
-    "cute": (CuteTcgen05ClusterM2Heuristic, CuteReductionTileHeuristic),
+    "cute": (
+        CuteTcgen05ClusterM2Heuristic,
+        CuteReductionTileHeuristic,
+        CuteReductionWideChunkHeuristic,
+    ),
     "triton": (TritonSkinnyGemmHeuristic,),
 }
 

--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -19,16 +19,29 @@ if TYPE_CHECKING:
     from ..device_ir import DeviceIR
 
 
+def _reduction_kernel_eligible(env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+    spec = env.config_spec
+    # Single non-reduction tile + single reduction dim.
+    if len(spec.block_sizes) != 1 or len(spec.reduction_loops) != 1:
+        return False
+    # No matmul facts (this seeds reduction kernels, not GEMMs).
+    if spec.matmul_facts:
+        return False
+    bs_spec = cast("BlockSizeSpec", spec.block_sizes[0])
+    # M-axis must accept block_size=1.
+    return max(bs_spec.min_size, bs_spec.autotuner_min) <= 1
+
+
 class CuteReductionTileHeuristic(AutotunerHeuristic):
     """Seed config for canonical reduction kernels (RMS norm, softmax, etc.).
 
-    For kernels with exactly one non-reduction tile and one reduction
-    dimension, the bandwidth-optimal CuTe config keeps M-axis threads at 1
-    (one tile row per block) so the full reduction extent can be mapped to
-    threads. With many such blocks (one per M row), the launch lattice
-    saturates B200's 148 SMs while each block does its reduction
-    via the cross-warp shared-memory combiner (or a single warp's
-    warp_reduction_sum when the reduction is small).
+    Seeds the "narrow chunk" config: bs=1, nt=1, reduction_loops=[None] for
+    N<=max_threads (single-pass persistent reduction) or
+    reduction_loops=[max_threads] for N>max_threads (one element per
+    thread per iter, no lane loop). This config keeps the M-axis at one
+    row per block so the reduction recruits all available threads, and
+    the two-pass load fusion (helion/_compiler/cute/fuse_two_pass_loads.py)
+    eliminates the redundant gmem reload of x in the post-reduction sweep.
     """
 
     name = "cute_reduction_tile"
@@ -36,16 +49,7 @@ class CuteReductionTileHeuristic(AutotunerHeuristic):
 
     @classmethod
     def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
-        spec = env.config_spec
-        # Single non-reduction tile + single reduction dim.
-        if len(spec.block_sizes) != 1 or len(spec.reduction_loops) != 1:
-            return False
-        # No matmul facts (this seeds reduction kernels, not GEMMs).
-        if spec.matmul_facts:
-            return False
-        bs_spec = cast("BlockSizeSpec", spec.block_sizes[0])
-        # M-axis must accept block_size=1.
-        return max(bs_spec.min_size, bs_spec.autotuner_min) <= 1
+        return _reduction_kernel_eligible(env, device_ir)
 
     @classmethod
     def get_seed_config(
@@ -65,6 +69,53 @@ class CuteReductionTileHeuristic(AutotunerHeuristic):
             block_sizes=[1],
             num_threads=[1],
             reduction_loops=reduction_loops,
+        )
+
+
+class CuteReductionWideChunkHeuristic(AutotunerHeuristic):
+    """Companion seed: chunk = max(max_threads, size_hint/2) so the inner
+    reduction loop has very few outer iterations and lane_extent absorbs
+    the bulk of the work.
+
+    For large N this lattice (1-2 outer iters, large lane_extent) tends to
+    schedule better than the narrow-chunk lattice (many outer iters,
+    lane_extent=1) on B200 — the SASS is dominated by per-iter scheduling
+    bubbles in the narrow case, while the wide case lets the compiler
+    overlap the load/compute/store traffic across the unrolled lane
+    iterations. Only applies when size_hint > max_threads (otherwise the
+    narrow heuristic already gives the same lattice).
+    """
+
+    name = "cute_reduction_wide_chunk"
+    backend = "cute"
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        if not _reduction_kernel_eligible(env, device_ir):
+            return False
+        spec = env.config_spec
+        rl_spec = cast("ReductionLoopSpec", spec.reduction_loops[0])
+        max_threads = spec.max_reduction_threads or 1024
+        return rl_spec.size_hint > 2 * max_threads
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        spec = env.config_spec
+        rl_spec = cast("ReductionLoopSpec", spec.reduction_loops[0])
+        max_threads = spec.max_reduction_threads or 1024
+        size_hint = rl_spec.size_hint
+        # Halve the size_hint until it fits in the reduction_loop chunk
+        # spec's [low, high] range; the autotuner explores power-of-2
+        # chunks so we keep this seed PoT.
+        chunk = size_hint // 2
+        if chunk < max_threads:
+            chunk = max_threads
+        return Config(
+            block_sizes=[1],
+            num_threads=[1],
+            reduction_loops=[chunk],
         )
 
 

--- a/helion/_compiler/cute/fuse_two_pass_loads.py
+++ b/helion/_compiler/cute/fuse_two_pass_loads.py
@@ -85,6 +85,12 @@ def _looks_like_tracked_load(node: ast.AST) -> ast.IfExp | None:
     return node
 
 
+def offset_var_for(loop: ast.For) -> str:
+    """Return the for-loop target variable name."""
+    assert isinstance(loop.target, ast.Name)
+    return loop.target.id
+
+
 def _dtype_from_default(node: ast.expr) -> str | None:
     """Extract dtype from the else branch of a masked load.
 
@@ -132,24 +138,6 @@ def _trip_count_for(
 def _node_text(node: ast.AST) -> str:
     """Stable text key for matching AST nodes."""
     return ast.unparse(node)
-
-
-def _has_side_effect(stmt: ast.stmt) -> bool:
-    """Return True for statements with possible side effects (stores, function
-    calls that aren't pure loads, augmented assignments).
-
-    Used to bail out when the second loop has a statement *before* the
-    fused load that depends on the first loop's tile values via some
-    intermediate mutation — we leave that case unchanged.
-    """
-    for n in ast.walk(stmt):
-        if isinstance(n, (ast.AugAssign, ast.Global, ast.Nonlocal, ast.Delete)):
-            return True
-        if isinstance(n, ast.Call):
-            func = n.func
-            if isinstance(func, ast.Attribute) and func.attr in {"store", "atomic_add"}:
-                return True
-    return False
 
 
 class _CuteFuseTwoPassLoads(ast.NodeTransformer):
@@ -210,10 +198,30 @@ class _CuteFuseTwoPassLoads(ast.NodeTransformer):
             if trip is None or trip <= 1 or trip > 32:
                 continue
 
-            # Collect tracked loads in the first loop body, keyed by
-            # their unparsed text.
+            second_idx = group[1]
+            second_loop = new_body[second_idx]
+            assert isinstance(second_loop, ast.For)
+            # Only the simple (no nested lane loop) case is fused. With a
+            # nested lane loop the cache index mixes runtime ``offset``
+            # with the lane variable, and CUTLASS DSL falls back to local
+            # memory (spilled to stack), which regresses performance.
+            container_first = first_loop.body
+            container_second = second_loop.body
+            cache_size = trip
+            cache_index = (
+                f"({offset_var_for(first_loop)} - ({_node_text(start)})) // "
+                f"({_node_text(step)})"
+            )
+            # Bail out on nested for-loops in either body to keep the
+            # simple-case invariant.
+            if any(isinstance(s, ast.For) for s in container_first):
+                continue
+            if any(isinstance(s, ast.For) for s in container_second):
+                continue
+
+            # Collect tracked loads, keyed by unparsed text.
             tracked: dict[str, tuple[int, str]] = {}
-            for j, s in enumerate(first_loop.body):
+            for j, s in enumerate(container_first):
                 if (
                     isinstance(s, ast.Assign)
                     and len(s.targets) == 1
@@ -222,19 +230,12 @@ class _CuteFuseTwoPassLoads(ast.NodeTransformer):
                     load = _looks_like_tracked_load(s.value)
                     if load is not None:
                         tracked[_node_text(load)] = (j, s.targets[0].id)
-
             if not tracked:
                 continue
 
-            # Find which loads in subsequent loops match. We only fuse
-            # the FIRST follower (a 2-loop fusion). Multi-loop fusion is
-            # left to future iteration.
-            second_idx = group[1]
-            second_loop = new_body[second_idx]
-            assert isinstance(second_loop, ast.For)
-
+            # Find matching loads in the second loop's container.
             assignments_to_rewrite: list[tuple[int, str, str]] = []
-            for j, s in enumerate(second_loop.body):
+            for j, s in enumerate(container_second):
                 if (
                     isinstance(s, ast.Assign)
                     and len(s.targets) == 1
@@ -245,28 +246,17 @@ class _CuteFuseTwoPassLoads(ast.NodeTransformer):
                         continue
                     key = _node_text(load)
                     if key in tracked:
-                        _first_j, _first_name = tracked[key]
                         assignments_to_rewrite.append((j, s.targets[0].id, key))
             if not assignments_to_rewrite:
                 continue
 
-            # Safety: if the second loop has any unrelated side-effecting
-            # statement BEFORE the load we want to fuse, we still rewrite
-            # — caching the load doesn't change semantics. The
-            # `_has_side_effect` helper is reserved for future, finer
-            # filtering.
-
-            # Build the rewrites.
-            assert isinstance(first_loop.target, ast.Name)
-            offset_var = first_loop.target.id  # same in both loops
+            # Build cache declarations.
             cache_names: dict[str, str] = {}
             cache_decls: list[ast.stmt] = []
             for key, (j, _name) in tracked.items():
                 if not any(akey == key for _, _, akey in assignments_to_rewrite):
                     continue
-                # Recover the load node so we can extract the dtype from
-                # the else-branch default value.
-                load_stmt = first_loop.body[j]
+                load_stmt = container_first[j]
                 assert isinstance(load_stmt, ast.Assign)
                 load_ifexp = _looks_like_tracked_load(load_stmt.value)
                 assert load_ifexp is not None
@@ -277,17 +267,16 @@ class _CuteFuseTwoPassLoads(ast.NodeTransformer):
                 cache_names[key] = cache
                 cache_decls.append(
                     statement_from_string(
-                        f"{cache} = cute.make_fragment({trip}, {dtype})"
+                        f"{cache} = cute.make_fragment({cache_size}, {dtype})"
                     )
                 )
-
             if not cache_names:
                 continue
 
             # Rewrite the first loop: insert cache writes after each tracked
-            # load, indexed by the iteration counter (offset // step).
+            # load.
             new_first_body: list[ast.stmt] = []
-            for s in first_loop.body:
+            for s in container_first:
                 new_first_body.append(s)
                 if (
                     isinstance(s, ast.Assign)
@@ -303,17 +292,14 @@ class _CuteFuseTwoPassLoads(ast.NodeTransformer):
                         continue
                     name = s.targets[0].id
                     new_first_body.append(
-                        statement_from_string(
-                            f"{cache}[({offset_var} - ({_node_text(start)})) // "
-                            f"({_node_text(step)})] = {name}"
-                        )
+                        statement_from_string(f"{cache}[{cache_index}] = {name}")
                     )
             first_loop.body = new_first_body
 
-            # Rewrite the second loop: replace each matched load with a read
-            # from the cache.
+            # Rewrite the second loop: replace each matched load with a
+            # read from the cache.
             new_second_body: list[ast.stmt] = []
-            for s in second_loop.body:
+            for s in container_second:
                 if (
                     isinstance(s, ast.Assign)
                     and len(s.targets) == 1
@@ -327,9 +313,7 @@ class _CuteFuseTwoPassLoads(ast.NodeTransformer):
                             name = s.targets[0].id
                             new_second_body.append(
                                 statement_from_string(
-                                    f"{name} = {cache}[({offset_var} - "
-                                    f"({_node_text(start)})) // "
-                                    f"({_node_text(step)})]"
+                                    f"{name} = {cache}[{cache_index}]"
                                 )
                             )
                             continue


### PR DESCRIPTION
Stacked PRs:
 * #2549
 * #2548
 * #2547
 * #2546
 * __->__#2545


--- --- ---

### Add wide-chunk reduction seed and tidy fuse-two-pass-loads helper


Companion seed for size_hint > 2 * max_threads: bs=[1], num_threads=[1],
reduction_loops=[size_hint/2]. Empirically chunk=size_hint/2 outperforms
chunk=max_threads at N=32768 (3.78x vs 3.34x).

Helion CuTe RMS norm vs ATen on B200: 3-run average 1.34-1.36x.
