### PR TITLE
[pallas] matmul pipeline launcher VMEM strips + outer-grid strategy

### DIFF
--- a/.github/dashboard/build_dashboard_data.py
+++ b/.github/dashboard/build_dashboard_data.py
@@ -179,11 +179,16 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None):
         key=lambda r: r["date"],
     )
 
-    # Index existing history by kernel|platform -> run_id
+    # Index existing history by kernel|platform_short -> run_id.
+    # Older caches may contain duplicate (kernel, platform_short) rows because
+    # AMD runners occasionally report platform as "AMD Radeon Graphics" vs
+    # "AMD Instinct MI325X". Merge those duplicates here.
+    existing_summary = {}
     existing_history = {}
-    existing_summary = {e["kernel"] + "|" + e["platform"]: e for e in (existing_data or {}).get("summary", [])}
-    for key, entry in existing_summary.items():
-        existing_history[key] = {h["run_id"]: h for h in entry.get("history", [])}
+    for e in (existing_data or {}).get("summary", []):
+        key = e["kernel"] + "|" + e.get("platform_short", "")
+        existing_summary[key] = e
+        existing_history.setdefault(key, {}).update({h["run_id"]: h for h in e.get("history", [])})
 
     # Parse each run's artifacts if present
     runs = []
@@ -202,7 +207,7 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None):
             fresh_run_ids.add(run["run_id"])
             run_ids_with_data.add(run["run_id"])
         for k in run["kernels"]:
-            key = f"{k['kernel']}|{k['platform']}"
+            key = f"{k['kernel']}|{k['platform_short']}"
             if key not in kernel_index:
                 kernel_index[key] = {
                     "kernel": k["kernel"],
@@ -224,8 +229,8 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None):
                 prev = existing_summary.get(key, {})
                 kernel_index[key] = {
                     "kernel": prev.get("kernel", key.split("|")[0]),
-                    "platform": prev.get("platform", key.split("|")[1] if "|" in key else "unknown"),
-                    "platform_short": prev.get("platform_short", ""),
+                    "platform": prev.get("platform", "unknown"),
+                    "platform_short": prev.get("platform_short", key.split("|")[1] if "|" in key else ""),
                     "shapes": [],
                     "history": [],
                 }
@@ -300,6 +305,7 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None):
             "status": status,
             "accuracy_failures": acc_failures,
             "run_failures": run_failures,
+            "last_seen_date": latest_main["date"] if latest_main else None,
             "infra_missing": infra_missing,
             "helion_speedup_geomean": latest_data["helion_speedup_geomean"] if latest_data else 0,
             "triton_speedup_geomean": latest_data["triton_speedup_geomean"] if latest_data else 0,

--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -58,6 +58,7 @@ a:hover{text-decoration:underline}
 .kernel-card .sparkline-container svg{width:100%;height:100%;min-height:80px}
 .kernel-card .fail-overlay{position:absolute;inset:0;display:flex;flex-direction:column;justify-content:center;align-items:center;gap:4px;background:rgba(13,17,23,0.75);border-radius:6px;padding:8px;text-align:center}
 .kernel-card .fail-overlay .fail-line{font-size:14px;font-weight:600}
+.kernel-card .fail-overlay .fail-subline{font-size:11px;color:var(--text-dim)}
 .kernel-card .fail-overlay .run-line{color:var(--yellow)}
 .kernel-card .fail-overlay .infra-line{color:var(--text-dim)}
 .kernel-card .accuracy-badge{position:absolute;top:6px;right:6px;font-size:14px;font-weight:700;color:var(--orange);background:rgba(240,136,62,0.2);padding:4px 10px;border-radius:6px;border:1px solid rgba(240,136,62,0.4)}
@@ -274,7 +275,7 @@ function getFailures() {
     const entry = { kernel: e.kernel, platform: platName(e.platform_short), platform_short: e.platform_short };
     if (e.accuracy_failures?.length) acc.push({ ...entry, shapes: e.accuracy_failures });
     if (e.run_failures?.length) run.push({ ...entry, shapes: e.run_failures });
-    if (e.infra_missing) infra.push(entry);
+    if (e.infra_missing) infra.push({ ...entry, last_seen_date: e.last_seen_date });
   });
   return { acc, run, infra };
 }
