### PR TITLE
[cute] Fix transpose shape-chains and add affine hl.arange reshape store

### DIFF
--- a/helion/_compiler/cute/cute_reshape.py
+++ b/helion/_compiler/cute/cute_reshape.py
@@ -541,6 +541,67 @@ def _stack_choice_expr(
     return selected
 
 
+def _permute_node_perm(node: Node, value: torch.Tensor) -> list[int] | None:
+    """Return the explicit permutation for a permute/transpose/t node."""
+    if node.target is torch.ops.aten.permute.default:
+        dims = node.args[1] if len(node.args) > 1 else node.kwargs.get("dims")
+        if not isinstance(dims, (list, tuple)):
+            return None
+        perm = [dim for dim in dims if isinstance(dim, int)]
+        return perm if len(perm) == len(dims) else None
+    if node.target is torch.ops.aten.transpose.int:
+        dim0 = node.args[1] if len(node.args) > 1 else node.kwargs.get("dim0")
+        dim1 = node.args[2] if len(node.args) > 2 else node.kwargs.get("dim1")
+        if not isinstance(dim0, int) or not isinstance(dim1, int):
+            return None
+        ndim = len(value.shape)
+        dim0 %= ndim
+        dim1 %= ndim
+        perm = list(range(ndim))
+        perm[dim0], perm[dim1] = perm[dim1], perm[dim0]
+        return perm
+    if node.target is torch.ops.aten.t.default:
+        if len(value.shape) != 2:
+            return None
+        return [1, 0]
+    return None
+
+
+def _materialized_permute_value(
+    ctx: LoweringContext,
+    node: Node,
+    value: torch.Tensor,
+) -> ast.AST | None:
+    """Return the already-materialized AST for a permute/transpose/t node.
+
+    ``codegen_cute_permute`` materializes a permute to a concrete scalar (via a
+    shared-memory shuffle) whenever it reorders active thread dims *and* a
+    downstream consumer needs values. When a later shape op folds back through
+    such a node we must reuse that materialized value instead of re-folding the
+    coordinate swap all the way to the raw source (which would silently drop the
+    already-emitted shuffle).
+    """
+    if not node.args:
+        return None
+    source = node.args[0]
+    if not isinstance(source, Node):
+        return None
+    source_val = source.meta.get("val")
+    if not isinstance(source_val, torch.Tensor):
+        return None
+    perm = _permute_node_perm(node, value)
+    if perm is None:
+        return None
+    cg = cast("GenerateAST", ctx.cg)
+    if not (
+        _permute_reorders_active_dims(cg, source_val, perm)
+        and _permute_needs_materialization(node)
+    ):
+        return None
+    resolved = ctx.env.get(node)
+    return resolved if isinstance(resolved, ast.AST) else None
+
+
 def _resolve_shape_chain_expr(
     ctx: LoweringContext,
     node: Node,
@@ -553,6 +614,16 @@ def _resolve_shape_chain_expr(
     if not isinstance(value, torch.Tensor):
         resolved = ctx.env.get(node)
         return resolved if isinstance(resolved, ast.AST) else None
+
+    # A permute/transpose/t node that was already materialized to a concrete
+    # per-thread scalar must not be folded again: doing so would silently drop
+    # the shuffle that already applied its coordinate swap and recurse to the raw
+    # source, collapsing two transposes into one. The materialized value already
+    # holds the correct element for the current thread (just like a load), so we
+    # return it directly as a chain leaf.
+    materialized = _materialized_permute_value(ctx, node, value)
+    if materialized is not None:
+        return materialized
 
     if node.target in (
         torch.ops.aten.reshape.default,
@@ -745,6 +816,26 @@ def resolve_cute_shape_chain_value(
     return _resolve_shape_chain_expr(
         ctx, node, _current_flat_index_for_value(ctx, value)
     )
+
+
+def resolve_cute_shape_chain_value_at(
+    state: CodegenState,
+    node: Node,
+    flat_index: str,
+) -> ast.AST | None:
+    """Resolve a shape-chain value (reshape/stack/...) at an explicit flat index.
+
+    The store path holds a ``CodegenState`` rather than the ``GraphInterpreter``
+    ``LoweringContext`` that the regular value-lowering path uses, but the shape
+    chain resolver only needs the ``GenerateAST`` codegen object and the
+    fx-node -> argument map, both of which ``CodegenState`` already carries.
+    """
+    from ..aten_lowering import LoweringContext
+
+    ctx = LoweringContext.__new__(LoweringContext)
+    ctx.cg = state.codegen
+    ctx.env = state.env
+    return _resolve_shape_chain_expr(ctx, node, flat_index)
 
 
 def codegen_cute_reshape(ctx: LoweringContext, node: Node) -> object:

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -1826,6 +1826,139 @@ def _codegen_cute_affine_range_store(
     )
 
 
+def _codegen_cute_affine_reshape_store(
+    state: CodegenState,
+    tensor: torch.Tensor,
+    subscript: list[object] | tuple[object, ...],
+    ast_subscript: list[object] | tuple[object, ...],
+    extra_mask: ast.AST | None,
+    value_node: torch.fx.Node | None,
+) -> ast.AST | None:
+    """Lower a 2-D affine-row store fed by a reshape/stack chain.
+
+    Handles ``out[(begin*K):(begin*K + block*K), tile_n] = reshaped`` where the
+    leading index is a ``CuteAffineRangeIndex`` (factor ``K``) over the m-tile,
+    the trailing index is the n-tile, and the value is a row-major shape chain
+    (e.g. ``stack([a, b], dim=1).reshape(block*K, block_n)``).
+
+    Each m-tile thread owns row ``m_local`` of the source; the reshaped tensor
+    has ``K`` rows per source row, so the thread loops ``s in range(K)`` and
+    writes the value resolved at flat index ``(K*m_local + s)*block_n + n_local``
+    to output row ``K*m_global + s``, column ``n_global``.
+    """
+    from .._compiler.ast_extension import create
+    from .._compiler.cute.cute_reshape import _get_block_local_coord
+    from .._compiler.cute.cute_reshape import resolve_cute_shape_chain_value_at
+    from .._compiler.cute.indexing import CuteAffineRangeIndex
+    from .._compiler.cute.indexing import is_cute_shape_chain_target
+    from .._compiler.generate_ast import GenerateAST
+
+    if (
+        tensor.ndim != 2
+        or len(subscript) != 2
+        or len(ast_subscript) != 2
+        or extra_mask is not None
+        or value_node is None
+        or not isinstance(state.codegen, GenerateAST)
+    ):
+        return None
+    affine = ast_subscript[0]
+    if not isinstance(affine, CuteAffineRangeIndex):
+        return None
+    if affine.step != 1 or affine.factor <= 0:
+        return None
+    n_index = subscript[1]
+    if not isinstance(n_index, torch.SymInt):
+        return None
+    env = CompileEnvironment.current()
+    block_id_n = env.get_block_id(n_index)
+    if block_id_n is None:
+        return None
+    block_id_m = _cute_affine_range_block_id(state, affine)
+    if block_id_m is None:
+        return None
+
+    if value_node.op != "call_function" or not is_cute_shape_chain_target(
+        value_node.target
+    ):
+        return None
+    value_val = value_node.meta.get("val")
+    if not isinstance(value_val, torch.Tensor) or value_val.ndim != 2:
+        return None
+
+    m_global = _cute_active_index_var(state, block_id_m)
+    n_global = _cute_active_index_var(state, block_id_n)
+    if m_global is None or n_global is None:
+        return None
+    m_local = _get_block_local_coord(state.codegen, block_id_m)
+    n_local = _get_block_local_coord(state.codegen, block_id_n)
+    if m_local is None or n_local is None:
+        return None
+    block_n = state.device_function.resolved_block_size(block_id_n)
+    if not isinstance(block_n, int):
+        return None
+
+    factor = affine.factor
+    lane_var = state.device_function.new_var("affine_lane", dce=True)
+    row_local = f"cutlass.Int32({factor}) * ({m_local}) + cutlass.Int32({lane_var})"
+    flat_index = (
+        f"(({row_local}) * cutlass.Int32({block_n})) + ({n_local})"
+        if block_n != 1
+        else f"({row_local}) + ({n_local})"
+    )
+    value_ast = resolve_cute_shape_chain_value_at(state, value_node, flat_index)
+    if value_ast is None:
+        return None
+
+    backend = env.backend
+    index_dtype = backend.dtype_str(env.index_dtype)
+    target_dtype = backend.dtype_str(tensor.dtype)
+    value_expr = backend.ast_to_dtype_expr(ast.unparse(value_ast), target_dtype)
+
+    # Bind the resolved (possibly select-based) value to a variable so the CuTe
+    # DSL sees the stack `ifexp` as its own assignment rather than nested inside
+    # the `.store(...)` call / masked store ternary.
+    value_var = state.device_function.new_var("affine_value", dce=True)
+
+    row_index = (
+        f"{index_dtype}(cutlass.Int32({factor}) * ({m_global}) "
+        f"+ cutlass.Int32({lane_var}))"
+    )
+    col_index = f"{index_dtype}({n_global})"
+    tensor_name = state.device_function.tensor_arg(tensor).name
+    store_expr = _cute_scalar_store_expr(tensor_name, [row_index, col_index], value_var)
+
+    store_stmt: ast.stmt = create(ast.Expr, value=expr_from_string(store_expr))
+    mask_parts = [
+        mask
+        for mask in (
+            _cute_active_mask_var(state, block_id_m),
+            _cute_active_mask_var(state, block_id_n),
+        )
+        if mask is not None
+    ]
+    if mask_parts:
+        # Use a guard statement (not a ternary) so the CuTe DSL accepts the
+        # device-value mask condition.
+        mask_ast = expr_from_string(" and ".join(mask_parts))
+        assert isinstance(mask_ast, ast.expr)
+        store_stmt = ast.fix_missing_locations(
+            ast.If(test=mask_ast, body=[store_stmt], orelse=[])
+        )
+
+    return create(
+        ast.For,
+        target=create(ast.Name, id=lane_var, ctx=ast.Store()),
+        iter=expr_from_string(f"range({factor})"),
+        body=[
+            statement_from_string(f"{value_var} = {value_expr}"),
+            store_stmt,
+        ],
+        orelse=[],
+        type_comment=None,
+    )
+
+
 def _is_cute_affine_range_load_for_store(
     state: CodegenState,
     subscript: list[object] | tuple[object, ...],
@@ -5154,6 +5287,17 @@ def _(state: CodegenState) -> ast.AST:
         )
         if affine_range_store is not None:
             state.add_statement(affine_range_store)
+            return ast.Constant(value=None)
+        affine_reshape_store = _codegen_cute_affine_reshape_store(
+            state,
+            tensor,
+            subscript,
+            ast_subscript,
+            extra_mask,
+            value_node,
+        )
+        if affine_reshape_store is not None:
+            state.add_statement(affine_reshape_store)
             return ast.Constant(value=None)
         strided_slice_store = _codegen_cute_strided_slice_store(
             state,

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -115,7 +115,6 @@ class TestViews(RefEagerTestBase, TestCase):
         _code, result = code_and_output(fn, args)
         torch.testing.assert_close(result, args[0] + args[1].transpose(0, 1))
 
-    @xfailIfCute("CuTe transpose+unsqueeze chain produces incorrect values")
     def test_transpose_T_unsqueeze(self):
         @helion.kernel(autotune_effort="none")
         def fn(x: torch.Tensor) -> torch.Tensor:
@@ -316,7 +315,6 @@ class TestViews(RefEagerTestBase, TestCase):
         expected = x.sum(dim=(1, 2))
         torch.testing.assert_close(result, expected)
 
-    @xfailIfCute("torch.stack with affine hl.arange indexing not supported on cute")
     @xfailIfPallas("torch.stack not supported on pallas")
     def test_stack_power_of_2(self):
         @helion.kernel(autotune_effort="none", static_shapes=True)


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2674
 * #2673
 * #2670
 * #2669
 * #2668
 * __->__#2667
 * #2666
 * #2665
 * #2662
 * #2660


--- --- ---

[cute] Fix transpose shape-chains and add affine hl.arange reshape store

- Stop folding a shape-chain through an already-materialized permute/transpose
  node back to the raw load (which silently dropped a transpose), composing
  chained transposes correctly.
- Lower a 2-D affine-row + tiled-col store whose value is a reshape/stack
  shape-chain (out[(tile.begin*F):(...), tile_n] = reshaped) by resolving the
  shape-chain value per interleaved row and storing via a scalar pointer offset.

Un-xfails test_transpose_T_unsqueeze and test_stack_power_of_2.