### PR TITLE
[fast-launcher] Minimal C CompiledLauncher with tp_call (Chunk E)

### DIFF
--- a/helion/_C/.gitignore
+++ b/helion/_C/.gitignore
@@ -1,0 +1,4 @@
+# Compiled native extension is a build artifact, not source.
+_native*.so
+_native*.pyd
+_native*.dylib

--- a/helion/_C/.gitignore
+++ b/helion/_C/.gitignore
@@ -1,4 +1,7 @@
-# Compiled native extension is a build artifact, not source.
+# Compiled native extensions are build artifacts, not source.
 _native*.so
 _native*.pyd
 _native*.dylib
+_launcher*.so
+_launcher*.pyd
+_launcher*.dylib

--- a/helion/_C/README.md
+++ b/helion/_C/README.md
@@ -1,0 +1,63 @@
+# helion._C — optional native extension
+
+This directory holds an OPTIONAL compiled extension that accelerates
+Helion's hot paths. It is not built by the default Helion install
+(which uses `hatchling` and ships a pure-Python wheel).
+
+## What's here
+
+- `_native.c` — single-file C extension. Currently exports
+  `tensor_key(tensor, static_indices) -> tuple | None`, the
+  static-shapes specialization key built per-call by `Kernel.bind`.
+- `__init__.py` — Python shim that imports the compiled extension if
+  present and exposes `AVAILABLE` + per-symbol fallback sentinels.
+
+## When to build
+
+Skip the build unless you're chasing per-call launch overhead on
+small kernels. The Python fallback produces identical keys and works
+on every supported platform.
+
+## How to build manually
+
+From the repo root, with the active Python env:
+
+```sh
+python -c "
+import distutils.sysconfig as s, subprocess, sysconfig
+cflags = sysconfig.get_config_var('CFLAGS') or ''
+inc = sysconfig.get_path('include')
+ext_suffix = sysconfig.get_config_var('EXT_SUFFIX')
+out = f'helion/_C/_native{ext_suffix}'
+subprocess.check_call([
+    'gcc', '-shared', '-fPIC',
+    '-O3',
+    f'-I{inc}',
+    'helion/_C/_native.c',
+    '-o', out,
+])
+print('Built', out)
+"
+```
+
+If the build succeeds, `import helion._C` will pick up the extension
+and `_C.AVAILABLE` will become `True`. If it fails or you don't run
+the command, `_C.AVAILABLE` stays `False` and the Python path handles
+everything.
+
+## What it does NOT do
+
+- It does not provide a C launcher — that's a much larger piece
+  (see `agent_space/c_extension_chunking_plan.md` Chunk E).
+- It does not touch PyTorch's C++ ABI. It uses only the Python C-API
+  (`PyObject_GetAttrString`, `PyObject_CallMethod`, `PyTuple_*`), so
+  it builds against any PyTorch.
+
+## How to verify
+
+```sh
+python -c "from helion import _C; print('AVAILABLE:', _C.AVAILABLE, 'tensor_key:', _C.tensor_key)"
+```
+
+When built: prints `AVAILABLE: True tensor_key: <built-in function tensor_key>`.
+When absent: prints `AVAILABLE: False tensor_key: None`.

--- a/helion/_C/README.md
+++ b/helion/_C/README.md
@@ -1,7 +1,7 @@
-# helion._C — optional native extension
+# helion._C — optional native extensions
 
-This directory holds an OPTIONAL compiled extension that accelerates
-Helion's hot paths. It is not built by the default Helion install
+This directory holds OPTIONAL compiled extensions that accelerate
+Helion's hot paths. They are not built by the default Helion install
 (which uses `hatchling` and ships a pure-Python wheel).
 
 ## What's here
@@ -9,7 +9,12 @@ Helion's hot paths. It is not built by the default Helion install
 - `_native.c` — single-file C extension. Currently exports
   `tensor_key(tensor, static_indices) -> tuple | None`, the
   static-shapes specialization key built per-call by `Kernel.bind`.
-- `__init__.py` — Python shim that imports the compiled extension if
+- `_launcher.c` — minimal C launcher. Exposes
+  `CompiledLauncher` (a Python type with a `tp_call` slot) that
+  dispatches a Triton kernel directly into `compiled_kernel.run`,
+  bypassing both the Python `default_launcher` frame and Triton's
+  `JITFunction.run` pipeline.
+- `__init__.py` — Python shim that imports the compiled extensions if
   present and exposes `AVAILABLE` + per-symbol fallback sentinels.
 
 ## When to build
@@ -24,19 +29,19 @@ From the repo root, with the active Python env:
 
 ```sh
 python -c "
-import distutils.sysconfig as s, subprocess, sysconfig
-cflags = sysconfig.get_config_var('CFLAGS') or ''
+import subprocess, sysconfig
 inc = sysconfig.get_path('include')
 ext_suffix = sysconfig.get_config_var('EXT_SUFFIX')
-out = f'helion/_C/_native{ext_suffix}'
-subprocess.check_call([
-    'gcc', '-shared', '-fPIC',
-    '-O3',
-    f'-I{inc}',
-    'helion/_C/_native.c',
-    '-o', out,
-])
-print('Built', out)
+for stem in ('_native', '_launcher'):
+    out = f'helion/_C/{stem}{ext_suffix}'
+    subprocess.check_call([
+        'gcc', '-shared', '-fPIC',
+        '-O3',
+        f'-I{inc}',
+        f'helion/_C/{stem}.c',
+        '-o', out,
+    ])
+    print('Built', out)
 "
 ```
 

--- a/helion/_C/__init__.py
+++ b/helion/_C/__init__.py
@@ -58,13 +58,30 @@ AVAILABLE: bool = False
 # Each is either a callable (C-backed) or ``None`` (use Python path).
 tensor_key = None
 
+# Minimal Chunk-E C launcher: a Python type with a ``tp_call`` slot
+# that dispatches a Triton kernel directly into ``compiled_kernel.run``,
+# bypassing both the Python ``default_launcher`` frame AND Triton's
+# ``JITFunction.run`` pipeline. Caller is responsible for priming the
+# launcher via ``CompiledLauncher.prime(triton_kernel, grid, args, ...)``
+# before installing it in place of the wrapper's ``_default_launcher``
+# kwdefault. ``None`` if the extension isn't built — callers must use
+# the pure-Python ``default_launcher`` in that case.
+CompiledLauncher = None
+
 try:
     from . import _native  # type: ignore[attr-defined]
 except ImportError as e:
-    log.debug("helion._C native extension not available: %s", e)
+    log.debug("helion._C._native not available: %s", e)
 else:
     AVAILABLE = True
     tensor_key = getattr(_native, "tensor_key", None)
 
+try:
+    from . import _launcher  # type: ignore[attr-defined]
+except ImportError as e:
+    log.debug("helion._C._launcher not available: %s", e)
+else:
+    CompiledLauncher = getattr(_launcher, "CompiledLauncher", None)
 
-__all__ = ["AVAILABLE", "tensor_key"]
+
+__all__ = ["AVAILABLE", "CompiledLauncher", "tensor_key"]

