### PR TITLE
[cute] Reject missing-keepdim reduction broadcast in type propagation

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -3253,6 +3253,8 @@ class CuteBackend(Backend):
             "_cute_fp8e4m3fn_to_float32": "from helion._compiler.cute.quantized_helpers import fp8e4m3fn_to_float32 as _cute_fp8e4m3fn_to_float32",
             "_cute_float4_e2m1fn_x2_to_float32": "from helion._compiler.cute.quantized_helpers import float4_e2m1fn_x2_to_float32 as _cute_float4_e2m1fn_x2_to_float32",
             "_cute_grid_barrier": "from helion._compiler.cute.grid_barrier import grid_barrier as _cute_grid_barrier",
+            "_cute_atomic_max_float32": "from helion._compiler.cute.atomic_helpers import atomic_max_float32 as _cute_atomic_max_float32",
+            "_cute_atomic_min_float32": "from helion._compiler.cute.atomic_helpers import atomic_min_float32 as _cute_atomic_min_float32",
         }
 
     def program_id_expr(self, dim: int, *, index_dtype: str) -> str:

--- a/helion/_compiler/cute/atomic_helpers.py
+++ b/helion/_compiler/cute/atomic_helpers.py
@@ -1,0 +1,132 @@
+# pyrefly: ignore-errors
+"""Float atomic max/min helpers for the CuTe backend.
+
+NVVM/PTX has no native ``atom.max``/``atom.min`` for floating-point types
+(only integer types support these). The CUTLASS DSL's ``cute.arch.atomic_max``
+/ ``cute.arch.atomic_min`` therefore lower a float operand to an invalid
+``nvvm.atomicrmw (f32, max)`` combination, which aborts the process with
+``LLVM ERROR: Invalid AtomicType and Op combination for nvvm.atomicrmw``.
+
+The standard workaround (used by CUDA's ``atomicMax(float*)`` emulation and by
+CUTLASS's own :func:`cute.arch.atomic_fmax`) reinterprets the float bit pattern
+as an integer and dispatches to the *integer* atomics, which are natively
+supported:
+
+  * For a non-negative ``val`` (sign bit clear) the IEEE-754 bit pattern is
+    monotonic when read as a signed ``i32``, so a signed integer atomic
+    reproduces the float comparison.
+  * For a negative ``val`` (sign bit set) the ordering inverts, so we flip
+    max<->min and operate on the *unsigned* integer representation.
+
+This handles mixed-sign contents of the target cell correctly (the same
+property that makes the CUDA idiom correct), and emits only integer atomics
+that the CuTe backend already supports.
+
+Only float32 is implemented here; that is what Helion's float atomic
+max/min lowering needs for the test suite. 16-bit float atomics would need a
+sub-word RMW (CAS on the enclosing 32-bit word) and are intentionally left
+unsupported.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import cutlass
+from cutlass import Float32
+from cutlass import Int32
+from cutlass import Uint32
+from cutlass._mlir.dialects import llvm
+import cutlass.cute as cute
+from cutlass.cutlass_dsl import dsl_user_op
+
+if TYPE_CHECKING:
+    from cutlass._mlir import ir
+
+
+@dsl_user_op
+def atomic_max_float32(
+    ptr: cute.Pointer,
+    val: Float32,
+    *,
+    sem: str = "relaxed",
+    loc: ir.Location | None = None,
+    ip: ir.InsertionPoint | None = None,
+) -> Float32:
+    """Atomic float32 max via integer-bitcast dispatch to integer atomics.
+
+    Returns the previous float32 value stored at ``ptr``.
+    """
+    intval = llvm.bitcast(Int32.mlir_type, val.ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+
+    def neg_body() -> Int32:
+        # Negative val: float order inverts, use unsigned min.
+        return Int32(
+            Uint32(
+                cute.arch.atomic_min(ptr, Uint32(intval), sem=sem, loc=loc, ip=ip)
+            ).ir_value(loc=loc, ip=ip)
+        )
+
+    def nonneg_body() -> Int32:
+        # Non-negative val: signed order matches float order, use signed max.
+        return cute.arch.atomic_max(ptr, Int32(intval), sem=sem, loc=loc, ip=ip)
+
+    old_intval = cutlass.cutlass_dsl.if_generate(
+        Int32(intval) < Int32(0),
+        neg_body,
+        nonneg_body,
+        [],
+        [Int32],
+        loc=loc,
+        ip=ip,
+    )
+    assert not isinstance(old_intval, list)
+    return Float32(
+        llvm.bitcast(
+            Float32.mlir_type, old_intval.ir_value(loc=loc, ip=ip), loc=loc, ip=ip
+        )
+    )
+
+
+@dsl_user_op
+def atomic_min_float32(
+    ptr: cute.Pointer,
+    val: Float32,
+    *,
+    sem: str = "relaxed",
+    loc: ir.Location | None = None,
+    ip: ir.InsertionPoint | None = None,
+) -> Float32:
+    """Atomic float32 min via integer-bitcast dispatch to integer atomics.
+
+    Returns the previous float32 value stored at ``ptr``.
+    """
+    intval = llvm.bitcast(Int32.mlir_type, val.ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+
+    def neg_body() -> Int32:
+        # Negative val: float order inverts, use unsigned max.
+        return Int32(
+            Uint32(
+                cute.arch.atomic_max(ptr, Uint32(intval), sem=sem, loc=loc, ip=ip)
+            ).ir_value(loc=loc, ip=ip)
+        )
+
+    def nonneg_body() -> Int32:
+        # Non-negative val: signed order matches float order, use signed min.
+        return cute.arch.atomic_min(ptr, Int32(intval), sem=sem, loc=loc, ip=ip)
+
+    old_intval = cutlass.cutlass_dsl.if_generate(
+        Int32(intval) < Int32(0),
+        neg_body,
+        nonneg_body,
+        [],
+        [Int32],
+        loc=loc,
+        ip=ip,
+    )
+    assert not isinstance(old_intval, list)
+    return Float32(
+        llvm.bitcast(
+            Float32.mlir_type, old_intval.ir_value(loc=loc, ip=ip), loc=loc, ip=ip
+        )
+    )

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -106,6 +106,13 @@ def prepare_graph_lowerings(graph: torch.fx.Graph) -> None:
                 if node.op == "call_function":
                     with node.meta["location"]:
                         prepare_node_lowering(graph_lowering, node)
+                        lowering = node.meta.get("lowering")
+                        if isinstance(lowering, PointwiseLowering):
+                            # Catch the missing-keepdim broadcast bug at graph
+                            # build time (backend- and config-independent) so it
+                            # is rejected consistently on every backend, before
+                            # any config-specific validation or codegen.
+                            lowering._check_reduction_broadcast_keepdim(node)
 
 
 def prepare_node_lowering(
@@ -654,6 +661,77 @@ class PointwiseLowering(InductorLowering):
                 else:
                     exprs.add(size_i)
             if len(exprs) >= 2:
+                raise exc.ShapeMismatch(
+                    str(shapes[0]),
+                    ", ".join(map(str, shapes[1:])),
+                )
+
+    def _check_reduction_broadcast_keepdim(self, node: torch.fx.Node) -> None:
+        """Reject a reduction result broadcast against a *different* tile axis.
+
+        This is the missing-``keepdim`` bug: e.g.
+        ``x[tile_m, :] - torch.amax(x[tile_m, :], dim=1)`` drops the reduced N
+        axis, then the surviving M axis is right-aligned onto N (``[M, N] - [M]``).
+        It is rejected on **every** backend at graph-build time (so the error is
+        config- and backend-independent), unlike the size-coincidence leniency in
+        :meth:`_check_block_broadcast_compatibility` which would otherwise let
+        ``[M, N] - [M]`` through whenever the M and N block sizes happen to match.
+
+        The check is gated on an operand actually being a reduction result, so it
+        does **not** touch structurally-identical but legitimately-handled
+        patterns such as matmul-epilogue column-vector / aux-tensor broadcasts
+        (``acc + colvec[tile_m]``), which the backend's epilogue classifier owns
+        and rejects with its own actionable diagnostics.
+        """
+        env = CompileEnvironment.current()
+        if not any(
+            isinstance(inp.meta.get("lowering"), ReductionLowering)
+            for inp in node.all_input_nodes
+        ):
+            return
+        inputs = self.input_fake_tensors(node)
+        if len(inputs) < 2:
+            return
+
+        shapes: list[list[int | torch.SymInt]] = [[*t.size()] for t in inputs]
+        max_rank = max((len(s) for s in shapes), default=0)
+        for i, s in enumerate(shapes):
+            pad = max_rank - len(s)
+            if pad > 0:
+                shapes[i] = [1] * pad + s
+
+        def is_one(x: int | torch.SymInt) -> bool:
+            if isinstance(x, int):
+                return x == 1
+            expr = _symint_expr(x)
+            if isinstance(expr, sympy.Integer):
+                return int(expr) == 1
+            block_id = env.get_block_id(x)
+            if block_id is not None:
+                bs = env.block_sizes[block_id]
+                if isinstance(bs.block_size_source, FixedBlockSizeSource):
+                    val = bs.block_size_source.value
+                    if isinstance(val, int):
+                        return val == 1
+                    vexpr = _symint_expr(val) if isinstance(val, torch.SymInt) else None
+                    return isinstance(vexpr, sympy.Integer) and int(vexpr) == 1
+            return False
+
+        for dim in range(max_rank):
+            symbols: set[object] = set()
+            for s in shapes:
+                size_i = s[dim]
+                if is_one(size_i):
+                    continue
+                block_id = env.resolve_block_id(size_i)
+                if block_id is not None:
+                    symbols.add(
+                        env.block_sizes[env.canonical_block_id(block_id)].symbol()
+                    )
+            # Two *distinct* tile axes aligned in the same broadcast position is a
+            # wrong-axis (missing-keepdim) reduction broadcast, even when their
+            # current sizes coincide.
+            if len(symbols) >= 2:
                 raise exc.ShapeMismatch(
                     str(shapes[0]),
                     ", ".join(map(str, shapes[1:])),

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -1829,6 +1829,21 @@ class BlockReductionStrategy(ReductionStrategy):
             reduce_axis = self._aliased_active_thread_axis(block_axes)
         if reduce_axis is None:
             aliased_block_id = self._aliased_strategy_block_id()
+            # Only treat the reduce dim as a strided thread reduction when the
+            # aliased block is actually backed by a *live* thread axis. A block
+            # with ``block_size == 1`` (a grid/serial dim such as a size-1
+            # contributor axis) reports no live thread extent; its
+            # ``_thread_axis_map`` entry still records a phantom local axis that
+            # collides with an unrelated sibling block's real thread axis (e.g.
+            # the M tile on CuTe). Using that phantom axis would fold the
+            # reduction across the sibling's tile instead of squeezing the
+            # size-1 dim, so bail to the loop-carried / passthrough path.
+            if (
+                aliased_block_id is not None
+                and self.fn.tile_strategy.thread_extent_for_block_id(aliased_block_id)
+                is None
+            ):
+                aliased_block_id = None
             if aliased_block_id is not None:
                 reduce_axis = self.fn.tile_strategy.thread_axis_for_block_id(
                     aliased_block_id

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -7,6 +7,7 @@ import functools
 import itertools
 import math
 import operator
+import re
 from typing import TYPE_CHECKING
 from typing import NamedTuple
 from typing import TypeVar
@@ -393,13 +394,37 @@ def _split_one_lane_loop(loop: ast.For, lane_var: str) -> list[ast.AST]:
     if not markers:
         return [loop]
 
+    marker_indices = {i for i, _ in markers}
+
+    # A matmul whose *output* is reduced over a lane-distributed axis (e.g.
+    # matmul_layernorm's ``acc.sum(-1)`` over the synthetic-lane N output) cannot
+    # be handled by the per-lane / two-pass paths below: each lane owns a
+    # distinct output column, so the reduction must combine DIFFERENT lanes, and
+    # the matmul (an unduplicatable cross-thread shared-memory reduction) cannot
+    # be re-run in a second lane pass.  The register-stash lowering runs the
+    # matmul once, stashes each lane's output in a per-thread fragment, and
+    # re-derives every downstream reduction / consumer from the stash.
+    #
+    # This is gated narrowly so it does NOT disturb kernels the existing paths
+    # already handle correctly:
+    #   * an unduplicatable op must feed the reduction, and
+    #   * the marker results must NOT be consumed by a cross-lane loop-carried
+    #     accumulator.  Online-softmax attention carries ``mi``/``di`` across the
+    #     lane loop (``di = di * alpha + sum``); there the per-lane restore is
+    #     correct, so the stash path must stay out of the way.
+    if any(
+        _contains_unduplicatable_op(stmt) for stmt in body
+    ) and not _markers_feed_cross_lane_carry(body, lane_var, markers):
+        stashed = _split_lane_loop_with_register_stash(loop, lane_var, markers)
+        if stashed is not None:
+            return stashed
+
     # Safety: the two-pass split is only valid when the reduction marker is the
     # ONLY cross-lane carried value in this lane loop. If the body has another
     # loop-carried accumulator across the lanes (e.g. a matmul ``dot_acc`` or a
     # plain ``extra += per_lane`` sum that already accumulates over the lanes),
     # splitting would drop or double-count it. Fall back to the original
     # single-pass per-lane behavior by replacing each marker with its raw input.
-    marker_indices = {i for i, _ in markers}
     if _has_extra_cross_lane_carry(body, lane_var, marker_indices):
         return [_restore_per_lane_markers(loop, markers)]
 
@@ -419,7 +444,9 @@ def _split_one_lane_loop(loop: ast.For, lane_var: str) -> list[ast.AST]:
     # reduction-input producers. That is only safe for side-effect-free
     # producers. A matmul / collective in the slice (cross-thread shared-memory
     # reductions, ``cute.gemm``, ``dot``) cannot be duplicated without racing on
-    # shared memory, so fall back to per-lane behavior in that case.
+    # shared memory, so fall back to per-lane behavior in that case (the
+    # register-stash path above handles the cases where the per-lane restore
+    # would be numerically wrong).
     if any(_contains_unduplicatable_op(body[i]) for i in phase1_indices):
         return [_restore_per_lane_markers(loop, markers)]
 
@@ -495,6 +522,370 @@ def _split_one_lane_loop(loop: ast.For, lane_var: str) -> list[ast.AST]:
     if lane_varying_tail:
         result.append(_create_lane_loop(lane_var, extent, lane_varying_tail))
     return result
+
+
+_LANE_STASH_COUNTER = itertools.count()
+
+
+def _stash_dtype_for_value(
+    value_name: str, body: list[ast.AST], markers: list[tuple[int, _LaneReduceMarker]]
+) -> str:
+    """Pick a CuTe scalar dtype constructor for a stashed lane value.
+
+    Prefer the accumulator dtype of a marker whose input transitively reads the
+    stashed value (matmul outputs feed an fp32 ``sum``), then any cast that
+    wraps the value's defining assignment, then ``cutlass.Float32``.
+    """
+    from .ast_read_writes import ReadWrites
+
+    for _idx, m in markers:
+        slice_indices, _ = _backward_slice(body, {m.input_name})
+        reads_value = any(
+            value_name in ReadWrites.from_ast(body[i]).reads for i in slice_indices
+        )
+        if reads_value:
+            ctor = _dtype_ctor_from_identity(m.identity_expr)
+            if ctor is not None:
+                return ctor
+    for stmt in body:
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and stmt.targets[0].id == value_name
+            and isinstance(stmt.value, ast.Call)
+            and isinstance(stmt.value.func, ast.Attribute)
+            and isinstance(stmt.value.func.value, ast.Name)
+            and stmt.value.func.value.id == "cutlass"
+        ):
+            return f"cutlass.{stmt.value.func.attr}"
+    return "cutlass.Float32"
+
+
+def _strip_ssa_suffix(name: str) -> str:
+    """Strip Helion's SSA / loop-carry suffixes from a variable name.
+
+    ``acc_1`` / ``acc_copy`` / ``acc_copy_0`` all collapse to ``acc`` so a
+    loop-carried accumulator can be matched to its per-iteration rewrites.
+    """
+    base = re.sub(r"(_copy)(_\d+)*$", "", name)
+    return re.sub(r"(_\d+)+$", "", base)
+
+
+def _assigns_simple_name(stmt: ast.AST, names: set[str]) -> bool:
+    """Return True when ``stmt`` is ``X = ...`` for some ``X`` in ``names``."""
+    return (
+        isinstance(stmt, ast.Assign)
+        and len(stmt.targets) == 1
+        and isinstance(stmt.targets[0], ast.Name)
+        and stmt.targets[0].id in names
+    )
+
+
+def _undup_stmt_rederives(stmt: ast.AST, name: str) -> bool:
+    """Return True when ``stmt`` (an unduplicatable statement, typically the
+    matmul K ``for`` loop) re-derives the loop-carried accumulator ``name``.
+
+    The statement re-derives ``name`` when it both reads ``name`` (the live-in
+    accumulator) and writes a value transitively dependent on ``name`` whose
+    SSA-stripped name equals ``name`` (e.g. ``acc_1 = acc_copy_0 + ...``).  A
+    plain input the matmul only reads (``indices_2``) is not re-derived.
+    """
+    from .ast_read_writes import ReadWrites
+
+    if not isinstance(stmt, ast.For):
+        rw = ReadWrites.from_ast(stmt)
+        return name in rw.reads and any(_strip_ssa_suffix(w) == name for w in rw.writes)
+    if name not in ReadWrites.from_ast(stmt).reads:
+        return False
+    # Forward slice from ``name`` within the loop body; True when it reaches a
+    # write whose stripped name is ``name``.
+    inner = list(stmt.body)
+    tainted = {name}
+    changed = True
+    while changed:
+        changed = False
+        for s in inner:
+            rw = ReadWrites.from_ast(s)
+            if set(rw.reads) & tainted:
+                for w in rw.writes:
+                    if w not in tainted:
+                        tainted.add(w)
+                        changed = True
+    return any(_strip_ssa_suffix(w) == name for w in tainted if w != name)
+
+
+def _split_lane_loop_with_register_stash(
+    loop: ast.For,
+    lane_var: str,
+    markers: list[tuple[int, _LaneReduceMarker]],
+) -> list[ast.AST] | None:
+    """Lower a lane loop whose reduction inputs depend on an unduplicatable op.
+
+    The standard two-pass split re-runs the reduction-input producers in a
+    second pass, which is unsafe when a matmul / cross-thread reduction is in
+    the slice.  Instead, run the matmul-bearing *compute region* (the prefix of
+    the body up to and including the last unduplicatable statement) exactly
+    once, stashing each lane's unduplicatable-derived live-out values into
+    per-thread register fragments.  Every downstream reduction marker and
+    consumer is then re-derived from the stash (a plain register read, safely
+    duplicatable), one accumulate/finalize pass per marker in dependency order,
+    plus a final consume pass for the side-effecting statements.
+
+    Returns the replacement statement list, or ``None`` when the pattern does
+    not apply (caller then falls back to the per-lane single-pass behavior).
+    """
+    from .ast_read_writes import ReadWrites
+
+    body: list[ast.AST] = list(loop.body)
+    marker_indices = {i for i, _ in markers}
+    extent = _lane_loop_extent(loop)
+
+    # Compute region: prefix of the body up to (and including) the last
+    # unduplicatable statement.  Everything after it must be free of
+    # unduplicatable ops so it can be re-derived from the stash.
+    undup_indices = [
+        i for i in range(len(body)) if _contains_unduplicatable_op(body[i])
+    ]
+    if not undup_indices:
+        return None
+    region_end = max(undup_indices)
+    region = body[: region_end + 1]
+    tail = body[region_end + 1 :]
+    tail_offset = region_end + 1
+    if any(_contains_unduplicatable_op(s) for s in tail):
+        return None
+    # A marker inside the compute region cannot be re-derived from the stash
+    # (its reduction would have to run before the matmul finishes).
+    if any(i <= region_end for i in marker_indices):
+        return None
+
+    if extent <= 0 or extent > 256:
+        return None
+
+    lane_varying = _lane_varying_names(body, lane_var)
+
+    tail_reads: set[str] = set()
+    for stmt in tail:
+        tail_reads |= set(ReadWrites.from_ast(stmt).reads)
+
+    # Identify the loop-carried accumulators produced by the unduplicatable
+    # statements — values whose post-region magnitude depends on the matmul and
+    # therefore cannot be recomputed.  These are exactly the names that MUST be
+    # stashed.  Helion emits a matmul K loop as
+    # ``acc = 0; for k: acc_copy = acc; ...; acc_<n> = acc_copy_0 + reduce`` and
+    # an implicit phi makes the post-loop ``acc`` equal the loop output
+    # ``acc_<n>`` (collapsed by a later rename pass).  A name X is carried when:
+    #   * X is written by a non-unduplicatable region statement (its ``acc = 0``
+    #     seed) and read after the region (lane-varying), and
+    #   * an unduplicatable statement's body re-derives X — its forward slice
+    #     from X reaches a write whose SSA-stripped name equals X (``acc_1`` /
+    #     ``acc_copy`` -> ``acc``).
+    # The forward-slice condition distinguishes a true accumulator (``acc``,
+    # rewritten each K step) from a plain input that the matmul merely reads
+    # (``indices_2``, unchanged through the loop).
+    seed_writes: set[str] = set()
+    for i, stmt in enumerate(region):
+        if i in undup_indices:
+            continue
+        seed_writes |= set(ReadWrites.from_ast(stmt).writes)
+    # The carried accumulator's *name* (``acc`` from ``acc = 0``) is not itself
+    # lane-varying — only the loop output alias (``acc_1``) is — so do NOT filter
+    # candidates by ``lane_varying`` here.  The re-derives check confirms the
+    # matmul transforms the accumulator, and below we require the re-deriving
+    # statement to be lane-varying so a genuinely lane-invariant accumulator is
+    # left alone.
+    candidate_carried = seed_writes & tail_reads
+    carried: set[str] = set()
+    for name in candidate_carried:
+        for i in undup_indices:
+            if not _undup_stmt_rederives(body[i], name):
+                continue
+            stmt_reads = set(ReadWrites.from_ast(body[i]).reads)
+            if lane_var in stmt_reads or bool(stmt_reads & lane_varying):
+                carried.add(name)
+                break
+    # Also stash any value DIRECTLY produced by an unduplicatable statement that
+    # is read by the tail (e.g. a matmul whose output is a fresh name rather than
+    # an accumulator phi).
+    undup_writes: set[str] = set()
+    for i in undup_indices:
+        undup_writes |= set(ReadWrites.from_ast(body[i]).writes)
+    direct = undup_writes & lane_varying & tail_reads
+    stash_names = sorted(carried | direct)
+    if not stash_names:
+        return None
+
+    stash_set = set(stash_names)
+    # Region statements that are *duplicatable* and can be recomputed cheaply in
+    # the later passes (e.g. ``indices_2 = thread_idx[0] + lane * 4``).  Drop the
+    # unduplicatable statements and any statement that produces a stashed name.
+    recompute: list[ast.AST] = []
+    for i, stmt in enumerate(region):
+        if i in undup_indices:
+            continue
+        writes = set(ReadWrites.from_ast(stmt).writes)
+        if writes & stash_set:
+            continue
+        recompute.append(stmt)
+    # Keep only the recompute statements that (transitively) feed the tail.
+    recompute_keep_idx, _ = _backward_slice(recompute, tail_reads)
+    recompute_kept = [recompute[i] for i in recompute_keep_idx]
+    # The recompute slice must not pull in an unduplicatable op or reference a
+    # stashed name (which is only available from the fragment, not recomputable).
+    for s in recompute_kept:
+        if _contains_unduplicatable_op(s):
+            return None
+
+    # Allocate one register fragment per stashed value.
+    uid = next(_LANE_STASH_COUNTER)
+    frag_by_name: dict[str, str] = {}
+    decls: list[ast.AST] = []
+    for name in stash_names:
+        frag = f"_lane_stash_{uid}_{name}"
+        frag_by_name[name] = frag
+        dtype = _stash_dtype_for_value(name, body, markers)
+        decls.append(
+            statement_from_string(f"{frag} = cute.make_fragment({extent}, {dtype})")
+        )
+
+    def read_stash_stmts() -> list[ast.AST]:
+        return [
+            statement_from_string(f"{name} = {frag_by_name[name]}[{lane_var}]")
+            for name in stash_names
+        ]
+
+    # Phase 0: run the compute region once and stash the live-out values.
+    phase0_body: list[ast.AST] = list(region)
+    for name in stash_names:
+        phase0_body.append(
+            statement_from_string(f"{frag_by_name[name]}[{lane_var}] = {name}")
+        )
+
+    # The marker assignments within the tail produce already-finalized scalars
+    # (computed once after each reduction pass), so they must NOT be re-run as
+    # per-lane passthroughs inside any later pass.  Build the re-derivable tail
+    # (every non-marker statement) and the set of finalized marker result vars
+    # that downstream slices treat as pre-defined boundaries.
+    marker_result_vars = {m.result_var for _, m in markers}
+    rederivable_tail = [s for s in tail if _is_lane_reduce_marker_assign(s) is None]
+
+    result: list[ast.AST] = []
+    result.extend(decls)
+    result.append(_create_lane_loop(lane_var, extent, phase0_body))
+
+    # Process each marker in source order (they are sequentially dependent: a
+    # later marker's input may read an earlier marker's finalized scalar).
+    for _idx, m in markers:
+        acc_var = f"{m.result_var}_lane_acc"
+        result.append(statement_from_string(f"{acc_var} = {m.identity_expr}"))
+        # Accumulate pass: recompute cheap region producers, read the stash,
+        # then re-derive this marker's input and fold it into the accumulator.
+        # The slice runs over the re-derivable tail only; references to other
+        # markers' results stop at those finalized scalars.
+        input_slice_idx, _ = _backward_slice(rederivable_tail, {m.input_name})
+        input_stmts = [
+            rederivable_tail[i]
+            for i in input_slice_idx
+            if not _assigns_simple_name(rederivable_tail[i], marker_result_vars)
+        ]
+        acc_body: list[ast.AST] = []
+        acc_body.extend(_clone_stmt(s) for s in recompute_kept)
+        acc_body.extend(read_stash_stmts())
+        acc_body.extend(_clone_stmt(s) for s in input_stmts)
+        ctor = _dtype_ctor_from_identity(m.identity_expr)
+        combine_val = f"{ctor}({m.input_name})" if ctor is not None else m.input_name
+        acc_body.append(
+            statement_from_string(
+                f"{acc_var} = {_combine_expr(m.reduction_type, acc_var, combine_val)}"
+            )
+        )
+        result.append(_create_lane_loop(lane_var, extent, acc_body))
+        if m.group_span > 1 and m.group_pre > 1 and m.group_lane_expr:
+            reduced = _grouped_warp_reduce_expr(
+                m.reduction_type,
+                acc_var,
+                m.identity_expr,
+                m.group_lane_expr,
+                pre=m.group_pre,
+                group_span=m.group_span,
+            )
+        elif m.threads_in_group > 1:
+            reduced = _warp_reduce_expr(m.reduction_type, acc_var, m.threads_in_group)
+        else:
+            reduced = acc_var
+        result.append(
+            statement_from_string(f"{m.result_var} = {m.finalize_expr(reduced)}")
+        )
+
+    # Final consume pass: everything in the tail except the marker assignments,
+    # re-derived from the stash + finalized scalars.  Only keep statements that
+    # feed a side effect (a store / in-place write).
+    consume_candidates = [s for i, s in enumerate(body) if i >= tail_offset]
+    consume_candidates = [
+        s for s in consume_candidates if _is_lane_reduce_marker_assign(s) is None
+    ]
+    keep_idx = _live_phase2_indices(consume_candidates)
+    consume_kept = [s for i, s in enumerate(consume_candidates) if i in keep_idx]
+    if consume_kept:
+        consume_body: list[ast.AST] = []
+        consume_body.extend(_clone_stmt(s) for s in recompute_kept)
+        consume_body.extend(read_stash_stmts())
+        consume_body.extend(_clone_stmt(s) for s in consume_kept)
+        result.append(_create_lane_loop(lane_var, extent, consume_body))
+    return result
+
+
+def _markers_feed_cross_lane_carry(
+    body: list[ast.AST],
+    lane_var: str,
+    markers: list[tuple[int, _LaneReduceMarker]],
+) -> bool:
+    """Return True when the lane loop carries an accumulator across the lanes
+    that a marker result feeds (online-softmax attention's ``m_i`` / ``l_i`` /
+    ``acc`` recurrence).
+
+    Helion represents a loop-carried value with a phi ``X_copy = X`` read at the
+    TOP of the loop body (before the value is rewritten) and a corresponding
+    output assignment renamed back to ``X`` by a later pass.  Such an
+    accumulating lane loop must keep the existing per-lane restore lowering, so
+    the register-stash path (which assumes each marker result is consumed only by
+    per-lane / store consumers, never carried across lanes) must not fire.
+
+    matmul_layernorm's N-output lane loop has no such top-level ``X_copy = X``
+    carry (its ``acc`` is the matmul accumulator, carried by the *inner* K loop,
+    not across the lane iterations), so this returns False and the stash path is
+    free to run.
+    """
+    from .ast_read_writes import ReadWrites
+
+    if not markers:
+        return False
+
+    # Live-in names of the lane body (read before written), excluding the lane
+    # var.  A loop-carried accumulator phi is live-in.
+    written_so_far: set[str] = set()
+    live_in: set[str] = set()
+    for stmt in body:
+        rw = ReadWrites.from_ast(stmt)
+        for name in rw.reads:
+            if name != lane_var and name not in written_so_far:
+                live_in.add(name)
+        written_so_far |= set(rw.writes)
+
+    # Detect top-level phi copies ``X_copy = X`` of a live-in accumulator.
+    for stmt in body:
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and isinstance(stmt.value, ast.Name)
+        ):
+            src = stmt.value.id
+            dst = stmt.targets[0].id
+            if src in live_in and _strip_ssa_suffix(dst) == _strip_ssa_suffix(src):
+                return True
+    return False
 
 
 def _has_extra_cross_lane_carry(

--- a/helion/language/atomic_ops.py
+++ b/helion/language/atomic_ops.py
@@ -154,6 +154,33 @@ def _resolve_cute_atomic_kwargs(cute_func: str, requested: list[str]) -> list[st
     return resolved
 
 
+_CUTE_FLOAT_ATOMIC_HELPERS: dict[str, str] = {
+    "atomic_max": "_cute_atomic_max_float32",
+    "atomic_min": "_cute_atomic_min_float32",
+}
+
+
+def _cute_atomic_callee(cute_func: str, target_dtype_torch: torch.dtype) -> str:
+    """Pick the callee for a CuTe atomic op.
+
+    NVVM/PTX has no native ``atom.max``/``atom.min`` for floating point, so
+    float ``atomic_max``/``atomic_min`` are routed through runtime helpers that
+    emulate them with integer atomics (registered in
+    ``CuteBackend.library_imports``). All other ops, and integer max/min, use
+    the native ``cute.arch.<func>`` directly.
+    """
+    helper = _CUTE_FLOAT_ATOMIC_HELPERS.get(cute_func)
+    if helper is None or not target_dtype_torch.is_floating_point:
+        return f"cute.arch.{cute_func}"
+    if target_dtype_torch is not torch.float32:
+        raise exc.BackendUnsupported(
+            "cute",
+            f"{cute_func} on floating-point dtype {target_dtype_torch} "
+            "(only float32 is supported)",
+        )
+    return helper
+
+
 def _codegen_common_cute(
     cute_func: str,
     state: CodegenState,
@@ -176,6 +203,7 @@ def _codegen_common_cute(
 
     backend = CompileEnvironment.current().backend
     target_dtype = backend.dtype_str(target.dtype)
+    callee = _cute_atomic_callee(cute_func, target.dtype)
     cast_value_exprs = [
         expr_from_string(
             backend.ast_to_dtype_expr("{value}", target_dtype),
@@ -191,6 +219,7 @@ def _codegen_common_cute(
         sem,
         cast_value_exprs,
         keyword_names,
+        callee,
     )
     if tensor_index_stmt is not None:
         return tensor_index_stmt
@@ -204,7 +233,7 @@ def _codegen_common_cute(
     )
     placeholders = dict(zip(keyword_names, cast_value_exprs, strict=True))
     atomic_expr = expr_from_string(
-        f"cute.arch.{cute_func}({{ptr}}, {values_section}, sem={{sem}})",
+        f"{callee}({{ptr}}, {values_section}, sem={{sem}})",
         ptr=expr_from_string(pointer),
         sem=sem,
         **placeholders,
@@ -551,6 +580,7 @@ def _codegen_tensor_index_common_cute(
     sem: ast.AST,
     value_exprs: list[ast.AST],
     keyword_names: list[str],
+    callee: str,
 ) -> ast.AST | None:
     from .._compiler.compile_environment import CompileEnvironment
     from .memory_ops import _cute_active_index_var
@@ -585,6 +615,7 @@ def _codegen_tensor_index_common_cute(
             sem,
             value_exprs,
             keyword_names,
+            callee,
         )
 
     env = CompileEnvironment.current()
@@ -599,6 +630,7 @@ def _codegen_tensor_index_common_cute(
             sem,
             value_exprs,
             keyword_names,
+            callee,
         )
     block_id = env.resolve_codegen_block_id(block_id, state.codegen, fx_node.graph)
     if (index_var := _cute_active_index_var(state, block_id)) is None:
@@ -611,6 +643,7 @@ def _codegen_tensor_index_common_cute(
             sem,
             value_exprs,
             keyword_names,
+            callee,
         )
 
     tensor_name = state.device_function.tensor_arg(target).name
@@ -621,8 +654,7 @@ def _codegen_tensor_index_common_cute(
     )
     placeholders = dict(zip(keyword_names, value_exprs, strict=True))
     atomic_expr = expr_from_string(
-        "cute.arch."
-        + cute_func
+        callee
         + "("
         + f"({tensor_name}.iterator + "
         + f"cute.crd2idx((cutlass.Int32({iota_start}) + {index_var},), {tensor_name}.layout)).llvm_ptr, "
@@ -655,6 +687,7 @@ def _codegen_tensor_index_loop_common_cute(
     sem: ast.AST,
     value_exprs: list[ast.AST],
     keyword_names: list[str],
+    callee: str,
 ) -> ast.AST | None:
     from .._compiler.ast_extension import statement_from_string
 
@@ -717,8 +750,7 @@ def _codegen_tensor_index_loop_common_cute(
     )
     placeholders = dict(zip(keyword_names, indexed_values, strict=True))
     atomic_expr = expr_from_string(
-        "cute.arch."
-        + cute_func
+        callee
         + "("
         + f"({tensor_name}.iterator + "
         + f"cute.crd2idx(({{index}},), {tensor_name}.layout)).llvm_ptr, "

--- a/test/test_atomic_ops.py
+++ b/test/test_atomic_ops.py
@@ -11,7 +11,6 @@ from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
-from helion._testing import skipIfCute
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfRocm
 from helion._testing import skipIfTileIR
@@ -538,11 +537,6 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
             out_y, torch.full([16, 128], 2.0, device=DEVICE) + y.sum(dim=0)
         )
 
-    @skipIfCute(
-        "CuTe atomic_max/atomic_min on float32 emit an unsupported NVVM "
-        "atomicrmw (no native float atomic max/min); needs a CAS-loop "
-        "emulation"
-    )
     def test_structural_atomic_max_min_shared_tile(self):
         @helion.kernel(static_shapes=True)
         def structural_atomic_max_kernel(x: torch.Tensor) -> torch.Tensor:

--- a/test/test_atomic_ops.py
+++ b/test/test_atomic_ops.py
@@ -481,7 +481,6 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
                 expected = torch.ones(16, 128, device=DEVICE) + x.sum(dim=0)
                 torch.testing.assert_close(result, expected)
 
-    @skipIfCute("CuTe does not handle structural shared-tile atomics yet")
     def test_structural_atomic_add_two_contributor_dims(self):
         @helion.kernel(static_shapes=True)
         def structural_atomic_add_2_contributor_kernel(
@@ -508,7 +507,6 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
         expected = torch.ones(16, 128, device=DEVICE) + x.sum(dim=(0, 1))
         torch.testing.assert_close(result, expected)
 
-    @skipIfCute("CuTe does not handle structural shared-tile atomics yet")
     def test_structural_atomic_add_multiple_outputs(self):
         @helion.kernel(static_shapes=True)
         def structural_atomic_add_two_outputs_kernel(
@@ -540,7 +538,11 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
             out_y, torch.full([16, 128], 2.0, device=DEVICE) + y.sum(dim=0)
         )
 
-    @skipIfCute("CuTe does not handle structural shared-tile atomics yet")
+    @skipIfCute(
+        "CuTe atomic_max/atomic_min on float32 emit an unsupported NVVM "
+        "atomicrmw (no native float atomic max/min); needs a CAS-loop "
+        "emulation"
+    )
     def test_structural_atomic_max_min_shared_tile(self):
         @helion.kernel(static_shapes=True)
         def structural_atomic_max_kernel(x: torch.Tensor) -> torch.Tensor:

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -108,11 +108,10 @@ class TestErrors(RefEagerTestDisabled, TestCase):
         """Binary op should detect broadcast shape mismatch from reduction without keep_dims.
 
         This mirrors the softmax pattern where a row-wise reduction loses the