@@ -395,7 +396,10 @@ function renderOverviewGrid() {
         if (e.run_failures?.length || e.infra_missing) {
           overlay = '<div class="fail-overlay">';
           if (e.run_failures?.length) overlay += `<div class="fail-line run-line">${e.run_failures.length} shapes failed</div>`;
-          if (e.infra_missing) overlay += `<div class="fail-line infra-line">runner failed</div>`;
+          if (e.infra_missing) {
+            overlay += '<div class="fail-line infra-line">No Result</div>';
+            if (e.last_seen_date) overlay += `<div class="fail-subline">last seen ${formatDate(e.last_seen_date)}</div>`;
+          }
           overlay += '</div>';
         } else if (e.accuracy_failures?.length) {
           overlay = `<div class="accuracy-badge">${e.accuracy_failures.length} accuracy fail</div>`;
@@ -755,15 +759,17 @@ function showFailuresModal(fails) {
     h += `<p style="font-size:12px;color:var(--text-dim);margin-bottom:8px">${desc}</p>`;
     h += '<ul class="fail-list">';
     items.forEach(f => {
-      const shapes = f.shapes ? `<span class="fail-shapes">Shapes: ${f.shapes.map(escHtml).join(', ')}</span>` : '';
-      h += `<li><span class="fail-kernel">${escHtml(f.kernel)}</span>${platBadge(f.platform_short)}${shapes}</li>`;
+      let detail = '';
+      if (f.shapes) detail = `<span class="fail-shapes">Shapes: ${f.shapes.map(escHtml).join(', ')}</span>`;
+      else if (f.last_seen_date) detail = `<span class="fail-shapes">Last seen: ${formatDate(f.last_seen_date)}</span>`;
+      h += `<li><span class="fail-kernel">${escHtml(f.kernel)}</span>${platBadge(f.platform_short)}${detail}</li>`;
     });
     return h + '</ul>';
   };
   let html = modalHeader('CI Failures', 'Accuracy mismatches, kernel run failures, and infra issues');
   html += renderSection('Accuracy Failures', 'Kernel ran but produced incorrect output.', fails.acc);
   html += renderSection('Shape Failures', 'Shapes that failed to run (crash, OOM, compile error, timeout, or unsupported config).', fails.run);
-  html += renderSection('Runner Failures', 'Kernel missing from latest run — likely CI runner unavailable, job timeout, or artifact upload failed.', fails.infra);
+  html += renderSection('No Result', 'Benchmark did not produce output for this kernel — possible causes: runner unavailable, job timeout, crash, artifact upload failed, or harness skipped this kernel+platform combination.', fails.infra);
   openModal(html);
 }
 function showDetailModal(kernel, platform_short) {
@@ -784,7 +790,8 @@ function showDetailModal(kernel, platform_short) {
     html += `<div class="run-warn" style="margin-bottom:12px">${e.run_failures.length} shape failure(s): ${e.run_failures.join(', ')}</div>`;
   }
   if (e.infra_missing) {
-    html += `<div class="infra-warn" style="margin-bottom:12px">Runner failed — kernel missing from latest run (CI runner unavailable, timeout, or artifact upload failed)</div>`;
+    const lastSeen = e.last_seen_date ? ` (last seen ${formatDate(e.last_seen_date)})` : '';
+    html += `<div class="infra-warn" style="margin-bottom:12px">No result in latest run${lastSeen} — runner unavailable, timeout, crash, upload failed, or harness skipped this kernel+platform</div>`;
   }
   html += '<h3 style="font-size:13px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.3px;margin-bottom:8px">Run History</h3>';
   html += '<div class="table-scroll" style="max-height:300px"><table class="data-table"><thead><tr><th>Commit</th><th>Date</th><th>Latency</th><th>Speedup</th><th>Compile Time</th></tr></thead><tbody>';


### PR DESCRIPTION
Stacked PRs:
 * #2586
 * #2585
 * #2584
 * __->__#2583


--- --- ---

### [pallas] matmul pipeline launcher VMEM strips + outer-grid strategy


Adds the Pallas backend matmul codegen and pipeline launcher
infrastructure required to keep matmul work on the MXU and amortize
HBM<->VMEM traffic across the K loop. Five mechanisms land together:

1. bf16/f16 2D pl.dot dispatch
   Routes MXU-legal tiles through pl.dot instead of lax.dot_general.
   Mosaic backend lowers pl.dot directly to the TPU MXU; the f32-input
   path still uses lax.dot_general with precision=Precision.HIGHEST.

2. K-loop accumulator stays in pipeline VMEM
   The matmul accumulator is allocated in pipeline VMEM scratch instead
   of HBM, eliminating per-iteration HBM round-trips on the inner K
   reduction.

3. Reduction-axis threading through default_pallas_pipeline_launcher
   New _reduction_grid_dims parameter marks reduction axes as
   "arbitrary" in dimension_semantics so the pipeliner does not assume
   cross-iteration independence. Non-reduction axes stay "parallel".

4. VMEM strip BlockSpecs for emit_pipeline outer in_specs
   The hand-written reference kernel uses (bm, K) BlockSpecs to keep
   the inner-pipeline dim at full extent so the pipeliner slices from
   VMEM instead of DMA-ing per inner iteration from HBM. Adds
   _pipeline_vmem_strip_indices + a per-byte budget guard.

5. Outer-grid matmul strategy with M=1 NaN refusal + outer-pid DCE
   Lifts the K reduction inside emit_pipeline and rewrites the body
   so the outer grid only carries M, N. Refuses outer-grid when any
   outer tile dim is 1 (fixes a NaN reproducer on M=1 shapes) and
   DCEs the dead outer-pid reads from the generated code.

Measured on bf16 1024x1024x1024 headline matmul (TPU v7, median-of-3
seeds, paired interleaved-4way + 200-call jax.profiler trace): -10us
total Helion us per call vs main (74.76 -> 65.78us launcher overhead,
kernel device us flat at ~6us). Acts as the prerequisite for the
launcher fast-path commits stacked above (those reference
_reduction_grid_dims and _pipeline_vmem_strip_indices in their cache
key signatures).