### PR TITLE
[cute] Un-xfail/un-skip 29 CuTe example tests across reductions, attention, matmul

### DIFF
--- a/examples/int4_gemm.py
+++ b/examples/int4_gemm.py
@@ -58,35 +58,42 @@ def matmul_bf16_int4(A: Tensor, B: Tensor) -> Tensor:
         acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
 
         for tile_k_packed in hl.tile(K // 2, block_size=block_size_k_packed):
-            # Load corresponding tiles from A (need to load twice the packed tile size)
-            # We need to map tile_k_packed to the corresponding range in A
+            # Load corresponding tiles from A (need to load twice the packed tile size).
+            # We map tile_k_packed to the corresponding (factor-2 widened) range in A.
+            # This affine-widened slice is lowered as an affine ``hl.arange()`` index and,
+            # on the CuTe backend, is consumed by the packed-affine matmul load fusion
+            # below (the affine A load feeds directly into ``hl.dot``).
             a_tile_begin = tile_k_packed.begin * 2
             a_tile_len = block_size_k_packed * 2
-            a_tile = A[tile_m, a_tile_begin : (a_tile_begin + a_tile_len)].to(
-                torch.float32
-            )  # [BLOCK_SIZE_M, BLOCK_SIZE_K]
+            a_tile = A[
+                tile_m, a_tile_begin : (a_tile_begin + a_tile_len)
+            ]  # [BLOCK_SIZE_M, BLOCK_SIZE_K]
 
             # Load packed int8 data from B
             b_tile = B[tile_k_packed, tile_n]  # [BLOCK_SIZE_K//2, BLOCK_SIZE_N]
 
-            # Extract low and high 4-bit values with sign extension
-            # Low nibble: sign-extend from 4-bit to 8-bit using left shift then arithmetic right shift
-            b_lo = ((b_tile << 4) >> 4).to(torch.int8)  # Sign-extend low 4 bits
-            b_hi = (b_tile >> 4).to(torch.int8)  # Sign-extend high 4 bits
+            # Extract low and high 4-bit values with sign extension.
+            # The low nibble is sign-extended arithmetically (mask to 4 bits, then
+            # subtract 16 when the sign bit is set) rather than via ``(x << 4) >> 4``;
+            # the explicit arithmetic form is portable across backends and avoids
+            # relying on narrow-int (int8) shift truncation semantics.
+            b_lo_raw = (b_tile & 0xF).to(torch.int32)
+            b_lo = torch.where(b_lo_raw >= 8, b_lo_raw - 16, b_lo_raw)  # low 4 bits
+            b_hi = (b_tile >> 4).to(torch.int32)  # high 4 bits (arithmetic >>)
 
-            # Stack and reshape to interleave low and high bits
-            # Stack along a new dimension to get [BLOCK_SIZE_K//2, 2, BLOCK_SIZE_N]
-            b_stacked = torch.stack([b_lo, b_hi], dim=1)
-
-            # Reshape to interleave: [BLOCK_SIZE_K//2, 2, BLOCK_SIZE_N] -> [BLOCK_SIZE_K, BLOCK_SIZE_N]
-            # This will place elements in the order: b_lo[0], b_hi[0], b_lo[1], b_hi[1], ...
+            # Stack and reshape to interleave low and high bits.
+            # Stack along a new dimension to get [BLOCK_SIZE_K//2, 2, BLOCK_SIZE_N],
+            # then reshape to interleave into [BLOCK_SIZE_K, BLOCK_SIZE_N] in the order
+            # b_lo[0], b_hi[0], b_lo[1], b_hi[1], ..., matching the A[2*kp]/A[2*kp+1] pairs.
+            b_stacked = torch.stack([b_lo.to(A.dtype), b_hi.to(A.dtype)], dim=1)
             b_unpacked = b_stacked.reshape(
                 tile_k_packed.block_size * 2, tile_n.block_size
-            ).to(torch.float32)
+            )
 
-            a_tile = a_tile.unsqueeze(2)  # [BLOCK_SIZE_M, BLOCK_SIZE_K, 1]
-            b_unpacked = b_unpacked.unsqueeze(0)
-            acc = acc + (a_tile * b_unpacked).sum(dim=1)  # [BLOCK_SIZE_M, BLOCK_SIZE_N]
+            # Matmul over the widened K dimension.  Using ``hl.dot`` lets the affine
+            # A load and the interleaved B unpack fuse into a single packed-affine
+            # matmul (the supported lowering for factor-widened affine loads).
+            acc = hl.dot(a_tile, b_unpacked, acc=acc)  # [BLOCK_SIZE_M, BLOCK_SIZE_N]
 
         C[tile_m, tile_n] = acc.to(torch.bfloat16)
 

--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -1296,6 +1296,8 @@ def codegen_mm_cute(ctx: LoweringContext, node: Node) -> ast.AST:
         out_dtype=effective_out_dtype,
         lhs_dtype=lhs_node.meta["val"].dtype,
         rhs_dtype=rhs_node.meta["val"].dtype,
+        lhs_node=lhs_node,
+        rhs_node=rhs_node,
     )
 
 
@@ -1384,6 +1386,9 @@ def codegen_addmm_cute(ctx: LoweringContext, node: Node) -> ast.AST:
         acc_dtype=acc_node.meta["val"].dtype,
         lhs_dtype=lhs_node.meta["val"].dtype,
         rhs_dtype=rhs_node.meta["val"].dtype,
+        lhs_node=lhs_node,
+        rhs_node=rhs_node,
+        acc_node=acc_node,
     )
 
 
@@ -1466,6 +1471,9 @@ def codegen_baddbmm_cute(ctx: LoweringContext, node: Node) -> ast.AST:
         acc_dtype=acc_node.meta["val"].dtype,
         lhs_dtype=lhs_node.meta["val"].dtype,
         rhs_dtype=rhs_node.meta["val"].dtype,
+        lhs_node=lhs_node,
+        rhs_node=rhs_node,
+        acc_node=acc_node,
     )
 
 

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -619,6 +619,66 @@ class Backend(abc.ABC):
             raise exc.BackendUnsupported(self.name, "RNG ops")
         return [*args, *self.launcher_keyword_args(config, has_barrier=has_barrier)]
 
+    def _cute_matmul_contraction_reduction_block_ids(self) -> set[int]:
+        """Reduction block ids that are also a matmul-contraction (K) axis.
+
+        These are the blocks that must keep real threads for the whole K extent
+        instead of being split into ``threads x synthetic-lane`` (see OPTION B in
+        ``CuteBackend.create_loop_strategy`` and
+        ``cute_matmul_contraction_block_ids``).
+        """
+        from .compile_environment import CompileEnvironment
+        from .cute.matmul_utils import cute_matmul_contraction_block_ids
+
+        env = CompileEnvironment.current()
+        canonical_block_id = getattr(
+            env, "canonical_block_id", lambda block_id: block_id
+        )
+        contraction = cute_matmul_contraction_block_ids()
+        if not contraction:
+            return set()
+        return {
+            info.block_id
+            for info in env.block_sizes
+            if info.reduction and canonical_block_id(info.block_id) in contraction
+        }
+
+    def _cute_matmul_contraction_thread_reserve(
+        self, fn: DeviceFunction, tile_block_ids: list[int]
+    ) -> int:
+        """Threads to reserve for matmul-contraction reduction axes.
+
+        Returns the product of the per-axis full thread extents (power-of-two,
+        capped at ``max_reduction_threads``) of every reduction block that is a
+        matmul-contraction axis and is *not* one of ``tile_block_ids`` (i.e. it
+        is handled by a separate reduction strategy, not this tile strategy).
+        """
+        from torch._inductor.runtime.runtime_utils import next_power_of_2
+
+        from .._compat import shape_env_size_hint
+        from .compile_environment import CompileEnvironment
+
+        env = CompileEnvironment.current()
+        max_reduction_threads = self.max_reduction_threads()
+        if max_reduction_threads is None:
+            return 1
+        tile_ids = set(tile_block_ids)
+        reserve = 1
+        for block_id in self._cute_matmul_contraction_reduction_block_ids():
+            if block_id in tile_ids:
+                continue
+            numel = env.block_sizes[block_id].numel
+            if isinstance(numel, (int, sympy.Integer)):
+                size_hint = int(numel)
+            elif isinstance(numel, sympy.Expr):
+                size_hint = shape_env_size_hint(env.shape_env, numel)
+            else:
+                size_hint = env.size_hint(numel)
+            if size_hint <= 1:
+                continue
+            reserve *= next_power_of_2(min(size_hint, max_reduction_threads))
+        return reserve
+
     def create_loop_strategy(
         self, fn: DeviceFunction, block_ids: list[int], config: Config
     ) -> TileStrategy:
@@ -2789,6 +2849,7 @@ class CuteBackend(Backend):
             "_cute_inline_asm_elementwise": "from helion._compiler.cute.inline_asm_helpers import inline_asm_elementwise as _cute_inline_asm_elementwise",
             "_cute_fp8e4m3fn_to_float32": "from helion._compiler.cute.quantized_helpers import fp8e4m3fn_to_float32 as _cute_fp8e4m3fn_to_float32",
             "_cute_float4_e2m1fn_x2_to_float32": "from helion._compiler.cute.quantized_helpers import float4_e2m1fn_x2_to_float32 as _cute_float4_e2m1fn_x2_to_float32",
+            "_cute_grid_barrier": "from helion._compiler.cute.grid_barrier import grid_barrier as _cute_grid_barrier",
         }
 
     def program_id_expr(self, dim: int, *, index_dtype: str) -> str:
@@ -2839,8 +2900,9 @@ class CuteBackend(Backend):
         return super().cast_ast(x, target_dtype)
 
     def grid_barrier_stmt(self, sem_arg: str) -> str | None:
-        del sem_arg
-        raise exc.BackendUnsupported(self.name, "hl.barrier()")
+        # ``sem_arg`` is a TensorArg that arrives as a ``cute.Tensor``; its
+        # ``.iterator`` is the underlying ``cute.Pointer`` to the semaphore.
+        return f"_cute_grid_barrier({sem_arg}.iterator)"
 
     def lane_index_expr(
         self, offset_var: str, elements_per_thread: int, *, axis: int
@@ -3009,6 +3071,16 @@ class CuteBackend(Backend):
     ) -> str:
         # Use Python ternary instead of cute.where for max/min because
         # these operate on scalar registers, not tensors.
+        #
+        # Cast the incoming value to the accumulator dtype first.  The
+        # accumulator is promoted to the computation dtype (fp32 for
+        # half-precision inputs), but the per-iteration reduction input keeps
+        # the tensor's storage dtype (e.g. bf16 for a masked half load).  The
+        # CUTLASS DSL strictly type-checks the two branches of a Python ternary
+        # ("Then and else blocks of ifexp return different types"), so a bare
+        # ``acc if acc > val else val`` with mixed fp32/bf16 operands fails to
+        # compile.  The cast is a no-op when ``val`` already matches.
+        val = self.cast_expr(val, self.dtype_str(dtype))
         if reduction_type == "sum":
             return f"({acc} + {val})"
         if reduction_type == "max":
@@ -3841,6 +3913,23 @@ class CuteBackend(Backend):
                     )
                     for block_id in block_ids
                 ]
+            # OPTION B (matmul-contraction synthetic-lane fix): when a reduction
+            # block is the *contraction* (K) axis of a matmul lowered through the
+            # scalar fallback, it must keep enough real hardware threads to cover
+            # its full extent so the cross-warp shared-memory reduction sums the
+            # whole K.  Otherwise the budget below would hand the free tile axes
+            # the threads and leave K split into ``threads x synthetic-lane`` -
+            # the reduction then sums only the thread lanes, never the synthetic
+            # lanes, so each contracted dot product covers only a fraction of K.
+            # Reserve the K block's full thread extent up front by shrinking the
+            # thread limit available to the free tile axes; the contraction axis
+            # then claims that budget when its reduction strategy is created and
+            # the synthetic lane is pushed onto the free tile axes instead.
+            reserved_contraction_threads = self._cute_matmul_contraction_thread_reserve(
+                fn, block_ids
+            )
+            if reserved_contraction_threads > 1:
+                thread_limit = max(1, thread_limit // reserved_contraction_threads)
             static_threads = _shrink_auto_thread_counts(nd_block_size, thread_limit)
             from .cute.thread_budget import check_thread_limit
 

--- a/helion/_compiler/cute/cute_epilogue.py
+++ b/helion/_compiler/cute/cute_epilogue.py
@@ -121,23 +121,26 @@ class _AuxiliaryTensorStep:
     classify time).
 
     ``broadcast_axis`` is ``None`` when the aux tensor matches the
-    carrier rank exactly (``residual[tile_m, tile_n]``) or ``1`` for
+    carrier rank exactly (``residual[tile_m, tile_n]``), ``1`` for
     a trailing-axis (rowvec) broadcast aux load (``bias[tile_n]``
-    with shape ``(N,)``). The leading-axis (colvec / M-axis) form is
-    not accepted: a bare rank-1 operand on the RHS aligns to the
-    *last* dimension under PyTorch broadcasting rules
-    (``acc + bias[tile_m]`` is either a shape error when BM ≠ BN
-    or a rowvec broadcast when BM == BN), so accepting the colvec
-    pattern would silently rewrite the user's broadcast direction.
-    Users wanting an explicit colvec broadcast must spell it out
-    with ``[:, None]`` / ``.unsqueeze(-1)``; that is a separate
-    pattern handler not yet wired up. The splice site
+    with shape ``(N,)``), or ``0`` for a leading-axis (row /
+    M-axis) broadcast aux load spelled explicitly as a ``(1, N)``
+    tensor indexed ``bias[tile_m, tile_n]``. A *bare* rank-1
+    operand on the RHS (``acc + bias[tile_m]``) is still rejected
+    because it aligns to the *last* dimension under PyTorch
+    broadcasting rules (it is either a shape error when BM ≠ BN or
+    a rowvec broadcast when BM == BN), so accepting it as a colvec
+    would silently rewrite the user's broadcast direction. The
+    ``(1, N)`` form is unambiguous: the user materialized the unit
+    M axis themselves, so row 0 broadcasts over every output row.
+    The splice site
     (``memory_ops._codegen_cute_store_tcgen05_tile``) owns the
-    canonical broadcast-view contract — it builds a 2-D logical
-    view of the rank-1 tensor with stride 0 on the orthogonal axis
-    so the existing ``partition_C → flat_divide → partition_D``
-    pipeline can run unchanged. Mirrors Quack's ``RowVecLoad``
-    epilogue (``quack/quack/epi_ops.py``).
+    canonical broadcast-view contract — for both broadcast axes it
+    builds a 2-D logical view with stride 0 on the broadcast
+    (M) axis and stride 1 on the data (N) axis so the existing
+    ``partition_C → flat_divide → partition_D`` pipeline can run
+    unchanged. Mirrors Quack's ``RowVecLoad`` epilogue
+    (``quack/quack/epi_ops.py``).
     """
 
     op_name: str

--- a/helion/_compiler/cute/cute_fx_walk.py
+++ b/helion/_compiler/cute/cute_fx_walk.py
@@ -208,19 +208,33 @@ def aux_tensor_load_kind(
       rank-1 operand to the *last* dimension of a rank-2 LHS:
       ``acc + bias[tile_m]`` is either a shape error (BM ≠ BN) or
       rowvec broadcast against the trailing axis (BM == BN). A
-      user wanting M-axis (column-vector) broadcasting must write
-      it explicitly (``bias[tile_m][:, None]`` /
-      ``.unsqueeze(-1)``); that is a separate, deferred pattern.
-      See :class:`Tcgen05UnaryEpilogueChain` (``cute_epilogue.py``)
-      for the splice-side broadcast-view contract.
+      user wanting M-axis (column-vector) broadcasting via a bare
+      rank-1 operand must write it explicitly (``bias[tile_m][:,
+      None]`` / ``.unsqueeze(-1)``); that is a separate, deferred
+      pattern. See :class:`Tcgen05UnaryEpilogueChain`
+      (``cute_epilogue.py``) for the splice-side broadcast-view
+      contract.
+    - ``("broadcast", 0)``: a rank-2 leading-axis broadcast aux
+      load (``bias[tile_m, tile_n]`` where ``bias`` has shape
+      ``(1, N)``). The underlying tensor's rank is 2 with a unit
+      leading (M) axis, the load result shape equals the carrier
+      tile shape, the load's two index symbols are exactly
+      ``carrier_tile_index_nodes`` in order, and the trailing
+      extent equals ``carrier_global_shape[1]``. This is the
+      explicit ``[1, N]`` row-broadcast form: PyTorch broadcasts
+      row 0 of the aux to every output row. The splice site builds
+      the same stride-``(0, 1)`` 2-D view as the trailing-axis
+      rowvec form (row 0 reused across M).
 
     The classifier returns ``None`` for everything else: 3-D
     underlying tensors with a static collapse
     (``aux3d[tile_m, tile_n, 0]``), broadcast variants whose index
     is not the exact carrier tile-id symbol (e.g. ``bias[tile_n + 1]``),
     rank mismatches, kwargs, non-default ``extra_mask`` /
-    ``eviction_policy`` positions, or rank-1 indexed by the
-    carrier's leading-axis tile id (``bias[tile_m]`` — see above).
+    ``eviction_policy`` positions, rank-1 indexed by the carrier's
+    leading-axis tile id (``bias[tile_m]`` — see above), or rank-2
+    aux whose underlying shape neither equals the carrier global
+    output shape nor is the ``(1, N)`` leading-broadcast form.
 
     Strict on ``kwargs`` (must be empty) and on the ``extra_mask``
     / ``eviction_policy`` argument positions — both must be
@@ -238,7 +252,12 @@ def aux_tensor_load_kind(
     broadcast classifier additionally checks that the rank-1 aux's
     extent matches the output's global size on the broadcast axis,
     closing the gap where the bias is smaller than the global axis
-    but happens to be divisible by the tile extent.
+    but happens to be divisible by the tile extent. The exact-shape
+    classifier also uses it to reject a rank-2 aux whose underlying
+    shape does not equal the global output shape (e.g. a ``(1, N)``
+    tensor whose per-tile load result happens to match the carrier
+    tile but which broadcasts over M) so it can never be silently
+    treated as a full ``[M, N]`` exact aux.
     """
     from ...language.memory_ops import load as helion_load
 
