### PR TITLE
[cute] FP8 scaled_mm on the CuTe backend, matching CUTLASS on B200 compute-bound shapes

### DIFF
--- a/cute_scaled_mm.py
+++ b/cute_scaled_mm.py
@@ -1,0 +1,645 @@
+# Fused rowwise-scale FP8 scaled_mm on top of the CUTLASS CuTe DSL persistent GEMM.
+#
+#   out[m,n] = scale_a[m] * scale_b[n] * sum_k(a_fp8[m,k] * b_fp8[k,n])
+#
+# scale_a [M] f32, scale_b [N] f32, a/b fp8 e4m3, out bf16.
+#
+# The scale is fused INTO the epilogue: after the accumulator is loaded from TMEM
+# to registers (still f32), we multiply each register element by
+# scale_a[m]*scale_b[n] BEFORE casting to bf16. The per-register (m,n) global
+# coords are obtained from an identity coordinate tensor partitioned IDENTICALLY
+# to the accumulator fragment (the EVT Row/Col-broadcast trick, done by hand).
+from typing import Any, Optional, Tuple, Type, Union
+from functools import lru_cache
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.cute.testing as testing
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+from cutlass.cutlass_dsl import Int32
+from cutlass.cute.nvgpu import cpasync, tcgen05
+
+import cute_dense_gemm_persistent as G
+
+# reuse host-side helpers
+prepare_tensors = G.prepare_tensors
+
+
+# ---------------------------------------------------------------------------
+# Custom TMA-store epilogue WITH fused rowwise scale.
+# Mirrors cutlass.utils.gemm.sm100.epilogue_tma_store, plus scale multiply.
+# ---------------------------------------------------------------------------
+@cute.jit
+def epilogue_tma_store_scaled(
+    gemm_kernel: Any,
+    epi_tidx: Int32,
+    warp_idx: Int32,
+    tma_atom_c: cute.CopyAtom,
+    tCtAcc_base: cute.Tensor,
+    sC: cute.Tensor,
+    tCgC_base: cute.Tensor,
+    tCgSA_base: cute.Tensor,  # scale_a broadcast (M,N,L) stride(1,0,0), part like tCgC
+    tCgSB_base: cute.Tensor,  # scale_b broadcast (M,N,L) stride(0,1,0), part like tCgC
+    epi_tile: cute.Tile,
+    num_tiles_executed: Int32,
+    mma_tile_coord_mnl: Tuple[Int32, Int32, Int32],
+    acc_consumer_state: pipeline.PipelineState,
+    acc_pipeline: pipeline.PipelineAsync,
+    c_pipeline: pipeline.PipelineTmaStore,
+) -> pipeline.PipelineState:
+    from cutlass.utils.gemm.sm100 import (
+        transform_partitioned_tensor_layout,
+        epilogue_tmem_copy_and_partition,
+        epilogue_smem_copy_and_partition,
+    )
+
+    tCgC = transform_partitioned_tensor_layout(tCgC_base)
+    tCtAcc = transform_partitioned_tensor_layout(tCtAcc_base)
+    tCgSA = transform_partitioned_tensor_layout(tCgSA_base)
+    tCgSB = transform_partitioned_tensor_layout(tCgSB_base)
+
+    tiled_copy_t2r, tTR_tAcc_base, tTR_rAcc = epilogue_tmem_copy_and_partition(
+        gemm_kernel, epi_tidx, tCtAcc, tCgC, epi_tile, gemm_kernel.use_2cta_instrs
+    )
+
+    tTR_rC = cute.make_rmem_tensor(tTR_rAcc.shape, gemm_kernel.c_dtype)
+    tiled_copy_r2s, tRS_rC, tRS_sC = epilogue_smem_copy_and_partition(
+        gemm_kernel, tiled_copy_t2r, tTR_rC, epi_tidx, sC
+    )
+
+    # Partition the scale broadcast tensors the SAME way as the accumulator's
+    # global C destination, so a vectorized copy fills register fragments
+    # aligned element-for-element with tTR_rAcc (EVT Col/Row broadcast).
+    thr_copy_t2r = tiled_copy_t2r.get_slice(epi_tidx)
+    sA_epi = cute.flat_divide(tCgSA, epi_tile)
+    sB_epi = cute.flat_divide(tCgSB, epi_tile)
+    tTR_gSA_base = thr_copy_t2r.partition_D(sA_epi)
+    tTR_gSB_base = thr_copy_t2r.partition_D(sB_epi)
+
+    tCgC_epi = cute.flat_divide(tCgC, epi_tile)
+    bSG_sC, bSG_gC_partitioned = cpasync.tma_partition(
+        tma_atom_c,
+        0,
+        cute.make_layout(1),
+        cute.group_modes(sC, 0, 2),
+        cute.group_modes(tCgC_epi, 0, 2),
+    )
+
+    epilog_sync_barrier = pipeline.NamedBarrier(
+        barrier_id=gemm_kernel.epilog_sync_bar_id,
+        num_threads=32 * len(gemm_kernel.epilogue_warp_id),
+    )
+
+    bSG_gC = bSG_gC_partitioned[(None, None, None, *mma_tile_coord_mnl)]
+    # (T2R, T2R_M, T2R_N, EPI_M, EPI_N)
+    tTR_gSA = tTR_gSA_base[(None, None, None, None, None, *mma_tile_coord_mnl)]
+    tTR_gSB = tTR_gSB_base[(None, None, None, None, None, *mma_tile_coord_mnl)]
+    tTR_tAcc = tTR_tAcc_base[(None, None, None, None, None, acc_consumer_state.index)]
+
+    tTR_gSA = cute.group_modes(tTR_gSA, 3, cute.rank(tTR_gSA))
+    tTR_gSB = cute.group_modes(tTR_gSB, 3, cute.rank(tTR_gSB))
+
+    # Issue the scale_b gmem load BEFORE waiting on the accumulator, so its
+    # memory latency overlaps with the MMA wait. scale_a is uniform over a
+    # thread's N-fragment (broadcast over N) -> read as a SINGLE scalar.
+    if cutlass.const_expr(gemm_kernel.fuse_scale):
+        tTR_rSB_full = cute.make_rmem_tensor(tTR_gSB.shape, gemm_kernel.acc_dtype)
+        cute.autovec_copy(tTR_gSB, tTR_rSB_full)
+
+    acc_pipeline.consumer_wait(acc_consumer_state)
+
+    tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+    bSG_gC = cute.group_modes(bSG_gC, 1, cute.rank(bSG_gC))
+
+    subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+    num_prev_subtiles = num_tiles_executed * subtile_cnt
+
+    for subtile_idx in range(subtile_cnt):
+        # Load accumulator (f32) from TMEM to registers
+        tTR_tAcc_mn = tTR_tAcc[(None, None, None, subtile_idx)]
+        cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
+        # Apply rowwise scale on the f32 accumulator BEFORE the bf16 cast.
+        if cutlass.const_expr(gemm_kernel.fuse_scale):
+            acc_vec = tiled_copy_r2s.retile(tTR_rAcc).load()
+            sa = tTR_gSA[(0, 0, 0, subtile_idx)]
+            sb_vec = tiled_copy_r2s.retile(
+                tTR_rSB_full[(None, None, None, subtile_idx)]
+            ).load()
+            acc_vec = acc_vec * sa * sb_vec
+        else:
+            acc_vec = tiled_copy_r2s.retile(tTR_rAcc).load()
+        acc_vec = acc_vec.to(gemm_kernel.c_dtype)
+        tRS_rC.store(acc_vec)
+
+        c_buffer = (num_prev_subtiles + subtile_idx) % gemm_kernel.num_c_stage
+        cute.copy(tiled_copy_r2s, tRS_rC, tRS_sC[(None, None, None, c_buffer)])
+        cute.arch.fence_proxy("async.shared", space="cta")
+        epilog_sync_barrier.arrive_and_wait()
+
+        if warp_idx == gemm_kernel.epilogue_warp_id[0]:
+            cute.copy(
+                tma_atom_c,
+                bSG_sC[(None, c_buffer)],
+                bSG_gC[(None, subtile_idx)],
+            )
+            c_pipeline.producer_commit()
+            c_pipeline.producer_acquire()
+        epilog_sync_barrier.arrive_and_wait()
+
+    epilog_sync_barrier.arrive_and_wait()
+
+    with cute.arch.elect_one():
+        acc_pipeline.consumer_release(acc_consumer_state)
+    acc_consumer_state.advance()
+    return acc_consumer_state
+
+
+class ScaledGemmKernel(G.PersistentDenseGemmKernel):
+    fuse_scale = True
+
+    @cute.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        c: cute.Tensor,
+        scale_a: cute.Tensor,
+        scale_b: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+    ):
+        self.a_dtype = a.element_type
+        self.b_dtype = b.element_type
+        self.c_dtype = c.element_type
+        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
+        self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
+        self.c_layout = utils.LayoutEnum.from_tensor(c)
+
+        if cutlass.const_expr(self.a_dtype != self.b_dtype):
+            raise TypeError(f"Type must match: {self.a_dtype} != {self.b_dtype}")
+
+        tiled_mma = self._create_tiled_mma()
+        self._setup_attributes()
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+
+        a_op = utils.sm100.cluster_shape_to_tma_atom_A(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op, a, a_smem_layout, self.mma_tiler, tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=(cutlass.TFloat32 if a.element_type is cutlass.Float32 else None),
+        )
+        b_op = utils.sm100.cluster_shape_to_tma_atom_B(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op, b, b_smem_layout, self.mma_tiler, tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=(cutlass.TFloat32 if b.element_type is cutlass.Float32 else None),
+        )
+
+        a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+        self.num_tma_load_bytes = (a_copy_size + b_copy_size) * atom_thr_size
+
+        epi_smem_layout = cute.select(self.c_smem_layout_staged, mode=[0, 1])
+        tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileS2GOp(), c, epi_smem_layout, self.epi_tile
+        )
+
+        self.tile_sched_params, grid = self._compute_grid(
+            c, self.cta_tile_shape_mnk, self.cluster_shape_mn, max_active_clusters
+        )
+
+        self.kernel(
+            tiled_mma,
+            tma_atom_a, tma_tensor_a,
+            tma_atom_b, tma_tensor_b,
+            tma_atom_c, tma_tensor_c,
+            scale_a, scale_b,
+            self.cluster_layout_vmnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.c_smem_layout_staged,
+            self.epi_tile,
+            self.tile_sched_params,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            stream=stream,
+        )
+        return
+
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        mScaleA: cute.Tensor,
+        mScaleB: cute.Tensor,
+        cluster_layout_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        c_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout, None],
+        epi_tile: cute.Tile,
+        tile_sched_params: utils.PersistentTileSchedulerParams,
+    ):
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+
+        if warp_idx == self.tma_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_a)
+            cpasync.prefetch_descriptor(tma_atom_b)
+            cpasync.prefetch_descriptor(tma_atom_c)
+
+        use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+
+        bidx, bidy, bidz = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(
+            cta_rank_in_cluster
+        )
+        tidx, _, _ = cute.arch.thread_idx()
+
+        @cute.struct
+        class SharedStorage:
+            ab_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage * 2]
+            acc_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage * 2]
+            tmem_dealloc_mbar: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+
+        ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        ab_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_tma_producer
+        )
+        ab_producer, ab_consumer = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.ab_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=ab_pipeline_producer_group,
+            consumer_group=ab_pipeline_consumer_group,
+            tx_count=self.num_tma_load_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+
+        acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_acc_consumer_threads = len(self.epilogue_warp_id) * (
+            2 if use_2cta_instrs else 1
+        )
+        acc_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_acc_consumer_threads
+        )
+        acc_pipeline = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_stage,
+            producer_group=acc_pipeline_producer_group,
+            consumer_group=acc_pipeline_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=self.tmem_alloc_sync_bar_id,
+            num_threads=32 * len((self.mma_warp_id, *self.epilogue_warp_id)),
+        )
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=tmem_alloc_barrier,
+            allocator_warp_id=self.epilogue_warp_id[0],
+            is_two_cta=use_2cta_instrs,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar.ptr,
+        )
+
+        pipeline_init_arrive = pipeline.pipeline_init_arrive
+        pipeline_init_wait = pipeline.pipeline_init_wait
+        pipeline_init_arrive(cluster_shape_mn=cluster_layout_vmnk, is_relaxed=True)
+
+        sA = smem.allocate_tensor(
+            element_type=self.a_dtype,
+            layout=a_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=a_smem_layout_staged.inner,
+        )
+        sB = smem.allocate_tensor(
+            element_type=self.b_dtype,
+            layout=b_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=b_smem_layout_staged.inner,
+        )
+
+        a_full_mcast_mask = None
+        b_full_mcast_mask = None
+        if cutlass.const_expr(self.is_a_mcast or self.is_b_mcast or use_2cta_instrs):
+            a_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+            )
+            b_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
+            )
+
+        gA_mkl = cute.local_tile(
+            mA_mkl, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None)
+        )
+        gB_nkl = cute.local_tile(
+            mB_nkl, cute.slice_(self.mma_tiler, (0, None, None)), (None, None, None)
+        )
+        gC_mnl = cute.local_tile(
+            mC_mnl, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None)
+        )
+        # Broadcast scale tensors over the C (M, N, L) shape:
+        #  - scale_a: value depends on m only  -> stride (1, 0, 0)
+        #  - scale_b: value depends on n only  -> stride (0, 1, 0)
+        sa_bc = cute.make_tensor(
+            mScaleA.iterator,
+            cute.make_layout(mC_mnl.shape, stride=(1, 0, 0)),
+        )
+        sb_bc = cute.make_tensor(
+            mScaleB.iterator,
+            cute.make_layout(mC_mnl.shape, stride=(0, 1, 0)),
+        )
+        gSA_mnl = cute.local_tile(
+            sa_bc, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None)
+        )
+        gSB_mnl = cute.local_tile(
+            sb_bc, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None)
+        )
+        k_tile_cnt = cute.size(gA_mkl, mode=[3])
+
+        thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+        tCgA = thr_mma.partition_A(gA_mkl)
+        tCgB = thr_mma.partition_B(gB_nkl)
+        tCgC = thr_mma.partition_C(gC_mnl)
+        tCgSA = thr_mma.partition_C(gSA_mnl)
+        tCgSB = thr_mma.partition_C(gSB_mnl)
+
+        a_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
+        )
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_atom_a,
+            block_in_cluster_coord_vmnk[2],
+            a_cta_layout,
+            cute.group_modes(sA, 0, 3),
+            cute.group_modes(tCgA, 0, 3),
+        )
+        b_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
+        )
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_atom_b,
+            block_in_cluster_coord_vmnk[1],
+            b_cta_layout,
+            cute.group_modes(sB, 0, 3),
+            cute.group_modes(tCgB, 0, 3),
+        )
+
+        tCrA = tiled_mma.make_fragment_A(sA)
+        tCrB = tiled_mma.make_fragment_B(sB)
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        tCtAcc_fake = tiled_mma.make_fragment_C(
+            cute.append(acc_shape, self.num_acc_stage)
+        )
+
+        pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
+
+        tile_sched = utils.StaticPersistentTileScheduler.create(
+            tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+        )
+        work_tile = tile_sched.initial_work_tile_info()
+
+        # ---- TMA load warp ----
+        if warp_idx == self.tma_warp_id:
+            while work_tile.is_valid_tile:
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+                tAgA_slice = tAgA[(None, mma_tile_coord_mnl[0], None, mma_tile_coord_mnl[2])]
+                tBgB_slice = tBgB[(None, mma_tile_coord_mnl[1], None, mma_tile_coord_mnl[2])]
+                ab_producer.reset()
+                peek_ab_empty_status = ab_producer.try_acquire()
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    handle = ab_producer.acquire_and_advance(peek_ab_empty_status)
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA_slice[(None, handle.count)],
+                        tAsA[(None, handle.index)],
+                        tma_bar_ptr=handle.barrier,
+                        mcast_mask=a_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB_slice[(None, handle.count)],
+                        tBsB[(None, handle.index)],
+                        tma_bar_ptr=handle.barrier,
+                        mcast_mask=b_full_mcast_mask,
+                    )
+                    peek_ab_empty_status = cutlass.Boolean(1)
+                    if handle.count + 1 < k_tile_cnt:
+                        peek_ab_empty_status = ab_producer.try_acquire()
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+            ab_producer.tail()
+
+        # ---- MMA warp ----
+        if warp_idx == self.mma_warp_id:
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+            acc_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_acc_stage
+            )
+            while work_tile.is_valid_tile:
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+                tCtAcc = tCtAcc_base[(None, None, None, acc_producer_state.index)]
+                ab_consumer.reset()
+                peek_ab_full_status = cutlass.Boolean(1)
+                if is_leader_cta:
+                    peek_ab_full_status = ab_consumer.try_wait()
+                if is_leader_cta:
+                    acc_pipeline.producer_acquire(acc_producer_state)
+                tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                for k_tile in range(k_tile_cnt):
+                    if is_leader_cta:
+                        handle = ab_consumer.wait_and_advance(peek_ab_full_status)
+                        num_kblocks = cute.size(tCrA, mode=[2])
+                        for kblk_idx in cutlass.range(num_kblocks, unroll_full=True):
+                            kblk_crd = (None, None, kblk_idx, handle.index)
+                            cute.gemm(
+                                tiled_mma, tCtAcc,
+                                tCrA[kblk_crd], tCrB[kblk_crd], tCtAcc,
+                            )
+                            tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                        handle.release()
+                        peek_ab_full_status = cutlass.Boolean(1)
+                        if handle.count + 1 < k_tile_cnt:
+                            peek_ab_full_status = ab_consumer.try_wait()
+                if is_leader_cta:
+                    acc_pipeline.producer_commit(acc_producer_state)
+                acc_producer_state.advance()
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+            acc_pipeline.producer_tail(acc_producer_state)
+
+        sC = smem.allocate_tensor(
+            element_type=self.c_dtype,
+            layout=c_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=c_smem_layout_staged.inner,
+        )
+
+        # ---- Epilogue warps ----
+        if warp_idx < self.mma_warp_id:
+            tmem.allocate(self.num_tmem_alloc_cols)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+            acc_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_acc_stage
+            )
+            c_producer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, 32 * len(self.epilogue_warp_id)
+            )
+            c_pipeline = pipeline.PipelineTmaStore.create(
+                num_stages=self.num_c_stage, producer_group=c_producer_group
+            )
+            while work_tile.is_valid_tile:
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+                num_tiles_executed = tile_sched.num_tiles_executed
+                acc_consumer_state = epilogue_tma_store_scaled(
+                    self,
+                    tidx,
+                    warp_idx,
+                    tma_atom_c,
+                    tCtAcc_base,
+                    sC,
+                    tCgC,
+                    tCgSA,
+                    tCgSB,
+                    epi_tile,
+                    num_tiles_executed,
+                    mma_tile_coord_mnl,
+                    acc_consumer_state,
+                    acc_pipeline,
+                    c_pipeline,
+                )
+            c_pipeline.producer_tail()
+            tmem.relinquish_alloc_permit()
+            tmem.free(tmem_ptr)
+
+
+@cute.jit
+def scaled_bmm(
+    gemm_op: cutlass.Constexpr,
+    a: cute.Tensor,   # (l, m, k)
+    b: cute.Tensor,   # (l, k, n)
+    c: cute.Tensor,   # (l, m, n)
+    scale_a: cute.Tensor,  # (m,)
+    scale_b: cute.Tensor,  # (n,)
+    max_active_clusters: cutlass.Constexpr,
+    stream: cuda.CUstream,
+):
+    a = cute.make_tensor(a.iterator, cute.select(a.layout, mode=[1, 2, 0]))
+    b = cute.make_tensor(b.iterator, cute.select(b.layout, mode=[2, 1, 0]))
+    c = cute.make_tensor(c.iterator, cute.select(c.layout, mode=[1, 2, 0]))
+    gemm_op(a, b, c, scale_a, scale_b, max_active_clusters, stream)
+
+
+@lru_cache(maxsize=8)
+def compile_scaled_bmm(
+    mnkl,
+    a, b, c, scale_a, scale_b,
+    acc_dtype,
+    a_major, b_major, c_major,
+    mma_tiler_mn=(256, 128),
+    cluster_shape_mn=(2, 1),
+    max_active_clusters=None,
+    use_2cta_instrs=True,
+    use_tma_store=True,
+    fuse_scale=True,
+):
+    from cutlass.cute.runtime import make_fake_stream
+
+    gemm = ScaledGemmKernel(
+        acc_dtype, use_2cta_instrs, mma_tiler_mn, cluster_shape_mn, use_tma_store
+    )
+    gemm.fuse_scale = fuse_scale
+    if not gemm.can_implement(
+        mnkl, a.element_type, b.element_type, c.element_type, a_major, b_major, c_major
+    ):
+        raise testing.CantImplementError("config not implementable")
+    stream = make_fake_stream()
+    return cute.compile(
+        scaled_bmm, gemm, a, b, c, scale_a, scale_b, max_active_clusters, stream
+    )
+
+
+def build(M, K, N, mma_tiler_mn=(256, 128), cluster_shape_mn=(2, 1), fuse_scale=True):
+    """Build a fused scaled_mm. Returns (compiled, tensors dict, call_fn)."""
+    import torch
+    from cutlass.cute.runtime import from_dlpack
+
+    DT_AB, DT_C, DT_ACC = cutlass.Float8E4M3FN, cutlass.BFloat16, cutlass.Float32
+    mnkl = (M, N, K, 1)
+    a_f32, b_f32, c_f32, a_st, b_st, c_st = prepare_tensors(
+        mnkl, DT_AB, DT_AB, DT_C, "k", "k", "n"
+    )
+    a_ = create_cute_tensor_for_fp8(a_st, DT_AB, 2, source_f32_tensor=a_f32)
+    b_ = create_cute_tensor_for_fp8(b_st, DT_AB, 1, source_f32_tensor=b_f32)
+    c_ = create_cute_tensor_for_fp8(c_st, DT_C, 2, source_f32_tensor=c_f32)
+
+    sa_t = (torch.rand(M, device="cuda", dtype=torch.float32) + 0.5)
+    sb_t = (torch.rand(N, device="cuda", dtype=torch.float32) + 0.5)
+    sa_ = from_dlpack(sa_t, assumed_align=4)
+    sb_ = from_dlpack(sb_t, assumed_align=4)
+
+    maxcl = utils.HardwareInfo().get_max_active_clusters(
+        cluster_shape_mn[0] * cluster_shape_mn[1]
+    )
+    compiled = compile_scaled_bmm(
+        mnkl, a_, b_, c_, sa_, sb_, DT_ACC, "k", "k", "n",
+        mma_tiler_mn, cluster_shape_mn, maxcl, True, True, fuse_scale,
+    )
+    tensors = dict(
+        a_f32=a_f32, b_f32=b_f32, c_st=c_st,
+        a_=a_, b_=b_, c_=c_, sa_=sa_, sb_=sb_, sa_t=sa_t, sb_t=sb_t,
+    )
+    return compiled, tensors
+
+
+# import after class def to avoid circulars
+from cutlass.utils import create_cute_tensor_for_fp8  # noqa: E402

