### PR TITLE
[Pallas] Fix indirect gather

### DIFF
--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -342,6 +342,9 @@ def _generated_index_code(
         return _index_expr_from_ast(state, subscript_index)
 
     if isinstance(pattern, IndirectGatherPattern):
+        # The gather emitter consumes the tensor index and projects the full
+        # resident table axis through one-hot, so normal load codegen must
+        # expose that axis instead of indexing it a second time.
         return ":"
 
     raise RuntimeError(

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -315,6 +315,7 @@ def _generated_index_code(
     """Generate index code based on the indexing pattern."""
     from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
     from helion._compiler.pallas.plan_tiling import ArbitrarySlicePattern
+    from helion._compiler.pallas.plan_tiling import IndirectGatherPattern
     from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
     from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
     from helion._compiler.pallas.plan_tiling import TilePattern
@@ -339,6 +340,9 @@ def _generated_index_code(
         if isinstance(idx, int):
             return str(idx)
         return _index_expr_from_ast(state, subscript_index)
+
+    if isinstance(pattern, IndirectGatherPattern):
+        return ":"
 
     raise RuntimeError(
         f"Unhandled indexing pattern type: {type(pattern).__name__}. "

--- a/helion/_compiler/pallas/gather.py
+++ b/helion/_compiler/pallas/gather.py
@@ -112,6 +112,16 @@ def emit_gather(
     ast_idx = ast_subscripts[plan.indirect_pos]
     assert isinstance(ast_idx, ast.AST)
     idx_name = state.codegen.lift(ast_idx, dce=False, prefix="index").id
+    tensor = state.proxy_arg(0)
+    subscript = state.proxy_arg(1)
+    assert isinstance(tensor, torch.Tensor)
+    assert isinstance(subscript, (list, tuple))
+
+    from . import codegen as pallas_codegen
+
+    parts, _ = pallas_codegen.index_parts(state, subscript, tensor)
+    base_index = ", ".join(parts)
+    table_expr = f"{name}[{base_index}]"
 
     if plan.emit_select:
         mask_expr = (
@@ -120,7 +130,7 @@ def emit_gather(
         for _ in range(plan.table_ndim - 1):
             mask_expr = f"jnp.expand_dims({mask_expr}, axis=-1)"
         result = expr_from_string(
-            f"jnp.sum({name}[...] * {mask_expr}, "
+            f"jnp.sum({table_expr} * {mask_expr}, "
             f"axis=jnp.ndim({idx_name}[...])"
             f").astype({plan.jnp_dtype})"
         )
@@ -132,18 +142,18 @@ def emit_gather(
 
     if plan.use_highest_precision:
         oh_dtype = "jnp.float32"
-        table_expr = f"{name}[...].astype(jnp.float32)"
+        table_dot_expr = f"{table_expr}.astype(jnp.float32)"
         precision_arg = "precision=jax.lax.Precision.HIGHEST, "
     else:
         oh_dtype = plan.jnp_dtype
-        table_expr = f"{name}[...]"
+        table_dot_expr = table_expr
         precision_arg = ""
 
     p = plan.indirect_pos
     result = expr_from_string(
         "jax.lax.dot_general("
         f"jax.nn.one_hot({idx_name}[...], {name}.shape[{p}], dtype={oh_dtype}), "
-        f"{table_expr}, "
+        f"{table_dot_expr}, "
         f"(((jnp.ndim({idx_name}[...]),), ({p},)), ((), ())), "
         "preferred_element_type=jnp.float32, "
         f"{precision_arg}"

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -637,6 +637,27 @@ class TestPallas(TestCase):
         torch.testing.assert_close(result, expected)
         self.assertIn("astype(jnp.int32)", code)
 
+    def test_indirect_gather_with_tiled_dim(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def pallas_indirect_gather_with_tiled_dim(
+            values: torch.Tensor, indices: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.empty([indices.size(0), values.size(1)], device=values.device)
+            for tile_m, tile_n in hl.tile(out.size()):
+                out[tile_m, tile_n] = values[indices[tile_m], tile_n]
+            return out
+
+        values = torch.randn(16, 8, device=DEVICE, dtype=torch.float32)
+        indices = torch.randperm(16, device=DEVICE).to(torch.int32)
+        code, result = code_and_output(
+            pallas_indirect_gather_with_tiled_dim,
+            (values, indices),
+            block_sizes=[4, 4],
+        )
+
+        torch.testing.assert_close(result, values[indices.to(torch.int64), :])
+        self.assertIn("values[:,", code)
+
     def test_inplace_add(self) -> None:
         x = torch.randn(1024, device=DEVICE, dtype=torch.float32)
         y = torch.randn(1024, device=DEVICE, dtype=torch.float32)


### PR DESCRIPTION

Pallas indirect gather always used the full Pallas ref as the table operand: `one_hot(indices, values.shape[0]) @ values[...]`

That drops any non-indirect index that still needs explicit Pallas codegen. For example, for: `out[tile_m, tile_n] = values[indices[tile_m], tile_n]`, an inner `tile_n` can lower to `pl.ds(...)`. The old code still gathered from `values[...]`, so the gather ignored that `tile_n` slice.

Wiring the regular indexing should fix it. 