### PR TITLE
Emit vectorized 128-bit loads for CuTe inner reductions

### DIFF
--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
 
+import torch
+
 from ...runtime.config import Config
 from ..cute.strategies import TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY
 from ..cute.strategies import Tcgen05PersistenceModel
@@ -34,6 +36,48 @@ def _reduction_kernel_eligible(env: CompileEnvironment, device_ir: DeviceIR) -> 
     bs_spec = cast("BlockSizeSpec", spec.block_sizes[0])
     # M-axis must accept block_size=1.
     return max(bs_spec.min_size, bs_spec.autotuner_min) <= 1
+
+
+def _cute_seed_vec_width(
+    env: CompileEnvironment,
+    rl_spec: ReductionLoopSpec,
+    max_threads: int,
+    size_hint: int,
+    device_ir: DeviceIR,
+) -> int:
+    """Pick a default vector width for the cute_vector_widths seed.
+
+    Returns 1 (scalar) when the kernel has no plausible LDG.128 win, or
+    the dtype is not supported by the vector load helper. For supported
+    dtypes, prefer 4 (fp32) / 8 (fp16/bf16) when the reduction is wide
+    enough that a vec-load actually halves the number of inner-loop iters.
+    """
+    spec = env.config_spec
+    if not spec.cute_vector_widths.valid_block_ids():
+        return 1
+    if size_hint < max_threads * 2:
+        # Reduction extent already fits in one wide chunk; vec wouldn't
+        # remove enough loop iters to matter.
+        return 1
+    # Find the dtype of the reduction-source tensor by walking nodes that
+    # have a fake-tensor value matching the reduction extent.
+    dtype: torch.dtype | None = None
+    rdim_size = rl_spec.size_hint
+    for graph_info in device_ir.graphs:
+        for node in graph_info.graph.nodes:
+            val = node.meta.get("val")
+            if isinstance(val, torch.Tensor) and val.ndim >= 1:
+                last = val.shape[-1]
+                if isinstance(last, int) and last == rdim_size:
+                    dtype = val.dtype
+                    break
+        if dtype is not None:
+            break
+    if dtype is torch.float32:
+        return 4
+    if dtype in (torch.float16, torch.bfloat16):
+        return 8
+    return 1
 
 
 class CuteReductionTileHeuristic(AutotunerHeuristic):
@@ -69,11 +113,15 @@ class CuteReductionTileHeuristic(AutotunerHeuristic):
             reduction_loops: list[int | None] = [None]
         else:
             reduction_loops = [max_threads]
-        return Config(
-            block_sizes=[1],
-            num_threads=[1],
-            reduction_loops=reduction_loops,
-        )
+        seed: dict[str, Any] = {
+            "block_sizes": [1],
+            "num_threads": [1],
+            "reduction_loops": reduction_loops,
+        }
+        vec = _cute_seed_vec_width(env, rl_spec, max_threads, size_hint, device_ir)
+        if vec > 1:
+            seed["cute_vector_widths"] = [vec]
+        return Config(**seed)
 
 
 class CuteReductionWideChunkHeuristic(AutotunerHeuristic):
@@ -116,11 +164,15 @@ class CuteReductionWideChunkHeuristic(AutotunerHeuristic):
         chunk = size_hint // 2
         if chunk < max_threads:
             chunk = max_threads
-        return Config(
-            block_sizes=[1],
-            num_threads=[1],
-            reduction_loops=[chunk],
-        )
+        seed: dict[str, Any] = {
+            "block_sizes": [1],
+            "num_threads": [1],
+            "reduction_loops": [chunk],
+        }
+        vec = _cute_seed_vec_width(env, rl_spec, max_threads, size_hint, device_ir)
+        if vec > 1:
+            seed["cute_vector_widths"] = [vec]
+        return Config(**seed)
 
 
 class CuteTcgen05ClusterM2Heuristic(AutotunerHeuristic):

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -2616,7 +2616,11 @@ class CuteBackend(Backend):
         plan_layouts(graphs, config, tile_strategy)
 
     def supports_config_key(self, key: str) -> bool:
-        if key == "num_threads" or key.startswith("tcgen05_"):
+        if (
+            key == "num_threads"
+            or key == "cute_vector_widths"
+            or key.startswith("tcgen05_")
+        ):
             return True
         return super().supports_config_key(key)
 
@@ -2725,6 +2729,7 @@ class CuteBackend(Backend):
             "hl": "import helion.language as hl",
             "cutlass": "import cutlass",
             "cute": "import cutlass.cute as cute",
+            "ir": "from cutlass._mlir import ir",
             "_default_cute_launcher": "from helion.runtime import default_cute_launcher as _default_cute_launcher",
             "_next_power_of_2": "from helion._utils import next_power_of_2 as _next_power_of_2",
             "_cute_argreduce_index": "from helion._compiler.cute.reduce_helpers import _cute_argreduce_index",
