### PR TITLE
[Pallas] Avoid bool reshape lowering

### DIFF
--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -662,6 +662,16 @@ def codegen_view_pallas(ctx: LoweringContext, node: Node) -> object:
     shape_str = ctx.cg.device_function.tile_strategy.shape_str(
         [*node.meta["val"].size()]
     )
+    input_node = node.args[0]
+    if isinstance(input_node, Node):
+        input_val = input_node.meta.get("val")
+        if isinstance(input_val, torch.Tensor) and input_val.dtype is torch.bool:
+            # Mosaic cannot reshape bool vectors directly:
+            # https://github.com/jax-ml/jax/issues/37370
+            return expr_from_string(
+                f"(jnp.reshape(({{tensor}}).astype(jnp.int32), {shape_str}) != 0)",
+                tensor=tensor,
+            )
     return expr_from_string(f"jnp.reshape({{tensor}}, {shape_str})", tensor=tensor)
 
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -613,6 +613,30 @@ class TestPallas(TestCase):
         torch.testing.assert_close(result, x + offsets[None, :])
         self.assertIn("jnp.arange", code)
 
+    def test_bool_view_expand_where(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def pallas_bool_view_expand_where(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile([m, n]):
+                mask = x[tile_m, 0] > 0
+                mask_2d = mask.view(tile_m.block_size, 1).expand(
+                    tile_m.block_size, tile_n.block_size
+                )
+                out[tile_m, tile_n] = torch.where(mask_2d, x[tile_m, tile_n], 0.0)
+            return out
+
+        x = torch.randn(16, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_bool_view_expand_where,
+            (x,),
+            block_sizes=[16, 128],
+        )
+
+        expected = torch.where(x[:, :1] > 0, x, torch.zeros_like(x))
+        torch.testing.assert_close(result, expected)
+        self.assertIn("astype(jnp.int32)", code)
+
     def test_inplace_add(self) -> None:
         x = torch.randn(1024, device=DEVICE, dtype=torch.float32)
         y = torch.randn(1024, device=DEVICE, dtype=torch.float32)


### PR DESCRIPTION
Similar to https://github.com/pytorch/helion/pull/2216

We cast to int to support to reshape, then !=0 to cast back to bool.