### PR TITLE
[benchmarks] Fix flash_attention accuracy after attention returns (out, lse)

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -1552,8 +1552,11 @@ def run_kernel_variants(
                 if isinstance(kfunc, Kernel):
                     # Helion kernel - we call it in a lambda to delay execution until measurement
                     if operator_name == "flash_attention":
+                        # examples.attention.attention returns (out, lse); the
+                        # tritonbench flash_attention operator only compares the
+                        # output tensor, so unwrap it before wrapping in a list.
                         measured_func_callable = lambda: [  # noqa: E731
-                            kfunc(*args, **kwargs)
+                            kfunc(*args, **kwargs)[0]
                         ]
                     else:
                         measured_func_callable = lambda: kfunc(*args, **kwargs)  # noqa: E731


### PR DESCRIPTION
[benchmarks] Fix flash_attention accuracy after attention returns (out, lse)

#2657 changed examples.attention.attention to return (out, lse) to support
the new backward pass. The flash_attention benchmark wrapper in run.py fed
that tuple straight into tritonbench's accuracy(), which calls
torch.isnan(output) on each output and failed with:

    isnan(): argument 'input' (position 1) must be Tensor, not tuple

on all six shapes (H100 and MI350X benchmark dashboard "Shape Failure").
Latency measurement was unaffected; only the accuracy check broke.

Unwrap the output tensor before wrapping it in the list, restoring the
[out] shape that accuracy()'s zip expects.