### PR TITLE
[pallas] torch.compile(tpu) capture for Helion Pallas kernels

### DIFF
--- a/helion/_compiler/_dynamo/variables.py
+++ b/helion/_compiler/_dynamo/variables.py
@@ -32,9 +32,15 @@ if TYPE_CHECKING:
 
 
 def _detect_mutated_inputs(body: list[ast.stmt], param_names: set[str]) -> list[str]:
-    """Find params mutated via subscript assignment (e.g. x[tile] = ...)."""
+    """Find params mutated in place via subscript store (x[tile] = ...) or
+    atomic op (hl.atomic_*(x, ...)).
+
+    Uses ``inplace_writes`` rather than ``writes`` so that a plain rebind of a
+    param name (``x, y = torch.broadcast_tensors(x, y)``) is not mistaken for a
+    mutation of the caller's tensor.
+    """
     rw = ReadWrites.from_list(body)
-    return [name for name in rw.writes if name in param_names]
+    return [name for name in rw.inplace_writes if name in param_names]
 
 
 def _validate_return(

--- a/helion/runtime/_tpu_compile_capture.py
+++ b/helion/runtime/_tpu_compile_capture.py
@@ -1,0 +1,367 @@
+"""Make a Helion Pallas kernel capturable by ``torch.compile(backend="tpu")``.
+
+Wrapping it as a ``torch.library.custom_op`` (+ ``register_fake`` meta) makes it
+opaque to Dynamo, so torch_xla captures one XLA node instead of tracing the eager
+torch_tpu -> jax bridge (which breaks). Same mechanism as torch_tpu's ``jax_op``.
+
+Two registration paths (opt in with ``HELION_TPU_COMPILE_CAPTURE=1``):
+
+* **Decoration-time** -- annotated, functional, benchmark-free kernels (``config=``
+  / ``autotune_effort="none"`` / ``aot_kernel``) register at definition: zero
+  warm-up, schema from annotations, scalars folded to ``hl.constexpr`` per call.
+* **First-call** (fallback) -- unannotated, mutating, or ``configs=[...]`` kernels
+  register on one eager warm-up; a miss under compile raises.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+import typing
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+
+import torch
+
+from .._compiler._dynamo.variables import _detect_mutated_inputs
+from .._compiler._dynamo.variables import infer_output_spec
+from ..language import constexpr
+
+if TYPE_CHECKING:
+    from .kernel import Kernel
+
+_capture_lib = torch.library.Library("helion_capture", "FRAGMENT")
+_op_counter = 0
+# {(id(kernel), signature) -> op or None}. A flat dict keyed by id() keeps the
+# under-compile lookup Dynamo-traceable (a WeakIdKeyDictionary thrashes it);
+# id() reuse is moot for module-scope kernels, which live for the process.
+_op_cache: dict[Any, Callable[..., Any] | None] = {}
+
+# Python scalar types that map directly to a torch.library schema type.
+_SCHEMA_TYPES: dict[type, str] = {float: "float", int: "int", bool: "bool"}
+
+# Sentinel: tells Kernel.__call__ to run its normal dispatch path.
+RUN_NORMAL = object()
+
+_MISS_MESSAGE = (
+    "Helion kernel {name!r} could not be captured under torch.compile on the "
+    "Pallas backend. Run it once eagerly (this shape) before compiling. Kernels "
+    "with input mutation or aliasing are not capturable."
+)
+_NOT_CAPTURABLE_MESSAGE = (
+    "Capture supports Tensor/tuple outputs with no input mutation or aliasing; "
+    "non-Tensor args (scalars, dtypes, flags) are baked in per value. These inputs "
+    "are not capturable."
+)
+
+
+def _define_op(
+    kernel: Kernel,
+    in_decl: str,
+    n_out: int,
+    fake: Callable[..., Any],
+    impl: Callable[..., Any],
+) -> Callable[..., Any]:
+    """Define + register one uniquely named ``helion_capture`` op and return it.
+
+    The fake is registered before the impl so a fake failure can't leave a live
+    impl with no meta. Outputs are Tensors (contiguous).
+    """
+    global _op_counter
+    _op_counter += 1
+    name = f"{kernel.name}_{_op_counter}"
+    out_decl = "Tensor" if n_out == 1 else "(" + ", ".join(["Tensor"] * n_out) + ")"
+    _capture_lib.define(f"{name}({in_decl}) -> {out_decl}")
+    torch.library.register_fake(f"helion_capture::{name}", fake)
+    _capture_lib.impl(name, impl, "CompositeExplicitAutograd")
+    return getattr(torch.ops.helion_capture, name)
+
+
+def _fake_and_impl(
+    kernel: Kernel,
+    n_out: int,
+    reconstruct: Callable[[tuple[Any, ...]], tuple[Any, ...]],
+    *,
+    validate: bool,
+) -> tuple[Callable[..., Any], Callable[..., Any]]:
+    """Build the (fake, impl) for a capture op. ``reconstruct`` maps the op's
+    incoming args to the kernel's full arg tuple (scalars folded to constexpr). The
+    fake infers output shapes per call (torch_xla recompiles per static shape) and,
+    when ``validate``, rejects input mutation/aliasing -- the decoration path never
+    traced at registration, while the first-call path already validated up front.
+    """
+
+    def fake(*args: object) -> torch.Tensor | tuple[torch.Tensor, ...]:
+        spec = infer_output_spec(kernel, reconstruct(args))
+        leaf = spec["leaf_specs"]
+        if validate and (
+            spec.get("mutated_inputs")
+            or spec.get("direct_aliases")
+            or any(s["type"] != "tensor" for s in leaf)
+        ):
+            raise RuntimeError(_NOT_CAPTURABLE_MESSAGE)
+        outs = [
+            torch.empty(s["shape"], dtype=s["dtype"], device=s["device"]) for s in leaf
+        ]
+        return outs[0] if n_out == 1 else tuple(outs)
+
+    def impl(*args: object) -> torch.Tensor | tuple[torch.Tensor, ...]:
+        full = reconstruct(args)
+        out = kernel.bind(full)(*full)
+        return tuple(out) if n_out > 1 else out
+
+    return fake, impl
+
+
+# --------------------------------------------------------------------------- #
+# Decoration-time path (the standard way): schema from annotations.
+# --------------------------------------------------------------------------- #
+def _decoration_schema(kernel: Kernel) -> tuple[list[type | None], int] | None:
+    """Derive ``(kinds, n_out)`` from the kernel's type hints, or None if the return
+    isn't ``Tensor``/``tuple[Tensor, ...]`` or a param isn't schema-able (dtype,
+    list, ConstExpr, ...). ``kinds[i]`` is ``None`` for a Tensor param (annotated
+    ``torch.Tensor`` or unannotated), else the scalar type. An annotation that won't
+    resolve makes ``get_type_hints`` raise; ``register_decoration_op`` catches that.
+    """
+    hints = typing.get_type_hints(kernel.fn)
+    ret = hints.get("return")
+    if ret is torch.Tensor:
+        n_out = 1
+    elif (
+        typing.get_origin(ret) is tuple
+        and (args := typing.get_args(ret))
+        and all(a is torch.Tensor for a in args)
+    ):
+        n_out = len(args)
+    else:
+        return None
+    kinds: list[type | None] = []
+    for name in kernel.signature.parameters:
+        hint = hints.get(name)
+        if hint is None or hint is torch.Tensor:
+            kinds.append(None)
+        elif hint in _SCHEMA_TYPES:
+            kinds.append(hint)
+        else:
+            return None
+    return kinds, n_out
+
+
+def _is_functional(kernel: Kernel) -> bool:
+    """True if the kernel body neither mutates an input nor returns one directly.
+
+    AST-only (no trace), so it is safe to check at decoration time. Subtle view
+    aliasing isn't detectable here; such kernels are rare in the pointwise/norm
+    domain and would otherwise be caught by the first-call trace.
+    """
+    names = set(kernel.signature.parameters)
+    src = textwrap.dedent(inspect.getsource(kernel.fn))
+    body = ast.parse(src).body[0].body  # type: ignore[attr-defined]
+    if _detect_mutated_inputs(body, names):
+        return False
+    return not any(
+        isinstance(node, ast.Return)
+        and isinstance(node.value, ast.Name)
+        and node.value.id in names
+        for node in ast.walk(ast.Module(body, []))
+    )
+
+
+def _resolves_without_benchmark(kernel: Kernel) -> bool:
+    """True if the kernel resolves a config with no runtime benchmark, any shape.
+
+    Mirrors the benchmark-free cases of the autotune dispatch (backend.autotune):
+    a single ``config=``, ``autotune_effort="none"`` with at most one config, or an
+    ``aot_kernel`` (heuristic cache, never benchmarks). ``force_autotune`` overrides
+    all of these (it benchmarks regardless), and ``configs=[...]`` / open autotuning
+    benchmark per shape -- those use the first-call warm-up path instead.
+    """
+    s = kernel.settings
+    if s.force_autotune:
+        return False
+    if s.autotune_effort == "none":
+        return len(kernel.configs) <= 1
+    return len(kernel.configs) == 1 or s.autotune_cache == "AOTAutotuneCache"
+
+
+def register_decoration_op(kernel: Kernel) -> Callable[..., Any] | None:
+    """Register the kernel's custom_op at decoration time, or None if ineligible.
+
+    Eligible kernels are functional, fully schema-derivable from annotations, and
+    benchmark-free; the returned callable takes the kernel's own signature and
+    routes through the op under torch.compile (scalars are folded to constexpr).
+    """
+    # Defensive: this runs in Kernel.__init__ (callers gate on the Pallas backend),
+    # so an ineligible/exotic kernel must return None, never raise and break the
+    # kernel's definition.
+    try:
+        parsed = _decoration_schema(kernel)
+        if (
+            parsed is None
+            or not _resolves_without_benchmark(kernel)
+            or not _is_functional(kernel)
+        ):
+            return None
+        return _build_decoration_op(kernel, *parsed)
+    except Exception:
+        return None
+
+
+def _build_decoration_op(
+    kernel: Kernel, kinds: list[type | None], n_out: int
+) -> Callable[..., Any]:
+    decl = ", ".join(
+        f"Tensor a{i}" if k is None else f"{_SCHEMA_TYPES[k]} a{i}"
+        for i, k in enumerate(kinds)
+    )
+
+    def fold(args: tuple[Any, ...]) -> tuple[Any, ...]:
+        # Scalars are constexpr (compile-time constants for the Pallas kernel);
+        # otherwise Helion materializes them as device buffers that orphan under
+        # capture (torch_tpu aborts: "argument not provided").
+        return tuple(
+            constexpr(a) if k is not None else a
+            for a, k in zip(args, kinds, strict=True)
+        )
+
+    # validate=True: the AST eligibility check can't see view-aliasing or in-place
+    # methods, so the fake re-validates per call and raises a clean compile error.
+    fake, impl = _fake_and_impl(kernel, n_out, fold, validate=True)
+    op = _define_op(kernel, decl, n_out, fake, impl)
+
+    def captured(args: tuple[Any, ...]) -> object:
+        return op(*kernel.normalize_args(*args))
+
+    return captured
+
+
+# --------------------------------------------------------------------------- #
+# First-call path (fallback): schema from a trace, scalars baked per value.
+# --------------------------------------------------------------------------- #
+def _freeze(v: object) -> object:
+    """Hashable view of a non-Tensor arg; raises TypeError if it holds a Tensor."""
+    if isinstance(v, torch.Tensor):
+        raise TypeError("Tensor inside a container arg")
+    if isinstance(v, (list, tuple)):
+        return tuple(_freeze(x) for x in v)
+    if isinstance(v, dict):
+        return tuple(sorted((k, _freeze(x)) for k, x in v.items()))
+    return v
+
+
+def _signature(args: tuple[Any, ...]) -> tuple[Any, ...] | None:
+    """Cache key over the arg *structure*, or None if a non-Tensor arg isn't
+    hashable. Tensors contribute only their position (generic over shape/dtype);
+    each distinct scalar/flag value keys a distinct (baked) op."""
+    try:
+        key = tuple(
+            ("tensor",)
+            if isinstance(a, torch.Tensor)
+            else ("const", type(a).__name__, _freeze(a))
+            for a in args
+        )
+        hash(key)
+    except TypeError:
+        return None
+    return key
+
+
+def _tensors(args: tuple[Any, ...]) -> tuple[torch.Tensor, ...]:
+    """The Tensor args, in order -- the actual arguments the captured op takes."""
+    return tuple(a for a in args if isinstance(a, torch.Tensor))
+
+
+def _const_scalar(a: object) -> object:
+    """Fold an int/float (incl. bool) arg to ``hl.constexpr``; others pass through."""
+    return constexpr(a) if isinstance(a, (int, float)) else a
+
+
+def build_op(kernel: Kernel, args: tuple[Any, ...]) -> Callable[..., Any] | None:
+    """Register (once, cached) a first-call custom_op for this kernel+signature.
+
+    Returns the op, or None if not capturable. Registration is best-effort: it runs
+    in the eager ``__call__`` path (result discarded, kernel then runs normally), so
+    a failure must cache None and fall through, never break the eager call.
+    ``_register_op`` returns None for the expected uncapturable cases (mutation/
+    aliasing/non-Tensor outputs); the except catches the rest -- e.g. a return inside
+    control flow, which ``infer_output_spec`` raises on -- and caches the miss so it
+    isn't retried (re-running it would re-autotune every call).
+    """
+    sig = _signature(args)
+    if sig is None:
+        return None
+    key = (id(kernel), sig)
+    if key not in _op_cache:
+        try:
+            _op_cache[key] = _register_op(kernel, args)
+        except Exception:
+            _op_cache[key] = None
+    return _op_cache[key]
+
+
+def _register_op(kernel: Kernel, args: tuple[Any, ...]) -> Callable[..., Any] | None:
+    # Fill omitted defaults (e.g. eps) so infer_output_spec's strict zip lines up
+    # and the baked consts carry every non-Tensor value.
+    args = kernel.normalize_args(*args)
+    spec = infer_output_spec(kernel, args)
+    leaf_specs = spec["leaf_specs"]
+    if (
+        spec.get("mutated_inputs")
+        or spec.get("direct_aliases")
+        or not leaf_specs
+        or any(s["type"] != "tensor" for s in leaf_specs)
+    ):
+        return None
+
+    consts = {
+        i: _const_scalar(a)
+        for i, a in enumerate(args)
+        if not isinstance(a, torch.Tensor)
+    }
+    n_args = len(args)
+
+    def rebuild(tensors: tuple[torch.Tensor, ...]) -> tuple[Any, ...]:
+        it = iter(tensors)
+        return tuple(consts[i] if i in consts else next(it) for i in range(n_args))
+
+    # Autotune the folded specialization eagerly; the impl runs it under
+    # torch.compile, where autotuning can't happen, so cache the config now.
+    if any(isinstance(a, (int, float)) for a in args):
+        full = rebuild(_tensors(args))
+        kernel.bind(full)(*full)
+
+    n_in, n_out = n_args - len(consts), len(leaf_specs)
+    in_decl = ", ".join(f"Tensor a{i}" for i in range(n_in))
+    # validate=False: capturability was already checked above on the real args.
+    fake, impl = _fake_and_impl(kernel, n_out, rebuild, validate=False)
+    return _define_op(kernel, in_decl, n_out, fake, impl)
+
+
+def _lookup_under_compile(kernel: Kernel, args: tuple[Any, ...]) -> object:
+    """Pure cache lookup + call -- the only Dynamo-traceable first-call path."""
+    sig = _signature(args)
+    op = _op_cache.get((id(kernel), sig)) if sig is not None else None
+    if op is None:
+        raise RuntimeError(_MISS_MESSAGE.format(name=kernel.name))
+    return op(*_tensors(args))
+
+
+# --------------------------------------------------------------------------- #
+# Entry points.
+# --------------------------------------------------------------------------- #
+def auto_capture_call(kernel: Kernel, args: tuple[Any, ...]) -> object:
+    """Pallas path for ``Kernel.__call__`` (opt-in ``HELION_TPU_COMPILE_CAPTURE``).
+
+    A decoration-registered op (zero warm-up) is preferred; otherwise the first-call
+    path registers on one eager warm-up and raises on a miss under compile.
+    """
+    cap = getattr(kernel, "_capture_op", None)
+    if torch.compiler.is_compiling():
+        if cap is not None:
+            return cap(args)
+        return _lookup_under_compile(kernel, args)
+    if cap is None:
+        build_op(kernel, args)
+    return RUN_NORMAL

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -9,6 +9,7 @@ import inspect
 import itertools
 import logging
 import operator
+import os
 import re
 import sys
 import textwrap
@@ -99,6 +100,10 @@ def _td_layout_guard_active_for_config(
 
 _R = TypeVar("_R")
 CompiledConfig = Callable[..., _R]
+
+# Opt-in: auto-capture Pallas kernels under torch.compile (see _tpu_compile_capture).
+# Off by default so the eager dispatch path is unchanged.
+_TPU_COMPILE_CAPTURE = os.environ.get("HELION_TPU_COMPILE_CAPTURE", "0") == "1"
 
 # Cache for GraphModule hashes
 _graph_module_hash_cache: WeakIdKeyDictionary = WeakIdKeyDictionary()
@@ -224,6 +229,16 @@ class Kernel(Generic[_R]):
         self.__code__ = fn.__code__
         self.__defaults__ = fn.__defaults__
         self.__kwdefaults__ = fn.__kwdefaults__
+
+        # Opt-in: register the torch.compile(backend="tpu") capture op now, so an
+        # annotated/functional/benchmark-free Pallas kernel is captured with zero
+        # warm-up (like a hand-written custom_op). None if it must use first-call
+        # registration (unannotated, mutating, or autotuning among configs=[...]).
+        self._capture_op: Callable[..., Any] | None = None
+        if self.settings.backend == "pallas" and _TPU_COMPILE_CAPTURE:
+            from ._tpu_compile_capture import register_decoration_op
+
+            self._capture_op = register_decoration_op(self)
 
     def _settings_signature(self) -> str:
         """Return a stable string of settings that influence Triton codegen.
@@ -453,6 +468,15 @@ class Kernel(Generic[_R]):
         """
         if kwargs:
             args = self.normalize_args(*args, **kwargs)
+        if self.settings.backend == "pallas" and _TPU_COMPILE_CAPTURE:
+            # Local import: _tpu_compile_capture pulls in the dynamo HOP machinery,
+            # not ready when kernel.py first loads during ``import helion``.
+            from ._tpu_compile_capture import RUN_NORMAL
+            from ._tpu_compile_capture import auto_capture_call
+
+            result = auto_capture_call(self, args)
+            if result is not RUN_NORMAL:
+                return cast("_R", result)
         return self.bind(args)(*args)
 
     def reset(self) -> None:
@@ -1485,6 +1509,8 @@ def _find_device(args: tuple[object, ...]) -> torch.device:
             return arg
         if isinstance(arg, torch.Tensor):
             return arg.device
+        if isinstance(arg, ConstExpr):
+            continue  # a constexpr-wrapped value carries no device; skip it
         if isinstance(arg, (tuple, list)):
             for item in arg:
                 try:

--- a/test/test_compile_capture.py
+++ b/test/test_compile_capture.py
@@ -1,0 +1,220 @@
+"""Unit tests for the TPU compile-capture support logic.
+
+Most cover the device-independent pieces (schema/eligibility derivation, cache-key
+signature, scalar folding, default filling, and the mutation detector) so the
+capture path's correctness does not rest solely on hardware runs; these require no
+backend. One Pallas-gated test exercises ``register_decoration_op`` end to end; it
+runs under the pallas-interpret backend, so no TPU hardware is needed.
+"""
+
+from __future__ import annotations
+
+import ast
+import unittest
+
+import pytest
+import torch
+
+import helion
+from helion._compiler._dynamo.variables import _detect_mutated_inputs
+from helion._testing import DEVICE
+from helion._testing import skipUnlessPallas
+import helion.language as hl
+from helion.runtime._tpu_compile_capture import _const_scalar
+from helion.runtime._tpu_compile_capture import _decoration_schema
+from helion.runtime._tpu_compile_capture import _freeze
+from helion.runtime._tpu_compile_capture import _is_functional
+from helion.runtime._tpu_compile_capture import _resolves_without_benchmark
+from helion.runtime._tpu_compile_capture import _signature
+from helion.runtime._tpu_compile_capture import _tensors
+from helion.runtime._tpu_compile_capture import register_decoration_op
+
+
+@helion.kernel(
+    backend="pallas", static_shapes=True, config=helion.Config(block_sizes=[16, 16])
+)
+def _cap_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    x, y = torch.broadcast_tensors(x, y)  # rebind: also exercises inplace_writes fix
+    out = torch.empty(x.shape, dtype=x.dtype, device=x.device)
+    for tile in hl.tile(out.size()):
+        out[tile] = x[tile] + y[tile]
+    return out
+
+
+def _body(src: str) -> list[ast.stmt]:
+    return ast.parse(src).body
+
+
+class TestDetectMutatedInputs:
+    def test_param_rebind_is_not_mutation(self) -> None:
+        # The bug this guards: `x, y = ...` rebinds names but does not mutate the
+        # caller's tensors, so it must not be reported as an input mutation.
+        body = _body("x, y = torch.broadcast_tensors(x, y)\nout = x + y\n")
+        assert _detect_mutated_inputs(body, {"x", "y"}) == []
+
+    def test_subscript_store_is_mutation(self) -> None:
+        body = _body("x[tile] = y[tile]\n")
+        assert _detect_mutated_inputs(body, {"x", "y"}) == ["x"]
+
+    def test_atomic_is_mutation(self) -> None:
+        body = _body("hl.atomic_add(x, [i], v)\n")
+        assert _detect_mutated_inputs(body, {"x"}) == ["x"]
+
+    def test_store_to_local_not_flagged(self) -> None:
+        # `out` is not a parameter, so storing into it is not an input mutation.
+        body = _body("out[tile] = x[tile]\n")
+        assert _detect_mutated_inputs(body, {"x"}) == []
+
+
+class TestSignature:
+    def test_bool_int_float_do_not_collide(self) -> None:
+        # True == 1 == 1.0 hash-equal; the key must keep them distinct.
+        kb = _signature((True,))
+        ki = _signature((1,))
+        kf = _signature((1.0,))
+        assert kb != ki != kf and kb != kf
+        assert _signature((1,)) == _signature((1,))
+
+    def test_distinct_scalar_values_distinct_keys(self) -> None:
+        assert _signature((1e-5,)) != _signature((1e-6,))
+
+    def test_tensors_are_shape_and_dtype_generic(self) -> None:
+        # The op is generic over shape/dtype (the fake infers per call), so two
+        # tensors key the SAME op -- one op serves every shape.
+        a = torch.empty(4, 8, dtype=torch.float32)
+        b = torch.empty(16, 16, dtype=torch.float16)
+        assert _signature((a,)) == _signature((b,))
+        assert _signature((a,)) != _signature((1.0,))  # tensor vs scalar differ
+
+    def test_list_arg_is_keyable(self) -> None:
+        assert _signature(([8192],)) is not None
+        assert _signature(([8192],)) == _signature(([8192],))
+
+    def test_list_holding_tensor_is_rejected(self) -> None:
+        assert _signature(([torch.empty(2)],)) is None
+
+
+class TestFreeze:
+    def test_nested_container_frozen(self) -> None:
+        assert _freeze([1, [2, 3]]) == (1, (2, 3))
+
+    def test_tensor_inside_container_raises(self) -> None:
+        with pytest.raises(TypeError):
+            _freeze([torch.empty(2)])
+
+
+class TestConstScalar:
+    def test_int_and_float_folded(self) -> None:
+        assert isinstance(_const_scalar(1e-5), hl.constexpr)
+        assert isinstance(_const_scalar(3), hl.constexpr)
+        assert isinstance(_const_scalar(True), hl.constexpr)
+
+    def test_non_scalar_passes_through(self) -> None:
+        t = torch.empty(2)
+        assert _const_scalar(t) is t
+        assert _const_scalar(None) is None
+        assert _const_scalar([1, 2]) == [1, 2]
+
+
+class TestArgs:
+    def test_normalize_args_fills_trailing_default(self) -> None:
+        # Capture relies on normalize_args filling omitted scalar defaults (eps).
+        @helion.kernel()
+        def k(x: torch.Tensor, eps: float = 1e-5) -> torch.Tensor:
+            return x
+
+        x = torch.empty(4)
+        assert k.normalize_args(x) == (x, 1e-5)
+
+    def test_tensors_extracts_in_order(self) -> None:
+        a, b = torch.empty(2), torch.empty(3)
+        assert _tensors((a, 0.5, b)) == (a, b)
+
+
+_C16 = helion.Config(block_sizes=[16])
+_C32 = helion.Config(block_sizes=[32])
+
+
+def _pallas_kernel(fn: object, **settings: object) -> object:
+    return helion.kernel(fn, backend="pallas", **settings)  # type: ignore[arg-type]
+
+
+class TestResolvesWithoutBenchmark:
+    """The decoration path only registers kernels that resolve a config with NO
+    runtime benchmark; an over-broad predicate would autotune at lowering (crash)."""
+
+    def _k(self, **settings: object) -> object:
+        def k(x: torch.Tensor) -> torch.Tensor:
+            return x
+
+        return _pallas_kernel(k, **settings)
+
+    def test_single_config_is_benchmark_free(self) -> None:
+        assert _resolves_without_benchmark(self._k(config=_C16))
+
+    def test_multiple_configs_benchmark(self) -> None:
+        assert not _resolves_without_benchmark(self._k(configs=[_C16, _C32]))
+
+    def test_effort_none_at_most_one_config_is_benchmark_free(self) -> None:
+        assert _resolves_without_benchmark(self._k(autotune_effort="none"))
+        # effort="none" with >=2 configs still benchmarks (FiniteSearch).
+        assert not _resolves_without_benchmark(
+            self._k(autotune_effort="none", configs=[_C16, _C32])
+        )
+
+    def test_force_autotune_overrides(self) -> None:
+        # force_autotune benchmarks regardless of a provided config.
+        assert not _resolves_without_benchmark(
+            self._k(config=_C16, force_autotune=True)
+        )
+
+
+class TestDecorationSchema:
+    def test_all_tensor_single_output(self) -> None:
+        def k(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            return x
+
+        assert _decoration_schema(_pallas_kernel(k, config=_C16)) == ([None, None], 1)
+
+    def test_typed_scalar_and_tuple_return(self) -> None:
+        def k(x: torch.Tensor, eps: float) -> tuple[torch.Tensor, torch.Tensor]:
+            return x, x
+
+        assert _decoration_schema(_pallas_kernel(k, config=_C16)) == ([None, float], 2)
+
+    def test_unannotated_return_is_ineligible(self) -> None:
+        def k(x: torch.Tensor):  # no return annotation
+            return x
+
+        assert _decoration_schema(_pallas_kernel(k, config=_C16)) is None
+
+
+class TestIsFunctional:
+    def test_pure_kernel(self) -> None:
+        def k(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(out.size()):
+                out[tile] = x[tile]
+            return out
+
+        assert _is_functional(_pallas_kernel(k, config=_C16))
+
+    def test_returning_an_input_is_rejected(self) -> None:
+        def k(x: torch.Tensor) -> torch.Tensor:
+            return x
+
+        assert not _is_functional(_pallas_kernel(k, config=_C16))
+
+
+@skipUnlessPallas("Pallas/TPU backend not available")
+class TestCompileCaptureRoundtrip(unittest.TestCase):
+    def test_captured_callable_matches_eager(self) -> None:
+        # End-to-end: register_decoration_op registers ONE op (annotated, functional,
+        # benchmark-free); the returned callable runs it on the Pallas backend and
+        # must match the eager kernel (generic over shape -- 2nd shape reuses the op).
+        captured = register_decoration_op(_cap_add)
+        self.assertIsNotNone(captured)
+        for m, n in [(64, 64), (32, 128)]:
+            x = torch.randn(m, n, device=DEVICE)
+            y = torch.randn(m, n, device=DEVICE)
+            torch.testing.assert_close(captured((x, y)), _cap_add(x, y))


### PR DESCRIPTION
Stacked PRs:
 * __->__#2730
 * #2727
 * #2726
 * #2725


--- --- ---

### Decoration-time `torch.compile(backend="tpu")` capture for Helion Pallas kernels

Wrap a Helion Pallas kernel as a `torch.library.custom_op` (with a `register_fake` meta) so it is opaque to Dynamo and torch_xla captures it as a single XLA-graph node — instead of tracing into the eager `torch_tpu → jax` bridge, which is not Dynamo-traceable and breaks `fullgraph`.

#### How you use it

Write a normal **annotated** Helion kernel that pins a `config=`, opt in, and call it inside a `torch.compile(backend="tpu")` region — nothing else:

```python
import os
os.environ["HELION_TPU_COMPILE_CAPTURE"] = "1"   # opt in (read at import — set it first)

import torch, helion
import helion.language as hl

@helion.kernel(backend="pallas", config=helion.Config(block_sizes=[256, 256]))
def add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
    out = torch.empty_like(x)
    for tile in hl.tile(out.size()):
        out[tile] = x[tile] + y[tile]
    return out

def model(x, y):
    return add(x, y) * 2             # a Helion kernel inside a larger fn

compiled = torch.compile(model, backend="tpu", dynamic=False)
compiled(x, y)                        # `add` is captured as one XLA node — no warm-up
```

Because `add` is annotated, functional, and pins a `config=`, its `torch.library.custom_op` is registered **when the kernel is defined** (in `Kernel.__init__`, gated on the opt-in), so the first `compiled(x, y)` captures it with **zero warm-up**. Scalar args go in the op schema and are folded to `hl.constexpr` per call. A kernel that instead autotunes among `configs=[...]`, is unannotated, or mutates an input is registered on **one eager call** (`add(x, y)`) before compiling — see *Fallback + safety* below.

#### Same pattern as a hand-written custom kernel

Capture uses the exact same primitives as a GPU `torch.library.custom_op` / torch_tpu's `jax_op` (`custom_op` + `register_fake`), with Helion's jax-free `infer_output_spec` as the fake — so the user writes none, and the captured node is an opaque XLA node **indistinguishable from a hand-written custom kernel**: zero warm-up, recompiled per static shape, config baked in (never autotunes at lowering).

#### Fallback + safety

Kernels that don't fit the decoration mold fall back to **first-call** registration — the op is registered as a side effect of one eager warm-up:

- `configs=[...]` (benchmark among a list) and unannotated kernels register this way; a miss under compile (not warmed at that signature) raises clearly. `configs=[...]` needs the warm-up **per shape** regardless — the benchmark can't run at lowering.
- **Mutating/aliasing kernels are not capturable** — first-call registration returns no op (rejected via `infer_output_spec`), so a compile attempt **raises rather than silently miscompiling**, the same donation conflict torch_tpu's `jax_op` sidesteps with `mutates_args=()`. If an annotated kernel's aliasing slips past the decoration-time AST check (e.g. returning an input), the decoration `fake` re-validates per call via `infer_output_spec` and raises too.

### Results

Measured on tpu7x, wall-time ms (median).

#### 1. New capture vs the old eager Pallas-call path

`Helion eager` = the kernel run **without** `torch.compile`, through the eager `JaxCallable`/`call_custom_kernel` dispatch; `Helion captured` = the same kernel under `torch.compile(backend="tpu")` as one XLA node. Per single kernel the capture is roughly neutral (the eager direct-call path is already well optimized), with wins where the eager dispatch was heavier (rms_norm, broadcast_matmul, cross_entropy, layer_norm). The larger structural win is collapsing N per-call dispatches in a multi-kernel `fullgraph` region into one XLA graph.

| kernel | Helion eager (old path) | Helion captured | capture vs eager |
|---|---|---|---|
| attention | 51.62 | 51.47 | 1.00× |
| softmax | 0.478 | 0.496 | 0.96× |
| batch_softmax | 0.952 | 0.981 | 0.97× |
| softmax_two_pass | 0.331 | 0.365 | 0.91× |
| bmm | 1.512 | 1.522 | 0.99× |
| matmul_layernorm | 0.480 | 0.481 | 1.00× |
| broadcast_matmul | 1.764 | 1.422 | 1.24× |
| matmul | 1.594 | 1.613 | 0.99× |
| swiglu | 2.343 | 2.378 | 0.99× |
| geglu | 2.410 | 2.436 | 0.99× |
| cross_entropy | 0.270 | 0.215 | 1.25× |
| layer_norm | 1.128 | 0.911 | 1.24× |
| rms_norm | 0.607 | 0.425 | 1.43× |

#### 2. Helion (captured) vs the PyTorch baselines under torch_tpu

`torch_tpu eager` = the PyTorch reference run eagerly; `torch.compile(tpu)` = the same reference under `torch.compile(backend="tpu")`; `Helion` = the Helion kernel captured.

| kernel | shape | torch_tpu eager | torch.compile(tpu) | Helion | Helion vs torch.compile | Helion vs torch_tpu eager |
|---|---|---|---|---|---|---|
| attention | [8,32,8192,256] | 92.03 | 92.15 | 51.47 | **1.79×** | **1.79×** |
| softmax | [65536,2560] | 0.742 | 0.722 | 0.496 | **1.45×** | **1.49×** |
| batch_softmax | [64,2048,4096] | 1.901 | 1.357 | 0.981 | **1.38×** | **1.94×** |
| softmax_two_pass | [8192,8192] | 0.402 | 0.419 | 0.365 | **1.15×** | **1.10×** |
| bmm | [64,2048,2048,2048] | 3.195 | 1.560 | 1.522 | **1.02×** | **2.10×** |
| matmul_layernorm | [4096,4096,4096] | 0.529 | 0.481 | 0.481 | 1.00× | **1.10×** |
| broadcast_matmul | [64,2048,2048,2048] | 1.806 | 1.413 | 1.422 | 0.99× | **1.27×** |
| matmul | [8192,8192,8192] | 1.537 | 1.510 | 1.613 | 0.94× | 0.95× |
| swiglu | [16,16384,4096] | 3.551 | 2.205 | 2.378 | 0.93× | **1.49×** |
| geglu | [16,8192,8192] | 3.780 | 2.226 | 2.436 | 0.91× | **1.55×** |
| cross_entropy | [128,2048] | 0.391 | 0.188 | 0.215 | 0.88× | **1.81×** |
| layer_norm | [16384,16384] | 0.876 | 0.776 | 0.911 | 0.85× | 0.96× |
| rms_norm | [8192,8192] | 1.177 | 0.341 | 0.425 | 0.80× | **2.77×** |

Helion (captured) beats `torch_tpu eager` on 11/13 and `torch.compile(tpu)` on 5/13 (matmul_layernorm neutral). rms_norm (0.80× vs 0.75×) and layer_norm (0.85× vs 0.77×) improved against `torch.compile` versus the earlier run; the remaining gaps there are inherent to Helion-kernel-vs-XLA for those ops, unchanged by the capture mechanism.
