### PR TITLE
[Pallas] Fix BlockSpec for emit_pipeline nested in outer non-grid loop

### DIFF
--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -1511,6 +1511,17 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                 else:
                     block_shape_parts.append(str(int(shape[dim_idx])))
                 lambda_parts.append(pid_var)
+            elif bid is not None and state.codegen.active_device_loops.get(bid):
+                # Outer non-grid device loop -- the HBM ref is pre-sliced via
+                # ``.at[pl.ds(offset, bs)]`` (see _make_hbm_slice), so the
+                # BlockSpec sees an already-sliced ref of size ``bs`` along
+                # this dim. Use the full sliced size with a constant index.
+                bs_var = state.device_function.block_size_var(bid)
+                if bs_var:
+                    block_shape_parts.append(bs_var)
+                else:
+                    block_shape_parts.append(str(int(shape[dim_idx])))
+                lambda_parts.append("0")
             else:
                 idx_meta = (
                     subscript_meta[dim_idx]
@@ -1544,23 +1555,30 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     def _make_hbm_slice(
         fake: torch.Tensor, hbm_name: str, subscript_meta: list[object]
     ) -> str:
-        """Build an HBM ref slicing expression for outer grid dims."""
+        """Slice the HBM ref for outer non-grid device loop dims.
+
+        Outer grid dims are handled by BlockSpec via captured ``program_id``,
+        and inner pipeline dims are handled by BlockSpec via the iteration
+        lambda — so this only adds ``pl.ds(offset, bs)`` slices for outer
+        device loops whose offset is a closure variable in this scope.
+        """
         dim_to_bid = _get_dim_block_ids(subscript_meta, env)
         shape = fake.shape
         parts: list[str] = []
         needs_slice = False
         for dim_idx in range(len(shape)):
             bid = dim_to_bid.get(dim_idx)
-            if bid is not None and bid not in block_ids:
-                grid_loops = state.codegen.active_device_loops.get(bid)
-                if grid_loops:
-                    offset = state.codegen.offset_var(bid)
-                    bs_var = state.device_function.block_size_var(bid)
-                    if bs_var:
-                        parts.append(f"pl.ds({offset}, {bs_var})")
-                        needs_slice = True
-                    else:
-                        parts.append(":")
+            if (
+                bid is not None
+                and bid not in block_ids
+                and bid not in _bid_to_pid_var
+                and state.codegen.active_device_loops.get(bid)
+            ):
+                offset = state.codegen.offset_var(bid)
+                bs_var = state.device_function.block_size_var(bid)
+                if bs_var:
+                    parts.append(f"pl.ds({offset}, {bs_var})")
+                    needs_slice = True
                 else:
                     parts.append(":")
             else:
@@ -1613,7 +1631,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         in_tensors.append((fake, hbm_name))
         in_specs.append(_make_block_spec(fake, sub_meta))
         body_params.append(vmem_name)
-        pipeline_in_args.append(hbm_name)
+        pipeline_in_args.append(_make_hbm_slice(fake, hbm_name, sub_meta))
 
     for fake, _tensor_node, sub_meta in stored_tensors.values():
         if id(fake) not in pipelined_tensor_ids:
@@ -1625,7 +1643,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         out_tensors.append((fake, hbm_name))
         out_specs.append(_make_block_spec(fake, sub_meta))
         body_params.append(vmem_name)
-        pipeline_out_args.append(hbm_name)
+        pipeline_out_args.append(_make_hbm_slice(fake, hbm_name, sub_meta))
 
     # Build the body function
     body_fn_name = state.device_function.new_var("_pipeline_body")

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -309,27 +309,6 @@ def pallas_add_3d(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
-def pallas_nested_non_grid_outer_loop(x: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
-    """Grid (``tile_m``) → non-grid device loop (``tile_n``) wrapping an
-    inner emit_pipeline (``tile_k``) whose body reads ``w[tile_k, tile_n]``.
-
-    The inner pipeline's BlockSpec for ``w`` has to encode ``tile_n`` —
-    an outer non-grid loop offset — along ``w``'s last dim. Mirrors the
-    epilogue structure of ``squeeze_and_excitation_net``.
-    """
-    m, k = x.size()
-    n = w.size(1)
-    out = torch.empty([m, n], dtype=x.dtype, device=x.device)
-    for tile_m in hl.tile(m):
-        for tile_n in hl.tile(n):
-            acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
-            for tile_k in hl.tile(k):
-                acc = torch.addmm(acc, x[tile_m, tile_k], w[tile_k, tile_n])
-            out[tile_m, tile_n] = acc.to(x.dtype)
-    return out
-
-
-@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_attention(
     q_in: torch.Tensor, k_in: torch.Tensor, v_in: torch.Tensor
 ) -> torch.Tensor:
@@ -1208,19 +1187,34 @@ class TestPallas(TestCase):
         "JAX interpret mode (program_id_p.bind asserts during trace)"
     )
     def test_nested_non_grid_outer_loop_emit_pipeline(self) -> None:
-        """Outer non-grid device loop around an ``emit_pipeline`` whose
-        body reads a tensor indexed by that outer tile compiles and
-        produces correct matmul output.
+        """Grid (``tile_m``) → non-grid device loop (``tile_n``) wrapping
+        an inner emit_pipeline (``tile_k``) whose body reads
+        ``w[tile_k, tile_n]`` compiles and produces correct matmul output.
+        Mirrors the epilogue structure of ``squeeze_and_excitation_net``.
 
         ``n`` must exceed the effective ``bs_n`` (128 lanes on TPU) so the
         inner BlockSpec for ``w`` is actually block-sized rather than
         coincidentally equalling the full ``n`` dim.
         """
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def kernel(x: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            n = w.size(1)
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m in hl.tile(m):
+                for tile_n in hl.tile(n):
+                    acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                    for tile_k in hl.tile(k):
+                        acc = torch.addmm(acc, x[tile_m, tile_k], w[tile_k, tile_n])
+                    out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
         m, k, n = 32, 256, 256
         x = torch.randn(m, k, device=DEVICE, dtype=torch.float32)
         w = torch.randn(k, n, device=DEVICE, dtype=torch.float32)
         code, result = code_and_output(
-            pallas_nested_non_grid_outer_loop,
+            kernel,
             (x, w),
             block_sizes=[16, 128, 128],
             pallas_loop_type="emit_pipeline",

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -310,13 +310,12 @@ def pallas_add_3d(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
 @helion.kernel(backend="pallas", static_shapes=True)
 def pallas_nested_non_grid_outer_loop(x: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
-    """Outer grid (``tile_m``) → outer non-grid device loop (``tile_n``)
-    → inner pipeline (``tile_k``) where the pipeline reads
-    ``w[tile_k, tile_n]``.
+    """Grid (``tile_m``) → non-grid device loop (``tile_n``) wrapping an
+    inner emit_pipeline (``tile_k``) whose body reads ``w[tile_k, tile_n]``.
 
-    The inner pipeline's BlockSpec for ``w`` has to encode ``tile_n``
-    — an outer non-grid loop offset — along ``w``'s last dim.
-    Mirrors the epilogue structure of ``squeeze_and_excitation_net``.
+    The inner pipeline's BlockSpec for ``w`` has to encode ``tile_n`` —
+    an outer non-grid loop offset — along ``w``'s last dim. Mirrors the
+    epilogue structure of ``squeeze_and_excitation_net``.
     """
     m, k = x.size()
     n = w.size(1)
@@ -1213,16 +1212,19 @@ class TestPallas(TestCase):
         body reads a tensor indexed by that outer tile.
 
         BlockSpec for the inner pipeline must encode the outer non-grid
-        offset; before the fix this fell through to the full-dim shape
-        and the matmul broadcast-failed with mismatched shapes.
+        offset; without the fix this falls through to the full-dim shape
+        and the matmul broadcast-fails with ``(bs_m, bs_n) vs (bs_m, n)``.
+        ``n`` must exceed the effective ``bs_n`` (128 lanes on TPU) for the
+        mismatch to be visible — otherwise the broken full-dim spec
+        coincidentally equals the correct block shape.
         """
-        m, k, n = 32, 256, 128
+        m, k, n = 32, 256, 256
         x = torch.randn(m, k, device=DEVICE, dtype=torch.float32)
         w = torch.randn(k, n, device=DEVICE, dtype=torch.float32)
         code, result = code_and_output(
             pallas_nested_non_grid_outer_loop,
             (x, w),
-            block_sizes=[16, 64, 128],
+            block_sizes=[16, 128, 128],
             pallas_loop_type="emit_pipeline",
         )
         self.assertIn("pltpu.emit_pipeline", code)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -309,9 +309,7 @@ def pallas_add_3d(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
-def pallas_nested_non_grid_outer_loop(
-    x: torch.Tensor, w: torch.Tensor
-) -> torch.Tensor:
+def pallas_nested_non_grid_outer_loop(x: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
     """Outer grid (``tile_m``) → outer non-grid device loop (``tile_n``)
     → inner pipeline (``tile_k``) where the pipeline reads
     ``w[tile_k, tile_n]``.
@@ -1206,6 +1204,10 @@ class TestPallas(TestCase):
         compiled under ``pallas_loop_type='fori_loop'``."""
         self._check_scalar_lookup_in_pipeline("fori_loop")
 
+    @xfailIfPallasInterpret(
+        "pl.program_id captured into emit_pipeline body is not supported in "
+        "JAX interpret mode (program_id_p.bind asserts during trace)"
+    )
     def test_nested_non_grid_outer_loop_emit_pipeline(self) -> None:
         """Outer non-grid device loop around an ``emit_pipeline`` whose
         body reads a tensor indexed by that outer tile.

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -309,6 +309,30 @@ def pallas_add_3d(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_nested_non_grid_outer_loop(
+    x: torch.Tensor, w: torch.Tensor
+) -> torch.Tensor:
+    """Outer grid (``tile_m``) → outer non-grid device loop (``tile_n``)
+    → inner pipeline (``tile_k``) where the pipeline reads
+    ``w[tile_k, tile_n]``.
+
+    The inner pipeline's BlockSpec for ``w`` has to encode ``tile_n``
+    — an outer non-grid loop offset — along ``w``'s last dim.
+    Mirrors the epilogue structure of ``squeeze_and_excitation_net``.
+    """
+    m, k = x.size()
+    n = w.size(1)
+    out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+    for tile_m in hl.tile(m):
+        for tile_n in hl.tile(n):
+            acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+            for tile_k in hl.tile(k):
+                acc = torch.addmm(acc, x[tile_m, tile_k], w[tile_k, tile_n])
+            out[tile_m, tile_n] = acc.to(x.dtype)
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_attention(
     q_in: torch.Tensor, k_in: torch.Tensor, v_in: torch.Tensor
 ) -> torch.Tensor:
@@ -1181,6 +1205,26 @@ class TestPallas(TestCase):
         """Same kernel as :meth:`test_scalar_lookup_with_emit_pipeline`
         compiled under ``pallas_loop_type='fori_loop'``."""
         self._check_scalar_lookup_in_pipeline("fori_loop")
+
+    def test_nested_non_grid_outer_loop_emit_pipeline(self) -> None:
+        """Outer non-grid device loop around an ``emit_pipeline`` whose
+        body reads a tensor indexed by that outer tile.
+
+        BlockSpec for the inner pipeline must encode the outer non-grid
+        offset; before the fix this fell through to the full-dim shape
+        and the matmul broadcast-failed with mismatched shapes.
+        """
+        m, k, n = 32, 256, 128
+        x = torch.randn(m, k, device=DEVICE, dtype=torch.float32)
+        w = torch.randn(k, n, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_nested_non_grid_outer_loop,
+            (x, w),
+            block_sizes=[16, 64, 128],
+            pallas_loop_type="emit_pipeline",
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+        torch.testing.assert_close(result, x @ w, rtol=1e-2, atol=1e-2)
 
     def test_two_pass_reduction_emit_pipeline(self) -> None:
         """Two inner reduction loops over the same dim compile and run under

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1209,14 +1209,12 @@ class TestPallas(TestCase):
     )
     def test_nested_non_grid_outer_loop_emit_pipeline(self) -> None:
         """Outer non-grid device loop around an ``emit_pipeline`` whose
-        body reads a tensor indexed by that outer tile.
+        body reads a tensor indexed by that outer tile compiles and
+        produces correct matmul output.
 
-        BlockSpec for the inner pipeline must encode the outer non-grid
-        offset; without the fix this falls through to the full-dim shape
-        and the matmul broadcast-fails with ``(bs_m, bs_n) vs (bs_m, n)``.
-        ``n`` must exceed the effective ``bs_n`` (128 lanes on TPU) for the
-        mismatch to be visible — otherwise the broken full-dim spec
-        coincidentally equals the correct block shape.
+        ``n`` must exceed the effective ``bs_n`` (128 lanes on TPU) so the
+        inner BlockSpec for ``w`` is actually block-sized rather than
+        coincidentally equalling the full ``n`` dim.
         """
         m, k, n = 32, 256, 256
         x = torch.randn(m, k, device=DEVICE, dtype=torch.float32)


### PR DESCRIPTION
## Summary

Fix `_make_block_spec` for emit_pipeline nested inside an outer non-grid device loop. Previously, when a tensor dimension was indexed by a non-grid outer loop bid (e.g. `tile_n` from `for tile_n in hl.tile(n)` nested inside `for tile_m in hl.tile(m)`), `_make_block_spec` fell through to a full-dim BlockSpec and the inner pipeline body broadcast-failed on `acc + load @ load`.

Concrete failure from `squeeze_and_excitation_net_fwd` default config (`emit_pipeline`, `block_sizes=[16, 128, 128, 128]`) on `[1024, 1024, 1024]` and `[4096, 4096, 4096]`:

```
TypeError: add got incompatible shapes for broadcasting: (16, 128), (16, 1024)
```

Generated `b` BlockSpec was `(128, 1024)` with `lambda _j: (_j, 0)` (full `n` dim) instead of `(128, 128)` with the outer offset applied.

## Fix

`helion/language/_tracing_ops.py`:

1. New `elif` branch in `_make_block_spec` for outer non-grid device loop bids — emits `(bs_var,)` block_shape with constant `0` lambda index (the HBM ref is pre-sliced, so the BlockSpec sees an already-sliced ref of size `bs` along that dim).
2. Wire `_make_hbm_slice` (previously dead code) into the `pipeline_in_args` / `pipeline_out_args` construction so the HBM ref is pre-sliced via `.at[pl.ds(offset, bs)]` before being passed to `emit_pipeline`.
3. Tighten `_make_hbm_slice` to skip outer GRID bids (those are already encoded via captured `pl.program_id` in BlockSpec) — prevents double slicing.

Branch ordering in `_make_block_spec`:
- `bid in block_ids` → inner pipeline dim (unchanged)
- `bid in _bid_to_pid_var` → outer grid dim (unchanged)
- `bid in active_device_loops` → outer non-grid dim (**new branch**)
- else → scalar / static (unchanged)

## Test

`test/test_pallas.py` adds `test_nested_non_grid_outer_loop_emit_pipeline`. The kernel under test is a small matmul with the trap structure: grid `tile_m` → non-grid `tile_n` → inner pipeline `tile_k` reading `w[tile_k, tile_n]`. It compiles under `pallas_loop_type='emit_pipeline'` and checks the result against `x @ w`. Shape is `n=256` with `block_sizes=[16, 128, 128]` so that the effective `bs_n` (clamped up to the 128-lane TPU minimum) is strictly less than `n` — otherwise the inner BlockSpec for `w` would coincidentally equal the full-`n` shape and the test would compile-pass even when the BlockSpec is wrong. The new test fails on `main` (broadcast mismatch `(16, 128) vs (16, 256)`) and passes on this branch.

`@xfailIfPallasInterpret(...)` is applied because JAX interpret mode cannot trace `pl.program_id` captured into an `emit_pipeline` body (`program_id_p.bind` asserts during the scheduler's body trace).

## Verification

End-to-end on TPU (Pallas backend):
- `pytest test/test_examples.py -k test_squeeze_and_excitation_net` — fwd passes.
- `squeeze_and_excitation_net_fwd` with `HELION_AUTOTUNE_EFFORT=none` (forces default config = `emit_pipeline` with `block_sizes=[16, 128, 128, 128]`) — runs cleanly on both `[1024]^3` and `[4096]^3`.
