### PR TITLE
[cutedsl] add best-of-K autotuning and stabilize benchmarking

### DIFF
--- a/benchmarks/cute/compare_matmul_backends.py
+++ b/benchmarks/cute/compare_matmul_backends.py
@@ -13,7 +13,7 @@ baseline. Use quack only to see public-API perf as a torch.compile user would.
 See ``perf_gap_findings.md``.
 
 Each impl runs in a fresh subprocess (so HELION_BACKEND env mutation does not
-leak), with steady-state methodology (2 s thermal warmup, do_bench
+leak), with steady-state methodology (10 s thermal warmup, do_bench
 warmup=1 s + rep=500 ms, 5 runs), and reports best plus mom-median ms/TFLOP/s.
 The gate metric is mom-median TFLOP/s: the median of the five do_bench medians.
 Best-of-N is diagnostic only.
@@ -118,6 +118,9 @@ from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_C_STORE_MODE_SKIP_EPILOGUE_STORE,
 )
 from helion._compiler.cute.tcgen05_constants import TCGEN05_C_STORE_MODES
+from helion._compiler.cute.tcgen05_constants import TCGEN05_CONSUMER_REGS_CHOICES
+from helion._compiler.cute.tcgen05_constants import TCGEN05_CONSUMER_REGS_CONFIG_KEY
+from helion._compiler.cute.tcgen05_constants import TCGEN05_CONSUMER_REGS_DEFAULT
 from helion._compiler.cute.tcgen05_constants import TCGEN05_CUBIN_LINEINFO_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_DIAGNOSTIC_INVALID_OUTPUT_CONFIG_KEY,
@@ -912,12 +915,21 @@ def _check_close(
         )
 
 
-def _gpu_warmup(duration_ms: int = 2000) -> None:
+def _gpu_warmup(duration_ms: int = 10000) -> None:
     """Drive the GPU to a stable clock state with sustained matmul work.
 
-    Without this, the first benchmark run after process startup gets
-    artificially good numbers because the GPU has not been clock-cycled
-    into its sustained-load state yet.
+    Without warmup the first benchmark in a new process is at the mercy of
+    the GPU's current clock state, which on B200 ranges from idle (120 MHz)
+    to sustained boost (~1965 MHz) with a ~5-7 s cold-to-boost ramp. The
+    direction of the bias depends on what the GPU was doing before this
+    process started: if the GPU was idle, the first samples are clocked
+    low and the kernel measures artificially slow; if the GPU was recently
+    hot from neighbor activity but is now coasting on residual boost, the
+    first samples measure artificially fast. Either way, the steady-state
+    measurement under sustained load is the canonical number, and the
+    warmup ensures we start there.
+
+    The default 10 s duration covers the cold-to-boost ramp on B200.
     """
     a = torch.randn(4096, 4096, device="cuda", dtype=torch.bfloat16)
     torch.cuda.synchronize()
