### PR TITLE
[cutedsl] generalize hardcoded tcgen05 FFI seeds into a shape-derived heuristic

### DIFF
--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from .common import dedupe_configs
 from .cute import CuteReductionTileHeuristic
 from .cute import CuteReductionWideChunkHeuristic
+from .cute import CuteTcgen05ClusterM2FfiHeuristic
 from .cute import CuteTcgen05ClusterM2Heuristic
 from .cute import CuteTileVecHeuristic
 from .cute import CuteTileVecWarpPerRowHeuristic
@@ -24,6 +25,7 @@ if TYPE_CHECKING:
 # All active heuristics by backend
 HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
     "cute": (
+        CuteTcgen05ClusterM2FfiHeuristic,
         CuteTcgen05ClusterM2Heuristic,
         CuteReductionTileHeuristic,
         CuteReductionWideChunkHeuristic,

--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -514,7 +514,9 @@ class CuteTcgen05ClusterM2Heuristic(AutotunerHeuristic):
         return m_tile_reachable and n_tile_reachable and cls._select_bk(env) is not None
 
     @classmethod
-    def get_seed_config(cls, env: CompileEnvironment, device_ir: DeviceIR) -> Config:
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
         spec = env.config_spec
         bk = cls._select_bk(env)
         if bk is None:
@@ -524,14 +526,26 @@ class CuteTcgen05ClusterM2Heuristic(AutotunerHeuristic):
             spec._tcgen05_cluster_m2_search_constraints is not None
             and spec._tcgen05_cluster_m2_search_constraints.allow_edge_k_tail_family
         )
