### PR TITLE
Fix CuTe synthetic-lane persistent reductions

### DIFF
--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -811,13 +811,17 @@ class DeviceIR:
             graph_to_info: dict[int, RolledReductionInfo] = {}
             allow_loop = False
 
-            # Check if any graph contains matmul or dev_prts stacking with rdim
+            # Check if any graph contains matmul or dev_prts stacking with
+            # rdim, or reduces over rdim along a non-tile (hl.arange) axis
+            # that cannot be sliced inside the reduction loop.
             can_roll_graphs = True
             for graph_info in self.graphs[:num_original_graphs]:
                 roller = ReductionRoller(self, rdim, {})
-                if roller.has_matmul_with_rdim(
-                    graph_info.graph
-                ) or roller.has_stack_tensor_with_rdim(graph_info.graph):
+                if (
+                    roller.has_matmul_with_rdim(graph_info.graph)
+                    or roller.has_stack_tensor_with_rdim(graph_info.graph)
+                    or roller.has_unrollable_reduction(graph_info.graph)
+                ):
                     can_roll_graphs = False
                     break
 

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -525,6 +525,21 @@ class PersistentReductionStrategy(ReductionStrategy):
             lane_extent = env.backend.create_synthetic_reduction_lanes(
                 self._thread_count, size_hint
             )
+            # When the reduction extent exceeds the live thread count a
+            # synthetic lane loop serializes the excess and codegen_reduction
+            # folds each lane into a per-thread accumulator. The cross-thread
+            # combine then runs as a single warp reduction inside that loop,
+            # which is only correct within one warp -- the cross-warp two-stage
+            # path is incompatible with the lane loop. Cap the thread count to
+            # the warp size so the per-lane warp reduction stays correct; the
+            # lane loop grows to cover the rest (issue #2643).
+            if lane_extent is not None and (
+                self._thread_count > _CUTE_WARP_REDUCTION_THREADS
+            ):
+                self._thread_count = _CUTE_WARP_REDUCTION_THREADS
+                lane_extent = env.backend.create_synthetic_reduction_lanes(
+                    self._thread_count, size_hint
+                )
             if lane_extent is not None:
                 self._synthetic_cute_lane_var = fn.new_var(
                     f"synthetic_lane_{block_index}",
@@ -716,9 +731,37 @@ class PersistentReductionStrategy(ReductionStrategy):
             )
         acc_dtype = get_computation_dtype(fake_input.dtype)
         default = ir.Reduction.default_accumulator(reduction_type, acc_dtype)
+        reduce_input = input_name
+        if (
+            self._synthetic_cute_lane_var is not None
+            and isinstance(default, (float, int, bool))
+            and not backend.is_indexed_reduction(reduction_type)
+        ):
+            # Synthetic-lane persistent reduction (CuTe): the reduction extent
+            # exceeds the live thread count, so the reduction body runs inside
+            # a synthetic lane loop (see codegen_preamble) that wraps the whole
+            # device body. Carry a per-thread accumulator across lanes -- init
+            # it before the loop and fold each lane's value in -- so the warp
+            # reduction on the final lane sees every element. Without this the
+            # warp reduction would only combine the last lane's slice and drop
+            # the rest, silently returning a wrong result (issue #2643).
+            current_grid = state.codegen.current_grid_state
+            assert isinstance(current_grid, DeviceGridState)
+            assert state.fx_node is not None
+            shape_dims = self.fn.tile_strategy.shape_dims([*fake_input.size()])
+            acc = self.fn.new_var(f"{state.fx_node.name}_acc", dce=True)
+            current_grid.outer_prefix.append(
+                statement_from_string(
+                    f"{acc} = {backend.full_expr(shape_dims, constant_repr(default), acc_dtype)}"
+                )
+            )
+            state.add_statement(
+                f"{acc} = {backend.reduction_combine_expr(reduction_type, acc, input_name, acc_dtype)}"
+            )
+            reduce_input = acc
         if isinstance(default, (float, int, bool)):
             cross_warp = self._cute_cross_warp_reduction_expr(
-                state, input_name, reduction_type, default, acc_dtype
+                state, reduce_input, reduction_type, default, acc_dtype
             )
         else:
             cross_warp = None
