### PR TITLE
[Pallas] Suppress Pallas RNG x64 warning spam in random tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import warnings
+
+
+def pytest_configure() -> None:
+    # TODO(tcombes): remove this once Pallas RNG generation avoids int64.
+    # JAX x64 is disabled on TPU, so RNG-generated int64s are truncated and
+    # spam Pallas test logs with one warning per generated statement.
+    warnings.filterwarnings(
+        "ignore",
+        message=(
+            "Explicitly requested dtype int64 requested in .* is not available, "
+            "and will be truncated to dtype int32.*"
+        ),
+        category=UserWarning,
+    )


### PR DESCRIPTION
The logs are currently unreadable (see for example https://github.com/pytorch/helion/actions/runs/26558134110/job/78234430031?pr=2560), because of 8000+ of such warnings. 

Ideally we will fix this directly in random generation, but I don't think it's trivial. This is a bandaid to make logs readable in the meantime.