### PR TITLE
Vec-aware two-pass load fusion for CuTe reductions

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -1888,6 +1888,12 @@ def _emit_mma_pipeline(
     if lhs_fake.ndim != 2 or rhs_fake.ndim != 2:
         return None
 
+    # Universal-MMA / tcgen05 MMA kernels rely on runtime tensor layouts
+    # for SMEM-load guards and TMA descriptors; baking literal shapes
+    # silently miscompiles those paths.  Mirror the flag set in
+    # ``_emit_cute_matmul`` so the host-side launcher disables the bake.
+    cg.cute_uses_matmul = True
+
     df = cg.device_function
     lhs_arg = df.tensor_arg(lhs_fake)
     rhs_arg = df.tensor_arg(rhs_fake)

--- a/helion/_compiler/cute/fuse_two_pass_loads.py
+++ b/helion/_compiler/cute/fuse_two_pass_loads.py
@@ -42,6 +42,7 @@ two for-loops' ``target`` / ``iter`` / range bounds.
 from __future__ import annotations
 
 import ast
+import re
 
 from ..ast_extension import statement_from_string
 
@@ -83,6 +84,79 @@ def _looks_like_tracked_load(node: ast.AST) -> ast.IfExp | None:
     if not isinstance(func, ast.Attribute) or func.attr != "load":
         return None
     return node
+
+
+def _looks_like_unmasked_load(node: ast.AST) -> ast.Call | None:
+    """Return the Call if ``node`` is an unmasked scalar ``(PTR).load()``.
+
+    The CuTe scalar load emitter drops the ``if mask else CONST`` wrapping
+    when no mask is active (e.g. ``weight[:]`` loads in RMS-norm consume
+    sweeps); we still want to fuse those across the two passes.
+    """
+    if isinstance(node, ast.Call):
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "load":
+            return node
+    return None
+
+
+def _looks_like_vec_load(node: ast.AST) -> ast.Call | None:
+    """Return the Call if ``node`` is a ``cute.arch.load(ptr, vec_type)``
+    expression — the hoisted U16 vec load emitted by the LoopedReductionStrategy
+    ``unroll`` mode.
+    """
+    if not isinstance(node, ast.Call):
+        return None
+    func = node.func
+    if not isinstance(func, ast.Attribute):
+        return None
+    if func.attr != "load":
+        return None
+    val = func.value
+    # Match either ``cute.arch.load`` or ``cute.arch.<whatever>.load`` — we
+    # only care that ``arch`` is in the call chain because that's what the
+    # cute helper uses.
+    while isinstance(val, ast.Attribute):
+        if val.attr == "arch":
+            return node
+        val = val.value
+    return None
+
+
+def _load_kind(node: ast.AST) -> str | None:
+    """Classify the load shape into ``"masked"`` / ``"unmasked"`` / ``"vec"``.
+
+    Returns None when ``node`` doesn't look like a gmem load we can fuse.
+    """
+    if _looks_like_tracked_load(node) is not None:
+        return "masked"
+    if _looks_like_vec_load(node) is not None:
+        return "vec"
+    if _looks_like_unmasked_load(node) is not None:
+        return "unmasked"
+    return None
+
+
+def _vec_width(node: ast.AST) -> int | None:
+    """Extract the V from ``cute.arch.load(ptr, ir.VectorType.get([V], ...))``.
+
+    Returns None when the expression isn't a recognised vec load.
+    """
+    if not isinstance(node, ast.Call) or len(node.args) < 2:
+        return None
+    vec_arg = node.args[1]
+    if (
+        isinstance(vec_arg, ast.Call)
+        and isinstance(vec_arg.func, ast.Attribute)
+        and vec_arg.func.attr == "get"
+        and len(vec_arg.args) >= 1
+    ):
+        shape_arg = vec_arg.args[0]
+        if isinstance(shape_arg, ast.List) and len(shape_arg.elts) == 1:
+            elt = shape_arg.elts[0]
+            if isinstance(elt, ast.Constant) and isinstance(elt.value, int):
+                return elt.value
+    return None
 
 
 def offset_var_for(loop: ast.For) -> str:
@@ -140,6 +214,49 @@ def _node_text(node: ast.AST) -> str:
     return ast.unparse(node)
 
 
+def _rewrite_vec_extract(
+    node: ast.AST, hoist_var: str, cache: str, idx_expr: str, vec_w: int
+) -> None:
+    """In-place rewrite of ``hoist_var[<vi>]`` -> ``cache[(idx_expr)*V + vi]``
+    inside ``node``.  Used after the vec hoist itself has been deleted from
+    the consume sweep so the dependent extracts still resolve.
+    """
+
+    class _RewriteVecExtract(ast.NodeTransformer):
+        def visit_Subscript(self, node: ast.Subscript) -> ast.AST:
+            self.generic_visit(node)
+            if isinstance(node.value, ast.Name) and node.value.id == hoist_var:
+                vi_text = ast.unparse(node.slice)
+                new = ast.parse(f"{cache}[({idx_expr}) * {vec_w} + ({vi_text})]").body[
+                    0
+                ]
+                assert isinstance(new, ast.Expr)
+                return new.value
+            return node
+
+    transformer = _RewriteVecExtract()
+    transformer.visit(node)
+    ast.fix_missing_locations(node)
+
+
+def _canonical_load_text(node: ast.AST, lane_var_alias: dict[str, str]) -> str:
+    """Stringify a load node with lane-base / hoist variables canonicalised.
+
+    The strategy creates fresh variable names for each sweep
+    (``reduction_lane_base_1`` in the reduce sweep, ``reduction_lane_base_2``
+    in the consume sweep, ``_unroll_vec_0`` vs ``_unroll_vec_1``...).  The
+    fuser matches loads across the two sweeps, so it must compare their
+    textual form modulo the rename — otherwise identical loads compare
+    unequal and fusion bails.
+    """
+    text = ast.unparse(node)
+    for old, new in lane_var_alias.items():
+        # Word-boundary replacement so suffixed vars don't pick up matches
+        # for shorter prefixes.
+        text = re.sub(rf"\b{re.escape(old)}\b", new, text)
+    return text
+
+
 class _CuteFuseTwoPassLoads(ast.NodeTransformer):
     """See module docstring."""
 
@@ -152,6 +269,143 @@ class _CuteFuseTwoPassLoads(ast.NodeTransformer):
         name = f"_fuse_cache_{self._counter}"
         self._counter += 1
         return name
+
+    def _resolve_load_container(
+        self,
+        outer_loop: ast.For,
+        start: ast.expr,
+        step: ast.expr,
+        trip: int,
+    ) -> tuple[list[ast.stmt], str, int] | None:
+        """Find the body list holding the actual gmem loads + the index
+        expression used to address the cache for one iter of ``outer_loop``.
+
+        Returns ``(container, cache_index_expr, cache_size)`` or None when
+        the body shape is not recognised.
+
+        Supported shapes:
+          A) Flat body (``for offset ...: load...``) — original simple case.
+          B) One nested for-loop (lane loop): ``for lane in range(K)`` —
+             cache index is ``(offset - start) // step * K + lane`` and the
+             container is the lane loop body.
+          C) Two nested for-loops (lane + constexpr vec lane) — the load
+             dispatcher hoists vec loads ABOVE the constexpr loop, so the
+             container is the lane loop body (between base_stmt and
+             vec_for); index is ``(offset - start) // step * K + lane``.
+        """
+        body = outer_loop.body
+        offset_var = offset_var_for(outer_loop)
+        cache_index_outer = (
+            f"({offset_var} - ({_node_text(start)})) // ({_node_text(step)})"
+        )
+        for_children = [s for s in body if isinstance(s, ast.For)]
+        if not for_children:
+            return body, cache_index_outer, trip
+        if len(for_children) != 1:
+            return None
+        # Shape B/C: one nested lane loop
+        lane_loop = for_children[0]
+        if not isinstance(lane_loop.target, ast.Name):
+            return None
+        # Resolve lane extent from range(K)
+        lane_range = _range_bounds(lane_loop.iter)
+        if lane_range is None:
+            return None
+        lane_start, lane_end, lane_step = lane_range
+        lane_trip = _trip_count_for(
+            lane_start, lane_end, lane_step, self._constexpr_values
+        )
+        if lane_trip is None or lane_trip < 1 or lane_trip > 32:
+            return None
+        lane_var = lane_loop.target.id
+        cache_index = f"({cache_index_outer}) * {lane_trip} + ({lane_var})"
+        # Check if the lane body contains a NESTED for (the constexpr vec
+        # loop in shape C).  If yes, the cache loads sit BEFORE that
+        # constexpr loop (the vec-hoist pattern from the LoopedReduction
+        # ``unroll`` mode).
+        lane_inner_fors = [s for s in lane_loop.body if isinstance(s, ast.For)]
+        if not lane_inner_fors:
+            # Shape B: lane body itself is the load container.
+            return lane_loop.body, cache_index, trip * lane_trip
+        if len(lane_inner_fors) != 1:
+            return None
+        # Shape C: cache the hoisted vec loads (which sit BEFORE the
+        # constexpr loop).  The constexpr V-loop itself is left alone
+        # because it only reads ``hoist_var[vi].bitcast(...)`` — once the
+        # hoist is replaced by a cache read, those inner extracts still
+        # work unchanged.
+        return lane_loop.body, cache_index, trip * lane_trip
+
+    def _build_second_alias(
+        self, first_loop: ast.For, second_loop: ast.For
+    ) -> dict[str, str]:
+        """Collect per-loop variable renames that need to be normalised so
+        the two sweeps' load expressions compare equal.
+
+        Currently handles the LoopedReductionStrategy's ``unroll`` mode:
+          - ``reduction_lane_base_<N>`` (per sweep)
+          - ``reduction_vec_lane_<N>`` (per sweep)
+        """
+        alias: dict[str, str] = {}
+
+        def _collect(loop: ast.For, prefix: str) -> str | None:
+            for s in ast.walk(loop):
+                if isinstance(s, ast.Name) and s.id.startswith(prefix):
+                    return s.id
+                if isinstance(s, ast.Assign):
+                    for t in s.targets:
+                        if isinstance(t, ast.Name) and t.id.startswith(prefix):
+                            return t.id
+            return None
+
+        for prefix in ("reduction_lane_base_", "reduction_vec_lane_"):
+            first_var = _collect(first_loop, prefix)
+            second_var = _collect(second_loop, prefix)
+            if first_var and second_var and first_var != second_var:
+                # Canonicalise the second sweep's var to the first sweep's
+                # name so textual comparison succeeds.
+                alias[second_var] = first_var
+        return alias
+
+    def _dtype_for_load_kind(self, node: ast.AST, kind: str) -> str | None:
+        """Extract the storage dtype string for the fragment that backs the
+        cached load.  For masked scalar loads, derive from the ``else
+        CONST`` branch.  For unmasked / vec loads, derive from the pointer
+        or vec-type expression.
+        """
+        if kind == "masked":
+            assert isinstance(node, ast.IfExp)
+            return _dtype_from_default(node.orelse)
+        if kind == "unmasked":
+            # ``(ptr_expr).load()`` — the load expression itself doesn't
+            # carry a dtype, but we can look it up later via the assignment
+            # target's downstream usage.  For now, fall back to a Float32
+            # cache which the cute compiler will coerce.  (RMS-norm consume
+            # sweeps in fp16/bf16 take the masked path; this fallback is
+            # rarely exercised.)
+            return None
+        if kind == "vec":
+            # ``cute.arch.load(ptr, ir.VectorType.get([V], <elem>.mlir_type))``
+            # Pull the element type expression out so the fragment is the
+            # right dtype.  The third arg to VectorType.get is the elem.
+            assert isinstance(node, ast.Call)
+            if len(node.args) >= 2:
+                vec_arg = node.args[1]
+                # ir.VectorType.get([V], <elem>.mlir_type)
+                if (
+                    isinstance(vec_arg, ast.Call)
+                    and isinstance(vec_arg.func, ast.Attribute)
+                    and vec_arg.func.attr == "get"
+                    and len(vec_arg.args) >= 2
+                ):
+                    elem_arg = vec_arg.args[1]
+                    if (
+                        isinstance(elem_arg, ast.Attribute)
+                        and elem_arg.attr == "mlir_type"
+                    ):
+                        return ast.unparse(elem_arg.value)
+            return None
+        return None
 
     def _try_fuse(self, body: list[ast.stmt]) -> list[ast.stmt] | None:
         # Find top-level ``for offset in range(...)`` loops with matching
@@ -201,124 +455,181 @@ class _CuteFuseTwoPassLoads(ast.NodeTransformer):
             second_idx = group[1]
             second_loop = new_body[second_idx]
             assert isinstance(second_loop, ast.For)
-            # Only the simple (no nested lane loop) case is fused. With a
-            # nested lane loop the cache index mixes runtime ``offset``
-            # with the lane variable, and CUTLASS DSL falls back to local
-            # memory (spilled to stack), which regresses performance.
-            container_first = first_loop.body
-            container_second = second_loop.body
-            cache_size = trip
-            cache_index = (
-                f"({offset_var_for(first_loop)} - ({_node_text(start)})) // "
-                f"({_node_text(step)})"
-            )
-            # Bail out on nested for-loops in either body to keep the
-            # simple-case invariant.
-            if any(isinstance(s, ast.For) for s in container_first):
+            # Resolve the load-container for each sweep: usually the for
+            # body itself, but for wide-chunk / vec configs the loads sit
+            # inside a nested lane for-loop.  Track the (load_container,
+            # cache_index) pair so the rewrite handles both shapes.
+            first_ctx = self._resolve_load_container(first_loop, start, step, trip)
+            second_ctx = self._resolve_load_container(second_loop, start, step, trip)
+            if first_ctx is None or second_ctx is None:
                 continue
-            if any(isinstance(s, ast.For) for s in container_second):
+            first_container, first_cache_index, first_cache_size = first_ctx
+            second_container, second_cache_index, second_cache_size = second_ctx
+            if first_cache_size != second_cache_size:
                 continue
+            cache_size = first_cache_size
+            # Sanity cap (avoid runaway register pressure).
+            if cache_size > 64:
+                continue
+            cache_index = first_cache_index
+            second_cache_index_str = second_cache_index
 
-            # Collect tracked loads, keyed by unparsed text.
-            tracked: dict[str, tuple[int, str]] = {}
-            for j, s in enumerate(container_first):
+            # Build a canonical-form alias map that smooths over per-sweep
+            # variable renames (``reduction_lane_base_1`` vs
+            # ``reduction_lane_base_2``, lane var counters, etc.) so the
+            # two sweeps' loads compare equal by text.
+            second_alias = self._build_second_alias(first_loop, second_loop)
+
+            # Collect tracked loads from the first container.  Vec loads
+            # (the ``unroll`` mode's U16 vec hoist) cache via a *scalar*
+            # fragment of ``cache_size * V`` slots — one slot per
+            # extracted lane — because the CUTLASS DSL's
+            # ``cute.make_fragment(N, dtype)`` does not currently accept a
+            # vec element type.  Scalar (masked / unmasked) loads cache as
+            # the existing fast path.
+            tracked: dict[str, tuple[int, str, str, str | None, int | None]] = {}
+            for j, s in enumerate(first_container):
                 if (
                     isinstance(s, ast.Assign)
                     and len(s.targets) == 1
                     and isinstance(s.targets[0], ast.Name)
                 ):
-                    load = _looks_like_tracked_load(s.value)
-                    if load is not None:
-                        tracked[_node_text(load)] = (j, s.targets[0].id)
+                    kind = _load_kind(s.value)
+                    if kind is None:
+                        continue
+                    dtype = self._dtype_for_load_kind(s.value, kind)
+                    if dtype is None:
+                        continue
+                    v_width = _vec_width(s.value) if kind == "vec" else 1
+                    if kind == "vec" and v_width is None:
+                        continue
+                    tracked[_node_text(s.value)] = (
+                        j,
+                        s.targets[0].id,
+                        kind,
+                        dtype,
+                        v_width,
+                    )
             if not tracked:
                 continue
 
-            # Find matching loads in the second loop's container.
+            # Match loads in the second container.
             assignments_to_rewrite: list[tuple[int, str, str]] = []
-            for j, s in enumerate(container_second):
+            for j, s in enumerate(second_container):
                 if (
                     isinstance(s, ast.Assign)
                     and len(s.targets) == 1
                     and isinstance(s.targets[0], ast.Name)
                 ):
-                    load = _looks_like_tracked_load(s.value)
-                    if load is None:
+                    kind = _load_kind(s.value)
+                    if kind is None:
                         continue
-                    key = _node_text(load)
+                    # Canonicalise the second sweep's load text against the
+                    # first sweep's variable names before keying.
+                    key = _canonical_load_text(s.value, second_alias)
                     if key in tracked:
                         assignments_to_rewrite.append((j, s.targets[0].id, key))
             if not assignments_to_rewrite:
                 continue
 
-            # Build cache declarations.
-            cache_names: dict[str, str] = {}
+            # Build cache declarations.  For vec loads, allocate
+            # ``cache_size * V`` scalar slots; for scalar loads use the
+            # original ``cache_size`` count.
+            cache_names: dict[str, tuple[str, int]] = {}
             cache_decls: list[ast.stmt] = []
-            for key, (j, _name) in tracked.items():
+            for key, (_j, _name, _kind, dtype, vec_w) in tracked.items():
                 if not any(akey == key for _, _, akey in assignments_to_rewrite):
                     continue
-                load_stmt = container_first[j]
-                assert isinstance(load_stmt, ast.Assign)
-                load_ifexp = _looks_like_tracked_load(load_stmt.value)
-                assert load_ifexp is not None
-                dtype = _dtype_from_default(load_ifexp.orelse)
-                if dtype is None:
+                if dtype is None or vec_w is None:
                     continue
                 cache = self._new_cache_name()
-                cache_names[key] = cache
+                cache_names[key] = (cache, vec_w)
+                cache_total = cache_size * vec_w
                 cache_decls.append(
                     statement_from_string(
-                        f"{cache} = cute.make_fragment({cache_size}, {dtype})"
+                        f"{cache} = cute.make_fragment({cache_total}, {dtype})"
                     )
                 )
             if not cache_names:
                 continue
 
-            # Rewrite the first loop: insert cache writes after each tracked
-            # load.
+            # Rewrite the first container: append cache writes after each
+            # tracked load assignment.  Vec loads write V scalars per
+            # cache slot; scalar loads write a single scalar.
             new_first_body: list[ast.stmt] = []
-            for s in container_first:
+            for s in first_container:
                 new_first_body.append(s)
                 if (
                     isinstance(s, ast.Assign)
                     and len(s.targets) == 1
                     and isinstance(s.targets[0], ast.Name)
                 ):
-                    load = _looks_like_tracked_load(s.value)
-                    if load is None:
+                    if _load_kind(s.value) is None:
                         continue
-                    key = _node_text(load)
-                    cache = cache_names.get(key)
-                    if cache is None:
+                    key = _node_text(s.value)
+                    entry = cache_names.get(key)
+                    if entry is None:
                         continue
+                    cache, vec_w = entry
                     name = s.targets[0].id
-                    new_first_body.append(
-                        statement_from_string(f"{cache}[{cache_index}] = {name}")
-                    )
-            first_loop.body = new_first_body
+                    if vec_w == 1:
+                        new_first_body.append(
+                            statement_from_string(f"{cache}[{cache_index}] = {name}")
+                        )
+                    else:
+                        for v in range(vec_w):
+                            new_first_body.append(
+                                statement_from_string(
+                                    f"{cache}[({cache_index}) * {vec_w} + {v}] = "
+                                    f"{name}[{v}]"
+                                )
+                            )
+            first_container[:] = new_first_body
 
-            # Rewrite the second loop: replace each matched load with a
-            # read from the cache.
+            # Rewrite the second container: replace each matched load.
+            # Scalar loads become a single cache read.  Vec loads are
+            # eliminated entirely (the consume sweep's hoist disappears)
+            # and any downstream ``hoist_var[vi]`` extracts inside the
+            # nested constexpr V-loop are rewritten to read from the cache
+            # at ``cache_index*V + vi``.
+            vec_extract_rewrites: list[tuple[str, str, str, int]] = []
             new_second_body: list[ast.stmt] = []
-            for s in container_second:
+            for s in second_container:
                 if (
                     isinstance(s, ast.Assign)
                     and len(s.targets) == 1
                     and isinstance(s.targets[0], ast.Name)
                 ):
-                    load = _looks_like_tracked_load(s.value)
-                    if load is not None:
-                        key = _node_text(load)
-                        cache = cache_names.get(key)
-                        if cache is not None:
+                    kind = _load_kind(s.value)
+                    if kind is not None:
+                        key = _canonical_load_text(s.value, second_alias)
+                        entry = cache_names.get(key)
+                        if entry is not None:
+                            cache, vec_w = entry
                             name = s.targets[0].id
-                            new_second_body.append(
-                                statement_from_string(
-                                    f"{name} = {cache}[{cache_index}]"
+                            if vec_w == 1:
+                                new_second_body.append(
+                                    statement_from_string(
+                                        f"{name} = {cache}[{second_cache_index_str}]"
+                                    )
                                 )
-                            )
+                            else:
+                                # Drop the hoist entirely; remember that
+                                # ``name[vi]`` needs to be rewritten to
+                                # ``cache[idx*V + vi]`` in subsequent
+                                # statements (especially inside the
+                                # constexpr V-loop).
+                                vec_extract_rewrites.append(
+                                    (name, cache, second_cache_index_str, vec_w)
+                                )
                             continue
                 new_second_body.append(s)
-            second_loop.body = new_second_body
+            # Apply the vec extract rewrites recursively to ``new_second_body``.
+            if vec_extract_rewrites:
+                for hoist_var, cache, idx_expr, vec_w in vec_extract_rewrites:
+                    for stmt in new_second_body:
+                        _rewrite_vec_extract(stmt, hoist_var, cache, idx_expr, vec_w)
+            second_container[:] = new_second_body
 
             # Insert cache declarations before the first loop.
             for decl in cache_decls:

--- a/helion/_compiler/cute/matmul_fallback.py
+++ b/helion/_compiler/cute/matmul_fallback.py
@@ -200,6 +200,8 @@ def _emit_cute_matmul(
     rhs_dtype: torch.dtype | None = None,
 ) -> ast.AST:
     """Build a CuTe matmul fallback using a cross-thread reduction over K."""
+    if hasattr(cg, "cute_uses_matmul"):
+        cg.cute_uses_matmul = True  # type: ignore[attr-defined]
     reduction_dtype: torch.dtype | None = acc_dtype or out_dtype
     lhs_terms: tuple[ast.AST, ...]
     if isinstance(lhs, CutePackedAffineLoad):

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -81,6 +81,7 @@ class GenerateAST(NodeVisitor, CodegenInterface):
         self.module_statements: list[ast.stmt] = []
         self.cute_direct_entry_plans: list[dict[str, object]] = []
         self.cute_wrapper_plans: list[dict[str, object]] = []
+        self.cute_uses_matmul: bool = False
         self.statements_stack: list[list[ast.AST]] = [self.host_statements]
         self.on_device = False
         self.active_device_loops: dict[int, list[DeviceLoopOrGridState]] = (
@@ -902,6 +903,13 @@ def generate_ast(
                 else []
             )
             final_host_statements = rng_statements + codegen.host_statements
+            if codegen.cute_uses_matmul or codegen.cute_wrapper_plans:
+                final_host_statements = [
+                    statement_from_string(
+                        f"{codegen.device_function.name}._helion_cute_disable_bake_tensor_shapes = True"
+                    ),
+                    *final_host_statements,
+                ]
             launcher_arg_positions: dict[str, int] | None = None
 
             def resolve_cute_plan_arg_positions(

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -1815,10 +1815,41 @@ def _create_cute_wrapper(
     for i, entry in enumerate(schema_key):
         kind = entry[0]
         if kind == "tensor":
-            (_, _dtype, rank) = entry
-            assert isinstance(rank, int)
             ptr_name = f"arg{i}_ptr"
             params.append(f"{ptr_name}: cute.Pointer")
+            if len(entry) == 5:
+                # ("tensor", dtype, rank, sizes, strides) — baked layout.
+                # Wrapper plans (matmul TMA) also reference
+                # ``arg{i}_shape{d}`` / ``arg{i}_stride{d}`` names, so we
+                # bind those names to their literal values in the wrapper
+                # body before constructing the tensor.
+                (_, _dtype, rank, sizes_t, strides_t) = entry
+                assert isinstance(rank, int)
+                assert isinstance(sizes_t, tuple) and len(sizes_t) == rank
+                assert isinstance(strides_t, tuple) and len(strides_t) == rank
+                shape_literals = [repr(int(s)) for s in sizes_t]
+                stride_literals = [repr(int(s)) for s in strides_t]
+                for d, lit in enumerate(shape_literals):
+                    body.append(f"    arg{i}_shape{d} = {lit}")
+                for d, lit in enumerate(stride_literals):
+                    body.append(f"    arg{i}_stride{d} = {lit}")
+                shape_tuple = (
+                    f"({shape_literals[0]},)"
+                    if rank == 1
+                    else f"({', '.join(shape_literals)})"
+                )
+                stride_tuple = (
+                    f"({stride_literals[0]},)"
+                    if rank == 1
+                    else f"({', '.join(stride_literals)})"
+                )
+                body.append(
+                    f"    arg{i} = cute.make_tensor({ptr_name}, layout=cute.make_layout({shape_tuple}, stride={stride_tuple}))"
+                )
+                call_args.append(f"arg{i}")
+                continue
+            (_, _dtype, rank) = entry
+            assert isinstance(rank, int)
             shape_names = [f"arg{i}_shape{d}" for d in range(rank)]
             stride_names = [f"arg{i}_stride{d}" for d in range(rank)]
             params.extend(f"{name}: cutlass.Int64" for name in shape_names)
@@ -2472,18 +2503,38 @@ def _build_cute_schema_and_args(
     cute_kernel: object,
     args: tuple[object, ...],
     grid: tuple[int, int, int],
+    bake_tensor_shapes: bool = True,
 ) -> tuple[tuple[tuple[object, ...], ...], tuple[object, ...]]:
     gmem_space, make_ptr_obj, current_stream_obj = _get_cute_launcher_imports()
     make_ptr = cast("Any", make_ptr_obj)
     current_stream = cast("Any", current_stream_obj)
     constexpr_flags = _cute_kernel_param_is_constexpr(cute_kernel)
+    # Kernels that emit cute MMA ops (universal matmul fallback or tcgen05
+    # TMA wrapper plans) need runtime tensor layouts: the wrapper's
+    # ``cute.make_tensor`` feeds into ``.mark_layout_dynamic`` (TMA path) or
+    # into in-kernel arithmetic that relies on dynamic shape/stride
+    # propagation (universal MMA SMEM-load guards). Baking literal shapes
+    # silently miscompiles those paths.
+    if bake_tensor_shapes:
+        any_obj = cast("Any", cute_kernel)
+        disable_bake = bool(
+            getattr(any_obj, "_helion_cute_disable_bake_tensor_shapes", False)
+            or getattr(any_obj, "_helion_cute_wrapper_plans", None)
+        )
+        if disable_bake:
+            bake_tensor_shapes = False
     schema: list[tuple[object, ...]] = []
     launch_args: list[object] = []
     for i, arg in enumerate(args):
         if isinstance(arg, torch.Tensor):
             _validate_cute_launcher_tensor(arg)
             ndim = arg.ndim
-            schema.append(("tensor", str(arg.dtype), ndim))
+            if ndim <= 0:
+                raise exc.BackendUnsupported(
+                    "cute", "launcher requires tensor rank >= 1"
+                )
+            sizes_t = tuple(int(arg.size(d)) for d in range(ndim))
+            strides_t = tuple(int(arg.stride(d)) for d in range(ndim))
             launch_args.append(
                 make_ptr(
                     cast("Any", _torch_dtype_to_cutlass(arg.dtype)),
@@ -2492,10 +2543,21 @@ def _build_cute_schema_and_args(
                     assumed_align=16,
                 )
             )
-            sizes = arg.size()
-            strides = arg.stride()
-            launch_args.extend(int(sizes[d]) for d in range(ndim))
-            launch_args.extend(int(strides[d]) for d in range(ndim))
+            # ``cute.make_layout`` rejects a 0 in any shape dimension, so
+            # zero-sized tensors must keep the runtime-shape path.
+            if bake_tensor_shapes and all(s > 0 for s in sizes_t):
+                # Bake the shape / stride tuple into the schema key.  The
+                # generated wrapper substitutes literal Int values for each
+                # dimension, so the CuTe DSL sees a fully static tensor
+                # layout and the per-load offset arithmetic collapses to
+                # constant strides — typically a 2-3x reduction in
+                # ``smsp__inst_executed`` for reduction kernels where the
+                # inner loop is dominated by stride multiplies.
+                schema.append(("tensor", str(arg.dtype), ndim, sizes_t, strides_t))
+            else:
+                schema.append(("tensor", str(arg.dtype), ndim))
+                launch_args.extend(sizes_t)
+                launch_args.extend(strides_t)
             continue
 
         scalar_kind, scalar_value = _normalize_cute_scalar(arg)

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -912,6 +912,43 @@ class TestCuteBackend(TestCase):
         self.assertIn("ir.VectorType.get([4], cutlass.Uint16.mlir_type)", code)
         self.assertIn(".bitcast(cutlass.BFloat16)", code)
 
+    def test_two_pass_load_fusion_shape_b_wide_chunk(self) -> None:
+        """Shape B: V=1 wide-chunk reduction emits a lane loop inside the
+        outer offset loop, and the fuser caches loaded x values across the
+        reduce and consume sweeps."""
+        args = (torch.randn(2, 16384, device=DEVICE, dtype=torch.float32) + 2.0,)
+        code, out = code_and_output(
+            cute_normalize_by_sum,
+            args,
+            block_sizes=[1],
+            reduction_loop=8192,
+        )
+        (x,) = args
+        expected = x / x.sum(-1, keepdim=True)
+        torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+        # The fuser allocates a fragment and rewrites the consume sweep's
+        # load to read from the cache.
+        self.assertIn("cute.make_fragment", code)
+        self.assertIn("_fuse_cache_0", code)
+
+    def test_two_pass_load_fusion_shape_c_vec_unroll(self) -> None:
+        """Shape C: V>1 unroll mode hoists a Uint16 vec load above the
+        constexpr V-loop; the fuser recognises the vec hoist and caches
+        cache_size * V scalar slots across the two sweeps."""
+        args = (torch.randn(2, 16384, device=DEVICE, dtype=torch.bfloat16) + 2.0,)
+        code, out = code_and_output(
+            cute_normalize_by_sum_fp32_cast,
+            args,
+            block_sizes=[1],
+            reduction_loop=8192,
+            cute_vector_widths=[4],
+        )
+        (x,) = args
+        expected = (x.float() / x.float().sum(-1, keepdim=True)).to(x.dtype)
+        torch.testing.assert_close(out, expected, rtol=1e-2, atol=1e-2)
+        self.assertIn("cute.make_fragment", code)
+        self.assertIn("_fuse_cache_0", code)
+
     def test_strided_threaded_block_reduction(self) -> None:
         args = (torch.randn(4, 16, device=DEVICE, dtype=torch.float32),)
         code, out = code_and_output(cute_row_centered, args, block_sizes=[2, 8, 8])


### PR DESCRIPTION

Extend the existing _CuteFuseTwoPassLoads peephole to handle the wide-
chunk reduction shapes the autotuner is now picking:

- Shape B (wide V=1): the lane body is a nested ``for lane_idx ...``
  loop.  The fuser previously bailed on any nested for; now it descends
  into the lane loop body to find the load + cache it.  Cache index is
  ``(outer_iter // step) * lane_trip + lane_var``.

- Shape C (V>1 unroll): the LoopedReductionStrategy in ``unroll`` mode
  hoists a ``cute.arch.load(ptr, ir.VectorType.get([V], Uint16.mlir_type))``
  above the constexpr V-loop.  The fuser recognises the vec hoist,
  allocates a scalar fragment sized ``cache_size * V``, and rewrites the
  consume sweep's hoist + per-lane extracts to read directly from the
  cache (the consume sweep no longer issues a redundant vec load).

Also canonicalises per-sweep variable renames
(``reduction_lane_base_1`` vs ``reduction_lane_base_2``, etc.) so the
two sweeps' load expressions compare equal by text before fusion.

Validation on B200:
- All 88 cute backend + layout tests pass.
- bf16 rms_norm V=1 wide chunk now fuses across the two sweeps (the
  previously emitted scalar wide config used to lose fusion entirely);
  bf16 V>1 unroll keeps fusion too.
- rms_norm bench avg: 1.34x -> 1.37x.  The remaining gap to torch.compile
  comes from the autotuner still preferring the narrow chunk seed at
  these sizes — wide+V configs are correctness-clean and ready to be
  picked once a future seed expansion biases toward them.
