### PR TITLE
[triton][AMD] Enable load cache modifier autotuning

### DIFF
--- a/helion/_compiler/_inductor/template_buffer.py
+++ b/helion/_compiler/_inductor/template_buffer.py
@@ -730,6 +730,7 @@ class HelionTemplateBuffer(TemplateBuffer):
         subscript: list[object],
         extra_mask: ast.expr | None,
         eviction_policy: ast.AST | None,
+        cache_modifier: ast.AST | None,
         codegen_load: Callable[..., ast.expr],
         *,
         prologue_first_indexing: dict[str, str],
@@ -748,7 +749,12 @@ class HelionTemplateBuffer(TemplateBuffer):
         param_name = state.device_function.tensor_arg(tensor).name
         if param_name not in self._fusion_metadata.prologue_fused_params:
             return codegen_load(
-                state, tensor, [*subscript], extra_mask, eviction_policy
+                state,
+                tensor,
+                [*subscript],
+                extra_mask,
+                eviction_policy,
+                cache_modifier,
             )
 
         # Read prologue variable names from kernel (set by _setup_prologue_hook).

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -939,6 +939,8 @@ class TritonBackend(Backend):
         return False
 
     def supports_config_key(self, key: str) -> bool:
+        if key == "load_cache_modifiers":
+            return True
         if key == "waves_per_eu":
             from .._compat import is_hip
 

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -315,6 +315,7 @@ class DeviceFunction:
 
         self.rng_seed_count = 0
         self.device_load_index = 0
+        self.device_load_cache_modifier_index = 0
         self.device_store_index = 0
         # Single counter for both loads and stores for indexing assignment
         self.device_memory_op_index = 0

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -2197,23 +2197,26 @@ class WalkHostAST(NodeVisitor):
 
 def _count_device_loads_and_stores(
     device_ir: DeviceIR,
-) -> tuple[int, int, list[int]]:
+) -> tuple[int, int, int, list[int]]:
     """Count the number of load and store operations in device code for autotuning.
 
     Returns:
-        tuple[int, int, list[int]]: (
+        tuple[int, int, int, list[int]]: (
             total_load_count,
             loads_without_eviction_policy,
+            loads_without_cache_modifier,
             store_indices,
         )
             - total_load_count: all loads (for indexing tunable)
             - loads_without_eviction_policy: loads that need eviction policy tuning
+            - loads_without_cache_modifier: loads that need cache modifier tuning
             - store_indices: positions of store ops in the combined indexing list
     """
     from ..language import memory_ops
 
     total_load_count = 0
     loads_without_eviction_policy = 0
+    loads_without_cache_modifier = 0
     memory_op_index = 0
     store_indices: list[int] = []
 
