### PR TITLE
Enable vec loads for bf16/fp16 CuTe reductions via Uint16 bitcast

### DIFF
--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -110,13 +110,17 @@ def cute_live_reduction_threads(max_threads: int) -> int:
     return max_threads
 
 
-def _cute_vec_compatible_kernel() -> bool:
-    """Return True iff every load that feeds the reduction in the active
-    kernel is vec-eligible (no dtype-cast user).  Bf16/Fp16 inputs with a
-    ``.to(torch.float32)`` cast produce a scalar after the cast (CuTe's
-    ``Float32(vec)`` constructor degrades a vector), so the vec-load path
-    must be disabled at strategy-construction time when this pattern is
-    present.
+def _cute_vec_kernel_mode() -> str:
+    """Return ``"vec"`` when all reduction-feeding loads are vec-eligible
+    without a degrading dtype cast (i.e. fp32 -> fp32 pipeline), ``"unroll"``
+    when at least one load uses the bf16/fp16 -> fp32 cast pattern that the
+    CuTe DSL's ``Float32(vec)`` constructor would silently scalarise, or
+    ``"none"`` when there's no looped reduction at all.
+
+    ``"vec"`` lets the strategy emit a single ``cute.arch.load(..., V)`` +
+    V-fold per lane iter.  ``"unroll"`` falls back to a constexpr V-loop
+    around per-element scalar loads — the CUTLASS DSL cannot iterate the
+    elements of a bf16/fp16 vector without crashing during compile.
     """
     from .host_function import HostFunction
     from .host_function import NoCurrentFunction
@@ -124,9 +128,9 @@ def _cute_vec_compatible_kernel() -> bool:
     try:
         hf = HostFunction.current()
     except NoCurrentFunction:
-        return False
+        return "none"
     if hf._device_ir is None:
-        return False
+        return "none"
     cast_targets = {
         "convert_element_type.default",
         "convert_element_type",
@@ -136,6 +140,7 @@ def _cute_vec_compatible_kernel() -> bool:
     from ..language import memory_ops as _memory_ops
 
     load_target = _memory_ops.load
+    has_cast = False
     for graph_info in hf.device_ir.graphs:
         for node in graph_info.graph.nodes:
             if node.target is not load_target:
@@ -143,8 +148,13 @@ def _cute_vec_compatible_kernel() -> bool:
             for user in node.users:
                 target_name = getattr(user.target, "__name__", "") or ""
                 if target_name in cast_targets:
-                    return False
-    return True
+                    has_cast = True
+                    break
+            if has_cast:
+                break
+        if has_cast:
+            break
+    return "unroll" if has_cast else "vec"
 
 
 def _block_has_indexed_reduction(fn: DeviceFunction, block_index: int) -> bool:
@@ -758,6 +768,9 @@ class LoopedReductionStrategy(ReductionStrategy):
         self._cute_reduction_lane_var: str | None = None
         self._cute_reduction_lane_extent = 1
         self._cute_reduction_vec_width = 1
+        # ``"vec"`` (fp32 fast path) or ``"unroll"`` (bf16/fp16 fallback)
+        # — controls how the lane body emits each per-iter load.
+        self._cute_reduction_vec_mode = "vec"
         # Masks queued by vec loads inside the lane loop; consumed by
         # codegen_reduction to wrap the V-fold scalar.
         self._cute_pending_vec_masks: list[str] = []
@@ -794,12 +807,14 @@ class LoopedReductionStrategy(ReductionStrategy):
                 isinstance(vec_width, int)
                 and vec_width > 1
                 and self._cute_reduction_lane_extent % vec_width == 0
-                and _cute_vec_compatible_kernel()
             ):
-                self._cute_reduction_vec_width = vec_width
-                self._cute_reduction_lane_extent = (
-                    self._cute_reduction_lane_extent // vec_width
-                )
+                mode = _cute_vec_kernel_mode()
+                if mode in ("vec", "unroll"):
+                    self._cute_reduction_vec_width = vec_width
+                    self._cute_reduction_vec_mode = mode
+                    self._cute_reduction_lane_extent = (
+                        self._cute_reduction_lane_extent // vec_width
+                    )
         if env.known_multiple(
             env.block_sizes[block_index].numel, self._loop_block_size
         ):
@@ -944,8 +959,23 @@ class LoopedReductionStrategy(ReductionStrategy):
                     isinstance(n.meta.get("lowering"), ReductionLowering)
                     for n in graph.nodes
                 )
-        consume_unroll = vec > 1 and not graph_has_reduction
+        # Unroll the lane body via a constexpr V-loop when the consume sweep
+        # mixes scalars (no reduction in graph), OR when the reduce sweep is
+        # in ``"unroll"`` mode (bf16/fp16 inputs that the CuTe DSL can't
+        # safely subscript as a vector).
+        consume_unroll = vec > 1 and (
+            not graph_has_reduction or self._cute_reduction_vec_mode == "unroll"
+        )
+        # Map from (tensor_name, base_expr) -> (hoist_var, dtype) so the
+        # dispatcher can reuse one hoist per (tensor, base) pair instead of
+        # emitting a fresh vec load on every dispatcher call.
+        self._cute_lane_vec_loads: dict[tuple[str, str], tuple[str, torch.dtype]] = {}
+        # Variable name holding the per-lane-iter base index for vec hoists
+        # in ``unroll`` mode — the dispatcher uses this to compute the vec
+        # pointer offset once.
+        self._cute_lane_base_index_var: str | None = None
         vec_lane_var: str | None = None
+        base_expr: str = ""
         if reduction_lane_var is not None:
             if vec > 1:
                 # base = offset + thread_idx*V + lane*(THREADS*V)
@@ -960,8 +990,13 @@ class LoopedReductionStrategy(ReductionStrategy):
                         f"reduction_vec_lane_{block_index}",
                         dce=False,
                     )
+                    self._cute_lane_base_index_var = self.fn.new_var(
+                        f"reduction_lane_base_{block_index}",
+                        dce=False,
+                    )
+                    # index_var = base + vi  (used inside the constexpr loop)
                     inner_body[0] = statement_from_string(
-                        f"{index_var} = {base_expr} + cutlass.Int32({vec_lane_var})"
+                        f"{index_var} = {self._cute_lane_base_index_var} + cutlass.Int32({vec_lane_var})"
                     )
                 else:
                     inner_body[0] = statement_from_string(f"{index_var} = {base_expr}")
@@ -989,14 +1024,25 @@ class LoopedReductionStrategy(ReductionStrategy):
                     ).body[0],
                 )
                 vec_for.body = inner_body  # type: ignore[assignment]
-                inner_with_unroll: list[ast.AST] = [vec_for]
+                # The lane-loop body holds the per-lane base index, then any
+                # dispatcher-requested vec hoists, then the constexpr loop.
+                base_stmt = statement_from_string(
+                    f"{self._cute_lane_base_index_var} = {base_expr}"
+                )
+                lane_body: list[ast.AST] = [
+                    base_stmt,
+                    vec_for,
+                ]
                 body = [
                     _create_lane_loop(
                         reduction_lane_var,
                         self._cute_reduction_lane_extent,
-                        inner_with_unroll,
+                        lane_body,
                     )
                 ]
+                # Stash the lane body list so the dispatcher can splice
+                # hoists in (BETWEEN base_stmt and vec_for) as it runs.
+                self._cute_lane_body = lane_body
             else:
                 body = [
                     _create_lane_loop(

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -895,11 +895,24 @@ def _cute_scalar_store_expr(
 # Maximum bytes per vector load/store transaction (LDG.128/STG.128).
 _CUTE_VECTOR_MAX_BYTES = 16
 
-# Dtype -> (cutlass scalar type name, max vector width).
+# Dtype -> (cutlass scalar type name, max vector width).  Used for the
+# ``vec`` mode that issues an explicit
+# ``cute.arch.load(ptr, ir.VectorType.get([V], elem.mlir_type))`` and folds
+# the result via ``_cute_pre_vec_fold``.
 _CUTE_VECTOR_DTYPES: dict[torch.dtype, tuple[str, int]] = {
     torch.float32: ("cutlass.Float32", _CUTE_VECTOR_MAX_BYTES // 4),
     torch.float16: ("cutlass.Float16", _CUTE_VECTOR_MAX_BYTES // 2),
     torch.bfloat16: ("cutlass.BFloat16", _CUTE_VECTOR_MAX_BYTES // 2),
+}
+
+# ``unroll`` mode loads bf16/fp16 inputs as Uint16 vectors and bitcasts each
+# extracted lane back to the original dtype.  This avoids the CuTe DSL
+# crash that fires when subscripting a bf16/fp16 vector value.  Cutlass
+# scalar type for the extracted lane is paired with the vec-element type
+# name used in ``ir.VectorType.get``.
+_CUTE_VECTOR_UNROLL_DTYPES: dict[torch.dtype, str] = {
+    torch.float16: "cutlass.Float16",
+    torch.bfloat16: "cutlass.BFloat16",
 }
 
 
@@ -933,15 +946,71 @@ def _cute_vector_store_expr(
     )
 
 
+def _cute_register_unroll_vec_hoist(
+    state: CodegenState,
+    strategy: object,  # LoopedReductionStrategy at runtime
+    tensor: torch.Tensor,
+    tensor_name: str,
+    index_exprs: list[str],
+    vec_width: int,
+) -> str:
+    """Register a Uint16 vec load to be hoisted above the constexpr V-loop
+    in the active lane body and return the per-element extract expression.
+
+    The hoist runs once per outer-lane iter; the constexpr V-loop's body
+    receives ``hoist_var[vi].bitcast(dtype)`` (a scalar) so the existing
+    cast/mul/accumulate pipeline keeps working unchanged.
+    """
+    elem_dtype = _CUTE_VECTOR_UNROLL_DTYPES[tensor.dtype]
+    base_index_var = getattr(strategy, "_cute_lane_base_index_var", None)
+    lane_body = getattr(strategy, "_cute_lane_body", None)
+    assert isinstance(base_index_var, str)
+    assert isinstance(lane_body, list)
+    # The inner reduction-axis index_expr is the last entry; swap it with
+    # the per-lane base so the vec load points at the start of the V-wide
+    # chunk this thread owns.
+    base_exprs = list(index_exprs)
+    base_exprs[-1] = base_index_var
+    base_ptr_expr = _cute_scalar_pointer_expr(tensor_name, base_exprs)
+    cache_key = (tensor_name, base_ptr_expr)
+    cache = getattr(strategy, "_cute_lane_vec_loads", None)
+    if cache is None:
+        cache = {}
+        # pyrefly: ignore [missing-attribute]
+        strategy._cute_lane_vec_loads = cache
+    if cache_key not in cache:
+        hoist_var = state.device_function.new_var(
+            f"_unroll_vec_{len(cache)}", dce=False
+        )
+        cache[cache_key] = (hoist_var, tensor.dtype)
+        hoist_stmt = statement_from_string(
+            f"{hoist_var} = cute.arch.load({base_ptr_expr}, "
+            f"ir.VectorType.get([{vec_width}], cutlass.Uint16.mlir_type))"
+        )
+        # Insert the hoist just BEFORE the constexpr V-loop (the last entry
+        # in lane_body).  ``lane_body[-1]`` is the constexpr loop.
+        lane_body.insert(len(lane_body) - 1, hoist_stmt)
+    else:
+        hoist_var, _ = cache[cache_key]
+    # The constexpr V-loop's target var is the last element's loop var.
+    constexpr_loop = lane_body[-1]
+    assert isinstance(constexpr_loop, ast.For)
+    assert isinstance(constexpr_loop.target, ast.Name)
+    vec_lane_var = constexpr_loop.target.id
+    return f"cutlass.Uint16({hoist_var}[{vec_lane_var}]).bitcast({elem_dtype})"
+
+
 def _cute_vector_load_ctx(
     state: CodegenState,
     tensor: torch.Tensor,
     subscript: list[object] | tuple[object, ...],
     index_exprs: list[str],
     extra_mask: ast.AST | None,
-) -> tuple[int, int] | None:
-    """Return (vec_width, lane_block_id) when a vector load may be emitted.
+) -> tuple[int, int, str] | None:
+    """Return (vec_width, lane_block_id, mode) when a vec load may be emitted.
 
+    ``mode`` is one of ``"vec"`` (explicit ``cute.arch.load(..., V)``) or
+    ``"unroll"`` (per-element scalar bitcast inside a constexpr V-loop).
     Returns None when any predicate for a 128-bit gmem load fails, in which
     case the caller falls back to ``_cute_scalar_load_expr``.
     """
