### PR TITLE
[Autotuner] Run accuracy check in benchmark worker subprocess

### DIFF
--- a/helion/autotuner/accuracy.py
+++ b/helion/autotuner/accuracy.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import torch
+from torch.utils._pytree import tree_flatten
+from torch.utils._pytree import tree_map_only
+
+_FP8_DTYPES = {
+    torch.float8_e4m3fn,
+    torch.float8_e5m2,
+    torch.float8_e4m3fnuz,
+    torch.float8_e5m2fnuz,
+    torch.float8_e8m0fnu,
+}
+
+
+def _assert_close(actual: object, expected: object, atol: float, rtol: float) -> None:
+    """Like torch.testing.assert_close but handles fp8 and uses chunked comparison for large tensors."""
+
+    def convert(t: torch.Tensor) -> torch.Tensor:
+        return t.view(torch.uint8) if t.dtype in _FP8_DTYPES else t
+
+    actual_flat, actual_spec = tree_flatten(
+        tree_map_only(torch.Tensor, convert, actual)
+    )
+    expected_flat, expected_spec = tree_flatten(
+        tree_map_only(torch.Tensor, convert, expected)
+    )
+
+    if actual_spec != expected_spec:
+        raise AssertionError(
+            f"Output tree structure mismatch during autotuner accuracy check:\n"
+            f"  actual:   {actual_spec} ({len(actual_flat)} leaves)\n"
+            f"  expected: {expected_spec} ({len(expected_flat)} leaves)"
+        )
+
+    for a, e in zip(actual_flat, expected_flat, strict=True):
+        if isinstance(a, torch.Tensor):
+            _chunked_assert_close(a, e, atol=atol, rtol=rtol)
+        elif isinstance(a, str):
+            if not isinstance(e, str):
+                raise AssertionError(f"Type mismatch {a} vs {e}")
+            if a != e:
+                raise AssertionError(f"string mismatch {a} vs {e}")
+        else:
+            torch.testing.assert_close(a, e, atol=atol, rtol=rtol)
+
+
+def _chunked_assert_close(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    atol: float,
+    rtol: float,
+    chunk_size: int = 2**22,  # ~4M elements per chunk
+) -> None:
+    """Memory-efficient assert_close for large tensors.
+
+    Processes the comparison in chunks to avoid allocating multiple
+    full-size temporary tensors.  Uses torch.testing.assert_close on
+    each chunk so error messages retain full detail.
+    """
+    if actual.numel() <= chunk_size:
+        torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+        return
+    a_flat = actual.reshape(-1)
+    e_flat = expected.reshape(-1)
+    for i in range(0, a_flat.numel(), chunk_size):
+        a_chunk = a_flat[i : i + chunk_size]
+        e_chunk = e_flat[i : i + chunk_size]
+        torch.testing.assert_close(a_chunk, e_chunk, atol=atol, rtol=rtol)

--- a/helion/autotuner/accuracy_job.py
+++ b/helion/autotuner/accuracy_job.py
@@ -1,0 +1,49 @@
+"""Picklable accuracy-check job executed inside a ``BenchmarkWorker``."""
+
+from __future__ import annotations
+
+import dataclasses
+import functools
+from typing import TYPE_CHECKING
+
+import torch
+
+from .accuracy import _assert_close
+from .benchmarking import synchronize_device
+from .kernel_args import load_trusted_kernel_args
+from .logger import capture_output
+from .precompile_future import _load_compiled_fn
+
+if TYPE_CHECKING:
+    from .precompile_future import SerializedCompiledFunction
+
+
+@functools.cache
+def _load_baseline(path: str) -> object:
+    # Cached like load_trusted_kernel_args: every config in one autotune run
+    # compares against the same baseline, so the worker reads it off disk once.
+    return torch.load(path, weights_only=False)
+
+
+@dataclasses.dataclass
+class AccuracyCheckJob:
+    fn_spec: SerializedCompiledFunction
+    args_path: str
+    baseline_path: str
+    atol: float
+    rtol: float
+
+    def __call__(self) -> bool:
+        # Subprocess inherits parent stderr; capture so Triton runtime
+        # diagnostics don't leak to the user's terminal.
+        with capture_output():
+            fn = _load_compiled_fn(self.fn_spec)
+            args = load_trusted_kernel_args(self.args_path)
+            baseline_output = _load_baseline(self.baseline_path)
+            output = fn(*args)
+            synchronize_device(output)
+            try:
+                _assert_close(output, baseline_output, atol=self.atol, rtol=self.rtol)
+            except AssertionError:
+                return False
+            return True

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -27,6 +27,9 @@ from .. import exc
 from ..runtime.precompile_shim import already_compiled
 from ..runtime.precompile_shim import already_compiled_fail
 from ..runtime.precompile_shim import make_precompiler
