### PR TITLE
[pallas] route whole-matrix matmuls through XLA's lax.dot_general

### DIFF
--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -11,6 +11,8 @@ from .cute import CuteTcgen05ClusterM2Heuristic
 from .cute import CuteTileVecHeuristic
 from .cute import CuteTileVecWarpPerRowHeuristic
 from .cute import CuteTileVecWarpReduceHeuristic
+from .pallas import PallasMatmulF32NoTilingSeedHeuristic
+from .pallas import PallasMatmulNoTilingSeedHeuristic
 from .triton import TritonB200MatmulHeuristic
 from .triton import TritonReductionTileHeuristic
 from .triton import TritonSkinnyGemmHeuristic
@@ -38,6 +40,10 @@ HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
         TritonB200MatmulHeuristic,
         TritonSplitJoinRotateHeuristic,
         TritonReductionTileHeuristic,
+    ),
+    "pallas": (
+        PallasMatmulNoTilingSeedHeuristic,
+        PallasMatmulF32NoTilingSeedHeuristic,
     ),
 }
 

--- a/helion/_compiler/autotuner_heuristics/pallas.py
+++ b/helion/_compiler/autotuner_heuristics/pallas.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import NamedTuple
+
+import torch
+
+from ...runtime.config import Config
+from .common import clamp_block_size_targets
+from .registry import AutotunerHeuristic
+
+if TYPE_CHECKING:
+    from ..compile_environment import CompileEnvironment
+    from ..device_ir import DeviceIR
+
+
+# Square bf16/fp16 cubes that get the no-tiling ``[N, N, N]`` seed (dims per the
+# device-us ablation; ~17% on-device speedup on bf16 1024^3 via prefetch).
+_PALLAS_NO_TILING_DIMS: frozenset[int] = frozenset({1024, 2048, 4096})
+
+# f32 stays pinned to 1024: the ablation showed forced no-tiling regresses
+# ~2-2.5% on 2048/4096 vs the autotuner's tiled picks.
+_PALLAS_F32_NO_TILING_DIMS: frozenset[int] = frozenset({1024})
+
+
+class _PallasMatmulFactDims(NamedTuple):
+    """Static-shape view of a 2D matmul fact (all fields narrowed to ``int``)."""
+
+    m: int
+    k: int
+    n: int
+    m_block_id: int
+    k_block_id: int
+    n_block_id: int
+
+
+_BF16_DTYPES: tuple[torch.dtype, ...] = (torch.bfloat16, torch.float16)
+_F32_DTYPES: tuple[torch.dtype, ...] = (torch.float32,)
+
+
+def _pallas_matmul_seed_dims_or_none(
+    env: CompileEnvironment,
+    *,
+    allowed_dtypes: tuple[torch.dtype, ...] = _BF16_DTYPES,
+) -> _PallasMatmulFactDims | None:
+    """Return the single 2D matmul fact's static dims, or ``None``.
+
+    Shared eligibility gate: exactly one matmul fact, 2D x 2D, same dtype in
+    ``allowed_dtypes`` (default bf16/fp16; pass ``(float32,)`` for f32), all
+    dims and block-ids known.
+    """
+    facts = env.config_spec.matmul_facts
+    if len(facts) != 1:
+        return None
+    fact = facts[0]
+    if fact.lhs_ndim != 2 or fact.rhs_ndim != 2:
+        return None
+    if fact.lhs_dtype not in allowed_dtypes:
+        return None
+    if fact.rhs_dtype != fact.lhs_dtype:
+        return None
+    if (
+        fact.static_m is None
+        or fact.static_n is None
+        or fact.static_k is None
+        or fact.m_block_id is None
+        or fact.n_block_id is None
+        or fact.k_block_id is None
+    ):
+        return None
+    return _PallasMatmulFactDims(
+        m=fact.static_m,
+        k=fact.static_k,
+        n=fact.static_n,
+        m_block_id=fact.m_block_id,
+        k_block_id=fact.k_block_id,
+        n_block_id=fact.n_block_id,
+    )
+
+
+def _pallas_matmul_supports_loop_type_and_pre_broadcast(
+    env: CompileEnvironment,
+) -> bool:
+    spec = env.config_spec
+    return spec.supports_config_key("pallas_loop_type") and spec.supports_config_key(
+        "pallas_pre_broadcast"
+    )
+
+
+class _PallasNoTilingSeedHeuristic(AutotunerHeuristic):
+    """Seed ``block_sizes == [N, N, N]`` for a square matmul whose dim is in
+    ``_dims``, so the backend lowers via ``lax.dot_general`` instead of
+    ``pl.pallas_call`` (see ``PallasBackend._detect_matmul_dot_general_lowering``)
+    -- the former is XLA-visible, so ``cross_program_prefetch`` applies.  It falls
+    back to ``pl.pallas_call`` when the autotuner picks a tiled config.  Subclasses
+    set ``_allowed_dtypes`` and ``_dims``.
+    """
+
+    backend = "pallas"
+    _allowed_dtypes: tuple[torch.dtype, ...]
+    _dims: frozenset[int]
+
+    @classmethod
+    def _seed_block_sizes(cls, env: CompileEnvironment) -> list[int] | None:
+        """The ``[N, N, N]`` no-tiling block sizes for an eligible matmul, else None."""
+        dims = _pallas_matmul_seed_dims_or_none(env, allowed_dtypes=cls._allowed_dtypes)
+        if dims is None or not (dims.m == dims.k == dims.n) or dims.m not in cls._dims:
+            return None
+        return clamp_block_size_targets(
+            env,
+            [
+                (dims.m_block_id, dims.m, dims.m),
+                (dims.k_block_id, dims.k, dims.k),
+                (dims.n_block_id, dims.n, dims.n),
+            ],
+        )
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        return cls._seed_block_sizes(
+            env
+        ) is not None and _pallas_matmul_supports_loop_type_and_pre_broadcast(env)
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        block_sizes = cls._seed_block_sizes(env)
+        if block_sizes is None:
+            return None
+        return Config(
+            block_sizes=block_sizes,
+            pallas_loop_type="unroll",
+            pallas_pre_broadcast=True,
+        )
+
+
+class PallasMatmulNoTilingSeedHeuristic(_PallasNoTilingSeedHeuristic):
+    """bf16/fp16 square cubes in ``_PALLAS_NO_TILING_DIMS``."""
+
+    name = "pallas_matmul_no_tiling_seed"
+    _allowed_dtypes = _BF16_DTYPES
+    _dims = _PALLAS_NO_TILING_DIMS
+
+
+class PallasMatmulF32NoTilingSeedHeuristic(_PallasNoTilingSeedHeuristic):
+    """f32 square cubes in ``_PALLAS_F32_NO_TILING_DIMS`` (narrower than bf16 --
+    the ablation showed forced no-tiling regresses on f32 2048/4096)."""
+
+    name = "pallas_matmul_f32_no_tiling_seed"
+    _allowed_dtypes = _F32_DTYPES
+    _dims = _PALLAS_F32_NO_TILING_DIMS

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -2098,6 +2098,140 @@ class PallasBackend(Backend):
 
         return result or None
 
