### PR TITLE
Cap CuTe synthetic-lane reductions to a single warp

### DIFF
--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -630,6 +630,20 @@ class PersistentReductionStrategy(ReductionStrategy):
                 lane_extent = env.backend.create_synthetic_reduction_lanes(
                     self._thread_count, size_hint
                 )
+                # The synthetic lane loop folds each lane into a per-thread
+                # accumulator that is then combined with a single warp reduction
+                # over ``_reduction_thread_count`` threads. That warp reduction
+                # is only correct within one warp, so cap the thread count to
+                # the warp size and let the lane loop grow to cover the rest;
+                # otherwise a multi-warp group silently drops lanes (#2643).
+                if (
+                    lane_extent is not None
+                    and self._thread_count > _CUTE_WARP_REDUCTION_THREADS
+                ):
+                    self._thread_count = _CUTE_WARP_REDUCTION_THREADS
+                    lane_extent = env.backend.create_synthetic_reduction_lanes(
+                        self._thread_count, size_hint
+                    )
                 if lane_extent is not None:
                     self._synthetic_cute_lane_var = fn.new_var(
                         f"synthetic_lane_{block_index}",

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -477,20 +477,39 @@ class TestReductions(RefEagerTestBase, TestCase):
         x = torch.randn([64, 128], device=DEVICE, dtype=HALF_DTYPE)
 
         # The unified rdim must not be offered as a looped reduction: rolling
-        # it cannot re-index the iota-indexed arange load (issue #2643). This
-        # registration check is backend-agnostic.
+        # it cannot re-index the iota-indexed arange load (issue #2643).
         bound = mixed.bind((x,))
         self.assertEqual(bound.env.config_spec.reduction_loops.valid_block_ids(), [])
 
-        # Issue #2643 is a Triton rolling bug; the persistent fallback computes
-        # correctly there. CuTe lowers hl.arange reductions via a thread-layout
-        # warp-reduction path (unaffected by rolling) that has a separate
-        # limitation when an arange reduction is combined with a slice reduction
-        # over the same dim, so only run the numeric check on Triton.
-        if _get_backend() == "triton":
-            _code, output = code_and_output(mixed, (x,))
-            expected = x.to(torch.float32).sum(-1) + x.to(torch.float32).pow(2).sum(-1)
-            torch.testing.assert_close(output, expected, rtol=1e-2, atol=1e-2)
+        _code, output = code_and_output(mixed, (x,))
+        expected = x.to(torch.float32).sum(-1) + x.to(torch.float32).pow(2).sum(-1)
+        torch.testing.assert_close(output, expected, rtol=1e-2, atol=1e-2)
+
+    def test_arange_reduction_with_synthetic_lanes(self):
+        """A persistent ``hl.arange()`` reduction whose extent exceeds the live
+        thread count must accumulate across synthetic lanes.
+
+        On CuTe, when the reduction extent is wider than the threads available
+        for it, the body runs inside a synthetic lane loop. The per-thread
+        value must be carried across lanes so the final warp reduction sees
+        every element; otherwise only the last lane's slice is reduced and the
+        result is silently wrong (issue #2643). ``block_size=16`` splits the
+        CuTe thread budget so the 128-wide reduction needs that lane loop.
+        """
+
+        @helion.kernel(static_shapes=True)
+        def arange_reduce(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.shape
+            out = torch.empty([m], dtype=torch.float32, device=x.device)
+            for tile_m in hl.tile(m):
+                tile_n = hl.arange(n)
+                out[tile_m] = x[tile_m, tile_n].to(torch.float32).pow(2).sum(-1)
+            return out
+
+        x = torch.randn([64, 128], device=DEVICE, dtype=HALF_DTYPE)
+        _code, output = code_and_output(arange_reduce, (x,), block_size=16)
+        expected = x.to(torch.float32).pow(2).sum(-1)
+        torch.testing.assert_close(output, expected, rtol=1e-2, atol=1e-2)
 
     def test_fp16_var_mean(self):
         @helion.kernel(static_shapes=True)


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2674
 * #2673
 * #2670
 * #2669
 * #2668
 * #2667
 * #2666
 * #2665
 * __->__#2662
 * #2660


--- --- ---

Cap CuTe synthetic-lane reductions to a single warp

When a persistent reduction's extent exceeds the live thread count, CuTe runs
the reduction body inside a synthetic lane loop and (via the lane-reduction
two-pass rewrite) folds each lane into a per-thread accumulator that is then
combined with a single warp reduction over `_reduction_thread_count` threads.

`cute.arch.warp_reduction_*` is only correct within one warp, so when the
thread count exceeds the warp size the multi-warp group silently drops lanes --
e.g. a 128-wide reduction split across 64 threads returned the sum of only 64
elements. Cap the synthetic-lane thread count to the warp size; the lane loop
grows to cover the rest.

Also add regression tests: arange-dim reductions stay persistent (issue #2643),
including the size-coincidence variant, plus the synthetic-lane path forced via
a block size that splits the thread budget.

Relates to #2643