-        dimension and then is subtracted from a 2D tensor without keep_dims.
-        On Triton this surfaces as a ``ShapeMismatch`` from the MLIR
-        ``make_shape_compatible`` check; CuTe instead lowers the full-row
-        reduction as a row-wise scalar, which broadcasts legally and produces
-        the correct softmax, so no error is raised there.
+        dimension and is then subtracted from a 2D tile without keep_dims, so the
+        reduction's M axis is silently aligned onto the N axis. Helion rejects
+        this with ``ShapeMismatch`` on every backend at graph-build time -- the
+        correct kernel uses ``keepdim=True`` (see examples/softmax.py).
         """
 
         # Mirror scratch.py behavior exactly
@@ -127,18 +126,8 @@ class TestErrors(RefEagerTestDisabled, TestCase):
             return out
 
         x = torch.randn(32, 64, device=DEVICE)
-        if _get_backend() == "cute":
-            # CuTe lowers the dim-1 reduction as a row-wise scalar; the broadcast
-            # is legal and yields the correct softmax. Use an explicit config so
-            # the reduction axis keeps a thread budget (the default config has
-            # both tile axes consume the full 1024-thread budget).
-            _, result = code_and_output(fn, (x,), block_sizes=[16, 16], num_warps=4)
-            torch.testing.assert_close(
-                result, torch.softmax(x, dim=1), atol=1e-4, rtol=1e-4
-            )
-        else:
-            with self.assertRaises(helion.exc.ShapeMismatch):
-                fn(x)
+        with self.assertRaises(helion.exc.ShapeMismatch):
+            fn(x)
 
     def test_tile_unpacking(self):
         @helion.kernel()

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -12,7 +12,6 @@ from helion._testing import RefEagerTestDisabled
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
-from helion._testing import skipIfCute
 from helion.autotuner.base_search import PopulationBasedSearch
 from helion.autotuner.base_search import PopulationMember
 from helion.autotuner.differential_evolution import DifferentialEvolutionSearch
@@ -105,12 +104,15 @@ class TestErrors(RefEagerTestDisabled, TestCase):
         ):
             search.autotune()
 
-    @skipIfCute("CuTe lowers the full-row reduction as a row-wise scalar")
     def test_shape_mismatch_missing_keepdims(self):
         """Binary op should detect broadcast shape mismatch from reduction without keep_dims.
 
         This mirrors the softmax pattern where a row-wise reduction loses the
         dimension and then is subtracted from a 2D tensor without keep_dims.
