### PR TITLE
[autotune] compare each candidate against the current best in the same timing window

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -28,6 +28,7 @@ from torch.utils._pytree import tree_map_only
 from .. import exc
 from .._compat import extract_device
 from .._compat import get_device_name
+from ..runtime.settings import _env_get_bool
 from ..runtime.settings import _env_get_int
 from .benchmark_provider import BenchmarkProvider
 from .benchmark_provider import BenchmarkResult
@@ -35,6 +36,7 @@ from .benchmark_provider import LocalBenchmarkProvider
 from .benchmark_provider import _clone_args
 from .benchmark_provider import _unset_fn
 from .benchmarking import interleaved_bench
+from .benchmarking import paired_interleaved_bench
 from .logger import AutotuningLogger
 from .metrics import AutotuneMetrics
 from .metrics import _run_post_autotune_hooks
@@ -1212,15 +1214,21 @@ class PopulationBasedSearch(BaseSearch):
         self,
         best: PopulationMember,
         top_k: int | None = None,
+        *,
+        paired: bool | None = None,
     ) -> PopulationMember:
         """Re-benchmark the top-``top_k`` candidates once and re-pick the fastest.
 
         Hardens against the noisy single ``interleaved_bench`` median the search
-        ranks by.  ``top_k`` defaults to ``HELION_AUTOTUNE_FINAL_PICK_TOP_K``
-        (10); returns ``best`` unchanged when ``top_k <= 1`` or < 2 finite.
+        ranks by.  With ``paired`` (default on) each candidate is timed against
+        ``best`` in one window so common-mode drift cancels.  Knobs:
+        ``HELION_AUTOTUNE_FINAL_PICK_TOP_K`` (10), ``..._PAIRED``; returns
+        ``best`` unchanged when ``top_k <= 1`` or < 2 finite.
         """
         if top_k is None:
             top_k = max(0, _env_get_int("HELION_AUTOTUNE_FINAL_PICK_TOP_K", 10))
+        if paired is None:
+            paired = _env_get_bool("HELION_AUTOTUNE_FINAL_PICK_PAIRED", True)
         if top_k <= 1:
             return best
 
@@ -1244,6 +1252,9 @@ class PopulationBasedSearch(BaseSearch):
         if len(candidates) < 2:
             return best
 
+        if paired and self._paired_rebenchmark_available():
+            return self._run_final_pick_verification_paired(best, candidates)
+
         self.rebenchmark(candidates, desc="Final-pick verification")
         best_member = min(candidates, key=performance)
         if not math.isfinite(best_member.perf):
@@ -1266,6 +1277,106 @@ class PopulationBasedSearch(BaseSearch):
         if self._final_pick_supported():
             best = self.run_final_pick_verification(best)
         return best.config
