### PR TITLE
[cute] Enable FP8 (e4m3) scaled_mm on the tcgen05 tensor-core path

### DIFF
--- a/benchmarks/cute/compare_matmul_backends.py
+++ b/benchmarks/cute/compare_matmul_backends.py
@@ -192,6 +192,10 @@ MATMUL_EPILOGUES = (
     "silu",
     "gelu",
     "residual_add",
+    # FP8 RowWise scaled_mm: out = scale_a[m] * scale_b[n] * (a_fp8 @ b_fp8).
+    # The rowwise scale is fused into the epilogue. Intended for --dtype
+    # float8_e4m3fn; the reference is torch._scaled_mm.
+    "scaled_mm",
 )
 QUACK_TUNE_CHOICES = ("off", "brief")
 # Brief tuning covers the documented default, larger cluster/swizzle variants,
@@ -725,7 +729,12 @@ def _dtype_from_name(name: str) -> torch.dtype:
         "float16": torch.float16,
         "bfloat16": torch.bfloat16,
         "float32": torch.float32,
+        "float8_e4m3fn": torch.float8_e4m3fn,
     }[name]
+
+
+def _is_fp8(dtype: torch.dtype) -> bool:
+    return dtype == torch.float8_e4m3fn
 
 
 def _tflops(m: int, n: int, k: int, ms: float) -> float:
