### PR TITLE
[cutedsl] make tcgen05 ab_stages budget-aware searchable

### DIFF
--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -2028,6 +2028,64 @@ class CuteTcgen05Config:
         ):
             config["tcgen05_ab_stages"] = 2
 
+    def _fix_ab_stages_search_config(self, config: dict[str, object]) -> None:
+        # Budget-aware ab=3 admission for the lifted ``for_search`` cap (see
+        # ``optional_fragments`` and cute_plan.md §4.5 for the empirical narrative).
+        # Mirror ``_fix_c_stages_search_config`` (fail-CLOSED, cast-based): on the
+        # canonical 256x256 DEFAULT-layout role-local path, demote a directly-sampled
+        # ab=3 to 2 when it does not fit the per-CTA SMEM budget. The invariant — the
+        # new dimension over the bare-AB ``_fix_ab_stages_three_search_config`` gate —
+        # is REAL source-C presence, keyed on the PRECISE
+        # ``exact_shape_aux_kernel_detected`` (rank-2 exact-shape residual_add), NOT
+        # the broad ``aux_kernel_detected`` (also True for a rowvec broadcast bias
+        # that has no source-C ring): a real source-C materializes the larger
+        # (128, 64) C ring, so AB(ab=3) + C overflows the cap even at c=2 and MUST
+        # demote, while the plain / rowvec-bias family (no source-C ring) keeps the
+        # bare-AB calibration so its ab=3 winner stays searchable. The exact-shape
+        # residual cluster_m=2 full-tile candidates are already forced to ab=2 by
+        # ``_fix_aux_tma_full_tile_search_config`` (runs first); this gate's source-C
+        # branch is the fail-closed backstop for any exact-shape residual ab=3 that
+        # projection does not claim (e.g. cluster_m=1). The EXPLICIT_EPI_TILE
+        # direct-entry (TVM-FFI) seeds use a separate (128, 32) tile + own admission
+        # and are out of the DEFAULT-layout scope, so their seeded ab=3/ab=6 is
+        # untouched.
+        if not self.search_enabled:
+            return
+        if config.get("tcgen05_ab_stages") != 3:
+            return
+        if not self._is_default_layout_full_tile_config(config):
+            return
+        block_sizes = cast("list[int]", config["block_sizes"])
+        cluster_m = cast("int", config.get("tcgen05_cluster_m", 1))
+        if self.exact_shape_aux_kernel_detected:
+            # Real source-C present: require AB(ab=3) + the (128, 64) C ring to fit
+            # together. ``c_stages_fits`` fails CLOSED when no SMEM budget is
+            # recorded (non-B200 / CPU host), so the over-budget and no-budget
+            # arms are both covered by a single ``not c_stages_fits`` check.
+            c_stages = cast("int", config.get("tcgen05_c_stages", 2))
+            fits = self.c_stages_fits(
+                bm=block_sizes[0],
+                bn=block_sizes[1],
+                bk=block_sizes[2],
+                cluster_m=cluster_m,
+                ab_stages=3,
+                c_stages=c_stages,
+                has_source_c=True,
+            )
+        else:
+            # Plain / rowvec-bias store (no source-C ring): the bare-AB gate is the
+            # calibrated admission — the small no-source-C epilogue D ring rides the
+            # non-AB reservation. ``ab_stages_three_fits`` returns False with no
+            # budget recorded, so this also fails CLOSED.
+            fits = self.ab_stages_three_fits(
+                bm=block_sizes[0],
+                bn=block_sizes[1],
+                bk=block_sizes[2],
+                cluster_m=cluster_m,
+            )
+        if not fits:
+            config["tcgen05_ab_stages"] = 2
+
     def _fix_with_scheduler_search_config(self, config: dict[str, object]) -> None:
         if not (self.search_enabled and self.aux_kernel_detected):
             return
@@ -2948,6 +3006,17 @@ class CuteTcgen05Config:
             ab_stages_max = max(3, TCGEN05_TARGET10_TVM_FFI_AB_STAGES)
         elif not for_search:
             ab_stages_max = 3
+        elif self.ab_stages_three_search_constraints is not None:
+            # Cycle 97: make ab=3 BUDGET-AWARE-SEARCHABLE. Where the device/dtype
+            # admits ab=3 at all (the SMEM-budget constraints were recorded by
+            # ``allow_ab_stages_three_search`` at bind time — B200-class optin cap,
+            # bf16/fp16), lift the ``for_search`` cap to 3 so the autotuner can
+            # SAMPLE ab=3 directly instead of reaching it only through the per-shape
+            # FFI / gelu seeds. ``_fix_ab_stages_search_config`` then demotes any
+            # sampled ab=3 that does not fit (the residual/source-C ring overflows;
+            # cluster_m=1 256x256 overflows bare-AB) before codegen, so admission is
+            # free but an overflowing kernel is never generated.
+            ab_stages_max = 3
         else:
             ab_stages_max = 2
         if for_search:
@@ -3736,6 +3805,14 @@ class CuteTcgen05Config:
         self._fix_aux_tma_full_tile_search_config(config)
         self._fix_with_scheduler_search_config(config)
         self._fix_aux_tma_search_config(config)
+        # Cycle 97: budget-aware ab-stages admission for the lifted for_search
+        # cap. Runs after the family projections (FFI / gelu / aux-TMA full-tile)
+        # have set their validated stage tuple, so a directly-SAMPLED ab=3 that no
+        # projection claimed — and that does not fit (residual/source-C ring
+        # overflow, or cluster_m=1 256x256 bare-AB overflow) — is demoted to 2 on
+        # the DEFAULT-layout full-tile path before codegen. The plain silu/gelu
+        # ab=3 winner (no source-C, cluster_m=2) is preserved.
+        self._fix_ab_stages_search_config(config)
         # Final c-stages admission: demote a directly-sampled (or any unclaimed)
         # deeper C ring on the canonical 256x256 DEFAULT-layout path that does
         # not fit AB+C under the B200 cap. Runs after the family fixups so their

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -1036,7 +1036,17 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             for_search=True
         )["tcgen05_ab_stages"]
         self.assertIsInstance(search_ab_stages_fragment, IntegerFragment)
-        self.assertEqual(search_ab_stages_fragment.high, 2)
+        # Cycle 97: the for_search ab cap is BUDGET-AWARE — lifted to 3 wherever
+        # ab=3 is admissible (the SMEM-budget constraints were recorded at bind
+        # time, i.e. bf16/fp16 on a B200-class optin cap), else 2. Conditioning on
+        # the recorded constraints keeps the assertion deterministic across hosts.
+        expected_search_ab_high = (
+            3
+            if bound.config_spec._cute_tcgen05_config.ab_stages_three_search_constraints
+            is not None
+            else 2
+        )
+        self.assertEqual(search_ab_stages_fragment.high, expected_search_ab_high)
         self.assertIn(
             TCGEN05_PURE_CLC_SCHEDULER_OBJECT_CONFIG_KEY,
             bound.config_spec._tcgen05_optional_fragments(),
@@ -1235,7 +1245,21 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             ]
         )
         self.assertIsInstance(non_target_ab_stages_fragment, IntegerFragment)
-        self.assertEqual(non_target_ab_stages_fragment.high, 2)
+        # Cycle 97: ab=3 is now BUDGET-AWARE-SEARCHABLE for ANY bf16/fp16 kernel
+        # whose device admits it (constraints recorded) — not only the per-shape
+        # seed targets. The non-seed kernel still gets the lifted cap; a sampled
+        # over-budget ab=3 is demoted by ``_fix_ab_stages_search_config``.
+        expected_non_target_ab_high = (
+            3
+            if (
+                non_target_bound.config_spec._cute_tcgen05_config.ab_stages_three_search_constraints
+                is not None
+            )
+            else 2
+        )
+        self.assertEqual(
+            non_target_ab_stages_fragment.high, expected_non_target_ab_high
+        )
 
         @helion.kernel(backend="cute")
         def cute_matmul_mma_no_ab3_budget(
@@ -1273,6 +1297,10 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             )["tcgen05_ab_stages"]
         )
         self.assertIsInstance(no_budget_ab_stages_fragment, IntegerFragment)
+        # Cycle 97: with no recorded SMEM budget (``per_cta_ab_smem_budget_bytes``
+        # patched to 0 -> constraints stay None) the for_search ab cap stays at 2 —
+        # the budget-aware lift is gated on the recorded constraints, so a device
+        # below the B200 envelope never admits ab=3 into search.
         self.assertEqual(no_budget_ab_stages_fragment.high, 2)
 
         @helion.kernel(backend="cute")
@@ -2931,6 +2959,209 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         )
         tcfg.fix_search_config(ab2_c4_no_budget.config)
         self.assertEqual(ab2_c4_no_budget.config["tcgen05_c_stages"], 2)