+        # Generalized known-good CtaGroup.TWO template (the DEFAULT-layout,
+        # non-FFI config family that the hand-pinned per-shape seeds shared).
+        # Pinning the full perf-critical knob set — not just the tile + cluster
+        # — gives the autotuner a strong, complete starting point for ANY
+        # 2-CTA-eligible matmul shape instead of relying on the search to
+        # rediscover num_warps/num_stages/staging from a partial seed.
+        # ``tcgen05_strategy`` (ROLE_LOCAL_MONOLITHIC) is the default, so it is
+        # left implicit; the search still owns every one of these knobs.
         seed: dict[str, Any] = {
             "block_sizes": [
                 TCGEN05_TWO_CTA_BLOCK_M,
                 TCGEN05_TWO_CTA_BLOCK_N,
                 bk,
             ],
+            "num_warps": 8,
+            "num_stages": 4,
             "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
             "tcgen05_cluster_m": 2,
+            "tcgen05_cluster_n": 1,
+            "tcgen05_acc_stages": 2,
             # Matches the validated tcgen05 search restriction.
             "tcgen05_num_epi_warps": 4,
             TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
@@ -542,10 +556,11 @@ class CuteTcgen05ClusterM2Heuristic(AutotunerHeuristic):
             seed.update(tcgen05_two_cta_edge_k_tail_seed_overrides())
         else:
             seed["l2_groupings"] = [TCGEN05_TWO_CTA_SEED_L2_GROUPING]
+            seed["tcgen05_c_stages"] = 2
             # When the SMEM-budget gate admits ``ab=3`` for this seed tile
-            # shape, seed the canonical 4096^3 fast config family directly so
-            # it reaches the autotuner's initial population without depending
-            # on a search-stage mutation.
+            # shape, seed the canonical fast config family directly so it
+            # reaches the autotuner's initial population without depending on a
+            # search-stage mutation.
             if spec._tcgen05_ab_stages_three_fits(
                 bm=TCGEN05_TWO_CTA_BLOCK_M,
                 bn=TCGEN05_TWO_CTA_BLOCK_N,
@@ -591,3 +606,42 @@ class CuteTcgen05ClusterM2Heuristic(AutotunerHeuristic):
                 return bk
             bk //= 2
         return None
+
+
+class CuteTcgen05ClusterM2FfiHeuristic(CuteTcgen05ClusterM2Heuristic):
+    """Generalized TVM-FFI direct-entry seed for full-tile CtaGroup.TWO bf16 GEMMs.
+
+    The direct-entry codegen (``build_target1_direct_entry_source`` /
+    ``_create_cute_direct_entry``) builds its A/B/D TMA descriptors from the
+    runtime tensor shapes, so the fast launch path is shape-GENERAL: the only
+    real constraints are structural (256x256 CTA tile, cluster_m=2, a bk in the
+    direct-entry stage-tuple table, bf16 operands, the 128x32 explicit epilogue
+    subtile). This heuristic emits that full ``explicit_epi_tile`` + flat-role +
+    ``tvm_ffi_launch`` config for ANY eligible shape, replacing the bank of
+    hand-pinned per-shape seeds.
+
+    The DEFAULT-layout sibling (``CuteTcgen05ClusterM2Heuristic``) still seeds
+    the non-FFI config, so the autotuner benchmarks both and keeps whichever
+    wins: full-autotune A/B measured the FFI direct entry ~7-21% faster on
+    smaller / square GEMMs (1024x4096x1024, 2048^3) where launch + epilogue
+    overhead dominates, and tied on large compute-bound shapes
+    (8192x1024x1024, 8192x2048x2048). An FFI config that fails to compile or
+    the accuracy check for a given shape is dropped by the autotuner,
+    degrading gracefully to the DEFAULT seed.
+    """
+
+    name = "cute_tcgen05_cluster_m2_ffi"
+    backend = "cute"
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        return env.config_spec._tcgen05_full_tile_direct_entry_seed_eligible()
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        # Single source of truth lives on the ConfigSpec/CuteTcgen05Config so the
+        # search-projection (``_fix_target1_tvm_ffi_search_config``) and this
+        # population seed emit the identical FFI envelope.
+        return env.config_spec._tcgen05_full_tile_direct_entry_seed_config()

--- a/helion/_compiler/cute/aux_tensor.py
+++ b/helion/_compiler/cute/aux_tensor.py
@@ -31,12 +31,10 @@ import torch
 
 from ...language import matmul_ops
 from ...language import memory_ops
-from ...language._gelu_tanh_approx import _gelu_erf
 from ..compile_environment import CompileEnvironment
 from .cute_epilogue import _AuxiliaryTensorStep
 from .cute_epilogue import analyze_tcgen05_unary_epilogue_chain
 from .cute_fx_walk import build_inner_outputs_index_from_graphs
-from .cute_fx_walk import walk_carrier_to_tcgen05_matmul
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -65,6 +63,11 @@ _TCGEN05_AUX_DETECTOR_MMA_TARGETS = (
     torch.ops.aten.baddbmm.default,
     matmul_ops.dot,
 )
+# Dtypes the tcgen05 SMEM-staged MMA can TMA-load directly as operands. An
+# operand whose backing load is some other dtype (e.g. int16 cast to bf16 in
+# ``w.to(bfloat16)``) is converted in registers and cannot be staged for
+# tcgen05, so the dot falls back to the non-tcgen05 path.
+_TCGEN05_NATIVE_MMA_OPERAND_DTYPES = (torch.bfloat16, torch.float16)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -441,226 +444,6 @@ def host_function_has_tcgen05_exact_shape_aux_kernel_pattern(
     )
 
 
-def _host_function_has_tcgen05_single_store_pattern(
-    host_function: HostFunction,
-    *,
-    intermediate_op: object | None,
-) -> bool:
-    """Return True iff the host function has exactly one tcgen05 matmul store.
-
-    ``intermediate_op`` selects the chain shape between the MMA carrier and
-    the store-feeding cast:
-      * ``None`` — identity store (``mma -> convert -> store``).
-      * ``aten.relu.default`` — relu epilogue (``mma -> relu -> convert -> store``).
-
-    Unified entry point for the identity-store and relu-store gates so
-    they cannot drift; mirrors the ``extra_trace_through`` shape on the
-    walker side. The bias-store detector lives separately because
-    ``aten.add.Tensor`` is a two-operand op whose extra-operand shape
-    (rank-1 trailing-axis broadcast) must be checked.
-    """
-    device_ir = host_function.device_ir
-    graphs = device_ir.graphs
-    if not graphs:
-        return False
-
-    mma_nodes, _operand_load_nodes = _tcgen05_aux_detector_mma_facts(graphs)
-    if not mma_nodes:
-        return False
-
-    cast_input = _single_store_cast_input(graphs)
-    if cast_input is None:
-        return False
-    if intermediate_op is not None:
-        if (
-            cast_input.op != "call_function"
-            or cast_input.target is not intermediate_op
-            or cast_input.kwargs
-            or len(cast_input.args) != 1
-        ):
-            return False
-        next_input = cast_input.args[0]
-        if not isinstance(next_input, torch.fx.Node):
-            return False
-        carrier_anchor: torch.fx.Node = next_input
-    else:
-        carrier_anchor = cast_input
-    return (
-        walk_carrier_to_tcgen05_matmul(
-            carrier_anchor,
-            mma_nodes,
-            build_inner_outputs_index_from_graphs(graphs),
-        )
-        is not None
-    )
-
-
-def host_function_has_tcgen05_identity_matmul_store_pattern(
-    host_function: HostFunction,
-) -> bool:
-    """Return True only for a single identity store of a tcgen05 matmul result."""
-    return _host_function_has_tcgen05_single_store_pattern(
-        host_function, intermediate_op=None
-    )
-
-
-def host_function_has_tcgen05_relu_matmul_store_pattern(
-    host_function: HostFunction,
-) -> bool:
-    """Return True only for a single ``relu`` + cast store of a tcgen05 matmul.
-
-    Symmetrical to ``host_function_has_tcgen05_identity_matmul_store_pattern``;
-    gates the Target 4 TVM-FFI direct-entry seed without broadening the
-    general identity-store detector. The two detectors are mutually
-    exclusive: the identity walker rejects a relu in the chain, and this
-    walker requires one.
-    """
-    return _host_function_has_tcgen05_single_store_pattern(
-        host_function, intermediate_op=torch.ops.aten.relu.default
-    )
-
-
-def host_function_has_tcgen05_gelu_matmul_store_pattern(
-    host_function: HostFunction,
-) -> bool:
-    """Return True only for a single plain-``gelu`` + cast store of a matmul.
-
-    Gates the cycle-87 Target 8 TVM-FFI direct-entry seed (MatmulTarget 27,
-    1536x6144x1536 fp16 ``gelu(acc)``). The accepted chain shape is
-    ``mma -> _gelu_erf -> convert -> store`` where ``_gelu_erf`` is the
-    single-FX-node internal op the ``aten.gelu.default`` decomposition
-    materializes for the default (``approximate="none"``) erf GELU — the
-    same form ``torch.nn.functional.gelu(acc)`` produces. Symmetrical to the
-    identity/relu store detectors via
-    ``_host_function_has_tcgen05_single_store_pattern``.
-
-    Mutually exclusive with the identity/relu/bias/bias_relu detectors: the
-    identity walker rejects a unary op in the chain, relu requires
-    ``aten.relu.default`` rather than ``_gelu_erf``, and the bias / bias_relu
-    walkers require an ``aten.add.Tensor`` bias load between the carrier and
-    the store. The bias_residual_gelu MatmulTargets (12/28) carry bias +
-    residual ``add`` ops before the gelu, so their store-feeding cast does
-    not sit directly on a lone ``_gelu_erf`` and is rejected here. This
-    detector does fire on the bf16 gelu MatmulTargets 4/19, but the T8 seed's
-    fp16-pinned shape fact keeps the seed mutually exclusive with them.
-    """
-    return _host_function_has_tcgen05_single_store_pattern(
-        host_function, intermediate_op=_gelu_erf
-    )
-
-
-def host_function_has_tcgen05_bias_matmul_store_pattern(
-    host_function: HostFunction,
-    *,
-    expected_bias_dtypes: tuple[torch.dtype, ...] = (torch.bfloat16,),
-) -> bool:
-    """Return True for a single ``acc + bias[n]`` store of a tcgen05 matmul.
-
-    Gates the Target 2 (bf16-only) and Target 10 (bf16/fp16) TVM-FFI
-    direct-entry seeds for the rank-1 trailing-axis (rowvec) bias
-    epilogue. The accepted chain shape is
-    ``mma -> aten.add.Tensor(carrier, bias_load) -> convert -> store``
-    where:
-
-    * ``bias_load`` is a ``helion.language.memory_ops.load`` against a
-      rank-1 (``shape == (N,)``) GMEM tensor whose dtype is one of
-      ``expected_bias_dtypes``.
-    * One operand of the ``add`` is the MMA carrier reached via
-      ``walk_carrier_to_tcgen05_matmul``; the other is the rank-1
-      ``bias_load``.
-
-    Mutually exclusive with the identity/relu detectors: identity
-    rejects any binary op in the chain, and relu requires a single-arg
-    ``aten.relu.default`` rather than the two-arg add. A T6 host
-    function (``acc + bias[n] -> relu -> convert -> store``) is also
-    rejected here because the convert-and-store walker requires the
-    cast to feed directly off the bias add, not via a relu.
-    """
-    device_ir = host_function.device_ir
-    graphs = device_ir.graphs
-    if not graphs:
-        return False
-
-    mma_nodes, _operand_load_nodes = _tcgen05_aux_detector_mma_facts(graphs)
-    if not mma_nodes:
-        return False
-
-    cast_input = _single_store_cast_input(graphs)
-    if cast_input is None:
-        return False
-    return _bias_add_walks_to_mma_carrier(
-        cast_input,
-        mma_nodes,
-        graphs,
-        expected_bias_dtypes=expected_bias_dtypes,
-    )
-
-
-def host_function_has_tcgen05_bias_relu_matmul_store_pattern(
-    host_function: HostFunction,
-) -> bool:
-    """Return True for a single ``relu(acc + bias[n])`` store of a tcgen05 matmul.
-
-    Gates the Target 6 TVM-FFI direct-entry seed for the composition of
-    T2's rank-1 trailing-axis (rowvec) bias add and T4's relu activation.
-    The accepted chain shape is
-    ``mma -> aten.add.Tensor(carrier, bias_load) -> aten.relu.default ->
-    convert -> store`` where:
-
-    * ``bias_load`` is a ``helion.language.memory_ops.load`` against a
-      rank-1 (``shape == (N,)``) bf16 GMEM tensor.
-    * One operand of the ``add`` is the MMA carrier reached via
-      ``walk_carrier_to_tcgen05_matmul``; the other is the rank-1
-      ``bias_load``.
-    * The relu sits between the add and the cast that feeds the store.
-
-    Mutually exclusive with the identity/relu/bias detectors:
-
-    * Identity rejects any binary op in the chain.
-    * Relu rejects any binary op in the chain (the relu walker requires
-      ``cast_input.target is aten.relu.default`` and ``relu_input`` to
-      be the MMA carrier directly, not a bias add).
-    * Bias rejects any unary op between the add and the cast (the bias
-      walker requires ``cast_input.target is aten.add.Tensor`` directly,
-      not wrapped by a relu).
-
-    Cycle-6 P2 dtype gate applied: the runtime validator only admits
-    bf16 bias tensors, so non-bf16 bias loads must not enable the T6
-    seed at the host-detector level either (otherwise they would reach
-    a direct-entry plan and fail only at launch).
-    """
-    device_ir = host_function.device_ir
-    graphs = device_ir.graphs
-    if not graphs:
-        return False
-
-    mma_nodes, _operand_load_nodes = _tcgen05_aux_detector_mma_facts(graphs)
-    if not mma_nodes:
-        return False
-
-    cast_input = _single_store_cast_input(graphs)
-    if cast_input is None:
-        return False
-    # T6 requires a relu directly feeding the cast.
-    if (
-        cast_input.op != "call_function"
-        or cast_input.target is not torch.ops.aten.relu.default
-        or cast_input.kwargs
-        or len(cast_input.args) != 1
-    ):
-        return False
-    relu_input = cast_input.args[0]
-    if not isinstance(relu_input, torch.fx.Node):
-        return False
-    # T6 stays pinned to bf16 (its matmul-fact gate is bf16-only).
-    return _bias_add_walks_to_mma_carrier(
-        relu_input,
-        mma_nodes,
-        graphs,
-        expected_bias_dtypes=(torch.bfloat16,),
-    )
-
-
 def _tcgen05_aux_detector_mma_facts(
     graphs: Sequence[GraphInfo],
 ) -> tuple[set[torch.fx.Node], set[torch.fx.Node]]:
@@ -686,6 +469,47 @@ def _tcgen05_aux_detector_mma_facts(
     return mma_nodes, operand_load_nodes
 
 
+def host_function_matmul_has_non_tcgen05_operand(
+    host_function: HostFunction,
+) -> bool:
+    """Return True when a matmul operand sources from a load whose dtype is not
+    a tcgen05-native MMA dtype (bf16/fp16).
+
+    The canonical case is the ``bf16 x int16`` GEMM, where one operand is
+    ``w[tile].to(bfloat16)``: the matmul facts only see the post-cast bf16
+    dtype, so the shape-structural FFI/flat-role direct-entry seed would treat
+    it as a plain bf16 GEMM. But the backing load is int16, which the
+    SMEM-staged tcgen05 MMA cannot TMA-load, so the dot lowers through the
+    non-tcgen05 fallback that rejects the flat-role seed config. Detect the
+    real operand-source dtype here (tracing through the same
+    ``convert_element_type`` wrappers MMA codegen accepts) so the seed stays
+    ineligible for such kernels.
+    """
+    graphs = host_function.device_ir.graphs
+    if not graphs:
+        return False
+    for graph_info in graphs:
+        for node in graph_info.graph.nodes:
+            if (
+                node.op != "call_function"
+                or node.target not in _TCGEN05_AUX_DETECTOR_MMA_TARGETS
+            ):
+                continue
+            for arg in node.args:
+                if not isinstance(arg, torch.fx.Node):
+                    continue
+                load_node = _trace_to_load_through_casts(arg)
+                if load_node is None:
+                    continue
+                val = load_node.meta.get("val")
+                if (
+                    isinstance(val, torch.Tensor)
+                    and val.dtype not in _TCGEN05_NATIVE_MMA_OPERAND_DTYPES
+                ):
+                    return True
+    return False
+
+
 def _store_value_pairs_from_graph(
     graph: torch.fx.Graph,
 ) -> list[tuple[torch.fx.Node, torch.fx.Node]]:
@@ -709,92 +533,6 @@ def _output_tensor_from_store_node(store_node: torch.fx.Node) -> torch.Tensor | 
         return None
     tensor_val = tensor_arg.meta.get("val")
     return tensor_val if isinstance(tensor_val, torch.Tensor) else None
-
-
-def _single_store_cast_input(
-    graphs: Sequence[GraphInfo],
-) -> torch.fx.Node | None:
-    """Return the FX node feeding the lone store's ``convert_element_type``.
-
-    Returns ``None`` unless the host function has exactly one store whose
-    value is a kwarg-free ``prims.convert_element_type.default`` call with
-    a single FX-node arg. This is the entry shape shared by the
-    identity/relu/bias/bias_relu direct-entry detectors.
-    """
-    store_outputs: list[torch.fx.Node] = []
-    for graph_info in graphs:
-        for store_node, store_value in _store_value_pairs_from_graph(graph_info.graph):
-            if _output_tensor_from_store_node(store_node) is not None:
-                store_outputs.append(store_value)
-    if len(store_outputs) != 1:
-        return None
-    store_value = store_outputs[0]
-    if (
-        store_value.op != "call_function"
-        or store_value.target is not torch.ops.prims.convert_element_type.default
-        or store_value.kwargs
-    ):
-        return None
-    cast_input = store_value.args[0] if store_value.args else None
-    return cast_input if isinstance(cast_input, torch.fx.Node) else None
-
-
-def _is_rank1_bias_load_of_dtype(
-    node: torch.fx.Node, expected_dtypes: tuple[torch.dtype, ...]
-) -> bool:
-    """Return True iff ``node`` is a rank-1 ``memory_ops.load`` of one of ``expected_dtypes``.
-
-    The host-side detector is parameterized by the caller's expected
-    bias dtypes so T2/T6 stay pinned to bf16 (their matmul-fact gates
-    are bf16-only) while T10 admits ``(bf16, fp16)``. Without per-caller
-    parameterization a fp16 bias against a bf16-operand kernel would
-    silently flip ``bias_matmul_store_detected = True`` for T2/T6 too,
-    perturbing the autotune mutation pool (cycle 40 lesson).
-    """
-    if node.op != "call_function" or node.target is not memory_ops.load:
-        return False
-    host_arg = node.args[0] if node.args else None
-    if not isinstance(host_arg, torch.fx.Node):
-        return False
-    host_val = host_arg.meta.get("val")
-    if not isinstance(host_val, torch.Tensor):
-        return False
-    return host_val.ndim == 1 and host_val.dtype in expected_dtypes
-
-
-def _bias_add_walks_to_mma_carrier(
-    add_node: torch.fx.Node,
-    mma_nodes: set[torch.fx.Node],
-    graphs: Sequence[GraphInfo],
-    *,
-    expected_bias_dtypes: tuple[torch.dtype, ...],
-) -> bool:
-    """Return True iff ``add_node`` is ``aten.add.Tensor(carrier, bias_load)``.
-
-    One operand of the add must walk to an MMA carrier via
-    :func:`walk_carrier_to_tcgen05_matmul`; the other must satisfy
-    :func:`_is_rank1_bias_load_of_dtype` with the caller-supplied
-    ``expected_bias_dtypes`` set. Either operand may be the carrier
-    (commutative).
-    """
-    if (
-        add_node.op != "call_function"
-        or add_node.target is not torch.ops.aten.add.Tensor
-        or add_node.kwargs
-        or len(add_node.args) != 2
-    ):
-        return False
-    add_lhs, add_rhs = add_node.args
-    if not isinstance(add_lhs, torch.fx.Node) or not isinstance(add_rhs, torch.fx.Node):
-        return False
-    inner_outputs_index = build_inner_outputs_index_from_graphs(graphs)
-    carrier_first = walk_carrier_to_tcgen05_matmul(
-        add_lhs, mma_nodes, inner_outputs_index
-    ) is not None and _is_rank1_bias_load_of_dtype(add_rhs, expected_bias_dtypes)
-    carrier_second = walk_carrier_to_tcgen05_matmul(
-        add_rhs, mma_nodes, inner_outputs_index
-    ) is not None and _is_rank1_bias_load_of_dtype(add_lhs, expected_bias_dtypes)
-    return carrier_first or carrier_second
 
 
 def _same_static_shape(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -102,46 +102,6 @@ from .tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODE_NORMAL
 from .tcgen05_constants import TCGEN05_SCHED_CONSUMER_WAIT_MODES
 from .tcgen05_constants import TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_SCHED_STAGE_COUNTS
-from .tcgen05_constants import TCGEN05_TARGET1_TVM_FFI_AB_STAGES
-from .tcgen05_constants import TCGEN05_TARGET1_TVM_FFI_BLOCK_K
-from .tcgen05_constants import TCGEN05_TARGET1_TVM_FFI_C_STAGES
-from .tcgen05_constants import TCGEN05_TARGET1_TVM_FFI_SHAPE
-from .tcgen05_constants import TCGEN05_TARGET2_TVM_FFI_AB_STAGES
-from .tcgen05_constants import TCGEN05_TARGET2_TVM_FFI_BLOCK_K
-from .tcgen05_constants import TCGEN05_TARGET2_TVM_FFI_C_STAGES
-from .tcgen05_constants import TCGEN05_TARGET2_TVM_FFI_SHAPE
-from .tcgen05_constants import TCGEN05_TARGET3_TVM_FFI_AB_STAGES
-from .tcgen05_constants import TCGEN05_TARGET3_TVM_FFI_BLOCK_K
-from .tcgen05_constants import TCGEN05_TARGET3_TVM_FFI_C_STAGES
-from .tcgen05_constants import TCGEN05_TARGET3_TVM_FFI_SHAPE
-from .tcgen05_constants import TCGEN05_TARGET4_TVM_FFI_AB_STAGES
-from .tcgen05_constants import TCGEN05_TARGET4_TVM_FFI_BLOCK_K
-from .tcgen05_constants import TCGEN05_TARGET4_TVM_FFI_C_STAGES
-from .tcgen05_constants import TCGEN05_TARGET4_TVM_FFI_SHAPE
-from .tcgen05_constants import TCGEN05_TARGET5_TVM_FFI_AB_STAGES
-from .tcgen05_constants import TCGEN05_TARGET5_TVM_FFI_BLOCK_K
-from .tcgen05_constants import TCGEN05_TARGET5_TVM_FFI_C_STAGES
-from .tcgen05_constants import TCGEN05_TARGET5_TVM_FFI_SHAPE
-from .tcgen05_constants import TCGEN05_TARGET6_TVM_FFI_AB_STAGES
-from .tcgen05_constants import TCGEN05_TARGET6_TVM_FFI_BLOCK_K
-from .tcgen05_constants import TCGEN05_TARGET6_TVM_FFI_C_STAGES
-from .tcgen05_constants import TCGEN05_TARGET6_TVM_FFI_SHAPE
-from .tcgen05_constants import TCGEN05_TARGET7_TVM_FFI_AB_STAGES
-from .tcgen05_constants import TCGEN05_TARGET7_TVM_FFI_BLOCK_K
-from .tcgen05_constants import TCGEN05_TARGET7_TVM_FFI_C_STAGES
-from .tcgen05_constants import TCGEN05_TARGET7_TVM_FFI_SHAPE
-from .tcgen05_constants import TCGEN05_TARGET8_GELU_AB_STAGES
-from .tcgen05_constants import TCGEN05_TARGET8_GELU_BLOCK_K
-from .tcgen05_constants import TCGEN05_TARGET8_GELU_C_STAGES
-from .tcgen05_constants import TCGEN05_TARGET8_GELU_SHAPE
-from .tcgen05_constants import TCGEN05_TARGET9_TVM_FFI_AB_STAGES
-from .tcgen05_constants import TCGEN05_TARGET9_TVM_FFI_BLOCK_K
-from .tcgen05_constants import TCGEN05_TARGET9_TVM_FFI_C_STAGES
-from .tcgen05_constants import TCGEN05_TARGET9_TVM_FFI_SHAPE
-from .tcgen05_constants import TCGEN05_TARGET10_TVM_FFI_AB_STAGES
-from .tcgen05_constants import TCGEN05_TARGET10_TVM_FFI_BLOCK_K
-from .tcgen05_constants import TCGEN05_TARGET10_TVM_FFI_C_STAGES
-from .tcgen05_constants import TCGEN05_TARGET10_TVM_FFI_SHAPE
 from .tcgen05_constants import TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
@@ -165,6 +125,7 @@ from .tcgen05_constants import TCGEN05_TWO_CTA_SEED_PID_TYPE
 from .tcgen05_constants import tcgen05_ab_smem_bytes_per_cta
 from .tcgen05_constants import tcgen05_c_smem_bytes_per_cta
 from .tcgen05_constants import tcgen05_default_epilogue_tile_size
+from .tcgen05_constants import tcgen05_direct_entry_stage_tuple_allowed
 from .tcgen05_constants import tcgen05_two_cta_edge_k_tail_seed_overrides
 
 if TYPE_CHECKING:
@@ -246,29 +207,12 @@ class CuteTcgen05Config:
         self.search_enabled: bool = False
         self.aux_kernel_detected: bool = False
         self.exact_shape_aux_kernel_detected: bool = False
-        self.identity_matmul_store_detected: bool = False
-        self.relu_matmul_store_detected: bool = False
-        self.bias_matmul_store_detected: bool = False
-        # T10-only bias detection: T10 admits fp16 bias against fp16
-        # operands. Kept as a separate flag so T2/T6 — both bf16-only
-        # at the matmul-fact level — cannot accidentally enable on a
-        # fp16 bias load (cycle 42 P2 fix; cycle 40 perturbation lesson).
-        self.bias_matmul_store_fp16_detected: bool = False
-        self.bias_relu_matmul_store_detected: bool = False
-        # Plain ``gelu(acc)`` store (no bias, no residual) — cycle-87 T8
-        # (MatmulTarget 27, fp16). Kept separate from bias_residual_gelu
-        # (T12/T28) since those carry add ops before the gelu.
-        self.gelu_matmul_store_detected: bool = False
-        self.target1_tvm_ffi_seed_enabled: bool = False
-        self.target2_tvm_ffi_seed_enabled: bool = False
-        self.target3_tvm_ffi_seed_enabled: bool = False
-        self.target4_tvm_ffi_seed_enabled: bool = False
-        self.target5_tvm_ffi_seed_enabled: bool = False
-        self.target6_tvm_ffi_seed_enabled: bool = False
-        self.target7_tvm_ffi_seed_enabled: bool = False
-        self.target8_gelu_seed_enabled: bool = False
-        self.target9_tvm_ffi_seed_enabled: bool = False
-        self.target10_tvm_ffi_seed_enabled: bool = False
+        # True when the kernel feeds a matmul an operand sourced from a load
+        # whose dtype is not a tcgen05-native MMA dtype (e.g. an int16 tensor
+        # cast to bf16, ``w.to(bfloat16)``). Such an operand cannot be TMA-staged
+        # for the SMEM tcgen05 MMA, so the dot lowers through the non-tcgen05
+        # fallback and the FFI/flat-role direct-entry seed must stay ineligible.
+        self.matmul_has_non_tcgen05_operand: bool = False
         self.cluster_m_search_choices: tuple[int, ...] | None = None
         self.cluster_m2_search_constraints: Tcgen05ClusterM2SearchConstraints | None = (
             None
@@ -333,216 +277,6 @@ class CuteTcgen05Config:
         )
         self.restrict_cluster_m_search((1, 2))
 
-    def allow_target1_tvm_ffi_seed(self) -> None:
-        if not self.identity_matmul_store_detected:
-            return
-        if not self._has_target1_tvm_ffi_matmul_fact():
-            return
-        target_k = TCGEN05_TARGET1_TVM_FFI_SHAPE[2]
-        self.target1_tvm_ffi_seed_enabled = True
-        self.cluster_m2_search_constraints = Tcgen05ClusterM2SearchConstraints(
-            static_k=target_k,
-            max_k_tiles=TCGEN05_TWO_CTA_MAX_K_TILES,
-        )
-        self.cluster_m_search_choices = (1, 2)
-        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
-            self.allowed_pid_types = (
-                *self.allowed_pid_types,
-                cast("PidTypeLiteral", TCGEN05_TWO_CTA_SEED_PID_TYPE),
-            )
-
-    def allow_target4_tvm_ffi_seed(self) -> None:
-        if not self.relu_matmul_store_detected:
-            return
-        if not self._has_target4_tvm_ffi_matmul_fact():
-            return
-        target_k = TCGEN05_TARGET4_TVM_FFI_SHAPE[2]
-        self.target4_tvm_ffi_seed_enabled = True
-        self.cluster_m2_search_constraints = Tcgen05ClusterM2SearchConstraints(
-            static_k=target_k,
-            max_k_tiles=TCGEN05_TWO_CTA_MAX_K_TILES,
-        )
-        self.cluster_m_search_choices = (1, 2)
-        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
-            self.allowed_pid_types = (
-                *self.allowed_pid_types,
-                cast("PidTypeLiteral", TCGEN05_TWO_CTA_SEED_PID_TYPE),
-            )
-
-    def allow_target5_tvm_ffi_seed(self) -> None:
-        # T5 mirrors T4 at the transposed (1024, 8192, 1024) identity-store
-        # shape; the shape fact gate distinguishes it from T1.
-        if not self.identity_matmul_store_detected:
-            return
-        if not self._has_target5_tvm_ffi_matmul_fact():
-            return
-        target_k = TCGEN05_TARGET5_TVM_FFI_SHAPE[2]
-        self.target5_tvm_ffi_seed_enabled = True
-        self.cluster_m2_search_constraints = Tcgen05ClusterM2SearchConstraints(
-            static_k=target_k,
-            max_k_tiles=TCGEN05_TWO_CTA_MAX_K_TILES,
-        )
-        self.cluster_m_search_choices = (1, 2)
-        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
-            self.allowed_pid_types = (
-                *self.allowed_pid_types,
-                cast("PidTypeLiteral", TCGEN05_TWO_CTA_SEED_PID_TYPE),
-            )
-
-    def allow_target3_tvm_ffi_seed(self) -> None:
-        # T3 reuses T4/T5's envelope at the larger (2048, 4096, 2048)
-        # identity-store shape; K=2048 -> k_tile_count=16, well below
-        # ``TCGEN05_TWO_CTA_MAX_K_TILES``. Shape fact distinguishes T1/T5.
-        if not self.identity_matmul_store_detected:
-            return
-        if not self._has_target3_tvm_ffi_matmul_fact():
-            return
-        target_k = TCGEN05_TARGET3_TVM_FFI_SHAPE[2]
-        self.target3_tvm_ffi_seed_enabled = True
-        self.cluster_m2_search_constraints = Tcgen05ClusterM2SearchConstraints(
-            static_k=target_k,
-            max_k_tiles=TCGEN05_TWO_CTA_MAX_K_TILES,
-        )
-        self.cluster_m_search_choices = (1, 2)
-        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
-            self.allowed_pid_types = (
-                *self.allowed_pid_types,
-                cast("PidTypeLiteral", TCGEN05_TWO_CTA_SEED_PID_TYPE),
-            )
-
-    def allow_target2_tvm_ffi_seed(self) -> None:
-        # T2 reuses T3/T4/T5's envelope at (4096, 2048, 2048) with a
-        # rank-1 rowvec bias epilogue. The bias-store gate is unique to
-        # T2 (mutually exclusive with identity/relu/bias_relu).
-        if not self.bias_matmul_store_detected:
-            return
-        if not self._has_target2_tvm_ffi_matmul_fact():
-            return
-        target_k = TCGEN05_TARGET2_TVM_FFI_SHAPE[2]
-        self.target2_tvm_ffi_seed_enabled = True
-        self.cluster_m2_search_constraints = Tcgen05ClusterM2SearchConstraints(
-            static_k=target_k,
-            max_k_tiles=TCGEN05_TWO_CTA_MAX_K_TILES,
-        )
-        self.cluster_m_search_choices = (1, 2)
-        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
-            self.allowed_pid_types = (
-                *self.allowed_pid_types,
-                cast("PidTypeLiteral", TCGEN05_TWO_CTA_SEED_PID_TYPE),
-            )
-
-    def allow_target6_tvm_ffi_seed(self) -> None:
-        # T6 mirrors T2's envelope at (8192, 2048, 2048) with a fused
-        # ``relu(acc + bias[n])`` epilogue. The bias-relu-store gate is
-        # unique to T6 (mutually exclusive with identity/relu/bias).
-        if not self.bias_relu_matmul_store_detected:
-            return
-        if not self._has_target6_tvm_ffi_matmul_fact():
-            return
-        target_k = TCGEN05_TARGET6_TVM_FFI_SHAPE[2]
-        self.target6_tvm_ffi_seed_enabled = True
-        self.cluster_m2_search_constraints = Tcgen05ClusterM2SearchConstraints(
-            static_k=target_k,
-            max_k_tiles=TCGEN05_TWO_CTA_MAX_K_TILES,
-        )
-        self.cluster_m_search_choices = (1, 2)
-        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
-            self.allowed_pid_types = (
-                *self.allowed_pid_types,
-                cast("PidTypeLiteral", TCGEN05_TWO_CTA_SEED_PID_TYPE),
-            )
-
-    def allow_target7_tvm_ffi_seed(self) -> None:
-        # T7 mirrors T3/T5's envelope at (2048, 8192, 2048) identity-store
-        # shape; shape fact distinguishes it from T1/T3/T5.
-        if not self.identity_matmul_store_detected:
-            return
-        if not self._has_target7_tvm_ffi_matmul_fact():
-            return
-        target_k = TCGEN05_TARGET7_TVM_FFI_SHAPE[2]
-        self.target7_tvm_ffi_seed_enabled = True
-        self.cluster_m2_search_constraints = Tcgen05ClusterM2SearchConstraints(
-            static_k=target_k,
-            max_k_tiles=TCGEN05_TWO_CTA_MAX_K_TILES,
-        )
-        self.cluster_m_search_choices = (1, 2)
-        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
-            self.allowed_pid_types = (
-                *self.allowed_pid_types,
-                cast("PidTypeLiteral", TCGEN05_TWO_CTA_SEED_PID_TYPE),
-            )
-
-    def allow_target8_gelu_seed(self) -> None:
-        # T8 (cycle 87, MatmulTarget 27) mirrors T6's two-CTA envelope at
-        # the (1536, 6144, 1536) fp16 problem with a plain ``gelu(acc)``
-        # epilogue. The plain-gelu-store gate is unique to T8 (mutually
-        # exclusive with identity/relu/bias/bias_relu via the chain shape),
-        # and the fp16-pinned shape fact keeps it mutually exclusive with the
-        # bf16 gelu MatmulTargets 4/19 that share the chain shape.
-        if not self.gelu_matmul_store_detected:
-            return
-        if not self._has_target8_gelu_matmul_fact():
-            return
-        target_k = TCGEN05_TARGET8_GELU_SHAPE[2]
-        self.target8_gelu_seed_enabled = True
-        self.cluster_m2_search_constraints = Tcgen05ClusterM2SearchConstraints(
-            static_k=target_k,
-            max_k_tiles=TCGEN05_TWO_CTA_MAX_K_TILES,
-        )
-        self.cluster_m_search_choices = (1, 2)
-        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
-            self.allowed_pid_types = (
-                *self.allowed_pid_types,
-                cast("PidTypeLiteral", TCGEN05_TWO_CTA_SEED_PID_TYPE),
-            )
-
-    def allow_target9_tvm_ffi_seed(self) -> None:
-        # T9 mirrors T3/T5/T7's envelope at (2048, 2048, 2048)
-        # identity-store shape; shape fact distinguishes it from T1/T3/T5/T7.
-        if not self.identity_matmul_store_detected:
-            return
-        if not self._has_target9_tvm_ffi_matmul_fact():
-            return
-        target_k = TCGEN05_TARGET9_TVM_FFI_SHAPE[2]
-        self.target9_tvm_ffi_seed_enabled = True
-        self.cluster_m2_search_constraints = Tcgen05ClusterM2SearchConstraints(
-            static_k=target_k,
-            max_k_tiles=TCGEN05_TWO_CTA_MAX_K_TILES,
-        )
-        self.cluster_m_search_choices = (1, 2)
-        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
-            self.allowed_pid_types = (
-                *self.allowed_pid_types,
-                cast("PidTypeLiteral", TCGEN05_TWO_CTA_SEED_PID_TYPE),
-            )
-
-    def allow_target10_tvm_ffi_seed(self) -> None:
-        # T10 mirrors T2's bias-store envelope at (2048, 2048, 2048)
-        # with fp16-or-bf16 operands; shape + bias-store + matmul fact
-        # dtype gate distinguishes it from T2 (4096x2048x2048 bf16) and
-        # the square identity-store T9. T10 admits both the bf16
-        # bias-store flag (matches T2's host detector) and a separate
-        # fp16 bias-store flag — T2 cannot fire on fp16 because its
-        # detector is bf16-pinned.
-        if not (
-            self.bias_matmul_store_detected or self.bias_matmul_store_fp16_detected
-        ):
-            return
-        if not self._has_target10_tvm_ffi_matmul_fact():
-            return
-        target_k = TCGEN05_TARGET10_TVM_FFI_SHAPE[2]
-        self.target10_tvm_ffi_seed_enabled = True
-        self.cluster_m2_search_constraints = Tcgen05ClusterM2SearchConstraints(
-            static_k=target_k,
-            max_k_tiles=TCGEN05_TWO_CTA_MAX_K_TILES,
-        )
-        self.cluster_m_search_choices = (1, 2)
-        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
-            self.allowed_pid_types = (
-                *self.allowed_pid_types,
-                cast("PidTypeLiteral", TCGEN05_TWO_CTA_SEED_PID_TYPE),
-            )
-
     @staticmethod
     def cluster_m2_bk_is_valid(
         bk: int, constraints: Tcgen05ClusterM2SearchConstraints
@@ -563,6 +297,137 @@ class CuteTcgen05Config:
         if constraints.static_k % bk == 0:
             return constraints.static_k // bk <= constraints.max_k_tiles
         return False
+
+    def full_tile_direct_entry_seed_bk(self) -> int | None:
+        """Largest valid full-tile direct-entry K tile for the live shape.
+
+        Mirrors the full-tile branch of the heuristic bk selection: the highest
+        power-of-two ``bk`` within the K block-size fragment that divides
+        ``static_k`` within the ``max_k_tiles`` cap.
+        """
+        constraints = self.cluster_m2_search_constraints
+        if (
+            constraints is None
+            or constraints.allow_edge_k_tail_family
+            or len(self.config_spec.block_sizes) != 3
+        ):
+            return None
+        bk_fragment = cast(
+            "BlockSizeFragment",
+            self.config_spec.block_sizes[2]._fragment(self.config_spec),
+        )
+        bk = bk_fragment.high
+        while bk >= bk_fragment.low:
+            if self.cluster_m2_bk_is_valid(bk, constraints):
+                return bk
+            bk //= 2
+        return None
+
+    def full_tile_direct_entry_seed_eligible(self) -> bool:
+        """Structural eligibility for the generalized TVM-FFI direct-entry seed.
+
+        The direct-entry codegen + runtime validator build their A/B/D TMA
+        descriptors from the runtime tensor shapes, so the fast launch path is
+        shape-general; the constraints are purely structural: a full-tile (NOT
+        edge+K-tail) CtaGroup.TWO bf16 GEMM, the 256x256 CTA tile reachable, a
+        direct-entry-valid ``bk``, and the ``(ab=3, c=2)`` stage tuple admitted
+        and SMEM-fitting. Both ``optional_fragments`` (to add the FFI search
+        surface) and ``CuteTcgen05ClusterM2FfiHeuristic`` (to gate the seed) use
+        this so they cannot disagree.
+        """
+        # A non-tcgen05-native matmul operand (e.g. an int16 tensor cast to
+        # bf16) forces the dot through the non-tcgen05 fallback, where the
+        # flat-role / FFI seed config is rejected. The matmul facts only record
+        # the post-cast dtype (bf16), so gate on the operand-source detector.
+        if self.matmul_has_non_tcgen05_operand:
+            return False
+        constraints = self.cluster_m2_search_constraints
+        if constraints is None or constraints.allow_edge_k_tail_family:
+            return False
+        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
+            return False
+        if len(self.config_spec.block_sizes) != 3:
+            return False
+        facts = self.config_spec.matmul_facts
+        if len(facts) != 1:
+            return False
+        fact = facts[0]
+        if fact.lhs_dtype is not torch.bfloat16 or fact.rhs_dtype is not torch.bfloat16:
+            return False
+        bm_fragment = cast(
+            "BlockSizeFragment",
+            self.config_spec.block_sizes[0]._fragment(self.config_spec),
+        )
+        bn_fragment = cast(
+            "BlockSizeFragment",
+            self.config_spec.block_sizes[1]._fragment(self.config_spec),
+        )
+        if not (bm_fragment.low <= TCGEN05_TWO_CTA_BLOCK_M <= bm_fragment.high):
+            return False
+        if not (bn_fragment.low <= TCGEN05_TWO_CTA_BLOCK_N <= bn_fragment.high):
+            return False
+        bk = self.full_tile_direct_entry_seed_bk()
+        if bk is None:
+            return False
+        if not tcgen05_direct_entry_stage_tuple_allowed(
+            bk=bk, ab_stage_count=3, c_stage_count=2
+        ):
+            return False
+        return self.ab_stages_three_fits(
+            bm=TCGEN05_TWO_CTA_BLOCK_M,
+            bn=TCGEN05_TWO_CTA_BLOCK_N,
+            bk=bk,
+            cluster_m=2,
+        )
+
+    def full_tile_direct_entry_seed_config(self) -> Config | None:
+        """Generalized TVM-FFI direct-entry seed config for the live shape.
+
+        Single source of truth for the FFI ``explicit_epi_tile`` + flat-role +
+        ``tvm_ffi_launch`` config: emitted into the autotuner population by
+        ``CuteTcgen05ClusterM2FfiHeuristic`` AND used by
+        ``_fix_target1_tvm_ffi_search_config`` to project FFI-requesting search
+        candidates onto the validated CtaGroup.TWO envelope (this is what the
+        per-shape ``_target{N}`` seeds used to do, generalized to any eligible
+        shape). Returns ``None`` for ineligible shapes.
+        """
+        if not self.full_tile_direct_entry_seed_eligible():
+            return None
+        bk = self.full_tile_direct_entry_seed_bk()
+        if bk is None:
+            return None
+        seed: dict[str, Any] = {
+            "block_sizes": [TCGEN05_TWO_CTA_BLOCK_M, TCGEN05_TWO_CTA_BLOCK_N, bk],
+            "l2_groupings": [2],
+            "num_warps": 8,
+            "num_stages": 4,
+            "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
+            "tcgen05_cluster_m": 2,
+            "tcgen05_cluster_n": 1,
+            "tcgen05_ab_stages": 3,
+            "tcgen05_acc_stages": 2,
+            "tcgen05_c_stages": 2,
+            TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY: 1,
+            "tcgen05_num_epi_warps": 4,
+            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
+                Tcgen05PersistenceModel.STATIC_PERSISTENT.value
+            ),
+            TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: (
+                Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
+            ),
+            # (epi_tile_m, epi_tile_n, d_store_box_n) = (128, 32, 32) is the only
+            # explicit-epilogue subtile the direct-entry D-descriptor codegen
+            # accepts (asserted in tcgen05_direct_entry.py / cute_mma.py), so it
+            # is fixed for every eligible shape.
+            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: 128,
+            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: 32,
+            TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: 32,
+            TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY: True,
+            TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True,
+        }
+        if self.config_spec.indexing.length in (3, 4):
+            seed["indexing"] = ["tensor_descriptor"] * self.config_spec.indexing.length
+        return Config(**seed)
 
     def _c_input_seed_config(self) -> Config | None:
         if not self.aux_kernel_detected:
@@ -817,940 +682,8 @@ class CuteTcgen05Config:
         seed_config["l2_groupings"] = [TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_L2_GROUPING]
         return Config(**seed_config)
 
-    def _has_target1_tvm_ffi_matmul_fact(self) -> bool:
-        target_m, target_n, target_k = TCGEN05_TARGET1_TVM_FFI_SHAPE
-        return any(
-            fact.static_m == target_m
-            and fact.static_n == target_n
-            and fact.static_k == target_k
-            and fact.lhs_dtype == torch.bfloat16
-            and fact.rhs_dtype == torch.bfloat16
-            for fact in self.config_spec.matmul_facts
-        )
-
-    def _has_target4_tvm_ffi_matmul_fact(self) -> bool:
-        target_m, target_n, target_k = TCGEN05_TARGET4_TVM_FFI_SHAPE
-        return any(
-            fact.static_m == target_m
-            and fact.static_n == target_n
-            and fact.static_k == target_k
-            and fact.lhs_dtype == torch.bfloat16
-            and fact.rhs_dtype == torch.bfloat16
-            for fact in self.config_spec.matmul_facts
-        )
-
-    def _has_target5_tvm_ffi_matmul_fact(self) -> bool:
-        target_m, target_n, target_k = TCGEN05_TARGET5_TVM_FFI_SHAPE
-        return any(
-            fact.static_m == target_m
-            and fact.static_n == target_n
-            and fact.static_k == target_k
-            and fact.lhs_dtype == torch.bfloat16
-            and fact.rhs_dtype == torch.bfloat16
-            for fact in self.config_spec.matmul_facts
-        )
-
-    def _has_target3_tvm_ffi_matmul_fact(self) -> bool:
-        target_m, target_n, target_k = TCGEN05_TARGET3_TVM_FFI_SHAPE
-        return any(
-            fact.static_m == target_m
-            and fact.static_n == target_n
-            and fact.static_k == target_k
-            and fact.lhs_dtype == torch.bfloat16
-            and fact.rhs_dtype == torch.bfloat16
-            for fact in self.config_spec.matmul_facts
-        )
-
-    def _has_target2_tvm_ffi_matmul_fact(self) -> bool:
-        target_m, target_n, target_k = TCGEN05_TARGET2_TVM_FFI_SHAPE
-        return any(
-            fact.static_m == target_m
-            and fact.static_n == target_n
-            and fact.static_k == target_k
-            and fact.lhs_dtype == torch.bfloat16
-            and fact.rhs_dtype == torch.bfloat16
-            for fact in self.config_spec.matmul_facts
-        )
-
-    def _has_target6_tvm_ffi_matmul_fact(self) -> bool:
-        target_m, target_n, target_k = TCGEN05_TARGET6_TVM_FFI_SHAPE
-        return any(
-            fact.static_m == target_m
-            and fact.static_n == target_n
-            and fact.static_k == target_k
-            and fact.lhs_dtype == torch.bfloat16
-            and fact.rhs_dtype == torch.bfloat16
-            for fact in self.config_spec.matmul_facts
-        )
-
-    def _has_target7_tvm_ffi_matmul_fact(self) -> bool:
-        target_m, target_n, target_k = TCGEN05_TARGET7_TVM_FFI_SHAPE
-        return any(
-            fact.static_m == target_m
-            and fact.static_n == target_n
-            and fact.static_k == target_k
-            and fact.lhs_dtype == torch.bfloat16
-            and fact.rhs_dtype == torch.bfloat16
-            for fact in self.config_spec.matmul_facts
-        )
-
-    def _has_target8_gelu_matmul_fact(self) -> bool:
-        # T8 is fp16-only at the (1536, 6144, 1536) plain-gelu shape. The
-        # fp16 pin is what keeps the seed mutually exclusive with the bf16
-        # gelu MatmulTargets 4 (2048x4096x2048) and 19 (3072x3072x3072) that
-        # share the plain-gelu chain shape detected by
-        # ``host_function_has_tcgen05_gelu_matmul_store_pattern``.
-        target_m, target_n, target_k = TCGEN05_TARGET8_GELU_SHAPE
-        return any(
-            fact.static_m == target_m
-            and fact.static_n == target_n
-            and fact.static_k == target_k
-            and fact.lhs_dtype == torch.float16
-            and fact.rhs_dtype == torch.float16
-            for fact in self.config_spec.matmul_facts
-        )
-
-    def _has_target9_tvm_ffi_matmul_fact(self) -> bool:
-        target_m, target_n, target_k = TCGEN05_TARGET9_TVM_FFI_SHAPE
-        return any(
-            fact.static_m == target_m
-            and fact.static_n == target_n
-            and fact.static_k == target_k
-            and fact.lhs_dtype == torch.bfloat16
-            and fact.rhs_dtype == torch.bfloat16
-            for fact in self.config_spec.matmul_facts
-        )
-
-    def _has_target10_tvm_ffi_matmul_fact(self) -> bool:
-        # T10 admits fp16 and bf16 operands at the square 2048³ bias
-        # shape. ``lhs_dtype == rhs_dtype`` keeps the operand dtype
-        # pinned so the runtime validator can derive the admitted
-        # operand dtype from a single plan field.
-        target_m, target_n, target_k = TCGEN05_TARGET10_TVM_FFI_SHAPE
-        return any(
-            fact.static_m == target_m
-            and fact.static_n == target_n
-            and fact.static_k == target_k
-            and fact.lhs_dtype in (torch.bfloat16, torch.float16)
-            and fact.lhs_dtype == fact.rhs_dtype
-            for fact in self.config_spec.matmul_facts
-        )
-
-    def _target1_tvm_ffi_seed_config(self) -> Config | None:
-        if not self.target1_tvm_ffi_seed_enabled:
-            return None
-        if self.aux_kernel_detected:
-            return None
-        if not self.identity_matmul_store_detected:
-            return None
-        if not self._has_target1_tvm_ffi_matmul_fact():
-            return None
-        constraints = self.cluster_m2_search_constraints
-        if constraints is None or constraints.allow_edge_k_tail_family:
-            return None
-        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
-            return None
-        if len(self.config_spec.block_sizes) != 3:
-            return None
-        if self.config_spec.indexing.length != 3:
-            return None
-        if not self.cluster_m2_bk_is_valid(
-            TCGEN05_TARGET1_TVM_FFI_BLOCK_K, constraints
-        ):
-            return None
-        if not self.ab_stages_three_fits(
-            bm=TCGEN05_TWO_CTA_BLOCK_M,
-            bn=TCGEN05_TWO_CTA_BLOCK_N,
-            bk=TCGEN05_TARGET1_TVM_FFI_BLOCK_K,
-            cluster_m=2,
-            ab_stages=TCGEN05_TARGET1_TVM_FFI_AB_STAGES,
-        ):
-            return None
-        range_count = len(self.config_spec.range_unroll_factors)
-        seed_config: dict[str, Any] = {
-            "block_sizes": [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET1_TVM_FFI_BLOCK_K,
-            ],
-            "indexing": [
-                "tensor_descriptor",
-                "tensor_descriptor",
-                "tensor_descriptor",
-            ],
-            "l2_groupings": [1],
-            "loop_orders": [[0, 1]],
-            "num_stages": 4,
-            "num_warps": 8,
-            "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
-            "range_flattens": [None] * range_count,
-            "range_multi_buffers": [None] * range_count,
-            "range_num_stages": [0] * range_count,
-            "range_unroll_factors": [1] * range_count,
-            "range_warp_specializes": [None] * range_count,
-            "tcgen05_cluster_m": 2,
-            "tcgen05_cluster_n": 1,
-            "tcgen05_ab_stages": TCGEN05_TARGET1_TVM_FFI_AB_STAGES,
-            "tcgen05_acc_stages": 2,
-            "tcgen05_c_stages": TCGEN05_TARGET1_TVM_FFI_C_STAGES,
-            TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY: 1,
-            "tcgen05_num_epi_warps": 4,
-            TCGEN05_STRATEGY_CONFIG_KEY: Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
-            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
-                Tcgen05PersistenceModel.STATIC_PERSISTENT.value
-            ),
-            TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: (
-                Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
-            ),
-            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: 128,
-            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: 32,
-            TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: 32,
-            TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY: True,
-            TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True,
-        }
-        return Config(**seed_config)
-
-    def _target4_tvm_ffi_seed_config(self) -> Config | None:
-        if not self.target4_tvm_ffi_seed_enabled:
-            return None
-        if self.aux_kernel_detected:
-            return None
-        if not self.relu_matmul_store_detected:
-            return None
-        if not self._has_target4_tvm_ffi_matmul_fact():
-            return None
-        constraints = self.cluster_m2_search_constraints
-        if constraints is None or constraints.allow_edge_k_tail_family:
-            return None
-        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
-            return None
-        if len(self.config_spec.block_sizes) != 3:
-            return None
-        if self.config_spec.indexing.length != 3:
-            return None
-        if not self.cluster_m2_bk_is_valid(
-            TCGEN05_TARGET4_TVM_FFI_BLOCK_K, constraints
-        ):
-            return None
-        if not self.ab_stages_three_fits(
-            bm=TCGEN05_TWO_CTA_BLOCK_M,
-            bn=TCGEN05_TWO_CTA_BLOCK_N,
-            bk=TCGEN05_TARGET4_TVM_FFI_BLOCK_K,
-            cluster_m=2,
-            ab_stages=TCGEN05_TARGET4_TVM_FFI_AB_STAGES,
-        ):
-            return None
-        range_count = len(self.config_spec.range_unroll_factors)
-        # ``l2_groupings=[2]`` is the T4 autotune-selected value; keep
-        # ``_is_target4_tvm_ffi_seed_config`` matching and let
-        # ``implicit_default_keys_to_preserve`` retain it across overrides.
-        seed_config: dict[str, Any] = {
-            "block_sizes": [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET4_TVM_FFI_BLOCK_K,
-            ],
-            "indexing": [
-                "tensor_descriptor",
-                "tensor_descriptor",
-                "tensor_descriptor",
-            ],
-            "l2_groupings": [2],
-            "loop_orders": [[0, 1]],
-            "num_stages": 4,
-            "num_warps": 8,
-            "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
-            "range_flattens": [None] * range_count,
-            "range_multi_buffers": [None] * range_count,
-            "range_num_stages": [0] * range_count,
-            "range_unroll_factors": [1] * range_count,
-            "range_warp_specializes": [None] * range_count,
-            "tcgen05_cluster_m": 2,
-            "tcgen05_cluster_n": 1,
-            "tcgen05_ab_stages": TCGEN05_TARGET4_TVM_FFI_AB_STAGES,
-            "tcgen05_acc_stages": 2,
-            "tcgen05_c_stages": TCGEN05_TARGET4_TVM_FFI_C_STAGES,
-            TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY: 1,
-            "tcgen05_num_epi_warps": 4,
-            TCGEN05_STRATEGY_CONFIG_KEY: Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
-            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
-                Tcgen05PersistenceModel.STATIC_PERSISTENT.value
-            ),
-            TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: (
-                Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
-            ),
-            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: 128,
-            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: 32,
-            TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: 32,
-            TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY: True,
-            TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True,
-        }
-        return Config(**seed_config)
-
-    def _target5_tvm_ffi_seed_config(self) -> Config | None:
-        if not self.target5_tvm_ffi_seed_enabled:
-            return None
-        if self.aux_kernel_detected:
-            return None
-        # T5 shares the identity-store gate with T1 but at the T5 shape.
-        # The fact check below distinguishes T1 from T5.
-        if not self.identity_matmul_store_detected:
-            return None
-        if not self._has_target5_tvm_ffi_matmul_fact():
-            return None
-        constraints = self.cluster_m2_search_constraints
-        if constraints is None or constraints.allow_edge_k_tail_family:
-            return None
-        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
-            return None
-        if len(self.config_spec.block_sizes) != 3:
-            return None
-        if self.config_spec.indexing.length != 3:
-            return None
-        if not self.cluster_m2_bk_is_valid(
-            TCGEN05_TARGET5_TVM_FFI_BLOCK_K, constraints
-        ):
-            return None
-        if not self.ab_stages_three_fits(
-            bm=TCGEN05_TWO_CTA_BLOCK_M,
-            bn=TCGEN05_TWO_CTA_BLOCK_N,
-            bk=TCGEN05_TARGET5_TVM_FFI_BLOCK_K,
-            cluster_m=2,
-            ab_stages=TCGEN05_TARGET5_TVM_FFI_AB_STAGES,
-        ):
-            return None
-        range_count = len(self.config_spec.range_unroll_factors)
-        # T5 mirrors T4's seed knobs at the transposed M/N identity-store
-        # shape; ``l2_groupings=[2]`` is inherited pending a T5 sweep.
-        seed_config: dict[str, Any] = {
-            "block_sizes": [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET5_TVM_FFI_BLOCK_K,
-            ],
-            "indexing": [
-                "tensor_descriptor",
-                "tensor_descriptor",
-                "tensor_descriptor",
-            ],
-            "l2_groupings": [2],
-            "loop_orders": [[0, 1]],
-            "num_stages": 4,
-            "num_warps": 8,
-            "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
-            "range_flattens": [None] * range_count,
-            "range_multi_buffers": [None] * range_count,
-            "range_num_stages": [0] * range_count,
-            "range_unroll_factors": [1] * range_count,
-            "range_warp_specializes": [None] * range_count,
-            "tcgen05_cluster_m": 2,
-            "tcgen05_cluster_n": 1,
-            "tcgen05_ab_stages": TCGEN05_TARGET5_TVM_FFI_AB_STAGES,
-            "tcgen05_acc_stages": 2,
-            "tcgen05_c_stages": TCGEN05_TARGET5_TVM_FFI_C_STAGES,
-            TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY: 1,
-            "tcgen05_num_epi_warps": 4,
-            TCGEN05_STRATEGY_CONFIG_KEY: Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
-            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
-                Tcgen05PersistenceModel.STATIC_PERSISTENT.value
-            ),
-            TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: (
-                Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
-            ),
-            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: 128,
-            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: 32,
-            TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: 32,
-            TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY: True,
-            TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True,
-        }
-        return Config(**seed_config)
-
-    def _target2_tvm_ffi_seed_config(self) -> Config | None:
-        if not self.target2_tvm_ffi_seed_enabled:
-            return None
-        # T2's rowvec bias sets ``aux_kernel_detected`` True; the SIMT
-        # aux pipeline doesn't need the c_input_warp/aux-TMA wiring
-        # used by exact-shape rank-2 aux tensors. The bias-store gate
-        # keeps T2 mutually exclusive with identity/relu stores.
-        if not self.bias_matmul_store_detected:
-            return None
-        if not self._has_target2_tvm_ffi_matmul_fact():
-            return None
-        constraints = self.cluster_m2_search_constraints
-        if constraints is None or constraints.allow_edge_k_tail_family:
-            return None
-        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
-            return None
-        if len(self.config_spec.block_sizes) != 3:
-            return None
-        # Accept indexing length 3 (no closure) or 4 (with bias closure).
-        if self.config_spec.indexing.length not in (3, 4):
-            return None
-        if not self.cluster_m2_bk_is_valid(
-            TCGEN05_TARGET2_TVM_FFI_BLOCK_K, constraints
-        ):
-            return None
-        if not self.ab_stages_three_fits(
-            bm=TCGEN05_TWO_CTA_BLOCK_M,
-            bn=TCGEN05_TWO_CTA_BLOCK_N,
-            bk=TCGEN05_TARGET2_TVM_FFI_BLOCK_K,
-            cluster_m=2,
-            ab_stages=TCGEN05_TARGET2_TVM_FFI_AB_STAGES,
-        ):
-            return None
-        range_count = len(self.config_spec.range_unroll_factors)
-        # T2 mirrors T3/T4/T5's seed knobs at the (4096, 2048, 2048)
-        # bias-store shape; ``l2_groupings=[2]`` is inherited pending a
-        # T2 sweep. The 4th indexing slot (bias) uses ``tensor_descriptor``.
-        indexing_length = self.config_spec.indexing.length
-        seed_config: dict[str, Any] = {
-            "block_sizes": [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET2_TVM_FFI_BLOCK_K,
-            ],
-            "indexing": ["tensor_descriptor"] * indexing_length,
-            "l2_groupings": [2],
-            "loop_orders": [[0, 1]],
-            "num_stages": 4,
-            "num_warps": 8,
-            "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
-            "range_flattens": [None] * range_count,
-            "range_multi_buffers": [None] * range_count,
-            "range_num_stages": [0] * range_count,
-            "range_unroll_factors": [1] * range_count,
-            "range_warp_specializes": [None] * range_count,
-            "tcgen05_cluster_m": 2,
-            "tcgen05_cluster_n": 1,
-            "tcgen05_ab_stages": TCGEN05_TARGET2_TVM_FFI_AB_STAGES,
-            "tcgen05_acc_stages": 2,
-            "tcgen05_c_stages": TCGEN05_TARGET2_TVM_FFI_C_STAGES,
-            TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY: 1,
-            "tcgen05_num_epi_warps": 4,
-            TCGEN05_STRATEGY_CONFIG_KEY: Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
-            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
-                Tcgen05PersistenceModel.STATIC_PERSISTENT.value
-            ),
-            TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: (
-                Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
-            ),
-            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: 128,
-            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: 32,
-            TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: 32,
-            TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY: True,
-            TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True,
-        }
-        return Config(**seed_config)
-
-    def _target6_tvm_ffi_seed_config(self) -> Config | None:
-        if not self.target6_tvm_ffi_seed_enabled:
-            return None
-        # T6's rowvec bias + relu sets ``aux_kernel_detected`` True (same
-        # as T2). The bias-relu-store gate keeps T6 mutually exclusive
-        # with identity/relu/bias stores.
-        if not self.bias_relu_matmul_store_detected:
-            return None
-        if not self._has_target6_tvm_ffi_matmul_fact():
-            return None
-        constraints = self.cluster_m2_search_constraints
-        if constraints is None or constraints.allow_edge_k_tail_family:
-            return None
-        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
-            return None
-        if len(self.config_spec.block_sizes) != 3:
-            return None
-        # Accept indexing length 3 (no closure) or 4 (with bias closure).
-        if self.config_spec.indexing.length not in (3, 4):
-            return None
-        if not self.cluster_m2_bk_is_valid(
-            TCGEN05_TARGET6_TVM_FFI_BLOCK_K, constraints
-        ):
-            return None
-        if not self.ab_stages_three_fits(
-            bm=TCGEN05_TWO_CTA_BLOCK_M,
-            bn=TCGEN05_TWO_CTA_BLOCK_N,
-            bk=TCGEN05_TARGET6_TVM_FFI_BLOCK_K,
-            cluster_m=2,
-            ab_stages=TCGEN05_TARGET6_TVM_FFI_AB_STAGES,
-        ):
-            return None
-        range_count = len(self.config_spec.range_unroll_factors)
-        # T6 mirrors T2/T3/T4/T5's seed knobs at the (8192, 2048, 2048)
-        # bias-relu-store shape; ``l2_groupings=[2]`` is inherited pending
-        # a T6 sweep. The 4th indexing slot (bias) uses ``tensor_descriptor``.
-        indexing_length = self.config_spec.indexing.length
-        seed_config: dict[str, Any] = {
-            "block_sizes": [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET6_TVM_FFI_BLOCK_K,
-            ],
-            "indexing": ["tensor_descriptor"] * indexing_length,
-            "l2_groupings": [2],
-            "loop_orders": [[0, 1]],
-            "num_stages": 4,
-            "num_warps": 8,
-            "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
-            "range_flattens": [None] * range_count,
-            "range_multi_buffers": [None] * range_count,
-            "range_num_stages": [0] * range_count,
-            "range_unroll_factors": [1] * range_count,
-            "range_warp_specializes": [None] * range_count,
-            "tcgen05_cluster_m": 2,
-            "tcgen05_cluster_n": 1,
-            "tcgen05_ab_stages": TCGEN05_TARGET6_TVM_FFI_AB_STAGES,
-            "tcgen05_acc_stages": 2,
-            "tcgen05_c_stages": TCGEN05_TARGET6_TVM_FFI_C_STAGES,
-            TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY: 1,
-            "tcgen05_num_epi_warps": 4,
-            TCGEN05_STRATEGY_CONFIG_KEY: Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
-            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
-                Tcgen05PersistenceModel.STATIC_PERSISTENT.value
-            ),
-            TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: (
-                Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
-            ),
-            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: 128,
-            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: 32,
-            TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: 32,
-            TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY: True,
-            TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True,
-        }
-        return Config(**seed_config)
-
-    def _target3_tvm_ffi_seed_config(self) -> Config | None:
-        if not self.target3_tvm_ffi_seed_enabled:
-            return None
-        if self.aux_kernel_detected:
-            return None
-        # T3 shares the identity-store gate with T1/T5 but at the T3
-        # shape. The fact check below distinguishes T3 from T1/T5.
-        if not self.identity_matmul_store_detected:
-            return None
-        if not self._has_target3_tvm_ffi_matmul_fact():
-            return None
-        constraints = self.cluster_m2_search_constraints
-        if constraints is None or constraints.allow_edge_k_tail_family:
-            return None
-        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
-            return None
-        if len(self.config_spec.block_sizes) != 3:
-            return None
-        if self.config_spec.indexing.length != 3:
-            return None
-        if not self.cluster_m2_bk_is_valid(
-            TCGEN05_TARGET3_TVM_FFI_BLOCK_K, constraints
-        ):
-            return None
-        if not self.ab_stages_three_fits(
-            bm=TCGEN05_TWO_CTA_BLOCK_M,
-            bn=TCGEN05_TWO_CTA_BLOCK_N,
-            bk=TCGEN05_TARGET3_TVM_FFI_BLOCK_K,
-            cluster_m=2,
-            ab_stages=TCGEN05_TARGET3_TVM_FFI_AB_STAGES,
-        ):
-            return None
-        range_count = len(self.config_spec.range_unroll_factors)
-        # T3 mirrors T4/T5's seed knobs at the larger 2048x4096x2048
-        # identity-store shape; ``l2_groupings=[2]`` is inherited pending
-        # a T3 sweep.
-        seed_config: dict[str, Any] = {
-            "block_sizes": [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET3_TVM_FFI_BLOCK_K,
-            ],
-            "indexing": [
-                "tensor_descriptor",
-                "tensor_descriptor",
-                "tensor_descriptor",
-            ],
-            "l2_groupings": [2],
-            "loop_orders": [[0, 1]],
-            "num_stages": 4,
-            "num_warps": 8,
-            "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
-            "range_flattens": [None] * range_count,
-            "range_multi_buffers": [None] * range_count,
-            "range_num_stages": [0] * range_count,
-            "range_unroll_factors": [1] * range_count,
-            "range_warp_specializes": [None] * range_count,
-            "tcgen05_cluster_m": 2,
-            "tcgen05_cluster_n": 1,
-            "tcgen05_ab_stages": TCGEN05_TARGET3_TVM_FFI_AB_STAGES,
-            "tcgen05_acc_stages": 2,
-            "tcgen05_c_stages": TCGEN05_TARGET3_TVM_FFI_C_STAGES,
-            TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY: 1,
-            "tcgen05_num_epi_warps": 4,
-            TCGEN05_STRATEGY_CONFIG_KEY: Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
-            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
-                Tcgen05PersistenceModel.STATIC_PERSISTENT.value
-            ),
-            TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: (
-                Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
-            ),
-            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: 128,
-            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: 32,
-            TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: 32,
-            TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY: True,
-            TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True,
-        }
-        return Config(**seed_config)
-
-    def _target7_tvm_ffi_seed_config(self) -> Config | None:
-        if not self.target7_tvm_ffi_seed_enabled:
-            return None
-        if self.aux_kernel_detected:
-            return None
-        # T7 shares the identity-store gate with T1/T3/T5 but at the T7
-        # shape. The fact check below distinguishes T7 from T1/T3/T5.
-        if not self.identity_matmul_store_detected:
-            return None
-        if not self._has_target7_tvm_ffi_matmul_fact():
-            return None
-        constraints = self.cluster_m2_search_constraints
-        if constraints is None or constraints.allow_edge_k_tail_family:
-            return None
-        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
-            return None
-        if len(self.config_spec.block_sizes) != 3:
-            return None
-        if self.config_spec.indexing.length != 3:
-            return None
-        if not self.cluster_m2_bk_is_valid(
-            TCGEN05_TARGET7_TVM_FFI_BLOCK_K, constraints
-        ):
-            return None
-        if not self.ab_stages_three_fits(
-            bm=TCGEN05_TWO_CTA_BLOCK_M,
-            bn=TCGEN05_TWO_CTA_BLOCK_N,
-            bk=TCGEN05_TARGET7_TVM_FFI_BLOCK_K,
-            cluster_m=2,
-            ab_stages=TCGEN05_TARGET7_TVM_FFI_AB_STAGES,
-        ):
-            return None
-        range_count = len(self.config_spec.range_unroll_factors)
-        # T7 mirrors T3/T4/T5's seed knobs at the larger 2048x8192x2048
-        # identity-store shape; ``l2_groupings=[2]`` is inherited pending
-        # a T7 sweep.
-        seed_config: dict[str, Any] = {
-            "block_sizes": [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET7_TVM_FFI_BLOCK_K,
-            ],
-            "indexing": [
-                "tensor_descriptor",
-                "tensor_descriptor",
-                "tensor_descriptor",
-            ],
-            "l2_groupings": [2],
-            "loop_orders": [[0, 1]],
-            "num_stages": 4,
-            "num_warps": 8,
-            "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
-            "range_flattens": [None] * range_count,
-            "range_multi_buffers": [None] * range_count,
-            "range_num_stages": [0] * range_count,
-            "range_unroll_factors": [1] * range_count,
-            "range_warp_specializes": [None] * range_count,
-            "tcgen05_cluster_m": 2,
-            "tcgen05_cluster_n": 1,
-            "tcgen05_ab_stages": TCGEN05_TARGET7_TVM_FFI_AB_STAGES,
-            "tcgen05_acc_stages": 2,
-            "tcgen05_c_stages": TCGEN05_TARGET7_TVM_FFI_C_STAGES,
-            TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY: 1,
-            "tcgen05_num_epi_warps": 4,
-            TCGEN05_STRATEGY_CONFIG_KEY: Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
-            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
-                Tcgen05PersistenceModel.STATIC_PERSISTENT.value
-            ),
-            TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: (
-                Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
-            ),
-            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: 128,
-            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: 32,
-            TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: 32,
-            TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY: True,
-            TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True,
-        }
-        return Config(**seed_config)
-
-    def _target8_gelu_seed_config(self) -> Config | None:
-        if not self.target8_gelu_seed_enabled:
-            return None
-        # T8 (cycle 87, MatmulTarget 27) is a plain ``gelu(acc)`` store with
-        # no auxiliary tensor at the (1536, 6144, 1536) fp16 shape. Unlike the
-        # bf16 two-CTA seeds (T1-T9) and the T10 fp16 bias seed, T8 uses the
-        # DEFAULT epilogue layout and the normal (non-FFI) launch path: the
-        # ``explicit_epi_tile`` overrides + ``tvm_ffi_launch`` / flat-role
-        # codegen path is gated bf16-only (and fp16 only for the T10 2048³
-        # bias envelope) in ``cute_mma.py`` ``_emit_mma_pipeline``, so it
-        # rejects a fp16 gelu store. The cycle-86/87 force-config win
-        # (``256x256x128, ab=3``, ~649 TF mom-median) was measured on this
-        # plain default-layout config, so the seed reproduces exactly that.
-        # The plain-gelu-store gate keeps it mutually exclusive with
-        # identity/relu/bias/bias_relu stores; the fp16-pinned shape fact
-        # keeps it mutually exclusive with the bf16 gelu MatmulTargets 4/19
-        # that share the chain shape.
-        if self.aux_kernel_detected:
-            return None
-        if not self.gelu_matmul_store_detected:
-            return None
-        if not self._has_target8_gelu_matmul_fact():
-            return None
-        constraints = self.cluster_m2_search_constraints
-        if constraints is None or constraints.allow_edge_k_tail_family:
-            return None
-        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
-            return None
-        if len(self.config_spec.block_sizes) != 3:
-            return None
-        if self.config_spec.indexing.length != 3:
-            return None
-        if not self.cluster_m2_bk_is_valid(TCGEN05_TARGET8_GELU_BLOCK_K, constraints):
-            return None
-        if not self.ab_stages_three_fits(
-            bm=TCGEN05_TWO_CTA_BLOCK_M,
-            bn=TCGEN05_TWO_CTA_BLOCK_N,
-            bk=TCGEN05_TARGET8_GELU_BLOCK_K,
-            cluster_m=2,
-            ab_stages=TCGEN05_TARGET8_GELU_AB_STAGES,
-        ):
-            return None
-        range_count = len(self.config_spec.range_unroll_factors)
-        # T8 uses the validated two-CTA tile/stage envelope (256x256x128,
-        # ab=3, acc=2, c=2, cluster_m=2) at the DEFAULT epilogue layout;
-        # ``l2_groupings=[2]`` is inherited from the two-CTA envelope pending
-        # a dedicated T8 sweep.
-        seed_config: dict[str, Any] = {
-            "block_sizes": [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET8_GELU_BLOCK_K,
-            ],
-            "indexing": [
-                "tensor_descriptor",
-                "tensor_descriptor",
-                "tensor_descriptor",
-            ],
-            "l2_groupings": [2],
-            "loop_orders": [[0, 1]],
-            "num_stages": 4,
-            "num_warps": 8,
-            "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
-            "range_flattens": [None] * range_count,
-            "range_multi_buffers": [None] * range_count,
-            "range_num_stages": [0] * range_count,
-            "range_unroll_factors": [1] * range_count,
-            "range_warp_specializes": [None] * range_count,
-            "tcgen05_cluster_m": 2,
-            "tcgen05_cluster_n": 1,
-            "tcgen05_ab_stages": TCGEN05_TARGET8_GELU_AB_STAGES,
-            "tcgen05_acc_stages": 2,
-            "tcgen05_c_stages": TCGEN05_TARGET8_GELU_C_STAGES,
-            TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY: 1,
-            "tcgen05_num_epi_warps": 4,
-            TCGEN05_STRATEGY_CONFIG_KEY: Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
-            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
-                Tcgen05PersistenceModel.STATIC_PERSISTENT.value
-            ),
-        }
-        return Config(**seed_config)
-
-    def _target10_tvm_ffi_seed_config(self) -> Config | None:
-        if not self.target10_tvm_ffi_seed_enabled:
-            return None
-        # T10's rowvec bias sets ``aux_kernel_detected`` True (same as T2).
-        # The bias-store gate (bf16 or fp16 variant) keeps T10 mutually
-        # exclusive with identity/relu/bias_relu stores.
-        if not (
-            self.bias_matmul_store_detected or self.bias_matmul_store_fp16_detected
-        ):
-            return None
-        if not self._has_target10_tvm_ffi_matmul_fact():
-            return None
-        constraints = self.cluster_m2_search_constraints
-        if constraints is None or constraints.allow_edge_k_tail_family:
-            return None
-        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
-            return None
-        if len(self.config_spec.block_sizes) != 3:
-            return None
-        # Accept indexing length 3 (no closure) or 4 (with bias closure).
-        if self.config_spec.indexing.length not in (3, 4):
-            return None
-        if not self.cluster_m2_bk_is_valid(
-            TCGEN05_TARGET10_TVM_FFI_BLOCK_K, constraints
-        ):
-            return None
-        if not self.ab_stages_three_fits(
-            bm=TCGEN05_TWO_CTA_BLOCK_M,
-            bn=TCGEN05_TWO_CTA_BLOCK_N,
-            bk=TCGEN05_TARGET10_TVM_FFI_BLOCK_K,
-            cluster_m=2,
-            ab_stages=TCGEN05_TARGET10_TVM_FFI_AB_STAGES,
-        ):
-            return None
-        range_count = len(self.config_spec.range_unroll_factors)
-        # Cycle-41 force-config measurements (see cycle 42 task brief):
-        # role_local_monolithic + c_input=0 + l2_groupings=[2] + ab=3
-        # measured 742.4 TF / +3.7% gap vs Quack's 770.9 TF on the T22
-        # (2048³ fp16 bias) target, closing 21pp of the previous gap.
-        # The cycle 40 alternative (ab=2 + role_local_with_sched +
-        # c_input=1 + l2_groupings=[2]) measured at HEAD level (640 TF),
-        # so we explicitly stay on monolithic + c_input=0 here.
-        indexing_length = self.config_spec.indexing.length
-        seed_config: dict[str, Any] = {
-            "block_sizes": [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET10_TVM_FFI_BLOCK_K,
-            ],
-            "indexing": ["tensor_descriptor"] * indexing_length,
-            "l2_groupings": [2],
-            "loop_orders": [[0, 1]],
-            "num_stages": 4,
-            "num_warps": 8,
-            "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
-            "range_flattens": [None] * range_count,
-            "range_multi_buffers": [None] * range_count,
-            "range_num_stages": [0] * range_count,
-            "range_unroll_factors": [1] * range_count,
-            "range_warp_specializes": [None] * range_count,
-            "tcgen05_cluster_m": 2,
-            "tcgen05_cluster_n": 1,
-            "tcgen05_ab_stages": TCGEN05_TARGET10_TVM_FFI_AB_STAGES,
-            "tcgen05_acc_stages": 2,
-            "tcgen05_c_stages": TCGEN05_TARGET10_TVM_FFI_C_STAGES,
-            TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY: 1,
-            "tcgen05_num_epi_warps": 4,
-            TCGEN05_STRATEGY_CONFIG_KEY: Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
-            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
-                Tcgen05PersistenceModel.STATIC_PERSISTENT.value
-            ),
-            TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: (
-                Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
-            ),
-            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: 128,
-            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: 32,
-            TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: 32,
-            TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY: True,
-            TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True,
-        }
-        return Config(**seed_config)
-
-    def _target9_tvm_ffi_seed_config(self) -> Config | None:
-        if not self.target9_tvm_ffi_seed_enabled:
-            return None
-        if self.aux_kernel_detected:
-            return None
-        # T9 shares the identity-store gate with T1/T3/T5/T7 but at the
-        # T9 shape. The fact check below distinguishes T9 from T1/T3/T5/T7.
-        if not self.identity_matmul_store_detected:
-            return None
-        if not self._has_target9_tvm_ffi_matmul_fact():
-            return None
-        constraints = self.cluster_m2_search_constraints
-        if constraints is None or constraints.allow_edge_k_tail_family:
-            return None
-        if TCGEN05_TWO_CTA_SEED_PID_TYPE not in self.allowed_pid_types:
-            return None
-        if len(self.config_spec.block_sizes) != 3:
-            return None
-        if self.config_spec.indexing.length != 3:
-            return None
-        if not self.cluster_m2_bk_is_valid(
-            TCGEN05_TARGET9_TVM_FFI_BLOCK_K, constraints
-        ):
-            return None
-        if not self.ab_stages_three_fits(
-            bm=TCGEN05_TWO_CTA_BLOCK_M,
-            bn=TCGEN05_TWO_CTA_BLOCK_N,
-            bk=TCGEN05_TARGET9_TVM_FFI_BLOCK_K,
-            cluster_m=2,
-            ab_stages=TCGEN05_TARGET9_TVM_FFI_AB_STAGES,
-        ):
-            return None
-        range_count = len(self.config_spec.range_unroll_factors)
-        # T9 mirrors T3/T5/T7's seed knobs at the square 2048x2048x2048
-        # identity-store shape; ``l2_groupings=[2]`` is inherited pending
-        # a T9 sweep.
-        seed_config: dict[str, Any] = {
-            "block_sizes": [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET9_TVM_FFI_BLOCK_K,
-            ],
-            "indexing": [
-                "tensor_descriptor",
-                "tensor_descriptor",
-                "tensor_descriptor",
-            ],
-            "l2_groupings": [2],
-            "loop_orders": [[0, 1]],
-            "num_stages": 4,
-            "num_warps": 8,
-            "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
-            "range_flattens": [None] * range_count,
-            "range_multi_buffers": [None] * range_count,
-            "range_num_stages": [0] * range_count,
-            "range_unroll_factors": [1] * range_count,
-            "range_warp_specializes": [None] * range_count,
-            "tcgen05_cluster_m": 2,
-            "tcgen05_cluster_n": 1,
-            "tcgen05_ab_stages": TCGEN05_TARGET9_TVM_FFI_AB_STAGES,
-            "tcgen05_acc_stages": 2,
-            "tcgen05_c_stages": TCGEN05_TARGET9_TVM_FFI_C_STAGES,
-            TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY: 1,
-            "tcgen05_num_epi_warps": 4,
-            TCGEN05_STRATEGY_CONFIG_KEY: Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
-            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
-                Tcgen05PersistenceModel.STATIC_PERSISTENT.value
-            ),
-            TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: (
-                Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
-            ),
-            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY: 128,
-            TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY: 32,
-            TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY: 32,
-            TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY: True,
-            TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True,
-        }
-        return Config(**seed_config)
-
     def autotune_seed_configs(self) -> list[Config]:
         seeds: list[Config] = []