+
+    def _paired_rebenchmark_available(self) -> bool:
+        """True when the paired re-rank path has the real-autotune scaffolding.
+
+        Needs ``self.args``/``kernel``/``benchmark_provider``/``settings`` to
+        build per-candidate partials for :func:`paired_interleaved_bench`.
+        Unit-test scaffolds that patch ``self.rebenchmark`` directly fall back to
+        the absolute-median path, as does a user-supplied ``autotune_benchmark_fn``
+        (it owns its own ranking).
+        """
+        if getattr(self, "args", None) is None:
+            return False
+        if getattr(self, "kernel", None) is None:
+            return False
+        if getattr(self, "benchmark_provider", None) is None:
+            return False
+        if getattr(self, "settings", None) is None:
+            return False
+        return self.settings.autotune_benchmark_fn is None
+
+    def _run_final_pick_verification_paired(
+        self,
+        best: PopulationMember,
+        candidates: list[PopulationMember],
+    ) -> PopulationMember:
+        """Paired-sample re-rank: time each candidate against ``best`` in one window.
+
+        :func:`paired_interleaved_bench` runs each candidate call back-to-back
+        with one ``best`` call, so common-mode drift cancels; rank by the paired
+        delta (smaller = faster than ``best``), tie-broken by absolute median.
+        """
+        # Repeat count mirrors :meth:`rebenchmark` so the measurement scales
+        # with kernel cost the same way the absolute-median path does.
+        base_repeat = (
+            int(200 / self.best_perf_so_far)
+            if math.isfinite(self.best_perf_so_far) and self.best_perf_so_far > 0
+            else 1000
+        )
+        repeat = min(1000, max(3, base_repeat))
+        if (capstr := os.getenv("HELION_CAP_REBENCHMARK_REPEAT")) is not None:
+            repeat = min(repeat, int(capstr))
+
+        if len(self.benchmark_provider.mutated_arg_indices) > 0:
+            benchmark_args = _clone_args(
+                self.args,
+                self.kernel.env.process_group_name,
+                idx_to_clone=self.benchmark_provider.mutated_arg_indices,
+            )
+        else:
+            benchmark_args = self.args
+        candidate_fns: list[Callable[..., object]] = [
+            functools.partial(member.fn, *benchmark_args) for member in candidates
+        ]
+        reference_fn: Callable[..., object] = functools.partial(
+            best.fn, *benchmark_args
+        )
+
+        try:
+            paired_results = paired_interleaved_bench(
+                candidate_fns,
+                reference_fn,
+                repeat=repeat,
+                desc="Final-pick verification (paired)"
+                if self.settings.autotune_progress_bar
+                else None,
+            )
+        except Exception as err:  # pragma: no cover - defensive
+            self.log(
+                f"Paired-sample rebenchmark failed ({err!r}); "
+                f"falling back to absolute-median rebenchmark."
+            )
+            return self.run_final_pick_verification(
+                best, top_k=len(candidates), paired=False
+            )
+
+        # paired_results[i] == (absolute median ms, paired delta vs best).
+        for slot_idx, (median_ms, _delta_ms) in enumerate(paired_results):
+            if math.isfinite(median_ms):
+                candidates[slot_idx].perfs.append(median_ms)
+                self.best_perf_so_far = min(self.best_perf_so_far, median_ms)
+
+        # Rank by paired delta (smaller = faster than best), tie-break by median.
+        def _paired_key(slot_idx: int) -> tuple[float, float]:
+            median_ms, delta_ms = paired_results[slot_idx]
+            if not math.isfinite(delta_ms) or not math.isfinite(median_ms):
+                return (inf, inf)
+            return (delta_ms, median_ms)
+
+        best_slot = min(range(len(candidates)), key=_paired_key)
+        best_median, best_delta = paired_results[best_slot]
+        if not math.isfinite(best_delta) or not math.isfinite(best_median):
+            return best
+        best_member = candidates[best_slot]
+        if best_member is not best:
+            self.log(
+                f"Final-pick re-picked {best_member.config} "
+                f"(paired delta {best_delta:+.4f}ms) over {best.config}"
+            )
+        self.best_perf_so_far = min(self.best_perf_so_far, best_median)
+        return best_member
 
 
 def population_statistics(population: list[PopulationMember]) -> str:

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -28,6 +28,7 @@ from torch.utils._pytree import tree_map_only
 from .. import exc
 from .._compat import extract_device
 from .._compat import get_device_name
+from ..runtime.settings import _env_get_int
 from .benchmark_provider import BenchmarkProvider
 from .benchmark_provider import BenchmarkResult
 from .benchmark_provider import LocalBenchmarkProvider
@@ -1202,6 +1203,69 @@ class PopulationBasedSearch(BaseSearch):
         )
         self.log(f"Finishing phase complete: final config={current.config}")
         return current
