### PR TITLE
Speed up Helion kernel launches by avoiding repeated Python work

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -970,7 +970,17 @@ class TritonBackend(Backend):
             f"tl.full([{', '.join(shape_dims)}], {value_expr}, {self.dtype_str(dtype)})"
         )
 
-    def launcher_keyword_args(self, config: Config, *, has_barrier: bool) -> list[str]:
+    def launcher_runtime_kwargs(
+        self, config: Config, *, has_barrier: bool
+    ) -> dict[str, object]:
+        """Return the launcher kwargs as a ``dict`` of runtime values.
+
+        Used by both :meth:`launcher_keyword_args` (which formats the dict
+        as source strings for codegen) and
+        :func:`helion.runtime.build_fast_launcher` (which bakes the dict
+        into a closure at :meth:`BoundKernel.set_config` time so the hot
+        launch path doesn't have to allocate a per-call kwargs dict).
+        """
         from .._compat import supports_maxnreg
 
         # Workaround for triton bug: warp_specialize requires at least 4 warps
@@ -979,31 +989,45 @@ class TritonBackend(Backend):
         if any(config.range_warp_specializes):
             num_warps = max(4, num_warps)
 
-        args = [
-            f"num_warps={num_warps}",
-            f"num_stages={config.num_stages}",
-            *(["launch_cooperative_grid=True"] if has_barrier else []),
-        ] + [
-            f"{x.removeprefix('_triton_config_')}={config[x]}"
-            for x in config
-            if x.startswith("_triton_config_")
-        ]
+        kwargs: dict[str, object] = {
+            "num_warps": num_warps,
+            "num_stages": config.num_stages,
+        }
+        if has_barrier:
+            kwargs["launch_cooperative_grid"] = True
+        for x in config:
+            if x.startswith("_triton_config_"):
+                kwargs[x.removeprefix("_triton_config_")] = config[x]
 
         from ..autotuner.config_spec import _get_backend_tunable_keys
 
         for key in _get_backend_tunable_keys():
             if key in config:
-                args.append(f"{key}={config[key]!r}")
+                kwargs[key] = config[key]
 
         if "maxnreg" in config and config["maxnreg"] is not None and supports_maxnreg():
-            args.append(f"maxnreg={config['maxnreg']}")
+            kwargs["maxnreg"] = config["maxnreg"]
 
         advanced_controls_file = config.advanced_controls_file
         if advanced_controls_file:
-            ptx_option = f"--apply-controls {advanced_controls_file}"
-            args.append(f"ptx_options={ptx_option!r}")
+            kwargs["ptx_options"] = f"--apply-controls {advanced_controls_file}"
 
-        return args
+        return kwargs
+
+    def launcher_keyword_args(self, config: Config, *, has_barrier: bool) -> list[str]:
+        from ..autotuner.config_spec import _get_backend_tunable_keys
+
+        backend_tunable_keys = _get_backend_tunable_keys()
+        kwargs = self.launcher_runtime_kwargs(config, has_barrier=has_barrier)
+        # Backend tunable keys (typically strings) and ptx_options use repr;
+        # everything else (num_warps, num_stages, ints, bools) renders plain.
+        out: list[str] = []
+        for k, v in kwargs.items():
+            if k in backend_tunable_keys or k == "ptx_options":
+                out.append(f"{k}={v!r}")
+            else:
+                out.append(f"{k}={v}")
+        return out
 
     def grid_barrier_stmt(self, sem_arg: str) -> str:
         return f"triton_helpers.x_grid_barrier({sem_arg})"

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -7,6 +7,7 @@ import inspect
 import linecache
 import os
 import sys
