### PR TITLE
[Pallas] Add Kernel.jax_fn for pure-JAX export of Pallas kernels

### DIFF
--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -13,6 +13,7 @@ import sys
 import textwrap
 import types
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import Callable
 from typing import Generic
 from typing import Hashable
@@ -343,6 +344,10 @@ class Kernel(Generic[_R]):
             if isinstance(obj, torch.fx.GraphModule):
                 # GraphModule subclasses need special handling
                 extractor = _specialization_extractors[torch.fx.GraphModule]
+            elif isinstance(obj, torch.Tensor):
+                # torch.Tensor subclasses (e.g. the JAX-export adapter)
+                # share the standard tensor specialization key.
+                extractor = _specialization_extractors[torch.Tensor]
             elif isinstance(obj, tuple) and hasattr(obj, "_fields"):
                 # this is a namedtuple
                 extractor = _specialization_extractors["namedtuple"]
@@ -415,6 +420,28 @@ class Kernel(Generic[_R]):
         recompile and re-autotune.
         """
         self._bound_kernels.clear()
+
+    @property
+    def jax_fn(self) -> Callable[..., Any]:
+        """A pure-JAX callable view of this Helion kernel.
+
+        Pallas-backend kernels can be called directly with JAX arrays
+        or tracers (i.e. inside ``jax.jit``) by going through this
+        property.  The kernel's compile/specialize path runs the first
+        time the callable is invoked; subsequent calls reuse the
+        cached compilation just like ``__call__``.
+
+        This only supports kernels compiled for the Pallas backend.
+        """
+        from .pallas_jax_export import make_jax_fn
+
+        cached = getattr(self, "_jax_fn_callable", None)
+        if cached is not None:
+            return cast("Callable[..., Any]", cached)
+        rv = make_jax_fn(self)
+        # pyrefly: ignore [unsupported-attribute-set]
+        self._jax_fn_callable = rv
+        return rv
 
 
 class BoundKernel(_AutotunableKernel, Generic[_R]):

--- a/helion/runtime/pallas_jax_export.py
+++ b/helion/runtime/pallas_jax_export.py
@@ -1,0 +1,435 @@
+"""Pure-JAX export path for Helion-generated Pallas kernels.
+
+The torch-tensor launchers (``default_pallas_*_launcher``) compile a
+``pl.pallas_call`` and wrap it in a ``JaxCallable`` so that torch tensor
+inputs/outputs cross the torch<->JAX boundary.  This module reuses the
+same compile step (``_pallas_compile_jit_fn``) but skips the JaxCallable
+wrap so the kernel can be invoked from inside a ``jax.jit`` with JAX
+arrays directly — exposed via ``Kernel.jax_fn``.
+
+The Helion-generated wrapper is torch-flavoured (it calls
+``q.size(-2)``, ``q.reshape(...)``, ``torch.empty_like(...)``).  To run
+that wrapper unchanged on JAX inputs, we wrap each input in a
+``_JaxExportTensor`` — a ``torch.Tensor`` subclass whose storage is
+``device='meta'`` (so torch operations only touch shape/dtype) but
+which carries the underlying JAX array on the side.  Operations the
+wrapper performs that *return a tensor we will later read back into
+JAX* — ``reshape`` / ``view`` / ``empty_like`` / ``F.pad`` — must be
+intercepted via ``__torch_function__`` so the JAX side stays in sync.
+Pure-shape introspection (``.size()``, ``.shape``, ``.ndim``,
+``.dim()``) is left to the meta storage (it carries shape).  Anything
+else falls through to torch's meta backend, which will raise from
+``func`` itself if real storage is needed; if a future Helion
+codegen change starts emitting a new tensor-returning op in the
+host wrapper, that op needs adding to the intercept list here.
+
+The export launcher recognises these adapters, extracts the JAX
+arrays, drives the Pallas call, and re-wraps the JAX outputs as
+adapters so the wrapper's trailing ``out.view(...)`` propagates the
+JAX side correctly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import cast
+
+import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from . import _BlockSpecInfo
+    from . import _PallasLoopKind
+    from .kernel import Kernel
+
+
+_TORCH_TO_JNP_DTYPE: dict[torch.dtype, object] | None = None
+_JNP_TO_TORCH_DTYPE: dict[object, torch.dtype] | None = None
+
+
+def _build_dtype_maps() -> tuple[dict[torch.dtype, object], dict[object, torch.dtype]]:
+    """Return cached torch<->jnp dtype maps, building them on first use.
+
+    Built lazily so importing this module never imports JAX (which is
+    optional and TPU-only on most checkouts).
+    """
+    global _TORCH_TO_JNP_DTYPE, _JNP_TO_TORCH_DTYPE
+    if _TORCH_TO_JNP_DTYPE is not None and _JNP_TO_TORCH_DTYPE is not None:
+        return _TORCH_TO_JNP_DTYPE, _JNP_TO_TORCH_DTYPE
+    import jax.numpy as jnp
+
+    pairs: list[tuple[torch.dtype, object]] = [
+        (torch.float32, jnp.float32.dtype),
+        (torch.float64, jnp.float64.dtype),
+        (torch.float16, jnp.float16.dtype),
+        (torch.bfloat16, jnp.bfloat16.dtype),
+        (torch.int8, jnp.int8.dtype),
+        (torch.int16, jnp.int16.dtype),
+        (torch.int32, jnp.int32.dtype),
+        (torch.int64, jnp.int64.dtype),
+        (torch.uint8, jnp.uint8.dtype),
+        (torch.bool, jnp.bool_.dtype),
+    ]
+    _TORCH_TO_JNP_DTYPE = dict(pairs)
+    _JNP_TO_TORCH_DTYPE = {j: t for t, j in pairs}
+    return _TORCH_TO_JNP_DTYPE, _JNP_TO_TORCH_DTYPE
+
+
+def _jnp_to_torch_dtype(jnp_dtype: object) -> torch.dtype:
+    _, j2t = _build_dtype_maps()
+    return j2t[jnp_dtype]
+
+
+class _JaxExportTensor(torch.Tensor):
+    """A ``torch.Tensor`` subclass that carries a JAX array on the side.
+
+    The underlying storage is ``device='meta'`` so all torch operations
+    invoked by the Helion-generated wrapper see correct shape/dtype but
+    perform no real compute on the torch side.  ``__torch_function__``
+    intercepts the small set of operations the wrapper actually uses
+    (``reshape``/``view``/``empty_like``/``F.pad``) and mirrors them on
+    the JAX array so the JAX side stays in sync.
+
+    Use ``_JaxExportTensor.from_jax(arr, device=...)`` to construct one;
+    use ``adapter._jax_arr`` (or :func:`_unwrap_jax` on a result) to
+    recover the underlying JAX array.
+    """
+
+    _jax_arr: object
+    _declared_device: torch.device
+
+    @staticmethod
+    def from_jax(jax_arr: object, *, device: torch.device) -> _JaxExportTensor:
+        torch_dtype = _jnp_to_torch_dtype(jax_arr.dtype)  # type: ignore[union-attr]
+        meta = torch.empty(
+            tuple(int(s) for s in jax_arr.shape),  # type: ignore[union-attr]
+            dtype=torch_dtype,
+            device="meta",
+        )
+        out = torch.Tensor._make_subclass(_JaxExportTensor, meta, require_grad=False)
+        out._jax_arr = jax_arr
+        out._declared_device = device
+        return out
+
+    @property
+    def device(self) -> torch.device:  # pyrefly: ignore[bad-override]
+        # Helion's ``_find_device``/specialization machinery reads this to
+        # decide which backend to compile for; the real meta storage
+        # would otherwise route compilation through the meta device.
+        return self._declared_device
+
+    @classmethod
+    def __torch_function__(
+        cls,
+        func: object,
+        types: tuple[type, ...],
+        args: tuple[object, ...] = (),
+        kwargs: dict[str, object] | None = None,
+    ) -> object:
+        if kwargs is None:
+            kwargs = {}
+
+        # ``torch.empty_like(adapter, device='meta')`` shows up in
+        # generated wrappers when the kernel allocates an output-only
+        # tensor.  Allocate a JAX-side empty with matching shape/dtype
+        # so the export launcher can use the JAX array as the output
+        # placeholder.
+        if func is torch.empty_like:
+            template = args[0] if args else kwargs.get("input")
+            assert isinstance(template, _JaxExportTensor)
+            import jax.numpy as jnp
+
+            new_jax = jnp.empty(
+                tuple(int(s) for s in template._jax_arr.shape),  # type: ignore[union-attr]
+                dtype=template._jax_arr.dtype,  # type: ignore[union-attr]
+            )
+            return cls.from_jax(new_jax, device=template._declared_device)
+
+        # ``q_view = q_in.reshape([...])`` and ``out.view(...)`` are
+        # the wrapper's only shape-mutating operations.  Re-wrap the
+        # JAX array under the new shape so subsequent attribute reads
+        # (``.size(...)``, ``.shape``) on the result stay in sync.
+        if func is torch.Tensor.reshape or func is torch.Tensor.view:
+            t = args[0]
+            assert isinstance(t, _JaxExportTensor)
+            new_shape = _normalize_shape(args[1:], kwargs)
+            import jax.numpy as jnp
+
+            new_jax = jnp.reshape(t._jax_arr, list(new_shape))  # type: ignore[arg-type]
+            return cls.from_jax(new_jax, device=t._declared_device)
+
+        # ``_pallas_apply_ds_padding`` calls ``torch.nn.functional.pad``
+        # on adapter inputs to bring tile-misaligned tensors up to a
+        # block multiple before the pallas_call.  Mirror the same
+        # zero-padding on the JAX side so the JAX array passed to the
+        # kernel matches the adapter's reported shape.
+        if func is torch.nn.functional.pad:
+            t = args[0]
+            assert isinstance(t, _JaxExportTensor)
+            pad_widths = args[1] if len(args) > 1 else kwargs["pad"]
+            mode = kwargs.get("mode", "constant")
+            value = kwargs.get("value")
+            import jax.numpy as jnp
+
+            # ``F.pad`` walks dims back-to-front in pairs of
+            # (left_pad, right_pad).  ``jnp.pad`` takes a list of
+            # ``(before, after)`` pairs in dim order — invert.
+            pairs: list[tuple[int, int]] = [(0, 0)] * t.ndim
+            n_pairs = len(pad_widths) // 2  # type: ignore[arg-type]
+            for i in range(n_pairs):
+                left = int(pad_widths[2 * i])  # type: ignore[index]
+                right = int(pad_widths[2 * i + 1])  # type: ignore[index]
+                pairs[t.ndim - 1 - i] = (left, right)
+            assert mode == "constant", (
+                f"_JaxExportTensor only supports F.pad mode='constant', got {mode!r}"
+            )
+            new_jax = jnp.pad(
+                t._jax_arr,  # type: ignore[arg-type]
+                pairs,
+                mode="constant",
+                constant_values=0 if value is None else value,
+            )
+            return cls.from_jax(new_jax, device=t._declared_device)
+
+        # Catch-all: any op the wrapper might invoke that we haven't
+        # special-cased above.  Shape-only ops (``.size()``, ``.shape``,
+        # ``.ndim``, ``.dim()``) work on the meta storage; ops that
+        # need real data raise from torch's meta backend.  If a new
+        # tensor-returning op appears here whose result the wrapper
+        # later passes back into the kernel, it must be added to the
+        # intercept list above so the JAX side stays in sync.
+        with torch._C.DisableTorchFunctionSubclass():
+            return func(*args, **kwargs)  # type: ignore[operator]
+
+
+def _normalize_shape(
+    rest: tuple[object, ...], kwargs: dict[str, object]
+) -> tuple[object, ...]:
+    """Normalise the shape arg of ``Tensor.reshape``/``Tensor.view``.
+
+    Accepts both ``t.reshape(2, 3)`` and ``t.reshape([2, 3])`` /
+    ``t.reshape((2, 3))`` calling conventions.
+    """
+    if "shape" in kwargs:
+        candidate = kwargs["shape"]
+        if isinstance(candidate, (list, tuple)):
+            return tuple(candidate)
+        return (candidate,)
+    if len(rest) == 1 and isinstance(rest[0], (list, tuple)):
+        return tuple(rest[0])
+    return rest
+
+
+def _unwrap_jax(obj: object) -> object:
+    """Recursively unwrap ``_JaxExportTensor`` instances to JAX arrays."""
+    if isinstance(obj, _JaxExportTensor):
+        return obj._jax_arr
+    if isinstance(obj, tuple):
+        return tuple(_unwrap_jax(x) for x in obj)
+    if isinstance(obj, list):
+        return [_unwrap_jax(x) for x in obj]
+    return obj
+
+
+def _device_for_jax_export() -> torch.device:
+    """Pick the torch device used to drive Helion compilation in jax_fn.
+
+    Helion's specialization key includes the input device type.  For
+    the JAX-export path we don't actually run any torch ops on real
+    storage, so we just need a device that lines up with the active
+    backend.  Prefer ``tpu`` when ``torch_tpu`` is loaded; otherwise
+    fall back to CPU (this matches the interpret-mode test
+    environment).
+    """
+    if hasattr(torch, "tpu"):
+        try:
+            if torch.tpu.is_available():
+                return torch.device("tpu", 0)
+        except Exception:
+            pass
+    return torch.device("cpu")
+
+
+def default_pallas_jax_launcher(
+    pallas_kernel: object,
+    grid: tuple[int, ...],
+    *args: object,
+    _output_indices: list[int] | None = None,
+    _inplace_indices: list[int] | None = None,
+    _block_spec_info: _BlockSpecInfo | None = None,
+    _scratch_shapes: list[object] | None = None,
+    _pipeline_arg_indices: list[int] | None = None,
+    _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
+    _smem_arg_indices: list[int] | None = None,
+    _pallas_interpret: bool | None = None,
+    _kind: _PallasLoopKind | None = None,
+    **kwargs: object,
+) -> object:
+    """Pallas launcher used when running a Helion kernel inside ``jax.jit``.
+
+    Each tensor argument in ``args`` is a ``_JaxExportTensor`` whose
+    underlying ``_jax_arr`` is either a concrete JAX array or a JAX
+    tracer.  This launcher pulls the JAX side out, calls the shared
+    ``_pallas_compile_jit_fn`` to build a fresh ``pl.pallas_call``
+    (no JaxCallable, no torch<->JAX bridge), invokes it on the JAX
+    inputs, and re-wraps the output(s) as ``_JaxExportTensor`` so the
+    Helion wrapper's trailing reshape/view operations stay traceable.
+    """
+    from . import _pallas_apply_ds_padding
+    from . import _pallas_compile_jit_fn
+    from . import _pallas_output_only_descriptors
+    from . import _pallas_padded_output_dims_by_arg
+    from . import _pallas_slice_to_orig
+    from . import _PallasLoopKind as _LoopKind
+    from .settings import is_pallas_interpret
+
+    interpret = (
+        _pallas_interpret if _pallas_interpret is not None else is_pallas_interpret()
+    )
+
+    if _kind is None:
+        _kind = _LoopKind.UNROLL
+    output_indices = _output_indices if _output_indices is not None else []
+
+    # Capture original shapes BEFORE padding so output-only tensors can
+    # be sliced back after the pallas_call.  ``_pallas_apply_ds_padding``
+    # calls ``F.pad`` on each entry, which the adapter intercepts and
+    # mirrors on the JAX side, so no JAX-side duplicate is needed here.
+    orig_shapes: dict[int, tuple[int, ...]] = {}
+    if _ds_pad_dims:
+        for arg_idx, _, _, _ in _ds_pad_dims:
+            if arg_idx in orig_shapes:
+                continue
+            a = args[arg_idx]
+            if isinstance(a, _JaxExportTensor):
+                orig_shapes[arg_idx] = tuple(int(s) for s in a._jax_arr.shape)  # type: ignore[union-attr]
+
+        args, _ = _pallas_apply_ds_padding(args, output_indices, _ds_pad_dims)
+
+    device = next(
+        (a._declared_device for a in args if isinstance(a, _JaxExportTensor)),
+        _device_for_jax_export(),
+    )
+
+    result = _pallas_compile_jit_fn(
+        pallas_kernel,
+        grid,
+        args,
+        kind=_kind,
+        _output_indices=output_indices,
+        _inplace_indices=_inplace_indices,
+        _block_spec_info=_block_spec_info,
+        _smem_arg_indices=_smem_arg_indices,
+        _scratch_shapes=_scratch_shapes,
+        _pipeline_arg_indices=_pipeline_arg_indices,
+        _matmul_dot_general=None,
+        interpret=interpret,
+    )
+
+    jax_inputs = [
+        cast("_JaxExportTensor", args[i])._jax_arr for i in result.tensor_arg_indices
+    ]
+    jax_results = result.jit_fn(*jax_inputs)  # type: ignore[operator]
+    if not isinstance(jax_results, (tuple, list)):
+        jax_results = (jax_results,)
+
+    # Same descriptor list the torch fast-path uses (see
+    # ``_LauncherFastPath.output_only_descriptors``).  In-place positions
+    # would normally alias back into a torch tensor on the torch path — but
+    # JAX has no in-place mutation, so when every output is in-place we
+    # surface them as fresh JAX values instead of returning ``None``.
+    descriptors = _pallas_output_only_descriptors(
+        output_indices, result.arg_to_tensor_pos
+    )
+    if not descriptors:
+        descriptors = tuple(enumerate(output_indices))
+
+    output_results: list[object] = [jax_results[out_idx] for out_idx, _ in descriptors]
+    output_orig_pos: list[int] = [orig_pos for _, orig_pos in descriptors]
+
+    # Slice padded output results back to their original shapes via the
+    # same ``arg → padded dims`` grouping the torch fast-path uses
+    # (see ``_LauncherFastPath.padded_output_dims_by_arg``); we just
+    # slice on JAX arrays via the shared ``_pallas_slice_to_orig`` helper.
+    if _ds_pad_dims and orig_shapes:
+        padded_dims_by_arg = _pallas_padded_output_dims_by_arg(
+            _ds_pad_dims, set(orig_shapes.keys())
+        )
+        for i, orig_pos in enumerate(output_orig_pos):
+            dims = padded_dims_by_arg.get(orig_pos)
+            orig_shape = orig_shapes.get(orig_pos)
+            if dims and orig_shape is not None:
+                output_results[i] = _pallas_slice_to_orig(
+                    cast(
+                        "torch.Tensor", output_results[i]
+                    ),  # JAX arrays index identically
+                    dims,
+                    cast("torch.Size", orig_shape),
+                )
+
+    if len(output_results) == 1:
+        return _JaxExportTensor.from_jax(output_results[0], device=device)
+    return tuple(_JaxExportTensor.from_jax(r, device=device) for r in output_results)
+
+
+def make_jax_fn(kernel: Kernel) -> Callable[..., Any]:
+    """Build the callable returned by ``Kernel.jax_fn``.
+
+    The returned callable can be invoked with JAX arrays / tracers
+    inside ``jax.jit`` and returns JAX arrays.  Internally it drives
+    the same Helion-generated wrapper that the torch-tensor launchers
+    use; only the launcher kwarg changes.
+    """
+
+    def _runtime_call(*args: object) -> object:
+        from . import _PallasLoopKind as _LoopKind
+
+        device = _device_for_jax_export()
+        adapter_args: list[object] = []
+        for a in args:
+            if (
+                hasattr(a, "shape")
+                and hasattr(a, "dtype")
+                and not isinstance(a, torch.Tensor)
+            ):
+                adapter_args.append(_JaxExportTensor.from_jax(a, device=device))
+            else:
+                adapter_args.append(a)
+
+        # Compile the helion kernel for these (adapter) arg shapes.  We
+        # go through the same Kernel.bind/compile path used by the
+        # torch entrypoint so specialization, autotune, etc. all run
+        # exactly once per shape signature — the adapter is a
+        # torch.Tensor subclass so this just works.
+        bound = kernel.bind(tuple(adapter_args))
+        bound.ensure_config_exists(adapter_args)
+        compiled = bound._run
+        assert compiled is not None
+
+        # Resolve the JAX-export launcher to use for the kernel's
+        # configured loop type.  ``_run`` is the generated wrapper
+        # which forwards ``_launcher`` via kwargs.
+        config = bound._config
+        assert config is not None
+        kind = _LoopKind(cast("str", config.config.get("pallas_loop_type", "unroll")))
+
+        def _launcher(
+            pallas_kernel: object,
+            grid: tuple[int, ...],
+            *launch_args: object,
+            **launch_kwargs: object,
+        ) -> object:
+            return default_pallas_jax_launcher(
+                pallas_kernel,
+                grid,
+                *launch_args,
+                _kind=kind,
+                **cast("dict[str, Any]", launch_kwargs),
+            )
+
+        result = compiled(*adapter_args, _launcher=_launcher)
+        return _unwrap_jax(result)
+
+    return _runtime_call

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 import os
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import Callable
 import unittest
 
