### PR TITLE
[compile] Migrate all backends to DeviceIRLowering. Remove legacy path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,7 @@ site
 tags
 TAGS
 torch
-triton
+/triton
 *.user
 uv.lock
 venv

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -567,16 +567,16 @@ class Backend(abc.ABC):
         """
         return None
 
-    def get_device_ir_lowering(self) -> DeviceIRLowering | None:
-        """Return a DeviceIRLowering for this backend, or None for the legacy path.
+    def get_device_ir_lowering(self) -> DeviceIRLowering:
+        """Return a DeviceIRLowering for this backend.
 
-        Backends that have migrated to the structured lowering pipeline
-        return a ``DeviceIRLowering`` subclass.  Backends that
-        have not yet migrated return ``None``, causing
-        ``KernelCompiler.lower()`` to fall back to the legacy
-        ``lower_to_device_ir()`` function.
+        Backends override this to return a backend-specific subclass
+        that customizes the lowering pipeline.  The base implementation
+        returns the generic ``DeviceIRLowering``.
         """
-        return None
+        from .device_ir_lowering import DeviceIRLowering
+
+        return DeviceIRLowering()
 
     @staticmethod
     def reserved_launch_param_names() -> frozenset[str]:
@@ -798,6 +798,11 @@ class TritonBackend(Backend):
     @property
     def name(self) -> str:
         return "triton"
+
+    def get_device_ir_lowering(self) -> DeviceIRLowering:
+        from .triton.device_ir_lowering import TritonDeviceIRLowering
+
+        return TritonDeviceIRLowering()
 
     @property
     def experimental(self) -> bool:
@@ -1186,6 +1191,11 @@ class PallasBackend(Backend):
     @property
     def name(self) -> str:
         return "pallas"
+
+    def get_device_ir_lowering(self) -> DeviceIRLowering:
+        from .pallas.device_ir_lowering import PallasDeviceIRLowering
+
+        return PallasDeviceIRLowering()
 
     @property
     def max_tensor_numel(self) -> int | None:
@@ -4033,6 +4043,11 @@ class CuteBackend(Backend):
 
 class MetalBackend(Backend):
     """Metal Shading Language (MSL) code generation backend for macOS."""
+
+    def get_device_ir_lowering(self) -> DeviceIRLowering:
+        from .metal.device_ir_lowering import MetalDeviceIRLowering
+
+        return MetalDeviceIRLowering()
 
     @staticmethod
     def _get_dtype_to_metal() -> dict[torch.dtype, str]:

--- a/helion/_compiler/cute/device_ir_lowering.py
+++ b/helion/_compiler/cute/device_ir_lowering.py
@@ -9,6 +9,7 @@ import torch
 
 from ..compile_environment import CompileEnvironment
 from ..device_ir_lowering import DeviceIRLowering
+from ..device_ir_lowering import register_load_store_tunables
 
 if TYPE_CHECKING:
     from ..device_ir import DeviceIR
@@ -30,6 +31,7 @@ class CuteDeviceIRLowering(DeviceIRLowering):
 
     def register(self, device_ir: DeviceIR) -> None:
         super().register(device_ir)
+        register_load_store_tunables(device_ir)
         _register_cute_vector_widths(device_ir)
         _track_cute_indexed_reductions(device_ir)
 

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -21,7 +21,6 @@ from typing import cast
 from unittest.mock import patch
 
 import torch
-from torch._dynamo.convert_frame import compile_lock
 from torch._inductor.decomposition import select_decomp_table
 from torch.fx._lazy_graph_module import _LazyGraphModule
 from torch.fx.experimental import proxy_tensor
@@ -49,11 +48,9 @@ from .host_function import HostFunction
 from .inductor_lowering import APIFuncLowering
 from .inductor_lowering import CodegenState
 from .inductor_lowering import codegen_call_with_graph
-from .inductor_lowering import prepare_graph_lowerings
 from .loop_dependency_checker import LoopDependencyChecker
 from .matmul_utils import tensor_matmul_replacement
 from .matmul_utils import torch_matmul_replacement
