### PR TITLE
[test] Split cute compiler-pass tests by pass, drop kernel name from filenames

### DIFF
--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -14,6 +14,7 @@ from helion._testing import HALF_DTYPE
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
+from helion.exc import BackendUnsupported
 import helion.language as hl
 from helion.runtime import _create_cute_direct_entry
 from helion.runtime import _cute_cluster_shape
@@ -3032,3 +3033,121 @@ class TestCuteBackend(TestCase):
         self.assertIn("_cute_grouped_reduce_warp", code)
         self.assertIn("group_span=32", code)
         self.assertNotIn("_cute_grouped_reduce_shared_two_stage", code)
+
+
+@helion.kernel(backend="cute")
+def _cute_2d_tile_reduction_kernel(x: torch.Tensor) -> torch.Tensor:
+    """2D reduction kernel: outer M-grid tile + inner N-reduction tile.
+
+    Used by the thread-budget rejection tests and the warp-reduce
+    heuristic registration test below.
+    """
+    m, n = x.size()
+    out = torch.empty_like(x)
+    block_size_m = hl.register_block_size(m)
+    block_size_n = hl.register_block_size(n)
+    for tile_m in hl.tile(m, block_size=block_size_m):
+        mi = hl.full([tile_m], float("-inf"), dtype=torch.float32)
+        di = hl.zeros([tile_m], dtype=torch.float32)
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            local_amax = torch.amax(values, dim=1)
+            mi_next = torch.maximum(mi, local_amax)
+            di = di * torch.exp(mi - mi_next) + torch.exp(
+                values - mi_next[:, None]
+            ).sum(dim=1)
+            mi = mi_next
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            out[tile_m, tile_n] = torch.exp(values - mi[:, None]) / di[:, None]
+    return out
+
+
+@onlyBackends(["cute"])
+class TestCuteThreadBudgetRejection(TestCase):
+    """The CuTe launcher raises ``BackendUnsupported`` when a config
+    would force the launcher to silently truncate the joint thread
+    count below what codegen committed to.
+
+    The original bug: codegen for ``block_sizes=[8, 1024], num_threads=
+    [0, 256]`` commits to an 8 * 256 = 2048-thread layout, but the
+    launcher caps at MAX_THREADS_PER_BLOCK = 1024 → an axis is silently
+    dropped and the kernel writes nan.  The guard (in
+    ``CuteBackend.launcher_keyword_args``) rejects such configs cleanly
+    so the autotuner doesn't record them as "fast but wrong".
+    """
+
+    def test_joint_thread_overflow_rejected(self) -> None:
+        """A 2048-thread codegen budget on a launcher capped at 1024
+        MUST raise ``BackendUnsupported`` instead of silently truncating.
+        """
+        x = torch.randn(4096, 1024, device=DEVICE, dtype=HALF_DTYPE)
+        with pytest.raises(BackendUnsupported):
+            code_and_output(
+                _cute_2d_tile_reduction_kernel,
+                (x,),
+                block_sizes=[8, 1024],
+                num_threads=[0, 256],
+                cute_vector_widths=[1, 4],
+            )
+
+    def test_in_budget_multi_row_passes(self) -> None:
+        """A multi-row config that DOES fit in 1024 threads must still
+        compile and run cleanly — the rejection must be precise, not
+        over-broad.
+        """
+        x = torch.randn(4096, 256, device=DEVICE, dtype=HALF_DTYPE)
+        _, out = code_and_output(
+            _cute_2d_tile_reduction_kernel,
+            (x,),
+            block_sizes=[2, 256],
+            num_threads=[1, 32],  # 2 * 32 = 64 threads — within budget
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+
+@onlyBackends(["cute"])
+class TestCuteTileVecWarpReduceHeuristic(TestCase):
+    """Pins the ``CuteTileVecWarpReduceHeuristic`` autotuner seed:
+    ``block_sizes=[1, V*32]``, ``num_threads=[0, 32]``,
+    ``cute_vector_widths=[1, V]`` — the warp-reduce config family that
+    is the picked default for 2D reduction kernels with no rolled
+    reduction.
+    """
+
+    def test_seed_compiles_to_warp_reduction(self) -> None:
+        """The seed config must produce a working kernel that uses
+        ``cute.arch.warp_reduction_*`` and not the shared-memory
+        two-stage reduce.
+        """
+        x = torch.randn(4096, 6400, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _cute_2d_tile_reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        self.assertIn("cute.arch.warp_reduction_max", code)
+        self.assertIn("cute.arch.warp_reduction_sum", code)
+        # Block of 32 threads on the reduction axis — exactly one warp.
+        self.assertIn("block=(32, 1, 1)", code)
+        # Should NOT use the shared-memory two-stage reduce at this size.
+        self.assertNotIn("_cute_grouped_reduce_shared_two_stage", code)
+
+    def test_heuristic_class_is_registered(self) -> None:
+        """The class must be discoverable and registered for the cute
+        backend so the autotuner can use it as a seed.
+        """
+        from helion._compiler.autotuner_heuristics import HEURISTICS_BY_BACKEND
+        from helion._compiler.autotuner_heuristics.cute import (
+            CuteTileVecWarpReduceHeuristic,
+        )
+
+        self.assertIn(
+            CuteTileVecWarpReduceHeuristic, HEURISTICS_BY_BACKEND.get("cute", ())
+        )

--- a/test/test_cute_fuse_two_pass_loads.py
+++ b/test/test_cute_fuse_two_pass_loads.py
@@ -1,0 +1,149 @@
+"""Tests for the CuTe ``fuse_two_pass_loads`` AST pass.
+
+When a kernel reads the same gmem tensor in two sequential inner-tile
+loops over the same range, the pass detects the redundant load and
+caches the first sweep's values in a small ``cute.make_fragment(...)``.
+The second sweep then reads from the fragment instead of issuing a
+second LDG, eliminating the duplicate HBM/L1 traffic.
+
+The pass canonicalizes per-sweep variable names (``mask_<N>``,
+``lane_base_<N>``, ``vec_lane_<N>``, ``_tile_unroll_vec_<N>_<M>``) so
+the two sweeps' load expressions compare equal modulo the rename
+suffix. Without canonicalization, ``vec_lane_1`` vs ``vec_lane_2``
+would mis-key the fuser's match table and the cache would never fire.
+
+Lives in ``helion/_compiler/cute/fuse_two_pass_loads.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import HALF_DTYPE
+from helion._testing import TestCase
+from helion._testing import code_and_output
+from helion._testing import onlyBackends
+import helion.language as hl
+
+cutlass = pytest.importorskip("cutlass")
+cute = pytest.importorskip("cutlass.cute")
+
+
+@pytest.fixture(autouse=True)
+def _disable_online_to_3pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tests in this file pin codegen details of the ORIGINAL online
+    two-pass form.  The ``online_to_3pass`` rewrite would change them,
+    so disable it here; the rewrite itself is covered in
+    ``test_cute_online_to_3pass.py``.
+    """
+    monkeypatch.setenv("HELION_DISABLE_ONLINE_TO_3PASS", "1")
+
+
+@helion.kernel(backend="cute")
+def _reduction_kernel(x: torch.Tensor) -> torch.Tensor:
+    m, n = x.size()
+    out = torch.empty_like(x)
+    block_size_m = hl.register_block_size(m)
+    block_size_n = hl.register_block_size(n)
+    for tile_m in hl.tile(m, block_size=block_size_m):
+        mi = hl.full([tile_m], float("-inf"), dtype=torch.float32)
+        di = hl.zeros([tile_m], dtype=torch.float32)
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            local_amax = torch.amax(values, dim=1)
+            mi_next = torch.maximum(mi, local_amax)
+            di = di * torch.exp(mi - mi_next) + torch.exp(
+                values - mi_next[:, None]
+            ).sum(dim=1)
+            mi = mi_next
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            out[tile_m, tile_n] = torch.exp(values - mi[:, None]) / di[:, None]
+    return out
+
+
+@onlyBackends(["cute"])
+class TestCuteFuseTwoPassLoads(TestCase):
+    def test_fuser_fires_with_vec_hoist(self) -> None:
+        """When the vec hoist runs, the two sweeps' loads use names like
+        ``lane_base_1`` vs ``lane_base_2``, ``vec_lane_1`` vs ``vec_lane_2``,
+        and ``_tile_unroll_vec_1_0`` vs ``_tile_unroll_vec_1_1``. The
+        alias map canonicalizes these so the fuser matches and emits one
+        ``_fuse_cache_*`` fragment instead of re-reading from gmem.
+
+        The cache_size cap is 64; for inner-tile trip=8 and lane_trip=1
+        the cache_size=8 fits.
+        """
+        x = torch.randn(4096, 1024, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # Cache fragment allocated.
+        self.assertIn("_fuse_cache_", code)
+        # When the load-pipeline pass is OFF the consume sweep just
+        # reads from cache so the kernel has 1 ``cute.arch.load`` total.
+        # With pipelining ON the reduce sweep's load is hoisted into a
+        # prologue + per-iter prefetch (2 load sites), so the total is
+        # 2. The consume sweep emits NO load (cache hit) either way.
+        load_count = code.count("cute.arch.load(")
+        self.assertTrue(
+            load_count in {1, 2},
+            f"expected 1 or 2 cute.arch.load sites, got {load_count}",
+        )
+        # The consume sweep (second top-level ``for tile_offset`` loop)
+        # must not contain a gmem load.
+        consume_marker = "for tile_offset_2 in range"
+        consume_start = code.rfind(consume_marker)
+        self.assertGreater(consume_start, 0)
+        self.assertNotIn(
+            "cute.arch.load(",
+            code[consume_start:],
+            "consume sweep must read from _fuse_cache_, not gmem",
+        )
+
+    def test_fuser_skips_when_cache_size_too_large(self) -> None:
+        """The fuser caps cache_size at 64 to avoid the register-pressure
+        regression measured earlier when the per-thread fragment grew
+        beyond the register budget. So for trip > 64 the consume sweep
+        still loads from gmem.
+
+        For (4096, 12672) with block_size 128, trip = 99, V = 4, so the
+        cache_size would be 99 — fuser must bail.
+        """
+        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # Both sweeps load from gmem (cache fragment NOT allocated since
+        # the fuser bails on cache_size > 64).
+        self.assertNotIn("_fuse_cache_", code)
+        # When the load-pipeline pass is OFF the kernel has exactly
+        # 2 ``cute.arch.load`` calls (one per sweep).  With pipelining
+        # ON each load site is hoisted into a prologue and a per-iter
+        # prefetch, so the total is 4.  Both forms are correct; assert
+        # at least 2.
+        self.assertGreaterEqual(code.count("cute.arch.load("), 2)
+        # Each sweep must contain at least one gmem load.
+        first_sweep_marker = "for tile_offset_2 in range"
+        first_sweep_start = code.find(first_sweep_marker)
+        second_sweep_start = code.find(first_sweep_marker, first_sweep_start + 1)
+        self.assertGreater(second_sweep_start, first_sweep_start)
+        first_sweep = code[first_sweep_start:second_sweep_start]
+        second_sweep = code[second_sweep_start:]
+        self.assertIn("cute.arch.load(", first_sweep)
+        self.assertIn("cute.arch.load(", second_sweep)

--- a/test/test_cute_hoist_loop_invariant_recip.py
+++ b/test/test_cute_hoist_loop_invariant_recip.py
@@ -1,0 +1,318 @@
+"""Tests for the CuTe ``hoist_loop_invariant_recips`` AST pass.
+
+A multi-sub-pass orchestration that runs after the strategy lowers the
+kernel and before the cute DSL trace:
+
+1. **Alias DCE** — inline pure SSA-style ``NAME = ANOTHER_NAME`` chains
+   so the per-iter ``mi_copy = mi; mi_copy_0 = mi_copy`` aliases that
+   Helion's SSA maintenance leaves behind collapse to direct ``mi``
+   reads.
+2. **Reciprocal hoist** (the original P16 pass, now outer-in) — walks
+   for-loops outer-to-inner and rewrites ``x / scalar`` to
+   ``inv = 1.0 / scalar`` hoisted above the OUTERMOST legal scope plus
+   ``x * inv`` inside. fp32 divide is ~22 cycles on B200 vs ~2 for
+   multiply, and softmax's consume sweep emits one divide per fp16
+   element across N elements per row.
+3. **FMA-friendly scale hoist** — ``(A - INV) * CONST`` where ``INV``
+   is loop-invariant becomes ``A * CONST - HOISTED`` where
+   ``HOISTED = INV * CONST`` is hoisted above the loop. Same value,
+   one fewer inner-loop multiply, and FMA-friendly for ptx codegen.
+4. **DCE for dead pure assigns** — removes the original ``v_X = A - INV``
+   subs that became dead after the FMA hoist.
+
+The hoist-OUT passes (2 and 3) use a **canonical-aware invariance**
+mode that maps names through Helion's rename-group map so ``v_1_0``
+(which renames to ``mi`` post-pass) is recognized as the SAME variable
+as ``mi``. Without this canonicalization the FMA hoist would lift
+``mi * 1.4427`` ABOVE the reduce loop and capture the stale initial
+``-inf`` value of ``mi``, producing wildly wrong outputs.
+
+Lives in ``helion/_compiler/cute/hoist_loop_invariant_recip.py``.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import HALF_DTYPE
+from helion._testing import TestCase
+from helion._testing import code_and_output
+from helion._testing import onlyBackends
+import helion.language as hl
+
+cutlass = pytest.importorskip("cutlass")
+cute = pytest.importorskip("cutlass.cute")
+
+
+@pytest.fixture(autouse=True)
+def _disable_online_to_3pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tests in this file pin codegen details of the ORIGINAL online
+    two-pass form.  The ``online_to_3pass`` rewrite would change them,
+    so disable it here; the rewrite itself is covered in
+    ``test_cute_online_to_3pass.py``.
+    """
+    monkeypatch.setenv("HELION_DISABLE_ONLINE_TO_3PASS", "1")
+
+
+@helion.kernel(backend="cute")
+def _reduction_kernel(x: torch.Tensor) -> torch.Tensor:
+    m, n = x.size()
+    out = torch.empty_like(x)
+    block_size_m = hl.register_block_size(m)
+    block_size_n = hl.register_block_size(n)
+    for tile_m in hl.tile(m, block_size=block_size_m):
+        mi = hl.full([tile_m], float("-inf"), dtype=torch.float32)
+        di = hl.zeros([tile_m], dtype=torch.float32)
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            local_amax = torch.amax(values, dim=1)
+            mi_next = torch.maximum(mi, local_amax)
+            di = di * torch.exp(mi - mi_next) + torch.exp(
+                values - mi_next[:, None]
+            ).sum(dim=1)
+            mi = mi_next
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            out[tile_m, tile_n] = torch.exp(values - mi[:, None]) / di[:, None]
+    return out
+
+
+@onlyBackends(["cute"])
+class TestCuteHoistRecip(TestCase):
+    """Reciprocal hoist (P16 + outer-in walk from P17)."""
+
+    def test_recip_hoist_fires_on_two_pass_pattern(self) -> None:
+        """The consume sweep's per-element divide by ``di`` (a per-row
+        scalar) must be rewritten to a single hoisted
+        ``_helion_inv_div_*`` reciprocal + multiply.
+        """
+        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # The hoisted reciprocal declaration must reference the
+        # loop-external root name ``di``.
+        self.assertIn("_helion_inv_div_", code)
+        self.assertIn("= 1.0 / di", code)
+        # The inner divide must have been rewritten to a multiply against
+        # the hoisted reciprocal name.
+        self.assertIn("* _helion_inv_div_", code)
+        # The original per-element divide pattern is no longer present.
+        self.assertNotIn("/ di_copy_1_0", code)
+
+    def test_recip_hoist_does_not_fire_on_loop_dependent_divisor(self) -> None:
+        """When the divisor changes per-iteration (e.g. ``local_sum``
+        computed inside the loop), the pass must NOT hoist it.
+        """
+
+        @helion.kernel(backend="cute")
+        def divide_inside_loop(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(m):
+                for tile_n in hl.tile(n):
+                    values = x[tile_m, tile_n]
+                    # The divisor changes per tile_n iteration.
+                    local_sum = torch.sum(values, dim=1, keepdim=True)
+                    out[tile_m, tile_n] = values / local_sum
+            return out
+
+        x = torch.randn(4096, 1024, device=DEVICE, dtype=HALF_DTYPE)
+        code, _ = code_and_output(
+            divide_inside_loop,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        # No reciprocal hoist — local_sum is recomputed every iter.
+        self.assertNotIn("_helion_inv_div_", code)
+
+    def test_recip_hoist_disable_env(self) -> None:
+        """``HELION_DISABLE_HOIST_RECIP=1`` disables the pass for
+        experimentation.
+        """
+        old = os.environ.get("HELION_DISABLE_HOIST_RECIP")
+        os.environ["HELION_DISABLE_HOIST_RECIP"] = "1"
+        try:
+            x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
+            code, out = code_and_output(
+                _reduction_kernel,
+                (x,),
+                block_sizes=[1, 128],
+                num_threads=[0, 32],
+                cute_vector_widths=[1, 4],
+            )
+            ref = torch.nn.functional.softmax(x, dim=1)
+            torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+            # No reciprocal hoist with the env disabled.
+            self.assertNotIn("_helion_inv_div_", code)
+            # The original per-element divide is still there.
+            self.assertIn("/ di_copy_", code)
+        finally:
+            if old is None:
+                os.environ.pop("HELION_DISABLE_HOIST_RECIP", None)
+            else:
+                os.environ["HELION_DISABLE_HOIST_RECIP"] = old
+
+
+@onlyBackends(["cute"])
+class TestCuteAliasDCE(TestCase):
+    """Alias DCE sub-pass (inline SSA-style ``NAME = ANOTHER_NAME`` chains)."""
+
+    def test_ssa_alias_chain_inlined(self) -> None:
+        """The per-iter ``mi_copy_*`` and ``di_copy_*`` alias chains
+        Helion's SSA maintenance inserts MUST be inlined so the deepest
+        use reads the root name directly.
+        """
+        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # Neither ``mi_copy`` nor ``di_copy`` should appear in the
+        # generated code — both were SSA snapshots whose only purpose
+        # was to capture the value at a specific point; with the
+        # snapshot removed the inner use reads the root directly.
+        self.assertEqual(code.count("_copy"), 0)
+
+    def test_useless_cascade_alias_removed(self) -> None:
+        """The original inner-first hoist produced a cascade of useless
+        ``_helion_inv_div_N = 1.0 * _helion_inv_div_{N+1}`` aliases when
+        the consume loop was 3 levels deep.  The outer-in walk emits a
+        single hoist at the outermost legal scope instead.
+        """
+        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # The useless cascade text MUST be gone.
+        self.assertEqual(code.count("1.0 * _helion_inv_div_"), 0)
+        # Exactly ONE reciprocal hoist for the consume sweep's ``1.0/di``.
+        self.assertEqual(code.count("= 1.0 / di"), 1)
+
+
+@onlyBackends(["cute"])
+class TestCuteFMAScaleHoist(TestCase):
+    """FMA-friendly scale hoist sub-pass + DCE for dead Sub assigns."""
+
+    def test_fma_scale_hoist_above_consume(self) -> None:
+        """The consume loop's ``exp2((v_9 - mi) * 1.4427)`` pattern with
+        ``mi`` loop-invariant MUST get a hoisted
+        ``_helion_scaled_K = mi * 1.4426950408889634`` placed BEFORE the
+        consume loop, and the inner expression must be rewritten to
+        ``v_9 * 1.4427 - _helion_scaled_K``.
+        """
+        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # A scaled hoist for ``mi * 1.4426950408889634`` must be emitted.
+        self.assertIn("_helion_scaled_", code)
+        self.assertIn("= mi * 1.4426950408889634", code)
+        # The inner consume body must use the FMA-friendly form.
+        self.assertIn("cute.math.exp2(v_9 * 1.4426950408889634 - _helion_scaled_", code)
+
+    def test_fma_scale_hoist_in_reduce_v_loop(self) -> None:
+        """In the reduce loop's INNER ``for vec_lane_1`` V-loop, the
+        ``(v_5 - v_1) * 1.4427`` pattern has ``v_1`` loop-invariant
+        w.r.t. the V-loop (v_1 is the new-max from the warp_reduce
+        that runs before the V-loop), so the scale hoist must also
+        fire here.
+        """
+        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # The reduce-loop scale hoist for ``v_1 * 1.4427``.
+        self.assertIn("= v_1 * 1.4426950408889634", code)
+        # The V-loop body uses the FMA-friendly form via v_5.
+        self.assertIn("cute.math.exp2(v_5 * 1.4426950408889634 - _helion_scaled_", code)
+
+    def test_dce_removes_dead_sub_after_fma_hoist(self) -> None:
+        """After the FMA hoist rewrites ``cast(v_X) * CONST`` to read
+        the underlying ``A`` directly (where ``v_X = A - INV`` was the
+        Sub statement), the ``v_X = A - INV`` becomes dead and the
+        final DCE pass must remove it.
+        """
+        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # The consume-loop ``v_10 = v_9 - mi`` MUST be DCE'd.
+        self.assertNotIn("v_10 = v_9 - mi", code)
+        # Same for the inner reduce V-loop ``v_6 = v_5 - v_1``.
+        self.assertNotIn("v_6 = v_5 - v_1", code)
+        # But statements that ARE read MUST NOT be DCE'd.
+        self.assertIn("di = v_4 + sum_1", code)
+
+    def test_invariance_canonicalization_does_not_break_consume(self) -> None:
+        """The pass must use the post-rename canonical name map for
+        invariance analysis on hoist-OUT passes, so that ``mi`` in the
+        REDUCE loop body is correctly classified as loop-VARIANT
+        (because ``v_1_0 = v_1`` will be renamed to ``mi = v_1``).
+        Without this, the FMA hoist would lift the ``mi * 1.4427`` scale
+        ABOVE the reduce loop and capture the stale initial ``-inf``
+        value of ``mi`` — silently producing wildly wrong outputs.
+        """
+        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        # Tight tolerance — this test specifically guards a silent
+        # mis-compile (the bench would still "look fast" with wrong
+        # outputs if we regressed here).
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # The ``mi`` scale hoist for the consume sweep lives BETWEEN
+        # the two outer for-loops (after the reduce loop finishes
+        # mutating ``mi`` via the rename ``v_1_0 -> mi``), not before
+        # the reduce loop.
+        reduce_end = code.find("mi = v_1\n")
+        self.assertGreaterEqual(reduce_end, 0)
+        scaled_consume = code.find("= mi * 1.4426950408889634")
+        self.assertGreater(scaled_consume, reduce_end)

--- a/test/test_cute_hoist_warp_reduce.py
+++ b/test/test_cute_hoist_warp_reduce.py
@@ -1,0 +1,111 @@
+"""Tests for the CuTe ``hoist_warp_reduce`` AST pass.
+
+When the codegen emits a ``cute.arch.warp_reduction_*`` call inside a
+constexpr ``range_constexpr(V)`` loop body, the reduce runs V times per
+outer iter even though the result depends on values gathered across
+ALL V lanes of the warp.
+
+The pass moves the warp reduce OUT of the V-loop: build a per-thread
+``_helion_vfold_acc_*`` accumulator with the V-loop iterates folding
+into it, then call ``cute.arch.warp_reduction_*`` ONCE per outer iter
+on the accumulator. The number of warp shuffles per outer iter drops
+from V*K to K (where K is the number of reduce sites — 2 for online
+softmax: one for max, one for sum).
+
+Lives in ``helion/_compiler/cute/hoist_warp_reduce.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import HALF_DTYPE
+from helion._testing import TestCase
+from helion._testing import code_and_output
+from helion._testing import onlyBackends
+import helion.language as hl
+
+cutlass = pytest.importorskip("cutlass")
+cute = pytest.importorskip("cutlass.cute")
+
+
+@pytest.fixture(autouse=True)
+def _disable_online_to_3pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tests in this file pin codegen details of the ORIGINAL online
+    two-pass form.  The ``online_to_3pass`` rewrite would change them,
+    so disable it here; the rewrite itself is covered in
+    ``test_cute_online_to_3pass.py``.
+    """
+    monkeypatch.setenv("HELION_DISABLE_ONLINE_TO_3PASS", "1")
+
+
+@helion.kernel(backend="cute")
+def _reduction_kernel(x: torch.Tensor) -> torch.Tensor:
+    m, n = x.size()
+    out = torch.empty_like(x)
+    block_size_m = hl.register_block_size(m)
+    block_size_n = hl.register_block_size(n)
+    for tile_m in hl.tile(m, block_size=block_size_m):
+        mi = hl.full([tile_m], float("-inf"), dtype=torch.float32)
+        di = hl.zeros([tile_m], dtype=torch.float32)
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            local_amax = torch.amax(values, dim=1)
+            mi_next = torch.maximum(mi, local_amax)
+            di = di * torch.exp(mi - mi_next) + torch.exp(
+                values - mi_next[:, None]
+            ).sum(dim=1)
+            mi = mi_next
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            out[tile_m, tile_n] = torch.exp(values - mi[:, None]) / di[:, None]
+    return out
+
+
+@onlyBackends(["cute"])
+class TestCuteHoistWarpReduce(TestCase):
+    def test_warp_reduce_hoisted_out_of_v_loop(self) -> None:
+        """The pass must remove the ``cute.arch.warp_reduction_max`` and
+        ``cute.arch.warp_reduction_sum`` calls from inside the
+        ``range_constexpr(V)`` loop body. Before the pass, the V-loop
+        body contained V calls to each warp reduce (one per vec lane).
+        After the pass, the V-loop body has zero warp reduces — they
+        live OUTSIDE the loop with a per-thread local fold first.
+        """
+        x = torch.randn(4096, 6400, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # Both reduces still get emitted (correctness), just outside the V-loop.
+        self.assertIn("warp_reduction_max", code)
+        self.assertIn("warp_reduction_sum", code)
+        # Sanity: the V-loop is still present.
+        self.assertIn("cutlass.range_constexpr(", code)
+        # The hoist creates a fresh accumulator var visible in the body.
+        self.assertIn("_helion_vfold_acc_", code)
+
+    def test_no_hoist_when_v_loop_absent(self) -> None:
+        """When V=1 there's no constexpr V-loop, so the hoist pass must be
+        a no-op — the reduce stays where the strategy emitted it.
+        """
+        x = torch.randn(4096, 4096, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 1],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # No hoist accumulator names (no V-loop to hoist out of).
+        self.assertNotIn("_helion_vfold_acc_", code)

--- a/test/test_cute_merge_sibling_v_loops.py
+++ b/test/test_cute_merge_sibling_v_loops.py
@@ -1,0 +1,143 @@
+"""Tests for the CuTe ``merge_sibling_v_loops`` AST pass.
+
+After ``hoist_warp_reduce`` runs, two-pass online softmax still has TWO
+``range_constexpr(V)`` loops per outer iter — one for max, one for sum.
+Both loops bitcast the SAME ``_tile_unroll_vec_*`` hoist var to extract
+the per-lane scalar.
+
+The pass introduces a small ``cute.make_fragment(V, cutlass.Float32)``
+cache. V-loop 1 stores ``Float32(values)`` into the cache once per lane;
+V-loop 2 reads the cached fp32 value back instead of re-running the
+``Uint16 -> Float16`` bitcast chain. Eliminates the redundant per-lane
+bitcast+cast pair.
+
+A second peephole removes
+``A = Float<N>(warp_reduction_*(...)) ; B = Float32(A)`` round-trips
+left over after ``hoist_warp_reduce`` promoted the accumulator to fp32
+— the Float<N> wrap is dead in that situation.
+
+Lives in ``helion/_compiler/cute/merge_sibling_v_loops.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import HALF_DTYPE
+from helion._testing import TestCase
+from helion._testing import code_and_output
+from helion._testing import onlyBackends
+import helion.language as hl
+
+cutlass = pytest.importorskip("cutlass")
+cute = pytest.importorskip("cutlass.cute")
+
+
+@pytest.fixture(autouse=True)
+def _disable_online_to_3pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tests in this file pin codegen details of the ORIGINAL online
+    two-pass form.  The ``online_to_3pass`` rewrite would change them,
+    so disable it here; the rewrite itself is covered in
+    ``test_cute_online_to_3pass.py``.
+    """
+    monkeypatch.setenv("HELION_DISABLE_ONLINE_TO_3PASS", "1")
+
+
+@helion.kernel(backend="cute")
+def _reduction_kernel(x: torch.Tensor) -> torch.Tensor:
+    m, n = x.size()
+    out = torch.empty_like(x)
+    block_size_m = hl.register_block_size(m)
+    block_size_n = hl.register_block_size(n)
+    for tile_m in hl.tile(m, block_size=block_size_m):
+        mi = hl.full([tile_m], float("-inf"), dtype=torch.float32)
+        di = hl.zeros([tile_m], dtype=torch.float32)
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            local_amax = torch.amax(values, dim=1)
+            mi_next = torch.maximum(mi, local_amax)
+            di = di * torch.exp(mi - mi_next) + torch.exp(
+                values - mi_next[:, None]
+            ).sum(dim=1)
+            mi = mi_next
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            out[tile_m, tile_n] = torch.exp(values - mi[:, None]) / di[:, None]
+    return out
+
+
+@onlyBackends(["cute"])
+class TestCuteMergeSiblingVLoops(TestCase):
+    def test_merge_fires_on_two_v_loop_pattern(self) -> None:
+        """The pass must fire on the canonical two-V-loop shape and emit
+        a ``_helion_vmerge_cache_*`` fragment populated in V-loop 1 and
+        read in V-loop 2.
+        """
+        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # Cache fragment allocated.
+        self.assertIn("_helion_vmerge_cache_", code)
+        # Cache write in V-loop 1 (writes Float32(values) at the
+        # vec_lane index).
+        self.assertIn("_helion_vmerge_cache_0[vec_lane_1]", code)
+        # The cache is allocated as Float32 (promotes from fp16 so V-loop
+        # 2 doesn't need the redundant Float32 cast).
+        self.assertIn(
+            "_helion_vmerge_cache_0 = cute.make_fragment(4, cutlass.Float32)",
+            code,
+        )
+
+    def test_cast_elision_on_warp_reduction(self) -> None:
+        """The double-cast peephole must collapse
+        ``A = Float16(warp_reduction(...)); B = Float32(A)`` into
+        ``A = warp_reduction(...); B = A``. The inner Float16 wrap on
+        the max-reduce becomes dead after ``hoist_warp_reduce`` promoted
+        the accumulator to fp32.
+        """
+        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # The original pattern ``local_amax = Float16(warp_reduction_max(...))``
+        # must have been elided to just ``local_amax = warp_reduction_max(...)``.
+        self.assertNotIn(
+            "local_amax = cutlass.Float16(cute.arch.warp_reduction_max",
+            code,
+        )
+        self.assertIn(
+            "local_amax = cute.arch.warp_reduction_max",
+            code,
+        )
+
+    def test_no_merge_when_v_loop_absent(self) -> None:
+        """When V=1 there's no constexpr V-loop, so the merge pass must
+        be a no-op — no cache fragment should be emitted.
+        """
+        x = torch.randn(4096, 4096, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 1],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        self.assertNotIn("_helion_vmerge_cache_", code)

--- a/test/test_cute_online_to_3pass.py
+++ b/test/test_cute_online_to_3pass.py
@@ -1,0 +1,194 @@
+"""Tests for the CuTe ``online_to_3pass`` AST rewrite.
+
+The CuTe backend pre-processes the user's AST before tracing.  When
+the body matches the canonical two-loop online softmax pattern
+(a running ``mi``/``di`` update sweep followed by a normalize sweep)
+AND the reduction-axis extent is at or above the cutoff (default 2048),
+the pass rewrites the body into THREE inner ``for tile_n`` loops:
+
+  1. max-only sweep
+  2. sum-only sweep
+  3. consume sweep (unchanged)
+
+The 3-pass form's two reductions are independent (no rescale data
+dependency between them) and compile to materially faster code on
+CuTe for large-N inputs — the autotuner can now pick layouts that
+benefit from the parallelism the online form blocked.
+
+Lives in ``helion/_compiler/cute/online_to_3pass.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+import pytest
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import HALF_DTYPE
+from helion._testing import TestCase
+from helion._testing import code_and_output
+from helion._testing import onlyBackends
+import helion.language as hl
+
+cutlass = pytest.importorskip("cutlass")
+cute = pytest.importorskip("cutlass.cute")
+
+
+@helion.kernel(backend="cute")
+def _online_two_pass_kernel(x: torch.Tensor) -> torch.Tensor:
+    """The exact canonical online two-pass softmax pattern the rewrite
+    detects: outer tile loop holding ``mi`` and ``di``, an online update
+    sweep, then a normalize sweep.
+    """
+    m, n = x.size()
+    out = torch.empty_like(x)
+    block_size_m = hl.register_block_size(m)
+    block_size_n = hl.register_block_size(n)
+    for tile_m in hl.tile(m, block_size=block_size_m):
+        mi = hl.full([tile_m], float("-inf"), dtype=torch.float32)
+        di = hl.zeros([tile_m], dtype=torch.float32)
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            local_amax = torch.amax(values, dim=1)
+            mi_next = torch.maximum(mi, local_amax)
+            di = di * torch.exp(mi - mi_next) + torch.exp(
+                values - mi_next[:, None]
+            ).sum(dim=1)
+            mi = mi_next
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            out[tile_m, tile_n] = torch.exp(values - mi[:, None]) / di[:, None]
+    return out
+
+
+@onlyBackends(["cute"])
+class TestCuteOnlineTo3PassRewrite(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._env_to_restore: dict[str, str | None] = {}
+        # The Kernel decorator caches bound kernels by input signature
+        # (shape + dtype + stride).  Each test in this class flips env
+        # vars that change the compiler pipeline behavior, so we must
+        # invalidate the cache before every test or stale compilations
+        # leak across cases.
+        _online_two_pass_kernel.reset()
+
+    def tearDown(self) -> None:
+        for name, prev in self._env_to_restore.items():
+            if prev is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = prev
+        _online_two_pass_kernel.reset()
+        super().tearDown()
+
+    def _set_env(self, name: str, value: str | None) -> None:
+        if name not in self._env_to_restore:
+            self._env_to_restore[name] = os.environ.get(name)
+        if value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = value
+
+    def _generated_loop_count(self, code: str) -> int:
+        """Count the number of inner ``for tile_offset_N in range(`` sites in
+        the generated CuTe source.  Each inner sweep yields one of these
+        loops, so this is the number of inner sweeps the rewrite emitted.
+        """
+        return len(re.findall(r"for tile_offset_\d+ in range\(", code))
+
+    def test_rewrite_fires_on_canonical_pattern(self) -> None:
+        """For (4096, 12672) the rewrite MUST fire and the generated
+        kernel MUST have THREE inner ``for tile_offset`` loops (max,
+        sum, consume) instead of TWO.
+        """
+        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _online_two_pass_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # 3 inner sweeps now (was 2 in the original online form).
+        self.assertEqual(self._generated_loop_count(code), 3)
+
+    def test_shape_gate_skips_small_n(self) -> None:
+        """For (4096, 256) the rewrite MUST be skipped by the
+        reduction-axis-extent gate (256 < default cutoff 2048), so the
+        generated kernel still has TWO inner sweeps (the original
+        online form).
+        """
+        x = torch.randn(4096, 256, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _online_two_pass_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        self.assertEqual(self._generated_loop_count(code), 2)
+
+    def test_disable_env_skips_rewrite(self) -> None:
+        """``HELION_DISABLE_ONLINE_TO_3PASS=1`` MUST skip the pass even
+        when the shape and pattern would otherwise match — the kernel
+        falls back to the original 2-loop online form.
+        """
+        self._set_env("HELION_DISABLE_ONLINE_TO_3PASS", "1")
+        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _online_two_pass_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        self.assertEqual(self._generated_loop_count(code), 2)
+
+    def test_min_n_env_override(self) -> None:
+        """``HELION_ONLINE_TO_3PASS_MIN_N=0`` MUST always fire the rewrite
+        regardless of reduction-axis extent (useful for A/B sweeps).
+        Verify by running a small-N shape which the default gate would
+        skip and observe the 3-loop form.
+        """
+        self._set_env("HELION_ONLINE_TO_3PASS_MIN_N", "0")
+        x = torch.randn(4096, 256, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _online_two_pass_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        self.assertEqual(self._generated_loop_count(code), 3)
+
+    def test_correctness_after_rewrite(self) -> None:
+        """Tight-tolerance correctness check on multiple large-N
+        shapes.  Guards against any silent numeric drift introduced by
+        the rewrite (the 3-pass and online forms have different
+        rounding paths in fp16 — the diff must stay inside the existing
+        tolerance).
+        """
+        for n_val in (4096, 6400, 12672, 16384):
+            x = torch.randn(4096, n_val, device=DEVICE, dtype=HALF_DTYPE)
+            _, out = code_and_output(
+                _online_two_pass_kernel,
+                (x,),
+                block_sizes=[1, 128],
+                num_threads=[0, 32],
+                cute_vector_widths=[1, 4],
+            )
+            ref = torch.nn.functional.softmax(x, dim=1)
+            torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)

--- a/test/test_cute_pipeline_inner_loads.py
+++ b/test/test_cute_pipeline_inner_loads.py
@@ -1,0 +1,274 @@
+"""Tests for the CuTe ``pipeline_inner_loads`` AST pass.
+
+Software-pipelines the per-iteration vec load by one stage:
+
+- Pre-issues the iter 0 vec load above the inner loop (prologue).
+- Inside the body issues the NEXT iter's load BEFORE the current
+  iter's compute body runs.
+- Drains the last prefetched load at end-of-loop.
+
+The SASS scheduler then has multiple ``ld.global`` instructions in
+flight per warp, hiding HBM round-trip latency on kernels where the
+inner-loop body has a sequential dependency chain that otherwise
+prevents the compiler from issuing the next load early.
+
+Measured ~18-37% drop in
+``smsp__average_warps_issue_stalled_long_scoreboard_per_issue_active.ratio``
+on the (4096, 12672) softmax shape (NCU) and +20% wall-clock gain on
+wide-N shapes like (4096, 10240) and (4096, 16384).
+
+P19 adds an opt-in loop-carried-scalar-write gate
+(``HELION_LOAD_PIPELINE_CARRIED_ONLY=1``) that restricts pipelining to
+outer loops with a loop-carried scalar write (reduction accumulators
+like ``mi``/``di``). Skips pure stream-store loops where the inter-iter
+slack isn't useful. Default remains pipeline-everything.
+
+Lives in ``helion/_compiler/cute/pipeline_inner_loads.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+import pytest
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import HALF_DTYPE
+from helion._testing import TestCase
+from helion._testing import code_and_output
+from helion._testing import onlyBackends
+import helion.language as hl
+
+cutlass = pytest.importorskip("cutlass")
+cute = pytest.importorskip("cutlass.cute")
+
+
+@pytest.fixture(autouse=True)
+def _disable_online_to_3pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tests in this file pin codegen details of the ORIGINAL online
+    two-pass form.  The ``online_to_3pass`` rewrite would change them,
+    so disable it here; the rewrite itself is covered in
+    ``test_cute_online_to_3pass.py``.
+    """
+    monkeypatch.setenv("HELION_DISABLE_ONLINE_TO_3PASS", "1")
+
+
+@helion.kernel(backend="cute")
+def _reduction_kernel(x: torch.Tensor) -> torch.Tensor:
+    m, n = x.size()
+    out = torch.empty_like(x)
+    block_size_m = hl.register_block_size(m)
+    block_size_n = hl.register_block_size(n)
+    for tile_m in hl.tile(m, block_size=block_size_m):
+        mi = hl.full([tile_m], float("-inf"), dtype=torch.float32)
+        di = hl.zeros([tile_m], dtype=torch.float32)
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            local_amax = torch.amax(values, dim=1)
+            mi_next = torch.maximum(mi, local_amax)
+            di = di * torch.exp(mi - mi_next) + torch.exp(
+                values - mi_next[:, None]
+            ).sum(dim=1)
+            mi = mi_next
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            out[tile_m, tile_n] = torch.exp(values - mi[:, None]) / di[:, None]
+    return out
+
+
+def _shadow_var_count(code: str, kind: str) -> int:
+    """Count ``_pipe_<kind>_N = `` occurrences (prologue + per-iter
+    prefetch assignments, so 2 per pipelined load site)."""
+    return len(re.findall(rf"_pipe_{kind}_\d+ = ", code))
+
+
+@onlyBackends(["cute"])
+class TestCutePipelineInnerLoads(TestCase):
+    """Default behavior: pipeline every qualifying inner load."""
+
+    def test_pipeline_fires_on_two_pass_pattern(self) -> None:
+        """Both the reduce and consume sweeps of the two-pass kernel
+        match the (single inner-lane loop, single load) shape so the
+        pass rewrites both sweeps.  Each rewrite emits a prologue
+        snapshot and a per-iter prefetch — 2 ``_pipe_lane_base_*`` assigns
+        and 2 ``_pipe_load_*`` assigns per pipelined site, for 4 total
+        of each across the two sweeps.
+        """
+        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # 2 sweeps * 2 assigns each = 4 _pipe_lane_base_* writes and
+        # 4 _pipe_load_* writes.
+        self.assertEqual(_shadow_var_count(code, "lane_base"), 4)
+        self.assertEqual(_shadow_var_count(code, "load"), 4)
+        # The snapshot ``lane_base_<N> = _pipe_lane_base_<M>`` form must
+        # appear inside the loop body — that's the substitution that
+        # gives the SASS scheduler one full iter of slack to issue the
+        # next load.
+        self.assertRegex(code, r"lane_base_\d+ = _pipe_lane_base_\d+")
+        self.assertRegex(code, r"_tile_unroll_vec_\d+_\d+ = _pipe_load_\d+")
+
+    def test_pipeline_skips_when_lane_reps_greater_than_one(self) -> None:
+        """V=4 with block_size=256 forces the inner lane loop to
+        ``for lane in range(2):`` (block=256, V=4 → 2 lanes per
+        thread).  The pipeline transform must SKIP this case: the
+        per-iter prefetch advances ``_pipe_lane_base`` to the next
+        outer iter but uses the CURRENT ``lane`` index, which would
+        corrupt the snapshot read by the NEXT lane index in the same
+        outer iter.
+        """
+        x = torch.randn(4096, 8192, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 256],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # lane_reps == 2, so the pass bails -- no _pipe_* vars.
+        self.assertNotIn("_pipe_lane_base_", code)
+        self.assertNotIn("_pipe_load_", code)
+
+    def test_pipeline_disable_env(self) -> None:
+        """``HELION_DISABLE_LOAD_PIPELINE=1`` disables the pass for
+        experimentation.  The kernel must still compile and produce
+        correct output without the pipeline rewrite.
+        """
+        old = os.environ.get("HELION_DISABLE_LOAD_PIPELINE")
+        os.environ["HELION_DISABLE_LOAD_PIPELINE"] = "1"
+        try:
+            x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
+            code, out = code_and_output(
+                _reduction_kernel,
+                (x,),
+                block_sizes=[1, 128],
+                num_threads=[0, 32],
+                cute_vector_widths=[1, 4],
+            )
+            ref = torch.nn.functional.softmax(x, dim=1)
+            torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+            # No pipeline vars when the pass is disabled.
+            self.assertNotIn("_pipe_lane_base_", code)
+            self.assertNotIn("_pipe_load_", code)
+        finally:
+            if old is None:
+                os.environ.pop("HELION_DISABLE_LOAD_PIPELINE", None)
+            else:
+                os.environ["HELION_DISABLE_LOAD_PIPELINE"] = old
+
+
+@onlyBackends(["cute"])
+class TestCutePipelineCarriedOnlyGate(TestCase):
+    """Opt-in carried-only gate (``HELION_LOAD_PIPELINE_CARRIED_ONLY=1``).
+
+    The default pipelines BOTH sweeps of a two-pass softmax: the reduce
+    sweep (which writes the ``mi``/``di`` accumulator) and the consume
+    sweep (a pure stream-store). With the gate enabled, only the reduce
+    sweep is pipelined; the consume sweep falls back to inline loads.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._env_to_restore: dict[str, str | None] = {}
+
+    def tearDown(self) -> None:
+        for name, prev in self._env_to_restore.items():
+            if prev is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = prev
+        super().tearDown()
+
+    def _set_env(self, name: str, value: str | None) -> None:
+        """Restore-aware env var setter."""
+        if name not in self._env_to_restore:
+            self._env_to_restore[name] = os.environ.get(name)
+        if value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = value
+
+    def test_carried_only_pipelines_reduce_sweep(self) -> None:
+        """With the gate enabled, the reduce sweep (which writes ``mi``
+        and ``di`` — both defined in the outer function-body scope
+        before the loop) MUST still be pipelined.
+        """
+        self._set_env("HELION_LOAD_PIPELINE_CARRIED_ONLY", "1")
+        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # The reduce sweep MUST still be pipelined — there's a
+        # loop-carried scalar write to ``mi`` (pre-rename: ``v_1_0
+        # = v_1``) so the gate fires positive.
+        self.assertIn("_pipe_lane_base_", code)
+        self.assertIn("_pipe_load_", code)
+        # And the per-iter snapshot ``lane_base_<N> = _pipe_lane_base_<M>``
+        # form appears inside the reduce loop body.
+        self.assertRegex(code, r"lane_base_\d+ = _pipe_lane_base_\d+")
+
+    def test_carried_only_skips_consume_sweep(self) -> None:
+        """With the gate enabled, the consume sweep (which only stores
+        into ``out[k]`` and never writes a scalar accumulator in the
+        outer scope) MUST NOT be pipelined.
+
+        The reduce-sweep pipeline writes ``_pipe_lane_base_0`` and
+        ``_pipe_load_0``; the consume sweep would have written
+        ``_pipe_lane_base_1`` and ``_pipe_load_1`` under the default
+        behavior.  Under the gate, only the ``_0`` indices appear.
+        """
+        self._set_env("HELION_LOAD_PIPELINE_CARRIED_ONLY", "1")
+        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
+        code, _ = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        # ONLY the reduce-sweep pipe (index 0) — no index 1.
+        self.assertIn("_pipe_load_0", code)
+        self.assertNotIn("_pipe_load_1", code)
+        self.assertNotIn("_pipe_lane_base_1", code)
+        # And the consume sweep retains its original inline
+        # ``cute.arch.load`` (no snapshot/prefetch rewrite).
+        self.assertIn("_tile_unroll_vec_1_1 = cute.arch.load(", code)
+
+    def test_pipeline_all_overrides_carried_only(self) -> None:
+        """``HELION_LOAD_PIPELINE_ALL=1`` must explicitly override the
+        gate even when ``HELION_LOAD_PIPELINE_CARRIED_ONLY`` is also
+        set, restoring the pre-P19 "pipeline every qualifying loop"
+        behavior.
+        """
+        self._set_env("HELION_LOAD_PIPELINE_CARRIED_ONLY", "1")
+        self._set_env("HELION_LOAD_PIPELINE_ALL", "1")
+        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
+        code, _ = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        # Both sweeps pipelined → both _pipe_load_0 and _pipe_load_1
+        # appear.
+        self.assertIn("_pipe_load_0", code)
+        self.assertIn("_pipe_load_1", code)

--- a/test/test_cute_tile_loop_vec_hoist.py
+++ b/test/test_cute_tile_loop_vec_hoist.py
@@ -1,0 +1,180 @@
+"""Tests for the CuTe tile-loop vec hoist codegen.
+
+The hoist emits a single ``cute.arch.load(..., ir.VectorType.get([V], ...))``
+above the constexpr V-loop in ``CuteNDTileStrategy``; the V-loop body then
+reads per-lane scalars via bitcast extracts from the hoist var. This
+replaces V scalar fp16 loads with one V*2-byte vec load per thread per
+outer iter.
+
+The hoist is gated to V<=4 for fp16/bf16 (the CuTe DSL's
+``nvvm.load.ext`` ICEs at V=8); V=8 falls back to a 2x V=4 split with
+``_a`` / ``_b`` suffixed hoist vars covering vec lanes 0-3 and 4-7.
+
+Lives in ``helion/_compiler/tile_strategy.py``
+(``CuteNDTileStrategy._cute_*_by_block`` hooks) and
+``helion/language/memory_ops.py`` (``_cute_register_tile_unroll_vec_hoist``
+and ``_cute_vector_load_ctx`` ``"tile_unroll"`` / ``"tile_unroll_split2"``
+modes).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import HALF_DTYPE
+from helion._testing import TestCase
+from helion._testing import code_and_output
+from helion._testing import onlyBackends
+import helion.language as hl
+
+cutlass = pytest.importorskip("cutlass")
+cute = pytest.importorskip("cutlass.cute")
+
+
+@pytest.fixture(autouse=True)
+def _disable_online_to_3pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tests in this file pin codegen details of the ORIGINAL online
+    two-pass form.  The ``online_to_3pass`` rewrite (in
+    ``helion/_compiler/cute/online_to_3pass.py``) rewrites the kernel
+    into a 3-loop form for N >= 2048, which by design changes the
+    codegen those tests inspect.  Disable the rewrite globally for
+    this file's tests; the rewrite itself is covered in
+    ``test_cute_online_to_3pass.py``.
+    """
+    monkeypatch.setenv("HELION_DISABLE_ONLINE_TO_3PASS", "1")
+
+
+@helion.kernel(backend="cute")
+def _reduction_kernel(x: torch.Tensor) -> torch.Tensor:
+    """A two-pass reduction kernel that exercises the vec hoist path.
+
+    Mirrors the structure ``examples/softmax.py::softmax_two_pass`` uses
+    (an outer M-grid tile, an inner N-tile loop) so the inner load goes
+    through ``CuteNDTileStrategy``'s tile-loop vec hoist when
+    ``cute_vector_widths`` is set.
+    """
+    m, n = x.size()
+    out = torch.empty_like(x)
+    block_size_m = hl.register_block_size(m)
+    block_size_n = hl.register_block_size(n)
+    for tile_m in hl.tile(m, block_size=block_size_m):
+        mi = hl.full([tile_m], float("-inf"), dtype=torch.float32)
+        di = hl.zeros([tile_m], dtype=torch.float32)
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            local_amax = torch.amax(values, dim=1)
+            mi_next = torch.maximum(mi, local_amax)
+            di = di * torch.exp(mi - mi_next) + torch.exp(
+                values - mi_next[:, None]
+            ).sum(dim=1)
+            mi = mi_next
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            out[tile_m, tile_n] = torch.exp(values - mi[:, None]) / di[:, None]
+    return out
+
+
+@onlyBackends(["cute"])
+class TestCuteTileLoopVecHoist(TestCase):
+    def test_vec_hoist_fires_at_v4_fp16(self) -> None:
+        """When ``cute_vector_widths=[1, 4]`` is set on a fp16 reduction
+        kernel and the inner tile aligns with V, the codegen must emit a
+        ``cute.arch.load(..., ir.VectorType.get([4], cutlass.Uint16.mlir_type))``
+        — the new tile-loop vec hoist path that replaces 4 scalar fp16
+        loads with one 8-byte vec load per thread per iter.
+        """
+        x = torch.randn(4096, 6400, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # The vec hoist target var name is _tile_unroll_vec_*.
+        self.assertIn("_tile_unroll_vec_", code)
+        # The hoisted load wraps the actual ptr in an IfExp for
+        # in-bounds guard; the VectorType arg pins the V/dtype.
+        self.assertIn(
+            "ir.VectorType.get([4], cutlass.Uint16.mlir_type)",
+            code,
+        )
+        # And the per-V-lane extract is a bitcast back to Float16.
+        self.assertIn("bitcast(cutlass.Float16)", code)
+
+    def test_vec_hoist_v8_uses_4plus4_split(self) -> None:
+        """V=8 fp16/bf16 cannot use a single ``cute.arch.load`` (the CuTe
+        DSL's ``nvvm.load.ext`` ICEs at V=8), so the codegen lowers it as
+        TWO back-to-back ``cute.arch.load(..., V=4)`` calls (covering vec
+        lanes 0-3 and 4-7).
+        """
+        x = torch.randn(4096, 8192, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 256],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 8],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # The single-V=8 load form is still NOT emitted (would ICE).
+        self.assertNotIn("ir.VectorType.get([8]", code)
+        # The split-2 path emits TWO V=4 vec loads per outer-lane iter
+        # with the ``_a`` / ``_b`` suffix on the hoist var names.  When
+        # the load-pipeline pass fires, the ``_a`` load assignment text
+        # gets rewritten to ``_tile_unroll_vec_1_0_a = _pipe_load_*``
+        # with the actual ``cute.arch.load`` hoisted into the prologue;
+        # the ``_b`` load is left as an inline ``cute.arch.load`` call.
+        self.assertTrue(
+            "_tile_unroll_vec_1_0_a = cute.arch.load(" in code
+            or "_tile_unroll_vec_1_0_a = _pipe_load_" in code,
+            "expected _a hoist var either as inline load or pipeline snapshot",
+        )
+        self.assertIn("_tile_unroll_vec_1_0_b = cute.arch.load(", code)
+        # Both halves use V=4.
+        self.assertGreaterEqual(
+            code.count("ir.VectorType.get([4], cutlass.Uint16.mlir_type)"),
+            2,
+        )
+        # The constexpr V-loop now runs 8 iters (not 4).
+        self.assertIn("cutlass.range_constexpr(8)", code)
+        # The per-vec-lane extract uses the if-else split selector so the
+        # constexpr loop unroller picks the right half per iter.
+        self.assertIn("if vec_lane_1 < 4 else", code)
+
+    def test_vec_hoist_bf16(self) -> None:
+        """The vec hoist must also fire for bf16 (also a uint16-backed type)."""
+        x = torch.randn(4096, 6400, device=DEVICE, dtype=torch.bfloat16)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        self.assertIn("ir.VectorType.get([4]", code)
+        self.assertIn("cutlass.BFloat16", code)
+
+    def test_scalar_load_when_vec_width_is_one(self) -> None:
+        """When V=1 the vec hoist must NOT fire — the codegen falls back to
+        the scalar load path so the change is opt-in.
+        """
+        x = torch.randn(4096, 6400, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 1],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        self.assertNotIn("_tile_unroll_vec_", code)

--- a/test/test_cute_warp_per_row_layout.py
+++ b/test/test_cute_warp_per_row_layout.py
@@ -1,0 +1,207 @@
+"""Tests for the CuTe warp-per-row layout (multi-row CTAs with
+one warp per row).
+
+For 2D reduction kernels (outer M-grid tile + inner N-reduction tile)
+where:
+
+- 1 outer grid block (M), 1 inner non-reduction tile (N)
+- N is a 32-multiple
+- joint thread count <= 1024
+- no MMA
+
+``layout_propagation.py`` detects the shape and emits a
+``CuTeGridExecutionPlan(block_axis_priority={N: 0, M: 1})``. The
+thread-axis assignment then swaps so:
+
+- N (inner reduction axis) lands on ``thread_idx[0]`` (32 contiguous
+  lanes = one warp per row)
+- M (outer grid row axis) lands on ``thread_idx[1]`` (warp index = row
+  index)
+
+The reduction dispatcher's ``group_span`` becomes the per-row size
+(32 — one warp), NOT the per-CTA size (M_block * 32), so it falls
+through to ``_cute_grouped_reduce_warp`` (single warp shuffle, no
+shared memory, no sync_threads).
+
+Lives in:
+- ``helion/_compiler/cute/layout_propagation.py``
+  (``_plan_warp_per_row_execution`` shape detector)
+- ``helion/_compiler/tile_strategy.py`` (``_compute_thread_axis_offset``
+  honors ``block_axis_priority``)
+- ``helion/_compiler/tile_dispatch.py`` (``thread_axis_for_strategy``
+  dedups sibling strategies with identical block_ids in the same branch)
+- ``helion/_compiler/autotuner_heuristics/cute.py``
+  (``CuteTileVecWarpPerRowHeuristic`` seeds the multi-row config)
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import HALF_DTYPE
+from helion._testing import TestCase
+from helion._testing import code_and_output
+from helion._testing import onlyBackends
+import helion.language as hl
+
+cutlass = pytest.importorskip("cutlass")
+cute = pytest.importorskip("cutlass.cute")
+
+
+@pytest.fixture(autouse=True)
+def _disable_online_to_3pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tests in this file pin codegen details of the ORIGINAL online
+    two-pass form.  The ``online_to_3pass`` rewrite would change them,
+    so disable it here; the rewrite itself is covered in
+    ``test_cute_online_to_3pass.py``.
+    """
+    monkeypatch.setenv("HELION_DISABLE_ONLINE_TO_3PASS", "1")
+
+
+@helion.kernel(backend="cute")
+def _reduction_kernel(x: torch.Tensor) -> torch.Tensor:
+    m, n = x.size()
+    out = torch.empty_like(x)
+    block_size_m = hl.register_block_size(m)
+    block_size_n = hl.register_block_size(n)
+    for tile_m in hl.tile(m, block_size=block_size_m):
+        mi = hl.full([tile_m], float("-inf"), dtype=torch.float32)
+        di = hl.zeros([tile_m], dtype=torch.float32)
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            local_amax = torch.amax(values, dim=1)
+            mi_next = torch.maximum(mi, local_amax)
+            di = di * torch.exp(mi - mi_next) + torch.exp(
+                values - mi_next[:, None]
+            ).sum(dim=1)
+            mi = mi_next
+        for tile_n in hl.tile(n, block_size=block_size_n):
+            values = x[tile_m, tile_n]
+            out[tile_m, tile_n] = torch.exp(values - mi[:, None]) / di[:, None]
+    return out
+
+
+@onlyBackends(["cute"])
+class TestCuteWarpPerRowLayout(TestCase):
+    def test_multi_row_threaded_uses_warp_per_row(self) -> None:
+        """``block_sizes=[8, 128], num_threads=[0, 32]`` — M is threaded.
+
+        With the warp-per-row layout, the codegen swaps the thread-axis
+        assignment so N (the reduction axis) lands on ``thread_idx[0]``
+        (32 contiguous threads = one warp per row) and M lands on
+        ``thread_idx[1]`` (warp index = row index).  Each warp's
+        per-row reduction uses ``_cute_grouped_reduce_warp`` with
+        ``pre=1, group_span=32`` (one warp shuffle per warp), NOT
+        the cross-warp ``_cute_grouped_reduce_shared_two_stage`` path.
+
+        The launch becomes ``block=(32, 8, 1)``: joint thread count
+        is 8 × 32 = 256 (8 warps per CTA for higher occupancy on
+        reduction-shaped kernels).
+        """
+        x = torch.randn(4096, 128, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[8, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # Warp-per-row launch: N (the reduction axis with 32 threads)
+        # lands on axis 0, M (8 rows) lands on axis 1.
+        self.assertIn("block=(32, 8, 1)", code)
+        # Each warp reduces its own row via _cute_grouped_reduce_warp.
+        self.assertIn("_cute_grouped_reduce_warp", code)
+        self.assertIn("pre=1, group_span=32", code)
+        # NO cross-warp SMEM reduce.
+        self.assertNotIn("_cute_grouped_reduce_shared_two_stage", code)
+
+    def test_warp_per_row_axis_swap_emits_warp_reduce(self) -> None:
+        """The warp-per-row plan swaps the thread-axis assignment so:
+
+        * N (inner reduction axis) lands on ``thread_idx[0]``
+        * M (outer grid row axis) lands on ``thread_idx[1]``
+
+        And the reduction dispatcher picks the per-warp
+        ``_cute_grouped_reduce_warp`` path with ``pre=1, group_span=32``
+        instead of the cross-warp SMEM path that would dominate without
+        the axis swap.
+        """
+        x = torch.randn(4096, 12672, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[2, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # The launch is ``block=(32, 2, 1)`` — N on axis 0 (32 threads
+        # per warp = one row), M on axis 1 (2 warps = 2 rows).
+        self.assertIn("block=(32, 2, 1)", code)
+        # M uses ``thread_idx[1]`` for the row index.
+        self.assertIn(
+            "indices_0 = tile_offset_0 + cutlass.Int32(cute.arch.thread_idx()[1])",
+            code,
+        )
+        # N uses ``thread_idx[0]`` for the lane (32 contiguous lanes).
+        self.assertIn("cute.arch.thread_idx()[0]) * 4", code)
+        # Per-warp reduce.
+        self.assertIn("_cute_grouped_reduce_warp", code)
+        self.assertIn("pre=1, group_span=32", code)
+        # NO shared-memory two-stage reduce.
+        self.assertNotIn("_cute_grouped_reduce_shared_two_stage", code)
+
+    def test_single_row_baseline_uses_warp_reduce(self) -> None:
+        """Single-row baseline: ``block_sizes=[1, 128]`` with
+        ``num_threads=[0, 32]`` produces one CTA per row, each with one
+        warp of 32 threads. The reduce uses
+        ``cute.arch.warp_reduction_max``, NOT the two-stage SMEM helper.
+        Pin this so a future regression in heuristic seed coverage
+        would be caught.
+        """
+        x = torch.randn(4096, 128, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[1, 128],
+            num_threads=[0, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # One warp per CTA.
+        self.assertIn("block=(32, 1, 1)", code)
+        # Warp reduce, no shared-mem reduction.
+        self.assertIn("cute.arch.warp_reduction_max", code)
+        self.assertNotIn("_cute_grouped_reduce_shared_two_stage", code)
+
+    def test_serial_multi_row_does_not_swap_axes(self) -> None:
+        """``block_sizes=[8, 128], num_threads=[1, 32]`` — M is SERIALIZED
+        via a ``for lane_0 in range(8)`` loop, not threaded across warps.
+        The warp-per-row axis swap MUST NOT fire here (it only applies
+        when M is on the thread axis).  The single-warp ``block=(32, 1, 1)``
+        layout stays; only the grid count drops (M / 8 CTAs).
+        """
+        x = torch.randn(4096, 128, device=DEVICE, dtype=HALF_DTYPE)
+        code, out = code_and_output(
+            _reduction_kernel,
+            (x,),
+            block_sizes=[8, 128],
+            num_threads=[1, 32],
+            cute_vector_widths=[1, 4],
+        )
+        ref = torch.nn.functional.softmax(x, dim=1)
+        torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+        # M serialized — a ``for lane_0 in range(8):`` loop wraps the
+        # per-row body.
+        self.assertIn("for lane_0 in range(8):", code)
+        # Single-warp launch (axis swap did NOT fire).
+        self.assertIn("block=(32, 1, 1)", code)
+        # Warp reduce still fires since group_span = 32.
+        self.assertIn("cute.arch.warp_reduction_max", code)


### PR DESCRIPTION

Replaces ``test/test_cute_softmax_perf.py`` (kernel name in the
filename was the issue — these tests cover compiler passes, not a
specific kernel) with per-pass files that mirror the source layout
under ``helion/_compiler/cute/``:

- test_cute_tile_loop_vec_hoist.py — P1 vec hoist (4 tests)
- test_cute_fuse_two_pass_loads.py — P2/P5 fuser + alias map (2 tests)
- test_cute_hoist_warp_reduce.py — P11 warp_reduce hoist (2 tests)
- test_cute_merge_sibling_v_loops.py — P14 V-loop merge + cast elision (3 tests)
- test_cute_hoist_loop_invariant_recip.py — P16+P17 LICM passes
  (TestCuteHoistRecip + TestCuteAliasDCE + TestCuteFMAScaleHoist, 9 tests)
- test_cute_pipeline_inner_loads.py — P18+P19 load pipeline (6 tests)
- test_cute_online_to_3pass.py — P21 online→3-pass rewrite (5 tests)
- test_cute_warp_per_row_layout.py — P15 warp-per-row layout (4 tests)

Each file uses an autouse ``_disable_online_to_3pass`` fixture that
sets ``HELION_DISABLE_ONLINE_TO_3PASS=1`` to pin the ORIGINAL online
two-pass codegen the per-pass assertions look at. The rewrite itself
is covered in ``test_cute_online_to_3pass.py`` (no autouse fixture).

Each file defines its own ``_reduction_kernel`` at module scope so
the tests are self-contained and the kernel-cache key is per-file —
no autouse fixture flips across modules.

P6 (BackendUnsupported guard for joint thread overflow) and P7
(``CuteTileVecWarpReduceHeuristic`` seed + registration) move to
``test_cute_backend.py`` (TestCuteThreadBudgetRejection and
TestCuteTileVecWarpReduceHeuristic + shared ``_cute_2d_tile_reduction_kernel``).

Dropped the old file's ``TestCuteSoftmaxCorrectness`` shape-pinned
end-to-end tests — those are now redundant with
``test/test_examples.py::test_softmax_two_pass`` /
``::test_softmax_two_pass_block_ptr`` which exercise the same configs
end-to-end through the example harness.

40 tests total across the new files + the 5 added to
test_cute_backend.py. All passing under ``HELION_BACKEND=cute`` on B200.
