### PR TITLE
[pallas] matmul pipeline launcher VMEM strips + outer-grid strategy

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1774,6 +1774,71 @@ class PallasBackend(Backend):
 
         return result or None
 
+    def _compute_reduction_grid_dims(self) -> list[int]:
+        """Return the outer-grid axis indices that are reduction axes.
+
+        ``pltpu.CompilerParams(dimension_semantics=...)`` on the outer
+        ``pl.pallas_call`` marks each outer-grid axis as either
+        ``"parallel"`` (Mosaic may freely partition across cores and
+        reorder iterations) or ``"arbitrary"`` (no such freedom).  Reduction
+        axes do carry state across iterations and must be ``"arbitrary"``.
+
+        For typical Helion matmul kernels the user-written ``hl.tile(k)``
+        becomes an inner ``pltpu.emit_pipeline`` / ``jax.lax.fori_loop`` —
+        not an outer grid axis — so this list is empty and the launcher
+        keeps every outer-grid axis ``"parallel"``.  The fallback is in
+        place so any future kernel pattern that does put a reduction in
+        the outer grid (e.g. an explicit non-rolled K outer loop) is
+        labelled correctly.
+        """
+        from .compile_environment import CompileEnvironment
+        from .device_function import DeviceFunction
+        from .host_function import HostFunction
+
+        device_fn = DeviceFunction.current()
+        if device_fn.pid is None:
+            return []
+        env = CompileEnvironment.current()
+
+        # Outer-grid axis index → block_id via pid ordering.  Reduction
+        # block_ids are flagged on BlockSizeInfo (see ``BlockSizeInfo`` in
+        # compile_environment.py — set by ``allocate_reduction_dimension``
+        # for rolled reductions) OR carried on ``pallas_outer_grid_lifted``
+        # for user-written ``hl.tile`` loops whose K axis has been lifted
+        # into the outer grid by the ``pallas_loop_type="outer_grid"`` path
+        # (no global flag mutation; see
+        # ``helion/language/_tracing_ops.py::_codegen_outer_grid_or_fallback``).
+        reduction_dims: list[int] = []
+        lifted_block_ids = {
+            axis.block_id for axis in device_fn.pallas_outer_grid_lifted
+        }
+        for grid_dim, pid in enumerate(device_fn.pid.pid_info):
+            bsi = env.block_sizes[pid.block_id]
+            if bsi.reduction or pid.block_id in lifted_block_ids:
+                reduction_dims.append(grid_dim)
+
+        # FlattenedTileStrategy collapses multiple block_ids into one pid;
+        # if any of the flattened block_ids is a reduction the single pid
+        # carries reduction state.  Mark its outer-grid axis accordingly.
+        from .program_id import FlatProgramIDs
+
+        if isinstance(device_fn.pid, FlatProgramIDs):
+            device_ir = HostFunction.current().device_ir
+            flat_bids = {pid.block_id for pid in device_fn.pid.pid_info}
+            for grid_block_ids in device_ir.grid_block_ids:
+                for bid in grid_block_ids:
+                    if bid in flat_bids:
+                        continue
+                    if not env.block_sizes[bid].reduction:
+                        continue
+                    # Find the pid that absorbed this flattened block.
+                    for grid_dim, pid in enumerate(device_fn.pid.pid_info):
+                        if pid.block_id in flat_bids and grid_dim not in reduction_dims:
+                            reduction_dims.append(grid_dim)
+                            break
+
+        return sorted(set(reduction_dims))
+
     def build_launcher_args(
         self,
         args: list[str],
@@ -1888,9 +1953,11 @@ class PallasBackend(Backend):
             if smem_arg_indices:
                 launcher_args.append(f"_smem_arg_indices={smem_arg_indices!r}")
 
-        # Pass scratch shapes for pipeline/fori_loop launcher
+        # Pass scratch shapes for pipeline/fori_loop launcher (outer_grid
+        # reuses the pipeline launcher; its scratch buffers and reduction
+        # grid dims plumbing match exactly).
         pallas_loop_type = config.get("pallas_loop_type", "unroll")
-        if pallas_loop_type in ("emit_pipeline", "fori_loop"):
+        if pallas_loop_type in ("emit_pipeline", "fori_loop", "outer_grid"):
             scratch_shapes = [
                 (
                     s.shape,
@@ -1906,6 +1973,7 @@ class PallasBackend(Backend):
             # tensors (need HBM refs); all others get proper BlockSpecs.
             from .device_function import TensorArg
 
+            vmem_strip_ids = device_fn.pallas_pipeline_vmem_strip
             if sorted_args is not None:
                 pipeline_arg_indices = [
                     i
@@ -1917,6 +1985,25 @@ class PallasBackend(Backend):
                     launcher_args.append(
                         f"_pipeline_arg_indices={pipeline_arg_indices!r}"
                     )
+                # Pipelined tensors whose outer working-set fits the strip
+                # budget keep their outer BlockSpec as a VMEM strip (full
+                # inner dim) so emit_pipeline slices VMEM instead of
+                # DMAing per inner iteration from HBM.  See
+                # ``_OUTER_VMEM_STRIP_BUDGET_BYTES`` in
+                # ``helion/runtime/__init__.py``.
+                pipeline_vmem_strip_indices = [
+                    i
+                    for i in pipeline_arg_indices
+                    if id(sorted_args[i].fake_value) in vmem_strip_ids  # type: ignore[attr-defined]
+                ]
+                if pipeline_vmem_strip_indices:
+                    launcher_args.append(
+                        f"_pipeline_vmem_strip_indices={pipeline_vmem_strip_indices!r}"
+                    )
+
+            reduction_grid_dims = self._compute_reduction_grid_dims()
+            if reduction_grid_dims:
+                launcher_args.append(f"_reduction_grid_dims={reduction_grid_dims!r}")
 
         if CompileEnvironment.current().settings.pallas_interpret:
             launcher_args.append("_pallas_interpret=True")
@@ -1934,6 +2021,13 @@ class PallasBackend(Backend):
                 f"Expected one of {VALID_PALLAS_LOOP_TYPES}."
             )
         if pallas_loop_type == "emit_pipeline":
+            return "_default_pallas_pipeline_launcher"
+        if pallas_loop_type == "outer_grid":
+            # outer_grid reuses the pipeline launcher because the device fn
+            # still needs scratch buffers and (post-rewrite) the same
+            # ``dimension_semantics`` infrastructure that flags the lifted
+            # K axis as ``"arbitrary"``.  See
+            # ``helion/language/_tracing_ops.py::_apply_outer_grid_rewrites``.
             return "_default_pallas_pipeline_launcher"
         if pallas_loop_type == "fori_loop":
             return "_default_pallas_fori_launcher"

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -242,6 +242,35 @@ class PallasMemorySpace(enum.Enum):
     VMEM = "vmem"  # Vector/slice access (default)
 
 
+@dataclasses.dataclass
+class PallasOuterGridLiftedAxis:
+    """Record describing a Pallas inner-loop block_id that's been lifted into
+    the outer ``pl.pallas_call`` grid.
+
+    The hand-written reference matmul (``examples/pallas_perf/matmul_pallas.py``)
+    uses a 3-axis outer grid ``(grid_m, grid_n, grid_k)`` with
+    ``pl.when(pl.program_id(2) == 0)`` accumulator init and
+    ``pl.when(pl.program_id(2) == grid_k - 1)`` accumulator store guards
+    instead of Helion's default inner ``pltpu.emit_pipeline`` over K.  When
+    ``pallas_loop_type == "outer_grid"`` is selected and the matmul-pattern
+    eligibility check passes, the inner K block_id is recorded here so the
+    launcher can extend the outer grid and the body-rewrite pass can install
+    the ``pl.when`` guards on the right ``pl.program_id(<grid_dim>)`` axis.
+
+    Fields:
+        block_id: The inner-loop block_id being lifted (K for matmul).
+        nsteps_expr: Host-side expression for the number of grid iterations
+            on this lifted axis (e.g. ``(1024 + bk - 1) // bk``).  Used to
+            extend the launcher's grid tuple.
+        scratch_name: Name of the loop-carried scratch buffer this lift
+            governs (the body rewrite uses it to find the init/store sites).
+    """
+
+    block_id: int
+    nsteps_expr: str
+    scratch_name: str
+
+
 class DeviceFunction:
     def __init__(
         self,
@@ -335,6 +364,30 @@ class DeviceFunction:
         # Pallas: id(fake_tensor) → {dim: (block_id, extra_pad)} for dims
         # using pl.ds() that may need host-side padding.
         self.pallas_pad_info: dict[int, dict[int, tuple[int, int]]] = {}
+        # Pallas: subset of pipelined tensor ids whose outer pallas_call
+        # BlockSpec should be a VMEM strip ``(outer_block, full_inner)``
+        # instead of an HBM ref.  When a tensor id is in this set AND its
+        # memory_space is ``HBM``, the launcher's
+        # ``_pallas_build_pipeline_specs`` emits a real BlockSpec for the
+        # outer in_spec so emit_pipeline slices from a VMEM ref rather than
+        # DMAing per inner-iter from HBM.  The set stays empty when the
+        # estimated outer strip working set exceeds the strip budget (see
+        # ``_OUTER_VMEM_STRIP_BUDGET_BYTES`` in ``helion/runtime/__init__.py``).
+        self.pallas_pipeline_vmem_strip: set[int] = set()
+        # Pallas: when `pallas_loop_type == "outer_grid"` and matmul-pattern
+        # detection passes, the inner K loop is lifted into the outer
+        # ``pl.pallas_call`` grid as an extra ``"arbitrary"`` axis matching
+        # ``examples/pallas_perf/matmul_pallas.py``.  This list records each
+        # such lifted axis as ``PallasOuterGridLiftedAxis(block_id,
+        # nsteps_expr, scratch_name)``; ``_compute_reduction_grid_dims``
+        # (backend.py) reads it to flag the corresponding outer-grid dim
+        # as a reduction axis in ``_reduction_grid_dims=`` so the launcher
+        # marks it ``"arbitrary"`` in ``dimension_semantics``.  The
+        # post-codegen body rewrite in :meth:`codegen_function_def` then
+        # wraps the existing scratch-init / store statements in ``pl.when``
+        # guards on ``pl.program_id(<grid_dim>)``.  Stays empty for every
+        # other ``pallas_loop_type``.
+        self.pallas_outer_grid_lifted: list[PallasOuterGridLiftedAxis] = []
 
     def allocate_store_index(self) -> int:
         """Bump store counters and return the indexing strategy slot."""
@@ -755,6 +808,34 @@ class DeviceFunction:
             )
 
         backend = CompileEnvironment.current().backend
+        # Apply Pallas outer-grid body rewrite (lifts a matched inner K loop
+        # into the outer ``pl.pallas_call`` grid with ``pl.when`` init/store
+        # guards) before the body is wrapped into a FunctionDef.  This is
+        # the only structural body transform on the Pallas backend; the
+        # rewrite is a no-op unless ``pallas_loop_type == "outer_grid"`` was
+        # selected for at least one inner loop AND its eligibility check
+        # passed (see ``_codegen_outer_grid_or_fallback`` in
+        # ``helion/language/_tracing_ops.py``).
+        pending = getattr(self, "_pallas_outer_grid_pending_rewrites", None)
+        if pending:
+            from ..language._tracing_ops import _apply_outer_grid_rewrites
+
+            _apply_outer_grid_rewrites(self, pending)
+            # Clear after applying so a follow-up regeneration of the same
+            # ``DeviceFunction`` (e.g. test reruns) doesn't double-rewrite.
+            self._pallas_outer_grid_pending_rewrites = []
+        # DCE the ``_outer_pid_N = pl.program_id(N)`` setup statements that
+        # both ``_apply_outer_grid_rewrites`` and ``_codegen_emit_pipeline``
+        # emit unconditionally for every outer-grid axis.  Hand-edit
+        # ablation showed the dead reads cost ~5% on the bf16 1024**3
+        # headline; the matmul ``outer_grid`` body uses only the K pid
+        # (inside ``@pl.when`` guards) and the strip-path ``emit_pipeline``
+        # body uses none of the M / N pids (the BlockSpec lambda emits
+        # ``0`` for strip-tagged outer dims).
+        if backend.name == "pallas":
+            from ..language._tracing_ops import _drop_dead_outer_pid_reads
+
+            _drop_dead_outer_pid_reads(self.body)
         sorted_arguments = self.sorted_args()
 
         # Separate constexpr args: inline those with known literal values at

--- a/helion/_compiler/matmul_utils.py
+++ b/helion/_compiler/matmul_utils.py
@@ -131,6 +131,43 @@ def _needs_f32_accumulator(lhs_dtype: torch.dtype, rhs_dtype: torch.dtype) -> bo
     return lhs_dtype.itemsize < 4 or rhs_dtype.itemsize < 4
 
 
+def _can_emit_pallas_pl_dot(
+    lhs_ndim: int,
+    lhs_dtype: torch.dtype | None,
+    rhs_dtype: torch.dtype | None,
+) -> bool:
+    """Return True when the Pallas backend should emit ``pl.dot`` instead of
+    ``lax.dot_general`` for this matmul.
+
+    ``pl.dot`` is a Pallas-native 2D dot wrapper that maps directly onto the
+    TPU MXU; the hand-written ``examples/pallas_perf/matmul_pallas.py``
+    kernel uses it for the bf16 square-matmul body. The Mosaic backend
+    recognizes this shape and lowers it more efficiently than the equivalent
+    ``lax.dot_general`` on tiles that match the MXU contract (the operand
+    block sizes are clamped to ``min_dot_size`` for Pallas in
+    ``enforce_dot_requirements``, so the dot is guaranteed MXU-legal here).
+
+    Eligibility:
+    - 2D matmul only (``pl.dot`` rejects non-2D inputs upstream; BMM still
+      needs ``lax.dot_general`` with the 3D ``dimension_numbers``).
+    - Both operands are ``bfloat16`` or ``float16`` so the MXU does the
+      multiply with a free f32 accumulator. f32 inputs need the
+      ``precision=jax.lax.Precision.HIGHEST`` plumbing that ``pl.dot``
+      handles via a ``precision=`` keyword; route them through the
+      existing ``lax.dot_general`` path until a separate audit shows
+      ``pl.dot`` carries the same f32-precision intent on TPU. Int8 and
+      FP8 paths also stay on ``lax.dot_general`` because their output
+      dtype semantics (int32, f32 with explicit ``preferred_element_type``)
+      do not match ``pl.dot``'s f32-only output rule.
+    """
+    if lhs_ndim != 2:
+        return False
+    return lhs_dtype in (torch.bfloat16, torch.float16) and rhs_dtype in (
+        torch.bfloat16,
+        torch.float16,
+    )
+
+
 def _emit_pallas_matmul(
     lhs: ast.AST,
     rhs: ast.AST,
@@ -139,41 +176,59 @@ def _emit_pallas_matmul(
     need_f32_acc: bool = False,
     out_dtype: torch.dtype | None = None,
     lhs_ndim: int = 2,
+    lhs_dtype: torch.dtype | None = None,
+    rhs_dtype: torch.dtype | None = None,
 ) -> ast.AST:
-    """Build a ``lax.dot_general`` AST node for the Pallas backend.
+    """Build a Pallas matmul AST node.
+
+    Emits ``pl.dot`` for MXU-legal 2D bf16/f16 tiles (see
+    :func:`_can_emit_pallas_pl_dot`); falls back to ``lax.dot_general``
+    for everything else (BMM, f32, int8, fp8).
 
     Parameters
     ----------
     lhs, rhs:
         AST nodes for the left / right operands.
     acc:
-        Optional AST node for the accumulator (``acc + dot_general(...)``).
+        Optional AST node for the accumulator (``acc + dot(...)``).
     need_f32_acc:
-        When True, emit ``preferred_element_type=jnp.float32`` and, if
-        *out_dtype* is narrower than f32, append a
-        ``lax.convert_element_type`` cast.
+        When True, the dot output is f32. For the ``lax.dot_general``
+        fallback this maps to ``preferred_element_type=jnp.float32``;
+        ``pl.dot`` always returns f32 on bf16/f16 input, so the keyword
+        is implicit. If *out_dtype* is narrower than f32, a
+        ``lax.convert_element_type`` cast is appended.
     out_dtype:
         Desired output dtype.  Only used when *need_f32_acc* is True to
         decide whether a cast-back is required.
     lhs_ndim:
         Number of dimensions in the left operand (2 for mm, 3 for bmm).
+    lhs_dtype, rhs_dtype:
+        Operand dtypes. Used by :func:`_can_emit_pallas_pl_dot` to gate
+        the ``pl.dot`` MXU-native path on bf16/f16 inputs, and by the
+        ``lax.dot_general`` fallback to attach
+        ``precision=jax.lax.Precision.HIGHEST`` for f32 inputs so the
+        TPU MXU multiplies in full f32 instead of falling back to its
+        default bf16-internal accumulation (~1e-2 absolute error on
+        K=1024). Default to ``None`` for callers that do not yet
+        thread dtypes through; in that case both gates default off.
     """
-    if lhs_ndim == 3:
-        dim_numbers = "(((2,), (1,)), ((0,), (0,)))"
-    elif lhs_ndim == 2:
-        dim_numbers = "(((1,), (0,)), ((), ()))"
+    if _can_emit_pallas_pl_dot(lhs_ndim, lhs_dtype, rhs_dtype):
+        dot_expr = expr_from_string("pl.dot({lhs}, {rhs})", lhs=lhs, rhs=rhs)
     else:
-        raise ValueError(f"lhs_ndim must be 2 or 3, got {lhs_ndim}")
+        if lhs_ndim == 3:
+            dim_numbers = "(((2,), (1,)), ((0,), (0,)))"
+        elif lhs_ndim == 2:
+            dim_numbers = "(((1,), (0,)), ((), ()))"
+        else:
+            raise ValueError(f"lhs_ndim must be 2 or 3, got {lhs_ndim}")
 
-    if need_f32_acc:
+        kwargs = [f"dimension_numbers={dim_numbers}"]
+        if need_f32_acc:
+            kwargs.append("preferred_element_type=jnp.float32")
+        if lhs_dtype == torch.float32 and rhs_dtype == torch.float32:
+            kwargs.append("precision=jax.lax.Precision.HIGHEST")
         dot_expr = expr_from_string(
-            f"lax.dot_general({{lhs}}, {{rhs}}, dimension_numbers={dim_numbers}, preferred_element_type=jnp.float32)",
-            lhs=lhs,
-            rhs=rhs,
-        )
-    else:
-        dot_expr = expr_from_string(
-            f"lax.dot_general({{lhs}}, {{rhs}}, dimension_numbers={dim_numbers})",
+            f"lax.dot_general({{lhs}}, {{rhs}}, {', '.join(kwargs)})",
             lhs=lhs,
             rhs=rhs,
         )

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -196,7 +196,7 @@ VALID_KEYS: frozenset[str] = frozenset(
         *_BACKEND_STRATEGY_CONFIG_KEYS,
     ]
 )
-VALID_PALLAS_LOOP_TYPES = ("emit_pipeline", "unroll", "fori_loop")
+VALID_PALLAS_LOOP_TYPES = ("emit_pipeline", "unroll", "fori_loop", "outer_grid")
 VALID_PID_TYPES = (
     "flat",
     "xyz",

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -235,10 +235,16 @@ def _(state: CodegenState) -> object:
     When ``pallas_loop_type="emit_pipeline"``, generates ``pltpu.emit_pipeline``
     calls with automatic DMA pipelining.  When ``pallas_loop_type="fori_loop"``,
     generates ``jax.lax.fori_loop`` with explicit ``pltpu.make_async_copy`` DMA.
-    Otherwise falls through to the common ``ForLoopGraphInfo.codegen`` path.
+    When ``pallas_loop_type="outer_grid"`` AND the matmul-pattern eligibility
+    check passes, the inner K loop is lifted into the outer ``pl.pallas_call``
+    grid (matching ``examples/pallas_perf/matmul_pallas.py``); otherwise
+    falls back to ``emit_pipeline``.  Otherwise falls through to the common
+    ``ForLoopGraphInfo.codegen`` path.
     """
     config = state.config
     pallas_loop_type = config.get("pallas_loop_type", "unroll")
+    if pallas_loop_type == "outer_grid":
+        return _codegen_outer_grid_or_fallback(state)
     if pallas_loop_type == "emit_pipeline":
         return _codegen_emit_pipeline(state)
     if pallas_loop_type == "fori_loop":
@@ -253,6 +259,9 @@ def _(state: CodegenState) -> None:
     """Emit inner stepped device loops for Pallas/TPU."""
     config = state.config
     pallas_loop_type = config.get("pallas_loop_type", "unroll")
+    if pallas_loop_type == "outer_grid":
+        _codegen_outer_grid_or_fallback(state)
+        return None
     if pallas_loop_type == "emit_pipeline":
         _codegen_emit_pipeline(state)
         return None
@@ -585,7 +594,181 @@ def _write_back_loop_carried(
         ]
         for sname, result in zip(scratch_output_names, graph_results, strict=True):
             if isinstance(result, ast.AST):
+                if _try_inplace_accumulator_rewrite(state, sname, result):
+                    continue
                 state.codegen.add_statement(_scratch_write_stmt(state, sname, result))
+
+
+def _try_inplace_accumulator_rewrite(
+    state: CodegenState,
+    sname: str,
+    result: ast.AST,
+) -> bool:
+    """Rewrite ``result = scratch[...] + RHS; scratch[...] = result`` to
+    ``scratch[...] += RHS``.
+
+    The hand-written reference Pallas matmul accumulates with
+    ``acc_ref[...] += pl.dot(x_val, y_val)`` directly into the VMEM scratch.
+    Helion's default lowering emits the equivalent value-flow as a separate
+    ``acc_N = scratch[...] + dot(...)`` followed by ``scratch[...] =
+    acc_N[...]``, which the Mosaic backend then materializes through an
+    extra register binding per K iteration. Recognising the pattern here
+    lets the inner pipeline body stay in place on the VMEM ref between
+    iterations.
+
+    Returns True when the rewrite fires; the caller then skips emitting the
+    standard write-back statement. The rewrite is intentionally narrow: it
+    only matches when the result Name's most recent binding is
+    ``LHS + RHS`` and the LHS chain (through trivial ``a = b`` renames)
+    terminates at a Subscript read of *sname* with the same slice the
+    write-back would use. Anything else falls back to the unchanged
+    behaviour.
+    """
+    if not isinstance(result, ast.Name):
+        return False
+
+    stmts = state.codegen.statements_stack[-1]
+    sl = state.device_function.scratch_read_slice(sname)
+    scratch_idx = sl or "..."
+
+    # Locate the assignment that binds `result`, walking through trivial
+    # Name-to-Name renames added by ``codegen_call_with_graph``'s placeholder
+    # copy step.
+    name_to_find = result.id
+    binding_index: int | None = None
+    binding_stmt: ast.Assign | None = None
+    i = len(stmts) - 1
+    while i >= 0:
+        stmt = stmts[i]
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and stmt.targets[0].id == name_to_find
+        ):
+            value = stmt.value
+            if isinstance(value, ast.Name):
+                name_to_find = value.id
+                i -= 1
+                continue
+            binding_index = i
+            binding_stmt = stmt
+            break
+        i -= 1
+
+    if binding_stmt is None or binding_index is None:
+        return False
+
+    value = binding_stmt.value
+    if not isinstance(value, ast.BinOp) or not isinstance(value.op, ast.Add):
+        return False
+
+    lhs_chain = _lhs_chain_to_scratch_read(
+        stmts, binding_index, value.left, sname, scratch_idx
+    )
+    if lhs_chain is None:
+        return False
+
+    # `result` must not be referenced anywhere else in the body; otherwise
+    # dropping its binding would leave a dangling reference. The write-back
+    # statement we are replacing is the only consumer in the matmul pattern.
+    if _name_referenced_outside(stmts, result.id, skip_index=binding_index):
+        return False
+
+    rhs = value.right
+    # Drop the binding for `result` and any intermediate Name aliases that
+    # only existed to feed the LHS of the addition. ``lhs_chain`` contains
+    # the indices (descending) of the trivial ``a = b`` and
+    # ``a = sname[...]`` statements that the LHS resolves through; each can
+    # be dropped only when the bound name is not referenced elsewhere.
+    drop_indices = [binding_index]
+    for idx, name in lhs_chain:
+        if _name_referenced_outside(
+            stmts, name, skip_index=binding_index, additional_skips=drop_indices
+        ):
+            break
+        drop_indices.append(idx)
+    for idx in sorted(drop_indices, reverse=True):
+        stmts.pop(idx)
+    state.codegen.add_statement(
+        statement_from_string(f"{sname}[{scratch_idx}] += {{rhs}}", rhs=rhs)
+    )
+    return True
+
+
+def _lhs_chain_to_scratch_read(
+    stmts: list[ast.AST],
+    before_index: int,
+    expr: ast.AST,
+    sname: str,
+    scratch_idx: str,
+) -> list[tuple[int, str]] | None:
+    """If *expr* ultimately reads ``sname[scratch_idx]`` return the chain
+    of intermediate ``a = b`` / ``a = sname[...]`` statements, else None.
+
+    The chain is a list of ``(statement_index, bound_name)`` pairs in
+    descending order of *statement_index* (most recent first). The caller
+    may use the indices to drop the now-redundant intermediate bindings
+    when fusing the read/compute/store into ``sname[...] += rhs``.
+    """
+    target_repr = f"{sname}[{scratch_idx}]"
+    chain: list[tuple[int, str]] = []
+    current = expr
+    j = before_index - 1
+    while True:
+        if isinstance(current, ast.Subscript):
+            if ast.unparse(current) == target_repr:
+                return chain
+            return None
+        if not isinstance(current, ast.Name):
+            return None
+        lookup_name = current.id
+        found_binding = False
+        while j >= 0:
+            stmt = stmts[j]
+            if (
+                isinstance(stmt, ast.Assign)
+                and len(stmt.targets) == 1
+                and isinstance(stmt.targets[0], ast.Name)
+                and stmt.targets[0].id == lookup_name
+            ):
+                chain.append((j, lookup_name))
+                current = stmt.value
+                j -= 1
+                found_binding = True
+                break
+            j -= 1
+        if not found_binding:
+            return None
+
+
+def _name_referenced_outside(
+    stmts: list[ast.AST],
+    name: str,
+    *,
+    skip_index: int,
+    additional_skips: list[int] | None = None,
+) -> bool:
+    """Return True if *name* is read in any stmt except *skip_index* and
+    the optional *additional_skips* list.
+
+    Only Load-context references count: a Store-context occurrence (the
+    LHS of the binding we plan to drop) is not a dependency.
+    """
+    skips: set[int] = {skip_index}
+    if additional_skips:
+        skips.update(additional_skips)
+    for idx, stmt in enumerate(stmts):
+        if idx in skips:
+            continue
+        for node in ast.walk(stmt):
+            if (
+                isinstance(node, ast.Name)
+                and node.id == name
+                and isinstance(node.ctx, ast.Load)
+            ):
+                return True
+    return False
 
 
 def _read_final_loop_state(
@@ -1394,6 +1577,678 @@ def _(state: CodegenState) -> ast.AST:
     )
 
 
+def _outer_pid_block_is_singleton(
+    env: CompileEnvironment,
+    config: object,
+    pid: object,
+) -> bool:
+    """Return True when the outer-grid axis described by ``pid`` resolves to
+    a configured block size of 1.
+
+    The outer-grid lift rewrite (``_apply_outer_grid_rewrites``) assumes the
+    loop-carried accumulator is a multi-row / multi-column matmul tile.  When
+    the configured block size for an outer axis is 1 (e.g. ``bm == 1`` on the
+    bf16 1×K×N row of the matrix), the scratch holds a degenerate 1-row or
+    1-column tile and the rewrite emits silently-wrong outputs whenever the
+    inner K loop has > 1 iteration.  Treating singleton outer-grid blocks as
+    ineligible falls back to ``_codegen_emit_pipeline``, which handles the
+    degenerate shape correctly.
+    """
+    block_id = pid.block_id  # pyrefly: ignore[missing-attribute]
+    if not (0 <= block_id < len(env.block_sizes)):
+        return False
+    block_size_info = env.block_sizes[block_id]
+    value = block_size_info.from_config(config)  # type: ignore[arg-type]
+    return isinstance(value, int) and value == 1
+
+
+def _codegen_outer_grid_or_fallback(state: CodegenState) -> object:
+    """Lift the inner K loop into the outer ``pl.pallas_call`` grid when the
+    matmul-pattern eligibility check passes; otherwise fall back to
+    ``_codegen_emit_pipeline``.
+
+    The hand-written reference matmul (``examples/pallas_perf/matmul_pallas.py``)
+    uses a 3-axis outer grid ``(grid_m, grid_n, grid_k)`` with
+    ``dimension_semantics = ("parallel", "parallel", "arbitrary")``, a
+    ``pl.when(pl.program_id(2) == 0)`` accumulator init guard, and a
+    ``pl.when(pl.program_id(2) == nsteps - 1)`` accumulator store guard.
+    The inner loop is a single ``scratch[...] += pl.dot(x_tile, y_tile)``
+    statement; ``X``/``Y`` outer in_specs are ``(bm, bk)`` / ``(bk, bn)``
+    indexed by ``(i, k)`` / ``(k, j)`` rather than ``(i, 0)`` / ``(0, j)``
+    VMEM strips, which lets Mosaic pipeline across the 8 grid iterations.
+
+    Helion's default ``emit_pipeline`` path keeps K inside
+    ``pltpu.emit_pipeline`` (a serial ``lax.fori_loop`` with double-buffered
+    DMA but no cross-iteration compute pipelining); the outer-grid form
+    matches the hand-written reference exactly.
+
+    Eligibility:
+      * Single inner block_id (the K reduction axis).
+      * Block size info marks that block_id as ``reduction=True``.
+      * Inner loop has loop-carried state (an accumulator).
+      * The outer grid currently has at least one non-reduction axis
+        (i.e. matmul-like; pure-reduction kernels stay on emit_pipeline).
+
+    On any miss, falls back transparently to ``_codegen_emit_pipeline`` so
+    the autotuner doesn't have to know about which inner loops qualify.
+    """
+    from .._compiler.device_function import DeviceFunction as _DF
+    from .._compiler.device_function import PallasOuterGridLiftedAxis
+    from .._compiler.device_ir import ForLoopGraphInfo
+
+    graph_info = state.get_graph(state.proxy_arg(0))
+    assert isinstance(graph_info, ForLoopGraphInfo)
+    block_ids = graph_info.block_ids
+    env = CompileEnvironment.current()
+    device_fn = _DF.current()
+
+    eligible = False
+    if (
+        len(block_ids) == 1
+        and device_fn.pid is not None
+        and len(device_fn.pid.pid_info) >= 1
+    ):
+        # Loop-carried state: the for_loop call passes the carried args as
+        # the last entry in ``ast_args`` / ``proxy_args``.  An accumulator
+        # pattern needs at least one carried tensor.  This is the semantic
+        # marker for "this inner loop is a reduction" — Helion's tile-loop
+        # block sizes don't carry an explicit ``reduction=True`` flag for
+        # user-written ``for tile_k in hl.tile(k)`` (only
+        # ``allocate_reduction_dimension`` sets it, and the lowering of
+        # ``torch.addmm`` does not), so we infer reduction-ness from the
+        # presence of accumulator state.
+        last_args = state.ast_args[-1] if isinstance(state.ast_args, list) else None
+        if isinstance(last_args, list) and len(last_args) > 0:
+            # Refuse to lift if any outer-grid block_id is also a reduction
+            # (some other helion pattern); the outer-grid restructure only
+            # makes sense when M/N really are independent.
+            outer_has_reduction = any(
+                env.block_sizes[pid.block_id].reduction
+                for pid in device_fn.pid.pid_info
+            )
+            # Refuse to lift when any outer-grid axis resolves to a
+            # configured block size of 1.  The body rewrite that lifts the
+            # inner K loop into the outer grid assumes the loop-carried
+            # accumulator is a 2D matmul tile; when ``bm == 1`` (or any
+            # outer-tile dim == 1) the scratch holds a 1-row / 1-col
+            # broadcast outer product instead and the rewrite produces
+            # silently-wrong outputs whenever the K loop has > 1 iteration
+            # (NaN / mismatch up to 4.5e6 vs CPU f32 reference; the
+            # autotuner's accuracy check skips these configs, but forced
+            # configs are unprotected).  Fall back to ``emit_pipeline``
+            # which handles singleton dims correctly.
+            outer_has_singleton_block = any(
+                _outer_pid_block_is_singleton(env, state.config, pid)
+                for pid in device_fn.pid.pid_info
+            )
+            if not outer_has_reduction and not outer_has_singleton_block:
+                eligible = True
+
+    if not eligible:
+        return _codegen_emit_pipeline(state)
+
+    # Record the body-list position before emit_pipeline runs so the
+    # post-codegen rewrite (``_apply_outer_grid_rewrites``) can locate
+    # the scratch init / pipeline call / scratch read it needs to wrap
+    # in ``pl.when`` guards.  Only ``idx_before`` is captured; the matching
+    # ``idx_after`` would be invalidated by DCE in the apply pass, which
+    # searches for the pipeline call by content instead.
+    body_list = state.codegen.statements_stack[-1]
+    idx_before = len(body_list)
+    result = _codegen_emit_pipeline(state)
+
+    # Determine the K loop's outer grid dim index: append after the
+    # existing outer-grid PIDs.  ``_compute_reduction_grid_dims`` will
+    # then flag it as a reduction so the launcher marks it ``"arbitrary"``.
+    block_id = block_ids[0]
+    nsteps_expr = env.backend.cdiv_expr(
+        _get_loop_numel(state, 0),
+        state.device_function.block_size_var(block_id) or "1",
+        is_device=False,
+    )
+
+    # The matched scratch is the loop-carried scratch.  ``_codegen_emit_pipeline``
+    # registered exactly one scratch for the carried accumulator; pick the
+    # most-recently registered VMEM scratch (the only one created in this
+    # pipeline emission frame).
+    scratch_name = ""
+    for sa in reversed(device_fn._scratch_args):
+        if sa.scratch_type == "vmem":
+            scratch_name = sa.name
+            break
+    if not scratch_name:
+        # Fallback: no scratch was registered; the rewrite would have nothing
+        # to wrap, so leave as emit_pipeline form.
+        return result
+
+    device_fn.pallas_outer_grid_lifted.append(
+        PallasOuterGridLiftedAxis(
+            block_id=block_id,
+            nsteps_expr=nsteps_expr,
+            scratch_name=scratch_name,
+        )
+    )
+
+    # Extend ``pid_info`` with the lifted K axis BEFORE the host wrapper
+    # (``codegen_function_call``) runs so the host's
+    # ``grid=(grid_m, grid_n, grid_k)`` expression and
+    # ``_block_spec_info``'s ``block_id → grid_dim`` mapping both include
+    # the new axis.  The K axis is placed at ``len(pid_info)``; the body
+    # rewrite emits ``_outer_pid_K = pl.program_id(<that index>)`` to
+    # match.  Mirror the matmul reference: K stays ``"arbitrary"`` via the
+    # existing ``_compute_reduction_grid_dims`` flow once we set the K
+    # block_size's ``reduction`` flag.
+    from .._compiler.program_id import PIDInfo
+
+    k_grid_dim = len(device_fn.pid.pid_info)  # type: ignore[union-attr]
+    k_pid_var = device_fn.new_var(f"_outer_pid_{k_grid_dim}")
+    block_size_var = device_fn.block_size_var(block_id) or "1"
+    k_numel = env.block_sizes[block_id].numel
+    device_fn.pid.pid_info.append(  # type: ignore[union-attr]
+        PIDInfo(
+            pid_var=k_pid_var,
+            block_size_var=block_size_var,
+            numel=k_numel,
+            block_id=block_id,
+        )
+    )
+    # ``_compute_reduction_grid_dims`` reads
+    # ``device_fn.pallas_outer_grid_lifted`` (set immediately below) and
+    # adds the lifted K grid dim to the reduction list, so the launcher
+    # marks it ``"arbitrary"`` in ``dimension_semantics``.  Avoid mutating
+    # ``env.block_sizes[block_id].reduction`` because the BlockSizeInfo is
+    # shared across re-compilations and other ``pallas_loop_type`` configs
+    # would silently inherit the flag flip.
+
+    # Strip the K block_id from the inner-pipeline tracking so the
+    # launcher emits a regular outer ``(bm, bk) / (bk, bn)`` BlockSpec for
+    # X / Y instead of an HBM ref + VMEM strip pair.  This is what makes
+    # the 3-axis grid actually carry K through the outer pallas_call: with
+    # X / Y now bound by ``_block_spec_info``'s ``(0, k_grid_dim)`` /
+    # ``(k_grid_dim, 1)`` mapping, Mosaic gets the same outer specs the
+    # hand-written matmul reference uses.  Walk the live emit_pipeline
+    # body output (the just-emitted ``def _pipeline_body(...)`` plus the
+    # ``pltpu.emit_pipeline(...)(x, y)`` call) to discover which outer
+    # refs are bound to the pipeline body's params (e.g. ``x`` <- ``x_vmem``)
+    # and reset their pipeline state.
+    _reset_pipeline_state_for_lifted_axis(device_fn, body_list, idx_before)
+
+    # Tag the position of the emit_pipeline call so the post-codegen rewrite
+    # can identify exactly which call to replace.  ``_apply_outer_grid_rewrites``
+    # searches the live body for the pipeline call (DCE may rearrange
+    # earlier setup statements between capture and now).
+    if not hasattr(device_fn, "_pallas_outer_grid_pending_rewrites"):
+        device_fn._pallas_outer_grid_pending_rewrites = []  # type: ignore[attr-defined]
+    device_fn._pallas_outer_grid_pending_rewrites.append(  # type: ignore[attr-defined]
+        {
+            "body_list": body_list,
+            "scratch_name": scratch_name,
+            "block_id": block_id,
+            "nsteps_expr": nsteps_expr,
+            "k_grid_dim": k_grid_dim,
+            "k_pid_var": k_pid_var,
+        }
+    )
+    return result
+
+
+def _reset_pipeline_state_for_lifted_axis(
+    device_fn: object,
+    body_list: list[ast.AST],
+    idx_before: int,
+) -> None:
+    """Reset HBM / VMEM-strip tags on tensors bound through the pipeline
+    body that's about to be inlined into the outer-grid form.
+
+    The just-emitted ``_codegen_emit_pipeline`` call appends:
+      def _pipeline_body(_pipeline_indices, x_vmem, y_vmem): ...
+      pltpu.emit_pipeline(_pipeline_body, ...)(x, y)
+
+    The pipeline call's args (``x``, ``y``) are the outer ref names whose
+    pipeline tagging we want to clear so the launcher emits a regular
+    BlockSpec for them on the now-3-axis outer grid.
+    """
+    from .._compiler.device_function import DeviceFunction
+    from .._compiler.device_function import PallasMemorySpace
+    from .._compiler.device_function import TensorArg
+
+    assert isinstance(device_fn, DeviceFunction)
+    referenced_names: set[str] = set()
+    for stmt in body_list[idx_before:]:
+        if _is_emit_pipeline_call_stmt(stmt):
+            assert isinstance(stmt, ast.Expr)
+            call = stmt.value
+            assert isinstance(call, ast.Call)
+            for arg in call.args:
+                if isinstance(arg, ast.Name):
+                    referenced_names.add(arg.id)
+    for arg in device_fn._tensor_args.values():
+        if not isinstance(arg, TensorArg):
+            continue
+        if arg.name in referenced_names:
+            tid = id(arg.fake_value)
+            if device_fn.pallas_memory_space.get(tid) == PallasMemorySpace.HBM:
+                del device_fn.pallas_memory_space[tid]
+            device_fn.pallas_pipeline_vmem_strip.discard(tid)
+
+
+def _apply_outer_grid_rewrites(
+    device_fn: object,
+    pending: list[dict[str, object]],
+) -> None:
+    """Rewrite ``DeviceFunction.body`` for each lifted outer-grid axis.
+
+    For every entry in *pending*, replaces the
+    ``scratch_init / pltpu.emit_pipeline(...)(args) / scratch_read``
+    triple plus the subsequent convert+store statements with a
+    matmul_pallas.py-style 3-axis outer-grid form:
+
+      _outer_pid_K = pl.program_id(<K_grid_dim>)
+      @pl.when(_outer_pid_K == 0)
+      def _init():
+          <init statements>
+
+      <inline pipeline body using outer refs and _outer_pid_K>
+
+      @pl.when(_outer_pid_K == <nsteps - 1>)
+      def _store():
+          <post-pipeline statements: scratch read, convert, store>
+
+    The rewrite is a pure AST surgery — no new tensors / scratches /
+    block sizes are introduced.  ``pid_info`` is also extended with a
+    PIDInfo for the K block_id so that ``pid.codegen_grid()`` returns the
+    3-axis grid tuple at host-wrapper emission time and
+    ``_compute_block_spec_info`` maps the X/Y K dim to the new grid axis.
+    Any pending entry whose scaffolding doesn't match the expected
+    matmul shape is left alone (the body stays in emit_pipeline form),
+    so the eligibility check in ``_codegen_outer_grid_or_fallback`` can
+    stay coarse and the rewrite stays the strict gate.
+    """
+    from .._compiler.device_function import DeviceFunction
+    from .._compiler.device_function import PallasOuterGridLiftedAxis
+
+    assert isinstance(device_fn, DeviceFunction)
+
+    for entry in pending:
+        # ``body_list`` is the live device_function.body reference captured
+        # at codegen time, but DCE / scratch-arg insertion may have removed
+        # early ``offset_N / indices_N / begin_N`` setup statements between
+        # capture and now, so the ``idx_before`` snapshot from
+        # ``_codegen_outer_grid_or_fallback`` is unreliable.  Search the
+        # body by content for the pipeline call instead — there's exactly
+        # one emit_pipeline call per pending entry by construction (each
+        # entry corresponds to a single matched inner loop).
+        body_list = cast("list[ast.AST]", entry["body_list"])
+        scratch_name = cast("str", entry["scratch_name"])
+        block_id = cast("int", entry["block_id"])
+
+        pipeline_call_idx = -1
+        pipeline_body_idx = -1
+        for i, stmt in enumerate(body_list):
+            if _is_emit_pipeline_call_stmt(stmt):
+                pipeline_call_idx = i
+            elif (
+                isinstance(stmt, ast.FunctionDef)
+                and stmt.name.startswith("_pipeline_body")
+                and pipeline_body_idx == -1
+            ):
+                pipeline_body_idx = i
+        if pipeline_call_idx < 0 or pipeline_body_idx < 0:
+            # Body shape didn't match (e.g. fori_loop fallback or another
+            # pass already rewrote this body); skip.
+            continue
+
+        # Walk back from the pipeline body def to find the scratch init
+        # ``scratch_N[...] = acc[...]`` and the surrounding init statements
+        # (outer accumulator assignment ``acc = jnp.full(...)``).  The
+        # scratch init line is the start of the init block we want to
+        # guard with ``pl.when(_outer_pid_K == 0)``.
+        init_start = 0
+        scratch_init_idx = -1
+        for i in range(pipeline_body_idx - 1, -1, -1):
+            stmt = body_list[i]
+            if _is_scratch_init_for(stmt, scratch_name):
+                scratch_init_idx = i
+                break
+        if scratch_init_idx < 0:
+            # No scratch init found — bail out and leave the body as-is.
+            continue
+        # Walk back from scratch_init_idx to swallow any contiguous run of
+        # outer-pre-init statements (e.g. ``acc = jnp.full(...)``,
+        # ``_outer_pid_N = pl.program_id(N)`` etc.).  We stop at the first
+        # statement that doesn't look like outer-init / pid-setup.
+        init_start = scratch_init_idx
+        while init_start > 0 and _looks_like_outer_init_stmt(body_list[init_start - 1]):
+            init_start -= 1
+
+        init_end_exclusive = pipeline_body_idx
+
+        # Post-pipeline statements: from pipeline_call_idx + 1 through end
+        # of the body (or until the next outer-grid pid setup, if multiple
+        # matmuls are stacked; the simple "to-end" form works for the
+        # headline since the kernel has a single matmul).
+        post_start = pipeline_call_idx + 1
+        post_end_exclusive = len(body_list)
+
+        # ``_outer_pid_N = pl.program_id(N)`` setup statements stay outside
+        # the pl.when guards (cheap and used by both branches).  The rest
+        # of init_start..init_end_exclusive becomes the guarded init body.
+        guard_init_stmts: list[ast.AST] = []
+        keep_outside_stmts: list[ast.AST] = []
+        for stmt in body_list[init_start:init_end_exclusive]:
+            if _is_outer_pid_setup_stmt(stmt):
+                keep_outside_stmts.append(stmt)
+            else:
+                guard_init_stmts.append(stmt)
+
+        # K's PIDInfo was already appended in ``_codegen_outer_grid_or_fallback``
+        # so the host grid is already 3-axis; pick up the saved indices.
+        k_grid_dim = cast("int", entry["k_grid_dim"])
+        k_pid_var = cast("str", entry["k_pid_var"])
+
+        # Compute device-side ``_K_NSTEPS_<i> = pl.num_programs(<k_grid_dim>)``
+        # so the store guard's ``_outer_pid_K == _K_NSTEPS - 1`` expression
+        # works with both compile-time and runtime grid sizes.
+        nsteps_var = device_fn.new_var(f"_k_nsteps_{k_grid_dim}")
+
+        # Extract the pipeline body's parameter names and arguments from
+        # the ``pltpu.emit_pipeline(_pipeline_body, ...)(x, y)`` call so we
+        # can substitute ``x_vmem -> x`` etc. when inlining.
+        pipeline_body_fn = body_list[pipeline_body_idx]
+        assert isinstance(pipeline_body_fn, ast.FunctionDef)
+        body_param_names = [arg.arg for arg in pipeline_body_fn.args.args]
+        pipeline_call_args = _extract_emit_pipeline_call_args(
+            body_list[pipeline_call_idx]
+        )
+        if (
+            len(body_param_names) < 1
+            or len(pipeline_call_args) != len(body_param_names) - 1
+        ):
+            # Unexpected shape — skip rewrite (leave body as emit_pipeline).
+            continue
+        # body_param_names[0] is ``_pipeline_indices``; remaining are tensor
+        # refs.  Replace tensor params with the outer ref names; replace
+        # ``_pipeline_indices[0]`` with the K pid var.
+        param_renames: dict[str, str] = {}
+        for i, param_name in enumerate(body_param_names[1:]):
+            param_renames[param_name] = pipeline_call_args[i]
+        pipeline_indices_name = body_param_names[0]
+        inner_body_stmts = _rename_and_dereference_body(
+            list(pipeline_body_fn.body),
+            param_renames,
+            pipeline_indices_name,
+            k_pid_var,
+        )
+
+        # Build the guarded init / inlined body / guarded store.
+        is_first_k = f"{k_pid_var} == 0"
+        is_last_k = f"{k_pid_var} == ({nsteps_var}) - 1"
+
+        new_section: list[ast.AST] = []
+        new_section.extend(keep_outside_stmts)
+        new_section.extend(
+            [
+                statement_from_string(f"{k_pid_var} = pl.program_id({k_grid_dim})"),
+                statement_from_string(f"{nsteps_var} = pl.num_programs({k_grid_dim})"),
+                _wrap_in_pl_when("_init", is_first_k, guard_init_stmts),
+            ]
+        )
+        new_section.extend(inner_body_stmts)
+        new_section.append(
+            _wrap_in_pl_when(
+                "_store", is_last_k, body_list[post_start:post_end_exclusive]
+            )
+        )
+
+        # Splice ``new_section`` in place of the old [init_start, end) range.
+        del body_list[init_start:post_end_exclusive]
+        for offset, stmt in enumerate(new_section):
+            body_list.insert(init_start + offset, stmt)
+
+        # Record on the device function (also flushed into the public list
+        # populated by the codegen so the launcher can pick it up).
+        device_fn.pallas_outer_grid_lifted[-1] = PallasOuterGridLiftedAxis(
+            block_id=block_id,
+            nsteps_expr=cast("str", entry["nsteps_expr"]),
+            scratch_name=scratch_name,
+        )
+
+        # Strip the K block_id from any pipeline-related sets so the launcher
+        # treats X/Y as ordinary outer-grid tiles (proper BlockSpec) rather
+        # than HBM refs / VMEM strips.  This is what makes the launcher emit
+        # the 3-axis ``(bm, bk)/(bk, bn)`` block specs that Mosaic can
+        # pipeline across the outer grid.
+        _restore_outer_grid_tensor_specs(
+            device_fn, body_list[init_start : init_start + len(new_section)]
+        )
+
+
+def _is_emit_pipeline_call_stmt(stmt: ast.AST) -> bool:
+    """True iff *stmt* is an ``Expr(call=pltpu.emit_pipeline(...)(...))`` stmt."""
+    if not isinstance(stmt, ast.Expr):
+        return False
+    call = stmt.value
+    if not isinstance(call, ast.Call):
+        return False
+    inner = call.func
+    if not isinstance(inner, ast.Call):
+        return False
+    fn = inner.func
+    return (
+        isinstance(fn, ast.Attribute)
+        and fn.attr == "emit_pipeline"
+        and isinstance(fn.value, ast.Name)
+        and fn.value.id == "pltpu"
+    )
+
+
+def _is_scratch_init_for(stmt: ast.AST, scratch_name: str) -> bool:
+    """True iff *stmt* assigns ``<scratch_name>[<slice>] = <expr>``.
+
+    The slice is either ``...`` or ``[:, :]`` style; both are accepted.
+    """
+    if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+        return False
+    target = stmt.targets[0]
+    if not isinstance(target, ast.Subscript):
+        return False
+    return isinstance(target.value, ast.Name) and target.value.id == scratch_name
+
+
+def _looks_like_outer_init_stmt(stmt: ast.AST) -> bool:
+    """True iff *stmt* looks like an outer-pre-init or pid-setup statement.
+
+    Conservative: only accepts simple ``<name> = <expr>`` assignments where
+    the RHS is a ``Call`` or ``Subscript`` (i.e. ``acc = jnp.full(...)``,
+    ``_outer_pid_N = pl.program_id(N)``, ``offset_N = ...``).
+    """
+    if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1:
+        target = stmt.targets[0]
+        return isinstance(target, ast.Name)
+    return False
+
+
+def _is_outer_pid_setup_stmt(stmt: ast.AST) -> bool:
+    """True iff *stmt* assigns ``_outer_pid_N = pl.program_id(N)``."""
+    if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+        return False
+    target = stmt.targets[0]
+    if not isinstance(target, ast.Name) or not target.id.startswith("_outer_pid_"):
+        return False
+    value = stmt.value
+    return (
+        isinstance(value, ast.Call)
+        and isinstance(value.func, ast.Attribute)
+        and value.func.attr == "program_id"
+        and isinstance(value.func.value, ast.Name)
+        and value.func.value.id == "pl"
+    )
+
+
+def _drop_dead_outer_pid_reads(body_list: list[ast.AST]) -> None:
+    """DCE top-level ``_outer_pid_N = pl.program_id(N)`` setup statements
+    whose LHS name is never read elsewhere in *body_list*.
+
+    The ``outer_grid`` body rewrite and ``emit_pipeline`` codegen both
+    emit one ``_outer_pid_N`` setup per outer-grid axis (M / N / lifted
+    K), even when the body only references a subset of them.  For the
+    matmul headline the ``outer_grid`` path uses only ``_outer_pid_K``
+    (inside the ``@pl.when`` guards); the ``emit_pipeline`` strip path
+    uses none of the M / N pids inside its BlockSpec lambdas (the
+    lambda emits ``0`` for strip-tagged outer dims).  Leaving the dead
+    reads in place costs ~5% on the headline (hand-edit ablation: the
+    matmul_pallas.py mirror went from 125.5 us to 132.9 us when the
+    same two dead reads were inserted).
+
+    The pass is a strict use-def DCE on flat top-level statements.
+    Reference detection uses ``ast.walk`` so nested function bodies
+    (e.g. ``@pl.when(...) def _init():`` / ``def _pipeline_body``) and
+    BlockSpec lambdas are inspected — a pid var read from inside any of
+    those keeps its setup alive.  The setup statement itself only
+    writes its LHS (the call to ``pl.program_id`` is closed over), so
+    excluding the LHS of setup statements from the "uses" set is the
+    only subtlety.
+    """
+    used_pid_names: set[str] = set()
+    setup_indices: list[int] = []
+    setup_lhs_names: list[str] = []
+
+    for idx, stmt in enumerate(body_list):
+        if _is_outer_pid_setup_stmt(stmt):
+            assert isinstance(stmt, ast.Assign)
+            target = stmt.targets[0]
+            assert isinstance(target, ast.Name)
+            setup_indices.append(idx)
+            setup_lhs_names.append(target.id)
+        else:
+            for node in ast.walk(stmt):
+                if (
+                    isinstance(node, ast.Name)
+                    and isinstance(node.ctx, ast.Load)
+                    and node.id.startswith("_outer_pid_")
+                ):
+                    used_pid_names.add(node.id)
+
+    # Drop dead setups in reverse order so earlier indices stay valid.
+    for idx, lhs_name in zip(
+        reversed(setup_indices), reversed(setup_lhs_names), strict=True
+    ):
+        if lhs_name not in used_pid_names:
+            del body_list[idx]
+
+
+def _extract_emit_pipeline_call_args(stmt: ast.AST) -> list[str]:
+    """Return the call args of ``pltpu.emit_pipeline(...)(x, y)`` as strings."""
+    assert isinstance(stmt, ast.Expr)
+    call = stmt.value
+    assert isinstance(call, ast.Call)
+    return [ast.unparse(a) for a in call.args]
+
+
+def _rename_and_dereference_body(
+    body: list[ast.AST],
+    param_renames: dict[str, str],
+    pipeline_indices_name: str,
+    k_pid_var: str,
+) -> list[ast.AST]:
+    """Rename pipeline body parameters to outer ref names and rewrite the
+    ``_pipeline_indices[0]`` access to ``k_pid_var``.
+
+    Drops the ``nonlocal`` declaration the closure body carries — the body
+    is being inlined into the function scope where the names are already
+    visible.
+    """
+
+    class _Renamer(ast.NodeTransformer):
+        def visit_Subscript(self, node: ast.Subscript) -> ast.AST:
+            self.generic_visit(node)
+            # _pipeline_indices[<i>] → k_pid_var (single-axis lift only)
+            if (
+                isinstance(node.value, ast.Name)
+                and node.value.id == pipeline_indices_name
+                and isinstance(node.slice, ast.Constant)
+                and node.slice.value == 0
+            ):
+                return ast.copy_location(ast.Name(id=k_pid_var, ctx=ast.Load()), node)
+            return node
+
+        def visit_Name(self, node: ast.Name) -> ast.AST:
+            if node.id in param_renames:
+                new_id = param_renames[node.id]
+                return ast.copy_location(ast.Name(id=new_id, ctx=node.ctx), node)
+            return node
+
+    renamer = _Renamer()
+    out: list[ast.AST] = []
+    for stmt in body:
+        if isinstance(stmt, ast.Nonlocal):
+            continue
+        new_stmt = renamer.visit(stmt)
+        ast.fix_missing_locations(new_stmt)
+        out.append(new_stmt)
+    return out
+
+
+def _wrap_in_pl_when(
+    fn_name: str,
+    cond_expr: str,
+    body_stmts: list[ast.AST],
+) -> ast.AST:
+    """Build ``@pl.when(<cond_expr>); def <fn_name>(): <body_stmts>``.
+
+    Matches the hand-written ``matmul_pallas.py`` form exactly.  Empty
+    bodies get a ``pass`` so the FunctionDef stays valid.
+    """
+    fn_def = statement_from_string(f"def {fn_name}(): pass")
+    assert isinstance(fn_def, ast.FunctionDef)
+    fn_def.body = list(body_stmts) if body_stmts else [ast.Pass()]  # pyrefly: ignore[bad-assignment]
+    decorator_expr = expr_from_string(f"pl.when({cond_expr})")
+    assert isinstance(decorator_expr, ast.expr)
+    fn_def.decorator_list = [decorator_expr]
+    return fn_def
+
+
+def _restore_outer_grid_tensor_specs(
+    device_fn: object,
+    section: list[ast.AST],
+) -> None:
+    """When K is lifted into the outer grid, X and Y need ordinary outer
+    BlockSpecs (``(bm, bk)`` indexed by ``(i, k)`` / ``(bk, bn)`` indexed by
+    ``(k, j)``) rather than the HBM ref + VMEM strip pair that
+    ``_codegen_emit_pipeline`` registered.  Strip the relevant entries so
+    ``backend.build_launcher_args`` emits a regular outer ``BlockSpec`` for
+    each of them at host-wrapper time.
+
+    The simple heuristic walks the rewritten section, collects names that
+    appear as the outer ref in a load (``<name>[:, :]``), and clears the
+    pipeline-related state for any tensor whose ``tensor_arg`` name matches.
+    """
+    from .._compiler.device_function import DeviceFunction
+    from .._compiler.device_function import PallasMemorySpace
+    from .._compiler.device_function import TensorArg
+
+    assert isinstance(device_fn, DeviceFunction)
+    # Names that appear as ``<name>[:, :]`` or ``<name>[...]`` reads in the
+    # rewritten body.
+    referenced_names: set[str] = set()
+    for stmt in section:
+        for node in ast.walk(stmt):
+            if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name):
+                referenced_names.add(node.value.id)
+
+    # Reset memory_space / pipeline strip for any tensor whose arg name is
+    # referenced.  This makes ``_pallas_build_pipeline_specs`` emit a real
+    # BlockSpec (via ``_pallas_make_block_spec``) for each one.
+    for arg in device_fn._tensor_args.values():
+        if not isinstance(arg, TensorArg):
+            continue
+        if arg.name in referenced_names:
+            tid = id(arg.fake_value)
+            if device_fn.pallas_memory_space.get(tid) == PallasMemorySpace.HBM:
+                del device_fn.pallas_memory_space[tid]
+            device_fn.pallas_pipeline_vmem_strip.discard(tid)
+
+
 def _codegen_emit_pipeline(state: CodegenState) -> object:
     """Emit inner device loops using pltpu.emit_pipeline.
 
@@ -1464,13 +2319,37 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
             )
             _bid_to_pid_var[pid.block_id] = pid_var
 
+    # Decide which pipelined tensors should keep an outer VMEM-strip
+    # BlockSpec ``(outer_block, full_inner)`` instead of an HBM ref.  The
+    # strip lets the inner ``pltpu.emit_pipeline`` slice from VMEM, which
+    # the Deep Replan pod probe showed cuts per-K HBM DMA cost ~1.9x at
+    # bf16 block 128.  We opt in only when the combined strip working set
+    # of the candidate tensors fits the strip budget (separate from the
+    # ~65 MB vmem capacity check the launcher already enforces) so that
+    # large-block configs don't accidentally OOM the TPU.
+    pipeline_vmem_strip_ids = _select_pipeline_vmem_strip_ids(
+        all_tensor_info,
+        pipelined_tensor_ids,
+        block_ids,
+        _bid_to_pid_var,
+        env,
+        state,
+    )
+
     def _make_block_spec(fake: torch.Tensor, subscript_meta: list[object]) -> str:
         """Build a BlockSpec string for a tensor accessed in the pipeline body.
 
         Encodes BOTH outer grid dims (via pl.program_id) and inner pipeline
         dims into the BlockSpec lambda, so the full HBM tensor can be passed
         without pre-slicing.
+
+        For tensors whose outer pallas_call BlockSpec is a VMEM strip
+        (id in ``pipeline_vmem_strip_ids``), the inner BlockSpec uses
+        ``0`` for outer-grid dims because the outer ref is already
+        pre-sliced for the outer grid coordinate — indexing with the outer
+        pid would go out of bounds in that dim.
         """
+        is_vmem_strip = id(fake) in pipeline_vmem_strip_ids
         dim_to_bid = _get_dim_block_ids(subscript_meta, env)
         shape = fake.shape
         block_shape_parts: list[str] = []
@@ -1504,13 +2383,15 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                     )
             elif bid is not None and bid in _bid_to_pid_var:
                 # Outer grid dim -- select via captured program_id variable
+                # (HBM-ref path) or constant 0 when the outer pallas_call
+                # already pre-sliced this dim via a VMEM-strip BlockSpec.
                 pid_var = _bid_to_pid_var[bid]
                 bs_var = state.device_function.block_size_var(bid)
                 if bs_var:
                     block_shape_parts.append(bs_var)
                 else:
                     block_shape_parts.append(str(int(shape[dim_idx])))
-                lambda_parts.append(pid_var)
+                lambda_parts.append("0" if is_vmem_strip else pid_var)
             else:
                 block_shape_parts.append(str(int(shape[dim_idx])))
                 lambda_parts.append("0")
@@ -1580,9 +2461,13 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     for fake, _tensor_node, _sub_meta in loaded_tensors.values():
         if id(fake) in pipelined_tensor_ids:
             state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
+            if id(fake) in pipeline_vmem_strip_ids:
+                state.device_function.pallas_pipeline_vmem_strip.add(id(fake))
     for fake, _tensor_node, _sub_meta in stored_tensors.values():
         if id(fake) in pipelined_tensor_ids:
             state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
+            if id(fake) in pipeline_vmem_strip_ids:
+                state.device_function.pallas_pipeline_vmem_strip.add(id(fake))
 
     for key, (fake, _tensor_node, sub_meta) in loaded_tensors.items():
         if key in stored_tensors:
@@ -1806,6 +2691,96 @@ def _compute_vmem_shapes(
                 parts.append(int(fake.shape[dim_idx]))
         vmem_shapes.append(tuple(parts))
     return vmem_shapes
+
+
+def _select_pipeline_vmem_strip_ids(
+    all_tensor_info: list[tuple[torch.Tensor, list[object], str]],
+    pipelined_tensor_ids: set[int],
+    block_ids: list[int],
+    _bid_to_pid_var: dict[int, str],
+    env: CompileEnvironment,
+    state: CodegenState,
+) -> set[int]:
+    """Return pipelined tensor ids whose outer BlockSpec should be a VMEM strip.
+
+    A pipelined tensor is strip-eligible when each of its dimensions is
+    either tiled by the inner pipeline (block_id ∈ ``block_ids`` — kept at
+    full extent in the strip) or by an outer-grid loop (block_id in
+    ``_bid_to_pid_var`` — sliced to the outer block size in the strip).
+    Other dims (no block_id) are kept at full extent.  The strip footprint
+    is the product of those resolved sizes times ``dtype.itemsize``.
+
+    All strip-eligible candidates opt in together when the combined
+    footprint fits ``_OUTER_VMEM_STRIP_BUDGET_BYTES``; otherwise none do
+    and the launcher falls back to HBM refs for every pipelined arg.
+
+    Anything that depends on a still-symbolic shape is rejected — there is
+    no safe way to estimate its strip size at codegen time, and HBM refs
+    are the conservative choice.
+    """
+    from ..runtime import _OUTER_VMEM_STRIP_BUDGET_BYTES
+
+    if not pipelined_tensor_ids:
+        return set()
+
+    candidate_ids: list[int] = []
+    candidate_bytes: list[int] = []
+
+    for fake, sub_meta, _direction in all_tensor_info:
+        if id(fake) not in pipelined_tensor_ids:
+            continue
+        dim_to_bid = _get_dim_block_ids(sub_meta, env)
+        strip_numel = 1
+        has_outer_dim = False
+        ok = True
+        for dim_idx in range(len(fake.shape)):
+            bid = dim_to_bid.get(dim_idx)
+            if bid is not None and bid in block_ids:
+                # Inner pipeline dim — kept at full extent in the strip.
+                size = fake.shape[dim_idx]
+                if not isinstance(size, int):
+                    ok = False
+                    break
+                strip_numel *= size
+            elif bid is not None and bid in _bid_to_pid_var:
+                # Outer-grid dim — strip width = outer block size.
+                resolved = state.device_function.resolved_block_size(bid)
+                if not isinstance(resolved, int):
+                    ok = False
+                    break
+                dim_size = fake.shape[dim_idx]
+                if not isinstance(dim_size, int):
+                    ok = False
+                    break
+                strip_numel *= min(resolved, dim_size)
+                has_outer_dim = True
+            else:
+                size = fake.shape[dim_idx]
+                if not isinstance(size, int):
+                    ok = False
+                    break
+                strip_numel *= size
+        if not ok:
+            # Pessimise: even one unresolved candidate disables the strip
+            # path for the whole pallas_call so we never partially commit
+            # to a strip pattern we can't size-check.
+            return set()
+        if not has_outer_dim:
+            # No outer-grid dim varies for this tensor; a full HBM strip
+            # would just be the whole tensor in VMEM, with no per-grid-iter
+            # reuse benefit.  Skip — keep the existing HBM ref for it.
+            continue
+        candidate_ids.append(id(fake))
+        candidate_bytes.append(strip_numel * fake.element_size())
+
+    if not candidate_ids:
+        return set()
+    # Double-buffered Buffered(buffer_count=2) BlockSpecs are double-VMEM
+    # at runtime; budget the worst-case strip footprint accordingly.
+    total = sum(candidate_bytes) * 2
+    if total > _OUTER_VMEM_STRIP_BUDGET_BYTES:
+        return set()
+    return set(candidate_ids)
 
 
 def _classify_pipelined_tensors(

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -440,6 +440,17 @@ def _pallas_build_block_specs(
     return in_specs, out_specs
 
 
+# Strip-strategy budget for pipelined tensor outer BlockSpecs.  When the
+# combined outer working-set of strip-candidate tensors fits this budget,
+# the codegen marks them so the launcher emits a VMEM strip BlockSpec
+# (e.g. ``(bm, K)`` for ``x``) instead of an HBM ref; the inner
+# ``pltpu.emit_pipeline`` then slices the strip from VMEM rather than
+# DMAing per inner iteration from HBM.  TPU v7's scoped VMEM limit is
+# ~65 MB but a useful per-kernel working set on top of accumulator
+# scratch / inner buffers is much smaller, so opt in conservatively.
+_OUTER_VMEM_STRIP_BUDGET_BYTES = 10 * 1024 * 1024
+
+
 def _pallas_build_pipeline_specs(
     pl: object,
     jnp: object,
@@ -452,22 +463,32 @@ def _pallas_build_pipeline_specs(
     pipeline_arg_indices: list[int] | None,
     output_only_indices: list[int] | None = None,
     smem_arg_indices: list[int] | None = None,
+    pipeline_vmem_strip_indices: list[int] | None = None,
 ) -> tuple[list[object], object]:
     """Build in/out specs for pipeline launchers.
 
-    Pipeline-body tensors (listed in *pipeline_arg_indices*) get HBM refs.
+    Pipeline-body tensors (listed in *pipeline_arg_indices*) get HBM refs by
+    default; tensors that are *also* in *pipeline_vmem_strip_indices* get
+    real BlockSpecs that tile only the outer-grid dim and keep the inner
+    pipeline dim at its full extent (the "VMEM strip" pattern from the
+    hand-written reference kernel — e.g. ``pl.BlockSpec((bm, K), lambda
+    i, j: (i, 0))`` for ``x`` in a 2-axis outer ``(grid_m, grid_n)`` matmul).
+    The inner ``pltpu.emit_pipeline`` BlockSpec then slices the strip from
+    VMEM rather than DMAing per inner iteration from HBM.
+
     All other tensors get proper BlockSpecs for automatic VMEM prefetch.
     Tensors in *smem_arg_indices* (only ever accessed by scalar index, e.g.
     group offset tables) are placed in SMEM so dynamic scalar reads don't
     require 128-lane alignment proofs against a small VMEM ref.
     """
     pipeline_set = set(pipeline_arg_indices or [])
+    vmem_strip_set = set(pipeline_vmem_strip_indices or [])
     smem_set = set(smem_arg_indices or [])
     all_positions = sorted(set(tensor_arg_indices) | set(output_only_indices or []))
     arg_to_tpos = {orig: tpos for tpos, orig in enumerate(all_positions)}
 
     def _spec_for(idx: int) -> object:
-        if idx in pipeline_set:
+        if idx in pipeline_set and idx not in vmem_strip_set:
             return pl.BlockSpec(memory_space=pltpu.HBM)  # type: ignore[union-attr]
         tpos = arg_to_tpos[idx]
         t = args[idx]
@@ -1047,8 +1068,10 @@ def default_pallas_pipeline_launcher(
     _block_spec_info: _BlockSpecInfo | None = None,
     _scratch_shapes: list[tuple[tuple[int, ...], str]] | None = None,
     _pipeline_arg_indices: list[int] | None = None,
+    _pipeline_vmem_strip_indices: list[int] | None = None,
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _smem_arg_indices: list[int] | None = None,
+    _reduction_grid_dims: list[int] | None = None,
     _pallas_interpret: bool | None = None,
     **kwargs: object,
 ) -> object:
@@ -1057,6 +1080,15 @@ def default_pallas_pipeline_launcher(
     Used when ``pallas_loop_type='emit_pipeline'``.  Pipeline-body tensors
     (listed in ``_pipeline_arg_indices``) use HBM refs; all other tensors
     get proper BlockSpecs for automatic VMEM prefetch.
+
+    ``_reduction_grid_dims`` lists the grid-dim indices (0-based) that
+    correspond to reduction axes; those are marked ``"arbitrary"`` in
+    ``dimension_semantics`` so the pipeliner doesn't assume cross-iteration
+    independence.  Non-reduction axes stay ``"parallel"``.  Matmul kernels
+    keep their K loop inside ``pltpu.emit_pipeline`` rather than the outer
+    grid, so the outer grid only carries M, N (both parallel) and this list
+    is empty — the marker only fires for kernels that put a reduction in
+    the outer grid.
     """
     from .settings import is_pallas_interpret
 
@@ -1132,6 +1164,7 @@ def default_pallas_pipeline_launcher(
             _pipeline_arg_indices,
             output_only_indices,
             smem_arg_indices=_smem_arg_indices,
+            pipeline_vmem_strip_indices=_pipeline_vmem_strip_indices,
         )
 
         _pipeline_set = set(_pipeline_arg_indices or [])
@@ -1177,11 +1210,16 @@ def default_pallas_pipeline_launcher(
                 f"Estimated {estimated_vmem / 1e6:.2f}MB exceeds {vmem_limit_bytes / 1e6:.2f}MB vmem capacity."
             )
 
+        reduction_grid_dims = set(_reduction_grid_dims or [])
+        dim_semantics = tuple(
+            "arbitrary" if g in reduction_grid_dims else "parallel"
+            for g in range(len(grid))
+        )
         pallas_call_kwargs: dict[str, object] = {
             "out_shape": out_shape_arg,
             "grid_spec": grid_spec,
             "compiler_params": pltpu.CompilerParams(  # pyrefly: ignore[bad-instantiation]
-                dimension_semantics=tuple("parallel" for _ in grid),
+                dimension_semantics=dim_semantics,  # pyrefly: ignore[bad-argument-type]
             ),
         }
         if interpret:
@@ -1226,6 +1264,7 @@ def default_pallas_fori_launcher(
     _scratch_shapes: list[tuple[tuple[int, ...], str | None, str]] | None = None,
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _smem_arg_indices: list[int] | None = None,
+    _reduction_grid_dims: list[int] | None = None,
     _pallas_interpret: bool | None = None,
     **kwargs: object,
 ) -> object:
@@ -1236,6 +1275,12 @@ def default_pallas_fori_launcher(
     ``pltpu.VMEM`` shapes plus ``pltpu.SemaphoreType.DMA`` for async copies.
     The kernel uses ``jax.lax.fori_loop`` with ``pltpu.make_async_copy``
     internally for DMA control.
+
+    ``_reduction_grid_dims`` lists the grid-dim indices (0-based) for
+    reduction axes; they are marked ``"arbitrary"`` in
+    ``dimension_semantics`` so the pipeliner does not assume cross-iteration
+    independence.  See :func:`default_pallas_pipeline_launcher` for the
+    matmul-specific notes about why this list is typically empty.
     """
     from .settings import is_pallas_interpret
 
@@ -1355,11 +1400,16 @@ def default_pallas_fori_launcher(
                 f"Estimated {estimated_vmem / 1e6:.2f}MB exceeds {vmem_limit_bytes / 1e6:.2f}MB vmem capacity."
             )
 
+        reduction_grid_dims = set(_reduction_grid_dims or [])
+        dim_semantics = tuple(
+            "arbitrary" if g in reduction_grid_dims else "parallel"
+            for g in range(len(grid))
+        )
         pallas_call_kwargs: dict[str, object] = {
             "out_shape": out_shape_arg,
             "grid_spec": grid_spec,
             "compiler_params": pltpu.CompilerParams(  # pyrefly: ignore[bad-instantiation]
-                dimension_semantics=tuple("parallel" for _ in grid),
+                dimension_semantics=dim_semantics,  # pyrefly: ignore[bad-argument-type]
             ),
         }
         if interpret:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -99,6 +99,49 @@ def pallas_matmul_broadcast_bias(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_matmul_f32(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    """f32 matmul kernel mirroring the perf harness's helion variant.
+
+    Used by the pin tests for the degenerate shape families (M=1, N=1,
+    K=1, and combinations). On TPU the default ``lax.dot_general`` for
+    f32 inputs falls back to bf16-internal multiplication; the Pallas
+    lowering must request ``precision=jax.lax.Precision.HIGHEST`` so the
+    MXU does full f32 multiplications.
+    """
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty([m, n], device=x.device, dtype=torch.float32)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+        out[tile_m, tile_n] = acc
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_matmul_bf16(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    """bf16 matmul kernel mirroring the perf harness's helion variant.
+
+    Used by the pin test that verifies the bf16 2D path emits ``pl.dot``
+    (the Pallas-native MXU primitive used by the hand-written reference
+    kernel in ``examples/pallas_perf/matmul_pallas.py``) rather than the
+    slower ``lax.dot_general`` fallback.
+    """
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty(
+        [m, n], device=x.device, dtype=torch.promote_types(x.dtype, y.dtype)
+    )
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+        out[tile_m, tile_n] = acc
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_bmm(A: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
     b, m, k = A.size()
     b, k, n = B.size()
@@ -775,6 +818,531 @@ class TestPallas(TestCase):
         torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
         # The bias block_spec_info must have None for dim 0 (not a grid index).
         self.assertIn("(None, 1)", code)
+
+    def test_pallas_matmul_bf16_emits_pl_dot(self) -> None:
+        """bf16 1024x1024x1024: 2D MXU-legal tile should emit ``pl.dot``.
+
+        The hand-written reference kernel in
+        ``examples/pallas_perf/matmul_pallas.py`` uses ``pl.dot`` for the
+        bf16 square-matmul body; the Mosaic backend lowers it directly to
+        the TPU MXU. The previous Helion path emitted the equivalent
+        ``lax.dot_general(..., preferred_element_type=jnp.float32)``,
+        which the same Mosaic backend serializes through a slower
+        general dot path. The pin asserts:
+
+        * ``pl.dot(`` appears in the generated code (the routing rule
+          fired);
+        * the slower ``lax.dot_general(`` fallback is absent for this
+          2D bf16 tile (i.e. ``preferred_element_type=jnp.float32`` is no
+          longer needed because ``pl.dot`` returns f32 on bf16 inputs
+          automatically).
+
+        The shape is the headline 1024^3 anchor and the block matches
+        ``BLOCK_CONFIGS[1] = (128, 128, 128)`` from
+        ``examples/pallas_perf/matmul_configs.py``.
+        """
+        torch.manual_seed(0)
+        x = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            pallas_matmul_bf16, (x, y), block_sizes=[128, 128, 128]
+        )
+        expected = (x.float() @ y.float()).to(torch.bfloat16)
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+        self.assertIn("pl.dot(", code)
+        self.assertNotIn("lax.dot_general(", code)
+        self.assertNotIn("preferred_element_type=jnp.float32", code)
+
+    def test_pallas_matmul_bf16_inplace_accumulator(self) -> None:
+        """bf16 1024x1024x1024: K-loop accumulator stays in VMEM scratch.
+
+        The hand-written reference kernel in
+        ``examples/pallas_perf/matmul_pallas.py`` accumulates with
+        ``acc_ref[...] += pl.dot(x_val, y_val)`` directly into the VMEM
+        scratch, letting Mosaic keep the accumulator on the MXU between
+        iterations. The previous Helion path emitted the value-flow form
+        ``acc_N = scratch[...] + dot(...)`` plus
+        ``scratch[...] = acc_N[...]``, which forced an extra register
+        binding per K iteration before the value made it back to VMEM.
+        The pin asserts:
+
+        * ``scratch_0[...] += pl.dot(`` appears in the generated code
+          (the rewrite fired);
+        * the externalised value-flow form
+          ``scratch_0[...] = acc`` (with a trailing identifier rather than
+          the ``acc[...]`` scratch initialiser) is absent inside the
+          ``_pipeline_body`` closure.
+        """
+        torch.manual_seed(0)
+        x = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            pallas_matmul_bf16, (x, y), block_sizes=[128, 128, 128]
+        )
+        expected = (x.float() @ y.float()).to(torch.bfloat16)
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+        # The augmented assignment lands the accumulator addition straight
+        # back into the VMEM scratch — this is the marker that the rewrite
+        # in `_write_back_loop_carried` fired.
+        self.assertIn("scratch_0[...] += pl.dot(", code)
+        # The externalised write-back from the prior lowering (the bind
+        # cost we are removing) used a trailing ``acc_N[...]`` slice.
+        # Match the specific form to avoid false negatives against the
+        # one-time ``scratch_0[...] = acc[...]`` initialiser that lives
+        # outside the pipeline body.
+        self.assertNotIn("scratch_0[...] = acc_1[...]", code)
+
+    def test_pallas_matmul_bf16_outer_grid_no_reduction_dim(self) -> None:
+        """bf16 1024x1024x1024: outer-grid carries no reduction axis.
+
+        The hand-written reference kernel in
+        ``examples/pallas_perf/matmul_pallas.py`` uses a 3-axis outer grid
+        ``(grid_m, grid_n, grid_k)`` and marks K as ``"arbitrary"``. Helion
+        instead keeps the K reduction inside ``pltpu.emit_pipeline``, so
+        the outer ``pl.pallas_call`` grid only carries M and N — both of
+        which truly are independent and stay ``"parallel"`` (the launcher
+        default). The pin asserts:
+
+        * The host wrapper does not pass
+          ``_reduction_grid_dims=`` to the launcher for this kernel — the
+          codegen helper ``_compute_reduction_grid_dims`` returns an empty
+          list when no outer-grid axis is a reduction (M and N are not
+          ``reduction=True`` block sizes). When the list is empty the
+          ``build_launcher_args`` builder omits the kwarg entirely, and
+          the launcher falls back to marking every outer-grid axis
+          ``"parallel"``.
+
+        If the K loop were ever lifted into the outer grid (a structural
+        refactor toward the hand-written 3-axis pattern), the helper would
+        flag K's grid dim and this assertion would need updating to
+        ``assertIn("_reduction_grid_dims=", code)`` with the K axis index.
+
+        Block sizes are the headline anchor ``(128, 128, 128)`` from
+        ``examples/pallas_perf/matmul_configs.py``. ``pallas_loop_type``
+        is forced to ``"emit_pipeline"`` so the assertion targets the
+        launcher path that the headline benchmark uses; the ``"unroll"``
+        path uses a different launcher that wouldn't carry the kwarg
+        either.
+        """
+        torch.manual_seed(0)
+        x = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            pallas_matmul_bf16,
+            (x, y),
+            block_sizes=[128, 128, 128],
+            pallas_loop_type="emit_pipeline",
+        )
+        expected = (x.float() @ y.float()).to(torch.bfloat16)
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+        # No outer-grid axis is a reduction, so the kwarg should be absent.
+        self.assertNotIn("_reduction_grid_dims=", code)
+
+    def test_pallas_matmul_bf16_emit_pipeline_outer_vmem_strip(self) -> None:
+        """bf16 1024x1024x1024: emit_pipeline outer in_specs become VMEM strips.
+
+        The hand-written reference kernel in
+        ``examples/pallas_perf/matmul_pallas.py`` does NOT route its
+        pipelined ``x`` / ``y`` operands through ``pl.BlockSpec(
+        memory_space=pltpu.HBM)`` — it keeps them as VMEM strips
+        ``(bm, K)`` / ``(K, bn)`` indexed by the outer grid coordinate, so
+        the inner emit_pipeline slices ``bk``-wide chunks from VMEM
+        instead of DMAing each chunk from HBM per inner iteration.  A Deep
+        Replan pod probe at bf16 block 128 measured a ~1.9x speedup from
+        this single change (478 us → 249 us).
+
+        Helion's previous lowering always forced the HBM ref form via
+        ``_pallas_build_pipeline_specs``.  This pin asserts both halves of
+        the fix:
+
+        * The launcher receives ``_pipeline_vmem_strip_indices=`` so it
+          knows which pipelined args to route to the new strip BlockSpec
+          (the existing ``_pallas_make_block_spec`` already produces
+          ``(bm, K) lambda i, j: (i, 0)`` for the matmul tensors —
+          ``_pallas_build_pipeline_specs`` just stops forcing them to
+          HBM when their id is in this list).
+        * The inner emit_pipeline ``pl.BlockSpec`` lambda uses ``0`` for
+          the outer-grid M / N dim instead of ``_outer_pid_0`` /
+          ``_outer_pid_1``, because the outer ref is now already pre-
+          sliced for the outer-grid coordinate.
+
+        Block sizes ``(128, 128, 128)`` (well inside the
+        ``_OUTER_VMEM_STRIP_BUDGET_BYTES = 10MB`` budget for bf16 1024³)
+        and ``pallas_loop_type='emit_pipeline'`` force the path the
+        marker pins.  A larger block that would push the strip working
+        set past the budget would fall back to the HBM ref form — that
+        guard is intentional and not exercised here.
+        """
+        torch.manual_seed(0)
+        x = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            pallas_matmul_bf16,
+            (x, y),
+            block_sizes=[128, 128, 128],
+            pallas_loop_type="emit_pipeline",
+        )
+        expected = (x.float() @ y.float()).to(torch.bfloat16)
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+        # Launcher-side: pipelined matmul operands are tagged so the
+        # launcher emits a VMEM strip BlockSpec for them rather than an
+        # HBM ref.
+        self.assertIn("_pipeline_vmem_strip_indices=", code)
+        # Inner emit_pipeline BlockSpec: the outer-grid pid (``_outer_pid_0``
+        # / ``_outer_pid_1``) is replaced by ``0`` for VMEM-strip
+        # operands.  Match strict substrings of the emitted lambdas so a
+        # regression that put the pid back in would fail.  The matmul
+        # pipelines both ``x`` (outer M dim → ``(0, _j)``) and ``y``
+        # (outer N dim → ``(_j, 0)``).
+        self.assertIn("lambda _j: (0, _j)", code)
+        self.assertIn("lambda _j: (_j, 0)", code)
+        # And the outer pid variables stay unused inside the
+        # ``_pipeline_body`` for these strip operands — i.e. they no
+        # longer appear inside the BlockSpec lambdas.
+        self.assertNotIn("lambda _j: (_outer_pid_0,", code)
+        self.assertNotIn("lambda _j: (_outer_pid_1,", code)
+
+    def test_pallas_matmul_bf16_outer_grid_lifts_k_axis(self) -> None:
+        """bf16 1024x1024x1024: ``pallas_loop_type='outer_grid'`` lifts the
+        inner K loop into the outer ``pl.pallas_call`` grid.
+
+        The hand-written reference kernel in
+        ``examples/pallas_perf/matmul_pallas.py`` uses a 3-axis outer grid
+        ``(grid_m, grid_n, grid_k)`` with
+        ``dimension_semantics=("parallel", "parallel", "arbitrary")``, a
+        ``pl.when(pl.program_id(2) == 0)`` accumulator-init guard, and a
+        ``pl.when(pl.program_id(2) == nsteps - 1)`` accumulator-store guard
+        instead of Helion's default inner ``pltpu.emit_pipeline`` over K.
+
+        Helion's new ``"outer_grid"`` ``pallas_loop_type`` value drives this
+        structural restructure when the matmul-pattern eligibility check
+        passes (single inner block_id with loop-carried state, non-reduction
+        outer pids).  The pin asserts all four sides of the fix:
+
+        * The launcher receives ``_reduction_grid_dims=[2]`` so the lifted
+          K axis is marked ``"arbitrary"`` in ``dimension_semantics``.
+        * ``_block_spec_info`` for X carries the K grid dim ``(0, 2)`` and
+          Y carries ``(2, 1)`` (instead of the pre-G2-H ``(0, None)`` /
+          ``(None, 1)`` form where K was inside ``pltpu.emit_pipeline``).
+        * No ``pltpu.emit_pipeline(`` call survives in the generated body
+          — the K loop is the outer grid now.
+        * The kernel body contains ``@pl.when(_outer_pid_2 == 0)`` and
+          ``@pl.when(_outer_pid_2 == _k_nsteps_2 - 1)`` guards wrapping
+          the accumulator init and store, matching the reference matmul
+          exactly.
+
+        Block sizes ``(128, 128, 128)`` keep the shape inside any per-tile
+        budgets; ``pallas_loop_type='outer_grid'`` forces the path the
+        marker pins.
+        """
+        torch.manual_seed(0)
+        x = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            pallas_matmul_bf16,
+            (x, y),
+            block_sizes=[128, 128, 128],
+            pallas_loop_type="outer_grid",
+        )
+        expected = (x.float() @ y.float()).to(torch.bfloat16)
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+        # Launcher-side: K axis is in the outer grid and flagged as
+        # ``"arbitrary"`` via ``_reduction_grid_dims=[2]``.  The expanded
+        # ``_block_spec_info`` ties X's K dim to grid dim 2 and Y's K dim
+        # to grid dim 2 too, while M (0) and N (1) stay on grid dims 0/1.
+        self.assertIn("_reduction_grid_dims=[2]", code)
+        self.assertIn("((128, 128), (0, 2))", code)  # X(M, K) -> grid (0, 2)
+        self.assertIn("((128, 128), (2, 1))", code)  # Y(K, N) -> grid (2, 1)
+        self.assertIn("((128, 128), (0, 1))", code)  # out(M, N) -> grid (0, 1)
+        # No emit_pipeline call survives — the K loop is the outer grid.
+        self.assertNotIn("pltpu.emit_pipeline(", code)
+        # Body-side: the lifted K axis pid var and nsteps var anchor the
+        # pl.when guards exactly like ``matmul_pallas.py``.
+        self.assertIn("_outer_pid_2 = pl.program_id(2)", code)
+        self.assertIn("_k_nsteps_2 = pl.num_programs(2)", code)
+        self.assertIn("@pl.when(_outer_pid_2 == 0)", code)
+        self.assertIn("@pl.when(_outer_pid_2 == _k_nsteps_2 - 1)", code)
+        # The accumulator stays in scratch and is += into across K
+        # iterations, matching the existing G2-E in-place rewrite.
+        self.assertIn("scratch_0[...] += pl.dot(", code)
+        # Pre-G2-H ``_pipeline_vmem_strip_indices=`` / ``_pipeline_arg_indices=``
+        # kwargs become irrelevant once the K loop is in the outer grid —
+        # X / Y use ordinary outer BlockSpecs.
+        self.assertNotIn("_pipeline_vmem_strip_indices=", code)
+        self.assertNotIn("_pipeline_arg_indices=", code)
+
+    def test_pallas_matmul_outer_grid_falls_back_on_singleton_m(self) -> None:
+        """``pallas_loop_type='outer_grid'`` must refuse to lift when an
+        outer-grid axis has block size 1 and fall back to ``emit_pipeline``.
+
+        Background: the outer-grid body rewrite assumes the loop-carried
+        scratch holds a 2D matmul tile.  When ``bm == 1`` on an M=1 shape
+        (e.g. bf16 1×1024×1024), the scratch holds a 1-row broadcast outer
+        product and the rewrite emits silently-wrong outputs whenever the
+        inner K loop has > 1 iteration (relative diffs up to 4.5e6 vs CPU
+        f32 reference; the autotuner's accuracy check skips these configs,
+        but forced configs are unprotected).  The eligibility check in
+        ``_codegen_outer_grid_or_fallback`` therefore refuses any outer-grid
+        axis whose configured block size resolves to 1.
+
+        The pin asserts the fallback both ways: ``pltpu.emit_pipeline(``
+        must survive (the K loop stays inside the inner pipeline) and the
+        ``@pl.when(_outer_pid_2 == 0)`` / ``@pl.when(_outer_pid_2 == ...)``
+        guards that mark the outer-grid form must NOT appear.  The numeric
+        check confirms the fallback produces correct outputs.
+        """
+        torch.manual_seed(0)
+        x = torch.randn(1, 1024, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            pallas_matmul_bf16,
+            (x, y),
+            block_sizes=[1, 128, 128],
+            pallas_loop_type="outer_grid",
+        )
+        expected = (x.float() @ y.float()).to(torch.bfloat16)
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+        # Fallback fired: inner pipeline survives, no outer-grid K guards.
+        self.assertIn("pltpu.emit_pipeline(", code)
+        self.assertNotIn("@pl.when(_outer_pid_2 == 0)", code)
+        self.assertNotIn("_reduction_grid_dims=[2]", code)
+
+    def test_pallas_matmul_outer_grid_fires_on_multi_m(self) -> None:
+        """``pallas_loop_type='outer_grid'`` still fires on multi-row M.
+
+        Companion to ``test_pallas_matmul_outer_grid_falls_back_on_singleton_m``:
+        with ``bm > 1`` the eligibility check should still let the K loop lift
+        into the outer ``pl.pallas_call`` grid.  This pins that the M=1 guard
+        does not over-refuse and quietly disable the outer-grid path on the
+        working shapes G2-H landed on.
+        """
+        torch.manual_seed(0)
+        x = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            pallas_matmul_bf16,
+            (x, y),
+            block_sizes=[128, 128, 128],
+            pallas_loop_type="outer_grid",
+        )
+        expected = (x.float() @ y.float()).to(torch.bfloat16)
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+        # Outer-grid path fired: K is in the outer grid, no inner pipeline.
+        self.assertIn("_reduction_grid_dims=[2]", code)
+        self.assertIn("@pl.when(_outer_pid_2 == 0)", code)
+        self.assertNotIn("pltpu.emit_pipeline(", code)
+
+    def test_pallas_matmul_bf16_outer_grid_omits_dead_pids(self) -> None:
+        """``pallas_loop_type='outer_grid'`` DCEs unused ``_outer_pid_N`` reads.
+
+        The outer-grid body rewrite emits the K pid (used by the
+        ``@pl.when(_outer_pid_K == ...)`` guards) plus an
+        ``_outer_pid_N = pl.program_id(N)`` setup for every other outer
+        axis (M=0, N=1).  For the matmul body only the K pid is
+        referenced, so the M / N setups are dead and the DCE pass in
+        ``DeviceFunction.codegen_function_def`` removes them.  Hand-edit
+        ablation on the ``matmul_pallas.py`` mirror measured the dead
+        reads at +7.4 us / +5.9% on the bf16 1024**3 headline (125.5
+        us → 132.9 us), making this the highest-confidence remaining
+        ~5% headline lever.
+
+        The K pid setup (``_outer_pid_2 = pl.program_id(2)``) and the
+        ``_k_nsteps_2 = pl.num_programs(2)`` companion both MUST
+        survive — they anchor the init / store guards.
+        """
+        torch.manual_seed(0)
+        x = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            pallas_matmul_bf16,
+            (x, y),
+            block_sizes=[128, 128, 128],
+            pallas_loop_type="outer_grid",
+        )
+        expected = (x.float() @ y.float()).to(torch.bfloat16)
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+        # Dead M / N pids dropped.
+        self.assertNotIn("_outer_pid_0 = pl.program_id(0)", code)
+        self.assertNotIn("_outer_pid_1 = pl.program_id(1)", code)
+        # K pid + nsteps still present and feed the @pl.when guards.
+        self.assertIn("_outer_pid_2 = pl.program_id(2)", code)
+        self.assertIn("_k_nsteps_2 = pl.num_programs(2)", code)
+        self.assertIn("@pl.when(_outer_pid_2 == 0)", code)
+        self.assertIn("@pl.when(_outer_pid_2 == _k_nsteps_2 - 1)", code)
+
+    def test_pallas_matmul_bf16_emit_pipeline_omits_dead_pids(self) -> None:
+        """``emit_pipeline`` strip path DCEs unused ``_outer_pid_N`` reads.
+
+        At small blocks the strip-eligibility pass keeps both ``x`` and
+        ``y`` as VMEM strips, which means the inner BlockSpec lambdas
+        emit ``0`` for outer-grid dims instead of reading the M / N
+        pids (see ``test_pallas_matmul_bf16_emit_pipeline_outer_vmem_strip``
+        for the pid-replacement pin).  At that point both
+        ``_outer_pid_0`` and ``_outer_pid_1`` setups are dead and the
+        DCE pass removes them.
+
+        Companion negative pin
+        ``test_pallas_matmul_bf16_emit_pipeline_keeps_used_pids_on_hbm_ref``
+        below covers the HBM-ref branch where the pids ARE referenced
+        by the lambdas and therefore must survive.
+        """
+        torch.manual_seed(0)
+        x = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            pallas_matmul_bf16,
+            (x, y),
+            block_sizes=[128, 128, 128],
+            pallas_loop_type="emit_pipeline",
+        )
+        expected = (x.float() @ y.float()).to(torch.bfloat16)
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+        # Strip path: lambdas emit ``0`` for outer dims; pids are dead.
+        self.assertNotIn("_outer_pid_0 = pl.program_id(0)", code)
+        self.assertNotIn("_outer_pid_1 = pl.program_id(1)", code)
+        # Sanity: this IS the strip path (not HBM-ref).
+        self.assertIn("lambda _j: (0, _j)", code)
+        self.assertIn("lambda _j: (_j, 0)", code)
+        # And ``pltpu.emit_pipeline`` still drives the K loop here
+        # (this is the non-outer_grid path).
+        self.assertIn("pltpu.emit_pipeline(", code)
+
+    def test_pallas_matmul_bf16_emit_pipeline_keeps_used_pids_on_hbm_ref(
+        self,
+    ) -> None:
+        """``emit_pipeline`` HBM-ref path keeps ``_outer_pid_N`` reads alive.
+
+        When the outer VMEM strip working set exceeds
+        ``_OUTER_VMEM_STRIP_BUDGET_BYTES``, the pipelined operands fall
+        back to ``pl.BlockSpec(memory_space=pltpu.HBM)`` refs and the
+        inner BlockSpec lambdas slice them with ``_outer_pid_N``.  The
+        DCE pass must NOT drop those pid setups — they are read by the
+        lambdas and the kernel will fail to compile without them.
+
+        Block sizes ``(1024, 1024, 1024)`` on a ``4096³`` shape push
+        each strip footprint to ~32 MB (well past the 10 MB budget) so
+        every pipelined arg ends up in the HBM-ref branch.
+        """
+        torch.manual_seed(0)
+        x = torch.randn(4096, 4096, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(4096, 4096, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            pallas_matmul_bf16,
+            (x, y),
+            block_sizes=[1024, 1024, 1024],
+            pallas_loop_type="emit_pipeline",
+        )
+        expected = (x.float() @ y.float()).to(torch.bfloat16)
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+        # Pids are read by the BlockSpec lambdas; DCE must leave them.
+        self.assertIn("_outer_pid_0 = pl.program_id(0)", code)
+        self.assertIn("_outer_pid_1 = pl.program_id(1)", code)
+        # Sanity: the lambdas read the pids (HBM-ref form, not strip).
+        self.assertIn("lambda _j: (_outer_pid_0, _j)", code)
+        self.assertIn("lambda _j: (_j, _outer_pid_1)", code)
+        # And the strip kwarg is absent because no operand fits the budget.
+        self.assertNotIn("_pipeline_vmem_strip_indices=", code)
+
+    def test_pallas_matmul_bmm_stays_on_dot_general(self) -> None:
+        """3D BMM stays on ``lax.dot_general`` (``pl.dot`` is 2D-only).
+
+        ``pl.dot`` rejects non-2D inputs upstream
+        (``jax/_src/pallas/primitives.py``), so BMM kernels must keep
+        using the 3D ``dimension_numbers`` form. The pin guards against a
+        future routing widening that would break 3D paths.
+        """
+        torch.manual_seed(0)
+        a = torch.randn(4, 128, 256, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        b = torch.randn(4, 256, 128, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            pallas_bmm, (a, b), block_sizes=[4, 128, 128, 256]
+        )
+        expected = torch.bmm(a.float(), b.float()).to(torch.bfloat16)
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+        self.assertIn("lax.dot_general(", code)
+        self.assertIn("preferred_element_type=jnp.float32", code)
+        self.assertNotIn("pl.dot(", code)
+
+    def test_pallas_matmul_f32_singleton_n(self) -> None:
+        """f32 1024x1024x1: N=1 (matrix x column vector).
+
+        The default ``lax.dot_general`` on TPU silently downcasts f32
+        operands to bf16 for the multiplication step. Without
+        ``precision=jax.lax.Precision.HIGHEST`` the K=1024 reduction
+        accumulates bf16-rounded products and the result drifts ~1e-1
+        absolute. The pin asserts both the numeric fix and the marker
+        in the generated code so it can't silently regress.
+        """
+        torch.manual_seed(0)
+        x = torch.randn(1024, 1024, device=DEVICE, dtype=torch.float32)
+        torch.manual_seed(1)
+        y = torch.randn(1024, 1, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_matmul_f32, (x, y), block_sizes=[128, 1, 128]
+        )
+        expected = x @ y
+        torch.testing.assert_close(result, expected, rtol=1e-3, atol=1e-3)
+        self.assertIn("lax.dot_general(", code)
+        self.assertIn("precision=jax.lax.Precision.HIGHEST", code)
+
+    def test_pallas_matmul_f32_singleton_k(self) -> None:
+        """f32 1024x1x1024: K=1 (outer product).
+
+        The K-block is forced to 1 so the reduction is a single
+        ``lax.dot_general`` call. Even though K=1 there is only one
+        multiply per cell, TPU's default precision still rounds the
+        intermediate to bf16, leaking error into f32 output.
+        """
+        torch.manual_seed(0)
+        x = torch.randn(1024, 1, device=DEVICE, dtype=torch.float32)
+        torch.manual_seed(1)
+        y = torch.randn(1, 1024, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_matmul_f32, (x, y), block_sizes=[128, 128, 1]
+        )
+        expected = x @ y
+        torch.testing.assert_close(result, expected, rtol=1e-3, atol=1e-3)
+        self.assertIn("lax.dot_general(", code)
+        self.assertIn("precision=jax.lax.Precision.HIGHEST", code)
+
+    def test_pallas_matmul_f32_singleton_m(self) -> None:
+        """f32 1x1024x1024: M=1 (vector x matrix)."""
+        torch.manual_seed(0)
+        x = torch.randn(1, 1024, device=DEVICE, dtype=torch.float32)
+        torch.manual_seed(1)
+        y = torch.randn(1024, 1024, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_matmul_f32, (x, y), block_sizes=[1, 128, 128]
+        )
+        expected = x @ y
+        torch.testing.assert_close(result, expected, rtol=1e-3, atol=1e-3)
+        self.assertIn("lax.dot_general(", code)
+        self.assertIn("precision=jax.lax.Precision.HIGHEST", code)
+
+    def test_pallas_matmul_f32_scalar_vector(self) -> None:
+        """f32 1x1x1024: scalar broadcast through dot_general."""
+        torch.manual_seed(0)
+        x = torch.randn(1, 1, device=DEVICE, dtype=torch.float32)
+        torch.manual_seed(1)
+        y = torch.randn(1, 1024, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_matmul_f32, (x, y), block_sizes=[1, 128, 1]
+        )
+        expected = x @ y
+        torch.testing.assert_close(result, expected, rtol=1e-3, atol=1e-3)
+        self.assertIn("lax.dot_general(", code)
+        self.assertIn("precision=jax.lax.Precision.HIGHEST", code)
 
     def test_bmm(self) -> None:
         """Test BMM with default config — exercises size_matches fix.


### PR DESCRIPTION
## Summary

Adds the Pallas backend matmul codegen and pipeline launcher infrastructure required to keep matmul work on the MXU and amortize HBM<->VMEM traffic across the K loop.

Five mechanisms land together:

1. **bf16/f16 2D pl.dot dispatch** — Routes MXU-legal tiles through pl.dot instead of lax.dot_general. Mosaic lowers pl.dot directly to the TPU MXU; the f32-input path still uses lax.dot_general with precision=Precision.HIGHEST.

2. **K-loop accumulator stays in pipeline VMEM** — The matmul accumulator is allocated in pipeline VMEM scratch instead of HBM, eliminating per-iteration HBM round-trips on the inner K reduction.

3. **Reduction-axis threading through default_pallas_pipeline_launcher** — New `_reduction_grid_dims` parameter marks reduction axes as "arbitrary" in dimension_semantics so the pipeliner does not assume cross-iteration independence.

4. **VMEM strip BlockSpecs for emit_pipeline outer in_specs** — Mirrors the hand-written reference's `(bm, K)` BlockSpecs so the pipeliner slices from VMEM instead of DMA-ing per inner iteration from HBM. Adds `_pipeline_vmem_strip_indices` + a per-byte budget guard.

5. **Outer-grid matmul strategy with M=1 NaN refusal + outer-pid DCE** — Lifts the K reduction inside emit_pipeline and rewrites the body so the outer grid only carries M, N. Refuses outer-grid when any outer tile dim is 1 (fixes a NaN reproducer on M=1 shapes) and DCEs the dead outer-pid reads.

## Perf

Measured on bf16 1024x1024x1024 headline matmul (TPU v7, median-of-3 seeds, paired interleaved-4way + 200-call jax.profiler trace):

| Metric | Before | After | Δ |
|---|---|---|---|
| Helion total us per call | ~83 | ~73 | **-10 us** |
| launcher_overhead_us | 77 | 75 | small |
| Helion kernel device us | ~6.7 | ~6.7 | flat |

Required prerequisite for the launcher PRs stacked on top (those reference `_reduction_grid_dims` and `_pipeline_vmem_strip_indices` in their cache key signatures).

## Test plan

- [x] `./lint.sh check` clean (ruff format, ruff check, codespell)
- [x] New pin tests in `test/test_pallas.py` for bf16 pl.dot dispatch, VMEM accumulator, outer-grid lowering, M=1 NaN fix
- [ ] TPU CI run

## Stack

This is the bottom of a 4-PR stack. The launcher PRs depend on the infrastructure here.