### PR TITLE
[cute] Support column-major (K-major) B on the tcgen05 fp8 TMA path

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -1826,13 +1826,36 @@ def _emit_mma_pipeline(
     epi_elem_dtype_str = (
         _dtype_map[epi_elem_dtype] if epi_elem_dtype is not None else input_dtype_str
     )
-    tcgen05_use_tma = (
-        input_dtype in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
-        and lhs_fake.is_contiguous()
-        and rhs_fake.is_contiguous()
+
+    def _tcgen05_tma_2d_major(t: torch.Tensor) -> str | None:
+        # A 2D operand is TMA-eligible if it is contiguous in EITHER axis.
+        # Returns "row" (last-dim contiguous), "col" (first-dim contiguous),
+        # or None (neither -> not TMA-eligible). Row-major contiguous returns
+        # "row"; a transposed/column-major view returns "col".
+        if t.dim() != 2:
+            return "row" if t.is_contiguous() else None
+        s = t.stride()
+        if s[1] == 1:
+            return "row"
+        if s[0] == 1:
+            return "col"
+        return None
+
+    _dtype_tma_ok = input_dtype in (
+        torch.float16,
+        torch.bfloat16,
+        torch.float8_e4m3fn,
     )
-    tcgen05_use_tma_a = tcgen05_use_tma
-    tcgen05_use_tma_b = tcgen05_use_tma
+    _lhs_major = _tcgen05_tma_2d_major(lhs_fake)
+    _rhs_major = _tcgen05_tma_2d_major(rhs_fake)
+    # A must be row-major (M,K) K-contiguous == "row"; the K-major A SMEM
+    # layout Helion emits expects the standard row-major A. Only B's major
+    # mode is made layout-aware here.
+    tcgen05_use_tma_a = _dtype_tma_ok and _lhs_major == "row"
+    tcgen05_use_tma_b = _dtype_tma_ok and _rhs_major in ("row", "col")
+    # B is K-major when its (K, N) storage is K-contiguous (column-major),
+    # i.e. stride[0] == 1 -> _rhs_major == "col".
+    tcgen05_b_k_major = _rhs_major == "col"
     tcgen05_use_tma = tcgen05_use_tma_a or tcgen05_use_tma_b
     tcgen05_use_tma_pipeline = tcgen05_use_tma_a and tcgen05_use_tma_b
     tcgen05_requested_pure_matmul_role_lifecycle = is_pure_matmul_role_lifecycle_config(
@@ -3115,6 +3138,7 @@ def _emit_mma_pipeline(
                 bm,
                 bn,
                 tcgen05_cluster_m=tcgen05_cluster_m,
+                b_k_major=tcgen05_b_k_major,
             )
         )
     else:
@@ -3290,6 +3314,7 @@ def _emit_mma_pipeline(
                     bm,
                     bn,
                     tcgen05_cluster_m=tcgen05_cluster_m,
+                    b_k_major=tcgen05_b_k_major,
                 )
             )
         else:
@@ -3307,6 +3332,7 @@ def _emit_mma_pipeline(
                     bm,
                     bn,
                     tcgen05_cluster_m=tcgen05_cluster_m,
+                    b_k_major=tcgen05_b_k_major,
                 )
             )
     if mma_impl == "tcgen05":
