### PR TITLE
[pallas] bypass JaxCallable for static-shape kernels via direct call_custom_kernel

### DIFF
--- a/.github/dashboard/build_dashboard_data.py
+++ b/.github/dashboard/build_dashboard_data.py
@@ -63,7 +63,9 @@ def fetch_runs(repo, workflow_name, days):
         if not data or not data.get("workflow_runs"):
             break
         for r in data["workflow_runs"]:
-            if r.get("conclusion") in ("success", "failure"):
+            # Include cancelled runs: successful jobs within them still upload artifacts
+            # before the workflow is killed (e.g., the 6-hour job timeout).
+            if r.get("conclusion") in ("success", "failure", "cancelled"):
                 runs.append({
                     "run_id": str(r["id"]),
                     "sha": r["head_sha"][:8],

--- a/.github/dashboard/build_dashboard_data.py
+++ b/.github/dashboard/build_dashboard_data.py
@@ -159,7 +159,7 @@ def build_history_entry(run, metrics, shapes):
         "helion_speedup_geomean": round(geo_mean(metrics.get("helion_speedup", [])), 4),
         "triton_speedup_geomean": round(geo_mean(metrics.get("triton_speedup", [])), 4),
         "torch_compile_speedup_geomean": round(geo_mean(metrics.get("torch_compile_speedup", [])), 4),
-        "compile_time_avg_s": round(avg(metrics.get("helion_compile_time_s", [])), 2),
+        "compile_time_geomean_s": round(geo_mean(metrics.get("helion_compile_time_s", [])), 2),
         "helion_latency_avg_ms": round(avg(helion_lat), 4) if helion_lat else 0,
         "per_shape": {
             "shapes": shapes,
@@ -269,7 +269,7 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None):
                 break
 
         speedup_delta = fmt_delta(latest_data["helion_speedup_geomean"], prev_data["helion_speedup_geomean"]) if latest_data and prev_data else None
-        compile_delta = fmt_delta(prev_data["compile_time_avg_s"], latest_data["compile_time_avg_s"]) if latest_data and prev_data and latest_data["compile_time_avg_s"] > 0 else None
+        compile_delta = fmt_delta(prev_data["compile_time_geomean_s"], latest_data["compile_time_geomean_s"]) if latest_data and prev_data and latest_data["compile_time_geomean_s"] > 0 else None
         latency_delta = fmt_delta(prev_data["helion_latency_avg_ms"], latest_data["helion_latency_avg_ms"]) if latest_data and prev_data and latest_data["helion_latency_avg_ms"] > 0 else None
 
         classify_delta = latency_delta if latency_delta is not None else speedup_delta
@@ -312,7 +312,7 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None):
             "helion_speedup_geomean": latest_data["helion_speedup_geomean"] if latest_data else 0,
             "triton_speedup_geomean": latest_data["triton_speedup_geomean"] if latest_data else 0,
             "torch_compile_speedup_geomean": latest_data["torch_compile_speedup_geomean"] if latest_data else 0,
-            "compile_time_avg_s": latest_data["compile_time_avg_s"] if latest_data else 0,
+            "compile_time_geomean_s": latest_data["compile_time_geomean_s"] if latest_data else 0,
             "helion_latency_avg_ms": latest_data["helion_latency_avg_ms"] if latest_data else 0,
             "speedup_delta_pct": speedup_delta,
             "compile_delta_pct": compile_delta,

--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -386,7 +386,7 @@ function renderOverviewGrid() {
         html += '</div>';
         html += '<div class="kc-body"><div class="kc-left">';
         html += `<div class="kc-row"><span class="kc-label">Latency</span><span class="kc-val" style="color:${color}">${e.helion_latency_avg_ms.toFixed(2)} ms</span></div>`;
-        html += `<div class="kc-row"><span class="kc-label">Compile time</span><span class="kc-val">${formatCompileTime(e.compile_time_avg_s)}</span></div>`;
+        html += `<div class="kc-row"><span class="kc-label">Compile time</span><span class="kc-val">${formatCompileTime(e.compile_time_geomean_s)}</span></div>`;
         html += `<div class="kc-delta">Latency vs prev: ${formatDelta(e.latency_delta_pct, true)}</div>`;
         html += `<div class="kc-delta">Compile time vs prev: ${formatDelta(e.compile_delta_pct, true)}</div>`;
         html += '</div>';
@@ -524,7 +524,7 @@ function renderSpeedup() {
       <td style="color:var(--green)">${formatSpeedup(e.helion_speedup_geomean)}</td>
       <td style="color:var(--blue)">${formatSpeedup(e.torch_compile_speedup_geomean)}</td>
       <td style="color:var(--purple)">${formatSpeedup(e.triton_speedup_geomean)}</td>
-      <td>${formatCompileTime(e.compile_time_avg_s)}</td>
+      <td>${formatCompileTime(e.compile_time_geomean_s)}</td>
       <td style="color:${colors[bestIdx]}">${names[bestIdx]}</td>
     </tr>`;
   });
@@ -570,8 +570,8 @@ function renderCompare(baseRunIdOverride, cmpRunIdOverride, baseBranchOverride, 
       if (!baseH && !cmpH) return;
       const baseSpeedup = baseH ? baseH.helion_speedup_geomean : null;
       const cmpSpeedup = cmpH ? cmpH.helion_speedup_geomean : null;
-      const baseCompile = baseH ? baseH.compile_time_avg_s : null;
-      const cmpCompile = cmpH ? cmpH.compile_time_avg_s : null;
+      const baseCompile = baseH ? baseH.compile_time_geomean_s : null;
+      const cmpCompile = cmpH ? cmpH.compile_time_geomean_s : null;
       const baseLatency = baseH ? baseH.helion_latency_avg_ms : null;
       const cmpLatency = cmpH ? cmpH.helion_latency_avg_ms : null;
       let speedupDelta = null;
@@ -778,7 +778,7 @@ function showDetailModal(kernel, platform_short) {
   const color = platColor(platform_short);
   let html = modalHeader(
     `${escHtml(kernel)} ${platBadge(platform_short)}`,
-    `Latency: ${e.helion_latency_avg_ms.toFixed(2)} ms | Speedup: ${formatSpeedup(e.helion_speedup_geomean)} | Compile Time: ${formatCompileTime(e.compile_time_avg_s)}`);
+    `Latency: ${e.helion_latency_avg_ms.toFixed(2)} ms | Speedup: ${formatSpeedup(e.helion_speedup_geomean)} | Compile Time: ${formatCompileTime(e.compile_time_geomean_s)}`);
   html += '<div class="modal-split"><div class="modal-lhs">';
   if (e.status !== 'unchanged') {
     html += `<div style="margin-bottom:12px"><span class="kc-tag ${e.status}">${e.status} perf</span></div>`;
@@ -814,7 +814,7 @@ function showDetailModal(kernel, platform_short) {
       <td style="font-size:11px">${formatDate(h.date)}</td>
       <td>${h.helion_latency_avg_ms.toFixed(2)} ms${latencyDelta}</td>
       <td>${formatSpeedup(h.helion_speedup_geomean)}${speedupDelta}</td>
-      <td>${formatCompileTime(h.compile_time_avg_s)}</td>
+      <td>${formatCompileTime(h.compile_time_geomean_s)}</td>
     </tr>`;
   });
   html += '</tbody></table></div>';
@@ -884,7 +884,7 @@ function showDetailModal(kernel, platform_short) {
         spEl.on('plotly_click', clickHandler);
       }
       // Compile time over time
-      const ctVals = histFwd.map(h => h.compile_time_avg_s > 0 ? h.compile_time_avg_s : null);
+      const ctVals = histFwd.map(h => h.compile_time_geomean_s > 0 ? h.compile_time_geomean_s : null);
       const ctTrace = {
         x: xLabels, y: ctVals,
         mode: 'lines+markers', line: { color: '#f0883e', width: 2 }, marker: { size: 6 },

--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -93,17 +93,6 @@
       "triton-pin": "0d9283bf49"
     },
     {
-      "runner": "linux.rocm.gpu.gfx942.1",
-      "python-version": "3.12",
-      "ref-eager": false,
-      "image": "rocm/dev-ubuntu-24.04:7.0-complete",
-      "runtime-version": "rocm7.0",
-      "container-options": "--device=/dev/kfd --device=/dev/dri",
-      "pytorch-version": "pytorch-nightly",
-      "alias": "mi325x",
-      "backend": "triton"
-    },
-    {
       "runner": "linux.rocm.gpu.ecosystem.gfx950.1",
       "python-version": "3.12",
       "ref-eager": false,

--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -83,14 +83,14 @@
       "runner": "linux.dgx.b200",
       "python-version": "3.12",
       "ref-eager": false,
-      "image": "nvidia/cuda:13.1.0-devel-ubuntu24.04",
+      "image": "nvidia/cuda:13.2.0-devel-ubuntu24.04",
       "runtime-version": "cu130",
       "container-options": "--gpus all",
       "pytorch-version": "pytorch-2.11",
       "alias": "b200",
       "backend": "tileir",
       "triton-repo": "https://github.com/triton-lang/Triton-to-tile-IR.git",
-      "triton-pin": "5d3ab8c13c"
+      "triton-pin": "0d9283bf49"
     },
     {
       "runner": "linux.rocm.gpu.gfx942.1",

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -172,26 +172,9 @@ jobs:
             echo "Using baseline: $BASELINE"
             echo "Available implementations for $kernel: $IMPLS"
 
-            # Do autotuning but do not record the results
-            ${{ inputs.env-vars }} python benchmarks/run.py \
-                --op $kernel \
-                --metrics speedup,accuracy \
-                --latency-measure-mode triton_do_bench \
-                --cudagraph \
-                --only $IMPLS \
-                --only-match-mode prefix-with-baseline \
-                --baseline $BASELINE \
-                --atol 1e-2 \
-                --rtol 1e-2 \
-                --input-sample-mode equally-spaced-k \
-                --keep-going \
-                ${{ inputs.custom-args }}
-
-            # Relax the GPU
-            sleep 2m
-
-            # Run again with cache and record results
-            ${{ inputs.env-vars }} HELION_PRINT_OUTPUT_CODE=1 HELION_ASSERT_CACHE_HIT=1 python benchmarks/run.py \
+            # Single pass: autotune search + codegen + compilation happen inline,
+            # so --measure-compile-time reports end-to-end user-visible compile time.
+            ${{ inputs.env-vars }} HELION_PRINT_OUTPUT_CODE=1 python benchmarks/run.py \
                 --op $kernel \
                 --metrics speedup,accuracy,latency \
                 --measure-compile-time \

--- a/.github/workflows/benchmark_dispatch.yml
+++ b/.github/workflows/benchmark_dispatch.yml
@@ -13,11 +13,6 @@ on:
         required: false
         type: boolean
         default: true
-      run_mi325x:
-        description: 'Run benchmark on MI325X'
-        required: false
-        type: boolean
-        default: false
       run_mi350x:
         description: 'Run benchmark on MI350X'
         required: false
@@ -90,33 +85,6 @@ jobs:
       runtime-version: cu130
       container-options: --gpus all
       alias: b200
-      kernels: ${{ matrix.kernels }}
-      env-vars: ${{ github.event.inputs.env_vars }}
-      custom-args: ${{ github.event.inputs.custom_args }}
-
-  gen-matrix-mi325x:
-    uses: ./.github/workflows/compute-benchmark-matrix.yml
-    if: ${{ github.event.inputs.run_mi325x == 'true' }}
-    with:
-      max-runners: 6
-      kernels: ${{ github.event.inputs.kernels }}
-
-  run-mi325x:
-    needs: gen-matrix-mi325x
-    uses: ./.github/workflows/benchmark.yml
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.gen-matrix-mi325x.outputs.matrix) }}
-    permissions:
-      id-token: write
-      contents: read
-    with:
-      runner: linux.rocm.gpu.gfx942.1
-      python-version: "3.12"
-      image: rocm/dev-ubuntu-24.04:7.1.1-complete
-      runtime-version: rocm7.1
-      container-options: --device=/dev/kfd --device=/dev/dri
-      alias: mi325x
       kernels: ${{ matrix.kernels }}
       env-vars: ${{ github.event.inputs.env_vars }}
       custom-args: ${{ github.event.inputs.custom_args }}

