### PR TITLE
[cutedsl] require CuTe 4.5.1 / tvm-ffi / CUDA 13 and drop build-compat shims

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -111,6 +111,16 @@ class Backend(abc.ABC):
         """Backend name used to look up registered codegen functions."""
         return self.name
 
+    def validate_environment(self) -> None:
+        """Raise a ``helion.exc.*`` error if this backend cannot run here.
+
+        Called once per :class:`CompileEnvironment` for the *selected* backend
+        (never at registration time), so a backend can hard-require libraries,
+        CUDA versions, or hardware and fail fast with an actionable message
+        instead of crashing deep in codegen. The default is a no-op.
+        """
+        return None
+
     @abc.abstractmethod
     def dtype_str(self, dtype: torch.dtype) -> str:
         """Convert a torch dtype to a backend-specific type string.
@@ -2906,6 +2916,11 @@ class CuteBackend(Backend):
     @property
     def name(self) -> str:
         return "cute"
+
+    def validate_environment(self) -> None:
+        from .cute.cutedsl_compat import check_cute_backend_requirements
+
+        check_cute_backend_requirements()
 
     def customize_ast(self, hf: HostFunction) -> None:
         """CuTe-specific AST rewrites that rewrite high-level patterns into

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -232,6 +232,7 @@ class CompileEnvironment:
         )
         self.process_group_name = None
         self._backend = get_backend_class(settings.backend)()
