### PR TITLE
[fast-launcher] Static-kernel launcher (Inductor-style) + bound device

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -985,7 +985,17 @@ class TritonBackend(Backend):
             f"tl.full([{', '.join(shape_dims)}], {value_expr}, {self.dtype_str(dtype)})"
         )
 
-    def launcher_keyword_args(self, config: Config, *, has_barrier: bool) -> list[str]:
+    def launcher_runtime_kwargs(
+        self, config: Config, *, has_barrier: bool
+    ) -> dict[str, object]:
+        """Return the launcher kwargs as a ``dict`` of runtime values.
+
+        Used by both :meth:`launcher_keyword_args` (which formats the dict
+        as source strings for codegen) and
+        :func:`helion.runtime.build_fast_launcher` (which bakes the dict
+        into a closure at :meth:`BoundKernel.set_config` time so the hot
+        launch path doesn't have to allocate a per-call kwargs dict).
+        """
         from .._compat import supports_maxnreg
 
         # Workaround for triton bug: warp_specialize requires at least 4 warps
@@ -994,31 +1004,45 @@ class TritonBackend(Backend):
         if any(config.range_warp_specializes):
             num_warps = max(4, num_warps)
 
-        args = [
-            f"num_warps={num_warps}",
-            f"num_stages={config.num_stages}",
-            *(["launch_cooperative_grid=True"] if has_barrier else []),
-        ] + [
-            f"{x.removeprefix('_triton_config_')}={config[x]}"
-            for x in config
-            if x.startswith("_triton_config_")
-        ]
+        kwargs: dict[str, object] = {
+            "num_warps": num_warps,
+            "num_stages": config.num_stages,
+        }
+        if has_barrier:
+            kwargs["launch_cooperative_grid"] = True
+        for x in config:
+            if x.startswith("_triton_config_"):
+                kwargs[x.removeprefix("_triton_config_")] = config[x]
 
         from ..autotuner.config_spec import _get_backend_tunable_keys
 
         for key in _get_backend_tunable_keys():
             if key in config:
-                args.append(f"{key}={config[key]!r}")
+                kwargs[key] = config[key]
 
         if "maxnreg" in config and config["maxnreg"] is not None and supports_maxnreg():
-            args.append(f"maxnreg={config['maxnreg']}")
+            kwargs["maxnreg"] = config["maxnreg"]
 
         advanced_controls_file = config.advanced_controls_file
         if advanced_controls_file:
-            ptx_option = f"--apply-controls {advanced_controls_file}"
-            args.append(f"ptx_options={ptx_option!r}")
+            kwargs["ptx_options"] = f"--apply-controls {advanced_controls_file}"
 
-        return args
+        return kwargs
+
+    def launcher_keyword_args(self, config: Config, *, has_barrier: bool) -> list[str]:
+        from ..autotuner.config_spec import _get_backend_tunable_keys
+
+        backend_tunable_keys = _get_backend_tunable_keys()
+        kwargs = self.launcher_runtime_kwargs(config, has_barrier=has_barrier)
+        # Backend tunable keys (typically strings) and ptx_options use repr;
+        # everything else (num_warps, num_stages, ints, bools) renders plain.
+        out: list[str] = []
+        for k, v in kwargs.items():
+            if k in backend_tunable_keys or k == "ptx_options":
+                out.append(f"{k}={v!r}")
+            else:
+                out.append(f"{k}={v}")
+        return out
 
     def grid_barrier_stmt(self, sem_arg: str) -> str:
         return f"triton_helpers.x_grid_barrier({sem_arg})"

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -27,6 +27,8 @@ from .._compiler.cute.tcgen05_constants import (
 )
 from .._compiler.cute.tcgen05_constants import TCGEN05_DIRECT_ENTRY_TOTAL_WORK_CLUSTERS
 from .._utils import triton_is_available
+from ._fast_launcher import StaticLauncher as StaticLauncher
+from ._fast_launcher import default_launcher as default_launcher
 from .config import Config as Config
 from .kernel import Kernel as Kernel
 from .kernel import kernel as kernel
@@ -155,40 +157,6 @@ def get_num_sm(device: torch.device, *, reserved_sms: int = 0) -> int:
     if reserved_sms <= 0:
         return available_sms
     return max(available_sms - reserved_sms, 1)
