### PR TITLE
[triton] contiguity hint for swizzle gathers; improved triton nvpf4_gemv

### DIFF
--- a/examples/nvfp4_gemv.py
+++ b/examples/nvfp4_gemv.py
@@ -29,6 +29,7 @@ from helion._testing import DEVICE
 from helion._testing import run_example
 import helion.language as hl
 from helion.runtime import default_cute_launcher
+from helion.runtime.settings import _get_backend
 
 cutlass: Any
 cute: Any
@@ -623,7 +624,7 @@ FP4IN_CONFIGS: dict[BackendName, helion.Config] = {
 
 
 def _selected_backend(backend: BackendName | None) -> BackendName:
-    selected = helion.Settings().backend if backend is None else backend
+    selected = _get_backend() if backend is None else backend
     if selected not in ("triton", "cute"):
         raise ValueError(
             f"nvfp4_gemv supports backend='triton' or 'cute', got {selected!r}"

--- a/examples/nvfp4_gemv.py
+++ b/examples/nvfp4_gemv.py
@@ -17,19 +17,10 @@ from __future__ import annotations
 
 import functools
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import Literal
 from typing import cast
 
-import cutlass
-from cutlass import Int32
-from cutlass._mlir.dialects import llvm
-import cutlass.cute as cute
-from cutlass.cute.arch.nvvm_wrappers import _normalize_ptr
-from cutlass.cute.typing import Float32
-from cutlass.cute.typing import Pointer as CutePointer
-from cutlass.cute.typing import Tensor as CuteTensor
-from cutlass.cutlass_dsl import T
-from cutlass.cutlass_dsl import dsl_user_op
 import torch
 from torch import Tensor
 
@@ -38,6 +29,28 @@ from helion._testing import DEVICE
 from helion._testing import run_example
 import helion.language as hl
 from helion.runtime import default_cute_launcher
+
+cutlass: Any
+cute: Any
+dsl_user_op: Any
+
+try:
+    import cutlass
+    from cutlass import Int32
+    from cutlass._mlir.dialects import llvm
+    import cutlass.cute as cute
+    from cutlass.cute.arch.nvvm_wrappers import _normalize_ptr
+    from cutlass.cute.typing import Float32
+    from cutlass.cute.typing import Pointer as CutePointer
+    from cutlass.cute.typing import Tensor as CuteTensor
+    from cutlass.cutlass_dsl import T
+    from cutlass.cutlass_dsl import dsl_user_op
+except ModuleNotFoundError as e:
+    if e.name is None or not e.name.startswith("cutlass"):
+        raise
+    cutlass = cast("Any", None)
+    cute = cast("Any", None)
+    dsl_user_op = cast("Any", None)
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/examples/nvfp4_gemv.py
+++ b/examples/nvfp4_gemv.py
@@ -35,20 +35,25 @@ cutlass: Any
 cute: Any
 dsl_user_op: Any
 
-try:
-    import cutlass
-    from cutlass import Int32
-    from cutlass._mlir.dialects import llvm
-    import cutlass.cute as cute
-    from cutlass.cute.arch.nvvm_wrappers import _normalize_ptr
-    from cutlass.cute.typing import Float32
-    from cutlass.cute.typing import Pointer as CutePointer
-    from cutlass.cute.typing import Tensor as CuteTensor
-    from cutlass.cutlass_dsl import T
-    from cutlass.cutlass_dsl import dsl_user_op
-except ModuleNotFoundError as e:
-    if e.name is None or not e.name.startswith("cutlass"):
-        raise
+if _get_backend() == "cute":
+    try:
+        import cutlass
+        from cutlass import Int32
+        from cutlass._mlir.dialects import llvm
+        import cutlass.cute as cute
+        from cutlass.cute.arch.nvvm_wrappers import _normalize_ptr
+        from cutlass.cute.typing import Float32
+        from cutlass.cute.typing import Pointer as CutePointer
+        from cutlass.cute.typing import Tensor as CuteTensor
+        from cutlass.cutlass_dsl import T
+        from cutlass.cutlass_dsl import dsl_user_op
+    except ModuleNotFoundError as e:
+        if e.name is None or not e.name.startswith("cutlass"):
+            raise
+        cutlass = cast("Any", None)
+        cute = cast("Any", None)
+        dsl_user_op = cast("Any", None)
+else:
     cutlass = cast("Any", None)
     cute = cast("Any", None)
     dsl_user_op = cast("Any", None)

--- a/examples/nvfp4_gemv.py
+++ b/examples/nvfp4_gemv.py
@@ -15,7 +15,9 @@ Two variants are provided:
 # %%
 from __future__ import annotations
 
+import functools
 from typing import TYPE_CHECKING
+from typing import Literal
 from typing import cast
 
 import cutlass
@@ -41,6 +43,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from cutlass._mlir import ir
+
+BackendName = Literal["triton", "cute"]
 
 BF16IN_CONFIG = helion.Config(
     block_sizes=[1, 128],
@@ -502,8 +506,7 @@ def _fp4_storage(tensor: Tensor) -> Tensor:
     return tensor
 
 
-@helion.kernel(static_shapes=True, config=BF16IN_CONFIG, backend="cute")
-def _nvfp4_gemv_bf16in_kernel(
+def _nvfp4_gemv_bf16in_body(
     weight_fp4x2: Tensor,
     x_values: Tensor,
     weight_scale: Tensor,
@@ -530,7 +533,7 @@ def _nvfp4_gemv_bf16in_kernel(
                     torch.float32
                 )
             scale_offsets = swizzled_scale_offsets(
-                row,
+                cast("int", row),
                 tile_k.index,
                 K_groups,
             )
@@ -544,8 +547,7 @@ def _nvfp4_gemv_bf16in_kernel(
     return out
 
 
-@helion.kernel(static_shapes=True, config=FP4IN_CONFIG, backend="cute")
-def _nvfp4_gemv_fp4in_kernel(
+def _nvfp4_gemv_fp4in_body(
     weight_fp4x2: Tensor,
     x_fp4x2: Tensor,
     weight_scale: Tensor,
@@ -569,7 +571,7 @@ def _nvfp4_gemv_fp4in_kernel(
                 x_lo, x_hi = hl.float4_e2m1fn_x2_to_float32(x_fp4x2[tile_k, byte])
                 contrib = contrib + weight_lo * x_lo + weight_hi * x_hi
             weight_scale_offsets = swizzled_scale_offsets(
-                row,
+                cast("int", row),
                 tile_k.index,
                 K_groups,
             )
@@ -593,13 +595,59 @@ def _nvfp4_gemv_fp4in_kernel(
     return out
 
 
+# Share the DSL bodies across backends; each backend keeps its tuned config.
+BF16IN_TRITON_CONFIG = helion.Config(block_sizes=[1, 512], num_warps=1, num_stages=2)
+FP4IN_TRITON_CONFIG = helion.Config(block_sizes=[1, 128], num_warps=4, num_stages=3)
+
+BF16IN_CONFIGS: dict[BackendName, helion.Config] = {
+    "triton": BF16IN_TRITON_CONFIG,
+    "cute": BF16IN_CONFIG,
+}
+FP4IN_CONFIGS: dict[BackendName, helion.Config] = {
+    "triton": FP4IN_TRITON_CONFIG,
+    "cute": FP4IN_CONFIG,
+}
+
+
+def _selected_backend(backend: BackendName | None) -> BackendName:
+    selected = helion.Settings().backend if backend is None else backend
+    if selected not in ("triton", "cute"):
+        raise ValueError(
+            f"nvfp4_gemv supports backend='triton' or 'cute', got {selected!r}"
+        )
+    return selected
+
+
+@functools.cache
+def _nvfp4_gemv_bf16in_kernel(backend: BackendName) -> helion.Kernel[Tensor]:
+    return helion.kernel(
+        _nvfp4_gemv_bf16in_body,
+        static_shapes=True,
+        config=BF16IN_CONFIGS[backend],
+        backend=backend,
+    )
+
+
+@functools.cache
+def _nvfp4_gemv_fp4in_kernel(backend: BackendName) -> helion.Kernel[Tensor]:
+    return helion.kernel(
+        _nvfp4_gemv_fp4in_body,
+        static_shapes=True,
+        config=FP4IN_CONFIGS[backend],
+        backend=backend,
+    )
+
+
 def nvfp4_gemv_bf16in(
     weight_packed: Tensor,
     x_bf16: Tensor,
     weight_scale: Tensor,
     alpha: float = 1.0,
+    *,
+    backend: BackendName | None = None,
 ) -> Tensor:
     """Compute ``weight_packed @ x_bf16`` for NVFP4 weights and BF16 input."""
+    backend = _selected_backend(backend)
     weight_fp4x2 = _as_fp4x2(weight_packed)
     weight_bytes = weight_fp4x2.view(torch.uint8)
     scale_cols = weight_bytes.shape[1] // 8
@@ -612,7 +660,7 @@ def nvfp4_gemv_bf16in(
     out = torch.empty(
         weight_bytes.shape[0], dtype=torch.bfloat16, device=weight_bytes.device
     )
-    if _can_use_fast_cute_path(
+    if backend == "cute" and _can_use_fast_cute_path(
         weight_bytes,
         x_bf16,
         weight_scale,
@@ -630,7 +678,7 @@ def nvfp4_gemv_bf16in(
             block=(128, 1, 1),
         )
         return out
-    return _nvfp4_gemv_bf16in_kernel(
+    return _nvfp4_gemv_bf16in_kernel(backend)(
         weight_fp4x2.view(weight_bytes.shape[0], weight_bytes.shape[1] // 8, 8),
         x_bf16.view(weight_bytes.shape[1] // 8, 16),
         weight_scale.reshape(-1),
@@ -645,8 +693,11 @@ def nvfp4_gemv_fp4in(
     weight_scale: Tensor,
     x_scale: Tensor,
     alpha: float = 1.0,
+    *,
+    backend: BackendName | None = None,
 ) -> Tensor:
     """Compute ``weight_packed @ x_packed`` for NVFP4 weights and input."""
+    backend = _selected_backend(backend)
     weight_fp4x2 = _as_fp4x2(weight_packed)
     x_fp4x2 = _as_fp4x2(x_packed)
     weight_bytes = weight_fp4x2.view(torch.uint8)
@@ -662,7 +713,7 @@ def nvfp4_gemv_fp4in(
     out = torch.empty(
         weight_bytes.shape[0], dtype=torch.bfloat16, device=weight_bytes.device
     )
-    if _can_use_fast_cute_path(
+    if backend == "cute" and _can_use_fast_cute_path(
         weight_bytes,
         x_bytes,
         weight_scale,
@@ -682,7 +733,7 @@ def nvfp4_gemv_fp4in(
             block=(64, 1, 1),
         )
         return out
-    return _nvfp4_gemv_fp4in_kernel(
+    return _nvfp4_gemv_fp4in_kernel(backend)(
         weight_fp4x2.view(weight_bytes.shape[0], weight_bytes.shape[1] // 8, 8),
         x_fp4x2.view(weight_bytes.shape[1] // 8, 8),
         weight_scale.reshape(-1),
@@ -764,22 +815,23 @@ def make_fp8_scales(shape: tuple[int, ...], device: torch.device) -> Tensor:
     return swizzle_fp8_scales(logical_scales)
 
 
-def check_bf16in(M: int, K_bytes: int) -> None:
+def check_bf16in(M: int, K_bytes: int, backend: BackendName) -> None:
     weight = torch.randint(0, 256, (M, K_bytes), dtype=torch.uint8, device=DEVICE).view(
         torch.float4_e2m1fn_x2
     )
     x = torch.randn(K_bytes * 2, dtype=torch.bfloat16, device=DEVICE)
     weight_scale = make_fp8_scales((M, K_bytes // 8), DEVICE)
     run_example(
-        nvfp4_gemv_bf16in,
+        functools.partial(nvfp4_gemv_bf16in, backend=backend),
         reference_nvfp4_gemv_bf16in,
         (weight, x, weight_scale),
+        kernel_name=f"helion-{backend}",
         atol=4.0,
         rtol=2e-1,
     )
 
 
-def check_fp4in(M: int, K_bytes: int) -> None:
+def check_fp4in(M: int, K_bytes: int, backend: BackendName) -> None:
     weight = torch.randint(0, 256, (M, K_bytes), dtype=torch.uint8, device=DEVICE).view(
         torch.float4_e2m1fn_x2
     )
@@ -789,9 +841,10 @@ def check_fp4in(M: int, K_bytes: int) -> None:
     weight_scale = make_fp8_scales((M, K_bytes // 8), DEVICE)
     x_scale = make_fp8_scales((K_bytes // 8,), DEVICE)
     run_example(
-        nvfp4_gemv_fp4in,
+        functools.partial(nvfp4_gemv_fp4in, backend=backend),
         reference_nvfp4_gemv_fp4in,
         (weight, x, weight_scale, x_scale),
+        kernel_name=f"helion-{backend}",
         atol=4.0,
         rtol=2e-1,
     )
@@ -803,7 +856,9 @@ def nvfp4_gemv_bf16in_tritonbench(
     x_bf16: Tensor,
     weight_scale: Tensor,
 ) -> Callable[[], Tensor]:
-    return lambda: nvfp4_gemv_bf16in(weight_packed, x_bf16, weight_scale)
+    return lambda: nvfp4_gemv_bf16in(
+        weight_packed, x_bf16, weight_scale, backend="triton"
+    )
 
 
 def nvfp4_gemv_fp4in_tritonbench(
@@ -813,12 +868,15 @@ def nvfp4_gemv_fp4in_tritonbench(
     weight_scale: Tensor,
     x_scale: Tensor,
 ) -> Callable[[], Tensor]:
-    return lambda: nvfp4_gemv_fp4in(weight_packed, x_packed, weight_scale, x_scale)
+    return lambda: nvfp4_gemv_fp4in(
+        weight_packed, x_packed, weight_scale, x_scale, backend="triton"
+    )
 
 
 def main() -> None:
-    check_bf16in(64, 128)
-    check_fp4in(64, 128)
+    for backend in ("triton", "cute"):
+        check_bf16in(64, 128, backend)
+        check_fp4in(64, 128, backend)
 
 
 if __name__ == "__main__":

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -955,6 +955,22 @@ class TritonBackend(Backend):
     def experimental(self) -> bool:
         return False
 
+    def transform_host_arg(
+        self,
+        arg: Argument,
+        host_str: str,
+        tensor_host_args: list[str],
+    ) -> str:
+        from .device_function import TensorArg
+
+        # Bind fp4x2 storage as uint8; Triton has no pointer type for the shell dtype.
+        if (
+            isinstance(arg, TensorArg)
+            and arg.fake_value.dtype is torch.float4_e2m1fn_x2
+        ):
+            return f"{host_str}.view(torch.uint8)"
+        return host_str
+
     def supports_config_key(self, key: str) -> bool:
         if key == "load_cache_modifiers":
             return True

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -236,6 +236,333 @@ class IndexingStrategy:
         )
 
 
+class _PointerLoadContiguity:
+    """Derive ``tl.max_contiguous`` for a narrow blocked-gather pattern.
+
+    This targets scale-buffer layouts such as NVFP4 SWIZZLE_32_4_4, where the
+    gather is blocked-contiguous but Triton sees only pointer arithmetic.
+
+    Allowlist:
+    - Triton pointer loads from a 1-D stride-1 tensor.
+    - One computed integer gather index built from tile indices, constants,
+      broadcasts, ``+``, ``-``, constant ``*``, ``//``, ``%``, ``>> const``,
+      and ``& (2**k - 1)``.
+    - Constant block sizes and constant tile begins. Tile indices are evaluated
+      as ``begin + arange(block)`` for program 0.
+    - Uniform scalar terms that do not shift a run-varying floor/rem boundary.
+
+    Blocklist:
+    - Stores/atomics, non-pointer indexing, and multi-index gathers.
+    - Data-dependent or float indices, non-constant divisors, products of two
+      index terms, symbolic begins, arbitrary bitwise ops, and cross-axis
+      modulo patterns.
+    - Scalar, full-tile, or non-vector-width runs.
+
+    For modulo terms that vary along the run axis, the divisor must divide the
+    run extent. That keeps later program IDs from changing the run shape measured
+    in program 0.
+    """
+
+    # Byte widths worth asserting as vector runs.
+    _USEFUL_RUN_BYTES: ClassVar[tuple[int, ...]] = (4, 8, 16)
+    # Aten integer ops allowed in the gather index.
+    _ADD: ClassVar[set[str]] = {
+        "add",
+        "add.Tensor",
+        "add.Scalar",
+        "sub",
+        "sub.Tensor",
+        "sub.Scalar",
+    }
+    _MUL: ClassVar[set[str]] = {"mul", "mul.Tensor", "mul.Scalar"}
+    _DIV: ClassVar[set[str]] = {
+        "div.Tensor_mode",
+        "floor_divide",
+        "remainder",
+        "remainder.Scalar",
+        "remainder.Tensor",
+    }
+    _RSHIFT: ClassVar[set[str]] = {"__rshift__.Scalar", "rshift"}
+    _BITWISE_AND: ClassVar[set[str]] = {"bitwise_and.Scalar", "and_"}
+
+    def __init__(
+        self,
+        state: CodegenState,
+        fake_tensor: torch.Tensor,
+        subscript: list[object],
+    ) -> None:
+        self.state = state
+        self.fake_tensor = fake_tensor
+        self.subscript = subscript
+        self.extents: dict[torch.fx.Node, int] = {}
+        self.begins: dict[torch.fx.Node, int] = {}
+        self._cache: dict[torch.fx.Node, object] = {}
+        self._unknown_scalars: set[torch.fx.Node] = set()
+
+    def derive(self) -> list[int] | None:
+        """Return a per-result-dim ``tl.max_contiguous`` list, or None to emit nothing."""
+        index_node = self._gather_index_node()
+        if index_node is None:
+            return None
+
+        # Allowlisted expression shape plus every floor/rem site.
+        tiles: set[torch.fx.Node] = set()
+        divisions: list[tuple[int, object]] = []
+        if not self._walk(index_node, tiles, divisions) or not tiles:
+            return None
+        if not self._resolve_extents(tiles):
+            return None
+
+        rank = len(
+            SubscriptIndexing.compute_shape(
+                self.fake_tensor, self.subscript, self.state
+            )
+        )
+        if rank == 0:
+            return None
+
+        # Evaluate the candidate index with real integer tensors.
+        from torch._subclasses.fake_tensor import unset_fake_temporarily
+
+        with unset_fake_temporarily():
+            offset = self._eval(index_node)
+            if not isinstance(offset, torch.Tensor) or offset.ndim != rank:
+                return None
+            run_extent = offset.shape[-1]
+            for divisor, dividend in divisions:
+                if not self._run_axis_safe(divisor, dividend, offset, run_extent):
+                    return None
+            k = self._max_run(offset.to(torch.int64))
+
+        # Blocklist hints that are scalar, already full-tile, or not vector-sized.
+        if not (2 <= k < run_extent):
+            return None
+        if k * self.fake_tensor.element_size() not in self._USEFUL_RUN_BYTES:
+            return None
+
+        contiguity = [1] * rank
+        contiguity[-1] = k
+        return contiguity
+
+    def _run_axis_safe(
+        self, divisor: int, dividend: object, offset: torch.Tensor, run_extent: int
+    ) -> bool:
+        """Can one floor/rem site reuse the program-0 run for all programs?"""
+        val = self._eval(dividend)
+        if not isinstance(val, torch.Tensor):
+            return True
+        flat = val.broadcast_to(offset.shape).reshape(-1, run_extent)
+        varies_run = run_extent > 1 and not torch.equal(flat[:, 1:], flat[:, :-1])
+        if not varies_run:
+            return True
+        if self._has_unknown_scalar(dividend):
+            return False
+        varies_other = not torch.equal(flat, flat[:1].expand_as(flat))
+        return not varies_other and run_extent % divisor == 0
+
+    def _gather_index_node(self) -> torch.fx.Node | None:
+        """The single computed index of a 1-D stride-1 advanced-indexing gather."""
+        # Plain affine loads are already handled by Triton's AxisInfo.
+        if not any(isinstance(k, torch.Tensor) for k in self.subscript):
+            return None
+        # The proof is on the index, so the tensor stride must be 1.
+        if (
+            self.fake_tensor.ndim != 1
+            or self._const_int(self.fake_tensor.stride(0)) != 1
+        ):
+            return None
+        fx_node = getattr(self.state, "fx_node", None)
+        if fx_node is None or len(fx_node.args) < 2:
+            return None
+        index_args = fx_node.args[1]
+        if not isinstance(index_args, (list, tuple)):
+            return None
+        idx_nodes = [a for a in index_args if isinstance(a, torch.fx.Node)]
+        if len(idx_nodes) != 1:  # v1: single computed index
+            return None
+        return idx_nodes[0]
+
+    def _resolve_extents(self, tiles: set[torch.fx.Node]) -> bool:
+        """Resolve constexpr block sizes and begins for tile-index leaves."""
+        env = CompileEnvironment.current()
+        active_loops = self.state.codegen.active_device_loops
+        for ti in tiles:
+            val = ti.meta.get("val")
+            if not isinstance(val, torch.Tensor) or val.ndim < 1:
+                return False
+            bid = env.get_block_id(val.size(0))
+            if bid is None:
+                return False
+            loops = active_loops.get(bid)
+            info = loops[-1].block_id_to_info.get(bid) if loops else None
+            if info is None:
+                return False
+            begin = info.begin_expr
+            # Blocklist symbolic begins; the proof evaluates a concrete program-0 tile.
+            if begin is None or not begin.is_number:
+                return False
+            bs = self._const_int(env.block_sizes[bid].from_config(self.state.config))
+            if bs is None or bs <= 0:
+                return False
+            self.extents[ti] = bs
+            self.begins[ti] = int(begin)
+        return True
+
+    def _walk(
+        self,
+        node: object,
+        tiles: set[torch.fx.Node],
+        divisions: list[tuple[int, object]],
+    ) -> bool:
+        """Walk the allowlisted integer expression shape."""
+        seen: set[torch.fx.Node] = set()
+
+        def rec(n: object) -> bool:
+            if self._const_int(n) is not None:
+                return True
+            if not isinstance(n, torch.fx.Node):
+                return False
+            if n in seen:
+                return True
+            seen.add(n)
+            name = self._op_name(n)
+            if name == "tile_index":
+                tiles.add(n)
+                return True
+            if name in ("subscript", "load"):
+                src = n.args[0]
+                if not isinstance(src, torch.fx.Node) or not self._is_op(
+                    src, "tile_index"
+                ):
+                    return False
+                tiles.add(src)
+                return True
+            if name in ("sym_size.int", "_get_symnode", "sym_size"):
+                self._unknown_scalars.add(n)
+                return True
+            if name in self._DIV:
+                d = self._const_int(n.args[1])
+                if d is None or d <= 0:
+                    return False
+                divisions.append((d, n.args[0]))
+                return rec(n.args[0])
+            if name in self._RSHIFT:
+                shift = self._const_int(n.args[1])
+                if shift is None or shift < 0:
+                    return False
+                divisions.append((1 << shift, n.args[0]))
+                return rec(n.args[0])
+            if name in self._BITWISE_AND:
+                divisor, dividend = self._bitwise_and_divisor(n)
+                if divisor is None:
+                    return False
+                divisions.append((divisor, dividend))
+                return rec(dividend)
+            if name in self._MUL:
+                # Allowlist affine scaling only.
+                if not any(self._const_int(a) is not None for a in n.args):
+                    return False
+                return all(rec(a) for a in n.args)
+            if name in self._ADD:
+                return all(rec(a) for a in n.args)
+            return False
+
+        return rec(node)
+
+    def _eval(self, node: object) -> object:
+        """Evaluate an allowlisted index expression for program 0."""
+        c = self._const_int(node)
+        if c is not None:
+            return c
+        assert isinstance(node, torch.fx.Node)
+        if node in self._cache:
+            return self._cache[node]
+        name = self._op_name(node)
+        if name == "tile_index":
+            v: object = (
+                torch.arange(self.extents[node], dtype=torch.int64) + self.begins[node]
+            )
+        elif node in self._unknown_scalars:
+            v = 0
+        elif name in ("subscript", "load"):
+            base = self._eval(node.args[0])
+            assert isinstance(base, torch.Tensor)
+            index = node.args[1]
+            assert isinstance(index, (tuple, list))
+            # Replay broadcast subscripts such as ``tile.index[None, :]``.
+            v = base[tuple(index)]  # pyrefly: ignore [bad-index, bad-argument-type]
+        else:
+            args = [self._eval(a) for a in node.args]
+            assert callable(node.target)
+            v = node.target(*args, **node.kwargs)
+        self._cache[node] = v
+        return v
+
+    @staticmethod
+    def _max_run(offset: torch.Tensor) -> int:
+        """Largest power-of-two k s.t. every tile-aligned group of k along the last
+        axis is consecutive (off[..., j*k + t] == off[..., j*k] + t)."""
+        n = offset.shape[-1]
+        best = 1
+        k = 2
+        while k <= n and n % k == 0:
+            grp = offset.reshape(*offset.shape[:-1], n // k, k)
+            expect = grp[..., :1] + torch.arange(k, dtype=offset.dtype)
+            if torch.equal(grp, expect):
+                best = k
+                k *= 2
+            else:
+                break
+        return best
+
+    @staticmethod
+    def _op_name(node: object) -> str:
+        target = getattr(node, "target", None)
+        name = getattr(target, "__name__", None)
+        return name or str(target)
+
+    def _has_unknown_scalar(self, node: object) -> bool:
+        seen: set[torch.fx.Node] = set()
+
+        def rec(n: object) -> bool:
+            if not isinstance(n, torch.fx.Node) or n in seen:
+                return False
+            seen.add(n)
+            return n in self._unknown_scalars or any(rec(arg) for arg in n.args)
+
+        return rec(node)
+
+    @classmethod
+    def _bitwise_and_divisor(cls, node: torch.fx.Node) -> tuple[int | None, object]:
+        if len(node.args) != 2:
+            return None, None
+        for i, arg in enumerate(node.args):
+            mask = cls._const_int(arg)
+            if mask is None or mask <= 0:
+                continue
+            divisor = mask + 1
+            if divisor & (divisor - 1) == 0:
+                return divisor, node.args[1 - i]
+        return None, None
+
+    @classmethod
+    def _is_op(cls, node: object, name: str) -> bool:
+        return isinstance(node, torch.fx.Node) and cls._op_name(node) == name
+
+    @staticmethod
+    def _const_int(x: object) -> int | None:
+        if isinstance(x, bool):
+            return None
+        if isinstance(x, int):
+            return int(x)
+        if isinstance(x, torch.SymInt):
+            try:
+                return int(x)
+            except Exception:
+                return None
+        return None
+
+
 class PointerIndexingStrategy(IndexingStrategy):
     """Generate the original pointer math to load/store from tensors"""
 
@@ -258,10 +585,29 @@ class PointerIndexingStrategy(IndexingStrategy):
             else:
                 extra = ", other=0"
         name = state.device_function.tensor_arg(fake_tensor).name
+        # Optional hint for the allowlisted blocked-gather pattern.
+        offset_ast = indexing.index_expr
+        try:
+            contiguity = _PointerLoadContiguity(state, fake_tensor, subscript).derive()
+        except Exception:
+            contiguity = None
+        if contiguity is not None:
+            # Triton propagates the hint from ``index``, but not ``index * 1``.
+            inner_ast = offset_ast
+            if (
+                isinstance(inner_ast, ast.BinOp)
+                and isinstance(inner_ast.op, ast.Mult)
+                and isinstance(inner_ast.right, ast.Constant)
+                and inner_ast.right.value == 1
+            ):
+                inner_ast = inner_ast.left
+            offset_ast = expr_from_string(
+                f"tl.max_contiguous({{off}}, {contiguity!r})", off=inner_ast
+            )
         extra += ", eviction_policy={ev}" if eviction_policy is not None else ""
         extra += ", cache_modifier={cm}" if cache_modifier is not None else ""
         load_placeholders: dict[str, ast.AST] = {
-            "offset": indexing.index_expr,
+            "offset": offset_ast,
             "mask": indexing.mask_expr,
         }
         if eviction_policy is not None:

--- a/helion/language/quantized_ops.py
+++ b/helion/language/quantized_ops.py
@@ -55,8 +55,9 @@ _FP4X2_TO_F32_ASM = """
 {
     .reg .b8 b0, b1, b2, b3;
     .reg .b16 lo, hi;
-    .reg .b32 h2;
-    mov.b32 {b0, b1, b2, b3}, $2;
+    .reg .b32 packed, h2;
+    and.b32 packed, $2, 0xFF;
+    mov.b32 {b0, b1, b2, b3}, packed;
     cvt.rn.f16x2.e2m1x2 h2, b0;
     mov.b32 {lo, hi}, h2;
     cvt.f32.f16 $0, lo;

--- a/helion/language/quantized_ops.py
+++ b/helion/language/quantized_ops.py
@@ -53,11 +53,10 @@ def _(state: CodegenState) -> list[ast.AST]:
 # Triton uses inline asm for the same fp4x2 unpack instruction as CuTe.
 _FP4X2_TO_F32_ASM = """
 {
-    .reg .b8 b0, b1, b2, b3;
+    .reg .b8 b0;
     .reg .b16 lo, hi;
-    .reg .b32 packed, h2;
-    and.b32 packed, $2, 0xFF;
-    mov.b32 {b0, b1, b2, b3}, packed;
+    .reg .b32 h2;
+    mov.b16 {b0, _}, $2;
     cvt.rn.f16x2.e2m1x2 h2, b0;
     mov.b32 {lo, hi}, h2;
     cvt.f32.f16 $0, lo;
@@ -69,7 +68,7 @@ _FP4X2_TO_F32_ASM = """
 @_decorators.codegen(float4_e2m1fn_x2_to_float32, "triton")
 def _(state: CodegenState) -> list[ast.AST]:
     value = state.codegen.lift(
-        expr_from_string("{value}.to(tl.int32)", value=state.ast_arg(0)),
+        expr_from_string("{value}.to(tl.int16)", value=state.ast_arg(0)),
         dce=True,
         prefix="fp4_packed",
     )
@@ -78,7 +77,7 @@ def _(state: CodegenState) -> list[ast.AST]:
         func=expr_from_string("tl.inline_asm_elementwise"),
         args=[
             create(ast.Constant, value=_FP4X2_TO_F32_ASM),
-            create(ast.Constant, value="=f,=f,r"),
+            create(ast.Constant, value="=f,=f,h"),
             create(ast.List, elts=[value], ctx=ast.Load()),
             expr_from_string("(tl.float32, tl.float32)"),
             create(ast.Constant, value=True),  # is_pure

--- a/helion/language/quantized_ops.py
+++ b/helion/language/quantized_ops.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
-import ast
 from typing import TYPE_CHECKING
 
 import torch
 
 from .. import exc
-from .._compiler.ast_extension import create
 from .._compiler.ast_extension import expr_from_string
 from . import _decorators
 
 if TYPE_CHECKING:
+    import ast
+
     from .._compiler.inductor_lowering import CodegenState
 
 __all__ = ["float4_e2m1fn_x2_to_float32"]
@@ -50,40 +50,51 @@ def _(state: CodegenState) -> list[ast.AST]:
     ]
 
 
-# Triton uses inline asm for the same fp4x2 unpack instruction as CuTe.
-_FP4X2_TO_F32_ASM = """
-{
-    .reg .b8 b0, b1, b2, b3;
-    .reg .b16 lo, hi;
-    .reg .b32 packed, h2;
-    and.b32 packed, $2, 0xFF;
-    mov.b32 {b0, b1, b2, b3}, packed;
-    cvt.rn.f16x2.e2m1x2 h2, b0;
-    mov.b32 {lo, hi}, h2;
-    cvt.f32.f16 $0, lo;
-    cvt.f32.f16 $1, hi;
-}
-"""
+def _triton_dequant_e2m1(state: CodegenState, nibble: ast.AST) -> ast.AST:
+    sign = state.codegen.lift(
+        expr_from_string("(({nibble} >> 3) & 1).to(tl.float32)", nibble=nibble),
+        dce=True,
+        prefix="fp4_sign",
+    )
+    value = state.codegen.lift(
+        expr_from_string("({nibble} & 0x7).to(tl.float32)", nibble=nibble),
+        dce=True,
+        prefix="fp4_value",
+    )
+    abs_value = state.codegen.lift(
+        expr_from_string(
+            "tl.where({value} < 4.0, {value} * 0.5, "
+            "tl.where({value} < 6.0, {value} - 2.0, {value} * 2.0 - 8.0))",
+            value=value,
+        ),
+        dce=True,
+        prefix="fp4_abs",
+    )
+    return expr_from_string(
+        "{abs_value} * (1.0 - 2.0 * {sign})",
+        abs_value=abs_value,
+        sign=sign,
+    )
 
 
 @_decorators.codegen(float4_e2m1fn_x2_to_float32, "triton")
 def _(state: CodegenState) -> list[ast.AST]:
-    value = expr_from_string("{value}.to(tl.int32)", value=state.ast_arg(0))
-    call = create(
-        ast.Call,
-        func=expr_from_string("tl.inline_asm_elementwise"),
-        args=[
-            create(ast.Constant, value=_FP4X2_TO_F32_ASM),
-            create(ast.Constant, value="=f,=f,r"),
-            create(ast.List, elts=[value], ctx=ast.Load()),
-            expr_from_string("(tl.float32, tl.float32)"),
-            create(ast.Constant, value=True),  # is_pure
-            create(ast.Constant, value=1),  # pack
-        ],
-        keywords=[],
+    value = state.codegen.lift(
+        expr_from_string("{value}.to(tl.int32)", value=state.ast_arg(0)),
+        dce=True,
+        prefix="fp4_packed",
     )
-    result = state.codegen.lift(call, dce=True, prefix="fp4_pair")
+    lo = state.codegen.lift(
+        expr_from_string("{value} & 0xF", value=value),
+        dce=True,
+        prefix="fp4_lo",
+    )
+    hi = state.codegen.lift(
+        expr_from_string("({value} >> 4) & 0xF", value=value),
+        dce=True,
+        prefix="fp4_hi",
+    )
     return [
-        expr_from_string(f"{result.id}[0]"),
-        expr_from_string(f"{result.id}[1]"),
+        _triton_dequant_e2m1(state, lo),
+        _triton_dequant_e2m1(state, hi),
     ]

--- a/helion/language/quantized_ops.py
+++ b/helion/language/quantized_ops.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
+import ast
 from typing import TYPE_CHECKING
 
 import torch
 
 from .. import exc
+from .._compiler.ast_extension import create
 from .._compiler.ast_extension import expr_from_string
 from . import _decorators
 
 if TYPE_CHECKING:
-    import ast
-
     from .._compiler.inductor_lowering import CodegenState
 
 __all__ = ["float4_e2m1fn_x2_to_float32"]
@@ -50,31 +50,20 @@ def _(state: CodegenState) -> list[ast.AST]:
     ]
 
 
-def _triton_dequant_e2m1(state: CodegenState, nibble: ast.AST) -> ast.AST:
-    sign = state.codegen.lift(
-        expr_from_string("(({nibble} >> 3) & 1).to(tl.float32)", nibble=nibble),
-        dce=True,
-        prefix="fp4_sign",
-    )
-    value = state.codegen.lift(
-        expr_from_string("({nibble} & 0x7).to(tl.float32)", nibble=nibble),
-        dce=True,
-        prefix="fp4_value",
-    )
-    abs_value = state.codegen.lift(
-        expr_from_string(
-            "tl.where({value} < 4.0, {value} * 0.5, "
-            "tl.where({value} < 6.0, {value} - 2.0, {value} * 2.0 - 8.0))",
-            value=value,
-        ),
-        dce=True,
-        prefix="fp4_abs",
-    )
-    return expr_from_string(
-        "{abs_value} * (1.0 - 2.0 * {sign})",
-        abs_value=abs_value,
-        sign=sign,
-    )
+# Triton uses inline asm for the same fp4x2 unpack instruction as CuTe.
+_FP4X2_TO_F32_ASM = """
+{
+    .reg .b8 b0, b1, b2, b3;
+    .reg .b16 lo, hi;
+    .reg .b32 packed, h2;
+    and.b32 packed, $2, 0xFF;
+    mov.b32 {b0, b1, b2, b3}, packed;
+    cvt.rn.f16x2.e2m1x2 h2, b0;
+    mov.b32 {lo, hi}, h2;
+    cvt.f32.f16 $0, lo;
+    cvt.f32.f16 $1, hi;
+}
+"""
 
 
 @_decorators.codegen(float4_e2m1fn_x2_to_float32, "triton")
@@ -84,17 +73,21 @@ def _(state: CodegenState) -> list[ast.AST]:
         dce=True,
         prefix="fp4_packed",
     )
-    lo = state.codegen.lift(
-        expr_from_string("{value} & 0xF", value=value),
-        dce=True,
-        prefix="fp4_lo",
+    call = create(
+        ast.Call,
+        func=expr_from_string("tl.inline_asm_elementwise"),
+        args=[
+            create(ast.Constant, value=_FP4X2_TO_F32_ASM),
+            create(ast.Constant, value="=f,=f,r"),
+            create(ast.List, elts=[value], ctx=ast.Load()),
+            expr_from_string("(tl.float32, tl.float32)"),
+            create(ast.Constant, value=True),  # is_pure
+            create(ast.Constant, value=1),  # pack
+        ],
+        keywords=[],
     )
-    hi = state.codegen.lift(
-        expr_from_string("({value} >> 4) & 0xF", value=value),
-        dce=True,
-        prefix="fp4_hi",
-    )
+    result = state.codegen.lift(call, dce=True, prefix="fp4_pair")
     return [
-        _triton_dequant_e2m1(state, lo),
-        _triton_dequant_e2m1(state, hi),
+        expr_from_string(f"{result.id}[0]"),
+        expr_from_string(f"{result.id}[1]"),
     ]

--- a/helion/language/quantized_ops.py
+++ b/helion/language/quantized_ops.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
+import ast
 from typing import TYPE_CHECKING
 
 import torch
 
 from .. import exc
+from .._compiler.ast_extension import create
 from .._compiler.ast_extension import expr_from_string
 from . import _decorators
 
 if TYPE_CHECKING:
-    import ast
-
     from .._compiler.inductor_lowering import CodegenState
 
 __all__ = ["float4_e2m1fn_x2_to_float32"]
@@ -42,6 +42,43 @@ def _(state: CodegenState) -> list[ast.AST]:
     call = expr_from_string(
         "_cute_float4_e2m1fn_x2_to_float32({value})",
         value=state.ast_arg(0),
+    )
+    result = state.codegen.lift(call, dce=True, prefix="fp4_pair")
+    return [
+        expr_from_string(f"{result.id}[0]"),
+        expr_from_string(f"{result.id}[1]"),
+    ]
+
+
+# Triton uses inline asm for the same fp4x2 unpack instruction as CuTe.
+_FP4X2_TO_F32_ASM = """
+{
+    .reg .b8 b0, b1, b2, b3;
+    .reg .b16 lo, hi;
+    .reg .b32 h2;
+    mov.b32 {b0, b1, b2, b3}, $2;
+    cvt.rn.f16x2.e2m1x2 h2, b0;
+    mov.b32 {lo, hi}, h2;
+    cvt.f32.f16 $0, lo;
+    cvt.f32.f16 $1, hi;
+}
+"""
+
+
+@_decorators.codegen(float4_e2m1fn_x2_to_float32, "triton")
+def _(state: CodegenState) -> list[ast.AST]:
+    call = create(
+        ast.Call,
+        func=expr_from_string("tl.inline_asm_elementwise"),
+        args=[
+            create(ast.Constant, value=_FP4X2_TO_F32_ASM),
+            create(ast.Constant, value="=f,=f,r"),
+            create(ast.List, elts=[state.ast_arg(0)], ctx=ast.Load()),
+            expr_from_string("(tl.float32, tl.float32)"),
+            create(ast.Constant, value=True),  # is_pure
+            create(ast.Constant, value=1),  # pack
+        ],
+        keywords=[],
     )
     result = state.codegen.lift(call, dce=True, prefix="fp4_pair")
     return [

--- a/helion/language/quantized_ops.py
+++ b/helion/language/quantized_ops.py
@@ -68,13 +68,14 @@ _FP4X2_TO_F32_ASM = """
 
 @_decorators.codegen(float4_e2m1fn_x2_to_float32, "triton")
 def _(state: CodegenState) -> list[ast.AST]:
+    value = expr_from_string("{value}.to(tl.int32)", value=state.ast_arg(0))
     call = create(
         ast.Call,
         func=expr_from_string("tl.inline_asm_elementwise"),
         args=[
             create(ast.Constant, value=_FP4X2_TO_F32_ASM),
             create(ast.Constant, value="=f,=f,r"),
-            create(ast.List, elts=[state.ast_arg(0)], ctx=ast.Load()),
+            create(ast.List, elts=[value], ctx=ast.Load()),
             expr_from_string("(tl.float32, tl.float32)"),
             create(ast.Constant, value=True),  # is_pure
             create(ast.Constant, value=1),  # pack

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1852,7 +1852,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             rtol=2e-1,
         )
 
-    @onlyBackends(["cute"])
+    @onlyBackends(["cute", "triton"])
     @skipIfNotCUDA()
     @skipIfCudaCapabilityLessThan(
         (10, 0), reason="NVFP4 conversion instructions require Blackwell"

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -124,6 +124,245 @@ class TestIndexing(RefEagerTestBase, TestCase):
             result, torch.arange(0, 100, device=DEVICE, dtype=torch.int32)
         )
 
+    @onlyBackends(["triton"])
+    @skipIfTileIR("hint is emitted by the Triton pointer indexing strategy")
+    @skipIfRefEager("asserts on generated Triton code")
+    def test_contiguity_hint_fires_on_swizzle_gather(self):
+        # Allowlist: swizzled 1-D gathers with four-element contiguous runs.
+        @helion.kernel(static_shapes=True)
+        def swizzle_gather(scale: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+            (n,) = out.shape
+            for tg in hl.tile(n):
+                idx = (tg.index // 4) * 512 + tg.index % 4
+                out[tg] = scale[idx]
+            return out
+
+        @helion.kernel(static_shapes=True)
+        def bitwise_swizzle_gather(
+            scale: torch.Tensor, out: torch.Tensor
+        ) -> torch.Tensor:
+            (n,) = out.shape
+            for tg in hl.tile(n):
+                idx = (tg.index >> 2) * 512 + (tg.index & 3)
+                out[tg] = scale[idx]
+            return out
+
+        n = 64
+        scale = torch.randn(8192, device=DEVICE, dtype=torch.float32)
+        out = torch.empty(n, device=DEVICE, dtype=torch.float32)
+        for fn in (swizzle_gather, bitwise_swizzle_gather):
+            code, result = code_and_output(
+                fn, (scale, out), indexing="pointer", block_size=[16]
+            )
+            self.assertIn("tl.max_contiguous(", code)
+            self.assertIn(", [4])", code)
+            i = torch.arange(n, device=DEVICE)
+            torch.testing.assert_close(result, scale[(i // 4) * 512 + i % 4])
+
+    @onlyBackends(["triton"])
+    @skipIfTileIR("hint is emitted by the Triton pointer indexing strategy")
+    @skipIfRefEager("asserts on generated Triton code")
+    def test_contiguity_hint_ignores_outer_axis_modulus(self):
+        # Allowlist: outer-axis modulo is constant along the inner run axis.
+        @helion.kernel(static_shapes=True)
+        def swizzle_2d(scale: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+            rows, cols = out.shape
+            for tr, tc in hl.tile([rows, cols]):
+                idx = (
+                    (tc.index[None, :] // 4) * 512
+                    + (tr.index[:, None] % 8) * 16
+                    + tc.index[None, :] % 4
+                )
+                out[tr, tc] = scale[idx]
+            return out
+
+        rows, cols = 2, 32
+        scale = torch.randn(8192, device=DEVICE, dtype=torch.float32)
+        out = torch.empty(rows, cols, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            swizzle_2d, (scale, out), indexing="pointer", block_size=[2, 32]
+        )
+        self.assertIn("tl.max_contiguous(", code)
+        self.assertIn(", [1, 4])", code)
+        r = torch.arange(rows, device=DEVICE)[:, None]
+        c = torch.arange(cols, device=DEVICE)[None, :]
+        torch.testing.assert_close(result, scale[(c // 4) * 512 + (r % 8) * 16 + c % 4])
+
+    @onlyBackends(["triton"])
+    @skipIfTileIR("hint is emitted by the Triton pointer indexing strategy")
+    @skipIfRefEager("asserts on generated Triton code")
+    def test_contiguity_hint_allows_scalar_outer_terms(self):
+        # Allowlist: scalar row swizzle terms are uniform across the inner run.
+        @helion.kernel(static_shapes=True)
+        def swizzle_scalar_row(scale: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+            rows, cols = out.shape
+            for tr in hl.tile(rows, block_size=1):
+                row = tr.begin
+                for tc in hl.tile(cols, block_size=16):
+                    idx = (
+                        ((row >> 7) * 1 + (tc.index >> 2)) * 512
+                        + (row & 31) * 16
+                        + ((row >> 5) & 3) * 4
+                        + (tc.index & 3)
+                    )
+                    out[row, tc] = scale[idx]
+            return out
+
+        rows, cols = 2, 32
+        scale = torch.randn(8192, device=DEVICE, dtype=torch.float32)
+        out = torch.empty(rows, cols, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            swizzle_scalar_row, (scale, out), indexing="pointer"
+        )
+        self.assertIn("tl.max_contiguous(", code)
+        self.assertIn(", [4])", code)
+        r = torch.arange(rows, device=DEVICE)[:, None]
+        c = torch.arange(cols, device=DEVICE)[None, :]
+        expected = scale[
+            ((r >> 7) * 1 + (c >> 2)) * 512
+            + (r & 31) * 16
+            + ((r >> 5) & 3) * 4
+            + (c & 3)
+        ]
+        torch.testing.assert_close(result, expected)
+
+    @onlyBackends(["triton"])
+    @skipIfTileIR("hint is emitted by the Triton pointer indexing strategy")
+    @skipIfRefEager("asserts on generated Triton code")
+    def test_contiguity_hint_does_not_fire_outside_swizzle(self):
+        # Blocklist: plain loads, data gathers, permutations, and non-useful widths.
+        @helion.kernel(static_shapes=True)
+        def affine_load(scale: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+            (n,) = out.shape
+            for tg in hl.tile(n):
+                out[tg] = scale[tg]  # plain affine tile load (no gather)
+            return out
+
+        @helion.kernel(static_shapes=True)
+        def clean_gather(scale: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+            (n,) = out.shape
+            for tg in hl.tile(n):
+                out[tg] = scale[tg.index]  # contiguous gather: run == block (no win)
+            return out
+
+        @helion.kernel(static_shapes=True)
+        def data_gather(
+            scale: torch.Tensor, idxbuf: torch.Tensor, out: torch.Tensor
+        ) -> torch.Tensor:
+            (n,) = out.shape
+            for tg in hl.tile(n):
+                out[tg] = scale[idxbuf[tg]]  # data-dependent index: purity bail
+            return out
+
+        @helion.kernel(static_shapes=True)
+        def permute_gather(scale: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+            (n,) = out.shape
+            for tg in hl.tile(n):
+                idx = (tg.index % 4) * 512 + tg.index // 4  # permutation: run == 1
+                out[tg] = scale[idx]
+            return out
+
+        @helion.kernel(static_shapes=True)
+        def swizzle_gather_wide(scale: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+            (n,) = out.shape
+            for tg in hl.tile(n):
+                idx = (tg.index // 4) * 512 + tg.index % 4  # swizzle, but 8-byte elt
+                out[tg] = scale[idx]  # k(4) * 8 bytes == 32, not a vectorizable width
+            return out
+
+        @helion.kernel(static_shapes=True)
+        def unsupported_bitwise_mask(
+            scale: torch.Tensor, out: torch.Tensor
+        ) -> torch.Tensor:
+            (n,) = out.shape
+            for tg in hl.tile(n):
+                idx = (tg.index & 5) * 512 + (tg.index & 3)
+                out[tg] = scale[idx]
+            return out
+
+        @helion.kernel(static_shapes=True)
+        def scalar_shifted_mask(scale: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+            rows, cols = out.shape
+            for tr in hl.tile(rows, block_size=1):
+                row = tr.begin
+                for tc in hl.tile(cols, block_size=16):
+                    idx = ((tc.index + row) >> 2) * 512 + ((tc.index + row) & 3)
+                    out[row, tc] = scale[idx]
+            return out
+
+        n = 64
+        f32 = torch.randn(8192, device=DEVICE, dtype=torch.float32)
+        small = f32[:n].contiguous()
+        out = torch.empty(n, device=DEVICE, dtype=torch.float32)
+        idxbuf = torch.randint(0, 8192, (n,), device=DEVICE, dtype=torch.int64)
+        i64 = torch.randint(0, 1000, (8192,), device=DEVICE, dtype=torch.int64)
+        out64 = torch.empty(n, device=DEVICE, dtype=torch.int64)
+
+        cases = [
+            (affine_load, (small, out)),
+            (clean_gather, (small, out)),
+            (data_gather, (f32, idxbuf, out)),
+            (permute_gather, (f32, out)),
+            (swizzle_gather_wide, (i64, out64)),
+            (unsupported_bitwise_mask, (f32, out)),
+        ]
+        for fn, args in cases:
+            code, _ = code_and_output(fn, args, indexing="pointer", block_size=[16])
+            self.assertNotIn(
+                "tl.max_contiguous", code, f"{fn.fn.__name__} should get no hint"
+            )
+
+        out2d = torch.empty(2, 32, device=DEVICE)
+        code, _ = code_and_output(scalar_shifted_mask, (f32, out2d), indexing="pointer")
+        self.assertNotIn("tl.max_contiguous", code)
+
+    @onlyBackends(["triton"])
+    @skipIfTileIR("hint is emitted by the Triton pointer indexing strategy")
+    @skipIfRefEager("asserts on generated Triton code")
+    def test_contiguity_hint_does_not_fire_on_shifted_tile(self):
+        # Blocklist: begin=1 breaks the four-element swizzle run.
+        @helion.kernel(static_shapes=True)
+        def shifted_swizzle(scale: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+            (n,) = out.shape
+            for tg in hl.tile(1, n):
+                idx = (tg.index >> 2) * 512 + (tg.index & 3)
+                out[tg] = scale[idx]
+            return out
+
+        n = 64
+        scale = torch.randn(8192, device=DEVICE, dtype=torch.float32)
+        out = torch.zeros(n, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            shifted_swizzle, (scale, out), indexing="pointer", block_size=[16]
+        )
+        self.assertNotIn("tl.max_contiguous", code)
+        i = torch.arange(1, n, device=DEVICE)
+        torch.testing.assert_close(result[1:], scale[(i // 4) * 512 + i % 4])
+
+    @onlyBackends(["triton"])
+    @skipIfTileIR("hint is emitted by the Triton pointer indexing strategy")
+    @skipIfRefEager("asserts on generated Triton code")
+    def test_contiguity_hint_fires_on_aligned_begin(self):
+        # Allowlist: begin=4 keeps the four-element swizzle run aligned.
+        @helion.kernel(static_shapes=True)
+        def aligned_swizzle(scale: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+            (n,) = out.shape
+            for tg in hl.tile(4, n):
+                idx = (tg.index >> 2) * 512 + (tg.index & 3)
+                out[tg] = scale[idx]
+            return out
+
+        n = 64
+        scale = torch.randn(8192, device=DEVICE, dtype=torch.float32)
+        out = torch.zeros(n, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            aligned_swizzle, (scale, out), indexing="pointer", block_size=[16]
+        )
+        self.assertIn("tl.max_contiguous(", code)
+        self.assertIn(", [4])", code)
+        i = torch.arange(4, n, device=DEVICE)
+        torch.testing.assert_close(result[4:], scale[(i // 4) * 512 + i % 4])
+
     @pytest.mark.xfail(
         _get_backend() == "cute",
         reason="CuTe matmul fallback with non-power-of-two static dimensions can generate invalid shared-memory indexing",

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -230,7 +230,7 @@ class TestIndexing(RefEagerTestBase, TestCase):
     @skipIfTileIR("hint is emitted by the Triton pointer indexing strategy")
     @skipIfRefEager("asserts on generated Triton code")
     def test_contiguity_hint_does_not_fire_outside_swizzle(self):
-        # Blocklist: plain loads, data gathers, permutations, and non-useful widths.
+        # Blocklist: plain loads, data gathers, permutations, and non-vectorizable widths.
         @helion.kernel(static_shapes=True)
         def affine_load(scale: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
             (n,) = out.shape

--- a/test/test_quantized_ops.py
+++ b/test/test_quantized_ops.py
@@ -124,7 +124,8 @@ class TestTritonQuantizedOps(RefEagerTestDisabled, TestCase):
         raw_i32 = raw.to(torch.int32)
         torch.testing.assert_close(lo, _dequant_e2m1(raw_i32 & 0xF))
         torch.testing.assert_close(hi, _dequant_e2m1((raw_i32 >> 4) & 0xF))
-        self.assertIn("tl.inline_asm_elementwise", code)
+        self.assertIn("tl.where", code)
+        self.assertNotIn("tl.inline_asm_elementwise", code)
 
 
 if __name__ == "__main__":

--- a/test/test_quantized_ops.py
+++ b/test/test_quantized_ops.py
@@ -124,8 +124,9 @@ class TestTritonQuantizedOps(RefEagerTestDisabled, TestCase):
         raw_i32 = raw.to(torch.int32)
         torch.testing.assert_close(lo, _dequant_e2m1(raw_i32 & 0xF))
         torch.testing.assert_close(hi, _dequant_e2m1((raw_i32 >> 4) & 0xF))
-        self.assertIn(" = load.to(tl.int32)", code)
+        self.assertIn(" = load.to(tl.int16)", code)
         self.assertIn("[fp4_packed_", code)
+        self.assertIn("=f,=f,h", code)
         self.assertIn("tl.inline_asm_elementwise", code)
 
 

--- a/test/test_quantized_ops.py
+++ b/test/test_quantized_ops.py
@@ -96,5 +96,36 @@ class TestCuteQuantizedOps(RefEagerTestDisabled, TestCase):
         self.assertIn("_cute_float4_e2m1fn_x2_to_float32", code)
 
 
+@onlyBackends(["triton"])
+class TestTritonQuantizedOps(RefEagerTestDisabled, TestCase):
+    @skipIfNotCUDA()
+    @skipIfCudaCapabilityLessThan(
+        (10, 0), reason="FP4/FP8 conversion instructions require Blackwell"
+    )
+    def test_float4_e2m1fn_x2_to_float32(self):
+        # Also covers fp4x2 host args viewed as uint8 for Triton.
+        @helion.kernel(autotune_effort="none")
+        def fp4_to_f32_pair(
+            x: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            lo = torch.empty(x.shape, dtype=torch.float32, device=x.device)
+            hi = torch.empty(x.shape, dtype=torch.float32, device=x.device)
+            for tile in hl.tile(x.size(0), block_size=16):
+                lo_value, hi_value = hl.float4_e2m1fn_x2_to_float32(x[tile])
+                lo[tile] = lo_value
+                hi[tile] = hi_value
+            return lo, hi
+
+        raw = torch.arange(16, dtype=torch.uint8, device=DEVICE) * 17  # 0x00..0xFF
+        code, (lo, hi) = code_and_output(
+            fp4_to_f32_pair,
+            (raw.view(torch.float4_e2m1fn_x2),),
+        )
+        raw_i32 = raw.to(torch.int32)
+        torch.testing.assert_close(lo, _dequant_e2m1(raw_i32 & 0xF))
+        torch.testing.assert_close(hi, _dequant_e2m1((raw_i32 >> 4) & 0xF))
+        self.assertIn("tl.inline_asm_elementwise", code)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_quantized_ops.py
+++ b/test/test_quantized_ops.py
@@ -124,8 +124,9 @@ class TestTritonQuantizedOps(RefEagerTestDisabled, TestCase):
         raw_i32 = raw.to(torch.int32)
         torch.testing.assert_close(lo, _dequant_e2m1(raw_i32 & 0xF))
         torch.testing.assert_close(hi, _dequant_e2m1((raw_i32 >> 4) & 0xF))
-        self.assertIn("tl.where", code)
-        self.assertNotIn("tl.inline_asm_elementwise", code)
+        self.assertIn(" = load.to(tl.int32)", code)
+        self.assertIn("[fp4_packed_", code)
+        self.assertIn("tl.inline_asm_elementwise", code)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
NVFP4 gemv kernel reads per-block scales through a swizzled index that's contiguous in short runs but hidden behind modular arithmetic. This can elude Triton's auto-vectorization. This PR has the compiler instead insert a contiguity hint (_PointerLoadContiguity) that proves the run at compile time and emits tl.max_contiguous, restoring vectorization.

SWIZZLE_32_4_4 scale layout gathers through:

```python
def swizzled_scale_offsets(row, col, cols):
      num_col_tiles = _ceil_div(cols, 4)
      tile_offset = ((row // 128) * num_col_tiles + col // 4) * 512
      return tile_offset + (row % 32) * 16 + ((row % 128) // 32) * 4 + col % 4
```

Along the inner axis this is contiguous in runs of 4 (col % 4 = 0,1,2,3) before each col // 4 step jumps by 512. Triton's AxisInfo doesn't recover that run. Once the * 512 floor term is folded into the offset it can't prove the per-4 contiguity, so the load lowers to a per-lane gather.

The contiguity hint does the following: 

```python
# before
load_3 = tl.load(weight_scale_bytes + v_139, None)

# after
load_3 = tl.load(weight_scale_bytes + tl.max_contiguous(v_139, [1, 4]), None)
```
`tl.max_contiguous` is a compiler assertion so the approach here is deliberately narrow:
  - Evaluates the gather index for program 0, modeling each tile index as begin + arange(block) (the exact lane values codegen emits), then measures the longest power-of-two k where every aligned group of k is +1-consecutive.
  - Generalizes to all programs with a per-floor/rem check: for any // d or % d whose dividend varies along the run axis, it requires d | run_extent, so the per-program base p * block vanishes mod d and can't change the run shape.

We make sure it never fires for the following:
  - Plain / affine loads (scale[tile], scale[tile.index])
  - Data-dependent gathers (scale[idx_buf[tile]])
  - Permutations ((i % 4) * 512 + i // 4)
  - Non-vectorizable widths
  - Non-power-of-two-minus-one masks (i & 5)
  - Shifted / unaligned tile begins (hl.tile(1, n))
  - Anything else non-affine or unprovable.

This helps Triton get parity with Cute for nvfp4_gemv on the benchmarking done in #2433  ([script](https://gist.github.com/ethche/c4f9fc0249aaeb41f0ad7b63e7ac8595))

bf16in
Method | Latency (µs) | max_rel |
-- | -- | -- |
CUDA | 23.51 | 3.6e‑3 |
Helion CuTe | 16.81 | 3.6e‑3 |
Helion Triton | 15.85 | 3.6e‑3 | 

fp4in
Method | Latency (µs) | max_rel |
-- | -- | -- |
CUDA | 44.01 | 0 |
Helion CuTe | 44.51 | 0 |
Helion Triton | 42.09 | 0 |

@choijon5 @zou3519 