@@ -273,8 +292,16 @@ def aux_tensor_load_kind(
     # Without the carrier shape we cannot disambiguate the broadcast
     # axis, so only the rank-2 exact form is accepted in this mode
     # — broadcast classification is gated on having a known carrier.
+    # A unit leading axis is the ``(1, N)`` leading-broadcast form,
+    # which is *not* an exact aux; reject it here so the defensive
+    # path can never silently treat it as a full ``[M, N]`` tensor
+    # (it falls to the loud-failure backstop instead).
     if carrier_tile_shape is None:
-        if len(aux_shape) == 2 and len(aux_tensor_shape) == 2:
+        if (
+            len(aux_shape) == 2
+            and len(aux_tensor_shape) == 2
+            and aux_tensor_shape[0] != 1
+        ):
             return ("exact", None)
         return None
 
@@ -289,8 +316,21 @@ def aux_tensor_load_kind(
         index_list=index_list,
         carrier_tile_shape=carrier_tile_shape,
         carrier_tile_index_nodes=carrier_tile_index_nodes,
+        carrier_global_shape=carrier_global_shape,
     ):
         return ("exact", None)
+
+    leading = _matches_leading_broadcast(
+        aux_shape=aux_shape,
+        aux_tensor_shape=aux_tensor_shape,
+        aux_tensor_val=aux_tensor_val,
+        index_list=index_list,
+        carrier_tile_shape=carrier_tile_shape,
+        carrier_tile_index_nodes=carrier_tile_index_nodes,
+        carrier_global_shape=carrier_global_shape,
+    )
+    if leading is not None:
+        return leading
 
     return _matches_broadcast(
         aux_shape=aux_shape,
@@ -381,6 +421,75 @@ def _matches_broadcast(
     return ("broadcast", axis)
 
 
+def _matches_leading_broadcast(
+    *,
+    aux_shape: tuple[object, ...],
+    aux_tensor_shape: tuple[object, ...],
+    aux_tensor_val: torch.Tensor,
+    index_list: Sequence[object],
+    carrier_tile_shape: tuple[object, ...],
+    carrier_tile_index_nodes: tuple[torch.fx.Node, ...] | None,
+    carrier_global_shape: tuple[object, ...] | None,
+) -> tuple[str, int] | None:
+    """Check whether a load matches the rank-2 leading-axis
+    (column / M-axis) broadcast aux pattern, and return
+    ``("broadcast", 0)`` on success.
+
+    The accepted form is ``bias[tile_m, tile_n]`` where ``bias`` has
+    shape ``(1, N)``: a unit leading axis that PyTorch broadcasts
+    over every output row. Unlike the bare rank-1 trailing-axis form
+    (``bias[tile_n]``), this is an *explicit* rank-2 index of an
+    ``[1, N]`` tensor, so the broadcast direction is unambiguous —
+    the user materialized the unit M axis themselves. The load result
+    shape must equal the carrier tile shape dim-by-dim, both index
+    symbols must be exactly ``carrier_tile_index_nodes`` in order,
+    and the trailing extent must equal the output's global N.
+
+    The splice site builds the same 2-D ``cute.make_layout((m, n),
+    stride=(0, 1))`` view as the trailing-axis rowvec form: for a
+    contiguous ``(1, N)`` tensor element ``(0, n)`` lives at offset
+    ``n``, so stride ``(0, 1)`` over the ``.iterator`` makes every
+    output row ``m`` read row 0. Non-contiguous-trailing aux is
+    rejected loudly (the hard-coded stride 1 would otherwise be
+    wrong).
+    """
+    if (
+        len(aux_tensor_shape) != 2
+        or len(aux_shape) != 2
+        or len(index_list) != 2
+        or len(carrier_tile_shape) != 2
+    ):
+        return None
+    if aux_tensor_shape[0] != 1:
+        return None
+    if carrier_tile_index_nodes is None or len(carrier_tile_index_nodes) != 2:
+        # The leading-broadcast splice is unpredicated; without the
+        # carrier tile-id symbols we cannot confirm the load indexes
+        # the carrier's own (m, n) tile, so bail to the loud-failure
+        # backstop rather than broadcast a mismatched index silently.
+        return None
+    for idx, expected in zip(index_list, carrier_tile_index_nodes, strict=True):
+        if idx is not expected:
+            return None
+    for aux_dim, carrier_dim in zip(aux_shape, carrier_tile_shape, strict=True):
+        if aux_dim != carrier_dim:
+            return None
+    # Contiguous ``(1, N)`` so the stride-(0, 1) view's offset of
+    # element (m, n) is exactly n. The trailing stride must be 1; the
+    # leading stride is irrelevant (M extent is 1) but a contiguous
+    # tensor reports stride (N, 1) — accept any leading stride.
+    if aux_tensor_val.stride()[1] != 1:
+        return None
+    if carrier_global_shape is not None:
+        if len(carrier_global_shape) != 2:
+            return None
+        # The aux's trailing extent must match the output's global N
+        # so the per-tile slice never reads past the underlying row.
+        if aux_tensor_shape[1] != carrier_global_shape[1]:
+            return None
+    return ("broadcast", 0)
+
+
 def _matches_exact(
     *,
     aux_shape: tuple[object, ...],
@@ -388,6 +497,7 @@ def _matches_exact(
     index_list: Sequence[object],
     carrier_tile_shape: tuple[object, ...],
     carrier_tile_index_nodes: tuple[torch.fx.Node, ...] | None,
+    carrier_global_shape: tuple[object, ...] | None,
 ) -> bool:
     """Check whether a load matches the exact-shape aux pattern:
     underlying tensor rank equals carrier rank, result shape equals
@@ -397,6 +507,16 @@ def _matches_exact(
     (``carrier_tile_index_nodes is None``), fall back to checking
     each entry of ``index_list`` is an FX symint node — used only
     for defensive paths that lose the tile-id walk.
+
+    When ``carrier_global_shape`` is provided the underlying aux
+    tensor's full shape must equal the global output shape
+    dim-by-dim. Without this gate a ``(1, N)`` aux load whose
+    per-tile result happens to match the carrier tile shape (the
+    load slices ``bias[tile_m, tile_n]`` and broadcasts row 0 over
+    M) would be wrongly accepted as a full ``[M, N]`` exact aux and
+    the splice would ``local_tile`` past the unit M extent, reading
+    OOB rows. The leading-broadcast classifier handles that ``(1,
+    N)`` form separately.
     """
     rank = len(carrier_tile_shape)
     if (
@@ -408,6 +528,14 @@ def _matches_exact(
     for aux_dim, carrier_dim in zip(aux_shape, carrier_tile_shape, strict=True):
         if aux_dim != carrier_dim:
             return False
+    if carrier_global_shape is not None:
+        if len(carrier_global_shape) != rank:
+            return False
+        for aux_dim, global_dim in zip(
+            aux_tensor_shape, carrier_global_shape, strict=True
+        ):
+            if aux_dim != global_dim:
+                return False
     if carrier_tile_index_nodes is not None:
         if len(carrier_tile_index_nodes) != len(index_list):
             return False

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -998,6 +998,17 @@ def prepare_cute_collective_lane_loop_suppression(
         ):
             continue
 
+        # Mirror the real codegen bailout in ``_emit_mma_pipeline`` (it returns
+        # ``None`` and falls back to the scalar matmul path when non-root lane
+        # loops are active, see the ``_has_non_root_lane_loops`` guard there).
+        # If we predicted the collective tcgen05 path here but codegen actually
+        # takes the scalar fallback, requesting root lane-loop suppression would
+        # drop the synthetic-lane index/mask definitions for the grid axis and
+        # produce a ``NameError`` at runtime. Only register the loads / request
+        # suppression when the collective path will truly be taken.
+        if _has_non_root_lane_loops(cg):
+            continue
+
         cute_state = cg.device_function.cute_state
         _register_collective_handled_loads(cute_state, lhs_load, rhs_load)
         if grid_state.has_lane_loops():

--- a/helion/_compiler/cute/cute_reshape.py
+++ b/helion/_compiler/cute/cute_reshape.py
@@ -319,32 +319,79 @@ def _permute_reorders_active_dims(
     return [dim for dim in perm if dim in active_dims] != active_dims
 
 
+# Per-thread pointwise / cast ops whose output element on a given thread is a
+# pure function of that same thread's input element(s). A transpose-like shape op
+# feeding such an op only relabels the logical layout; the scalar each thread
+# holds is unchanged, so the shape op can stay folded into the load index and we
+# can look *through* these ops to find the ultimate consumer.
+_LAYOUT_PRESERVING_POINTWISE_TARGETS = frozenset(
+    {
+        torch.ops.aten.mul.Tensor,
+        torch.ops.aten.mul.Scalar,
+        torch.ops.aten.add.Tensor,
+        torch.ops.aten.add.Scalar,
+        torch.ops.aten.sub.Tensor,
+        torch.ops.aten.sub.Scalar,
+        torch.ops.aten.div.Tensor,
+        torch.ops.aten.div.Scalar,
+        torch.ops.aten.neg.default,
+        torch.ops.aten.exp.default,
+        torch.ops.aten.exp2.default,
+        torch.ops.aten._to_copy.default,
+        torch.ops.prims.convert_element_type.default,
+    }
+)
+
+
 def _shape_op_needs_materialization(node: Node) -> bool:
     """Return True when non-store consumers need values, not just metadata."""
     from ...language import memory_ops
+    from ...language.matmul_ops import dot as hl_dot
+    from ...language.matmul_ops import dot_scaled as hl_dot_scaled
 
     matmul_targets = {
         torch.ops.aten.mm.default,
         torch.ops.aten.addmm.default,
         torch.ops.aten.bmm.default,
         torch.ops.aten.baddbmm.default,
+        hl_dot,
+        hl_dot_scaled,
     }
     reduction_names = ("sum", "amax", "amin", "prod", "mean")
-    for user in node.users:
+
+    def _consumer_needs_materialization(user: Node, visited: set[Node]) -> bool:
         if user.op != "call_function":
             return True
         if user.target is memory_ops.store:
-            continue
+            return False
         # CuTe matmul fallbacks consume one scalar per thread/lane. In that mode a
         # transpose-like shape op only changes the logical operand layout, not the
         # scalar value held by the current thread.
         if user.target in matmul_targets:
-            continue
+            return False
         target_name = str(user.target)
         if any(name in target_name for name in reduction_names):
-            continue
+            return False
+        # Layout-preserving per-thread pointwise/cast ops keep each thread's
+        # element in place, so recurse to find the ultimate consumer instead of
+        # forcing a shared-memory shuffle for the intervening op.
+        if user.target in _LAYOUT_PRESERVING_POINTWISE_TARGETS:
+            if user in visited:
+                return False
+            visited.add(user)
+            # A pointwise op with no downstream users is not provably safe to
+            # fold (we cannot see where its value flows), so stay conservative
+            # and materialize, matching the pre-recursion behavior.
+            if not user.users:
+                return True
+            return any(
+                _consumer_needs_materialization(downstream, visited)
+                for downstream in user.users
+            )
         return True
-    return False
+
+    visited: set[Node] = set()
+    return any(_consumer_needs_materialization(user, visited) for user in node.users)
 
 
 def _permute_needs_materialization(node: Node) -> bool:

--- a/helion/_compiler/cute/device_state.py
+++ b/helion/_compiler/cute/device_state.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from ... import exc
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from collections.abc import Sequence
 
     import torch
@@ -237,6 +238,20 @@ class CuteDeviceFunctionState:
     def __init__(self) -> None:
         self._tcgen05_store_values: dict[str, CuteTcgen05StoreValue] = {}
         self._tcgen05_consumed_store_value_ids: set[int] = set()
+        # tcgen05 TMA-store atom/tensor kernel-arg names are allocated once per
+        # matmul accumulator. When a single accumulator fans out to multiple
+        # output stores (e.g. aux = pre-activation, out = gelu(pre)), each store
+        # site must emit its own descriptor kernel params or the generated
+        # function gets duplicate argument names. Track which StoreValue object
+        # ids have already emitted their TMA-store kernel params so 2nd+ store
+        # sites can allocate fresh per-store names.
+        self._tcgen05_emitted_tma_store_value_ids: set[int] = set()
+        # Snapshot of the accumulator consumer-state stage index, keyed by the
+        # acc consumer-state variable name. A multi-store fan-out reads the same
+        # accumulator TMEM stage; the primary store advances the consumer state
+        # after its loop, so later stores must read the stage index captured
+        # before that advance instead of the live (already-advanced) index.
+        self._tcgen05_acc_stage_index_vars: dict[str, str] = {}
         # FX matmul / hl.dot / addmm nodes lowered through tcgen05. The store
         # path uses this to recognize fused epilogue chains that must use the
         # tcgen05 store splice instead of falling through to SIMT store codegen.
@@ -307,6 +322,42 @@ class CuteDeviceFunctionState:
             return value
         return None
 
+    def get_or_create_tcgen05_acc_stage_index_var(
+        self,
+        acc_consumer_state: str,
+        new_var: Callable[[str], str],
+    ) -> tuple[str, bool]:
+        """Return (snapshot_var, is_new) for an accumulator's stage index.
+
+        The first (primary) store of an accumulator captures the consumer-state
+        stage index into this variable before it advances the consumer state.
+        Later fan-out stores reuse the snapshot so they read the same live
+        accumulator TMEM stage. ``is_new`` is True only for the primary store,
+        which must emit the ``<var> = <acc_consumer_state>.index`` assignment.
+        """
+        existing = self._tcgen05_acc_stage_index_vars.get(acc_consumer_state)
+        if existing is not None:
+            return existing, False
+        snapshot = new_var("tcgen05_acc_stage_index")
+        self._tcgen05_acc_stage_index_vars[acc_consumer_state] = snapshot
+        return snapshot, True
+
+    def tcgen05_tma_store_names_already_emitted(
+        self, value: CuteTcgen05StoreValue
+    ) -> bool:
+        """Return whether this StoreValue already emitted TMA-store kernel params.
+
+        The first store site that uses a given accumulator's StoreValue keeps the
+        per-matmul ``tma_store_atom`` / ``tma_store_tensor`` names. Later store
+        sites fanning out from the same accumulator must allocate fresh per-store
+        names so the generated kernel signature has no duplicate parameters and so
+        each store binds its own TMA descriptor.
+        """
+        value_id = id(value)
+        already_emitted = value_id in self._tcgen05_emitted_tma_store_value_ids
+        self._tcgen05_emitted_tma_store_value_ids.add(value_id)
+        return already_emitted
+
     def register_tcgen05_matmul_plan(self, plan: CuteTcgen05MatmulPlan) -> None:
         if self.matmul_plan is not None:
             if self.matmul_plan != plan:
@@ -355,6 +406,29 @@ class CuteDeviceFunctionState:
 
     def is_tcgen05_post_loop(self, stmt: ast.stmt) -> bool:
         return id(stmt) in self._post_loop_stmt_ids
+
+    def move_tcgen05_post_loop_stmts_to_end(self, body: list[ast.AST]) -> list[ast.AST]:
+        """Reorder ``body`` so post-loop-tagged statements run last.
+
+        The persistent codegen path pulls post-loop cleanup out of the work-tile
+        loop. The non-persistent (flat-grid) path leaves those statements where
+        the store lowering emitted them. When a single accumulator fans out to
+        multiple stores, the primary store's matmul drain / TMEM-free teardown is
+        emitted inline before later store bodies; the teardown must instead run
+        after every store has read the still-live accumulator TMEM. Moving the
+        tagged statements to the end (preserving relative order) keeps the
+        single-store case a no-op while fixing the fan-out ordering.
+        """
+        if not self._post_loop_stmt_ids:
+            return body
+        remaining: list[ast.AST] = []
+        post_loop: list[ast.AST] = []
+        for stmt in body:
+            if id(stmt) in self._post_loop_stmt_ids:
+                post_loop.append(stmt)
+            else:
+                remaining.append(stmt)
+        return [*remaining, *post_loop]
 
     @property
     def has_tcgen05_post_loop_marks(self) -> bool:

--- a/helion/_compiler/cute/grid_barrier.py
+++ b/helion/_compiler/cute/grid_barrier.py
@@ -1,0 +1,98 @@
+# pyrefly: ignore-errors
+"""Grid-wide barrier helper for the CuTe backend.
+
+Helion's persistent multi-phase loop machinery (``program_id.py``
+``_emit_phase_loops``) emits a barrier statement between device-loop phases
+when a kernel uses ``hl.barrier()`` (e.g. the barrier-based split-K matmul
+example).  The Triton backend lowers that to
+``triton_helpers.x_grid_barrier(sem)``; this module provides the equivalent
+for the CuTe backend.
+
+The semantics mirror inductor's ``x_grid_barrier``
+(``torch/_inductor/runtime/triton_helpers.py``): every CTA in the persistent
+grid arrives at a shared, zero-initialized ``uint32`` semaphore via an atomic
+release add, then spin-waits (atomic acquire add of 0) on the high "flip" bit
+toggling.  CTA 0 contributes ``0x80000000 - (expected - 1)`` and every other
+CTA contributes ``1``, so once all ``expected`` CTAs have arrived the
+accumulated value rolls the flip bit, releasing every spinner.
+
+The CuTe wrinkle is that the kernel runs many threads per CTA (Triton runs a
+single program per CTA), so a naive port would issue one atomic per thread and
+over-count.  We therefore:
+
+  1. ``sync_threads()`` to fence this CTA's stores and synchronize its threads,
+  2. elect a single leader thread (``thread_idx`` all zero) to perform the
+     global atomics and the spin-wait,
+  3. ``sync_threads()`` again so all threads in the CTA wait for the leader.
+
+The expected CTA count is ``grid_dim()[0]`` (the persistent grid is launched as
+``(_NUM_SM,)``), and the CTA-0-vs-others contribution is keyed on
+``block_idx()[0] == 0``.
+
+This is decorated with ``@cute.jit`` (not ``@dsl_user_op``) so the spin loop's
+Python ``while`` over a dynamic value traces into an ``scf.WhileOp``, exactly
+like CUTLASS's own ``cutlass.utils.distributed`` spin-lock helpers.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import cutlass
+import cutlass.cute as cute
+
+if TYPE_CHECKING:
+    from cutlass._mlir import ir
+
+_FLIP_BIT = 0x80000000
+
+
+@cute.jit
+def grid_barrier(
+    sem_ptr: cute.Pointer,
+    *,
+    loc: ir.Location | None = None,
+    ip: ir.InsertionPoint | None = None,
+) -> None:
+    """Wait for all CTAs in the (1-D persistent) grid to reach this barrier.
+
+    :param sem_ptr: pointer to a single, zero-initialized ``uint32`` semaphore
+        shared by every CTA in the grid (Helion allocates it as
+        ``torch.zeros((1,), dtype=torch.uint32)`` and passes the CuTe tensor's
+        ``.iterator`` pointer).
+    """
+    # Ensure stores before this barrier are visible and synchronize the block.
+    cute.arch.sync_threads()
+
+    tidx, tidy, tidz = cute.arch.thread_idx()
+    is_leader = (tidx == 0) and (tidy == 0) and (tidz == 0)
+
+    # Only the leader thread touches the global semaphore so the per-CTA arrival
+    # is counted exactly once.
+    if is_leader:
+        expected = cutlass.Uint32(cute.arch.grid_dim()[0])
+        bidx = cute.arch.block_idx()[0]
+        nb = (
+            (cutlass.Uint32(_FLIP_BIT) - (expected - cutlass.Uint32(1)))
+            if bidx == 0
+            else cutlass.Uint32(1)
+        )
+
+        old_arrive = cute.arch.atomic_add(
+            sem_ptr, nb, sem="release", scope="gpu", loc=loc, ip=ip
+        )
+
+        # Spin until the flip bit toggles relative to our arrival snapshot.
+        current_arrive = old_arrive
+        while ((old_arrive ^ current_arrive) & cutlass.Uint32(_FLIP_BIT)) == 0:
+            current_arrive = cute.arch.atomic_add(
+                sem_ptr,
+                cutlass.Uint32(0),
+                sem="acquire",
+                scope="gpu",
+                loc=loc,
+                ip=ip,
+            )
+
+    # All threads wait for the leader to clear the barrier.
+    cute.arch.sync_threads()

--- a/helion/_compiler/cute/hoist_loop_invariant_recip.py
+++ b/helion/_compiler/cute/hoist_loop_invariant_recip.py
@@ -470,6 +470,16 @@ def _inline_invariant_aliases_in_body(body: list[ast.stmt]) -> None:
             if name in alias_def_idx:
                 multi_assigned.add(name)
             non_alias_assign_idx.setdefault(name, []).append(idx)
+            # Also record this write under its canonical (post-rename)
+            # name so the Pass-4 root-reassignment safety check can see
+            # that a snapshot's chain root is reassigned through a renamed
+            # alias (e.g. ``v_9 = acc_cnt + ...`` writes canonical
+            # ``acc_cnt``). Without this, a snapshot taken before that
+            # write could be inlined past the reassignment, dropping the
+            # loop-carried value.
+            canon = _RENAME_GROUPS.get(name, name)
+            if canon != name:
+                non_alias_assign_idx.setdefault(canon, []).append(idx)
     for name in multi_assigned:
         alias_def_idx.pop(name, None)
         alias_rhs.pop(name, None)
@@ -596,6 +606,13 @@ def _inline_invariant_aliases_in_body(body: list[ast.stmt]) -> None:
         # are dropped only after the safety check, so they still count
         # as reassignment points if they exist).
         root_assign_idxs = list(non_alias_assign_idx.get(root, []))
+        # Also count reassignments of ROOT's canonical (post-rename)
+        # name: a renamed alias like ``v_9 = acc_cnt + ...`` writes the
+        # same logical loop-carried variable as ``root``, and inlining
+        # the snapshot past it would drop the carried value.
+        canon_root = _RENAME_GROUPS.get(root, root)
+        if canon_root != root:
+            root_assign_idxs.extend(non_alias_assign_idx.get(canon_root, []))
         if root in alias_def_idx:
             root_assign_idxs.append(alias_def_idx[root])
         # Reassignments strictly between the snapshot and any use are

--- a/helion/_compiler/cute/matmul_fallback.py
+++ b/helion/_compiler/cute/matmul_fallback.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 import torch
 
+from ... import exc
 from ..ast_extension import expr_from_string
 from ..ast_extension import statement_from_string
 from ..compile_environment import CompileEnvironment
@@ -15,6 +16,186 @@ from .indexing import CutePackedTerms
 
 if TYPE_CHECKING:
     from ..helper_function import CodegenInterface
+
+
+# fx ops that preserve the underlying byte storage of a tensor (no dtype
+# change, no arithmetic).  Used to trace a matmul operand back to its raw
+# ``memory_ops.load`` so we can tell a raw fp8 *byte* load apart from a
+# *computed* fp8 register value (e.g. ``p = exp2(...).to(fp8)``).
+_FP8_LOAD_PASSTHROUGH_TARGETS = frozenset(
+    {
+        torch.ops.aten.clone.default,
+        torch.ops.aten.detach.default,
+        torch.ops.aten.permute.default,
+        torch.ops.aten.reshape.default,
+        torch.ops.aten.squeeze.dim,
+        torch.ops.aten.squeeze.default,
+        torch.ops.aten.t.default,
+        torch.ops.aten.transpose.int,
+        torch.ops.aten.unsqueeze.default,
+        torch.ops.aten.view.default,
+        torch.ops.aten._unsafe_view.default,
+        torch.ops.aten.expand.default,
+    }
+)
+
+
+def _cute_operand_is_computed_fp8(node: object) -> bool:
+    """Return True when an fp8 operand is a *computed* register value.
+
+    A computed fp8 value (e.g. ``p = exp2(...).to(fp8)``) is produced by a
+    dtype conversion from a non-fp8 source and lands in registers as a typed
+    ``cutlass.Float8E4M3FN``.  Widening it uses an ordinary numeric cast -
+    routing it through the raw-byte PTX decode emits an invalid
+    ``(i8) -> f8E4M3FN`` conversion that fails to lower.
+
+    A *raw* fp8 load (possibly hoisted out of the K loop, so its fx node is a
+    loop-carried ``_new_var`` placeholder) keeps the value as raw
+    ``cutlass.Uint8`` bytes and MUST go through the PTX decode.  Anything that
+    is not provably a from-non-fp8 conversion is treated as a raw load.
+    """
+    import torch.fx
+
+    cur = node
+    for _ in range(64):
+        if not isinstance(cur, torch.fx.Node):
+            return False
+        if (
+            cur.op == "call_function"
+            and cur.target is torch.ops.prims.convert_element_type.default
+        ):
+            source = cur.args[0] if cur.args else None
+            src_dtype = None
+            if isinstance(source, torch.fx.Node):
+                src_val = source.meta.get("val")
+                if isinstance(src_val, torch.Tensor):
+                    src_dtype = src_val.dtype
+            # A convert *from* a non-fp8 dtype produces a computed fp8 value.
+            return src_dtype is not torch.float8_e4m3fn
+        if cur.op != "call_function" or cur.target not in _FP8_LOAD_PASSTHROUGH_TARGETS:
+            return False
+        inputs = [a for a in cur.args if isinstance(a, torch.fx.Node)]
+        if len(inputs) != 1:
+            return False
+        cur = inputs[0]
+    return False
+
+
+# fx ops that re-expose a value at the same numeric magnitude (no rescale).
+# Tracing the accumulator through these reaches the loop-carried phi without
+# crossing an arithmetic rescale.
+_ACC_PHI_PASSTHROUGH_TARGETS = frozenset(
+    {
+        torch.ops.aten.clone.default,
+        torch.ops.aten.detach.default,
+        torch.ops.aten.permute.default,
+        torch.ops.aten.reshape.default,
+        torch.ops.aten.squeeze.dim,
+        torch.ops.aten.squeeze.default,
+        torch.ops.aten.t.default,
+        torch.ops.aten.transpose.int,
+        torch.ops.aten.unsqueeze.default,
+        torch.ops.aten.view.default,
+        torch.ops.aten._unsafe_view.default,
+        torch.ops.aten.expand.default,
+        torch.ops.prims.convert_element_type.default,
+    }
+)
+
+
+def _cute_acc_is_rescaled_loop_carried(acc_node: object) -> bool:
+    """Return True for a *rescaled* loop-carried accumulator (online softmax).
+
+    The cross-lane ``dot_acc`` accumulator (sum the K products across lane
+    iterations in fp32, then add the accumulator once) is correct - and more
+    precise - for:
+
+    * a standalone ``addmm`` whose bias is a plain load (loop-invariant), and
+    * a plain matmul K-loop ``acc = hl.dot(x, y, acc=acc)`` where ``acc`` is the
+      loop-carried phi added to verbatim (no rescale inside the K loop).
+
+    A flash-attention online-softmax recurrence instead *rescales* the
+    accumulator every K iteration (``acc = acc * alpha + p @ v``).  The ``acc``
+    operand passed to the dot is therefore a value *derived from* the loop phi
+    through an arithmetic rescale rather than the bare phi.  There ``dot_acc``
+    double-counts every prior product (the running sum is re-added each
+    iteration while the rescaled base is recomputed), so the matmul must emit a
+    per-iteration ``acc = (rescaled acc) + product`` update and let the loop phi
+    carry the running sum.
+
+    Detection: strip pure dtype-casts / views off ``acc``.  If what remains is
+    a ``_new_var`` loop-carried phi (or anything not derived from a phi), the
+    accumulator is NOT rescaled -> keep ``dot_acc``.  If the phi is only
+    reachable *through* an arithmetic op (mul/add/sub/div/...), the accumulator
+    is rescaled -> use the per-iteration form.
+    """
+    import torch.fx
+
+    from ...language._tracing_ops import _new_var
+
+    if not isinstance(acc_node, torch.fx.Node):
+        return False
+
+    # Strip pure casts / views: a bare (possibly re-typed) loop phi is a plain
+    # accumulation, not a rescale.
+    cur = acc_node
+    for _ in range(64):
+        if not isinstance(cur, torch.fx.Node):
+            return False
+        if cur.op == "call_function" and cur.target is _new_var:
+            return False  # bare loop phi -> plain accumulation
+        if cur.op == "call_function" and cur.target in _ACC_PHI_PASSTHROUGH_TARGETS:
+            inputs = [a for a in cur.args if isinstance(a, torch.fx.Node)]
+            if len(inputs) == 1:
+                cur = inputs[0]
+                continue
+        break
+
+    # ``cur`` is an arithmetic node (or otherwise).  It is a rescaled
+    # accumulator only if it is fed by a loop-carried phi.
+    seen: set[torch.fx.Node] = set()
+    stack = [cur]
+    while stack:
+        node = stack.pop()
+        if node in seen:
+            continue
+        seen.add(node)
+        if len(seen) > 256:
+            break
+        if node.op == "call_function" and node.target is _new_var:
+            src = node.args[0] if node.args else None
+            if isinstance(src, torch.fx.Node) and src.op == "placeholder":
+                return True
+        if node.op != "call_function":
+            continue
+        for arg in node.args:
+            if isinstance(arg, torch.fx.Node):
+                stack.append(arg)
+            elif isinstance(arg, (list, tuple)):
+                stack.extend(a for a in arg if isinstance(a, torch.fx.Node))
+    return False
+
+
+def _cast_operand_to_f32(
+    term: ast.AST, dtype: torch.dtype | None, *, is_computed_fp8: bool
+) -> ast.AST:
+    """Promote a sub-f32 matmul operand to float32 for the scalar fallback.
+
+    Raw ``float8_e4m3fn`` tensors are loaded as raw ``cutlass.Uint8`` bytes
+    (the CuTe DSL has no scalar fp8 dereference), so a plain numeric cast would
+    interpret the storage byte as an integer (e.g. ``0x40`` -> ``64.0``)
+    instead of decoding the fp8 value.  Route those through the bit-exact PTX
+    decode helper.
+
+    A *computed* fp8 value (``exp2(...).to(fp8)``) is already a typed
+    ``cutlass.Float8E4M3FN`` register value, so it widens with the ordinary
+    numeric cast - applying the byte decode there emits an invalid
+    ``(i8) -> f8E4M3FN`` conversion.  bf16/fp16 are genuine numeric widenings
+    and always use the ordinary cast.
+    """
+    if dtype is torch.float8_e4m3fn and not is_computed_fp8:
+        return expr_from_string("_cute_fp8e4m3fn_to_float32({x})", x=term)
+    return cast_ast(term, torch.float32)
 
 
 def _cute_active_thread_layout(
@@ -117,15 +298,29 @@ def _emit_cute_grouped_sum_reduction(
     pre = 1
     for axis in range(thread_axis):
         pre *= axis_sizes.get(axis, 1)
-    if pre <= 1:
+    group_span = pre * reduce_extent
+    # ``cute.arch.warp_reduction_sum`` shuffles only within a single 32-thread
+    # warp (``shuffle_sync_bfly`` clamps to lane 31), so a direct warp reduce
+    # is only correct when the whole reduction group fits inside one warp.  A
+    # contraction dim with >32 threads (e.g. head_dim=64 on the QK matmul) must
+    # use the shared-memory two-stage reduction instead - otherwise it silently
+    # sums only the first 32 of the contraction elements.
+    direct_warp_ok = pre <= 1 and reduce_extent <= 32
+    if direct_warp_ok:
         return backend.reduction_expr(
             input_name, "sum", 0, threads_in_group=reduce_extent
         )
 
     lane_expr = backend.thread_linear_index_expr(axis_sizes)
     if lane_expr is None:
-        return backend.reduction_expr(
-            input_name, "sum", 0, threads_in_group=reduce_extent
+        if reduce_extent <= 32:
+            return backend.reduction_expr(
+                input_name, "sum", 0, threads_in_group=reduce_extent
+            )
+        raise exc.BackendUnsupported(
+            "cute",
+            "CuTe scalar matmul fallback cannot reduce a >32-thread contraction "
+            "without a linear thread index",
         )
 
     num_threads = 1
@@ -135,12 +330,17 @@ def _emit_cute_grouped_sum_reduction(
     for size in getattr(cg, "max_thread_block_dims", ()):
         actual_threads *= max(size, 1)
     if actual_threads > 0 and num_threads > actual_threads:
-        return backend.reduction_expr(
-            input_name, "sum", 0, threads_in_group=reduce_extent
+        if reduce_extent <= 32:
+            return backend.reduction_expr(
+                input_name, "sum", 0, threads_in_group=reduce_extent
+            )
+        raise exc.BackendUnsupported(
+            "cute",
+            "CuTe scalar matmul fallback cannot reduce a >32-thread contraction "
+            "when the planned thread count exceeds the launch block",
         )
 
     identity_expr = f"{backend.dtype_str(value_dtype)}(0)"
-    group_span = pre * reduce_extent
     if group_span <= 32:
         return (
             "_cute_grouped_reduce_warp("
@@ -198,6 +398,9 @@ def _emit_cute_matmul(
     acc_dtype: torch.dtype | None = None,
     lhs_dtype: torch.dtype | None = None,
     rhs_dtype: torch.dtype | None = None,
+    lhs_node: object = None,
+    rhs_node: object = None,
+    acc_node: object = None,
 ) -> ast.AST:
     """Build a CuTe matmul fallback using a cross-thread reduction over K."""
     if hasattr(cg, "cute_uses_matmul"):
@@ -219,8 +422,16 @@ def _emit_cute_matmul(
         and _needs_f32_accumulator(lhs_dtype, rhs_dtype)
     ):
         reduction_dtype = torch.float32
-        rhs_terms = tuple(cast_ast(term, reduction_dtype) for term in rhs_terms)
-        lhs_terms = tuple(cast_ast(term, reduction_dtype) for term in lhs_terms)
+        lhs_computed_fp8 = _cute_operand_is_computed_fp8(lhs_node)
+        rhs_computed_fp8 = _cute_operand_is_computed_fp8(rhs_node)
+        rhs_terms = tuple(
+            _cast_operand_to_f32(term, rhs_dtype, is_computed_fp8=rhs_computed_fp8)
+            for term in rhs_terms
+        )
+        lhs_terms = tuple(
+            _cast_operand_to_f32(term, lhs_dtype, is_computed_fp8=lhs_computed_fp8)
+            for term in lhs_terms
+        )
     if len(lhs_terms) == len(rhs_terms):
         term_pairs = zip(lhs_terms, rhs_terms, strict=True)
     elif len(lhs_terms) == 1:
@@ -254,6 +465,21 @@ def _emit_cute_matmul(
         lane_vars = getattr(loop_state.strategy, "_lane_var_by_block", None)
         lane_var = lane_vars.get(k_block_id) if isinstance(lane_vars, dict) else None
         if not accumulate_in_lane_loop:
+            lane_var = None
+        # BUG#1 fix: a flash-attention online-softmax accumulator is rescaled
+        # (``acc = acc * alpha + p @ v``) every iteration of the K lane loop.
+        # The cross-lane ``dot_acc`` running sum would then be re-added each
+        # iteration while ``acc`` is independently rescaled, double-counting
+        # every prior product.  When ``acc`` is such a loop-carried value, emit
+        # the per-iteration ``acc = acc + product`` update instead (the loop
+        # phi carries the running sum) by skipping the ``dot_acc`` path.  A
+        # loop-invariant accumulator (e.g. a standalone ``addmm`` bias) keeps
+        # ``dot_acc`` so the per-lane products are summed before the bias add.
+        if (
+            lane_var is not None
+            and acc is not None
+            and _cute_acc_is_rescaled_loop_carried(acc_node)
+        ):
             lane_var = None
         if lane_var is not None:
             product_name = cg.lift(product, dce=True, prefix="dot_product").id

--- a/helion/_compiler/cute/matmul_utils.py
+++ b/helion/_compiler/cute/matmul_utils.py
@@ -643,6 +643,98 @@ def cute_resolve_active_matmul_k_block_id(
     return lhs_k_block_id
 
 
+def _cute_matmul_operand_indices() -> dict[object, tuple[int, int]]:
+    """``(lhs_arg_index, rhs_arg_index)`` for each matmul op the CuTe backend
+    lowers through the scalar fallback.
+
+    The contraction (K) axis is ``lhs.shape[-1]`` / ``rhs.shape[-2]``; the free
+    (output) axes are ``lhs.shape[-2]`` (M) and ``rhs.shape[-1]`` (N).  Includes
+    both the aten matmul family and Helion's device-IR ``hl.dot`` / ``dot_scaled``
+    ops, which appear *before* aten lowering when the tile strategies are built.
+    """
+    from ...language import matmul_ops
+
+    return {
+        torch.ops.aten.mm.default: (0, 1),
+        torch.ops.aten.bmm.default: (0, 1),
+        torch.ops.aten.bmm.dtype: (0, 1),
+        torch.ops.aten.addmm.default: (1, 2),
+        torch.ops.aten.baddbmm.default: (1, 2),
+        matmul_ops.dot: (0, 1),
+        matmul_ops.dot_scaled: (0, 3),
+    }
+
+
+def cute_matmul_contraction_block_ids() -> set[int]:
+    """Return block ids that are the *contraction* (K) axis of some matmul.
+
+    A matmul's contraction axis is ``lhs.shape[-1]`` (equivalently
+    ``rhs.shape[-2]``).  When such an axis is also a reduction block that the
+    CuTe backend would otherwise split into ``N`` hardware threads x a synthetic
+    per-thread lane loop, the cross-thread matmul reduction only sums the ``N``
+    thread lanes - never the synthetic-lane partials - so each contracted dot
+    product covers only ``N`` of the ``K`` elements.  The thread-budget planner
+    uses this set to give the contraction axis priority for real threads (so the
+    already-landed cross-warp shared-memory reduction can sum the full ``K``)
+    and pushes the synthetic lanes onto the free / output tile axes instead,
+    where a lane loop is correct.
+
+    Returns the *canonical* block ids so callers can compare against either the
+    raw or canonical form.
+    """
+    from ..host_function import HostFunction
+    from ..host_function import NoCurrentFunction
+
+    if not CompileEnvironment.has_current():
+        return set()
+    env = CompileEnvironment.current()
+    canonical_block_id = getattr(env, "canonical_block_id", lambda block_id: block_id)
+    try:
+        hf = HostFunction.current()
+    except NoCurrentFunction:
+        return set()
+    # Guard via getattr so a test double exposing only the public ``device_ir``
+    # (without the private ``_device_ir`` backing field) is handled too; the
+    # real HostFunction.device_ir property asserts when ``_device_ir`` is None,
+    # so we must avoid touching the property in that case.
+    if getattr(hf, "_device_ir", "unset") is None:
+        return set()
+    device_ir = hf.device_ir
+    operand_indices_by_target = _cute_matmul_operand_indices()
+    result: set[int] = set()
+    for graph_info in getattr(device_ir, "graphs", ()):
+        graph = getattr(graph_info, "graph", None)
+        if not isinstance(graph, torch.fx.Graph):
+            continue
+        for node in graph.nodes:
+            if node.op != "call_function":
+                continue
+            operand_indices = operand_indices_by_target.get(node.target)
+            if operand_indices is None:
+                continue
+            lhs_idx, rhs_idx = operand_indices
+            args = node.args
+            if len(args) <= max(lhs_idx, rhs_idx):
+                continue
+            lhs_arg = args[lhs_idx]
+            rhs_arg = args[rhs_idx]
+            if not isinstance(lhs_arg, Node) or not isinstance(rhs_arg, Node):
+                continue
+            lhs_val = lhs_arg.meta.get("val")
+            rhs_val = rhs_arg.meta.get("val")
+            if not isinstance(lhs_val, torch.Tensor) or not isinstance(
+                rhs_val, torch.Tensor
+            ):
+                continue
+            if lhs_val.ndim < 1 or rhs_val.ndim < 2:
+                continue
+            for k_size in (lhs_val.shape[-1], rhs_val.shape[-2]):
+                block_id = env.resolve_block_id(k_size)
+                if block_id is not None:
+                    result.add(canonical_block_id(block_id))
+    return result
+
+
 def cute_outer_accumulator_out_dtype(
     resolved_out_dtype: torch.dtype,
     outer_acc_dtype: torch.dtype | None,

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -681,11 +681,46 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                     if persistent_body is not None:
                         # pyrefly: ignore [bad-assignment]
                         self.device_function.body = persistent_body
+                    else:
+                        # The persistent path pulls tcgen05 post-loop cleanup to
+                        # the end of the body; the non-persistent (flat-grid)
+                        # path must do the same so a multi-store fan-out's
+                        # one-shot teardown runs after every store reads the
+                        # accumulator. No-op when there are no post-loop marks.
+                        self.device_function.body = self.device_function.cute_state.move_tcgen05_post_loop_stmts_to_end(
+                            list(self.device_function.body)
+                        )
                 # Mark extra params as placeholder args — they appear only in
                 # placeholder strings, not in the AST body, so DCE would
                 # otherwise remove them.
                 for param in self._extra_params:
                     self.device_function.placeholder_args.add(param)
+                if CompileEnvironment.current().backend.name == "cute":
+                    from .tile_strategy import (
+                        interchange_lane_outside_serial_reductions,
+                    )
+                    from .tile_strategy import restore_unprocessed_lane_reduce_markers
+                    from .tile_strategy import split_lane_loop_reductions
+
+                    # First interchange any ``for LANE: ... for MB: ...`` nest
+                    # whose inner serial loop carries lane-reduce markers into a
+                    # lane-outside-mb accumulator nest plus a lane-inside-mb
+                    # reduction nest; then split the (now inner) lane loops into
+                    # the two-pass accumulate/finalize/consume structure.
+                    self.device_function.body = (
+                        interchange_lane_outside_serial_reductions(
+                            list(self.device_function.body)
+                        )
+                    )
+                    self.device_function.body = split_lane_loop_reductions(
+                        list(self.device_function.body)
+                    )
+                    # Safety net: revert any lane-reduce marker that neither pass
+                    # rewrote so no ``_helion_lane_reduce`` call leaks into the
+                    # emitted kernel.
+                    self.device_function.body = restore_unprocessed_lane_reduce_markers(
+                        list(self.device_function.body)
+                    )
                 self.device_function.dead_code_elimination()
                 if not self.device_function.preamble and not self.device_function.body:
                     raise exc.EmptyDeviceLoopAfterDCE

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -245,6 +245,95 @@ class ReductionStrategy(TileStrategy):
                     return True
         return False
 
+    def _reduction_block_in_device_lane_loop(self) -> bool:
+        """Return True when a ``DeviceLoopState`` distributes this reduction
+        block across a per-thread lane loop (CuteNDTileStrategy lanes).
+
+        Unlike :meth:`_reduction_block_has_lane_loops`, this does NOT feed
+        :meth:`_needs_loop_carried_accumulator` — it is a dedicated signal for
+        the two-pass marker so the existing warp / vec-fold paths keep their
+        tuned behavior.
+        """
+        codegen = getattr(self, "_codegen", None)
+        if codegen is None:
+            return False
+        for loops in codegen.active_device_loops.values():
+            for loop_state in loops:
+                if (
+                    isinstance(loop_state, DeviceLoopState)
+                    and self.block_index in loop_state.lane_loop_blocks
+                ):
+                    return True
+        return False
+
+    def _lane_reduce_threads_in_group(self) -> int | None:
+        """Return ``threads_in_group`` for a two-pass lane reduction over this
+        block, or ``None`` when this reduction is not over a lane-distributed
+        block.
+
+        When the block is split across a per-thread lane loop, the per-lane
+        partials must first be accumulated across the lane loop and then
+        combined across the live thread axis (``threads_in_group``). A value of
+        1 means the block has no live thread axis (a pure lane loop), so the
+        accumulator alone is the result.
+        """
+        # A synthetic reduction lane (PersistentReductionStrategy) always
+        # distributes the reduction axis across a lane loop; the live thread
+        # axis is ``_reduction_thread_count`` wide.
+        if getattr(self, "_synthetic_cute_lane_var", None) is not None:
+            return max(1, self._reduction_thread_count())
+        if not (
+            self._reduction_block_has_lane_loops()
+            or self._reduction_block_in_device_lane_loop()
+        ):
+            return None
+        threads = self._reduction_thread_count()
+        return max(1, threads)
+
+    def _lane_reduce_marker_unsupported(self, state: CodegenState) -> bool:
+        """Return True when the two-pass lane-reduction marker cannot be
+        handled by the ``split_lane_loop_reductions`` post-pass, so the caller
+        must fall back to the existing single-pass path.
+
+        Two situations are unsupported:
+
+        * An active *serial* device loop (over a different block) wraps this
+          reduction inside the lane scope. The post-pass splits the lane loop
+          at its top level, but here the reduction needs the lanes reduced
+          *per* serial iteration (the lane loop is outside the serial loop).
+        * An active ``LoopedReductionStrategy`` already rolls this block: the
+          rolled loop carries its own accumulator (and vec-fold) for the lane
+          reduction, so emitting a marker would double-handle it.
+        """
+        for block_id, loops in state.codegen.active_device_loops.items():
+            for loop_state in loops:
+                if not isinstance(loop_state, DeviceLoopState):
+                    continue
+                if isinstance(loop_state.strategy, LoopedReductionStrategy):
+                    # The rolled reduction owns the lane reduction over its
+                    # block; defer to its accumulate / vec-fold machinery.
+                    if block_id == self.block_index:
+                        return True
+                    continue
+                if (
+                    block_id != self.block_index
+                    and block_id not in loop_state.block_thread_axes
+                    and block_id not in loop_state.lane_loop_blocks
+                ):
+                    # The reduction's lane loop is OUTSIDE this serial device
+                    # loop. A synthetic-lane PersistentReductionStrategy can be
+                    # repaired by the ``interchange_lane_outside_serial_reductions``
+                    # post-pass (it splits the lane loop into a lane-inside-mb
+                    # two-pass nest for the broadcast consumer plus a
+                    # lane-outside-mb nest for any per-feature accumulators), so
+                    # keep emitting the marker in that case. Other (non-synthetic)
+                    # situations remain unsupported. ``getattr`` guards strategies
+                    # without a synthetic lane var (e.g. BlockReductionStrategy).
+                    if getattr(self, "_synthetic_cute_lane_var", None) is not None:
+                        continue
+                    return True
+        return False
+
     def _reduction_block_is_serial(self) -> bool:
         """Return True when this reduction block is being traversed by a
         serial ``DeviceLoopState`` (a Python ``for`` loop) rather than a
@@ -515,22 +604,38 @@ class PersistentReductionStrategy(ReductionStrategy):
             isinstance(graph, ReductionLoopGraphInfo) and block_index in graph.block_ids
             for graph in fn.codegen.codegen_graphs
         )
-        if not is_graph_reduction_dim and self._thread_count > 0:
+        if self._thread_count > 0:
             if isinstance(numel, (int, sympy.Integer)):
                 size_hint = int(numel)
             elif isinstance(numel, sympy.Expr):
                 size_hint = shape_env_size_hint(env.shape_env, numel)
             else:
                 size_hint = env.size_hint(numel)
-            lane_extent = env.backend.create_synthetic_reduction_lanes(
-                self._thread_count, size_hint
+            # For a non-graph-reduction dim we always try to recover the
+            # full extent through a synthetic lane loop. For a graph
+            # reduction dim we only need the synthetic lane loop when
+            # ``adjust_reduction_thread_count`` shrank ``thread_count``
+            # below the (padded) reduction extent — otherwise every logical
+            # lane is already backed by a live thread and the warp/cross-warp
+            # reduction covers the whole axis. Without this, a shrunk
+            # graph-reduction dim only addresses the first ``thread_count``
+            # elements (e.g. layer_norm_bwd's feature axis), leaving the
+            # remaining columns/partial sums uncomputed.
+            needs_synthetic = not is_graph_reduction_dim or (
+                self._thread_count < next_power_of_2(min(size_hint, max_threads))
+                if max_threads is not None
+                else False
             )
-            if lane_extent is not None:
-                self._synthetic_cute_lane_var = fn.new_var(
-                    f"synthetic_lane_{block_index}",
-                    dce=False,
+            if needs_synthetic:
+                lane_extent = env.backend.create_synthetic_reduction_lanes(
+                    self._thread_count, size_hint
                 )
-                self._synthetic_cute_lane_extent = lane_extent
+                if lane_extent is not None:
+                    self._synthetic_cute_lane_var = fn.new_var(
+                        f"synthetic_lane_{block_index}",
+                        dce=False,
+                    )
+                    self._synthetic_cute_lane_extent = lane_extent
 
     def _reduction_thread_count(self) -> int:
         return self._thread_count
@@ -716,6 +821,29 @@ class PersistentReductionStrategy(ReductionStrategy):
             )
         acc_dtype = get_computation_dtype(fake_input.dtype)
         default = ir.Reduction.default_accumulator(reduction_type, acc_dtype)
+        if (
+            self._synthetic_cute_lane_var is not None
+            and not backend.is_indexed_reduction(reduction_type)
+            and isinstance(default, (float, int, bool))
+            and not self._lane_reduce_marker_unsupported(state)
+            and (threads := self._lane_reduce_threads_in_group()) is not None
+        ):
+            # The reduction axis is split across a synthetic per-thread lane
+            # loop: the single warp reduction only covers one lane's worth of
+            # elements. Emit a marker so the ``split_lane_loop_reductions``
+            # post-pass produces the two-pass (accumulate across lanes ->
+            # warp-combine across ``threads`` -> consume) structure.
+            from .tile_strategy import _lane_reduce_marker_expr
+
+            identity_expr = backend.cast_expr(
+                constant_repr(default), _dtype_str(acc_dtype)
+            )
+            expr = _lane_reduce_marker_expr(
+                input_name, reduction_type, identity_expr, threads
+            )
+            return expr_from_string(
+                self.maybe_reshape(expr, dim, fake_input, fake_output)
+            )
         if isinstance(default, (float, int, bool)):
             cross_warp = self._cute_cross_warp_reduction_expr(
                 state, input_name, reduction_type, default, acc_dtype
@@ -1873,13 +2001,38 @@ class BlockReductionStrategy(ReductionStrategy):
             expr = strided_expr
         elif self._needs_loop_carried_accumulator():
             # The reduction block is not backed by a live thread axis in the
-            # active loop nest (it is iterated either by a serial device
-            # loop, by a synthetic lane loop, or has no thread axis at
-            # all). A warp-level reduction would fold together unrelated
-            # tensor elements, so each iteration contributes only its
-            # current scalar value and the surrounding loop-carried
-            # accumulator performs the real reduction.
-            expr = input_name
+            # active loop nest (it is iterated either by a serial device loop,
+            # by a lane loop, or has no thread axis at all).
+            if (
+                (
+                    self._reduction_block_has_lane_loops()
+                    or self._reduction_block_in_device_lane_loop()
+                )
+                and not self._lane_reduce_marker_unsupported(state)
+                and (threads := self._lane_reduce_threads_in_group()) is not None
+            ):
+                # The block is split across a per-thread lane loop. The
+                # single-pass lane loop can only produce a per-lane partial,
+                # but every consumer needs the full reduction. Emit a marker
+                # that the ``split_lane_loop_reductions`` post-pass rewrites
+                # into a two-pass (accumulate across lanes -> combine across
+                # ``threads`` -> consume) lane structure.
+                from .tile_strategy import _lane_reduce_marker_expr
+
+                acc_dtype = get_computation_dtype(fake_input.dtype)
+                identity_expr = env.backend.cast_expr(
+                    constant_repr(default), _dtype_str(acc_dtype)
+                )
+                expr = _lane_reduce_marker_expr(
+                    input_name, reduction_type, identity_expr, threads
+                )
+            else:
+                # A serial device loop (or no thread axis at all). A warp-level
+                # reduction would fold together unrelated tensor elements, so
+                # each iteration contributes only its current scalar value and
+                # the surrounding loop-carried accumulator performs the real
+                # reduction.
+                expr = input_name
         else:
             expr = self.call_reduction_function(
                 input_name,

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -89,6 +89,742 @@ def _create_lane_loop(lane_var: str, extent: int, body: list[ast.AST]) -> ast.Fo
     return loop
 
 
+# Marker call emitted by reduction strategies when a reduction over a
+# lane-distributed block is generated inside a single-pass lane loop.  The
+# ``split_lane_loop_reductions`` post-pass recognizes these markers and
+# rewrites the enclosing lane loop into a two-pass structure:
+#
+#   (phase 1) accumulate the per-lane reduction inputs across the lane loop,
+#             then combine across the live thread axis (``threads_in_group``)
+#             into the final scalar;
+#   (finalize) define the reduced scalar between the two passes;
+#   (phase 2) re-iterate the lanes to apply any lane-varying consumers (e.g.
+#             the broadcast normalize / store) using the finalized scalar.
+#
+# The marker never reaches the emitted kernel — the post-pass strips every
+# marker it processes.
+_HELION_LANE_REDUCE_MARKER = "_helion_lane_reduce"
+
+
+def _lane_reduce_marker_expr(
+    input_name: str,
+    reduction_type: str,
+    identity_expr: str,
+    threads_in_group: int,
+) -> str:
+    return (
+        f"{_HELION_LANE_REDUCE_MARKER}({input_name}, {reduction_type!r}, "
+        f"{identity_expr}, {threads_in_group})"
+    )
+
+
+@dataclasses.dataclass
+class _LaneReduceMarker:
+    result_var: str
+    input_name: str
+    reduction_type: str
+    identity_expr: str
+    threads_in_group: int
+    # The original RHS expression with the marker call replaced by the string
+    # ``{finalized}``; ``finalize_expr(x)`` substitutes ``x`` to re-apply any
+    # surrounding dtype cast / reshape to the finalized reduced scalar.
+    wrap_template: str
+
+    def finalize_expr(self, reduced: str) -> str:
+        return self.wrap_template.replace("__HELION_FINALIZED__", f"({reduced})")
+
+
+def _find_lane_reduce_call(node: ast.AST) -> ast.Call | None:
+    for sub in ast.walk(node):
+        if (
+            isinstance(sub, ast.Call)
+            and isinstance(sub.func, ast.Name)
+            and sub.func.id == _HELION_LANE_REDUCE_MARKER
+        ):
+            return sub
+    return None
+
+
+class _ReplaceLaneReduceCall(ast.NodeTransformer):
+    def visit_Call(self, node: ast.Call) -> ast.AST:
+        self.generic_visit(node)
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id == _HELION_LANE_REDUCE_MARKER
+        ):
+            return ast.copy_location(
+                create(ast.Name, id="__HELION_FINALIZED__", ctx=ast.Load()), node
+            )
+        return node
+
+
+def _is_lane_reduce_marker_assign(stmt: ast.AST) -> _LaneReduceMarker | None:
+    """If ``stmt`` assigns an expression containing a single
+    ``_helion_lane_reduce(IN, TYPE, ID, T)`` marker call, return a
+    :class:`_LaneReduceMarker`; otherwise return ``None``.
+
+    The marker may be nested inside a surrounding cast/reshape (e.g.
+    ``R = cutlass.Float32(_helion_lane_reduce(...))``); the wrapping is
+    captured so it can be re-applied to the finalized reduced scalar.
+    """
+    if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+        return None
+    target = stmt.targets[0]
+    if not isinstance(target, ast.Name):
+        return None
+    call = _find_lane_reduce_call(stmt.value)
+    if call is None or len(call.args) != 4:
+        return None
+    input_node, type_node, identity_node, threads_node = call.args
+    input_name = ast.unparse(input_node)
+    reduction_type = ast.literal_eval(type_node)
+    identity_expr = ast.unparse(identity_node)
+    threads_in_group = int(ast.literal_eval(threads_node))
+    # Build the wrap template by replacing the marker call with a sentinel.
+    wrapped = _ReplaceLaneReduceCall().visit(ast.parse(ast.unparse(stmt.value)).body[0])
+    assert isinstance(wrapped, ast.Expr)
+    wrap_template = ast.unparse(wrapped.value)
+    return _LaneReduceMarker(
+        result_var=target.id,
+        input_name=input_name,
+        reduction_type=reduction_type,
+        identity_expr=identity_expr,
+        threads_in_group=threads_in_group,
+        wrap_template=wrap_template,
+    )
+
+
+def _combine_expr(reduction_type: str, acc: str, val: str) -> str:
+    if reduction_type == "sum":
+        return f"({acc}) + ({val})"
+    if reduction_type == "prod":
+        return f"({acc}) * ({val})"
+    if reduction_type == "max":
+        return f"({acc}) if ({acc}) > ({val}) else ({val})"
+    if reduction_type == "min":
+        return f"({acc}) if ({acc}) < ({val}) else ({val})"
+    raise NotImplementedError(f"lane reduce combine {reduction_type!r}")
+
+
+def _dtype_ctor_from_identity(identity_expr: str) -> str | None:
+    """Extract the dtype constructor (e.g. ``cutlass.Float32``) from an identity
+    expression like ``cutlass.Float32(0)`` so the per-lane input can be cast to
+    the accumulator's dtype before combining."""
+    try:
+        node = ast.parse(identity_expr, mode="eval").body
+    except SyntaxError:
+        return None
+    if isinstance(node, ast.Call):
+        return ast.unparse(node.func)
+    return None
+
+
+def _warp_reduce_expr(reduction_type: str, acc: str, threads_in_group: int) -> str:
+    tg = f", threads_in_group={threads_in_group}"
+    if reduction_type == "sum":
+        return f"cute.arch.warp_reduction_sum({acc}{tg})"
+    if reduction_type == "max":
+        return f"cute.arch.warp_reduction_max({acc}{tg})"
+    if reduction_type == "min":
+        return f"cute.arch.warp_reduction(({acc}), lambda a, b: a if a < b else b{tg})"
+    if reduction_type == "prod":
+        return f"cute.arch.warp_reduction(({acc}), lambda a, b: (a * b){tg})"
+    raise NotImplementedError(f"lane warp reduce {reduction_type!r}")
+
+
+def _backward_slice(body: list[ast.AST], roots: set[str]) -> tuple[list[int], set[str]]:
+    """Return the indices of the statements in ``body`` that (transitively)
+    produce any name in ``roots``, plus the set of all names those statements
+    write.  Statements are scanned in reverse so a producer is included once a
+    later consumer (already selected) reads its output.
+    """
+    from .ast_read_writes import ReadWrites
+
+    needed = set(roots)
+    selected: list[int] = []
+    written: set[str] = set()
+    for idx in range(len(body) - 1, -1, -1):
+        stmt = body[idx]
+        rw = ReadWrites.from_ast(stmt)
+        writes = set(rw.writes)
+        if writes & needed:
+            selected.append(idx)
+            written |= writes
+            needed |= set(rw.reads)
+    selected.reverse()
+    return selected, written
+
+
+def split_lane_loop_reductions(body: list[ast.AST]) -> list[ast.AST]:
+    """Rewrite single-pass lane loops that contain ``_helion_lane_reduce``
+    markers into the two-pass accumulate / finalize / consume structure.
+
+    Operates bottom-up so nested lane loops are handled before their parents.
+    Lane loops without markers are returned unchanged (their inner statements
+    are still recursed into so nested markers are processed).
+    """
+    new_body: list[ast.AST] = []
+    for stmt in body:
+        new_body.extend(_split_stmt_lane_reductions(stmt))
+    return new_body
+
+
+def _restore_stmt_lane_reduce_markers(stmt: ast.AST) -> ast.AST:
+    """Recurse into statement-list fields and replace any surviving
+    ``R = ..._helion_lane_reduce(IN, TYPE, ID, T)...`` assignment with
+    ``R = ...IN...`` (the raw per-lane input)."""
+    for field in ("body", "orelse", "finalbody"):
+        old = getattr(stmt, field, None)
+        if isinstance(old, list) and all(isinstance(s, ast.stmt) for s in old):
+            setattr(stmt, field, [_restore_stmt_lane_reduce_markers(s) for s in old])
+    if isinstance(stmt, ast.Assign):
+        m = _is_lane_reduce_marker_assign(stmt)
+        if m is not None:
+            return statement_from_string(
+                f"{m.result_var} = {m.finalize_expr(m.input_name)}"
+            )
+    return stmt
+
+
+def restore_unprocessed_lane_reduce_markers(
+    body: list[ast.AST],
+) -> list[ast.AST]:
+    """Replace any surviving ``R = ..._helion_lane_reduce(IN, TYPE, ID, T)...``
+    assignment with ``R = ...IN...`` (the raw per-lane input).
+
+    A safety net: ``split_lane_loop_reductions`` only rewrites markers it can
+    place in a two-pass lane structure. A marker emitted in a context neither
+    that pass nor ``interchange_lane_outside_serial_reductions`` handles would
+    otherwise leak the ``_helion_lane_reduce`` call into the emitted kernel.
+    Reverting to the per-lane input keeps the kernel compilable (it falls back
+    to the original single-pass per-lane reduction behavior).
+
+    Recurses only into statement-bearing fields (``body``/``orelse``/
+    ``finalbody``) instead of using ``ast.NodeTransformer``; markers are always
+    statement-level assignments, so this avoids the transformer's in-place
+    mutation of expression list fields, which fails when an AST node carries a
+    ``torch.fx`` ``immutable_list`` (e.g. multi-output ``inline_asm_elementwise``).
+    """
+    return [_restore_stmt_lane_reduce_markers(stmt) for stmt in body]
+
+
+def _split_stmt_lane_reductions(stmt: ast.AST) -> list[ast.AST]:
+    # Recurse into any statement-list-bearing fields first so nested lane
+    # loops are rewritten before the enclosing one.
+    for field in ("body", "orelse", "finalbody"):
+        old = getattr(stmt, field, None)
+        if isinstance(old, list) and all(isinstance(s, ast.stmt) for s in old):
+            setattr(stmt, field, split_lane_loop_reductions(old))
+    lane_var = getattr(stmt, HELION_LANE_LOOP_VAR_ATTR, None)
+    if (
+        lane_var is None
+        or not isinstance(stmt, ast.For)
+        or not isinstance(stmt.target, ast.Name)
+        or stmt.target.id != lane_var
+    ):
+        return [stmt]
+    return _split_one_lane_loop(stmt, lane_var)
+
+
+def _split_one_lane_loop(loop: ast.For, lane_var: str) -> list[ast.AST]:
+    from .ast_read_writes import ReadWrites
+
+    body: list[ast.AST] = list(loop.body)
+    markers: list[tuple[int, _LaneReduceMarker]] = []
+    for idx, stmt in enumerate(body):
+        parsed = _is_lane_reduce_marker_assign(stmt)
+        if parsed is not None:
+            markers.append((idx, parsed))
+    if not markers:
+        return [loop]
+
+    # Safety: the two-pass split is only valid when the reduction marker is the
+    # ONLY cross-lane carried value in this lane loop. If the body has another
+    # loop-carried accumulator across the lanes (e.g. a matmul ``dot_acc`` or a
+    # plain ``extra += per_lane`` sum that already accumulates over the lanes),
+    # splitting would drop or double-count it. Fall back to the original
+    # single-pass per-lane behavior by replacing each marker with its raw input.
+    marker_indices = {i for i, _ in markers}
+    if _has_extra_cross_lane_carry(body, lane_var, marker_indices):
+        return [_restore_per_lane_markers(loop, markers)]
+
+    input_roots = {m.input_name for _, m in markers}
+
+    # Phase 1: the backward slice that produces all reduction inputs.
+    phase1_indices, _phase1_written = _backward_slice(body, input_roots)
+
+    # Sequentially-dependent reductions (one marker's input depends on another
+    # marker's result, e.g. online softmax's sum-of-exp needing the max first)
+    # would require a multi-pass split. The single-pass phase-1/finalize/phase-2
+    # structure can't express that, so fall back to per-lane behavior.
+    if set(phase1_indices) & marker_indices:
+        return [_restore_per_lane_markers(loop, markers)]
+
+    # The phase-1 (accumulate) and phase-2 (consume) passes both re-run the
+    # reduction-input producers. That is only safe for side-effect-free
+    # producers. A matmul / collective in the slice (cross-thread shared-memory
+    # reductions, ``cute.gemm``, ``dot``) cannot be duplicated without racing on
+    # shared memory, so fall back to per-lane behavior in that case.
+    if any(_contains_unduplicatable_op(body[i]) for i in phase1_indices):
+        return [_restore_per_lane_markers(loop, markers)]
+
+    extent = _lane_loop_extent(loop)
+
+    prefix: list[ast.AST] = []  # acc init statements (outside the lane loops)
+    accumulate_body: list[ast.AST] = [body[i] for i in phase1_indices]
+    finalize: list[ast.AST] = []
+    for _, m in markers:
+        acc_var = f"{m.result_var}_lane_acc"
+        prefix.append(statement_from_string(f"{acc_var} = {m.identity_expr}"))
+        # Cast the per-lane input to the accumulator dtype before combining so
+        # the CUTLASS DSL's strict ternary type check (max/min emit a Python
+        # ``a if a > b else b``) does not see mixed fp32/bf16 operands.
+        ctor = _dtype_ctor_from_identity(m.identity_expr)
+        combine_val = f"{ctor}({m.input_name})" if ctor is not None else m.input_name
+        accumulate_body.append(
+            statement_from_string(
+                f"{acc_var} = {_combine_expr(m.reduction_type, acc_var, combine_val)}"
+            )
+        )
+        if m.threads_in_group > 1:
+            reduced = _warp_reduce_expr(m.reduction_type, acc_var, m.threads_in_group)
+        else:
+            reduced = acc_var
+        finalize.append(
+            statement_from_string(f"{m.result_var} = {m.finalize_expr(reduced)}")
+        )
+
+    # Phase 2: everything except the marker assignments themselves; the
+    # reduced scalar is already finalized so consumers read it directly.
+    phase2_body = [s for i, s in enumerate(body) if i not in marker_indices]
+
+    # A statement is lane-varying if it (transitively) reads the lane var.
+    # Statements that only depend on the finalized scalar(s) are lane-invariant
+    # and run once after the lane loops; lane-varying consumers run in a second
+    # lane loop, but only those that contribute to a side effect (a store, an
+    # if-with-store, an in-place write). Pure lane-varying producers that fed
+    # only the (now-removed) reduction markers are dropped.
+    lane_varying_names = _lane_varying_names(phase2_body, lane_var)
+
+    def is_lane_varying(stmt: ast.AST) -> bool:
+        reads = set(ReadWrites.from_ast(stmt).reads)
+        return lane_var in reads or bool(reads & lane_varying_names)
+
+    keep_indices = _live_phase2_indices(phase2_body)
+    lane_invariant_tail: list[ast.AST] = []
+    lane_varying_tail: list[ast.AST] = []
+    for i, s in enumerate(phase2_body):
+        if is_lane_varying(s):
+            if i in keep_indices:
+                lane_varying_tail.append(s)
+        else:
+            lane_invariant_tail.append(s)
+
+    result: list[ast.AST] = []
+    result.extend(prefix)
+    result.append(_create_lane_loop(lane_var, extent, accumulate_body))
+    result.extend(finalize)
+    result.extend(lane_invariant_tail)
+    if lane_varying_tail:
+        result.append(_create_lane_loop(lane_var, extent, lane_varying_tail))
+    return result
+
+
+def _has_extra_cross_lane_carry(
+    body: list[ast.AST], lane_var: str, marker_indices: set[int]
+) -> bool:
+    """Return True when ``body`` contains a loop-carried accumulator across the
+    lanes that is INDEPENDENT of the reduction markers.
+
+    Two-pass splitting is correct whenever every cross-lane carried value
+    transitively consumes a marker result (e.g. an online-softmax
+    ``mi = max(mi, local_amax)`` or ``di = di + sum``): after the split the
+    carried update runs once per outer iteration on the fully-reduced scalar.
+    But an *independent* carried accumulator — one that does not depend on any
+    marker result, such as a matmul ``dot_acc += dot_product`` — must keep
+    accumulating once per lane, so the split would drop or corrupt it. In that
+    case the caller falls back to the single-pass per-lane behavior.
+
+    A carried value is detected as a name that is *live-in* to the lane body
+    (read before it is written within the body, directly or through a
+    ``X_copy = X`` alias) and also written within the body.
+    """
+    from .ast_read_writes import ReadWrites
+
+    written_so_far: set[str] = set()
+    aliases: dict[str, str] = {}  # copy_var -> original carried name
+    live_in: set[str] = set()
+    for stmt in body:
+        rw = ReadWrites.from_ast(stmt)
+        for name in rw.reads:
+            if name != lane_var and name not in written_so_far:
+                live_in.add(name)
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and isinstance(stmt.value, ast.Name)
+        ):
+            aliases[stmt.targets[0].id] = stmt.value.id
+        written_so_far |= set(rw.writes)
+
+    def root(name: str) -> str:
+        seen: set[str] = set()
+        while name in aliases and name not in seen:
+            seen.add(name)
+            name = aliases[name]
+        return name
+
+    # Names that (transitively) depend on a marker result. Carried values that
+    # only depend on these are fine under the two-pass split.
+    marker_results = {
+        m.result_var
+        for i, stmt in enumerate(body)
+        if i in marker_indices
+        and (m := _is_lane_reduce_marker_assign(stmt)) is not None
+    }
+    marker_tainted = set(marker_results)
+    changed = True
+    while changed:
+        changed = False
+        for stmt in body:
+            rw = ReadWrites.from_ast(stmt)
+            if set(rw.reads) & marker_tainted:
+                for w in rw.writes:
+                    if w not in marker_tainted:
+                        marker_tainted.add(w)
+                        changed = True
+
+    # Names that (transitively) depend on the lane var. A carried accumulator
+    # whose per-iteration update is lane-varying (e.g. a matmul
+    # ``dot_acc += dot_product(lane)``) cannot move to the once-per-tile tail,
+    # so the two-pass split would break it. A lane-invariant update (e.g.
+    # welford's ``acc_cnt += block_size``) is fine in the tail.
+    lane_varying = _lane_varying_names(body, lane_var)
+
+    # Bail if some carried accumulator is independent of every marker AND its
+    # update consumes a lane-varying value.
+    for idx, stmt in enumerate(body):
+        if idx in marker_indices:
+            continue
+        rw = ReadWrites.from_ast(stmt)
+        reads = set(rw.reads)
+        update_is_lane_varying = lane_var in reads or bool(reads & lane_varying)
+        if not update_is_lane_varying:
+            continue
+        for w in rw.writes:
+            if root(w) in live_in and root(w) not in marker_tainted:
+                return True
+    return False
+
+
+def _restore_per_lane_markers(
+    loop: ast.For, markers: list[tuple[int, _LaneReduceMarker]]
+) -> ast.For:
+    """Replace each ``_helion_lane_reduce`` marker in ``loop`` with its raw
+    per-lane input, restoring the original single-pass behavior (used when the
+    two-pass split is unsafe)."""
+    body = list(loop.body)
+    for idx, m in markers:
+        body[idx] = statement_from_string(
+            f"{m.result_var} = {m.finalize_expr(m.input_name)}"
+        )
+    loop.body = body
+    return loop
+
+
+_UNDUPLICATABLE_CALLS = (
+    "_cute_grouped_reduce_shared_two_stage",
+    "_cute_grouped_reduce_shared_tree",
+    "_cute_grouped_reduce_warp",
+    "cute.gemm",
+    "warp_reduction",
+)
+
+
+def _contains_unduplicatable_op(stmt: ast.AST) -> bool:
+    """Return True when ``stmt`` (or any nested statement) contains a matmul /
+    collective whose shared-memory side effects make it unsafe to re-run in a
+    second lane pass."""
+    src = ast.unparse(stmt)
+    return any(call in src for call in _UNDUPLICATABLE_CALLS)
+
+
+def _has_side_effect(stmt: ast.AST) -> bool:
+    """Return True when ``stmt`` produces an observable side effect (a store,
+    an in-place / atomic write, or any non-plain-assignment statement such as
+    an ``if mask: tensor[...].store(...)``)."""
+    from .ast_read_writes import ReadWrites
+
+    if isinstance(stmt, ast.Assign):
+        return bool(ReadWrites.from_ast(stmt).inplace_writes)
+    # Conservatively treat structured / expression statements as
+    # side-effecting (store calls live inside ``if`` blocks / bare exprs).
+    return True
+
+
+def _live_phase2_indices(body: list[ast.AST]) -> set[int]:
+    """Indices of statements in ``body`` that contribute to a side effect
+    (directly, or by feeding a later side-effecting statement)."""
+    from .ast_read_writes import ReadWrites
+
+    needed_names: set[str] = set()
+    keep: set[int] = set()
+    for idx in range(len(body) - 1, -1, -1):
+        stmt = body[idx]
+        rw = ReadWrites.from_ast(stmt)
+        writes = set(rw.writes)
+        if _has_side_effect(stmt) or (writes & needed_names):
+            keep.add(idx)
+            needed_names |= set(rw.reads)
+    return keep
+
+
+def _lane_loop_extent(loop: ast.For) -> int:
+    call = loop.iter
+    assert isinstance(call, ast.Call)
+    assert len(call.args) == 1
+    return int(ast.literal_eval(call.args[0]))
+
+
+def _lane_varying_names(body: list[ast.AST], lane_var: str) -> set[str]:
+    """Names whose values (transitively) depend on the lane var within ``body``."""
+    from .ast_read_writes import ReadWrites
+
+    varying = {lane_var}
+    changed = True
+    while changed:
+        changed = False
+        for stmt in body:
+            rw = ReadWrites.from_ast(stmt)
+            if set(rw.reads) & varying:
+                for w in rw.writes:
+                    if w not in varying:
+                        varying.add(w)
+                        changed = True
+    varying.discard(lane_var)
+    return varying
+
+
+def _is_serial_for(stmt: ast.AST) -> bool:
+    """Return True when ``stmt`` is an ordinary serial ``for`` loop (a device
+    serial loop), NOT a per-thread lane loop."""
+    return (
+        isinstance(stmt, ast.For)
+        and getattr(stmt, HELION_LANE_LOOP_VAR_ATTR, None) is None
+    )
+
+
+def _clone_stmt(stmt: ast.AST) -> ast.AST:
+    """Return an independent copy of ``stmt`` via unparse + reparse.
+
+    ``interchange_lane_outside_serial_reductions`` emits two loop nests that
+    both re-run the shared (side-effect-free) producers. Splicing the same node
+    objects into two places in the tree breaks AST walking, so each reused
+    statement is rebuilt from its source text into a fresh ExtendedAST node.
+    """
+    return statement_from_string(ast.unparse(stmt))
+
+
+def _clone_expr(node: ast.AST) -> ast.AST:
+    return expr_from_string(ast.unparse(node))
+
+
+def _forward_live_names(body: list[ast.AST], roots: set[str]) -> set[str]:
+    """Names produced by the forward slice that (transitively) consumes any
+    name in ``roots`` within ``body``."""
+    from .ast_read_writes import ReadWrites
+
+    tainted = set(roots)
+    changed = True
+    while changed:
+        changed = False
+        for stmt in body:
+            rw = ReadWrites.from_ast(stmt)
+            if set(rw.reads) & tainted:
+                for w in rw.writes:
+                    if w not in tainted:
+                        tainted.add(w)
+                        changed = True
+    return tainted
+
+
+def interchange_lane_outside_serial_reductions(
+    body: list[ast.AST],
+) -> list[ast.AST]:
+    """Interchange a ``for LANE: ... for MB: ...`` nest whose inner serial loop
+    contains ``_helion_lane_reduce`` markers.
+
+    layer_norm_bwd / rms_norm_bwd compute, inside a serial ``mb`` loop, BOTH a
+    per-feature accumulator that must keep the lane loop OUTSIDE the ``mb`` loop
+    (``grad_w_acc += ...``) AND a feature reduction whose result is broadcast
+    back into a per-row store (``grad_x``), which needs every lane summed *per*
+    ``mb`` iteration (lane INSIDE ``mb``). A single lane loop cannot satisfy
+    both nestings, so emit two specialized loop nests:
+
+    * Nest B (grad_w): the original ``for LANE: ... for MB: ...`` loop with the
+      lane-reduce markers and the reduction-consuming side effects removed —
+      keeping only the per-feature accumulators and their stores.
+    * Nest A (grad_x): a ``for MB: ... for LANE: ...`` loop carrying only the
+      lane reduction and its broadcast consumer. Its inner lane loop still holds
+      the markers so the subsequent ``split_lane_loop_reductions`` pass produces
+      the per-``mb`` accumulate -> warp-combine -> consume structure.
+
+    Returns ``body`` unchanged when no such pattern is present.
+    """
+    new_body: list[ast.AST] = []
+    for stmt in body:
+        new_body.extend(_interchange_stmt(stmt))
+    return new_body
+
+
+def _interchange_stmt(stmt: ast.AST) -> list[ast.AST]:
+    for field in ("body", "orelse", "finalbody"):
+        old = getattr(stmt, field, None)
+        if isinstance(old, list) and all(isinstance(s, ast.stmt) for s in old):
+            setattr(stmt, field, interchange_lane_outside_serial_reductions(old))
+    lane_var = getattr(stmt, HELION_LANE_LOOP_VAR_ATTR, None)
+    if (
+        lane_var is None
+        or not isinstance(stmt, ast.For)
+        or not isinstance(stmt.target, ast.Name)
+        or stmt.target.id != lane_var
+    ):
+        return [stmt]
+    return _interchange_one_lane_loop(stmt, lane_var)
+
+
+def _interchange_one_lane_loop(loop: ast.For, lane_var: str) -> list[ast.AST]:
+    from .ast_read_writes import ReadWrites
+
+    body: list[ast.AST] = list(loop.body)
+    # Find the single inner serial ``for`` loop that carries lane-reduce markers.
+    mb_index: int | None = None
+    for idx, stmt in enumerate(body):
+        if _is_serial_for(stmt) and any(
+            _is_lane_reduce_marker_assign(s) is not None
+            for s in cast("ast.For", stmt).body
+        ):
+            if mb_index is not None:
+                # More than one candidate serial loop: not the simple pattern.
+                return [loop]
+            mb_index = idx
+    if mb_index is None:
+        return [loop]
+
+    mb_loop = cast("ast.For", body[mb_index])
+    lane_prefix = body[:mb_index]
+    lane_suffix = body[mb_index + 1 :]
+    mb_body: list[ast.AST] = list(mb_loop.body)
+
+    markers = [
+        (i, m)
+        for i, s in enumerate(mb_body)
+        if (m := _is_lane_reduce_marker_assign(s)) is not None
+    ]
+    if not markers:
+        return [loop]
+    marker_indices = {i for i, _ in markers}
+    marker_results = {m.result_var for _, m in markers}
+
+    # The mb body's only side effect that consumes a marker result is the
+    # broadcast-reduction store (e.g. ``grad_x[mb] = ...``). Everything else in
+    # the mb body / suffix (the per-feature accumulators and their stores) is
+    # independent of the reduction and is handled correctly by Nest B alone.
+    grad_x_seed = {m.input_name for _, m in markers} | marker_results
+    grad_x_live = _forward_live_names(mb_body, grad_x_seed)
+
+    def is_reduction_store(stmt: ast.AST) -> bool:
+        return _has_side_effect(stmt) and bool(
+            set(ReadWrites.from_ast(stmt).reads) & grad_x_live
+        )
+
+    if not any(is_reduction_store(s) for s in mb_body):
+        # The lane reduction inside the serial loop is not consumed by a
+        # broadcast store, so the interchange does not apply. Markers nested in
+        # a serial loop are not reachable by ``split_lane_loop_reductions`` (it
+        # only rewrites top-level lane loops), so restore them to their raw
+        # per-lane inputs to avoid leaving an unprocessed marker behind.
+        restored: list[ast.stmt] = [cast("ast.stmt", s) for s in mb_body]
+        for idx, m in markers:
+            restored[idx] = statement_from_string(
+                f"{m.result_var} = {m.finalize_expr(m.input_name)}"
+            )
+        mb_loop.body = restored
+        return [loop]
+
+    # A name is lane-varying if it (transitively) depends on the lane var across
+    # the whole lane-loop body; lane-invariant names (mb bounds, masks, ...) are
+    # recomputed once rather than per lane.
+    lane_varying = _lane_varying_names([*lane_prefix, *mb_body, *lane_suffix], lane_var)
+
+    def reads_lane(stmt: ast.AST) -> bool:
+        reads = set(ReadWrites.from_ast(stmt).reads)
+        return lane_var in reads or bool(reads & lane_varying)
+
+    # --- Nest A (grad_x): for MB: for LANE: <reduction + broadcast store> ------
+    # Backward slice from the reduction-broadcast stores and the marker inputs,
+    # across both the mb body and the lane prefix. The per-feature accumulators
+    # feed only the suffix stores (never the reduction store), so they are
+    # naturally excluded — no carry analysis is required.
+    mb_bound_names = set(ReadWrites.from_ast(mb_loop.iter).reads)
+    needed = {m.input_name for _, m in markers} | mb_bound_names
+    keep_mb_a: list[ast.AST] = []
+    for idx in range(len(mb_body) - 1, -1, -1):
+        stmt = mb_body[idx]
+        rw = ReadWrites.from_ast(stmt)
+        if idx in marker_indices:
+            keep_mb_a.append(stmt)
+            needed |= set(rw.reads) - marker_results
+            continue
+        if is_reduction_store(stmt) or (set(rw.writes) & needed):
+            keep_mb_a.append(stmt)
+            needed |= set(rw.reads)
+    keep_mb_a.reverse()
+    keep_prefix_a: list[ast.AST] = []
+    for stmt in reversed(lane_prefix):
+        rw = ReadWrites.from_ast(stmt)
+        if set(rw.writes) & needed:
+            keep_prefix_a.append(stmt)
+            needed |= set(rw.reads)
+    keep_prefix_a.reverse()
+
+    # Partition kept statements into lane-invariant (run once per mb iteration)
+    # vs lane-varying (recomputed per lane inside the inner lane loop).
+    prefix_invariant_a = [_clone_stmt(s) for s in keep_prefix_a if not reads_lane(s)]
+    prefix_varying_a = [_clone_stmt(s) for s in keep_prefix_a if reads_lane(s)]
+    mb_head_a = [_clone_stmt(s) for s in keep_mb_a if not reads_lane(s)]
+    mb_varying_a = [_clone_stmt(s) for s in keep_mb_a if reads_lane(s)]
+
+    extent = _lane_loop_extent(loop)
+    inner_lane_loop_a = _create_lane_loop(
+        lane_var, extent, [*prefix_varying_a, *mb_varying_a]
+    )
+    mb_loop_a = create(
+        ast.For,
+        target=_clone_expr(mb_loop.target),
+        iter=_clone_expr(mb_loop.iter),
+        body=[*mb_head_a, inner_lane_loop_a],
+        orelse=[],
+        type_comment=None,
+    )
+    nest_a: list[ast.AST] = [*prefix_invariant_a, mb_loop_a]
+
+    # --- Nest B (grad_w): the original lane loop with markers reverted to their
+    # raw per-lane inputs. Its per-feature accumulators (lane-outside-mb) are
+    # already correct; its reduction-broadcast store writes a partial (per-lane)
+    # value that Nest A re-stores with the full reduction afterwards.
+    restored_mb_body = list(mb_loop.body)
+    for idx, m in markers:
+        restored_mb_body[idx] = statement_from_string(
+            f"{m.result_var} = {m.finalize_expr(m.input_name)}"
+        )
+    mb_loop.body = restored_mb_body
+    nest_b = loop
+
+    return [nest_b, *nest_a]
+
+
 @dataclasses.dataclass
 class LoopDimInfo:
     begin_var_name: str | None = None
@@ -135,6 +871,10 @@ class DeviceLoopState(DeviceLoopOrGridState):
     inner_statements: list[ast.AST]
     outer_prefix: list[ast.AST] = dataclasses.field(default_factory=list)
     outer_suffix: list[ast.AST] = dataclasses.field(default_factory=list)
+    # Block ids that this device loop distributes across a per-thread lane
+    # loop (CuTe only). A reduction over one of these blocks needs the
+    # two-pass lane structure (see ``split_lane_loop_reductions``).
+    lane_loop_blocks: set[int] = dataclasses.field(default_factory=set)
 
 
 @dataclasses.dataclass
@@ -2433,6 +3173,7 @@ class CuteNDTileStrategy(NDTileStrategy):
             block_id_to_info=block_id_to_info,
             thread_axis_sizes=tracker.sizes,
             block_thread_axes=tracker.block_axes,
+            lane_loop_blocks=set(self._lane_var_by_block),
         )
 
     def supports_index_rank_expansion(self) -> bool:

--- a/helion/language/atomic_ops.py
+++ b/helion/language/atomic_ops.py
@@ -393,6 +393,24 @@ def _cute_unindexed_axis_leader_predicate(
     indexed_block_ids: set[int] = set()
     has_block_size_index = False
     for idx in index:
+        if isinstance(idx, torch.Tensor):
+            # A gather/scatter index tensor (e.g. ``output[idxs, tile_f]``)
+            # covers the tile dimension it was loaded along: the per-thread
+            # ``idxs`` value differs across that axis, so it is *indexed* and
+            # must not be collapsed to a single leader thread.
+            tensor_block_id = (
+                env.resolve_block_id(idx.shape[0]) if idx.ndim >= 1 else None
+            )
+            if tensor_block_id is not None and state.fx_node is not None:
+                has_block_size_index = True
+                indexed_block_ids.add(
+                    env.resolve_codegen_block_id(
+                        tensor_block_id,
+                        state.codegen,
+                        state.fx_node.graph,
+                    )
+                )
+            continue
         if not isinstance(idx, torch.SymInt):
             continue
         expr = _symint_expr(idx)

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -718,6 +718,21 @@ def _(state: CodegenState) -> object:
             f"{TCGEN05_DIRECT_ENTRY_PLAN_CONFIG_KEY}=True requires hl.dot "
             "to lower through the tcgen05 K-loop path",
         )
+    dot_lhs_node = (
+        state.fx_node.args[0]
+        if state.fx_node is not None and len(state.fx_node.args) > 0
+        else None
+    )
+    dot_rhs_node = (
+        state.fx_node.args[1]
+        if state.fx_node is not None and len(state.fx_node.args) > 1
+        else None
+    )
+    dot_acc_node = (
+        state.fx_node.args[2]
+        if state.fx_node is not None and len(state.fx_node.args) > 2
+        else None
+    )
     return _emit_cute_matmul(
         state.codegen,
         lhs_ast,
@@ -733,6 +748,9 @@ def _(state: CodegenState) -> object:
         acc_dtype=acc_dtype,
         lhs_dtype=lhs_proxy.dtype,
         rhs_dtype=rhs_proxy.dtype,
+        lhs_node=dot_lhs_node,
+        rhs_node=dot_rhs_node,
+        acc_node=None if is_acc_none else dot_acc_node,
     )
 
 

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -2249,8 +2249,66 @@ def _codegen_cute_store_tcgen05_tile(
                 "cute",
                 "tcgen05 pure role-lifecycle supports only identity pure-matmul stores",
             )
+    # When one matmul accumulator fans out to multiple output stores (e.g.
+    # aux = pre-activation and out = gelu(pre)), the per-matmul TMA-store
+    # atom/tensor kernel-arg names allocated in cute_mma are shared by every
+    # store site. Emitting them verbatim at each site produces duplicate kernel
+    # parameters (SyntaxError) and binds both device epilogues to the same TMA
+    # descriptor. The secondary store gets fresh per-store descriptor names so
+    # each store threads its own TMA descriptor; the first store keeps the
+    # original names. The secondary store also reuses the accumulator the first
+    # store already consumed: the accumulator TMEM stays live until the
+    # one-shot teardown frees it, so the secondary store reads it directly
+    # without re-running the accumulator pipeline's consumer wait/release/advance
+    # (those would hang waiting on a producer that has already drained) and
+    # without re-emitting the matmul drain / TMEM-free teardown.
+    is_secondary_store = (
+        tcgen05_value.use_tma_store_epilogue
+        and not tcgen05_value.pure_matmul_role_lifecycle
+        and df.cute_state.tcgen05_tma_store_names_already_emitted(tcgen05_value)
+    )
+    if is_secondary_store:
+        tcgen05_value = dataclasses.replace(
+            tcgen05_value,
+            tma_store_atom=df.new_var("tcgen05_tma_store_atom"),
+            tma_store_tensor=df.new_var("tcgen05_tma_store_tensor"),
+        )
     tcgen05_lifecycle = tcgen05_value.lifecycle_context
     tcgen05_pure_matmul_object = tcgen05_value.pure_matmul_object
+
+    # Snapshot the accumulator consumer-state stage index. The primary store
+    # captures it before advancing the consumer state; fan-out stores read the
+    # same live TMEM stage through the snapshot rather than the already-advanced
+    # live index. For single-store kernels the assignment is unused and DCE
+    # drops it, so the generated code is unchanged.
+    tcgen05_acc_stage_index_var, tcgen05_acc_stage_index_is_primary = (
+        df.cute_state.get_or_create_tcgen05_acc_stage_index_var(
+            tcgen05_lifecycle.acc_consumer_state,
+            df.new_var,
+        )
+    )
+    # The snapshot is captured at top level (before the store's control-flow
+    # block) by the primary store so fan-out stores can read it; CuTe DSL
+    # forbids defining a value inside one control-flow block and reading it in
+    # another. For single-store kernels the assignment is unused and DCE drops
+    # it, keeping generated code unchanged.
+    tcgen05_acc_stage_index_top_level_stmts = (
+        [
+            statement_from_string(
+                f"{tcgen05_acc_stage_index_var} = "
+                f"{tcgen05_lifecycle.acc_consumer_state}.index"
+            )
+        ]
+        if tcgen05_acc_stage_index_is_primary
+        else []
+    )
+    # The primary store keeps reading the live consumer index so single-store
+    # codegen is byte-identical; only fan-out stores route through the snapshot.
+    tcgen05_acc_stage_index_expr = (
+        f"{tcgen05_lifecycle.acc_consumer_state}.index"
+        if not is_secondary_store
+        else tcgen05_acc_stage_index_var
+    )
 
     # Backstop for callers that bypass Config.normalize() validation;
     # see _tcgen05_epi_warp_count docstring and cute_plan.md.
@@ -2829,24 +2887,31 @@ def _codegen_cute_store_tcgen05_tile(
                 source_for_local_tile = rec.aux_view2d
                 aux_tile_is_local = True
             else:
-                # Rank-1 trailing-axis (rowvec) broadcast aux: build a
-                # 2-D logical view of the rank-1 underlying tensor with
+                # M-axis (row) broadcast aux: build a 2-D logical view
+                # over the underlying tensor's ``.iterator`` with
                 # stride 0 on the leading (M) axis and stride 1 on the
                 # trailing (N) axis. Stride 0 on M causes every lane
                 # "owning" output ``(m, n)`` to read the same source
-                # element regardless of m, which is the rowvec
-                # broadcast semantic that matches PyTorch's
-                # ``acc + bias[tile_n]`` (rank-1 RHS aligns to the
-                # trailing axis). The view feeds the same
-                # ``partition_C → flat_divide → partition_D`` pipeline
-                # used by exact-shape aux. Mirrors Quack's
-                # ``RowVecLoad`` epilogue (``quack/quack/epi_ops.py``).
-                # Only the trailing axis (``broadcast_axis == 1``)
-                # form is accepted at classify time — see
-                # ``aux_tensor_load_kind`` /
-                # ``_AuxiliaryTensorStep.broadcast_axis`` for the
-                # rejection of the leading-axis form.
-                assert rec.broadcast_axis == 1
+                # element regardless of m, which is the broadcast
+                # semantic shared by two accepted forms:
+                #   * ``broadcast_axis == 1`` — a bare rank-1 tensor
+                #     ``bias[tile_n]`` with shape ``(N,)`` (rank-1 RHS
+                #     aligns to the trailing axis under PyTorch
+                #     broadcasting).
+                #   * ``broadcast_axis == 0`` — an explicit ``(1, N)``
+                #     tensor ``bias[tile_m, tile_n]`` (row 0 broadcasts
+                #     over M).
+                # Both have the same contiguous N-major memory layout
+                # (element ``(0, n)`` at offset ``n``), so the
+                # stride-(0, 1) view over ``.iterator`` is identical
+                # and feeds the same ``partition_C → flat_divide →
+                # partition_D`` pipeline used by exact-shape aux.
+                # Mirrors Quack's ``RowVecLoad`` epilogue
+                # (``quack/quack/epi_ops.py``). The classifier
+                # (``aux_tensor_load_kind``) admits only these two
+                # broadcast shapes; everything else drops to the
+                # loud-failure backstop.
+                assert rec.broadcast_axis in (0, 1)
                 assert rec.aux_view2d is not None
                 lines.append(
                     f"{rec.aux_view2d} = cute.make_tensor("
@@ -3490,11 +3555,17 @@ def _codegen_cute_store_tcgen05_tile(
         f"{ttr_gc} = {thr_copy_t2r}.partition_D({tcgc_epi})",
         (
             f"{ttr_tacc_stage} = {ttr_tacc_base}["
-            f"(None, None, None, None, None, {tcgen05_lifecycle.acc_consumer_state}.index)]"
+            f"(None, None, None, None, None, {tcgen05_acc_stage_index_expr})]"
         ),
-        (
-            f"if {tcgen05_lifecycle.epi_active}:\n"
-            f"    {tcgen05_lifecycle.acc_pipeline}.consumer_wait({tcgen05_lifecycle.acc_consumer_state})"
+        *(
+            []
+            if is_secondary_store
+            else [
+                (
+                    f"if {tcgen05_lifecycle.epi_active}:\n"
+                    f"    {tcgen05_lifecycle.acc_pipeline}.consumer_wait({tcgen05_lifecycle.acc_consumer_state})"
+                )
+            ]
         ),
         f"{ttr_tacc} = cute.group_modes({ttr_tacc_stage}, 3, cute.rank({ttr_tacc_stage}))",
         f"{ttr_gc_grouped} = cute.group_modes({ttr_gc}, 3, cute.rank({ttr_gc}))",
@@ -3553,21 +3624,38 @@ def _codegen_cute_store_tcgen05_tile(
             f"{simt_acc_vec_prelude}"
             f"        {acc_vec} = {simt_acc_vec_rhs}\n"
             f"        {ttr_rd}.store({acc_vec})\n"
-            f"        if _tcgen05_subtile == {subtile_count} - 1:\n"
-            # `cute.copy(t2r, ...)` issues async TMEM->reg loads. Releasing
-            # the acc consumer slot lets the MMA producer re-acquire the TMEM
-            # stage and issue UMMAs that overwrite TMEM, so we must fence the
-            # in-flight async TMEM loads first to avoid a race on the last
-            # subtile's `ttr_racc` / `ttr_rd` data. This matches Quack's
-            # sm100 gemm fence-before-release pattern.
-            f"            cute.arch.fence_view_async_tmem_load()\n"
-            f"            with cute.arch.elect_one():\n"
-            f"                {tcgen05_lifecycle.acc_pipeline}.consumer_release({tcgen05_lifecycle.acc_consumer_state})\n"
-            f"{simt_store_copy_source}"
+            # The secondary fan-out store reuses the still-live accumulator and
+            # must not release it; the primary store owns the release + advance.
+            + (
+                ""
+                if is_secondary_store
+                else (
+                    f"        if _tcgen05_subtile == {subtile_count} - 1:\n"
+                    # `cute.copy(t2r, ...)` issues async TMEM->reg loads.
+                    # Releasing the acc consumer slot lets the MMA producer
+                    # re-acquire the TMEM stage and issue UMMAs that overwrite
+                    # TMEM, so we must fence the in-flight async TMEM loads
+                    # first to avoid a race on the last subtile's `ttr_racc` /
+                    # `ttr_rd` data. This matches Quack's sm100 gemm
+                    # fence-before-release pattern.
+                    f"            cute.arch.fence_view_async_tmem_load()\n"
+                    f"            with cute.arch.elect_one():\n"
+                    f"                {tcgen05_lifecycle.acc_pipeline}.consumer_release({tcgen05_lifecycle.acc_consumer_state})\n"
+                )
+            )
+            + f"{simt_store_copy_source}"
             # Advance is a per-thread local state update, so it intentionally
             # stays outside elect_one; only the mbarrier release is elected.
-            f"if {tcgen05_lifecycle.epi_active}:\n"
-            + emit_pipeline_advance(tcgen05_lifecycle.acc_consumer_state, indent="    ")
+            + (
+                ""
+                if is_secondary_store
+                else (
+                    f"if {tcgen05_lifecycle.epi_active}:\n"
+                    + emit_pipeline_advance(
+                        tcgen05_lifecycle.acc_consumer_state, indent="    "
+                    )
+                )
+            )
         ),
     ]
     tma_store_pipeline_setup = [
@@ -3784,12 +3872,12 @@ def _codegen_cute_store_tcgen05_tile(
                 f"    {tcgen05_lifecycle.acc_pipeline}.consumer_wait({tcgen05_lifecycle.acc_consumer_state})"
             )
         ]
-        if diagnose_acc_wait_before_subtile_loop
+        if diagnose_acc_wait_before_subtile_loop and not is_secondary_store
         else []
     )
     tma_store_loop_acc_wait = (
         ""
-        if diagnose_acc_wait_before_subtile_loop
+        if diagnose_acc_wait_before_subtile_loop or is_secondary_store
         else (
             f"        if _tcgen05_subtile == 0:\n"
             f"            {tcgen05_lifecycle.acc_pipeline}.consumer_wait({tcgen05_lifecycle.acc_consumer_state})\n"
@@ -3852,6 +3940,20 @@ def _codegen_cute_store_tcgen05_tile(
             "        ",
             safe_direct_aux_with_full_tile=partial_tma_needs_full_tile_guard,
         )
+        # The secondary fan-out store reuses the still-live accumulator TMEM and
+        # must not release it: the primary store already owns the accumulator
+        # pipeline consumer release, and the one-shot teardown frees the TMEM
+        # after every store has read it.
+        acc_release = (
+            ""
+            if is_secondary_store
+            else (
+                f"        if _tcgen05_subtile == {subtile_count} - 1:\n"
+                f"            cute.arch.fence_view_async_tmem_load()\n"
+                f"            with cute.arch.elect_one():\n"
+                f"                {tcgen05_acc_pipeline}.consumer_release({tcgen05_acc_consumer_state})\n"
+            )
+        )
         return (
             f"{acc_wait}"
             f"        {ttr_tacc_mn} = {ttr_tacc}[(None, None, None, cutlass.Int32(_tcgen05_subtile))]\n"
@@ -3859,10 +3961,7 @@ def _codegen_cute_store_tcgen05_tile(
             f"{early_aux_prelude}"
             f"{late_prelude}"
             f"        {acc_vec} = {rhs}\n"
-            f"        if _tcgen05_subtile == {subtile_count} - 1:\n"
-            f"            cute.arch.fence_view_async_tmem_load()\n"
-            f"            with cute.arch.elect_one():\n"
-            f"                {tcgen05_acc_pipeline}.consumer_release({tcgen05_acc_consumer_state})\n"
+            f"{acc_release}"
             f"        {store_target}.store({acc_vec})\n"
         )
 
@@ -4351,7 +4450,7 @@ def _codegen_cute_store_tcgen05_tile(
         f"{bsg_gd} = cute.group_modes({bsg_gd}, 1, cute.rank({bsg_gd}))",
         (
             f"{ttr_tacc_stage} = {ttr_tacc_base}["
-            f"(None, None, None, None, None, {tcgen05_lifecycle.acc_consumer_state}.index)]"
+            f"(None, None, None, None, None, {tcgen05_acc_stage_index_expr})]"
         ),
         f"{ttr_tacc} = cute.group_modes({ttr_tacc_stage}, 3, cute.rank({ttr_tacc_stage}))",
         f"{subtile_count} = cutlass.const_expr(cute.size({ttr_tacc}.shape, mode=[3]))",
@@ -4415,11 +4514,17 @@ def _codegen_cute_store_tcgen05_tile(
             )
         )
     else:
+        # The secondary fan-out store does not own the accumulator consumer
+        # state, so it must not advance it (the primary store advances once).
         tma_store_acc_advance = (
-            f"if {tcgen05_lifecycle.epi_active}:\n"
-            + emit_pipeline_advance(
-                tcgen05_lifecycle.acc_consumer_state,
-                indent="    ",
+            ""
+            if is_secondary_store
+            else (
+                f"if {tcgen05_lifecycle.epi_active}:\n"
+                + emit_pipeline_advance(
+                    tcgen05_lifecycle.acc_consumer_state,
+                    indent="    ",
+                )
             )
         )
         tma_store_body_core = [
@@ -4520,6 +4625,7 @@ def _codegen_cute_store_tcgen05_tile(
                 tma_store_role_invariant_stmts
             )
             main_stmts = [
+                *tcgen05_acc_stage_index_top_level_stmts,
                 *tma_store_hoisted_stmts,
                 *tma_store_role_invariant_stmts,
                 sync_before_stmt,
@@ -4538,6 +4644,7 @@ def _codegen_cute_store_tcgen05_tile(
             )
             df.cute_state.register_tcgen05_epi_role_stmts([main_stmt])
             main_stmts = [
+                *tcgen05_acc_stage_index_top_level_stmts,
                 *tma_store_hoisted_stmts,
                 sync_before_stmt,
                 main_stmt,
@@ -4552,7 +4659,7 @@ def _codegen_cute_store_tcgen05_tile(
         main_stmt = statement_from_string(
             "if True:\n" + textwrap.indent("\n".join(store_body), "    ")
         )
-        main_stmts = [main_stmt]
+        main_stmts = [*tcgen05_acc_stage_index_top_level_stmts, main_stmt]
     # Pipeline drain + TMEM dealloc are one-shot cleanup. They must run
     # AFTER all tiles have been processed (in the persistent path) and
     # naturally land at the end of the kernel in the non-persistent path.
@@ -4565,7 +4672,11 @@ def _codegen_cute_store_tcgen05_tile(
         # serialize the next tile's epilogue against this tile's TMA stores.
         # The tail must run before TMEM dealloc setup below.
         tma_store_post_loop_tail = tma_store_pipeline_tail
-    if tcgen05_pure_matmul_object is not None:
+    if is_secondary_store:
+        # The matmul drain + TMEM-free teardown is one-shot and owned by the
+        # primary store; the secondary fan-out store emits only its store body.
+        post_loop_stmts = []
+    elif tcgen05_pure_matmul_object is not None:
         post_loop_stmts = tcgen05_pure_matmul_object.emit_store_post_loop_stmts(
             df.cute_state,
             candidate_names,
@@ -5577,6 +5688,45 @@ def _(state: CodegenState) -> ast.AST:
     raise exc.BackendUnsupported("metal", f"load tensor type: {type(tensor)}")
 
 
+def _cute_load_feeds_sort_or_scan(load_node: object) -> bool:
+    """Return True if ``load_node`` feeds a sort/topk/_associative_scan.
+
+    Direct users (sort/topk and the scalar ``_associative_scan`` path) are
+    matched immediately.  For a tuple ``_associative_scan`` the index stream is
+    typically a ``load`` that flows through a chain of dtype-cast / shape ops
+    (e.g. ``indices[tile].float().unsqueeze(1).expand_as(vals)``) before
+    reaching the scan.  To recover a scalar load for that stream we follow the
+    forward chain through those pass-through ops.
+    """
+    from torch.fx.node import Node
+
+    from .._compiler.cute.indexing import is_cute_shape_chain_target
+
+    if not isinstance(load_node, Node):
+        return False
+
+    passthrough_targets = (torch.ops.prims.convert_element_type.default,)
+    seen: set[Node] = set()
+    stack: list[Node] = [load_node]
+    while stack:
+        node = stack.pop()
+        for user in node.users:
+            if not isinstance(user, Node):
+                continue
+            target = user.target
+            if (
+                target in (torch.ops.aten.sort.default, torch.ops.aten.topk.default)
+                or getattr(target, "__name__", None) == "_associative_scan"
+            ):
+                return True
+            if (
+                is_cute_shape_chain_target(target) or target in passthrough_targets
+            ) and user not in seen:
+                seen.add(user)
+                stack.append(user)
+    return False
+
+
 @_decorators.codegen(load, "cute")
 def _(state: CodegenState) -> object:
     tensor = state.proxy_arg(0)
@@ -5768,11 +5918,7 @@ def _(state: CodegenState) -> object:
         if mask_expr is None:
             return expr_from_string(load_expr)
         return expr_from_string(f"({load_expr} if {mask_expr} else cutlass.Boolean(0))")
-    if state.fx_node is not None and any(
-        user.target in (torch.ops.aten.sort.default, torch.ops.aten.topk.default)
-        or getattr(user.target, "__name__", None) == "_associative_scan"
-        for user in state.fx_node.users
-    ):
+    if state.fx_node is not None and _cute_load_feeds_sort_or_scan(state.fx_node):
         from .._compiler.cute.indexing import CuteSortableLoad
 
         tensor_dim = 0

--- a/helion/language/scan_ops.py
+++ b/helion/language/scan_ops.py
@@ -350,7 +350,7 @@ def _(state: CodegenState) -> ast.AST | list[ast.AST]:
 
 
 @_decorators.codegen(_associative_scan, "cute")
-def _(state: CodegenState) -> ast.AST:
+def _(state: CodegenState) -> ast.AST | list[ast.AST]:
     from torch.fx.node import Node
 
     from .._compiler.ast_extension import expr_from_string
@@ -364,7 +364,7 @@ def _(state: CodegenState) -> ast.AST:
     reverse = bool(state.proxy_arg(3))
     is_tuple_input = bool(state.proxy_arg(4))
     if is_tuple_input:
-        raise exc.BackendUnsupported("cute", "tuple associative_scan")
+        return _cute_codegen_tuple_scan(state, combine_graph_id, dim, reverse)
 
     helper_graph_info = state.get_graph(combine_graph_id)
     assert isinstance(helper_graph_info, HelperFunctionGraphInfo)
@@ -463,6 +463,392 @@ def _(state: CodegenState) -> ast.AST:
         )
     )
     return expr_from_string(acc)
+
+
+def _cute_recover_scan_load(node: object) -> tuple[object, object] | None:
+    """Walk back from a scan tuple-element node to its ``CuteSortableLoad``.
+
+    The value stream is usually a direct ``load`` that already carries
+    ``cute_sortable_load`` in its meta.  The index stream typically flows
+    through dtype-cast / shape ops (``float().unsqueeze(1).expand_as(...)``);
+    those are pass-throughs for a per-lane scalar in CuTe, so we follow them
+    back to the underlying scalar load.
+
+    Returns ``(CuteSortableLoad, load_node)`` or ``None`` if no load is found.
+    """
+    from torch.fx.node import Node
+
+    from .._compiler.cute.indexing import CuteSortableLoad
+    from .._compiler.cute.indexing import is_cute_shape_chain_target
+
+    passthrough_targets = (torch.ops.prims.convert_element_type.default,)
+    current = node
+    seen: set[Node] = set()
+    while isinstance(current, Node) and current not in seen:
+        seen.add(current)
+        load = current.meta.get("cute_sortable_load")
+        if isinstance(load, CuteSortableLoad):
+            return load, current
+        target = current.target
+        if is_cute_shape_chain_target(target) or target in passthrough_targets:
+            if current.args and isinstance(current.args[0], Node):
+                current = current.args[0]
+                continue
+        break
+    return None
+
+
+def _cute_strip_mask_term(mask_expr: str, scan_mask_var: str | None) -> str | None:
+    """Drop the scan-dimension term from a combined ``and``-mask expression.
+
+    The recovered load's mask is built per-lane and combines one boolean per
+    indexed dimension (e.g. ``(mask_0) and (mask_1)``).  When re-loading at a
+    different scan position the scan-dim term is replaced by an explicit
+    ``scan_row < size`` check, so here we remove the original scan-dim mask
+    var and keep only the dimension-constant terms.  Returns the remaining
+    expression, or ``None`` if nothing is left.
+    """
+    if scan_mask_var is None:
+        return mask_expr
+    parts = [part.strip() for part in mask_expr.split(" and ")]
+    kept = [part for part in parts if part.strip("()") != scan_mask_var]
+    if not kept:
+        return None
+    return " and ".join(kept)
+
+
+def _cute_scan_sort_index_pos(load: object, scan_index_var: str) -> int:
+    """Index position in ``load.index_exprs`` matching the scan dimension.
+
+    ``scan_index_var`` is the per-lane index variable for the dimension being
+    scanned (e.g. ``indices_0``).  The position whose index expression equals
+    that variable is the one we sweep over during the serial scan.
+    """
+    from .._compiler.cute.indexing import CuteSortableLoad
+
+    assert isinstance(load, CuteSortableLoad)
+    for pos, expr in enumerate(load.index_exprs):
+        if expr == scan_index_var:
+            return pos
+    # Fall back to the load's own recorded sort position (e.g. a 1D load whose
+    # sole index is the scan dimension but was renamed by an upstream cast).
+    return load.sort_index_pos
+
+
+def _cute_inline_combine_graph(
+    state: CodegenState,
+    helper_graph_info: object,
+    left_vars: list[str],
+    right_vars: list[str],
+) -> tuple[list[str], list[str]]:
+    """Inline a tuple combine graph as CuTe scalar expressions.
+
+    ``left_vars``/``right_vars`` are the per-lane scalar variable names holding
+    the left (accumulator) and right (incoming) tuple elements.  Returns a
+    tuple ``(body_lines, out_exprs)`` where ``body_lines`` are 4-space-indented
+    assignment statements (to be spliced inside the scan ``for`` loop) and
+    ``out_exprs`` are the output expression strings, one per tuple element.
+    """
+    import operator as operator_mod
+
+    from .._compiler.compile_environment import CompileEnvironment
+    from .._compiler.device_ir import HelperFunctionGraphInfo
+
+    assert isinstance(helper_graph_info, HelperFunctionGraphInfo)
+    env = CompileEnvironment.current()
+    graph = helper_graph_info.graph
+
+    placeholders = [n for n in graph.nodes if n.op == "placeholder"]
+    num_inputs = len(placeholders)
+    assert num_inputs == len(left_vars) + len(right_vars), (
+        "combine graph arity does not match scan tuple width"
+    )
+    # Unpacked layout: (left_e0, left_e1, ..., right_e0, right_e1, ...)
+    arg_vars = [*left_vars, *right_vars]
+
+    binary_ops: dict[object, str] = {
+        operator_mod.add: "+",
+        torch.add: "+",
+        torch.ops.aten.add.Tensor: "+",
+        torch.ops.aten.add.Scalar: "+",
+        operator_mod.sub: "-",
+        torch.sub: "-",
+        torch.ops.aten.sub.Tensor: "-",
+        torch.ops.aten.sub.Scalar: "-",
+        operator_mod.mul: "*",
+        torch.mul: "*",
+        torch.ops.aten.mul.Tensor: "*",
+        torch.ops.aten.mul.Scalar: "*",
+        torch.ops.aten.eq.Tensor: "==",
+        torch.ops.aten.eq.Scalar: "==",
+        torch.ops.aten.ne.Tensor: "!=",
+        torch.ops.aten.ne.Scalar: "!=",
+        torch.ops.aten.lt.Tensor: "<",
+        torch.ops.aten.lt.Scalar: "<",
+        torch.ops.aten.gt.Tensor: ">",
+        torch.ops.aten.gt.Scalar: ">",
+        torch.ops.aten.le.Tensor: "<=",
+        torch.ops.aten.le.Scalar: "<=",
+        torch.ops.aten.ge.Tensor: ">=",
+        torch.ops.aten.ge.Scalar: ">=",
+    }
+    min_ops = (torch.minimum, torch.ops.aten.minimum.default)
+    max_ops = (torch.maximum, torch.ops.aten.maximum.default)
+    where_ops = (torch.where, torch.ops.aten.where.self)
+
+    env_map: dict[object, str] = dict(zip(placeholders, arg_vars, strict=True))
+
+    def operand(value: object) -> str:
+        if isinstance(value, torch.fx.Node):
+            assert value in env_map, f"unresolved combine node: {value}"
+            return env_map[value]
+        if isinstance(value, bool):
+            return "True" if value else "False"
+        if isinstance(value, (int, float)):
+            return repr(value)
+        raise exc.BackendUnsupported(
+            "cute", f"associative_scan combine operand {value!r}"
+        )
+
+    lines: list[str] = []
+
+    def emit(node: torch.fx.Node, expr: str) -> None:
+        var = state.device_function.new_var("scan_combine")
+        lines.append(f"    {var} = {expr}")
+        env_map[node] = var
+
+    for node in graph.nodes:
+        if node.op in ("placeholder", "output"):
+            continue
+        if node.op != "call_function":
+            raise exc.BackendUnsupported(
+                "cute", f"associative_scan combine op {node.op}"
+            )
+        target = node.target
+        if target in binary_ops:
+            lhs = operand(node.args[0])
+            rhs = operand(node.args[1])
+            emit(node, f"({lhs}) {binary_ops[target]} ({rhs})")
+        elif target in where_ops:
+            cond = operand(node.args[0])
+            tval = operand(node.args[1])
+            fval = operand(node.args[2])
+            emit(node, env.backend.where_expr(cond, tval, fval))
+        elif target in min_ops:
+            lhs = operand(node.args[0])
+            rhs = operand(node.args[1])
+            emit(node, f"({lhs}) if ({lhs}) < ({rhs}) else ({rhs})")
+        elif target in max_ops:
+            lhs = operand(node.args[0])
+            rhs = operand(node.args[1])
+            emit(node, f"({lhs}) if ({lhs}) > ({rhs}) else ({rhs})")
+        elif target is torch.ops.prims.convert_element_type.default:
+            # Per-lane scalars are already in their storage dtype; treat the
+            # cast as a pass-through (matches the load/store scalar pipeline).
+            env_map[node] = operand(node.args[0])
+        else:
+            raise exc.BackendUnsupported(
+                "cute", f"associative_scan combine function: {target}"
+            )
+
+    output_nodes = next(n for n in graph.nodes if n.op == "output")
+    outputs = output_nodes.args[0]
+    assert isinstance(outputs, (tuple, list))
+    out_exprs = [operand(o) for o in outputs]
+    return lines, out_exprs
+
+
+def _cute_codegen_tuple_scan(
+    state: CodegenState,
+    combine_graph_id: int,
+    dim: int,
+    reverse: bool,
+) -> list[ast.AST]:
+    """CuTe codegen for ``hl.associative_scan`` over a tuple of streams.
+
+    Implements a serial per-lane inclusive scan: for each output position
+    ``out_pos`` along the scan dimension, fold the user's combine graph over
+    elements ``0..out_pos`` (inclusive), carrying one accumulator per tuple
+    element.  This mirrors the scalar CuTe scan but supports an arbitrary
+    (non-monoid) combine and multiple parallel streams (e.g. value + index for
+    segmented reduction).  Correctness, not performance, is the goal: the loop
+    is O(n) per lane.
+    """
+    from torch.fx.node import Node
+
+    from .._compiler.ast_extension import expr_from_string
+    from .._compiler.ast_extension import statement_from_string
+    from .._compiler.compile_environment import CompileEnvironment
+    from .._compiler.cute.indexing import CuteSortableLoad
+    from .._compiler.device_ir import HelperFunctionGraphInfo
+
+    helper_graph_info = state.get_graph(combine_graph_id)
+    assert isinstance(helper_graph_info, HelperFunctionGraphInfo)
+
+    fx_node = state.fx_node
+    if fx_node is None:
+        raise exc.BackendUnsupported("cute", "associative_scan without FX node")
+    input_nodes = fx_node.args[1]
+    if not isinstance(input_nodes, (tuple, list)):
+        raise exc.BackendUnsupported("cute", "tuple associative_scan input")
+
+    # Fake-tensor metadata lives on the per-stream input nodes (the scan node
+    # itself produces a tuple and may carry no ``val``).
+    vals = [cast("torch.fx.Node", n).meta["val"] for n in input_nodes]
+    first_val = vals[0]
+    ndim = first_val.ndim
+    if dim < 0:
+        dim += ndim
+
+    env = CompileEnvironment.current()
+    from .._compiler.cute.cute_reshape import _get_dim_local_coord
+    from .._compiler.cute.cute_reshape import _resolve_dim_block_id
+    from .memory_ops import _cute_active_index_var
+    from .memory_ops import _cute_tensor_dim_size_expr
+
+    # The scan loops over the *block-local* positions of the scan dimension.
+    # ``first_val.shape[dim]`` is the per-tile block size (the fake tensor has
+    # block-sized dims), which gives both the loop bound and the block id.
+    extent = first_val.shape[dim]
+    n_hint = env.size_hint(extent) if isinstance(extent, torch.SymInt) else extent
+    if not isinstance(n_hint, int):
+        raise exc.BackendUnsupported("cute", "dynamic associative_scan extent")
+
+    scan_block_id = _resolve_dim_block_id(state.codegen, first_val, dim)
+    if scan_block_id is None:
+        raise exc.BackendUnsupported("cute", "associative_scan scan-dim block id")
+    # The current lane's block-local position along the scan dim.
+    out_pos_expr = _get_dim_local_coord(state.codegen, first_val, dim)
+    # The tile's global offset along the scan dim, so a local ``scan_i`` maps to
+    # the global row ``offset + scan_i``.
+    offset_expr = state.codegen.offset_var(scan_block_id)
+    scan_global_index_var = _cute_active_index_var(state, scan_block_id)
+
+    # Recover a scalar load per tuple element and the index position that
+    # corresponds to the scan dimension within that load.
+    loads: list[CuteSortableLoad] = []
+    load_nodes: list[object] = []
+    sort_positions: list[int] = []
+    for node in input_nodes:
+        recovered = _cute_recover_scan_load(node)
+        if recovered is None or not isinstance(recovered[0], CuteSortableLoad):
+            raise exc.BackendUnsupported("cute", "tuple associative_scan input load")
+        load, load_node = recovered
+        assert isinstance(load, CuteSortableLoad)
+        loads.append(load)
+        load_nodes.append(load_node)
+        if scan_global_index_var is not None:
+            sort_positions.append(
+                _cute_scan_sort_index_pos(load, scan_global_index_var)
+            )
+        else:
+            sort_positions.append(load.sort_index_pos)
+
+    index_dtype = env.backend.dtype_str(env.index_dtype)
+    out_pos = state.device_function.new_var("scan_out_pos")
+    scan_i = state.device_function.new_var("scan_i")
+    scan_row = state.device_function.new_var("scan_row")
+    include = state.device_function.new_var("scan_include")
+    initialized = state.device_function.new_var("scan_initialized")
+
+    acc_vars = [state.device_function.new_var("scan_acc") for _ in loads]
+    value_vars = [state.device_function.new_var("scan_value") for _ in loads]
+
+    state.codegen.add_statement(
+        statement_from_string(f"{out_pos} = {index_dtype}({out_pos_expr})")
+    )
+    for acc_var, val in zip(acc_vars, vals, strict=True):
+        dtype_str = env.backend.dtype_str(val.dtype)
+        state.codegen.add_statement(
+            statement_from_string(f"{acc_var} = {dtype_str}(0)")
+        )
+    state.codegen.add_statement(statement_from_string(f"{initialized} = False"))
+
+    # Global scan row for this iteration: ``offset + scan_i``.
+    row_line = f"    {scan_row} = cutlass.Int32({offset_expr}) + {scan_i}"
+
+    # Per-iteration value loads (re-load each stream at the scanned global row).
+    # Cast each loaded scalar to the *scanned* element dtype (``vals[i].dtype``):
+    # the recovered load may have a different storage dtype than the value
+    # entering the scan (e.g. the index stream is ``indices`` int64 but scanned
+    # as float32 after ``idxs.float()``).  Each load is guarded so an
+    # out-of-range scanned row (partial final tile) reads 0 instead of faulting.
+    value_lines: list[str] = []
+    for val_var, load, load_node, pos, val in zip(
+        value_vars, loads, load_nodes, sort_positions, vals, strict=True
+    ):
+        scan_dtype_str = env.backend.dtype_str(val.dtype)
+        load_dtype_str = env.backend.dtype_str(load.dtype)
+        index_exprs = list(load.index_exprs)
+        index_exprs[pos] = scan_row
+        load_expr = f"{load.tensor_name}[{', '.join(index_exprs)}]"
+        # Rebuild the mask for the scanned row: the scan-dim bound becomes
+        # ``scan_row < tensor_size``; any non-scan-dim masks (e.g. the feature
+        # column bound) are constant w.r.t. ``scan_i`` and reused as-is.
+        load_tensor = (
+            load_node.args[0].meta["val"]
+            if isinstance(load_node, Node)
+            and load_node.args
+            and isinstance(load_node.args[0], Node)
+            else None
+        )
+        scan_dim_mask: str | None = None
+        if isinstance(load_tensor, torch.Tensor):
+            size_expr = _cute_tensor_dim_size_expr(state, load_tensor, pos)
+            scan_dim_mask = f"({scan_row}) < cutlass.Int32({size_expr})"
+        mask_terms: list[str] = []
+        if scan_dim_mask is not None:
+            mask_terms.append(scan_dim_mask)
+        if load.mask_expr is not None and scan_global_index_var is not None:
+            scan_mask_var = state.codegen.mask_var(scan_block_id)
+            non_scan_mask = _cute_strip_mask_term(load.mask_expr, scan_mask_var)
+            if non_scan_mask is not None:
+                mask_terms.append(non_scan_mask)
+        if mask_terms:
+            mask_expr = " and ".join(f"({term})" for term in mask_terms)
+            load_expr = f"({load_expr} if {mask_expr} else {load_dtype_str}(0))"
+        value_lines.append(f"    {val_var} = {scan_dtype_str}({load_expr})")
+
+    include_expr = f"{scan_i} >= {out_pos}" if reverse else f"{scan_i} <= {out_pos}"
+
+    # Inline the user's combine graph (one statement per node, 4-space
+    # indented to sit inside the scan ``for`` loop).
+    combine_lines, combine_exprs = _cute_inline_combine_graph(
+        state, helper_graph_info, acc_vars, value_vars
+    )
+    # Fold: when this position is included and we already have a running prefix,
+    # combine; on the first included element seed the accumulator with the
+    # value.  Stage combined results so reads of the old accumulator inside the
+    # combine graph see the prefix from before this step.
+    next_vars = [state.device_function.new_var("scan_next") for _ in acc_vars]
+    fold_lines: list[str] = []
+    for next_var, acc_var, val_var, combine_expr in zip(
+        next_vars, acc_vars, value_vars, combine_exprs, strict=True
+    ):
+        fold_lines.append(
+            f"    {next_var} = ({combine_expr}) if ({include} and {initialized}) "
+            f"else ({val_var} if {include} else {acc_var})"
+        )
+    for next_var, acc_var in zip(next_vars, acc_vars, strict=True):
+        fold_lines.append(f"    {acc_var} = {next_var}")
+    fold_lines.append(f"    {initialized} = True if {include} else {initialized}")
+
+    state.codegen.add_statement(
+        statement_from_string(
+            "\n".join(
+                [
+                    f"for {scan_i} in range(cutlass.Int32(0), cutlass.Int32({n_hint}), cutlass.Int32(1)):",
+                    f"    {include} = {include_expr}",
+                    row_line,
+                    *value_lines,
+                    *combine_lines,
+                    *fold_lines,
+                ]
+            )
+        )
+    )
+
+    return [expr_from_string(acc_var) for acc_var in acc_vars]
 
 
 def _get_input_tensor_ast(state: CodegenState, is_tuple_input: bool) -> ast.AST:

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -1435,6 +1435,7 @@ def _torch_dtype_to_cutlass(dtype: torch.dtype) -> object:
             torch.int32: cutlass.Int32,
             torch.int64: cutlass.Int64,
             torch.uint8: cutlass.Uint8,
+            torch.uint32: cutlass.Uint32,
             torch.uint64: cutlass.Int64,
         }
         _TORCH_DTYPE_TO_CUTLASS = mapping

--- a/test/test_barrier.py
+++ b/test/test_barrier.py
@@ -288,12 +288,13 @@ class TestBarrier(RefEagerTestBase, TestCase):
 
 @onlyBackends(["cute"])
 class TestCuteBarrier(RefEagerTestBase, TestCase):
-    def test_barrier_requires_real_backend_support(self) -> None:
+    def test_dep_across_barrier(self) -> None:
         x = torch.arange(8, device=DEVICE, dtype=torch.float32)
-        with self.assertRaisesRegex(exc.BackendUnsupported, "hl.barrier"):
-            code_and_output(
-                barrier_dep_single,
-                (x,),
-                block_sizes=[8, 8],
-                pid_type="persistent_blocked",
-            )
+        code, out = code_and_output(
+            barrier_dep_single,
+            (x,),
+            block_sizes=[8, 8],
+            pid_type="persistent_blocked",
+        )
+        expected = x * 2 + 1
+        torch.testing.assert_close(out, expected)

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -5,7 +5,6 @@ import unittest
 from unittest.mock import patch
 
 from packaging import version
-import pytest
 import torch
 import torch.nn.functional as F
 from torch.testing._internal.common_utils import instantiate_parametrized_tests
@@ -21,7 +20,6 @@ from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import _get_backend
 from helion._testing import check_example
-from helion._testing import get_nvidia_gpu_model
 from helion._testing import import_path
 from helion._testing import onlyBackends
 from helion._testing import skipIfA10G
@@ -187,7 +185,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[64, 64, 32],
         )
 
-    @xfailIfCute("CuTe barrier-based split-K example is still unsupported")
     @xfailIfPallas("missing barrier implementation")
     @skipIfTileIR("PassManager::run failed")
     @skipIfXPU("Split-K barrier not supported on XPU backend")
@@ -207,7 +204,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             split_k=64,
         )
 
-    @xfailIfCute("CuTe barrier-based split-K example is still unsupported")
     @xfailIfPallas("missing barrier implementation")
     @skipIfTileIR("PassManager::run failed")
     @skipIfRefEager("Test requires compiled kernel with specific config")
@@ -431,9 +427,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[1, 128, 128, 256],
         )
 
-    @skipIfFn(
-        lambda: _get_backend() == "cute", "CuTe FP8 GEMM example is not supported yet"
-    )
     @skipIfNotCUDA()
     @skipIfCudaCapabilityLessThan((9, 0), reason="FP8 requires CUDA capability >= 9.0")
     def test_fp8_gemm(self):
@@ -462,7 +455,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             num_stages=3,
         )
 
-    @xfailIfCute("CuTe template closure example still exceeds runtime resources")
     def test_template_via_closure0(self):
         bias = torch.randn([1, 512], device=DEVICE, dtype=HALF_DTYPE)
         args = (
@@ -484,7 +476,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             l2_grouping=64,
         )
 
-    @xfailIfCute("CuTe template closure example still exceeds runtime resources")
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
     @skipIfXPU("Failed on XPU - https://github.com/pytorch/helion/issues/795")
     @skipIfTileIR("TileIR does not support block_ptr indexing")
@@ -614,7 +605,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             expected,
         )
 
-    @xfailIfCute("CuTe Welford example still returns incorrect results")
     def test_welford(self):
         s, d = 128, 1024
         weight = torch.rand((d,), device=DEVICE, dtype=torch.float32)
@@ -633,10 +623,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             ),
         )
 
-    @skipIfFn(
-        lambda: _get_backend() == "cute",
-        "CuTe low-memory dropout example is flaky and currently skipped",
-    )
     def test_low_mem_dropout(self):
         from examples.low_mem_dropout import low_mem_dropout
         from examples.low_mem_dropout import low_mem_dropout_bwd
@@ -757,7 +743,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             fn_name="swiglu_bwd",
         )
 
-    @xfailIfCute("CuTe RMSNorm backward example still returns incorrect results")
     @parametrize("dtype", (torch.float32, HALF_DTYPE))
     def test_rms_norm_bwd(self, dtype):
         """Test backward pass for rms norm weight gradient."""
@@ -852,10 +837,6 @@ class TestExamples(RefEagerTestBase, TestCase):
         )
 
     @skipIfTileIR("PassManager::run failed")
-    @xfailIfCute(
-        "CuTe tcgen05 MMA path does not yet emit indices/masks for the "
-        "user-level epilogue write that follows the MMA"
-    )
     def test_epilogue_subtiling_gelu_aux(self):
         m, k, n = 8192, 8192, 8192
         x = torch.randn([m, k], device=DEVICE, dtype=HALF_DTYPE)
@@ -876,10 +857,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=block_sizes,
         )
 
-    @skipIfFn(
-        lambda: _get_backend() == "cute",
-        "CuTe attention pointer destabilizes later cute tests when it fails in-process",
-    )
     def test_attention_pointer(self):
         args = (
             torch.randn(1, 32, 512, 64, dtype=torch.float32, device=DEVICE),
@@ -894,9 +871,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             indexing="pointer",
         )
 
-    @xfailIfCute(
-        "CuTe attention block-pointer example still exceeds thread-block limits"
-    )
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
     @skipIfXPU("failure on XPU")
     @skipIfTileIR("TileIR does not support block_ptr indexing")
@@ -915,10 +889,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             indexing="block_ptr",
         )
 
-    @skipIfFn(
-        lambda: _get_backend() == "cute",
-        "CuTe dynamic attention destabilizes later cute tests when it fails in-process",
-    )
     def test_attention_dynamic(self):
         args = (
             torch.randn(1, 32, 512, 64, dtype=torch.float32, device=DEVICE),
@@ -933,9 +903,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[1, 64, 32],
         )
 
-    @xfailIfCute(
-        "CuTe attention-style online-softmax kernel still returns incorrect results"
-    )
     def test_xsa(self):
         args = (
             torch.randn(2, 32, 1024, 64, dtype=HALF_DTYPE, device=DEVICE),
@@ -951,9 +918,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[1, 64, 32],
         )
 
-    @xfailIfCute(
-        "CuTe attention-style online-softmax kernel still returns incorrect results"
-    )
     def test_xsa_near_zero_v(self):
         q = torch.randn(2, 4, 128, 64, dtype=HALF_DTYPE, device=DEVICE)
         k = torch.randn_like(q)
@@ -1141,7 +1105,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[16, 8, 16],
         )
 
-    @xfailIfCute("CuTe segment reduction example is not supported yet")
     @xfailIfPallas("requires triton module")
     @skipIfRefEager(
         "torch._higher_order_ops.associative_scan with tuple arg is not supported by ref eager mode yet"
@@ -1169,7 +1132,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             fn_name="segmented_reduction_helion",
         )
 
-    @xfailIfCute("CuTe persistent attention example still exceeds thread-block limits")
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
     @skipIfXPU("failure on XPU")
     @skipIfTileIR("TileIR does not support block_ptr indexing")
@@ -1344,7 +1306,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             atol=atol,
         )
 
-    @xfailIfCute("CuTe LayerNorm backward example still returns incorrect results")
     @skipIfA10G("accuracy check fails on A10G GPUs")
     def test_layernorm_bwd(self):
         """Test combined backward pass for layer norm with bias."""
@@ -1708,8 +1669,6 @@ class TestExamples(RefEagerTestBase, TestCase):
         "JAX interpret cannot trace dynamic shapes (TypeError: JitTracer ~int32[])"
     )
     def test_kl_div(self):
