### PR TITLE
[Pallas] Fix inplace output preload for aliased outputs (shared by multiple tiles)

### DIFF
--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -384,6 +384,70 @@ def _estimate_pallas_vmem_bytes(
 _BlockSpecInfo = list[
     tuple[tuple[int | None, ...], tuple[int | tuple[int, int, int] | None, ...]] | None
 ]
+_PallasCopyGuards = dict[int, tuple[int, ...]]
+
+
+def _pallas_tensor_pos_map(
+    tensor_arg_indices: list[int],
+    output_only_indices: list[int] | None,
+) -> dict[int, int]:
+    all_positions = sorted(set(tensor_arg_indices) | set(output_only_indices or []))
+    return {orig: tpos for tpos, orig in enumerate(all_positions)}
+
+
+def _pallas_grid_dims_used_by_block_spec(
+    block_info: tuple[
+        tuple[int | None, ...], tuple[int | tuple[int, int, int] | None, ...]
+    ],
+) -> set[int]:
+    used: set[int] = set()
+    _, grid_dims = block_info
+    for grid_dim in grid_dims:
+        if isinstance(grid_dim, int):
+            used.add(grid_dim)
+        elif isinstance(grid_dim, tuple):
+            used.add(grid_dim[0])
+    return used
+
+
+def _pallas_shared_output_plan(
+    grid: tuple[int, ...],
+    tensor_arg_indices: list[int],
+    output_only_indices: list[int],
+    output_indices: list[int],
+    inplace_indices: set[int],
+    block_spec_info: _BlockSpecInfo | None,
+) -> tuple[_PallasCopyGuards, tuple[str, ...]]:
+    """Plan ordered updates for aliased outputs shared by multiple programs."""
+    dim_semantics = ["parallel"] * len(grid)
+    copy_guards: _PallasCopyGuards = {}
+    if not output_indices or not grid:
+        return copy_guards, tuple(dim_semantics)
+    if block_spec_info is None:
+        return copy_guards, tuple(dim_semantics)
+
+    arg_to_tpos = _pallas_tensor_pos_map(tensor_arg_indices, output_only_indices)
+    for orig_pos in output_indices:
+        if orig_pos not in inplace_indices:
+            continue
+        tensor_pos = arg_to_tpos.get(orig_pos)
+        if tensor_pos is None or tensor_pos >= len(block_spec_info):
+            continue
+        block_info = block_spec_info[tensor_pos]
+        if block_info is None:
+            continue
+        used_dims = _pallas_grid_dims_used_by_block_spec(block_info)
+        # These programs update the same output tile and must observe one
+        # shared accumulator, not a freshly preloaded copy per program.
+        shared_dims = tuple(
+            dim for dim, size in enumerate(grid) if size > 1 and dim not in used_dims
+        )
+        if not shared_dims:
+            continue
+        copy_guards[orig_pos] = shared_dims
+        for dim in shared_dims:
+            dim_semantics[dim] = "arbitrary"
+    return copy_guards, tuple(dim_semantics)
 
 
 def _pallas_build_block_specs(
@@ -977,6 +1041,7 @@ def _pallas_make_reordered_kernel(
     n_extra_refs: int = 0,
     skip_inplace_copy: set[int] | None = None,
     _smem_arg_indices: list[int] | None = None,
+    _copy_guards: _PallasCopyGuards | None = None,
 ) -> object:
     """Create a wrapper kernel that reorders pallas_call refs to the original arg order.
 
@@ -991,8 +1056,11 @@ def _pallas_make_reordered_kernel(
     where direct load/store is not allowed.
     """
     _skip_copy = skip_inplace_copy or set()
+    copy_guards = _copy_guards or {}
 
     def reordered_kernel(*refs: object) -> None:
+        from jax.experimental import pallas as pl
+
         n_kernel_params = len(args)
         original_order: list[object] = [None] * n_kernel_params
         for tensor_pos, orig_pos in enumerate(tensor_arg_indices):
@@ -1007,6 +1075,18 @@ def _pallas_make_reordered_kernel(
                     # [...] cannot be used for SMEMs,
                     # TODO(dunfanlu): handle in-place copy for SMEM refs
                     pass
+                elif orig_pos in copy_guards:
+                    should_copy = True
+                    for dim in copy_guards[orig_pos]:
+                        should_copy = should_copy & (pl.program_id(dim) == 0)
+
+                    @pl.when(should_copy)
+                    def _copy_shared_output(
+                        out_ref: object = out_ref,
+                        in_ref: object = in_ref,
+                    ) -> None:
+                        out_ref[...] = in_ref[...]  # type: ignore[index]
+
                 else:
                     out_ref[...] = in_ref[...]  # type: ignore[index]
             original_order[orig_pos] = out_ref
@@ -1230,6 +1310,14 @@ def default_pallas_launcher(
             spec_args, _output_indices, _inplace_indices, interpret=interpret
         )
 
+        copy_guards, dimension_semantics = _pallas_shared_output_plan(
+            grid,
+            tensor_arg_indices,
+            output_only_indices,
+            _output_indices,
+            inplace_positions,
+            _block_spec_info,
+        )
         in_specs, out_specs = _pallas_build_block_specs(
             pl,
             jnp,
@@ -1253,6 +1341,7 @@ def default_pallas_launcher(
             inplace_positions,
             arg_to_tensor_pos,
             _smem_arg_indices=_smem_arg_indices,
+            _copy_guards=copy_guards,
         )
 
         out_shape_arg = out_shapes if len(out_shapes) > 1 else out_shapes[0]
@@ -1284,6 +1373,10 @@ def default_pallas_launcher(
         if in_specs is not None:
             pallas_call_kwargs["in_specs"] = in_specs
             pallas_call_kwargs["out_specs"] = out_specs
+        if any(sem != "parallel" for sem in dimension_semantics):
+            pallas_call_kwargs["compiler_params"] = pltpu.CompilerParams(  # pyrefly: ignore[bad-instantiation]
+                dimension_semantics=dimension_semantics,
+            )
 
         jit_fn = pl.pallas_call(
             reordered_kernel,  # pyrefly: ignore[bad-argument-type]
@@ -1433,6 +1526,15 @@ def default_pallas_pipeline_launcher(
         assert _block_spec_info is not None, (
             "emit_pipeline launcher requires _block_spec_info from codegen"
         )
+        copy_guards, dimension_semantics = _pallas_shared_output_plan(
+            grid,
+            tensor_arg_indices,
+            output_only_indices,
+            _output_indices,
+            inplace_positions,
+            _block_spec_info,
+        )
+
         in_specs_list, out_specs = _pallas_build_pipeline_specs(
             pl,
             jnp,
@@ -1460,6 +1562,7 @@ def default_pallas_pipeline_launcher(
             n_extra_refs=len(scratch_shapes),
             skip_inplace_copy=_pipeline_set,
             _smem_arg_indices=_smem_arg_indices,
+            _copy_guards=copy_guards,
         )
 
         out_shape_arg = out_shapes if len(out_shapes) > 1 else out_shapes[0]
@@ -1494,7 +1597,7 @@ def default_pallas_pipeline_launcher(
             "out_shape": out_shape_arg,
             "grid_spec": grid_spec,
             "compiler_params": pltpu.CompilerParams(  # pyrefly: ignore[bad-instantiation]
-                dimension_semantics=tuple("parallel" for _ in grid),
+                dimension_semantics=dimension_semantics,
             ),
         }
         if interpret:
@@ -1648,6 +1751,15 @@ def default_pallas_fori_launcher(
         assert _block_spec_info is not None, (
             "fori_loop launcher requires _block_spec_info from codegen"
         )
+        copy_guards, dimension_semantics = _pallas_shared_output_plan(
+            grid,
+            tensor_arg_indices,
+            output_only_indices,
+            _output_indices,
+            inplace_positions,
+            _block_spec_info,
+        )
+
         in_specs_list, out_specs = _pallas_build_pipeline_specs(
             pl,
             jnp,
@@ -1675,6 +1787,7 @@ def default_pallas_fori_launcher(
             n_extra_refs=len(scratch_shapes),
             skip_inplace_copy=_fori_pipeline_set,
             _smem_arg_indices=_smem_arg_indices,
+            _copy_guards=copy_guards,
         )
 
         out_shape_arg = out_shapes if len(out_shapes) > 1 else out_shapes[0]
@@ -1709,7 +1822,7 @@ def default_pallas_fori_launcher(
             "out_shape": out_shape_arg,
             "grid_spec": grid_spec,
             "compiler_params": pltpu.CompilerParams(  # pyrefly: ignore[bad-instantiation]
-                dimension_semantics=tuple("parallel" for _ in grid),
+                dimension_semantics=dimension_semantics,
             ),
         }
         if interpret:

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -10,6 +10,7 @@ import os
 import sys
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Literal
 from typing import cast
 
 import torch
@@ -385,6 +386,7 @@ _BlockSpecInfo = list[
     tuple[tuple[int | None, ...], tuple[int | tuple[int, int, int] | None, ...]] | None
 ]
 _PallasCopyGuards = dict[int, tuple[int, ...]]
+_PallasDimensionSemantic = Literal["parallel", "arbitrary"]
 
 
 def _pallas_tensor_pos_map(
@@ -417,9 +419,9 @@ def _pallas_shared_output_plan(
     output_indices: list[int],
     inplace_indices: set[int],
     block_spec_info: _BlockSpecInfo | None,
-) -> tuple[_PallasCopyGuards, tuple[str, ...]]:
+) -> tuple[_PallasCopyGuards, tuple[_PallasDimensionSemantic, ...]]:
     """Plan ordered updates for aliased outputs shared by multiple programs."""
-    dim_semantics = ["parallel"] * len(grid)
+    dim_semantics: list[_PallasDimensionSemantic] = ["parallel"] * len(grid)
     copy_guards: _PallasCopyGuards = {}
     if not output_indices or not grid:
         return copy_guards, tuple(dim_semantics)

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -38,6 +38,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from collections.abc import Iterable
 
+    import jax
+
 _CUTLASS_SHUTDOWN_PATCHED = False
 
 
@@ -1031,6 +1033,35 @@ def _pallas_prepare_args(
     )
 
 
+def _pallas_do_smem_inplace_copy(
+    in_ref: object,
+    out_ref: object,
+    current_indices: tuple[int, ...] = (),
+) -> None:
+    if len(current_indices) == len(in_ref.shape):  # type: ignore[attr-defined]
+        out_ref[current_indices] = in_ref[current_indices]  # type: ignore[index]
+        return
+    next_dim = len(current_indices)
+    for i in range(in_ref.shape[next_dim]):  # type: ignore[attr-defined]
+        _pallas_do_smem_inplace_copy(in_ref, out_ref, (*current_indices, i))
+
+
+def _pallas_inplace_copy(in_ref: object, out_ref: object, *, is_smem: bool) -> None:
+    if is_smem:
+        _pallas_do_smem_inplace_copy(in_ref, out_ref)
+    else:
+        out_ref[...] = in_ref[...]  # type: ignore[index]
+
+
+def _pallas_copy_guard(dims: tuple[int, ...]) -> bool | jax.Array:
+    from jax.experimental import pallas as pl
+
+    should_copy = True
+    for dim in dims:
+        should_copy = should_copy & (pl.program_id(dim) == 0)
+    return should_copy
+
+
 def _pallas_make_reordered_kernel(
     pallas_kernel: object,
     args: tuple[object, ...],
@@ -1058,7 +1089,11 @@ def _pallas_make_reordered_kernel(
     where direct load/store is not allowed.
     """
     _skip_copy = skip_inplace_copy or set()
-    copy_guards = _copy_guards or {}
+    copy_guards = {
+        orig_pos: guard_dims
+        for orig_pos, guard_dims in (_copy_guards or {}).items()
+        if guard_dims
+    }
 
     def reordered_kernel(*refs: object) -> None:
         from jax.experimental import pallas as pl
@@ -1073,24 +1108,23 @@ def _pallas_make_reordered_kernel(
             out_ref = refs[n_tensor_inputs + out_idx]
             if orig_pos in inplace_positions and orig_pos not in _skip_copy:
                 in_ref = refs[arg_to_tensor_pos[orig_pos]]
-                if _smem_arg_indices is not None and orig_pos in _smem_arg_indices:
-                    # [...] cannot be used for SMEMs,
-                    # TODO(dunfanlu): handle in-place copy for SMEM refs
-                    pass
-                elif orig_pos in copy_guards:
-                    should_copy = True
-                    for dim in copy_guards[orig_pos]:
-                        should_copy = should_copy & (pl.program_id(dim) == 0)
+                is_smem = (
+                    _smem_arg_indices is not None and orig_pos in _smem_arg_indices
+                )
+                copy_guard_dims = copy_guards.get(orig_pos)
+                if copy_guard_dims:
+                    should_copy = _pallas_copy_guard(copy_guard_dims)
 
                     @pl.when(should_copy)
                     def _copy_shared_output(
                         out_ref: object = out_ref,
                         in_ref: object = in_ref,
+                        is_smem: bool = is_smem,
                     ) -> None:
-                        out_ref[...] = in_ref[...]  # type: ignore[index]
+                        _pallas_inplace_copy(in_ref, out_ref, is_smem=is_smem)
 
                 else:
-                    out_ref[...] = in_ref[...]  # type: ignore[index]
+                    _pallas_inplace_copy(in_ref, out_ref, is_smem=is_smem)
             original_order[orig_pos] = out_ref
         extra_refs = refs[n_tensor_inputs + len(_output_indices) :]
         pallas_kernel(*original_order, *extra_refs)  # type: ignore[operator]

--- a/test/test_atomic_ops.py
+++ b/test/test_atomic_ops.py
@@ -11,6 +11,7 @@ from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
+from helion._testing import skipIfCute
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfRocm
 from helion._testing import skipIfTileIR
@@ -154,65 +155,6 @@ def atomic_add_tensor_index_kernel(
     out = torch.zeros([n], dtype=values.dtype, device=values.device)
     for tile in hl.tile(n):
         hl.atomic_add(out, [indices[tile]], values[tile])
-    return out
-
-
-@helion.kernel(static_shapes=True)
-def pallas_structural_atomic_add_kernel(x: torch.Tensor) -> torch.Tensor:
-    """Structurally shared output tile: contributor dim is leading K."""
-    k, m, n = x.shape
-    out = torch.ones([m, n], dtype=x.dtype, device=x.device)
-    for tile_k, tile_m, tile_n in hl.tile([k, m, n]):
-        value = torch.sum(x[tile_k, tile_m, tile_n], dim=0)
-        hl.atomic_add(out, [tile_m, tile_n], value)
-    return out
-
-
-@helion.kernel(static_shapes=True)
-def pallas_structural_atomic_add_2_contributor_kernel(
-    x: torch.Tensor,
-) -> torch.Tensor:
-    """Two contributor dims both update the same output tile."""
-    r, k, m, n = x.shape
-    out = torch.ones([m, n], dtype=x.dtype, device=x.device)
-    for tile_r, tile_k, tile_m, tile_n in hl.tile([r, k, m, n]):
-        value = torch.sum(torch.sum(x[tile_r, tile_k, tile_m, tile_n], dim=0), dim=0)
-        hl.atomic_add(out, [tile_m, tile_n], value)
-    return out
-
-
-@helion.kernel(static_shapes=True)
-def pallas_structural_atomic_add_two_outputs_kernel(
-    x: torch.Tensor, y: torch.Tensor
-) -> tuple[torch.Tensor, torch.Tensor]:
-    k, m, n = x.shape
-    out_x = torch.ones([m, n], dtype=x.dtype, device=x.device)
-    out_y = torch.full([m, n], 2.0, dtype=y.dtype, device=y.device)
-    for tile_k, tile_m, tile_n in hl.tile([k, m, n]):
-        x_value = torch.sum(x[tile_k, tile_m, tile_n], dim=0)
-        y_value = torch.sum(y[tile_k, tile_m, tile_n], dim=0)
-        hl.atomic_add(out_x, [tile_m, tile_n], x_value)
-        hl.atomic_add(out_y, [tile_m, tile_n], y_value)
-    return out_x, out_y
-
-
-@helion.kernel(static_shapes=True)
-def pallas_structural_atomic_max_kernel(x: torch.Tensor) -> torch.Tensor:
-    out = torch.full(
-        [x.size(1), x.size(2)], -1000.0, dtype=x.dtype, device=x.device
-    )
-    for tile_k, tile_m, tile_n in hl.tile(x.size()):
-        value = torch.amax(x[tile_k, tile_m, tile_n], dim=0)
-        hl.atomic_max(out, [tile_m, tile_n], value)
-    return out
-
-
-@helion.kernel(static_shapes=True)
-def pallas_structural_atomic_min_kernel(x: torch.Tensor) -> torch.Tensor:
-    out = torch.full([x.size(1), x.size(2)], 1000.0, dtype=x.dtype, device=x.device)
-    for tile_k, tile_m, tile_n in hl.tile(x.size()):
-        value = torch.amin(x[tile_k, tile_m, tile_n], dim=0)
-        hl.atomic_min(out, [tile_m, tile_n], value)
     return out
 
 
@@ -516,6 +458,16 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
 
     @onlyBackends(["pallas"])
     def test_pallas_structural_atomic_add_shared_tile(self):
+        @helion.kernel(static_shapes=True)
+        def pallas_structural_atomic_add_kernel(x: torch.Tensor) -> torch.Tensor:
+            """Structurally shared output tile: contributor dim is leading K."""
+            k, m, n = x.shape
+            out = torch.ones([m, n], dtype=x.dtype, device=x.device)
+            for tile_k, tile_m, tile_n in hl.tile([k, m, n]):
+                value = torch.sum(x[tile_k, tile_m, tile_n], dim=0)
+                hl.atomic_add(out, [tile_m, tile_n], value)
+            return out
+
         x = torch.randn(4, 16, 128, device=DEVICE, dtype=torch.float32)
 
         for loop_type in ("unroll", "fori_loop", "emit_pipeline"):
@@ -529,30 +481,56 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
                 expected = torch.ones(16, 128, device=DEVICE) + x.sum(dim=0)
                 torch.testing.assert_close(result, expected)
 
-    @onlyBackends(["pallas"])
-    def test_pallas_structural_atomic_add_two_contributor_dims(self):
+    @skipIfCute("CuTe does not handle structural shared-tile atomics yet")
+    def test_structural_atomic_add_two_contributor_dims(self):
+        @helion.kernel(static_shapes=True)
+        def structural_atomic_add_2_contributor_kernel(
+            x: torch.Tensor,
+        ) -> torch.Tensor:
+            """Two contributor dims both update the same output tile."""
+            r, k, m, n = x.shape
+            out = torch.ones([m, n], dtype=x.dtype, device=x.device)
+            for tile_r, tile_k, tile_m, tile_n in hl.tile([r, k, m, n]):
+                value = torch.sum(
+                    torch.sum(x[tile_r, tile_k, tile_m, tile_n], dim=0), dim=0
+                )
+                hl.atomic_add(out, [tile_m, tile_n], value)
+            return out
+
         x = torch.randn(3, 4, 16, 128, device=DEVICE, dtype=torch.float32)
 
         code, result = code_and_output(
-            pallas_structural_atomic_add_2_contributor_kernel,
+            structural_atomic_add_2_contributor_kernel,
             (x,),
             block_sizes=[1, 1, 8, 128],
-            pallas_loop_type="fori_loop",
         )
 
         expected = torch.ones(16, 128, device=DEVICE) + x.sum(dim=(0, 1))
         torch.testing.assert_close(result, expected)
 
-    @onlyBackends(["pallas"])
-    def test_pallas_structural_atomic_add_multiple_outputs(self):
+    @skipIfCute("CuTe does not handle structural shared-tile atomics yet")
+    def test_structural_atomic_add_multiple_outputs(self):
+        @helion.kernel(static_shapes=True)
+        def structural_atomic_add_two_outputs_kernel(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            k, m, n = x.shape
+            out_x = torch.ones([m, n], dtype=x.dtype, device=x.device)
+            out_y = torch.full([m, n], 2.0, dtype=y.dtype, device=y.device)
+            for tile_k, tile_m, tile_n in hl.tile([k, m, n]):
+                x_value = torch.sum(x[tile_k, tile_m, tile_n], dim=0)
+                y_value = torch.sum(y[tile_k, tile_m, tile_n], dim=0)
+                hl.atomic_add(out_x, [tile_m, tile_n], x_value)
+                hl.atomic_add(out_y, [tile_m, tile_n], y_value)
+            return out_x, out_y
+
         x = torch.randn(4, 16, 128, device=DEVICE, dtype=torch.float32)
         y = torch.randn(4, 16, 128, device=DEVICE, dtype=torch.float32)
 
         code, (out_x, out_y) = code_and_output(
-            pallas_structural_atomic_add_two_outputs_kernel,
+            structural_atomic_add_two_outputs_kernel,
             (x, y),
             block_sizes=[1, 8, 128],
-            pallas_loop_type="emit_pipeline",
         )
 
         torch.testing.assert_close(
@@ -562,12 +540,32 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
             out_y, torch.full([16, 128], 2.0, device=DEVICE) + y.sum(dim=0)
         )
 
-    @onlyBackends(["pallas"])
-    def test_pallas_structural_atomic_max_min_shared_tile(self):
+    @skipIfCute("CuTe does not handle structural shared-tile atomics yet")
+    def test_structural_atomic_max_min_shared_tile(self):
+        @helion.kernel(static_shapes=True)
+        def structural_atomic_max_kernel(x: torch.Tensor) -> torch.Tensor:
+            out = torch.full(
+                [x.size(1), x.size(2)], -1000.0, dtype=x.dtype, device=x.device
+            )
+            for tile_k, tile_m, tile_n in hl.tile(x.size()):
+                value = torch.amax(x[tile_k, tile_m, tile_n], dim=0)
+                hl.atomic_max(out, [tile_m, tile_n], value)
+            return out
+
+        @helion.kernel(static_shapes=True)
+        def structural_atomic_min_kernel(x: torch.Tensor) -> torch.Tensor:
+            out = torch.full(
+                [x.size(1), x.size(2)], 1000.0, dtype=x.dtype, device=x.device
+            )
+            for tile_k, tile_m, tile_n in hl.tile(x.size()):
+                value = torch.amin(x[tile_k, tile_m, tile_n], dim=0)
+                hl.atomic_min(out, [tile_m, tile_n], value)
+            return out
+
         x = torch.randn(4, 16, 128, device=DEVICE, dtype=torch.float32)
 
         code_max, result_max = code_and_output(
-            pallas_structural_atomic_max_kernel,
+            structural_atomic_max_kernel,
             (x,),
             block_sizes=[1, 8, 128],
         )
@@ -577,7 +575,7 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result_max, expected_max)
 
         code_min, result_min = code_and_output(
-            pallas_structural_atomic_min_kernel,
+            structural_atomic_min_kernel,
             (x,),
             block_sizes=[1, 8, 128],
         )

--- a/test/test_atomic_ops.py
+++ b/test/test_atomic_ops.py
@@ -157,6 +157,65 @@ def atomic_add_tensor_index_kernel(
     return out
 
 
+@helion.kernel(static_shapes=True)
+def pallas_structural_atomic_add_kernel(x: torch.Tensor) -> torch.Tensor:
+    """Structurally shared output tile: contributor dim is leading K."""
+    k, m, n = x.shape
+    out = torch.ones([m, n], dtype=x.dtype, device=x.device)
+    for tile_k, tile_m, tile_n in hl.tile([k, m, n]):
+        value = torch.sum(x[tile_k, tile_m, tile_n], dim=0)
+        hl.atomic_add(out, [tile_m, tile_n], value)
+    return out
+
+
+@helion.kernel(static_shapes=True)
+def pallas_structural_atomic_add_2_contributor_kernel(
+    x: torch.Tensor,
+) -> torch.Tensor:
+    """Two contributor dims both update the same output tile."""
+    r, k, m, n = x.shape
+    out = torch.ones([m, n], dtype=x.dtype, device=x.device)
+    for tile_r, tile_k, tile_m, tile_n in hl.tile([r, k, m, n]):
+        value = torch.sum(torch.sum(x[tile_r, tile_k, tile_m, tile_n], dim=0), dim=0)
+        hl.atomic_add(out, [tile_m, tile_n], value)
+    return out
+
+
+@helion.kernel(static_shapes=True)
+def pallas_structural_atomic_add_two_outputs_kernel(
+    x: torch.Tensor, y: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    k, m, n = x.shape
+    out_x = torch.ones([m, n], dtype=x.dtype, device=x.device)
+    out_y = torch.full([m, n], 2.0, dtype=y.dtype, device=y.device)
+    for tile_k, tile_m, tile_n in hl.tile([k, m, n]):
+        x_value = torch.sum(x[tile_k, tile_m, tile_n], dim=0)
+        y_value = torch.sum(y[tile_k, tile_m, tile_n], dim=0)
+        hl.atomic_add(out_x, [tile_m, tile_n], x_value)
+        hl.atomic_add(out_y, [tile_m, tile_n], y_value)
+    return out_x, out_y
+
+
+@helion.kernel(static_shapes=True)
+def pallas_structural_atomic_max_kernel(x: torch.Tensor) -> torch.Tensor:
+    out = torch.full(
+        [x.size(1), x.size(2)], -1000.0, dtype=x.dtype, device=x.device
+    )
+    for tile_k, tile_m, tile_n in hl.tile(x.size()):
+        value = torch.amax(x[tile_k, tile_m, tile_n], dim=0)
+        hl.atomic_max(out, [tile_m, tile_n], value)
+    return out
+
+
+@helion.kernel(static_shapes=True)
+def pallas_structural_atomic_min_kernel(x: torch.Tensor) -> torch.Tensor:
+    out = torch.full([x.size(1), x.size(2)], 1000.0, dtype=x.dtype, device=x.device)
+    for tile_k, tile_m, tile_n in hl.tile(x.size()):
+        value = torch.amin(x[tile_k, tile_m, tile_n], dim=0)
+        hl.atomic_min(out, [tile_m, tile_n], value)
+    return out
+
+
 # New kernels for other atomics
 
 
@@ -454,6 +513,78 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
             torch.bfloat16
         )
         torch.testing.assert_close(result, expected, atol=0.1, rtol=0.05)
+
+    @onlyBackends(["pallas"])
+    def test_pallas_structural_atomic_add_shared_tile(self):
+        x = torch.randn(4, 16, 128, device=DEVICE, dtype=torch.float32)
+
+        for loop_type in ("unroll", "fori_loop", "emit_pipeline"):
+            with self.subTest(loop_type=loop_type):
+                code, result = code_and_output(
+                    pallas_structural_atomic_add_kernel,
+                    (x,),
+                    block_sizes=[1, 8, 128],
+                    pallas_loop_type=loop_type,
+                )
+                expected = torch.ones(16, 128, device=DEVICE) + x.sum(dim=0)
+                torch.testing.assert_close(result, expected)
+
+    @onlyBackends(["pallas"])
+    def test_pallas_structural_atomic_add_two_contributor_dims(self):
+        x = torch.randn(3, 4, 16, 128, device=DEVICE, dtype=torch.float32)
+
+        code, result = code_and_output(
+            pallas_structural_atomic_add_2_contributor_kernel,
+            (x,),
+            block_sizes=[1, 1, 8, 128],
+            pallas_loop_type="fori_loop",
+        )
+
+        expected = torch.ones(16, 128, device=DEVICE) + x.sum(dim=(0, 1))
+        torch.testing.assert_close(result, expected)
+
+    @onlyBackends(["pallas"])
+    def test_pallas_structural_atomic_add_multiple_outputs(self):
+        x = torch.randn(4, 16, 128, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(4, 16, 128, device=DEVICE, dtype=torch.float32)
+
+        code, (out_x, out_y) = code_and_output(
+            pallas_structural_atomic_add_two_outputs_kernel,
+            (x, y),
+            block_sizes=[1, 8, 128],
+            pallas_loop_type="emit_pipeline",
+        )
+
+        torch.testing.assert_close(
+            out_x, torch.ones(16, 128, device=DEVICE) + x.sum(dim=0)
+        )
+        torch.testing.assert_close(
+            out_y, torch.full([16, 128], 2.0, device=DEVICE) + y.sum(dim=0)
+        )
+
+    @onlyBackends(["pallas"])
+    def test_pallas_structural_atomic_max_min_shared_tile(self):
+        x = torch.randn(4, 16, 128, device=DEVICE, dtype=torch.float32)
+
+        code_max, result_max = code_and_output(
+            pallas_structural_atomic_max_kernel,
+            (x,),
+            block_sizes=[1, 8, 128],
+        )
+        expected_max = torch.maximum(
+            torch.full([16, 128], -1000.0, device=DEVICE), x.amax(dim=0)
+        )
+        torch.testing.assert_close(result_max, expected_max)
+
+        code_min, result_min = code_and_output(
+            pallas_structural_atomic_min_kernel,
+            (x,),
+            block_sizes=[1, 8, 128],
+        )
+        expected_min = torch.minimum(
+            torch.full([16, 128], 1000.0, device=DEVICE), x.amin(dim=0)
+        )
+        torch.testing.assert_close(result_min, expected_min)
 
     def test_atomic_add_code_generation(self):
         """Test that the generated code contains atomic_add."""

--- a/test/test_atomic_ops.py
+++ b/test/test_atomic_ops.py
@@ -633,7 +633,6 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
             )
         self.assertIn("Invalid memory semantic 'ERROR'", str(ctx.exception))
 
-    @xfailIfPallas("https://github.com/pytorch/helion/issues/2304")
     @skipIfRefEager(
         "Test is block size dependent which is not supported in ref eager mode"
     )

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1017,7 +1017,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             skip_accuracy=True,  # TODO(yf225): fix unstable numerics
         )
 
-    @xfailIfPallas("InductorLoweringError")
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
     def test_matmul_split_k(self):
         args = (

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -16,7 +16,6 @@ from helion._testing import skipIfMetal
 from helion._testing import skipIfXPU
 from helion._testing import skipUnlessTensorDescriptor
 from helion._testing import xfailIfPallas
-from helion._testing import xfailIfPallasInterpret
 from helion._testing import xfailIfPallasTpu
 import helion.language as hl
 
@@ -168,7 +167,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(grid_2d_idx_nested, args)
         torch.testing.assert_close(result, grid_2d_pytorch(args[0], args[1]))
 
-    @xfailIfPallasInterpret("numerical mismatch in JAX interpret mode")
     @skipIfMetal("BUG: hl.grid begin/end broken with CuteNDTileStrategy on Metal")
     def test_grid_begin_end(self):
         @helion.kernel(autotune_effort="none")
@@ -232,7 +230,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(grid_end_step_kwarg, (x,))
         torch.testing.assert_close(result, grid_end_step_kwarg_pytorch(x))
 
-    @xfailIfPallasInterpret("numerical mismatch in JAX interpret mode")
     def test_grid_multidim_begin_end(self):
         @helion.kernel(autotune_effort="none")
         def grid_multidim_begin_end(x: torch.Tensor) -> torch.Tensor:

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -191,7 +191,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, grid_begin_end_pytorch(x))
 
     @skipIfMetal("BUG: hl.grid begin/end broken with CuteNDTileStrategy on Metal")
-    @xfailIfPallas("Grid begin/end not working on Pallas")
     def test_grid_begin_end_step(self):
         @helion.kernel(autotune_effort="none")
         def grid_begin_end_step(x: torch.Tensor) -> torch.Tensor:
@@ -213,7 +212,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, grid_begin_end_step_pytorch(x))
 
     @skipIfMetal("BUG: hl.grid begin/end broken with CuteNDTileStrategy on Metal")
-    @xfailIfPallas("Grid begin/end not working on Pallas")
     def test_grid_end_step_kwarg(self):
         @helion.kernel(autotune_effort="none")
         def grid_end_step_kwarg(x: torch.Tensor) -> torch.Tensor:
@@ -258,7 +256,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         code, result = code_and_output(grid_multidim_begin_end, (x,))
         torch.testing.assert_close(result, grid_multidim_begin_end_pytorch(x))
 
-    @xfailIfPallas("Grid begin/end not working on Pallas")
     def test_grid_multidim_begin_end_step(self):
         @helion.kernel(autotune_effort="none")
         def grid_multidim_begin_end_step(x: torch.Tensor) -> torch.Tensor:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -213,13 +213,6 @@ def pallas_inplace_add(x: torch.Tensor, y: torch.Tensor) -> None:
         x[tile] = x[tile] + y[tile]
 
 
-@helion.kernel(backend="pallas", static_shapes=True, autotune_effort="none")
-def pallas_shared_output_disjoint_rows(x: torch.Tensor) -> torch.Tensor:
-    for row in hl.grid(2):
-        x[row, :] = x[row, :] + (row + 10)
-    return x
-
-
 @helion.kernel(backend="pallas", static_shapes=True)
 def pallas_add_2d(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     out = torch.empty_like(x)
@@ -902,6 +895,12 @@ class TestPallas(TestCase):
         torch.testing.assert_close(x, expected)
 
     def test_shared_output_disjoint_rows(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True, autotune_effort="none")
+        def pallas_shared_output_disjoint_rows(x: torch.Tensor) -> torch.Tensor:
+            for row in hl.grid(2):
+                x[row, :] = x[row, :] + (row + 10)
+            return x
+
         x = torch.zeros([2, 128], device=DEVICE, dtype=torch.float32)
         expected = torch.stack(
             [

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1886,7 +1886,7 @@ class TestPallas(TestCase):
         result = fn(x)
         torch.testing.assert_close(result, x)
 
-    @xfailIfPallasInterpret("numerical mismatch in JAX interpret mode")
+    @skipIfPallasInterpret("SMEM preload copy is too expensive in JAX interpret mode")
     def test_scalar_access_2D_constexpr(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True, config=helion.Config())
         def fn(x: torch.Tensor) -> torch.Tensor:
@@ -2087,6 +2087,9 @@ class TestPallas(TestCase):
         expected = x[x.shape[0] // 2 :] + 0.5
         torch.testing.assert_close(result, expected)
 
+    @skipIfPallasInterpret(
+        "2D SMEM preload copy is too expensive in JAX interpret mode"
+    )
     def test_scalar_access_hl_grid_2d(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True, config=helion.Config())
         def fn(x: torch.Tensor) -> torch.Tensor:
@@ -2105,6 +2108,9 @@ class TestPallas(TestCase):
         _, result = code_and_output(fn, (x,), loop_order=[1, 0])
         torch.testing.assert_close(result, expected)
 
+    @skipIfPallasInterpret(
+        "2D SMEM preload copy is too expensive in JAX interpret mode"
+    )
     def test_scalar_access_hl_grid_2d_nested(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True, config=helion.Config())
         def fn(x: torch.Tensor) -> torch.Tensor:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -213,6 +213,13 @@ def pallas_inplace_add(x: torch.Tensor, y: torch.Tensor) -> None:
         x[tile] = x[tile] + y[tile]
 
 
+@helion.kernel(backend="pallas", static_shapes=True, autotune_effort="none")
+def pallas_shared_output_disjoint_rows(x: torch.Tensor) -> torch.Tensor:
+    for row in hl.grid(2):
+        x[row, :] = x[row, :] + (row + 10)
+    return x
+
+
 @helion.kernel(backend="pallas", static_shapes=True)
 def pallas_add_2d(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     out = torch.empty_like(x)
@@ -893,6 +900,17 @@ class TestPallas(TestCase):
         code, result = code_and_output(pallas_inplace_add, (x, y), block_size=1024)
         # x should be mutated in place
         torch.testing.assert_close(x, expected)
+
+    def test_shared_output_disjoint_rows(self) -> None:
+        x = torch.zeros([2, 128], device=DEVICE, dtype=torch.float32)
+        expected = torch.stack(
+            [
+                torch.full([128], 10.0, device=DEVICE),
+                torch.full([128], 11.0, device=DEVICE),
+            ]
+        )
+        code, result = code_and_output(pallas_shared_output_disjoint_rows, (x,))
+        torch.testing.assert_close(result, expected)
 
     def test_pointwise_mul(self) -> None:
         args = (

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -2061,6 +2061,18 @@ class TestPallas(TestCase):
         expected = x + 0.5
         torch.testing.assert_close(result, expected)
 
+    def test_scalar_access_hl_grid_inplace(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True, config=helion.Config())
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            for i in hl.grid(x.size(0)):
+                x[i] = x[i] + 1
+            return x
+
+        x = torch.arange(128, device=DEVICE, dtype=torch.float32)
+        expected = x + 1
+        result = fn(x)
+        torch.testing.assert_close(result, expected)
+
     def test_scalar_access_hl_grid_offset(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True, config=helion.Config())
         def fn(x: torch.Tensor) -> torch.Tensor:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -629,7 +629,6 @@ class TestPallas(TestCase):
         self.assertNotIn("pltpu.emit_pipeline", code)
         self.assertIn("out[:]", code)
 
-    @xfailIfPallasInterpret("numerical mismatch in JAX interpret mode")
     def test_pipeline_kernel_tile_begin_plus_offset_is_elementwise(self) -> None:
         x = torch.arange(1024, device=DEVICE, dtype=torch.float32)
         code, result = code_and_output(


### PR DESCRIPTION
[Pallas] Fix inplace output preload for aliased outputs shared by multiple tiles.

When an output BlockSpec does not use a varying grid dimension, multiple programs update the same resident output tile. The launcher used to run:

```python
out_ref[...] = in_ref[...]
```

in every program. Later programs could reload the original input value and erase earlier updates.

The launcher now detects those shared output dims, marks them `arbitrary`, and guards the preload so it runs only for the first program along the shared dims.