@@ -936,7 +948,7 @@ def _bench_steady(
     warmup_ms: int,
     rep_ms: int,
     cache_warmup_calls: int = 5,
-    thermal_warmup_ms: int = 2000,
+    thermal_warmup_ms: int = 10000,
 ) -> dict[str, Any]:
     """Steady-state benchmark.
 
@@ -1236,6 +1248,8 @@ def _make_helion_config_from_args(args: argparse.Namespace) -> helion.Config:
             config["tcgen05_warp_spec_scheduler_warps"] = 1
     if args.helion_c_input_warps is not None:
         config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY] = args.helion_c_input_warps
+    if args.helion_consumer_regs is not None:
+        config[TCGEN05_CONSUMER_REGS_CONFIG_KEY] = args.helion_consumer_regs
     if args.helion_persistence_model is not None:
         config["tcgen05_persistence_model"] = args.helion_persistence_model
     if args.helion_acc_producer_mode != TCGEN05_ACC_PRODUCER_MODE_NORMAL:
@@ -1733,6 +1747,8 @@ def _build_subprocess_cmd(args: argparse.Namespace, impl: str) -> list[str]:
             cmd.extend(["--helion-strategy", args.helion_strategy])
         if args.helion_c_input_warps is not None:
             cmd.extend(["--helion-c-input-warps", str(args.helion_c_input_warps)])
+        if args.helion_consumer_regs is not None:
+            cmd.extend(["--helion-consumer-regs", str(args.helion_consumer_regs)])
         if args.helion_persistence_model is not None:
             cmd.extend(["--helion-persistence-model", args.helion_persistence_model])
         if args.helion_l2_swizzle_size is not None:
@@ -4190,6 +4206,8 @@ def _build_two_cta_ncu_profile_command(
             cmd.extend(["--helion-strategy", args.helion_strategy])
         if args.helion_c_input_warps is not None:
             cmd.extend(["--helion-c-input-warps", str(args.helion_c_input_warps)])
+        if args.helion_consumer_regs is not None:
+            cmd.extend(["--helion-consumer-regs", str(args.helion_consumer_regs)])
         if args.helion_persistence_model is not None:
             cmd.extend(["--helion-persistence-model", args.helion_persistence_model])
         cmd.extend(_helion_diagnostic_flag_args(args))
@@ -6270,6 +6288,19 @@ def parse_args() -> argparse.Namespace:
         choices=(0, 1),
         default=None,
         help="Optional tcgen05 C-input warp override for fixed Helion configs.",
+    )
+    parser.add_argument(
+        "--helion-consumer-regs",
+        type=int,
+        choices=TCGEN05_CONSUMER_REGS_CHOICES,
+        default=None,
+        help=(
+            "Optional tcgen05 consumer register-cap override for fixed Helion "
+            "configs. Sets the tcgen05_consumer_regs config key, which "
+            "CuTe codegen emits as cute.arch.setmaxregister_increase(<value>). "
+            "Default None omits the key (CuTe defaults to "
+            f"{TCGEN05_CONSUMER_REGS_DEFAULT})."
+        ),
     )
     parser.add_argument(
         "--helion-persistence-model",

--- a/helion/autotuner/aot_cache.py
+++ b/helion/autotuner/aot_cache.py
@@ -48,6 +48,7 @@ from .base_cache import LooseAutotuneCacheKey
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from typing import Callable
 
     from .base_search import BaseSearch
 
@@ -303,8 +304,13 @@ class AOTAutotuneCache(AutotuneCacheBase):
         cls._mode_announced.clear()
         log.debug("Cleared AOTAutotuneCache caches")
 
-    def __init__(self, autotuner: BaseSearch) -> None:
-        super().__init__(autotuner)
+    def __init__(
+        self,
+        autotuner: BaseSearch,
+        *,
+        autotuner_factory: Callable[[], BaseSearch] | None = None,
+    ) -> None:
+        super().__init__(autotuner, autotuner_factory=autotuner_factory)
         self.mode = get_aot_mode()
         self.hardware_id = get_hardware_info().hardware_id
         self.data_dir = get_aot_data_dir()

--- a/helion/autotuner/base_cache.py
+++ b/helion/autotuner/base_cache.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import abc
 import dataclasses
 import functools
+import gc
 import hashlib
 import logging
+import math
 import os
 import sys
 from typing import TYPE_CHECKING
@@ -12,6 +14,7 @@ from typing import Any
 from typing import Callable
 from typing import Hashable
 
+import torch
 from torch._inductor.codecache import build_code_hash
 from torch._inductor.codecache import torch_key
 
@@ -60,7 +63,11 @@ class AutotuneCacheMeta(abc.ABCMeta):
                     f"(e.g. BoundKernel); got {type(kernel).__name__}. "
                     f"External kernels are not cacheable."
                 )
-            return cls(search_cls(kernel, args))  # type: ignore[misc]
+
+            def autotuner_factory() -> BaseSearch:
+                return search_cls(kernel, args)
+
+            return cls(autotuner_factory(), autotuner_factory=autotuner_factory)  # type: ignore[misc]
 
         return factory
 
@@ -126,6 +133,10 @@ class LooseAutotuneCacheKey(BoundKernelInMemoryCacheKey):
     backend: Kernel backend (e.g. triton, pallas)
     config_spec_hash: Hash of the config spec (available knobs and their ranges)
     extra_cache_key: Optional extra cache key from the kernel (e.g. fusion context hash)
+    best_of_k: Number of autotune trials run with different random seeds; the
+        winning config across trials is the one cached. Default ``1`` (the
+        historical single-trial path) is hidden from ``repr`` so K=1 cache
+        hashes stay byte-identical to entries written before this field existed.
     """
 
     kernel_source_hash: str
@@ -134,6 +145,20 @@ class LooseAutotuneCacheKey(BoundKernelInMemoryCacheKey):
     backend: str
     config_spec_hash: str = ""
     extra_cache_key: str = ""
+    # ``repr=False`` keeps the field out of the dataclass-generated ``repr``;
+    # ``__repr__`` below adds it only when it deviates from the default so the
+    # K=1 hash matches historical bytes exactly.
+    best_of_k: int = dataclasses.field(default=1, repr=False)
+
+    def __repr__(self) -> str:
+        # Reproduce the dataclass-generated repr for all auto-repr fields, then
+        # append ``best_of_k`` only when it is non-default. This preserves the
+        # byte-identical hash for K=1 entries written before the field existed.
+        auto_fields = [f for f in dataclasses.fields(self) if f.repr]
+        body = ", ".join(f"{f.name}={getattr(self, f.name)!r}" for f in auto_fields)
+        if self.best_of_k != 1:
+            body = f"{body}, best_of_k={self.best_of_k!r}"
+        return f"{type(self).__name__}({body})"
 
     def stable_hash(self) -> str:
         return hashlib.sha256(repr(self).encode("utf-8")).hexdigest()
