### PR TITLE
[pallas] Auto-capture Helion kernels under torch.compile (opt-in)

### DIFF
--- a/helion/runtime/_tpu_compile_capture.py
+++ b/helion/runtime/_tpu_compile_capture.py
@@ -1,15 +1,16 @@
 """Make a Helion Pallas/TPU kernel capturable by ``torch.compile(backend="tpu")``.
 
-A ``@helion.kernel`` call on Pallas goes through the eager torch_tpu -> jax
-bridge, paying a per-call dispatch cost; under ``torch.compile`` Dynamo would
-trace *into* that bridge (into jax) and break. Wrapping the kernel as a
-``torch.library.custom_op`` makes it opaque to Dynamo and lets torch_xla capture
-it as a single XLA-graph node, collapsing the dispatch cost.
+Wrapping a Helion kernel as a ``torch.library.custom_op`` makes it opaque to
+Dynamo so torch_xla captures it as one XLA-graph node, instead of tracing into
+the eager torch_tpu -> jax bridge (which breaks). Schema + jax-free fake come
+from Helion's output-spec inference. The op is cached per (kernel, shape, dtype).
 
-``tpu_compile_capture`` derives the op schema and fake (meta) impl from the example
-inputs using Helion's jax-free shape inference, so the user writes no
-boilerplate. The op is specialized to the example shapes/dtypes -- call it once
-per (kernel, shape, dtype); a new signature registers a fresh op.
+Two entry points:
+  * ``tpu_compile_capture(kernel, example_inputs)`` -- explicit one-line wrap; robust
+    (the user calls the returned op directly).
+  * ``auto_capture_call`` -- called from ``Kernel.__call__`` to register the op as
+    a side effect of an eager warm-up (opt-in ``HELION_TPU_COMPILE_CAPTURE=1``), so
+    no wrap is needed. Static shapes only; registration must be single-threaded.
 """
 
 from __future__ import annotations
@@ -25,72 +26,66 @@ if TYPE_CHECKING:
 
 _capture_lib = torch.library.Library("helion_capture", "FRAGMENT")
 _op_counter = 0
-_op_cache: dict[Any, Callable[..., Any]] = {}
+# {(id(kernel), shapes, dtypes) -> op or None}. A flat dict keyed by id() keeps
+# the under-compile lookup Dynamo-traceable (a WeakIdKeyDictionary thrashes it);
+# id() reuse is moot for module-scope kernels, which live for the process.
+_op_cache: dict[Any, Callable[..., Any] | None] = {}
+
+# Sentinel: tells Kernel.__call__ to run its normal dispatch path.
+RUN_NORMAL = object()
 
 
-def tpu_compile_capture(
-    kernel: Kernel, example_inputs: tuple[Any, ...]
-) -> Callable[..., Any]:
-    """Wrap ``kernel`` so ``torch.compile(backend="tpu")`` captures it as one node.
+def _signature(args: tuple[Any, ...]) -> tuple[Any, ...] | None:
+    """Cache key for an all-Tensor call, or None if any arg isn't a Tensor."""
+    if not all(isinstance(a, torch.Tensor) for a in args):
+        return None
+    return tuple((tuple(a.shape), a.dtype) for a in args)
 
-    Args:
-        kernel: a ``@helion.kernel`` (Pallas/TPU backend).
-        example_inputs: representative positional args (all Tensors, no scalars).
-            Used once (jax-free) to derive output shapes/dtypes; the op is
-            specialized to them. Output must be a Tensor or tuple of Tensors,
-            with no input mutation/aliasing.
+
+def build_op(kernel: Kernel, args: tuple[Any, ...]) -> Callable[..., Any] | None:
+    """Register (once, cached) a custom_op for this kernel+signature.
+
+    Returns the op, or ``None`` if the kernel/signature isn't capturable
+    (non-tensor args/outputs, input mutation/aliasing, or any registration
+    failure). Never raises -- callers fall back to normal dispatch.
     """
+    sig = _signature(args)
+    if sig is None:
+        return None
+    key = (id(kernel), sig)
+    if key in _op_cache:
+        return _op_cache[key]
+    try:
+        op = _register_op(kernel, args)
+    except Exception:
+        op = None
+    _op_cache[key] = op
+    return op
 
-    if kernel.settings.backend != "pallas":
-        raise NotImplementedError(
-            f"tpu_compile_capture targets the Pallas/TPU backend; {kernel.name!r} "
-            f"uses backend {kernel.settings.backend!r}. On other backends Helion "
-            "kernels are already captured by torch.compile via its HOP lowering "
-            "(see the torch_compile_fusion setting); capture is unneeded there."
-        )
+
+def _register_op(kernel: Kernel, args: tuple[Any, ...]) -> Callable[..., Any] | None:
     from .._compiler._dynamo.variables import infer_output_spec
 
-    global _op_counter
-    args = tuple(example_inputs)
-    if not all(isinstance(a, torch.Tensor) for a in args):
-        raise NotImplementedError(
-            "tpu_compile_capture supports all-Tensor positional args (no scalars)"
-        )
-
-    cache_key = (
-        id(kernel),
-        tuple((tuple(a.shape), a.dtype, str(a.device)) for a in args),
-    )
-    cached = _op_cache.get(cache_key)
-    if cached is not None:
-        return cached
-
     spec = infer_output_spec(kernel, args)
