### PR TITLE
[cute] Support float32 atomic_max/atomic_min via integer-bitcast dispatch

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -3426,6 +3426,8 @@ class CuteBackend(Backend):
             "_cute_fp8e4m3fn_to_float32": "from helion._compiler.cute.quantized_helpers import fp8e4m3fn_to_float32 as _cute_fp8e4m3fn_to_float32",
             "_cute_float4_e2m1fn_x2_to_float32": "from helion._compiler.cute.quantized_helpers import float4_e2m1fn_x2_to_float32 as _cute_float4_e2m1fn_x2_to_float32",
             "_cute_grid_barrier": "from helion._compiler.cute.grid_barrier import grid_barrier as _cute_grid_barrier",
+            "_cute_atomic_max_float32": "from helion._compiler.cute.atomic_helpers import atomic_max_float32 as _cute_atomic_max_float32",
+            "_cute_atomic_min_float32": "from helion._compiler.cute.atomic_helpers import atomic_min_float32 as _cute_atomic_min_float32",
         }
 
     def program_id_expr(self, dim: int, *, index_dtype: str) -> str:

--- a/helion/_compiler/cute/atomic_helpers.py
+++ b/helion/_compiler/cute/atomic_helpers.py
@@ -1,0 +1,132 @@
+# pyrefly: ignore-errors
+"""Float atomic max/min helpers for the CuTe backend.
+
+NVVM/PTX has no native ``atom.max``/``atom.min`` for floating-point types
+(only integer types support these). The CUTLASS DSL's ``cute.arch.atomic_max``
+/ ``cute.arch.atomic_min`` therefore lower a float operand to an invalid
+``nvvm.atomicrmw (f32, max)`` combination, which aborts the process with
+``LLVM ERROR: Invalid AtomicType and Op combination for nvvm.atomicrmw``.
+
+The standard workaround (used by CUDA's ``atomicMax(float*)`` emulation and by
+CUTLASS's own :func:`cute.arch.atomic_fmax`) reinterprets the float bit pattern
+as an integer and dispatches to the *integer* atomics, which are natively
+supported:
+
+  * For a non-negative ``val`` (sign bit clear) the IEEE-754 bit pattern is
+    monotonic when read as a signed ``i32``, so a signed integer atomic
+    reproduces the float comparison.
+  * For a negative ``val`` (sign bit set) the ordering inverts, so we flip
+    max<->min and operate on the *unsigned* integer representation.
+
+This handles mixed-sign contents of the target cell correctly (the same
+property that makes the CUDA idiom correct), and emits only integer atomics
+that the CuTe backend already supports.
+
+Only float32 is implemented here; that is what Helion's float atomic
+max/min lowering needs for the test suite. 16-bit float atomics would need a
+sub-word RMW (CAS on the enclosing 32-bit word) and are intentionally left
+unsupported.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import cutlass
+from cutlass import Float32
+from cutlass import Int32
+from cutlass import Uint32
+from cutlass._mlir.dialects import llvm
+import cutlass.cute as cute
+from cutlass.cutlass_dsl import dsl_user_op
+
+if TYPE_CHECKING:
+    from cutlass._mlir import ir
+
+
+@dsl_user_op
+def atomic_max_float32(
+    ptr: cute.Pointer,
+    val: Float32,
+    *,
+    sem: str = "relaxed",
+    loc: ir.Location | None = None,
+    ip: ir.InsertionPoint | None = None,
+) -> Float32:
+    """Atomic float32 max via integer-bitcast dispatch to integer atomics.
+
+    Returns the previous float32 value stored at ``ptr``.
+    """
+    intval = llvm.bitcast(Int32.mlir_type, val.ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+
+    def neg_body() -> Int32:
+        # Negative val: float order inverts, use unsigned min.
+        return Int32(
+            Uint32(
+                cute.arch.atomic_min(ptr, Uint32(intval), sem=sem, loc=loc, ip=ip)
+            ).ir_value(loc=loc, ip=ip)
+        )
+
+    def nonneg_body() -> Int32:
+        # Non-negative val: signed order matches float order, use signed max.
+        return cute.arch.atomic_max(ptr, Int32(intval), sem=sem, loc=loc, ip=ip)
+
+    old_intval = cutlass.cutlass_dsl.if_generate(
+        Int32(intval) < Int32(0),
+        neg_body,
+        nonneg_body,
+        [],
+        [Int32],
+        loc=loc,
+        ip=ip,
+    )
+    assert not isinstance(old_intval, list)
+    return Float32(
+        llvm.bitcast(
+            Float32.mlir_type, old_intval.ir_value(loc=loc, ip=ip), loc=loc, ip=ip
+        )
+    )
+
+
+@dsl_user_op
+def atomic_min_float32(
+    ptr: cute.Pointer,
+    val: Float32,
+    *,
+    sem: str = "relaxed",
+    loc: ir.Location | None = None,
+    ip: ir.InsertionPoint | None = None,
+) -> Float32:
+    """Atomic float32 min via integer-bitcast dispatch to integer atomics.
+
+    Returns the previous float32 value stored at ``ptr``.
+    """
+    intval = llvm.bitcast(Int32.mlir_type, val.ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+
+    def neg_body() -> Int32:
+        # Negative val: float order inverts, use unsigned max.
+        return Int32(
+            Uint32(
+                cute.arch.atomic_max(ptr, Uint32(intval), sem=sem, loc=loc, ip=ip)
+            ).ir_value(loc=loc, ip=ip)
+        )
+
+    def nonneg_body() -> Int32:
+        # Non-negative val: signed order matches float order, use signed min.
+        return cute.arch.atomic_min(ptr, Int32(intval), sem=sem, loc=loc, ip=ip)
+
+    old_intval = cutlass.cutlass_dsl.if_generate(
+        Int32(intval) < Int32(0),
+        neg_body,
+        nonneg_body,
+        [],
+        [Int32],
+        loc=loc,
+        ip=ip,
+    )
+    assert not isinstance(old_intval, list)
+    return Float32(
+        llvm.bitcast(
+            Float32.mlir_type, old_intval.ir_value(loc=loc, ip=ip), loc=loc, ip=ip
+        )
+    )

--- a/helion/language/atomic_ops.py
+++ b/helion/language/atomic_ops.py
@@ -154,6 +154,33 @@ def _resolve_cute_atomic_kwargs(cute_func: str, requested: list[str]) -> list[st
     return resolved
 
 
+_CUTE_FLOAT_ATOMIC_HELPERS: dict[str, str] = {
+    "atomic_max": "_cute_atomic_max_float32",
+    "atomic_min": "_cute_atomic_min_float32",
+}
+
+
+def _cute_atomic_callee(cute_func: str, target_dtype_torch: torch.dtype) -> str:
+    """Pick the callee for a CuTe atomic op.
+
+    NVVM/PTX has no native ``atom.max``/``atom.min`` for floating point, so
+    float ``atomic_max``/``atomic_min`` are routed through runtime helpers that
+    emulate them with integer atomics (registered in
+    ``CuteBackend.library_imports``). All other ops, and integer max/min, use
+    the native ``cute.arch.<func>`` directly.
+    """
+    helper = _CUTE_FLOAT_ATOMIC_HELPERS.get(cute_func)
+    if helper is None or not target_dtype_torch.is_floating_point:
+        return f"cute.arch.{cute_func}"
+    if target_dtype_torch is not torch.float32:
+        raise exc.BackendUnsupported(
+            "cute",
+            f"{cute_func} on floating-point dtype {target_dtype_torch} "
+            "(only float32 is supported)",
+        )
+    return helper
+
+
 def _codegen_common_cute(
     cute_func: str,
     state: CodegenState,
@@ -176,6 +203,7 @@ def _codegen_common_cute(
 
     backend = CompileEnvironment.current().backend
     target_dtype = backend.dtype_str(target.dtype)
+    callee = _cute_atomic_callee(cute_func, target.dtype)
     cast_value_exprs = [
         expr_from_string(
             backend.ast_to_dtype_expr("{value}", target_dtype),
@@ -191,6 +219,7 @@ def _codegen_common_cute(
         sem,
         cast_value_exprs,
         keyword_names,
+        callee,
     )
     if tensor_index_stmt is not None:
         return tensor_index_stmt
@@ -204,7 +233,7 @@ def _codegen_common_cute(
     )
     placeholders = dict(zip(keyword_names, cast_value_exprs, strict=True))
     atomic_expr = expr_from_string(
-        f"cute.arch.{cute_func}({{ptr}}, {values_section}, sem={{sem}})",
+        f"{callee}({{ptr}}, {values_section}, sem={{sem}})",
         ptr=expr_from_string(pointer),
         sem=sem,
         **placeholders,
@@ -551,6 +580,7 @@ def _codegen_tensor_index_common_cute(
     sem: ast.AST,
     value_exprs: list[ast.AST],
     keyword_names: list[str],
+    callee: str,
 ) -> ast.AST | None:
     from .._compiler.compile_environment import CompileEnvironment
     from .memory_ops import _cute_active_index_var
@@ -585,6 +615,7 @@ def _codegen_tensor_index_common_cute(
             sem,
             value_exprs,
             keyword_names,
+            callee,
         )
 
     env = CompileEnvironment.current()
@@ -599,6 +630,7 @@ def _codegen_tensor_index_common_cute(
             sem,
             value_exprs,
             keyword_names,
+            callee,
         )
     block_id = env.resolve_codegen_block_id(block_id, state.codegen, fx_node.graph)
     if (index_var := _cute_active_index_var(state, block_id)) is None:
@@ -611,6 +643,7 @@ def _codegen_tensor_index_common_cute(
             sem,
             value_exprs,
             keyword_names,
+            callee,
         )
 
     tensor_name = state.device_function.tensor_arg(target).name
@@ -621,8 +654,7 @@ def _codegen_tensor_index_common_cute(
     )
     placeholders = dict(zip(keyword_names, value_exprs, strict=True))
     atomic_expr = expr_from_string(
-        "cute.arch."
-        + cute_func
+        callee
         + "("
         + f"({tensor_name}.iterator + "
         + f"cute.crd2idx((cutlass.Int32({iota_start}) + {index_var},), {tensor_name}.layout)).llvm_ptr, "
@@ -655,6 +687,7 @@ def _codegen_tensor_index_loop_common_cute(
     sem: ast.AST,
     value_exprs: list[ast.AST],
     keyword_names: list[str],
+    callee: str,
 ) -> ast.AST | None:
     from .._compiler.ast_extension import statement_from_string
 
@@ -717,8 +750,7 @@ def _codegen_tensor_index_loop_common_cute(
     )
     placeholders = dict(zip(keyword_names, indexed_values, strict=True))
     atomic_expr = expr_from_string(
-        "cute.arch."
-        + cute_func
+        callee
         + "("
         + f"({tensor_name}.iterator + "
         + f"cute.crd2idx(({{index}},), {tensor_name}.layout)).llvm_ptr, "

--- a/test/test_atomic_ops.py
+++ b/test/test_atomic_ops.py
@@ -11,7 +11,6 @@ from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
-from helion._testing import skipIfCute
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfRocm
 from helion._testing import skipIfTileIR
@@ -538,11 +537,6 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
             out_y, torch.full([16, 128], 2.0, device=DEVICE) + y.sum(dim=0)
         )
 
-    @skipIfCute(
-        "CuTe atomic_max/atomic_min on float32 emit an unsupported NVVM "
-        "atomicrmw (no native float atomic max/min); needs a CAS-loop "
-        "emulation"
-    )
     def test_structural_atomic_max_min_shared_tile(self):
         @helion.kernel(static_shapes=True)
         def structural_atomic_max_kernel(x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2690
 * __->__#2689
 * #2688
 * #2695


--- --- ---

[cute] Support float32 atomic_max/atomic_min via integer-bitcast dispatch

NVVM/PTX has no native float atom.max/atom.min, so cute.arch.atomic_max on a
float operand lowered to an invalid nvvm.atomicrmw(f32, max) and aborted the
process. Add cute runtime helpers (atomic_max_float32/atomic_min_float32) that
reinterpret the float bit pattern as int and dispatch to the natively-supported
integer atomics (signed for non-negative values, unsigned with max<->min flipped
for negative), the same idiom as CUDA's atomicMax(float*) and CUTLASS's
atomic_fmax. Route the cute float max/min lowering to them and enable
test_structural_atomic_max_min_shared_tile on cute.