### PR TITLE
[fast-launcher] Add helion._native optional Rust extension shim

### DIFF
--- a/helion/_native/.gitignore
+++ b/helion/_native/.gitignore
@@ -1,0 +1,5 @@
+# Build artifacts are not source.
+target/
+*.so
+*.pyd
+*.dylib

--- a/helion/_native/__init__.py
+++ b/helion/_native/__init__.py
@@ -1,0 +1,103 @@
+"""Optional native (Rust) accelerators for Helion's hot paths.
+
+This package is the integration point for a compiled extension that
+re-implements a handful of per-call Python operations in Rust (built
+with `PyO3 <https://pyo3.rs>`_) — most notably the launcher dispatch
+itself. None of those accelerators are in tree yet; this module is the
+stable Python-side contract they will plug into.
+
+Layout
+------
+- ``_launcher`` (added in a later commit) — the compiled Rust
+  extension.
+- This ``__init__.py`` exposes ``AVAILABLE`` and the public function
+  names. When the extension is importable, the names resolve to its
+  Rust implementations. When it isn't, they resolve to ``None`` and
+  callers must use the pure-Python fallback.
+
+Caller pattern
+--------------
+::
+
+    from helion import _native
+
+    if _native.CompiledLauncher is not None:
+        launcher = _native.CompiledLauncher()
+        launcher.prime(...)
+        # install in place of the Python ``default_launcher``
+    # otherwise the Python ``default_launcher`` keeps running.
+
+This two-level guard (module ``AVAILABLE`` flag plus per-symbol
+``None`` sentinel) lets the native path bail out on unsupported
+configurations (e.g. ABI mismatch, missing toolchain) without losing
+the per-call speedup on the common path.
+
+Why an optional extension
+-------------------------
+Helion ships as a pure-Python wheel via ``hatchling``. A failed Rust
+build, an unsupported PyTorch ABI, or a non-CPython interpreter must
+not break ``import helion``. The Python fallback is the source of
+truth; the Rust accelerator is a strict subset that fast-paths the
+common case.
+
+Why Rust (not C)
+----------------
+The launcher is a small, performance-sensitive piece of code with a
+narrow Python C-API surface. Rust + PyO3 gives the same access to the
+CPython C API with:
+
+- Memory safety (no leaked references on error paths — PyO3's
+  ``PyResult`` / ``Bound`` types handle that).
+- A standard build system (``cargo``) instead of an ad-hoc
+  ``gcc`` one-liner.
+
+Per-call performance is essentially identical to hand-written C: both
+go through the same CPython entry points for tensor metadata reads
+and Triton kernel dispatch, and PyO3's macro-generated trampolines
+add negligible overhead on the hot path.
+"""
+
+from __future__ import annotations
+
+import logging
+
+log: logging.Logger = logging.getLogger(__name__)
+
+# Set to ``True`` after a successful import of the compiled extension;
+# ``False`` when it is missing or failed to load. Callers should check
+# this AND the individual symbol (which may be ``None`` for functions
+# the extension didn't provide).
+AVAILABLE: bool = False
+
+# Public function slots. Re-bound below if the extension imports.
+# Each is either a callable (Rust-backed) or ``None`` (use Python).
+
+# Reserved slot for a future per-tensor specialization-key
+# accelerator. The earlier C experiment found only ~110 ns per call
+# of saving (within run-to-run variance for typical kernels), so this
+# slot is intentionally left unused until a path through the PyTorch
+# stable ABI can do better. ``None`` means: use the pure-Python
+# ``_tensor_key`` in ``helion/runtime/kernel.py``.
+tensor_key = None
+
+# Minimal Chunk-E Rust launcher: a Python type with a ``__call__``
+# slot that dispatches a Triton kernel directly into
+# ``compiled_kernel.run``, bypassing both the Python
+# ``default_launcher`` frame AND Triton's ``JITFunction.run``
+# pipeline. Caller is responsible for priming the launcher via
+# ``CompiledLauncher.prime(triton_kernel, grid, args, ...)`` before
+# installing it in place of the wrapper's ``_default_launcher``
+# kwdefault. ``None`` if the extension isn't built — callers must use
+# the pure-Python ``default_launcher`` in that case.
+CompiledLauncher = None
+
+try:
+    from . import _launcher  # type: ignore[attr-defined]
+except ImportError as e:
+    log.debug("helion._native._launcher not available: %s", e)
+else:
+    AVAILABLE = True
+    CompiledLauncher = getattr(_launcher, "CompiledLauncher", None)
+
+
+__all__ = ["AVAILABLE", "CompiledLauncher", "tensor_key"]

