### PR TITLE
[pallas] bypass JaxCallable for static-shape kernels via direct call_custom_kernel

### DIFF
--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from contextlib import suppress
 import contextvars
+from dataclasses import dataclass
 import importlib
 import inspect
 import linecache
@@ -524,6 +525,26 @@ def _pallas_check_dtypes(args: tuple[object, ...]) -> None:
             )
 
 
+@dataclass(slots=True)
+class _DirectCallKernel:
+    """Pre-captured metadata for a direct ``call_custom_kernel`` invocation.
+
+    Built lazily on the first call of a static-shape Pallas kernel and
+    attached to the launcher cache so subsequent calls bypass
+    ``JaxCallable.__call__``.  ``sig`` guards against shape changes on a
+    reused cache entry (mismatch falls back to the JaxCallable slow path).
+    """
+
+    call_custom_kernel: object
+    kernel_name: str
+    kernel_key: str
+    output_shapes: object
+    donate_argnums: object
+    out_tree: object
+    alias_items: tuple[tuple[int, int], ...]
+    sig: tuple[object, ...]
+
+
 _HELION_STATIC_JAX_CALLABLE_CLASS: type | None = None
 
 
@@ -534,19 +555,29 @@ def _make_helion_static_jax_callable_class() -> type:
     if _HELION_STATIC_JAX_CALLABLE_CLASS is not None:
         return _HELION_STATIC_JAX_CALLABLE_CLASS
 
+    from torch_tpu._internal.pallas import (  # pyrefly: ignore[missing-import]
+        tpu_torch_pallas,
+    )
     from torch_tpu._internal.pallas.pallas import (  # pyrefly: ignore[missing-import]
         JaxCallable,
     )
 
     class _HelionStaticJaxCallable(JaxCallable):  # type: ignore[misc, valid-type]
-        """``JaxCallable`` subclass used as the anchor for the launcher fast path.
+        """``JaxCallable`` subclass with a direct-call snapshot.
 