+
+    def _final_pick_supported(self) -> bool:
+        """True only on Pallas/TPU; final-pick is untested on other backends."""
+        return self.config_spec.backend_name == "pallas"
+
+    def run_final_pick_verification(
+        self,
+        best: PopulationMember,
+        top_k: int | None = None,
+    ) -> PopulationMember:
+        """Re-benchmark the top-``top_k`` candidates once and re-pick the fastest.
+
+        Hardens against the noisy single ``interleaved_bench`` median the search
+        ranks by.  ``top_k`` defaults to ``HELION_AUTOTUNE_FINAL_PICK_TOP_K``
+        (10); returns ``best`` unchanged when ``top_k <= 1`` or < 2 finite.
+        """
+        if top_k is None:
+            top_k = max(0, _env_get_int("HELION_AUTOTUNE_FINAL_PICK_TOP_K", 10))
+        if top_k <= 1:
+            return best
+
+        # Top-k candidates by current perf, ``best`` first so its identity wins
+        # ties when we fall back.
+        candidates: list[PopulationMember] = []
+        seen_ids: set[int] = set()
+        for member in (
+            best,
+            *sorted(
+                (m for m in self.population if math.isfinite(m.perf)),
+                key=performance,
+            ),
+        ):
+            if id(member) in seen_ids:
+                continue
+            seen_ids.add(id(member))
+            candidates.append(member)
+            if len(candidates) >= top_k:
+                break
+        if len(candidates) < 2:
+            return best
+
+        self.rebenchmark(candidates, desc="Final-pick verification")
+        best_member = min(candidates, key=performance)
+        if not math.isfinite(best_member.perf):
+            return best
+        if best_member is not best:
+            self.log(
+                f"Final-pick re-picked {best_member.config} "
+                f"({best_member.perf:.4f}ms) over {best.config}"
+            )
+        self.best_perf_so_far = min(self.best_perf_so_far, best_member.perf)
+        return best_member
+
+    def _finalize(self) -> Config:
+        """Finishing phase + final-pick re-rank; return the chosen config.
+
+        Shared tail of the search ``_autotune`` methods; the final-pick re-rank
+        runs only on TPU/Pallas (see ``_final_pick_supported``).
+        """
+        best = self.run_finishing_phase(self.best, self.finishing_rounds)
+        if self._final_pick_supported():
+            best = self.run_final_pick_verification(best)
+        return best.config
 
 
 def population_statistics(population: list[PopulationMember]) -> str:

--- a/helion/autotuner/benchmarking.py
+++ b/helion/autotuner/benchmarking.py
@@ -291,6 +291,86 @@ def interleaved_bench_generic(
     return [statistics.median(times) for times in all_times]
 
 
+def paired_interleaved_bench(
+    fns: list[Callable[..., object]],
+    reference_fn: Callable[..., object],
+    *,
+    repeat: int,
+    desc: str | None = None,
+) -> list[tuple[float, float]]:
+    """Paired-sample timing: each candidate is paired with ``reference_fn``.
+
+    For every iteration and every candidate ``fns[j]``, the helper times
+    one ``fns[j]()`` call immediately followed by one ``reference_fn()``
+    call (both with per-call ``synchronize_device``).  The candidate and
+    its paired reference time are accumulated together so that any
+    chip-thermal or scheduling drift that affects one call also affects
+    the other inside the same ~microsecond window.
+
+    The returned ``(median_ms, paired_delta_median_ms)`` per fn lets the
+    caller rank by paired delta instead of absolute median.  Ranking by
+    paired delta cancels common-mode drift that accumulates across the
+    ``repeat`` axis (the dominant noise source on noisy TPU pods, per
+    plan.md §2.10 / Deep Replan 6); ranking by absolute median does not.
+
+    Wall-clock based via ``time.perf_counter()`` + ``synchronize_device``
+    so the same helper works for CUDA, Pallas / TPU, CuTe, and any other
+    backend that exposes a device synchronization primitive.
+
+    Args:
+        fns: List of candidate functions to benchmark.
+        reference_fn: Stable reference function (typically the cohort's
+            current best) timed once per candidate per iteration so the
+            paired deltas are one-to-one.
+        repeat: Number of paired iterations per candidate.
+        desc: Optional description for progress bar.
+
+    Returns:
+        A list of ``(median_ms, paired_delta_median_ms)`` tuples, one per
+        candidate in ``fns``.  ``paired_delta_median_ms`` is positive when
+        the candidate is slower than the reference and negative when
+        faster.
+    """
+    # warmup
+    out: object = None
+    for fn in fns:
+        out = fn()
+    out = reference_fn()
+    synchronize_device(out)
+
+    fn_times: list[list[float]] = [[] for _ in range(len(fns))]
+    ref_paired_times: list[list[float]] = [[] for _ in range(len(fns))]
+
+    iterator = iter_with_progress(
+        range(repeat),
+        total=repeat,
+        description=desc,
+        enabled=desc is not None,
+    )
+    for _i in iterator:
+        for j in range(len(fns)):
+            synchronize_device(out)
+            t0 = time.perf_counter()
+            out = fns[j]()
+            synchronize_device(out)
+            t1 = time.perf_counter()
+            out = reference_fn()
+            synchronize_device(out)
+            t2 = time.perf_counter()
+            fn_times[j].append((t1 - t0) * 1000)
+            ref_paired_times[j].append((t2 - t1) * 1000)
+
+    results: list[tuple[float, float]] = []
+    for j in range(len(fns)):
+        candidate_median = statistics.median(fn_times[j])
+        paired_deltas = [
+            c - r for c, r in zip(fn_times[j], ref_paired_times[j], strict=True)
+        ]
+        paired_delta_median = statistics.median(paired_deltas)
+        results.append((candidate_median, paired_delta_median))
+    return results
+
+
 def _summarize_statistics_fallback(
     times: list[float],
     quantiles: list[float] | None,

--- a/helion/autotuner/pattern_search.py
+++ b/helion/autotuner/pattern_search.py
@@ -204,9 +204,8 @@ class PatternSearch(PopulationBasedSearch):
             # Log final statistics for this generation
             self.log(f"Generation {generation} complete:", self.statistics)
 
-        # Run finishing phase to simplify the best configuration
-        best = self.run_finishing_phase(self.best, self.finishing_rounds)
-        return best.config
+        # Finishing phase + (TPU-only) final-pick re-rank.
+        return self._finalize()
 
     def _pattern_search_from(
         self, current: PopulationMember, visited: set[Config]

--- a/helion/autotuner/surrogate_pattern_search.py
+++ b/helion/autotuner/surrogate_pattern_search.py
@@ -481,9 +481,8 @@ class LFBOPatternSearch(PatternSearch):
                 # Fit model
                 self._fit_surrogate()
 
-        # Run finishing phase to simplify the best configuration
-        best = self.run_finishing_phase(self.best, self.finishing_rounds)
-        return best.config
+        # Finishing phase + (TPU-only) final-pick re-rank.
+        return self._finalize()
 
     def _generate_neighbors(self, base: FlatConfig) -> list[FlatConfig]:
         """

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1413,6 +1413,130 @@ class TestPallas(TestCase):
             search.config_spec = SimpleNamespace(backend_name=backend_name)  # pyrefly: ignore[bad-assignment]
             self.assertFalse(search._final_pick_supported())
 
+    def test_pallas_autotuner_final_pick_uses_interleaved_timing(self) -> None:
+        """Final-pick verification ranks by paired delta, not absolute median.
+
+        On a noisy TPU pod the per-call absolute median drifts 10-20% between
+        rebenchmarks, so two near-tied candidates can swap rank.  The paired
+        path times each candidate against the running best in the same window,
+        so common-mode drift cancels in the (candidate - best) delta.
+
+        Scenario: ``[512, 512, 512]`` is intrinsically 5us faster than
+        ``[256, 256, 256]`` (paired delta always +5us for the slow config), but
+        on this rebenchmark a DC drift offset pushed the fast config's absolute
+        median *above* the slow one's (240us vs 200us).  The paired path picks
+        the true-fast config; the legacy absolute-median path mis-ranks and
+        picks the slow one -- so paired timing is both necessary and sufficient.
+        """
+        from unittest.mock import patch
+
+        from helion.autotuner.base_search import PopulationBasedSearch
+        from helion.autotuner.base_search import PopulationMember
+        from helion.runtime.config import Config
+
+        fast_cfg = Config(block_sizes=[512, 512, 512])
+        slow_cfg = Config(block_sizes=[256, 256, 256])
+
+        def fast_fn() -> None:
+            return None
+
+        def slow_fn() -> None:
+            return None
+
+        def make_search() -> tuple[PopulationBasedSearch, PopulationMember]:
+            fast_member = PopulationMember(
+                fn=fast_fn,
+                perfs=[0.200],
+                flat_values=[id(fast_cfg)],
+                config=fast_cfg,
+                status="ok",
+                compile_time=0.0,
+            )
+            slow_member = PopulationMember(
+                fn=slow_fn,
+                perfs=[0.201],
+                flat_values=[id(slow_cfg)],
+                config=slow_cfg,
+                status="ok",
+                compile_time=0.0,
+            )
+            search = PopulationBasedSearch.__new__(PopulationBasedSearch)
+            search.population = [fast_member, slow_member]
+            search.best_perf_so_far = min(m.perf for m in search.population)
+            search.log = lambda *a, **kw: None  # pyrefly: ignore[bad-assignment]
+            return search, fast_member
+
+        # Absolute medians a noisy rebenchmark observes this round: a DC drift
+        # offset inflated the fast config above the slow one (240us vs 200us);
+        # the kernel-intrinsic paired delta still favors fast (slow is +5us).
+        fast_ms, slow_ms = 0.240, 0.200
+
+        def fake_paired(
+            fns: list[Callable[[], object]],
+            reference_fn: Callable[[], object],
+            *,
+            repeat: int,
+            desc: str | None = None,
+        ) -> list[tuple[float, float]]:
+            results: list[tuple[float, float]] = []
+            for fn in fns:
+                inner = getattr(fn, "func", fn)  # unwrap functools.partial
+                if inner is fast_fn:
+                    results.append((fast_ms, 0.0))
+                else:
+                    results.append((slow_ms, 0.005))  # +5us above the reference
+            return results
+
+        class _FakeBenchmarkProvider:
+            mutated_arg_indices: tuple[int, ...] = ()
+
+        class _FakeSettings:
+            autotune_benchmark_fn = None
+            autotune_progress_bar: bool = False
+
+        class _FakeKernel:
+            class env:
+                process_group_name: str | None = None
+
+        # Paired path: populate the real-autotune scaffolding so
+        # ``_paired_rebenchmark_available()`` returns True.
+        search, fast_member = make_search()
+        search.args = ()
+        search.kernel = _FakeKernel()  # pyrefly: ignore[bad-assignment]
+        search.benchmark_provider = _FakeBenchmarkProvider()  # pyrefly: ignore[bad-assignment]
+        search.settings = _FakeSettings()  # pyrefly: ignore[bad-assignment]
+        with patch(
+            "helion.autotuner.base_search.paired_interleaved_bench",
+            side_effect=fake_paired,
+        ):
+            paired_final = search.run_final_pick_verification(fast_member, top_k=5)
+        self.assertEqual(
+            list(paired_final.config["block_sizes"]),
+            [512, 512, 512],
+            "Paired final-pick must pick the true-fast config even when chip "
+            "drift inflates its absolute median above the slow config.",
+        )
+
+        # Legacy (paired=False) path on the same absolute medians picks slow,
+        # because 240us > 200us -- exactly the failure mode paired timing fixes.
+        def fake_rebenchmark(
+            members: list[PopulationMember], *, desc: str = ""
+        ) -> None:
+            for member in members:
+                member.perfs.append(fast_ms if member.config is fast_cfg else slow_ms)
+
+        search, fast_member = make_search()
+        with patch.object(search, "rebenchmark", side_effect=fake_rebenchmark):
+            legacy_final = search.run_final_pick_verification(
+                fast_member, top_k=5, paired=False
+            )
+        self.assertEqual(
+            list(legacy_final.config["block_sizes"]),
+            [256, 256, 256],
+            "Legacy absolute-median path mis-ranks the slow config as best when "
+            "drift flips the absolute median -- why paired timing is needed.",
+        )
+
     def test_bmm(self) -> None:
         """Test BMM with default config — exercises size_matches fix.
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1343,6 +1343,76 @@ class TestPallas(TestCase):
             f"{(reference.float() - baseline_result.float()).abs().max().item()}).",
         )
 
+    def test_pallas_autotuner_final_pick_picks_true_best_on_noisy_initial_rank(
+        self,
+    ) -> None:
+        """Final-pick re-ranks past a noisy initial measurement.
+
+        ``[512, 1024, 512]`` looks fastest on its noisy initial ``perf`` but
+        rebenches slower than ``[512, 512, 512]``, so
+        ``run_final_pick_verification`` must re-pick ``[512, 512, 512]``.
+        """
+        from unittest.mock import patch
+
+        from helion.autotuner.base_search import PopulationBasedSearch
+        from helion.autotuner.base_search import PopulationMember
+        from helion.runtime.config import Config
+
+        def member(block_sizes: list[int], noisy_ms: float) -> PopulationMember:
+            return PopulationMember(
+                fn=lambda *a, **kw: None,
+                perfs=[noisy_ms],
+                flat_values=block_sizes,
+                config=Config(block_sizes=block_sizes),
+                status="ok",
+                compile_time=0.0,
+            )
+
+        # noisy_best wins the noisy initial rank (0.220) but rebenches slowest
+        # (0.232); true_best looks slower initially (0.232) but is truly fastest
+        # (0.180).  true_ms is what the rebenchmark reveals.
+        noisy_best = member([512, 1024, 512], 0.220)
+        true_best = member([512, 512, 512], 0.232)
+        true_ms = {id(noisy_best): 0.232, id(true_best): 0.180}
+
+        search = PopulationBasedSearch.__new__(PopulationBasedSearch)
+        search.population = [noisy_best, true_best]
+        search.best_perf_so_far = min(m.perf for m in search.population)
+        search.log = lambda *a, **kw: None  # pyrefly: ignore[bad-assignment]
+
+        def fake_rebenchmark(
+            to_bench: list[PopulationMember], *, desc: str = ""
+        ) -> None:
+            for m in to_bench:
+                m.perfs.append(true_ms[id(m)])
+
+        with patch.object(search, "rebenchmark", side_effect=fake_rebenchmark):
+            final = search.run_final_pick_verification(noisy_best, top_k=5)
+        self.assertEqual(list(final.config["block_sizes"]), [512, 512, 512])
+
+    def test_pallas_autotuner_final_pick_supported_only_on_pallas_backend(
+        self,
+    ) -> None:
+        """The final-pick re-rank is gated to the Pallas/TPU backend.
+
+        It's only validated on TPU; on Triton/CuTe/Metal (GPU) it would run
+        an untested wall-clock re-rank, so the production call sites
+        (pattern_search / surrogate_pattern_search) skip it via
+        ``_final_pick_supported``.
+        """
+        from types import SimpleNamespace
+
+        from helion.autotuner.base_search import PopulationBasedSearch
+
+        search = PopulationBasedSearch.__new__(PopulationBasedSearch)
+
+        search.config_spec = SimpleNamespace(backend_name="pallas")  # pyrefly: ignore[bad-assignment]
+        self.assertTrue(search._final_pick_supported())
+
+        for backend_name in ("triton", "cute", "metal", "tileir"):
+            search.config_spec = SimpleNamespace(backend_name=backend_name)  # pyrefly: ignore[bad-assignment]
+            self.assertFalse(search._final_pick_supported())
+
     def test_bmm(self) -> None:
         """Test BMM with default config — exercises size_matches fix.
 


### PR DESCRIPTION
Stacked PRs:
 * #2632
 * #2631
 * #2629
 * #2628
 * __->__#2627
 * #2626


--- --- ---

### [autotune] compare each candidate against the current best in the same timing window


Follow-on to the final-verification pass. Instead of timing each candidate
in isolation (absolute numbers drift as the chip heats up), time each one
back-to-back with the current best in the same window and rank by the
difference -- machine-wide drift hits both calls and cancels.

This paired-sample timing is the any-backend fallback; on TPU the next PRs
swap in a direct on-chip measurement, so no config change on its own. Knob:
HELION_AUTOTUNE_FINAL_PICK_PAIRED (default on). Includes a pin test.
