### PR TITLE
[pallas] direct-call hot-path squeezes: output cache + sig-lock + closure baking + speculative dispatch

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1157,6 +1157,12 @@ class PallasBackend(Backend):
             "_default_pallas_launcher": "from helion.runtime import default_pallas_launcher as _default_pallas_launcher",
             "_default_pallas_pipeline_launcher": "from helion.runtime import default_pallas_pipeline_launcher as _default_pallas_pipeline_launcher",
             "_default_pallas_fori_launcher": "from helion.runtime import default_pallas_fori_launcher as _default_pallas_fori_launcher",
+            # Generated host code for ``static_shapes=True`` Pallas kernels
+            # caches the per-output-only meta placeholder on the inner
+            # device function and bumps ``_OUTPUT_TENSOR_ALLOCATIONS`` on
+            # first allocation via ``_helion_runtime._bump_output_tensor_allocations()``;
+            # see the ``output_meta_init_stmts`` block in ``generate_ast.py``.
+            "_helion_runtime": "import helion.runtime as _helion_runtime",
         }
 
     # Config keys that Pallas actually uses.  Everything else

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -877,10 +877,30 @@ def generate_ast(
             output_only_names = getattr(
                 CompileEnvironment.current().backend, "_output_only_names", []
             )
+            output_meta_init_stmts: list[ast.stmt] = []
             if output_only_names:
                 oo_set = set(output_only_names)
+                # When ``static_shapes=True`` the output-only meta
+                # placeholder's shape / dtype / device are constant across
+                # every call of this compiled kernel, so the per-call
+                # ``torch.empty(..., device='meta')`` (~2us each on the
+                # headline shape) can be hoisted to a one-shot cache slot
+                # attached to the inner device function. Subsequent calls
+                # reuse the cached placeholder; the launcher reassigns the
+                # variable to the real result tensor as before.
+                #
+                # For ``static_shapes=False`` the shape can change across
+                # calls (the same compiled kernel cache entry may serve
+                # multiple shapes once dynamic-shape support widens), so the
+                # per-call allocation is preserved unchanged.
+                cache_static_shapes = (
+                    CompileEnvironment.current().settings.static_shapes
+                )
+                inner_fn_name = codegen.device_function.name
+                cached_meta_index = 0
+                new_host_statements: list[ast.AST] = []
                 for stmt in codegen.host_statements:
-                    if (
+                    if not (
                         isinstance(stmt, ast.Assign)
                         and len(stmt.targets) == 1
                         and isinstance(stmt.targets[0], ast.Name)
@@ -888,12 +908,45 @@ def generate_ast(
                         and not getattr(stmt, "_is_kernel_call", False)
                         and isinstance(stmt.value, ast.Call)
                     ):
-                        call = stmt.value
-                        call.keywords = [
-                            kw for kw in call.keywords if kw.arg != "device"
-                        ] + [
-                            ast.keyword(arg="device", value=ast.Constant(value="meta"))
-                        ]
+                        new_host_statements.append(stmt)
+                        continue
+                    call = stmt.value
+                    call.keywords = [
+                        kw for kw in call.keywords if kw.arg != "device"
+                    ] + [ast.keyword(arg="device", value=ast.Constant(value="meta"))]
+                    if not cache_static_shapes:
+                        new_host_statements.append(stmt)
+                        continue
+                    varname = stmt.targets[0].id
+                    cache_attr = f"_helion_output_meta_cache_{cached_meta_index}"
+                    cached_meta_index += 1
+                    # 2-statement replacement:
+                    #   <var> = <inner_fn_name>.<cache_attr>
+                    #   if <var> is None:
+                    #       <var> = <orig_torch.empty_call>
+                    #       <inner_fn_name>.<cache_attr> = <var>
+                    #       _helion_runtime._bump_output_tensor_allocations()
+                    #
+                    # The cache slot is initialized to ``None`` at module
+                    # import via ``output_meta_init_stmts`` (inserted
+                    # between the inner device-function def and the host
+                    # function def).
+                    get_stmt = statement_from_string(
+                        f"{varname} = {inner_fn_name}.{cache_attr}"
+                    )
+                    if_template = (
+                        f"if {varname} is None:\n"
+                        f"    {varname} = {{__orig_call__}}\n"
+                        f"    {inner_fn_name}.{cache_attr} = {varname}\n"
+                        f"    _helion_runtime._bump_output_tensor_allocations()\n"
+                    )
+                    if_stmt = statement_from_string(if_template, __orig_call__=call)
+                    new_host_statements.extend([get_stmt, if_stmt])
+                    output_meta_init_stmts.append(
+                        statement_from_string(f"{inner_fn_name}.{cache_attr} = None")
+                    )
+                if cache_static_shapes and output_meta_init_stmts:
+                    codegen.host_statements = new_host_statements
 
             # Inject RNG seed buffer creation if needed
             rng_statements = (
@@ -1067,6 +1120,15 @@ def generate_ast(
                 *codegen.module_statements,
                 *codegen.device_function.codegen_helper_functions(),
                 *kernel_def,
+                # ``output_meta_init_stmts`` initialize the per-output cache
+                # slot to ``None`` on the inner device function so the host
+                # function can run its ``if cache is None`` first-call
+                # population branch.  Must come after ``kernel_def`` (which
+                # defines the inner function) and before ``host_def`` (which
+                # references the cache slots).  Empty list for
+                # ``static_shapes=False`` kernels or kernels with no
+                # output-only tensors.
+                *output_meta_init_stmts,
                 *generated_direct_entry_defs,
                 host_def,
                 *call_def,

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -30,7 +30,11 @@ from .._compiler.cute.tcgen05_constants import TCGEN05_DIRECT_ENTRY_TOTAL_WORK_C
 from .._utils import triton_is_available
 from .config import Config as Config
 from .kernel import Kernel as Kernel
+from .kernel import _bump_kernel_fast_path_hits as _bump_kernel_fast_path_hits
+from .kernel import _kernel_fast_path_hits as _kernel_fast_path_hits
+from .kernel import _reset_kernel_fast_path_hits as _reset_kernel_fast_path_hits
 from .kernel import kernel as kernel
+from .settings import is_pallas_interpret as _module_is_pallas_interpret
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -627,6 +631,85 @@ def _reset_call_custom_kernel_direct_hits() -> None:
     _CALL_CUSTOM_KERNEL_DIRECT_HITS = 0
 
 
+# Per-call host-side output ``torch.Tensor`` allocations performed by the
+# generated launcher wrapper.  For ``static_shapes=True`` kernels the
+# generated host function caches the meta-device placeholder for each
+# output-only tensor as a function attribute on the inner Helion-emitted
+# function so the per-call ``torch.empty(..., device='meta')`` (~2us)
+# only runs once at first invocation; subsequent calls reuse the cached
+# placeholder.  This counter increments exactly once per cached slot
+# (i.e. once per output-only tensor, the first time it is built); pin
+# tests assert that ``N`` repeat calls produce no additional
+# increments.
+#
+# For dynamic-shape kernels the generated host function still allocates
+# a fresh meta placeholder each call (shape may change), so the
+# counter bumps on every call.
+_OUTPUT_TENSOR_ALLOCATIONS = 0
+
+
+def _output_tensor_allocations() -> int:
+    """Return the count of generated-host-code output meta allocations.
+
+    Test instrumentation: pin tests assert that a static-shape Pallas
+    kernel allocates each output-only meta placeholder exactly once
+    across ``1 + n_repeats`` consecutive calls.
+    """
+    return _OUTPUT_TENSOR_ALLOCATIONS
+
+
+def _reset_output_tensor_allocations() -> None:
+    """Reset the output-meta-allocation counter (test instrumentation)."""
+    global _OUTPUT_TENSOR_ALLOCATIONS
+    _OUTPUT_TENSOR_ALLOCATIONS = 0
+
+
+def _bump_output_tensor_allocations() -> None:
+    """Increment the output-meta-allocation counter.
+
+    Called from generated host code on each fresh meta-tensor allocation
+    (i.e. on the cache-population path for ``static_shapes=True`` kernels,
+    or on every call for dynamic-shape kernels).
+    """
+    global _OUTPUT_TENSOR_ALLOCATIONS
+    _OUTPUT_TENSOR_ALLOCATIONS += 1
+
+
+# Per-call direct-dispatch sig-check elisions.  G5-launcher-Y squeeze:
+# after the first successful direct-dispatch hit on a static-shape
+# launcher cache entry, the per-arg ``(shape, dtype)`` signature is
+# guaranteed stable across every subsequent call hitting the same
+# launcher cache slot (the slot is keyed by ``grid`` and a grid-stable
+# cache hit on a static-shape kernel implies shape-stable args).  The
+# first match flips ``_DirectCallKernel.sig_locked`` to ``True`` so
+# subsequent calls skip the per-call tuple build + tuple comparison
+# entirely and bump this counter.  Pin tests assert the counter
+# increments on second-and-later direct-dispatch hits.
+_DIRECT_CALL_SIG_CHECKS_SKIPPED = 0
+
+
+def _direct_call_sig_checks_skipped() -> int:
+    """Return the count of direct-dispatch sig-check elisions.
+
+    Test instrumentation: pin tests assert that a static-shape Pallas
+    kernel skips the per-call ``direct_sig`` tuple build + comparison
+    on second-and-later direct-dispatch hits by reading this counter
+    before / after invocations.
+    """
+    return _DIRECT_CALL_SIG_CHECKS_SKIPPED
+
+
+def _reset_direct_call_sig_checks_skipped() -> None:
+    """Reset the sig-check-skip counter (test instrumentation)."""
+    global _DIRECT_CALL_SIG_CHECKS_SKIPPED
+    _DIRECT_CALL_SIG_CHECKS_SKIPPED = 0
+
+
+# The G5-decorator ``_kernel_fast_path_hits`` counter is defined in
+# ``helion/runtime/kernel.py`` to avoid a re-import cycle; re-exported via
+# the top-level import block above.
+
+
 @dataclass(slots=True)
 class _DirectCallKernel:
     """Pre-captured metadata for a direct ``call_custom_kernel`` invocation.
@@ -653,6 +736,55 @@ class _DirectCallKernel:
     dynamic-shape kernels reusing the same launcher cache entry across
     calls with different shapes fall back to the JaxCallable slow path
     on a sig mismatch.
+
+    G5-launcher-Y squeeze additions:
+    - ``invoke`` is a pre-built closure that captures
+      ``(call_custom_kernel, kernel_name, kernel_key, output_shapes,
+      donate_argnums, out_tree, alias_items)`` and takes only
+      ``input_tensors`` as a positional argument.  The hot path calls
+      ``direct_call.invoke(input_tensors)`` instead of doing the
+      attribute walk + kwarg construction per call, saving the
+      per-call kwargs dict allocation (~1 us) plus six attribute
+      reads.  The closure also branches on a pre-baked
+      ``has_aliases`` flag so the empty-alias_items case (matmul +
+      every output-only kernel) skips the for-loop iteration
+      entirely.
+    - ``sig_locked`` flips ``True`` after the first successful sig
+      match in the launcher hot path.  Once locked, subsequent calls
+      hitting the same launcher cache entry skip the per-call
+      ``direct_sig`` tuple build + comparison (the launcher cache is
+      grid-keyed and a grid-stable cache hit on a static-shape kernel
+      implies shape-stable args, so the sig check is provably
+      constant-True after the first match).  Counter
+      ``_DIRECT_CALL_SIG_CHECKS_SKIPPED`` bumps on every skip.
+
+    G5-launcher-Z squeeze additions:
+    - ``full_invoke`` is a pre-built closure that captures *everything*
+      needed by the locked hot path — the ``tensor_arg_indices``
+      tuple used to walk ``args`` and call ``.contiguous()``, the
+      three test-instrumentation counter bumps (batched via
+      ``_bump_direct_locked_counters``), the constant
+      ``call_custom_kernel`` kwargs, and the post-call
+      ``out_tree.unflatten`` / alias copy-back.  Takes only ``args``
+      as a positional argument and returns the final user-facing
+      result tensor (or tuple, or ``None`` for in-place kernels)
+      directly, so the launcher's locked hot path becomes
+      ``return direct_call.full_invoke(args)`` — eliminating the
+      per-call ``_pallas_invoke_and_return_fast`` function call,
+      the ``fast_path`` attribute reads inside it, and the three
+      separate global-counter ``+= 1`` statements.
+
+      Populated lazily by ``_maybe_bake_full_invoke`` (called from
+      the launcher's cache-hit branch on the call after
+      ``sig_locked`` flips to True).  Two closure variants are
+      pre-baked depending on the kernel shape pattern
+      (``full_invoke_pure_output`` for matmul + every output-only
+      kernel, ``full_invoke_inplace_only`` for in-place kernels with
+      no output-only tensors).  Mixed in-place + output-only kernels
+      opt out — the field is set to the
+      ``_DIRECT_CALL_FULL_INVOKE_UNAVAILABLE`` sentinel so the
+      launcher hot path checks against the sentinel and falls back
+      to ``_pallas_invoke_and_return_fast``.
     """
 
     call_custom_kernel: object
@@ -663,6 +795,195 @@ class _DirectCallKernel:
     out_tree: object
     alias_items: tuple[tuple[int, int], ...]
     sig: tuple[object, ...]
+    invoke: object
+    # ``full_invoke`` defaults to ``None`` so existing construction sites
+    # that don't yet populate it (and any future ones added before the
+    # launcher's lazy-bake fires) stay forward-compatible.  See
+    # ``_maybe_bake_full_invoke`` for the populator.
+    full_invoke: object = None
+    sig_locked: bool = False
+
+
+def _bump_direct_locked_counters() -> None:
+    """Bump the three counters fired on every locked direct-dispatch call.
+
+    Batches the three test-instrumentation increments
+    (``_CALL_CUSTOM_KERNEL_DIRECT_HITS``, ``_JAXCALLABLE_KEY_CACHE_HITS``,
+    ``_DIRECT_CALL_SIG_CHECKS_SKIPPED``) into a single function call so
+    the locked-path closure (``full_invoke``) avoids three separate
+    ``LOAD_GLOBAL`` / ``STORE_GLOBAL`` bytecode triples per call.
+    """
+    global \
+        _CALL_CUSTOM_KERNEL_DIRECT_HITS, \
+        _JAXCALLABLE_KEY_CACHE_HITS, \
+        _DIRECT_CALL_SIG_CHECKS_SKIPPED
+    _CALL_CUSTOM_KERNEL_DIRECT_HITS += 1
+    _JAXCALLABLE_KEY_CACHE_HITS += 1
+    _DIRECT_CALL_SIG_CHECKS_SKIPPED += 1
+
+
+def _build_direct_call_invoke(
+    call_custom_kernel: object,
+    kernel_name: str,
+    kernel_key: str,
+    output_shapes: object,
+    donate_argnums: object,
+    out_tree: object,
+    alias_items: tuple[tuple[int, int], ...],
+) -> object:
+    """Pre-bake a closure that runs the direct-dispatch hot path.
+
+    The closure captures every per-call constant (kernel name / key,
+    output shapes, donate_argnums, out_tree, alias items, and the
+    ``call_custom_kernel`` reference itself) so the launcher hot path
+    can elide six attribute reads + the per-call kwargs dict allocation
+    on every invocation.  Two closure variants are pre-baked:
+
+    * ``invoke_no_alias`` for the empty-``alias_items`` case (output-only
+      kernels like matmul) — skips the alias for-loop entirely.
+    * ``invoke_with_alias`` for the non-empty alias case (in-place
+      output kernels) — iterates the captured tuple.
+
+    Returning the right closure once at cache-build time avoids a
+    per-call branch on ``alias_items``.
+    """
+    if not alias_items:
+
+        def invoke_no_alias(input_tensors: list[object]) -> object:
+            results = call_custom_kernel(  # type: ignore[operator]
+                kernel_name,
+                kernel_key,
+                inputs=input_tensors,
+                output_shapes=output_shapes,
+                donate_argnums=donate_argnums,
+            )
+            return out_tree.unflatten(results)  # type: ignore[attr-defined]
+
+        return invoke_no_alias
+
+    def invoke_with_alias(input_tensors: list[object]) -> object:
+        results = call_custom_kernel(  # type: ignore[operator]
+            kernel_name,
+            kernel_key,
+            inputs=input_tensors,
+            output_shapes=output_shapes,
+            donate_argnums=donate_argnums,
+        )
+        for in_idx, out_idx in alias_items:
+            input_tensors[in_idx].copy_(results[out_idx])  # type: ignore[attr-defined]
+        return out_tree.unflatten(results)  # type: ignore[attr-defined]
+
+    return invoke_with_alias
+
+
+def _build_direct_call_full_invoke(
+    call_custom_kernel: object,
+    kernel_name: str,
+    kernel_key: str,
+    output_shapes: object,
+    donate_argnums: object,
+    out_tree: object,
+    alias_items: tuple[tuple[int, int], ...],
+    tensor_arg_indices: tuple[int, ...],
+    output_only_count: int,
+) -> object | None:
+    """Pre-bake the full locked-path closure (G5-launcher-Z squeeze).
+
+    The closure takes ``args`` (the full launcher-arg tuple) and returns
+    the final user-facing result — folding together what was previously
+    split across the launcher cache-hit branch,
+    ``_pallas_invoke_and_return_fast``, and ``invoke_*`` closures into a
+    single function call.  Specifically the closure captures:
+
+    * ``tensor_arg_indices`` so the per-call ``[args[i].contiguous() ...]``
+      list-comp uses a captured tuple instead of reading
+      ``fast_path.tensor_arg_indices_tuple`` per call.
+    * ``call_custom_kernel`` (pre-bound ``tpu_torch_pallas`` ref) plus
+      the four constant kwargs so the per-call ``call_custom_kernel(...)``
+      invocation needs no attribute reads.
+    * ``out_tree`` and ``alias_items`` so the post-call unflatten /
+      alias copy-back is bound at cache-build time.
+
+    Bumps the three test-instrumentation counters once per call via
+    ``_bump_direct_locked_counters`` so the pin tests
+    (``test_pallas_call_custom_kernel_direct_hits_on_repeat_invocations``,
+    ``test_pallas_jaxcallable_key_cache_hits_on_repeat_invocations``,
+    ``test_pallas_direct_call_sig_check_locks_on_static_shapes``)
+    keep firing exactly once per locked call.
+
+    Only used by the locked hot path
+    (``direct_call.sig_locked is True``).  The first
+    direct-dispatch call (sig check still running, lock about to flip)
+    goes through ``invoke`` so the ``_DIRECT_CALL_SIG_CHECKS_SKIPPED``
+    counter only bumps after the lock has flipped — matching the pin
+    test's expectation that calls 1 and 2 do NOT bump the skip counter.
+
+    Returns ``None`` when no closure variant is safe to bake for the
+    given combination of ``alias_items`` and ``output_only_count`` —
+    specifically the "mixed in-place + output-only" case
+    (``alias_items`` non-empty AND ``output_only_count > 0``), where the
+    post-call work in ``_pallas_invoke_and_return_fast`` filters the
+    flat ``results`` list down to just the output-only entries.  The
+    launcher's locked-path short-circuit then falls back to calling
+    ``_pallas_invoke_and_return_fast`` for those kernels.
+
+    Returns one of:
+    * ``full_invoke_pure_output`` — ``output_only_count > 0`` AND no
+      ``alias_items``: matmul / pure-output pattern.  Returns
+      ``out_tree.unflatten(results)`` directly.
+    * ``full_invoke_inplace_only`` — ``output_only_count == 0`` AND
+      ``alias_items`` non-empty: in-place kernel (e.g. ``x[tile] +=
+      ...``).  Copies the results back to the donated input tensors
+      and returns ``None``.
+    """
+    bump_counters = _bump_direct_locked_counters
+
+    if output_only_count > 0 and not alias_items:
+
+        def full_invoke_pure_output(args: tuple[object, ...]) -> object:
+            bump_counters()
+            input_tensors = [
+                args[i].contiguous()  # type: ignore[attr-defined]
+                for i in tensor_arg_indices
+            ]
+            results = call_custom_kernel(  # type: ignore[operator]
+                kernel_name,
+                kernel_key,
+                inputs=input_tensors,
+                output_shapes=output_shapes,
+                donate_argnums=donate_argnums,
+            )
+            return out_tree.unflatten(results)  # type: ignore[attr-defined]
+
+        return full_invoke_pure_output
+
+    if output_only_count == 0:
+
+        def full_invoke_inplace_only(args: tuple[object, ...]) -> object | None:
+            bump_counters()
+            input_tensors = [
+                args[i].contiguous()  # type: ignore[attr-defined]
+                for i in tensor_arg_indices
+            ]
+            results = call_custom_kernel(  # type: ignore[operator]
+                kernel_name,
+                kernel_key,
+                inputs=input_tensors,
+                output_shapes=output_shapes,
+                donate_argnums=donate_argnums,
+            )
+            for in_idx, out_idx in alias_items:
+                input_tensors[in_idx].copy_(results[out_idx])  # type: ignore[attr-defined]
+            return None
+
+        return full_invoke_inplace_only
+
+    # Mixed in-place + output-only kernel: the post-call work needs to
+    # filter ``results`` down to just the output-only entries (using
+    # ``fast_path.output_only_descriptors``); not safely pre-bakable
+    # without bringing the fast-path descriptors into the closure.
+    # Fall back to ``_pallas_invoke_and_return_fast``.
+    return None
 
 
 _HELION_STATIC_JAX_CALLABLE_CLASS: type | None = None
@@ -814,7 +1135,26 @@ def _make_helion_static_jax_callable_class() -> type:
             # Build the launcher-side direct-call structure so the next
             # call can bypass this ``__call__`` entirely.  The launcher's
             # first-time cache build reads ``self._helion_direct_call``
-            # right after the first invocation returns.
+            # right after the first invocation returns.  Pre-bake the
+            # ``invoke`` closure now (cache-build time) so the per-call
+            # hot path skips the attribute walk + kwargs dict
+            # allocation; see ``_build_direct_call_invoke`` for the two
+            # closure variants (with / without alias copy-back).
+            invoke = _build_direct_call_invoke(
+                tpu_torch_pallas.call_custom_kernel,
+                self.name,
+                kernel_key,
+                output_shapes,
+                self.donate_argnums,
+                out_tree,
+                alias_items,
+            )
+            # ``full_invoke`` is populated lazily by the launcher's
+            # lift code (it needs ``tensor_arg_indices`` and the
+            # ``fast_path.output_only_count`` value, which only the
+            # launcher knows).  See ``_build_direct_call_full_invoke``
+            # and the launcher's lazy-lift branch.  Defaults to ``None``
+            # so we don't have to pass it explicitly here.
             self._helion_direct_call = _DirectCallKernel(
                 call_custom_kernel=tpu_torch_pallas.call_custom_kernel,
                 kernel_name=self.name,
@@ -824,6 +1164,7 @@ def _make_helion_static_jax_callable_class() -> type:
                 out_tree=out_tree,
                 alias_items=alias_items,
                 sig=sig_tuple,
+                invoke=invoke,
             )
             return result
 
@@ -957,6 +1298,56 @@ def _pallas_apply_ds_padding_fast(
     return tuple(args_list), orig_output_tensors, True
 
 
+_DIRECT_CALL_FULL_INVOKE_UNAVAILABLE: object = object()
+
+
+def _maybe_bake_full_invoke(
+    direct_call: _DirectCallKernel,
+    fast_path: _LauncherFastPath,
+    tensor_arg_indices: list[int],
+) -> None:
+    """Populate ``direct_call.full_invoke`` once it's safe to short-circuit.
+
+    Called from the launcher hot path on the call after the sig check
+    locked (and only when there is no ds-padding to do this call).
+    The closure built here captures everything needed by the locked
+    path — ``tensor_arg_indices`` for the contiguous walk, the
+    ``call_custom_kernel`` constants, the post-call
+    ``out_tree.unflatten`` / alias copy-back — so subsequent calls
+    take exactly one attribute lookup (``direct_call.full_invoke``)
+    and one function call from launcher entry to result.
+
+    Only safe to bake when there is no per-call ds-padding (the
+    closure short-circuits the post-call output-handling loop in
+    ``_pallas_invoke_and_return_fast``, which is what runs the
+    ds-pad slicing).  The launcher only calls this helper after
+    confirming ``_orig_output_tensors is None`` on the current call
+    and ``fast_path.padded_output_arg_indices`` is empty (or the
+    ``_LauncherFastPath`` precomputation determined no padding is
+    needed for the static-shape signature).
+
+    Sets ``direct_call.full_invoke`` to the sentinel
+    ``_DIRECT_CALL_FULL_INVOKE_UNAVAILABLE`` when the kernel pattern
+    is one that ``_build_direct_call_full_invoke`` refuses to
+    pre-bake (mixed in-place + output-only).  The launcher checks
+    against the sentinel so subsequent calls don't retry baking.
+    """
+    invoke = _build_direct_call_full_invoke(
+        direct_call.call_custom_kernel,
+        direct_call.kernel_name,
+        direct_call.kernel_key,
+        direct_call.output_shapes,
+        direct_call.donate_argnums,
+        direct_call.out_tree,
+        direct_call.alias_items,
+        tuple(tensor_arg_indices),
+        fast_path.output_only_count,
+    )
+    direct_call.full_invoke = (
+        invoke if invoke is not None else _DIRECT_CALL_FULL_INVOKE_UNAVAILABLE
+    )
+
+
 def _pallas_invoke_and_return_fast(
     jax_callable: object,
     args: tuple[object, ...],
@@ -985,34 +1376,48 @@ def _pallas_invoke_and_return_fast(
         cast("torch.Tensor", args[i]).contiguous() for i in tensor_arg_indices
     ]
     if direct_call is not None:
-        # Guard the direct-dispatch path on the per-arg shape / dtype
-        # signature.  Dynamic-shape kernels reusing the same launcher
-        # cache entry across calls with different shapes fall back to
-        # the JaxCallable slow path on a sig mismatch.
-        direct_sig: tuple[object, ...] = tuple(
-            (a.shape, a.dtype) for a in input_tensors
-        )
-        if direct_sig == direct_call.sig:
-            global _CALL_CUSTOM_KERNEL_DIRECT_HITS, _JAXCALLABLE_KEY_CACHE_HITS
+        # G5-launcher-Y squeeze: once the launcher has seen one
+        # successful sig match on this cache entry, the per-call
+        # ``direct_sig`` tuple build + comparison is provably
+        # constant-True (the launcher cache is grid-keyed and a
+        # grid-stable cache hit on a static-shape kernel implies
+        # shape-stable args).  Skip the check on the locked path and
+        # call the pre-baked ``invoke`` closure directly.
+        global \
+            _CALL_CUSTOM_KERNEL_DIRECT_HITS, \
+            _JAXCALLABLE_KEY_CACHE_HITS, \
+            _DIRECT_CALL_SIG_CHECKS_SKIPPED
+        if direct_call.sig_locked:
             _CALL_CUSTOM_KERNEL_DIRECT_HITS += 1
-            # The direct-dispatch path is a stricter version of the
-            # JaxCallable-subclass invocation-key elision (it skips the
-            # subclass entirely); bump the JaxCallable counter too so
-            # both pin tests stay valid signals for "the per-call
-            # invocation-key f-string build was elided".
             _JAXCALLABLE_KEY_CACHE_HITS += 1
-            results = direct_call.call_custom_kernel(  # type: ignore[operator]
-                direct_call.kernel_name,
-                direct_call.kernel_key,
-                inputs=input_tensors,
-                output_shapes=direct_call.output_shapes,
-                donate_argnums=direct_call.donate_argnums,
-            )
-            for in_idx, out_idx in direct_call.alias_items:
-                input_tensors[in_idx].copy_(results[out_idx])
-            results = direct_call.out_tree.unflatten(results)  # type: ignore[attr-defined]
+            _DIRECT_CALL_SIG_CHECKS_SKIPPED += 1
+            results = direct_call.invoke(input_tensors)  # type: ignore[operator]
         else:
-            results = jax_callable(*input_tensors)  # type: ignore[operator]
+            # First direct-dispatch call on this cache entry: verify
+            # the per-arg shape / dtype signature matches the captured
+            # one.  Dynamic-shape kernels reusing the same launcher
+            # cache entry across calls with different shapes fall back
+            # to the JaxCallable slow path on a sig mismatch.
+            direct_sig: tuple[object, ...] = tuple(
+                (a.shape, a.dtype) for a in input_tensors
+            )
+            if direct_sig == direct_call.sig:
+                _CALL_CUSTOM_KERNEL_DIRECT_HITS += 1
+                # The direct-dispatch path is a stricter version of
+                # the JaxCallable-subclass invocation-key elision (it
+                # skips the subclass entirely); bump the JaxCallable
+                # counter too so both pin tests stay valid signals
+                # for "the per-call invocation-key f-string build was
+                # elided".
+                _JAXCALLABLE_KEY_CACHE_HITS += 1
+                # Lock the sig check for subsequent calls so the
+                # per-call tuple-build / compare disappears from the
+                # hot path entirely.  See module-level
+                # ``_DIRECT_CALL_SIG_CHECKS_SKIPPED`` docstring.
+                direct_call.sig_locked = True
+                results = direct_call.invoke(input_tensors)  # type: ignore[operator]
+            else:
+                results = jax_callable(*input_tensors)  # type: ignore[operator]
     else:
         results = jax_callable(*input_tensors)  # type: ignore[operator]
 
@@ -1025,6 +1430,22 @@ def _pallas_invoke_and_return_fast(
 
     if results is None:
         return None
+    # G5-launcher-Y squeeze: matmul / single-output kernels (the
+    # universal pattern on TPU: ``out = torch.empty(...); ... return
+    # out``) hit the dominant ``output_only_count == 1`` /
+    # ``_orig_output_tensors is None`` shape on every call.  In that
+    # case the post-call work reduces to "is ``results`` a torch
+    # tensor → return it" with no list build, no interpret-mode
+    # branch, no isinstance check loop, and no enumerate.  Short
+    # circuit before the generic loop so the hot path skips a list
+    # allocation + 3 isinstance checks per call.
+    if (
+        output_only_count == 1
+        and _orig_output_tensors is None
+        and isinstance(results, torch.Tensor)
+    ):
+        return results
+
     if not isinstance(results, (tuple, list)):
         results = (results,)
 
@@ -1481,17 +1902,13 @@ def default_pallas_launcher(
     are excluded from pallas_call inputs to save VMEM.  Their results are
     returned as torch tensors.
     """
-    from .settings import is_pallas_interpret
-
-    interpret = (
-        _pallas_interpret if _pallas_interpret is not None else is_pallas_interpret()
-    )
-    if interpret:
-        _ensure_cpu_tpu_info()
-
-    if _output_indices is None:
-        _output_indices = []
-
+    # G5-launcher-Z squeeze: defer ``interpret`` computation to the slow
+    # path — the cache-hit branch never uses it, so the per-call
+    # ``_module_is_pallas_interpret()`` call (which walks a thread-local
+    # ``CompileEnvironment`` and falls back to ``os.environ.get``,
+    # ~2-3us per call) is wasted on every hot-path invocation.  Once
+    # the launcher cache exists the interpret mode is implicit in the
+    # cached ``jax_callable`` (the slow path baked it in).
     cache = getattr(pallas_kernel, "_pallas_cache", None)
     if cache is not None and cache[0] == grid:
         global _LAUNCHER_FAST_PATH_HITS
@@ -1504,6 +1921,26 @@ def default_pallas_launcher(
             fast_path,
             direct_call,
         ) = cache
+        # G5-launcher-Z fastest path: once ``full_invoke`` is populated
+        # (lazy lift below, on the second-or-later call), we know the
+        # locked path can be entered with a single attribute call.
+        # ``full_invoke`` only exists when:
+        # - the JaxCallable subclass populated ``_helion_direct_call``
+        #   (static_shapes=True path)
+        # - the launcher saw at least one successful sig match
+        #   (so ``sig_locked`` is True)
+        # - the kernel has no ds-padding to do
+        # so reaching ``full_invoke is not None`` provably means the
+        # entire post-call work reduces to its closure body and we can
+        # skip ``_pallas_invoke_and_return_fast`` entirely.
+        if direct_call is not None:
+            full_invoke = direct_call.full_invoke
+            if (
+                full_invoke is not None
+                and full_invoke is not _DIRECT_CALL_FULL_INVOKE_UNAVAILABLE
+            ):
+                return full_invoke(args)  # type: ignore[operator]
+
         # Lazily lift the direct-call kernel off the JaxCallable subclass
         # once the first call has populated it.  Mutating the cache tuple
         # in place is OK: ``_pallas_cache`` is keyed by ``grid`` and we
@@ -1528,12 +1965,37 @@ def default_pallas_launcher(
                 fast_path,
                 fast_path.padded_output_arg_indices,
             )
+        # Lazily bake ``full_invoke`` once the sig has locked and the
+        # path is safe to short-circuit.  Requires: direct_call exists,
+        # sig is locked, no ds-padding work pending this call.  We need
+        # the launcher's view of ``tensor_arg_indices`` + ``fast_path``
+        # (the JaxCallable subclass doesn't know either).
+        if (
+            direct_call is not None
+            and direct_call.sig_locked
+            and _orig_output_tensors is None
+            and not (_ds_pad_dims and fast_path.ds_pad_required is not False)
+            and direct_call.full_invoke is None
+        ):
+            _maybe_bake_full_invoke(direct_call, fast_path, tensor_arg_indices)
+
         # ``_pallas_check_dtypes`` is elided on cache-hit: the first
         # call already validated and any dtype-incompatible call after
         # would fail loudly inside ``JaxCallable.__call__``.
         return _pallas_invoke_and_return_fast(
             jax_callable, args, fast_path, _orig_output_tensors, direct_call
         )
+
+    interpret = (
+        _pallas_interpret
+        if _pallas_interpret is not None
+        else _module_is_pallas_interpret()
+    )
+    if interpret:
+        _ensure_cpu_tpu_info()
+
+    if _output_indices is None:
+        _output_indices = []
 
     _orig_output_tensors = None
     if _ds_pad_dims:
@@ -1694,19 +2156,6 @@ def default_pallas_pipeline_launcher(
     is empty — the marker only fires for kernels that put a reduction in
     the outer grid.
     """
-    from .settings import is_pallas_interpret
-
-    interpret = (
-        _pallas_interpret if _pallas_interpret is not None else is_pallas_interpret()
-    )
-    if interpret:
-        _ensure_cpu_tpu_info()
-
-    if _output_indices is None:
-        _output_indices = []
-    if _scratch_shapes is None:
-        _scratch_shapes = []
-
     cache = getattr(pallas_kernel, "_pallas_pipeline_cache", None)
     if cache is not None and cache[0] == grid:
         global _LAUNCHER_FAST_PATH_HITS
@@ -1719,6 +2168,14 @@ def default_pallas_pipeline_launcher(
             fast_path,
             direct_call,
         ) = cache
+        if direct_call is not None:
+            full_invoke = direct_call.full_invoke
+            if (
+                full_invoke is not None
+                and full_invoke is not _DIRECT_CALL_FULL_INVOKE_UNAVAILABLE
+            ):
+                return full_invoke(args)  # type: ignore[operator]
+
         if direct_call is None:
             direct_call = getattr(jax_callable, "_helion_direct_call", None)
             if direct_call is not None:
@@ -1739,9 +2196,30 @@ def default_pallas_pipeline_launcher(
                 fast_path,
                 fast_path.padded_output_arg_indices,
             )
+        if (
+            direct_call is not None
+            and direct_call.sig_locked
+            and _orig_output_tensors is None
+            and not (_ds_pad_dims and fast_path.ds_pad_required is not False)
+            and direct_call.full_invoke is None
+        ):
+            _maybe_bake_full_invoke(direct_call, fast_path, tensor_arg_indices)
         return _pallas_invoke_and_return_fast(
             jax_callable, args, fast_path, _orig_output_tensors, direct_call
         )
+
+    interpret = (
+        _pallas_interpret
+        if _pallas_interpret is not None
+        else _module_is_pallas_interpret()
+    )
+    if interpret:
+        _ensure_cpu_tpu_info()
+
+    if _output_indices is None:
+        _output_indices = []
+    if _scratch_shapes is None:
+        _scratch_shapes = []
 
     _orig_output_tensors = None
     if _ds_pad_dims:
@@ -1933,19 +2411,6 @@ def default_pallas_fori_launcher(
     independence.  See :func:`default_pallas_pipeline_launcher` for the
     matmul-specific notes about why this list is typically empty.
     """
-    from .settings import is_pallas_interpret
-
-    interpret = (
-        _pallas_interpret if _pallas_interpret is not None else is_pallas_interpret()
-    )
-    if interpret:
-        _ensure_cpu_tpu_info()
-
-    if _output_indices is None:
-        _output_indices = []
-    if _scratch_shapes is None:
-        _scratch_shapes = []
-
     cache = getattr(pallas_kernel, "_pallas_fori_cache", None)
     if cache is not None and cache[0] == grid:
         global _LAUNCHER_FAST_PATH_HITS
@@ -1958,6 +2423,14 @@ def default_pallas_fori_launcher(
             fast_path,
             direct_call,
         ) = cache
+        if direct_call is not None:
+            full_invoke = direct_call.full_invoke
+            if (
+                full_invoke is not None
+                and full_invoke is not _DIRECT_CALL_FULL_INVOKE_UNAVAILABLE
+            ):
+                return full_invoke(args)  # type: ignore[operator]
+
         if direct_call is None:
             direct_call = getattr(jax_callable, "_helion_direct_call", None)
             if direct_call is not None:
@@ -1978,9 +2451,30 @@ def default_pallas_fori_launcher(
                 fast_path,
                 fast_path.padded_output_arg_indices,
             )
+        if (
+            direct_call is not None
+            and direct_call.sig_locked
+            and _orig_output_tensors is None
+            and not (_ds_pad_dims and fast_path.ds_pad_required is not False)
+            and direct_call.full_invoke is None
+        ):
+            _maybe_bake_full_invoke(direct_call, fast_path, tensor_arg_indices)
         return _pallas_invoke_and_return_fast(
             jax_callable, args, fast_path, _orig_output_tensors, direct_call
         )
+
+    interpret = (
+        _pallas_interpret
+        if _pallas_interpret is not None
+        else _module_is_pallas_interpret()
+    )
+    if interpret:
+        _ensure_cpu_tpu_info()
+
+    if _output_indices is None:
+        _output_indices = []
+    if _scratch_shapes is None:
+        _scratch_shapes = []
 
     _orig_output_tensors = None
     if _ds_pad_dims:

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -193,6 +193,19 @@ class Kernel(Generic[_R]):
         self._specialize_extra: dict[
             Hashable, list[Callable[[Sequence[object]], Hashable]]
         ] = {}
+        # G5-decorator fast path: speculative single-bound-kernel cache.
+        # Holds a tuple ``(fast_key, bound_kernel)`` where ``fast_key`` is
+        # the per-call fingerprint computed by ``_kernel_fast_call_key``
+        # for the most recent successful ``bind(...)`` result whose
+        # ``BoundKernel._run`` is populated.  ``Kernel.__call__`` checks
+        # the cached ``fast_key`` against the incoming args' fingerprint
+        # *before* entering ``bind`` / ``BoundKernel.__call__`` and
+        # short-circuits to ``bound._run(*args)`` on a hit, skipping
+        # ``_base_specialization_key`` / ``_get_bound_kernel_cache_key``
+        # / ``BoundKernel.__call__``'s ``if self._run is None`` check
+        # entirely.  ``None`` until the slow path completes one call and
+        # ``BoundKernel._run`` is set.
+        self._last_bound: tuple[tuple[object, ...], BoundKernel[_R]] | None = None
         if any(
             param.kind
             in (
@@ -410,9 +423,53 @@ class Kernel(Generic[_R]):
         Returns:
             _R: The result of the Kernel function call.
         """
+        # G5-decorator fast path: skip ``bind`` / ``_base_specialization_key``
+        # / ``BoundKernel.__call__`` entirely when ``args`` matches the
+        # most recently dispatched ``BoundKernel``'s per-call
+        # fingerprint.  Steady-state matmul / output-only kernel calls
+        # (single shape, static dtype / stride / device) hit this branch
+        # every time after the first warmup call seeds ``_last_bound``.
+        #
+        # Bail conditions for safety:
+        # - ``kwargs`` non-empty (must run through ``normalize_args``);
+        # - ``self._key_fn is not None`` (caller-supplied
+        #   ``helion.kernel(key=...)`` extractor; we don't replicate it
+        #   on the fast path because its return value can depend on
+        #   tensor *values* — see ``_base_specialization_key`` lines
+        #   appending ``self._key_fn(*args)`` — so a fast-key match on
+        #   the same ``(dtype, shape, stride, device)`` could still
+        #   require a different ``BoundKernel``.  Skip the speculative
+        #   cache entirely for these kernels);
+        # - ``args`` contains an unsupported type (``_kernel_fast_call_key``
+        #   returns ``None``).
+        if not kwargs and self._key_fn is None:
+            last = self._last_bound
+            if last is not None:
+                fast_key = _kernel_fast_call_key(args)
+                if fast_key is not None and fast_key == last[0]:
+                    _bump_kernel_fast_path_hits()
+                    # ``_last_bound`` is only installed once ``_run`` is
+                    # set (and the slot is cleared on ``reset()``), so
+                    # the ``Callable[..., _R] | None`` type is narrowed
+                    # to ``Callable[..., _R]`` here.
+                    return last[1]._run(*args)  # type: ignore[misc]
         if kwargs:
             args = self.normalize_args(*args, **kwargs)
-        return self.bind(args)(*args)
+        bound = self.bind(args)
+        # Install / refresh the speculative cache only once the
+        # ``BoundKernel`` has a compiled ``_run``; the first call still
+        # falls into ``BoundKernel.__call__``'s slow path (which triggers
+        # autotune / set_config / compile_config), so we trigger the
+        # bound invocation first and then promote it to ``_last_bound``
+        # for subsequent calls.  Skip the install when ``_key_fn`` is
+        # set so the fast path stays disabled across the kernel's
+        # lifetime — symmetric with the bail at the top of this method.
+        result = bound(*args)
+        if bound._run is not None and self._key_fn is None:
+            fast_key = _kernel_fast_call_key(args)
+            if fast_key is not None:
+                self._last_bound = (fast_key, bound)
+        return result
 
     def reset(self) -> None:
         """
@@ -420,6 +477,7 @@ class Kernel(Generic[_R]):
         recompile and re-autotune.
         """
         self._bound_kernels.clear()
+        self._last_bound = None
 
 
 class BoundKernel(_AutotunableKernel, Generic[_R]):
@@ -1420,6 +1478,109 @@ def _safe_bucket_dim(s: int | torch.SymInt) -> Hashable:
 
 
 _EMPTY_FROZENSET: frozenset[int] = frozenset()
+
+
+# G5-decorator: per-call ``Kernel.__call__`` decorator fast-path hits.
+# Counter lives here (not in ``helion/runtime/__init__.py``) because the
+# bump fires from ``Kernel.__call__`` and routing through the parent
+# module would create an import cycle (``helion.runtime`` imports
+# ``Kernel`` from this module at line ``from .kernel import Kernel``).
+# The parent module re-exports the three accessors so test code reads
+# ``helion.runtime._kernel_fast_path_hits()`` consistent with the other
+# per-call counters defined alongside ``_DirectCallKernel``.
+_KERNEL_FAST_PATH_HITS: int = 0
+
+
+def _kernel_fast_path_hits() -> int:
+    """Return the count of decorator-fast-path direct-dispatch hits."""
+    return _KERNEL_FAST_PATH_HITS
+
+
+def _reset_kernel_fast_path_hits() -> None:
+    """Reset the decorator-fast-path counter (test instrumentation)."""
+    global _KERNEL_FAST_PATH_HITS
+    _KERNEL_FAST_PATH_HITS = 0
+
+
+def _bump_kernel_fast_path_hits() -> None:
+    """Increment the decorator-fast-path counter.
+
+    Called from ``Kernel.__call__`` on every cache-hit invocation that
+    short-circuits to the cached ``BoundKernel._run`` without entering
+    ``Kernel.bind`` / ``BoundKernel.__call__``.
+    """
+    global _KERNEL_FAST_PATH_HITS
+    _KERNEL_FAST_PATH_HITS += 1
+
+
+# Types whose values are themselves hashable in a way that uniquely
+# determines their specialization key — primitive scalars, dtypes,
+# devices, and the ``ConstExpr`` wrapper.  Sequences and dicts deliberately
+# excluded: their specialization key recursively walks per element,
+# which we don't want to replicate on the hot path; ``Kernel.__call__``
+# falls through to the slow ``bind`` path on those types.
+_FAST_KEY_VALUE_TYPES: tuple[type, ...] = (
+    int,
+    float,
+    bool,
+    str,
+    type(None),
+    torch.dtype,
+    torch.device,
+)
+
+
+def _kernel_fast_call_key(args: tuple[object, ...]) -> tuple[object, ...] | None:
+    """Build a cheap per-call fingerprint for the decorator fast path.
+
+    Returns a tuple comparable with ``==`` against a previously cached
+    fingerprint, or ``None`` if any arg's type isn't on the supported
+    fast-path allow-list (``torch.Tensor``, scalar / primitive,
+    ``torch.dtype``, ``torch.device``, ``ConstExpr``).  Sequence / dict
+    / GraphModule / custom-class args fall through to the slow path
+    (``Kernel.bind`` / ``_base_specialization_key``) because their
+    specialization key recurses per element, which is too expensive to
+    replicate inline on the hot path for a single-slot cache.
+
+    The per-tensor entry captures the same metadata as the slow
+    ``_tensor_key`` path (``dtype``, ``shape``, ``stride``) plus the
+    tensor's ``device`` (the slow path captures device only via
+    ``_device_specialization_key`` over all args; the fast path captures
+    it per-tensor so a device change is caught even when the tensor's
+    other metadata coincides).  Pinning per-tensor ``device`` rather than
+    a global device fingerprint also lets the fast path correctly miss
+    when one of two same-shape tensors moves to a different device.
+    """
+    n = len(args)
+    if n == 0:
+        # Zero-arg kernels can't pin a fingerprint to anything useful;
+        # fall through to the slow path.  (The slow path's
+        # ``_find_device`` would also raise ``NoTensorArgs`` here, but
+        # we don't want to silently mask that.)
+        return None
+    key: list[object] = []
+    for arg in args:
+        if isinstance(arg, torch.Tensor):
+            # ``shape`` returns the cached ``torch.Size``; ``stride()``
+            # returns a fresh tuple but is cheap.  ``dtype`` and
+            # ``device`` are interned singletons.
+            key.append((torch.Tensor, arg.dtype, arg.shape, arg.stride(), arg.device))
+        elif isinstance(arg, ConstExpr):
+            # ConstExpr's specialization key is ``arg.value`` (see
+            # ``_specialization_extractors[ConstExpr]``); fingerprint by
+            # ``(ConstExpr, value)`` so two ``ConstExpr`` with the same
+            # value share the cached bound kernel.  Value itself must be
+            # one of the supported fast-key value types (otherwise its
+            # equality semantics aren't safe for the speculative cache).
+            value = arg.value
+            if not isinstance(value, _FAST_KEY_VALUE_TYPES):
+                return None
+            key.append((ConstExpr, value))
+        elif isinstance(arg, _FAST_KEY_VALUE_TYPES):
+            key.append((type(arg), arg))
+        else:
+            return None
+    return tuple(key)
 
 
 def _bucketed_size(obj: torch.Tensor) -> tuple[Hashable, ...]:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -2003,6 +2003,633 @@ class TestPallas(TestCase):
             "Three repeat calls must each hit the direct-dispatch path.",
         )
 
+    def test_pallas_direct_call_sig_check_locks_on_static_shapes(self) -> None:
+        """Static-shape kernel locks the per-call sig check on first match.
+
+        G5-launcher-Y squeeze (2026-05-25 plan.md §5 G5-launcher-Y):
+        once the launcher's direct-dispatch path sees one successful
+        ``direct_sig == direct_call.sig`` match on a launcher cache
+        entry, the per-call tuple build + comparison is provably
+        constant-True (the launcher cache is grid-keyed and a
+        grid-stable cache hit on a static-shape kernel implies
+        shape-stable args).  The first match flips
+        ``_DirectCallKernel.sig_locked`` to ``True`` so subsequent calls
+        skip the per-call tuple build + comparison entirely and bump
+        ``helion.runtime._DIRECT_CALL_SIG_CHECKS_SKIPPED``.
+
+        The test asserts: calls 1 (slow path, populates cache) + 2
+        (first direct-dispatch hit, sig matches, lock flips) do NOT
+        bump the skip counter; calls 3..N each skip the sig check and
+        bump the counter exactly once per call.  Output equality is
+        preserved (the lock is safe under static_shapes=True).
+        """
+        from helion import runtime as helion_runtime
+
+        # Define inside the test so the launcher cache is fresh and
+        # not polluted by other tests that bind the same kernel.
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def _matmul_sig_lock_pin(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty(
+                [m, n],
+                device=x.device,
+                dtype=torch.promote_types(x.dtype, y.dtype),
+            )
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc
+            return out
+
+        torch.manual_seed(0)
+        x = torch.randn(256, 256, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(256, 256, device=DEVICE, dtype=torch.bfloat16)
+
+        bound = _matmul_sig_lock_pin.bind((x, y))
+        config = bound.config_spec.default_config()
+        compiled_fn = bound.compile_config(config)
+
+        helion_runtime._reset_direct_call_sig_checks_skipped()
+        self.assertEqual(helion_runtime._direct_call_sig_checks_skipped(), 0)
+
+        # Call 1: slow path (seeds the JaxCallable cache; no
+        # direct-dispatch yet, no sig check, no skip).
+        reference = compiled_fn(x, y).clone()
+        self.assertEqual(
+            helion_runtime._direct_call_sig_checks_skipped(),
+            0,
+            "First call must be the slow path; no sig check yet.",
+        )
+
+        # Call 2: first direct-dispatch call.  Runs the sig check,
+        # matches, flips ``sig_locked``.  Does NOT bump the skip
+        # counter (the lock only takes effect on subsequent calls).
+        result = compiled_fn(x, y)
+        self.assertTrue(
+            torch.equal(result, reference),
+            "Direct-dispatch first-match call output diverged "
+            "(max_abs_diff="
+            f"{(result.float() - reference.float()).abs().max().item()}).",
+        )
+        self.assertEqual(
+            helion_runtime._direct_call_sig_checks_skipped(),
+            0,
+            "First sig-match call must run the sig check, not skip it.",
+        )
+
+        # Calls 3..N: sig_locked is True; each call skips the per-call
+        # tuple build + comparison and bumps the skip counter.
+        n_repeats = 5
+        for _ in range(n_repeats):
+            result = compiled_fn(x, y)
+            self.assertTrue(
+                torch.equal(result, reference),
+                "Sig-locked direct-dispatch call output diverged "
+                "(max_abs_diff="
+                f"{(result.float() - reference.float()).abs().max().item()}).",
+            )
+        self.assertEqual(
+            helion_runtime._direct_call_sig_checks_skipped(),
+            n_repeats,
+            f"Sig-locked direct-dispatch calls must each skip the "
+            f"sig check; expected {n_repeats} skips, got "
+            f"{helion_runtime._direct_call_sig_checks_skipped()}.",
+        )
+
+    def test_pallas_launcher_caches_output_tensor(self) -> None:
+        """Static-shape kernel caches the per-call output meta placeholder.
+
+        The generated host code's ``torch.empty(..., device='meta')`` for
+        each output-only tensor is hoisted to a one-shot cache slot
+        attached to the inner Helion-emitted function (see the
+        ``output_meta_init_stmts`` block in
+        ``helion/_compiler/generate_ast.py``).  On a
+        ``static_shapes=True`` kernel the output shape / dtype / device
+        are constant across calls, so the meta placeholder is built
+        exactly once on the first call and reused on every subsequent
+        call; the runtime counter
+        ``helion.runtime._OUTPUT_TENSOR_ALLOCATIONS`` is bumped exactly
+        once per cached slot.
+        """
+        from helion import runtime as helion_runtime
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def _matmul_output_meta_pin(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty(
+                [m, n],
+                device=x.device,
+                dtype=torch.promote_types(x.dtype, y.dtype),
+            )
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc
+            return out
+
+        torch.manual_seed(0)
+        x = torch.randn(256, 256, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(256, 256, device=DEVICE, dtype=torch.bfloat16)
+
+        bound = _matmul_output_meta_pin.bind((x, y))
+        config = bound.config_spec.default_config()
+        compiled_fn = bound.compile_config(config)
+
+        helion_runtime._reset_output_tensor_allocations()
+        self.assertEqual(helion_runtime._output_tensor_allocations(), 0)
+
+        # First call populates the cache and bumps the counter once.
+        # Save the result so we can confirm bitwise equality vs a
+        # freshly-compiled baseline (which proves that the cached meta
+        # placeholder does not contaminate the result).
+        reference = compiled_fn(x, y).clone()
+        self.assertEqual(
+            helion_runtime._output_tensor_allocations(),
+            1,
+            "First call must allocate the meta placeholder exactly once.",
+        )
+
+        # Repeat invocations: the cache slot is now populated, so the
+        # ``if out is None`` branch in the generated host code does not
+        # fire and the counter stays at 1.
+        n_repeats = 10
+        for _ in range(n_repeats):
+            result = compiled_fn(x, y)
+            self.assertTrue(
+                torch.equal(result, reference),
+                "Output diverged after cached meta-placeholder reuse "
+                f"(max_abs_diff="
+                f"{(result.float() - reference.float()).abs().max().item()}).",
+            )
+        self.assertEqual(
+            helion_runtime._output_tensor_allocations(),
+            1,
+            f"Repeat calls must reuse the cached meta placeholder; "
+            f"expected exactly 1 allocation across "
+            f"{1 + n_repeats} calls, got "
+            f"{helion_runtime._output_tensor_allocations()}.",
+        )
+
+        # Compare to a freshly-compiled baseline kernel (no caching
+        # state on the inner device function): the result must be
+        # bitwise identical, proving the cache only stores the meta
+        # placeholder (zero-storage metadata only), not any kernel
+        # output bytes.
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def _matmul_output_meta_baseline(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty(
+                [m, n],
+                device=x.device,
+                dtype=torch.promote_types(x.dtype, y.dtype),
+            )
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc
+            return out
+
+        bound_baseline = _matmul_output_meta_baseline.bind((x, y))
+        baseline_fn = bound_baseline.compile_config(
+            bound_baseline.config_spec.default_config()
+        )
+        baseline_result = baseline_fn(x, y)
+        self.assertTrue(
+            torch.equal(reference, baseline_result),
+            "Cached-meta result diverged from freshly-compiled baseline "
+            f"(max_abs_diff="
+            f"{(reference.float() - baseline_result.float()).abs().max().item()}).",
+        )
+
+    def test_pallas_direct_call_full_invoke_bakes_on_locked_static_shapes(
+        self,
+    ) -> None:
+        """Static-shape kernel pre-bakes the full locked-path closure.
+
+        G5-launcher-Z squeeze (2026-05-25 plan.md §5 G5-launcher-Z):
+        once the launcher sees a successful sig-lock on the
+        direct-dispatch path, it pre-bakes a ``full_invoke`` closure
+        on ``_DirectCallKernel`` that folds the ``args.contiguous()``
+        walk, the ``call_custom_kernel`` invocation, and the
+        ``out_tree.unflatten`` together with the three locked-path
+        counter bumps into a single function call.  Subsequent
+        launcher invocations short-circuit before
+        ``_pallas_invoke_and_return_fast`` entirely, returning
+        ``direct_call.full_invoke(args)`` directly.
+
+        The test asserts: (a) ``full_invoke`` is ``None`` before the
+        first call; (b) still ``None`` after calls 1 (slow path) and
+        2 (first sig-match, lock flip); (c) populated after call 3
+        (the bake-trigger call); (d) every subsequent call returns a
+        bitwise-identical result; (e) the three test-instrumentation
+        counters fire exactly once per locked invocation (the
+        ``_bump_direct_locked_counters`` batched bump must match the
+        unbatched cycle-28 path's accounting).
+        """
+        from helion import runtime as helion_runtime
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def _matmul_full_invoke_pin(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty(
+                [m, n],
+                device=x.device,
+                dtype=torch.promote_types(x.dtype, y.dtype),
+            )
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc
+            return out
+
+        torch.manual_seed(0)
+        x = torch.randn(256, 256, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(256, 256, device=DEVICE, dtype=torch.bfloat16)
+
+        bound = _matmul_full_invoke_pin.bind((x, y))
+        config = bound.config_spec.default_config()
+        compiled_fn = bound.compile_config(config)
+
+        # The generated host function lives in ``compiled_fn``;
+        # ``compiled_fn.__globals__`` is the generated module
+        # namespace, which holds the inner ``_helion_<host>`` device
+        # function — the object the launcher writes its cache onto.
+        # The exact cache attribute name (``_pallas_cache`` /
+        # ``_pallas_pipeline_cache`` / ``_pallas_fori_cache``) depends
+        # on which ``pallas_loop_type`` the default config picks
+        # (``unroll`` / ``emit_pipeline`` / ``fori_loop``); read
+        # whichever one is populated.
+        _CACHE_ATTRS = (
+            "_pallas_cache",
+            "_pallas_pipeline_cache",
+            "_pallas_fori_cache",
+        )
+
+        def _find_pallas_kernel() -> object:
+            module_globals = compiled_fn.__globals__
+            inner_name = f"_helion_{compiled_fn.__name__}"
+            inner = module_globals.get(inner_name)
+            assert inner is not None, (
+                f"Generated module must export the inner Helion "
+                f"function ``{inner_name}`` from "
+                f"``compiled_fn.__globals__``; found keys "
+                f"{[k for k in module_globals if k.startswith('_helion')]}."
+            )
+            return inner
+
+        def _read_cache(pallas_kernel: object) -> tuple:
+            for attr in _CACHE_ATTRS:
+                cache = getattr(pallas_kernel, attr, None)
+                if cache is not None:
+                    return cache  # type: ignore[return-value]
+            raise AssertionError(
+                f"None of {_CACHE_ATTRS} populated on the inner "
+                f"Helion kernel ``{type(pallas_kernel).__name__}``; "
+                f"available attrs: "
+                f"{[a for a in dir(pallas_kernel) if a.startswith('_pallas')]}."
+            )
+
+        helion_runtime._reset_direct_call_sig_checks_skipped()
+        helion_runtime._reset_call_custom_kernel_direct_hits()
+        helion_runtime._reset_jaxcallable_key_cache_hits()
+
+        # Call 1: slow path; builds the launcher cache, snapshots the
+        # ``_helion_direct_call`` on the JaxCallable subclass, returns
+        # the reference output.  No counters bumped yet.
+        reference = compiled_fn(x, y).clone()
+        pallas_kernel = _find_pallas_kernel()
+        cache = _read_cache(pallas_kernel)
+        # cache tuple shape: (grid, jax_callable, tensor_arg_indices,
+        # arg_to_tensor_pos, fast_path, direct_call).
+        # direct_call is None until the launcher's lazy-lift fires on
+        # call 2.
+        self.assertIsNone(
+            cache[5],
+            "direct_call slot must be None before the lazy lift fires "
+            "(it's populated lazily on call 2).",
+        )
+
+        # Call 2: cache hit, lazy lift of direct_call off the
+        # JaxCallable subclass, sig check matches, lock flips.
+        # full_invoke is NOT baked yet (the launcher only bakes on the
+        # call *after* sig_locked flips to True, since baking requires
+        # the sig_locked precondition to gate the short-circuit).
+        result_2 = compiled_fn(x, y)
+        cache = _read_cache(pallas_kernel)
+        direct_call = cache[5]
+        self.assertIsNotNone(
+            direct_call,
+            "direct_call slot must be populated after the lazy lift on call 2.",
+        )
+        self.assertTrue(
+            direct_call.sig_locked,
+            "sig_locked must flip to True on the first successful sig match (call 2).",
+        )
+        self.assertIsNone(
+            direct_call.full_invoke,
+            "full_invoke must NOT be baked until call 3 (the launcher "
+            "only bakes when sig_locked is already True on entry).",
+        )
+        self.assertTrue(
+            torch.equal(result_2, reference),
+            "Call 2 (first sig-match) output diverged "
+            "(max_abs_diff="
+            f"{(result_2.float() - reference.float()).abs().max().item()}).",
+        )
+
+        # Call 3: bake-trigger call.  Enters the launcher with
+        # sig_locked=True and full_invoke=None, so ``_maybe_bake_full_invoke``
+        # populates ``direct_call.full_invoke`` before dispatching
+        # through ``_pallas_invoke_and_return_fast``'s locked path.
+        # This call still bumps the counters via the locked-path
+        # branch in ``_pallas_invoke_and_return_fast`` (one batch of
+        # three increments).
+        result_3 = compiled_fn(x, y)
+        self.assertIsNotNone(
+            direct_call.full_invoke,
+            "full_invoke must be baked on call 3 (the launcher bakes "
+            "after sig_locked is True and before invoking the locked "
+            "path).",
+        )
+        # Sanity check: the baked closure isn't the
+        # ``_DIRECT_CALL_FULL_INVOKE_UNAVAILABLE`` sentinel (this
+        # matmul fits the pure-output pattern).
+        self.assertIsNot(
+            direct_call.full_invoke,
+            helion_runtime._DIRECT_CALL_FULL_INVOKE_UNAVAILABLE,
+            "full_invoke must be a real closure for a pure-output "
+            "kernel; got the unavailability sentinel.",
+        )
+        self.assertTrue(
+            torch.equal(result_3, reference),
+            "Call 3 (bake-trigger) output diverged "
+            "(max_abs_diff="
+            f"{(result_3.float() - reference.float()).abs().max().item()}).",
+        )
+
+        # Calls 4..N: full_invoke is now baked, so the launcher
+        # short-circuits to ``direct_call.full_invoke(args)`` before
+        # ``_pallas_invoke_and_return_fast``.  Every call still bumps
+        # the three locked counters once (via
+        # ``_bump_direct_locked_counters`` inside the closure).
+        # Snapshot baseline counters for the post-bake-only delta.
+        skipped_before = helion_runtime._direct_call_sig_checks_skipped()
+        direct_hits_before = helion_runtime._call_custom_kernel_direct_hits()
+        keycache_hits_before = helion_runtime._jaxcallable_key_cache_hits()
+        n_repeats = 5
+        for _ in range(n_repeats):
+            result = compiled_fn(x, y)
+            self.assertTrue(
+                torch.equal(result, reference),
+                "Post-bake locked-path call output diverged "
+                "(max_abs_diff="
+                f"{(result.float() - reference.float()).abs().max().item()}).",
+            )
+        # Each post-bake call must bump all three counters exactly
+        # once (the batched ``_bump_direct_locked_counters`` matches
+        # the cycle-28 unbatched three-increment accounting).
+        self.assertEqual(
+            helion_runtime._direct_call_sig_checks_skipped() - skipped_before,
+            n_repeats,
+            f"Post-bake locked-path calls must each bump the sig-skip "
+            f"counter; expected {n_repeats} new skips, got "
+            f"{helion_runtime._direct_call_sig_checks_skipped() - skipped_before}.",
+        )
+        self.assertEqual(
+            helion_runtime._call_custom_kernel_direct_hits() - direct_hits_before,
+            n_repeats,
+            f"Post-bake locked-path calls must each bump the "
+            f"direct-hits counter; expected {n_repeats} new hits, got "
+            f"{helion_runtime._call_custom_kernel_direct_hits() - direct_hits_before}.",
+        )
+        self.assertEqual(
+            helion_runtime._jaxcallable_key_cache_hits() - keycache_hits_before,
+            n_repeats,
+            f"Post-bake locked-path calls must each bump the "
+            f"key-cache counter; expected {n_repeats} new hits, got "
+            f"{helion_runtime._jaxcallable_key_cache_hits() - keycache_hits_before}.",
+        )
+
+    def test_pallas_kernel_decorator_fast_path_skips_bind_on_repeat_calls(
+        self,
+    ) -> None:
+        """Static-shape kernel short-circuits Kernel.__call__ to BoundKernel._run.
+
+        G5-decorator squeeze (2026-05-25 plan.md §5 G5-decorator): once
+        ``Kernel.__call__`` has dispatched one call to a ``BoundKernel``
+        whose ``_run`` is set, the speculative ``_last_bound`` slot is
+        populated with the per-call fingerprint
+        (``_kernel_fast_call_key``) for the args.  Subsequent calls with
+        args matching that fingerprint (per-tensor
+        ``dtype/shape/stride/device`` + per-scalar value identity) skip
+        ``Kernel.bind`` (which spends ~12-20us on
+        ``_base_specialization_key`` / ``_device_specialization_key`` /
+        ``_get_bound_kernel_cache_key``) and
+        ``BoundKernel.__call__`` (which costs an attribute load + an
+        ``is None`` check) entirely, routing through the
+        ``_last_bound[1]._run(*args)`` direct dispatch.  The counter
+        ``helion.runtime._kernel_fast_path_hits()`` bumps once per
+        shortcut.
+
+        The test asserts: call 1 goes through the slow ``bind`` path
+        (counter stays at 0); calls 2..N each shortcut and bump the
+        counter exactly once per call.  Output equality is preserved
+        (the bypass is safe under static_shapes=True because the
+        fingerprint captures exactly what the slow
+        ``_base_specialization_key`` derives from for tensor args).
+        """
+        from helion import runtime as helion_runtime
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def _matmul_decorator_fast_path_pin(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty(
+                [m, n],
+                device=x.device,
+                dtype=torch.promote_types(x.dtype, y.dtype),
+            )
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc
+            return out
+
+        torch.manual_seed(0)
+        x = torch.randn(256, 256, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(256, 256, device=DEVICE, dtype=torch.bfloat16)
+
+        # Pin the slow-path fingerprint installer: before any call,
+        # ``_last_bound`` must be ``None`` (no speculative cache).
+        self.assertIsNone(
+            _matmul_decorator_fast_path_pin._last_bound,
+            "Fast-path slot must be None before the first call.",
+        )
+
+        helion_runtime._reset_kernel_fast_path_hits()
+        self.assertEqual(helion_runtime._kernel_fast_path_hits(), 0)
+
+        # Call 1: slow path (autotune / compile / set_config /
+        # _run := compiled_fn).  After the call, ``_last_bound`` is
+        # installed with the fingerprint for ``(x, y)``.  The counter
+        # is still 0 — the slow path itself does not bump it.
+        reference = _matmul_decorator_fast_path_pin(x, y).clone()
+        self.assertEqual(
+            helion_runtime._kernel_fast_path_hits(),
+            0,
+            "First call must run the slow ``bind`` path; counter must not bump.",
+        )
+        self.assertIsNotNone(
+            _matmul_decorator_fast_path_pin._last_bound,
+            "Fast-path slot must be populated after the first call "
+            "completes (the slow path installs ``_last_bound`` once "
+            "``BoundKernel._run`` is set).",
+        )
+
+        # Calls 2..N: ``_last_bound`` is populated and the per-call
+        # fingerprint matches, so each call shortcuts to
+        # ``last[1]._run(*args)`` and bumps the counter.
+        n_repeats = 10
+        for _ in range(n_repeats):
+            result = _matmul_decorator_fast_path_pin(x, y)
+            self.assertTrue(
+                torch.equal(result, reference),
+                "Decorator fast-path call output diverged "
+                "(max_abs_diff="
+                f"{(result.float() - reference.float()).abs().max().item()}).",
+            )
+        self.assertEqual(
+            helion_runtime._kernel_fast_path_hits(),
+            n_repeats,
+            f"Each post-warmup call must bump the decorator fast-path "
+            f"counter exactly once; expected {n_repeats} hits, got "
+            f"{helion_runtime._kernel_fast_path_hits()}.",
+        )
+
+        # Sanity: a shape-changing call must miss the fast path
+        # (different fingerprint) and route back through the slow
+        # ``bind`` path.  The counter must NOT bump on that call.
+        x2 = torch.randn(128, 128, device=DEVICE, dtype=torch.bfloat16)
+        y2 = torch.randn(128, 128, device=DEVICE, dtype=torch.bfloat16)
+        hits_before_miss = helion_runtime._kernel_fast_path_hits()
+        _ = _matmul_decorator_fast_path_pin(x2, y2)
+        self.assertEqual(
+            helion_runtime._kernel_fast_path_hits(),
+            hits_before_miss,
+            "Shape-changing call must miss the fast path; counter must not bump.",
+        )
+
+        # Bail #1: passing kwargs forces ``Kernel.__call__`` through
+        # ``normalize_args`` and the slow ``bind`` path; the fast-path
+        # check is skipped (the speculative cache is keyed on positional
+        # args only).  After the kwargs call ``_last_bound`` is
+        # refreshed for the normalized positional form, so the
+        # immediately-following positional call hits the fast path
+        # again.  Pinned so a future change to the kwargs branch can't
+        # silently break the bail.
+        hits_before_kwargs = helion_runtime._kernel_fast_path_hits()
+        _ = _matmul_decorator_fast_path_pin(x=x, y=y)
+        self.assertEqual(
+            helion_runtime._kernel_fast_path_hits(),
+            hits_before_kwargs,
+            "kwargs call must bail out of the fast path; counter must "
+            "not bump on the kwargs invocation itself.",
+        )
+
+    def test_pallas_kernel_decorator_fast_path_bails_on_key_fn(self) -> None:
+        """Kernels created with ``helion.kernel(key=...)`` skip the fast path.
+
+        G5-decorator bail: the speculative single-bound-kernel cache
+        only fingerprints ``(dtype, shape, stride, device)`` per tensor
+        (and the literal value for primitives / ``ConstExpr``).  A
+        user-supplied ``key=`` extractor passed to ``helion.kernel``
+        can derive its bucket from tensor *values* (e.g. a heuristic
+        that picks a different config based on a hash of the input),
+        so two calls with identical metadata may legitimately need
+        different ``BoundKernel`` instances.  ``Kernel.__call__`` must
+        bail at the top before consulting ``_last_bound`` whenever
+        ``self._key_fn is not None``, and must NOT install
+        ``_last_bound`` on the post-call refresh either.
+
+        The test asserts both bails by inspecting ``_last_bound``
+        across a sequence of calls on a kernel with a ``key=`` fn:
+        the slot stays ``None`` permanently and the counter never
+        bumps.
+        """
+        from helion import runtime as helion_runtime
+
+        @helion.kernel(
+            backend="pallas",
+            static_shapes=True,
+            key=lambda x, y: ("static-key",),
+        )
+        def _matmul_decorator_keyfn_pin(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty(
+                [m, n],
+                device=x.device,
+                dtype=torch.promote_types(x.dtype, y.dtype),
+            )
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc
+            return out
+
+        torch.manual_seed(0)
+        x = torch.randn(256, 256, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(256, 256, device=DEVICE, dtype=torch.bfloat16)
+
+        helion_runtime._reset_kernel_fast_path_hits()
+        self.assertEqual(helion_runtime._kernel_fast_path_hits(), 0)
+        self.assertIsNone(_matmul_decorator_keyfn_pin._last_bound)
+
+        # 1 warmup + 5 hot calls.  None should touch the fast path.
+        reference = _matmul_decorator_keyfn_pin(x, y).clone()
+        for _ in range(5):
+            result = _matmul_decorator_keyfn_pin(x, y)
+            self.assertTrue(
+                torch.equal(result, reference),
+                "Key-fn kernel call output diverged "
+                f"(max_abs_diff="
+                f"{(result.float() - reference.float()).abs().max().item()}).",
+            )
+
+        self.assertEqual(
+            helion_runtime._kernel_fast_path_hits(),
+            0,
+            "Key-fn kernels must skip the decorator fast path; counter "
+            "must stay at 0 across warmup + 5 hot calls.",
+        )
+        self.assertIsNone(
+            _matmul_decorator_keyfn_pin._last_bound,
+            "Key-fn kernels must NOT populate ``_last_bound`` either "
+            "(the post-call install path is gated on the same "
+            "``_key_fn is None`` precondition as the cache-check).",
+        )
+
     def test_bmm(self) -> None:
         """Test BMM with default config — exercises size_matches fix.
 


### PR DESCRIPTION
## Summary

Four cooperating optimizations on the `_DirectCallKernel` static-shape fast path that together cut another -11us of host-side overhead per call on the bf16 1024x1024x1024 headline.

1. **Static-shape output meta-tensor allocation cache** — The output `torch.empty()` allocation is shape-invariant for static-shape kernels. Cache the meta-tensor per kernel signature so repeat calls skip `torch.empty` + device-tag setup. Codegen change: emit the cache key alongside the launcher args. Counter `_output_tensor_allocations` bumps on cache miss.

2. **Signature-locked direct-call closure** — On the first locked call, snapshot the resolved tensor-arg indices + non-tensor-args layout into a baked closure. Subsequent calls skip the per-call sig check + closure rebuild. The lock key is the kernel-name + input-signature pair so changes to the kernel's signature invalidate. Counter `_direct_call_sig_checks_skipped` tracks lock hits.

3. **Pre-baked full_invoke closure + deferred interpret check** — Combines the direct-call signature lock with a baked `full_invoke` closure that pre-resolves the `call_custom_kernel` target. The `pl.pallas_call` interpret-mode check (only used in test) is deferred to first call, not per-call. C-locked counters `_c_locked_counts` surface direct/locked/baked call counts for the pin tests.

4. **Speculative `Kernel._last_bound` cache for repeated invocations** — For workloads that call a kernel repeatedly with the same signature (the common case for inference loops), cache the bound kernel on `Kernel` itself so back-to-back calls skip the per-call signature resolution. The speculative cache invalidates on any signature change.

## Perf

Measured on bf16 1024x1024x1024 headline matmul (TPU v7, median-of-3 seeds):

| Metric | Before (PR #2590 base) | After | Δ |
|---|---|---|---|
| Helion total us per call | ~72 | **~61** | **-11 us** |
| launcher_overhead_us | 60.8 | **50.4** | **-10.4 us** |
| Helion kernel device us | ~6.6 | ~6.6 | flat |

Sub-2us individual delta on most calls, but together they push the Helion Python launcher overhead down to ~50us per call. Remaining ~50us is pinned by torch_tpu's `call_custom_kernel` C++ wrapper and JAX's pytree unflatten (out of this PR's scope).

## Cumulative perf for the full stack

| Metric | main baseline | After stack (this PR) | Δ |
|---|---|---|---|
| Helion total us per call | ~83 | ~56 | **-30%** |
| Helion kernel device us | ~6.7 | ~6.6 | flat |

## Test plan

- [x] `./lint.sh check` clean
- [x] New pin tests for each squeeze: output meta cache, sig-lock, full_invoke closure baking, speculative dispatch
- [ ] TPU CI run

## Stack

- #2588 — pallas matmul pipeline launcher VMEM strips + outer-grid strategy
- #2589 — fast-path host-side launcher with pre-computed cache entries
- #2590 (base) — bypass JaxCallable for static-shape kernels via direct call_custom_kernel
- **this PR (top of stack)**

## Known autoreview findings (to address before un-drafting)

P1:
- `full_invoke_pure_output` returns pytree directly; regular path returns tuple — divergence for multi-output kernels with non-tuple return types
- `_kernel_fast_call_key` missing `_dynamo_static_indices` — false cache hits under torch.compile

P3:
- ~27 stale comment references (G5-launcher-Y / cycle-28 / plan.md §X / dates) — strip per CLAUDE.md
- Repeated `_matmul_*_pin` kernel definitions in tests — factor into a fixture helper
- `_make_counter` factory to dedupe the 4 counter triples