-        The class body is intentionally minimal here; stacked PRs attach
-        the direct-call snapshot (``_helion_direct_call``) that lets the
-        launcher hot path bypass ``JaxCallable.__call__`` entirely.
+        The first call goes through the JaxCallable slow path and
+        populates ``_helion_direct_call`` with a pre-captured
+        ``_DirectCallKernel``; the launcher hot path picks that up so
+        subsequent calls bypass ``JaxCallable.__call__`` entirely.
         """
 
-        __slots__ = ()
+        __slots__ = ("_helion_direct_call",)
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            super().__init__(*args, **kwargs)  # type: ignore[misc]
+            # Pre-captured metadata so the launcher hot path can bypass
+            # this ``__call__`` entirely; populated on the first call.
+            self._helion_direct_call: _DirectCallKernel | None = None
 
         def __call__(self, *args: object, **kwargs: object) -> object:
             # First call goes through the JaxCallable slow path; the launcher
@@ -566,9 +597,24 @@ def _make_helion_static_jax_callable_class() -> type:
             cached_entry = self.output_shapes.get(kernel_key)
             if cached_entry is None:
                 return result
-            # Snapshot left intentionally empty in this commit; stacked PRs
-            # attach a direct-call structure here so subsequent calls bypass
-            # this ``__call__``.
+            output_shapes, out_tree = cached_entry
+            sig_tuple = tuple(
+                (a.shape, a.dtype)  # type: ignore[attr-defined]
+                for a in args
+            )
+            alias_items = tuple(self.input_output_aliases.items())
+            # Stash the launcher-side direct-call structure so the next call
+            # can bypass this ``__call__`` entirely.
+            self._helion_direct_call = _DirectCallKernel(
+                call_custom_kernel=tpu_torch_pallas.call_custom_kernel,
+                kernel_name=self.name,
+                kernel_key=kernel_key,
+                output_shapes=output_shapes,
+                donate_argnums=self.donate_argnums,
+                out_tree=out_tree,
+                alias_items=alias_items,
+                sig=sig_tuple,
+            )
             return result
 
     _HELION_STATIC_JAX_CALLABLE_CLASS = _HelionStaticJaxCallable
@@ -742,13 +788,35 @@ def _pallas_invoke_and_return_fast(
     args: tuple[object, ...],
     fast_path: _LauncherFastPath,
     _orig_output_tensors: dict[int, torch.Tensor] | None,
+    direct_call: _DirectCallKernel | None = None,
 ) -> object:
-    """Run the JaxCallable and collect output-only results from the precomputed ``fast_path``."""
+    """Run the JaxCallable (or pre-baked direct call) and collect output-only
+    results; ``direct_call`` bypasses ``jax_callable`` when the sig matches."""
     tensor_arg_indices = fast_path.tensor_arg_indices_tuple
     input_tensors = [
         cast("torch.Tensor", args[i]).contiguous() for i in tensor_arg_indices
     ]
-    results = jax_callable(*input_tensors)  # type: ignore[operator]
+    if direct_call is not None:
+        # Guard on shape/dtype sig: mismatch (dynamic shape reusing cache entry)
+        # falls back to the JaxCallable slow path.
+        direct_sig: tuple[object, ...] = tuple(
+            (a.shape, a.dtype) for a in input_tensors
+        )
+        if direct_sig == direct_call.sig:
+            results = direct_call.call_custom_kernel(  # type: ignore[operator]
+                direct_call.kernel_name,
+                direct_call.kernel_key,
+                inputs=input_tensors,
+                output_shapes=direct_call.output_shapes,
+                donate_argnums=direct_call.donate_argnums,
+            )
+            for in_idx, out_idx in direct_call.alias_items:
+                input_tensors[in_idx].copy_(results[out_idx])
+            results = direct_call.out_tree.unflatten(results)  # type: ignore[attr-defined]
+        else:
+            results = jax_callable(*input_tensors)  # type: ignore[operator]
+    else:
+        results = jax_callable(*input_tensors)  # type: ignore[operator]
 
     output_only_count = fast_path.output_only_count
     if output_only_count == 0 and _orig_output_tensors is None:
@@ -1186,6 +1254,7 @@ def default_pallas_launcher(
             tensor_arg_indices,
             arg_to_tensor_pos,
             fast_path,
+            None,
         )
         cache = pallas_kernel._pallas_cache  # pyrefly: ignore[missing-attribute]
 
@@ -1196,7 +1265,21 @@ def default_pallas_launcher(
         tensor_arg_indices,
         arg_to_tensor_pos,
         fast_path,
+        direct_call,
     ) = cache
+    if direct_call is None:
+        # Lazily lift the direct-call kernel off the JaxCallable subclass.
+        direct_call = getattr(jax_callable, "_helion_direct_call", None)
+        if direct_call is not None:
+            pallas_kernel._pallas_cache = (  # pyrefly: ignore[missing-attribute]
+                cache[0],
+                jax_callable,
+                tensor_arg_indices,
+                arg_to_tensor_pos,
+                fast_path,
+                direct_call,
+            )
+
     _orig_output_tensors: dict[int, torch.Tensor] | None = None
     if _ds_pad_dims and fast_path.ds_pad_required is not False:
         args, _orig_output_tensors, _ = _pallas_apply_ds_padding_fast(
@@ -1206,7 +1289,7 @@ def default_pallas_launcher(
             fast_path.padded_output_arg_indices,
         )
     return _pallas_invoke_and_return_fast(
-        jax_callable, args, fast_path, _orig_output_tensors
+        jax_callable, args, fast_path, _orig_output_tensors, direct_call
     )
 
 
@@ -1387,6 +1470,7 @@ def default_pallas_pipeline_launcher(
             tensor_arg_indices,
             arg_to_tensor_pos,
             fast_path,
+            None,
         )
         cache = pallas_kernel._pallas_pipeline_cache  # pyrefly: ignore[missing-attribute]
 
@@ -1397,7 +1481,20 @@ def default_pallas_pipeline_launcher(
         tensor_arg_indices,
         arg_to_tensor_pos,
         fast_path,
+        direct_call,
     ) = cache
+    if direct_call is None:
+        direct_call = getattr(jax_callable, "_helion_direct_call", None)
+        if direct_call is not None:
+            pallas_kernel._pallas_pipeline_cache = (  # pyrefly: ignore[missing-attribute]
+                cache[0],
+                jax_callable,
+                tensor_arg_indices,
+                arg_to_tensor_pos,
+                fast_path,
+                direct_call,
+            )
+
     _orig_output_tensors: dict[int, torch.Tensor] | None = None
     if _ds_pad_dims and fast_path.ds_pad_required is not False:
         args, _orig_output_tensors, _ = _pallas_apply_ds_padding_fast(
@@ -1407,7 +1504,7 @@ def default_pallas_pipeline_launcher(
             fast_path.padded_output_arg_indices,
         )
     return _pallas_invoke_and_return_fast(
-        jax_callable, args, fast_path, _orig_output_tensors
+        jax_callable, args, fast_path, _orig_output_tensors, direct_call
     )
 
 
@@ -1588,6 +1685,7 @@ def default_pallas_fori_launcher(
             tensor_arg_indices,
             arg_to_tensor_pos,
             fast_path,
+            None,
         )
         cache = pallas_kernel._pallas_fori_cache  # pyrefly: ignore[missing-attribute]
 
@@ -1598,7 +1696,20 @@ def default_pallas_fori_launcher(
         tensor_arg_indices,
         arg_to_tensor_pos,
         fast_path,
+        direct_call,
     ) = cache
+    if direct_call is None:
+        direct_call = getattr(jax_callable, "_helion_direct_call", None)
+        if direct_call is not None:
+            pallas_kernel._pallas_fori_cache = (  # pyrefly: ignore[missing-attribute]
+                cache[0],
+                jax_callable,
+                tensor_arg_indices,
+                arg_to_tensor_pos,
+                fast_path,
+                direct_call,
+            )
+
     _orig_output_tensors: dict[int, torch.Tensor] | None = None
     if _ds_pad_dims and fast_path.ds_pad_required is not False:
         args, _orig_output_tensors, _ = _pallas_apply_ds_padding_fast(
@@ -1608,7 +1719,7 @@ def default_pallas_fori_launcher(
             fast_path.padded_output_arg_indices,
         )
     return _pallas_invoke_and_return_fast(
-        jax_callable, args, fast_path, _orig_output_tensors
+        jax_callable, args, fast_path, _orig_output_tensors, direct_call
     )
 
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -13,6 +13,7 @@ from helion._testing import DEVICE
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
+from helion._testing import skipIfPallasInterpret
 from helion._testing import skipUnlessPallas
 from helion._testing import xfailIfPallas
 from helion._testing import xfailIfPallasInterpret
@@ -1111,6 +1112,74 @@ class TestPallas(TestCase):
             cached,
             "Repeat calls on a cached static-shape kernel must populate the "
             "launcher fast-path cache on the inner device function.",
+        )
+
+    @skipIfPallasInterpret(
+        "direct call_custom_kernel dispatch is torch_tpu/TPU-only; the "
+        "_DirectCallKernel snapshot is not built in JAX interpret mode"
+    )
+    def test_pallas_call_custom_kernel_direct_matches_jaxcallable_output(
+        self,
+    ) -> None:
+        """Direct ``call_custom_kernel`` dispatch must produce bitwise-identical
+        output to the JaxCallable path on bf16 matmul (pin against silent
+        divergence from a refactor)."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def _matmul_direct_correctness(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty(
+                [m, n],
+                device=x.device,
+                dtype=torch.promote_types(x.dtype, y.dtype),
+            )
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc
+            return out
+
+        torch.manual_seed(0)
+        x = torch.randn(256, 256, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(256, 256, device=DEVICE, dtype=torch.bfloat16)
+
+        bound = _matmul_direct_correctness.bind((x, y))
+        config = bound.config_spec.default_config()
+        compiled_fn = bound.compile_config(config)
+
+        # First call: slow path (JaxCallable wrapper).  Saves the reference.
+        reference = compiled_fn(x, y).clone()
+
+        # Subsequent calls: direct ``call_custom_kernel`` dispatch.  Each output
+        # must be bitwise identical to the reference.
+        for i in range(3):
+            result = compiled_fn(x, y)
+            self.assertTrue(
+                torch.equal(result, reference),
+                f"Direct-dispatch call {i + 1} output diverged from the "
+                f"JaxCallable-path reference (max_abs_diff="
+                f"{(result.float() - reference.float()).abs().max().item()}).",
+            )
+
+        # Confirm the direct-call snapshot was actually built (slot 5 of the
+        # launcher cache), so the equality above exercised the direct path and
+        # is not a trivial slow-path-vs-slow-path comparison.
+        cache_attrs = ("_pallas_cache", "_pallas_pipeline_cache", "_pallas_fori_cache")
+        caches = [
+            getattr(value, a)
+            for value in compiled_fn.__globals__.values()
+            for a in cache_attrs
+            if getattr(value, a, None) is not None
+        ]
+        self.assertTrue(
+            caches and caches[0][5] is not None,
+            "Repeat calls must build the _DirectCallKernel snapshot "
+            "(direct-dispatch path engaged), not stay on the slow path.",
         )
 
     def test_bmm(self) -> None:


### PR DESCRIPTION
Stacked PRs:
 * #2597
 * #2595
 * __->__#2594
 * #2593


--- --- ---

### [pallas] bypass JaxCallable for static-shape kernels via direct call_custom_kernel


#2593 added the fast-path launcher harness (the per-call setup cache), but each
call still routes through the `JaxCallable` wrapper to reach the kernel, redoing
bookkeeping that never changes for a static-shape kernel. This PR adds the direct
call: warmed-up static-shape kernels skip the wrapper and invoke the low-level
entry point, `call_custom_kernel`, directly.

The fix: on the first call, snapshot everything the wrapper resolved -- the
`call_custom_kernel` target, the output shapes, which inputs are donated, how to
rebuild the output structure, and the argument `(shape, dtype)` signature -- into
a small `_DirectCallKernel` object stored on the launcher cache. Every later call
checks the signature once and, on a match, calls `call_custom_kernel` directly,
skipping the wrapper. If the signature ever differs (a dynamic shape reusing the
cache) it falls back to the wrapper; non-static-shape kernels are untouched.

On its own the win is small -- `launcher_overhead_us` 65.79 -> 65.08 on the bf16
1024^3 headline (TPU v7, median-of-3), within measurement noise -- but it's the
groundwork for #2597, which locks the signature check after the first match and
pre-bakes the direct-call dispatch into a reusable closure (~another -11us). A pin test confirms the bypass is taken -- it asserts the `_DirectCallKernel` snapshot is built on the launcher cache, and that direct dispatch is bitwise-identical to the wrapper path.