+        self._backend.validate_environment()
         if self._backend.experimental:
             from torch._dynamo.utils import warn_once
 

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -5688,8 +5688,6 @@ def _emit_mma_pipeline(
             acc_tmem_cols=tcgen05_plan.acc_tmem_cols,
             is_two_cta=tcgen05_is_two_cta,
             use_tma=tcgen05_use_tma,
-            ab_stage_count=tcgen05_ab_stage_count_value,
-            acc_stage_count=tcgen05_acc_stage_count_value,
             skip_ab_producer_advance=diagnose_skip_ab_producer_advance,
         )
         tcgen05_pure_matmul_object = (

--- a/helion/_compiler/cute/cutedsl_compat.py
+++ b/helion/_compiler/cute/cutedsl_compat.py
@@ -3,88 +3,62 @@ from __future__ import annotations
 from functools import lru_cache
 import inspect
 
+# The cute backend hard-requires the CuTe DSL 4.5.1 API generation, the
+# apache-tvm-ffi package, and CUDA >= 13. ``check_cute_backend_requirements``
+# (wired through ``CuteBackend.validate_environment``) enforces this up front so
+# the rest of the backend can assume the modern APIs unconditionally rather than
+# carry per-build compatibility shims and inline workarounds.
+CUTE_MIN_CUDA_VERSION = "13"
+
 
 @lru_cache(maxsize=1)
-def cutedsl_has_opresultlist_fix() -> bool:
-    """Detect whether ``cutlass.cutlass_dsl.cutlass.if_generate`` recognises
-    ``ir.OpResultList`` containers for multi-result ``scf.if`` ops.
+def _cute_backend_requirement_error() -> str | None:
+    """Return why the cute backend cannot run here, or ``None`` if it can.
 
-    The PyPI ``nvidia-cutlass-dsl==4.5.0.dev0`` wheel (uploaded 2026-04-08)
-    ships an ``if_generate`` that wraps a multi-result ``OpResultList`` in a
-    one-element Python list, which then breaks the result-type ``zip`` and
-    raises ``DSLRuntimeError: <OpResultList> to integer conversion is not
-    supported`` from the next ``Int32(...)`` call. Newer (post-PyPI) builds
-    add an explicit ``isinstance(mlir_results, ir.OpResultList)`` guard that
-    fixes the bug — and is the marker we look for here.
-
-    Returns ``True`` when the fix is present, ``False`` for the buggy build.
+    Cached because the answer is fixed for the lifetime of the process. The
+    CuTe DSL generation is detected by *feature*, not by ``cutlass.__version__``:
+    the published wheels under-report the API generation (the 4.5.1 API has
+    shipped in wheels that still self-report ``4.5.0``), so a version-string
+    comparison would spuriously reject a working install.
     """
     try:
+        import cutlass.cute as cute  # noqa: F401
         from cutlass.cutlass_dsl.cutlass import if_generate
-    except Exception:
-        return True
-    try:
-        src = inspect.getsource(if_generate)
-    except (OSError, TypeError):
-        return True
-    return "ir.OpResultList" in src
-
-
-@lru_cache(maxsize=1)
-def cutedsl_tmem_allocator_skip_dealloc_init_kwarg() -> str | None:
-    """Return the kwarg name (if any) that requests "skip dealloc-mbarrier init"
-    on ``TmemAllocator``, or ``None`` if no such kwarg exists on this build.
-
-    Older PyPI builds (``nvidia-cutlass-dsl==4.5.0.dev0``) had no skip path;
-    intermediate builds added ``dealloc_mbarrier_initialized: bool = False`` —
-    pass ``True`` to skip.  The current 4.5.0 release renamed the flag to
-    ``initialize_mbarrier: bool = True`` — pass ``False`` to skip.
-    Helion needs to skip on the epilogue allocator (the matmul prologue
-    already initialized the barrier).  ``@dsl_user_op`` strips kwargs from
-    the public wrapper, so we resolve the underlying ``__wrapped__`` first.
-    """
-    try:
+        from cutlass.pipeline import PipelineTmaUmma
         from cutlass.utils import TmemAllocator
-    except Exception:
-        return None
+    except ImportError as e:
+        return f"the CuTe DSL is not importable (need nvidia-cutlass-dsl >= 4.5.1): {e}"
+
+    # 4.5.1 names the TmemAllocator skip-init kwarg ``initialize_mbarrier`` (it
+    # was ``dealloc_mbarrier_initialized`` in intermediate builds and absent from
+    # 4.5.0.dev0). ``@dsl_user_op`` strips kwargs from the public wrapper, so
+    # resolve ``__wrapped__`` first.
     init = TmemAllocator.__init__
     inner = getattr(init, "__wrapped__", init)
     try:
-        sig = inspect.signature(inner)
+        params = inspect.signature(inner).parameters
     except (TypeError, ValueError):
-        return None
-    if "dealloc_mbarrier_initialized" in sig.parameters:
-        return "dealloc_mbarrier_initialized"
-    if "initialize_mbarrier" in sig.parameters:
-        return "initialize_mbarrier"
-    return None
+        params = {}
+    if "initialize_mbarrier" not in params:
+        return (
+            "the installed CuTe DSL is too old (need >= 4.5.1: "
+            "TmemAllocator.initialize_mbarrier kwarg is missing)"
+        )
 
-
-@lru_cache(maxsize=1)
-def cutedsl_tma_umma_tail_has_peer_cta_semantics() -> bool:
-    """Detect whether ``PipelineTmaUmma.producer_tail`` lets peer CTAs wait.
-
-    ``cutedsl_has_opresultlist_fix`` only answers whether nested
-    ``PipelineState.advance()`` can be called safely. It does not prove that
-    the installed ``PipelineTmaUmma.producer_tail`` has the current upstream
-    semantics where every CTA advances and calls ``producer_acquire``. Older
-    source shapes that gate the whole tail to the leader CTA skip peer CTA
-    empty-barrier participation, so Helion must inline the tail for them even
-    if the ``advance`` bug is fixed.
-
-    Returns ``True`` when the source looks like the current peer-CTA-safe
-    implementation, ``False`` when it is leader-gated or cannot be inspected.
-    """
+    # 4.5.1 fixed the multi-result ``scf.if`` lowering used by nested
+    # ``PipelineState.advance()`` (4.5.0.dev0 raised a DSLRuntimeError from the
+    # ``OpResultList`` path) and gave ``PipelineTmaUmma.producer_tail`` peer-CTA
+    # semantics (older source gated the whole tail to the leader CTA). Both are
+    # detected from source.
     try:
-        from cutlass.pipeline import PipelineTmaUmma
-    except ImportError:
-        return False
-    try:
-        src = inspect.getsource(PipelineTmaUmma.producer_tail)
-    except (OSError, TypeError):
-        return False
-    # Deliberately fail closed: if upstream reshapes this function in a way
-    # this text probe no longer recognizes, Helion inlines its known-good tail.
+        if "ir.OpResultList" not in inspect.getsource(if_generate):
+            return (
+                "the installed CuTe DSL is too old (need >= 4.5.1: "
+                "if_generate is missing the OpResultList fix)"
+            )
+        tail_src = inspect.getsource(PipelineTmaUmma.producer_tail)
+    except (OSError, TypeError) as e:
+        return f"the installed CuTe DSL source cannot be inspected (need >= 4.5.1): {e}"
     leader_markers = (
         "block_idx_in_cluster",
         "cta_rank",
@@ -92,180 +66,69 @@ def cutedsl_tma_umma_tail_has_peer_cta_semantics() -> bool:
         "rank_in_cluster",
         "is_leader_cta",
     )
-    return "producer_acquire(" in src and not any(
-        marker in src for marker in leader_markers
-    )
+    if "producer_acquire(" not in tail_src or any(
+        marker in tail_src for marker in leader_markers
+    ):
+        return (
+            "the installed CuTe DSL is too old (need >= 4.5.1: "
+            "PipelineTmaUmma.producer_tail lacks peer-CTA semantics)"
+        )
+
+    try:
+        import tvm_ffi  # noqa: F401
+    except ImportError:
+        return (
+            "the apache-tvm-ffi package is required by the cute backend "
+            "(install it via `pip install apache-tvm-ffi`)"
+        )
+
+    from ..._compat import requires_cuda_version
+
+    if not requires_cuda_version(CUTE_MIN_CUDA_VERSION):
+        import torch
+
+        return (
+            f"the cute backend requires CUDA >= {CUTE_MIN_CUDA_VERSION}, "
+            f"but torch.version.cuda is {torch.version.cuda!r}"
+        )
+    return None
 
 
-def emit_dealloc_mbarrier_initialized_kwarg() -> str:
-    """Emit a kwarg telling ``TmemAllocator(...)`` to skip dealloc-mbarrier
-    init (because the prologue allocator already initialized it).
+def check_cute_backend_requirements() -> None:
+    """Raise :class:`helion.exc.CuteBackendUnavailable` if the cute backend
+    cannot run in the current environment (missing/old CuTe DSL, missing
+    tvm-ffi, or CUDA < 13)."""
+    reason = _cute_backend_requirement_error()
+    if reason is not None:
+        from ... import exc
 
-    Returns the kwarg with a leading comma so it's safe to splice as the
-    *last* argument; returns ``""`` on builds without any skip kwarg.
-    Handles both spellings: the older ``dealloc_mbarrier_initialized=True``
-    and the newer ``initialize_mbarrier=False``.
-    """
-    name = cutedsl_tmem_allocator_skip_dealloc_init_kwarg()
-    if name == "dealloc_mbarrier_initialized":
-        return ", dealloc_mbarrier_initialized=True"
-    if name == "initialize_mbarrier":
-        return ", initialize_mbarrier=False"
-    return ""
-
-
-def _advance_lines(state_expr: str, indent: str) -> list[str]:
-    """Inline body of a single ``state.advance()`` (buggy-cutedsl workaround)."""
-    phase_update = (
-        f"{indent}{state_expr}._phase = ({state_expr}._phase ^ cutlass.Int32(1)) "
-        f"if {state_expr}._index == {state_expr}.stages else {state_expr}._phase"
-    )
-    index_update = (
-        f"{indent}{state_expr}._index = cutlass.Int32(0) "
-        f"if {state_expr}._index == {state_expr}.stages else {state_expr}._index"
-    )
-    return [
-        f"{indent}{state_expr}._count = {state_expr}._count + cutlass.Int32(1)",
-        f"{indent}{state_expr}._index = {state_expr}._index + cutlass.Int32(1)",
-        phase_update,
-        index_update,
-    ]
+        raise exc.CuteBackendUnavailable(reason)
 
 
 def emit_pipeline_advance(state_expr: str, *, indent: str = "") -> str:
     """Emit code equivalent to ``<state_expr>.advance()``.
 
-    On cutedsl builds with the OpResultList fix this returns the natural
-    ``state.advance()`` call. On the buggy PyPI 4.5.0.dev0 build it inlines
-    the same semantics using two single-result Python ternaries (each of
-    which lowers to a single-result ``scf.if`` and avoids the broken
-    multi-result path inside ``pipeline.PipelineState.advance``). The
-    workaround body is wrapped in ``if True:`` so the returned string is
-    always exactly one Python top-level statement — both code paths can
-    therefore be passed straight to ``statement_from_string`` or spliced
-    into an existing block body without breaking ``ast.parse``.
-
-    The emitted lines all carry ``indent`` so the caller can splice the
+    The leading ``indent`` is applied so the caller can splice the returned
     string into an existing block without further reflowing.
     """
-    if cutedsl_has_opresultlist_fix():
-        return f"{indent}{state_expr}.advance()"
-
-    inner = indent + "    "
-    body = "\n".join(_advance_lines(state_expr, inner))
-    return f"{indent}if True:\n{body}"
+    return f"{indent}{state_expr}.advance()"
 
 
 def emit_producer_tail_tma_umma(
     pipeline_expr: str,
     state_expr: str,
     *,
-    num_stages: int,
     indent: str = "",
     skip_advances: bool = False,
 ) -> str:
-    """Emit code equivalent to ``<pipeline>.producer_tail(<state>)`` for a
-    ``PipelineTmaUmma`` (sm100 TMA→UMMA) pipeline.
-
-    The current cutedsl implementation calls ``state.advance()``
-    ``num_stages-1`` times and then ``producer_acquire``. On the buggy PyPI
-    build that inner ``advance`` raises the OpResultList ``DSLRuntimeError``;
-    some intermediate builds also had the advance fix but still gated the
-    whole tail to the leader CTA. Helion's user-level ``state.advance()``
-    workaround can't reach nested calls, so we inline the whole tail unless
-    both the advance bug and the TMA tail ownership shape are known-good.
-
-    Unlike ``PipelineUmmaAsync``, ``PipelineTmaUmma.producer_tail`` is
-    intentionally not leader-CTA gated. Peer CTAs still need to advance
-    their local producer state and wait for the empty barrier; the inner
-    ``producer_acquire`` implementation gates only the full-barrier arrive
-    to the leader CTA.
-
-    ``num_stages`` is a compile-time constant from helion's tcgen05 plan
-    (``ab_stage_count`` for the TMA pipeline).
+    """Emit ``<pipeline>.producer_tail(<state>)`` for a ``PipelineTmaUmma``
+    (sm100 TMA->UMMA) pipeline.
 
     ``skip_advances`` is only for guarded invalid-output diagnostics that
-    isolate AB producer state rollover. It preserves the tail acquire but
-    removes every state advance, including calls hidden inside upstream
-    ``producer_tail``.
+    isolate AB producer-state rollover: it preserves the tail acquire but drops
+    every state advance (including the ones ``producer_tail`` performs
+    internally), so it emits a bare ``producer_acquire`` instead.
     """
     if skip_advances:
         return f"{indent}{pipeline_expr}.producer_acquire({state_expr})"
-
-    if (
-        cutedsl_has_opresultlist_fix()
-        and cutedsl_tma_umma_tail_has_peer_cta_semantics()
-    ):
-        return f"{indent}{pipeline_expr}.producer_tail({state_expr})"
-
-    body_lines: list[str] = []
-    for _ in range(num_stages - 1):
-        body_lines.extend(_advance_lines(state_expr, indent))
-    body_lines.append(f"{indent}{pipeline_expr}.producer_acquire({state_expr})")
-    return "\n".join(body_lines)
-
-
-def emit_producer_tail_tma_async(
-    pipeline_expr: str,
-    state_expr: str,
-    *,
-    num_stages: int,
-    indent: str = "",
-) -> str:
-    """Emit code equivalent to ``<pipeline>.producer_tail(<state>)`` for a
-    ``PipelineTmaAsync`` G2S load pipeline.
-
-    Like the UMMA-facing pipelines, cutedsl's tail implementation advances the
-    producer state internally before the final empty-barrier acquire. On buggy
-    PyPI builds those nested ``state.advance()`` calls hit the OpResultList
-    lowering bug, so inline the same state updates unless the installed DSL has
-    the fix.
-    """
-    if cutedsl_has_opresultlist_fix():
-        return f"{indent}{pipeline_expr}.producer_tail({state_expr})"
-
-    inner = indent + "    "
-    body_lines: list[str] = [f"{indent}if True:"]
-    for _ in range(num_stages - 1):
-        body_lines.extend(_advance_lines(state_expr, inner))
-    body_lines.append(f"{inner}{pipeline_expr}.producer_acquire({state_expr})")
-    return "\n".join(body_lines)
-
-
-def emit_producer_tail_umma_async(
-    pipeline_expr: str,
-    state_expr: str,
-    *,
-    num_stages: int,
-    indent: str = "",
-) -> str:
-    """Emit code equivalent to ``<pipeline>.producer_tail(<state>)`` for a
-    ``PipelineUmmaAsync`` (sm100 UMMA→async-consumer) pipeline.
-
-    The cutedsl implementation gates the drain to the leader CTA, advances
-    ``num_stages - 1`` times, then calls ``producer_acquire``. We inline
-    the same leader guard plus advances so each ``advance`` becomes the
-    same single-result-ternary workaround used by
-    :func:`emit_pipeline_advance`. ``num_stages`` is the compile-time
-    ``acc_stage_count`` from helion's tcgen05 plan.
-    """
-    if cutedsl_has_opresultlist_fix():
-        return f"{indent}{pipeline_expr}.producer_tail({state_expr})"
-
-    inner = indent + "    "
-    leader_inner = inner + "    "
-    body_lines = [
-        f"{indent}if True:",
-        f"{inner}_pt_bidx = cute.arch.block_idx_in_cluster()",
-        f"{inner}_pt_cta_rank = cute.arch.make_warp_uniform(_pt_bidx)",
-        f"{inner}if _pt_cta_rank % cutlass.Int32(2) == cutlass.Int32(0):",
-    ]
-    for _ in range(num_stages - 1):
-        body_lines.extend(
-            (
-                f"{leader_inner}if True:",
-                *_advance_lines(state_expr, leader_inner + "    "),
-            )
-        )
-    body_lines.append(f"{leader_inner}{pipeline_expr}.producer_acquire({state_expr})")
-    return "\n".join(body_lines)
+    return f"{indent}{pipeline_expr}.producer_tail({state_expr})"

--- a/helion/_compiler/cute/tcgen05_lifecycle.py
+++ b/helion/_compiler/cute/tcgen05_lifecycle.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 
-from .cutedsl_compat import emit_dealloc_mbarrier_initialized_kwarg
 from .cutedsl_compat import emit_producer_tail_tma_umma
-from .cutedsl_compat import emit_producer_tail_umma_async
 
 
 @dataclasses.dataclass(frozen=True)
@@ -27,8 +25,6 @@ class Tcgen05LifecycleContext:
     acc_tmem_cols: str
     is_two_cta: bool
     use_tma: bool
-    ab_stage_count: int
-    acc_stage_count: int
     skip_ab_producer_advance: bool = False
 
     def render_store_post_loop_lines(
@@ -45,7 +41,6 @@ class Tcgen05LifecycleContext:
                 + emit_producer_tail_tma_umma(
                     self.tma_pipeline,
                     self.tma_producer_state,
-                    num_stages=self.ab_stage_count,
                     indent="    ",
                     skip_advances=self.skip_ab_producer_advance,
                 )
@@ -62,12 +57,7 @@ class Tcgen05LifecycleContext:
                 (f"if {self.exec_active}:\n    {self.tmem_alloc_barrier}.arrive()"),
                 (
                     f"if {self.exec_active}:\n"
-                    + emit_producer_tail_umma_async(
-                        self.acc_pipeline,
-                        self.acc_producer_state,
-                        num_stages=self.acc_stage_count,
-                        indent="    ",
-                    )
+                    f"    {self.acc_pipeline}.producer_tail({self.acc_producer_state})"
                 ),
                 (
                     f"{self.tmem_allocator} = cutlass.utils.TmemAllocator("
@@ -78,7 +68,7 @@ class Tcgen05LifecycleContext:
                     "two_cta_tmem_dealloc_mbar_ptr="
                     f"{self.tmem_dealloc_mbar_ptr}, "
                     f"num_allocated_columns={self.acc_tmem_cols}"
-                    f"{emit_dealloc_mbarrier_initialized_kwarg()})"
+                    ", initialize_mbarrier=False)"
                 ),
             ]
         )

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -17,7 +17,6 @@ from .ast_extension import expr_from_string
 from .ast_extension import statement_from_string
 from .compile_environment import CompileEnvironment
 from .cute.cutedsl_compat import emit_pipeline_advance
