### PR TITLE
[cute] Support scalar associative_scan over non-last dimension

### DIFF
--- a/helion/language/scan_ops.py
+++ b/helion/language/scan_ops.py
@@ -380,7 +380,13 @@ def _(state: CodegenState) -> ast.AST | list[ast.AST]:
     if dim < 0:
         dim += input_tensor.ndim
     if dim != input_tensor.ndim - 1:
-        raise exc.BackendUnsupported("cute", "associative_scan non-last dimension")
+        # A non-last-dim scalar scan is a single-stream serial scan; reuse the
+        # dim-agnostic machinery the tuple path already relies on (it folds the
+        # combine graph over global rows along an arbitrary scan dimension).
+        (result,) = _cute_codegen_serial_scan(
+            state, helper_graph_info, [input_node], dim, reverse
+        )
+        return result
 
     scan_source = state.ast_args[1]
     sorted_source: tuple[CuteSortableLoad, bool] | None = None
@@ -653,7 +659,10 @@ def _cute_inline_combine_graph(
 
     output_nodes = next(n for n in graph.nodes if n.op == "output")
     outputs = output_nodes.args[0]
-    assert isinstance(outputs, (tuple, list))
+    # A scalar (single-tensor) combine graph returns one value directly; a tuple
+    # combine graph returns a tuple/list.  Normalize to a list of outputs.
+    if not isinstance(outputs, (tuple, list)):
+        outputs = [outputs]
     out_exprs = [operand(o) for o in outputs]
     return lines, out_exprs
 
@@ -674,12 +683,6 @@ def _cute_codegen_tuple_scan(
     segmented reduction).  Correctness, not performance, is the goal: the loop
     is O(n) per lane.
     """
-    from torch.fx.node import Node
-
-    from .._compiler.ast_extension import expr_from_string
-    from .._compiler.ast_extension import statement_from_string
-    from .._compiler.compile_environment import CompileEnvironment
-    from .._compiler.cute.indexing import CuteSortableLoad
     from .._compiler.device_ir import HelperFunctionGraphInfo
 
     helper_graph_info = state.get_graph(combine_graph_id)
@@ -691,6 +694,34 @@ def _cute_codegen_tuple_scan(
     input_nodes = fx_node.args[1]
     if not isinstance(input_nodes, (tuple, list)):
         raise exc.BackendUnsupported("cute", "tuple associative_scan input")
+
+    return _cute_codegen_serial_scan(
+        state, helper_graph_info, list(input_nodes), dim, reverse
+    )
+
+
+def _cute_codegen_serial_scan(
+    state: CodegenState,
+    helper_graph_info: object,
+    input_nodes: list[object],
+    dim: int,
+    reverse: bool,
+) -> list[ast.AST]:
+    """Dim-agnostic serial per-lane inclusive scan shared by the scalar and
+    tuple CuTe scan paths.
+
+    ``input_nodes`` is one FX node per scanned stream (a single element for a
+    scalar scan, multiple for a tuple scan).  For each output position along the
+    scan dimension this folds the user's combine graph over the global rows
+    ``0..out_pos`` (inclusive), carrying one accumulator per stream.  Returns one
+    output expression per stream.
+    """
+    from torch.fx.node import Node
+
+    from .._compiler.ast_extension import expr_from_string
+    from .._compiler.ast_extension import statement_from_string
+    from .._compiler.compile_environment import CompileEnvironment
+    from .._compiler.cute.indexing import CuteSortableLoad
 
     # Fake-tensor metadata lives on the per-stream input nodes (the scan node
     # itself produces a tuple and may carry no ``val``).
@@ -706,23 +737,38 @@ def _cute_codegen_tuple_scan(
     from .memory_ops import _cute_active_index_var
     from .memory_ops import _cute_tensor_dim_size_expr
 
-    # The scan loops over the *block-local* positions of the scan dimension.
-    # ``first_val.shape[dim]`` is the per-tile block size (the fake tensor has
-    # block-sized dims), which gives both the loop bound and the block id.
-    extent = first_val.shape[dim]
-    n_hint = env.size_hint(extent) if isinstance(extent, torch.SymInt) else extent
-    if not isinstance(n_hint, int):
-        raise exc.BackendUnsupported("cute", "dynamic associative_scan extent")
-
     scan_block_id = _resolve_dim_block_id(state.codegen, first_val, dim)
     if scan_block_id is None:
         raise exc.BackendUnsupported("cute", "associative_scan scan-dim block id")
+
+    # The scan loops over the *block-local* positions of the scan dimension; the
+    # loop bound is the scan dim's block (tile) size.  Prefer the concrete block
+    # size from config (the fake tensor's scan dim may be a fresh symbol that
+    # ``size_hint`` cannot resolve to the tile size), falling back to the fake
+    # extent's size hint.
+    block_size = env.block_sizes[scan_block_id].from_config(
+        state.device_function.config
+    )
+    if isinstance(block_size, int):
+        n_hint = block_size
+    else:
+        extent = first_val.shape[dim]
+        n_hint = env.size_hint(extent) if isinstance(extent, torch.SymInt) else extent
+    if not isinstance(n_hint, int):
+        raise exc.BackendUnsupported("cute", "dynamic associative_scan extent")
+
     # The current lane's block-local position along the scan dim.
     out_pos_expr = _get_dim_local_coord(state.codegen, first_val, dim)
-    # The tile's global offset along the scan dim, so a local ``scan_i`` maps to
-    # the global row ``offset + scan_i``.
-    offset_expr = state.codegen.offset_var(scan_block_id)
+    # The tile's global base along the scan dim, so a local ``scan_i`` maps to the
+    # global row ``base + scan_i``.  ``offset_var`` aliases the per-thread global
+    # index when the scan dim is split across threads (it equals
+    # ``global_index``), so derive the base as ``global_index - local_coord``
+    # which is the genuine tile base in both the looped and thread-split cases.
     scan_global_index_var = _cute_active_index_var(state, scan_block_id)
+    if scan_global_index_var is not None:
+        offset_expr = f"({scan_global_index_var}) - ({out_pos_expr})"
+    else:
+        offset_expr = state.codegen.offset_var(scan_block_id)
 
     # Recover a scalar load per tuple element and the index position that
     # corresponds to the scan dimension within that load.

--- a/test/test_associative_scan.py
+++ b/test/test_associative_scan.py
@@ -11,7 +11,6 @@ from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
 from helion._testing import skipIfRefEager
-from helion._testing import xfailIfCute
 import helion.language as hl
 from helion.runtime.settings import _get_backend
 
@@ -521,7 +520,6 @@ class TestAssociativeScan(RefEagerTestBase, TestCase):
         # Verify @helion.kernel decorator doesn't appear in generated code
         self.assertNotIn("@helion.kernel", code)
 
-    @xfailIfCute("CUTe does not support tuple associative_scan yet")
     @skipIfRefEager(
         "torch._higher_order_ops.associative_scan with tuple arg is not supported by ref eager mode yet"
     )
@@ -573,10 +571,10 @@ class TestAssociativeScan(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
 
         # Verify the generated code structure
-        self.assertIn("def helion_combine_fn_", code)
-        self.assertIn("tl.associative_scan", code)
+        if _get_backend() == "triton":
+            self.assertIn("def helion_combine_fn_", code)
+            self.assertIn("tl.associative_scan", code)
 
-    @xfailIfCute("CUTe does not support tuple associative_scan yet")
     @skipIfRefEager(
         "torch._higher_order_ops.associative_scan with tuple arg is not supported by ref eager mode yet"
     )
@@ -633,10 +631,10 @@ class TestAssociativeScan(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
 
         # Verify the generated code structure
-        self.assertIn("def segmented_combine_fn_", code)
-        self.assertIn("tl.associative_scan", code)
+        if _get_backend() == "triton":
+            self.assertIn("def segmented_combine_fn_", code)
+            self.assertIn("tl.associative_scan", code)
 
-    @xfailIfCute("CUTe does not support tuple associative_scan yet")
     @skipIfRefEager(
         "torch._higher_order_ops.associative_scan with tuple arg is not supported by ref eager mode yet"
     )
@@ -705,10 +703,10 @@ class TestAssociativeScan(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result_indices, expected_indices)
 
         # Verify the generated code structure
-        self.assertIn("def argmax_combine_fn_", code)
-        self.assertIn("tl.associative_scan", code)
+        if _get_backend() == "triton":
+            self.assertIn("def argmax_combine_fn_", code)
+            self.assertIn("tl.associative_scan", code)
 
-    @xfailIfCute("CUTe associative_scan supports only last-dimension scans")
     def test_associative_scan_in_helper_function(self):
         """Test calling a function that internally uses hl.associative_scan."""
 
@@ -933,7 +931,6 @@ class TestAssociativeScan(RefEagerTestBase, TestCase):
             self.assertIn("param_0 + param_1", code)
             self.assertIn("param_0 * param_1", code)
 
-    @xfailIfCute("CUTe does not support tuple associative_scan yet")
     @skipIfRefEager(
         "torch._higher_order_ops.associative_scan with tuple arg is not supported by ref eager mode yet"
     )
@@ -984,10 +981,10 @@ class TestAssociativeScan(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, expected)
 
         # Verify the generated code structure
-        self.assertIn("def helion_combine_tuple_fn_", code)
-        self.assertIn("tl.associative_scan", code)
+        if _get_backend() == "triton":
+            self.assertIn("def helion_combine_tuple_fn_", code)
+            self.assertIn("tl.associative_scan", code)
 
-    @xfailIfCute("CUTe does not support tuple associative_scan yet")
     def test_associative_scan_argmax_tuple_format(self):
         """Test cumulative argmax using tuple format combine function."""
 
@@ -1053,8 +1050,9 @@ class TestAssociativeScan(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result_indices, expected_indices)
 
         # Verify the generated code structure
-        self.assertIn("def argmax_combine_tuple_fn_", code)
-        self.assertIn("tl.associative_scan", code)
+        if _get_backend() == "triton":
+            self.assertIn("def argmax_combine_tuple_fn_", code)
+            self.assertIn("tl.associative_scan", code)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2674
 * #2673
 * #2670
 * #2669
 * #2668
 * #2667
 * #2666
 * __->__#2665
 * #2662
 * #2660


--- --- ---

[cute] Support scalar associative_scan over non-last dimension

Route the scalar (single-tensor) CuTe associative_scan codegen for a
non-last scan dim through the dim-agnostic serial-scan machinery the
tuple path already used (extracted into a shared _cute_codegen_serial_scan
helper), and fix the loop bound (from_config block size) and tile-base
(offset = global_index - local_coord) so it is correct for both looped and
thread-split scan dims. Un-xfail the scan tests on cute.