--- a/.github/workflows/benchmark_nightly.yml
+++ b/.github/workflows/benchmark_nightly.yml
@@ -25,7 +25,6 @@ jobs:
               inputs: {
                 run_h100: 'true',
                 run_b200: 'true',
-                run_mi325x: 'true',
                 run_mi350x: 'true'
               }
             })

--- a/examples/jagged_dense_bmm.py
+++ b/examples/jagged_dense_bmm.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import torch
 
 import helion
+from helion._testing import DEVICE
 from helion._testing import run_example
 import helion.language as hl
 
@@ -126,26 +127,22 @@ def random_input(
     max_seq_len: int = 3,
     dtype: torch.dtype = torch.float32,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    lengths = torch.randint(
-        max_seq_len + 1, size=(batch_size,), device=torch.device("cuda")
-    )
-    seq_offsets = torch.zeros(
-        (batch_size + 1,), dtype=torch.int64, device=torch.device("cuda")
-    )
+    lengths = torch.randint(max_seq_len + 1, size=(batch_size,), device=DEVICE)
+    seq_offsets = torch.zeros((batch_size + 1,), dtype=torch.int64, device=DEVICE)
     seq_offsets[1:] = torch.cumsum(lengths, dim=0)
     jagged_size = int(seq_offsets[-1].item())
     jagged = (
-        torch.empty((jagged_size, D), dtype=dtype, device=torch.device("cuda"))
+        torch.empty((jagged_size, D), dtype=dtype, device=DEVICE)
         .uniform_(-1.0, 1.0)
         .requires_grad_()
     )
     dense = (
-        torch.empty((batch_size, D, K), dtype=dtype, device=torch.device("cuda"))
+        torch.empty((batch_size, D, K), dtype=dtype, device=DEVICE)
         .uniform_(-1.0, 1.0)
         .requires_grad_()
     )
     bias = (
-        torch.empty((batch_size, K), dtype=dtype, device=torch.device("cuda"))
+        torch.empty((batch_size, K), dtype=dtype, device=DEVICE)
         .uniform_(-1.0, 1.0)
         .requires_grad_()
     )

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -1533,16 +1533,26 @@ class WalkDeviceAST(NodeVisitor):
             return None
         if not isinstance(target, ast.Subscript):
             raise exc.InvalidAssignment
+        assert isinstance(target, ExtendedAST)
+        assert isinstance(target.value, ExtendedAST)
+        assert target.value._type_info is not None
+        # Handle list element assignment (e.g., cached[i] = tensor in static_range)
+        if isinstance(target.value._type_info, SequenceType):
+            index_value = self.visit(target.slice)
+            if not isinstance(index_value, int):
+                raise exc.InvalidSequenceSubscription(target.slice)
+            val = self.visit(node.value)
+            base_list = self.visit(target.value)
+            assert isinstance(base_list, list)
+            base_list[index_value] = val
+            return None
         assert isinstance(node.value, ExtendedAST)
         rhs_type = node.value._type_info
-        assert isinstance(target, ExtendedAST)
         lhs_type = target._type_info
         if not isinstance(lhs_type, TensorType) or not isinstance(
             rhs_type, (TensorType, NumericType, LiteralType)
         ):
             raise exc.NonTensorSubscriptAssign(lhs_type, rhs_type)
-        assert isinstance(target.value, ExtendedAST)
-        assert target.value._type_info is not None
         target_origin = target.value._type_info.origin
         if not target_origin.is_host() and not isinstance(
             target.value._type_info, StackTensorType

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -90,20 +90,6 @@ def index_str(
         out_pos += 1
         tensor_dim += 1
 
-    from helion._compiler.device_function import PallasMemorySpace
-
-    requires_smem_access = all(":" not in p and "pl.ds" not in p for p in parts)
-    if requires_smem_access:
-        # Don't override HBM — pipeline tensors keep their memory space
-        tid = id(tensor)
-        if (
-            state.codegen.device_function.pallas_memory_space.get(tid)
-            != PallasMemorySpace.HBM
-        ):
-            state.codegen.device_function.pallas_memory_space[tid] = (
-                PallasMemorySpace.SMEM
-            )
-
     return ", ".join(parts), none_dims
 
 

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -131,6 +131,37 @@ def _analyze_indexing(node: torch.fx.Node, config: Config) -> None:
     )
     node.meta["indexing_patterns"] = indexing_patterns
 
+    # Track SMEM eligibility (simplified — does not distinguish read vs write):
+    #   SMEM: only scalar access.  VMEM: vector/slice + scalar reads.
+    # A fully correct policy would check read vs write per access:
+    #   - Scalar read-only tensors could stay in VMEM (no SMEM needed)
+    #   - Scalar write requires SMEM
+    #   - Mixed scalar-write + slice needs tensor duplication (unsupported)
+    # For now we conservatively put all-scalar tensors in SMEM and
+    # mixed tensors in VMEM. This is correct for the common cases
+    # (scalar-only → SMEM, mixed scalar-read + slice → VMEM) but
+    # over-allocates SMEM for scalar-read-only tensors.
+    from ..device_function import PallasMemorySpace
+
+    is_all_scalar = all(
+        isinstance(p, (ArbitraryIndexPattern, TileBeginWithOffsetPattern, NonePattern))
+        for p in indexing_patterns
+    )
+    tid = id(tensor_val)
+    current = device_fn.pallas_memory_space.get(tid)
+    if is_all_scalar:
+        # Only mark for SMEM if not already assigned to VMEM or HBM
+        if current is None:
+            device_fn.pallas_memory_space[tid] = PallasMemorySpace.SMEM
+    else:
+        # Override SMEM → VMEM: this is intentional. When a tensor has
+        # both scalar and slice accesses, we keep it in VMEM because
+        # scalar *reads* work from VMEM (only scalar writes require
+        # SMEM). We optimistically assume the scalar access is a read.
+        # Don't override HBM (pipeline tensors).
+        if current != PallasMemorySpace.HBM:
+            device_fn.pallas_memory_space[tid] = PallasMemorySpace.VMEM
+
 
 def _analyze_subscript_patterns(
     tensor: torch.Tensor,

--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -1385,6 +1385,16 @@ class SequenceType(CollectionType):
 
         return super().propagate_getitem(key, origin)
 
+    def propagate_setitem(
+        self, key: TypeInfo, value: TypeInfo, origin: Origin
+    ) -> TypeInfo:
+        if self.python_type is list and isinstance(key, SymIntType):
+            if not self.element_types:
+                raise exc.TypeInferenceError("Cannot index empty sequence")
+            new_elements = [elem.merge(value) for elem in self.element_types]
+            return SequenceType(origin=origin, element_types=new_elements)
+        return super().propagate_setitem(key, value, origin)
+
     def merge(self, other: TypeInfo, var_name: str | None = None) -> TypeInfo:
         if isinstance(other, SequenceType):
             self_elements = self.element_types

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -2236,7 +2236,9 @@ class TestExamples(RefEagerTestBase, TestCase):
         lambda: _get_backend() == "cute",
         "CuTe Mamba2 chunk-state destabilizes later cute tests when it fails in-process",
     )
-    @xfailIfPallas("SMEM load lowering: Can only load scalars from SMEM")
+    @xfailIfPallas(
+        "dA_cumsum has mixed scalar+slice access (VMEM), but Mosaic requires 32-bit for VMEM scalar extracts"
+    )
     def test_mamba2_chunk_state(self):
         batch, nheads, ngroups, seqlen, chunk_size, headdim, dstate = (
             2,

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -885,7 +885,7 @@ class TestExamples(RefEagerTestBase, TestCase):
         )
 
     @xfailIfCute("CuTe jagged dense bmm example still returns incorrect results")
-    @xfailIfPallas("tensor-derived if-predicates not supported")
+    @xfailIfPallas("Pallas rejects int64 inputs (jagged offsets)")
     @skipIfXPU("Jagged tensor operations not fully supported on XPU")
     @skipIfRefEager("hl.jagged_tile does not support ref mode yet")
     def test_jagged_dense_bmm(self):

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -910,6 +910,68 @@ class TestPallas(TestCase):
         expected = x + 1.0
         torch.testing.assert_close(result, expected)
 
+    def test_mixed_scalar_and_slice_access(self) -> None:
+        """Tensor accessed both as scalar and slice should not be placed in SMEM.
+
+        When a tensor has one access that is all-scalar (e.g. x[i, j, k])
+        and another that uses a slice (e.g. x[i, j, tile]), placing it in
+        SMEM causes 'Can only load scalars from SMEM' at runtime. The tensor
+        must stay in VMEM to support both access patterns.
+        """
+
+        @helion.kernel(
+            backend="pallas",
+            static_shapes=True,
+        )
+        def mixed_access(x: torch.Tensor) -> torch.Tensor:
+            B, N = x.shape
+            out = torch.empty_like(x)
+            for tile_b, tile_n in hl.tile([B, N], block_size=[1, None]):
+                # scalar access: x[tile_b.begin, N-1]
+                last_val = x[tile_b.begin, N - 1]
+                # slice access: x[tile_b.begin, tile_n]
+                out[tile_b.begin, tile_n] = x[tile_b.begin, tile_n] + last_val
+            return out
+
+        x = torch.randn(4, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(mixed_access, (x,), block_sizes=[128])
+        # x has mixed access (scalar + slice), so it must stay in VMEM
+        self.assertNotIn("_smem_arg_indices", code)
+        expected = x + x[:, -1:]
+        torch.testing.assert_close(result, expected)
+
+    @xfailIfPallas(
+        "Mixed scalar write + slice needs tensor duplication into SMEM and VMEM"
+    )
+    def test_mixed_scalar_write_and_slice_access(self) -> None:
+        """Tensor with both scalar write and slice access is unsupported.
+
+        SMEM only supports scalar access; VMEM doesn't support scalar writes.
+        A tensor that needs both would require duplication into SMEM (for the
+        scalar write) and VMEM (for the slice access), which is not yet
+        implemented.
+        """
+
+        @helion.kernel(
+            backend="pallas",
+            static_shapes=True,
+        )
+        def mixed_write(x: torch.Tensor) -> torch.Tensor:
+            B, N = x.shape
+            out = torch.empty_like(x)
+            for tile_b, tile_n in hl.tile([B, N], block_size=[1, None]):
+                # slice read
+                out[tile_b.begin, tile_n] = x[tile_b.begin, tile_n]
+                # scalar write to same tensor
+                out[tile_b.begin, N - 1] = x[tile_b.begin, 0]
+            return out
+
+        x = torch.randn(4, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(mixed_write, (x,), block_sizes=[128])
+        expected = x.clone()
+        expected[:, -1] = x[:, 0]
+        torch.testing.assert_close(result, expected)
+
     def test_scalar_access_hl_grid(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True, config=helion.Config())
         def fn(x: torch.Tensor) -> torch.Tensor:

--- a/test/test_unroll_tuples.py
+++ b/test/test_unroll_tuples.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import unittest
 
 import torch
+from torch.testing._internal.common_device_type import largeTensorTest
 
 import helion
 from helion import exc
@@ -12,6 +13,7 @@ from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
 from helion._testing import skipIfRefEager
+from helion._testing import skipIfRocm
 import helion.language as hl
 
 
@@ -414,6 +416,73 @@ def kernel_list_comprehension_host_and_device(
 
         result[tile_idx] = acc
     return result
+
+
+@helion.kernel(autotune_effort="none")
+def kernel_list_register_cache_layernorm(
+    input_list: list[torch.Tensor],
+    ln_eps: float = 1e-5,
+) -> torch.Tensor:
+    """Two-pass layernorm over concatenated list elements using register cache."""
+    G = len(input_list)
+    M, D = input_list[0].shape
+    FULL_D = G * D
+    FULL_D = hl.specialize(FULL_D)
+    D = hl.specialize(D)
+    output = torch.empty(
+        [M, FULL_D], dtype=input_list[0].dtype, device=input_list[0].device
+    )
+    d_block = hl.register_block_size(helion.next_power_of_2(D))
+    for tile_m, tile_d in hl.tile([M, D], block_size=[None, d_block]):
+        row_sum = hl.zeros([tile_m], dtype=torch.float32)
+        row_sq_sum = hl.zeros([tile_m], dtype=torch.float32)
+        cached = [hl.zeros([tile_m, tile_d], dtype=input_list[0].dtype)] * G
+        for i in hl.static_range(G):
+            val = input_list[i][tile_m, tile_d]
+            cached[i] = val
+            val_f32 = val.to(torch.float32)
+            row_sum = row_sum + torch.sum(val_f32, dim=-1)
+            row_sq_sum = row_sq_sum + torch.sum(val_f32 * val_f32, dim=-1)
+        mean = row_sum / FULL_D
+        var = (row_sq_sum / FULL_D) - (mean * mean)
+        rstd = 1.0 / torch.sqrt(var + ln_eps)
+        for i in hl.static_range(G):
+            normalized = (cached[i].to(torch.float32) - mean[:, None]) * rstd[:, None]
+            output[tile_m, tile_d + i * D] = normalized.to(output.dtype)
+    return output
+
+
+@helion.kernel(autotune_effort="none")
+def kernel_list_no_cache_layernorm(
+    input_list: list[torch.Tensor],
+    ln_eps: float = 1e-5,
+) -> torch.Tensor:
+    """Two-pass layernorm without register cache (re-gathers in pass 2)."""
+    G = len(input_list)
+    M, D = input_list[0].shape
+    FULL_D = G * D
+    FULL_D = hl.specialize(FULL_D)
+    D = hl.specialize(D)
+    output = torch.empty(
+        [M, FULL_D], dtype=input_list[0].dtype, device=input_list[0].device
+    )
+    d_block = hl.register_block_size(helion.next_power_of_2(D))
+    for tile_m, tile_d in hl.tile([M, D], block_size=[None, d_block]):
+        row_sum = hl.zeros([tile_m], dtype=torch.float32)
+        row_sq_sum = hl.zeros([tile_m], dtype=torch.float32)
+        for i in hl.static_range(G):
+            val = input_list[i][tile_m, tile_d]
+            val_f32 = val.to(torch.float32)
+            row_sum = row_sum + torch.sum(val_f32, dim=-1)
+            row_sq_sum = row_sq_sum + torch.sum(val_f32 * val_f32, dim=-1)
+        mean = row_sum / FULL_D
+        var = (row_sq_sum / FULL_D) - (mean * mean)
+        rstd = 1.0 / torch.sqrt(var + ln_eps)
+        for i in hl.static_range(G):
+            val = input_list[i][tile_m, tile_d]
+            normalized = (val.to(torch.float32) - mean[:, None]) * rstd[:, None]
+            output[tile_m, tile_d + i * D] = normalized.to(output.dtype)
+    return output
 
 
 @onlyBackends(["triton"])
@@ -854,6 +923,88 @@ class TestUnrollTuples(RefEagerTestBase, TestCase):
         # = x * (2 + 4 + 6 + 4 + 8 + 12 + 6 + 12 + 18 + 8 + 16 + 24) = x * 120
         expected = x * 120
         torch.testing.assert_close(result, expected)
+
+    @largeTensorTest("8GB", device=DEVICE)
+    @skipIfRefEager("RuntimeError in ref eager mode")
+    def test_list_register_cache_layernorm(self):
+        """Test two-pass layernorm with register-cached list elements."""
+        M, D, G = 1024 * 1024, 32, 8
+        tensors = [
+            torch.randn(M, D, device=DEVICE, dtype=torch.bfloat16) for _ in range(G)
+        ]
+
+        code, result = code_and_output(kernel_list_register_cache_layernorm, (tensors,))
+
+        # Reference: concat then layernorm (no affine)
+        concatenated = torch.cat(tensors, dim=1).float()
+        mean = concatenated.mean(dim=-1)
+        var = ((concatenated - mean[:, None]) ** 2).mean(dim=-1)
+        rstd = 1.0 / torch.sqrt(var + 1e-5)
+        expected = ((concatenated - mean[:, None]) * rstd[:, None]).to(tensors[0].dtype)
+
+        torch.testing.assert_close(result, expected, atol=5 * 1e-2, rtol=5 * 1e-2)
+
+        # Verify register caching: G loads in pass 1, no re-loads in pass 2
+        triton_kernel = code[: code.index("\ndef kernel_list_register_cache")]
+        load_count = triton_kernel.count("tl.load")
+        assert load_count == G, f"Expected {G} loads, got {load_count}"
+
+    @largeTensorTest("8GB", device=DEVICE)
+    @skipIfRefEager("RuntimeError in ref eager mode")
+    def test_list_no_cache_layernorm(self):
+        """Test two-pass layernorm without register cache (re-gathers in pass 2)."""
+        M, D, G = 1024 * 1024, 32, 8
+        tensors = [
+            torch.randn(M, D, device=DEVICE, dtype=torch.bfloat16) for _ in range(G)
+        ]
+
+        code, result = code_and_output(kernel_list_no_cache_layernorm, (tensors,))
+
+        # Reference: concat then layernorm (no affine)
+        concatenated = torch.cat(tensors, dim=1).float()
+        mean = concatenated.mean(dim=-1)
+        var = ((concatenated - mean[:, None]) ** 2).mean(dim=-1)
+        rstd = 1.0 / torch.sqrt(var + 1e-5)
+        expected = ((concatenated - mean[:, None]) * rstd[:, None]).to(tensors[0].dtype)
+
+        torch.testing.assert_close(result, expected, atol=5 * 1e-2, rtol=5 * 1e-2)
+
+        # No cache: G loads in pass 1 + G loads in pass 2
+        triton_kernel = code[: code.index("\ndef kernel_list_no_cache")]
+        load_count = triton_kernel.count("tl.load")
+        assert load_count == 2 * G, f"Expected {2 * G} loads, got {load_count}"
+
+    @largeTensorTest("12GB", device=DEVICE)
+    @skipIfRefEager("Benchmark not applicable in ref eager mode")
+    @skipIfRocm("Benchmark timing unreliable on ROCm")
+    def test_register_cache_faster_than_no_cache(self):
+        """Verify register-cached layernorm is faster than re-gathering."""
+        from triton.testing import do_bench
+
+        M, D, G = 1024 * 1024, 32, 8
+        tensors = [
+            torch.randn(M, D, device=DEVICE, dtype=torch.bfloat16) for _ in range(G)
+        ]
+
+        # Warmup and correctness check
+        cached_result = kernel_list_register_cache_layernorm(tensors)
+        no_cache_result = kernel_list_no_cache_layernorm(tensors)
+        torch.testing.assert_close(
+            cached_result, no_cache_result, atol=5 * 1e-2, rtol=5 * 1e-2
+        )
+
+        ms_cached = do_bench(lambda: kernel_list_register_cache_layernorm(tensors))
+        ms_no_cache = do_bench(lambda: kernel_list_no_cache_layernorm(tensors))
+
+        speedup = ms_no_cache / ms_cached
+        print(
+            f"\nRegister cache: {ms_cached:.3f} ms, "
+            f"No cache: {ms_no_cache:.3f} ms, "
+            f"Speedup: {speedup:.2f}x"
+        )
+        assert speedup > 1.0, (
+            f"Expected register cache to be faster, got speedup={speedup:.2f}x"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked PRs:
 * #2586
 * __->__#2585
 * #2584
 * #2583


--- --- ---

### [pallas] bypass JaxCallable for static-shape kernels via direct call_custom_kernel


Static-shape kernels with no in-place outputs follow a predictable
dispatch path: pl.pallas_call returns a JaxCallable that wraps
torch_tpu.tpu_torch_pallas.call_custom_kernel. The JaxCallable wrapper
does its own caching/dispatch but adds a layer of Python (key building,
flat-tree validation, output dispatch) on the hot path.

This change adds _DirectCallKernel that snapshots the call_custom_kernel
target + signature on the first call and calls it directly on
subsequent calls, bypassing JaxCallable.__call__ entirely for the
static-shape case. The non-static-shape path is unchanged.

Measured on bf16 1024x1024x1024 headline matmul (TPU v7,
median-of-3 seeds): launcher_overhead_us drops within paired-sample
noise band (65.79 -> 65.08). The direct path counter
_call_custom_kernel_direct_hits bumps on every locked call; pin test
asserts the bypass is wired up. Modest by itself, foundation for the
direct-call hot-path squeezes stacked above (sig-lock, pre-baked
closure, speculative dispatch) which add another -11us in aggregate.