### PR TITLE
[Pallas] Add fp8_attention to TPU benchmark sweep

### DIFF
--- a/benchmarks/run_tpu.py
+++ b/benchmarks/run_tpu.py
@@ -147,6 +147,16 @@ def _welford_shapes(num_shapes: int | None = None) -> list[tuple[str, tuple[Any,
     ]
 
 
+def _fp8_attention_baseline(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+) -> torch.Tensor:
+    # `fp8_attention_pytorch` returns a callable factory; unwrap it to the
+    # harness's `baseline_fn(*args) -> Tensor` contract.
+    from examples.fp8_attention import fp8_attention_pytorch
+
+    return fp8_attention_pytorch(q, k, v)()
+
+
 def _welford_baseline(
     weight: torch.Tensor, bias: torch.Tensor, x: torch.Tensor, eps: float = 1e-05
 ) -> torch.Tensor:
@@ -167,6 +177,30 @@ def _attention_shapes(
         (1, 4, 512, 64),
         (1, 4, 1024, 64),
         (2, 8, 512, 64),
+    ]
+    if num_shapes is not None:
+        configs = configs[:num_shapes]
+    return [
+        (
+            f"[{z},{h},{n},{d}]",
+            tuple(
+                torch.randn(z, h, n, d, device=DEVICE, dtype=torch.bfloat16)
+                for _ in range(3)
+            ),
+        )
+        for z, h, n, d in configs
+    ]
+
+
+def _fp8_attention_shapes(
+    num_shapes: int | None = None,
+) -> list[tuple[str, tuple[Any, ...]]]:
+    # Mirrors examples/fp8_attention.py main() — the canonical shapes that
+    # the example's own correctness check exercises.
+    configs = [
+        (1, 2, 128, 64),
+        (2, 4, 256, 64),
+        (4, 8, 512, 128),
     ]
     if num_shapes is not None:
         configs = configs[:num_shapes]
@@ -842,6 +876,17 @@ KERNEL_MAPPINGS: dict[str, KernelMapping] = {
         torch.nn.functional.scaled_dot_product_attention,
         _attention_shapes,
         None,
+    ),
+    # FP8 outputs vs the _scaled_mm reference can disagree on a few percent
+    # of elements at the harness's default tolerance (rtol=1e-2, atol=1e-1).
+    # The example's own check() uses atol/rtol=0.1; allow up to 5% mismatch
+    # here to mirror that intent while still catching gross regressions.
+    "fp8_attention": (
+        "fp8_attention",
+        "fp8_attention",
+        _fp8_attention_baseline,
+        _fp8_attention_shapes,
+        0.05,
     ),
     "bmm": ("bmm", "bmm", torch.bmm, _bmm_shapes, None),
     # Renamed from "matmul" to "gemm" so this kernel shares the same dashboard

--- a/examples/fp8_attention.py
+++ b/examples/fp8_attention.py
@@ -162,6 +162,19 @@ def fp8_attention_tritonbench(
 
 
 # %%
+def fp8_attention(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+    """End-to-end FP8 attention: preprocess bf16 (q,k,v) and run the kernel.
+
+    Tensor-returning entry point used by `benchmarks/run_tpu.py` (the
+    harness expects `fn(*args) -> Tensor`, while `fp8_attention_tritonbench`
+    returns a callable factory).
+    """
+    batch, heads, *_ = q.shape
+    q_fp8, k_fp8, v_fp8 = preprocess_fp8_attention_inputs(q, k, v)
+    return fp8_attention_kernel(q_fp8, k_fp8, v_fp8, batch, heads)
+
+
+# %%
 def _fp8_attention_pytorch_impl(
     q_fp8: torch.Tensor,
     k_fp8: torch.Tensor,


### PR DESCRIPTION
## Summary

Wires `examples/fp8_attention.py` into the TPU benchmark sweep (`benchmarks/run_tpu.py`) so fp8_attention runs alongside the other kernels on the dashboard.

## Changes

`examples/fp8_attention.py`:

- New tensor-returning entry point `fp8_attention(q, k, v) -> Tensor` that preprocesses bf16 inputs and runs `fp8_attention_kernel`. The existing `fp8_attention_tritonbench` returns a callable factory and doesn't fit the `run_tpu.py` harness contract.

`benchmarks/run_tpu.py`:

- `_fp8_attention_shapes` — mirrors `examples/fp8_attention.py:main()`: `(1,2,128,64)`, `(2,4,256,64)`, `(4,8,512,128)`, bf16.
- `_fp8_attention_baseline` — lazy-imports `fp8_attention_pytorch` and unwraps its callable factory to match the harness's `baseline_fn(*args) -> Tensor` contract.
- `KERNEL_MAPPINGS["fp8_attention"]` — entry with `max_mismatch_pct=0.05` (the example's own `check()` uses `atol=rtol=0.1`; the harness defaults to `rtol=1e-2`, and FP8 e4m3 output disagrees with `_scaled_mm` on a few percent of elements at that gate). Inline comment captures the rationale.

## Verification

Standalone per-shape autotune on TPU (Pallas backend, `HELION_AUTOTUNE_EFFORT=full`, `HELION_FORCE_AUTOTUNE=1`) runs cleanly on all three shapes and produces speedups against the `torch._scaled_mm`-based reference. The TPU benchmark CI job will exercise the actual harness path end-to-end.
