### PR TITLE
[cute] Lower chunked-recurrence GEMM (gdn_fwd_h)

### DIFF
--- a/helion/_compiler/cute/matmul_fallback.py
+++ b/helion/_compiler/cute/matmul_fallback.py
@@ -179,6 +179,118 @@ def _cute_acc_is_rescaled_loop_carried(acc_node: object) -> bool:
     return False
 
 
+def _node_args_iter(node: object) -> list[object]:
+    """Flatten a node's args (including list/tuple-nested args) to a list."""
+    out: list[object] = []
+    if not hasattr(node, "args"):
+        return out
+    for arg in node.args:  # type: ignore[attr-defined]
+        if isinstance(arg, (list, tuple)):
+            out.extend(arg)
+        else:
+            out.append(arg)
+    return out
+
+
+def _cute_k_block_varying_nodes(graph: object, k_block_id: int) -> set[object]:
+    """Return the fx nodes whose value varies along the K-contraction tile.
+
+    The within-K-tile per-element index for block ``k_block_id`` is the
+    ``_get_symnode('block_size_{k_block_id}')`` node (used directly as a load
+    index) and any ``tile_index`` / ``tile_id`` taken over it.  Every fx value
+    transitively computed from one of those seeds varies as the lane / K
+    contraction index advances.  ``acc`` rescales that touch this set are
+    lane-VARYING (flash-attention's ``alpha``); rescales that avoid it are
+    lane-INVARIANT (GDN's per-chunk decay, which indexes ``g`` by the chunk
+    boundary, not the within-chunk position).
+    """
+    import torch.fx
+
+    from ...language import _tracing_ops
+
+    if not isinstance(graph, torch.fx.Graph):
+        return set()
+
+    block_size_name = f"block_size_{k_block_id}"
+    seeds: set[torch.fx.Node] = set()
+    for node in graph.nodes:
+        if node.op != "call_function":
+            continue
+        if (
+            node.target is _tracing_ops._get_symnode
+            and node.args
+            and node.args[0] == block_size_name
+        ):
+            seeds.add(node)
+    # Forward-propagate: any node consuming a varying value also varies.  This
+    # also captures the ``tile_index`` / ``tile_id`` taken over the K block-size
+    # symnode (still the within-tile index) and everything downstream.
+    varying: set[torch.fx.Node] = set(seeds)
+    changed = True
+    while changed:
+        changed = False
+        for node in graph.nodes:
+            if node in varying or node.op != "call_function":
+                continue
+            for arg in _node_args_iter(node):
+                if isinstance(arg, torch.fx.Node) and arg in varying:
+                    varying.add(node)
+                    changed = True
+                    break
+    return cast("set[object]", varying)
+
+
+def _cute_rescale_is_lane_invariant(acc_node: object, k_block_id: int | None) -> bool:
+    """Return True when ``acc``'s rescale does NOT depend on the K-contraction
+    tile index (lane-invariant rescale).
+
+    Only meaningful when ``acc`` is a rescaled loop-carried accumulator (see
+    ``_cute_acc_is_rescaled_loop_carried``).  GDN's chunk recurrence multiplies
+    the accumulator by a per-chunk decay (``b_h *= exp(g[..., chunk_last]))``
+    that is constant across the within-chunk / lane index, so the cross-lane
+    ``dot_acc`` running sum stays correct (the rescale factors out of the sum).
+    Flash-attention's ``acc = acc * alpha`` instead rescales by ``alpha``, which
+    is derived from the per-K-tile scores, so it is lane-varying and the
+    per-iteration update must be kept.
+    """
+    import torch.fx
+
+    from ...language._tracing_ops import _new_var
+
+    if k_block_id is None or not isinstance(acc_node, torch.fx.Node):
+        return False
+
+    graph = acc_node.graph
+    varying = _cute_k_block_varying_nodes(graph, k_block_id)
+    if not varying:
+        # No identifiable K-tile index node: be conservative and treat the
+        # rescale as lane-varying (keep the existing per-iteration behavior).
+        return False
+
+    # Walk the rescale subgraph feeding ``acc_node``.  Stop at the loop-carried
+    # phi (``_new_var`` of a placeholder) — the phi carries the running value
+    # and is not part of the rescale dependency we are classifying.
+    seen: set[torch.fx.Node] = set()
+    stack: list[torch.fx.Node] = [acc_node]
+    while stack:
+        node = stack.pop()
+        if node in seen:
+            continue
+        seen.add(node)
+        if len(seen) > 1024:
+            return False  # too large to analyze safely -> conservative
+        if node in varying:
+            return False  # rescale touches a K-varying value -> lane-varying
+        if node.op == "call_function" and node.target is _new_var:
+            continue  # loop-carried phi: do not recurse past it
+        if node.op != "call_function":
+            continue
+        for arg in _node_args_iter(node):
+            if isinstance(arg, torch.fx.Node):
+                stack.append(arg)
+    return True
+
+
 def _cast_operand_to_f32(
     term: ast.AST, dtype: torch.dtype | None, *, is_computed_fp8: bool
 ) -> ast.AST:
@@ -615,10 +727,20 @@ def _emit_cute_matmul(
         # phi carries the running sum) by skipping the ``dot_acc`` path.  A
         # loop-invariant accumulator (e.g. a standalone ``addmm`` bias) keeps
         # ``dot_acc`` so the per-lane products are summed before the bias add.
+        #
+        # EXCEPTION: a *lane-invariant* rescale (GDN's chunk recurrence
+        # ``b_h *= decay`` where ``decay`` depends only on the chunk, not the
+        # within-chunk / lane index) factors out of the cross-lane sum:
+        # ``sum_c (b_h*decay + p_k[c]*b_v[c]) over c`` is wrong, but the
+        # mathematically intended update ``b_h = b_h*decay + sum_c p_k[c]*b_v[c]``
+        # is exactly what the ``dot_acc`` path produces once the AST post-pass
+        # hoists the rescale + final add out of the lane loop.  Keep ``dot_acc``
+        # in that case; only flash-attention's lane-varying rescale falls back.
         if (
             lane_var is not None
             and acc is not None
             and _cute_acc_is_rescaled_loop_carried(acc_node)
+            and not _cute_rescale_is_lane_invariant(acc_node, k_block_id)
         ):
             lane_var = None
         if lane_var is not None:

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -1032,6 +1032,7 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                 for param in self._extra_params:
                     self.device_function.placeholder_args.add(param)
                 if CompileEnvironment.current().backend.name == "cute":
+                    from .tile_strategy import hoist_lane_invariant_chunk_recurrence
                     from .tile_strategy import (
                         interchange_lane_outside_serial_reductions,
                     )
@@ -1055,6 +1056,13 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                     # rewrote so no ``_helion_lane_reduce`` call leaks into the
                     # emitted kernel.
                     self.device_function.body = restore_unprocessed_lane_reduce_markers(
+                        list(self.device_function.body)
+                    )
+                    # Restructure chunked-recurrence ``for chunk: for lane:``
+                    # nests whose matmul ``dot_acc`` running-sum needs the
+                    # lane-invariant rescale / chunk-entry stores / final combine
+                    # hoisted to run once per chunk (gdn_fwd_h).
+                    self.device_function.body = hoist_lane_invariant_chunk_recurrence(
                         list(self.device_function.body)
                     )
                 self.device_function.dead_code_elimination()

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -673,6 +673,22 @@ def _lane_varying_names(body: list[ast.AST], lane_var: str) -> set[str]:
     return varying
 
 
+def _lane_body_live_in(body: list[ast.AST], lane_var: str) -> set[str]:
+    """Names read in ``body`` before they are written (live-in), excluding the
+    lane var.  A loop-carried accumulator phi is live-in to the lane body."""
+    from .ast_read_writes import ReadWrites
+
+    written: set[str] = set()
+    live_in: set[str] = set()
+    for stmt in body:
+        rw = ReadWrites.from_ast(stmt)
+        for name in rw.reads:
+            if name != lane_var and name not in written:
+                live_in.add(name)
+        written |= set(rw.writes)
+    return live_in
+
+
 def _is_serial_for(stmt: ast.AST) -> bool:
     """Return True when ``stmt`` is an ordinary serial ``for`` loop (a device
     serial loop), NOT a per-thread lane loop."""
@@ -890,6 +906,306 @@ def _interchange_one_lane_loop(loop: ast.For, lane_var: str) -> list[ast.AST]:
     nest_b = loop
 
     return [nest_b, *nest_a]
+
+
+# ---------------------------------------------------------------------------
+# Chunked-recurrence (GDN) lane-invariant accumulator hoist.
+#
+# A chunked recurrence such as gdn_fwd_h carries an accumulator ``b_h`` across a
+# SERIAL chunk loop and, inside each chunk, contracts a matmul over the
+# within-chunk position ``c`` (lowered as an inner lane loop).  ``matmul_fallback``
+# emits the running-sum ``dot_acc`` form for this matmul (because the per-chunk
+# rescale is lane-invariant), producing inside the lane loop:
+#
+#       dot_acc_base = <lane-invariant rescale of b_h>      # e.g. b_h * decay
+#       dot_acc = dot_acc + <product(c)>                    # accumulate over c
+#       b_h = dot_acc_base + dot_acc                        # WRONG: per-lane reassign
+#
+# with ``dot_acc = <identity>`` reset OUTSIDE the chunk loop.  Reassigning ``b_h``
+# every lane iteration corrupts the recurrence (and any lane-invariant op that
+# must read the chunk-ENTRY ``b_h``, e.g. the store of ``b_h`` and the matmul
+# operand ``c_h = b_h``).  This pass restructures the nest to apply the rescale
+# and the final add once per chunk:
+#
+#   for chunk:
+#       dot_acc = <identity>                  # reset per chunk
+#       <lane-invariant chunk-entry stores using b_h>
+#       dot_acc_base = <rescale of frozen b_h>
+#       for lane:
+#           <producers; dot_acc = dot_acc + product(c)>
+#       b_h = dot_acc_base + dot_acc          # once per chunk
+# ---------------------------------------------------------------------------
+
+
+def _find_dot_acc_recurrence(
+    lane_loop: ast.For, lane_var: str
+) -> tuple[str, str, str] | None:
+    """If ``lane_loop`` ends with the chunked-recurrence ``dot_acc`` triple,
+    return ``(acc_var, dot_acc_base_var, dot_acc_var)``; else ``None``.
+
+    The triple (emitted by ``_emit_cute_matmul``'s lane-invariant ``dot_acc``
+    path) is, as the LAST three statements of the lane-loop body:
+
+        dot_acc_base = <expr>             # lane-invariant rescale of acc
+        dot_acc = dot_acc + <product>    # running sum over the lane axis
+        acc = dot_acc_base + dot_acc     # final combine
+    """
+    body = lane_loop.body
+    if len(body) < 3:
+        return None
+    base_stmt, sum_stmt, final_stmt = body[-3], body[-2], body[-1]
+
+    def assign_name(stmt: ast.AST) -> str | None:
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+        ):
+            return stmt.targets[0].id
+        return None
+
+    base_var = assign_name(base_stmt)
+    dot_acc_var = assign_name(sum_stmt)
+    acc_var = assign_name(final_stmt)
+    if base_var is None or dot_acc_var is None or acc_var is None:
+        return None
+    if not (base_var.startswith("dot_acc_base") and dot_acc_var.startswith("dot_acc")):
+        return None
+    # ``dot_acc = dot_acc + product``: a running self-sum over the lane axis.
+    assert isinstance(sum_stmt, ast.Assign)
+    if not (
+        isinstance(sum_stmt.value, ast.BinOp)
+        and isinstance(sum_stmt.value.op, ast.Add)
+        and isinstance(sum_stmt.value.left, ast.Name)
+        and sum_stmt.value.left.id == dot_acc_var
+    ):
+        return None
+    # ``acc = dot_acc_base + dot_acc``: the final per-chunk combine.
+    assert isinstance(final_stmt, ast.Assign)
+    final_reads = {n.id for n in ast.walk(final_stmt.value) if isinstance(n, ast.Name)}
+    if final_reads != {base_var, dot_acc_var}:
+        return None
+    # The rescale (``dot_acc_base``) must be lane-INVARIANT: it must not read the
+    # lane var nor any value derived from it within the lane body.
+    lane_body: list[ast.AST] = list(body)
+    lane_varying = _lane_varying_names(lane_body, lane_var)
+    from .ast_read_writes import ReadWrites
+
+    base_reads = set(ReadWrites.from_ast(base_stmt).reads)
+    if lane_var in base_reads or (base_reads & lane_varying):
+        return None
+    return acc_var, base_var, dot_acc_var
+
+
+def _single_lane_loop_in_body(
+    body: list[ast.AST],
+) -> tuple[int, ast.For, str] | None:
+    """If ``body`` contains exactly one direct lane loop, return its index, the
+    loop node, and its lane var; else ``None``."""
+    found: tuple[int, ast.For, str] | None = None
+    for idx, stmt in enumerate(body):
+        lane_var = getattr(stmt, HELION_LANE_LOOP_VAR_ATTR, None)
+        if (
+            lane_var is not None
+            and isinstance(stmt, ast.For)
+            and isinstance(stmt.target, ast.Name)
+            and stmt.target.id == lane_var
+        ):
+            if found is not None:
+                return None
+            found = (idx, stmt, lane_var)
+    return found
+
+
+def _find_reset_assign(body: list[ast.AST], var: str) -> int | None:
+    """Index of the last ``var = <expr>`` plain assignment in ``body`` (the
+    ``dot_acc`` reset emitted before the chunk loop), or ``None``."""
+    for idx in range(len(body) - 1, -1, -1):
+        stmt = body[idx]
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and stmt.targets[0].id == var
+        ):
+            return idx
+    return None
+
+
+def hoist_lane_invariant_chunk_recurrence(
+    body: list[ast.AST],
+) -> list[ast.AST]:
+    """Restructure ``for chunk: for lane: <dot_acc recurrence>`` nests so the
+    lane-invariant rescale, chunk-entry stores, and final accumulator combine
+    run once per chunk (see the module comment above).
+
+    Tightly gated: only fires on a serial chunk loop whose single inner lane
+    loop ends with the ``dot_acc`` triple and whose ``dot_acc`` reset sits in
+    the same statement list before the chunk loop.
+    """
+    new_body: list[ast.AST] = []
+    for stmt in body:
+        # Recurse into nested statement-bearing fields first.
+        for field in ("body", "orelse", "finalbody"):
+            old = getattr(stmt, field, None)
+            if isinstance(old, list) and all(isinstance(s, ast.stmt) for s in old):
+                setattr(stmt, field, hoist_lane_invariant_chunk_recurrence(old))
+
+        info = _detect_chunk_recurrence(stmt)
+        if info is None:
+            new_body.append(stmt)
+            continue
+        dot_acc_var = info[0]
+        reset_idx = _find_reset_assign(new_body, dot_acc_var)
+        if reset_idx is None:
+            # No relocatable reset found: bail out (leave nest unchanged).
+            new_body.append(stmt)
+            continue
+        reset_stmt = new_body.pop(reset_idx)
+        assert isinstance(stmt, ast.For)
+        new_body.append(_rewrite_chunk_recurrence(stmt, info, reset_stmt))
+    return new_body
+
+
+def _detect_chunk_recurrence(
+    stmt: ast.AST,
+) -> tuple[str, int, ast.For, str, str, str, str] | None:
+    """Return ``(dot_acc_var, lane_idx, lane_loop, lane_var, acc_var, base_var,
+    dot_acc_var)`` when ``stmt`` is a serial chunk loop carrying the ``dot_acc``
+    recurrence, else ``None``."""
+    if not _is_serial_for(stmt) or not isinstance(stmt, ast.For):
+        return None
+    found = _single_lane_loop_in_body(list(stmt.body))
+    if found is None:
+        return None
+    lane_idx, lane_loop, lane_var = found
+    triple = _find_dot_acc_recurrence(lane_loop, lane_var)
+    if triple is None:
+        return None
+    acc_var, base_var, dot_acc_var = triple
+    return dot_acc_var, lane_idx, lane_loop, lane_var, acc_var, base_var, dot_acc_var
+
+
+def _rewrite_chunk_recurrence(
+    stmt: ast.For,
+    info: tuple[str, int, ast.For, str, str, str, str],
+    reset_stmt: ast.AST,
+) -> ast.For:
+    """Build the restructured chunk loop (see module comment)."""
+    from .ast_read_writes import ReadWrites
+
+    _dot_acc, lane_idx, lane_loop, lane_var, acc_var, _base_var, _dot_acc2 = info
+    chunk_body: list[ast.AST] = list(stmt.body)
+    lane_body: list[ast.AST] = list(lane_loop.body)
+    base_stmt = lane_body[-3]
+    sum_stmt = lane_body[-2]
+    final_stmt = lane_body[-1]
+    producers: list[ast.AST] = lane_body[:-3]
+
+    lane_varying = _lane_varying_names(lane_body, lane_var)
+
+    def reads_lane(s: ast.AST) -> bool:
+        reads = set(ReadWrites.from_ast(s).reads)
+        return lane_var in reads or bool(reads & lane_varying)
+
+    # The "accumulator family": the names that all hold the chunk-ENTRY
+    # accumulator value.  Helion may capture the loop-carried phi through a chain
+    # of plain copy-aliases (``b_h_copy = b_h``; ``b_h_copy_0 = b_h_copy``) and
+    # the rescale / chunk-entry store read those copies, not ``acc_var`` (which
+    # is the chunk-EXIT result).  Build the copy-alias closure over the chunk
+    # prefix and the lane producers, seeded from the loop-carried phi: a name
+    # that is live-in to the lane body (read before written) and feeds the
+    # lane-invariant rescale ``base_stmt``.
+    chunk_prefix = chunk_body[:lane_idx]
+    copy_src: dict[str, str] = {}
+    for s in (*chunk_prefix, *producers):
+        if (
+            isinstance(s, ast.Assign)
+            and len(s.targets) == 1
+            and isinstance(s.targets[0], ast.Name)
+            and isinstance(s.value, ast.Name)
+        ):
+            copy_src[s.targets[0].id] = s.value.id
+
+    def copy_root(name: str) -> str:
+        seen: set[str] = set()
+        while name in copy_src and name not in seen:
+            seen.add(name)
+            name = copy_src[name]
+        return name
+
+    base_slice_indices, _ = _backward_slice(
+        producers, set(ReadWrites.from_ast(base_stmt).reads)
+    )
+    base_slice_reads = set(ReadWrites.from_ast(base_stmt).reads)
+    for i in base_slice_indices:
+        base_slice_reads |= set(ReadWrites.from_ast(producers[i]).reads)
+    lane_live_in = _lane_body_live_in(producers, lane_var)
+    phi_roots = {
+        copy_root(name) for name in base_slice_reads if copy_root(name) in lane_live_in
+    }
+    acc_family = set(phi_roots)
+    for name in (*copy_src.keys(),):
+        if copy_root(name) in phi_roots:
+            acc_family.add(name)
+
+    # Backward slice feeding the lane-invariant rescale ``base_stmt``: those
+    # producers are lane-invariant and hoist before the lane loop with it.
+    base_seed = set(ReadWrites.from_ast(base_stmt).reads)
+    hoist_indices, _ = _backward_slice(producers, base_seed)
+    hoist_set = set(hoist_indices)
+
+    # Lane-invariant side-effecting statements whose backward slice reaches the
+    # (frozen) chunk-ENTRY accumulator (the store of ``b_h``) must hoist before
+    # the lane loop so they run once per chunk on the frozen value; bring their
+    # producers along.  A store that does NOT read the accumulator stays in the
+    # lane loop (it is a genuinely per-lane side effect).
+    entry_indices: list[int] = []
+    for idx, prod in enumerate(producers):
+        if idx in hoist_set or reads_lane(prod) or not _has_side_effect(prod):
+            continue
+        slice_indices, _ = _backward_slice(
+            producers[:idx], set(ReadWrites.from_ast(prod).reads)
+        )
+        slice_reads = set(ReadWrites.from_ast(prod).reads)
+        for i in slice_indices:
+            slice_reads |= set(ReadWrites.from_ast(producers[i]).reads)
+        if not (acc_family & slice_reads):
+            continue
+        # The store + its lane-invariant producer slice all hoist.
+        if any(reads_lane(producers[i]) for i in slice_indices):
+            continue
+        entry_indices.append(idx)
+        hoist_set.update(slice_indices)
+
+    hoist_pre = sorted(hoist_set | set(entry_indices))
+    pre_lane = [producers[i] for i in hoist_pre]
+    lane_kept = [
+        producers[i]
+        for i in range(len(producers))
+        if i not in hoist_set and i not in set(entry_indices)
+    ]
+
+    new_lane_loop = _create_lane_loop(
+        lane_var, _lane_loop_extent(lane_loop), [*lane_kept, sum_stmt]
+    )
+    new_chunk_body: list[ast.AST] = [
+        *chunk_body[:lane_idx],
+        reset_stmt,
+        *pre_lane,
+        base_stmt,
+        new_lane_loop,
+        final_stmt,
+        *chunk_body[lane_idx + 1 :],
+    ]
+    return create(
+        ast.For,
+        target=stmt.target,
+        iter=stmt.iter,
+        body=new_chunk_body,
+        orelse=stmt.orelse,
+        type_comment=None,
+    )
 
 
 @dataclasses.dataclass

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -32,7 +32,6 @@ from helion._testing import skipIfRefEager
 from helion._testing import skipIfRocm
 from helion._testing import skipIfTileIR
 from helion._testing import skipIfXPU
