### PR TITLE
[pallas] fix fori_loop's output mapping

### DIFF
--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -302,6 +302,22 @@ def _get_indexing_patterns(state: CodegenState, tensor: torch.Tensor) -> list[ob
     return patterns
 
 
+def _arbitrary_index_pattern_code(
+    pattern: object,
+    idx: object,
+    state: CodegenState,
+    subscript_index: int,
+    in_pipeline: bool,
+) -> str:
+    from helion._utils import is_scalar_index
+
+    if in_pipeline and is_scalar_index(idx):
+        return "0"
+    if isinstance(idx, int):
+        return str(idx)
+    return _index_expr_from_ast(state, subscript_index)
+
+
 def _generated_index_code(
     pattern: object,
     idx: object,
@@ -327,20 +343,22 @@ def _generated_index_code(
         )
 
     if isinstance(pattern, TileIndexWithOffsetPattern):
-        return _tile_index_with_offset_pattern_code(pattern, state, tensor, tensor_dim)
+        return _tile_index_with_offset_pattern_code(
+            pattern, state, tensor, tensor_dim, in_pipeline, pipeline_block_ids
+        )
 
     if isinstance(pattern, TileBeginWithOffsetPattern):
         return _tile_begin_with_offset_pattern_code(
-            pattern, state, subscript_index, tensor_dim
+            pattern, state, subscript_index, tensor_dim, in_pipeline, pipeline_block_ids
         )
 
     if isinstance(pattern, ArbitrarySlicePattern):
         return _slice_code(idx, pattern, state, tensor, tensor_dim)
 
     if isinstance(pattern, ArbitraryIndexPattern):
-        if isinstance(idx, int):
-            return str(idx)
-        return _index_expr_from_ast(state, subscript_index)
+        return _arbitrary_index_pattern_code(
+            pattern, idx, state, subscript_index, in_pipeline
+        )
 
     if isinstance(pattern, IndirectGatherPattern):
         # The gather emitter consumes the tensor index and projects the full
@@ -409,6 +427,8 @@ def _tile_index_with_offset_pattern_code(
     state: CodegenState,
     tensor: torch.Tensor,
     tensor_dim: int,
+    in_pipeline: bool,
+    pipeline_block_ids: set[int],
 ) -> str:
     from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
 
@@ -416,6 +436,7 @@ def _tile_index_with_offset_pattern_code(
 
     block_id = pattern.block_id
     offset_str = state.device_function.literal_expr(pattern.offset)
+
     return _ds_expr(state, block_id, offset_str, tensor=tensor, tensor_dim=tensor_dim)
 
 
@@ -424,11 +445,19 @@ def _tile_begin_with_offset_pattern_code(
     state: CodegenState,
     subscript_index: int,
     tensor_dim: int,
+    in_pipeline: bool,
+    pipeline_block_ids: set[int],
 ) -> str:
     from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
     from helion._compiler.tile_strategy import DeviceLoopState
 
     assert isinstance(pattern, TileBeginWithOffsetPattern)
+
+    block_id = pattern.block_id
+    offset_str = state.device_function.literal_expr(pattern.offset)
+
+    if in_pipeline and block_id in pipeline_block_ids:
+        return offset_str
 
     can_tile = _can_tile_dimension(state, tensor_dim)
 
@@ -437,9 +466,9 @@ def _tile_begin_with_offset_pattern_code(
 
     assert isinstance(pattern.offset, int)
 
-    loops = state.codegen.active_device_loops.get(pattern.block_id)
+    loops = state.codegen.active_device_loops.get(block_id)
     if loops and any(isinstance(loop, DeviceLoopState) for loop in loops):
-        offset = state.codegen.offset_var(pattern.block_id)
+        offset = state.codegen.offset_var(block_id)
         if pattern.offset != 0:
             offset = f"{offset} + {pattern.offset}"
         return offset

--- a/helion/_utils.py
+++ b/helion/_utils.py
@@ -89,3 +89,27 @@ def convert_tile_indices_to_slices(index: object) -> object:
     if isinstance(index, tuple):
         return tuple(_extract_slice(idx) for idx in index)
     return _extract_slice(index)
+
+
+def is_scalar_index(idx: object) -> bool:
+    """Return True if the given index behaves as a single scalar coordinate."""
+    import torch
+
+    if isinstance(idx, torch.SymInt):
+        # Exclude tiled block ranges.
+        from helion._compiler.compile_environment import CompileEnvironment
+        from helion._compiler.compile_environment import NoCurrentEnvironment
+
+        try:
+            env = CompileEnvironment.current()
+            if env.get_block_id(idx) is not None:
+                return False
+        except NoCurrentEnvironment:
+            pass
+        return True
+
+    if isinstance(idx, int):
+        return True
+    if hasattr(idx, "ndim"):
+        return idx.ndim == 0
+    return False

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -1512,8 +1512,25 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                     block_shape_parts.append(str(int(shape[dim_idx])))
                 lambda_parts.append(pid_var)
             else:
-                block_shape_parts.append(str(int(shape[dim_idx])))
-                lambda_parts.append("0")
+                idx_meta = (
+                    subscript_meta[dim_idx]
+                    if dim_idx < len(subscript_meta)
+                    else slice(None)
+                )
+                from helion._utils import is_scalar_index
+
+                if is_scalar_index(idx_meta):
+                    block_shape_parts.append("1")
+                    if isinstance(idx_meta, torch.Tensor):
+                        var_name = state.device_function.tensor_arg(idx_meta).name
+                        lambda_parts.append(var_name)
+                    else:
+                        lambda_parts.append(
+                            state.device_function.literal_expr(idx_meta)
+                        )
+                else:
+                    block_shape_parts.append(str(int(shape[dim_idx])))
+                    lambda_parts.append("0")
 
         block_shape_str = ", ".join(block_shape_parts)
         lambda_body = ", ".join(lambda_parts)
@@ -1803,7 +1820,13 @@ def _compute_vmem_shapes(
                 else:
                     parts.append(int(fake.shape[dim_idx]))
             else:
-                parts.append(int(fake.shape[dim_idx]))
+                idx_meta = sub_meta[dim_idx] if dim_idx < len(sub_meta) else slice(None)
+                from helion._utils import is_scalar_index
+
+                if is_scalar_index(idx_meta):
+                    parts.append(1)
+                else:
+                    parts.append(int(fake.shape[dim_idx]))
         vmem_shapes.append(tuple(parts))
     return vmem_shapes
 

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -2101,7 +2101,19 @@ def _codegen_fori_loop(state: CodegenState) -> object:
                 else:
                     parts.append(":")
             else:
-                parts.append(":")
+                idx_meta = (
+                    subscript_meta[dim_idx]
+                    if dim_idx < len(subscript_meta)
+                    else slice(None)
+                )
+                from helion._utils import is_scalar_index
+
+                if is_scalar_index(idx_meta):
+                    offset_expr = state.device_function.literal_expr(idx_meta)
+                    parts.append(f"pl.ds({offset_expr}, 1)")
+                    needs_slice = True
+                else:
+                    parts.append(":")
         if not needs_slice:
             return hbm_name
         return f"{hbm_name}.at[{', '.join(parts)}]"

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -462,6 +462,48 @@ def pallas_rand_add(x: torch.Tensor, seed: int) -> torch.Tensor:
     return out
 
 
+@helion.kernel(backend="pallas", static_shapes=True)
+def kernel_output_index_remapping(
+    x: torch.Tensor,  # [batch*heads, seq_len, head_dim]
+    batch: int,
+    heads: int,
+) -> torch.Tensor:
+    """Reshapes a [batch*heads, seq_len, head_dim] tensor to [batch, heads, seq_len, head_dim].
+
+    Iterates over the combined batch*heads dimension and the seq_len dimension.
+    """
+    batch_heads, seq_len, head_dim = x.size()
+    out = torch.empty([batch, heads, seq_len, head_dim], dtype=x.dtype, device=x.device)
+    for bh in hl.grid(batch_heads):
+        b = bh // heads
+        h = bh % heads
+        for tile_m in hl.tile(seq_len):
+            out[b, h, tile_m, :] = x[bh, tile_m, :]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def kernel_tile_index_is_blockwise(
+    x: torch.Tensor,
+) -> torch.Tensor:
+    seq_len = x.size(0)
+    out = torch.empty_like(x)
+    for tile_m in hl.tile(seq_len):
+        out[tile_m.index] = x[tile_m.index] + 1.0
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def kernel_tile_begin_plus_offset_is_elementwise(
+    x: torch.Tensor,
+) -> torch.Tensor:
+    seq_len = x.size(0)
+    out = torch.zeros_like(x)
+    for tile_m in hl.tile(seq_len):
+        out[tile_m.begin + 5] = x[tile_m.begin + 5] + 1.0
+    return out
+
+
 @onlyBackends(["triton", "pallas"])
 @skipUnlessPallas("JAX/Pallas TPU not available")
 class TestPallas(TestCase):
@@ -512,6 +554,64 @@ class TestPallas(TestCase):
             r"Ran out of memory in memory space vmem.*Estimated [0-9.]+MB exceeds",
         ):
             code_and_output(pallas_add_2d, args_fp8, block_sizes=[4096, 8192])
+
+    def test_output_index_remapping_in_pipeline(self) -> None:
+        total_elements = 8 * 128 * 128
+        x = torch.arange(total_elements, device=DEVICE, dtype=torch.bfloat16).view(
+            8, 128, 128
+        )
+        batch = 2
+        heads = 4
+        code, result = code_and_output(
+            kernel_output_index_remapping,
+            (x, batch, heads),
+            block_sizes=[32],
+            pallas_loop_type="emit_pipeline",
+        )
+
+        with self.subTest("correctness"):
+            expected = x.reshape(batch, heads, 128, 128)
+            torch.testing.assert_close(result, expected)
+
+        with self.subTest("pipeline_emit"):
+            self.assertIn("pltpu.emit_pipeline", code)
+
+        with self.subTest("shrunken_blockspec"):
+            self.assertIn(
+                "pl.BlockSpec((1, 1, _BLOCK_SIZE_1, 128), "
+                "lambda _j: (offset_0 // heads, offset_0 % heads, _j, 0)",
+                code,
+            )
+
+        with self.subTest("body_vmem_indices"):
+            self.assertIn("out_vmem[0, 0, :, :]", code)
+
+    def test_pipeline_kernel_tile_index_is_blockwise(self) -> None:
+        x = torch.arange(1024, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            kernel_tile_index_is_blockwise,
+            (x,),
+            block_sizes=[256],
+            pallas_loop_type="emit_pipeline",
+        )
+        torch.testing.assert_close(result, x + 1.0)
+        self.assertNotIn("pltpu.emit_pipeline", code)
+        self.assertIn("out[:]", code)
+
+    def test_pipeline_kernel_tile_begin_plus_offset_is_elementwise(self) -> None:
+        x = torch.arange(1024, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            kernel_tile_begin_plus_offset_is_elementwise,
+            (x,),
+            block_sizes=[256],
+            pallas_loop_type="emit_pipeline",
+        )
+        expected = torch.zeros_like(x)
+        expected[5::256] = x[5::256] + 1.0
+        torch.testing.assert_close(result, expected)
+        self.assertNotIn("pltpu.emit_pipeline", code)
+        self.assertIn("_smem_arg_indices", code)
+        self.assertIn("out[5]", code)
 
     def test_add_1d(self) -> None:
         args = (torch.randn(1024, device=DEVICE), torch.randn(1024, device=DEVICE))

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -586,6 +586,36 @@ class TestPallas(TestCase):
         with self.subTest("body_vmem_indices"):
             self.assertIn("out_vmem[0, 0, :, :]", code)
 
+    def test_output_index_remapping_in_fori_loop(self) -> None:
+        total_elements = 8 * 128 * 128
+        x = torch.arange(total_elements, device=DEVICE, dtype=torch.bfloat16).view(
+            8, 128, 128
+        )
+        batch = 2
+        heads = 4
+        code, result = code_and_output(
+            kernel_output_index_remapping,
+            (x, batch, heads),
+            block_sizes=[32],
+            pallas_loop_type="fori_loop",
+        )
+
+        with self.subTest("correctness"):
+            expected = x.reshape(batch, heads, 128, 128)
+            torch.testing.assert_close(result, expected)
+
+        with self.subTest("fori_loop_emit"):
+            self.assertIn("jax.lax.fori_loop", code)
+
+        with self.subTest("body_vmem_indices"):
+            self.assertIn("out_buf[0, 0, :, :]", code)
+
+        with self.subTest("vmem_shape_allocation"):
+            self.assertIn("((1, 1, 32, 128), 'jnp.bfloat16', 'vmem')", code)
+
+        with self.subTest("hbm_dma_slices"):
+            self.assertIn("pl.ds(symnode_0, 1), pl.ds(symnode_1, 1)", code)
+
     def test_pipeline_kernel_tile_index_is_blockwise(self) -> None:
         x = torch.arange(1024, device=DEVICE, dtype=torch.float32)
         code, result = code_and_output(


### PR DESCRIPTION
Fix the handling of output buffers with fori_loop by lowering
the copy from HBM with a dynamic slice (vs. copying the whole
buffer).

Stacked PR -- baseline: https://github.com/pytorch/helion/pull/2599