@@ -2739,6 +2744,7 @@ class CuteBackend(Backend):
             "_cute_grouped_reduce_shared_tree": "from helion._compiler.cute.reduce_helpers import _cute_grouped_reduce_shared_tree",
             "_cute_grouped_reduce_shared_two_stage": "from helion._compiler.cute.reduce_helpers import _cute_grouped_reduce_shared_two_stage",
             "_cute_grouped_reduce_warp": "from helion._compiler.cute.reduce_helpers import _cute_grouped_reduce_warp",
+            "_cute_pre_vec_fold": "from helion._compiler.cute.reduce_helpers import _cute_pre_vec_fold",
             "_cute_store_shared_remote_x4": "from helion._compiler.cute.cluster_helpers import store_shared_remote_x4 as _cute_store_shared_remote_x4",
             "_cute_issue_clc_query_nomulticast": "from helion._compiler.cute.clc_helpers import issue_clc_query_nomulticast as _cute_issue_clc_query_nomulticast",
             "_cute_inline_asm_elementwise": "from helion._compiler.cute.inline_asm_helpers import inline_asm_elementwise as _cute_inline_asm_elementwise",

--- a/helion/_compiler/cute/reduce_helpers.py
+++ b/helion/_compiler/cute/reduce_helpers.py
@@ -756,3 +756,106 @@ def _cute_argreduce_index(
             extent=extent,
         )
     raise ValueError(f"unsupported CuTe argreduce type: {reduction_type!r}")
+
+
+# Per-thread V-fold helpers for vectorized loads.  Used by the looped
+# reduction strategy to collapse a length-V vector load into a scalar
+# before the warp-level reduction.
+
+
+@cute.jit
+def _cute_pre_vec_fold_sum(vec: object, *, V: cutlass.Constexpr[int]) -> object:
+    acc = vec[0]
+    for i in cutlass.range_constexpr(1, V):
+        acc = acc + vec[i]
+    return acc
+
+
+@cute.jit
+def _cute_pre_vec_fold_max(vec: object, *, V: cutlass.Constexpr[int]) -> object:
+    acc = vec[0]
+    for i in cutlass.range_constexpr(1, V):
+        candidate = vec[i]
+        acc = max(acc, candidate)
+    return acc
+
+
+@cute.jit
+def _cute_pre_vec_fold_min(vec: object, *, V: cutlass.Constexpr[int]) -> object:
+    acc = vec[0]
+    for i in cutlass.range_constexpr(1, V):
+        candidate = vec[i]
+        acc = min(acc, candidate)
+    return acc
+
+
+@cute.jit
+def _cute_pre_vec_fold_prod(vec: object, *, V: cutlass.Constexpr[int]) -> object:
+    acc = vec[0]
+    for i in cutlass.range_constexpr(1, V):
+        acc = acc * vec[i]
+    return acc
+
+
+def _cute_pre_vec_fold(vec: object, reduction_type: str, *, V: int) -> object:
+    if reduction_type == "sum":
+        return _cute_pre_vec_fold_sum(vec, V=V)
+    if reduction_type == "max":
+        return _cute_pre_vec_fold_max(vec, V=V)
+    if reduction_type == "min":
+        return _cute_pre_vec_fold_min(vec, V=V)
+    if reduction_type == "prod":
+        return _cute_pre_vec_fold_prod(vec, V=V)
+    raise ValueError(f"unsupported CuTe pre-vec-fold type: {reduction_type!r}")
+
+
+# Variant that ALSO casts each element of the input vec to fp32 before
+# accumulating.  Lets the looped-reduction strategy keep the vec-load
+# fast path on bf16/fp16 inputs that would otherwise be degraded by the
+# scalarising ``cutlass.Float32(vec)`` cast.
+
+
+@cute.jit
+def _cute_pre_vec_fold_sum_fp32(vec: object, *, V: cutlass.Constexpr[int]) -> object:
+    acc = cutlass.Float32(vec[0])
+    for i in cutlass.range_constexpr(1, V):
+        acc = acc + cutlass.Float32(vec[i])
+    return acc
+
+
+@cute.jit
+def _cute_pre_vec_fold_max_fp32(vec: object, *, V: cutlass.Constexpr[int]) -> object:
+    acc = cutlass.Float32(vec[0])
+    for i in cutlass.range_constexpr(1, V):
+        candidate = cutlass.Float32(vec[i])
+        acc = max(acc, candidate)
+    return acc
+
+
+@cute.jit
+def _cute_pre_vec_fold_min_fp32(vec: object, *, V: cutlass.Constexpr[int]) -> object:
+    acc = cutlass.Float32(vec[0])
+    for i in cutlass.range_constexpr(1, V):
+        candidate = cutlass.Float32(vec[i])
+        acc = min(acc, candidate)
+    return acc
+
+
+@cute.jit
+def _cute_pre_vec_fold_prod_fp32(vec: object, *, V: cutlass.Constexpr[int]) -> object:
+    acc = cutlass.Float32(vec[0])
+    for i in cutlass.range_constexpr(1, V):
+        acc = acc * cutlass.Float32(vec[i])
+    return acc
+
+
+def _cute_pre_vec_fold_fp32(vec: object, reduction_type: str, *, V: int) -> object:
+    if reduction_type == "sum":
+        return _cute_pre_vec_fold_sum_fp32(vec, V=V)
+    if reduction_type == "max":
+        return _cute_pre_vec_fold_max_fp32(vec, V=V)
+    if reduction_type == "min":
+        return _cute_pre_vec_fold_min_fp32(vec, V=V)
+    if reduction_type == "prod":
+        return _cute_pre_vec_fold_prod_fp32(vec, V=V)
+    raise ValueError(f"unsupported CuTe pre-vec-fold type: {reduction_type!r}")

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -327,17 +327,25 @@ class ForLoopGraphInfo(NodeArgsGraphInfo):
         args = state.ast_args[3]
         assert isinstance(args, list)
         assert all(isinstance(x, ast.AST) for x in args)
