### PR TITLE
[pallas] direct-call hot-path squeezes: output cache + sig-lock + closure baking + speculative dispatch

### DIFF
--- a/.github/ci_commit_pins/tritonbench.txt
+++ b/.github/ci_commit_pins/tritonbench.txt
@@ -1,0 +1,1 @@
+ec05cc818c816e9a34b8be483ecb499be8fe6a91

--- a/.github/dashboard/build_dashboard_data.py
+++ b/.github/dashboard/build_dashboard_data.py
@@ -14,12 +14,22 @@ import glob
 import json
 import math
 import os
+import re
 import subprocess
 import urllib.error
 import urllib.request
 import zipfile
 
 RETENTION_DAYS = 365
+
+
+def get_active_platforms(workflow_path):
+    """Extract active platform aliases from the benchmark dispatch workflow."""
+    try:
+        with open(workflow_path) as f:
+            return set(re.findall(r"alias:\s*(\S+)", f.read()))
+    except OSError:
+        return None
 
 
 def geo_mean(values):
@@ -100,13 +110,16 @@ def download_artifacts(repo, run_id, dest):
             os.remove(zip_path)
 
 
-def parse_run(run_dir):
+def parse_run(run_dir, active_platforms=None):
     """Parse all helionbench.json files in a run directory into kernel entries."""
     kernels = []
     for bench_dir in sorted(glob.glob(os.path.join(run_dir, "benchmark-results-*"))):
         dirname = os.path.basename(bench_dir)
         parts = dirname.replace("benchmark-results-", "").split("-", 1)
         platform_short = parts[0] if parts else "unknown"
+
+        if active_platforms and platform_short not in active_platforms:
+            continue
 
         bench_file = os.path.join(bench_dir, "helionbench.json")
         if not os.path.exists(bench_file):
@@ -173,7 +186,7 @@ def build_history_entry(run, metrics, shapes):
     }
 
 
-def build_dashboard_data(cache_dir, runs_meta, existing_data=None):
+def build_dashboard_data(cache_dir, runs_meta, existing_data=None, active_platforms=None):
     """Aggregate benchmark data across runs into the dashboard JSON structure."""
     cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=RETENTION_DAYS)
     runs_meta_sorted = sorted(
@@ -188,6 +201,8 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None):
     existing_summary = {}
     existing_history = {}
     for e in (existing_data or {}).get("summary", []):
+        if active_platforms and e.get("platform_short", "") not in active_platforms:
+            continue
         key = e["kernel"] + "|" + e.get("platform_short", "")
         existing_summary[key] = e
         existing_history.setdefault(key, {}).update({h["run_id"]: h for h in e.get("history", [])})
@@ -196,7 +211,7 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None):
     runs = []
     for meta in runs_meta_sorted:
         run_dir = os.path.join(cache_dir, meta["run_id"])
-        kernels = parse_run(run_dir) if os.path.isdir(run_dir) and os.listdir(run_dir) else []
+        kernels = parse_run(run_dir, active_platforms) if os.path.isdir(run_dir) and os.listdir(run_dir) else []
         runs.append({**meta, "kernel_count": len(kernels), "kernels": kernels})
 
     # Build kernel history: fresh artifacts override, then fill from existing history
@@ -366,8 +381,16 @@ def main():
     parser.add_argument("--repo", required=True)
     parser.add_argument("--workflow-name", default="Benchmark Dispatch")
     parser.add_argument("--existing-url", default=None, help="URL to fetch previous dashboard-data.json for incremental updates")
+    parser.add_argument("--dispatch-workflow", default=".github/workflows/benchmark_dispatch.yml",
+                        help="Path to benchmark dispatch workflow to derive active platforms")
     parser.add_argument("--output", default="dashboard-data.json")
     args = parser.parse_args()
+
+    active_platforms = get_active_platforms(args.dispatch_workflow)
+    if active_platforms:
+        print(f"Active platforms: {', '.join(sorted(active_platforms))}")
+    else:
+        print("Warning: could not read dispatch workflow, showing all platforms")
 
     existing = {}
     if args.existing_url:
@@ -390,7 +413,7 @@ def main():
         print(f"Downloading run {r['run_id']} ({r['sha']})...")
         download_artifacts(args.repo, r["run_id"], os.path.join(cache_dir, r["run_id"]))
 
-    data = build_dashboard_data(cache_dir, runs, existing)
+    data = build_dashboard_data(cache_dir, runs, existing, active_platforms)
     with open(args.output, "w") as f:
         json.dump(data, f, indent=2)
 

--- a/.github/dashboard/build_dashboard_data.py
+++ b/.github/dashboard/build_dashboard_data.py
@@ -159,7 +159,7 @@ def build_history_entry(run, metrics, shapes):
         "helion_speedup_geomean": round(geo_mean(metrics.get("helion_speedup", [])), 4),
         "triton_speedup_geomean": round(geo_mean(metrics.get("triton_speedup", [])), 4),
         "torch_compile_speedup_geomean": round(geo_mean(metrics.get("torch_compile_speedup", [])), 4),
