### PR TITLE
[Pallas] Fix wrapper tensor output classification

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1919,13 +1919,17 @@ class PallasBackend(Backend):
             for i, arg in enumerate(sorted_args):
                 if not isinstance(arg, TensorArg):
                     continue
-                if id(arg.fake_value.untyped_storage()) not in input_storages:
+                arg_name = arg.host_str()
+                if (
+                    id(arg.fake_value.untyped_storage()) not in input_storages
+                    and arg_name in write_names
+                ):
                     # Tensor created inside the function body (output)
                     output_indices.append(i)
-                    if arg.host_str() in read_names or arg.host_str() not in empty_vars:
+                    if arg_name in read_names or arg_name not in empty_vars:
                         # Also read by the kernel (e.g. broadcast result)
                         inplace_indices.append(i)
-                elif arg.host_str() in mutated_params:
+                elif arg_name in mutated_params:
                     # Input tensor mutated in-place
                     output_indices.append(i)
                     inplace_indices.append(i)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -737,6 +737,49 @@ class TestPallas(TestCase):
         torch.testing.assert_close(x, x_copy)
         torch.testing.assert_close(y, y_copy)
 
+    def test_wrapper_gather_before_loop_is_read_only_input(self) -> None:
+        """A tensor created by eager wrapper code and only read by Pallas is not output."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def gather_then_tile(x: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
+            gathered = x[idx]
+            out = torch.empty_like(gathered)
+            for tile in hl.tile(out.size()):
+                out[tile] = gathered[tile] + 1.0
+            return out
+
+        x = torch.randn(128, device=DEVICE, dtype=torch.float32)
+        idx = torch.arange(127, -1, -1, device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(gather_then_tile, (x, idx), block_sizes=[128])
+        torch.testing.assert_close(result, x[idx] + 1.0)
+        self.assertIn("_output_indices=[1]", code)
+        self.assertIn("_inplace_indices=[]", code)
+
+    def test_wrapper_gather_and_scatter_around_loop(self) -> None:
+        """Eager prologue gather and epilogue scatter compose around Pallas."""
+
+        @helion.kernel(
+            backend="pallas",
+            static_shapes=True,
+            ignore_warnings=[helion.exc.TensorOperationInWrapper],
+        )
+        def gather_tile_scatter(x: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
+            gathered = x[idx]
+            out = torch.empty_like(gathered)
+            for tile in hl.tile(out.size()):
+                out[tile] = gathered[tile] + 1.0
+            scattered = torch.empty_like(out)
+            scattered[idx] = out
+            return scattered
+
+        x = torch.randn(128, device=DEVICE, dtype=torch.float32)
+        idx = torch.arange(127, -1, -1, device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(gather_tile_scatter, (x, idx), block_sizes=[128])
+        expected = torch.empty_like(x)
+        expected[idx] = x[idx] + 1.0
+        torch.testing.assert_close(result, expected)
+        self.assertIn("_inplace_indices=[]", code)
+
     def test_add_2d(self) -> None:
         args = (
             torch.randn(64, 512, device=DEVICE, dtype=torch.float32),


### PR DESCRIPTION
MOtivating example:

```python
@helion.kernel()
def sample_helion_body(
    A: torch.Tensor,
    W: torch.Tensor,
    sorted: torch.Tensor,
) -> torch.Tensor:
    T, K = A.shape
    N = W.shape[1]

    A_sorted = A[sorted]  # pytorch eager prologue
    C_sorted = torch.empty(T, N, dtype=A.dtype, device=A.device)

    for tile_t, tile_n in hl.tile([T, N]):
        ...

    C = torch.empty(T, N, dtype=A.dtype, device=A.device)
    C[sorted_to_orig_token_idx] = C_sorted  # pytorch eager epilogue
    return C
```

The bug was that Helion treated any tensor created in the wrapper as a Pallas output, so in this exact case: A_sorted was classified as output in the helion launcher. We need to check that we actually write to this tensor, otherwise it's an input.