-        target1_tvm_ffi_seed = self._target1_tvm_ffi_seed_config()
-        if target1_tvm_ffi_seed is not None:
-            seeds.append(target1_tvm_ffi_seed)
-        target2_tvm_ffi_seed = self._target2_tvm_ffi_seed_config()
-        if target2_tvm_ffi_seed is not None:
-            seeds.append(target2_tvm_ffi_seed)
-        target3_tvm_ffi_seed = self._target3_tvm_ffi_seed_config()
-        if target3_tvm_ffi_seed is not None:
-            seeds.append(target3_tvm_ffi_seed)
-        target4_tvm_ffi_seed = self._target4_tvm_ffi_seed_config()
-        if target4_tvm_ffi_seed is not None:
-            seeds.append(target4_tvm_ffi_seed)
-        target5_tvm_ffi_seed = self._target5_tvm_ffi_seed_config()
-        if target5_tvm_ffi_seed is not None:
-            seeds.append(target5_tvm_ffi_seed)
-        target6_tvm_ffi_seed = self._target6_tvm_ffi_seed_config()
-        if target6_tvm_ffi_seed is not None:
-            seeds.append(target6_tvm_ffi_seed)
-        target7_tvm_ffi_seed = self._target7_tvm_ffi_seed_config()
-        if target7_tvm_ffi_seed is not None:
-            seeds.append(target7_tvm_ffi_seed)
-        target8_gelu_seed = self._target8_gelu_seed_config()
-        if target8_gelu_seed is not None:
-            seeds.append(target8_gelu_seed)
-        target9_tvm_ffi_seed = self._target9_tvm_ffi_seed_config()
-        if target9_tvm_ffi_seed is not None:
-            seeds.append(target9_tvm_ffi_seed)
-        target10_tvm_ffi_seed = self._target10_tvm_ffi_seed_config()
-        if target10_tvm_ffi_seed is not None:
-            seeds.append(target10_tvm_ffi_seed)
         c_input_seed = self._c_input_seed_config()
         if c_input_seed is not None:
             seeds.append(c_input_seed)
