### PR TITLE
[Autotuner] Clear JIT fast-path caches during rebenchmarking

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -33,6 +33,7 @@ from .benchmark_provider import BenchmarkResult
 from .benchmark_provider import LocalBenchmarkProvider
 from .benchmark_provider import _clone_args
 from .benchmark_provider import _unset_fn
+from .benchmarking import clear_jit_fast_path_caches
 from .benchmarking import interleaved_bench
 from .logger import AutotuningLogger
 from .metrics import AutotuneMetrics
@@ -995,7 +996,19 @@ class PopulationBasedSearch(BaseSearch):
             )
         else:
             benchmark_args = self.args
-        iterator = [functools.partial(m.fn, *benchmark_args) for m in members]
+
+        def make_rebenchmark_callable(member: PopulationMember) -> Callable[[], object]:
+            run_member = functools.partial(member.fn, *benchmark_args)
+
+            def wrapped() -> object:
+                try:
+                    return run_member()
+                finally:
+                    clear_jit_fast_path_caches(member.fn, self.log)
+
+            return wrapped
+
+        iterator = [make_rebenchmark_callable(m) for m in members]
         _backend = getattr(getattr(self, "config_spec", None), "backend", None)
         interleaved_benchmark = (
             _backend.get_interleaved_bench() if _backend is not None else None
@@ -1003,10 +1016,14 @@ class PopulationBasedSearch(BaseSearch):
         benchmark_function: Callable[..., list[float]] = (
             self.settings.autotune_benchmark_fn or interleaved_benchmark
         )
-        if self.settings.autotune_progress_bar:
-            new_timings = benchmark_function(iterator, repeat=repeat, desc=desc)
-        else:
-            new_timings = benchmark_function(iterator, repeat=repeat)
+        try:
+            if self.settings.autotune_progress_bar:
+                new_timings = benchmark_function(iterator, repeat=repeat, desc=desc)
+            else:
+                new_timings = benchmark_function(iterator, repeat=repeat)
+        finally:
+            for m in members:
+                clear_jit_fast_path_caches(m.fn, self.log)
         new_timings = self._confirm_suspicious_rebenchmark_timings(
             members,
             new_timings,

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -30,6 +30,7 @@ from ..runtime.precompile_shim import make_precompiler
 from .benchmark_job import BenchmarkJob
 from .benchmark_worker import BenchmarkSubprocessError
 from .benchmark_worker import BenchmarkWorker
+from .benchmarking import clear_jit_fast_path_caches
 from .benchmarking import do_bench
 from .benchmarking import do_bench_generic
 from .benchmarking import synchronize_device
@@ -876,17 +877,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         remain pinned in GPU memory by its _last_call cache across config
         benchmarks.
         """
-        try:
-            fn_name = getattr(fn, "__name__", None)
-            fn_globals = getattr(fn, "__globals__", None)
-            if fn_name is None or fn_globals is None:
-                return
-            triton_jit_fn = fn_globals.get(f"_helion_{fn_name}")
-            clear = getattr(triton_jit_fn, "clear_fast_path_caches", None)
-            if clear is not None:
-                clear()
-        except Exception:
-            self.log.debug("Failed to clear Triton JIT fast-path cache.", exc_info=True)
+        clear_jit_fast_path_caches(fn, self.log)
 
     def _benchmark_function(self, config: Config, fn: CompiledConfig) -> float:
         """Benchmark a single compiled function.  Returns time in ms or inf."""

--- a/helion/autotuner/benchmarking.py
+++ b/helion/autotuner/benchmarking.py
@@ -5,6 +5,7 @@ import logging
 import math
 import statistics
 import time
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import TypeVar
@@ -16,6 +17,9 @@ from ..runtime.settings import _get_backend
 from ..runtime.settings import is_pallas_interpret
 from .progress_bar import iter_with_progress
 from helion._dist_utils import sync_object
+
+if TYPE_CHECKING:
+    from .logger import AutotuningLogger
 
 T = TypeVar("T")
 
@@ -69,6 +73,25 @@ def _maybe_cudagraph_replay(
     except Exception:
         _log.debug("CUDA graph benchmark capture failed; falling back", exc_info=True)
         return fn
+
+
+def clear_jit_fast_path_caches(
+    fn: Callable[..., object],
+    log: logging.Logger | AutotuningLogger | None = None,
+) -> None:
+    """Clear Triton JIT fast-path caches for a generated Helion wrapper."""
+    try:
+        fn_name = getattr(fn, "__name__", None)
+        fn_globals = getattr(fn, "__globals__", None)
+        if fn_name is None or fn_globals is None:
+            return
+        triton_jit_fn = fn_globals.get(f"_helion_{fn_name}")
+        clear = getattr(triton_jit_fn, "clear_fast_path_caches", None)
+        if clear is not None:
+            clear()
+    except Exception:
+        if log is not None:
+            log.debug("Failed to clear Triton JIT fast-path cache.", exc_info=True)
 
 
 def _get_tpu_tensors(result: object) -> list[torch.Tensor]:

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -49,6 +49,7 @@ from helion.autotuner import LFBOPatternSearch
 from helion.autotuner import LFBOTreeSearch
 from helion.autotuner import PatternSearch
 from helion.autotuner.base_search import BaseSearch
+from helion.autotuner.base_search import PopulationBasedSearch
 from helion.autotuner.base_search import PopulationMember
 from helion.autotuner.benchmark_provider import LocalBenchmarkProvider
 from helion.autotuner.config_fragment import BooleanFragment
@@ -2281,6 +2282,72 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         )
         # Should have been called with 2 functions
         self.assertEqual(benchmark_calls[0][0], 2)
+
+    def test_rebenchmark_clears_jit_fast_path_caches(self) -> None:
+        settings = Settings(
+            autotune_log_level=logging.CRITICAL,
+            autotune_suspicious_rebenchmark_ratio=0,
+        )
+        search = PopulationBasedSearch.__new__(PopulationBasedSearch)
+        search.settings = settings
+        search.args = ()
+        search.log = AutotuningLogger(settings)
+        search.best_perf_so_far = 100.0
+        search.benchmark_provider = SimpleNamespace(mutated_arg_indices=[])
+        search.kernel = SimpleNamespace(env=SimpleNamespace(process_group_name=None))
+        search.config_spec = SimpleNamespace(backend=None)
+        events: list[str] = []
+
+        class FakeJITFunction:
+            def __init__(self, name: str) -> None:
+                self.name = name
+
+            def clear_fast_path_caches(self) -> None:
+                events.append(f"clear {self.name}")
+
+        def generated_kernel_a() -> None:
+            events.append("run a")
+
+        def generated_kernel_b() -> None:
+            events.append("run b")
+
+        globals_key_a = f"_helion_{generated_kernel_a.__name__}"
+        globals_key_b = f"_helion_{generated_kernel_b.__name__}"
+        generated_kernel_a.__globals__[globals_key_a] = FakeJITFunction("a")
+        generated_kernel_b.__globals__[globals_key_b] = FakeJITFunction("b")
+
+        def custom_benchmark_fn(
+            fns: list[Callable[[], object]], *, repeat: int, desc: str | None = None
+        ) -> list[float]:
+            for _ in range(2):
+                for fn in fns:
+                    fn()
+            return [100.0, 101.0]
+
+        search.settings.autotune_benchmark_fn = custom_benchmark_fn
+        member_a = PopulationMember(generated_kernel_a, [100.0], [], helion.Config())
+        member_b = PopulationMember(generated_kernel_b, [101.0], [], helion.Config())
+        try:
+            search.rebenchmark([member_a, member_b])
+        finally:
+            del generated_kernel_a.__globals__[globals_key_a]
+            del generated_kernel_b.__globals__[globals_key_b]
+
+        self.assertEqual(
+            events,
+            [
+                "run a",
+                "clear a",
+                "run b",
+                "clear b",
+                "run a",
+                "clear a",
+                "run b",
+                "clear b",
+                "clear a",
+                "clear b",
+            ],
+        )
 
     def test_autotune_configuration_cloning(self) -> None:
         """Tests base_search._clone_args function."""


### PR DESCRIPTION
#2367 cleared triton jit fast-path during benchmarking, but we still observed OOM errors due to rebenchmarking. This PR clears Triton JIT fast-path caches during autotuner rebenchmarking, matching the cleanup already done after normal benchmark runs.

This prevents generated Helion wrapper calls from leaving tensors pinned through Triton `_last_call` fast-path state across repeated rebenchmark invocations.

  - Added a shared `clear_jit_fast_path_caches()` helper.
  - Reused the helper in `LocalBenchmarkProvider`.
  - Wrapped rebenchmark callables so caches are cleared after each invocation, with a final cleanup guard.
  - Added regression coverage for rebenchmark cleanup.