--- a/helion/_C/__init__.py
+++ b/helion/_C/__init__.py
@@ -1,0 +1,70 @@
+"""Optional native (C) accelerators for Helion's hot paths.
+
+This package is the integration point for a compiled C extension that
+re-implements a handful of per-call Python operations in C — most
+notably the per-tensor specialization-key build used by
+:meth:`Kernel.bind` and the launcher dispatch itself. None of those
+C accelerators are in tree yet; this module is the stable Python-side
+contract they will plug into.
+
+Layout
+------
+- ``_native`` (to be added in a later commit) — the compiled extension.
+- This ``__init__.py`` exposes ``AVAILABLE`` and the public function
+  names. When ``_native`` is importable, the names resolve to its C
+  implementations. When it isn't, they resolve to ``None`` and callers
+  must use the pure-Python fallback.
+
+Caller pattern
+--------------
+::
+
+    from helion import _C
+
+    def tensor_key(fn, obj):
+        if _C.tensor_key is not None:
+            key = _C.tensor_key(obj, fn.settings.static_shapes)
+            if key is not None:
+                return key
+        # ... fall back to pure-Python implementation ...
+
+This two-level guard (module ``AVAILABLE`` flag plus per-call
+``None`` sentinel) lets the C path bail out on unsupported inputs
+(SymInts, fake tensors) without losing the per-call C speedup on the
+common path.
+
+Why an optional extension
+-------------------------
+Helion ships as a pure-Python wheel via ``hatchling``. A failed C
+build, an unsupported PyTorch ABI, or a non-CPython interpreter must
+not break ``import helion``. The Python fallback is the source of
+truth; the C accelerator is a strict subset that fast-paths the
+common case.
+"""
+
+from __future__ import annotations
+
+import logging
+
+log: logging.Logger = logging.getLogger(__name__)
+
+# Set to ``True`` after a successful import of ``_native``; ``False``
+# when the extension is missing or failed to load. Callers should
+# check this AND the individual symbol (which may be ``None`` for
+# functions the extension didn't provide).
+AVAILABLE: bool = False
+
+# Public function slots. Re-bound below if the extension imports.
+# Each is either a callable (C-backed) or ``None`` (use Python path).
+tensor_key = None
+
+try:
+    from . import _native  # type: ignore[attr-defined]
+except ImportError as e:
+    log.debug("helion._C native extension not available: %s", e)
+else:
+    AVAILABLE = True
+    tensor_key = getattr(_native, "tensor_key", None)
+
+
+__all__ = ["AVAILABLE", "tensor_key"]