@@ -2140,8 +1073,8 @@ class CuteTcgen05Config:
         # monolithic-ab=3 SIMT region (T20 reliably) or randomly lands on a
         # catastrophic SIMT cluster_m=2 pick (T25 variance: 756 aux-TMA vs 286
         # SIMT), so the +2.4-14 pp aux-TMA gain is not banked deterministically.
-        # This is the aux-TMA analogue of the cycle-87
-        # ``_fix_target8_gelu_search_config`` projection. Tightly bounded:
+        # This is the aux-TMA analogue of the FFI direct-entry search
+        # projection (``_fix_target1_tvm_ffi_search_config``). Tightly bounded:
         # cluster_m=1 candidates are left untouched (search still explores
         # them), the edge+K-tail T12 family keeps its own
         # ``_aux_tma_edge_search_enabled`` CLC path, and the gate fires only
@@ -2251,31 +1184,6 @@ class CuteTcgen05Config:
         return self._is_validated_clc_persistence_search_candidate(projected_config)
 
     def implicit_default_keys_to_preserve(self, config: dict[str, object]) -> set[str]:
-        if (
-            self._is_target1_tvm_ffi_seed_config(config)
-            or self._is_target2_tvm_ffi_seed_config(config)
-            or self._is_target3_tvm_ffi_seed_config(config)
-            or self._is_target4_tvm_ffi_seed_config(config)
-            or self._is_target5_tvm_ffi_seed_config(config)
-            or self._is_target6_tvm_ffi_seed_config(config)
-            or self._is_target7_tvm_ffi_seed_config(config)
-            or self._is_target8_gelu_seed_config(config)
-            or self._is_target9_tvm_ffi_seed_config(config)
-            or self._is_target10_tvm_ffi_seed_config(config)
-        ):
-            return {
-                "indexing",
-                "l2_groupings",
-                "loop_orders",
-                "num_stages",
-                "num_warps",
-                "pid_type",
-                "range_flattens",
-                "range_multi_buffers",
-                "range_num_stages",
-                "range_unroll_factors",
-                "range_warp_specializes",
-            }
         if not self._is_clc_aux_tma_config(config):
             return set()
         preserve_keys = {"l2_groupings"}
@@ -2289,260 +1197,36 @@ class CuteTcgen05Config:
             )
         return preserve_keys
 
