### PR TITLE
[ref] Implement associative_scan in ref mode without the torch HOP

### DIFF
--- a/helion/language/scan_ops.py
+++ b/helion/language/scan_ops.py
@@ -16,6 +16,8 @@ from . import _decorators
 if TYPE_CHECKING:
     from .._compiler.device_ir import HelperFunctionGraphInfo
     from .._compiler.helper_function import CombineFunction
+    from .._compiler.helper_function import CombineFunctionBasic
+    from .._compiler.helper_function import CombineFunctionTuple
     from .._compiler.inductor_lowering import CodegenState
     from .._compiler.type_info import Origin
     from .._compiler.type_info import TypeInfo
@@ -107,9 +109,34 @@ def _(
     dim: int,
     reverse: bool = False,
 ) -> torch.Tensor | tuple[torch.Tensor, ...]:
-    return higher_order_ops.associative_scan(
-        combine_fn, input_tensor, dim, reverse=reverse
+    # Eager inclusive scan. Ref mode must not call torch's associative_scan HOP: it
+    # runs Dynamo, which breaks under Helion's active RefMode TorchFunctionMode.
+    from .._compiler.helper_function import create_combine_function_wrapper
+
+    is_tuple = isinstance(input_tensor, (tuple, list))
+    leaves = tuple(input_tensor) if is_tuple else (input_tensor,)
+    combine = create_combine_function_wrapper(
+        combine_fn, is_tuple_input=is_tuple, target_format="tuple"
     )
+
+    scan_dim = dim % leaves[0].ndim
+    length = leaves[0].size(scan_dim)
+    order = reversed(range(length)) if reverse else range(length)
+
+    acc: tuple[torch.Tensor, ...] | None = None
+    out: list[tuple[torch.Tensor, ...]] = [()] * length
+    for k in order:
+        cur = tuple(leaf.select(scan_dim, k) for leaf in leaves)
+        if acc is None:
+            acc = cur
+        elif is_tuple:
+            acc = tuple(cast("CombineFunctionTuple", combine)(acc, cur))
+        else:
+            acc = (cast("CombineFunctionBasic", combine)(acc[0], cur[0]),)
+        out[k] = acc
+
+    result = tuple(torch.stack(col, dim=scan_dim) for col in zip(*out, strict=True))
+    return result if is_tuple else result[0]
 
 
 @_decorators.register_to_device_ir(associative_scan)

--- a/test/test_associative_scan.py
+++ b/test/test_associative_scan.py
@@ -427,6 +427,10 @@ class TestAssociativeScan(RefEagerTestBase, TestCase):
         self.assertEqual(result.shape, x.shape)
         self.assertEqual(result.dtype, x.dtype)
 
+    @skipIfRefEager(
+        "torch._higher_order_ops.associative_scan maps to hl.associative_scan only during tracing; "
+        "ref eager mode runs the raw torch HOP, which is unsupported"
+    )
     def test_associative_scan_torch_hops_mapping(self):
         """Test that torch._higher_order_ops.associative_scan automatically maps to hl.associative_scan."""
 


### PR DESCRIPTION
### Stack (merge bottom-up)
- **#2713** — bump nightly CUDA lanes to cu130 *(base)*
- **#2715** — this PR

> This bug was only exposed by the #2713 CUDA bump. Helion's `cu128` nightly channel had been frozen at an April nightly (`torch==2.12.0.dev20260408`); #2713 moves the lanes to the live `cu130` channel, so CI now runs a **current** nightly PyTorch — which is where this latent crash shows up. That is also why it cannot reproduce on the stale wheel or on a torch release.

---

## Problem

In ref/interpret mode (`HELION_INTERPRET=1`), `hl.associative_scan` / `cumsum` / `cumprod` call PyTorch's `associative_scan` HOP. For the default `combine_mode="pointwise"`, that HOP routes through `_maybe_compile_and_run_fn`, which **`torch.compile`s `combine_fn` on every eager call**:

```python
def _maybe_compile_and_run_fn(fn, *args):
    if not torch.compiler.is_dynamo_compiling():
        with setup_compilation_env() as backend:
            return torch.compile(fn, backend=backend, fullgraph=True)(*args)  # Dynamo
    else:
        return fn(*args)
```

With Helion's `RefMode` `TorchFunctionMode` active, current nightlies raise:

```
NameError: name '___get_torch_function_mode_stack_at' is not defined
```

while Dynamo builds guards for that compile — an upstream regression (cf. pytorch/pytorch#172088). It stayed hidden as long as CI ran the frozen April nightly; the #2713 bump to a live nightly is what surfaced it.

`associative_scan` was the **only** one of the 38 `@_decorators.ref` ops that went through the compiler. The other 37 — including its sibling `reduce`, which also takes a `combine_fn` and already runs eagerly — apply torch ops directly.

## Fix

A reference path shouldn't invoke the compiler. Apply `combine_fn` directly as an eager inclusive scan along `dim` — matching torch's ordering and flip-based `reverse`, handling single-tensor and tuple inputs. No Dynamo, no dependency on torch's scan internals. The compiled device-IR path (`tl.associative_scan`) is unchanged.

With this, **every ref op runs eagerly** — `associative_scan` is now consistent with `reduce` and the other 36.

## Tests

Existing `test_associative_scan.py` already runs in both compiled and ref-eager modes (`TestAssociativeScan(RefEagerTestBase, ...)`), so it covers the changed path.

One test, `test_associative_scan_torch_hops_mapping`, is now `@skipIfRefEager`. It calls `torch._higher_order_ops.associative_scan` **directly** to verify the HOP-to-`hl` mapping — but that mapping (`device_func_replacement`) only happens during **tracing**, and a raw HOP call has no `torch_function` hook for ref mode to intercept. The test still runs in compiled mode (where the mapping and its codegen assertions apply); this matches the sibling raw-HOP tests already skipped in ref-eager.

Validated locally on torch 2.11:
- Eager scan matches `associative_scan(combine_mode="generic")` and `torch.cumsum`/`cumprod` across float32/float64/int32/int64 x dim {0,1,-1} x {forward, reverse} and tuple inputs.
- `test_associative_scan.py`: ref-eager 21 passed / 6 skipped; compiled 27 passed.

The nightly-only crash is confirmed by this PR's `a10g-ref-eager` CI lane (runs the current nightly with #2713's cu130 bump).