### PR TITLE
[cute] Fix autotune IndexError on reduction kernels with nested tiling

### DIFF
--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -31,6 +31,7 @@ from torch.utils import _pytree as pytree
 from .. import Config
 from .. import exc
 from .. import language as hl
+from ..autotuner.config_spec import CuteVectorWidthSpec
 from ..autotuner.config_spec import ReductionLoopSpec
 from ..language import _tracing_ops
 from ..language._decorators import args_to_proxies
@@ -837,42 +838,11 @@ class DeviceIR:
         """
         env = CompileEnvironment.current()
         rdims = [bs for bs in env.block_sizes if bs.reduction]
-        # Register cute_vector_widths slots for non-reduction tile blocks
-        # upfront — this is for kernels like softmax_two_pass that drive
-        # their own inner tile loop over the reduction axis (no rolled
-        # reductions registered).  ``CuteNDTileStrategy`` reads these
-        # slots in ``__init__`` to wire up vec-aware lane loops; if no
-        # slots are registered, the autotuner has nothing to vary and
-        # the strategy defaults to scalar loads.  Skipped when rolled
-        # reductions are present so the reduction-dim slot stays at
-        # index 0 of ``cute_vector_widths`` (matches the
-        # ``CuteReductionTileHeuristic`` seed and user-facing API).
+        # Eager tile-slot registration (see _register_cute_tile_vec_slots).
+        # A present reduction must keep its slot at index 0, so reduction
+        # kernels register their tile slots after the reduction-loop pass below.
         if env.backend_name == "cute" and not rdims:
-            from ..autotuner.config_spec import CuteVectorWidthSpec
-
-            already_registered = set(
-                env.config_spec.cute_vector_widths.valid_block_ids()
-            )
-            tile_blocks = [bs for bs in env.block_sizes if not bs.reduction]
-            for tile_bs in tile_blocks:
-                if tile_bs.block_id in already_registered:
-                    continue
-                # Skip blocks with unbound static size (e.g. jagged
-                # kernels' dynamic-extent tiles): ``size_hint()`` asserts
-                # the size is int/SymInt and the strategy's vec gate
-                # requires a static ``EPT % V == 0`` anyway.
-                if not isinstance(tile_bs.size, (int, torch.SymInt)):
-                    continue
-                try:
-                    size_hint_val = int(tile_bs.size_hint())
-                except (TypeError, ValueError, AttributeError, AssertionError):
-                    continue
-                env.config_spec.cute_vector_widths.append(
-                    CuteVectorWidthSpec(
-                        block_id=tile_bs.block_id,
-                        size_hint=size_hint_val,
-                    )
-                )
+            self._register_cute_tile_vec_slots(env)
         if not rdims:
             return
         num_original_graphs = len(self.graphs)
@@ -945,8 +915,6 @@ class DeviceIR:
                     )
                 )
                 if env.backend_name == "cute":
-                    from ..autotuner.config_spec import CuteVectorWidthSpec
-
                     env.config_spec.cute_vector_widths.append(
                         CuteVectorWidthSpec(
                             block_id=rdim.block_id,
@@ -991,6 +959,36 @@ class DeviceIR:
                             if block_id is not None:
                                 indexed_blocks.add(block_id)
             env.config_spec.cute_indexed_reduction_block_ids = indexed_blocks
+
+        # Reduction-dim slots are registered above; add the remaining
+        # non-reduction tile slots after them (keeps the rdim slot at index 0).
+        if env.backend_name == "cute":
+            self._register_cute_tile_vec_slots(env)
+
+    def _register_cute_tile_vec_slots(self, env: CompileEnvironment) -> None:
+        """Eagerly register cute_vector_widths slots for non-reduction tile blocks.
+
+        Eager (not lazy in codegen) keeps the config-spec width fixed before the
+        autotuner snapshots it; callers register reduction-dim slots first so
+        those keep index 0.
+        """
+        already_registered = set(env.config_spec.cute_vector_widths.valid_block_ids())
+        for tile_bs in env.block_sizes:
+            if tile_bs.reduction or tile_bs.block_id in already_registered:
+                continue
+            # Non-static size (jagged / AutoSize) never forms a lane loop.
+            if not isinstance(tile_bs.size, (int, torch.SymInt)):
+                continue
+            try:
+                size_hint_val = int(tile_bs.size_hint())
+            except (TypeError, ValueError, AttributeError, AssertionError):
+                continue
+            env.config_spec.cute_vector_widths.append(
+                CuteVectorWidthSpec(
+                    block_id=tile_bs.block_id,
+                    size_hint=size_hint_val,
+                )
+            )
 
     def build_codegen_graphs(self, config: Config) -> list[GraphInfo]:
         """Build and return graph copies with reduction rolling and epilogue subtiling applied.

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -3668,10 +3668,10 @@ class CuteNDTileStrategy(NDTileStrategy):
                         ):
                             self._cute_lane_vec_width_by_block[block_id] = vec_width
                     else:
-                        # Unregistered only when bs.size is non-static (the eager
-                        # pass skips those) — run scalar.  A missing static-size
-                        # slot is an eager-pass bug.
-                        assert not isinstance(
+                        # Metal shares this strategy without vec-width tuning,
+                        # and non-static sizes are eager-skipped — both run
+                        # scalar.  A missing static slot on cute is a bug.
+                        assert env_local.backend_name != "cute" or not isinstance(
                             env_local.block_sizes[block_id].size,
                             (int, torch.SymInt),
                         ), (

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -3628,8 +3628,6 @@ class CuteNDTileStrategy(NDTileStrategy):
         # ``LoopedReductionStrategy._cute_lane_vec_loads``.
         self._cute_lane_vec_loads_by_block: dict[int, dict] = {}
         if not mma_mode:
-            from ..autotuner.config_spec import CuteVectorWidthSpec
-
             env_local = CompileEnvironment.current()
             cute_vec_widths_cfg = cast(
                 "list[int]",
@@ -3650,38 +3648,37 @@ class CuteNDTileStrategy(NDTileStrategy):
                     self._lane_var_by_block[block_id] = self.fn.new_var(
                         f"lane_{block_id}"
                     )
-                    # Register a cute_vector_widths slot for this lane
-                    # block if not already present (rolled reductions
-                    # register their own via device_ir).  We add idempotently
-                    # so the autotuner can explore V in {1,2,4,8}.
+                    elements_per_thread = static_bs // nt
+                    # Vec slot is registered eagerly in device-IR analysis; read
+                    # the tuned V.  Never append here — growing the spec during
+                    # codegen breaks the autotuner's fixed-width unflatten.
                     if (
                         block_id
-                        not in env_local.config_spec.cute_vector_widths.valid_block_ids()
+                        in env_local.config_spec.cute_vector_widths.valid_block_ids()
                     ):
-                        import contextlib
-
-                        # Silently skip when append fails (e.g.
-                        # config_spec frozen) — the lane loop just
-                        # runs in scalar mode in that case.
-                        with contextlib.suppress(Exception):
-                            env_local.config_spec.cute_vector_widths.append(
-                                CuteVectorWidthSpec(
-                                    block_id=block_id,
-                                    size_hint=static_bs,
-                                )
-                            )
-                    elements_per_thread = static_bs // nt
-                    vec_width = env_local.config_spec.cute_vector_widths.config_get(
-                        cute_vec_widths_cfg,
-                        block_id,
-                        1,
-                    )
-                    if (
-                        isinstance(vec_width, int)
-                        and vec_width > 1
-                        and elements_per_thread % vec_width == 0
-                    ):
-                        self._cute_lane_vec_width_by_block[block_id] = vec_width
+                        vec_width = env_local.config_spec.cute_vector_widths.config_get(
+                            cute_vec_widths_cfg,
+                            block_id,
+                            1,
+                        )
+                        if (
+                            isinstance(vec_width, int)
+                            and vec_width > 1
+                            and elements_per_thread % vec_width == 0
+                        ):
+                            self._cute_lane_vec_width_by_block[block_id] = vec_width
+                    else:
+                        # Unregistered only when bs.size is non-static (the eager
+                        # pass skips those) — run scalar.  A missing static-size
+                        # slot is an eager-pass bug.
+                        assert not isinstance(
+                            env_local.block_sizes[block_id].size,
+                            (int, torch.SymInt),
+                        ), (
+                            f"cute_vector_widths slot missing for static-size "
+                            f"block_id={block_id}; it must be registered during "
+                            f"device-IR analysis, not lazily during codegen"
+                        )
 
     def _configured_block_size_int(self, block_size: SymIntLike) -> int | None:
         if isinstance(block_size, int):

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -634,6 +634,23 @@ def cute_permute_store_then_read(x: torch.Tensor) -> torch.Tensor:
     return out
 
 
+@helion.kernel(backend="cute")
+def cute_reduction_with_nested_tiles(x: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
+    """RMS-norm-backward-shaped kernel: a `.mean(-1)` reduction plus nested
+    non-reduction M tiling (register_block_size + inner hl.tile)."""
+    m, n = x.size()
+    out = torch.empty_like(x)
+    block_m = hl.register_block_size(m)
+    for tile_cta in hl.tile(m, block_size=block_m):
+        for tile_m in hl.tile(tile_cta.begin, tile_cta.end):
+            row = x[tile_m, :].to(torch.float32)
+            mean_sq = (row * row).mean(-1)
+            out[tile_m, :] = (
+                row * torch.rsqrt(mean_sq[:, None] + 1e-6) * w[None, :]
+            ).to(x.dtype)
+    return out
+
+
 @onlyBackends(["cute"])
 class TestCuteBackend(TestCase):
     def test_pointwise_add(self) -> None:
@@ -644,6 +661,29 @@ class TestCuteBackend(TestCase):
         code, out = code_and_output(cute_add, args)
         x, y = args
         torch.testing.assert_close(out, x + y)
+
+    def test_reduction_with_nested_tiles_registers_vec_slots_eagerly(self) -> None:
+        """Regression: a cute reduction kernel with its own non-reduction tiling
+        (rms_norm backward) registered the tile's cute_vector_widths slot lazily
+        during codegen, growing the config spec after the autotuner snapshotted
+        it -> IndexError.  Assert the slots are registered eagerly instead.
+        """
+        x = torch.randn(512, 4096, device=DEVICE, dtype=HALF_DTYPE)
+        w = torch.randn(4096, device=DEVICE, dtype=HALF_DTYPE)
+        bound = cute_reduction_with_nested_tiles.bind((x, w))
+        tile_block_ids = {
+            bs.block_id for bs in bound.env.block_sizes if not bs.reduction
+        }
+        registered = set(bound.config_spec.cute_vector_widths.valid_block_ids())
+        self.assertTrue(tile_block_ids, "kernel should expose non-reduction tiles")
+        missing = tile_block_ids - registered
+        self.assertFalse(
+            missing,
+            f"non-reduction tile blocks {sorted(missing)} were not registered in "
+            f"cute_vector_widths during device-IR analysis (registered: "
+            f"{sorted(registered)}); they would be appended lazily during codegen "
+            f"and grow the config spec mid-autotune",
+        )
 
     def test_pointwise_add_three_inputs(self) -> None:
         args = (


### PR DESCRIPTION
`HELION_BACKEND=cute python examples/rms_norm.py` crashed on my RTX 5090 with IndexError: list index out of range while autotuning the bwd kernel.

cute_vector_widths slots for non-reduction tile blocks were registered eagerly only when no reduction axis was present. Reduction kernels with their own tiling instead registered the slot lazily during codegen, growing the config spec after the surrogate search had snapshotted its fixed-width flat config and so the next unflatten ran off the end.

This PR register those slots eagerly during device-ir analysis for the reduction case too, appended after the reduction-dim slot so it keeps index 0  (the seed-heuristic invariant). The lazy codegen append becomes a read-only lookup plus a scoped guardrail assert.