-
-
-def default_launcher(
-    triton_kernel: object,
-    grid: tuple[int, ...],
-    *args: object,
-    num_warps: int,
-    num_stages: int,
-    ptx_options: str | None = None,
-    launch_cooperative_grid: bool = False,
-    **kwargs: dict,
-) -> object:
-    """Default launcher function that executes the kernel immediately."""
-    # For both CUDA and MTIA, use the same kernel execution
-    run_kwargs: dict = {
-        "grid": grid,
-        "warmup": False,
-        "num_warps": num_warps,
-        "num_stages": num_stages,
-        "launch_cooperative_grid": launch_cooperative_grid,
-        **kwargs,
-    }
-    if ptx_options is not None:
-        run_kwargs["ptx_options"] = ptx_options
-    try:
-        return triton_kernel.run(  # type: ignore[union-attr]
-            *args,
-            **run_kwargs,
-        )
-    except Exception as error:
-        message = str(error)
-        if "Cannot make_shape_compatible: incompatible dimensions" in message:
-            raise exc.ShapeMismatch("kernel operands", message) from error
-        raise
 
 
 def _pallas_make_block_spec(

--- a/helion/runtime/_fast_launcher.py
+++ b/helion/runtime/_fast_launcher.py
@@ -1,0 +1,499 @@
+"""Minimal static-kernel launcher (Inductor-style).
+
+Public entry points re-exported from :mod:`helion.runtime`:
+
+* :func:`default_launcher` — Triton's full per-call pipeline. Used as
+  the fallback when the static launcher can't engage (and as the
+  codegen wrapper's ``_launcher`` kwdefault before
+  :meth:`BoundKernel.set_config` installs the static launcher).
+* :class:`StaticLauncher` — lazy-priming launcher that builds PyTorch
+  Inductor's ``StaticallyLaunchedCudaKernel`` on first call and
+  dispatches every subsequent call straight to ``cuLaunchKernel`` via
+  ``torch._C._StaticCudaLauncher``. Skips Triton's Python-side
+  ``CudaLauncher.__call__`` wrapper.
+* :func:`_build_fast_launcher` — factory used by
+  ``BoundKernel._install_fast_launcher`` (private; pulls config /
+  env from the bound kernel and constructs a ``StaticLauncher``).
+
+Falls back to :func:`default_launcher` on any construction failure:
+older PyTorch without ``_StaticCudaLauncher``, missing cubin path,
+hooks installed at prime time, kernel with ``num_ctas != 1`` /
+``launch_pdl`` / global+profile scratch, etc.
+
+Two correctness guards run on every call (matching Inductor's
+static-launcher invariants):
+
+* **Alignment**: per-call check on the tensor pointer positions
+  captured at prime time. Any unaligned arg falls back to
+  ``default_launcher`` (Triton's full path), which compiles a
+  matching spec. Inductor clones unaligned inputs and copies writes
+  back using IR metadata; Helion has no such metadata, so a clone
+  here could silently drop writes to in-place / output args.
+* **``used_global_vals`` mutation**: snapshot taken at prime time;
+  any per-call mismatch falls back to ``default_launcher`` so Triton's
+  own ``RuntimeError`` surfaces instead of the static path silently
+  using the stale binary.
+
+The launcher does NOT carry multi-spec dispatch, per-call hook
+re-reads, a multi-device guard, or debug-knob retracking. If your
+workload swaps CUDA devices mid-process, attaches launch hooks AFTER
+the first call, or relies on per-knob recompilation, set
+``HELION_SKIP_FAST_LAUNCHER=1`` and Triton's default path will handle
+those edges.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import TYPE_CHECKING
+
+import torch
+
+from .. import exc
+
+if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
+
+    from .._compiler.compile_environment import CompileEnvironment
+    from .config import Config
+
+log: logging.Logger = logging.getLogger(__name__)
+
+# Sentinel for "key not present" lookups — distinguishes a missing
+# entry from a legitimately-stored ``None`` value, which the pool's
+# global-mutation check would otherwise conflate.
+_MISSING: object = object()
+
+# Optional imports for the static-launcher path. If any fails (older
+# PyTorch without ``_StaticCudaLauncher``, MTIA build, etc.),
+# ``_STATIC_LAUNCHER_AVAILABLE`` stays False and every call routes
+# through :func:`default_launcher`.
+try:
+    from torch._inductor.runtime.cache_dir_utils import triton_cache_dir
+    from torch._inductor.runtime.runtime_utils import triton_hash_to_path_key
+    from torch._inductor.runtime.static_triton_launcher import (
+        statically_launched_kernel_by_device,
+    )
+    from triton.runtime.driver import driver
+
+    _STATIC_LAUNCHER_AVAILABLE = True
+except ImportError:
+    _STATIC_LAUNCHER_AVAILABLE = False
+
+
+def default_launcher(
+    triton_kernel: object,
+    grid: tuple[int, ...],
+    *args: object,
+    num_warps: int,
+    num_stages: int,
+    ptx_options: str | None = None,
+    launch_cooperative_grid: bool = False,
+    **kwargs: dict,
+) -> object:
+    """Triton's full per-call pipeline; fallback for the static path."""
+    run_kwargs: dict = {
+        "grid": grid,
+        "warmup": False,
+        "num_warps": num_warps,
+        "num_stages": num_stages,
+        "launch_cooperative_grid": launch_cooperative_grid,
+        **kwargs,
+    }
+    if ptx_options is not None:
+        run_kwargs["ptx_options"] = ptx_options
+    try:
+        return triton_kernel.run(  # type: ignore[union-attr]
+            *args,
+            **run_kwargs,
+        )
+    except Exception as error:
+        message = str(error)
+        if "Cannot make_shape_compatible: incompatible dimensions" in message:
+            raise exc.ShapeMismatch("kernel operands", message) from error
+        raise
+
+
+class StaticLauncher:
+    """Lazy-priming static-kernel launcher.
+
+    First call:
+      - Run Triton warmup compile to obtain a ``CompiledKernel``.
+      - Locate the on-disk cubin (``triton_cache_dir`` + hash + name).
+      - Build ``StaticallyLaunchedCudaKernel`` and ``load_kernel``.
+      - Compute the constexpr-arg filter (the static launcher's
+        ``arg_tys`` only enumerates runtime params; Helion's wrapper
+        passes constexpr args inline too).
+
+    Subsequent calls:
+      - Unpack ``grid`` into 3 ints.
+      - Fetch the current CUDA stream.
+      - Filter out constexpr args.
+      - ``static_kernel.run(grid_x, grid_y, grid_z, stream, *args)``
+        jumps straight into ``cuLaunchKernel`` via PyTorch's C++
+        extension — no Triton Python wrapper, no per-call guards.
+
+    On any priming failure: ``self._static_kernel`` stays ``None`` and
+    every call routes through :func:`default_launcher`. The escape
+    hatch ``HELION_SKIP_STATIC_LAUNCHER=1`` forces this state.
+    """
+
+    __slots__ = (
+        "_device",
+        "_device_index",
+        "_get_stream",
+        "_keep_indices",
+        "_prime_lock",
+        "_primed",
+        "_ptr_indices",
+        "_run_kwargs",
+        "_static_kernel",
+        "_expected_globals",
+    )
+
+    def __init__(
+        self,
+        *,
+        device: torch.device,
+        num_warps: int,
+        num_stages: int,
+        launch_cooperative_grid: bool = False,
+        ptx_options: str | None = None,
+        extra_kwargs: dict | None = None,
+    ) -> None:
+        run_kwargs: dict = {
+            "num_warps": num_warps,
+            "num_stages": num_stages,
+            "launch_cooperative_grid": launch_cooperative_grid,
+        }
+        if extra_kwargs:
+            run_kwargs.update(extra_kwargs)
+        if ptx_options is not None:
+            run_kwargs["ptx_options"] = ptx_options
+        self._run_kwargs = run_kwargs
+        self._primed = False
+        self._prime_lock = threading.Lock()
+        self._static_kernel: object | None = None
+        self._keep_indices: tuple[int, ...] | None = None
+        # Positions in the ORIGINAL ``*args`` that are tensor pointers
+        # — used per-call for the 16-byte alignment check (see the
+        # alignment guard in :meth:`__call__`).
+        self._ptr_indices: tuple[int, ...] = ()
+        # Expected values for ``triton_kernel.used_global_vals``,
+        # snapshotted at prime time. Keyed by ``(name, gid)`` (the same
+        # composite key Triton uses) so we can look up the live
+        # ``globals_dict`` from ``triton_kernel.used_global_vals`` on
+        # each call without holding our own reference to it. Mutation
+        # between calls => fall back to ``default_launcher`` so
+        # Triton's own guard raises rather than our launcher silently
+        # dispatching the stale binary.
+        #
+        # NOTE: ``gid`` is ``id(globals_dict)``. If a module is
+        # reloaded between prime and a later call, the old ``id`` may
+        # be reused by an unrelated dict, and the live ``ugv`` lookup
+        # for that ``(name, gid)`` could match a different module's
+        # globals. Vanishingly unlikely in practice (Triton's own
+        # ``used_global_vals`` is the source of truth and isn't
+        # mutated by user code), but worth knowing.
+        self._expected_globals: dict[tuple[str, int], object] = {}
+        self._get_stream: object | None = None
+        # Device the bound kernel was created for (carried from
+        # ``BoundKernel._env.device``, which itself comes from the
+        # first tensor arg at bind time). ``device.index`` is what
+        # Triton's driver APIs (``load_kernel``, ``get_current_stream``)
+        # take — they expect an int, not a ``torch.device``. The
+        # bound-kernel cache key is keyed on the full device (incl.
+        # index), so two GPUs don't collide here.
+        self._device: torch.device = device
+        self._device_index: int = device.index if device.index is not None else 0
+
+    def _device_guard(self) -> AbstractContextManager[None]:
+        """Context manager that makes the launcher's bound device current.
+
+        Device-type-aware: ``torch.cuda.device`` covers CUDA *and* ROCm
+        (PyTorch reports both as ``cuda``); ``torch.xpu.device`` covers
+        Intel XPU. Using ``torch.cuda.device`` unconditionally would raise
+        ``RuntimeError: PyTorch was compiled without CUDA support`` on an
+        XPU-only build, even though Inductor's static launcher supports
+        ``xpu``.
+        """
+        if self._device.type == "xpu":
+            return torch.xpu.device(self._device_index)
+        return torch.cuda.device(self._device_index)
+
+    def _try_prime(
+        self,
+        triton_kernel: object,
+        grid: tuple[int, ...],
+        args: tuple[object, ...],
+    ) -> None:
+        """Best-effort: warmup compile + build the static kernel.
+        Leaves ``self._static_kernel = None`` on any failure so the
+        caller falls through to ``default_launcher``.
+        """
+        if not _STATIC_LAUNCHER_AVAILABLE:
+            return
+        if os.environ.get("HELION_SKIP_STATIC_LAUNCHER", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        ):
+            return
+        # Inductor's static launcher dispatches by device type and only
+        # supports ``cuda`` (incl. ROCm — PyTorch reports both as
+        # ``cuda``), ``hip``, and ``xpu``. Anything else (cpu, mps,
+        # ...) → bail to ``default_launcher``.
+        if self._device.type not in ("cuda", "hip", "xpu"):
+            return
+        try:
+            warmup_kwargs = {**self._run_kwargs, "grid": grid, "warmup": True}
+            compiled_kernel = triton_kernel.run(  # type: ignore[union-attr]
+                *args, **warmup_kwargs
+            )
+            if compiled_kernel is None:
+                return
+            device_index = self._device_index
+            cubin_path = os.path.join(
+                triton_cache_dir(device_index),
+                triton_hash_to_path_key(compiled_kernel.hash),
+                f"{compiled_kernel.src.fn.__name__}.cubin",
+            )
+            if not os.path.exists(cubin_path):
+                return
+            compiled_kernel._cubin_path = cubin_path
+            static_kernel = statically_launched_kernel_by_device(
+                compiled_kernel, device_type=self._device.type
+            )
+            static_kernel.load_kernel(device_index)
+            # Helion's generated wrapper passes ALL positional args
+            # (including ``tl.constexpr`` parameters); the static
+            # launcher's ``arg_tys`` only encodes runtime params, so
+            # we pre-compute which positions to KEEP. ``None`` means
+            # no filtering needed.
+            full_constexprs = getattr(static_kernel, "full_constexprs", None)
+            if full_constexprs:
+                constexpr_set = set(full_constexprs)
+                n_args = len(static_kernel.arg_names)
+                self._keep_indices = tuple(
+                    i for i in range(n_args) if i not in constexpr_set
+                )
+            # Map pointer positions back to ORIGINAL arg positions so
+            # the per-call alignment check walks just those tensors.
+            # ``arg_tys`` is in filtered (non-constexpr) order; the
+            # ``_keep_indices`` table translates filtered → original.
+            keep = self._keep_indices
+            arg_tys = static_kernel.arg_tys
+            if keep is None:
+                self._ptr_indices = tuple(i for i, t in enumerate(arg_tys) if t == "O")
+            else:
+                self._ptr_indices = tuple(
+                    keep[i] for i, t in enumerate(arg_tys) if t == "O"
+                )
+            # Snapshot expected values for ``used_global_vals`` so
+            # per-call mutation surfaces as a fallback to
+            # ``default_launcher`` (which itself raises Triton's
+            # RuntimeError). We keep only the (name, gid) → expected
+            # mapping — the live ``globals_dict`` is fetched from
+            # ``triton_kernel.used_global_vals`` per call, so this
+            # launcher doesn't pin module dicts independently of
+            # Triton's own ownership.
+            ugv = getattr(triton_kernel, "used_global_vals", None)
+            if ugv:
+                self._expected_globals = {
+                    (name, gid): val for (name, gid), (val, _gdict) in ugv.items()
+                }
+            self._static_kernel = static_kernel
+            # Cache the bound method to skip Triton's ``LazyProxy``
+            # resolution on every call: ``driver.active`` is a property
+            # that calls ``_active_driver_proxy()`` each access
+            # (~150-400 ns), and the launcher is pinned to one device
+            # so the binding never needs to be re-resolved.
+            self._get_stream = driver.active.get_current_stream  # pyrefly: ignore
+        except Exception:
+            # Surface the underlying cause at DEBUG so users diagnosing
+            # silent fallbacks (HELION_LOGS=all) can see why the static
+            # path is disabled. Any failure here just means we route
+            # through ``default_launcher`` — semantically equivalent,
+            # only slower.
+            log.debug("StaticLauncher prime failed", exc_info=True)
+            self._static_kernel = None
+
+    def __call__(
+        self,
+        triton_kernel: object,
+        grid: tuple[int, ...],
+        *args: object,
+        # Spelled-out kwargs so CPython binds the wrapper's kwargs
+        # into local slots rather than packing a per-call **kwargs
+        # dict. Values are unused — the launcher's ``_run_kwargs``
+        # has them baked in.
+        num_warps: int | None = None,
+        num_stages: int | None = None,
+        launch_cooperative_grid: bool = False,
+        **kwargs: object,
+    ) -> object:
+        # Under ``torch.compile``, dynamo traces through this
+        # ``__call__`` and chokes on the ``getattr(triton_kernel,
+        # "used_global_vals", ...)`` below ("Unsupported hasattr call"
+        # on ``TritonKernelVariable``). Route compile-time tracing
+        # straight through ``default_launcher`` (= Triton's
+        # ``JITFunction.run``), which dynamo already knows how to
+        # handle via its Triton-kernel-variable rules.
+        if torch.compiler.is_compiling():
+            return default_launcher(
+                triton_kernel,
+                grid,
+                *args,
+                **self._run_kwargs,
+            )
+        if not self._primed:
+            with self._prime_lock:
+                if not self._primed:
+                    # Prime under the launcher's bound device so the
+                    # static kernel's cubin is loaded into the right
+                    # CUDA context (``cuModuleLoad`` uses the current
+                    # context; loading in cuda:0's context but launching
+                    # on cuda:1's stream would yield "invalid argument"
+                    # from ``cuLaunchKernel``).
+                    with self._device_guard():
+                        self._try_prime(triton_kernel, grid, args)
+                    self._primed = True
+        static_kernel = self._static_kernel
+        if static_kernel is None:
+            return default_launcher(
+                triton_kernel,
+                grid,
+                *args,
+                **self._run_kwargs,
+            )
+        # ``used_global_vals`` mutation check: walk the prime-time
+        # snapshot and look up each entry's live ``globals_dict`` via
+        # ``triton_kernel.used_global_vals``. Iterating the snapshot
+        # (not the live mapping) catches both value mutations AND
+        # entries removed from ``used_global_vals`` between prime and
+        # call. The ``_MISSING`` sentinel disambiguates a removed key
+        # from a value that's legitimately ``None``.
+        if self._expected_globals:
+            ugv = getattr(triton_kernel, "used_global_vals", None) or {}
+            for (name, gid), expected in self._expected_globals.items():
+                entry = ugv.get((name, gid), _MISSING)
+                if entry is _MISSING:
+                    return default_launcher(
+                        triton_kernel,
+                        grid,
+                        *args,
+                        **self._run_kwargs,
+                    )
+                _val, gdict = entry
+                if gdict.get(name, _MISSING) != expected:
+                    return default_launcher(
+                        triton_kernel,
+                        grid,
+                        *args,
+                        **self._run_kwargs,
+                    )
+        # Alignment guard: the compiled binary was specialized for
+        # whichever alignment we saw at prime time (usually all
+        # 16-byte aligned, since the CUDA caching allocator emits
+        # aligned blocks). A misaligned arg here would hit
+        # ``CUDA error: misaligned address``.
+        #
+        # Inductor's ``align_inputs_from_check_idxs`` clones the
+        # unaligned tensor to an aligned copy, relying on its IR
+        # metadata to know which clones need to be copied back after
+        # the launch (writes to outputs). Helion doesn't track
+        # read/write status per arg, so a clone would silently drop
+        # any kernel writes to that position — wrong-result bug for
+        # in-place / output kernels. Fall back to ``default_launcher``
+        # instead; Triton's full path will compile a new spec for the
+        # new alignment if needed.
+        #
+        # The ``isinstance`` check guards against optional / union-typed
+        # positions where ``arg_tys == "O"`` at prime time but a later
+        # call passes ``None`` or a non-tensor — ``.data_ptr()`` would
+        # raise. Fall through to ``default_launcher`` so Triton can
+        # produce a clearer error or compile a new spec.
+        for i in self._ptr_indices:
+            arg = args[i]
+            if not isinstance(arg, torch.Tensor) or arg.data_ptr() & 15:
+                return default_launcher(
+                    triton_kernel,
+                    grid,
+                    *args,
+                    **self._run_kwargs,
+                )
+        try:
+            grid_size = len(grid)
+            grid_0 = grid[0]
+            grid_1 = grid[1] if grid_size > 1 else 1
+            grid_2 = grid[2] if grid_size > 2 else 1
+            # pyrefly: ignore[not-callable]
+            stream = self._get_stream(self._device_index)
+            keep = self._keep_indices
+            # Wrap the launch in the launcher's bound device so
+            # ``cuLaunchKernel`` runs in the matching CUDA context. The
+            # cost is two C calls (``cuCtxGetCurrent`` /
+            # ``cuCtxSetCurrent``) per call — small, and necessary for
+            # correctness when the caller's current device differs from
+            # the launcher's bound device (e.g. a kernel pinned to
+            # cuda:1 called while the default cuda:0 is current).
+            with self._device_guard():
+                if keep is None:
+                    # pyrefly: ignore[missing-attribute]
+                    return static_kernel.run(grid_0, grid_1, grid_2, stream, *args)
+                # pyrefly: ignore[missing-attribute]
+                return static_kernel.run(
+                    grid_0,
+                    grid_1,
+                    grid_2,
+                    stream,
+                    *(args[i] for i in keep),
+                )
+        except Exception as error:
+            message = str(error)
+            if "Cannot make_shape_compatible: incompatible dimensions" in message:
+                raise exc.ShapeMismatch("kernel operands", message) from error
+            raise
+
+
+def _build_fast_launcher(
+    *,
+    config: Config,
+    env: CompileEnvironment,
+) -> StaticLauncher:
+    """Build a :class:`StaticLauncher` for the given config + env.
+
+    Invoked from :meth:`BoundKernel.set_config` after the generated
+    Triton kernel is compiled. The returned object's ``__call__``
+    signature matches :func:`default_launcher`, so the generated
+    wrapper can use it as a drop-in replacement (threaded through as
+    ``_launcher=`` by ``set_config``).
+
+    Consumes :meth:`TritonBackend.launcher_runtime_kwargs` to extract
+    the raw runtime values from the config (the same source of truth
+    ``launcher_keyword_args`` uses for codegen), then splits the dict
+    into the named ``StaticLauncher`` parameters plus any leftover
+    backend-tunable keys (``maxnreg``, ``_triton_config_*``-stripped
+    keys, etc.) which are folded into ``extra_kwargs``. ``extra_kwargs``
+    is forwarded to ``default_launcher`` on the fallback path; the
+    static-launcher hot path ignores it because the cubin produced at
+    prime time has those values baked in already.
+    """
+    backend = env.backend
+    kwargs = backend.launcher_runtime_kwargs(  # type: ignore[attr-defined]
+        config, has_barrier=env.has_barrier
+    )
+    num_warps = kwargs.pop("num_warps")
+    num_stages = kwargs.pop("num_stages")
+    launch_cooperative_grid = kwargs.pop("launch_cooperative_grid", False)
+    ptx_options = kwargs.pop("ptx_options", None)
+    return StaticLauncher(
+        device=env.device,
+        num_warps=num_warps,
+        num_stages=num_stages,
+        launch_cooperative_grid=launch_cooperative_grid,
+        ptx_options=ptx_options,
+        extra_kwargs=kwargs or None,
+    )

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -142,19 +142,20 @@ def _resolve_index_dtype(
 
 def _device_specialization_key(
     args: Sequence[object],
-) -> tuple[str | None, tuple[int, int] | None]:
+) -> tuple[str | None, tuple[int, int] | None, int | None]:
     """Return the recursive argument device key used by bound-kernel caching.
 
     `_find_device` intentionally searches tensors and bare `torch.device`
     objects inside supported containers to match binding device selection.
-    Capability splits mixed-sm cache entries. Device index remains excluded so
-    same-capability devices share bound kernels, matching prior behavior.
+    Capability splits mixed-sm cache entries; ``device.index`` splits
+    same-capability cards (e.g. cuda:0 vs cuda:1) so each device gets its
+    own ``BoundKernel`` + correctly-pinned ``StaticLauncher``.
     """
     try:
         device = _find_device(tuple(args))
     except exc.NoTensorArgs:
-        return None, None
-    return device.type, target_device_capability(device)
+        return None, None, None
+    return device.type, target_device_capability(device), device.index
 
 
 class Kernel(Generic[_R]):
@@ -304,10 +305,16 @@ class Kernel(Generic[_R]):
                 result.append(value)
             else:
                 result.append(self._specialization_key(value))
-        device_type, device_capability = _device_specialization_key(args)
+        device_type, device_capability, device_index = _device_specialization_key(args)
         if self._key_fn is not None:
-            return (*result, device_type, device_capability, self._key_fn(*args))
-        return (*result, device_type, device_capability)
+            return (
+                *result,
+                device_type,
+                device_capability,
+                device_index,
+                self._key_fn(*args),
+            )
+        return (*result, device_type, device_capability, device_index)
 
     def specialization_key(self, args: Sequence[object]) -> tuple[Hashable, ...]:
         """
@@ -968,11 +975,87 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             config: The configuration to set.
         """
         config = self._normalize_config(config)
-        self._run = self.compile_config(config)
+        compiled = self.compile_config(config)
+        # Clone the compiled function so each BoundKernel has its own
+        # ``__kwdefaults__`` to mutate. ``compile_config`` returns
+        # functions loaded via ``PyCodeCache``, which keys on source
+        # hash — two BoundKernels for the same kernel on cuda:0 vs
+        # cuda:1 generate IDENTICAL Triton source (device isn't baked
+        # in), share a function object, and an in-place
+        # ``__kwdefaults__["_launcher"] = ...`` in
+        # :meth:`_install_fast_launcher` would clobber the earlier
+        # BoundKernel's device-pinned launcher.
+        run = types.FunctionType(
+            compiled.__code__,
+            compiled.__globals__,
+            compiled.__name__,
+            compiled.__defaults__,
+            compiled.__closure__,
+        )
+        if compiled.__kwdefaults__ is not None:
+            run.__kwdefaults__ = dict(compiled.__kwdefaults__)
+        self._install_fast_launcher(run, config)
+        self._run = run
         self._config = config
         counters["best_config_decorator"][
             self.format_kernel_decorator(config, self.settings)
         ] = 1
+
+    def _install_fast_launcher(
+        self,
+        compiled: CompiledConfig,
+        config: Config,
+    ) -> None:
+        """Re-point ``compiled``'s ``_launcher`` kwarg default at a fast closure.
+
+        The generated host wrapper declares
+        ``def add(x, y, *, _launcher=_default_launcher)``; Python stores the
+        ``_default_launcher`` value in ``compiled.__kwdefaults__``. By
+        overwriting that entry with a :class:`helion.runtime.StaticLauncher`
+        closure (built once with this config's ``num_warps`` / ``num_stages``
+        / etc. baked in), every direct call to ``compiled(*args)`` —
+        including from ``BoundKernel.__call__`` on the steady-state hot
+        path — uses the fast launcher with no extra Python wrapping.
+
+        The autotune trial harness and any external caller that explicitly
+        passes ``_launcher=`` overrides the kwdefault automatically, so
+        this is safe.
+
+        Non-Triton backends and any priming failure cause the kwdefault to
+        be left at :func:`default_launcher`. Setting the env var
+        ``HELION_SKIP_FAST_LAUNCHER=1`` (or ``true`` / ``yes``) is an
+        escape hatch: the fast launcher is not installed and every
+        Helion call goes through ``default_launcher`` (= Triton's
+        ``JITFunction.run``). Useful for quickly bisecting whether a
+        bug is in the fast launcher itself.
+        """
+        from ._fast_launcher import _build_fast_launcher
+
+        if os.environ.get("HELION_SKIP_FAST_LAUNCHER", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        ):
+            return
+
+        backend = self.env.backend
+        if not isinstance(backend, TritonBackend):
+            return
+        kwdefaults = getattr(compiled, "__kwdefaults__", None)
+        if not kwdefaults or "_launcher" not in kwdefaults:
+            # No ``_launcher`` kwonly default — nothing to wire up.
+            # (Should not happen for Helion-compiled Triton kernels.)
+            return
+
+        try:
+            launcher = _build_fast_launcher(config=config, env=self._env)
+        except Exception:
+            log.debug(
+                "StaticLauncher disabled: _build_fast_launcher raised",
+                exc_info=True,
+            )
+            return
+        kwdefaults["_launcher"] = launcher
 
     def _specialize_extra(self) -> list[Callable[[Sequence[object]], Hashable]]:
         """

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -152,8 +152,8 @@ class TestConfigAPI(TestCase):
         ):
             sm100_key = device_key_kernel._base_specialization_key((device,))
 
-        self.assertEqual(sm90_key[-2:], ("cuda", (9, 0)))
-        self.assertEqual(sm100_key[-2:], ("cuda", (10, 0)))
+        self.assertEqual(sm90_key[-3:], ("cuda", (9, 0), 0))
+        self.assertEqual(sm100_key[-3:], ("cuda", (10, 0), 0))
         self.assertNotEqual(sm90_key, sm100_key)
 
     def test_config_constructor_signature_contains_expected_kwargs(self) -> None:

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -34,6 +34,7 @@ from helion._testing import skipIfPyTorchBaseVerLessThan
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
 from helion._testing import skipUnlessTensorDescriptor
+from helion._testing import synchronize_device
 import helion.language as hl
 from helion.runtime.settings import _get_backend
 
@@ -1253,21 +1254,49 @@ class TestHelionTritonPrinter(TestCase):
             self.assertIn("div_floor_integer", result)
 
 
+def _scope_launcher(testcase: unittest.TestCase, launcher: str) -> None:
+    """Force the named launcher via ``HELION_SKIP_FAST_LAUNCHER`` for
+    the duration of the test, restoring the prior env var on cleanup.
+
+    - ``"default"`` sets ``HELION_SKIP_FAST_LAUNCHER=1``, routing every
+      call through :func:`helion.runtime.default_launcher` (Triton's
+      ``JITFunction.run``).
+    - ``"static"`` unsets the env var, letting Helion install its
+      :class:`helion.runtime.StaticLauncher`.
+    """
+    prev = os.environ.get("HELION_SKIP_FAST_LAUNCHER")
+    if launcher == "default":
+        os.environ["HELION_SKIP_FAST_LAUNCHER"] = "1"
+    elif launcher == "static":
+        os.environ.pop("HELION_SKIP_FAST_LAUNCHER", None)
+    else:
+        raise ValueError(f"unknown launcher: {launcher!r}")
+
+    def _restore() -> None:
+        if prev is None:
+            os.environ.pop("HELION_SKIP_FAST_LAUNCHER", None)
+        else:
+            os.environ["HELION_SKIP_FAST_LAUNCHER"] = prev
+
+    testcase.addCleanup(_restore)
+
+
+@instantiate_parametrized_tests
 @onlyBackends(["triton"])
 class TestLauncher(TestCase):
     """Launcher-agnostic contract tests — every launcher
     implementation must satisfy these regardless of which Triton
-    dispatch path it uses. Currently exercises whichever launcher
-    Helion installs by default; the same scenarios are pinned down
-    against the static-kernel launcher in
-    ``test/test_static_launcher.py``.
+    dispatch path it uses. Each test is parametrized over
+    ``launcher=["default", "static"]`` so both paths are exercised.
     """
 
-    def test_unaligned_input_produces_correct_output(self) -> None:
+    @parametrize("launcher", ["default", "static"])
+    def test_unaligned_input_produces_correct_output(self, launcher: str) -> None:
         """An unaligned tensor (e.g. ``x[1:]`` on fp32) primed after
         an aligned call must still produce the correct numeric output:
         the launcher either falls back to Triton's full path or
         otherwise handles the new alignment cleanly."""
+        _scope_launcher(self, launcher)
 
         @helion.kernel(
             static_shapes=True,
@@ -1287,15 +1316,19 @@ class TestLauncher(TestCase):
         self.assertNotEqual(unaligned.data_ptr() % 16, 0)
 
         add(aligned, aligned)
-        torch.cuda.synchronize()
+        synchronize_device()
         out = add(unaligned, unaligned)
-        torch.cuda.synchronize()
+        synchronize_device()
         torch.testing.assert_close(out, unaligned + unaligned)
 
-    def test_unaligned_writes_to_user_out_arg_land_on_original(self) -> None:
+    @parametrize("launcher", ["default", "static"])
+    def test_unaligned_writes_to_user_out_arg_land_on_original(
+        self, launcher: str
+    ) -> None:
         """If the kernel writes to an unaligned user-supplied output
         buffer, those writes must land on the user's tensor (not on
         a clone)."""
+        _scope_launcher(self, launcher)
 
         @helion.kernel(
             static_shapes=True,
@@ -1316,7 +1349,7 @@ class TestLauncher(TestCase):
         # Prime with aligned slices, then call with only ``out``
         # unaligned so the test isolates the write-to-unaligned case.
         add_write_out(x_aligned, y_aligned, base_out[:n])
-        torch.cuda.synchronize()
+        synchronize_device()
 
         out_unaligned = base_out[1 : n + 1]
         self.assertEqual(x_aligned.data_ptr() % 16, 0)
@@ -1324,17 +1357,19 @@ class TestLauncher(TestCase):
         self.assertNotEqual(out_unaligned.data_ptr() % 16, 0)
         out_unaligned.fill_(0.0)
         add_write_out(x_aligned, y_aligned, out_unaligned)
-        torch.cuda.synchronize()
+        synchronize_device()
         torch.testing.assert_close(out_unaligned, x_aligned + y_aligned)
 
     @skipIfRefEager(
         "Inspects the bound kernel's Triton JITFunction, which doesn't "
         "exist in ref-eager mode"
     )
-    def test_used_global_vals_mutation_raises(self) -> None:
+    @parametrize("launcher", ["default", "static"])
+    def test_used_global_vals_mutation_raises(self, launcher: str) -> None:
         """Mutating a tracked global (e.g. a ``_BLOCK_SIZE_*``
         constexpr captured via ``used_global_vals``) between calls
         must trigger ``RuntimeError`` from Triton's own guard."""