+    def _detect_matmul_dot_general_lowering(
+        self,
+        *,
+        sorted_args: list[Argument] | None,
+        config: Config,
+        output_indices: list[int],
+        inplace_indices: list[int],
+        block_spec_info: object,
+    ) -> dict[str, object] | None:
+        """Detect a pure-matmul, no-tiling kernel the launcher can lower as
+        ``jax.jit(lax.dot_general(...))`` instead of ``pl.pallas_call(...)``.
+
+        Eligible when: 2 input tensors + 1 output-only tensor; all 2D with
+        matching M/K/N contiguous layout (BMM not covered yet); the device IR
+        has one ``aten.mm``/``addmm`` family op; and the picked block sizes
+        cover every dim (single launch, no inner K tile).  Returns the spec
+        dict consumed by ``_build_matmul_dot_general_jit_fn``, else ``None``.
+        """
+        from .compile_environment import CompileEnvironment
+        from .device_function import DeviceFunction
+        from .device_function import TensorArg
+        from .host_function import HostFunction
+
+        if sorted_args is None or not output_indices:
+            return None
+        # Pure-output kernels only (no in-place mutation, single output).
+        if inplace_indices or len(output_indices) != 1:
+            return None
+
+        # Exactly 2 inputs + 1 output, all tensors (a scalar arg means it isn't
+        # a pure ``out = matmul(x, y)``).
+        tensor_positions = [
+            i for i, arg in enumerate(sorted_args) if isinstance(arg, TensorArg)
+        ]
+        if len(sorted_args) != 3 or len(tensor_positions) != 3:
+            return None
+
+        out_pos = output_indices[0]
+        input_positions = [p for p in tensor_positions if p != out_pos]
+        if len(input_positions) != 2:
+            return None
+
+        lhs_arg = sorted_args[input_positions[0]]
+        rhs_arg = sorted_args[input_positions[1]]
+        out_arg = sorted_args[out_pos]
+        assert isinstance(lhs_arg, TensorArg)
+        assert isinstance(rhs_arg, TensorArg)
+        assert isinstance(out_arg, TensorArg)
+        lhs_t = lhs_arg.fake_value
+        rhs_t = rhs_arg.fake_value
+        out_t = out_arg.fake_value
+        # 2D matmul, matching contraction dim, statically-known shapes.
+        if lhs_t.ndim != 2 or rhs_t.ndim != 2 or out_t.ndim != 2:
+            return None
+        try:
+            m = int(lhs_t.shape[0])
+            k_lhs = int(lhs_t.shape[1])
+            k_rhs = int(rhs_t.shape[0])
+            n = int(rhs_t.shape[1])
+            out_m = int(out_t.shape[0])
+            out_n = int(out_t.shape[1])
+        except (TypeError, ValueError):
+            return None
+        if k_lhs != k_rhs or out_m != m or out_n != n:
+            return None
+
+        # The device IR must contain an aten.mm/addmm/bmm family op
+        # (via the shared ``_loop_contains_matmul`` predicate).
+        device_fn = DeviceFunction.current()
+        device_ir = HostFunction.current().device_ir
+        if not device_ir.grid_block_ids:
+            return None
+        # Any root-grid loop containing a matmul qualifies.
+        matmul_present = any(
+            _loop_contains_matmul(device_fn, list(grid_block_ids))
+            for grid_block_ids in device_ir.grid_block_ids
+        )
+        if not matmul_present:
+            return None
+
+        # Orient to lhs=(M, K), rhs=(K, N); the user may have written
+        # ``f(y, x) -> x @ y``. For all-equal dims either ordering is the same.
+        if lhs_t.shape == (m, k_lhs) and rhs_t.shape == (k_lhs, n):
+            lhs_arg_pos, rhs_arg_pos = input_positions
+            lhs_resolved, rhs_resolved = lhs_t, rhs_t
+        elif lhs_t.shape == (k_lhs, n) and rhs_t.shape == (m, k_lhs):
+            rhs_arg_pos, lhs_arg_pos = input_positions
+            lhs_resolved, rhs_resolved = rhs_t, lhs_t
+        else:
+            return None
+
+        # Every block size must be >= max(M, N, K): a smaller block means a
+        # multi-launch (tiled) kernel, not the no-tiling case.
+        env = CompileEnvironment.current()
+        max_dim = max(m, k_lhs, n)
+        for bsi in env.block_sizes:
+            if bsi is None:  # type: ignore[unreachable]
+                continue
+            try:
+                bs = bsi.from_config(config)
+            except Exception:
+                return None
+            if not isinstance(bs, int) or bs < max_dim:
+                return None
+
+        # Every tensor must be fully untiled (all grid_dims None); outer-grid
+        # BlockSpecs still need pl.pallas_call.
+        if block_spec_info is None or not isinstance(block_spec_info, list):
+            return None
+        for pos in (input_positions[0], input_positions[1], out_pos):
+            if pos >= len(block_spec_info):
+                return None
+            entry = block_spec_info[pos]
+            if entry is None:
+                return None
+            block_shape, grid_dims = entry
+            if any(gd is not None for gd in grid_dims):
+                return None
+
+        # All checks passed; build the launcher spec. bf16/fp16 output from an
+        # f32 accumulator needs preferred f32 + cast-back; f32 is already f32.
+        f32_acc = out_t.dtype in (torch.bfloat16, torch.float16)
+        # Map positions to the launcher's tensor-arg order (sorted non-output
+        # positions; see ``_pallas_prepare_args``).
+        non_output_positions = sorted(p for p in tensor_positions if p != out_pos)
+        return {
+            "lhs_tensor_arg_index": non_output_positions.index(lhs_arg_pos),
+            "rhs_tensor_arg_index": non_output_positions.index(rhs_arg_pos),
+            "lhs_dtype": self.dtype_str(lhs_resolved.dtype),
+            "rhs_dtype": self.dtype_str(rhs_resolved.dtype),
+            "out_dtype": self.dtype_str(out_t.dtype),
+            "f32_accumulator": bool(f32_acc),
+        }
+
     def build_launcher_args(
         self,
         args: list[str],
@@ -2248,6 +2382,21 @@ class PallasBackend(Backend):
 
         if CompileEnvironment.current().settings.pallas_interpret:
             launcher_args.append("_pallas_interpret=True")
+
+        # No-tiling pure 2D matmul: emit ``_matmul_dot_general=...`` so the
+        # launcher uses ``jax.jit(lax.dot_general(...))`` instead of
+        # ``pl.pallas_call(...)``. XLA can then attach cross_program_prefetch,
+        # closing the ~12% gap to ``jnp.matmul`` that ``tpu_custom_call``
+        # opacity imposes. Falls back silently when ineligible.
+        matmul_spec = self._detect_matmul_dot_general_lowering(
+            sorted_args=sorted_args,
+            config=config,
+            output_indices=output_indices,
+            inplace_indices=inplace_indices,
+            block_spec_info=block_spec_info,
+        )
+        if matmul_spec is not None:
+            launcher_args.append(f"_matmul_dot_general={matmul_spec!r}")
 
         return launcher_args
 

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -1276,6 +1276,48 @@ def _pallas_apply_ds_padding(
     return tuple(args_list), orig_output_tensors
 
 
+def _build_matmul_dot_general_jit_fn(
+    spec: dict[str, object],
+) -> Callable[..., object]:
+    """Build a ``jax.jit(lax.dot_general)`` wrapper replacing the
+    ``pl.pallas_call`` for a single-launch (no-tiling) Pallas matmul.
+
+    Same call signature as the ``pl.pallas_call`` it replaces, so torch_tpu's
+    dispatch is unchanged.  XLA sees a plain ``dot_general`` op (so
+    ``cross_program_prefetch_index`` is reachable), bypassing the Pallas
+    ``custom_call`` opacity that blocks the prefetch planner.  ``spec`` (from
+    ``_detect_matmul_dot_general_lowering``) carries the lhs/rhs arg positions
+    and the f32-accumulator flag.
+    """
+    import jax
+    import jax.lax as lax
+    import jax.numpy as jnp
+
+    out_dtype_str = cast("str", spec["out_dtype"])
+    out_jnp_dtype = cast("Any", _pallas_jnp_dtype_map().get(out_dtype_str, jnp.float32))
+    f32_accumulator = bool(spec.get("f32_accumulator"))
+    lhs_idx = int(cast("int", spec["lhs_tensor_arg_index"]))
+    rhs_idx = int(cast("int", spec["rhs_tensor_arg_index"]))
+
+    # Accumulate in f32 and cast back only when the output is narrower than f32
+    # (bf16/fp16 out); otherwise accumulate straight into the output dtype.
+    needs_cast = f32_accumulator and out_jnp_dtype is not jnp.float32
+    preferred = jnp.float32 if needs_cast else out_jnp_dtype
+
+    def matmul_fn(*tensor_inputs: Any) -> Any:  # noqa: ANN401
+        result = lax.dot_general(
+            tensor_inputs[lhs_idx],
+            tensor_inputs[rhs_idx],
+            dimension_numbers=(((1,), (0,)), ((), ())),
+            preferred_element_type=preferred,
+        )
+        if needs_cast:
+            result = lax.convert_element_type(result, out_jnp_dtype)
+        return result
+
+    return cast("Callable[..., object]", jax.jit(matmul_fn))
+
+
 def default_pallas_launcher(
     pallas_kernel: object,
     grid: tuple[int, ...],
@@ -1286,6 +1328,7 @@ def default_pallas_launcher(
     _smem_arg_indices: list[int] | None = None,
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _pallas_interpret: bool | None = None,
+    _matmul_dot_general: dict[str, object] | None = None,
     **kwargs: object,
 ) -> object:
     """Default launcher for Pallas kernels on TPU (or CPU with interpret=True).
@@ -1377,23 +1420,29 @@ def default_pallas_launcher(
 
         out_shape_arg = out_shapes if len(out_shapes) > 1 else out_shapes[0]
 
-        estimated_vmem = _estimate_pallas_vmem_bytes(
-            pl,
-            pltpu,
-            in_specs,
-            out_specs,
-            None,
-            spec_args,
-            tensor_arg_indices,
-            _output_indices,
-            pallas_aliases,
-        )
-        vmem_limit_bytes = _get_vmem_limit_bytes(pltpu)
-        if estimated_vmem > vmem_limit_bytes:
-            raise RuntimeError(
-                f"XLA:TPU compile permanent error. Ran out of memory in memory space vmem. "
-                f"Estimated {estimated_vmem / 1e6:.2f}MB exceeds {vmem_limit_bytes / 1e6:.2f}MB vmem capacity."
+        # The VMEM estimate only applies to the ``pl.pallas_call`` lowering.
+        # The ``jax.jit(lax.dot_general)`` path doesn't allocate VMEM the
+        # same way (XLA's planner streams the contraction).  Skipping the
+        # check for that path lets large no-tiling configs reach the
+        # dot_general substitution below.
+        if _matmul_dot_general is None:
+            estimated_vmem = _estimate_pallas_vmem_bytes(
+                pl,
+                pltpu,
+                in_specs,
+                out_specs,
+                None,
+                spec_args,
+                tensor_arg_indices,
+                _output_indices,
+                pallas_aliases,
             )
+            vmem_limit_bytes = _get_vmem_limit_bytes(pltpu)
+            if estimated_vmem > vmem_limit_bytes:
+                raise RuntimeError(
+                    f"XLA:TPU compile permanent error. Ran out of memory in memory space vmem. "
+                    f"Estimated {estimated_vmem / 1e6:.2f}MB exceeds {vmem_limit_bytes / 1e6:.2f}MB vmem capacity."
+                )
 
         pallas_call_kwargs: dict[str, object] = {
             "out_shape": out_shape_arg,
@@ -1409,10 +1458,16 @@ def default_pallas_launcher(
                 dimension_semantics=dimension_semantics,
             )
 
-        jit_fn = pl.pallas_call(
-            reordered_kernel,  # pyrefly: ignore[bad-argument-type]
-            **pallas_call_kwargs,  # type: ignore[arg-type]
-        )
+        if _matmul_dot_general is not None:
+            # Substitute ``lax.dot_general`` for ``pl.pallas_call`` on
+            # no-tiling matmul configs so XLA sees a regular ``dot`` and
+            # can attach ``cross_program_prefetch_index``.
+            jit_fn = _build_matmul_dot_general_jit_fn(_matmul_dot_general)
+        else:
+            jit_fn = pl.pallas_call(
+                reordered_kernel,  # pyrefly: ignore[bad-argument-type]
+                **pallas_call_kwargs,  # type: ignore[arg-type]
+            )
 
         jax_callable = _pallas_build_callable(
             pallas_kernel,
@@ -1489,6 +1544,7 @@ def default_pallas_pipeline_launcher(
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _smem_arg_indices: list[int] | None = None,
     _pallas_interpret: bool | None = None,
+    _matmul_dot_general: dict[str, object] | None = None,
     **kwargs: object,
 ) -> object:
     """Launcher for Pallas kernels using PrefetchScalarGridSpec with scratch memory.
@@ -1606,23 +1662,27 @@ def default_pallas_pipeline_launcher(
             grid=grid,
         )
 
-        estimated_vmem = _estimate_pallas_vmem_bytes(
-            pl,
-            pltpu,
-            in_specs_list,
-            out_specs,
-            scratch_shapes,
-            spec_args,
-            tensor_arg_indices,
-            _output_indices,
-            pallas_aliases,
-        )
-        vmem_limit_bytes = _get_vmem_limit_bytes(pltpu)
-        if estimated_vmem > vmem_limit_bytes:
-            raise RuntimeError(
-                f"XLA:TPU compile permanent error. Ran out of memory in memory space vmem. "
-                f"Estimated {estimated_vmem / 1e6:.2f}MB exceeds {vmem_limit_bytes / 1e6:.2f}MB vmem capacity."
+        # The VMEM-estimate check doesn't apply to the
+        # ``jax.jit(lax.dot_general)`` path, which doesn't go through
+        # ``pl.pallas_call``.
+        if _matmul_dot_general is None:
+            estimated_vmem = _estimate_pallas_vmem_bytes(
+                pl,
+                pltpu,
+                in_specs_list,
+                out_specs,
+                scratch_shapes,
+                spec_args,
+                tensor_arg_indices,
+                _output_indices,
+                pallas_aliases,
             )
+            vmem_limit_bytes = _get_vmem_limit_bytes(pltpu)
+            if estimated_vmem > vmem_limit_bytes:
+                raise RuntimeError(
+                    f"XLA:TPU compile permanent error. Ran out of memory in memory space vmem. "
+                    f"Estimated {estimated_vmem / 1e6:.2f}MB exceeds {vmem_limit_bytes / 1e6:.2f}MB vmem capacity."
+                )
 
         pallas_call_kwargs: dict[str, object] = {
             "out_shape": out_shape_arg,
@@ -1634,10 +1694,14 @@ def default_pallas_pipeline_launcher(
         if interpret:
             pallas_call_kwargs["interpret"] = True
 
-        jit_fn = pl.pallas_call(
-            reordered_kernel,  # pyrefly: ignore[bad-argument-type]
-            **pallas_call_kwargs,  # type: ignore[arg-type]
-        )
+        if _matmul_dot_general is not None:
+            # Substitute ``lax.dot_general`` on no-tiling matmul configs.
+            jit_fn = _build_matmul_dot_general_jit_fn(_matmul_dot_general)
+        else:
+            jit_fn = pl.pallas_call(
+                reordered_kernel,  # pyrefly: ignore[bad-argument-type]
+                **pallas_call_kwargs,  # type: ignore[arg-type]
+            )
 
         jax_callable = _pallas_build_callable(
             pallas_kernel,

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1469,6 +1469,56 @@ class TestPallas(TestCase):
             final = search.run_final_pick_verification(noisy_best, top_k=5)
         self.assertEqual(list(final.config["block_sizes"]), [512, 512, 512])
 
+    def test_pallas_matmul_bf16_no_tiling_seed_covers_large_cubes(self) -> None:
+        """No-tiling seed fires on each bf16 cube in ``_PALLAS_NO_TILING_DIMS``.
+
+        Per cube N, ``PallasMatmulNoTilingSeedHeuristic`` is eligible and plants
+        the ``[N, N, N] unroll pb=True`` compiler seed; a cube outside the set
+        (256) is refused so the seed stays scoped to ablation-validated shapes.
+        """
+        from helion._compiler.autotuner_heuristics.pallas import _PALLAS_NO_TILING_DIMS
+        from helion._compiler.autotuner_heuristics.pallas import (
+            PallasMatmulNoTilingSeedHeuristic,
+        )
+
+        self.assertEqual(sorted(_PALLAS_NO_TILING_DIMS), [1024, 2048, 4096])
+
+        for dim in sorted(_PALLAS_NO_TILING_DIMS):
+            x = torch.empty(dim, dim, device=DEVICE, dtype=torch.bfloat16)
+            y = torch.empty(dim, dim, device=DEVICE, dtype=torch.bfloat16)
+            bound = pallas_matmul_bf16.bind((x, y))
+
+            self.assertTrue(
+                PallasMatmulNoTilingSeedHeuristic.is_eligible(
+                    bound.env, bound.host_function.device_ir
+                ),
+                f"heuristic must fire on bf16 {dim}-cube",
+            )
+            seeded = [
+                (
+                    tuple(cfg.config.get("block_sizes", ())),
+                    cfg.config.get("pallas_loop_type"),
+                    cfg.config.get("pallas_pre_broadcast"),
+                )
+                for cfg in bound.config_spec.compiler_seed_configs
+            ]
+            self.assertIn(
+                ((dim, dim, dim), "unroll", True),
+                seeded,
+                f"compiler seeds must include the no-tiling entry on bf16 {dim}-cube",
+            )
+
+        # 256-cube is outside the set, so the heuristic must refuse it.
+        small_x = torch.empty(256, 256, device=DEVICE, dtype=torch.bfloat16)
+        small_y = torch.empty(256, 256, device=DEVICE, dtype=torch.bfloat16)
+        small_bound = pallas_matmul_bf16.bind((small_x, small_y))
+        self.assertFalse(
+            PallasMatmulNoTilingSeedHeuristic.is_eligible(
+                small_bound.env, small_bound.host_function.device_ir
+            ),
+            "heuristic must refuse cubes outside _PALLAS_NO_TILING_DIMS",
+        )
+
     def test_pallas_autotuner_compiler_seed_survives_final_pick(self) -> None:
         """Compiler-seeded members are re-considered during final-pick.
 
@@ -1600,6 +1650,84 @@ class TestPallas(TestCase):
         self.assertIn("lax.dot_general(", code)
         self.assertIn("preferred_element_type=jnp.float32", code)
         self.assertNotIn("pl.dot(", code)
+
+    def test_pallas_matmul_dot_general_lowering_fires_on_no_tiling(self) -> None:
+        """No-tiling 2-input matmul emits ``lax.dot_general``, not ``pl.pallas_call``.
+
+        Spies on ``_build_matmul_dot_general_jit_fn``: it runs once on first
+        compile (not on cache-hit repeats) and the output matches the
+        ``pl.pallas_call`` path.
+        """
+        from unittest.mock import patch
+
+        from helion import runtime as helion_runtime
+        from helion.runtime.config import Config
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def _matmul_dot_general_pin(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty(
+                [m, n],
+                device=x.device,
+                dtype=torch.promote_types(x.dtype, y.dtype),
+            )
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc
+            return out
+
+        torch.manual_seed(0)
+        x = torch.randn(256, 256, device=DEVICE, dtype=torch.bfloat16)
+        torch.manual_seed(1)
+        y = torch.randn(256, 256, device=DEVICE, dtype=torch.bfloat16)
+
+        # Force the no-tiling config (block_sizes match input dims).
+        bound = _matmul_dot_general_pin.bind((x, y))
+        no_tiling_cfg = Config(block_sizes=[256, 256, 256])
+
+        with patch.object(
+            helion_runtime,
+            "_build_matmul_dot_general_jit_fn",
+            wraps=helion_runtime._build_matmul_dot_general_jit_fn,
+        ) as build_spy:
+            compiled_fn = bound.compile_config(no_tiling_cfg)
+            result_no_tiling = compiled_fn(x, y)
+            for _ in range(3):
+                compiled_fn(x, y)
+        self.assertEqual(
+            build_spy.call_count,
+            1,
+            "Pure matmul + no-tiling config must lower via ``lax.dot_general`` "
+            "exactly once (first cache-build); cache hits must not rebuild.",
+        )
+
+        # Tiled config must keep the pl.pallas_call path (builder not run), and
+        # its output must match the no-tiling dot_general path within bf16 tol.
+        bound_ref = _matmul_dot_general_pin.bind((x, y))
+        tiled_cfg = Config(block_sizes=[128, 128, 128])
+        with patch.object(
+            helion_runtime,
+            "_build_matmul_dot_general_jit_fn",
+            wraps=helion_runtime._build_matmul_dot_general_jit_fn,
+        ) as build_spy_tiled:
+            compiled_ref = bound_ref.compile_config(tiled_cfg)
+            result_tiled = compiled_ref(x, y)
+        self.assertEqual(
+            build_spy_tiled.call_count,
+            0,
+            "tiled config (block_size < input_dim) must not run the dot_general builder",
+        )
+        max_abs_diff = (
+            (result_no_tiling.float() - result_tiled.float()).abs().max().item()
+        )
+        self.assertLess(
+            max_abs_diff,
+            5e-2,
+            f"dot_general output diverged from pallas_call by {max_abs_diff}",
+        )
 
     def test_bmm(self) -> None:
         """Test BMM with default config — exercises size_matches fix.


### PR DESCRIPTION
Stacked PRs:
 * #2632
 * __->__#2631
 * #2629
 * #2626


--- --- ---

### [pallas] route whole-matrix matmuls through XLA's lax.dot_general


When the autotuner picks a config whose tile covers the whole matrix (the
"no-tiling" case), lower the matmul through XLA's lax.dot_general instead of
an opaque custom Pallas call. XLA can then see the matmul and apply
cross-program prefetch (overlap loading the next input with compute), which
the opaque path can't. A compiler seed plants this whole-matrix config so the
autotuner considers it.

Measured (TPU v7, on-chip us, median of 5 seeds):
- bf16 1024^3: 6.65 -> 6.20us (0.84x -> 0.90x vs JAX)
- bf16 2048^3: 25.35 -> 24.47us (0.90x -> 0.93x vs JAX)
Closes most of the gap to JAX; the next PR closes the rest. Includes pin tests.
