### PR TITLE
Fix dynamic shapes tracing support for non-padding backends

### DIFF
--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -962,6 +962,19 @@ class CompileEnvironment:
                     )
         return result
 
+    def try_concretize_symint(self, size: int | torch.SymInt) -> int | torch.SymInt:
+        """Convert a SymInt to a plain int when the value is provably concrete.
+
+        Backed SymInts (whose values are determined by input shapes) are
+        concretized via their size hint.  Unbacked SymInts (e.g. block-size
+        variables) are left symbolic.
+        """
+        if not isinstance(size, torch.SymInt):
+            return size
+        if _has_unbacked(size._sympy_()):
+            return size
+        return self.size_hint(size)
+
     def size_hint(self, n: int | torch.SymInt) -> int:
         if isinstance(n, torch.SymInt):
             expr = n._sympy_()

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -974,15 +974,12 @@ class SubscriptIndexing(NamedTuple):
                 slice_size = compute_slice_size(k, size)
 
                 if slice_size != 1:
-                    if (
-                        isinstance(slice_size, int)
-                        and not env.backend.pad_factory_tensors_to_power_of_2
-                    ):
-                        # On backends that don't pad factory ops to
-                        # power-of-2, keep concrete dims concrete so shape
-                        # inference can prove equality with concretely-sized
-                        # buffers (matches _device_indexing_size).
-                        output_size.append(slice_size)
+                    # On backends that don't pad factory ops to
+                    # power-of-2, keep concrete dims concrete so shape
+                    # inference can prove equality with concretely-sized
+                    # buffers (matches _device_indexing_size).
+                    if not env.backend.pad_factory_tensors_to_power_of_2:
+                        output_size.append(env.try_concretize_symint(slice_size))
                     else:
                         rdim = env.allocate_reduction_dimension(slice_size)
                         output_size.append(rdim.var)

--- a/helion/_compiler/type_info.py
+++ b/helion/_compiler/type_info.py
@@ -368,17 +368,14 @@ class TensorType(TypeInfo):
                             output_sizes.append(output_size)
                             continue
                     # On backends that don't pad factory ops to power-of-2,
-                    # concrete int dims must stay concrete so subsequent shape
+                    # concrete dims must stay concrete so subsequent shape
                     # inference can prove equality with other concretely-sized
-                    # buffers (e.g. host-allocated accumulators via new_zeros).
+                    # buffers (e.g. host-allocated accumulators via hl.zeros).
                     # Allocating a reduction-dim block here would introduce a
                     # fresh unbacked symbol that does not unify with the int
                     # even when the hint matches.
-                    if (
-                        isinstance(output_size, int)
-                        and not env.backend.pad_factory_tensors_to_power_of_2
-                    ):
-                        output_sizes.append(output_size)
+                    if not env.backend.pad_factory_tensors_to_power_of_2:
+                        output_sizes.append(env.try_concretize_symint(output_size))
                         continue
                     rdim = CompileEnvironment.current().allocate_reduction_dimension(
                         output_size

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -376,7 +376,6 @@ class TestExamples(RefEagerTestBase, TestCase):
         lambda: _get_backend() == "cute",
         "CuTe matmul+layernorm example is unsupported and too expensive in-process",
     )
-    @xfailIfPallas("JAX tracer error with dynamic shapes")
     def test_matmul_layernorm_dynamic_shapes(self):
         args = (
             torch.randn([128, 256], device=DEVICE, dtype=torch.float32),

--- a/test/test_loops.py
+++ b/test/test_loops.py
@@ -408,7 +408,7 @@ class TestLoops(RefEagerTestBase, TestCase):
         else:
             torch.testing.assert_close(result, expected)
 
-    @xfailIfPallas("data-dependent bounds hit JAX tracing issues on pallas")
+    @xfailIfPallas("int64 index dtype not supported on Pallas")
     @skipIfXPU("worker crash on XPU")
     def test_data_dependent_bounds3(self):
         @helion.kernel()


### PR DESCRIPTION
**The Problem**

The kernel matmul_layernorm with static_shapes=False has this structure:

```
n = hl.specialize(y.size(1))          # host code — n becomes concrete 400
for tile_m in hl.tile(m):
    acc = hl.zeros([tile_m, n], ...)   # creates tensor with shape [block_m, 400]
    for tile_k in hl.tile(k):
        acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, :])
```

With `static_shapes=False`, input tensor dimensions are symbolic (backed SymInts like `s0`, `s1`, etc.).
`hl.specialize(y.size(1))` pins `n` to the concrete value 400, so `acc` gets shape `[u_block_m, 400]`.

The problem is how `y[tile_k, :]` computes its output shape. y is a kernel argument defined in host code,
so its `TensorType` has a host origin. When a host-origin tensor is subscripted in device context, the
compiler needs to map its full tensor dimensions down to block-sized dimensions. For tile-indexed
dimensions (like `tile_k`), the output uses the block size variable. For sliced dimensions (like :), the
compiler calls `allocate_reduction_dimension(size)`, which creates a fresh unbacked SymInt (e.g. u5) to
represent that dimension.

This works on Triton because Triton pads factory tensors to power-of-2, so both `acc` and `y[tile_k, :]` end
up with the same block-size variable through normalization. But on Pallas, there's no padding; `acc` has
concrete 400 while `y[tile_k, :]` has unbacked `u5`. When `torch.addmm` checks that `acc.size(1)` matches the
matmul result's dimension 1, it sees `400 != u5` and raises a shape mismatch error.

The same issue affected `weight[:]` and `bias[:]`: their dimensions also got fresh unbacked SymInts instead
of the concrete 400 that acc used.

**The Fix**

On backends that don't pad factory tensors to power-of-2 (Pallas), we skip allocate_reduction_dimension
for sliced dimensions and instead concretize them using the new helper function `try_concretize_symint()`.
This resolves backed SymInts to their concrete int values, so `y[tile_k, :]` produces shape `[u_block_k, 400]`,
matching `acc`'s `[u_block_m, 400]`.

The fix is applied in two places because the compiler traces through the kernel code twice: once during
type propagation and once during device IR lowering. Both had the same pattern of allocating
unnecessary unbacked SymInts for non-tiled dimensions.

`try_concretize_symint()` itself is a general helper: it converts any backed SymInt to a plain int (since
backed SymInts have values fully determined by input shapes), while leaving unbacked SymInts (like
block-size variables) symbolic.