@@ -164,8 +189,23 @@ class AutotuneCacheBase(BaseAutotuner, abc.ABC, metaclass=AutotuneCacheMeta):
     provide implementations for get and put methods.
     """
 
-    def __init__(self, autotuner: BaseSearch) -> None:
+    def __init__(
+        self,
+        autotuner: BaseSearch,
+        *,
+        autotuner_factory: Callable[[], BaseSearch] | None = None,
+    ) -> None:
+        """Initialize the cache.
+
+        ``autotuner_factory`` is an optional zero-argument callable that
+        returns a fresh inner ``BaseSearch`` instance. It is required for
+        ``autotune_best_of_k > 1`` (used by :meth:`_run_autotune_trials`
+        to construct one ``BaseSearch`` per trial). When ``None``,
+        ``autotune_best_of_k`` must equal 1; otherwise
+        :meth:`_run_autotune_trials` raises ``RuntimeError``.
+        """
         self.autotuner = autotuner
+        self._autotuner_factory = autotuner_factory
         kernel = self.autotuner.kernel
         if not kernel.is_cacheable():
             raise TypeError(
@@ -270,7 +310,7 @@ class AutotuneCacheBase(BaseAutotuner, abc.ABC, metaclass=AutotuneCacheMeta):
 
         self.autotuner.log("Starting autotuning process, this may take a while...")
 
-        config = self.autotuner.autotune()
+        config = self._run_autotune_trials()
 
         if not skip_cache_env:
             self.put(config)
@@ -278,3 +318,201 @@ class AutotuneCacheBase(BaseAutotuner, abc.ABC, metaclass=AutotuneCacheMeta):
             log.debug("cache put: %s", str(config))
 
         return config
+
+    def _release_trial_state(self) -> None:
+        """Reclaim CUDA allocator state between best-of-K trials.
+
+        ``LocalBenchmarkProvider.cleanup`` (called from
+        ``BaseSearch.autotune``'s exit stack and from
+        ``_run_rebench_round``) breaks the search-provider-budget-hook
+        reference cycle and drops the baseline tensors, so refcounting
+        can free the provider's GPU memory deterministically. This
+        helper then runs a Python ``gc.collect`` pass to catch any other
+        cycles, plus ``torch.cuda.empty_cache`` so the caching allocator
+        returns the freed blocks to the driver pool before the next
+        trial / the post-autotune steady-state measurement allocates.
+        """
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+            torch.cuda.empty_cache()
+
+    def _run_one_trial(self, i: int, k: int, trial_seed: int) -> tuple[Config, float]:
+        """Construct a fresh trial autotuner, run it, return its results.
+
+        The trial autotuner is scoped to this helper's local frame so it
+        becomes unreachable as soon as we return. The caller then runs
+        ``_release_trial_state`` to release the provider's CUDA memory
+        before the next trial / rebench / ``_bench_steady`` step.
+        Returns ``(trial_config, trial_low_water_perf)``; any exception
+        from the inner ``autotune()`` propagates to the caller (whose
+        ``try``/``finally`` still runs ``_release_trial_state``).
+        """
+        assert self._autotuner_factory is not None
+        trial_autotuner = self._autotuner_factory()
+        # Swap so logging/error-reporting reflects the active trial.
+        self.autotuner = trial_autotuner
+        self.autotuner.log(f"Best-of-K trial {i + 1}/{k} starting (seed={trial_seed})")
+        trial_config = trial_autotuner.autotune()
+        trial_low_water_perf = trial_autotuner.best_perf_so_far
+        self.autotuner.log(
+            f"Best-of-K trial {i + 1}/{k} complete: "
+            f"low-water perf={trial_low_water_perf:.4f}ms "
+            f"config={trial_config}"
+        )
+        return trial_config, trial_low_water_perf
+
+    def _run_autotune_trials(self) -> Config:
+        """Run the configured number of autotune trials and return the best config.
+
+        When ``settings.autotune_best_of_k == 1`` (the default) this falls
+        through to a single ``self.autotuner.autotune()`` call, leaving
+        behavior byte-identical to the historical single-trial path.
+
+        When ``settings.autotune_best_of_k > 1`` this runs K independent
+        autotune trials with deterministic per-trial seeds
+        (``seed = base + i for i in range(K)``). Each trial uses a fresh
+        ``BaseSearch`` built via ``self._autotuner_factory`` so per-trial
+        state (population, surrogate, training data, benchmark provider,
+        budget timer) is isolated by construction. After all K trials
+        complete, each trial's *returned* config is re-benchmarked once
+        in a single fresh-provider round to pick the final winner fairly
+        — using each trial's own ``best_perf_so_far`` would bias toward
+        trials that happened to hit an optimistic outlier timing during
+        their search.
+
+        Cost: K full autotune wall-times + one extra K-config benchmark
+        round at the end.
+
+        After each trial and after the final rebench round, the trial's
+        local autotuner is dropped and ``_release_trial_state`` runs a
+        Python GC pass + ``torch.cuda.empty_cache`` to return the
+        provider's freed CUDA blocks to the driver pool before the next
+        allocation wave (the next trial or the post-autotune
+        ``_bench_steady`` measurement). Without this, the caching
+        allocator stays fragmented across the autotune and the
+        post-autotune steady-state measurement sees a per-launch
+        overhead that is proportionally large for fast-launch kernels.
+        """
+        settings = self.autotuner.settings
+        k = settings.autotune_best_of_k
+        if k <= 1:
+            return self.autotuner.autotune()
+        if self._autotuner_factory is None:
+            raise RuntimeError(
+                "autotune_best_of_k > 1 requires a registered _autotuner_factory; "
+                "the public Cache(autotuner) constructor does not support best-of-K. "
+                "Use default_autotuner_fn or wire your custom autotuner_fn to attach "
+                "the factory via Cache(autotuner, autotuner_factory=...)."
+            )
+
+        base_seed = settings.autotune_random_seed
+        # Snapshot any settings the autotuner mutates inside ``_prepare`` /
+        # ``set_adaptive_compile_timeout`` so trial N+1 starts with the same
+        # values trial 1 saw. Without this, trial 1's adaptive-timeout
+        # narrowing leaks into later trials and they are not independent.
+        base_compile_timeout = settings.autotune_compile_timeout
+        original_autotuner = self.autotuner
+
+        self.autotuner.log(
+            f"Best-of-K autotune: running {k} trials with seeds "
+            f"[{base_seed}, {base_seed + k - 1}]"
+        )
+
+        trial_results: list[tuple[int, Config, float]] = []
+        try:
+            for i in range(k):
+                trial_seed = base_seed + i
+                try:
+                    settings.autotune_random_seed = trial_seed
+                    settings.autotune_compile_timeout = base_compile_timeout
+                    trial_config, trial_low_water_perf = self._run_one_trial(
+                        i, k, trial_seed
+                    )
+                    trial_results.append((i, trial_config, trial_low_water_perf))
+                finally:
+                    settings.autotune_random_seed = base_seed
+                    settings.autotune_compile_timeout = base_compile_timeout
+                    # Restore the cache wrapper's original autotuner so the
+                    # finished trial's autotuner has no remaining strong
+                    # refs once ``_run_one_trial``'s local scope unwinds.
+                    # The provider's ``cleanup`` (run inside ``autotune``'s
+                    # exit stack) breaks the search-provider-budget-hook
+                    # cycle and drops the baseline tensors;
+                    # ``_release_trial_state`` then returns the freed
+                    # CUDA blocks to the driver pool before the next
+                    # trial / the post-autotune ``_bench_steady`` runs.
+                    self.autotuner = original_autotuner
+                    self._release_trial_state()
+        finally:
+            self.autotuner = original_autotuner
+
+        # Final rebench: time each trial's returned config in a single fresh
+        # benchmark round so we pick by an apples-to-apples measurement
+        # rather than each trial's optimistic low-water mark.
+        rebench_perfs = self._rebench_trial_configs(
+            [config for (_, config, _) in trial_results]
+        )
+
+        best_idx = min(
+            range(len(trial_results)),
+            key=lambda j: (
+                rebench_perfs[j] if math.isfinite(rebench_perfs[j]) else math.inf
+            ),
+        )
+        best_trial_idx, best_config, _ = trial_results[best_idx]
+        best_perf = rebench_perfs[best_idx]
+
+        low_water_summary = ", ".join(f"{p:.4f}" for (_, _, p) in trial_results)
+        rebench_summary = ", ".join(f"{p:.4f}" for p in rebench_perfs)
+        self.autotuner.log(
+            f"Best-of-K complete: picked trial {best_trial_idx + 1}/{k} "
+            f"(rebench perf={best_perf:.4f}ms); "
+            f"per-trial low-water perfs (ms): [{low_water_summary}]; "
+            f"per-trial rebench perfs (ms): [{rebench_summary}]"
+        )
+        return best_config
+
+    def _rebench_trial_configs(self, configs: list[Config]) -> list[float]:
+        """Benchmark K candidate configs in a single fresh autotuner round.
+
+        Returns one perf (ms) per input config, in input order. Used to pick
+        the best-of-K winner without trusting each trial's own optimistic
+        ``best_perf_so_far`` low-water mark, which can be inflated by a
+        single fast outlier timing during the search.
+
+        The rebench autotuner is scoped to a private helper so it becomes
+        unreachable as soon as we return; ``_release_trial_state`` then
+        releases CUDA memory before the caller proceeds to the
+        post-autotune ``_bench_steady`` measurement.
+        """
+        perfs = self._run_rebench_round(configs)
+        self._release_trial_state()
+        return perfs
+
+    def _run_rebench_round(self, configs: list[Config]) -> list[float]:
+        """Build the rebench autotuner, time the configs, return their perfs.
+
+        Scoped to its own frame so the rebench autotuner becomes
+        unreachable when this returns and the caller's
+        ``_release_trial_state`` pass can return its CUDA blocks to the
+        driver pool. Note that ``benchmark_provider.cleanup`` (called in
+        the ``finally`` below) is what actually drops the provider's
+        baseline tensors and breaks the search-provider-budget-hook
+        reference cycle; this helper just controls scope so the released
+        memory is reclaimed before the caller's ``empty_cache`` runs.
+        """
+        assert self._autotuner_factory is not None
+        rebench_autotuner = self._autotuner_factory()
+        # ``_prepare`` constructs the ``benchmark_provider``; ``setup`` /
+        # ``cleanup`` bracket the provider's lifetime. Mirror the lifecycle
+        # ``BaseSearch.autotune`` runs internally.
+        rebench_autotuner._prepare()
+        rebench_autotuner.benchmark_provider.setup()
+        try:
+            results = rebench_autotuner.benchmark_batch(
+                configs, desc="Best-of-K rebench"
+            )
+        finally:
+            rebench_autotuner.benchmark_provider.cleanup()
+        return [r.perf for r in results]

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -600,7 +600,16 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         )
 
     def cleanup(self) -> None:
-        """Release precompile tmpdir and related resources."""
+        """Release precompile tmpdir, baseline tensors, and the budget hook.
+
+        The budget hook installed by ``BaseSearch._prepare`` is a bound
+        method that holds a reference to the search; without resetting it
+        the search ``->`` provider ``->`` bound-method ``->`` search
+        reference cycle keeps both alive until the next cyclic GC pass.
+        Dropping the baseline tensors here lets refcount reclaim the
+        cloned-arg GPU memory deterministically as soon as the provider
+        loses its last external reference.
+        """
         if self._benchmark_worker is not None:
             self._benchmark_worker.shutdown()
             self._benchmark_worker = None
@@ -609,6 +618,15 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             self._precompile_tmpdir = None
         self._precompile_args_path = None
         self._precompile_result_counter = count()
+        # Drop the baseline tensors (GPU memory) so refcount frees them
+        # the moment the provider loses its last external reference.
+        self._baseline_output = None
+        self._baseline_post_args = None
+        # Restore the class-level no-op default so the provider no longer
+        # holds a bound-method reference back to the search. Without this
+        # the search-provider-budget-hook cycle (search -> provider ->
+        # bound-method -> search) survives until cyclic GC runs.
+        self.budget_exceeded_fn = _never_exceeded
 
     def _subprocess_benchmark_uses_wall_clock(self) -> bool:
         backend = getattr(self.config_spec, "backend", None)

--- a/helion/autotuner/local_cache.py
+++ b/helion/autotuner/local_cache.py
@@ -26,6 +26,7 @@ from .base_cache import StrictAutotuneCacheKey
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from collections.abc import Sequence
+    from typing import Callable
 
     from .base_search import BaseSearch
 
@@ -125,8 +126,13 @@ class LocalAutotuneCache(AutotuneCacheBase):
     PyTorch. Use StrictLocalAutotuneCache to consider these properties.
     """
 
