### PR TITLE
Bake tensor shapes/strides as constexpr in the CuTe launcher

### DIFF
--- a/helion/_compiler/cute/matmul_fallback.py
+++ b/helion/_compiler/cute/matmul_fallback.py
@@ -200,6 +200,8 @@ def _emit_cute_matmul(
     rhs_dtype: torch.dtype | None = None,
 ) -> ast.AST:
     """Build a CuTe matmul fallback using a cross-thread reduction over K."""
+    if hasattr(cg, "cute_uses_matmul"):
+        cg.cute_uses_matmul = True  # type: ignore[attr-defined]
     reduction_dtype: torch.dtype | None = acc_dtype or out_dtype
     lhs_terms: tuple[ast.AST, ...]
     if isinstance(lhs, CutePackedAffineLoad):

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -77,6 +77,7 @@ class GenerateAST(NodeVisitor, CodegenInterface):
         self.host_statements: list[ast.AST] = []
         self.module_statements: list[ast.stmt] = []
         self.cute_wrapper_plans: list[dict[str, object]] = []
+        self.cute_uses_matmul: bool = False
         self.statements_stack: list[list[ast.AST]] = [self.host_statements]
         self.on_device = False
         self.active_device_loops: dict[int, list[DeviceLoopOrGridState]] = (
@@ -871,6 +872,13 @@ def generate_ast(
                 else []
             )
             final_host_statements = rng_statements + codegen.host_statements
+            if codegen.cute_uses_matmul or codegen.cute_wrapper_plans:
+                final_host_statements = [
+                    statement_from_string(
+                        f"{codegen.device_function.name}._helion_cute_disable_bake_tensor_shapes = True"
+                    ),
+                    *final_host_statements,
+                ]
             if codegen.cute_wrapper_plans:
                 launcher_arg_positions: dict[str, int] = {}
                 for idx, arg in enumerate(

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -1754,10 +1754,41 @@ def _create_cute_wrapper(
     for i, entry in enumerate(schema_key):
         kind = entry[0]
         if kind == "tensor":
-            (_, _dtype, rank) = entry
-            assert isinstance(rank, int)
             ptr_name = f"arg{i}_ptr"
             params.append(f"{ptr_name}: cute.Pointer")
+            if len(entry) == 5:
+                # ("tensor", dtype, rank, sizes, strides) — baked layout.
+                # Wrapper plans (matmul TMA) also reference
+                # ``arg{i}_shape{d}`` / ``arg{i}_stride{d}`` names, so we
+                # bind those names to their literal values in the wrapper
+                # body before constructing the tensor.
+                (_, _dtype, rank, sizes_t, strides_t) = entry
+                assert isinstance(rank, int)
+                assert isinstance(sizes_t, tuple) and len(sizes_t) == rank
+                assert isinstance(strides_t, tuple) and len(strides_t) == rank
+                shape_literals = [repr(int(s)) for s in sizes_t]
+                stride_literals = [repr(int(s)) for s in strides_t]
+                for d, lit in enumerate(shape_literals):
+                    body.append(f"    arg{i}_shape{d} = {lit}")
+                for d, lit in enumerate(stride_literals):
+                    body.append(f"    arg{i}_stride{d} = {lit}")
+                shape_tuple = (
+                    f"({shape_literals[0]},)"
+                    if rank == 1
+                    else f"({', '.join(shape_literals)})"
+                )
+                stride_tuple = (
+                    f"({stride_literals[0]},)"
+                    if rank == 1
+                    else f"({', '.join(stride_literals)})"
+                )
+                body.append(
+                    f"    arg{i} = cute.make_tensor({ptr_name}, layout=cute.make_layout({shape_tuple}, stride={stride_tuple}))"
+                )
+                call_args.append(f"arg{i}")
+                continue
+            (_, _dtype, rank) = entry
+            assert isinstance(rank, int)
             shape_names = [f"arg{i}_shape{d}" for d in range(rank)]
             stride_names = [f"arg{i}_stride{d}" for d in range(rank)]
             params.extend(f"{name}: cutlass.Int64" for name in shape_names)
@@ -1943,12 +1974,27 @@ def _build_cute_schema_and_args(
     cute_kernel: object,
     args: tuple[object, ...],
     grid: tuple[int, int, int],
+    bake_tensor_shapes: bool = True,
 ) -> tuple[tuple[tuple[object, ...], ...], tuple[object, ...]]:
     gmem_space, make_ptr_obj, current_stream_obj = _get_cute_launcher_imports()
     make_ptr = cast("Any", make_ptr_obj)
     current_stream = cast("Any", current_stream_obj)
     _ensure_cute_dsl_arch_env(args)
     constexpr_flags = _cute_kernel_param_is_constexpr(cute_kernel)
+    # Kernels that emit cute MMA ops (universal matmul fallback or tcgen05
+    # TMA wrapper plans) need runtime tensor layouts: the wrapper's
+    # ``cute.make_tensor`` feeds into ``.mark_layout_dynamic`` (TMA path) or
+    # into in-kernel arithmetic that relies on dynamic shape/stride
+    # propagation (universal MMA SMEM-load guards). Baking literal shapes
+    # silently miscompiles those paths.
+    if bake_tensor_shapes:
+        any_obj = cast("Any", cute_kernel)
+        disable_bake = bool(
+            getattr(any_obj, "_helion_cute_disable_bake_tensor_shapes", False)
+            or getattr(any_obj, "_helion_cute_wrapper_plans", None)
+        )
+        if disable_bake:
+            bake_tensor_shapes = False
     schema: list[tuple[object, ...]] = []
     launch_args: list[object] = []
     for i, arg in enumerate(args):
@@ -1960,7 +2006,8 @@ def _build_cute_schema_and_args(
                 raise exc.BackendUnsupported(
                     "cute", "launcher requires tensor rank >= 1"
                 )
-            schema.append(("tensor", str(arg.dtype), ndim))
+            sizes_t = tuple(int(arg.size(d)) for d in range(ndim))
+            strides_t = tuple(int(arg.stride(d)) for d in range(ndim))
             launch_args.append(
                 make_ptr(
                     cast("Any", _torch_dtype_to_cutlass(arg.dtype)),
@@ -1969,10 +2016,21 @@ def _build_cute_schema_and_args(
                     assumed_align=16,
                 )
             )
-            sizes = arg.size()
-            strides = arg.stride()
-            launch_args.extend(int(sizes[d]) for d in range(ndim))
-            launch_args.extend(int(strides[d]) for d in range(ndim))
+            # ``cute.make_layout`` rejects a 0 in any shape dimension, so
+            # zero-sized tensors must keep the runtime-shape path.
+            if bake_tensor_shapes and all(s > 0 for s in sizes_t):
+                # Bake the shape / stride tuple into the schema key.  The
+                # generated wrapper substitutes literal Int values for each
+                # dimension, so the CuTe DSL sees a fully static tensor
+                # layout and the per-load offset arithmetic collapses to
+                # constant strides — typically a 2-3x reduction in
+                # ``smsp__inst_executed`` for reduction kernels where the
+                # inner loop is dominated by stride multiplies.
+                schema.append(("tensor", str(arg.dtype), ndim, sizes_t, strides_t))
+            else:
+                schema.append(("tensor", str(arg.dtype), ndim))
+                launch_args.extend(sizes_t)
+                launch_args.extend(strides_t)
             continue
 
         scalar_kind, scalar_value = _normalize_cute_scalar(arg)


### PR DESCRIPTION
Stacked PRs:
 * __->__#2549
 * #2548
 * #2547
 * #2546


--- --- ---

### Bake tensor shapes/strides as constexpr in the CuTe launcher


NCU profile showed Helion's bf16 rms_norm running ~63M warp instructions
vs torch.compile's ~23M at N=32768 — a 2.7x instruction ratio, NOT a
bandwidth gap (Helion: 1.15 TB/s, torch.compile: 1.97 TB/s, both on the
same kernel grid). Root cause: the CuTe launcher was passing each
tensor's shape/stride as runtime ``cutlass.Int64`` parameters, so every
``x.iterator + indices_0 * x.layout.stride[0] + rindex_1 *
x.layout.stride[1]`` in the generated kernel compiled to dynamic-stride
multiplies instead of constant-fold-able literals.

Fix: when ``bake_tensor_shapes=True`` (the new default), the launcher
embeds each tensor's sizes/strides directly into the cache schema key
and emits literal Int values in the wrapper instead of runtime params.
The wrapper still defines the ``arg{i}_shape{d}`` / ``arg{i}_stride{d}``
names by binding them to the literals so wrapper plans (matmul TMA) that
reference those names continue to work unchanged.

Validation on B200 (bf16 rms_norm vs ATen):

| size       | baseline (3d8f6938) | after this commit |
|------------|---------------------|-------------------|
| 2048×1024  | 0.34x               | ~0.33-0.51x       |
| 2048×2048  | 0.46x               | ~0.72-0.73x (+58%)|
| 2048×4096  | 0.70x               | ~0.99-1.11x (+50%)|
| 2048×8192  | 1.24x               | ~1.88-1.94x (+52%)|
| 2048×16384 | 2.32x               | ~3.55-3.60x (+53%)|
| 2048×32768 | 3.13x               | ~3.39-3.73x (+12%)|
| avg        | 1.34x               | ~1.86-1.94x (+41%)|

Hand-tuned CuTe rms_norm with static shapes runs at 79us on N=32768;
helion now runs at ~86us (was 113us); torch.compile is 114us.  We're
now FASTER than torch.compile at large N.

All 88 cute backend + layout tests pass.  Pre-existing pyrefly errors in
``helion/runtime/__init__.py`` and ``helion/_compiler/device_function.py``
remain pre-existing; no new pyrefly errors added.