@@ -832,9 +841,27 @@ def _make_inputs(
     seed: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     torch.manual_seed(seed)
+    if _is_fp8(dtype):
+        # fp8 has a tiny dynamic range, so build the operands in f32 and cast.
+        # b is laid out column-major (K-contiguous), the layout the tcgen05
+        # fp8 path and torch._scaled_mm expect for the second operand.
+        a = (torch.randn((m, k), device="cuda") * 0.4).to(dtype)
+        b = (torch.randn((k, n), device="cuda") * 0.4).to(dtype).T.contiguous().T
+        return a, b
     a = torch.randn((m, k), device="cuda", dtype=dtype)
     b = torch.randn((k, n), device="cuda", dtype=dtype) / math.sqrt(k)
     return a, b
+
+
+def _make_scales(
+    args: argparse.Namespace,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-row (scale_a [m,1]) and per-column (scale_b [1,n]) f32 rowwise scales
+    for the ``scaled_mm`` epilogue. Non-trivial (random) values so a broadcast
+    bug actually surfaces in the correctness check."""
+    scale_a = (torch.rand((args.m, 1), device="cuda") + 0.5).to(torch.float32)
+    scale_b = (torch.rand((1, args.n), device="cuda") + 0.5).to(torch.float32)
+    return scale_a, scale_b
 
 
 def _make_epilogue_inputs(
@@ -842,10 +869,13 @@ def _make_epilogue_inputs(
 ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
     bias = None
     residual = None
+    # fp8 epilogue aux tensors (bias/residual) are kept in the *output* dtype
+    # (bf16); only the matmul operands are fp8.
+    aux_dtype = torch.bfloat16 if _is_fp8(dtype) else dtype
     if args.epilogue in ("bias", "bias_relu", "bias_residual_gelu"):
-        bias = torch.randn((args.n,), device="cuda", dtype=dtype)
+        bias = torch.randn((args.n,), device="cuda", dtype=aux_dtype)
     if args.epilogue in ("bias_residual_gelu", "residual_add"):
-        residual = torch.randn((args.m, args.n), device="cuda", dtype=dtype)
+        residual = torch.randn((args.m, args.n), device="cuda", dtype=aux_dtype)
     return bias, residual
 
 
@@ -857,7 +887,18 @@ def _make_matmul_problem(
     dtype = _dtype_from_name(args.dtype)
     a, b = _make_inputs(args.m, args.n, args.k, dtype, seed=args.seed)
     bias, residual = _make_epilogue_inputs(args, dtype)
+    # Stash the rowwise scales on args so the (a, b, bias, residual) tuple
+    # threaded through every impl stays unchanged. Only the scaled_mm path reads
+    # them, via _scaled_mm_scales().
+    if args.epilogue == "scaled_mm":
+        args._scale_a, args._scale_b = _make_scales(args)
     return dtype, a, b, bias, residual
+
+
+def _scaled_mm_scales(
+    args: argparse.Namespace,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return args._scale_a, args._scale_b
 
 
 def _apply_epilogue(
@@ -889,6 +930,11 @@ def _apply_epilogue(
     if args.epilogue == "residual_add":
         assert residual is not None
         return acc + residual
+    if args.epilogue == "scaled_mm":
+        # out = scale_a[m] * scale_b[n] * acc, cast to bf16. The scale is folded
+        # on the f32 accumulator before the cast (matches the fused epilogue).
+        scale_a, scale_b = _scaled_mm_scales(args)
+        return (acc.float() * scale_a * scale_b).to(torch.bfloat16)
     raise AssertionError(f"unhandled epilogue {args.epilogue!r}")
 
 
@@ -900,7 +946,10 @@ def _matmul_expected(
     residual: torch.Tensor | None,
     dtype: torch.dtype,
 ) -> torch.Tensor:
-    return _apply_epilogue(args, a @ b, bias, residual, dtype)
+    # acc is f32; for fp8 inputs the product is computed in f32 to mirror the
+    # tensor-core accumulate before any epilogue (scaled_mm, activation, ...).
+    acc = (a.float() @ b.float()) if _is_fp8(dtype) else (a @ b)
+    return _apply_epilogue(args, acc, bias, residual, dtype)
 
 
 def _check_close(
@@ -908,6 +957,14 @@ def _check_close(
 ) -> None:
     if dtype == torch.float32:
         torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-4)
+    elif _is_fp8(dtype):
+        # fp8 (e4m3) operands carry ~2 decimal digits, so the GEMM accumulates
+        # substantial quantization error; use a relative-error tolerance like
+        # the scaled_mm unit checks.
+        ref_max = expected.float().abs().max().item() + 1e-12
+        rel = (actual.float() - expected.float()).abs().max().item() / ref_max
+        if rel > 0.1:
+            raise AssertionError(f"fp8 mismatch: rel_err={rel:.4f} > 0.1")
     else:
         # bf16/fp16 GEMMs accumulate enough rounding noise that benchmark
         # smoke tests need a looser threshold than unit tests.
@@ -1020,7 +1077,17 @@ def _result(
 
 def _benchmark_aten(args: argparse.Namespace) -> dict[str, Any]:
     dtype, a, b, bias, residual = _make_matmul_problem(args)
-    fn = lambda: _apply_epilogue(args, a @ b, bias, residual, dtype)  # noqa: E731
+    if args.epilogue == "scaled_mm":
+        # ATen's fp8 rowwise GEMM is torch._scaled_mm — the SOTA baseline to
+        # time against (a dequantized f32 matmul would be a misleadingly slow
+        # reference). _apply_epilogue still owns the scaled_mm *semantics* for
+        # the correctness reference in _matmul_expected.
+        scale_a, scale_b = _scaled_mm_scales(args)
+        fn = lambda: torch._scaled_mm(  # noqa: E731
+            a, b, scale_a, scale_b, use_fast_accum=False, out_dtype=torch.bfloat16
+        )
+    else:
+        fn = lambda: _apply_epilogue(args, a @ b, bias, residual, dtype)  # noqa: E731
     stats = _bench_steady(
         fn,
         num_runs=args.num_runs,
@@ -1533,17 +1600,31 @@ def _helion_matmul_args(
     if args.epilogue == "residual_add":
         assert residual is not None
         return (a, b, ResidualAddEpilogue(residual))
+    if args.epilogue == "scaled_mm":
+        scale_a, scale_b = _scaled_mm_scales(args)
+        # examples/fp8_matmul.fp8_matmul takes (x, y, sa2d, sb1d) directly and
+        # bakes the scale in itself (not via an epilogue callable): scale_a as a
+        # (M, N) stride-(1,0) colvec view, scale_b as a rank-1 row vector.
+        scale_a2d = scale_a.reshape(args.m, 1).expand(args.m, args.n)
+        scale_b1d = scale_b.reshape(args.n)
+        return (a, b, scale_a2d, scale_b1d)
     raise AssertionError(f"unhandled epilogue {args.epilogue!r}")
 
 
 def _prepare_helion(args: argparse.Namespace) -> _PreparedHelion:
     backend = args.helion_backend
     os.environ["HELION_BACKEND"] = backend
-    from examples.matmul import matmul
 
     dtype, a, b, bias, residual = _make_matmul_problem(args)
     expected = _matmul_expected(args, a, b, bias, residual, dtype)
     kernel_args = _helion_matmul_args(args, a, b, bias, residual)
+
+    if args.epilogue == "scaled_mm":
+        # fp8 RowWise scaled_mm uses examples/fp8_matmul.py (hl.dot + fused
+        # rowwise scale); the example matmul's torch.addmm does not accept fp8.
+        from examples.fp8_matmul import fp8_matmul as matmul
+    else:
+        from examples.matmul import matmul
 
     bound = matmul.bind(kernel_args)
     config = _make_helion_config_from_args(args) if args.helion_force_config else None
@@ -5931,7 +6012,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--dtype",
-        choices=("float16", "bfloat16", "float32"),
+        choices=("float16", "bfloat16", "float32", "float8_e4m3fn"),
         default="bfloat16",
     )
     parser.add_argument("--num-runs", type=int, default=5)
@@ -6387,6 +6468,27 @@ def _uses_invalid_output_diagnostic_mode(args: argparse.Namespace) -> bool:
 
 
 def _validate_args(args: argparse.Namespace) -> None:
+    # fp8 + scaled_mm wiring. The scaled_mm epilogue is the fp8 RowWise path; it
+    # is only meaningful for fp8 inputs, and the only impls that implement it are
+    # ATen (torch._scaled_mm) and Helion. quack-direct/quack do not.
+    if args.epilogue == "scaled_mm" and args.dtype != "float8_e4m3fn":
+        raise SystemExit("--epilogue scaled_mm requires --dtype float8_e4m3fn")
+    if args.dtype == "float8_e4m3fn":
+        if args.epilogue != "scaled_mm":
+            raise SystemExit("--dtype float8_e4m3fn requires --epilogue scaled_mm")
+        impls = args.impls or list(DEFAULT_IMPLS)
+        requested = [args.impl] if args.impl != "all" else impls
+        bad = [i for i in requested if i in ("quack", "quack-direct")]
+        if bad:
+            raise SystemExit(
+                f"impl(s) {bad} do not support fp8 scaled_mm; use --impls with "
+                "aten and/or helion-cute (quack-direct has no fp8 rowwise GEMM here)"
+            )
+        if "helion-triton" in requested:
+            raise SystemExit(
+                "helion-triton does not support the fp8 tcgen05 path; "
+                "use --impls aten helion-cute"
+            )
     special_modes = (
         args.helion_two_cta_diagnostic_sweep,
         args.helion_two_cta_codegen_report,

--- a/examples/fp8_matmul.py
+++ b/examples/fp8_matmul.py
@@ -1,0 +1,126 @@
+"""
+Helion FP8 RowWise scaled_mm Example
+====================================
+FP8 (e4m3) RowWise scaled matrix multiplication on Helion:
+
+    out[m, n] = scale_a[m] * scale_b[n] * sum_k a[m, k] * b[k, n]
+
+``scale_a`` is passed as a ``(M, N)`` stride-(1,0) column-vector view (read as a
+scalar per subtile in the fused tcgen05 epilogue) and ``scale_b`` as a rank-1
+per-column row vector; this is the layout the CuTe backend's
+fused-rowwise-scale epilogue recognizes.
+"""
+
+# %%
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+import helion
+from helion._testing import DEVICE
+import helion.language as hl
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+# %%
+@helion.kernel(static_shapes=True)
+def fp8_matmul(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_a2d: torch.Tensor,
+    scale_b1d: torch.Tensor,
+) -> torch.Tensor:
+    """FP8 RowWise scaled_mm: ``out = scale_a[m] * scale_b[n] * (x @ y)`` in BF16.
+
+    Args:
+        x: Left input [m, k] in FP8 (e4m3), row-major.
+        y: Right input [k, n] in FP8 (e4m3), column-major (K-contiguous) preferred.
+        scale_a2d: Per-row scale as a ``(m, n)`` stride-(1,0) column-vector view.
+        scale_b1d: Per-column scale as a rank-1 ``(n,)`` row vector.
+
+    Returns:
+        Output [m, n] in BF16.
+    """
+    m, k = x.size()
+    k2, n = y.size()
+    assert k == k2, f"size mismatch {k} != {k2}"
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+        # Fold the rowwise scale on the f32 accumulator before the bf16 cast.
+        out[tile_m, tile_n] = (acc * scale_a2d[tile_m, tile_n] * scale_b1d[tile_n]).to(
+            torch.bfloat16
+        )
+    return out
+
+
+# %%
+def reference_scaled_mm(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> torch.Tensor:
+    """Reference using ``torch._scaled_mm`` (column-major second operand)."""
+    if y.stride(0) == 1 and y.stride(1) > 1:
+        y_col_major = y
+    else:
+        y_col_major = y.T.contiguous().T
+    return torch._scaled_mm(
+        x, y_col_major, scale_a, scale_b, use_fast_accum=False, out_dtype=torch.bfloat16
+    )
+
+
+# %%
+def fp8_matmul_tritonbench(
+    tb_op: object,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> Callable[[], torch.Tensor]:
+    """Wrapper for TritonBench: a [m, k] fp8, b [k, n] fp8 (col-major), rowwise
+    scales scale_a [m, 1], scale_b [1, n]."""
+    m, _ = a.size()
+    _, n = b.size()
+    scale_a2d = scale_a.reshape(m, 1).expand(m, n)
+    scale_b1d = scale_b.reshape(n)
+    return lambda: fp8_matmul(a, b, scale_a2d, scale_b1d)
+
+
+# %%
+def check(m: int, k: int, n: int) -> None:
+    """Validate fp8_matmul against the torch._scaled_mm reference."""
+    x = (torch.randn([m, k], device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+    y = (torch.randn([k, n], device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+    y = y.T.contiguous().T  # column-major (K-contiguous)
+    scale_a = (torch.rand([m, 1], device=DEVICE) + 0.5).to(torch.float32)
+    scale_b = (torch.rand([1, n], device=DEVICE) + 0.5).to(torch.float32)
+    scale_a2d = scale_a.reshape(m, 1).expand(m, n)
+    scale_b1d = scale_b.reshape(n)
+
+    from helion._testing import run_example
+
+    run_example(
+        lambda a, b: fp8_matmul(a, b, scale_a2d, scale_b1d),
+        lambda a, b: reference_scaled_mm(a, b, scale_a, scale_b),
+        (x, y),
+        atol=0.1,
+        rtol=0.1,
+    )
+
+
+# %%
+def main() -> None:
+    check(64, 2048, 2048)
+
+
+# %%
+if __name__ == "__main__":
+    main()

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -118,6 +118,21 @@ _TRACE_THROUGH_TARGETS = {
     # data shuffle.  Permuted operands fall back to scalar codegen.
 }
 
+# Extra forward-trace targets used ONLY for *output dtype* inference
+# (``_trace_mma_to_store_dtype``). These are the whitelisted fused-epilogue
+# aux-binary ops (e.g. the rowwise scale ``acc * scale[...]``). Tracing
+# through them only follows the chain to the store node and reads the store
+# *target tensor's* dtype, so it never changes the inferred dtype; it just
+# lets inference reach the store past a fused scale/bias step. This is needed
+# for fp8 inputs (whose ``input_dtype`` is never a valid epilogue output
+# dtype) so the plan picks up the real bf16/f16/f32 store dtype.
+_DTYPE_TRACE_EXTRA_TARGETS = {
+    torch.ops.aten.mul.Tensor,
+    torch.ops.aten.add.Tensor,
+    torch.ops.aten.sub.Tensor,
+    torch.ops.aten.div.Tensor,
+}
+
 # Register reallocation budget for tcgen05 warp-specialized kernels.
 # Producer warps (TMA loads, scheduler) only do address arithmetic and
 # barrier ops, so they can give back registers; consumer warps (MMA
@@ -443,7 +458,12 @@ def _has_mma_operands(lhs_node: Node, rhs_node: Node) -> bool:
         return False
     lhs_load, _, lhs_fake = lhs_info
     rhs_load, _, rhs_fake = rhs_info
-    supported = {torch.float16, torch.bfloat16, torch.float32}
+    supported = {
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+        torch.float8_e4m3fn,
+    }
     return (
         lhs_fake.dtype in supported
         and rhs_fake.dtype in supported
@@ -1726,6 +1746,7 @@ def _trace_mma_to_store_dtype(
                 or target is _tracing_ops._new_var
                 or target is operator.getitem
                 or target in _TRACE_THROUGH_TARGETS
+                or target in _DTYPE_TRACE_EXTRA_TARGETS
             ):
                 stack.append(user)
                 continue
@@ -1778,6 +1799,7 @@ def _emit_mma_pipeline(
         torch.float16: "cutlass.Float16",
         torch.bfloat16: "cutlass.BFloat16",
         torch.float32: "cutlass.Float32",
+        torch.float8_e4m3fn: "cutlass.Float8E4M3FN",
     }
     input_dtype_str = _dtype_map[input_dtype]
     acc_dtype_str = "cutlass.Float32"
@@ -1805,7 +1827,7 @@ def _emit_mma_pipeline(
         _dtype_map[epi_elem_dtype] if epi_elem_dtype is not None else input_dtype_str
     )
     tcgen05_use_tma = (
-        input_dtype in (torch.float16, torch.bfloat16)
+        input_dtype in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
         and lhs_fake.is_contiguous()
         and rhs_fake.is_contiguous()
     )
@@ -5187,7 +5209,12 @@ def _mma_impl_matches_problem_shape(
 ) -> bool:
     if mma_impl == "universal":
         return True
-    if input_dtype not in (torch.float16, torch.bfloat16) or bn < 8 or bn % 8 != 0:
+    is_fp8 = input_dtype == torch.float8_e4m3fn
+    if (
+        input_dtype not in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
+        or bn < 8
+        or bn % 8 != 0
+    ):
         return False
     if bn > 256 and (
         mma_impl != "tcgen05"
@@ -5201,16 +5228,21 @@ def _mma_impl_matches_problem_shape(
     ):
         return False
     if mma_impl == "warp":
-        # Warp MMA atom is fixed-K (16 elements per BF16/FP16 instruction).
+        # Warp MMA atom is fixed-K (16 elements per BF16/FP16 instruction);
+        # fp8 is only wired through tcgen05.
+        if is_fp8:
+            return False
         return bk == 16 and bm >= 16 and bm % 16 == 0 and bn == 8
     if mma_impl == "tcgen05":
-        # tcgen05 mma instruction K is 16 elements for BF16/FP16, but the
-        # tile's K can be any positive multiple of that (the inner cute.gemm
-        # loop just runs more instructions per K iteration). Larger tile_k
-        # roughly halves the per-K-iter overhead per doubling. Production
-        # remains capped at block_n=256 to keep AB SMEM staging budget sane;
-        # the explicit G4 proof key admits only the smallest 512-N candidate.
-        if bk < 16 or bk > 256 or bk % 16 != 0:
+        # tcgen05 mma instruction K is 16 elements for BF16/FP16 (32 for FP8),
+        # but the tile's K can be any positive multiple of that (the inner
+        # cute.gemm loop just runs more instructions per K iteration). Larger
+        # tile_k roughly halves the per-K-iter overhead per doubling.
+        # Production remains capped at block_n=256 to keep AB SMEM staging
+        # budget sane; the explicit G4 proof key admits only the smallest
+        # 512-N candidate.
+        mma_k = 32 if is_fp8 else 16
+        if bk < mma_k or bk > 256 or bk % mma_k != 0:
             return False
         if bm in (64, 128):
             return True
@@ -5276,7 +5308,12 @@ def _choose_mma_impl(
         tcgen05_cluster_m=tcgen05_cluster_m,
         tcgen05_large_bn_proof=tcgen05_large_bn_proof,
     ):
-        if support.tcgen05_f16bf16:
+        tcgen05_ok = (
+            support.tcgen05_f8
+            if input_dtype == torch.float8_e4m3fn
+            else support.tcgen05_f16bf16
+        )
+        if tcgen05_ok:
             return "tcgen05"
     if _mma_impl_matches_problem_shape("warp", input_dtype, bm=bm, bn=bn, bk=bk):
         if support.warp_f16bf16:

--- a/helion/_compiler/cute/mma_support.py
+++ b/helion/_compiler/cute/mma_support.py
@@ -11,6 +11,7 @@ class CuteMmaSupport:
     warp_f16bf16: bool
     warpgroup_f16bf16: bool
     tcgen05_f16bf16: bool
+    tcgen05_f8: bool = False
 
     @property
     def supported_impls(self) -> tuple[str, ...]:
@@ -91,6 +92,28 @@ def _probe_tcgen05_f16bf16() -> bool:
         return False
 
 
+def _probe_tcgen05_f8() -> tuple[bool, str | None]:
+    try:
+        import cutlass
+        from cutlass.cute.nvgpu import tcgen05
+
+        # fp8 (e4m3) MMA on tcgen05 uses the F8F6F4 op with MMA-K=32 (vs 16
+        # for BF16/FP16) and a separate a_dtype/b_dtype.
+        tcgen05.MmaF8F6F4Op(
+            cutlass.Float8E4M3FN,
+            cutlass.Float8E4M3FN,
+            cutlass.Float32,
+            (128, 8, 32),
+            tcgen05.CtaGroup.ONE,
+            tcgen05.OperandSource.SMEM,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.K,
+        )
+        return True, None
+    except Exception as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+
+
 def get_cute_mma_support() -> CuteMmaSupport:
     device = _current_cuda_device()
     if device is None:
@@ -99,15 +122,18 @@ def get_cute_mma_support() -> CuteMmaSupport:
             warp_f16bf16=False,
             warpgroup_f16bf16=False,
             tcgen05_f16bf16=False,
+            tcgen05_f8=False,
         )
 
     cutlass_arch = _current_cutlass_arch_name()
 
     # The universal atom is the only lowering Helion currently wires up end-to-end.
     universal = cutlass_arch is not None
+    tcgen05_f8_ok, _ = _probe_tcgen05_f8()
     return CuteMmaSupport(
         universal=universal,
         warp_f16bf16=_probe_warp_f16bf16(),
         warpgroup_f16bf16=_probe_warpgroup_f16bf16(),
         tcgen05_f16bf16=_probe_tcgen05_f16bf16(),
+        tcgen05_f8=tcgen05_f8_ok,
     )

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -318,22 +318,28 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
             rhs_dtype=rhs.dtype,
         )
     )
+    # tcgen05 MMA-K is 16 elements for BF16/FP16 but 32 for FP8 (e4m3); the
+    # block_k search granularity and minimum must follow the active dtype.
+    is_fp8 = lhs.dtype == torch.float8_e4m3fn
+    mma_k = 32 if is_fp8 else 16
     if (
         env.backend_name == "cute"
         and lhs.ndim == 2
         and rhs.ndim == 2
-        and lhs.dtype in (torch.float16, torch.bfloat16)
+        and lhs.dtype in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
         and rhs.dtype == lhs.dtype
         and static_m is not None
         and static_n is not None
         and static_k is not None
         and static_m >= 64
         and static_n >= 8
-        and static_k >= 16
+        and static_k >= mma_k
     ):
         from .._compiler.cute.mma_support import get_cute_mma_support
 
-        if get_cute_mma_support().tcgen05_f16bf16:
+        support = get_cute_mma_support()
+        tcgen05_supported = support.tcgen05_f8 if is_fp8 else support.tcgen05_f16bf16
+        if tcgen05_supported:
 
             def pow2_floor_at_least(value: int, minimum: int) -> int:
                 return 1 << (max(minimum, value).bit_length() - 1)
@@ -342,8 +348,9 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
             max_tcgen05_m = 256 if max_tcgen05_n >= 128 and static_m >= 256 else 128
             # Larger tile_k packs more cute.gemm instructions per K loop
             # iteration on tcgen05 (mma instruction K is fixed at 16 for
-            # BF16/FP16). Cap at 128 to keep AB SMEM staging budget sane.
-            max_tcgen05_k = min(128, pow2_floor_at_least(static_k, 16))
+            # BF16/FP16, 32 for FP8). Cap at 128 to keep AB SMEM staging
+            # budget sane.
+            max_tcgen05_k = min(128, pow2_floor_at_least(static_k, mma_k))
             max_search_m = min(max_tcgen05_m, pow2_floor_at_least(static_m, 64))
             max_search_n = max_tcgen05_n
             max_search_k = max_tcgen05_k
@@ -475,7 +482,7 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
                 if block_idx is None:
                     continue
                 if axis_name == "k":
-                    min_size = 16
+                    min_size = mma_k
                 elif axis_name == "m":
                     min_size = min_search_m
                 else:

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -458,6 +458,39 @@ def cute_matmul_mma(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     return out
 
 
+@helion.kernel(backend="cute", static_shapes=True)
+def cute_matmul_mma_fp8(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    # fp8 (e4m3) inputs, f32 accumulate, bf16 output -- the tcgen05 MMA atom
+    # for fp8 is MmaF8F6F4Op (MMA-K=32 vs 16 for bf16/fp16).
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+        out[tile_m, tile_n] = acc.to(torch.bfloat16)
+    return out
+
+
+@helion.kernel(backend="cute", static_shapes=True)
+def cute_matmul_mma_fp8_rowvec_scale(
+    x: torch.Tensor, y: torch.Tensor, scale_n: torch.Tensor
+) -> torch.Tensor:
+    # fp8 GEMM with a fused per-column (rowvec) scale in the epilogue.
+    # Exercises the rowvec aux chain on the tcgen05 fp8 path (and, for
+    # TMA-store configs, the register-hoist of the rowvec load).
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+        out[tile_m, tile_n] = (acc * scale_n[tile_n]).to(torch.bfloat16)
+    return out
+
+
 @helion.kernel(backend="cute")
 def cute_matmul_mma_epilogue(
     x: torch.Tensor, y: torch.Tensor, bias: torch.Tensor
@@ -1154,6 +1187,44 @@ class TestCuteBackend(TestCase):
             code,
         )
         self.assertIn("cutlass.pipeline.NamedBarrier(barrier_id=1", code)
+
+    def test_matmul_mma_tcgen05_fp8(self) -> None:
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = (torch.randn(256, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = (torch.randn(128, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        code, out = code_and_output(
+            cute_matmul_mma_fp8, (x, y), block_sizes=[128, 128, 128]
+        )
+        ref = x.float() @ y.float()
+        torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+        # fp8 routes through the tcgen05 F8F6F4 MMA atom (MMA-K=32).
+        self.assertIn("cutlass.utils.blackwell_helpers.make_trivial_tiled_mma", code)
+        self.assertIn("cutlass.Float8E4M3FN", code)
+        self.assertIn("cute.nvgpu.tcgen05", code)
+        self.assertIn("cute.gemm(", code)
+
+    def test_matmul_mma_tcgen05_fp8_rowvec_scale(self) -> None:
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = (torch.randn(256, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = (torch.randn(128, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        scale_n = torch.rand(128, device=DEVICE) + 0.5
+        code, out = code_and_output(
+            cute_matmul_mma_fp8_rowvec_scale,
+            (x, y, scale_n),
+            block_sizes=[128, 128, 128],
+        )
+        ref = (x.float() @ y.float()) * scale_n.float()
+        torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+        self.assertIn("cutlass.Float8E4M3FN", code)
+        self.assertIn("cute.nvgpu.tcgen05", code)
 
     def test_matmul_dot_out_dtype_falls_back_from_mma(self) -> None:
         args = (


### PR DESCRIPTION
Stacked PRs:
 * #2756
 * #2755
 * #2754
 * #2742
 * #2741
 * #2740
 * #2739
 * __->__#2736


--- --- ---

### [cute] Enable FP8 (e4m3) scaled_mm on the tcgen05 tensor-core path


Minimal backend changes (from pytorch/helion#2696) so the CuTe backend
routes FP8 (e4m3) hl.dot through the tcgen05 F8F6F4 MMA atom instead of
the SIMT universal-MMA fallback.

Files (each verified individually necessary — reverting any one drops the
fp8 path back to SIMT or fails to compile):
- mma_support.py: fp8 tcgen05 capability probe via MmaF8F6F4Op (tcgen05_f8).
- matmul_ops.py: admit float8_e4m3fn into the tcgen05 admission gate;
  MMA-K=32 for fp8 (block_k granularity/minimum follow the dtype).
- cute_mma.py: fp8 dtype map (Float8E4M3FN), _has_mma_operands,
  tcgen05_use_tma, bk%32 in _mma_impl_matches_problem_shape,
  _choose_mma_impl probe; trace the output dtype through fused-scale ops
  (mul/add/sub/div) so the epilogue plan sees the bf16 store rather than
  the fp8 input dtype (required for any fused rowwise-scale fp8 kernel).
- test/test_cute_backend.py: test_matmul_mma_tcgen05_fp8[_rowvec_scale].

Deliberately omitted from #2696 as perf-polish, not enablement (verified
the fp8 tcgen05 path is selected and numerically correct without them):
tcgen05_config.py deep AB staging, program_id.py persistent fp8 whitelist,
and the memory_ops.py / cute_fx_walk.py fused-scale rowvec register-hoist
and colvec scalar-read optimizations.

Tooling for the fp8 path:
- examples/fp8_matmul.py: standalone FP8 RowWise scaled_mm example
  (out = scale_a[m] * scale_b[n] * (x @ y), bf16 out) using hl.dot with the
  rowwise scale fused in the epilogue, plus a torch._scaled_mm reference and
  a tritonbench wrapper. Distinct from examples/matmul.py, whose torch.addmm
  inner loop does not accept fp8 operands.
- benchmarks/cute/compare_matmul_backends.py: accept --dtype float8_e4m3fn
  and a new --epilogue scaled_mm (fp8 RowWise). scaled_mm semantics live in
  _apply_epilogue; aten times torch._scaled_mm, helion-cute uses the example
  kernel above.

Benchmark (NVIDIA B200, CUDA 13.2, FP8 e4m3 rowwise scaled_mm,
m=64 k=2048 n=2048, tritonbench cudagraph + L2-clear, median):

  SIMT universal-MMA (pre-change) : 979.70 us   tcgen05=False
  tcgen05 autotuned (this change) : 280.98 us   tcgen05=True
  speedup                         : 3.49x

Autotuner (full effort) selected a real tensor-core config
(tcgen05_strategy=role_local_with_scheduler, cluster_m=1,
block_sizes=[64,16,64], block_k=64 = 2x the fp8 MMA-K of 32),
rel_err=0.0000 vs torch._scaled_mm. Before this change the fp8 path could
never reach tcgen05 (admission gate required bf16/fp16), so the search
ceiling was the SIMT path regardless of effort.

End-to-end via compare_matmul_backends.py (fp8 scaled_mm, m=64 k=2048
n=2048, --impls aten helion-cute, steady-state mom-median):
  aten (torch._scaled_mm) : 11.3 us   47.7 TFLOP/s
  helion-cute (tcgen05)   : 287.6 us    1.9 TFLOP/s
helion-cute correctly engages tcgen05 and is numerically correct; ATen
wins this tiny, launch/memory-bound shape (same pattern as fp16 below).
The compute-bound regime (large M) is where the fp8 tensor-core kernel is
competitive; the deep-staging/persistent pieces needed to match
torch._scaled_mm at small M were the perf-polish omitted above.

Autotune sanity check via benchmarks/cute/compare_matmul_backends.py
(fp16, Helion-CuTe autotuned vs Quack-direct, mom-median TFLOP/s):
  4096x4096x4096 : helion 1120 vs quack 1107  (101.6%, matches SOTA)
  64x2048x2048   : helion 35.5 vs quack 28.2   (125.9%)
confirming the tcgen05 autotune path is sound on the bf16/fp16 atom too.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
