### PR TITLE
[cute] Lower baddbmm with static M=N collapsed onto the reduced N dim

### DIFF
--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -32,14 +32,17 @@ from .cute.iota_utils import cute_free_arange_indexed_dim_key
 from .cute.iota_utils import cute_iota_has_atomic_tensor_index_only_users
 from .cute.iota_utils import cute_iota_is_free_memory_index
 from .cute.matmul_fallback import _emit_cute_matmul
+from .cute.matmul_fallback import _emit_cute_matmul_n_collapse
 from .cute.matmul_utils import cute_lower_rhs_for_matmul
 from .cute.matmul_utils import cute_outer_accumulates_result
 from .cute.matmul_utils import cute_outer_accumulator_dtype
 from .cute.matmul_utils import cute_outer_accumulator_out_dtype
 from .cute.matmul_utils import cute_rematerialize_rhs_at_contraction_block
+from .cute.matmul_utils import cute_rematerialize_rhs_at_index_override
 from .cute.matmul_utils import cute_resolve_active_block_id
 from .cute.matmul_utils import cute_resolve_active_matmul_k_block_id
 from .cute.matmul_utils import cute_static_k_invariant_extent
+from .cute.matmul_utils import cute_static_mn_collapse_n_block_id
 from .cute.matmul_utils import cute_static_serial_matmul_k_extent
 from .cute.matmul_utils import emit_cute_serial_scalar_mm_from_loads
 from .cute.strategies import is_pure_matmul_role_lifecycle_config
@@ -1422,6 +1425,155 @@ def codegen_addmm_cute(ctx: LoweringContext, node: Node) -> ast.AST:
     )
 
 
