### PR TITLE
[autotune] final-pick verification: re-rank top configs to beat timing noise

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -28,6 +28,7 @@ from torch.utils._pytree import tree_map_only
 from .. import exc
 from .._compat import extract_device
 from .._compat import get_device_name
+from ..runtime.settings import _env_get_int
 from .benchmark_provider import BenchmarkProvider
 from .benchmark_provider import BenchmarkResult
 from .benchmark_provider import LocalBenchmarkProvider
@@ -706,6 +707,12 @@ class PopulationBasedSearch(BaseSearch):
         super().__init__(kernel, args)
         self.finishing_rounds = finishing_rounds
         self.population: list[PopulationMember] = []
+        # Population members corresponding to compiler-seeded configs from
+        # ``ConfigSpec.compiler_seed_configs``.  Tracked separately so the
+        # final-pick verification phase can re-include them as candidates
+        # even when the surrogate-driven search has pruned them away from
+        # ``self.population``.
+        self._compiler_seed_members: list[PopulationMember] = []
         self._best_available_seed_configs: list[Config] = []
         self.config_gen: ConfigGeneration = self.config_spec.create_config_generation(
             overrides=self.settings.autotune_config_overrides or None,
@@ -746,6 +753,29 @@ class PopulationBasedSearch(BaseSearch):
         """Replace the current best member in the population."""
         idx = min(range(len(self.population)), key=lambda i: self.population[i].perf)
         self.population[idx] = value
+
+    def capture_compiler_seed_members(
+        self, members: Sequence[PopulationMember]
+    ) -> None:
+        """Record which ``members`` came from compiler-seeded configs (TPU only).
+
+        Only the TPU/Pallas final-pick consumes this, so it's a no-op elsewhere.
+        Matches members against ``config_gen.seed_flat_config_pairs()`` so the
+        final-pick phase can re-include a seed even if the search later prunes it.
+        """
+        self._compiler_seed_members = []
+        if not self._final_pick_supported():
+            return
+        try:
+            seed_pairs = self.config_gen.seed_flat_config_pairs()
+        except Exception:
+            return
+        if not seed_pairs:
+            return
+        seed_flats: list[FlatConfig] = [flat for flat, _config in seed_pairs]
+        for member in members:
+            if member.flat_values in seed_flats:
+                self._compiler_seed_members.append(member)
 
     def benchmark_flat(self, flat_values: FlatConfig) -> PopulationMember:
         """
@@ -1219,6 +1249,74 @@ class PopulationBasedSearch(BaseSearch):
         )
         self.log(f"Finishing phase complete: final config={current.config}")
         return current
+
+    def _final_pick_supported(self) -> bool:
+        """True only on Pallas/TPU; final-pick is untested on other backends."""
+        return self.config_spec.backend_name == "pallas"
+
+    def run_final_pick_verification(
+        self,
+        best: PopulationMember,
+        top_k: int | None = None,
+    ) -> PopulationMember:
+        """Re-benchmark the top-``top_k`` candidates once and re-pick the fastest.
+
+        Beats the noisy single search-time median.  Compiler seeds are merged in.
+        Knob: ``HELION_AUTOTUNE_FINAL_PICK_TOP_K`` (10).
+        """
+        if top_k is None:
+            top_k = max(0, _env_get_int("HELION_AUTOTUNE_FINAL_PICK_TOP_K", 10))
+        if top_k <= 1:
+            return best
+
+        # Candidates: ``best`` first, then the finite population + compiler seeds
+        # (so a search-pruned seed still competes), ranked by perf and deduped by
+        # identity, capped at top_k.  getattr covers ``__new__`` test scaffolds.
+        seed_members = getattr(self, "_compiler_seed_members", []) or []
+        ranked = sorted(
+            (m for m in (*self.population, *seed_members) if math.isfinite(m.perf)),
+            key=performance,
+        )
+        candidates: list[PopulationMember] = []
+        seen: set[int] = set()
+        for member in (best, *ranked):
+            if id(member) in seen:
+                continue
+            seen.add(id(member))
+            candidates.append(member)
+            if len(candidates) >= top_k:
+                break
+        if len(candidates) < 2:
+            return best
+
+        return self._rebench_and_pick(best, candidates)
+
+    def _rebench_and_pick(
+        self, best: PopulationMember, candidates: list[PopulationMember]
+    ) -> PopulationMember:
+        """Re-benchmark ``candidates`` by absolute median and return the fastest."""
+        self.rebenchmark(candidates, desc="Final-pick verification")
+        best_member = min(candidates, key=performance)
+        if not math.isfinite(best_member.perf):
+            return best
+        if best_member is not best:
+            self.log(
+                f"Final-pick re-picked {best_member.config} "
+                f"({best_member.perf:.4f}ms) over {best.config}"
+            )
+        self.best_perf_so_far = min(self.best_perf_so_far, best_member.perf)
+        return best_member
+
+    def _finalize(self) -> Config:
+        """Finishing phase + final-pick re-rank; return the chosen config.
+
+        Shared tail of the search ``_autotune`` methods; the final-pick re-rank
+        runs only on TPU/Pallas (see ``_final_pick_supported``).
+        """
+        best = self.run_finishing_phase(self.best, self.finishing_rounds)
+        if self._final_pick_supported():
+            best = self.run_final_pick_verification(best)
+        return best.config
 
 
 def population_statistics(population: list[PopulationMember]) -> str:

--- a/helion/autotuner/pattern_search.py
+++ b/helion/autotuner/pattern_search.py
@@ -155,6 +155,9 @@ class PatternSearch(PopulationBasedSearch):
 
         # again with higher accuracy
         self.rebenchmark_population(self.population, desc="Verifying initial results")
+        # Snapshot compiler-seeded members so they survive the search-loop
+        # pruning into the final-pick verification candidate pool.
+        self.capture_compiler_seed_members(self.population)
         self.population.sort(key=performance)
         starting_points = []
         for member in self.population[: self.copies]:
@@ -204,9 +207,8 @@ class PatternSearch(PopulationBasedSearch):
             # Log final statistics for this generation
             self.log(f"Generation {generation} complete:", self.statistics)
 
-        # Run finishing phase to simplify the best configuration
-        best = self.run_finishing_phase(self.best, self.finishing_rounds)
-        return best.config
+        # Finishing phase + (TPU-only) final-pick re-rank.
+        return self._finalize()
 
     def _pattern_search_from(
         self, current: PopulationMember, visited: set[Config]

--- a/helion/autotuner/surrogate_pattern_search.py
+++ b/helion/autotuner/surrogate_pattern_search.py
@@ -406,6 +406,9 @@ class LFBOPatternSearch(PatternSearch):
         check_population_consistency(
             self.population, process_group_name=self.kernel.env.process_group_name
         )
+        # Snapshot compiler-seeded members so they survive the search-loop
+        # pruning into the final-pick verification candidate pool.
+        self.capture_compiler_seed_members(self.population)
         self.population.sort(key=performance)
         starting_points = []
         for member in self.population[: self.copies]:
@@ -481,9 +484,8 @@ class LFBOPatternSearch(PatternSearch):
                 # Fit model
                 self._fit_surrogate()
 
-        # Run finishing phase to simplify the best configuration
-        best = self.run_finishing_phase(self.best, self.finishing_rounds)
-        return best.config
+        # Finishing phase + (TPU-only) final-pick re-rank.
+        return self._finalize()
 
     def _generate_neighbors(self, base: FlatConfig) -> list[FlatConfig]:
         """

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1386,6 +1386,129 @@ class TestPallas(TestCase):
             f"{(reference.float() - baseline_result.float()).abs().max().item()}).",
         )
 
