### PR TITLE
Kernel metadata hooks

### DIFF
--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -143,8 +143,8 @@ def my_kernel(x: torch.Tensor) -> torch.Tensor:
 
 .. autoattribute:: Settings.autotune_log
 
-   When set, Helion writes per-config autotuning telemetry (config index, generation, status, perf, compile time, timestamp, config JSON) to ``<value>.csv`` and mirrors the autotune log output to ``<value>.log`` for population-based autotuners (currently ``PatternSearch`` and ``DifferentialEvolution``).
-   The kernel identity (id, name, source, input shapes, dtypes, hardware) is written once per run to ``<value>.meta.json`` so the per-config CSV rows can be grouped by kernel across runs.
+   When set, Helion writes per-config autotuning telemetry (kernel id, sample id, config index, generation, status, perf, compile time, timestamp, config JSON) to ``<value>.csv`` and mirrors the autotune log output to ``<value>.log`` for population-based autotuners (currently ``PatternSearch`` and ``DifferentialEvolution``).
+   The kernel identity (id, name, source, input shapes, dtypes, hardware) is written once per run to ``<value>.meta.json``. ``kernel_id`` is a stable content hash (of the kernel source and code-generation settings) that appears on every CSV row, acting as the foreign key to join rows back to the sidecar and group them by kernel across runs; ``sample_id`` additionally identifies each ``(kernel, config)`` pair so repeated benchmarks of the same config can be deduplicated.
    Controlled by ``HELION_AUTOTUNE_LOG``.
 
 .. autoattribute:: Settings.autotune_compile_timeout

--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -144,6 +144,7 @@ def my_kernel(x: torch.Tensor) -> torch.Tensor:
 .. autoattribute:: Settings.autotune_log
 
    When set, Helion writes per-config autotuning telemetry (config index, generation, status, perf, compile time, timestamp, config JSON) to ``<value>.csv`` and mirrors the autotune log output to ``<value>.log`` for population-based autotuners (currently ``PatternSearch`` and ``DifferentialEvolution``).
+   The kernel identity (id, name, source, input shapes, dtypes, hardware) is written once per run to ``<value>.meta.json`` so the per-config CSV rows can be grouped by kernel across runs.
    Controlled by ``HELION_AUTOTUNE_LOG``.
 
 .. autoattribute:: Settings.autotune_compile_timeout

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -252,16 +252,16 @@ class BaseSearch(BaseAutotuner):
         budget = self.settings.autotune_budget_seconds
         if budget is not None:
             self.log(f"Autotune budget: {budget}s")
-        outer_kernel = getattr(self.kernel, "kernel", None)
+        kernel_obj = getattr(self.kernel, "kernel", None)
         kernel_idx = -1
         kernel_source = ""
-        if outer_kernel is not None:
-            kernel_idx = outer_kernel.kernel_id()
+        if kernel_obj is not None:
+            kernel_idx = kernel_obj.kernel_id()
             try:
-                kernel_source = outer_kernel.kernel_source()
+                kernel_source = kernel_obj.kernel_source()
             except Exception:
                 self.log.debug("Failed to read Helion kernel source", exc_info=True)
-        kernel_name = getattr(outer_kernel, "name", "")
+        kernel_name = getattr(kernel_obj, "name", "")
         tensors = [arg for arg in self.args if isinstance(arg, torch.Tensor)]
         input_shapes = str([tuple(t.shape) for t in tensors])
         dtypes = str([str(t.dtype) for t in tensors])

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -38,6 +38,7 @@ from .benchmarking import clear_jit_fast_path_caches
 from .benchmarking import interleaved_bench
 from .logger import AutotuningLogger
 from .metrics import AutotuneMetrics
+from .metrics import KernelMetadata
 from .metrics import _run_post_autotune_hooks
 from .precompile_future import PrecompileFuture as PrecompileFuture
 from helion._dist_utils import all_gather_object
@@ -252,24 +253,37 @@ class BaseSearch(BaseAutotuner):
         if budget is not None:
             self.log(f"Autotune budget: {budget}s")
         outer_kernel = getattr(self.kernel, "kernel", None)
-        kernel_source_hash = ""
+        kernel_idx = -1
+        kernel_source = ""
         if outer_kernel is not None:
+            kernel_idx = outer_kernel.kernel_id()
             try:
-                kernel_source_hash = outer_kernel.kernel_source_hash()
+                kernel_source = outer_kernel.kernel_source()
             except Exception:
-                self.log.debug(
-                    "Failed to compute Helion kernel source hash", exc_info=True
-                )
+                self.log.debug("Failed to read Helion kernel source", exc_info=True)
+        kernel_name = getattr(outer_kernel, "name", "")
+        tensors = [arg for arg in self.args if isinstance(arg, torch.Tensor)]
+        input_shapes = str([tuple(t.shape) for t in tensors])
+        dtypes = str([str(t.dtype) for t in tensors])
+        hardware = get_device_name(extract_device(self.args)) or ""
         self._autotune_metrics: AutotuneMetrics = AutotuneMetrics(
-            kernel_idx=outer_kernel.kernel_id() if outer_kernel is not None else -1,
-            kernel_name=getattr(outer_kernel, "name", ""),
-            kernel_source_hash=kernel_source_hash,
-            input_shapes=str(
-                [tuple(arg.shape) for arg in self.args if isinstance(arg, torch.Tensor)]
-            ),
-            hardware=get_device_name(extract_device(self.args)) or "",
+            kernel_idx=kernel_idx,
+            kernel_name=kernel_name,
+            kernel_source=kernel_source,
+            input_shapes=input_shapes,
+            hardware=hardware,
             random_seed=self.settings.autotune_random_seed,
             search_algorithm=type(self).__name__,
+        )
+        # Written once per run to the <autotune_log>.meta.json sidecar so the
+        # per-config CSV rows can be grouped by kernel across runs.
+        self._kernel_metadata: KernelMetadata = KernelMetadata(
+            kernel_idx=kernel_idx,
+            kernel_name=kernel_name,
+            kernel_source=kernel_source,
+            input_shapes=input_shapes,
+            dtypes=dtypes,
+            hardware=hardware,
         )
         self.benchmark_provider = self._benchmark_provider_cls(
             kernel=self.kernel,
@@ -461,7 +475,9 @@ class BaseSearch(BaseAutotuner):
         exit_stack = contextlib.ExitStack()
         with exit_stack:
             if self.settings.autotune_log:
-                exit_stack.enter_context(self.log.autotune_logging())
+                exit_stack.enter_context(
+                    self.log.autotune_logging(metadata=self._kernel_metadata)
+                )
             self.log.reset()
             # Autotuner triggers bugs in remote triton compile service.
             # Skip storing Triton intermediate IRs (.ttir, .ttgir, .llir, etc.)

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -253,13 +253,13 @@ class BaseSearch(BaseAutotuner):
         if budget is not None:
             self.log(f"Autotune budget: {budget}s")
         kernel_obj = getattr(self.kernel, "kernel", None)
-        kernel_idx = -1
+        kernel_id = ""
         kernel_source = ""
         if kernel_obj is not None:
-            kernel_idx = kernel_obj.kernel_id()
             try:
                 kernel_source = kernel_obj.kernel_source()
-            except Exception:
+                kernel_id = kernel_obj.kernel_id()
+            except OSError:
                 self.log.debug("Failed to read Helion kernel source", exc_info=True)
         kernel_name = getattr(kernel_obj, "name", "")
         tensors = [arg for arg in self.args if isinstance(arg, torch.Tensor)]
@@ -267,7 +267,7 @@ class BaseSearch(BaseAutotuner):
         dtypes = str([str(t.dtype) for t in tensors])
         hardware = get_device_name(extract_device(self.args)) or ""
         self._autotune_metrics: AutotuneMetrics = AutotuneMetrics(
-            kernel_idx=kernel_idx,
+            kernel_id=kernel_id,
             kernel_name=kernel_name,
             kernel_source=kernel_source,
             input_shapes=input_shapes,
@@ -278,7 +278,7 @@ class BaseSearch(BaseAutotuner):
         # Written once per run to the <autotune_log>.meta.json sidecar so the
         # per-config CSV rows can be grouped by kernel across runs.
         self._kernel_metadata: KernelMetadata = KernelMetadata(
-            kernel_idx=kernel_idx,
+            kernel_id=kernel_id,
             kernel_name=kernel_name,
             kernel_source=kernel_source,
             input_shapes=input_shapes,

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -251,8 +251,19 @@ class BaseSearch(BaseAutotuner):
         budget = self.settings.autotune_budget_seconds
         if budget is not None:
             self.log(f"Autotune budget: {budget}s")
+        outer_kernel = getattr(self.kernel, "kernel", None)
+        kernel_source_hash = ""
+        if outer_kernel is not None:
+            try:
+                kernel_source_hash = outer_kernel.kernel_source_hash()
+            except Exception:
+                self.log.debug(
+                    "Failed to compute Helion kernel source hash", exc_info=True
+                )
         self._autotune_metrics: AutotuneMetrics = AutotuneMetrics(
-            kernel_name=getattr(getattr(self.kernel, "kernel", None), "name", ""),
+            kernel_idx=outer_kernel.kernel_id() if outer_kernel is not None else -1,
+            kernel_name=getattr(outer_kernel, "name", ""),
+            kernel_source_hash=kernel_source_hash,
             input_shapes=str(
                 [tuple(arg.shape) for arg in self.args if isinstance(arg, torch.Tensor)]
             ),

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 import datetime
 import functools
+import hashlib
 from itertools import count
 from itertools import starmap
 import math
@@ -392,6 +393,19 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             self._compute_effective_tolerances()
         )
         self._jobs = self._decide_num_jobs()
+
+    def _sample_id(self, config: Config) -> str:
+        """Return a stable per-(kernel, config) id for telemetry rows.
+
+        Computed as ``sha256(kernel_source + decorator(config))`` so the same
+        kernel benchmarked with the same config produces the same id across
+        runs, enabling label aggregation/dedup for the cost-model dataset.
+        """
+        payload = (
+            self._autotune_metrics.kernel_source
+            + self.kernel.format_kernel_decorator(config, self.settings)
+        )
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
     def _compute_baseline(
         self,
@@ -848,6 +862,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                     process_group_name=self.kernel.env.process_group_name,
                 )
             ):
+                sample_id = self._sample_id(config)
                 self.log.record_autotune_entry(
                     AutotuneLogEntry(
                         generation=self._autotune_metrics.num_generations,
@@ -855,6 +870,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                         perf_ms=None,
                         compile_time=compile_time,
                         config=config,
+                        sample_id=sample_id,
                     )
                 )
                 perf = self._benchmark_function(config, fn)
@@ -866,6 +882,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
                         perf_ms=perf if math.isfinite(perf) else None,
                         compile_time=compile_time,
                         config=config,
+                        sample_id=sample_id,
                     )
                 )
                 results[valid_indices[index]] = BenchmarkResult(

--- a/helion/autotuner/logger.py
+++ b/helion/autotuner/logger.py
@@ -313,6 +313,7 @@ class AutotuneLogSink:
         self._csv_writer = csv.writer(self._csv_file)
         self._csv_writer.writerow(
             [
+                "kernel_id",
                 "timestamp_s",
                 "config_index",
                 "generation",
@@ -362,8 +363,12 @@ class AutotuneLogSink:
         compile_field = ""
         if entry.compile_time is not None:
             compile_field = f"{entry.compile_time:.2f}"
+        # kernel_id is the foreign key joining each row back to the kernel
+        # identity stored once in the .meta.json sidecar.
+        kernel_id = self._metadata.kernel_id if self._metadata is not None else ""
         self._csv_writer.writerow(
             [
+                kernel_id,
                 timestamp_field,
                 self._config_counter,
                 entry.generation,

--- a/helion/autotuner/logger.py
+++ b/helion/autotuner/logger.py
@@ -269,6 +269,8 @@ class AutotuneLogEntry(NamedTuple):
     perf_ms: float | None
     compile_time: float | None
     config: Config
+    # Stable per-(kernel, config) id: sha256(kernel_source + decorator(config)).
+    sample_id: str = ""
 
 
 class AutotuneLogSink:
@@ -314,6 +316,7 @@ class AutotuneLogSink:
         self._csv_writer.writerow(
             [
                 "kernel_id",
+                "sample_id",
                 "timestamp_s",
                 "config_index",
                 "generation",
@@ -369,6 +372,7 @@ class AutotuneLogSink:
         self._csv_writer.writerow(
             [
                 kernel_id,
+                entry.sample_id,
                 timestamp_field,
                 self._config_counter,
                 entry.generation,

--- a/helion/autotuner/logger.py
+++ b/helion/autotuner/logger.py
@@ -5,6 +5,7 @@ import csv
 import hashlib
 import io
 import itertools
+import json
 import logging
 import math
 import os
@@ -37,6 +38,7 @@ if TYPE_CHECKING:
     from ..runtime.config import Config
     from ..runtime.settings import Settings
     from .base_search import _AutotunableKernel
+    from .metrics import KernelMetadata
 
 else:
     CsvWriter = Any  # type: ignore[assignment]
@@ -114,15 +116,20 @@ class AutotuningLogger:
 
     @contextlib.contextmanager
     def autotune_logging(
-        self, base_path: str | None = None
+        self, base_path: str | None = None, metadata: KernelMetadata | None = None
     ) -> Iterator[AutotuneLogSink | None]:
-        """Attach an :class:`AutotuneLogSink` for the duration of a tuning run."""
+        """Attach an :class:`AutotuneLogSink` for the duration of a tuning run.
+
+        When ``metadata`` is provided, the kernel identity (source, id, shapes)
+        is written once to the ``<base>.meta.json`` sidecar so the per-config
+        CSV rows can be grouped by kernel across runs.
+        """
 
         path = base_path or self._settings.autotune_log
         if not path:
             yield None
             return
-        with AutotuneLogSink(path) as sink:
+        with AutotuneLogSink(path, metadata) as sink:
             self._attach_sink(sink)
             sink.start_run()
             try:
@@ -269,10 +276,12 @@ class AutotuneLogSink:
     Writes autotune results to CSV and connects autotune logs to a file handler.
     """
 
-    def __init__(self, base_path: str) -> None:
+    def __init__(self, base_path: str, metadata: KernelMetadata | None = None) -> None:
         self._base_path = Path(base_path)
         self.csv_path = self._base_path.with_suffix(".csv")
         self.log_path = self._base_path.with_suffix(".log")
+        self.meta_path = self._base_path.with_suffix(".meta.json")
+        self._metadata = metadata
         self._csv_file: io.TextIOWrapper | None = None
         self._csv_writer: CsvWriter | None = None
         self._log_handler: logging.FileHandler | None = None
@@ -296,6 +305,10 @@ class AutotuneLogSink:
             return
         self.csv_path.parent.mkdir(parents=True, exist_ok=True)
         self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        if self._metadata is not None:
+            self.meta_path.write_text(
+                json.dumps(self._metadata.to_dict(), indent=2), encoding="utf-8"
+            )
         self._csv_file = self.csv_path.open("w", encoding="utf-8", newline="")
         self._csv_writer = csv.writer(self._csv_file)
         self._csv_writer.writerow(

--- a/helion/autotuner/metrics.py
+++ b/helion/autotuner/metrics.py
@@ -32,7 +32,7 @@ class AutotuneMetrics:
     num_generations: int = 0
     autotune_time: float = 0.0
     best_perf_ms: float = 0.0
-    kernel_idx: int = -1
+    kernel_id: str = ""
     kernel_name: str = ""
     kernel_source: str = ""
     input_shapes: str = ""
@@ -45,7 +45,7 @@ class AutotuneMetrics:
 
     def to_dict(self) -> dict[str, object]:
         return {
-            "kernel_idx": self.kernel_idx,
+            "kernel_id": self.kernel_id,
             "kernel_name": self.kernel_name,
             "kernel_source": self.kernel_source,
             "input_shapes": self.input_shapes,
@@ -68,11 +68,12 @@ class KernelMetadata:
     Written once per autotuning run to the ``<autotune_log>.meta.json`` sidecar
     that sits next to the per-config CSV telemetry. The CSV records each config
     and its result; this provides the stable identity needed to group those rows
-    across runs. ``kernel_source`` is the stable cross-process key;
-    ``kernel_idx`` is a process-local convenience id.
+    across runs. ``kernel_id`` is the stable, content-derived foreign key (a
+    hash of the kernel source and code-generation settings); ``kernel_source``
+    carries the full source text for analysis and debugging.
     """
 
-    kernel_idx: int = -1
+    kernel_id: str = ""
     kernel_name: str = ""
     kernel_source: str = ""
     input_shapes: str = ""
@@ -81,7 +82,7 @@ class KernelMetadata:
 
     def to_dict(self) -> dict[str, object]:
         return {
-            "kernel_idx": self.kernel_idx,
+            "kernel_id": self.kernel_id,
             "kernel_name": self.kernel_name,
             "kernel_source": self.kernel_source,
             "input_shapes": self.input_shapes,

--- a/helion/autotuner/metrics.py
+++ b/helion/autotuner/metrics.py
@@ -8,7 +8,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 _post_autotune_hooks: list[Callable[[AutotuneMetrics], None]] = []
-_kernel_metadata_hooks: list[Callable[[KernelMetadata], None]] = []
 
 
 def register_post_autotune_hook(hook: Callable[[AutotuneMetrics], None]) -> None:
@@ -24,25 +23,6 @@ def _run_post_autotune_hooks(metrics: AutotuneMetrics) -> None:
         hook(metrics)
 
 
-def register_kernel_metadata_hook(hook: Callable[[KernelMetadata], None]) -> None:
-    """Register a hook fired whenever a kernel is bound to a config and compiled.
-
-    Unlike :func:`register_post_autotune_hook`, this fires on every path that
-    activates a config (autotune, on-disk cache hit, and default config), so it
-    captures kernels that never go through the autotuner.
-    """
-    _kernel_metadata_hooks.append(hook)
-
-
-def remove_kernel_metadata_hook(hook: Callable[[KernelMetadata], None]) -> None:
-    _kernel_metadata_hooks.remove(hook)
-
-
-def _run_kernel_metadata_hooks(metadata: KernelMetadata) -> None:
-    for hook in _kernel_metadata_hooks:
-        hook(metadata)
-
-
 @dataclasses.dataclass
 class AutotuneMetrics:
     _start_time: float = dataclasses.field(default_factory=time.perf_counter)
@@ -54,7 +34,7 @@ class AutotuneMetrics:
     best_perf_ms: float = 0.0
     kernel_idx: int = -1
     kernel_name: str = ""
-    kernel_source_hash: str = ""
+    kernel_source: str = ""
     input_shapes: str = ""
     hardware: str = ""
     random_seed: int = 0
@@ -67,7 +47,7 @@ class AutotuneMetrics:
         return {
             "kernel_idx": self.kernel_idx,
             "kernel_name": self.kernel_name,
-            "kernel_source_hash": self.kernel_source_hash,
+            "kernel_source": self.kernel_source,
             "input_shapes": self.input_shapes,
             "hardware": self.hardware,
             "random_seed": self.random_seed,
@@ -83,31 +63,28 @@ class AutotuneMetrics:
 
 @dataclasses.dataclass
 class KernelMetadata:
-    """Metadata for a single kernel that has been bound to a config and compiled.
+    """Per-run identity for the kernel being autotuned.
 
-    Emitted on every path that activates a config so that cache hits and
-    default-config runs are captured in addition to autotuned runs. ``path``
-    records which path produced the record ("autotune", "default", or
-    "explicit").
+    Written once per autotuning run to the ``<autotune_log>.meta.json`` sidecar
+    that sits next to the per-config CSV telemetry. The CSV records each config
+    and its result; this provides the stable identity needed to group those rows
+    across runs. ``kernel_source`` is the stable cross-process key;
+    ``kernel_idx`` is a process-local convenience id.
     """
 
     kernel_idx: int = -1
     kernel_name: str = ""
-    kernel_source_hash: str = ""
-    config: str = ""
+    kernel_source: str = ""
     input_shapes: str = ""
     dtypes: str = ""
     hardware: str = ""
-    path: str = ""
 
     def to_dict(self) -> dict[str, object]:
         return {
             "kernel_idx": self.kernel_idx,
             "kernel_name": self.kernel_name,
-            "kernel_source_hash": self.kernel_source_hash,
-            "config": self.config,
+            "kernel_source": self.kernel_source,
             "input_shapes": self.input_shapes,
             "dtypes": self.dtypes,
             "hardware": self.hardware,
-            "path": self.path,
         }

--- a/helion/autotuner/metrics.py
+++ b/helion/autotuner/metrics.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 _post_autotune_hooks: list[Callable[[AutotuneMetrics], None]] = []
+_kernel_metadata_hooks: list[Callable[[KernelMetadata], None]] = []
 
 
 def register_post_autotune_hook(hook: Callable[[AutotuneMetrics], None]) -> None:
@@ -23,6 +24,25 @@ def _run_post_autotune_hooks(metrics: AutotuneMetrics) -> None:
         hook(metrics)
 
 
+def register_kernel_metadata_hook(hook: Callable[[KernelMetadata], None]) -> None:
+    """Register a hook fired whenever a kernel is bound to a config and compiled.
+
+    Unlike :func:`register_post_autotune_hook`, this fires on every path that
+    activates a config (autotune, on-disk cache hit, and default config), so it
+    captures kernels that never go through the autotuner.
+    """
+    _kernel_metadata_hooks.append(hook)
+
+
+def remove_kernel_metadata_hook(hook: Callable[[KernelMetadata], None]) -> None:
+    _kernel_metadata_hooks.remove(hook)
+
+
+def _run_kernel_metadata_hooks(metadata: KernelMetadata) -> None:
+    for hook in _kernel_metadata_hooks:
+        hook(metadata)
+
+
 @dataclasses.dataclass
 class AutotuneMetrics:
     _start_time: float = dataclasses.field(default_factory=time.perf_counter)
@@ -32,7 +52,9 @@ class AutotuneMetrics:
     num_generations: int = 0
     autotune_time: float = 0.0
     best_perf_ms: float = 0.0
+    kernel_idx: int = -1
     kernel_name: str = ""
+    kernel_source_hash: str = ""
     input_shapes: str = ""
     hardware: str = ""
     random_seed: int = 0
@@ -43,7 +65,9 @@ class AutotuneMetrics:
 
     def to_dict(self) -> dict[str, object]:
         return {
+            "kernel_idx": self.kernel_idx,
             "kernel_name": self.kernel_name,
+            "kernel_source_hash": self.kernel_source_hash,
             "input_shapes": self.input_shapes,
             "hardware": self.hardware,
             "random_seed": self.random_seed,
@@ -54,4 +78,36 @@ class AutotuneMetrics:
             "num_generations": self.num_generations,
             "autotune_time": self.autotune_time,
             "best_perf_ms": self.best_perf_ms,
+        }
+
+
+@dataclasses.dataclass
+class KernelMetadata:
+    """Metadata for a single kernel that has been bound to a config and compiled.
+
+    Emitted on every path that activates a config so that cache hits and
+    default-config runs are captured in addition to autotuned runs. ``path``
+    records which path produced the record ("autotune", "default", or
+    "explicit").
+    """
+
+    kernel_idx: int = -1
+    kernel_name: str = ""
+    kernel_source_hash: str = ""
+    config: str = ""
+    input_shapes: str = ""
+    dtypes: str = ""
+    hardware: str = ""
+    path: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kernel_idx": self.kernel_idx,
+            "kernel_name": self.kernel_name,
+            "kernel_source_hash": self.kernel_source_hash,
+            "config": self.config,
+            "input_shapes": self.input_shapes,
+            "dtypes": self.dtypes,
+            "hardware": self.hardware,
+            "path": self.path,
         }

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -4,6 +4,7 @@ import ast
 import contextlib
 import dataclasses
 import functools
+import hashlib
 import inspect
 import itertools
 import logging
@@ -224,40 +225,35 @@ class Kernel(Generic[_R]):
         self.__defaults__ = fn.__defaults__
         self.__kwdefaults__ = fn.__kwdefaults__
 
+    def _settings_signature(self) -> str:
+        """Return a stable string of settings that influence Triton codegen.
+
+        Mirrors the settings captured by
+        :meth:`BoundKernel.format_kernel_decorator` so the kernel id reflects
+        the same code-generation-affecting knobs.
+        """
+        parts = [f"static_shapes={self.settings.static_shapes}"]
+        if self.settings.index_dtype is not None:
+            parts.append(f"index_dtype={self.settings.index_dtype}")
+        return ", ".join(parts)
+
     @functools.cache  # noqa: B019
-    def kernel_id(self) -> int:
+    def kernel_id(self) -> str:
         """
-        Return the process-local integer id for this kernel.
+        Return a stable, content-derived identifier for this kernel.
 
-        This reuses the Helion kernel side-table index (``kernel_idx``) that the
-        ``torch.compile`` integration assigns. The id is allocated lazily and is
-        idempotent: the same ``Kernel`` instance always maps to the same index
-        within a process, whether it is first seen on the autotune, cached, or
-        ``torch.compile`` tracing path.
+        The id is the SHA-256 hash of the kernel source together with the
+        settings that influence Triton code generation (see
+        :meth:`_settings_signature`). Because it is derived purely from content,
+        it is stable across processes and runs, making it suitable as a foreign
+        key for grouping telemetry rows by kernel during analysis.
 
-        Note: the id is process-local and NOT stable across processes. Use
-        :meth:`kernel_source` for a stable, content-derived identifier when
-        joining telemetry across runs.
-
-        Returns ``-1`` when the side table is unavailable (e.g. on PyTorch
-        versions that predate the Helion higher-order-op integration).
+        Raises ``OSError`` if the source cannot be located (e.g. functions
+        defined in an interactive REPL or generated dynamically); see
+        :meth:`kernel_source`.
         """
-        try:
-            from .._compiler._dynamo.higher_order_ops import helion_kernel_side_table
-        except Exception as e:  # pragma: no cover - depends on torch version
-            log.debug(
-                "Could not import the Helion kernel side table for kernel %r; "
-                "falling back to kernel_id=-1. This usually means the installed "
-                "PyTorch (%s) predates the Helion higher-order-op integration. "
-                "kernel_id is process-local anyway; telemetry can still group "
-                "rows for this kernel by kernel_source(). Cause: %s",
-                self.name,
-                torch.__version__,
-                e,
-                exc_info=True,
-            )
-            return -1
-        return helion_kernel_side_table.add_kernel(self)
+        payload = self.kernel_source() + self._settings_signature()
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
     @functools.cache  # noqa: B019
     def kernel_source(self) -> str:

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -4,7 +4,6 @@ import ast
 import contextlib
 import dataclasses
 import functools
-import hashlib
 import inspect
 import itertools
 import logging
@@ -37,7 +36,6 @@ from torch.utils._pytree import tree_map_only
 from torch.utils.weak import WeakIdKeyDictionary
 
 from .. import exc
-from .._compat import get_device_name
 from .._compat import target_device_capability
 from .._compile_time import measure
 from .._compiler.ast_extension import unparse
@@ -57,9 +55,6 @@ from .._dist_utils import check_config_consistancy as dist_check_config_consista
 from .._logging import LazyString
 from .._utils import counters
 from ..autotuner.base_search import _AutotunableKernel
-from ..autotuner.metrics import KernelMetadata
-from ..autotuner.metrics import _kernel_metadata_hooks
-from ..autotuner.metrics import _run_kernel_metadata_hooks
 from ..language.constexpr import ConstExpr
 from .config import Config
 from .ref_mode import RefModeContext
@@ -229,6 +224,7 @@ class Kernel(Generic[_R]):
         self.__defaults__ = fn.__defaults__
         self.__kwdefaults__ = fn.__kwdefaults__
 
+    @functools.cache  # noqa: B019
     def kernel_id(self) -> int:
         """
         Return the process-local integer id for this kernel.
@@ -240,7 +236,8 @@ class Kernel(Generic[_R]):
         ``torch.compile`` tracing path.
 
         Note: the id is process-local and NOT stable across processes. Use
-        :meth:`kernel_source_hash` for a stable, content-derived identifier.
+        :meth:`kernel_source` for a stable, content-derived identifier when
+        joining telemetry across runs.
 
         Returns ``-1`` when the side table is unavailable (e.g. on PyTorch
         versions that predate the Helion higher-order-op integration).
@@ -261,14 +258,14 @@ class Kernel(Generic[_R]):
             return -1
         return helion_kernel_side_table.add_kernel(self)
 
-    def kernel_source_hash(self) -> str:
+    def kernel_source(self) -> str:
         """
-        Return a stable SHA-256 hash of the kernel's source text.
+        Return the kernel's source text.
 
-        This deterministic ID across processes is suitable as a
-        content-derived key for joining telemetry across runs.
+        This is the stable identifier across processes/runs, suitable for
+        grouping telemetry rows by kernel during analysis.
         """
-        return hashlib.sha256(inspect.getsource(self.fn).encode("utf-8")).hexdigest()
+        return inspect.getsource(self.fn)
 
     def _get_bound_kernel_cache_key(
         self, args: tuple[object, ...], signature: tuple[Hashable, ...]
@@ -894,10 +891,10 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             config = self.env.backend.autotune(self, args, force=force, **kwargs)
         if ephemeral is not None:
             self.env.backend.finalize_ephemeral_cache(self, config)
-        self.set_config(config, path="autotune")
+        self.set_config(config)
         return config
 
-    def set_config(self, config: ConfigLike, *, path: str = "explicit") -> None:
+    def set_config(self, config: ConfigLike) -> None:
         """
         Set the configuration for the kernel and compile it.
 
@@ -905,8 +902,6 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
 
         Args:
             config: The configuration to set.
-            path: How this config was produced, recorded in the emitted kernel
-                metadata. One of "autotune", "default", or "explicit".
         """
         config = self._normalize_config(config)
         self._run = self.compile_config(config)
@@ -914,33 +909,6 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         counters["best_config_decorator"][
             self.format_kernel_decorator(config, self.settings)
         ] = 1
-        self._emit_kernel_metadata(config, path)
-
-    def _emit_kernel_metadata(self, config: Config, path: str) -> None:
-        """Emit kernel metadata to any registered hooks.
-
-        Fires on every path that activates a config (autotune, on-disk cache hit,
-        and default/user config), so kernels that never go through the autotuner
-        are also captured. Telemetry must never break kernel execution, so any
-        failure here is swallowed.
-        """
-        if not _kernel_metadata_hooks:
-            return
-        try:
-            tensors = [a for a in self.fake_args if isinstance(a, torch.Tensor)]
-            metadata = KernelMetadata(
-                kernel_idx=self.kernel.kernel_id(),
-                kernel_name=self.kernel.name,
-                kernel_source_hash=self.kernel.kernel_source_hash(),
-                config=self.format_kernel_decorator(config, self.settings),
-                input_shapes=str([tuple(t.shape) for t in tensors]),
-                dtypes=str([str(t.dtype) for t in tensors]),
-                hardware=get_device_name(self._env.device) or "",
-                path=path,
-            )
-            _run_kernel_metadata_hooks(metadata)
-        except Exception:
-            log.debug("Failed to emit Helion kernel metadata", exc_info=True)
 
     def _specialize_extra(self) -> list[Callable[[Sequence[object]], Hashable]]:
         """
@@ -1114,7 +1082,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             return  # Already have a config
         if (config := self._implicit_config()) is not None:
             with measure("BoundKernel.set_config"):
-                self.set_config(config, path="default")
+                self.set_config(config)
         else:
             with measure("BoundKernel.autotune"):
                 self.autotune(args, force=False)

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -246,10 +246,11 @@ class Kernel(Generic[_R]):
             from .._compiler._dynamo.higher_order_ops import helion_kernel_side_table
         except Exception as e:  # pragma: no cover - depends on torch version
             log.debug(
-                "Could not import the Helion kernel side table for kernel %r!!! "
-                "Falling back to kernel_id=-1. This usually means the installed "
-                "PyTorch (%s) predates the Helion higher-order-op integration, so "
-                "telemetry for this kernel will lack a stable kernel id. Cause: %s",
+                "Could not import the Helion kernel side table for kernel %r; "
+                "falling back to kernel_id=-1. This usually means the installed "
+                "PyTorch (%s) predates the Helion higher-order-op integration. "
+                "kernel_id is process-local anyway; telemetry can still group "
+                "rows for this kernel by kernel_source(). Cause: %s",
                 self.name,
                 torch.__version__,
                 e,

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -4,6 +4,7 @@ import ast
 import contextlib
 import dataclasses
 import functools
+import hashlib
 import inspect
 import itertools
 import logging
@@ -36,6 +37,7 @@ from torch.utils._pytree import tree_map_only
 from torch.utils.weak import WeakIdKeyDictionary
 
 from .. import exc
+from .._compat import get_device_name
 from .._compat import target_device_capability
 from .._compile_time import measure
 from .._compiler.ast_extension import unparse
@@ -55,6 +57,9 @@ from .._dist_utils import check_config_consistancy as dist_check_config_consista
 from .._logging import LazyString
 from .._utils import counters
 from ..autotuner.base_search import _AutotunableKernel
+from ..autotuner.metrics import KernelMetadata
+from ..autotuner.metrics import _kernel_metadata_hooks
+from ..autotuner.metrics import _run_kernel_metadata_hooks
 from ..language.constexpr import ConstExpr
 from .config import Config
 from .ref_mode import RefModeContext
@@ -223,6 +228,47 @@ class Kernel(Generic[_R]):
         self.__code__ = fn.__code__
         self.__defaults__ = fn.__defaults__
         self.__kwdefaults__ = fn.__kwdefaults__
+
+    def kernel_id(self) -> int:
+        """
+        Return the process-local integer id for this kernel.
+
+        This reuses the Helion kernel side-table index (``kernel_idx``) that the
+        ``torch.compile`` integration assigns. The id is allocated lazily and is
+        idempotent: the same ``Kernel`` instance always maps to the same index
+        within a process, whether it is first seen on the autotune, cached, or
+        ``torch.compile`` tracing path.
+
+        Note: the id is process-local and NOT stable across processes. Use
+        :meth:`kernel_source_hash` for a stable, content-derived identifier.
+
+        Returns ``-1`` when the side table is unavailable (e.g. on PyTorch
+        versions that predate the Helion higher-order-op integration).
+        """
+        try:
+            from .._compiler._dynamo.higher_order_ops import helion_kernel_side_table
+        except Exception as e:  # pragma: no cover - depends on torch version
+            log.debug(
+                "Could not import the Helion kernel side table for kernel %r!!! "
+                "Falling back to kernel_id=-1. This usually means the installed "
+                "PyTorch (%s) predates the Helion higher-order-op integration, so "
+                "telemetry for this kernel will lack a stable kernel id. Cause: %s",
+                self.name,
+                torch.__version__,
+                e,
+                exc_info=True,
+            )
+            return -1
+        return helion_kernel_side_table.add_kernel(self)
+
+    def kernel_source_hash(self) -> str:
+        """
+        Return a stable SHA-256 hash of the kernel's source text.
+
+        This deterministic ID across processes is suitable as a
+        content-derived key for joining telemetry across runs.
+        """
+        return hashlib.sha256(inspect.getsource(self.fn).encode("utf-8")).hexdigest()
 
     def _get_bound_kernel_cache_key(
         self, args: tuple[object, ...], signature: tuple[Hashable, ...]
@@ -848,10 +894,10 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             config = self.env.backend.autotune(self, args, force=force, **kwargs)
         if ephemeral is not None:
             self.env.backend.finalize_ephemeral_cache(self, config)
-        self.set_config(config)
+        self.set_config(config, path="autotune")
         return config
 
-    def set_config(self, config: ConfigLike) -> None:
+    def set_config(self, config: ConfigLike, *, path: str = "explicit") -> None:
         """
         Set the configuration for the kernel and compile it.
 
@@ -859,6 +905,8 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
 
         Args:
             config: The configuration to set.
+            path: How this config was produced, recorded in the emitted kernel
+                metadata. One of "autotune", "default", or "explicit".
         """
         config = self._normalize_config(config)
         self._run = self.compile_config(config)
@@ -866,6 +914,33 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         counters["best_config_decorator"][
             self.format_kernel_decorator(config, self.settings)
         ] = 1
+        self._emit_kernel_metadata(config, path)
+
+    def _emit_kernel_metadata(self, config: Config, path: str) -> None:
+        """Emit kernel metadata to any registered hooks.
+
+        Fires on every path that activates a config (autotune, on-disk cache hit,
+        and default/user config), so kernels that never go through the autotuner
+        are also captured. Telemetry must never break kernel execution, so any
+        failure here is swallowed.
+        """
+        if not _kernel_metadata_hooks:
+            return
+        try:
+            tensors = [a for a in self.fake_args if isinstance(a, torch.Tensor)]
+            metadata = KernelMetadata(
+                kernel_idx=self.kernel.kernel_id(),
+                kernel_name=self.kernel.name,
+                kernel_source_hash=self.kernel.kernel_source_hash(),
+                config=self.format_kernel_decorator(config, self.settings),
+                input_shapes=str([tuple(t.shape) for t in tensors]),
+                dtypes=str([str(t.dtype) for t in tensors]),
+                hardware=get_device_name(self._env.device) or "",
+                path=path,
+            )
+            _run_kernel_metadata_hooks(metadata)
+        except Exception:
+            log.debug("Failed to emit Helion kernel metadata", exc_info=True)
 
     def _specialize_extra(self) -> list[Callable[[Sequence[object]], Hashable]]:
         """
@@ -1039,7 +1114,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             return  # Already have a config
         if (config := self._implicit_config()) is not None:
             with measure("BoundKernel.set_config"):
-                self.set_config(config)
+                self.set_config(config, path="default")
         else:
             with measure("BoundKernel.autotune"):
                 self.autotune(args, force=False)

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -259,6 +259,7 @@ class Kernel(Generic[_R]):
             return -1
         return helion_kernel_side_table.add_kernel(self)
 
+    @functools.cache  # noqa: B019
     def kernel_source(self) -> str:
         """
         Return the kernel's source text.
@@ -1443,7 +1444,8 @@ def _graph_module_key(fn: Kernel, obj: torch.fx.GraphModule) -> Hashable:
 
 
 _specialization_extractors: dict[
-    type[object] | str, Callable[[Kernel, object], Hashable]
+    type[object] | str,
+    Callable[[Kernel, object], Hashable],
     # pyrefly: ignore [bad-assignment]
 ] = {
     torch.Tensor: _tensor_key,

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -458,6 +458,8 @@ class TestAutotuneIgnoreErrors(TestCase):
         self.assertEqual(
             rows[0],
             [
+                "kernel_id",
+                "sample_id",
                 "timestamp_s",
                 "config_index",
                 "generation",
@@ -467,10 +469,13 @@ class TestAutotuneIgnoreErrors(TestCase):
                 "config",
             ],
         )
-        self.assertEqual(rows[1][1], "1")
-        self.assertEqual(rows[1][2], "5")
-        self.assertEqual(rows[1][3], "ok")
-        self.assertEqual(rows[1][4], "1.234000")
+        # No metadata/sample_id supplied here, so the identity columns are empty.
+        self.assertEqual(rows[1][0], "")
+        self.assertEqual(rows[1][1], "")
+        self.assertEqual(rows[1][3], "1")
+        self.assertEqual(rows[1][4], "5")
+        self.assertEqual(rows[1][5], "ok")
+        self.assertEqual(rows[1][6], "1.234000")
         log_text = log_path.read_text()
         self.assertIn("finalized entry", log_text)
 
@@ -706,7 +711,8 @@ class TestAutotuneIgnoreErrors(TestCase):
         csv_path = base_path.with_suffix(".csv")
         self.assertTrue(csv_path.exists())
         rows = list(csv.reader(csv_path.read_text().splitlines()))
-        statuses = [row[3] for row in rows[1:]]  # skip header
+        status_idx = rows[0].index("status")  # look up by name; column order may change
+        statuses = [row[status_idx] for row in rows[1:]]  # skip header
         started_count = sum(1 for s in statuses if s == "started")
         completed_count = sum(1 for s in statuses if s in ("ok", "error", "timeout"))
         self.assertGreater(started_count, 0, "Should log started entries")
@@ -3913,6 +3919,7 @@ class TestAutotuneBudget(TestCase):
             num_compile_failures=0,
             num_accuracy_failures=0,
             num_generations=0,
+            kernel_source="",
         )
         provider.mutated_arg_indices = ()
         provider._benchmark_worker = None

--- a/test/test_kernel_metadata.py
+++ b/test/test_kernel_metadata.py
@@ -134,7 +134,7 @@ class TestMetadataSchema(TestCase):
 
 
 class TestAutotuneLogSink(TestCase):
-    def _entry(self, perf_ms: float) -> AutotuneLogEntry:
+    def _entry(self, perf_ms: float, sample_id: str = "sample-xyz") -> AutotuneLogEntry:
         """
         Create fake log entry for testing.
         """
@@ -144,6 +144,7 @@ class TestAutotuneLogSink(TestCase):
             perf_ms=perf_ms,
             compile_time=0.5,
             config=helion.Config(block_sizes=[16]),
+            sample_id=sample_id,
         )
 
     def test_sink_writes_metadata_sidecar_and_per_config_rows(self) -> None:
@@ -180,6 +181,9 @@ class TestAutotuneLogSink(TestCase):
             # kernel_id foreign key is stamped on every row, matching the sidecar.
             kid_col = header.index("kernel_id")
             self.assertTrue(all(row[kid_col] == "abc123" for row in data_rows))
+            # sample_id (per-(kernel, config) key) is carried from the entry.
+            sid_col = header.index("sample_id")
+            self.assertTrue(all(row[sid_col] == "sample-xyz" for row in data_rows))
 
     def test_sink_without_metadata_writes_no_sidecar(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/test/test_kernel_metadata.py
+++ b/test/test_kernel_metadata.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import TestCase
+from helion._testing import skipIfRefEager
+from helion.autotuner.metrics import AutotuneMetrics
+from helion.autotuner.metrics import KernelMetadata
+from helion.autotuner.metrics import register_kernel_metadata_hook
+from helion.autotuner.metrics import register_post_autotune_hook
+from helion.autotuner.metrics import remove_kernel_metadata_hook
+from helion.autotuner.metrics import remove_post_autotune_hook
+import helion.language as hl
+
+
+@helion.kernel(config=helion.Config(block_sizes=[16]))
+def _add_kernel(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size(0)):
+        out[tile] = x[tile] + y[tile]
+    return out
+
+
+@helion.kernel(config=helion.Config(block_sizes=[16]))
+def _other_kernel(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size(0)):
+        out[tile] = x[tile] * y[tile]
+    return out
+
+
+def _side_table_available() -> bool:
+    try:
+        from helion._compiler._dynamo.higher_order_ops import helion_kernel_side_table
+    except Exception:
+        return False
+    return helion_kernel_side_table is not None
+
+
+class TestKernelId(TestCase):
+    @unittest.skipUnless(_side_table_available(), "kernel side table unavailable")
+    def test_kernel_id_idempotent(self) -> None:
+        first = _add_kernel.kernel_id()
+        second = _add_kernel.kernel_id()
+        self.assertEqual(first, second)
+        self.assertGreaterEqual(first, 0)
+
+    @unittest.skipUnless(_side_table_available(), "kernel side table unavailable")
+    def test_kernel_id_distinct_between_kernels(self) -> None:
+        self.assertNotEqual(_add_kernel.kernel_id(), _other_kernel.kernel_id())
+
+    @unittest.skipUnless(_side_table_available(), "kernel side table unavailable")
+    def test_kernel_id_matches_side_table(self) -> None:
+        from helion._compiler._dynamo.higher_order_ops import helion_kernel_side_table
+
+        idx = _add_kernel.kernel_id()
+        self.assertIs(helion_kernel_side_table.get_kernel(idx), _add_kernel)
+
+    def test_kernel_source_hash_stable_and_hex(self) -> None:
+        first = _add_kernel.kernel_source_hash()
+        second = _add_kernel.kernel_source_hash()
+        self.assertEqual(first, second)
+        self.assertEqual(len(first), 64)
+        int(first, 16)  # raises ValueError if not hex
+        self.assertNotEqual(first, _other_kernel.kernel_source_hash())
+
+
+class TestMetadataSchema(TestCase):
+    def test_autotune_metrics_to_dict_has_kernel_fields(self) -> None:
+        record = AutotuneMetrics(
+            kernel_idx=7, kernel_name="k", kernel_source_hash="abc"
+        ).to_dict()
+        self.assertEqual(record["kernel_idx"], 7)
+        self.assertEqual(record["kernel_name"], "k")
+        self.assertEqual(record["kernel_source_hash"], "abc")
+
+    def test_kernel_metadata_to_dict_round_trip(self) -> None:
+        record = KernelMetadata(
+            kernel_idx=3,
+            kernel_name="k",
+            kernel_source_hash="abc",
+            config="helion.Config(...)",
+            input_shapes="[(16,)]",
+            dtypes="['torch.float32']",
+            hardware="TestGPU",
+            path="default",
+        ).to_dict()
+        self.assertEqual(record["kernel_idx"], 3)
+        self.assertEqual(record["path"], "default")
+        # Must be JSON serializable for any downstream sink.
+        json.dumps(record)
+
+
+class TestMetadataHooks(TestCase):
+    def test_kernel_metadata_hook_fires(self) -> None:
+        seen: list[KernelMetadata] = []
+        hook = seen.append
+        register_kernel_metadata_hook(hook)
+        try:
+            from helion.autotuner.metrics import _run_kernel_metadata_hooks
+
+            metadata = KernelMetadata(kernel_idx=1, path="default")
+            _run_kernel_metadata_hooks(metadata)
+        finally:
+            remove_kernel_metadata_hook(hook)
+        self.assertEqual(len(seen), 1)
+        self.assertEqual(seen[0].kernel_idx, 1)
+        # Hook is removed: a second dispatch must not reach it.
+        from helion.autotuner.metrics import _run_kernel_metadata_hooks
+
+        _run_kernel_metadata_hooks(KernelMetadata(kernel_idx=2))
+        self.assertEqual(len(seen), 1)
+
+    def test_post_autotune_hook_fires(self) -> None:
+        seen: list[AutotuneMetrics] = []
+        hook = seen.append
+        register_post_autotune_hook(hook)
+        try:
+            from helion.autotuner.metrics import _run_post_autotune_hooks
+
+            _run_post_autotune_hooks(AutotuneMetrics(kernel_idx=5))
+        finally:
+            remove_post_autotune_hook(hook)
+        self.assertEqual(len(seen), 1)
+        self.assertEqual(seen[0].kernel_idx, 5)
+
+
+class TestEndToEndEmission(TestCase):
+    @skipIfRefEager(
+        "Ref eager mode runs kernels via run_ref(), which bypasses "
+        "set_config()/metadata emission"
+    )
+    def test_set_config_emits_metadata_on_default_path(self) -> None:
+        seen: list[KernelMetadata] = []
+        hook = seen.append
+        register_kernel_metadata_hook(hook)
+        try:
+            x = torch.randn(64, device=DEVICE)
+            y = torch.randn(64, device=DEVICE)
+            result = _add_kernel(x, y)
+            torch.testing.assert_close(result, x + y)
+        finally:
+            remove_kernel_metadata_hook(hook)
+
+        records = [m for m in seen if m.kernel_name == "_add_kernel"]
+        self.assertTrue(records, "expected a KernelMetadata record for _add_kernel")
+        record = records[-1]
+        self.assertEqual(record.path, "default")
+        self.assertIn("64", record.input_shapes)
+        if _side_table_available():
+            self.assertEqual(record.kernel_idx, _add_kernel.kernel_id())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_kernel_metadata.py
+++ b/test/test_kernel_metadata.py
@@ -165,15 +165,21 @@ class TestAutotuneLogSink(TestCase):
 
             # Sidecar holds the kernel identity (stored once).
             sidecar = json.loads(sink.meta_path.read_text(encoding="utf-8"))
+            self.assertEqual(sidecar["kernel_id"], "abc123")
             self.assertEqual(sidecar["kernel_name"], "_add_kernel")
             self.assertIn("def _add_kernel", sidecar["kernel_source"])
 
             # Per-config CSV holds one row per benchmarked config + its result.
             with sink.csv_path.open(encoding="utf-8", newline="") as f:
                 rows = list(csv.reader(f))
-            self.assertEqual(rows[0][:1], ["timestamp_s"])
+            header = rows[0]
+            self.assertEqual(header[0], "kernel_id")
+            self.assertIn("timestamp_s", header)
             data_rows = rows[1:]
             self.assertEqual(len(data_rows), 2)
+            # kernel_id foreign key is stamped on every row, matching the sidecar.
+            kid_col = header.index("kernel_id")
+            self.assertTrue(all(row[kid_col] == "abc123" for row in data_rows))
 
     def test_sink_without_metadata_writes_no_sidecar(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/test/test_kernel_metadata.py
+++ b/test/test_kernel_metadata.py
@@ -51,15 +51,6 @@ def _probe_kernel(x: torch.Tensor) -> torch.Tensor:
     return out
 
 
-# Same source, different code-generation settings -> different kernel_id.
-_probe_static = helion.kernel(
-    _probe_kernel, config=helion.Config(block_sizes=[16]), static_shapes=True
-)
-_probe_dynamic = helion.kernel(
-    _probe_kernel, config=helion.Config(block_sizes=[16]), static_shapes=False
-)
-
-
 class TestKernelIdentity(TestCase):
     def test_kernel_source_stable_and_distinct(self) -> None:
         """
@@ -99,6 +90,13 @@ class TestKernelIdentity(TestCase):
         """
         Identical source under different codegen settings yields different ids.
         """
+        # Same source, different code-generation settings -> different kernel_id.
+        _probe_static = helion.kernel(
+            _probe_kernel, config=helion.Config(block_sizes=[16]), static_shapes=True
+        )
+        _probe_dynamic = helion.kernel(
+            _probe_kernel, config=helion.Config(block_sizes=[16]), static_shapes=False
+        )
         self.assertEqual(_probe_static.kernel_source(), _probe_dynamic.kernel_source())
         self.assertNotEqual(_probe_static.kernel_id(), _probe_dynamic.kernel_id())
 
@@ -189,7 +187,10 @@ class TestMetadataSchema(TestCase):
 class TestAutotuneLogSink(TestCase):
     def _entry(self, perf_ms: float, sample_id: str = "sample-xyz") -> AutotuneLogEntry:
         """
-        Create fake log entry for testing.
+        Build a minimal AutotuneLogEntry for sink tests.
+
+        Only perf_ms and sample_id vary across callers; the remaining fields
+        (generation, status, compile_time, config) are fixed placeholders.
         """
         return AutotuneLogEntry(
             generation=0,
@@ -201,6 +202,12 @@ class TestAutotuneLogSink(TestCase):
         )
 
     def test_sink_writes_metadata_sidecar_and_per_config_rows(self) -> None:
+        """
+        With KernelMetadata, the sink writes both outputs over a run: a JSON
+        sidecar holding the kernel identity once, and a CSV with one row per
+        recorded config. Each CSV row is stamped with the kernel_id foreign key
+        (matching the sidecar) and carries the entry's sample_id.
+        """
         metadata = KernelMetadata(
             kernel_id="abc123",
             kernel_name="_add_kernel",
@@ -239,6 +246,11 @@ class TestAutotuneLogSink(TestCase):
             self.assertTrue(all(row[sid_col] == "sample-xyz" for row in data_rows))
 
     def test_sink_without_metadata_writes_no_sidecar(self) -> None:
+        """
+        When the sink is created without KernelMetadata, a full run (start,
+        record, end) writes no sidecar file, since there is no kernel identity
+        to persist.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             base = f"{tmp}/run"
             with AutotuneLogSink(base) as sink:

--- a/test/test_kernel_metadata.py
+++ b/test/test_kernel_metadata.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+import hashlib
 import json
 import tempfile
 import unittest
@@ -18,6 +19,9 @@ import helion.language as hl
 
 @helion.kernel(config=helion.Config(block_sizes=[16]))
 def _add_kernel(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    """
+    A kernel that adds two tensors.
+    """
     out = torch.empty_like(x)
     for tile in hl.tile(x.size(0)):
         out[tile] = x[tile] + y[tile]
@@ -26,67 +30,104 @@ def _add_kernel(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
 @helion.kernel(config=helion.Config(block_sizes=[16]))
 def _other_kernel(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    """
+    A kernel that multiplies two tensors.
+    """
     out = torch.empty_like(x)
     for tile in hl.tile(x.size(0)):
         out[tile] = x[tile] * y[tile]
     return out
 
 
-def _side_table_available() -> bool:
-    try:
-        from helion._compiler._dynamo.higher_order_ops import helion_kernel_side_table
-    except Exception:
-        return False
-    return helion_kernel_side_table is not None
+def _probe_kernel(x: torch.Tensor) -> torch.Tensor:
+    """
+    A bare kernel function used to build kernels with identical source but
+    different settings.
+    """
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size(0)):
+        out[tile] = x[tile] + 1
+    return out
+
+
+# Same source, different code-generation settings -> different kernel_id.
+_probe_static = helion.kernel(
+    _probe_kernel, config=helion.Config(block_sizes=[16]), static_shapes=True
+)
+_probe_dynamic = helion.kernel(
+    _probe_kernel, config=helion.Config(block_sizes=[16]), static_shapes=False
+)
 
 
 class TestKernelIdentity(TestCase):
     def test_kernel_source_stable_and_distinct(self) -> None:
+        """
+        Check if the kernel source is stable and distinct between kernels.
+        """
         first = _add_kernel.kernel_source()
         second = _add_kernel.kernel_source()
         self.assertEqual(first, second)
         self.assertIn("def _add_kernel", first)
         self.assertNotEqual(first, _other_kernel.kernel_source())
 
-    @unittest.skipUnless(_side_table_available(), "kernel side table unavailable")
-    def test_kernel_id_idempotent(self) -> None:
+    def test_kernel_id_is_stable_hex_hash(self) -> None:
+        """
+        kernel_id is a stable 64-character sha256 hex digest.
+        """
         first = _add_kernel.kernel_id()
         second = _add_kernel.kernel_id()
         self.assertEqual(first, second)
-        self.assertGreaterEqual(first, 0)
+        self.assertEqual(len(first), 64)
+        int(first, 16)  # raises ValueError if not valid hex
 
-    @unittest.skipUnless(_side_table_available(), "kernel side table unavailable")
     def test_kernel_id_distinct_between_kernels(self) -> None:
+        """
+        Different kernel source yields a different kernel_id.
+        """
         self.assertNotEqual(_add_kernel.kernel_id(), _other_kernel.kernel_id())
 
-    @unittest.skipUnless(_side_table_available(), "kernel side table unavailable")
-    def test_kernel_id_matches_side_table(self) -> None:
-        from helion._compiler._dynamo.higher_order_ops import helion_kernel_side_table
+    def test_kernel_id_matches_manual_hash(self) -> None:
+        """
+        kernel_id equals sha256(source + settings signature).
+        """
+        payload = _add_kernel.kernel_source() + _add_kernel._settings_signature()
+        expected = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+        self.assertEqual(_add_kernel.kernel_id(), expected)
 
-        idx = _add_kernel.kernel_id()
-        self.assertIs(helion_kernel_side_table.get_kernel(idx), _add_kernel)
+    def test_kernel_id_changes_with_settings(self) -> None:
+        """
+        Identical source under different codegen settings yields different ids.
+        """
+        self.assertEqual(_probe_static.kernel_source(), _probe_dynamic.kernel_source())
+        self.assertNotEqual(_probe_static.kernel_id(), _probe_dynamic.kernel_id())
 
 
 class TestMetadataSchema(TestCase):
     def test_autotune_metrics_to_dict_has_kernel_fields(self) -> None:
+        """
+        Check if the AutotuneMetrics.to_dict() method includes the kernel fields.
+        """
         record = AutotuneMetrics(
-            kernel_idx=7, kernel_name="k", kernel_source="def k(): ..."
+            kernel_id="abc123", kernel_name="k", kernel_source="def k(): ..."
         ).to_dict()
-        self.assertEqual(record["kernel_idx"], 7)
+        self.assertEqual(record["kernel_id"], "abc123")
         self.assertEqual(record["kernel_name"], "k")
         self.assertEqual(record["kernel_source"], "def k(): ...")
         json.dumps(record)
 
     def test_kernel_metadata_to_dict_round_trip(self) -> None:
+        """
+        Check if the KernelMetadata.to_dict() is JSON serializable.
+        """
         record = KernelMetadata(
-            kernel_idx=3,
+            kernel_id="abc123",
             kernel_name="k",
             kernel_source="def k(): ...",
             input_shapes="[(16,)]",
             dtypes="['torch.float32']",
             hardware="TestGPU",
         ).to_dict()
-        self.assertEqual(record["kernel_idx"], 3)
+        self.assertEqual(record["kernel_id"], "abc123")
         self.assertEqual(record["kernel_source"], "def k(): ...")
         # Must be JSON serializable for the sidecar file.
         json.dumps(record)
@@ -94,6 +135,9 @@ class TestMetadataSchema(TestCase):
 
 class TestAutotuneLogSink(TestCase):
     def _entry(self, perf_ms: float) -> AutotuneLogEntry:
+        """
+        Create fake log entry for testing.
+        """
         return AutotuneLogEntry(
             generation=0,
             status="ok",
@@ -104,7 +148,7 @@ class TestAutotuneLogSink(TestCase):
 
     def test_sink_writes_metadata_sidecar_and_per_config_rows(self) -> None:
         metadata = KernelMetadata(
-            kernel_idx=1,
+            kernel_id="abc123",
             kernel_name="_add_kernel",
             kernel_source=_add_kernel.kernel_source(),
             input_shapes="[(64,)]",

--- a/test/test_kernel_metadata.py
+++ b/test/test_kernel_metadata.py
@@ -4,6 +4,7 @@ import csv
 import hashlib
 import json
 import tempfile
+import types
 import unittest
 
 import torch
@@ -101,6 +102,35 @@ class TestKernelIdentity(TestCase):
         self.assertEqual(_probe_static.kernel_source(), _probe_dynamic.kernel_source())
         self.assertNotEqual(_probe_static.kernel_id(), _probe_dynamic.kernel_id())
 
+    def test_kernel_id_independent_of_config(self) -> None:
+        """
+        kernel_id must NOT depend on the (autotunable) config: the same source
+        and settings under different configs share one id, so it stays constant
+        across the configs benchmarked in a run and can group their rows.
+        """
+        k16 = helion.kernel(_probe_kernel, config=helion.Config(block_sizes=[16]))
+        k32 = helion.kernel(_probe_kernel, config=helion.Config(block_sizes=[32]))
+        self.assertEqual(k16.kernel_id(), k32.kernel_id())
+
+    def test_dynamic_source_raises_oserror(self) -> None:
+        """
+        kernel_source/kernel_id raise OSError (and nothing broader) when the
+        source cannot be located, e.g. a function defined dynamically. This is
+        the contract the narrowed ``except OSError`` in the autotuner relies on.
+        """
+        namespace: dict[str, object] = {}
+        exec(
+            compile("def _dynamic(x, y):\n    return x\n", "<dynamic>", "exec"),
+            namespace,
+        )
+        fn = namespace["_dynamic"]
+        assert isinstance(fn, types.FunctionType)
+        dynamic = helion.kernel(fn, config=helion.Config(block_sizes=[16]))
+        with self.assertRaises(OSError):
+            dynamic.kernel_source()
+        with self.assertRaises(OSError):
+            dynamic.kernel_id()
+
 
 class TestMetadataSchema(TestCase):
     def test_autotune_metrics_to_dict_has_kernel_fields(self) -> None:
@@ -131,6 +161,29 @@ class TestMetadataSchema(TestCase):
         self.assertEqual(record["kernel_source"], "def k(): ...")
         # Must be JSON serializable for the sidecar file.
         json.dumps(record)
+
+    def test_default_metadata_has_empty_identity(self) -> None:
+        """
+        Default KernelMetadata carries an empty identity and still serializes,
+        so a sidecar can be written even when the kernel is unidentifiable.
+        """
+        record = KernelMetadata().to_dict()
+        self.assertEqual(record["kernel_id"], "")
+        self.assertEqual(record["kernel_source"], "")
+        json.dumps(record)
+
+    def test_log_entry_defaults_to_empty_sample_id(self) -> None:
+        """
+        sample_id is optional on AutotuneLogEntry and defaults to empty.
+        """
+        entry = AutotuneLogEntry(
+            generation=0,
+            status="ok",
+            perf_ms=1.0,
+            compile_time=0.1,
+            config=helion.Config(block_sizes=[16]),
+        )
+        self.assertEqual(entry.sample_id, "")
 
 
 class TestAutotuneLogSink(TestCase):
@@ -193,6 +246,35 @@ class TestAutotuneLogSink(TestCase):
                 sink.record(self._entry(0.1))
                 sink.end_run()
             self.assertFalse(sink.meta_path.exists())
+
+    def test_sink_without_metadata_rows_have_empty_kernel_id(self) -> None:
+        """
+        Without metadata the CSV still has the kernel_id column, but the
+        foreign key is empty on every row (no kernel identity to attach).
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            base = f"{tmp}/run"
+            with AutotuneLogSink(base) as sink:
+                sink.start_run()
+                sink.record(self._entry(0.1))
+                sink.end_run()
+            with sink.csv_path.open(encoding="utf-8", newline="") as f:
+                rows = list(csv.reader(f))
+            header = rows[0]
+            self.assertEqual(header[0], "kernel_id")
+            kid_col = header.index("kernel_id")
+            self.assertTrue(all(row[kid_col] == "" for row in rows[1:]))
+
+    def test_record_before_open_is_noop(self) -> None:
+        """
+        Recording on a sink that was never opened writes nothing and does not
+        create the CSV file (guards against lifecycle ordering bugs).
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            base = f"{tmp}/run"
+            sink = AutotuneLogSink(base)  # not opened
+            sink.record(self._entry(0.1))
+            self.assertFalse(sink.csv_path.exists())
 
 
 if __name__ == "__main__":

--- a/test/test_kernel_metadata.py
+++ b/test/test_kernel_metadata.py
@@ -1,20 +1,18 @@
 from __future__ import annotations
 
+import csv
 import json
+import tempfile
 import unittest
 
 import torch
 
 import helion
-from helion._testing import DEVICE
 from helion._testing import TestCase
-from helion._testing import skipIfRefEager
+from helion.autotuner.logger import AutotuneLogEntry
+from helion.autotuner.logger import AutotuneLogSink
 from helion.autotuner.metrics import AutotuneMetrics
 from helion.autotuner.metrics import KernelMetadata
-from helion.autotuner.metrics import register_kernel_metadata_hook
-from helion.autotuner.metrics import register_post_autotune_hook
-from helion.autotuner.metrics import remove_kernel_metadata_hook
-from helion.autotuner.metrics import remove_post_autotune_hook
 import helion.language as hl
 
 
@@ -42,7 +40,14 @@ def _side_table_available() -> bool:
     return helion_kernel_side_table is not None
 
 
-class TestKernelId(TestCase):
+class TestKernelIdentity(TestCase):
+    def test_kernel_source_stable_and_distinct(self) -> None:
+        first = _add_kernel.kernel_source()
+        second = _add_kernel.kernel_source()
+        self.assertEqual(first, second)
+        self.assertIn("def _add_kernel", first)
+        self.assertNotEqual(first, _other_kernel.kernel_source())
+
     @unittest.skipUnless(_side_table_available(), "kernel side table unavailable")
     def test_kernel_id_idempotent(self) -> None:
         first = _add_kernel.kernel_id()
@@ -61,99 +66,79 @@ class TestKernelId(TestCase):
         idx = _add_kernel.kernel_id()
         self.assertIs(helion_kernel_side_table.get_kernel(idx), _add_kernel)
 
-    def test_kernel_source_hash_stable_and_hex(self) -> None:
-        first = _add_kernel.kernel_source_hash()
-        second = _add_kernel.kernel_source_hash()
-        self.assertEqual(first, second)
-        self.assertEqual(len(first), 64)
-        int(first, 16)  # raises ValueError if not hex
-        self.assertNotEqual(first, _other_kernel.kernel_source_hash())
-
 
 class TestMetadataSchema(TestCase):
     def test_autotune_metrics_to_dict_has_kernel_fields(self) -> None:
         record = AutotuneMetrics(
-            kernel_idx=7, kernel_name="k", kernel_source_hash="abc"
+            kernel_idx=7, kernel_name="k", kernel_source="def k(): ..."
         ).to_dict()
         self.assertEqual(record["kernel_idx"], 7)
         self.assertEqual(record["kernel_name"], "k")
-        self.assertEqual(record["kernel_source_hash"], "abc")
+        self.assertEqual(record["kernel_source"], "def k(): ...")
+        json.dumps(record)
 
     def test_kernel_metadata_to_dict_round_trip(self) -> None:
         record = KernelMetadata(
             kernel_idx=3,
             kernel_name="k",
-            kernel_source_hash="abc",
-            config="helion.Config(...)",
+            kernel_source="def k(): ...",
             input_shapes="[(16,)]",
             dtypes="['torch.float32']",
             hardware="TestGPU",
-            path="default",
         ).to_dict()
         self.assertEqual(record["kernel_idx"], 3)
-        self.assertEqual(record["path"], "default")
-        # Must be JSON serializable for any downstream sink.
+        self.assertEqual(record["kernel_source"], "def k(): ...")
+        # Must be JSON serializable for the sidecar file.
         json.dumps(record)
 
 
-class TestMetadataHooks(TestCase):
-    def test_kernel_metadata_hook_fires(self) -> None:
-        seen: list[KernelMetadata] = []
-        hook = seen.append
-        register_kernel_metadata_hook(hook)
-        try:
-            from helion.autotuner.metrics import _run_kernel_metadata_hooks
+class TestAutotuneLogSink(TestCase):
+    def _entry(self, perf_ms: float) -> AutotuneLogEntry:
+        return AutotuneLogEntry(
+            generation=0,
+            status="ok",
+            perf_ms=perf_ms,
+            compile_time=0.5,
+            config=helion.Config(block_sizes=[16]),
+        )
 
-            metadata = KernelMetadata(kernel_idx=1, path="default")
-            _run_kernel_metadata_hooks(metadata)
-        finally:
-            remove_kernel_metadata_hook(hook)
-        self.assertEqual(len(seen), 1)
-        self.assertEqual(seen[0].kernel_idx, 1)
-        # Hook is removed: a second dispatch must not reach it.
-        from helion.autotuner.metrics import _run_kernel_metadata_hooks
+    def test_sink_writes_metadata_sidecar_and_per_config_rows(self) -> None:
+        metadata = KernelMetadata(
+            kernel_idx=1,
+            kernel_name="_add_kernel",
+            kernel_source=_add_kernel.kernel_source(),
+            input_shapes="[(64,)]",
+            dtypes="['torch.float32']",
+            hardware="TestGPU",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            base = f"{tmp}/run"
+            with AutotuneLogSink(base, metadata) as sink:
+                sink.start_run()
+                sink.record(self._entry(0.1))
+                sink.record(self._entry(0.2))
+                sink.end_run()
 
-        _run_kernel_metadata_hooks(KernelMetadata(kernel_idx=2))
-        self.assertEqual(len(seen), 1)
+            # Sidecar holds the kernel identity (stored once).
+            sidecar = json.loads(sink.meta_path.read_text(encoding="utf-8"))
+            self.assertEqual(sidecar["kernel_name"], "_add_kernel")
+            self.assertIn("def _add_kernel", sidecar["kernel_source"])
 
-    def test_post_autotune_hook_fires(self) -> None:
-        seen: list[AutotuneMetrics] = []
-        hook = seen.append
-        register_post_autotune_hook(hook)
-        try:
-            from helion.autotuner.metrics import _run_post_autotune_hooks
+            # Per-config CSV holds one row per benchmarked config + its result.
+            with sink.csv_path.open(encoding="utf-8", newline="") as f:
+                rows = list(csv.reader(f))
+            self.assertEqual(rows[0][:1], ["timestamp_s"])
+            data_rows = rows[1:]
+            self.assertEqual(len(data_rows), 2)
 
-            _run_post_autotune_hooks(AutotuneMetrics(kernel_idx=5))
-        finally:
-            remove_post_autotune_hook(hook)
-        self.assertEqual(len(seen), 1)
-        self.assertEqual(seen[0].kernel_idx, 5)
-
-
-class TestEndToEndEmission(TestCase):
-    @skipIfRefEager(
-        "Ref eager mode runs kernels via run_ref(), which bypasses "
-        "set_config()/metadata emission"
-    )
-    def test_set_config_emits_metadata_on_default_path(self) -> None:
-        seen: list[KernelMetadata] = []
-        hook = seen.append
-        register_kernel_metadata_hook(hook)
-        try:
-            x = torch.randn(64, device=DEVICE)
-            y = torch.randn(64, device=DEVICE)
-            result = _add_kernel(x, y)
-            torch.testing.assert_close(result, x + y)
-        finally:
-            remove_kernel_metadata_hook(hook)
-
-        records = [m for m in seen if m.kernel_name == "_add_kernel"]
-        self.assertTrue(records, "expected a KernelMetadata record for _add_kernel")
-        record = records[-1]
-        self.assertEqual(record.path, "default")
-        self.assertIn("64", record.input_shapes)
-        if _side_table_available():
-            self.assertEqual(record.kernel_idx, _add_kernel.kernel_id())
+    def test_sink_without_metadata_writes_no_sidecar(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = f"{tmp}/run"
+            with AutotuneLogSink(base) as sink:
+                sink.start_run()
+                sink.record(self._entry(0.1))
+                sink.end_run()
+            self.assertFalse(sink.meta_path.exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Objective:** Adds a stable way to identify a Helion kernel in autotuning telemetry, so per-config autotune results can be grouped by kernel across runs. This is a building block for the data collection behind the upcoming LLM-based autotuner.

When autotune_log (HELION_AUTOTUNE_LOG) is set, the kernel identity is written once per autotuning run to a <autotune_log>.meta.json sidecar next to the existing per-config .csv/.log outputs. The CSV records each config and its result; the sidecar provides the stable identity needed to group those rows by kernel. No new behavior or overhead when autotune_log is unset.

**NOTE:** Modifies the current CSV schema