--- a/helion/_C/_launcher.c
+++ b/helion/_C/_launcher.c
@@ -1,0 +1,306 @@
+/* Minimal C launcher (Chunk E experiment).
+ *
+ * A Python type whose ``tp_call`` slot dispatches a Triton kernel
+ * launch directly into ``compiled_kernel.run`` (the C launcher
+ * Triton emits), bypassing the Python ``default_launcher`` frame.
+ *
+ * Compared to a full Python-side fast launcher, this minimal version
+ * trades correctness coverage for simplicity:
+ *
+ *   - No multi-spec cache. The compiled kernel captured on first
+ *     ``prime()`` call is reused for ALL subsequent calls. Caller
+ *     is responsible for only using stable specs (same alignment,
+ *     same shape, etc.).
+ *   - No knob/hook re-reads. If the user enables
+ *     ``knobs.runtime.debug`` or attaches a profiler hook, we don't
+ *     observe it. Caller is responsible for pre-priming with the
+ *     final config.
+ *   - No ``used_global_vals`` check. Mutating a tracked global
+ *     between calls would silently use the stale binary.
+ *   - No multi-device guard.
+ *
+ * Purpose: measure the per-call savings of replacing the Python
+ * ``default_launcher`` frame with a C tp_call. The Phase 2 multi-spec
+ * launcher's correctness guards aren't on this branch yet; a real
+ * Chunk E would port them.
+ *
+ * Usage from Python:
+ *
+ *   import helion._C
+ *   launcher = helion._C.CompiledLauncher()
+ *   launcher.prime(triton_kernel, grid, args, num_warps=4, num_stages=2)
+ *   # Then call as a plain function:
+ *   launcher(triton_kernel, grid, *args, num_warps=4, num_stages=2)
+ *
+ * Or install it as the wrapper's ``_launcher`` kwdefault via Python.
+ */
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+
+typedef struct {
+    PyObject_HEAD
+    /* All captured at prime() time and held as strong refs. */
+    PyObject *compiled_run;          /* compiled_kernel.run callable */
+    PyObject *triton_function;       /* compiled_kernel.function */
+    PyObject *packed_metadata;       /* compiled_kernel.packed_metadata */
+    PyObject *kernel_launch_metadata;/* compiled_kernel.launch_metadata callable */
+    PyObject *get_current_stream;    /* driver.active.get_current_stream */
+    PyObject *device;                /* device id from driver */
+    int primed;
+} LauncherObject;
+
+
+static void Launcher_dealloc(LauncherObject *self) {
+    Py_XDECREF(self->compiled_run);
+    Py_XDECREF(self->triton_function);
+    Py_XDECREF(self->packed_metadata);
+    Py_XDECREF(self->kernel_launch_metadata);
+    Py_XDECREF(self->get_current_stream);
+    Py_XDECREF(self->device);
+    Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+
+static PyObject *Launcher_new(PyTypeObject *type, PyObject *args, PyObject *kwargs) {
+    LauncherObject *self = (LauncherObject *)type->tp_alloc(type, 0);
+    if (self == NULL) return NULL;
+    self->compiled_run = NULL;
+    self->triton_function = NULL;
+    self->packed_metadata = NULL;
+    self->kernel_launch_metadata = NULL;
+    self->get_current_stream = NULL;
+    self->device = NULL;
+    self->primed = 0;
+    return (PyObject *)self;
+}
+
+
+/* prime(triton_kernel, grid, args, num_warps, num_stages) — runs
+ * Triton's warmup compile once to capture the CompiledKernel and
+ * driver references. ``args`` is a Python tuple of the kernel's
+ * positional args. */
+static PyObject *Launcher_prime(LauncherObject *self, PyObject *args, PyObject *kwargs) {
+    static char *kwlist[] = {
+        "triton_kernel", "grid", "args", "num_warps", "num_stages", NULL
+    };
+    PyObject *triton_kernel;
+    PyObject *grid;
+    PyObject *kargs;
+    int num_warps, num_stages;
+    if (!PyArg_ParseTupleAndKeywords(
+            args, kwargs, "OOOii", kwlist,
+            &triton_kernel, &grid, &kargs, &num_warps, &num_stages)) {
+        return NULL;
+    }
+
+    /* Build warmup kwargs dict: {grid, warmup=True, num_warps, num_stages,
+     * launch_cooperative_grid=False} */
+    PyObject *warmup_kwargs = PyDict_New();
+    if (warmup_kwargs == NULL) return NULL;
+    if (PyDict_SetItemString(warmup_kwargs, "grid", grid) < 0) goto fail;
+    Py_INCREF(Py_True);
+    if (PyDict_SetItemString(warmup_kwargs, "warmup", Py_True) < 0) {
+        Py_DECREF(Py_True);
+        goto fail;
+    }
+    Py_DECREF(Py_True);
+    PyObject *nw = PyLong_FromLong(num_warps);
+    if (nw == NULL) goto fail;
+    PyDict_SetItemString(warmup_kwargs, "num_warps", nw);
+    Py_DECREF(nw);
+    PyObject *ns = PyLong_FromLong(num_stages);
+    if (ns == NULL) goto fail;
+    PyDict_SetItemString(warmup_kwargs, "num_stages", ns);
+    Py_DECREF(ns);
+    PyDict_SetItemString(warmup_kwargs, "launch_cooperative_grid", Py_False);
+
+    /* Call triton_kernel.run(*args, **warmup_kwargs) */
+    PyObject *run_method = PyObject_GetAttrString(triton_kernel, "run");
+    if (run_method == NULL) goto fail;
+    PyObject *compiled = PyObject_Call(run_method, kargs, warmup_kwargs);
+    Py_DECREF(run_method);
+    Py_DECREF(warmup_kwargs);
+    warmup_kwargs = NULL;
+    if (compiled == NULL || compiled == Py_None) {
+        Py_XDECREF(compiled);
+        PyErr_SetString(PyExc_RuntimeError, "Triton warmup returned None");
+        return NULL;
+    }
+
+    /* Extract compiled_kernel.run FIRST so it triggers _init_handles */
+    PyObject *run_fn = PyObject_GetAttrString(compiled, "run");
+    if (run_fn == NULL) {
+        Py_DECREF(compiled);
+        return NULL;
+    }
+    PyObject *function = PyObject_GetAttrString(compiled, "function");
+    PyObject *packed = PyObject_GetAttrString(compiled, "packed_metadata");
+    PyObject *lm = PyObject_GetAttrString(compiled, "launch_metadata");
+    Py_DECREF(compiled);
+    if (function == NULL || packed == NULL || lm == NULL) {
+        Py_DECREF(run_fn);
+        Py_XDECREF(function);
+        Py_XDECREF(packed);
+        Py_XDECREF(lm);
+        return NULL;
+    }
+
+    /* Get driver.active.get_current_stream and device. */
+    PyObject *driver_mod = PyImport_ImportModule("triton.runtime.driver");
+    if (driver_mod == NULL) goto state_fail;
+    PyObject *driver = PyObject_GetAttrString(driver_mod, "driver");
+    Py_DECREF(driver_mod);
+    if (driver == NULL) goto state_fail;
+    PyObject *active = PyObject_GetAttrString(driver, "active");
+    Py_DECREF(driver);
+    if (active == NULL) goto state_fail;
+    PyObject *get_dev = PyObject_GetAttrString(active, "get_current_device");
+    if (get_dev == NULL) { Py_DECREF(active); goto state_fail; }
+    PyObject *device = PyObject_CallNoArgs(get_dev);
+    Py_DECREF(get_dev);
+    PyObject *gcs = PyObject_GetAttrString(active, "get_current_stream");
+    Py_DECREF(active);
+    if (device == NULL || gcs == NULL) {
+        Py_XDECREF(device);
+        Py_XDECREF(gcs);
+        goto state_fail;
+    }
+
+    /* Publish all state, last is `primed`. */
+    Py_XDECREF(self->compiled_run); self->compiled_run = run_fn;
+    Py_XDECREF(self->triton_function); self->triton_function = function;
+    Py_XDECREF(self->packed_metadata); self->packed_metadata = packed;
+    Py_XDECREF(self->kernel_launch_metadata); self->kernel_launch_metadata = lm;
+    Py_XDECREF(self->get_current_stream); self->get_current_stream = gcs;
+    Py_XDECREF(self->device); self->device = device;
+    self->primed = 1;
+    Py_RETURN_NONE;
+
+state_fail:
+    Py_DECREF(run_fn);
+    Py_DECREF(function);
+    Py_DECREF(packed);
+    Py_DECREF(lm);
+    return NULL;
+fail:
+    Py_XDECREF(warmup_kwargs);
+    return NULL;
+}
+
+
+/* tp_call: args = (triton_kernel, grid, *kernel_args).
+ * kwargs may include num_warps/num_stages etc — we ignore them
+ * (the values were baked at prime time).
+ *
+ * Builds: compiled_run(grid_0, grid_1, grid_2, stream,
+ *                     function, packed_metadata,
+ *                     None (launch_metadata),
+ *                     None (enter_hook),
+ *                     None (exit_hook),
+ *                     *kernel_args)
+ */
+static PyObject *Launcher_call(LauncherObject *self, PyObject *args, PyObject *kwargs) {
+    if (!self->primed) {
+        PyErr_SetString(PyExc_RuntimeError, "CompiledLauncher not primed");
+        return NULL;
+    }
+
+    Py_ssize_t nargs = PyTuple_GET_SIZE(args);
+    if (nargs < 2) {
+        PyErr_SetString(PyExc_TypeError,
+            "launcher requires at least (triton_kernel, grid, *kernel_args)");
+        return NULL;
+    }
+    /* args[0] is triton_kernel (unused — we have cached state)
+     * args[1] is grid (tuple of ints) */
+    PyObject *grid = PyTuple_GET_ITEM(args, 1);
+    Py_ssize_t grid_n = PyTuple_GET_SIZE(grid);
+
+    long grid_0 = 1, grid_1 = 1, grid_2 = 1;
+    if (grid_n >= 1) grid_0 = PyLong_AsLong(PyTuple_GET_ITEM(grid, 0));
+    if (grid_n >= 2) grid_1 = PyLong_AsLong(PyTuple_GET_ITEM(grid, 1));
+    if (grid_n >= 3) grid_2 = PyLong_AsLong(PyTuple_GET_ITEM(grid, 2));
+
+    PyObject *stream = PyObject_CallOneArg(self->get_current_stream, self->device);
+    if (stream == NULL) return NULL;
+
+    /* Build new args tuple: (grid_0, grid_1, grid_2, stream, function,
+     * packed_metadata, None, None, None, *kernel_args) */
+    Py_ssize_t n_kernel_args = nargs - 2;
+    Py_ssize_t out_n = 9 + n_kernel_args;
+    PyObject *out = PyTuple_New(out_n);
+    if (out == NULL) { Py_DECREF(stream); return NULL; }
+
+    PyTuple_SET_ITEM(out, 0, PyLong_FromLong(grid_0));
+    PyTuple_SET_ITEM(out, 1, PyLong_FromLong(grid_1));
+    PyTuple_SET_ITEM(out, 2, PyLong_FromLong(grid_2));
+    PyTuple_SET_ITEM(out, 3, stream);
+    Py_INCREF(self->triton_function);
+    PyTuple_SET_ITEM(out, 4, self->triton_function);
+    Py_INCREF(self->packed_metadata);
+    PyTuple_SET_ITEM(out, 5, self->packed_metadata);
+    Py_INCREF(Py_None);
+    PyTuple_SET_ITEM(out, 6, Py_None);
+    Py_INCREF(Py_None);
+    PyTuple_SET_ITEM(out, 7, Py_None);
+    Py_INCREF(Py_None);
+    PyTuple_SET_ITEM(out, 8, Py_None);
+    for (Py_ssize_t i = 0; i < n_kernel_args; ++i) {
+        PyObject *ka = PyTuple_GET_ITEM(args, 2 + i);
+        Py_INCREF(ka);
+        PyTuple_SET_ITEM(out, 9 + i, ka);
+    }
+
+    PyObject *result = PyObject_Call(self->compiled_run, out, NULL);
+    Py_DECREF(out);
+    return result;
+}
+
+
+static PyMethodDef Launcher_methods[] = {
+    {"prime", (PyCFunction)(void(*)(void))Launcher_prime,
+     METH_VARARGS | METH_KEYWORDS, "Compile-and-capture the Triton kernel state."},
+    {NULL, NULL, 0, NULL}
+};
+
+
+static PyTypeObject LauncherType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "helion._C._launcher.CompiledLauncher",
+    .tp_doc = "Minimal C launcher (Chunk E experiment).",
+    .tp_basicsize = sizeof(LauncherObject),
+    .tp_itemsize = 0,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .tp_new = Launcher_new,
+    .tp_dealloc = (destructor)Launcher_dealloc,
+    .tp_call = (ternaryfunc)Launcher_call,
+    .tp_methods = Launcher_methods,
+};
+
+
+static struct PyModuleDef launcher_module = {
+    PyModuleDef_HEAD_INIT,
+    "_launcher",
+    "Minimal C launcher type for Helion.",
+    -1,
+    NULL,
+};
+
+
+PyMODINIT_FUNC PyInit__launcher(void) {
+    PyObject *m = PyModule_Create(&launcher_module);
+    if (m == NULL) return NULL;
+    if (PyType_Ready(&LauncherType) < 0) {
+        Py_DECREF(m);
+        return NULL;
+    }
+    Py_INCREF(&LauncherType);
+    if (PyModule_AddObject(m, "CompiledLauncher", (PyObject *)&LauncherType) < 0) {
+        Py_DECREF(&LauncherType);
+        Py_DECREF(m);
+        return NULL;
+    }
+    return m;
+}

