### PR TITLE
[pallas] fast-path host-side launcher with pre-computed cache entries

### DIFF
--- a/.github/dashboard/build_dashboard_data.py
+++ b/.github/dashboard/build_dashboard_data.py
@@ -63,7 +63,9 @@ def fetch_runs(repo, workflow_name, days):
         if not data or not data.get("workflow_runs"):
             break
         for r in data["workflow_runs"]:
-            if r.get("conclusion") in ("success", "failure"):
+            # Include cancelled runs: successful jobs within them still upload artifacts
+            # before the workflow is killed (e.g., the 6-hour job timeout).
+            if r.get("conclusion") in ("success", "failure", "cancelled"):
                 runs.append({
                     "run_id": str(r["id"]),
                     "sha": r["head_sha"][:8],

--- a/.github/dashboard/build_dashboard_data.py
+++ b/.github/dashboard/build_dashboard_data.py
@@ -179,11 +179,16 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None):
         key=lambda r: r["date"],
     )
 
-    # Index existing history by kernel|platform -> run_id
+    # Index existing history by kernel|platform_short -> run_id.
+    # Older caches may contain duplicate (kernel, platform_short) rows because
+    # AMD runners occasionally report platform as "AMD Radeon Graphics" vs
+    # "AMD Instinct MI325X". Merge those duplicates here.
+    existing_summary = {}
     existing_history = {}
-    existing_summary = {e["kernel"] + "|" + e["platform"]: e for e in (existing_data or {}).get("summary", [])}
-    for key, entry in existing_summary.items():
-        existing_history[key] = {h["run_id"]: h for h in entry.get("history", [])}
+    for e in (existing_data or {}).get("summary", []):
+        key = e["kernel"] + "|" + e.get("platform_short", "")
+        existing_summary[key] = e
+        existing_history.setdefault(key, {}).update({h["run_id"]: h for h in e.get("history", [])})
 
     # Parse each run's artifacts if present
     runs = []
@@ -202,7 +207,7 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None):
             fresh_run_ids.add(run["run_id"])
             run_ids_with_data.add(run["run_id"])
         for k in run["kernels"]:
-            key = f"{k['kernel']}|{k['platform']}"
+            key = f"{k['kernel']}|{k['platform_short']}"
             if key not in kernel_index:
                 kernel_index[key] = {
                     "kernel": k["kernel"],
@@ -224,8 +229,8 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None):
                 prev = existing_summary.get(key, {})
                 kernel_index[key] = {
                     "kernel": prev.get("kernel", key.split("|")[0]),
-                    "platform": prev.get("platform", key.split("|")[1] if "|" in key else "unknown"),
-                    "platform_short": prev.get("platform_short", ""),
+                    "platform": prev.get("platform", "unknown"),
+                    "platform_short": prev.get("platform_short", key.split("|")[1] if "|" in key else ""),
                     "shapes": [],
                     "history": [],
                 }
@@ -300,6 +305,7 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None):
             "status": status,
             "accuracy_failures": acc_failures,
             "run_failures": run_failures,
+            "last_seen_date": latest_main["date"] if latest_main else None,
             "infra_missing": infra_missing,
             "helion_speedup_geomean": latest_data["helion_speedup_geomean"] if latest_data else 0,
             "triton_speedup_geomean": latest_data["triton_speedup_geomean"] if latest_data else 0,

--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -58,6 +58,7 @@ a:hover{text-decoration:underline}
 .kernel-card .sparkline-container svg{width:100%;height:100%;min-height:80px}
 .kernel-card .fail-overlay{position:absolute;inset:0;display:flex;flex-direction:column;justify-content:center;align-items:center;gap:4px;background:rgba(13,17,23,0.75);border-radius:6px;padding:8px;text-align:center}
 .kernel-card .fail-overlay .fail-line{font-size:14px;font-weight:600}
+.kernel-card .fail-overlay .fail-subline{font-size:11px;color:var(--text-dim)}
 .kernel-card .fail-overlay .run-line{color:var(--yellow)}
 .kernel-card .fail-overlay .infra-line{color:var(--text-dim)}
 .kernel-card .accuracy-badge{position:absolute;top:6px;right:6px;font-size:14px;font-weight:700;color:var(--orange);background:rgba(240,136,62,0.2);padding:4px 10px;border-radius:6px;border:1px solid rgba(240,136,62,0.4)}
