### PR TITLE
[cute] Fix fp16 reduction identity dtype and reshape-into-reduction

### DIFF
--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -290,6 +290,99 @@ class ReductionStrategy(TileStrategy):
         threads = self._reduction_thread_count()
         return max(1, threads)
 
+    def _reshape_merged_reduction_group_params(
+        self,
+    ) -> tuple[int, int, str] | None:
+        """Return ``(pre, group_span, lane_expr)`` for a reshape-merged
+        reduction whose live thread axis is interleaved with a *sibling*
+        thread axis, or ``None`` when no such interleaving exists.
+
+        When ``x[tile0, tile1, tile2].reshape(tile0, -1).sum(-1)`` merges
+        ``tile1`` (a live thread axis) and ``tile2`` (a lane loop) into a
+        single synthetic reduction block, the reduction's live thread axis
+        (``tile1``) shares the launch warp with the *unrelated* ``tile0``
+        row axis. A plain ``cute.arch.warp_reduction_*(threads_in_group=N)``
+        folds together CONSECUTIVE warp lanes, so it would sum across both
+        ``tile1`` AND ``tile0`` (cross-contaminating rows). Instead the
+        reduction must be grouped/strided so each lane only combines the
+        lanes that share its ``tile0`` coordinate.
+
+        This computes the ``pre`` (product of live thread extents on axes
+        *below* the reduce axis) and ``group_span`` (``pre`` times the
+        reduce axis extent) used by ``_cute_grouped_reduce_warp``. Returns
+        ``None`` when ``pre == 1`` (no sibling axis below the reduce axis),
+        in which case the plain consecutive-lane warp reduction is already
+        correct.
+        """
+        env = CompileEnvironment.current()
+        backend = env.backend
+        if backend.name != "cute":
+            return None
+        numel = env.block_sizes[self.block_index].numel
+        if not isinstance(numel, sympy.Expr):
+            return None
+        # Source block ids merged into this reduction dim by the reshape.
+        source_block_ids: set[int] = set()
+        for symbol in numel.free_symbols:
+            if not isinstance(symbol, sympy.Symbol):
+                return None
+            block_id = env.get_block_id(symbol)
+            if block_id is None:
+                return None
+            source_block_ids.add(env.canonical_block_id(block_id))
+        if len(source_block_ids) < 2:
+            # A single source block needs no de-interleaving.
+            return None
+        tile_strategy = self.fn.tile_strategy
+        # The reduce axis is the (single) live thread axis spanned by the
+        # source blocks. A lane-looped source block has ``extent is None``.
+        reduce_axis: int | None = None
+        reduce_extent = 1
+        for block_id in source_block_ids:
+            axis = tile_strategy.thread_axis_for_block_id(block_id)
+            extent = tile_strategy.thread_extent_for_block_id(block_id)
+            if axis is None or extent is None or extent <= 1:
+                continue
+            if reduce_axis is not None and reduce_axis != axis:
+                # More than one live thread axis among the source blocks is
+                # not expressible as a single grouped warp reduce.
+                return None
+            reduce_axis = axis
+            reduce_extent = max(reduce_extent, extent)
+        if reduce_axis is None:
+            return None
+        # Live thread extents of ALL blocks (siblings included) so the linear
+        # lane index strides are computed correctly. The reduction block's own
+        # synthetic thread axis is excluded -- it is fictional (no real warp
+        # lanes back it); the source live axis carries the actual data.
+        logical_axis_sizes: dict[int, int] = {reduce_axis: reduce_extent}
+        for info in env.block_sizes:
+            block_id = info.block_id
+            if block_id == self.block_index or block_id in source_block_ids:
+                continue
+            axis = tile_strategy.thread_axis_for_block_id(block_id)
+            extent = tile_strategy.thread_extent_for_block_id(block_id)
+            if axis is None or extent is None or extent <= 1:
+                continue
+            logical_axis_sizes[axis] = max(logical_axis_sizes.get(axis, 1), extent)
+        pre = 1
+        for axis in range(reduce_axis):
+            pre *= logical_axis_sizes.get(axis, 1)
+        if pre <= 1:
+            # No sibling thread axis below the reduce axis: the reduce axis is
+            # already at the bottom of the linear lane index, so consecutive
+            # warp lanes belong to the reduction and the plain warp reduce is
+            # correct.
+            return None
+        group_span = pre * reduce_extent
+        if group_span > 32:
+            # Cross-warp grouped reduction is not handled by the marker path.
+            return None
+        lane_expr = backend.thread_linear_index_expr(logical_axis_sizes)
+        if lane_expr is None:
+            return None
+        return pre, group_span, lane_expr
+
     def _lane_reduce_marker_unsupported(self, state: CodegenState) -> bool:
         """Return True when the two-pass lane-reduction marker cannot be
         handled by the ``split_lane_loop_reductions`` post-pass, so the caller
@@ -798,6 +891,12 @@ class PersistentReductionStrategy(ReductionStrategy):
         identity_expr = backend.cast_expr(
             constant_repr(default_value), _dtype_str(dtype)
         )
+        # The two-stage shared reduce takes ``dtype`` (the accumulation dtype,
+        # ``get_computation_dtype(fake_input.dtype)``) from ``type(identity)``.
+        # Upcast the (possibly fp16/bf16) masked input to that same dtype so the
+        # helper's ``input if mask else identity`` selection unifies cleanly and
+        # the reduction still accumulates in the wider accumulation dtype.
+        input_expr = backend.cast_expr(input_name, _dtype_str(dtype))
         group_count = num_threads // group_span
         lane_var = self.fn.new_var("persistent_reduce_lane", dce=True)
         lane_in_group_var = self.fn.new_var("persistent_reduce_lane_in_group", dce=True)
@@ -808,7 +907,7 @@ class PersistentReductionStrategy(ReductionStrategy):
         state.add_statement(f"{lane_mod_pre_var} = ({lane_in_group_var}) % 1")
         state.add_statement(
             f"{result_var} = _cute_grouped_reduce_shared_two_stage("
-            f"{input_name}, {reduction_type!r}, {identity_expr}, "
+            f"{input_expr}, {reduction_type!r}, {identity_expr}, "
             f"{lane_var}, {lane_in_group_var}, {lane_mod_pre_var}, "
             f"pre=1, group_span={group_span}, group_count={group_count})"
         )
@@ -852,9 +951,22 @@ class PersistentReductionStrategy(ReductionStrategy):
             identity_expr = backend.cast_expr(
                 constant_repr(default), _dtype_str(acc_dtype)
             )
-            expr = _lane_reduce_marker_expr(
-                input_name, reduction_type, identity_expr, threads
-            )
+            group_params = self._reshape_merged_reduction_group_params()
+            if group_params is not None:
+                group_pre, group_span, group_lane_expr = group_params
+                expr = _lane_reduce_marker_expr(
+                    input_name,
+                    reduction_type,
+                    identity_expr,
+                    threads,
+                    group_pre=group_pre,
+                    group_span=group_span,
+                    group_lane_expr=group_lane_expr,
+                )
+            else:
+                expr = _lane_reduce_marker_expr(
+                    input_name, reduction_type, identity_expr, threads
+                )
             return expr_from_string(
                 self.maybe_reshape(expr, dim, fake_input, fake_output)
             )

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -111,10 +111,21 @@ def _lane_reduce_marker_expr(
     reduction_type: str,
     identity_expr: str,
     threads_in_group: int,
+    *,
+    group_pre: int = 1,
+    group_span: int = 0,
+    group_lane_expr: str = "",
 ) -> str:
+    # ``group_*`` (optional) carry the parameters of a strided grouped warp
+    # reduction. They are required when the reduction's live thread axis is
+    # interleaved with an unrelated sibling thread axis on the same warp (a
+    # reshape-merged reduction). ``group_lane_expr`` is base64-free but may
+    # contain commas/parens, so it is passed as a string literal that the
+    # post-pass re-parses.
     return (
         f"{_HELION_LANE_REDUCE_MARKER}({input_name}, {reduction_type!r}, "
-        f"{identity_expr}, {threads_in_group})"
+        f"{identity_expr}, {threads_in_group}, {group_pre}, {group_span}, "
+        f"{group_lane_expr!r})"
     )
 
 
@@ -129,6 +140,14 @@ class _LaneReduceMarker:
     # ``{finalized}``; ``finalize_expr(x)`` substitutes ``x`` to re-apply any
     # surrounding dtype cast / reshape to the finalized reduced scalar.
     wrap_template: str
+    # Optional strided grouped warp reduction (reshape-merged reductions whose
+    # live thread axis shares a warp with an unrelated sibling axis). When
+    # ``group_span`` > 0 the finalize uses ``_cute_grouped_reduce_warp`` with
+    # ``group_pre``/``group_span``/``group_lane_expr`` instead of a plain
+    # consecutive-lane ``cute.arch.warp_reduction_*``.
+    group_pre: int = 1
+    group_span: int = 0
+    group_lane_expr: str = ""
 
     def finalize_expr(self, reduced: str) -> str:
         return self.wrap_template.replace("__HELION_FINALIZED__", f"({reduced})")
@@ -173,13 +192,24 @@ def _is_lane_reduce_marker_assign(stmt: ast.AST) -> _LaneReduceMarker | None:
     if not isinstance(target, ast.Name):
         return None
     call = _find_lane_reduce_call(stmt.value)
-    if call is None or len(call.args) != 4:
+    if call is None or len(call.args) != 7:
         return None
-    input_node, type_node, identity_node, threads_node = call.args
+    (
+        input_node,
+        type_node,
+        identity_node,
+        threads_node,
+        group_pre_node,
+        group_span_node,
+        group_lane_node,
+    ) = call.args
     input_name = ast.unparse(input_node)
     reduction_type = ast.literal_eval(type_node)
     identity_expr = ast.unparse(identity_node)
     threads_in_group = int(ast.literal_eval(threads_node))
+    group_pre = int(ast.literal_eval(group_pre_node))
+    group_span = int(ast.literal_eval(group_span_node))
+    group_lane_expr = ast.literal_eval(group_lane_node)
     # Build the wrap template by replacing the marker call with a sentinel.
     wrapped = _ReplaceLaneReduceCall().visit(ast.parse(ast.unparse(stmt.value)).body[0])
     assert isinstance(wrapped, ast.Expr)
@@ -191,6 +221,9 @@ def _is_lane_reduce_marker_assign(stmt: ast.AST) -> _LaneReduceMarker | None:
         identity_expr=identity_expr,
         threads_in_group=threads_in_group,
         wrap_template=wrap_template,
+        group_pre=group_pre,
+        group_span=group_span,
+        group_lane_expr=group_lane_expr,
     )
 
 
@@ -217,6 +250,28 @@ def _dtype_ctor_from_identity(identity_expr: str) -> str | None:
     if isinstance(node, ast.Call):
         return ast.unparse(node.func)
     return None
+
+
+def _grouped_warp_reduce_expr(
+    reduction_type: str,
+    acc: str,
+    identity_expr: str,
+    lane_expr: str,
+    *,
+    pre: int,
+    group_span: int,
+) -> str:
+    """Strided grouped warp reduction over a single warp.
+
+    Reduces ``acc`` across the ``group_span`` lanes that share the same
+    ``lane % pre`` within each ``group_span``-lane block, so an interleaved
+    sibling thread axis (occupying the low ``pre`` strides) stays distinct.
+    """
+    return (
+        "_cute_grouped_reduce_warp("
+        f"{acc}, {reduction_type!r}, {identity_expr}, {lane_expr}, "
+        f"pre={pre}, group_span={group_span})"
+    )
 
 
 def _warp_reduce_expr(reduction_type: str, acc: str, threads_in_group: int) -> str:
@@ -386,7 +441,19 @@ def _split_one_lane_loop(loop: ast.For, lane_var: str) -> list[ast.AST]:
                 f"{acc_var} = {_combine_expr(m.reduction_type, acc_var, combine_val)}"
             )
         )
-        if m.threads_in_group > 1:
+        if m.group_span > 1 and m.group_pre > 1 and m.group_lane_expr:
+            # Strided grouped reduction: the reduce axis shares a warp with an
+            # unrelated sibling axis, so combine only the lanes that share the
+            # current lane's sibling coordinate.
+            reduced = _grouped_warp_reduce_expr(
+                m.reduction_type,
+                acc_var,
+                m.identity_expr,
+                m.group_lane_expr,
+                pre=m.group_pre,
+                group_span=m.group_span,
+            )
+        elif m.threads_in_group > 1:
             reduced = _warp_reduce_expr(m.reduction_type, acc_var, m.threads_in_group)
         else:
             reduced = acc_var

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -43,7 +43,6 @@ class TestViews(RefEagerTestBase, TestCase):
         )
         torch.testing.assert_close(result, x + 1)
 
-    @xfailIfCute("CuTe DSL fails to compile reshape-broadcast softmax pattern")
     def test_softmax_unsqueeze(self):
         @helion.kernel(config={"block_size": 1})
         def softmax(x: torch.Tensor) -> torch.Tensor:
@@ -63,7 +62,6 @@ class TestViews(RefEagerTestBase, TestCase):
             result, torch.nn.functional.softmax(x, dim=1), rtol=1e-2, atol=1e-1
         )
 
-    @xfailIfCute("CuTe DSL fails to compile reshape-broadcast softmax pattern")
     def test_softmax_view_reshape(self):
         @helion.kernel(config={"block_size": 1})
         def softmax(x: torch.Tensor) -> torch.Tensor:
@@ -301,7 +299,6 @@ class TestViews(RefEagerTestBase, TestCase):
         expected = torch.matmul(x, y)
         torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
 
-    @xfailIfCute("reshape into reduction dim not supported on cute")
     @xfailIfPallas("triton.next_power_of_2 in generated host code crashes pallas")
     def test_reshape_sum(self):
         @helion.kernel(static_shapes=True)


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2674
 * #2673
 * #2670
 * #2669
 * #2668
 * #2667
 * __->__#2666
 * #2665
 * #2662
 * #2660


--- --- ---

[cute] Fix fp16 reduction identity dtype and reshape-into-reduction

Two CuTe reduction correctness fixes:
- Upcast the masked reduction input to the accumulation dtype in the
  two-stage cross-warp reduce so an fp16/bf16 masked input unifies with the
  fp32 identity (fixes a DSL ifexp type-mismatch in softmax), while still
  accumulating in the wider dtype.
- When a reshape merges multiple tile axes into the reduction dim, scope the
  warp reduction to only the reduced source axes via a strided grouped warp
  reduce (group_pre/group_span), so sibling thread axes are not folded in
  (fixes all-rows-identical results).

Un-xfails test_softmax_unsqueeze, test_softmax_view_reshape, test_reshape_sum.