### PR TITLE
[cute] Synthetic thread axes for free hl.arange, dependent stores, and matmul fallbacks

### DIFF
--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -28,12 +28,15 @@ from .cute.indexing import CuteShapeChainView
 from .cute.indexing import CuteSortableLoad
 from .cute.indexing import is_cute_shape_chain_target
 from .cute.indexing import match_cute_affine_range_iota
+from .cute.iota_utils import cute_free_arange_indexed_dim_key
 from .cute.iota_utils import cute_iota_has_atomic_tensor_index_only_users
+from .cute.iota_utils import cute_iota_is_free_memory_index
 from .cute.matmul_fallback import _emit_cute_matmul
 from .cute.matmul_utils import cute_lower_rhs_for_matmul
 from .cute.matmul_utils import cute_outer_accumulates_result
 from .cute.matmul_utils import cute_outer_accumulator_dtype
 from .cute.matmul_utils import cute_outer_accumulator_out_dtype
+from .cute.matmul_utils import cute_rematerialize_rhs_at_contraction_block
 from .cute.matmul_utils import cute_resolve_active_block_id
 from .cute.matmul_utils import cute_resolve_active_matmul_k_block_id
 from .cute.matmul_utils import cute_static_k_invariant_extent
@@ -52,6 +55,7 @@ from .node_masking import cached_masked_value
 from .node_masking import getitem_masked_value
 
 if TYPE_CHECKING:
+    from .generate_ast import GenerateAST
     from .helper_function import CodegenInterface
 
 
@@ -896,9 +900,31 @@ def codegen_stack_cute(ctx: LoweringContext, node: Node) -> object:
         raise exc.BackendUnsupported("cute", "stack inputs")
     if _shape_chain_only_users(node):
         return CuteShapeChainView(node)
