### PR TITLE
[Pallas] Fix mask broadcast on size-1 tensor dimensions

### DIFF
--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -87,7 +87,13 @@ def _load_mask_expr(
 
         if isinstance(pattern, TilePattern):
             block_id = pattern.block_id
-            if _tile_needs_mask(state, block_id, tensor, tensor_dim):
+            # Skip masking for size-1 (broadcast) dims: a single element is
+            # always valid, and applying a block-sized mask would broadcast
+            # the dim from 1 to block_size, causing shape mismatches.
+            dim_size = tensor.shape[tensor_dim]
+            if (not isinstance(dim_size, int) or dim_size > 1) and _tile_needs_mask(
+                state, block_id, tensor, tensor_dim
+            ):
                 mask_var = state.codegen.mask_var(block_id)
                 if mask_var is not None:
                     if dtype_str is None:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -2810,6 +2810,58 @@ class TestPallas(TestCase):
         self.assertTrue(torch.all(result >= x))
         self.assertTrue(torch.all(result < x + 1.0))
 
+    def test_broadcast_mask_size1_first_dim(self) -> None:
+        """Mask must not be applied to size-1 broadcast dims (first dim)."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def k(x: torch.Tensor, bias: torch.Tensor) -> torch.Tensor:
+            out = torch.empty(
+                [x.size(0), bias.size(0)],
+                device=x.device,
+                dtype=x.dtype,
+            )
+            for tile_m, tile_n in hl.tile(out.size()):
+                out[tile_m, tile_n] = x[tile_m, tile_n] + bias[tile_n]
+            return out
+
+        x = torch.randn(1, 10, device=DEVICE, dtype=torch.float32)
+        bias = torch.randn(10, device=DEVICE, dtype=torch.float32)
+        _, result = code_and_output(k, (x, bias), block_sizes=[16, 16])
+        expected = x + bias
+        torch.testing.assert_close(result, expected)
+
+    def test_broadcast_mask_size1_last_dim(self) -> None:
+        """Mask must not be applied to size-1 broadcast dims (last dim)."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def k(x: torch.Tensor, bias: torch.Tensor, out: torch.Tensor) -> None:
+            for tile_m, tile_n in hl.tile(out.size()):
+                out[tile_m, tile_n] = x[tile_m, tile_n] + bias[tile_n]
+
+        x = torch.randn(10, 1, device=DEVICE, dtype=torch.float32)
+        bias = torch.randn(10, device=DEVICE, dtype=torch.float32)
+        out = torch.zeros(10, 10, device=DEVICE, dtype=torch.float32)
+        code, _result = code_and_output(k, (x, bias, out), block_sizes=[16, 16])
+        expected = x + bias[None, :]
+        torch.testing.assert_close(out, expected)
+
+    def test_broadcast_mask_size1_multiple_dims(self) -> None:
+        """Mask must not be applied to size-1 broadcast dims (multiple dims)."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def k(x: torch.Tensor, bias: torch.Tensor, out: torch.Tensor) -> None:
+            for tile_0, tile_1, tile_2 in hl.tile(out.size()):
+                tmp0 = x[tile_0, tile_1, tile_2]
+                tmp1 = bias[tile_2].unsqueeze(0).unsqueeze(0)
+                out[tile_0, tile_1, tile_2] = tmp0 + tmp1.to(torch.float32)
+
+        x = torch.randn(1, 10, 1, device=DEVICE, dtype=torch.float32)
+        bias = torch.arange(10, device=DEVICE, dtype=torch.int32)
+        out = torch.zeros(1, 10, 10, device=DEVICE, dtype=torch.float32)
+        code, _result = code_and_output(k, (x, bias, out), block_sizes=[1, 16, 16])
+        expected = x + bias.float()
+        torch.testing.assert_close(out, expected)
+
 
 @skipUnlessPallas("JAX/Pallas TPU not available")
 class TestPallasIndirectGather(TestCase):


### PR DESCRIPTION

When a tensor has a size-1 dimension that is tiled alongside a larger
output dimension, the Pallas codegen would generate a mask multiplication
like `tensor[:,:,:] * mask[None, None, :]`. Because the mask has shape
(BLOCK_SIZE,) and the tensor's corresponding dim is 1, NumPy/JAX
broadcasting rules expand the tensor from (1) to (BLOCK_SIZE) in that
dimension. This produces a shape that no longer matches other operands,
causing "incompatible shapes for broadcasting" errors.

For example, with `in_ptr0` of shape (1, 10, 1) and output (1, 10, 10):
- block_shape = (1, 16, 16)
- Pallas loads block: (1, 10, 1)
- mask_2 = indices_2 < 10, shape (16,)
- `in_ptr0[:,:,:] * mask_2[None,None,:]` broadcasts (1,10,1)*(1,1,16)
  to (1,10,16) -- wrong shape, should stay (1,10,1)

The fix: skip mask application when a dimension's size is statically
known to be 1. A singleton dimension cannot be out of bounds (index 0
is always valid), and the mask would only corrupt the shape via
broadcast. For symbolic (non-integer) dim sizes, the mask is still
applied conservatively.

Authored with the help of an AI assistant.