### PR TITLE
[cute] Warp-per-row layout for softmax-shape reductions

### DIFF
--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -8,6 +8,7 @@ from .cute import CuteReductionTileHeuristic
 from .cute import CuteReductionWideChunkHeuristic
 from .cute import CuteTcgen05ClusterM2Heuristic
 from .cute import CuteTileVecHeuristic
+from .cute import CuteTileVecWarpPerRowHeuristic
 from .cute import CuteTileVecWarpReduceHeuristic
 from .triton import TritonSkinnyGemmHeuristic
 
@@ -25,6 +26,7 @@ HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
         CuteReductionWideChunkHeuristic,
         CuteTileVecHeuristic,
         CuteTileVecWarpReduceHeuristic,
+        CuteTileVecWarpPerRowHeuristic,
     ),
     "triton": (TritonSkinnyGemmHeuristic,),
 }

--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -349,6 +349,102 @@ class CuteTileVecWarpReduceHeuristic(AutotunerHeuristic):
             return None
 
 
+class CuteTileVecWarpPerRowHeuristic(AutotunerHeuristic):
+    """P15: warp-per-row layout for softmax-shaped tile kernels.
+
+    Sibling seed for ``CuteTileVecWarpReduceHeuristic`` that puts MORE
+    than one row per CTA — each warp owns one row. The warp-per-row
+    plan in ``layout_propagation.py`` swaps the thread-axis assignment
+    so:
+
+    * N (reduction axis) lands on ``thread_idx[0]`` (32 contiguous
+      threads = one warp per row)
+    * M (outer grid row axis) lands on ``thread_idx[1]`` (warp index =
+      row index)
+
+    The strided reduction dispatcher then picks the direct
+    ``cute.arch.warp_reduction_*`` path with ``threads_in_group=32``
+    (group_span == 32, one warp per group), avoiding the
+    cross-warp shared-memory two-stage reduce that would dominate when
+    rows are spread across threads.
+
+    Seeds ``block_sizes=[2, V * 32]``, ``num_threads=[0, 32]``,
+    ``cute_vector_widths=[1, V]`` so each row stays inside a single
+    warp and 2 rows fit in one CTA (giving 64 threads = 2 warps per
+    CTA -> higher occupancy on softmax-shaped reductions).
+
+    Eligible whenever ``CuteTileVecWarpReduceHeuristic`` is eligible
+    and the outer tile fragment admits M >= 2.
+    """
+
+    name = "cute_tile_vec_warp_per_row"
+    backend = "cute"
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        spec = env.config_spec
+        if spec.matmul_facts:
+            return False
+        if len(spec.block_sizes) != 2 or spec.reduction_loops:
+            return False
+        inner_block_id = (
+            cast("Any", spec.block_sizes[1]).block_ids[0]
+            if hasattr(cast("Any", spec.block_sizes[1]), "block_ids")
+            else None
+        )
+        if inner_block_id is None:
+            return False
+        if inner_block_id not in spec.cute_vector_widths.valid_block_ids():
+            return False
+        dtype = _cute_tile_inner_block_dtype(env, device_ir, inner_block_id)
+        vec = _cute_tile_seed_vec_width_for_dtype(dtype)
+        if vec <= 1:
+            return False
+        bn_fragment = cast("Any", spec.block_sizes[1])._fragment(spec)
+        bn_high = getattr(bn_fragment, "high", None)
+        if not isinstance(bn_high, int) or bn_high < vec * 32:
+            return False
+        # Outer (M) fragment must admit M=2 (warp-per-row launches 2
+        # warps per CTA so each row is one warp).
+        bm_fragment = cast("Any", spec.block_sizes[0])._fragment(spec)
+        bm_low = getattr(bm_fragment, "low", 1)
+        bm_high = getattr(bm_fragment, "high", None)
+        if not isinstance(bm_high, int):
+            return False
+        return bm_low <= 2 <= bm_high
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        spec = env.config_spec
+        inner_block_id = (
+            cast("Any", spec.block_sizes[1]).block_ids[0]
+            if hasattr(cast("Any", spec.block_sizes[1]), "block_ids")
+            else None
+        )
+        if inner_block_id is None:
+            return None
+        dtype = _cute_tile_inner_block_dtype(env, device_ir, inner_block_id)
+        vec = _cute_tile_seed_vec_width_for_dtype(dtype)
+        if vec <= 1:
+            return None
+        bn_fragment = cast("Any", spec.block_sizes[1])._fragment(spec)
+        bn_high = getattr(bn_fragment, "high", None)
+        block_n = vec * 32
+        if isinstance(bn_high, int) and bn_high < block_n:
+            return None
+        seed: dict[str, Any] = {
+            "block_sizes": [2, block_n],
+            "num_threads": [0, 32],
+            "cute_vector_widths": [1, vec],
+        }
+        try:
+            return Config(**seed)
+        except Exception:
+            return None
+
+
 class CuteReductionWideChunkHeuristic(AutotunerHeuristic):
     """Companion seed: chunk = max(max_threads, size_hint/2) so the inner
     reduction loop has very few outer iterations and lane_extent absorbs

--- a/helion/_compiler/cute/layout_propagation.py
+++ b/helion/_compiler/cute/layout_propagation.py
@@ -70,6 +70,7 @@ def plan_layouts(
     for graph_info in graphs:
         _seed_constraints(graph_info, tile_strategy)
         _plan_matmul_execution(graph_info, tile_strategy)
+        _plan_warp_per_row_execution(graph_info, tile_strategy)
         _forward_propagate(graph_info)
         _backward_propagate(graph_info)
         _resolve_layouts(graph_info)
@@ -224,6 +225,116 @@ def _plan_matmul_execution(
                 ),
             ),
         )
+
+
+def _plan_warp_per_row_execution(
+    graph_info: GraphInfo,
+    tile_strategy: TileStrategyDispatch,
+) -> None:
+    """Detect the softmax-shaped warp-per-row layout.
+
+    When the kernel has a single 1-D outer grid loop over rows (M-axis)
+    and an inner non-reduction tile loop over the reduction axis (N),
+    and the autotuner picks ``num_threads`` such that:
+
+      * M-block (outer grid) has a thread extent >= 2 (multi-row CTAs)
+      * N-tile (inner) has a thread extent >= 32 and is a multiple of 32
+      * Joint thread extent (M_threads * N_threads) <= 1024
+
+    we want each CUDA warp to own ONE row so the inner reduction can
+    use ``cute.arch.warp_reduction_*`` (single warp shuffle) rather
+    than the cross-warp shared-memory two-stage reduce. That requires
+    swapping the thread-axis assignment so:
+
+      * N (inner) lands on thread_idx[0] (32 contiguous threads per warp)
+      * M (outer grid) lands on thread_idx[1] (warp index = row index)
+
+    This emits a ``CuTeGridExecutionPlan`` that sets
+    ``block_axis_priority`` to put N before M and disables the
+    reduction-axis reservation (no reduction strategy claims a thread
+    axis here — the strided reduction inside the inner tile body picks
+    the warp-reduce path because ``group_span = N_threads = 32`` once
+    M has moved to a higher-indexed thread axis).
+    """
+    from ..host_function import HostFunction
+    from ..reduction_strategy import ReductionStrategy
+    from ..tile_strategy import CuteNDTileStrategy
+
+    if not isinstance(graph_info, RootGraphInfo):
+        return
+    device_ir = HostFunction.current().device_ir
+    # Only one outer grid (1 M-block).
+    if len(device_ir.grid_block_ids) != 1 or len(device_ir.grid_block_ids[0]) != 1:
+        return
+    (m_block_id,) = device_ir.grid_block_ids[0]
+    # No MMA — those use a different plan.
+    matmul_nodes = [
+        node
+        for node in graph_info.graph.nodes
+        if node.op == "call_function" and node.target is torch.ops.aten.mm.default
+    ]
+    if matmul_nodes:
+        return
+    # Don't conflict with a plan already attached for this graph (e.g.
+    # the matmul plan above).
+    if graph_info.cute_grid_execution_plans:
+        return
+    # No reduction strategy (rolled reduction) — that path runs the
+    # CuteTileVecWarpReduceHeuristic-style single-row layout already.
+    if any(
+        isinstance(s, ReductionStrategy) and s.thread_axes_used() > 0
+        for s in tile_strategy.strategies
+    ):
+        return
+    # Find the M strategy (outer grid) and the N strategy (inner tile)
+    # by walking ``tile_strategy.strategies``.  The M strategy owns
+    # ``m_block_id``; the N strategy is any other CuteNDTileStrategy
+    # with a different block_id and at least one thread axis.
+    m_strategy = tile_strategy.block_id_to_strategy.get((m_block_id,))
+    if not isinstance(m_strategy, CuteNDTileStrategy):
+        return
+    if m_strategy.thread_axes_used() != 1:
+        return
+    m_threads = tile_strategy.thread_extent_for_block_id(m_block_id)
+    if not isinstance(m_threads, int) or m_threads < 2:
+        return
+    n_strategies: list[CuteNDTileStrategy] = []
+    for strategy in tile_strategy.strategies:
+        if strategy is m_strategy:
+            continue
+        if not isinstance(strategy, CuteNDTileStrategy):
+            continue
+        if strategy.thread_axes_used() != 1:
+            continue
+        if m_block_id in strategy.block_ids:
+            continue
+        n_strategies.append(strategy)
+    if not n_strategies:
+        return
+    n_block_ids = {bid for s in n_strategies for bid in s.block_ids}
+    if len(n_block_ids) != 1:
+        # Multiple distinct inner blocks — not the simple softmax shape.
+        return
+    (n_block_id,) = n_block_ids
+    n_threads = tile_strategy.thread_extent_for_block_id(n_block_id)
+    if not isinstance(n_threads, int) or n_threads < 32 or n_threads % 32 != 0:
+        return
+    # Joint thread budget check.
+    from .thread_budget import MAX_THREADS_PER_BLOCK
+
+    if m_threads * n_threads > MAX_THREADS_PER_BLOCK:
+        return
+    graph_info.cute_grid_execution_plans = (
+        *graph_info.cute_grid_execution_plans,
+        CuTeGridExecutionPlan(
+            scoped_block_ids=frozenset({m_block_id, n_block_id}),
+            block_axis_priority={
+                n_block_id: 0,
+                m_block_id: 1,
+            },
+            disable_reduction_axis_reservation_for=frozenset({m_block_id, n_block_id}),
+        ),
+    )
 
 
 def _direct_grouped_n_scalar_block_id(

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -1663,6 +1663,20 @@ class BlockReductionStrategy(ReductionStrategy):
                 logical_axis_sizes,
             )
             return None
+        # Skip to the direct ``cute.arch.warp_reduction_*`` path when the
+        # entire CTA is a single warp (num_threads == group_span <= 32):
+        # the standard ``call_reduction_function`` can emit a one-shot
+        # warp_reduction with ``threads_in_group=group_span``.
+        #
+        # When ``num_threads > group_span`` (e.g. warp-per-row layouts
+        # with multiple warps per CTA, each owning one row), keep the
+        # ``_cute_grouped_reduce_warp`` path at the bottom — it picks
+        # the right per-warp reduce even when other thread axes coexist
+        # within the CTA.  The "skip" shortcut would route through
+        # ``_needs_loop_carried_accumulator``, which returns True when
+        # the reduction block is no longer in ``active_device_loops``
+        # (e.g. ``cute_dynamic_row_sum``'s ``acc.sum(-1)`` after the
+        # inner ``hl.tile`` exits) and would silently drop the reduce.
         if pre <= 1 and group_span <= 32 and num_threads == group_span:
             debug(
                 "skip small direct",

--- a/helion/_compiler/tile_dispatch.py
+++ b/helion/_compiler/tile_dispatch.py
@@ -334,14 +334,34 @@ class TileStrategyDispatch:
         return branches
 
     def thread_axis_for_strategy(self, target: TileStrategy) -> int | None:
-        """Return the starting thread-axis index for a strategy in its branch."""
+        """Return the starting thread-axis index for a strategy in its branch.
+
+        Strategies that share their entire ``block_ids`` set with an
+        earlier strategy in the branch (e.g. two sibling ``hl.tile`` loops
+        over the same N-axis in a softmax kernel) reuse the earlier
+        strategy's thread axis — they are mutually exclusive in time, so
+        they map to the same hardware lane.  Without this dedup the
+        warp-per-row layout would assign one axis per inner tile loop
+        and bury M on axis 2 or 3.
+        """
         for branch in self._strategy_branches():
             if target not in branch:
                 continue
             axis = 0
+            seen_block_id_sets: dict[tuple[int, ...], int] = {}
             for strategy in self._ordered_strategies_for_branch(branch):
+                key = tuple(sorted(strategy.block_ids))
+                cached = seen_block_id_sets.get(key)
+                if cached is not None:
+                    # Same block-id footprint as an earlier sibling —
+                    # they're mutually exclusive in time so they share
+                    # the axis.
+                    if strategy is target:
+                        return cached
+                    continue
                 if strategy is target:
                     return axis
+                seen_block_id_sets[key] = axis
                 axis += strategy.thread_axes_used()
         return None
 

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -680,10 +680,34 @@ class BlockSizeTileStrategy(TileStrategy):
         Counts axes already claimed by active device loops, reserving at
         least one axis for reduction strategies when the backend places
         reductions first.
+
+        When a ``CuTeGridExecutionPlan`` with ``block_axis_priority`` is
+        in scope for this strategy's blocks, the offset is instead
+        derived from ``thread_axis_for_strategy`` so the M/N axis order
+        is dictated by the plan (e.g. the warp-per-row layout swaps the
+        outer M-grid and inner N-tile axes so each warp owns one row).
         """
         from .reduction_strategy import ReductionStrategy
 
         env = CompileEnvironment.current()