@@ -3335,6 +3361,7 @@ def _emit_mma_pipeline(
                 smem_swizzle_b=tcgen05_smem_swizzle_b,
                 explicit_epi_tile_m=tcgen05_explicit_epi_tile_m,
                 explicit_epi_tile_n=tcgen05_explicit_epi_tile_n,
+                b_k_major=tcgen05_b_k_major,
             )
         )
         prefix.append(
@@ -3941,6 +3968,11 @@ def _emit_mma_pipeline(
                 "k_total_size": k_total_size,
                 "kernel_args": [tma_atom_a, tma_tensor_a, tma_atom_b, tma_tensor_b],
             }
+            # K-major (column-major / K-contiguous) B. Only recorded when True
+            # so MN-major (row-major B) wrapper-plan literals stay byte-identical
+            # to the golden.
+            if tcgen05_b_k_major:
+                ab_tma_plan["b_k_major"] = True
             # ``smem_swizzle_*`` overrides are recorded only when codegen
             # selected an explicit SMEM atom kind (either from a user
             # override or the scalar-edge fallback workaround). Keeping
@@ -5332,6 +5364,7 @@ def _make_tiled_mma_setup(
     bn: int,
     *,
     tcgen05_cluster_m: int = 1,
+    b_k_major: bool = False,
 ) -> list[ast.AST]:
     if mma_impl == "warp":
         tiled_mma_expr = (
@@ -5347,6 +5380,7 @@ def _make_tiled_mma_setup(
             bm,
             bn,
             tcgen05_cluster_m=tcgen05_cluster_m,
+            b_k_major=b_k_major,
         )
     else:
         assert mma_thread_linear
@@ -5375,16 +5409,24 @@ def _tcgen05_tiled_mma_expr(
     bn: int,
     *,
     tcgen05_cluster_m: int = 1,
+    b_k_major: bool = False,
 ) -> str:
     cta_group_expr = "cute.nvgpu.tcgen05.CtaGroup.ONE"
     if _tcgen05_use_2cta_instrs(bm=bm, cluster_m=tcgen05_cluster_m):
         cta_group_expr = "cute.nvgpu.tcgen05.CtaGroup.TWO"
+    # A is always K-major. B is MN-major for row-major (N-contiguous) B and
+    # K-major for column-major (K-contiguous) B.
+    b_major_expr = (
+        "cute.nvgpu.OperandMajorMode.K"
+        if b_k_major
+        else "cute.nvgpu.OperandMajorMode.MN"
+    )
     return (
         "cutlass.utils.blackwell_helpers.make_trivial_tiled_mma("
         f"{input_dtype_str}, "
         f"{input_dtype_str}, "
         "cute.nvgpu.OperandMajorMode.K, "
-        "cute.nvgpu.OperandMajorMode.MN, "
+        f"{b_major_expr}, "
         f"{acc_dtype_str}, "
         f"{cta_group_expr}, "
         f"({bm}, {bn}), "
@@ -5431,6 +5473,7 @@ def _make_tcgen05_layout_plan_setup(
     smem_swizzle_b: int | None = None,
     explicit_epi_tile_m: int | None = None,
     explicit_epi_tile_n: int | None = None,
+    b_k_major: bool = False,
 ) -> list[ast.AST]:
     # `compute_epilogue_tile_shape` must receive `elem_ty_d` and `elem_ty_c`
     # equal to the eventual D-output dtype so the helper takes the
@@ -5463,7 +5506,7 @@ def _make_tcgen05_layout_plan_setup(
         ),
         statement_from_string(
             f"{plan.smem_b_layout} = "
-            f"{tcgen05_smem_layout_expr(tiled_mma=tiled_mma, bm=bm, bn=bn, bk=bk, dtype_str=input_dtype_str, num_stages=ab_stage_count, operand='b', swizzle_override=smem_swizzle_b)}"
+            f"{tcgen05_smem_layout_expr(tiled_mma=tiled_mma, bm=bm, bn=bn, bk=bk, dtype_str=input_dtype_str, num_stages=ab_stage_count, operand='b', swizzle_override=smem_swizzle_b, b_k_major=b_k_major)}"
         ),
         statement_from_string(
             f"{plan.c_layout} = cutlass.utils.layout.LayoutEnum.ROW_MAJOR"

--- a/helion/_compiler/cute/strategies.py
+++ b/helion/_compiler/cute/strategies.py
@@ -389,6 +389,7 @@ def tcgen05_smem_layout_expr(
     num_stages: int,
     operand: str,
     swizzle_override: int | None,
+    b_k_major: bool = False,
 ) -> str:
     """Emit the CuTe expression that builds the staged SMEM layout for A or B.
 
@@ -439,6 +440,17 @@ def tcgen05_smem_layout_expr(
             "order=(1, 2, 3))"
         )
     assert operand == "b", f"unexpected operand {operand!r}"
+    if b_k_major:
+        # K-major (column-major / K-contiguous) B. Delegate to CuTe's helper
+        # with ``is_k_major=True`` so the SMEM atom selection mirrors the
+        # K-major A path exactly; the smem_swizzle_b override knob is not
+        # plumbed through this path (correctness-first), which is fine
+        # since the fp8 default path uses swizzle_override=None.
+        return (
+            "cutlass.utils.blackwell_helpers.make_smem_layout_b("
+            f"{tiled_mma}, ({bm}, {bn}, {bk}), {dtype_str}, {num_stages}, "
+            "is_k_major=True)"
+        )
     if swizzle_override is None:
         return (
             "cutlass.utils.blackwell_helpers.make_smem_layout_b("

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -2177,6 +2177,9 @@ def _append_cute_wrapper_plan(
     smem_swizzle_b: int | None = (
         int(smem_swizzle_b_raw) if isinstance(smem_swizzle_b_raw, int) else None
     )
+    # K-major (column-major / K-contiguous) B. Absent on the MN-major
+    # (row-major B) default path.
+    b_k_major = bool(plan.get("b_k_major"))
     kernel_args = [str(arg) for arg in cast("list[object]", plan["kernel_args"])]
     assert len(kernel_args) == 4
     tma_atom_a, tma_tensor_a, tma_atom_b, tma_tensor_b = kernel_args
@@ -2218,6 +2221,7 @@ def _append_cute_wrapper_plan(
         num_stages=ab_stage_count,
         operand="b",
         swizzle_override=smem_swizzle_b,
+        b_k_major=b_k_major,
     )
     body.extend(
         (
@@ -2226,8 +2230,12 @@ def _append_cute_wrapper_plan(
                 f"{input_dtype}, "
                 f"{input_dtype}, "
                 "cute.nvgpu.OperandMajorMode.K, "
-                "cute.nvgpu.OperandMajorMode.MN, "
-                f"{acc_dtype}, "
+                + (
+                    "cute.nvgpu.OperandMajorMode.K, "
+                    if b_k_major
+                    else "cute.nvgpu.OperandMajorMode.MN, "
+                )
+                + f"{acc_dtype}, "
                 f"{cta_group}, "
                 f"({bm}, {bn}), "
                 "cute.nvgpu.tcgen05.OperandSource.SMEM)"
@@ -2245,7 +2253,10 @@ def _append_cute_wrapper_plan(
                 f"(arg{rhs_idx}_shape1, arg{rhs_idx}_shape0), "
                 f"stride=(arg{rhs_idx}_stride1, arg{rhs_idx}_stride0)))"
             ),
-            f"    {rhs_tma}.mark_layout_dynamic(leading_dim=0)",
+            # B is viewed as (N, K). For row-major B (MN-major) the N axis
+            # (position 0) is contiguous; for column-major B (K-major, native
+            # fp8 layout) the K axis (position 1) is contiguous.
+            f"    {rhs_tma}.mark_layout_dynamic(leading_dim={1 if b_k_major else 0})",
             # ``make_tiled_tma_atom_A`` vs ``_B`` asymmetry:
             # - ``_B`` always passes ``cluster_layout_vmnk.shape`` as
             #   its trailing arg (CuTe's signature for B requires the

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -1247,6 +1247,32 @@ class TestCuteBackend(TestCase):
         self.assertIn("cute.nvgpu.tcgen05", code)
         self.assertIn("cute.gemm(", code)
 
+    def test_matmul_mma_tcgen05_fp8_col_major_b(self) -> None:
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = (torch.randn(256, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        # Column-major (K-contiguous) B. Helion must emit a K-major B operand
+        # (OperandMajorMode.K for B) and a matching K-major B SMEM layout,
+        # rather than forcing the slow non-TMA fallback.
+        y = (torch.randn(128, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = y.T.contiguous().T
+        self.assertFalse(y.is_contiguous())
+        code, out = code_and_output(
+            cute_matmul_mma_fp8, (x, y), block_sizes=[128, 128, 128]
+        )
+        ref = x.float() @ y.float()
+        torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+        # B is emitted K-major: both A and B operand major modes are K, so
+        # OperandMajorMode.K appears at least twice (A + B); the MN-major B
+        # spelling must be absent.
+        self.assertIn("cutlass.Float8E4M3FN", code)
+        self.assertIn("cute.nvgpu.tcgen05", code)
+        self.assertGreaterEqual(code.count("cute.nvgpu.OperandMajorMode.K"), 2)
+        self.assertNotIn("cute.nvgpu.OperandMajorMode.MN", code)
+
     def test_matmul_mma_tcgen05_fp8_rowvec_scale(self) -> None:
         support = get_cute_mma_support()
         if not support.tcgen05_f8:


### PR DESCRIPTION
Stacked PRs:
 * #2754
 * #2742
 * #2741
 * __->__#2740


--- --- ---

### [cute] Support column-major (K-major) B on the tcgen05 fp8 TMA path


fp8 scaled_mm feeds B column-major (K-contiguous) -- the layout
torch._scaled_mm requires and the standalone CUTLASS CuTe kernel uses
(b_major="k"). Helion previously gated the tcgen05 TMA path on
rhs.is_contiguous() (row-major only) and hardcoded B as MN-major, so a
column-major B operand was forced onto the slow non-TMA fallback
(~5 TFLOP/s), and even feeding row-major B used the slower MN-major MMA
layout.

This makes B's major mode layout-aware:
- cute_mma.py: classify a 2D operand as TMA-eligible when contiguous in
  EITHER axis (row -> MN-major, col -> K-major) instead of requiring
  row-major is_contiguous(); compute tcgen05_b_k_major from rhs stride and
  thread it through _make_tiled_mma_setup / _make_tcgen05_layout_plan_setup
  and onto the ab_tma wrapper plan.
- _tcgen05_tiled_mma_expr / strategies.tcgen05_smem_layout_expr: emit
  OperandMajorMode.K and make_smem_layout_b(is_k_major=True) for B when
  K-major (delegating to CuTe's helper, mirroring the K-major A path).
- runtime/__init__.py: host wrapper emits the K-major B tiled_mma +
  SMEM layout and marks the B TMA view leading_dim=1 (K axis) for K-major
  vs leading_dim=0 (N axis) for MN-major.
- test_cute_backend.py: test_matmul_mma_tcgen05_fp8_col_major_b.

All paths default to the prior MN-major behavior when B is row-major, so
existing golden/codegen tests are byte-identical (full cute suite: 93
passed). K-major B is correct (rel_err 0.0000 vs torch._scaled_mm).

Benchmark (B200, CUDA 13.2, fp8 e4m3 scaled_mm, m=k=n=4096,
CtaGroup.TWO cluster_m=2 ab_stages=3 role-local, do_bench, 10s warmup):

  row-major B (MN-major, old forced layout) :  577 TFLOP/s   31% of aten
  col-major B (K-major, this change)        : 1143 TFLOP/s   62% of aten
  torch._scaled_mm                          : 1857 TFLOP/s

i.e. ~2x from using the tensor-core-native K-major B layout. The
remaining gap to torch._scaled_mm is deep AB staging (ab_stages>3), a
separate lever.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
