### PR TITLE
[compiler] Add MemoryOpFact linking loads/stores to metadata

### DIFF
--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -77,6 +77,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
     from collections.abc import Sequence
 
+    from ..autotuner.config_spec import MemoryOpFact
     from .cute.layout import CuTeGridExecutionPlan
 
     class _TLS(Protocol):
@@ -831,7 +832,7 @@ class DeviceIR:
         This is analysis-only: it runs the roller to determine which graphs can
         be rolled, records lightweight RolledReductionInfo entries, and registers
         config_spec entries for the autotuner.  Sub-graphs created by the roller
-        (e.g. ReductionLoopGraphInfo) are kept so that _count_device_loads_and_stores
+        (e.g. ReductionLoopGraphInfo) are kept so that _collect_memory_op_facts
         can account for their loads/stores in the indexing config.
         """
         env = CompileEnvironment.current()
@@ -2195,59 +2196,136 @@ class WalkHostAST(NodeVisitor):
             self.current_phase_roots = []
 
 
-def _count_device_loads_and_stores(
-    device_ir: DeviceIR,
-) -> tuple[int, int, int, list[int]]:
-    """Count the number of load and store operations in device code for autotuning.
+# Matmul/dot FX targets mapped to (lhs_arg_index, rhs_arg_index). Used to tag
+# which load nodes feed a matmul (and as which operand) at the recognition site,
+# instead of scanning every load's downstream users.
+def _matmul_operand_positions() -> dict[object, tuple[int, int]]:
+    from ..language import matmul_ops
 
-    Returns:
-        tuple[int, int, int, list[int]]: (
-            total_load_count,
-            loads_without_eviction_policy,
-            loads_without_cache_modifier,
-            store_indices,
-        )
-            - total_load_count: all loads (for indexing tunable)
-            - loads_without_eviction_policy: loads that need eviction policy tuning
-            - loads_without_cache_modifier: loads that need cache modifier tuning
-            - store_indices: positions of store ops in the combined indexing list
+    return {
+        # mat1=0, mat1_scale=1, mat1_format=2, mat2=3 -> lhs/rhs matrices are 0/3
+        matmul_ops.dot_scaled: (0, 3),
+        matmul_ops.dot: (0, 1),
+        torch.ops.aten.mm.default: (0, 1),
+        torch.ops.aten.bmm.default: (0, 1),
+        torch.ops.aten.addmm.default: (1, 2),
+        torch.ops.aten.baddbmm.default: (1, 2),
+    }
+
+
+def _trace_back_to_load(arg: object, load_op: object) -> torch.fx.Node | None:
+    """Follow a matmul operand back through pass-through ops to its load node.
+
+    Only follows single-input pass-through ops (cast / transpose / view / unary
+    elementwise), so an operand that is a genuine computation of two loads (e.g.
+    ``a[...] + bias[...]``) is left untagged rather than mis-attributed to its
+    first input. Returns the producing ``hl.load`` node, or ``None``.
     """
+    cur = arg
+    for _ in range(8):
+        if not isinstance(cur, torch.fx.Node):
+            return None
+        if cur.target is load_op:
+            return cur
+        tensor_inputs = [
+            a
+            for a in cur.args
+            if isinstance(a, torch.fx.Node)
+            and isinstance(a.meta.get("val"), torch.Tensor)
+        ]
+        if len(tensor_inputs) != 1:
+            return None
+        cur = tensor_inputs[0]
+    return None
+
+
+def _load_needs_eviction_tunable(node: torch.fx.Node) -> bool:
+    """A load gets an eviction-policy slot only when the user did not pass one."""
+    eviction_policy_arg = node.kwargs.get("eviction_policy")
+    if eviction_policy_arg is None and len(node.args) >= 4:
+        eviction_policy_arg = node.args[3]
+    return eviction_policy_arg is None
+
+
+def _accessed_tensor_fake(node: torch.fx.Node) -> torch.Tensor | None:
+    """Fake tensor of the buffer a load/store accesses (``args[0]``)."""
+    arg = node.args[0] if node.args else None
+    if isinstance(arg, torch.fx.Node):
+        val = arg.meta.get("val")
+        if isinstance(val, torch.Tensor):
+            return val
+    return None
+
+
+def _collect_memory_op_facts(device_ir: DeviceIR) -> list[MemoryOpFact]:
+    """Walk every device graph once and record per-load/store metadata.
+
+    Produces one ``MemoryOpFact`` per load/store in the same order used to size
+    ``Config.indexing``, so ``memory_op_facts[i]`` describes
+    ``config.indexing[i]``. This is the single source of truth for load/store
+    counts, eviction slots, and ``store_indices`` (all derived from the result).
+    """
+    from ..autotuner.config_spec import MemoryOpFact
     from ..language import memory_ops
 