-        with state.codegen.add_device_loop(
-            state.device_function.tile_strategy.codegen_device_loop(
-                state, self.block_ids
-            ),
-            needs_barrier_before=self.needs_barrier_before,
-        ):
-            return codegen_call_with_graph(
-                state.codegen,
-                self.graph,
-                args,
-            )
+        # Make the active graph reachable by the strategy so it can pick
+        # different lane-loop shapes for the reduce vs consume sweeps.
+        # pyrefly: ignore [missing-attribute]
+        state.codegen._cute_active_graph_info = self
+        try:
+            with state.codegen.add_device_loop(
+                state.device_function.tile_strategy.codegen_device_loop(
+                    state, self.block_ids
+                ),
+                needs_barrier_before=self.needs_barrier_before,
+            ):
+                return codegen_call_with_graph(
+                    state.codegen,
+                    self.graph,
+                    args,
+                )
+        finally:
+            # pyrefly: ignore [missing-attribute]
+            state.codegen._cute_active_graph_info = None
 
 
 class ReductionLoopGraphInfo(ForLoopGraphInfo):
@@ -823,6 +831,15 @@ class DeviceIR:
                         size_hint=rdim.size_hint(),
                     )
                 )
+                if env.backend_name == "cute":
+                    from ..autotuner.config_spec import CuteVectorWidthSpec
+
+                    env.config_spec.cute_vector_widths.append(
+                        CuteVectorWidthSpec(
+                            block_id=rdim.block_id,
+                            size_hint=rdim.size_hint(),
+                        )
+                    )
             graphs_with_rolled_rdim |= used_graphs
 
         # Track which rdims appear as the reduction axis of an indexed

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -4,6 +4,7 @@ import ast
 import logging
 import operator
 from typing import TYPE_CHECKING
+from typing import cast
 
 import sympy
 import torch
@@ -21,6 +22,7 @@ from .cute.layout import LayoutTag as _CuteLayoutTag
 from .cute.layout_propagation import META_KEY as _CUTE_LAYOUT_META_KEY
 from .device_function import find_block_size_symbols
 from .host_function import HostFunction
+from .inductor_lowering import ReductionLowering
 from .inductor_lowering import install_inductor_kernel_handlers
 from .tile_strategy import CompactedShape
 from .tile_strategy import DeviceGridState
@@ -106,6 +108,43 @@ def cute_live_reduction_threads(max_threads: int) -> int:
     # autotuner / config_spec keeps the size_hint <= max_threads case here so
     # no synthetic lane wrap is required.
     return max_threads
+
+
+def _cute_vec_compatible_kernel() -> bool:
+    """Return True iff every load that feeds the reduction in the active
+    kernel is vec-eligible (no dtype-cast user).  Bf16/Fp16 inputs with a
+    ``.to(torch.float32)`` cast produce a scalar after the cast (CuTe's
+    ``Float32(vec)`` constructor degrades a vector), so the vec-load path
+    must be disabled at strategy-construction time when this pattern is
+    present.
+    """
+    from .host_function import HostFunction
+    from .host_function import NoCurrentFunction
+
+    try:
+        hf = HostFunction.current()
+    except NoCurrentFunction:
+        return False
+    if hf._device_ir is None:
+        return False
+    cast_targets = {
+        "convert_element_type.default",
+        "convert_element_type",
+        "_to_copy.default",
+        "_to_copy",
+    }
+    from ..language import memory_ops as _memory_ops
+
+    load_target = _memory_ops.load
+    for graph_info in hf.device_ir.graphs:
+        for node in graph_info.graph.nodes:
+            if node.target is not load_target:
+                continue
+            for user in node.users:
+                target_name = getattr(user.target, "__name__", "") or ""
+                if target_name in cast_targets:
+                    return False
+    return True
 
 
 def _block_has_indexed_reduction(fn: DeviceFunction, block_index: int) -> bool:
@@ -718,6 +757,14 @@ class LoopedReductionStrategy(ReductionStrategy):
         self._loop_block_size = block_size
         self._cute_reduction_lane_var: str | None = None
         self._cute_reduction_lane_extent = 1
+        self._cute_reduction_vec_width = 1
+        # Masks queued by vec loads inside the lane loop; consumed by
+        # codegen_reduction to wrap the V-fold scalar.
+        self._cute_pending_vec_masks: list[str] = []
+        # Set when a vec load was actually emitted for the current
+        # reduction's lane body — codegen_reduction inspects this to
+        # decide whether to emit the V-fold step.
+        self._cute_emitted_vec_load = False
         if (
             env.backend.name == "cute"
             and thread_count > 0
@@ -731,6 +778,28 @@ class LoopedReductionStrategy(ReductionStrategy):
                 f"reduction_lane_{block_index}",
                 dce=False,
             )
+            # Read autotuner-selected vector width and partition lane extent
+            # into outer × inner = lane_extent/V × V.  When V==1 (default)
+            # this preserves the original scalar codegen.
+            cute_vector_widths = cast(
+                "list[int]",
+                fn.config.config.get("cute_vector_widths", []) or [],
+            )
+            vec_width = env.config_spec.cute_vector_widths.config_get(
+                cute_vector_widths,
+                block_index,
+                1,
+            )
+            if (
+                isinstance(vec_width, int)
+                and vec_width > 1
+                and self._cute_reduction_lane_extent % vec_width == 0
+                and _cute_vec_compatible_kernel()
+            ):
+                self._cute_reduction_vec_width = vec_width
+                self._cute_reduction_lane_extent = (
+                    self._cute_reduction_lane_extent // vec_width
+                )
         if env.known_multiple(
             env.block_sizes[block_index].numel, self._loop_block_size
         ):
@@ -861,10 +930,45 @@ class LoopedReductionStrategy(ReductionStrategy):
             ),
         ]
         reduction_lane_var = self._cute_reduction_lane_var
+        vec = self._cute_reduction_vec_width
+        # Detect whether the upcoming graph contains a reduction op so we
+        # can choose between the reduce-sweep shape (single vec load +
+        # V-fold) and the consume-sweep shape (V scalar elementwise ops in
+        # an inner constexpr loop).
+        active_graph_info = getattr(state.codegen, "_cute_active_graph_info", None)
+        graph_has_reduction = True
+        if vec > 1 and active_graph_info is not None:
+            graph = getattr(active_graph_info, "graph", None)
+            if graph is not None:
+                graph_has_reduction = any(
+                    isinstance(n.meta.get("lowering"), ReductionLowering)
+                    for n in graph.nodes
+                )
+        consume_unroll = vec > 1 and not graph_has_reduction
+        vec_lane_var: str | None = None
         if reduction_lane_var is not None:
-            inner_body[0] = statement_from_string(
-                f"{index_var} = {offset_var} + {self._index_init_expr(f'({block_size_var})', env.index_type(), block_index)} + cutlass.Int32({reduction_lane_var}) * {self._thread_count}"
-            )
+            if vec > 1:
+                # base = offset + thread_idx*V + lane*(THREADS*V)
+                base_expr = (
+                    f"{offset_var} + "
+                    f"{self._index_init_expr(f'({block_size_var})', env.index_type(), block_index)} "
+                    f"* {vec} + "
+                    f"cutlass.Int32({reduction_lane_var}) * {self._thread_count * vec}"
+                )
+                if consume_unroll:
+                    vec_lane_var = self.fn.new_var(
+                        f"reduction_vec_lane_{block_index}",
+                        dce=False,
+                    )
+                    inner_body[0] = statement_from_string(
+                        f"{index_var} = {base_expr} + cutlass.Int32({vec_lane_var})"
+                    )
+                else:
+                    inner_body[0] = statement_from_string(f"{index_var} = {base_expr}")
+            else:
+                inner_body[0] = statement_from_string(
+                    f"{index_var} = {offset_var} + {self._index_init_expr(f'({block_size_var})', env.index_type(), block_index)} + cutlass.Int32({reduction_lane_var}) * {self._thread_count}"
+                )
         if (mask_var := self._mask_var) is not None:
             inner_body.append(
                 statement_from_string(
@@ -875,13 +979,32 @@ class LoopedReductionStrategy(ReductionStrategy):
         if reduction_lane_var is not None:
             from .tile_strategy import _create_lane_loop
 
-            body = [
-                _create_lane_loop(
-                    reduction_lane_var,
-                    self._cute_reduction_lane_extent,
-                    inner_body,
+            if consume_unroll and vec_lane_var is not None:
+                # for vi in cutlass.range_constexpr(V): ...
+                vec_for = cast(
+                    "ast.For",
+                    ast.parse(
+                        f"for {vec_lane_var} in cutlass.range_constexpr({vec}):\n"
+                        f"    pass"
+                    ).body[0],
                 )
-            ]
+                vec_for.body = inner_body  # type: ignore[assignment]
+                inner_with_unroll: list[ast.AST] = [vec_for]
+                body = [
+                    _create_lane_loop(
+                        reduction_lane_var,
+                        self._cute_reduction_lane_extent,
+                        inner_with_unroll,
+                    )
+                ]
+            else:
+                body = [
+                    _create_lane_loop(
+                        reduction_lane_var,
+                        self._cute_reduction_lane_extent,
+                        inner_body,
+                    )
+                ]
 
         for_node = create(
             ast.For,
@@ -945,8 +1068,46 @@ class LoopedReductionStrategy(ReductionStrategy):
             )
             result = self.fn.new_var(state.fx_node.name, dce=True)
             if not backend.is_indexed_reduction(reduction_type):
+                vec_input = input_name
+                if (
+                    backend.name == "cute"
+                    and self._cute_reduction_vec_width > 1
+                    and self._cute_emitted_vec_load
+                ):
+                    # The vec load + downstream elementwise ops produced a
+                    # length-V vector; fold it into a scalar so the warp-level
+                    # reduction stays unchanged.
+                    folded = self.fn.new_var(f"{state.fx_node.name}_vfold", dce=True)
+                    state.add_statement(
+                        f"{folded} = _cute_pre_vec_fold({vec_input}, "
+                        f"{reduction_type!r}, V={self._cute_reduction_vec_width})"
+                    )
+                    # If any vec load was masked, gate the folded scalar by
+                    # the same mask so masked-out rows don't pollute acc.
+                    if self._cute_pending_vec_masks:
+                        identity_repr = constant_repr(default)
+                        identity_expr = backend.cast_expr(
+                            identity_repr, _dtype_str(acc_dtype)
+                        )
+                        mask_combined = " and ".join(
+                            f"({m})" for m in self._cute_pending_vec_masks
+                        )
+                        gated = self.fn.new_var(
+                            f"{state.fx_node.name}_vfold_gated", dce=True
+                        )
+                        state.add_statement(
+                            f"{gated} = {folded} if ({mask_combined}) "
+                            f"else {identity_expr}"
+                        )
+                        vec_input = gated
+                        self._cute_pending_vec_masks.clear()
+                    else:
+                        vec_input = folded
+                # Reset for the next reduction's lane body (the consume
+                # sweep may also be codegen'd later but with no vec load).
+                self._cute_emitted_vec_load = False
                 combine_expr = backend.reduction_combine_expr(
-                    reduction_type, acc, input_name, acc_dtype
+                    reduction_type, acc, vec_input, acc_dtype
                 )
                 state.add_statement(f"{acc} = {combine_expr}")
                 expr = self._cute_cross_warp_reduction_expr(

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -159,6 +159,7 @@ BACKEND_SPECIFIC_KEYS: frozenset[str] = (
     | _BACKEND_STRATEGY_CONFIG_KEYS
     | {
         "num_threads",
+        "cute_vector_widths",
         "pallas_loop_type",
         "pallas_pre_broadcast",
     }
@@ -187,6 +188,7 @@ VALID_KEYS: frozenset[str] = frozenset(
         "load_eviction_policies",
         "pallas_loop_type",
         "pallas_pre_broadcast",
+        "cute_vector_widths",
         *BACKEND_TUNABLE_KEYS,
         "advanced_controls_file",
         "epilogue_subtile",
@@ -282,6 +284,9 @@ class ConfigSpec:
         self.l2_groupings: BlockIdSequence[L2GroupingSpec] = BlockIdSequence()
         self.flatten_loops: BlockIdSequence[FlattenLoopSpec] = BlockIdSequence()
         self.reduction_loops: BlockIdSequence[ReductionLoopSpec] = BlockIdSequence()
+        self.cute_vector_widths: BlockIdSequence[CuteVectorWidthSpec] = (
+            BlockIdSequence()
+        )
         self.range_unroll_factors: BlockIdSequence[RangeUnrollFactorSpec] = (
             BlockIdSequence()
         )
@@ -757,6 +762,7 @@ class ConfigSpec:
             ("l2_groupings", self.l2_groupings, True),
             ("loop_orders", self.loop_orders, False),
             ("reduction_loops", self.reduction_loops, True),
+            ("cute_vector_widths", self.cute_vector_widths, True),
             ("range_unroll_factors", self.range_unroll_factors, True),
             ("range_warp_specializes", self.range_warp_specialize, True),
             ("range_num_stages", self.range_num_stages, True),
@@ -948,6 +954,7 @@ class ConfigSpec:
             "l2_groupings",
             "flatten_loops",
             "reduction_loops",
+            "cute_vector_widths",
             "range_unroll_factors",
             "range_warp_specializes",
             "range_num_stages",
@@ -1727,6 +1734,42 @@ class ReductionLoopSpec(_PowerOfTwoBlockIdItem):
 
     def _fill_missing(self) -> None:
         return None
+
+
+_CUTE_VECTOR_WIDTH_CHOICES: tuple[int, ...] = (1, 2, 4, 8)
+
+
+class CuteVectorWidthSpec(_BlockIdItem):
+    """Per-reduction-block vector load width for the CuTe backend.
+
+    V=1 disables vectorization (scalar loads). V=2/4/8 emits
+    ``cute.arch.load(..., ir.VectorType.get([V], elem_dtype.mlir_type))``
+    for the inner reduction load, lowering to LDG.64/LDG.128.
+    """
+
+    def __init__(
+        self,
+        *,
+        block_id: int,
+        size_hint: int,
+    ) -> None:
+        super().__init__([block_id])
+        self.size_hint = size_hint
+
+    def _fragment(self, base: ConfigSpec) -> EnumFragment:
+        return EnumFragment(choices=_CUTE_VECTOR_WIDTH_CHOICES)
+
+    def _normalize(self, name: str, value: object) -> int:
+        if not isinstance(value, int):
+            raise InvalidConfig(f"{name} must be an integer, got {value!r}")
+        if value not in _CUTE_VECTOR_WIDTH_CHOICES:
+            raise InvalidConfig(
+                f"{name} must be one of {_CUTE_VECTOR_WIDTH_CHOICES}, got {value!r}"
+            )
+        return value
+
+    def _fill_missing(self) -> int:
+        return 1
 
 
 class _OptionalIntSpec(_BlockIdItem):

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -892,6 +892,163 @@ def _cute_scalar_store_expr(
     return f"{_cute_scalar_pointer_expr(tensor_name, index_exprs)}.store({value})"
 
 
+# Maximum bytes per vector load/store transaction (LDG.128/STG.128).
+_CUTE_VECTOR_MAX_BYTES = 16
+
+# Dtype -> (cutlass scalar type name, max vector width).
+_CUTE_VECTOR_DTYPES: dict[torch.dtype, tuple[str, int]] = {
+    torch.float32: ("cutlass.Float32", _CUTE_VECTOR_MAX_BYTES // 4),
+    torch.float16: ("cutlass.Float16", _CUTE_VECTOR_MAX_BYTES // 2),
+    torch.bfloat16: ("cutlass.BFloat16", _CUTE_VECTOR_MAX_BYTES // 2),
+}
+
+
+def _cute_vector_load_expr(
+    tensor_name: str,
+    index_exprs: list[str],
+    dtype: torch.dtype,
+    *,
+    vec_width: int,
+) -> str:
+    elem_str, _ = _CUTE_VECTOR_DTYPES[dtype]
+    ptr = _cute_scalar_pointer_expr(tensor_name, index_exprs)
+    return (
+        f"cute.arch.load({ptr}, ir.VectorType.get([{vec_width}], {elem_str}.mlir_type))"
+    )
+
+
+def _cute_vector_store_expr(
+    tensor_name: str,
+    index_exprs: list[str],
+    value: str,
+    dtype: torch.dtype,
+    *,
+    vec_width: int,
+) -> str:
+    elem_str, _ = _CUTE_VECTOR_DTYPES[dtype]
+    ptr = _cute_scalar_pointer_expr(tensor_name, index_exprs)
+    return (
+        f"cute.arch.store({ptr}, {value}, "
+        f"ir.VectorType.get([{vec_width}], {elem_str}.mlir_type))"
+    )
+
+
+def _cute_vector_load_ctx(
+    state: CodegenState,
+    tensor: torch.Tensor,
+    subscript: list[object] | tuple[object, ...],
+    index_exprs: list[str],
+    extra_mask: ast.AST | None,
+) -> tuple[int, int] | None:
+    """Return (vec_width, lane_block_id) when a vector load may be emitted.
+
+    Returns None when any predicate for a 128-bit gmem load fails, in which
+    case the caller falls back to ``_cute_scalar_load_expr``.
+    """
+    from .._compiler.reduction_strategy import LoopedReductionStrategy
+
+    env = CompileEnvironment.current()
+    if env.backend.name != "cute":
+        return None
+    if extra_mask is not None:
+        return None
+    if "None" in index_exprs:
+        return None
+    if tensor.dtype not in _CUTE_VECTOR_DTYPES:
+        return None
+    # Only enable the vec path when the load's result eventually feeds a
+    # reduction op.  The consume-sweep mixes the loaded vector with scalar
+    # values (e.g. the post-reduction inverse-RMS), and broadcasting
+    # scalar->vec is not supported by the CuTe DSL today.  Also bail when
+    # the load's immediate user is a dtype cast, because the CuTe DSL's
+    # ``Float32(vec)`` constructor degrades a vector to its first element
+    # rather than broadcasting the cast across the lanes.
+    fx_node = state.fx_node
+    if fx_node is None:
+        return None
+    # Check immediate users for an early-cast pattern (``to(dtype)``).
+    for user in fx_node.users:
+        target = user.target
+        target_name = getattr(target, "__name__", "") or ""
+        if target_name in (
+            "_to_copy.default",
+            "_to_copy",
+            "convert_element_type",
+            "convert_element_type.default",
+        ):
+            return None
+    visited: set[torch.fx.Node] = set()
+    pending = list(fx_node.users.keys())
+    feeds_reduction = False
+    while pending:
+        user = pending.pop()
+        if user in visited:
+            continue
+        visited.add(user)
+        target_name = getattr(user.target, "__name__", "") or ""
+        target_qualname = getattr(user.target, "_qualname", "") or ""
+        if (
+            "reduction" in target_name
+            or "_inductor_lowering_extra" in target_name
+            or "reduction" in target_qualname
+        ):
+            feeds_reduction = True
+            break
+        pending.extend(user.users.keys())
+    if not feeds_reduction:
+        return None
+    # The innermost dim of the load must be the reduction lane axis and
+    # the tensor must be stride-1 in that dim so that consecutive lane
+    # iters fetch consecutive bytes.
+    try:
+        if int(tensor.stride(-1)) != 1:
+            return None
+    except (TypeError, ValueError):
+        return None
+    # Locate the innermost (last) non-None subscript and pull the active
+    # block_id off it.  Slices resolve to the matching tensor-dim block via
+    # the strategy that's currently active for that block.
+    inner_block_id: int | None = None
+    tensor_dim = 0
+    for idx in subscript:
+        if idx is None:
+            continue
+        if isinstance(idx, torch.SymInt):
+            bid = env.get_block_id(idx)
+            if bid is not None:
+                inner_block_id = bid
+        elif isinstance(idx, slice) and idx == slice(None):
+            if tensor_dim < tensor.ndim:
+                dim_size = tensor.shape[tensor_dim]
+                if isinstance(dim_size, (int, torch.SymInt)):
+                    for cand_bid, bs in enumerate(env.block_sizes):
+                        bs_numel = bs.numel
+                        if not isinstance(bs_numel, (int, torch.SymInt)):
+                            continue
+                        if env.known_equal(
+                            bs_numel, dim_size
+                        ) and state.codegen.active_device_loops.get(cand_bid):
+                            inner_block_id = cand_bid
+                            break
+        tensor_dim += 1
+    if inner_block_id is None:
+        return None
+    loops = state.codegen.active_device_loops.get(inner_block_id)
+    if not loops:
+        return None
+    strategy = getattr(loops[-1], "strategy", None)
+    if not isinstance(strategy, LoopedReductionStrategy):
+        return None
+    vec_width = getattr(strategy, "_cute_reduction_vec_width", 1)
+    if vec_width <= 1:
+        return None
+    if strategy._mask_var is not None:
+        return None
+    if strategy._cute_reduction_lane_extent <= 0:
+        return None
+    return vec_width, inner_block_id
+
+
 def _cute_stack_tensor_offset_expr(
     state: CodegenState,
     tensor_like: torch.Tensor,
@@ -5109,7 +5266,6 @@ def _(state: CodegenState) -> object:
         inactive_slice_expr="None",
         inactive_singleton_slice_expr="0",
     )
-    load_expr = _cute_scalar_load_expr(tensor_name, index_exprs, tensor.dtype)
     mask_expr = _cute_combined_mask(
         state,
         subscript,
@@ -5117,6 +5273,27 @@ def _(state: CodegenState) -> object:
         tensor=tensor,
         include_tensor_index_masks=False,
     )
+    vec_ctx = _cute_vector_load_ctx(state, tensor, subscript, index_exprs, extra_mask)
+    if vec_ctx is not None:
+        vec_width, vec_block_id = vec_ctx
+        load_expr = _cute_vector_load_expr(
+            tensor_name, index_exprs, tensor.dtype, vec_width=vec_width
+        )
+        # The mask is deferred to the post-fold scalar in codegen_reduction.
+        # The vec load itself is unconditional; the mask is recorded on the
+        # active LoopedReductionStrategy and applied around the folded sum.
+        from .._compiler.reduction_strategy import LoopedReductionStrategy
+
+        loops = state.codegen.active_device_loops.get(vec_block_id)
+        if loops:
+            strategy = loops[-1].strategy
+            if isinstance(strategy, LoopedReductionStrategy):
+                strategy._cute_emitted_vec_load = True
+                if mask_expr is not None:
+                    strategy._cute_pending_vec_masks.append(mask_expr)
+        mask_expr = None
+    else:
+        load_expr = _cute_scalar_load_expr(tensor_name, index_exprs, tensor.dtype)
     if tensor.dtype is torch.bool:
         load_expr = f"({load_expr} != cutlass.Uint8(0))"
         if mask_expr is None:

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -137,6 +137,16 @@ def cute_row_sum(x: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="cute")
+def cute_normalize_by_sum(x: torch.Tensor) -> torch.Tensor:
+    n, _m = x.size()
+    out = torch.empty_like(x)
+    for tile_n in hl.tile(n):
+        row_sum = x[tile_n, :].sum(-1)
+        out[tile_n, :] = x[tile_n, :] / row_sum[:, None]
+    return out
+
+
+@helion.kernel(backend="cute")
 def cute_row_centered(x: torch.Tensor) -> torch.Tensor:
     n, m = x.size()
     out = torch.empty_like(x)
@@ -846,6 +856,32 @@ class TestCuteBackend(TestCase):
         self.assertIn("_cute_grouped_reduce_shared_two_stage", code)
         self.assertIn("group_span=1024", code)
         self.assertIn("block=(1024, 1, 1)", code)
+
+    def test_cute_vector_widths_partitions_lane_extent(self) -> None:
+        """cute_vector_widths=[V] partitions the lane extent into
+        outer x inner=V, so the consume sweep walks each V-chunk via a
+        constexpr V-loop and the per-thread base stride becomes V."""
+        args = (torch.randn(2, 16384, device=DEVICE, dtype=torch.float32) + 2.0,)
+        code_v1, _ = code_and_output(
+            cute_normalize_by_sum,
+            args,
+            block_sizes=[1],
+            reduction_loop=8192,
+        )
+        code_v4, _ = code_and_output(
+            cute_normalize_by_sum,
+            args,
+            block_sizes=[1],
+            reduction_loop=8192,
+            cute_vector_widths=[4],
+        )
+        # V=1 baseline: no constexpr V-loop, no per-thread V-stride.
+        self.assertNotIn("cutlass.range_constexpr(4)", code_v1)
+        self.assertNotIn("thread_idx()[0]) * 4", code_v1)
+        # V=4: the consume sweep emits a constexpr V-loop and the per-thread
+        # base index is offset by ``thread_idx * V``.
+        self.assertIn("cutlass.range_constexpr(4)", code_v4)
+        self.assertIn("thread_idx()[0]) * 4", code_v4)
 
     def test_strided_threaded_block_reduction(self) -> None:
         args = (torch.randn(4, 16, device=DEVICE, dtype=torch.float32),)


### PR DESCRIPTION
Stacked PRs:
 * #2548
 * #2547
 * __->__#2546


--- --- ---

### Emit vectorized 128-bit loads for CuTe inner reductions


Add a cute_vector_widths config knob (per-reduction-block, choices
1/2/4/8) that lets the LoopedReductionStrategy issue a single
cute.arch.load(ptr, ir.VectorType.get([V], dtype.mlir_type)) per lane
iter instead of V scalar loads.  Each thread covers V contiguous
elements at stride THREADS*V; the V-wide vector is folded into one
scalar via _cute_pre_vec_fold_<op> before the existing warp-level
reduction.  Outer-axis masks (M-tile predicates) move from the load
expression to the V-fold scalar so the vec load can stay unconditional.

The consume sweep, which the strategy emits after the reduction, is
unrolled by V via a constexpr inner loop so its scalar pipeline can
still process every element after the vec-aware index_var.  Vec is
gated to the reduce sweep only (graph contains a reduction op) and
disabled when any load feeding the reduction has a dtype cast, since
the CuTe DSL's Float32(vec) constructor degrades vectors to their first
element.  The autotuner heuristics seed V=4/8 (fp32/fp16-bf16) on
configs whose reduction chunk is wide enough to make the vec load
profitable.

Validation on B200 (fp32 inputs):
- cute_row_sum (M=2048, N=16384): 0.132ms (V=1) -> 0.098ms (V=2/4),
  ~35% reduction in wall time.
- All 88 cute backend + layout tests pass.
- Full rms_norm tritonbench avg unchanged (1.34x) because the
  production case uses bf16 with a Float32 cast on the load; the
  dispatcher silently demotes V=1 in that case.  bf16 vec-cast
  support is left for a follow-up (it needs a cast-aware vec helper
  to bypass the DSL's vector-scalarising constructor).
