### PR TITLE
[Pallas] Add generic fallback scatter 

### DIFF
--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -316,6 +316,7 @@ def _generated_index_code(
     from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
     from helion._compiler.pallas.plan_tiling import ArbitrarySlicePattern
     from helion._compiler.pallas.plan_tiling import IndirectGatherPattern
+    from helion._compiler.pallas.plan_tiling import IndirectScatterPattern
     from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
     from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
     from helion._compiler.pallas.plan_tiling import TilePattern
@@ -345,6 +346,9 @@ def _generated_index_code(
         # The gather emitter consumes the tensor index and projects the full
         # resident table axis through one-hot, so normal load codegen must
         # expose that axis instead of indexing it a second time.
+        return ":"
+
+    if isinstance(pattern, IndirectScatterPattern):
         return ":"
 
     raise RuntimeError(

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -349,6 +349,9 @@ def _generated_index_code(
         return ":"
 
     if isinstance(pattern, IndirectScatterPattern):
+        # The scatter emitter consumes the tensor index and projects source lanes
+        # through one-hot matrices, so normal store codegen must expose the full
+        # resident target axis instead of indexing it a second time.
         return ":"
 
     raise RuntimeError(

--- a/helion/_compiler/pallas/gather.py
+++ b/helion/_compiler/pallas/gather.py
@@ -112,6 +112,11 @@ def build_scatter_plan(
     """Validate a Pallas scatter site and return its one-hot plan."""
     from ..compile_environment import CompileEnvironment
 
+    if not tensor.dtype.is_floating_point:
+        raise NotImplementedError(
+            f"Pallas scatter: only floating-point output dtypes are supported, "
+            f"got {tensor.dtype}"
+        )
     if len(indirect_positions) > 1:
         raise NotImplementedError(
             "Pallas scatter: multiple indirect dims are not supported"

--- a/helion/_compiler/pallas/gather.py
+++ b/helion/_compiler/pallas/gather.py
@@ -1,8 +1,10 @@
-"""Pallas indirect-gather lowering.
+"""Pallas indirect-gather/scatter lowering.
 
 No native gather in Pallas. Floating ``table[idx]`` emits
 ``one_hot(idx, V) @ table``; int32 ``table[idx]`` emits a boolean one-hot
-select and reduction. Scatter is rejected at plan_tiling time.
+select and reduction. Scatter store projects source lanes to target rows with
+one-hot matrices, resolves duplicate lanes within one program, and merges
+updates with the existing target block.
 """
 
 from __future__ import annotations
@@ -35,6 +37,14 @@ class GatherPlan:
     index_ndim: int
     emit_select: bool
     use_highest_precision: bool
+
+
+@dataclass(frozen=True)
+class ScatterPlan:
+    indirect_pos: int
+    jnp_dtype: str
+    target_ndim: int
+    index_ndim: int
 
 
 def build_gather_plan(
@@ -91,6 +101,36 @@ def build_gather_plan(
         index_ndim=index_ndim,
         emit_select=emit_select,
         use_highest_precision=use_highest,
+    )
+
+
+def build_scatter_plan(
+    tensor: torch.Tensor,
+    subscript: list[object] | tuple[object, ...],
+    indirect_positions: list[int],
+) -> ScatterPlan:
+    """Validate a Pallas scatter site and return its one-hot plan."""
+    from ..compile_environment import CompileEnvironment
+
+    if len(indirect_positions) > 1:
+        raise NotImplementedError(
+            "Pallas scatter: multiple indirect dims are not supported"
+        )
+    indirect_pos = indirect_positions[0]
+    if indirect_pos != 0:
+        raise NotImplementedError("Pallas scatter: only indirect dim 0 is supported")
+    idx_element = subscript[indirect_pos]
+    index_ndim = idx_element.meta["val"].ndim  # type: ignore[union-attr]
+    if index_ndim != 1:
+        raise NotImplementedError(
+            "Pallas scatter: only rank-1 tensor indices are supported"
+        )
+    jnp_dtype = CompileEnvironment.current().backend.dtype_str(tensor.dtype)
+    return ScatterPlan(
+        indirect_pos=indirect_pos,
+        jnp_dtype=jnp_dtype,
+        target_ndim=tensor.ndim,
+        index_ndim=index_ndim,
     )
 
 
@@ -171,3 +211,83 @@ def emit_gather(
             f"jnp.expand_dims({{result}}, axis={dim})", result=result
         )
     return result
+
+
+def _scatter_one_hot_name(
+    state: CodegenState,
+    plan: ScatterPlan,
+    name: str,
+) -> str:
+    ast_subscripts = state.ast_args[1]
+    assert isinstance(ast_subscripts, list)
+    ast_idx = ast_subscripts[plan.indirect_pos]
+    assert isinstance(ast_idx, ast.AST)
+    idx_name = state.codegen.lift(ast_idx, dce=False, prefix="index").id
+    return (
+        f"jax.nn.one_hot({idx_name}[...], {name}.shape[{plan.indirect_pos}], "
+        "dtype=jnp.float32)"
+    )
+
+
+def emit_scatter_store(
+    state: CodegenState,
+    plan: ScatterPlan,
+    name: str,
+    base_index: str,
+    value: ast.AST,
+) -> ast.AST:
+    """Emit one Pallas program's tensor-indexed store block.
+
+    ``base_index`` is the target block with the indirect dimension replaced by
+    ``:``. For ``target[idx, cols] = value`` this is ``target[:, cols]``.
+
+    The lowering builds:
+      - ``oh``: one-hot source-lane-to-target-row map, shape ``[M, V]``.
+      - ``same_output_row``/``is_lane_j_after_i``/``is_last_writer``: local duplicate
+        detection. If two lanes in this program target the same row, only the
+        last source lane is kept.
+      - ``row_to_lane``: target-row-to-source-lane map, shape ``[V, M]``.
+      - ``updates``: projected values for every row in ``base_index``.
+      - ``mask``: rows touched by this program.
+
+    The final expression is ``where(mask, updates, old_target_block)`` so
+    untouched rows keep their previous value. Duplicate handling is local to
+    this Pallas program; duplicate writes from different programs have the same
+    unspecified winner semantics as regular parallel stores in other backends.
+    """
+    oh = _scatter_one_hot_name(state, plan, name)
+    m = f"jnp.shape({oh})[0]"
+    eye = f"jnp.eye({m}, dtype=jnp.float32)"
+    is_lane_j_after_i = f"jnp.triu(jnp.ones(({m}, {m}), dtype=jnp.float32), k=1)"
+    same_output_row = (
+        f"jax.lax.dot_general({oh}, jnp.swapaxes({oh}, 0, 1), (((1,), (0,)), ((), ())))"
+    )
+    is_last_writer = f"(jnp.sum(({same_output_row}) * ({is_lane_j_after_i}), axis=1) == 0).astype(jnp.float32)"
+    row_to_lane = (
+        f"jax.lax.dot_general(jnp.swapaxes({oh}, 0, 1), "
+        f"({eye}) * jnp.expand_dims({is_last_writer}, axis=0), "
+        "(((1,), (0,)), ((), ())))"
+    )
+    updates = expr_from_string(
+        "jax.lax.dot_general("
+        f"{row_to_lane}, "
+        "{value}.astype(jnp.float32), "
+        "(((1,), (0,)), "
+        "((), ())), "
+        "preferred_element_type=jnp.float32, "
+        "precision=jax.lax.Precision.HIGHEST"
+        f").astype({plan.jnp_dtype})",
+        value=value,
+    )
+    mask_expr = (
+        "jax.lax.dot_general("
+        f"{row_to_lane}, "
+        "jnp.ones_like({value}, dtype=jnp.float32), "
+        "(((1,), (0,)), ((), ()))"
+        ") > 0"
+    )
+    return expr_from_string(
+        f"jnp.where({mask_expr}, {{updates}}, {name}[{base_index}])",
+        updates=updates,
+        value=value,
+    )

--- a/helion/_compiler/pallas/gather.py
+++ b/helion/_compiler/pallas/gather.py
@@ -228,6 +228,8 @@ def _scatter_one_hot_name(
     ast_idx = ast_subscripts[plan.indirect_pos]
     assert isinstance(ast_idx, ast.AST)
     idx_name = state.codegen.lift(ast_idx, dce=False, prefix="index").id
+    # TODO(tcombes): investigate making the metadata into dtype,
+    # currently hitting Mosaic issues with bf16 mask.
     return (
         f"jax.nn.one_hot({idx_name}[...], {name}.shape[{plan.indirect_pos}], "
         "dtype=jnp.float32)"

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from ..host_function import SymbolOrigin
     from ..tile_dispatch import TileStrategyDispatch
     from .gather import GatherPlan
+    from .gather import ScatterPlan
 
 
 @dataclass
@@ -67,7 +68,7 @@ class NonePattern(IndexingPattern):
 
 @dataclass
 class TensorIndexPattern(IndexingPattern):
-    """Tensor-valued index - no tiling. Resolved to IndirectGatherPattern for loads, rejected for stores."""
+    """Tensor-valued index - no tiling. Resolved for indirect load/store codegen."""
 
 
 @dataclass
@@ -75,6 +76,13 @@ class IndirectGatherPattern(IndexingPattern):
     """Indirect gather load ``table[idx, ...]`` - no tiling on this dim."""
 
     plan: GatherPlan
+
+
+@dataclass
+class IndirectScatterPattern(IndexingPattern):
+    """Indirect scatter store ``table[idx, ...]`` - no tiling on this dim."""
+
+    plan: ScatterPlan
 
 
 @dataclass
@@ -387,24 +395,33 @@ def _resolve_tensor_index_patterns(
     patterns: list[IndexingPattern],
     config: Config,
 ) -> None:
-    """Replace TensorIndexPattern with IndirectGatherPattern for loads. Raise for stores."""
+    """Replace TensorIndexPattern with Pallas indirect load/store patterns."""
     positions = [i for i, p in enumerate(patterns) if isinstance(p, TensorIndexPattern)]
     if not positions:
         return
 
     from ...language import memory_ops
 
-    if node.target is not memory_ops.load:
-        op_name = getattr(node.target, "__name__", str(node.target))
-        raise NotImplementedError(
-            f"Pallas: indirect store (scatter) is not supported (op={op_name})."
-        )
+    if node.target is memory_ops.load:
+        from .gather import build_gather_plan
 
-    from .gather import build_gather_plan
+        plan = build_gather_plan(tensor, subscript, positions, patterns, config)
+        for i in positions:
+            patterns[i] = IndirectGatherPattern(plan=plan)
+        return
 
-    plan = build_gather_plan(tensor, subscript, positions, patterns, config)
-    for i in positions:
-        patterns[i] = IndirectGatherPattern(plan=plan)
+    if node.target is memory_ops.store:
+        from .gather import build_scatter_plan
+
+        plan = build_scatter_plan(tensor, subscript, positions)
+        for i in positions:
+            patterns[i] = IndirectScatterPattern(plan=plan)
+        return
+
+    op_name = getattr(node.target, "__name__", str(node.target))
+    raise NotImplementedError(
+        f"Pallas: indirect scatter is not supported for op={op_name}."
+    )
 
 
 # Helper functions moved from memory_ops.py

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -420,7 +420,7 @@ def _resolve_tensor_index_patterns(
 
     op_name = getattr(node.target, "__name__", str(node.target))
     raise NotImplementedError(
-        f"Pallas: indirect scatter is not supported for op={op_name}."
+        f"Pallas: tensor-indexed memory op is not supported for op={op_name}."
     )
 
 

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -340,7 +340,9 @@ def _(state: CodegenState) -> None:
         for pattern in patterns or ()
         if isinstance(pattern, IndirectScatterPattern)
     ]
-    assert len(scatter_patterns) <= 1
+    assert len(scatter_patterns) <= 1, (
+        "Pallas store expected at most one indirect scatter pattern"
+    )
     if scatter_patterns:
         value = emit_scatter_store(
             state, scatter_patterns[0].plan, name, idx_str, value

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -331,6 +331,20 @@ def _(state: CodegenState) -> None:
         state, tensor, subscript, parts, value
     )
     idx_str = ", ".join(parts)
+    patterns = state.fx_node.meta.get("indexing_patterns") if state.fx_node else ()
+    from .._compiler.pallas.gather import emit_scatter_store
+    from .._compiler.pallas.plan_tiling import IndirectScatterPattern
+
+    scatter_patterns = [
+        pattern
+        for pattern in patterns or ()
+        if isinstance(pattern, IndirectScatterPattern)
+    ]
+    assert len(scatter_patterns) <= 1
+    if scatter_patterns:
+        value = emit_scatter_store(
+            state, scatter_patterns[0].plan, name, idx_str, value
+        )
     state.codegen.add_statement(
         statement_from_string(f"{name}[{idx_str}] = {{value}}", value=value)
     )

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1029,7 +1029,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             mod.jagged_dense_bmm_reference(*args),
         )
 
-    @xfailIfPallas("tensor-derived if-predicates not supported")
+    @xfailIfPallasTpu("tensor-derived if-predicates not supported")
     @skipIfRefEager("Test has skip_accuracy=True and doesn't call assert_close")
     def test_moe_matmul_ogs(self):
         mod = import_path(EXAMPLES_DIR / "moe_matmul_ogs.py")
@@ -1565,7 +1565,7 @@ class TestExamples(RefEagerTestBase, TestCase):
                 rtol=1e-2,
             )
 
-    @xfailIfPallas("tensor-derived if-predicates not supported")
+    @xfailIfPallasTpu("tensor-derived if-predicates not supported")
     def test_grouped_gemm_jagged(self):
         # Build small jagged grouped GEMM inputs
         torch.manual_seed(0)

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1029,7 +1029,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             mod.jagged_dense_bmm_reference(*args),
         )
 
-    @xfailIfPallasTpu("tensor-derived if-predicates not supported")
     @skipIfRefEager("Test has skip_accuracy=True and doesn't call assert_close")
     def test_moe_matmul_ogs(self):
         mod = import_path(EXAMPLES_DIR / "moe_matmul_ogs.py")

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -667,16 +667,24 @@ class TestPallas(TestCase):
         self.assertIn("values[:,", code)
 
     def test_scatter_store(self) -> None:
-        values = torch.randn(16, 8, device=DEVICE, dtype=torch.float32)
-        indices = torch.randperm(16, device=DEVICE).to(torch.int32)
-        code, result = code_and_output(
-            pallas_scatter_store, (values, indices), block_sizes=[4, 4]
-        )
+        for dtype in (torch.float32, torch.bfloat16):
+            with self.subTest(dtype=dtype):
+                values = torch.randn(16, 8, device=DEVICE, dtype=dtype)
+                indices = torch.randperm(16, device=DEVICE).to(torch.int32)
+                code, result = code_and_output(
+                    pallas_scatter_store, (values, indices), block_sizes=[4, 4]
+                )
 
-        expected = torch.zeros_like(values)
-        expected[indices.to(torch.int64)] = values
-        torch.testing.assert_close(result, expected)
-        self.assertIn("one_hot", code)
+                expected = torch.zeros_like(values)
+                expected[indices.to(torch.int64)] = values
+                torch.testing.assert_close(result, expected)
+                self.assertIn("one_hot", code)
+                self.assertIn("jnp.triu", code)
+                self.assertIn("jnp.eye", code)
+                self.assertIn("jnp.swapaxes", code)
+                self.assertIn("jnp.ones_like", code)
+                self.assertIn("jnp.where", code)
+                self.assertIn("dot_general", code)
 
     def test_scatter_store_duplicate_indices(self) -> None:
         values = torch.randn(16, 8, device=DEVICE, dtype=torch.float32)
@@ -692,7 +700,6 @@ class TestPallas(TestCase):
         expected = torch.zeros_like(values)
         expected[indices.to(torch.int64)] = values
         torch.testing.assert_close(result, expected)
-        self.assertIn("triu", code)
 
     def test_tensor_index_atomic_add_raises(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -694,6 +694,29 @@ class TestPallas(TestCase):
         torch.testing.assert_close(result, expected)
         self.assertIn("triu", code)
 
+    def test_tensor_index_atomic_add_raises(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def atomic_add_tensor_index(
+            values: torch.Tensor, indices: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.zeros_like(values)
+            for tile in hl.tile(values.size(0)):
+                hl.atomic_add(out, [indices[tile]], values[tile])
+            return out
+
+        values = torch.randn(16, device=DEVICE, dtype=torch.float32)
+        indices = torch.randperm(16, device=DEVICE).to(torch.int32)
+
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "tensor-indexed memory op is not supported for op=atomic_add",
+        ):
+            code_and_output(
+                atomic_add_tensor_index,
+                (values, indices),
+                block_size=16,
+            )
+
     def test_inplace_add(self) -> None:
         x = torch.randn(1024, device=DEVICE, dtype=torch.float32)
         y = torch.randn(1024, device=DEVICE, dtype=torch.float32)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -717,6 +717,34 @@ class TestPallas(TestCase):
                 block_size=16,
             )
 
+    def test_scatter_store_multiple_tensor_indices_raises(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def scatter_store_multiple_tensor_indices(
+            values: torch.Tensor, row_indices: torch.Tensor, col_indices: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.zeros(
+                [values.size(0), values.size(0)],
+                dtype=values.dtype,
+                device=values.device,
+            )
+            for tile in hl.tile(values.size(0)):
+                out[row_indices[tile], col_indices[tile]] = values[tile, tile]
+            return out
+
+        values = torch.randn(16, 16, device=DEVICE, dtype=torch.float32)
+        row_indices = torch.randperm(16, device=DEVICE).to(torch.int32)
+        col_indices = torch.randperm(16, device=DEVICE).to(torch.int32)
+
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "multiple indirect dims are not supported",
+        ):
+            code_and_output(
+                scatter_store_multiple_tensor_indices,
+                (values, row_indices, col_indices),
+                block_size=16,
+            )
+
     def test_inplace_add(self) -> None:
         x = torch.randn(1024, device=DEVICE, dtype=torch.float32)
         y = torch.randn(1024, device=DEVICE, dtype=torch.float32)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -231,6 +231,14 @@ def pallas_arange_add(x: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_scatter_store(values: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
+    out = torch.zeros_like(values)
+    for tile_m, tile_n in hl.tile(values.size()):
+        out[indices[tile_m], tile_n] = values[tile_m, tile_n]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_inner_loop_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     """Kernel with an outer grid loop and an inner device loop."""
     m, n = x.size()
@@ -657,6 +665,34 @@ class TestPallas(TestCase):
 
         torch.testing.assert_close(result, values[indices.to(torch.int64), :])
         self.assertIn("values[:,", code)
+
+    def test_scatter_store(self) -> None:
+        values = torch.randn(16, 8, device=DEVICE, dtype=torch.float32)
+        indices = torch.randperm(16, device=DEVICE).to(torch.int32)
+        code, result = code_and_output(
+            pallas_scatter_store, (values, indices), block_sizes=[4, 4]
+        )
+
+        expected = torch.zeros_like(values)
+        expected[indices.to(torch.int64)] = values
+        torch.testing.assert_close(result, expected)
+        self.assertIn("one_hot", code)
+
+    def test_scatter_store_duplicate_indices(self) -> None:
+        values = torch.randn(16, 8, device=DEVICE, dtype=torch.float32)
+        indices = torch.tensor(
+            [0, 1, 1, 2, 4, 4, 4, 8, 8, 9, 10, 10, 12, 13, 14, 14],
+            device=DEVICE,
+            dtype=torch.int32,
+        )
+        code, result = code_and_output(
+            pallas_scatter_store, (values, indices), block_sizes=[16, 8]
+        )
+
+        expected = torch.zeros_like(values)
+        expected[indices.to(torch.int64)] = values
+        torch.testing.assert_close(result, expected)
+        self.assertIn("triu", code)
 
     def test_inplace_add(self) -> None:
         x = torch.randn(1024, device=DEVICE, dtype=torch.float32)
@@ -3081,24 +3117,6 @@ class TestPallasIndirectGather(TestCase):
         self.assertNotIn("dot_general", code)
         ref = table.cpu()[indices.long().cpu()].to(device=DEVICE)
         torch.testing.assert_close(result, ref)
-
-    @parametrize("static_shapes", (True, False))
-    def test_scatter_raises(self, static_shapes: bool) -> None:
-        """Indirect store has no Pallas strategy; plan_tiling must raise."""
-
-        @helion.kernel(backend="pallas", static_shapes=static_shapes)
-        def scatter(
-            out: torch.Tensor, values: torch.Tensor, indices: torch.Tensor
-        ) -> torch.Tensor:
-            for tile_b, tile_e in hl.tile([values.size(0), values.size(1)]):
-                out[indices[tile_b], tile_e] = values[tile_b, tile_e]
-            return out
-
-        out = torch.zeros(16, 64, device=DEVICE, dtype=torch.float32)
-        values = torch.randn(8, 64, device=DEVICE, dtype=torch.float32)
-        indices = torch.arange(8, device=DEVICE, dtype=torch.int32)
-        with self.assertRaisesRegex(Exception, "indirect store"):
-            code_and_output(scatter, (out, values, indices), block_sizes=[8, 64])
 
     @parametrize("static_shapes", (True, False))
     def test_gather_1d_index_bumps_block_to_tpu_alignment(


### PR DESCRIPTION
Same high level idea as the onehot gather, however it's more involved, because with a simple onehot, we would sum upon duplicate indices instead of picking the last one, which meaningfully changes the semantics.

#### Detailed example below:

A store like this: `out[indices[tile_m], tile_n] = values[tile_m, tile_n]`

is lowered roughly to this Pallas code:

```python
idx = indices[...]                                      # [M]
value = values[...]                                    # [M, N]
old = out[:, cols]                                     # [V, N]

oh = jax.nn.one_hot(idx, out.shape[0], dtype=jnp.float32)  # [M, V]

same_output_row = oh @ oh.T                               # [M, M]
is_lane_j_after_i = jnp.triu(jnp.ones((M, M), dtype=jnp.float32), k=1)
is_last_writer = (
    jnp.sum(same_output_row * is_lane_j_after_i, axis=1) == 0
).astype(jnp.float32)

row_to_lane = oh.T @ (jnp.eye(M, dtype=jnp.float32) * is_last_writer[None, :])

updates = row_to_lane @ value                         # [V, N]
mask = (row_to_lane @ jnp.ones_like(value, dtype=jnp.float32)) > 0

out[:, cols] = jnp.where(mask, updates, old)
```

Small example with duplicates:

```python
idx = [2, 4, 2, 1]
value = [a, b, c, d]
```

Assume `V = 5`, so target rows are `0..4`, and `M = 4` source lanes.

First we build `oh`, shape `[M, V]`. Each source lane points to one target row:

```text
lane 0 writes row 2: [0, 0, 1, 0, 0]
lane 1 writes row 4: [0, 0, 0, 0, 1]
lane 2 writes row 2: [0, 0, 1, 0, 0]
lane 3 writes row 1: [0, 1, 0, 0, 0]
```

Then `same_output_row = oh @ oh.T`, shape `[M, M]`. It says which source lanes
write the same target row:

```text
same_output_row =
[
  [1, 0, 1, 0],   # lane 0 conflicts with lane 2
  [0, 1, 0, 0],
  [1, 0, 1, 0],   # lane 2 conflicts with lane 0
  [0, 0, 0, 1],
]
```

`is_lane_j_after_i` is only about lane order. Entry `[i, j]` is `1` when lane `j` is
later than lane `i`:

```text
is_lane_j_after_i =
[
  [0, 1, 1, 1],
  [0, 0, 1, 1],
  [0, 0, 0, 1],
  [0, 0, 0, 0],
]
```

So `same_output_row * is_lane_j_after_i` answers: does this lane have a later lane that writes the same target row?

```text
[
  [0, 0, 1, 0],   # lane 0 has a later duplicate: lane 2
  [0, 0, 0, 0],
  [0, 0, 0, 0],
  [0, 0, 0, 0],
]
```

Then:

```python
is_last_writer = (sum(same_output_row * is_lane_j_after_i, axis=1) == 0)
```

gives:

```text
is_last_writer = [False, True, True, True]
```

Lane `0` is removed. Lane `2` stays, so row `2` gets `c`, not `a`.

Next we build `row_to_lane`, shape `[V, M]`. It maps each target row to the
source lane that should provide its value:

```text
row_to_lane =
[
  [0, 0, 0, 0],   # row 0 untouched
  [0, 0, 0, 1],   # row 1 takes lane 3 -> d
  [0, 0, 1, 0],   # row 2 takes lane 2 -> c
  [0, 0, 0, 0],   # row 3 untouched
  [0, 1, 0, 0],   # row 4 takes lane 1 -> b
]
```

Now:

```python
updates = row_to_lane @ value
```

becomes:

```text
updates = [0, d, c, 0, b]
```

and:

```python
mask = row_to_lane @ ones_like(value) > 0
```

becomes:

```text
mask = [False, True, True, False, True]
```

Finally:

```python
out[:] = where(mask, updates, old_out[:])
```

keeps old values for rows `0` and `3`, and writes rows `1`, `2`, and `4`.