### PR TITLE
[pallas] lower bf16/fp16 matmuls through pl.dot on TPU

### DIFF
--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -1117,6 +1117,8 @@ def _pallas_dot(ctx: LoweringContext, node: Node, with_acc: bool) -> ast.AST:
         need_f32_acc=need_f32_acc,
         out_dtype=out_dtype,
         lhs_ndim=lhs_ndim,
+        lhs_dtype=lhs_dtype,
+        rhs_dtype=rhs_dtype,
     )
 
 

--- a/helion/_compiler/matmul_utils.py
+++ b/helion/_compiler/matmul_utils.py
@@ -131,6 +131,27 @@ def _needs_f32_accumulator(lhs_dtype: torch.dtype, rhs_dtype: torch.dtype) -> bo
     return lhs_dtype.itemsize < 4 or rhs_dtype.itemsize < 4
 
 
+def _can_emit_pallas_pl_dot(
+    lhs_ndim: int,
+    lhs_dtype: torch.dtype | None,
+    rhs_dtype: torch.dtype | None,
+) -> bool:
+    """Return True when the Pallas backend should emit ``pl.dot`` instead of
+    ``lax.dot_general``.
+
+    ``pl.dot`` is a Pallas-native 2D dot that maps directly onto the TPU MXU
+    and lowers more efficiently than ``lax.dot_general`` on MXU-legal tiles.
+    Eligible only for 2D bf16/f16 matmuls (the MXU's native input dtypes);
+    BMM (3D), f32, int8 and fp8 stay on ``lax.dot_general``.
+    """
+    if lhs_ndim != 2:
+        return False
+    return lhs_dtype in (torch.bfloat16, torch.float16) and rhs_dtype in (
+        torch.bfloat16,
+        torch.float16,
+    )
+
+
 def _emit_pallas_matmul(
     lhs: ast.AST,
     rhs: ast.AST,
@@ -139,41 +160,32 @@ def _emit_pallas_matmul(
     need_f32_acc: bool = False,
     out_dtype: torch.dtype | None = None,
     lhs_ndim: int = 2,
+    lhs_dtype: torch.dtype | None = None,
+    rhs_dtype: torch.dtype | None = None,
 ) -> ast.AST:
-    """Build a ``lax.dot_general`` AST node for the Pallas backend.
+    """Build a Pallas matmul AST node.
 
-    Parameters
-    ----------
-    lhs, rhs:
-        AST nodes for the left / right operands.
-    acc:
-        Optional AST node for the accumulator (``acc + dot_general(...)``).
-    need_f32_acc:
-        When True, emit ``preferred_element_type=jnp.float32`` and, if
-        *out_dtype* is narrower than f32, append a
-        ``lax.convert_element_type`` cast.
-    out_dtype:
-        Desired output dtype.  Only used when *need_f32_acc* is True to
-        decide whether a cast-back is required.
-    lhs_ndim:
-        Number of dimensions in the left operand (2 for mm, 3 for bmm).
+    Emits ``pl.dot`` for MXU-legal 2D bf16/f16 tiles (see
+    :func:`_can_emit_pallas_pl_dot`); else ``lax.dot_general`` (BMM, f32, int8,
+    fp8).  With ``need_f32_acc`` the dot output is f32 (``dot_general`` gets
+    ``preferred_element_type=jnp.float32``; ``pl.dot`` is already f32 on bf16/f16
+    input), cast back to ``out_dtype`` when that is narrower.
     """
-    if lhs_ndim == 3:
-        dim_numbers = "(((2,), (1,)), ((0,), (0,)))"
-    elif lhs_ndim == 2:
-        dim_numbers = "(((1,), (0,)), ((), ()))"
+    if _can_emit_pallas_pl_dot(lhs_ndim, lhs_dtype, rhs_dtype):
+        dot_expr = expr_from_string("pl.dot({lhs}, {rhs})", lhs=lhs, rhs=rhs)
     else:
-        raise ValueError(f"lhs_ndim must be 2 or 3, got {lhs_ndim}")
+        if lhs_ndim == 3:
+            dim_numbers = "(((2,), (1,)), ((0,), (0,)))"
+        elif lhs_ndim == 2:
+            dim_numbers = "(((1,), (0,)), ((), ()))"
+        else:
+            raise ValueError(f"lhs_ndim must be 2 or 3, got {lhs_ndim}")
 
-    if need_f32_acc:
+        kwargs = [f"dimension_numbers={dim_numbers}"]
+        if need_f32_acc:
+            kwargs.append("preferred_element_type=jnp.float32")
         dot_expr = expr_from_string(
-            f"lax.dot_general({{lhs}}, {{rhs}}, dimension_numbers={dim_numbers}, preferred_element_type=jnp.float32)",
-            lhs=lhs,
-            rhs=rhs,
-        )
-    else:
-        dot_expr = expr_from_string(
-            f"lax.dot_general({{lhs}}, {{rhs}}, dimension_numbers={dim_numbers})",
+            f"lax.dot_general({{lhs}}, {{rhs}}, {', '.join(kwargs)})",
             lhs=lhs,
             rhs=rhs,
         )

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -754,6 +754,8 @@ def _(state: CodegenState) -> object:
         need_f32_acc=need_f32_acc,
         out_dtype=out_dtype,
         lhs_ndim=lhs_proxy.ndim,
+        lhs_dtype=lhs_dtype,
+        rhs_dtype=rhs_dtype,
     )
 
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -100,6 +100,42 @@ def pallas_matmul_broadcast_bias(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_matmul_f32(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    """f32 matmul kernel mirroring the perf harness's helion variant."""
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty([m, n], device=x.device, dtype=torch.float32)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+        out[tile_m, tile_n] = acc
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_matmul_bf16(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    """bf16 matmul kernel mirroring the perf harness's helion variant.
+
+    Used by the pin test that verifies the bf16 2D path emits ``pl.dot``
+    (the Pallas-native MXU primitive used by the hand-written reference
+    kernel in ``examples/pallas_perf/matmul_pallas.py``) rather than the
+    slower ``lax.dot_general`` fallback.
+    """
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty(
+        [m, n], device=x.device, dtype=torch.promote_types(x.dtype, y.dtype)
+    )
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+        out[tile_m, tile_n] = acc
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_bmm(A: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
     b, m, k = A.size()
     b, k, n = B.size()
@@ -1508,6 +1544,62 @@ class TestPallas(TestCase):
             "Compiler-seeded [512, 512, 512] must be re-benched and re-rank "
             "ahead of the last-gen best once its true 0.190 ms perf is measured.",
         )
+
+    def test_pallas_matmul_bf16_emits_pl_dot(self) -> None:
+        """bf16 1024x1024x1024: 2D MXU-legal tile should emit ``pl.dot``.
+
+        The hand-written reference kernel in
+        ``examples/pallas_perf/matmul_pallas.py`` uses ``pl.dot`` for the
+        bf16 square-matmul body; the Mosaic backend lowers it directly to
+        the TPU MXU. The previous Helion path emitted the equivalent
+        ``lax.dot_general(..., preferred_element_type=jnp.float32)``,
+        which the same Mosaic backend serializes through a slower
+        general dot path. The pin asserts:
+
+        * ``pl.dot(`` appears in the generated code (the routing rule
+          fired);
+        * the slower ``lax.dot_general(`` fallback is absent for this
+          2D bf16 tile (i.e. ``preferred_element_type=jnp.float32`` is no
+          longer needed because ``pl.dot`` returns f32 on bf16 inputs
+          automatically).
+
+        The shape is the headline 1024^3 anchor and the block matches
+        ``BLOCK_CONFIGS[1] = (128, 128, 128)`` from
+        ``examples/pallas_perf/matmul_configs.py``.
+        """
+        torch.manual_seed(0)
+        x = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(1024, 1024, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            pallas_matmul_bf16, (x, y), block_sizes=[128, 128, 128]
+        )
+        expected = (x.float() @ y.float()).to(torch.bfloat16)
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+        self.assertIn("pl.dot(", code)
+        self.assertNotIn("lax.dot_general(", code)
+        self.assertNotIn("preferred_element_type=jnp.float32", code)
+
+    def test_pallas_matmul_bmm_stays_on_dot_general(self) -> None:
+        """3D BMM stays on ``lax.dot_general`` (``pl.dot`` is 2D-only).
+
+        ``pl.dot`` rejects non-2D inputs upstream
+        (``jax/_src/pallas/primitives.py``), so BMM kernels must keep
+        using the 3D ``dimension_numbers`` form. The pin guards against a
+        future routing widening that would break 3D paths.
+        """
+        torch.manual_seed(0)
+        a = torch.randn(4, 128, 256, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        b = torch.randn(4, 256, 128, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            pallas_bmm, (a, b), block_sizes=[4, 128, 128, 256]
+        )
+        expected = torch.bmm(a.float(), b.float()).to(torch.bfloat16)
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
+        self.assertIn("lax.dot_general(", code)
+        self.assertIn("preferred_element_type=jnp.float32", code)
+        self.assertNotIn("pl.dot(", code)
 
     def test_bmm(self) -> None:
         """Test BMM with default config — exercises size_matches fix.


### PR DESCRIPTION
Stacked PRs:
 * #2632
 * #2631
 * __->__#2629
 * #2626


--- --- ---

### [pallas] lower bf16/fp16 matmuls through pl.dot on TPU


bf16/fp16 matmuls now lower to Pallas's native matmul (pl.dot) instead of
lax.dot_general, matching the hand-written reference: pl.dot maps onto the
TPU MXU and Mosaic lowers it more efficiently on MXU-legal 2D tiles. BMM,
f32, int8 and fp8 stay on lax.dot_general. Includes a pin test.