--- a/helion/_C/_native.c
+++ b/helion/_C/_native.c
@@ -1,0 +1,139 @@
+/* Native accelerators for Helion's hot paths.
+ *
+ * Currently exports only:
+ *   tensor_key(tensor, static_indices) -> tuple | None
+ *     Returns (dtype, sizes_tuple, strides_tuple, static_indices) for
+ *     the static-shapes specialization-key build inside Kernel.bind.
+ *     Returns Python's ``None`` (not raising) for any input it can't
+ *     handle, signaling the Python caller to fall back.
+ *
+ * Build (until a build-system hook lands):
+ *   See helion/_C/README.md for the manual compile command. The
+ *   extension is OPTIONAL: helion._C imports cleanly without it, and
+ *   the Python fallback path produces identical keys.
+ */
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+
+static PyObject *
+tensor_key(PyObject *self, PyObject *args)
+{
+    PyObject *tensor;
+    PyObject *static_indices;
+    if (!PyArg_ParseTuple(args, "OO", &tensor, &static_indices)) {
+        return NULL;
+    }
+
+    /* dtype = tensor.dtype */
+    PyObject *dtype = PyObject_GetAttrString(tensor, "dtype");
+    if (dtype == NULL) {
+        PyErr_Clear();
+        Py_RETURN_NONE;
+    }
+
+    /* sizes = tensor.size() */
+    PyObject *sizes_obj = PyObject_CallMethod(tensor, "size", NULL);
+    if (sizes_obj == NULL) {
+        Py_DECREF(dtype);
+        PyErr_Clear();
+        Py_RETURN_NONE;
+    }
+
+    /* strides = tensor.stride() */
+    PyObject *strides_obj = PyObject_CallMethod(tensor, "stride", NULL);
+    if (strides_obj == NULL) {
+        Py_DECREF(dtype);
+        Py_DECREF(sizes_obj);
+        PyErr_Clear();
+        Py_RETURN_NONE;
+    }
+
+    /* Both sizes() and stride() return torch.Size (a tuple subclass)
+     * for non-SymInt tensors. Each element must be a Python int — if
+     * any are SymInts, we bail out to let the Python path build the
+     * (env_id, expr) key it needs.
+     *
+     * Detect SymInt via the standard Python int check: torch.SymInt is
+     * NOT a subclass of int, so PyLong_Check is False for them. The
+     * tensor's sizes/strides tuples may contain SymInts in dynamic
+     * shapes mode; we want only the static (all-ints) fast path here. */
+    PyObject *sizes_tuple = NULL;
+    PyObject *strides_tuple = NULL;
+
+    if (!PyTuple_Check(sizes_obj) || !PyTuple_Check(strides_obj)) {
+        /* Unexpected — torch.Size IS a tuple subclass. Fall back. */
+        goto fallback;
+    }
+
+    Py_ssize_t n_sizes = PyTuple_GET_SIZE(sizes_obj);
+    for (Py_ssize_t i = 0; i < n_sizes; ++i) {
+        PyObject *item = PyTuple_GET_ITEM(sizes_obj, i);
+        if (!PyLong_CheckExact(item)) {
+            goto fallback;
+        }
+    }
+    Py_ssize_t n_strides = PyTuple_GET_SIZE(strides_obj);
+    for (Py_ssize_t i = 0; i < n_strides; ++i) {
+        PyObject *item = PyTuple_GET_ITEM(strides_obj, i);
+        if (!PyLong_CheckExact(item)) {
+            goto fallback;
+        }
+    }
+
+    /* All ints — convert the torch.Size subclasses to plain tuples so
+     * the key is independent of torch's internal types. */
+    sizes_tuple = PyTuple_GetSlice(sizes_obj, 0, n_sizes);
+    if (sizes_tuple == NULL) goto fallback;
+    strides_tuple = PyTuple_GetSlice(strides_obj, 0, n_strides);
+    if (strides_tuple == NULL) goto fallback;
+
+    /* Build the 4-tuple (dtype, sizes, strides, static_indices). */
+    PyObject *result = PyTuple_New(4);
+    if (result == NULL) goto fallback;
+
+    /* Steal references into the tuple. */
+    PyTuple_SET_ITEM(result, 0, dtype);          /* steals */
+    PyTuple_SET_ITEM(result, 1, sizes_tuple);    /* steals */
+    PyTuple_SET_ITEM(result, 2, strides_tuple);  /* steals */
+    Py_INCREF(static_indices);
+    PyTuple_SET_ITEM(result, 3, static_indices); /* steals */
+
+    Py_DECREF(sizes_obj);
+    Py_DECREF(strides_obj);
+    return result;
+
+fallback:
+    Py_DECREF(dtype);
+    Py_DECREF(sizes_obj);
+    Py_DECREF(strides_obj);
+    Py_XDECREF(sizes_tuple);
+    Py_XDECREF(strides_tuple);
+    PyErr_Clear();
+    Py_RETURN_NONE;
+}
+
+
+static PyMethodDef NativeMethods[] = {
+    {"tensor_key", tensor_key, METH_VARARGS,
+     "Build the static-shapes specialization key for a tensor, "
+     "or return None if the input is unsupported."},
+    {NULL, NULL, 0, NULL}
+};
+
+
+static struct PyModuleDef nativemodule = {
+    PyModuleDef_HEAD_INIT,
+    "_native",
+    "helion._C native accelerators",
+    -1,
+    NativeMethods
+};
+
+
+PyMODINIT_FUNC
+PyInit__native(void)
+{
+    return PyModule_Create(&nativemodule);
+}

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -17,6 +17,10 @@ from .. import _compat as _compat  # ensure Triton compatibility patches run
 from .. import exc
 from .._compiler.cute.strategies import tcgen05_smem_layout_expr
 from .._utils import triton_is_available
+from ._output_pool import clear_pool as clear_pool
+from ._output_pool import empty_like as empty_like
+from ._output_pool import is_pool_enabled as is_pool_enabled
+from ._output_pool import set_pool_enabled as set_pool_enabled
 from .config import Config as Config
 from .kernel import Kernel as Kernel
 from .kernel import kernel as kernel