+def _cute_baddbmm_result_reduced_over_block(
+    node: Node,
+    n_block_id: int,
+) -> bool:
+    """Whether *node*'s collapsed result is summed away over *n_block_id*.
+
+    The matmul's M (lhs free) and N (rhs free) axes collapse to ``n_block_id``,
+    so the standard fallback would compute only the diagonal.  Folding the N
+    reduction into the matmul (layout A) is correct *only* when N is genuinely
+    reduced out downstream.  This guard requires:
+
+    * ``n_block_id`` is a reduction block (allocated for a ``sum`` /
+      reduction), and a reduction node over it exists somewhere in the device
+      IR (the ``.sum(-1)``), and
+    * the baddbmm result does not escape to any non-passthrough consumer in its
+      own graph - either it is consumed only by a same-graph reduction over the
+      block, or it is purely loop-carried (its only users are the graph output
+      and/or pure casts), so the carried value reaches the downstream reduction.
+
+    Returns ``False`` otherwise, leaving the (unchanged) standard path.
+    """
+    from ..language._tracing_ops import _new_var
+    from .host_function import HostFunction
+    from .inductor_lowering import ReductionLowering
+
+    env = CompileEnvironment.current()
+    canonical_block_id = getattr(env, "canonical_block_id", lambda block_id: block_id)
+    target_canonical = canonical_block_id(n_block_id)
+
+    if not env.block_sizes[n_block_id].reduction:
+        return False
+
+    # A reduction over the (canonical) N block must exist in the device IR.
+    device_ir = HostFunction.current().device_ir
+    has_block_reduction = False
+    for graph_info in getattr(device_ir, "graphs", ()):
+        graph = getattr(graph_info, "graph", None)
+        if not isinstance(graph, torch.fx.Graph):
+            continue
+        for other in graph.nodes:
+            lowering = other.meta.get("lowering")
+            if (
+                isinstance(lowering, ReductionLowering)
+                and canonical_block_id(lowering.block_index) == target_canonical
+            ):
+                has_block_reduction = True
+                break
+        if has_block_reduction:
+            break
+    if not has_block_reduction:
+        return False
+
+    passthrough = {
+        torch.ops.aten.clone.default,
+        torch.ops.aten.detach.default,
+        torch.ops.aten.to.dtype,
+        torch.ops.prims.convert_element_type.default,
+        _new_var,
+    }
+
+    # Walk forward inside the baddbmm's own graph; the result must not reach any
+    # non-passthrough consumer other than a reduction over the block or the
+    # graph output (loop carry).
+    seen: set[Node] = set()
+    stack: list[Node] = [node]
+    while stack:
+        cur = stack.pop()
+        for user in cur.users:
+            if not isinstance(user, Node) or user in seen:
+                continue
+            seen.add(user)
+            if len(seen) > 64:
+                return False
+            if user.op == "output":
+                continue
+            lowering = user.meta.get("lowering")
+            if (
+                isinstance(lowering, ReductionLowering)
+                and canonical_block_id(lowering.block_index) == target_canonical
+            ):
+                continue
+            if user.op == "call_function" and user.target in passthrough:
+                stack.append(user)
+                continue
+            return False
+    return True
+
+
+def _maybe_codegen_cute_baddbmm_n_collapse(
+    ctx: LoweringContext,
+    node: Node,
+    *,
+    lhs: ast.AST | CutePackedAffineLoad,
+    acc: ast.AST,
+    lhs_node: Node,
+    rhs_node: Node,
+    acc_node: Node,
+    k_block_id: int | None,
+    static_k_extent: int | None,
+) -> ast.AST | None:
+    """Layout (A) for a static-M==N-collapse baddbmm reduced over N.
+
+    See ``cute_static_mn_collapse_n_block_id`` /
+    ``_emit_cute_matmul_n_collapse``.  Returns ``None`` (caller keeps the
+    standard path) unless the tightly-gated pattern holds: the lhs M axis and
+    rhs N axis share a block id and the result is summed away over that block.
+    """
+    if not isinstance(lhs, ast.AST):
+        return None
+    n_block_id = cute_static_mn_collapse_n_block_id(ctx.cg, lhs_node, rhs_node)
+    if n_block_id is None:
+        return None
+    if not _cute_baddbmm_result_reduced_over_block(node, n_block_id):
+        return None
+    env = CompileEnvironment.current()
+    size_hint = getattr(env, "size_hint", None)
+    n_size = rhs_node.meta["val"].shape[-1]
+    n_extent = size_hint(n_size) if callable(size_hint) else int(n_size)
+    if not isinstance(n_extent, int) or n_extent <= 0:
+        return None
+
+    def rhs_at_n(n_var: str) -> ast.AST:
+        rematerialized = cute_rematerialize_rhs_at_index_override(
+            ctx, rhs_node, n_block_id, n_var
+        )
+        if rematerialized is None:
+            raise exc.BackendUnsupported(
+                "cute",
+                "CuTe static-MN-collapse baddbmm could not re-materialize the rhs "
+                "at the serial N index",
+            )
+        return rematerialized
+
+    return _emit_cute_matmul_n_collapse(
+        ctx.cg,
+        lhs,
+        rhs_at_n=rhs_at_n,
+        n_extent=n_extent,
+        k_block_id=k_block_id,
+        static_k_extent=static_k_extent,
+        acc=acc,
+        acc_dtype=acc_node.meta["val"].dtype,
+        lhs_dtype=lhs_node.meta["val"].dtype,
+        rhs_dtype=rhs_node.meta["val"].dtype,
+        lhs_node=lhs_node,
+        rhs_node=rhs_node,
+    )
+
+
 @baddbmm_lowering.register_codegen("cute")
 def codegen_baddbmm_cute(ctx: LoweringContext, node: Node) -> ast.AST:
     assert not node.kwargs, "baddbmm kwargs not supported"
@@ -1491,6 +1643,19 @@ def codegen_baddbmm_cute(ctx: LoweringContext, node: Node) -> ast.AST:
             "cute",
             "CuTe scalar matmul fallback requires an active K tile or a K-invariant static shortcut",
         )
