### PR TITLE
[pallas] fast-path host-side launcher with pre-computed cache entries

### DIFF
--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -543,6 +543,420 @@ def _pallas_check_dtypes(args: tuple[object, ...]) -> None:
             )
 
 
+# Per-call launcher fast-path: hoists the four host-side per-call iterations
+# (``_pallas_check_dtypes`` over args, ``_pallas_apply_ds_padding`` over
+# ``_ds_pad_dims``, ``_pallas_invoke_and_return``'s output-only loop, and the
+# ``input_tensors`` list comp) into a one-shot precomputation stored on the
+# cached launcher entry.  On a cache hit the launcher branches on a single
+# precomputed flag instead of iterating the same constant lists.  See
+# Deep Replan 2026-05-23 §2.7 in ``plan.md`` for the per-call dispatch cost
+# decomposition.
+_LAUNCHER_FAST_PATH_HITS = 0
+
+
+def _launcher_fast_path_hits() -> int:
+    """Return the count of fast-path cache-hit launcher invocations.
+
+    Test instrumentation: pin tests assert that a static-shape Pallas
+    kernel hit the fast path on second-and-later calls by reading this
+    counter before / after invocations.
+    """
+    return _LAUNCHER_FAST_PATH_HITS
+
+
+def _reset_launcher_fast_path_hits() -> None:
+    """Reset the fast-path counter (test instrumentation)."""
+    global _LAUNCHER_FAST_PATH_HITS
+    _LAUNCHER_FAST_PATH_HITS = 0
+
+
+# Per-call torch_tpu JaxCallable invocation-key cache hits.  See
+# ``_make_helion_static_jax_callable_class`` for how the cache is built:
+# the Helion ``JaxCallable`` subclass short-circuits torch_tpu's
+# ``_get_kernel_invocation_key`` (an f-string built from a per-call walk
+# of every arg's shape / dtype) when the arg signature matches the one
+# observed on the first call.  Pin tests bump / read this counter to
+# assert the static-shape kernel actually exercises the short-circuit
+# branch on repeat invocations.
+_JAXCALLABLE_KEY_CACHE_HITS = 0
+
+
+def _jaxcallable_key_cache_hits() -> int:
+    """Return the count of cached-invocation-key hits inside ``JaxCallable``.
+
+    Test instrumentation: pin tests assert that a static-shape Pallas
+    kernel reuses the cached invocation key on second-and-later calls
+    by reading this counter before / after invocations.
+    """
+    return _JAXCALLABLE_KEY_CACHE_HITS
+
+
+def _reset_jaxcallable_key_cache_hits() -> None:
+    """Reset the cached-invocation-key counter (test instrumentation)."""
+    global _JAXCALLABLE_KEY_CACHE_HITS
+    _JAXCALLABLE_KEY_CACHE_HITS = 0
+
+
+_HELION_STATIC_JAX_CALLABLE_CLASS: type | None = None
+
+
+def _make_helion_static_jax_callable_class() -> type:
+    """Build a ``JaxCallable`` subclass that caches torch_tpu's per-call
+    invocation key.
+
+    torch_tpu's ``JaxCallable.__call__`` runs four host-side steps on
+    every call:
+
+    1. ``_validate_args(*args)`` walks every arg checking
+       ``static_argnums`` membership / ``isinstance(torch.Tensor)``.
+    2. ``_get_kernel_invocation_key`` builds an f-string by iterating
+       every arg's ``shape`` and ``dtype``.  Measured at ~10-15us per
+       call on the headline (Deep Replan 2026-05-23 §2.7).
+    3. ``self.output_shapes.get(kernel_key, ...)`` dict lookup.
+    4. ``tpu_torch_pallas.lookup_custom_kernel(self.name, kernel_key)``
+       C++ call.
+
+    For ``static_shapes=True`` Helion kernels every cached launcher
+    entry maps to a single shape signature (the Helion-side launcher
+    cache is grid-keyed and ``static_shapes=True`` makes the grid
+    static), so the kernel invocation key is constant across every
+    call hitting a given JaxCallable.  The subclass caches the first
+    call's ``(arg_shape_dtype_signature, kernel_key, output_shapes,
+    out_tree, input_output_aliases_items)`` and reuses the cached
+    triple on every subsequent call with a matching signature.
+
+    Signature is built from each arg's ``shape`` and ``dtype`` so the
+    cache is safe to use even when the same JaxCallable is reused by a
+    dynamic-shape kernel (different shapes get the slow path until the
+    sig matches).  Helion calls JaxCallable as
+    ``jax_callable(*input_tensors)`` with already-filtered torch
+    tensors (no ``None`` values, no static args), so the per-arg sig
+    construction is dominated by tuple unpacking, not isinstance
+    checks.
+
+    The class is built lazily on first use so importing
+    ``helion.runtime`` doesn't require ``torch_tpu`` (the rest of the
+    runtime tolerates ``torch_tpu`` being absent in interpret mode).
+    """
+
+    global _HELION_STATIC_JAX_CALLABLE_CLASS
+    if _HELION_STATIC_JAX_CALLABLE_CLASS is not None:
+        return _HELION_STATIC_JAX_CALLABLE_CLASS
+
+    from torch_tpu._internal.pallas import (  # pyrefly: ignore[missing-import]
+        tpu_torch_pallas,
+    )
+    from torch_tpu._internal.pallas.pallas import (  # pyrefly: ignore[missing-import]
+        JaxCallable,
+    )
+
+    class _HelionStaticJaxCallable(JaxCallable):  # type: ignore[misc, valid-type]
+        """``JaxCallable`` with a pre-cached invocation key.
+
+        See ``_make_helion_static_jax_callable_class`` for context.
+        """
+
+        __slots__ = ("_helion_sig", "_helion_key_cache")
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            super().__init__(*args, **kwargs)  # type: ignore[misc]
+            # ``_helion_sig`` is a tuple ``(arg0_shape_dtype, arg1_..., ...)``
+            # used as a lightweight comparison key for the fast path.
+            # ``_helion_key_cache`` carries the cached triple ``(kernel_key,
+            # output_shapes, out_tree)`` plus a tuple of pre-iterated
+            # ``input_output_aliases.items()`` pairs so the per-call alias
+            # loop iterates a tuple instead of a dict.
+            self._helion_sig: tuple[object, ...] | None = None
+            self._helion_key_cache: (
+                tuple[str, object, object, tuple[tuple[int, int], ...]] | None
+            ) = None
+
+        def __call__(self, *args: object, **kwargs: object) -> object:
+            cached = self._helion_key_cache
+            if cached is not None and not kwargs:
+                # Compare against the cached arg signature.  ``args`` is
+                # the Helion-side already-filtered tuple of torch tensors;
+                # we trust that pattern and skip ``_validate_args``.
+                sig: tuple[object, ...] = tuple(
+                    (a.shape, a.dtype)  # type: ignore[attr-defined]
+                    for a in args
+                )
+                if sig == self._helion_sig:
+                    global _JAXCALLABLE_KEY_CACHE_HITS
+                    _JAXCALLABLE_KEY_CACHE_HITS += 1
+                    kernel_key, output_shapes, out_tree, alias_items = cached
+                    results = tpu_torch_pallas.call_custom_kernel(
+                        self.name,
+                        kernel_key,
+                        inputs=list(args),
+                        output_shapes=output_shapes,
+                        donate_argnums=self.donate_argnums,
+                    )
+                    for in_idx, out_idx in alias_items:
+                        args[in_idx].copy_(results[out_idx])  # type: ignore[attr-defined]
+                    return out_tree.unflatten(results)  # type: ignore[attr-defined]
+
+            # First call (or sig mismatch): run the base path which traces
+            # / registers / caches inside torch_tpu, then snapshot the
+            # invocation key for subsequent hot-path reuse.  ``super`` does
+            # the heavy lifting (trace, register, output_shapes cache,
+            # call_custom_kernel, copy_back, unflatten).  After it returns
+            # we know ``self.output_shapes`` contains the exact entry we
+            # need, so we mine it for the cached metadata.
+            result = super().__call__(*args, **kwargs)
+
+            # Snapshot the metadata used by the fast path.  We re-build
+            # the key once here (after the slow-path call already paid
+            # the cost) so subsequent calls can avoid it.  Skip the
+            # snapshot if kwargs is non-empty (we don't fast-path that
+            # case) or if the base path didn't populate output_shapes
+            # for any reason (defensive).
+            if kwargs or not self.output_shapes:
+                return result
+
+            from torch_tpu._internal.pallas.pallas import (  # pyrefly: ignore[missing-import]
+                _get_kernel_invocation_key,
+            )
+
+            kernel_key = _get_kernel_invocation_key(
+                self.trace_key, args, kwargs, self.static_argnums
+            )
+            cached_entry = self.output_shapes.get(kernel_key)
+            if cached_entry is None:
+                return result
+            output_shapes, out_tree = cached_entry
+            self._helion_sig = tuple(
+                (a.shape, a.dtype)  # type: ignore[attr-defined]
+                for a in args
+            )
+            self._helion_key_cache = (
+                kernel_key,
+                output_shapes,
+                out_tree,
+                tuple(self.input_output_aliases.items()),
+            )
+            return result
+
+    _HELION_STATIC_JAX_CALLABLE_CLASS = _HelionStaticJaxCallable
+    return _HelionStaticJaxCallable
+
+
+class _LauncherFastPath:
+    """Precomputed per-call state for a cached Pallas launcher entry.
+
+    Built once on the first call (the "cache build") and reused on every
+    subsequent call with the same grid / static-shape signature.  Allows
+    the launcher hot path to elide:
+
+    * ``_pallas_check_dtypes`` — dtypes are stable for static_shapes
+      kernels; the first-call check already raised on bad dtypes.
+    * ``_pallas_apply_ds_padding`` iteration when no arg actually needed
+      padding (``ds_pad_required == False``).
+    * ``_pallas_invoke_and_return``'s output-only-results loop when there
+      are no output-only tensors (``output_only_count == 0``).
+    * Re-construction of intermediate ``set`` / ``dict`` objects for the
+      ``_ds_pad_dims`` post-processing (we precompute the
+      ``orig_output_arg_indices`` set and per-arg dim lists).
+    """
+
+    __slots__ = (
+        "ds_pad_required",
+        "ds_pad_orig_output_arg_indices",
+        "output_only_count",
+        "output_only_descriptors",
+        "padded_output_arg_indices",
+        "padded_output_dims_by_arg",
+        "tensor_arg_indices_tuple",
+    )
+
+    def __init__(
+        self,
+        tensor_arg_indices: list[int],
+        arg_to_tensor_pos: dict[int, int],
+        _output_indices: list[int],
+        _ds_pad_dims: list[tuple[int, int, int, int]] | None,
+    ) -> None:
+        # Tuple form is faster than list for hot-path iteration in the
+        # ``input_tensors = [args[i].contiguous() ...]`` comprehension.
+        self.tensor_arg_indices_tuple: tuple[int, ...] = tuple(tensor_arg_indices)
+
+        # Precompute output-only descriptors as a tuple of ``(out_idx,
+        # orig_pos)``; the launcher's output-only loop iterates this
+        # directly instead of re-checking ``orig_pos not in
+        # arg_to_tensor_pos`` per iteration.
+        descriptors: list[tuple[int, int]] = [
+            (out_idx, orig_pos)
+            for out_idx, orig_pos in enumerate(_output_indices)
+            if orig_pos not in arg_to_tensor_pos
+        ]
+        self.output_only_descriptors: tuple[tuple[int, int], ...] = tuple(descriptors)
+        self.output_only_count: int = len(descriptors)
+
+        # ds_pad postprocessing precomputation.  ``ds_pad_required`` is
+        # set on the first call once we know whether any pad amount is
+        # non-zero for the static-shape signature.  ``None`` means
+        # "compute it now" (sentinel for the first-call fall-through).
+        self.ds_pad_required: bool | None = None
+
+        if _ds_pad_dims:
+            output_arg_set = set(_output_indices)
+            # Pre-bucket the per-arg dim lists used by
+            # ``_pallas_invoke_and_return`` for the post-call slice
+            # copy-back / result slicing.
+            padded_dims_by_arg: dict[int, list[int]] = {}
+            padded_output_arg_indices: set[int] = set()
+            for arg_idx, dim, _bs, _extra in _ds_pad_dims:
+                if arg_idx in output_arg_set:
+                    padded_dims_by_arg.setdefault(arg_idx, []).append(dim)
+                    padded_output_arg_indices.add(arg_idx)
+            self.padded_output_dims_by_arg: dict[int, list[int]] = padded_dims_by_arg
+            self.padded_output_arg_indices: frozenset[int] = frozenset(
+                padded_output_arg_indices
+            )
+            self.ds_pad_orig_output_arg_indices: frozenset[int] = frozenset(
+                idx for idx in padded_output_arg_indices if idx in arg_to_tensor_pos
+            )
+        else:
+            self.padded_output_dims_by_arg = {}
+            self.padded_output_arg_indices = frozenset()
+            self.ds_pad_orig_output_arg_indices = frozenset()
+
+
+def _pallas_apply_ds_padding_fast(
+    args: tuple[object, ...],
+    _ds_pad_dims: list[tuple[int, int, int, int]],
+    fast_path: _LauncherFastPath,
+    padded_output_arg_indices: frozenset[int],
+) -> tuple[tuple[object, ...], dict[int, torch.Tensor] | None, bool]:
+    """``_pallas_apply_ds_padding`` with a precomputed-fast-path short-circuit.
+
+    Computes ``pad_amount`` per entry; if every entry is zero (the common
+    case once the autotuner picks block sizes that divide the static
+    shape), returns ``(args, None, False)`` so the launcher skips the
+    pad allocation and the post-call copy-back.  On first call also
+    flips ``fast_path.ds_pad_required`` so subsequent calls can elide
+    this iteration entirely.
+    """
+    args_list: list[object] | None = None
+    orig_output_tensors: dict[int, torch.Tensor] | None = None
+    any_padding = False
+    for arg_idx, dim, block_size, extra_pad in _ds_pad_dims:
+        a = args[arg_idx] if args_list is None else args_list[arg_idx]
+        if not isinstance(a, torch.Tensor):
+            continue
+        pad_amount = (-a.shape[dim]) % block_size + extra_pad
+        if pad_amount == 0:
+            continue
+        any_padding = True
+        if args_list is None:
+            args_list = list(args)
+        if arg_idx in padded_output_arg_indices:
+            if orig_output_tensors is None:
+                orig_output_tensors = {}
+            if arg_idx not in orig_output_tensors:
+                orig_output_tensors[arg_idx] = cast("torch.Tensor", a)
+        pad_widths = [0] * (2 * a.ndim)
+        pad_widths[2 * (a.ndim - 1 - dim) + 1] = pad_amount
+        args_list[arg_idx] = torch.nn.functional.pad(a, pad_widths)
+    if fast_path.ds_pad_required is None:
+        # First-call precomputation: lock in whether any pad amount is
+        # non-zero so subsequent calls can elide the iteration outright.
+        fast_path.ds_pad_required = any_padding
+    if args_list is None:
+        return args, None, False
+    return tuple(args_list), orig_output_tensors, True
+
+
+def _pallas_invoke_and_return_fast(
+    jax_callable: object,
+    args: tuple[object, ...],
+    fast_path: _LauncherFastPath,
+    _orig_output_tensors: dict[int, torch.Tensor] | None,
+) -> object:
+    """Hot-path version of ``_pallas_invoke_and_return``.
+
+    Reads the precomputed ``fast_path`` to:
+
+    * Skip the ``output_only_results`` loop when ``output_only_count == 0``.
+    * Skip the ``_ds_pad_dims`` post-processing when
+      ``_orig_output_tensors is None``.
+    * Iterate the precomputed ``output_only_descriptors`` tuple instead
+      of zipping over ``_output_indices`` and checking
+      ``arg_to_tensor_pos`` membership per iteration.
+    """
+    tensor_arg_indices = fast_path.tensor_arg_indices_tuple
+    input_tensors = [
+        cast("torch.Tensor", args[i]).contiguous() for i in tensor_arg_indices
+    ]
+    results = jax_callable(*input_tensors)  # type: ignore[operator]
+
+    output_only_count = fast_path.output_only_count
+    if output_only_count == 0 and _orig_output_tensors is None:
+        # Hottest path: no output-only tensors, no ds-pad postprocess.
+        # The JaxCallable already wrote any in-place outputs through
+        # the donated input/output aliases.
+        return None
+
+    if results is None:
+        return None
+    if not isinstance(results, (tuple, list)):
+        results = (results,)
+
+    output_only_results: list[object] = []
+    if output_only_count > 0:
+        for out_idx, orig_pos in fast_path.output_only_descriptors:
+            result = results[out_idx]
+            if not isinstance(result, torch.Tensor):
+                # Interpret mode: pallas_call returns JAX arrays.
+                out_tensor = cast("torch.Tensor", args[orig_pos])
+                device = out_tensor.device
+                if device.type == "meta":
+                    device = torch.device("cpu")
+                result = _jax_to_torch(result, device=device, dtype=out_tensor.dtype)
+            output_only_results.append(result)
+
+    if _orig_output_tensors is not None:
+        padded_dims_by_arg = fast_path.padded_output_dims_by_arg
+        # Copy sliced results back into original in-place output tensors.
+        for arg_idx in fast_path.ds_pad_orig_output_arg_indices:
+            orig_tensor = _orig_output_tensors.get(arg_idx)
+            if orig_tensor is None:
+                continue
+            dims = padded_dims_by_arg.get(arg_idx)
+            if not dims:
+                continue
+            padded = cast("torch.Tensor", args[arg_idx])
+            slices = [slice(None)] * padded.ndim
+            for dim in dims:
+                slices[dim] = slice(None, orig_tensor.shape[dim])
+            orig_tensor.copy_(padded[tuple(slices)])
+
+        # Slice padded output-only results back to original shapes.
+        if output_only_results:
+            for compacted_idx, (_, orig_pos) in enumerate(
+                fast_path.output_only_descriptors
+            ):
+                orig = _orig_output_tensors.get(orig_pos)
+                dims = padded_dims_by_arg.get(orig_pos)
+                if (
+                    orig is not None
+                    and dims
+                    and compacted_idx < len(output_only_results)
+                ):
+                    t = output_only_results[compacted_idx]
+                    if isinstance(t, torch.Tensor):
+                        slices = [slice(None)] * t.ndim
+                        for dim in dims:
+                            slices[dim] = slice(None, orig.shape[dim])
+                        output_only_results[compacted_idx] = t[tuple(slices)]
+
+    if output_only_count == 0:
+        return None
+    if output_only_count == 1:
+        return output_only_results[0]
+    return tuple(output_only_results)
+
+
 def _pallas_prepare_args(
     args: tuple[object, ...],
     _output_indices: list[int],
@@ -706,14 +1120,19 @@ def _pallas_build_callable(
         return _make_interpret_callable()
 
     import jax
-    from torch_tpu._internal.pallas.pallas import (  # pyrefly: ignore[missing-import]
-        JaxCallable,
-    )
 
     kernel_name = getattr(pallas_kernel, "__name__", "pallas_kernel")
 
     jax.config.update("jax_export_ignore_forward_compatibility", True)
-    jax_callable = JaxCallable(
+    # Use a JaxCallable subclass that caches torch_tpu's per-call
+    # invocation key (see ``_make_helion_static_jax_callable_class`` for
+    # the rationale).  The subclass falls back to the base ``__call__``
+    # whenever the arg sig differs from the first observed sig, so the
+    # short-circuit only fires when shapes / dtypes are stable across
+    # calls -- the static_shapes=True common case.  Dynamic-shape kernels
+    # still go through the base path until the sig matches.
+    callable_cls = _make_helion_static_jax_callable_class()
+    jax_callable = callable_cls(
         name=kernel_name,
         jit_fn=jax.jit(jit_fn),
         trace_key=f"{kernel_name}_{id(pallas_kernel)}_{grid}{trace_key_suffix}",
@@ -947,7 +1366,34 @@ def default_pallas_launcher(
     if _output_indices is None:
         _output_indices = []
 
-    _orig_output_tensors: dict[int, torch.Tensor] | None = None
+    cache = getattr(pallas_kernel, "_pallas_cache", None)
+    if cache is not None and cache[0] == grid:
+        global _LAUNCHER_FAST_PATH_HITS
+        _LAUNCHER_FAST_PATH_HITS += 1
+        (
+            _,
+            jax_callable,
+            tensor_arg_indices,
+            arg_to_tensor_pos,
+            fast_path,
+        ) = cache
+
+        _orig_output_tensors: dict[int, torch.Tensor] | None = None
+        if _ds_pad_dims and fast_path.ds_pad_required is not False:
+            args, _orig_output_tensors, _ = _pallas_apply_ds_padding_fast(
+                args,
+                _ds_pad_dims,
+                fast_path,
+                fast_path.padded_output_arg_indices,
+            )
+        # ``_pallas_check_dtypes`` is elided on cache-hit: the first
+        # call already validated and any dtype-incompatible call after
+        # would fail loudly inside ``JaxCallable.__call__``.
+        return _pallas_invoke_and_return_fast(
+            jax_callable, args, fast_path, _orig_output_tensors
+        )
+
+    _orig_output_tensors = None
     if _ds_pad_dims:
         args, _orig_output_tensors = _pallas_apply_ds_padding(
             args, _output_indices, _ds_pad_dims
@@ -955,98 +1401,110 @@ def default_pallas_launcher(
 
     _pallas_check_dtypes(args)
 
-    cache = getattr(pallas_kernel, "_pallas_cache", None)
-    if cache is not None and cache[0] == grid:
-        _, jax_callable, tensor_arg_indices, arg_to_tensor_pos = cache
-    else:
-        from jax.experimental import pallas as pl
-        from jax.experimental.pallas import tpu as pltpu
-        import jax.numpy as jnp
+    from jax.experimental import pallas as pl
+    from jax.experimental.pallas import tpu as pltpu
+    import jax.numpy as jnp
 
-        (
-            tensor_arg_indices,
-            output_only_indices,
-            non_tensor_args,
-            n_tensor_inputs,
-            arg_to_tensor_pos,
-            inplace_positions,
-            out_shapes,
-            pallas_aliases,
-        ) = _pallas_prepare_args(
-            args, _output_indices, _inplace_indices, interpret=interpret
+    (
+        tensor_arg_indices,
+        output_only_indices,
+        non_tensor_args,
+        n_tensor_inputs,
+        arg_to_tensor_pos,
+        inplace_positions,
+        out_shapes,
+        pallas_aliases,
+    ) = _pallas_prepare_args(
+        args, _output_indices, _inplace_indices, interpret=interpret
+    )
+
+    in_specs, out_specs = _pallas_build_block_specs(
+        pl,
+        jnp,
+        pltpu,
+        grid,
+        args,
+        tensor_arg_indices,
+        _output_indices,
+        _block_spec_info,
+        _smem_arg_indices,
+        output_only_indices,
+    )
+
+    reordered_kernel = _pallas_make_reordered_kernel(
+        pallas_kernel,
+        args,
+        tensor_arg_indices,
+        non_tensor_args,
+        n_tensor_inputs,
+        _output_indices,
+        inplace_positions,
+        arg_to_tensor_pos,
+        _smem_arg_indices=_smem_arg_indices,
+    )
+
+    out_shape_arg = out_shapes if len(out_shapes) > 1 else out_shapes[0]
+
+    estimated_vmem = _estimate_pallas_vmem_bytes(
+        pl,
+        pltpu,
+        in_specs,
+        out_specs,
+        None,
+        args,
+        tensor_arg_indices,
+        _output_indices,
+        pallas_aliases,
+    )
+    vmem_limit_bytes = _get_vmem_limit_bytes(pltpu)
+    if estimated_vmem > vmem_limit_bytes:
+        raise RuntimeError(
+            f"XLA:TPU compile permanent error. Ran out of memory in memory space vmem. "
+            f"Estimated {estimated_vmem / 1e6:.2f}MB exceeds {vmem_limit_bytes / 1e6:.2f}MB vmem capacity."
         )
 
-        in_specs, out_specs = _pallas_build_block_specs(
-            pl,
-            jnp,
-            pltpu,
-            grid,
-            args,
-            tensor_arg_indices,
-            _output_indices,
-            _block_spec_info,
-            _smem_arg_indices,
-            output_only_indices,
-        )
+    pallas_call_kwargs: dict[str, object] = {
+        "out_shape": out_shape_arg,
+        "grid": grid,
+    }
+    if interpret:
+        pallas_call_kwargs["interpret"] = True
+    if in_specs is not None:
+        pallas_call_kwargs["in_specs"] = in_specs
+        pallas_call_kwargs["out_specs"] = out_specs
 
-        reordered_kernel = _pallas_make_reordered_kernel(
-            pallas_kernel,
-            args,
-            tensor_arg_indices,
-            non_tensor_args,
-            n_tensor_inputs,
-            _output_indices,
-            inplace_positions,
-            arg_to_tensor_pos,
-            _smem_arg_indices=_smem_arg_indices,
-        )
+    jit_fn = pl.pallas_call(
+        reordered_kernel,  # pyrefly: ignore[bad-argument-type]
+        **pallas_call_kwargs,  # type: ignore[arg-type]
+    )
 
-        out_shape_arg = out_shapes if len(out_shapes) > 1 else out_shapes[0]
+    jax_callable = _pallas_build_callable(
+        pallas_kernel,
+        grid,
+        jit_fn,
+        _output_indices,
+        arg_to_tensor_pos,
+        tensor_arg_indices,
+        cache_attr="_pallas_cache",
+        call_aliases=pallas_aliases,
+        interpret=interpret,
+    )
 
-        estimated_vmem = _estimate_pallas_vmem_bytes(
-            pl,
-            pltpu,
-            in_specs,
-            out_specs,
-            None,
-            args,
-            tensor_arg_indices,
-            _output_indices,
-            pallas_aliases,
-        )
-        vmem_limit_bytes = _get_vmem_limit_bytes(pltpu)
-        if estimated_vmem > vmem_limit_bytes:
-            raise RuntimeError(
-                f"XLA:TPU compile permanent error. Ran out of memory in memory space vmem. "
-                f"Estimated {estimated_vmem / 1e6:.2f}MB exceeds {vmem_limit_bytes / 1e6:.2f}MB vmem capacity."
-            )
-
-        pallas_call_kwargs: dict[str, object] = {
-            "out_shape": out_shape_arg,
-            "grid": grid,
-        }
-        if interpret:
-            pallas_call_kwargs["interpret"] = True
-        if in_specs is not None:
-            pallas_call_kwargs["in_specs"] = in_specs
-            pallas_call_kwargs["out_specs"] = out_specs
-
-        jit_fn = pl.pallas_call(
-            reordered_kernel,  # pyrefly: ignore[bad-argument-type]
-            **pallas_call_kwargs,  # type: ignore[arg-type]
-        )
-
-        jax_callable = _pallas_build_callable(
-            pallas_kernel,
-            grid,
-            jit_fn,
-            _output_indices,
-            arg_to_tensor_pos,
-            tensor_arg_indices,
-            cache_attr="_pallas_cache",
-            call_aliases=pallas_aliases,
-            interpret=interpret,
-        )
+    fast_path = _LauncherFastPath(
+        tensor_arg_indices,
+        arg_to_tensor_pos,
+        _output_indices,
+        _ds_pad_dims,
+    )
+    # Extend the cache tuple with the fast-path metadata.  See
+    # ``_pallas_build_callable`` for the base 4-tuple shape.
+    pallas_kernel._pallas_cache = (  # pyrefly: ignore[missing-attribute]
+        grid,
+        jax_callable,
+        tensor_arg_indices,
+        arg_to_tensor_pos,
+        fast_path,
+    )
 
     return _pallas_invoke_and_return(
         jax_callable,
@@ -1103,7 +1561,31 @@ def default_pallas_pipeline_launcher(
     if _scratch_shapes is None:
         _scratch_shapes = []
 
-    _orig_output_tensors: dict[int, torch.Tensor] | None = None
+    cache = getattr(pallas_kernel, "_pallas_pipeline_cache", None)
+    if cache is not None and cache[0] == grid:
+        global _LAUNCHER_FAST_PATH_HITS
+        _LAUNCHER_FAST_PATH_HITS += 1
+        (
+            _,
+            jax_callable,
+            tensor_arg_indices,
+            arg_to_tensor_pos,
+            fast_path,
+        ) = cache
+
+        _orig_output_tensors: dict[int, torch.Tensor] | None = None
+        if _ds_pad_dims and fast_path.ds_pad_required is not False:
+            args, _orig_output_tensors, _ = _pallas_apply_ds_padding_fast(
+                args,
+                _ds_pad_dims,
+                fast_path,
+                fast_path.padded_output_arg_indices,
+            )
+        return _pallas_invoke_and_return_fast(
+            jax_callable, args, fast_path, _orig_output_tensors
+        )
+
+    _orig_output_tensors = None
     if _ds_pad_dims:
         args, _orig_output_tensors = _pallas_apply_ds_padding(
             args, _output_indices, _ds_pad_dims
@@ -1111,137 +1593,147 @@ def default_pallas_pipeline_launcher(
 
     _pallas_check_dtypes(args)
 
-    cache = getattr(pallas_kernel, "_pallas_pipeline_cache", None)
-    if cache is not None and cache[0] == grid:
-        _, jax_callable, tensor_arg_indices, arg_to_tensor_pos = cache
-    else:
-        from jax.experimental import pallas as pl
-        from jax.experimental.pallas import tpu as pltpu
-        import jax.numpy as jnp
+    from jax.experimental import pallas as pl
+    from jax.experimental.pallas import tpu as pltpu
+    import jax.numpy as jnp
 
-        (
-            tensor_arg_indices,
-            output_only_indices,
-            non_tensor_args,
-            n_tensor_inputs,
-            arg_to_tensor_pos,
-            inplace_positions,
-            out_shapes,
-            pallas_aliases,
-        ) = _pallas_prepare_args(
-            args, _output_indices, _inplace_indices, interpret=interpret
-        )
+    (
+        tensor_arg_indices,
+        output_only_indices,
+        non_tensor_args,
+        n_tensor_inputs,
+        arg_to_tensor_pos,
+        inplace_positions,
+        out_shapes,
+        pallas_aliases,
+    ) = _pallas_prepare_args(
+        args, _output_indices, _inplace_indices, interpret=interpret
+    )
 
-        # Build scratch shapes for VMEM
-        _jnp_dtype_map = _pallas_jnp_dtype_map()
-        scratch_shapes = []
-        for scratch_entry in _scratch_shapes:
-            if len(scratch_entry) == 3:
-                shape, dtype_str, scratch_type = scratch_entry
-            else:
-                shape, dtype_str = scratch_entry  # type: ignore[misc]
-                scratch_type = "vmem"
-            if scratch_type == "dma_semaphore":
-                scratch_shapes.append(pltpu.SemaphoreType.DMA(()))
-            else:
-                jnp_dtype = _jnp_dtype_map.get(dtype_str, jnp.float32)
-                scratch_shapes.append(
-                    pltpu.VMEM(shape, jnp_dtype)  # pyrefly: ignore[bad-argument-type]
-                )
-
-        assert _block_spec_info is not None, (
-            "emit_pipeline launcher requires _block_spec_info from codegen"
-        )
-        in_specs_list, out_specs = _pallas_build_pipeline_specs(
-            pl,
-            jnp,
-            pltpu,
-            grid,
-            args,
-            tensor_arg_indices,
-            _output_indices,
-            _block_spec_info,
-            _pipeline_arg_indices,
-            output_only_indices,
-            smem_arg_indices=_smem_arg_indices,
-            pipeline_vmem_strip_indices=_pipeline_vmem_strip_indices,
-        )
-
-        _pipeline_set = set(_pipeline_arg_indices or [])
-        reordered_kernel = _pallas_make_reordered_kernel(
-            pallas_kernel,
-            args,
-            tensor_arg_indices,
-            non_tensor_args,
-            n_tensor_inputs,
-            _output_indices,
-            inplace_positions,
-            arg_to_tensor_pos,
-            n_extra_refs=len(scratch_shapes),
-            skip_inplace_copy=_pipeline_set,
-            _smem_arg_indices=_smem_arg_indices,
-        )
-
-        out_shape_arg = out_shapes if len(out_shapes) > 1 else out_shapes[0]
-
-        grid_spec = pltpu.PrefetchScalarGridSpec(
-            num_scalar_prefetch=0,
-            in_specs=in_specs_list,
-            out_specs=out_specs,
-            scratch_shapes=scratch_shapes,
-            grid=grid,
-        )
-
-        estimated_vmem = _estimate_pallas_vmem_bytes(
-            pl,
-            pltpu,
-            in_specs_list,
-            out_specs,
-            scratch_shapes,
-            args,
-            tensor_arg_indices,
-            _output_indices,
-            pallas_aliases,
-        )
-        vmem_limit_bytes = _get_vmem_limit_bytes(pltpu)
-        if estimated_vmem > vmem_limit_bytes:
-            raise RuntimeError(
-                f"XLA:TPU compile permanent error. Ran out of memory in memory space vmem. "
-                f"Estimated {estimated_vmem / 1e6:.2f}MB exceeds {vmem_limit_bytes / 1e6:.2f}MB vmem capacity."
+    # Build scratch shapes for VMEM
+    _jnp_dtype_map = _pallas_jnp_dtype_map()
+    scratch_shapes = []
+    for scratch_entry in _scratch_shapes:
+        if len(scratch_entry) == 3:
+            shape, dtype_str, scratch_type = scratch_entry
+        else:
+            shape, dtype_str = scratch_entry  # type: ignore[misc]
+            scratch_type = "vmem"
+        if scratch_type == "dma_semaphore":
+            scratch_shapes.append(pltpu.SemaphoreType.DMA(()))
+        else:
+            jnp_dtype = _jnp_dtype_map.get(dtype_str, jnp.float32)
+            scratch_shapes.append(
+                pltpu.VMEM(shape, jnp_dtype)  # pyrefly: ignore[bad-argument-type]
             )
 
-        reduction_grid_dims = set(_reduction_grid_dims or [])
-        dim_semantics = tuple(
-            "arbitrary" if g in reduction_grid_dims else "parallel"
-            for g in range(len(grid))
-        )
-        pallas_call_kwargs: dict[str, object] = {
-            "out_shape": out_shape_arg,
-            "grid_spec": grid_spec,
-            "compiler_params": pltpu.CompilerParams(  # pyrefly: ignore[bad-instantiation]
-                dimension_semantics=dim_semantics,  # pyrefly: ignore[bad-argument-type]
-            ),
-        }
-        if interpret:
-            pallas_call_kwargs["interpret"] = True
+    assert _block_spec_info is not None, (
+        "emit_pipeline launcher requires _block_spec_info from codegen"
+    )
+    in_specs_list, out_specs = _pallas_build_pipeline_specs(
+        pl,
+        jnp,
+        pltpu,
+        grid,
+        args,
+        tensor_arg_indices,
+        _output_indices,
+        _block_spec_info,
+        _pipeline_arg_indices,
+        output_only_indices,
+        smem_arg_indices=_smem_arg_indices,
+        pipeline_vmem_strip_indices=_pipeline_vmem_strip_indices,
+    )
 
-        jit_fn = pl.pallas_call(
-            reordered_kernel,  # pyrefly: ignore[bad-argument-type]
-            **pallas_call_kwargs,  # type: ignore[arg-type]
+    _pipeline_set = set(_pipeline_arg_indices or [])
+    reordered_kernel = _pallas_make_reordered_kernel(
+        pallas_kernel,
+        args,
+        tensor_arg_indices,
+        non_tensor_args,
+        n_tensor_inputs,
+        _output_indices,
+        inplace_positions,
+        arg_to_tensor_pos,
+        n_extra_refs=len(scratch_shapes),
+        skip_inplace_copy=_pipeline_set,
+        _smem_arg_indices=_smem_arg_indices,
+    )
+
+    out_shape_arg = out_shapes if len(out_shapes) > 1 else out_shapes[0]
+
+    grid_spec = pltpu.PrefetchScalarGridSpec(
+        num_scalar_prefetch=0,
+        in_specs=in_specs_list,
+        out_specs=out_specs,
+        scratch_shapes=scratch_shapes,
+        grid=grid,
+    )
+
+    estimated_vmem = _estimate_pallas_vmem_bytes(
+        pl,
+        pltpu,
+        in_specs_list,
+        out_specs,
+        scratch_shapes,
+        args,
+        tensor_arg_indices,
+        _output_indices,
+        pallas_aliases,
+    )
+    vmem_limit_bytes = _get_vmem_limit_bytes(pltpu)
+    if estimated_vmem > vmem_limit_bytes:
+        raise RuntimeError(
+            f"XLA:TPU compile permanent error. Ran out of memory in memory space vmem. "
+            f"Estimated {estimated_vmem / 1e6:.2f}MB exceeds {vmem_limit_bytes / 1e6:.2f}MB vmem capacity."
         )
 
-        jax_callable = _pallas_build_callable(
-            pallas_kernel,
-            grid,
-            jit_fn,
-            _output_indices,
-            arg_to_tensor_pos,
-            tensor_arg_indices,
-            cache_attr="_pallas_pipeline_cache",
-            call_aliases=pallas_aliases,
-            trace_key_suffix="_pipeline",
-            interpret=interpret,
-        )
+    reduction_grid_dims = set(_reduction_grid_dims or [])
+    dim_semantics = tuple(
+        "arbitrary" if g in reduction_grid_dims else "parallel"
+        for g in range(len(grid))
+    )
+    pallas_call_kwargs: dict[str, object] = {
+        "out_shape": out_shape_arg,
+        "grid_spec": grid_spec,
+        "compiler_params": pltpu.CompilerParams(  # pyrefly: ignore[bad-instantiation]
+            dimension_semantics=dim_semantics,  # pyrefly: ignore[bad-argument-type]
+        ),
+    }
+    if interpret:
+        pallas_call_kwargs["interpret"] = True
+
+    jit_fn = pl.pallas_call(
+        reordered_kernel,  # pyrefly: ignore[bad-argument-type]
+        **pallas_call_kwargs,  # type: ignore[arg-type]
+    )
+
+    jax_callable = _pallas_build_callable(
+        pallas_kernel,
+        grid,
+        jit_fn,
+        _output_indices,
+        arg_to_tensor_pos,
+        tensor_arg_indices,
+        cache_attr="_pallas_pipeline_cache",
+        call_aliases=pallas_aliases,
+        trace_key_suffix="_pipeline",
+        interpret=interpret,
+    )
+
+    fast_path = _LauncherFastPath(
+        tensor_arg_indices,
+        arg_to_tensor_pos,
+        _output_indices,
+        _ds_pad_dims,
+    )
+    pallas_kernel._pallas_pipeline_cache = (  # pyrefly: ignore[missing-attribute]
+        grid,
+        jax_callable,
+        tensor_arg_indices,
+        arg_to_tensor_pos,
+        fast_path,
+    )
 
     return _pallas_invoke_and_return(
         jax_callable,
@@ -1295,7 +1787,31 @@ def default_pallas_fori_launcher(
     if _scratch_shapes is None:
         _scratch_shapes = []
 
-    _orig_output_tensors: dict[int, torch.Tensor] | None = None
+    cache = getattr(pallas_kernel, "_pallas_fori_cache", None)
+    if cache is not None and cache[0] == grid:
+        global _LAUNCHER_FAST_PATH_HITS
+        _LAUNCHER_FAST_PATH_HITS += 1
+        (
+            _,
+            jax_callable,
+            tensor_arg_indices,
+            arg_to_tensor_pos,
+            fast_path,
+        ) = cache
+
+        _orig_output_tensors: dict[int, torch.Tensor] | None = None
+        if _ds_pad_dims and fast_path.ds_pad_required is not False:
+            args, _orig_output_tensors, _ = _pallas_apply_ds_padding_fast(
+                args,
+                _ds_pad_dims,
+                fast_path,
+                fast_path.padded_output_arg_indices,
+            )
+        return _pallas_invoke_and_return_fast(
+            jax_callable, args, fast_path, _orig_output_tensors
+        )
+
+    _orig_output_tensors = None
     if _ds_pad_dims:
         args, _orig_output_tensors = _pallas_apply_ds_padding(
             args, _output_indices, _ds_pad_dims
@@ -1303,135 +1819,145 @@ def default_pallas_fori_launcher(
 
     _pallas_check_dtypes(args)
 
-    cache = getattr(pallas_kernel, "_pallas_fori_cache", None)
-    if cache is not None and cache[0] == grid:
-        _, jax_callable, tensor_arg_indices, arg_to_tensor_pos = cache
-    else:
-        from jax.experimental import pallas as pl
-        from jax.experimental.pallas import tpu as pltpu
-        import jax.numpy as jnp
+    from jax.experimental import pallas as pl
+    from jax.experimental.pallas import tpu as pltpu
+    import jax.numpy as jnp
 
-        (
-            tensor_arg_indices,
-            output_only_indices,
-            non_tensor_args,
-            n_tensor_inputs,
-            arg_to_tensor_pos,
-            inplace_positions,
-            out_shapes,
-            pallas_aliases,
-        ) = _pallas_prepare_args(
-            args, _output_indices, _inplace_indices, interpret=interpret
-        )
+    (
+        tensor_arg_indices,
+        output_only_indices,
+        non_tensor_args,
+        n_tensor_inputs,
+        arg_to_tensor_pos,
+        inplace_positions,
+        out_shapes,
+        pallas_aliases,
+    ) = _pallas_prepare_args(
+        args, _output_indices, _inplace_indices, interpret=interpret
+    )
 
-        # Build scratch shapes: VMEM buffers + DMA semaphores
-        _jnp_dtype_map = _pallas_jnp_dtype_map()
-        scratch_shapes = []
-        for shape, dtype_str, scratch_type in _scratch_shapes:
-            if scratch_type == "dma_semaphore":
-                scratch_shapes.append(pltpu.SemaphoreType.DMA(()))
-            else:  # "vmem"
-                assert dtype_str is not None
-                jnp_dtype = _jnp_dtype_map.get(dtype_str, jnp.float32)
-                scratch_shapes.append(
-                    pltpu.VMEM(shape, jnp_dtype)  # pyrefly: ignore[bad-argument-type]
-                )
-
-        # Build in_specs/out_specs: proper BlockSpecs for outer grid dims,
-        # HBM refs for tensors used in the fori_loop body (DMA handles tiling).
-        _fori_pipeline_indices = kwargs.get("_pipeline_arg_indices")
-        assert _block_spec_info is not None, (
-            "fori_loop launcher requires _block_spec_info from codegen"
-        )
-        in_specs_list, out_specs = _pallas_build_pipeline_specs(
-            pl,
-            jnp,
-            pltpu,
-            grid,
-            args,
-            tensor_arg_indices,
-            _output_indices,
-            _block_spec_info,
-            _fori_pipeline_indices,  # type: ignore[arg-type]
-            output_only_indices,
-            smem_arg_indices=_smem_arg_indices,
-        )
-
-        _fori_pipeline_set = set(_fori_pipeline_indices or [])  # type: ignore[arg-type]
-        reordered_kernel = _pallas_make_reordered_kernel(
-            pallas_kernel,
-            args,
-            tensor_arg_indices,
-            non_tensor_args,
-            n_tensor_inputs,
-            _output_indices,
-            inplace_positions,
-            arg_to_tensor_pos,
-            n_extra_refs=len(scratch_shapes),
-            skip_inplace_copy=_fori_pipeline_set,
-            _smem_arg_indices=_smem_arg_indices,
-        )
-
-        out_shape_arg = out_shapes if len(out_shapes) > 1 else out_shapes[0]
-
-        grid_spec = pltpu.PrefetchScalarGridSpec(
-            num_scalar_prefetch=0,
-            in_specs=in_specs_list,
-            out_specs=out_specs,
-            scratch_shapes=scratch_shapes,
-            grid=grid,
-        )
-
-        estimated_vmem = _estimate_pallas_vmem_bytes(
-            pl,
-            pltpu,
-            in_specs_list,
-            out_specs,
-            scratch_shapes,
-            args,
-            tensor_arg_indices,
-            _output_indices,
-            pallas_aliases,
-        )
-        vmem_limit_bytes = _get_vmem_limit_bytes(pltpu)
-        if estimated_vmem > vmem_limit_bytes:
-            raise RuntimeError(
-                f"XLA:TPU compile permanent error. Ran out of memory in memory space vmem. "
-                f"Estimated {estimated_vmem / 1e6:.2f}MB exceeds {vmem_limit_bytes / 1e6:.2f}MB vmem capacity."
+    # Build scratch shapes: VMEM buffers + DMA semaphores
+    _jnp_dtype_map = _pallas_jnp_dtype_map()
+    scratch_shapes = []
+    for shape, dtype_str, scratch_type in _scratch_shapes:
+        if scratch_type == "dma_semaphore":
+            scratch_shapes.append(pltpu.SemaphoreType.DMA(()))
+        else:  # "vmem"
+            assert dtype_str is not None
+            jnp_dtype = _jnp_dtype_map.get(dtype_str, jnp.float32)
+            scratch_shapes.append(
+                pltpu.VMEM(shape, jnp_dtype)  # pyrefly: ignore[bad-argument-type]
             )
 
-        reduction_grid_dims = set(_reduction_grid_dims or [])
-        dim_semantics = tuple(
-            "arbitrary" if g in reduction_grid_dims else "parallel"
-            for g in range(len(grid))
-        )
-        pallas_call_kwargs: dict[str, object] = {
-            "out_shape": out_shape_arg,
-            "grid_spec": grid_spec,
-            "compiler_params": pltpu.CompilerParams(  # pyrefly: ignore[bad-instantiation]
-                dimension_semantics=dim_semantics,  # pyrefly: ignore[bad-argument-type]
-            ),
-        }
-        if interpret:
-            pallas_call_kwargs["interpret"] = True
+    # Build in_specs/out_specs: proper BlockSpecs for outer grid dims,
+    # HBM refs for tensors used in the fori_loop body (DMA handles tiling).
+    _fori_pipeline_indices = kwargs.get("_pipeline_arg_indices")
+    assert _block_spec_info is not None, (
+        "fori_loop launcher requires _block_spec_info from codegen"
+    )
+    in_specs_list, out_specs = _pallas_build_pipeline_specs(
+        pl,
+        jnp,
+        pltpu,
+        grid,
+        args,
+        tensor_arg_indices,
+        _output_indices,
+        _block_spec_info,
+        _fori_pipeline_indices,  # type: ignore[arg-type]
+        output_only_indices,
+        smem_arg_indices=_smem_arg_indices,
+    )
 
-        jit_fn = pl.pallas_call(
-            reordered_kernel,  # pyrefly: ignore[bad-argument-type]
-            **pallas_call_kwargs,  # type: ignore[arg-type]
+    _fori_pipeline_set = set(_fori_pipeline_indices or [])  # type: ignore[arg-type]
+    reordered_kernel = _pallas_make_reordered_kernel(
+        pallas_kernel,
+        args,
+        tensor_arg_indices,
+        non_tensor_args,
+        n_tensor_inputs,
+        _output_indices,
+        inplace_positions,
+        arg_to_tensor_pos,
+        n_extra_refs=len(scratch_shapes),
+        skip_inplace_copy=_fori_pipeline_set,
+        _smem_arg_indices=_smem_arg_indices,
+    )
+
+    out_shape_arg = out_shapes if len(out_shapes) > 1 else out_shapes[0]
+
+    grid_spec = pltpu.PrefetchScalarGridSpec(
+        num_scalar_prefetch=0,
+        in_specs=in_specs_list,
+        out_specs=out_specs,
+        scratch_shapes=scratch_shapes,
+        grid=grid,
+    )
+
+    estimated_vmem = _estimate_pallas_vmem_bytes(
+        pl,
+        pltpu,
+        in_specs_list,
+        out_specs,
+        scratch_shapes,
+        args,
+        tensor_arg_indices,
+        _output_indices,
+        pallas_aliases,
+    )
+    vmem_limit_bytes = _get_vmem_limit_bytes(pltpu)
+    if estimated_vmem > vmem_limit_bytes:
+        raise RuntimeError(
+            f"XLA:TPU compile permanent error. Ran out of memory in memory space vmem. "
+            f"Estimated {estimated_vmem / 1e6:.2f}MB exceeds {vmem_limit_bytes / 1e6:.2f}MB vmem capacity."
         )
 
-        jax_callable = _pallas_build_callable(
-            pallas_kernel,
-            grid,
-            jit_fn,
-            _output_indices,
-            arg_to_tensor_pos,
-            tensor_arg_indices,
-            cache_attr="_pallas_fori_cache",
-            call_aliases=pallas_aliases,
-            trace_key_suffix="_fori",
-            interpret=interpret,
-        )
+    reduction_grid_dims = set(_reduction_grid_dims or [])
+    dim_semantics = tuple(
+        "arbitrary" if g in reduction_grid_dims else "parallel"
+        for g in range(len(grid))
+    )
+    pallas_call_kwargs: dict[str, object] = {
+        "out_shape": out_shape_arg,
+        "grid_spec": grid_spec,
+        "compiler_params": pltpu.CompilerParams(  # pyrefly: ignore[bad-instantiation]
+            dimension_semantics=dim_semantics,  # pyrefly: ignore[bad-argument-type]
+        ),
+    }
+    if interpret:
+        pallas_call_kwargs["interpret"] = True
+
+    jit_fn = pl.pallas_call(
+        reordered_kernel,  # pyrefly: ignore[bad-argument-type]
+        **pallas_call_kwargs,  # type: ignore[arg-type]
+    )
+
+    jax_callable = _pallas_build_callable(
+        pallas_kernel,
+        grid,
+        jit_fn,
+        _output_indices,
+        arg_to_tensor_pos,
+        tensor_arg_indices,
+        cache_attr="_pallas_fori_cache",
+        call_aliases=pallas_aliases,
+        trace_key_suffix="_fori",
+        interpret=interpret,
+    )
+
+    fast_path = _LauncherFastPath(
+        tensor_arg_indices,
+        arg_to_tensor_pos,
+        _output_indices,
+        _ds_pad_dims,
+    )
+    pallas_kernel._pallas_fori_cache = (  # pyrefly: ignore[missing-attribute]
+        grid,
+        jax_callable,
+        tensor_arg_indices,
+        arg_to_tensor_pos,
+        fast_path,
+    )
 
     return _pallas_invoke_and_return(
         jax_callable,

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1344,6 +1344,500 @@ class TestPallas(TestCase):
         self.assertIn("lax.dot_general(", code)
         self.assertIn("precision=jax.lax.Precision.HIGHEST", code)
 
+    def test_pallas_autotuner_final_pick_picks_true_best_on_noisy_initial_rank(
+        self,
+    ) -> None:
+        """Final-pick verification re-ranks past noisy initial measurements.
+
+        On TPU pod-wide thermal / scheduler noise sometimes causes the
+        bf16 1024^3 autotuner to record a single-call median of ~224 us
+        for ``block_sizes=[512, 1024, 512]`` while
+        ``block_sizes=[512, 512, 512]`` records ~232 us in the same pass
+        and ~190 us when re-measured back-to-back (Deep Replan 2026-05-23,
+        plan.md §2.1 (a)). The new
+        ``PopulationBasedSearch.run_final_pick_verification`` phase
+        guards against that by re-benchmarking the top-K candidates
+        ``HELION_AUTOTUNE_FINAL_PICK_PASSES`` extra times and ranking by
+        the median of per-pass medians.
+
+        The pin asserts that when the **initial** ``perf`` of the
+        ``[512, 1024, 512]`` candidate is noisy-better but its true
+        repeated rebenchmark stays slower than ``[512, 512, 512]``, the
+        verification picks ``[512, 512, 512]``. The two block-512 configs
+        are the ones the bf16 1024^3 autotuner historically ties between
+        ([512, 512, 512] and [256, 256, 256]); the [512, 1024, 512]
+        config is the one we are explicitly steering away from.
+        """
+        from unittest.mock import patch
+
+        from helion.autotuner.base_search import PopulationBasedSearch
+        from helion.autotuner.base_search import PopulationMember
+        from helion.runtime.config import Config
+
+        # Fake measured times in ms.  "True" means the steady-state cost
+        # the kernel actually pays; "noisy initial" is the first
+        # rebenchmark median seen during search, which mis-ranks the
+        # configs.  ``[512, 1024, 512]`` shows a deceptive 0.220 ms in the
+        # initial benchmark even though every repeated probe lands above
+        # 0.232 ms; ``[512, 512, 512]`` shows a slow 0.232 ms initial but
+        # is consistently 0.190 ms when re-measured.
+        scripted_candidates = [
+            {
+                "block_sizes": [512, 1024, 512],
+                "noisy_initial_ms": 0.220,
+                "true_passes_ms": [0.232, 0.234, 0.230],
+            },
+            {
+                "block_sizes": [512, 512, 512],
+                "noisy_initial_ms": 0.232,
+                "true_passes_ms": [0.190, 0.192, 0.188],
+            },
+            {
+                "block_sizes": [256, 256, 256],
+                "noisy_initial_ms": 0.234,
+                "true_passes_ms": [0.205, 0.210, 0.208],
+            },
+            {
+                "block_sizes": [128, 128, 128],
+                "noisy_initial_ms": 0.260,
+                "true_passes_ms": [0.300, 0.305, 0.302],
+            },
+        ]
+
+        members: list[PopulationMember] = []
+        for entry in scripted_candidates:
+            config = Config(block_sizes=list(entry["block_sizes"]))
+            members.append(
+                PopulationMember(
+                    fn=lambda *a, **kw: None,
+                    perfs=[entry["noisy_initial_ms"]],
+                    flat_values=list(entry["block_sizes"]),
+                    config=config,
+                    status="ok",
+                    compile_time=0.0,
+                )
+            )
+
+        # Construct a minimal search instance without going through the
+        # full constructor (which requires a compiled kernel + arg tensors).
+        # ``log`` must itself be callable plus expose ``.debug`` /
+        # ``.warning`` like the real ``AutotuningLogger`` does, so wrap a
+        # no-op callable in a small adapter.
+        class _NoopLog:
+            def __call__(self, *_: object, **__: object) -> None:
+                return None
+
+            def debug(self, *_: object, **__: object) -> None:
+                return None
+
+            def warning(self, *_: object, **__: object) -> None:
+                return None
+
+        search = PopulationBasedSearch.__new__(PopulationBasedSearch)
+        search.population = members
+        search.best_perf_so_far = min(m.perf for m in members)
+        search.log = _NoopLog()
+
+        # Lookup of true per-pass timings keyed by config identity.  The
+        # pass counter advances per rebenchmark call so each pass sees a
+        # different scripted timing.
+        true_passes_by_id: dict[int, list[float]] = {
+            id(m): list(entry["true_passes_ms"])
+            for m, entry in zip(members, scripted_candidates, strict=True)
+        }
+
+        def fake_rebenchmark(
+            members_to_bench: list[PopulationMember], *, desc: str = ""
+        ) -> None:
+            for member in members_to_bench:
+                # Pop the next scripted timing for this member; reuse the
+                # last value if we exhaust the script.
+                queue = true_passes_by_id[id(member)]
+                timing = queue.pop(0) if queue else member.perfs[-1]
+                member.perfs.append(timing)
+                if timing < search.best_perf_so_far:
+                    search.best_perf_so_far = timing
+
+        with patch.object(search, "rebenchmark", side_effect=fake_rebenchmark):
+            initial_best = min(members, key=lambda m: m.perf)
+            self.assertEqual(
+                list(initial_best.config["block_sizes"]),
+                [512, 1024, 512],
+                "Precondition: noisy initial perf misranks 1024-bn config as best",
+            )
+            final_best = search.run_final_pick_verification(
+                initial_best, passes=3, top_k=5
+            )
+
+        self.assertIn(
+            list(final_best.config["block_sizes"]),
+            ([512, 512, 512], [256, 256, 256]),
+            "Final-pick verification must re-rank away from [512, 1024, 512] "
+            "(under-parallelised bn==N) and into the [512, 512, 512] or "
+            "[256, 256, 256] family.",
+        )
+
+    def test_pallas_matmul_bf16_square_seed_in_initial_population(self) -> None:
+        """Compiler seeds the headline-fast config into the initial population.
+
+        Deep Replan 2026-05-23 (plan.md §2.5 row 2) measured the forced
+        ``emit_pipeline [512, 512, 512] pb=False`` config on bf16 1024**3
+        at 161 us -- the fastest known Helion config -- but the autotuner
+        kept mis-ranking it against ``unroll`` family picks because of
+        per-call noise on short kernels.
+
+        ``PallasMatmulSquareSeedHeuristic`` plants this config in the
+        initial population (via ``ConfigSpec.compiler_seed_configs``,
+        the same path used by ``TritonSkinnyGemmHeuristic``).
+        Together with the existing final-pick verification phase
+        (re-ranking the top-10) this guarantees the autotuner always
+        considers the headline-fast config -- the search no longer has
+        to discover it by mutation.
+
+        Pin asserts:
+          1. The heuristic is eligible for bf16 1024**3.
+          2. ``compiler_seed_configs`` includes the
+             ``[512, 512, 512] emit_pipeline pb=False`` config.
+          3. The skinny shape (M=1) is NOT seeded (the heuristic refuses
+             when any static dim is below 512 so the M=1 / N=1 / K=1
+             paths -- which want ``unroll [_, _, 1]`` or
+             ``fori_loop`` -- aren't biased toward an inappropriate
+             family).
+        """
+        from helion._compiler.autotuner_heuristics.pallas import (
+            PallasMatmulSquareSeedHeuristic,
+        )
+
+        torch.manual_seed(0)
+        x = torch.empty(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.empty(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        bound = pallas_matmul_bf16.bind((x, y))
+
+        self.assertTrue(
+            PallasMatmulSquareSeedHeuristic.is_eligible(
+                bound.env, bound.host_function.device_ir
+            ),
+            "Heuristic must fire on bf16 1024**3 (all dims >= 512, 2D matmul).",
+        )
+        self.assertIn(
+            PallasMatmulSquareSeedHeuristic.name,
+            bound.config_spec.autotuner_heuristics,
+            "Heuristic name must be recorded so the seed is attributable.",
+        )
+        seed_blocks = (512, 512, 512)
+        seeded = [
+            (
+                tuple(cfg.config.get("block_sizes", ())),
+                cfg.config.get("pallas_loop_type"),
+                cfg.config.get("pallas_pre_broadcast"),
+            )
+            for cfg in bound.config_spec.compiler_seed_configs
+        ]
+        self.assertIn(
+            (seed_blocks, "emit_pipeline", False),
+            seeded,
+            "Compiler seed configs must include the headline-fast "
+            "[512, 512, 512] emit_pipeline pb=False entry.",
+        )
+
+        skinny_x = torch.empty(1, 1024, device=DEVICE, dtype=torch.bfloat16)
+        skinny_y = torch.empty(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        skinny_bound = pallas_matmul_bf16.bind((skinny_x, skinny_y))
+        self.assertFalse(
+            PallasMatmulSquareSeedHeuristic.is_eligible(
+                skinny_bound.env, skinny_bound.host_function.device_ir
+            ),
+            "Heuristic must refuse skinny shapes (M=1) so the [512, 512, 512] "
+            "block tile isn't seeded for shapes that can't use it.",
+        )
+        skinny_seeded = [
+            tuple(cfg.config.get("block_sizes", ()))
+            for cfg in skinny_bound.config_spec.compiler_seed_configs
+        ]
+        self.assertNotIn(
+            seed_blocks,
+            skinny_seeded,
+            "Skinny shape must not receive the [512, 512, 512] seed.",
+        )
+
+    def test_pallas_autotuner_compiler_seed_survives_final_pick(self) -> None:
+        """Compiler-seeded members are re-considered during final-pick verification.
+
+        The LFBO surrogate-driven search aggressively prunes the
+        population between generations: by the time
+        ``run_final_pick_verification`` fires, ``self.population`` may
+        hold only 2-3 members of the last generation's neighbors plus
+        the running best.  Without this pin a compiler-seeded
+        ``[512, 512, 512] emit_pipeline pb=False`` config that measured
+        merely "average" on its noisy initial bench would be dropped
+        from later generations -- the verification phase would never
+        see it.
+
+        The fix snapshots compiler-seeded members on
+        ``PopulationBasedSearch._compiler_seed_members`` at the end of
+        the initial-rebench step and merges them into the verification
+        candidate pool, so a backend's hand-picked seed always gets
+        re-benched against the search's best even when the search
+        moved away from it.
+        """
+        from unittest.mock import patch
+
+        from helion.autotuner.base_search import PopulationBasedSearch
+        from helion.autotuner.base_search import PopulationMember
+        from helion.runtime.config import Config
+
+        # "Last-gen population" = two random survivors of the LFBO
+        # pattern search, both around 0.205 ms.  "Compiler seed" = the
+        # hand-picked fast config that scored 0.215 ms on its noisy
+        # initial bench (so the LFBO surrogate dropped it from later
+        # generations) but consistently rebenches at 0.190 ms.
+        last_gen = [
+            (
+                Config(block_sizes=[1024, 256, 1024]),
+                0.205,
+                [0.207, 0.206, 0.204],
+            ),
+            (
+                Config(block_sizes=[256, 256, 256]),
+                0.210,
+                [0.212, 0.211, 0.209],
+            ),
+        ]
+        compiler_seed = (
+            Config(
+                block_sizes=[512, 512, 512],
+                pallas_loop_type="emit_pipeline",
+                pallas_pre_broadcast=False,
+            ),
+            0.215,
+            [0.190, 0.191, 0.189],
+        )
+
+        def make_member(config: Config, noisy_perf: float) -> PopulationMember:
+            return PopulationMember(
+                fn=lambda *a, **kw: None,
+                perfs=[noisy_perf],
+                flat_values=[id(config)],  # opaque -- never read by the test
+                config=config,
+                status="ok",
+                compile_time=0.0,
+            )
+
+        last_gen_members = [make_member(cfg, perf) for cfg, perf, _passes in last_gen]
+        seed_member = make_member(compiler_seed[0], compiler_seed[1])
+        true_passes_by_id: dict[int, list[float]] = {
+            id(member): list(passes)
+            for member, (_cfg, _noisy, passes) in zip(
+                last_gen_members, last_gen, strict=True
+            )
+        }
+        true_passes_by_id[id(seed_member)] = list(compiler_seed[2])
+
+        class _NoopLog:
+            def __call__(self, *_: object, **__: object) -> None:
+                return None
+
+            def debug(self, *_: object, **__: object) -> None:
+                return None
+
+            def warning(self, *_: object, **__: object) -> None:
+                return None
+
+        search = PopulationBasedSearch.__new__(PopulationBasedSearch)
+        search.population = last_gen_members  # seed NOT in last-gen population
+        search.best_perf_so_far = min(m.perf for m in last_gen_members)
+        search._compiler_seed_members = [seed_member]
+        search.log = _NoopLog()
+
+        def fake_rebenchmark(
+            members_to_bench: list[PopulationMember], *, desc: str = ""
+        ) -> None:
+            for member in members_to_bench:
+                queue = true_passes_by_id[id(member)]
+                timing = queue.pop(0) if queue else member.perfs[-1]
+                member.perfs.append(timing)
+                if timing < search.best_perf_so_far:
+                    search.best_perf_so_far = timing
+
+        with patch.object(search, "rebenchmark", side_effect=fake_rebenchmark):
+            initial_best = min(last_gen_members, key=lambda m: m.perf)
+            self.assertEqual(
+                list(initial_best.config["block_sizes"]),
+                [1024, 256, 1024],
+                "Precondition: search's running best is one of the last-gen members.",
+            )
+            final_best = search.run_final_pick_verification(
+                initial_best, passes=3, top_k=10
+            )
+
+        self.assertEqual(
+            list(final_best.config["block_sizes"]),
+            [512, 512, 512],
+            "Compiler-seeded [512, 512, 512] must be re-benched and "
+            "re-rank ahead of the last-gen best once its true 0.190 ms "
+            "perf is measured.",
+        )
+
+    def test_pallas_launcher_fast_path_hits_on_repeat_invocations(self) -> None:
+        """Cached static-shape Pallas launcher elides per-call helper iteration.
+
+        Deep Replan 2026-05-23 (§2.7 in ``plan.md``) decomposed the
+        bf16 1024^3 headline gap to per-call Python dispatch overhead.
+        On a cache hit, ``default_pallas_launcher`` /
+        ``default_pallas_pipeline_launcher`` / ``default_pallas_fori_launcher``
+        each branch into a fast path that:
+
+        * Reuses a precomputed ``_LauncherFastPath`` instance carried on
+          the cached launcher entry instead of re-running
+          ``_pallas_apply_ds_padding`` / ``_pallas_check_dtypes`` /
+          the output-only-results loop per call.
+        * Increments ``helion.runtime._LAUNCHER_FAST_PATH_HITS`` on each
+          cache hit so this pin can assert the elision is exercised.
+
+        The kernel allocates its output via ``torch.empty`` inside the
+        kernel body, so ``out`` is an output-only tensor and the fast
+        path exercises both the output-only-results loop short-circuit
+        and the ds-pad skip (1024-divisible block sizes mean every
+        pad_amount is 0).  The test binds + ``compile_config`` directly
+        so autotuning doesn't muddy the counter (autotuning would call
+        the launcher hundreds of times across configs); only the
+        compiled callable's per-call launcher work is observed.
+
+        Regression hazard pinned: if a refactor splits the cache tuple
+        differently or removes the counter increment, this test fails.
+        Equally, if a refactor accidentally takes the slow path on
+        every call (e.g. by storing a 4-tuple instead of a 5-tuple and
+        always missing the new ``fast_path`` unpack), the hit count
+        drops to 0 and the test fails.
+        """
+        from helion import runtime as helion_runtime
+
+        torch.manual_seed(0)
+        x = torch.randn(256, 256, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(256, 256, device=DEVICE, dtype=torch.bfloat16)
+
+        bound = pallas_matmul_bf16.bind((x, y))
+        config = bound.config_spec.default_config()
+        compiled_fn = bound.compile_config(config)
+
+        helion_runtime._reset_launcher_fast_path_hits()
+        self.assertEqual(helion_runtime._launcher_fast_path_hits(), 0)
+
+        # First call seeds the launcher cache (slow path / no counter
+        # bump); subsequent calls take the fast path.
+        result = compiled_fn(x, y)
+        expected = (x.float() @ y.float()).to(torch.bfloat16)
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+        self.assertEqual(
+            helion_runtime._launcher_fast_path_hits(),
+            0,
+            "First call should miss the launcher cache and run the "
+            "slow path (no fast-path counter bump).",
+        )
+
+        # Repeat invocations: same kernel, same shape, same dtype → cache hit.
+        n_repeats = 4
+        for _ in range(n_repeats):
+            result = compiled_fn(x, y)
+            torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+
+        self.assertEqual(
+            helion_runtime._launcher_fast_path_hits(),
+            n_repeats,
+            f"Repeat calls on a cached static-shape kernel must each hit "
+            f"the launcher fast path. Expected {n_repeats} hits; got "
+            f"{helion_runtime._launcher_fast_path_hits()}.",
+        )
+
+    def test_pallas_jaxcallable_key_cache_hits_on_repeat_invocations(self) -> None:
+        """Cached static-shape JaxCallable reuses torch_tpu invocation key.
+
+        Deep Replan 2026-05-23 (§2.7 in ``plan.md``) localized ~50us of
+        the per-call Pallas dispatch overhead to torch_tpu's
+        ``JaxCallable.__call__``, of which the f-string built by
+        ``_get_kernel_invocation_key`` (per-arg shape / dtype walk) is a
+        measurable slice on every call.  For ``static_shapes=True``
+        kernels the invocation key is constant across calls, so Helion
+        installs a ``JaxCallable`` subclass that caches the first
+        call's ``(arg_shape_dtype_signature, kernel_key, output_shapes,
+        out_tree, input_output_aliases_items)`` and on subsequent calls
+        with a matching signature short-circuits to a direct
+        ``tpu_torch_pallas.call_custom_kernel`` invocation, bumping
+        ``helion.runtime._JAXCALLABLE_KEY_CACHE_HITS`` once per cache
+        hit.
+
+        The test asserts the counter increments exactly ``n_repeats``
+        times across ``1 + n_repeats`` consecutive calls of the same
+        compiled callable: the first call seeds the JaxCallable's
+        internal ``output_shapes`` cache and the subclass's
+        ``_helion_key_cache``; calls 2..N reuse them.
+        """
+        from helion import runtime as helion_runtime
+
+        # Define the kernel inside the test so the inner Helion-emitted
+        # function (and its ``_pallas_pipeline_cache``) is unique to
+        # this test run -- no cross-test pollution from other tests
+        # that bind ``pallas_matmul_bf16``.  The launcher cache lives on
+        # the *inner* generated function, not on the user-facing
+        # decorator object, so clearing attributes off the module-level
+        # ``pallas_matmul_bf16`` wouldn't help.
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def _matmul_jaxcallable_pin(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty(
+                [m, n],
+                device=x.device,
+                dtype=torch.promote_types(x.dtype, y.dtype),
+            )
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc
+            return out
+
+        torch.manual_seed(0)
+        x = torch.randn(256, 256, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(256, 256, device=DEVICE, dtype=torch.bfloat16)
+
+        bound = _matmul_jaxcallable_pin.bind((x, y))
+        config = bound.config_spec.default_config()
+        compiled_fn = bound.compile_config(config)
+
+        helion_runtime._reset_jaxcallable_key_cache_hits()
+        self.assertEqual(helion_runtime._jaxcallable_key_cache_hits(), 0)
+
+        # First call seeds the JaxCallable cache (slow path / no counter bump).
+        result = compiled_fn(x, y)
+        expected = (x.float() @ y.float()).to(torch.bfloat16)
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+        self.assertEqual(
+            helion_runtime._jaxcallable_key_cache_hits(),
+            0,
+            "First call must miss the cached invocation key (no counter bump).",
+        )
+
+        # Subsequent calls share the same arg shape / dtype signature
+        # so the subclass's fast-path short-circuit fires every time.
+        n_repeats = 4
+        for _ in range(n_repeats):
+            result = compiled_fn(x, y)
+            torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+
+        self.assertEqual(
+            helion_runtime._jaxcallable_key_cache_hits(),
+            n_repeats,
+            f"Repeat calls on a cached static-shape kernel must each "
+            f"reuse the cached JaxCallable invocation key. Expected "
+            f"{n_repeats} hits; got "
+            f"{helion_runtime._jaxcallable_key_cache_hits()}.",
+        )
+
     def test_bmm(self) -> None:
         """Test BMM with default config — exercises size_matches fix.
 


### PR DESCRIPTION
## Summary

Replaces per-call closure rebuilding in `default_pallas_pipeline_launcher` (and siblings) with a precomputed fast-path cache that runs once at first invocation and is keyed on the kernel + grid signature for static-shape kernels.

Two cooperating mechanisms:

1. **Per-kernel `_pallas_pipeline_cache`** — First call walks the full `_pallas_prepare_args` -> `_pallas_build_*` pipeline once and stores the resulting tensor_arg_indices, arg_to_tensor_pos, jax_callable, and pl.pallas_call object on `pallas_kernel`. Subsequent calls with the same grid signature do a single attribute lookup and dispatch directly. Same code path for the fori_loop and emit_pipeline launchers.

2. **Pre-cached torch_tpu JaxCallable invocation key** — After the first invocation populates the JaxCallable internal cache, the launcher snapshots the cache key + flat input pytree layout so repeat calls bypass JaxCallable.\_\_call\_\_'s key construction. The torch_tpu side already deduplicates by key, so this just saves the dict-key building work on the hot path.

## Perf

Measured on bf16 1024x1024x1024 headline matmul (TPU v7, median-of-3 seeds, paired interleaved-4way):

| Metric | Before (PR #2588 base) | After | Δ |
|---|---|---|---|
| Helion total us per call | ~83 | ~72 | **-12 us** |
| launcher_overhead_us | 77 | 65.79 | **-11.6 us** |
| Helion kernel device us | ~6.7 | ~6.6 | flat |

Counter `_launcher_fast_path_hits` and `_jaxcallable_key_cache_hits` bump on every fast-path call so the pin tests can assert the cache is wired up.

## Test plan

- [x] `./lint.sh check` clean
- [x] New pin tests: `test_pallas_launcher_fast_path_hits_on_repeat_invocations` + JaxCallable key cache hit assertions
- [ ] TPU CI run

## Stack

- #2588 (base) — pallas matmul pipeline launcher VMEM strips + outer-grid strategy
- **this PR**
- pallas-launcher-direct-call (next)
- pallas-launcher-squeezes (top)