### PR TITLE
[Pallas] int32 gather lowering

### DIFF
--- a/helion/_compiler/pallas/gather.py
+++ b/helion/_compiler/pallas/gather.py
@@ -1,7 +1,8 @@
 """Pallas indirect-gather lowering.
 
-No native gather in Pallas. ``table[idx]`` emits ``one_hot(idx, V) @ table``.
-Scatter is rejected at plan_tiling time.
+No native gather in Pallas. Floating ``table[idx]`` emits
+``one_hot(idx, V) @ table``; int32 ``table[idx]`` emits a boolean one-hot
+select and reduction. Scatter is rejected at plan_tiling time.
 """
 
 from __future__ import annotations
@@ -30,6 +31,8 @@ class GatherPlan:
     indirect_pos: int
     none_dims: tuple[int, ...]
     jnp_dtype: str
+    table_ndim: int
+    emit_select: bool
     use_highest_precision: bool
 
 
@@ -53,9 +56,11 @@ def build_gather_plan(
         raise NotImplementedError(
             "Pallas gather: only dim-0 indirect indexing is supported"
         )
-    if not tensor.dtype.is_floating_point:
+    emit_select = not tensor.dtype.is_floating_point
+    if emit_select and tensor.dtype != torch.int32:
         raise NotImplementedError(
-            f"Pallas gather: table must be floating point, got {tensor.dtype}"
+            f"Pallas gather: integer table gather only supports torch.int32, "
+            f"got {tensor.dtype}"
         )
 
     elements = resident_block_elements(tensor, patterns, config)
@@ -79,6 +84,8 @@ def build_gather_plan(
         indirect_pos=indirect_pos,
         none_dims=none_dims,
         jnp_dtype=jnp_dtype,
+        table_ndim=tensor.ndim,
+        emit_select=emit_select,
         use_highest_precision=use_highest,
     )
 
@@ -101,6 +108,23 @@ def emit_gather(
     ast_idx = ast_subscripts[plan.indirect_pos]
     assert isinstance(ast_idx, ast.AST)
     idx_name = state.codegen.lift(ast_idx, dce=False, prefix="index").id
+
+    if plan.emit_select:
+        mask_expr = (
+            f"jax.nn.one_hot({idx_name}[...], {name}.shape[0], dtype={plan.jnp_dtype})"
+        )
+        for _ in range(plan.table_ndim - 1):
+            mask_expr = f"jnp.expand_dims({mask_expr}, axis=-1)"
+        result = expr_from_string(
+            f"jnp.sum({name}[...] * {mask_expr}, "
+            f"axis=jnp.ndim({idx_name}[...])"
+            f").astype({plan.jnp_dtype})"
+        )
+        for dim in plan.none_dims:
+            result = expr_from_string(
+                f"jnp.expand_dims({{result}}, axis={dim})", result=result
+            )
+        return result
 
     if plan.use_highest_precision:
         oh_dtype = "jnp.float32"

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1614,13 +1614,35 @@ class TestExamples(RefEagerTestBase, TestCase):
             num_stages=3,
         )
 
-    @xfailIfPallas("BackendError on pallas")
+    @xfailIfPallas("Pallas f32 dot uses default TPU precision")
     @skipIfXPU("Timeout on XPU")
     def test_gather_gemv(self):
         args = (
             torch.randn([4, 512, 512], device=DEVICE, dtype=torch.float32),
             torch.randint(0, 4, [2], device=DEVICE, dtype=torch.int32),
             torch.randn([512], device=DEVICE, dtype=torch.float32),
+        )
+
+        def expected(w, idx, x):
+            return w[idx].to(x.dtype) @ x
+
+        check_example(
+            "gather_gemv",
+            args,
+            expected(*args),
+            fn_name="gather_gemv",
+            emit_code=False,
+            block_sizes=[16, 16],
+            num_warps=8,
+            num_stages=1,
+        )
+
+    @skipIfXPU("Timeout on XPU")
+    def test_gather_gemv_half(self):
+        args = (
+            torch.randn([4, 512, 512], device=DEVICE, dtype=HALF_DTYPE),
+            torch.randint(0, 4, [2], device=DEVICE, dtype=torch.int32),
+            torch.randn([512], device=DEVICE, dtype=HALF_DTYPE),
         )
 
         def expected(w, idx, x):

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1614,13 +1614,11 @@ class TestExamples(RefEagerTestBase, TestCase):
             num_stages=3,
         )
 
-    @xfailIfPallas("Pallas f32 dot uses default TPU precision")
-    @skipIfXPU("Timeout on XPU")
-    def test_gather_gemv(self):
+    def _check_gather_gemv(self, dtype: torch.dtype):
         args = (
-            torch.randn([4, 512, 512], device=DEVICE, dtype=torch.float32),
+            torch.randn([4, 512, 512], device=DEVICE, dtype=dtype),
             torch.randint(0, 4, [2], device=DEVICE, dtype=torch.int32),
-            torch.randn([512], device=DEVICE, dtype=torch.float32),
+            torch.randn([512], device=DEVICE, dtype=dtype),
         )
 
         def expected(w, idx, x):