-        if _get_backend() == "cute" and "B200" in get_nvidia_gpu_model():
-            pytest.xfail("CuTe KL-div example still launches out of resources on B200")
         args = (
             torch.randn([1024, 4096], device=DEVICE, dtype=torch.float32).log_softmax(
                 dim=-1
@@ -1763,7 +1722,6 @@ class TestExamples(RefEagerTestBase, TestCase):
     def test_gather_gemv_half(self):
         self._check_gather_gemv(HALF_DTYPE)
 
-    @xfailIfCute("CuTe int4 GEMM example is not supported yet")
     @xfailIfPallas("int4 unpacking not supported on pallas")
     def test_int4_gemm(self):
         # Matrix dimensions
@@ -2063,9 +2021,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             num_stages=3,
         )
 
-    @xfailIfCute(
-        "CuTe squeeze-and-excitation forward still exceeds thread-block limits"
-    )
     @skipIfCudaSharedMemoryLessThan(
         131072, reason="block sizes exceed device shared memory limit"
     )
@@ -2094,7 +2049,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             atol=0.15,
         )
 
-    @xfailIfCute("CuTe squeeze-and-excitation backward still fails lowering/runtime")
     @xfailIfPallas("conflicting tiling patterns")
     @skipIfA10G("failure on a10g")
     @skipIfXPU("Squeeze-and-excitation network not supported on XPU")
