### PR TITLE
[autotuner] add per-fragment config priors to bias the initial population

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -33,6 +33,8 @@ if TYPE_CHECKING:
     from torch._inductor.ops_handler import OpsHandler
 
     from ..autotuner.config_fragment import ConfigSpecFragment
+    from ..autotuner.config_priors import ValuePrior
+    from ..autotuner.config_spec import ConfigSpec
     from ..runtime.config import Config
     from ..runtime.kernel import BoundKernel
     from .device_function import Argument
@@ -120,6 +122,20 @@ class Backend(abc.ABC):
         instead of crashing deep in codegen. The default is a no-op.
         """
         return None
+
+    def config_value_priors(self, config_spec: ConfigSpec) -> dict[str, ValuePrior]:
+        """Per-config-key priors that bias the autotuner's random exploration.
+
+        Returns a mapping from config-key name (e.g. ``"num_warps"``,
+        ``"indexing"``, ``"tcgen05_cluster_m"``) to a
+        :data:`~helion.autotuner.config_priors.ValuePrior`. Half of the random
+        portion of the initial population is drawn using these priors (the other
+        half stays uniform), so the search starts denser in the region good
+        configs tend to occupy without losing coverage. Keys without a prior --
+        and every key when this returns an empty mapping -- are sampled
+        uniformly. The default is no bias.
+        """
+        return {}
 
     @abc.abstractmethod
     def dtype_str(self, dtype: torch.dtype) -> str:

--- a/helion/autotuner/config_generation.py
+++ b/helion/autotuner/config_generation.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 
     from .. import Config
     from . import ConfigSpec
+    from .config_priors import ValuePrior
 
 FlatConfig = list[object]
 
@@ -487,6 +488,47 @@ class ConfigGeneration:
             self._repair_cute_num_threads(config)
             return config
 
+    @functools.cached_property
+    def _config_value_priors(self) -> dict[str, ValuePrior]:
+        """Per-config-key sampling priors supplied by the active backend."""
+        return dict(self.config_spec.backend.config_value_priors(self.config_spec))
+
+    @functools.cached_property
+    def _flat_index_to_key_pos(self) -> dict[int, tuple[str, int]]:
+        """Map each flat_spec index to its ``(config key, position-in-key)``."""
+        mapping: dict[int, tuple[str, int]] = {}
+        for key, (indices, _is_sequence) in self._key_to_flat_indices.items():
+            for position, flat_idx in enumerate(indices):
+                mapping[flat_idx] = (key, position)
+        return mapping
+
+    def biased_random_flat(self) -> FlatConfig:
+        """Random flat config biased by the backend's per-key value priors.
+
+        Identical to :meth:`random_flat` except that, for each flat slot whose
+        config key has a registered prior, the value is drawn from that prior
+        (falling back to the fragment's uniform ``random()`` when the prior
+        declines). Used for half of the random portion of the initial
+        population; with no priors this is exactly ``random_flat``.
+        """
+        priors = self._config_value_priors
+        if not priors:
+            return self.random_flat()
+        index_to_key_pos = self._flat_index_to_key_pos
+        with sync_seed(process_group_name=self.process_group_name):
+            config: FlatConfig = []
+            for i, spec in enumerate(self.flat_spec):
+                value: object | None = None
+                key_pos = index_to_key_pos.get(i)
+                if key_pos is not None:
+                    prior = priors.get(key_pos[0])
+                    if prior is not None:
+                        value = prior(spec, key_pos[1])
+                config.append(spec.random() if value is None else value)
+            self.shrink_config(config, PowerOfTwoFragment(1, 2048, 32).random())
+            self._repair_cute_num_threads(config)
+            return config
+
     def random_config(self) -> Config:
         errors: dict[str, int] = {}
         for _ in range(64):
@@ -532,7 +574,17 @@ class ConfigGeneration:
             if len(result) >= n:
                 return result[:n]
 
-        result.extend(self.random_flat() for _ in range(n - len(result)))
+        # Fill the remainder with random configs. When the backend supplies
+        # value priors, half the random fill is drawn from those priors (biased
+        # toward the region good configs occupy) and half stays uniform so the
+        # search keeps full coverage; with no priors every fill is uniform,
+        # leaving the historical behavior unchanged.
+        priors_present = bool(self._config_value_priors)
+        for j in range(n - len(result)):
+            if priors_present and j % 2 == 0:
+                result.append(self.biased_random_flat())
+            else:
+                result.append(self.random_flat())
         return result
 
     def random_population(

--- a/helion/autotuner/config_priors.py
+++ b/helion/autotuner/config_priors.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import random
+from typing import TYPE_CHECKING
+from typing import Callable
+
+if TYPE_CHECKING:
+    from .config_fragment import ConfigSpecFragment
+
+# A ``ValuePrior`` biases the random sampling of a single flat-config slot that
+# belongs to one config key. It receives the slot's fragment and the slot's
+# position within the key (``0`` for scalar keys; ``0..n-1`` for sequence keys
+# such as ``indexing`` or ``block_sizes``) and returns a biased value, or
+# ``None`` to fall back to the fragment's uniform ``random()``.
+#
+# Returned values must be representable by the fragment (e.g. a member of an
+# ``EnumFragment``'s ``choices``, or within an integer fragment's range);
+# :func:`weighted_choice` enforces this, so a backend can list aspirational
+# values without worrying about which a given kernel actually exposes.
+ValuePrior = Callable[["ConfigSpecFragment", int], object]
+
+
+def _fragment_accepts(fragment: ConfigSpecFragment, value: object) -> bool:
+    """Best-effort check that ``value`` lies in this fragment's value space."""
+    choices = getattr(fragment, "choices", None)
+    if choices is not None:
+        return value in choices
+    low = getattr(fragment, "low", None)
+    high = getattr(fragment, "high", None)
+    if isinstance(low, int) and isinstance(high, int) and isinstance(value, int):
+        return low <= value <= high
+    return True
+
+
+def weighted_choice(weighted_values: dict[object, float]) -> ValuePrior:
+    """Build a position-agnostic prior that samples from ``weighted_values``.
+
+    Values the slot's fragment cannot represent are dropped before sampling; if
+    nothing representable remains, the prior returns ``None`` so the caller falls
+    back to the fragment's uniform ``random()``. This lets a backend express one
+    bias (e.g. ``{"tensor_descriptor": 4.0, "pointer": 1.0}``) that applies to
+    whichever slots of a key the live kernel actually exposes.
+    """
+    items = [(v, w) for v, w in weighted_values.items() if w > 0]
+
+    def _prior(fragment: ConfigSpecFragment, position: int) -> object:
+        allowed = [(v, w) for v, w in items if _fragment_accepts(fragment, v)]
+        if not allowed:
+            return None
+        values, weights = zip(*allowed, strict=True)
+        return random.choices(values, weights=weights, k=1)[0]
+
+    return _prior

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -4065,5 +4065,93 @@ class TestAutotuneBudget(TestCase):
         self.assertFalse(provider._subprocess_benchmark_uses_wall_clock())
 
 