-from .cute.cutedsl_compat import emit_producer_tail_tma_async
 from .cute.strategies import TCGEN05_L2_SWIZZLE_SIZE_DEFAULT
 from .cute.strategies import l2_swizzle_size_from_config
 from .cute.tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODE_CONFIG_KEY
@@ -4172,7 +4171,6 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         aux_producer_state_name = aux_pipeline_plan.producer_state
         aux_rings = aux_pipeline_plan.rings
         aux_epi_tile_var = aux_pipeline_plan.epi_tile_var
-        aux_stage_count = aux_pipeline_plan.stage_count
         aux_tma_barrier_var = (
             device_function.new_var("tcgen05_aux_tma_barrier")
             if aux_use_tma_load
@@ -4646,11 +4644,7 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         if aux_use_tma_load:
             prelude.append(
                 statement_from_string(
-                    emit_producer_tail_tma_async(
-                        aux_pipeline_name,
-                        aux_producer_state_name,
-                        num_stages=aux_stage_count,
-                    )
+                    f"{aux_pipeline_name}.producer_tail({aux_producer_state_name})"
                 )
             )
 

--- a/helion/exc.py
+++ b/helion/exc.py
@@ -318,6 +318,14 @@ class MissingEnableTile(BaseError):
     )
 
 
