### PR TITLE
Fix fbcode CI torch.compile fusion with newer PyTorch

### DIFF
--- a/helion/_compat.py
+++ b/helion/_compat.py
@@ -581,7 +581,7 @@ def requires_torch_version(min_version: str) -> bool:
 
 @functools.cache
 def supports_torch_compile_fusion() -> bool:
-    """Check whether this PyTorch build exposes Helion's fusion entrypoint."""
+    """Check whether this PyTorch build exposes Helion's fusion entrypoints."""
     if torch.xpu.is_available():
         return False
     if not requires_torch_version("2.11"):
@@ -595,6 +595,7 @@ def supports_torch_compile_fusion() -> bool:
         init_names = TemplateBuffer.__init__.__code__.co_names
         assert "allow_prologue_fusion" in init_names
         assert "allow_epilogue_fusion" in init_names
+        assert hasattr(TemplateBuffer, "has_aliasing_or_mutation_for_prologue_fusion")
     except (ImportError, AttributeError, AssertionError):
         return False
     return True

--- a/helion/_compiler/_inductor/template_buffer.py
+++ b/helion/_compiler/_inductor/template_buffer.py
@@ -18,6 +18,7 @@ from torch._inductor.ir import FinalizeCodegenResult
 from torch._inductor.ir import IRNode
 from torch._inductor.ir import Layout
 from torch._inductor.ir import MultiOutputLayout
+from torch._inductor.ir import MutationOutput
 from torch._inductor.ir import ReinterpretView
 from torch._inductor.ir import TemplateBuffer
 from torch._inductor.ir import TensorBox
@@ -54,6 +55,7 @@ if TYPE_CHECKING:
     from typing import Iterable
 
     from torch._inductor.ir import MultiOutput
+    from torch._inductor.scheduler import SchedulerNode
 
     from ..inductor_lowering import CodegenState
     from helion.runtime.kernel import BoundKernel
@@ -183,6 +185,33 @@ class HelionTemplateBuffer(TemplateBuffer):
             named_inputs=named_inputs,  # pyrefly: ignore[unexpected-keyword]
         )
 
+    @staticmethod
+    def _refresh_range_tree_node_symbols(kernel: Any) -> None:  # noqa: ANN401
+        """Keep Inductor range-tree lookups in sync after symbol renames."""
+
+        def refresh(nodes: dict[sympy.Symbol, Any]) -> None:
+            for old_symbol, entry in list(nodes.items()):
+                new_symbol = entry.symbol()
+                if old_symbol != new_symbol and old_symbol in entry.parent.var_list:
+                    entry.parent.var_list[entry.parent.var_list.index(old_symbol)] = (
+                        new_symbol
+                    )
+                if old_symbol in entry.parent.var_ranges:
+                    entry.parent.var_ranges.setdefault(
+                        new_symbol, entry.parent.var_ranges[old_symbol]
+                    )
+                for symbol in (
+                    new_symbol,
+                    sympy.Symbol(str(new_symbol), integer=True),
+                    sympy.Symbol(str(new_symbol)),
+                ):
+                    nodes[symbol] = entry
+
+        refresh(kernel.range_tree_nodes)
+        for subgraph in kernel.subgraph_bodies.values():
+            if subgraph.range_tree_nodes is not None:
+                refresh(subgraph.range_tree_nodes)
+
     def _render_with_hooks(self, kernel: Any) -> PartialRender:  # noqa: ANN401
         """Set up fusion hooks, read metadata, return a placeholder PartialRender.
 
@@ -194,6 +223,7 @@ class HelionTemplateBuffer(TemplateBuffer):
         """
         # 1. Set up fusion hooks (requires V.kernel context).
         kernel._setup_fusion_hooks()
+        self._refresh_range_tree_node_symbols(kernel)
 
         # 2. Read pre-computed fusion metadata from kernel into a single object.
         prologue_fused_params = set(kernel._prologue_vars.keys())
@@ -373,6 +403,46 @@ class HelionTemplateBuffer(TemplateBuffer):
     def set_current_node(self, node: object) -> AbstractContextManager[None]:
         return nullcontext()
 
+    def has_aliasing_or_mutation_for_prologue_fusion(
+        self,
+        scheduler_node: SchedulerNode,
+    ) -> bool:
+        """Return the Inductor fusion-blocking alias/mutation state.
+
+        Inductor's prologue-fusion gate asks templates this as a whole-template
+        question before checking ``allowed_prologue_inps``.  Helion mutating
+        templates can still safely fuse producers for independent inputs, so
+        ignore only safe synthetic MutationOutput buffers here.  The
+        MutationOutputs remain in the scheduler graph for dependencies and
+        memory planning.
+        """
+        mutation_names: set[str] = set()
+        for output in scheduler_node.get_outputs():
+            if output.get_aliases():
+                return True
+
+            mutations = output.get_mutations()
+            if not mutations:
+                continue
+            if not isinstance(output.node, MutationOutput):
+                return True
+            mutation_names.update(mutations)
+
+        if not mutation_names:
+            return False
+
+        allowed_prologue_inps = self.get_allowed_prologue_inps()
+        if any(name in allowed_prologue_inps for name in mutation_names):
+            return True
+
+        for inp in cast("Sequence[IRNode]", self.inputs):
+            if (
+                inp.get_name() in allowed_prologue_inps
+                and not mutation_names.isdisjoint(inp.get_read_names())
+            ):
+                return True
+        return False
+
     def _build_call_args(
         self,
         call_order: list[str],
@@ -456,6 +526,11 @@ class HelionTemplateBuffer(TemplateBuffer):
             for param_name, inp in realized_inputs.items()
             if "." in param_name
         }