-from helion._testing import xfailIfCute
 from helion._testing import xfailIfPallas
 from helion._testing import xfailIfPallasInterpret
 from helion._testing import xfailIfPallasTpu
@@ -2403,7 +2402,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             indexing="block_ptr",
         )
 
-    @xfailIfCute("CuTe GDN forward example still fails CUTLASS DSL codegen")
     @xfailIfPallasTpu("operation not supported on TPU")
     def test_gdn_fwd_h(self):
         """Test gated delta net forward h kernel."""


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * __->__#2674
 * #2673
 * #2670
 * #2669
 * #2668
 * #2667
 * #2666
 * #2665
 * #2662
 * #2660


--- --- ---

[cute] Lower chunked-recurrence GEMM (gdn_fwd_h)

A chunk-recurrence kernel carries a 2D accumulator b_h across a sequential
chunk loop, with a matmul whose contraction is the chunk dim. CuTe lowered
the chunk tile as an outer serial loop plus an inner lane loop over the
within-chunk index c, but emitted the whole loop body inside the lane loop,
so per-chunk-once ops (the h store, the lane-invariant decay b_h *= exp(g),
and the b_h accumulation) wrongly ran once per c.

Two pieces:
- Lane-invariance discriminator (matmul_fallback): keep the cross-lane
  dot_acc running-sum when the accumulator's rescale is invariant across the
  contraction/lane axis (a per-chunk recurrence), while flash-attention's
  per-element (lane-varying) rescale still uses the per-iteration form.
- Chunk-recurrence AST post-pass (tile_strategy, hooked in generate_ast):
  for a chunk-loop/lane-loop nest with a lane-invariant-rescaled dot_acc
  accumulator, reset dot_acc per chunk, hoist the chunk-entry store and the
  decay out of the lane loop, keep the b_v producers and the dot_acc
  accumulation inside it, and emit b_h = entry*decay + dot_acc once per chunk.

Gated to cute and to this pattern; attention and all other matmuls unchanged.
Un-xfails test_gdn_fwd_h.