### PR TITLE
[pallas] enable emit_pipeline BlockSpecs for jagged tile ranges

### DIFF
--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -377,6 +377,21 @@ def _get_loop_numel(state: CodegenState, loop_dim_index: int) -> str:
     return f"(({end}) - ({begin}))"
 
 
+def _is_static_int(expr: str) -> bool:
+    """True if a begin/end expression string is a compile-time integer constant.
+
+    Used to decide whether a tile loop's ``[begin, end)`` extent is statically
+    known. When it is not (data-dependent bounds — a jagged ``hl.tile(start,
+    end)`` or even ``hl.tile(0, dynamic_end)``), the final tile may be a partial
+    sub-range of the backing tensor, so an output store must clamp its extent.
+    """
+    try:
+        int(expr)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
 def _compute_grid_and_block_sizes(
     state: CodegenState,
     block_ids: list[int],
@@ -1429,6 +1444,8 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     begin_exprs, iter_step_exprs, slice_size_exprs = _pallas_loop_begin_and_step_exprs(
         state, block_ids, block_size_vars
     )
+    # Loop end expressions (used to clamp store extents for data-dependent begins).
+    end_exprs = [_get_loop_begin_and_end(state, i)[1] for i in range(len(block_ids))]
 
     # Pipelined tensors flow through emit_pipeline's per-iter Buffered
     # BlockSpec; the rest stay on the outer pallas_call BlockSpec
@@ -1464,7 +1481,9 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
             )
             _bid_to_pid_var[pid.block_id] = pid_var
 