+        _scope_launcher(self, launcher)
 
         @helion.kernel(
             static_shapes=True,
@@ -1348,7 +1383,7 @@ class TestLauncher(TestCase):
 
         x = torch.randn(1024, device=DEVICE, dtype=torch.float32)
         add(x, x)
-        torch.cuda.synchronize()
+        synchronize_device()
 
         from triton.runtime.jit import JITFunction
 
@@ -1366,11 +1401,12 @@ class TestLauncher(TestCase):
         try:
             with self.assertRaises(RuntimeError):
                 add(x, x)
-                torch.cuda.synchronize()
+                synchronize_device()
         finally:
             gdict[name] = original
 
-    def test_correct_result_on_each_cuda_device(self) -> None:
+    @parametrize("launcher", ["default", "static"])
+    def test_correct_result_on_each_cuda_device(self, launcher: str) -> None:
         """The same kernel called on ``cuda:0`` then ``cuda:1`` must
         yield correct numeric results landing on each device. Whether
         the two calls share a ``BoundKernel`` (cache key collapses on
@@ -1386,6 +1422,7 @@ class TestLauncher(TestCase):
         non-default device."""
         if torch.cuda.device_count() < 2:
             self.skipTest("requires >= 2 CUDA devices")
+        _scope_launcher(self, launcher)
 
         @helion.kernel(
             static_shapes=True,

--- a/test/test_static_launcher.py
+++ b/test/test_static_launcher.py
@@ -1,0 +1,205 @@
+"""Static-kernel-launcher specific tests.
+
+The launcher (``helion.runtime.StaticLauncher``) builds PyTorch
+Inductor's ``StaticallyLaunchedCudaKernel`` on first call and
+dispatches every subsequent call straight to ``cuLaunchKernel`` via
+``torch._C._StaticCudaLauncher``. Falls back to ``default_launcher``
+on any priming failure.
+
+These tests pin down behavior unique to the static path: correctness
+match against the default path, internal priming state, both env-var
+escape hatches (``HELION_SKIP_STATIC_LAUNCHER`` and
+``HELION_SKIP_FAST_LAUNCHER``), constexpr-arg filtering before the
+C-level dispatch, and the cross-device fall-back. Launcher-agnostic
+behaviors (unaligned input / output handling and
+``used_global_vals`` mutation) are covered for both launchers via
+the parametrized ``TestLauncher`` class in ``test/test_misc.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import RefEagerTestDisabled
+from helion._testing import TestCase
+from helion._testing import skipIfNotCUDA
+from helion._testing import skipIfNotTriton
+import helion.language as hl
+from helion.runtime import StaticLauncher
+
+
+@helion.kernel(
+    static_shapes=True,
+    config=helion.Config(block_sizes=[1024], num_warps=4, num_stages=2),
+)
+def _static_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for i in hl.tile(out.size(0)):
+        out[i] = x[i] + y[i]
+    return out
+
+
+def _installed_launcher(kernel: helion.Kernel) -> StaticLauncher:
+    bound = next(iter(kernel._bound_kernels.values()))  # type: ignore[attr-defined]
+    return bound._run.__kwdefaults__["_launcher"]
+
+
+@skipIfNotTriton("static launcher is Triton-specific")
+class TestStaticLauncher(RefEagerTestDisabled, TestCase):
+    def setUp(self) -> None:
+        # Other test files (e.g. TestLauncher in test_misc.py) set these
+        # env vars and restore them via addCleanup, but pytest-xdist
+        # dispatches tests across workers and pytest-rerunfailures
+        # reruns failures — both can land tests on the same worker in
+        # orders that briefly expose the env var before cleanup. We
+        # snapshot + clear here so each TestStaticLauncher test starts
+        # in a known state regardless of what ran before.
+        super().setUp()
+        for name in ("HELION_SKIP_FAST_LAUNCHER", "HELION_SKIP_STATIC_LAUNCHER"):
+            prev = os.environ.pop(name, None)
+            if prev is not None:
+                self.addCleanup(os.environ.__setitem__, name, prev)
+
+    @skipIfNotCUDA()
+    def test_result_matches_default_path(self) -> None:
+        """Output from the static-launcher path matches the
+        ``default_launcher`` result on the same inputs."""
+        _static_add.reset()
+        x = torch.randn(4096, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(4096, device=DEVICE, dtype=torch.float32)
+        expected = (x + y).clone()
+        result = _static_add(x, y)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(result, expected)
+
+    @skipIfNotCUDA()
+    def test_static_kernel_attached_after_first_call(self) -> None:
+        """First call primes the launcher; the static kernel is
+        attached if PyTorch + Triton support it. (No-op on older
+        environments — we just check the launcher exposes its state.)
+        """
+        _static_add.reset()
+        x = torch.randn(4096, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(4096, device=DEVICE, dtype=torch.float32)
+        _static_add(x, y)
+        torch.cuda.synchronize()
+        launcher = _installed_launcher(_static_add)
+        self.assertIsInstance(launcher, StaticLauncher)
+        self.assertTrue(launcher._primed)
+
+    @skipIfNotCUDA()
+    def test_skip_env_var_uses_default_launcher(self) -> None:
+        """``HELION_SKIP_STATIC_LAUNCHER=1`` set BEFORE priming routes
+        every call through ``default_launcher``. Result is still
+        correct."""
+        prev = os.environ.get("HELION_SKIP_STATIC_LAUNCHER")
+        os.environ["HELION_SKIP_STATIC_LAUNCHER"] = "1"
+        try:
+            _static_add.reset()
+            x = torch.randn(4096, device=DEVICE, dtype=torch.float32)
+            y = torch.randn(4096, device=DEVICE, dtype=torch.float32)
+            expected = (x + y).clone()
+            result = _static_add(x, y)
+            torch.cuda.synchronize()
+            torch.testing.assert_close(result, expected)
+            launcher = _installed_launcher(_static_add)
+            self.assertIsNone(launcher._static_kernel)
+        finally:
+            if prev is None:
+                os.environ.pop("HELION_SKIP_STATIC_LAUNCHER", None)
+            else:
+                os.environ["HELION_SKIP_STATIC_LAUNCHER"] = prev
+
+    @skipIfNotCUDA()
+    def test_constexpr_args_filtered(self) -> None:
+        """A kernel that takes a constexpr arg (block size etc.) must
+        still produce correct output through the static launcher —
+        the launcher's ``_keep_indices`` filters constexpr positions
+        out of ``*args`` before the C-level dispatch."""
+
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64, 32], num_warps=4, num_stages=2),
+        )
+        def _sum_rows(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.shape
+            out = torch.empty(m, device=x.device, dtype=x.dtype)
+            for tile_m in hl.tile(m):
+                acc = torch.zeros_like(out[tile_m])
+                for tile_n in hl.tile(n):
+                    acc = acc + x[tile_m, tile_n].sum(-1)
+                out[tile_m] = acc
+            return out
+
+        x = torch.randn(128, 256, device=DEVICE, dtype=torch.float32)
+        expected = x.sum(-1).clone()
+        result = _sum_rows(x)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(result, expected)
+
+    @skipIfNotCUDA()
+    def test_skip_fast_launcher_env_var_disables_install(self) -> None:
+        """``HELION_SKIP_FAST_LAUNCHER=1`` (the upstream escape hatch)
+        leaves the wrapper's ``_launcher`` kwdefault at the
+        ``default_launcher`` module-level function — no static
+        launcher is installed at all."""
+        from helion.runtime import default_launcher
+
+        prev = os.environ.get("HELION_SKIP_FAST_LAUNCHER")
+        os.environ["HELION_SKIP_FAST_LAUNCHER"] = "1"
+        try:
+            _static_add.reset()
+            x = torch.randn(64, device=DEVICE, dtype=torch.float32)
+            y = torch.randn(64, device=DEVICE, dtype=torch.float32)
+            expected = (x + y).clone()
+            result = _static_add(x, y)
+            torch.cuda.synchronize()
+            torch.testing.assert_close(result, expected)
+            launcher = _installed_launcher(_static_add)
+            self.assertIs(launcher, default_launcher)
+        finally:
+            if prev is None:
+                os.environ.pop("HELION_SKIP_FAST_LAUNCHER", None)
+            else:
+                os.environ["HELION_SKIP_FAST_LAUNCHER"] = prev
+
+    @skipIfNotCUDA()
+    def test_separate_bound_kernels_per_cuda_device(self) -> None:
+        """The bound-kernel cache key includes ``device.index``, so
+        ``cuda:0`` and ``cuda:1`` get **distinct** ``BoundKernel``
+        cache entries — each with its own ``StaticLauncher`` pinned to
+        the right device. Verifies the cache shape; per-device numeric
+        correctness is covered by ``TestLauncher`` in ``test_misc.py``."""
+        if torch.cuda.device_count() < 2:
+            self.skipTest("requires >= 2 CUDA devices")
+        _static_add.reset()
+
+        device0 = torch.device(DEVICE.type, 0)
+        device1 = torch.device(DEVICE.type, 1)
+
+        x0 = torch.randn(1024, device=device0, dtype=torch.float32)
+        with torch.cuda.device(device0.index):
+            _static_add(x0, x0)
+        torch.cuda.synchronize(0)
+
+        x1 = torch.randn(1024, device=device1, dtype=torch.float32)
+        with torch.cuda.device(device1.index):
+            _static_add(x1, x1)
+        torch.cuda.synchronize(1)
+
+        bound_kernels = list(_static_add._bound_kernels.values())  # type: ignore[attr-defined]
+        self.assertEqual(len(bound_kernels), 2)
+        per_device_index = {
+            bk._env.device.index: bk._run.__kwdefaults__["_launcher"]._device_index
+            for bk in bound_kernels
+        }
+        self.assertEqual(per_device_index, {0: 0, 1: 1})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked PRs:
 * #2636
 * __->__#2635


--- --- ---

### [fast-launcher] Static-kernel launcher (Inductor-style) + bound device


Adds StaticLauncher, a minimal launcher that builds PyTorch Inductor's
StaticallyLaunchedCudaKernel on first call and dispatches every
subsequent call straight into cuLaunchKernel via
torch._C._StaticCudaLauncher, skipping Triton's Python-side
CudaLauncher.__call__ frame. Two per-call correctness guards run on
the hot path: a 16-byte alignment check on tensor pointer args (falls
back to default_launcher on mismatch — Helion lacks the read/write IR
metadata Inductor uses to safely clone unaligned writes) and a
used_global_vals mutation check that surfaces Triton's own
RuntimeError instead of dispatching a stale binary. The launcher
takes its bound torch.device at construction time (threaded through
from BoundKernel._env.device) so the cubin is loaded into the right
CUDA context at prime time. The bound-kernel cache key includes
``device.index``, so cuda:0 and cuda:1 get distinct BoundKernels each
with its own correctly-pinned StaticLauncher — like raw Triton, the
caller is responsible for setting the current CUDA context (e.g.
``torch.cuda.device(N)``) before launching on a non-default device.
Under ``torch.compile``, the launcher short-circuits to
``default_launcher`` so dynamo can trace through its existing
Triton-kernel-variable rules.

The builder is a private ``_build_fast_launcher(config, env)`` that
consumes ``TritonBackend.launcher_runtime_kwargs`` — the same source
of truth ``launcher_keyword_args`` uses for codegen — so the Triton
runtime kwargs (num_warps, num_stages, maxnreg, backend tunables,
ptx_options, ...) come from one place rather than being mirrored in
``BoundKernel._install_fast_launcher``.


Bench script: https://www.internalfb.com/intern/paste/P2359280237/
