### PR TITLE
[cute] Emit cross-thread reduction for a reduced inner tiled dim

### DIFF
--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -1532,6 +1532,87 @@ class BlockReductionStrategy(ReductionStrategy):
         # instead of the newly created one from TileStrategy.__init__
         return self._codegen.index_var(block_idx)
 
+    def _reduction_thread_count(self) -> int:
+        """Return the live thread extent of the reduced tile block.
+
+        Unlike a real reduction axis, a tile block reduced over its inner
+        (tiled) dim is mapped to a normal tile thread axis (plus, when the
+        block is wider than its thread extent, a runtime lane loop). When that
+        block has a live thread axis the partials must be combined ACROSS those
+        threads, so report the thread extent (0 when the block has no live
+        thread axis, e.g. a pure lane loop / serial dim — the base behavior).
+        """
+        extent = self.fn.tile_strategy.thread_extent_for_block_id(self.block_index)
+        return extent if extent is not None and extent > 0 else 0
+
+    def _lane_loop_cross_warp_group_params(
+        self,
+    ) -> tuple[int, int, int, str] | None:
+        """Return ``(pre, group_span, group_count, lane_expr)`` for a tile block
+        that is reduced over its inner (tiled) dim AND carries a runtime lane
+        loop, or ``None`` when no cross-warp de-interleaving is required.
+
+        When the reduced block is mapped to a thread axis ABOVE a sibling tile
+        axis (e.g. ``hl.tile([o, d])`` where ``d`` is reduced, ``d`` on
+        ``thread_idx[1]`` and ``o`` on ``thread_idx[0]``), the threads that
+        share a row are strided by the sibling axis extent (stride 32 here), so
+        the reduce group is spread across warps. A plain
+        ``cute.arch.warp_reduction_*`` would fold together CONSECUTIVE lanes
+        (different rows). Compute the grouped/strided parameters that the
+        cross-warp ``_cute_grouped_reduce_shared_two_stage`` helper needs:
+
+        * ``pre`` — product of live thread extents on axes *below* the reduce
+          axis (the sibling rows that must stay distinct);
+        * ``group_span`` — ``pre`` times the reduce-axis extent (the lanes that
+          form one reduction);
+        * ``group_count`` — the number of independent groups in the CTA;
+        * ``lane_expr`` — the linear thread index across all live thread axes.
+
+        Returns ``None`` (so the caller keeps the plain warp-reduce / no-op
+        finalize) unless the reduce group is genuinely cross-warp
+        (``pre > 1`` and ``group_span`` a multiple of 32 greater than 32).
+        """
+        env = CompileEnvironment.current()
+        backend = env.backend
+        if backend.name != "cute":
+            return None
+        block_axes, axis_sizes = self._active_thread_layout()
+        reduce_axis = block_axes.get(self.block_index)
+        if reduce_axis is None:
+            reduce_axis = self._aliased_active_thread_axis(block_axes)
+        if reduce_axis is None:
+            return None
+        # Live thread extents per axis (sibling axes included) so the linear
+        # lane index strides are computed correctly.
+        logical_axis_sizes = {
+            axis: size for axis, size in axis_sizes.items() if size > 1
+        }
+        if reduce_axis not in logical_axis_sizes:
+            return None
+        pre = 1
+        for axis in range(reduce_axis):
+            pre *= logical_axis_sizes.get(axis, 1)
+        if pre <= 1:
+            # The reduce axis is already at the bottom of the linear lane
+            # index: consecutive warp lanes belong to the reduction, so the
+            # plain warp reduce is correct (no de-interleaving needed).
+            return None
+        reduce_extent = logical_axis_sizes[reduce_axis]
+        group_span = pre * reduce_extent
+        if group_span <= 32 or group_span % 32 != 0:
+            # Single-warp (or non-warp-aligned) groups are not handled by the
+            # cross-warp two-stage path.
+            return None
+        num_threads = 1
+        for size in logical_axis_sizes.values():
+            num_threads *= size
+        if num_threads % group_span != 0:
+            return None
+        lane_expr = backend.thread_linear_index_expr(logical_axis_sizes)
+        if lane_expr is None:
+            return None
+        return pre, group_span, num_threads // group_span, lane_expr
+
     def _active_thread_layout(self) -> tuple[dict[int, int], dict[int, int]]:
         axis_sizes: dict[int, int] = {}
         block_axes: dict[int, int] = {}
@@ -2204,9 +2285,29 @@ class BlockReductionStrategy(ReductionStrategy):
                 identity_expr = env.backend.cast_expr(
                     constant_repr(default), _dtype_str(acc_dtype)
                 )
