### PR TITLE
Don't roll reductions over hl.arange dims into loops

### DIFF
--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -811,13 +811,17 @@ class DeviceIR:
             graph_to_info: dict[int, RolledReductionInfo] = {}
             allow_loop = False
 
-            # Check if any graph contains matmul or dev_prts stacking with rdim
+            # Check if any graph contains matmul or dev_prts stacking with
+            # rdim, or reduces over rdim along a non-tile (hl.arange) axis
+            # that cannot be sliced inside the reduction loop.
             can_roll_graphs = True
             for graph_info in self.graphs[:num_original_graphs]:
                 roller = ReductionRoller(self, rdim, {})
-                if roller.has_matmul_with_rdim(
-                    graph_info.graph
-                ) or roller.has_stack_tensor_with_rdim(graph_info.graph):
+                if (
+                    roller.has_matmul_with_rdim(graph_info.graph)
+                    or roller.has_stack_tensor_with_rdim(graph_info.graph)
+                    or roller.has_unrollable_reduction(graph_info.graph)
+                ):
                     can_roll_graphs = False
                     break
 

--- a/helion/_compiler/roll_reduction.py
+++ b/helion/_compiler/roll_reduction.py
@@ -22,6 +22,7 @@ from ..language._tracing_ops import _if
 from ..language._tracing_ops import is_for_loop_target
 from ..language.matmul_ops import dot as hl_dot
 from ..language.matmul_ops import dot_scaled as hl_dot_scaled
+from ..language.memory_ops import load
 from ..language.memory_ops import store
 from ..language.reduce_ops import _reduce
 from ..language.view_ops import join as hl_join
@@ -394,6 +395,69 @@ class ReductionRoller:
             return False
 
         return any(is_matmul_with_rdim(node) for node in graph.nodes)
+
+    def has_unrollable_reduction(self, graph: torch.fx.Graph) -> bool:
+        """Check if a graph reduces over the rdim along a non-tile axis.
+
+        A reduction can only be rolled into a loop when the dimension being
+        reduced is indexed by a re-bindable block index var (e.g. a ``hl.tile``
+        axis or a ``[..., :]`` slice), so the producing load can be re-indexed
+        in ``_REDUCTION_BLOCK``-sized chunks inside the loop. A dimension
+        indexed by ``hl.arange(n)`` instead carries a fixed full-extent
+        ``iota`` index that cannot be re-bound per loop iteration, so rolling
+        would leave the full-extent load outside the loop and emit a shape
+        mismatch (issue #2643). Such reductions must stay persistent.
+
+        Detected by walking back from each reduction over ``self.rdim`` to the
+        loads feeding it and checking whether any is indexed by an ``iota``
+        node sized to the rdim. The output-shape of the load is not a reliable
+        signal: when the arange size coincides with another reduction of the
+        same size, ``allocate_reduction_dimension`` unifies them and the load
+        axis surfaces as the rdim symbol rather than a concrete int.
+        """
+        env = CompileEnvironment.current()
+        rdim_block_id = self.rdim.block_id
+
+        def is_rdim_iota(node: object) -> bool:
+            if not (
+                isinstance(node, torch.fx.Node)
+                and node.op == "call_function"
+                and node.target is torch.ops.prims.iota.default
+            ):
+                return False
+            val = node.meta.get("val", None)
+            return isinstance(val, torch.Tensor) and any(
+                env.resolve_block_id(size) == rdim_block_id for size in val.size()
+            )
+
+        def is_iota_indexed_load(node: torch.fx.Node) -> bool:
+            if node.target is not load:
+                return False
+            # load(tensor, index_list, ...): an iota in the index list cannot
+            # be re-indexed in chunks inside the reduction loop.
+            for arg in node.args:
+                entries = arg if isinstance(arg, (list, tuple)) else (arg,)
+                if any(is_rdim_iota(entry) for entry in entries):
+                    return True
+            return False
+
+        def depends_on_iota_indexed_load(reduction: torch.fx.Node) -> bool:
+            seen: set[torch.fx.Node] = set()
+            stack = list(reduction.all_input_nodes)
+            while stack:
+                node = stack.pop()
+                if node in seen:
+                    continue
+                seen.add(node)
+                if node.op == "call_function" and is_iota_indexed_load(node):
+                    return True
+                stack.extend(node.all_input_nodes)
+            return False
+
+        return any(
+            self.is_reduction(node) and depends_on_iota_indexed_load(node)
+            for node in graph.nodes
+        )
 
     def has_stack_tensor_with_rdim(self, graph: torch.fx.Graph) -> bool:
         """Check if a graph contains stack tensors with rdim inputs."""

--- a/test/test_barrier.py
+++ b/test/test_barrier.py
@@ -239,6 +239,9 @@ class TestBarrier(RefEagerTestBase, TestCase):
             def has_stack_tensor_with_rdim(self, graph: torch.fx.Graph) -> bool:
                 return False
 
+            def has_unrollable_reduction(self, graph: torch.fx.Graph) -> bool:
+                return False
+
             def process(self, graph: torch.fx.Graph) -> torch.fx.Graph:
                 reduction_graph = torch.fx.Graph()
                 reduction_graph.output(())

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -414,6 +414,84 @@ class TestReductions(RefEagerTestBase, TestCase):
             layer_norm_reduction, args, block_size=32, reduction_loop=4
         )
 