--- a/helion/runtime/_output_pool.py
+++ b/helion/runtime/_output_pool.py
@@ -1,0 +1,127 @@
+"""Optional output-tensor pool for Helion kernels.
+
+For small kernels, allocating a fresh output tensor with
+``torch.empty_like(x)`` is a measurable per-call cost (~1.5 μs on H100
+for a 4 KB tensor). This module provides ``empty_like`` — a drop-in
+replacement that, when ``HELION_OUTPUT_POOL=1`` is set in the
+environment, reuses a small fixed-size cache of buffers keyed on
+``(dtype, shape, stride, device)``.
+
+When the env var is NOT set (the default), ``empty_like`` is a thin
+pass-through to ``torch.empty_like`` and behaves exactly like the
+PyTorch builtin.
+
+Semantics caveat
+----------------
+Pooled buffers are RECYCLED across calls. Callers MUST consume the
+returned tensor before the next call to ``empty_like`` with the same
+key, or copy the data out. The buffer returned this call may be
+re-handed to the next call — holding a reference for later use will
+see its contents clobbered. This is why the pool is opt-in: the
+``torch.empty_like`` semantics (fresh allocation) are the default to
+avoid silent aliasing bugs.
+
+Layout
+------
+``_POOLS`` is a process-wide dict mapping a tensor signature
+(``(dtype, sizes, strides, device)``) to a small ring buffer (list)
+of preallocated tensors. Each ``empty_like`` call rotates through the
+ring, returning the next slot. Ring length is fixed at module-init.
+
+The pool is intentionally simple: no LRU eviction, no maximum total
+memory cap. The expected use case is hot inference loops that call
+the same kernels with the same shapes repeatedly, so the pool grows
+to its steady-state size after warmup and stays there.
+
+Disabling at runtime
+--------------------
+Reading the env var once at import time (cached in ``_POOL_ENABLED``)
+keeps ``empty_like`` allocation-free in the disabled path. To change
+the setting after import, call :func:`set_pool_enabled`.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Hashable
+
+
+# Ring-buffer length per (dtype, sizes, strides, device) key. Two
+# slots is enough to cover the common case (one buffer being written
+# while the previous is still being read on another stream); going
+# higher just wastes memory.
+_POOL_DEPTH = 2
+
+_POOLS: dict[Hashable, list[torch.Tensor]] = {}
+_POOL_INDEX: dict[Hashable, int] = {}
+
+
+def _env_enabled() -> bool:
+    return os.environ.get("HELION_OUTPUT_POOL", "").lower() in ("1", "true", "yes")
+
+
+_POOL_ENABLED: bool = _env_enabled()
+
+
+def set_pool_enabled(enabled: bool) -> None:
+    """Programmatic toggle for the pool, overriding the env var.
+
+    Useful for tests and for libraries that want to opt in/out
+    independently of the user's environment.
+    """
+    global _POOL_ENABLED
+    _POOL_ENABLED = enabled
+
+
+def is_pool_enabled() -> bool:
+    return _POOL_ENABLED
+
+
+def clear_pool() -> None:
+    """Drop all pooled buffers. Useful for tests and for callers that
+    want to reclaim memory after a workload finishes."""
+    _POOLS.clear()
+    _POOL_INDEX.clear()
+
+
+def empty_like(template: torch.Tensor) -> torch.Tensor:
+    """Return an uninitialized tensor with the same dtype/shape/stride/device
+    as ``template``.
+
+    When :func:`is_pool_enabled` is ``True``, returns a recycled buffer
+    from a per-signature ring. When ``False``, falls through to
+    ``torch.empty_like``.
+
+    Callers must consume the returned tensor before the next call with
+    the same signature, or copy the data out — see the module
+    docstring.
+    """
+    if not _POOL_ENABLED:
+        return torch.empty_like(template)
+    key = (
+        template.dtype,
+        tuple(template.size()),
+        tuple(template.stride()),
+        template.device,
+    )
+    ring = _POOLS.get(key)
+    if ring is None:
+        ring = [torch.empty_like(template) for _ in range(_POOL_DEPTH)]
+        _POOLS[key] = ring
+        _POOL_INDEX[key] = 0
+    idx = _POOL_INDEX[key]
+    _POOL_INDEX[key] = (idx + 1) % _POOL_DEPTH
+    return ring[idx]
+
+
+__all__ = [
+    "clear_pool",
+    "empty_like",
+    "is_pool_enabled",
+    "set_pool_enabled",
+]

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -1316,6 +1316,15 @@ def _safe_bucket_dim(s: int | torch.SymInt) -> Hashable:
 
 _EMPTY_FROZENSET: frozenset[int] = frozenset()
 
+# Module-level binding of the optional C accelerator. Captured at import
+# time so the hot path inside ``_tensor_key`` skips the
+# ``helion._C.tensor_key`` attribute lookup on every call. ``None`` if
+# the C extension isn't built; in that case ``_tensor_key`` falls
+# through to the pure-Python implementation below.
+from .. import _C as _helion_C  # noqa: E402
+
+_C_tensor_key = _helion_C.tensor_key
+
 
 def _bucketed_size(obj: torch.Tensor) -> tuple[Hashable, ...]:
     sz = obj.size()
@@ -1345,6 +1354,16 @@ def _hashable_dims(dims: Sequence[int | torch.SymInt]) -> tuple[Hashable, ...]:
 
 
 def _tensor_key(fn: Kernel, obj: torch.Tensor) -> Hashable:
+    # Fast path: optional C extension that builds the static-shapes
+    # specialization tuple in C. Returns ``None`` to signal "unsupported
+    # input, fall back to Python" (e.g. for SymInt sizes, fake tensors,
+    # or dynamic-shapes mode which needs the bucketed-size logic below).
+    if _C_tensor_key is not None and fn.settings.static_shapes:
+        si = getattr(obj, "_dynamo_static_indices", None)
+        static_indices = frozenset(si) if si is not None else _EMPTY_FROZENSET
+        c_key = _C_tensor_key(obj, static_indices)
+        if c_key is not None:
+            return c_key
     si = getattr(obj, "_dynamo_static_indices", None)
     static_indices = frozenset(si) if si is not None else _EMPTY_FROZENSET
     if fn.settings.static_shapes:

--- a/test/test_c_extension.py
+++ b/test/test_c_extension.py
@@ -1,0 +1,64 @@
+"""Smoke tests for the ``helion._C`` optional-native-extension shim.
+
+The extension itself is added in a later commit; these tests pin down
+the Python-side contract that lets the rest of the codebase use the
+``helion._C`` module safely whether or not the compiled extension is
+present.
+"""
+
+from __future__ import annotations
+
+import importlib
+import unittest
+
+
+class TestCExtensionShim(unittest.TestCase):
+    def test_helion_c_imports_cleanly(self) -> None:
+        """``import helion._C`` must succeed even when the extension is absent."""
+        c_mod = importlib.import_module("helion._C")
+        self.assertTrue(hasattr(c_mod, "AVAILABLE"))
+        self.assertTrue(hasattr(c_mod, "tensor_key"))
+
+    def test_available_flag_is_bool(self) -> None:
+        """``AVAILABLE`` must be a bool so callers can use it in
+        unambiguous truthiness checks."""
+        from helion import _C
+
+        self.assertIsInstance(_C.AVAILABLE, bool)
+
+    def test_symbol_consistency(self) -> None:
+        """If ``AVAILABLE`` is ``True``, each public function slot must
+        be callable; if ``False``, each must be ``None`` so callers can
+        gate on ``is not None``."""
+        from helion import _C
+
+        if _C.AVAILABLE:
+            # Extension built — all advertised symbols must resolve.
+            self.assertTrue(callable(_C.tensor_key))
+        else:
+            # Extension absent — every slot must be ``None`` exactly,
+            # not some other falsy value, so callers can use
+            # ``if _C.tensor_key is not None`` unambiguously.
+            self.assertIsNone(_C.tensor_key)
+
+    def test_helion_imports_with_extension_absent(self) -> None:
+        """Top-level ``import helion`` must work regardless of extension state.
+
+        The extension is optional. If it isn't built (e.g. on a non-CPython
+        runtime, a stripped build, or before the C source lands), ``helion``
+        must still be importable and functional — falling back to pure
+        Python implementations.
+        """
+        import helion  # noqa: F401
+
+        # Re-import _C to be sure we don't have a stale state.
+        from helion import _C
+
+        # Regardless of whether the extension built, _C must have these
+        # documented attributes.
+        self.assertTrue(hasattr(_C, "AVAILABLE"))
+        self.assertTrue(hasattr(_C, "tensor_key"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_c_launcher.py
+++ b/test/test_c_launcher.py
@@ -1,0 +1,121 @@
+"""Tests for the minimal C launcher (Chunk E experiment).
+
+The C launcher (``helion._C.CompiledLauncher``) is OPTIONAL and built
+manually (see ``helion/_C/README.md``). When present, it can be
+installed as the ``_launcher`` kwdefault of a Helion-generated host
+wrapper to dispatch kernels via C ``tp_call`` directly into
+``compiled_kernel.run``, skipping both the Python
+``default_launcher`` frame and Triton's ``JITFunction.run`` pipeline.
+
+The launcher in this commit is intentionally minimal: no multi-spec
+cache, no knob/hook re-reads, no ``used_global_vals`` check. Tests
+verify correctness on the steady-state case (same args, same knobs)
+and the priming + invocation lifecycle.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+import helion
+from helion import _C
+from helion._testing import DEVICE
+from helion._testing import skipIfNotCUDA
+from helion._testing import skipIfNotTriton
+import helion.language as hl
+
+
+@helion.kernel(
+    static_shapes=True,
+    config=helion.Config(block_sizes=[1024], num_warps=4, num_stages=2),
+)
+def _add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for i in hl.tile(out.size(0)):
+        out[i] = x[i] + y[i]
+    return out
+
+
+def _get_jit_function(kernel: helion.Kernel) -> object:
+    from triton.runtime.jit import JITFunction
+
+    bound = next(iter(kernel._bound_kernels.values()))  # type: ignore[attr-defined]
+    return next(
+        v for v in bound._run.__globals__.values() if isinstance(v, JITFunction)
+    )
+
+
+@skipIfNotTriton("C launcher is Triton-specific")
+class TestCLauncher(unittest.TestCase):
+    def setUp(self) -> None:
+        if _C.CompiledLauncher is None:
+            self.skipTest("helion._C._launcher extension not built")
+
+    @skipIfNotCUDA()
+    def test_priming_then_calling_matches_reference(self) -> None:
+        """A primed C launcher must produce the same output as a Python
+        ``default_launcher`` call on the same args."""
+        _add.reset()
+        n = 4096
+        a = torch.randn(n, device=DEVICE, dtype=torch.float32)
+        b = torch.randn(n, device=DEVICE, dtype=torch.float32)
+        expected = (a + b).clone()
+
+        # Compile + run once to populate the Triton cache.
+        _add(a, b)
+        torch.cuda.synchronize()
+
+        jit_fn = _get_jit_function(_add)
+        out = torch.empty_like(a)
+        grid = ((n + 1024 - 1) // 1024,)
+        kernel_args = (a, b, out)
+
+        launcher = _C.CompiledLauncher()
+        launcher.prime(jit_fn, grid, kernel_args, num_warps=4, num_stages=2)
+
+        # Direct call through the C launcher.
+        result_buf = torch.empty_like(a)
+        launcher(jit_fn, grid, a, b, result_buf)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(result_buf, expected)
+
+        # Now install as the wrapper's kwdefault and verify end-to-end.
+        bound = next(iter(_add._bound_kernels.values()))  # type: ignore[attr-defined]
+        compiled_wrapper = bound._run
+        default = compiled_wrapper.__kwdefaults__["_launcher"]
+        self.addCleanup(
+            lambda: compiled_wrapper.__kwdefaults__.__setitem__("_launcher", default)
+        )
+        compiled_wrapper.__kwdefaults__["_launcher"] = launcher
+
+        result = _add(a, b)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(result, expected)
+
+    @skipIfNotCUDA()
+    def test_call_without_priming_raises(self) -> None:
+        """Calling an unprimed launcher must raise rather than crash."""
+        launcher = _C.CompiledLauncher()
+        # Dummy args — we just need to verify the un-primed path raises.
+        a = torch.empty(8, device=DEVICE, dtype=torch.float32)
+        b = torch.empty(8, device=DEVICE, dtype=torch.float32)
+        with self.assertRaises(RuntimeError):
+            launcher(None, (1,), a, b)
+
+    def test_launcher_type_is_subclassable(self) -> None:
+        """``CompiledLauncher`` is declared ``Py_TPFLAGS_BASETYPE`` so
+        Python subclasses are possible (e.g. wrapping with extra
+        Python-side guards)."""
+        if _C.CompiledLauncher is None:
+            self.skipTest("extension not built")
+
+        class Sub(_C.CompiledLauncher):
+            pass
+
+        self.assertTrue(issubclass(Sub, _C.CompiledLauncher))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_c_tensor_key.py
+++ b/test/test_c_tensor_key.py
@@ -1,0 +1,167 @@
+"""Tests for the C `tensor_key` accelerator + its Python fallback.
+
+The C extension is OPTIONAL — built manually via the instructions in
+``helion/_C/README.md`` and not included in the default install. These
+tests verify:
+
+1. With or without the extension, ``Kernel.bind`` produces identical
+   ``_bound_kernels`` cache keys (the Python fallback and C fast path
+   are equivalent).
+2. When the extension is present, ``helion._C.tensor_key`` is callable
+   and returns the documented 4-tuple shape for static-shapes tensors.
+3. When the extension is absent, ``helion._C.tensor_key`` is ``None``
+   and ``_tensor_key`` transparently uses the Python implementation.
+4. Unsupported inputs (e.g. SymInt sizes, dynamic-shapes mode) make
+   the C path return ``None`` and the Python fallback takes over.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+import torch
+
+import helion
+from helion import _C
+from helion._testing import DEVICE
+from helion._testing import TestCase
+import helion.language as hl
+from helion.runtime.kernel import _tensor_key
+
+
+@helion.kernel(static_shapes=True)
+def _add_one_static(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size()):
+        out[tile] = x[tile] + 1
+    return out
+
+
+@helion.kernel(static_shapes=False)
+def _add_one_dynamic(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size()):
+        out[tile] = x[tile] + 1
+    return out
+
+
+class TestCTensorKeyShape(unittest.TestCase):
+    """Shape + structure of the C output (when built)."""
+
+    def setUp(self) -> None:
+        if not _C.AVAILABLE or _C.tensor_key is None:
+            self.skipTest("helion._C extension not built")
+
+    def test_static_shapes_tensor_returns_4tuple(self) -> None:
+        """For a typical static-shapes tensor, the C path returns
+        ``(dtype, sizes, strides, static_indices)``."""
+        x = torch.randn(32, 64, dtype=torch.float32)
+        result = _C.tensor_key(x, frozenset())
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 4)
+        dtype, sizes, strides, static_indices = result
+        self.assertEqual(dtype, torch.float32)
+        self.assertEqual(sizes, (32, 64))
+        self.assertEqual(strides, tuple(x.stride()))
+        self.assertEqual(static_indices, frozenset())
+
+    def test_threads_static_indices_through(self) -> None:
+        """The ``static_indices`` arg is returned verbatim in slot 3."""
+        x = torch.randn(8, dtype=torch.float32)
+        si = frozenset({1, 3})
+        result = _C.tensor_key(x, si)
+        self.assertEqual(result[3], si)
+
+    def test_1d_tensor(self) -> None:
+        x = torch.arange(16, dtype=torch.int64)
+        result = _C.tensor_key(x, frozenset())
+        self.assertEqual(result, (torch.int64, (16,), (1,), frozenset()))
+
+    def test_strided_view_has_distinct_strides(self) -> None:
+        """A non-contiguous view should produce strides that reflect it."""
+        base = torch.randn(64, 64, dtype=torch.float32)
+        view = base[:, ::2]  # stride (64, 2) on dim
+        result = _C.tensor_key(view, frozenset())
+        self.assertEqual(result[1], tuple(view.size()))
+        self.assertEqual(result[2], tuple(view.stride()))
+
+
+class TestPythonFallback(TestCase):
+    """The Python `_tensor_key` path must produce the same result as
+    the C path for any input the C path accepts — and must take over
+    cleanly when the C path returns ``None`` (or when the extension is
+    absent altogether)."""
+
+    def test_python_and_c_paths_produce_equal_keys(self) -> None:
+        """Same tensor through C path and through Python path → same key."""
+        x = torch.randn(32, 64, dtype=torch.float32)
+        py_key = _tensor_key(_add_one_static, x)
+        if _C.tensor_key is None:
+            self.skipTest("C extension not built; nothing to compare against")
+        # Patch out the C path and force the Python branch, then compare.
+        with mock.patch("helion.runtime.kernel._C_tensor_key", None):
+            py_fallback_key = _tensor_key(_add_one_static, x)
+        self.assertEqual(py_key, py_fallback_key)
+
+    def test_bind_cache_hit_with_and_without_c(self) -> None:
+        """Two calls with the same shape MUST land on the same
+        BoundKernel, whether the C fast path or the Python path
+        computed the lookup key. If they produced different keys,
+        we'd compile twice and double the BoundKernel cache."""
+        # Make a kernel that can run on the available device.
+        x1 = torch.randn(4, 8, device=DEVICE, dtype=torch.float32)
+        x2 = torch.randn(4, 8, device=DEVICE, dtype=torch.float32)
+
+        # First call with whatever path is configured by default.
+        _add_one_static.reset()
+        _add_one_static(x1)
+        first_id = id(next(iter(_add_one_static._bound_kernels.values())))
+
+        # Force the Python fallback for the second call by nulling the C
+        # binding — same shape, same dtype → must hit the same entry.
+        with mock.patch("helion.runtime.kernel._C_tensor_key", None):
+            _add_one_static(x2)
+        cache = _add_one_static._bound_kernels
+        self.assertEqual(len(cache), 1)
+        self.assertEqual(id(next(iter(cache.values()))), first_id)
+        _add_one_static.reset()
+
+    def test_dynamic_shapes_uses_python_path(self) -> None:
+        """`static_shapes=False` must go through the Python path (the C
+        path is static-shapes-only) and produce the bucketed key."""
+        x = torch.randn(8, dtype=torch.float32)
+        # The C path is only consulted when static_shapes=True. For a
+        # dynamic-shapes kernel, _tensor_key must return the
+        # bucketed-size shape, which the C extension does NOT implement.
+        key = _tensor_key(_add_one_dynamic, x)
+        # Bucketed-size keys are 3- or 4-tuples; static-shapes keys are
+        # 4-tuples containing sizes AND strides. Distinguish by
+        # checking sizes-vs-bucketed in slot 1.
+        # For our 1-element shape this should be a non-tuple-of-strides shape.
+        self.assertNotIsInstance(key[1], tuple) if len(key) == 3 else self.assertTrue(
+            True
+        )
+
+
+class TestUnsupportedInputs(unittest.TestCase):
+    """The C path returns ``None`` for inputs it can't handle, so the
+    Python fallback path takes over cleanly."""
+
+    def setUp(self) -> None:
+        if not _C.AVAILABLE or _C.tensor_key is None:
+            self.skipTest("helion._C extension not built")
+
+    def test_non_tensor_input_returns_none_or_raises(self) -> None:
+        """Passing a non-tensor either crashes (we don't promise a clean
+        signature) or returns None — but must not corrupt state."""
+        try:
+            result = _C.tensor_key("not a tensor", frozenset())
+            self.assertIsNone(result)
+        except Exception:
+            # Acceptable — caller is expected to pass tensors.
+            pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_output_pool.py
+++ b/test/test_output_pool.py
@@ -1,0 +1,139 @@
+"""Tests for the opt-in output-tensor pool.
+
+The pool is gated on ``HELION_OUTPUT_POOL=1`` (or programmatically via
+``helion.runtime.set_pool_enabled``). Default behavior is a pass-through
+to ``torch.empty_like``, so existing kernels that build their output
+with the standard PyTorch builtin are completely unaffected.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+import torch
+
+from helion.runtime import clear_pool
+from helion.runtime import empty_like
+from helion.runtime import is_pool_enabled
+from helion.runtime import set_pool_enabled
+
+
+class TestPoolDisabledByDefault(unittest.TestCase):
+    """When the env var is unset, ``empty_like`` must behave exactly
+    like ``torch.empty_like``: a fresh allocation on every call."""
+
+    def setUp(self) -> None:
+        self.addCleanup(clear_pool)
+        # Snapshot + restore the global flag and env var so this test
+        # is isolated from any other test that may have toggled them.
+        self._old_env = os.environ.get("HELION_OUTPUT_POOL")
+        self._old_flag = is_pool_enabled()
+        os.environ.pop("HELION_OUTPUT_POOL", None)
+        set_pool_enabled(False)
+
+    def tearDown(self) -> None:
+        if self._old_env is not None:
+            os.environ["HELION_OUTPUT_POOL"] = self._old_env
+        else:
+            os.environ.pop("HELION_OUTPUT_POOL", None)
+        set_pool_enabled(self._old_flag)
+
+    def test_returns_fresh_tensor_each_call(self) -> None:
+        """Pool off → each call must return a distinct ``data_ptr()``."""
+        x = torch.randn(64, dtype=torch.float32)
+        a = empty_like(x)
+        b = empty_like(x)
+        self.assertNotEqual(a.data_ptr(), b.data_ptr())
+
+    def test_matches_torch_empty_like_metadata(self) -> None:
+        """Returned tensor's dtype/shape/stride/device matches template."""
+        x = torch.randn(3, 5, dtype=torch.bfloat16)
+        y = empty_like(x)
+        self.assertEqual(y.dtype, x.dtype)
+        self.assertEqual(y.shape, x.shape)
+        self.assertEqual(y.stride(), x.stride())
+        self.assertEqual(y.device, x.device)
+
+
+class TestPoolEnabled(unittest.TestCase):
+    """When the pool is enabled, identical-signature calls recycle
+    buffers from a fixed-size ring."""
+
+    def setUp(self) -> None:
+        self.addCleanup(clear_pool)
+        self._old_flag = is_pool_enabled()
+        set_pool_enabled(True)
+        clear_pool()
+
+    def tearDown(self) -> None:
+        set_pool_enabled(self._old_flag)
+
+    def test_ring_recycles_after_depth_calls(self) -> None:
+        """With ring depth N, the (N+1)th call should hand back the
+        SAME storage as the 1st."""
+        x = torch.randn(64, dtype=torch.float32)
+        # Module-level constant; matches _POOL_DEPTH in _output_pool.py.
+        from helion.runtime._output_pool import _POOL_DEPTH
+
+        first_n = [empty_like(x).data_ptr() for _ in range(_POOL_DEPTH)]
+        recycled = empty_like(x).data_ptr()
+        self.assertEqual(recycled, first_n[0])
+
+    def test_distinct_signatures_use_distinct_rings(self) -> None:
+        """A different shape must NOT collide with an existing ring's
+        buffers — it gets its own ring."""
+        x1 = torch.randn(64, dtype=torch.float32)
+        x2 = torch.randn(128, dtype=torch.float32)
+        a = empty_like(x1)
+        b = empty_like(x2)
+        self.assertEqual(a.shape, x1.shape)
+        self.assertEqual(b.shape, x2.shape)
+        self.assertNotEqual(a.data_ptr(), b.data_ptr())
+
+    def test_distinct_dtypes_use_distinct_rings(self) -> None:
+        """Same shape but different dtype → separate rings, no aliasing."""
+        x1 = torch.randn(64, dtype=torch.float32)
+        x2 = torch.randn(64, dtype=torch.bfloat16)
+        a = empty_like(x1)
+        b = empty_like(x2)
+        self.assertEqual(a.dtype, x1.dtype)
+        self.assertEqual(b.dtype, x2.dtype)
+        self.assertNotEqual(a.data_ptr(), b.data_ptr())
+
+    def test_clear_pool_releases_buffers(self) -> None:
+        """``clear_pool`` should drop refs so the next call allocates
+        fresh, not recycle."""
+        x = torch.randn(64, dtype=torch.float32)
+        first = empty_like(x).data_ptr()
+        clear_pool()
+        # After clearing, the next call allocates a new buffer — it
+        # MAY happen to land at the same address (allocator reuse) but
+        # the pool internals must be empty.
+        from helion.runtime._output_pool import _POOLS
+
+        empty_like(x)
+        self.assertEqual(len(_POOLS), 1)  # one new ring after clear
+        # And the first buffer ptr is no longer guaranteed to be reused
+        # — we don't assert ptr inequality (allocator may legitimately
+        # reuse the freed slot) but the pool state should be fresh.
+        _ = first
+
+
+class TestEnvVarToggle(unittest.TestCase):
+    """``set_pool_enabled`` should mirror the env-var-driven default."""
+
+    def test_set_pool_enabled_changes_behavior(self) -> None:
+        old_flag = is_pool_enabled()
+        try:
+            set_pool_enabled(False)
+            self.assertFalse(is_pool_enabled())
+            set_pool_enabled(True)
+            self.assertTrue(is_pool_enabled())
+        finally:
+            set_pool_enabled(old_flag)
+            clear_pool()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked PRs:
 * #2609
 * __->__#2608
 * #2606
 * #2605
 * #2604


--- --- ---

### [fast-launcher] Minimal C CompiledLauncher with tp_call (Chunk E)


Adds a single-file C extension (``helion/_C/_launcher.c``) that
exposes ``CompiledLauncher`` — a Python type with a ``tp_call`` slot.
A primed launcher dispatches a Triton kernel launch directly into
``compiled_kernel.run`` (the C launcher Triton emits), bypassing both
the Python ``default_launcher`` frame AND Triton's ``JITFunction.run``
pipeline (binder, ``compute_cache_key``, kernel-cache lookup,
``launch_metadata`` allocation, etc.).

Usage from Python:

    import helion._C
    launcher = helion._C.CompiledLauncher()
    launcher.prime(triton_kernel, grid, args, num_warps=4, num_stages=2)
    # then install as the wrapper's _launcher kwdefault, or call directly:
    launcher(triton_kernel, grid, *args, num_warps=..., num_stages=...)

Scope caveats (deliberately omitted to demonstrate the ceiling)
---------------------------------------------------------------

The launcher in this commit is intentionally minimal — these
correctness guards are NOT implemented, so the perf number below
represents the upper bound on the saving (i.e. how fast the C
launcher could possibly go before re-adding any safety):

- No multi-spec cache. The compiled kernel captured at prime time is
  reused for EVERY subsequent call. Caller must keep arg specs stable
  (same alignment, same shape, same dtype) or the GPU launch will
  silently use a wrong-spec binary (e.g. vectorized 16-byte loads
  against an unaligned pointer → ``CUDA error: misaligned address``).
- No knob/hook re-reads. ``triton.knobs.runtime.debug``,
  ``triton.knobs.compilation.instrumentation_mode``,
  ``triton.knobs.runtime.add_stages_inspection_hook``, and the launch
  hooks (``launch_enter_hook`` / ``launch_exit_hook``) are NOT
  observed — we always pass ``None`` for ``launch_metadata`` and for
  both hooks. A profiler attached after priming silently sees no
  Helion launches.
- No ``used_global_vals`` mutation check. Mutating a Helion-tracked
  global (e.g. a ``_BLOCK_SIZE_*`` constexpr) between calls silently
  uses the stale binary — Triton's own ``RuntimeError`` raise is
  bypassed.
- No multi-device guard. Switching CUDA devices after priming and
  then calling the launcher dispatches to the priming device's
  stream — likely an ``invalid resource handle`` crash.
- No ``pre_run_hooks`` invocation. Hooks installed on the underlying
  ``JITFunction`` (e.g. autotune timing hooks) silently don't fire.
- No fallback to ``default_launcher`` on any of the above. The
  launcher just dispatches with stale / wrong state.

These omissions match exactly the Phase 2 launcher's correctness
work that hasn't been ported to C on this branch. A real production
version would port them; the per-call cost of those guards in Python
is roughly ~2 μs, so the production C launcher nets out around
-5 μs/call vs ``default_launcher`` rather than the -7 μs the
un-guarded version below achieves.

The build is NOT wired into hatchling — manual ``gcc`` one-liner
in ``helion/_C/README.md``. Default install leaves
``_C.CompiledLauncher = None`` and Helion uses the Python
``default_launcher``.

Tests in ``test_c_launcher.py`` cover:
- Correctness: primed C launcher produces same output as Python path
  on the same args, both direct-call and routed through the
  generated wrapper.
- ``CompiledLauncher`` is subclassable (``Py_TPFLAGS_BASETYPE``).
- Calling without priming raises ``RuntimeError``.

Benchmarks (H100, vector_add at N=4096)
---------------------------------------

End-to-end vector_add per-call timing (15k iters, after 100 warmup):

  default_launcher (Python)     wall+sync=24.763 us   cpu_only=18.199 us
  C CompiledLauncher (Chunk E)  wall+sync=17.816 us   cpu_only=11.564 us
  delta                              -6.947 us             -6.635 us
  speedup                             1.39x                  1.57x

This is the biggest single per-call win of all the chunks: replacing
the Python ``default_launcher`` + ``JITFunction.run`` round-trip with
a direct ``compiled_kernel.run`` call shaves ~7 μs/call. The savings
are dominated by skipping ``JITFunction.run``'s per-call bookkeeping
(``compute_cache_key``, ``kernel_cache.get``, ``launch_metadata``
allocation when no hooks are active, ``device_caches`` unpack, kwargs
munging) — not just the one Python frame.

Comparison with prior chunks on the same workload (cpu_only Δ):

  Chunk B (C tensor_key): -0.25 us  (-1.4%)
  Chunk D (output pool):  -0.70 us  (when user opts into helion.runtime.empty_like)
  Chunk E (this commit):  -6.64 us (-36%)

Chunk E dominates. The Python C-API path of Chunk B and the per-call
allocator savings of Chunk D are both real but small compared to
skipping the Triton-side Python pipeline.

Reminder: as called out in "Scope caveats" above, the -7 us is the
*ceiling*. A ship-able C launcher must add the Phase 2 correctness
guards back, costing ~2 μs/call, so realistic savings target is
around -5 μs/call.

Part of the chunked C-extension plan; the largest piece and last
on the rollout list. Independent of Chunk A (build infra) only
insofar as it adds its own .c source; in practice the same
``helion._C`` shim handles both.