-    def _make_block_spec(fake: torch.Tensor, subscript_meta: list[object]) -> str:
+    def _make_block_spec(
+        fake: torch.Tensor, subscript_meta: list[object], is_store: bool = False
+    ) -> str:
         """Build a BlockSpec string for a tensor accessed in the pipeline body.
 
         Encodes BOTH outer grid dims (via pl.program_id) and inner pipeline
@@ -1489,19 +1508,69 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                 slice_size_expr = slice_size_exprs[bid_idx]
                 begin_expr = begin_exprs[bid_idx]
                 iter_step_expr = iter_step_exprs[bid_idx]
-                block_shape_parts.append(slice_size_expr)
                 from .memory_ops import _record_pad_info
 
                 extra_pad = _compute_pipeline_or_dma_extra_pad(
                     begin_expr, bid, env, state
                 )
                 _record_pad_info(state, fake, dim_idx, bid, extra_pad)
-                if begin_expr == "0" and iter_step_expr == slice_size_expr:
-                    lambda_parts.append(lambda_params[bid_idx])
-                else:
-                    lambda_parts.append(
-                        f"(({begin_expr}) + ({lambda_params[bid_idx]}) * ({iter_step_expr})) // ({slice_size_expr})"
+                begin_is_zero = begin_expr == "0"
+                end_expr = end_exprs[bid_idx]
+                dim_size = shape[dim_idx]
+                # Whether this loop spans the ENTIRE backing tensor dim, i.e.
+                # ``[0, dim_size)`` with a compile-time-constant extent. Only
+                # then is a full-block store safe: a partial final tile overruns
+                # past ``dim_size`` into padding, which the host-side pad handles.
+                # For any sub-range -- a jagged ``hl.tile(start, end)``, a
+                # ``hl.tile(0, dynamic_end)``, or even a static ``hl.tile(0, k)``
+                # with ``k < dim_size`` -- a full-block store would overrun into
+                # live rows of the tensor, so the extent must be clamped.
+                covers_full_dim = (
+                    begin_is_zero
+                    and _is_static_int(end_expr)
+                    and isinstance(dim_size, int)
+                    and int(end_expr) == dim_size
+                )
+                # Loads need a dynamic ``pl.ds`` only for a non-zero begin (a
+                # block-aligned index can't express an arbitrary start; the
+                # over-read past ``end`` is zeroed by the inner-loop mask).
+                # Stores need it whenever they target a sub-range (not the full
+                # dim), so the extent can be clamped and a partial final tile
+                # does not overrun live rows. Full-dim, from-zero loops keep the
+                # original block-index codegen (no change).
+                if not begin_is_zero or (is_store and not covers_full_dim):
+                    # Dynamic ``pl.ds`` at the true element offset, with a
+                    # ``pl.BoundedSlice`` block shape (required for ds-style
+                    # index maps). Lifts the "emit_pipeline fails on unaligned
+                    # dims" limitation so data-dependent tile loops can pipeline.
+                    block_shape_parts.append(f"pl.BoundedSlice({slice_size_expr})")
+                    start_expr = (
+                        f"({begin_expr}) + ({lambda_params[bid_idx]}) "
+                        f"* ({iter_step_expr})"
                     )
+                    if is_store:
+                        # Clamp the store extent to min(block, end - offset) so a
+                        # short final tile writes only its valid rows
+                        # [begin, end) instead of overrunning into the next
+                        # sub-range (which would corrupt it under cross-iteration
+                        # double-buffering, and is wasteful for large blocks).
+                        size_expr = (
+                            f"jnp.minimum({slice_size_expr}, "
+                            f"({end_exprs[bid_idx]}) - ({start_expr}))"
+                        )
+                    else:
+                        size_expr = slice_size_expr
+                    lambda_parts.append(f"pl.ds({start_expr}, {size_expr})")
+                else:
+                    # Static, from-zero loop: a block-aligned index is exact.
+                    # Identical to the pre-existing codegen.
+                    block_shape_parts.append(slice_size_expr)
+                    if iter_step_expr == slice_size_expr:
+                        lambda_parts.append(lambda_params[bid_idx])
+                    else:
+                        lambda_parts.append(
+                            f"(({begin_expr}) + ({lambda_params[bid_idx]}) * ({iter_step_expr})) // ({slice_size_expr})"
+                        )
             elif bid is not None and bid in _bid_to_pid_var:
                 # Outer grid dim -- select via captured program_id variable
                 pid_var = _bid_to_pid_var[bid]
@@ -1551,6 +1620,18 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
             f"lambda {lambda_param_str}: ({lambda_body},), "
             f"pipeline_mode=pl.Buffered(buffer_count=2))"
         )
+
+    def _make_load_block_spec(
+        fake: torch.Tensor, subscript_meta: list[object]
+    ) -> str:
+        """BlockSpec for a pipelined input (full-block ``pl.ds``; mask zeroes over-read)."""
+        return _make_block_spec(fake, subscript_meta, is_store=False)
+
+    def _make_store_block_spec(
+        fake: torch.Tensor, subscript_meta: list[object]
+    ) -> str:
+        """BlockSpec for a pipelined output (clamped ``pl.ds`` extent on dynamic bounds)."""
+        return _make_block_spec(fake, subscript_meta, is_store=True)
 
     def _make_hbm_slice(
         fake: torch.Tensor, hbm_name: str, subscript_meta: list[object]
@@ -1629,7 +1710,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
             hbm_name.replace("_hbm", "") + "_vmem"
         )
         in_tensors.append((fake, hbm_name))
-        in_specs.append(_make_block_spec(fake, sub_meta))
+        in_specs.append(_make_load_block_spec(fake, sub_meta))
         body_params.append(vmem_name)
         pipeline_in_args.append(_make_hbm_slice(fake, hbm_name, sub_meta))
 
@@ -1641,7 +1722,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
             hbm_name.replace("_hbm", "") + "_vmem"
         )
         out_tensors.append((fake, hbm_name))
-        out_specs.append(_make_block_spec(fake, sub_meta))
+        out_specs.append(_make_store_block_spec(fake, sub_meta))
         body_params.append(vmem_name)
         pipeline_out_args.append(_make_hbm_slice(fake, hbm_name, sub_meta))
 

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -1621,15 +1621,11 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
             f"pipeline_mode=pl.Buffered(buffer_count=2))"
         )
 
-    def _make_load_block_spec(
-        fake: torch.Tensor, subscript_meta: list[object]
-    ) -> str:
+    def _make_load_block_spec(fake: torch.Tensor, subscript_meta: list[object]) -> str:
         """BlockSpec for a pipelined input (full-block ``pl.ds``; mask zeroes over-read)."""
         return _make_block_spec(fake, subscript_meta, is_store=False)
 
-    def _make_store_block_spec(
-        fake: torch.Tensor, subscript_meta: list[object]
-    ) -> str:
+    def _make_store_block_spec(fake: torch.Tensor, subscript_meta: list[object]) -> str:
         """BlockSpec for a pipelined output (clamped ``pl.ds`` extent on dynamic bounds)."""
         return _make_block_spec(fake, subscript_meta, is_store=True)
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -324,6 +324,24 @@ def pallas_inner_loop_add_with_scalar_access(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_jagged_segment_add(
+    x: torch.Tensor, offsets: torch.Tensor
+) -> torch.Tensor:
+    """Outer grid over jagged segments + an inner ``hl.tile(start, end)`` loop
+    whose begin (``offsets[g]``) is an arbitrary runtime offset. A
+    block-aligned BlockSpec index can only address starts that are multiples of
+    the block size, so the emit_pipeline path must slice the segment with a
+    dynamic ``pl.ds`` (``pl.BoundedSlice`` block)."""
+    out = torch.empty_like(x)
+    for g in hl.grid(offsets.size(0) - 1):
+        start = offsets[g]
+        end = offsets[g + 1]
+        for tile in hl.tile(start, end):
+            out[tile, :] = x[tile, :] + 1.0
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_add_3d(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     """Kernel with an outer grid loop and a 2D inner device loop."""
     b, m, n = x.size()
@@ -1908,6 +1926,60 @@ class TestPallas(TestCase):
         torch.testing.assert_close(result, args[0] + args[1])
         # out is output-only, excluded from pallas_call inputs
         self.assertIn("_inplace_indices=[]", code)
+
+    @xfailIfPallasInterpret(
+        "dynamic pl.ds / pl.BoundedSlice BlockSpecs are not supported by JAX's "
+        "Pallas interpret mode (concrete-shape requirement); runs on real TPU."
+    )
+    def test_emit_pipeline_data_dependent_begin_uses_dynamic_ds(self) -> None:
+        """A data-dependent ``hl.tile(start, end)`` inner loop under
+        ``pallas_loop_type='emit_pipeline'`` must address the jagged segment
+        with a dynamic ``pl.ds`` slice + ``pl.BoundedSlice`` block, not a
+        block-aligned ``// block_size`` index (which only addresses starts that
+        are exact multiples of the block size). Regression test for the
+        "emit_pipeline fails on unaligned dims" limitation.
+        """
+        # Arbitrary, deliberately non-block-aligned segment bounds covering
+        # [0, 48) so the output is fully written (out = x + 1 everywhere).
+        offsets = torch.tensor([0, 10, 31, 48], device=DEVICE, dtype=torch.int32)
+        x = torch.randn(48, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_jagged_segment_add,
+            (x, offsets),
+            block_sizes=[16],
+            pallas_loop_type="emit_pipeline",
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+        # The fix: dynamic ds slice + BoundedSlice block for the runtime begin.
+        self.assertIn("pl.BoundedSlice", code)
+        self.assertIn("pl.ds(", code)
+        # Load/store asymmetry: the input spec reads a full block (the over-read
+        # past ``end`` is zeroed by the mask), while the output spec clamps its
+        # extent to min(block, end - offset) so a short final tile writes only
+        # its valid rows instead of overrunning into the next segment.
+        in_part, _, out_part = code.partition("out_specs=")
+        self.assertIn("in_specs=", in_part)
+        self.assertNotIn("jnp.minimum", in_part)  # input: full block
+        self.assertIn("jnp.minimum", out_part)  # output: clamped extent
+        torch.testing.assert_close(result, x + 1.0, rtol=1e-5, atol=1e-5)
+
+    def test_emit_pipeline_static_begin_keeps_block_index(self) -> None:
+        """Control: a static (zero-begin) inner loop must NOT switch to the
+        dynamic ds/BoundedSlice path, so aligned/static kernels are unchanged.
+        """
+        args = (
+            torch.randn(64, 128, device=DEVICE, dtype=torch.float32),
+            torch.randn(64, 128, device=DEVICE, dtype=torch.float32),
+        )
+        code, result = code_and_output(
+            pallas_inner_loop_add,
+            args,
+            block_sizes=[8, 128],
+            pallas_loop_type="emit_pipeline",
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+        self.assertNotIn("pl.BoundedSlice", code)
+        torch.testing.assert_close(result, args[0] + args[1])
 
     def _check_scalar_lookup_in_pipeline(self, loop_type: str) -> None:
         torch.manual_seed(0)
@@ -3599,16 +3671,19 @@ class TestPallas(TestCase):
         _code2, result2 = code_and_output(sum_with_dynamic_offset, (data, offsets))
         torch.testing.assert_close(result2, ref, rtol=1e-3, atol=1e-3)
 
-    @xfailIfPallas(
-        "emit_pipeline BlockSpec index_map drops the tile.begin offset, "
-        "so a non-zero start in hl.tile(start, end, ...) reads from offset 0 "
-        "instead and produces wrong results."
+    @xfailIfPallasInterpret(
+        "emit_pipeline now includes tile.begin via a dynamic pl.ds BlockSpec, "
+        "but JAX's Pallas interpret mode does not support dynamic pl.ds / "
+        "pl.BoundedSlice (concrete-shape requirement). Expected to pass on real "
+        "TPU; xfail only under interpret."
     )
     def test_non_zero_tile_begin_emit_pipeline(self) -> None:
         """Same kernel as ``test_non_zero_tile_begin`` but pinned to emit_pipeline.
 