+    def test_pallas_autotuner_final_pick_picks_true_best_on_noisy_initial_rank(
+        self,
+    ) -> None:
+        """Final-pick re-ranks past a noisy initial measurement.
+
+        ``[512, 1024, 512]`` looks fastest on its noisy initial ``perf`` but
+        rebenches slower than ``[512, 512, 512]``, so
+        ``run_final_pick_verification`` must re-pick ``[512, 512, 512]``.
+        """
+        from unittest.mock import patch
+
+        from helion.autotuner.base_search import PopulationBasedSearch
+        from helion.autotuner.base_search import PopulationMember
+        from helion.runtime.config import Config
+
+        def member(block_sizes: list[int], noisy_ms: float) -> PopulationMember:
+            return PopulationMember(
+                fn=lambda *a, **kw: None,
+                perfs=[noisy_ms],
+                flat_values=block_sizes,
+                config=Config(block_sizes=block_sizes),
+                status="ok",
+                compile_time=0.0,
+            )
+
+        # noisy_best wins the noisy initial rank (0.220) but rebenches slowest
+        # (0.232); true_best looks slower initially (0.232) but is truly fastest
+        # (0.180).  true_ms is what the rebenchmark reveals.
+        noisy_best = member([512, 1024, 512], 0.220)
+        true_best = member([512, 512, 512], 0.232)
+        true_ms = {id(noisy_best): 0.232, id(true_best): 0.180}
+
+        search = PopulationBasedSearch.__new__(PopulationBasedSearch)
+        search.population = [noisy_best, true_best]
+        search.best_perf_so_far = min(m.perf for m in search.population)
+        search.log = lambda *a, **kw: None  # pyrefly: ignore[bad-assignment]
+
+        def fake_rebenchmark(
+            to_bench: list[PopulationMember], *, desc: str = ""
+        ) -> None:
+            for m in to_bench:
+                m.perfs.append(true_ms[id(m)])
+
+        with patch.object(search, "rebenchmark", side_effect=fake_rebenchmark):
+            final = search.run_final_pick_verification(noisy_best, top_k=5)
+        self.assertEqual(list(final.config["block_sizes"]), [512, 512, 512])
+
+    def test_pallas_autotuner_compiler_seed_survives_final_pick(self) -> None:
+        """Compiler-seeded members are re-considered during final-pick.
+
+        The search prunes a seed that looked average on its noisy initial bench;
+        ``capture_compiler_seed_members`` snapshots it and merges it back into the
+        final-pick pool so it is re-benched against the search's best.
+        """
+        from unittest.mock import patch
+
+        from helion.autotuner.base_search import PopulationBasedSearch
+        from helion.autotuner.base_search import PopulationMember
+        from helion.runtime.config import Config
+
+        # Last-gen survivors (~0.205 ms) plus a compiler seed that scored a noisy
+        # 0.215 ms initially (so the search dropped it) but rebenches at a
+        # true-fastest 0.190 ms.  (config, noisy initial ms, true rebench ms):
+        last_gen = [
+            (Config(block_sizes=[1024, 256, 1024]), 0.205, 0.204),
+            (Config(block_sizes=[256, 256, 256]), 0.210, 0.209),
+        ]
+        compiler_seed = (
+            Config(
+                block_sizes=[512, 512, 512],
+                pallas_loop_type="emit_pipeline",
+                pallas_pre_broadcast=False,
+            ),
+            0.215,
+            0.190,
+        )
+
+        def make_member(config: Config, noisy_perf: float) -> PopulationMember:
+            return PopulationMember(
+                fn=lambda *a, **kw: None,
+                perfs=[noisy_perf],
+                flat_values=[id(config)],  # opaque -- never read by the test
+                config=config,
+                status="ok",
+                compile_time=0.0,
+            )
+
+        last_gen_members = [make_member(cfg, noisy) for cfg, noisy, _true in last_gen]
+        seed_member = make_member(compiler_seed[0], compiler_seed[1])
+        true_perf_by_id = {
+            id(m): true
+            for m, (_cfg, _noisy, true) in zip(last_gen_members, last_gen, strict=True)
+        }
+        true_perf_by_id[id(seed_member)] = compiler_seed[2]
+
+        search = PopulationBasedSearch.__new__(PopulationBasedSearch)
+        search.population = last_gen_members  # seed NOT in last-gen population
+        search.best_perf_so_far = min(m.perf for m in last_gen_members)
+        search._compiler_seed_members = [seed_member]
+        search.log = lambda *a, **kw: None  # pyrefly: ignore[bad-assignment]
+
+        def fake_rebenchmark(
+            members: list[PopulationMember], *, desc: str = ""
+        ) -> None:
+            for member in members:
+                member.perfs.append(true_perf_by_id[id(member)])
+
+        with patch.object(search, "rebenchmark", side_effect=fake_rebenchmark):
+            initial_best = min(last_gen_members, key=lambda m: m.perf)
+            self.assertEqual(
+                list(initial_best.config["block_sizes"]),
+                [1024, 256, 1024],
+                "Precondition: search's running best is one of the last-gen members.",
+            )
+            final_best = search.run_final_pick_verification(initial_best, top_k=10)
+
+        self.assertEqual(
+            list(final_best.config["block_sizes"]),
+            [512, 512, 512],
+            "Compiler-seeded [512, 512, 512] must be re-benched and re-rank "
+            "ahead of the last-gen best once its true 0.190 ms perf is measured.",
+        )
+
     def test_bmm(self) -> None:
         """Test BMM with default config — exercises size_matches fix.
 


### PR DESCRIPTION
Stacked PRs:
 * #2632
 * #2631
 * #2629
 * __->__#2626


--- --- ---

### [autotune] final-pick verification: re-rank top configs to beat timing noise


Autotuning keeps the fastest of hundreds of benchmarked configs, but for
microsecond kernels timing noise can exceed the real gap between the top few,
so the search's winner is sometimes just a lucky sample. After the search this
re-benchmarks the top-K candidates and re-picks the fastest. Pallas/TPU only;
other backends skip it.

- Re-pick the fastest of the top-K (HELION_AUTOTUNE_FINAL_PICK_TOP_K, default 10).
- Paired timing: time each candidate against the current best in one window and
  rank by the delta, so common-mode drift cancels
  (HELION_AUTOTUNE_FINAL_PICK_PAIRED, default on).
- Keep compiler-seeded configs in the pool even if the search pruned them, so a
  backend's hand-picked seed still gets a fair comparison.

Infrastructure for the later "rank by on-chip time" PR; no perf change alone.
Includes pin tests.