+class CuteBackendUnavailable(BaseError):
+    message = (
+        "The 'cute' backend cannot run in this environment: {0}\n"
+        "The cute backend requires nvidia-cutlass-dsl >= 4.5.1, the "
+        "apache-tvm-ffi package, and CUDA >= 13."
+    )
+
+
 class UndefinedVariable(BaseError):
     message = "{} is not defined."
 

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -25,6 +25,7 @@ from helion._compiler.cute.tcgen05_constants import (
 from helion._testing import TestCase
 from helion._testing import onlyBackends
 from helion._testing import skipIfXPU
+from helion._testing import skipUnlessCuteAvailable
 import helion.language as hl
 
 
@@ -378,12 +379,14 @@ class TestSettingsEnv(TestCase):
             settings = helion.Settings()
         self.assertEqual(settings.backend, "tileir")
 
+    @skipUnlessCuteAvailable("Constructs a cute CompileEnvironment")
     def test_compile_environment_selects_cute_backend(self) -> None:
         settings = helion.Settings(backend="cute")
         env = CompileEnvironment(torch.device("cpu"), settings)
         self.assertEqual(env.backend_name, "cute")
         self.assertEqual(env.backend.default_launcher_name, "_default_cute_launcher")
 
+    @skipUnlessCuteAvailable("Constructs a cute CompileEnvironment")
     def test_num_threads_support_is_backend_specific(self) -> None:
         triton_env = CompileEnvironment(
             torch.device("cpu"), helion.Settings(backend="triton")

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -15,6 +15,7 @@ from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
 from helion.exc import BackendUnsupported
+from helion.exc import CuteBackendUnavailable
 import helion.language as hl
 from helion.runtime import _create_cute_direct_entry
 from helion.runtime import _cute_cluster_shape
@@ -3184,3 +3185,44 @@ class TestCuteTileVecWarpReduceHeuristic(TestCase):
         self.assertIn(
             CuteTileVecWarpReduceHeuristic, HEURISTICS_BY_BACKEND.get("cute", ())
         )
+
+
+class TestCuteBackendRequirements(TestCase):
+    """The cute backend hard-requires CuTe DSL >= 4.5.1, apache-tvm-ffi, and
+    CUDA >= 13, enforced up front via ``CuteBackend.validate_environment``.
+    This module is ``importorskip``-gated on cutlass, so the environment under
+    test already satisfies the requirements (the gate must pass here).
+    """
+
+    def test_requirements_satisfied_in_this_environment(self) -> None:
+        from helion._compiler.cute.cutedsl_compat import _cute_backend_requirement_error
+
+        self.assertIsNone(_cute_backend_requirement_error())
+
+    def test_check_does_not_raise_when_satisfied(self) -> None:
+        from helion._compiler.cute.cutedsl_compat import check_cute_backend_requirements
+
+        check_cute_backend_requirements()  # must not raise in this environment
+
+    def test_validate_environment_passes(self) -> None:
+        from helion._compiler.backend import CuteBackend
+
+        CuteBackend().validate_environment()  # must not raise in this environment
+
+    def test_unmet_requirement_raises_with_actionable_message(self) -> None:
+        from helion._compiler.cute import cutedsl_compat
+
+        with (
+            patch.object(
+                cutedsl_compat,
+                "_cute_backend_requirement_error",
+                return_value="the apache-tvm-ffi package is required (simulated)",
+            ),
+            self.assertRaises(CuteBackendUnavailable) as ctx,
+        ):
+            cutedsl_compat.check_cute_backend_requirements()
+        message = str(ctx.exception)
+        self.assertIn("apache-tvm-ffi package is required (simulated)", message)
+        # The fixed tail names all three requirements so the user knows the set.
+        self.assertIn("nvidia-cutlass-dsl >= 4.5.1", message)
+        self.assertIn("CUDA >= 13", message)

--- a/test/test_cute_device_state.py
+++ b/test/test_cute_device_state.py
@@ -73,8 +73,6 @@ def _lifecycle(**overrides: object) -> Tcgen05LifecycleContext:
         "acc_tmem_cols": "tcgen05_acc_tmem_cols",
         "is_two_cta": False,
         "use_tma": True,
-        "ab_stage_count": 2,
-        "acc_stage_count": 1,
     }
     kwargs.update(overrides)
     return Tcgen05LifecycleContext(**kwargs)

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -19751,87 +19751,6 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
             producer_body,
         )
 
