### PR TITLE
[pallas] cache static-shape output meta-tensor allocation in pallas launcher

### DIFF
--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -915,8 +915,18 @@ def generate_ast(
             )
             if output_only_names:
                 oo_set = set(output_only_names)
+                # ``static_shapes=True``: cache the output-only meta placeholder
+                # ``torch.empty(..., device='meta')`` on the inner device
+                # function so repeat calls reuse it (shape/dtype/device are
+                # constant).  ``static_shapes=False`` keeps the per-call alloc.
+                cache_static_shapes = (
+                    CompileEnvironment.current().settings.static_shapes
+                )
+                inner_fn_name = codegen.device_function.name
+                cached_meta_index = 0
+                new_host_statements: list[ast.AST] = []
                 for stmt in codegen.host_statements:
-                    if (
+                    if not (
                         isinstance(stmt, ast.Assign)
                         and len(stmt.targets) == 1
                         and isinstance(stmt.targets[0], ast.Name)
@@ -924,12 +934,33 @@ def generate_ast(
                         and not getattr(stmt, "_is_kernel_call", False)
                         and isinstance(stmt.value, ast.Call)
                     ):
-                        call = stmt.value
-                        call.keywords = [
-                            kw for kw in call.keywords if kw.arg != "device"
-                        ] + [
-                            ast.keyword(arg="device", value=ast.Constant(value="meta"))
-                        ]
+                        new_host_statements.append(stmt)
+                        continue
+                    call = stmt.value
+                    call.keywords = [
+                        kw for kw in call.keywords if kw.arg != "device"
+                    ] + [ast.keyword(arg="device", value=ast.Constant(value="meta"))]
+                    if not cache_static_shapes:
+                        new_host_statements.append(stmt)
+                        continue
+                    # Read the cache slot (``getattr`` -> ``None`` on the first
+                    # call) and populate it inline on the miss.  Kept inline (no
+                    # helper/lambda) so the warm path stays a plain attr read.
+                    varname = stmt.targets[0].id
+                    cache_attr = f"_helion_output_meta_cache_{cached_meta_index}"
+                    cached_meta_index += 1
+                    get_stmt = statement_from_string(
+                        f"{varname} = getattr({inner_fn_name}, '{cache_attr}', None)"
+                    )
+                    if_stmt = statement_from_string(
+                        f"if {varname} is None:\n"
+                        f"    {varname} = {inner_fn_name}.{cache_attr} = "
+                        f"{{__orig_call__}}\n",
+                        __orig_call__=call,
+                    )
+                    new_host_statements.extend([get_stmt, if_stmt])
+                if cache_static_shapes:
+                    codegen.host_statements = new_host_statements
 
             # Inject RNG seed buffer creation if needed
             rng_statements = (

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1182,6 +1182,92 @@ class TestPallas(TestCase):
             "(direct-dispatch path engaged), not stay on the slow path.",
         )
 
+    def test_pallas_launcher_caches_output_tensor(self) -> None:
+        """Static-shape kernel caches the output ``device='meta'`` placeholder and
+        reuses the same object across calls (no per-call re-allocation)."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def _matmul_output_meta_pin(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty(
+                [m, n],
+                device=x.device,
+                dtype=torch.promote_types(x.dtype, y.dtype),
+            )
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc
+            return out
+
+        torch.manual_seed(0)
+        x = torch.randn(256, 256, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(256, 256, device=DEVICE, dtype=torch.bfloat16)
+
+        bound = _matmul_output_meta_pin.bind((x, y))
+        config = bound.config_spec.default_config()
+        compiled_fn = bound.compile_config(config)
+
+        reference = compiled_fn(x, y).clone()
+        owners = [
+            value
+            for value in compiled_fn.__globals__.values()
+            if getattr(value, "_helion_output_meta_cache_0", None) is not None
+        ]
+        self.assertTrue(owners, "Output meta placeholder was not cached.")
+        cached_meta = owners[0]._helion_output_meta_cache_0
+
+        # Repeat calls must reuse the same placeholder object and keep the output.
+        n_repeats = 10
+        for _ in range(n_repeats):
+            result = compiled_fn(x, y)
+            self.assertTrue(
+                torch.equal(result, reference),
+                "Output diverged after cached meta-placeholder reuse "
+                f"(max_abs_diff="
+                f"{(result.float() - reference.float()).abs().max().item()}).",
+            )
+            self.assertIs(
+                owners[0]._helion_output_meta_cache_0,
+                cached_meta,
+                "Repeat calls must reuse the cached placeholder, not re-allocate.",
+            )
+
+        # Bitwise-identical to a fresh-compiled baseline: the cache holds only the
+        # zero-storage meta placeholder, not output bytes.
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def _matmul_output_meta_baseline(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty(
+                [m, n],
+                device=x.device,
+                dtype=torch.promote_types(x.dtype, y.dtype),
+            )
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc
+            return out
+
+        bound_baseline = _matmul_output_meta_baseline.bind((x, y))
+        baseline_fn = bound_baseline.compile_config(
+            bound_baseline.config_spec.default_config()
+        )
+        baseline_result = baseline_fn(x, y)
+        self.assertTrue(
+            torch.equal(reference, baseline_result),
+            "Cached-meta result diverged from fresh-compiled baseline "
+            f"(max_abs_diff="
+            f"{(reference.float() - baseline_result.float()).abs().max().item()}).",
+        )
+
     def test_bmm(self) -> None:
         """Test BMM with default config — exercises size_matches fix.
 
@@ -1398,7 +1484,7 @@ class TestPallas(TestCase):
 
         # test that we're not manually allocating and donating out tensor HBM,
         # but are instead taking over tensor returned by torch_tpu JaxCallable
-        self.assertIn("out = torch.empty_like(q_view, device='meta')", _code)
+        self.assertIn("torch.empty_like(q_view, device='meta')", _code)
         self.assertIn("out = _launcher(", _code)
 
     def test_hl_zeros_outer_arithmetic_emit_pipeline(self) -> None:


### PR DESCRIPTION
Stacked PRs:
 * #2597
 * __->__#2595
 * #2594
 * #2593


--- --- ---

### [pallas] cache static-shape output meta-tensor allocation in pallas launcher


This continues the per-call cleanup from #2593 / #2594. With the launcher cache
in place, one piece of repeated host work left on a cache hit is the output
`torch.empty()` allocation -- which, for a static-shape kernel, produces the
same shape, dtype, and device on every call.

This caches it. The output meta-tensor (shape + dtype + device descriptor) is
stored per kernel signature, so repeat calls reuse it instead of re-running
`torch.empty` and the device-tag setup. The generated host code reads the slot with `getattr` on later calls (populated on the first), so repeat calls skip `torch.empty` and the device-tag setup. A pin test asserts repeat calls reuse the same placeholder object (no re-allocation).

It's orthogonal to #2594's direct-call bypass -- a different slice of the same
hot path -- but builds on #2593's launcher-cache plumbing.

Measured: `launcher_overhead_us` 48.6 -> 42.0 median (bf16 1024^3, TPU v7,
config-pinned 10-sweep), about -6.6us. The `torch.empty(device='meta')` placeholder costs ~6.6us
on the torch-TPU PrivateUse1 backend (the device-tag dispatch, not the
zero-storage allocation), so caching it pays for the host-side bookkeeping. The
cache read/populate is inlined on the hot path on purpose: routing it through a
helper + lambda re-introduces ~6us of per-call overhead and erases the win.