@@ -2139,7 +2093,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             atol=0.3,
         )
 
-    @xfailIfCute("CuTe squeeze-and-excitation backward still fails lowering/runtime")
     @xfailIfPallas("tensor accessed with conflicting tiling patterns")
     @skipIfA10G("failure on a10g")
     @skipIfTileIR("accuracy failure")
@@ -2184,7 +2137,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             atol=0.3,
         )
 
-    @xfailIfCute("CuTe squeeze-and-excitation backward still fails lowering/runtime")
     @skipIfA10G("failure on a10g")
     @skipIfTileIR("accuracy failure")
     @skipIfXPU("ocloc compilation failure with 256-GRF kernel on XPU backend")
@@ -2407,7 +2359,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[128, 128, 128],
         )
 
-    @xfailIfCute("CuTe batched softmax example still fails CUTLASS DSL codegen")
     def test_batch_softmax(self):
         args = (torch.randn([16, 512, 1024], device=DEVICE, dtype=torch.bfloat16),)
         check_example(
@@ -2417,9 +2368,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[8],
         )
 
-    @xfailIfCute(
-        "CuTe batched softmax block-pointer example still fails CUTLASS DSL codegen"
-    )
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
     @skipIfTileIR("TileIR does not support block_ptr indexing")
     def test_batch_softmax_block_ptr(self):