-        Documents the known emit_pipeline tile.begin bug.  Will start passing
-        once the BlockSpec ``index_map`` is taught to include ``tile.begin``.
+        The non-zero ``tile.begin`` is now carried by a dynamic ``pl.ds``
+        BlockSpec index_map, so this produces correct results on TPU. It still
+        xfails under JAX Pallas interpret, which cannot execute dynamic
+        ``pl.ds`` / ``pl.BoundedSlice`` BlockSpecs.
         """
         sum_with_constant_offset, _ = self._non_zero_tile_begin_kernels()
         N, A, B = 128, 8, 256

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -324,9 +324,7 @@ def pallas_inner_loop_add_with_scalar_access(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
-def pallas_jagged_segment_add(
-    x: torch.Tensor, offsets: torch.Tensor
-) -> torch.Tensor:
+def pallas_jagged_segment_add(x: torch.Tensor, offsets: torch.Tensor) -> torch.Tensor:
     """Outer grid over jagged segments + an inner ``hl.tile(start, end)`` loop
     whose begin (``offsets[g]``) is an arbitrary runtime offset. A
     block-aligned BlockSpec index can only address starts that are multiples of


### PR DESCRIPTION
Jagged attention-style kernels often have an outer hl.grid over segments and an inner hl.tile(start, end) over the rows in each segment. In those kernels, start and end are runtime values loaded from offsets, so the tile range is not necessarily aligned to the block size.

