### PR TITLE
Add AWS Bedrock provider to LLM autotuner transport

### DIFF
--- a/helion/autotuner/llm/transport.py
+++ b/helion/autotuner/llm/transport.py
@@ -34,6 +34,12 @@ _ANTHROPIC_ADAPTIVE_MIN_VERSIONS: dict[str, tuple[int, int]] = {
     "opus": (4, 5),
     "sonnet": (4, 6),
 }
+# Per-family minimum (major, minor) at/after which the `temperature` knob is
+# deprecated and rejected (HTTP 400 on the API, ValidationException on Bedrock).
+# Opus 4.7+ rejects it. Below-minimum / unlisted families still accept it.
+_ANTHROPIC_TEMPERATURE_DEPRECATED_MIN_VERSIONS: dict[str, tuple[int, int]] = {
+    "opus": (4, 7),
+}
 # Minor capped at 2 digits + non-digit lookahead so 8-digit date suffixes (e.g.
 # `claude-opus-4-20250514`) don't get mis-parsed as the minor version.
 _ANTHROPIC_MODEL_VERSION_RE = re.compile(
@@ -48,6 +54,9 @@ _PROVIDER_ALIASES = {
     "openai": "openai_responses",
     "openai_responses": "openai_responses",
     "openai-responses": "openai_responses",
+    "bedrock": "bedrock",
+    "aws_bedrock": "bedrock",
+    "aws-bedrock": "bedrock",
 }
 
 
@@ -58,7 +67,7 @@ def normalize_provider(provider: str) -> str:
         return resolved
     raise ValueError(
         f"Unsupported LLM provider {provider!r}. "
-        "Valid providers are: anthropic, openai, openai_responses."
+        "Valid providers are: anthropic, openai, openai_responses, bedrock."
     )
 
 
@@ -67,6 +76,12 @@ def infer_provider(model: str, provider: str | None = None) -> str:
     if provider is not None:
         return normalize_provider(provider)
     normalized = model.lower()
+    # Bedrock must be opted into explicitly with a `bedrock/` prefix (e.g.
+    # `bedrock/us.anthropic.claude-sonnet-4-6`), or via HELION_LLM_PROVIDER=bedrock.
+    # A bare region-prefixed id like `us.anthropic.claude-...` is NOT auto-routed
+    # to Bedrock, since the same model string can be served by the direct API.
+    if normalized.startswith("bedrock/"):
+        return "bedrock"
     if normalized.startswith(("claude", "anthropic/")):
         return "anthropic"
     if normalized.startswith(
@@ -78,7 +93,7 @@ def infer_provider(model: str, provider: str | None = None) -> str:
 
 def strip_provider_prefix(model: str) -> str:
     """Remove a provider prefix before sending the model name to the API."""
-    for prefix in ("anthropic/", "openai/"):
+    for prefix in ("anthropic/", "openai/", "bedrock/"):
         if model.startswith(prefix):
             return model.removeprefix(prefix)
     return model
@@ -158,15 +173,38 @@ def _anthropic_thinking_budget_tokens(effort_level: str | None) -> int | None:
     return _ANTHROPIC_THINKING_BUDGET_BY_EFFORT[normalized]
 
 
-def _supports_anthropic_adaptive(model: str) -> bool:
-    match = _ANTHROPIC_MODEL_VERSION_RE.match(model.lower())
+def _anthropic_version_at_least(
+    model: str, minimums: dict[str, tuple[int, int]]
+) -> bool:
+    """Return True if `model`'s (family, version) meets the per-family minimum.
+
+    Tolerates Bedrock-style IDs (e.g. `us.anthropic.claude-opus-4-8`) by matching
+    the `claude-...` segment anywhere in the string, not just at the start.
+    """
+    normalized = model.lower()
+    # Bedrock prefixes the model with a region/partition + `anthropic.`; drop
+    # everything up to and including that so the `claude-...` regex can match.
+    if "anthropic." in normalized:
+        normalized = normalized.rsplit("anthropic.", 1)[1]
+    match = _ANTHROPIC_MODEL_VERSION_RE.match(normalized)
     if match is None:
         return False
     family, major_str, minor_str = match.groups()
-    minimum = _ANTHROPIC_ADAPTIVE_MIN_VERSIONS.get(family)
+    minimum = minimums.get(family)
     if minimum is None:
         return False
     return (int(major_str), int(minor_str) if minor_str else 0) >= minimum
+
+
+def _supports_anthropic_adaptive(model: str) -> bool:
+    return _anthropic_version_at_least(model, _ANTHROPIC_ADAPTIVE_MIN_VERSIONS)
+
+
+def _temperature_deprecated(model: str) -> bool:
+    """Whether the model rejects the `temperature` knob (Opus 4.7+)."""
+    return _anthropic_version_at_least(
+        model, _ANTHROPIC_TEMPERATURE_DEPRECATED_MIN_VERSIONS
+    )
 
 
 def _anthropic_max_tokens(
@@ -272,11 +310,11 @@ def _anthropic_payload(
             "type": "enabled",
             "budget_tokens": thinking_token_budget,
         }
-    # Claude Opus 4.7, extended thinking, and fast mode each reject `temperature`.
+    # Claude Opus 4.7+, extended thinking, and fast mode each reject `temperature`.
     if (
         not enable_thinking
         and not fast_mode
-        and not normalized_model.lower().startswith("claude-opus-4-7")
+        and not _temperature_deprecated(normalized_model)
     ):
         payload["temperature"] = DEFAULT_ANTHROPIC_TEMPERATURE
     if system_prompt:
@@ -516,6 +554,86 @@ def _post_json(
     raise RuntimeError(f"Unexpected JSON payload from {url}: {type(body).__name__}")
 
 
+# Anthropic-on-Bedrock requires this version string in the request body and
+# forbids the `model` field (the model is named by `modelId` on the API call).
+_BEDROCK_ANTHROPIC_VERSION = "bedrock-2023-05-31"
+
+
+def _resolve_bedrock_region(api_base: str | None) -> str | None:
+    """Pick the AWS region for Bedrock from the api_base override or env."""
+    # Allow `api_base` to carry the region (e.g. "us-east-1") for parity with
+    # the other providers' single knob; otherwise fall back to the standard
+    # AWS env vars, then let boto3's own config/role resolution take over.
+    return (
+        api_base or os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+    )
+
+
+def _call_bedrock(
+    *,
+    model: str,
+    api_base: str | None,
+    messages: list[dict[str, str]],
+    max_output_tokens: int,
+    request_timeout_s: float,
+    effort_level: str | None,
+    fast_mode: bool,
+) -> str:
+    """Invoke Anthropic-on-Bedrock via boto3, reusing the Anthropic codecs.
+
+    Auth is handled by boto3's default credential chain (IAM role, env creds,
+    or profile) -- no API key is read. The request body is the same Anthropic
+    Messages payload used by the direct API, minus `model` and plus the Bedrock
+    `anthropic_version`.
+
+    Request/response format and the boto3 ``invoke_model`` usage follow the AWS
+    reference example:
+    https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-runtime_example_bedrock-runtime_InvokeModel_AnthropicClaude_section.html
+    """
+    try:
+        # boto3 is an optional dependency: only required when the Bedrock
+        # provider is actually used, so it isn't a Helion install requirement.
+        import boto3  # pyrefly: ignore [missing-import]
+        import botocore.config  # pyrefly: ignore [missing-import]
+    except ImportError as e:
+        raise RuntimeError(
+            "Bedrock provider requested but boto3 is not installed. "
+            "Install it with `pip install boto3`."
+        ) from e
+
+    payload = _anthropic_payload(
+        model,
+        messages,
+        max_output_tokens,
+        effort_level,
+        fast_mode,
+    )
+    # On Bedrock the model is named by `modelId`, not in the body.
+    model_id = payload.pop("model")
+    payload["anthropic_version"] = _BEDROCK_ANTHROPIC_VERSION
+
+    client = boto3.client(
+        "bedrock-runtime",
+        region_name=_resolve_bedrock_region(api_base),
+        config=botocore.config.Config(
+            read_timeout=request_timeout_s,
+            connect_timeout=request_timeout_s,
+            retries={"max_attempts": 2, "mode": "standard"},
+        ),
+    )
+    try:
+        response = client.invoke_model(modelId=model_id, body=json.dumps(payload))
+    except Exception as e:  # botocore.exceptions.ClientError and friends
+        raise RuntimeError(f"Bedrock invoke_model failed for {model_id!r}: {e}") from e
+
+    body = json.loads(response["body"].read())
+    if not isinstance(body, dict):
+        raise RuntimeError(
+            f"Unexpected Bedrock payload from {model_id!r}: {type(body).__name__}"
+        )
+    return extract_anthropic_text(body)
+
+
 def call_provider(
     provider: str,
     *,
@@ -530,6 +648,18 @@ def call_provider(
 ) -> str:
     """Resolve credentials, send one request, and extract text from the response."""
     normalized_provider = normalize_provider(provider)
+    if normalized_provider == "bedrock":
+        # Bedrock uses boto3/SigV4 instead of an HTTP+api-key transport, so it
+        # bypasses the _ProviderConfig path entirely.
+        return _call_bedrock(
+            model=model,
+            api_base=api_base,
+            messages=messages,
+            max_output_tokens=max_output_tokens,
+            request_timeout_s=request_timeout_s,
+            effort_level=effort_level,
+            fast_mode=fast_mode,
+        )
     config = _provider_config(normalized_provider)
     resolved_api_key = _resolve_api_key(normalized_provider, api_key)
     response = _post_json(

--- a/test/test_llm_autotuner.py
+++ b/test/test_llm_autotuner.py
@@ -1112,17 +1112,19 @@ class TestBedrockTransport(TestCase):
                 raise ImportError(f"No module named {name!r}")
             return real_import(name, *args, **kwargs)
 
-        with patch.object(builtins, "__import__", side_effect=fake_import):
-            with self.assertRaisesRegex(RuntimeError, "boto3 is not installed"):
-                call_provider(
-                    "bedrock",
-                    model="us.anthropic.claude-sonnet-4-6",
-                    api_base=None,
-                    api_key=None,
-                    messages=[{"role": "user", "content": "hi"}],
-                    max_output_tokens=64,
-                    request_timeout_s=120.0,
-                )
+        with (
+            patch.object(builtins, "__import__", side_effect=fake_import),
+            self.assertRaisesRegex(RuntimeError, "boto3 is not installed"),
+        ):
+            call_provider(
+                "bedrock",
+                model="us.anthropic.claude-sonnet-4-6",
+                api_base=None,
+                api_key=None,
+                messages=[{"role": "user", "content": "hi"}],
+                max_output_tokens=64,
+                request_timeout_s=120.0,
+            )
 
 
 class TestLLMSeededLFBOTreeSearch(TestCase):

--- a/test/test_llm_autotuner.py
+++ b/test/test_llm_autotuner.py
@@ -934,6 +934,197 @@ class TestLLMTransport(TestCase):
         self.assertNotIn("speed", captured["payload"])
 
 
+class TestBedrockTransport(TestCase):
+    """Tests for the AWS Bedrock provider (boto3/SigV4, no API key)."""
+
+    def test_infer_provider_requires_explicit_bedrock_prefix(self):
+        """Bedrock must be opted into with an explicit `bedrock/` prefix (or the
+        HELION_LLM_PROVIDER override). Bare region-prefixed Bedrock model IDs are
+        NOT auto-routed, since the same string can be served by the direct API."""
+        from helion.autotuner.llm.transport import infer_provider
+
+        cases = {
+            # Explicit bedrock/ prefix -> bedrock.
+            "bedrock/us.anthropic.claude-sonnet-4-6": "bedrock",
+            "bedrock/us.anthropic.claude-opus-4-8": "bedrock",
+            # Bare region-prefixed Bedrock IDs are NOT auto-detected.
+            "us.anthropic.claude-sonnet-4-6": "unsupported",
+            "apac.anthropic.claude-3-5-haiku-20241022-v1:0": "unsupported",
+            # Bare Anthropic / OpenAI IDs keep their existing providers.
+            "claude-opus-4-7": "anthropic",
+            "anthropic/claude-3-5-sonnet": "anthropic",
+            "gpt-5.5": "openai_responses",
+            "custom/model": "unsupported",
+            # Explicit provider override still routes a bare id to bedrock.
+            ("us.anthropic.claude-sonnet-4-6", "bedrock"): "bedrock",
+        }
+        for model, expected in cases.items():
+            with self.subTest(model=model):
+                if isinstance(model, tuple):
+                    self.assertEqual(infer_provider(model[0], model[1]), expected)
+                else:
+                    self.assertEqual(infer_provider(model), expected)
+
+    def test_normalize_provider_aliases_and_error(self):
+        """Bedrock provider aliases canonicalize; bedrock joins the error message."""
+        from helion.autotuner.llm.transport import normalize_provider
+
+        for alias in ("bedrock", "aws_bedrock", "aws-bedrock"):
+            with self.subTest(alias=alias):
+                self.assertEqual(normalize_provider(alias), "bedrock")
+        with self.assertRaisesRegex(ValueError, "bedrock"):
+            normalize_provider("bogus")
+
+    def test_strip_provider_prefix_drops_bedrock(self):
+        """The bedrock/ prefix is stripped like anthropic/ and openai/."""
+        from helion.autotuner.llm.transport import strip_provider_prefix
+
+        self.assertEqual(
+            strip_provider_prefix("bedrock/us.anthropic.claude-opus-4-8"),
+            "us.anthropic.claude-opus-4-8",
+        )
+        self.assertEqual(
+            strip_provider_prefix("us.anthropic.claude-opus-4-8"),
+            "us.anthropic.claude-opus-4-8",
+        )
+
+    def test_temperature_deprecated_version_matrix(self):
+        """`temperature` deprecation follows per-family minimum versions and
+        tolerates Bedrock-prefixed IDs."""
+        from helion.autotuner.llm.transport import _temperature_deprecated
+
+        cases = {
+            # Opus 4.7+ rejects temperature (both bare and Bedrock-prefixed forms).
+            "claude-opus-4-7": True,
+            "claude-opus-4-8": True,
+            "us.anthropic.claude-opus-4-7": True,
+            "us.anthropic.claude-opus-4-8": True,
+            "us.anthropic.claude-opus-5-0": True,
+            # Opus 4.6 and earlier still accept temperature.
+            "claude-opus-4-6": False,
+            "us.anthropic.claude-opus-4-6-v1": False,
+            "us.anthropic.claude-opus-4-5-20251101-v1:0": False,
+            # Sonnet has no temperature-deprecation entry -> always accepts it.
+            "claude-sonnet-4-6": False,
+            "us.anthropic.claude-sonnet-4-6": False,
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0": False,
+            # Non-Anthropic / unknown strings fall through.
+            "gpt-5.5": False,
+            "custom-model": False,
+        }
+        for model, expected in cases.items():
+            with self.subTest(model=model):
+                self.assertEqual(_temperature_deprecated(model), expected)
+
+    def test_resolve_bedrock_region_precedence(self):
+        """Region comes from api_base override first, then AWS_REGION,
+        then AWS_DEFAULT_REGION."""
+        from helion.autotuner.llm.transport import _resolve_bedrock_region
+
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(_resolve_bedrock_region("us-west-2"), "us-west-2")
+            self.assertIsNone(_resolve_bedrock_region(None))
+        with patch.dict(os.environ, {"AWS_REGION": "us-east-1"}, clear=True):
+            self.assertEqual(_resolve_bedrock_region(None), "us-east-1")
+            # Explicit api_base still wins over the env var.
+            self.assertEqual(_resolve_bedrock_region("eu-west-1"), "eu-west-1")
+        with patch.dict(os.environ, {"AWS_DEFAULT_REGION": "ap-south-1"}, clear=True):
+            self.assertEqual(_resolve_bedrock_region(None), "ap-south-1")
+
+    def test_call_provider_bedrock_invokes_boto3_and_extracts_text(self):
+        """call_provider('bedrock', ...) builds the Anthropic body, moves the
+        model to modelId, adds anthropic_version, and parses the response."""
+        import json
+
+        from helion.autotuner.llm.transport import call_provider
+
+        captured = {}
+
+        class FakeBody:
+            def __init__(self, payload: bytes) -> None:
+                self._payload = payload
+
+            def read(self) -> bytes:
+                return self._payload
+
+        class FakeBedrockClient:
+            def invoke_model(self, *, modelId, body):
+                captured["modelId"] = modelId
+                captured["body"] = json.loads(body)
+                resp = {"content": [{"type": "text", "text": '{"configs": []}'}]}
+                return {"body": FakeBody(json.dumps(resp).encode("utf-8"))}
+
+        def fake_boto3_client(service, *, region_name=None, config=None):
+            captured["service"] = service
+            captured["region_name"] = region_name
+            return FakeBedrockClient()
+
+        fake_boto3 = SimpleNamespace(client=fake_boto3_client)
+        fake_botocore_config = SimpleNamespace(
+            config=SimpleNamespace(Config=lambda **kw: ("config", kw))
+        )
+        messages = [
+            {"role": "system", "content": "tune kernels"},
+            {"role": "user", "content": "suggest configs"},
+        ]
+        with (
+            patch.dict(os.environ, {"AWS_REGION": "us-east-2"}, clear=True),
+            patch.dict(
+                "sys.modules",
+                {
+                    "boto3": fake_boto3,
+                    "botocore": SimpleNamespace(config=fake_botocore_config.config),
+                    "botocore.config": fake_botocore_config.config,
+                },
+            ),
+        ):
+            response = call_provider(
+                "bedrock",
+                model="us.anthropic.claude-sonnet-4-6",
+                api_base=None,
+                api_key=None,
+                messages=messages,
+                max_output_tokens=512,
+                request_timeout_s=120.0,
+            )
+
+        self.assertEqual(response, '{"configs": []}')
+        self.assertEqual(captured["service"], "bedrock-runtime")
+        self.assertEqual(captured["region_name"], "us-east-2")
+        # The model is named via modelId, not in the request body.
+        self.assertEqual(captured["modelId"], "us.anthropic.claude-sonnet-4-6")
+        self.assertNotIn("model", captured["body"])
+        # Bedrock requires the version string and the standard Anthropic fields.
+        self.assertEqual(captured["body"]["anthropic_version"], "bedrock-2023-05-31")
+        self.assertEqual(captured["body"]["system"], "tune kernels")
+        self.assertEqual(captured["body"]["messages"][0]["role"], "user")
+
+    def test_call_provider_bedrock_missing_boto3_raises_clear_error(self):
+        """A helpful error is raised when boto3 is not installed."""
+        import builtins
+
+        from helion.autotuner.llm.transport import call_provider
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "boto3" or name.startswith("botocore"):
+                raise ImportError(f"No module named {name!r}")
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=fake_import):
+            with self.assertRaisesRegex(RuntimeError, "boto3 is not installed"):
+                call_provider(
+                    "bedrock",
+                    model="us.anthropic.claude-sonnet-4-6",
+                    api_base=None,
+                    api_key=None,
+                    messages=[{"role": "user", "content": "hi"}],
+                    max_output_tokens=64,
+                    request_timeout_s=120.0,
+                )
+
+
 class TestLLMSeededLFBOTreeSearch(TestCase):
     """Tests for the two-stage LLM-seeded hybrid autotuner."""
 


### PR DESCRIPTION
Adds a `bedrock` provider to the LLM-guided autotuner so Claude models can be used for config search on machines that have AWS credentials (IAM role, env creds, or profile) but no Anthropic/OpenAI API key. Bedrock InvokeModel uses the same Anthropic Messages payload Helion already builds, so this reuses `_anthropic_payload` and `extract_anthropic_text` unchanged and only swaps the transport: boto3 `invoke_model` (SigV4) instead of HTTP + api-key.

API reference: https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-runtime_example_bedrock-runtime_InvokeModel_AnthropicClaude_section.html

What's added:
- `_call_bedrock`: builds the Anthropic payload, moves `model` -> `modelId`, injects `anthropic_version: "bedrock-2023-05-31"`, and invokes via `boto3.client("bedrock-runtime")` with read/connect timeouts and retries. Auth uses boto3's default credential chain; no API key is read.
- `call_provider`: routes the `bedrock` provider to `_call_bedrock`, bypassing the `_ProviderConfig` HTTP path.
- `infer_provider`: recognizes Bedrock Anthropic model IDs -- the region/partition-prefixed `*.anthropic.claude-*` form (e.g. `us.anthropic.claude-sonnet-4-6`) and an explicit `bedrock/` prefix -- before the bare `anthropic/` rule.
- Provider aliases (`bedrock`, `aws_bedrock`, `aws-bedrock`) and `strip_provider_prefix` support for the `bedrock/` prefix.
- `_resolve_bedrock_region`: region from the `api_base` override, then `AWS_REGION` / `AWS_DEFAULT_REGION`, then boto3's own resolution.

Also fixes a latent bug surfaced while testing Opus 4.8 on Bedrock: the `temperature`-deprecation guard was hardcoded to a `claude-opus-4-7` startswith, which missed Opus 4.8 (and never matched Bedrock-prefixed IDs). Replaced it with a version-aware check:
- `_ANTHROPIC_TEMPERATURE_DEPRECATED_MIN_VERSIONS = {"opus": (4, 7)}`
- `_anthropic_version_at_least`: shared (family, version) comparison that also tolerates Bedrock-prefixed IDs by matching the `claude-...` segment after `anthropic.`. `_supports_anthropic_adaptive` now delegates to it, and a new `_temperature_deprecated` uses it for the temperature guard. This corrects Opus 4.8 on the direct Anthropic API path too, not just Bedrock.

Usage:
  HELION_AUTOTUNER=LLMGuidedSearch \
  HELION_LLM_PROVIDER=bedrock \
  HELION_LLM_MODEL=us.anthropic.claude-sonnet-4-6 \
  python your_kernel.py

Tested: routing/version unit checks plus live end-to-end calls through `call_provider` on Bedrock (us-east-2) for claude-opus-4-8 and claude-sonnet-4-6, both the standard and adaptive-thinking (effort=medium) paths. AI assistance (Claude) was used for this change.