### PR TITLE
[cute] Match CUTLASS on FP8 scaled_mm: bk=128, drop harmful setmaxregister split, K-major B

### DIFF
--- a/examples/scaled_mm.py
+++ b/examples/scaled_mm.py
@@ -159,13 +159,16 @@ def scaled_mm_compute(
 # %%
 # Compute-bound FP8 RowWise scaled_mm on Helion's CuTe (tcgen05) backend.
 # This config is the deeply-pipelined 2-CTA recipe that matches CUTLASS on the
-# Blackwell M=512 compute-bound shapes (256x128 cluster(2,1), bk=64, ab_stages=8,
-# role_local_monolithic = 6-warp inline-scheduler layout). The rowwise scale is
-# fused in the epilogue: ``scale_a`` (per-row) is passed as a stride-(1,0)
-# ``(M, N)`` view so the backend reads it as a scalar, and ``scale_b`` (per-col)
-# as a rank-1 row-vector that is register-hoisted before the accumulator wait.
+# Blackwell M=512 compute-bound shapes (256x128 cluster(2,1), bk=128, ab_stages=8,
+# role_local_monolithic = 6-warp inline-scheduler layout). bk=128 mirrors the
+# CUTLASS persistent-GEMM mma-tiler K (mma_inst_k=32 x 4), halving the K-loop
+# iteration count vs bk=64 and the per-iteration pipeline-sync/TMA-issue overhead
+# (~1.3x -> ~1.05x on the long-K down_proj shape). The rowwise scale is fused in
+# the epilogue: ``scale_a`` (per-row) is passed as a stride-(1,0) ``(M, N)`` view
+# so the backend reads it as a scalar, and ``scale_b`` (per-col) as a rank-1
+# row-vector that is register-hoisted before the accumulator wait.
 _SCALED_MM_CUTE_FP8_CONFIG = helion.Config(
-    block_sizes=[256, 128, 64],
+    block_sizes=[256, 128, 128],
     cute_vector_widths=[1, 1, 1],
     indexing=[
         "pointer",
@@ -193,6 +196,12 @@ _SCALED_MM_CUTE_FP8_CONFIG = helion.Config(
     tcgen05_warp_spec_register_decrease=120,
     tcgen05_warp_spec_register_increase=256,
     tcgen05_warp_spec_scheduler_warps=0,
+    # Skip the producer/consumer setmaxregister split: this kernel's SMEM
+    # footprint already pins occupancy at 1 CTA/SM, so forcing the consumer
+    # increase ceiling only makes ptxas over-allocate and spill (255 reg +
+    # ~17 KB local spill). Letting ptxas pick its natural ~190-reg allocation
+    # removes the spill and matches CUTLASS on all 4 M=512 shapes.
+    tcgen05_warp_spec_register_realloc=False,
 )
 
 

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -96,6 +96,8 @@ from .tcgen05_constants import TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
 from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_TMA_STORE_MAX_AB_STAGES
+from .tcgen05_constants import TCGEN05_WARP_SPEC_REGISTER_REALLOC_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_WARP_SPEC_REGISTER_REALLOC_DEFAULT
 from .tcgen05_lifecycle import Tcgen05LifecycleContext
 from .tcgen05_pure_matmul import Tcgen05PureMatmulObjectModel
 
@@ -1064,6 +1066,10 @@ class _PerKiterTmaArgs:
     # full-tile branch and scalar fallback. Non-pipelined/asymmetric or two-CTA
     # TMA paths must keep the guarded fallback path.
     static_full_tiles: bool = False
+    # Cached leader-CTA predicates to avoid redundant special-register reads
+    # in the K-loop. Empty string if not applicable (one-CTA mode).
+    is_leader_cta_var: str = ""
+    is_v_leader_cta_var: str = ""
 
 
 def _kloop_tma_copy_a_src(args: _PerKiterTmaArgs, *, k_offset: str) -> str:
@@ -1107,6 +1113,8 @@ def _tcgen05_two_cta_owner_predicate(
     is_two_cta: bool,
     gate_exec_warp: bool,
     cluster_n: int = 1,
+    is_leader_cta_var: str | None = None,
+    is_v_leader_cta_var: str | None = None,
 ) -> str | None:
     """Owner-of-the-V-pair predicate for AB consumer release / MMA issuance.
 
@@ -1119,15 +1127,25 @@ def _tcgen05_two_cta_owner_predicate(
     must use ``rank % 2 == 0``; rank 2 must commit on its own V-pair's empty
     barrier or the cluster races (cycle-26 hang root cause; see cute_plan.md
     §6.12.3).
+
+    If ``is_leader_cta_var`` or ``is_v_leader_cta_var`` are provided, they
+    are used as cached boolean variables instead of recomputing the predicate
+    inline (avoiding redundant special-register reads in the K-loop).
     """
     predicate_terms = []
     if gate_exec_warp:
         predicate_terms.append(exec_active)
     if is_two_cta:
         if cluster_n > 1:
-            predicate_terms.append(_TCGEN05_V_LEADER_PREDICATE)
+            # Use cached variable if available, otherwise fall back to inline expression
+            predicate_terms.append(
+                is_v_leader_cta_var if is_v_leader_cta_var else _TCGEN05_V_LEADER_PREDICATE
+            )
         else:
-            predicate_terms.append(_TCGEN05_CLUSTER_LEADER_PREDICATE)
+            # Use cached variable if available, otherwise fall back to inline expression
+            predicate_terms.append(
+                is_leader_cta_var if is_leader_cta_var else _TCGEN05_CLUSTER_LEADER_PREDICATE
+            )
     if not predicate_terms:
         return None
     return " and ".join(predicate_terms)
@@ -1230,6 +1248,8 @@ def _build_kloop_pipeline_consumer_if(
             is_two_cta=args.is_two_cta,
             gate_exec_warp=gate_exec_warp,
             cluster_n=args.cluster_n,
+            is_leader_cta_var=args.is_leader_cta_var or None,
+            is_v_leader_cta_var=args.is_v_leader_cta_var or None,
         ),
         indent="" if args.static_full_tiles else "    ",
     )
@@ -1266,6 +1286,8 @@ def _build_kloop_pipeline_consumer_prefetch_stmts(
         is_two_cta=args.is_two_cta,
         gate_exec_warp=gate_exec_warp,
         cluster_n=args.cluster_n,
+        is_leader_cta_var=args.is_leader_cta_var or None,
+        is_v_leader_cta_var=args.is_v_leader_cta_var or None,
     )
     if owner_predicate is not None:
         predicate = f"{predicate} and {owner_predicate}"
@@ -1308,6 +1330,8 @@ def _build_kloop_pipeline_release_if(
         is_two_cta=args.is_two_cta,
         gate_exec_warp=gate_exec_warp,
         cluster_n=args.cluster_n,
+        is_leader_cta_var=args.is_leader_cta_var or None,
+        is_v_leader_cta_var=args.is_v_leader_cta_var or None,
     )
     advance_src = emit_pipeline_advance(args.tma_consumer_state)
     indent = "" if args.static_full_tiles else "    "
@@ -1340,6 +1364,8 @@ def _build_tcgen05_mma_accumulate_reset_stmt(
     gate_exec_warp: bool = True,
     is_two_cta: bool = False,
     cluster_n: int = 1,
+    is_leader_cta_var: str | None = None,
+    is_v_leader_cta_var: str | None = None,
 ) -> ast.stmt:
     reset_src = f"{tiled_mma}.set(cute.nvgpu.tcgen05.Field.ACCUMULATE, False)"
     predicate = _tcgen05_two_cta_owner_predicate(
@@ -1347,6 +1373,8 @@ def _build_tcgen05_mma_accumulate_reset_stmt(
         is_two_cta=is_two_cta,
         gate_exec_warp=gate_exec_warp,
         cluster_n=cluster_n,
+        is_leader_cta_var=is_leader_cta_var,
+        is_v_leader_cta_var=is_v_leader_cta_var,
     )
     if predicate is None:
         return statement_from_string(reset_src)
@@ -1364,6 +1392,8 @@ def _build_tcgen05_mma_issue_stmt(
     gate_exec_warp: bool = True,
     is_two_cta: bool = False,
     cluster_n: int = 1,
+    is_leader_cta_var: str | None = None,
+    is_v_leader_cta_var: str | None = None,
 ) -> ast.stmt:
     issue_src = (
         f"for _tcgen05_kblk_idx in range(cute.size({tcgen05_frag_a}, mode=[2])):\n"
@@ -1381,6 +1411,8 @@ def _build_tcgen05_mma_issue_stmt(
         is_two_cta=is_two_cta,
         gate_exec_warp=gate_exec_warp,
         cluster_n=cluster_n,
+        is_leader_cta_var=is_leader_cta_var,
+        is_v_leader_cta_var=is_v_leader_cta_var,
     )
     if predicate is not None:
         issue_src = f"if {predicate}:\n{textwrap.indent(issue_src, '    ')}"
@@ -1826,10 +1858,25 @@ def _emit_mma_pipeline(
     epi_elem_dtype_str = (
         _dtype_map[epi_elem_dtype] if epi_elem_dtype is not None else input_dtype_str
     )
+    # B operand majorness. ``B`` is logically ``[K, N]``. The validated path
+    # is MN-major (N-contiguous, ``stride(1)==1`` -- the row-major ``b[k, n]``
+    # case). CUTLASS-style FP8 GEMMs instead pass ``B`` column-major
+    # (K-contiguous, ``stride(0)==1``), which is K-major: still a perfectly
+    # TMA-loadable layout, but the MMA operand mode and SMEM/TMA tile layout
+    # must switch from ``OperandMajorMode.MN`` to ``OperandMajorMode.K``. Detect
+    # it here so the tiled-mma / smem-layout / TMA-view codegen can follow.
+    tcgen05_b_k_major = (
+        rhs_fake.dim() == 2
+        and rhs_fake.stride(0) == 1
+        and rhs_fake.stride(1) == rhs_fake.shape[0]
+    )
+    # A K-major B is contiguous in the transposed (column-major) sense; treat it
+    # as TMA-loadable rather than bailing to the unvalidated scalar/guard path.
+    rhs_tma_loadable = rhs_fake.is_contiguous() or tcgen05_b_k_major
     tcgen05_use_tma = (
         input_dtype in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
         and lhs_fake.is_contiguous()
-        and rhs_fake.is_contiguous()
+        and rhs_tma_loadable
     )
     tcgen05_use_tma_a = tcgen05_use_tma
     tcgen05_use_tma_b = tcgen05_use_tma
@@ -2454,6 +2501,10 @@ def _emit_mma_pipeline(
     tcgen05_epi_acc_frag_base = df.new_var("tcgen05_epi_acc_frag_base")
     tcgen05_plan = _new_tcgen05_layout_plan(df) if mma_impl == "tcgen05" else None
     tcgen05_cluster_layout_vmnk = df.new_var("tcgen05_cluster_layout_vmnk")
+    # Cached leader-CTA predicates to avoid redundant special-register reads.
+    # Declared early so they're available for per_tile statement generation.
+    tcgen05_is_leader_cta = df.new_var("tcgen05_is_leader_cta")
+    tcgen05_is_v_leader_cta = df.new_var("tcgen05_is_v_leader_cta")
 
     # === outer_prefix: MMA setup + shared memory alloc + accumulator init ===
     prefix = device_loop.outer_prefix
@@ -2596,6 +2647,8 @@ def _emit_mma_pipeline(
                 is_two_cta=tcgen05_is_two_cta,
                 gate_exec_warp=False,
                 cluster_n=tcgen05_cluster_n,
+                is_leader_cta_var=tcgen05_is_leader_cta if tcgen05_is_two_cta else None,
+                is_v_leader_cta_var=tcgen05_is_v_leader_cta if tcgen05_is_two_cta else None,
             )
             assert ab_consumer_prefetch_owner_predicate is not None
             _emit_per_tile(
@@ -2631,6 +2684,8 @@ def _emit_mma_pipeline(
             tiled_mma=tiled_mma,
             is_two_cta=tcgen05_is_two_cta,
             cluster_n=tcgen05_cluster_n,
+            is_leader_cta_var=tcgen05_is_leader_cta if tcgen05_is_two_cta else None,
+            is_v_leader_cta_var=tcgen05_is_v_leader_cta if tcgen05_is_two_cta else None,
         )
         prefix.append(reset_accumulate_stmt)
         per_tile_stmts.append(reset_accumulate_stmt)
@@ -3021,6 +3076,8 @@ def _emit_mma_pipeline(
             is_two_cta=tcgen05_is_two_cta,
             gate_exec_warp=True,
             cluster_n=tcgen05_cluster_n,
+            is_leader_cta_var=tcgen05_is_leader_cta if tcgen05_is_two_cta else None,
+            is_v_leader_cta_var=tcgen05_is_v_leader_cta if tcgen05_is_two_cta else None,
         )
         candidate_block_shape = tcgen05_matmul_plan.block_shape
         df.cute_state.register_tcgen05_matmul_plan(tcgen05_matmul_plan)
@@ -3115,6 +3172,7 @@ def _emit_mma_pipeline(
                 bm,
                 bn,
                 tcgen05_cluster_m=tcgen05_cluster_m,
+                tcgen05_b_k_major=tcgen05_b_k_major,
             )
         )
     else:
@@ -3249,20 +3307,33 @@ def _emit_mma_pipeline(
             # gate as ``aux_stages``), so T1-T7 stay byte-identical at
             # the 256 default.
             consumer_regs_value = _tcgen05_consumer_regs_from_config(df.config)
-            prefix.append(
-                statement_from_string(
-                    f"if not ({consumer_predicate}):\n"
-                    f"    cute.arch.setmaxregister_decrease("
-                    f"{_TCGEN05_PRODUCER_REGS})"
-                )
+            # The producer/consumer setmaxregister split only improves
+            # occupancy when registers are the occupancy limiter. For the
+            # deep-pipeline FP8 GEMMs whose SMEM footprint already pins
+            # occupancy at 1 CTA/SM, forcing the consumer ``increase`` ceiling
+            # makes ptxas over-allocate and spill where the natural allocation
+            # fits with no spill. ``tcgen05_warp_spec_register_realloc=False``
+            # skips both calls; default True keeps the validated emission.
+            tcgen05_emit_register_realloc = _tcgen05_config_bool(
+                df.config,
+                TCGEN05_WARP_SPEC_REGISTER_REALLOC_CONFIG_KEY,
+                TCGEN05_WARP_SPEC_REGISTER_REALLOC_DEFAULT,
             )
-            prefix.append(
-                statement_from_string(
-                    f"if {consumer_predicate}:\n"
-                    f"    cute.arch.setmaxregister_increase("
-                    f"{consumer_regs_value})"
+            if tcgen05_emit_register_realloc:
+                prefix.append(
+                    statement_from_string(
+                        f"if not ({consumer_predicate}):\n"
+                        f"    cute.arch.setmaxregister_decrease("
+                        f"{_TCGEN05_PRODUCER_REGS})"
+                    )
                 )
-            )
+                prefix.append(
+                    statement_from_string(
+                        f"if {consumer_predicate}:\n"
+                        f"    cute.arch.setmaxregister_increase("
+                        f"{consumer_regs_value})"
+                    )
+                )
             prefix.append(
                 statement_from_string(
                     # tcgen05 tiled_mma slicing is CTA-scoped, not per-thread.
@@ -3290,6 +3361,7 @@ def _emit_mma_pipeline(
                     bm,
                     bn,
                     tcgen05_cluster_m=tcgen05_cluster_m,
+                    tcgen05_b_k_major=tcgen05_b_k_major,
                 )
             )
         else:
@@ -3307,6 +3379,7 @@ def _emit_mma_pipeline(
                     bm,
                     bn,
                     tcgen05_cluster_m=tcgen05_cluster_m,
+                    tcgen05_b_k_major=tcgen05_b_k_major,
                 )
             )
     if mma_impl == "tcgen05":
@@ -3930,6 +4003,9 @@ def _emit_mma_pipeline(
                 "ab_stage_count": tcgen05_ab_stage_count_value,
                 "input_dtype": input_dtype_str,
                 "acc_dtype": acc_dtype_str,
+                # B operand majorness (False = MN-major row-major [K,N];
+                # True = K-major column-major [K,N], the CUTLASS-style operand).
+                "b_k_major": tcgen05_b_k_major,
                 # B1 (cycle-3 review): plumb the validated problem
                 # shape onto the AB plan so the direct-entry plan can
                 # carry an envelope identity that the runtime
@@ -4091,6 +4167,24 @@ def _emit_mma_pipeline(
                         f"{tcgen05_cluster_layout_vmnk}.get_flat_coord({tma_cta_rank_in_cluster})"
                     )
                 )
+                # Cache the leader-CTA predicate to avoid redundant special-register reads
+                # in the K-loop. With use_2cta=True cluster_n=1, the cluster-leader rank 0
+                # is the only V-leader; with cluster_n>1 both ranks {0,2} are V-leaders.
+                if tcgen05_is_two_cta:
+                    if tcgen05_cluster_n > 1:
+                        prefix.append(
+                            statement_from_string(
+                                f"{tcgen05_is_v_leader_cta} = "
+                                f"{tma_cta_rank_in_cluster} % cutlass.Int32(2) == cutlass.Int32(0)"
+                            )
+                        )
+                    else:
+                        prefix.append(
+                            statement_from_string(
+                                f"{tcgen05_is_leader_cta} = "
+                                f"{tma_cta_rank_in_cluster} == cutlass.Int32(0)"
+                            )
+                        )
                 if tcgen05_is_two_cta:
                     prefix.append(
                         statement_from_string(
@@ -4581,6 +4675,8 @@ def _emit_mma_pipeline(
                 scalar_load_b=scalar_load_b,
                 cluster_n=tcgen05_cluster_n,
                 static_full_tiles=tcgen05_static_full_tma_fast_path,
+                is_leader_cta_var=tcgen05_is_leader_cta if tcgen05_is_two_cta else "",
+                is_v_leader_cta_var=tcgen05_is_v_leader_cta if tcgen05_is_two_cta else "",
             )
             if tcgen05_use_tma_pipeline:
                 if tcgen05_use_separate_tma_producer:
@@ -4692,6 +4788,8 @@ def _emit_mma_pipeline(
                                 gate_exec_warp=tcgen05_static_full_tma_fast_path,
                                 is_two_cta=tcgen05_is_two_cta,
                                 cluster_n=tcgen05_cluster_n,
+                                is_leader_cta_var=tcgen05_is_leader_cta if tcgen05_is_two_cta else None,
+                                is_v_leader_cta_var=tcgen05_is_v_leader_cta if tcgen05_is_two_cta else None,
                             )
                         )
                     exec_loop_body.append(
@@ -4852,6 +4950,8 @@ def _emit_mma_pipeline(
                             mma_stage=mma_stage,
                             is_two_cta=tcgen05_is_two_cta,
                             cluster_n=tcgen05_cluster_n,
+                            is_leader_cta_var=tcgen05_is_leader_cta if tcgen05_is_two_cta else None,
+                            is_v_leader_cta_var=tcgen05_is_v_leader_cta if tcgen05_is_two_cta else None,
                         )
                     )
                 if tcgen05_use_tma:
@@ -5127,6 +5227,13 @@ def _tcgen05_config_int(config: object, key: str, default: int) -> int:
     return value
 
 
+def _tcgen05_config_bool(config: object, key: str, default: bool) -> bool:
+    value = cast("_ConfigLike", config).get(key, default)
+    if not isinstance(value, bool):
+        return default
+    return value
+
+
 def _tcgen05_cluster_m(config: object) -> int:
     return max(1, min(2, _tcgen05_config_int(config, "tcgen05_cluster_m", 1)))
 
@@ -5359,6 +5466,7 @@ def _make_tiled_mma_setup(
     bn: int,
     *,
     tcgen05_cluster_m: int = 1,
+    tcgen05_b_k_major: bool = False,
 ) -> list[ast.AST]:
     if mma_impl == "warp":
         tiled_mma_expr = (
@@ -5374,6 +5482,7 @@ def _make_tiled_mma_setup(
             bm,
             bn,
             tcgen05_cluster_m=tcgen05_cluster_m,
+            b_k_major=tcgen05_b_k_major,
         )
     else:
         assert mma_thread_linear
@@ -5402,16 +5511,24 @@ def _tcgen05_tiled_mma_expr(
     bn: int,
     *,
     tcgen05_cluster_m: int = 1,
+    b_k_major: bool = False,
 ) -> str:
     cta_group_expr = "cute.nvgpu.tcgen05.CtaGroup.ONE"
     if _tcgen05_use_2cta_instrs(bm=bm, cluster_m=tcgen05_cluster_m):
         cta_group_expr = "cute.nvgpu.tcgen05.CtaGroup.TWO"
+    # A is always K-major. B is MN-major for row-major ``[K, N]`` and K-major
+    # for the column-major (CUTLASS-style) ``[K, N]`` operand.
+    b_major_mode_expr = (
+        "cute.nvgpu.OperandMajorMode.K"
+        if b_k_major
+        else "cute.nvgpu.OperandMajorMode.MN"
+    )
     return (
         "cutlass.utils.blackwell_helpers.make_trivial_tiled_mma("
         f"{input_dtype_str}, "
         f"{input_dtype_str}, "
         "cute.nvgpu.OperandMajorMode.K, "
-        "cute.nvgpu.OperandMajorMode.MN, "
+        f"{b_major_mode_expr}, "
         f"{acc_dtype_str}, "
         f"{cta_group_expr}, "
         f"({bm}, {bn}), "

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -119,6 +119,7 @@ from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_L2_GROUPING
 from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_SCHEDULER_L2_SWIZZLE_SIZE
 from .tcgen05_constants import TCGEN05_TWO_CTA_MAX_K_TILES
 from .tcgen05_constants import TCGEN05_TWO_CTA_SEED_PID_TYPE
+from .tcgen05_constants import TCGEN05_WARP_SPEC_REGISTER_REALLOC_CONFIG_KEY
 from .tcgen05_constants import tcgen05_ab_smem_bytes_per_cta
 from .tcgen05_constants import tcgen05_c_smem_bytes_per_cta
 from .tcgen05_constants import tcgen05_default_epilogue_tile_size
@@ -186,6 +187,7 @@ CUTE_TCGEN05_DIAGNOSTIC_CONFIG_KEYS: frozenset[str] = frozenset(
         TCGEN05_SCHED_CONSUMER_WAIT_MODE_CONFIG_KEY,
         TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY,
         TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY,
+        TCGEN05_WARP_SPEC_REGISTER_REALLOC_CONFIG_KEY,
     }
 )
 CUTE_TCGEN05_STRATEGY_CONFIG_KEYS: frozenset[str] = frozenset(
@@ -2232,6 +2234,11 @@ class CuteTcgen05Config:
         )
         self._validate_bool_config(
             config, TCGEN05_LARGE_BN_PROOF_CONFIG_KEY, fix_invalid=fix_invalid
+        )
+        self._validate_bool_config(
+            config,
+            TCGEN05_WARP_SPEC_REGISTER_REALLOC_CONFIG_KEY,
+            fix_invalid=fix_invalid,
         )
         self._validate_bool_config(
             config,

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -389,6 +389,19 @@ TCGEN05_CONSUMER_REGS_CONFIG_KEY = "tcgen05_consumer_regs"
 TCGEN05_CONSUMER_REGS_DEFAULT = 256
 TCGEN05_CONSUMER_REGS_CHOICES = (224, 232, 240, 256)
 
+# Producer/consumer ``setmaxregister`` reallocation toggle. The warp-spec
+# split (producers ``setmaxregister_decrease`` to a lean budget, consumers
+# ``setmaxregister_increase`` to a high ceiling) only buys occupancy when the
+# per-thread register count is the occupancy limiter. For the deep-pipeline
+# FP8 GEMMs whose SMEM footprint already pins occupancy to 1 CTA/SM, the
+# ``increase`` ceiling instead makes ``ptxas`` over-allocate and spill (NCU:
+# 255 reg/thread + ~17 KB local-memory spill at bk=128) where the natural
+# allocation fits in ~190 reg with no spill. Setting this False skips emitting
+# both setmaxregister calls so ptxas picks its natural register count. Default
+# True preserves the validated warp-spec emission byte-for-byte.
+TCGEN05_WARP_SPEC_REGISTER_REALLOC_CONFIG_KEY = "tcgen05_warp_spec_register_realloc"
+TCGEN05_WARP_SPEC_REGISTER_REALLOC_DEFAULT = True
+
 # Stage tuples that the TVM-FFI flat-role seed accepts, keyed by ``bk``. The
 # general FFI seed eligibility (``tcgen05_config.py``) consumes this table via
 # ``tcgen05_direct_entry_stage_tuple_allowed``. ``bk=64`` admits the shallow

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -2164,6 +2164,10 @@ def _append_cute_wrapper_plan(
     input_dtype = str(plan["input_dtype"])
     acc_dtype = str(plan["acc_dtype"])
     ab_stage_count = plan_int("ab_stage_count", 2)
+    # B operand majorness. False = MN-major (row-major ``[K, N]``); True =
+    # K-major (column-major ``[K, N]``, the CUTLASS-style FP8 operand). Drives
+    # the MMA operand mode and the ``rhs_tma`` view / dynamic-leading-dim.
+    b_k_major = bool(plan.get("b_k_major", False))
     # Optional ``smem_swizzle_*`` overrides recorded by the device-side
     # codegen when the user opts into a non-default A/B SMEM atom
     # swizzle. When absent the wrapper emits the legacy
@@ -2226,8 +2230,12 @@ def _append_cute_wrapper_plan(
                 f"{input_dtype}, "
                 f"{input_dtype}, "
                 "cute.nvgpu.OperandMajorMode.K, "
-                "cute.nvgpu.OperandMajorMode.MN, "
-                f"{acc_dtype}, "
+                + (
+                    "cute.nvgpu.OperandMajorMode.K, "
+                    if b_k_major
+                    else "cute.nvgpu.OperandMajorMode.MN, "
+                )
+                + f"{acc_dtype}, "
                 f"{cta_group}, "
                 f"({bm}, {bn}), "
                 "cute.nvgpu.tcgen05.OperandSource.SMEM)"
@@ -2238,6 +2246,11 @@ def _append_cute_wrapper_plan(
             ),
             f"    {smem_a_layout} = {smem_a_layout_expr}",
             f"    {smem_b_layout} = {smem_b_layout_expr}",
+            # B is logically ``[K, N]``; TMA wants it presented as ``[N, K]``
+            # (swap shape/stride). The dynamic (non-contiguous) leading dim then
+            # differs by majorness: MN-major (row-major B) is N-contiguous so the
+            # N axis (dim 0 of the [N, K] view) is dynamic; K-major (column-major
+            # B) is K-contiguous so the K axis (dim 1) is dynamic.
             (
                 f"    {rhs_tma} = cute.make_tensor("
                 f"arg{rhs_idx}.iterator, "
@@ -2245,7 +2258,7 @@ def _append_cute_wrapper_plan(
                 f"(arg{rhs_idx}_shape1, arg{rhs_idx}_shape0), "
                 f"stride=(arg{rhs_idx}_stride1, arg{rhs_idx}_stride0)))"
             ),
-            f"    {rhs_tma}.mark_layout_dynamic(leading_dim=0)",
+            f"    {rhs_tma}.mark_layout_dynamic(leading_dim={1 if b_k_major else 0})",
             # ``make_tiled_tma_atom_A`` vs ``_B`` asymmetry:
             # - ``_B`` always passes ``cluster_layout_vmnk.shape`` as
             #   its trailing arg (CuTe's signature for B requires the

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -1207,6 +1207,31 @@ class TestCuteBackend(TestCase):
         self.assertIn("cute.nvgpu.tcgen05", code)
         self.assertIn("cute.gemm(", code)
 
+    def test_matmul_mma_tcgen05_fp8_col_major_b(self) -> None:
+        # B passed column-major [K, N] (K-contiguous), the CUTLASS-style FP8
+        # operand layout. The tcgen05 MMA must switch operand B to
+        # OperandMajorMode.K; the row-major path uses OperandMajorMode.MN.
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = (torch.randn(256, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y_row = (torch.randn(128, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y_col = y_row.t().contiguous().t()  # column-major [K, N]
+        self.assertEqual(y_col.stride(), (1, 128))
+        code, out = code_and_output(
+            cute_matmul_mma_fp8, (x, y_col), block_sizes=[128, 128, 128]
+        )
+        ref = x.float() @ y_col.float()
+        torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+        # K-major B emits OperandMajorMode.K for *both* operands (A is always
+        # K-major); the row-major path would emit one .MN. The runtime guard
+        # for the unvalidated persistent fallback must not fire.
+        self.assertIn("cute.nvgpu.OperandMajorMode.K", code)
+        self.assertNotIn("OperandMajorMode.MN", code)
+        self.assertNotIn("outside the validated persistent scheduler", code)
+
     def test_matmul_mma_tcgen05_fp8_rowvec_scale(self) -> None:
         support = get_cute_mma_support()
         if not support.tcgen05_f8:
@@ -1225,6 +1250,40 @@ class TestCuteBackend(TestCase):
         torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
         self.assertIn("cutlass.Float8E4M3FN", code)
         self.assertIn("cute.nvgpu.tcgen05", code)
+
+    def test_matmul_mma_tcgen05_fp8_register_realloc_toggle(self) -> None:
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = (torch.randn(256, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = (torch.randn(128, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        scale_n = torch.rand(128, device=DEVICE) + 0.5
+        ref = (x.float() @ y.float()) * scale_n.float()
+
+        # Default keeps the producer/consumer setmaxregister split.
+        code_on, out_on = code_and_output(
+            cute_matmul_mma_fp8_rowvec_scale,
+            (x, y, scale_n),
+            block_sizes=[128, 128, 128],
+        )
+        self.assertIn("setmaxregister_increase", code_on)
+        self.assertIn("setmaxregister_decrease", code_on)
+        torch.testing.assert_close(out_on.float(), ref, atol=1.0, rtol=1e-1)
+
+        # register_realloc=False skips both setmaxregister calls so ptxas
+        # picks its natural register count (avoids the bk=128 over-allocation
+        # spill); output must stay identical.
+        code_off, out_off = code_and_output(
+            cute_matmul_mma_fp8_rowvec_scale,
+            (x, y, scale_n),
+            block_sizes=[128, 128, 128],
+            tcgen05_warp_spec_register_realloc=False,
+        )
+        self.assertNotIn("setmaxregister_increase", code_off)
+        self.assertNotIn("setmaxregister_decrease", code_off)
+        torch.testing.assert_close(out_off.float(), ref, atol=1.0, rtol=1e-1)
 
     def test_matmul_dot_out_dtype_falls_back_from_mma(self) -> None:
         args = (


### PR DESCRIPTION
Stacked PRs:
 * __->__#2708
 * #2696


--- --- ---

### [cute] Match CUTLASS on FP8 scaled_mm: bk=128, drop harmful setmaxregister split, K-major B


Brings the Helion CuTe FP8 RowWise scaled_mm to parity with vLLM cutlass /
the standalone CuTe kernel on the 4 Qwen3-1.7B M=512 compute-bound shapes,
and wires it into vLLM's FP8 W8A8 RowWise serving path.

Changes:

1. scaled_mm_cute config: bk 64 -> 128. Mirrors the CUTLASS persistent-GEMM
   mma-tiler K (mma_inst_k=32 x 4), halving the K-loop iteration count and the
   per-iteration pipeline-sync / TMA-issue overhead.

2. New config knob `tcgen05_warp_spec_register_realloc` (default True =
   byte-identical). When False, skips emitting the producer/consumer
   setmaxregister split. That split (producers setmaxregister_decrease to a
   lean budget, consumers setmaxregister_increase(256)) only buys occupancy
   when registers are the occupancy limiter. These deep-pipeline FP8 GEMMs are
   SMEM-limited to 1 CTA/SM, so the increase ceiling instead made ptxas
   over-allocate to 255 reg/thread and spill ~17 KB to local memory at bk=128,
   where the natural allocation fits in ~190 reg with zero spill. scaled_mm
   opts in with realloc=False; all other configs are unchanged.

3. Column-major (K-major) B support in the tcgen05 codegen. B is logically
   [K, N]; the validated path was MN-major (row-major, N-contiguous). CUTLASS
   passes B column-major (K-contiguous), which previously disabled TMA and fell
   to an unvalidated runtime guard. Detect B majorness from strides and emit
   OperandMajorMode.K (vs .MN) for the B operand, the matching make_smem_layout_b
   (auto-derived from the tiled_mma), and the right rhs_tma dynamic leading-dim.
   This makes the Helion-vs-cutlass comparison apples-to-apples (cutlass consumes
   column-major weights directly, no transpose copy).

Diagnosis was confirmed by editing the generated CuTe directly before the
codegen change: deleting the two setmaxregister lines alone took o_proj
1.19x -> 1.04x and dropped the spill 17.5 KB -> 0.

GEMM microbenchmark (idle B200, cudagraph + per-iter L2 flush, Helion/vLLM
ratio, lower is better):

  shape (M=512)        before   after    standalone   col-major B
  qkv 2048x4096        1.25x    1.022x   ~1.03x       1.077x
  o_proj 2048x2048     1.19x    1.040x   1.03x        1.032x
  down_proj 6144x2048  1.40x    0.975x   1.014x       1.076x
  gate_up 2048x12288   1.27x    1.011x   0.995x       1.009x
  avg                  1.26x    1.012x   ~1.02x       1.049x

End-to-end vLLM serving (RedHatAI/Qwen3-1.7B-FP8-dynamic RowWise, 1x B200,
tp=1, vllm bench serve, random in=512/out=600, concurrency=16, num-prompts=160,
--disable-shuffle, fresh server per arm, cudagraph capture). Helion fallbacks=0:

  metric                    cutlass   helion   helion/cutlass
  output tok/s              7500.1    7514.5   1.002x
  total tok/s             13900.2   13926.8   1.002x
  mean TPOT (ms)              2.045    2.048   1.001x
  mean TTFT (ms)             49.21    45.23    0.919x
  median TTFT (ms)           52.80    43.69    0.827x

Throughput/TPOT at parity (the FP8 GEMMs are a modest slice of step time at
1.7B/bs=16); prefill TTFT is meaningfully better (median 52.8->43.7ms, 0.83x)
since prefill is the compute-bound M=512 regime the kernel targets.

All outputs numerically correct (rel_err <= 0.002). The realloc default (True)
and the MN-major B path keep every existing config byte-identical; all 94
test_cute_backend tests pass. Adds
test_matmul_mma_tcgen05_fp8_register_realloc_toggle and
test_matmul_mma_tcgen05_fp8_col_major_b.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
