### PR TITLE
[cutedsl] productionize aux-TMA selection via search projection

### DIFF
--- a/helion/_compiler/cute/aux_tensor.py
+++ b/helion/_compiler/cute/aux_tensor.py
@@ -31,6 +31,7 @@ import torch
 
 from ...language import matmul_ops
 from ...language import memory_ops
+from ...language._gelu_tanh_approx import _gelu_erf
 from ..compile_environment import CompileEnvironment
 from .cute_epilogue import _AuxiliaryTensorStep
 from .cute_epilogue import analyze_tcgen05_unary_epilogue_chain
@@ -516,6 +517,35 @@ def host_function_has_tcgen05_relu_matmul_store_pattern(
     """
     return _host_function_has_tcgen05_single_store_pattern(
         host_function, intermediate_op=torch.ops.aten.relu.default
+    )
+
+
+def host_function_has_tcgen05_gelu_matmul_store_pattern(
+    host_function: HostFunction,
+) -> bool:
+    """Return True only for a single plain-``gelu`` + cast store of a matmul.
+
+    Gates the cycle-87 Target 8 TVM-FFI direct-entry seed (MatmulTarget 27,
+    1536x6144x1536 fp16 ``gelu(acc)``). The accepted chain shape is
+    ``mma -> _gelu_erf -> convert -> store`` where ``_gelu_erf`` is the
+    single-FX-node internal op the ``aten.gelu.default`` decomposition
+    materializes for the default (``approximate="none"``) erf GELU — the
+    same form ``torch.nn.functional.gelu(acc)`` produces. Symmetrical to the
+    identity/relu store detectors via
+    ``_host_function_has_tcgen05_single_store_pattern``.
+
+    Mutually exclusive with the identity/relu/bias/bias_relu detectors: the
+    identity walker rejects a unary op in the chain, relu requires
+    ``aten.relu.default`` rather than ``_gelu_erf``, and the bias / bias_relu
+    walkers require an ``aten.add.Tensor`` bias load between the carrier and
+    the store. The bias_residual_gelu MatmulTargets (12/28) carry bias +
+    residual ``add`` ops before the gelu, so their store-feeding cast does
+    not sit directly on a lone ``_gelu_erf`` and is rejected here. This
+    detector does fire on the bf16 gelu MatmulTargets 4/19, but the T8 seed's
+    fp16-pinned shape fact keeps the seed mutually exclusive with them.
+    """
+    return _host_function_has_tcgen05_single_store_pattern(
+        host_function, intermediate_op=_gelu_erf
     )
 
 

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -128,6 +128,10 @@ from .tcgen05_constants import TCGEN05_TARGET7_TVM_FFI_AB_STAGES
 from .tcgen05_constants import TCGEN05_TARGET7_TVM_FFI_BLOCK_K
 from .tcgen05_constants import TCGEN05_TARGET7_TVM_FFI_C_STAGES
 from .tcgen05_constants import TCGEN05_TARGET7_TVM_FFI_SHAPE
+from .tcgen05_constants import TCGEN05_TARGET8_GELU_AB_STAGES
+from .tcgen05_constants import TCGEN05_TARGET8_GELU_BLOCK_K
+from .tcgen05_constants import TCGEN05_TARGET8_GELU_C_STAGES
+from .tcgen05_constants import TCGEN05_TARGET8_GELU_SHAPE
 from .tcgen05_constants import TCGEN05_TARGET9_TVM_FFI_AB_STAGES
 from .tcgen05_constants import TCGEN05_TARGET9_TVM_FFI_BLOCK_K
 from .tcgen05_constants import TCGEN05_TARGET9_TVM_FFI_C_STAGES
@@ -247,6 +251,10 @@ class CuteTcgen05Config:
         # fp16 bias load (cycle 42 P2 fix; cycle 40 perturbation lesson).
         self.bias_matmul_store_fp16_detected: bool = False
         self.bias_relu_matmul_store_detected: bool = False
+        # Plain ``gelu(acc)`` store (no bias, no residual) — cycle-87 T8
+        # (MatmulTarget 27, fp16). Kept separate from bias_residual_gelu
+        # (T12/T28) since those carry add ops before the gelu.
+        self.gelu_matmul_store_detected: bool = False
         self.target1_tvm_ffi_seed_enabled: bool = False
         self.target2_tvm_ffi_seed_enabled: bool = False
         self.target3_tvm_ffi_seed_enabled: bool = False
@@ -254,6 +262,7 @@ class CuteTcgen05Config:
         self.target5_tvm_ffi_seed_enabled: bool = False
         self.target6_tvm_ffi_seed_enabled: bool = False
         self.target7_tvm_ffi_seed_enabled: bool = False
+        self.target8_gelu_seed_enabled: bool = False
         self.target9_tvm_ffi_seed_enabled: bool = False
         self.target10_tvm_ffi_seed_enabled: bool = False
         self.cluster_m_search_choices: tuple[int, ...] | None = None
@@ -448,6 +457,30 @@ class CuteTcgen05Config:
             return
         target_k = TCGEN05_TARGET7_TVM_FFI_SHAPE[2]
         self.target7_tvm_ffi_seed_enabled = True
+        self.cluster_m2_search_constraints = Tcgen05ClusterM2SearchConstraints(
+            static_k=target_k,
+            max_k_tiles=TCGEN05_TWO_CTA_MAX_K_TILES,
+        )
+        self.cluster_m_search_choices = (1, 2)
+        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
+            self.allowed_pid_types = (
+                *self.allowed_pid_types,
+                cast("PidTypeLiteral", TCGEN05_TWO_CTA_SEED_PID_TYPE),
+            )
+
+    def allow_target8_gelu_seed(self) -> None:
+        # T8 (cycle 87, MatmulTarget 27) mirrors T6's two-CTA envelope at
+        # the (1536, 6144, 1536) fp16 problem with a plain ``gelu(acc)``
+        # epilogue. The plain-gelu-store gate is unique to T8 (mutually
+        # exclusive with identity/relu/bias/bias_relu via the chain shape),
+        # and the fp16-pinned shape fact keeps it mutually exclusive with the
+        # bf16 gelu MatmulTargets 4/19 that share the chain shape.
+        if not self.gelu_matmul_store_detected:
+            return
+        if not self._has_target8_gelu_matmul_fact():
+            return
+        target_k = TCGEN05_TARGET8_GELU_SHAPE[2]
+        self.target8_gelu_seed_enabled = True
         self.cluster_m2_search_constraints = Tcgen05ClusterM2SearchConstraints(
             static_k=target_k,
             max_k_tiles=TCGEN05_TWO_CTA_MAX_K_TILES,
@@ -854,6 +887,22 @@ class CuteTcgen05Config:
             and fact.static_k == target_k
             and fact.lhs_dtype == torch.bfloat16
             and fact.rhs_dtype == torch.bfloat16
+            for fact in self.config_spec.matmul_facts
+        )
+
+    def _has_target8_gelu_matmul_fact(self) -> bool:
+        # T8 is fp16-only at the (1536, 6144, 1536) plain-gelu shape. The
+        # fp16 pin is what keeps the seed mutually exclusive with the bf16
+        # gelu MatmulTargets 4 (2048x4096x2048) and 19 (3072x3072x3072) that
+        # share the plain-gelu chain shape detected by
+        # ``host_function_has_tcgen05_gelu_matmul_store_pattern``.
+        target_m, target_n, target_k = TCGEN05_TARGET8_GELU_SHAPE
+        return any(
+            fact.static_m == target_m
+            and fact.static_n == target_n
+            and fact.static_k == target_k
+            and fact.lhs_dtype == torch.float16
+            and fact.rhs_dtype == torch.float16
             for fact in self.config_spec.matmul_facts
         )
 
@@ -1423,6 +1472,88 @@ class CuteTcgen05Config:
         }
         return Config(**seed_config)
 
+    def _target8_gelu_seed_config(self) -> Config | None:
+        if not self.target8_gelu_seed_enabled:
+            return None
+        # T8 (cycle 87, MatmulTarget 27) is a plain ``gelu(acc)`` store with
+        # no auxiliary tensor at the (1536, 6144, 1536) fp16 shape. Unlike the
+        # bf16 two-CTA seeds (T1-T9) and the T10 fp16 bias seed, T8 uses the
+        # DEFAULT epilogue layout and the normal (non-FFI) launch path: the
+        # ``explicit_epi_tile`` overrides + ``tvm_ffi_launch`` / flat-role
+        # codegen path is gated bf16-only (and fp16 only for the T10 2048³
+        # bias envelope) in ``cute_mma.py`` ``_emit_mma_pipeline``, so it
+        # rejects a fp16 gelu store. The cycle-86/87 force-config win
+        # (``256x256x128, ab=3``, ~649 TF mom-median) was measured on this
+        # plain default-layout config, so the seed reproduces exactly that.
+        # The plain-gelu-store gate keeps it mutually exclusive with
+        # identity/relu/bias/bias_relu stores; the fp16-pinned shape fact
+        # keeps it mutually exclusive with the bf16 gelu MatmulTargets 4/19
+        # that share the chain shape.
+        if self.aux_kernel_detected:
+            return None
+        if not self.gelu_matmul_store_detected:
+            return None
+        if not self._has_target8_gelu_matmul_fact():
+            return None
+        constraints = self.cluster_m2_search_constraints
+        if constraints is None or constraints.allow_edge_k_tail_family:
+            return None
+        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
+            return None
+        if len(self.config_spec.block_sizes) != 3:
+            return None
+        if self.config_spec.indexing.length != 3:
+            return None
+        if not self.cluster_m2_bk_is_valid(TCGEN05_TARGET8_GELU_BLOCK_K, constraints):
+            return None
+        if not self.ab_stages_three_fits(
+            bm=TCGEN05_TWO_CTA_BLOCK_M,
+            bn=TCGEN05_TWO_CTA_BLOCK_N,
+            bk=TCGEN05_TARGET8_GELU_BLOCK_K,
+            cluster_m=2,
+            ab_stages=TCGEN05_TARGET8_GELU_AB_STAGES,
+        ):
+            return None
+        range_count = len(self.config_spec.range_unroll_factors)
+        # T8 uses the validated two-CTA tile/stage envelope (256x256x128,
+        # ab=3, acc=2, c=2, cluster_m=2) at the DEFAULT epilogue layout;
+        # ``l2_groupings=[2]`` is inherited from the two-CTA envelope pending
+        # a dedicated T8 sweep.
+        seed_config: dict[str, Any] = {
+            "block_sizes": [
+                TCGEN05_TWO_CTA_BLOCK_M,
+                TCGEN05_TWO_CTA_BLOCK_N,
+                TCGEN05_TARGET8_GELU_BLOCK_K,
+            ],
+            "indexing": [
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "tensor_descriptor",
+            ],
+            "l2_groupings": [2],
+            "loop_orders": [[0, 1]],
+            "num_stages": 4,
+            "num_warps": 8,
+            "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
+            "range_flattens": [None] * range_count,
+            "range_multi_buffers": [None] * range_count,
+            "range_num_stages": [0] * range_count,
+            "range_unroll_factors": [1] * range_count,
+            "range_warp_specializes": [None] * range_count,
+            "tcgen05_cluster_m": 2,
+            "tcgen05_cluster_n": 1,
+            "tcgen05_ab_stages": TCGEN05_TARGET8_GELU_AB_STAGES,
+            "tcgen05_acc_stages": 2,
+            "tcgen05_c_stages": TCGEN05_TARGET8_GELU_C_STAGES,
+            TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY: 1,
+            "tcgen05_num_epi_warps": 4,
+            TCGEN05_STRATEGY_CONFIG_KEY: Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
+            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
+                Tcgen05PersistenceModel.STATIC_PERSISTENT.value
+            ),
+        }
+        return Config(**seed_config)
+
     def _target10_tvm_ffi_seed_config(self) -> Config | None:
         if not self.target10_tvm_ffi_seed_enabled:
             return None
@@ -1607,6 +1738,9 @@ class CuteTcgen05Config:
         target7_tvm_ffi_seed = self._target7_tvm_ffi_seed_config()
         if target7_tvm_ffi_seed is not None:
             seeds.append(target7_tvm_ffi_seed)
+        target8_gelu_seed = self._target8_gelu_seed_config()
+        if target8_gelu_seed is not None:
+            seeds.append(target8_gelu_seed)
         target9_tvm_ffi_seed = self._target9_tvm_ffi_seed_config()
         if target9_tvm_ffi_seed is not None:
             seeds.append(target9_tvm_ffi_seed)
@@ -1806,6 +1940,48 @@ class CuteTcgen05Config:
         ):
             config[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY] = TCGEN05_AUX_LOAD_MODE_SIMT
 
+    def _fix_aux_tma_full_tile_search_config(self, config: dict[str, object]) -> None:
+        # Cycle 88 (Workstream B): on the residual full-tile cluster_m=2
+        # family (T20/T14/T25/T28 — exact-shape-gated by
+        # ``_aux_tma_full_tile_search_enabled``), project every cluster_m=2
+        # candidate onto the validated aux-TMA producer regime
+        # (role_local_with_scheduler + scheduler/c-input warp + ab=2 +
+        # aux_load_mode=tma). Clean force-config measurements show aux-TMA
+        # strictly beats the same-config SIMT control on this family (T20
+        # 962.6 vs 844.0 TF = +14%; T25 730.8 vs 324.7 TF = +125%) and also
+        # beats the autotuner's default monolithic-ab=3 SIMT pick (T20 ~915
+        # TF). Without this projection the population search either keeps the
+        # monolithic-ab=3 SIMT region (T20 reliably) or randomly lands on a
+        # catastrophic SIMT cluster_m=2 pick (T25 variance: 756 aux-TMA vs 286
+        # SIMT), so the +2.4-14 pp aux-TMA gain is not banked deterministically.
+        # This is the aux-TMA analogue of the cycle-87
+        # ``_fix_target8_gelu_search_config`` projection. Tightly bounded:
+        # cluster_m=1 candidates are left untouched (search still explores
+        # them), the edge+K-tail T12 family keeps its own
+        # ``_aux_tma_edge_search_enabled`` CLC path, and the gate fires only
+        # when ``exact_shape_aux_kernel_detected`` is True (residual subset
+        # only — no non-residual target is perturbed).
+        if not self.search_enabled:
+            return
+        if not self._aux_tma_full_tile_search_enabled():
+            return
+        if config.get("tcgen05_cluster_m") != 2:
+            return
+        if not self._is_validated_cluster_m2_full_tile_search_candidate(config):
+            return
+        # ab=2 is the aux-TMA producer's validated stage depth for this family
+        # (the aux SMEM ring forces ab<=2 under the 232 KB B200 cap; the
+        # cycle-86/88 measurements ran at ab=2). ``_c_input_seed_config``
+        # already emits exactly this regime as a seed, so the shape envelope
+        # validated above is sufficient — no extra SMEM-fit check is needed.
+        config[TCGEN05_STRATEGY_CONFIG_KEY] = (
+            Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value
+        )
+        config[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY] = 1
+        config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY] = 1
+        config["tcgen05_ab_stages"] = 2
+        config[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY] = TCGEN05_AUX_LOAD_MODE_TMA
+
     @staticmethod
     def _is_with_scheduler_c_input_config(config: dict[str, object]) -> bool:
         return (
@@ -1876,6 +2052,7 @@ class CuteTcgen05Config:
             or self._is_target5_tvm_ffi_seed_config(config)
             or self._is_target6_tvm_ffi_seed_config(config)
             or self._is_target7_tvm_ffi_seed_config(config)
+            or self._is_target8_gelu_seed_config(config)
             or self._is_target9_tvm_ffi_seed_config(config)
             or self._is_target10_tvm_ffi_seed_config(config)
         ):
@@ -2066,6 +2243,32 @@ class CuteTcgen05Config:
             and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY) == 128
             and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY) == 32
             and config.get(TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY) == 32
+        )
+
+    @staticmethod
+    def _is_target8_gelu_seed_config(config: dict[str, object]) -> bool:
+        # T8 (cycle 87, MatmulTarget 27) is the lone fp16 gelu two-CTA seed
+        # that uses the DEFAULT epilogue layout and the normal (non-FFI)
+        # launch path (the explicit-epi-tile / FFI codegen path is bf16-only
+        # except for the T10 fp16 bias envelope). The matcher therefore pins
+        # the validated two-CTA tile/stage envelope at the DEFAULT layout
+        # (no tvm_ffi_launch, no flat-role, no epi-tile overrides). The
+        # plain-gelu-store gate happens upstream.
+        return (
+            config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is not True
+            and config.get(TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY) is not True
+            and config.get("block_sizes")
+            == [
+                TCGEN05_TWO_CTA_BLOCK_M,
+                TCGEN05_TWO_CTA_BLOCK_N,
+                TCGEN05_TARGET8_GELU_BLOCK_K,
+            ]
+            and config.get("tcgen05_ab_stages") == TCGEN05_TARGET8_GELU_AB_STAGES
+            and config.get("tcgen05_c_stages") == TCGEN05_TARGET8_GELU_C_STAGES
+            and config.get("tcgen05_cluster_m") == 2
+            and config.get("tcgen05_cluster_n") == 1
+            and config.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY)
+            in (None, Tcgen05LayoutStrategy.DEFAULT.value)
         )
 
     @staticmethod
@@ -2588,6 +2791,8 @@ class CuteTcgen05Config:
             ab_stages_max = max(3, TCGEN05_TARGET6_TVM_FFI_AB_STAGES)
         elif not for_search and self._target7_tvm_ffi_seed_config() is not None:
             ab_stages_max = max(3, TCGEN05_TARGET7_TVM_FFI_AB_STAGES)
+        elif not for_search and self._target8_gelu_seed_config() is not None:
+            ab_stages_max = max(3, TCGEN05_TARGET8_GELU_AB_STAGES)
         elif not for_search and self._target9_tvm_ffi_seed_config() is not None:
             ab_stages_max = max(3, TCGEN05_TARGET9_TVM_FFI_AB_STAGES)
         elif not for_search and self._target10_tvm_ffi_seed_config() is not None:
@@ -2681,11 +2886,11 @@ class CuteTcgen05Config:
                 config.pop(key, None)
 
     def _fix_target1_tvm_ffi_search_config(self, config: dict[str, object]) -> None:
-        # T1-T7 plus T9-T10 share the TVM-FFI direct-entry promotion
-        # surface; pick the seed matching the detected (shape, store) so
-        # search candidates project onto the right envelope. The
-        # shape+store gates are mutually exclusive so at most one seed
-        # is non-None.
+        # T1-T7 plus T9-T10 share the TVM-FFI direct-entry promotion surface;
+        # pick the seed matching the detected (shape, store) so search
+        # candidates project onto the right envelope. The shape+store gates
+        # are mutually exclusive so at most one seed is non-None. (T8 is
+        # deliberately not in this list — see the note after the chain below.)
         seed = self._target1_tvm_ffi_seed_config()
         if seed is None:
             seed = self._target2_tvm_ffi_seed_config()
@@ -2703,6 +2908,10 @@ class CuteTcgen05Config:
             seed = self._target9_tvm_ffi_seed_config()
         if seed is None:
             seed = self._target10_tvm_ffi_seed_config()
+        # T8 (cycle 87) is intentionally absent: it is a plain DEFAULT-layout
+        # seed that does not use the FFI / explicit-epi-tile promotion surface
+        # (that path is bf16-only / T10-fp16-bias-only), so it must not be
+        # projected onto the FFI envelope here.
         if not self._target1_tvm_ffi_promotion_requested(
             config, seed_enabled=seed is not None
         ):
@@ -2744,6 +2953,47 @@ class CuteTcgen05Config:
             config[TCGEN05_PURE_CLC_SCHEDULER_OBJECT_CONFIG_KEY] = True
         if pure_dynamic_scheduler_requested:
             config[TCGEN05_PURE_DYNAMIC_SCHEDULER_OBJECT_CONFIG_KEY] = True
+
+    def _fix_target8_gelu_search_config(self, config: dict[str, object]) -> None:
+        # Project T8 (cycle 87, MatmulTarget 27) ``cluster_m=2`` search
+        # candidates onto the validated bk=128, ab=3 two-CTA stage tuple at
+        # the DEFAULT epilogue layout. Without this, the for_search
+        # ``tcgen05_ab_stages`` fragment caps ab at 2, so the autotuner never
+        # samples the seed's ab=3 (and lands in the slower bk=64 / ab=2
+        # regime, ~558-578 TF vs the seed's ~650+ TF — the cycle-86/87
+        # coverage gap). This is the plain-config analogue of
+        # ``_fix_target1_tvm_ffi_search_config`` for the bf16 / T10 FFI seeds:
+        # those project onto the FFI envelope, T8 projects onto the plain
+        # DEFAULT-layout envelope (the FFI / explicit-epi-tile path is
+        # bf16-only and rejects a fp16 gelu store). Other tiles (bk=64,
+        # cluster_m=1) are left untouched so the search still explores them.
+        seed = self._target8_gelu_seed_config()
+        if seed is None:
+            return
+        if config.get("tcgen05_cluster_m") != 2:
+            return
+        block_sizes = config.get("block_sizes")
+        if not (
+            isinstance(block_sizes, list)
+            and block_sizes[:3]
+            == [
+                TCGEN05_TWO_CTA_BLOCK_M,
+                TCGEN05_TWO_CTA_BLOCK_N,
+                TCGEN05_TARGET8_GELU_BLOCK_K,
+            ]
+        ):
+            return
+        if not self.ab_stages_three_fits(
+            bm=TCGEN05_TWO_CTA_BLOCK_M,
+            bn=TCGEN05_TWO_CTA_BLOCK_N,
+            bk=TCGEN05_TARGET8_GELU_BLOCK_K,
+            cluster_m=2,
+            ab_stages=TCGEN05_TARGET8_GELU_AB_STAGES,
+        ):
+            return
+        config["tcgen05_ab_stages"] = TCGEN05_TARGET8_GELU_AB_STAGES
+        config["tcgen05_acc_stages"] = 2
+        config["tcgen05_c_stages"] = TCGEN05_TARGET8_GELU_C_STAGES
 
     def aux_load_mode_autotune_fragments(self) -> dict[str, ConfigSpecFragment]:
         if not self._aux_tma_search_enabled():
@@ -3319,6 +3569,8 @@ class CuteTcgen05Config:
         self._fix_cluster_m1_persistent_search_config(config)
         self._fix_ab_stages_three_search_config(config)
         self._fix_target1_tvm_ffi_search_config(config)
+        self._fix_target8_gelu_search_config(config)
+        self._fix_aux_tma_full_tile_search_config(config)
         self._fix_with_scheduler_search_config(config)
         self._fix_aux_tma_search_config(config)
         # CLC admission depends on the projected cluster/pid/strategy tuple

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -406,12 +406,40 @@ TCGEN05_TARGET9_TVM_FFI_C_STAGES = 2
 # converged on the (ab=3, c=2) stage tuple under the role_local_monolithic
 # strategy with ``c_input_seed=0`` and ``l2_groupings=[2]``; this seed
 # closed the gap on T22 (fp16 2048³ bias) from +21.25% to +3.7% vs Quack.
-# T10 is the first envelope that admits fp16 operands — the per-target
-# fp16 admission gates are scoped to T10's shape so T1-T9 stay bf16-only.
+# T10 is the first TVM-FFI envelope that admits fp16 operands — the per-target
+# fp16 admission gates are scoped to T10's shape so the other FFI seeds
+# (T1-T7, T9) stay bf16-only. (The cycle-87 T8 fp16 plain-gelu seed below is
+# a separate, non-FFI DEFAULT-layout seed and does not use this envelope.)
 TCGEN05_TARGET10_TVM_FFI_SHAPE = (2048, 2048, 2048)
 TCGEN05_TARGET10_TVM_FFI_BLOCK_K = 128
 TCGEN05_TARGET10_TVM_FFI_AB_STAGES = 3
 TCGEN05_TARGET10_TVM_FFI_C_STAGES = 2
+# Validated cycle-87 Target8 envelope (1536x6144x1536 + plain ``gelu(acc)``
+# epilogue, fp16 operands). Unlike the bf16 / T10 FFI seeds, T8 is NOT a
+# TVM-FFI seed: it uses the DEFAULT epilogue layout and the normal (non-FFI)
+# launch path on the bk=128 (ab=3, c=2) two-CTA stage tuple, because the
+# ``explicit_epi_tile`` / ``tvm_ffi_launch`` flat-role codegen path is gated
+# bf16-only (and fp16 only for the T10 2048³ bias envelope) and rejects a
+# fp16 gelu store. This is the medium-square fp16 MatmulTarget 27 coverage
+# gap from the cycle-86 study: the cold autotuner converges on the
+# ``256x256x64, ab=1/2`` (~556-578 TF) regime, but the validated
+# ``256x256x128, ab=3`` two-CTA envelope force-configs to ~649 TF.
+# K=1536 -> k_tile_count=12 (well below the ``TCGEN05_TWO_CTA_MAX_K_TILES``
+# cap; M_tiles*N_tiles = 6*24 = 144 work clusters). The plain-gelu-store gate
+# (``gelu(acc)`` with no bias and no residual) is unique to T8 and mutually
+# exclusive with the identity/relu/bias/bias_relu gates via the chain shape
+# (a single ``_gelu_erf`` unary op between the MMA carrier and the store
+# cast). The bf16 gelu MatmulTargets 4 (2048x4096x2048) and 19
+# (3072x3072x3072) share the same plain-gelu chain shape, so the detector
+# fires on them too, but the fp16-pinned shape fact below keeps the T8 seed
+# mutually exclusive with them (and the bias_residual_gelu MatmulTargets
+# 12/28 are excluded at the chain-shape level because their stores carry bias
+# + residual adds before the gelu). The "target8" slot name is the eighth
+# internal seed slot and is unrelated to MatmulTarget 8.
+TCGEN05_TARGET8_GELU_SHAPE = (1536, 6144, 1536)
+TCGEN05_TARGET8_GELU_BLOCK_K = 128
+TCGEN05_TARGET8_GELU_AB_STAGES = 3
+TCGEN05_TARGET8_GELU_C_STAGES = 2
 
 # Stage tuples that the TVM-FFI direct entry accepts, keyed by ``bk``.
 # The codegen-side ``tcgen05_direct_entry`` source builder and the

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -499,6 +499,14 @@ class ConfigSpec:
         self._cute_tcgen05_config.bias_relu_matmul_store_detected = value
 
     @property
+    def cute_tcgen05_gelu_matmul_store_detected(self) -> bool:
+        return self._cute_tcgen05_config.gelu_matmul_store_detected
+
+    @cute_tcgen05_gelu_matmul_store_detected.setter
+    def cute_tcgen05_gelu_matmul_store_detected(self, value: bool) -> None:
+        self._cute_tcgen05_config.gelu_matmul_store_detected = value
+
+    @property
     def _tcgen05_cluster_m_search_choices(self) -> tuple[int, ...] | None:
         return self._cute_tcgen05_config.cluster_m_search_choices
 
@@ -586,6 +594,9 @@ class ConfigSpec:
 
     def allow_tcgen05_target7_tvm_ffi_seed(self) -> None:
         self._cute_tcgen05_config.allow_target7_tvm_ffi_seed()
+
+    def allow_tcgen05_target8_gelu_seed(self) -> None:
+        self._cute_tcgen05_config.allow_target8_gelu_seed()
 
     def allow_tcgen05_target9_tvm_ffi_seed(self) -> None:
         self._cute_tcgen05_config.allow_target9_tvm_ffi_seed()

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -537,6 +537,9 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                     host_function_has_tcgen05_exact_shape_aux_kernel_pattern,
                 )
                 from .._compiler.cute.aux_tensor import (
+                    host_function_has_tcgen05_gelu_matmul_store_pattern,
+                )
+                from .._compiler.cute.aux_tensor import (
                     host_function_has_tcgen05_identity_matmul_store_pattern,
                 )
                 from .._compiler.cute.aux_tensor import (
@@ -578,6 +581,15 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                 )
                 self.env.config_spec.cute_tcgen05_bias_relu_matmul_store_detected = (
                     host_function_has_tcgen05_bias_relu_matmul_store_pattern(
+                        self.host_function
+                    )
+                )
+                # Plain ``gelu(acc)`` store (no bias, no residual) — cycle-87
+                # T8 (MatmulTarget 27, fp16). Fires on the bf16 gelu
+                # MatmulTargets 4/19 too (same chain shape); the T8 seed's
+                # fp16-pinned shape fact keeps it mutually exclusive there.
+                self.env.config_spec.cute_tcgen05_gelu_matmul_store_detected = (
+                    host_function_has_tcgen05_gelu_matmul_store_pattern(
                         self.host_function
                     )
                 )
@@ -640,6 +652,19 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                     # bias but has a different shape; T4 shares relu
                     # but a different shape and no bias).
                     self.env.config_spec.allow_tcgen05_target6_tvm_ffi_seed()
+                if self.env.config_spec.cute_tcgen05_gelu_matmul_store_detected:
+                    # T8 (cycle 87, MatmulTarget 27) gates on the plain-gelu-
+                    # store detection (``gelu(acc)`` with no bias and no
+                    # residual) and writes into the same cluster_m=2 search
+                    # constraints + pid_type allowlist used by the other
+                    # two-CTA seeds. The plain-gelu-store detector is mutually
+                    # exclusive with identity (no unary op), relu (relu, not
+                    # gelu), and bias/bias_relu (no add) walkers via the chain
+                    # shape. The bf16 gelu MatmulTargets 4/19 share the chain
+                    # shape so the detector fires on them too, but T8's
+                    # fp16-pinned shape gate (1536x6144x1536) keeps the seed
+                    # mutually exclusive on the matmul fact.
+                    self.env.config_spec.allow_tcgen05_target8_gelu_seed()
                 if not self.env.settings.disable_autotuner_heuristics:
                     for seed_config in self.env.config_spec.autotune_seed_configs():
                         if (

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -66,6 +66,9 @@ from helion._compiler.cute.tcgen05_constants import (
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TARGET1_TVM_FFI_AB_STAGES
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TARGET1_TVM_FFI_BLOCK_K
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TARGET1_TVM_FFI_C_STAGES
+from helion._compiler.cute.tcgen05_constants import TCGEN05_TARGET8_GELU_AB_STAGES
+from helion._compiler.cute.tcgen05_constants import TCGEN05_TARGET8_GELU_BLOCK_K
+from helion._compiler.cute.tcgen05_constants import TCGEN05_TARGET8_GELU_C_STAGES
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
@@ -1300,6 +1303,163 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         )
 
     @onlyBackends(["cute"])
+    def test_cute_tcgen05_target8_gelu_seed_config(self) -> None:
+        # T8 (cycle 87, MatmulTarget 27): fp16 plain ``gelu(acc)`` at
+        # 1536x6144x1536 produces a single plain two-CTA seed using the
+        # DEFAULT epilogue layout (no FFI / explicit-epi-tile, which is
+        # bf16-only). The bf16 gelu shapes (T4/T19) share the chain shape so
+        # the detector fires on them, but the fp16-pinned shape fact must
+        # keep the T8 seed disabled there.
+        @helion.kernel(backend="cute")
+        def cute_matmul_gelu(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = torch.nn.functional.gelu(acc).to(x.dtype)
+            return out
+
+        fp16_args = (
+            torch.empty([1536, 1536], device=DEVICE, dtype=torch.float16),
+            torch.empty([1536, 6144], device=DEVICE, dtype=torch.float16),
+        )
+        with (
+            patch_cute_mma_support(),
+            patch("helion.language.matmul_ops._cuda_num_sms_or_zero", return_value=132),
+        ):
+            bound = cute_matmul_gelu.bind(fp16_args)
+        self.assertTrue(
+            bound.config_spec.cute_tcgen05_gelu_matmul_store_detected,
+            "plain-gelu store detector must fire on the fp16 T8 shape",
+        )
+        seeds = [config.config for config in bound.config_spec.autotune_seed_configs()]
+        gelu_seeds = [
+            seed
+            for seed in seeds
+            if seed.get("block_sizes")
+            == [
+                TCGEN05_TWO_CTA_BLOCK_M,
+                TCGEN05_TWO_CTA_BLOCK_N,
+                TCGEN05_TARGET8_GELU_BLOCK_K,
+            ]
+            and seed.get("tcgen05_ab_stages") == TCGEN05_TARGET8_GELU_AB_STAGES
+        ]
+        self.assertEqual(len(gelu_seeds), 1)
+        seed = gelu_seeds[0]
+        # The T8 seed must NOT use the FFI / explicit-epi-tile path (the
+        # fp16 gelu store is rejected by that codegen gate).
+        self.assertIsNot(seed.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY), True)
+        self.assertIsNot(seed.get(TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY), True)
+        self.assertIn(
+            seed.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY),
+            (None, Tcgen05LayoutStrategy.DEFAULT.value),
+        )
+        self.assertEqual(seed["tcgen05_cluster_m"], 2)
+        self.assertEqual(seed["tcgen05_cluster_n"], 1)
+        self.assertEqual(seed["tcgen05_c_stages"], TCGEN05_TARGET8_GELU_C_STAGES)
+        self.assertEqual(seed["pid_type"], "persistent_interleaved")
+        self.assertEqual(seed["l2_groupings"], [2])
+        # Seed survives flatten/unflatten against the live spec.
+        config_gen = bound.config_spec.create_config_generation()
+        transferred = [
+            config.config
+            for _flat, config in config_gen.seed_flat_config_pairs()
+            if config.config.get("block_sizes")
+            == [
+                TCGEN05_TWO_CTA_BLOCK_M,
+                TCGEN05_TWO_CTA_BLOCK_N,
+                TCGEN05_TARGET8_GELU_BLOCK_K,
+            ]
+            and config.config.get("tcgen05_ab_stages") == TCGEN05_TARGET8_GELU_AB_STAGES
+        ]
+        self.assertGreaterEqual(len(transferred), 1)
+        # The transferred seed survives ``num_warps`` normalization (8 -> 4)
+        # while keeping the tile/stage/cluster envelope intact.
+        self.assertEqual(transferred[0]["tcgen05_cluster_m"], 2)
+        self.assertEqual(
+            transferred[0]["block_sizes"],
+            [
+                TCGEN05_TWO_CTA_BLOCK_M,
+                TCGEN05_TWO_CTA_BLOCK_N,
+                TCGEN05_TARGET8_GELU_BLOCK_K,
+            ],
+        )
+
+        # The search projection promotes a cluster_m=2 + bk=128 candidate
+        # (which the for_search ab fragment caps at ab=2) back to the seed's
+        # ab=3 stage tuple, so the autotuner actually samples the fast regime.
+        promoted = helion.Config(
+            block_sizes=[
+                TCGEN05_TWO_CTA_BLOCK_M,
+                TCGEN05_TWO_CTA_BLOCK_N,
+                TCGEN05_TARGET8_GELU_BLOCK_K,
+            ],
+            indexing=["tensor_descriptor", "tensor_descriptor", "tensor_descriptor"],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=1,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=4,
+        )
+        bound.config_spec.normalize(promoted, _fix_invalid=True)
+        self.assertEqual(
+            promoted.config["tcgen05_ab_stages"], TCGEN05_TARGET8_GELU_AB_STAGES
+        )
+        self.assertEqual(
+            promoted.config["tcgen05_c_stages"], TCGEN05_TARGET8_GELU_C_STAGES
+        )
+        # A bk=64 candidate is left in its own regime (not promoted).
+        not_promoted = helion.Config(
+            block_sizes=[TCGEN05_TWO_CTA_BLOCK_M, TCGEN05_TWO_CTA_BLOCK_N, 64],
+            indexing=["tensor_descriptor", "tensor_descriptor", "tensor_descriptor"],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=1,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+        )
+        bound.config_spec.normalize(not_promoted, _fix_invalid=True)
+        self.assertEqual(not_promoted.config["tcgen05_ab_stages"], 2)
+        self.assertEqual(not_promoted.config["block_sizes"][2], 64)
+
+        # bf16 gelu (T19 shape) fires the detector but must NOT enable the
+        # fp16-pinned T8 seed.
+        bf16_args = (
+            torch.empty([3072, 3072], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([3072, 3072], device=DEVICE, dtype=torch.bfloat16),
+        )
+        with (
+            patch_cute_mma_support(),
+            patch("helion.language.matmul_ops._cuda_num_sms_or_zero", return_value=132),
+        ):
+            bf16_bound = cute_matmul_gelu.bind(bf16_args)
+        self.assertTrue(
+            bf16_bound.config_spec.cute_tcgen05_gelu_matmul_store_detected,
+            "plain-gelu detector also fires on the bf16 gelu shape",
+        )
+        self.assertFalse(
+            bf16_bound.config_spec._cute_tcgen05_config.target8_gelu_seed_enabled,
+            "T8 seed must stay disabled on bf16 (fp16-pinned shape fact)",
+        )
+        self.assertFalse(
+            any(
+                config.config.get("tcgen05_ab_stages") == TCGEN05_TARGET8_GELU_AB_STAGES
+                and config.config.get("block_sizes")
+                == [
+                    TCGEN05_TWO_CTA_BLOCK_M,
+                    TCGEN05_TWO_CTA_BLOCK_N,
+                    TCGEN05_TARGET8_GELU_BLOCK_K,
+                ]
+                for config in bf16_bound.config_spec.autotune_seed_configs()
+            )
+        )
+
+    @onlyBackends(["cute"])
     def test_cute_tcgen05_cluster_m2_edge_k_tail_bk_requires_tail(self) -> None:
         valid_tail = Tcgen05ClusterM2SearchConstraints(
             static_k=5000,
@@ -2506,6 +2666,95 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 == TCGEN05_AUX_LOAD_MODE_TMA
                 for config in spec.compiler_seed_configs
             )
+        )
+
+    @onlyBackends(["cute"])
+    def test_cute_tcgen05_aux_tma_full_tile_search_projection(self) -> None:
+        # Cycle 88 (Workstream B): on the residual full-tile cluster_m=2
+        # family (T20-shape 6144³ bf16 residual_add), the search projection
+        # ``_fix_aux_tma_full_tile_search_config`` forces cluster_m=2 SIMT
+        # candidates onto the validated aux-TMA producer regime so the
+        # +14 pp aux-TMA gain is banked deterministically. cluster_m=1
+        # candidates stay untouched.
+        @helion.kernel(backend="cute")
+        def cute_matmul_residual_add(
+            x: torch.Tensor,
+            y: torch.Tensor,
+            residual: torch.Tensor,
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = (acc + residual[tile_m, tile_n]).to(x.dtype)
+            return out
+
+        args = (
+            torch.empty([6144, 6144], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([6144, 6144], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([6144, 6144], device=DEVICE, dtype=torch.bfloat16),
+        )
+        with (
+            patch_cute_mma_support(),
+            patch("helion.language.matmul_ops._cuda_num_sms_or_zero", return_value=132),
+        ):
+            bound = cute_matmul_residual_add.bind(args)
+        spec = bound.config_spec
+        self.assertTrue(spec.cute_tcgen05_exact_shape_aux_kernel_detected)
+        self.assertTrue(spec._cute_tcgen05_config._aux_tma_full_tile_search_enabled())
+        # The aux-TMA seed is present in the compiler seed pool.
+        self.assertTrue(
+            any(
+                config.config.get(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY)
+                == TCGEN05_AUX_LOAD_MODE_TMA
+                for config in spec.autotune_seed_configs()
+            )
+        )
+        # A cluster_m=2 SIMT monolithic ab=3 candidate is projected onto the
+        # aux-TMA regime (role_local_with_scheduler + warps + ab=2 + tma).
+        cm2 = helion.Config(
+            block_sizes=[256, 256, 128],
+            indexing=["tensor_descriptor", "tensor_descriptor", "tensor_descriptor"],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=1,
+            tcgen05_ab_stages=3,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_strategy=Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
+            tcgen05_persistence_model="static_persistent",
+        )
+        spec.normalize(cm2, _fix_invalid=True)
+        self.assertEqual(
+            cm2.config[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY], TCGEN05_AUX_LOAD_MODE_TMA
+        )
+        self.assertEqual(
+            cm2.config["tcgen05_strategy"],
+            Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER.value,
+        )
+        self.assertEqual(cm2.config["tcgen05_ab_stages"], 2)
+        self.assertEqual(cm2.config[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY], 1)
+        self.assertEqual(cm2.config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY], 1)
+        # A cluster_m=1 candidate is left in its own regime (not forced to TMA).
+        cm1 = helion.Config(
+            block_sizes=[128, 256, 64],
+            indexing=["pointer", "tensor_descriptor", "tensor_descriptor"],
+            pid_type="flat",
+            tcgen05_cluster_m=1,
+            tcgen05_cluster_n=1,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=2,
+            tcgen05_strategy=Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
+        )
+        spec.normalize(cm1, _fix_invalid=True)
+        self.assertEqual(cm1.config["tcgen05_cluster_m"], 1)
+        self.assertNotEqual(
+            cm1.config.get(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY),
+            TCGEN05_AUX_LOAD_MODE_TMA,
         )
 
     @onlyBackends(["cute"])


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2682
 * #2681
 * #2680
 * #2679
 * #2678
 * #2656
 * #2655
 * __->__#2654
 * #2653
 * #2652
 * #2651


--- --- ---

[cutedsl] productionize aux-TMA selection via search projection

Make aux-TMA selection deterministic by projecting it into the
autotuner search space for the residual-add family, and add an fp16
gelu epilogue seed. Stabilizes config selection across re-autotunes.