+    def test_reduction_over_arange_dim_stays_persistent(self):
+        """Issue #2643: a reduction over an ``hl.arange()`` axis must not be
+        registered as a rollable (looped) reduction.
+
+        The arange axis is a concrete size with no block index var to re-bind
+        per loop iteration, so the producing load cannot be sliced inside the
+        reduction loop. Rolling it emitted a shape mismatch during codegen, so
+        the autotuner must never offer a ``reduction_loop`` for it -- the
+        reduction stays persistent.
+        """
+
+        @helion.kernel(static_shapes=True)
+        def rms_over_arange(qkv: torch.Tensor) -> torch.Tensor:
+            num_tokens, qk_heads, head_dim = qkv.shape
+            out = torch.empty(
+                [num_tokens, qk_heads], dtype=torch.float32, device=qkv.device
+            )
+            for tile_m, tile_gn in hl.tile(
+                [num_tokens, qk_heads], block_size=[1, None]
+            ):
+                tile_n = hl.arange(head_dim)
+                x_blk = qkv[tile_m, tile_gn, tile_n].to(dtype=torch.float32)
+                out[tile_m, tile_gn] = x_blk.pow(2).sum(dim=-1)
+            return out
+
+        qkv = torch.randn([64, 8, 128], device=DEVICE, dtype=HALF_DTYPE)
+
+        # The arange reduction axis must not be offered as a looped reduction,
+        # otherwise the autotuner could pick a reduction_loop value that
+        # produced a shape mismatch (issue #2643).
+        bound = rms_over_arange.bind((qkv,))
+        self.assertEqual(bound.env.config_spec.reduction_loops.valid_block_ids(), [])
+
+        _code, output = code_and_output(rms_over_arange, (qkv,))
+        expected = qkv.to(torch.float32).pow(2).sum(dim=-1)
+        torch.testing.assert_close(output, expected, rtol=1e-2, atol=1e-2)
+
+    def test_reduction_over_arange_dim_size_coincides_with_slice(self):
+        """Issue #2643 variant: an ``hl.arange()`` reduction whose size
+        coincides with a slice reduction of the same size in the same loop.
+
+        ``allocate_reduction_dimension`` unifies the two same-size reduction
+        dimensions, so the arange load's reduced axis surfaces as the rdim
+        symbol (not a concrete int) and an output-shape check would be fooled
+        into thinking it is rollable. The arange axis is still indexed by an
+        ``iota`` node that cannot be re-indexed inside a reduction loop, so the
+        reduction must stay persistent.
+        """
+
+        @helion.kernel(static_shapes=True)
+        def mixed(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.shape
+            out = torch.empty([m], dtype=torch.float32, device=x.device)
+            for tile_m in hl.tile(m):
+                slice_sum = x[tile_m, :].to(torch.float32).sum(-1)
+                tile_n = hl.arange(n)
+                arange_sum = x[tile_m, tile_n].to(torch.float32).pow(2).sum(-1)
+                out[tile_m] = slice_sum + arange_sum
+            return out
+
+        x = torch.randn([64, 128], device=DEVICE, dtype=HALF_DTYPE)
+
+        # The unified rdim must not be offered as a looped reduction: rolling
+        # it cannot re-index the iota-indexed arange load (issue #2643). This
+        # registration check is backend-agnostic.
+        bound = mixed.bind((x,))
+        self.assertEqual(bound.env.config_spec.reduction_loops.valid_block_ids(), [])
+
+        # Issue #2643 is a Triton rolling bug; the persistent fallback computes
+        # correctly there. CuTe lowers hl.arange reductions via a thread-layout
+        # warp-reduction path (unaffected by rolling) that has a separate
+        # limitation when an arange reduction is combined with a slice reduction
+        # over the same dim, so only run the numeric check on Triton.
+        if _get_backend() == "triton":
+            _code, output = code_and_output(mixed, (x,))
+            expected = x.to(torch.float32).sum(-1) + x.to(torch.float32).pow(2).sum(-1)
+            torch.testing.assert_close(output, expected, rtol=1e-2, atol=1e-2)
+
     def test_fp16_var_mean(self):
         @helion.kernel(static_shapes=True)
         def layer_norm_fwd_repro(


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2674
 * #2673
 * #2670
 * #2669
 * #2668
 * #2667
 * #2666
 * #2665
 * #2662
 * __->__#2660


--- --- ---

Don't roll reductions over hl.arange dims into loops

A reduction over a dimension created by hl.arange(n) (e.g.
`x[tile_m, hl.arange(n)].sum(-1)`) was registered as a rollable reduction,
so the autotuner could pick a reduction_loops value. When it did, codegen
left the full-extent iota load (tl.arange(0, n)) outside the reduction loop
while the accumulator was only _REDUCTION_BLOCK wide, producing a Triton
ShapeMismatch.

A reduction can only be rolled when the reduced dimension is indexed by a
re-bindable block index var (a hl.tile axis or a `[..., :]` slice), so the
producing load can be re-indexed in _REDUCTION_BLOCK-sized chunks inside the
loop. An hl.arange index is a fixed iota node that cannot be re-bound per
iteration.

Add ReductionRoller.has_unrollable_reduction(), used as a pre-check in
register_rollable_reductions() alongside the existing matmul/stack checks.
It walks back from each reduction over the rdim to the loads feeding it and,
if any is indexed by an iota node sized to the rdim, leaves the reduction
unregistered so it stays persistent (which already works correctly).

The check inspects the iota index node rather than the load's output shape:
when an arange size coincides with another reduction of the same size,
allocate_reduction_dimension unifies them and the load axis surfaces as the
rdim symbol rather than a concrete int, which an output-shape check would
miss.

Fixes #2643