### PR TITLE
[pallas] Skip the inner-loop pad when its begin is block-aligned

### DIFF
--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -448,6 +448,31 @@ def _pallas_loop_begin_and_step_exprs(
     return begin_exprs, iter_step_exprs, slice_size_exprs
 
 
+def _pipeline_begin_alignment(
+    begin_expr: str,
+    state: CodegenState,
+) -> int | None:
+    """Return a proven divisor of ``begin_expr``, or ``None``.
+
+    A nested-tile inner loop's begin is its outer loop's ``offset_var``, which is
+    a multiple of the outer block size when that outer loop begins at 0 — so it
+    needs no extra pad. Returns that block size in that case.
+    """
+    for block_id, loops in state.codegen.active_device_loops.items():
+        if not loops:
+            continue
+        if state.codegen.offset_var(block_id) != begin_expr:
+            continue
+        info = loops[-1].block_id_to_info.get(block_id)
+        # Only sound when the outer loop begins at 0, so the offset is a clean
+        # multiple of the outer block size.
+        if info is None or info.begin_expr not in (0, sympy.Integer(0)):
+            return None
+        outer_bs = state.device_function.resolved_block_size(block_id)
+        return outer_bs if isinstance(outer_bs, int) else None
+    return None
+
+
 def _compute_pipeline_or_dma_extra_pad(
     begin_expr: str,
     bid: int,
@@ -459,17 +484,19 @@ def _compute_pipeline_or_dma_extra_pad(
     When ``pl.ds(offset, block_size)`` reads from a tensor whose loop starts
     at a non-zero begin, the last block can overshoot the tensor boundary
     beyond what ``(-shape) % block_size`` accounts for.  The worst case is
-    ``block_size - 1`` extra elements when the begin is data-dependent.
-
-    # TODO(dunfanlu): if begin isn't "0" but is another constexpr int,
-    # we should be able to use a smaller padding than bs-1?
+    ``block_size - 1`` extra elements when the begin is data-dependent, but a
+    begin that is provably a multiple of ``block_size`` (e.g. an outer tile's
+    aligned offset) needs no extra padding at all.
     """
     if begin_expr == "0":
         return 0
     bs_val = state.device_function.resolved_block_size(bid)
-    if isinstance(bs_val, int):
-        return bs_val - 1
-    return 0
+    if not isinstance(bs_val, int):
+        return 0
+    alignment = _pipeline_begin_alignment(begin_expr, state)
+    if alignment is not None and alignment % bs_val == 0:
+        return 0
+    return bs_val - 1
 
 
 def _scratch_read(state: CodegenState, sname: str) -> str:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import ast
 import math
 import os
+import re
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
@@ -3196,6 +3198,30 @@ class TestPallas(TestCase):
         self.assertIn("pl.ds(", code)
         self.assertIn("_pipeline_arg_indices=", code)
         torch.testing.assert_close(result, x * r)
+
+    def test_pipeline_begin_aligned_skips_pad(self) -> None:
+        # A block-aligned inner begin (the outer tile's offset) needs no boundary
+        # pad, so _ds_pad_dims must report extra_pad == 0 rather than block_size-1.
+        # Locks the pad-skip optimization (would be block_size-1 if it regressed).
+        x = torch.randn(64, 128, device=DEVICE, dtype=torch.float32)
+        r = torch.randn(64, 1, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_row_scale_mul,
+            (x, r),
+            block_sizes=[8],
+            pallas_loop_type="fori_loop",
+        )
+        torch.testing.assert_close(result, x * r)
+        match = re.search(r"_ds_pad_dims=(\[[^\]]*\])", code)
+        self.assertIsNotNone(match, "expected _ds_pad_dims in the launcher call")
+        pad_dims = ast.literal_eval(
+            match.group(1)
+        )  # [(arg, dim, block_size, extra_pad)]
+        self.assertTrue(pad_dims, "expected pl.ds pad dims to be present")
+        self.assertTrue(
+            all(extra_pad == 0 for *_, extra_pad in pad_dims),
+            f"block-aligned begin should skip the pad (extra_pad==0), got {pad_dims}",
+        )
 
     def test_squeeze_slice_access(self) -> None:
         """Test for the [None, :] indexing pattern (subscript index for slice >= tensor_ndim)"""


### PR DESCRIPTION
Stacked PRs:
 * #2730
 * #2727
 * __->__#2726
 * #2725


--- --- ---

### [pallas] Skip the inner-loop pad when its begin is block-aligned


For a nested-tile reduction the inner pipeline's begin is the outer loop's
offset_var, which is a multiple of the outer block size when the outer loop
begins at 0 — so it needs no boundary padding. _pipeline_begin_alignment proves
this and zeroes the extra pad, eliminating per-call F.pad copies.

Verified on tpu7x rms_norm-bwd [8192,8192]: device time 1.275 -> 0.348ms (3.66x);
the padded f32[8223,8192] tensor + fill + dynamic-update-slice + copies vanish,
correctness PASS, and Helion now beats torch.compile (0.708 vs 0.749ms wall).
