### PR TITLE
[fast-launcher] Opt-in output-tensor pool (Chunk D, Python-only)

### DIFF
--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -17,6 +17,10 @@ from .. import _compat as _compat  # ensure Triton compatibility patches run
 from .. import exc
 from .._compiler.cute.strategies import tcgen05_smem_layout_expr
 from .._utils import triton_is_available
+from ._output_pool import clear_pool as clear_pool
+from ._output_pool import empty_like as empty_like
+from ._output_pool import is_pool_enabled as is_pool_enabled
+from ._output_pool import set_pool_enabled as set_pool_enabled
 from .config import Config as Config
 from .kernel import Kernel as Kernel
 from .kernel import kernel as kernel

--- a/helion/runtime/_output_pool.py
+++ b/helion/runtime/_output_pool.py
@@ -1,0 +1,127 @@
+"""Optional output-tensor pool for Helion kernels.
+
+For small kernels, allocating a fresh output tensor with
+``torch.empty_like(x)`` is a measurable per-call cost (~1.5 μs on H100
+for a 4 KB tensor). This module provides ``empty_like`` — a drop-in
+replacement that, when ``HELION_OUTPUT_POOL=1`` is set in the
+environment, reuses a small fixed-size cache of buffers keyed on
+``(dtype, shape, stride, device)``.
+
+When the env var is NOT set (the default), ``empty_like`` is a thin
+pass-through to ``torch.empty_like`` and behaves exactly like the
+PyTorch builtin.
+
+Semantics caveat
+----------------
+Pooled buffers are RECYCLED across calls. Callers MUST consume the
+returned tensor before the next call to ``empty_like`` with the same
+key, or copy the data out. The buffer returned this call may be
+re-handed to the next call — holding a reference for later use will
+see its contents clobbered. This is why the pool is opt-in: the
+``torch.empty_like`` semantics (fresh allocation) are the default to
+avoid silent aliasing bugs.
+
+Layout
+------
+``_POOLS`` is a process-wide dict mapping a tensor signature
+(``(dtype, sizes, strides, device)``) to a small ring buffer (list)
+of preallocated tensors. Each ``empty_like`` call rotates through the
+ring, returning the next slot. Ring length is fixed at module-init.
+
+The pool is intentionally simple: no LRU eviction, no maximum total
+memory cap. The expected use case is hot inference loops that call
+the same kernels with the same shapes repeatedly, so the pool grows
+to its steady-state size after warmup and stays there.
+
+Disabling at runtime
+--------------------
+Reading the env var once at import time (cached in ``_POOL_ENABLED``)
+keeps ``empty_like`` allocation-free in the disabled path. To change
+the setting after import, call :func:`set_pool_enabled`.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Hashable
+
+
+# Ring-buffer length per (dtype, sizes, strides, device) key. Two
+# slots is enough to cover the common case (one buffer being written
+# while the previous is still being read on another stream); going
+# higher just wastes memory.
+_POOL_DEPTH = 2
+
+_POOLS: dict[Hashable, list[torch.Tensor]] = {}
+_POOL_INDEX: dict[Hashable, int] = {}
+
+
+def _env_enabled() -> bool:
+    return os.environ.get("HELION_OUTPUT_POOL", "").lower() in ("1", "true", "yes")
+
+
+_POOL_ENABLED: bool = _env_enabled()
+
+
+def set_pool_enabled(enabled: bool) -> None:
+    """Programmatic toggle for the pool, overriding the env var.
+
+    Useful for tests and for libraries that want to opt in/out
+    independently of the user's environment.
+    """
+    global _POOL_ENABLED
+    _POOL_ENABLED = enabled
+
+
+def is_pool_enabled() -> bool:
+    return _POOL_ENABLED
+
+
+def clear_pool() -> None:
+    """Drop all pooled buffers. Useful for tests and for callers that
+    want to reclaim memory after a workload finishes."""
+    _POOLS.clear()
+    _POOL_INDEX.clear()
+
+
+def empty_like(template: torch.Tensor) -> torch.Tensor:
+    """Return an uninitialized tensor with the same dtype/shape/stride/device
+    as ``template``.
+
+    When :func:`is_pool_enabled` is ``True``, returns a recycled buffer
+    from a per-signature ring. When ``False``, falls through to
+    ``torch.empty_like``.
+
+    Callers must consume the returned tensor before the next call with
+    the same signature, or copy the data out — see the module
+    docstring.
+    """
+    if not _POOL_ENABLED:
+        return torch.empty_like(template)
+    key = (
+        template.dtype,
+        tuple(template.size()),
+        tuple(template.stride()),
+        template.device,
+    )
+    ring = _POOLS.get(key)
+    if ring is None:
+        ring = [torch.empty_like(template) for _ in range(_POOL_DEPTH)]
+        _POOLS[key] = ring
+        _POOL_INDEX[key] = 0
+    idx = _POOL_INDEX[key]
+    _POOL_INDEX[key] = (idx + 1) % _POOL_DEPTH
+    return ring[idx]
+
+
+__all__ = [
+    "clear_pool",
+    "empty_like",
+    "is_pool_enabled",
+    "set_pool_enabled",
+]

--- a/test/test_output_pool.py
+++ b/test/test_output_pool.py
@@ -1,0 +1,139 @@
+"""Tests for the opt-in output-tensor pool.
+
+The pool is gated on ``HELION_OUTPUT_POOL=1`` (or programmatically via
+``helion.runtime.set_pool_enabled``). Default behavior is a pass-through
+to ``torch.empty_like``, so existing kernels that build their output
+with the standard PyTorch builtin are completely unaffected.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+import torch
+
+from helion.runtime import clear_pool
+from helion.runtime import empty_like
+from helion.runtime import is_pool_enabled
+from helion.runtime import set_pool_enabled
+
+
+class TestPoolDisabledByDefault(unittest.TestCase):
+    """When the env var is unset, ``empty_like`` must behave exactly
+    like ``torch.empty_like``: a fresh allocation on every call."""
+
+    def setUp(self) -> None:
+        self.addCleanup(clear_pool)
+        # Snapshot + restore the global flag and env var so this test
+        # is isolated from any other test that may have toggled them.
+        self._old_env = os.environ.get("HELION_OUTPUT_POOL")
+        self._old_flag = is_pool_enabled()
+        os.environ.pop("HELION_OUTPUT_POOL", None)
+        set_pool_enabled(False)
+
+    def tearDown(self) -> None:
+        if self._old_env is not None:
+            os.environ["HELION_OUTPUT_POOL"] = self._old_env
+        else:
+            os.environ.pop("HELION_OUTPUT_POOL", None)
+        set_pool_enabled(self._old_flag)
+
+    def test_returns_fresh_tensor_each_call(self) -> None:
+        """Pool off → each call must return a distinct ``data_ptr()``."""
+        x = torch.randn(64, dtype=torch.float32)
+        a = empty_like(x)
+        b = empty_like(x)
+        self.assertNotEqual(a.data_ptr(), b.data_ptr())
+
+    def test_matches_torch_empty_like_metadata(self) -> None:
+        """Returned tensor's dtype/shape/stride/device matches template."""
+        x = torch.randn(3, 5, dtype=torch.bfloat16)
+        y = empty_like(x)
+        self.assertEqual(y.dtype, x.dtype)
+        self.assertEqual(y.shape, x.shape)
+        self.assertEqual(y.stride(), x.stride())
+        self.assertEqual(y.device, x.device)
+
+
+class TestPoolEnabled(unittest.TestCase):
+    """When the pool is enabled, identical-signature calls recycle
+    buffers from a fixed-size ring."""
+
+    def setUp(self) -> None:
+        self.addCleanup(clear_pool)
+        self._old_flag = is_pool_enabled()
+        set_pool_enabled(True)
+        clear_pool()
+
+    def tearDown(self) -> None:
+        set_pool_enabled(self._old_flag)
+
+    def test_ring_recycles_after_depth_calls(self) -> None:
+        """With ring depth N, the (N+1)th call should hand back the
+        SAME storage as the 1st."""
+        x = torch.randn(64, dtype=torch.float32)
+        # Module-level constant; matches _POOL_DEPTH in _output_pool.py.
+        from helion.runtime._output_pool import _POOL_DEPTH
+
+        first_n = [empty_like(x).data_ptr() for _ in range(_POOL_DEPTH)]
+        recycled = empty_like(x).data_ptr()
+        self.assertEqual(recycled, first_n[0])
+
+    def test_distinct_signatures_use_distinct_rings(self) -> None:
+        """A different shape must NOT collide with an existing ring's
+        buffers — it gets its own ring."""
+        x1 = torch.randn(64, dtype=torch.float32)
+        x2 = torch.randn(128, dtype=torch.float32)
+        a = empty_like(x1)
+        b = empty_like(x2)
+        self.assertEqual(a.shape, x1.shape)
+        self.assertEqual(b.shape, x2.shape)
+        self.assertNotEqual(a.data_ptr(), b.data_ptr())
+
+    def test_distinct_dtypes_use_distinct_rings(self) -> None:
+        """Same shape but different dtype → separate rings, no aliasing."""
+        x1 = torch.randn(64, dtype=torch.float32)
+        x2 = torch.randn(64, dtype=torch.bfloat16)
+        a = empty_like(x1)
+        b = empty_like(x2)
+        self.assertEqual(a.dtype, x1.dtype)
+        self.assertEqual(b.dtype, x2.dtype)
+        self.assertNotEqual(a.data_ptr(), b.data_ptr())
+
+    def test_clear_pool_releases_buffers(self) -> None:
+        """``clear_pool`` should drop refs so the next call allocates
+        fresh, not recycle."""
+        x = torch.randn(64, dtype=torch.float32)
+        first = empty_like(x).data_ptr()
+        clear_pool()
+        # After clearing, the next call allocates a new buffer — it
+        # MAY happen to land at the same address (allocator reuse) but
+        # the pool internals must be empty.
+        from helion.runtime._output_pool import _POOLS
+
+        empty_like(x)
+        self.assertEqual(len(_POOLS), 1)  # one new ring after clear
+        # And the first buffer ptr is no longer guaranteed to be reused
+        # — we don't assert ptr inequality (allocator may legitimately
+        # reuse the freed slot) but the pool state should be fresh.
+        _ = first
+
+
+class TestEnvVarToggle(unittest.TestCase):
+    """``set_pool_enabled`` should mirror the env-var-driven default."""
+
+    def test_set_pool_enabled_changes_behavior(self) -> None:
+        old_flag = is_pool_enabled()
+        try:
+            set_pool_enabled(False)
+            self.assertFalse(is_pool_enabled())
+            set_pool_enabled(True)
+            self.assertTrue(is_pool_enabled())
+        finally:
+            set_pool_enabled(old_flag)
+            clear_pool()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked PRs:
 * #2565
 * #2611
 * #2605
 * __->__#2604


