### PR TITLE
[Autotuner] Support autotuing with non-dense mutated input

### DIFF
--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -102,7 +102,14 @@ def _clone_args(
         if not isinstance(arg, torch.Tensor):
             continue
         if _should_clone(i):
-            clone = arg.detach().clone()
+            clone = torch.empty_strided(
+                size=arg.size(),
+                stride=arg.stride(),
+                dtype=arg.dtype,
+                device=arg.device,
+                layout=arg.layout,
+            )
+            clone.copy_(arg)
             clone.requires_grad_(arg.requires_grad)
             args_flat[i] = clone
 

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -3021,19 +3021,18 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         mutated_clones = [0]
         non_mutated_clones = [0]
 
-        original_clone = torch.Tensor.clone
+        original_copy = torch.Tensor.copy_
 
-        def tracking_clone(self, *args, **kwargs):
-            result = original_clone(self, *args, **kwargs)
-            if self.data_ptr() in mutated_ptrs:
-                mutated_ptrs.add(result.data_ptr())
+        def tracking_copy(self, src, **kwargs):
+            original_copy(self, src, **kwargs)
+            if src.data_ptr() in mutated_ptrs:
+                mutated_ptrs.add(self.data_ptr())
                 mutated_clones[0] += 1
-            if self.data_ptr() in non_mutated_ptrs:
-                non_mutated_ptrs.add(result.data_ptr())
+            if src.data_ptr() in non_mutated_ptrs:
+                non_mutated_ptrs.add(self.data_ptr())
                 non_mutated_clones[0] += 1
-            return result
 
-        with patch.object(torch.Tensor, "clone", tracking_clone):
+        with patch.object(torch.Tensor, "copy_", tracking_copy):
             inplace_add(a, b, epsilon, out)
 
         # Mutated tensor (out) should be cloned during baseline AND benchmarking:
@@ -3055,6 +3054,40 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         )
 
         expected = torch.full([128], 3.0, device=DEVICE) + epsilon
+        torch.testing.assert_close(out, expected)
+
+    def test_autotune_non_dense_tensor_cloning(self) -> None:
+        """
+        During autotune benchmarking, the cloned arg should retain
+        storage layout for non dense mutated input.
+        """
+
+        config1 = helion.Config(block_sizes=[32], num_warps=4)
+        config2 = helion.Config(block_sizes=[64], num_warps=4)
+
+        @helion.kernel(configs=[config1, config2], autotune_log_level=0)
+        def inplace_add(
+            a: torch.Tensor,
+            b: torch.Tensor,
+            epsilon: float,
+            out: torch.Tensor,
+        ):
+            # This kernel requires out tensor with padding
+            assert out.stride(0) == 2
+            for tile in hl.tile(out.size()):
+                out[tile] += a[tile] + b[tile] + epsilon
+
+        a = torch.full([128], 1.0, device=DEVICE)
+        b = torch.full([128], 2.0, device=DEVICE)
+        epsilon = 1e-6
+        out_dense = torch.zeros([256], device=DEVICE)
+        out = out_dense[::2]  # shape [128], stride [2], non-dense
+
+        # Run autotuning
+        inplace_add(a, b, epsilon, out)
+
+        # assertion inside the testing kernel should not fail
+        expected = torch.full([128], 3.0 + epsilon, device=DEVICE)
         torch.testing.assert_close(out, expected)
 
     @skipIfXPU("CUDA specific API used to check memory usage")


### PR DESCRIPTION
### Issue

For some inference kernels, the output tensor could be padded and hence non-dense. e.g., vLLM supports [per_token_group_fp8_quant_packed](https://github.com/xiaohongchen1991/vllm/blob/440e8a475e3d2c124431e64248a7e101c98a205e/vllm/kernels/helion/ops/per_token_group_fp8_quant_packed.py#L196) kernel that requires the mutated input tensor [output_s_packed](https://github.com/xiaohongchen1991/vllm/blob/440e8a475e3d2c124431e64248a7e101c98a205e/vllm/kernels/helion/ops/per_token_group_fp8_quant_packed.py#L226-L227) to be TMA aligned and UE8M0 packed. This means this tensor could be non-dense for certain input shapes. To make sure the the passed in mutated [output_s_packed](https://github.com/xiaohongchen1991/vllm/blob/440e8a475e3d2c124431e64248a7e101c98a205e/vllm/kernels/helion/ops/per_token_group_fp8_quant_packed.py#L226-L227) has the correct storage layout, we assert the following in the kernel implementation.
```
    assert output_s_packed.shape == (num_tokens, (groups_per_row + 3) // 4)
    assert output_s_packed.stride() == (1, ((num_tokens + 3) // 4) * 4)
```

During kernel autotuning, autotuner will clone the input args for benchmarking. Current implementation is using ```torch.clone``` which only preserve [memory layout](https://docs.pytorch.org/docs/2.12/tensor_attributes.html#torch.memory_format) when the tensor is non-overlapping and dense. When the tensor is non-dense, torch.clone will return a contiguous tensor used for benchmarking and will fail the assertion above since memory layout changed. Even if there is no such assertions, the kernel benchmarking could still fail since the kernel is implemented based on non-dense memory format.

### What changed in this PR

Instead of using ```torch.clone```, we changed the cloning logic to
```
            clone = torch.empty_strided(
                size=arg.size(),
                stride=arg.stride(),
                dtype=arg.dtype,
                device=arg.device,
                layout=arg.layout,
            )
            clone.copy_(arg)
```
so that memory layout is preserved for non-dense tensor as well.

### Testing
Added a unit test case to cover non-dense mutated input clone during benchmarking.

```pytest test``` passed except those for CuteDSL backend since CuteDSL is not available in my dev environment. 