### PR TITLE
[cute] Reject missing-keepdim reduction broadcast in type propagation

### DIFF
--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -106,6 +106,13 @@ def prepare_graph_lowerings(graph: torch.fx.Graph) -> None:
                 if node.op == "call_function":
                     with node.meta["location"]:
                         prepare_node_lowering(graph_lowering, node)
+                        lowering = node.meta.get("lowering")
+                        if isinstance(lowering, PointwiseLowering):
+                            # Catch the missing-keepdim broadcast bug at graph
+                            # build time (backend- and config-independent) so it
+                            # is rejected consistently on every backend, before
+                            # any config-specific validation or codegen.
+                            lowering._check_reduction_broadcast_keepdim(node)
 
 
 def prepare_node_lowering(
@@ -654,6 +661,77 @@ class PointwiseLowering(InductorLowering):
                 else:
                     exprs.add(size_i)
             if len(exprs) >= 2:
+                raise exc.ShapeMismatch(
+                    str(shapes[0]),
+                    ", ".join(map(str, shapes[1:])),
+                )
+
+    def _check_reduction_broadcast_keepdim(self, node: torch.fx.Node) -> None:
+        """Reject a reduction result broadcast against a *different* tile axis.
+
+        This is the missing-``keepdim`` bug: e.g.
+        ``x[tile_m, :] - torch.amax(x[tile_m, :], dim=1)`` drops the reduced N
+        axis, then the surviving M axis is right-aligned onto N (``[M, N] - [M]``).
+        It is rejected on **every** backend at graph-build time (so the error is
+        config- and backend-independent), unlike the size-coincidence leniency in
+        :meth:`_check_block_broadcast_compatibility` which would otherwise let
+        ``[M, N] - [M]`` through whenever the M and N block sizes happen to match.
+
+        The check is gated on an operand actually being a reduction result, so it
+        does **not** touch structurally-identical but legitimately-handled
+        patterns such as matmul-epilogue column-vector / aux-tensor broadcasts
+        (``acc + colvec[tile_m]``), which the backend's epilogue classifier owns
+        and rejects with its own actionable diagnostics.
+        """
+        env = CompileEnvironment.current()
+        if not any(
+            isinstance(inp.meta.get("lowering"), ReductionLowering)
+            for inp in node.all_input_nodes
+        ):
+            return
+        inputs = self.input_fake_tensors(node)
+        if len(inputs) < 2:
+            return
+
+        shapes: list[list[int | torch.SymInt]] = [[*t.size()] for t in inputs]
+        max_rank = max((len(s) for s in shapes), default=0)
+        for i, s in enumerate(shapes):
+            pad = max_rank - len(s)
+            if pad > 0:
+                shapes[i] = [1] * pad + s
+
+        def is_one(x: int | torch.SymInt) -> bool:
+            if isinstance(x, int):
+                return x == 1
+            expr = _symint_expr(x)
+            if isinstance(expr, sympy.Integer):
+                return int(expr) == 1
+            block_id = env.get_block_id(x)
+            if block_id is not None:
+                bs = env.block_sizes[block_id]
+                if isinstance(bs.block_size_source, FixedBlockSizeSource):
+                    val = bs.block_size_source.value
+                    if isinstance(val, int):
+                        return val == 1
+                    vexpr = _symint_expr(val) if isinstance(val, torch.SymInt) else None
+                    return isinstance(vexpr, sympy.Integer) and int(vexpr) == 1
+            return False
+
+        for dim in range(max_rank):
+            symbols: set[object] = set()
+            for s in shapes:
+                size_i = s[dim]
+                if is_one(size_i):
+                    continue
+                block_id = env.resolve_block_id(size_i)
+                if block_id is not None:
+                    symbols.add(
+                        env.block_sizes[env.canonical_block_id(block_id)].symbol()
+                    )
+            # Two *distinct* tile axes aligned in the same broadcast position is a
+            # wrong-axis (missing-keepdim) reduction broadcast, even when their
+            # current sizes coincide.
+            if len(symbols) >= 2:
                 raise exc.ShapeMismatch(
                     str(shapes[0]),
                     ", ".join(map(str, shapes[1:])),

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -12,7 +12,6 @@ from helion._testing import RefEagerTestDisabled
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
-from helion._testing import skipIfCute
 from helion.autotuner.base_search import PopulationBasedSearch
 from helion.autotuner.base_search import PopulationMember
 from helion.autotuner.differential_evolution import DifferentialEvolutionSearch
@@ -105,12 +104,14 @@ class TestErrors(RefEagerTestDisabled, TestCase):
         ):
             search.autotune()
 
-    @skipIfCute("CuTe lowers the full-row reduction as a row-wise scalar")
     def test_shape_mismatch_missing_keepdims(self):
         """Binary op should detect broadcast shape mismatch from reduction without keep_dims.
 
         This mirrors the softmax pattern where a row-wise reduction loses the
-        dimension and then is subtracted from a 2D tensor without keep_dims.
+        dimension and is then subtracted from a 2D tile without keep_dims, so the
+        reduction's M axis is silently aligned onto the N axis. Helion rejects
+        this with ``ShapeMismatch`` on every backend at graph-build time -- the
+        correct kernel uses ``keepdim=True`` (see examples/softmax.py).
         """
 
         # Mirror scratch.py behavior exactly
@@ -124,8 +125,9 @@ class TestErrors(RefEagerTestDisabled, TestCase):
                 out[tile_m, :] = out_rows
             return out
 
+        x = torch.randn(32, 64, device=DEVICE)
         with self.assertRaises(helion.exc.ShapeMismatch):
-            fn(torch.randn(32, 64, device=DEVICE))
+            fn(x)
 
     def test_tile_unpacking(self):
         @helion.kernel()


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #2690
 * #2689
 * #2688
 * __->__#2695


--- --- ---

[cute] Reject missing-keepdim reduction broadcast in type propagation

Addresses jansel's review on #2688: a reduction-without-keepdim broadcast
(e.g. x[tile_m, :] - amax(x[tile_m, :], dim=1), aligning the M axis onto N)
should shape-error on every backend, not just Triton. Add a build-time
(type-propagation) check, prepare_graph_lowerings -> _check_reduction_broadcast_keepdim,
gated on a reduction operand so it does not touch matmul-epilogue colvec/aux
broadcasts owned by the cute tcgen05 classifier. cute now raises ShapeMismatch
consistently; the test asserts it on both backends.