-    total_load_count = 0
-    loads_without_eviction_policy = 0
-    loads_without_cache_modifier = 0
+    load_op = memory_ops.load
+    store_op = memory_ops.store
+    operand_positions = _matmul_operand_positions()
+
+    host = HostFunction.current()
+    # Matmul operands always precede their matmul in graph order, so `operands` is
+    # complete by the time we apply it to the (operand-less) facts below.
+    operands: dict[torch.fx.Node, str] = {}
+    records: list[tuple[torch.fx.Node, MemoryOpFact]] = []
     memory_op_index = 0
-    store_indices: list[int] = []
+    eviction_index = 0
 
     for graph_info in device_ir.graphs:
         for node in graph_info.graph.nodes:
-            if node.op == "call_function":
-                # Check if this is a load operation
-                if node.target is memory_ops.load:
-                    total_load_count += 1
-                    memory_op_index += 1
-                    # Check if this load needs eviction policy tuning
-                    # (user can still specify eviction_policy to override tuning)
-                    eviction_policy_arg = node.kwargs.get("eviction_policy")
-                    if eviction_policy_arg is None:
-                        # Check if eviction_policy was passed as positional arg (index 3)
-                        if len(node.args) >= 4:
-                            eviction_policy_arg = node.args[3]
-                        if eviction_policy_arg is None:
-                            loads_without_eviction_policy += 1
-                    loads_without_cache_modifier += 1
-                # Check if this is a store operation
-                elif node.target is memory_ops.store:
-                    store_indices.append(memory_op_index)
-                    memory_op_index += 1
+            if node.op != "call_function":
+                continue
 
-    return (
-        total_load_count,
-        loads_without_eviction_policy,
-        loads_without_cache_modifier,
-        store_indices,
-    )
+            positions = operand_positions.get(node.target)
+            if positions is not None:
+                for arg_index, operand in (
+                    (positions[0], "lhs"),
+                    (positions[1], "rhs"),
+                ):
+                    if arg_index < len(node.args):
+                        load = _trace_back_to_load(node.args[arg_index], load_op)
+                        if load is not None:
+                            operands.setdefault(load, operand)
+                continue
+
+            is_load = node.target is load_op
+            if not (is_load or node.target is store_op):
+                continue
+
+            this_eviction_index: int | None = None
+            if is_load and _load_needs_eviction_tunable(node):
+                this_eviction_index = eviction_index
+                eviction_index += 1
+
+            fake = _accessed_tensor_fake(node)
+            origin = host.tensor_to_origin.get(fake) if fake is not None else None
+            records.append(
+                (
+                    node,
+                    MemoryOpFact(
+                        indexing_index=memory_op_index,
+                        kind="load" if is_load else "store",
+                        eviction_index=this_eviction_index,
+                        tensor_name=origin.root_rw_name() if origin else None,
+                        dtype=fake.dtype if fake is not None else None,
+                        ndim=fake.ndim if fake is not None else 0,
+                        num_reuses=len(node.users) if is_load else 0,
+                        matmul_operand=None,
+                    ),
+                )
+            )
+            memory_op_index += 1
+
+    return [fact._replace(matmul_operand=operands.get(node)) for node, fact in records]
 
 
 def _indexing_uses_tensor_descriptor(
@@ -2463,18 +2541,17 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
                     )
                 config_spec.allowed_pid_types = non_persistent_pid_types
 