+        mutation_dependent_inp_names = {
+            inp.get_name()  # type: ignore[union-attr]
+            for inp in inputs  # type: ignore[union-attr]
+            if inp.get_read_names() & mutated_inp_names
+        }
         buf = cls(
             layout=MultiOutputLayout(device=dev),  # pyrefly: ignore[bad-argument-type]
             inputs=inputs,
@@ -465,6 +540,7 @@ class HelionTemplateBuffer(TemplateBuffer):
                 for inp in inputs  # type: ignore[union-attr]
                 if inp.get_name() not in mutated_inp_names
                 and inp.get_name() not in container_inp_names
+                and inp.get_name() not in mutation_dependent_inp_names
             ),
             named_inputs=realized_inputs,
             **buffer_kwargs,

--- a/test/test_torch_compile.py
+++ b/test/test_torch_compile.py
@@ -5,6 +5,7 @@ import functools
 import math
 import operator
 import re
+from typing import Any
 import unittest
 from unittest.mock import patch
 
@@ -12,10 +13,12 @@ import torch
 from torch._inductor import config as inductor_config
 from torch._inductor.codecache import FxGraphCache
 from torch._inductor.codecache import PyCodeCache
+from torch._inductor.ir import MutationOutput
 from torch._inductor.utils import fresh_cache
 from torch._inductor.utils import run_and_get_code
 from torch.testing._internal.common_utils import instantiate_parametrized_tests
 from torch.testing._internal.common_utils import parametrize
+from torch.utils._ordered_set import OrderedSet
 
 import helion
 from helion._compat import requires_torch_version
@@ -1773,6 +1776,100 @@ class TestTorchCompile(RefEagerTestDisabled, TestCase):
             kernels_ref=[k_add_inplace_ref],
             expected_num_kernels_ref=1,
         )
+
+    @unittest.skipUnless(
+        supports_torch_compile_fusion(),
+        "torch_compile_fusion=True requires PyTorch nightly build",
+    )
+    def test_mutating_template_prologue_fusion_respects_allowed_inputs(self):
+        """Only independent non-mutated inputs may prologue-fuse into mutation.
+
+        The hook returns True when Inductor should block prologue fusion.  Helion
+        should allow an independent producer feeding a non-mutated input, but
+        still block aliases, real mutations, and producers tied to mutated data.
+        """
+        from helion._compiler._inductor.template_buffer import HelionTemplateBuffer
+
+        class FakeInput:
+            def __init__(self, name, reads):
+                self._name = name
+                self._reads = OrderedSet(reads)
+
+            def get_name(self):
+                return self._name
+
+            def get_read_names(self):
+                return self._reads
+
+        class FakeOutput:
+            def __init__(self, *, aliases=(), mutations=(), node=None):
+                self._aliases = aliases
+                self._mutations = mutations
+                self.node = node
+
+            def get_aliases(self):
+                return self._aliases
+
+            def get_mutations(self):
+                return self._mutations
+
+        class FakeSchedulerNode:
+            def __init__(self, outputs):
+                self._outputs = outputs
+
+            def get_outputs(self):
+                return self._outputs
+
+        mutation_output = object.__new__(MutationOutput)
+        mutating_outputs = [FakeOutput(mutations=("x",), node=mutation_output)]
+
+        def blocks_prologue_fusion(
+            *,
+            input_name="y_prologue",
+            reads=("y",),
+            outputs=None,
+        ) -> bool:
+            template: Any = object.__new__(HelionTemplateBuffer)
+            template.inputs = [FakeInput(input_name, reads)]
+            template.allowed_prologue_inps = OrderedSet((input_name,))
+            return template.has_aliasing_or_mutation_for_prologue_fusion(
+                FakeSchedulerNode(mutating_outputs if outputs is None else outputs)
+            )
+
+        cases = [
+            (
+                "allow independent non-mutated prologue",
+                False,
+                {},
+            ),
+            (
+                "block prologue that replaces mutated input",
+                True,
+                {"input_name": "x", "reads": ("x",)},
+            ),
+            (
+                "block prologue that reads mutated input",
+                True,
+                {"reads": ("x",)},
+            ),
+            (
+                "block aliasing template output",
+                True,
+                {"outputs": [FakeOutput(aliases=("x",))]},
+            ),
+            (
+                "block real non-synthetic mutation",
+                True,
+                {"outputs": [FakeOutput(mutations=("x",), node=object())]},
+            ),
+        ]
+
+        for name, expected, kwargs in cases:
+            with self.subTest(name):
+                self.assertIs(
+                    blocks_prologue_fusion(**kwargs),
+                    expected,
+                )
 
     @parametrize("allow_torch_compile_fusion", (True, False))
     @skipIfTileIR("torch.compile missing kernel metadata on tileir")


### PR DESCRIPTION
Fix Helion torch.compile fusion failures seen in fbcode CI with a newer PyTorch/Inductor version.

Newer Inductor rejects template prologue fusion when the template scheduler node reports mutation. PyTorch PR https://github.com/pytorch/pytorch/pull/185317 adds a template hook for that gate, and this Helion change implements the hook instead of monkey patching SchedulerNode.

Helion allows independent non-mutated prologue producers while still blocking aliases, real mutations, direct mutation inputs, and producers that read mutated inputs through allowed_prologue_inps.

Also refreshes Inductor range-tree symbol mappings after fusion hook setup to fix `Unregistered range symbol` failures from renamed prologue/epilogue range variables.

Adds a regression test for the allowed and blocked prologue-fusion cases.