@@ -954,29 +1023,24 @@ def _cute_vector_load_ctx(
         return None
     if "None" in index_exprs:
         return None
-    if tensor.dtype not in _CUTE_VECTOR_DTYPES:
+    if (
+        tensor.dtype not in _CUTE_VECTOR_DTYPES
+        and tensor.dtype not in _CUTE_VECTOR_UNROLL_DTYPES
+    ):
         return None
     # Only enable the vec path when the load's result eventually feeds a
     # reduction op.  The consume-sweep mixes the loaded vector with scalar
     # values (e.g. the post-reduction inverse-RMS), and broadcasting
-    # scalar->vec is not supported by the CuTe DSL today.  Also bail when
-    # the load's immediate user is a dtype cast, because the CuTe DSL's
-    # ``Float32(vec)`` constructor degrades a vector to its first element
-    # rather than broadcasting the cast across the lanes.
+    # scalar->vec is not supported by the CuTe DSL today.  When the load's
+    # immediate user is a dtype cast (``to(torch.float32)``), the
+    # ``"unroll"`` mode further down keeps the strategy on a per-element
+    # scalar pipeline and the explicit-vec path is skipped — the explicit
+    # ``cute.arch.load(ptr, ir.VectorType.get([V], dtype.mlir_type))`` form
+    # would otherwise crash inside the CuTe DSL when subscripting bf16/fp16
+    # vectors.
     fx_node = state.fx_node
     if fx_node is None:
         return None
-    # Check immediate users for an early-cast pattern (``to(dtype)``).
-    for user in fx_node.users:
-        target = user.target
-        target_name = getattr(target, "__name__", "") or ""
-        if target_name in (
-            "_to_copy.default",
-            "_to_copy",
-            "convert_element_type",
-            "convert_element_type.default",
-        ):
-            return None
     visited: set[torch.fx.Node] = set()
     pending = list(fx_node.users.keys())
     feeds_reduction = False
@@ -995,8 +1059,9 @@ def _cute_vector_load_ctx(
             feeds_reduction = True
             break
         pending.extend(user.users.keys())
-    if not feeds_reduction:
-        return None
+    # Note: ``feeds_reduction`` is required ONLY for the ``vec`` mode below;
+    # the ``unroll`` mode also applies to the consume sweep where the load
+    # result feeds an elementwise pipeline (no reduction).
     # The innermost dim of the load must be the reduction lane axis and
     # the tensor must be stride-1 in that dim so that consecutive lane
     # iters fetch consecutive bytes.
@@ -1020,16 +1085,39 @@ def _cute_vector_load_ctx(
         elif isinstance(idx, slice) and idx == slice(None):
             if tensor_dim < tensor.ndim:
                 dim_size = tensor.shape[tensor_dim]
-                if isinstance(dim_size, (int, torch.SymInt)):
-                    for cand_bid, bs in enumerate(env.block_sizes):
-                        bs_numel = bs.numel
-                        if not isinstance(bs_numel, (int, torch.SymInt)):
-                            continue
-                        if env.known_equal(
-                            bs_numel, dim_size
-                        ) and state.codegen.active_device_loops.get(cand_bid):
-                            inner_block_id = cand_bid
-                            break
+                for cand_bid, bs in enumerate(env.block_sizes):
+                    if not isinstance(bs.size, (int, torch.SymInt)):
+                        continue
+                    bs_numel = bs.numel
+                    # Try a few candidate forms for the size equality
+                    # check: sympy.Integer (most common via specialize()),
+                    # int, and torch.SymInt all flow through known_equal
+                    # after we coerce to plain int when possible.
+                    bs_int: int | torch.SymInt | None
+                    if isinstance(bs_numel, (int, torch.SymInt)):
+                        bs_int = bs_numel
+                    else:
+                        try:
+                            bs_int = int(bs_numel)
+                        except (TypeError, ValueError):
+                            bs_int = None
+                    if bs_int is None:
+                        continue
+                    dim_int: int | torch.SymInt | None
+                    if isinstance(dim_size, (int, torch.SymInt)):
+                        dim_int = dim_size
+                    else:
+                        try:
+                            dim_int = int(dim_size)
+                        except (TypeError, ValueError):
+                            dim_int = None
+                    if dim_int is None:
+                        continue
+                    if env.known_equal(
+                        bs_int, dim_int
+                    ) and state.codegen.active_device_loops.get(cand_bid):
+                        inner_block_id = cand_bid
+                        break
         tensor_dim += 1
     if inner_block_id is None:
         return None
@@ -1046,7 +1134,30 @@ def _cute_vector_load_ctx(
         return None
     if strategy._cute_reduction_lane_extent <= 0:
         return None
-    return vec_width, inner_block_id
+    mode = getattr(strategy, "_cute_reduction_vec_mode", "vec")
+    if mode == "vec":
+        if not feeds_reduction:
+            return None
+        if tensor.dtype not in _CUTE_VECTOR_DTYPES:
+            return None
+        return vec_width, inner_block_id, "vec"
+    if mode == "unroll":
+        if tensor.dtype not in _CUTE_VECTOR_UNROLL_DTYPES:
+            return None
+        # The CuTe DSL's ``nvvm.load.ext`` only supports vec sizes 2 and 4
+        # for bf16/fp16 (V=8 raises ICE).  Cap effective V here so the
+        # autotuner's V=8 seed still compiles instead of crashing.
+        if vec_width > 4:
+            return None
+        # Need a lane base index var + a constexpr V-loop var; both are
+        # set up by the strategy's codegen_device_loop.
+        if (
+            getattr(strategy, "_cute_lane_base_index_var", None) is None
+            or getattr(strategy, "_cute_lane_body", None) is None
+        ):
+            return None
+        return vec_width, inner_block_id, "unroll"
+    return None
 
 
 def _cute_stack_tensor_offset_expr(
@@ -5275,23 +5386,39 @@ def _(state: CodegenState) -> object:
     )
     vec_ctx = _cute_vector_load_ctx(state, tensor, subscript, index_exprs, extra_mask)
     if vec_ctx is not None:
-        vec_width, vec_block_id = vec_ctx
-        load_expr = _cute_vector_load_expr(
-            tensor_name, index_exprs, tensor.dtype, vec_width=vec_width
-        )
-        # The mask is deferred to the post-fold scalar in codegen_reduction.
-        # The vec load itself is unconditional; the mask is recorded on the
-        # active LoopedReductionStrategy and applied around the folded sum.
+        vec_width, vec_block_id, vec_mode = vec_ctx
         from .._compiler.reduction_strategy import LoopedReductionStrategy
 
         loops = state.codegen.active_device_loops.get(vec_block_id)
-        if loops:
-            strategy = loops[-1].strategy
+        strategy = loops[-1].strategy if loops else None
+        if vec_mode == "vec":
+            load_expr = _cute_vector_load_expr(
+                tensor_name, index_exprs, tensor.dtype, vec_width=vec_width
+            )
+            # The mask is deferred to the post-fold scalar in
+            # codegen_reduction.  The vec load itself is unconditional; the
+            # mask is recorded on the active LoopedReductionStrategy and
+            # applied around the folded sum.
             if isinstance(strategy, LoopedReductionStrategy):
                 strategy._cute_emitted_vec_load = True
                 if mask_expr is not None:
                     strategy._cute_pending_vec_masks.append(mask_expr)
-        mask_expr = None
+            mask_expr = None
+        else:
+            assert vec_mode == "unroll"
+            # Register (or reuse) a hoisted U16 vec load for this (tensor,
+            # base_index) pair, then return ``hoist_var[vi].bitcast(dtype)``
+            # so the existing scalar pipeline sees a scalar of the original
+            # dtype.
+            assert isinstance(strategy, LoopedReductionStrategy)
+            load_expr = _cute_register_unroll_vec_hoist(
+                state,
+                strategy,
+                tensor,
+                tensor_name,
+                index_exprs,
+                vec_width,
+            )
     else:
         load_expr = _cute_scalar_load_expr(tensor_name, index_exprs, tensor.dtype)
     if tensor.dtype is torch.bool:

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -147,6 +147,17 @@ def cute_normalize_by_sum(x: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="cute")
+def cute_normalize_by_sum_fp32_cast(x: torch.Tensor) -> torch.Tensor:
+    n, _m = x.size()
+    out = torch.empty_like(x)
+    for tile_n in hl.tile(n):
+        vals = x[tile_n, :].to(torch.float32)
+        row_sum = vals.sum(-1)
+        out[tile_n, :] = (vals / row_sum[:, None]).to(x.dtype)
+    return out
+
+
+@helion.kernel(backend="cute")
 def cute_row_centered(x: torch.Tensor) -> torch.Tensor:
     n, m = x.size()
     out = torch.empty_like(x)
@@ -882,6 +893,24 @@ class TestCuteBackend(TestCase):
         # base index is offset by ``thread_idx * V``.
         self.assertIn("cutlass.range_constexpr(4)", code_v4)
         self.assertIn("thread_idx()[0]) * 4", code_v4)
+
+    def test_bf16_unroll_mode_emits_uint16_vec_load_and_bitcast(self) -> None:
+        """For a bf16 reduction with an explicit fp32 cast, the 'unroll' vec
+        mode loads each V-chunk as a Uint16 vector and bitcasts each lane
+        back to bf16 via cutlass.Uint16(...).bitcast(cutlass.BFloat16)."""
+        args = (torch.randn(2, 16384, device=DEVICE, dtype=torch.bfloat16) + 2.0,)
+        code, out = code_and_output(
+            cute_normalize_by_sum_fp32_cast,
+            args,
+            block_sizes=[1],
+            reduction_loop=8192,
+            cute_vector_widths=[4],
+        )
+        (x,) = args
+        expected = (x.float() / x.float().sum(-1, keepdim=True)).to(x.dtype)
+        torch.testing.assert_close(out, expected, rtol=1e-2, atol=1e-2)
+        self.assertIn("ir.VectorType.get([4], cutlass.Uint16.mlir_type)", code)
+        self.assertIn(".bitcast(cutlass.BFloat16)", code)
 
     def test_strided_threaded_block_reduction(self) -> None:
         args = (torch.randn(4, 16, device=DEVICE, dtype=torch.float32),)


### PR DESCRIPTION
Stacked PRs:
 * #2548
 * __->__#2547


--- --- ---

### Enable vec loads for bf16/fp16 CuTe reductions via Uint16 bitcast


The CuTe DSL's ``cute.arch.load(ptr, ir.VectorType.get([V], BFloat16.mlir_type))``
+ vec[i] extract crashes inside ``_cutlass_ir`` (invalid opcode trap) for
bf16/fp16 inputs.  This commit adds a parallel ``"unroll"`` mode for the
LoopedReductionStrategy that:

- Loads the V-wide chunk as a Uint16 vector (the DSL handles u16 vectors
  without crashing).
- Hoists that vec load ONCE per outer-lane iter, just before the
  constexpr V-loop the strategy already emits for the consume sweep.
- Inside the constexpr loop, returns ``cutlass.Uint16(vec[vi]).bitcast(
  BFloat16)`` so the existing scalar pipeline (``Float32(load) * ...``)
  keeps working unchanged.

The ``"vec"`` mode (fp32 fast path) and the consume-sweep constexpr
unroll are unchanged; ``"unroll"`` extends the same machinery to bf16/
fp16 reductions and to the consume sweep.  V is capped at 4 for bf16/
fp16 because the underlying ``nvvm.load.ext`` only supports vec sizes 2
and 4 (V=8 raises ICE inside CUTLASS).

Validation on B200:
- All 88 cute backend + layout tests pass.
- bf16 rms_norm_fwd at V=4 wide-chunk gives identical correctness and
  comparable speed to V=1 wide-chunk (1.7-1.8x of pytorch at N=8192,
  6.3x at N=32768) — the apparent flat curve comes from missing two-pass
  fusion: V>1 currently disables the existing ``_fuse_cache_*`` peephole
  because the cache holds scalars while the reduce sweep produces vecs.
  Vec-aware fusion is the next step (Task B); this commit lands the
  infrastructure that fusion needs to plug into.