@@ -2510,15 +2458,7 @@ class TestExamples(RefEagerTestBase, TestCase):
         )
 
     @skipIfPallas("flex_attention requires torch.compile and closures")
-    @skipIfFn(
-        lambda: _get_backend() == "cute",
-        "CuTe flex attention destabilizes later cute tests when it fails in-process",
-    )
     @skipIfRefEager("scalar_prefetch indexing not supported in ref interpreter")
-    @skipIfFn(
-        lambda: _get_backend() == "cute",
-        "CuTe flex attention example still returns incorrect results",
-    )
     def test_flex_attention(self):
         z, h, n_ctx, head_dim = 2, 4, 256, 64
         q, k, v = [
@@ -2534,10 +2474,6 @@ class TestExamples(RefEagerTestBase, TestCase):
         expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
         torch.testing.assert_close(out, expected, atol=1e-1, rtol=1e-1)
 
-    @skipIfFn(
-        lambda: _get_backend() == "cute",
-        "CuTe Mamba2 chunk-state destabilizes later cute tests when it fails in-process",
-    )
     @xfailIfPallasTpu(
         "dA_cumsum has mixed scalar+slice access (VMEM), but Mosaic requires 32-bit for VMEM scalar extracts"
     )
@@ -2574,7 +2510,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             rtol=0.1,
         )
 
