### PR TITLE
[pallas] Add helion.tpu_compile_capture for torch.compile on TPU

### DIFF
--- a/helion/__init__.py
+++ b/helion/__init__.py
@@ -12,6 +12,7 @@ from .runtime import Config
 from .runtime import Kernel
 from .runtime import kernel
 from .runtime import kernel as jit  # alias
+from .runtime._tpu_compile_capture import tpu_compile_capture
 from .runtime.settings import RefMode
 from .runtime.settings import Settings
 
@@ -28,6 +29,7 @@ __all__ = [
     "language",
     "next_power_of_2",
     "runtime",
+    "tpu_compile_capture",
 ]
 
 _logging.init_logs()

--- a/helion/runtime/_tpu_compile_capture.py
+++ b/helion/runtime/_tpu_compile_capture.py
@@ -1,0 +1,105 @@
+"""Make a Helion Pallas/TPU kernel capturable by ``torch.compile(backend="tpu")``.
+
+A ``@helion.kernel`` call on Pallas goes through the eager torch_tpu -> jax
+bridge, paying a per-call dispatch cost; under ``torch.compile`` Dynamo would
+trace *into* that bridge (into jax) and break. Wrapping the kernel as a
+``torch.library.custom_op`` makes it opaque to Dynamo and lets torch_xla capture
+it as a single XLA-graph node, collapsing the dispatch cost.
+
+``tpu_compile_capture`` derives the op schema and fake (meta) impl from the example
+inputs using Helion's jax-free shape inference, so the user writes no
+boilerplate. The op is specialized to the example shapes/dtypes -- call it once
+per (kernel, shape, dtype); a new signature registers a fresh op.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+
+import torch
+
+if TYPE_CHECKING:
+    from .kernel import Kernel
+
+_capture_lib = torch.library.Library("helion_capture", "FRAGMENT")
+_op_counter = 0
+_op_cache: dict[Any, Callable[..., Any]] = {}
+
+
+def tpu_compile_capture(
+    kernel: Kernel, example_inputs: tuple[Any, ...]
+) -> Callable[..., Any]:
+    """Wrap ``kernel`` so ``torch.compile(backend="tpu")`` captures it as one node.
+
+    Args:
+        kernel: a ``@helion.kernel`` (Pallas/TPU backend).
+        example_inputs: representative positional args (all Tensors, no scalars).
+            Used once (jax-free) to derive output shapes/dtypes; the op is
+            specialized to them. Output must be a Tensor or tuple of Tensors,
+            with no input mutation/aliasing.
+    """
+
+    if kernel.settings.backend != "pallas":
+        raise NotImplementedError(
+            f"tpu_compile_capture targets the Pallas/TPU backend; {kernel.name!r} "
+            f"uses backend {kernel.settings.backend!r}. On other backends Helion "
+            "kernels are already captured by torch.compile via its HOP lowering "
+            "(see the torch_compile_fusion setting); capture is unneeded there."
+        )
+    from .._compiler._dynamo.variables import infer_output_spec
+
+    global _op_counter
+    args = tuple(example_inputs)
+    if not all(isinstance(a, torch.Tensor) for a in args):
+        raise NotImplementedError(
+            "tpu_compile_capture supports all-Tensor positional args (no scalars)"
+        )
+
+    cache_key = (
+        id(kernel),
+        tuple((tuple(a.shape), a.dtype, str(a.device)) for a in args),
+    )
+    cached = _op_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    spec = infer_output_spec(kernel, args)
+    if spec.get("mutated_inputs") or spec.get("direct_aliases"):
+        raise NotImplementedError(
+            "tpu_compile_capture does not support kernels that mutate or alias inputs"
+        )
+    leaf_specs = spec["leaf_specs"]
+    if not leaf_specs or any(s["type"] != "tensor" for s in leaf_specs):
+        raise NotImplementedError(
+            "tpu_compile_capture supports Tensor or tuple-of-Tensor outputs"
+        )
+
+    n_in, n_out = len(args), len(leaf_specs)
+    _op_counter += 1
+    name = f"{kernel.name}_{_op_counter}"
+    in_decl = ", ".join(f"Tensor a{i}" for i in range(n_in))
+    out_decl = "Tensor" if n_out == 1 else "(" + ", ".join(["Tensor"] * n_out) + ")"
+    _capture_lib.define(f"{name}({in_decl}) -> {out_decl}")
+
+    def impl(*tensors: torch.Tensor) -> torch.Tensor | tuple[torch.Tensor, ...]:
+        out = kernel(*tensors)
+        # A multi-tensor return is boxed as a tuple by the schema; normalize a
+        # list return so eager and captured paths agree.
+        return tuple(out) if n_out > 1 else out
+
+    _capture_lib.impl(name, impl, "CompositeExplicitAutograd")
+
+    def fake(*tensors: torch.Tensor) -> torch.Tensor | tuple[torch.Tensor, ...]:
+        outs = [
+            torch.empty(s["shape"], dtype=s["dtype"], device=s["device"])
+            for s in leaf_specs
+        ]
+        return outs[0] if n_out == 1 else tuple(outs)
+
+    torch.library.register_fake(f"helion_capture::{name}", fake)
+
+    op = getattr(torch.ops.helion_capture, name)
+    _op_cache[cache_key] = op
+    return op


### PR DESCRIPTION
Stacked PRs:
 * #2730
 * #2729
 * __->__#2728
 * #2727
 * #2726
 * #2725


--- --- ---

### [pallas] Add `helion.tpu_compile_capture` for torch.compile on TPU

Explicit one-line wrap so a Helion Pallas kernel can run inside `torch.compile(backend="tpu")`:

```python
op = helion.tpu_compile_capture(kernel, example_inputs)   # wrap once
@torch.compile(backend="tpu")
def f(x, y):
    return op(x, y)                                        # call op in place of the kernel
```

It wraps the kernel as a `torch.library.custom_op` (with a `register_fake` meta derived from Helion's jax-free `infer_output_spec`) so it is opaque to Dynamo and torch_xla captures it as one XLA-graph node — instead of tracing into the eager `torch_tpu → jax` bridge, which is not Dynamo-traceable and breaks `fullgraph`.

#### Same mechanism as torch_tpu's own custom kernels

This is exactly how torch_tpu itself exposes a Pallas kernel to `torch.compile`: its public `jax_op(name, fn)` registers a JAX/Pallas function as a `torch.library.custom_op` + `register_fake`. A captured Helion kernel uses the same two primitives, so it behaves like a hand-written torch_tpu custom kernel under torch.compile.

#### What it changes (and what it doesn't)

Capture wraps the **same** Pallas kernel, so a single kernel is **not** faster — eager and captured run identically (measured: geglu eager 2.41 ms ≈ captured 2.43 ms; an old 1-D-flatten geglu, eager 17.2 ms ≈ captured 17.5 ms). The value is:

1. **Compatibility (the main reason):** without capture you cannot run a Helion Pallas kernel inside `torch.compile(backend="tpu")` at all — Dynamo traces into the untraceable eager bridge and `fullgraph` breaks.
2. **Per-call dispatch collapse, in a graph:** the eager per-call dispatch (`call_custom_kernel` + lazy-graph enqueue) is **~37 µs**; under capture the kernel is one XLA node, so in a multi-op region N dispatches collapse to one. Measured: 50 tiny kernels in one graph, **1860 µs → 75 µs (24.9×)**, per-call **37 µs → 1.5 µs**. For a single isolated kernel there is nothing to amortize, so it is ~neutral (slightly slower for tiny kernels: 43 µs → 66 µs).

So the speedup shows up in real models (many ops fused into one XLA graph), not single-kernel microbenchmarks. The per-kernel-quality comparison vs the PyTorch baselines is in #2730.

(#2730 generalizes the op so it is shape-generic — one op per kernel, no per-shape warm-up, no raise on a new shape.)