--- a/test/test_native_extension.py
+++ b/test/test_native_extension.py
@@ -1,0 +1,63 @@
+"""Smoke tests for the ``helion._native`` optional-extension shim.
+
+The Rust extension itself is added in a later commit; these tests pin
+down the Python-side contract that lets the rest of the codebase use
+the ``helion._native`` module safely whether or not the compiled
+extension is present.
+"""
+
+from __future__ import annotations
+
+import importlib
+import unittest
+
+
+class TestNativeExtensionShim(unittest.TestCase):
+    def test_helion_native_imports_cleanly(self) -> None:
+        """``import helion._native`` must succeed even when the extension is absent."""
+        mod = importlib.import_module("helion._native")
+        self.assertTrue(hasattr(mod, "AVAILABLE"))
+        self.assertTrue(hasattr(mod, "tensor_key"))
+        self.assertTrue(hasattr(mod, "CompiledLauncher"))
+
+    def test_available_flag_is_bool(self) -> None:
+        """``AVAILABLE`` must be a bool so callers can use it in
+        unambiguous truthiness checks."""
+        from helion import _native
+
+        self.assertIsInstance(_native.AVAILABLE, bool)
+
+    def test_symbol_consistency(self) -> None:
+        """``tensor_key`` is reserved as ``None`` (no Rust accelerator
+        ships in this slot yet). ``CompiledLauncher`` is either a class
+        when the extension is built, or ``None`` when it isn't."""
+        from helion import _native
+
+        # tensor_key has no Rust implementation; the slot is reserved.
+        self.assertIsNone(_native.tensor_key)
+
+        if _native.AVAILABLE:
+            self.assertTrue(callable(_native.CompiledLauncher))
+        else:
+            self.assertIsNone(_native.CompiledLauncher)
+
+    def test_helion_imports_with_extension_absent(self) -> None:
+        """Top-level ``import helion`` must work regardless of extension state.
+
+        The extension is optional. If it isn't built (e.g. on a non-CPython
+        runtime, a stripped build, or before the Rust source lands),
+        ``helion`` must still be importable and functional — falling back to
+        pure Python implementations.
+        """
+        import helion  # noqa: F401
+
+        # Re-import to be sure we don't have a stale state.
+        from helion import _native
+
+        self.assertTrue(hasattr(_native, "AVAILABLE"))
+        self.assertTrue(hasattr(_native, "tensor_key"))
+        self.assertTrue(hasattr(_native, "CompiledLauncher"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked PRs:
 * #2609
 * __->__#2606
 * #2565
 * #2611
 * #2605
 * #2604


--- --- ---

### [fast-launcher] Add helion._native optional Rust extension shim


Introduces ``helion/_native/``, the integration point for an optional
compiled extension that re-implements Helion's hot paths in Rust
(via `PyO3 <https://pyo3.rs>`_). The Rust source itself lands in a
later commit; this one just establishes the Python-side contract.

What this commit adds
---------------------

- ``helion/_native/__init__.py`` — pure-Python shim with the slots
  every caller can rely on:

  * ``AVAILABLE: bool`` — ``True`` when the compiled extension
    imported, ``False`` otherwise.
  * ``CompiledLauncher = None`` — replaced with the Rust class on
    successful import.
  * ``tensor_key = None`` — reserved extension point; no Rust
    accelerator ships in this slot yet (an earlier C experiment found
    only ~110 ns/call savings, within run-to-run variance for typical
    kernels).

  The import is wrapped in ``try / except ImportError`` so a failed
  build or unsupported runtime keeps the package importable. Callers
  check ``if _native.X is not None`` to decide between the fast
  path and the pure-Python fallback.

- ``helion/_native/.gitignore`` — excludes Cargo's ``target/``
  directory and the built shared library from version control.
  Source is in tree, build artifacts are not.

Why Rust (not C)
----------------

A previous draft of this stack used a hand-written C extension. The
Rust version is functionally identical and benchmarks the same on the
hot path (both go through the same CPython entry points for tensor
metadata reads and Triton kernel dispatch). Rust buys us:

- Memory safety on error paths — PyO3's ``PyResult`` / ``Bound`` types
  prevent the kinds of reference-leak bugs that the manual
  ``Py_XDECREF`` ladder in C is prone to.
- A standard build system (``cargo``) instead of an ad-hoc ``gcc``
  one-liner.

Benchmarks (H100, vector_add at N=4096)
---------------------------------------

This commit is a Python shim with no compiled code — there is no
perf delta. The Rust extension lands in the next commit and is what
moves the numbers. Reproducible baseline for the upcoming comparison:

  Variant                                       wall+sync   cpu_only
  prior commit (Phase 2 fast launcher)          ~19.7 us    ~14.0 us
  + this commit (helion._native shim, no .rs)   ~19.7 us    ~14.0 us
