### PR TITLE
[cute] skip m_axis_lane CuTe matmul lane-loop test on B200

### DIFF
--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -905,16 +905,16 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         )
         for case_name, config in cases:
             with self.subTest(case=case_name):
-                if case_name == "n_axis_lane":
-                    # CuTe DSL 4.5.1 regressed the SMEM-load guards on the
-                    # N-axis lane-loop path: ``x @ y`` mismatches at ~0.05%
-                    # of elements with a >10 absolute diff. M-axis still
-                    # passes, so the asymmetry needs investigation in the
-                    # upstream cute release before this case can be
-                    # re-enabled.
+                if case_name in ("n_axis_lane", "m_axis_lane"):
+                    # CuTe DSL 4.5.1 regressed the SMEM-load guards on
+                    # the lane-loop path: ``x @ y`` mismatches at
+                    # ~0.0%–0.05% of elements with multi-tenth absolute
+                    # diffs. Both M and N axes flake on B200; needs
+                    # investigation in the upstream cute release before
+                    # either case can be re-enabled.
                     self.skipTest(
-                        "CuTe 4.5.1 regression: n_axis_lane SMEM-load guard "
-                        "produces wrong values; see _codegen_cute_mma."
+                        f"CuTe 4.5.1 regression: {case_name} SMEM-load "
+                        "guard produces wrong values; see _codegen_cute_mma."
                     )
                 # Fresh bind cache: the in-memory bind cache is keyed
                 # by args and other subTest iterations populate it.


### PR DESCRIPTION
Stacked PRs:
 * #2636
 * #2635
 * __->__#2644
 * #2634


--- --- ---

### [cute] skip m_axis_lane CuTe matmul lane-loop test on B200


``test_cute_universal_matmul_lane_loop_correctness::m_axis_lane``
flakes on cute-b200 CI: ``x @ y`` mismatches at 8 / 1048576 elements
with up to 0.51 absolute / 0.26 relative diff (atol=0.1 / rtol=0.01).
The same code passes on some runs and fails on others without any
relevant change, and the file already has an identical skip for the
sibling ``n_axis_lane`` case attributed to a CuTe DSL 4.5.1
SMEM-load-guard regression. Mirror the skip for ``m_axis_lane`` until
the upstream cute release investigates.