+from .accuracy import _FP8_DTYPES
+from .accuracy import _assert_close
+from .accuracy_job import AccuracyCheckJob
 from .benchmark_job import BenchmarkJob
 from .benchmark_worker import BenchmarkSubprocessError
 from .benchmark_worker import BenchmarkWorker
@@ -65,71 +68,6 @@ if TYPE_CHECKING:
     from .base_search import _AutotunableKernel
     from .logger import AutotuningLogger
     from .metrics import AutotuneMetrics
-
-
-_FP8_DTYPES = {
-    torch.float8_e4m3fn,
-    torch.float8_e5m2,
-    torch.float8_e4m3fnuz,
-    torch.float8_e5m2fnuz,
-    torch.float8_e8m0fnu,
-}
-
-
-def _assert_close(actual: object, expected: object, atol: float, rtol: float) -> None:
-    """Like torch.testing.assert_close but handles fp8 and uses chunked comparison for large tensors."""
-
-    def convert(t: torch.Tensor) -> torch.Tensor:
-        return t.view(torch.uint8) if t.dtype in _FP8_DTYPES else t
-
-    actual_flat, actual_spec = tree_flatten(
-        tree_map_only(torch.Tensor, convert, actual)
-    )
-    expected_flat, expected_spec = tree_flatten(
-        tree_map_only(torch.Tensor, convert, expected)
-    )
-
-    if actual_spec != expected_spec:
-        raise AssertionError(
-            f"Output tree structure mismatch during autotuner accuracy check:\n"
-            f"  actual:   {actual_spec} ({len(actual_flat)} leaves)\n"
-            f"  expected: {expected_spec} ({len(expected_flat)} leaves)"
-        )
-
-    for a, e in zip(actual_flat, expected_flat, strict=True):
-        if isinstance(a, torch.Tensor):
-            _chunked_assert_close(a, e, atol=atol, rtol=rtol)
-        elif isinstance(a, str):
-            if not isinstance(e, str):
-                raise AssertionError(f"Type mismatch {a} vs {e}")
-            if a != e:
-                raise AssertionError(f"string mismatch {a} vs {e}")
-        else:
-            torch.testing.assert_close(a, e, atol=atol, rtol=rtol)
-
-
-def _chunked_assert_close(
-    actual: torch.Tensor,
-    expected: torch.Tensor,
-    atol: float,
-    rtol: float,
-    chunk_size: int = 2**22,  # ~4M elements per chunk
-) -> None:
-    """Memory-efficient assert_close for large tensors.
-
-    Processes the comparison in chunks to avoid allocating multiple
-    full-size temporary tensors.  Uses torch.testing.assert_close on
-    each chunk so error messages retain full detail.
-    """
-    if actual.numel() <= chunk_size:
-        torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
-        return
-    a_flat = actual.reshape(-1)
-    e_flat = expected.reshape(-1)
-    for i in range(0, a_flat.numel(), chunk_size):
-        a_chunk = a_flat[i : i + chunk_size]
-        e_chunk = e_flat[i : i + chunk_size]
-        torch.testing.assert_close(a_chunk, e_chunk, atol=atol, rtol=rtol)
 
 
 def _clone_args(
@@ -373,6 +311,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         self._autotune_metrics = autotune_metrics
         self._precompile_tmpdir: tempfile.TemporaryDirectory[str] | None = None
         self._precompile_args_path: str | None = None
+        self._precompile_baseline_path: str | None = None
         self._precompile_result_counter: count[int] = count()
         self._benchmark_worker: BenchmarkWorker | None = None
         # budget_exceeded_fn inherits the class-level _never_exceeded default
@@ -589,6 +528,21 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             args_path = os.path.join(self._precompile_tmpdir.name, "args.pt")
             torch.save(self.args, args_path)
             self._precompile_args_path = args_path
+            # Only the worker accuracy job reads the baseline, so skip writing it
+            # unless that job will run: subprocess benchmarking on, the check on,
+            # and no custom fn forcing the in-process path.
+            if (
+                self._subprocess_benchmark_enabled()
+                and self.settings.autotune_accuracy_check
+                and self.settings.autotune_baseline_accuracy_check_fn is None
+            ):
+                baseline_path = os.path.join(
+                    self._precompile_tmpdir.name, "baseline.pt"
+                )
+                torch.save(self._baseline_output, baseline_path)
+                self._precompile_baseline_path = baseline_path
+            else:
+                self._precompile_baseline_path = None
 
     def _next_precompile_result_path(self) -> str:
         """Return a fresh path for a precompile result file."""
@@ -617,6 +571,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             self._precompile_tmpdir.cleanup()
             self._precompile_tmpdir = None
         self._precompile_args_path = None
+        self._precompile_baseline_path = None
         self._precompile_result_counter = count()
         # Drop the baseline tensors (GPU memory) so refcount frees them
         # the moment the provider loses its last external reference.
@@ -1119,19 +1074,71 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             self._autotune_metrics.num_compile_failures += 1
             return inf
 
-        # Kernel is known-safe; accuracy check launches in-process without hang risk.
+        # Run the accuracy check in the worker too: a config can pass timing and
+        # still crash here, and a crash must not poison the parent CUDA context.
         if self.settings.autotune_accuracy_check:
             try:
-                output = fn(*self.args)
-                synchronize_device(output)
-                if not self._validate_against_baseline(config, output, self.args):
-                    self._autotune_metrics.num_accuracy_failures += 1
-                    return inf
-            except Exception as e:
-                self.log.debug(
-                    f"Accuracy check raised for {config!r}: {type(e).__name__}: {e}"
+                passed = self._run_subprocess_accuracy_job(fn)
+            except BenchmarkSubprocessError as e:
+                # Timeout or unexpected worker exit; skip config and continue.
+                self.log.warning(
+                    f"Accuracy check subprocess failed for {config!r}: {e}"
                 )
                 self._autotune_metrics.num_compile_failures += 1
+                return inf
+            except Exception as e:
+                e.__traceback__ = None
+                if match_unrecoverable_runtime_error(e):
+                    # Worker is already killed; parent CUDA is unaffected.
+                    # Skip this config and continue the search.
+                    decorator = self.kernel.format_kernel_decorator(
+                        config, self.settings
+                    )
+                    self.log.warning(
+                        f"Skipping config that triggered an unrecoverable runtime "
+                        f"error in the accuracy check subprocess: "
+                        f"{type(e).__qualname__}: {e}\n  Config: {decorator}"
+                    )
+                    self.kernel.maybe_log_repro(self.log.warning, self.args, config)
+                    self._autotune_metrics.num_compile_failures += 1
+                    return inf
+                self.log.debug(
+                    f"Accuracy check subprocess raised for {config!r}: "
+                    f"{type(e).__name__}: {e}"
+                )
+                self._autotune_metrics.num_compile_failures += 1
+                return inf
+            # None means a custom check fn can't run in the worker; validate
+            # in-process instead.
+            if passed is None:
+                try:
+                    output = fn(*self.args)
+                    synchronize_device(output)
+                    passed = self._validate_against_baseline(config, output, self.args)
+                except Exception as e:
+                    e.__traceback__ = None
+                    if match_unrecoverable_runtime_error(e):
+                        # This ran in the parent process, so the IMA poisoned
+                        # the parent CUDA context; the search cannot continue.
+                        self.kernel.maybe_log_repro(self.log.error, self.args, config)
+                        raise exc.TritonUnrecoverableRuntimeError(
+                            reason=str(e),
+                            decorator=self.kernel.format_kernel_decorator(
+                                config, self.settings
+                            ),
+                            error=f"{type(e).__qualname__}: {e}",
+                        ) from e
+                    self.log.debug(
+                        f"Accuracy check raised for {config!r}: {type(e).__name__}: {e}"
+                    )
+                    self._autotune_metrics.num_compile_failures += 1
+                    return inf
+                finally:
+                    # Same as the in-process path: drop JIT fast-path caches so
+                    # this fn's tensors aren't pinned in GPU memory across configs.
+                    self._clear_jit_fast_path_caches(fn)
+            if not passed:
+                self._autotune_metrics.num_accuracy_failures += 1
                 return inf
 
         return float(latency)
@@ -1161,6 +1168,42 @@ class LocalBenchmarkProvider(BenchmarkProvider):
             use_wall_clock=self._subprocess_benchmark_uses_wall_clock(),
         )
         return float(
+            self._benchmark_worker.run(
+                job,
+                timeout=float(self.settings.autotune_benchmark_timeout),
+            )
+        )
+
+    def _run_subprocess_accuracy_job(self, fn: CompiledConfig) -> bool | None:
+        """Validate ``fn`` against the baseline inside the benchmark worker.
+
+        Returns whether the output matched, or ``None`` when a custom check fn
+        can't run in the worker and the caller should validate in-process.
+        """
+        if (
+            self._precompile_args_path is None
+            or self._precompile_baseline_path is None
+            or self.settings.autotune_baseline_accuracy_check_fn is not None
+        ):
+            return None
+        try:
+            fn_spec = _serialize_compiled_fn(fn)
+        except RuntimeError:
+            return None
+
+        if self._benchmark_worker is None:
+            self._benchmark_worker = BenchmarkWorker(device=None)
+
+        # Only checks the output; mutated-arg kernels disable the subprocess
+        # path (see _subprocess_benchmark_enabled), so they never reach here.
+        job = AccuracyCheckJob(
+            fn_spec=fn_spec,
+            args_path=self._precompile_args_path,
+            baseline_path=self._precompile_baseline_path,
+            atol=self._effective_atol,
+            rtol=self._effective_rtol,
+        )
+        return bool(
             self._benchmark_worker.run(
                 job,
                 timeout=float(self.settings.autotune_benchmark_timeout),

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -2464,7 +2464,13 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         config1 = helion.Config(block_sizes=[128], num_warps=4)
         config2 = helion.Config(block_sizes=[256], num_warps=4)
 
-        @helion.kernel(configs=[config1, config2], autotune_log_level=0)
+        # Pin the accuracy check to the parent so the patched _assert_close
+        # below is observed; the default subprocess path runs it in the worker.
+        @helion.kernel(
+            configs=[config1, config2],
+            autotune_log_level=0,
+            autotune_benchmark_subprocess=False,
+        )
         def vec_add(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
             out = torch.empty_like(a)
             for tile in hl.tile(a.size()):

--- a/test/test_benchmark_worker.py
+++ b/test/test_benchmark_worker.py
@@ -390,6 +390,60 @@ class TestSubprocessBenchmarkIntegration(RefEagerTestDisabled, unittest.TestCase
         self.assertGreaterEqual(call_count[0], 6)
         self.assertGreaterEqual(call_count[1], 2)
 
+    @skipIfXPU("matmul config space includes maxnreg, unsupported on XPU")
+    def test_autotune_continues_when_accuracy_check_crashes(self) -> None:
+        # A config can pass the timed run and then crash in the accuracy
+        # check. Patches the accuracy job to raise a sticky CUDA error for a
+        # fraction of configs; the worker dies and respawns, and autotune must
+        # still pick a best config from the rest instead of aborting.
+        if not torch.cuda.is_available():
+            self.skipTest("requires CUDA")
+
+        original = LocalBenchmarkProvider._run_subprocess_accuracy_job
+        call_count = [0, 0]  # [total, simulated_crashes]
+
+        def maybe_crash(
+            self: LocalBenchmarkProvider,
+            fn: CompiledConfig,
+        ) -> bool | None:
+            call_count[0] += 1
+            if call_count[0] % 3 == 0:
+                call_count[1] += 1
+                if self._benchmark_worker is None:
+                    self._benchmark_worker = BenchmarkWorker(device=None)
+                # Run a job that raises a sticky error inside the worker, so the
+                # worker is killed and a sticky error propagates from the
+                # accuracy step, as a real accuracy-check crash would.
+                self._benchmark_worker.run(
+                    _RaiseRuntimeError("an illegal memory access was encountered"),
+                    timeout=float(self.settings.autotune_benchmark_timeout),
+                )
+            return original(self, fn)
+
+        examples_dir = Path(__file__).parent.parent / "examples"
+        matmul = import_path(examples_dir / "matmul.py").matmul
+
+        args = (
+            torch.randn([512, 512], device=DEVICE),
+            torch.randn([512, 512], device=DEVICE),
+        )
+        bound_kernel = matmul.bind(args)
+        bound_kernel.settings.autotune_benchmark_subprocess = True
+        bound_kernel.settings.autotune_benchmark_timeout = 60
+        bound_kernel.settings.autotune_precompile = None
+
+        random.seed(123)
+        with patch.object(
+            LocalBenchmarkProvider,
+            "_run_subprocess_accuracy_job",
+            maybe_crash,
+        ):
+            best = RandomSearch(bound_kernel, args, 20).autotune()
+
+        self.assertIsNotNone(best)
+        self.assertGreaterEqual(call_count[0], 6)
+        self.assertGreaterEqual(call_count[1], 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
[Autotuner] Run accuracy check in benchmark worker subprocess

Multiple tl.dot in one kernel can probabilistically throw an illegal
memory access on H100 (triton-lang/triton#10486). A config can pass the
timed benchmark and then crash during the accuracy check, and when that
check runs in-process the IMA poisons the parent CUDA context and aborts
the entire autotune run.

Move the accuracy check into the benchmark worker subprocess: an IMA now
kills the worker (which respawns) instead of the parent, so the search
skips the bad config and continues. Configs with a custom baseline check
fn, or whose compiled fn can't be serialized, fall back to the existing
in-process path.

Extract _assert_close, _chunked_assert_close, and _FP8_DTYPES into a new
accuracy.py. The picklable AccuracyCheckJob runs in the worker and needs
these helpers, but importing them from benchmark_provider would create a
cycle (benchmark_provider imports accuracy_job); a small leaf module
breaks it.

Add a test that autotune still picks a best config when the accuracy
check crashes for a fraction of configs.