-    def __init__(self, autotuner: BaseSearch) -> None:
-        super().__init__(autotuner)
+    def __init__(
+        self,
+        autotuner: BaseSearch,
+        *,
+        autotuner_factory: Callable[[], BaseSearch] | None = None,
+    ) -> None:
+        super().__init__(autotuner, autotuner_factory=autotuner_factory)
         self.key = self._generate_key()
 
     def _generate_key(self) -> LooseAutotuneCacheKey:
@@ -189,6 +195,7 @@ class LocalAutotuneCache(AutotuneCacheBase):
             backend=self.kernel.env.backend.name,
             config_spec_hash=config_spec_hash,
             extra_cache_key=self.kernel.extra_cache_key(),
+            best_of_k=self.autotuner.settings.autotune_best_of_k,
         )
 
     def _get_local_cache_path(self) -> Path:

--- a/helion/autotuner/remote_cache.py
+++ b/helion/autotuner/remote_cache.py
@@ -13,6 +13,7 @@ from .local_cache import StrictLocalAutotuneCache
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from typing import Callable
 
     from .base_search import BaseSearch
 
@@ -92,8 +93,13 @@ class RemoteAutotuneCache(LocalAutotuneCache):
     On *put*: write to both local and remote.
     """
 
-    def __init__(self, autotuner: BaseSearch) -> None:
-        super().__init__(autotuner)
+    def __init__(
+        self,
+        autotuner: BaseSearch,
+        *,
+        autotuner_factory: Callable[[], BaseSearch] | None = None,
+    ) -> None:
+        super().__init__(autotuner, autotuner_factory=autotuner_factory)
         self._backend = _load_remote_backend()
 
     def get(self) -> Config | None:
@@ -124,8 +130,13 @@ class RemoteAutotuneCache(LocalAutotuneCache):
 class StrictRemoteAutotuneCache(StrictLocalAutotuneCache):
     """Strict local cache extended with a remote read-through / write-through layer."""
 
-    def __init__(self, autotuner: BaseSearch) -> None:
-        super().__init__(autotuner)
+    def __init__(
+        self,
+        autotuner: BaseSearch,
+        *,
+        autotuner_factory: Callable[[], BaseSearch] | None = None,
+    ) -> None:
+        super().__init__(autotuner, autotuner_factory=autotuner_factory)
         self._backend = _load_remote_backend()
 
     def get(self) -> Config | None:

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -29,6 +29,7 @@ from .ref_mode import RefMode
 
 if TYPE_CHECKING:
     from ..autotuner.base_search import BaseAutotuner
+    from ..autotuner.base_search import BaseSearch
     from ..autotuner.pattern_search import InitialPopulationStrategy
     from .config import Config
     from .kernel import BoundKernel
@@ -284,8 +285,14 @@ def default_autotuner_fn(
         if k not in kwargs and k in parameters:
             kwargs[k] = v
 
-    # pyrefly: ignore [bad-argument-type]
-    autotuner = autotuner_cls(bound_kernel, args, **kwargs)
+    def autotuner_factory() -> BaseSearch:
+        """Build a fresh inner BaseSearch instance.
+
+        Used by the best-of-K cache layer to construct K independent
+        autotuner instances, one per trial.
+        """
+        # pyrefly: ignore [bad-argument-type]
+        return autotuner_cls(bound_kernel, args, **kwargs)
 
     cache_name = bound_kernel.settings.autotune_cache
     cache_cls = cache_classes.get(cache_name)
@@ -295,7 +302,11 @@ def default_autotuner_fn(
             f"{', '.join(cache_classes.keys())}"
         )
 
-    return cache_cls(autotuner)
+    # The cache layer's best-of-K loop calls ``autotuner_factory`` once per
+    # trial. The first construction here is the autotuner the cache wraps
+    # for the K=1 path; the factory is also passed through so K>1 trials can
+    # build additional fresh autotuners.
+    return cache_cls(autotuner_factory(), autotuner_factory=autotuner_factory)
 
 
 def _get_autotune_random_seed() -> int:
@@ -423,6 +434,9 @@ class _Settings:
     )
     autotune_random_seed: int = dataclasses.field(
         default_factory=_get_autotune_random_seed
+    )
+    autotune_best_of_k: int = dataclasses.field(
+        default_factory=functools.partial(_env_get_int, "HELION_AUTOTUNE_BEST_OF_K", 1)
     )
     autotune_accuracy_check: bool = dataclasses.field(
         default_factory=functools.partial(
@@ -613,6 +627,16 @@ class Settings(_Settings):
         "autotune_precompile": "Autotuner precompile mode: 'fork', 'spawn', or falsy/None to disable. Defaults to 'fork' on non-Windows platforms.",
         "autotune_precompile_jobs": "Maximum concurrent Triton precompile processes, default to cpu count.",
         "autotune_random_seed": "Seed used for autotuner random number generation. Defaults to HELION_AUTOTUNE_RANDOM_SEED or a time-based seed.",
+        "autotune_best_of_k": (
+            "When > 1, run autotuning K times with different random seeds and "
+            "keep the config with the best benchmark performance. Each trial "
+            "uses ``seed = autotune_random_seed + i`` for i in range(K), so two "
+            "runs with the same base seed produce the same K configs. Cost is "
+            "K× the autotune wall time. Cache entries are keyed on K, so a "
+            "K≥2 result will not be overwritten by a later K=1 run and "
+            "vice versa. Default 1 (current single-trial behavior). Set "
+            "HELION_AUTOTUNE_BEST_OF_K=N to override."
+        ),
         "autotune_accuracy_check": "If True, validate candidate configs against the baseline kernel output before accepting them during autotuning.",
         "autotune_rebenchmark_threshold": "If a config is within threshold*best_perf, re-benchmark it to avoid outliers. Defaults to effort profile value. Set HELION_REBENCHMARK_THRESHOLD to override.",
         "autotune_suspicious_rebenchmark_ratio": "When subprocess benchmarking is enabled, recheck rebenchmark timings below ratio*previous_timing before accepting them. Defaults to 0.9. Set HELION_AUTOTUNE_SUSPICIOUS_REBENCHMARK_RATIO=0 to disable.",
@@ -767,6 +791,13 @@ class Settings(_Settings):
 
         if self.backend == "tileir" and os.environ.get("ENABLE_TILE", "0") != "1":
             raise exc.MissingEnableTile
+
+        if self.autotune_best_of_k < 1:
+            raise ValueError(
+                f"autotune_best_of_k must be >= 1, got {self.autotune_best_of_k!r}; "
+                f"set HELION_AUTOTUNE_BEST_OF_K to a positive integer "
+                f"(default 1 = single-trial behavior)"
+            )
 
         self._check_ref_eager_mode_before_print_output_code()
 

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -2845,6 +2845,399 @@ class TestAutotuneRandomSeed(RefEagerTestDisabled, TestCase):
         self.assertNotEqual(first, second)
 
 
+class TestAutotuneBestOfKSettings(TestCase):
+    """Settings-only coverage for ``autotune_best_of_k`` (no GPU/backend
+    dependency)."""
+
+    def test_default_is_one(self) -> None:
+        with without_env_var("HELION_AUTOTUNE_BEST_OF_K"):
+            self.assertEqual(helion.Settings().autotune_best_of_k, 1)
+
+    def test_env_var_override(self) -> None:
+        with patch.dict(os.environ, {"HELION_AUTOTUNE_BEST_OF_K": "5"}, clear=False):
+            self.assertEqual(helion.Settings().autotune_best_of_k, 5)
+
+    def test_setting_override(self) -> None:
+        self.assertEqual(helion.Settings(autotune_best_of_k=3).autotune_best_of_k, 3)
+
+    def test_k_zero_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, r"autotune_best_of_k must be >= 1"):
+            helion.Settings(autotune_best_of_k=0)
+
+    def test_k_negative_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, r"autotune_best_of_k must be >= 1"):
+            helion.Settings(autotune_best_of_k=-3)
+
+
+@onlyBackends(["triton"])
+class TestAutotuneBestOfK(RefEagerTestDisabled, TestCase):
+    """Best-of-K multi-seed autotune selection — cache key + K-loop coverage.
+
+    Covers:
+      - K = 1 leaves the cache hash byte-identical with the pre-feature
+        repr (no field appended to the dataclass repr).
+      - K > 1 differentiates the cache hash structurally; the K value
+        appears as a field on the key dataclass, not concatenated into
+        ``extra_cache_key``.
+      - K > 1 with no ``_autotuner_factory`` wired raises a clear error.
+      - The K-loop runs K trials with deterministic per-trial seeds,
+        and the winner is picked by the **final rebench** (not the
+        per-trial ``best_perf_so_far`` low-water mark).
+      - The autotuner reference on the cache is restored to the
+        original after the loop.
+    """
+
+    def test_cache_key_byte_identical_when_k_is_one(self) -> None:
+        """K=1 cache hash must match the bytes produced by the original
+        ``LooseAutotuneCacheKey`` repr (before ``best_of_k`` was added)."""
+        from helion.autotuner.base_cache import LooseAutotuneCacheKey
+
+        # Build a key with K=1 and one with K=5; the K=1 repr must equal
+        # the repr that omits ``best_of_k`` entirely.
+        common_kwargs = {
+            "specialization_key": (),
+            "extra_results": (),
+            "kernel_source_hash": "abc",
+            "hardware": "B200",
+            "runtime_name": "12.6",
+            "backend": "triton",
+            "config_spec_hash": "h1",
+            "extra_cache_key": "",
+        }
+        k1 = LooseAutotuneCacheKey(**common_kwargs, best_of_k=1)
+        k5 = LooseAutotuneCacheKey(**common_kwargs, best_of_k=5)
+        # K=1 repr matches a manually-constructed repr without best_of_k.
+        expected_k1_repr = (
+            "LooseAutotuneCacheKey("
+            "specialization_key=(), extra_results=(), "
+            "kernel_source_hash='abc', hardware='B200', "
+            "runtime_name='12.6', backend='triton', "
+            "config_spec_hash='h1', extra_cache_key='')"
+        )
+        self.assertEqual(repr(k1), expected_k1_repr)
+        # K=5 includes the field in the repr.
+        self.assertIn("best_of_k=5", repr(k5))
+        # Hashes differ structurally.
+        self.assertNotEqual(k1.stable_hash(), k5.stable_hash())
+
+    def test_cache_key_does_not_alias_extra_cache_key(self) -> None:
+        """A K=1 key with ``extra_cache_key`` carrying a literal
+        ``;best_of_k=5`` suffix must NOT collide with a K=5 key whose
+        ``extra_cache_key`` is empty — i.e. the K must be a structural
+        field, not folded into the string."""
+        from helion.autotuner.base_cache import LooseAutotuneCacheKey
+
+        k1_aliased = LooseAutotuneCacheKey(
+            specialization_key=(),
+            extra_results=(),
+            kernel_source_hash="abc",
+            hardware="B200",
+            runtime_name="12.6",
+            backend="triton",
+            config_spec_hash="h1",
+            extra_cache_key="foo;best_of_k=5",
+            best_of_k=1,
+        )
+        k5 = LooseAutotuneCacheKey(
+            specialization_key=(),
+            extra_results=(),
+            kernel_source_hash="abc",
+            hardware="B200",
+            runtime_name="12.6",
+            backend="triton",
+            config_spec_hash="h1",
+            extra_cache_key="foo",
+            best_of_k=5,
+        )
+        self.assertNotEqual(k1_aliased.stable_hash(), k5.stable_hash())
+
+    def test_best_of_k_gt_1_without_factory_raises(self) -> None:
+        """The bare ``Cache(autotuner)`` constructor must reject K>1 at
+        run time rather than silently fall back to single-trial."""
+        from helion.autotuner.local_cache import LocalAutotuneCache
+
+        @helion.kernel(autotune_best_of_k=3, autotune_log_level=0)
+        def add(a, b):
+            out = torch.empty_like(a)
+            for tile in hl.tile(out.size()):
+                out[tile] = a[tile] + b[tile]
+            return out
+
+        args = (
+            torch.randn([8, 32], device=DEVICE),
+            torch.randn([8, 32], device=DEVICE),
+        )
+        bound = add.bind(args)
+
+        # Build a cache with NO autotuner_factory wired; this models the
+        # external ``Cache(autotuner)`` constructor path.
+        class _MinimalSearch:
+            def __init__(self):
+                self.kernel = bound
+                self.settings = bound.settings
+                self.args = args
+                self.best_perf_so_far = math.inf
+                self._skip_cache = False
+
+                class _Log:
+                    def __call__(self, *a, **kw):
+                        pass
+
+                    def reset(self):
+                        pass
+
+                    def warning(self, *a, **kw):
+                        pass
+
+                self.log = _Log()
+
+            def autotune(self, *, skip_cache: bool = False):
+                return None  # never reached: K>1 must raise before this
+
+        cache = LocalAutotuneCache(_MinimalSearch())  # no autotuner_factory
+        with (
+            patch("helion.autotuner.base_cache.should_skip_cache", return_value=True),
+            self.assertRaisesRegex(
+                RuntimeError,
+                r"autotune_best_of_k > 1 requires a registered _autotuner_factory",
+            ),
+        ):
+            cache.autotune()
+
+    def test_k_loop_runs_k_trials_with_deterministic_seeds(self) -> None:
+        """The K-loop runs K trials with seeds ``base + i``."""
+        from helion.autotuner.local_cache import LocalAutotuneCache
+        from helion.runtime.config import Config
+
+        seeds_seen: list[int] = []
+        # ``block_sizes`` must be powers of two; pick four distinct values.
+        trial_configs = [Config(block_sizes=[16, 1 << (3 + i)]) for i in range(4)]
+        # Low-water perfs (per-trial best_perf_so_far) and rebench perfs
+        # disagree on the winner: low-water best is index 2, rebench
+        # best is index 3.
+        low_water_perfs = [3.0, 5.0, 1.0, 2.0]
+        rebench_perfs = [3.0, 5.0, 8.0, 2.0]
+        trial_idx = {"n": 0}
+
+        class MockTrialSearch:
+            def __init__(self, bound_kernel, args, **kwargs):
+                self.kernel = bound_kernel
+                self.settings = bound_kernel.settings
+                self.args = args
+                self.best_perf_so_far = math.inf
+                self._skip_cache = False
+
+                class _Log:
+                    def __call__(self, *a, **kw):
+                        pass
+
+                    def reset(self):
+                        pass
+
+                    def warning(self, *a, **kw):
+                        pass
+
+                self.log = _Log()
+
+            def autotune(self, *, skip_cache: bool = False):
+                i = trial_idx["n"]
+                seeds_seen.append(self.settings.autotune_random_seed)
+                self.best_perf_so_far = low_water_perfs[i]
+                cfg = trial_configs[i]
+                trial_idx["n"] += 1
+                return cfg
+
+        def mock_autotuner_fn(bound_kernel, args, **kwargs):
+            def factory():
+                return MockTrialSearch(bound_kernel, args, **kwargs)
+
+            return LocalAutotuneCache(factory(), autotuner_factory=factory)
+
+        @helion.kernel(
+            autotuner_fn=mock_autotuner_fn,
+            autotune_best_of_k=4,
+            autotune_random_seed=100,
+            autotune_log_level=0,
+        )
+        def add(a, b):
+            out = torch.empty_like(a)
+            for tile in hl.tile(out.size()):
+                out[tile] = a[tile] + b[tile]
+            return out
+
+        args = (
+            torch.randn([8, 32], device=DEVICE),
+            torch.randn([8, 32], device=DEVICE),
+        )
+        bound = add.bind(args)
+
+        # Patch the final-rebench step so we can return the desired perfs
+        # without needing a real benchmark_provider.
+        with (
+            patch("helion.autotuner.base_cache.should_skip_cache", return_value=True),
+            patch.object(
+                LocalAutotuneCache,
+                "_rebench_trial_configs",
+                lambda self, configs: rebench_perfs,
+            ),
+        ):
+            picked = bound.autotune(args)
+
+        # K trials ran.
+        self.assertEqual(trial_idx["n"], 4)
+        # Deterministic seeds: base + i.
+        self.assertEqual(seeds_seen, [100, 101, 102, 103])
+        # Winner is picked by REBENCH (index 3), not by low-water (index 2).
+        rebench_winner = rebench_perfs.index(min(rebench_perfs))
+        low_water_winner = low_water_perfs.index(min(low_water_perfs))
+        self.assertNotEqual(rebench_winner, low_water_winner)
+        self.assertEqual(picked, trial_configs[rebench_winner])
+
+    def test_k_loop_restores_autotuner_and_settings(self) -> None:
+        """After the K-loop, ``cache.autotuner`` must equal the original
+        instance, and the mutated settings must be restored to base."""
+        from helion.autotuner.local_cache import LocalAutotuneCache
+        from helion.runtime.config import Config
+
+        cfg = Config(block_sizes=[16, 32])
+
+        class MockSearch:
+            def __init__(self, bound_kernel, args, **kwargs):
+                self.kernel = bound_kernel
+                self.settings = bound_kernel.settings
+                self.args = args
+                self.best_perf_so_far = math.inf
+                self._skip_cache = False
+
+                class _Log:
+                    def __call__(self, *a, **kw):
+                        pass
+
+                    def reset(self):
+                        pass
+
+                    def warning(self, *a, **kw):
+                        pass
+
+                self.log = _Log()
+
+            def autotune(self, *, skip_cache: bool = False):
+                # Simulate the adaptive-timeout mutation that the real
+                # BaseSearch does inside _prepare()/set_adaptive_compile_timeout.
+                self.settings.autotune_compile_timeout = 5
+                self.best_perf_so_far = 1.0
+                return cfg
+
+        original_autotuner_ref = {"r": None}
+
+        def mock_autotuner_fn(bound_kernel, args, **kwargs):
+            def factory():
+                return MockSearch(bound_kernel, args, **kwargs)
+
+            inner = factory()
+            original_autotuner_ref["r"] = inner
+            return LocalAutotuneCache(inner, autotuner_factory=factory)
+
+        @helion.kernel(
+            autotuner_fn=mock_autotuner_fn,
+            autotune_best_of_k=3,
+            autotune_random_seed=100,
+            autotune_compile_timeout=60,
+            autotune_log_level=0,
+        )
+        def add(a, b):
+            out = torch.empty_like(a)
+            for tile in hl.tile(out.size()):
+                out[tile] = a[tile] + b[tile]
+            return out
+
+        args = (
+            torch.randn([8, 32], device=DEVICE),
+            torch.randn([8, 32], device=DEVICE),
+        )
+        bound = add.bind(args)
+
+        with (
+            patch("helion.autotuner.base_cache.should_skip_cache", return_value=True),
+            patch.object(
+                LocalAutotuneCache,
+                "_rebench_trial_configs",
+                lambda self, configs: [1.0] * len(configs),
+            ),
+        ):
+            captured_cache = bound.settings.autotuner_fn(bound, args)
+            self.assertIsNotNone(original_autotuner_ref["r"])
+            self.assertIs(captured_cache.autotuner, original_autotuner_ref["r"])
+            captured_cache.autotune()
+
+        # After the K-loop, the cache's ``autotuner`` reference must be
+        # restored to the original instance (no leaked trial swap).
+        self.assertIs(captured_cache.autotuner, original_autotuner_ref["r"])
+        # And the settings the autotuner mutated must be restored to base.
+        self.assertEqual(bound.settings.autotune_compile_timeout, 60)
+        self.assertEqual(bound.settings.autotune_random_seed, 100)
+
+    def test_k_one_falls_through_to_single_trial(self) -> None:
+        """With ``autotune_best_of_k=1`` the K-loop must not run; the
+        cache calls the autotuner exactly once and returns its config.
+        """
+        from helion.autotuner.local_cache import LocalAutotuneCache
+        from helion.runtime.config import Config
+
+        call_count = {"n": 0}
+        only_config = Config(block_sizes=[16, 32])
+
+        class _Log:
+            def __call__(self, *a, **kw):
+                pass
+
+            def reset(self):
+                pass
+
+            def warning(self, *a, **kw):
+                pass
+
+        class SingleTrialSearch:
+            def __init__(self, bound_kernel, args, **kwargs):
+                self.kernel = bound_kernel
+                self.settings = bound_kernel.settings
+                self.args = args
+                self.best_perf_so_far = 1.0
+                self._skip_cache = False
+                self.log = _Log()
+
+            def autotune(self, *, skip_cache: bool = False):
+                call_count["n"] += 1
+                return only_config
+
+        def mock_autotuner_fn(bound_kernel, args, **kwargs):
+            def factory():
+                return SingleTrialSearch(bound_kernel, args, **kwargs)
+
+            return LocalAutotuneCache(factory(), autotuner_factory=factory)
+
+        @helion.kernel(
+            autotuner_fn=mock_autotuner_fn,
+            autotune_best_of_k=1,
+            autotune_log_level=0,
+        )
+        def add(a, b):
+            out = torch.empty_like(a)
+            for tile in hl.tile(out.size()):
+                out[tile] = a[tile] + b[tile]
+            return out
+
+        args = (
+            torch.randn([8, 32], device=DEVICE),
+            torch.randn([8, 32], device=DEVICE),
+        )
+        bound = add.bind(args)
+        with patch("helion.autotuner.base_cache.should_skip_cache", return_value=True):
+            picked = bound.autotune(args)
+        self.assertEqual(call_count["n"], 1)
+        self.assertEqual(picked, only_config)
+
+
 @onlyBackends(["triton", "cute"])
 class TestAutotuneCacheSelection(TestCase):
     """Selection of the autotune cache via HELION_AUTOTUNE_CACHE."""


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2682
 * #2681
 * #2680
 * #2679
 * #2678
 * #2656
 * #2655
 * #2654
 * #2653
 * __->__#2652
 * #2651


--- --- ---

[cutedsl] add best-of-K autotuning and stabilize benchmarking

Benchmark each candidate config best-of-K to reduce launch-noise
variance, fix a reference-cycle leak in the benchmark provider, and
extend GPU warmup. Add a --helion-consumer-regs knob to the backend
comparison script.