-    def test_aux_pipeline_producer_advance_indent_fallback_path(self) -> None:
-        """Producer-body indent regression for the fallback
-        ``emit_pipeline_advance`` path: when
-        ``cutedsl_has_opresultlist_fix()`` returns False (PyPI
-        4.5.0.dev0 build), ``emit_pipeline_advance`` returns a
-        multi-line ``if True: \\n    <line1> \\n    <line2>``
-        block rather than a single
-        ``state.advance()`` call. The producer-body
-        subtile-loop emitter must indent every line of that
-        block to the loop body's indent (``    `` for the
-        ``for _tcgen05_aux_subtile in ...:`` loop), not just
-        the first — otherwise the inner lines under-indent
-        and produce a SyntaxError when ``statement_from_string``
-        parses the loop source.
-        """
-        from helion._compiler.cute import cutedsl_compat
-
-        kernel = self._residual_kernel()
-        args = (
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([4096, 4096], device=DEVICE, dtype=torch.bfloat16),
-        )
-        config = self._canonical_c_input_config()
-        with (
-            patch_cute_mma_support(),
-            patch.object(
-                cutedsl_compat, "cutedsl_has_opresultlist_fix", return_value=False
-            ),
-        ):
-            bound = kernel.bind(args)
-            bound.env.config_spec.cute_tcgen05_search_enabled = True
-            code = bound.to_triton_code(config)
-
-        # The fallback ``emit_pipeline_advance`` body contains
-        # the ``state._count = state._count + cutlass.Int32(1)``
-        # update wrapped in ``if True: ...``. Pin that every
-        # such line under the producer subtile-loop body is
-        # indented at least to the loop's ``    `` body
-        # indent. The producer subtile loop is the
-        # ``for _tcgen05_aux_subtile in cutlass.range(...):``
-        # in the C-input warp role-local while body. Find the
-        # producer advance lines (those that update
-        # ``tcgen05_aux_pipeline_producer_state``) and verify
-        # each line carries a leading "    " indent.
-        producer_state_count_lines = [
-            line
-            for line in code.split("\n")
-            if (
-                "tcgen05_aux_pipeline_producer_state._count" in line
-                or "tcgen05_aux_pipeline_producer_state._index" in line
-                or "tcgen05_aux_pipeline_producer_state._phase" in line
-            )
-        ]
-        # Each producer-state update line lives inside the
-        # subtile loop body (which itself nests inside the
-        # role-local while + cluster-init prefix). The loop
-        # body indent is at least ``        `` (8 spaces) —
-        # role-local-while body indent + per-iter body indent.
-        # Pin a minimum of 8-space indent so an under-indented
-        # ``if True:\n``-then-flat-body emission would fail.
-        self.assertTrue(
-            producer_state_count_lines,
-            "expected at least one producer_state update line "
-            "in the fallback advance body; the fallback path "
-            "must emit explicit count/index/phase updates",
-        )
-        for line in producer_state_count_lines:
-            stripped = line.lstrip(" ")
-            indent_width = len(line) - len(stripped)
-            self.assertGreaterEqual(
-                indent_width,
-                8,
-                f"producer-state update line under-indented "
-                f"({indent_width} spaces): {line!r}. The "
-                f"subtile loop body requires ≥8-space indent; "
-                f"under-indentation indicates the multi-line "
-                f"``emit_pipeline_advance`` block was spliced "
-                f"without per-line reflow.",
-            )
-
     def test_aux_pipeline_multi_store_fanout_gate_closes(self) -> None:
         """Multi-store fan-out regression: a kernel that consumes
         one matmul result into multiple stores with different aux
@@ -20779,170 +20698,44 @@ class TestCuteTcgen05AuxPipelineCycle2a(unittest.TestCase):
 
 @onlyBackends(["cute"])
 class TestCuteDslCompat(unittest.TestCase):
-    def test_umma_async_tail_workaround_preserves_leader_cta_guard(self) -> None:
+    """The cute backend hard-requires the 4.5.1 CuTe DSL API (enforced up front
+    by ``CuteBackend.validate_environment``), so the pipeline emitters render
+    the native CuTe calls directly with no per-build workarounds."""
+
+    def test_pipeline_advance_emits_native_call(self) -> None:
         from helion._compiler.cute import cutedsl_compat
 
-        with patch.object(
-            cutedsl_compat, "cutedsl_has_opresultlist_fix", return_value=False
-        ):
-            src = cutedsl_compat.emit_producer_tail_umma_async(
-                "acc_pipeline", "acc_state", num_stages=3
-            )
-
-        self.assertIn("cute.arch.block_idx_in_cluster()", src)
-        self.assertIn("cute.arch.make_warp_uniform(_pt_bidx)", src)
-        leader_guard = "if _pt_cta_rank % cutlass.Int32(2) == cutlass.Int32(0):"
-        self.assertIn(leader_guard, src)
-        self.assertLess(
-            src.index(leader_guard),
-            src.index("acc_state._count = acc_state._count + cutlass.Int32(1)"),
-        )
-        self.assertLess(
-            src.index("acc_state._count = acc_state._count + cutlass.Int32(1)"),
-            src.index("acc_pipeline.producer_acquire(acc_state)"),
+        self.assertEqual(
+            cutedsl_compat.emit_pipeline_advance("ab_state"),
+            "ab_state.advance()",
         )
         self.assertEqual(
-            src.count("acc_state._count = acc_state._count + cutlass.Int32(1)"),
-            2,
+            cutedsl_compat.emit_pipeline_advance("ab_state", indent="    "),
+            "    ab_state.advance()",
         )
-        self.assertNotIn("acc_pipeline.sync_object_empty.wait", src)
-        self.assertIn("acc_pipeline.producer_acquire(acc_state)", src)
 
-    def test_tma_umma_tail_uses_upstream_when_advance_and_tail_safe(self) -> None:
+    def test_tma_umma_tail_emits_native_producer_tail(self) -> None:
         from helion._compiler.cute import cutedsl_compat
 
-        with (
-            patch.object(
-                cutedsl_compat, "cutedsl_has_opresultlist_fix", return_value=True
-            ),
-            patch.object(
-                cutedsl_compat,
-                "cutedsl_tma_umma_tail_has_peer_cta_semantics",
-                return_value=True,
-            ),
-        ):
-            self.assertEqual(
-                cutedsl_compat.emit_producer_tail_tma_umma(
-                    "ab_pipeline", "ab_state", num_stages=3
-                ),
-                "ab_pipeline.producer_tail(ab_state)",
-            )
-
-    def test_tma_umma_tail_inlines_when_tail_semantics_unsafe(self) -> None:
-        from helion._compiler.cute import cutedsl_compat
-
-        with (
-            patch.object(
-                cutedsl_compat, "cutedsl_has_opresultlist_fix", return_value=True
-            ),
-            patch.object(
-                cutedsl_compat,
-                "cutedsl_tma_umma_tail_has_peer_cta_semantics",
-                return_value=False,
-            ),
-        ):
-            src = cutedsl_compat.emit_producer_tail_tma_umma(
-                "ab_pipeline", "ab_state", num_stages=3
-            )
-
-        self.assertNotIn("block_idx_in_cluster", src)
-        self.assertNotIn("_pt_cta_rank", src)
-        self.assertNotIn("if True", src)
-        self.assertLess(
-            src.index("ab_state._count = ab_state._count + cutlass.Int32(1)"),
-            src.index("ab_pipeline.producer_acquire(ab_state)"),
+        self.assertEqual(
+            cutedsl_compat.emit_producer_tail_tma_umma("ab_pipeline", "ab_state"),
+            "ab_pipeline.producer_tail(ab_state)",
         )
         self.assertEqual(
-            src.count("ab_state._count = ab_state._count + cutlass.Int32(1)"),
-            2,
+            cutedsl_compat.emit_producer_tail_tma_umma(
+                "ab_pipeline", "ab_state", indent="    "
+            ),
+            "    ab_pipeline.producer_tail(ab_state)",
         )
-        self.assertIn("ab_pipeline.producer_acquire(ab_state)", src)
 
-    def test_tma_umma_tail_inlines_when_advance_workaround_needed(self) -> None:
+    def test_tma_umma_tail_skip_advances_emits_bare_acquire(self) -> None:
         from helion._compiler.cute import cutedsl_compat
 
-        with patch.object(
-            cutedsl_compat, "cutedsl_has_opresultlist_fix", return_value=False
-        ):
-            src = cutedsl_compat.emit_producer_tail_tma_umma(
-                "ab_pipeline", "ab_state", num_stages=3
-            )
-
-        self.assertNotIn("block_idx_in_cluster", src)
-        self.assertNotIn("if True", src)
-        self.assertIn("ab_pipeline.producer_acquire(ab_state)", src)
-
-    def test_tma_async_tail_uses_upstream_when_advance_safe(self) -> None:
-        from helion._compiler.cute import cutedsl_compat
-
-        with patch.object(
-            cutedsl_compat, "cutedsl_has_opresultlist_fix", return_value=True
-        ):
-            self.assertEqual(
-                cutedsl_compat.emit_producer_tail_tma_async(
-                    "aux_pipeline", "aux_state", num_stages=2
-                ),
-                "aux_pipeline.producer_tail(aux_state)",
-            )
-
-    def test_tma_async_tail_inlines_when_advance_workaround_needed(self) -> None:
-        from helion._compiler.cute import cutedsl_compat
-
-        with patch.object(
-            cutedsl_compat, "cutedsl_has_opresultlist_fix", return_value=False
-        ):
-            src = cutedsl_compat.emit_producer_tail_tma_async(
-                "aux_pipeline", "aux_state", num_stages=2
-            )
-
-        parsed = ast.parse(src)
-        self.assertEqual(len(parsed.body), 1, src)
-        self.assertNotIn("producer_tail", src)
-        self.assertIn("aux_state._count = aux_state._count + cutlass.Int32(1)", src)
-        self.assertIn("aux_pipeline.producer_acquire(aux_state)", src)
-
-    def test_tma_umma_tail_can_skip_state_advances(self) -> None:
-        from helion._compiler.cute import cutedsl_compat
-
-        with (
-            patch.object(
-                cutedsl_compat, "cutedsl_has_opresultlist_fix", return_value=True
-            ),
-            patch.object(
-                cutedsl_compat,
-                "cutedsl_tma_umma_tail_has_peer_cta_semantics",
-                return_value=True,
-            ),
-        ):
-            src = cutedsl_compat.emit_producer_tail_tma_umma(
-                "ab_pipeline",
-                "ab_state",
-                num_stages=3,
-                skip_advances=True,
-            )
-
+        src = cutedsl_compat.emit_producer_tail_tma_umma(
+            "ab_pipeline", "ab_state", skip_advances=True
+        )
         self.assertEqual(src, "ab_pipeline.producer_acquire(ab_state)")
         self.assertNotIn("producer_tail", src)
-        self.assertNotIn("ab_state._count", src)
-        self.assertNotIn("ab_state.advance", src)
-
-    def test_tma_umma_tail_detector_allows_state_rename(self) -> None:
-        from helion._compiler.cute import cutedsl_compat
-
-        cutedsl_compat.cutedsl_tma_umma_tail_has_peer_cta_semantics.cache_clear()
-        src = """
-def producer_tail(self, producer_state):
-    for i in range(self.num_stages - 1):
-        producer_state.advance()
-    self.producer_acquire(producer_state)
-"""
-        try:
-            with patch.object(cutedsl_compat.inspect, "getsource", return_value=src):
-                self.assertTrue(
-                    cutedsl_compat.cutedsl_tma_umma_tail_has_peer_cta_semantics()
-                )
-        finally:
-            cutedsl_compat.cutedsl_tma_umma_tail_has_peer_cta_semantics.cache_clear()
 
 
 @onlyBackends(["cute"])


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2682
 * #2681
 * #2680
 * #2679
 * __->__#2678
 * #2656
 * #2655
 * #2654
 * #2653
 * #2652
 * #2651


--- --- ---

[cutedsl] require CuTe 4.5.1 / tvm-ffi / CUDA 13 and drop build-compat shims

Make the cute backend hard-require the CuTe DSL 4.5.1 API generation, the
apache-tvm-ffi package, and CUDA >= 13. A new `Backend.validate_environment`
hook (called once per CompileEnvironment for the *selected* backend, never at
registration) raises `helion.exc.CuteBackendUnavailable` with an actionable
message when any requirement is missing, instead of crashing deep in codegen.

The DSL generation is feature-detected, not read from `cutlass.__version__`:
the published wheels under-report the API generation (the 4.5.1 API ships in
wheels that still self-report "4.5.0"), so a version-string compare would
spuriously reject a working install. The gate checks exactly the capabilities
the backend now assumes: the `initialize_mbarrier` TmemAllocator kwarg, the
`if_generate` OpResultList fix, peer-CTA `PipelineTmaUmma.producer_tail`,
`import tvm_ffi`, and CUDA >= 13.

Because those are now guaranteed, the per-build compatibility shims in
`cutedsl_compat.py` are removed: `cutedsl_has_opresultlist_fix`,
`cutedsl_tmem_allocator_skip_dealloc_init_kwarg`,
`cutedsl_tma_umma_tail_has_peer_cta_semantics`,
`emit_dealloc_mbarrier_initialized_kwarg`, `emit_producer_tail_tma_async`,
`emit_producer_tail_umma_async`, and the inline `_advance_lines` workaround
bodies. The surviving emitters (`emit_pipeline_advance`,
`emit_producer_tail_tma_umma`) now render the native CuTe calls directly;
emissions are byte-identical to the prior non-buggy 4.5.1 path. The vestigial
`num_stages` params and the `ab_stage_count`/`acc_stage_count` fields of
`Tcgen05LifecycleContext` (only ever read to size the deleted inline bodies)
are dropped.

Tests for the removed shim machinery are replaced with coverage of the
simplified emitters and the new requirement gate.