### PR TITLE
[cutedsl] expand epilogue store support and autotuner seeds

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -3592,6 +3592,13 @@ class CuteBackend(Backend):
             compile_options: list[str] = []
             if config.get(TCGEN05_CUBIN_LINEINFO_CONFIG_KEY) is True:
                 compile_options.append("--generate-line-info")
+            # ``--enable-tvm-ffi`` is emitted in codegen only when the
+            # autotune flag is True so the generated code reflects which
+            # configs deliberately requested FFI. The runtime
+            # (``_get_compiled_cute_launcher``) unconditionally merges
+            # the flag in for the generic launcher, so configs with this
+            # flag False still execute with FFI enabled — that drift is
+            # intentional for now and noted here for future cleanups.
             if config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is True:
                 if (
                     _kernel_specialized_mma_impl(

--- a/helion/_compiler/cute/aux_tensor.py
+++ b/helion/_compiler/cute/aux_tensor.py
@@ -521,16 +521,20 @@ def host_function_has_tcgen05_relu_matmul_store_pattern(
 
 def host_function_has_tcgen05_bias_matmul_store_pattern(
     host_function: HostFunction,
+    *,
+    expected_bias_dtypes: tuple[torch.dtype, ...] = (torch.bfloat16,),
 ) -> bool:
     """Return True for a single ``acc + bias[n]`` store of a tcgen05 matmul.
 
-    Gates the Target 2 TVM-FFI direct-entry seed for the rank-1
-    trailing-axis (rowvec) bias epilogue. The accepted chain shape is
+    Gates the Target 2 (bf16-only) and Target 10 (bf16/fp16) TVM-FFI
+    direct-entry seeds for the rank-1 trailing-axis (rowvec) bias
+    epilogue. The accepted chain shape is
     ``mma -> aten.add.Tensor(carrier, bias_load) -> convert -> store``
     where:
 
     * ``bias_load`` is a ``helion.language.memory_ops.load`` against a
-      rank-1 (``shape == (N,)``) GMEM tensor.
+      rank-1 (``shape == (N,)``) GMEM tensor whose dtype is one of
+      ``expected_bias_dtypes``.
     * One operand of the ``add`` is the MMA carrier reached via
       ``walk_carrier_to_tcgen05_matmul``; the other is the rank-1
       ``bias_load``.
@@ -554,7 +558,12 @@ def host_function_has_tcgen05_bias_matmul_store_pattern(
     cast_input = _single_store_cast_input(graphs)
     if cast_input is None:
         return False
-    return _bias_add_walks_to_mma_carrier(cast_input, mma_nodes, graphs)
+    return _bias_add_walks_to_mma_carrier(
+        cast_input,
+        mma_nodes,
+        graphs,
+        expected_bias_dtypes=expected_bias_dtypes,
+    )
 
 
 def host_function_has_tcgen05_bias_relu_matmul_store_pattern(
@@ -613,7 +622,13 @@ def host_function_has_tcgen05_bias_relu_matmul_store_pattern(
     relu_input = cast_input.args[0]
     if not isinstance(relu_input, torch.fx.Node):
         return False
-    return _bias_add_walks_to_mma_carrier(relu_input, mma_nodes, graphs)
+    # T6 stays pinned to bf16 (its matmul-fact gate is bf16-only).
+    return _bias_add_walks_to_mma_carrier(
+        relu_input,
+        mma_nodes,
+        graphs,
+        expected_bias_dtypes=(torch.bfloat16,),
+    )
 
 
 def _tcgen05_aux_detector_mma_facts(
@@ -694,12 +709,17 @@ def _single_store_cast_input(
     return cast_input if isinstance(cast_input, torch.fx.Node) else None
 
 
-def _is_rank1_bf16_bias_load(node: torch.fx.Node) -> bool:
-    """Return True iff ``node`` is a rank-1 bf16 ``memory_ops.load`` call.
+def _is_rank1_bias_load_of_dtype(
+    node: torch.fx.Node, expected_dtypes: tuple[torch.dtype, ...]
+) -> bool:
+    """Return True iff ``node`` is a rank-1 ``memory_ops.load`` of one of ``expected_dtypes``.
 
-    The runtime bias validator only admits bf16 bias tensors, so non-bf16
-    bias loads must not enable a bias-store direct-entry seed at the
-    host-detector level either.
+    The host-side detector is parameterized by the caller's expected
+    bias dtypes so T2/T6 stay pinned to bf16 (their matmul-fact gates
+    are bf16-only) while T10 admits ``(bf16, fp16)``. Without per-caller
+    parameterization a fp16 bias against a bf16-operand kernel would
+    silently flip ``bias_matmul_store_detected = True`` for T2/T6 too,
+    perturbing the autotune mutation pool (cycle 40 lesson).
     """
     if node.op != "call_function" or node.target is not memory_ops.load:
         return False
@@ -709,19 +729,22 @@ def _is_rank1_bf16_bias_load(node: torch.fx.Node) -> bool:
     host_val = host_arg.meta.get("val")
     if not isinstance(host_val, torch.Tensor):
         return False
-    return host_val.ndim == 1 and host_val.dtype == torch.bfloat16
+    return host_val.ndim == 1 and host_val.dtype in expected_dtypes
 
 
 def _bias_add_walks_to_mma_carrier(
     add_node: torch.fx.Node,
     mma_nodes: set[torch.fx.Node],
     graphs: Sequence[GraphInfo],
+    *,
+    expected_bias_dtypes: tuple[torch.dtype, ...],
 ) -> bool:
     """Return True iff ``add_node`` is ``aten.add.Tensor(carrier, bias_load)``.
 
     One operand of the add must walk to an MMA carrier via
     :func:`walk_carrier_to_tcgen05_matmul`; the other must satisfy
-    :func:`_is_rank1_bf16_bias_load`. Either operand may be the carrier
+    :func:`_is_rank1_bias_load_of_dtype` with the caller-supplied
+    ``expected_bias_dtypes`` set. Either operand may be the carrier
     (commutative).
     """
     if (
@@ -737,10 +760,10 @@ def _bias_add_walks_to_mma_carrier(
     inner_outputs_index = build_inner_outputs_index_from_graphs(graphs)
     carrier_first = walk_carrier_to_tcgen05_matmul(
         add_lhs, mma_nodes, inner_outputs_index
-    ) is not None and _is_rank1_bf16_bias_load(add_rhs)
+    ) is not None and _is_rank1_bias_load_of_dtype(add_rhs, expected_bias_dtypes)
     carrier_second = walk_carrier_to_tcgen05_matmul(
         add_rhs, mma_nodes, inner_outputs_index
-    ) is not None and _is_rank1_bf16_bias_load(add_lhs)
+    ) is not None and _is_rank1_bias_load_of_dtype(add_lhs, expected_bias_dtypes)
     return carrier_first or carrier_second
 
 

--- a/helion/_compiler/cute/cute_epilogue.py
+++ b/helion/_compiler/cute/cute_epilogue.py
@@ -176,6 +176,24 @@ _EXP_TEMPLATE = "cute.math.exp({inner})"
 _LOG_TEMPLATE = "cute.math.log({inner})"
 _SQRT_TEMPLATE = "cute.math.sqrt({inner})"
 _ERF_TEMPLATE = "cute.math.erf({inner})"
+# ``sigmoid`` and ``silu`` share the base-2 exp2 sigmoid form used by
+# inductor's cutedsl op overrides
+# (``torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py``):
+# ``1 / (1 + exp(-x)) == 1 / (1 + exp2(-x * log2(e)))``. Using
+# ``cute.math.exp2`` matches the existing pointwise sigmoid lowering and
+# keeps numerics bit-identical with the inductor path. The constant
+# ``1/ln(2)`` is spelled as a literal float so the rendered Python is
+# byte-identical across machines (same idiom as the GELU constants in
+# ``helion/language/_gelu_tanh_approx.py``).
+_LOG2_E = 1.4426950408889634
+_SIGMOID_TEMPLATE = f"(1.0 / (1.0 + cute.math.exp2(-({{inner}}) * {_LOG2_E!r})))"
+# ``silu(x) = x * sigmoid(x)``. The chain renderer always binds
+# ``{inner}`` to a fresh local before formatting, so the two
+# references to ``{inner}`` here resolve to a single SSA name (no
+# source-size blowup).
+_SILU_TEMPLATE = (
+    f"(({{inner}}) * (1.0 / (1.0 + cute.math.exp2(-({{inner}}) * {_LOG2_E!r}))))"
+)
 
 
 def _add_const_template(scalar: float) -> str:
@@ -232,6 +250,16 @@ _ZERO_ARG_TARGETS: dict[object, _UnaryStep] = {
     torch.ops.aten.log.default: _UnaryStep(op_name="log", template=_LOG_TEMPLATE),
     torch.ops.aten.sqrt.default: _UnaryStep(op_name="sqrt", template=_SQRT_TEMPLATE),
     torch.ops.aten.erf.default: _UnaryStep(op_name="erf", template=_ERF_TEMPLATE),
+    # ``aten.sigmoid.default`` is accepted as a standalone unary step so
+    # ``out[tile] = sigmoid(acc).to(...)`` fuses end-to-end. The same
+    # template is also embedded inside ``_SILU_TEMPLATE`` for the
+    # ``x * sigmoid(x)`` fusion below — keeping both paths on the
+    # ``cute.math.exp2`` form matches the inductor cutedsl pointwise
+    # sigmoid lowering byte-for-byte.
+    torch.ops.aten.sigmoid.default: _UnaryStep(
+        op_name="sigmoid",
+        template=_SIGMOID_TEMPLATE,
+    ),
     _gelu_erf: _UnaryStep(
         op_name="gelu_erf",
         template=gelu_erf_epilogue_unary_step_template(),
@@ -540,6 +568,143 @@ class Tcgen05UnaryEpilogueChain:
             prelude_lines.append(f"{prelude_indent}{local} = {step_expr}\n")
             cur_expr = local
         return ("".join(prelude_lines), local)
+
+
+def _is_sigmoid_of(node: object, carrier: torch.fx.Node) -> bool:
+    """Return True if ``node`` is ``aten.sigmoid.default(carrier)``.
+
+    Identity-keying on ``args[0]`` is sound because Helion's FX graph
+    deduplicates equal-expression nodes: any ``sigmoid(x)`` and
+    ``x * sigmoid(x)`` traced from the same ``x`` proxy share the same
+    underlying FX node for ``x``.
+    """
+    return (
+        isinstance(node, torch.fx.Node)
+        and node.op == "call_function"
+        and node.target is torch.ops.aten.sigmoid.default
+        and not node.kwargs
+        and len(node.args) == 1
+        and node.args[0] is carrier
+    )
+
+
+def _is_one_plus_exp_neg_of(node: object, carrier: torch.fx.Node) -> bool:
+    """Return True if ``node`` is ``add(exp(neg(carrier)), 1)`` (with the
+    scalar ``1`` on either side of the ``add``).
+
+    Matches the inductor-specific silu decomposition (see
+    ``torch/_inductor/decomposition.py``::``silu``) which expands
+    ``aten.silu.default`` as ``x / (1 + x.neg().exp())`` for exact eager
+    matching. That decomposition expands the silu denominator into
+    ``add(exp(neg(carrier)), 1)`` where the literal ``1`` is the Python
+    int ``1`` after the FX ``1 + tensor`` desugars to
+    ``tensor.__radd__(1)``. ``_classify_silu`` consumes this helper to
+    confirm a ``div`` node has the silu shape.
+    """
+    if not isinstance(node, torch.fx.Node):
+        return False
+    if node.op != "call_function" or node.kwargs:
+        return False
+    if node.target is not torch.ops.aten.add.Tensor:
+        return False
+    if len(node.args) != 2:
+        return False
+    a0, a1 = node.args
+    # ``1`` literal on either side. ``isinstance(True, int)`` is True in
+    # Python; explicitly reject booleans so an unlikely
+    # ``add(exp_node, True)`` is not misread as silu.
+    if (
+        isinstance(a0, torch.fx.Node)
+        and isinstance(a1, int)
+        and not isinstance(a1, bool)
+    ):
+        exp_node, scalar = a0, a1
+    elif (
+        isinstance(a1, torch.fx.Node)
+        and isinstance(a0, int)
+        and not isinstance(a0, bool)
+    ):
+        exp_node, scalar = a1, a0
+    else:
+        return False
+    if scalar != 1:
+        return False
+    if (
+        exp_node.op != "call_function"
+        or exp_node.target is not torch.ops.aten.exp.default
+        or exp_node.kwargs
+        or len(exp_node.args) != 1
+    ):
+        return False
+    neg_node = exp_node.args[0]
+    if not isinstance(neg_node, torch.fx.Node):
+        return False
+    return (
+        neg_node.op == "call_function"
+        and neg_node.target is torch.ops.aten.neg.default
+        and not neg_node.kwargs
+        and len(neg_node.args) == 1
+        and neg_node.args[0] is carrier
+    )
+
+
+def _classify_silu(
+    cur: torch.fx.Node,
+) -> tuple[_UnaryStep, torch.fx.Node] | None:
+    """Fold a decomposed silu activation into one chain step.
+
+    Two FX shapes are accepted:
+
+    - ``mul(carrier, sigmoid(carrier))`` / ``mul(sigmoid(carrier), carrier)``
+      — the core ``torch._decomp`` decomposition for ``aten.silu``
+      (``torch/_decomp/decompositions.py``::``silu``) is
+      ``self * torch.sigmoid(self)``. That FX shape is a non-scalar
+      binary multiply whose two operands point at the same carrier
+      node, so ``_classify_binary`` rejects it.
+
+    - ``div(carrier, add(exp(neg(carrier)), 1))`` — the
+      inductor-specific decomposition
+      (``torch/_inductor/decomposition.py``::``silu``) uses
+      ``x / (1 + x.neg().exp())`` for exact eager matching. The
+      ``aten.silu`` decomp registered into Helion's FX trace comes
+      from this inductor-specific entry (it shadows the core
+      decomposition because ``select_decomp_table`` is built from the
+      inductor lowering tables in ``helion._compiler.device_ir``).
+      This is the shape T13 / T17 / T26 hit in practice.
+
+    The same ``_SILU_TEMPLATE`` (``x * (1 / (1 + exp2(-x * log2_e)))``)
+    renders both forms. The pattern only matches when the inner
+    references point at the *same* carrier FX node — divergent
+    operands fall through to the generic binary classifier.
+
+    Returns ``None`` if ``cur`` is not a silu shape so the caller can
+    fall through to ``_classify_binary`` for ordinary scalar /
+    aux-tensor binaries.
+    """
+    if cur.kwargs:
+        return None
+    if len(cur.args) < 2:
+        return None
+    target = cur.target
+    lhs = cur.args[0]
+    rhs = cur.args[1]
+    # ``mul(carrier, sigmoid(carrier))`` form — core decomposition.
+    if target is torch.ops.aten.mul.Tensor:
+        if not (isinstance(lhs, torch.fx.Node) and isinstance(rhs, torch.fx.Node)):
+            return None
+        if _is_sigmoid_of(rhs, lhs):
+            return _UnaryStep(op_name="silu", template=_SILU_TEMPLATE), lhs
+        if _is_sigmoid_of(lhs, rhs):
+            return _UnaryStep(op_name="silu", template=_SILU_TEMPLATE), rhs
+        return None
+    # ``div(carrier, add(exp(neg(carrier)), 1))`` form — inductor decomp.
+    if target is torch.ops.aten.div.Tensor:
+        if not isinstance(lhs, torch.fx.Node):
+            return None
+        if _is_one_plus_exp_neg_of(rhs, lhs):
+            return _UnaryStep(op_name="silu", template=_SILU_TEMPLATE), lhs
+        return None
+    return None
 
 
 def _classify_binary(
@@ -925,6 +1090,26 @@ def analyze_tcgen05_unary_epilogue_chain(
                 steps.reverse()
                 return Tcgen05UnaryEpilogueChain(steps=tuple(steps)), anchor
             cur = arg
+            continue
+        # Decomposed silu — collapse multi-node silu shapes
+        # (``mul(x, sigmoid(x))`` and the inductor-form
+        # ``div(x, 1 + exp(-x))``) into a single chain step. Run before
+        # the generic binary classifier: the silu shape's two operands
+        # both reach back to the same carrier, neither is a scalar
+        # literal nor an aux-tensor load, so the generic classifier
+        # would reject it. See :func:`_classify_silu` for the accepted
+        # FX shapes and the rationale for matching the inductor form.
+        silu = _classify_silu(cur)
+        if silu is not None:
+            step, carrier = silu
+            steps.append(step)
+            anchor = walk_carrier_to_tcgen05_matmul(
+                carrier, target_fx_nodes, inner_outputs_by_graph_id
+            )
+            if anchor is not None:
+                steps.reverse()
+                return Tcgen05UnaryEpilogueChain(steps=tuple(steps)), anchor
+            cur = carrier
             continue
         # Binary ops (scalar literal *or* aux-tensor load on the
         # other side). The classifier rejects multi-tensor cases

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -115,6 +115,13 @@ from .tcgen05_constants import TCGEN05_TARGET6_TVM_FFI_C_STAGES
 from .tcgen05_constants import TCGEN05_TARGET7_TVM_FFI_AB_STAGES
 from .tcgen05_constants import TCGEN05_TARGET7_TVM_FFI_BLOCK_K
 from .tcgen05_constants import TCGEN05_TARGET7_TVM_FFI_C_STAGES
+from .tcgen05_constants import TCGEN05_TARGET9_TVM_FFI_AB_STAGES
+from .tcgen05_constants import TCGEN05_TARGET9_TVM_FFI_BLOCK_K
+from .tcgen05_constants import TCGEN05_TARGET9_TVM_FFI_C_STAGES
+from .tcgen05_constants import TCGEN05_TARGET10_TVM_FFI_AB_STAGES
+from .tcgen05_constants import TCGEN05_TARGET10_TVM_FFI_BLOCK_K
+from .tcgen05_constants import TCGEN05_TARGET10_TVM_FFI_C_STAGES
+from .tcgen05_constants import TCGEN05_TARGET10_TVM_FFI_SHAPE
 from .tcgen05_constants import TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
@@ -1875,15 +1882,15 @@ def _trace_mma_to_store_dtype(
     return None
 
 
-def _is_rank1_bf16_bias_load(node: Node) -> bool:
-    """``helion.language.load`` of a rank-1 bf16 GMEM tensor.
+def _is_rank1_bias_load_of_dtype(node: Node, expected_dtype: torch.dtype) -> bool:
+    """``helion.language.load`` of a rank-1 ``expected_dtype`` GMEM tensor.
 
-    Shared by the T2 (``acc + bias[n]``) and T6 (``relu(acc + bias[n])``)
-    direct-entry walkers below. The runtime validator only admits bf16
-    bias tensors, so the codegen walker is gated on dtype too — a non-bf16
-    bias kernel at T2/T6 shape must not reach the direct-entry path (it
-    would otherwise fail loudly at launch instead of falling back to the
-    wrapper-dispatch route at codegen).
+    Shared by the T2 (``acc + bias[n]``), T6 (``relu(acc + bias[n])``),
+    and T10 (fp16/bf16 2048³ bias) direct-entry codegen walkers. The
+    bias dtype is pinned to the caller-supplied operand dtype so a
+    fp16 bias against a bf16-operand matmul (or vice versa) is rejected
+    at the codegen walker boundary instead of only at the runtime
+    validator.
     """
     from ...language import memory_ops
 
@@ -1895,7 +1902,7 @@ def _is_rank1_bf16_bias_load(node: Node) -> bool:
     host_val = host_arg.meta.get("val")
     if not isinstance(host_val, torch.Tensor):
         return False
-    return host_val.ndim == 1 and host_val.dtype == torch.bfloat16
+    return host_val.ndim == 1 and host_val.dtype == expected_dtype
 
 
 def _trace_mma_to_single_cast_store_dtype(
@@ -1993,9 +2000,13 @@ def _trace_mma_to_single_relu_store_dtype(
 
 
 def _validate_bias_add_chain(
-    add_node: Node, mma_set: set[Node], inner_outputs_index: dict
+    add_node: Node,
+    mma_set: set[Node],
+    inner_outputs_index: dict,
+    *,
+    expected_bias_dtype: torch.dtype,
 ) -> bool:
-    """``aten.add.Tensor(carrier, rank-1 bf16 bias_load)`` (or commuted)."""
+    """``aten.add.Tensor(carrier, rank-1 ``expected_bias_dtype`` bias_load)`` (or commuted)."""
     from .cute_fx_walk import walk_carrier_to_tcgen05_matmul
 
     if (
@@ -2009,19 +2020,21 @@ def _validate_bias_add_chain(
     if not isinstance(add_lhs, Node) or not isinstance(add_rhs, Node):
         return False
     # Either side of the add can be the carrier (commutative); the other
-    # must be a rank-1 bias load.
+    # must be a rank-1 bias load whose dtype matches the operand dtype.
     carrier_first = walk_carrier_to_tcgen05_matmul(
         add_lhs, mma_set, inner_outputs_index
-    ) is not None and _is_rank1_bf16_bias_load(add_rhs)
+    ) is not None and _is_rank1_bias_load_of_dtype(add_rhs, expected_bias_dtype)
     carrier_second = walk_carrier_to_tcgen05_matmul(
         add_rhs, mma_set, inner_outputs_index
-    ) is not None and _is_rank1_bf16_bias_load(add_lhs)
+    ) is not None and _is_rank1_bias_load_of_dtype(add_lhs, expected_bias_dtype)
     return carrier_first or carrier_second
 
 
 def _trace_mma_to_single_bias_store_dtype(
     mma_node: Node,
     graphs: list[GraphInfo],
+    *,
+    expected_bias_dtype: torch.dtype,
 ) -> torch.dtype | None:
     """Return the store dtype only for exactly one ``acc + bias[n]`` + cast store.
 
@@ -2030,7 +2043,7 @@ def _trace_mma_to_single_bias_store_dtype(
     ``aten.add.Tensor`` between the MMA carrier and the cast that feeds
     the store, where one of the add's operands is the MMA carrier and the
     other is a rank-1 ``helion.language.load`` against a GMEM tensor with
-    shape ``(N,)``.
+    shape ``(N,)`` and dtype ``expected_bias_dtype``.
 
     Mutually exclusive with the identity and relu walkers: identity
     rejects any binary op in the chain, and relu requires a single-arg
@@ -2038,34 +2051,30 @@ def _trace_mma_to_single_bias_store_dtype(
     (``acc + bias[n] -> relu -> convert -> store``) chain is rejected
     because the cast feeds off a relu rather than the add.
     """
+
+    def _validate(cast_input: Node, mma_set: set[Node], idx: dict) -> bool:
+        return _validate_bias_add_chain(
+            cast_input, mma_set, idx, expected_bias_dtype=expected_bias_dtype
+        )
+
     return _trace_mma_to_single_cast_store_dtype(
         mma_node,
         graphs,
         extra_trace_through=frozenset({torch.ops.aten.add.Tensor}),
-        validate_cast_input=_validate_bias_add_chain,
+        validate_cast_input=_validate,
     )
 
 
 def _trace_mma_to_single_bias_relu_store_dtype(
     mma_node: Node,
     graphs: list[GraphInfo],
+    *,
+    expected_bias_dtype: torch.dtype,
 ) -> torch.dtype | None:
     """Return the store dtype only for one ``relu(acc + bias[n])`` + cast store.
 
-    The chain accepted here is ``mma -> aten.add.Tensor(carrier,
-    bias_load) -> aten.relu.default -> convert_element_type -> store``:
-    exactly one ``aten.add.Tensor`` (with a rank-1 bf16 GMEM bias load on
-    one side and the MMA carrier on the other) followed by exactly one
-    ``aten.relu.default`` between the MMA carrier and the cast that feeds
-    the store. Mirrors ``_trace_mma_to_single_bias_store_dtype`` but
-    additionally requires the relu wrapper, gating the Target 6 TVM-FFI
-    direct-entry seed without broadening the T2 (no relu) or T4 (no bias)
-    walkers.
-
-    Mutually exclusive with the identity (no binary op), relu (no add),
-    and bias (no relu) walkers via the chain shape: T6's ``cast_input``
-    is a relu whose input is a bias add, while the T2 walker requires
-    the cast_input to be the bias add itself.
+    Same as :func:`_trace_mma_to_single_bias_store_dtype` but with an
+    intervening ``aten.relu.default`` between the add and the cast.
     """
 
     def _validate(cast_input: Node, mma_set: set[Node], idx: dict) -> bool:
@@ -2081,7 +2090,9 @@ def _trace_mma_to_single_bias_relu_store_dtype(
         relu_input = cast_input.args[0]
         if not isinstance(relu_input, Node):
             return False
-        return _validate_bias_add_chain(relu_input, mma_set, idx)
+        return _validate_bias_add_chain(
+            relu_input, mma_set, idx, expected_bias_dtype=expected_bias_dtype
+        )
 
     return _trace_mma_to_single_cast_store_dtype(
         mma_node,
@@ -3269,14 +3280,36 @@ def _emit_mma_pipeline(
         aux_descriptors_compatible_with_explicit_epi_tile = all(
             d.broadcast_axis == 1 for d in aux_tensor_descriptors_value
         )
+        # T10 (cycle 42) admits fp16 operands at the validated 2048³
+        # bias-store shape. The explicit-epi-tile dtype gate stays
+        # bf16-only for T1-T9; only T10's shape+bias-store unlocks fp16
+        # here. Compute the bias-store fingerprint early so the dtype gate
+        # below can require the bias chain — without it a fp16 identity
+        # or relu kernel at 2048³ would otherwise slip through this gate.
+        _t10_bias_store_present = (
+            _trace_mma_to_single_bias_store_dtype(
+                fx_node,
+                cg.codegen_graphs,
+                expected_bias_dtype=input_dtype,
+            )
+            is not None
+        )
+        explicit_epi_tile_t10_fp16_ok = (
+            input_dtype == torch.float16
+            and epi_elem_dtype_str == "cutlass.Float16"
+            and (m_size, n_size, k_total_size) == TCGEN05_TARGET10_TVM_FFI_SHAPE
+            and _t10_bias_store_present
+        )
+        explicit_epi_tile_bf16_ok = (
+            input_dtype == torch.bfloat16 and epi_elem_dtype_str == "cutlass.BFloat16"
+        )
         if explicit_epi_tile_requested:
             if not (
                 tcgen05_static_full_tiles
                 and tcgen05_is_two_cta
                 and bm == TCGEN05_TWO_CTA_BLOCK_M
                 and bn == TCGEN05_TWO_CTA_BLOCK_N
-                and input_dtype == torch.bfloat16
-                and epi_elem_dtype_str == "cutlass.BFloat16"
+                and (explicit_epi_tile_bf16_ok or explicit_epi_tile_t10_fp16_ok)
                 and aux_descriptors_compatible_with_explicit_epi_tile
             ):
                 raise exc.BackendUnsupported(
@@ -3284,6 +3317,7 @@ def _emit_mma_pipeline(
                     "explicit tcgen05 epilogue tile overrides are validated only "
                     "for static-full bf16 pure matmul CtaGroup.TWO kernels "
                     "(rank-1 rowvec aux tensors admitted for the T2 bias "
+                    "envelope; fp16 admitted only for the T10 2048³ bias "
                     "envelope)",
                 )
             if (
@@ -3315,10 +3349,11 @@ def _emit_mma_pipeline(
                 and bn == TCGEN05_TWO_CTA_BLOCK_N
                 # T1 validated at bk=64, T4 validated at bk=128. Both share
                 # the bm=bn=256, cluster_m=2, cluster_n=1 envelope and use
-                # the same flat-role launch shape.
+                # the same flat-role launch shape. T10 (cycle 42) reuses
+                # the same flat-role shape at fp16 operand dtype, pinned
+                # to the 2048³ bias envelope below.
                 and bk in (64, 128)
-                and input_dtype == torch.bfloat16
-                and epi_elem_dtype_str == "cutlass.BFloat16"
+                and (explicit_epi_tile_bf16_ok or explicit_epi_tile_t10_fp16_ok)
                 and aux_descriptors_compatible_with_explicit_epi_tile
                 and tcgen05_use_tma_store_epilogue
                 and tcgen05_warp_spec.scheduler_warps == 0
@@ -3330,7 +3365,8 @@ def _emit_mma_pipeline(
                     "cute",
                     f"{TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY}=True requires "
                     "the guarded static-full bf16 pure matmul CtaGroup.TWO "
-                    "256x256 bk in {64,128} explicit-epilogue-tile path",
+                    "256x256 bk in {64,128} explicit-epilogue-tile path "
+                    "(fp16 admitted only for the T10 2048³ bias envelope)",
                 )
         tcgen05_use_pure_clc_scheduler_object = (
             tcgen05_requested_pure_clc_scheduler_object
@@ -3383,13 +3419,25 @@ def _emit_mma_pipeline(
                 if fx_node is not None
                 else None
             )
+            # Pin the bias-load dtype to the operand dtype so a kernel
+            # with mismatched operand/bias dtypes (e.g. bf16 operands +
+            # fp16 bias smuggled in) is rejected at the codegen walker
+            # rather than only at the runtime validator.
             bias_store_dtype = (
-                _trace_mma_to_single_bias_store_dtype(fx_node, cg.codegen_graphs)
+                _trace_mma_to_single_bias_store_dtype(
+                    fx_node,
+                    cg.codegen_graphs,
+                    expected_bias_dtype=input_dtype,
+                )
                 if fx_node is not None
                 else None
             )
             bias_relu_store_dtype = (
-                _trace_mma_to_single_bias_relu_store_dtype(fx_node, cg.codegen_graphs)
+                _trace_mma_to_single_bias_relu_store_dtype(
+                    fx_node,
+                    cg.codegen_graphs,
+                    expected_bias_dtype=input_dtype,
+                )
                 if fx_node is not None
                 else None
             )
@@ -3498,6 +3546,49 @@ def _emit_mma_pipeline(
                 and acc_expr is None
                 and identity_store_dtype == input_dtype
             )
+            # T9 (2048x2048x2048) uses identity store at the same
+            # bk=128 (ab=3, c=2) stage tuple as T3/T4/T5/T6/T7. The
+            # K=2048 problem yields ``k_tile_count = 16`` (same as
+            # T2/T3/T6/T7); this fits the ``TCGEN05_TWO_CTA_MAX_K_TILES``
+            # cap. T9 is the square 2048³ identity-store envelope
+            # (M_tiles*N_tiles = 8*8 = 64 work clusters). The
+            # identity-store gate is shared with the T1/T3/T5/T7 seeds;
+            # the shape gate below pins it to T9 so a T1/T3/T5/T7 host
+            # function does not get a T9 admission and vice versa.
+            target9_envelope_ok = (
+                (m_size, n_size, k_total_size) == (2048, 2048, 2048)
+                and bk == TCGEN05_TARGET9_TVM_FFI_BLOCK_K
+                and (tcgen05_ab_stage_count_value, tcgen05_c_stage_count_value)
+                == (TCGEN05_TARGET9_TVM_FFI_AB_STAGES, TCGEN05_TARGET9_TVM_FFI_C_STAGES)
+                and acc_expr is None
+                and identity_store_dtype == input_dtype
+            )
+            # T10 (2048x2048x2048) uses a rank-1 trailing-axis (rowvec)
+            # ``acc + bias[n]`` epilogue at the same bk=128 (ab=3, c=2)
+            # stage tuple as T2 but at the square 2048³ shape (T9's
+            # shape, T2's bias add). T10 is the only direct-entry
+            # envelope that admits fp16 operands — every other
+            # envelope is pinned to bf16 via the upstream
+            # explicit-epi-tile / flat-role-coordinates gates and via
+            # the per-target ``input_dtype in (bf16, fp16)`` check
+            # below. The bias-store walker confirms exactly one
+            # ``aten.add.Tensor(carrier, bias_load)`` in the chain;
+            # the cycle-42 walker is dtype-pinned to the operand
+            # dtype so an fp16-bias kernel against a bf16-operand
+            # matmul (or vice versa) is rejected at the host detector
+            # before it can produce a T10 seed.
+            target10_envelope_ok = (
+                (m_size, n_size, k_total_size) == TCGEN05_TARGET10_TVM_FFI_SHAPE
+                and bk == TCGEN05_TARGET10_TVM_FFI_BLOCK_K
+                and (tcgen05_ab_stage_count_value, tcgen05_c_stage_count_value)
+                == (
+                    TCGEN05_TARGET10_TVM_FFI_AB_STAGES,
+                    TCGEN05_TARGET10_TVM_FFI_C_STAGES,
+                )
+                and acc_expr is None
+                and bias_store_dtype == input_dtype
+                and input_dtype in (torch.bfloat16, torch.float16)
+            )
             common_ok = (
                 tcgen05_use_flat_role_coordinates
                 and TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY in df.config
@@ -3514,8 +3605,9 @@ def _emit_mma_pipeline(
                         "TVM-FFI flat-role seed (pure-CLC scheduler "
                         "object is not validated for T2 bias-store, "
                         "T3 identity-store, T4 relu-store, T5 "
-                        "identity-store, T6 bias-relu-store, or T7 "
-                        "identity-store)",
+                        "identity-store, T6 bias-relu-store, T7 "
+                        "identity-store, T9 identity-store, or T10 "
+                        "fp16/bf16 bias-store)",
                     )
             if tcgen05_use_direct_entry_plan:
                 direct_entry_ok = common_ok and (
@@ -3526,6 +3618,8 @@ def _emit_mma_pipeline(
                     or target2_envelope_ok
                     or target6_envelope_ok
                     or target7_envelope_ok
+                    or target9_envelope_ok
+                    or target10_envelope_ok
                 )
                 if not direct_entry_ok:
                     raise exc.BackendUnsupported(
@@ -3533,8 +3627,9 @@ def _emit_mma_pipeline(
                         f"{TCGEN05_DIRECT_ENTRY_PLAN_CONFIG_KEY}=True "
                         "requires the validated T1 identity-store, T2 "
                         "bias-store, T3 identity-store, T4 relu-store, "
-                        "T5 identity-store, T6 bias-relu-store, or T7 "
-                        "identity-store TVM-FFI flat-role seed",
+                        "T5 identity-store, T6 bias-relu-store, T7 "
+                        "identity-store, T9 identity-store, or T10 "
+                        "fp16/bf16 bias-store TVM-FFI flat-role seed",
                     )
         # Cycle-16 H3 Option B (staged): the productive
         # ``DYNAMIC_PERSISTENT`` codegen path is staged for cycle 17.
@@ -4310,12 +4405,13 @@ def _emit_mma_pipeline(
                         # the active stage with the existing
                         # ``partition_C → flat_divide(epi_tile) →
                         # partition_D`` pipeline, then lane-0
-                        # releases. Per-subtile staging keeps the
-                        # SMEM footprint small enough that
-                        # cluster_m=2 + ``tcgen05_ab_stages=3`` still
-                        # fits the 228 KB B200 cap (cycle 2b of the
-                        # producer-body split,
-                        # ``cute_plan.md`` §7.5.3.2).
+                        # releases. Per-subtile staging reduces the
+                        # epilogue SMEM footprint vs whole-tile
+                        # staging, but the AB ring at ``bk=128`` plus
+                        # the aux/D-store rings still overshoots the
+                        # 232 KB B200 cap at ``cluster_m=2 +
+                        # tcgen05_ab_stages=3`` (cycle 48 measured
+                        # 263 KB used at bk=128; bk=64 fits).
                         tile_shape_expr=tcgen05_plan.epi_tile,
                         # Single C-input warp = 32 lanes (validator
                         # pins ``c_input_warp_count`` to ``{0, 1}``

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -128,6 +128,14 @@ from .tcgen05_constants import TCGEN05_TARGET7_TVM_FFI_AB_STAGES
 from .tcgen05_constants import TCGEN05_TARGET7_TVM_FFI_BLOCK_K
 from .tcgen05_constants import TCGEN05_TARGET7_TVM_FFI_C_STAGES
 from .tcgen05_constants import TCGEN05_TARGET7_TVM_FFI_SHAPE
+from .tcgen05_constants import TCGEN05_TARGET9_TVM_FFI_AB_STAGES
+from .tcgen05_constants import TCGEN05_TARGET9_TVM_FFI_BLOCK_K
+from .tcgen05_constants import TCGEN05_TARGET9_TVM_FFI_C_STAGES
+from .tcgen05_constants import TCGEN05_TARGET9_TVM_FFI_SHAPE
+from .tcgen05_constants import TCGEN05_TARGET10_TVM_FFI_AB_STAGES
+from .tcgen05_constants import TCGEN05_TARGET10_TVM_FFI_BLOCK_K
+from .tcgen05_constants import TCGEN05_TARGET10_TVM_FFI_C_STAGES
+from .tcgen05_constants import TCGEN05_TARGET10_TVM_FFI_SHAPE
 from .tcgen05_constants import TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
@@ -233,6 +241,11 @@ class CuteTcgen05Config:
         self.identity_matmul_store_detected: bool = False
         self.relu_matmul_store_detected: bool = False
         self.bias_matmul_store_detected: bool = False
+        # T10-only bias detection: T10 admits fp16 bias against fp16
+        # operands. Kept as a separate flag so T2/T6 — both bf16-only
+        # at the matmul-fact level — cannot accidentally enable on a
+        # fp16 bias load (cycle 42 P2 fix; cycle 40 perturbation lesson).
+        self.bias_matmul_store_fp16_detected: bool = False
         self.bias_relu_matmul_store_detected: bool = False
         self.target1_tvm_ffi_seed_enabled: bool = False
         self.target2_tvm_ffi_seed_enabled: bool = False
@@ -241,6 +254,8 @@ class CuteTcgen05Config:
         self.target5_tvm_ffi_seed_enabled: bool = False
         self.target6_tvm_ffi_seed_enabled: bool = False
         self.target7_tvm_ffi_seed_enabled: bool = False
+        self.target9_tvm_ffi_seed_enabled: bool = False
+        self.target10_tvm_ffi_seed_enabled: bool = False
         self.cluster_m_search_choices: tuple[int, ...] | None = None
         self.cluster_m2_search_constraints: Tcgen05ClusterM2SearchConstraints | None = (
             None
@@ -444,6 +459,53 @@ class CuteTcgen05Config:
                 cast("PidTypeLiteral", TCGEN05_TWO_CTA_SEED_PID_TYPE),
             )
 
+    def allow_target9_tvm_ffi_seed(self) -> None:
+        # T9 mirrors T3/T5/T7's envelope at (2048, 2048, 2048)
+        # identity-store shape; shape fact distinguishes it from T1/T3/T5/T7.
+        if not self.identity_matmul_store_detected:
+            return
+        if not self._has_target9_tvm_ffi_matmul_fact():
+            return
+        target_k = TCGEN05_TARGET9_TVM_FFI_SHAPE[2]
+        self.target9_tvm_ffi_seed_enabled = True
+        self.cluster_m2_search_constraints = Tcgen05ClusterM2SearchConstraints(
+            static_k=target_k,
+            max_k_tiles=TCGEN05_TWO_CTA_MAX_K_TILES,
+        )
+        self.cluster_m_search_choices = (1, 2)
+        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
+            self.allowed_pid_types = (
+                *self.allowed_pid_types,
+                cast("PidTypeLiteral", TCGEN05_TWO_CTA_SEED_PID_TYPE),
+            )
+
+    def allow_target10_tvm_ffi_seed(self) -> None:
+        # T10 mirrors T2's bias-store envelope at (2048, 2048, 2048)
+        # with fp16-or-bf16 operands; shape + bias-store + matmul fact
+        # dtype gate distinguishes it from T2 (4096x2048x2048 bf16) and
+        # the square identity-store T9. T10 admits both the bf16
+        # bias-store flag (matches T2's host detector) and a separate
+        # fp16 bias-store flag — T2 cannot fire on fp16 because its
+        # detector is bf16-pinned.
+        if not (
+            self.bias_matmul_store_detected or self.bias_matmul_store_fp16_detected
+        ):
+            return
+        if not self._has_target10_tvm_ffi_matmul_fact():
+            return
+        target_k = TCGEN05_TARGET10_TVM_FFI_SHAPE[2]
+        self.target10_tvm_ffi_seed_enabled = True
+        self.cluster_m2_search_constraints = Tcgen05ClusterM2SearchConstraints(
+            static_k=target_k,
+            max_k_tiles=TCGEN05_TWO_CTA_MAX_K_TILES,
+        )
+        self.cluster_m_search_choices = (1, 2)
+        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
+            self.allowed_pid_types = (
+                *self.allowed_pid_types,
+                cast("PidTypeLiteral", TCGEN05_TWO_CTA_SEED_PID_TYPE),
+            )
+
     @staticmethod
     def cluster_m2_bk_is_valid(
         bk: int, constraints: Tcgen05ClusterM2SearchConstraints
@@ -553,16 +615,40 @@ class CuteTcgen05Config:
                 ]
         return Config(**seed_config)
 
-    def _aux_tma_search_enabled(self) -> bool:
-        # The TMA aux producer is currently admitted only for the validated
-        # Target8-style edge+K-tail family. Exact-shape aux tensors use the
-        # aux-TMA producer on both full and partial-output tiles; non-staged
-        # aux operands remain on the direct guarded load path.
+    def _aux_tma_edge_search_enabled(self) -> bool:
+        # The TMA aux producer's original admission: the validated Target8-style
+        # double-edge + K-tail family with ``cluster_m=2``. The CLC-persistent
+        # variants and edge-perf knobs remain pinned to this slice.
         constraints = self.cluster_m2_search_constraints
         return (
             self.exact_shape_aux_kernel_detected
             and constraints is not None
             and constraints.allow_edge_k_tail_family
+        )
+
+    def _aux_tma_full_tile_search_enabled(self) -> bool:
+        # Cycle 46: also admit aux-TMA on full-tile cluster_m=2 problems
+        # (T14/T20/T25/T28 residual_add family). The codegen-side gate at
+        # ``cute_mma.py`` ``tcgen05_static_output_tiles`` already accepts
+        # full-tile shapes; only the search-space gate was excluding them.
+        # Edge-perf knobs (``_set_clc_aux_tma_edge_perf_knobs``) and
+        # CLC-persistent variants stay pinned to ``_aux_tma_edge_search_enabled``
+        # so this widening does not perturb the 5000³ T12 family.
+        constraints = self.cluster_m2_search_constraints
+        return (
+            self.exact_shape_aux_kernel_detected
+            and constraints is not None
+            and not constraints.allow_edge_k_tail_family
+        )
+
+    def _aux_tma_search_enabled(self) -> bool:
+        # The TMA aux producer is admitted on either the edge+K-tail family or
+        # the full-tile cluster_m=2 family. Exact-shape aux tensors use the
+        # aux-TMA producer on both full and partial-output tiles; non-staged
+        # aux operands remain on the direct guarded load path.
+        return (
+            self._aux_tma_edge_search_enabled()
+            or self._aux_tma_full_tile_search_enabled()
         )
 
     def _aux_tma_seed_config(self, c_input_seed: Config) -> Config | None:
@@ -768,6 +854,32 @@ class CuteTcgen05Config:
             and fact.static_k == target_k
             and fact.lhs_dtype == torch.bfloat16
             and fact.rhs_dtype == torch.bfloat16
+            for fact in self.config_spec.matmul_facts
+        )
+
+    def _has_target9_tvm_ffi_matmul_fact(self) -> bool:
+        target_m, target_n, target_k = TCGEN05_TARGET9_TVM_FFI_SHAPE
+        return any(
+            fact.static_m == target_m
+            and fact.static_n == target_n
+            and fact.static_k == target_k
+            and fact.lhs_dtype == torch.bfloat16
+            and fact.rhs_dtype == torch.bfloat16
+            for fact in self.config_spec.matmul_facts
+        )
+
+    def _has_target10_tvm_ffi_matmul_fact(self) -> bool:
+        # T10 admits fp16 and bf16 operands at the square 2048³ bias
+        # shape. ``lhs_dtype == rhs_dtype`` keeps the operand dtype
+        # pinned so the runtime validator can derive the admitted
+        # operand dtype from a single plan field.
+        target_m, target_n, target_k = TCGEN05_TARGET10_TVM_FFI_SHAPE
+        return any(
+            fact.static_m == target_m
+            and fact.static_n == target_n
+            and fact.static_k == target_k
+            and fact.lhs_dtype in (torch.bfloat16, torch.float16)
+            and fact.lhs_dtype == fact.rhs_dtype
             for fact in self.config_spec.matmul_facts
         )
 
@@ -1311,6 +1423,167 @@ class CuteTcgen05Config:
         }
         return Config(**seed_config)
 
+    def _target10_tvm_ffi_seed_config(self) -> Config | None:
+        if not self.target10_tvm_ffi_seed_enabled:
+            return None
+        # T10's rowvec bias sets ``aux_kernel_detected`` True (same as T2).
+        # The bias-store gate (bf16 or fp16 variant) keeps T10 mutually
+        # exclusive with identity/relu/bias_relu stores.
+        if not (
+            self.bias_matmul_store_detected or self.bias_matmul_store_fp16_detected
+        ):
+            return None
+        if not self._has_target10_tvm_ffi_matmul_fact():
+            return None
+        constraints = self.cluster_m2_search_constraints
+        if constraints is None or constraints.allow_edge_k_tail_family:
+            return None
+        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
+            return None
+        if len(self.config_spec.block_sizes) != 3:
+            return None
+        # Accept indexing length 3 (no closure) or 4 (with bias closure).
+        if self.config_spec.indexing.length not in (3, 4):
+            return None
+        if not self.cluster_m2_bk_is_valid(
+            TCGEN05_TARGET10_TVM_FFI_BLOCK_K, constraints
+        ):
+            return None
+        if not self.ab_stages_three_fits(
+            bm=TCGEN05_TWO_CTA_BLOCK_M,
+            bn=TCGEN05_TWO_CTA_BLOCK_N,
+            bk=TCGEN05_TARGET10_TVM_FFI_BLOCK_K,
+            cluster_m=2,
+            ab_stages=TCGEN05_TARGET10_TVM_FFI_AB_STAGES,
+        ):
+            return None
+        range_count = len(self.config_spec.range_unroll_factors)
+        # Cycle-41 force-config measurements (see cycle 42 task brief):
+        # role_local_monolithic + c_input=0 + l2_groupings=[2] + ab=3
+        # measured 742.4 TF / +3.7% gap vs Quack's 770.9 TF on the T22
+        # (2048³ fp16 bias) target, closing 21pp of the previous gap.
+        # The cycle 40 alternative (ab=2 + role_local_with_sched +
+        # c_input=1 + l2_groupings=[2]) measured at HEAD level (640 TF),
+        # so we explicitly stay on monolithic + c_input=0 here.
+        indexing_length = self.config_spec.indexing.length
+        seed_config: dict[str, Any] = {
+            "block_sizes": [
+                TCGEN05_TWO_CTA_BLOCK_M,
+                TCGEN05_TWO_CTA_BLOCK_N,
+                TCGEN05_TARGET10_TVM_FFI_BLOCK_K,
+            ],
+            "indexing": ["tensor_descriptor"] * indexing_length,
+            "l2_groupings": [2],
+            "loop_orders": [[0, 1]],
+            "num_stages": 4,
+            "num_warps": 8,
+            "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
+            "range_flattens": [None] * range_count,
+            "range_multi_buffers": [None] * range_count,
+            "range_num_stages": [0] * range_count,
+            "range_unroll_factors": [1] * range_count,
+            "range_warp_specializes": [None] * range_count,
+            "tcgen05_cluster_m": 2,
+            "tcgen05_cluster_n": 1,
+            "tcgen05_ab_stages": TCGEN05_TARGET10_TVM_FFI_AB_STAGES,
+            "tcgen05_acc_stages": 2,
+            "tcgen05_c_stages": TCGEN05_TARGET10_TVM_FFI_C_STAGES,
+            TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY: 1,
+            "tcgen05_num_epi_warps": 4,
+            TCGEN05_STRATEGY_CONFIG_KEY: Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
+            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
+                Tcgen05PersistenceModel.STATIC_PERSISTENT.value
+            ),
+            TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: (
+                Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
+            ),
+            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: 128,
+            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: 32,
+            TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: 32,
+            TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY: True,
+            TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True,
+        }
+        return Config(**seed_config)
+
+    def _target9_tvm_ffi_seed_config(self) -> Config | None:
+        if not self.target9_tvm_ffi_seed_enabled:
+            return None
+        if self.aux_kernel_detected:
+            return None
+        # T9 shares the identity-store gate with T1/T3/T5/T7 but at the
+        # T9 shape. The fact check below distinguishes T9 from T1/T3/T5/T7.
+        if not self.identity_matmul_store_detected:
+            return None
+        if not self._has_target9_tvm_ffi_matmul_fact():
+            return None
+        constraints = self.cluster_m2_search_constraints
+        if constraints is None or constraints.allow_edge_k_tail_family:
+            return None
+        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
+            return None
+        if len(self.config_spec.block_sizes) != 3:
+            return None
+        if self.config_spec.indexing.length != 3:
+            return None
+        if not self.cluster_m2_bk_is_valid(
+            TCGEN05_TARGET9_TVM_FFI_BLOCK_K, constraints
+        ):
+            return None
+        if not self.ab_stages_three_fits(
+            bm=TCGEN05_TWO_CTA_BLOCK_M,
+            bn=TCGEN05_TWO_CTA_BLOCK_N,
+            bk=TCGEN05_TARGET9_TVM_FFI_BLOCK_K,
+            cluster_m=2,
+            ab_stages=TCGEN05_TARGET9_TVM_FFI_AB_STAGES,
+        ):
+            return None
+        range_count = len(self.config_spec.range_unroll_factors)
+        # T9 mirrors T3/T5/T7's seed knobs at the square 2048x2048x2048
+        # identity-store shape; ``l2_groupings=[2]`` is inherited pending
+        # a T9 sweep.
+        seed_config: dict[str, Any] = {
+            "block_sizes": [
+                TCGEN05_TWO_CTA_BLOCK_M,
+                TCGEN05_TWO_CTA_BLOCK_N,
+                TCGEN05_TARGET9_TVM_FFI_BLOCK_K,
+            ],
+            "indexing": [
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "tensor_descriptor",
+            ],
+            "l2_groupings": [2],
+            "loop_orders": [[0, 1]],
+            "num_stages": 4,
+            "num_warps": 8,
+            "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
+            "range_flattens": [None] * range_count,
+            "range_multi_buffers": [None] * range_count,
+            "range_num_stages": [0] * range_count,
+            "range_unroll_factors": [1] * range_count,
+            "range_warp_specializes": [None] * range_count,
+            "tcgen05_cluster_m": 2,
+            "tcgen05_cluster_n": 1,
+            "tcgen05_ab_stages": TCGEN05_TARGET9_TVM_FFI_AB_STAGES,
+            "tcgen05_acc_stages": 2,
+            "tcgen05_c_stages": TCGEN05_TARGET9_TVM_FFI_C_STAGES,
+            TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY: 1,
+            "tcgen05_num_epi_warps": 4,
+            TCGEN05_STRATEGY_CONFIG_KEY: Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
+            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
+                Tcgen05PersistenceModel.STATIC_PERSISTENT.value
+            ),
+            TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: (
+                Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
+            ),
+            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: 128,
+            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: 32,
+            TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: 32,
+            TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY: True,
+            TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True,
+        }
+        return Config(**seed_config)
+
     def autotune_seed_configs(self) -> list[Config]:
         seeds: list[Config] = []
         target1_tvm_ffi_seed = self._target1_tvm_ffi_seed_config()
@@ -1334,6 +1607,12 @@ class CuteTcgen05Config:
         target7_tvm_ffi_seed = self._target7_tvm_ffi_seed_config()
         if target7_tvm_ffi_seed is not None:
             seeds.append(target7_tvm_ffi_seed)
+        target9_tvm_ffi_seed = self._target9_tvm_ffi_seed_config()
+        if target9_tvm_ffi_seed is not None:
+            seeds.append(target9_tvm_ffi_seed)
+        target10_tvm_ffi_seed = self._target10_tvm_ffi_seed_config()
+        if target10_tvm_ffi_seed is not None:
+            seeds.append(target10_tvm_ffi_seed)
         c_input_seed = self._c_input_seed_config()
         if c_input_seed is not None:
             seeds.append(c_input_seed)
@@ -1514,9 +1793,16 @@ class CuteTcgen05Config:
         if not self._aux_tma_search_enabled():
             config[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY] = TCGEN05_AUX_LOAD_MODE_SIMT
             return
+        # Aux-TMA is kept when the projected cluster_m=2 candidate matches either
+        # the validated edge+K-tail shape or the cycle-46 full-tile shape, and
+        # the strategy is the ROLE_LOCAL_WITH_SCHEDULER + c-input warp combo that
+        # the aux-TMA producer warp requires.
+        if not self._is_with_scheduler_c_input_config(config):
+            config[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY] = TCGEN05_AUX_LOAD_MODE_SIMT
+            return
         if not (
             self._is_validated_cluster_m2_edge_search_candidate(config)
-            and self._is_with_scheduler_c_input_config(config)
+            or self._is_validated_cluster_m2_full_tile_search_candidate(config)
         ):
             config[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY] = TCGEN05_AUX_LOAD_MODE_SIMT
 
@@ -1530,8 +1816,13 @@ class CuteTcgen05Config:
         )
 
     def _clc_persistence_search_enabled(self) -> bool:
-        """CLC search is the sm100+ slice of the aux-TMA edge+K-tail gate."""
-        if not self._aux_tma_search_enabled():
+        """CLC search is the sm100+ slice of the aux-TMA edge+K-tail gate.
+
+        Cycle 46 widened ``_aux_tma_search_enabled`` to also admit the full-tile
+        cluster_m=2 family, but the CLC-persistent perf knobs and validated
+        candidate shape are still scoped to ``_aux_tma_edge_search_enabled``.
+        """
+        if not self._aux_tma_edge_search_enabled():
             return False
         capability = self.config_spec.target_device_capability
         if capability is None:
@@ -1585,6 +1876,8 @@ class CuteTcgen05Config:
             or self._is_target5_tvm_ffi_seed_config(config)
             or self._is_target6_tvm_ffi_seed_config(config)
             or self._is_target7_tvm_ffi_seed_config(config)
+            or self._is_target9_tvm_ffi_seed_config(config)
+            or self._is_target10_tvm_ffi_seed_config(config)
         ):
             return {
                 "indexing",
@@ -1775,6 +2068,56 @@ class CuteTcgen05Config:
             and config.get(TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY) == 32
         )
 
+    @staticmethod
+    def _is_target9_tvm_ffi_seed_config(config: dict[str, object]) -> bool:
+        # T9 mirrors T3/T4/T5/T6/T7 at the bk=128 stage tuple; the
+        # identity-store gate happens upstream.
+        return (
+            config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is True
+            and config.get(TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY) is True
+            and config.get("block_sizes")
+            == [
+                TCGEN05_TWO_CTA_BLOCK_M,
+                TCGEN05_TWO_CTA_BLOCK_N,
+                TCGEN05_TARGET9_TVM_FFI_BLOCK_K,
+            ]
+            and config.get("tcgen05_ab_stages") == TCGEN05_TARGET9_TVM_FFI_AB_STAGES
+            and config.get("tcgen05_c_stages") == TCGEN05_TARGET9_TVM_FFI_C_STAGES
+            and config.get("tcgen05_cluster_m") == 2
+            and config.get("tcgen05_cluster_n") == 1
+            and config.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY)
+            == Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
+            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY) == 128
+            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY) == 32
+            and config.get(TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY) == 32
+        )
+
+    @staticmethod
+    def _is_target10_tvm_ffi_seed_config(config: dict[str, object]) -> bool:
+        # T10 mirrors T2's bias-store envelope at the bk=128 stage tuple
+        # with cycle-41's validated knobs (role_local_monolithic,
+        # l2_groupings=[2], ab=3). Shape + bias-store dtype gates happen
+        # upstream in ``_target10_tvm_ffi_seed_config``.
+        return (
+            config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is True
+            and config.get(TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY) is True
+            and config.get("block_sizes")
+            == [
+                TCGEN05_TWO_CTA_BLOCK_M,
+                TCGEN05_TWO_CTA_BLOCK_N,
+                TCGEN05_TARGET10_TVM_FFI_BLOCK_K,
+            ]
+            and config.get("tcgen05_ab_stages") == TCGEN05_TARGET10_TVM_FFI_AB_STAGES
+            and config.get("tcgen05_c_stages") == TCGEN05_TARGET10_TVM_FFI_C_STAGES
+            and config.get("tcgen05_cluster_m") == 2
+            and config.get("tcgen05_cluster_n") == 1
+            and config.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY)
+            == Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
+            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY) == 128
+            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY) == 32
+            and config.get(TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY) == 32
+        )
+
     def _validate_target1_ab_stage_envelope(
         self, config: dict[str, object], *, fix_invalid: bool
     ) -> None:
@@ -1942,6 +2285,15 @@ class CuteTcgen05Config:
         key: str,
         config: dict[str, object],
     ) -> tuple[bool, object]:
+        if key == TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY:
+            # The autotuner search surface for this key is the collapsed
+            # ``EnumFragment((True,))``; autotuner-generated configs always
+            # set it via ``default_flat()`` mutation. ``flatten`` only hits
+            # this branch on user-supplied configs that omit the key, where
+            # absence means "no FFI promotion requested" — matches the
+            # validation-view default and the special case at
+            # ``normalize_pre_pid_type``.
+            return True, False
         if key != TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY:
             return False, None
         projected_config = {
@@ -2085,6 +2437,36 @@ class CuteTcgen05Config:
             return False
         return constraints.allow_edge_k_tail_family
 
+    def _is_validated_cluster_m2_full_tile_search_candidate(
+        self, config: dict[str, object]
+    ) -> bool:
+        # Cycle 46: full-tile cluster_m=2 candidate gate for aux-TMA admission.
+        # After ``_fix_cluster_m2_search_config`` projects a full-tile sample to
+        # the canonical 256x256x bk shape with ``persistent_interleaved`` pid,
+        # this returns True so aux-TMA stays during the search-time fixup.
+        # bk validity is already enforced by ``_fix_cluster_m2_search_config``;
+        # we re-check it here so a stale/unprojected config cannot slip through.
+        if config.get("tcgen05_cluster_m") != 2:
+            return False
+        constraints = self.cluster_m2_search_constraints
+        if constraints is None or constraints.allow_edge_k_tail_family:
+            return False
+        if config.get("pid_type") != TCGEN05_TWO_CTA_SEED_PID_TYPE:
+            return False
+        if config.get("tcgen05_cluster_n", 1) != 1:
+            return False
+        block_sizes = config.get("block_sizes")
+        if not isinstance(block_sizes, list) or len(block_sizes) < 3:
+            return False
+        if block_sizes[0] != TCGEN05_TWO_CTA_BLOCK_M:
+            return False
+        if block_sizes[1] != TCGEN05_TWO_CTA_BLOCK_N:
+            return False
+        bk = block_sizes[2]
+        if not isinstance(bk, int) or isinstance(bk, bool):
+            return False
+        return self.cluster_m2_bk_is_valid(bk, constraints)
+
     def _fix_cluster_m1_persistent_search_config(
         self, config: dict[str, object]
     ) -> None:
@@ -2206,6 +2588,10 @@ class CuteTcgen05Config:
             ab_stages_max = max(3, TCGEN05_TARGET6_TVM_FFI_AB_STAGES)
         elif not for_search and self._target7_tvm_ffi_seed_config() is not None:
             ab_stages_max = max(3, TCGEN05_TARGET7_TVM_FFI_AB_STAGES)
+        elif not for_search and self._target9_tvm_ffi_seed_config() is not None:
+            ab_stages_max = max(3, TCGEN05_TARGET9_TVM_FFI_AB_STAGES)
+        elif not for_search and self._target10_tvm_ffi_seed_config() is not None:
+            ab_stages_max = max(3, TCGEN05_TARGET10_TVM_FFI_AB_STAGES)
         elif not for_search:
             ab_stages_max = 3
         else:
@@ -2233,11 +2619,22 @@ class CuteTcgen05Config:
             or self._target5_tvm_ffi_seed_config() is not None
             or self._target6_tvm_ffi_seed_config() is not None
             or self._target7_tvm_ffi_seed_config() is not None
+            or self._target9_tvm_ffi_seed_config() is not None
+            or self._target10_tvm_ffi_seed_config() is not None
         ):
+            # Search collapses the FFI-launch knob to a single True
+            # choice — the runtime now always enables FFI, so the
+            # autotuner only needs to explore the True arm to keep the
+            # seeded direct-entry config family in scope. Validation
+            # keeps a Boolean surface so an absent user-config key still
+            # means "no FFI promotion requested" (default False).
+            tvm_ffi_launch_fragment: ConfigSpecFragment = (
+                EnumFragment((True,)) if for_search else BooleanFragment()
+            )
             fragments.update(
                 {
                     TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY: BooleanFragment(),
-                    TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: BooleanFragment(),
+                    TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: tvm_ffi_launch_fragment,
                     TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: EnumFragment((None, 128)),
                     TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: EnumFragment((None, 32)),
                     TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: EnumFragment(
@@ -2284,10 +2681,11 @@ class CuteTcgen05Config:
                 config.pop(key, None)
 
     def _fix_target1_tvm_ffi_search_config(self, config: dict[str, object]) -> None:
-        # T1-T7 share the TVM-FFI direct-entry promotion surface; pick
-        # the seed matching the detected (shape, store) so search
-        # candidates project onto the right envelope. The shape+store
-        # gates are mutually exclusive so at most one seed is non-None.
+        # T1-T7 plus T9-T10 share the TVM-FFI direct-entry promotion
+        # surface; pick the seed matching the detected (shape, store) so
+        # search candidates project onto the right envelope. The
+        # shape+store gates are mutually exclusive so at most one seed
+        # is non-None.
         seed = self._target1_tvm_ffi_seed_config()
         if seed is None:
             seed = self._target2_tvm_ffi_seed_config()
@@ -2301,6 +2699,10 @@ class CuteTcgen05Config:
             seed = self._target6_tvm_ffi_seed_config()
         if seed is None:
             seed = self._target7_tvm_ffi_seed_config()
+        if seed is None:
+            seed = self._target9_tvm_ffi_seed_config()
+        if seed is None:
+            seed = self._target10_tvm_ffi_seed_config()
         if not self._target1_tvm_ffi_promotion_requested(
             config, seed_enabled=seed is not None
         ):
@@ -2355,12 +2757,19 @@ class CuteTcgen05Config:
     def aux_stages_autotune_fragments(self) -> dict[str, ConfigSpecFragment]:
         """Per-config aux-pipeline stage-count knob.
 
-        Admitted only under ``_aux_tma_search_enabled``, which pins the
+        Admitted only under ``_aux_tma_edge_search_enabled``, which pins the
         surface to the validated edge+K-tail family with ``cluster_m=2``
         and the c-input warp + aux-TMA combination. Configs outside that
         gate never see the knob; codegen at the default of 2 is unchanged.
+
+        Cycle 46 intentionally keeps this scoped to the edge+K-tail gate
+        even though ``_aux_tma_search_enabled`` was widened to admit the
+        full-tile cluster_m=2 family. The stage-count choices were tuned
+        on the T8/CLC edge rows; exposing them to T14/T20/T25/T28 would
+        let autotune sample stage counts on shapes they were not measured
+        on.
         """
-        if not self._aux_tma_search_enabled():
+        if not self._aux_tma_edge_search_enabled():
             return {}
         return {
             TCGEN05_AUX_STAGES_CONFIG_KEY: EnumFragment(TCGEN05_AUX_STAGE_COUNT_CHOICES)
@@ -2370,13 +2779,18 @@ class CuteTcgen05Config:
         """Per-config consumer-warp ``setmaxregister_increase`` ceiling knob.
 
         Admission mirrors ``aux_stages_autotune_fragments``: the
-        ``_aux_tma_search_enabled`` gate pins the search to the validated
-        wide-N CLC + aux-TMA seed family with the c-input warp + aux-TMA
-        combination. Configs outside that gate never see the knob. The
-        default value (256) is included in ``TCGEN05_CONSUMER_REGS_CHOICES``
-        so default-with-knob emits the same code as default-without-knob.
+        ``_aux_tma_edge_search_enabled`` gate pins the search to the
+        validated wide-N CLC + aux-TMA seed family with the c-input warp +
+        aux-TMA combination. Configs outside that gate never see the
+        knob. The default value (256) is included in
+        ``TCGEN05_CONSUMER_REGS_CHOICES`` so default-with-knob emits the
+        same code as default-without-knob.
+
+        Cycle 46 intentionally keeps this scoped to the edge+K-tail gate
+        even though ``_aux_tma_search_enabled`` was widened (see
+        ``aux_stages_autotune_fragments``).
         """
-        if not self._aux_tma_search_enabled():
+        if not self._aux_tma_edge_search_enabled():
             return {}
         return {
             TCGEN05_CONSUMER_REGS_CONFIG_KEY: EnumFragment(
@@ -2414,6 +2828,8 @@ class CuteTcgen05Config:
             or self._target5_tvm_ffi_seed_config() is not None
             or self._target6_tvm_ffi_seed_config() is not None
             or self._target7_tvm_ffi_seed_config() is not None
+            or self._target9_tvm_ffi_seed_config() is not None
+            or self._target10_tvm_ffi_seed_config() is not None
         )
         if self.aux_kernel_detected:
             strategy_choices: tuple[str, ...] = (
@@ -2582,7 +2998,15 @@ class CuteTcgen05Config:
                         key, fragment, config[key]
                     )
                 elif key in optional_search_fragments:
-                    config[key] = optional_search_fragments[key].default()
+                    if key == TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY:
+                        # An omitted user-config means "no FFI promotion
+                        # requested" — fill from the validation surface
+                        # so the non-seed envelope and promotion gates
+                        # that key off ``config.get(...) is True`` stay
+                        # consistent.
+                        config[key] = optional_fragments[key].default()
+                    else:
+                        config[key] = optional_search_fragments[key].default()
             self._clamp_l2_swizzle_size_to_shape(config)
             self._validate_target1_ab_stage_envelope(config, fix_invalid=fix_invalid)
         else:

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -283,8 +283,11 @@ TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY = "tcgen05_tvm_ffi_launch"
 # targets can re-explore. ``{2, 3}`` fit structurally on B200 — see
 # ``cute_plan.md`` for the SMEM-budget audit. The autotune gate
 # (``aux_stages_autotune_fragments`` in ``tcgen05_config.py``) admits
-# the knob only for the ``_aux_tma_search_enabled`` family so other
-# paths stay byte-identical at the default.
+# the knob only for the ``_aux_tma_edge_search_enabled`` family so other
+# paths stay byte-identical at the default. (Cycle 46 widened
+# ``_aux_tma_search_enabled`` to also admit the full-tile cluster_m=2
+# family, but this stage-count knob remains scoped to the edge gate
+# because its choices were measured only on the T8/CLC edge rows.)
 TCGEN05_AUX_STAGES_CONFIG_KEY = "tcgen05_aux_stages"
 TCGEN05_AUX_STAGE_COUNT_DEFAULT = 2
 TCGEN05_AUX_STAGE_COUNT_CHOICES = (2, 3)
@@ -300,10 +303,13 @@ TCGEN05_AUX_STAGE_COUNT_CHOICES = (2, 3)
 # ``cute_mma.py`` ``_emit_mma_pipeline`` consumer branch; the
 # autotune gate (``consumer_regs_autotune_fragments`` in
 # ``tcgen05_config.py``) admits the knob only for the
-# ``_aux_tma_search_enabled`` family (mirroring the aux_stages gate)
-# so other paths stay byte-identical at the 256 default. The
-# choices include 256 so the default-with-knob configuration matches
-# the default-without-knob emission byte-for-byte.
+# ``_aux_tma_edge_search_enabled`` family (mirroring the aux_stages
+# gate) so other paths stay byte-identical at the 256 default. (Cycle
+# 46 widened ``_aux_tma_search_enabled`` to also admit the full-tile
+# cluster_m=2 family, but this register-cap knob stays scoped to the
+# edge gate because its choices were measured only on the T8/CLC edge
+# rows.) The choices include 256 so the default-with-knob configuration
+# matches the default-without-knob emission byte-for-byte.
 TCGEN05_CONSUMER_REGS_CONFIG_KEY = "tcgen05_consumer_regs"
 TCGEN05_CONSUMER_REGS_DEFAULT = 256
 TCGEN05_CONSUMER_REGS_CHOICES = (224, 232, 240, 256)
@@ -382,14 +388,39 @@ TCGEN05_TARGET7_TVM_FFI_SHAPE = (2048, 8192, 2048)
 TCGEN05_TARGET7_TVM_FFI_BLOCK_K = 128
 TCGEN05_TARGET7_TVM_FFI_AB_STAGES = 3
 TCGEN05_TARGET7_TVM_FFI_C_STAGES = 2
+# Validated cycle-38 Target9 envelope (2048x2048x2048 + identity epilogue):
+# admits the TVM-FFI direct entry on the bk=128 (ab=3, c=2) stage tuple.
+# T9 mirrors T3/T5/T7's identity-store envelope at the square
+# 2048x2048x2048 problem. K=2048 -> k_tile_count=16 (same as T2/T3/T6/T7).
+# The identity-store gate is shared with T1/T3/T5/T7; the shape gate
+# pins it to T9 so a T1/T3/T5/T7 host function does not get a T9 seed.
+TCGEN05_TARGET9_TVM_FFI_SHAPE = (2048, 2048, 2048)
+TCGEN05_TARGET9_TVM_FFI_BLOCK_K = 128
+TCGEN05_TARGET9_TVM_FFI_AB_STAGES = 3
+TCGEN05_TARGET9_TVM_FFI_C_STAGES = 2
+# Validated cycle-42 Target10 envelope (2048x2048x2048 + ``acc + bias[n]``
+# epilogue, fp16 or bf16 operand dtype): admits the TVM-FFI direct entry
+# on the bk=128 (ab=3, c=2) stage tuple. T10 mirrors T2's bias-store
+# envelope at the square 2048x2048x2048 problem (T9's shape, T2's
+# rank-1 trailing-axis bias add). Cycle-41 force-config measurements
+# converged on the (ab=3, c=2) stage tuple under the role_local_monolithic
+# strategy with ``c_input_seed=0`` and ``l2_groupings=[2]``; this seed
+# closed the gap on T22 (fp16 2048³ bias) from +21.25% to +3.7% vs Quack.
+# T10 is the first envelope that admits fp16 operands — the per-target
+# fp16 admission gates are scoped to T10's shape so T1-T9 stay bf16-only.
+TCGEN05_TARGET10_TVM_FFI_SHAPE = (2048, 2048, 2048)
+TCGEN05_TARGET10_TVM_FFI_BLOCK_K = 128
+TCGEN05_TARGET10_TVM_FFI_AB_STAGES = 3
+TCGEN05_TARGET10_TVM_FFI_C_STAGES = 2
 
 # Stage tuples that the TVM-FFI direct entry accepts, keyed by ``bk``.
 # The codegen-side ``tcgen05_direct_entry`` source builder and the
 # runtime-side ``_validate_target1_direct_entry_args`` both consume this
 # table so they cannot drift out of sync. ``bk=64`` covers Target 1's
 # two envelopes; ``bk=128`` covers the cycle-2 Target 4, cycle-3 Target
-# 5, cycle-4 Target 3, cycle-6 Target 2, cycle-7 Target 6, and cycle-8
-# Target 7 envelopes (all share the (3, 2) stage tuple).
+# 5, cycle-4 Target 3, cycle-6 Target 2, cycle-7 Target 6, cycle-8
+# Target 7, cycle-38 Target 9, and cycle-42 Target 10 envelopes (all
+# share the (3, 2) stage tuple).
 TCGEN05_DIRECT_ENTRY_STAGE_TUPLES_BY_BK: dict[int, tuple[tuple[int, int], ...]] = {
     TCGEN05_TARGET1_TVM_FFI_BLOCK_K: ((3, 2), (6, 4)),
     TCGEN05_TARGET4_TVM_FFI_BLOCK_K: (
@@ -399,17 +430,18 @@ TCGEN05_DIRECT_ENTRY_STAGE_TUPLES_BY_BK: dict[int, tuple[tuple[int, int], ...]] 
 
 # Accepted (lhs_shape, rhs_shape, d_shape) envelopes keyed by ``bk``.
 # Ties the direct-entry tensor shape envelope to the plan's ``bk`` so a
-# bk=64 (T1) plan cannot launch with T2/T3/T4/T5/T6/T7-shaped tensors
-# and vice versa. Each entry is
+# bk=64 (T1) plan cannot launch with T2/T3/T4/T5/T6/T7/T9/T10-shaped
+# tensors and vice versa. Each entry is
 # ``((lhs_m, lhs_k), (rhs_k, rhs_n), (d_m, d_n))``. T2, T3, T4, T5, T6,
-# and T7 share ``bk=128`` but have distinct M/N/K shapes; all six are
-# admitted in the same bk-keyed table so the runtime validator accepts
-# any of them (it additionally dispatches on the per-plan
-# ``validated_shape`` so a T3-plan with T4/T5/T7 tensors is still
-# rejected; T2 and T6 plans each carry a ``bias_idx`` so a 3-arg
-# launch is rejected against either plan even at the same shape
-# envelope, and a 4-arg launch is rejected against the T3/T4/T5/T7
-# plans).
+# T7, T9, and T10 share ``bk=128`` but have distinct M/N/K shapes (with
+# T9 and T10 sharing the square 2048³ shape but differing on epilogue +
+# input dtype); all eight are admitted in the same bk-keyed table so
+# the runtime validator accepts any of them (it additionally dispatches
+# on the per-plan ``validated_shape`` so a T3-plan with T4/T5/T7/T9/T10
+# tensors is still rejected; T2, T6, and T10 plans each carry a
+# ``bias_idx`` so a 3-arg launch is rejected against any of them even
+# at the same shape envelope, and a 4-arg launch is rejected against
+# the T3/T4/T5/T7/T9 plans).
 TCGEN05_DIRECT_ENTRY_SHAPE_SETS_BY_BK: dict[
     int,
     tuple[tuple[tuple[int, int], tuple[int, int], tuple[int, int]], ...],
@@ -422,6 +454,7 @@ TCGEN05_DIRECT_ENTRY_SHAPE_SETS_BY_BK: dict[
         ((4096, 2048), (2048, 2048), (4096, 2048)),
         ((8192, 2048), (2048, 2048), (8192, 2048)),
         ((2048, 2048), (2048, 8192), (2048, 8192)),
+        ((2048, 2048), (2048, 2048), (2048, 2048)),
     ),
 }
 
@@ -442,13 +475,14 @@ TCGEN05_DIRECT_ENTRY_CLUSTER_M = 2
 
 # Total work-cluster counts produced by the codegen scheduler for the
 # validated direct-entry shapes. Target 1 (1024x4096x1024) yields 64
-# work clusters; Targets 2 (4096x2048x2048), 3 (2048x4096x2048), 4
-# (8192x1024x1024), and 5 (1024x8192x1024) each yield 128; Target 6
-# (8192x2048x2048) and Target 7 (2048x8192x2048) each yield 256 (per
-# ``_tcgen05_num_work_clusters_expr`` in program_id.py:
-# dims[0] = ceil(M_tiles*cluster_m / cluster_m) * N_tiles at
-# cluster_m=2 cluster_n=1; T1 = 4*16 = 64; T4 = 32*4 = 128; T5 = 4*32
-# = 128; T2 = 16*8 = 128; T3 = 8*16 = 128; T6 = 32*8 = 256;
+# work clusters; Target 9 (2048x2048x2048) yields 64; Targets 2
+# (4096x2048x2048), 3 (2048x4096x2048), 4 (8192x1024x1024), and 5
+# (1024x8192x1024) each yield 128; Target 6 (8192x2048x2048) and
+# Target 7 (2048x8192x2048) each yield 256 (per
+# ``_tcgen05_num_work_clusters_expr`` in program_id.py: dims[0] =
+# ceil(M_tiles*cluster_m / cluster_m) * N_tiles at cluster_m=2
+# cluster_n=1; T1 = 4*16 = 64; T9 = 8*8 = 64; T4 = 32*4 = 128;
+# T5 = 4*32 = 128; T2 = 16*8 = 128; T3 = 8*16 = 128; T6 = 32*8 = 256;
 # T7 = 8*32 = 256). The runtime grid is
 # ``(cluster_m, cluster_n, min(total_clusters, num_sms // cluster_m))``;
 # both ``total_clusters`` and ``num_sms // cluster_m`` are admissible

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -483,6 +483,14 @@ class ConfigSpec:
         self._cute_tcgen05_config.bias_matmul_store_detected = value
 
     @property
+    def cute_tcgen05_bias_matmul_store_fp16_detected(self) -> bool:
+        return self._cute_tcgen05_config.bias_matmul_store_fp16_detected
+
+    @cute_tcgen05_bias_matmul_store_fp16_detected.setter
+    def cute_tcgen05_bias_matmul_store_fp16_detected(self, value: bool) -> None:
+        self._cute_tcgen05_config.bias_matmul_store_fp16_detected = value
+
+    @property
     def cute_tcgen05_bias_relu_matmul_store_detected(self) -> bool:
         return self._cute_tcgen05_config.bias_relu_matmul_store_detected
 
@@ -578,6 +586,12 @@ class ConfigSpec:
 
     def allow_tcgen05_target7_tvm_ffi_seed(self) -> None:
         self._cute_tcgen05_config.allow_target7_tvm_ffi_seed()
+
+    def allow_tcgen05_target9_tvm_ffi_seed(self) -> None:
+        self._cute_tcgen05_config.allow_target9_tvm_ffi_seed()
+
+    def allow_tcgen05_target10_tvm_ffi_seed(self) -> None:
+        self._cute_tcgen05_config.allow_target10_tvm_ffi_seed()
 
     @staticmethod
     def _tcgen05_cluster_m2_bk_is_valid(

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -31,6 +31,9 @@ from .._compiler.cute.tcgen05_constants import (
     TCGEN05_DIRECT_ENTRY_STAGE_TUPLES_BY_BK as _DIRECT_ENTRY_STAGE_TUPLES_BY_BK,
 )
 from .._compiler.cute.tcgen05_constants import TCGEN05_DIRECT_ENTRY_TOTAL_WORK_CLUSTERS
+from .._compiler.cute.tcgen05_constants import (
+    TCGEN05_TARGET10_TVM_FFI_SHAPE as _TCGEN05_TARGET10_TVM_FFI_SHAPE,
+)
 from .._utils import triton_is_available
 from .config import Config as Config
 from .kernel import Kernel as Kernel
@@ -2653,20 +2656,50 @@ def _validate_target1_direct_entry_args(
             "tcgen05 direct entry requires a validated stage tuple, got "
             f"bk={bk} (ab,c)=({ab_stage_count},{c_stage_count})",
         )
+    # The legacy validator pinned every direct-entry plan to bf16. T10
+    # (cycle 42, 2048³ bias) is the first fp16-admitting envelope; the
+    # admission is scoped to that exact ``(validated_shape, has_bias)``
+    # signature so T1-T9 still reject fp16 plans here.
+    plan_input_dtype = plan.get("input_dtype")
+    plan_output_dtype = plan.get("output_dtype")
+    indices = _target1_direct_entry_arg_indices(plan)
+    has_bias = len(indices) == 4
+    plan_validated_shape_raw = plan.get("validated_shape")
+    plan_validated_shape: tuple[int, int, int] | None = None
     if (
-        plan.get("input_dtype") != "cutlass.BFloat16"
-        or plan.get("output_dtype") != "cutlass.BFloat16"
+        isinstance(plan_validated_shape_raw, (list, tuple))
+        and len(plan_validated_shape_raw) == 3
+        and all(isinstance(v, int) for v in plan_validated_shape_raw)
     ):
+        plan_validated_shape = (
+            int(plan_validated_shape_raw[0]),
+            int(plan_validated_shape_raw[1]),
+            int(plan_validated_shape_raw[2]),
+        )
+    target10_dtype_admission_ok = (
+        plan_input_dtype == "cutlass.Float16"
+        and plan_output_dtype == "cutlass.Float16"
+        and has_bias
+        and plan_validated_shape == _TCGEN05_TARGET10_TVM_FFI_SHAPE
+    )
+    bf16_dtype_admission_ok = (
+        plan_input_dtype == "cutlass.BFloat16"
+        and plan_output_dtype == "cutlass.BFloat16"
+    )
+    if not (bf16_dtype_admission_ok or target10_dtype_admission_ok):
         raise exc.BackendUnsupported(
             "cute",
-            "tcgen05 direct entry requires bf16 input/output dtypes",
+            "tcgen05 direct entry requires bf16 input/output dtypes "
+            "(fp16 admitted only for the T10 2048³ bias envelope)",
         )
+    expected_arg_dtype = (
+        torch.float16 if target10_dtype_admission_ok else torch.bfloat16
+    )
+    expected_arg_dtype_label = "fp16" if expected_arg_dtype is torch.float16 else "bf16"
 
-    indices = _target1_direct_entry_arg_indices(plan)
-    # T1/T3/T4/T5 keep the 3-tensor (lhs/rhs/output) signature; T2 adds
-    # a 4th rank-1 trailing-axis bias tensor signalled by the plan's
-    # ``bias_idx`` (= ``indices[3]``).
-    has_bias = len(indices) == 4
+    # T1/T3/T4/T5 keep the 3-tensor (lhs/rhs/output) signature; T2, T6,
+    # and T10 add a 4th rank-1 trailing-axis bias tensor signalled by
+    # the plan's ``bias_idx`` (= ``indices[3]``).
     if not has_bias and (indices != (0, 1, 2) or len(args) != 3):
         raise exc.BackendUnsupported(
             "cute",
@@ -2686,10 +2719,10 @@ def _validate_target1_direct_entry_args(
                 "tcgen05 direct entry requires tensor arguments",
             )
         _validate_cute_launcher_tensor(arg)
-        if arg.dtype is not torch.bfloat16:
+        if arg.dtype is not expected_arg_dtype:
             raise exc.BackendUnsupported(
                 "cute",
-                "tcgen05 direct entry requires bf16 tensor arguments",
+                f"tcgen05 direct entry requires {expected_arg_dtype_label} tensor arguments",
             )
         if arg.ndim != 2 or int(arg.stride(1)) != 1:
             raise exc.BackendUnsupported(
@@ -2710,18 +2743,13 @@ def _validate_target1_direct_entry_args(
     # asserts that the plan's ``validated_shape`` is one of the
     # bk-allowed shapes (so a future plan-construction-site bug that
     # forged an off-envelope shape into a plan still gets caught).
-    validated_shape_raw = plan.get("validated_shape")
-    if not (
-        isinstance(validated_shape_raw, (list, tuple))
-        and len(validated_shape_raw) == 3
-        and all(isinstance(v, int) for v in validated_shape_raw)
-    ):
+    if plan_validated_shape is None:
         raise exc.BackendUnsupported(
             "cute",
             f"tcgen05 direct entry plan requires validated_shape, got "
-            f"{validated_shape_raw!r}",
+            f"{plan_validated_shape_raw!r}",
         )
-    plan_m, plan_n, plan_k = (int(v) for v in validated_shape_raw)
+    plan_m, plan_n, plan_k = plan_validated_shape
     bk_allowed_shapes = _DIRECT_ENTRY_SHAPE_SETS_BY_BK.get(bk, ())
     expected_lhs = (plan_m, plan_k)
     expected_rhs = (plan_k, plan_n)
@@ -2752,15 +2780,20 @@ def _validate_target1_direct_entry_args(
                 "tcgen05 direct entry bias requires a tensor argument",
             )
         _validate_cute_launcher_tensor(bias_arg)
-        if bias_arg.dtype is not torch.bfloat16:
+        # T2/T6 stay pinned to bf16 (their plans set
+        # ``plan_input_dtype == 'cutlass.BFloat16'``); T10 admits an fp16
+        # bias whose dtype must match the operand dtype recorded in the
+        # plan (``expected_arg_dtype`` above).
+        if bias_arg.dtype is not expected_arg_dtype:
             raise exc.BackendUnsupported(
                 "cute",
-                "tcgen05 direct entry bias requires a bf16 tensor",
+                f"tcgen05 direct entry bias requires a {expected_arg_dtype_label} tensor",
             )
-        # The bias tensor for T2 is rank-1 with N elements (trailing-axis
-        # rowvec broadcast); stride must be 1 so the GMEM load uses
-        # contiguous reads. The N-extent matches the matmul's N to keep
-        # the bias broadcast aligned with the output tile columns.
+        # The bias tensor for T2/T6/T10 is rank-1 with N elements
+        # (trailing-axis rowvec broadcast); stride must be 1 so the GMEM
+        # load uses contiguous reads. The N-extent matches the matmul's
+        # N to keep the bias broadcast aligned with the output tile
+        # columns.
         if (
             bias_arg.ndim != 1
             or int(bias_arg.stride(0)) != 1
@@ -2769,7 +2802,7 @@ def _validate_target1_direct_entry_args(
             raise exc.BackendUnsupported(
                 "cute",
                 "tcgen05 direct entry bias requires a contiguous rank-1 "
-                f"bf16 tensor of shape ({plan_n},), got shape "
+                f"{expected_arg_dtype_label} tensor of shape ({plan_n},), got shape "
                 f"{tuple(int(bias_arg.size(d)) for d in range(bias_arg.ndim))!r} "
                 f"stride {tuple(int(bias_arg.stride(d)) for d in range(bias_arg.ndim))!r}",
             )
@@ -3201,6 +3234,27 @@ def _get_compiled_cute_direct_entry_launcher(
     return launcher
 
 
+_TVM_FFI_COMPILE_OPTION = "--enable-tvm-ffi"
+
+
+def _merge_tvm_ffi_compile_option(compile_options: str | None) -> str:
+    """Ensure ``--enable-tvm-ffi`` is present in *compile_options*.
+
+    The generic launcher always benefits from the FFI bridge (it skips
+    CUTLASS-DSL's per-arg cast/pointer work). Other flags such as
+    ``--generate-line-info`` may already be present (e.g. when the
+    autotuner picks ``tcgen05_cubin_lineinfo=True``), so we splice rather
+    than replace.
+    """
+    if compile_options is None:
+        return _TVM_FFI_COMPILE_OPTION
+    tokens = compile_options.split()
+    if _TVM_FFI_COMPILE_OPTION in tokens:
+        return compile_options
+    tokens.append(_TVM_FFI_COMPILE_OPTION)
+    return " ".join(tokens)
+
+
 def _get_compiled_cute_launcher(
     cute_kernel: object,
     schema_key: tuple[tuple[object, ...], ...],
@@ -3208,6 +3262,15 @@ def _get_compiled_cute_launcher(
     compile_options: str | None = None,
     arch_args: tuple[object, ...] | None = None,
 ) -> object:
+    # Always ensure ``--enable-tvm-ffi`` is present on the generic launcher
+    # path: the generated wrapper signature (``cute.Pointer`` + scalars) is
+    # TVM-FFI compatible and the FFI bridge bypasses CUTLASS-DSL's per-arg
+    # cast/pointer work in ``generate_execution_args``. We merge rather
+    # than replace because other flags (e.g. ``--generate-line-info`` when
+    # ``tcgen05_cubin_lineinfo`` is True) can already be in
+    # ``compile_options``. The direct-entry path is unaffected -- it goes
+    # through ``_CompiledCuteDirectEntryLauncher`` with an explicit value.
+    compile_options = _merge_tvm_ffi_compile_option(compile_options)
     try:
         # pyrefly: ignore [missing-attribute]
         cache = cute_kernel._helion_cute_compiled_launchers

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -566,38 +566,66 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                         self.host_function
                     )
                 )
+                # T10 (cycle 42) admits fp16 bias. The default detector
+                # call above is bf16-only so T2/T6 cannot perturb their
+                # autotune mutation pool on a fp16-bias kernel; T10
+                # gates on this separate (bf16, fp16) variant instead.
+                self.env.config_spec.cute_tcgen05_bias_matmul_store_fp16_detected = (
+                    host_function_has_tcgen05_bias_matmul_store_pattern(
+                        self.host_function,
+                        expected_bias_dtypes=(torch.bfloat16, torch.float16),
+                    )
+                )
                 self.env.config_spec.cute_tcgen05_bias_relu_matmul_store_detected = (
                     host_function_has_tcgen05_bias_relu_matmul_store_pattern(
                         self.host_function
                     )
                 )
                 if self.env.config_spec.cute_tcgen05_identity_matmul_store_detected:
-                    # T1, T3, T5, and T7 all gate on identity-store
+                    # T1, T3, T5, T7, and T9 all gate on identity-store
                     # detection and write into the same cluster_m=2
                     # search constraints + pid_type allowlist. Mutual
                     # exclusion is via shape facts (T1 = 1024x4096x1024,
                     # T3 = 2048x4096x2048, T5 = 1024x8192x1024,
-                    # T7 = 2048x8192x2048) so at most one seed is
-                    # non-``None`` per host function; the values
-                    # written here must stay equal across the four
-                    # ``allow_target{1,3,5,7}_tvm_ffi_seed`` paths.
+                    # T7 = 2048x8192x2048, T9 = 2048x2048x2048) so at
+                    # most one seed is non-``None`` per host function;
+                    # the values written here must stay equal across
+                    # the five
+                    # ``allow_target{1,3,5,7,9}_tvm_ffi_seed`` paths.
                     self.env.config_spec.allow_tcgen05_target1_tvm_ffi_seed()
                     self.env.config_spec.allow_tcgen05_target3_tvm_ffi_seed()
                     self.env.config_spec.allow_tcgen05_target5_tvm_ffi_seed()
                     self.env.config_spec.allow_tcgen05_target7_tvm_ffi_seed()
+                    self.env.config_spec.allow_tcgen05_target9_tvm_ffi_seed()
                 if self.env.config_spec.cute_tcgen05_relu_matmul_store_detected:
                     self.env.config_spec.allow_tcgen05_target4_tvm_ffi_seed()
                 if self.env.config_spec.cute_tcgen05_bias_matmul_store_detected:
-                    # T2 gates on the bias-store detection (rank-1
-                    # trailing-axis ``acc + bias[n]``) and writes into the
-                    # same cluster_m=2 search constraints + pid_type
-                    # allowlist used by the T1/T3/T5 identity-store and
-                    # T4 relu-store seeds. The bias-store detector is
-                    # mutually exclusive with both identity and relu
-                    # store walkers (rejected by the chain shape), and
-                    # T2's shape gate (4096x2048x2048) keeps it
-                    # mutually exclusive on the matmul fact.
+                    # T2 gates on the bf16-only bias-store detection
+                    # (rank-1 trailing-axis ``acc + bias[n]``) and
+                    # writes into the same cluster_m=2 search
+                    # constraints + pid_type allowlist used by the
+                    # T1/T3/T5 identity-store and T4 relu-store seeds.
+                    # The bias-store detector is mutually exclusive
+                    # with identity and relu store walkers (rejected by
+                    # the chain shape), and T2's shape gate
+                    # (4096x2048x2048) keeps it mutually exclusive on
+                    # the matmul fact.
                     self.env.config_spec.allow_tcgen05_target2_tvm_ffi_seed()
+                if (
+                    self.env.config_spec.cute_tcgen05_bias_matmul_store_detected
+                    or self.env.config_spec.cute_tcgen05_bias_matmul_store_fp16_detected
+                ):
+                    # T10 (cycle 42) shares the cluster_m=2 search
+                    # constraints + pid_type allowlist with T2 but
+                    # admits fp16 bias against fp16 operands too. T2
+                    # and T10 are mutually exclusive at the matmul-fact
+                    # level: T2's shape is 4096x2048x2048 (bf16-only),
+                    # T10's shape is 2048x2048x2048 (bf16 or fp16). At
+                    # most one seed is non-``None`` for any given host
+                    # function. T10 enables on either bf16-only or the
+                    # broader (bf16, fp16) bias detection so a fp16
+                    # bias kernel still routes through T10.
+                    self.env.config_spec.allow_tcgen05_target10_tvm_ffi_seed()
                 if self.env.config_spec.cute_tcgen05_bias_relu_matmul_store_detected:
                     # T6 gates on the bias-relu-store detection
                     # (``relu(acc + bias[n])``) and writes into the

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -1682,7 +1682,7 @@ class TestCuteBackend(TestCase):
         cute_kernel = type("DummyCuteKernel", (), {})()
         schema_key = (("tensor", 2, "float32"),)
         block = (32, 1, 1)
-        compiled_calls: list[tuple[object, tuple[object, ...]]] = []
+        compiled_calls: list[tuple[object, tuple[object, ...], str | None]] = []
         launched_args: list[tuple[object, ...]] = []
 
         class FakeCompiled:
@@ -1690,8 +1690,12 @@ class TestCuteBackend(TestCase):
                 launched_args.append(args)
                 return ("launched", args)
 
-        def fake_compile(jit_func: object, *args: object) -> FakeCompiled:
-            compiled_calls.append((jit_func, args))
+        def fake_compile(
+            jit_func: object,
+            *args: object,
+            options: str | None = None,
+        ) -> FakeCompiled:
+            compiled_calls.append((jit_func, args, options))
             return FakeCompiled()
 
         with (
@@ -1702,7 +1706,9 @@ class TestCuteBackend(TestCase):
             first = launcher(1, 2, 3)
             second = launcher(4, 5, 6)
 
-        self.assertEqual(compiled_calls, [("jit-wrapper", (1, 2, 3))])
+        self.assertEqual(
+            compiled_calls, [("jit-wrapper", (1, 2, 3), "--enable-tvm-ffi")]
+        )
         self.assertEqual(launched_args, [(1, 2, 3), (4, 5, 6)])
         self.assertEqual(first, ("launched", (1, 2, 3)))
         self.assertEqual(second, ("launched", (4, 5, 6)))
@@ -1737,9 +1743,13 @@ class TestCuteBackend(TestCase):
             )
             result = launcher(1, 2, 3)
 
+        # The runtime merges ``--enable-tvm-ffi`` into any caller-provided
+        # compile_options so the generic launcher always benefits from
+        # the FFI bridge (e.g. when the autotuner selects
+        # ``tcgen05_cubin_lineinfo=True``).
         self.assertEqual(
             compiled_calls,
-            [("jit-wrapper", (1, 2, 3), "--generate-line-info")],
+            [("jit-wrapper", (1, 2, 3), "--generate-line-info --enable-tvm-ffi")],
         )
         self.assertEqual(result, ("launched", (1, 2, 3)))
 

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -3021,7 +3021,7 @@ class TestCuteLowerings(unittest.TestCase):
                 # Relu-store at T1 shape is still rejected: the T1 envelope
                 # requires identity-store, and the T4 envelope requires the
                 # 8192x1024x1024 shape.
-                "T1 identity-store, T2 bias-store, T3 identity-store, T4 relu-store, T5 identity-store, T6 bias-relu-store, or T7 identity-store",
+                "T1 identity-store, T2 bias-store, T3 identity-store, T4 relu-store, T5 identity-store, T6 bias-relu-store, T7 identity-store, T9 identity-store, or T10 fp16/bf16 bias-store",
             ):
                 bound.to_triton_code(cfg)
 
@@ -3100,7 +3100,7 @@ class TestCuteLowerings(unittest.TestCase):
             bound.env.config_spec.cute_tcgen05_search_enabled = True
             with self.assertRaisesRegex(
                 exc.BackendUnsupported,
-                "T1 identity-store, T2 bias-store, T3 identity-store, T4 relu-store, T5 identity-store, T6 bias-relu-store, or T7 identity-store",
+                "T1 identity-store, T2 bias-store, T3 identity-store, T4 relu-store, T5 identity-store, T6 bias-relu-store, T7 identity-store, T9 identity-store, or T10 fp16/bf16 bias-store",
             ):
                 bound.to_triton_code(cfg)
 
@@ -3144,7 +3144,7 @@ class TestCuteLowerings(unittest.TestCase):
             bound.env.config_spec.cute_tcgen05_search_enabled = True
             with self.assertRaisesRegex(
                 exc.BackendUnsupported,
-                "T1 identity-store, T2 bias-store, T3 identity-store, T4 relu-store, T5 identity-store, T6 bias-relu-store, or T7 identity-store",
+                "T1 identity-store, T2 bias-store, T3 identity-store, T4 relu-store, T5 identity-store, T6 bias-relu-store, T7 identity-store, T9 identity-store, or T10 fp16/bf16 bias-store",
             ):
                 bound.to_triton_code(cfg)
 
@@ -3183,7 +3183,7 @@ class TestCuteLowerings(unittest.TestCase):
             bound.env.config_spec.cute_tcgen05_search_enabled = True
             with self.assertRaisesRegex(
                 exc.BackendUnsupported,
-                "T1 identity-store, T2 bias-store, T3 identity-store, T4 relu-store, T5 identity-store, T6 bias-relu-store, or T7 identity-store",
+                "T1 identity-store, T2 bias-store, T3 identity-store, T4 relu-store, T5 identity-store, T6 bias-relu-store, T7 identity-store, T9 identity-store, or T10 fp16/bf16 bias-store",
             ):
                 bound.to_triton_code(cfg)
 
@@ -3475,7 +3475,8 @@ class TestCuteLowerings(unittest.TestCase):
                 # envelope's failure path.
                 r"requires the validated T1 identity-store, T2 bias-store, "
                 r"T3 identity-store, T4 relu-store, T5 identity-store, "
-                r"T6 bias-relu-store, or T7 identity-store "
+                r"T6 bias-relu-store, T7 identity-store, T9 identity-store, "
+                r"or T10 fp16/bf16 bias-store "
                 r"TVM-FFI flat-role seed",
             ):
                 bound.to_triton_code(cfg)
@@ -3524,7 +3525,8 @@ class TestCuteLowerings(unittest.TestCase):
                 # envelope's failure path.
                 r"requires the validated T1 identity-store, T2 bias-store, "
                 r"T3 identity-store, T4 relu-store, T5 identity-store, "
-                r"T6 bias-relu-store, or T7 identity-store "
+                r"T6 bias-relu-store, T7 identity-store, T9 identity-store, "
+                r"or T10 fp16/bf16 bias-store "
                 r"TVM-FFI flat-role seed",
             ):
                 bound.to_triton_code(cfg)
@@ -4277,7 +4279,8 @@ class TestCuteLowerings(unittest.TestCase):
                 # envelope's failure path.
                 r"requires the validated T1 identity-store, T2 bias-store, "
                 r"T3 identity-store, T4 relu-store, T5 identity-store, "
-                r"T6 bias-relu-store, or T7 identity-store "
+                r"T6 bias-relu-store, T7 identity-store, T9 identity-store, "
+                r"or T10 fp16/bf16 bias-store "
                 r"TVM-FFI flat-role seed",
             ):
                 bound.to_triton_code(cfg)
@@ -4335,7 +4338,8 @@ class TestCuteLowerings(unittest.TestCase):
                 # envelope's failure path.
                 r"requires the validated T1 identity-store, T2 bias-store, "
                 r"T3 identity-store, T4 relu-store, T5 identity-store, "
-                r"T6 bias-relu-store, or T7 identity-store "
+                r"T6 bias-relu-store, T7 identity-store, T9 identity-store, "
+                r"or T10 fp16/bf16 bias-store "
                 r"TVM-FFI flat-role seed",
             ):
                 bound_bias_only.to_triton_code(cfg)
@@ -4401,7 +4405,8 @@ class TestCuteLowerings(unittest.TestCase):
                 # envelope's failure path.
                 r"requires the validated T1 identity-store, T2 bias-store, "
                 r"T3 identity-store, T4 relu-store, T5 identity-store, "
-                r"T6 bias-relu-store, or T7 identity-store "
+                r"T6 bias-relu-store, T7 identity-store, T9 identity-store, "
+                r"or T10 fp16/bf16 bias-store "
                 r"TVM-FFI flat-role seed",
             ):
                 bound.to_triton_code(cfg)
@@ -4588,7 +4593,8 @@ class TestCuteLowerings(unittest.TestCase):
                 # envelope's failure path.
                 r"requires the validated T1 identity-store, T2 bias-store, "
                 r"T3 identity-store, T4 relu-store, T5 identity-store, "
-                r"T6 bias-relu-store, or T7 identity-store "
+                r"T6 bias-relu-store, T7 identity-store, T9 identity-store, "
+                r"or T10 fp16/bf16 bias-store "
                 r"TVM-FFI flat-role seed",
             ):
                 bound.to_triton_code(cfg)
@@ -4637,7 +4643,8 @@ class TestCuteLowerings(unittest.TestCase):
                 # envelope's failure path.
                 r"requires the validated T1 identity-store, T2 bias-store, "
                 r"T3 identity-store, T4 relu-store, T5 identity-store, "
-                r"T6 bias-relu-store, or T7 identity-store "
+                r"T6 bias-relu-store, T7 identity-store, T9 identity-store, "
+                r"or T10 fp16/bf16 bias-store "
                 r"TVM-FFI flat-role seed",
             ):
                 bound.to_triton_code(cfg)
@@ -4733,6 +4740,239 @@ class TestCuteLowerings(unittest.TestCase):
         # accordingly using the same atol as T3.
         expected = (args[0].float() @ args[1].float()).to(torch.bfloat16)
         torch.testing.assert_close(out, expected, atol=1.25, rtol=1e-2)
+
+    def test_tcgen05_direct_entry_plan_admits_target9_identity_store(self) -> None:
+        """Target 9 envelope (2048x2048x2048 + identity) reaches the direct entry."""
+        args = (
+            torch.empty([2048, 2048], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([2048, 2048], device=DEVICE, dtype=torch.bfloat16),
+        )
+        cfg = _make_tcgen05_role_local_monolithic_seed_config(
+            block_sizes=[256, 256, 128],
+            l2_groupings=[2],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=1,
+            tcgen05_ab_stages=3,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+            **{
+                TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: (
+                    Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
+                ),
+                TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: 128,
+                TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: 32,
+                TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: 32,
+                TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY: True,
+                TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True,
+                TCGEN05_DIRECT_ENTRY_PLAN_CONFIG_KEY: True,
+            },
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_role_local_monolithic_4096_bf16.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code = bound.to_triton_code(cfg)
+        # Identity-store + direct-entry plan should record the T9
+        # direct-entry plan and route through the runtime-built
+        # direct entry (compiler-emitted entry is gated to bk=64).
+        self.assertIn("_helion_cute_direct_entry_plans", code)
+        self.assertIn("tcgen05_target1_direct_entry", code)
+        self.assertNotIn("_helion_cute_generated_direct_entry", code)
+
+    def test_tcgen05_direct_entry_plan_rejects_target9_shape_with_bk64(
+        self,
+    ) -> None:
+        """T9 shape with bk=64 fails at codegen.
+
+        The T9 envelope predicate pins ``bk`` to its validated block_k
+        so a (T9 shape) + (bk=64) cross-mismatch is rejected at codegen
+        instead of only at the runtime validator.
+        """
+        args = (
+            torch.empty([2048, 2048], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([2048, 2048], device=DEVICE, dtype=torch.bfloat16),
+        )
+        cfg = _make_tcgen05_role_local_monolithic_seed_config(
+            block_sizes=[256, 256, 64],
+            l2_groupings=[2],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=1,
+            tcgen05_ab_stages=3,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+            **{
+                TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: (
+                    Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
+                ),
+                TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: 128,
+                TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: 32,
+                TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: 32,
+                TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY: True,
+                TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True,
+                TCGEN05_DIRECT_ENTRY_PLAN_CONFIG_KEY: True,
+            },
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_role_local_monolithic_4096_bf16.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            with self.assertRaisesRegex(
+                exc.BackendUnsupported,
+                # Anchor on the full enumerated tail of the
+                # direct-entry rejection error so the test verifies (a)
+                # the rejection path was hit and (b) the listing tail
+                # is intact, without spuriously matching on a different
+                # envelope's failure path.
+                r"requires the validated T1 identity-store, T2 bias-store, "
+                r"T3 identity-store, T4 relu-store, T5 identity-store, "
+                r"T6 bias-relu-store, T7 identity-store, T9 identity-store, "
+                r"or T10 fp16/bf16 bias-store "
+                r"TVM-FFI flat-role seed",
+            ):
+                bound.to_triton_code(cfg)
+
+    def test_tcgen05_direct_entry_plan_admits_target10_bias_bf16(self) -> None:
+        """Target 10 envelope (2048³ + bf16 bias) reaches the direct entry.
+
+        T10 admits both fp16 and bf16 operands at the square 2048³ bias
+        shape (the matmul-fact gate requires ``lhs_dtype == rhs_dtype``
+        and either dtype). The bf16 path stays distinct from T2 via
+        the shape gate (T2 = 4096x2048x2048).
+        """
+        args = (
+            torch.empty([2048, 2048], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([2048, 2048], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([2048], device=DEVICE, dtype=torch.bfloat16),
+        )
+        cfg = _make_tcgen05_role_local_monolithic_seed_config(
+            block_sizes=[256, 256, 128],
+            l2_groupings=[2],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=1,
+            tcgen05_ab_stages=3,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+            **{
+                TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: (
+                    Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
+                ),
+                TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: 128,
+                TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: 32,
+                TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: 32,
+                TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY: True,
+                TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True,
+                TCGEN05_DIRECT_ENTRY_PLAN_CONFIG_KEY: True,
+            },
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_role_local_monolithic_bias_bf16.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code = bound.to_triton_code(cfg)
+        # Bias-store + direct-entry plan at bf16 at the T10 shape
+        # should record the T10 direct-entry plan with ``bias_idx``
+        # and route through the runtime-built direct entry.
+        self.assertIn("_helion_cute_direct_entry_plans", code)
+        self.assertIn("tcgen05_target1_direct_entry", code)
+        self.assertIn("'bias_idx'", code)
+        self.assertNotIn("_helion_cute_generated_direct_entry", code)
+
+    def test_tcgen05_direct_entry_plan_admits_target10_bias_fp16(self) -> None:
+        """Target 10 envelope (2048³ + fp16 bias) reaches the direct entry."""
+        args = (
+            torch.empty([2048, 2048], device=DEVICE, dtype=torch.float16),
+            torch.empty([2048, 2048], device=DEVICE, dtype=torch.float16),
+            torch.empty([2048], device=DEVICE, dtype=torch.float16),
+        )
+        cfg = _make_tcgen05_role_local_monolithic_seed_config(
+            block_sizes=[256, 256, 128],
+            l2_groupings=[2],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=1,
+            tcgen05_ab_stages=3,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+            **{
+                TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: (
+                    Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
+                ),
+                TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: 128,
+                TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: 32,
+                TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: 32,
+                TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY: True,
+                TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True,
+                TCGEN05_DIRECT_ENTRY_PLAN_CONFIG_KEY: True,
+            },
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_role_local_monolithic_bias_bf16.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code = bound.to_triton_code(cfg)
+        # Bias-store + direct-entry plan at fp16 should record the T10
+        # direct-entry plan with ``bias_idx`` and route through the
+        # runtime-built direct entry.
+        self.assertIn("_helion_cute_direct_entry_plans", code)
+        self.assertIn("tcgen05_target1_direct_entry", code)
+        self.assertIn("'bias_idx'", code)
+        self.assertNotIn("_helion_cute_generated_direct_entry", code)
+
+    def test_tcgen05_direct_entry_plan_rejects_target10_dtype_mismatch(
+        self,
+    ) -> None:
+        """T10 codegen rejects a bf16-matmul kernel with fp16 bias (or any cross-dtype).
+
+        The T10 envelope predicate pins ``bias_store_dtype == input_dtype``,
+        so a kernel where the operand dtype and the bias dtype disagree
+        cannot reach the direct entry. This guards against a fp16 bias
+        smuggled into a bf16-operand T2/T6 plan (or vice versa).
+        """
+        # bf16 operands + fp16 bias: the operand-dtype-vs-bias-dtype
+        # mismatch is the cycle-42 invariant the codegen walker is
+        # supposed to catch before launch.
+        args = (
+            torch.empty([2048, 2048], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([2048, 2048], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([2048], device=DEVICE, dtype=torch.float16),
+        )
+        cfg = _make_tcgen05_role_local_monolithic_seed_config(
+            block_sizes=[256, 256, 128],
+            l2_groupings=[2],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=1,
+            tcgen05_ab_stages=3,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_num_epi_warps=4,
+            **{
+                TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: (
+                    Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
+                ),
+                TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: 128,
+                TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: 32,
+                TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: 32,
+                TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY: True,
+                TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True,
+                TCGEN05_DIRECT_ENTRY_PLAN_CONFIG_KEY: True,
+            },
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_role_local_monolithic_bias_bf16.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            with self.assertRaisesRegex(
+                exc.BackendUnsupported,
+                r"requires the validated T1 identity-store, T2 bias-store, "
+                r"T3 identity-store, T4 relu-store, T5 identity-store, "
+                r"T6 bias-relu-store, T7 identity-store, T9 identity-store, "
+                r"or T10 fp16/bf16 bias-store "
+                r"TVM-FFI flat-role seed",
+            ):
+                bound.to_triton_code(cfg)
 
     def test_tcgen05_pure_clc_scheduler_object_builds_initial_work_tile(self) -> None:
         obj = Tcgen05PureClcSchedulerObject(
@@ -9865,6 +10105,309 @@ class TestCuteLowerings(unittest.TestCase):
             "non-scalar binary ops",
             msg,
         )
+
+    def test_tcgen05_fused_silu_epilogue_runtime_correctness_bf16(self) -> None:
+        """``out[tile] = F.silu(acc).to(x.dtype)`` after a bf16 tcgen05
+        matmul splices the silu activation inline at the per-thread T2R
+        register and matches eager ``F.silu(x @ y).to(x.dtype)``.
+
+        Entrance test for the silu fused-epilogue path. PyTorch's
+        inductor-specific decomposition expands
+        ``aten.silu.default`` as ``x / (1 + x.neg().exp())`` (see
+        ``torch/_inductor/decomposition.py``), which traces to
+        ``div(carrier, add(exp(neg(carrier)), 1))`` — a non-scalar
+        binary divide whose two operands both walk back to the matmul
+        accumulator. The generic binary classifier rejects that
+        shape; ``_classify_silu`` in
+        ``helion/_compiler/cute/cute_epilogue.py`` collapses the
+        whole div / add / exp / neg subgraph into a single chain step
+        rendered with the same ``cute.math.exp2``-based sigmoid form
+        Inductor's cutedsl op overrides use. Mirrors the activation
+        target Quack's bench labels ``silu`` (T13 / T17 in
+        ``benchmarks/cute/cute_autotune_sweep.py``).
+        """
+
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_silu_bf16(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = torch.nn.functional.silu(acc).to(x.dtype)
+            return out
+
+        x = torch.randn(128, 128, dtype=torch.bfloat16, device=DEVICE)
+        y = torch.randn(128, 128, dtype=torch.bfloat16, device=DEVICE)
+        bound = cute_matmul_silu_bf16.bind((x, y))
+        bound.env.config_spec.cute_tcgen05_search_enabled = True
+        bound.set_config(
+            _make_tcgen05_persistent_config(
+                block_sizes=[128, 128, 32],
+                pid_type="persistent_interleaved",
+            )
+        )
+        out = bound(x, y)
+        expected = torch.nn.functional.silu((x @ y).float()).to(x.dtype)
+        # bf16 silu has the same tolerance as gelu — the sigmoid form
+        # introduces one extra rounding step beyond a plain relu.
+        torch.testing.assert_close(out, expected, atol=2e-1, rtol=1e-2)
+
+    def test_tcgen05_fused_silu_epilogue_runtime_correctness_fp16(self) -> None:
+        """``out[tile] = F.silu(acc).to(x.dtype)`` after an fp16 tcgen05
+        matmul matches eager ``F.silu(x @ y).to(x.dtype)``.
+
+        Pins that the fp16 LLaMA up-proj silu shape (T26 in
+        ``benchmarks/cute/cute_autotune_sweep.py``) fuses through the
+        same ``_classify_silu`` path as the bf16 entry test above.
+        Separate from the bf16 test because tcgen05 picks distinct
+        kernel layouts for the two dtypes, so an fp16 regression
+        cannot piggyback on a bf16-only test.
+        """
+
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_silu_fp16(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = torch.nn.functional.silu(acc).to(x.dtype)
+            return out
+
+        x = torch.randn(128, 128, dtype=torch.float16, device=DEVICE)
+        y = torch.randn(128, 128, dtype=torch.float16, device=DEVICE)
+        bound = cute_matmul_silu_fp16.bind((x, y))
+        bound.env.config_spec.cute_tcgen05_search_enabled = True
+        bound.set_config(
+            _make_tcgen05_persistent_config(
+                block_sizes=[128, 128, 32],
+                pid_type="persistent_interleaved",
+            )
+        )
+        out = bound(x, y)
+        expected = torch.nn.functional.silu((x @ y).float()).to(x.dtype)
+        torch.testing.assert_close(out, expected, atol=2e-1, rtol=1e-2)
+
+    def test_tcgen05_fused_silu_epilogue_codegen_marker(self) -> None:
+        """The spliced silu chain step renders the
+        ``cute.math.exp2``-based sigmoid form inline against the
+        already-bound chain carrier.
+
+        Pins the silu rendering — ``cute.math.exp2`` plus the
+        ``LOG2_E`` constant — and that the splice substitutes the
+        rendered expression for the multi-node FX subgraph (no
+        ``aten.div`` survives the splice; the chain analyzer
+        collapsed the whole ``div(x, 1 + exp(-x))`` decomposition
+        into one ``tcgen05_chain_step`` local). The constant is
+        spelled as the same literal Inductor's cutedsl sigmoid
+        override uses (``torch/_inductor/codegen/cutedsl/cutedsl_op_overrides.py``)
+        so a future drift between the two paths is caught here.
+        """
+
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_silu_marker(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = torch.nn.functional.silu(acc).to(x.dtype)
+            return out
+
+        x = torch.randn(128, 128, dtype=torch.bfloat16, device=DEVICE)
+        y = torch.randn(128, 128, dtype=torch.bfloat16, device=DEVICE)
+        with patch_cute_mma_support():
+            bound = cute_matmul_silu_marker.bind((x, y))
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            cfg = _make_tcgen05_persistent_config(
+                block_sizes=[128, 128, 32],
+                pid_type="persistent_interleaved",
+            )
+            bound.set_config(cfg)
+            code = bound.to_triton_code(cfg)
+        # The chain analyzer accepted the decomposed silu; the splice
+        # site emitted the sigmoid form (``cute.math.exp2`` + LOG2_E)
+        # at the per-thread T2R register.
+        self.assertIn("cute.math.exp2", code)
+        self.assertIn("tcgen05_acc_loaded", code)
+        self.assertIn("tcgen05_chain_step", code)
+        self.assertIn("1.4426950408889634", code)
+
+    def test_tcgen05_fused_sigmoid_epilogue_runtime_correctness_bf16(self) -> None:
+        """``out[tile] = torch.sigmoid(acc).to(x.dtype)`` after a bf16 tcgen05
+        matmul splices the sigmoid activation inline at the per-thread T2R
+        register and matches eager ``torch.sigmoid(x @ y).to(x.dtype)``.
+
+        Exercises the ``aten.sigmoid.default`` registration in
+        ``_ZERO_ARG_TARGETS`` (``cute_epilogue.py``) — neither
+        ``aten.sigmoid`` nor ``aten.sigmoid.default`` has a registered
+        decomposition (only ``aten.sigmoid_backward`` and the hard
+        variants do), so the user-side ``torch.sigmoid(acc)`` traces
+        through as a single FX node and lands on the standalone
+        sigmoid whitelist row directly — distinct from the silu chain
+        steps below, which are matched by ``_classify_silu`` and
+        never reach the ``_ZERO_ARG_TARGETS`` lookup. Pinning the
+        standalone path keeps a future refactor from accidentally
+        deleting the sigmoid row on the assumption that silu fusion
+        renders the row redundant.
+        """
+
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_sigmoid_bf16(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = torch.sigmoid(acc).to(x.dtype)
+            return out
+
+        x = torch.randn(128, 128, dtype=torch.bfloat16, device=DEVICE)
+        y = torch.randn(128, 128, dtype=torch.bfloat16, device=DEVICE)
+        bound = cute_matmul_sigmoid_bf16.bind((x, y))
+        bound.env.config_spec.cute_tcgen05_search_enabled = True
+        cfg = _make_tcgen05_persistent_config(
+            block_sizes=[128, 128, 32],
+            pid_type="persistent_interleaved",
+        )
+        bound.set_config(cfg)
+        # Capture the generated code first so the assertions confirm
+        # the splice routed through the ``_ZERO_ARG_TARGETS`` sigmoid
+        # row (``cute.math.exp2`` + ``LOG2_E``) before running the
+        # kernel for numerical correctness.
+        with patch_cute_mma_support():
+            code = bound.to_triton_code(cfg)
+        self.assertIn("cute.math.exp2", code)
+        self.assertIn("1.4426950408889634", code)
+        self.assertIn("tcgen05_chain_step", code)
+        out = bound(x, y)
+        expected = torch.sigmoid((x @ y).float()).to(x.dtype)
+        torch.testing.assert_close(out, expected, atol=2e-1, rtol=1e-2)
+
+    def test_tcgen05_fused_silu_mul_form_runtime_correctness_bf16(self) -> None:
+        """``out[tile] = (acc * torch.sigmoid(acc)).to(x.dtype)`` fuses
+        through the ``_classify_silu`` mul-form branch.
+
+        Validates the second ``_classify_silu`` arm
+        (``mul(carrier, sigmoid(carrier))`` / ``mul(sigmoid(carrier),
+        carrier)``) which the inductor-decomp-driven silu tests above
+        never exercise: those tests trace through
+        ``torch/_inductor/decomposition.py``::``silu`` which expands
+        ``aten.silu`` as ``x / (1 + x.neg().exp())``, so they hit the
+        ``div`` arm of ``_classify_silu`` only. Hand-written silu
+        spelled as ``acc * torch.sigmoid(acc)`` is a real user
+        pattern (the ``examples/swiglu.py`` reference path constructs
+        it this way), and the mul arm fuses it as a single step
+        rather than tripping the loud-failure backstop with a
+        non-scalar binary multiply rejection.
+
+        Confirms the chain step lands at the splice site by reading
+        the generated code: the rendered silu form (``cute.math.exp2``
+        + the carrier appearing twice — once for the outer ``x *``
+        and once inside the exp2 argument) survives only if the mul
+        arm of ``_classify_silu`` matched; otherwise the splice
+        falls through to the loud-failure path and ``to_triton_code``
+        raises ``BackendUnsupported`` before returning.
+        """
+
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_silu_mul_form_bf16(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                # Hand-written silu — should trace as
+                # ``mul(carrier, sigmoid(carrier))`` (one FX mul
+                # plus one FX sigmoid) and fuse via ``_classify_silu``'s
+                # mul arm, not via the ``div(x, 1 + exp(-x))`` arm
+                # that the F.silu decomposition produces.
+                out[tile_m, tile_n] = (acc * torch.sigmoid(acc)).to(x.dtype)
+            return out
+
+        x = torch.randn(128, 128, dtype=torch.bfloat16, device=DEVICE)
+        y = torch.randn(128, 128, dtype=torch.bfloat16, device=DEVICE)
+        bound = cute_matmul_silu_mul_form_bf16.bind((x, y))
+        bound.env.config_spec.cute_tcgen05_search_enabled = True
+        cfg = _make_tcgen05_persistent_config(
+            block_sizes=[128, 128, 32],
+            pid_type="persistent_interleaved",
+        )
+        bound.set_config(cfg)
+        with patch_cute_mma_support():
+            code = bound.to_triton_code(cfg)
+        # The splice site emitted the silu form. If the mul arm of
+        # ``_classify_silu`` had not matched, the chain analyzer
+        # would have returned ``None`` and the store would have
+        # raised ``BackendUnsupported`` before producing this code.
+        self.assertIn("cute.math.exp2", code)
+        self.assertIn("1.4426950408889634", code)
+        self.assertIn("tcgen05_chain_step", code)
+        # The standalone sigmoid template renders the bare
+        # ``1.0 / (1.0 + ...)`` without an outer ``x *`` factor; the
+        # silu template wraps it in ``(carrier) * (1.0 / ...)``. A
+        # successful mul-arm match emits the silu template, which
+        # references the carrier-local twice in one rendered chain
+        # step (once for the outer mul, once inside the exp2
+        # argument). Reject any rendering that lacks both
+        # occurrences inside a single chain-step block — that would
+        # indicate the splice degenerated to the plain sigmoid
+        # template plus a free-standing outer mul.
+        chain_step_index = code.find("tcgen05_chain_step")
+        # The renderer emits ``<chain_step_var> = (carrier) * (1.0 / (1.0 +
+        # cute.math.exp2(...)))`` on a single line; the assignment line
+        # must reference both the outer ``*`` and the ``exp2`` call
+        # ahead of the next chain-step assignment.
+        next_chain_step = code.find("tcgen05_chain_step", chain_step_index + 1)
+        chain_step_line_end = code.find("\n", chain_step_index)
+        if next_chain_step == -1 or next_chain_step > chain_step_line_end:
+            single_step = code[chain_step_index:chain_step_line_end]
+        else:
+            single_step = code[chain_step_index:next_chain_step]
+        self.assertIn("*", single_step)
+        self.assertIn("cute.math.exp2", single_step)
+        out = bound(x, y)
+        ref = x @ y
+        expected = (ref * torch.sigmoid(ref)).to(x.dtype)
+        torch.testing.assert_close(out, expected, atol=2e-1, rtol=1e-2)
 
     def test_tcgen05_fused_bias_gelu_tanh_approx_runtime_correctness(
         self,
@@ -19443,8 +19986,8 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         population for aux-detected kernels.
 
         Pin: an aux-detected residual kernel's
-        ``autotune_seed_configs()`` list contains a config with
-        the productive C-input warp shape:
+        ``autotune_seed_configs()`` list contains the canonical
+        productive C-input warp shape:
             - ``tcgen05_strategy = ROLE_LOCAL_WITH_SCHEDULER``
             - ``tcgen05_warp_spec_scheduler_warps = 1``
             - ``tcgen05_warp_spec_c_input_warps = 1``
@@ -19452,6 +19995,11 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
             - ``block_sizes = [256, 256, 128]``
             - ``tcgen05_cluster_m = 2``
             - ``pid_type = persistent_interleaved``
+
+        Cycle 46 also adds an aux-TMA variant of the same shape
+        (``aux_load_mode=tma``) when the full-tile cluster_m=2
+        family is admitted, so the seed list contains the base
+        c-input seed plus its aux-TMA twin.
         """
         from helion._compiler.cute.strategies import Tcgen05Strategy
 
@@ -19467,34 +20015,44 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         c_input_seeds = [
             s for s in seeds if s.config.get("tcgen05_warp_spec_c_input_warps") == 1
         ]
+        # Base c-input seed (no aux load mode key) plus its aux-TMA twin.
         self.assertEqual(
             len(c_input_seeds),
-            1,
-            f"expected exactly one c_input=1 seed, got {len(c_input_seeds)} "
+            2,
+            f"expected base + aux-TMA c_input=1 seeds, got {len(c_input_seeds)} "
             f"out of {len(seeds)} seeds: {[s.config for s in seeds]}",
         )
-        seed = c_input_seeds[0].config
-        self.assertEqual(
-            seed["tcgen05_strategy"],
-            Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value,
-        )
-        self.assertEqual(seed["tcgen05_warp_spec_scheduler_warps"], 1)
-        self.assertEqual(seed["tcgen05_warp_spec_c_input_warps"], 1)
-        self.assertEqual(seed["tcgen05_ab_stages"], 2)
-        self.assertEqual(seed["block_sizes"][0], 256)
-        self.assertEqual(seed["block_sizes"][1], 256)
-        self.assertEqual(seed["tcgen05_cluster_m"], 2)
-        self.assertEqual(seed["pid_type"], "persistent_interleaved")
-        # Pin ``l2_groupings=[1]``: direct verification on 4096^3
-        # and 8192x4096x2048 shows ``c_input_warps=1 +
-        # cluster_m=2 + l2_groupings=[g]`` produces 60-69%
-        # mismatched elements for every ``g > 1``. The matched
-        # cycle 2c forced c_input=1 baselines all run at
-        # ``g=1``. The cluster_m2 seed's
-        # ``TCGEN05_TWO_CTA_SEED_L2_GROUPING=4`` is intentionally
-        # NOT mirrored here (would defeat the purpose of the
-        # seed by producing wrong output).
-        self.assertEqual(seed["l2_groupings"], [1])
+        base_seeds = [
+            s for s in c_input_seeds if "tcgen05_aux_load_mode" not in s.config
+        ]
+        aux_tma_seeds = [
+            s for s in c_input_seeds if s.config.get("tcgen05_aux_load_mode") == "tma"
+        ]
+        self.assertEqual(len(base_seeds), 1)
+        self.assertEqual(len(aux_tma_seeds), 1)
+        # The aux-TMA seed is a pure overlay on the base seed.
+        for seed_config in (base_seeds[0].config, aux_tma_seeds[0].config):
+            self.assertEqual(
+                seed_config["tcgen05_strategy"],
+                Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value,
+            )
+            self.assertEqual(seed_config["tcgen05_warp_spec_scheduler_warps"], 1)
+            self.assertEqual(seed_config["tcgen05_warp_spec_c_input_warps"], 1)
+            self.assertEqual(seed_config["tcgen05_ab_stages"], 2)
+            self.assertEqual(seed_config["block_sizes"][0], 256)
+            self.assertEqual(seed_config["block_sizes"][1], 256)
+            self.assertEqual(seed_config["tcgen05_cluster_m"], 2)
+            self.assertEqual(seed_config["pid_type"], "persistent_interleaved")
+            # Pin ``l2_groupings=[1]``: direct verification on 4096^3
+            # and 8192x4096x2048 shows ``c_input_warps=1 +
+            # cluster_m=2 + l2_groupings=[g]`` produces 60-69%
+            # mismatched elements for every ``g > 1``. The matched
+            # cycle 2c forced c_input=1 baselines all run at
+            # ``g=1``. The cluster_m2 seed's
+            # ``TCGEN05_TWO_CTA_SEED_L2_GROUPING=4`` is intentionally
+            # NOT mirrored here (would defeat the purpose of the
+            # seed by producing wrong output).
+            self.assertEqual(seed_config["l2_groupings"], [1])
 
     def test_aux_autotune_seeds_omit_c_input_config_for_pure_matmul(self) -> None:
         """Autotune seed pin (pure-matmul case).


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2682
 * #2681
 * #2680
 * #2679
 * #2678
 * #2656
 * #2655
 * #2654
 * #2653
 * #2652
 * __->__#2651


--- --- ---

[cutedsl] expand epilogue store support and autotuner seeds

Add silu/sigmoid activation epilogues alongside identity, bias, and
residual-add store paths, each with autotuner seeds and aux-TMA
admission gating. Enable the tvm-ffi launcher by default to cut host
overhead on small shapes.