### PR TITLE
[ Pallas] Slice outer-pipeline tiles in nested emit_pipeline BlockSpecs

### DIFF
--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -1512,7 +1512,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                     block_shape_parts.append(str(int(shape[dim_idx])))
                 lambda_parts.append(pid_var)
             elif bid is not None and state.codegen.active_device_loops.get(bid):
-                # Outer pipeline dim -- slice to that tile's block via its offset
+                # Outer pipeline dim: slice to that tile's block via its offset
                 bs_var = state.device_function.block_size_var(bid)
                 offset_v = state.codegen.offset_var(bid)
                 assert bs_var is not None  # a pipelined tile always has a block size

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -1511,6 +1511,16 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                 else:
                     block_shape_parts.append(str(int(shape[dim_idx])))
                 lambda_parts.append(pid_var)
+            elif bid is not None and state.codegen.active_device_loops.get(bid):
+                # Outer pipeline dim -- slice to that tile's block via its offset
+                bs_var = state.device_function.block_size_var(bid)
+                offset_v = state.codegen.offset_var(bid)
+                assert bs_var is not None  # a pipelined tile always has a block size
+                from .memory_ops import _record_pad_info
+
+                block_shape_parts.append(bs_var)
+                lambda_parts.append(f"({offset_v}) // ({bs_var})")
+                _record_pad_info(state, fake, dim_idx, bid, 0)
             else:
                 idx_meta = (
                     subscript_meta[dim_idx]

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -587,6 +587,39 @@ class TestPallas(TestCase):
         with self.subTest(name="body_vmem_indices"):
             self.assertIn("out_vmem[0, 0, :, :]", code)
 
+    def test_emit_pipeline_nested_matmul_tiled_n(self) -> None:
+        """A tensor indexed by an outer pipeline tile (the RHS column tile ``nt``,
+        read in the inner contraction pipeline) must be sliced to that tile's
+        block, not left at its full N extent."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def nested_matmul(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+            M, K = a.shape
+            K, N = b.shape
+            out = torch.empty((M, N), dtype=a.dtype, device=a.device)
+            for mt in hl.tile(M):
+                for nt in hl.tile(N):
+                    acc = hl.zeros([mt, nt], dtype=torch.float32)
+                    for kt in hl.tile(K):
+                        acc = acc + torch.matmul(a[mt, kt], b[kt, nt])
+                    out[mt, nt] = acc.to(a.dtype)
+            return out
+
+        torch.manual_seed(0)
+        a = torch.randn(64, 128, device=DEVICE, dtype=torch.bfloat16)
+        # N = 256 > block_n = 128 -> two output-column tiles (nt is an outer
+        # pipeline tile relative to the inner kt contraction pipeline that loads b).
+        b = torch.randn(128, 256, device=DEVICE, dtype=torch.bfloat16)
+        code, out = code_and_output(
+            nested_matmul,
+            (a, b),
+            block_sizes=[32, 128, 128],
+            pallas_loop_type="emit_pipeline",
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+        expected = a @ b
+        torch.testing.assert_close(out, expected)
+
     def test_output_index_remapping_in_fori_loop(self) -> None:
         total_elements = 8 * 128 * 128
         x = torch.arange(total_elements, device=DEVICE, dtype=torch.bfloat16).view(

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -616,7 +616,6 @@ class TestPallas(TestCase):
             block_sizes=[32, 128, 128],
             pallas_loop_type="emit_pipeline",
         )
-        self.assertIn("pltpu.emit_pipeline", code)
         expected = a @ b
         torch.testing.assert_close(out, expected)
 


### PR DESCRIPTION
Currently, _make_block_spec correctly handles:
- var belonging to inner pipeline
- var belonging to grid 

But it the var belongs to another outer pipeline (not the grid, not it's own pipeline), we fail to slice it in the blockspec.

In the PR example, we'd get: 
```
TypeError: add got incompatible shapes for broadcasting: (32, 128), (32, 256)
```
 - `(32, 128)` = the accumulator acc: [block_m, block_n] = [32, 128]. Which is correct.
 - `(32, 256)` = the matmul result: b[kt, nt]. Which is left unsliced.

We need to make sure that b's N dim is sliced. 