@@ -1636,28 +1634,16 @@ class TestExamples(RefEagerTestBase, TestCase):
             num_warps=8,
             num_stages=1,
         )
+
+    # Pallas f32 succeeds under CPU emulation but fails on TPU.
+    @skipIfPallas("Pallas int32 gather coverage uses test_gather_gemv_half")
+    @skipIfXPU("Timeout on XPU")
+    def test_gather_gemv(self):
+        self._check_gather_gemv(torch.float32)
 
     @skipIfXPU("Timeout on XPU")
     def test_gather_gemv_half(self):
-        args = (
-            torch.randn([4, 512, 512], device=DEVICE, dtype=HALF_DTYPE),
-            torch.randint(0, 4, [2], device=DEVICE, dtype=torch.int32),
-            torch.randn([512], device=DEVICE, dtype=HALF_DTYPE),
-        )
-
-        def expected(w, idx, x):
-            return w[idx].to(x.dtype) @ x
-
-        check_example(
-            "gather_gemv",
-            args,
-            expected(*args),
-            fn_name="gather_gemv",
-            emit_code=False,
-            block_sizes=[16, 16],
-            num_warps=8,
-            num_stages=1,
-        )
+        self._check_gather_gemv(HALF_DTYPE)
 
     @xfailIfCute("CuTe int4 GEMM example is not supported yet")
     @xfailIfPallas("int4 unpacking not supported on pallas")

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -2890,6 +2890,49 @@ class TestPallasIndirectGather(TestCase):
         torch.testing.assert_close(result, ref)
 
     @parametrize("static_shapes", (True, False))
+    def test_gather_int32_5d_table_broadcasts_mask(self, static_shapes: bool) -> None:
+        """Gather on higher-rank int32 tables broadcasts the select mask."""
+
+        @helion.kernel(backend="pallas", static_shapes=static_shapes)
+        def gather(indices: torch.Tensor, table: torch.Tensor) -> torch.Tensor:
+            out = torch.empty(
+                [
+                    indices.size(0),
+                    table.size(1),
+                    table.size(2),
+                    table.size(3),
+                    table.size(4),
+                ],
+                dtype=table.dtype,
+                device=table.device,
+            )
+            for tile_b, tile_i, tile_j, tile_k, tile_l in hl.tile(
+                [
+                    indices.size(0),
+                    table.size(1),
+                    table.size(2),
+                    table.size(3),
+                    table.size(4),
+                ]
+            ):
+                out[tile_b, tile_i, tile_j, tile_k, tile_l] = table[
+                    indices[tile_b], tile_i, tile_j, tile_k, tile_l
+                ]
+            return out
+
+        table = torch.randint(0, 100, (8, 2, 4, 4, 8), device=DEVICE, dtype=torch.int32)
+        indices = torch.randint(0, 8, (8,), device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(
+            gather,
+            (indices, table),
+            block_sizes=[8, 2, 4, 4, 8],
+        )
+        self.assertEqual(code.count("expand_dims"), 4)
+        self.assertNotIn("dot_general", code)
+        ref = table.cpu()[indices.long().cpu()].to(device=DEVICE)
+        torch.testing.assert_close(result, ref)
+
+    @parametrize("static_shapes", (True, False))
     def test_scatter_raises(self, static_shapes: bool) -> None:
         """Indirect store has no Pallas strategy; plan_tiling must raise."""
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -2877,13 +2877,17 @@ class TestPallasIndirectGather(TestCase):
         code_and_output(gather, (indices, table), block_sizes=[128, 256])
 
     @parametrize("static_shapes", (True, False))
-    def test_gather_integer_table_rejected(self, static_shapes: bool) -> None:
-        """Gather on non-floating tables raises at plan time."""
+    def test_gather_int32_table_uses_select_reduce(self, static_shapes: bool) -> None:
+        """Gather on int32 tables uses select-reduce instead of dot."""
         gather = self._gather_2d_kernel(static_shapes=static_shapes)
         table = torch.randint(0, 100, (16, 64), device=DEVICE, dtype=torch.int32)
         indices = torch.randint(0, 16, (256,), device=DEVICE, dtype=torch.int32)
-        with self.assertRaisesRegex(Exception, "must be floating point"):
-            code_and_output(gather, (indices, table), block_sizes=[128, 64])
+        code, result = code_and_output(gather, (indices, table), block_sizes=[128, 64])
+        self.assertIn("one_hot", code)
+        self.assertIn("dtype=jnp.int32", code)
+        self.assertNotIn("dot_general", code)
+        ref = table.cpu()[indices.long().cpu()].to(device=DEVICE)
+        torch.testing.assert_close(result, ref)
 
     @parametrize("static_shapes", (True, False))
     def test_scatter_raises(self, static_shapes: bool) -> None:


### PR DESCRIPTION
We emit gather as onehot for float dtypes, but we don't have the right matmul for int dtypes. 

Instead, we can use a similar idea, but with a select+reduction:

```
mask = jax.nn.one_hot(index, table.shape[0], dtype=jnp.int32)
mask = jnp.expand_dims(mask, axis=-1)
result = jnp.sum(table * mask, axis=jnp.ndim(index)).astype(jnp.int32)
```