--- a/examples/scaled_mm.py
+++ b/examples/scaled_mm.py
@@ -1,0 +1,339 @@
+"""
+FP8 RowWise Scaled Matrix Multiplication with Helion
+====================================================
+This example implements an FP8 (e4m3) RowWise ``scaled_mm`` kernel in Helion:
+
+    out[m, n] = scale_a[m] * scale_b[n] * sum_k a[m, k] * b[k, n]
+
+The rowwise scale is *linear/separable* across the K dimension, so it can be
+folded into each split-K partial before an atomic accumulation. This lets a
+single split-K kernel (no separate reduction kernel) cover the skinny-M regime
+(small M, large N/K) that is HBM-bandwidth bound, while filling the machine via
+split-K. The accumulator is FP32; results are atomically added into a pre-zeroed
+BF16 output.
+
+A reference using ``torch._scaled_mm`` validates correctness.
+"""
+
+# %%
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion.autotuner import PowerOfTwoFragment
+import helion.language as hl
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+# %%
+@helion.kernel(static_shapes=True)
+def scaled_mm(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> torch.Tensor:
+    """
+    FP8 RowWise scaled matrix multiplication using split-K parallelism.
+
+    Args:
+        x (torch.Tensor): Left input matrix of shape [m, k] in FP8 (e4m3).
+        y (torch.Tensor): Right input matrix of shape [k, n] in FP8 (e4m3).
+        scale_a (torch.Tensor): Per-row scale of shape [m, 1].
+        scale_b (torch.Tensor): Per-column scale of shape [1, n].
+
+    Returns:
+        torch.Tensor: Output matrix of shape [m, n] in BF16.
+    """
+    m, k = x.size()
+    k2, n = y.size()
+    assert k == k2, f"size mismatch {k} != {k2}"
+    split_k = hl.register_tunable("split_k", PowerOfTwoFragment(1, 256))
+    # When split_k == 1 every output tile is written exactly once, so we can use
+    # a plain store into an uninitialized buffer -- no atomics and, crucially,
+    # no output memset (which otherwise costs ~0.7-1.2us and is the whole gap to
+    # vLLM at moderate M). When split_k > 1 the reduction is split across CTAs
+    # to fill the machine on very skinny M, and partials are accumulated with
+    # atomic_add into a pre-zeroed output.
+    if split_k == 1:
+        out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    else:
+        out = torch.zeros([m, n], dtype=torch.bfloat16, device=x.device)
+    k_block = helion.next_power_of_2(helion.cdiv(k, split_k))
+    for tile_m, tile_n, outer_k in hl.tile([m, n, k], block_size=[None, None, k_block]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for inner_k in hl.tile(outer_k.begin, outer_k.end):
+            acc = hl.dot(x[tile_m, inner_k], y[inner_k, tile_n], acc=acc)
+        # Fold the rowwise scale into this K-split's partial (scale is linear
+        # across K, so summing the scaled partials yields the scaled total).
+        acc = acc * scale_a[tile_m, :] * scale_b[:, tile_n]
+        if split_k == 1:
+            out[tile_m, tile_n] = acc.to(torch.bfloat16)
+        else:
+            hl.atomic_add(out, [tile_m, tile_n], acc.to(torch.bfloat16))
+    return out
+
+
+# %%
+@helion.kernel(static_shapes=True)
+def scaled_mm_into(
+    out: torch.Tensor,
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Split-K FP8 RowWise scaled_mm that accumulates into a caller-provided,
+    pre-zeroed ``out``. Unlike :func:`scaled_mm`, this performs no internal
+    allocation or memset, so the ~0.7-1.2us output-zeroing tax can be hoisted
+    out of the timed region and overlapped on a separate CUDA stream with the
+    previous call's compute (double-buffered "ping-pong"). With that overlap
+    the kernel reaches its memset-free compute floor, matching vLLM.
+
+    Args:
+        out (torch.Tensor): Pre-zeroed output of shape [m, n] in BF16; mutated.
+        x (torch.Tensor): Left input matrix of shape [m, k] in FP8 (e4m3).
+        y (torch.Tensor): Right input matrix of shape [k, n] in FP8 (e4m3).
+        scale_a (torch.Tensor): Per-row scale of shape [m, 1].
+        scale_b (torch.Tensor): Per-column scale of shape [1, n].
+    """
+    m, k = x.size()
+    k2, n = y.size()
+    assert k == k2, f"size mismatch {k} != {k2}"
+    split_k = hl.register_tunable("split_k", PowerOfTwoFragment(2, 256))
+    k_block = helion.next_power_of_2(helion.cdiv(k, split_k))
+    for tile_m, tile_n, outer_k in hl.tile([m, n, k], block_size=[None, None, k_block]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for inner_k in hl.tile(outer_k.begin, outer_k.end):
+            acc = hl.dot(x[tile_m, inner_k], y[inner_k, tile_n], acc=acc)
+        acc = acc * scale_a[tile_m, :] * scale_b[:, tile_n]
+        hl.atomic_add(out, [tile_m, tile_n], acc.to(torch.bfloat16))
+    return out
+
+
+# %%
+@helion.kernel(static_shapes=True)
+def scaled_mm_compute(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Plain (no split-K, no atomics) FP8 RowWise scaled_mm for the *compute-bound*
+    regime (large M, or large N/K). Each output tile is computed by one program
+    and stored once, so Helion's autotuner is free to explore the full Blackwell
+    GEMM recipe (TMA loads, warp-specialized persistent mainloop, epilogue
+    subtiling, deep pipelining) without the split-K/atomic structure getting in
+    the way. Use full autotuning (HELION_AUTOTUNE_EFFORT=full) for these shapes.
+
+    Args:
+        x (torch.Tensor): Left input matrix of shape [m, k] in FP8 (e4m3).
+        y (torch.Tensor): Right input matrix of shape [k, n] in FP8 (e4m3).
+        scale_a (torch.Tensor): Per-row scale of shape [m, 1].
+        scale_b (torch.Tensor): Per-column scale of shape [1, n].
+
+    Returns:
+        torch.Tensor: Output matrix of shape [m, n] in BF16.
+    """
+    m, k = x.size()
+    k2, n = y.size()
+    assert k == k2, f"size mismatch {k} != {k2}"
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+        acc = acc * scale_a[tile_m, :] * scale_b[:, tile_n]
+        out[tile_m, tile_n] = acc.to(torch.bfloat16)
+    return out
+
+
+# %%
+# Compute-bound FP8 RowWise scaled_mm on Helion's CuTe (tcgen05) backend.
+# This config is the deeply-pipelined 2-CTA recipe that matches CUTLASS on the
+# Blackwell M=512 compute-bound shapes (256x128 cluster(2,1), bk=64, ab_stages=8,
+# role_local_monolithic = 6-warp inline-scheduler layout). The rowwise scale is
+# fused in the epilogue: ``scale_a`` (per-row) is passed as a stride-(1,0)
+# ``(M, N)`` view so the backend reads it as a scalar, and ``scale_b`` (per-col)
+# as a rank-1 row-vector that is register-hoisted before the accumulator wait.
+_SCALED_MM_CUTE_FP8_CONFIG = helion.Config(
+    block_sizes=[256, 128, 64],
+    cute_vector_widths=[1, 1, 1],
+    indexing=[
+        "pointer",
+        "pointer",
+        "pointer",
+        "tensor_descriptor",
+        "tensor_descriptor",
+    ],
+    l2_groupings=[1],
+    pid_type="persistent_blocked",
+    tcgen05_ab_stages=8,
+    tcgen05_acc_stages=2,
+    tcgen05_c_stages=2,
+    tcgen05_cluster_m=2,
+    tcgen05_cluster_n=1,
+    tcgen05_l2_swizzle_size=2,
+    tcgen05_layout_strategy="default",
+    tcgen05_num_epi_warps=4,
+    tcgen05_persistence_model="static_persistent",
+    tcgen05_strategy="role_local_monolithic",
+    tcgen05_warp_spec_ab_load_warps=1,
+    tcgen05_warp_spec_c_input_warps=0,
+    tcgen05_warp_spec_epi_load_warps=0,
+    tcgen05_warp_spec_mma_warps=1,
+    tcgen05_warp_spec_register_decrease=120,
+    tcgen05_warp_spec_register_increase=256,
+    tcgen05_warp_spec_scheduler_warps=0,
+)
+
+
+@helion.kernel(config=_SCALED_MM_CUTE_FP8_CONFIG, static_shapes=True, backend="cute")
+def _scaled_mm_cute_inner(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    sa2d: torch.Tensor,
+    sb1d: torch.Tensor,
+) -> torch.Tensor:
+    m, k = x.size()
+    k2, n = y.size()
+    assert k == k2, f"size mismatch {k} != {k2}"
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+        out[tile_m, tile_n] = (acc * sa2d[tile_m, tile_n] * sb1d[tile_n]).to(
+            torch.bfloat16
+        )
+    return out
+
+
+def scaled_mm_cute(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> torch.Tensor:
+    """FP8 RowWise scaled_mm on the CuTe backend (compute-bound regime).
+
+    Args:
+        x: Left input [m, k] in FP8 (e4m3), row-major.
+        y: Right input [k, n] in FP8 (e4m3), row-major.
+        scale_a: Per-row scale, shape [m, 1] or [m].
+        scale_b: Per-column scale, shape [1, n] or [n].
+
+    Returns:
+        Output [m, n] in BF16.
+    """
+    m, k = x.size()
+    k2, n = y.size()
+    assert k == k2, f"size mismatch {k} != {k2}"
+    # scale_a -> per-row column-vector broadcast (stride-(1,0) view, scalar read)
+    sa2d = scale_a.reshape(m, 1).expand(m, n)
+    # scale_b -> per-column row-vector (register-hoisted in the epilogue)
+    sb1d = scale_b.reshape(n)
+    return _scaled_mm_cute_inner(x, y, sa2d, sb1d)
+
+
+# %%
+def reference_scaled_mm(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> torch.Tensor:
+    """Reference using ``torch._scaled_mm`` (column-major second operand)."""
+    if y.stride(0) == 1 and y.stride(1) > 1:
+        y_col_major = y
+    else:
+        y_col_major = y.T.contiguous().T
+    return torch._scaled_mm(
+        x, y_col_major, scale_a, scale_b, use_fast_accum=False, out_dtype=torch.bfloat16
+    )
+
+
+# %%
+def scaled_mm_tritonbench(
+    tb_op: object,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> Callable[[], torch.Tensor]:
+    """Wrapper for TritonBench compatibility.
+
+    tritonbench passes ``a`` [m, k], ``b`` [k, n] (col-major), and rowwise
+    scales ``scale_a`` [m, 1], ``scale_b`` [1, n].
+    """
+    return lambda: scaled_mm(a, b, scale_a, scale_b)
+
+
+# %%
+def check(m: int, k: int, n: int) -> None:
+    """Validate the scaled_mm kernel against the torch._scaled_mm reference."""
+    x = torch.randn([m, k], device=DEVICE, dtype=torch.float32)
+    y = torch.randn([k, n], device=DEVICE, dtype=torch.float32)
+    x_fp8 = (x * 0.4).to(torch.float8_e4m3fn)
+    y_fp8 = (y * 0.4).to(torch.float8_e4m3fn).T.contiguous().T  # col-major
+    scale_a = (torch.rand([m, 1], device=DEVICE) + 0.5).to(torch.float32)
+    scale_b = (torch.rand([1, n], device=DEVICE) + 0.5).to(torch.float32)
+
+    from helion._testing import run_example
+
+    run_example(
+        lambda a, b: scaled_mm(a, b, scale_a, scale_b),
+        lambda a, b: reference_scaled_mm(a, b, scale_a, scale_b),
+        (x_fp8, y_fp8),
+        atol=0.1,
+        rtol=0.1,
+    )
+
+
+# %%
+shapes = [  # m, k, n  (skinny-M FP8 decode shapes)
+    (1, 4096, 4096),
+    (16, 4096, 4096),
+    (1, 4096, 14336),
+    (16, 4096, 14336),
+]
+
+
+# %%
+# Qwen3-1.7B FP8 (W8A8: per-channel weight + per-token dynamic act) linear-layer
+# GEMMs as seen by vllm_ops.cutlass_scaled_mm during vLLM serving benchmarks
+# (input 512 / output 600, batch-size sweep 1..64). (K, N) are fixed by the model;
+# lm_head is excluded (kept bf16). M is the token count per forward:
+#   decode -> running batch size {1,2,4,8,16,32,64}; prefill -> ~512-token chunk.
+_QWEN3_1_7B_LAYER_KN = [  # (k, n) per decoder layer (x28 layers)
+    (2048, 4096),  # qkv_proj      (q 2048 + k 1024 + v 1024, GQA)
+    (2048, 2048),  # o_proj
+    (2048, 12288),  # gate_up_proj  (2 x intermediate 6144, fused)
+    (6144, 2048),  # down_proj
+]
+_QWEN3_1_7B_M = [1, 2, 4, 8, 16, 32, 64, 512]  # decode batch sizes + 512-token prefill
+
+vllm_shapes = [  # m, k, n
+    (m, k, n) for m in _QWEN3_1_7B_M for (k, n) in _QWEN3_1_7B_LAYER_KN
+]
+
+
+# %%
+def main() -> None:
+    """Run correctness checks across the skinny-M shapes."""
+    for m, k, n in shapes:
+        print(f"Testing scaled_mm shape=(m={m}, k={k}, n={n})")
+        check(m, k, n)
+
+
+# %%
+if __name__ == "__main__":
+    main()

--- a/helion/_compiler/cute/cute_fx_walk.py
+++ b/helion/_compiler/cute/cute_fx_walk.py
@@ -310,6 +310,18 @@ def aux_tensor_load_kind(
     if len(carrier_tile_shape) != 2:
         return None
 
+    colvec = _matches_colvec_broadcast(
+        aux_shape=aux_shape,
+        aux_tensor_shape=aux_tensor_shape,
+        aux_tensor_val=aux_tensor_val,
+        index_list=index_list,
+        carrier_tile_shape=carrier_tile_shape,
+        carrier_tile_index_nodes=carrier_tile_index_nodes,
+        carrier_global_shape=carrier_global_shape,
+    )
+    if colvec is not None:
+        return colvec
+
     if _matches_exact(
         aux_shape=aux_shape,
         aux_tensor_shape=aux_tensor_shape,
@@ -488,6 +500,61 @@ def _matches_leading_broadcast(
         if aux_tensor_shape[1] != carrier_global_shape[1]:
             return None
     return ("broadcast", 0)
+
+
+def _matches_colvec_broadcast(
+    *,
+    aux_shape: tuple[object, ...],
+    aux_tensor_shape: tuple[object, ...],
+    aux_tensor_val: torch.Tensor,
+    index_list: Sequence[object],
+    carrier_tile_shape: tuple[object, ...],
+    carrier_tile_index_nodes: tuple[torch.fx.Node, ...] | None,
+    carrier_global_shape: tuple[object, ...] | None,
+) -> tuple[str, int] | None:
+    """Check whether a load is a per-row column-vector broadcast and
+    return ``("broadcast", 2)`` on success.
+
+    The accepted form is ``scale_a[tile_m, tile_n]`` where ``scale_a`` is a
+    full ``(M, N)`` view with **stride 0 on the trailing (N) axis** — i.e. an
+    ``unsqueeze(1).expand(M, N)`` of a per-row ``(M,)`` vector. Its value
+    depends only on ``m``, so it is *uniform over each thread's N fragment*
+    in the tcgen05 T2R epilogue. The splice therefore reads it as a single
+    **scalar** per subtile (matching CUTLASS's ``sa = tTR_gSA[(0,0,0,s)]``)
+    rather than a vector ``.load()``, avoiding a redundant N-wide read.
+
+    This must be tried *before* ``_matches_exact`` (a stride-0-N aux still
+    has the full ``(M, N)`` underlying shape, so the exact matcher would
+    otherwise claim it and emit a vector read). A genuine 2-D residual has a
+    non-zero trailing stride and falls through to ``_matches_exact``.
+    """
+    if (
+        len(aux_tensor_shape) != 2
+        or len(aux_shape) != 2
+        or len(index_list) != 2
+        or len(carrier_tile_shape) != 2
+    ):
+        return None
+    if carrier_tile_index_nodes is None or len(carrier_tile_index_nodes) != 2:
+        return None
+    for idx, expected in zip(index_list, carrier_tile_index_nodes, strict=True):
+        if idx is not expected:
+            return None
+    for aux_dim, carrier_dim in zip(aux_shape, carrier_tile_shape, strict=True):
+        if aux_dim != carrier_dim:
+            return None
+    if carrier_global_shape is not None:
+        if len(carrier_global_shape) != 2:
+            return None
+        if tuple(aux_tensor_shape) != tuple(carrier_global_shape):
+            return None
+    stride = aux_tensor_val.stride()
+    # Uniform over N (trailing stride 0) and varying over M (leading stride
+    # non-zero) — the column-vector broadcast. A real (M, N) tensor has
+    # trailing stride 1 and is left for the exact-shape matcher.
+    if len(stride) != 2 or stride[1] != 0 or stride[0] == 0:
+        return None
+    return ("broadcast", 2)
 
 
 def _matches_exact(

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -118,6 +118,21 @@ _TRACE_THROUGH_TARGETS = {
     # data shuffle.  Permuted operands fall back to scalar codegen.
 }
 
+# Extra forward-trace targets used ONLY for *output dtype* inference
+# (``_trace_mma_to_store_dtype``). These are the whitelisted fused-epilogue
+# aux-binary ops (e.g. the rowwise scale ``acc * scale[...]``). Tracing
+# through them only follows the chain to the store node and reads the store
+# *target tensor's* dtype, so it never changes the inferred dtype; it just
+# lets inference reach the store past a fused scale/bias step. This is needed
+# for fp8 inputs (whose ``input_dtype`` is never a valid epilogue output
+# dtype) so the plan picks up the real bf16/f16/f32 store dtype.
+_DTYPE_TRACE_EXTRA_TARGETS = {
+    torch.ops.aten.mul.Tensor,
+    torch.ops.aten.add.Tensor,
+    torch.ops.aten.sub.Tensor,
+    torch.ops.aten.div.Tensor,
+}
+
 # Register reallocation budget for tcgen05 warp-specialized kernels.
 # Producer warps (TMA loads, scheduler) only do address arithmetic and
 # barrier ops, so they can give back registers; consumer warps (MMA
@@ -443,7 +458,12 @@ def _has_mma_operands(lhs_node: Node, rhs_node: Node) -> bool:
         return False
     lhs_load, _, lhs_fake = lhs_info
     rhs_load, _, rhs_fake = rhs_info
-    supported = {torch.float16, torch.bfloat16, torch.float32}
+    supported = {
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+        torch.float8_e4m3fn,
+    }
     return (
         lhs_fake.dtype in supported
         and rhs_fake.dtype in supported
@@ -1726,6 +1746,7 @@ def _trace_mma_to_store_dtype(
                 or target is _tracing_ops._new_var
                 or target is operator.getitem
                 or target in _TRACE_THROUGH_TARGETS
+                or target in _DTYPE_TRACE_EXTRA_TARGETS
             ):
                 stack.append(user)
                 continue
@@ -1778,6 +1799,7 @@ def _emit_mma_pipeline(
         torch.float16: "cutlass.Float16",
         torch.bfloat16: "cutlass.BFloat16",
         torch.float32: "cutlass.Float32",
+        torch.float8_e4m3fn: "cutlass.Float8E4M3FN",
     }
     input_dtype_str = _dtype_map[input_dtype]
     acc_dtype_str = "cutlass.Float32"
@@ -1805,7 +1827,7 @@ def _emit_mma_pipeline(
         _dtype_map[epi_elem_dtype] if epi_elem_dtype is not None else input_dtype_str
     )
     tcgen05_use_tma = (
-        input_dtype in (torch.float16, torch.bfloat16)
+        input_dtype in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
         and lhs_fake.is_contiguous()
         and rhs_fake.is_contiguous()
     )
@@ -5187,7 +5209,12 @@ def _mma_impl_matches_problem_shape(
 ) -> bool:
     if mma_impl == "universal":
         return True
-    if input_dtype not in (torch.float16, torch.bfloat16) or bn < 8 or bn % 8 != 0:
+    is_fp8 = input_dtype == torch.float8_e4m3fn
+    if (
+        input_dtype not in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
+        or bn < 8
+        or bn % 8 != 0
+    ):
         return False
     if bn > 256 and (
         mma_impl != "tcgen05"
@@ -5201,16 +5228,21 @@ def _mma_impl_matches_problem_shape(
     ):
         return False
     if mma_impl == "warp":
-        # Warp MMA atom is fixed-K (16 elements per BF16/FP16 instruction).
+        # Warp MMA atom is fixed-K (16 elements per BF16/FP16 instruction);
+        # fp8 is only wired through tcgen05.
+        if is_fp8:
+            return False
         return bk == 16 and bm >= 16 and bm % 16 == 0 and bn == 8
     if mma_impl == "tcgen05":
-        # tcgen05 mma instruction K is 16 elements for BF16/FP16, but the
-        # tile's K can be any positive multiple of that (the inner cute.gemm
-        # loop just runs more instructions per K iteration). Larger tile_k
-        # roughly halves the per-K-iter overhead per doubling. Production
-        # remains capped at block_n=256 to keep AB SMEM staging budget sane;
-        # the explicit G4 proof key admits only the smallest 512-N candidate.
-        if bk < 16 or bk > 256 or bk % 16 != 0:
+        # tcgen05 mma instruction K is 16 elements for BF16/FP16 (32 for FP8),
+        # but the tile's K can be any positive multiple of that (the inner
+        # cute.gemm loop just runs more instructions per K iteration). Larger
+        # tile_k roughly halves the per-K-iter overhead per doubling.
+        # Production remains capped at block_n=256 to keep AB SMEM staging
+        # budget sane; the explicit G4 proof key admits only the smallest
+        # 512-N candidate.
+        mma_k = 32 if is_fp8 else 16
+        if bk < mma_k or bk > 256 or bk % mma_k != 0:
             return False
         if bm in (64, 128):
             return True
@@ -5303,7 +5335,12 @@ def _choose_mma_impl(
         tcgen05_cluster_m=tcgen05_cluster_m,
         tcgen05_large_bn_proof=tcgen05_large_bn_proof,
     ):
-        if support.tcgen05_f16bf16:
+        tcgen05_ok = (
+            support.tcgen05_f8
+            if input_dtype == torch.float8_e4m3fn
+            else support.tcgen05_f16bf16
+        )
+        if tcgen05_ok:
             return "tcgen05"
     if _mma_impl_matches_problem_shape("warp", input_dtype, bm=bm, bn=bn, bk=bk):
         if support.warp_f16bf16:

--- a/helion/_compiler/cute/mma_support.py
+++ b/helion/_compiler/cute/mma_support.py
@@ -14,9 +14,11 @@ class CuteMmaSupport:
     warp_f16bf16: bool
     warpgroup_f16bf16: bool
     tcgen05_f16bf16: bool
+    tcgen05_f8: bool = False
     warp_error: str | None = None
     warpgroup_error: str | None = None
     tcgen05_error: str | None = None
+    tcgen05_f8_error: str | None = None
 
     @property
     def supported_impls(self) -> tuple[str, ...]:
@@ -97,6 +99,28 @@ def _probe_tcgen05_f16bf16() -> tuple[bool, str | None]:
         return False, f"{type(exc).__name__}: {exc}"
 
 
+def _probe_tcgen05_f8() -> tuple[bool, str | None]:
+    try:
+        import cutlass
+        from cutlass.cute.nvgpu import tcgen05
+
+        # fp8 (e4m3) MMA on tcgen05 uses the F8F6F4 op with MMA-K=32 (vs 16
+        # for BF16/FP16) and a separate a_dtype/b_dtype.
+        tcgen05.MmaF8F6F4Op(
+            cutlass.Float8E4M3FN,
+            cutlass.Float8E4M3FN,
+            cutlass.Float32,
+            (128, 8, 32),
+            tcgen05.CtaGroup.ONE,
+            tcgen05.OperandSource.SMEM,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.K,
+        )
+        return True, None
+    except Exception as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+
+
 def get_cute_mma_support() -> CuteMmaSupport:
     device = _current_cuda_device()
     if device is None:
@@ -108,9 +132,11 @@ def get_cute_mma_support() -> CuteMmaSupport:
             warp_f16bf16=False,
             warpgroup_f16bf16=False,
             tcgen05_f16bf16=False,
+            tcgen05_f8=False,
             warp_error="CUDA unavailable",
             warpgroup_error="CUDA unavailable",
             tcgen05_error="CUDA unavailable",
+            tcgen05_f8_error="CUDA unavailable",
         )
 
     device_name = torch.cuda.get_device_name(device)
@@ -122,6 +148,7 @@ def get_cute_mma_support() -> CuteMmaSupport:
     warp_ok, warp_error = _probe_warp_f16bf16()
     warpgroup_ok, warpgroup_error = _probe_warpgroup_f16bf16()
     tcgen05_ok, tcgen05_error = _probe_tcgen05_f16bf16()
+    tcgen05_f8_ok, tcgen05_f8_error = _probe_tcgen05_f8()
 
     return CuteMmaSupport(
         device_name=device_name,
@@ -131,7 +158,9 @@ def get_cute_mma_support() -> CuteMmaSupport:
         warp_f16bf16=warp_ok,
         warpgroup_f16bf16=warpgroup_ok,
         tcgen05_f16bf16=tcgen05_ok,
+        tcgen05_f8=tcgen05_f8_ok,
         warp_error=warp_error,
         warpgroup_error=warpgroup_error,
         tcgen05_error=tcgen05_error,
+        tcgen05_f8_error=tcgen05_f8_error,
     )

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -945,6 +945,44 @@ class CuteTcgen05Config:
             and block_sizes[1] == TCGEN05_TWO_CTA_BLOCK_N
         )
 
+    def max_ab_stages_that_fit(
+        self,
+        *,
+        bm: int,
+        bn: int,
+        bk: int,
+        cluster_m: int,
+        hard_cap: int = 12,
+    ) -> int:
+        """Largest ``tcgen05_ab_stages`` whose AB SMEM fits the per-CTA budget.
+
+        Mirrors CUTLASS's ``_compute_stages`` (fill SMEM with as many AB
+        pipeline stages as fit). 1-byte fp8 operands fit ~2x more stages than
+        2-byte bf16, so the deeper pipeline that hides K-loop latency is only
+        reachable for fp8 once the bf16-tuned ``ab_stages<=3`` cap is lifted.
+        Returns at least 1; ``0`` when constraints are unknown.
+        """
+        constraints = self.ab_stages_three_search_constraints
+        if constraints is None or bm <= 0 or bn <= 0 or bk <= 0:
+            return 0
+        if cluster_m not in (1, 2):
+            return 0
+        best = 0
+        for ab_stages in range(1, hard_cap + 1):
+            bytes_per_cta = tcgen05_ab_smem_bytes_per_cta(
+                bm=bm,
+                bn=bn,
+                bk=bk,
+                dtype_bytes=constraints.dtype_bytes,
+                ab_stages=ab_stages,
+                cluster_m=cluster_m,
+            )
+            if bytes_per_cta <= constraints.per_cta_smem_budget_bytes:
+                best = ab_stages
+            else:
+                break
+        return best
+
     def _fix_ab_stages_three_search_config(self, config: dict[str, object]) -> None:
         if self.ab_stages_three_search_constraints is None:
             return
@@ -1224,10 +1262,33 @@ class CuteTcgen05Config:
             )
         ):
             return
+        # fp8 (1-byte) operands fit a deeper AB pipeline than the bf16-tuned
+        # cap of 3; admit ab_stages > 3 for fp8 as long as the AB SMEM fits the
+        # per-CTA budget. This lets Helion emit the same deeply-pipelined
+        # CtaGroup.TWO kernel CUTLASS uses for fp8 compute-bound GEMMs.
+        constraints = self.ab_stages_three_search_constraints
+        if constraints is not None and constraints.dtype_bytes < 2:
+            block_sizes = cast("list[int]", config.get("block_sizes"))
+            cluster_m = cast("int", config.get("tcgen05_cluster_m", 1))
+            if isinstance(block_sizes, list) and len(block_sizes) >= 3:
+                fit_max = self.max_ab_stages_that_fit(
+                    bm=block_sizes[0],
+                    bn=block_sizes[1],
+                    bk=block_sizes[2],
+                    cluster_m=cluster_m,
+                )
+                if fit_max > 0 and ab_stages <= fit_max:
+                    return
+                if fix_invalid and fit_max > 0:
+                    config["tcgen05_ab_stages"] = fit_max
+                    return
         if fix_invalid:
             config["tcgen05_ab_stages"] = 3
             return
-        raise InvalidConfig("tcgen05_ab_stages > 3 is not supported")
+        raise InvalidConfig(
+            "tcgen05_ab_stages > 3 is only supported by the validated "
+            "Target1 TVM-FFI seed (or fp8 within the SMEM budget)"
+        )
 
     def _is_validated_clc_persistence_search_candidate(
         self, config: dict[str, object]
@@ -1689,6 +1750,13 @@ class CuteTcgen05Config:
             # cluster_m=1 256x256 overflows bare-AB) before codegen, so admission is
             # free but an overflowing kernel is never generated.
             ab_stages_max = 3
+            # fp8 (1-byte) operands fit a deeper AB pipeline; widen the
+            # validation range so an explicit deep-staged fp8 config is
+            # accepted (``_validate_target1_ab_stage_envelope`` clamps it to
+            # the actual per-CTA SMEM budget for the chosen block sizes).
+            constraints = self.ab_stages_three_search_constraints
+            if constraints is not None and constraints.dtype_bytes < 2:
+                ab_stages_max = 12
         else:
             ab_stages_max = 2
         if for_search:

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -4503,6 +4503,8 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             "cutlass.Boolean",
             "cutlass.Float16",
             "cutlass.Float32",
+            "cutlass.Float8E4M3FN",
+            "cutlass.Float8E5M2",
             "cutlass.Int32",
         }
     )

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -318,22 +318,31 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
             rhs_dtype=rhs.dtype,
         )
     )
+    # tcgen05 MMA-K is 16 elements for BF16/FP16 but 32 for FP8 (e4m3); the
+    # block_k search granularity and minimum must follow the active dtype.
+    is_fp8 = lhs.dtype == torch.float8_e4m3fn
+    mma_k = 32 if is_fp8 else 16
     if (
         env.backend_name == "cute"
         and lhs.ndim == 2
         and rhs.ndim == 2
-        and lhs.dtype in (torch.float16, torch.bfloat16)
+        and (
+            lhs.dtype in (torch.float16, torch.bfloat16)
+            or lhs.dtype == torch.float8_e4m3fn
+        )
         and rhs.dtype == lhs.dtype
         and static_m is not None
         and static_n is not None
         and static_k is not None
         and static_m >= 64
         and static_n >= 8
-        and static_k >= 16
+        and static_k >= mma_k
     ):
         from .._compiler.cute.mma_support import get_cute_mma_support
 
-        if get_cute_mma_support().tcgen05_f16bf16:
+        support = get_cute_mma_support()
+        tcgen05_supported = support.tcgen05_f8 if is_fp8 else support.tcgen05_f16bf16
+        if tcgen05_supported:
 
             def pow2_floor_at_least(value: int, minimum: int) -> int:
                 return 1 << (max(minimum, value).bit_length() - 1)
@@ -342,8 +351,9 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
             max_tcgen05_m = 256 if max_tcgen05_n >= 128 and static_m >= 256 else 128
             # Larger tile_k packs more cute.gemm instructions per K loop
             # iteration on tcgen05 (mma instruction K is fixed at 16 for
-            # BF16/FP16). Cap at 128 to keep AB SMEM staging budget sane.
-            max_tcgen05_k = min(128, pow2_floor_at_least(static_k, 16))
+            # BF16/FP16, 32 for FP8). Cap at 128 to keep AB SMEM staging
+            # budget sane.
+            max_tcgen05_k = min(128, pow2_floor_at_least(static_k, mma_k))
             max_search_m = min(max_tcgen05_m, pow2_floor_at_least(static_m, 64))
             max_search_n = max_tcgen05_n
             max_search_k = max_tcgen05_k
@@ -475,7 +485,7 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
                 if block_idx is None:
                     continue
                 if axis_name == "k":
-                    min_size = 16
+                    min_size = mma_k
                 elif axis_name == "m":
                     min_size = min_search_m
                 else:

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -2647,9 +2647,12 @@ def _codegen_cute_store_tcgen05_tile(
         # Broadcast aux steps need a fresh AST var for the 2-D view
         # of the rank-1 underlying tensor (stride 0 on the orthogonal
         # axis). Exact-shape aux steps leave ``aux_view2d`` as None.
+        # broadcast_axis 0/1 build a stride-0 2-D view of a rank-1 tensor;
+        # the colvec form (2) reuses the exact-shape pipeline over its own
+        # (M, N) stride-(1,0) view, so it needs no separate ``aux_view2d``.
         aux_view2d = (
             df.new_var(f"tcgen05_aux_view2d_{aux_idx}")
-            if aux_step.broadcast_axis is not None
+            if aux_step.broadcast_axis in (0, 1)
             else None
         )
         aux_step_records.append(
@@ -2825,6 +2828,41 @@ def _codegen_cute_store_tcgen05_tile(
         aux_consumer_state_name = ""
         aux_pipeline_uses_tma_load = False
         aux_ring_smem_names = tuple(None for _ in aux_step_records)
+
+    # Row-vector register hoist (fp8 only). A rowvec aux (``bias[n]`` /
+    # rowwise ``scale_b[n]``) varies across each thread's N (vectorized
+    # epilogue) fragment, so the default per-subtile GMEM ``.load()`` issued
+    # AFTER the accumulator ``consumer_wait`` exposes its latency. CUTLASS's
+    # ``epilogue_tma_store_scaled`` instead reads the whole rowvec into
+    # registers ONCE (``cute.autovec_copy(tTR_gSB, tTR_rSB_full)``) BEFORE the
+    # acc wait so its latency overlaps the MMA. Mirror that here: hoist the
+    # per-tile rowvec LDG into a register tensor in the setup block (which
+    # runs before the subtile loop, hence before the acc wait), then read it
+    # per subtile from registers. fp8-gated because fp8 GEMMs are
+    # latency-bound at these compute-bound shapes (bf16's larger operands hide
+    # the load already, and the cycle-39/74 ablations found no bf16 win); the
+    # rowvec register tensor is small (1-D broadcast) so no spill risk. SMEM
+    # staging (``use_aux_smem_source``) owns its own ring, so skip there.
+    _ab_tma_plans_for_hoist = [
+        plan
+        for plan in state.codegen.cute_wrapper_plans
+        if plan.get("kind") == "tcgen05_ab_tma"
+    ]
+    aux_input_is_fp8 = (
+        len(_ab_tma_plans_for_hoist) == 1
+        and str(_ab_tma_plans_for_hoist[0].get("input_dtype")) == "cutlass.Float8E4M3FN"
+    )
+    aux_hoisted_vars: list[str | None] = []
+    for aux_idx, rec in enumerate(aux_step_records):
+        if (
+            aux_input_is_fp8
+            and rec.broadcast_axis == 1
+            and tcgen05_aux_use_tma_store_epilogue
+            and not use_aux_smem_source
+        ):
+            aux_hoisted_vars.append(df.new_var(f"tcgen05_aux_hoisted_{aux_idx}"))
+        else:
+            aux_hoisted_vars.append(None)
 
     rowvec_aux_stage_records: list[_RowvecAuxStageRecord | None] = []
     for aux_idx, rec in enumerate(aux_step_records):
@@ -3102,9 +3140,11 @@ def _codegen_cute_store_tcgen05_tile(
                 )
                 continue
 
-            if rec.broadcast_axis is None:
-                # Exact-shape rank-2 aux: slice the per-tile region
-                # of the underlying 2-D tensor directly.
+            if rec.broadcast_axis is None or rec.broadcast_axis == 2:
+                # Exact-shape rank-2 aux (or the colvec form, which is a full
+                # (M, N) stride-(1,0) view): slice the per-tile region of the
+                # underlying 2-D tensor directly. The colvec's per-subtile read
+                # is specialized to a scalar in ``_aux_subtile_load_source``.
                 source_for_local_tile = rec.aux_tensor_name
                 aux_tile_is_local = False
             elif rowvec_stage is not None:
@@ -3198,6 +3238,20 @@ def _codegen_cute_store_tcgen05_tile(
                     ),
                 ]
             )
+            hoisted = aux_hoisted_vars[aux_idx]
+            if hoisted is not None:
+                # Issue the whole-tile rowvec GMEM read into registers here
+                # (per-output-tile setup, before the subtile loop / acc wait)
+                # so its latency overlaps the MMA. See ``aux_hoisted_vars``.
+                lines.extend(
+                    [
+                        (
+                            f"{hoisted} = cute.make_rmem_tensor("
+                            f"{rec.ttr_aux_grouped}.shape, {rec.aux_dtype})"
+                        ),
+                        f"cute.autovec_copy({rec.ttr_aux_grouped}, {hoisted})",
+                    ]
+                )
         return lines
 
     def _aux_subtile_load_source(
@@ -3405,6 +3459,29 @@ def _codegen_cute_store_tcgen05_tile(
                     f"cute.filter_zeros({rec.ttr_aux_subtile}), "
                     f"cute.filter_zeros({rec.aux_rmem}))\n"
                     f"{prelude_indent}{rec.aux_loaded} = {rec.aux_rmem}.load()\n"
+                )
+                continue
+            hoisted = aux_hoisted_vars[aux_idx]
+            if hoisted is not None:
+                # Read the per-subtile slice from the register tensor the
+                # per-tile setup already loaded (latency overlapped the MMA),
+                # instead of issuing a fresh per-subtile GMEM ``.load()``.
+                lines.append(
+                    f"{prelude_indent}{rec.aux_loaded} = "
+                    f"{hoisted}[(None, None, None, "
+                    f"cutlass.Int32(_tcgen05_subtile))].load()\n"
+                )
+                continue
+            if rec.broadcast_axis == 2:
+                # Column-vector (per-row) aux: uniform over each thread's N
+                # fragment, so read a single SCALAR per subtile (T2R index
+                # (0,0,0)) instead of a redundant N-wide vector ``.load()``.
+                # Matches CUTLASS's ``sa = tTR_gSA[(0,0,0,subtile)]``; the
+                # scalar broadcasts in the ``acc * aux`` chain multiply.
+                lines.append(
+                    f"{prelude_indent}{rec.aux_loaded} = "
+                    f"{rec.ttr_aux_grouped}"
+                    f"[(0, 0, 0, cutlass.Int32(_tcgen05_subtile))]\n"
                 )
                 continue
             lines.extend(

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -458,6 +458,39 @@ def cute_matmul_mma(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     return out
 
 
+@helion.kernel(backend="cute", static_shapes=True)
+def cute_matmul_mma_fp8(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    # fp8 (e4m3) inputs, f32 accumulate, bf16 output -- the tcgen05 MMA atom
+    # for fp8 is MmaF8F6F4Op (MMA-K=32 vs 16 for bf16/fp16).
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+        out[tile_m, tile_n] = acc.to(torch.bfloat16)
+    return out
+
+
+@helion.kernel(backend="cute", static_shapes=True)
+def cute_matmul_mma_fp8_rowvec_scale(
+    x: torch.Tensor, y: torch.Tensor, scale_n: torch.Tensor
+) -> torch.Tensor:
+    # fp8 GEMM with a fused per-column (rowvec) scale in the epilogue.
+    # Exercises the rowvec aux chain on the tcgen05 fp8 path (and, for
+    # TMA-store configs, the register-hoist of the rowvec load).
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+        out[tile_m, tile_n] = (acc * scale_n[tile_n]).to(torch.bfloat16)
+    return out
+
+
 @helion.kernel(backend="cute")
 def cute_matmul_mma_epilogue(
     x: torch.Tensor, y: torch.Tensor, bias: torch.Tensor
@@ -1154,6 +1187,44 @@ class TestCuteBackend(TestCase):
             code,
         )
         self.assertIn("cutlass.pipeline.NamedBarrier(barrier_id=1", code)
+
+    def test_matmul_mma_tcgen05_fp8(self) -> None:
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = (torch.randn(256, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = (torch.randn(128, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        code, out = code_and_output(
+            cute_matmul_mma_fp8, (x, y), block_sizes=[128, 128, 128]
+        )
+        ref = x.float() @ y.float()
+        torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+        # fp8 routes through the tcgen05 F8F6F4 MMA atom (MMA-K=32).
+        self.assertIn("cutlass.utils.blackwell_helpers.make_trivial_tiled_mma", code)
+        self.assertIn("cutlass.Float8E4M3FN", code)
+        self.assertIn("cute.nvgpu.tcgen05", code)
+        self.assertIn("cute.gemm(", code)
+
+    def test_matmul_mma_tcgen05_fp8_rowvec_scale(self) -> None:
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = (torch.randn(256, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = (torch.randn(128, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        scale_n = torch.rand(128, device=DEVICE) + 0.5
+        code, out = code_and_output(
+            cute_matmul_mma_fp8_rowvec_scale,
+            (x, y, scale_n),
+            block_sizes=[128, 128, 128],
+        )
+        ref = (x.float() @ y.float()) * scale_n.float()
+        torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+        self.assertIn("cutlass.Float8E4M3FN", code)
+        self.assertIn("cute.nvgpu.tcgen05", code)
 
     def test_matmul_dot_out_dtype_falls_back_from_mma(self) -> None:
         args = (


### PR DESCRIPTION
Stacked PRs:
 * #2708
 * __->__#2696


--- --- ---

### [cute] FP8 scaled_mm on the CuTe backend, matching CUTLASS on B200 compute-bound shapes


Enable FP8 (e4m3) RowWise scaled_mm on Helion's CuTe/tcgen05 backend and close
the perf gap to CUTLASS's own CuTe DSL persistent GEMM on the Qwen3 M=512
compute-bound shapes (was unsupported -> 1.6x -> ~1.06x vs vLLM, i.e. parity
with the standalone within contention noise).

Helion kernel: examples/scaled_mm.py::scaled_mm_cute (+ _SCALED_MM_CUTE_FP8_CONFIG).
Reference: cute_scaled_mm.py -- the standalone CUTLASS CuTe DSL fused-rowwise-scale
persistent GEMM used as the 1.0x target.

Backend changes:
- mma_support.py: fp8 tcgen05 capability probe via MmaF8F6F4Op (tcgen05_f8).
- matmul_ops.py: admit float8_e4m3fn into the tcgen05 search; MMA-K=32 for fp8.
- cute_mma.py: fp8 dtype map (Float8E4M3FN), _has_mma_operands, tcgen05_use_tma,
  bk%32 in _mma_impl_matches_problem_shape, _choose_mma_impl probe; trace the
  output dtype through fused-scale ops (mul/add/sub/div) so the epilogue plan
  sees the bf16 store rather than the fp8 input dtype.
- program_id.py: add cutlass.Float8E4M3FN/E5M2 to the persistent role-local
  pure-call whitelist (unblocks CtaGroup.TWO for fp8).
- tcgen05_config.py: SMEM-budget-based deep AB staging for fp8
  (max_ab_stages_that_fit); validation admits ab_stages>3 for fp8 -> the
  generated mainloop reaches CUTLASS depth (bk=64, ab_stages=8).
- memory_ops.py: register-hoist a row-vector epilogue aux before the
  accumulator consumer_wait (latency overlaps the MMA), fp8-gated.
- cute_fx_walk.py: classify a stride-(1,0) (M,N) aux as a per-row column vector
  -> ("broadcast", 2); memory_ops.py reads it as a scalar per subtile (matches
  CUTLASS's sa = tTR_gSA[(0,0,0,s)]) instead of a redundant N-wide vector load.

Tests: test_matmul_mma_tcgen05_fp8 and test_matmul_mma_tcgen05_fp8_rowvec_scale
in test/test_cute_backend.py. bf16 paths unchanged.
