### PR TITLE
test_examples: skip test_jagged_dense_add on Pallas

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -999,6 +999,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[128, 64],
         )
 
+    @skipIfPallas("TODO: follow up on timeout due to google-pytorch/torch_tpu@42d10ff")
     @xfailIfPallas("BlockSpec tiling failure")
     def test_jagged_dense_add(self):
         mod = import_path(EXAMPLES_DIR / "jagged_dense_add.py")


### PR DESCRIPTION
It has started timing out in CI. Note that this is not yet expected to work, which is why I'm keeping the xfail.