-    @staticmethod
-    def _is_target1_tvm_ffi_seed_config(config: dict[str, object]) -> bool:
-        return (
-            config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is True
-            and config.get(TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY) is True
-            and config.get("block_sizes")
-            == [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET1_TVM_FFI_BLOCK_K,
-            ]
-            and config.get("tcgen05_ab_stages") == TCGEN05_TARGET1_TVM_FFI_AB_STAGES
-            and config.get("tcgen05_c_stages") == TCGEN05_TARGET1_TVM_FFI_C_STAGES
-            and config.get("tcgen05_cluster_m") == 2
-            and config.get("tcgen05_cluster_n") == 1
-            and config.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY)
-            == Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY) == 128
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY) == 32
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY) == 32
-        )
-
-    @staticmethod
-    def _is_target4_tvm_ffi_seed_config(config: dict[str, object]) -> bool:
-        return (
-            config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is True
-            and config.get(TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY) is True
-            and config.get("block_sizes")
-            == [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET4_TVM_FFI_BLOCK_K,
-            ]
-            and config.get("tcgen05_ab_stages") == TCGEN05_TARGET4_TVM_FFI_AB_STAGES
-            and config.get("tcgen05_c_stages") == TCGEN05_TARGET4_TVM_FFI_C_STAGES
-            and config.get("tcgen05_cluster_m") == 2
-            and config.get("tcgen05_cluster_n") == 1
-            and config.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY)
-            == Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY) == 128
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY) == 32
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY) == 32
-        )
-
-    @staticmethod
-    def _is_target5_tvm_ffi_seed_config(config: dict[str, object]) -> bool:
-        # T5 mirrors T4 at the bk=128 stage tuple (shape gated upstream).
-        return (
-            config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is True
-            and config.get(TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY) is True
-            and config.get("block_sizes")
-            == [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET5_TVM_FFI_BLOCK_K,
-            ]
-            and config.get("tcgen05_ab_stages") == TCGEN05_TARGET5_TVM_FFI_AB_STAGES
-            and config.get("tcgen05_c_stages") == TCGEN05_TARGET5_TVM_FFI_C_STAGES
-            and config.get("tcgen05_cluster_m") == 2
-            and config.get("tcgen05_cluster_n") == 1
-            and config.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY)
-            == Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY) == 128
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY) == 32
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY) == 32
-        )
-
-    @staticmethod
-    def _is_target2_tvm_ffi_seed_config(config: dict[str, object]) -> bool:
-        # T2 mirrors T3/T4/T5 at the bk=128 stage tuple; the bias-store
-        # gate happens upstream in ``_target2_tvm_ffi_seed_config``.
-        return (
-            config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is True
-            and config.get(TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY) is True
-            and config.get("block_sizes")
-            == [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET2_TVM_FFI_BLOCK_K,
-            ]
-            and config.get("tcgen05_ab_stages") == TCGEN05_TARGET2_TVM_FFI_AB_STAGES
-            and config.get("tcgen05_c_stages") == TCGEN05_TARGET2_TVM_FFI_C_STAGES
-            and config.get("tcgen05_cluster_m") == 2
-            and config.get("tcgen05_cluster_n") == 1
-            and config.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY)
-            == Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY) == 128
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY) == 32
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY) == 32
-        )
-
-    @staticmethod
-    def _is_target3_tvm_ffi_seed_config(config: dict[str, object]) -> bool:
-        # T3 mirrors T4/T5 at the bk=128 stage tuple; the identity-store
-        # gate happens upstream in ``_target3_tvm_ffi_seed_config``.
-        return (
-            config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is True
-            and config.get(TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY) is True
-            and config.get("block_sizes")
-            == [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET3_TVM_FFI_BLOCK_K,
-            ]
-            and config.get("tcgen05_ab_stages") == TCGEN05_TARGET3_TVM_FFI_AB_STAGES
-            and config.get("tcgen05_c_stages") == TCGEN05_TARGET3_TVM_FFI_C_STAGES
-            and config.get("tcgen05_cluster_m") == 2
-            and config.get("tcgen05_cluster_n") == 1
-            and config.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY)
-            == Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY) == 128
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY) == 32
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY) == 32
-        )
-
-    @staticmethod
-    def _is_target6_tvm_ffi_seed_config(config: dict[str, object]) -> bool:
-        # T6 mirrors T2/T3/T4/T5 at the bk=128 stage tuple; the
-        # bias-relu-store gate happens upstream.
-        return (
-            config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is True
-            and config.get(TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY) is True
-            and config.get("block_sizes")
-            == [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET6_TVM_FFI_BLOCK_K,
-            ]
-            and config.get("tcgen05_ab_stages") == TCGEN05_TARGET6_TVM_FFI_AB_STAGES
-            and config.get("tcgen05_c_stages") == TCGEN05_TARGET6_TVM_FFI_C_STAGES
-            and config.get("tcgen05_cluster_m") == 2
-            and config.get("tcgen05_cluster_n") == 1
-            and config.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY)
-            == Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY) == 128
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY) == 32
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY) == 32
-        )
-
-    @staticmethod
-    def _is_target7_tvm_ffi_seed_config(config: dict[str, object]) -> bool:
-        # T7 mirrors T3/T4/T5/T6 at the bk=128 stage tuple; the
-        # identity-store gate happens upstream.
-        return (
-            config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is True
-            and config.get(TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY) is True
-            and config.get("block_sizes")
-            == [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET7_TVM_FFI_BLOCK_K,
-            ]
-            and config.get("tcgen05_ab_stages") == TCGEN05_TARGET7_TVM_FFI_AB_STAGES
-            and config.get("tcgen05_c_stages") == TCGEN05_TARGET7_TVM_FFI_C_STAGES
-            and config.get("tcgen05_cluster_m") == 2
-            and config.get("tcgen05_cluster_n") == 1
-            and config.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY)
-            == Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY) == 128
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY) == 32
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY) == 32
-        )
-
-    @staticmethod
-    def _is_target8_gelu_seed_config(config: dict[str, object]) -> bool:
-        # T8 (cycle 87, MatmulTarget 27) is the lone fp16 gelu two-CTA seed
-        # that uses the DEFAULT epilogue layout and the normal (non-FFI)
-        # launch path (the explicit-epi-tile / FFI codegen path is bf16-only
-        # except for the T10 fp16 bias envelope). The matcher therefore pins
-        # the validated two-CTA tile/stage envelope at the DEFAULT layout
-        # (no tvm_ffi_launch, no flat-role, no epi-tile overrides). The
-        # plain-gelu-store gate happens upstream.
-        return (
-            config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is not True
-            and config.get(TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY) is not True
-            and config.get("block_sizes")
-            == [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET8_GELU_BLOCK_K,
-            ]
-            and config.get("tcgen05_ab_stages") == TCGEN05_TARGET8_GELU_AB_STAGES
-            and config.get("tcgen05_c_stages") == TCGEN05_TARGET8_GELU_C_STAGES
-            and config.get("tcgen05_cluster_m") == 2
-            and config.get("tcgen05_cluster_n") == 1
-            and config.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY)
-            in (None, Tcgen05LayoutStrategy.DEFAULT.value)
-        )
-
-    @staticmethod
-    def _is_target9_tvm_ffi_seed_config(config: dict[str, object]) -> bool:
-        # T9 mirrors T3/T4/T5/T6/T7 at the bk=128 stage tuple; the
-        # identity-store gate happens upstream.
-        return (
-            config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is True
-            and config.get(TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY) is True
-            and config.get("block_sizes")
-            == [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET9_TVM_FFI_BLOCK_K,
-            ]
-            and config.get("tcgen05_ab_stages") == TCGEN05_TARGET9_TVM_FFI_AB_STAGES
-            and config.get("tcgen05_c_stages") == TCGEN05_TARGET9_TVM_FFI_C_STAGES
-            and config.get("tcgen05_cluster_m") == 2
-            and config.get("tcgen05_cluster_n") == 1
-            and config.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY)
-            == Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY) == 128
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY) == 32
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY) == 32
-        )
-
-    @staticmethod
-    def _is_target10_tvm_ffi_seed_config(config: dict[str, object]) -> bool:
-        # T10 mirrors T2's bias-store envelope at the bk=128 stage tuple
-        # with cycle-41's validated knobs (role_local_monolithic,
-        # l2_groupings=[2], ab=3). Shape + bias-store dtype gates happen
-        # upstream in ``_target10_tvm_ffi_seed_config``.
-        return (
-            config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is True
-            and config.get(TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY) is True
-            and config.get("block_sizes")
-            == [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET10_TVM_FFI_BLOCK_K,
-            ]
-            and config.get("tcgen05_ab_stages") == TCGEN05_TARGET10_TVM_FFI_AB_STAGES
-            and config.get("tcgen05_c_stages") == TCGEN05_TARGET10_TVM_FFI_C_STAGES
-            and config.get("tcgen05_cluster_m") == 2
-            and config.get("tcgen05_cluster_n") == 1
-            and config.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY)
-            == Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY) == 128
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY) == 32
-            and config.get(TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY) == 32
-        )
-
     def _validate_target1_ab_stage_envelope(
         self, config: dict[str, object], *, fix_invalid: bool
     ) -> None:
         ab_stages = config.get("tcgen05_ab_stages")
         if type(ab_stages) is not int or ab_stages <= 3:
             return
-        if self._is_target1_tvm_ffi_seed_config(config):
+        # ab>3 is only valid on the TVM-FFI direct-entry path, and only for the
+        # (bk, ab, c) stage tuples the direct-entry codegen accepts (bk=64
+        # admits (ab=6, c=4)). Everything else clamps (or rejects) to ab=3.
+        block_sizes = config.get("block_sizes")
+        bk = (
+            block_sizes[2]
+            if isinstance(block_sizes, list) and len(block_sizes) >= 3
+            else None
+        )
+        c_stages = config.get("tcgen05_c_stages")
+        if (
+            config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is True
+            and isinstance(bk, int)
+            and not isinstance(bk, bool)
+            and type(c_stages) is int
+            and tcgen05_direct_entry_stage_tuple_allowed(
+                bk=bk, ab_stage_count=ab_stages, c_stage_count=c_stages
+            )
+        ):
             return
         if fix_invalid:
             config["tcgen05_ab_stages"] = 3
             return
-        raise InvalidConfig(
-            "tcgen05_ab_stages > 3 is only supported by the validated "
-            "Target1 TVM-FFI seed"
-        )
+        raise InvalidConfig("tcgen05_ab_stages > 3 is not supported")
 
     def _is_validated_clc_persistence_search_candidate(
         self, config: dict[str, object]
@@ -2984,28 +1668,15 @@ class CuteTcgen05Config:
             num_epi_warps_fragment = EnumFragment(self.num_epi_warps_validation_choices)
         else:
             num_epi_warps_fragment = IntegerFragment(1, 4, 4)
-        if not for_search and self._target1_tvm_ffi_seed_config() is not None:
-            ab_stages_max = TCGEN05_TARGET1_TVM_FFI_AB_STAGES
-        elif not for_search and self._target2_tvm_ffi_seed_config() is not None:
-            ab_stages_max = max(3, TCGEN05_TARGET2_TVM_FFI_AB_STAGES)
-        elif not for_search and self._target3_tvm_ffi_seed_config() is not None:
-            ab_stages_max = max(3, TCGEN05_TARGET3_TVM_FFI_AB_STAGES)
-        elif not for_search and self._target4_tvm_ffi_seed_config() is not None:
-            ab_stages_max = max(3, TCGEN05_TARGET4_TVM_FFI_AB_STAGES)
-        elif not for_search and self._target5_tvm_ffi_seed_config() is not None:
-            ab_stages_max = max(3, TCGEN05_TARGET5_TVM_FFI_AB_STAGES)
-        elif not for_search and self._target6_tvm_ffi_seed_config() is not None:
-            ab_stages_max = max(3, TCGEN05_TARGET6_TVM_FFI_AB_STAGES)
-        elif not for_search and self._target7_tvm_ffi_seed_config() is not None:
-            ab_stages_max = max(3, TCGEN05_TARGET7_TVM_FFI_AB_STAGES)
-        elif not for_search and self._target8_gelu_seed_config() is not None:
-            ab_stages_max = max(3, TCGEN05_TARGET8_GELU_AB_STAGES)
-        elif not for_search and self._target9_tvm_ffi_seed_config() is not None:
-            ab_stages_max = max(3, TCGEN05_TARGET9_TVM_FFI_AB_STAGES)
-        elif not for_search and self._target10_tvm_ffi_seed_config() is not None:
-            ab_stages_max = max(3, TCGEN05_TARGET10_TVM_FFI_AB_STAGES)
-        elif not for_search:
-            ab_stages_max = 3
+        if not for_search:
+            # Validation admits what the direct-entry codegen supports: bk=64
+            # accepts the deep (ab=6, c=4) tuple (see
+            # ``TCGEN05_DIRECT_ENTRY_STAGE_TUPLES_BY_BK``), so the validation
+            # surface lifts the AB cap to 6 for FFI-eligible shapes. The actual
+            # (bk, ab, c) tuple is gated by ``_validate_target1_ab_stage_envelope``;
+            # SEARCH stays capped at 3 (budget-aware) since the generalized seed
+            # runs at ab=3 and deeper pipelines are not worth searching.
+            ab_stages_max = 6 if self.full_tile_direct_entry_seed_eligible() else 3
         elif self.ab_stages_three_search_constraints is not None:
             # Cycle 97: make ab=3 BUDGET-AWARE-SEARCHABLE. Where the device/dtype
             # admits ab=3 at all (the SMEM-budget constraints were recorded by
@@ -3034,17 +1705,7 @@ class CuteTcgen05Config:
             "tcgen05_num_epi_warps": num_epi_warps_fragment,
             TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY: EnumFragment(l2_swizzle_choices),
         }
-        if (
-            self._target1_tvm_ffi_seed_config() is not None
-            or self._target2_tvm_ffi_seed_config() is not None
-            or self._target3_tvm_ffi_seed_config() is not None
-            or self._target4_tvm_ffi_seed_config() is not None
-            or self._target5_tvm_ffi_seed_config() is not None
-            or self._target6_tvm_ffi_seed_config() is not None
-            or self._target7_tvm_ffi_seed_config() is not None
-            or self._target9_tvm_ffi_seed_config() is not None
-            or self._target10_tvm_ffi_seed_config() is not None
-        ):
+        if self.full_tile_direct_entry_seed_eligible():
             # Search collapses the FFI-launch knob to a single True
             # choice — the runtime now always enables FFI, so the
             # autotuner only needs to explore the True arm to keep the
@@ -3104,32 +1765,11 @@ class CuteTcgen05Config:
                 config.pop(key, None)
 
     def _fix_target1_tvm_ffi_search_config(self, config: dict[str, object]) -> None:
-        # T1-T7 plus T9-T10 share the TVM-FFI direct-entry promotion surface;
-        # pick the seed matching the detected (shape, store) so search
-        # candidates project onto the right envelope. The shape+store gates
-        # are mutually exclusive so at most one seed is non-None. (T8 is
-        # deliberately not in this list — see the note after the chain below.)
-        seed = self._target1_tvm_ffi_seed_config()
-        if seed is None:
-            seed = self._target2_tvm_ffi_seed_config()
-        if seed is None:
-            seed = self._target3_tvm_ffi_seed_config()
-        if seed is None:
-            seed = self._target4_tvm_ffi_seed_config()
-        if seed is None:
-            seed = self._target5_tvm_ffi_seed_config()
-        if seed is None:
-            seed = self._target6_tvm_ffi_seed_config()
-        if seed is None:
-            seed = self._target7_tvm_ffi_seed_config()
-        if seed is None:
-            seed = self._target9_tvm_ffi_seed_config()
-        if seed is None:
-            seed = self._target10_tvm_ffi_seed_config()
-        # T8 (cycle 87) is intentionally absent: it is a plain DEFAULT-layout
-        # seed that does not use the FFI / explicit-epi-tile promotion surface
-        # (that path is bf16-only / T10-fp16-bias-only), so it must not be
-        # projected onto the FFI envelope here.
+        # The generalized direct-entry seed projects FFI-requesting search
+        # candidates onto the validated CtaGroup.TWO envelope for ANY eligible
+        # shape (returns None for ineligible shapes, in which case the
+        # promotion surface is stripped back to the DEFAULT layout below).
+        seed = self.full_tile_direct_entry_seed_config()
         if not self._target1_tvm_ffi_promotion_requested(
             config, seed_enabled=seed is not None
         ):
@@ -3171,47 +1811,6 @@ class CuteTcgen05Config:
             config[TCGEN05_PURE_CLC_SCHEDULER_OBJECT_CONFIG_KEY] = True
         if pure_dynamic_scheduler_requested:
             config[TCGEN05_PURE_DYNAMIC_SCHEDULER_OBJECT_CONFIG_KEY] = True
-
-    def _fix_target8_gelu_search_config(self, config: dict[str, object]) -> None:
-        # Project T8 (cycle 87, MatmulTarget 27) ``cluster_m=2`` search
-        # candidates onto the validated bk=128, ab=3 two-CTA stage tuple at
-        # the DEFAULT epilogue layout. Without this, the for_search
-        # ``tcgen05_ab_stages`` fragment caps ab at 2, so the autotuner never
-        # samples the seed's ab=3 (and lands in the slower bk=64 / ab=2
-        # regime, ~558-578 TF vs the seed's ~650+ TF — the cycle-86/87
-        # coverage gap). This is the plain-config analogue of
-        # ``_fix_target1_tvm_ffi_search_config`` for the bf16 / T10 FFI seeds:
-        # those project onto the FFI envelope, T8 projects onto the plain
-        # DEFAULT-layout envelope (the FFI / explicit-epi-tile path is
-        # bf16-only and rejects a fp16 gelu store). Other tiles (bk=64,
-        # cluster_m=1) are left untouched so the search still explores them.
-        seed = self._target8_gelu_seed_config()
-        if seed is None:
-            return
-        if config.get("tcgen05_cluster_m") != 2:
-            return
-        block_sizes = config.get("block_sizes")
-        if not (
-            isinstance(block_sizes, list)
-            and block_sizes[:3]
-            == [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET8_GELU_BLOCK_K,
-            ]
-        ):
-            return
-        if not self.ab_stages_three_fits(
-            bm=TCGEN05_TWO_CTA_BLOCK_M,
-            bn=TCGEN05_TWO_CTA_BLOCK_N,
-            bk=TCGEN05_TARGET8_GELU_BLOCK_K,
-            cluster_m=2,
-            ab_stages=TCGEN05_TARGET8_GELU_AB_STAGES,
-        ):
-            return
-        config["tcgen05_ab_stages"] = TCGEN05_TARGET8_GELU_AB_STAGES
-        config["tcgen05_acc_stages"] = 2
-        config["tcgen05_c_stages"] = TCGEN05_TARGET8_GELU_C_STAGES
 
     def aux_load_mode_autotune_fragments(self) -> dict[str, ConfigSpecFragment]:
         if not self._aux_tma_search_enabled():
@@ -3288,17 +1887,7 @@ class CuteTcgen05Config:
         # Aux kernels are the only current trigger for scheduler/c_input warp
         # search. The surface is derived from aux_kernel_detected so repeated
         # detection or repeated fragment construction stays idempotent.