@@ -726,7 +769,7 @@ class PersistentReductionStrategy(ReductionStrategy):
             expr = cross_warp
         else:
             expr = self.call_reduction_function(
-                input_name,
+                reduce_input,
                 reduction_type,
                 dim,
                 fake_input,

--- a/helion/_compiler/roll_reduction.py
+++ b/helion/_compiler/roll_reduction.py
@@ -22,6 +22,7 @@ from ..language._tracing_ops import _if
 from ..language._tracing_ops import is_for_loop_target
 from ..language.matmul_ops import dot as hl_dot
 from ..language.matmul_ops import dot_scaled as hl_dot_scaled
+from ..language.memory_ops import load
 from ..language.memory_ops import store
 from ..language.reduce_ops import _reduce
 from ..language.view_ops import join as hl_join
@@ -394,6 +395,69 @@ class ReductionRoller:
             return False
 
         return any(is_matmul_with_rdim(node) for node in graph.nodes)
+
+    def has_unrollable_reduction(self, graph: torch.fx.Graph) -> bool:
+        """Check if a graph reduces over the rdim along a non-tile axis.
+
+        A reduction can only be rolled into a loop when the dimension being
+        reduced is indexed by a re-bindable block index var (e.g. a ``hl.tile``
+        axis or a ``[..., :]`` slice), so the producing load can be re-indexed
+        in ``_REDUCTION_BLOCK``-sized chunks inside the loop. A dimension
+        indexed by ``hl.arange(n)`` instead carries a fixed full-extent
+        ``iota`` index that cannot be re-bound per loop iteration, so rolling
+        would leave the full-extent load outside the loop and emit a shape
+        mismatch (issue #2643). Such reductions must stay persistent.
+
+        Detected by walking back from each reduction over ``self.rdim`` to the
+        loads feeding it and checking whether any is indexed by an ``iota``
+        node sized to the rdim. The output-shape of the load is not a reliable
+        signal: when the arange size coincides with another reduction of the
+        same size, ``allocate_reduction_dimension`` unifies them and the load
+        axis surfaces as the rdim symbol rather than a concrete int.
+        """
+        env = CompileEnvironment.current()
+        rdim_block_id = self.rdim.block_id
+
+        def is_rdim_iota(node: object) -> bool:
+            if not (
+                isinstance(node, torch.fx.Node)
+                and node.op == "call_function"
+                and node.target is torch.ops.prims.iota.default
+            ):
+                return False
+            val = node.meta.get("val", None)
+            return isinstance(val, torch.Tensor) and any(
+                env.resolve_block_id(size) == rdim_block_id for size in val.size()
+            )
+
+        def is_iota_indexed_load(node: torch.fx.Node) -> bool:
+            if node.target is not load:
+                return False
+            # load(tensor, index_list, ...): an iota in the index list cannot
+            # be re-indexed in chunks inside the reduction loop.
+            for arg in node.args:
+                entries = arg if isinstance(arg, (list, tuple)) else (arg,)
+                if any(is_rdim_iota(entry) for entry in entries):
+                    return True
+            return False
+
+        def depends_on_iota_indexed_load(reduction: torch.fx.Node) -> bool:
+            seen: set[torch.fx.Node] = set()
+            stack = list(reduction.all_input_nodes)
+            while stack:
+                node = stack.pop()
+                if node in seen:
+                    continue
+                seen.add(node)
+                if node.op == "call_function" and is_iota_indexed_load(node):
+                    return True
+                stack.extend(node.all_input_nodes)
+            return False
+
+        return any(
+            self.is_reduction(node) and depends_on_iota_indexed_load(node)
+            for node in graph.nodes
+        )
 
     def has_stack_tensor_with_rdim(self, graph: torch.fx.Graph) -> bool:
         """Check if a graph contains stack tensors with rdim inputs."""

--- a/test/test_barrier.py
+++ b/test/test_barrier.py
@@ -239,6 +239,9 @@ class TestBarrier(RefEagerTestBase, TestCase):
             def has_stack_tensor_with_rdim(self, graph: torch.fx.Graph) -> bool:
                 return False
 
+            def has_unrollable_reduction(self, graph: torch.fx.Graph) -> bool:
+                return False
+
             def process(self, graph: torch.fx.Graph) -> torch.fx.Graph:
                 reduction_graph = torch.fx.Graph()
                 reduction_graph.output(())

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -478,20 +478,39 @@ class TestReductions(RefEagerTestBase, TestCase):
         x = torch.randn([64, 128], device=DEVICE, dtype=HALF_DTYPE)
 
         # The unified rdim must not be offered as a looped reduction: rolling
-        # it cannot re-index the iota-indexed arange load (issue #2643). This
-        # registration check is backend-agnostic.
+        # it cannot re-index the iota-indexed arange load (issue #2643).
         bound = mixed.bind((x,))
         self.assertEqual(bound.env.config_spec.reduction_loops.valid_block_ids(), [])
 
-        # Issue #2643 is a Triton rolling bug; the persistent fallback computes
-        # correctly there. CuTe lowers hl.arange reductions via a thread-layout
-        # warp-reduction path (unaffected by rolling) that has a separate
-        # limitation when an arange reduction is combined with a slice reduction
-        # over the same dim, so only run the numeric check on Triton.
-        if _get_backend() == "triton":
-            _code, output = code_and_output(mixed, (x,))
-            expected = x.to(torch.float32).sum(-1) + x.to(torch.float32).pow(2).sum(-1)
-            torch.testing.assert_close(output, expected, rtol=1e-2, atol=1e-2)
+        _code, output = code_and_output(mixed, (x,))
+        expected = x.to(torch.float32).sum(-1) + x.to(torch.float32).pow(2).sum(-1)
+        torch.testing.assert_close(output, expected, rtol=1e-2, atol=1e-2)
+
+    def test_arange_reduction_with_synthetic_lanes(self):
+        """A persistent ``hl.arange()`` reduction whose extent exceeds the live
+        thread count must accumulate across synthetic lanes.
+
+        On CuTe, when the reduction extent is wider than the threads available
+        for it, the body runs inside a synthetic lane loop. The per-thread
+        value must be carried across lanes so the final warp reduction sees
+        every element; otherwise only the last lane's slice is reduced and the
+        result is silently wrong (issue #2643). ``block_size=16`` splits the
+        CuTe thread budget so the 128-wide reduction needs that lane loop.
+        """
+
+        @helion.kernel(static_shapes=True)
+        def arange_reduce(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.shape
+            out = torch.empty([m], dtype=torch.float32, device=x.device)
+            for tile_m in hl.tile(m):
+                tile_n = hl.arange(n)
+                out[tile_m] = x[tile_m, tile_n].to(torch.float32).pow(2).sum(-1)
+            return out
+
+        x = torch.randn([64, 128], device=DEVICE, dtype=HALF_DTYPE)
+        _code, output = code_and_output(arange_reduce, (x,), block_size=16)
+        expected = x.to(torch.float32).pow(2).sum(-1)
+        torch.testing.assert_close(output, expected, rtol=1e-2, atol=1e-2)
 
     def test_fp16_var_mean(self):
         @helion.kernel(static_shapes=True)

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -415,6 +415,84 @@ class TestReductions(RefEagerTestBase, TestCase):
             layer_norm_reduction, args, block_size=32, reduction_loop=4
         )
 
+    def test_reduction_over_arange_dim_stays_persistent(self):
+        """Issue #2643: a reduction over an ``hl.arange()`` axis must not be
+        registered as a rollable (looped) reduction.
+
+        The arange axis is a concrete size with no block index var to re-bind
+        per loop iteration, so the producing load cannot be sliced inside the
+        reduction loop. Rolling it emitted a shape mismatch during codegen, so
+        the autotuner must never offer a ``reduction_loop`` for it -- the
+        reduction stays persistent.
+        """
+
+        @helion.kernel(static_shapes=True)
+        def rms_over_arange(qkv: torch.Tensor) -> torch.Tensor:
+            num_tokens, qk_heads, head_dim = qkv.shape
+            out = torch.empty(
+                [num_tokens, qk_heads], dtype=torch.float32, device=qkv.device
+            )
+            for tile_m, tile_gn in hl.tile(
+                [num_tokens, qk_heads], block_size=[1, None]
+            ):
+                tile_n = hl.arange(head_dim)
+                x_blk = qkv[tile_m, tile_gn, tile_n].to(dtype=torch.float32)
+                out[tile_m, tile_gn] = x_blk.pow(2).sum(dim=-1)
+            return out
+
+        qkv = torch.randn([64, 8, 128], device=DEVICE, dtype=HALF_DTYPE)
+
+        # The arange reduction axis must not be offered as a looped reduction,
+        # otherwise the autotuner could pick a reduction_loop value that
+        # produced a shape mismatch (issue #2643).
+        bound = rms_over_arange.bind((qkv,))
+        self.assertEqual(bound.env.config_spec.reduction_loops.valid_block_ids(), [])
+
+        _code, output = code_and_output(rms_over_arange, (qkv,))
+        expected = qkv.to(torch.float32).pow(2).sum(dim=-1)
+        torch.testing.assert_close(output, expected, rtol=1e-2, atol=1e-2)
+
+    def test_reduction_over_arange_dim_size_coincides_with_slice(self):
+        """Issue #2643 variant: an ``hl.arange()`` reduction whose size
+        coincides with a slice reduction of the same size in the same loop.
+
+        ``allocate_reduction_dimension`` unifies the two same-size reduction
+        dimensions, so the arange load's reduced axis surfaces as the rdim
+        symbol (not a concrete int) and an output-shape check would be fooled
+        into thinking it is rollable. The arange axis is still indexed by an
+        ``iota`` node that cannot be re-indexed inside a reduction loop, so the
+        reduction must stay persistent.
+        """
+
+        @helion.kernel(static_shapes=True)
+        def mixed(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.shape
+            out = torch.empty([m], dtype=torch.float32, device=x.device)
+            for tile_m in hl.tile(m):
+                slice_sum = x[tile_m, :].to(torch.float32).sum(-1)
+                tile_n = hl.arange(n)
+                arange_sum = x[tile_m, tile_n].to(torch.float32).pow(2).sum(-1)
+                out[tile_m] = slice_sum + arange_sum
+            return out
+
+        x = torch.randn([64, 128], device=DEVICE, dtype=HALF_DTYPE)
+
+        # The unified rdim must not be offered as a looped reduction: rolling
+        # it cannot re-index the iota-indexed arange load (issue #2643). This
+        # registration check is backend-agnostic.
+        bound = mixed.bind((x,))
+        self.assertEqual(bound.env.config_spec.reduction_loops.valid_block_ids(), [])
+
+        # Issue #2643 is a Triton rolling bug; the persistent fallback computes
+        # correctly there. CuTe lowers hl.arange reductions via a thread-layout
+        # warp-reduction path (unaffected by rolling) that has a separate
+        # limitation when an arange reduction is combined with a slice reduction
+        # over the same dim, so only run the numeric check on Triton.
+        if _get_backend() == "triton":
+            _code, output = code_and_output(mixed, (x,))
+            expected = x.to(torch.float32).sum(-1) + x.to(torch.float32).pow(2).sum(-1)
+            torch.testing.assert_close(output, expected, rtol=1e-2, atol=1e-2)
+
     def test_fp16_var_mean(self):
         @helion.kernel(static_shapes=True)
         def layer_norm_fwd_repro(


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * __->__#2661
 * #2660


--- --- ---

Fix CuTe synthetic-lane persistent reductions

A persistent reduction whose extent exceeds the live thread count runs its
body inside a synthetic lane loop on CuTe (each thread processes several
elements across lane iterations). The reduction codegen emitted the warp
reduction with no cross-lane accumulation, so only the final lane's slice was
reduced and the rest was silently dropped -- e.g. a 128-wide reduction with
64 threads returned the sum of only 64 elements. This surfaced once arange
reductions were forced persistent (previous commit), but affects any
persistent reduction that needs synthetic lanes.

Two parts:
- codegen_reduction: when synthetic lanes are present, carry a per-thread
  accumulator across lanes (init in the grid loop's outer_prefix, fold each
  lane in) and feed it to the warp reduction. The warp reduction stays inside
  the lane loop; the final lane holds the complete accumulator, so the result
  it stores is correct.
- __init__: cap the reduction thread count to the warp size when synthetic
  lanes are used. A single warp reduction is only correct within one warp, and
  the cross-warp two-stage path is incompatible with the lane loop, so the
  lane loop grows to cover the extent instead.

Also drop the Triton-only guard on the size-coincidence test (the mixed
arange+slice kernel now computes correctly on CuTe) and add a focused
synthetic-lane regression test.

Relates to #2643