### PR TITLE
[cute] Enable cute-gated tests: structural atomics + config reuse

### DIFF
--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -1829,6 +1829,21 @@ class BlockReductionStrategy(ReductionStrategy):
             reduce_axis = self._aliased_active_thread_axis(block_axes)
         if reduce_axis is None:
             aliased_block_id = self._aliased_strategy_block_id()
+            # Only treat the reduce dim as a strided thread reduction when the
+            # aliased block is actually backed by a *live* thread axis. A block
+            # with ``block_size == 1`` (a grid/serial dim such as a size-1
+            # contributor axis) reports no live thread extent; its
+            # ``_thread_axis_map`` entry still records a phantom local axis that
+            # collides with an unrelated sibling block's real thread axis (e.g.
+            # the M tile on CuTe). Using that phantom axis would fold the
+            # reduction across the sibling's tile instead of squeezing the
+            # size-1 dim, so bail to the loop-carried / passthrough path.
+            if (
+                aliased_block_id is not None
+                and self.fn.tile_strategy.thread_extent_for_block_id(aliased_block_id)
+                is None
+            ):
+                aliased_block_id = None
             if aliased_block_id is not None:
                 reduce_axis = self.fn.tile_strategy.thread_axis_for_block_id(
                     aliased_block_id

--- a/test/test_atomic_ops.py
+++ b/test/test_atomic_ops.py
@@ -481,7 +481,6 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
                 expected = torch.ones(16, 128, device=DEVICE) + x.sum(dim=0)
                 torch.testing.assert_close(result, expected)
 
-    @skipIfCute("CuTe does not handle structural shared-tile atomics yet")
     def test_structural_atomic_add_two_contributor_dims(self):
         @helion.kernel(static_shapes=True)
         def structural_atomic_add_2_contributor_kernel(
@@ -508,7 +507,6 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
         expected = torch.ones(16, 128, device=DEVICE) + x.sum(dim=(0, 1))
         torch.testing.assert_close(result, expected)
 
-    @skipIfCute("CuTe does not handle structural shared-tile atomics yet")
     def test_structural_atomic_add_multiple_outputs(self):
         @helion.kernel(static_shapes=True)
         def structural_atomic_add_two_outputs_kernel(
@@ -540,7 +538,11 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
             out_y, torch.full([16, 128], 2.0, device=DEVICE) + y.sum(dim=0)
         )
 
-    @skipIfCute("CuTe does not handle structural shared-tile atomics yet")
+    @skipIfCute(
+        "CuTe atomic_max/atomic_min on float32 emit an unsupported NVVM "
+        "atomicrmw (no native float atomic max/min); needs a CAS-loop "
+        "emulation"
+    )
     def test_structural_atomic_max_min_shared_tile(self):
         @helion.kernel(static_shapes=True)
         def structural_atomic_max_kernel(x: torch.Tensor) -> torch.Tensor:

--- a/test/test_matmul.py
+++ b/test/test_matmul.py
@@ -374,7 +374,6 @@ class TestMatmul(RefEagerTestBase, TestCase):
         else:
             self.assertIn("tl.atomic_add", code)
 
-    @skipIfNotTriton("config reuse crashes CUDA on cute, corrupting test state")
     @skipIfRefEager("config_spec is not supported in ref eager mode")
     def test_matmul_config_reuse_with_unit_dim(self):
         torch.manual_seed(0)


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2690
 * #2689
 * __->__#2688
 * #2695


--- --- ---

[cute] Enable cute-gated tests: structural atomics, config reuse, reduction-broadcast

- reduction_strategy.py: when a size-1 (block_size==1) contributor/grid dim is
  reduced, don't fold it onto a sibling block's phantom thread axis; bail to the
  loop-carried/passthrough path so the size-1 dim is squeezed correctly. Fixes
  wrong results for structural shared-tile atomic reductions on CuTe.
- test_atomic_ops: enable test_structural_atomic_add_two_contributor_dims and
  test_structural_atomic_add_multiple_outputs on cute (now correct); clarify the
  remaining skip on max/min (needs float atomic CAS emulation).
- test_errors: make test_shape_mismatch_missing_keepdims backend-aware (CuTe
  lowers the full-row reduction as a row-wise scalar that broadcasts legally and
  is correct, so it does not raise ShapeMismatch like Triton).
- test_matmul: drop the stale skip on test_matmul_config_reuse_with_unit_dim
  (config reuse no longer crashes on cute).