-        "compile_time_avg_s": round(avg(metrics.get("helion_compile_time_s", [])), 2),
+        "compile_time_geomean_s": round(geo_mean(metrics.get("helion_compile_time_s", [])), 2),
         "helion_latency_avg_ms": round(avg(helion_lat), 4) if helion_lat else 0,
         "per_shape": {
             "shapes": shapes,
@@ -269,7 +269,7 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None):
                 break
 
         speedup_delta = fmt_delta(latest_data["helion_speedup_geomean"], prev_data["helion_speedup_geomean"]) if latest_data and prev_data else None
-        compile_delta = fmt_delta(prev_data["compile_time_avg_s"], latest_data["compile_time_avg_s"]) if latest_data and prev_data and latest_data["compile_time_avg_s"] > 0 else None
+        compile_delta = fmt_delta(prev_data["compile_time_geomean_s"], latest_data["compile_time_geomean_s"]) if latest_data and prev_data and latest_data["compile_time_geomean_s"] > 0 else None
         latency_delta = fmt_delta(prev_data["helion_latency_avg_ms"], latest_data["helion_latency_avg_ms"]) if latest_data and prev_data and latest_data["helion_latency_avg_ms"] > 0 else None
 
         classify_delta = latency_delta if latency_delta is not None else speedup_delta
@@ -312,7 +312,7 @@ def build_dashboard_data(cache_dir, runs_meta, existing_data=None):
             "helion_speedup_geomean": latest_data["helion_speedup_geomean"] if latest_data else 0,
             "triton_speedup_geomean": latest_data["triton_speedup_geomean"] if latest_data else 0,
             "torch_compile_speedup_geomean": latest_data["torch_compile_speedup_geomean"] if latest_data else 0,
-            "compile_time_avg_s": latest_data["compile_time_avg_s"] if latest_data else 0,
+            "compile_time_geomean_s": latest_data["compile_time_geomean_s"] if latest_data else 0,
             "helion_latency_avg_ms": latest_data["helion_latency_avg_ms"] if latest_data else 0,
             "speedup_delta_pct": speedup_delta,
             "compile_delta_pct": compile_delta,

--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -386,7 +386,7 @@ function renderOverviewGrid() {
         html += '</div>';
         html += '<div class="kc-body"><div class="kc-left">';
         html += `<div class="kc-row"><span class="kc-label">Latency</span><span class="kc-val" style="color:${color}">${e.helion_latency_avg_ms.toFixed(2)} ms</span></div>`;
-        html += `<div class="kc-row"><span class="kc-label">Compile time</span><span class="kc-val">${formatCompileTime(e.compile_time_avg_s)}</span></div>`;
+        html += `<div class="kc-row"><span class="kc-label">Compile time</span><span class="kc-val">${formatCompileTime(e.compile_time_geomean_s)}</span></div>`;
         html += `<div class="kc-delta">Latency vs prev: ${formatDelta(e.latency_delta_pct, true)}</div>`;
         html += `<div class="kc-delta">Compile time vs prev: ${formatDelta(e.compile_delta_pct, true)}</div>`;
         html += '</div>';
@@ -524,7 +524,7 @@ function renderSpeedup() {
       <td style="color:var(--green)">${formatSpeedup(e.helion_speedup_geomean)}</td>
       <td style="color:var(--blue)">${formatSpeedup(e.torch_compile_speedup_geomean)}</td>
       <td style="color:var(--purple)">${formatSpeedup(e.triton_speedup_geomean)}</td>
-      <td>${formatCompileTime(e.compile_time_avg_s)}</td>
+      <td>${formatCompileTime(e.compile_time_geomean_s)}</td>
       <td style="color:${colors[bestIdx]}">${names[bestIdx]}</td>
     </tr>`;
   });
@@ -570,8 +570,8 @@ function renderCompare(baseRunIdOverride, cmpRunIdOverride, baseBranchOverride, 
       if (!baseH && !cmpH) return;
       const baseSpeedup = baseH ? baseH.helion_speedup_geomean : null;
       const cmpSpeedup = cmpH ? cmpH.helion_speedup_geomean : null;
-      const baseCompile = baseH ? baseH.compile_time_avg_s : null;
-      const cmpCompile = cmpH ? cmpH.compile_time_avg_s : null;
+      const baseCompile = baseH ? baseH.compile_time_geomean_s : null;
+      const cmpCompile = cmpH ? cmpH.compile_time_geomean_s : null;
       const baseLatency = baseH ? baseH.helion_latency_avg_ms : null;
       const cmpLatency = cmpH ? cmpH.helion_latency_avg_ms : null;
       let speedupDelta = null;
@@ -778,7 +778,7 @@ function showDetailModal(kernel, platform_short) {
   const color = platColor(platform_short);
   let html = modalHeader(
     `${escHtml(kernel)} ${platBadge(platform_short)}`,
-    `Latency: ${e.helion_latency_avg_ms.toFixed(2)} ms | Speedup: ${formatSpeedup(e.helion_speedup_geomean)} | Compile Time: ${formatCompileTime(e.compile_time_avg_s)}`);
+    `Latency: ${e.helion_latency_avg_ms.toFixed(2)} ms | Speedup: ${formatSpeedup(e.helion_speedup_geomean)} | Compile Time: ${formatCompileTime(e.compile_time_geomean_s)}`);
   html += '<div class="modal-split"><div class="modal-lhs">';
   if (e.status !== 'unchanged') {
     html += `<div style="margin-bottom:12px"><span class="kc-tag ${e.status}">${e.status} perf</span></div>`;
@@ -814,7 +814,7 @@ function showDetailModal(kernel, platform_short) {
       <td style="font-size:11px">${formatDate(h.date)}</td>
       <td>${h.helion_latency_avg_ms.toFixed(2)} ms${latencyDelta}</td>
       <td>${formatSpeedup(h.helion_speedup_geomean)}${speedupDelta}</td>
-      <td>${formatCompileTime(h.compile_time_avg_s)}</td>
+      <td>${formatCompileTime(h.compile_time_geomean_s)}</td>
     </tr>`;
   });
   html += '</tbody></table></div>';
