### PR TITLE
[fast-launcher] Opt-in output-tensor pool + codegen rewrite + autotune

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -899,6 +899,7 @@ class TritonBackend(Backend):
             "tl_math": "from torch._inductor.runtime.triton_helpers import math as tl_math",
             "libdevice": "from torch._inductor.runtime.triton_compat import libdevice",
             "_default_launcher": "from helion.runtime import default_launcher as _default_launcher",
+            "_helion_pool_empty_like": "from helion.runtime._output_pool import _empty_like as _helion_pool_empty_like",
             "fast_dividef": "from triton.language.extra.libdevice import fast_dividef",
             "fast_expf": "from triton.language.extra.libdevice import fast_expf",
         }

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -838,6 +838,102 @@ if __name__ == "__main__":
     """)
 
 
+def _rewrite_output_allocs_for_pool(host_statements: list[ast.stmt]) -> None:
+    """Route output-tensor allocations through ``helion.runtime._output_pool.empty_like``.
+
+    Walks the generated host wrapper statements, looking for
+    ``Assign(target=Name(v), value=Call(torch.empty_like(template)))``
+    where the target name ``v`` is passed as a positional arg to a
+    kernel launcher call elsewhere in the same scope. Today Helion's
+    codegen emits ``torch.empty_like`` only for kernel-output buffers
+    that the kernel fully overwrites before any read, so replacing
+    the factory call with the pool helper is safe.
+
+    The rewrite is intentionally narrow: a future codegen path that
+    creates an ``empty_like`` buffer then reads its uninitialized
+    contents before the launcher writes them would be a pre-existing
+    correctness bug (the ``torch.empty_like`` contract is "contents
+    undefined"); the pool merely makes the prior call's leftover
+    contents — instead of allocator garbage — visible to such a read.
+    Either way, the user code is at fault.
+
+    Other names (helpers, locals returned from utility functions,
+    etc.) are left alone, as are ``torch.empty_like`` calls with
+    keyword args (see the second-pass shape filter below).
+
+    ``torch.empty`` with explicit ``(shape, dtype, device)`` args
+    would also be safe to pool, but our pool helper only accepts the
+    template-tensor signature, so we'd need a separate helper for the
+    explicit-args case. Easy to extend later.
+    """
+    # First pass: collect names passed as positional args to kernel
+    # launcher calls. The launcher call's statement is marked with
+    # ``_is_kernel_call=True`` by the codegen.
+    launcher_arg_names: set[str] = set()
+    for stmt in host_statements:
+        if not getattr(stmt, "_is_kernel_call", False):
+            continue
+        call: ast.AST | None = None
+        if (
+            isinstance(stmt, ast.Expr)
+            and isinstance(stmt.value, ast.Call)
+            or isinstance(stmt, ast.Assign)
+            and isinstance(stmt.value, ast.Call)
+        ):
+            call = stmt.value
+        if not isinstance(call, ast.Call):
+            continue
+        for arg in call.args:
+            if isinstance(arg, ast.Name):
+                launcher_arg_names.add(arg.id)
+
+    # Second pass: rewrite ``torch.<fn>(...)`` factory expressions
+    # whose Assign target is a launcher-arg name. Each rewritten call
+    # site gets a unique ``_slot`` kwarg so two same-key allocations
+    # in the same wrapper (e.g. a multi-output kernel emitting
+    # ``out1 = torch.empty_like(x); out2 = torch.empty_like(x)``) map
+    # to distinct cache entries instead of collapsing onto one buffer
+    # (which would silently alias the outputs).
+    slot_id = 0
+    for stmt in host_statements:
+        if not (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and stmt.targets[0].id in launcher_arg_names
+            and not getattr(stmt, "_is_kernel_call", False)
+            and isinstance(stmt.value, ast.Call)
+        ):
+            continue
+        call = stmt.value
+        # Match ``torch.empty_like(...)``: an Attribute whose value is
+        # ``Name('torch')`` and whose attr is ``empty_like``.
+        if not (
+            isinstance(call.func, ast.Attribute)
+            and isinstance(call.func.value, ast.Name)
+            and call.func.value.id == "torch"
+            and call.func.attr == "empty_like"
+        ):
+            continue
+        # Skip the rewrite when the call has kwargs (e.g.
+        # ``torch.empty_like(x, dtype=torch.float32)``) or any
+        # non-trivial positional args beyond the template. The pool
+        # helper keys on the template's metadata; overriding dtype /
+        # device / memory_format etc. via kwargs would silently produce
+        # a buffer with the WRONG signature on cache hit. Keeping the
+        # original ``torch.empty_like(...)`` call is correct and the
+        # ~1.4 us / call cost only applies to those rarer sites.
+        if call.keywords or len(call.args) != 1:
+            continue
+        # Replace the called function with the pool helper, threading
+        # the per-site slot id through as a kwarg.
+        call.func = ast.Name(id="_helion_pool_empty_like", ctx=ast.Load())
+        call.keywords = [
+            ast.keyword(arg="_slot", value=ast.Constant(value=slot_id)),
+        ]
+        slot_id += 1
+
+
 def generate_ast(
     func: HostFunction,
     config: Config,
@@ -895,6 +991,28 @@ def generate_ast(
                         ] + [
                             ast.keyword(arg="device", value=ast.Constant(value="meta"))
                         ]
+
+            # Always rewrite the wrapper's ``torch.empty_like(x)`` calls
+            # to route through ``helion.runtime._output_pool.empty_like`` (the pool
+            # helper). When the pool is OFF at runtime (the default),
+            # the helper short-circuits to ``torch.empty_like`` for a
+            # ~30 ns/call overhead. When ON (autotune mode or explicit
+            # ``set_pool_enabled(True)``), the helper returns a
+            # recycled buffer from a small per-signature ring and skips
+            # the allocator entirely (~1 us/call saving).
+            #
+            # The rewrite is conservative: only triggers on assignments
+            # whose target name is consumed by a kernel launcher call
+            # in the same scope. Tensors that escape via other paths
+            # (returned by helpers, captured by closures, etc.) are not
+            # safe to recycle and stay on ``torch.empty_like``.
+            #
+            # Doing the rewrite unconditionally — rather than gating on
+            # an env var at codegen time — means a single compiled
+            # wrapper works for both autotune (pool on) and production
+            # (pool off). Autotune sets the runtime flag around the
+            # benchmark loop and restores it afterwards.
+            _rewrite_output_allocs_for_pool(codegen.host_statements)
 
             # Inject RNG seed buffer creation if needed
             rng_statements = (

--- a/helion/_compiler/output_header.py
+++ b/helion/_compiler/output_header.py
@@ -26,6 +26,7 @@ library_imports: dict[str, str] = {
     "tl_math": "from torch._inductor.runtime.triton_helpers import math as tl_math",
     "libdevice": "from torch._inductor.runtime.triton_compat import libdevice",
     "_default_launcher": "from helion.runtime import default_launcher as _default_launcher",
+    "_helion_pool_empty_like": "from helion.runtime._output_pool import _empty_like as _helion_pool_empty_like",
 }
 
 disallowed_names: dict[str, None] = dict.fromkeys(
@@ -35,6 +36,7 @@ disallowed_names: dict[str, None] = dict.fromkeys(
         "_default_launcher",
         "_default_pallas_launcher",
         "_default_cute_launcher",
+        "_helion_pool_empty_like",
         "_NUM_SM",
     ]
 )

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -950,6 +950,9 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             # Narrow capture: only the kernel compile+launch sites (which can
             # emit Triton C-level MLIR diagnostics). Leave the accuracy check
             # and Python-level logging outside so warnings still reach stderr.
+            # Pool stays off here so the accuracy check runs with the live
+            # (production) allocator semantics and output mismatches surface
+            # naturally.
             with capture_output() as _captured_output:
                 synchronize_device()
                 output = fn(*working_args)  # make sure the kernel is compiled
@@ -974,7 +977,29 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                 # while other ranks return immediately, this will cause stuck jobs!
                 return inf
 
-            with capture_output() as _captured_output:
+            # Autotune passes the SAME ``working_args`` to every
+            # benchmark iteration, so the output's
+            # ``(dtype, shape, stride, device)`` signature is invariant
+            # across calls. ``enable_pool`` scopes the output pool to
+            # this benchmark loop:
+            #
+            # - ``_helion_pool_empty_like(x)`` returns the cached buffer
+            #   for this ``(dtype, shape, device)`` triple instead of
+            #   going through ``torch.empty_like`` (~1.4 us/call).
+            # - Same Python tensor identity across calls (the pool's
+            #   per-key cache returns the same object each iteration),
+            #   so any launcher-level same-args identity fast path can
+            #   keep hitting on the OUT arg too.
+            #
+            # The aliasing hazard the pool normally carries doesn't
+            # apply during autotune: each iteration discards its
+            # output before the next call begins, and ``do_bench``
+            # only reads the elapsed time, not the tensor contents.
+            # Per-thread state; the context manager restores the prior
+            # setting and clears buffers on exit.
+            from ..runtime._output_pool import _enable_pool
+
+            with capture_output() as _captured_output, _enable_pool():
                 benchmark_function = self.kernel.bench_compile_config(
                     config, allow_print=False
                 )

--- a/helion/runtime/_output_pool.py
+++ b/helion/runtime/_output_pool.py
@@ -1,0 +1,166 @@
+"""Optional output-tensor pool for Helion kernels.
+
+For small kernels, allocating a fresh output tensor with
+``torch.empty_like(x)`` is a measurable per-call cost (~1.5 μs on H100
+for a 4 KB tensor). This module provides ``_empty_like`` — a drop-in
+replacement that, when ``HELION_OUTPUT_POOL=1`` is set in the
+environment, caches one buffer per ``(dtype, shape, device, _slot)``
+key and returns the cached buffer on subsequent calls with the same
+key.
+
+When the env var is NOT set (the default), ``_empty_like`` is a thin
+pass-through to ``torch.empty_like`` and behaves exactly like the
+PyTorch builtin.
+
+Everything in this module is private (``_``-prefixed): the pool is
+internal infrastructure consumed by Helion's codegen and autotuner,
+not part of the public ``helion.runtime`` surface.
+
+Semantics caveat
+----------------
+Pooled buffers are RECYCLED across calls. The same call site with the
+same ``(dtype, shape, device, _slot)`` key gets the **same Python
+tensor object** every call — its contents are overwritten by the
+kernel each iteration. Callers MUST consume the returned tensor before
+the next call with the same key, or copy the data out: holding a
+reference for later use will see its contents clobbered. This is why
+the pool is opt-in: ``torch.empty_like`` semantics (fresh allocation)
+are the default to avoid silent aliasing bugs.
+
+Thread safety
+-------------
+The enabled flag and the cache are both **per-thread** (backed by
+``threading.local``). Calling :func:`_set_pool_enabled` /
+:func:`_enable_pool` / :func:`_empty_like` from one thread has no
+effect on what other threads see. This matches the autotune use case
+(one tuner thread scopes the pool to its bench loop without affecting
+concurrent inference threads) and avoids the bookkeeping that a
+process-global shared cache would need.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import threading
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from collections.abc import Hashable
+
+
+def _env_enabled() -> bool:
+    return os.environ.get("HELION_OUTPUT_POOL", "").lower() in ("1", "true", "yes")
+
+
+# Default flag, captured once at import. Each thread inherits this
+# value on first read but can override via ``_set_pool_enabled``.
+_DEFAULT_ENABLED: bool = _env_enabled()
+
+# Per-thread state. ``_state.enabled`` (bool) and ``_state.cache``
+# (dict) are lazily initialized on first access via the helpers below.
+_state: threading.local = threading.local()
+
+
+def _cache() -> dict[Hashable, torch.Tensor]:
+    cache = getattr(_state, "cache", None)
+    if cache is None:
+        cache = {}
+        _state.cache = cache
+    return cache
+
+
+def _set_pool_enabled(enabled: bool) -> None:
+    """Programmatic toggle for the pool, overriding the env var.
+
+    Per-thread: only affects the calling thread.
+    """
+    _state.enabled = enabled
+
+
+def _is_pool_enabled() -> bool:
+    """Whether the pool is currently enabled on the calling thread."""
+    return getattr(_state, "enabled", _DEFAULT_ENABLED)
+
+
+def _clear_pool() -> None:
+    """Drop all pooled buffers for the calling thread.
+
+    Useful for tests and for callers that want to reclaim memory after
+    a workload finishes.
+    """
+    _cache().clear()
+
+
+@contextlib.contextmanager
+def _enable_pool() -> Generator[None, None, None]:
+    """Context manager: enable the pool for the duration of the
+    ``with`` block on the calling thread, then disable and clear the
+    cache on exit.
+
+    NOT re-entrant. Calling :func:`_enable_pool` while the pool is
+    already enabled on the same thread raises ``RuntimeError``. The
+    autotuner is the only caller today and never nests; we surface the
+    constraint loudly so accidental nesting (which would clobber
+    another scope's cached buffers via the exit-time ``_clear_pool``)
+    fails immediately rather than silently.
+
+    Per-thread: only affects the calling thread.
+    """
+    if _is_pool_enabled():
+        raise RuntimeError(
+            "helion.runtime._output_pool._enable_pool() is not re-entrant; "
+            "pool is already enabled on this thread"
+        )
+    _set_pool_enabled(True)
+    try:
+        yield
+    finally:
+        _set_pool_enabled(False)
+        _clear_pool()
+
+
+def _empty_like(template: torch.Tensor, _slot: int = 0) -> torch.Tensor:
+    """Return an uninitialized tensor with the same dtype/shape/device
+    as ``template``.
+
+    When :func:`_is_pool_enabled` is ``True``, returns the cached buffer
+    for the ``(dtype, shape, device, _slot)`` key, allocating one on
+    first use. The same Python tensor object is returned across calls
+    with the same key. When ``False``, falls through to
+    ``torch.empty_like``.
+
+    ``_slot`` disambiguates multiple kernel-output allocations in the
+    same generated wrapper that share a ``(dtype, shape, device)``
+    triple. The codegen rewrite (``_rewrite_output_allocs_for_pool``)
+    assigns a unique ``_slot`` per call site so that, e.g., a two-output
+    kernel emitting two ``empty_like(x)`` allocations gets two distinct
+    cached buffers rather than collapsing both onto one (which would
+    silently alias them). Default ``_slot=0`` covers the single-output
+    case and direct callers.
+
+    Callers must consume the returned tensor before the next call with
+    the same signature, or copy the data out — see the module
+    docstring.
+    """
+    if not _is_pool_enabled():
+        return torch.empty_like(template)
+    cache = _cache()
+    key = (template.dtype, tuple(template.size()), template.device, _slot)
+    buf = cache.get(key)
+    if buf is None:
+        buf = torch.empty_like(template)
+        cache[key] = buf
+    return buf
+
+
+__all__ = [
+    "_clear_pool",
+    "_empty_like",
+    "_enable_pool",
+    "_is_pool_enabled",
+    "_set_pool_enabled",
+]

--- a/test/test_output_pool.py
+++ b/test/test_output_pool.py
@@ -1,0 +1,150 @@
+"""Tests for the opt-in output-tensor pool.
+
+The pool is gated on ``HELION_OUTPUT_POOL=1`` (or programmatically via
+``helion.runtime._output_pool._set_pool_enabled``). Default behavior
+is a pass-through to ``torch.empty_like``, so existing kernels that
+build their output with the standard PyTorch builtin are completely
+unaffected.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+import torch
+
+from helion.runtime._output_pool import _clear_pool as clear_pool
+from helion.runtime._output_pool import _empty_like as empty_like
+from helion.runtime._output_pool import _is_pool_enabled as is_pool_enabled
+from helion.runtime._output_pool import _set_pool_enabled as set_pool_enabled
+
+
+class TestPoolDisabledByDefault(unittest.TestCase):
+    """When the env var is unset, ``empty_like`` must behave exactly
+    like ``torch.empty_like``: a fresh allocation on every call."""
+
+    def setUp(self) -> None:
+        self.addCleanup(clear_pool)
+        # Snapshot + restore the global flag and env var so this test
+        # is isolated from any other test that may have toggled them.
+        self._old_env = os.environ.get("HELION_OUTPUT_POOL")
+        self._old_flag = is_pool_enabled()
+        os.environ.pop("HELION_OUTPUT_POOL", None)
+        set_pool_enabled(False)
+
+    def tearDown(self) -> None:
+        if self._old_env is not None:
+            os.environ["HELION_OUTPUT_POOL"] = self._old_env
+        else:
+            os.environ.pop("HELION_OUTPUT_POOL", None)
+        set_pool_enabled(self._old_flag)
+
+    def test_returns_fresh_tensor_each_call(self) -> None:
+        """Pool off → each call must return a distinct ``data_ptr()``."""
+        x = torch.randn(64, dtype=torch.float32)
+        a = empty_like(x)
+        b = empty_like(x)
+        self.assertNotEqual(a.data_ptr(), b.data_ptr())
+
+    def test_matches_torch_empty_like_metadata(self) -> None:
+        """Returned tensor's dtype/shape/stride/device matches template."""
+        x = torch.randn(3, 5, dtype=torch.bfloat16)
+        y = empty_like(x)
+        self.assertEqual(y.dtype, x.dtype)
+        self.assertEqual(y.shape, x.shape)
+        self.assertEqual(y.stride(), x.stride())
+        self.assertEqual(y.device, x.device)
+
+
+class TestPoolEnabled(unittest.TestCase):
+    """When the pool is enabled, repeat calls for the same
+    ``(dtype, shape, device)`` key return the SAME cached buffer."""
+
+    def setUp(self) -> None:
+        self.addCleanup(clear_pool)
+        self._old_flag = is_pool_enabled()
+        set_pool_enabled(True)
+        clear_pool()
+
+    def tearDown(self) -> None:
+        set_pool_enabled(self._old_flag)
+
+    def test_same_key_returns_same_tensor(self) -> None:
+        """Two calls with the same template key return the same Python
+        tensor object (and therefore the same storage)."""
+        x = torch.randn(64, dtype=torch.float32)
+        a = empty_like(x)
+        b = empty_like(x)
+        self.assertIs(a, b)
+        self.assertEqual(a.data_ptr(), b.data_ptr())
+
+    def test_distinct_shapes_get_distinct_buffers(self) -> None:
+        """A different shape must NOT collide with an existing cache
+        entry — it gets its own buffer."""
+        x1 = torch.randn(64, dtype=torch.float32)
+        x2 = torch.randn(128, dtype=torch.float32)
+        a = empty_like(x1)
+        b = empty_like(x2)
+        self.assertEqual(a.shape, x1.shape)
+        self.assertEqual(b.shape, x2.shape)
+        self.assertNotEqual(a.data_ptr(), b.data_ptr())
+
+    def test_distinct_dtypes_get_distinct_buffers(self) -> None:
+        """Same shape but different dtype → separate cache entries,
+        no aliasing."""
+        x1 = torch.randn(64, dtype=torch.float32)
+        x2 = torch.randn(64, dtype=torch.bfloat16)
+        a = empty_like(x1)
+        b = empty_like(x2)
+        self.assertEqual(a.dtype, x1.dtype)
+        self.assertEqual(b.dtype, x2.dtype)
+        self.assertNotEqual(a.data_ptr(), b.data_ptr())
+
+    def test_distinct_slots_get_distinct_buffers(self) -> None:
+        """Same ``(dtype, shape, device)`` but different ``_slot`` →
+        distinct cached buffers. Disambiguates multiple kernel-output
+        allocations in the same generated wrapper."""
+        x = torch.randn(64, dtype=torch.float32)
+        a = empty_like(x, _slot=0)
+        b = empty_like(x, _slot=1)
+        # Distinct tensor objects, distinct storage.
+        self.assertIsNot(a, b)
+        self.assertNotEqual(a.data_ptr(), b.data_ptr())
+        # And idempotent per-slot.
+        self.assertIs(empty_like(x, _slot=0), a)
+        self.assertIs(empty_like(x, _slot=1), b)
+
+    def test_clear_pool_releases_buffers(self) -> None:
+        """``clear_pool`` should drop refs so the next call allocates
+        fresh, not recycle."""
+        x = torch.randn(64, dtype=torch.float32)
+        first = empty_like(x)
+        clear_pool()
+        from helion.runtime._output_pool import _cache
+
+        self.assertEqual(len(_cache()), 0)
+        second = empty_like(x)
+        # New cache entry after clear; the returned tensor is a fresh
+        # allocation (not the same Python object as ``first``).
+        self.assertIsNot(first, second)
+        self.assertEqual(len(_cache()), 1)
+
+
+class TestEnvVarToggle(unittest.TestCase):
+    """``set_pool_enabled`` should mirror the env-var-driven default."""
+
+    def test_set_pool_enabled_changes_behavior(self) -> None:
+        old_flag = is_pool_enabled()
+        try:
+            set_pool_enabled(False)
+            self.assertFalse(is_pool_enabled())
+            set_pool_enabled(True)
+            self.assertTrue(is_pool_enabled())
+        finally:
+            set_pool_enabled(old_flag)
+            clear_pool()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_pool_autotune.py
+++ b/test/test_pool_autotune.py
@@ -1,0 +1,96 @@
+"""Tests for autotune-only output-pool enable.
+
+The codegen rewrite is unconditional now (every Helion wrapper calls
+``_helion_pool_empty_like`` for output allocations), so the SAME
+compiled wrapper is used in autotune mode (pool ON) and production
+(pool OFF). The autotuner flips the pool flag around its per-config
+benchmark and restores afterwards; the pool helper checks the flag at
+each call.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from helion.runtime import _output_pool as _pool_mod
+
+
+class TestPoolAutotuneEnable(unittest.TestCase):
+    def setUp(self) -> None:
+        # Save and force pool off so each test starts clean.
+        self._prev = _pool_mod._is_pool_enabled()
+        _pool_mod._set_pool_enabled(False)
+        _pool_mod._clear_pool()
+
+    def tearDown(self) -> None:
+        _pool_mod._set_pool_enabled(self._prev)
+        _pool_mod._clear_pool()
+
+    def test_default_is_off(self) -> None:
+        """Pool flag defaults to off so production calls hit the
+        standard allocator."""
+        self.assertFalse(_pool_mod._is_pool_enabled())
+
+    def test_helper_passthrough_when_off(self) -> None:
+        """``empty_like`` returns a fresh tensor (no pool) when the
+        flag is off."""
+        x = torch.randn(64)
+        a = _pool_mod._empty_like(x)
+        b = _pool_mod._empty_like(x)
+        # No pool -> distinct allocations.
+        self.assertIsNot(a, b)
+        self.assertNotEqual(a.data_ptr(), b.data_ptr())
+
+    def test_helper_recycles_when_on(self) -> None:
+        """When the pool is on, repeat calls for the same
+        ``(dtype, shape, device)`` triple return the SAME cached
+        tensor object."""
+        _pool_mod._set_pool_enabled(True)
+        try:
+            x = torch.randn(64)
+            a = _pool_mod._empty_like(x)
+            b = _pool_mod._empty_like(x)
+            self.assertIs(a, b)
+            self.assertEqual(a.data_ptr(), b.data_ptr())
+        finally:
+            _pool_mod._set_pool_enabled(False)
+
+    def test_enable_pool_context_manager(self) -> None:
+        """``enable_pool()`` flips the flag inside the ``with`` block
+        and clears the cache + disables the pool on exit. Mirrors how
+        ``benchmark_provider._benchmark_function`` scopes the pool to
+        its per-config bench loop."""
+        observed = []
+        _pool_mod._set_pool_enabled(False)
+        observed.append(("before", _pool_mod._is_pool_enabled()))
+        with _pool_mod._enable_pool():
+            observed.append(("during", _pool_mod._is_pool_enabled()))
+            # Populate the cache so we can verify it's cleared on exit.
+            _pool_mod._empty_like(torch.randn(8))
+            self.assertEqual(len(_pool_mod._cache()), 1)
+        observed.append(("after", _pool_mod._is_pool_enabled()))
+        self.assertEqual(
+            observed,
+            [("before", False), ("during", True), ("after", False)],
+        )
+        # Cache cleared on exit so the next caller starts clean.
+        self.assertEqual(len(_pool_mod._cache()), 0)
+
+    def test_enable_pool_not_reentrant(self) -> None:
+        """``enable_pool()`` raises if the pool is already enabled on
+        the calling thread. Nesting would silently clobber the outer
+        scope's cached buffers via the exit-time clear, so we fail
+        loudly instead."""
+        _pool_mod._set_pool_enabled(True)
+        try:
+            with self.assertRaises(RuntimeError), _pool_mod._enable_pool():
+                pass
+        finally:
+            _pool_mod._set_pool_enabled(False)
+            _pool_mod._clear_pool()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_pool_codegen_rewrite.py
+++ b/test/test_pool_codegen_rewrite.py
@@ -1,0 +1,233 @@
+"""Tests for the ``HELION_OUTPUT_POOL=1`` codegen rewrite.
+
+The rewrite swaps ``torch.empty_like(x)`` in the generated host wrapper
+to ``_helion_pool_empty_like(x)`` (== ``helion.runtime._output_pool._empty_like``) when
+the env var is set. On cache hit, the pool returns a recycled buffer
+instead of allocating, saving ~0.7 μs per call.
+
+These tests verify:
+- Rewrite fires when the env var is set; absent otherwise.
+- End-to-end correctness: output matches a fresh ``torch.empty_like``
+  baseline regardless of which path produced the output buffer.
+- Pool entries actually accumulate when the wrapper is exercised.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import unittest
+
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import skipIfNotCUDA
+from helion._testing import skipIfNotTriton
+import helion.language as hl
+
+
+def _make_add_kernel():
+    """Build a fresh kernel inside each test so the codegen runs under
+    the test's current env-var state (the rewrite is decided at compile
+    time, not at call time)."""
+
+    @helion.kernel(
+        static_shapes=True,
+        config=helion.Config(block_sizes=[1024], num_warps=4, num_stages=2),
+    )
+    def add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        out = torch.empty_like(x)
+        for tile in hl.tile(out.size(0)):
+            out[tile] = x[tile] + y[tile]
+        return out
+
+    return add
+
+
+@skipIfNotTriton("codegen rewrite is Triton-backend-only")
+class TestPoolCodegenRewrite(unittest.TestCase):
+    def _toggle_env(self, value: str | None) -> None:
+        prev = os.environ.get("HELION_OUTPUT_POOL")
+        self.addCleanup(
+            lambda: (
+                os.environ.__setitem__("HELION_OUTPUT_POOL", prev)
+                if prev is not None
+                else os.environ.pop("HELION_OUTPUT_POOL", None)
+            )
+        )
+        if value is None:
+            os.environ.pop("HELION_OUTPUT_POOL", None)
+        else:
+            os.environ["HELION_OUTPUT_POOL"] = value
+
+    @skipIfNotCUDA()
+    def test_rewrite_fires_when_env_var_set(self) -> None:
+        """Wrapper source must contain ``_helion_pool_empty_like`` when
+        ``HELION_OUTPUT_POOL=1`` was set at compile time."""
+        self._toggle_env("1")
+        add = _make_add_kernel()
+        x = torch.randn(4096, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(4096, device=DEVICE, dtype=torch.float32)
+        add(x, y)
+        bound = next(iter(add._bound_kernels.values()))  # type: ignore[attr-defined]
+        src = inspect.getsource(bound._run)
+        # Look at the rewritten call site, not the ``# src[...]``
+        # comment that preserves the user's original line for debugging.
+        # The actual emitted call should be the pool helper.
+        rewritten_line = [
+            ln for ln in src.splitlines() if "out = " in ln and "#" not in ln
+        ]
+        self.assertTrue(rewritten_line, "no rewritten 'out = ...' line found")
+        self.assertIn("_helion_pool_empty_like(x, _slot=0)", rewritten_line[0])
+
+    @skipIfNotCUDA()
+    def test_rewrite_present_even_without_env_var(self) -> None:
+        """The rewrite is unconditional now — the wrapper always emits
+        ``_helion_pool_empty_like``. When the pool is OFF at runtime
+        (default), the helper short-circuits to ``torch.empty_like``.
+
+        Doing the rewrite unconditionally lets a single compiled
+        wrapper work for both autotune (pool on) and production (pool
+        off) without recompiling.
+        """
+        self._toggle_env(None)
+        add = _make_add_kernel()
+        x = torch.randn(4096, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(4096, device=DEVICE, dtype=torch.float32)
+        add(x, y)
+        bound = next(iter(add._bound_kernels.values()))  # type: ignore[attr-defined]
+        src = inspect.getsource(bound._run)
+        rewritten_line = [
+            ln for ln in src.splitlines() if "out = " in ln and "#" not in ln
+        ]
+        self.assertTrue(rewritten_line, "no 'out = ...' line found")
+        self.assertIn("_helion_pool_empty_like(x, _slot=0)", rewritten_line[0])
+
+    @skipIfNotCUDA()
+    def test_end_to_end_correctness_with_rewrite(self) -> None:
+        """Same numeric output regardless of which path allocates."""
+        x = torch.randn(4096, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(4096, device=DEVICE, dtype=torch.float32)
+        expected = x + y
+
+        # Compile with rewrite off.
+        self._toggle_env(None)
+        add_no_pool = _make_add_kernel()
+        ref = add_no_pool(x, y)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(ref, expected)
+
+        # Compile with rewrite on. NOTE: importing helion.runtime here
+        # re-uses the module-level pool state — clear it to avoid
+        # cross-test interference.
+        self._toggle_env("1")
+        from helion.runtime._output_pool import _clear_pool as clear_pool
+        from helion.runtime._output_pool import _set_pool_enabled as set_pool_enabled
+
+        clear_pool()
+        set_pool_enabled(True)
+        try:
+            add_pool = _make_add_kernel()
+            for _ in range(3):
+                got = add_pool(x, y)
+                torch.cuda.synchronize()
+                torch.testing.assert_close(got, expected)
+        finally:
+            set_pool_enabled(False)
+            clear_pool()
+
+    @skipIfNotCUDA()
+    def test_pool_populated_after_calls(self) -> None:
+        """Multiple calls with the same shape should populate one
+        ``(dtype, shape, device, _slot)`` entry in the pool cache — not
+        allocate fresh per call."""
+        self._toggle_env("1")
+        from helion.runtime._output_pool import _cache
+        from helion.runtime._output_pool import _clear_pool as clear_pool
+        from helion.runtime._output_pool import _set_pool_enabled as set_pool_enabled
+
+        clear_pool()
+        set_pool_enabled(True)
+        try:
+            add = _make_add_kernel()
+            x = torch.randn(4096, device=DEVICE, dtype=torch.float32)
+            y = torch.randn(4096, device=DEVICE, dtype=torch.float32)
+            for _ in range(5):
+                add(x, y)
+            # Exactly one cache entry — same key.
+            self.assertEqual(len(_cache()), 1)
+        finally:
+            set_pool_enabled(False)
+            clear_pool()
+
+
+class TestRewriteSlotDisambiguation(unittest.TestCase):
+    """Multiple eligible ``torch.empty_like`` Assigns in the same
+    wrapper must each get a UNIQUE ``_slot`` kwarg, so that two
+    same-key kernel-output buffers don't collapse onto a single cached
+    tensor (which would silently alias them at runtime)."""
+
+    def test_two_outputs_get_distinct_slots(self) -> None:
+        import ast
+
+        from helion._compiler.generate_ast import _rewrite_output_allocs_for_pool
+
+        # Build the AST equivalent of:
+        #     out1 = torch.empty_like(x)
+        #     out2 = torch.empty_like(x)
+        #     launcher(x, out1, out2)
+        # then mark the launcher Expr as ``_is_kernel_call=True`` (the
+        # codegen sets that attribute on kernel-launch statements).
+        def _empty_like_assign(target: str) -> ast.Assign:
+            return ast.Assign(
+                targets=[ast.Name(id=target, ctx=ast.Store())],
+                value=ast.Call(
+                    func=ast.Attribute(
+                        value=ast.Name(id="torch", ctx=ast.Load()),
+                        attr="empty_like",
+                        ctx=ast.Load(),
+                    ),
+                    args=[ast.Name(id="x", ctx=ast.Load())],
+                    keywords=[],
+                ),
+            )
+
+        launcher_expr = ast.Expr(
+            value=ast.Call(
+                func=ast.Name(id="launcher", ctx=ast.Load()),
+                args=[
+                    ast.Name(id="x", ctx=ast.Load()),
+                    ast.Name(id="out1", ctx=ast.Load()),
+                    ast.Name(id="out2", ctx=ast.Load()),
+                ],
+                keywords=[],
+            )
+        )
+        launcher_expr._is_kernel_call = True  # type: ignore[attr-defined]
+
+        stmts = [
+            _empty_like_assign("out1"),
+            _empty_like_assign("out2"),
+            launcher_expr,
+        ]
+        _rewrite_output_allocs_for_pool(stmts)
+
+        # Both Assigns rewritten to the pool helper with distinct _slot.
+        slots: list[int] = []
+        for stmt in stmts[:2]:
+            assert isinstance(stmt, ast.Assign)
+            call = stmt.value
+            assert isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+            self.assertEqual(call.func.id, "_helion_pool_empty_like")
+            self.assertEqual(len(call.keywords), 1)
+            kw = call.keywords[0]
+            self.assertEqual(kw.arg, "_slot")
+            assert isinstance(kw.value, ast.Constant)
+            slots.append(kw.value.value)
+        self.assertEqual(slots, [0, 1])
+        self.assertEqual(len(set(slots)), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked PRs:
 * __->__#2636
 * #2635


--- --- ---

### [fast-launcher] Opt-in output-tensor pool + codegen rewrite + autotune


Adds an opt-in per-(dtype, shape, device, _slot) output-tensor pool.
The codegen rewrite ``_rewrite_output_allocs_for_pool`` unconditionally
swaps ``torch.empty_like(x)`` for kernel-output buffers to
``_helion_pool_empty_like(x, _slot=N)`` in the generated host wrapper;
the helper checks the per-thread pool flag at runtime and short-circuits
to ``torch.empty_like`` when off. ``_slot`` disambiguates multi-output
kernels that share a ``(dtype, shape, device)`` key. The autotuner
scopes the pool with ``with _enable_pool():`` around its per-config
``do_bench`` loop so the OUT tensor keeps a stable Python identity
across iterations.

All pool APIs are private (``_``-prefixed: ``_empty_like``,
``_set_pool_enabled``, ``_is_pool_enabled``, ``_clear_pool``,
``_enable_pool``) — the pool is internal infrastructure, not part of
the public ``helion.runtime`` surface. Per-thread state via
``threading.local`` so one tuner thread's pool doesn't leak into
concurrent inference threads. ``_enable_pool`` is non-reentrant and
raises if already enabled.

Benchmarks (H100, 10 trials × 200k iters, N=4096 fp32 add of n inputs,
StaticLauncher in use):

  n_args  pool=OFF    pool=ON     delta
  ------  --------    --------    ---------------
       2  10.67 µs    8.49 µs     -2.18 µs  (-20%)
       8  12.52 µs    10.93 µs    -1.59 µs  (-13%)
      16  16.28 µs    14.16 µs    -2.12 µs  (-13%)

The roughly 2 µs/call saving is the per-call ``torch.empty_like``
allocation that the pool replaces with a cached-buffer lookup.