-                expr = _lane_reduce_marker_expr(
-                    input_name, reduction_type, identity_expr, threads
-                )
+                group_params = self._lane_loop_cross_warp_group_params()
+                if group_params is not None:
+                    # The reduce group is spread across warps (the reduced tile
+                    # dim sits ABOVE a sibling tile axis on the linear thread
+                    # index). Carry the strided/grouped params so the post-pass
+                    # finalize uses the cross-warp two-stage shared reduction
+                    # instead of a (row-cross-contaminating) consecutive-lane
+                    # warp reduce.
+                    group_pre, group_span, group_count, group_lane_expr = group_params
+                    expr = _lane_reduce_marker_expr(
+                        input_name,
+                        reduction_type,
+                        identity_expr,
+                        threads,
+                        group_pre=group_pre,
+                        group_span=group_span,
+                        group_lane_expr=group_lane_expr,
+                        group_count=group_count,
+                    )
+                else:
+                    expr = _lane_reduce_marker_expr(
+                        input_name, reduction_type, identity_expr, threads
+                    )
             else:
                 # A serial device loop (or no thread axis at all). A warp-level
                 # reduction would fold together unrelated tensor elements, so

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -116,17 +116,24 @@ def _lane_reduce_marker_expr(
     group_pre: int = 1,
     group_span: int = 0,
     group_lane_expr: str = "",
+    group_count: int = 1,
 ) -> str:
-    # ``group_*`` (optional) carry the parameters of a strided grouped warp
+    # ``group_*`` (optional) carry the parameters of a strided grouped
     # reduction. They are required when the reduction's live thread axis is
-    # interleaved with an unrelated sibling thread axis on the same warp (a
-    # reshape-merged reduction). ``group_lane_expr`` is base64-free but may
-    # contain commas/parens, so it is passed as a string literal that the
-    # post-pass re-parses.
+    # interleaved with an unrelated sibling thread axis. ``group_lane_expr`` is
+    # base64-free but may contain commas/parens, so it is passed as a string
+    # literal that the post-pass re-parses.
+    #
+    # When ``group_span <= 32`` the de-interleaving fits in a single warp and
+    # the finalize uses ``_cute_grouped_reduce_warp``. When ``group_span > 32``
+    # (and a multiple of 32) the reduction group is spread across warps, so the
+    # finalize uses the cross-warp ``_cute_grouped_reduce_shared_two_stage``;
+    # ``group_count`` (the number of independent groups in the CTA) is needed
+    # only by that two-stage helper.
     return (
         f"{_HELION_LANE_REDUCE_MARKER}({input_name}, {reduction_type!r}, "
         f"{identity_expr}, {threads_in_group}, {group_pre}, {group_span}, "
-        f"{group_lane_expr!r})"
+        f"{group_lane_expr!r}, {group_count})"
     )
 
 
@@ -141,14 +148,17 @@ class _LaneReduceMarker:
     # ``{finalized}``; ``finalize_expr(x)`` substitutes ``x`` to re-apply any
     # surrounding dtype cast / reshape to the finalized reduced scalar.
     wrap_template: str
-    # Optional strided grouped warp reduction (reshape-merged reductions whose
-    # live thread axis shares a warp with an unrelated sibling axis). When
-    # ``group_span`` > 0 the finalize uses ``_cute_grouped_reduce_warp`` with
-    # ``group_pre``/``group_span``/``group_lane_expr`` instead of a plain
-    # consecutive-lane ``cute.arch.warp_reduction_*``.
+    # Optional strided grouped reduction (the reduction's live thread axis
+    # shares a warp / CTA with an unrelated sibling axis). When ``group_span``
+    # > 0 the finalize uses a grouped reduction keyed on ``group_lane_expr``
+    # instead of a plain consecutive-lane ``cute.arch.warp_reduction_*``:
+    # ``_cute_grouped_reduce_warp`` when ``group_span <= 32`` (single warp),
+    # ``_cute_grouped_reduce_shared_two_stage`` when ``group_span`` is a
+    # multiple of 32 greater than 32 (cross-warp, ``group_count`` groups).
     group_pre: int = 1
     group_span: int = 0
     group_lane_expr: str = ""
+    group_count: int = 1
 
     def finalize_expr(self, reduced: str) -> str:
         return self.wrap_template.replace("__HELION_FINALIZED__", f"({reduced})")
@@ -193,7 +203,7 @@ def _is_lane_reduce_marker_assign(stmt: ast.AST) -> _LaneReduceMarker | None:
     if not isinstance(target, ast.Name):
         return None
     call = _find_lane_reduce_call(stmt.value)