+
+        # Plan-driven path: honor ``block_axis_priority`` so the outer
+        # grid loop can reserve an axis for a lower-priority inner tile
+        # loop even when that inner loop has not yet entered
+        # ``active_device_loops``.  Used by the warp-per-row layout where
+        # the outer M-grid must take a HIGHER thread-axis index than the
+        # inner N-tile so 32 contiguous threads on axis 0 form one warp
+        # per row.
+        plan = self.fn.tile_strategy.current_cute_grid_execution_plan(
+            block_ids=self.block_ids
+        )
+        if plan is not None and any(
+            plan.priority_for_block(block_id) is not None for block_id in self.block_ids
+        ):
+            offset = self.fn.tile_strategy.thread_axis_for_strategy(self)
+            if offset is not None:
+                return offset
+
         seen: set[int] = set()
         active_reduction_axes = 0
         active_non_reduction_axes = 0
@@ -707,9 +731,6 @@ class BlockSizeTileStrategy(TileStrategy):
         has_reduction_strategy = any(
             isinstance(strategy, ReductionStrategy) and strategy.thread_axes_used() > 0
             for strategy in self.fn.tile_strategy.strategies
-        )
-        plan = self.fn.tile_strategy.current_cute_grid_execution_plan(
-            block_ids=self.block_ids
         )
         if plan is not None and any(
             plan.disables_reduction_axis_reservation(block_id)

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -3008,7 +3008,16 @@ class TestCuteBackend(TestCase):
         self.assertIn("cute.arch.warp_reduction_sum", code)
         self.assertNotIn("cute.gemm", code)
 
-    def test_strided_threaded_reduction_cross_warp_shared_memory(self) -> None:
+    def test_strided_threaded_reduction_uses_warp_per_row(self) -> None:
+        """With ``block_sizes=[32, 32]`` and the default
+        ``num_threads=[32, 32]`` the warp-per-row plan (P15) swaps the
+        thread-axis assignment so each warp owns one M-row.  The
+        ``acc.sum(-1)`` then lowers to a per-warp reduction (each warp
+        sums its row across the 32 lanes) instead of routing through
+        the cross-warp ``_cute_grouped_reduce_shared_two_stage`` SMEM
+        path.  The launch dim stays ``(32, 32, 1)`` (N on axis 0, M on
+        axis 1) so the joint thread count still fits the budget.
+        """
         args = (
             torch.randn(512, 512, device=DEVICE, dtype=torch.float32),
             torch.tensor([200], device=DEVICE, dtype=torch.int64),
@@ -3018,4 +3027,8 @@ class TestCuteBackend(TestCase):
         expected = x[:, : end.item()].sum(dim=1)
         torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
         self.assertIn("block=(32, 32, 1)", code)
-        self.assertIn("_cute_grouped_reduce_shared_two_stage", code)
+        # Each warp reduces its own row via ``_cute_grouped_reduce_warp``
+        # with ``group_span=32``; no shared-memory two-stage reduce.
+        self.assertIn("_cute_grouped_reduce_warp", code)
+        self.assertIn("group_span=32", code)
+        self.assertNotIn("_cute_grouped_reduce_shared_two_stage", code)

--- a/test/test_cute_softmax_perf.py
+++ b/test/test_cute_softmax_perf.py
@@ -571,22 +571,20 @@ class TestCuteMultiRowInvestigation(TestCase):
         # is reduced (4096 / 8 = 512 CTAs vs 4096).
         self.assertIn("block=(32, 1, 1)", code)
 
-    def test_multi_row_threaded_8_compiles_uses_shared_reduce(self) -> None:
-        """``block_sizes=[8, 128], num_threads=[0, 32]`` — M is threaded,
-        so we get ``block=(8, 32, 1)`` (M on thread_idx[0], N on
-        thread_idx[1]).  The inner reduction's strided thread-reduction
-        has pre=8, group_span=256, which dispatches to
-        ``_cute_grouped_reduce_shared_two_stage``.  This is the
-        "P9 finding" path: with the current axis layout the warp
-        boundaries don't align with rows (warp 0 = thread_idx[0..7] x
-        thread_idx[1..3] = data from 8 rows × 4 N-segments), so the
-        per-row reduce needs SMEM.  Slower than single-row.
+    def test_multi_row_threaded_8_uses_warp_per_row(self) -> None:
+        """``block_sizes=[8, 128], num_threads=[0, 32]`` — M is threaded.
 
-        Note: a true "warp-per-row" layout would require ``block=(32,
-        8, 1)`` (N on thread_idx[0], M on thread_idx[1]) — but the
-        current ``CuteNDTileStrategy`` claims thread axes in the order
-        M (outer grid) → axis 0, N (inner tile) → axis 1.  Swapping
-        would require new infra in ``_BaseNDTileStrategy._thread_axis_map``.
+        With the warp-per-row layout (P15), the codegen swaps the
+        thread-axis assignment so N (the reduction axis) lands on
+        ``thread_idx[0]`` (32 contiguous threads = one warp per row)
+        and M lands on ``thread_idx[1]`` (warp index = row index).
+        Each warp's per-row reduction uses ``_cute_grouped_reduce_warp``
+        with ``pre=1, group_span=32`` (one warp shuffle per warp), NOT
+        the cross-warp ``_cute_grouped_reduce_shared_two_stage`` path.
+
+        The launch becomes ``block=(32, 8, 1)`` (was ``(8, 32, 1)``
+        before P15) and the joint thread count is 8 × 32 = 256, giving
+        8 warps per CTA for higher occupancy on softmax-shaped kernels.
         """
         x = torch.randn(4096, 128, device=DEVICE, dtype=HALF_DTYPE)
         code, out = code_and_output(
@@ -598,15 +596,55 @@ class TestCuteMultiRowInvestigation(TestCase):
         )
         ref = torch.nn.functional.softmax(x, dim=1)
         torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
-        # Block is (M=8 on thread_idx[0], N=32 on thread_idx[1], 1).
-        # NOT the warp-per-row ``(32, 8, 1)`` that would let warp-reduce
-        # fire — this is the "wrong" layout that hits shared-mem reduce.
-        self.assertIn("block=(8, 32, 1)", code)
-        # Reduction goes through shared-memory two-stage path (the
-        # "bad" path the prompt's P9 warned about).
-        self.assertIn("_cute_grouped_reduce_shared_two_stage", code)
-        # group_span = pre * reduce_extent = 8 * 32 = 256.
-        self.assertIn("group_span=256", code)
+        # Warp-per-row launch: N (the reduction axis with 32 threads)
+        # lands on axis 0, M (8 rows) lands on axis 1.
+        self.assertIn("block=(32, 8, 1)", code)
+        # Each warp reduces its own row via _cute_grouped_reduce_warp
+        # — NO cross-warp SMEM reduce.
+        self.assertIn("_cute_grouped_reduce_warp", code)
+        self.assertIn("pre=1, group_span=32", code)
+        self.assertNotIn("_cute_grouped_reduce_shared_two_stage", code)
+
+    def test_warp_per_row_axis_swap_emits_warp_reduce(self) -> None:
+        """P15: when M is threaded (``num_threads=[0, 32]``) the warp-per-row
+        plan swaps the thread-axis assignment so:
+
+        * N (inner reduction axis) lands on ``thread_idx[0]``
+        * M (outer grid row axis) lands on ``thread_idx[1]``
+
+        And the reduction dispatcher picks the per-warp
+        ``_cute_grouped_reduce_warp`` path with ``pre=1, group_span=32``
+        (each warp does ONE warp shuffle for its own row independently)
+        instead of ``_cute_grouped_reduce_shared_two_stage`` (the
+        cross-warp SMEM path that would dominate without the axis swap).
+        """
+        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            softmax_two_pass_kernel,
+            (x,),
+            block_sizes=[2, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # The launch is ``block=(32, 2, 1)`` — N on axis 0 (32 threads
+        # per warp = one row), M on axis 1 (2 warps = 2 rows).
+        self.assertIn("block=(32, 2, 1)", code)
+        # M uses ``thread_idx[1]`` for the row index.
+        self.assertIn(
+            "indices_0 = tile_offset_0 + cutlass.Int32(cute.arch.thread_idx()[1])",
+            code,
+        )
+        # N uses ``thread_idx[0]`` for the lane (32 contiguous lanes).
+        self.assertIn("cute.arch.thread_idx()[0]) * 4", code)
+        # Per-warp reduce via ``_cute_grouped_reduce_warp`` (with pre=1
+        # the helper does ONE warp shuffle per warp -- effectively the
+        # direct cute.arch.warp_reduction_* path).
+        self.assertIn("_cute_grouped_reduce_warp", code)
+        self.assertIn("pre=1, group_span=32", code)
+        # NO shared-memory two-stage reduce.
+        self.assertNotIn("_cute_grouped_reduce_shared_two_stage", code)
 
     def test_single_row_warp_reduce_is_baseline(self) -> None:
         """Pin the single-row + warp-reduce config that ``CuteTileVecWarpReduceHeuristic``

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -113,8 +113,11 @@ class TestReductions(RefEagerTestBase, TestCase):
     def test_cross_warp_reduction_non_sum_ops(self):
         """Exercise shared-memory (two-stage) strided reduction for non-sum ops.
 
-        Using block_sizes=[4, 32] gives group_span=128 (>32 and %32==0),
-        which triggers the shared two-stage reduction path on CuTe.
+        Using block_sizes=[1, 128] keeps the outer M-block at one row per
+        CTA (so the warp-per-row layout's ``m_threads >= 2`` check fails)
+        while the inner reduction spans 128 threads (4 warps cooperating
+        on a single row), giving group_span=128 (>32 and %32==0) which
+        triggers the shared two-stage reduction path on CuTe.
         """
 
         @helion.kernel(autotune_effort="none")
@@ -162,7 +165,7 @@ class TestReductions(RefEagerTestBase, TestCase):
         ]
         for kernel, ref_fn in cases:
             with self.subTest(kernel=kernel.__name__):
-                code, out = code_and_output(kernel, (x,), block_sizes=[4, 32])
+                code, out = code_and_output(kernel, (x,), block_sizes=[1, 128])
                 torch.testing.assert_close(out, ref_fn(x), rtol=1e-4, atol=1e-4)
                 if _get_backend() == "cute":
                     self.assertIn("_cute_grouped_reduce_shared_two_stage", code)


### PR DESCRIPTION
Stacked PRs:
 * #2579
 * #2578
 * #2577
 * #2576
 * #2575
 * #2574
 * __->__#2573


--- --- ---

### [cute] Warp-per-row layout for softmax-shape reductions


Adds support for processing multiple rows per CTA where each warp
handles ONE row independently — no cross-warp reduce needed.
Previously the autotuner could only pick block_sizes=[1, ...] (1
warp/CTA, 50% theoretical occupancy on B200); the multi-row configs
went through SMEM two-stage reduce, regressing perf.

Pieces:

- layout_propagation.py: detect "softmax shape" (1 outer grid block on
  M, 1 inner non-reduction tile on N, no MMA, joint threads <= 1024,
  N has 32-multiple threads). Emit CuTeGridExecutionPlan that swaps
  the thread-axis priority so N is on thread_idx[0] (32 lanes/warp =
  1 warp per row) and M is on thread_idx[1] (warp index = row index).

- tile_strategy.py: _compute_thread_axis_offset now honors the plan's
  block_axis_priority. The outer M strategy reserves axis 0 for the
  inner N tile loop even before N's loop is active.

- tile_dispatch.py: thread_axis_for_strategy dedups strategies that
  share their full block_ids set with an earlier sibling in the same
  branch — softmax's two hl.tile(n) loops are mutually exclusive in
  time, so they share the same thread axis. Without this dedup the
  warp-per-row layout would push M to axis 2 or 3.

- reduction_strategy.py: clarifies the existing dispatch — with
  warp-per-row group_span == num_threads_per_row (32), so the
  dispatcher naturally falls through to _cute_grouped_reduce_warp
  (no SMEM two-stage).

- autotuner_heuristics/cute.py: CuteTileVecWarpPerRowHeuristic seeds
  block_sizes=[2, V*32], num_threads=[0, 32], cute_vector_widths=[1, V].

Bench (HELION_AUTOTUNE_EFFORT=quick, B200, fp16, M=4096):
  Shape          Pre-P15   Post-P15   Delta
  (4096, 256)     67 GB/s   85 GB/s   +26%   (autotuner picks [2, 128]/[2, 32])
  (4096, 6400)  1136 GB/s 1190 GB/s   + 5%
  (4096, 12672) 1448 GB/s 1448 GB/s   flat   (single-row still wins here)
  average        884 GB/s  908 GB/s   + 3%

Tests:
- test_cute_softmax_perf.py: test_warp_per_row_axis_swap_emits_warp_reduce,
  test_multi_row_threaded_8_uses_warp_per_row (renamed).
- test_cute_backend.py: test_strided_threaded_reduction_uses_warp_per_row
  (renamed from _shared_memory variant; the inputs that previously
  triggered SMEM now go through the warp-per-row layout).

Generated kernel for [2, 128] /[0, 32] / V=4 launches block=(32, 2, 1)
with thread_idx[1] indexing the row and thread_idx[0] indexing the
warp lane; emits _cute_grouped_reduce_warp (not the two-stage SMEM
helper).
