### PR TITLE
[cosmetic/UI] Quieter console output and nicer progress formatting

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -9,7 +9,6 @@ import logging
 import math
 from math import inf
 import os
-import pprint
 import random
 import re
 import sys
@@ -1235,18 +1234,18 @@ def population_statistics(population: list[PopulationMember]) -> str:
             status_counts["ok"] += 1
     if len(working) == 0:
         raise exc.NoConfigFound
-    parts: list[str] = []
-    for label in ("error", "timeout", "ok"):
-        count = status_counts.get(label, 0)
-        if count:
-            parts.append(f"{label}={count}")
-
-    parts.extend(
-        (
-            f"min={working[0].perf:.4f}",
-            f"mid={working[len(working) // 2].perf:.4f}",
-            f"max={working[-1].perf:.4f}",
-            f"best={pprint.pformat(dict(population[0].config), width=100, compact=True)}",
-        )
+    count_parts = [
+        f"{label}={status_counts[label]}"
+        for label in ("error", "timeout", "ok")
+        if status_counts[label]
+    ]
+    perf_parts = (
+        f"min={working[0].perf:.4f}",
+        f"mid={working[len(working) // 2].perf:.4f}",
+        f"max={working[-1].perf:.4f}",
     )
-    return "\n" + "\n".join(parts)
+    lines = [f"{' '.join(count_parts)} | {' '.join(perf_parts)}", "best:"]
+    best_config = dict(population[0].config)
+    key_width = max((len(k) for k in best_config), default=0)
+    lines.extend(f"  {k:<{key_width}} = {v!r}" for k, v in best_config.items())
+    return "\n" + "\n".join(lines)

--- a/helion/autotuner/benchmark_job.py
+++ b/helion/autotuner/benchmark_job.py
@@ -10,6 +10,7 @@ from typing import cast
 from .benchmarking import do_bench
 from .benchmarking import do_bench_generic
 from .kernel_args import load_trusted_kernel_args
+from .logger import capture_output
 from .precompile_future import _load_compiled_fn
 
 if TYPE_CHECKING:
@@ -25,16 +26,19 @@ class BenchmarkJob:
     use_wall_clock: bool = False
 
     def __call__(self) -> float:
-        fn = _load_compiled_fn(self.fn_spec)
-        args = load_trusted_kernel_args(self.args_path)
-        bench = do_bench_generic if self.use_wall_clock else do_bench
-        # return_mode="median" guarantees a float return (not the tuple variant).
-        return cast(
-            "float",
-            bench(
-                functools.partial(fn, *args),
-                return_mode="median",
-                warmup=self.warmup,
-                rep=self.rep,
-            ),
-        )
+        # Subprocess inherits parent stderr; capture so Triton runtime
+        # diagnostics don't leak to the user's terminal.
+        with capture_output():
+            fn = _load_compiled_fn(self.fn_spec)
+            args = load_trusted_kernel_args(self.args_path)
+            bench = do_bench_generic if self.use_wall_clock else do_bench
+            # return_mode="median" guarantees a float return (not the tuple variant).
+            return cast(
+                "float",
+                bench(
+                    functools.partial(fn, *args),
+                    return_mode="median",
+                    warmup=self.warmup,
+                    rep=self.rep,
+                ),
+            )

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import abc
-import contextlib
 import datetime
 import functools
 from itertools import count
@@ -36,7 +35,6 @@ from .benchmarking import do_bench_generic
 from .benchmarking import synchronize_device
 from .logger import SUPPRESSED_TRITON_CODE_MSG
 from .logger import AutotuneLogEntry
-from .logger import _get_failure_dump_dir
 from .logger import capture_output
 from .logger import classify_triton_exception
 from .logger import format_triton_compile_failure
@@ -748,11 +746,18 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         for i, config in enumerate(all_configs):
             if self._budget_exceeded_synced():
                 break
+            # Defensive: if `capture_output().__enter__` itself raises, the
+            # except handler below still needs `captured` bound.
+            captured: list[str] = [""]
             try:
-                compiled[i] = self.kernel.compile_config(config, allow_print=False)
-            except Exception:
+                with capture_output() as captured:
+                    compiled[i] = self.kernel.compile_config(config, allow_print=False)
+            except Exception as e:
                 if not compiled and i == len(all_configs) - 1:
                     raise
+                maybe_dump_triton_failure(
+                    self.kernel, config, e, captured_output=captured[0] or None
+                )
                 self.log.warning(
                     "Skipping config that failed to compile: %s",
                     self.kernel.format_kernel_decorator(config, self.settings),
@@ -895,13 +900,6 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             # None means the subprocess path could not handle this config
             # (e.g., serialization failed); fall through to in-process.
 
-        _captured_output: list[str] = [""]
-        _capture_ctx = (
-            capture_output()
-            if _get_failure_dump_dir()
-            else contextlib.nullcontext(_captured_output)
-        )
-
         if len(self.mutated_arg_indices) > 0:
             working_args = _clone_args(
                 self.args,
@@ -941,16 +939,21 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             if not compile_success_all:
                 return inf
 
+        # Defensive: if `capture_output().__enter__` itself raises, the except
+        # handler below still needs `_captured_output` bound.
+        _captured_output: list[str] = [""]
         try:
             # TODO(jansel): early exit with fewer trials if early runs are slow
             self.log.debug(lambda: f"Running {config} at {datetime.datetime.now()}")
             t0 = time.perf_counter()
-            synchronize_device()
 
-            with _capture_ctx as _captured_output:
+            # Narrow capture: only the kernel compile+launch sites (which can
+            # emit Triton C-level MLIR diagnostics). Leave the accuracy check
+            # and Python-level logging outside so warnings still reach stderr.
+            with capture_output() as _captured_output:
+                synchronize_device()
                 output = fn(*working_args)  # make sure the kernel is compiled
-
-            synchronize_device(output)
+                synchronize_device(output)
 
             pass_accuracy_check = (
                 not self.settings.autotune_accuracy_check
@@ -971,23 +974,24 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                 # while other ranks return immediately, this will cause stuck jobs!
                 return inf
 
-            benchmark_function = self.kernel.bench_compile_config(
-                config, allow_print=False
-            )
-            benchmark_function(*working_args)  # warmup benchmark kernel
+            with capture_output() as _captured_output:
+                benchmark_function = self.kernel.bench_compile_config(
+                    config, allow_print=False
+                )
+                benchmark_function(*working_args)  # warmup benchmark kernel
 
-            t1 = time.perf_counter()
-            _backend = getattr(getattr(self, "config_spec", None), "backend", None)
-            benchmark_runner = (
-                _backend.get_do_bench() if _backend is not None else None
-            ) or do_bench
-            res = benchmark_runner(
-                functools.partial(benchmark_function, *working_args),
-                return_mode="median",
-                warmup=1,  # we are already warmed up above
-                rep=50,
-                process_group_name=self.kernel.env.process_group_name,
-            )
+                t1 = time.perf_counter()
+                _backend = getattr(getattr(self, "config_spec", None), "backend", None)
+                benchmark_runner = (
+                    _backend.get_do_bench() if _backend is not None else None
+                ) or do_bench
+                res = benchmark_runner(
+                    functools.partial(benchmark_function, *working_args),
+                    return_mode="median",
+                    warmup=1,  # we are already warmed up above
+                    rep=50,
+                    process_group_name=self.kernel.env.process_group_name,
+                )
             res = sync_object(
                 res, process_group_name=self.kernel.env.process_group_name
             )
@@ -1041,6 +1045,9 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                     code=SUPPRESSED_TRITON_CODE_MSG,
                 ) from e
             elif action == "warn":
+                # Compile-related failures (e.g., PTXASError, PassManager
+                # failed). Message is debug to keep autotune output quiet;
+                # repro is warning so HELION_PRINT_REPRO=1 stays visible.
                 decorator = self.kernel.format_kernel_decorator(config, self.settings)
                 log_generated_triton_code_debug(
                     self.log,
@@ -1048,9 +1055,9 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                     config,
                     prefix=f"Generated Triton code for {decorator}:",
                 )
-                self.log.warning(format_triton_compile_failure(config, e, self.kernel))
+                self.log.debug(format_triton_compile_failure(config, e, self.kernel))
                 self.kernel.maybe_log_repro(self.log.warning, self.args, config)
-            else:
+            else:  # action == "debug" (CUDA OOM, expected runtime failures)
                 decorator = self.kernel.format_kernel_decorator(config, self.settings)
                 log_generated_triton_code_debug(
                     self.log,

--- a/helion/autotuner/logger.py
+++ b/helion/autotuner/logger.py
@@ -365,7 +365,9 @@ class AutotuneLogSink:
 
 
 SUPPRESSED_TRITON_CODE_MSG = (
-    "Enable HELION_AUTOTUNE_LOG_LEVEL=DEBUG to log generated Triton code."
+    "Set HELION_AUTOTUNE_LOG_LEVEL=DEBUG to log the generated Triton code, "
+    "or HELION_AUTOTUNER_TRITON_FAILURE_DUMP_DIR=<dir> to write per-failure dumps "
+    "(source code + traceback) to <dir>."
 )
 
 
@@ -397,7 +399,7 @@ def _format_triton_code(kernel: _AutotunableKernel, config: Config, prefix: str)
     return f"{prefix}\n{code}"
 
 
-_FAILURE_DUMP_ENV = "HELION_AUTOTUNER_TRITON_FAILURE_DUMP"
+_FAILURE_DUMP_ENV = "HELION_AUTOTUNER_TRITON_FAILURE_DUMP_DIR"
 
 
 def _get_failure_dump_dir() -> str | None:
@@ -415,7 +417,7 @@ def maybe_dump_triton_failure(
     remote_traceback: str | None = None,
     captured_output: str | None = None,
 ) -> None:
-    """Dump a Triton failure report if HELION_AUTOTUNER_TRITON_FAILURE_DUMP is set."""
+    """Dump a Triton failure report if HELION_AUTOTUNER_TRITON_FAILURE_DUMP_DIR is set."""
     dump_dir = _get_failure_dump_dir()
     if not dump_dir:
         return

--- a/helion/autotuner/precompile_future.py
+++ b/helion/autotuner/precompile_future.py
@@ -719,12 +719,7 @@ class PrecompileFuture:
             formatted = (
                 f"{formatted}\nRemote traceback (spawned process):\n{error.traceback}"
             )
-        if classification == "warn":
-            self.ctx.log.warning(formatted)
-            self.ctx.kernel.maybe_log_repro(
-                self.ctx.log.warning, self.ctx.args, self.config
-            )
-        elif not ignore_errors:
+        if not ignore_errors:
             self.ctx.log.debug(formatted)
             self.ctx.kernel.maybe_log_repro(
                 self.ctx.log.debug, self.ctx.args, self.config

--- a/helion/autotuner/progress_bar.py
+++ b/helion/autotuner/progress_bar.py
@@ -33,10 +33,9 @@ class SpeedColumn(ProgressColumn):
     """Render the processing speed in configs per second."""
 
     def render(self, task: Task) -> Text:
-        return Text(
-            f"{task.speed:.1f} configs/s" if task.speed is not None else "- configs/s",
-            style="magenta",
-        )
+        # Fixed-width placeholder before first sample to avoid bar jitter.
+        speed = f"{task.speed:.1f}" if task.speed is not None else "..."
+        return Text(f"{speed:>5} configs/s", style="bold blue")
 
 
 def iter_with_progress(
@@ -65,7 +64,7 @@ def iter_with_progress(
 
     with Progress(
         TextColumn("[progress.description]{task.description}"),
-        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+        TextColumn("[bold blue]{task.percentage:>3.0f}%"),
         BarColumn(bar_width=None, complete_style="yellow", finished_style="green"),
         MofNCompleteColumn(),
         SpeedColumn(),

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -1109,7 +1109,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             if not is_ref_mode_enabled(self.kernel.settings):
                 kernel_decorator = self.format_kernel_decorator(config, self.settings)
                 print(
-                    f"Using default config: {kernel_decorator}",
+                    f"Using default config:\n\t{kernel_decorator}",
                     file=sys.stderr,
                 )
             return config

--- a/helion/runtime/precompile_shim.py
+++ b/helion/runtime/precompile_shim.py
@@ -98,7 +98,7 @@ def make_precompiler(
                     compiled_kernel._init_handles()
             except Exception as e:
                 action = classify_triton_exception(e)
-                if action != "debug":
+                if action == "raise":
                     print(
                         format_triton_compile_failure(config, e, bound_kernel),
                         file=sys.stderr,


### PR DESCRIPTION
Quieter and tidier autotune console output:
- Triton C-level MLIR error dumps no longer leak to the terminal during autotune. This makes output hard to see, users don't really care about these dumps. 
- \`Using default config:\` wraps cleanly instead of dumping a 700-char line.
- Autotune end-of-search summary uses aligned \`key = value\` config instead of a \`pprint\` dict.
- Progress-bar percentage + speed render in bold blue.

Full MLIR/Triton stderr diagnostics are still available by setting \`HELION_AUTOTUNER_TRITON_FAILURE_DUMP_DIR =<dir>\` — written to content-hashed \`.py\` files (deduplicated, typically 1–5 files per autotune run, not one per failed config).

## Before

**\`python examples/add.py\`**, before:
\`\`\`
Using default config: @helion.kernel(config=helion.Config(atomic_indexing=[], block_sizes=[32, 32], flatten_loops=[False], indexing=['pointer', 'pointer', 'pointer'], l2_groupings=[1], load_eviction_policies=['', ''], loop_orders=[[0, 1]], num_stages=1, num_warps=4, pid_type='flat', range_flattens=[None], range_multi_buffers=[None], range_num_stages=[], range_unroll_factors=[0], range_warp_specializes=[None]), static_shapes=True)
Benchmarking 100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 153/153 - configs/s
\`\`\`

**During autotune**, hundreds of lines per failed config like:
\`\`\`
/tmp/torchinductor_.../foo.py:53:49: error: 'ttng.async_tma_store_wait' op...
module attributes {ttg.maxnreg = 64 : i32} { ... }
{-# external_resources: { mlir_reproducer: { pipeline: "...", ... } } #-}
\`\`\`
…are now captured and silenced by default. Set \`HELION_AUTOTUNER_TRITON_FAILURE_DUMP_DIR=<dir>\` to write them to a directory

**Autotune end-of-search stats**, before:
\`\`\`
ok=20
min=0.0200
mid=0.0234
max=0.0237
best={'atomic_indexing': [],
 'block_sizes': [256, 64],
 'flatten_loops': [True],
 ...}
\`\`\`

## After:
\`\`\`
<img width="893" height="456" alt="image" src="https://github.com/user-attachments/assets/05b75f3b-ee88-46ab-8bba-a80e0b9ae537" />

\`\`\`