-        target1_tvm_ffi_seed_enabled = (
-            self._target1_tvm_ffi_seed_config() is not None
-            or self._target2_tvm_ffi_seed_config() is not None
-            or self._target3_tvm_ffi_seed_config() is not None
-            or self._target4_tvm_ffi_seed_config() is not None
-            or self._target5_tvm_ffi_seed_config() is not None
-            or self._target6_tvm_ffi_seed_config() is not None
-            or self._target7_tvm_ffi_seed_config() is not None
-            or self._target9_tvm_ffi_seed_config() is not None
-            or self._target10_tvm_ffi_seed_config() is not None
-        )
+        direct_entry_seed_eligible = self.full_tile_direct_entry_seed_eligible()
         if self.aux_kernel_detected:
             strategy_choices: tuple[str, ...] = (
                 Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
@@ -3318,7 +1907,7 @@ class CuteTcgen05Config:
         # residual family's production config + runs the full regression sweep,
         # so no passing target can pick it before it is characterized per-family.
         store_warps_choices: tuple[int, ...] = (0,)
-        if target1_tvm_ffi_seed_enabled:
+        if direct_entry_seed_eligible:
             layout_choices = (
                 Tcgen05LayoutStrategy.DEFAULT.value,
                 Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value,
@@ -3801,7 +2390,6 @@ class CuteTcgen05Config:
         self._fix_cluster_m1_persistent_search_config(config)
         self._fix_ab_stages_three_search_config(config)
         self._fix_target1_tvm_ffi_search_config(config)
-        self._fix_target8_gelu_search_config(config)
         self._fix_aux_tma_full_tile_search_config(config)
         self._fix_with_scheduler_search_config(config)
         self._fix_aux_tma_search_config(config)

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -483,39 +483,11 @@ TCGEN05_TARGET9_TVM_FFI_C_STAGES = 2
 # closed the gap on T22 (fp16 2048³ bias) from +21.25% to +3.7% vs Quack.
 # T10 is the first TVM-FFI envelope that admits fp16 operands — the per-target
 # fp16 admission gates are scoped to T10's shape so the other FFI seeds
-# (T1-T7, T9) stay bf16-only. (The cycle-87 T8 fp16 plain-gelu seed below is
-# a separate, non-FFI DEFAULT-layout seed and does not use this envelope.)
+# (T1-T7, T9) stay bf16-only.
 TCGEN05_TARGET10_TVM_FFI_SHAPE = (2048, 2048, 2048)
 TCGEN05_TARGET10_TVM_FFI_BLOCK_K = 128
 TCGEN05_TARGET10_TVM_FFI_AB_STAGES = 3
 TCGEN05_TARGET10_TVM_FFI_C_STAGES = 2
-# Validated cycle-87 Target8 envelope (1536x6144x1536 + plain ``gelu(acc)``
-# epilogue, fp16 operands). Unlike the bf16 / T10 FFI seeds, T8 is NOT a
-# TVM-FFI seed: it uses the DEFAULT epilogue layout and the normal (non-FFI)
-# launch path on the bk=128 (ab=3, c=2) two-CTA stage tuple, because the
-# ``explicit_epi_tile`` / ``tvm_ffi_launch`` flat-role codegen path is gated
-# bf16-only (and fp16 only for the T10 2048³ bias envelope) and rejects a
-# fp16 gelu store. This is the medium-square fp16 MatmulTarget 27 coverage
-# gap from the cycle-86 study: the cold autotuner converges on the
-# ``256x256x64, ab=1/2`` (~556-578 TF) regime, but the validated
-# ``256x256x128, ab=3`` two-CTA envelope force-configs to ~649 TF.
-# K=1536 -> k_tile_count=12 (well below the ``TCGEN05_TWO_CTA_MAX_K_TILES``
-# cap; M_tiles*N_tiles = 6*24 = 144 work clusters). The plain-gelu-store gate
-# (``gelu(acc)`` with no bias and no residual) is unique to T8 and mutually
-# exclusive with the identity/relu/bias/bias_relu gates via the chain shape
-# (a single ``_gelu_erf`` unary op between the MMA carrier and the store
-# cast). The bf16 gelu MatmulTargets 4 (2048x4096x2048) and 19
-# (3072x3072x3072) share the same plain-gelu chain shape, so the detector
-# fires on them too, but the fp16-pinned shape fact below keeps the T8 seed
-# mutually exclusive with them (and the bias_residual_gelu MatmulTargets
-# 12/28 are excluded at the chain-shape level because their stores carry bias
-# + residual adds before the gelu). The "target8" slot name is the eighth
-# internal seed slot and is unrelated to MatmulTarget 8.
-TCGEN05_TARGET8_GELU_SHAPE = (1536, 6144, 1536)
-TCGEN05_TARGET8_GELU_BLOCK_K = 128
-TCGEN05_TARGET8_GELU_AB_STAGES = 3
-TCGEN05_TARGET8_GELU_C_STAGES = 2
-
 # Stage tuples that the TVM-FFI direct entry accepts, keyed by ``bk``.
 # The codegen-side ``tcgen05_direct_entry`` source builder and the
 # runtime-side ``_validate_target1_direct_entry_args`` both consume this
@@ -528,36 +500,6 @@ TCGEN05_DIRECT_ENTRY_STAGE_TUPLES_BY_BK: dict[int, tuple[tuple[int, int], ...]] 
     TCGEN05_TARGET1_TVM_FFI_BLOCK_K: ((3, 2), (6, 4)),
     TCGEN05_TARGET4_TVM_FFI_BLOCK_K: (
         (TCGEN05_TARGET4_TVM_FFI_AB_STAGES, TCGEN05_TARGET4_TVM_FFI_C_STAGES),
-    ),
-}
-
-# Accepted (lhs_shape, rhs_shape, d_shape) envelopes keyed by ``bk``.
-# Ties the direct-entry tensor shape envelope to the plan's ``bk`` so a
-# bk=64 (T1) plan cannot launch with T2/T3/T4/T5/T6/T7/T9/T10-shaped
-# tensors and vice versa. Each entry is
-# ``((lhs_m, lhs_k), (rhs_k, rhs_n), (d_m, d_n))``. T2, T3, T4, T5, T6,
-# T7, T9, and T10 share ``bk=128`` but have distinct M/N/K shapes (with
-# T9 and T10 sharing the square 2048³ shape but differing on epilogue +
-# input dtype); all eight are admitted in the same bk-keyed table so
-# the runtime validator accepts any of them (it additionally dispatches
-# on the per-plan ``validated_shape`` so a T3-plan with T4/T5/T7/T9/T10
-# tensors is still rejected; T2, T6, and T10 plans each carry a
-# ``bias_idx`` so a 3-arg launch is rejected against any of them even
-# at the same shape envelope, and a 4-arg launch is rejected against
-# the T3/T4/T5/T7/T9 plans).
-TCGEN05_DIRECT_ENTRY_SHAPE_SETS_BY_BK: dict[
-    int,
-    tuple[tuple[tuple[int, int], tuple[int, int], tuple[int, int]], ...],
-] = {
-    TCGEN05_TARGET1_TVM_FFI_BLOCK_K: (((1024, 1024), (1024, 4096), (1024, 4096)),),
-    TCGEN05_TARGET4_TVM_FFI_BLOCK_K: (
-        ((8192, 1024), (1024, 1024), (8192, 1024)),
-        ((1024, 1024), (1024, 8192), (1024, 8192)),
-        ((2048, 2048), (2048, 4096), (2048, 4096)),
-        ((4096, 2048), (2048, 2048), (4096, 2048)),
-        ((8192, 2048), (2048, 2048), (8192, 2048)),
-        ((2048, 2048), (2048, 8192), (2048, 8192)),
-        ((2048, 2048), (2048, 2048), (2048, 2048)),
     ),
 }
 

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -459,52 +459,12 @@ class ConfigSpec:
         self._cute_tcgen05_config.exact_shape_aux_kernel_detected = value
 
     @property
-    def cute_tcgen05_identity_matmul_store_detected(self) -> bool:
-        return self._cute_tcgen05_config.identity_matmul_store_detected
+    def cute_tcgen05_matmul_has_non_tcgen05_operand(self) -> bool:
+        return self._cute_tcgen05_config.matmul_has_non_tcgen05_operand
 
-    @cute_tcgen05_identity_matmul_store_detected.setter
-    def cute_tcgen05_identity_matmul_store_detected(self, value: bool) -> None:
-        self._cute_tcgen05_config.identity_matmul_store_detected = value
-
-    @property
-    def cute_tcgen05_relu_matmul_store_detected(self) -> bool:
-        return self._cute_tcgen05_config.relu_matmul_store_detected
-
-    @cute_tcgen05_relu_matmul_store_detected.setter
-    def cute_tcgen05_relu_matmul_store_detected(self, value: bool) -> None:
-        self._cute_tcgen05_config.relu_matmul_store_detected = value
-
-    @property
-    def cute_tcgen05_bias_matmul_store_detected(self) -> bool:
-        return self._cute_tcgen05_config.bias_matmul_store_detected
-
-    @cute_tcgen05_bias_matmul_store_detected.setter
-    def cute_tcgen05_bias_matmul_store_detected(self, value: bool) -> None:
-        self._cute_tcgen05_config.bias_matmul_store_detected = value
-
-    @property
-    def cute_tcgen05_bias_matmul_store_fp16_detected(self) -> bool:
-        return self._cute_tcgen05_config.bias_matmul_store_fp16_detected
-
-    @cute_tcgen05_bias_matmul_store_fp16_detected.setter
-    def cute_tcgen05_bias_matmul_store_fp16_detected(self, value: bool) -> None:
-        self._cute_tcgen05_config.bias_matmul_store_fp16_detected = value
-
-    @property
-    def cute_tcgen05_bias_relu_matmul_store_detected(self) -> bool:
-        return self._cute_tcgen05_config.bias_relu_matmul_store_detected
-
-    @cute_tcgen05_bias_relu_matmul_store_detected.setter
-    def cute_tcgen05_bias_relu_matmul_store_detected(self, value: bool) -> None:
-        self._cute_tcgen05_config.bias_relu_matmul_store_detected = value
-
-    @property
-    def cute_tcgen05_gelu_matmul_store_detected(self) -> bool:
-        return self._cute_tcgen05_config.gelu_matmul_store_detected
-
-    @cute_tcgen05_gelu_matmul_store_detected.setter
-    def cute_tcgen05_gelu_matmul_store_detected(self, value: bool) -> None:
-        self._cute_tcgen05_config.gelu_matmul_store_detected = value
+    @cute_tcgen05_matmul_has_non_tcgen05_operand.setter
+    def cute_tcgen05_matmul_has_non_tcgen05_operand(self, value: bool) -> None:
+        self._cute_tcgen05_config.matmul_has_non_tcgen05_operand = value
 
     @property
     def _tcgen05_cluster_m_search_choices(self) -> tuple[int, ...] | None:
@@ -558,6 +518,15 @@ class ConfigSpec:
     ) -> None:
         self._cute_tcgen05_config.num_epi_warps_validation_choices = value
 
+    def _tcgen05_full_tile_direct_entry_seed_eligible(self) -> bool:
+        return self._cute_tcgen05_config.full_tile_direct_entry_seed_eligible()
+
+    def _tcgen05_full_tile_direct_entry_seed_bk(self) -> int | None:
+        return self._cute_tcgen05_config.full_tile_direct_entry_seed_bk()
+
+    def _tcgen05_full_tile_direct_entry_seed_config(self) -> helion.Config | None:
+        return self._cute_tcgen05_config.full_tile_direct_entry_seed_config()
+
     def restrict_tcgen05_cluster_m_search(self, choices: tuple[int, ...]) -> None:
         self._cute_tcgen05_config.restrict_cluster_m_search(choices)
 
@@ -573,36 +542,6 @@ class ConfigSpec:
             max_k_tiles=max_k_tiles,
             allow_edge_k_tail_family=allow_edge_k_tail_family,
         )
-
-    def allow_tcgen05_target1_tvm_ffi_seed(self) -> None:
-        self._cute_tcgen05_config.allow_target1_tvm_ffi_seed()
-
-    def allow_tcgen05_target2_tvm_ffi_seed(self) -> None:
-        self._cute_tcgen05_config.allow_target2_tvm_ffi_seed()
-
-    def allow_tcgen05_target3_tvm_ffi_seed(self) -> None:
-        self._cute_tcgen05_config.allow_target3_tvm_ffi_seed()
-
-    def allow_tcgen05_target4_tvm_ffi_seed(self) -> None:
-        self._cute_tcgen05_config.allow_target4_tvm_ffi_seed()
-
-    def allow_tcgen05_target5_tvm_ffi_seed(self) -> None:
-        self._cute_tcgen05_config.allow_target5_tvm_ffi_seed()
-
-    def allow_tcgen05_target6_tvm_ffi_seed(self) -> None:
-        self._cute_tcgen05_config.allow_target6_tvm_ffi_seed()
-
-    def allow_tcgen05_target7_tvm_ffi_seed(self) -> None:
-        self._cute_tcgen05_config.allow_target7_tvm_ffi_seed()
-
-    def allow_tcgen05_target8_gelu_seed(self) -> None:
-        self._cute_tcgen05_config.allow_target8_gelu_seed()
-
-    def allow_tcgen05_target9_tvm_ffi_seed(self) -> None:
-        self._cute_tcgen05_config.allow_target9_tvm_ffi_seed()
-
-    def allow_tcgen05_target10_tvm_ffi_seed(self) -> None:
-        self._cute_tcgen05_config.allow_target10_tvm_ffi_seed()
 
     @staticmethod
     def _tcgen05_cluster_m2_bk_is_valid(

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -430,20 +430,31 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
             allow_cluster_m2_search = (
                 allow_full_tile_cluster_m2_search or allow_edge_cluster_m2_search
             )
-            # Small-shape wave-quantization gate. Suppress cluster_m=2
-            # search when the cluster_m=2 work-cluster count cannot fill
-            # one wave of cluster slots (``num_sms // 2``); the persistent
-            # warp-spec prologue dominates and cluster_m=1 wins. ``num_sms
-            # == 0`` (non-CUDA / mocked) keeps search live. See
-            # cute_plan.md §7.6.3.2 for the NCU rationale and B200 numbers.
+            # Small-shape wave-quantization gate. Suppress cluster_m=2 search
+            # only for genuinely tiny problems that cannot fill a meaningful
+            # fraction of the device; below that the persistent warp-spec
+            # prologue dominates and cluster_m=1 wins. The original gate used
+            # ``num_sms // 2`` (one full wave of 2-SM cluster slots), but that
+            # was calibrated for the DEFAULT-layout cluster_m=2 path. The
+            # generalized TVM-FFI direct entry (see
+            # ``CuteTcgen05ClusterM2FfiHeuristic``) has a much lower launch +
+            # epilogue overhead, which shifts the cluster_m=1/2 crossover well
+            # below one wave: full-autotune A/B on B200 shows cluster_m=2 + FFI
+            # winning at 64 work clusters (1024x4096x1024 and 2048^3, ~64
+            # clusters on the 148-SM B200 = 0.86 of a wave) by 7-21% over
+            # cluster_m=1. Use ``num_sms // 4`` so those validated shapes are
+            # admitted on current and larger Blackwell SKUs while still
+            # suppressing the truly tiny shapes (fewer than a quarter-wave of
+            # cluster slots) that have no FFI coverage. ``num_sms == 0`` (non-CUDA / mocked) keeps search
+            # live. See cute_plan.md §7.6.3.2 for the original NCU rationale.
             if allow_cluster_m2_search:
                 num_sms_for_cm2_threshold = _cuda_num_sms_or_zero(lhs.device)
                 if num_sms_for_cm2_threshold > 0:
                     cm2_work_clusters = (static_m // TCGEN05_TWO_CTA_BLOCK_M) * (
                         static_n // TCGEN05_TWO_CTA_BLOCK_N
                     )
-                    cm2_one_wave_slots = num_sms_for_cm2_threshold // 2
-                    if cm2_work_clusters < cm2_one_wave_slots:
+                    cm2_min_clusters = num_sms_for_cm2_threshold // 4
+                    if cm2_work_clusters < cm2_min_clusters:
                         allow_cluster_m2_search = False
             # Narrow the autotune search to tcgen05 configs that have been
             # validated to compile and run correctly on B200. Static full-tile

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -25,14 +25,20 @@ from .._compiler.cute.strategies import tcgen05_explicit_d_store_tile_expr
 from .._compiler.cute.strategies import tcgen05_smem_layout_expr
 from .._compiler.cute.tcgen05_constants import TCGEN05_DIRECT_ENTRY_CLUSTER_M
 from .._compiler.cute.tcgen05_constants import (
-    TCGEN05_DIRECT_ENTRY_SHAPE_SETS_BY_BK as _DIRECT_ENTRY_SHAPE_SETS_BY_BK,
-)
-from .._compiler.cute.tcgen05_constants import (
     TCGEN05_DIRECT_ENTRY_STAGE_TUPLES_BY_BK as _DIRECT_ENTRY_STAGE_TUPLES_BY_BK,
 )
 from .._compiler.cute.tcgen05_constants import TCGEN05_DIRECT_ENTRY_TOTAL_WORK_CLUSTERS
 from .._compiler.cute.tcgen05_constants import (
     TCGEN05_TARGET10_TVM_FFI_SHAPE as _TCGEN05_TARGET10_TVM_FFI_SHAPE,
+)
+from .._compiler.cute.tcgen05_constants import (
+    TCGEN05_TWO_CTA_BLOCK_M as _TCGEN05_TWO_CTA_BLOCK_M,
+)
+from .._compiler.cute.tcgen05_constants import (
+    TCGEN05_TWO_CTA_BLOCK_N as _TCGEN05_TWO_CTA_BLOCK_N,
+)
+from .._compiler.cute.tcgen05_constants import (
+    TCGEN05_TWO_CTA_MAX_K_TILES as _TCGEN05_TWO_CTA_MAX_K_TILES,
 )
 from .._utils import triton_is_available
 from .config import Config as Config
@@ -2732,18 +2738,12 @@ def _validate_target1_direct_entry_args(
             )
         arg_shapes.append(tuple(int(arg.size(dim)) for dim in range(arg.ndim)))
     observed_shapes = tuple(arg_shapes)
-    # B1 (cycle-3 review): each direct-entry plan carries its
-    # validated problem shape so the validator can dispatch on the
-    # exact (M, N, K) envelope baked into the plan. T4 and T5 share
-    # ``bk=128`` (and the same ``(ab,c)`` stage tuple and cluster
-    # geometry), so the bk-keyed shape-set alone cannot distinguish
-    # a T4-plan from a T5-plan — the plan-carried ``validated_shape``
-    # is what keeps them apart at the validator boundary. The legacy
-    # bk-keyed shape-set (``_DIRECT_ENTRY_SHAPE_SETS_BY_BK``) remains
-    # as defense-in-depth: the per-plan check below additionally
-    # asserts that the plan's ``validated_shape`` is one of the
-    # bk-allowed shapes (so a future plan-construction-site bug that
-    # forged an off-envelope shape into a plan still gets caught).
+    # Each direct-entry plan carries its validated problem shape so the
+    # validator can dispatch on the exact (M, N, K) envelope baked into the
+    # plan. The per-plan check below asserts that the plan's
+    # ``validated_shape`` satisfies the structural CtaGroup.TWO constraints
+    # for the plan's ``bk`` (so a plan-construction-site bug that forged an
+    # off-envelope shape into a plan still gets caught).
     if plan_validated_shape is None:
         raise exc.BackendUnsupported(
             "cute",
@@ -2751,17 +2751,30 @@ def _validate_target1_direct_entry_args(
             f"{plan_validated_shape_raw!r}",
         )
     plan_m, plan_n, plan_k = plan_validated_shape
-    bk_allowed_shapes = _DIRECT_ENTRY_SHAPE_SETS_BY_BK.get(bk, ())
     expected_lhs = (plan_m, plan_k)
     expected_rhs = (plan_k, plan_n)
     expected_d = (plan_m, plan_n)
     expected_shapes = (expected_lhs, expected_rhs, expected_d)
-    if expected_shapes not in bk_allowed_shapes:
+    # The direct-entry codegen builds its A/B/D TMA descriptors from the runtime
+    # tensor shapes, so the fast launch path is shape-GENERAL. Admit any shape
+    # that satisfies the structural CtaGroup.TWO constraints the descriptors and
+    # the (bm=bn=256, cluster_m=2) tiling require: M/N divisible by the 256 CTA
+    # tile and K an exact multiple of the K tile within the validated K-tile cap.
+    structural_shape_ok = (
+        plan_m % _TCGEN05_TWO_CTA_BLOCK_M == 0
+        and plan_n % _TCGEN05_TWO_CTA_BLOCK_N == 0
+        and bk > 0
+        and plan_k % bk == 0
+        and plan_k // bk <= _TCGEN05_TWO_CTA_MAX_K_TILES
+    )
+    if not structural_shape_ok:
         raise exc.BackendUnsupported(
             "cute",
-            f"tcgen05 direct entry plan bk={bk} carries unvalidated "
-            f"validated_shape={plan_m, plan_n, plan_k}; bk-allowed shape "
-            f"envelopes are {bk_allowed_shapes!r}",
+            f"tcgen05 direct entry plan bk={bk} validated_shape="
+            f"{plan_m, plan_n, plan_k} is not a structurally valid CtaGroup.TWO "
+            f"shape (need M%{_TCGEN05_TWO_CTA_BLOCK_M}==0, "
+            f"N%{_TCGEN05_TWO_CTA_BLOCK_N}==0, K%bk==0, "
+            f"K/bk<={_TCGEN05_TWO_CTA_MAX_K_TILES})",
         )
     if observed_shapes != expected_shapes:
         raise exc.BackendUnsupported(

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -528,22 +528,10 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                     host_function_has_tcgen05_aux_kernel_pattern,
                 )
                 from .._compiler.cute.aux_tensor import (
-                    host_function_has_tcgen05_bias_matmul_store_pattern,
-                )
-                from .._compiler.cute.aux_tensor import (
-                    host_function_has_tcgen05_bias_relu_matmul_store_pattern,
-                )
-                from .._compiler.cute.aux_tensor import (
                     host_function_has_tcgen05_exact_shape_aux_kernel_pattern,
                 )
                 from .._compiler.cute.aux_tensor import (
-                    host_function_has_tcgen05_gelu_matmul_store_pattern,
-                )
-                from .._compiler.cute.aux_tensor import (
-                    host_function_has_tcgen05_identity_matmul_store_pattern,
-                )
-                from .._compiler.cute.aux_tensor import (
-                    host_function_has_tcgen05_relu_matmul_store_pattern,
+                    host_function_matmul_has_non_tcgen05_operand,
                 )
 
                 self.env.config_spec.cute_tcgen05_aux_kernel_detected = (
@@ -554,117 +542,9 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                         self.host_function
                     )
                 )
-                self.env.config_spec.cute_tcgen05_identity_matmul_store_detected = (
-                    host_function_has_tcgen05_identity_matmul_store_pattern(
-                        self.host_function
-                    )
+                self.env.config_spec.cute_tcgen05_matmul_has_non_tcgen05_operand = (
+                    host_function_matmul_has_non_tcgen05_operand(self.host_function)
                 )
-                self.env.config_spec.cute_tcgen05_relu_matmul_store_detected = (
-                    host_function_has_tcgen05_relu_matmul_store_pattern(
-                        self.host_function
-                    )
-                )
-                self.env.config_spec.cute_tcgen05_bias_matmul_store_detected = (
-                    host_function_has_tcgen05_bias_matmul_store_pattern(
-                        self.host_function
-                    )
-                )
-                # T10 (cycle 42) admits fp16 bias. The default detector
-                # call above is bf16-only so T2/T6 cannot perturb their
-                # autotune mutation pool on a fp16-bias kernel; T10
-                # gates on this separate (bf16, fp16) variant instead.
-                self.env.config_spec.cute_tcgen05_bias_matmul_store_fp16_detected = (
-                    host_function_has_tcgen05_bias_matmul_store_pattern(
-                        self.host_function,
-                        expected_bias_dtypes=(torch.bfloat16, torch.float16),
-                    )
-                )
-                self.env.config_spec.cute_tcgen05_bias_relu_matmul_store_detected = (
-                    host_function_has_tcgen05_bias_relu_matmul_store_pattern(
-                        self.host_function
-                    )
-                )
-                # Plain ``gelu(acc)`` store (no bias, no residual) — cycle-87
-                # T8 (MatmulTarget 27, fp16). Fires on the bf16 gelu
-                # MatmulTargets 4/19 too (same chain shape); the T8 seed's
-                # fp16-pinned shape fact keeps it mutually exclusive there.
-                self.env.config_spec.cute_tcgen05_gelu_matmul_store_detected = (
-                    host_function_has_tcgen05_gelu_matmul_store_pattern(
-                        self.host_function
-                    )
-                )
-                if self.env.config_spec.cute_tcgen05_identity_matmul_store_detected:
-                    # T1, T3, T5, T7, and T9 all gate on identity-store
-                    # detection and write into the same cluster_m=2
-                    # search constraints + pid_type allowlist. Mutual
-                    # exclusion is via shape facts (T1 = 1024x4096x1024,
-                    # T3 = 2048x4096x2048, T5 = 1024x8192x1024,
-                    # T7 = 2048x8192x2048, T9 = 2048x2048x2048) so at
-                    # most one seed is non-``None`` per host function;
-                    # the values written here must stay equal across
-                    # the five
-                    # ``allow_target{1,3,5,7,9}_tvm_ffi_seed`` paths.
-                    self.env.config_spec.allow_tcgen05_target1_tvm_ffi_seed()
-                    self.env.config_spec.allow_tcgen05_target3_tvm_ffi_seed()
-                    self.env.config_spec.allow_tcgen05_target5_tvm_ffi_seed()
-                    self.env.config_spec.allow_tcgen05_target7_tvm_ffi_seed()
-                    self.env.config_spec.allow_tcgen05_target9_tvm_ffi_seed()
-                if self.env.config_spec.cute_tcgen05_relu_matmul_store_detected:
-                    self.env.config_spec.allow_tcgen05_target4_tvm_ffi_seed()
-                if self.env.config_spec.cute_tcgen05_bias_matmul_store_detected:
-                    # T2 gates on the bf16-only bias-store detection
-                    # (rank-1 trailing-axis ``acc + bias[n]``) and
-                    # writes into the same cluster_m=2 search
-                    # constraints + pid_type allowlist used by the
-                    # T1/T3/T5 identity-store and T4 relu-store seeds.
-                    # The bias-store detector is mutually exclusive
-                    # with identity and relu store walkers (rejected by
-                    # the chain shape), and T2's shape gate
-                    # (4096x2048x2048) keeps it mutually exclusive on
-                    # the matmul fact.
-                    self.env.config_spec.allow_tcgen05_target2_tvm_ffi_seed()
-                if (
-                    self.env.config_spec.cute_tcgen05_bias_matmul_store_detected
-                    or self.env.config_spec.cute_tcgen05_bias_matmul_store_fp16_detected
-                ):
-                    # T10 (cycle 42) shares the cluster_m=2 search
-                    # constraints + pid_type allowlist with T2 but
-                    # admits fp16 bias against fp16 operands too. T2
-                    # and T10 are mutually exclusive at the matmul-fact
-                    # level: T2's shape is 4096x2048x2048 (bf16-only),
-                    # T10's shape is 2048x2048x2048 (bf16 or fp16). At
-                    # most one seed is non-``None`` for any given host
-                    # function. T10 enables on either bf16-only or the
-                    # broader (bf16, fp16) bias detection so a fp16
-                    # bias kernel still routes through T10.
-                    self.env.config_spec.allow_tcgen05_target10_tvm_ffi_seed()
-                if self.env.config_spec.cute_tcgen05_bias_relu_matmul_store_detected:
-                    # T6 gates on the bias-relu-store detection
-                    # (``relu(acc + bias[n])``) and writes into the
-                    # same cluster_m=2 search constraints + pid_type
-                    # allowlist used by the T1/T3/T5 identity-store,
-                    # T4 relu-store, and T2 bias-store seeds. The
-                    # bias-relu-store detector is mutually exclusive
-                    # with identity (no binary op), relu (no add), and
-                    # bias (no relu) walkers via the chain shape, and
-                    # T6's shape gate (8192x2048x2048) keeps it
-                    # mutually exclusive on the matmul fact (T2 shares
-                    # bias but has a different shape; T4 shares relu
-                    # but a different shape and no bias).
-                    self.env.config_spec.allow_tcgen05_target6_tvm_ffi_seed()
-                if self.env.config_spec.cute_tcgen05_gelu_matmul_store_detected:
-                    # T8 (cycle 87, MatmulTarget 27) gates on the plain-gelu-
-                    # store detection (``gelu(acc)`` with no bias and no
-                    # residual) and writes into the same cluster_m=2 search
-                    # constraints + pid_type allowlist used by the other
-                    # two-CTA seeds. The plain-gelu-store detector is mutually
-                    # exclusive with identity (no unary op), relu (relu, not
-                    # gelu), and bias/bias_relu (no add) walkers via the chain
-                    # shape. The bf16 gelu MatmulTargets 4/19 share the chain
-                    # shape so the detector fires on them too, but T8's
-                    # fp16-pinned shape gate (1536x6144x1536) keeps the seed
-                    # mutually exclusive on the matmul fact.
-                    self.env.config_spec.allow_tcgen05_target8_gelu_seed()
                 if not self.env.settings.disable_autotuner_heuristics:
                     for seed_config in self.env.config_spec.autotune_seed_configs():
                         if (

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -17,11 +17,8 @@ from helion._compiler.backend import TritonBackend
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY
-from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_SWIZZLE_A_KEY
-from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_SWIZZLE_B_KEY
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY
 from helion._compiler.cute.strategies import TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY
-from helion._compiler.cute.strategies import TCGEN05_STRATEGY_CONFIG_KEY
 from helion._compiler.cute.strategies import TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY
 from helion._compiler.cute.strategies import TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY
 from helion._compiler.cute.strategies import Tcgen05LayoutStrategy
@@ -29,8 +26,6 @@ from helion._compiler.cute.strategies import Tcgen05PersistenceModel
 from helion._compiler.cute.strategies import Tcgen05Strategy
 from helion._compiler.cute.tcgen05_config import CuteTcgen05Config
 from helion._compiler.cute.tcgen05_config import Tcgen05ClusterM2SearchConstraints
-from helion._compiler.cute.tcgen05_constants import TCGEN05_ACC_PRODUCER_MODE_CONFIG_KEY
-from helion._compiler.cute.tcgen05_constants import TCGEN05_ACC_PRODUCER_MODE_SKIP_UMMA
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_ACC_WAIT_PLACEMENT_BEFORE_SUBTILE_LOOP,
 )
@@ -45,30 +40,9 @@ from helion._compiler.cute.tcgen05_constants import (
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_C_ACQUIRE_PLACEMENT_FIRST_IN_LOOP,
 )
-from helion._compiler.cute.tcgen05_constants import TCGEN05_C_STORE_MODE_CONFIG_KEY
-from helion._compiler.cute.tcgen05_constants import (
-    TCGEN05_C_STORE_MODE_SKIP_EPILOGUE_STORE,
-)
-from helion._compiler.cute.tcgen05_constants import TCGEN05_CUBIN_LINEINFO_CONFIG_KEY
-from helion._compiler.cute.tcgen05_constants import (
-    TCGEN05_DIAGNOSTIC_INVALID_OUTPUT_CONFIG_KEY,
-)
-from helion._compiler.cute.tcgen05_constants import TCGEN05_EPILOGUE_LAYOUT_CONFIG_KEY
-from helion._compiler.cute.tcgen05_constants import (
-    TCGEN05_EPILOGUE_LAYOUT_SPLIT_FIRST_T2R,
-)
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY,
 )
-from helion._compiler.cute.tcgen05_constants import (
-    TCGEN05_PURE_CLC_SCHEDULER_OBJECT_CONFIG_KEY,
-)
-from helion._compiler.cute.tcgen05_constants import TCGEN05_TARGET1_TVM_FFI_AB_STAGES
-from helion._compiler.cute.tcgen05_constants import TCGEN05_TARGET1_TVM_FFI_BLOCK_K
-from helion._compiler.cute.tcgen05_constants import TCGEN05_TARGET1_TVM_FFI_C_STAGES
-from helion._compiler.cute.tcgen05_constants import TCGEN05_TARGET8_GELU_AB_STAGES
-from helion._compiler.cute.tcgen05_constants import TCGEN05_TARGET8_GELU_BLOCK_K
-from helion._compiler.cute.tcgen05_constants import TCGEN05_TARGET8_GELU_C_STAGES
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from helion._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
@@ -988,7 +962,15 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             )
 
     @onlyBackends(["cute"])
