### PR TITLE
[Pallas] Fix atomic add semantics (when targeting an output ref)

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1870,6 +1870,24 @@ class PallasBackend(Backend):
             if has_rng_ops:
                 block_spec_info.append(None)  # RNG seed buffer is untiled
             launcher_args.append(f"_block_spec_info={block_spec_info!r}")
+            atomic_infos: list[dict[str, object]] = []
+            if sorted_args is not None:
+                for i, arg in enumerate(sorted_args):
+                    if not isinstance(arg, TensorArg):
+                        continue
+                    target_id = id(arg.fake_value)
+                    ops = device_fn.pallas_atomic_target_ops.get(target_id)
+                    if ops:
+                        atomic_infos.append(
+                            {
+                                "target_arg_pos": i,
+                                "ops": tuple(sorted(ops)),
+                                "return_used": target_id
+                                in device_fn.pallas_atomic_return_used_target_ids,
+                            }
+                        )
+            if atomic_infos:
+                launcher_args.append(f"_pallas_atomic_infos={atomic_infos!r}")
 
         pad_info = self._compute_pad_info(sorted_args, config)
         if pad_info:

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -312,6 +312,11 @@ class DeviceFunction:
         self._atomic_indexing_config = config.atomic_indexing
         self.atomic_indexing_strategies: list[IndexingStrategy] = []
         self.atomic_op_index = 0
+        # Pallas atomics are lowered as ordered read-modify-write sequences.
+        # Codegen records their target tensors so the runtime launcher can
+        # identify grid dimensions that contribute to the same output tile.
+        self.pallas_atomic_target_ops: dict[int, set[str]] = {}
+        self.pallas_atomic_return_used_target_ids: set[int] = set()
 
         self.rng_seed_count = 0
         self.device_load_index = 0

