### PR TITLE
[autotuner] Surface workload hints and compiler analysis to the LLM prompt

### DIFF
--- a/helion/autotuner/llm/prompting.py
+++ b/helion/autotuner/llm/prompting.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import textwrap
 from typing import TYPE_CHECKING
 
+from ..base_search import normalize_autotune_seed_configs
 from .configs import describe_config_space
 from .feedback import MAX_CHANGED_FIELDS_PER_CONFIG
 from .feedback import format_config_for_prompt
@@ -16,6 +17,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from collections.abc import Sequence
 
+    from ...runtime.config import Config
     from ..base_search import _AutotunableKernel
     from ..config_spec import ConfigSpec
 
@@ -197,6 +199,91 @@ def build_initial_search_guidance(
     )
 
 
+# One-line purpose for each compiler-owned autotuner heuristic, keyed by the
+# heuristic's ``name`` (see helion/_compiler/autotuner_heuristics/). Used to
+# annotate the fired-heuristic names surfaced to the LLM. Names without an entry
+# still render (with no annotation), so a new heuristic is never silently
+# dropped from the prompt.
+_HEURISTIC_PURPOSES: Mapping[str, str] = {
+    "triton_skinny_gemm": (
+        "skinny GEMM (one operand dim >> the other): tile the long dims and "
+        "use a deep K tile"
+    ),
+    "triton_split_join_rotate": (
+        "split/join rotate kernel (rope): each program loads a large untiled "
+        "inner slab, so keep every block_size at 1 (larger outer tiles waste "
+        "work and overflow Triton's block-numel cap)"
+    ),
+    "triton_reduction_tile": (
+        "canonical row reduction (softmax/rms_norm/cross_entropy): one row per "
+        "program with a single persistent pass over the reduction axis "
+        "(reduction_loops null, not a rolled loop), warps scaled to the "
+        "reduction width"
+    ),
+}
+
+
+def _config_list_lines(configs: Sequence[Config]) -> str:
+    """Render configs as ``  - <config>`` lines for a prompt section."""
+    return "\n".join(f"  - {format_config_for_prompt(config)}" for config in configs)
+
+
+def build_compiler_analysis_section(config_spec: ConfigSpec) -> str:
+    """Surface the compiler's fired heuristics and seed configs to the LLM.
+
+    Helion fires eligible heuristics before autotuning; their names and
+    analytical seed configs already feed the search seed path. This also shows
+    them to the LLM as a structural prior. No-op ("") when nothing fired.
+    """
+    heuristic_names = config_spec.autotuner_heuristics
+    seed_configs = config_spec.compiler_seed_configs
+    if not heuristic_names and not seed_configs:
+        return ""
+
+    body_parts: list[str] = [
+        (
+            "Helion's compiler statically analyzed this kernel's structure and "
+            "derived the following structural priors. Treat them as strong "
+            "starting points: include configs matching these and nearby "
+            "mutations before venturing to unrelated families."
+        )
+    ]
+    if heuristic_names:
+        name_lines = "\n".join(
+            (
+                f"  - {name}: {_HEURISTIC_PURPOSES[name]}"
+                if name in _HEURISTIC_PURPOSES
+                else f"  - {name}"
+            )
+            for name in heuristic_names
+        )
+        body_parts.append("Fired compiler heuristics:\n" + name_lines)
+    if seed_configs:
+        body_parts.append(
+            "Compiler-derived seed config(s):\n" + _config_list_lines(seed_configs)
+        )
+    return _section("Compiler Analysis", "\n".join(body_parts))
+
+
+def build_author_seed_section(kernel: _AutotunableKernel) -> str:
+    """Surface author-provided ``autotune_seed_configs`` to the LLM as an anchor.
+
+    No-op ("") for kernels that declare no seeds.
+    """
+    seed_configs = normalize_autotune_seed_configs(kernel.settings)
+    if not seed_configs:
+        return ""
+    body = (
+        "The kernel author provided the following seed config(s) as a known-good "
+        "starting point for this specific kernel. Treat them as a strong prior:\n"
+        f"{_config_list_lines(seed_configs)}\n"
+        "Include at least one candidate matching each seed exactly, plus several "
+        "that explore nearby (small mutations of the seed's fields), before "
+        "venturing to unrelated families."
+    )
+    return _section("Author Seed Configs", body)
+
+
 def build_initial_prompt(
     *,
     kernel: _AutotunableKernel,
@@ -228,6 +315,8 @@ def build_initial_prompt(
         describe_kernel(kernel, args),
         _section("Configuration Space", describe_config_space(config_spec)),
         default_section,
+        build_compiler_analysis_section(config_spec),
+        build_author_seed_section(kernel),
         guidance,
         _section("Task", task_section),
     )

--- a/helion/autotuner/llm/workload.py
+++ b/helion/autotuner/llm/workload.py
@@ -10,6 +10,8 @@ import torch
 
 from ..._compat import get_device_name
 from ..._compat import num_compute_units
+from ..._compiler.autotuner_heuristics.common import REDUCTION_TARGET_NAMES
+from ..._compiler.autotuner_heuristics.common import op_name_parts
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -18,6 +20,12 @@ if TYPE_CHECKING:
     from ..base_search import _AutotunableKernel
     from ..config_spec import ConfigSpec
 
+
+# M*N*K threshold above which a standalone 2D GEMM is "large" enough to want the
+# flat / small-K-tile hint below. ~16G sits between a 2048^3 GEMM (8.6G, left
+# untouched) and a 4096^3 GEMM (69G, measurably helped — see the ablation). A
+# necessary but not sufficient condition: see _is_large_balanced_gemm.
+_LARGE_MATMUL_MNK = 16_000_000_000
 
 MATMUL_TARGETS = frozenset(
     {
@@ -30,7 +38,6 @@ MATMUL_TARGETS = frozenset(
 )
 MATMUL_API_NAMES = frozenset({"dot", "dot_scaled"})
 BATCH_MATMUL_TARGET_NAMES = frozenset({"bmm", "baddbmm"})
-REDUCTION_TARGET_NAMES = frozenset({"amax", "sum", "softmax", "logsumexp"})
 EXP_TARGET_NAMES = frozenset({"exp", "exp2"})
 
 
@@ -102,21 +109,6 @@ def describe_kernel(kernel: _AutotunableKernel, args: Sequence[object]) -> str:
     return "\n\n".join(parts)
 
 
-def _target_name_parts(target: object) -> frozenset[str]:
-    """Extract coarse name tokens for a traced call target."""
-    parts: set[str] = set()
-    for raw in (
-        getattr(target, "__name__", None),
-        getattr(target, "name", None),
-        str(target),
-    ):
-        if not isinstance(raw, str):
-            continue
-        parts.add(raw)
-        parts.update(piece for piece in raw.split(".") if piece)
-    return frozenset(parts)
-
-
 def _iter_call_targets(kernel: _AutotunableKernel) -> Iterator[object]:
     """Yield traced call targets from compiler-generated FX graphs."""
     host_function = getattr(kernel, "host_function", None)
@@ -145,7 +137,7 @@ def detect_workload_traits(
     saw_exp = False
 
     for target in _iter_call_targets(kernel):
-        name_parts = _target_name_parts(target)
+        name_parts = op_name_parts(target)
         if target in MATMUL_TARGETS or name_parts & MATMUL_API_NAMES:
             saw_matmul = True
         if name_parts & BATCH_MATMUL_TARGET_NAMES:
@@ -246,6 +238,38 @@ def _attention_reduction_hints(tensors: Sequence[torch.Tensor]) -> list[str]:
     return hints
 
 
+def _reduction_hints() -> list[str]:
+    """Cache-eviction guidance for pure (non-attention) reductions.
+
+    Memory-bound row reductions recover their remaining headroom from
+    ``load_eviction_policies`` (which the LLM tends to leave at default), not
+    larger tiles. Family-general: no specific kernel or shape.
+    """
+    return [
+        (
+            "This kernel is a memory-bound reduction/normalization that streams "
+            "each input row once. The best configs are usually conservative: one "
+            "row per program (small leading block_size, e.g. 1), no reduction "
+            "looping (reduction_loops null) when the reduction dim fits, and "
+            "num_stages 1-2 — not large tiles or deep pipelining."
+        ),
+        (
+            "The main remaining speedup for such streaming reductions is "
+            "cache-eviction hints, which the search often overlooks: set "
+            "load_eviction_policies to 'last' (or 'first') on the streamed input "
+            "loads instead of leaving them empty, so a value read once is not "
+            "kept in cache. Include several configs that try 'last' on every "
+            "load_eviction_policies entry; leaving them all empty typically "
+            "leaves ~15-20% on the table for these kernels."
+        ),
+        (
+            "num_warps 4 is usually the balanced choice here; reserve 8+ warps "
+            "and any aggressive tiling for a small minority of exploratory "
+            "configs."
+        ),
+    ]
+
+
 def _matmul_hints(
     tensors: Sequence[torch.Tensor],
     *,
@@ -272,6 +296,16 @@ def _matmul_hints(
     k2, n = shapes[1]
     total_tiles_64 = (m // 64) * (n // 64)
     hints = [f"Matmul-like: [{m}x{k}] @ [{k2}x{n}], ~{total_tiles_64} tiles at 64x64"]
+
+    # Large *balanced* standalone 2D GEMM: emit only the flat / K=32 guidance and
+    # early-return, dropping the default tail below (which pushes persistent
+    # scheduling and a K<=64 tile that are counterproductive at this size). Gated
+    # to a pure matmul so a reduction/attention-fused kernel keeps its own hints.
+    is_pure_matmul = not (workload_traits & {"reduction", "attention_reduction"})
+    if is_pure_matmul and _is_large_balanced_gemm(m, n, k, total_tiles_64):
+        hints.extend(_large_matmul_hints(m, n))
+        return hints
+
     if total_tiles_64 > num_compute_units() * 4:
         hints.append(
             "Problem large enough for persistent kernels - "
@@ -294,6 +328,43 @@ def _matmul_hints(
     return hints
 
 
+def _is_large_balanced_gemm(m: int, n: int, k: int, total_tiles_64: int) -> bool:
+    """Whether a rank-2 GEMM is large *and* has a balanced large-tile output grid.
+
+    Requires both a large M*N*K and an M*N grid with at least one 64x64 tile per
+    compute unit. The grid guard rejects skinny shapes (e.g. [1, 5e5] @ [5e5,
+    32768]) that clear the FLOP threshold but have a degenerate output grid, where
+    "keep M/N tiles large" advice would be wrong.
+    """
+    return m * n * k >= _LARGE_MATMUL_MNK and total_tiles_64 >= num_compute_units()
+
+
+def _large_matmul_hints(m: int, n: int) -> list[str]:
+    """Pipelining/scheduling guidance for a large *standalone* 2D GEMM.
+
+    At this size LFBO prefers a small K-tile (32) and plain `flat` scheduling,
+    while the default guidance pushes a K-tile of 64 and persistent scheduling;
+    the caller suppresses that default for this branch. Keyed purely on operand
+    size (no kernel name or specific shape).
+    """
+    return [
+        (
+            f"This is a large compute-bound GEMM ([{m}x*] @ [*x{n}]). For a plain "
+            "standalone GEMM at this size, prefer pid_type='flat' as the primary "
+            "scheduling family — flat is frequently faster here than persistent "
+            "scheduling even though the tile count exceeds the SM count, so make "
+            "most configs flat and reserve persistent for a minority probe."
+        ),
+        (
+            "The reduction (K) tile is the key pipelining knob at this size: make "
+            "the K-tile 32 (not 64) your primary choice — e.g. block_sizes "
+            "[128, 256, 32] / [256, 256, 32] — which shrinks the per-stage working "
+            "set so the K-loop overlaps better at pipeline depth num_stages 4-5. "
+            "Keep M/N tiles large (128-256)."
+        ),
+    ]
+
+
 def _format_workload_analysis(hints: list[str]) -> str:
     """Render workload hints as an optional prompt section."""
     if not hints:
@@ -309,5 +380,7 @@ def compute_workload_hints(
     hints = _summary_hints(tensors, workload_traits=workload_traits)
     if "attention_reduction" in workload_traits:
         hints.extend(_attention_reduction_hints(tensors))
+    elif "reduction" in workload_traits and "matmul" not in workload_traits:
+        hints.extend(_reduction_hints())
     hints.extend(_matmul_hints(tensors, workload_traits=workload_traits))
     return _format_workload_analysis(hints)

--- a/test/test_llm_autotuner.py
+++ b/test/test_llm_autotuner.py
@@ -16,6 +16,9 @@ from helion.autotuner.config_fragment import IntegerFragment
 from helion.autotuner.config_fragment import ListOf
 from helion.autotuner.config_fragment import PowerOfTwoFragment
 from helion.autotuner.effort_profile import get_effort_profile
+from helion.autotuner.llm.prompting import build_author_seed_section
+from helion.autotuner.llm.prompting import build_compiler_analysis_section
+from helion.autotuner.llm.workload import compute_workload_hints
 from helion.autotuner.logger import AutotuningLogger
 from helion.autotuner.metrics import AutotuneMetrics
 import helion.language as hl
@@ -387,6 +390,127 @@ class TestLLMGuidedSearch(TestCase):
         future.set_exception(RuntimeError("simulated provider 401"))
         with self.assertRaisesRegex(RuntimeError, "simulated provider 401"):
             search._wait_for_initial_llm_response(future)
+
+
+class TestAuthorSeedConfigPrompt(TestCase):
+    """Author-provided autotune_seed_configs surface in the initial prompt."""
+
+    def test_renders_all_seed_config_values(self):
+        kernel = SimpleNamespace(
+            settings=Settings(
+                autotune_seed_configs=[
+                    helion.Config(block_sizes=[1, 1]),
+                    helion.Config(block_sizes=[16, 16], num_warps=8),
+                ]
+            )
+        )
+        section = build_author_seed_section(kernel)
+        self.assertIn("Author Seed Configs", section)
+        self.assertIn('"block_sizes":[1,1]', section)
+        self.assertIn('"block_sizes":[16,16]', section)
+        self.assertIn('"num_warps":8', section)
+
+    def test_empty_when_no_author_seeds(self):
+        kernel = SimpleNamespace(settings=Settings())
+        self.assertEqual(build_author_seed_section(kernel), "")
+
+
+class TestCompilerAnalysisPrompt(TestCase):
+    """Compiler-fired heuristics + analytical seed configs surface in the prompt."""
+
+    def test_renders_heuristic_name_purpose_and_seed(self):
+        config_spec = SimpleNamespace(
+            autotuner_heuristics=["triton_skinny_gemm"],
+            compiler_seed_configs=[helion.Config(block_sizes=[64, 64, 256])],
+        )
+        section = build_compiler_analysis_section(config_spec)
+        self.assertIn("Compiler Analysis", section)
+        self.assertIn("triton_skinny_gemm", section)
+        self.assertIn("skinny GEMM", section)
+        self.assertIn('"block_sizes":[64,64,256]', section)
+        self.assertIn("structural prior", section.lower())
+
+    def test_empty_when_nothing_fired(self):
+        config_spec = SimpleNamespace(autotuner_heuristics=[], compiler_seed_configs=[])
+        self.assertEqual(build_compiler_analysis_section(config_spec), "")
+
+
+def _meta_tensor(shape: list[int]) -> torch.Tensor:
+    """Shape/dtype-only tensor for workload-hint tests (no real device needed)."""
+    return torch.randn(shape, device="meta", dtype=torch.float16)  # @ignore-device-lint
+
+
+class TestReductionWorkloadHints(TestCase):
+    """Pure (non-attention, non-matmul) reductions get cache-eviction guidance."""
+
+    def test_reduction_gets_eviction_hint_family_general(self):
+        args = (_meta_tensor([1024, 1024]),)
+        hints = compute_workload_hints(args, workload_traits=frozenset({"reduction"}))
+        self.assertIn("load_eviction_policies", hints)
+        self.assertIn("last", hints.lower())
+        # Family-general: no specific kernel name or shape.
+        self.assertNotIn("softmax", hints.lower())
+        self.assertNotIn("1024", hints)
+
+    def test_not_emitted_for_matmul_attention_or_non_reduction(self):
+        sentence = "memory-bound reduction/normalization that streams"
+        for traits in (
+            frozenset({"matmul", "reduction"}),
+            frozenset({"matmul", "reduction", "attention_reduction"}),
+            frozenset(),
+        ):
+            with self.subTest(traits=sorted(traits)):
+                args = (
+                    _meta_tensor([1024, 1024]),
+                    _meta_tensor([1024, 1024]),
+                )
+                hints = compute_workload_hints(args, workload_traits=traits)
+                self.assertNotIn(sentence, hints)
+
+
+class TestLargeMatmulWorkloadHints(TestCase):
+    """Large standalone 2D GEMMs get coherent flat + small-K guidance.
+
+    The default matmul guidance is counterproductive for a large GEMM (it pushes
+    persistent and caps K-tile at 64); the large branch suppresses it and
+    recommends flat pid + K-tile 32. Double-gated to a rank-2 pure-matmul
+    workload so it cannot leak to fused or batched (SSM-style) kernels.
+    """
+
+    _PERSISTENT_PUSH = "try pid_type='persistent_blocked' with l2_groupings"
+    _DEFAULT_START_TILE = "as starting point"
+
+    @staticmethod
+    def _hints(shapes, traits=frozenset({"matmul"})):
+        args = tuple(_meta_tensor(s) for s in shapes)
+        return compute_workload_hints(args, workload_traits=frozenset(traits))
+
+    def test_large_2d_gemm_gets_flat_k32_and_suppresses_default(self):
+        hints = self._hints([[4096, 4096], [4096, 4096]])
+        self.assertIn("large compute-bound GEMM", hints)
+        self.assertIn("K-tile 32", hints)
+        self.assertIn("pid_type='flat'", hints)
+        self.assertNotIn(self._PERSISTENT_PUSH, hints)
+        self.assertNotIn(self._DEFAULT_START_TILE, hints)
+
+    def test_medium_gemm_keeps_default_guidance(self):
+        hints = self._hints([[2048, 2048], [2048, 2048]])
+        self.assertNotIn("large compute-bound GEMM", hints)
+        self.assertIn(self._DEFAULT_START_TILE, hints)
+
+    def test_does_not_leak_to_fused_batched_or_non_matmul(self):
+        # Fused matmul+reduction, batched (rank-3) operands, and non-matmul
+        # workloads must never get the standalone large-GEMM hint.
+        cases = (
+            ([[4096, 4096], [4096, 4096]], frozenset({"matmul", "reduction"})),
+            ([[8, 4096, 4096], [8, 4096, 4096]], frozenset({"matmul"})),
+            ([[4096, 4096]], frozenset()),
+        )
+        for shapes, traits in cases:
+            with self.subTest(traits=sorted(traits), rank=len(shapes[0])):
+                self.assertNotIn(
+                    "large compute-bound GEMM", self._hints(shapes, traits)
+                )
 
 
 class TestLLMTransport(TestCase):


### PR DESCRIPTION
Stacked PRs:
 * __->__#2649
 * #2648


--- --- ---

### [autotuner] Surface workload hints and compiler analysis to the LLM prompt

Add three prompt sections to the LLM-guided autotuner so the model gets the
structural priors Helion already computes:

- build_compiler_analysis_section: render the compiler's fired autotuner
  heuristics (with a one-line purpose) and their analytical seed configs,
  framed as a compiler-derived structural prior. These already feed the LFBO
  seed path; this is the missing wire that also shows them to the LLM.
- build_author_seed_section: render any author-provided autotune_seed_configs
  with concrete values so the model can anchor on them.
- compute_workload_hints: add two family-general workload hints -- a cache
  eviction hint for pure (non-attention, non-matmul) reductions, and a coherent
  flat + small-K-tile recommendation for large standalone 2D GEMMs that
  suppresses the counterproductive default matmul guidance. Both are gated so
  they cannot leak to fused / batched / attention kernels.

--- --- ---

## Benchmarking vs LFBO (B200)

LLM-guided autotuner (`LLMGuidedSearch`, `effort=full`) vs a frozen LFBO
baseline, 3 seeds (0-2) per kernel on B200. Tuning LLM: **Claude Opus 4.8**
(`HELION_LLM_MODEL=claude-opus-4-8`, fast mode). Per-kernel
`ratio = median(LLM) / median(LFBO)` (lower = LLM faster); geomean across
kernels.

### Dev suite (23 kernels)

| kernel | LLM (ms) | LFBO (ms) | perf ratio | LLM tune (s) | LFBO tune (s) | tune speedup |
|---|---:|---:|---:|---:|---:|---:|
| `matmul_split_k_k16k` † | 0.5824 | 6.2520 | 0.093 | 29.8 | 263.9 | 8.9x |
| `swiglu_2k` | 0.0085 | 0.0099 | 0.861 | 30.5 | 98.9 | 3.2x |
| `matmul_sq_8k` | 1.1336 | 1.2886 | 0.880 | 51.6 | 623.1 | 12.1x |
| `fp8_attention_s2k_d64` | 0.8013 | 0.8942 | 0.896 | 31.1 | 402.5 | 12.9x |
| `rms_norm_w1k` | 0.0085 | 0.0095 | 0.902 | 23.3 | 227.4 | 9.7x |
| `matmul_sq_1k` | 0.0120 | 0.0126 | 0.955 | 27.4 | 154.0 | 5.6x |
| `softmax_w32k` | 0.1596 | 0.1611 | 0.991 | 50.7 | 328.0 | 6.5x |
| `attention_s8k_d64` | 4.9676 | 4.9629 | 1.001 | 59.3 | 696.6 | 11.8x |
| `rope` | 0.0224 | 0.0223 | 1.005 | 47.4 | 546.1 | 11.5x |
| `swiglu_8k` | 0.0665 | 0.0661 | 1.006 | 28.8 | 120.7 | 4.2x |
| `gdn_s4k_c64` | 0.0548 | 0.0544 | 1.008 | 34.7 | 72.6 | 2.1x |
| `gdn_s2k_c128` | 0.0232 | 0.0230 | 1.011 | 32.5 | 52.5 | 1.6x |
| `mamba2_s2k_c128` | 0.0228 | 0.0224 | 1.017 | 34.2 | 227.3 | 6.6x |
| `matmul_split_k_k1k` | 0.0572 | 0.0559 | 1.022 | 28.0 | 304.2 | 10.9x |
| `attention_s512_d64` | 0.0340 | 0.0331 | 1.026 | 29.7 | 286.5 | 9.7x |
| `rms_norm_w8k` | 0.0281 | 0.0274 | 1.027 | 27.9 | 160.2 | 5.7x |
| `grouped_gemm_g4_m512` | 0.4088 | 0.3966 | 1.031 | 45.1 | 505.3 | 11.2x |
| `softmax_w1k` | 0.0087 | 0.0084 | 1.034 | 28.0 | 200.2 | 7.1x |
| `matmul_sq_4k` | 0.1521 | 0.1378 | 1.103 | 35.1 | 280.6 | 8.0x |
| `fp8_attention_s512_d64` | 0.0372 | 0.0337 | 1.105 | 28.5 | 169.2 | 5.9x |
| `attention_s4k_d64` | 1.2588 | 1.1362 | 1.108 | 49.3 | 612.8 | 12.4x |
| `mamba2_s4k_c256` | 0.0447 | 0.0393 | 1.139 | 31.2 | 312.6 | 10.0x |
| `rms_norm_w32k` | 0.1160 | 0.0932 | 1.245 | 39.2 | 187.2 | 4.8x |
| **geomean (all)** | | | **0.913** | | | **7.0x** |
| **geomean (excl. † split-K)** | | | **1.013** | | | |

### Held-out suite (13 kernels)

| kernel | LLM (ms) | LFBO (ms) | ratio |
|---|---:|---:|---:|
| `matmul_split_k_k64k` † | 2.5225 | 38.3918 | 0.066 |
| `fp8_attention_s512_d128` | 0.0475 | 0.0490 | 0.969 |
| `matmul_skinnym` | 0.0225 | 0.0230 | 0.978 |
| `cross_entropy` | 0.0338 | 0.0338 | 1.000 |
| `softmax_w8k` | 0.0325 | 0.0324 | 1.001 |
| `geglu` | 0.0249 | 0.0248 | 1.004 |
| `matmul_largek` | 0.5528 | 0.5486 | 1.008 |
| `layer_norm` | 0.0086 | 0.0084 | 1.021 |
| `bmm` | 0.0329 | 0.0321 | 1.026 |
| `matmul_split_k_k4k` | 0.1639 | 0.1474 | 1.112 |
| `flex_attention` | 0.0795 | 0.0707 | 1.125 |
| `attention_s4k_d128` | 2.5500 | 2.0486 | 1.245 |
| `moe_matmul_ogs` | 0.4811 | 0.3834 | 1.255 |
| **geomean (all)** | | | **0.854** |
| **geomean (excl. † split-K)** | | | **1.058** |

† `matmul_split_k` shapes: LFBO is bimodal here -- across seeds it lands the
good config only sometimes and a 10-30x slower one otherwise, so its median sits
on a poor config. The raw geomean (0.91 / 0.85) therefore reflects LFBO's
split-K unreliability rather than a clean LLM win; the **excl.-split-K geomean
(1.01 dev / 1.06 held-out)** is the fair "at parity" number. Ratios are medians;
a few GEMM/attention shapes show a few percent of seed variance.

**Efficiency (the main win).** The `LLM tune` / `LFBO tune` columns in the dev
table above show the autotuning-cost win: geomean **7.0x faster** and ~10x fewer
configs evaluated, totaling **13.7 min (LLM) vs 113.9 min (LFBO)** to tune all 23
kernels. (Held-out LFBO compile times weren't recorded -- that baseline froze
configs/perf only.)

Notable per-kernel: `rope` stays at parity (1.005) after dropping its hard-coded
`autotune_seed_configs=[1, 1]` -- the #2648 heuristic now supplies it; held-out
`cross_entropy` reaches 1.000 via the row-reduction heuristic.