--- --- ---

### [fast-launcher] Opt-in output-tensor pool (Chunk D, Python-only)


Adds ``helion.runtime.empty_like`` — a drop-in replacement for
``torch.empty_like`` that, when ``HELION_OUTPUT_POOL=1`` is set,
returns a buffer from a small fixed-size ring keyed on
``(dtype, sizes, strides, device)``. When the env var is unset
(the default), it's a pass-through to ``torch.empty_like``.

Why opt-in: the pool RECYCLES buffers across calls. Holding a
reference to the returned tensor past the next call with the same
signature will see its contents clobbered when that next call hands
back the same slot. The fresh-allocation semantics of
``torch.empty_like`` are the default to avoid silent aliasing bugs.

What ships in this commit:
- ``helion/runtime/_output_pool.py``:
  - ``empty_like(template)`` — the public entrypoint.
  - ``set_pool_enabled(bool)`` / ``is_pool_enabled()`` — programmatic
    toggle, overrides the env var (useful for tests and libraries).
  - ``clear_pool()`` — drops all pooled buffers, reclaiming memory.
- Re-exports from ``helion.runtime`` so callers write
  ``from helion.runtime import empty_like``.

What this commit does NOT do: it doesn't wire the pool into codegen
(i.e. the generated host wrapper still emits the user's literal
``torch.empty_like(x)`` call). The codegen rewrite that auto-wires
the pool lands in the next commit. Until then, users who want the
pool must manually import ``helion.runtime.empty_like`` in their
kernel source.

Pure-Python, no C extension dependency.

Tests in ``test_output_pool.py`` cover:
- Pool-off (default): each call returns a fresh ``data_ptr()``; the
  returned tensor's metadata matches ``torch.empty_like``.
- Pool-on: ring of depth ``_POOL_DEPTH`` recycles; the (N+1)th call
  hands back the SAME storage as the 1st.
- Distinct signatures (different shape / different dtype) get
  distinct rings — no cross-signature aliasing.
- ``clear_pool()`` drops all rings.
- ``set_pool_enabled`` programmatic toggle.
Benchmarks (H100, vector_add at N=4096, this commit's state)
------------------------------------------------------------

No end-to-end change yet: kernels still call ``torch.empty_like``
verbatim — the pool helper is only reachable via manual import.

  Variant                            wall+sync   cpu_only
  baseline (main)                    24.34 us    17.91 us
  + this commit (pool runtime only)  24.28 us    17.78 us

The pool's per-call cost in isolation (timeit, fp32 4096):
  torch.empty_like(a)                  1.38 us
  helion.runtime.empty_like(a) (pool)  0.69 us  (-0.69 us, 2.0x)

Real end-to-end savings land in the NEXT commit's codegen rewrite.