-    if spec.get("mutated_inputs") or spec.get("direct_aliases"):
-        raise NotImplementedError(
-            "tpu_compile_capture does not support kernels that mutate or alias inputs"
-        )
     leaf_specs = spec["leaf_specs"]
-    if not leaf_specs or any(s["type"] != "tensor" for s in leaf_specs):
-        raise NotImplementedError(
-            "tpu_compile_capture supports Tensor or tuple-of-Tensor outputs"
-        )
+    if (
+        spec.get("mutated_inputs")
+        or spec.get("direct_aliases")
+        or not leaf_specs
+        or any(s["type"] != "tensor" for s in leaf_specs)
+    ):
+        return None
 
-    n_in, n_out = len(args), len(leaf_specs)
+    global _op_counter
     _op_counter += 1
     name = f"{kernel.name}_{_op_counter}"
+    n_in, n_out = len(args), len(leaf_specs)
     in_decl = ", ".join(f"Tensor a{i}" for i in range(n_in))
     out_decl = "Tensor" if n_out == 1 else "(" + ", ".join(["Tensor"] * n_out) + ")"
     _capture_lib.define(f"{name}({in_decl}) -> {out_decl}")
 
-    def impl(*tensors: torch.Tensor) -> torch.Tensor | tuple[torch.Tensor, ...]:
-        out = kernel(*tensors)
-        # A multi-tensor return is boxed as a tuple by the schema; normalize a
-        # list return so eager and captured paths agree.
-        return tuple(out) if n_out > 1 else out
-
-    _capture_lib.impl(name, impl, "CompositeExplicitAutograd")
-
+    # Register the fake before the impl so a fake failure can't leave a live
+    # impl with no meta. Captured outputs are contiguous (torch.empty).
     def fake(*tensors: torch.Tensor) -> torch.Tensor | tuple[torch.Tensor, ...]:
         outs = [
             torch.empty(s["shape"], dtype=s["dtype"], device=s["device"])
@@ -100,6 +95,63 @@ def tpu_compile_capture(
 
     torch.library.register_fake(f"helion_capture::{name}", fake)
 
-    op = getattr(torch.ops.helion_capture, name)
-    _op_cache[cache_key] = op
+    def impl(*tensors: torch.Tensor) -> torch.Tensor | tuple[torch.Tensor, ...]:
+        # bind() directly, not kernel(*tensors): the latter re-enters the
+        # Kernel.__call__ capture hook and recurses into this op.
+        out = kernel.bind(tensors)(*tensors)
+        return tuple(out) if n_out > 1 else out
+
+    _capture_lib.impl(name, impl, "CompositeExplicitAutograd")
+    return getattr(torch.ops.helion_capture, name)
+
+
+def tpu_compile_capture(
+    kernel: Kernel, example_inputs: tuple[Any, ...]
+) -> Callable[..., Any]:
+    """Wrap ``kernel`` so ``torch.compile(backend="tpu")`` captures it as one node.
+
+    Args:
+        kernel: a ``@helion.kernel`` (Pallas/TPU backend).
+        example_inputs: representative positional args (all Tensors, no scalars);
+            used once (jax-free) to derive output shapes/dtypes. Output must be a
+            Tensor or tuple of Tensors, with no input mutation/aliasing.
+    """
+
+    if kernel.settings.backend != "pallas":
+        raise NotImplementedError(
+            f"tpu_compile_capture targets the Pallas/TPU backend; {kernel.name!r} "
+            f"uses backend {kernel.settings.backend!r}. On other backends Helion "
+            "kernels are already captured by torch.compile via its HOP lowering "
+            "(see the torch_compile_fusion setting); capture is unneeded there."
+        )
+    op = build_op(kernel, tuple(example_inputs))
+    if op is None:
+        raise NotImplementedError(
+            "tpu_compile_capture supports all-Tensor inputs and Tensor/tuple outputs "
+            "with no input mutation or aliasing"
+        )
     return op
+
+
+def auto_capture_call(kernel: Kernel, args: tuple[Any, ...]) -> object:
+    """Pallas path for ``Kernel.__call__``.
+
+    Eager: register the op as a side effect, then run the normal path. Under
+    compile: a pure cache lookup (fullgraph-safe) returns the captured op; a miss
+    raises a clear error rather than silently falling into the jax bridge (which
+    Dynamo can't trace). Misses mean the kernel wasn't warmed up at this shape,
+    has dynamic shapes, or isn't capturable.
+    """
+    if not torch.compiler.is_compiling():
+        build_op(kernel, args)
+        return RUN_NORMAL
+    sig = _signature(args)
+    op = _op_cache.get((id(kernel), sig)) if sig is not None else None
+    if op is not None:
+        return op(*args)
+    raise RuntimeError(
+        f"Helion kernel {kernel.name!r} could not be captured under torch.compile "
+        "on the Pallas backend. Run it once eagerly at this shape before compiling, "
+        "or use helion.tpu_compile_capture(kernel, example_inputs). Kernels with dynamic "
+        "shapes, non-tensor args, or input mutation are not auto-capturable."
+    )

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -8,6 +8,7 @@ import inspect
 import itertools
 import logging
 import operator
+import os
 import re
 import sys
 import textwrap
@@ -98,6 +99,10 @@ def _td_layout_guard_active_for_config(
 
 _R = TypeVar("_R")
 CompiledConfig = Callable[..., _R]
+
+# Opt-in: auto-capture Pallas kernels under torch.compile (see _tpu_compile_capture).
+# Off by default so the eager dispatch path is unchanged.
+_TPU_COMPILE_CAPTURE = os.environ.get("HELION_TPU_COMPILE_CAPTURE", "0") == "1"
 
 # Cache for GraphModule hashes
 _graph_module_hash_cache: WeakIdKeyDictionary = WeakIdKeyDictionary()
@@ -412,6 +417,15 @@ class Kernel(Generic[_R]):
         """
         if kwargs:
             args = self.normalize_args(*args, **kwargs)
+        if self.settings.backend == "pallas" and _TPU_COMPILE_CAPTURE:
+            # Local import: _tpu_compile_capture pulls in the dynamo HOP machinery,
+            # not ready when kernel.py first loads during ``import helion``.
+            from ._tpu_compile_capture import RUN_NORMAL
+            from ._tpu_compile_capture import auto_capture_call
+
+            result = auto_capture_call(self, args)
+            if result is not RUN_NORMAL:
+                return cast("_R", result)
         return self.bind(args)(*args)
 
     def reset(self) -> None:


### PR DESCRIPTION
Stacked PRs:
 * #2730
 * __->__#2729
 * #2728
 * #2727
 * #2726
 * #2725


--- --- ---

### [pallas] Auto-capture Helion kernels under torch.compile (opt-in)

With `HELION_TPU_COMPILE_CAPTURE=1`, `Kernel.__call__` on the Pallas backend registers each kernel as a `torch.library.custom_op` (the same `custom_op` + `register_fake` pattern torch_tpu's own `jax_op` uses) so `torch.compile(backend="tpu")` captures it as one XLA-graph node — no per-kernel wrapping. Off by default (eager dispatch unchanged); registration is failure-safe.

#### How you use it

Write a normal Helion kernel and call it inside a `torch.compile(backend="tpu")` region — nothing else:

```python
import os
os.environ["HELION_TPU_COMPILE_CAPTURE"] = "1"   # opt in (read at import; set it first)

import torch, helion
import helion.language as hl

@helion.kernel(backend="pallas", config=helion.Config(block_sizes=[256, 256]))
def add(x, y):
    out = torch.empty_like(x)
    for tile in hl.tile(out.size()):
        out[tile] = x[tile] + y[tile]
    return out

def model(x, y):
    return add(x, y) * 2            # a Helion kernel inside a larger fn

compiled = torch.compile(model, backend="tpu", dynamic=False)
compiled(x, y)                       # `add` is auto-captured as one XLA node
```

#### How it integrates into torch_tpu

When the flag is set, `Kernel.__call__` routes through `auto_capture_call`: eagerly it registers a `torch.library.custom_op` whose impl runs the kernel through torch_tpu's normal Pallas dispatch (`call_custom_kernel`); under `torch.compile`, the op is opaque to Dynamo, so torch_xla lowers it as a single node in the StableHLO graph instead of tracing into the eager `torch_tpu → jax` bridge (which isn't traceable and breaks `fullgraph`). The Pallas/Mosaic kernel ends up in the XLA graph exactly as a hand-written torch_tpu custom kernel would.

#### Do you need `HELION_TPU_COMPILE_CAPTURE=1`?

For this **auto** path, yes — the env var gates the `Kernel.__call__` hook. Without it (and without the explicit wrap), a Helion kernel reached under `torch.compile(backend="tpu")` falls into the eager `torch_tpu → jax` bridge and breaks. If you'd rather not set a global flag, use the explicit API from #2728 instead — `op = helion.tpu_compile_capture(kernel, example_inputs)` — which needs no env var.

#### When would you *not* want it under torch.compile?

Under `torch.compile(backend="tpu")` a Helion Pallas kernel essentially needs capture to work in `fullgraph`, so you normally want it on. Leave it off when:

- **The kernel isn't capturable** (input mutation/aliasing). Capture is failure-safe — it skips — and you accept a graph break around the kernel (it runs eager).
- **You're debugging / want the eager path** as a correctness baseline.
- **You're not on TPU.** On GPU/Triton, Helion already has a native HOP → Inductor lowering; capture is TPU-only and would only hide the kernel from Inductor.

Default-off keeps eager dispatch byte-for-byte unchanged, so turning it on is an explicit, contained opt-in.


#### Decoration-time registration (#2730)

#2730 (stacked above) moves registration to **kernel-definition time** for kernels that look like a hand-written custom op — annotated, functional, and resolving a config without benchmarking — so they are captured with **zero warm-up**. The eager first-call registration described here remains the fallback for `configs=[...]`, unannotated, or mutating kernels.