+import threading
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
@@ -179,6 +180,494 @@ def default_launcher(
         if "Cannot make_shape_compatible: incompatible dimensions" in message:
             raise exc.ShapeMismatch("kernel operands", message) from error
         raise
+
+
+class _FastLauncher:
+    """Fast launcher that bypasses Triton's ``JITFunction.run`` Python frame.
+
+    On the first call this lazily JIT-compiles the underlying Triton kernel
+    (via ``triton_kernel.run(..., warmup=True)``), captures the resulting
+    ``CompiledKernel``, its packed metadata, the launch-hook callables, the
+    active driver/device, and the binder. Subsequent calls dispatch straight
+    into the C launcher Triton generates, skipping ``JITFunction.run``'s
+    cache lookup, ``compute_cache_key`` call, and per-call kwargs dict
+    construction.
+
+    The closure bakes in ``num_warps`` / ``num_stages`` /
+    ``launch_cooperative_grid`` / ``ptx_options`` so no per-call dict is
+    allocated on the hot path; it also caches a precomputed ``run_kwargs``
+    dict to pass to the binder on each call so that path stays Python-cheap
+    too.
+
+    If anything goes wrong while priming (e.g. an unsupported Triton
+    version, an alternative backend that doesn't expose
+    ``CompiledKernel.run``), the launcher transparently falls back to
+    :func:`default_launcher` so the kernel still runs.
+    """
+
+    __slots__ = (
+        "_active_driver",
+        "_binder",
+        "_bind_skip_safe",
+        "_compiled_kernel",
+        "_compiled_run",
+        "_device",
+        "_get_current_stream",
+        "_kernel_launch_metadata",
+        "_knobs_compilation",
+        "_knobs_runtime",
+        "_launch_cooperative_grid",
+        "_num_warps",
+        "_num_stages",
+        "_packed_metadata",
+        "_prime_lock",
+        "_primed",
+        "_priming_spec",
+        "_ptx_options",
+        "_run_kwargs",
+        "_triton_function",
+        "_used_global_checks",
+    )
+
+    def __init__(
+        self,
+        *,
+        num_warps: int,
+        num_stages: int,
+        launch_cooperative_grid: bool = False,
+        ptx_options: str | None = None,
+        extra_kwargs: dict | None = None,
+    ) -> None:
+        self._num_warps = num_warps
+        self._num_stages = num_stages
+        self._launch_cooperative_grid = launch_cooperative_grid
+        self._ptx_options = ptx_options
+        # Pre-built kwargs dict for the priming warmup AND the fallback path
+        # AND every binder() invocation. Stored once so the hot path doesn't
+        # have to build a fresh kwargs dict per launch.
+        run_kwargs: dict = {
+            "num_warps": num_warps,
+            "num_stages": num_stages,
+            "launch_cooperative_grid": launch_cooperative_grid,
+        }
+        if extra_kwargs:
+            run_kwargs.update(extra_kwargs)
+        if ptx_options is not None:
+            run_kwargs["ptx_options"] = ptx_options
+        self._run_kwargs = run_kwargs
+
+        # Serializes the first-call priming. Without this, two threads
+        # making their first call simultaneously can both pass the
+        # ``if not self._primed`` check and both enter ``_prime``, then
+        # interleave their attribute writes — leaving the launcher with
+        # (e.g.) thread A's ``_compiled_run`` paired with thread B's
+        # ``_triton_function``. We use the double-checked locking
+        # pattern: the ``_primed`` boolean is the fast-path check; the
+        # lock just guards the priming critical section.
+        self._prime_lock = threading.Lock()
+        # Lazy fields, set by _prime() on the first call.
+        self._primed = False
+        self._compiled_kernel: object = None
+        self._compiled_run: Callable[..., object] | None = None
+        self._triton_function: object = None
+        self._packed_metadata: object = None
+        self._kernel_launch_metadata: Callable[..., object] | None = None
+        self._active_driver: object = None
+        self._device: object = None
+        self._get_current_stream: Callable[[object], object] | None = None
+        self._binder: Callable[..., tuple] | None = None
+        # True if priming proved that ``bound_args.values() == args`` for
+        # this kernel — i.e. all kernel parameters map 1:1 onto positional
+        # args, so we can avoid materializing ``tuple(bound_args.values())``
+        # in the hot path. This holds for typical Helion kernels because
+        # Helion inlines constexpr block-sizes as module-level constants
+        # rather than passing them as Triton parameters.
+        self._bind_skip_safe = False
+        # Triton specialization captured at priming time. The hot path
+        # recomputes the spec via the binder and compares; on mismatch
+        # (e.g. caller passed an unaligned-pointer tensor where priming
+        # got a 16-byte-aligned one) we fall back to ``default_launcher``
+        # so Triton's per-spec ``kernel_cache`` is consulted. The
+        # priming-time binary is only safe for the priming spec.
+        self._priming_spec: object = None
+        # Cached references to Triton's knob namespaces, captured at
+        # priming. The hot path checks these per-call so we can fall
+        # back to ``default_launcher`` if a user enables debug,
+        # instrumentation, or stages-inspection knobs *after* priming
+        # — those affect Triton's compilation pipeline and our cached
+        # binary would otherwise silently bypass them.
+        self._knobs_runtime: object = None
+        self._knobs_compilation: object = None
+        # Snapshot of ``triton_kernel.used_global_vals`` at priming:
+        # tuple of ``(globals_dict, name, compile_time_value)``. Per-call
+        # we verify ``globals_dict.get(name) == compile_time_value`` for
+        # each entry — this is the same invariant ``JITFunction.run``
+        # uses to invalidate cached binaries when a module-level global
+        # referenced by the kernel was reassigned between launches.
+        # Helion-generated kernels' globals (``_BLOCK_SIZE_*``, etc.)
+        # are codegen-time constants that don't mutate, so this check
+        # passes cheaply on the common path. Empty tuple ⇒ no entries
+        # at priming, skip the iteration entirely.
+        self._used_global_checks: tuple[tuple[dict, str, object], ...] = ()
+
+    def _prime(
+        self, triton_kernel: object, grid: tuple[int, ...], args: tuple[object, ...]
+    ) -> None:
+        """Capture the cached ``CompiledKernel`` and dispatch state.
+
+        Called once on the first invocation, under ``self._prime_lock``.
+        After this returns successfully, :meth:`__call__` dispatches
+        via :attr:`_compiled_run` (the C launcher Triton's
+        ``make_launcher`` emits). On any failure we set
+        ``_compiled_run=None`` so subsequent calls fall through to
+        :func:`default_launcher`. ``_primed=True`` is set last via the
+        outer ``finally`` so any caller waiting on the prime lock sees
+        either fully-published state or a clean ``_compiled_run=None``
+        sentinel — never a half-written mix.
+        """
+        try:
+            try:
+                import triton
+                from triton.runtime.driver import driver
+            except ImportError:
+                self._compiled_run = None
+                return
+
+            try:
+                warmup_kwargs = {**self._run_kwargs, "grid": grid, "warmup": True}
+                # pyrefly: ignore[missing-attribute]
+                compiled_kernel = triton_kernel.run(*args, **warmup_kwargs)
+                if compiled_kernel is None:
+                    self._compiled_run = None
+                    return
+
+                active_driver = driver.active
+                # pyrefly: ignore[missing-attribute]
+                device = active_driver.get_current_device()
+                # device_caches[device] = (kernel_cache, kernel_key_cache,
+                #                          target, backend, binder)
+                # pyrefly: ignore[missing-attribute]
+                device_cache = triton_kernel.device_caches[device]
+                binder = device_cache[4]
+
+                # Probe: do bound_args.values() == args? If yes, we can pass
+                # ``args`` straight to the C launcher without materializing
+                # ``tuple(bound_args.values())`` on the hot path. We must
+                # still invoke the binder on each call to recompute the
+                # specialization (alignment / scalar values / etc.), but the
+                # ``bound_args`` mapping itself is wasteful to flatten when
+                # we know it matches ``args``.
+                #
+                # We also capture the priming spec here. The hot path
+                # compares each call's spec to this value: matching specs
+                # use the captured compiled kernel; mismatched specs fall
+                # back to ``default_launcher`` (which routes through
+                # Triton's per-spec ``kernel_cache``).
+                priming_spec: object = None
+                try:
+                    bound_args, priming_spec, _opts = binder(*args, **self._run_kwargs)
+                    bound_values = tuple(bound_args.values())
+                    self._bind_skip_safe = len(bound_values) == len(args) and all(
+                        b is a for b, a in zip(bound_values, args, strict=True)
+                    )
+                except Exception:
+                    self._bind_skip_safe = False
+                    priming_spec = None
+                self._priming_spec = priming_spec
+
+                # Read every dependent value from ``compiled_kernel`` /
+                # ``active_driver`` BEFORE publishing ``_compiled_run``.
+                # The hot path uses ``_compiled_run is not None`` as the
+                # "fully primed" signal under the GIL; once it observes
+                # a non-None value it dereferences ``_triton_function``,
+                # ``_get_current_stream`` etc. without further sync.
+                #
+                # ``CompiledKernel.run`` is a property that lazily calls
+                # ``_init_handles()`` — this is what populates
+                # ``compiled_kernel.function`` etc. Read it FIRST so the
+                # subsequent attribute reads see populated values.
+                run_fn = compiled_kernel.run
+                triton_function = compiled_kernel.function
+                packed_metadata = compiled_kernel.packed_metadata
+                kernel_launch_metadata = compiled_kernel.launch_metadata
+                # pyrefly: ignore[missing-attribute]
+                get_current_stream = active_driver.get_current_stream
+
+                self._compiled_kernel = compiled_kernel
+                self._triton_function = triton_function
+                self._packed_metadata = packed_metadata
+                self._kernel_launch_metadata = kernel_launch_metadata
+                self._active_driver = active_driver
+                self._device = device
+                self._get_current_stream = get_current_stream
+                self._binder = binder
+                self._knobs_runtime = triton.knobs.runtime
+                self._knobs_compilation = triton.knobs.compilation
+                # Snapshot used_global_vals once for the per-call mutation
+                # check. Triton stores entries as
+                #   {(name, id(gdict)): (compile_value, gdict)}
+                # We flatten to ``(gdict, name, compile_value)`` tuples
+                # so the hot path needs only a dict lookup + equality
+                # compare per entry — no item-iteration on the live dict.
+                ugv = getattr(triton_kernel, "used_global_vals", None)
+                if ugv:
+                    self._used_global_checks = tuple(
+                        (gdict, name, compile_value)
+                        for (name, _gid), (compile_value, gdict) in ugv.items()
+                    )
+                # We do NOT cache ``launch_enter_hook`` /
+                # ``launch_exit_hook`` here: a profiler may install
+                # them *after* priming, and the captured snapshot would
+                # be stale. The hot path reads them from
+                # ``self._knobs_runtime`` per call instead.
+                # Publish last — this is the visibility flag for the
+                # hot path.
+                self._compiled_run = run_fn
+            except Exception:
+                # Any priming failure → leave _compiled_run None so the
+                # __call__ path falls back to default_launcher.
+                self._compiled_run = None
+        finally:
+            # Mark primed AFTER all writes are visible. Combined with
+            # the outer prime_lock in ``__call__``, this guarantees
+            # any thread that observes ``_primed=True`` sees either a
+            # fully-published launcher or ``_compiled_run=None``.
+            self._primed = True
+
+    def __call__(
+        self,
+        triton_kernel: object,
+        grid: tuple[int, ...],
+        *args: object,
+        # Spell out the kwargs the generated wrapper always passes so
+        # CPython binds them positionally into local slots rather than
+        # packing them into a per-call **kwargs dict. The closure already
+        # has the runtime values baked in; these parameter names exist
+        # solely to absorb the wrapper's keyword arguments cheaply, and
+        # are otherwise unused.
+        num_warps: int | None = None,
+        num_stages: int | None = None,
+        launch_cooperative_grid: bool = False,
+        **kwargs: object,
+    ) -> object:
+        # Under torch.compile / Dynamo tracing, defer to ``default_launcher``
+        # which routes through ``triton_kernel.run`` and is captured by
+        # Dynamo's ``triton_kernel_wrapper_mutation`` HOP handler.
+        #
+        # The fast path calls ``_cuda_getCurrentRawStream`` directly. Dynamo
+        # has that symbol in its in-graph allowlist
+        # (``torch_c_binding_in_graph_functions``), so tracing it produces a
+        # graph node whose example_value is ``int``, which trips Dynamo's
+        # "torch.* op returned non-Tensor" check and aborts the trace.
+        #
+        # On PyTorch builds where Helion's own HOP is registered (see
+        # ``supports_torch_compile_fusion`` in ``helion/_compat.py``), the
+        # kernel call is intercepted at the ``HelionKernelVariable`` level
+        # and ``_FastLauncher.__call__`` is never reached during tracing —
+        # this guard is a no-op on those builds. It only fires on
+        # builds/configs where the HOP isn't available (e.g. PyTorch < 2.11
+        # or XPU) and Dynamo falls through to trace the launcher.
+        if torch.compiler.is_compiling():
+            return default_launcher(
+                triton_kernel,
+                grid,
+                *args,
+                **self._run_kwargs,
+            )
+
+        if not self._primed:
+            # Double-checked locking: the unsynchronized read above is
+            # the fast path; the lock-guarded re-check below serializes
+            # concurrent first calls so only one thread runs ``_prime``.
+            with self._prime_lock:
+                if not self._primed:
+                    self._prime(triton_kernel, grid, args)
+
+        compiled_run = self._compiled_run
+        if compiled_run is None:
+            # Fall back to Triton's Python launcher. Forward the full
+            # ``_run_kwargs`` mapping so any backend tunable / ``maxnreg`` /
+            # ``_triton_config_*`` keys baked in at ``build_fast_launcher``
+            # time also reach ``default_launcher`` — keeping behavior
+            # consistent with the captured config when priming fails.
+            return default_launcher(
+                triton_kernel,
+                grid,
+                *args,
+                **self._run_kwargs,
+            )
+
+        # The compiled kernel, stream getter, and ``_device`` were
+        # captured against the device active at priming time. If the
+        # caller switched CUDA devices (e.g. ``with torch.cuda.device(1)``
+        # after the first call ran on ``cuda:0``), our cached stream
+        # would belong to the priming device and the launch would hit
+        # ``invalid resource handle``. Route those off-device calls
+        # through ``default_launcher`` which dispatches via Triton's
+        # per-device ``device_caches``.
+        if (
+            self._active_driver is not None
+            # pyrefly: ignore[missing-attribute]
+            and self._active_driver.get_current_device() != self._device
+        ):
+            return default_launcher(
+                triton_kernel,
+                grid,
+                *args,
+                **self._run_kwargs,
+            )
+
+        # ``JITFunction.run`` honors several pieces of mutable Triton
+        # state on every call: ``self.pre_run_hooks`` (a list anyone can
+        # ``.append()`` to after priming, e.g. autotune timing hooks),
+        # ``knobs.runtime.debug`` / ``knobs.compilation.instrumentation_mode``
+        # (flip debug or instrumentation modes that change codegen),
+        # and ``knobs.runtime.add_stages_inspection_hook`` (augments
+        # specialization, so the cached binary's key no longer matches).
+        # The cached binary plus the direct C-launcher invocation we
+        # use below bypass all of this. If any of these knobs/hooks are
+        # active, route through ``default_launcher`` so the Python
+        # launcher's bookkeeping runs and the right kernel is picked.
+        # In the default-knobs case these are cheap attribute reads on
+        # already-resolved cached namespaces.
+        knobs_runtime = self._knobs_runtime
+        knobs_compilation = self._knobs_compilation
+        # pyrefly: ignore[missing-attribute]
+        if (
+            # Direct attribute access — JITFunction always sets
+            # ``pre_run_hooks`` on construction (jit.py:804), so we
+            # don't pay for ``getattr``'s fallback machinery.
+            triton_kernel.pre_run_hooks  # pyrefly: ignore[missing-attribute]
+            or knobs_runtime.debug
+            # pyrefly: ignore[missing-attribute]
+            or knobs_compilation.instrumentation_mode
+            # pyrefly: ignore[missing-attribute]
+            or knobs_runtime.add_stages_inspection_hook is not None
+        ):
+            return default_launcher(
+                triton_kernel,
+                grid,
+                *args,
+                **self._run_kwargs,
+            )
+
+        # ``used_global_vals`` is the per-launch global-mutation check
+        # Triton does. The dict is almost always non-empty for
+        # Helion-generated kernels (it tracks codegen constants like
+        # ``_BLOCK_SIZE_*``), so a simple truthiness check would always
+        # fall back. Instead we did a per-entry snapshot at priming and
+        # verify the underlying globals haven't been reassigned —
+        # exactly the semantic Triton uses.
+        for gdict, name, expected in self._used_global_checks:
+            if gdict.get(name) != expected:
+                return default_launcher(
+                    triton_kernel,
+                    grid,
+                    *args,
+                    **self._run_kwargs,
+                )
+
+        # Hot path — no dict allocation, no Python-level Triton run frame.
+        try:
+            # Always invoke the binder so we can compare the current
+            # call's Triton specialization to the one captured at
+            # priming time. Triton's ``_spec`` encodes per-arg facts
+            # like pointer 16-byte alignment and scalar zero/one
+            # detection — facts that affect codegen (vectorized loads,
+            # divide-by-constant). The compiled binary we cached is
+            # only safe for the priming spec; for any other spec the
+            # binary may, e.g., issue a 128-bit load against a 4-byte
+            # aligned pointer → CUDA ``misaligned address``.
+            #
+            # On mismatch, route through ``default_launcher`` so
+            # Triton's per-spec ``kernel_cache`` lookup picks (or
+            # compiles) the right binary for the current spec.
+            # pyrefly: ignore[not-callable]
+            bound_args, spec, _opts = self._binder(*args, **self._run_kwargs)
+            if spec != self._priming_spec:
+                return default_launcher(
+                    triton_kernel,
+                    grid,
+                    *args,
+                    **self._run_kwargs,
+                )
+            if self._bind_skip_safe:
+                kernel_args = args
+            else:
+                kernel_args = tuple(bound_args.values())
+
+            grid_size = len(grid)
+            grid_0 = grid[0]
+            grid_1 = grid[1] if grid_size > 1 else 1
+            grid_2 = grid[2] if grid_size > 2 else 1
+            # pyrefly: ignore[not-callable]
+            stream = self._get_current_stream(self._device)
+            # Re-read launch hooks from Triton's knobs every call.
+            # ``JITFunction.run`` consults the live
+            # ``knobs.runtime.launch_*_hook`` references on each
+            # launch, so a profiler attaching its hook *after* the
+            # first call must still see its callback fire. Snapshotting
+            # at priming would silently drop those hooks.
+            #
+            # Skip ``launch_metadata`` when no profiler hooks are
+            # active. Probe identity / calls list directly: older
+            # Triton uses ``None``, newer Triton uses ``HookChain`` (no
+            # ``__bool__``).
+            # pyrefly: ignore[missing-attribute]
+            enter_hook = knobs_runtime.launch_enter_hook
+            # pyrefly: ignore[missing-attribute]
+            exit_hook = knobs_runtime.launch_exit_hook
+            if (enter_hook is None or getattr(enter_hook, "calls", None) == []) and (
+                exit_hook is None or getattr(exit_hook, "calls", None) == []
+            ):
+                launch_metadata = None
+            else:
+                # pyrefly: ignore[not-callable]
+                launch_metadata = self._kernel_launch_metadata(
+                    grid, stream, *kernel_args
+                )
+            return compiled_run(
+                grid_0,
+                grid_1,
+                grid_2,
+                stream,
+                self._triton_function,
+                self._packed_metadata,
+                launch_metadata,
+                enter_hook,
+                exit_hook,
+                *kernel_args,
+            )
+        except Exception as error:
+            message = str(error)
+            if "Cannot make_shape_compatible: incompatible dimensions" in message:
+                raise exc.ShapeMismatch("kernel operands", message) from error
+            raise
+
+
+def build_fast_launcher(
+    *,
+    num_warps: int,
+    num_stages: int,
+    launch_cooperative_grid: bool = False,
+    ptx_options: str | None = None,
+    extra_kwargs: dict | None = None,
+) -> _FastLauncher:
+    """Build a :class:`_FastLauncher` closure with config baked in.
+
+    Invoked from :meth:`BoundKernel.set_config` after the generated Triton
+    kernel is compiled. The returned object's ``__call__`` signature
+    matches :func:`default_launcher`, so the generated wrapper can use it
+    as a drop-in replacement (threaded through as ``_launcher=`` by the
+    bound-kernel-level wrapper installed in ``set_config``).
+    """
+    return _FastLauncher(
+        num_warps=num_warps,
+        num_stages=num_stages,
+        launch_cooperative_grid=launch_cooperative_grid,
+        ptx_options=ptx_options,
+        extra_kwargs=extra_kwargs,
+    )
 
 
 def _pallas_make_block_spec(

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -863,11 +863,76 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             config: The configuration to set.
         """
         config = self._normalize_config(config)
-        self._run = self.compile_config(config)
+        compiled = self.compile_config(config)
+        self._install_fast_launcher(compiled, config)
+        self._run = compiled
         self._config = config
         counters["best_config_decorator"][
             self.format_kernel_decorator(config, self.settings)
         ] = 1
+
+    def _install_fast_launcher(
+        self,
+        compiled: CompiledConfig,
+        config: Config,
+    ) -> None:
+        """Re-point ``compiled``'s ``_launcher`` kwarg default at a fast closure.
+
+        The generated host wrapper declares
+        ``def add(x, y, *, _launcher=_default_launcher)``; Python stores the
+        ``_default_launcher`` value in ``compiled.__kwdefaults__``. By
+        overwriting that entry with a :class:`helion.runtime._FastLauncher`
+        closure (built once with this config's ``num_warps`` / ``num_stages``
+        / etc. baked in), every direct call to ``compiled(*args)`` —
+        including from ``BoundKernel.__call__`` on the steady-state hot
+        path — uses the fast launcher with no extra Python wrapping.
+
+        The autotune trial harness and any external caller that explicitly
+        passes ``_launcher=`` (e.g. ``benchmarks/launch_overhead.py``)
+        overrides the kwdefault automatically, so this is safe.
+
+        Non-Triton backends and any priming failure cause the kwdefault to
+        be left at :func:`default_launcher`.
+        """
+        from . import build_fast_launcher
+
+        backend = self.env.backend
+        if not isinstance(backend, TritonBackend):
+            return
+        kwdefaults = getattr(compiled, "__kwdefaults__", None)
+        if not kwdefaults or "_launcher" not in kwdefaults:
+            # No ``_launcher`` kwonly default — nothing to wire up.
+            # (Should not happen for Helion-compiled Triton kernels.)
+            return
+
+        try:
+            kwargs = backend.launcher_runtime_kwargs(
+                config, has_barrier=self._env.has_barrier
+            )
+        except Exception:
+            log.debug(
+                "FastLauncher disabled: backend.launcher_runtime_kwargs raised",
+                exc_info=True,
+            )
+            return
+
+        num_warps = cast("int", kwargs.pop("num_warps"))
+        num_stages = cast("int", kwargs.pop("num_stages"))
+        launch_cooperative_grid = cast(
+            "bool", kwargs.pop("launch_cooperative_grid", False)
+        )
+        ptx_options = cast("str | None", kwargs.pop("ptx_options", None))
+        # Anything left in kwargs (backend tunable keys, maxnreg,
+        # _triton_config_*) is forwarded as ``extra_kwargs`` to be baked
+        # into the closure.
+        fast_launcher = build_fast_launcher(
+            num_warps=num_warps,
+            num_stages=num_stages,
+            launch_cooperative_grid=launch_cooperative_grid,
+            ptx_options=ptx_options,
+            extra_kwargs=kwargs or None,
+        )
+        kwdefaults["_launcher"] = fast_launcher
 
     def _specialize_extra(self) -> list[Callable[[Sequence[object]], Hashable]]:
         """

--- a/test/test_fast_launcher.py
+++ b/test/test_fast_launcher.py
@@ -1,0 +1,585 @@
+from __future__ import annotations
+
+import threading
+import time
+import unittest
+from unittest import mock
+
+import pytest
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import RefEagerTestDisabled
+from helion._testing import TestCase
+from helion._testing import skipIfFn
+from helion._testing import skipIfNotCUDA
+from helion._testing import skipIfNotTriton
+import helion.language as hl
+from helion.runtime import _FastLauncher
+from helion.runtime import build_fast_launcher
+from helion.runtime.kernel import _tensor_key
+
+triton = pytest.importorskip("triton")
+from triton.runtime.driver import driver  # noqa: E402
+
+
+class _FakeActiveDriver:
+    def get_current_device(self) -> str:
+        return "fake-device"
+
+    def get_current_stream(self, device: object) -> str:
+        return f"stream-for-{device}"
+
+
+class _FakeCompiledKernel:
+    def __init__(self) -> None:
+        self.compiled_run_published = threading.Event()
+        self.packed_metadata = "packed"
+        self.launch_metadata = lambda grid, stream, *args: "metadata"
+
+    def run(self, *args: object) -> tuple[str, tuple[object, ...]]:
+        return ("run", args)
+
+    @property
+    def function(self) -> str:
+        # _FastLauncher used to publish _compiled_run immediately before this
+        # attribute read. Sleeping here makes that partial initialization window
+        # deterministic for the racing thread.
+        self.compiled_run_published.set()
+        time.sleep(0.2)
+        return "function"
+
+
+class _FakeTritonKernel:
+    def __init__(self, compiled: _FakeCompiledKernel) -> None:
+        self.compiled = compiled
+        self.device_caches = {"fake-device": (None, None, None, None, self.binder)}
+        # Match the JITFunction surface that FastLauncher reads per-call.
+        self.pre_run_hooks: list[object] = []
+        self.used_global_vals: dict[
+            tuple[str, int], tuple[object, dict[str, object]]
+        ] = {}
+
+    def binder(
+        self, *args: object, **kwargs: object
+    ) -> tuple[dict[int, object], None, None]:
+        return dict(enumerate(args)), None, None
+
+    def run(self, *args: object, **kwargs: object) -> object:
+        if kwargs.get("warmup"):
+            return self.compiled
+        return ("default", args)
+
+
+def _get_jit_function(kernel: helion.Kernel) -> object:
+    """Return the underlying ``triton.JITFunction`` behind a primed Helion kernel.
+
+    The generated host wrapper closes over the JITFunction as
+    ``_helion_<name>`` in its ``__globals__``. We scan for the unique
+    JITFunction instance there so tests can install Triton-side hooks
+    (e.g. ``pre_run_hooks``) on a real kernel without patching.
+    """
+    from triton.runtime.jit import JITFunction
+
+    bound = next(iter(kernel._bound_kernels.values()))  # type: ignore[attr-defined]
+    return next(
+        v for v in bound._run.__globals__.values() if isinstance(v, JITFunction)
+    )
+
+
+@helion.kernel(config={"block_size": 16})
+def _fast_launcher_add_one(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size()):
+        out[tile] = x[tile] + 1
+    return out
+
+
+# Large block size + 2 stages makes Triton emit vectorized 16-byte loads,
+# which exposes the launcher's per-call spec lookup gap loudly (misaligned
+# pointer → CUDA misaligned-address error) rather than as a silent numeric
+# drift.
+@helion.kernel(
+    static_shapes=True,
+    config=helion.Config(block_sizes=[1024], num_warps=4, num_stages=2),
+)
+def _fast_launcher_add_vectorized(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for i in hl.tile(out.size(0)):
+        out[i] = x[i] + y[i]
+    return out
+
+
+@skipIfNotTriton("fast launcher is Triton-specific")
+class TestFastLauncher(RefEagerTestDisabled, TestCase):
+    def test_first_launch_prime_is_thread_safe(self) -> None:
+        """Concurrent first calls must not observe partially primed launch state."""
+        compiled = _FakeCompiledKernel()
+        triton_kernel = _FakeTritonKernel(compiled)
+        launcher = build_fast_launcher(num_warps=4, num_stages=3)
+        errors: list[tuple[str, str, str]] = []
+        results: list[tuple[str, object]] = []
+
+        old_active = driver._active
+        old_default = driver._default
+        old_enter = triton.knobs.runtime.launch_enter_hook
+        old_exit = triton.knobs.runtime.launch_exit_hook
+        driver._active = _FakeActiveDriver()
+        driver._default = _FakeActiveDriver()
+        triton.knobs.runtime.launch_enter_hook = None
+        triton.knobs.runtime.launch_exit_hook = None
+        try:
+
+            def first_call() -> None:
+                try:
+                    results.append(("first", launcher(triton_kernel, (1,), "x")))
+                except Exception as e:
+                    errors.append(("first", type(e).__name__, str(e)))
+
+            def racing_call() -> None:
+                self.assertTrue(compiled.compiled_run_published.wait(timeout=2))
+                try:
+                    results.append(("racer", launcher(triton_kernel, (1,), "y")))
+                except Exception as e:
+                    errors.append(("racer", type(e).__name__, str(e)))
+
+            threads = [
+                threading.Thread(target=first_call),
+                threading.Thread(target=racing_call),
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+        finally:
+            driver._active = old_active
+            driver._default = old_default
+            triton.knobs.runtime.launch_enter_hook = old_enter
+            triton.knobs.runtime.launch_exit_hook = old_exit
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(results), 2)
+
+    @skipIfNotCUDA()
+    @skipIfFn(
+        lambda: torch.cuda.device_count() < 2,
+        "test requires at least two CUDA devices",
+    )
+    def test_fast_launcher_uses_current_call_device(self) -> None:
+        """The cached launcher must not reuse cuda:0 launch state for cuda:1."""
+        _fast_launcher_add_one.reset()
+        old_device = torch.cuda.current_device()
+        try:
+            with torch.cuda.device(0):
+                x0 = torch.arange(16, device="cuda:0", dtype=torch.float32)
+                y0 = _fast_launcher_add_one(x0)
+                torch.cuda.synchronize(0)
+                torch.testing.assert_close(y0, x0 + 1)
+
+            with torch.cuda.device(1):
+                x1 = torch.arange(16, device="cuda:1", dtype=torch.float32)
+                y1 = _fast_launcher_add_one(x1)
+                torch.cuda.synchronize(1)
+                torch.testing.assert_close(y1, x1 + 1)
+                self.assertEqual(y1.device, torch.device("cuda:1"))
+        finally:
+            torch.cuda.set_device(old_device)
+            _fast_launcher_add_one.reset()
+
+    @skipIfNotCUDA()
+    def test_binder_spec_differs_for_aligned_vs_unaligned_pointers(self) -> None:
+        """Pre-condition for the alignment correctness gap.
+
+        ``_FastLauncher.__call__`` recomputes ``self._binder(...)`` on
+        every hot call but discards the returned ``_spec``, always
+        launching the kernel captured at priming time. Helion's tensor
+        key only tracks dtype/shape/stride, so two views with the same
+        shape but different pointer alignment share one
+        ``BoundKernel`` and one ``_FastLauncher`` — yet Triton would
+        normally compile them as distinct specializations. This test
+        pins down that the binder still reports distinct specs, so
+        the launcher's "ignore ``_spec``" shortcut is observably
+        unsafe. If a future Triton change collapses these specs, this
+        assertion stops holding and the related correctness test below
+        can be retired.
+        """
+        _fast_launcher_add_vectorized.reset()
+        n = 1024
+        base = torch.randn(n + 4, device=DEVICE, dtype=torch.float32)
+        aligned = base[:n]
+        unaligned = base[1 : n + 1]
+        out_buf = torch.empty_like(aligned)
+
+        self.assertEqual(aligned.data_ptr() % 16, 0)
+        self.assertNotEqual(unaligned.data_ptr() % 16, 0)
+        self.assertEqual(
+            _tensor_key(_fast_launcher_add_vectorized, aligned),
+            _tensor_key(_fast_launcher_add_vectorized, unaligned),
+        )
+
+        # Run once to ensure ``set_config`` has installed a fast launcher.
+        _fast_launcher_add_vectorized(aligned, aligned)
+        bound = _fast_launcher_add_vectorized.bind((aligned, aligned))
+        compiled = bound._run
+        self.assertIsNotNone(compiled)
+        launcher = compiled.__kwdefaults__.get("_launcher")
+        if not isinstance(launcher, _FastLauncher) or launcher._binder is None:
+            self.skipTest(
+                "fast launcher not installed (non-Triton backend or unsupported Triton)"
+            )
+
+        _, spec_aligned, _ = launcher._binder(
+            aligned, aligned, out_buf, **launcher._run_kwargs
+        )
+        _, spec_unaligned, _ = launcher._binder(
+            unaligned, unaligned, out_buf, **launcher._run_kwargs
+        )
+        self.assertNotEqual(spec_aligned, spec_unaligned)
+
+    def _patched_driver_and_hooks(self) -> tuple[object, object, object, object]:
+        """Snapshot driver + launch hooks so tests can stub them safely."""
+        old_active = driver._active
+        old_default = driver._default
+        old_enter = triton.knobs.runtime.launch_enter_hook
+        old_exit = triton.knobs.runtime.launch_exit_hook
+        driver._active = _FakeActiveDriver()
+        driver._default = _FakeActiveDriver()
+        triton.knobs.runtime.launch_enter_hook = None
+        triton.knobs.runtime.launch_exit_hook = None
+        return old_active, old_default, old_enter, old_exit
+
+    def _restore_driver_and_hooks(
+        self, saved: tuple[object, object, object, object]
+    ) -> None:
+        old_active, old_default, old_enter, old_exit = saved
+        driver._active = old_active
+        driver._default = old_default
+        triton.knobs.runtime.launch_enter_hook = old_enter
+        triton.knobs.runtime.launch_exit_hook = old_exit
+
+    @skipIfNotCUDA()
+    def test_pre_run_hook_installed_after_priming_fires_on_real_kernel(
+        self,
+    ) -> None:
+        """A ``pre_run_hook`` installed after priming must fire on the next call.
+
+        ``JITFunction.run`` iterates ``self.pre_run_hooks`` at the top
+        of every launch. The fast launcher's cached C-launcher path
+        skips them, so an attached profiler / autotune-timer would
+        silently miss every Helion launch. The hot path inspects
+        ``triton_kernel.pre_run_hooks`` per call and falls back when
+        non-empty so the hook actually runs — and we assert that here
+        end-to-end on a real kernel.
+        """
+        _fast_launcher_add_one.reset()
+        x = torch.arange(16, device=DEVICE, dtype=torch.float32)
+        try:
+            torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+            jit_fn = _get_jit_function(_fast_launcher_add_one)
+            calls: list[bool] = []
+            jit_fn.pre_run_hooks.append(  # pyrefly: ignore[missing-attribute]
+                lambda *a, **kw: calls.append(True)
+            )
+            try:
+                torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+                self.assertEqual(len(calls), 1)
+            finally:
+                jit_fn.pre_run_hooks.clear()  # pyrefly: ignore[missing-attribute]
+        finally:
+            _fast_launcher_add_one.reset()
+
+    @skipIfNotCUDA()
+    def test_used_global_vals_mutation_surfaces_to_user_on_real_kernel(
+        self,
+    ) -> None:
+        """Mutating a tracked global must surface as a Triton ``RuntimeError``.
+
+        Helion-generated Triton kernels reference codegen constants
+        (e.g. ``_BLOCK_SIZE_0``) as module-level ``constexpr`` globals;
+        Triton tracks them in ``used_global_vals`` and raises if the
+        value changes between launches — the cached binary has the
+        old value baked into codegen, so silently reusing it would
+        produce wrong output. The fast launcher's snapshot+equality
+        check on every call mirrors that semantic. Without it, the
+        Helion kernel would skip Triton's mismatch check entirely.
+
+        This test also verifies the snapshot check does not
+        false-positive: ``used_global_vals`` is non-empty on every
+        Helion kernel, so a naive non-empty test would defeat the
+        fast path. We assert that no recompile happens on a
+        non-mutation call (kernel_cache unchanged) and that the fast
+        path is restored after the global is reverted.
+        """
+        _fast_launcher_add_one.reset()
+        x = torch.arange(16, device=DEVICE, dtype=torch.float32)
+        try:
+            torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+            jit_fn = _get_jit_function(_fast_launcher_add_one)
+            (name, _gid), (compile_value, gdict) = next(
+                iter(jit_fn.used_global_vals.items())  # pyrefly: ignore[missing-attribute]
+            )
+            dev = driver.active.get_current_device()
+            kernel_cache = jit_fn.device_caches[dev][0]  # pyrefly: ignore[missing-attribute]
+
+            # No-mutation call: cache unchanged (proves no false-positive
+            # fallback / recompile despite ``used_global_vals`` being
+            # non-empty).
+            cache_size = len(kernel_cache)
+            torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+            self.assertEqual(len(kernel_cache), cache_size)
+
+            # Mutation: hot path's per-entry equality check detects the
+            # change, falls back to ``default_launcher`` -> ``JITFunction.run``
+            # which raises rather than silently using the stale binary.
+            import triton.language as tl
+
+            gdict[name] = tl.constexpr(8)
+            try:
+                with self.assertRaises(RuntimeError):
+                    _fast_launcher_add_one(x)
+            finally:
+                gdict[name] = compile_value
+
+            # Restore: fast path is usable again; still no recompile.
+            cache_size = len(kernel_cache)
+            torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+            self.assertEqual(len(kernel_cache), cache_size)
+        finally:
+            _fast_launcher_add_one.reset()
+
+    @skipIfNotCUDA()
+    def test_knobs_runtime_debug_set_after_priming_compiles_new_binary_on_real_kernel(
+        self,
+    ) -> None:
+        """Enabling ``knobs.runtime.debug`` mid-run must trigger Triton recompile.
+
+        ``JITFunction.run`` ORs ``knobs.runtime.debug`` into the per-call
+        ``debug`` kwarg, which becomes part of Triton's cache key.
+        Setting ``debug=True`` after priming needs a different compiled
+        binary than the one we primed with. The fast launcher's hot
+        path inspects the knob per call and falls back when set; this
+        gives ``JITFunction.run`` the chance to compile and cache the
+        debug binary. We assert the kernel_cache grew end-to-end.
+        """
+        _fast_launcher_add_one.reset()
+        x = torch.arange(16, device=DEVICE, dtype=torch.float32)
+        old_debug = triton.knobs.runtime.debug
+        triton.knobs.runtime.debug = False
+        try:
+            torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+            jit_fn = _get_jit_function(_fast_launcher_add_one)
+            dev = driver.active.get_current_device()
+            kernel_cache = jit_fn.device_caches[dev][0]  # pyrefly: ignore[missing-attribute]
+            cache_size = len(kernel_cache)
+
+            triton.knobs.runtime.debug = True
+            torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+            self.assertGreater(len(kernel_cache), cache_size)
+        finally:
+            triton.knobs.runtime.debug = old_debug
+            _fast_launcher_add_one.reset()
+
+    def test_knobs_instrumentation_mode_set_after_priming_takes_fallback(
+        self,
+    ) -> None:
+        """Setting ``knobs.compilation.instrumentation_mode`` mid-run skips fast path."""
+        compiled = _FakeCompiledKernel()
+        triton_kernel = _FakeTritonKernel(compiled)
+        launcher = build_fast_launcher(num_warps=4, num_stages=3)
+        saved = self._patched_driver_and_hooks()
+        old_mode = triton.knobs.compilation.instrumentation_mode
+        triton.knobs.compilation.instrumentation_mode = ""
+        try:
+            first = launcher(triton_kernel, (1,), "x")
+            self.assertEqual(first[0], "run")
+            triton.knobs.compilation.instrumentation_mode = "profile"
+            second = launcher(triton_kernel, (1,), "y")
+            self.assertEqual(second[0], "default")
+        finally:
+            triton.knobs.compilation.instrumentation_mode = old_mode
+            self._restore_driver_and_hooks(saved)
+
+    def test_concurrent_first_calls_serialize_priming(self) -> None:
+        """Two threads racing through ``_prime`` must not both publish state.
+
+        ``_FastLauncher`` previously gated priming with a bare
+        ``if not self._primed`` check, so two threads concurrently
+        making their first call could both enter ``_prime``. The fast
+        path then reads ``_triton_function``, ``_packed_metadata``,
+        ``_priming_spec``, ``_used_global_checks`` and ``_compiled_run``
+        without synchronization — if those attribute writes from two
+        primings interleave, a later call dispatches with a Frankenstein
+        mix from two different priming runs.
+
+        We widen the race window deterministically by wrapping
+        ``_FastLauncher._prime`` with a delay so the first thread to
+        enter waits for the second to also pass ``if not self._primed``.
+        With the prime lock, the second thread is blocked at the lock
+        and re-checks ``_primed`` after acquiring it — only ONE thread
+        ever runs the priming body. We assert that here.
+        """
+
+        class _ConcurrentFakeCompiled:
+            def __init__(self, tag: str) -> None:
+                self.tag = tag
+                self.packed_metadata = ("packed", tag)
+                self.launch_metadata = lambda grid, stream, *args: ("md", tag)
+
+            def run(self, *args: object) -> tuple[str, str, tuple[object, ...]]:
+                return ("run", self.tag, args)
+
+            @property
+            def function(self) -> tuple[str, str]:
+                return ("function", self.tag)
+
+        class _RacingTritonKernel:
+            def __init__(self) -> None:
+                self.device_caches = {
+                    "fake-device": (None, None, None, None, self.binder)
+                }
+                self.pre_run_hooks: list[object] = []
+                self.used_global_vals: dict[
+                    tuple[str, int], tuple[object, dict[str, object]]
+                ] = {}
+                self._tag_counter = 0
+                self._tag_lock = threading.Lock()
+
+            def binder(
+                self, *args: object, **kwargs: object
+            ) -> tuple[dict[int, object], None, None]:
+                return dict(enumerate(args)), None, None
+
+            def run(self, *args: object, **kwargs: object) -> object:
+                if kwargs.get("warmup"):
+                    with self._tag_lock:
+                        self._tag_counter += 1
+                        tag = f"compiled-{self._tag_counter}"
+                    return _ConcurrentFakeCompiled(tag)
+                return ("default", args)
+
+        triton_kernel = _RacingTritonKernel()
+        launcher = build_fast_launcher(num_warps=4, num_stages=3)
+
+        orig_prime = _FastLauncher._prime
+        priming_body_entries = [0]
+        entries_lock = threading.Lock()
+        # The first thread waits to give the second thread a chance to
+        # also reach the ``if not self._primed`` check, so both would
+        # enter ``_prime`` under the BROKEN (no-lock) implementation.
+        both_threads_started = threading.Event()
+        threads_started = [0]
+
+        def delayed_prime(self: object, *p_args: object, **p_kwargs: object) -> None:
+            with entries_lock:
+                priming_body_entries[0] += 1
+            orig_prime(self, *p_args, **p_kwargs)
+
+        def synchronized_call(tag: str) -> None:
+            # Mark this thread as ready, then wait for the partner
+            # before invoking the launcher. This ensures both threads
+            # hit ``__call__`` essentially simultaneously.
+            with entries_lock:
+                threads_started[0] += 1
+                if threads_started[0] == 2:
+                    both_threads_started.set()
+            both_threads_started.wait(timeout=2)
+            launcher(triton_kernel, (1,), tag)
+
+        saved = self._patched_driver_and_hooks()
+        errors: list[str] = []
+
+        def call_first(tag: str) -> None:
+            try:
+                synchronized_call(tag)
+            except Exception as e:
+                errors.append(f"{tag}: {type(e).__name__}: {e}")
+
+        try:
+            with mock.patch.object(_FastLauncher, "_prime", delayed_prime):
+                threads = [
+                    threading.Thread(target=call_first, args=("x",)),
+                    threading.Thread(target=call_first, args=("y",)),
+                ]
+                for t in threads:
+                    t.start()
+                for t in threads:
+                    t.join()
+        finally:
+            self._restore_driver_and_hooks(saved)
+
+        self.assertEqual(errors, [])
+        # Under the lock, exactly one thread enters the priming body.
+        # Without the lock, both threads would (since both passed the
+        # ``if not self._primed`` check before either ran ``_prime``).
+        self.assertEqual(priming_body_entries[0], 1)
+        # Sanity-check the published state is internally consistent.
+        triton_function = launcher._triton_function
+        self.assertIsNotNone(triton_function)
+        self.assertEqual(triton_function[0], "function")
+        function_tag = triton_function[1]  # type: ignore[index]
+        self.assertEqual(launcher._packed_metadata, ("packed", function_tag))
+        self.assertEqual(launcher._compiled_kernel.tag, function_tag)  # type: ignore[attr-defined]
+
+    @skipIfNotCUDA()
+    def test_launch_hooks_installed_after_priming_fire_on_real_kernel(
+        self,
+    ) -> None:
+        """``launch_enter_hook`` / ``launch_exit_hook`` installed after priming must fire.
+
+        The Triton C launcher invokes both hooks with a ``launch_metadata``
+        argument. The fast launcher used to snapshot the hook references
+        at priming, so profilers attaching afterwards were silently
+        dropped. The hot path now re-reads them from
+        ``triton.knobs.runtime`` per call — we assert the hooks fire on
+        a real kernel here.
+        """
+        _fast_launcher_add_one.reset()
+        x = torch.arange(16, device=DEVICE, dtype=torch.float32)
+        old_enter = triton.knobs.runtime.launch_enter_hook
+        old_exit = triton.knobs.runtime.launch_exit_hook
+        triton.knobs.runtime.launch_enter_hook = None
+        triton.knobs.runtime.launch_exit_hook = None
+        try:
+            torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+            enter_md: list[object] = []
+            exit_md: list[object] = []
+            triton.knobs.runtime.launch_enter_hook = lambda md: enter_md.append(md)
+            triton.knobs.runtime.launch_exit_hook = lambda md: exit_md.append(md)
+            torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+            self.assertEqual(len(enter_md), 1)
+            self.assertEqual(len(exit_md), 1)
+        finally:
+            triton.knobs.runtime.launch_enter_hook = old_enter
+            triton.knobs.runtime.launch_exit_hook = old_exit
+            _fast_launcher_add_one.reset()
+
+    @skipIfNotCUDA()
+    def test_unaligned_call_after_aligned_priming_matches_reference(self) -> None:
+        """Aligned-then-unaligned call should still produce correct output.
+
+        Before the spec-aware hot path, the second call launched the
+        binary compiled for the aligned spec (vectorized 16-byte loads)
+        and tripped ``CUDA error: misaligned address``. With the spec
+        check in :class:`_FastLauncher.__call__`, the unaligned call
+        observes a different ``_spec`` from the binder and falls back
+        to ``default_launcher``, which routes through Triton's
+        per-spec ``kernel_cache`` and picks (or compiles) the
+        unaligned binary.
+        """
+        _fast_launcher_add_vectorized.reset()
+        n = 1024
+        base = torch.randn(n + 4, device=DEVICE, dtype=torch.float32)
+        aligned = base[:n]
+        unaligned = base[1 : n + 1]
+
+        torch.testing.assert_close(
+            _fast_launcher_add_vectorized(aligned, aligned), aligned + aligned
+        )
+        torch.testing.assert_close(
+            _fast_launcher_add_vectorized(unaligned, unaligned), unaligned + unaligned
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

Modified from the stack at https://github.com/pytorch/helion/pull/2533.
The improvement is not as big as the original PR, because we added some more checks. 

When this is useful: **the fast path is single-spec**. It caches state
from the very first call and only stays engaged when subsequent
calls produce the same Triton ``_spec`` (pointer alignment, scalar
specialization, divisibility hints, etc.) as that first call. Calls
with a different spec fall back to ``default_launcher`` — correct,
but no Python-overhead reduction. Most real call sites (a model's
forward/backward calling the same kernel on tensors with stable
alignment/shape) match this assumption.

Every time you call a Helion kernel, the GPU compiler underneath
(Triton) redoes a bunch of bookkeeping it does not actually need to
repeat: rebinding arguments, recomputing cache keys, dictionary
lookups. On small kernels, this Python work dominates total
wall-clock time per call.

We do the bookkeeping once on the first call, cache the result, and
on every later call jump straight into Triton's C launcher.

End-to-end validation on H100 via TritonBench:

  HELION_AUTOTUNE_EFFORT=none python benchmarks/run.py \
      --kernel <name> --metrics walltime,accuracy --num-inputs 5

  (--metrics walltime is required; the default --metrics latency uses
  CUDA events and excludes Python-side launch overhead.)

vector_add (--only helion_add, no baseline):

| x_val | before (us) | after (us) | delta (us) |
| ----: | ----------: | ---------: | ---------: |
|  4096 |       23.08 |      20.25 |      -2.83 |
|  8192 |       22.23 |      19.69 |      -2.54 |
| 16384 |       22.57 |      20.05 |      -2.52 |
| 32768 |       23.35 |      20.27 |      -3.08 |
| 65536 |       22.64 |      20.51 |      -2.13 |
|   avg |       22.77 |      20.15 |      -2.62 |

rms_norm (with llama_rms baseline; accuracy=1 means match):

| (M, H)        | before (us) | after (us) | delta (us) | accuracy |
| ------------- | ----------: | ---------: | ---------: | -------: |
| (2048, 1024)  |       34.26 |      31.15 |      -3.11 |        1 |
| (2048, 2048)  |       34.42 |      33.11 |      -1.31 |        1 |
| (2048, 4096)  |       34.35 |      30.80 |      -3.55 |        1 |
| (2048, 8192)  |       82.44 |      82.53 |      +0.09 |        1 |
| (2048, 16384) |      182.99 |     183.02 |      +0.03 |        1 |

The improvement is a fixed per-call cost removed; it dominates on
small kernels and is amortized away at larger shapes. Numerics are
unchanged (accuracy stays at 1 vs the llama_rms baseline).

At small rms_norm shapes the wins (~2-3.5 us) are comparable to
vector_add's (~2.6 us avg). At larger rms_norm shapes the actual
GPU work dwarfs the saved Python overhead, so the deltas are noise.

For reference, autotuned Helion vs Triton/torch baselines at the
smallest vector_add shape (HELION_AUTOTUNE_EFFORT default, not
"none"):

  python benchmarks/run.py --kernel vector_add \
      --metrics walltime,accuracy --num-inputs 1 \
      --only helion_add,triton_add,torch_add

| impl                   | walltime (us) | accuracy   |
| ---------------------- | ------------: | ---------- |
| torch_add (eager)      |          4.46 | (baseline) |
| triton_add             |          9.26 | 1          |
| helion_add (autotuned) |         20.63 | 1          |

This PR removes the per-call Python work in the Triton launcher.
The remaining ~11.4 us gap between helion_add and triton_add is
Helion-over-Triton framing in Kernel.__call__ itself, which will be
addressed in later PRs.

Additionally, fall back to the default Triton launcher under
torch.compile / Dynamo tracing on PyTorch builds where Helion's HOP
isn't registered (supports_torch_compile_fusion() is False). The
fast launcher's direct _cuda_getCurrentRawStream call returns int
and trips Dynamo's "torch.* op returned non-Tensor" check; on builds
where the HOP intercepts the call earlier, this guard is a no-op.

Correctness fixes vs. the original fast-launcher draft
------------------------------------------------------

While iterating on review, several correctness gaps in the cached
hot path were closed. Each fix has a dedicated unit test in
``test/test_fast_launcher.py``:

1. Per-call Triton specialization mismatch (alignment / scalar
   divisibility / etc.). The priming call captured a compiled binary
   tied to its ``_spec`` (e.g. 16-byte-aligned pointers ⇒ vectorized
   loads). A later call with a different spec reused that binary and
   crashed with ``CUDA error: misaligned address``. The hot path now
   recomputes the spec via the cached binder and falls back to
   ``default_launcher`` (which routes through Triton's per-spec
   ``kernel_cache``) on mismatch.
   Tests: ``test_binder_spec_differs_for_aligned_vs_unaligned_pointers``,
   ``test_unaligned_call_after_aligned_priming_matches_reference``.

2. ``used_global_vals`` guard always firing. The previous check
   treated any non-empty ``used_global_vals`` dict as "fall back",
   which made every call to a kernel that reads a global take the
   slow path. We now snapshot
   ``((gdict, name, expected_value), ...)`` at priming time and
   per-call verify ``gdict.get(name) == expected``, so only an
   actual mutation triggers fallback. The test mutates the real
   ``_BLOCK_SIZE_0`` constexpr global of a Helion kernel and asserts
   the user observes a ``RuntimeError`` (Triton's mismatch raise) —
   silently reusing the stale cached binary would have produced
   wrong output. It also asserts ``kernel_cache`` does not grow on
   non-mutation calls, proving the per-entry equality check does
   not false-positive on Helion's always-populated
   ``used_global_vals``.
   Test:
   ``test_used_global_vals_mutation_surfaces_to_user_on_real_kernel``.

3. Concurrent first-call race on priming. Two threads racing into
   ``__call__`` could both observe ``_primed=False`` and both run
   ``_prime``, with the second thread potentially observing
   half-published state. Priming is now guarded by a
   ``threading.Lock`` with double-checked locking; ``_prime`` itself
   publishes ``_compiled_run`` last and sets ``_primed=True`` only
   in a ``finally`` block, so a partial/failed prime cannot leak
   torn state.
   Test: ``test_concurrent_first_calls_serialize_priming`` — two
   threads enter ``__call__`` simultaneously; asserts exactly one
   reaches the priming body.

4. Stale Triton ``launch_enter_hook`` / ``launch_exit_hook``. These
   were captured at priming time, so a profiler installed after the
   first call (the common Triton/Proton flow) was silently bypassed.
   The hooks are now re-read from ``triton.knobs.runtime`` on every
   call, and ``launch_metadata`` is computed only when at least one
   hook is active. The test installs real hooks on a real Helion
   kernel after priming and asserts they fire — the property we
   actually care about (not just that we routed differently).
   Test: ``test_launch_hooks_installed_after_priming_fire_on_real_kernel``.

5. Hook-driven Triton state changes after priming. Three independent
   surfaces — ``triton_kernel.pre_run_hooks`` (the JIT side),
   ``triton.knobs.runtime.add_stages_inspection_hook`` (the spec /
   compile side), and the launch hooks from (4) — all need to take
   effect on the next launch. The hot path inspects each per call
   and falls back to ``default_launcher`` when set (or, for launch
   hooks, re-reads them and forwards to the C launcher), so the
   user-installed hook actually runs. Each test installs the hook
   on a real Helion kernel and asserts it was invoked, exercising
   the end-to-end purpose of the fallback rather than just the
   routing decision.
   Tests:
   ``test_pre_run_hook_installed_after_priming_fires_on_real_kernel``,
   ``test_stages_inspection_hook_installed_after_priming_fires_on_real_kernel``.

   For ``knobs.runtime.debug`` the end-to-end observable is that
   Triton's ``device_caches`` ``kernel_cache`` grows after the flip
   — flipping the knob changes the cache key (debug becomes part of
   the spec), so a new binary must be compiled. The test asserts
   ``len(kernel_cache)`` increased on a real Helion kernel after
   setting ``debug=True`` post-priming.
   Test:
   ``test_knobs_runtime_debug_set_after_priming_compiles_new_binary_on_real_kernel``.

   ``knobs.compilation.instrumentation_mode`` has no equally clean
   public observable (its effect is internal to Triton's compile
   pipeline), so it remains a mechanical fallback-routing test on
   the fake-kernel harness:
   ``test_knobs_instrumentation_mode_set_after_priming_takes_fallback``.

6. Multi-device launches. The current CUDA stream is queried at
   call time, not cached at priming, so a kernel launched on a
   different device than the priming call still routes to the right
   stream.
   Test: ``test_fast_launcher_uses_current_call_device``.

7. Thread-safe first launch. Earlier review flagged a window where
   the first launch could partially publish; see fix (3).
   Test: ``test_first_launch_prime_is_thread_safe``.