The old emit_pipeline code assumed the pipelined dimension could be addressed by a block index like _j, or by integer-dividing an offset by the block size. That works for ordinary loops like hl.tile(0, n), but it is not correct for jagged ranges such as hl.tile(offsets[g], offsets[g + 1]).

For example, if a segment starts at row 10 and the block size is 16, block-index addressing cannot represent “start at row 10”. It either rounds/truncates to a block-aligned location or drops the tile begin entirely.

For pipelined dimensions with a non-zero or data-dependent begin, the generated BlockSpec now uses:
```python
pl.BoundedSlice(block_size)
pl.ds(start + j * step, size)
```
This lets the BlockSpec describe the actual element offset for each pipeline iteration, instead of forcing the offset through a block-aligned index. Loads and stores now intentionally use separate BlockSpec construction:
  - Load specs use a full-block dynamic slice, for example pl.ds(offset, block_size).
  - Store specs clamp the dynamic slice length, for example pl.ds(offset, jnp.minimum(block_size, end - offset)).

The reason for asymmetry between loads and stores is:
- for loads extra elements past the logical jagged range are read but ignored by the mask in the pipeline body
- for stores, we need to be stricter because writes past the logical range would corrupt neighboring rows.
- zero-begin subranges are also handled conservatively. hl.tile(0, 10) into a larger tensor still needs a clamped store, even though the begin is zero, because the final store must not write beyond row 10 into live tensor data.

For ordinary static full-dimension loops, such as hl.tile(0, n) where the compiler can prove the loop covers the whole backing tensor dimension, the code keeps the previous block-index BlockSpec. That avoids changing the common aligned path and keeps the fix focused on subrange and jagged cases.

Performance improvements for jagged gdpa:
| block | fori_loop (before) | emit_pipeline (after) | speedup |
|---:|:---|:---|---:|
| 512 | 9.968 ms (50.2 TFLOP/s) | 6.135 ms (81.6 TFLOP/s) | 1.62× |
| 1024 | 8.028 ms (62.4 TFLOP/s) | 5.803 ms (86.3 TFLOP/s) | 1.38× |
| 2048 | 7.157 ms (70.0 TFLOP/s) | 6.055 ms (82.7 TFLOP/s) | 1.18× |