@@ -2233,6 +2236,7 @@ def _count_device_loads_and_stores(
                             eviction_policy_arg = node.args[3]
                         if eviction_policy_arg is None:
                             loads_without_eviction_policy += 1
+                    loads_without_cache_modifier += 1
                 # Check if this is a store operation
                 elif node.target is memory_ops.store:
                     store_indices.append(memory_op_index)
@@ -2241,6 +2245,7 @@ def _count_device_loads_and_stores(
     return (
         total_load_count,
         loads_without_eviction_policy,
+        loads_without_cache_modifier,
         store_indices,
     )
 
@@ -2274,13 +2279,15 @@ def _count_device_atomics(device_ir: DeviceIR) -> int:
 def _register_load_store_tunables(
     total_load_count: int,
     loads_without_eviction_policy: int,
+    loads_without_cache_modifier: int,
     store_indices: list[int],
 ) -> None:
-    """Register list-based tunables (indexing, eviction policies) for all device loads and stores.
+    """Register list-based tunables for device loads and stores.
 
     Args:
         total_load_count: Total number of loads (for indexing tunable)
         loads_without_eviction_policy: Number of loads that need eviction policy tuning
+        loads_without_cache_modifier: Number of loads that need cache modifier tuning
         store_indices: Positions of store ops in the combined indexing list
     """
     store_count = len(store_indices)
@@ -2292,12 +2299,22 @@ def _register_load_store_tunables(
     from ..autotuner.config_fragment import EnumFragment
     from ..autotuner.config_fragment import ListOf
     from ..autotuner.config_spec import get_valid_eviction_policies
+    from ..autotuner.config_spec import get_valid_load_cache_modifiers
 
     # Register eviction policies only for loads without explicit eviction_policy
     if loads_without_eviction_policy > 0:
         env.config_spec.load_eviction_policies = ListOf(
             EnumFragment(choices=get_valid_eviction_policies(env.backend_name)),
             length=loads_without_eviction_policy,
+        )
+
+    # Register cache modifiers only for loads and only when the backend has
+    # a non-trivial search space.
+    load_cache_modifier_choices = get_valid_load_cache_modifiers(env.backend_name)
+    if loads_without_cache_modifier > 0 and len(load_cache_modifier_choices) > 1:
+        env.config_spec.load_cache_modifiers = ListOf(
+            EnumFragment(choices=load_cache_modifier_choices),
+            length=loads_without_cache_modifier,
         )
 
     # Indexing applies to ALL loads and stores
@@ -2450,11 +2467,13 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
         (
             total_load_count,
             loads_without_eviction_policy,
+            loads_without_cache_modifier,
             store_indices,
         ) = _count_device_loads_and_stores(device_ir)
         _register_load_store_tunables(
             total_load_count,
             loads_without_eviction_policy,
+            loads_without_cache_modifier,
             store_indices,
         )
         _register_atomic_tunables(_count_device_atomics(device_ir))

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -197,6 +197,7 @@ class IndexingStrategy:
         subscript: list[object],
         extra_mask: ast.AST | None,
         eviction_policy: ast.AST | None,
+        cache_modifier: ast.AST | None,
     ) -> ast.AST:
         raise NotImplementedError
 
@@ -245,6 +246,7 @@ class PointerIndexingStrategy(IndexingStrategy):
         subscript: list[object],
         extra_mask: ast.AST | None,
         eviction_policy: ast.AST | None,
+        cache_modifier: ast.AST | None,
     ) -> ast.AST:
         indexing = SubscriptIndexing.create(state, fake_tensor, subscript, extra_mask)
         extra = ""
@@ -257,12 +259,14 @@ class PointerIndexingStrategy(IndexingStrategy):
                 extra = ", other=0"
         name = state.device_function.tensor_arg(fake_tensor).name
         extra += ", eviction_policy={ev}" if eviction_policy is not None else ""
+        extra += ", cache_modifier={cm}" if cache_modifier is not None else ""
         load_expr = expr_from_string(
             f"tl.load({name} + {{offset}}, {{mask}}{extra})",
             offset=indexing.index_expr,
             mask=indexing.mask_expr,
             # pyrefly: ignore [bad-argument-type]
             ev=eviction_policy,
+            cm=cache_modifier,
         )
         # If any dimensions need broadcasting from size-1 to block_size, apply broadcast_to
         if indexing.needs_broadcast():
@@ -390,13 +394,21 @@ class BlockPtrIndexingStrategy(IndexingStrategy):
         subscript: list[object],
         extra_mask: ast.AST | None,
         eviction_policy: ast.AST | None,
+        cache_modifier: ast.AST | None,
     ) -> ast.AST:
         if not BlockedSubscriptIndexing.is_supported(state, fake_tensor, subscript):
             return PointerIndexingStrategy().codegen_load(
-                state, fake_tensor, subscript, extra_mask, eviction_policy
+                state,
+                fake_tensor,
+                subscript,
+                extra_mask,
+                eviction_policy,
+                cache_modifier,
             )
         indexing = BlockedSubscriptIndexing.create(state, fake_tensor, subscript)
-        extra = ", eviction_policy={ev}" if eviction_policy is not None else ""
+        extra = ""
+        extra += ", eviction_policy={ev}" if eviction_policy is not None else ""
+        extra += ", cache_modifier={cm}" if cache_modifier is not None else ""
         result = indexing.reshape_load(
             state,
             expr_from_string(
@@ -404,6 +416,7 @@ class BlockPtrIndexingStrategy(IndexingStrategy):
                 block_ptr=indexing.make_block_ptr(state),
                 # pyrefly: ignore [bad-argument-type]
                 ev=eviction_policy,
+                cm=cache_modifier,
             ),
         )
 
@@ -588,10 +601,16 @@ class TensorDescriptorIndexingStrategy(IndexingStrategy):
         subscript: list[object],
         extra_mask: ast.AST | None,
         eviction_policy: ast.AST | None,
+        cache_modifier: ast.AST | None,
     ) -> ast.AST:
         if not self.is_supported(state, fake_tensor, subscript):
             return PointerIndexingStrategy().codegen_load(
-                state, fake_tensor, subscript, extra_mask, eviction_policy
+                state,
+                fake_tensor,
+                subscript,
+                extra_mask,
+                eviction_policy,
+                cache_modifier,
             )
         indexing = BlockedSubscriptIndexing.create(state, fake_tensor, subscript)
 
@@ -790,6 +809,7 @@ class StackIndexingStrategy:
         subscript: list[object],
         extra_mask: ast.AST | None,
         eviction_policy: ast.AST | None,
+        cache_modifier: ast.AST | None,
     ) -> ast.AST:
         tensor_like, dev_ptrs = stack_tensor
         indexing = SubscriptIndexing.create(state, tensor_like, subscript, extra_mask)
@@ -812,6 +832,7 @@ class StackIndexingStrategy:
 
         dtype = triton_type(tensor_like.dtype)
         extra += ", eviction_policy={ev}" if eviction_policy is not None else ""
+        extra += ", cache_modifier={cm}" if cache_modifier is not None else ""
         return expr_from_string(
             f"tl.load(({{base}}.to(tl.pointer_type({dtype}))){stack_broadcast} + ({{offset}}){tensor_broadcast}, {{mask}}{extra})",
             base=dev_ptrs_ast,
@@ -819,6 +840,7 @@ class StackIndexingStrategy:
             mask=mask_expr,
             # pyrefly: ignore [bad-argument-type]
             ev=eviction_policy,
+            cm=cache_modifier,
         )
 
     @staticmethod

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -260,13 +260,17 @@ class PointerIndexingStrategy(IndexingStrategy):
         name = state.device_function.tensor_arg(fake_tensor).name
         extra += ", eviction_policy={ev}" if eviction_policy is not None else ""
         extra += ", cache_modifier={cm}" if cache_modifier is not None else ""
+        load_placeholders: dict[str, ast.AST] = {
+            "offset": indexing.index_expr,
+            "mask": indexing.mask_expr,
+        }
+        if eviction_policy is not None:
+            load_placeholders["ev"] = eviction_policy
+        if cache_modifier is not None:
+            load_placeholders["cm"] = cache_modifier
         load_expr = expr_from_string(
             f"tl.load({name} + {{offset}}, {{mask}}{extra})",
-            offset=indexing.index_expr,
-            mask=indexing.mask_expr,
-            # pyrefly: ignore [bad-argument-type]
-            ev=eviction_policy,
-            cm=cache_modifier,
+            **load_placeholders,
         )
         # If any dimensions need broadcasting from size-1 to block_size, apply broadcast_to
         if indexing.needs_broadcast():
@@ -409,14 +413,18 @@ class BlockPtrIndexingStrategy(IndexingStrategy):
         extra = ""
         extra += ", eviction_policy={ev}" if eviction_policy is not None else ""
         extra += ", cache_modifier={cm}" if cache_modifier is not None else ""
+        load_placeholders: dict[str, ast.AST] = {
+            "block_ptr": indexing.make_block_ptr(state)
+        }
+        if eviction_policy is not None:
+            load_placeholders["ev"] = eviction_policy
+        if cache_modifier is not None:
+            load_placeholders["cm"] = cache_modifier
         result = indexing.reshape_load(
             state,
             expr_from_string(
                 f"tl.load({{block_ptr}}, boundary_check={indexing.boundary_check(state)}, padding_option='zero'{extra})",
-                block_ptr=indexing.make_block_ptr(state),
-                # pyrefly: ignore [bad-argument-type]
-                ev=eviction_policy,
-                cm=cache_modifier,
+                **load_placeholders,
             ),
         )
 
@@ -833,14 +841,18 @@ class StackIndexingStrategy:
         dtype = triton_type(tensor_like.dtype)
         extra += ", eviction_policy={ev}" if eviction_policy is not None else ""
         extra += ", cache_modifier={cm}" if cache_modifier is not None else ""
+        load_placeholders: dict[str, ast.AST] = {
+            "base": dev_ptrs_ast,
+            "offset": indexing.index_expr,
+            "mask": mask_expr,
+        }
+        if eviction_policy is not None:
+            load_placeholders["ev"] = eviction_policy
+        if cache_modifier is not None:
+            load_placeholders["cm"] = cache_modifier
         return expr_from_string(
             f"tl.load(({{base}}.to(tl.pointer_type({dtype}))){stack_broadcast} + ({{offset}}){tensor_broadcast}, {{mask}}{extra})",
-            base=dev_ptrs_ast,
-            offset=indexing.index_expr,
-            mask=mask_expr,
-            # pyrefly: ignore [bad-argument-type]
-            ev=eviction_policy,
-            cm=cache_modifier,
+            **load_placeholders,
         )
 
     @staticmethod

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -160,6 +160,7 @@ BACKEND_SPECIFIC_KEYS: frozenset[str] = (
     | {
         "num_threads",
         "cute_vector_widths",
+        "load_cache_modifiers",
         "pallas_loop_type",
         "pallas_pre_broadcast",
     }
@@ -186,6 +187,7 @@ VALID_KEYS: frozenset[str] = frozenset(
         "indexing",
         "atomic_indexing",
         "load_eviction_policies",
+        "load_cache_modifiers",
         "pallas_loop_type",
         "pallas_pre_broadcast",
         "cute_vector_widths",
@@ -244,6 +246,12 @@ _CUTE_IMPLICIT_DEFAULT_KEYS: frozenset[str] = frozenset(
 def get_valid_eviction_policies(backend_name: str) -> tuple[str, ...]:
     if backend_name == "triton" and not supports_amd_cdna_tunables():
         return ("", "first", "last")
+    return ("",)
+
+
+def get_valid_load_cache_modifiers(backend_name: str) -> tuple[str, ...]:
+    if backend_name == "triton" and supports_amd_cdna_tunables():
+        return ("", ".cg")
     return ("",)
 
 
@@ -306,6 +314,10 @@ class ConfigSpec:
         self.tensor_numel_constraints: list[TensorNumelConstraint] = []
         self.load_eviction_policies = ListOf(
             EnumFragment(choices=get_valid_eviction_policies(self.backend_name)),
+            length=0,
+        )
+        self.load_cache_modifiers = ListOf(
+            EnumFragment(choices=get_valid_load_cache_modifiers(self.backend_name)),
             length=0,
         )
         self.indexing = ListOf(
@@ -982,6 +994,7 @@ class ConfigSpec:
             "range_flattens",
             "static_ranges",
             "load_eviction_policies",
+            "load_cache_modifiers",
             "indexing",
             "atomic_indexing",
         ):
@@ -993,6 +1006,7 @@ class ConfigSpec:
             "num_warps",
             "num_stages",
             "load_eviction_policies",
+            "load_cache_modifiers",
             "indexing",
             "atomic_indexing",
             "pid_type",
@@ -1009,6 +1023,13 @@ class ConfigSpec:
         if self.supports_config_key("load_eviction_policies"):
             config.setdefault(
                 "load_eviction_policies", self.load_eviction_policies.default()
+            )
+        if (
+            self.supports_config_key("load_cache_modifiers")
+            and self.load_cache_modifiers.length > 0
+        ):
+            config.setdefault(
+                "load_cache_modifiers", self.load_cache_modifiers.default()
             )
         if self.supports_config_key("indexing"):
             config.setdefault("indexing", self.indexing.default())
@@ -1429,6 +1450,11 @@ class ConfigSpec:
             )
         if self.supports_config_key("load_eviction_policies"):
             fields["load_eviction_policies"] = self.load_eviction_policies
+        if (
+            self.supports_config_key("load_cache_modifiers")
+            and self.load_cache_modifiers.length > 0
+        ):
+            fields["load_cache_modifiers"] = self.load_cache_modifiers
         if self.supports_config_key("num_threads"):
             fields["num_threads"] = self.num_threads
         if is_tileir:
@@ -1546,6 +1572,7 @@ class ConfigSpec:
             "range_flattens",
             "static_ranges",
             "load_eviction_policies",
+            "load_cache_modifiers",
             "indexing",
             "atomic_indexing",
         ):

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -6212,6 +6212,14 @@ def _(state: CodegenState) -> ast.AST:
         assert isinstance(eviction_policy, str)
         eviction_policy = ast.Constant(value=eviction_policy)
 
+    cache_modifier = None
+    if state.codegen.on_device:
+        modifier_idx = device_fn.device_load_cache_modifier_index
+        device_fn.device_load_cache_modifier_index += 1
+        modifiers = state.config.load_cache_modifiers
+        if modifier_idx < len(modifiers) and modifiers[modifier_idx]:
+            cache_modifier = ast.Constant(value=modifiers[modifier_idx])
+
     if isinstance(tensor, torch.Tensor):
         tile_index_result = _maybe_materialize_tile_index_load(state, tensor, subscript)
         if tile_index_result is not None:
@@ -6229,11 +6237,12 @@ def _(state: CodegenState) -> ast.AST:
                 [*subscript],
                 extra_mask,
                 eviction_policy,
+                cache_modifier,
                 strategy.codegen_load,
             )
 
         return strategy.codegen_load(
-            state, tensor, [*subscript], extra_mask, eviction_policy
+            state, tensor, [*subscript], extra_mask, eviction_policy, cache_modifier
         )
     if isinstance(tensor, tuple):
         from .._compiler.indexing_strategy import StackIndexingStrategy
@@ -6245,7 +6254,13 @@ def _(state: CodegenState) -> ast.AST:
         assert len(stack_tensor_ast) == 2
         tensor_like_ast, dev_ptrs_ast = stack_tensor_ast
         return StackIndexingStrategy.codegen_load(
-            state, tensor, dev_ptrs_ast, [*subscript], extra_mask, eviction_policy
+            state,
+            tensor,
+            dev_ptrs_ast,
+            [*subscript],
+            extra_mask,
+            eviction_policy,
+            cache_modifier,
         )
     raise NotImplementedError(f"Unsupported tensor type: {type(tensor)}")
 
@@ -6286,7 +6301,7 @@ def _(state: CodegenState) -> ast.AST:
         device_fn.device_memory_op_index += 1
         strategy = device_fn.get_indexing_strategy(indexing_idx)
         return strategy.codegen_load(
-            state, tensor, [*subscript], extra_mask, eviction_policy
+            state, tensor, [*subscript], extra_mask, eviction_policy, None
         )
     raise exc.BackendUnsupported("metal", f"load tensor type: {type(tensor)}")
 

--- a/helion/runtime/config.py
+++ b/helion/runtime/config.py
@@ -17,6 +17,7 @@ PidTypeLiteral = Literal[
     "persistent_interleaved",
 ]
 EvictionPolicyLiteral = Literal["", "first", "last"]
+LoadCacheModifierLiteral = Literal["", ".cg"]
 NumSmMultiplierLiteral = Literal[1, 2, 4, 8]
 MaxnregLiteral = Literal[32, 64, 128, 256] | None
 
@@ -41,6 +42,7 @@ class Config(Mapping[str, object]):
         range_flattens: list[bool | None] | None = None,
         static_ranges: list[bool] | None = None,
         load_eviction_policies: list[EvictionPolicyLiteral] | None = None,
+        load_cache_modifiers: list[LoadCacheModifierLiteral] | None = None,
         num_warps: int | None = None,
         num_stages: int | None = None,
         pid_type: PidTypeLiteral | None = None,
@@ -69,6 +71,7 @@ class Config(Mapping[str, object]):
             range_flattens: Controls flatten parameter for tl.range calls.
             static_ranges: Whether to use tl.static_range instead tl.range.
             load_eviction_policies: Eviction policies for load operations ("", "first", "last").
+            load_cache_modifiers: Cache modifiers for load operations ("", ".cg").
             num_warps: Number of warps per block.
             num_stages: Number of stages for software pipelining.
             pid_type: Program ID type strategy ("flat", "xyz", "persistent_blocked", "persistent_interleaved").
@@ -107,6 +110,7 @@ class Config(Mapping[str, object]):
             "range_flattens": range_flattens,
             "static_ranges": static_ranges,
             "load_eviction_policies": load_eviction_policies,
+            "load_cache_modifiers": load_cache_modifiers,
             "num_warps": num_warps,
             "num_stages": num_stages,
             "indexing": indexing,
@@ -304,6 +308,13 @@ class Config(Mapping[str, object]):
     def load_eviction_policies(self) -> list[EvictionPolicyLiteral]:
         return cast(
             "list[EvictionPolicyLiteral]", self.config.get("load_eviction_policies", [])
+        )
+
+    @property
+    def load_cache_modifiers(self) -> list[LoadCacheModifierLiteral]:
+        return cast(
+            "list[LoadCacheModifierLiteral]",
+            self.config.get("load_cache_modifiers", []),
         )
 
     @property

--- a/test/test_cache_modifier.py
+++ b/test/test_cache_modifier.py
@@ -17,7 +17,7 @@ import helion.language as hl
 
 
 @onlyBackends(["triton"])
-class TestLoadCacheModifierAutotune(RefEagerTestBase, TestCase):
+class TestCacheModifier(RefEagerTestBase, TestCase):
     @skipIfRefEager("Config spec inspection not applicable in ref eager mode")
     @skipIfTileIR("tileir backend will ignore `cache_modifier` hint")
     def test_autotune_load_cache_modifier_registered_for_amd(self):

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -85,9 +85,7 @@ def _known_keys_strategy() -> st.SearchStrategy[dict[str, Any]]:
             "load_eviction_policies": st.lists(
                 st.sampled_from(["", "first", "last"]), max_size=4
             ),
-            "load_cache_modifiers": st.lists(
-                st.sampled_from(["", ".cg"]), max_size=4
-            ),
+            "load_cache_modifiers": st.lists(st.sampled_from(["", ".cg"]), max_size=4),
             "num_warps": st.integers(min_value=1, max_value=64),
             "num_stages": st.integers(min_value=1, max_value=16),
             "pid_type": st.sampled_from(

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -85,6 +85,9 @@ def _known_keys_strategy() -> st.SearchStrategy[dict[str, Any]]:
             "load_eviction_policies": st.lists(
                 st.sampled_from(["", "first", "last"]), max_size=4
             ),
+            "load_cache_modifiers": st.lists(
+                st.sampled_from(["", ".cg"]), max_size=4
+            ),
             "num_warps": st.integers(min_value=1, max_value=64),
             "num_stages": st.integers(min_value=1, max_value=16),
             "pid_type": st.sampled_from(
@@ -116,6 +119,7 @@ def _unknown_keys_strategy() -> st.SearchStrategy[dict[str, Any]]:
                     "range_flattens",
                     "static_ranges",
                     "load_eviction_policies",
+                    "load_cache_modifiers",
                     "num_warps",
                     "num_stages",
                     "pid_type",
@@ -173,6 +177,7 @@ class TestConfigAPI(TestCase):
             "range_flattens",
             "static_ranges",
             "load_eviction_policies",
+            "load_cache_modifiers",
             "num_warps",
             "num_stages",
             "pid_type",
@@ -728,6 +733,25 @@ class TestHardwareConfigSpecRanges(TestCase):
             nvidia_spec.load_eviction_policies.inner.choices,
             ("", "first", "last"),
         )
+
+    def test_load_cache_modifier_choices_do_not_leak_mocked_amd_state(self) -> None:
+        """Mocked AMD capability detection should not poison later Triton specs."""
+        from helion._compiler.backend import TritonBackend
+        from helion.autotuner.config_spec import ConfigSpec
+
+        with patch(
+            "helion.autotuner.config_spec.supports_amd_cdna_tunables",
+            return_value=True,
+        ):
+            amd_spec = ConfigSpec(backend=TritonBackend())
+        self.assertEqual(amd_spec.load_cache_modifiers.inner.choices, ("", ".cg"))
+
+        with patch(
+            "helion.autotuner.config_spec.supports_amd_cdna_tunables",
+            return_value=False,
+        ):
+            nvidia_spec = ConfigSpec(backend=TritonBackend())
+        self.assertEqual(nvidia_spec.load_cache_modifiers.inner.choices, ("",))
 
 
 class TestCuteTcgen05ConfigSpecSplit(TestCase):

--- a/test/test_load_cache_modifier_autotune.py
+++ b/test/test_load_cache_modifier_autotune.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from unittest import mock
+import unittest
+
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import RefEagerTestBase
+from helion._testing import TestCase
+from helion._testing import code_and_output
+from helion._testing import onlyBackends
+from helion._testing import skipIfRefEager
+from helion._testing import skipIfTileIR
+import helion.language as hl
+
+
+@onlyBackends(["triton"])
+class TestLoadCacheModifierAutotune(RefEagerTestBase, TestCase):
+    @skipIfRefEager("Config spec inspection not applicable in ref eager mode")
+    @skipIfTileIR("tileir backend will ignore `cache_modifier` hint")
+    def test_autotune_load_cache_modifier_registered_for_amd(self):
+        @helion.kernel
+        def kernel_with_loads_and_store(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                val_x = hl.load(x, [tile])
+                val_y = hl.load(y, [tile])
+                hl.store(out, [tile], val_x + val_y)
+            return out
+
+        x = torch.randn([128], device=DEVICE, dtype=torch.float32)
+        y = torch.randn([128], device=DEVICE, dtype=torch.float32)
+
+        with mock.patch(
+            "helion.autotuner.config_spec.supports_amd_cdna_tunables",
+            return_value=True,
+        ):
+            bound_kernel = kernel_with_loads_and_store.bind((x, y))
+
+        fragment = bound_kernel.config_spec.load_cache_modifiers
+        self.assertEqual(fragment.length, 2)
+        self.assertEqual(fragment.inner.choices, ("", ".cg"))
+
+    @skipIfRefEager("Config spec inspection not applicable in ref eager mode")
+    @skipIfTileIR("tileir backend will ignore `cache_modifier` hint")
+    def test_load_cache_modifier_not_registered_without_backend_choices(self):
+        @helion.kernel
+        def kernel_with_loads(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = hl.load(x, [tile]) + hl.load(y, [tile])
+            return out
+
+        x = torch.randn([128], device=DEVICE, dtype=torch.float32)
+        y = torch.randn([128], device=DEVICE, dtype=torch.float32)
+
+        with mock.patch(
+            "helion.autotuner.config_spec.supports_amd_cdna_tunables",
+            return_value=False,
+        ):
+            bound_kernel = kernel_with_loads.bind((x, y))
+
+        self.assertEqual(bound_kernel.config_spec.load_cache_modifiers.length, 0)
+
+    @skipIfTileIR("tileir backend will ignore `cache_modifier` hint")
+    def test_configured_load_cache_modifier_emitted(self):
+        @helion.kernel(
+            config={
+                "block_size": 16,
+                "indexing": "pointer",
+                "load_cache_modifiers": [".cg", ""],
+            }
+        )
+        def kernel_with_configured_modifier(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                val_x = hl.load(x, [tile])
+                val_y = hl.load(y, [tile])
+                out[tile] = val_x + val_y
+            return out
+
+        x = torch.randn([128], device=DEVICE, dtype=torch.float32)
+        y = torch.randn([128], device=DEVICE, dtype=torch.float32)
+
+        with mock.patch(
+            "helion.autotuner.config_spec.supports_amd_cdna_tunables",
+            return_value=True,
+        ):
+            code, result = code_and_output(kernel_with_configured_modifier, (x, y))
+
+        torch.testing.assert_close(result, x + y)
+        self.assertIn("cache_modifier", code)
+        self.assertIn(".cg", code)
+        self.assertNotIn("cache_modifier=''", code)
+
+    @skipIfTileIR("tileir backend will ignore `cache_modifier` hint")
+    def test_default_load_cache_modifier_config_is_elided(self):
+        @helion.kernel(config={"block_size": 16, "indexing": "pointer"})
+        def kernel_with_default_modifiers(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                val_x = hl.load(x, [tile])
+                val_y = hl.load(y, [tile])
+                out[tile] = val_x + val_y
+            return out
+
+        x = torch.randn([128], device=DEVICE, dtype=torch.float32)
+        y = torch.randn([128], device=DEVICE, dtype=torch.float32)
+
+        with mock.patch(
+            "helion.autotuner.config_spec.supports_amd_cdna_tunables",
+            return_value=True,
+        ):
+            code, result = code_and_output(kernel_with_default_modifiers, (x, y))
+
+        torch.testing.assert_close(result, x + y)
+        self.assertNotIn("cache_modifier=", code)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_load_cache_modifier_autotune.py
+++ b/test/test_load_cache_modifier_autotune.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from unittest import mock
 import unittest
+from unittest import mock
 
 import torch
 


### PR DESCRIPTION
Adds a new autotuner config key, `load_cache_modifiers`, that lets the autotuner pick the cache_modifier per device load. For Triton AMD backend, `load_eviction_policy` is a no-op so to have more precise control over cache eviction, most Triton kernels use cache_modifiers.

Due to the unambiguous improvements in AMD performance, we enable this as a search space. For now, we only expose two options: default and `.cg` (cache at global level), which allows bypassing L1 cache.
- `.ca` (cache at all levels) is another option but produces almost identical behavior to default
- `.cv` (volatile, no caching) does appear to show gains for gather_gemv but benefits are limited over using `.cg` instead.
- `load_cache_modifier` is also valid for Nvidia hardware, but the benefits will be more minor given that `load_eviction_policy` works (and certain combos of eviction policy and cache modifier will produce errors). 
For now we only enable for AMD, a follow up PR will be made for nvidia if there are benefits in perf.

Performance on Mi350
RoPE (autotune_effort = quick):
| H | T | default-only us | autotune us | speedup |
|---:|---:|---:|---:|---:|
| 8192 | 1024 | 35.869 | 19.466 | 1.843x |
| 8192 | 2048 | 87.432 | 62.148 | 1.407x |
| 8192 | 4096 | 140.030 | 105.838 | 1.323x |
| 8192 | 8192 | 126.670 | 79.958 | 1.584x |
| 8192 | 16384 | 583.259 | 294.148 | 1.983x |

gather_gemv (autotune_effort = quick):
| B | N | S | default-only us | cg-only search us | speedup |
|---:|---:|---:|---:|---:|---:|
| 8 | 2 | 2048 | 45.418 | 26.481 | 1.715x |
| 8 | 2 | 4096 | 106.283 | 83.853 | 1.268x |
| 8 | 2 | 8192 | 117.302 | 107.716 | 1.089x |