### PR TITLE
[cutedsl] overlap epilogue store via a dedicated store warp

### DIFF
--- a/benchmarks/cute/compare_matmul_backends.py
+++ b/benchmarks/cute/compare_matmul_backends.py
@@ -84,6 +84,7 @@ import torch
 
 import helion
 from helion._compiler.cute.strategies import TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY
+from helion._compiler.cute.strategies import TCGEN05_WARP_SPEC_STORE_WARPS_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_ACC_PRODUCER_MODE_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_ACC_PRODUCER_MODE_NORMAL
 from helion._compiler.cute.tcgen05_constants import TCGEN05_ACC_PRODUCER_MODE_SKIP_UMMA
@@ -1248,6 +1249,8 @@ def _make_helion_config_from_args(args: argparse.Namespace) -> helion.Config:
             config["tcgen05_warp_spec_scheduler_warps"] = 1
     if args.helion_c_input_warps is not None:
         config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY] = args.helion_c_input_warps
+    if args.helion_store_warps is not None:
+        config[TCGEN05_WARP_SPEC_STORE_WARPS_KEY] = args.helion_store_warps
     if args.helion_consumer_regs is not None:
         config[TCGEN05_CONSUMER_REGS_CONFIG_KEY] = args.helion_consumer_regs
     if args.helion_persistence_model is not None:
@@ -1747,6 +1750,8 @@ def _build_subprocess_cmd(args: argparse.Namespace, impl: str) -> list[str]:
             cmd.extend(["--helion-strategy", args.helion_strategy])
         if args.helion_c_input_warps is not None:
             cmd.extend(["--helion-c-input-warps", str(args.helion_c_input_warps)])
+        if args.helion_store_warps is not None:
+            cmd.extend(["--helion-store-warps", str(args.helion_store_warps)])
         if args.helion_consumer_regs is not None:
             cmd.extend(["--helion-consumer-regs", str(args.helion_consumer_regs)])
         if args.helion_persistence_model is not None:
@@ -1857,6 +1862,7 @@ def _two_cta_edge_k_tail_monolithic_args(
             "helion_num_epi_warps": 4,
             "helion_strategy": "role_local_monolithic",
             "helion_c_input_warps": 0,
+            "helion_store_warps": 0,
             "helion_require_tcgen05": 1,
             "helion_range_flattens": list(_HELION_DEFAULT_RANGE_FLATTENS),
             "helion_range_multi_buffers": list(_HELION_DEFAULT_RANGE_MULTI_BUFFERS),
@@ -4206,6 +4212,8 @@ def _build_two_cta_ncu_profile_command(
             cmd.extend(["--helion-strategy", args.helion_strategy])
         if args.helion_c_input_warps is not None:
             cmd.extend(["--helion-c-input-warps", str(args.helion_c_input_warps)])
+        if args.helion_store_warps is not None:
+            cmd.extend(["--helion-store-warps", str(args.helion_store_warps)])
         if args.helion_consumer_regs is not None:
             cmd.extend(["--helion-consumer-regs", str(args.helion_consumer_regs)])
         if args.helion_persistence_model is not None:
@@ -6288,6 +6296,17 @@ def parse_args() -> argparse.Namespace:
         choices=(0, 1),
         default=None,
         help="Optional tcgen05 C-input warp override for fixed Helion configs.",
+    )
+    parser.add_argument(
+        "--helion-store-warps",
+        type=int,
+        choices=(0, 1),
+        default=None,
+        help=(
+            "Optional tcgen05 store-warp override for fixed Helion configs "
+            "(Workstream A Stage 3 inert store warp; only valid under "
+            "role_local_with_scheduler)."
+        ),
     )
     parser.add_argument(
         "--helion-consumer-regs",

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -3693,6 +3693,13 @@ def _emit_mma_pipeline(
             # WITH_SCHEDULER and ``{0}`` under MONOLITHIC; codegen
             # body for the C-input warp is inert today.
             c_input_warp_count=tcgen05_warp_spec.c_input_warps,
+            # ``store_warp_count`` plumbs the Stage-3 store-warp slot
+            # (cycle 91, ``cute_plan.md`` §4.2) through the plan the same
+            # way. Validator restricts it to ``{0, 1}`` under WITH_SCHEDULER
+            # and ``{0}`` under MONOLITHIC; the store warp's body is inert in
+            # cycle 91 (it occupies the former padding slot, so launch
+            # accounting is unchanged), the R2S->TMA-D drain lands in Stage 4.
+            store_warp_count=tcgen05_warp_spec.store_warps,
             persistence_model=tcgen05_persistence_model_for_plan,
             cluster_n=tcgen05_cluster_n,
             l2_swizzle_size=tcgen05_l2_swizzle_size_value,
@@ -3740,13 +3747,17 @@ def _emit_mma_pipeline(
         #     ``_fix_tcgen05_ab_stages_three_search_config``).
         # The predicate mirrors the productive-body aux-pipeline
         # allocation gate at ``_emit_mma_pipeline`` below
-        # (``has_c_input_warp AND aux_tensor_descriptors AND
-        # aux_single_store_value``). When the multi-store
-        # fan-out gate closes the productive body, the aux SMEM
-        # ring + ``c_pipeline_aux`` are NOT allocated and the
-        # kernel falls back to GMEM-aux reads with no extra
-        # SMEM cost, so the rejection must NOT fire — fan-out
-        # ``ab=3 + c_input=1`` paths are legal and pinned by
+        # (``has_aux_producer_warp AND aux_tensor_descriptors AND
+        # aux_single_store_value``), where the aux producer is the
+        # C-input warp (SIMT or TMA) OR — under the cycle-94 merge —
+        # the store warp (TMA only). The store-warp TMA aux ring has
+        # the SAME SMEM cost as the C-input TMA ring, so ab=3 overshoots
+        # the cap identically and must be rejected for it too. When the
+        # multi-store fan-out gate closes the productive body, the aux
+        # SMEM ring + ``c_pipeline_aux`` are NOT allocated and the
+        # kernel falls back to GMEM-aux reads with no extra SMEM cost,
+        # so the rejection must NOT fire — fan-out ``ab=3 + c_input=1``
+        # paths are legal and pinned by
         # ``test_aux_pipeline_ab_stages_3_with_c_input_fanout_not_rejected``.
         c_input_aux_tensor_descriptors = (
             tcgen05_matmul_plan.c_input_aux_tensor_descriptors
@@ -3754,8 +3765,14 @@ def _emit_mma_pipeline(
         aux_single_store_value = (
             len({d.store_value_node for d in c_input_aux_tensor_descriptors}) <= 1
         )
+        ab_reject_aux_tma_requested = (
+            df.config.get(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY) == TCGEN05_AUX_LOAD_MODE_TMA
+        )
+        ab_reject_has_aux_producer_warp = tcgen05_matmul_plan.has_c_input_warp or (
+            tcgen05_matmul_plan.has_store_warp and ab_reject_aux_tma_requested
+        )
         if (
-            tcgen05_matmul_plan.has_c_input_warp
+            ab_reject_has_aux_producer_warp
             and c_input_aux_tensor_descriptors
             and aux_single_store_value
             and tcgen05_matmul_plan.ab_stage_count >= 3
@@ -3763,8 +3780,11 @@ def _emit_mma_pipeline(
             raise exc.BackendUnsupported(
                 "cute",
                 "tcgen05 ``tcgen05_ab_stages=3`` is incompatible "
-                "with the productive C-input warp "
-                "(``tcgen05_warp_spec_c_input_warps=1`` + "
+                "with a productive aux producer warp "
+                "(``tcgen05_warp_spec_c_input_warps=1``, or the "
+                "cycle-94 store-warp merge "
+                "``tcgen05_warp_spec_store_warps=1`` + "
+                "``tcgen05_aux_load_mode=tma``, + "
                 "non-empty aux tensors from the epilogue chain): "
                 "the aux SMEM ring + AB pipeline together "
                 "overshoot the 232 KB B200 SMEM cap at every "
@@ -3772,9 +3792,8 @@ def _emit_mma_pipeline(
                 "``(bm=bn=256, bk=128, cluster_m=2)`` shape uses "
                 "263 KB vs 232 KB cap). Drop to "
                 "``tcgen05_ab_stages=2`` for residual epilogues "
-                "with ``tcgen05_warp_spec_c_input_warps=1``, or "
-                "drop ``tcgen05_warp_spec_c_input_warps=0`` to "
-                "keep ``tcgen05_ab_stages=3``. See "
+                "with an aux producer warp, or drop the aux "
+                "producer warp to keep ``tcgen05_ab_stages=3``. See "
                 "``cute_plan.md`` §1.3 / §7.5.3.2.",
             )
         df.cute_state.block_shape = candidate_block_shape
@@ -4208,6 +4227,15 @@ def _emit_mma_pipeline(
                     if c_input_is_sched_consumer
                     else tcgen05_matmul_plan.c_input_warp_count
                 )
+                # Workstream A Stage 4 (cycle 93): the store warp now runs a
+                # PRODUCTIVE role-local body — it joins the (widened) epilogue
+                # role-local while and consumes the scheduler broadcast to read
+                # the per-tile coordinates it needs for the shared descriptor
+                # setup. It is therefore a REAL sched consumer, so the cycle-91
+                # ``- store_warp_count`` subtraction (which excluded the inert
+                # Stage-3 warp) is REMOVED: the count goes back to including the
+                # store warp. The store warp is a sched consumer + the C-store
+                # ring consumer; it is NOT an acc-pipeline or AB consumer.
             )
             if tcgen05_matmul_plan.is_clc_persistent and tcgen05_sched_cluster_size > 1:
                 tcgen05_sched_consumer_arrive_count = (
@@ -4288,8 +4316,27 @@ def _emit_mma_pipeline(
                 desc.store_value_node for desc in c_input_aux_tensor_descriptors
             }
             aux_single_store_value = len(aux_store_value_nodes) <= 1
+            # Workstream A Stage 5 (cycle 94, the merge): the aux residual load
+            # runs on a dedicated PRODUCER warp. The C-input warp is the producer
+            # in BOTH the SIMT (cooperative ld/st) and the TMA (bulk copy) aux
+            # paths. The merge lets the STORE warp (id 7, 120-reg, idle between
+            # the early aux load and the late TMA-D drain) be that producer — but
+            # ONLY for the TMA path: the merge injects the store warp's aux body
+            # as a TMA bulk producer into the epilogue role-local while. There is
+            # no SIMT store-warp producer body, and the SIMT producer arrive
+            # count is hardcoded to ``c_input_warp_count * 32`` (= 0 with no
+            # C-input warp), which would pair a 0-thread producer group with a
+            # 32-thread SIMT copy and wedge the consumer. So ``store_warps=1 +
+            # SIMT aux`` must fall back to the direct-GMEM aux path (the producer
+            # gate stays closed), exactly as before this merge landed.
+            store_warp_is_aux_producer = (
+                tcgen05_matmul_plan.has_store_warp and tcgen05_aux_tma_requested
+            )
+            has_aux_producer_warp = (
+                tcgen05_matmul_plan.has_c_input_warp or store_warp_is_aux_producer
+            )
             aux_productive_body_gate_open = (
-                tcgen05_matmul_plan.has_c_input_warp
+                has_aux_producer_warp
                 and c_input_aux_tensor_descriptors
                 and aux_single_store_value
             )
@@ -4298,10 +4345,11 @@ def _emit_mma_pipeline(
                 and all_aux_tensor_descriptors
                 and not aux_productive_body_gate_open
             ):
-                if not tcgen05_matmul_plan.has_c_input_warp:
+                if not has_aux_producer_warp:
                     reason = (
-                        "requires the productive C-input warp "
-                        "(``tcgen05_warp_spec_c_input_warps=1``)"
+                        "requires a productive aux producer warp "
+                        "(``tcgen05_warp_spec_c_input_warps=1`` or "
+                        "``tcgen05_warp_spec_store_warps=1``)"
                     )
                 elif not c_input_aux_tensor_descriptors:
                     reason = (
@@ -4413,11 +4461,16 @@ def _emit_mma_pipeline(
                         # tcgen05_ab_stages=3`` (cycle 48 measured
                         # 263 KB used at bk=128; bk=64 fits).
                         tile_shape_expr=tcgen05_plan.epi_tile,
-                        # Single C-input warp = 32 lanes (validator
-                        # pins ``c_input_warp_count`` to ``{0, 1}``
-                        # under WITH_SCHEDULER); all 32 lanes
-                        # participate in the producer-side
-                        # cooperative copy.
+                        # SIMT producer thread count. A single C-input warp = 32
+                        # lanes (validator pins ``c_input_warp_count`` to
+                        # ``{0, 1}`` under WITH_SCHEDULER); all 32 lanes do the
+                        # cooperative SIMT copy. This is only consumed on the
+                        # SIMT aux path; the store-warp merge is TMA-only (the
+                        # ``store_warp_is_aux_producer`` gate above requires
+                        # ``aux_load_mode=tma``), where the producer group is the
+                        # 1-thread ``PipelineTmaAsync`` group and this SIMT count
+                        # is unused — so ``c_input_warp_count * 32`` (= 0 in the
+                        # merge) is correct and never reaches the SIMT branch.
                         c_input_warp_thread_count=(
                             tcgen05_matmul_plan.c_input_warp_count * 32
                         ),

--- a/helion/_compiler/cute/device_state.py
+++ b/helion/_compiler/cute/device_state.py
@@ -114,6 +114,15 @@ class CuteTcgen05MatmulPlan:
     # The scheduler-pipeline arrive count includes this warp only when the
     # productive aux-body gate is open.
     c_input_warp_count: int = 0
+    # Optional epilogue store/drain warp (Workstream A Stage 3, cycle 91).
+    # WITH_SCHEDULER may lift this to one warp; like ``c_input_warp_count`` the
+    # lifted warp occupies the previous inert padding slot so
+    # ``launched_warp_count`` stays warpgroup-aligned (no extra warp launched).
+    # The store warp's body is inert in cycle 91 (the TMA-D store still runs on
+    # warp 0); Stage 4 moves the R2S->TMA-D drain onto it. It sits at the END of
+    # the warp-id order (after the C-input warp) so existing warp ids do not
+    # shift.
+    store_warp_count: int = 0
     persistence_model: str = "static_persistent"
     cluster_n: int = 1
     l2_swizzle_size: int = 1
@@ -201,6 +210,24 @@ class CuteTcgen05MatmulPlan:
         return self.scheduler_warp_id + self.scheduler_warp_count
 
     @property
+    def has_store_warp(self) -> bool:
+        return self.store_warp_count > 0
+
+    @property
+    def store_warp_id(self) -> int:
+        # The store warp is only valid in scheduler-backed role-local kernels;
+        # it sits at the END of the warp-id order — after the C-input warp (if
+        # present) — so adding it never shifts existing warp ids. With sched=1
+        # and no C-input that puts it at warp id 7 (warpgroup 1, warps 4-7),
+        # which is the former inert padding slot.
+        assert self.has_store_warp, (
+            "store_warp_id is only valid when store_warp_count > 0"
+        )
+        return (
+            self.scheduler_warp_id + self.scheduler_warp_count + self.c_input_warp_count
+        )
+
+    @property
     def role_warp_count(self) -> int:
         return (
             self.epi_warp_count
@@ -208,6 +235,7 @@ class CuteTcgen05MatmulPlan:
             + self.ab_load_warp_count
             + self.scheduler_warp_count
             + self.c_input_warp_count
+            + self.store_warp_count
         )
 
     @property
@@ -215,10 +243,11 @@ class CuteTcgen05MatmulPlan:
         # ``setmaxregister`` is warpgroup-uniform on Blackwell: all 4 warps in a
         # warpgroup must request a compatible register budget. Scheduler-backed
         # kernels therefore round the role count up to a full warpgroup. With
-        # the default C-input count this pads 7 role warps to 8; with one
-        # C-input warp, that warp occupies the former padding slot. MONOLITHIC
-        # keeps its historical 6-warp launch because generated-code golden pins
-        # and validated runtime behavior depend on that shape.
+        # the default C-input / store counts this pads 7 role warps to 8; with
+        # one C-input OR one store warp (cycle 91, Workstream A Stage 3), that
+        # warp occupies the former padding slot and the launch stays at 8.
+        # MONOLITHIC keeps its historical 6-warp launch because generated-code
+        # golden pins and validated runtime behavior depend on that shape.
         if self.has_scheduler_warp:
             warpgroup = 4
             return (self.role_warp_count + warpgroup - 1) // warpgroup * warpgroup

--- a/helion/_compiler/cute/strategies.py
+++ b/helion/_compiler/cute/strategies.py
@@ -141,6 +141,18 @@ ROLE_LOCAL_MONOLITHIC_SCHEDULER_WARPS = 0
 # narrowed to 0 until the productive TMA producer body lands and perf
 # is characterized.
 ROLE_LOCAL_MONOLITHIC_C_INPUT_WARPS = 0
+# ``store_warps`` slot for the dedicated epilogue store/drain warp that
+# Workstream A Stage 4 (``cute_plan.md`` §4.2) will eventually use to take
+# the two epilog_sync barriers + warp-0 TMA-D store off the 4-warp epi
+# critical path. Default 0 keeps the historical inert-padding behavior under
+# ``ROLE_LOCAL_WITH_SCHEDULER``. Cycle 91 (Workstream A Stage 3) widens the
+# validator to accept the value 1 under ``ROLE_LOCAL_WITH_SCHEDULER`` so the
+# foundation lift is reachable; the codegen body remains inert (the warp
+# occupies what was previously the inert padding slot under the 7-role-warp /
+# 8-launched shape, so launched-warp accounting is unchanged — see
+# ``CuteTcgen05MatmulPlan.launched_warp_count``). The autotune surface stays
+# narrowed to 0 until the productive store body lands and perf is characterized.
+ROLE_LOCAL_MONOLITHIC_STORE_WARPS = 0
 # Today's role-local lowering uses a (decrease, increase) register split of
 # (120, 256). The decrease side runs on TMA-load + scheduler warps; the
 # increase side runs on MMA-exec + epilogue + epilogue-load warps.
@@ -190,6 +202,17 @@ class Tcgen05WarpSpec:
       ``_tcgen05_strategy_autotune_fragments`` until the productive
       body lands and perf is characterized; only the user-config
       validation surface accepts ``{0, 1}``.
+    - ``store_warps``: dedicated epilogue store/drain warp count.
+      Workstream A Stage 3 (cycle 91, ``cute_plan.md`` §4.2) widens the
+      ``ROLE_LOCAL_WITH_SCHEDULER`` accept set to ``{0, 1}`` (foundation
+      lift, mirror of ``c_input_warps``). Setting this to 1 under
+      WITH_SCHEDULER reuses the inert padding warp: with 4 epi + 1 exec
+      + 1 ab_load + 1 sched + 1 store, ``role_warp_count`` equals 8 and
+      ``launched_warp_count`` (warpgroup-aligned) stays at 8 — no extra
+      warp is launched. The codegen body of the store warp is inert in
+      cycle 91; the productive R2S->TMA-D drain is Stage 4. The autotune
+      surface stays narrowed to ``0``; only user-config validation
+      accepts ``{0, 1}``. ``ROLE_LOCAL_MONOLITHIC`` stays at ``{0}``.
     - ``register_split``: ``(decrease, increase)`` ``setmaxregister``
       counts. The current 6-warp shape uses ``(120, 256)``. Each
       entry's range is enforced by its per-field fragment in
@@ -211,6 +234,19 @@ class Tcgen05WarpSpec:
     # lowering use the field name, not position.
     _: dataclasses.KW_ONLY
     c_input_warps: int = 0
+    # ``store_warps``: dedicated epilogue store/drain warp count.
+    # Workstream A Stage 3 (cycle 91, ``cute_plan.md`` §4.2) widens the
+    # validator to admit ``{0, 1}`` under ``ROLE_LOCAL_WITH_SCHEDULER`` so
+    # an explicit ``helion.Config(tcgen05_warp_spec_store_warps=1)``
+    # round-trips end-to-end and the launched-warp accounting recognizes
+    # the slot. Like ``c_input_warps``, a 1 here under WITH_SCHEDULER reuses
+    # the inert padding warp (4 epi + 1 exec + 1 ab + 1 sched + 1 store = 8
+    # role warps = the warpgroup-aligned launch envelope, so no extra warp
+    # is launched). The codegen body of the store warp is inert in cycle 91;
+    # the productive R2S->TMA-D drain is Stage 4. The autotune surface stays
+    # narrowed to ``0``; only the user-config validation surface accepts
+    # ``{0, 1}``.
+    store_warps: int = 0
 
     @property
     def total_warps(self) -> int:
@@ -221,6 +257,7 @@ class Tcgen05WarpSpec:
             + self.epi_load_warps
             + self.scheduler_warps
             + self.c_input_warps
+            + self.store_warps
         )
 
 
@@ -235,6 +272,7 @@ ROLE_LOCAL_MONOLITHIC_DEFAULT_WARP_SPEC = Tcgen05WarpSpec(
     scheduler_warps=ROLE_LOCAL_MONOLITHIC_SCHEDULER_WARPS,
     register_split=ROLE_LOCAL_MONOLITHIC_REGISTER_SPLIT,
     c_input_warps=ROLE_LOCAL_MONOLITHIC_C_INPUT_WARPS,
+    store_warps=ROLE_LOCAL_MONOLITHIC_STORE_WARPS,
 )
 
 
@@ -464,6 +502,11 @@ TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY = "tcgen05_warp_spec_scheduler_warps"
 # the autotune surface, validated to ``{0, 1}`` only under
 # ``ROLE_LOCAL_WITH_SCHEDULER`` in the user-config validation surface.
 TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY = "tcgen05_warp_spec_c_input_warps"
+# ``store_warps``: dedicated epilogue store/drain warp count. Workstream A
+# Stage 3 (cycle 91, ``cute_plan.md`` §4.2); today narrowed to 0 in the
+# autotune surface, validated to ``{0, 1}`` only under
+# ``ROLE_LOCAL_WITH_SCHEDULER`` in the user-config validation surface.
+TCGEN05_WARP_SPEC_STORE_WARPS_KEY = "tcgen05_warp_spec_store_warps"
 # Register-split is exposed as two scalar keys (decrease, increase)
 # rather than a tuple value because flat config values are scalars.
 TCGEN05_WARP_SPEC_REGISTER_DECREASE_KEY = "tcgen05_warp_spec_register_decrease"
@@ -502,6 +545,7 @@ TCGEN05_WARP_SPEC_KEYS: tuple[str, ...] = (
     TCGEN05_WARP_SPEC_EPI_LOAD_WARPS_KEY,
     TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY,
     TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY,
+    TCGEN05_WARP_SPEC_STORE_WARPS_KEY,
     TCGEN05_WARP_SPEC_REGISTER_DECREASE_KEY,
     TCGEN05_WARP_SPEC_REGISTER_INCREASE_KEY,
 )
@@ -562,6 +606,7 @@ TCGEN05_WARP_SPEC_DEFAULTS_BY_KEY: dict[str, int] = {
     TCGEN05_WARP_SPEC_EPI_LOAD_WARPS_KEY: ROLE_LOCAL_MONOLITHIC_EPI_LOAD_WARPS,
     TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY: ROLE_LOCAL_MONOLITHIC_SCHEDULER_WARPS,
     TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY: ROLE_LOCAL_MONOLITHIC_C_INPUT_WARPS,
+    TCGEN05_WARP_SPEC_STORE_WARPS_KEY: ROLE_LOCAL_MONOLITHIC_STORE_WARPS,
     TCGEN05_WARP_SPEC_REGISTER_DECREASE_KEY: ROLE_LOCAL_MONOLITHIC_REGISTER_SPLIT[0],
     TCGEN05_WARP_SPEC_REGISTER_INCREASE_KEY: ROLE_LOCAL_MONOLITHIC_REGISTER_SPLIT[1],
 }
@@ -604,6 +649,12 @@ def warp_spec_from_config(config: Mapping[str, object]) -> Tcgen05WarpSpec:
         # never carry the key) round-trip via ``ConfigSpec.normalize``
         # picking up ``ROLE_LOCAL_MONOLITHIC_C_INPUT_WARPS``.
         c_input_warps=_as_int(config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY]),
+        # ``store_warps`` added in cycle 91 (Workstream A Stage 3) as the
+        # foundation for the Stage-4 store-warp split. The validator below
+        # restricts its accept set per-strategy; the default is 0 so configs
+        # serialized before cycle 91 (which never carry the key) round-trip
+        # via ``ConfigSpec.normalize`` picking up the monolithic default.
+        store_warps=_as_int(config[TCGEN05_WARP_SPEC_STORE_WARPS_KEY]),
     )
 
 
@@ -783,6 +834,23 @@ _STRATEGY_REQUIRED_SCHEDULER_WARPS: dict[Tcgen05Strategy, int] = {
 # body lands and perf is characterized; only the user-config
 # validation surface accepts ``(0, 1)``.
 _STRATEGY_SUPPORTED_C_INPUT_WARPS: dict[Tcgen05Strategy, frozenset[int]] = {
+    Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC: frozenset({0}),
+    Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER: frozenset({0, 1}),
+    Tcgen05Strategy.PURE_MATMUL_ROLE_LIFECYCLE: frozenset({0}),
+}
+
+# Strategy-conditional ``store_warps`` accept set. Workstream A Stage 3
+# (cycle 91, ``cute_plan.md`` §4.2): only ``ROLE_LOCAL_WITH_SCHEDULER`` can
+# host the dedicated epilogue store/drain warp (the inert padding warp under
+# the WITH_SCHEDULER 8-warp shape becomes the store warp). Non-scheduler
+# strategies keep this at zero because their 6-warp shapes are fully populated.
+# Exactly mirrors ``_STRATEGY_SUPPORTED_C_INPUT_WARPS``: the data-model slot is
+# plumbed through normalize / round-trip / launch accounting so the accept set
+# can widen without config-shape churn, while the codegen body stays inert in
+# cycle 91 (the productive R2S->TMA-D drain is Stage 4). Values outside the
+# per-strategy accept set are rejected so user configs cannot reach an
+# unsupported combination silently.
+_STRATEGY_SUPPORTED_STORE_WARPS: dict[Tcgen05Strategy, frozenset[int]] = {
     Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC: frozenset({0}),
     Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER: frozenset({0, 1}),
     Tcgen05Strategy.PURE_MATMUL_ROLE_LIFECYCLE: frozenset({0}),
@@ -990,6 +1058,40 @@ def validate_tcgen05_strategy_invariants(
             f"tcgen05 strategy {strategy.value!r} only accepts "
             f"c_input_warps in {sorted(supported_c_input)!r}; got "
             f"c_input_warps={warp_spec.c_input_warps}"
+        )
+
+    # ``store_warps`` accept set is per-strategy; only the scheduler-backed
+    # path currently admits the optional epilogue store/drain warp. Mirrors
+    # the ``c_input_warps`` check above (cycle 91, Workstream A Stage 3).
+    supported_store = _STRATEGY_SUPPORTED_STORE_WARPS.get(strategy, frozenset())
+    if supported_store and warp_spec.store_warps not in supported_store:
+        errors.append(
+            f"tcgen05 strategy {strategy.value!r} only accepts "
+            f"store_warps in {sorted(supported_store)!r}; got "
+            f"store_warps={warp_spec.store_warps}"
+        )
+
+    # Cross-field guard: ``c_input_warps`` and ``store_warps`` each
+    # independently admit 1 under ``ROLE_LOCAL_WITH_SCHEDULER`` (both reuse
+    # the single inert padding slot under the 7-role-warp / 8-launched
+    # shape), but they cannot BOTH be 1 at once: ``role_warp_count`` would
+    # sum to 9 (4 epi + 1 exec + 1 ab_load + 1 sched + 1 c_input + 1 store),
+    # rounding ``launched_warp_count`` up to 12 (= 384 threads), which
+    # overflows the validated 1024-thread / 8-warp CTA launch envelope and
+    # surfaces only as a late, confusing ``BackendUnsupported`` at codegen.
+    # The intended Stage-3 path is store=1 with c_input=0; Stage 4 has the
+    # store warp SUBSUME the aux/epi-load role rather than run alongside a
+    # separate c_input warp, so this guard is forward-compatible.
+    if (
+        strategy is Tcgen05Strategy.ROLE_LOCAL_WITH_SCHEDULER
+        and warp_spec.c_input_warps + warp_spec.store_warps > 1
+    ):
+        errors.append(
+            f"tcgen05 strategy {strategy.value!r} cannot run a C-input warp "
+            f"and a store warp at the same time (they share the single "
+            f"warpgroup-padding slot): got "
+            f"c_input_warps={warp_spec.c_input_warps} + "
+            f"store_warps={warp_spec.store_warps} > 1. Set at most one to 1."
         )
 
     # ``epi_warps`` is intentionally NOT checked here — its accept-

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -35,6 +35,7 @@ from .strategies import TCGEN05_WARP_SPEC_MMA_WARPS_KEY
 from .strategies import TCGEN05_WARP_SPEC_REGISTER_DECREASE_KEY
 from .strategies import TCGEN05_WARP_SPEC_REGISTER_INCREASE_KEY
 from .strategies import TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY
+from .strategies import TCGEN05_WARP_SPEC_STORE_WARPS_KEY
 from .strategies import Tcgen05LayoutStrategy
 from .strategies import Tcgen05PersistenceModel
 from .strategies import Tcgen05Strategy
@@ -95,6 +96,7 @@ from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_STAGE_CONFIGS
 from .tcgen05_constants import TCGEN05_ONE_CTA_MAX_BLOCK_M
 from .tcgen05_constants import TCGEN05_PURE_CLC_SCHEDULER_OBJECT_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_PURE_DYNAMIC_SCHEDULER_OBJECT_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_RESIDUAL_FULL_TILE_DEEP_C_STAGES
 from .tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODE_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODE_NORMAL
 from .tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODES
@@ -161,6 +163,8 @@ from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_SCHEDULER_L2_SWIZZLE_
 from .tcgen05_constants import TCGEN05_TWO_CTA_MAX_K_TILES
 from .tcgen05_constants import TCGEN05_TWO_CTA_SEED_PID_TYPE
 from .tcgen05_constants import tcgen05_ab_smem_bytes_per_cta
+from .tcgen05_constants import tcgen05_c_smem_bytes_per_cta
+from .tcgen05_constants import tcgen05_default_epilogue_tile_size
 from .tcgen05_constants import tcgen05_two_cta_edge_k_tail_seed_overrides
 
 if TYPE_CHECKING:
@@ -1883,6 +1887,130 @@ class CuteTcgen05Config:
         )
         return bytes_per_cta <= constraints.per_cta_smem_budget_bytes
 
+    def c_stages_fits(
+        self,
+        *,
+        bm: int,
+        bn: int,
+        bk: int,
+        cluster_m: int,
+        ab_stages: int,
+        c_stages: int,
+        has_source_c: bool,
+    ) -> bool:
+        # Workstream A Stage 2 (cycle 90): budget-aware admission for the deeper
+        # C-store ring. Reuse the ``tcgen05_ab_stages=3`` SMEM-budget envelope
+        # (same dtype_bytes + per-CTA budget after the non-AB reservation) and
+        # require AB + C to fit together. This is the gate that keeps a deeper
+        # C ring (``tcgen05_c_stages=4``) out of the ab=3 regime, where AB+C
+        # overshoots the 232 KB B200 cap and ptxas raises a raw
+        # ``too much shared`` error during tuning. The C bytes use the REAL
+        # ``Tcgen05LayoutStrategy.DEFAULT`` epilogue subtile, not the (128, 32)
+        # EXPLICIT_EPI_TILE direct-entry tile, so the byte count matches the
+        # role-local codegen: a 256x256 16-bit tile is ``(128, 64)`` WITH a
+        # source-C (residual family) but ``(128, 32)`` WITHOUT one (plain
+        # matmul) -- ``compute_epilogue_tile_size`` shrinks N when no C tile
+        # competes for SMEM. ``has_source_c`` threads that distinction through.
+        constraints = self.ab_stages_three_search_constraints
+        if constraints is None:
+            return False
+        if cluster_m not in (1, 2):
+            return False
+        if bm <= 0 or bn <= 0 or bk <= 0:
+            return False
+        if ab_stages <= 0 or c_stages <= 0:
+            return False
+        ab_bytes = tcgen05_ab_smem_bytes_per_cta(
+            bm=bm,
+            bn=bn,
+            bk=bk,
+            dtype_bytes=constraints.dtype_bytes,
+            ab_stages=ab_stages,
+            cluster_m=cluster_m,
+        )
+        # The epilogue processes the full per-CTA output tile (bm, bn); unlike
+        # the AB operands it is NOT split across the cluster, so the C-ring
+        # bytes do not depend on cluster_m. ``elem_width`` is the operand /
+        # output element width in bits (the validated families are uniform
+        # 16-bit). ``elem_width_c`` is None for no-source-C (plain) kernels so
+        # the helper picks the smaller no-source-C epilogue tile.
+        elem_width = constraints.dtype_bytes * 8
+        epi_tile_m, epi_tile_n = tcgen05_default_epilogue_tile_size(
+            bm,
+            bn,
+            elem_width_d=elem_width,
+            elem_width_c=elem_width if has_source_c else None,
+        )
+        c_bytes = tcgen05_c_smem_bytes_per_cta(
+            epi_tile_m=epi_tile_m,
+            epi_tile_n=epi_tile_n,
+            dtype_bytes=constraints.dtype_bytes,
+            c_stages=c_stages,
+        )
+        return ab_bytes + c_bytes <= constraints.per_cta_smem_budget_bytes
+
+    def _fix_c_stages_search_config(self, config: dict[str, object]) -> None:
+        # Workstream A Stage 2 (cycle 90): true admission gate for the deeper C
+        # ring. ``tcgen05_c_stages`` is an ``EnumFragment((2, 4))`` knob, so the
+        # autotuner can SAMPLE c=4 independently of any projection — a directly
+        # sampled 256x256 cluster_m=2 ab=3 + c=4 reaches ptxas and fails with a
+        # raw ``too much shared`` error (verified cycle-90). Mirror
+        # ``_fix_ab_stages_three_search_config``: when a config carries c=4 from
+        # ANY source and ``c_stages_fits`` is False, demote it to 2.
+        #
+        # Scope: judge ONLY the canonical full-tile 256x256 DEFAULT-layout path,
+        # which is exactly where the AB+C arithmetic is calibrated (the validated
+        # CtaGroup.TWO cosize shapes) and where the role-local C ring lives. The
+        # narrow-N / bm=128 edge family (``_fix_aux_edge_search_config`` sets its
+        # own validated c=4 at a different cosize that the analytic model would
+        # mis-judge) and the EXPLICIT_EPI_TILE direct-entry seeds (separate
+        # (128, 32) tile + own admission) keep their c=4 untouched.
+        if not self.search_enabled:
+            return
+        if config.get("tcgen05_c_stages") != TCGEN05_RESIDUAL_FULL_TILE_DEEP_C_STAGES:
+            return
+        if not self._is_default_layout_full_tile_config(config):
+            return
+        # Fail CLOSED: the ``(2, 4)`` c-stages fragment is offered on every
+        # device, but with no SMEM budget recorded (non-B200 / CPU host) we
+        # cannot prove c=4 fits — demote rather than leave the ptxas-overflow
+        # window open. ``c_stages_fits`` itself returns False when constraints
+        # are absent, so a single ``not c_stages_fits`` check covers both the
+        # over-budget and the no-budget arms.
+        block_sizes = cast("list[int]", config["block_sizes"])
+        cluster_m = cast("int", config.get("tcgen05_cluster_m", 1))
+        ab_stages = cast("int", config.get("tcgen05_ab_stages", 2))
+        if not self.c_stages_fits(
+            bm=block_sizes[0],
+            bn=block_sizes[1],
+            bk=block_sizes[2],
+            cluster_m=cluster_m,
+            ab_stages=ab_stages,
+            c_stages=TCGEN05_RESIDUAL_FULL_TILE_DEEP_C_STAGES,
+            has_source_c=self.aux_kernel_detected,
+        ):
+            config["tcgen05_c_stages"] = 2
+
+    @staticmethod
+    def _is_default_layout_full_tile_config(config: dict[str, object]) -> bool:
+        # The canonical 256x256 DEFAULT-layout role-local tile, where the C-ring
+        # AB+C SMEM model is calibrated. EXPLICIT_EPI_TILE configs use a separate
+        # tile/admission and are excluded; an absent layout key defaults to
+        # DEFAULT.
+        layout = config.get(
+            TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY,
+            Tcgen05LayoutStrategy.DEFAULT.value,
+        )
+        if layout != Tcgen05LayoutStrategy.DEFAULT.value:
+            return False
+        block_sizes = config.get("block_sizes")
+        if not isinstance(block_sizes, list) or len(block_sizes) < 2:
+            return False
+        return (
+            block_sizes[0] == TCGEN05_TWO_CTA_BLOCK_M
+            and block_sizes[1] == TCGEN05_TWO_CTA_BLOCK_N
+        )
+
     def _fix_ab_stages_three_search_config(self, config: dict[str, object]) -> None:
         if self.ab_stages_three_search_constraints is None:
             return
@@ -1981,6 +2109,27 @@ class CuteTcgen05Config:
         config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY] = 1
         config["tcgen05_ab_stages"] = 2
         config[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY] = TCGEN05_AUX_LOAD_MODE_TMA
+        # Workstream A Stage 2 (cycle 90): give this family the deeper C-store
+        # ring (foundation for the Stage-4 store-warp split — the store warp
+        # drains tile N's TMA-D from the ring while the 4 epi warps run tile
+        # N+1's T2R; a 2-stage ring leaves no slack). At ab=2 the c=4 ring fits
+        # (128 KB AB + 64 KB C = 192 KB < 232 KB cap; the DEFAULT epi tile is
+        # (128, 64), so each C stage is 16 KB), confirmed correct on T20
+        # (cycle-90 force-config: c=2 942.2 TF vs c=4 936.1 TF — perf-neutral
+        # standalone, exactly the cycle-89 NCU prediction since the TMA-D store
+        # is already c_pipeline-overlapped). Gated by ``c_stages_fits`` so a
+        # future ab=3 candidate in this family cannot be lifted into overflow.
+        block_sizes = cast("list[int]", config["block_sizes"])
+        if self.c_stages_fits(
+            bm=block_sizes[0],
+            bn=block_sizes[1],
+            bk=block_sizes[2],
+            cluster_m=2,
+            ab_stages=2,
+            c_stages=TCGEN05_RESIDUAL_FULL_TILE_DEEP_C_STAGES,
+            has_source_c=True,
+        ):
+            config["tcgen05_c_stages"] = TCGEN05_RESIDUAL_FULL_TILE_DEEP_C_STAGES
 
     @staticmethod
     def _is_with_scheduler_c_input_config(config: dict[str, object]) -> bool:
@@ -3092,6 +3241,14 @@ class CuteTcgen05Config:
             strategy_choices = (Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,)
             scheduler_warps_choices = (0,)
             c_input_warps_choices = (0,)
+        # The store-warp slot stays narrowed to ``0`` in the autotune surface —
+        # only an explicit ``helion.Config(tcgen05_warp_spec_store_warps=1)``
+        # activates it. Cycle 93 (Workstream A Stage 4) landed the productive
+        # decouple body (the C-store edge + tail split, +1.1 % on T20), but the
+        # autotune surface stays at ``0`` until Stage 5 wires store=1 into the
+        # residual family's production config + runs the full regression sweep,
+        # so no passing target can pick it before it is characterized per-family.
+        store_warps_choices: tuple[int, ...] = (0,)
         if target1_tvm_ffi_seed_enabled:
             layout_choices = (
                 Tcgen05LayoutStrategy.DEFAULT.value,
@@ -3109,6 +3266,7 @@ class CuteTcgen05Config:
                 scheduler_warps_choices
             ),
             TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY: EnumFragment(c_input_warps_choices),
+            TCGEN05_WARP_SPEC_STORE_WARPS_KEY: EnumFragment(store_warps_choices),
             TCGEN05_WARP_SPEC_REGISTER_DECREASE_KEY: EnumFragment(
                 (ROLE_LOCAL_MONOLITHIC_DEFAULT_WARP_SPEC.register_split[0],)
             ),
@@ -3141,6 +3299,11 @@ class CuteTcgen05Config:
         )
         fragments[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY] = EnumFragment((0, 1))
         fragments[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY] = EnumFragment((0, 1))
+        # Cycle 91 (Workstream A Stage 3): the user-config validation surface
+        # accepts ``{0, 1}`` so an explicit ``store_warps=1`` round-trips; the
+        # per-strategy accept set in ``_STRATEGY_SUPPORTED_STORE_WARPS`` still
+        # pins it to ``{0}`` outside ROLE_LOCAL_WITH_SCHEDULER.
+        fragments[TCGEN05_WARP_SPEC_STORE_WARPS_KEY] = EnumFragment((0, 1))
         return fragments
 
     @staticmethod
@@ -3573,6 +3736,12 @@ class CuteTcgen05Config:
         self._fix_aux_tma_full_tile_search_config(config)
         self._fix_with_scheduler_search_config(config)
         self._fix_aux_tma_search_config(config)
+        # Final c-stages admission: demote a directly-sampled (or any unclaimed)
+        # deeper C ring on the canonical 256x256 DEFAULT-layout path that does
+        # not fit AB+C under the B200 cap. Runs after the family fixups so their
+        # validated c=4 (residual ab=2 projection above; edge/seed families,
+        # which this gate's scope excludes) is set first.
+        self._fix_c_stages_search_config(config)
         # CLC admission depends on the projected cluster/pid/strategy tuple
         # above, including the scheduler/c-input warp fix-ups.
         self._fix_clc_persistence_search_config(config)

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -125,6 +125,81 @@ def tcgen05_ab_smem_bytes_per_cta(
     return ab_stages * (a_per_stage + b_per_stage)
 
 
+# Workstream A Stage 2 (cycle 90): the residual full-tile family gets a deeper
+# C-store ring (foundation for the Stage-4 store-warp split, which drains tile N
+# while the epi warps run tile N+1). The validated deeper depth is 4 — the only
+# other ``EnumFragment((2, 4))`` choice — and it fits at ab=2 under the 232 KB
+# B200 SMEM cap (256x256x128 CtaGroup.TWO bf16: 128 KB AB + 64 KB C = 192 KB).
+# ab=3 + c=4 overflows (192 KB AB + 64 KB C = 256 KB → raw ``ptxas: too much
+# shared``), so the deeper ring is admitted only behind the c-stages SMEM budget
+# gate in ``CuteTcgen05Config``.
+TCGEN05_RESIDUAL_FULL_TILE_DEEP_C_STAGES = 4
+
+
+def tcgen05_default_epilogue_tile_size(
+    bm: int,
+    bn: int,
+    *,
+    elem_width_d: int,
+    elem_width_c: int | None,
+) -> tuple[int, int]:
+    """Return the DEFAULT (auto) epilogue subtile ``(tile_m, tile_n)`` in elems.
+
+    The role-local ``Tcgen05LayoutStrategy.DEFAULT`` path sizes its epilogue
+    subtile via ``cutlass.utils.blackwell_helpers.compute_epilogue_tile_shape``
+    (``tcgen05_default_epilogue_tile_expr``), whose tile choice is the pure
+    Python ``compute_epilogue_tile_size``. The tile depends on whether the
+    epilogue reads a source-C tensor: ``compute_epilogue_tile_size`` shrinks N
+    when a C tile competes for SMEM. For a 256x256 CTA tile with 16-bit elements
+    it is ``(128, 64)`` WITH a source C (residual family, ``elem_width_c`` set)
+    but ``(128, 32)`` WITHOUT one (plain matmul, ``elem_width_c=None``) — and in
+    both cases NOT the ``(128, 32)`` EXPLICIT_EPI_TILE direct-entry (TVM-FFI)
+    tile, which is a separate codepath. Pass ``elem_width_c`` matching the
+    config's real source-C presence so the SMEM budget gate matches codegen (and
+    tracks any future CuTe tile-rule change rather than a hard-coded guess).
+    """
+    # Lazy import: ``cutlass`` is only loaded on the cute backend, while this
+    # module is imported on the general autotuner path too.
+    from cutlass.utils.blackwell_helpers import compute_epilogue_tile_size
+
+    # The role-local epilogue D/C tensors are row-major (LayoutEnum.ROW_MAJOR,
+    # see ``cute_mma.py`` ``tcgen05_c_layout``), i.e. NOT M-major.
+    tile_m, tile_n = compute_epilogue_tile_size(
+        bm,
+        bn,
+        False,
+        elem_width_d,
+        elem_width_c,
+        d_is_m_major=False,
+        c_is_m_major=False,
+    )
+    return tile_m, tile_n
+
+
+def tcgen05_c_smem_bytes_per_cta(
+    *,
+    epi_tile_m: int,
+    epi_tile_n: int,
+    dtype_bytes: int,
+    c_stages: int,
+) -> int:
+    """Return per-CTA C-store-ring SMEM bytes for a tcgen05 epilogue.
+
+    The role-local TMA-store epilogue allocates a multistage SMEM ring whose
+    per-stage cosize is ``epi_tile_m * epi_tile_n * dtype_bytes``. The autotune
+    search-space gate sums this against the AB pipeline cost to admit a deeper
+    C ring (``tcgen05_c_stages=4``) only when the combined AB+C SMEM fits the
+    B200 optin budget after the same non-AB reservation the
+    ``tcgen05_ab_stages=3`` gate uses. For the residual full-tile family
+    (256x256 CTA tile, 16-bit, DEFAULT epi tile ``(128, 64)``): each C stage is
+    128*64*2 = 16 KB, so ab=2 + c=4 = 128 KB AB + 64 KB C = 192 KB (fits the
+    232 KB cap), while ab=3 + c=4 = 192 KB AB + 64 KB C = 256 KB (overflows).
+    """
+    assert c_stages >= 1
+    assert epi_tile_m > 0 and epi_tile_n > 0 and dtype_bytes > 0
+    return c_stages * epi_tile_m * epi_tile_n * dtype_bytes
+
+
 # C-store epilogue placement knobs. Keeping these in Config makes generated-code
 # changes visible to BoundKernel's Config-keyed compile cache; most values are
 # used for diagnostics, while the output-edge + K-tail seed uses the measured

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -1411,14 +1411,37 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         )
 
     def _tcgen05_epi_role_predicate(self) -> str:
-        """Boolean expression that gates the epilogue warps' role block."""
+        """Boolean expression that gates the epilogue warps' role block.
+
+        Workstream A Stage 4 (cycle 93, Path B shared-loop split): when the
+        matmul plan carries a store warp (``has_store_warp``), the predicate
+        is WIDENED to also admit ``store_warp_id`` so the store warp runs the
+        SAME epilogue role-local while as the 4 epi warps — sharing the
+        descriptor/SMEM/layout setup and the sched-consumer + subtile loop
+        (no re-derivation; this is what makes Path B cheap vs the independent
+        store-warp loop of Path A). Inside the loop the per-subtile tail is
+        split by warp role with inline gates emitted in the tail source
+        (``memory_ops._codegen_cute_store_tcgen05_tile``): the 4 epi warps
+        (``epi_active`` = ``warp_idx < epi_warp_count``) own T2R/R2S + the
+        C-store producer commit, and the store warp (``warp_idx ==
+        store_warp_id``) owns the consumer-wait + TMA-D + consumer-release
+        drain. When ``store_warps=0`` the predicate is the historical
+        ``warp_idx < epi_warp_count`` and codegen is byte-identical.
+        """
         plan = self._tcgen05_plan()
         assert plan is not None, (
             "tcgen05 epilogue role predicate requires a registered matmul plan"
         )
-        return (
+        epi_predicate = (
             "cute.arch.make_warp_uniform(cute.arch.warp_idx()) "
             f"< cutlass.Int32({plan.epi_warp_count})"
+        )
+        if not plan.has_store_warp:
+            return epi_predicate
+        return (
+            f"({epi_predicate} or "
+            "cute.arch.make_warp_uniform(cute.arch.warp_idx()) "
+            f"== cutlass.Int32({plan.store_warp_id}))"
         )
 
     def _tcgen05_scheduler_role_predicate(self) -> str:
@@ -2505,6 +2528,8 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         *,
         emit_pdl_wait: bool = True,
         initialize_tile_counter: bool = True,
+        store_aux_per_tile_stmts: list[ast.stmt] | None = None,
+        store_aux_predicate: str | None = None,
     ) -> ast.stmt:
         """Build a role-local ``while`` for one extracted role block.
 
@@ -2558,7 +2583,12 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                 role_prelude_stmts=role_prelude_stmts,
                 emit_pdl_wait=emit_pdl_wait,
                 initialize_tile_counter=initialize_tile_counter,
+                store_aux_per_tile_stmts=store_aux_per_tile_stmts,
+                store_aux_predicate=store_aux_predicate,
             )
+        assert store_aux_per_tile_stmts is None, (
+            "store-warp aux merge requires ROLE_LOCAL_WITH_SCHEDULER"
+        )
 
         # Match the shared scheduler's cluster shape so the role-local
         # scheduler visits the same tile sequence in the same order.
@@ -2673,6 +2703,8 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         role_prelude_stmts: list[ast.stmt] | None = None,
         emit_pdl_wait: bool = True,
         initialize_tile_counter: bool = True,
+        store_aux_per_tile_stmts: list[ast.stmt] | None = None,
+        store_aux_predicate: str | None = None,
     ) -> ast.stmt:
         """``ROLE_LOCAL_WITH_SCHEDULER`` consumer-side role-local while.
 
@@ -2874,6 +2906,22 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         per_tile_body.extend(_consumer_release_block())
         if dependency_stmts is not None:
             per_tile_body.extend(dependency_stmts)
+        # Cycle-94 merge: inject the store warp's aux GMEM->SMEM residual
+        # producer body AFTER the tile coords are materialized and BEFORE the
+        # store body (whose epi-warp consumers read the freshly staged aux),
+        # gated on the store-warp predicate so only the single producer warp
+        # issues the loads. The epi loop already owns the per-warp sched
+        # handshake, so the injected body carries no sched wait/release.
+        if store_aux_per_tile_stmts is not None:
+            assert store_aux_predicate is not None
+            per_tile_body.append(
+                create(
+                    ast.If,
+                    test=expr_from_string(store_aux_predicate),
+                    body=[_clone_stmt(stmt) for stmt in store_aux_per_tile_stmts],
+                    orelse=[],
+                )
+            )
         per_tile_body.extend(role_block.stmts)
         if tile_counter_var is not None and increment_tile_counter_per_tile:
             per_tile_body.append(
@@ -2893,6 +2941,13 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         # Final release + advance for the sentinel publish (lane-0
         # gate matches the per-iteration release inside the loop).
         prelude.extend(_consumer_release_block())
+        # Cycle-94 merge: no post-loop aux producer tail is injected. The store
+        # warp's aux producer_state advance lives inside the per-tile store-warp
+        # branch of THIS while; a post-loop ``producer_tail(state)`` would
+        # reference a loop-carried value defined in that nested region (IR
+        # domination error). The boundary drain is unnecessary because the
+        # epi-warp consumers release every aux stage by loop exit (see
+        # ``_build_c_input_warp_role_local_while(inline_aux_only=...)``).
 
         return create(
             ast.If,
@@ -3733,9 +3788,25 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         *,
         shared_body_extracted: list[ast.stmt] | None = None,
         tile_phase: str = "all",
-    ) -> ast.stmt:
+        inline_aux_only: bool = False,
+    ) -> ast.stmt | list[ast.stmt]:
         """Build the C-input warp's role-local while
         (``cute_plan.md`` §7.5.3.2 producer-body split).
+
+        Workstream A Stage 5 (cycle 94, the merge): when ``inline_aux_only`` is
+        set, this does NOT build a self-contained role-local while (which would
+        be a second sched-pipeline consumer on the warp). Instead it returns the
+        per-tile aux GMEM->SMEM producer body (``list[ast.stmt]``) for the
+        CALLER to inject into the (widened) epilogue role-local while on the
+        STORE warp, which already owns the single per-warp sched-pipeline
+        handshake. This is how the store/epi-load warp does BOTH the early
+        residual load and the late TMA-D store drain in one loop at 8 warps. No
+        post-loop producer tail is returned (the aux producer_state advance is
+        inside the shared loop's store-warp branch, so a post-loop tail would
+        hit an IR domination error; the boundary drain is unnecessary because
+        the consumers release all stages by loop exit). ``inline_aux_only`` uses
+        the post-L2 ``tile_offset_0/1`` coords (always present in the epi loop's
+        dependency stmts), so it asserts the post-L2 path.
 
         Active when the matmul plan has ``c_input_warp_count > 0``
         AND the forward FX walker discovered one or more
@@ -3804,8 +3875,11 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         ``TestCuteTcgen05AuxPipelineCycle2a``).
         """
         plan = self._tcgen05_plan()
-        assert plan is not None and plan.has_c_input_warp, (
-            "C-input role-local while requires a matmul plan with has_c_input_warp=True"
+        # The aux producer runs on the C-input warp normally; under the cycle-94
+        # merge (``inline_aux_only``) it runs on the store warp instead, so the
+        # producer-warp invariant is "C-input OR store warp present".
+        assert plan is not None and (plan.has_c_input_warp or plan.has_store_warp), (
+            "aux producer body requires a matmul plan with a C-input or store warp"
         )
         c_input_aux_tensor_descriptors = plan.c_input_aux_tensor_descriptors
         assert c_input_aux_tensor_descriptors, (
@@ -4477,6 +4551,45 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             lines.append(statement_from_string(loop_src))
             return lines
 
+        if inline_aux_only:
+            # Cycle-94 merge: return the per-tile aux producer body for injection
+            # into the store warp's branch of the (widened) epilogue role-local
+            # while. The epi loop owns the sched handshake and materializes the
+            # post-L2 tile coords, so no sched wait/release is emitted here. The
+            # full-tile guard mirrors the standalone builder so edge tiles (SIMT
+            # aux) commit no aux stages the consumer never releases.
+            #
+            # No post-loop ``producer_tail`` is returned: the aux producer_state
+            # is advanced inside the store-warp branch of the SHARED epilogue
+            # while, so a post-loop ``producer_tail(state)`` would reference a
+            # loop-carried value defined in that nested region (IR domination
+            # error). The tail is only a boundary drain for the TMA-load empty
+            # barriers, and the epi-warp consumers have already released every
+            # aux stage by loop exit, so it is safely omitted on the merge path.
+            assert has_post_l2_coords, (
+                "inline_aux_only merge requires post-L2 tile coords "
+                "(tile_offset_0/1) from the epilogue loop's dependency stmts"
+            )
+            inline_per_tile: list[ast.stmt] = []
+            aux_copy_lines_inline = _aux_copy_lines()
+            if aux_requires_full_tile:
+                inline_per_tile.extend(
+                    [
+                        statement_from_string(
+                            f"{aux_full_tile_var} = {aux_full_tile_expr}"
+                        ),
+                        create(
+                            ast.If,
+                            test=expr_from_string(aux_full_tile_var),
+                            body=aux_copy_lines_inline,
+                            orelse=[],
+                        ),
+                    ]
+                )
+            else:
+                inline_per_tile.extend(aux_copy_lines_inline)
+            return inline_per_tile
+
         prelude: list[ast.stmt] = []
         prelude.extend(_sched_consumer_wait_block())
         per_tile_body: list[ast.stmt] = [
@@ -4839,6 +4952,39 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             self._tcgen05_has_scheduler_warp()
             and cute_state.has_tcgen05_epi_role_full_edge_split
         )
+        # Cycle-94 merge gate: the store warp is the aux residual producer when
+        # there is a store warp, NO C-input warp, and a single-store-value
+        # exact-shape aux ring exists. In that case the aux GMEM->SMEM producer
+        # body is injected into the (widened) epilogue role-local while on the
+        # store warp rather than emitted as a standalone C-input role-local
+        # while (which would be a second per-warp sched consumer). The standalone
+        # C-input while below stays gated on ``has_c_input_warp`` and does not
+        # fire in the merge.
+        #
+        # TMA-ONLY: the merge injects a TMA bulk producer body; there is no SIMT
+        # store-warp producer. ``cute_mma._emit_mma_pipeline`` only allocates the
+        # aux pipeline for the store warp when ``aux_load_mode=tma``, so for
+        # ``store_warps=1 + SIMT aux`` the pipeline plan is absent and the gate
+        # closes (the kernel falls back to direct-GMEM aux). The
+        # ``use_tma_load`` check below makes that requirement explicit and
+        # defends against a future SIMT-producing aux plan reaching this path.
+        store_merge_plan = self._tcgen05_plan()
+        aux_plan_for_merge = device_function.cute_state.aux_pipeline_plan
+        store_aux_merge_active = (
+            store_merge_plan is not None
+            and store_merge_plan.has_store_warp
+            and not store_merge_plan.has_c_input_warp
+            and bool(store_merge_plan.c_input_aux_tensor_descriptors)
+            and len(
+                {
+                    d.store_value_node
+                    for d in store_merge_plan.c_input_aux_tensor_descriptors
+                }
+            )
+            <= 1
+            and aux_plan_for_merge is not None
+            and aux_plan_for_merge.use_tma_load
+        )
         for i, predicate in enumerate(ordered_predicates):
             stmts = merged[predicate]
             split_epi_role = (
@@ -4901,6 +5047,32 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                         _clone_stmt(stmt) for stmt in epi_role_prelude_stmts
                     ]
                 suffix = f"_{phase}" if phase else ""
+                # Cycle-94 merge: build the store warp's aux producer body for
+                # injection into the epilogue role-local while. Only on the epi
+                # predicate, and (under a full/edge split) only the full-tile
+                # phase stages the aux ring — the edge phase uses SIMT direct
+                # GMEM aux, like the standalone C-input builder.
+                store_aux_per_tile_stmts: list[ast.stmt] | None = None
+                store_aux_predicate: str | None = None
+                if (
+                    store_aux_merge_active
+                    and predicate == self._tcgen05_epi_role_predicate()
+                    and phase != "edge"
+                ):
+                    aux_inline = self._build_c_input_warp_role_local_while(
+                        device_function,
+                        layout,
+                        shared_body_extracted=partition.shared_body_extracted,
+                        tile_phase="all",
+                        inline_aux_only=True,
+                    )
+                    assert isinstance(aux_inline, list)
+                    store_aux_per_tile_stmts = aux_inline
+                    assert store_merge_plan is not None
+                    store_aux_predicate = (
+                        "cute.arch.make_warp_uniform(cute.arch.warp_idx()) "
+                        f"== cutlass.Int32({store_merge_plan.store_warp_id})"
+                    )
                 role_local_whiles.append(
                     self._build_role_local_while(
                         device_function,
@@ -4911,6 +5083,8 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                         role_prelude_stmts=role_prelude_stmts,
                         emit_pdl_wait=phase != "edge",
                         initialize_tile_counter=phase != "edge",
+                        store_aux_per_tile_stmts=store_aux_per_tile_stmts,
+                        store_aux_predicate=store_aux_predicate,
                     )
                 )
         # ``ROLE_LOCAL_WITH_SCHEDULER`` adds a fourth role-local while
@@ -4962,26 +5136,28 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                 ("full", "edge") if use_full_edge_scheduler_split else ("all",)
             )
             for c_input_phase in c_input_phases:
-                role_local_whiles.append(
-                    self._build_c_input_warp_role_local_while(
-                        device_function,
-                        layout,
-                        # ``shared_body_extracted`` carries the post-PID-
-                        # decomposition statements (incl. the L2-grouping
-                        # ``pid_0`` / ``pid_1`` / ``tile_offset_0`` /
-                        # ``tile_offset_1`` chain). The C-input producer
-                        # body needs the same chain so its per-CTA aux
-                        # GMEM tile coords match the consumer's
-                        # post-L2-remapped tile coords — without this
-                        # the producer fetches a misaligned aux tile
-                        # under ``l2_groupings=[g>1]`` and the residual
-                        # add reads wrong rows / columns of the
-                        # auxiliary tensor (cycle 2i: 60-69% mismatched
-                        # elements vs eager).
-                        shared_body_extracted=partition.shared_body_extracted,
-                        tile_phase=c_input_phase,
-                    )
+                c_input_while = self._build_c_input_warp_role_local_while(
+                    device_function,
+                    layout,
+                    # ``shared_body_extracted`` carries the post-PID-
+                    # decomposition statements (incl. the L2-grouping
+                    # ``pid_0`` / ``pid_1`` / ``tile_offset_0`` /
+                    # ``tile_offset_1`` chain). The C-input producer
+                    # body needs the same chain so its per-CTA aux
+                    # GMEM tile coords match the consumer's
+                    # post-L2-remapped tile coords — without this
+                    # the producer fetches a misaligned aux tile
+                    # under ``l2_groupings=[g>1]`` and the residual
+                    # add reads wrong rows / columns of the
+                    # auxiliary tensor (cycle 2i: 60-69% mismatched
+                    # elements vs eager).
+                    shared_body_extracted=partition.shared_body_extracted,
+                    tile_phase=c_input_phase,
                 )
+                # ``inline_aux_only`` is False here, so the builder returns the
+                # full role-local while statement (not the merge tuple).
+                assert isinstance(c_input_while, ast.stmt)
+                role_local_whiles.append(c_input_while)
         return role_local_whiles, shared_tile_body
 
     def setup_persistent_kernel(

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -2587,6 +2587,32 @@ def _codegen_cute_store_tcgen05_tile(
     c_pipeline_producer_group = df.new_var("tcgen05_c_pipeline_producer_group")
     c_pipeline = df.new_var("tcgen05_c_pipeline")
     subtile_count = df.new_var("tcgen05_subtile_count")
+    # Workstream A Stage 4 (cycle 93, Path B): the C-store producer->consumer
+    # edge over the C-ring SMEM (``tRS_sD``, depth ``c_stage_count``). Producer
+    # = the 4 epi warps (arrive after R2S + ``fence_view_async_shared``);
+    # consumer = the single store warp (waits, issues the TMA-D, releases the
+    # SMEM stage). Replaces the second ``epilog_sync_barrier`` (R2S-visible)
+    # CTA-wide barrier with a cheaper cross-warp pipeline edge that lets the
+    # epi warps proceed to the next subtile while the store warp drains.
+    c_store_edge_barriers = df.new_var("tcgen05_c_store_edge_barriers")
+    c_store_edge_producer_group = df.new_var("tcgen05_c_store_edge_producer_group")
+    c_store_edge_consumer_group = df.new_var("tcgen05_c_store_edge_consumer_group")
+    c_store_edge = df.new_var("tcgen05_c_store_edge")
+    c_store_edge_producer_state = df.new_var("tcgen05_c_store_edge_producer_state")
+    c_store_edge_consumer_state = df.new_var("tcgen05_c_store_edge_consumer_state")
+    # Separate consumer state for the LAGGED release. The store warp's TMA-D is
+    # an async bulk copy that reads the C-ring SMEM stage; the stage may not be
+    # reused (epi R2S overwrite) until that read completes. ``c_pipeline``
+    # (PipelineTmaStore) tracks store completion via ``cp_async_bulk_wait_group``
+    # (read=True), which after committing store i and waiting drains every store
+    # except the ``c_stages - 1`` most recent. So the store warp releases the
+    # C-ring stage from ``c_stages - 1`` subtiles ago (provably drained), lagging
+    # the consumer-wait by ``c_stages - 1``. This leaves exactly one free stage
+    # (edge depth ``c_stages``), giving the ~1-subtile store/T2R overlap the
+    # acc_stages=2 bound permits. The first ``c_stages - 1`` releases are
+    # suppressed (no drained stage yet); the trailing stages release naturally
+    # in subsequent tiles as the global subtile index advances.
+    c_store_edge_release_state = df.new_var("tcgen05_c_store_edge_release_state")
     epi_warp_ids = ", ".join(
         f"cutlass.Int32({i})" for i in range(tcgen05_value.epi_warp_count)
     )
@@ -2700,6 +2726,18 @@ def _codegen_cute_store_tcgen05_tile(
     # GMEM path byte-identical.
     aux_matmul_plan = df.cute_state.matmul_plan
     aux_pipeline_plan_obj = df.cute_state.aux_pipeline_plan
+    # Workstream A Stage 4 (cycle 93, Path B): when the plan carries a store
+    # warp, the per-subtile R2S->TMA-D tail is split by warp role and the
+    # second epilogue barrier is replaced by the C-store pipeline edge. The
+    # store warp drains the TMA-D so the 4 epi warps proceed to the next
+    # subtile's T2R. ``store_warps=0`` keeps the original fused tail unchanged
+    # (the production path; byte-identical codegen).
+    has_store_warp = aux_matmul_plan is not None and aux_matmul_plan.has_store_warp
+    store_warp_predicate = (
+        f"{tcgen05_value.warp_idx} == cutlass.Int32({aux_matmul_plan.store_warp_id})"
+        if aux_matmul_plan is not None and has_store_warp
+        else ""
+    )
     # Match each store-side record to its descriptor by
     # ``load_node`` FX-node identity rather than positional
     # index. The descriptor walker dedups by ``store_value_node``
@@ -2738,10 +2776,27 @@ def _codegen_cute_store_tcgen05_tile(
     aux_has_staged_steps = any(
         ring_idx is not None for ring_idx in aux_ring_index_by_step
     )
+    # Workstream A Stage 5 (cycle 94, the merge): the aux SMEM ring producer is
+    # the C-input warp normally (SIMT or TMA), or the store warp under the merge
+    # — but the store warp is TMA-ONLY (there is no SIMT store-warp producer;
+    # ``store_warps=1 + SIMT aux`` falls back to direct-GMEM aux). The epi-warp
+    # consumer reads the staged ring whenever a producer is present. The
+    # ``aux_pipeline_plan_obj is not None`` term already closes this gate for
+    # ``store_warps=1 + SIMT`` (``cute_mma`` never allocates the plan there);
+    # the explicit ``use_tma_load`` term on the store-warp branch makes the
+    # TMA-only requirement local and defensive.
+    aux_producer_warp_present = aux_matmul_plan is not None and (
+        aux_matmul_plan.has_c_input_warp
+        or (
+            aux_matmul_plan.has_store_warp
+            and aux_pipeline_plan_obj is not None
+            and aux_pipeline_plan_obj.use_tma_load
+        )
+    )
     use_aux_smem_source = (
         aux_step_records
         and aux_matmul_plan is not None
-        and aux_matmul_plan.has_c_input_warp
+        and aux_producer_warp_present
         and bool(aux_matmul_plan.c_input_aux_tensor_descriptors)
         and aux_pipeline_plan_obj is not None
         and aux_has_staged_steps
@@ -3841,12 +3896,64 @@ def _codegen_cute_store_tcgen05_tile(
             )
         ),
     ]
+    # Workstream A Stage 4 (cycle 93, Path B): C-store producer->consumer edge.
+    # Mirrors ``_emit_tcgen05_aux_pipeline_setup``'s SIMT PipelineAsync shape.
+    # producer_arrive_count = ``epi_warp_count`` (per-warp: each of the 4 epi
+    # warps arrives once via ``elect_one`` after R2S + fence); consumer_arrive
+    # _count = 1 (the single store warp); num_stages = ``c_stage_count`` so the
+    # store can lag up to ``c_stages`` subtiles behind the epi warps' T2R/R2S.
+    # Producer (epi ``producer_commit``) AND consumer (store ``consumer_wait`` /
+    # ``consumer_release``) BOTH land in this commit so the ring is never a
+    # one-sided handshake that wedges only after wrapping the depth (the
+    # cycle-2a partial-handshake lesson).
+    c_store_edge_setup = (
+        [
+            (
+                f"{c_store_edge_barriers} = cute.arch.alloc_smem("
+                f"cutlass.Int64, cutlass.Int32({tcgen05_value.c_stage_count * 2}))"
+            ),
+            (
+                f"{c_store_edge_producer_group} = cutlass.pipeline.CooperativeGroup("
+                f"cutlass.pipeline.Agent.Thread, "
+                f"cutlass.Int32({tcgen05_value.epi_warp_count}))"
+            ),
+            (
+                f"{c_store_edge_consumer_group} = cutlass.pipeline.CooperativeGroup("
+                "cutlass.pipeline.Agent.Thread, cutlass.Int32(1))"
+            ),
+            (
+                f"{c_store_edge} = cutlass.pipeline.PipelineAsync.create("
+                f"num_stages={tcgen05_value.c_stage_count}, "
+                f"producer_group={c_store_edge_producer_group}, "
+                f"consumer_group={c_store_edge_consumer_group}, "
+                f"barrier_storage={c_store_edge_barriers})"
+            ),
+            (
+                f"{c_store_edge_producer_state} = cutlass.pipeline.make_pipeline_state("
+                f"cutlass.pipeline.PipelineUserType.Producer, "
+                f"{tcgen05_value.c_stage_count})"
+            ),
+            (
+                f"{c_store_edge_consumer_state} = cutlass.pipeline.make_pipeline_state("
+                f"cutlass.pipeline.PipelineUserType.Consumer, "
+                f"{tcgen05_value.c_stage_count})"
+            ),
+            (
+                f"{c_store_edge_release_state} = cutlass.pipeline.make_pipeline_state("
+                f"cutlass.pipeline.PipelineUserType.Consumer, "
+                f"{tcgen05_value.c_stage_count})"
+            ),
+        ]
+        if has_store_warp
+        else []
+    )
     tma_store_pipeline_setup = [
         (
             f"{epilog_sync_barrier} = cutlass.pipeline.NamedBarrier("
             f"barrier_id=cutlass.Int32({tcgen05_value.epilog_sync_barrier_id}), "
             f"num_threads=cutlass.Int32({tcgen05_value.epi_warp_count * 32}))"
         ),
+        *c_store_edge_setup,
         (
             f"{c_pipeline_producer_group} = cutlass.pipeline.CooperativeGroup("
             f"cutlass.pipeline.Agent.Thread, cutlass.Int32({tcgen05_value.epi_warp_count * 32}))"
@@ -3909,6 +4016,41 @@ def _codegen_cute_store_tcgen05_tile(
             "tcgen05_strategy='pure_matmul_role_lifecycle' does not support "
             f"{TCGEN05_EPILOGUE_LAYOUT_CONFIG_KEY}={epilogue_layout!r}",
         )
+    if tcgen05_pure_matmul_object is not None and has_store_warp:
+        # Workstream A Stage 4 (cycle 93) wires the store-warp tail split into
+        # the non-pure ROLE_LOCAL_WITH_SCHEDULER path only. The pure-matmul
+        # role-lifecycle object renders its own tail (``render_tma_store_tail
+        # _region``) and is gated out here so a store warp never silently lands
+        # on the unsplit pure tail (a correctness break). Stage 5 may wire it.
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05_strategy='pure_matmul_role_lifecycle' does not support "
+            "tcgen05_warp_spec_store_warps>0 (Workstream A Stage 4 wires the "
+            "store-warp epilogue split into the non-pure WITH_SCHEDULER path)",
+        )
+    # The diagnostic split / module-helper epilogue layouts route the
+    # per-subtile tail through helpers that emit ONLY the ``if epi_active``
+    # half under ``has_store_warp`` (and ``module_helper_store_tail`` keeps the
+    # OLD two-barrier warp-0 ``c_pipeline`` tail while the main path suppressed
+    # the matching acquires) — so the C-store edge would have no consumer and
+    # wedge once the ring wraps, or the ``c_pipeline`` commit/acquire counts
+    # mismatch. They are diagnostic-only source-boundary layouts; production
+    # uses the DEFAULT layout, so reject the combination loudly (same guard
+    # class as the pure-matmul tail above). ``split_first_t2r`` routes through
+    # ``tma_store_subtile_body`` and IS handled by the Stage-4 split, so it is
+    # intentionally excluded.
+    if has_store_warp and (
+        diagnose_split_acc_t2r_store_tail
+        or diagnose_module_helper_acc_t2r
+        or diagnose_module_helper_store_tail
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            f"{TCGEN05_EPILOGUE_LAYOUT_CONFIG_KEY}={epilogue_layout!r} does not "
+            "support tcgen05_warp_spec_store_warps>0 (the diagnostic split / "
+            "module-helper epilogue layouts do not emit the store-warp tail "
+            "half of the Workstream A Stage 4 split; use the default layout)",
+        )
     if tcgen05_pure_matmul_object is not None:
         pure_c_store_pipeline = Tcgen05TmaStorePipelineParams(
             c_pipeline=c_pipeline,
@@ -3948,19 +4090,34 @@ def _codegen_cute_store_tcgen05_tile(
             )
         )
     else:
+        # Workstream A Stage 4 (cycle 93, Path B): the ``c_pipeline``
+        # (PipelineTmaStore) producer lifecycle is per-warp — its
+        # ``producer_acquire`` is a ``cp_async_bulk_wait_group`` and its
+        # ``producer_commit`` a ``cp_async_bulk_commit_group``, both scoped to
+        # the warp that ISSUES the TMA-D bulk copy. So when a store warp owns
+        # the TMA-D, the entire ``c_pipeline`` lifecycle (acquire + commit +
+        # tail) moves onto the store warp: its ``wait_group`` reuse guard lives
+        # in the store-warp tail (after the TMA-D + commit, gating the lagged
+        # release), the epi warps' historical store-prefix acquire lines are
+        # dropped (the C-ring is gated by the cross-warp C-store edge instead),
+        # and ``producer_tail`` (final ``wait_group(0)``) stays on the store warp.
+        c_pipeline_owner_predicate = (
+            store_warp_predicate
+            if has_store_warp
+            else f"{tcgen05_value.warp_idx} == cutlass.Int32(0)"
+        )
+        first_acquire_role_gate = (
+            f"{tcgen05_lifecycle.epi_active} and "
+            f"{tcgen05_value.warp_idx} == cutlass.Int32(0)"
+        )
         tma_store_pipeline_tail = (
-            f"if {tcgen05_value.warp_idx} == cutlass.Int32(0):\n"
-            f"    {c_pipeline}.producer_tail()"
+            f"if {c_pipeline_owner_predicate}:\n    {c_pipeline}.producer_tail()"
         )
         tma_store_first_subtile_acquire = (
             []
-            if diagnose_first_c_acquire_in_loop
+            if (diagnose_first_c_acquire_in_loop or has_store_warp)
             else [
-                (
-                    f"if {tcgen05_lifecycle.epi_active} and "
-                    f"{tcgen05_value.warp_idx} == cutlass.Int32(0):\n"
-                    f"    {c_pipeline}.producer_acquire()"
-                )
+                (f"if {first_acquire_role_gate}:\n    {c_pipeline}.producer_acquire()")
             ]
         )
         tma_store_loop_first_subtile_acquire = (
@@ -3969,12 +4126,12 @@ def _codegen_cute_store_tcgen05_tile(
                 f"{tcgen05_value.warp_idx} == cutlass.Int32(0):\n"
                 f"            {c_pipeline}.producer_acquire()\n"
             )
-            if diagnose_first_c_acquire_in_loop
+            if (diagnose_first_c_acquire_in_loop and not has_store_warp)
             else ""
         )
         tma_store_loop_later_subtile_acquire = (
             ""
-            if diagnose_later_c_acquire_before_barrier
+            if (diagnose_later_c_acquire_before_barrier or has_store_warp)
             else (
                 f"        if _tcgen05_subtile != 0 and "
                 f"{tcgen05_value.warp_idx} == cutlass.Int32(0):\n"
@@ -3987,7 +4144,7 @@ def _codegen_cute_store_tcgen05_tile(
                 f"{tcgen05_value.warp_idx} == cutlass.Int32(0):\n"
                 f"            {c_pipeline}.producer_acquire()\n"
             )
-            if diagnose_later_c_acquire_before_barrier
+            if (diagnose_later_c_acquire_before_barrier and not has_store_warp)
             else ""
         )
     if diagnose_split_epilogue_layout:
@@ -4097,6 +4254,9 @@ def _codegen_cute_store_tcgen05_tile(
     tcgen05_acc_consumer_state = tcgen05_lifecycle.acc_consumer_state
     tcgen05_warp_idx = tcgen05_value.warp_idx
     tcgen05_tma_store_atom = tcgen05_value.tma_store_atom
+    # Locals for the store-warp tail closure (Pyrefly drops the non-None
+    # tcgen05_value narrowing inside nested source formatters; see above).
+    tcgen05_role_local_tile_counter = tcgen05_value.role_local_tile_counter
 
     def tma_store_acc_t2r_region_body(
         *, acc_wait: str, allow_aux_chain: bool = False
@@ -4174,6 +4334,29 @@ def _codegen_cute_store_tcgen05_tile(
                     late_later_subtile_acquire=late_later_subtile_acquire
                 )
             )
+        if has_store_warp:
+            # Path B epi-warp tail (inside ``if epi_active:``): acquire the
+            # C-store edge stage (wait until the store warp released it, i.e.
+            # the prior TMA-D reading this physical C-ring slot completed),
+            # barrier-1 (intra-epi convergence), R2S, fence, then a C-store-edge
+            # PRODUCER commit in place of the second CTA barrier. The TMA-D +
+            # ``c_pipeline`` lifecycle move to the store warp's tail
+            # (``tma_store_store_warp_tail_region``). The epi warps drop
+            # straight into the next subtile's T2R after committing — that is
+            # the store/T2R overlap. The producer cooperative group is per-warp
+            # (count ``epi_warp_count``), so ``producer_acquire`` is a full-warp
+            # wait on every epi warp and ``producer_commit`` arrives once per
+            # warp via ``elect_one``.
+            return (
+                f"        {c_store_edge}.producer_acquire({c_store_edge_producer_state})\n"
+                f"        {epilog_sync_barrier}.arrive_and_wait()\n"
+                f"        {c_buffer} = ({tma_c_buffer_expr}) % cutlass.Int32({tcgen05_c_stage_count})\n"
+                f"        cute.copy({tiled_copy_r2s}, {trs_rd}, {trs_sd}[(None, None, None, {c_buffer})])\n"
+                f"        cute.arch.fence_view_async_shared()\n"
+                f"        with cute.arch.elect_one():\n"
+                f"            {c_store_edge}.producer_commit({c_store_edge_producer_state})\n"
+                f"        {c_store_edge_producer_state}.advance()\n"
+            )
         return (
             f"{late_later_subtile_acquire}"
             f"        {epilog_sync_barrier}.arrive_and_wait()\n"
@@ -4184,6 +4367,45 @@ def _codegen_cute_store_tcgen05_tile(
             f"        if {tcgen05_warp_idx} == cutlass.Int32(0):\n"
             f"            cute.copy({tcgen05_tma_store_atom}, {bsg_sd}[(None, {c_buffer})], {bsg_gd}[(None, cutlass.Int32(_tcgen05_subtile))])\n"
             f"            {c_pipeline}.producer_commit()\n"
+        )
+
+    def tma_store_store_warp_tail_region() -> str:
+        # Path B store-warp tail (inside ``if store_warp_predicate:``): consume
+        # the C-store edge, issue the TMA-D, and recycle the C-ring SMEM stage
+        # with a ``c_stages - 1`` lagged release so a stage is only freed for
+        # the epi producer AFTER its TMA-D read has provably completed.
+        #
+        # Ordering (per subtile, ``S`` = ``c_buffer``):
+        #  1. ``consumer_wait``: the epi warps' R2S of stage ``S`` has landed.
+        #  2. TMA-D ``S`` -> GMEM + ``c_pipeline.producer_commit`` (commit_group).
+        #  3. ``c_pipeline.producer_acquire`` = ``cp_async_bulk_wait_group(
+        #     c_stages - 1, read=True)``: after committing store i this drains
+        #     every store except the ``c_stages - 1`` most recent, i.e. proves
+        #     store ``i - (c_stages - 1)`` finished reading its SMEM stage.
+        #  4. release that proven-drained stage (the ``release_state``, which
+        #     lags the wait ``consumer_state`` by ``c_stages - 1``). Suppressed
+        #     for the first ``c_stages - 1`` global subtiles (nothing drained
+        #     yet); the trailing stages release naturally as later tiles' global
+        #     subtile index advances, and the final unreleased stores drain via
+        #     ``c_pipeline.producer_tail`` after the loop.
+        lag = tcgen05_c_stage_count - 1
+        global_subtile = (
+            f"({tcgen05_role_local_tile_counter} * "
+            f"cutlass.Int32({subtile_count}) + cutlass.Int32(_tcgen05_subtile))"
+            if tcgen05_role_local_tile_counter
+            else "cutlass.Int32(_tcgen05_subtile)"
+        )
+        return (
+            f"        {c_store_edge}.consumer_wait({c_store_edge_consumer_state})\n"
+            f"        {c_store_edge_consumer_state}.advance()\n"
+            f"        {c_buffer} = ({tma_c_buffer_expr}) % cutlass.Int32({tcgen05_c_stage_count})\n"
+            f"        cute.copy({tcgen05_tma_store_atom}, {bsg_sd}[(None, {c_buffer})], {bsg_gd}[(None, cutlass.Int32(_tcgen05_subtile))])\n"
+            f"        {c_pipeline}.producer_commit()\n"
+            f"        {c_pipeline}.producer_acquire()\n"
+            f"        if {global_subtile} >= cutlass.Int32({lag}):\n"
+            f"            with cute.arch.elect_one():\n"
+            f"                {c_store_edge}.consumer_release({c_store_edge_release_state})\n"
+            f"            {c_store_edge_release_state}.advance()\n"
         )
 
     def tma_store_subtile_body(
@@ -4201,6 +4423,21 @@ def _codegen_cute_store_tcgen05_tile(
             acc_wait=acc_wait,
             allow_aux_chain=True,
         )
+        if has_store_warp:
+            # Path B: the epi warps own T2R/R2S + the C-store producer commit;
+            # the store warp (a SEPARATE ``if``, NOT under ``epi_active``) owns
+            # the TMA-D + ``c_pipeline`` commit/acquire (its ``cp_async_bulk
+            # _wait_group`` reuse guard) + the lagged edge release. The C-ring
+            # acquire/commit move WHOLLY onto the store warp (PipelineTmaStore
+            # is per-warp commit-group state), so the epi warps never touch
+            # ``c_pipeline``; their store-prefix acquire lines are dropped.
+            return (
+                f"    if {tcgen05_epi_active}:\n"
+                f"{t2r_body}"
+                f"{tma_store_tail_region(late_later_subtile_acquire='')}"
+                f"    if {store_warp_predicate}:\n"
+                f"{tma_store_store_warp_tail_region()}"
+            )
         return (
             f"    if {tcgen05_epi_active}:\n"
             f"{first_subtile_acquire}"

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -118,6 +118,7 @@ from helion._compiler.cute.tcgen05_constants import (
 )
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_MAX_K_TILES
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_SEED_L2_GROUPING
+from helion._compiler.cute.tcgen05_constants import tcgen05_default_epilogue_tile_size
 from helion._hardware import HardwareInfo
 from helion._testing import DEVICE
 from helion._testing import HALF_DTYPE
@@ -2697,9 +2698,19 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             torch.empty([6144, 6144], device=DEVICE, dtype=torch.bfloat16),
             torch.empty([6144, 6144], device=DEVICE, dtype=torch.bfloat16),
         )
+        # Mock the SMEM budget to the B200 value at bind time (when
+        # ``allow_ab_stages_three_search`` records the budget into the
+        # constraints) so the c=4 lift's ``c_stages_fits`` gate is deterministic
+        # on any cute host (``@onlyBackends`` does not imply B200).
+        b200_budget = 232448 - 28 * 1024
         with (
             patch_cute_mma_support(),
             patch("helion.language.matmul_ops._cuda_num_sms_or_zero", return_value=132),
+            patch.object(
+                CuteTcgen05Config,
+                "per_cta_ab_smem_budget_bytes",
+                return_value=b200_budget,
+            ),
         ):
             bound = cute_matmul_residual_add.bind(args)
         spec = bound.config_spec
@@ -2727,6 +2738,8 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             tcgen05_strategy=Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
             tcgen05_persistence_model="static_persistent",
         )
+        # The budget was recorded into the constraints at bind time (mocked to
+        # B200 above), so ``c_stages_fits`` is deterministic here.
         spec.normalize(cm2, _fix_invalid=True)
         self.assertEqual(
             cm2.config[TCGEN05_AUX_LOAD_MODE_CONFIG_KEY], TCGEN05_AUX_LOAD_MODE_TMA
@@ -2738,7 +2751,12 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         self.assertEqual(cm2.config["tcgen05_ab_stages"], 2)
         self.assertEqual(cm2.config[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY], 1)
         self.assertEqual(cm2.config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY], 1)
-        # A cluster_m=1 candidate is left in its own regime (not forced to TMA).
+        # Cycle 90 (Workstream A Stage 2): the same projection deepens the C
+        # ring to 4 (foundation for the Stage-4 store-warp split). At ab=2 the
+        # c=4 ring fits under the 232 KB B200 cap, so the budget gate admits it.
+        self.assertEqual(cm2.config["tcgen05_c_stages"], 4)
+        # A cluster_m=1 candidate is left in its own regime (not forced to TMA),
+        # and the deeper C ring is NOT projected onto it.
         cm1 = helion.Config(
             block_sizes=[128, 256, 64],
             indexing=["pointer", "tensor_descriptor", "tensor_descriptor"],
@@ -2756,6 +2774,163 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             cm1.config.get(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY),
             TCGEN05_AUX_LOAD_MODE_TMA,
         )
+        self.assertEqual(cm1.config["tcgen05_c_stages"], 2)
+
+    @onlyBackends(["cute"])
+    def test_cute_tcgen05_c_stages_budget_gate(self) -> None:
+        # Cycle 90 (Workstream A Stage 2): the budget-aware ``c_stages_fits``
+        # check sums AB + C SMEM against the same 232 KB B200 envelope as the
+        # ab=3 gate, using the REAL DEFAULT epilogue tile — which depends on
+        # source-C presence: 256x256 16-bit is (128, 64) WITH source C (residual
+        # family, 16 KB/stage) but (128, 32) WITHOUT one (plain matmul, 8
+        # KB/stage). At the canonical 256x256x128 cluster_m=2 tile: ab=2 + c=4
+        # fits (the foundation depth); ab=3 + c=4 overflows (matching the
+        # cycle-90 probe where a directly sampled 256x256 ab=3 + c=4 hit a raw
+        # ``ptxas: too much shared`` error). Uses a plain (no-epilogue) matmul so
+        # the residual aux-TMA projection (which forces ab=2) does not claim the
+        # sampled candidate — the admission gate is the only thing acting on c=4.
+        # The SMEM budget is MOCKED to the B200 value so the gate is exercised
+        # deterministically on any cute host (``@onlyBackends`` does not imply
+        # B200).
+        b200_budget = 232448 - 28 * 1024  # optin cap - ab=3 reservation
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_plain(
+            x: torch.Tensor,
+            y: torch.Tensor,
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        args = (
+            torch.empty([6144, 6144], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([6144, 6144], device=DEVICE, dtype=torch.bfloat16),
+        )
+        with (
+            patch_cute_mma_support(),
+            patch("helion.language.matmul_ops._cuda_num_sms_or_zero", return_value=132),
+            patch.object(
+                CuteTcgen05Config,
+                "per_cta_ab_smem_budget_bytes",
+                return_value=b200_budget,
+            ),
+        ):
+            bound = cute_matmul_plain.bind(args)
+        spec = bound.config_spec
+        tcfg = spec._cute_tcgen05_config
+        # The DEFAULT epilogue tile for a 256x256 16-bit tile depends on
+        # source-C presence (N shrinks when no C tile competes for SMEM).
+        self.assertEqual(
+            tcgen05_default_epilogue_tile_size(
+                256, 256, elem_width_d=16, elem_width_c=16
+            ),
+            (128, 64),
+        )
+        self.assertEqual(
+            tcgen05_default_epilogue_tile_size(
+                256, 256, elem_width_d=16, elem_width_c=None
+            ),
+            (128, 32),
+        )
+        # With source-C (residual family, 16 KB/stage): ab=2 + c=4 = 192 KB fits;
+        # ab=3 + c=4 = 256 KB overflows.
+        self.assertTrue(
+            tcfg.c_stages_fits(
+                bm=256,
+                bn=256,
+                bk=128,
+                cluster_m=2,
+                ab_stages=2,
+                c_stages=4,
+                has_source_c=True,
+            )
+        )
+        self.assertFalse(
+            tcfg.c_stages_fits(
+                bm=256,
+                bn=256,
+                bk=128,
+                cluster_m=2,
+                ab_stages=3,
+                c_stages=4,
+                has_source_c=True,
+            )
+        )
+        # Without source-C (plain matmul, 8 KB/stage): ab=3 + c=4 = 224 KB still
+        # overflows the conservative budget (the cycle-90 probe confirmed the
+        # plain 256x256 ab=3 + c=4 hits raw ptxas ``too much shared``).
+        self.assertFalse(
+            tcfg.c_stages_fits(
+                bm=256,
+                bn=256,
+                bk=128,
+                cluster_m=2,
+                ab_stages=3,
+                c_stages=4,
+                has_source_c=False,
+            )
+        )
+        # True admission gate: a DIRECTLY sampled 256x256 ab=3 + c=4 candidate
+        # (no projection claims it — plain matmul, no aux) is demoted to c=2 so
+        # tuning never reaches the raw ptxas overflow. ab=3 alone fits, so the
+        # ab-stages gate keeps it — only c is demoted.
+        ab3_c4 = helion.Config(
+            block_sizes=[256, 256, 128],
+            indexing=["tensor_descriptor", "tensor_descriptor", "tensor_descriptor"],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=1,
+            tcgen05_ab_stages=3,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=4,
+            tcgen05_strategy=Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
+            tcgen05_persistence_model="static_persistent",
+        )
+        # The budget is already recorded in the constraints from bind (mocked to
+        # B200 above), so ``fix_search_config`` is deterministic here.
+        tcfg.fix_search_config(ab3_c4.config)
+        self.assertEqual(ab3_c4.config["tcgen05_ab_stages"], 3)
+        self.assertEqual(ab3_c4.config["tcgen05_c_stages"], 2)
+        # ab=2 + c=4 (fits) is preserved by the gate.
+        ab2_c4 = helion.Config(
+            block_sizes=[256, 256, 128],
+            indexing=["tensor_descriptor", "tensor_descriptor", "tensor_descriptor"],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=1,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=4,
+            tcgen05_strategy=Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
+            tcgen05_persistence_model="static_persistent",
+        )
+        tcfg.fix_search_config(ab2_c4.config)
+        self.assertEqual(ab2_c4.config["tcgen05_c_stages"], 4)
+        # Fail CLOSED: with no recorded SMEM budget (non-B200 / CPU host, where
+        # ``ab_stages_three_search_constraints`` is None) a sampled c=4 cannot be
+        # proven to fit, so it is demoted to 2 rather than left to overflow.
+        tcfg.ab_stages_three_search_constraints = None
+        ab2_c4_no_budget = helion.Config(
+            block_sizes=[256, 256, 128],
+            indexing=["tensor_descriptor", "tensor_descriptor", "tensor_descriptor"],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=1,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=4,
+            tcgen05_strategy=Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
+            tcgen05_persistence_model="static_persistent",
+        )
+        tcfg.fix_search_config(ab2_c4_no_budget.config)
+        self.assertEqual(ab2_c4_no_budget.config["tcgen05_c_stages"], 2)
 
     @onlyBackends(["cute"])
     def test_cute_tcgen05_c_input_seed_respects_disable_heuristics(self) -> None:

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -6472,6 +6472,678 @@ class TestCuteLowerings(unittest.TestCase):
         expected = (x @ y).to(x.dtype)
         torch.testing.assert_close(out, expected, atol=2e-1, rtol=1e-2)
 
+    def test_tcgen05_with_scheduler_store_warp_split_codegen(
+        self,
+    ) -> None:
+        """Workstream A Stage 4 (cycle 93, Path B) store-warp DECOUPLE pin.
+
+        Cycle 91 plumbed an INERT store warp (byte-identical to store=0).
+        Cycle 93 gives it a PRODUCTIVE body via the Path B shared-loop split:
+        the epilogue role predicate is WIDENED to admit the store warp
+        (warp id 7) into the SAME role-local while as the 4 epi warps, and the
+        per-subtile R2S->TMA-D tail is split by warp role through a new C-store
+        ``PipelineAsync`` edge (producer = 4 epi warps, consumer = 1 store
+        warp, depth = c_stages). The store warp is now a REAL sched consumer,
+        so the cycle-91 ``- store_warp_count`` sched-consumer subtraction is
+        removed (count goes 6 -> 7).
+
+        Pins (store_warps=1): the widened role gate, the C-store edge, the
+        epi-warp producer commit + the store-warp consumer wait/release, and
+        the sched consumer arrive count = 7. The launch envelope stays 8.
+
+        The store_warps=0 production path is asserted BYTE-IDENTICAL (the whole
+        split is behind ``has_store_warp``) by
+        ``test_tcgen05_with_scheduler_store_warp_zero_byte_identical``.
+        """
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_with_scheduler_store(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+
+        def _config(store_warps: int) -> helion.Config:
+            return helion.Config(
+                block_sizes=[256, 256, 128],
+                l2_groupings=[1],
+                num_warps=4,
+                num_sm_multiplier=1,
+                pid_type="persistent_interleaved",
+                tcgen05_cluster_m=2,
+                tcgen05_ab_stages=2,
+                tcgen05_acc_stages=2,
+                tcgen05_c_stages=4,
+                tcgen05_num_epi_warps=4,
+                tcgen05_strategy="role_local_with_scheduler",
+                tcgen05_warp_spec_scheduler_warps=1,
+                tcgen05_warp_spec_store_warps=store_warps,
+                indexing=[
+                    "tensor_descriptor",
+                    "tensor_descriptor",
+                    "tensor_descriptor",
+                ],
+            )
+
+        with patch_cute_mma_support():
+            bound = cute_matmul_with_scheduler_store.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code_store0 = bound.to_triton_code(_config(0))
+            code_store1 = bound.to_triton_code(_config(1))
+
+        # The productive store warp emits a DIFFERENT epilogue from store=0.
+        self.assertNotEqual(code_store1, code_store0)
+        # Widened epilogue role gate: epi warps OR the store warp (id 7).
+        self.assertIn(
+            "cute.arch.make_warp_uniform(cute.arch.warp_idx()) < cutlass.Int32(4) "
+            "or cute.arch.make_warp_uniform(cute.arch.warp_idx()) == cutlass.Int32(7)",
+            code_store1,
+        )
+        # C-store PipelineAsync edge: producer (4 epi) / consumer (1 store).
+        self.assertIn(
+            "tcgen05_c_store_edge = cutlass.pipeline.PipelineAsync.create(num_stages=4",
+            code_store1,
+        )
+        self.assertIn(
+            "tcgen05_c_store_edge_producer_group = "
+            "cutlass.pipeline.CooperativeGroup("
+            "cutlass.pipeline.Agent.Thread, cutlass.Int32(4))",
+            code_store1,
+        )
+        self.assertIn(
+            "tcgen05_c_store_edge_consumer_group = "
+            "cutlass.pipeline.CooperativeGroup("
+            "cutlass.pipeline.Agent.Thread, cutlass.Int32(1))",
+            code_store1,
+        )
+        # Epi-warp producer commit + store-warp consumer wait/release.
+        self.assertIn(
+            "tcgen05_c_store_edge.producer_commit(tcgen05_c_store_edge_producer_state)",
+            code_store1,
+        )
+        self.assertIn(
+            "tcgen05_c_store_edge.consumer_wait(tcgen05_c_store_edge_consumer_state)",
+            code_store1,
+        )
+        self.assertIn(
+            "tcgen05_c_store_edge.consumer_release(tcgen05_c_store_edge_release_state)",
+            code_store1,
+        )
+        # Store warp (id 7) owns the TMA-D + the c_pipeline lifecycle.
+        self.assertIn("if tcgen05_warp_idx == cutlass.Int32(7):", code_store1)
+        # Sched consumer arrive count is now 7 (the store warp is a REAL sched
+        # consumer; the cycle-91 ``- store_warp_count`` subtraction is removed).
+        self.assertIn(
+            "tcgen05_sched_pipeline_consumer_group = "
+            "cutlass.pipeline.CooperativeGroup("
+            "cutlass.pipeline.Agent.Thread, cutlass.Int32(7))",
+            code_store1,
+        )
+        # Launch envelope unchanged (8 warps either way).
+        self.assertIn("cute.make_layout((2, 1, 1))", code_store1)
+        self.assertIn("PipelineTmaUmma", code_store1)
+
+    def test_tcgen05_with_scheduler_store_warp_zero_byte_identical(
+        self,
+    ) -> None:
+        """Workstream A Stage 4 (cycle 93): store_warps=0 production path is
+        BYTE-IDENTICAL to a strategy-matched config with the store-warp field
+        absent. The entire Path B split is gated on ``has_store_warp``
+        (= ``store_warp_count>0``, default 0), so no passing target that uses
+        ``role_local_with_scheduler`` is perturbed — this is why no full sweep
+        is needed this cycle.
+        """
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_store_zero(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        base: dict[str, object] = {
+            "block_sizes": [256, 256, 128],
+            "l2_groupings": [1],
+            "num_warps": 4,
+            "num_sm_multiplier": 1,
+            "pid_type": "persistent_interleaved",
+            "tcgen05_cluster_m": 2,
+            "tcgen05_ab_stages": 2,
+            "tcgen05_acc_stages": 2,
+            "tcgen05_c_stages": 4,
+            "tcgen05_num_epi_warps": 4,
+            "tcgen05_strategy": "role_local_with_scheduler",
+            "tcgen05_warp_spec_scheduler_warps": 1,
+            "indexing": [
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "tensor_descriptor",
+            ],
+        }
+        with patch_cute_mma_support():
+            bound = cute_matmul_store_zero.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code_default = bound.to_triton_code(helion.Config(**base))
+            code_store0 = bound.to_triton_code(
+                helion.Config(**{**base, "tcgen05_warp_spec_store_warps": 0})
+            )
+        self.assertEqual(code_store0, code_default)
+        self.assertNotIn("tcgen05_c_store_edge", code_store0)
+
+    def test_tcgen05_store_warp_with_diagnostic_layout_rejected(self) -> None:
+        """Workstream A Stage 4 (cycle 93): reject store_warps=1 combined with a
+        diagnostic split / module-helper epilogue layout.
+
+        Those diagnostic layouts route the per-subtile tail through helpers that
+        emit only the ``if epi_active`` half under ``has_store_warp`` (and the
+        module-helper-store-tail keeps the OLD two-barrier warp-0 ``c_pipeline``
+        tail while the main path suppressed the matching acquires), so the
+        C-store edge would have no consumer and wedge at ring wrap. They are
+        diagnostic-only; production uses the DEFAULT layout, so the combo raises
+        ``BackendUnsupported`` (same guard class as the pure-matmul tail).
+        ``split_first_t2r`` routes through the Stage-4 split and is allowed.
+        """
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_store_diag(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        rejected_layouts = (
+            TCGEN05_EPILOGUE_LAYOUT_SPLIT_ACC_T2R_STORE_TAIL,
+            TCGEN05_EPILOGUE_LAYOUT_MODULE_HELPER_ACC_T2R,
+            TCGEN05_EPILOGUE_LAYOUT_MODULE_HELPER_STORE_TAIL,
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_store_diag.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            for epilogue_layout in rejected_layouts:
+                with self.subTest(epilogue_layout=epilogue_layout):
+                    cfg = helion.Config(
+                        block_sizes=[256, 256, 128],
+                        l2_groupings=[1],
+                        num_warps=4,
+                        num_sm_multiplier=1,
+                        pid_type="persistent_interleaved",
+                        tcgen05_cluster_m=2,
+                        tcgen05_ab_stages=2,
+                        tcgen05_acc_stages=2,
+                        tcgen05_c_stages=4,
+                        tcgen05_num_epi_warps=4,
+                        tcgen05_strategy="role_local_with_scheduler",
+                        tcgen05_warp_spec_scheduler_warps=1,
+                        tcgen05_warp_spec_store_warps=1,
+                        tcgen05_epilogue_layout=epilogue_layout,
+                        indexing=[
+                            "tensor_descriptor",
+                            "tensor_descriptor",
+                            "tensor_descriptor",
+                        ],
+                    )
+                    with self.assertRaisesRegex(
+                        exc.BackendUnsupported,
+                        "does not support tcgen05_warp_spec_store_warps>0",
+                    ):
+                        bound.to_triton_code(cfg)
+
+    def test_tcgen05_with_scheduler_store_warp_split_runtime_correctness(
+        self,
+    ) -> None:
+        """Runtime-correctness companion to
+        ``test_tcgen05_with_scheduler_store_warp_split_codegen``.
+
+        Workstream A Stage 4 (cycle 93): a ``ROLE_LOCAL_WITH_SCHEDULER`` config
+        with ``tcgen05_warp_spec_store_warps=1`` + the PRODUCTIVE Path B split
+        must LAUNCH (no ``CUDA_ERROR_LAUNCH_FAILED`` — the store warp at id 7
+        stays ``not epi_active`` -> same ``setmaxregister_decrease(120)`` as its
+        warpgroup-1 peers) AND produce correct output with NO C-ring deadlock at
+        wrap. ``c_stages=4`` with ``subtile_count=16`` per 256x256 tile wraps the
+        C-store ring 4x WITHIN one output tile, and the 1024x1024 problem has 16
+        output tiles, so both intra-tile and cross-tile ring wraps are exercised
+        (the cycle-2a partial-handshake deadlock surface).
+        """
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_with_scheduler_store_rt(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        torch.manual_seed(0)
+        x = torch.randn(1024, 1024, dtype=torch.bfloat16, device=DEVICE)
+        y = torch.randn(1024, 1024, dtype=torch.bfloat16, device=DEVICE)
+        config = helion.Config(
+            block_sizes=[256, 256, 128],
+            l2_groupings=[1],
+            num_warps=4,
+            num_sm_multiplier=1,
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=4,
+            tcgen05_num_epi_warps=4,
+            tcgen05_strategy="role_local_with_scheduler",
+            tcgen05_warp_spec_scheduler_warps=1,
+            tcgen05_warp_spec_store_warps=1,
+            indexing=[
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "tensor_descriptor",
+            ],
+        )
+        bound = cute_matmul_with_scheduler_store_rt.bind((x, y))
+        bound.env.config_spec.cute_tcgen05_search_enabled = True
+        bound.set_config(config)
+        out = bound(x, y)
+        expected = (x @ y).to(x.dtype)
+        torch.testing.assert_close(out, expected, atol=2e-1, rtol=1e-2)
+
+    def test_tcgen05_store_warp_aux_tma_merge_codegen(self) -> None:
+        """Workstream A Stage 5 (cycle 94, the merge) codegen pin.
+
+        The merged config ``c_input_warps=0 + store_warps=1 +
+        aux_load_mode=tma`` makes the single store/epi-load warp (id 7) the aux
+        residual PRODUCER (early per tile, GMEM->SMEM ring) AND the TMA-D store
+        drain consumer (late per subtile) in ONE role-local while at 8 warps —
+        no c_input/store collision. The epi warps consume the staged residual
+        from SMEM. This is validated-but-NOT-wired (the merge measured neutral
+        vs aux-TMA-alone under the acc_stages=2 overlap bound, so the autotune
+        surface stays ``store_warps=(0,)``); the pin guards the codegen shape if
+        a future change relaxes the bound and re-enables the merge.
+        """
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_merge(
+            x: torch.Tensor, y: torch.Tensor, residual: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = (acc + residual[tile_m, tile_n]).to(x.dtype)
+            return out
+
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        config = helion.Config(
+            block_sizes=[256, 256, 128],
+            l2_groupings=[1],
+            num_warps=4,
+            num_sm_multiplier=1,
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=4,
+            tcgen05_num_epi_warps=4,
+            tcgen05_strategy="role_local_with_scheduler",
+            tcgen05_warp_spec_scheduler_warps=1,
+            tcgen05_warp_spec_c_input_warps=0,
+            tcgen05_warp_spec_store_warps=1,
+            **{TCGEN05_AUX_LOAD_MODE_CONFIG_KEY: TCGEN05_AUX_LOAD_MODE_TMA},
+            indexing=[
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "tensor_descriptor",
+            ],
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_merge.bind(args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code = bound.to_triton_code(config)
+        # The store warp (id 7) is BOTH the aux-TMA producer and the C-store
+        # consumer in the widened epilogue role-local while.
+        self.assertIn(
+            "cute.arch.make_warp_uniform(cute.arch.warp_idx()) < cutlass.Int32(4) "
+            "or cute.arch.make_warp_uniform(cute.arch.warp_idx()) == cutlass.Int32(7)",
+            code,
+        )
+        # Aux-TMA producer pipeline (PipelineTmaAsync) is allocated even with
+        # c_input_warps=0 (the store warp is the producer).
+        self.assertIn("tcgen05_aux_pipeline = cutlass.pipeline.PipelineTmaAsync", code)
+        # Aux-TMA producer body fires on the store warp (id 7), and the C-store
+        # consumer drain also fires on it.
+        self.assertIn("tcgen05_aux_pipeline.producer_acquire", code)
+        self.assertIn("tcgen05_c_store_edge.consumer_wait", code)
+        # Epi warps consume the staged residual from SMEM (no per-tile GMEM
+        # residual load on the epi critical path).
+        self.assertIn("tcgen05_aux_pipeline.consumer_wait", code)
+
+    def test_tcgen05_store_warp_aux_tma_merge_runtime_correctness(self) -> None:
+        """Runtime-correctness + no-deadlock pin for the cycle-94 merge.
+
+        The merged store/epi-load warp must LAUNCH and produce correct residual
+        output with NO deadlock when both the aux ring AND the c=4 C-store ring
+        wrap (1024x1024 = 16 output tiles; subtile_count=16 per tile wraps both
+        rings within one tile). Guards the dual-role warp's two interleaved
+        pipelines (aux producer early + C-store consumer late) against a
+        wrap-deadlock.
+        """
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_merge_rt(
+            x: torch.Tensor, y: torch.Tensor, residual: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = (acc + residual[tile_m, tile_n]).to(x.dtype)
+            return out
+
+        torch.manual_seed(0)
+        x = torch.randn(1024, 1024, dtype=torch.bfloat16, device=DEVICE)
+        y = torch.randn(1024, 1024, dtype=torch.bfloat16, device=DEVICE)
+        residual = torch.randn(1024, 1024, dtype=torch.bfloat16, device=DEVICE)
+        config = helion.Config(
+            block_sizes=[256, 256, 128],
+            l2_groupings=[1],
+            num_warps=4,
+            num_sm_multiplier=1,
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=4,
+            tcgen05_num_epi_warps=4,
+            tcgen05_strategy="role_local_with_scheduler",
+            tcgen05_warp_spec_scheduler_warps=1,
+            tcgen05_warp_spec_c_input_warps=0,
+            tcgen05_warp_spec_store_warps=1,
+            **{TCGEN05_AUX_LOAD_MODE_CONFIG_KEY: TCGEN05_AUX_LOAD_MODE_TMA},
+            indexing=[
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "tensor_descriptor",
+            ],
+        )
+        bound = cute_matmul_merge_rt.bind((x, y, residual))
+        bound.env.config_spec.cute_tcgen05_search_enabled = True
+        bound.set_config(config)
+        out = bound(x, y, residual)
+        expected = (x.float() @ y.float() + residual.float()).to(torch.bfloat16)
+        torch.testing.assert_close(out, expected, atol=3e-1, rtol=2e-2)
+
+    def test_tcgen05_store_warp_aux_tma_merge_edge_tile_runtime(self) -> None:
+        """Cycle-94 autoreview #4b: the merge must handle EDGE tiles correctly.
+
+        A non-256-multiple shape (1152x1152) has M/N output-edge tiles that the
+        TMA-store full-tile epilogue routes through the SIMT direct-GMEM aux
+        path (``tile_phase="edge"`` in the role-local-while builder; the
+        store-warp aux producer stages the ring on full tiles only). Exact-
+        multiple shapes (the other merge runtime test at 1024^2) miss this path.
+        Pins correctness + no-deadlock across the full/edge aux split.
+        """
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_merge_edge_rt(
+            x: torch.Tensor, y: torch.Tensor, residual: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = (acc + residual[tile_m, tile_n]).to(x.dtype)
+            return out
+
+        torch.manual_seed(0)
+        # 1152 = 4.5 * 256: M and N both have a 128-wide output-edge tile.
+        x = torch.randn(1152, 512, dtype=torch.bfloat16, device=DEVICE)
+        y = torch.randn(512, 1152, dtype=torch.bfloat16, device=DEVICE)
+        residual = torch.randn(1152, 1152, dtype=torch.bfloat16, device=DEVICE)
+        config = helion.Config(
+            block_sizes=[256, 256, 128],
+            l2_groupings=[1],
+            num_warps=4,
+            num_sm_multiplier=1,
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_ab_stages=2,
+            tcgen05_acc_stages=2,
+            tcgen05_c_stages=4,
+            tcgen05_num_epi_warps=4,
+            tcgen05_strategy="role_local_with_scheduler",
+            tcgen05_warp_spec_scheduler_warps=1,
+            tcgen05_warp_spec_c_input_warps=0,
+            tcgen05_warp_spec_store_warps=1,
+            **{TCGEN05_AUX_LOAD_MODE_CONFIG_KEY: TCGEN05_AUX_LOAD_MODE_TMA},
+            indexing=[
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "tensor_descriptor",
+            ],
+        )
+        bound = cute_matmul_merge_edge_rt.bind((x, y, residual))
+        bound.env.config_spec.cute_tcgen05_search_enabled = True
+        bound.set_config(config)
+        out = bound(x, y, residual)
+        expected = (x.float() @ y.float() + residual.float()).to(torch.bfloat16)
+        torch.testing.assert_close(out, expected, atol=3e-1, rtol=2e-2)
+
+    def test_tcgen05_store_warp_simt_aux_falls_back_to_gmem(self) -> None:
+        """Cycle-94 autoreview #1: ``store_warps=1 + SIMT aux`` must NOT engage
+        the aux-on-store-warp merge (which is TMA-only).
+
+        The merge injects a TMA bulk aux producer on the store warp; there is no
+        SIMT store-warp producer, and the SIMT producer arrive count is
+        ``c_input_warp_count * 32`` (= 0 with no C-input warp). If the merge
+        gate fired on SIMT, it would pair a 0-thread producer group with a
+        32-thread SIMT cooperative copy -> consumers read uninitialized SMEM /
+        wedge. So ``store_warps=1 + aux_load_mode=simt`` must fall back to the
+        direct-GMEM aux path: NO aux SMEM-ring pipeline, NO 0-thread producer
+        group, residual read directly from GMEM, while the store-drain decouple
+        (cycle 93) stays active. Codegen is BYTE-IDENTICAL to the cycle-93
+        store=1/SIMT behavior. Correctness is also checked at a wrapping shape.
+        """
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_simt_store(
+            x: torch.Tensor, y: torch.Tensor, residual: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = (acc + residual[tile_m, tile_n]).to(x.dtype)
+            return out
+
+        compile_args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+
+        def _config() -> helion.Config:
+            return helion.Config(
+                block_sizes=[256, 256, 128],
+                l2_groupings=[1],
+                num_warps=4,
+                num_sm_multiplier=1,
+                pid_type="persistent_interleaved",
+                tcgen05_cluster_m=2,
+                tcgen05_ab_stages=2,
+                tcgen05_acc_stages=2,
+                tcgen05_c_stages=4,
+                tcgen05_num_epi_warps=4,
+                tcgen05_strategy="role_local_with_scheduler",
+                tcgen05_warp_spec_scheduler_warps=1,
+                tcgen05_warp_spec_c_input_warps=0,
+                tcgen05_warp_spec_store_warps=1,
+                # aux_load_mode defaults to SIMT (no TMA key).
+                indexing=[
+                    "tensor_descriptor",
+                    "tensor_descriptor",
+                    "tensor_descriptor",
+                ],
+            )
+
+        with patch_cute_mma_support():
+            bound = cute_matmul_simt_store.bind(compile_args)
+            bound.env.config_spec.cute_tcgen05_search_enabled = True
+            code = bound.to_triton_code(_config())
+        # No aux SMEM-ring pipeline (SIMT store-warp merge is gated off).
+        self.assertNotIn("tcgen05_aux_pipeline", code)
+        # No 0-thread producer cooperative group (the broken-merge symptom).
+        self.assertNotIn(
+            "cutlass.pipeline.CooperativeGroup("
+            "cutlass.pipeline.Agent.Thread, cutlass.Int32(0))",
+            code,
+        )
+        # The store-drain decouple (cycle 93) is still active.
+        self.assertIn("tcgen05_c_store_edge", code)
+        self.assertIn(
+            "cute.arch.make_warp_uniform(cute.arch.warp_idx()) < cutlass.Int32(4) "
+            "or cute.arch.make_warp_uniform(cute.arch.warp_idx()) == cutlass.Int32(7)",
+            code,
+        )
+
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+        torch.manual_seed(0)
+        x = torch.randn(1024, 1024, dtype=torch.bfloat16, device=DEVICE)
+        y = torch.randn(1024, 1024, dtype=torch.bfloat16, device=DEVICE)
+        residual = torch.randn(1024, 1024, dtype=torch.bfloat16, device=DEVICE)
+        bound_rt = cute_matmul_simt_store.bind((x, y, residual))
+        bound_rt.env.config_spec.cute_tcgen05_search_enabled = True
+        bound_rt.set_config(_config())
+        out = bound_rt(x, y, residual)
+        expected = (x.float() @ y.float() + residual.float()).to(torch.bfloat16)
+        torch.testing.assert_close(out, expected, atol=3e-1, rtol=2e-2)
+
+    def test_tcgen05_with_scheduler_store_and_c_input_warps_rejected(
+        self,
+    ) -> None:
+        """Cycle 91 autoreview #1: ``c_input_warps=1`` and ``store_warps=1``
+        cannot both be set under ROLE_LOCAL_WITH_SCHEDULER.
+
+        Each independently reuses the single inert warpgroup-padding slot, so
+        setting both sums ``role_warp_count`` to 9 -> ``launched_warp_count``
+        rounds to 12 (= 384 threads) -> the (128, 12, 1) block overflows the
+        validated 1024-thread / 8-warp launch envelope. The cross-field guard
+        in ``validate_tcgen05_strategy_invariants`` rejects this loudly at
+        normalize time with a clear message rather than letting it surface as a
+        late, confusing ``BackendUnsupported`` at codegen. The intended
+        Stage-3 path is store=1 with c_input=0.
+        """
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_store_and_c_input(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        args = (
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        with patch_cute_mma_support():
+            bound = cute_matmul_store_and_c_input.bind(args)
+        bound.env.config_spec.cute_tcgen05_search_enabled = True
+        dual_config: dict[str, object] = {
+            "block_sizes": [256, 256, 128],
+            "l2_groupings": [1],
+            "num_warps": 4,
+            "num_sm_multiplier": 1,
+            "pid_type": "persistent_interleaved",
+            "tcgen05_cluster_m": 2,
+            "tcgen05_ab_stages": 2,
+            "tcgen05_acc_stages": 2,
+            "tcgen05_c_stages": 2,
+            "tcgen05_num_epi_warps": 4,
+            "tcgen05_strategy": "role_local_with_scheduler",
+            "tcgen05_warp_spec_scheduler_warps": 1,
+            "tcgen05_warp_spec_c_input_warps": 1,
+            "tcgen05_warp_spec_store_warps": 1,
+            "indexing": [
+                "tensor_descriptor",
+                "tensor_descriptor",
+                "tensor_descriptor",
+            ],
+        }
+        with self.assertRaisesRegex(
+            exc.InvalidConfig,
+            "cannot run a C-input warp and a store warp at the same time",
+        ):
+            bound.env.config_spec.normalize(dual_config)
+
     def test_tcgen05_clc_persistent_codegen(self) -> None:
         """G2-H CLC scheduler-warp body codegen pin (cute_plan.md).
 
@@ -17594,8 +18266,13 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
         self.assertIn("partial output tiles", msg)
         self.assertIn("partial-output TMA-store epilogue", msg)
 
-    def test_aux_tma_load_rejects_c_input_warp_zero(self) -> None:
-        """Explicit aux TMA must not silently no-op when the producer gate is shut."""
+    def test_aux_tma_load_rejects_no_producer_warp(self) -> None:
+        """Explicit aux TMA must not silently no-op when the producer gate is shut.
+
+        Cycle 94 (Workstream A Stage 5, the merge): the aux producer warp can be
+        the C-input warp OR the store warp. With NEITHER set (c_input=0,
+        store=0), aux-TMA has no producer and must reject loudly.
+        """
 
         kernel = self._residual_kernel()
         args = (
@@ -17617,6 +18294,7 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
                 tcgen05_strategy="role_local_with_scheduler",
                 tcgen05_warp_spec_scheduler_warps=1,
                 tcgen05_warp_spec_c_input_warps=0,
+                tcgen05_warp_spec_store_warps=0,
                 **{TCGEN05_AUX_LOAD_MODE_CONFIG_KEY: TCGEN05_AUX_LOAD_MODE_TMA},
                 indexing=["tensor_descriptor"] * bound.env.config_spec.indexing.length,
             )
@@ -17624,7 +18302,7 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
                 bound.to_triton_code(cfg)
         msg = str(cm.exception)
         self.assertIn(TCGEN05_AUX_LOAD_MODE_CONFIG_KEY, msg)
-        self.assertIn("productive C-input warp", msg)
+        self.assertIn("productive aux producer warp", msg)
 
     def test_aux_tma_load_rejects_multi_store_fanout(self) -> None:
         """Explicit aux TMA rejects multi-store fan-out instead of falling back."""
@@ -19315,14 +19993,17 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
             with self.assertRaises(exc.BackendUnsupported) as cm:
                 bound.to_triton_code(config)
         msg = str(cm.exception)
-        # The rejection message names both knobs by their full
+        # The rejection message names the knobs by their full
         # ``helion.Config(...)`` field spelling so a user
         # dropping into the message can grep their config for
-        # the exact key names.
+        # the exact key names. Cycle 94 generalized the producer
+        # warp to "C-input OR the store-warp merge", so the
+        # remediation says "drop the aux producer warp" rather
+        # than naming ``c_input_warps=0`` specifically.
         self.assertIn("tcgen05_ab_stages=3", msg)
         self.assertIn("tcgen05_warp_spec_c_input_warps=1", msg)
         self.assertIn("tcgen05_ab_stages=2", msg)
-        self.assertIn("tcgen05_warp_spec_c_input_warps=0", msg)
+        self.assertIn("drop the aux producer warp", msg)
 
     def test_aux_pipeline_ab_stages_2_with_c_input_compiles(self) -> None:
         """Companion positive pin:


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2682
 * #2681
 * #2680
 * #2679
 * #2678
 * #2656
 * __->__#2655
 * #2654
 * #2653
 * #2652
 * #2651


--- --- ---

[cutedsl] overlap epilogue store via a dedicated store warp

Add a budget-aware c_stages admission gate and a deeper C ring, then
decouple the TMA-D store onto a dedicated store warp (8-warp envelope)
so the two-barrier + TMA-D tail drains off the epilogue warps, with an
option to merge the aux-TMA load and store drain onto one warp. Off by
default (store_warps=0, byte-identical); when enabled it raises active
warps and cuts epilogue-barrier stalls.