-    @xfailIfCute("CuTe Mamba2 chunk-scan example still returns incorrect results")
     @xfailIfPallas("BlockSpec tiling failure")
     def test_mamba2_chunk_scan(self):
         batch, nheads, ngroups, seqlen, chunk_size, headdim, dstate = (

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -19,7 +19,6 @@ from helion._testing import skipIfRefEager
 from helion._testing import skipIfRocm
 from helion._testing import skipIfTileIR
 from helion._testing import skipUnlessTensorDescriptor
-from helion._testing import xfailIfCute
 from helion._testing import xfailIfPallasTpu
 import helion.language as hl
 
@@ -779,7 +778,6 @@ class TestReductions(RefEagerTestBase, TestCase):
 
     @skipIfPallas("barrier and persistent_blocked not supported on Pallas")
     @skipIfTileIR("TileIR does not support barrier operations")
-    @xfailIfCute("cute: hl.barrier() phase synchronization is not supported")
     def test_reduction_loop_with_multiple_rdims(self):
         """Test that reduction_loops works when there are multiple reduction dimensions."""
 


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * __->__#2647


--- --- ---

[cute] Un-xfail/un-skip 29 CuTe example tests across reductions, attention, matmul

Implements the missing CuTe-backend features and correctness fixes behind the
skipped/xfailed example tests. Highlights:

- Attention matmul fallback: fix online-softmax dot_acc double-count, decode
  computed-vs-raw fp8 operands correctly, route >32-thread K reductions through
  shared memory, and reserve hardware threads for the matmul-contraction axis so
  head_dim is no longer split onto a synthetic lane. Unblocks attention_pointer,
  attention_dynamic, attention_block_pointer, attention_persistent, xsa,
  xsa_near_zero_v, flex_attention, fp8_attention, mamba2_chunk_scan.
- Reductions: two-pass synthetic-lane reduction + serial-loop interchange
  post-passes for reduce-then-broadcast, plus rename-group-aware recip hoisting.
  Unblocks welford, layernorm_bwd, rms_norm_bwd.
- grid_barrier: thread-aware CuTe grid-wide barrier (split_k_barrier; also frees
  test_reduction_loop_with_multiple_rdims).
- Misc: reduction-combine dtype cast (batch_softmax), fp8 GEMM decode (fp8_gemm),
  leading-axis aux broadcast + per-store tcgen05 TMA names (template_via_closure,
  epilogue_subtiling_gelu_aux), transpose-fold materialization (mamba2_chunk_state),
  lane-loop suppression guard (squeeze_and_excitation fwd/bwd), tuple
  associative_scan (segment_reduction), packed-affine int4 path (int4_gemm), and
  removal of stale markers (low_mem_dropout, kl_div).

Verified: cute suite 956 passed / 0 failed; triton regression clean; ruff +
pyrefly + codespell clean.

Still xfailed (documented, harder follow-ups): matmul_layernorm static/dynamic,
gdn_fwd_h, grouped_gemm_jagged_persistent, bf16xint16 (genuine bf16 precision).