-    if call is None or len(call.args) != 7:
+    if call is None or len(call.args) != 8:
         return None
     (
         input_node,
@@ -203,6 +213,7 @@ def _is_lane_reduce_marker_assign(stmt: ast.AST) -> _LaneReduceMarker | None:
         group_pre_node,
         group_span_node,
         group_lane_node,
+        group_count_node,
     ) = call.args
     input_name = ast.unparse(input_node)
     reduction_type = ast.literal_eval(type_node)
@@ -211,6 +222,7 @@ def _is_lane_reduce_marker_assign(stmt: ast.AST) -> _LaneReduceMarker | None:
     group_pre = int(ast.literal_eval(group_pre_node))
     group_span = int(ast.literal_eval(group_span_node))
     group_lane_expr = ast.literal_eval(group_lane_node)
+    group_count = int(ast.literal_eval(group_count_node))
     # Build the wrap template by replacing the marker call with a sentinel.
     wrapped = _ReplaceLaneReduceCall().visit(ast.parse(ast.unparse(stmt.value)).body[0])
     assert isinstance(wrapped, ast.Expr)
@@ -225,6 +237,7 @@ def _is_lane_reduce_marker_assign(stmt: ast.AST) -> _LaneReduceMarker | None:
         group_pre=group_pre,
         group_span=group_span,
         group_lane_expr=group_lane_expr,
+        group_count=group_count,
     )
 
 
@@ -273,6 +286,101 @@ def _grouped_warp_reduce_expr(
         f"{acc}, {reduction_type!r}, {identity_expr}, {lane_expr}, "
         f"pre={pre}, group_span={group_span})"
     )
+
+
+def _grouped_two_stage_reduce_stmts(
+    result_acc: str,
+    reduction_type: str,
+    acc: str,
+    identity_expr: str,
+    lane_expr: str,
+    *,
+    pre: int,
+    group_span: int,
+    group_count: int,
+) -> list[ast.AST]:
+    """Cross-warp grouped reduction over ``group_span`` (> 32) lanes.
+
+    Mirrors ``BlockReductionStrategy._strided_thread_reduction_expr``'s
+    ``group_span > 32`` branch: the reduce group is spread across warps, so a
+    single ``cute.arch.warp_reduction_*`` cannot fold it. The two-stage shared
+    helper reduces each warp, stages the per-warp partials in shared memory, and
+    combines them, keeping the ``pre`` interleaved sibling lanes distinct.
+
+    Unlike that reference emitter this path has no shared-memory-budget fallback,
+    but it does not need one: it only fires for a block-resident reduced tile
+    whose live thread count is bounded by ``MAX_THREADS_PER_BLOCK`` (<= 1024, so
+    <= 32 staged per-warp partials), which cannot overflow the reduction SMEM
+    budget.
+
+    Returns the (lane-index setup + reduce) statements that define
+    ``result_acc`` (used in place of the single-shuffle ``reduced`` scalar).
+    """
+    lane_var = f"{result_acc}_lane"
+    lane_in_group_var = f"{result_acc}_lane_in_group"
+    lane_mod_pre_var = f"{result_acc}_lane_mod_pre"
+    return [
+        statement_from_string(f"{lane_var} = {lane_expr}"),
+        statement_from_string(f"{lane_in_group_var} = ({lane_var}) % {group_span}"),
+        statement_from_string(f"{lane_mod_pre_var} = ({lane_in_group_var}) % {pre}"),
+        statement_from_string(
+            f"{result_acc} = _cute_grouped_reduce_shared_two_stage("
+            f"{acc}, {reduction_type!r}, {identity_expr}, "
+            f"{lane_var}, {lane_in_group_var}, {lane_mod_pre_var}, "
+            f"pre={pre}, group_span={group_span}, group_count={group_count})"
+        ),
+    ]
+
+
+def _finalize_lane_reduce_marker(m: _LaneReduceMarker, acc_var: str) -> list[ast.AST]:
+    """Combine a marker's per-lane accumulator ``acc_var`` across the live
+    thread axis and assign the finalized scalar to ``m.result_var``.
+
+    Picks the cross-thread combine that matches the marker's thread layout:
+
+    * a cross-warp two-stage shared reduction when the reduce group spans more
+      than one warp (``group_span`` a multiple of 32 > 32);
+    * a single-warp strided grouped reduction when the reduce axis shares a warp
+      with an unrelated sibling axis (``1 < group_span <= 32`` with ``pre`` > 1);
+    * a plain consecutive-lane warp reduction otherwise;
+    * the accumulator unchanged when there is no live thread axis to combine.
+    """
+    if m.group_span > 32 and m.group_span % 32 == 0 and m.group_lane_expr:
+        # Cross-warp: the reduce group is spread across warps, so fold the
+        # per-lane accumulator with the two-stage shared-memory reduction.
+        stmts = _grouped_two_stage_reduce_stmts(
+            f"{acc_var}_reduced",
+            m.reduction_type,
+            acc_var,
+            m.identity_expr,
+            m.group_lane_expr,
+            pre=m.group_pre,
+            group_span=m.group_span,
+            group_count=m.group_count,
+        )
+        stmts.append(
+            statement_from_string(
+                f"{m.result_var} = {m.finalize_expr(f'{acc_var}_reduced')}"
+            )
+        )
+        return stmts
+    if m.group_span > 1 and m.group_pre > 1 and m.group_lane_expr:
+        # Strided grouped reduction: the reduce axis shares a warp with an
+        # unrelated sibling axis, so combine only the lanes that share the
+        # current lane's sibling coordinate.
+        reduced = _grouped_warp_reduce_expr(
+            m.reduction_type,
+            acc_var,
+            m.identity_expr,
+            m.group_lane_expr,
+            pre=m.group_pre,
+            group_span=m.group_span,
+        )
+    elif m.threads_in_group > 1:
+        reduced = _warp_reduce_expr(m.reduction_type, acc_var, m.threads_in_group)
+    else:
+        reduced = acc_var
+    return [statement_from_string(f"{m.result_var} = {m.finalize_expr(reduced)}")]
 
 
 def _warp_reduce_expr(reduction_type: str, acc: str, threads_in_group: int) -> str:
@@ -468,25 +576,7 @@ def _split_one_lane_loop(loop: ast.For, lane_var: str) -> list[ast.AST]:
                 f"{acc_var} = {_combine_expr(m.reduction_type, acc_var, combine_val)}"
             )
         )
-        if m.group_span > 1 and m.group_pre > 1 and m.group_lane_expr:
-            # Strided grouped reduction: the reduce axis shares a warp with an
-            # unrelated sibling axis, so combine only the lanes that share the
-            # current lane's sibling coordinate.
-            reduced = _grouped_warp_reduce_expr(
-                m.reduction_type,
-                acc_var,
-                m.identity_expr,
-                m.group_lane_expr,
-                pre=m.group_pre,
-                group_span=m.group_span,
-            )
-        elif m.threads_in_group > 1:
-            reduced = _warp_reduce_expr(m.reduction_type, acc_var, m.threads_in_group)
-        else:
-            reduced = acc_var
-        finalize.append(
-            statement_from_string(f"{m.result_var} = {m.finalize_expr(reduced)}")
-        )
+        finalize.extend(_finalize_lane_reduce_marker(m, acc_var))
 
     # Phase 2: everything except the marker assignments themselves; the
     # reduced scalar is already finalized so consumers read it directly.
@@ -925,22 +1015,7 @@ def _split_lane_loop_with_register_stash(
             )
         )
         result.append(_create_lane_loop(lane_var, extent, acc_body))
-        if m.group_span > 1 and m.group_pre > 1 and m.group_lane_expr:
-            reduced = _grouped_warp_reduce_expr(
-                m.reduction_type,
-                acc_var,
-                m.identity_expr,
-                m.group_lane_expr,
-                pre=m.group_pre,
-                group_span=m.group_span,
-            )
-        elif m.threads_in_group > 1:
-            reduced = _warp_reduce_expr(m.reduction_type, acc_var, m.threads_in_group)
-        else:
-            reduced = acc_var
-        result.append(
-            statement_from_string(f"{m.result_var} = {m.finalize_expr(reduced)}")
-        )
+        result.extend(_finalize_lane_reduce_marker(m, acc_var))
 
     # Final consume pass: everything in the tail except the marker assignments,
     # re-derived from the stash + finalized scalars.  Only keep statements that

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -169,6 +169,61 @@ class TestReductions(RefEagerTestBase, TestCase):
                 if _get_backend() == "cute":
                     self.assertIn("_cute_grouped_reduce_shared_two_stage", code)
 