-from .node_masking import remove_unnecessary_masking
 from .roll_reduction import ReductionRoller
 from .source_location import current_location
 from .type_propagation import CallableType
@@ -2037,56 +2034,6 @@ class WalkHostAST(NodeVisitor):
             self.current_phase_roots = []
 
 
-def _count_device_loads_and_stores(
-    device_ir: DeviceIR,
-) -> tuple[int, int, list[int]]:
-    """Count the number of load and store operations in device code for autotuning.
-
-    Returns:
-        tuple[int, int, list[int]]: (
-            total_load_count,
-            loads_without_eviction_policy,
-            store_indices,
-        )
-            - total_load_count: all loads (for indexing tunable)
-            - loads_without_eviction_policy: loads that need eviction policy tuning
-            - store_indices: positions of store ops in the combined indexing list
-    """
-    from ..language import memory_ops
-
-    total_load_count = 0
-    loads_without_eviction_policy = 0
-    memory_op_index = 0
-    store_indices: list[int] = []
-
-    for graph_info in device_ir.graphs:
-        for node in graph_info.graph.nodes:
-            if node.op == "call_function":
-                # Check if this is a load operation
-                if node.target is memory_ops.load:
-                    total_load_count += 1
-                    memory_op_index += 1
-                    # Check if this load needs eviction policy tuning
-                    # (user can still specify eviction_policy to override tuning)
-                    eviction_policy_arg = node.kwargs.get("eviction_policy")
-                    if eviction_policy_arg is None:
-                        # Check if eviction_policy was passed as positional arg (index 3)
-                        if len(node.args) >= 4:
-                            eviction_policy_arg = node.args[3]
-                        if eviction_policy_arg is None:
-                            loads_without_eviction_policy += 1
-                # Check if this is a store operation
-                elif node.target is memory_ops.store:
-                    store_indices.append(memory_op_index)
-                    memory_op_index += 1
-
-    return (
-        total_load_count,
-        loads_without_eviction_policy,
-        store_indices,
-    )
-
-
 def _indexing_uses_tensor_descriptor(
     indexing_config: object,
     op_index: int,
@@ -2099,184 +2046,6 @@ def _indexing_uses_tensor_descriptor(
             and indexing_config[op_index] == "tensor_descriptor"
         )
     return False
-
-
-def _count_device_atomics(device_ir: DeviceIR) -> int:
-    """Count the number of atomic operations in device code for autotuning."""
-    from ..language import atomic_ops
-
-    atomic_count = 0
-    for graph_info in device_ir.graphs:
-        for node in graph_info.graph.nodes:
-            if node.op == "call_function" and node.target in vars(atomic_ops).values():
-                atomic_count += 1
-    return atomic_count
-
-
-def _register_load_store_tunables(
-    total_load_count: int,
-    loads_without_eviction_policy: int,
-    store_indices: list[int],
-) -> None:
-    """Register list-based tunables (indexing, eviction policies) for all device loads and stores.
-
-    Args:
-        total_load_count: Total number of loads (for indexing tunable)
-        loads_without_eviction_policy: Number of loads that need eviction policy tuning
-        store_indices: Positions of store ops in the combined indexing list
-    """
-    store_count = len(store_indices)
-    env = CompileEnvironment.current()
-    env.config_spec.store_indices = store_indices
-    if total_load_count == 0 and store_count == 0:
-        return
-
-    from ..autotuner.config_fragment import EnumFragment
-    from ..autotuner.config_fragment import ListOf
-    from ..autotuner.config_spec import get_valid_eviction_policies
-
-    # Register eviction policies only for loads without explicit eviction_policy
-    if loads_without_eviction_policy > 0:
-        env.config_spec.load_eviction_policies = ListOf(
-            EnumFragment(choices=get_valid_eviction_policies(env.backend_name)),
-            length=loads_without_eviction_policy,
-        )
-
-    # Indexing applies to ALL loads and stores
-    total_count = total_load_count + store_count
-    if total_count > 0:
-        env.config_spec.indexing = ListOf(
-            EnumFragment(choices=env.config_spec.valid_indexing_types()),
-            length=total_count,
-        )
-
-
-def _register_atomic_tunables(atomic_count: int) -> None:
-    """Register atomic_indexing tunable for all atomic operations."""
-    if atomic_count == 0:
-        return
-
-    from ..autotuner.config_fragment import EnumFragment
-    from ..autotuner.config_fragment import ListOf
-
-    env = CompileEnvironment.current()
-    env.config_spec.atomic_indexing = ListOf(
-        EnumFragment(choices=env.config_spec.valid_atomic_indexing_types()),
-        length=atomic_count,
-    )
-
-
-def _register_tensor_descriptor_layout_guards(device_ir: DeviceIR) -> None:
-    env = CompileEnvironment.current()
-    if env.settings.static_shapes:
-        return
-
-    from .._compat import supports_tensor_descriptor
-    from ..language import atomic_ops
-    from ..language import memory_ops
-
-    if not supports_tensor_descriptor():
-        return
-
-    atomic_targets = tuple(getattr(atomic_ops, name) for name in atomic_ops.__all__)
-
-    def tensor_arg_value(arg: object) -> object:
-        if isinstance(arg, torch.fx.Node):
-            return arg.meta.get("val")
-        return arg
-
-    memory_op_index = 0
-    atomic_op_index = 0
-    for graph_info in device_ir.graphs:
-        for node in graph_info.graph.nodes:
-            if node.op != "call_function":
-                continue
-            if node.target in (memory_ops.load, memory_ops.store):
-                tensor = tensor_arg_value(node.args[0])
-                if isinstance(tensor, torch.Tensor) and 2 <= tensor.ndim <= 5:
-                    env.register_tensor_descriptor_layout_guard(
-                        tensor, memory_op_index=memory_op_index
-                    )
-                memory_op_index += 1
-                continue
-            if node.target in atomic_targets:
-                tensor = tensor_arg_value(node.args[0])
-                if isinstance(tensor, torch.Tensor) and 2 <= tensor.ndim <= 5:
-                    env.register_tensor_descriptor_layout_guard(
-                        tensor, atomic_op_index=atomic_op_index
-                    )
-                atomic_op_index += 1
-
-
-def lower_to_device_ir(func: HostFunction) -> DeviceIR:
-    device_ir = DeviceIR()
-    with func, device_ir, compile_lock:
-        visitor = WalkHostAST(device_ir)
-        for stmt in func.body:
-            visitor.visit(stmt)
-        visitor.flush_phases()
-        device_ir.phases = visitor.phases
-        # Run dependency checks once, per phase, so codegen does not redo it per-config.
-        for phase in device_ir.phases:
-            checker = phase.loop_dependency_checker
-            for loop_node in phase.root_nodes:
-                checker.register_loop(loop_node)
-        for phase_idx, phase in enumerate(device_ir.phases):
-            for ridx in phase.roots:
-                graph_info = device_ir.graphs[device_ir.root_ids[ridx]]
-                assert isinstance(graph_info, RootGraphInfo)
-                graph_info.phase_index = phase_idx
-        # If there are no top-level device loops, we cannot generate a valid kernel.
-        # Raise a friendly error instead of emitting an empty Triton function body.
-        if len(device_ir.root_ids) == 0:
-            raise exc.NoDeviceLoopsInKernel
-        from ..language.random_ops import rewrite_implicit_random_ops
-
-        for graph in device_ir.graphs:
-            rewrite_implicit_random_ops(graph.graph)
-        for graph in device_ir.graphs:
-            prepare_graph_lowerings(graph.graph)
-        for graph in device_ir.graphs:
-            validate_host_tensor_usage(graph.graph)
-            add_tile_with_offset_metadata(graph)
-            remove_unnecessary_tile_index(graph.graph)
-            remove_unnecessary_masking(graph.graph)
-
-        # TODO(hinriksnaer): extract into a separate step? everything below
-        # is post-processing computed from the completed DeviceIR.
-        from .epilogue_subtiling import has_epilogue_subtiling_candidate
-
-        has_epilogue_subtile_candidate = False
-        for graph_info in device_ir.graphs:
-            if has_epilogue_subtiling_candidate(graph_info.graph):
-                has_epilogue_subtile_candidate = True
-                break
-        config_spec = CompileEnvironment.current().config_spec
-        config_spec.epilogue_subtile_candidate_enabled = has_epilogue_subtile_candidate
-        config_spec.epilogue_subtile_k_hint = 0
-        config_spec.epilogue_subtile_autotune_choices = None
-
-        device_ir.register_rollable_reductions()
-        config_spec = CompileEnvironment.current().config_spec
-        config_spec.raise_grid_block_minimums()
-        if len(device_ir.root_ids) > 1:
-            config_spec.disallow_pid_type("xyz")
-
-        # Count all device loads and stores and register tunables
-        (
-            total_load_count,
-            loads_without_eviction_policy,
-            store_indices,
-        ) = _count_device_loads_and_stores(device_ir)
-        _register_load_store_tunables(
-            total_load_count,
-            loads_without_eviction_policy,
-            store_indices,
-        )
-        _register_atomic_tunables(_count_device_atomics(device_ir))
-        _register_tensor_descriptor_layout_guards(device_ir)
-
-        return device_ir
 
 
 @dataclasses.dataclass

--- a/helion/_compiler/device_ir_lowering.py
+++ b/helion/_compiler/device_ir_lowering.py
@@ -105,9 +105,6 @@ class DeviceIRLowering:
         device_ir.register_rollable_reductions()
         detect_epilogue_subtiling(device_ir)
         register_grid_and_pid_constraints(device_ir)
-        register_load_store_tunables(device_ir)
-        register_atomic_tunables(device_ir)
-        register_tensor_descriptor_layout_guards(device_ir)
 
 
 # ── Shared helpers ──────────────────────────────────────────────────

--- a/helion/_compiler/kernel_compiler.py
+++ b/helion/_compiler/kernel_compiler.py
@@ -14,7 +14,6 @@ from .._compile_time import measure
 from . import ast_extension
 from .host_function import HostFunction
 from .host_function import KernelDefinition
-from .tensor_utils import patch_tensor_factories
 
 if TYPE_CHECKING:
     import types
@@ -148,22 +147,8 @@ class KernelCompiler:
 
     def lower(self, hf: HostFunction) -> None:
         lowering = self.env.backend.get_device_ir_lowering()
-        if lowering is not None:
-            with measure("HostFunction.lower_to_device_ir"):
-                hf.device_ir = lowering.run(hf)
-        else:
-            from .device_ir import lower_to_device_ir
-
-            factory_padding = (
-                patch_tensor_factories()
-                if self.env.backend.pad_factory_tensors_to_power_of_2
-                else contextlib.nullcontext()
-            )
-            with (
-                measure("HostFunction.lower_to_device_ir"),
-                factory_padding,
-            ):
-                hf.device_ir = lower_to_device_ir(hf)
+        with measure("HostFunction.lower_to_device_ir"):
+            hf.device_ir = lowering.run(hf)
 
     @contextlib.contextmanager
     def _compilation_context(self) -> typing.Generator[None, None, None]:

--- a/helion/_compiler/metal/device_ir_lowering.py
+++ b/helion/_compiler/metal/device_ir_lowering.py
@@ -1,0 +1,30 @@
+"""Metal-specific device IR lowering pipeline."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..device_ir_lowering import DeviceIRLowering
+
+if TYPE_CHECKING:
+    from ..device_ir import DeviceIR
+    from ..host_function import HostFunction
+
+
+class MetalDeviceIRLowering(DeviceIRLowering):
+    """Metal-specific overrides for the device IR lowering pipeline."""
+
+    def trace(self, device_ir: DeviceIR, func: HostFunction) -> None:
+        super().trace(device_ir, func)
+
+    def transform(self, device_ir: DeviceIR, func: HostFunction) -> None:
+        super().transform(device_ir, func)
+
+    def lower(self, device_ir: DeviceIR) -> None:
+        super().lower(device_ir)
+
+    def optimize(self, device_ir: DeviceIR) -> None:
+        super().optimize(device_ir)
+
+    def register(self, device_ir: DeviceIR) -> None:
+        super().register(device_ir)

--- a/helion/_compiler/pallas/device_ir_lowering.py
+++ b/helion/_compiler/pallas/device_ir_lowering.py
@@ -1,0 +1,30 @@
+"""Pallas-specific device IR lowering pipeline."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..device_ir_lowering import DeviceIRLowering
+
+if TYPE_CHECKING:
+    from ..device_ir import DeviceIR
+    from ..host_function import HostFunction
+
+
+class PallasDeviceIRLowering(DeviceIRLowering):
+    """Pallas-specific overrides for the device IR lowering pipeline."""
+
+    def trace(self, device_ir: DeviceIR, func: HostFunction) -> None:
+        super().trace(device_ir, func)
+
+    def transform(self, device_ir: DeviceIR, func: HostFunction) -> None:
+        super().transform(device_ir, func)
+
+    def lower(self, device_ir: DeviceIR) -> None:
+        super().lower(device_ir)
+
+    def optimize(self, device_ir: DeviceIR) -> None:
+        super().optimize(device_ir)
+
+    def register(self, device_ir: DeviceIR) -> None:
+        super().register(device_ir)

--- a/helion/_compiler/triton/__init__.py
+++ b/helion/_compiler/triton/__init__.py
@@ -1,0 +1,3 @@
+"""Triton backend compilation passes."""
+
+from __future__ import annotations

--- a/helion/_compiler/triton/device_ir_lowering.py
+++ b/helion/_compiler/triton/device_ir_lowering.py
@@ -1,0 +1,41 @@
+"""Triton-specific device IR lowering pipeline."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..device_ir_lowering import DeviceIRLowering
+from ..device_ir_lowering import register_atomic_tunables
+from ..device_ir_lowering import register_load_store_tunables
+from ..device_ir_lowering import register_tensor_descriptor_layout_guards
+
+if TYPE_CHECKING:
+    from ..device_ir import DeviceIR
+    from ..host_function import HostFunction
+
+
+class TritonDeviceIRLowering(DeviceIRLowering):
+    """Triton-specific overrides for the device IR lowering pipeline.
+
+    Adds Triton-specific tunable registration: load/store eviction
+    policies and indexing types, atomic indexing types, and tensor
+    descriptor layout guards.
+    """
+
+    def trace(self, device_ir: DeviceIR, func: HostFunction) -> None:
+        super().trace(device_ir, func)
+
+    def transform(self, device_ir: DeviceIR, func: HostFunction) -> None:
+        super().transform(device_ir, func)
+
+    def lower(self, device_ir: DeviceIR) -> None:
+        super().lower(device_ir)
+
+    def optimize(self, device_ir: DeviceIR) -> None:
+        super().optimize(device_ir)
+
+    def register(self, device_ir: DeviceIR) -> None:
+        super().register(device_ir)
+        register_load_store_tunables(device_ir)
+        register_atomic_tunables(device_ir)
+        register_tensor_descriptor_layout_guards(device_ir)


### PR DESCRIPTION
Stacked PRs:
 * __->__#2658
 * #2613
 * #2612


--- --- ---

### [compile] Migrate all backends to DeviceIRLowering. Remove legacy path


Create dedicated DeviceIRLowering subclasses for Triton, Pallas, and
Metal. Move Triton-specific tunable registration from the base
DeviceIRLowering. Remove the legacy path.
