### PR TITLE
[cute] V=8 fp16/bf16 via 4+4 split; multi-row investigation tests

### DIFF
--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -133,9 +133,16 @@ class CuteReductionTileHeuristic(AutotunerHeuristic):
 def _cute_tile_seed_vec_width_for_dtype(dtype: torch.dtype | None) -> int:
     """V seed for ``CuteNDTileStrategy`` lane-loop vec on a given dtype.
 
-    Returns 4 for fp32 (LDG.128 = 16 bytes), 4 for fp16/bf16 — the cute
-    DSL caps the bf16/fp16 vec unroll path at V=4 (LDG.64) because
-    V=8 hits an ICE inside ``nvvm.load.ext``.  Other dtypes get V=1.
+    Returns 4 for fp32 (LDG.128 = 16 bytes), 4 for fp16/bf16 (LDG.64,
+    8 bytes per thread per outer iter).  Note: V=8 for fp16/bf16 IS now
+    supported via a 2x V=4 split (see
+    ``_cute_register_tile_unroll_vec_hoist_split2``), but the autotuner
+    seed stays at 4 because the split emits two LDG.64s rather than a
+    single LDG.128 — empirically the per-element bookkeeping in the 8-
+    iter constexpr V-loop and the doubled fuser cache offset the
+    extra bytes-per-load.  The split path stays available as a
+    reachable point in the autotuner's V search space for shapes where
+    it does win.
     """
     if dtype is torch.float32:
         return 4

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -1083,6 +1083,121 @@ def _cute_register_tile_unroll_vec_hoist(
     return f"cutlass.Uint16({hoist_var}[{vec_lane_var}]).bitcast({elem_dtype})"
 
 
+def _cute_register_tile_unroll_vec_hoist_split2(
+    state: CodegenState,
+    strategy: object,  # BlockSizeTileStrategy (CuteNDTileStrategy)
+    block_id: int,
+    tensor: torch.Tensor,
+    tensor_name: str,
+    index_exprs: list[str],
+    vec_width: int,
+) -> str:
+    """Split-2 variant of ``_cute_register_tile_unroll_vec_hoist`` for V=8
+    on fp16/bf16.
+
+    The CuTe DSL's ``nvvm.load.ext`` ICEs at V=8 for these dtypes, so the
+    full 16-byte LDG.128 is decomposed into TWO back-to-back V=4 loads
+    (lanes 0-3 and 4-7).  The SASS scheduler is free to overlap the two
+    LDGs, so the per-thread bytes-per-load grows from 8 (V=4) to the
+    full 16 (effective V=8) without invoking the DSL bug.
+
+    Returns a per-vec-lane expression of the form::
+
+        (
+            cutlass.Uint16(_tile_unroll_vec_ < n > _ < m > _a[vi]).bitcast(dtype)
+            if vi < 4
+            else cutlass.Uint16(_tile_unroll_vec_ < n > _ < m > _b[vi - 4]).bitcast(
+                dtype
+            )
+        )
+
+    Because ``vec_lane_var`` is the target of a ``cutlass.range_constexpr(8)``
+    loop, it is a Python-int constant at each unrolled iter, so the
+    ``if vi < 4`` branch folds away at trace time and the emitted SASS
+    contains only the active load's extract.
+    """
+    assert vec_width == 8, (
+        "tile_unroll_split2 expects V=8 (4+4); other widths use tile_unroll"
+    )
+    half = vec_width // 2
+    elem_dtype = _CUTE_VECTOR_UNROLL_DTYPES[tensor.dtype]
+    base_var_by_block = getattr(strategy, "_cute_lane_base_index_var_by_block", {})
+    lane_body_by_block = getattr(strategy, "_cute_lane_body_by_block", {})
+    vec_lane_var_by_block = getattr(strategy, "_cute_vec_lane_var_by_block", {})
+    base_index_var = base_var_by_block.get(block_id)
+    lane_body = lane_body_by_block.get(block_id)
+    vec_lane_var = vec_lane_var_by_block.get(block_id)
+    assert isinstance(base_index_var, str)
+    assert isinstance(lane_body, list)
+    assert isinstance(vec_lane_var, str)
+    base_exprs = list(index_exprs)
+    base_exprs[-1] = base_index_var
+    base_ptr_expr_a = _cute_scalar_pointer_expr(tensor_name, base_exprs)
+    # The second-half pointer points 4 elements past the first.  Build
+    # it by substituting ``base_index_var + half`` for the inner index.
+    base_exprs_b = list(index_exprs)
+    base_exprs_b[-1] = f"({base_index_var} + {half})"
+    base_ptr_expr_b = _cute_scalar_pointer_expr(tensor_name, base_exprs_b)
+    cache_key = (tensor_name, base_ptr_expr_a, "split2")
+    cache_by_block = getattr(strategy, "_cute_lane_vec_loads_by_block", None)
+    if cache_by_block is None:
+        cache_by_block = {}
+        # pyrefly: ignore [missing-attribute]
+        strategy._cute_lane_vec_loads_by_block = cache_by_block
+    cache = cache_by_block.setdefault(block_id, {})
+    if cache_key not in cache:
+        slot = len(cache)
+        hoist_var_a = state.device_function.new_var(
+            f"_tile_unroll_vec_{block_id}_{slot}_a", dce=False
+        )
+        hoist_var_b = state.device_function.new_var(
+            f"_tile_unroll_vec_{block_id}_{slot}_b", dce=False
+        )
+        # Stash both names plus the split marker so this entry doesn't
+        # collide with the V=4 cache_key shape.  Downstream readers
+        # don't introspect this tuple — it's just a sentinel.
+        cache[cache_key] = ((hoist_var_a, hoist_var_b), tensor.dtype)
+        env_local = CompileEnvironment.current()
+        numel = env_local.block_sizes[block_id].numel
+        numel_expr = state.sympy_expr(numel)
+        anchor_exprs = list(index_exprs)
+        anchor_exprs[-1] = "0"
+        anchor_ptr_expr = _cute_scalar_pointer_expr(tensor_name, anchor_exprs)
+        # The first-half OOB guard checks the same V-aligned base used by
+        # the V=4 path; the second-half pointer is ``base + 4`` and only
+        # needs guarding when ``base + 4 < numel``.  Reuse the same
+        # anchor pointer for both halves' fallbacks (the per-element
+        # mask gate downstream drops any anchor-fetched bytes anyway).
+        guarded_ptr_a = (
+            f"({base_ptr_expr_a} if {base_index_var} < {numel_expr} "
+            f"else {anchor_ptr_expr})"
+        )
+        guarded_ptr_b = (
+            f"({base_ptr_expr_b} if ({base_index_var} + {half}) < {numel_expr} "
+            f"else {anchor_ptr_expr})"
+        )
+        hoist_stmt_a = statement_from_string(
+            f"{hoist_var_a} = cute.arch.load({guarded_ptr_a}, "
+            f"ir.VectorType.get([{half}], cutlass.Uint16.mlir_type))"
+        )
+        hoist_stmt_b = statement_from_string(
+            f"{hoist_var_b} = cute.arch.load({guarded_ptr_b}, "
+            f"ir.VectorType.get([{half}], cutlass.Uint16.mlir_type))"
+        )
+        # Insert both hoists just BEFORE the constexpr V-loop (the last
+        # entry in lane_body).  Emit them back-to-back so the SASS
+        # scheduler can issue the two LDGs together.
+        lane_body.insert(len(lane_body) - 1, hoist_stmt_a)
+        lane_body.insert(len(lane_body) - 1, hoist_stmt_b)
+    else:
+        (hoist_var_a, hoist_var_b), _ = cache[cache_key]
+    return (
+        f"(cutlass.Uint16({hoist_var_a}[{vec_lane_var}]).bitcast({elem_dtype}) "
+        f"if {vec_lane_var} < {half} "
+        f"else cutlass.Uint16({hoist_var_b}[{vec_lane_var} - {half}]).bitcast({elem_dtype}))"
+    )
+
+
 def _cute_vector_load_ctx(
     state: CodegenState,
     tensor: torch.Tensor,
@@ -1260,7 +1375,16 @@ def _cute_vector_load_ctx(
             return None
         if tensor.dtype not in _CUTE_VECTOR_UNROLL_DTYPES:
             return None
-        if vec_width > 4:
+        # The CuTe DSL's ``nvvm.load.ext`` ICEs at V=8 for fp16/bf16, so
+        # widths > 4 cannot use a single ``cute.arch.load``.  V=8 still
+        # gets full LDG.128 throughput via the ``tile_unroll_split2``
+        # mode: two back-to-back ``cute.arch.load(..., V=4)`` calls
+        # (covering vec lanes 0-3 and 4-7) emit as two LDG.64s that the
+        # SASS scheduler can overlap.  Wider Vs (16, 32, ...) are not
+        # supported.
+        if vec_width > 8:
+            return None
+        if vec_width == 8 and vec_width % 4 != 0:
             return None
         base_var_by_block = getattr(
             strategy, "_cute_lane_base_index_var_by_block", None
@@ -1284,6 +1408,8 @@ def _cute_vector_load_ctx(
         numel = env.block_sizes[inner_block_id].numel
         if not env.known_multiple(numel, vec_width):
             return None
+        if vec_width == 8:
+            return vec_width, inner_block_id, "tile_unroll_split2"
         return vec_width, inner_block_id, "tile_unroll"
     return None
 
@@ -5586,14 +5712,31 @@ def _(state: CodegenState) -> object:
                 index_exprs,
                 vec_width,
             )
-        else:
-            assert vec_mode == "tile_unroll"
+        elif vec_mode == "tile_unroll":
             # Same hoist protocol as ``LoopedReductionStrategy``'s
             # ``unroll`` mode but for ``CuteNDTileStrategy`` lane loops.
             from .._compiler.tile_strategy import BlockSizeTileStrategy
 
             assert isinstance(strategy, BlockSizeTileStrategy)
             load_expr = _cute_register_tile_unroll_vec_hoist(
+                state,
+                strategy,
+                vec_block_id,
+                tensor,
+                tensor_name,
+                index_exprs,
+                vec_width,
+            )
+        else:
+            assert vec_mode == "tile_unroll_split2"
+            # V=8 fp16/bf16: emit two back-to-back ``cute.arch.load(...,
+            # V=4)`` calls (lanes 0-3 and 4-7).  Works around the CuTe
+            # DSL's ``nvvm.load.ext`` ICE on V=8 while still issuing the
+            # full LDG.128 of bytes-per-thread-per-outer-iter.
+            from .._compiler.tile_strategy import BlockSizeTileStrategy
+
+            assert isinstance(strategy, BlockSizeTileStrategy)
+            load_expr = _cute_register_tile_unroll_vec_hoist_split2(
                 state,
                 strategy,
                 vec_block_id,

--- a/test/test_cute_softmax_perf.py
+++ b/test/test_cute_softmax_perf.py
@@ -99,11 +99,13 @@ class TestCuteSoftmaxVecHoist(TestCase):
         # And the per-V-lane extract is a bitcast back to Float16.
         self.assertIn("bitcast(cutlass.Float16)", code)
 
-    def test_vec_hoist_v8_falls_back_to_scalar(self) -> None:
-        """V=8 fp16/bf16 must NOT fire because the CuTe DSL's
-        ``nvvm.load.ext`` ICEs at V=8 — see the cap at
-        ``memory_ops.py`` ~line 1263 (``if vec_width > 4: return None``).
-        The codegen must fall back to scalar loads, not crash.
+    def test_vec_hoist_v8_uses_4plus4_split(self) -> None:
+        """V=8 fp16/bf16 cannot use a single ``cute.arch.load`` (the CuTe
+        DSL's ``nvvm.load.ext`` ICEs at V=8), so the codegen lowers it as
+        TWO back-to-back ``cute.arch.load(..., V=4)`` calls (covering vec
+        lanes 0-3 and 4-7).  The SASS scheduler is free to overlap the
+        two LDGs, so per-thread bytes-per-load still hit the full
+        LDG.128 (16 bytes) without invoking the DSL bug.
         """
         x = torch.randn(4096, 8192, device=DEVICE, dtype=HALF_DTYPE)
         code, out = code_and_output(
@@ -115,8 +117,22 @@ class TestCuteSoftmaxVecHoist(TestCase):
         )
         ref = torch.nn.functional.softmax(x, dim=1)
         torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
-        # No vec load was emitted (V=8 cap).
+        # The single-V=8 load form is still NOT emitted (would ICE).
         self.assertNotIn("ir.VectorType.get([8]", code)
+        # The split-2 path emits TWO V=4 vec loads per outer-lane iter
+        # with the ``_a`` / ``_b`` suffix on the hoist var names.
+        self.assertIn("_tile_unroll_vec_1_0_a = cute.arch.load(", code)
+        self.assertIn("_tile_unroll_vec_1_0_b = cute.arch.load(", code)
+        # Both halves use V=4.
+        self.assertGreaterEqual(
+            code.count("ir.VectorType.get([4], cutlass.Uint16.mlir_type)"),
+            2,
+        )
+        # The constexpr V-loop now runs 8 iters (not 4).
+        self.assertIn("cutlass.range_constexpr(8)", code)
+        # The per-vec-lane extract uses the if-else split selector so the
+        # constexpr loop unroller picks the right half per iter.
+        self.assertIn("if vec_lane_1 < 4 else", code)
 
     def test_vec_hoist_bf16(self) -> None:
         """The vec hoist must also fire for bf16 (also a uint16-backed type)."""
@@ -391,3 +407,139 @@ class TestCuteSoftmaxCorrectness(TestCase):
                 "cute_vector_widths": [1, 4],
             },
         )
+
+
+@onlyBackends(["cute"])
+class TestCuteMultiRowInvestigation(TestCase):
+    """P13: multi-row CTAs were investigated as a way to lift small-N
+    softmax shapes (e.g. (4096, 256)) toward ATen.  The investigation
+    concluded that within the current Helion CuTe launcher architecture,
+    multi-row CTAs do NOT improve wall-clock perf — the bottleneck is
+    the per-launch Python overhead in ``default_cute_launcher`` (~25us
+    per call), not the per-CTA scheduling overhead.
+
+    Findings (CUDA_VISIBLE_DEVICES=7, B200, fp16):
+
+    * Single-row (autotuned: ``block_sizes=[1, 128]``, ``num_threads=[0, 32]``,
+      ``cute_vector_widths=[1, 4]``): 31us wall / 134 GB/s
+      (4.3us GPU kernel time, ~25us Python launcher overhead).
+    * Multi-row 2/4/8/16/32 rows + serialized M (``num_threads=[1, 32]``):
+      31-36us wall / 116-133 GB/s — no improvement.
+    * Multi-row 8 rows + threaded M (``num_threads=[0, 32]``,
+      shared-mem reduce): 48us wall / 87 GB/s — WORSE due to
+      ``_cute_grouped_reduce_shared_two_stage`` cost.
+    * Hand-coded warp-per-row kernel with ``block=(32, M_block, 1)``:
+      kernel time drops to ~2us (NCU) but wall-clock stays at ~34us
+      because the Helion ``_CompiledCuteLauncher.__call__`` +
+      cutlass DSL ``generate_execution_args`` dominate (~30us per call).
+
+    The "warp-per-row" layout (one CUDA warp per row, with
+    ``thread_idx[0]`` = lane in row, ``thread_idx[1]`` = row index)
+    would require structurally swapping the thread-axis assignment
+    between the M-grid loop and the inner N-tile loop in
+    ``CuteNDTileStrategy``.  Even if implemented, the wall-clock gain
+    is bounded by the launcher overhead.
+
+    Future work to close the (4096, 256) gap should target either:
+    (a) reducing the per-call Helion CuTe launcher overhead, or
+    (b) using CUDA graphs / static launcher (not enabled in the
+    autotuner bench mode), or
+    (c) batching multiple shapes into one launch (kernel-level fusion).
+
+    These tests pin the multi-row configs as compilable / correct so
+    that a future architectural change does not silently regress them.
+    """
+
+    def test_multi_row_serial_8_compiles_and_is_correct(self) -> None:
+        """``block_sizes=[8, 128], num_threads=[1, 32]`` — M serialized
+        via a ``for lane_0 in range(8)`` loop inside the kernel.  This
+        is the path the prompt's example targeted; it does compile and
+        produce correct output, but is slower than single-row.
+        """
+        x = torch.randn(4096, 128, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            softmax_two_pass_kernel,
+            (x,),
+            block_sizes=[8, 128],
+            num_threads=[1, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # The M-axis is serialized — a ``for lane_0 in range(8):`` loop
+        # wraps the per-row body. (8 = block_sizes[0].)
+        self.assertIn("for lane_0 in range(8):", code)
+        # Warp-reduce IS used (since the M-axis doesn't contribute to
+        # group_span — it's serialized, so group_span = reduce_extent =
+        # 32 → warp-reduce path fires).
+        self.assertIn("cute.arch.warp_reduction_max", code)
+        # The launch is still a single-warp block; only the grid count
+        # is reduced (4096 / 8 = 512 CTAs vs 4096).
+        self.assertIn("block=(32, 1, 1)", code)
+
+    def test_multi_row_threaded_8_compiles_uses_shared_reduce(self) -> None:
+        """``block_sizes=[8, 128], num_threads=[0, 32]`` — M is threaded,
+        so we get ``block=(8, 32, 1)`` (M on thread_idx[0], N on
+        thread_idx[1]).  The inner reduction's strided thread-reduction
+        has pre=8, group_span=256, which dispatches to
+        ``_cute_grouped_reduce_shared_two_stage``.  This is the
+        "P9 finding" path: with the current axis layout the warp
+        boundaries don't align with rows (warp 0 = thread_idx[0..7] x
+        thread_idx[1..3] = data from 8 rows × 4 N-segments), so the
+        per-row reduce needs SMEM.  Slower than single-row.
+
+        Note: a true "warp-per-row" layout would require ``block=(32,
+        8, 1)`` (N on thread_idx[0], M on thread_idx[1]) — but the
+        current ``CuteNDTileStrategy`` claims thread axes in the order
+        M (outer grid) → axis 0, N (inner tile) → axis 1.  Swapping
+        would require new infra in ``_BaseNDTileStrategy._thread_axis_map``.
+        """
+        x = torch.randn(4096, 128, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            softmax_two_pass_kernel,
+            (x,),
+            block_sizes=[8, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # Block is (M=8 on thread_idx[0], N=32 on thread_idx[1], 1).
+        # NOT the warp-per-row ``(32, 8, 1)`` that would let warp-reduce
+        # fire — this is the "wrong" layout that hits shared-mem reduce.
+        self.assertIn("block=(8, 32, 1)", code)
+        # Reduction goes through shared-memory two-stage path (the
+        # "bad" path the prompt's P9 warned about).
+        self.assertIn("_cute_grouped_reduce_shared_two_stage", code)
+        # group_span = pre * reduce_extent = 8 * 32 = 256.
+        self.assertIn("group_span=256", code)
+
+    def test_single_row_warp_reduce_is_baseline(self) -> None:
+        """Pin the single-row + warp-reduce config that ``CuteTileVecWarpReduceHeuristic``
+        seeds — this is the autotuner's pick for (4096, 256) and the
+        baseline that multi-row attempts had to beat.  Documents the
+        baseline shape so a future regression in heuristic seed coverage
+        would be caught.
+        """
+        x = torch.randn(4096, 128, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            softmax_two_pass_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # One warp per CTA.
+        self.assertIn("block=(32, 1, 1)", code)
+        # Warp reduce, no shared-mem reduction.
+        self.assertIn("cute.arch.warp_reduction_max", code)
+        self.assertNotIn("_cute_grouped_reduce_shared_two_stage", code)
+        # The two-pass fuser must fire here so the consume sweep
+        # reads x from a register cache (only one ``cute.arch.load``).
+        # For (4096, 128) with block_size 128, trip = 1 → fuser bails;
+        # but the larger N=256 path with block_size=128 has trip=2
+        # which fires the fuser.  Document the trip-1 case here so the
+        # fuser path stays explicit.
+        self.assertEqual(code.count("cute.arch.load("), 2)


### PR DESCRIPTION
Stacked PRs:
 * #2579
 * #2578
 * #2577
 * #2576
 * #2575
 * #2574
 * #2573
 * #2572
 * __->__#2571


--- --- ---

### [cute] V=8 fp16/bf16 via 4+4 split; multi-row investigation tests


V=8 split (helion/language/memory_ops.py):
- _cute_register_tile_unroll_vec_hoist_split2 emits TWO back-to-back
  cute.arch.load(..., V=4) calls covering vec lanes 0-3 and 4-7, with
  hoist vars named _tile_unroll_vec_<N>_<M>_a / ..._b. Per-vec-lane
  extract uses an if/else split selector inside the constexpr V-loop.
- _cute_vector_load_ctx now returns mode "tile_unroll_split2" for V=8
  fp16/bf16 (was returning None due to the DSL nvvm.load.ext ICE).
- Adds the new mode to the load-emit dispatcher.

The split is correct and the fuser fires on both hoist halves, but
empirically V=8-split does NOT outperform V=4 on B200 softmax:

  Shape          V=4 best   V=8-split best
  (4096, 4096)   992 GB/s   885 GB/s
  (4096, 8192)   902 GB/s   887 GB/s
  (4096, 12672) 1447 GB/s   901 GB/s
  (4096, 32768) 1530 GB/s  1002 GB/s
  (8192, 8192)   968 GB/s   969 GB/s (tied)

The split emits 2x LDG.64 which the SASS scheduler does not fully
overlap (the second load has an address dependency on the first via
lane_base + 4), and the doubled fuser cache footprint (2 register
fragments × 50 elements vs 0 fragments for V=4 at the autotuned
point) offsets the bytes gain. The split-2 path stays in the
autotuner search space; the seed defaults to V=4.

Tests in test_cute_softmax_perf.py:
- test_vec_hoist_v8_uses_4plus4_split asserts the split emits two V=4
  hoist vars (_a / _b), range_constexpr(8), and the if/else split
  selector.
- TestCuteMultiRowInvestigation pins multi-row CTA compile/correctness
  behavior and codifies the finding (so future agents don't redo the
  investigation): on (4096, 256) the GPU kernel is 4us but the
  Helion CuTe Python launcher is ~25us per call, dominating wall
  clock. Multi-row would shrink CTA count 8x but not wall time.

No bench regression: average across the QuACK softmax shapes still
stands at ~0.66x ATen.
