### PR TITLE
[Pallas] Fix attention example VMEM regression by making LSE 3D

### DIFF
--- a/examples/attention.py
+++ b/examples/attention.py
@@ -65,8 +65,12 @@ def attention(
     v_view = v_in.reshape([-1, n_dim, head_dim])
     k_view = k_in.reshape([-1, n_dim, head_dim])
     out = torch.empty_like(q_view)
-    # Trailing size-1 dim works around a Pallas/TPU block-size inflation
-    # triggered by 2D outputs with a tile-indexed leading dim. See PR #2743.
+    # Trailing size-1 dim sidesteps a Helion block-size inflation: a 2-D
+    # `lse[B*H, S]` with a tile-indexed leading dim forces an 8-element
+    # sublane alignment on block_b, and adjust_block_size_constraints
+    # max-propagates that requirement to Q/K/V/out (which share the
+    # block_id), inflating their block_b and blowing up scoped VMEM.
+    # Tracked in pytorch/helion#2842.
     lse = torch.empty(
         [q_view.size(0), m_dim, 1], device=q_in.device, dtype=torch.float32
     )

--- a/examples/attention.py
+++ b/examples/attention.py
@@ -65,7 +65,11 @@ def attention(
     v_view = v_in.reshape([-1, n_dim, head_dim])
     k_view = k_in.reshape([-1, n_dim, head_dim])
     out = torch.empty_like(q_view)
-    lse = torch.empty([q_view.size(0), m_dim], device=q_in.device, dtype=torch.float32)
+    # Trailing size-1 dim works around a Pallas/TPU block-size inflation
+    # triggered by 2D outputs with a tile-indexed leading dim. See PR #2743.
+    lse = torch.empty(
+        [q_view.size(0), m_dim, 1], device=q_in.device, dtype=torch.float32
+    )
     sm_scale = 1.0 / math.sqrt(head_dim)
     qk_scale = sm_scale * 1.44269504  # 1/log(2)
     for tile_b, tile_m in hl.tile([q_view.size(0), m_dim]):
@@ -92,9 +96,9 @@ def attention(
             acc = torch.baddbmm(acc, p, v)
             m_i = m_ij
         acc = acc / l_i[:, :, None]
-        lse[tile_b, tile_m] = m_i + torch.log2(l_i)
+        lse[tile_b, tile_m, :] = (m_i + torch.log2(l_i))[:, :, None]
         out[tile_b, tile_m, :] = acc.to(out.dtype)
-    return out.view(q_in.size()), lse.view(q_in.size()[:-1])
+    return out.view(q_in.size()), lse.reshape(q_in.size()[:-1])
 
 
 # %%


### PR DESCRIPTION
## Summary
- Change attention example's `lse` from 2D `[B*H, S]` to 3D `[B*H, S, 1]`.
- External API unchanged: caller still sees `lse` as `[B, H, S]` fp32 (reshape at return). Backward kernel already flattens via `lse_in.reshape(-1)`, so it is unaffected.

## Why
On Pallas/TPU, a 2D output whose leading dim is the outer tile forces an 8-element TPU sublane alignment on the corresponding block_size. Helion's `adjust_block_size_constraints` takes the max alignment across all tile-indexed tensors sharing that block_id, so the requirement inflates `block_b` for Q/K/V/out as well. At `B=8 H=32 S=8192 D=256` bf16 with `block_sizes=[2, 512, 2048]` `unroll` `pb=False`, this expanded XLA's K and V input windows from `bf16[2,8192,256]` (16 MB each, double-buffered) to `bf16[8,8192,256]` (64 MB each), pushing total scoped VMEM past the 64 MiB cap.

Putting the alignment-sensitive dim on a trailing size-1 dim sidesteps the inflation. Verified by extracting `_block_spec_info` for both variants:
- 2D LSE: `_BLOCK_SIZE_0 = 8`, K/V block_shape `(8, None, None)` → 238 MB total
- 3D LSE: `_BLOCK_SIZE_0 = 2`, K/V block_shape `(2, None, None)` → 34 MB total

XLA allocator confirms the reduction matches.

## Impact (B=8 H=32 S=8192 D=256 bf16, TPU v7x)
| Config | Before this PR | After this PR |
| --- | --- | --- |
| `[2,512,2048] unroll pb=False` | fails to compile (238 MB needed, 64 MB cap) | 24.72 ms median |

The underlying compiler-level limitation (`adjust_block_size_constraints` max-propagating per-tensor TPU sublane alignment across independent tile-indexed tensors sharing a block_id) can be addressed in a follow-up.