+class TestConfigValuePriors(TestCase):
+    """Backend-supplied per-key priors bias the random half of the initial
+    population (config_generation), while the other half stays uniform."""
+
+    def _add_config_gen(self) -> tuple[ConfigGeneration, object]:
+        @helion.kernel(autotune_log_level=0)
+        def add(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(a)
+            for tile in hl.tile(out.size()):
+                out[tile] = a[tile] + b[tile]
+            return out
+
+        a = torch.randn(256, 256, device=DEVICE)
+        bound = add.bind((a, a))
+        return ConfigGeneration(bound.config_spec), bound
+
+    @staticmethod
+    def _forceable_slot(gen: ConfigGeneration) -> tuple[str, int, object]:
+        """Pick a config key the live kernel exposes and a value to force it to.
+
+        Backends expose different keys (e.g. the default backend has a scalar
+        ``num_warps`` slot; the cute backend exposes only sequence keys such as
+        ``block_sizes``), so the priors tests select a target dynamically rather
+        than hard-coding ``num_warps``. Returns ``(key, flat_index, value)``
+        where ``value`` is representable by the slot's fragment.
+        """
+        # Prefer a scalar ``num_warps`` slot when present: a power-of-two value
+        # in its range that won't be altered by repair logic.
+        for key, (indices, is_sequence) in gen._key_to_flat_indices.items():
+            if key == "num_warps" and not is_sequence and indices:
+                return key, indices[0], 4
+        # Otherwise use the first block-size slot, which every backend exposes.
+        block_key, (block_indices, _is_seq) = next(
+            (k, v) for k, v in gen._key_to_flat_indices.items() if k == "block_sizes"
+        )
+        flat_idx = block_indices[0]
+        fragment = gen.flat_spec[flat_idx]
+        # Use the fragment's own default: guaranteed representable and stable.
+        return block_key, flat_idx, fragment.default()
+
+    def test_no_priors_falls_through_to_uniform(self) -> None:
+        gen, _ = self._add_config_gen()
+        # With no priors, biased sampling is exactly uniform sampling and the
+        # population fill is unchanged. Control the priors explicitly rather than
+        # relying on the ambient backend default (the cute backend, for example,
+        # supplies non-empty priors).
+        gen._config_value_priors = {}
+        self.assertEqual(gen._config_value_priors, {})
+        flat = gen.biased_random_flat()
+        self.assertEqual(len(flat), len(gen.flat_spec))
+
+    def test_prior_forces_value(self) -> None:
+        from helion.autotuner.config_priors import weighted_choice
+
+        gen, _ = self._add_config_gen()
+        key, flat_idx, value = self._forceable_slot(gen)
+        # Control the priors directly on the instance so the test is independent
+        # of whatever priors the active backend supplies.
+        gen._config_value_priors = {key: weighted_choice({value: 1.0})}
+        # Disable size repair/shrink so the forced value is observed verbatim.
+        with (
+            patch.object(gen, "shrink_config", lambda *a, **k: None),
+            patch.object(gen, "_repair_cute_num_threads", lambda *a, **k: None),
+        ):
+            for _ in range(25):
+                self.assertEqual(gen.biased_random_flat()[flat_idx], value)
+
+    def test_population_fill_is_half_biased(self) -> None:
+        from helion.autotuner.config_priors import weighted_choice
+
+        gen, _ = self._add_config_gen()
+        key, _flat_idx, value = self._forceable_slot(gen)
+        gen._config_value_priors = {key: weighted_choice({value: 1.0})}
+        with (
+            # Suppress backend-supplied compiler seeds so the random-fill count
+            # is deterministic across backends (cute seeds a few configs).
+            patch.object(gen, "seed_flat_config_pairs", return_value=[]),
+            patch.object(
+                gen, "biased_random_flat", wraps=gen.biased_random_flat
+            ) as biased,
+            patch.object(gen, "random_flat", wraps=gen.random_flat) as uniform,
+        ):
+            # 1 default + 10 random fill slots (seeds suppressed above).
+            gen.random_population_flat(11)
+        self.assertEqual(biased.call_count, 5)
+        self.assertEqual(uniform.call_count, 5)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2682
 * #2681
 * #2680
 * __->__#2679
 * #2678
 * #2656
 * #2655
 * #2654
 * #2653
 * #2652
 * #2651


--- --- ---

[autotuner] add per-fragment config priors to bias the initial population

Add a general, backend-agnostic mechanism for biasing the autotuner's random
exploration toward the region good configs tend to occupy, as the foundation
for replacing the cute backend's hardcoded per-shape seed configs with a
learned distribution.

- `Backend.config_value_priors(config_spec)` is a new hook returning a mapping
  from config-key name (e.g. `num_warps`, `indexing`, `tcgen05_cluster_m`) to a
  `ValuePrior` -- a per-slot sampler that returns a biased value or `None` to
  fall back to the fragment's uniform `random()`. The default is no bias, so
  every existing backend is unaffected.
- `config_priors.weighted_choice` builds a prior from a weighted value map,
  dropping values the live fragment can't represent (so backends can list
  aspirational values safely).
- `ConfigGeneration.biased_random_flat` samples each flat slot from its key's
  prior when one exists; `random_population_flat` now draws half of the random
  fill from the biased sampler and half uniformly when the backend supplies
  priors. With no priors the fill is entirely uniform -- byte-identical to the
  prior behavior.

Because priors are keyed per config-key, the bias generalizes to any kernel
(not just matmuls): a kernel benefits on whichever shared knobs it exposes.
The cute backend's priors and the matmul seed heuristic that consume this land
in a follow-up.