### PR TITLE
[autotune] rank TPU matmul candidates by true on-chip time (the big win)

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -345,6 +345,18 @@ class Backend(abc.ABC):
         """
         return None
 
+    def get_paired_device_micros_bench(
+        self,
+    ) -> Callable[..., list[tuple[float, float]]] | None:
+        """Paired device-µs bench for the autotune final-pick re-rank, or None.
+
+        Backends that can cheaply report per-call on-device µs override this to
+        return a callable ``fn(candidates, reference, *, desc) ->
+        list[(candidate_device_micros, paired_delta_micros)]``. The default returns None,
+        leaving final-pick on its wall-clock rebench.
+        """
+        return None
+
     def supports_precompile(self) -> bool:
         """Whether this backend supports subprocess precompilation.
 
@@ -1911,6 +1923,18 @@ class PallasBackend(Backend):
         from ..autotuner.benchmarking import interleaved_bench_generic
 
         return interleaved_bench_generic
+
+    def get_paired_device_micros_bench(
+        self,
+    ) -> Callable[..., list[tuple[float, float]]] | None:
+        """Pallas ``jax.profiler`` device-µs bench for the final-pick re-rank.
+
+        Returns None (keeping the wall-clock rebench) when the user opts out via
+        ``HELION_AUTOTUNE_PALLAS_RANK_BY=wall_time`` or ``jax`` is unavailable.
+        """
+        from ..autotuner.benchmarking import make_pallas_paired_device_micros_bench
+
+        return make_pallas_paired_device_micros_bench()
 
     def supports_precompile(self) -> bool:
         return False

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -1289,6 +1289,13 @@ class PopulationBasedSearch(BaseSearch):
         if len(candidates) < 2:
             return best
 
