### PR TITLE
[benchmark] Cap per-shape autotune wall-clock in nightly CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -44,6 +44,10 @@ jobs:
     env:
       HELION_AUTOTUNE_LOG_LEVEL: INFO
       HELION_BACKEND: ${{ inputs.backend }}
+      # Per-shape autotune convergence cutoff (90 min): healthy searches finish
+      # well under it (slowest ~69 min); non-converging runaways are stopped with
+      # best-so-far.
+      HELION_AUTOTUNE_BUDGET_SECONDS: "5400"
 
     container:
       image: ${{ inputs.image }}


### PR DESCRIPTION
[benchmark] Cap per-shape autotune wall-clock in nightly CI

Set HELION_AUTOTUNE_BUDGET_SECONDS=5400 (90 min) in benchmark.yml so a non-converging autotune search is stopped with best-so-far instead of running until GitHub's 6h job cap silently cancels the run and uploads nothing (the dashboard "No Result" gaps). 90 min is a convergence cutoff: the slowest healthy B200 search is int4_gemm ~69 min/shape (an 18-generation converging search), while runaways (e.g. grouped_gemm shapes wandering into compile-bomb configs) hit 150-170 min/shape.