@@ -884,7 +884,7 @@ function showDetailModal(kernel, platform_short) {
         spEl.on('plotly_click', clickHandler);
       }
       // Compile time over time
-      const ctVals = histFwd.map(h => h.compile_time_avg_s > 0 ? h.compile_time_avg_s : null);
+      const ctVals = histFwd.map(h => h.compile_time_geomean_s > 0 ? h.compile_time_geomean_s : null);
       const ctTrace = {
         x: xLabels, y: ctVals,
         mode: 'lines+markers', line: { color: '#f0883e', width: 2 }, marker: { size: 6 },

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -133,6 +133,7 @@ jobs:
           mkdir -p benchmarks/ && pushd benchmarks/
           git clone https://github.com/pytorch-labs/tritonbench/
           pushd tritonbench/
+          git checkout $(cat $GITHUB_WORKSPACE/.github/ci_commit_pins/tritonbench.txt)
           git submodule update --init --recursive
           uv pip install -r requirements.txt
           python install.py --liger

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -172,26 +172,9 @@ jobs:
             echo "Using baseline: $BASELINE"
             echo "Available implementations for $kernel: $IMPLS"
 
-            # Do autotuning but do not record the results
-            ${{ inputs.env-vars }} python benchmarks/run.py \
-                --op $kernel \
-                --metrics speedup,accuracy \
-                --latency-measure-mode triton_do_bench \
-                --cudagraph \
-                --only $IMPLS \
-                --only-match-mode prefix-with-baseline \
-                --baseline $BASELINE \
-                --atol 1e-2 \
-                --rtol 1e-2 \
-                --input-sample-mode equally-spaced-k \
-                --keep-going \
-                ${{ inputs.custom-args }}
-
-            # Relax the GPU
-            sleep 2m
-
-            # Run again with cache and record results
-            ${{ inputs.env-vars }} HELION_PRINT_OUTPUT_CODE=1 HELION_ASSERT_CACHE_HIT=1 python benchmarks/run.py \
+            # Single pass: autotune search + codegen + compilation happen inline,
+            # so --measure-compile-time reports end-to-end user-visible compile time.
+            ${{ inputs.env-vars }} HELION_PRINT_OUTPUT_CODE=1 python benchmarks/run.py \
                 --op $kernel \
                 --metrics speedup,accuracy,latency \
                 --measure-compile-time \

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -60,6 +60,7 @@ jobs:
         run: |
           python3 .github/dashboard/build_dashboard_data.py \
             --repo ${{ github.repository }} \
+            --existing-url https://helionlang.com/dashboard/dashboard-data.json \
             --output ./dashboard-data.json
 
       - name: Add dashboard to site

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -60,7 +60,6 @@ jobs:
         run: |
           python3 .github/dashboard/build_dashboard_data.py \
             --repo ${{ github.repository }} \
-            --existing-url https://helionlang.com/dashboard/dashboard-data.json \
             --output ./dashboard-data.json
 
       - name: Add dashboard to site

--- a/helion/runtime/dist_utils.py
+++ b/helion/runtime/dist_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import torch
 import triton
 import triton.language as tl
 
@@ -97,7 +98,7 @@ def _wait_signal(addrs, sem: tl.constexpr) -> None:  # noqa: ANN001
 
 
 @triton.jit
-def symm_mem_sync(
+def _symm_mem_sync_cuda(
     signal_pad_ptrs,  # noqa: ANN001
     block_id,  # noqa: ANN001
     rank: tl.constexpr,
@@ -158,3 +159,59 @@ def symm_mem_sync(
 
     if hasSubsequentMemAccess:
         tl.debug_barrier()
+
+
+@triton.jit
+def _symm_mem_sync_rocm(
+    signal_pad_ptrs,  # noqa: ANN001
+    block_id,  # noqa: ANN001
+    rank: tl.constexpr,
+    world_size: tl.constexpr,
+    hasPreviousMemAccess: tl.constexpr = False,  # pyrefly: ignore[bad-function-definition]
+    hasSubsequentMemAccess: tl.constexpr = False,  # pyrefly: ignore[bad-function-definition]
+) -> None:
+    """
+    ROCm fallback for symmetric-memory barrier synchronization.
+
+    This avoids CUDA inline PTX asm and relies on Triton atomics.
+    """
+    if block_id is None:
+        block_id = _get_flat_bid()
+    signal_pad_ptrs = signal_pad_ptrs.to(tl.pointer_type(tl.uint64))
+    local_signal_pad_addr = tl.load(signal_pad_ptrs + rank).to(
+        tl.pointer_type(tl.uint32)
+    )
+
+    if hasPreviousMemAccess:
+        tl.debug_barrier()
+
+    for remote_rank in tl.static_range(0, world_size):
+        remote_signal_pad_addr = tl.load(signal_pad_ptrs + remote_rank).to(
+            tl.pointer_type(tl.uint32)
+        )
+        send_addr = remote_signal_pad_addr + block_id * world_size + rank
+        if hasPreviousMemAccess:
+            while tl.atomic_cas(send_addr, 0, 1, sem="release", scope="sys") != 0:
+                pass
+        else:
+            while tl.atomic_cas(send_addr, 0, 1, sem="relaxed", scope="sys") != 0:
+                pass
+    for remote_rank in tl.static_range(0, world_size):
+        wait_addr = local_signal_pad_addr + block_id * world_size + remote_rank
+        if hasSubsequentMemAccess:
+            while tl.atomic_cas(wait_addr, 1, 0, sem="acquire", scope="sys") != 1:
+                pass
+        else:
+            while tl.atomic_cas(wait_addr, 1, 0, sem="relaxed", scope="sys") != 1:
+                pass
+
+    if hasSubsequentMemAccess:
+        tl.debug_barrier()
+
+
+SYMM_MEM_SYNC_IMPL = (
+    "rocm_atomic" if torch.version.hip is not None else "cuda_inline_asm"
+)
+symm_mem_sync = (
+    _symm_mem_sync_rocm if torch.version.hip is not None else _symm_mem_sync_cuda
+)

--- a/helion/runtime/triton_helpers.py
+++ b/helion/runtime/triton_helpers.py
@@ -1,79 +1,116 @@
 from __future__ import annotations
 
+import torch
 import triton
 import triton.language as tl
 
 __all__ = ["triton_wait_signal"]
 
 
-@triton.jit
-def triton_wait_signal(
-    addr: tl.tensor,
-    expect: tl.constexpr,
-    update: tl.constexpr,
-    sem: tl.constexpr,
-    scope: tl.constexpr,
-    op: tl.constexpr,
-    skip_sync: tl.constexpr,
-    # pyrefly: ignore [bad-function-definition]
-    sync_before: tl.constexpr = False,
-) -> None:
-    """
-    Wait for a global memory barrier to reach the expected value.
+if torch.version.hip is not None:
+    TRITON_WAIT_SIGNAL_IMPL = "rocm_no_inline_asm"
 
-    This function implements a spin-wait loop that continuously checks a memory location
-    until it reaches the expected value, providing synchronization across CTAs.
-
-    Args:
-        addr: Memory address of the barrier to wait on (Must be a scalar)
-        expect: Expected value to wait for
-        update: Update the barrier with once acquired
-        sem: Memory semantics for the atomic operation. Options: "acquire", "relaxed".
-        scope: Scope of the atomic operation. Options: "gpu", "sys"
-        op: Atomic operation type: "ld", "atomic_cas"
-        skip_sync: Skip CTA sync after acquiring the barrier (default: False)
-        sync_before: Add a CTA sync before the wait (default: False)
-    """
-    tl.static_assert(
-        # pyrefly: ignore [missing-attribute]
-        addr.type.is_ptr(),
-        "Barrier address must be a scalar pointer. ",
-    )
-
-    tl.static_assert(
-        (sem == "acquire" or sem == "relaxed") or sem == "release",
-        "Invalid memory semantic. options: 'acquire', 'relaxed', 'release'. ",
-    )
-    tl.static_assert(
-        scope == "gpu" or scope == "sys", "Invalid scope. options: 'gpu', 'sys'. "
-    )
-    tl.static_assert(
-        op == "ld" or op == "atomic_cas",
-        "Invalid op. options: 'ld', 'atomic_cas'. ",
-    )
-
-    if sync_before:
-        tl.inline_asm_elementwise(
-            "bar.sync 0;", "=r", [], dtype=tl.int32, is_pure=False, pack=1
+    @triton.jit
+    def triton_wait_signal(
+        addr: tl.tensor,
+        expect: tl.constexpr,
+        update: tl.constexpr,
+        sem: tl.constexpr,
+        scope: tl.constexpr,
+        op: tl.constexpr,
+        skip_sync: tl.constexpr,
+        # pyrefly: ignore [bad-function-definition]
+        sync_before: tl.constexpr = False,
+    ) -> None:
+        """
+        ROCm-safe variant of wait signal without CUDA inline asm barriers.
+        """
+        tl.static_assert(
+            # pyrefly: ignore [missing-attribute]
+            addr.type.is_ptr(),
+            "Barrier address must be a scalar pointer. ",
+        )
+        tl.static_assert(
+            (sem == "acquire" or sem == "relaxed") or sem == "release",
+            "Invalid memory semantic. options: 'acquire', 'relaxed', 'release'. ",
+        )
+        tl.static_assert(
+            scope == "gpu" or scope == "sys", "Invalid scope. options: 'gpu', 'sys'. "
+        )
+        tl.static_assert(
+            op == "ld" or op == "atomic_cas",
+            "Invalid op. options: 'ld', 'atomic_cas'. ",
         )
 
-    # Spin-wait loop:
-    #   Uses atomic_add with update=0 for ld.global.{sem}.{scope}
-    #   Triton generates smem broadcasting of tl.atomic_add return value in ptx,
-    #   but it is optimized away by ptxas in SASS, hence no performance overhead.
-    if op == "ld":
-        while tl.atomic_add(addr, 0, sem=sem, scope=scope) != expect:
-            pass
-    elif op == "atomic_cas":
-        while tl.atomic_cas(addr, expect, update, sem=sem, scope=scope) != expect:
-            pass
-    else:
-        raise NotImplementedError(
-            f"Unsupported op '{op}' for wait signal on gmem barrier. "
+        if sync_before:
+            tl.debug_barrier()
+
+        if op == "ld":
+            while tl.atomic_add(addr, 0, sem=sem, scope=scope) != expect:
+                pass
+        elif op == "atomic_cas":
+            while tl.atomic_cas(addr, expect, update, sem=sem, scope=scope) != expect:
+                pass
+        else:
+            raise NotImplementedError(
+                f"Unsupported op '{op}' for wait signal on gmem barrier. "
+            )
+
+        if not skip_sync:
+            tl.debug_barrier()
+else:
+    TRITON_WAIT_SIGNAL_IMPL = "cuda_inline_asm"
+
+    @triton.jit
+    def triton_wait_signal(
+        addr: tl.tensor,
+        expect: tl.constexpr,
+        update: tl.constexpr,
+        sem: tl.constexpr,
+        scope: tl.constexpr,
+        op: tl.constexpr,
+        skip_sync: tl.constexpr,
+        # pyrefly: ignore [bad-function-definition]
+        sync_before: tl.constexpr = False,
+    ) -> None:
+        """
+        Wait for a global memory barrier to reach the expected value.
+        """
+        tl.static_assert(
+            # pyrefly: ignore [missing-attribute]
+            addr.type.is_ptr(),
+            "Barrier address must be a scalar pointer. ",
         )
 
-    if not skip_sync:
-        tl.inline_asm_elementwise(
-            "bar.sync 0;", "=r", [], dtype=tl.int32, is_pure=False, pack=1
+        tl.static_assert(
+            (sem == "acquire" or sem == "relaxed") or sem == "release",
+            "Invalid memory semantic. options: 'acquire', 'relaxed', 'release'. ",
         )
-    # tl.debug_barrier() cause significant performance loss. (Perhaps breaks triton prefetching?)
+        tl.static_assert(
+            scope == "gpu" or scope == "sys", "Invalid scope. options: 'gpu', 'sys'. "
+        )
+        tl.static_assert(
+            op == "ld" or op == "atomic_cas",
+            "Invalid op. options: 'ld', 'atomic_cas'. ",
+        )
+
+        if sync_before:
+            tl.inline_asm_elementwise(
+                "bar.sync 0;", "=r", [], dtype=tl.int32, is_pure=False, pack=1
+            )
+
+        if op == "ld":
+            while tl.atomic_add(addr, 0, sem=sem, scope=scope) != expect:
+                pass
+        elif op == "atomic_cas":
+            while tl.atomic_cas(addr, expect, update, sem=sem, scope=scope) != expect:
+                pass
+        else:
+            raise NotImplementedError(
+                f"Unsupported op '{op}' for wait signal on gmem barrier. "
+            )
+
+        if not skip_sync:
+            tl.inline_asm_elementwise(
+                "bar.sync 0;", "=r", [], dtype=tl.int32, is_pure=False, pack=1
+            )

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -25,7 +25,6 @@ from helion._testing import EXAMPLES_DIR
 from helion._testing import TestCase
 from helion._testing import import_path
 from helion._testing import onlyBackends
-from helion._testing import skipIfRocm
 from helion._testing import skipIfXPU
 from helion.autotuner import search_algorithms
 from helion.autotuner.effort_profile import _PROFILES
@@ -165,7 +164,6 @@ class TestDistributed(TestCase, MultiProcessTestCase):
         dist.barrier()
         dist.destroy_process_group()
 
-    @skipIfRocm("Distributed example requires CUDA/NCCL")
     @skipIfXPU("Distributed operations require CCL, not yet fully integrated")
     @skip_if_lt_x_gpu(4)
     def test_sync_seed(self):
@@ -194,17 +192,17 @@ class TestDistributed(TestCase, MultiProcessTestCase):
 
         self._cleanup_process()
 
-    @skipIfRocm("Distributed example requires CUDA/NCCL")
     @skipIfXPU("Distributed operations require CCL, not yet fully integrated")
     @skip_if_lt_x_gpu(4)
     @parametrize("autotuner", autotuner_names)
     def test_allreduce(self, autotuner):
         self._init_process()
         if autotuner == "fixed":
+            fixed_num_warps = 16 if torch.version.hip is not None else 32
             kernel = helion.kernel(
                 config=helion.Config(
                     block_sizes=[8192],
-                    num_warps=32,
+                    num_warps=fixed_num_warps,
                 ),
                 ignore_warnings=[helion.exc.TensorOperationInWrapper],
             )(one_shot_allreduce_kernel)
@@ -243,7 +241,6 @@ class TestDistributed(TestCase, MultiProcessTestCase):
         a_shared = symm_mem.empty(N, dtype=dtype, device=self.device).normal_()
 
         symm_mem_hdl = symm_mem.rendezvous(a_shared, group=group)
-
         result = kernel(
             a_shared,
             symm_mem_hdl.rank,
@@ -258,7 +255,6 @@ class TestDistributed(TestCase, MultiProcessTestCase):
 
         torch.testing.assert_close(result, expected, rtol=1e-1, atol=1e-1)
 
-    @skipIfRocm("Distributed example requires CUDA/NCCL")
     @skipIfXPU("Distributed operations require CCL, not yet fully integrated")
     @skip_if_lt_x_gpu(4)
     @parametrize(
@@ -323,7 +319,6 @@ class TestDistributed(TestCase, MultiProcessTestCase):
         torch.manual_seed(42)
         bias = torch.randn(D, device=self.device)
         weight = torch.randn(D, device=self.device)
-
         result = kernel(
             symm_mem_buffer,
             x,
@@ -339,7 +334,6 @@ class TestDistributed(TestCase, MultiProcessTestCase):
         expected = ref_kernel(x, bias, weight)
         torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
 
-    @skipIfRocm("Distributed example requires CUDA/NCCL")
     @skipIfXPU("Distributed operations require CCL, not yet fully integrated")
     @skip_if_lt_x_gpu(4)
     @parametrize("autotuner", autotuner_names)
@@ -411,7 +405,6 @@ class TestDistributed(TestCase, MultiProcessTestCase):
 
         symm_mem_buffer = symm_mem.empty(M, N, device=self.device)
         symm_mem_hdl = symm_mem.rendezvous(symm_mem_buffer, dist.group.WORLD.group_name)
-
         result = kernel(
             a,
             b,
@@ -426,7 +419,6 @@ class TestDistributed(TestCase, MultiProcessTestCase):
 
         torch.testing.assert_close(result, expected, rtol=1e-1, atol=1e-1)
 
-    @skipIfRocm("Distributed example requires CUDA/NCCL")
     @skipIfXPU("Distributed operations require CCL, not yet fully integrated")
     @skip_if_lt_x_gpu(4)
     def test_fp8_matmul_reduce_scatter(self):
@@ -474,7 +466,6 @@ class TestDistributed(TestCase, MultiProcessTestCase):
         torch.testing.assert_close(result, expected, rtol=8e-1, atol=8e-1)
         self._cleanup_process()
 
-    @skipIfRocm("Distributed example requires CUDA/NCCL")
     @skipIfXPU("Distributed operations require CCL, not yet fully integrated")
     @skip_if_lt_x_gpu(4)
     def test_two_dim_parallel_matmul(self):

--- a/test/test_examples_dist.py
+++ b/test/test_examples_dist.py
@@ -15,6 +15,7 @@ from torch.testing._internal.common_utils import instantiate_parametrized_tests
 from torch.testing._internal.common_utils import parametrize
 from torch.testing._internal.common_utils import run_tests
 
+import helion
 from helion._testing import EXAMPLES_DIR
 from helion._testing import TestCase
 from helion._testing import code_and_output
@@ -22,6 +23,16 @@ from helion._testing import import_path
 from helion._testing import onlyBackends
 from helion._testing import skipIfRocm
 from helion._testing import skipIfXPU
+
+
+def _set_preferred_symm_mem_backend(device: torch.device) -> str:
+    preferred = "NVSHMEM"
+    try:
+        symm_mem.set_backend(preferred)
+        selected = preferred
+    except RuntimeError:
+        selected = str(symm_mem.get_backend(device) or "unknown")
+    return selected
 
 
 @onlyBackends(["triton"])
@@ -119,7 +130,6 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
         backend_stream = mod.copy_engine_all_gather_w_progress(
             a_out, a_shared, progress, 1
         )
-
         _, result = code_and_output(
             mod.helion_matmul_w_progress,
             (a_out, a_shared, b, progress, 1, symm_mem_hdl.rank),
@@ -139,7 +149,6 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
         torch.cuda.current_stream().wait_stream(backend_stream)
         self._cleanup_process()
 
-    @skipIfRocm("Distributed example requires CUDA/NCCL")
     @skipIfXPU("Distributed operations require CCL, not yet fully integrated")
     @skip_if_lt_x_gpu(4)
     def test_all_reduce(self):
@@ -147,10 +156,10 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
 
         mod = import_path(EXAMPLES_DIR / "distributed" / "all_reduce.py")
 
-        # Only NVSHMEM backend implements `get_remote_tensor` for now.
-        symm_mem.set_backend("NVSHMEM")
+        selected_backend = _set_preferred_symm_mem_backend(self.device)
         group = dist.group.WORLD
-        symm_mem.enable_symm_mem_for_group(group.group_name)
+        if selected_backend == "NVSHMEM":
+            symm_mem.enable_symm_mem_for_group(group.group_name)
 
         N = 16384
         dtype = torch.bfloat16
@@ -160,9 +169,14 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
         ).normal_()
 
         symm_mem_hdl = symm_mem.rendezvous(a_shared, group=group)
-
+        kernel = mod.one_shot_all_reduce_kernel
+        if torch.version.hip is not None:
+            kernel = helion.kernel(
+                config=helion.Config(block_sizes=[8192], num_warps=16),
+                static_shapes=True,
+            )(mod.one_shot_all_reduce_kernel.fn)
         _, result = code_and_output(
-            mod.one_shot_all_reduce_kernel,
+            kernel,
             (
                 symm_mem_hdl.signal_pad_ptrs_dev,
                 a_shared,
@@ -185,7 +199,6 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
 
         self._cleanup_process()
 
-    @skipIfRocm("Distributed example requires CUDA/NCCL")
     @skipIfXPU("Distributed operations require CCL, not yet fully integrated")
     @skip_if_lt_x_gpu(4)
     @parametrize(
@@ -200,10 +213,10 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
 
         mod = import_path(EXAMPLES_DIR / "distributed" / "allreduce_bias_rmsnorm.py")
 
-        # Only NVSHMEM backend implements `get_remote_tensor` for now.
-        symm_mem.set_backend("NVSHMEM")
+        selected_backend = _set_preferred_symm_mem_backend(self.device)
         group = dist.group.WORLD
-        symm_mem.enable_symm_mem_for_group(group.group_name)
+        if selected_backend == "NVSHMEM":
+            symm_mem.enable_symm_mem_for_group(group.group_name)
 
         N, D = 128, 4096
         dtype = torch.float32
@@ -219,9 +232,16 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
 
         symm_mem_buffer = symm_mem.empty(N, D, dtype=dtype, device=self.device)
         symm_mem_hdl = symm_mem.rendezvous(symm_mem_buffer, group.group_name)
-
+        kernel = getattr(mod, kernel_name)
+        if (
+            torch.version.hip is not None
+            and kernel_name == "two_shot_allreduce_bias_rmsnorm_kernel"
+        ):
+            kernel = helion.jit(config=helion.Config(block_sizes=[4], num_warps=16))(
+                kernel.fn
+            )
         _, result = code_and_output(
-            getattr(mod, kernel_name),
+            kernel,
             (
                 symm_mem_buffer,
                 x,
@@ -243,7 +263,6 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
 
         self._cleanup_process()
 
-    @skipIfRocm("Distributed example requires CUDA/NCCL")
     @skipIfXPU("Distributed operations require CCL, not yet fully integrated")
     @skip_if_lt_x_gpu(4)
     def test_matmul_reduce_scatter_kernel(self):
@@ -251,10 +270,10 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
 
         mod = import_path(EXAMPLES_DIR / "distributed" / "matmul_reduce_scatter.py")
 
-        # Only NVSHMEM backend implements `get_remote_tensor` for now.
-        symm_mem.set_backend("NVSHMEM")
+        selected_backend = _set_preferred_symm_mem_backend(self.device)
         group = dist.group.WORLD
-        symm_mem.enable_symm_mem_for_group(group.group_name)
+        if selected_backend == "NVSHMEM":
+            symm_mem.enable_symm_mem_for_group(group.group_name)
 
         M, N, K = 512, 768, 1024
         dtype = torch.float32
@@ -274,7 +293,6 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
         # Setup symmetric memory like the wrapper does
         symm_mem_buffer = symm_mem.empty(M, N, dtype=dtype, device=self.device)
         symm_mem_hdl = symm_mem.rendezvous(symm_mem_buffer, group.group_name)
-
         _, result = code_and_output(
             mod.matmul_reduce_scatter_kernel,
             (
@@ -296,7 +314,6 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
 
         self._cleanup_process()
 
-    @skipIfRocm("Distributed example requires CUDA/NCCL")
     @skipIfXPU("Distributed operations require CCL, not yet fully integrated")
     @skip_if_lt_x_gpu(4)
     def test_matmul_reduce_scatter_wrapper(self):
@@ -304,10 +321,10 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
 
         mod = import_path(EXAMPLES_DIR / "distributed" / "matmul_reduce_scatter.py")
 
-        # Only NVSHMEM backend implements `get_remote_tensor` for now.
-        symm_mem.set_backend("NVSHMEM")
+        selected_backend = _set_preferred_symm_mem_backend(self.device)
         group = dist.group.WORLD
-        symm_mem.enable_symm_mem_for_group(group.group_name)
+        if selected_backend == "NVSHMEM":
+            symm_mem.enable_symm_mem_for_group(group.group_name)
 
         M, N, K = 512, 768, 1024
         dtype = torch.float32
@@ -327,7 +344,6 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
         # Setup symmetric memory like the wrapper does
         symm_mem_buffer = symm_mem.empty(M, N, dtype=dtype, device=self.device)
         symm_mem.rendezvous(symm_mem_buffer, group.group_name)
-
         result = mod.helion_matmul_reduce_scatter(
             symm_mem_buffer,
             a,

--- a/test/test_examples_dist.py
+++ b/test/test_examples_dist.py
@@ -84,6 +84,7 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
             world_size=self.world_size,
             rank=self.rank,
             store=store,
+            device_id=self.device,
         )
         torch.distributed.distributed_c10d._set_pg_timeout(
             timedelta(seconds=60), dist.group.WORLD
@@ -156,10 +157,8 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
 
         mod = import_path(EXAMPLES_DIR / "distributed" / "all_reduce.py")
 
-        selected_backend = _set_preferred_symm_mem_backend(self.device)
+        _set_preferred_symm_mem_backend(self.device)
         group = dist.group.WORLD
-        if selected_backend == "NVSHMEM":
-            symm_mem.enable_symm_mem_for_group(group.group_name)
 
         N = 16384
         dtype = torch.bfloat16
@@ -213,10 +212,8 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
 
         mod = import_path(EXAMPLES_DIR / "distributed" / "allreduce_bias_rmsnorm.py")
 
-        selected_backend = _set_preferred_symm_mem_backend(self.device)
+        _set_preferred_symm_mem_backend(self.device)
         group = dist.group.WORLD
-        if selected_backend == "NVSHMEM":
-            symm_mem.enable_symm_mem_for_group(group.group_name)
 
         N, D = 128, 4096
         dtype = torch.float32
@@ -270,10 +267,8 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
 
         mod = import_path(EXAMPLES_DIR / "distributed" / "matmul_reduce_scatter.py")
 
-        selected_backend = _set_preferred_symm_mem_backend(self.device)
+        _set_preferred_symm_mem_backend(self.device)
         group = dist.group.WORLD
-        if selected_backend == "NVSHMEM":
-            symm_mem.enable_symm_mem_for_group(group.group_name)
 
         M, N, K = 512, 768, 1024
         dtype = torch.float32
@@ -321,10 +316,8 @@ class TestExamplesDist(TestCase, MultiProcessTestCase):
 
         mod = import_path(EXAMPLES_DIR / "distributed" / "matmul_reduce_scatter.py")
 
-        selected_backend = _set_preferred_symm_mem_backend(self.device)
+        _set_preferred_symm_mem_backend(self.device)
         group = dist.group.WORLD
-        if selected_backend == "NVSHMEM":
-            symm_mem.enable_symm_mem_for_group(group.group_name)
 
         M, N, K = 512, 768, 1024
         dtype = torch.float32

--- a/test/test_torch_compile.py
+++ b/test/test_torch_compile.py
@@ -4884,6 +4884,7 @@ class TestTorchCompile(RefEagerTestDisabled, TestCase):
         kernel.reset()
         torch._dynamo.reset()
 
+        torch.manual_seed(0)
         x = torch.randn(128, device=DEVICE, dtype=torch.float32)
         y = torch.randn(128, device=DEVICE, dtype=torch.float32)
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#2586
 * #2585
 * #2584
 * #2583


--- --- ---

### [pallas] direct-call hot-path squeezes: output cache + sig-lock + closure baking + speculative dispatch


Four cooperating optimizations on the _DirectCallKernel static-shape
fast path that together cut another -11us of host-side overhead per
call on the bf16 1024x1024x1024 headline (median-of-3 seeds).

1. Static-shape output meta-tensor allocation cache
   The output torch.empty() allocation is shape-invariant for
   static-shape kernels. Cache the meta-tensor (shape + dtype +
   device descriptor) per kernel signature so repeat calls skip
   torch.empty + device-tag setup. Codegen change: emit the cache
   key alongside the launcher args. Counter
   _output_tensor_allocations bumps on cache miss.

2. Signature-locked direct-call closure
   On the first locked call, snapshot the resolved tensor-arg
   indices + non-tensor-args layout into a baked closure. Subsequent
   calls skip the per-call sig check + closure rebuild. The lock
   key is the kernel-name + input-signature pair so changes to the
   kernel's signature (re-autotune, dtype change) invalidate. Counter
   _direct_call_sig_checks_skipped tracks lock hits.

3. Pre-baked full_invoke closure + deferred interpret check
   Combines the direct-call signature lock with a baked full_invoke
   closure that pre-resolves the call_custom_kernel target. The
   pl.pallas_call interpret-mode check (only used in test) is
   deferred to first call, not per-call. C-locked counters
   _c_locked_counts surface direct/locked/baked call counts for the
   pin tests.

4. Speculative Kernel._last_bound cache for repeated invocations
   For workloads that call a kernel repeatedly with the same signature
   (the common case for inference loops), cache the bound kernel on
   Kernel itself so back-to-back calls skip the per-call signature
   resolution. The speculative cache invalidates on any signature
   change.

Net: 60.62us launcher_overhead_us at PR3 baseline -> 50.36us after
these squeezes (median-of-3, paired-sample). Sub-2us individual delta
on most calls, but together they push the Helion Python launcher
overhead down to ~50us per call, with the remaining ~50us pinned by
torch_tpu's call_custom_kernel C++ wrapper and JAX's pytree
unflatten (out of this PR's scope).