-    def test_cute_tcgen05_target1_tvm_ffi_seed_config(self) -> None:
+    def test_cute_tcgen05_full_tile_ffi_seed_config(self) -> None:
+        # The generalized FFI direct-entry seed drives ANY eligible bf16
+        # full-tile CtaGroup.TWO matmul (it replaced the bank of per-shape
+        # ``_target{N}`` seeds). The seed itself now lives on the
+        # ConfigSpec/CuteTcgen05Config and is emitted into the autotuner
+        # population by ``CuteTcgen05ClusterM2FfiHeuristic``; it is no longer
+        # part of ``autotune_seed_configs()`` (that chain is now only the
+        # c-input family). This asserts the eligibility gate + the generalized
+        # seed envelope plus the surviving search projection behavior.
         @helion.kernel(backend="cute")
         def cute_matmul_mma(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
             m, k = x.size()
@@ -1010,28 +992,119 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             patch("helion.language.matmul_ops._cuda_num_sms_or_zero", return_value=132),
         ):
             bound = cute_matmul_mma.bind(args)
-        tvm_ffi_seeds = [
-            config.config
-            for config in bound.config_spec.autotune_seed_configs()
-            if config.config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is True
-        ]
-        self.assertEqual(len(tvm_ffi_seeds), 1)
-        seed = tvm_ffi_seeds[0]
+        spec = bound.config_spec
+        self.assertTrue(spec._tcgen05_full_tile_direct_entry_seed_eligible())
+        seed_config = spec._tcgen05_full_tile_direct_entry_seed_config()
+        self.assertIsNotNone(seed_config)
+        seed = seed_config.config
+        self.assertIs(seed[TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY], True)
+        self.assertEqual(
+            seed[TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY],
+            Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value,
+        )
+        bk = spec._tcgen05_full_tile_direct_entry_seed_bk()
+        self.assertIsNotNone(bk)
         self.assertEqual(
             seed["block_sizes"],
-            [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET1_TVM_FFI_BLOCK_K,
-            ],
+            [TCGEN05_TWO_CTA_BLOCK_M, TCGEN05_TWO_CTA_BLOCK_N, bk],
         )
-        self.assertEqual(seed["num_warps"], 8)
-        self.assertEqual(seed["pid_type"], "persistent_interleaved")
+        self.assertEqual(seed["tcgen05_ab_stages"], 3)
         self.assertEqual(seed["tcgen05_cluster_m"], 2)
         self.assertEqual(seed["tcgen05_cluster_n"], 1)
-        self.assertEqual(seed["tcgen05_ab_stages"], TCGEN05_TARGET1_TVM_FFI_AB_STAGES)
-        self.assertEqual(seed["tcgen05_c_stages"], TCGEN05_TARGET1_TVM_FFI_C_STAGES)
-        self.assertEqual(seed["tcgen05_l2_swizzle_size"], 1)
+        self.assertEqual(seed["tcgen05_c_stages"], 2)
+        self.assertEqual(seed["num_warps"], 8)
+        self.assertEqual(seed["pid_type"], "persistent_interleaved")
+        self.assertEqual(seed[TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY], 128)
+        self.assertEqual(seed[TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY], 32)
+        self.assertEqual(seed[TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY], 32)
+        self.assertIs(seed[TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY], True)
+
+        # The same generalized seed is what the search projection uses to map
+        # FFI-requesting cluster_m=2 candidates onto the validated envelope.
+        projected_cluster_m2_config = helion.Config(
+            block_sizes=[256, 256, 128],
+            indexing=["tensor_descriptor", "tensor_descriptor", "tensor_descriptor"],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=1,
+        )
+        bound.config_spec.normalize(projected_cluster_m2_config, _fix_invalid=True)
+        self.assertIs(
+            projected_cluster_m2_config.config[TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY],
+            True,
+        )
+        self.assertEqual(
+            projected_cluster_m2_config.config["block_sizes"],
+            [TCGEN05_TWO_CTA_BLOCK_M, TCGEN05_TWO_CTA_BLOCK_N, bk],
+        )
+
+        # ab > 3 is only valid on the TVM-FFI direct-entry path for the
+        # (bk, ab, c) stage tuples the codegen accepts
+        # (``TCGEN05_DIRECT_ENTRY_STAGE_TUPLES_BY_BK``: bk=64 admits the deep
+        # (ab=6, c=4) tuple). ab=4 and ab=5 are admitted by NO bk, so they are
+        # rejected everywhere; a bare ab>3 config (no FFI launch) is likewise
+        # rejected. ``_fix_invalid=True`` clamps any such config down to ab=3.
+        def _non_seed_stage_config(requested_ab_stages: int) -> helion.Config:
+            return helion.Config(
+                block_sizes=[256, 256, 64],
+                indexing=[
+                    "tensor_descriptor",
+                    "tensor_descriptor",
+                    "tensor_descriptor",
+                ],
+                pid_type="persistent_interleaved",
+                tcgen05_cluster_m=1,
+                tcgen05_cluster_n=1,
+                tcgen05_ab_stages=requested_ab_stages,
+            )
+
+        for requested_ab_stages in (4, 5, 6):
+            with self.subTest(requested_ab_stages=requested_ab_stages):
+                fixed = _non_seed_stage_config(requested_ab_stages)
+                bound.config_spec.normalize(fixed, _fix_invalid=True)
+                self.assertEqual(fixed.config["tcgen05_ab_stages"], 3)
+
+                with self.assertRaisesRegex(
+                    helion.exc.InvalidConfig,
+                    "tcgen05_ab_stages > 3 is not supported",
+                ):
+                    bound.config_spec.normalize(
+                        _non_seed_stage_config(requested_ab_stages)
+                    )
+
+        # ab=6 IS accepted on the FFI direct-entry path at bk=64 with c=4: that
+        # is the (ab=6, c=4) tuple ``TCGEN05_DIRECT_ENTRY_STAGE_TUPLES_BY_BK``
+        # admits for bk=64. Plain normalize (no ``_fix_invalid``) leaves it at 6.
+        ffi_direct_entry_ab6 = helion.Config(
+            block_sizes=[256, 256, 64],
+            indexing=["tensor_descriptor", "tensor_descriptor", "tensor_descriptor"],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=1,
+            tcgen05_ab_stages=6,
+            tcgen05_c_stages=4,
+            **{TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True},
+        )
+        bound.config_spec.normalize(ffi_direct_entry_ab6)
+        self.assertEqual(ffi_direct_entry_ab6.config["tcgen05_ab_stages"], 6)
+
+        # ab=6 is rejected for bk=128 even on the FFI direct-entry path: bk=128
+        # only admits the (ab=3, c=2) tuple.
+        ffi_direct_entry_ab6_bk128 = helion.Config(
+            block_sizes=[256, 256, 128],
+            indexing=["tensor_descriptor", "tensor_descriptor", "tensor_descriptor"],
+            pid_type="persistent_interleaved",
+            tcgen05_cluster_m=2,
+            tcgen05_cluster_n=1,
+            tcgen05_ab_stages=6,
+            tcgen05_c_stages=4,
+            **{TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True},
+        )
+        with self.assertRaisesRegex(
+            helion.exc.InvalidConfig, "tcgen05_ab_stages > 3 is not supported"
+        ):
+            bound.config_spec.normalize(ffi_direct_entry_ab6_bk128)
+
         search_ab_stages_fragment = bound.config_spec._tcgen05_optional_fragments(
             for_search=True
         )["tcgen05_ab_stages"]
@@ -1047,219 +1120,6 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             else 2
         )
         self.assertEqual(search_ab_stages_fragment.high, expected_search_ab_high)
-        self.assertIn(
-            TCGEN05_PURE_CLC_SCHEDULER_OBJECT_CONFIG_KEY,
-            bound.config_spec._tcgen05_optional_fragments(),
-        )
-        self.assertNotIn(
-            TCGEN05_PURE_CLC_SCHEDULER_OBJECT_CONFIG_KEY,
-            bound.config_spec._tcgen05_optional_fragments(for_search=True),
-        )
-        self.assertEqual(
-            seed[TCGEN05_STRATEGY_CONFIG_KEY],
-            Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
-        )
-        self.assertIsNone(seed.get(TCGEN05_PURE_CLC_SCHEDULER_OBJECT_CONFIG_KEY))
-        self.assertEqual(
-            seed[TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY],
-            Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value,
-        )
-        self.assertEqual(seed[TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY], 128)
-        self.assertEqual(seed[TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY], 32)
-        self.assertEqual(seed[TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY], 32)
-        self.assertIs(seed[TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY], True)
-        self.assertEqual(seed["range_unroll_factors"], [1, 1])
-
-        config_gen = bound.config_spec.create_config_generation()
-        transferred_tvm_ffi_seeds = [
-            config.config
-            for _flat, config in config_gen.seed_flat_config_pairs()
-            if config.config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is True
-        ]
-        self.assertEqual(len(transferred_tvm_ffi_seeds), 1)
-        transferred_seed = transferred_tvm_ffi_seeds[0]
-        self.assertEqual(
-            transferred_seed[TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY],
-            Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value,
-        )
-        self.assertEqual(transferred_seed[TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY], 128)
-        self.assertEqual(transferred_seed[TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_N_KEY], 32)
-        self.assertEqual(
-            transferred_seed[TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY], 32
-        )
-        self.assertIs(transferred_seed[TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY], True)
-
-        bound.config_spec.user_defined_tunables["target1_extra"] = IntegerFragment(
-            1, 4, 2
-        )
-        projected_config = helion.Config(
-            block_sizes=[128, 32, 64],
-            indexing=["pointer", "pointer", "tensor_descriptor"],
-            pid_type="flat",
-            tcgen05_cluster_m=1,
-            tcgen05_cluster_n=1,
-            tcgen05_tvm_ffi_launch=True,
-            epilogue_subtile=2,
-            tcgen05_diagnostic_invalid_output=True,
-            tcgen05_c_store_mode=TCGEN05_C_STORE_MODE_SKIP_EPILOGUE_STORE,
-            tcgen05_acc_producer_mode=TCGEN05_ACC_PRODUCER_MODE_SKIP_UMMA,
-            tcgen05_aux_load_mode=TCGEN05_AUX_LOAD_MODE_TMA,
-            tcgen05_cubin_lineinfo=True,
-            tcgen05_epilogue_layout=TCGEN05_EPILOGUE_LAYOUT_SPLIT_FIRST_T2R,
-            tcgen05_warp_spec_scheduler_warps=1,
-            tcgen05_warp_spec_c_input_warps=1,
-            tcgen05_layout_overrides_smem_swizzle_a=128,
-            tcgen05_layout_overrides_smem_swizzle_b=64,
-            advanced_controls_file="/tmp/helion-test.acf",
-            target1_extra=3,
-        )
-        bound.config_spec.normalize(projected_config, _fix_invalid=True)
-        expected_seed_config = helion.Config(
-            **seed,
-            advanced_controls_file="/tmp/helion-test.acf",
-            target1_extra=3,
-        )
-        bound.config_spec.normalize(expected_seed_config, _fix_invalid=True)
-        self.assertEqual(projected_config.config, expected_seed_config.config)
-        self.assertEqual(
-            projected_config.config["block_sizes"],
-            [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET1_TVM_FFI_BLOCK_K,
-            ],
-        )
-        self.assertIs(projected_config.config[TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY], True)
-        self.assertEqual(
-            projected_config.config["tcgen05_ab_stages"],
-            TCGEN05_TARGET1_TVM_FFI_AB_STAGES,
-        )
-        self.assertEqual(
-            projected_config.config["tcgen05_c_stages"],
-            TCGEN05_TARGET1_TVM_FFI_C_STAGES,
-        )
-        self.assertIs(
-            projected_config.config[TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY],
-            True,
-        )
-        self.assertEqual(
-            projected_config.config[TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY],
-            Tcgen05LayoutStrategy.EXPLICIT_EPI_TILE.value,
-        )
-        for stale_key in (
-            "epilogue_subtile",
-            TCGEN05_DIAGNOSTIC_INVALID_OUTPUT_CONFIG_KEY,
-            TCGEN05_C_STORE_MODE_CONFIG_KEY,
-            TCGEN05_ACC_PRODUCER_MODE_CONFIG_KEY,
-            TCGEN05_AUX_LOAD_MODE_CONFIG_KEY,
-            TCGEN05_CUBIN_LINEINFO_CONFIG_KEY,
-            TCGEN05_EPILOGUE_LAYOUT_CONFIG_KEY,
-        ):
-            self.assertNotIn(stale_key, projected_config.config)
-        self.assertEqual(
-            projected_config.config[TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY], 0
-        )
-        self.assertEqual(
-            projected_config.config[TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY], 0
-        )
-        self.assertIsNone(
-            projected_config.config[TCGEN05_LAYOUT_OVERRIDES_SWIZZLE_A_KEY]
-        )
-        self.assertIsNone(
-            projected_config.config[TCGEN05_LAYOUT_OVERRIDES_SWIZZLE_B_KEY]
-        )
-
-        projected_cluster_m2_config = helion.Config(
-            block_sizes=[256, 256, 128],
-            indexing=["tensor_descriptor", "tensor_descriptor", "tensor_descriptor"],
-            pid_type="persistent_interleaved",
-            tcgen05_cluster_m=2,
-            tcgen05_cluster_n=1,
-        )
-        bound.config_spec.normalize(projected_cluster_m2_config, _fix_invalid=True)
-        self.assertIs(
-            projected_cluster_m2_config.config[TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY],
-            True,
-        )
-        self.assertEqual(
-            projected_cluster_m2_config.config["block_sizes"],
-            [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET1_TVM_FFI_BLOCK_K,
-            ],
-        )
-
-        for requested_ab_stages in (4, 5, 6):
-            with self.subTest(requested_ab_stages=requested_ab_stages):
-                non_seed_stage_config = helion.Config(
-                    block_sizes=[256, 256, 64],
-                    indexing=[
-                        "tensor_descriptor",
-                        "tensor_descriptor",
-                        "tensor_descriptor",
-                    ],
-                    pid_type="persistent_interleaved",
-                    tcgen05_cluster_m=1,
-                    tcgen05_cluster_n=1,
-                    tcgen05_ab_stages=requested_ab_stages,
-                )
-                bound.config_spec.normalize(non_seed_stage_config, _fix_invalid=True)
-                self.assertEqual(non_seed_stage_config.config["tcgen05_ab_stages"], 3)
-
-                invalid_non_seed_stage_config = helion.Config(
-                    block_sizes=[256, 256, 64],
-                    indexing=[
-                        "tensor_descriptor",
-                        "tensor_descriptor",
-                        "tensor_descriptor",
-                    ],
-                    pid_type="persistent_interleaved",
-                    tcgen05_cluster_m=1,
-                    tcgen05_cluster_n=1,
-                    tcgen05_ab_stages=requested_ab_stages,
-                )
-                with self.assertRaisesRegex(
-                    helion.exc.InvalidConfig, "validated Target1 TVM-FFI seed"
-                ):
-                    bound.config_spec.normalize(invalid_non_seed_stage_config)
-
-        non_target_args = (
-            torch.empty([1024, 1024], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([1024, 2048], device=DEVICE, dtype=torch.bfloat16),
-        )
-        with (
-            patch_cute_mma_support(),
-            patch("helion.language.matmul_ops._cuda_num_sms_or_zero", return_value=132),
-        ):
-            non_target_bound = cute_matmul_mma.bind(non_target_args)
-        self.assertFalse(
-            any(
-                config.config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is True
-                for config in non_target_bound.config_spec.autotune_seed_configs()
-            )
-        )
-        non_target_ab_stages_fragment = (
-            non_target_bound.config_spec._tcgen05_optional_fragments(for_search=True)[
-                "tcgen05_ab_stages"
-            ]
-        )
-        self.assertIsInstance(non_target_ab_stages_fragment, IntegerFragment)
-        # Cycle 97: ab=3 is now BUDGET-AWARE-SEARCHABLE for ANY bf16/fp16 kernel
-        # whose device admits it (constraints recorded) — not only the per-shape
-        # seed targets. The non-seed kernel still gets the lifted cap; a sampled
-        # over-budget ab=3 is demoted by ``_fix_ab_stages_search_config``.
-        expected_non_target_ab_high = (
-            3
-            if (
-                non_target_bound.config_spec._cute_tcgen05_config.ab_stages_three_search_constraints
-                is not None
-            )
-            else 2
-        )
-        self.assertEqual(
-            non_target_ab_stages_fragment.high, expected_non_target_ab_high
-        )
 
         @helion.kernel(backend="cute")
         def cute_matmul_mma_no_ab3_budget(
@@ -1285,11 +1145,10 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             ),
         ):
             no_ab3_budget_bound = cute_matmul_mma_no_ab3_budget.bind(args)