+        On Triton this surfaces as a ``ShapeMismatch`` from the MLIR
+        ``make_shape_compatible`` check; CuTe instead lowers the full-row
+        reduction as a row-wise scalar, which broadcasts legally and produces
+        the correct softmax, so no error is raised there.
         """
 
         # Mirror scratch.py behavior exactly
@@ -124,8 +126,19 @@ class TestErrors(RefEagerTestDisabled, TestCase):
                 out[tile_m, :] = out_rows
             return out
 
-        with self.assertRaises(helion.exc.ShapeMismatch):
-            fn(torch.randn(32, 64, device=DEVICE))
+        x = torch.randn(32, 64, device=DEVICE)
+        if _get_backend() == "cute":
+            # CuTe lowers the dim-1 reduction as a row-wise scalar; the broadcast
+            # is legal and yields the correct softmax. Use an explicit config so
+            # the reduction axis keeps a thread budget (the default config has
+            # both tile axes consume the full 1024-thread budget).
+            _, result = code_and_output(fn, (x,), block_sizes=[16, 16], num_warps=4)
+            torch.testing.assert_close(
+                result, torch.softmax(x, dim=1), atol=1e-4, rtol=1e-4
+            )
+        else:
+            with self.assertRaises(helion.exc.ShapeMismatch):
+                fn(x)
 
     def test_tile_unpacking(self):
         @helion.kernel()

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -306,10 +306,6 @@ class TestExamples(RefEagerTestBase, TestCase):
         torch.testing.assert_close(mat1.grad, mat1_ref.grad, atol=1e-1, rtol=1e-2)
         torch.testing.assert_close(mat2.grad, mat2_ref.grad, atol=1e-1, rtol=1e-2)
 
-    @skipIfFn(
-        lambda: _get_backend() == "cute",
-        "CuTe matmul+layernorm example is unsupported and too expensive in-process",
-    )
     def test_matmul_layernorm_static_shapes(self):
         args = (
             torch.randn([1024, 256], device=DEVICE, dtype=torch.float32),

--- a/test/test_matmul.py
+++ b/test/test_matmul.py
@@ -374,7 +374,6 @@ class TestMatmul(RefEagerTestBase, TestCase):
         else:
             self.assertIn("tl.atomic_add", code)
 
-    @skipIfNotTriton("config reuse crashes CUDA on cute, corrupting test state")
     @skipIfRefEager("config_spec is not supported in ref eager mode")
     def test_matmul_config_reuse_with_unit_dim(self):
         torch.manual_seed(0)


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * __->__#2694
 * #2690
 * #2689
 * #2688


--- --- ---

[cute] Reject missing-keepdim reduction broadcast in type propagation

Addresses jansel's review on #2688: a reduction-without-keepdim broadcast
(e.g. x[tile_m, :] - amax(x[tile_m, :], dim=1), which aligns the M axis onto N)
should shape-error on every backend, not just Triton. Previously only Triton
caught it (late, via MLIR); cute silently accepted it.

Add a build-time (type-propagation) check, prepare_graph_lowerings ->
_check_reduction_broadcast_keepdim, that rejects distinct tile axes aligned in
the same broadcast position when an operand is a reduction result -- even when
the two axes' block sizes coincide (which the existing codegen-time
_check_block_broadcast_compatibility lets through). Running at graph build makes
the error backend- and config-independent, so cute now raises ShapeMismatch too
(before its config-specific InvalidConfig). Revert the test to expect
ShapeMismatch on both backends.

The check is gated on an operand being a reduction so it does NOT touch the
structurally-identical matmul-epilogue colvec/aux broadcasts (acc + colvec[m])
that the cute tcgen05 classifier owns and rejects with its own diagnostics.
Verified zero new regressions across cute + triton reduction/broadcast/examples
suites (the 3 tcgen05 epilogue-rejection tests and the matmul-fallback tests
still pass).