-        # Count all device loads and stores and register tunables
-        (
-            total_load_count,
-            loads_without_eviction_policy,
-            loads_without_cache_modifier,
-            store_indices,
-        ) = _count_device_loads_and_stores(device_ir)
+        # Collect per-load/store metadata once; derive the load/store tunables
+        # from it so heuristics can map each Config.indexing slot to its graph op.
+        memory_op_facts = _collect_memory_op_facts(device_ir)
+        config_spec.memory_op_facts = memory_op_facts
+        load_count = sum(f.kind == "load" for f in memory_op_facts)
         _register_load_store_tunables(
-            total_load_count,
-            loads_without_eviction_policy,
-            loads_without_cache_modifier,
-            store_indices,
+            load_count,
+            sum(f.eviction_index is not None for f in memory_op_facts),
+            # cache_modifier is tuned for every load (no per-load override)
+            load_count,
+            [f.indexing_index for f in memory_op_facts if f.kind == "store"],
         )
         _register_atomic_tunables(_count_device_atomics(device_ir))
         _register_tensor_descriptor_layout_guards(device_ir)

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -85,6 +85,29 @@ class MatmulFact(NamedTuple):
     rhs_dtype: torch.dtype
 
 
+class MemoryOpFact(NamedTuple):
+    """Metadata linking one ``Config.indexing`` slot to its graph memory op.
+
+    One entry per load/store, recorded in the same graph-traversal order that
+    sizes ``Config.indexing`` / ``Config.load_eviction_policies`` (see
+    ``_collect_memory_op_facts`` in ``device_ir``), so
+    ``memory_op_facts[i].indexing_index == i`` describes ``config.indexing[i]``.
+
+    Autotuner heuristics use this to reason about *which* load/store a slot is
+    (the row load, a matmul operand, a reused buffer, ...) instead of guessing
+    from a bare positional index.
+    """
+
+    indexing_index: int  # slot in Config.indexing (== position in this list)
+    kind: str  # "load" | "store"
+    eviction_index: int | None  # slot in Config.load_eviction_policies, else None
+    tensor_name: str | None  # host buffer name being accessed, e.g. "x", "weight"
+    dtype: torch.dtype | None  # element dtype of the accessed tensor
+    ndim: int  # rank of the accessed tensor
+    num_reuses: int  # downstream FX consumers of the load (0 for stores)
+    matmul_operand: str | None  # matmul/dot operand: "lhs" | "rhs" | None
+
+
 def shrink_block_sizes_for_numel_constraints(
     constraints: list[TensorNumelConstraint],
     block_sizes: list[int],
@@ -339,6 +362,7 @@ class ConfigSpec:
         self.autotuner_heuristics: list[str] = []
         self.matmul_facts: list[MatmulFact] = []
         self.store_indices: list[int] = []
+        self.memory_op_facts: list[MemoryOpFact] = []
         self.backend_tunable_fragments = self.backend.tunable_fragments()
         unknown_tunables = set(self.backend_tunable_fragments) - BACKEND_TUNABLE_KEYS
         if unknown_tunables:

--- a/test/test_barrier.py
+++ b/test/test_barrier.py
@@ -283,7 +283,7 @@ class TestBarrier(RefEagerTestBase, TestCase):
             device_ir.register_rollable_reductions()
 
         # Sub-graphs (ReductionLoopGraphInfo) are kept so that
-        # _count_device_loads_and_stores can account for their loads/stores.
+        # _collect_memory_op_facts can account for their loads/stores.
         self.assertEqual(len(device_ir.graphs), original_graph_count + 1)
         self.assertEqual(len(device_ir.rolled_reductions), 1)
         self.assertEqual(len(fake_env.config_spec.reduction_loops), 1)

--- a/test/test_memory_op_facts.py
+++ b/test/test_memory_op_facts.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import RefEagerTestBase
+from helion._testing import TestCase
+from helion._testing import onlyBackends
+from helion._testing import skipIfNotCUDA
+from helion._testing import skipIfRefEager
+import helion.language as hl
+
+
+@helion.kernel
+def add_kernel(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.shape):
+        out[tile] = x[tile] + y[tile]
+    return out
+
+
+@helion.kernel
+def matmul_kernel(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    m, k = a.shape
+    _, n = b.shape
+    out = torch.empty([m, n], dtype=a.dtype, device=a.device)
+    for tm, tn in hl.tile([m, n]):
+        acc = hl.zeros([tm, tn], dtype=torch.float32)
+        for tk in hl.tile(k):
+            acc = hl.dot(a[tm, tk], b[tk, tn], acc=acc)
+        out[tm, tn] = acc
+    return out
+
+
+@skipIfRefEager("config spec inspection is not applicable in ref eager mode")
+class TestMemoryOpFacts(RefEagerTestBase, TestCase):
+    def test_specs_align_with_indexing_list(self):
+        x = torch.randn([256, 256], device=DEVICE, dtype=torch.float32)
+        spec = add_kernel.bind((x, x.clone())).config_spec
+        specs = spec.memory_op_facts
+
+        # One spec per indexing slot, in slot order.
+        self.assertEqual(len(specs), spec.indexing.length)
+        self.assertEqual([s.indexing_index for s in specs], list(range(len(specs))))
+
+        # store_indices and eviction list length are derived from the same specs.
+        self.assertEqual(
+            spec.store_indices,
+            [s.indexing_index for s in specs if s.kind == "store"],
+        )
+        self.assertEqual(
+            spec.load_eviction_policies.length,
+            sum(1 for s in specs if s.eviction_index is not None),
+        )
+
+    def test_load_store_metadata(self):
+        x = torch.randn([256, 256], device=DEVICE, dtype=torch.float32)
+        specs = add_kernel.bind((x, x.clone())).config_spec.memory_op_facts
+
+        self.assertEqual([s.kind for s in specs], ["load", "load", "store"])
+        self.assertEqual([s.tensor_name for s in specs], ["x", "y", "out"])
+        # Loads get sequential eviction slots; stores get none.
+        self.assertEqual([s.eviction_index for s in specs], [0, 1, None])
+        for s in specs:
+            self.assertEqual(s.dtype, torch.float32)
+            self.assertEqual(s.ndim, 2)
+        # Both loads are consumed downstream; the store has no users.
+        loads = [s for s in specs if s.kind == "load"]
+        self.assertTrue(all(s.num_reuses >= 1 for s in loads))
+
+    def test_matmul_operand_roles(self):
+        a = torch.randn([256, 128], device=DEVICE, dtype=torch.float32)
+        b = torch.randn([128, 64], device=DEVICE, dtype=torch.float32)
+        specs = matmul_kernel.bind((a, b)).config_spec.memory_op_facts
+
+        operands = {s.tensor_name: s.matmul_operand for s in specs if s.kind == "load"}
+        self.assertEqual(operands.get("a"), "lhs")
+        self.assertEqual(operands.get("b"), "rhs")
+        # The output store is not a matmul operand.
+        stores = [s for s in specs if s.kind == "store"]
+        self.assertTrue(all(s.matmul_operand is None for s in stores))
+
+    def test_computed_operand_is_not_tagged(self):
+        """An operand computed from two loads (a + c) must not be mis-attributed
+        to its first input; only the direct rhs load is tagged."""
+
+        @helion.kernel
+        def mm_bias(a: torch.Tensor, c: torch.Tensor, b: torch.Tensor):
+            m, k = a.shape
+            _, n = b.shape
+            out = torch.empty([m, n], dtype=a.dtype, device=a.device)
+            for tm, tn in hl.tile([m, n]):
+                acc = hl.zeros([tm, tn], dtype=torch.float32)
+                for tk in hl.tile(k):
+                    acc = hl.dot(a[tm, tk] + c[tm, tk], b[tk, tn], acc=acc)
+                out[tm, tn] = acc
+            return out
+
+        a = torch.randn([128, 64], device=DEVICE, dtype=torch.float32)
+        c = torch.randn([128, 64], device=DEVICE, dtype=torch.float32)
+        b = torch.randn([64, 32], device=DEVICE, dtype=torch.float32)
+        specs = mm_bias.bind((a, c, b)).config_spec.memory_op_facts
+
+        operands = {s.tensor_name: s.matmul_operand for s in specs if s.kind == "load"}
+        self.assertIsNone(operands.get("a"))
+        self.assertIsNone(operands.get("c"))
+        self.assertEqual(operands.get("b"), "rhs")
+
+    @skipIfNotCUDA()
+    @onlyBackends(["triton"])
+    def test_dot_scaled_operand_roles(self):
+        """dot_scaled's rhs matrix is arg 3 (mat2), not arg 1 (mat1_scale)."""
+
+        @helion.kernel(config=helion.Config(block_sizes=[32, 32]))
+        def scaled(x, x_scale, y, y_scale):
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=torch.float32, device=x.device)
+            for tm, tn in hl.tile([m, n]):
+                out[tm, tn] = hl.dot_scaled(
+                    x[tm, :], x_scale[tm, :], "e4m3", y[:, tn], y_scale[tn, :], "e4m3"
+                )
+            return out
+
+        scale_factor = 32
+        x = torch.randn([64, 64], device=DEVICE, dtype=torch.float16)
+        x_scale = torch.full(
+            [64, 64 // scale_factor], 127, device=DEVICE, dtype=torch.uint8
+        )
+        y = torch.randn([64, 64], device=DEVICE, dtype=torch.float16)
+        y_scale = torch.full(
+            [64, 64 // scale_factor], 127, device=DEVICE, dtype=torch.uint8
+        )
+        specs = scaled.bind((x, x_scale, y, y_scale)).config_spec.memory_op_facts
+
+        operands = {s.tensor_name: s.matmul_operand for s in specs if s.kind == "load"}
+        self.assertEqual(operands.get("x"), "lhs")
+        self.assertEqual(operands.get("y"), "rhs")
+        # The scale operands are not matmul matrices.
+        self.assertIsNone(operands.get("x_scale"))
+        self.assertIsNone(operands.get("y_scale"))
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
List-valued config parameters for loads/stores (e.g. indexing and load_eviction_policies )are stored as flat positional lists: config.indexing[i] is "the strategy for the i-th memory op in graph order," with no record of which load/store that is. This loses information the autotuner/compiler could use. Today the heuristics work around it by guessing from list structure:

  - cute.py assumes indexing.length == 3 means "A/B/C" and bails on fused epilogues because it can't tell which slot is which.
  - triton.py applies eviction uniformly (["last"] * eviction.length) because it can't target a specific load.

This PR records per-load/store metadata alongside those lists as `MemoryOpFact` so heuristics (and future tooling) can reason about the meaning of a slot — "the weight load, reused 4×, feeding the matmul as rhs" — instead of a bare index.

  - _count_device_loads_and_stores is replaced by _collect_memory_op_facts, a single compile-time pass. store_indices, the eviction-list length, and the indexing-list length are now derived from the facts
  list — so store_indices stays byte-identical and there's no change to the tunables themselves or the generated code.
  - role is tagged by walking backward from hl.dot / aten.mm / bmm / addmm nodes to the producing load (cheap; O(#matmuls)), only through single-input pass-through ops (cast/transpose/view). Intentionally does not tag operands computed from multiple tensor inputs, such as a[...] + bias[...], to avoid misattributing the first input load.
  -num_reuses is len(node.users), so it is an FX graph use count. num_reuses is not a direct measure of cache reuse, loop reuse, memory traffic, or runtime access frequency.

Here's the metadata stored in a `MemoryOpFact`
Field | Meaning
-- | --
indexing_index | Slot into config.indexing (corresponds to its position in the list).
kind | The operation type: "load" / "store".
eviction_index | Slot into config.load_eviction_policies, or None.
tensor_name | Host buffer name (e.g., x, weight, etc.).
dtype, ndim | Element data type and rank (dimensionality) of the accessed tensor.
num_reuses | Downstream FX consumers of a "load" operation.
matmul_operand | Matmul operand role: "lhs" / "rhs" / None.

@calebmkim this may be helpful for determining the eviction policy