--- a/helion/language/atomic_ops.py
+++ b/helion/language/atomic_ops.py
@@ -744,6 +744,7 @@ def _codegen_tensor_index_loop_common_cute(
 
 def _pallas_atomic_load_prev(
     state: CodegenState,
+    op: str,
 ) -> tuple[str, str, str]:
     """Load previous value for a Pallas atomic op.
 
@@ -763,6 +764,13 @@ def _pallas_atomic_load_prev(
     host_function = HostFunction.current()
     if target not in host_function.tensor_to_origin:
         raise exc.AtomicOnDeviceTensor("pallas atomic")
+
+    # Runtime uses this metadata to detect shared output tiles that need
+    # ordered contributor execution.
+    target_id = id(target)
+    state.device_function.pallas_atomic_target_ops.setdefault(target_id, set()).add(op)
+    if state.fx_node is not None and len(state.fx_node.users) > 0:
+        state.device_function.pallas_atomic_return_used_target_ids.add(target_id)
 
     name = state.device_function.tensor_arg(target).name
     index_str, _ = pallas_codegen.index_str(state, index, target)
@@ -1008,7 +1016,7 @@ def _(state: CodegenState) -> ast.AST:
     from .._compiler.ast_extension import statement_from_string
     from .._compiler.compile_environment import CompileEnvironment
 
-    name, index_str, prev_var = _pallas_atomic_load_prev(state)
+    name, index_str, prev_var = _pallas_atomic_load_prev(state, "atomic_add")
     value_ast = _to_ast_values([state.ast_args[2]])[0]
     target = state.proxy_arg(0)
     assert isinstance(target, torch.Tensor)
@@ -1100,7 +1108,7 @@ def _(state: CodegenState) -> ast.AST:
 def _(state: CodegenState) -> ast.AST:
     from .._compiler.ast_extension import statement_from_string
 
-    name, index_str, prev_var = _pallas_atomic_load_prev(state)
+    name, index_str, prev_var = _pallas_atomic_load_prev(state, "atomic_xchg")
     value_ast = _to_ast_values([state.ast_args[2]])[0]
     state.codegen.add_statement(
         statement_from_string(f"{name}[{index_str}] = {{value}}", value=value_ast)
@@ -1182,7 +1190,7 @@ def _(state: CodegenState) -> ast.AST:
 def _(state: CodegenState) -> ast.AST:
     from .._compiler.ast_extension import statement_from_string
 
-    name, index_str, prev_var = _pallas_atomic_load_prev(state)
+    name, index_str, prev_var = _pallas_atomic_load_prev(state, "atomic_and")
     value_ast = _to_ast_values([state.ast_args[2]])[0]
     state.codegen.add_statement(
         statement_from_string(
@@ -1263,7 +1271,7 @@ def _(state: CodegenState) -> ast.AST:
 def _(state: CodegenState) -> ast.AST:
     from .._compiler.ast_extension import statement_from_string
 
-    name, index_str, prev_var = _pallas_atomic_load_prev(state)
+    name, index_str, prev_var = _pallas_atomic_load_prev(state, "atomic_or")
     value_ast = _to_ast_values([state.ast_args[2]])[0]
     state.codegen.add_statement(
         statement_from_string(
@@ -1344,7 +1352,7 @@ def _(state: CodegenState) -> ast.AST:
 def _(state: CodegenState) -> ast.AST:
     from .._compiler.ast_extension import statement_from_string
 
-    name, index_str, prev_var = _pallas_atomic_load_prev(state)
+    name, index_str, prev_var = _pallas_atomic_load_prev(state, "atomic_xor")
     value_ast = _to_ast_values([state.ast_args[2]])[0]
     state.codegen.add_statement(
         statement_from_string(
@@ -1429,7 +1437,7 @@ def _(state: CodegenState) -> ast.AST:
 def _(state: CodegenState) -> ast.AST:
     from .._compiler.ast_extension import statement_from_string
 
-    name, index_str, prev_var = _pallas_atomic_load_prev(state)
+    name, index_str, prev_var = _pallas_atomic_load_prev(state, "atomic_max")
     value_ast = _to_ast_values([state.ast_args[2]])[0]
     state.codegen.add_statement(
         statement_from_string(
@@ -1512,7 +1520,7 @@ def _(state: CodegenState) -> ast.AST:
 def _(state: CodegenState) -> ast.AST:
     from .._compiler.ast_extension import statement_from_string
 
-    name, index_str, prev_var = _pallas_atomic_load_prev(state)
+    name, index_str, prev_var = _pallas_atomic_load_prev(state, "atomic_min")
     value_ast = _to_ast_values([state.ast_args[2]])[0]
     state.codegen.add_statement(
         statement_from_string(
@@ -1690,6 +1698,14 @@ def _(state: CodegenState) -> ast.AST:
     host_function = HostFunction.current()
     if target not in host_function.tensor_to_origin:
         raise exc.AtomicOnDeviceTensor("pallas atomic_cas")
+
+    # CAS does not use _pallas_atomic_load_prev, so record its metadata here.
+    target_id = id(target)
+    state.device_function.pallas_atomic_target_ops.setdefault(target_id, set()).add(
+        "atomic_cas"
+    )
+    if state.fx_node is not None and len(state.fx_node.users) > 0:
+        state.device_function.pallas_atomic_return_used_target_ids.add(target_id)
 
     name = state.device_function.tensor_arg(target).name
     index_str, _ = pallas_codegen.index_str(state, index, target)

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -9,6 +9,7 @@ import os
 import sys
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import TypedDict
 from typing import cast
 
 import torch
@@ -383,6 +384,119 @@ _BlockSpecInfo = list[
 ]
 
 
+class _PallasAtomicInfo(TypedDict):
+    target_arg_pos: int
+    ops: tuple[str, ...]
+    return_used: bool
+
+
+_PallasAtomicInfos = list[_PallasAtomicInfo]
+
+
+def _pallas_tensor_pos_map(
+    tensor_arg_indices: list[int],
+    output_only_indices: list[int] | None,
+) -> dict[int, int]:
+    all_positions = sorted(set(tensor_arg_indices) | set(output_only_indices or []))
+    return {orig: tpos for tpos, orig in enumerate(all_positions)}
+
+
+def _pallas_grid_dims_used_by_block_spec(
+    block_info: tuple[
+        tuple[int | None, ...], tuple[int | tuple[int, int, int] | None, ...]
+    ],
+) -> set[int]:
+    used: set[int] = set()
+    _, grid_dims = block_info
+    for grid_dim in grid_dims:
+        if isinstance(grid_dim, int):
+            used.add(grid_dim)
+        elif isinstance(grid_dim, tuple):
+            used.add(grid_dim[0])
+    return used
+
+
+def _pallas_atomic_contributor_plan(
+    grid: tuple[int, ...],
+    tensor_arg_indices: list[int],
+    output_only_indices: list[int],
+    output_indices: list[int],
+    inplace_indices: list[int] | None,
+    block_spec_info: _BlockSpecInfo | None,
+    atomic_infos: _PallasAtomicInfos | None,
+) -> tuple[dict[int, tuple[int, ...]], tuple[str, ...]]:
+    """Plan ordered shared-tile atomic RMW for Pallas outputs.
+
+    For a structural atomic such as split-K, the target BlockSpec maps only
+    output-tile dimensions while one or more grid dimensions contribute to the
+    same tile. Those contributor dimensions must run sequentially, and the
+    output preload must happen only for the first contributor.
+    """
+    dim_semantics = ["parallel"] * len(grid)
+    guarded_copies: dict[int, tuple[int, ...]] = {}
+    if not atomic_infos:
+        return guarded_copies, tuple(dim_semantics)
+    if block_spec_info is None:
+        raise RuntimeError(
+            "Pallas atomic lowering requires block-spec metadata for atomic targets"
+        )
+
+    output_set = set(output_indices)
+    inplace_set = set(inplace_indices or [])
+    arg_to_tpos = _pallas_tensor_pos_map(tensor_arg_indices, output_only_indices)
+    reduction_ops = {
+        "atomic_add",
+        "atomic_max",
+        "atomic_min",
+    }
+    for info in atomic_infos:
+        orig_pos = info["target_arg_pos"]
+        ops = info["ops"]
+        return_used = info["return_used"]
+        if orig_pos not in output_set:
+            raise RuntimeError(
+                "Pallas atomic target is not an output tensor; cannot lower atomic RMW safely"
+            )
+        tensor_pos = arg_to_tpos.get(orig_pos)
+        if tensor_pos is None or tensor_pos >= len(block_spec_info):
+            raise RuntimeError(
+                "Pallas atomic lowering requires block-spec metadata for the target tensor"
+            )
+        block_info = block_spec_info[tensor_pos]
+        if block_info is None:
+            raise RuntimeError(
+                "Pallas atomic lowering requires block-spec metadata for the target tensor"
+            )
+        used_dims = _pallas_grid_dims_used_by_block_spec(block_info)
+        # In split-K, the output tile uses the M/N grid dims; K is a contributor.
+        contributor_dims = tuple(
+            dim for dim, size in enumerate(grid) if size > 1 and dim not in used_dims
+        )
+        if not contributor_dims:
+            continue
+        if orig_pos not in inplace_set:
+            # TODO(tcombes): route this through launcher-owned VMEM scratch once
+            # shared atomic accumulator substitution is implemented.
+            raise RuntimeError(
+                "Pallas shared-tile atomics without an aliased input/output "
+                "target are not supported by this lowering"
+            )
+        unsupported = tuple(op for op in ops if op not in reduction_ops)
+        if unsupported:
+            raise RuntimeError(
+                "Pallas shared-tile atomics only support reduction-style ops "
+                f"for now; got {unsupported}"
+            )
+        if return_used:
+            raise RuntimeError(
+                "Pallas shared-tile atomics with used return values are not supported yet"
+            )
+        guarded_copies[orig_pos] = contributor_dims
+        for dim in contributor_dims:
+            dim_semantics[dim] = "arbitrary"
+    return guarded_copies, tuple(dim_semantics)
+
+
 def _pallas_build_block_specs(
     pl: object,
     jnp: object,
@@ -606,6 +720,7 @@ def _pallas_make_reordered_kernel(
     n_extra_refs: int = 0,
     skip_inplace_copy: set[int] | None = None,
     _smem_arg_indices: list[int] | None = None,
+    atomic_copy_guards: dict[int, tuple[int, ...]] | None = None,
 ) -> object:
     """Create a wrapper kernel that reorders pallas_call refs to the original arg order.
 
@@ -620,6 +735,9 @@ def _pallas_make_reordered_kernel(
     where direct load/store is not allowed.
     """
     _skip_copy = skip_inplace_copy or set()
+    _atomic_copy_guards = atomic_copy_guards or {}
+    if _atomic_copy_guards:
+        from jax.experimental import pallas as pl
 
     def reordered_kernel(*refs: object) -> None:
         n_kernel_params = len(args)
@@ -636,6 +754,25 @@ def _pallas_make_reordered_kernel(
                     # [...] cannot be used for SMEMs,
                     # TODO(dunfanlu): handle in-place copy for SMEM refs
                     pass
+                elif orig_pos in _atomic_copy_guards:
+                    # Only the first contributor initializes the accumulator;
+                    # later contributors must preserve earlier RMW updates.
+                    condition = None
+                    for dim in _atomic_copy_guards[orig_pos]:
+                        dim_is_first = pl.program_id(dim) == 0
+                        condition = (
+                            dim_is_first
+                            if condition is None
+                            else condition & dim_is_first
+                        )
+                    assert condition is not None
+
+                    @pl.when(condition)
+                    def _copy_atomic_initial_value(
+                        out_ref: object = out_ref, in_ref: object = in_ref
+                    ) -> None:
+                        out_ref[...] = in_ref[...]  # type: ignore[index]
+
                 else:
                     out_ref[...] = in_ref[...]  # type: ignore[index]
             original_order[orig_pos] = out_ref
@@ -897,6 +1034,7 @@ def default_pallas_launcher(
     _output_indices: list[int] | None = None,
     _inplace_indices: list[int] | None = None,
     _block_spec_info: _BlockSpecInfo | None = None,
+    _pallas_atomic_infos: _PallasAtomicInfos | None = None,
     _smem_arg_indices: list[int] | None = None,
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _pallas_interpret: bool | None = None,
@@ -966,6 +1104,15 @@ def default_pallas_launcher(
             _smem_arg_indices,
             output_only_indices,
         )
+        atomic_copy_guards, dimension_semantics = _pallas_atomic_contributor_plan(
+            grid,
+            tensor_arg_indices,
+            output_only_indices,
+            _output_indices,
+            _inplace_indices,
+            _block_spec_info,
+            _pallas_atomic_infos,
+        )
 
         reordered_kernel = _pallas_make_reordered_kernel(
             pallas_kernel,
@@ -977,6 +1124,7 @@ def default_pallas_launcher(
             inplace_positions,
             arg_to_tensor_pos,
             _smem_arg_indices=_smem_arg_indices,
+            atomic_copy_guards=atomic_copy_guards,
         )
 
         out_shape_arg = out_shapes if len(out_shapes) > 1 else out_shapes[0]
@@ -1003,6 +1151,10 @@ def default_pallas_launcher(
             "out_shape": out_shape_arg,
             "grid": grid,
         }
+        if any(dim != "parallel" for dim in dimension_semantics):
+            pallas_call_kwargs["compiler_params"] = pltpu.CompilerParams(  # pyrefly: ignore[bad-instantiation]
+                dimension_semantics=cast("Any", dimension_semantics),
+            )
         if interpret:
             pallas_call_kwargs["interpret"] = True
         if in_specs is not None:
@@ -1044,6 +1196,7 @@ def default_pallas_pipeline_launcher(
     _output_indices: list[int] | None = None,
     _inplace_indices: list[int] | None = None,
     _block_spec_info: _BlockSpecInfo | None = None,
+    _pallas_atomic_infos: _PallasAtomicInfos | None = None,
     _scratch_shapes: list[tuple[tuple[int, ...], str]] | None = None,
     _pipeline_arg_indices: list[int] | None = None,
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
@@ -1132,6 +1285,15 @@ def default_pallas_pipeline_launcher(
             output_only_indices,
             smem_arg_indices=_smem_arg_indices,
         )
+        atomic_copy_guards, dimension_semantics = _pallas_atomic_contributor_plan(
+            grid,
+            tensor_arg_indices,
+            output_only_indices,
+            _output_indices,
+            _inplace_indices,
+            _block_spec_info,
+            _pallas_atomic_infos,
+        )
 
         _pipeline_set = set(_pipeline_arg_indices or [])
         reordered_kernel = _pallas_make_reordered_kernel(
@@ -1146,6 +1308,7 @@ def default_pallas_pipeline_launcher(
             n_extra_refs=len(scratch_shapes),
             skip_inplace_copy=_pipeline_set,
             _smem_arg_indices=_smem_arg_indices,
+            atomic_copy_guards=atomic_copy_guards,
         )
 
         out_shape_arg = out_shapes if len(out_shapes) > 1 else out_shapes[0]
@@ -1180,7 +1343,7 @@ def default_pallas_pipeline_launcher(
             "out_shape": out_shape_arg,
             "grid_spec": grid_spec,
             "compiler_params": pltpu.CompilerParams(  # pyrefly: ignore[bad-instantiation]
-                dimension_semantics=tuple("parallel" for _ in grid),
+                dimension_semantics=cast("Any", dimension_semantics),
             ),
         }
         if interpret:
@@ -1222,6 +1385,7 @@ def default_pallas_fori_launcher(
     _output_indices: list[int] | None = None,
     _inplace_indices: list[int] | None = None,
     _block_spec_info: _BlockSpecInfo | None = None,
+    _pallas_atomic_infos: _PallasAtomicInfos | None = None,
     _scratch_shapes: list[tuple[tuple[int, ...], str | None, str]] | None = None,
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _smem_arg_indices: list[int] | None = None,
@@ -1310,6 +1474,15 @@ def default_pallas_fori_launcher(
             output_only_indices,
             smem_arg_indices=_smem_arg_indices,
         )
+        atomic_copy_guards, dimension_semantics = _pallas_atomic_contributor_plan(
+            grid,
+            tensor_arg_indices,
+            output_only_indices,
+            _output_indices,
+            _inplace_indices,
+            _block_spec_info,
+            _pallas_atomic_infos,
+        )
 
         _fori_pipeline_set = set(_fori_pipeline_indices or [])  # type: ignore[arg-type]
         reordered_kernel = _pallas_make_reordered_kernel(
@@ -1324,6 +1497,7 @@ def default_pallas_fori_launcher(
             n_extra_refs=len(scratch_shapes),
             skip_inplace_copy=_fori_pipeline_set,
             _smem_arg_indices=_smem_arg_indices,
+            atomic_copy_guards=atomic_copy_guards,
         )
 
         out_shape_arg = out_shapes if len(out_shapes) > 1 else out_shapes[0]
@@ -1358,7 +1532,7 @@ def default_pallas_fori_launcher(
             "out_shape": out_shape_arg,
             "grid_spec": grid_spec,
             "compiler_params": pltpu.CompilerParams(  # pyrefly: ignore[bad-instantiation]
-                dimension_semantics=tuple("parallel" for _ in grid),
+                dimension_semantics=cast("Any", dimension_semantics),
             ),
         }
         if interpret:

--- a/test/test_atomic_ops.py
+++ b/test/test_atomic_ops.py
@@ -17,6 +17,7 @@ from helion._testing import skipIfTileIR
 from helion._testing import skipUnlessTensorDescriptor
 from helion._testing import xfailIfPallas
 import helion.language as hl
+from helion.runtime import _pallas_atomic_contributor_plan
 from helion.runtime.settings import _get_backend
 
 
@@ -157,6 +158,109 @@ def atomic_add_tensor_index_kernel(
     return out
 
 
+@helion.kernel(static_shapes=True)
+def pallas_structural_atomic_add_kernel(x: torch.Tensor) -> torch.Tensor:
+    """Structurally shared output tile: contributor dim is leading K."""
+    k, m, n = x.shape
+    out = torch.ones([m, n], dtype=x.dtype, device=x.device)
+    for tile_k, tile_m, tile_n in hl.tile([k, m, n]):
+        value = torch.sum(x[tile_k, tile_m, tile_n], dim=0)
+        hl.atomic_add(out, [tile_m, tile_n], value)
+    return out
+
+
+@helion.kernel(static_shapes=True)
+def pallas_structural_atomic_add_2_contributor_kernel(
+    x: torch.Tensor,
+) -> torch.Tensor:
+    """Two contributor dims both update the same output tile."""
+    r, k, m, n = x.shape
+    out = torch.ones([m, n], dtype=x.dtype, device=x.device)
+    for tile_r, tile_k, tile_m, tile_n in hl.tile([r, k, m, n]):
+        value = torch.sum(torch.sum(x[tile_r, tile_k, tile_m, tile_n], dim=0), dim=0)
+        hl.atomic_add(out, [tile_m, tile_n], value)
+    return out
+
+
+@helion.kernel(static_shapes=True)
+def pallas_structural_atomic_add_two_outputs_kernel(
+    x: torch.Tensor, y: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    k, m, n = x.shape
+    out_x = torch.ones([m, n], dtype=x.dtype, device=x.device)
+    out_y = torch.full([m, n], 2.0, dtype=y.dtype, device=y.device)
+    for tile_k, tile_m, tile_n in hl.tile([k, m, n]):
+        x_value = torch.sum(x[tile_k, tile_m, tile_n], dim=0)
+        y_value = torch.sum(y[tile_k, tile_m, tile_n], dim=0)
+        hl.atomic_add(out_x, [tile_m, tile_n], x_value)
+        hl.atomic_add(out_y, [tile_m, tile_n], y_value)
+    return out_x, out_y
+
+
+@helion.kernel(static_shapes=True)
+def pallas_structural_atomic_add_used_return_kernel(
+    x: torch.Tensor,
+) -> torch.Tensor:
+    k, m, n = x.shape
+    out = torch.ones([m, n], dtype=x.dtype, device=x.device)
+    prev = torch.empty([m, n], dtype=x.dtype, device=x.device)
+    for tile_k, tile_m, tile_n in hl.tile([k, m, n]):
+        value = torch.sum(x[tile_k, tile_m, tile_n], dim=0)
+        old = hl.atomic_add(out, [tile_m, tile_n], value)
+        prev[tile_m, tile_n] = old
+    return prev
+
+
+@helion.kernel(static_shapes=True)
+def pallas_structural_atomic_xchg_kernel(x: torch.Tensor) -> torch.Tensor:
+    k, m, n = x.shape
+    out = torch.zeros([m, n], dtype=x.dtype, device=x.device)
+    for tile_k, tile_m, tile_n in hl.tile([k, m, n]):
+        value = torch.sum(x[tile_k, tile_m, tile_n], dim=0)
+        hl.atomic_xchg(out, [tile_m, tile_n], value)
+    return out
+
+
+@helion.kernel(static_shapes=True)
+def pallas_structural_atomic_cas_kernel(x: torch.Tensor) -> torch.Tensor:
+    k, m, n = x.shape
+    out = torch.zeros([m, n], dtype=x.dtype, device=x.device)
+    for tile_k, tile_m, tile_n in hl.tile([k, m, n]):
+        value = torch.sum(x[tile_k, tile_m, tile_n], dim=0)
+        hl.atomic_cas(out, [tile_m, tile_n], 0.0, value)
+    return out
+
+
+@helion.kernel(static_shapes=True)
+def pallas_structural_atomic_or_kernel(x: torch.Tensor) -> torch.Tensor:
+    k, m, n = x.shape
+    out = torch.zeros([m, n], dtype=x.dtype, device=x.device)
+    for tile_k, tile_m, tile_n in hl.tile([k, m, n]):
+        value = torch.sum(x[tile_k, tile_m, tile_n], dim=0)
+        hl.atomic_or(out, [tile_m, tile_n], value)
+    return out
+
+
+@helion.kernel(static_shapes=True)
+def pallas_structural_atomic_max_kernel(x: torch.Tensor) -> torch.Tensor:
+    k, m, n = x.shape
+    out = torch.full([m, n], -1000.0, dtype=x.dtype, device=x.device)
+    for tile_k, tile_m, tile_n in hl.tile([k, m, n]):
+        value = torch.amax(x[tile_k, tile_m, tile_n], dim=0)
+        hl.atomic_max(out, [tile_m, tile_n], value)
+    return out
+
+
+@helion.kernel(static_shapes=True)
+def pallas_structural_atomic_min_kernel(x: torch.Tensor) -> torch.Tensor:
+    k, m, n = x.shape
+    out = torch.full([m, n], 1000.0, dtype=x.dtype, device=x.device)
+    for tile_k, tile_m, tile_n in hl.tile([k, m, n]):
+        value = torch.amin(x[tile_k, tile_m, tile_n], dim=0)
+        hl.atomic_min(out, [tile_m, tile_n], value)
+    return out
+
+
 # New kernels for other atomics
 
 
@@ -274,6 +378,78 @@ def atomic_xchg_2d_td_kernel(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
 @onlyBackends(["triton", "cute", "pallas"])
 class TestAtomicOperations(RefEagerTestBase, TestCase):
+    @onlyBackends(["pallas"])
+    def test_pallas_output_ref_accumulator_contract(self):
+        import jax
+        from jax.experimental import pallas as pl
+        from jax.experimental.pallas import tpu as pltpu
+        import jax.numpy as jnp
+
+        def kernel(x_ref, out_ref):
+            k_pid = pl.program_id(0)
+
+            @pl.when(k_pid == 0)
+            def _init():
+                out_ref[...] = x_ref[...]
+
+            out_ref[...] = out_ref[...] + (k_pid + 1).astype(jnp.float32)
+
+        call = pl.pallas_call(
+            kernel,
+            out_shape=jax.ShapeDtypeStruct((8, 128), jnp.float32),
+            grid=(4,),
+            in_specs=[pl.BlockSpec((8, 128), lambda k: (0, 0))],
+            out_specs=pl.BlockSpec((8, 128), lambda k: (0, 0)),
+            input_output_aliases={0: 0},
+            compiler_params=pltpu.CompilerParams(dimension_semantics=("arbitrary",)),
+        )
+        x = jnp.ones((8, 128), dtype=jnp.float32)
+        result = jax.jit(call)(x).block_until_ready()
+        expected = x + sum(range(1, 5))
+        torch.testing.assert_close(
+            torch.from_numpy(jax.device_get(result).copy()),
+            torch.from_numpy(jax.device_get(expected).copy()),
+        )
+
+    @onlyBackends(["pallas"])
+    def test_pallas_atomic_contributor_plan_marks_arbitrary_dims(self):
+        copy_guards, dim_semantics = _pallas_atomic_contributor_plan(
+            (3, 4, 2, 1),
+            [0, 1],
+            [],
+            [1],
+            [1],
+            [
+                ((1, 1, 8, 128), (0, 1, 2, None)),
+                ((8, 128), (2, None)),
+            ],
+            [{"target_arg_pos": 1, "ops": ("atomic_add",), "return_used": False}],
+        )
+
+        self.assertEqual(copy_guards, {1: (0, 1)})
+        self.assertEqual(
+            dim_semantics, ("arbitrary", "arbitrary", "parallel", "parallel")
+        )
+
+    @onlyBackends(["pallas"])
+    def test_pallas_atomic_contributor_plan_rejects_non_aliased_output(self):
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "without an aliased input/output target are not supported",
+        ):
+            _pallas_atomic_contributor_plan(
+                (3, 4, 2, 1),
+                [0],
+                [1],
+                [1],
+                [],
+                [
+                    ((1, 1, 8, 128), (0, 1, 2, None)),
+                    ((8, 128), (2, None)),
+                ],
+                [{"target_arg_pos": 1, "ops": ("atomic_add",), "return_used": False}],
+            )
+
     def test_basic_atomic_add(self):
         x = torch.zeros(10, device=DEVICE)
         y = torch.ones(10, device=DEVICE)
@@ -454,6 +630,129 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
             torch.bfloat16
         )
         torch.testing.assert_close(result, expected, atol=0.1, rtol=0.05)
+
+    @onlyBackends(["pallas"])
+    def test_pallas_structural_atomic_add_shared_tile(self):
+        x = torch.randn(4, 16, 128, device=DEVICE, dtype=torch.float32)
+
+        for loop_type in ("unroll", "fori_loop", "emit_pipeline"):
+            with self.subTest(loop_type=loop_type):
+                code, result = code_and_output(
+                    pallas_structural_atomic_add_kernel,
+                    (x,),
+                    block_sizes=[1, 8, 128],
+                    pallas_loop_type=loop_type,
+                )
+                expected = torch.ones(16, 128, device=DEVICE) + x.sum(dim=0)
+                torch.testing.assert_close(result, expected)
+                self.assertIn("_pallas_atomic_infos=", code)
+
+    @onlyBackends(["pallas"])
+    def test_pallas_structural_atomic_add_two_contributor_dims(self):
+        x = torch.randn(3, 4, 16, 128, device=DEVICE, dtype=torch.float32)
+
+        code, result = code_and_output(
+            pallas_structural_atomic_add_2_contributor_kernel,
+            (x,),
+            block_sizes=[1, 1, 8, 128],
+            pallas_loop_type="fori_loop",
+        )
+
+        expected = torch.ones(16, 128, device=DEVICE) + x.sum(dim=(0, 1))
+        torch.testing.assert_close(result, expected)
+        self.assertIn("_pallas_atomic_infos=", code)
+
+    @onlyBackends(["pallas"])
+    def test_pallas_structural_atomic_add_multiple_outputs(self):
+        x = torch.randn(4, 16, 128, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(4, 16, 128, device=DEVICE, dtype=torch.float32)
+
+        code, (out_x, out_y) = code_and_output(
+            pallas_structural_atomic_add_two_outputs_kernel,
+            (x, y),
+            block_sizes=[1, 8, 128],
+            pallas_loop_type="emit_pipeline",
+        )
+
+        torch.testing.assert_close(
+            out_x, torch.ones(16, 128, device=DEVICE) + x.sum(dim=0)
+        )
+        torch.testing.assert_close(
+            out_y, torch.full([16, 128], 2.0, device=DEVICE) + y.sum(dim=0)
+        )
+        self.assertIn("_pallas_atomic_infos=", code)
+
+    @onlyBackends(["pallas"])
+    def test_pallas_structural_atomic_max_min_shared_tile(self):
+        x = torch.randn(4, 16, 128, device=DEVICE, dtype=torch.float32)
+
+        code_max, result_max = code_and_output(
+            pallas_structural_atomic_max_kernel,
+            (x,),
+            block_sizes=[1, 8, 128],
+        )
+        expected_max = torch.maximum(
+            torch.full([16, 128], -1000.0, device=DEVICE), x.amax(dim=0)
+        )
+        torch.testing.assert_close(result_max, expected_max)
+        self.assertIn("_pallas_atomic_infos=", code_max)
+
+        code_min, result_min = code_and_output(
+            pallas_structural_atomic_min_kernel,
+            (x,),
+            block_sizes=[1, 8, 128],
+        )
+        expected_min = torch.minimum(
+            torch.full([16, 128], 1000.0, device=DEVICE), x.amin(dim=0)
+        )
+        torch.testing.assert_close(result_min, expected_min)
+        self.assertIn("_pallas_atomic_infos=", code_min)
+
+    @onlyBackends(["pallas"])
+    def test_pallas_structural_atomic_add_used_return_rejected(self):
+        x = torch.randn(4, 16, 128, device=DEVICE, dtype=torch.float32)
+
+        with self.assertRaisesRegex(
+            RuntimeError, "used return values are not supported"
+        ):
+            code_and_output(
+                pallas_structural_atomic_add_used_return_kernel,
+                (x,),
+                block_sizes=[1, 8, 128],
+            )
+
+    @onlyBackends(["pallas"])
+    def test_pallas_structural_atomic_xchg_rejected(self):
+        x = torch.randn(4, 16, 128, device=DEVICE, dtype=torch.float32)
+
+        with self.assertRaisesRegex(RuntimeError, "only support reduction-style ops"):
+            code_and_output(
+                pallas_structural_atomic_xchg_kernel,
+                (x,),
+                block_sizes=[1, 8, 128],
+            )
+
+    @onlyBackends(["pallas"])
+    def test_pallas_structural_atomic_cas_rejected(self):
+        x = torch.randn(4, 16, 128, device=DEVICE, dtype=torch.float32)
+
+        with self.assertRaisesRegex(RuntimeError, "only support reduction-style ops"):
+            code_and_output(
+                pallas_structural_atomic_cas_kernel,
+                (x,),
+                block_sizes=[1, 8, 128],
+            )
+
+    @onlyBackends(["pallas"])
+    def test_pallas_structural_bitwise_atomic_rejected(self):
+        x = torch.randint(0, 16, (4, 16, 128), device=DEVICE, dtype=torch.int32)
+
+        with self.assertRaisesRegex(RuntimeError, "only support reduction-style ops"):
+            code_and_output(
+                pallas_structural_atomic_or_kernel,
+                (x,),
+                block_sizes=[1, 8, 128],
+            )
 
     def test_atomic_add_code_generation(self):
         """Test that the generated code contains atomic_add."""

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1053,7 +1053,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             skip_accuracy=True,  # TODO(yf225): fix unstable numerics
         )
 
-    @xfailIfPallas("InductorLoweringError")
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
     def test_matmul_split_k(self):
         args = (


### PR DESCRIPTION
## Pallas atomic add

### Example Helion Kernel

Split-K matmul is the motivating case:

```python
@helion.kernel(static_shapes=True)
def matmul_split_k(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
    m, k = x.shape
    _, n = y.shape
    out = torch.zeros([m, n], dtype=torch.promote_types(x.dtype, y.dtype), device=x.device)

    split_k = hl.register_tunable("split_k", PowerOfTwoFragment(1, 256))
    k_block = helion.next_power_of_2(helion.cdiv(k, split_k))

    for tm, tn, tk in hl.tile([m, n, k], block_size=[None, None, k_block]):
        acc = hl.zeros([tm, tn], dtype=torch.float32)
        for inner_k in hl.tile(tk.begin, tk.end):
            acc = torch.addmm(acc, x[tm, inner_k], y[inner_k, tn])
        hl.atomic_add(out, [tm, tn], acc)

    return out
```

### Current Lowering and Problem

Pallas atomic lowering currently emits ordinary read-modify-write code:

```python
prev = out[index]
out[index] = prev + value
```

That is fine when the program owns the output tile exclusively. Split-K is
different: multiple `k_split` programs update the same `out[tm, tn]` tile.

The wrapper also copies aliased input/output tensors before running the body:

```python
out_ref[...] = in_ref[...]
original_body(..., out_ref, ...)
```

For split-K, that means each contributor can refresh the output ref from the
original HBM value before doing its local RMW:

```python
# program k=0
out_ref[...] = in_ref[...]
out_ref[...] = out_ref[...] + partial_0

# program k=1
out_ref[...] = in_ref[...]      # wipes partial_0
out_ref[...] = out_ref[...] + partial_1
```

Marking `k_split` as sequential is necessary, but not sufficient. Ordered
contributors still lose updates if every contributor refreshes the output ref.

### Fix Sketch

For shared-tile reduction atomics where the target is an aliased output, use the
Pallas output ref as the accumulator.

Two changes are needed:

1. Mark contributor dimensions `arbitrary`.
2. Copy the aliased input into the output ref only for the first contributor.

Sketch:

```python
def wrapped_kernel(x_ref, y_ref, out_in_ref, out_ref):
    k_pid = pl.program_id(2)

    @pl.when(k_pid == 0)
    def init():
        out_ref[...] = out_in_ref[...]

    original_body(x_ref, y_ref, out_ref)
```

Pallas call:

```python
pl.pallas_call(
    wrapped_kernel,
    grid=(m_blocks, n_blocks, k_splits),
    input_output_aliases={out_in_pos: out_out_pos},
    compiler_params=pltpu.CompilerParams(
        dimension_semantics=("parallel", "parallel", "arbitrary"),
    ),
)
```

Now contributor programs for the same output tile run sequentially, and only the
first one initializes the accumulator:

```python
# program k=0
out_ref[...] = in_ref[...]
out_ref[...] = out_ref[...] + partial_0

# program k=1
out_ref[...] = out_ref[...] + partial_1
```

The existing atomic operation lowering stays as ordinary RMW. The launcher
provides the ordering and prevents repeated accumulator initialization.

### Appendix: Detecting When to Apply the Fix

Atomic codegen records metadata:

- target tensor identity / launcher argument position
- atomic op kind
- whether the previous-value return is used

The Pallas launcher has the grid and `BlockSpec` metadata. For each atomic
target:

1. Find the target tensor's `BlockSpec`.
2. Compute grid dimensions used by that `BlockSpec`.
3. Compute contributor dimensions:

   ```python
   contributor_dims = {
       dim
       for dim in range(len(grid))
       if grid[dim] > 1 and dim not in used_dims
   }
   ```

4. If `contributor_dims` is empty, the target is exclusive. Use the current RMW
   lowering.
5. If `contributor_dims` is non-empty, the target is shared. Apply the fix only
   when:

   - the target is an output tensor
   - the target is aliased input/output, not output-only
   - the op is `atomic_add`, `atomic_max`, or `atomic_min`
   - the atomic previous-value return is unused

Unsupported shared cases fail closed.

For split-K:

```text
grid = (m_block, n_block, k_split)
out BlockSpec uses (m_block, n_block)
contributor_dims = {k_split}
```

For a normal tiled output:

```text
grid = (m_block, n_block)
out BlockSpec uses (m_block, n_block)
contributor_dims = {}
```

### Appendix: More General Cases

This minimal lowering intentionally does not handle every possible atomic.

Rejected for now:

- atomics whose previous-value return is used
- `atomic_xchg`, `atomic_cas`, and bitwise shared-tile atomics
- output-only shared atomic targets
- dynamic duplicate-index scatter atomics where `BlockSpec` analysis cannot
  identify a structural contributor dimension

`arbitrary` gives ordering, but it does not by itself provide an accumulator.
The current fix works because the aliased Pallas output ref is the accumulator.
A more general fallback would need another launcher-provided accumulator ref
with lifetime across ordered contributor programs. Ordinary local variables or
per-program scratch buffers are not sufficient because each contributor would
get separate storage.