### PR TITLE
[flaky test] Skip bf16xint16 GEMM test under Pallas CPU interpret

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -28,6 +28,7 @@ from helion._testing import skipIfCudaSharedMemoryLessThan
 from helion._testing import skipIfFn
 from helion._testing import skipIfNotCUDA
 from helion._testing import skipIfPallas
+from helion._testing import skipIfPallasInterpret
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfRocm
 from helion._testing import skipIfTileIR
@@ -666,7 +667,11 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[block_size],
         )
 
-    @xfailIfPallas("precision differences with bf16xint16 operations on pallas")
+    @skipIfPallasInterpret(
+        "65536x1024x1280 GEMM is too slow under CPU interpret -- it exceeds the "
+        "300s per-test timeout and (thread timeout method) kills the whole job"
+    )
+    @xfailIfPallasTpu("precision differences with bf16xint16 operations on pallas")
     @skipIfTileIR("precision differences with bf16xint16 operations on tileir")
     @skipIfRocm("precision differences with bf16xint16 operations on rocm")
     @skipIfXPU("precision differences with bf16xint16 operations on xpu")


### PR DESCRIPTION
skip test_bf16xint16 that runs a 65536x1024x1280 GEMM. Under the pallas-interpret
CI job this executes via JAX interpret mode on CPU, single-threaded, where
it sits right at the 300s per-test timeout. Because the job uses
--timeout-method=thread, a timeout hard-kills the entire pytest process
(bypassing --reruns=2), so an occasional slow run fails the whole job.

The test was already @xfailIfPallas, i.e. expected to fail on pallas anyway (bf16xint16 precision differences), so running it there yields no signal -- only the risk of timing out and killing the job.