-    raise exc.BackendUnsupported(
-        "cute", "virtual shape-chain direct consumers are not yet supported"
-    )
+    # A stack materialized to a per-thread scalar is only correct when every
+    # consumer reads it element-wise (each output element is one stacked
+    # element), e.g. a direct store. A reduction or matmul that contracts over
+    # the virtual stacked dimension cannot gather the stacked operands from a
+    # single per-thread scalar and would silently produce wrong values, so only
+    # materialize when the direct consumers are stores (or further shape-chain
+    # ops); otherwise keep rejecting the pattern.
+    from ..language import memory_ops
+
+    if not all(
+        user.op == "call_function"
+        and (user.target is memory_ops.store or is_cute_shape_chain_target(user.target))
+        for user in node.users
+    ):
+        raise exc.BackendUnsupported(
+            "cute", "virtual shape-chain direct consumers are not yet supported"
+        )
+    from .cute.cute_reshape import resolve_cute_shape_chain_value
+
+    materialized = resolve_cute_shape_chain_value(ctx, node)
+    if materialized is None:
+        raise exc.BackendUnsupported(
+            "cute", "virtual shape-chain direct consumers are not yet supported"
+        )
+    return materialized
 
 
 expand_lowering = register_lowering(
@@ -1179,6 +1205,10 @@ def codegen_mm_cute(ctx: LoweringContext, node: Node) -> ast.AST:
         k_block_id = cute_resolve_active_block_id(
             ctx.cg, packed_node.meta["val"].shape[0]
         )
+    if k_block_id is None and packed_rhs is None:
+        remat = cute_rematerialize_rhs_at_contraction_block(ctx, lhs_node, rhs_node)
+        if remat is not None:
+            rhs, k_block_id = remat
     static_k_extent = (
         None
         if k_block_id is not None
@@ -1566,6 +1596,112 @@ def codegen_iota_pallas(ctx: LoweringContext, node: Node) -> object:
     )
 
 
+def _cute_compacted_tile_begin_lane_expr(
+    ctx: LoweringContext,
+    source_node: Node,
+    start: object,
+    step: object,
+    dtype: torch.dtype,
+) -> ast.AST | None:
+    """Resolve ``hl.arange(block // F)`` to the tile-local lane ``lane // F``.
+
+    Handles the compacted sub-block store ``out[tile.begin + hl.arange(block //
+    F)] = split_result`` where the value is a spread/compacted tile whose element
+    on lane ``t`` is the ``t // F`` piece. The arange must contribute only the
+    tile-local coordinate ``lane // F`` because ``tile.begin`` is added
+    explicitly; resolving it to the global ``index_var // F`` would fold the
+    tile's offset in twice. Returns ``None`` unless the pattern matches.
+    """
+    from .cute.cute_reshape import _get_block_local_coord
+    from .cute.iota_utils import cute_free_arange_compacted_tile_begin_factor
+    from .generate_ast import GenerateAST
+
+    assert isinstance(ctx.cg, GenerateAST)
+    cg = ctx.cg
+    match = cute_free_arange_compacted_tile_begin_factor(source_node, cg)
+    if match is None:
+        return None
+    block_id, factor = match
+    local_coord = _get_block_local_coord(cg, block_id)
+    if local_coord is None:
+        return None
+    expr = f"({local_coord}) // cutlass.Int32({factor})"
+    return _wrap_iota_coord_expr(ctx, expr, start, step, dtype)
+
+
+def _cute_free_arange_axis_expr(
+    cg: GenerateAST,
+    source_node: Node,
+    length_hint: int | None,
+    start: object,
+    step: object,
+) -> str | None:
+    """Map a free/unbound ``hl.arange`` index dim onto a synthetic thread axis.
+
+    Returns the per-thread coordinate expression (``thread_idx()[axis]``) when
+    ``source_node`` is an iota that flows into a load/store index but is bound
+    to no tile/reduction/grid axis. Returns ``None`` otherwise so the caller
+    keeps its existing (raising) behavior — this keeps the synthetic-axis path
+    a strict no-op for every already-supported arange.
+    """
+    if not isinstance(length_hint, int) or length_hint <= 0:
+        return None
+    if not cute_iota_is_free_memory_index(source_node, cg):
+        return None
+    # The synthetic axis is keyed by the size of the tensor dimension this
+    # arange indexes. Two arange dims that address the same logical dimension (the
+    # load and store ``hl.arange(k)`` over a K-sized axis) share one axis so a
+    # value loaded on a lane is stored back on that lane, while a cartesian
+    # ``row``/``col`` pair addressing differently-sized dims gets distinct axes.
+    # ``length``/``start``/``step`` round out the key so two distinct arange dims
+    # that happen to index equal-sized dims still separate.
+    dim_key = cute_free_arange_indexed_dim_key(source_node, cg)
+    if dim_key is None:
+        return None
+    key = (
+        dim_key,
+        length_hint,
+        _arange_endpoint_key(start),
+        _arange_endpoint_key(step),
+    )
+    return cg.allocate_cute_synthetic_arange_coord(key, length_hint)
+
+
+def _arange_endpoint_key(value: object) -> object:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, torch.SymInt):
+        return str(value._sympy_())
+    return repr(value)
+
+
+def _wrap_iota_coord_expr(
+    ctx: LoweringContext,
+    coord_expr: str,
+    start: object,
+    step: object,
+    dtype: torch.dtype,
+) -> ast.AST:
+    """Apply ``start``/``step``/``dtype`` to a per-thread iota coordinate.
+
+    Mirrors the trailing wrapping ``_cute_iota_expr`` applies to a resolved
+    block-id coordinate so the synthetic-axis path produces identical
+    ``start + step * coord`` arithmetic.
+    """
+    expr = coord_expr
+    if step != 1:
+        expr = f"{{step}} * ({expr})"
+    if start != 0:
+        expr = f"{{start}} + ({expr})"
+    if dtype != torch.int32:
+        expr = f"{CompileEnvironment.current().backend.dtype_str(dtype)}({expr})"
+    return expr_from_string(
+        expr,
+        start=ctx.to_ast(start),
+        step=ctx.to_ast(step),
+    )
+
+
 def _cute_iota_expr(
     ctx: LoweringContext,
     *,
@@ -1732,6 +1868,12 @@ def _cute_iota_expr(
     if block_id is None:
         if (affine_range := match_cute_affine_range_iota(source_node)) is not None:
             return affine_range
+    if (
+        compacted := _cute_compacted_tile_begin_lane_expr(
+            ctx, source_node, start, step, dtype
+        )
+    ) is not None:
+        return compacted
     if "val" in source_node.meta:
         fake_val = source_node.meta["val"]
         if isinstance(fake_val, torch.Tensor) and fake_val.ndim == 1:
@@ -1778,6 +1920,12 @@ def _cute_iota_expr(
                 "cute.make_identity_tensor({length})",
                 length=ctx.to_ast(length_arg),
             )
+        if (
+            synthetic := _cute_free_arange_axis_expr(
+                cg, source_node, length_hint, start, step
+            )
+        ) is not None:
+            return _wrap_iota_coord_expr(ctx, synthetic, start, step, dtype)
         raise exc.BackendUnsupported(
             "cute",
             "hl.arange() requires an active tile/reduction axis in cute kernels",
@@ -1834,6 +1982,12 @@ def _cute_iota_expr(
                 "cute.make_identity_tensor({length})",
                 length=ctx.to_ast(length_arg),
             )
+        elif (
+            synthetic := _cute_free_arange_axis_expr(
+                cg, source_node, length_hint, start, step
+            )
+        ) is not None:
+            return _wrap_iota_coord_expr(ctx, synthetic, start, step, dtype)
         else:
             raise exc.BackendUnsupported(
                 "cute",

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -679,6 +679,41 @@ class Backend(abc.ABC):
             reserve *= next_power_of_2(min(size_hint, max_reduction_threads))
         return reserve
 
+    def _cute_free_auto_thread_axis_count(
+        self, fn: DeviceFunction, config: Config
+    ) -> int:
+        """Count the kernel's free (non-reduction) tile axes that auto-thread.
+
+        These are the axes that compete for the thread budget left over after a
+        matmul-contraction reduction has reserved its slice (see OPTION B in
+        ``create_loop_strategy``).  The reserve's ``thread_limit`` shrink is
+        applied per ``create_loop_strategy`` call, but a kernel may build the M
+        and N tile axes in *separate* calls (e.g. M is the grid, N is a device
+        loop).  Each call only sees its own axes, so dividing the per-call
+        ``thread_limit`` by the reserve once is not enough: the product of every
+        free axis' threads must stay within ``1024 // reserve``.  Counting all
+        the free auto-threaded axes lets each call take only its fair share.
+        """
+        from .compile_environment import CompileEnvironment
+
+        env = CompileEnvironment.current()
+        count = 0
+        for block_id in _active_loop_block_ids(fn):
+            info = env.block_sizes[block_id]
+            if info.reduction:
+                continue
+            block_size = info.from_config(config)
+            if not isinstance(block_size, int) or block_size <= 1:
+                continue
+            threads = int(
+                env.config_spec.num_threads.config_get(config.num_threads, block_id, 0)
+            )
+            # Only auto-threaded (``num_threads == 0``) axes participate in the
+            # budget split; explicitly-threaded axes keep their configured count.
+            if threads == 0:
+                count += 1
+        return max(count, 1)
+
     def create_loop_strategy(
         self, fn: DeviceFunction, block_ids: list[int], config: Config
     ) -> TileStrategy:
@@ -2711,7 +2746,9 @@ class CuteBackend(Backend):
         tile_strategy: TileStrategyDispatch,
     ) -> None:
         from .cute.layout_propagation import plan_layouts
+        from .cute.view_subtile import annotate_view_subtiles
 
+        annotate_view_subtiles(graphs, config)
         plan_layouts(graphs, config, tile_strategy)
 
     def supports_config_key(self, key: str) -> bool:
@@ -3536,9 +3573,21 @@ class CuteBackend(Backend):
             and static_dims != (1, 1, 1)
             and not has_nested_device_loops
             and static_threads < dynamic_threads
+            # Synthetic free-``hl.arange`` thread axes are real launch lanes that
+            # the strategy's ``static_dims`` does not know about, so do not fall
+            # back to ``static_dims`` (which would drop them) when they are live.
+            and not codegen.cute_synthetic_arange_axis_sizes
         ):
             dims = static_dims
-        if dim_exprs is not None and dim_exprs != ("1", "1", "1"):
+        if (
+            dim_exprs is not None
+            and dim_exprs != ("1", "1", "1")
+            # ``dim_exprs`` is the strategy's static per-axis launch shape; it
+            # has no entry for synthetic free-``hl.arange`` axes, so adopting it
+            # wholesale would shrink those axes back to 1. Skip it when they are
+            # live (the synthetic extents are already folded into ``dims``).
+            and not codegen.cute_synthetic_arange_axis_sizes
+        ):
             if all(expr.isdigit() for expr in dim_exprs):
                 expr_dims = tuple(int(expr) for expr in dim_exprs)
                 if functools.reduce(
@@ -3930,7 +3979,17 @@ class CuteBackend(Backend):
                 fn, block_ids
             )
             if reserved_contraction_threads > 1:
-                thread_limit = max(1, thread_limit // reserved_contraction_threads)
+                # Budget left for the free tile axes after the contraction axis
+                # has claimed its full thread extent.
+                free_budget = max(1, thread_limit // reserved_contraction_threads)
+                # The free axes are built across separate ``create_loop_strategy``
+                # calls but their thread counts multiply, so split the budget so
+                # the product over every free axis stays within ``free_budget``.
+                free_axes = self._cute_free_auto_thread_axis_count(fn, config)
+                per_axis_limit = free_budget
+                while per_axis_limit > 1 and per_axis_limit**free_axes > free_budget:
+                    per_axis_limit //= 2
+                thread_limit = max(1, per_axis_limit)
             static_threads = _shrink_auto_thread_counts(nd_block_size, thread_limit)
             from .cute.thread_budget import check_thread_limit
 

--- a/helion/_compiler/cute/device_state.py
+++ b/helion/_compiler/cute/device_state.py
@@ -288,6 +288,13 @@ class CuteDeviceFunctionState:
         self.cluster_shape: tuple[int, int, int] | None = None
         self.block_shape: tuple[int, int, int] | None = None
         self.suppress_root_lane_loops = False
+        # Active block-id remapping for matmul operand re-materialization.
+        # Maps a source block_id (e.g. the rhs operand's loop-invariant
+        # contraction index) to the active contraction block_id so a
+        # re-lowered operand load reads ``rhs[..., k, ...]`` per contraction
+        # step instead of the loop-invariant ``rhs[..., m, ...]``.  Empty
+        # except while re-materializing a matmul operand load.
+        self.matmul_operand_block_remap: dict[int, int] = {}
 
     def register_tcgen05_store_value(
         self, name: str, value: CuteTcgen05StoreValue

--- a/helion/_compiler/cute/iota_utils.py
+++ b/helion/_compiler/cute/iota_utils.py
@@ -71,3 +71,385 @@ def cute_iota_has_atomic_tensor_index_only_users(
         cg,
         _visited=visited,
     )
+
+
+# Per-thread pointwise / reshape ops that keep each thread's scalar element in
+# place. A free ``hl.arange`` feeding such an op (e.g. ``start + arange`` or
+# ``arange < end`` for the bounds mask) still describes a per-lane coordinate,
+# so we look *through* these to confirm the arange ultimately lands in a
+# load/store index (or its mask).
+def _iota_index_passthrough_target(target: object) -> bool:
+    import torch
+
+    name = getattr(target, "__name__", "")
+    if name == "getitem":
+        return True
+    target_str = str(target)
+    return any(
+        op in target_str
+        for op in (
+            "add.",
+            "sub.",
+            "mul.",
+            "div.",
+            "lt.",
+            "le.",
+            "gt.",
+            "ge.",
+            "eq.",
+            "ne.",
+            "remainder.",
+            "bitwise_and.",
+            "bitwise_or.",
+            "__and__",
+            "__or__",
+            "expand.",
+            "unsqueeze.",
+            "view.",
+            "reshape.",
+            "_unsafe_view.",
+            "convert_element_type.",
+            "_to_copy.",
+        )
+    ) or target in (
+        torch.ops.aten.expand.default,
+        torch.ops.aten.unsqueeze.default,
+        torch.ops.aten.view.default,
+        torch.ops.aten.reshape.default,
+    )
+
+
+def _is_memory_op_index_user(source_node: Node, user: Node) -> bool:
+    """True when ``source_node`` appears in a load/store's index list."""
+    from ...language import memory_ops
+
+    if user.op != "call_function" or user.target not in (
+        memory_ops.load,
+        memory_ops.store,
+    ):
+        return False
+    if len(user.args) < 2:
+        return False
+    index_arg = user.args[1]
+    if not isinstance(index_arg, (list, tuple)):
+        return False
+    return any(entry is source_node for entry in index_arg)
+
+
+def cute_iota_is_free_memory_index(
+    source_node: Node,
+    cg: GenerateAST,
+    *,
+    _visited: set[Node] | None = None,
+) -> bool:
+    """True when a free ``hl.arange`` iota ultimately indexes a load/store.
+
+    Recognizes the unbound-arange-index pattern: an iota whose value flows
+    (possibly through per-lane pointwise/reshape ops, mask comparisons, or a
+    for-loop placeholder) into a ``memory_ops.load``/``memory_ops.store`` index
+    list. This is the gate for mapping the arange onto a synthetic thread axis.
+    """
+
+    visited = set() if _visited is None else _visited
+    if source_node in visited:
+        return False
+    visited.add(source_node)
+
+    for user in source_node.users:
+        if _is_memory_op_index_user(source_node, user):
+            return True
+        if user.op != "call_function":
+            continue
+        if _is_for_loop_placeholder_index_user(source_node, user, cg, visited):
+            return True
+        if _iota_index_passthrough_target(
+            user.target
+        ) and cute_iota_is_free_memory_index(user, cg, _visited=visited):
+            return True
+    return False
+
+
+def _is_for_loop_placeholder_index_user(
+    source_node: Node,
+    user: Node,
+    cg: GenerateAST,
+    visited: set[Node],
+) -> bool:
+    from ..device_ir import ForLoopGraphInfo
+
+    if (
+        not _tracing_ops.is_for_loop_target(user.target)
+        or not user.args
+        or not isinstance(user.args[0], int)
+    ):
+        return False
+    graph_info = cg.get_graph(user.args[0])
+    if not isinstance(graph_info, ForLoopGraphInfo):
+        return False
+    matched_placeholders = [
+        placeholder
+        for placeholder, outer_node in zip(
+            graph_info.graph.find_nodes(op="placeholder"),
+            graph_info.node_args,
+            strict=True,
+        )
+        if outer_node is source_node
+    ]
+    return any(
+        cute_iota_is_free_memory_index(placeholder, cg, _visited=visited)
+        for placeholder in matched_placeholders
+    )
+
+
+def cute_free_arange_indexed_dim_key(
+    source_node: Node,
+    cg: GenerateAST,
+    *,
+    _visited: set[Node] | None = None,
+) -> object | None:
+    """Return a stable key for the tensor dim a free ``hl.arange`` indexes.
+
+    The key is the (stringified) size of the tensor dimension the arange lands
+    in. Two arange dims that address the *same* logical dimension (e.g. the load
+    and store ``hl.arange(k)`` over a K-sized axis) yield the same key and
+    therefore share one synthetic thread axis, while a cartesian ``row``/``col``
+    pair addressing differently-sized dims gets distinct keys (distinct axes).
+    Returns ``None`` when no load/store index consumer is found.
+    """
+    visited = set() if _visited is None else _visited
+    if source_node in visited:
+        return None
+    visited.add(source_node)
+
+    for user in source_node.users:
+        key = _memory_op_indexed_dim_key(source_node, user)
+        if key is not None:
+            return key
+        if user.op != "call_function":
+            continue
+        placeholder_key = _for_loop_placeholder_dim_key(source_node, user, cg, visited)
+        if placeholder_key is not None:
+            return placeholder_key
+        if _iota_index_passthrough_target(user.target):
+            downstream = cute_free_arange_indexed_dim_key(user, cg, _visited=visited)
+            if downstream is not None:
+                return downstream
+    return None
+
+
+def _memory_op_indexed_dim_key(source_node: Node, user: Node) -> object | None:
+    import torch
+    from torch.fx.node import Node as FxNode
+
+    from ...language import memory_ops
+
+    if user.op != "call_function" or user.target not in (
+        memory_ops.load,
+        memory_ops.store,
+    ):
+        return None
+    if len(user.args) < 2:
+        return None
+    index_arg = user.args[1]
+    if not isinstance(index_arg, (list, tuple)):
+        return None
+    tensor_node = user.args[0]
+    if not isinstance(tensor_node, FxNode):
+        return None
+    tensor_val = tensor_node.meta.get("val")
+    if not isinstance(tensor_val, torch.Tensor):
+        return None
+    tensor_dim = 0
+    for entry in index_arg:
+        if entry is None:
+            # ``None`` introduces a new broadcast dim; it does not consume a
+            # tensor dimension.
+            continue
+        if entry is source_node:
+            if tensor_dim >= tensor_val.ndim:
+                return None
+            # Key on (index position, dim size). The position disambiguates two
+            # distinct free arange nodes that co-occur as different entries of a
+            # load/store index list but address equal-sized dims (e.g. a square
+            # cartesian ``out[arange(N), arange(N)]``): without the position they
+            # would share one synthetic thread axis and only the diagonal would
+            # be written. A single arange node reused across a load and a store
+            # still resolves to one key (one axis), preserving the roundtrip.
+            return (tensor_dim, str(tensor_val.shape[tensor_dim]))
+        tensor_dim += 1
+    return None
+
+
+def _for_loop_placeholder_dim_key(
+    source_node: Node,
+    user: Node,
+    cg: GenerateAST,
+    visited: set[Node],
+) -> object | None:
+    from ..device_ir import ForLoopGraphInfo
+
+    if (
+        not _tracing_ops.is_for_loop_target(user.target)
+        or not user.args
+        or not isinstance(user.args[0], int)
+    ):
+        return None
+    graph_info = cg.get_graph(user.args[0])
+    if not isinstance(graph_info, ForLoopGraphInfo):
+        return None
+    for placeholder, outer_node in zip(
+        graph_info.graph.find_nodes(op="placeholder"),
+        graph_info.node_args,
+        strict=True,
+    ):
+        if outer_node is source_node:
+            key = cute_free_arange_indexed_dim_key(placeholder, cg, _visited=visited)
+            if key is not None:
+                return key
+    return None
+
+
+def cute_free_arange_compacted_tile_begin_factor(
+    source_node: Node,
+    cg: GenerateAST,
+) -> tuple[int, int] | None:
+    """Detect ``out[tile.begin + hl.arange(block // F)] = compacted_tile``.
+
+    Returns ``(block_id, factor)`` when ``source_node`` is a free ``hl.arange``
+    whose only consumer is an ``add(arange, tile.begin)`` that feeds a load/store
+    index list, and whose length is the tile's block size divided by a constexpr
+    factor ``F`` (i.e. the arange addresses a *compacted* sub-block tile). The
+    arange must then resolve to the tile-LOCAL lane ``lane // F`` rather than the
+    global ``index_var // F``: the global form already folds the tile's offset in,
+    so adding ``tile.begin`` again double-counts it.
+
+    Returns ``None`` (a strict no-op) unless the whole pattern matches, so every
+    already-supported arange keeps its existing resolution.
+    """
+    import torch
+
+    factor = _arange_block_split_factor(source_node)
+    if factor is None:
+        return None
+    block_id, _ = factor
+
+    users = list(source_node.users)
+    if len(users) != 1:
+        return None
+    (add_node,) = users
+    if (
+        add_node.op != "call_function"
+        or add_node.target is not torch.ops.aten.add.Tensor
+    ):
+        return None
+
+    other = _add_sibling(add_node, source_node)
+    if other is None or not _is_tile_begin_node(other, block_id):
+        return None
+    if not _add_feeds_memory_index(add_node):
+        return None
+    return factor
+
+
+def _arange_block_split_factor(source_node: Node) -> tuple[int, int] | None:
+    """Return ``(block_id, factor)`` when the arange length is ``block // F``."""
+    import sympy
+    import torch
+    from torch.utils._sympy.functions import FloorDiv
+
+    from ..compile_environment import CompileEnvironment
+
+    fake_val = source_node.meta.get("val")
+    if not isinstance(fake_val, torch.Tensor) or fake_val.ndim != 1:
+        return None
+    length = fake_val.shape[0]
+    if not isinstance(length, torch.SymInt):
+        return None
+    expr = length._sympy_()
+    if not isinstance(expr, FloorDiv) or len(expr.args) != 2:
+        return None
+    base, divisor = expr.args
+    if not isinstance(base, sympy.Symbol) or not isinstance(divisor, sympy.Integer):
+        return None
+    factor = int(divisor)
+    if factor < 2:
+        return None
+    block_id = CompileEnvironment.current().get_block_id(base)
+    if block_id is None:
+        return None
+    return block_id, factor
+
+
+def _add_sibling(add_node: Node, source_node: Node) -> Node | None:
+    from torch.fx.node import Node as FxNode
+
+    siblings = [
+        arg
+        for arg in add_node.args
+        if isinstance(arg, FxNode) and arg is not source_node
+    ]
+    if len(siblings) != 1:
+        return None
+    return siblings[0]
+
+
+def _is_tile_begin_node(node: Node, block_id: int) -> bool:
+    """True when ``node`` is (a scalar arithmetic derivative of) ``tile.begin``.
+
+    The store base may pre-scale the begin to match a compacted output, e.g.
+    ``out[tile.begin // F + arange]``. We unwrap integer ``floordiv``/``mul``/
+    ``add`` chains whose tensor operand is the tile's ``tile_begin`` for the same
+    block id so both ``tile.begin + arange`` and ``tile.begin // F + arange``
+    qualify.
+    """
+    import operator
+
+    import torch
+    from torch.fx.node import Node as FxNode
+
+    from ...language.tile_ops import tile_begin
+    from ..compile_environment import CompileEnvironment
+
+    if node.op != "call_function" or not node.args:
+        return False
+
+    if node.target is tile_begin:
+        tile_arg = node.args[0]
+        if not isinstance(tile_arg, FxNode):
+            return False
+        tile_val = tile_arg.meta.get("val")
+        if not isinstance(tile_val, torch.SymInt):
+            return False
+        return CompileEnvironment.current().get_block_id(tile_val) == block_id
+
+    scalar_arith = {
+        torch.ops.aten.floor_divide.default,
+        torch.ops.aten.mul.Tensor,
+        torch.ops.aten.add.Tensor,
+        torch.ops.aten.sub.Tensor,
+        operator.floordiv,
+        operator.mul,
+        operator.add,
+        operator.sub,
+    }
+    if node.target in scalar_arith:
+        return any(
+            isinstance(arg, FxNode) and _is_tile_begin_node(arg, block_id)
+            for arg in node.args
+        )
+    return False
+
+
+def _add_feeds_memory_index(add_node: Node) -> bool:
+    from ...language import memory_ops
+
+    for user in add_node.users:
+        if (
+            user.op == "call_function"
+            and user.target in (memory_ops.load, memory_ops.store)
+            and len(user.args) >= 2
+            and isinstance(user.args[1], (list, tuple))
+            and any(entry is add_node for entry in user.args[1])
+        ):
+            return True
+    return False

--- a/helion/_compiler/cute/matmul_utils.py
+++ b/helion/_compiler/cute/matmul_utils.py
@@ -643,6 +643,118 @@ def cute_resolve_active_matmul_k_block_id(
     return lhs_k_block_id
 
 
+def cute_rematerialize_rhs_at_contraction_block(
+    ctx: LoweringContext,
+    lhs_node: torch.fx.Node,
+    rhs_node: torch.fx.Node,
+) -> tuple[ast.AST, int] | None:
+    """Re-lower a matmul ``rhs`` whose contraction axis is the *wrong* block.
+
+    Handles the case where ``lhs.shape[-1]`` (the contraction) and
+    ``rhs.shape[-2]`` (the contraction) resolve to *different* active block
+    ids that happen to share the same size (e.g. ``mask[b, q, k] @ q[b, q, h]``
+    where the lhs contracts on the inner ``tile_k`` loop but the rhs's middle
+    dim is indexed by the outer ``tile_q``).  The originally-lowered ``rhs``
+    load is then loop-invariant in the contraction loop and the matmul would
+    read ``rhs[..., q, ...]`` every step instead of ``rhs[..., k, ...]``.
+
+    Re-codegens the ``rhs`` load with the contraction block remapped from its
+    original (loop-invariant) block to the active contraction block, so each
+    contraction step reads the correct element.  Returns
+    ``(new_rhs_ast, k_block_id)`` on success, or ``None`` when the case does
+    not apply (caller keeps its existing behaviour).
+    """
+    env = CompileEnvironment.current()
+    canonical_block_id = getattr(env, "canonical_block_id", lambda block_id: block_id)
+    lhs_val = lhs_node.meta.get("val")
+    rhs_val = rhs_node.meta.get("val")
+    if not isinstance(lhs_val, torch.Tensor) or not isinstance(rhs_val, torch.Tensor):
+        return None
+    if lhs_val.ndim < 2 or rhs_val.ndim < 2:
+        return None
+    lhs_k_block_id = cute_resolve_active_block_id(ctx.cg, lhs_val.shape[-1])
+    rhs_k_block_id = cute_resolve_active_block_id(ctx.cg, rhs_val.shape[-2])
+    if lhs_k_block_id is None or rhs_k_block_id is None:
+        return None
+    if canonical_block_id(lhs_k_block_id) == canonical_block_id(rhs_k_block_id):
+        # Same block already - no remap needed; the standard resolver handles it.
+        return None
+    # The two contraction axes must have the same extent for the matmul to be
+    # well-defined; require the same static size before remapping.
+    if not env.known_equal(lhs_val.shape[-1], rhs_val.shape[-2]):
+        return None
+    # Only re-materialize a plain ``load`` whose middle (contraction) dim is the
+    # block we need to remap.  Anything more complex (computed operands,
+    # permutes) is left to the existing path.
+    if rhs_node.target is not load:
+        return None
+    if len(rhs_node.args) < 2 or not isinstance(rhs_node.args[1], (list, tuple)):
+        return None
+    # The remapped rhs would now contract on ``lhs_k_block_id``; reject if its
+    # free (N) axis collides with that same block.
+    rhs_n_block_id = cute_resolve_active_block_id(ctx.cg, rhs_val.shape[-1])
+    if rhs_n_block_id is not None and canonical_block_id(
+        rhs_n_block_id
+    ) == canonical_block_id(lhs_k_block_id):
+        return None
+
+    new_rhs = _cute_recodegen_load_with_block_remap(
+        ctx, rhs_node, {rhs_k_block_id: lhs_k_block_id}
+    )
+    if new_rhs is None:
+        return None
+    return new_rhs, lhs_k_block_id
+
+
+def _cute_recodegen_load_with_block_remap(
+    ctx: LoweringContext,
+    load_node: torch.fx.Node,
+    remap: dict[int, int],
+) -> ast.AST | None:
+    """Re-run the CuTe ``load`` codegen for *load_node* under a block remap."""
+    from ..generate_ast import GenerateAST
+    from ..inductor_lowering import CodegenState
+
+    cg = ctx.cg
+    if not isinstance(cg, GenerateAST):
+        return None
+    cute_state = cg.device_function.cute_state
+
+    def env_arg(arg: object) -> object:
+        if isinstance(arg, torch.fx.Node):
+            return ctx.env[arg]
+        if isinstance(arg, (list, tuple)):
+            return type(arg)(env_arg(a) for a in arg)
+        return arg
+
+    def proxy_arg(arg: object) -> object:
+        if isinstance(arg, torch.fx.Node):
+            return arg.meta["val"]
+        if isinstance(arg, (list, tuple)):
+            return type(arg)(proxy_arg(a) for a in arg)
+        return arg
+
+    proxy_args = [proxy_arg(a) for a in load_node.args]
+    ast_args = [env_arg(a) for a in load_node.args]
+    state = CodegenState(
+        cg,
+        fx_node=load_node,
+        env=ctx.env,
+        proxy_args=list(proxy_args),
+        ast_args=list(ast_args),
+    )
+    previous = dict(cute_state.matmul_operand_block_remap)
+    cute_state.matmul_operand_block_remap = dict(remap)
+    load_codegen = load._codegen["cute"]  # pyrefly: ignore[missing-attribute]
+    try:
+        result = load_codegen(state)
+    finally:
+        cute_state.matmul_operand_block_remap = previous
+    if isinstance(result, ast.AST):
+        return result
+    return None
+
+
 def _cute_matmul_operand_indices() -> dict[object, tuple[int, int]]:
     """``(lhs_arg_index, rhs_arg_index)`` for each matmul op the CuTe backend
     lowers through the scalar fallback.

--- a/helion/_compiler/cute/view_subtile.py
+++ b/helion/_compiler/cute/view_subtile.py
@@ -1,0 +1,110 @@
+"""Attach subtile coordinate metadata to view/reshape nodes that split a
+single tiled block dimension by a constexpr factor.
+
+A user-written ``val.view(block_size // F, F)`` (or ``reshape``) turns a 1-D
+block tile ``[D]`` distributed over a single thread axis into a 2-D tile
+``[D // F, F]``. The new dimensions carry no intrinsic per-thread coordinate,
+so without help ``hl.split``'s CuTe codegen reads constant-0 coordinates and
+every thread writes the same shared-memory slot.
+
+This pass detects that pattern and records, on the view node, the per-dimension
+``{block_id, divisor, modulus}`` mapping that ``cute_reshape._subtile_coord_expr``
+expands into ``block_local // divisor`` / ``block_local % modulus``. With the
+metadata attached, dim ``i`` of ``[D // F, F]`` maps thread lane ``t`` to
+``(t // F, t % F)`` so the flattened source index is ``t`` again — i.e. thread
+``t`` writes its own loaded scalar to ``smem[t]``.
+
+The pass is a strict no-op unless every gate matches, so existing reshape/split
+kernels are byte-for-byte unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from ...language.view_ops import split as hl_split
+from ..compile_environment import CompileEnvironment
+from .cute_reshape import CUTE_DIM_LOCAL_COORD_META
+
+if TYPE_CHECKING:
+    from ...runtime.config import Config
+    from ..device_ir import GraphInfo
+
+_VIEW_TARGETS = (
+    torch.ops.aten.view.default,
+    torch.ops.aten.reshape.default,
+    torch.ops.aten._unsafe_view.default,
+)
+
+
+def annotate_view_subtiles(graphs: list[GraphInfo], config: Config) -> None:
+    """Annotate single-block-dim split views with subtile coordinate metadata."""
+    env = CompileEnvironment.current()
+    for graph_info in graphs:
+        for node in graph_info.graph.nodes:
+            if node.op != "call_function" or node.target not in _VIEW_TARGETS:
+                continue
+            if CUTE_DIM_LOCAL_COORD_META in node.meta:
+                continue
+            # Only meaningful when the view feeds ``hl.split`` — that is the only
+            # consumer of this metadata. Restricting to split consumers keeps the
+            # pass from touching unrelated reshape nodes.
+            if not _feeds_split(node):
+                continue
+            meta = _split_subtile_coord_meta(node, env, config)
+            if meta is not None:
+                node.meta[CUTE_DIM_LOCAL_COORD_META] = meta
+
+
+def _feeds_split(node: torch.fx.Node) -> bool:
+    return any(
+        user.op == "call_function" and user.target is hl_split for user in node.users
+    )
+
+
+def _split_subtile_coord_meta(
+    node: torch.fx.Node,
+    env: CompileEnvironment,
+    config: Config,
+) -> list[object | None] | None:
+    """Return ``[..{block_id, divisor, modulus}..]`` for a 1-D-block split view.
+
+    Recognizes exactly ``[D] -> [D // F, F]`` where ``D`` is a single tiled
+    block dim mapped to one thread axis and ``F`` is a static constexpr factor.
+    """
+    output_val = node.meta.get("val")
+    source = node.args[0]
+    if not isinstance(source, torch.fx.Node):
+        return None
+    input_val = source.meta.get("val")
+    if not isinstance(output_val, torch.Tensor) or not isinstance(
+        input_val, torch.Tensor
+    ):
+        return None
+    # Only the bare ``[D] -> [D // F, F]`` shape is handled here.
+    if input_val.ndim != 1 or output_val.ndim != 2:
+        return None
+
+    factor = output_val.shape[1]
+    if not isinstance(factor, int) or factor < 2:
+        return None
+
+    block_id = env.get_block_id(input_val.shape[0])
+    if block_id is None:
+        return None
+    if env.block_sizes[block_id].reduction or env.is_jagged_tile(block_id):
+        return None
+
+    # The view collapses the whole block dim into ``[D // F, F]`` only when the
+    # configured block size is an exact multiple of the constexpr factor.
+    block_size = env.block_sizes[block_id].from_config(config)
+    if not isinstance(block_size, int) or block_size % factor != 0:
+        return None
+
+    # dim 0 (size D // F): block_local // F ; dim 1 (size F): block_local % F.
+    return [
+        {"block_id": block_id, "divisor": factor, "modulus": None},
+        {"block_id": block_id, "divisor": 1, "modulus": factor},
+    ]

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -753,6 +753,78 @@ class DeviceIR:
         assert isinstance(graph_info, RootGraphInfo)
         return graph_info.phase_index
 
+    @staticmethod
+    def branch_paths_mutually_exclusive(
+        path_a: list[tuple[int, int]] | None,
+        path_b: list[tuple[int, int]] | None,
+    ) -> bool:
+        """True when two control-flow branch paths can never both execute.
+
+        Paths are mutually exclusive when some dynamic ``_if`` appears in both
+        with different branch sides (one took the ``if`` body, the other the
+        ``else`` body). Each entry is ``(if_node_key, side)``.
+        """
+        if path_a is None or path_b is None:
+            return False
+        sides_b = dict(path_b)
+        return any(
+            node_id in sides_b and sides_b[node_id] != side for node_id, side in path_a
+        )
+
+    def reduction_block_id_branch_paths(
+        self,
+    ) -> dict[int, list[list[tuple[int, int]]]]:
+        """Map each reduction block id to the control-flow branch path(s) it runs in.
+
+        Walks the graph tree from each root, tracking ``(if_graph_id, side)``
+        decisions (side 0 = ``if`` body, 1 = ``else`` body) made by dynamic
+        ``_if`` nodes. For every reduction node it records the branch path of
+        the enclosing graph, keyed by the reduction's ``block_index``.
+
+        Two reductions whose paths diverge at a common ``_if`` (one took the
+        ``if`` body, the other the ``else`` body) are mutually exclusive in time
+        and may therefore share a CUDA thread axis. Returns ``{}`` when no
+        reduction lives under a dynamic branch (the common, non-branching case),
+        so callers leave the default thread-axis assignment untouched.
+        """
+        from .inductor_lowering import ReductionLowering
+
+        result: dict[int, list[list[tuple[int, int]]]] = {}
+
+        def walk(graph_id: int, path: list[tuple[int, int]]) -> None:
+            if not 0 <= graph_id < len(self.graphs):
+                return
+            graph = self.graphs[graph_id].graph
+            for node in graph.nodes:
+                if node.op != "call_function":
+                    continue
+                lowering = node.meta.get("lowering")
+                if isinstance(lowering, ReductionLowering) and isinstance(
+                    lowering.block_index, int
+                ):
+                    result.setdefault(lowering.block_index, [])
+                    if path not in result[lowering.block_index]:
+                        result[lowering.block_index].append(list(path))
+                if node.target is _tracing_ops._if and len(node.args) >= 3:
+                    _, if_graph_id, else_graph_id, *_rest = node.args
+                    if_node_key = id(node)
+                    if isinstance(if_graph_id, int):
+                        walk(if_graph_id, [*path, (if_node_key, 0)])
+                    if isinstance(else_graph_id, int):
+                        walk(else_graph_id, [*path, (if_node_key, 1)])
+                elif (
+                    _tracing_ops.is_for_loop_target(node.target)
+                    and node.args
+                    and isinstance(node.args[0], int)
+                ):
+                    # For/reduction loops do not introduce mutual exclusivity;
+                    # descend without extending the path.
+                    walk(node.args[0], path)
+
+        for root_id in self.root_ids:
+            walk(root_id, [])
+        return result
+
     def register_rollable_reductions(self) -> None:
         """Analyze graphs for rollable reductions and register ReductionLoopSpec entries.
 

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -92,6 +92,33 @@ class GenerateAST(NodeVisitor, CodegenInterface):
         self.max_thread_block_dims = [1, 1, 1]
         self.root_thread_block_dims = [1, 1, 1]
         self.referenced_thread_block_dims = [1, 1, 1]
+        # CuTe only: synthetic per-thread axes allocated for free/unbound
+        # ``hl.arange`` index dims that are not bound to any tile/reduction/grid
+        # axis. Maps a stable per-arange key (length, start-repr, step-repr) to
+        # the launch thread axis it occupies. ``thread_axis_sizes`` records the
+        # extent of each allocated synthetic axis so the launch-dim recovery in
+        # ``backend.py`` can grow the thread block to cover those lanes.
+        self.cute_synthetic_arange_axes: dict[tuple[object, ...], int] = {}
+        self.cute_synthetic_arange_axis_sizes: dict[int, int] = {}
+        # CuTe only: stack of ``(if_node_id, branch_side)`` entries describing the
+        # mutually-exclusive control-flow branch the current codegen is inside.
+        # ``branch_side`` is 0 for the ``if`` body and 1 for the ``else`` body of
+        # a given dynamic ``_if``. Two free ``hl.arange`` dims that live in
+        # mutually-exclusive branches (their paths diverge at a common ``_if``)
+        # may reuse the same synthetic thread axis since only one branch ever
+        # runs per program instance.
+        self._cute_branch_path: list[tuple[int, int]] = []
+        # Records the branch path captured when each synthetic arange axis was
+        # allocated, so a later arange in a mutually-exclusive branch can reuse it.
+        self._cute_synthetic_arange_axis_branch_paths: dict[
+            int, list[list[tuple[int, int]]]
+        ] = {}
+        # CuTe only: free ``hl.arange`` dims whose (joint) thread count would
+        # exceed the 1024-thread budget are chunked onto a sequential lane loop
+        # instead of claiming a fresh thread axis. Maps the per-arange ``key`` to
+        # the resolved per-thread coordinate expression so a load and store over
+        # the same arange share one lane loop.
+        self.cute_synthetic_arange_lane_exprs: dict[tuple[object, ...], str] = {}
         self.next_else_block: list[ast.AST] | None = None
         self.store_transform = store_transform
         self.load_transform = load_transform
@@ -352,6 +379,30 @@ class GenerateAST(NodeVisitor, CodegenInterface):
         finally:
             self._statement_owner_fx_node = prior
 
+    @contextlib.contextmanager
+    def cute_branch_scope(self, if_node_id: int, branch_side: int) -> Iterator[None]:
+        """Mark codegen as inside one branch of a dynamic ``_if`` (CuTe only).
+
+        ``branch_side`` is 0 for the ``if`` body and 1 for the ``else`` body.
+        Used so synthetic ``hl.arange`` axes allocated in mutually-exclusive
+        branches can share a single thread axis.
+        """
+        self._cute_branch_path.append((if_node_id, branch_side))
+        try:
+            yield
+        finally:
+            self._cute_branch_path.pop()
+
+    def _cute_branch_paths_mutually_exclusive(
+        self,
+        path_a: list[tuple[int, int]],
+        path_b: list[tuple[int, int]],
+    ) -> bool:
+        """True when two branch paths can never both execute."""
+        from .device_ir import DeviceIR
+
+        return DeviceIR.branch_paths_mutually_exclusive(path_a, path_b)
+
     def _record_thread_axis_sizes(self, axis_sizes: dict[int, int]) -> None:
         for axis, size in axis_sizes.items():
             if 0 <= axis < 3:
@@ -373,7 +424,289 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                 seen.add(key)
                 for axis, size in loop_state.thread_axis_sizes.items():
                     axis_sizes[axis] = max(axis_sizes.get(axis, 1), size)
+        # Synthetic axes for free ``hl.arange`` index dims (CuTe only) live
+        # outside the strategy loop states, so fold their extents in here too
+        # — that way ``_record_statement_thread_references`` grows the launch
+        # block to cover the lanes those arange dims address.
+        for axis, size in self.cute_synthetic_arange_axis_sizes.items():
+            axis_sizes[axis] = max(axis_sizes.get(axis, 1), size)
         return axis_sizes
+
+    def allocate_cute_synthetic_arange_coord(
+        self, key: tuple[object, ...], size: int
+    ) -> str | None:
+        """Resolve a free ``hl.arange`` dim to a per-thread coordinate expr.
+
+        Returns ``cute.arch.thread_idx()[axis]`` when the arange fits a fresh (or
+        reusable) CUDA thread axis within the 1024-thread budget. When it would
+        instead overflow the budget, the arange is chunked onto a sequential lane
+        loop (``thread_idx()[axis] * 1 + lane * 1`` collapses to ``lane``, or
+        ``thread_idx()[axis] + lane * nt`` when some thread lanes still fit) so
+        the full extent stays addressable; the lane loop wraps the grid body.
+        Returns ``None`` when no synthetic axis can be assigned (axis index >= 3).
+        """
+        lane_expr = self.cute_synthetic_arange_lane_exprs.get(key)
+        if lane_expr is not None:
+            return lane_expr
+        if (
+            key not in self.cute_synthetic_arange_axes
+            and self._cute_arange_needs_lane_loop(key, size)
+        ):
+            return self._allocate_cute_synthetic_arange_lane_loop(key, size)
+        axis = self.allocate_cute_synthetic_arange_axis(key, size)
+        if axis >= 3:
+            return None
+        return f"cutlass.Int32(cute.arch.thread_idx()[{axis}])"
+
+    def _cute_arange_proposed_total(self, axis: int, size: int) -> int:
+        """Joint thread count if ``size`` were placed on a fresh ``axis``."""
+        proposed_sizes = dict(self.cute_synthetic_arange_axis_sizes)
+        proposed_sizes[axis] = size
+        strategy_threads = 1
+        for strat_axis, strat_size in self._strategy_thread_axis_sizes().items():
+            if strat_axis not in proposed_sizes:
+                strategy_threads *= strat_size
+        total = strategy_threads
+        for axis_size in proposed_sizes.values():
+            total *= axis_size
+        return total
+
+    def _cute_arange_needs_lane_loop(self, key: tuple[object, ...], size: int) -> bool:
+        # The lane loop is hosted by the grid body wrapper, so only chunk when a
+        # grid state exists to carry it; otherwise keep the (raising) thread-axis
+        # path rather than emitting an un-iterated lane variable.
+        if self.current_grid_state is None:
+            return False
+        # A mutually-exclusive branch reuse never grows the budget, so prefer it.
+        if self._mutually_exclusive_synthetic_axis() is not None:
+            return False
+        used_axes = set(self._strategy_thread_axes())
+        used_axes.update(self.cute_synthetic_arange_axes.values())
+        axis = 0
+        while axis in used_axes:
+            axis += 1
+        from .cute.thread_budget import MAX_THREADS_PER_BLOCK
+
+        if axis >= 3:
+            return True
+        return self._cute_arange_proposed_total(axis, size) > MAX_THREADS_PER_BLOCK
+
+    def _allocate_cute_synthetic_arange_lane_loop(
+        self, key: tuple[object, ...], size: int
+    ) -> str:
+        """Chunk a free ``hl.arange`` onto a sequential lane loop.
+
+        Uses ``nt`` live thread lanes on a fresh axis (``nt`` is the largest
+        power-of-2 that keeps the joint budget within 1024, possibly 1) and a
+        ``ceil(size / nt)`` sequential lane loop covering the rest. The arange's
+        per-thread coordinate is ``thread_idx()[axis] + lane * nt``.
+        """
+        from torch._inductor.runtime.runtime_utils import next_power_of_2
+
+        from .cute.thread_budget import MAX_THREADS_PER_BLOCK
+
+        used_axes = set(self._strategy_thread_axes())
+        used_axes.update(self.cute_synthetic_arange_axes.values())
+        axis = 0
+        while axis in used_axes and axis < 3:
+            axis += 1
+
+        # Threads already committed (strategy axes + other synthetic axes).
+        committed = 1
+        for strat_size in self._strategy_thread_axis_sizes().values():
+            committed *= strat_size
+        for axis_size in self.cute_synthetic_arange_axis_sizes.values():
+            committed *= axis_size
+        budget = max(1, MAX_THREADS_PER_BLOCK // max(1, committed))
+        nt = 1
+        if axis < 3:
+            nt = min(next_power_of_2(size), 1 << (budget.bit_length() - 1))
+            nt = max(1, min(nt, size))
+        lane_extent = (size + nt - 1) // nt
+
+        lane_var = self.device_function.new_var(
+            f"arange_lane_{len(self.cute_synthetic_arange_lane_exprs)}", dce=False
+        )
+        grid_state = self.current_grid_state
+        if grid_state is not None:
+            grid_state.add_lane_loop(-1, lane_var, lane_extent)
+        if nt > 1 and axis < 3:
+            self.cute_synthetic_arange_axes[key] = axis
+            self.cute_synthetic_arange_axis_sizes[axis] = max(
+                self.cute_synthetic_arange_axis_sizes.get(axis, 1), nt
+            )
+            self._record_synthetic_axis_branch_path(axis)
+            self._record_active_thread_axis_sizes()
+            coord = (
+                f"(cutlass.Int32(cute.arch.thread_idx()[{axis}])"
+                f" + cutlass.Int32({lane_var}) * {nt})"
+            )
+        else:
+            coord = f"cutlass.Int32({lane_var})"
+        self.cute_synthetic_arange_lane_exprs[key] = coord
+        return coord
+
+    def allocate_cute_synthetic_arange_axis(
+        self, key: tuple[object, ...], size: int
+    ) -> int:
+        """Allocate (or reuse) a per-thread axis for a free ``hl.arange`` dim.
+
+        A free ``hl.arange(n)`` used directly as a load/store index is not
+        bound to any tile/reduction/grid block id, so it has no strategy
+        thread axis. We map each distinct arange onto its own CUDA thread
+        axis: thread ``thread_idx()[axis]`` holds element ``axis``. Arange dims
+        that share the same ``key`` (same length/start/step) describe the same
+        logical lane and reuse the same axis so a value loaded on a lane is
+        stored back on that lane.
+
+        The chosen axis follows any thread axes already claimed by real tile
+        strategies (so an ``hl.arange`` mixed with an ``hl.tile`` index does
+        not collide with the tile's axis). The size is recorded so the
+        launch-dim recovery enlarges the thread block accordingly.
+        """
+        existing = self.cute_synthetic_arange_axes.get(key)
+        if existing is not None:
+            self.cute_synthetic_arange_axis_sizes[existing] = max(
+                self.cute_synthetic_arange_axis_sizes.get(existing, 1), size
+            )
+            self._record_synthetic_axis_branch_path(existing)
+            self._record_active_thread_axis_sizes()
+            return existing
+        # Reuse a synthetic axis from a mutually-exclusive control-flow branch:
+        # if every arange already mapped onto some axis lives in a branch that
+        # can never co-execute with the current one, the axes never need lanes
+        # at the same time, so they may share one thread axis (size = max). This
+        # keeps the joint thread budget bounded for branch-by-grid kernels whose
+        # branches each use a distinct free ``hl.arange``.
+        shared = self._mutually_exclusive_synthetic_axis()
+        if shared is not None:
+            self.cute_synthetic_arange_axes[key] = shared
+            self.cute_synthetic_arange_axis_sizes[shared] = max(
+                self.cute_synthetic_arange_axis_sizes.get(shared, 1), size
+            )
+            self._record_synthetic_axis_branch_path(shared)
+            self._record_active_thread_axis_sizes()
+            return shared
+        used_axes = set(self._strategy_thread_axes())
+        used_axes.update(self.cute_synthetic_arange_axes.values())
+        axis = 0
+        while axis in used_axes:
+            axis += 1
+        from .cute.thread_budget import check_thread_limit
+
+        # Validate the joint thread count once the new axis is added.
+        proposed_sizes = dict(self.cute_synthetic_arange_axis_sizes)
+        proposed_sizes[axis] = size
+        strategy_threads = 1
+        for strat_axis, strat_size in self._strategy_thread_axis_sizes().items():
+            if strat_axis not in proposed_sizes:
+                strategy_threads *= strat_size
+        total = strategy_threads
+        for axis_size in proposed_sizes.values():
+            total *= axis_size
+        check_thread_limit(total, context=f"free hl.arange axis size={size}")
+        self.cute_synthetic_arange_axes[key] = axis
+        self.cute_synthetic_arange_axis_sizes[axis] = size
+        self._record_synthetic_axis_branch_path(axis)
+        self._record_active_thread_axis_sizes()
+        return axis
+
+    def _record_synthetic_axis_branch_path(self, axis: int) -> None:
+        """Remember the current branch path for an arange mapped onto ``axis``."""
+        paths = self._cute_synthetic_arange_axis_branch_paths.setdefault(axis, [])
+        current = list(self._cute_branch_path)
+        if current not in paths:
+            paths.append(current)
+
+    def _mutually_exclusive_synthetic_axis(self) -> int | None:
+        """Find a synthetic axis whose every arange is in a branch that can never
+        co-execute with the current branch path, so it can be safely reused."""
+        if not self._cute_branch_path:
+            return None
+        current = list(self._cute_branch_path)
+        for axis, paths in self._cute_synthetic_arange_axis_branch_paths.items():
+            if paths and all(
+                self._cute_branch_paths_mutually_exclusive(current, path)
+                for path in paths
+            ):
+                return axis
+        return None
+
+    def _strategy_thread_axis_sizes(self) -> dict[int, int]:
+        sizes: dict[int, int] = {}
+        for loops in self.active_device_loops.values():
+            for loop_state in loops:
+                for axis, size in loop_state.thread_axis_sizes.items():
+                    sizes[axis] = max(sizes.get(axis, 1), size)
+        if self.current_grid_state is not None:
+            for axis, size in self.current_grid_state.thread_axis_sizes.items():
+                sizes[axis] = max(sizes.get(axis, 1), size)
+        # Fold in axes reserved by strategies that have not been entered yet
+        # (e.g. a matmul K-reduction on axis 0) so synthetic ``hl.arange`` dims
+        # both avoid those axes and count them toward the thread budget.
+        for axis, size in self._all_strategy_reserved_axes().items():
+            sizes[axis] = max(sizes.get(axis, 1), size)
+        return sizes
+
+    def _all_strategy_reserved_axes(self) -> dict[int, int]:
+        """Thread axes reserved by every dispatcher strategy and their extent.
+
+        Unlike ``_strategy_thread_axis_sizes`` (which only sees *active* loop
+        states), this includes strategies that have not begun codegen yet — e.g.
+        a matmul's K-reduction strategy that always claims thread axis 0. A free
+        ``hl.arange`` allocated before that reduction's loop is entered must still
+        avoid its axis, otherwise the arange's row/col lanes collide with the
+        reduction's warp lanes and silently corrupt the result.
+        """
+        sizes: dict[int, int] = {}
+        tile_strategy = getattr(self.device_function, "tile_strategy", None)
+        if tile_strategy is None:
+            return sizes
+        for strategy in getattr(tile_strategy, "strategies", []):
+            if strategy.thread_axes_used() <= 0:
+                continue
+            base_axis = tile_strategy.thread_axis_for_strategy(strategy)
+            if base_axis is None:
+                continue
+            for block_id in strategy.block_ids:
+                axis = tile_strategy.thread_axis_for_block_id(block_id)
+                extent = tile_strategy.thread_extent_for_block_id(block_id)
+                if axis is None or not isinstance(extent, int) or extent <= 1:
+                    continue
+                sizes[axis] = max(sizes.get(axis, 1), extent)
+        return sizes
+
+    def _strategy_thread_axes(self) -> set[int]:
+        axes = set(self._strategy_thread_axis_sizes())
+        axes.update(self._all_strategy_reserved_axes())
+        # A strategy can structurally occupy a thread axis even when its block
+        # size is 1 (e.g. an ``hl.grid`` whose offset is
+        # ``pid * BLOCK + thread_idx[0]`` with ``BLOCK == 1``). Such an axis is
+        # not recorded in ``thread_axis_sizes`` (which only keeps sizes > 1) but
+        # it is referenced in the already-emitted setup statements, so scan
+        # those to avoid handing a synthetic arange an axis the grid already
+        # uses (which would mis-filter most lanes via the grid's bounds mask).
+        statement_groups: list[list[ast.AST]] = list(self.statements_stack)
+        grid_state = self.current_grid_state
+        if grid_state is not None:
+            statement_groups.extend(
+                (grid_state.outer_prefix, grid_state.lane_setup_statements)
+            )
+        for loops in self.active_device_loops.values():
+            for loop_state in loops:
+                outer_prefix = getattr(loop_state, "outer_prefix", None)
+                if isinstance(outer_prefix, list):
+                    statement_groups.append(outer_prefix)
+        for statements in statement_groups:
+            for stmt in statements:
+                axes.update(
+                    int(axis_text)
+                    for axis_text in re.findall(
+                        r"cute\.arch\.thread_idx\(\)\[(\d+)\]",
+                        ast.unparse(stmt),
+                    )
+                )
+        return axes
 
     def _record_statement_thread_references(
         self,
@@ -626,21 +959,24 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                         codegen_fn(state)
                     root = root_graph_info.graph
                     grid_state = self.current_grid_state
-                    if (
-                        isinstance(grid_state, DeviceGridState)
-                        and grid_state.has_lane_loops()
-                    ):
+                    if isinstance(grid_state, DeviceGridState):
+                        # Codegen the body first so synthetic free-``hl.arange``
+                        # lane loops registered *during* body lowering (CuTe
+                        # over-budget chunking) are visible to the wrap below.
                         wrapped_body: list[ast.AST] = []
                         with self.set_statements(wrapped_body):
                             codegen_call_with_graph(self, root, [])
-                        self.statements_stack[-1].extend(grid_state.outer_prefix)
-                        if self.device_function.cute_state.consume_root_lane_loop_suppression():
-                            self.statements_stack[-1].extend(wrapped_body)
+                        if grid_state.has_lane_loops():
+                            self.statements_stack[-1].extend(grid_state.outer_prefix)
+                            if self.device_function.cute_state.consume_root_lane_loop_suppression():
+                                self.statements_stack[-1].extend(wrapped_body)
+                            else:
+                                self.statements_stack[-1].extend(
+                                    grid_state.wrap_body(wrapped_body)
+                                )
+                            self.statements_stack[-1].extend(grid_state.outer_suffix)
                         else:
-                            self.statements_stack[-1].extend(
-                                grid_state.wrap_body(wrapped_body)
-                            )
-                        self.statements_stack[-1].extend(grid_state.outer_suffix)
+                            self.statements_stack[-1].extend(wrapped_body)
                     else:
                         codegen_call_with_graph(self, root, [])
                 finally:

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -111,6 +111,41 @@ def cute_live_reduction_threads(max_threads: int) -> int:
     return max_threads
 
 
+def _strategies_concurrent_with_block(
+    tile_dispatch: object,
+    block_index: int,
+) -> list[TileStrategy]:
+    """Return strategies that can co-execute with reduction ``block_index``.
+
+    Drops reduction strategies that live in a control-flow branch mutually
+    exclusive with ``block_index``'s branch so the per-block thread budget is
+    not over-counted (CuTe branch-by-pid kernels). Outside that pattern (no
+    branch paths) this returns every strategy unchanged.
+    """
+    from .device_ir import DeviceIR
+    from .host_function import HostFunction
+
+    strategies = list(getattr(tile_dispatch, "strategies", []))
+    device_ir = HostFunction.current().device_ir
+    red_paths = device_ir.reduction_block_id_branch_paths()
+    own_paths = red_paths.get(block_index)
+    if not own_paths:
+        return strategies
+    own_path = own_paths[0]
+    result: list[TileStrategy] = []
+    for strategy in strategies:
+        other_path = None
+        for other_block in strategy.block_ids:
+            paths = red_paths.get(other_block)
+            if paths:
+                other_path = paths[0]
+                break
+        if DeviceIR.branch_paths_mutually_exclusive(own_path, other_path):
+            continue
+        result.append(strategy)
+    return result
+
+
 def _cute_vec_kernel_mode() -> str:
     """Return ``"vec"`` when all reduction-feeding loads are vec-eligible
     without a degrading dtype cast (i.e. fp32 -> fp32 pipeline), ``"unroll"``
@@ -688,8 +723,13 @@ class PersistentReductionStrategy(ReductionStrategy):
         # already on the dispatcher by the time we get here.
         tile_dispatch = getattr(fn, "tile_strategy", None)
         if tile_dispatch is not None:
+            # Reductions in mutually-exclusive control-flow branches share a
+            # thread axis (see ``TileStrategyDispatch._branch_by_control_flow``),
+            # so they never co-execute and must not be multiplied into this
+            # reduction's thread budget. Drop them before adjusting.
+            concurrent = _strategies_concurrent_with_block(tile_dispatch, block_index)
             self._thread_count = env.backend.adjust_reduction_thread_count(
-                self._thread_count, tile_dispatch.strategies
+                self._thread_count, concurrent
             )
         self._synthetic_cute_lane_var: str | None = None
         self._synthetic_cute_lane_extent = 1

--- a/helion/_compiler/tile_dispatch.py
+++ b/helion/_compiler/tile_dispatch.py
@@ -315,7 +315,8 @@ class TileStrategyDispatch:
         grid_strategies = self.strategies[:num_grids]
 
         if num_grids <= 1:
-            return [self.strategies]
+            branched = self._branch_by_control_flow()
+            return branched if branched is not None else [self.strategies]
 
         loop_strategies = self.strategies[num_grids:]
         branches: list[list[TileStrategy]] = []
@@ -332,6 +333,67 @@ class TileStrategyDispatch:
                     branch.append(ls)
             branches.append(branch)
         return branches
+
+    def _branch_by_control_flow(self) -> list[list[TileStrategy]] | None:
+        """Split strategies into mutually-exclusive control-flow branches.
+
+        Handles the single-grid branch-by-pid pattern: a kernel whose body is
+        ``if pid == 0: ... elif pid == 1: ...`` where each branch carries its own
+        reduction (and free ``hl.arange``) over a distinct dimension. Such
+        reductions never co-execute, so they may share a CUDA thread axis instead
+        of each claiming a fresh one and blowing the per-block thread budget.
+
+        Returns ``None`` (caller falls back to the single-branch default) unless
+        at least one pair of reductions lives in mutually-exclusive branches.
+        """
+        from .device_ir import DeviceIR
+
+        if CompileEnvironment.current().backend.name != "cute":
+            return None
+        device_ir = HostFunction.current().device_ir
+        red_paths = device_ir.reduction_block_id_branch_paths()
+        if len(red_paths) < 2:
+            return None
+
+        def block_path(strategy: TileStrategy) -> list[tuple[int, int]] | None:
+            for block_id in strategy.block_ids:
+                paths = red_paths.get(block_id)
+                if paths:
+                    return paths[0]
+            return None
+
+        # Collect reduction strategies that carry a branch path.
+        branched_strategies = [s for s in self.strategies if block_path(s) is not None]
+        if len(branched_strategies) < 2:
+            return None
+        # Require at least one mutually-exclusive pair, else nothing is shared.
+        if not any(
+            DeviceIR.branch_paths_mutually_exclusive(block_path(a), block_path(b))
+            for i, a in enumerate(branched_strategies)
+            for b in branched_strategies[i + 1 :]
+        ):
+            return None
+
+        shared = [s for s in self.strategies if block_path(s) is None]
+        # Group branched strategies so that every pair within a group can
+        # co-execute (paths not mutually exclusive); distinct groups are
+        # mutually exclusive and become separate branches that share axes.
+        groups: list[list[TileStrategy]] = []
+        for candidate in branched_strategies:
+            placed = False
+            for group in groups:
+                if all(
+                    not DeviceIR.branch_paths_mutually_exclusive(
+                        block_path(candidate), block_path(member)
+                    )
+                    for member in group
+                ):
+                    group.append(candidate)
+                    placed = True
+                    break
+            if not placed:
+                groups.append([candidate])
+        return [[*shared, *group] for group in groups]
 
     def thread_axis_for_strategy(self, target: TileStrategy) -> int | None:
         """Return the starting thread-axis index for a strategy in its branch.

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -1821,11 +1821,16 @@ class FlattenedTileStrategy(BlockSizeTileStrategy):
         mask_var = self.mask_var(-1)
         if mask_var is not None:
             mask_terms = [f"{offsets_var} < ({self._numel_str(state, total_numel)})"]
-            thread_mask = env.backend.thread_in_tile_mask_expr(
-                block_size_var, axis=self._flat_thread_axis()
-            )
-            if thread_mask is not None:
-                mask_terms.insert(0, f"({thread_mask})")
+            # Skip the ``thread_idx[axis] < block_size`` term for a CuTe
+            # block-size-1 axis (see ``codegen_grid``): the axis is not a thread
+            # axis, so this term would otherwise pin the launch dim to 1 and
+            # block a synthetic free-``hl.arange`` axis from reusing it.
+            if not (env.backend.name == "cute" and not self._uses_thread_axis()):
+                thread_mask = env.backend.thread_in_tile_mask_expr(
+                    block_size_var, axis=self._flat_thread_axis()
+                )
+                if thread_mask is not None:
+                    mask_terms.insert(0, f"({thread_mask})")
             mask_expr = " and ".join(mask_terms)
             statements.append(statement_from_string(f"{mask_var} = {mask_expr}"))
         # pyrefly: ignore [bad-return]
@@ -1968,15 +1973,27 @@ class FlattenedTileStrategy(BlockSizeTileStrategy):
 
         pids.append(PIDInfo(pid_var, block_size_var, total_numel, self.block_ids[0]))
 
-        state.add_statement(
-            env.backend.arange_expr(
-                offsets_var,
-                pid_var,
-                block_size_var,
-                dtype,
-                axis=self._flat_thread_axis(),
+        # A CuTe grid whose block size is 1 does not claim a thread axis: its
+        # ``offsets = pid * 1 + thread_idx[axis]`` term is always 0 (launch dim
+        # for the axis is 1). Emit ``offsets = pid * 1`` instead so the axis is
+        # genuinely free for a synthetic free-``hl.arange`` thread axis to reuse
+        # without the grid's ``thread_idx[axis] < 1`` mask filtering its lanes.
+        if env.backend.name == "cute" and not self._uses_thread_axis():
+            state.add_statement(
+                statement_from_string(
+                    f"{offsets_var} = ({pid_var}) * ({block_size_var})"
+                )
             )
-        )
+        else:
+            state.add_statement(
+                env.backend.arange_expr(
+                    offsets_var,
+                    pid_var,
+                    block_size_var,
+                    dtype,
+                    axis=self._flat_thread_axis(),
+                )
+            )
         state.codegen.statements_stack[-1].extend(statements)
 
         pids.codegen(state)
@@ -2026,9 +2043,16 @@ class FlattenedTileStrategy(BlockSizeTileStrategy):
         lid = self.new_var("lid")
         numel_str = self._numel_str(state, total_numel)
         end_var = env.backend.cdiv_expr(numel_str, block_size_var, is_device=True)
-        arange_expr = env.backend.arange_expr(
-            offsets_var, lid, block_size_var, dtype, axis=self._flat_thread_axis()
-        )
+        # Mirror ``codegen_grid``: a CuTe block-size-1 loop axis does not claim a
+        # thread axis, so drop the always-zero ``+ thread_idx[axis]`` term so the
+        # axis stays free (and consistent with the mask emitted by
+        # ``_codegen_common``, which also drops its thread term for this case).
+        if env.backend.name == "cute" and not self._uses_thread_axis():
+            arange_expr = f"{offsets_var} = ({lid}) * ({block_size_var})"
+        else:
+            arange_expr = env.backend.arange_expr(
+                offsets_var, lid, block_size_var, dtype, axis=self._flat_thread_axis()
+            )
         for_node = create(
             ast.For,
             target=create(ast.Name, id=lid, ctx=ast.Store()),

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -2391,8 +2391,16 @@ def _(state: CodegenState) -> list[object]:
     assert all(isinstance(x, ast.AST) for x in if_args)
     assert all(isinstance(x, ast.AST) for x in else_args)
 
+    # Tag each branch with the dynamic ``_if`` node identity so synthetic
+    # ``hl.arange`` axes allocated in mutually-exclusive branches can share a
+    # single thread axis (only one branch runs per program instance).
+    if_node_id = id(state.fx_node)
+
     if_body_stmts: list[ast.AST] = []
-    with state.codegen.set_statements(if_body_stmts):
+    with (
+        state.codegen.set_statements(if_body_stmts),
+        state.codegen.cute_branch_scope(if_node_id, 0),
+    ):
         if_outputs = codegen_call_with_graph(
             state.codegen, graph_info.graph, [*if_args]
         )
@@ -2401,7 +2409,10 @@ def _(state: CodegenState) -> list[object]:
     else_graph = state.get_graph(graph_info.else_branch)
     assert isinstance(else_graph, ElseGraphInfo)
     else_body_stmts: list[ast.AST] = []
-    with state.codegen.set_statements(else_body_stmts):
+    with (
+        state.codegen.set_statements(else_body_stmts),
+        state.codegen.cute_branch_scope(if_node_id, 1),
+    ):
         else_outputs = codegen_call_with_graph(
             state.codegen, else_graph.graph, [*else_args]
         )

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -390,7 +390,22 @@ def _log_cute_layout(state: CodegenState, op_name: str) -> None:
     )
 
 
+def _cute_remap_block_id(state: CodegenState, block_id: int) -> int:
+    """Apply the active matmul-operand block-id remap, if any.
+
+    Used while re-materializing a matmul operand load so its contraction
+    dimension is indexed by the active contraction block instead of the
+    loop-invariant block it was originally lowered with.  Returns *block_id*
+    unchanged when no remap is active.
+    """
+    remap = state.device_function.cute_state.matmul_operand_block_remap
+    if not remap:
+        return block_id
+    return remap.get(block_id, block_id)
+
+
 def _cute_active_index_var(state: CodegenState, block_id: int) -> str | None:
+    block_id = _cute_remap_block_id(state, block_id)
     loops = state.codegen.active_device_loops.get(block_id)
     if loops:
         return loops[-1].strategy.index_var(block_id)
@@ -401,6 +416,7 @@ def _cute_active_index_var(state: CodegenState, block_id: int) -> str | None:
 
 
 def _cute_active_mask_var(state: CodegenState, block_id: int) -> str | None:
+    block_id = _cute_remap_block_id(state, block_id)
     loops = state.codegen.active_device_loops.get(block_id)
     if loops:
         return loops[-1].strategy.mask_var(block_id)
@@ -657,6 +673,7 @@ def _cute_index_exprs(
         raise exc.BackendUnsupported("cute", f"unlowerable symbolic index: {idx}")
 
     def active_loop_info(block_id: int) -> LoopDimInfo | None:
+        block_id = _cute_remap_block_id(state, block_id)
         loops = state.codegen.active_device_loops.get(block_id)
         if loops:
             return loops[-1].block_id_to_info.get(block_id)
@@ -668,6 +685,7 @@ def _cute_index_exprs(
     def active_local_coord(block_id: int) -> str | None:
         from .._compiler.cute.cute_reshape import _grid_local_coord_expr
 
+        block_id = _cute_remap_block_id(state, block_id)
         loops = state.codegen.active_device_loops.get(block_id)
         if loops:
             thread_axis = loops[-1].block_thread_axes.get(block_id)
@@ -681,6 +699,7 @@ def _cute_index_exprs(
         return None
 
     def tile_begin_expr(block_id: int, loop_info: LoopDimInfo | None) -> str:
+        block_id = _cute_remap_block_id(state, block_id)
         loops = state.codegen.active_device_loops.get(block_id)
         if loops:
             return state.codegen.offset_var(block_id)
@@ -700,6 +719,7 @@ def _cute_index_exprs(
         return begin_var
 
     def active_index_var(block_id: int) -> str | None:
+        block_id = _cute_remap_block_id(state, block_id)
         loops = state.codegen.active_device_loops.get(block_id)
         if loops:
             return loops[-1].strategy.index_var(block_id)
@@ -2133,12 +2153,14 @@ def _cute_combined_mask(
     terms: list[str] = []
 
     def mask_var_for_block_id(block_id: int) -> str | None:
+        block_id = _cute_remap_block_id(state, block_id)
         loops = state.codegen.active_device_loops.get(block_id)
         if loops:
             return loops[-1].strategy.mask_var(block_id)
         return None
 
     def active_index_var(block_id: int) -> str | None:
+        block_id = _cute_remap_block_id(state, block_id)
         loops = state.codegen.active_device_loops.get(block_id)
         if loops:
             return loops[-1].strategy.index_var(block_id)
@@ -2150,6 +2172,7 @@ def _cute_combined_mask(
     def active_local_coord(block_id: int) -> str | None:
         from .._compiler.cute.cute_reshape import _grid_local_coord_expr
 
+        block_id = _cute_remap_block_id(state, block_id)
         loops = state.codegen.active_device_loops.get(block_id)
         if loops:
             thread_axis = loops[-1].block_thread_axes.get(block_id)
@@ -2163,6 +2186,7 @@ def _cute_combined_mask(
         return None
 
     def tile_begin_expr(block_id: int) -> str:
+        block_id = _cute_remap_block_id(state, block_id)
         loops = state.codegen.active_device_loops.get(block_id)
         if loops:
             return state.codegen.offset_var(block_id)
@@ -4985,6 +5009,287 @@ def _codegen_cute_store_loaded_index_trailing_slices(
     return ast.Constant(value=None)
 
 
+def _cute_expand_broadcast_dim(value_node: torch.fx.Node) -> int | None:
+    """Return the dim an ``aten.expand`` broadcasts (input size 1 -> >1).
+
+    Returns ``None`` unless ``value_node`` is an ``aten.expand`` whose value has
+    exactly one broadcast dimension — i.e. the expanded value carries a stride-0
+    mode at exactly one position whose pre-expand extent was 1. This is the
+    signal that the stored value replicates one source element across that dim.
+    """
+    if value_node.target is not torch.ops.aten.expand.default:
+        return None
+    input_arg = value_node.args[0]
+    if not isinstance(input_arg, torch.fx.Node):
+        return None
+    out_val = value_node.meta.get("val")
+    in_val = input_arg.meta.get("val")
+    if not isinstance(out_val, torch.Tensor) or not isinstance(in_val, torch.Tensor):
+        return None
+    if out_val.ndim != in_val.ndim:
+        return None
+    env = CompileEnvironment.current()
+    broadcast_dims = [
+        dim
+        for dim in range(out_val.ndim)
+        if env.known_equal(in_val.shape[dim], 1)
+        and not env.known_equal(out_val.shape[dim], 1)
+        and out_val.stride(dim) == 0
+    ]
+    if len(broadcast_dims) != 1:
+        return None
+    return broadcast_dims[0]
+
+
+def _cute_block_tile_begin_expr(state: CodegenState, block_id: int) -> str | None:
+    """Return the *per-block* tile start for a tile mapped onto a thread axis.
+
+    In the CuTe SIMT model a tile dimension is spread across a thread axis, so
+    the strategy's ``index_var`` is the per-*thread* global index
+    (``pid * block + thread_idx[axis]``). Subtracting the thread-local coordinate
+    yields the per-*block* tile base (``pid * block``), shared by every thread in
+    the tile — the correct anchor for a broadcast lane loop. Returns ``None`` when
+    the block id has no active thread axis in this scope.
+    """
+    from .._compiler.cute.cute_reshape import _grid_local_coord_expr
+
+    loops = state.codegen.active_device_loops.get(block_id)
+    if not loops:
+        return None
+    loop_state = loops[-1]
+    thread_axis = loop_state.block_thread_axes.get(block_id)
+    global_index = loop_state.strategy.index_var(block_id)
+    if thread_axis is None or global_index is None:
+        return None
+    local_coord = _grid_local_coord_expr(state.codegen, block_id, thread_axis)
+    return state.codegen.lift(
+        expr_from_string(f"({global_index}) - ({local_coord})"),
+        dce=True,
+        prefix="tile_begin",
+    ).id
+
+
+def _cute_unsqueeze_expand_load_source(
+    value_node: torch.fx.Node, broadcast_dim: int
+) -> torch.fx.Node | None:
+    """Return the ``hl.load`` feeding ``expand(val[..., None, ...])``.
+
+    Walks ``value_node`` (an ``aten.expand``) back through a single
+    unsqueeze-style subscript op (``val[:, None, :]`` inserting the broadcast dim)
+    to the originating ``hl.load``. Returns ``None`` unless the chain is exactly
+    that shape, so the caller falls back to the load-agnostic path.
+    """
+    from .view_ops import subscript as subscript_op
+
+    inner = value_node.args[0]
+    if not isinstance(inner, torch.fx.Node):
+        return None
+    if inner.op == "call_function" and inner.target is subscript_op:
+        index_arg = inner.args[1] if len(inner.args) > 1 else None
+        if not isinstance(index_arg, (list, tuple)):
+            return None
+        # Exactly one ``None`` (the inserted broadcast dim) at ``broadcast_dim``.
+        none_positions = [pos for pos, entry in enumerate(index_arg) if entry is None]
+        if none_positions != [broadcast_dim]:
+            return None
+        load_node = inner.args[0]
+    else:
+        load_node = inner
+    if (
+        isinstance(load_node, torch.fx.Node)
+        and load_node.op == "call_function"
+        and load_node.target is load
+        and len(load_node.args) >= 2
+    ):
+        return load_node
+    return None
+
+
+def _codegen_cute_store_expand_broadcast_tile(
+    state: CodegenState,
+    tensor: torch.Tensor,
+    subscript: list[object] | tuple[object, ...],
+    ast_subscript: list[object] | tuple[object, ...],
+    value: ast.AST,
+    extra_mask: ast.AST | None,
+    value_node: torch.fx.Node,
+) -> ast.AST | None:
+    """Lower a store whose value is broadcast across a reused tile dimension.
+
+    Handles the pattern::
+
+        val = hl.load(src, [tile, hl.arange(k)])  # (block, k)
+        val_3d = val[:, None, :].expand(block, block, k)  # stride-0 middle dim
+        hl.store(out, [idx[tile], tile.index, hl.arange(k)], val_3d)
+
+    Here ``tile`` appears twice in the store index — once as a tensor indexer
+    (``idx[tile]``) and once as the bare tile index (``tile.index``) — while the
+    value is broadcast (stride 0) along the second (``tile.index``) position. The
+    generic SIMT store lowers both positions onto ``tile``'s single thread axis,
+    so each thread only writes the ``a == b`` diagonal of the ``(block, block)``
+    block. Instead emit a sequential lane loop over the broadcast position so a
+    thread holding ``val[a]`` writes the full ``out[idx[a], begin+b, :]`` row for
+    every ``b`` in the tile, filling the block. ``val`` is broadcast, so every
+    lane reads the same per-thread register.
+
+    Returns ``None`` (a strict no-op) unless every gate matches, so existing
+    kernels are byte-for-byte unchanged.
+    """
+    env = CompileEnvironment.current()
+    broadcast_dim = _cute_expand_broadcast_dim(value_node)
+    if broadcast_dim is None:
+        return None
+    if broadcast_dim >= len(subscript):
+        return None
+    broadcast_idx = subscript[broadcast_dim]
+    # The broadcast position must be a bare tile index (a SymInt block id), and
+    # that same block id must be reused by another (tensor) index position — the
+    # collision the generic path mis-handles.
+    if not isinstance(broadcast_idx, torch.SymInt):
+        return None
+    broadcast_block_id = env.get_block_id(broadcast_idx)
+    if broadcast_block_id is None:
+        return None
+    block_size = state.device_function.resolved_block_size(broadcast_block_id)
+    if not isinstance(block_size, int) or block_size <= 1:
+        return None
+    reused = False
+    for pos, idx in enumerate(subscript):
+        if pos == broadcast_dim:
+            continue
+        if isinstance(idx, torch.Tensor):
+            for dim_size in idx.shape:
+                if broadcast_block_id in _matching_block_ids(env, dim_size):
+                    reused = True
+                    break
+        if reused:
+            break
+    if not reused:
+        return None
+
+    # Walk the value chain ``expand -> unsqueeze(None) -> load`` to recover the
+    # source load. The stored value is a per-thread register holding ``val[a, c]``
+    # whose coordinates live on the *load*'s thread axes; the store's own free
+    # ``hl.arange`` index entries are distinct nodes that the synthetic-axis
+    # machinery assigns to *different* axes. Reusing the load's coordinate for
+    # those non-broadcast positions keeps the register and the store address on
+    # the same thread axis (otherwise thread ``(a, c_load, c_store)`` would write
+    # ``out[..., c_store] = val[a, c_load]`` for ``c_load != c_store``).
+    load_node = _cute_unsqueeze_expand_load_source(value_node, broadcast_dim)
+    load_coords: list[str] | None = None
+    load_subscript_proxy: tuple[object, ...] | None = None
+    if load_node is not None:
+        load_tensor_node = load_node.args[0]
+        load_subscript = load_node.args[1]
+        if isinstance(load_tensor_node, torch.fx.Node) and isinstance(
+            load_subscript, (list, tuple)
+        ):
+            load_tensor = load_tensor_node.meta.get("val")
+            if isinstance(load_tensor, torch.Tensor):
+                load_subscript_proxy = tuple(
+                    map_arg([*load_subscript], lambda arg: arg.meta["val"])
+                )
+                load_subscript_ast = map_arg(
+                    [*load_subscript], lambda arg: state.env[arg]
+                )
+                load_coords = _cute_index_exprs(
+                    state,
+                    [*load_subscript_proxy],
+                    [*load_subscript_ast],
+                    tensor=load_tensor,
+                    inactive_singleton_slice_expr="0",
+                )
+                if len(load_coords) != load_tensor.ndim:
+                    load_coords = None
+                    load_subscript_proxy = None
+
+    index_exprs = _cute_index_exprs(
+        state,
+        subscript,
+        ast_subscript,
+        tensor=tensor,
+        inactive_singleton_slice_expr="0",
+    )
+    if len(index_exprs) != tensor.ndim or "None" in index_exprs:
+        return None
+
+    # Re-align each non-broadcast free-``hl.arange`` store position onto the
+    # load's matching coordinate. Value dim ``d`` maps to load dim ``d`` before
+    # the unsqueezed broadcast dim and ``d - 1`` after it. Only positions where
+    # *both* the store and the matching load entry are free ``hl.arange`` index
+    # tensors are remapped — a tensor *indexer* (``idx[tile]``) keeps its own
+    # coordinate.
+    if load_coords is not None and load_subscript_proxy is not None:
+        for pos, idx in enumerate(subscript):
+            if pos == broadcast_dim or not isinstance(idx, torch.Tensor):
+                continue
+            load_dim = pos if pos < broadcast_dim else pos - 1
+            if not (0 <= load_dim < len(load_coords)):
+                continue
+            if isinstance(load_subscript_proxy[load_dim], torch.Tensor):
+                index_exprs[pos] = load_coords[load_dim]
+
+    # Replace the broadcast position's coordinate (currently the reused tile's
+    # per-thread global index) with ``block_begin + lane`` so the lane loop sweeps
+    # the full tile block, identically for every thread in the tile. ``block_begin``
+    # is the *per-block* tile start (``global_index - local_coord``); in the CuTe
+    # SIMT model the tile is mapped onto a thread axis, so the bare offset var
+    # still carries the per-thread ``thread_idx`` lane and must be stripped.
+    block_begin = _cute_block_tile_begin_expr(state, broadcast_block_id)
+    if block_begin is None:
+        return None
+    lane_var = state.device_function.new_var("bcast_lane", dce=True)
+    index_dtype = env.index_type()
+    broadcast_coord = f"({block_begin}) + {index_dtype}({lane_var})"
+    index_exprs[broadcast_dim] = broadcast_coord
+
+    backend = env.backend
+    target_dtype = backend.dtype_str(tensor.dtype)
+    tensor_name = state.device_function.tensor_arg(tensor).name
+    value = expr_from_string(
+        backend.ast_to_dtype_expr("{value}", target_dtype),
+        value=value,
+    )
+    store_expr = expr_from_string(
+        _cute_scalar_store_expr(tensor_name, index_exprs, "{value}"),
+        value=value,
+    )
+
+    # Base mask excludes the broadcast position (its bound is enforced by the lane
+    # bound below); other positions keep their tile/tensor masks.
+    base_subscript = [
+        slice(None) if pos == broadcast_dim else idx
+        for pos, idx in enumerate(subscript)
+    ]
+    mask_expr = _cute_combined_mask(state, base_subscript, extra_mask, tensor=tensor)
+    dim_size = _cute_tensor_dim_size_expr(state, tensor, broadcast_dim)
+    lane_bound = f"({broadcast_coord}) < {dim_size}"
+    mask_expr = lane_bound if mask_expr is None else f"({mask_expr}) and {lane_bound}"
+
+    from .._compiler.ast_extension import create
+
+    mask_ast = expr_from_string(mask_expr)
+    assert isinstance(mask_ast, ast.expr)
+    assert isinstance(store_expr, ast.expr)
+    body_stmt: ast.stmt = ast.fix_missing_locations(
+        ast.If(
+            test=mask_ast,
+            body=[ast.Expr(value=store_expr)],
+            orelse=[],
+        )
+    )
+    loop_stmt = create(
+        ast.For,
+        target=create(ast.Name, id=lane_var, ctx=ast.Store()),
+        iter=expr_from_string(f"range({block_size})"),
+        body=[body_stmt],
+        orelse=[],
+        type_comment=None,
+    )
+    state.add_statement(loop_stmt)
+    return ast.Constant(value=None)
+
+
 def _codegen_cute_store_permute_lane_loops(
     state: CodegenState,
     tensor: torch.Tensor,
@@ -5332,6 +5637,17 @@ def _(state: CodegenState) -> ast.AST:
                     tensor,
                     subscript,
                     ast_subscript,
+                    extra_mask,
+                    value_node,
+                )
+                if rewritten_stmt is not None:
+                    return rewritten_stmt
+                rewritten_stmt = _codegen_cute_store_expand_broadcast_tile(
+                    state,
+                    tensor,
+                    subscript,
+                    ast_subscript,
+                    value,
                     extra_mask,
                     value_node,
                 )

--- a/test/test_control_flow.py
+++ b/test/test_control_flow.py
@@ -343,7 +343,6 @@ class TestControlFlow(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, expected)
 
     @skipIfPallas("Pallas gather supports only dim-0 indirect indexing")
-    @skipIfCute("Cute requires hl.arange() to use an active tile/reduction axis")
     def test_grid_if_reduction_rolling_branch_graph_ids(self):
         """Test for reductions under branch-by-grid control flow.
 

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -14590,7 +14590,8 @@ class TestCuteLowerings(unittest.TestCase):
             fx_node=lhs,
             codegen=codegen,
             device_function=SimpleNamespace(
-                tensor_arg=lambda tensor: SimpleNamespace(name="A")
+                tensor_arg=lambda tensor: SimpleNamespace(name="A"),
+                cute_state=SimpleNamespace(matmul_operand_block_remap={}),
             ),
         )
 
@@ -15704,6 +15705,9 @@ class TestCuteLowerings(unittest.TestCase):
                 ),
             ),
             sympy_expr=lambda expr: str(expr),
+            device_function=SimpleNamespace(
+                cute_state=SimpleNamespace(matmul_operand_block_remap={})
+            ),
         )
         env = SimpleNamespace(
             get_block_id=lambda size: 1 if int(size) == 8 else None,
@@ -15736,7 +15740,10 @@ class TestCuteLowerings(unittest.TestCase):
 
     def test_cute_combined_mask_skips_none_axes(self) -> None:
         state = SimpleNamespace(
-            codegen=_FakeMaskCodegen(_FakeMaskedLoopStrategy([1]), {1})
+            codegen=_FakeMaskCodegen(_FakeMaskedLoopStrategy([1]), {1}),
+            device_function=SimpleNamespace(
+                cute_state=SimpleNamespace(matmul_operand_block_remap={})
+            ),
         )
         env = SimpleNamespace(
             get_block_id=lambda size: 1 if int(size) == 8 else None,

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1545,9 +1545,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             fn_name="grouped_gemm_jagged",
         )
 
-    @xfailIfCute(
-        "CuTe persistent grouped jagged GEMM example still fails lowering/runtime"
-    )
     @xfailIfPallas("CUDA-specific code paths")
     def test_grouped_gemm_jagged_persistent(self):
         # Build small jagged grouped GEMM inputs

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -271,7 +271,6 @@ class TestIndexing(RefEagerTestBase, TestCase):
             result, torch.where(torch.arange(200, device=DEVICE) % 2 == 0, x, 0)
         )
 
-    @xfailIfCute("CuTe does not yet lower untiled cartesian hl.arange store indices")
     def test_mask_store_cartesian(self):
         @helion.kernel(autotune_effort="none")
         def cartesian_masked_store_kernel(
@@ -346,7 +345,6 @@ class TestIndexing(RefEagerTestBase, TestCase):
         result = cartesian_masked_store_kernel(packed, shared_b, offsets)
         torch.testing.assert_close(result, expected)
 
-    @xfailIfCute("CuTe does not yet lower untiled 3D cartesian hl.arange store indices")
     def test_mask_store_cartesian_3d(self):
         @helion.kernel(autotune_effort="none")
         def cartesian_masked_store_kernel_3d(
@@ -2335,9 +2333,6 @@ class TestIndexing(RefEagerTestBase, TestCase):
 
         torch.testing.assert_close(result, expected)
 
-    @xfailIfCute(
-        "CuTe does not yet support static hl.arange tensor indexers mixed with non-consecutive tensor indexers"
-    )
     def test_non_consecutive_tensor_indexers_no_broadcast(self):
         """Test that non-consecutive tensor indexers don't get incorrectly broadcast.
 

--- a/test/test_loops.py
+++ b/test/test_loops.py
@@ -10,7 +10,6 @@ import torch
 
 import helion
 from helion import _compat
-from helion import exc
 from helion._compat import use_tileir_tunables
 from helion._compiler.static_loop_unroller import StaticLoopUnroller
 from helion._testing import DEVICE
@@ -338,11 +337,6 @@ class TestLoops(RefEagerTestBase, TestCase):
             return out
 
         x = torch.arange(37, device=DEVICE, dtype=torch.float32)
-        if _get_backend() == "cute":
-            with self.assertRaises(exc.Base):
-                code_and_output(copy_blockwise, (x,), block_sizes=[16])
-            return
-
         code, result = code_and_output(copy_blockwise, (x,), block_sizes=[16])
         torch.testing.assert_close(result, x)
         if _get_backend() == "triton":

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -300,8 +300,6 @@ class TestMisc(RefEagerTestBase, TestCase):
         Previously, the cast could be hoisted/ignored leading to FP32 p fed into BF16 v.
         This test ensures kernel runs and matches reference with BF16 inputs.
         """
-        if _get_backend() == "cute":
-            pytest.xfail("CUTe reduction codegen exceeds shared memory")
 
         @helion.kernel(autotune_effort="none", dot_precision=get_test_dot_precision())
         def kernel(

--- a/test/test_rng.py
+++ b/test/test_rng.py
@@ -23,7 +23,6 @@ from helion._testing import skipIfRefEager
 from helion._testing import skipIfRocm
 from helion._testing import skipIfXPU
 from helion._testing import skipUnlessCuteAvailable
-from helion._testing import xfailIfCute
 from helion._testing import xfailIfPallas
 import helion.language as hl
 from helion.runtime.config import Config
@@ -928,9 +927,6 @@ class TestRNG(RefEagerTestBase, TestCase):
         self.assertFalse(torch.allclose(result, result3))
         _assert_uses_philox(self, code)
 
-    @xfailIfCute(
-        "CuTe still rejects nested RNG tiles that require a fourth thread axis"
-    )
     @xfailIfPallas("nested rand_like tiles hit TPU MLIR refinement mismatch")
     @skipIfRefEager("compiled codegen inspection is not applicable in ref eager mode")
     def test_rand_like_nested_tiles_issue_1208(self):

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -14,7 +14,6 @@ from helion._testing import code_and_output
 from helion._testing import onlyBackends
 from helion._testing import skipIfRefEager
 from helion._testing import skipUnlessTensorDescriptor
-from helion._testing import xfailIfCute
 from helion._testing import xfailIfPallas
 import helion.language as hl
 from helion.runtime.settings import _get_backend
@@ -354,7 +353,6 @@ class TestViews(RefEagerTestBase, TestCase):
         expected[1::2] = b  # Every 2nd row starting from 1
         torch.testing.assert_close(result, expected, rtol=1e-5, atol=1e-5)
 
-    @xfailIfCute("torch.stack with direct store consumer not supported on cute")
     @xfailIfPallas("torch.stack not supported on pallas")
     def test_stack_non_power_of_2(self):
         @helion.kernel(autotune_effort="none", static_shapes=True)
@@ -389,7 +387,6 @@ class TestViews(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, expected, rtol=1e-5, atol=1e-5)
 
     @skipIfRefEager("ref eager does not support lifted variable")
-    @xfailIfCute("hl.split with reshaped input not supported on cute")
     @xfailIfPallas("hl.split and tl.reshape not supported on pallas")
     def test_view_blocksize_constexpr(self):
         @helion.kernel(static_shapes=True, autotune_effort="none")
@@ -407,9 +404,36 @@ class TestViews(RefEagerTestBase, TestCase):
         x = torch.randn(1024, dtype=torch.bfloat16, device=DEVICE)
         code, result = code_and_output(foo, (x,))
         self.assertEqual(result.numel(), x.numel() // 2)
-        self.assertIn("tl.reshape", code)
+        if _get_backend() == "triton":
+            self.assertIn("tl.reshape", code)
 
-    @xfailIfCute("torch.stack with direct store consumer not supported on cute")
+    @skipIfRefEager("ref eager does not support lifted variable")
+    @xfailIfPallas("hl.split and tl.reshape not supported on pallas")
+    def test_view_blocksize_constexpr_pairsum(self):
+        # The split-over-view + compacted-store machinery exercised by
+        # ``test_view_blocksize_constexpr`` (which only checks codegen shape)
+        # must produce genuine ``x.view(N // 2, 2).sum(-1)`` values.  This
+        # variant writes the compacted result to the matching output offset
+        # (``n_tile.begin // 2``) so the result is numerically meaningful.
+        @helion.kernel(static_shapes=True, autotune_effort="none")
+        def foo(x: torch.Tensor) -> torch.Tensor:
+            N = x.shape[0]
+            N = hl.specialize(N)
+            out = x.new_empty(N // 2)
+            for (n_tile,) in hl.tile([N]):
+                val = x[n_tile]
+                val = val.view(n_tile.block_size // 2, 2)
+                val_a, val_b = hl.split(val)
+                out[n_tile.begin // 2 + hl.arange(0, n_tile.block_size // 2)] = (
+                    val_a + val_b
+                )
+            return out
+
+        x = torch.randn(1024, dtype=torch.float32, device=DEVICE)
+        _code, result = code_and_output(foo, (x,))
+        expected = x.view(x.numel() // 2, 2).sum(-1)
+        torch.testing.assert_close(result, expected, rtol=1e-3, atol=1e-3)
+
     @xfailIfPallas("torch.stack not supported on pallas")
     def test_stack_dim0(self):
         with torch._inductor.config.patch(


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2674
 * #2673
 * #2670
 * __->__#2669
 * #2668
 * #2667
 * #2666
 * #2665
 * #2662
 * #2660


--- --- ---

[cute] Synthetic thread axes for free hl.arange, dependent stores, and matmul fallbacks

Core CuTe support for free (untiled) hl.arange used as a load/store index,
plus the stores and matmul lowerings that build on it:
- Map a free hl.arange index dim onto a synthetic per-thread axis (keyed by
  index position + dim size so cartesian siblings stay distinct); lane-loop
  chunk it when the joint thread count exceeds the 1024 budget; share an axis
  across mutually-exclusive control-flow branches so per-pid branches do not
  multiply the budget.
- Materialize a torch.stack consumed directly by a store; lower a broadcast
  tile store (expand over a reused tile dim) via a sequential lane loop; lower
  the compacted split-over-view store with tile-local arange coords and
  split-factor coord metadata.
- Distribute the matmul scalar-fallback contraction thread reserve across all
  free auto-thread axes, and re-materialize a 3D bmm rhs operand at the active
  contraction block when lhs/rhs K block ids differ.

Un-xfails mask_store_cartesian(/_3d), non_consecutive_tensor_indexers,
grid_if_reduction_rolling, grouped_gemm_jagged_persistent, view_blocksize_constexpr,
stack_non_power_of_2, stack_dim0, dtype_cast_preserved_before_second_dot,
and rand_like_nested_tiles_issue_1208.