### PR TITLE
[cutedsl] migrate to CuTe 4.5.1 APIs

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -4433,7 +4433,7 @@ def _emit_mma_pipeline(
     else:
         prefix.append(
             statement_from_string(
-                f"{acc_frag} = cute.make_fragment("
+                f"{acc_frag} = cute.make_rmem_tensor("
                 f"{tiled_mma}.partition_shape_C(({bm}, {bn})), {acc_dtype_str})"
             )
         )
@@ -6044,8 +6044,9 @@ def _tcgen05_tiled_mma_expr(
     return (
         "cutlass.utils.blackwell_helpers.make_trivial_tiled_mma("
         f"{input_dtype_str}, "
-        "cute.nvgpu.tcgen05.OperandMajorMode.K, "
-        "cute.nvgpu.tcgen05.OperandMajorMode.MN, "
+        f"{input_dtype_str}, "
+        "cute.nvgpu.OperandMajorMode.K, "
+        "cute.nvgpu.OperandMajorMode.MN, "
         f"{acc_dtype_str}, "
         f"{cta_group_expr}, "
         f"({bm}, {bn}), "
@@ -6871,7 +6872,7 @@ def codegen_cute_mma_direct_mm(
         prefix.append(stmt)
     prefix.append(
         statement_from_string(
-            f"{acc_frag} = cute.make_fragment("
+            f"{acc_frag} = cute.make_rmem_tensor("
             f"{tiled_mma}.partition_shape_C(({plan.bm}, {plan.bn})), {acc_dtype_str})"
         )
     )

--- a/helion/_compiler/cute/fuse_two_pass_loads.py
+++ b/helion/_compiler/cute/fuse_two_pass_loads.py
@@ -577,7 +577,7 @@ class _CuteFuseTwoPassLoads(ast.NodeTransformer):
             # (the ``unroll`` mode's U16 vec hoist) cache via a *scalar*
             # fragment of ``cache_size * V`` slots — one slot per
             # extracted lane — because the CUTLASS DSL's
-            # ``cute.make_fragment(N, dtype)`` does not currently accept a
+            # ``cute.make_rmem_tensor(N, dtype)`` does not currently accept a
             # vec element type.  Scalar (masked / unmasked) loads cache as
             # the existing fast path.
             tracked: dict[str, tuple[int, str, str, str | None, int | None]] = {}
@@ -678,7 +678,7 @@ class _CuteFuseTwoPassLoads(ast.NodeTransformer):
                     cache_total = cache_total_per_thread
                     cache_decls.append(
                         statement_from_string(
-                            f"{cache} = cute.make_fragment({cache_total}, {dtype})"
+                            f"{cache} = cute.make_rmem_tensor({cache_total}, {dtype})"
                         )
                     )
             if not cache_names:

--- a/helion/_compiler/cute/mma_support.py
+++ b/helion/_compiler/cute/mma_support.py
@@ -61,6 +61,7 @@ def _probe_warp_f16bf16() -> tuple[bool, str | None]:
 def _probe_warpgroup_f16bf16() -> tuple[bool, str | None]:
     try:
         import cutlass
+        from cutlass.cute.nvgpu import OperandMajorMode
         from cutlass.cute.nvgpu import warpgroup
 
         warpgroup.MmaF16BF16Op(
@@ -68,8 +69,8 @@ def _probe_warpgroup_f16bf16() -> tuple[bool, str | None]:
             cutlass.Float32,
             (64, 8, 16),
             warpgroup.OperandSource.SMEM,
-            warpgroup.OperandMajorMode.K,
-            warpgroup.OperandMajorMode.K,
+            OperandMajorMode.K,
+            OperandMajorMode.K,
         )
         return True, None
     except Exception as exc:
@@ -79,6 +80,7 @@ def _probe_warpgroup_f16bf16() -> tuple[bool, str | None]:
 def _probe_tcgen05_f16bf16() -> tuple[bool, str | None]:
     try:
         import cutlass
+        from cutlass.cute.nvgpu import OperandMajorMode
         from cutlass.cute.nvgpu import tcgen05
 
         tcgen05.MmaF16BF16Op(
@@ -87,8 +89,8 @@ def _probe_tcgen05_f16bf16() -> tuple[bool, str | None]:
             (128, 8, 16),
             tcgen05.CtaGroup.ONE,
             tcgen05.OperandSource.SMEM,
-            tcgen05.OperandMajorMode.K,
-            tcgen05.OperandMajorMode.K,
+            OperandMajorMode.K,
+            OperandMajorMode.K,
         )
         return True, None
     except Exception as exc:

--- a/helion/_compiler/cute/tcgen05_direct_entry.py
+++ b/helion/_compiler/cute/tcgen05_direct_entry.py
@@ -172,8 +172,9 @@ def _append_target1_ab_tma_descriptor_source(
             (
                 f"    {tiled_mma} = cutlass.utils.blackwell_helpers.make_trivial_tiled_mma("
                 f"{input_dtype}, "
-                "cute.nvgpu.tcgen05.OperandMajorMode.K, "
-                "cute.nvgpu.tcgen05.OperandMajorMode.MN, "
+                f"{input_dtype}, "
+                "cute.nvgpu.OperandMajorMode.K, "
+                "cute.nvgpu.OperandMajorMode.MN, "
                 f"{acc_dtype}, "
                 "cute.nvgpu.tcgen05.CtaGroup.TWO, "
                 f"({bm}, {bn}), "

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -3778,7 +3778,7 @@ def _codegen_cute_store_tcgen05_tile(
         ),
         (
             f"{simt_atom} = cute.make_copy_atom("
-            f"cute.nvgpu.CopyUniversalOp(), {target_dtype}, "
+            f"cute.nvgpu.CopyR2GOp(), {target_dtype}, "
             f"num_bits_per_copy={num_bits}, "
             f"l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE)"
         ),

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -2249,8 +2249,9 @@ def _append_cute_wrapper_plan(
             (
                 f"    {tiled_mma} = cutlass.utils.blackwell_helpers.make_trivial_tiled_mma("
                 f"{input_dtype}, "
-                "cute.nvgpu.tcgen05.OperandMajorMode.K, "
-                "cute.nvgpu.tcgen05.OperandMajorMode.MN, "
+                f"{input_dtype}, "
+                "cute.nvgpu.OperandMajorMode.K, "
+                "cute.nvgpu.OperandMajorMode.MN, "
                 f"{acc_dtype}, "
                 f"{cta_group}, "
                 f"({bm}, {bn}), "

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -954,7 +954,7 @@ class TestCuteBackend(TestCase):
         torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
         # The fuser allocates a fragment and rewrites the consume sweep's
         # load to read from the cache.
-        self.assertIn("cute.make_fragment", code)
+        self.assertIn("cute.make_rmem_tensor", code)
         self.assertIn("_fuse_cache_0", code)
 
     def test_two_pass_load_fusion_shape_c_vec_unroll(self) -> None:
@@ -972,7 +972,7 @@ class TestCuteBackend(TestCase):
         (x,) = args
         expected = (x.float() / x.float().sum(-1, keepdim=True)).to(x.dtype)
         torch.testing.assert_close(out, expected, rtol=1e-2, atol=1e-2)
-        self.assertIn("cute.make_fragment", code)
+        self.assertIn("cute.make_rmem_tensor", code)
         self.assertIn("_fuse_cache_0", code)
 
     def test_strided_threaded_block_reduction(self) -> None:

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -973,7 +973,7 @@ class TestCuteLowerings(unittest.TestCase):
             code = cute_matmul_mma_codegen_only.bind(args).to_triton_code(config)
 
         self.assertIn("cutlass.utils.blackwell_helpers.make_trivial_tiled_mma", code)
-        self.assertIn("cute.nvgpu.tcgen05.OperandMajorMode.MN", code)
+        self.assertIn("cute.nvgpu.OperandMajorMode.MN", code)
         self.assertIn(".make_fragment_B(", code)
         self.assertIn("cute.gemm(", code)
         self.assertIn(
@@ -1028,7 +1028,7 @@ class TestCuteLowerings(unittest.TestCase):
         self.assertGreaterEqual(config.config["block_sizes"][1], 8)
         self.assertLessEqual(config.config["block_sizes"][1], 128)
         self.assertIn("cutlass.utils.blackwell_helpers.make_trivial_tiled_mma", code)
-        self.assertIn("cute.nvgpu.tcgen05.OperandMajorMode.MN", code)
+        self.assertIn("cute.nvgpu.OperandMajorMode.MN", code)
         self.assertIn(".make_fragment_B(", code)
         self.assertIn("cute.gemm(", code)
         self.assertIn(
@@ -6402,7 +6402,7 @@ class TestCuteLowerings(unittest.TestCase):
         # only when the lowering selects the tcgen05 path (the
         # universal lane-loop fallback uses scalar ops, no tcgen05
         # symbols).
-        self.assertIn("cute.nvgpu.tcgen05.OperandMajorMode", code)
+        self.assertIn("cute.nvgpu.OperandMajorMode", code)
         # PipelineTmaUmma marker: pins the role-local TMA + UMMA
         # pipeline pairing, present only on the tcgen05 path.
         self.assertIn("PipelineTmaUmma", code)
@@ -18003,7 +18003,7 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         self.assertNotIn("'kind': 'tcgen05_d_tma'", code)
         self.assertNotIn("cutlass.pipeline.PipelineTmaStore.create", code)
         self.assertNotIn("cute.copy(tcgen05_tma_store_atom", code)
-        self.assertIn("cute.nvgpu.CopyUniversalOp()", code)
+        self.assertIn("cute.nvgpu.CopyR2GOp()", code)
 
     def _expected_c_input_warp_id(self, config: helion.Config) -> int:
         """Compute the expected ``c_input_warp_id`` from the config


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2682
 * #2681
 * #2680
 * #2679
 * #2678
 * #2656
 * #2655
 * #2654
 * __->__#2653
 * #2652
 * #2651


--- --- ---

[cutedsl] migrate to CuTe 4.5.1 APIs

Replace deprecated calls: make_fragment -> make_rmem_tensor,
OperandMajorMode -> cute.nvgpu, the two-dtype make_trivial_tiled_mma
overload, and the SIMT store atom CopyUniversalOp -> CopyR2GOp.
Behavior-preserving; clears all DeprecationWarnings.