+    n_collapse_result = _maybe_codegen_cute_baddbmm_n_collapse(
+        ctx,
+        node,
+        lhs=lhs,
+        acc=acc,
+        lhs_node=lhs_node,
+        rhs_node=rhs_node,
+        acc_node=acc_node,
+        k_block_id=k_block_id,
+        static_k_extent=static_k_extent,
+    )
+    if n_collapse_result is not None:
+        return n_collapse_result
     return _emit_cute_matmul(
         ctx.cg,
         lhs,

--- a/helion/_compiler/cute/device_state.py
+++ b/helion/_compiler/cute/device_state.py
@@ -295,6 +295,15 @@ class CuteDeviceFunctionState:
         # step instead of the loop-invariant ``rhs[..., m, ...]``.  Empty
         # except while re-materializing a matmul operand load.
         self.matmul_operand_block_remap: dict[int, int] = {}
+        # Active block-id -> raw index-expression override for matmul operand
+        # re-materialization.  Used by the static-MN-collapse baddbmm path: the
+        # rhs free (N) axis shares a block_id with the lhs M (output) axis, so
+        # the standard resolver would index the rhs at the M thread index
+        # (computing only the diagonal).  Re-lowering the rhs with this override
+        # makes its N axis read a serial N-loop variable instead, and suppresses
+        # masking for that axis (the serial loop already covers exactly [0, C)).
+        # Empty except while re-materializing such an operand load.
+        self.matmul_operand_index_override: dict[int, str] = {}
 
     def register_tcgen05_store_value(
         self, name: str, value: CuteTcgen05StoreValue

--- a/helion/_compiler/cute/matmul_fallback.py
+++ b/helion/_compiler/cute/matmul_fallback.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 from typing import TYPE_CHECKING
+from typing import cast
 
 import torch
 
@@ -15,6 +16,8 @@ from .indexing import CutePackedAffineLoad
 from .indexing import CutePackedTerms
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from ..helper_function import CodegenInterface
 
 
@@ -383,6 +386,143 @@ def _emit_cute_grouped_sum_reduction(
         num_threads=num_threads,
         group_count=num_threads // group_span,
     )
+
+
+def _emit_cute_matmul_n_collapse(
+    cg: CodegenInterface,
+    lhs: ast.AST,
+    *,
+    rhs_at_n: Callable[[str], ast.AST],
+    n_extent: int,
+    k_block_id: int | None,
+    static_k_extent: int | None,
+    acc: ast.AST,
+    acc_dtype: torch.dtype | None,
+    lhs_dtype: torch.dtype | None,
+    rhs_dtype: torch.dtype | None,
+    lhs_node: object,
+    rhs_node: object,
+) -> ast.AST:
+    """Lower a static-M==N-collapse baddbmm reduced over N (CuTe layout A).
+
+    The matmul's M (lhs free) and N (rhs free) axes share a block id, so the
+    standard fallback indexes the rhs N at the M thread index and computes only
+    the diagonal.  Here M stays the thread axis and N becomes a serial loop:
+
+        out_acc = 0
+        for n in range(N):
+            out_acc += K-reduce( lhs[m, k] * rhs[n, k] )
+        result = acc + out_acc
+
+    where the K reduction is the existing per-lane / cross-thread reduction.
+    Because the only consumer of this matmul's result is a sum over N, folding
+    the N reduction here makes ``result`` already the N-summed value and the
+    downstream ``.sum(-1)`` a no-op.
+    """
+    from ..generate_ast import GenerateAST
+
+    assert isinstance(cg, GenerateAST)
+    if hasattr(cg, "cute_uses_matmul"):
+        cg.cute_uses_matmul = True  # type: ignore[attr-defined]
+
+    reduction_dtype: torch.dtype | None = acc_dtype
+    if (
+        lhs_dtype is not None
+        and rhs_dtype is not None
+        and _needs_f32_accumulator(lhs_dtype, rhs_dtype)
+    ):
+        reduction_dtype = torch.float32
+    value_dtype = reduction_dtype or lhs_dtype or rhs_dtype or torch.float32
+
+    loop_state = None
+    if k_block_id is not None:
+        from ..tile_strategy import DeviceLoopOrGridState
+
+        active_device_loops = getattr(cg, "active_device_loops", None)
+        if isinstance(active_device_loops, dict):
+            loops = active_device_loops.get(k_block_id)
+            if loops and isinstance(loops[-1], DeviceLoopOrGridState):
+                loop_state = loops[-1]
+        # This path sums each K element across hardware threads (cross-thread
+        # reduction).  A K axis lowered as a *serial* per-thread lane loop would
+        # need the products accumulated across lane iterations, which this fold
+        # does not emit - reject it rather than silently summing one lane.
+        if loop_state is not None:
+            lane_vars = getattr(loop_state.strategy, "_lane_var_by_block", None)
+            if isinstance(lane_vars, dict) and k_block_id in lane_vars:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "CuTe static-MN-collapse baddbmm requires the contraction "
+                    "axis to be a cross-thread reduction, not a serial lane loop",
+                )
+
+    backend = CompileEnvironment.current().backend
+    zero_expr = f"{backend.dtype_str(value_dtype)}(0)"
+    out_acc = cg.device_function.new_var("dot_n_acc")
+    cg.add_statement(f"{out_acc} = {zero_expr}")
+
+    n_var = cg.device_function.new_var("dot_n")
+    loop_body: list[ast.AST] = []
+    with cg.set_statements(loop_body):
+        rhs = rhs_at_n(n_var)
+        lhs_term: ast.AST = lhs
+        rhs_term: ast.AST = rhs
+        if reduction_dtype is not None:
+            lhs_computed_fp8 = _cute_operand_is_computed_fp8(lhs_node)
+            rhs_computed_fp8 = _cute_operand_is_computed_fp8(rhs_node)
+            if (
+                lhs_dtype is not None
+                and rhs_dtype is not None
+                and _needs_f32_accumulator(lhs_dtype, rhs_dtype)
+            ):
+                lhs_term = _cast_operand_to_f32(
+                    lhs_term, lhs_dtype, is_computed_fp8=lhs_computed_fp8
+                )
+                rhs_term = _cast_operand_to_f32(
+                    rhs_term, rhs_dtype, is_computed_fp8=rhs_computed_fp8
+                )
+        product = expr_from_string("{lhs} * {rhs}", lhs=lhs_term, rhs=rhs_term)
+        if reduction_dtype is not None:
+            product = cast_ast(product, reduction_dtype)
+        if k_block_id is not None:
+            reduction_input = cg.lift(product, dce=True, prefix="dot_product").id
+            reduced_expr: ast.AST = expr_from_string(
+                _emit_cute_grouped_sum_reduction(
+                    cg,
+                    reduction_input,
+                    value_dtype=value_dtype,
+                    loop_state=loop_state,
+                    k_block_id=k_block_id,
+                )
+            )
+        else:
+            reduced_expr = product
+            if static_k_extent is not None and static_k_extent > 1:
+                scale = expr_from_string(
+                    f"{backend.dtype_str(value_dtype)}({static_k_extent})"
+                )
+                reduced_expr = expr_from_string(
+                    "({product}) * ({scale})", product=reduced_expr, scale=scale
+                )
+        cg.add_statement(
+            statement_from_string(
+                f"{out_acc} = {out_acc} + ({{reduced}})", reduced=reduced_expr
+            )
+        )
+
+    for_node = statement_from_string(f"for {n_var} in range({n_extent}):\n    pass")
+    assert isinstance(for_node, ast.For)
+    for_node.body = cast("list[ast.stmt]", loop_body)
+    cg.add_statement(for_node)
+
+    result: ast.AST = expr_from_string(out_acc)
+    base_acc = acc
+    if acc_dtype is not None and acc_dtype != reduction_dtype and reduction_dtype:
+        base_acc = cast_ast(base_acc, reduction_dtype)
+    result = expr_from_string("{acc} + {product}", acc=base_acc, product=result)
+    if acc_dtype is not None and acc_dtype != reduction_dtype:
+        result = cast_ast(result, acc_dtype)
+    return result
 
 
 def _emit_cute_matmul(

--- a/helion/_compiler/cute/matmul_utils.py
+++ b/helion/_compiler/cute/matmul_utils.py
@@ -755,6 +755,135 @@ def _cute_recodegen_load_with_block_remap(
     return None
 
 
+# fx view ops whose scalar-fallback lowering is a no-op (the underlying load
+# value is unchanged) - peeling them reaches the rhs's underlying ``load``.
+_CUTE_RHS_VIEW_PASSTHROUGH_TARGETS = (
+    torch.ops.aten.permute.default,
+    torch.ops.aten.transpose.int,
+    torch.ops.aten.t.default,
+    torch.ops.aten.clone.default,
+    torch.ops.aten.detach.default,
+    torch.ops.aten.view.default,
+    torch.ops.aten._unsafe_view.default,
+    torch.ops.aten.reshape.default,
+    torch.ops.prims.convert_element_type.default,
+)
+
+
+def cute_static_mn_collapse_n_block_id(
+    cg: CodegenInterface,
+    lhs_node: torch.fx.Node,
+    rhs_node: torch.fx.Node,
+) -> int | None:
+    """Detect the static-M==N collapse of a matmul reduced over N.
+
+    Returns the shared (M and N) block id when a matmul's lhs free axis
+    (``lhs.shape[-2]`` = M) and rhs free axis (``rhs.shape[-1]`` = N) resolve to
+    the *same* active block id (the collapse: M and N are the same static-size
+    dim).  In this case the standard resolver indexes the rhs N axis at the M
+    thread index, computing only ``out[m, m]`` (the diagonal).  Returns ``None``
+    when M and N are distinct blocks (every ordinary matmul/bmm), so the caller
+    keeps its existing diagonal-free behaviour.
+    """
+    env = CompileEnvironment.current()
+    canonical_block_id = getattr(env, "canonical_block_id", lambda block_id: block_id)
+    lhs_val = lhs_node.meta.get("val")
+    rhs_val = rhs_node.meta.get("val")
+    if not isinstance(lhs_val, torch.Tensor) or not isinstance(rhs_val, torch.Tensor):
+        return None
+    if lhs_val.ndim < 2 or rhs_val.ndim < 2:
+        return None
+    m_block_id = cute_resolve_active_block_id(cg, lhs_val.shape[-2])
+    n_block_id = cute_resolve_active_block_id(cg, rhs_val.shape[-1])
+    if m_block_id is None or n_block_id is None:
+        return None
+    if canonical_block_id(m_block_id) != canonical_block_id(n_block_id):
+        return None
+    # The contraction (K) axis must be a *different* block from the shared M/N
+    # block - otherwise this is not a well-formed matmul.
+    k_block_id = cute_resolve_active_block_id(cg, lhs_val.shape[-1])
+    if k_block_id is not None and canonical_block_id(k_block_id) == canonical_block_id(
+        m_block_id
+    ):
+        return None
+    return n_block_id
+
+
+def cute_underlying_load_node(node: torch.fx.Node) -> torch.fx.Node | None:
+    """Peel no-op view ops off *node* to reach its underlying ``load`` node."""
+    cur: torch.fx.Node | None = node
+    for _ in range(16):
+        if cur is None or cur.op != "call_function":
+            return None
+        if cur.target is load:
+            return cur
+        if cur.target not in _CUTE_RHS_VIEW_PASSTHROUGH_TARGETS:
+            return None
+        source = cur.args[0] if cur.args else None
+        cur = source if isinstance(source, torch.fx.Node) else None
+    return None
+
+
+def cute_rematerialize_rhs_at_index_override(
+    ctx: LoweringContext,
+    rhs_node: torch.fx.Node,
+    n_block_id: int,
+    index_expr: str,
+) -> ast.AST | None:
+    """Re-lower the rhs of a static-M==N-collapse matmul at a serial N index.
+
+    The rhs's free (N) axis shares a block id with the lhs M axis, so the
+    standard load indexes it at the M thread index.  Re-codegen the rhs's
+    underlying ``load`` with that block's index overridden to *index_expr* (a
+    serial N-loop variable) and masking for it suppressed, so the load reads
+    ``rhs[..., n, ...]`` for the loop's current n instead of the diagonal.
+    """
+    from ..generate_ast import GenerateAST
+    from ..inductor_lowering import CodegenState
+
+    cg = ctx.cg
+    if not isinstance(cg, GenerateAST):
+        return None
+    load_node = cute_underlying_load_node(rhs_node)
+    if load_node is None:
+        return None
+    cute_state = cg.device_function.cute_state
+
+    def env_arg(arg: object) -> object:
+        if isinstance(arg, torch.fx.Node):
+            return ctx.env[arg]
+        if isinstance(arg, (list, tuple)):
+            return type(arg)(env_arg(a) for a in arg)
+        return arg
+
+    def proxy_arg(arg: object) -> object:
+        if isinstance(arg, torch.fx.Node):
+            return arg.meta["val"]
+        if isinstance(arg, (list, tuple)):
+            return type(arg)(proxy_arg(a) for a in arg)
+        return arg
+
+    proxy_args = [proxy_arg(a) for a in load_node.args]
+    ast_args = [env_arg(a) for a in load_node.args]
+    state = CodegenState(
+        cg,
+        fx_node=load_node,
+        env=ctx.env,
+        proxy_args=list(proxy_args),
+        ast_args=list(ast_args),
+    )
+    previous = dict(cute_state.matmul_operand_index_override)
+    cute_state.matmul_operand_index_override = {n_block_id: index_expr}
+    load_codegen = load._codegen["cute"]  # pyrefly: ignore[missing-attribute]
+    try:
+        result = load_codegen(state)
+    finally:
+        cute_state.matmul_operand_index_override = previous
+    if isinstance(result, ast.AST):
+        return result
+    return None
+
+
 def _cute_matmul_operand_indices() -> dict[object, tuple[int, int]]:
     """``(lhs_arg_index, rhs_arg_index)`` for each matmul op the CuTe backend
     lowers through the scalar fallback.

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -404,7 +404,23 @@ def _cute_remap_block_id(state: CodegenState, block_id: int) -> int:
     return remap.get(block_id, block_id)
 
 
+def _cute_index_override(state: CodegenState, block_id: int) -> str | None:
+    """Return a raw index-expression override for *block_id*, if active.
+
+    Applied after ``_cute_remap_block_id``.  When set (only while
+    re-materializing the rhs of a static-MN-collapse baddbmm), the operand's
+    free (N) axis is indexed by this serial-loop variable instead of the shared
+    M thread index, and masking for that axis is suppressed.
+    """
+    override = state.device_function.cute_state.matmul_operand_index_override
+    if not override:
+        return None
+    return override.get(_cute_remap_block_id(state, block_id))
+
+
 def _cute_active_index_var(state: CodegenState, block_id: int) -> str | None:
+    if (override := _cute_index_override(state, block_id)) is not None:
+        return override
     block_id = _cute_remap_block_id(state, block_id)
     loops = state.codegen.active_device_loops.get(block_id)
     if loops:
@@ -416,6 +432,8 @@ def _cute_active_index_var(state: CodegenState, block_id: int) -> str | None:
 
 
 def _cute_active_mask_var(state: CodegenState, block_id: int) -> str | None:
+    if _cute_index_override(state, block_id) is not None:
+        return None
     block_id = _cute_remap_block_id(state, block_id)
     loops = state.codegen.active_device_loops.get(block_id)
     if loops:
@@ -719,6 +737,8 @@ def _cute_index_exprs(
         return begin_var
 
     def active_index_var(block_id: int) -> str | None:
+        if (override := _cute_index_override(state, block_id)) is not None:
+            return override
         block_id = _cute_remap_block_id(state, block_id)
         loops = state.codegen.active_device_loops.get(block_id)
         if loops:
@@ -2153,6 +2173,8 @@ def _cute_combined_mask(
     terms: list[str] = []
 
     def mask_var_for_block_id(block_id: int) -> str | None:
+        if _cute_index_override(state, block_id) is not None:
+            return None
         block_id = _cute_remap_block_id(state, block_id)
         loops = state.codegen.active_device_loops.get(block_id)
         if loops:
@@ -2160,6 +2182,8 @@ def _cute_combined_mask(
         return None
 
     def active_index_var(block_id: int) -> str | None:
+        if (override := _cute_index_override(state, block_id)) is not None:
+            return override
         block_id = _cute_remap_block_id(state, block_id)
         loops = state.codegen.active_device_loops.get(block_id)
         if loops:
@@ -2172,6 +2196,8 @@ def _cute_combined_mask(
     def active_local_coord(block_id: int) -> str | None:
         from .._compiler.cute.cute_reshape import _grid_local_coord_expr
 
+        if _cute_index_override(state, block_id) is not None:
+            return None
         block_id = _cute_remap_block_id(state, block_id)
         loops = state.codegen.active_device_loops.get(block_id)
         if loops:

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -14591,7 +14591,9 @@ class TestCuteLowerings(unittest.TestCase):
             codegen=codegen,
             device_function=SimpleNamespace(
                 tensor_arg=lambda tensor: SimpleNamespace(name="A"),
-                cute_state=SimpleNamespace(matmul_operand_block_remap={}),
+                cute_state=SimpleNamespace(
+                    matmul_operand_block_remap={}, matmul_operand_index_override={}
+                ),
             ),
         )
 
@@ -15706,7 +15708,9 @@ class TestCuteLowerings(unittest.TestCase):
             ),
             sympy_expr=lambda expr: str(expr),
             device_function=SimpleNamespace(
-                cute_state=SimpleNamespace(matmul_operand_block_remap={})
+                cute_state=SimpleNamespace(
+                    matmul_operand_block_remap={}, matmul_operand_index_override={}
+                )
             ),
         )
         env = SimpleNamespace(
@@ -15742,7 +15746,9 @@ class TestCuteLowerings(unittest.TestCase):
         state = SimpleNamespace(
             codegen=_FakeMaskCodegen(_FakeMaskedLoopStrategy([1]), {1}),
             device_function=SimpleNamespace(
-                cute_state=SimpleNamespace(matmul_operand_block_remap={})
+                cute_state=SimpleNamespace(
+                    matmul_operand_block_remap={}, matmul_operand_index_override={}
+                )
             ),
         )
         env = SimpleNamespace(

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -27,7 +27,6 @@ from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
 from helion._testing import skipIfXPU
 from helion._testing import skipUnlessTensorDescriptor
-from helion._testing import xfailIfCute
 import helion.language as hl
 
 _LARGE_BF16_SHAPE = (51200, 51200)
@@ -2592,9 +2591,6 @@ class TestIndexing(RefEagerTestBase, TestCase):
         expected = data[index_source, :, :]
         torch.testing.assert_close(result, expected)
 
-    @xfailIfCute(
-        "CuTe batched matmul lowering for full-slice loads in reduction loops is incorrect"
-    )
     def test_full_slice_in_reduction_loop(self):
         """Full slice between two tiled dims: q[tile_n, :, tile_d]
 
@@ -2624,7 +2620,8 @@ class TestIndexing(RefEagerTestBase, TestCase):
             torch.zeros(16, 16, 16, device=DEVICE), q, q.transpose(-2, -1)
         ).sum(-1)
         torch.testing.assert_close(result, expected, atol=0.2, rtol=0.01)
-        self.assertIn("tl.dot", code)
+        if _get_backend() == "triton":
+            self.assertIn("tl.dot", code)
 
     def test_symbolic_index_in_host_block(self):
         """Regression test for https://github.com/pytorch/helion/issues/1339.


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2674
 * __->__#2673
 * #2670
 * #2669
 * #2668
 * #2667
 * #2666
 * #2665
 * #2662
 * #2660


--- --- ---

[cute] Lower baddbmm with static M=N collapsed onto the reduced N dim

Support a batched matmul whose M and N output dims are the same static
(non-tiled) size and whose result is summed over N (e.g.
attn = baddbmm(qt, qt.T); out = attn.sum(-1)). Previously M and N both
collapsed onto qt's single C block, so the fallback emitted qt*qt (the
diagonal) and dropped N entirely.

Detect the collapse (M block == N block, where that block is the
downstream sum reduction and the baddbmm result only escapes via
loop-carry/casts), then fold the N sum into the matmul: emit a serial
N loop, re-materialize the rhs operand at the N index via a new
matmul_operand_index_override, multiply lhs[m,k]*rhs[n,k], reduce over K
(the existing cross-thread reduce), and accumulate across N. The
downstream .sum(-1) becomes the existing no-op pass-through. Gated tightly
to this pattern; mm/addmm and all other matmuls are unaffected.

Un-xfails test_full_slice_in_reduction_loop.