+        # TPU/Pallas: re-rank by per-call on-device µs when available; else fall
+        # back to the absolute-median rebench.
+        device_micros_bench = self._resolve_device_micros_paired_bench()
+        if device_micros_bench is not None:
+            return self._run_final_pick_verification_device_micros(
+                best, candidates, device_micros_bench=device_micros_bench
+            )
         return self._rebench_and_pick(best, candidates)
 
     def _rebench_and_pick(
@@ -1317,6 +1324,91 @@ class PopulationBasedSearch(BaseSearch):
         if self._final_pick_supported():
             best = self.run_final_pick_verification(best)
         return best.config
+
+    def _resolve_device_micros_paired_bench(
+        self,
+    ) -> Callable[..., list[tuple[float, float]]] | None:
+        """Paired device-µs bench from the backend, or None.
+
+        Pallas/TPU returns a ``jax.profiler`` closure (per-call on-chip µs) when
+        ``static_shapes`` is on and ``HELION_AUTOTUNE_PALLAS_RANK_BY=device_time`` (the
+        default); other backends and the ``wall_time`` opt-out return None.
+        """
+        # settings/config_spec are unset on the minimal final-pick test scaffolds;
+        # real searches always have them.
+        settings = getattr(self, "settings", None)
+        config_spec = getattr(self, "config_spec", None)
+        if settings is None or config_spec is None or not settings.static_shapes:
+            return None
+        return config_spec.backend.get_paired_device_micros_bench()
+
+    def _run_final_pick_verification_device_micros(
+        self,
+        best: PopulationMember,
+        candidates: list[PopulationMember],
+        *,
+        device_micros_bench: Callable[..., list[tuple[float, float]]],
+    ) -> PopulationMember:
+        """Re-rank the cohort by per-call on-chip µs instead of wall-clock.
+
+        ``device_micros_bench`` returns ``(device_micros, delta-vs-best)`` per candidate;
+        per-call device µs isn't masked by the ~125µs dispatch overhead. Picks the
+        smallest delta (tie-broken by absolute device µs). Device µs is not folded
+        into ``perfs`` (those are wall-clock ms). Falls back to the absolute-median
+        rebench on any error.
+        """
+        if len(self.benchmark_provider.mutated_arg_indices) > 0:
+            benchmark_args = _clone_args(
+                self.args,
+                self.kernel.env.process_group_name,
+                idx_to_clone=self.benchmark_provider.mutated_arg_indices,
+            )
+        else:
+            benchmark_args = self.args
+        candidate_fns: list[Callable[..., object]] = [
+            functools.partial(member.fn, *benchmark_args) for member in candidates
+        ]
+        reference_fn: Callable[..., object] = functools.partial(
+            best.fn, *benchmark_args
+        )
+        desc = (
+            "Final-pick verification device_micros"
+            if self.settings.autotune_progress_bar
+            else None
+        )
+        try:
+            results = device_micros_bench(candidate_fns, reference_fn, desc=desc)
+        except Exception as err:
+            self.log(f"Device-µs re-rank failed ({err!r}); falling back to rebench.")
+            return self._rebench_and_pick(best, candidates)
+
+        # results[i] == (absolute device µs, paired delta vs best).
+        device_micros_by_slot = [device_micros for device_micros, _ in results]
+        delta_by_slot = [delta for _, delta in results]
+        if not any(math.isfinite(u) and math.isfinite(d) for u, d in results):
+            self.log(
+                "Device-µs re-rank got no finite readings; falling back to rebench."
+            )
+            return self._rebench_and_pick(best, candidates)
+
+        def _device_key(slot: int) -> tuple[float, float]:
+            delta, device_micros = delta_by_slot[slot], device_micros_by_slot[slot]
+            if not math.isfinite(delta) or not math.isfinite(device_micros):
+                return (inf, inf)
+            return (delta, device_micros)
+
+        best_slot = min(range(len(candidates)), key=_device_key)
+        if not math.isfinite(delta_by_slot[best_slot]):
+            return best
+        best_member = candidates[best_slot]
+
+        if best_member is not best:
+            self.log(
+                f"Final-pick re-picked {best_member.config} (delta "
+                f"{delta_by_slot[best_slot]:+.3f}µs, absolute "
+                f"{device_micros_by_slot[best_slot]:.3f}µs) over {best.config}"
+            )
+        return best_member
 
 
 def population_statistics(population: list[PopulationMember]) -> str:

--- a/helion/autotuner/benchmarking.py
+++ b/helion/autotuner/benchmarking.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import contextlib
 import functools
+import glob
 import logging
 import math
+import os
 import statistics
+import tempfile
 import time
 from typing import TYPE_CHECKING
 from typing import Any
@@ -312,6 +316,159 @@ def interleaved_bench_generic(
             all_times[j].append((end - start) * 1000)  # convert to ms
 
     return [statistics.median(times) for times in all_times]
+
+
+def paired_device_micros_bench(
+    fns: list[Callable[..., object]],
+    reference_fn: Callable[..., object],
+    *,
+    device_micros_fn: Callable[[Callable[[], object]], float],
+    desc: str | None = None,
+) -> list[tuple[float, float]]:
+    """Paired device-µs timing for the final-pick re-rank.
+
+    Times each candidate and ``reference_fn`` via ``device_micros_fn`` and returns
+    ``(candidate_micros, candidate_micros - reference_micros)`` per candidate (negative delta
+    = faster on-device). Unlike single-call wall-clock µs, which on small Pallas
+    matmuls is ~96-98% dispatch overhead, ``device_micros_fn`` reports on-chip µs so
+    configs differing by a few µs are separable. An unusable trace yields
+    ``(inf, inf)`` so the caller deranks it.
+    """
+    iterator = iter_with_progress(
+        range(len(fns)),
+        total=len(fns),
+        description=desc,
+        enabled=desc is not None,
+    )
+    results: list[tuple[float, float]] = []
+    for j in iterator:
+        candidate_micros = device_micros_fn(fns[j])
+        reference_micros = device_micros_fn(reference_fn)
+        if math.isfinite(candidate_micros) and math.isfinite(reference_micros):
+            results.append((candidate_micros, candidate_micros - reference_micros))
+        else:
+            results.append((math.inf, math.inf))
+    return results
+
+
+# 100 calls/trace keeps the per-event average stable to ~0.1µs (measured), well
+# below the multi-µs deltas the re-rank separates.
+_PALLAS_AUTOTUNE_DEVICE_MICROS_DEFAULT_N_CALLS = 100
+_PALLAS_AUTOTUNE_DEVICE_MICROS_DEFAULT_N_WARMUP = 5
+# Min event count for a ``/device:TPU:0`` line to count as a kernel sample: above
+# the DVFS counter lines (<=~17 events), below the kernel band (>=~40). Per-call
+# us divides by the actual count, so partial-flush traces stay unbiased.
+_PALLAS_AUTOTUNE_DEVICE_MICROS_MIN_TRACE_EVENTS = 20
+
+
+def _autotune_rank_by_device_micros() -> bool:
+    """True unless ``HELION_AUTOTUNE_PALLAS_RANK_BY`` opts out of device-µs ranking.
+
+    Default ``device_time``; any other value (e.g. ``wall_time``) falls back to the
+    legacy wall-clock paired-sample ranking. Pallas-only (the device-µs path is
+    jax.profiler-based); inert on other backends.
+    """
+    value = (
+        os.environ.get("HELION_AUTOTUNE_PALLAS_RANK_BY", "device_time").strip().lower()
+    )
+    return value == "device_time"
+
+
+def _pallas_device_micros_for_fn(
+    fn: Callable[[], object],
+    *,
+    n_calls: int,
+    n_warmup: int,
+) -> float:
+    """Per-call on-device µs for ``fn`` under a single ``jax.profiler`` trace.
+
+    Wraps ``n_calls`` invocations in one ``start_trace``/``stop_trace`` window,
+    parses the ``.xplane.pb``, and returns ``total_ns / count / 1000`` for the
+    dominant ``/device:TPU:0`` event (count >=
+    ``_PALLAS_AUTOTUNE_DEVICE_MICROS_MIN_TRACE_EVENTS``, which excludes the DVFS
+    counter line). Returns ``+inf`` when the trace is unusable (no ``jax``, no
+    xplane/TPU plane, too few events). Kernel exceptions from ``fn`` propagate.
+    """
+    try:
+        import jax  # pyrefly: ignore[missing-module-attribute]
+    except ImportError:
+        return math.inf
+
+    # Warmup outside the trace window so first-call compile doesn't pollute it.
+    for _ in range(n_warmup):
+        fn()
+
+    with tempfile.TemporaryDirectory(prefix="helion_autotune_device_micros_") as td:
+        jax.profiler.start_trace(td)
+        last_out: object = None
+        try:
+            for _ in range(n_calls):
+                last_out = fn()
+        finally:
+            # Block on the last output so stop_trace sees every device event.
+            if last_out is not None:
+                with contextlib.suppress(TypeError, AttributeError):
+                    jax.block_until_ready(last_out)
+            jax.profiler.stop_trace()
+
+        matches = glob.glob(os.path.join(td, "**", "*.xplane.pb"), recursive=True)
+        if not matches:
+            return math.inf
+
+        pd = jax.profiler.ProfileData.from_file(matches[0])
+        best_total_ns = 0
+        best_count = 0
+        for plane in pd.planes:
+            if plane.name != "/device:TPU:0":
+                continue
+            for line in plane.lines:
+                totals: dict[str, int] = {}
+                counts: dict[str, int] = {}
+                for ev in line.events:
+                    totals[ev.name] = totals.get(ev.name, 0) + ev.duration_ns
+                    counts[ev.name] = counts.get(ev.name, 0) + 1
+                for name, total in totals.items():
+                    if (
+                        counts[name] >= _PALLAS_AUTOTUNE_DEVICE_MICROS_MIN_TRACE_EVENTS
+                        and total > best_total_ns
+                    ):
+                        best_total_ns, best_count = total, counts[name]
+        if best_total_ns == 0:
+            return math.inf
+        return best_total_ns / best_count / 1000.0
+
+
+def make_pallas_paired_device_micros_bench(
+    *,
+    n_calls: int = _PALLAS_AUTOTUNE_DEVICE_MICROS_DEFAULT_N_CALLS,
+    n_warmup: int = _PALLAS_AUTOTUNE_DEVICE_MICROS_DEFAULT_N_WARMUP,
+) -> Callable[..., list[tuple[float, float]]] | None:
+    """Paired device-µs bench closure for the Pallas backend, or None.
+
+    Returns None when the user opted out via ``HELION_AUTOTUNE_PALLAS_RANK_BY=wall_time``.
+    Otherwise the closure has the :func:`paired_device_micros_bench` signature and
+    captures ``n_calls`` / ``n_warmup``.
+    """
+    if not _autotune_rank_by_device_micros():
+        return None
+
+    def _bench(
+        fns: list[Callable[..., object]],
+        reference_fn: Callable[..., object],
+        *,
+        desc: str | None = None,
+    ) -> list[tuple[float, float]]:
+        def _device_micros_fn(fn: Callable[[], object]) -> float:
+            return _pallas_device_micros_for_fn(fn, n_calls=n_calls, n_warmup=n_warmup)
+
+        return paired_device_micros_bench(
+            fns,
+            reference_fn,
+            device_micros_fn=_device_micros_fn,
+            desc=desc,
+        )
+
+    return _bench
 
 
 def _summarize_statistics_fallback(

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import math
+import os
+from typing import TYPE_CHECKING
 from typing import Callable
 import unittest
 
@@ -19,6 +21,10 @@ from helion._testing import xfailIfPallas
 from helion._testing import xfailIfPallasInterpret
 from helion._testing import xfailIfPallasTpu
 import helion.language as hl
+
+if TYPE_CHECKING:
+    from helion.autotuner.base_search import PopulationBasedSearch
+    from helion.autotuner.base_search import PopulationMember
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
@@ -1593,6 +1599,154 @@ class TestPallas(TestCase):
             [512, 512, 512],
             "Compiler-seeded [512, 512, 512] must be re-benched and re-rank "
             "ahead of the last-gen best once its true 0.190 ms perf is measured.",
+        )
+
+    def _make_device_micros_search(
+        self,
+        specs: list[tuple[str, list[int], float, float]],
+    ) -> tuple[PopulationBasedSearch, dict[str, PopulationMember]]:
+        """Device-µs final-pick scaffold from ``(key, block_sizes, wall_ms,
+        device_micros)`` specs, with a fake Pallas backend reporting the scripted
+        device µs.
+        """
+        from helion.autotuner.base_search import PopulationBasedSearch
+        from helion.autotuner.base_search import PopulationMember
+        from helion.runtime.config import Config
+
+        def _new_fn() -> Callable[..., object]:
+            def _fn() -> None:
+                return None
+
+            return _fn
+
+        device_micros_by_fn: dict[int, float] = {}
+        members: dict[str, PopulationMember] = {}
+        for key, block_sizes, wall_ms, device_micros in specs:
+            fn = _new_fn()
+            cfg = Config(block_sizes=block_sizes)
+            device_micros_by_fn[id(fn)] = device_micros
+            members[key] = PopulationMember(
+                fn=fn,
+                perfs=[wall_ms],
+                flat_values=[id(cfg)],
+                config=cfg,
+                status="ok",
+                compile_time=0.0,
+            )
+
+        def fake_device_micros_bench(
+            fns: list[Callable[..., object]],
+            reference_fn: Callable[..., object],
+            *,
+            desc: str | None = None,
+        ) -> list[tuple[float, float]]:
+            ref = device_micros_by_fn[id(getattr(reference_fn, "func", reference_fn))]
+            vals = [device_micros_by_fn[id(getattr(fn, "func", fn))] for fn in fns]
+            return [(v, v - ref) for v in vals]
+
+        class _Backend:
+            @staticmethod
+            def get_paired_device_micros_bench() -> Callable[
+                ..., list[tuple[float, float]]
+            ]:
+                return fake_device_micros_bench
+
+        class _ConfigSpec:
+            backend = _Backend()
+
+        class _Settings:
+            autotune_benchmark_fn: Callable[..., list[float]] | None = None
+            autotune_progress_bar: bool = False
+            static_shapes: bool = True
+
+        class _Kernel:
+            class env:
+                process_group_name: str | None = None
+
+        class _BenchProvider:
+            mutated_arg_indices: tuple[int, ...] = ()
+
+        search = PopulationBasedSearch.__new__(PopulationBasedSearch)
+        search.population = list(members.values())
+        search.best_perf_so_far = min(m.perf for m in search.population)
+        search.log = lambda *a, **kw: None  # pyrefly: ignore[bad-assignment]
+        search.args = ()
+        search.kernel = _Kernel()  # pyrefly: ignore[bad-assignment]
+        search.benchmark_provider = _BenchProvider()  # pyrefly: ignore[bad-assignment]
+        search.settings = _Settings()  # pyrefly: ignore[bad-assignment]
+        search.config_spec = _ConfigSpec()  # pyrefly: ignore[bad-assignment]
+        search._compiler_seed_members = []
+        return search, members
+
+    def test_pallas_autotuner_final_pick_reranks_by_device_micros(self) -> None:
+        """Final-pick ranks by on-device µs, not wall-clock.
+
+        ``fast`` is 10µs on-device but 125µs wall-clock; ``slow`` is 30µs
+        on-device but 124µs wall-clock (1µs "faster"). The re-rank must pick
+        ``fast`` despite its slower wall-clock.
+        """
+        from unittest.mock import patch
+
+        search, m = self._make_device_micros_search(
+            [
+                ("fast", [1024, 1024, 1024], 0.125, 10.0),
+                ("slow", [128, 1024, 1024], 0.124, 30.0),
+            ]
+        )
+        with patch.dict(os.environ, {"HELION_AUTOTUNE_PALLAS_RANK_BY": "device_time"}):
+            final = search.run_final_pick_verification(m["slow"], top_k=5)
+        self.assertEqual(list(final.config["block_sizes"]), [1024, 1024, 1024])
+
+    @skipIfPallasInterpret(
+        "device-µs ranking needs a real TPU; CPU-interpret has no /device:TPU events"
+    )
+    def test_pallas_paired_device_micros_bench_finite_on_large_compute_bound_shape(
+        self,
+    ) -> None:
+        """``paired_device_micros_bench`` stays finite on a 4096³ compute-bound shape.
+
+        Guards the ``count >= _MIN_TRACE_EVENTS`` predicate (vs an exact
+        ``== n_calls``): on large shapes the ``stop_trace`` flush drops a few tail
+        events, so an exact match would return ``+inf`` and silently route the
+        autotuner to its wall-clock fallback. Two structurally-identical jit_fns
+        must yield finite device µs and a near-zero paired delta.
+        """
+        import jax
+        import jax.numpy as jnp
+
+        from helion.autotuner.benchmarking import _pallas_device_micros_for_fn
+        from helion.autotuner.benchmarking import paired_device_micros_bench
+
+        m = k = n = 4096
+        k1, k2 = jax.random.split(jax.random.PRNGKey(0))
+        x = jax.random.normal(k1, (m, k), dtype=jnp.bfloat16)
+        y = jax.random.normal(k2, (k, n), dtype=jnp.bfloat16)
+
+        @jax.jit
+        def matmul(a: object, b: object) -> object:
+            return jax.lax.dot_general(a, b, dimension_numbers=(((1,), (0,)), ((), ())))
+
+        def _device_micros_fn(fn: Callable[[], object]) -> float:
+            return _pallas_device_micros_for_fn(fn, n_calls=50, n_warmup=2)
+
+        results = paired_device_micros_bench(
+            [lambda: matmul(x, y)],
+            lambda: matmul(x, y),
+            device_micros_fn=_device_micros_fn,
+        )
+        median_micros, delta_micros = results[0]
+        self.assertTrue(
+            math.isfinite(median_micros) and median_micros > 0,
+            f"candidate device µs must be finite + positive on 4096³; got {median_micros!r}",
+        )
+        self.assertTrue(
+            math.isfinite(delta_micros),
+            f"paired delta must be finite on 4096³; got {delta_micros!r}",
+        )
+        self.assertLess(
+            abs(delta_micros),
+            5.0,
+            f"identical jit_fns should give a near-zero paired delta; got {delta_micros!r}",
         )
 
     def test_pallas_matmul_bf16_emits_pl_dot(self) -> None:


### PR DESCRIPTION
Stacked PRs:
 * __->__#2632
 * #2631
 * #2629
 * #2626


--- --- ---

### [autotune] rank TPU matmul candidates by true on-chip time (the big win)


Brings Helion's TPU matmul kernels to JAX parity.

On TPU every kernel call carries ~125us of fixed dispatch overhead, so the
autotuner's wall-clock timer can't tell a 3us kernel from a 9us one (both
read ~128us) and was picking dispatch-cheap, compute-slow configs. Fix: in
the final verification pass, measure each candidate's actual on-chip time via
jax.profiler traces and rank by that. (Relies on the no-tiling/dot_general
config and seed-capture plumbing from the earlier PRs.)

Measured (TPU v7, on-chip us, median of 5 seeds):
- bf16 1024^3: 6.20 -> 5.61us -> matches JAX (was 0.90x)
- bf16 2048^3: 24.47 -> 22.88us -> matches JAX (was 0.93x)
vs the launcher-stack start: now matches JAX and ~1.8x / ~2.8x faster than
hand-written Pallas (1024^3 / 2048^3). Opt out with
HELION_AUTOTUNE_RANK_BY=wall_us. Includes pin tests.
