### PR TITLE
[autotune] keep compiler-suggested configs in the running for the final pick

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -708,6 +708,12 @@ class PopulationBasedSearch(BaseSearch):
         super().__init__(kernel, args)
         self.finishing_rounds = finishing_rounds
         self.population: list[PopulationMember] = []
+        # Population members corresponding to compiler-seeded configs from
+        # ``ConfigSpec.compiler_seed_configs``.  Tracked separately so the
+        # final-pick verification phase can re-include them as candidates
+        # even when the surrogate-driven search has pruned them away from
+        # ``self.population``.
+        self._compiler_seed_members: list[PopulationMember] = []
         self._best_available_seed_configs: list[Config] = []
         self.config_gen: ConfigGeneration = self.config_spec.create_config_generation(
             overrides=self.settings.autotune_config_overrides or None,
@@ -748,6 +754,30 @@ class PopulationBasedSearch(BaseSearch):
         """Replace the current best member in the population."""
         idx = min(range(len(self.population)), key=lambda i: self.population[i].perf)
         self.population[idx] = value
+
+    def capture_compiler_seed_members(
+        self, members: Sequence[PopulationMember]
+    ) -> None:
+        """Snapshot which ``members`` came from compiler-seeded configs.
+
+        Called once by ``_autotune`` right after the initial population is
+        constructed.  Looks up the compiler-owned flat configs from
+        ``config_gen.seed_flat_config_pairs()`` and records the matching
+        members on ``self._compiler_seed_members`` so the final-pick
+        verification phase can re-include them even if the search loop
+        prunes them from ``self.population``.
+        """
+        self._compiler_seed_members = []
+        try:
+            seed_pairs = self.config_gen.seed_flat_config_pairs()
+        except Exception:
+            return
+        if not seed_pairs:
+            return
+        seed_flats: list[FlatConfig] = [flat for flat, _config in seed_pairs]
+        for member in members:
+            if member.flat_values in seed_flats:
+                self._compiler_seed_members.append(member)
 
     def benchmark_flat(self, flat_values: FlatConfig) -> PopulationMember:
         """
@@ -1220,9 +1250,10 @@ class PopulationBasedSearch(BaseSearch):
         """Re-benchmark the top-``top_k`` candidates once and re-pick the fastest.
 
         Hardens against the noisy single ``interleaved_bench`` median the search
-        ranks by.  With ``paired`` (default on) each candidate is timed against
-        ``best`` in one window so common-mode drift cancels.  Knobs:
-        ``HELION_AUTOTUNE_FINAL_PICK_TOP_K`` (10), ``..._PAIRED``; returns
+        ranks by.  Compiler-seed members are merged in so a hand-picked seed
+        survives surrogate pruning.  With ``paired`` (default on) each candidate
+        is timed against ``best`` in one window so common-mode drift cancels.
+        Knobs: ``HELION_AUTOTUNE_FINAL_PICK_TOP_K`` (10), ``..._PAIRED``; returns
         ``best`` unchanged when ``top_k <= 1`` or < 2 finite.
         """
         if top_k is None:
@@ -1232,17 +1263,20 @@ class PopulationBasedSearch(BaseSearch):
         if top_k <= 1:
             return best
 
-        # Top-k candidates by current perf, ``best`` first so its identity wins
-        # ties when we fall back.
+        # Top-k by current perf, ``best`` first so its identity wins ties on
+        # fallback.  Merge captured compiler-seed members with the last-gen
+        # population so a hand-picked seed pruned by the surrogate search is
+        # still re-benchmarked here.  ``_compiler_seed_members`` may be absent
+        # when a test builds the search via ``__new__``.
+        compiler_seed_members = getattr(self, "_compiler_seed_members", []) or []
+        candidate_pool: dict[int, PopulationMember] = {}
+        for member in (*self.population, *compiler_seed_members):
+            if math.isfinite(member.perf):
+                candidate_pool.setdefault(id(member), member)
+        scored_population = sorted(candidate_pool.values(), key=performance)
         candidates: list[PopulationMember] = []
         seen_ids: set[int] = set()
-        for member in (
-            best,
-            *sorted(
-                (m for m in self.population if math.isfinite(m.perf)),
-                key=performance,
-            ),
-        ):
+        for member in (best, *scored_population):
             if id(member) in seen_ids:
                 continue
             seen_ids.add(id(member))

--- a/helion/autotuner/pattern_search.py
+++ b/helion/autotuner/pattern_search.py
@@ -155,6 +155,9 @@ class PatternSearch(PopulationBasedSearch):
 
         # again with higher accuracy
         self.rebenchmark_population(self.population, desc="Verifying initial results")
+        # Snapshot compiler-seeded members so they survive the search-loop
+        # pruning into the final-pick verification candidate pool.
+        self.capture_compiler_seed_members(self.population)
         self.population.sort(key=performance)
         starting_points = []
         for member in self.population[: self.copies]:

--- a/helion/autotuner/surrogate_pattern_search.py
+++ b/helion/autotuner/surrogate_pattern_search.py
@@ -406,6 +406,9 @@ class LFBOPatternSearch(PatternSearch):
         check_population_consistency(
             self.population, process_group_name=self.kernel.env.process_group_name
         )
+        # Snapshot compiler-seeded members so they survive the search-loop
+        # pruning into the final-pick verification candidate pool.
+        self.capture_compiler_seed_members(self.population)
         self.population.sort(key=performance)
         starting_points = []
         for member in self.population[: self.copies]:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1537,6 +1537,86 @@ class TestPallas(TestCase):
             "drift flips the absolute median -- why paired timing is needed.",
         )
 
+    def test_pallas_autotuner_compiler_seed_survives_final_pick(self) -> None:
+        """Compiler-seeded members are re-considered during final-pick verification.
+
+        The surrogate-driven search prunes the population between generations, so
+        by the time ``run_final_pick_verification`` fires a compiler-seeded config
+        that looked merely average on its noisy initial bench may be gone from
+        ``self.population``.  ``capture_compiler_seed_members`` snapshots such
+        seeds and merges them back into the verification candidate pool, so a
+        backend's hand-picked seed is re-benched against the search's best even
+        when the search moved away from it.
+        """
+        from unittest.mock import patch
+
+        from helion.autotuner.base_search import PopulationBasedSearch
+        from helion.autotuner.base_search import PopulationMember
+        from helion.runtime.config import Config
+
+        # Last-gen survivors (~0.205 ms) plus a compiler seed that scored a noisy
+        # 0.215 ms initially (so the search dropped it) but rebenches at a
+        # true-fastest 0.190 ms.  (config, noisy initial ms, true rebench ms):
+        last_gen = [
+            (Config(block_sizes=[1024, 256, 1024]), 0.205, 0.204),
+            (Config(block_sizes=[256, 256, 256]), 0.210, 0.209),
+        ]
+        compiler_seed = (
+            Config(
+                block_sizes=[512, 512, 512],
+                pallas_loop_type="emit_pipeline",
+                pallas_pre_broadcast=False,
+            ),
+            0.215,
+            0.190,
+        )
+
+        def make_member(config: Config, noisy_perf: float) -> PopulationMember:
+            return PopulationMember(
+                fn=lambda *a, **kw: None,
+                perfs=[noisy_perf],
+                flat_values=[id(config)],  # opaque -- never read by the test
+                config=config,
+                status="ok",
+                compile_time=0.0,
+            )
+
+        last_gen_members = [make_member(cfg, noisy) for cfg, noisy, _true in last_gen]
+        seed_member = make_member(compiler_seed[0], compiler_seed[1])
+        true_perf_by_id = {
+            id(m): true
+            for m, (_cfg, _noisy, true) in zip(last_gen_members, last_gen, strict=True)
+        }
+        true_perf_by_id[id(seed_member)] = compiler_seed[2]
+
+        search = PopulationBasedSearch.__new__(PopulationBasedSearch)
+        search.population = last_gen_members  # seed NOT in last-gen population
+        search.best_perf_so_far = min(m.perf for m in last_gen_members)
+        search._compiler_seed_members = [seed_member]
+        search.log = lambda *a, **kw: None  # pyrefly: ignore[bad-assignment]
+
+        def fake_rebenchmark(
+            members: list[PopulationMember], *, desc: str = ""
+        ) -> None:
+            for member in members:
+                member.perfs.append(true_perf_by_id[id(member)])
+
+        with patch.object(search, "rebenchmark", side_effect=fake_rebenchmark):
+            initial_best = min(last_gen_members, key=lambda m: m.perf)
+            self.assertEqual(
+                list(initial_best.config["block_sizes"]),
+                [1024, 256, 1024],
+                "Precondition: search's running best is one of the last-gen members.",
+            )
+            final_best = search.run_final_pick_verification(initial_best, top_k=10)
+
+        self.assertEqual(
+            list(final_best.config["block_sizes"]),
+            [512, 512, 512],
+            "Compiler-seeded [512, 512, 512] must be re-benched and re-rank "
+            "ahead of the last-gen best once its true 0.190 ms perf is measured.",
+        )
+
     def test_bmm(self) -> None:
         """Test BMM with default config — exercises size_matches fix.
 


### PR DESCRIPTION
Stacked PRs:
 * #2632
 * #2631
 * #2629
 * __->__#2628
 * #2627
 * #2626


--- --- ---

### [autotune] keep compiler-suggested configs in the running for the final pick


Backends can seed the autotuner with configs they know are good, but the
search prunes aggressively, so a good seed is often dropped before the final
verification pass ever compares it.

This snapshots compiler-seeded configs that produced a valid result and
merges them back into the final-pick candidate pool, so a hand-picked seed
always gets a fair re-benchmarked comparison. It keeps the next matmul PR's
"no-tiling" seed alive long enough to be measured. Includes a pin test.