@@ -274,7 +275,7 @@ function getFailures() {
     const entry = { kernel: e.kernel, platform: platName(e.platform_short), platform_short: e.platform_short };
     if (e.accuracy_failures?.length) acc.push({ ...entry, shapes: e.accuracy_failures });
     if (e.run_failures?.length) run.push({ ...entry, shapes: e.run_failures });
-    if (e.infra_missing) infra.push(entry);
+    if (e.infra_missing) infra.push({ ...entry, last_seen_date: e.last_seen_date });
   });
   return { acc, run, infra };
 }
@@ -395,7 +396,10 @@ function renderOverviewGrid() {
         if (e.run_failures?.length || e.infra_missing) {
           overlay = '<div class="fail-overlay">';
           if (e.run_failures?.length) overlay += `<div class="fail-line run-line">${e.run_failures.length} shapes failed</div>`;
-          if (e.infra_missing) overlay += `<div class="fail-line infra-line">runner failed</div>`;
+          if (e.infra_missing) {
+            overlay += '<div class="fail-line infra-line">No Result</div>';
+            if (e.last_seen_date) overlay += `<div class="fail-subline">last seen ${formatDate(e.last_seen_date)}</div>`;
+          }
           overlay += '</div>';
         } else if (e.accuracy_failures?.length) {
           overlay = `<div class="accuracy-badge">${e.accuracy_failures.length} accuracy fail</div>`;
@@ -755,15 +759,17 @@ function showFailuresModal(fails) {
     h += `<p style="font-size:12px;color:var(--text-dim);margin-bottom:8px">${desc}</p>`;
     h += '<ul class="fail-list">';
     items.forEach(f => {
-      const shapes = f.shapes ? `<span class="fail-shapes">Shapes: ${f.shapes.map(escHtml).join(', ')}</span>` : '';
-      h += `<li><span class="fail-kernel">${escHtml(f.kernel)}</span>${platBadge(f.platform_short)}${shapes}</li>`;
+      let detail = '';
+      if (f.shapes) detail = `<span class="fail-shapes">Shapes: ${f.shapes.map(escHtml).join(', ')}</span>`;
+      else if (f.last_seen_date) detail = `<span class="fail-shapes">Last seen: ${formatDate(f.last_seen_date)}</span>`;
+      h += `<li><span class="fail-kernel">${escHtml(f.kernel)}</span>${platBadge(f.platform_short)}${detail}</li>`;
     });
     return h + '</ul>';
   };
   let html = modalHeader('CI Failures', 'Accuracy mismatches, kernel run failures, and infra issues');
   html += renderSection('Accuracy Failures', 'Kernel ran but produced incorrect output.', fails.acc);
   html += renderSection('Shape Failures', 'Shapes that failed to run (crash, OOM, compile error, timeout, or unsupported config).', fails.run);
-  html += renderSection('Runner Failures', 'Kernel missing from latest run — likely CI runner unavailable, job timeout, or artifact upload failed.', fails.infra);
+  html += renderSection('No Result', 'Benchmark did not produce output for this kernel — possible causes: runner unavailable, job timeout, crash, artifact upload failed, or harness skipped this kernel+platform combination.', fails.infra);
   openModal(html);
 }
 function showDetailModal(kernel, platform_short) {
@@ -784,7 +790,8 @@ function showDetailModal(kernel, platform_short) {
     html += `<div class="run-warn" style="margin-bottom:12px">${e.run_failures.length} shape failure(s): ${e.run_failures.join(', ')}</div>`;
   }
   if (e.infra_missing) {
-    html += `<div class="infra-warn" style="margin-bottom:12px">Runner failed — kernel missing from latest run (CI runner unavailable, timeout, or artifact upload failed)</div>`;
+    const lastSeen = e.last_seen_date ? ` (last seen ${formatDate(e.last_seen_date)})` : '';
+    html += `<div class="infra-warn" style="margin-bottom:12px">No result in latest run${lastSeen} — runner unavailable, timeout, crash, upload failed, or harness skipped this kernel+platform</div>`;
   }
   html += '<h3 style="font-size:13px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.3px;margin-bottom:8px">Run History</h3>';
   html += '<div class="table-scroll" style="max-height:300px"><table class="data-table"><thead><tr><th>Commit</th><th>Date</th><th>Latency</th><th>Speedup</th><th>Compile Time</th></tr></thead><tbody>';

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1571,10 +1571,12 @@ class PallasBackend(Backend):
         # Determine which arg positions are outputs.  A tensor is an output if:
         #   1. It was created inside the function body (not in input_sources), OR
         #   2. It is a function parameter that is mutated in-place (e.g. x[tile] += ...)
-        from .ast_read_writes import ReadWrites
         from .compile_environment import CompileEnvironment
+        from .device_function import DeviceFunction
         from .device_function import TensorArg
         from .host_function import HostFunction
+
+        device_fn = DeviceFunction.current()
 
         def _empty_allocated_vars(body: list[ast.stmt]) -> set[str]:
             """Return names of variables allocated with torch.empty/empty_like/new_empty.
@@ -1605,38 +1607,22 @@ class PallasBackend(Backend):
         if sorted_args is not None:
             env = CompileEnvironment.current()
             host_fn = HostFunction.current()
-            mutated_params = set(ReadWrites.from_list(host_fn.body).inplace_writes) & {
-                a.arg for a in host_fn.args.args
-            }
+            read_names, write_names = device_fn.get_tensor_read_write_names()
+            mutated_params = write_names & {a.arg for a in host_fn.args.args}
             input_storages = {id(t.untyped_storage()) for t in env.input_sources}
-            # Collect reads from for-loop bodies only (kernel code), excluding
-            # host-level reads like ``return out``.
-            # Note: Python AST counts ``out[tile] = val`` as a Load of ``out``
-            # (the object must be loaded to index into it), but from Pallas's
-            # perspective this is a pure write — the tensor data is not read.
-            # Subtract such "false reads" by checking inplace_writes counts.
-            #
             # Only tensors allocated with torch.empty/empty_like/new_empty can be
             # output-only — their initial values are undefined, so it's safe
             # to use HBM BlockSpecs.  Tensors allocated with torch.zeros_like,
             # torch.full, etc. have meaningful initial values that must be
             # preserved via VMEM BlockSpecs.
             empty_vars = _empty_allocated_vars(host_fn.body)
-            kernel_reads: set[str] = set()
-            for stmt in host_fn.body:
-                if isinstance(stmt, ast.For):
-                    body_rw = ReadWrites.from_list(stmt.body)
-                    for name, read_count in body_rw.reads.items():
-                        iw_count = body_rw.inplace_writes.get(name, 0)
-                        if read_count > iw_count or name not in empty_vars:
-                            kernel_reads.add(name)
             for i, arg in enumerate(sorted_args):
                 if not isinstance(arg, TensorArg):
                     continue
                 if id(arg.fake_value.untyped_storage()) not in input_storages:
                     # Tensor created inside the function body (output)
                     output_indices.append(i)
-                    if arg.host_str() in kernel_reads:
+                    if arg.host_str() in read_names or arg.host_str() not in empty_vars:
                         # Also read by the kernel (e.g. broadcast result)
                         inplace_indices.append(i)
                 elif arg.host_str() in mutated_params:
@@ -1668,9 +1654,6 @@ class PallasBackend(Backend):
                 block_spec_info.append(None)  # RNG seed buffer is untiled
             launcher_args.append(f"_block_spec_info={block_spec_info!r}")
 
-        from .device_function import DeviceFunction
-
-        device_fn = DeviceFunction.current()
         from .device_function import PallasMemorySpace
 
         mem_space = device_fn.pallas_memory_space

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -939,6 +939,43 @@ class DeviceFunction:
             (), None, name_hint=name_hint, scratch_type="dma_semaphore"
         )
 
+    def get_tensor_read_write_names(self) -> tuple[set[str], set[str]]:
+        """Returns AST names of read and written tensors"""
+        from helion.language import atomic_ops
+        from helion.language import memory_ops
+
+        read_names: set[str] = set()
+        write_names: set[str] = set()
+        for graph in self.codegen.codegen_graphs:
+            for node in graph.graph.nodes:
+                if node.op != "call_function":
+                    continue
+
+                def _get_tensor_name(node: torch.fx.Node) -> str:
+                    tensor_arg = node.args[0]
+                    assert isinstance(tensor_arg, torch.fx.Node)
+                    tensor_val = tensor_arg.meta.get("val")
+                    assert isinstance(tensor_val, torch.Tensor)
+                    return self.tensor_arg(tensor_val).name
+
+                if node.target is memory_ops.load:
+                    read_names.add(_get_tensor_name(node))
+                elif node.target is memory_ops.store:
+                    write_names.add(_get_tensor_name(node))
+                elif node.target in (
+                    atomic_ops.atomic_add,
+                    atomic_ops.atomic_cas,
+                    atomic_ops.atomic_or,
+                    atomic_ops.atomic_xor,
+                    atomic_ops.atomic_xchg,
+                    atomic_ops.atomic_min,
+                    atomic_ops.atomic_max,
+                    atomic_ops.atomic_and,
+                ):
+                    read_names.add(_get_tensor_name(node))
+                    write_names.add(_get_tensor_name(node))
+        return read_names, write_names
+
     def __enter__(self) -> None:
         try:
             tls.functions.append(self)

--- a/helion/autotuner/llm/transport.py
+++ b/helion/autotuner/llm/transport.py
@@ -157,12 +157,15 @@ def _anthropic_payload(
 ) -> dict[str, Any]:
     """Build an Anthropic Messages request payload."""
     system_prompt, input_messages = split_system_messages(messages)
+    normalized_model = strip_provider_prefix(model)
     payload: dict[str, Any] = {
-        "model": strip_provider_prefix(model),
+        "model": normalized_model,
         "messages": anthropic_messages_from_history(input_messages),
         "max_tokens": max_output_tokens,
-        "temperature": DEFAULT_ANTHROPIC_TEMPERATURE,
     }
+    # Claude Opus 4.7 returns HTTP 400 if `temperature` is present.
+    if not normalized_model.lower().startswith("claude-opus-4-7"):
+        payload["temperature"] = DEFAULT_ANTHROPIC_TEMPERATURE
     if system_prompt:
         payload["system"] = system_prompt
     return payload

--- a/helion/autotuner/llm_search.py
+++ b/helion/autotuner/llm_search.py
@@ -306,8 +306,8 @@ class LLMGuidedSearch(PopulationBasedSearch):
         return self._llm_executor.submit(self._call_llm, messages)
 
     def _max_output_tokens_for_request(self) -> int:
-        """Choose a small response budget that scales with configs_per_round."""
-        return max(384, min(1536, 192 + self.configs_per_round * 56))
+        """Response budget sized to fit verbose JSON from models like Opus 4.7."""
+        return max(512, min(4096, 256 + self.configs_per_round * 128))
 
     def _get_context_messages(self) -> list[dict[str, str]]:
         """Keep the fixed prompt prefix plus only the most recent round history."""

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -722,11 +722,17 @@ class TestPallas(TestCase):
         key = torch.randn(1, 4, 32, 64, dtype=torch.float32, device=DEVICE)
         val = torch.randn(1, 4, 32, 64, dtype=torch.float32, device=DEVICE)
         args = (query, key, val)
+
         _code, result = code_and_output(pallas_attention, args, block_sizes=[1, 32, 32])
         ref = torch.nn.functional.scaled_dot_product_attention(
             query.float().cpu(), key.float().cpu(), val.float().cpu()
         ).to(device=DEVICE)
         torch.testing.assert_close(result, ref, rtol=1e-2, atol=1e-2)
+
+        # test that we're not manually allocating and donating out tensor HBM,
+        # but are instead taking over tensor returned by torch_tpu JaxCallable
+        self.assertIn("out = torch.empty_like(q_view, device='meta')", _code)
+        self.assertIn("out = _launcher(", _code)
 
     def test_attention_emit_pipeline_correctness(self) -> None:
         """Test emit_pipeline attention with loop-carried state."""


### PR DESCRIPTION
Stacked PRs:
 * #2586
 * #2585
 * __->__#2584
 * #2583


--- --- ---

### [pallas] fast-path host-side launcher with pre-computed cache entries


Replaces the per-call closure rebuilding in
default_pallas_pipeline_launcher (and siblings) with a precomputed
fast-path cache that runs once at first invocation and is keyed on the
kernel + grid signature for static-shape kernels.

Two cooperating mechanisms:

1. Per-kernel _pallas_pipeline_cache
   First call walks the full _pallas_prepare_args -> _pallas_build_*
   pipeline once and stores the resulting tensor_arg_indices,
   arg_to_tensor_pos, jax_callable, and pl.pallas_call object on
   pallas_kernel. Subsequent calls with the same grid signature do a
   single attribute lookup and dispatch directly. Same code path for
   the fori_loop and emit_pipeline launchers.

2. Pre-cached torch_tpu JaxCallable invocation key
   After the first invocation populates the JaxCallable internal
   cache, the launcher snapshots the cache key + flat input pytree
   layout so repeat calls bypass JaxCallable.__call__'s key
   construction. The torch_tpu side already deduplicates by key, so
   this just saves the dict-key building work on the hot path.

Measured on bf16 1024x1024x1024 headline matmul (TPU v7, median-of-3
seeds, paired interleaved-4way): -12us total Helion us per call vs
PR1 baseline (77.37 -> 65.79us launcher overhead). Kernel device us
unchanged. Counter _launcher_fast_path_hits and
_jaxcallable_key_cache_hits bump on every fast-path call so the pin
tests can assert the cache is wired up.