+        # With no recorded SMEM budget the generalized FFI seed is ineligible
+        # (ab=3 cannot fit) and the for_search ab cap stays at 2.
         self.assertFalse(
-            any(
-                config.config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is True
-                for config in no_ab3_budget_bound.config_spec.autotune_seed_configs()
-            )
+            no_ab3_budget_bound.config_spec._tcgen05_full_tile_direct_entry_seed_eligible()
         )
         no_budget_ab_stages_fragment = (
             no_ab3_budget_bound.config_spec._tcgen05_optional_fragments(
@@ -1297,195 +1156,23 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             )["tcgen05_ab_stages"]
         )
         self.assertIsInstance(no_budget_ab_stages_fragment, IntegerFragment)
-        # Cycle 97: with no recorded SMEM budget (``per_cta_ab_smem_budget_bytes``
-        # patched to 0 -> constraints stay None) the for_search ab cap stays at 2 —
-        # the budget-aware lift is gated on the recorded constraints, so a device
-        # below the B200 envelope never admits ab=3 into search.
         self.assertEqual(no_budget_ab_stages_fragment.high, 2)
 
-        @helion.kernel(backend="cute")
-        def cute_matmul_relu(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-            m, k = x.size()
-            _, n = y.size()
-            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
-            for tile_m, tile_n in hl.tile([m, n]):
-                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
-                for tile_k in hl.tile(k):
-                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
-                out[tile_m, tile_n] = torch.relu(acc).to(x.dtype)
-            return out
-
-        with (
-            patch_cute_mma_support(),
-            patch("helion.language.matmul_ops._cuda_num_sms_or_zero", return_value=132),
-        ):
-            relu_bound = cute_matmul_relu.bind(args)
-        self.assertFalse(
-            relu_bound.config_spec.cute_tcgen05_identity_matmul_store_detected
-        )
-        self.assertEqual(relu_bound.config_spec._tcgen05_cluster_m_search_choices, (1,))
-        self.assertFalse(
-            any(
-                config.config.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY) is True
-                for config in relu_bound.config_spec.autotune_seed_configs()
-            )
-        )
-
-    @onlyBackends(["cute"])
-    def test_cute_tcgen05_target8_gelu_seed_config(self) -> None:
-        # T8 (cycle 87, MatmulTarget 27): fp16 plain ``gelu(acc)`` at
-        # 1536x6144x1536 produces a single plain two-CTA seed using the
-        # DEFAULT epilogue layout (no FFI / explicit-epi-tile, which is
-        # bf16-only). The bf16 gelu shapes (T4/T19) share the chain shape so
-        # the detector fires on them, but the fp16-pinned shape fact must
-        # keep the T8 seed disabled there.
-        @helion.kernel(backend="cute")
-        def cute_matmul_gelu(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-            m, k = x.size()
-            _, n = y.size()
-            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
-            for tile_m, tile_n in hl.tile([m, n]):
-                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
-                for tile_k in hl.tile(k):
-                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
-                out[tile_m, tile_n] = torch.nn.functional.gelu(acc).to(x.dtype)
-            return out
-
+        # An fp16 matmul is NOT eligible for the FFI seed (bf16-only).
         fp16_args = (
-            torch.empty([1536, 1536], device=DEVICE, dtype=torch.float16),
-            torch.empty([1536, 6144], device=DEVICE, dtype=torch.float16),
+            torch.empty([1024, 1024], device=DEVICE, dtype=torch.float16),
+            torch.empty([1024, 4096], device=DEVICE, dtype=torch.float16),
         )
         with (
             patch_cute_mma_support(),
             patch("helion.language.matmul_ops._cuda_num_sms_or_zero", return_value=132),
         ):
-            bound = cute_matmul_gelu.bind(fp16_args)
-        self.assertTrue(
-            bound.config_spec.cute_tcgen05_gelu_matmul_store_detected,
-            "plain-gelu store detector must fire on the fp16 T8 shape",
-        )
-        seeds = [config.config for config in bound.config_spec.autotune_seed_configs()]
-        gelu_seeds = [
-            seed
-            for seed in seeds
-            if seed.get("block_sizes")
-            == [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET8_GELU_BLOCK_K,
-            ]
-            and seed.get("tcgen05_ab_stages") == TCGEN05_TARGET8_GELU_AB_STAGES
-        ]
-        self.assertEqual(len(gelu_seeds), 1)
-        seed = gelu_seeds[0]
-        # The T8 seed must NOT use the FFI / explicit-epi-tile path (the
-        # fp16 gelu store is rejected by that codegen gate).
-        self.assertIsNot(seed.get(TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY), True)
-        self.assertIsNot(seed.get(TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY), True)
-        self.assertIn(
-            seed.get(TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY),
-            (None, Tcgen05LayoutStrategy.DEFAULT.value),
-        )
-        self.assertEqual(seed["tcgen05_cluster_m"], 2)
-        self.assertEqual(seed["tcgen05_cluster_n"], 1)
-        self.assertEqual(seed["tcgen05_c_stages"], TCGEN05_TARGET8_GELU_C_STAGES)
-        self.assertEqual(seed["pid_type"], "persistent_interleaved")
-        self.assertEqual(seed["l2_groupings"], [2])
-        # Seed survives flatten/unflatten against the live spec.
-        config_gen = bound.config_spec.create_config_generation()
-        transferred = [
-            config.config
-            for _flat, config in config_gen.seed_flat_config_pairs()
-            if config.config.get("block_sizes")
-            == [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET8_GELU_BLOCK_K,
-            ]
-            and config.config.get("tcgen05_ab_stages") == TCGEN05_TARGET8_GELU_AB_STAGES
-        ]
-        self.assertGreaterEqual(len(transferred), 1)
-        # The transferred seed survives ``num_warps`` normalization (8 -> 4)
-        # while keeping the tile/stage/cluster envelope intact.
-        self.assertEqual(transferred[0]["tcgen05_cluster_m"], 2)
-        self.assertEqual(
-            transferred[0]["block_sizes"],
-            [
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET8_GELU_BLOCK_K,
-            ],
-        )
-
-        # The search projection promotes a cluster_m=2 + bk=128 candidate
-        # (which the for_search ab fragment caps at ab=2) back to the seed's
-        # ab=3 stage tuple, so the autotuner actually samples the fast regime.
-        promoted = helion.Config(
-            block_sizes=[
-                TCGEN05_TWO_CTA_BLOCK_M,
-                TCGEN05_TWO_CTA_BLOCK_N,
-                TCGEN05_TARGET8_GELU_BLOCK_K,
-            ],
-            indexing=["tensor_descriptor", "tensor_descriptor", "tensor_descriptor"],
-            pid_type="persistent_interleaved",
-            tcgen05_cluster_m=2,
-            tcgen05_cluster_n=1,
-            tcgen05_ab_stages=2,
-            tcgen05_acc_stages=2,
-            tcgen05_c_stages=4,
-        )
-        bound.config_spec.normalize(promoted, _fix_invalid=True)
-        self.assertEqual(
-            promoted.config["tcgen05_ab_stages"], TCGEN05_TARGET8_GELU_AB_STAGES
-        )
-        self.assertEqual(
-            promoted.config["tcgen05_c_stages"], TCGEN05_TARGET8_GELU_C_STAGES
-        )
-        # A bk=64 candidate is left in its own regime (not promoted).
-        not_promoted = helion.Config(
-            block_sizes=[TCGEN05_TWO_CTA_BLOCK_M, TCGEN05_TWO_CTA_BLOCK_N, 64],
-            indexing=["tensor_descriptor", "tensor_descriptor", "tensor_descriptor"],
-            pid_type="persistent_interleaved",
-            tcgen05_cluster_m=2,
-            tcgen05_cluster_n=1,
-            tcgen05_ab_stages=2,
-            tcgen05_acc_stages=2,
-            tcgen05_c_stages=2,
-        )
-        bound.config_spec.normalize(not_promoted, _fix_invalid=True)
-        self.assertEqual(not_promoted.config["tcgen05_ab_stages"], 2)
-        self.assertEqual(not_promoted.config["block_sizes"][2], 64)
-
-        # bf16 gelu (T19 shape) fires the detector but must NOT enable the
-        # fp16-pinned T8 seed.
-        bf16_args = (
-            torch.empty([3072, 3072], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([3072, 3072], device=DEVICE, dtype=torch.bfloat16),
-        )
-        with (
-            patch_cute_mma_support(),
-            patch("helion.language.matmul_ops._cuda_num_sms_or_zero", return_value=132),
-        ):
-            bf16_bound = cute_matmul_gelu.bind(bf16_args)
-        self.assertTrue(
-            bf16_bound.config_spec.cute_tcgen05_gelu_matmul_store_detected,
-            "plain-gelu detector also fires on the bf16 gelu shape",
-        )
+            fp16_bound = cute_matmul_mma.bind(fp16_args)
         self.assertFalse(
-            bf16_bound.config_spec._cute_tcgen05_config.target8_gelu_seed_enabled,
-            "T8 seed must stay disabled on bf16 (fp16-pinned shape fact)",
+            fp16_bound.config_spec._tcgen05_full_tile_direct_entry_seed_eligible()
         )
-        self.assertFalse(
-            any(
-                config.config.get("tcgen05_ab_stages") == TCGEN05_TARGET8_GELU_AB_STAGES
-                and config.config.get("block_sizes")
-                == [
-                    TCGEN05_TWO_CTA_BLOCK_M,
-                    TCGEN05_TWO_CTA_BLOCK_N,
-                    TCGEN05_TARGET8_GELU_BLOCK_K,
-                ]
-                for config in bf16_bound.config_spec.autotune_seed_configs()
-            )
+        self.assertIsNone(
+            fp16_bound.config_spec._tcgen05_full_tile_direct_entry_seed_config()
         )
 
     @onlyBackends(["cute"])
@@ -2820,6 +2507,15 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         # The SMEM budget is MOCKED to the B200 value so the gate is exercised
         # deterministically on any cute host (``@onlyBackends`` does not imply
         # B200).
+        #
+        # An fp16 (NOT bf16) matmul is used so the generalized TVM-FFI
+        # direct-entry seed — which is bf16-only — is INELIGIBLE here. On a
+        # bf16-eligible shape ``_fix_target1_tvm_ffi_search_config`` claims every
+        # cluster_m=2 candidate and projects it onto the validated FFI envelope
+        # (ab=3, c=2), which would shadow the c-stages gate before it could act.
+        # fp16 still records the ab=3 SMEM-budget constraints (16-bit), so the
+        # c-stages gate is exercised in isolation at the canonical cluster_m=2
+        # 256x256x128 tile.
         b200_budget = 232448 - 28 * 1024  # optin cap - ab=3 reservation
 
         @helion.kernel(backend="cute")
@@ -2838,8 +2534,8 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             return out
 
         args = (
-            torch.empty([6144, 6144], device=DEVICE, dtype=torch.bfloat16),
-            torch.empty([6144, 6144], device=DEVICE, dtype=torch.bfloat16),
+            torch.empty([6144, 6144], device=DEVICE, dtype=torch.float16),
+            torch.empty([6144, 6144], device=DEVICE, dtype=torch.float16),
         )
         with (
             patch_cute_mma_support(),

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -4015,10 +4015,9 @@ class TestCuteLowerings(unittest.TestCase):
 
         P2 (cycle-6 review): the runtime validator only admits bf16 bias
         tensors, so the codegen walker
-        ``_trace_mma_to_single_bias_store_dtype`` and the host detector
-        ``host_function_has_tcgen05_bias_matmul_store_pattern`` must
-        reject non-bf16 bias loads. Otherwise an fp32 bias would reach
-        a direct-entry plan and fail only at launch.
+        ``_trace_mma_to_single_bias_store_dtype`` must reject non-bf16
+        bias loads. Otherwise an fp32 bias would reach a direct-entry
+        plan and fail only at launch.
         """
         args = (
             torch.empty([4096, 2048], device=DEVICE, dtype=torch.bfloat16),
@@ -4050,16 +4049,10 @@ class TestCuteLowerings(unittest.TestCase):
         )
         with patch_cute_mma_support():
             bound = cute_matmul_role_local_monolithic_bias_bf16.bind(args)
-            # The fp32 bias must not enable the T2 seed at the
-            # detector level — confirm at the autotune surface.
-            self.assertFalse(
-                bound.env.config_spec.cute_tcgen05_bias_matmul_store_detected
-            )
             bound.env.config_spec.cute_tcgen05_search_enabled = True
-            # And at the codegen walker — forcing the direct-entry
-            # plan key with an fp32 bias must reject at codegen rather
-            # than emit a plan that the runtime validator would then
-            # reject at launch.
+            # The codegen walker — forcing the direct-entry plan key with
+            # an fp32 bias must reject at codegen rather than emit a plan
+            # that the runtime validator would then reject at launch.
             with self.assertRaisesRegex(
                 exc.BackendUnsupported,
                 "T2 bias-store",
@@ -4351,10 +4344,9 @@ class TestCuteLowerings(unittest.TestCase):
 
         Mirrors the cycle-6 P2 review for T2: the runtime validator
         only admits bf16 bias tensors, so the codegen walker
-        ``_trace_mma_to_single_bias_relu_store_dtype`` and the host
-        detector ``host_function_has_tcgen05_bias_relu_matmul_store_pattern``
-        must reject non-bf16 bias loads. Otherwise an fp32 bias would
-        reach a direct-entry plan and fail only at launch.
+        ``_trace_mma_to_single_bias_relu_store_dtype`` must reject
+        non-bf16 bias loads. Otherwise an fp32 bias would reach a
+        direct-entry plan and fail only at launch.
         """
         args = (
             torch.empty([8192, 2048], device=DEVICE, dtype=torch.bfloat16),
@@ -4386,16 +4378,10 @@ class TestCuteLowerings(unittest.TestCase):
         )
         with patch_cute_mma_support():
             bound = cute_matmul_role_local_monolithic_bias_relu_bf16.bind(args)
-            # The fp32 bias must not enable the T6 seed at the
-            # detector level — confirm at the autotune surface.
-            self.assertFalse(
-                bound.env.config_spec.cute_tcgen05_bias_relu_matmul_store_detected
-            )
             bound.env.config_spec.cute_tcgen05_search_enabled = True
-            # And at the codegen walker — forcing the direct-entry
-            # plan key with an fp32 bias must reject at codegen rather
-            # than emit a plan that the runtime validator would then
-            # reject at launch.
+            # The codegen walker — forcing the direct-entry plan key with
+            # an fp32 bias must reject at codegen rather than emit a plan
+            # that the runtime validator would then reject at launch.
             with self.assertRaisesRegex(
                 exc.BackendUnsupported,
                 # Anchor on the full enumerated tail of the

--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -461,17 +461,19 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
     def test_cute_tcgen05_small_shape_wave_quantization_gate(self) -> None:
         """Cycle 38 (cute_plan.md §7.6.3.2): the cluster_m=2 search arm
         is narrowed for shapes whose cluster_m=2 work-cluster count
-        cannot saturate even one wave of cluster slots.
+        cannot saturate even a quarter-wave of cluster slots.
 
         The gate measures ``(M / 256) * (N / 256)`` cluster_m=2 work
-        clusters and compares against ``num_sms // 2`` (one wave of
-        cluster slots when each cluster occupies two SMs). With the
-        SM count mocked to B200's 148 the threshold is 74 cluster
-        slots; the §7.6.1.1 boost-target shapes 1024^3 and 2048^3
-        sit at 16 and 64 cluster slots respectively and therefore
-        narrow to ``cluster_m=1`` only. The 4096^3 G2 closure
-        baseline sits at 256 cluster slots > 74 and keeps
-        cluster_m=2 search exposed (positive control covered by
+        clusters and compares against ``num_sms // 4``. The threshold
+        was lowered from ``num_sms // 2`` (one full wave of 2-SM cluster
+        slots) because the generalized TVM-FFI direct entry has a much
+        lower launch/epilogue overhead and wins at ~64 work clusters
+        (0.86 of a wave on a 148-SM B200). With the SM count mocked to
+        B200's 148 the threshold is 37 cluster slots: 1024^3 sits at 16
+        clusters (< 37) and narrows to ``cluster_m=1`` only, while 2048^3
+        sits at 64 clusters (>= 37) and now KEEPS cluster_m=2 search
+        exposed. The 4096^3 G2 closure baseline (256 clusters) also keeps
+        cluster_m=2 search (covered by
         ``test_cute_tcgen05_two_cta_enters_validated_search_space``).
 
         Mocking ``_cuda_num_sms_or_zero`` keeps the test hermetic:
@@ -491,39 +493,48 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
                 out[tile_m, tile_n] = acc.to(x.dtype)
             return out
 
-        for size in (1024, 2048):
-            with self.subTest(size=size):
-                args = (
-                    torch.empty([size, size], device=DEVICE, dtype=HALF_DTYPE),
-                    torch.empty([size, size], device=DEVICE, dtype=HALF_DTYPE),
-                )
-                with (
-                    patch_cute_mma_support(),
-                    patch(
-                        "helion.language.matmul_ops._cuda_num_sms_or_zero",
-                        return_value=148,
-                    ),
-                ):
-                    bound = cute_matmul_mma.bind(args)
-                spec = bound.config_spec
-                # Below the one-wave SM-slot threshold: cluster_m=2
-                # search is suppressed and the cluster_m2 seed
-                # / fixup machinery is disabled so the autotuner
-                # never spends budget on the cluster_m=2 seed for a
-                # shape where it has no productive lever.
-                self.assertEqual(spec._tcgen05_cluster_m_search_choices, (1,))
-                self.assertIsNone(spec._tcgen05_cluster_m2_search_constraints)
-                # Keep this assertion scoped to the cluster_m=2 seed heuristic:
-                # future unrelated heuristics may still apply to these shapes.
-                self.assertNotIn(
-                    CuteTcgen05ClusterM2Heuristic.name,
-                    spec.autotuner_heuristics,
-                )
-                # Persistent pid types are still allowed (the static-
-                # full-tile gate above this is unaffected) — only the
-                # cluster_m search arm narrows.
-                self.assertIn("persistent_interleaved", spec.allowed_pid_types)
-                self.assertIn("persistent_blocked", spec.allowed_pid_types)
+        def bind_at(size: int):
+            args = (
+                torch.empty([size, size], device=DEVICE, dtype=HALF_DTYPE),
+                torch.empty([size, size], device=DEVICE, dtype=HALF_DTYPE),
+            )
+            with (
+                patch_cute_mma_support(),
+                patch(
+                    "helion.language.matmul_ops._cuda_num_sms_or_zero",
+                    return_value=148,
+                ),
+            ):
+                return cute_matmul_mma.bind(args).config_spec
+
+        # Suppressed: 1024^3 = 16 cluster slots < 148 // 4 = 37. cluster_m=2
+        # search is suppressed and the cluster_m2 seed / fixup machinery is
+        # disabled so the autotuner never spends budget on the cluster_m=2 seed
+        # for a shape where it has no productive lever.
+        suppressed_spec = bind_at(1024)
+        self.assertEqual(suppressed_spec._tcgen05_cluster_m_search_choices, (1,))
+        self.assertIsNone(suppressed_spec._tcgen05_cluster_m2_search_constraints)
+        # Keep this assertion scoped to the cluster_m=2 seed heuristic:
+        # future unrelated heuristics may still apply to these shapes.
+        self.assertNotIn(
+            CuteTcgen05ClusterM2Heuristic.name,
+            suppressed_spec.autotuner_heuristics,
+        )
+        # Persistent pid types are still allowed (the static-full-tile gate
+        # above this is unaffected) — only the cluster_m search arm narrows.
+        self.assertIn("persistent_interleaved", suppressed_spec.allowed_pid_types)
+        self.assertIn("persistent_blocked", suppressed_spec.allowed_pid_types)
+
+        # Admitted (positive control for the lowered // 4 boundary): 2048^3 = 64
+        # cluster slots >= 37. cluster_m=2 search stays exposed, its constraints
+        # are recorded, and the cluster_m=2 seed heuristic is registered.
+        admitted_spec = bind_at(2048)
+        self.assertEqual(admitted_spec._tcgen05_cluster_m_search_choices, (1, 2))
+        self.assertIsNotNone(admitted_spec._tcgen05_cluster_m2_search_constraints)
+        self.assertIn(
+            CuteTcgen05ClusterM2Heuristic.name,
+            admitted_spec.autotuner_heuristics,
+        )
 
     @onlyBackends(["cute"])
     def test_cute_tcgen05_cluster_m1_persistent_search_caps_m_tile(self) -> None:


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2682
 * __->__#2681
 * #2680
 * #2679
 * #2678
 * #2656
 * #2655
 * #2654
 * #2653
 * #2652
 * #2651


--- --- ---

[cutedsl] generalize hardcoded tcgen05 FFI seeds into a shape-derived heuristic

Replace the bank of ~10 exact-shape-pinned tcgen05 TVM-FFI "target" seed
configs (T1-T10 + the T8 gelu seed) and their store-pattern detectors /
per-shape gating with a single generalized CuteTcgen05ClusterM2FfiHeuristic
that emits the FFI direct-entry config for ANY eligible bf16 full-tile
CtaGroup.TWO matmul. The direct-entry codegen already builds its A/B/D TMA
descriptors from the runtime tensor shapes, so the launch-time validator is
now a structural check (M/N % 256 == 0, K % bk == 0, K-tile cap) instead of
an enumerated per-shape table.

Full-autotune A/B on B200 shows the generalized seed matches the hand-pinned
seeds on the validated shapes (1024x4096x1024, 2048^3, 8192x1024x1024,
8192x2048x2048) within noise and extends the 7-21% FFI win to previously
unseeded shapes (4096^3, 3072^3); fp16 matmuls fall back to DEFAULT layout.

Relax the cluster_m=2 wave-quantization gate from num_sms//2 to num_sms//4 so
the validated ~64-cluster shapes (which the deleted per-shape seeds used to
force-enable by bypassing the gate) keep cluster_m=2/FFI, while genuinely tiny
shapes stay cluster_m=1.

The c_input/aux-TMA/CLC seed family and the cute_mma.py diagnostic envelope
gate are retained. Net -2800 lines.