### PR TITLE
[autotuner] Add Triton row-reduction and rope split/join heuristics

### DIFF
--- a/examples/rope.py
+++ b/examples/rope.py
@@ -21,7 +21,7 @@ import helion.language as hl
 
 
 # %%
-@helion.kernel(autotune_seed_configs=helion.Config(block_sizes=[1, 1]))
+@helion.kernel
 def rope_fwd(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -94,7 +94,7 @@ def rope_fwd(
     return q_out, k_out
 
 
-@helion.kernel(autotune_seed_configs=helion.Config(block_sizes=[1, 1]))
+@helion.kernel
 def rope_bwd(
     grad_q_out: torch.Tensor,
     grad_k_out: torch.Tensor,

--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -11,7 +11,9 @@ from .cute import CuteTileVecHeuristic
 from .cute import CuteTileVecWarpPerRowHeuristic
 from .cute import CuteTileVecWarpReduceHeuristic
 from .triton import TritonB200MatmulHeuristic
+from .triton import TritonReductionTileHeuristic
 from .triton import TritonSkinnyGemmHeuristic
+from .triton import TritonSplitJoinRotateHeuristic
 
 if TYPE_CHECKING:
     from ...runtime.config import Config
@@ -29,7 +31,12 @@ HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
         CuteTileVecWarpReduceHeuristic,
         CuteTileVecWarpPerRowHeuristic,
     ),
-    "triton": (TritonSkinnyGemmHeuristic, TritonB200MatmulHeuristic),
+    "triton": (
+        TritonSkinnyGemmHeuristic,
+        TritonB200MatmulHeuristic,
+        TritonSplitJoinRotateHeuristic,
+        TritonReductionTileHeuristic,
+    ),
 }
 
 log: logging.Logger = logging.getLogger(__name__)

--- a/helion/_compiler/autotuner_heuristics/common.py
+++ b/helion/_compiler/autotuner_heuristics/common.py
@@ -12,6 +12,49 @@ if TYPE_CHECKING:
 
 HardwareTarget = tuple[str, str | None]
 
+# Reduction op name tokens used to detect a reduction in a traced graph. Shared
+# by the Triton split/join heuristic and the LLM workload-trait detection.
+REDUCTION_TARGET_NAMES = frozenset({"amax", "sum", "softmax", "logsumexp"})
+
+
+def op_name_parts(target: object) -> frozenset[str]:
+    """Coarse name fragments for a traced FX call target.
+
+    Collects the target's ``__name__``/``name``/``str()`` and their dot-split
+    pieces, so callers can match a node against a set of op names.
+    """
+    parts: set[str] = set()
+    for raw in (
+        getattr(target, "__name__", None),
+        getattr(target, "name", None),
+        str(target),
+    ):
+        if not isinstance(raw, str):
+            continue
+        parts.add(raw)
+        parts.update(piece for piece in raw.split(".") if piece)
+    return frozenset(parts)
+
+
+def is_canonical_row_reduction(env: CompileEnvironment) -> bool:
+    """Whether the kernel is a canonical single-tile row reduction.
+
+    A single non-reduction tile + a single reduction loop, with no matmul facts,
+    and an M-axis that admits one row per program. Shared by the CuTe and Triton
+    reduction heuristics so the structural gate cannot drift between backends.
+    """
+    spec = env.config_spec
+    # Single non-reduction tile + single reduction dim.
+    if len(spec.block_sizes) != 1 or len(spec.reduction_loops) != 1:
+        return False
+    # No matmul facts (this seeds reduction kernels, not GEMMs, and not a fused
+    # matmul+reduction, which keeps its own tiling).
+    if spec.matmul_facts:
+        return False
+    bs_spec = spec.block_sizes[0]
+    # M-axis must accept block_size=1 (one row per program).
+    return max(bs_spec.min_size, bs_spec.autotuner_min) <= 1
+
 
 def dedupe_configs(configs: Iterable[Config]) -> list[Config]:
     result: list[Config] = []

--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -15,27 +15,14 @@ from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_SEED_L2_GROUPING
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_SEED_PID_TYPE
 from ..cute.tcgen05_constants import tcgen05_two_cta_edge_k_tail_seed_overrides
+from .common import is_canonical_row_reduction
 from .registry import AutotunerHeuristic
 
 if TYPE_CHECKING:
     from ...autotuner.config_fragment import BlockSizeFragment
-    from ...autotuner.config_spec import BlockSizeSpec
     from ...autotuner.config_spec import ReductionLoopSpec
     from ..compile_environment import CompileEnvironment
     from ..device_ir import DeviceIR
-
-
-def _reduction_kernel_eligible(env: CompileEnvironment, device_ir: DeviceIR) -> bool:
-    spec = env.config_spec
-    # Single non-reduction tile + single reduction dim.
-    if len(spec.block_sizes) != 1 or len(spec.reduction_loops) != 1:
-        return False
-    # No matmul facts (this seeds reduction kernels, not GEMMs).
-    if spec.matmul_facts:
-        return False
-    bs_spec = cast("BlockSizeSpec", spec.block_sizes[0])
-    # M-axis must accept block_size=1.
-    return max(bs_spec.min_size, bs_spec.autotuner_min) <= 1
 
 
 def _cute_seed_vec_width(
@@ -103,7 +90,7 @@ class CuteReductionTileHeuristic(AutotunerHeuristic):
 
     @classmethod
     def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
-        return _reduction_kernel_eligible(env, device_ir)
+        return is_canonical_row_reduction(env)
 
     @classmethod
     def get_seed_config(
@@ -464,7 +451,7 @@ class CuteReductionWideChunkHeuristic(AutotunerHeuristic):
 
     @classmethod
     def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
-        if not _reduction_kernel_eligible(env, device_ir):
+        if not is_canonical_row_reduction(env):
             return False
         spec = env.config_spec
         rl_spec = cast("ReductionLoopSpec", spec.reduction_loops[0])

--- a/helion/_compiler/autotuner_heuristics/triton.py
+++ b/helion/_compiler/autotuner_heuristics/triton.py
@@ -7,9 +7,13 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
 
+from ...autotuner.config_fragment import EnumFragment
 from ...runtime.config import Config
+from .common import REDUCTION_TARGET_NAMES
 from .common import clamp_block_size_targets
+from .common import is_canonical_row_reduction
 from .common import matches_hardware
+from .common import op_name_parts
 from .registry import AutotunerHeuristic
 
 if TYPE_CHECKING:
@@ -245,3 +249,86 @@ class TritonB200MatmulHeuristic(AutotunerHeuristic):
         device_ir: DeviceIR,
     ) -> Config | None:
         return _seed_config_for_config_spec(env.config_spec)
+
+
+class TritonSplitJoinRotateHeuristic(AutotunerHeuristic):
+    """Seed all-ones ``block_sizes`` for split/join rotate kernels (rope).
+
+    These kernels load a large untiled inner slab per program, so tiling any
+    outer dim past 1 only wastes work and overflows Triton's block-numel cap.
+    Detected by ``hl.split`` + ``hl.join`` with no matmul and no reduction op.
+    """
+
+    name = "triton_split_join_rotate"
+    backend = "triton"
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        # A GEMM (even fused) is not a rope-style rotate.
+        if env.config_spec.matmul_facts:
+            return False
+        if not env.config_spec.block_sizes:
+            return False
+        # Local import avoids a circular import at module load
+        # (runtime.kernel -> autotuner_heuristics -> helion.language).
+        from ...language import join as hl_join
+        from ...language import split as hl_split
+
+        saw_split = False
+        saw_join = False
+        for graph_info in device_ir.graphs:
+            for node in graph_info.graph.nodes:
+                if node.op != "call_function":
+                    continue
+                target = node.target
+                if target is hl_split:
+                    saw_split = True
+                elif target is hl_join:
+                    saw_join = True
+                elif op_name_parts(target) & REDUCTION_TARGET_NAMES:
+                    # Fused reduction → not a pure rotate; keep its own tiling.
+                    return False
+        return saw_split and saw_join
+
+    @classmethod
+    def get_seed_config(cls, env: CompileEnvironment, device_ir: DeviceIR) -> Config:
+        return Config(block_sizes=[1] * len(env.config_spec.block_sizes))
+
+
+# Triton analog of ``CuteReductionTileHeuristic``.
+class TritonReductionTileHeuristic(AutotunerHeuristic):
+    """Seed the "one row per program, persistent reduction" config for reductions.
+
+    For canonical row reductions (softmax, rms_norm, layer_norm, cross_entropy)
+    LFBO converges on the same family across widths; this supplies it as a
+    search seed (a starting point, not a forced config):
+    ``block_sizes=[1]`` (one row per program), ``reduction_loops=[None]`` (a
+    single persistent pass, not the looped family the LLM cold-guesses), and
+    ``load_eviction_policies=['last']`` where the backend supports it. Gated by
+    ``is_canonical_row_reduction``, shared with ``CuteReductionTileHeuristic``.
+    """
+
+    name = "triton_reduction_tile"
+    backend = "triton"
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        return is_canonical_row_reduction(env)
+
+    @classmethod
+    def get_seed_config(cls, env: CompileEnvironment, device_ir: DeviceIR) -> Config:
+        spec = env.config_spec
+        seed: dict[str, Any] = {
+            "block_sizes": [1],
+            "reduction_loops": [None],
+        }
+        # Emit 'last' only where the backend supports it; backends that restrict
+        # eviction to ("",) keep the spec default so the seed stays valid.
+        eviction = spec.load_eviction_policies
+        if (
+            eviction.length
+            and isinstance(eviction.inner, EnumFragment)
+            and "last" in eviction.inner.choices
+        ):
+            seed["load_eviction_policies"] = ["last"] * eviction.length
+        return Config(**seed)

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -1792,13 +1792,15 @@ class ReductionLoopSpec(_PowerOfTwoBlockIdItem):
         return value
 
     def _encode_flat_value(self, base: ConfigSpec, value: object) -> object:
-        # None means "persistent reduction" in the normalized Config. In the
-        # flat search space that same choice is represented by an integer
-        # sentinel, typically the fragment default such as 1024 for a 1024-wide
-        # reduction. This is the one non-identity Config <-> FlatConfig
-        # mapping today.
+        # Encode None ("persistent reduction") so the inverse ``_flat_config``
+        # decodes it back to None. ``_flat_config`` returns None for any value
+        # >= size_hint, so the encoding must also be >= size_hint: use the
+        # fragment's ``high`` (always >= size_hint). The fragment *default* is
+        # capped at max_reduction_loop and can fall below size_hint, which would
+        # round-trip None into a slow looped config (e.g. size_hint=32000 ->
+        # default 4096 -> reduction_loops=[4096]).
         if value is None:
-            return self._flat_fragment(base).default()
+            return self._flat_fragment(base).high
         return value
 
     def _normalize(self, name: str, value: object) -> int | None:

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -10,7 +10,9 @@ import helion
 from helion._compiler.autotuner_heuristics import compiler_seed_configs
 from helion._compiler.autotuner_heuristics.cute import CuteTcgen05ClusterM2Heuristic
 from helion._compiler.autotuner_heuristics.registry import AutotunerHeuristic
+from helion._compiler.autotuner_heuristics.triton import TritonReductionTileHeuristic
 from helion._compiler.autotuner_heuristics.triton import TritonSkinnyGemmHeuristic
+from helion._compiler.autotuner_heuristics.triton import TritonSplitJoinRotateHeuristic
 from helion._compiler.backend import TritonBackend
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY
@@ -125,6 +127,7 @@ from helion.autotuner import IntegerFragment
 from helion.autotuner.config_spec import BlockSizeSpec
 from helion.autotuner.config_spec import ConfigSpec
 from helion.autotuner.config_spec import MatmulFact
+from helion.autotuner.config_spec import ReductionLoopSpec
 from helion.autotuner.pattern_search import InitialPopulationStrategy
 from helion.autotuner.pattern_search import PatternSearch
 import helion.language as hl
@@ -612,6 +615,213 @@ class TestTritonSkinnyGemmHeuristic(TestCase):
                         TritonSkinnyGemmHeuristic.name,
                         bound.config_spec.autotuner_heuristics,
                     )
+
+
+class TestTritonSplitJoinRotateHeuristic(TestCase):
+    """Rope split/join "rotate" heuristic: seeds all-ones ``block_sizes`` and
+    fires only for a split/join rotate kernel, not a plain elementwise one.
+    """
+
+    def test_seed_config_is_all_ones(self) -> None:
+        spec = ConfigSpec(backend=TritonBackend())
+        spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=2048))
+        spec.block_sizes.append(BlockSizeSpec(block_id=1, size_hint=2048))
+        env = MagicMock()
+        env.config_spec = spec
+        config = TritonSplitJoinRotateHeuristic.get_seed_config(env, MagicMock())
+        self.assertEqual(config.config["block_sizes"], [1, 1])
+
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler heuristics are not collected in ref eager mode")
+    def test_fires_for_rope_not_elementwise(self) -> None:
+        @helion.kernel(backend="triton")
+        def rope_like(
+            q: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+        ) -> torch.Tensor:
+            batch, heads, seq_len, head_dim = q.size()
+            half_dim = head_dim // 2
+            out = torch.empty_like(q)
+            for tile_b, tile_t in hl.tile([batch, seq_len]):
+                cos_pair = (
+                    cos[tile_b, tile_t, :]
+                    .to(torch.float32)
+                    .reshape([tile_b, tile_t, 2, half_dim])
+                    .permute(0, 1, 3, 2)
+                )
+                cos_first, cos_second = hl.split(cos_pair)
+                q_pair = (
+                    q[tile_b, :, tile_t, :]
+                    .to(torch.float32)
+                    .reshape([tile_b, heads, tile_t, 2, half_dim])
+                    .permute(0, 1, 2, 4, 3)
+                )
+                q_first, q_second = hl.split(q_pair)
+                out[tile_b, :, tile_t, :] = (
+                    hl.join(
+                        q_first * cos_first[:, None, :, :],
+                        q_second * cos_second[:, None, :, :],
+                    )
+                    .permute(0, 1, 2, 4, 3)
+                    .reshape([tile_b, heads, tile_t, head_dim])
+                    .to(out.dtype)
+                )
+            return out
+
+        @helion.kernel(backend="triton")
+        def elementwise(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile(x.size()):
+                out[tile_m, tile_n] = x[tile_m, tile_n] * y[tile_m, tile_n]
+            return out
+
+        q = torch.randn(2, 8, 256, 64, device=DEVICE, dtype=HALF_DTYPE)
+        angles = torch.randn(2, 256, 64, device=DEVICE, dtype=HALF_DTYPE)
+        rope = rope_like.bind((q, torch.cos(angles), torch.sin(angles)))
+        self.assertTrue(
+            TritonSplitJoinRotateHeuristic.is_eligible(
+                rope.env, rope.host_function.device_ir
+            )
+        )
+        seed = TritonSplitJoinRotateHeuristic.get_seed_config(
+            rope.env, rope.host_function.device_ir
+        )
+        self.assertEqual(
+            seed.config["block_sizes"], [1] * len(rope.config_spec.block_sizes)
+        )
+
+        xy = (
+            torch.randn(512, 512, device=DEVICE, dtype=HALF_DTYPE),
+            torch.randn(512, 512, device=DEVICE, dtype=HALF_DTYPE),
+        )
+        ew = elementwise.bind(xy)
+        self.assertFalse(
+            TritonSplitJoinRotateHeuristic.is_eligible(
+                ew.env, ew.host_function.device_ir
+            )
+        )
+
+
+class TestTritonReductionTileHeuristic(TestCase):
+    """Triton row-reduction heuristic: seeds the "one row per program,
+    persistent reduction" skeleton, fires only for a canonical row reduction,
+    and its persistent seed survives flatten/unflatten (the config_spec
+    sentinel round-trip fix).
+    """
+
+    def _reduction_spec(self, *, reduction_size_hint: int) -> ConfigSpec:
+        spec = ConfigSpec(backend=TritonBackend())
+        spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=1024))
+        spec.reduction_loops.append(
+            ReductionLoopSpec(block_id=1, size_hint=reduction_size_hint)
+        )
+        return spec
+
+    def test_seed_is_persistent_one_row(self) -> None:
+        # The structural seed: one row per program + persistent reduction. Warp
+        # count is left to the autotuner, not seeded.
+        env = MagicMock()
+        env.config_spec = self._reduction_spec(reduction_size_hint=1024)
+        seed = TritonReductionTileHeuristic.get_seed_config(env, MagicMock())
+        self.assertEqual(seed.config["block_sizes"], [1])
+        self.assertEqual(seed.config["reduction_loops"], [None])
+        self.assertNotIn("num_warps", seed.config)
+
+    def test_seed_broadcasts_last_eviction_over_load_slots(self) -> None:
+        # Streaming reductions want 'last' eviction, broadcast over the spec's
+        # load slots. Build the fragment explicitly so the test does not depend
+        # on the host backend's eviction choices.
+        from helion.autotuner.config_fragment import EnumFragment
+        from helion.autotuner.config_fragment import ListOf
+
+        env = MagicMock()
+        spec = self._reduction_spec(reduction_size_hint=1024)
+        spec.load_eviction_policies = ListOf(
+            EnumFragment(choices=("", "first", "last")), length=4
+        )
+        env.config_spec = spec
+        seed = TritonReductionTileHeuristic.get_seed_config(env, MagicMock())
+        self.assertEqual(
+            seed.config["load_eviction_policies"], ["last", "last", "last", "last"]
+        )
+
+    def test_persistent_seed_round_trips_through_config_generation(self) -> None:
+        # reduction_loops=[None] (persistent) MUST survive flatten/unflatten. For
+        # a wide reduction (size_hint 32000) a sentinel < size_hint would decode
+        # back to the SLOW looped family this heuristic exists to avoid; the
+        # config_spec fix encodes None as the fragment's ``high`` (>= size_hint).
+        from helion.autotuner.config_generation import ConfigGeneration
+
+        env = MagicMock()
+        spec = self._reduction_spec(reduction_size_hint=32000)
+        env.config_spec = spec
+        seed = TritonReductionTileHeuristic.get_seed_config(env, MagicMock())
+        spec.compiler_seed_configs = [seed]
+        pairs = ConfigGeneration(spec).seed_flat_config_pairs()
+        self.assertEqual(len(pairs), 1)
+        _flat, normalized = pairs[0]
+        self.assertEqual(normalized.config["reduction_loops"], [None])
+
+    def test_not_eligible_without_single_reduction_tile(self) -> None:
+        env = MagicMock()
+        # No reduction loop -> not a reduction.
+        spec = ConfigSpec(backend=TritonBackend())
+        spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=1024))
+        env.config_spec = spec
+        self.assertFalse(TritonReductionTileHeuristic.is_eligible(env, MagicMock()))
+        # A matmul fact disqualifies even a 1-tile/1-reduction shape.
+        spec_mm = self._reduction_spec(reduction_size_hint=1024)
+        spec_mm.matmul_facts = [MagicMock()]
+        env.config_spec = spec_mm
+        self.assertFalse(TritonReductionTileHeuristic.is_eligible(env, MagicMock()))
+
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler heuristics are not collected in ref eager mode")
+    def test_fires_for_reduction_not_matmul(self) -> None:
+        @helion.kernel(backend="triton")
+        def row_reduction(x: torch.Tensor) -> torch.Tensor:
+            m, _ = x.size()
+            out = torch.empty([m], dtype=x.dtype, device=x.device)
+            for tile_m in hl.tile(m):
+                row = x[tile_m, :]
+                shifted = row - torch.amax(row, dim=-1, keepdim=True)
+                out[tile_m] = torch.log(torch.sum(torch.exp(shifted), dim=-1))
+            return out
+
+        @helion.kernel(backend="triton")
+        def matmul(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        red = row_reduction.bind(
+            (torch.randn(1024, 1024, device=DEVICE, dtype=HALF_DTYPE),)
+        )
+        self.assertTrue(
+            TritonReductionTileHeuristic.is_eligible(
+                red.env, red.host_function.device_ir
+            )
+        )
+        seed = TritonReductionTileHeuristic.get_seed_config(
+            red.env, red.host_function.device_ir
+        )
+        self.assertEqual(seed.config["block_sizes"], [1])
+        self.assertEqual(seed.config["reduction_loops"], [None])
+
+        mm = matmul.bind(
+            (
+                torch.randn(256, 256, device=DEVICE, dtype=HALF_DTYPE),
+                torch.randn(256, 256, device=DEVICE, dtype=HALF_DTYPE),
+            )
+        )
+        self.assertFalse(
+            TritonReductionTileHeuristic.is_eligible(mm.env, mm.host_function.device_ir)
+        )
 
 
 class TestCuteTcgen05ClusterM2Heuristic(TestCase):


### PR DESCRIPTION
Stacked PRs:
 * #2649
 * __->__#2648


--- --- ---

### [autotuner] Add Triton row-reduction and rope split/join heuristics

Add two hardware-agnostic compiler autotuner heuristics for the Triton
backend, plus the config_spec fix that lets their persistent-reduction seed
round-trip:

- TritonReductionTileHeuristic: seeds the canonical "one row per program,
  persistent reduction" skeleton (block_sizes=[1], reduction_loops=[None])
  with 'last' load eviction broadcast over the load slots. Gated to a single
  non-reduction tile + single reduction loop with no matmul facts
  (is_canonical_row_reduction, shared with the CuTe reduction heuristic).
- TritonSplitJoinRotateHeuristic: seeds all-ones block_sizes for the rope
  split/join "rotate" idiom, where tiling any outer dim past 1 is pure waste
  and overflows Triton's block-numel cap. This lets the heuristic supply the
  seed analytically, so examples/rope.py no longer needs a hard-coded
  autotune_seed_configs=[1, 1].
- config_spec: encode a persistent reduction (None) in the flat search space as
  the fragment's `high` (>= size_hint) instead of its default. The default
  (capped at 4096) round-trips a wide reduction back to the slow looped family
  instead of persistent.