+
+    @onlyBackends(["cute"])
+    def test_cute_tcgen05_ab_stages_budget_gate(self) -> None:
+        # Cycle 97: ab=3 is BUDGET-AWARE-SEARCHABLE. The for_search ab cap is
+        # lifted to 3 wherever ab=3 is admissible (constraints recorded), and
+        # ``_fix_ab_stages_search_config`` demotes a sampled ab=3 that does not fit
+        # — fail-CLOSED, mirroring the c-stages budget gate. The new dimension over
+        # the bare-AB gate is REAL source-C presence, keyed on the PRECISE
+        # ``exact_shape_aux_kernel_detected`` (rank-2 exact-shape residual_add), NOT
+        # the broad ``aux_kernel_detected`` (which is also True for a rowvec bias
+        # that has no source-C ring). A real source-C kernel materializes the larger
+        # (128, 64) C ring, so AB(ab=3) + C overflows the 232 KiB B200 cap even at
+        # c=2 and MUST demote; the plain / rowvec-bias family (no source-C ring)
+        # keeps the calibrated bare-AB admission so its ab=3 cluster_m=2 winner stays
+        # searchable (cycle-97 force-config: bias 256x256x128 cluster_m=2 ab=3
+        # compiles + runs, T16 639.7 / T2 460.1 TF). The SMEM budget is MOCKED to the
+        # B200 value so the gate is deterministic on any cute host.
+        b200_budget = 232448 - 28 * 1024  # optin cap - ab=3 reservation
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_plain(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_bias(
+            x: torch.Tensor, y: torch.Tensor, bias: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = (acc + bias[tile_n]).to(x.dtype)
+            return out
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_residual_add(
+            x: torch.Tensor, y: torch.Tensor, residual: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                out[tile_m, tile_n] = (acc + residual[tile_m, tile_n]).to(x.dtype)
+            return out
+
+        plain_args = (
+            torch.empty([6144, 6144], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([6144, 6144], device=DEVICE, dtype=torch.bfloat16),
+        )
+        bias_args = (
+            torch.empty([1024, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096, 1024], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([1024], device=DEVICE, dtype=torch.bfloat16),
+        )
+        # T16 shape (4096x4096x512): K=512 -> bk=128 -> 4 divisible k-tiles, so
+        # cluster_m=2 search IS admitted (passes ``cluster_m2_bk_is_valid``). Used
+        # for the END-TO-END bias guard below — unlike the 1024x4096x1024 bias
+        # above (cluster_m=2 search OFF -> reprojects to cluster_m=1).
+        bias_t16_args = (
+            torch.empty([4096, 512], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([512, 4096], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([4096], device=DEVICE, dtype=torch.bfloat16),
+        )
+        residual_args = (
+            torch.empty([6144, 6144], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([6144, 6144], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([6144, 6144], device=DEVICE, dtype=torch.bfloat16),
+        )
+        with (
+            patch_cute_mma_support(),
+            patch("helion.language.matmul_ops._cuda_num_sms_or_zero", return_value=132),
+            patch.object(
+                CuteTcgen05Config,
+                "per_cta_ab_smem_budget_bytes",
+                return_value=b200_budget,
+            ),
+        ):
+            plain_bound = cute_matmul_plain.bind(plain_args)
+            bias_bound = cute_matmul_bias.bind(bias_args)
+            bias_t16_bound = cute_matmul_bias.bind(bias_t16_args)
+            residual_bound = cute_matmul_residual_add.bind(residual_args)
+
+        plain_tcfg = plain_bound.config_spec._cute_tcgen05_config
+        bias_tcfg = bias_bound.config_spec._cute_tcgen05_config
+        bias_t16_tcfg = bias_t16_bound.config_spec._cute_tcgen05_config
+        residual_tcfg = residual_bound.config_spec._cute_tcgen05_config
+        # Plain: no aux at all. Bias: broad aux True but NO source-C ring (rowvec).
+        # Residual: real rank-2 exact-shape source-C.
+        self.assertFalse(plain_tcfg.aux_kernel_detected)
+        self.assertFalse(plain_tcfg.exact_shape_aux_kernel_detected)
+        self.assertTrue(bias_tcfg.aux_kernel_detected)
+        self.assertFalse(bias_tcfg.exact_shape_aux_kernel_detected)
+        self.assertTrue(residual_tcfg.aux_kernel_detected)
+        self.assertTrue(residual_tcfg.exact_shape_aux_kernel_detected)
+
+        # The for_search ab fragment is lifted to 3 (the budget was recorded at
+        # bind via the mocked B200 cap) for every family.
+        for tcfg in (plain_tcfg, bias_tcfg, residual_tcfg):
+            ab_fragment = tcfg.optional_fragments(for_search=True)["tcgen05_ab_stages"]
+            self.assertEqual(ab_fragment.high, 3)
+
+        def _ab3_config(cluster_m: int = 2) -> helion.Config:
+            return helion.Config(
+                block_sizes=[256, 256, 128],
+                indexing=[
+                    "tensor_descriptor",
+                    "tensor_descriptor",
+                    "tensor_descriptor",
+                ],
+                pid_type="persistent_interleaved",
+                tcgen05_cluster_m=cluster_m,
+                tcgen05_cluster_n=1,
+                tcgen05_ab_stages=3,
+                tcgen05_acc_stages=2,
+                tcgen05_c_stages=2,
+                tcgen05_strategy=Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
+                tcgen05_persistence_model="static_persistent",
+            )
+
+        # PLAIN (no source-C): the bare AB pipeline (192 KiB at cluster_m=2) fits
+        # the 199 KiB budget and the small no-source-C epilogue D ring rides the
+        # non-AB reservation — the ab=3 winner is PRESERVED.
+        plain_ab3 = _ab3_config()
+        plain_tcfg.fix_search_config(plain_ab3.config)
+        self.assertEqual(plain_ab3.config["tcgen05_ab_stages"], 3)
+
+        # BIAS (broad-aux True, source-C False): the rowvec bias has NO source-C
+        # ring, so the gate's NON-source-C branch admits the same 192 KiB bare-AB
+        # ab=3 at cluster_m=2. This is the case that exercises the precise-signal
+        # fix — under the old broad ``aux_kernel_detected`` branch the gate would
+        # have wrongly demoted it (cycle-97 force-config proved bias 256x256x128
+        # cluster_m=2 ab=3 fits + runs). Call the gate in ISOLATION because the
+        # full chain's cluster_m=2 projection (``_fix_cluster_m2_search_config``)
+        # can reproject a bias candidate to cluster_m=1 for K-cap reasons unrelated
+        # to this gate; the gate itself must KEEP the bias cluster_m=2 ab=3.
+        bias_ab3 = _ab3_config()
+        bias_tcfg._fix_ab_stages_search_config(bias_ab3.config)
+        self.assertEqual(bias_ab3.config["tcgen05_ab_stages"], 3)
+
+        # BIAS END-TO-END (the P2 guard): on a bias shape where cluster_m=2 search
+        # is genuinely admitted (T16 = 4096x4096x512, K=512 -> 4 divisible k-tiles),
+        # the FULL ``fix_search_config`` chain must KEEP a cluster_m=2 256x256x128
+        # ab=3 bias candidate at ab=3 cluster_m=2 — NOT reprojected to cluster_m=1
+        # (the cluster_m=2 projection accepts it) and NOT demoted to ab=2 (no
+        # source-C ring). This locks in the bias-family "now admits cluster_m=2 ab=3"
+        # claim that GATE 2 confirmed empirically (T5/T9/T16), guarding it against a
+        # future regression the way the plain/silu winner is already covered.
+        self.assertTrue(bias_t16_tcfg.aux_kernel_detected)
+        self.assertFalse(bias_t16_tcfg.exact_shape_aux_kernel_detected)
+        self.assertIsNotNone(bias_t16_tcfg.cluster_m2_search_constraints)
+        bias_t16_ab3 = _ab3_config()
+        bias_t16_tcfg.fix_search_config(bias_t16_ab3.config)
+        self.assertEqual(bias_t16_ab3.config["tcgen05_ab_stages"], 3)
+        self.assertEqual(bias_t16_ab3.config["tcgen05_cluster_m"], 2)
+        self.assertEqual(bias_t16_ab3.config["block_sizes"][:3], [256, 256, 128])
+
+        # RESIDUAL source-C branch, in ISOLATION. The exact-shape aux-TMA full-tile
+        # projection forces ab=2 on a cluster_m=2 candidate BEFORE the gate runs, so
+        # to exercise the gate's source-C branch directly we call it on a cluster_m=1
+        # residual candidate (which no projection claims): AB(ab=3) + (128, 64) C
+        # ring overflows even at cluster_m=1, so it DEMOTES to 2.
+        residual_cm1_ab3 = _ab3_config(cluster_m=1)
+        residual_tcfg._fix_ab_stages_search_config(residual_cm1_ab3.config)
+        self.assertEqual(residual_cm1_ab3.config["tcgen05_ab_stages"], 2)
+
+        # And the same residual source-C branch demotes a cluster_m=2 candidate too
+        # (independent of the aux-TMA projection): call the gate in isolation.
+        residual_cm2_ab3 = _ab3_config(cluster_m=2)
+        residual_tcfg._fix_ab_stages_search_config(residual_cm2_ab3.config)
+        self.assertEqual(residual_cm2_ab3.config["tcgen05_ab_stages"], 2)
+
+        # Full chain on the cluster_m=2 residual: the aux-TMA projection forces ab=2
+        # first, and the gate is consistent (still 2).
+        residual_full = _ab3_config(cluster_m=2)
+        residual_tcfg.fix_search_config(residual_full.config)
+        self.assertEqual(residual_full.config["tcgen05_ab_stages"], 2)
+
+        # cluster_m=1 256x256 plain ab=3 overflows bare-AB (384 KiB > budget) and is
+        # demoted even without a source-C.
+        plain_cm1_ab3 = _ab3_config(cluster_m=1)
+        plain_tcfg.fix_search_config(plain_cm1_ab3.config)
+        self.assertEqual(plain_cm1_ab3.config["tcgen05_ab_stages"], 2)
+
+        # Fail CLOSED: with no recorded SMEM budget the sampled plain ab=3 cannot be
+        # proven to fit, so it is demoted to 2 rather than left to overflow.
+        plain_tcfg.ab_stages_three_search_constraints = None
+        plain_ab3_no_budget = _ab3_config()
+        plain_tcfg.fix_search_config(plain_ab3_no_budget.config)
+        self.assertEqual(plain_ab3_no_budget.config["tcgen05_ab_stages"], 2)
 
     @onlyBackends(["cute"])
     def test_cute_tcgen05_c_input_seed_respects_disable_heuristics(self) -> None:

--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -657,13 +657,16 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         """SMEM-budget gate validates explicit ``tcgen05_ab_stages=3`` configs.
 
         The 4096^3 BF16 matmul binding records the SMEM-budget gate so
-        search-time normalization can demote explicit ``ab=3`` candidates
+        search-time normalization can demote sampled ``ab=3`` candidates
         whose ``(bm, bn, bk, cluster_m)`` per-CTA AB-SMEM cost exceeds the
         device's optin SMEM cap minus the non-AB reservation (see
-        ``cute_plan.md`` §7.0). The broad random search fragment remains
-        capped at ``ab=2``; ``ab=3`` is now exposed through validated seeds
-        only, with the Target1 TVM-FFI seed owning the promoted search
-        family. The validation surface stays unchanged: explicit
+        ``cute_plan.md`` §7.0). Cycle 97 made ``ab=3`` BUDGET-AWARE-SEARCHABLE:
+        the broad random search fragment is now lifted to ``ab=3`` wherever
+        the SMEM-budget constraints are recorded (B200-class optin, bf16/fp16),
+        and ``_fix_ab_stages_search_config`` demotes a sampled ab=3 that does
+        not fit (over-budget bare AB, or the real source-C ring overflow) — so
+        the autotuner can reach the ab=3 winner directly instead of only via the
+        per-shape seeds. The validation surface stays unchanged: explicit
         ``helion.Config(tcgen05_ab_stages=3)`` always round-trips for
         explicit user configs.
 
@@ -691,10 +694,13 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         self.assertEqual(constraints.per_cta_smem_budget_bytes, b200_budget_bytes)
 
         search_fragments = spec._tcgen05_optional_fragments(for_search=True)
-        # Broad random search stays fail-closed at ab=2 unless the exact
-        # Target1 TVM-FFI seed is available. The validation surface is
-        # independently 3 for explicit configs.
-        self.assertEqual(search_fragments["tcgen05_ab_stages"].high, 2)
+        # Cycle 97: ab=3 is BUDGET-AWARE-SEARCHABLE — the for_search cap is lifted
+        # to 3 wherever the SMEM-budget constraints were recorded (here: the mocked
+        # B200 budget), so the autotuner can SAMPLE ab=3 directly. A sampled ab=3
+        # that does not fit is then demoted by ``_fix_ab_stages_search_config`` (the
+        # over-budget cases below). The validation surface is independently 3 for
+        # explicit configs.
+        self.assertEqual(search_fragments["tcgen05_ab_stages"].high, 3)
         validation_fragments = spec._tcgen05_optional_fragments(for_search=False)
         self.assertEqual(validation_fragments["tcgen05_ab_stages"].high, 3)
 


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2682
 * #2681
 * #2680
 * #2679
 * #2678
 * __->__#2656
 * #2655
 * #2654
 * #2653
 * #2652
 * #2651


--- --- ---

[cutedsl] make tcgen05 ab_stages budget-aware searchable

Lift the ab_stages search cap to 3 where SMEM admits, with a
fail-closed demotion, so the autotuner finds ab_stages=3 generically
instead of relying on per-shape seeds.