+    def test_2d_tile_inner_dim_reduction_to_scalar(self):
+        """Reduce the inner dim of a single 2D ``hl.tile([o, d])`` into a per-row scalar.
+
+        Unlike ``test_cross_warp_reduction_non_sum_ops`` (which uses a separate
+        inner ``hl.tile(m)`` loop), this tiles both dims together in ONE
+        ``hl.tile([o, d])`` and reduces the inner dim (``dim=-1``) into a scalar
+        ``out[tile_o]``. That routes to ``BlockReductionStrategy`` with a runtime
+        lane loop over the block-resident inner dim. This form previously emitted
+        a per-thread partial with NO cross-thread reduction (the stride-32 reduce
+        group is spread across warps), so the threads owning a row raced to store
+        their partial sums -> silently wrong output. The fix folds the lane loop
+        into a per-thread partial and then combines across warps via
+        ``_cute_grouped_reduce_shared_two_stage`` (group_span=128, >32 and %32==0).
+
+        ``d_block`` is forced to the full power-of-2 extent so the reduction stays
+        block-resident (the well-posed form). D=128 makes the reduce group span
+        4 warps, exercising the cross-warp two-stage path on CuTe.
+        """
+
+        @helion.kernel(static_shapes=True, autotune_effort="none")
+        def sum_kernel(w: torch.Tensor) -> torch.Tensor:
+            o, d = w.shape
+            d = hl.specialize(d)
+            out = torch.empty([o], dtype=torch.float32, device=w.device)
+            d_block = hl.register_block_size(
+                helion.next_power_of_2(d), helion.next_power_of_2(d)
+            )
+            for tile_o, tile_d in hl.tile([o, d], block_size=[None, d_block]):
+                out[tile_o] = torch.sum(w[tile_o, tile_d].to(torch.float32), dim=-1)
+            return out
+
+        @helion.kernel(static_shapes=True, autotune_effort="none")
+        def amax_kernel(w: torch.Tensor) -> torch.Tensor:
+            o, d = w.shape
+            d = hl.specialize(d)
+            out = torch.empty([o], dtype=torch.float32, device=w.device)
+            d_block = hl.register_block_size(
+                helion.next_power_of_2(d), helion.next_power_of_2(d)
+            )
+            for tile_o, tile_d in hl.tile([o, d], block_size=[None, d_block]):
+                out[tile_o] = torch.amax(w[tile_o, tile_d].to(torch.float32), dim=-1)
+            return out
+
+        w = torch.randn([512, 128], device=DEVICE, dtype=torch.float32)
+        cases = [
+            (sum_kernel, lambda t: t.sum(-1)),
+            (amax_kernel, lambda t: t.amax(-1)),
+        ]
+        for kernel, ref_fn in cases:
+            with self.subTest(kernel=kernel.__name__):
+                code, out = code_and_output(kernel, (w,))
+                torch.testing.assert_close(out, ref_fn(w), rtol=1e-4, atol=1e-4)
+                if _get_backend() == "cute":
+                    self.assertIn("_cute_grouped_reduce_shared_two_stage", code)
+
     def test_sum_constant_inner_dim(self):
         """Sum over a known-constant inner dimension (e.g., 2) should work.
 


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * __->__#2706


--- --- ---

[cute] Emit cross-thread reduction for a reduced inner tiled dim

A `torch.sum`/`torch.amax` over the inner dim of a single 2D
`hl.tile([o, d])` (storing a per-row scalar `out[tile_o]`) routed to
`BlockReductionStrategy`'s lane-loop marker path with `threads_in_group=1`
(the base `_reduction_thread_count` returns 0), so it emitted a per-thread
partial with NO cross-thread reduction. The threads spanning the reduced dim
then raced to store their partial sums to the same output element, producing
silently wrong results on CuTe (e.g. a gather + fused LayerNorm kernel that is
correct on Triton). Commit 81ec1023 made layout validation permissive for this
mixed scalar/block store but the reduction codegen was never taught to combine
across the reduced dim's threads.

Teach `BlockReductionStrategy` to:
- override `_reduction_thread_count` to report the reduced tile block's live
  thread extent (0 when it has no live thread axis, preserving base behavior);
- when the reduced block sits above a sibling tile axis so the reduce group is
  strided across warps, carry grouped/strided params on the lane-reduce marker
  so the finalize emits the cross-warp `_cute_grouped_reduce_shared_two_stage`
  reduction instead of a row-cross-contaminating consecutive-lane warp reduce.

The two marker finalize sites are refactored into a shared
`_finalize_lane_reduce_marker` dispatcher; the existing plain-warp, single-warp
grouped, vec-loop, and 1D-reduction paths are unchanged (the new path is gated
strictly on a live thread axis + runtime lane loop + a >32, %32==0 group span).

Adds `test_2d_tile_inner_dim_reduction_to_scalar` (sum + amax).