@@ -4157,6 +4158,189 @@ class TestPallasIndirectGather(TestCase):
 
 
 instantiate_parametrized_tests(TestPallasIndirectGather)
+
+
+@skipUnlessPallas("JAX/Pallas TPU not available")
+class TestPallasJaxFn(TestCase):
+    """End-to-end tests for the ``Kernel.jax_fn`` pure-JAX export path.
+
+    Covers all three ``pallas_loop_type`` flavours plus a multi-kernel
+    composition test, each exercising the kernel inside a ``jax.jit``
+    boundary with non-trivial pure-JAX prologue / epilogue around it.
+    """
+
+    def _import_jax(self) -> tuple[Any, Any]:
+        import jax
+        import jax.numpy as jnp
+
+        return jax, jnp
+
+    def test_jax_fn_emit_pipeline(self) -> None:
+        """jax_fn drives an emit_pipeline kernel inside ``jax.jit``."""
+        jax, jnp = self._import_jax()
+
+        @helion.kernel(
+            backend="pallas",
+            static_shapes=True,
+            config=helion.Config(
+                block_sizes=[128, 128], pallas_loop_type="emit_pipeline"
+            ),
+        )
+        def add_kernel(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(out.size()):
+                out[tile] = x[tile] + y[tile]
+            return out
+
+        jax_kernel = add_kernel.jax_fn
+
+        @jax.jit
+        def f(a: Any, b: Any, scale: float) -> Any:
+            # prologue (pure jax)
+            a = a * scale
+            b = jnp.tanh(b)
+            # kernel
+            c = jax_kernel(a, b)
+            # epilogue (pure jax)
+            return jnp.sum(c) + jnp.mean(c) * 0.5
+
+        a = jnp.ones((128, 128), dtype=jnp.float32)
+        b = jnp.full((128, 128), 0.5, dtype=jnp.float32)
+        scale = 2.0
+
+        result = float(f(a, b, scale))
+
+        # Reference: same prologue/epilogue, eager addition
+        ref_a = a * scale
+        ref_b = jnp.tanh(b)
+        ref_c = ref_a + ref_b
+        ref = float(jnp.sum(ref_c) + jnp.mean(ref_c) * 0.5)
+        self.assertAlmostEqual(result, ref, places=2)
+
+    def test_jax_fn_unroll(self) -> None:
+        """jax_fn drives an unroll kernel inside ``jax.jit``."""
+        jax, jnp = self._import_jax()
+
+        @helion.kernel(
+            backend="pallas",
+            static_shapes=True,
+            config=helion.Config(block_sizes=[128, 128], pallas_loop_type="unroll"),
+        )
+        def relu_add_kernel(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(out.size()):
+                out[tile] = torch.relu(x[tile]) + y[tile]
+            return out
+
+        jax_kernel = relu_add_kernel.jax_fn
+
+        @jax.jit
+        def f(a: Any, b: Any) -> Any:
+            a = a - 0.25
+            b = b * b
+            c = jax_kernel(a, b)
+            return jnp.sum(c * c)
+
+        a = jnp.linspace(-1.0, 1.0, 128 * 128, dtype=jnp.float32).reshape((128, 128))
+        b = jnp.full((128, 128), 0.3, dtype=jnp.float32)
+
+        result = float(f(a, b))
+
+        ref_a = a - 0.25
+        ref_b = b * b
+        ref_c = jnp.maximum(ref_a, 0.0) + ref_b
+        ref = float(jnp.sum(ref_c * ref_c))
+        self.assertAlmostEqual(result, ref, places=1)
+
+    def test_jax_fn_fori_loop(self) -> None:
+        """jax_fn drives a fori_loop kernel inside ``jax.jit``."""
+        jax, jnp = self._import_jax()
+
+        @helion.kernel(
+            backend="pallas",
+            static_shapes=True,
+            config=helion.Config(block_sizes=[128, 128], pallas_loop_type="fori_loop"),
+        )
+        def mul_add_kernel(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(x.size(0)):
+                for tile_n in hl.tile(x.size(1)):
+                    out[tile_m, tile_n] = x[tile_m, tile_n] * 1.5 + y[tile_m, tile_n]
+            return out
+
+        jax_kernel = mul_add_kernel.jax_fn
+
+        @jax.jit
+        def f(a: Any, b: Any) -> Any:
+            a = a * 0.5 + 1.0
+            b = jnp.exp(b * 0.1)
+            c = jax_kernel(a, b)
+            return jnp.mean(c)
+
+        a = jnp.full((128, 128), 2.0, dtype=jnp.float32)
+        b = jnp.zeros((128, 128), dtype=jnp.float32)
+
+        result = float(f(a, b))
+
+        ref_a = a * 0.5 + 1.0
+        ref_b = jnp.exp(b * 0.1)
+        ref_c = ref_a * 1.5 + ref_b
+        ref = float(jnp.mean(ref_c))
+        self.assertAlmostEqual(result, ref, places=2)
+
+    def test_jax_fn_multi_kernel_in_one_jit(self) -> None:
+        """A single ``jax.jit`` function uses two distinct Helion kernels."""
+        jax, jnp = self._import_jax()
+
+        @helion.kernel(
+            backend="pallas",
+            static_shapes=True,
+            config=helion.Config(block_sizes=[128, 128]),
+        )
+        def add_kernel(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(out.size()):
+                out[tile] = x[tile] + y[tile]
+            return out
+
+        @helion.kernel(
+            backend="pallas",
+            static_shapes=True,
+            config=helion.Config(block_sizes=[128, 128]),
+        )
+        def mul_kernel(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(out.size()):
+                out[tile] = x[tile] * y[tile]
+            return out
+
+        add_jax = add_kernel.jax_fn
+        mul_jax = mul_kernel.jax_fn
+
+        @jax.jit
+        def f(a: Any, b: Any, c: Any) -> Any:
+            # prologue
+            a = a + 1.0
+            # first kernel: a + b
+            ab = add_jax(a, b)
+            # middle pure-jax transform
+            ab = jnp.tanh(ab)
+            # second kernel: (tanh result) * c
+            out = mul_jax(ab, c)
+            # epilogue
+            return jnp.sum(out)
+
+        a = jnp.full((128, 128), 0.5, dtype=jnp.float32)
+        b = jnp.full((128, 128), 0.25, dtype=jnp.float32)
+        c = jnp.full((128, 128), 2.0, dtype=jnp.float32)
+
+        result = float(f(a, b, c))
+
+        ref_a = a + 1.0
+        ref_ab = jnp.tanh(ref_a + b)
+        ref_out = ref_ab * c
+        ref = float(jnp.sum(ref_out))
+        self.assertAlmostEqual(result, ref, places=2)
 
 
 class TestPallasPrinter(TestCase):


### PR DESCRIPTION

Expose a Helion Pallas kernel as a pure-JAX callable that can be used
directly inside `jax.jit`, e.g.:

```py
  @helion.kernel(backend="pallas", ...)
  def kf(a, b): ...

  jax_kernel = kf.jax_fn

  @jax.jit
  def f(a, b):
      ... # pure-jax prologue
      c = jax_kernel(a, b)
      ... # pure-jax epilogue
```

The wrapper Helion already generates is torch-flavoured (uses
`q.size(-2)`, `q.reshape(...)`, `torch.empty_like(...)`).  To run it
unchanged on JAX inputs, `pallas_jax_export.py` adds a
`_JaxExportTensor` adapter — a `torch.Tensor` subclass with `meta`
storage that carries the underlying JAX array on the side and
intercepts `reshape`/`view`/`empty_like`/`F.pad` via
`__torch_function__`.  A new `default_pallas_jax_launcher` reuses the
shared `_pallas_compile_jit_fn` from the previous refactor commit to
build a `pl.pallas_call`, calls it directly on the JAX side (no
JaxCallable, no torch<->JAX bridge), and slices padded outputs back
through the same `_pallas_slice_to_orig` helper used by the torch
path.

`Kernel._specialization_key` is updated to recognize torch.Tensor
subclasses (so the adapter shares the standard tensor key) and
`Kernel.jax_fn` is added.  Tests in `test/test_pallas.py::TestPallasJaxFn`
cover all three `pallas_loop_type` variants plus a multi-kernel test
where one `jax.jit` function chains two distinct Helion kernels with
non-trivial pure-JAX prologue/epilogue around them.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
