### PR TITLE
[Pallas] Add pallas_loop_type = 'outer_pipeline'

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1517,6 +1517,7 @@ class PallasBackend(Backend):
             "pltpu": "from jax.experimental.pallas import tpu as pltpu",
             "_default_pallas_launcher": "from helion.runtime import default_pallas_launcher as _default_pallas_launcher",
             "_default_pallas_pipeline_launcher": "from helion.runtime import default_pallas_pipeline_launcher as _default_pallas_pipeline_launcher",
+            "_default_pallas_outer_pipeline_launcher": "from helion.runtime import default_pallas_outer_pipeline_launcher as _default_pallas_outer_pipeline_launcher",
             "_default_pallas_fori_launcher": "from helion.runtime import default_pallas_fori_launcher as _default_pallas_fori_launcher",
         }
 
@@ -2415,7 +2416,7 @@ class PallasBackend(Backend):
 
         # Pass scratch shapes for pipeline/fori_loop launcher
         pallas_loop_type = config.get("pallas_loop_type", "unroll")
-        if pallas_loop_type in ("emit_pipeline", "fori_loop"):
+        if pallas_loop_type in ("emit_pipeline", "fori_loop", "outer_pipeline"):
             scratch_shapes = [
                 (
                     s.shape,
@@ -2475,6 +2476,8 @@ class PallasBackend(Backend):
             )
         if pallas_loop_type == "emit_pipeline":
             return "_default_pallas_pipeline_launcher"
+        if pallas_loop_type == "outer_pipeline":
+            return "_default_pallas_outer_pipeline_launcher"
         if pallas_loop_type == "fori_loop":
             return "_default_pallas_fori_launcher"
         return self.default_launcher_name

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -161,6 +161,7 @@ if TYPE_CHECKING:
     from .. import Config
     from ..runtime.settings import Settings
     from .backend import Backend
+    from .pallas.outer_pipeline import PipelineContext
 
     class _TLS(Protocol):
         env: CompileEnvironment | None
@@ -269,6 +270,7 @@ class CompileEnvironment:
         self._tensor_descriptor_layout_guard_source_cache: dict[int, Source | None] = {}
         self.jagged_tile_parent_ids: dict[int, list[int]] = {}
         self.jagged_tile_mask_shapes: dict[int, list[torch.SymInt]] = {}
+        self.outer_pipeline_context: PipelineContext | None = None
         self._symint_cache: dict[object, torch.SymInt] = {}
         self._foreign_symint_cache: dict[
             tuple[int, sympy.Expr], int | torch.SymInt
@@ -1247,6 +1249,7 @@ class BlockSizeInfo:
     reduction: bool
     block_size_source: BlockSizeSource
     debug_names: set[str] = dataclasses.field(default_factory=set)
+    max_extent: torch.SymInt | int | None = None
 
     def add_debug_name(self, name: str) -> None:
         if not name:
@@ -1309,6 +1312,22 @@ class BlockSizeInfo:
                     ).update_hint(hint)
         elif size is None or self.size is None or self.size != size:
             self.size = None
+
+    def mark_max_extent(self, max_extent: torch.SymInt | int | None) -> None:
+        """Record the declared static bound for a data-dependent tile loop."""
+        if max_extent is None:
+            return
+        if self.max_extent is None:
+            self.max_extent = max_extent
+            return
+        env = CompileEnvironment.current()
+        old = env.specialize_expr(_to_sympy(self.max_extent))
+        new = env.specialize_expr(_to_sympy(max_extent))
+        if old != new:
+            raise exc.IncorrectTileUsage(
+                "Conflicting hl.tile(max_extent=...) values for the same "
+                f"registered block size: {old} vs {new}."
+            )
 
     def symbol(self) -> sympy.Symbol:
         expr = _symint_expr(self.var)

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -204,7 +204,10 @@ def shape_env_var_hints(shape_env: ShapeEnv) -> dict[sympy.Symbol, sympy.Integer
     # torch renamed ShapeEnv.var_to_val -> ShapeEnv.backed_var_to_val.
     if (backed_var_to_val := getattr(shape_env, "backed_var_to_val", None)) is not None:
         return typing.cast("dict[sympy.Symbol, sympy.Integer]", backed_var_to_val)
-    return shape_env.var_to_val  # pyrefly: ignore [deprecated]
+    return typing.cast(
+        "dict[sympy.Symbol, sympy.Integer]",
+        shape_env.var_to_val,  # pyrefly: ignore [deprecated]
+    )
 
 
 class CompileEnvironment:
@@ -614,7 +617,7 @@ class CompileEnvironment:
                 return False
             expr = x._sympy_()
             if isinstance(expr, sympy.Symbol):
-                return symbol_is_type(expr, SymT.UNBACKED_INT)
+                return symbol_is_type(expr, SymT.UNBACKED_INT)  # pyrefly: ignore [bad-argument-type]
             return False
 
         # Check for existing reduction dimensions with the same size

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
     from .device_ir import GraphInfo
     from .host_function import HostFunction
     from .loop_dependency_checker import LoopDependencyChecker
+    from .pallas.outer_pipeline import PipelineContext
     from .tile_strategy import DeviceLoopOrGridState
     from .type_info import TensorType
 
@@ -240,6 +241,25 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                 out.add(name)
         return out
 
+    def _outer_pipeline_context_for_statement(self) -> PipelineContext | None:
+        """Return active outer-pipeline context for device statements only.
+
+        Keep the generic ``add_statement`` hook inert unless this is a fully
+        initialized Pallas outer-pipeline codegen. Some tests use lightweight
+        ``GenerateAST`` doubles that intentionally skip ``__init__``.
+        """
+        if not getattr(self, "on_device", False):
+            return None
+
+        device_function = getattr(self, "device_function", None)
+        config = getattr(device_function, "config", None)
+        if config is None:
+            return None
+        if config.get("pallas_loop_type", "unroll") != "outer_pipeline":
+            return None
+
+        return CompileEnvironment.current().outer_pipeline_context
+
     def add_statement(self, stmt: ast.AST | str | None) -> None:
         if stmt is None:
             return
@@ -250,13 +270,7 @@ class GenerateAST(NodeVisitor, CodegenInterface):
         # context for replay inside the pipeline body rather than the current
         # scope. The scope guards ensure the grid body holds nothing but this
         # prologue and the folded loop, so capturing everything here is sound.
-        outer_context = (
-            CompileEnvironment.current().outer_pipeline_context
-            if self.on_device
-            and self.device_function.config.get("pallas_loop_type", "unroll")
-            == "outer_pipeline"
-            else None
-        )
+        outer_context = self._outer_pipeline_context_for_statement()
         if outer_context is not None and outer_context.capturing_prologue_replay:
             outer_context.capture_prologue_statement(stmt)
         elif (

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -253,6 +253,8 @@ class GenerateAST(NodeVisitor, CodegenInterface):
         outer_context = (
             CompileEnvironment.current().outer_pipeline_context
             if self.on_device
+            and self.device_function.config.get("pallas_loop_type", "unroll")
+            == "outer_pipeline"
             else None
         )
         if outer_context is not None and outer_context.capturing_prologue_replay:

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -75,6 +75,7 @@ class GenerateAST(NodeVisitor, CodegenInterface):
 
         # Initialize our attributes
         self.host_function = func
+        CompileEnvironment.current().outer_pipeline_context = None
         self.codegen_graphs = func.device_ir.build_codegen_graphs(config)
         self.host_statements: list[ast.AST] = []
         self.module_statements: list[ast.stmt] = []
@@ -244,7 +245,34 @@ class GenerateAST(NodeVisitor, CodegenInterface):
             return
         if isinstance(stmt, str):
             stmt = statement_from_string(stmt)
-        self.statements_stack[-1].append(stmt)
+        # outer_pipeline: while capturing the grid-body prologue (everything
+        # emitted before the folded inner loop), divert statements into the
+        # context for replay inside the pipeline body rather than the current
+        # scope. The scope guards ensure the grid body holds nothing but this
+        # prologue and the folded loop, so capturing everything here is sound.
+        outer_context = (
+            CompileEnvironment.current().outer_pipeline_context
+            if self.on_device
+            else None
+        )
+        if outer_context is not None and outer_context.capturing_prologue_replay:
+            outer_context.capture_prologue_statement(stmt)
+        elif (
+            outer_context is not None
+            and outer_context.folded_block_ids
+            and not outer_context.emitting_folded_pipeline
+            and not any(
+                isinstance(loop_state, EmitPipelineLoopState)
+                for loop_state in self._active_loop_stack()
+            )
+        ):
+            raise exc.BackendUnsupported(
+                "pallas",
+                "outer_pipeline currently requires the folded hl.tile loop to "
+                "be the final statement in the grid body",
+            )
+        else:
+            self.statements_stack[-1].append(stmt)
         self._record_statement_thread_references([stmt])
         self._record_tcgen05_owned_statement(stmt)
 
@@ -879,6 +907,17 @@ class GenerateAST(NodeVisitor, CodegenInterface):
             assert node._root_id is not None
             # Loop dependency checks were already run during lowering; phase checker kept for symmetry/debug.
             self._phase_checker(node._root_id)
+            env = CompileEnvironment.current()
+            if (
+                env.backend.name == "pallas"
+                and self.device_function.config.get("pallas_loop_type", "unroll")
+                == "outer_pipeline"
+                and len(self.host_function.device_ir.root_ids) != 1
+            ):
+                raise exc.BackendUnsupported(
+                    "pallas",
+                    "outer_pipeline currently supports exactly one top-level grid",
+                )
 
             if len(self.host_function.device_ir.root_ids) == 1:
                 body = self.device_function.body

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -59,13 +59,20 @@ def _load_mask_expr(
     data-dependent bounds, constexpr sub-ranges), generates a mask term so
     that out-of-tile positions are zeroed.
 
-    Only applies to dimensions that are ds-padded (the ref is padded to a
-    multiple of block_size).  Grid/tile dimensions where BlockSpecs size the
-    ref to the actual remainder are not masked — a block-sized mask would
-    cause a shape mismatch against the smaller ref.
+    For ordinary emit_pipeline, preserve the existing load-mask behavior.
+    outer_pipeline uses the scalar-aware helper because dynamic
+    ``pl.BoundedSlice`` BlockSpecs make the HBM access legal while body
+    expressions still see the static block extent. Reductions or arbitrary lane
+    mixing across folded axes need their own masked lowering and are rejected by
+    outer_pipeline for now.
     """
     from helion._compiler.compile_environment import CompileEnvironment
     from helion._compiler.pallas.plan_tiling import TilePattern
+
+    env = CompileEnvironment.current()
+    if env.outer_pipeline_context is not None:
+        dtype_str = env.backend.dtype_str(tensor.dtype)
+        return _tile_mask_expr(state, subscript, tensor, dtype_str=dtype_str)
 
     assert state.fx_node is not None
     output_val = state.fx_node.meta.get("val")
@@ -73,7 +80,6 @@ def _load_mask_expr(
         return None
 
     indexing_patterns = _get_indexing_patterns(state, tensor)
-    env = CompileEnvironment.current()
     output_sizes = [*output_val.size()]
     mask_exprs: list[str] = []
     dtype_str: str | None = None
@@ -105,6 +111,73 @@ def _load_mask_expr(
         # TODO(dunfanlu): Do other patterns beside TilePattern require masking?
 
         out_dim += 1
+        tensor_dim += 1
+
+    if not mask_exprs:
+        return None
+    return "*".join(mask_exprs)
+
+
+def _tile_mask_expr(
+    state: CodegenState,
+    subscript: list[object],
+    tensor: torch.Tensor,
+    *,
+    dtype_str: str | None,
+    output_sizes: list[object] | None = None,
+) -> str | None:
+    """Build the boolean tile-mask expression for a Pallas access (or ``None``).
+
+    Emits a ``mask_var``-based factor for each tiled dim that needs one, skipping
+    size-1 (broadcast) dims. ``output_sizes`` overrides the inferred result
+    shape; ``dtype_str`` casts the mask so it can multiply float values.
+    """
+    from helion._compiler.pallas.plan_tiling import TilePattern
+
+    assert state.fx_node is not None
+    if output_sizes is None:
+        output_val = state.fx_node.meta.get("val")
+        if not isinstance(output_val, torch.Tensor):
+            return None
+        output_sizes = [*output_val.size()]
+
+    indexing_patterns = _get_indexing_patterns(state, tensor)
+    mask_exprs: list[str] = []
+    out_dim = 0
+    tensor_dim = 0
+    from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
+    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
+
+    for idx, pattern in zip(subscript, indexing_patterns, strict=True):
+        if idx is None:
+            out_dim += 1
+            continue
+        is_scalar = isinstance(
+            pattern, (ArbitraryIndexPattern, TileBeginWithOffsetPattern)
+        )
+
+        if isinstance(pattern, TilePattern):
+            block_id = pattern.block_id
+            # Skip masking for size-1 (broadcast) dims: a single element is
+            # always valid, and applying a block-sized mask would broadcast
+            # the dim from 1 to block_size, causing shape mismatches.
+            dim_size = tensor.shape[tensor_dim]
+            if (not isinstance(dim_size, int) or dim_size > 1) and _tile_needs_mask(
+                state, block_id, tensor, tensor_dim
+            ):
+                mask_var = state.codegen.mask_var(block_id)
+                if mask_var is not None:
+                    expand = state.tile_strategy.expand_str(output_sizes, out_dim)
+                    if dtype_str is None:
+                        expr = f"({mask_var}{expand})"
+                    else:
+                        expr = f"({mask_var}.astype({dtype_str}){expand})"
+                    mask_exprs.append(expr)
+
+        # TODO(dunfanlu): Do other patterns beside TilePattern require masking?
+
+        if not is_scalar:
+            out_dim += 1
         tensor_dim += 1
 
     if not mask_exprs:
@@ -193,10 +266,21 @@ def _tile_needs_mask(
     info = loops[-1].block_id_to_info.get(block_id)
     if info is None:
         return False
+    from helion._compiler.compile_environment import CompileEnvironment
+
+    env = CompileEnvironment.current()
     dim_size = tensor.shape[tensor_dim]
     if not info.is_end_matching(dim_size):
         return True
-    return info.begin_expr is not None and info.begin_expr != 0
+    if info.begin_expr is not None and info.begin_expr != 0:
+        return True
+    outer_context = env.outer_pipeline_context
+    if outer_context is not None and block_id in outer_context.axis_by_block_id:
+        block_value = state.device_function.resolved_block_size(block_id)
+        if not isinstance(block_value, int):
+            return True
+        return not env.block_sizes[block_id].known_multiple(block_value)
+    return False
 
 
 def _can_tile_dimension(state: CodegenState, tensor_dim: int) -> bool:
@@ -309,13 +393,56 @@ def _arbitrary_index_pattern_code(
     subscript_index: int,
     in_pipeline: bool,
 ) -> str:
+    from helion._compiler.compile_environment import CompileEnvironment
     from helion._utils import is_scalar_index
 
     if in_pipeline and is_scalar_index(idx):
         return "0"
+    block_id = CompileEnvironment.current().resolve_block_id(idx)
+    if (
+        grid_offset := _active_grid_loop_offset_code(
+            state, block_id, in_pipeline=in_pipeline
+        )
+    ) is not None:
+        return grid_offset
     if isinstance(idx, int):
         return str(idx)
     return _index_expr_from_ast(state, subscript_index)
+
+
+def _active_grid_loop_offset_code(
+    state: CodegenState,
+    block_id: int | None,
+    *,
+    in_pipeline: bool,
+    offset_str: str | None = None,
+) -> str | None:
+    # outer_pipeline: a non-pipelined tensor indexed by a folded outer-grid dim
+    # (an active DeviceGridState loop) is sliced in the body via that dim's
+    # offset var (e.g. ``offset_0``), optionally added to a constant ``offset_str``.
+    # Returns None when not applicable (in-pipeline tensors are pre-sliced).
+    if in_pipeline or block_id is None:
+        return None
+
+    from helion._compiler.compile_environment import CompileEnvironment
+
+    env = CompileEnvironment.current()
+    if (
+        env.outer_pipeline_context is None
+        and state.config.get("pallas_loop_type", "unroll") != "outer_pipeline"
+    ):
+        return None
+
+    from helion._compiler.tile_strategy import DeviceGridState
+
+    loops = state.codegen.active_device_loops.get(block_id)
+    if not loops or not isinstance(loops[-1], DeviceGridState):
+        return None
+
+    index = state.codegen.offset_var(block_id)
+    if offset_str is not None and offset_str != "0":
+        index = f"({index}) + {offset_str}"
+    return index
 
 
 def _generated_index_code(
@@ -457,6 +584,16 @@ def _tile_begin_with_offset_pattern_code(
 
     if in_pipeline and block_id in pipeline_block_ids:
         return offset_str
+
+    if (
+        grid_offset := _active_grid_loop_offset_code(
+            state,
+            block_id,
+            in_pipeline=in_pipeline,
+            offset_str=offset_str if pattern.offset != 0 else None,
+        )
+    ) is not None:
+        return grid_offset
 
     can_tile = _can_tile_dimension(state, tensor_dim)
 

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 from typing import TYPE_CHECKING
+from typing import cast
 
 import torch
 
@@ -170,7 +171,9 @@ def _tile_mask_expr(
             ):
                 mask_var = state.codegen.mask_var(block_id)
                 if mask_var is not None:
-                    expand = state.tile_strategy.expand_str(output_sizes, out_dim)
+                    expand = state.tile_strategy.expand_str(
+                        cast("list[int | torch.SymInt]", output_sizes), out_dim
+                    )
                     if dtype_str is None:
                         expr = f"({mask_var}{expand})"
                     else:

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -70,7 +70,10 @@ def _load_mask_expr(
     from helion._compiler.pallas.plan_tiling import TilePattern
 
     env = CompileEnvironment.current()
-    if env.outer_pipeline_context is not None:
+    if (
+        state.config.get("pallas_loop_type", "unroll") == "outer_pipeline"
+        and env.outer_pipeline_context is not None
+    ):
         dtype_str = env.backend.dtype_str(tensor.dtype)
         return _tile_mask_expr(state, subscript, tensor, dtype_str=dtype_str)
 
@@ -275,7 +278,11 @@ def _tile_needs_mask(
     if info.begin_expr is not None and info.begin_expr != 0:
         return True
     outer_context = env.outer_pipeline_context
-    if outer_context is not None and block_id in outer_context.axis_by_block_id:
+    if (
+        state.config.get("pallas_loop_type", "unroll") == "outer_pipeline"
+        and outer_context is not None
+        and block_id in outer_context.axis_by_block_id
+    ):
         block_value = state.device_function.resolved_block_size(block_id)
         if not isinstance(block_value, int):
             return True
@@ -428,8 +435,8 @@ def _active_grid_loop_offset_code(
 
     env = CompileEnvironment.current()
     if (
-        env.outer_pipeline_context is None
-        and state.config.get("pallas_loop_type", "unroll") != "outer_pipeline"
+        state.config.get("pallas_loop_type", "unroll") != "outer_pipeline"
+        or env.outer_pipeline_context is None
     ):
         return None
 

--- a/helion/_compiler/pallas/outer_pipeline.py
+++ b/helion/_compiler/pallas/outer_pipeline.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import ast
-from collections.abc import Callable
 import dataclasses
 from typing import TYPE_CHECKING
 from typing import Literal
 from typing import NamedTuple
+from typing import cast
 
 import torch
 
@@ -14,6 +14,8 @@ from ..ast_extension import ExtendedAST
 from ..ast_extension import expr_from_string
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from ..compile_environment import CompileEnvironment
     from ..inductor_lowering import CodegenState
 
@@ -201,9 +203,7 @@ class PipelineContext:
     @property
     def outer_offset_vars(self) -> list[str]:
         return [
-            axis.offset_var
-            for axis in self.outer_axes
-            if axis.offset_var is not None
+            axis.offset_var for axis in self.outer_axes if axis.offset_var is not None
         ]
 
     @property
@@ -488,6 +488,7 @@ class _PrologueTensorPipelineInputCollector(ast.NodeVisitor):
         outer_info = _outer_offset_dim(self.outer_context, dims)
         if outer_info is None:
             _raise_unsupported_outer_prologue_access(hbm_name)
+        assert outer_info is not None
         outer_dim, offset_name = outer_info
         existing = self.prologue_inputs.get(hbm_name)
         if existing is not None:
@@ -577,11 +578,11 @@ class _PrologueTensorPipelineInputRemapper(ast.NodeTransformer):
             return node
         outer_dim, _offset_name = outer_info
         dims[outer_dim] = ast.Constant(value=0)
-        new_slice: ast.AST
+        new_slice: ast.expr
         if len(dims) == 1:
-            new_slice = dims[0]
+            new_slice = cast("ast.expr", dims[0])
         else:
-            new_slice = ast.Tuple(elts=dims, ctx=ast.Load())
+            new_slice = ast.Tuple(elts=cast("list[ast.expr]", dims), ctx=ast.Load())
         return ast.copy_location(
             ast.Subscript(
                 value=ast.Name(id=remap.vmem_name, ctx=ast.Load()),

--- a/helion/_compiler/pallas/outer_pipeline.py
+++ b/helion/_compiler/pallas/outer_pipeline.py
@@ -610,12 +610,12 @@ def remap_prologue_tensor_pipeline_inputs(
     return body_stmts
 
 
-def static_cdiv(numer: int, denom: int) -> int:
-    """``ceil(numer / denom)`` for positive ``denom`` (>= 1); the folded
+def static_cdiv(number: int, denom: int) -> int:
+    """``ceil(number / denom)`` for positive ``denom`` (>= 1); the folded
     ``max_tiles`` count for a pipeline grid dim."""
     if denom <= 0:
         raise ValueError(f"outer_pipeline block size must be positive, got {denom}")
-    return max(1, -(-numer // denom))
+    return max(1, -(-number // denom))
 
 
 def declared_or_static_bound(

--- a/helion/_compiler/pallas/outer_pipeline.py
+++ b/helion/_compiler/pallas/outer_pipeline.py
@@ -1,0 +1,663 @@
+from __future__ import annotations
+
+import ast
+from collections.abc import Callable
+import dataclasses
+from typing import TYPE_CHECKING
+from typing import Literal
+from typing import NamedTuple
+
+import torch
+
+from ... import exc
+from ..ast_extension import ExtendedAST
+from ..ast_extension import expr_from_string
+
+if TYPE_CHECKING:
+    from ..compile_environment import CompileEnvironment
+    from ..inductor_lowering import CodegenState
+
+
+# Keep this local for now to avoid widening shared AST-helper APIs in this PR.
+def _clone_ast_value(value: object) -> object:
+    """Deep-copy an AST value while preserving Helion ``ExtendedAST`` metadata."""
+    if isinstance(value, list):
+        return [_clone_ast_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_clone_ast_value(item) for item in value)
+    if isinstance(value, ast.AST):
+        fields = {
+            field: _clone_ast_value(getattr(value, field)) for field in value._fields
+        }
+        if isinstance(value, ExtendedAST):
+            return value.copy(**fields)
+        return ast.copy_location(type(value)(**fields), value)
+    return value
+
+
+def _clone_expr(expr: ast.AST) -> ast.AST:
+    cloned = _clone_ast_value(expr)
+    assert isinstance(cloned, ast.AST)
+    return cloned
+
+
+class PrologueTensorPipelineInput(NamedTuple):
+    """A per-outer-step prologue tensor promoted to an emit_pipeline input."""
+
+    fake: torch.Tensor
+    block_spec: str
+    vmem_name: str
+    outer_dim: int
+    offset_name: str
+
+
+@dataclasses.dataclass(frozen=True)
+class PipelineExpr:
+    """AST-backed expression used by folded Pallas pipeline axes."""
+
+    expr: ast.AST
+
+    @classmethod
+    def from_string(cls, expr: str) -> PipelineExpr:
+        return cls(expr_from_string(expr))
+
+    def render_body(self) -> str:
+        return ast.unparse(self.expr)
+
+    def render_lambda(self, context: PipelineContext) -> str:
+        return context.resolve_for_lambda(self)
+
+
+@dataclasses.dataclass(frozen=True)
+class PipelineAxis:
+    """One folded dimension of a generated Pallas pipeline grid."""
+
+    block_id: int
+    kind: Literal["parallel", "ordered"]
+    begin: PipelineExpr
+    end: PipelineExpr
+    max_tiles: int | PipelineExpr
+    step: PipelineExpr
+    block_extent: str
+    lambda_param: str
+    pid_var: str | None = None
+    offset_var: str | None = None
+    index_var: str | None = None
+
+    @property
+    def dimension_semantic(self) -> str:
+        return "parallel" if self.kind == "parallel" else "arbitrary"
+
+    def max_tiles_expr(self) -> str:
+        if isinstance(self.max_tiles, int):
+            return str(self.max_tiles)
+        return self.max_tiles.render_body()
+
+    def start_expr(self) -> str:
+        return (
+            f"({self.begin.render_body()}) + "
+            f"({self.lambda_param}) * ({self.step.render_body()})"
+        )
+
+    def next_start_expr(self) -> str:
+        return f"({self.start_expr()}) + ({self.step.render_body()})"
+
+
+def _store_names(node: ast.AST) -> set[str]:
+    """Names assigned (``Store`` context) anywhere within ``node``."""
+    return {
+        child.id
+        for child in ast.walk(node)
+        if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Store)
+    }
+
+
+def _single_name_assign(stmt: ast.AST) -> tuple[str, ast.AST] | None:
+    """Return ``(name, value)`` for ``name = <expr>`` statements.
+
+    Scalar prologue assignments are replayed inside the pipeline body and also
+    inlined into BlockSpec lambdas so data-dependent folded bounds like
+    ``start = offsets[seq]`` can be expressed in the lambda's scope.
+    """
+    if (
+        isinstance(stmt, ast.Assign)
+        and len(stmt.targets) == 1
+        and isinstance(stmt.targets[0], ast.Name)
+    ):
+        return stmt.targets[0].id, stmt.value
+    return None
+
+
+@dataclasses.dataclass
+class PipelineContext:
+    """State for folding an outer grid into a Pallas emit_pipeline grid.
+
+    This context is created before grid-body codegen so the body can be emitted
+    directly in its final pipeline scope.  It is deliberately structural state,
+    not a second plan IR.
+    """
+
+    axes: list[PipelineAxis] = dataclasses.field(default_factory=list)
+    # Grid-body statements emitted before the folded loop: replayed inside the
+    # pipeline body, with their defined names (a leak-check for lambda rewrites)
+    # and single-name assigns (inlined into BlockSpec lambdas; see
+    # _outer_lambda_expr) tracked alongside.
+    prologue_replay_stmts: list[ast.AST] = dataclasses.field(default_factory=list)
+    prologue_defined_names: set[str] = dataclasses.field(default_factory=set)
+    prologue_assigns: dict[str, ast.AST] = dataclasses.field(default_factory=dict)
+    # True while the grid-body prologue is being captured (set False once the
+    # folded loop's codegen begins).
+    capturing_prologue_replay: bool = False
+    # True only while _codegen_emit_pipeline emits the generated function and
+    # emit_pipeline call into the outer scope; user statements after the folded
+    # loop should reject instead of being appended there.
+    emitting_folded_pipeline: bool = False
+    pipeline_index_var: str = "_pipeline_indices"
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.axes)
+
+    @property
+    def grid_parts(self) -> list[str]:
+        return [axis.max_tiles_expr() for axis in self.axes]
+
+    @property
+    def dimension_semantics(self) -> tuple[str, ...]:
+        return tuple(axis.dimension_semantic for axis in self.axes)
+
+    @property
+    def axis_by_block_id(self) -> dict[int, PipelineAxis]:
+        return {axis.block_id: axis for axis in self.axes}
+
+    @property
+    def ordered_axis(self) -> PipelineAxis | None:
+        ordered = [axis for axis in self.axes if axis.kind == "ordered"]
+        if not ordered:
+            return None
+        assert len(ordered) == 1
+        return ordered[0]
+
+    @property
+    def outer_axes(self) -> list[PipelineAxis]:
+        return [axis for axis in self.axes if axis.pid_var is not None]
+
+    @property
+    def folded_axes(self) -> list[PipelineAxis]:
+        return [axis for axis in self.axes if axis.pid_var is None]
+
+    @property
+    def outer_block_ids(self) -> list[int]:
+        return [axis.block_id for axis in self.outer_axes]
+
+    @property
+    def outer_grid_extents(self) -> list[str]:
+        return [axis.max_tiles_expr() for axis in self.outer_axes]
+
+    @property
+    def outer_pid_vars(self) -> list[str]:
+        return [axis.pid_var for axis in self.outer_axes if axis.pid_var is not None]
+
+    @property
+    def outer_offset_vars(self) -> list[str]:
+        return [
+            axis.offset_var
+            for axis in self.outer_axes
+            if axis.offset_var is not None
+        ]
+
+    @property
+    def outer_index_vars(self) -> list[str]:
+        return [
+            axis.index_var for axis in self.outer_axes if axis.index_var is not None
+        ]
+
+    @property
+    def folded_block_ids(self) -> list[int]:
+        return [axis.block_id for axis in self.folded_axes]
+
+    @property
+    def folded_max_tiles(self) -> list[int | PipelineExpr]:
+        return [axis.max_tiles for axis in self.folded_axes]
+
+    def add_folded_axis(self, axis: PipelineAxis) -> None:
+        if axis.pid_var is not None:
+            raise AssertionError("folded pipeline axes must not carry pid vars")
+        if axis.block_id in self.axis_by_block_id:
+            raise exc.BackendUnsupported(
+                "pallas",
+                "outer_pipeline cannot fold the same block id more than once",
+            )
+        self.axes.append(axis)
+
+    def resolve_for_lambda(self, expr: PipelineExpr | ast.AST | str) -> str:
+        """Render *expr* in BlockSpec lambda scope.
+
+        Replaces axis-local pid vars with lambda params, offset vars with the
+        precise start expression for that lambda coordinate, and recursively
+        inlines captured scalar prologue assignments so expressions like
+        ``start = offsets[seq]`` are self-contained in the BlockSpec lambda.
+        Axis index vars are intentionally not rewritten here: they can be
+        vector/lane expressions and must not silently collapse to a scalar
+        pipeline index.
+        """
+        if isinstance(expr, PipelineExpr):
+            expr_ast = _clone_expr(expr.expr)
+        elif isinstance(expr, ast.AST):
+            expr_ast = _clone_expr(expr)
+        else:
+            expr_ast = expr_from_string(expr)
+
+        replacements: dict[str, ast.AST] = {}
+        for axis in self.axes:
+            if axis.pid_var is not None:
+                replacements[axis.pid_var] = ast.Name(
+                    id=axis.lambda_param, ctx=ast.Load()
+                )
+            if axis.offset_var is not None:
+                replacements[axis.offset_var] = expr_from_string(axis.start_expr())
+
+        assigns = self.prologue_assigns
+
+        class Resolver(ast.NodeTransformer):
+            def __init__(self) -> None:
+                self.stack: set[str] = set()
+
+            def visit_Name(self, node: ast.Name) -> ast.AST:
+                if not isinstance(node.ctx, ast.Load):
+                    return node
+                if node.id in replacements:
+                    return self.visit(_clone_expr(replacements[node.id]))
+                if node.id in assigns and node.id not in self.stack:
+                    self.stack.add(node.id)
+                    try:
+                        return self.visit(_clone_expr(assigns[node.id]))
+                    finally:
+                        self.stack.remove(node.id)
+                return node
+
+        resolved = Resolver().visit(expr_ast)
+        ast.fix_missing_locations(resolved)
+        remaining_names = {
+            child.id
+            for child in ast.walk(resolved)
+            if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Load)
+        }
+        body_local_names = (
+            set(self.prologue_defined_names)
+            | set(self.outer_pid_vars)
+            | set(self.outer_offset_vars)
+            | set(self.outer_index_vars)
+        )
+        unresolved = sorted(remaining_names & body_local_names)
+        if unresolved:
+            raise exc.BackendUnsupported(
+                "pallas",
+                "outer_pipeline BlockSpec cannot reference body-local folded "
+                f"bound expression(s): {', '.join(unresolved)}",
+            )
+        return ast.unparse(resolved)
+
+    def capture_prologue_statement(self, stmt: ast.AST) -> None:
+        """Record a grid-body statement (emitted before the folded loop) for
+        replay in the pipeline body, tracking its defined names and any
+        single-name assignment for later BlockSpec-lambda inlining."""
+        assignment = _single_name_assign(stmt)
+        if assignment is None:
+            raise exc.BackendUnsupported(
+                "pallas",
+                "outer_pipeline prologue capture only supports simple single-name "
+                "assignments before the folded hl.tile loop",
+            )
+        name, value = assignment
+        self.prologue_replay_stmts.append(stmt)
+        self.prologue_defined_names.update(_store_names(stmt))
+        self.prologue_assigns[name] = value
+
+
+OuterPipelineContext = PipelineContext
+
+
+def _slice_elements(slice_node: ast.AST) -> list[ast.AST]:
+    """The per-dim index nodes of a subscript (unwraps a tuple subscript)."""
+    if isinstance(slice_node, ast.Tuple):
+        return list(slice_node.elts)
+    return [slice_node]
+
+
+def _is_full_slice(node: ast.AST) -> bool:
+    """True if ``node`` is a bare ``[:]`` slice (no lower/upper/step)."""
+    return (
+        isinstance(node, ast.Slice)
+        and node.lower is None
+        and node.upper is None
+        and node.step is None
+    )
+
+
+def _normalize_prologue_tensor_dims(
+    slice_node: ast.AST, rank: int
+) -> list[ast.AST] | None:
+    """Pad a subscript's index list with trailing full slices up to ``rank``."""
+    dims = _slice_elements(slice_node)
+    if len(dims) > rank:
+        return None
+    return [
+        *dims,
+        *[
+            ast.Slice(lower=None, upper=None, step=None)
+            for _ in range(rank - len(dims))
+        ],
+    ]
+
+
+def _dim_uses_any_name(dim: ast.AST, names: set[str]) -> bool:
+    return any(
+        isinstance(node, ast.Name) and node.id in names for node in ast.walk(dim)
+    )
+
+
+def _has_outer_axis_dim(
+    outer_context: OuterPipelineContext,
+    dims: list[ast.AST] | None,
+) -> bool:
+    """True if any dim uses a folded outer-grid offset or tile-index var."""
+    if dims is None:
+        return False
+    axis_names = set(outer_context.outer_offset_vars) | set(
+        outer_context.outer_index_vars
+    )
+    return any(_dim_uses_any_name(dim, axis_names) for dim in dims)
+
+
+def _has_outer_index_dim(
+    outer_context: OuterPipelineContext,
+    dims: list[ast.AST] | None,
+) -> bool:
+    """True if any dim uses a folded outer-grid tile/vector index var."""
+    if dims is None:
+        return False
+    index_names = set(outer_context.outer_index_vars)
+    return any(_dim_uses_any_name(dim, index_names) for dim in dims)
+
+
+def _raise_unsupported_outer_prologue_access(hbm_name: str) -> None:
+    raise exc.BackendUnsupported(
+        "pallas",
+        "unsupported outer_pipeline prologue tensor access to "
+        f"{hbm_name}; only scalar tensor[outer_offset, :, ...] with full "
+        "non-outer dimensions can be promoted to an emit_pipeline input. "
+        "Tile-vector outer indices are not supported in prologue tensor accesses.",
+    )
+
+
+def _outer_offset_dim(
+    outer_context: OuterPipelineContext,
+    dims: list[ast.AST],
+) -> tuple[int, str] | None:
+    """Detect ``tensor[outer_offset, :, ...]`` in captured prologue reads."""
+    result: tuple[int, str] | None = None
+    for dim, idx in enumerate(dims):
+        if isinstance(idx, ast.Name) and idx.id in outer_context.outer_offset_vars:
+            if result is not None:
+                return None
+            result = (dim, idx.id)
+        elif not _is_full_slice(idx):
+            return None
+    return result
+
+
+def _make_outer_prologue_block_spec(
+    fake: torch.Tensor,
+    outer_dim: int,
+    offset_name: str,
+    *,
+    outer_lambda_params: list[str],
+    outer_lambda_param_by_block: dict[int, str],
+    inner_lambda_params: list[str],
+    outer_lambda_expr: Callable[[str, dict[int, str]], str],
+    buffered_block_spec: Callable[[list[str], list[str], list[str]], str],
+) -> str:
+    """BlockSpec for a per-outer-step prologue operand such as ``k[seq]``."""
+    lambda_params = [*outer_lambda_params, *inner_lambda_params]
+    outer_index_expr = outer_lambda_expr(offset_name, outer_lambda_param_by_block)
+
+    block_shape_parts: list[str] = []
+    lambda_parts: list[str] = []
+    for dim, size in enumerate(fake.shape):
+        if dim == outer_dim:
+            block_shape_parts.append("1")
+            lambda_parts.append(outer_index_expr)
+        else:
+            if not isinstance(size, int):
+                raise exc.BackendUnsupported(
+                    "pallas",
+                    "outer_pipeline prologue tensor pipelining currently "
+                    "requires static non-outer tensor dimensions",
+                )
+            block_shape_parts.append(str(int(size)))
+            lambda_parts.append("0")
+    return buffered_block_spec(block_shape_parts, lambda_params, lambda_parts)
+
+
+class _PrologueTensorPipelineInputCollector(ast.NodeVisitor):
+    """Find ``tensor[outer_offset, :, ...]`` prologue reads to pipeline."""
+
+    def __init__(
+        self,
+        *,
+        state: CodegenState,
+        outer_context: OuterPipelineContext,
+        tensor_by_name: dict[str, torch.Tensor],
+        prologue_inputs: dict[str, PrologueTensorPipelineInput],
+        outer_lambda_params: list[str],
+        outer_lambda_param_by_block: dict[int, str],
+        inner_lambda_params: list[str],
+        outer_lambda_expr: Callable[[str, dict[int, str]], str],
+        buffered_block_spec: Callable[[list[str], list[str], list[str]], str],
+    ) -> None:
+        self.state = state
+        self.outer_context = outer_context
+        self.tensor_by_name = tensor_by_name
+        self.prologue_inputs = prologue_inputs
+        self.outer_lambda_params = outer_lambda_params
+        self.outer_lambda_param_by_block = outer_lambda_param_by_block
+        self.inner_lambda_params = inner_lambda_params
+        self.outer_lambda_expr = outer_lambda_expr
+        self.buffered_block_spec = buffered_block_spec
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:
+        self.generic_visit(node)
+        if not isinstance(node.value, ast.Name):
+            return
+        fake = self.tensor_by_name.get(node.value.id)
+        if fake is None:
+            return
+        hbm_name = node.value.id
+        dims = _normalize_prologue_tensor_dims(node.slice, len(fake.shape))
+        if dims is None:
+            raw_dims = _slice_elements(node.slice)
+            if _has_outer_axis_dim(self.outer_context, raw_dims):
+                _raise_unsupported_outer_prologue_access(hbm_name)
+            return
+        all_scalar_dims = all(not _is_full_slice(dim) for dim in dims)
+        if all_scalar_dims:
+            if _has_outer_index_dim(self.outer_context, dims):
+                _raise_unsupported_outer_prologue_access(hbm_name)
+            return
+        outer_info = _outer_offset_dim(self.outer_context, dims)
+        if outer_info is None:
+            _raise_unsupported_outer_prologue_access(hbm_name)
+        outer_dim, offset_name = outer_info
+        existing = self.prologue_inputs.get(hbm_name)
+        if existing is not None:
+            if existing.outer_dim != outer_dim or existing.offset_name != offset_name:
+                raise exc.BackendUnsupported(
+                    "pallas",
+                    "outer_pipeline cannot pipeline conflicting "
+                    f"outer-prologue slices of {hbm_name}",
+                )
+            return
+        vmem_name = self.state.device_function.new_var(
+            hbm_name.replace("_hbm", "") + "_vmem"
+        )
+        self.prologue_inputs[hbm_name] = PrologueTensorPipelineInput(
+            fake,
+            _make_outer_prologue_block_spec(
+                fake,
+                outer_dim,
+                offset_name,
+                outer_lambda_params=self.outer_lambda_params,
+                outer_lambda_param_by_block=self.outer_lambda_param_by_block,
+                inner_lambda_params=self.inner_lambda_params,
+                outer_lambda_expr=self.outer_lambda_expr,
+                buffered_block_spec=self.buffered_block_spec,
+            ),
+            vmem_name,
+            outer_dim,
+            offset_name,
+        )
+
+
+def collect_prologue_tensor_pipeline_inputs(
+    *,
+    state: CodegenState,
+    outer_context: OuterPipelineContext,
+    outer_lambda_params: list[str],
+    outer_lambda_param_by_block: dict[int, str],
+    inner_lambda_params: list[str],
+    outer_lambda_expr: Callable[[str, dict[int, str]], str],
+    buffered_block_spec: Callable[[list[str], list[str], list[str]], str],
+) -> dict[str, PrologueTensorPipelineInput]:
+    """Collect prologue tensor reads that should become emit_pipeline inputs."""
+    tensor_by_name = {
+        arg.name: fake for fake, arg in state.device_function._tensor_args.items()
+    }
+    prologue_inputs: dict[str, PrologueTensorPipelineInput] = {}
+    collector = _PrologueTensorPipelineInputCollector(
+        state=state,
+        outer_context=outer_context,
+        tensor_by_name=tensor_by_name,
+        prologue_inputs=prologue_inputs,
+        outer_lambda_params=outer_lambda_params,
+        outer_lambda_param_by_block=outer_lambda_param_by_block,
+        inner_lambda_params=inner_lambda_params,
+        outer_lambda_expr=outer_lambda_expr,
+        buffered_block_spec=buffered_block_spec,
+    )
+    for stmt in outer_context.prologue_replay_stmts:
+        collector.visit(stmt)
+    return prologue_inputs
+
+
+class _PrologueTensorPipelineInputRemapper(ast.NodeTransformer):
+    """Rewrite registered prologue tensor reads to their VMEM refs."""
+
+    def __init__(
+        self,
+        outer_context: OuterPipelineContext,
+        prologue_inputs: dict[str, PrologueTensorPipelineInput],
+    ) -> None:
+        self.outer_context = outer_context
+        self.prologue_inputs = prologue_inputs
+
+    def visit_Subscript(self, node: ast.Subscript) -> ast.AST:
+        self.generic_visit(node)
+        if not isinstance(node.value, ast.Name):
+            return node
+        remap = self.prologue_inputs.get(node.value.id)
+        if remap is None:
+            return node
+        fake = remap.fake
+        dims = _normalize_prologue_tensor_dims(node.slice, len(fake.shape))
+        if dims is None:
+            return node
+        outer_info = _outer_offset_dim(self.outer_context, dims)
+        if outer_info is None:
+            return node
+        outer_dim, _offset_name = outer_info
+        dims[outer_dim] = ast.Constant(value=0)
+        new_slice: ast.AST
+        if len(dims) == 1:
+            new_slice = dims[0]
+        else:
+            new_slice = ast.Tuple(elts=dims, ctx=ast.Load())
+        return ast.copy_location(
+            ast.Subscript(
+                value=ast.Name(id=remap.vmem_name, ctx=ast.Load()),
+                slice=new_slice,
+                ctx=node.ctx,
+            ),
+            node,
+        )
+
+
+def remap_prologue_tensor_pipeline_inputs(
+    outer_context: OuterPipelineContext,
+    prologue_inputs: dict[str, PrologueTensorPipelineInput],
+) -> list[ast.AST]:
+    """Replay captured prologue statements, remapping pipelined tensor reads."""
+    remapper = _PrologueTensorPipelineInputRemapper(outer_context, prologue_inputs)
+    body_stmts: list[ast.AST] = []
+    for stmt in outer_context.prologue_replay_stmts:
+        stmt_copy = _clone_ast_value(stmt)
+        assert isinstance(stmt_copy, ast.AST)
+        remapped = remapper.visit(stmt_copy)
+        assert isinstance(remapped, ast.AST)
+        ast.fix_missing_locations(remapped)
+        body_stmts.append(remapped)
+    return body_stmts
+
+
+def static_cdiv(numer: int, denom: int) -> int:
+    """``ceil(numer / denom)`` for positive ``denom`` (>= 1); the folded
+    ``max_tiles`` count for a pipeline grid dim."""
+    if denom <= 0:
+        raise ValueError(f"outer_pipeline block size must be positive, got {denom}")
+    return max(1, -(-numer // denom))
+
+
+def declared_or_static_bound(
+    env: CompileEnvironment,
+    block_id: int,
+) -> int | None:
+    """Return the static upper bound for a folded tile, if one exists."""
+    info = env.block_sizes[block_id]
+    if isinstance(info.size, int):
+        return info.size
+    if isinstance(info.max_extent, int):
+        return info.max_extent
+    if isinstance(info.size, torch.SymInt):
+        if not env.settings.static_shapes:
+            raise exc.BackendUnsupported(
+                "pallas",
+                "outer_pipeline requires a static folded tile extent when "
+                "static_shapes=False; pass a specialized integer max_extent "
+                "or use pallas_loop_type='fori_loop'.",
+            )
+        return int(env.size_hint(info.size))
+    if isinstance(info.max_extent, torch.SymInt):
+        if not env.settings.static_shapes:
+            raise exc.BackendUnsupported(
+                "pallas",
+                "outer_pipeline requires a static folded max_extent when "
+                "static_shapes=False; pass a specialized integer "
+                "max_extent or use pallas_loop_type='fori_loop'.",
+            )
+        return int(env.size_hint(info.max_extent))
+    return None
+
+
+def max_tiles_for_block(env: CompileEnvironment, block_id: int, block_size: int) -> int:
+    """Static pipeline-grid extent for a folded tile: ``cdiv(bound, block)``,
+    where ``bound`` is the loop's static extent or declared ``max_extent``. A
+    data-dependent extent with neither is rejected (no silent tile-dropping)."""
+    bound = declared_or_static_bound(env, block_id)
+    if bound is None:
+        from ... import exc
+
+        raise exc.InvalidConfig(
+            "outer_pipeline over a data-dependent hl.tile(begin, end) requires "
+            "hl.tile(..., max_extent=<static bound>)."
+        )
+    return static_cdiv(bound, block_size)

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -542,6 +542,16 @@ class XYZProgramIDs(ProgramIDs):
         )
 
 
+class EmptyGridProgramIDs(ProgramIDs):
+    """No outer launch grid; work is scheduled inside a nested Pallas primitive."""
+
+    def codegen(self, state: CodegenState) -> None:
+        return None
+
+    def codegen_grid(self) -> ast.AST:
+        return expr_from_string("()")
+
+
 class FlatProgramIDs(ProgramIDs):
     """Only use the x grid and compute other dimensions"""
 

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -28,8 +28,8 @@ from .compile_environment import _has_unbacked
 from .compile_environment import _to_sympy
 from .device_function import DeviceFunction
 from .host_function import HostFunction
-from .program_id import FlatProgramIDs
 from .program_id import EmptyGridProgramIDs
+from .program_id import FlatProgramIDs
 from .program_id import ForEachProgramID
 from .program_id import L2GroupingProgramIDs
 from .program_id import PersistentBlockedProgramIDs
@@ -2595,7 +2595,10 @@ class FlattenedTileStrategy(BlockSizeTileStrategy):
                 f"({self._expr_str(step)}) - 1) // ({self._expr_str(step)})"
             )
         if diff_expr is not None:
-            return sympy.ceiling(sympy.Mul(diff_expr, sympy.Pow(step_expr, -1)))
+            return cast(
+                "sympy.Expr",
+                sympy.ceiling(sympy.Mul(diff_expr, sympy.Pow(step_expr, -1))),
+            )
         return (
             f"((({self._expr_str(end)}) - ({self._expr_str(begin)})) + "
             f"({self._expr_str(step)}) - 1) // ({self._expr_str(step)})"
@@ -3184,6 +3187,16 @@ class _BaseNDTileStrategy(BlockSizeTileStrategy):
             return [None] * len(self.block_ids)
         return self._normalize_loop_steps(state.proxy_args[2], len(self.block_ids))
 
+    def _setup_mask(
+        self,
+        state: CodegenState,
+        block_idx: int,
+        block_size: SymIntLike,
+        index_var: str,
+        end: object,
+    ) -> ast.stmt | None:
+        raise NotImplementedError
+
     def _range_numel_expr(
         self, begin: object, end: object, step: object | None
     ) -> sympy.Expr | str:
@@ -3212,7 +3225,10 @@ class _BaseNDTileStrategy(BlockSizeTileStrategy):
                 f"({self._expr_str(step)}) - 1) // ({self._expr_str(step)})"
             )
         if diff_expr is not None:
-            return sympy.ceiling(sympy.Mul(diff_expr, sympy.Pow(step_expr, -1)))
+            return cast(
+                "sympy.Expr",
+                sympy.ceiling(sympy.Mul(diff_expr, sympy.Pow(step_expr, -1))),
+            )
         return (
             f"((({self._expr_str(end)}) - ({self._expr_str(begin)})) + "
             f"({self._expr_str(step)}) - 1) // ({self._expr_str(step)})"
@@ -3369,7 +3385,9 @@ class _BaseNDTileStrategy(BlockSizeTileStrategy):
 
         has_tensor_ends = any(isinstance(e, torch.Tensor) for e in ends)
         block_id_to_info = (
-            self._create_block_id_info_dict(state, ends_override=ends)
+            self._create_block_id_info_dict(
+                state, ends_override=cast("list[object]", ends)
+            )
             if has_tensor_ends
             else self._create_block_id_info_dict(state)
         )

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -29,6 +29,7 @@ from .compile_environment import _to_sympy
 from .device_function import DeviceFunction
 from .host_function import HostFunction
 from .program_id import FlatProgramIDs
+from .program_id import EmptyGridProgramIDs
 from .program_id import ForEachProgramID
 from .program_id import L2GroupingProgramIDs
 from .program_id import PersistentBlockedProgramIDs
@@ -3222,9 +3223,171 @@ class _BaseNDTileStrategy(BlockSizeTileStrategy):
             return self.fn.sympy_expr(_to_sympy(value))
         return ast.unparse(self._to_ast(value))
 
+    def _codegen_outer_pipeline_grid(self, state: CodegenState) -> DeviceGridState:
+        """Record a Pallas root grid for folding into a later emit_pipeline."""
+        from .pallas.outer_pipeline import PipelineAxis
+        from .pallas.outer_pipeline import PipelineContext
+        from .pallas.outer_pipeline import PipelineExpr
+
+        block_ids = self.block_ids
+        env = CompileEnvironment.current()
+        if env.outer_pipeline_context is not None:
+            raise exc.BackendUnsupported(
+                "pallas",
+                "outer_pipeline currently supports exactly one top-level grid",
+            )
+
+        block_sizes = self.block_size
+        assert len(block_sizes) == len(block_ids)
+        pids = self.select_pid_strategy()
+        if isinstance(pids, FlatProgramIDs) and len(block_ids) >= 2:
+            pids = XYZProgramIDs()
+        if isinstance(state.device_function.pid, ForEachProgramID):
+            raise exc.BackendUnsupported(
+                "pallas",
+                "outer_pipeline currently supports exactly one top-level grid",
+            )
+
+        assert state.ast_args is None
+        assert len(state.proxy_args) == 3
+        if state.proxy_args[1] is None:
+            begins: list[object] = [0] * len(block_ids)
+            ends_arg = state.proxy_args[0]
+        else:
+            begins_arg = state.proxy_args[0]
+            ends_arg = state.proxy_args[1]
+            begins = (
+                list(begins_arg)
+                if isinstance(begins_arg, (list, tuple))
+                else [begins_arg]
+            )
+            assert len(begins) == len(block_ids)
+        ends = list(ends_arg) if isinstance(ends_arg, (list, tuple)) else [ends_arg]
+        assert len(ends) == len(block_ids)
+        steps = self._root_grid_steps(state)
+
+        tracker = ThreadAxisTracker()
+        thread_axis_offset = self._thread_axis_offset(state)
+        thread_axis_map = self._thread_axis_map()
+        prologue: list[ast.AST] = []
+        index_vars_by_block: dict[int, str] = {}
+        offset_vars_by_block: dict[int, str] = {}
+        prologue_names: set[str] = set()
+        pipeline_axes: list[PipelineAxis] = []
+
+        for i, (block_idx, block_size, begin, end, step) in enumerate(
+            reversed(
+                self._reorder(
+                    [*zip(block_ids, block_sizes, begins, ends, steps, strict=True)]
+                )
+            )
+        ):
+            numel = self._range_numel_expr(begin, end, step)
+            dtype = env.index_type()
+            offset_var = self.offset_var(block_idx)
+            index_var = self.index_var(block_idx)
+            offset_vars_by_block[block_idx] = offset_var
+            index_vars_by_block[block_idx] = index_var
+            pid_var = state.device_function.new_var(f"pid_{i}", dce=True)
+            prologue_names.update({pid_var, offset_var, index_var})
+            begin_expr = self._expr_str(begin)
+
+            if step not in (None, 1):
+                step_expr = self._expr_str(step)
+                block_size_var = "1"
+                axis_step_expr = step_expr
+                offset_expr = f"({begin_expr}) + ({pid_var}) * ({step_expr})"
+            elif block_size != 1:
+                block_size_var = self.block_size_var(block_idx)
+                assert block_size_var is not None
+                self._setup_block_size_constexpr(state, block_size_var, block_size)
+                axis_step_expr = block_size_var
+                offset_expr = f"({begin_expr}) + ({pid_var}) * ({block_size_var})"
+            else:
+                block_size_var = "1"
+                axis_step_expr = "1"
+                offset_expr = f"({begin_expr}) + ({pid_var})"
+
+            axis = thread_axis_offset + thread_axis_map[block_idx]
+            uses_thread_axis = step in (
+                None,
+                1,
+            ) and self._uses_thread_axis_for_block(block_idx, block_size)
+            bs = block_size_var if uses_thread_axis else "1"
+            idx_expr = env.backend.grid_index_expr(offset_var, bs, dtype, axis=axis)
+            if uses_thread_axis and isinstance(block_size, int):
+                tracker.record(block_idx, axis, block_size)
+            prologue.extend(
+                [
+                    statement_from_string(
+                        f"{pid_var} = _pipeline_indices[{len(pids.pid_info)}]"
+                    ),
+                    statement_from_string(f"{offset_var} = {offset_expr}"),
+                    statement_from_string(f"{index_var} = {idx_expr}"),
+                ]
+            )
+            mask_statement = self._setup_mask(
+                state, block_idx, block_size, index_var, end
+            )
+            if mask_statement is not None:
+                prologue.append(mask_statement)
+            pid_info = PIDInfo(pid_var, block_size_var, numel, block_idx)
+            lambda_param = f"_o{len(pids.pid_info)}"
+            pipeline_axes.append(
+                PipelineAxis(
+                    block_id=block_idx,
+                    kind="parallel",
+                    begin=PipelineExpr.from_string(begin_expr),
+                    end=PipelineExpr.from_string(self._expr_str(end)),
+                    max_tiles=PipelineExpr.from_string(
+                        pid_info.num_pids_expr(is_device=False)
+                    ),
+                    step=PipelineExpr.from_string(axis_step_expr),
+                    block_extent=block_size_var,
+                    lambda_param=lambda_param,
+                    pid_var=pid_var,
+                    offset_var=offset_var,
+                    index_var=index_var,
+                )
+            )
+            pids.append(pid_info)
+
+        env.outer_pipeline_context = PipelineContext(
+            axes=pipeline_axes,
+            prologue_replay_stmts=prologue,
+            prologue_defined_names=prologue_names,
+            prologue_assigns={
+                stmt.targets[0].id: stmt.value
+                for stmt in prologue
+                if isinstance(stmt, ast.Assign)
+                and len(stmt.targets) == 1
+                and isinstance(stmt.targets[0], ast.Name)
+            },
+            capturing_prologue_replay=True,
+        )
+        state.device_function.set_pid(EmptyGridProgramIDs())
+
+        has_tensor_ends = any(isinstance(e, torch.Tensor) for e in ends)
+        block_id_to_info = (
+            self._create_block_id_info_dict(state, ends_override=ends)
+            if has_tensor_ends
+            else self._create_block_id_info_dict(state)
+        )
+        return DeviceGridState(
+            self,
+            block_id_to_info=block_id_to_info,
+            thread_axis_sizes=tracker.sizes,
+            block_thread_axes=tracker.block_axes,
+        )
+
     def codegen_grid(self, state: CodegenState) -> DeviceGridState:
         block_ids = self.block_ids
         env = CompileEnvironment.current()
+        if (
+            env.backend.name == "pallas"
+            and state.config.get("pallas_loop_type", "unroll") == "outer_pipeline"
+        ):
+            return self._codegen_outer_pipeline_grid(state)
         block_sizes = self.block_size
         assert len(block_sizes) == len(block_ids)
         pids = self.select_pid_strategy()

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -221,7 +221,8 @@ VALID_KEYS: frozenset[str] = frozenset(
         *_BACKEND_STRATEGY_CONFIG_KEYS,
     ]
 )
-VALID_PALLAS_LOOP_TYPES = ("emit_pipeline", "unroll", "fori_loop")
+AUTOTUNED_PALLAS_LOOP_TYPES = ("emit_pipeline", "unroll", "fori_loop")
+VALID_PALLAS_LOOP_TYPES = (*AUTOTUNED_PALLAS_LOOP_TYPES, "outer_pipeline")
 VALID_PID_TYPES = (
     "flat",
     "xyz",
@@ -1074,7 +1075,7 @@ class ConfigSpec:
                 # "emit_pipeline" fails on unaligned dims.
                 config.setdefault("pallas_loop_type", "fori_loop")
             else:
-                config.setdefault("pallas_loop_type", VALID_PALLAS_LOOP_TYPES[0])
+                config.setdefault("pallas_loop_type", AUTOTUNED_PALLAS_LOOP_TYPES[0])
 
         if self.supports_config_key("pid_type"):
             if "pid_type" in config:
@@ -1487,7 +1488,7 @@ class ConfigSpec:
         else:
             fields.update(self.backend_tunable_fragments)
         if self.has_pallas_inner_loops:
-            choices = VALID_PALLAS_LOOP_TYPES
+            choices = AUTOTUNED_PALLAS_LOOP_TYPES
             if self.has_symbolic_or_data_dependent_bounds:
                 # Exclude "unroll" (uses Python range(), can't handle traced
                 # bounds) and put "fori_loop" first: it handles both DMA-aligned

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -1544,7 +1544,9 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     if outer_context is None:
         has_loop_state = bool(args)
     else:
-        has_loop_state = bool(_loop_carried_indices(state, len(args))) if args else False
+        has_loop_state = (
+            bool(_loop_carried_indices(state, len(args))) if args else False
+        )
     if outer_context is not None and has_loop_state:
         raise BackendUnsupported(
             "pallas",
@@ -1553,13 +1555,12 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         )
 
     folded_max_tiles: list[int] = []
+    grid_parts: list[str] = []
     if outer_context is None:
         grid_parts, block_size_vars = _compute_grid_and_block_sizes(
             state, block_ids, env
         )
     else:
-        from .._compiler.pallas.outer_pipeline import PipelineAxis
-        from .._compiler.pallas.outer_pipeline import PipelineExpr
         from .._compiler.pallas.outer_pipeline import max_tiles_for_block
 
         block_size_vars = []
@@ -1588,6 +1589,9 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     # Loop end expressions (used to clamp store extents for data-dependent begins).
     end_exprs = [_get_loop_begin_and_end(state, i)[1] for i in range(len(block_ids))]
     if outer_context is not None:
+        from .._compiler.pallas.outer_pipeline import PipelineAxis
+        from .._compiler.pallas.outer_pipeline import PipelineExpr
+
         inner_lambda_params_for_axes = [
             f"_j{i}" if len(block_ids) > 1 else "_j" for i in range(len(block_ids))
         ]
@@ -1678,9 +1682,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
             f"pipeline_mode=pl.Buffered(buffer_count=2))"
         )
 
-    def _outer_lambda_expr(
-        expr: str, outer_lambda_params: dict[int, str]
-    ) -> str:
+    def _outer_lambda_expr(expr: str, outer_lambda_params: dict[int, str]) -> str:
         """Rewrite a body-local bound expr for use in a BlockSpec index_map lambda.
 
         Replaces outer pid vars with the lambda's pipeline-index params and
@@ -1730,6 +1732,15 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                     return block_value
             return None
 
+        def _static_int_axis_value(value: object) -> int | None:
+            if isinstance(value, int):
+                return value
+            if hasattr(value, "render_body"):
+                value = value.render_body()
+            if isinstance(value, str):
+                return _static_int_expr_value(value)
+            return None
+
         def _append_axis_dim(axis: object, dim_idx: int, dim_size: object) -> None:
             assert outer_context is not None
             from .._compiler.pallas.outer_pipeline import PipelineAxis
@@ -1740,8 +1751,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
             lambda_step_expr = axis.step.render_lambda(outer_context)
             lambda_end_expr = axis.end.render_lambda(outer_context)
             raw_start_expr = (
-                f"({lambda_begin_expr}) + ({axis.lambda_param}) "
-                f"* ({lambda_step_expr})"
+                f"({lambda_begin_expr}) + ({axis.lambda_param}) * ({lambda_step_expr})"
             )
             begin_is_zero = lambda_begin_expr == "0"
             exact_block_index = begin_is_zero and lambda_step_expr == block_extent
@@ -1752,11 +1762,46 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                 and int(lambda_end_expr) == dim_size
             )
             block_extent_int = _static_int_expr_value(block_extent, axis.block_id)
+            begin_int = _static_int_expr_value(lambda_begin_expr)
+            end_int = _static_int_expr_value(lambda_end_expr)
+            step_int = _static_int_expr_value(lambda_step_expr, axis.block_id)
+            max_tiles_int = _static_int_axis_value(axis.max_tiles)
+            static_in_bounds = False
+            if (
+                begin_int is not None
+                and end_int is not None
+                and step_int is not None
+                and block_extent_int is not None
+                and max_tiles_int is not None
+                and max_tiles_int > 0
+                and isinstance(dim_size, int)
+            ):
+                last_end = begin_int + (max_tiles_int - 1) * step_int + block_extent_int
+                static_in_bounds = last_end <= end_int and last_end <= dim_size
             full_static_blocks = (
                 covers_full_dim
                 and block_extent_int is not None
                 and dim_size % block_extent_int == 0
             )
+            if static_in_bounds:
+                if exact_block_index:
+                    block_shape_parts.append(block_extent)
+                    lambda_parts.append(axis.lambda_param)
+                    return
+                if block_extent_int == 1:
+                    block_shape_parts.append(block_extent)
+                    lambda_parts.append(raw_start_expr)
+                    return
+                if dim_idx == len(shape) - 1:
+                    raise BackendUnsupported(
+                        "pallas",
+                        "outer_pipeline dynamic BoundedSlice access on the "
+                        "innermost tensor dimension is not supported; tile a "
+                        "non-innermost dimension or use emit_pipeline.",
+                    )
+                block_shape_parts.append(f"pl.BoundedSlice({block_extent})")
+                lambda_parts.append(f"pl.ds({raw_start_expr}, {block_extent})")
+                return
             needs_dynamic_ds = not full_static_blocks
             if needs_dynamic_ds:
                 if dim_idx == len(shape) - 1:
@@ -1957,8 +2002,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                 bid is not None
                 and bid not in block_ids
                 and not (
-                    outer_context is not None
-                    and bid in outer_context.outer_block_ids
+                    outer_context is not None and bid in outer_context.outer_block_ids
                 )
                 and bid not in _bid_to_pid_var
                 and state.codegen.active_device_loops.get(bid)
@@ -2107,14 +2151,18 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         body_stmts,
     )
     if outer_context is None:
-        pipeline_mask_offset_expr = (
-            lambda i, bs: f"_pipeline_indices[{i}] * {bs} + jnp.arange({bs})"
-        )
+
+        def pipeline_mask_offset_expr(i: int, bs: str) -> str:
+            return f"_pipeline_indices[{i}] * {bs} + jnp.arange({bs})"
+
     else:
-        pipeline_mask_offset_expr = lambda i, bs: (
-            f"_pipeline_indices[{outer_rank + i}] * ({iter_step_exprs[i]}) "
-            f"+ jnp.arange({bs})"
-        )
+
+        def pipeline_mask_offset_expr(i: int, bs: str) -> str:
+            return (
+                f"_pipeline_indices[{outer_rank + i}] * ({iter_step_exprs[i]}) "
+                f"+ jnp.arange({bs})"
+            )
+
     # Set up mask variables for inner-loop block_ids (non-divisible bounds).
     _setup_inner_loop_masks(
         state,
@@ -2238,9 +2286,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         spec_parts.append(f"out_specs=[{out_specs_str}]")
     spec_parts.append("_explicit_indices=True")
     if outer_context is not None:
-        spec_parts.append(
-            f"dimension_semantics={outer_context.dimension_semantics!r}"
-        )
+        spec_parts.append(f"dimension_semantics={outer_context.dimension_semantics!r}")
     specs_str = ", ".join(spec_parts)
 
     all_pipeline_args = pipeline_in_args + pipeline_out_args

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -243,6 +243,8 @@ def _(state: CodegenState) -> object:
         return _codegen_emit_pipeline(state)
     if pallas_loop_type == "fori_loop":
         return _codegen_fori_loop(state)
+    if pallas_loop_type == "outer_pipeline":
+        return _codegen_emit_pipeline(state)
     # unroll: fall through to common codegen path
     # pyrefly: ignore[bad-return]
     return state.get_graph(state.proxy_arg(0)).codegen(state)
@@ -258,6 +260,9 @@ def _(state: CodegenState) -> None:
         return None
     if pallas_loop_type == "fori_loop":
         _codegen_fori_loop(state)
+        return None
+    if pallas_loop_type == "outer_pipeline":
+        _codegen_emit_pipeline(state)
         return None
     # pyrefly: ignore[bad-return]
     return state.get_graph(state.proxy_arg(0)).codegen(state)
@@ -335,6 +340,51 @@ def _get_dim_block_ids(
     return dim_to_bid
 
 
+def _validate_outer_pipeline_folded_body(
+    graph_info: object,
+    block_ids: list[int],
+    env: CompileEnvironment,
+    loaded_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
+    stored_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
+) -> None:
+    """First-PR legality checks for folding an inner tile into emit_pipeline."""
+    from .atomic_ops import ATOMIC_OPS
+    from .memory_ops import store as _store_op
+
+    folded_ids = set(block_ids)
+    for node in graph_info.graph.nodes:  # type: ignore[union-attr]
+        if node.op != "call_function":
+            continue
+        if node.target in ATOMIC_OPS:
+            raise BackendUnsupported(
+                "pallas",
+                "outer_pipeline does not support atomics in the folded hl.tile body",
+            )
+        if _aten_op_name(node.target) in _FOLDED_AXIS_REDUCTION_OPS:
+            raise BackendUnsupported(
+                "pallas",
+                "outer_pipeline does not support reductions in the folded "
+                "hl.tile body yet; keep the reduction outside the folded loop "
+                "or use fori_loop",
+            )
+        if node.target is not _store_op:
+            continue
+        sub_meta = _extract_subscript_vals(node.args[1])
+        store_block_ids = set(_get_dim_block_ids(sub_meta, env).values())
+        if not (store_block_ids & folded_ids):
+            raise BackendUnsupported(
+                "pallas",
+                "outer_pipeline folded-body stores must reference the folded "
+                "hl.tile index",
+            )
+
+    if set(loaded_tensors) & set(stored_tensors):
+        raise BackendUnsupported(
+            "pallas",
+            "outer_pipeline does not support folded-body read-modify-write stores",
+        )
+
+
 def _find_strategy(
     state: CodegenState,
     block_ids: list[int],
@@ -390,6 +440,30 @@ def _is_static_int(expr: str) -> bool:
     except (TypeError, ValueError):
         return False
     return True
+
+
+def _aten_op_name(target: object) -> str | None:
+    target_str = str(target)
+    if not target_str.startswith("aten."):
+        return None
+    parts = target_str.split(".")
+    return parts[1] if len(parts) > 1 else None
+
+
+_FOLDED_AXIS_REDUCTION_OPS = {
+    "amax",
+    "amin",
+    "argmax",
+    "argmin",
+    "logsumexp",
+    "max",
+    "mean",
+    "min",
+    "nanmean",
+    "nansum",
+    "prod",
+    "sum",
+}
 
 
 def _compute_grid_and_block_sizes(
@@ -677,16 +751,22 @@ def _setup_inner_loop_masks(
     env: CompileEnvironment,
     body_stmts: list[ast.AST],
     offset_expr_fn: Callable[[int, str], str],
+    force_mask_block_ids: set[int] | None = None,
 ) -> bool:
     """Set up mask variables for inner-loop block_ids.
 
     Args:
         offset_expr_fn: Given (block_id_index, block_size_var), returns a string
-            expression for the per-element offset (e.g. "_j * bs + jnp.arange(bs)").
+            expression for the per-element offset (e.g. "_j * step + jnp.arange(bs)").
+        force_mask_block_ids: block ids that must get a mask even when the
+            configured max extent is a known multiple of the block size. Folded
+            outer-pipeline axes need this because a dynamic BoundedSlice can be
+            shorter than its static max extent, and body code may mix lanes.
 
     Returns True if any mask requires explicit indices.
     """
     needs_explicit = False
+    force_mask_block_ids = force_mask_block_ids or set()
     if hasattr(strategy, "_setup_mask"):
         for i, bid in enumerate(block_ids):
             block_value = state.device_function.resolved_block_size(bid)
@@ -696,6 +776,19 @@ def _setup_inner_loop_masks(
             mask_stmt = strategy._setup_mask(
                 state, bid, block_value, offset_var, numel_expr
             )
+            if mask_stmt is None and bid in force_mask_block_ids:
+                mask_vars = getattr(strategy, "mask_vars", None)
+                if not isinstance(mask_vars, dict):
+                    raise BackendUnsupported(
+                        "pallas",
+                        "outer_pipeline requires a tile strategy that can "
+                        "materialize folded-axis validity masks",
+                    )
+                mask_var = state.device_function.new_var(f"mask_{bid}", dce=True)
+                mask_vars[bid] = mask_var
+                mask_stmt = statement_from_string(
+                    f"{mask_var} = ({offset_var}) < ({numel_expr})"
+                )
             if mask_stmt is not None:
                 needs_explicit = True
                 body_stmts.extend(
@@ -1428,6 +1521,18 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
 
     block_ids = graph_info.block_ids
     env = CompileEnvironment.current()
+    outer_context = (
+        env.outer_pipeline_context
+        if state.config.get("pallas_loop_type", "unroll") == "outer_pipeline"
+        else None
+    )
+    if outer_context is not None and outer_context.folded_block_ids:
+        raise BackendUnsupported(
+            "pallas",
+            "outer_pipeline currently supports one folded hl.tile loop",
+        )
+    if outer_context is not None:
+        outer_context.capturing_prologue_replay = False
 
     args = state.ast_args[-1]
     assert isinstance(args, list)
@@ -1436,16 +1541,70 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     # Check if we have loop-carried state (accumulators etc.)
     proxy_args = state.proxy_args[-1]
     assert isinstance(proxy_args, list)
-    has_loop_state = len(args) > 0
+    if outer_context is None:
+        has_loop_state = bool(args)
+    else:
+        has_loop_state = bool(_loop_carried_indices(state, len(args))) if args else False
+    if outer_context is not None and has_loop_state:
+        raise BackendUnsupported(
+            "pallas",
+            "outer_pipeline does not support loop-carried state in the folded "
+            "hl.tile loop",
+        )
 
-    grid_parts, block_size_vars = _compute_grid_and_block_sizes(state, block_ids, env)
+    folded_max_tiles: list[int] = []
+    if outer_context is None:
+        grid_parts, block_size_vars = _compute_grid_and_block_sizes(
+            state, block_ids, env
+        )
+    else:
+        from .._compiler.pallas.outer_pipeline import PipelineAxis
+        from .._compiler.pallas.outer_pipeline import PipelineExpr
+        from .._compiler.pallas.outer_pipeline import max_tiles_for_block
+
+        block_size_vars = []
+        for block_id in block_ids:
+            block_size_var = state.device_function.block_size_var(block_id)
+            assert block_size_var is not None
+            block_size_vars.append(block_size_var)
+            block_value = state.device_function.resolved_block_size(block_id)
+            if block_value is not None:
+                state.device_function.constexpr_arg(block_size_var, block_value)
+            if not isinstance(block_value, int):
+                raise BackendUnsupported(
+                    "pallas",
+                    "outer_pipeline requires concrete folded block sizes",
+                )
+            folded_max_tiles.append(max_tiles_for_block(env, block_id, block_value))
 
     loaded_tensors, stored_tensors = _classify_loop_tensors(graph_info, state)
+    if outer_context is not None:
+        _validate_outer_pipeline_folded_body(
+            graph_info, block_ids, env, loaded_tensors, stored_tensors
+        )
     begin_exprs, iter_step_exprs, slice_size_exprs = _pallas_loop_begin_and_step_exprs(
         state, block_ids, block_size_vars
     )
     # Loop end expressions (used to clamp store extents for data-dependent begins).
     end_exprs = [_get_loop_begin_and_end(state, i)[1] for i in range(len(block_ids))]
+    if outer_context is not None:
+        inner_lambda_params_for_axes = [
+            f"_j{i}" if len(block_ids) > 1 else "_j" for i in range(len(block_ids))
+        ]
+        for i, block_id in enumerate(block_ids):
+            outer_context.add_folded_axis(
+                PipelineAxis(
+                    block_id=block_id,
+                    kind="parallel",
+                    begin=PipelineExpr.from_string(begin_exprs[i]),
+                    end=PipelineExpr.from_string(end_exprs[i]),
+                    max_tiles=folded_max_tiles[i],
+                    step=PipelineExpr.from_string(iter_step_exprs[i]),
+                    block_extent=slice_size_exprs[i],
+                    lambda_param=inner_lambda_params_for_axes[i],
+                )
+            )
+        grid_parts = outer_context.grid_parts
 
     # Pipelined tensors flow through emit_pipeline's per-iter Buffered
     # BlockSpec; the rest stay on the outer pallas_call BlockSpec
@@ -1453,6 +1612,12 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     all_tensor_info, _vmem_shapes, pipelined_tensor_ids = _classify_pipelined_tensors(
         loaded_tensors, stored_tensors, block_ids, slice_size_exprs, env, state
     )
+    if outer_context is not None and len(pipelined_tensor_ids) < len(all_tensor_info):
+        raise BackendUnsupported(
+            "pallas",
+            "outer_pipeline currently requires folded-loop tensor accesses to "
+            "use emit_pipeline BlockSpecs",
+        )
 
     # Build in_specs and out_specs
     in_tensors: list[tuple[torch.Tensor, str]] = []
@@ -1471,15 +1636,62 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     # correctly maps to the block_id at grid dimension g.
     from .._compiler.device_function import DeviceFunction as _DF
 
+    outer_rank = len(outer_context.outer_block_ids) if outer_context else 0
     _bid_to_pid_var: dict[int, str] = {}
     device_fn = _DF.current()
-    if device_fn.pid is not None:
+    if outer_context is None and device_fn.pid is not None:
         for g, pid in enumerate(device_fn.pid.pid_info):
             pid_var = f"_outer_pid_{g}"
             state.add_statement(
                 statement_from_string(f"{pid_var} = pl.program_id({g})")
             )
             _bid_to_pid_var[pid.block_id] = pid_var
+
+    def _outer_lambda_params() -> tuple[list[str], dict[int, str]]:
+        """The ``_o{i}`` BlockSpec-lambda params for the folded outer grid dims,
+        plus a ``block_id -> param`` map."""
+        lambda_params: list[str] = []
+        outer_lambda_params: dict[int, str] = {}
+        if outer_context is not None:
+            for axis in outer_context.outer_axes:
+                param = axis.lambda_param
+                lambda_params.append(param)
+                outer_lambda_params[axis.block_id] = param
+        return lambda_params, outer_lambda_params
+
+    def _inner_lambda_params() -> list[str]:
+        """The ``_j{i}`` BlockSpec-lambda params for the folded inner tile dims."""
+        if outer_context is not None:
+            return [axis.lambda_param for axis in outer_context.folded_axes]
+        return [f"_j{i}" if len(block_ids) > 1 else "_j" for i in range(len(block_ids))]
+
+    def _buffered_block_spec(
+        block_shape_parts: list[str],
+        lambda_params: list[str],
+        lambda_parts: list[str],
+    ) -> str:
+        """Assemble a double-buffered ``pl.BlockSpec`` string from its block-shape
+        parts and index-map lambda params/parts."""
+        return (
+            f"pl.BlockSpec(({', '.join(block_shape_parts)},), "
+            f"lambda {', '.join(lambda_params)}: ({', '.join(lambda_parts)},), "
+            f"pipeline_mode=pl.Buffered(buffer_count=2))"
+        )
+
+    def _outer_lambda_expr(
+        expr: str, outer_lambda_params: dict[int, str]
+    ) -> str:
+        """Rewrite a body-local bound expr for use in a BlockSpec index_map lambda.
+
+        Replaces outer pid vars with the lambda's pipeline-index params and
+        recursively inlines captured prologue assignments (e.g. ``s =
+        x_offsets[g]``) so the lambda is self-contained. Raises BackendUnsupported
+        if any body-local folded name can't be resolved -- fails loud rather than
+        emitting a lambda that references an out-of-scope variable.
+        """
+        if outer_context is None:
+            return expr
+        return outer_context.resolve_for_lambda(expr)
 
     def _make_block_spec(
         fake: torch.Tensor, subscript_meta: list[object], is_store: bool = False
@@ -1494,26 +1706,100 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         shape = fake.shape
         block_shape_parts: list[str] = []
         lambda_parts: list[str] = []
-        lambda_params: list[str] = []
+        if outer_context is not None:
+            lambda_params = [axis.lambda_param for axis in outer_context.axes]
+            outer_lambda_params: dict[int, str] = {}
+            inner_lambda_params: list[str] = []
+        else:
+            lambda_params, outer_lambda_params = _outer_lambda_params()
+            inner_lambda_params = _inner_lambda_params()
+            lambda_params.extend(inner_lambda_params)
 
-        for i, _bid in enumerate(block_ids):
-            param = f"_j{i}" if len(block_ids) > 1 else "_j"
-            lambda_params.append(param)
+        def _static_int_expr_value(
+            expr: str, block_id: int | None = None
+        ) -> int | None:
+            expr = expr.strip()
+            if _is_static_int(expr):
+                return int(expr)
+            if block_id is None:
+                return None
+            block_size_var = state.device_function.block_size_var(block_id)
+            if expr == block_size_var:
+                block_value = state.device_function.resolved_block_size(block_id)
+                if isinstance(block_value, int):
+                    return block_value
+            return None
+
+        def _append_axis_dim(axis: object, dim_idx: int, dim_size: object) -> None:
+            assert outer_context is not None
+            from .._compiler.pallas.outer_pipeline import PipelineAxis
+
+            assert isinstance(axis, PipelineAxis)
+            block_extent = axis.block_extent
+            lambda_begin_expr = axis.begin.render_lambda(outer_context)
+            lambda_step_expr = axis.step.render_lambda(outer_context)
+            lambda_end_expr = axis.end.render_lambda(outer_context)
+            raw_start_expr = (
+                f"({lambda_begin_expr}) + ({axis.lambda_param}) "
+                f"* ({lambda_step_expr})"
+            )
+            begin_is_zero = lambda_begin_expr == "0"
+            exact_block_index = begin_is_zero and lambda_step_expr == block_extent
+            covers_full_dim = (
+                exact_block_index
+                and _is_static_int(lambda_end_expr)
+                and isinstance(dim_size, int)
+                and int(lambda_end_expr) == dim_size
+            )
+            block_extent_int = _static_int_expr_value(block_extent, axis.block_id)
+            full_static_blocks = (
+                covers_full_dim
+                and block_extent_int is not None
+                and dim_size % block_extent_int == 0
+            )
+            needs_dynamic_ds = not full_static_blocks
+            if needs_dynamic_ds:
+                if dim_idx == len(shape) - 1:
+                    raise BackendUnsupported(
+                        "pallas",
+                        "outer_pipeline dynamic BoundedSlice access on the "
+                        "innermost tensor dimension is not supported; tile a "
+                        "non-innermost dimension or use emit_pipeline.",
+                    )
+                block_shape_parts.append(f"pl.BoundedSlice({block_extent})")
+                extent_expr = (
+                    f"jnp.maximum(0, jnp.minimum({block_extent}, "
+                    f"({lambda_end_expr}) - ({raw_start_expr})))"
+                )
+                dim_size_expr = state.device_function.literal_expr(dim_size)
+                start_expr = (
+                    f"jnp.minimum(jnp.maximum({raw_start_expr}, 0), "
+                    f"({dim_size_expr}) - 1)"
+                )
+                lambda_parts.append(f"pl.ds({start_expr}, {extent_expr})")
+                return
+
+            block_shape_parts.append(block_extent)
+            if exact_block_index:
+                lambda_parts.append(axis.lambda_param)
+            else:
+                lambda_parts.append(raw_start_expr)
 
         for dim_idx in range(len(shape)):
             bid = dim_to_bid.get(dim_idx)
-            if bid is not None and bid in block_ids:
+            axis = (
+                outer_context.axis_by_block_id.get(bid)
+                if outer_context is not None and bid is not None
+                else None
+            )
+            if axis is not None:
+                _append_axis_dim(axis, dim_idx, shape[dim_idx])
+            elif outer_context is None and bid is not None and bid in block_ids:
                 # Inner pipeline dim -- tiled by pipeline grid
                 bid_idx = block_ids.index(bid)
                 slice_size_expr = slice_size_exprs[bid_idx]
                 begin_expr = begin_exprs[bid_idx]
                 iter_step_expr = iter_step_exprs[bid_idx]
-                from .memory_ops import _record_pad_info
-
-                extra_pad = _compute_pipeline_or_dma_extra_pad(
-                    begin_expr, bid, env, state
-                )
-                _record_pad_info(state, fake, dim_idx, bid, extra_pad)
                 begin_is_zero = begin_expr == "0"
                 end_expr = end_exprs[bid_idx]
                 dim_size = shape[dim_idx]
@@ -1531,47 +1817,71 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                     and isinstance(dim_size, int)
                     and int(end_expr) == dim_size
                 )
-                # Loads need a dynamic ``pl.ds`` only for a non-zero begin (a
-                # block-aligned index can't express an arbitrary start; the
-                # over-read past ``end`` is zeroed by the inner-loop mask).
-                # Stores need it whenever they target a sub-range (not the full
-                # dim), so the extent can be clamped and a partial final tile
-                # does not overrun live rows. Full-dim, from-zero loops keep the
-                # original block-index codegen (no change).
-                if not begin_is_zero or (is_store and not covers_full_dim):
-                    # Dynamic ``pl.ds`` at the true element offset, with a
-                    # ``pl.BoundedSlice`` block shape (required for ds-style
-                    # index maps). Lifts the "emit_pipeline fails on unaligned
-                    # dims" limitation so data-dependent tile loops can pipeline.
+                if outer_context is None and not (is_store and not covers_full_dim):
+                    from .memory_ops import _record_pad_info
+
+                    extra_pad = _compute_pipeline_or_dma_extra_pad(
+                        begin_expr, bid, env, state
+                    )
+                    _record_pad_info(state, fake, dim_idx, bid, extra_pad)
+                outer_load_needs_dynamic_extent = (
+                    outer_context is not None and not is_store and not covers_full_dim
+                )
+                # A dynamic ``pl.ds`` is required when the block-aligned index
+                # cannot express the true start, when a folded load targets a
+                # sub-range, or when a store targets a sub-range.
+                needs_dynamic_ds = (
+                    not begin_is_zero
+                    or outer_load_needs_dynamic_extent
+                    or (is_store and not covers_full_dim)
+                )
+                if needs_dynamic_ds:
+                    if outer_context is not None and dim_idx == len(shape) - 1:
+                        raise BackendUnsupported(
+                            "pallas",
+                            "outer_pipeline dynamic BoundedSlice access on the "
+                            "innermost tensor dimension is not supported; tile a "
+                            "non-innermost dimension or use emit_pipeline.",
+                        )
                     block_shape_parts.append(f"pl.BoundedSlice({slice_size_expr})")
-                    start_expr = (
-                        f"({begin_expr}) + ({lambda_params[bid_idx]}) "
+                    lambda_begin_expr = _outer_lambda_expr(
+                        begin_expr, outer_lambda_params
+                    )
+                    raw_start_expr = (
+                        f"({lambda_begin_expr}) + ({inner_lambda_params[bid_idx]}) "
                         f"* ({iter_step_expr})"
                     )
-                    if is_store:
-                        # Clamp the store extent to min(block, end - offset) so a
-                        # short final tile writes only its valid rows
-                        # [begin, end) instead of overrunning into the next
-                        # sub-range (which would corrupt it under cross-iteration
-                        # double-buffering, and is wasteful for large blocks).
-                        size_expr = (
-                            f"jnp.minimum({slice_size_expr}, "
-                            f"({end_exprs[bid_idx]}) - ({start_expr}))"
+                    lambda_end_expr = _outer_lambda_expr(
+                        end_exprs[bid_idx], outer_lambda_params
+                    )
+                    if outer_context is not None or is_store:
+                        extent_expr = (
+                            f"jnp.maximum(0, jnp.minimum({slice_size_expr}, "
+                            f"({lambda_end_expr}) - ({raw_start_expr})))"
                         )
                     else:
-                        size_expr = slice_size_expr
-                    lambda_parts.append(f"pl.ds({start_expr}, {size_expr})")
+                        extent_expr = slice_size_expr
+
+                    if outer_context is not None:
+                        dim_size_expr = state.device_function.literal_expr(dim_size)
+                        start_expr = (
+                            f"jnp.minimum(jnp.maximum({raw_start_expr}, 0), "
+                            f"({dim_size_expr}) - 1)"
+                        )
+                    else:
+                        start_expr = raw_start_expr
+                    lambda_parts.append(f"pl.ds({start_expr}, {extent_expr})")
                 else:
                     # Static, from-zero loop: a block-aligned index is exact.
                     # Identical to the pre-existing codegen.
                     block_shape_parts.append(slice_size_expr)
                     if iter_step_expr == slice_size_expr:
-                        lambda_parts.append(lambda_params[bid_idx])
+                        lambda_parts.append(inner_lambda_params[bid_idx])
                     else:
                         lambda_parts.append(
-                            f"(({begin_expr}) + ({lambda_params[bid_idx]}) * ({iter_step_expr})) // ({slice_size_expr})"
+                            f"(({begin_expr}) + ({inner_lambda_params[bid_idx]}) * ({iter_step_expr})) // ({slice_size_expr})"
                         )
-            elif bid is not None and bid in _bid_to_pid_var:
+            elif outer_context is None and bid is not None and bid in _bid_to_pid_var:
                 # Outer grid dim -- select via captured program_id variable
                 pid_var = _bid_to_pid_var[bid]
                 bs_var = state.device_function.block_size_var(bid)
@@ -1612,14 +1922,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                     block_shape_parts.append(str(int(shape[dim_idx])))
                     lambda_parts.append("0")
 
-        block_shape_str = ", ".join(block_shape_parts)
-        lambda_body = ", ".join(lambda_parts)
-        lambda_param_str = ", ".join(lambda_params)
-        return (
-            f"pl.BlockSpec(({block_shape_str},), "
-            f"lambda {lambda_param_str}: ({lambda_body},), "
-            f"pipeline_mode=pl.Buffered(buffer_count=2))"
-        )
+        return _buffered_block_spec(block_shape_parts, lambda_params, lambda_parts)
 
     def _make_load_block_spec(fake: torch.Tensor, subscript_meta: list[object]) -> str:
         """BlockSpec for a pipelined input (full-block ``pl.ds``; mask zeroes over-read)."""
@@ -1648,6 +1951,10 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
             if (
                 bid is not None
                 and bid not in block_ids
+                and not (
+                    outer_context is not None
+                    and bid in outer_context.outer_block_ids
+                )
                 and bid not in _bid_to_pid_var
                 and state.codegen.active_device_loops.get(bid)
             ):
@@ -1663,6 +1970,23 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         if not needs_slice:
             return hbm_name
         return f"{hbm_name}.at[{', '.join(parts)}]"
+
+    prologue_tensor_pipeline_inputs = {}
+    if outer_context is not None:
+        from .._compiler.pallas.outer_pipeline import (
+            collect_prologue_tensor_pipeline_inputs,
+        )
+
+        outer_lambda_params, outer_lambda_param_by_block = _outer_lambda_params()
+        prologue_tensor_pipeline_inputs = collect_prologue_tensor_pipeline_inputs(
+            state=state,
+            outer_context=outer_context,
+            outer_lambda_params=outer_lambda_params,
+            outer_lambda_param_by_block=outer_lambda_param_by_block,
+            inner_lambda_params=_inner_lambda_params(),
+            outer_lambda_expr=_outer_lambda_expr,
+            buffered_block_spec=_buffered_block_spec,
+        )
 
     # --- Handle loop-carried state as scratch VMEM buffers ---
     scratch_names: list[str] = []
@@ -1695,6 +2019,10 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     for fake, _tensor_node, _sub_meta in stored_tensors.values():
         if id(fake) in pipelined_tensor_ids:
             state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
+    for prologue_input in prologue_tensor_pipeline_inputs.values():
+        state.device_function.pallas_memory_space[id(prologue_input.fake)] = (
+            PallasMemorySpace.HBM
+        )
 
     for key, (fake, _tensor_node, sub_meta) in loaded_tensors.items():
         if key in stored_tensors:
@@ -1709,6 +2037,12 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         in_specs.append(_make_load_block_spec(fake, sub_meta))
         body_params.append(vmem_name)
         pipeline_in_args.append(_make_hbm_slice(fake, hbm_name, sub_meta))
+
+    for hbm_name, prologue_input in prologue_tensor_pipeline_inputs.items():
+        in_tensors.append((prologue_input.fake, hbm_name))
+        in_specs.append(prologue_input.block_spec)
+        body_params.append(prologue_input.vmem_name)
+        pipeline_in_args.append(hbm_name)
 
     for fake, _tensor_node, sub_meta in stored_tensors.values():
         if id(fake) not in pipelined_tensor_ids:
@@ -1725,17 +2059,34 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     # Build the body function
     body_fn_name = state.device_function.new_var("_pipeline_body")
     body_stmts: list[ast.AST] = []
+    if outer_context is not None:
+        from .._compiler.pallas.outer_pipeline import (
+            remap_prologue_tensor_pipeline_inputs,
+        )
+
+        body_stmts.extend(
+            remap_prologue_tensor_pipeline_inputs(
+                outer_context, prologue_tensor_pipeline_inputs
+            )
+        )
 
     # Build block_id_to_info for the pipeline state
     block_id_to_info: dict[int, LoopDimInfo] = {}
-    for block_id in block_ids:
+    for i, block_id in enumerate(block_ids):
         block_size = env.block_sizes[block_id]
         # when the block_size.size is None, we cannot form a SymPy expr for the numel
         sympy_end_expr = block_size.numel if block_size.size is not None else None
-        block_id_to_info[block_id] = LoopDimInfo(
-            end_var_name=None,
-            end_expr=sympy_end_expr,
-        )
+        if outer_context is None:
+            block_id_to_info[block_id] = LoopDimInfo(
+                end_var_name=None,
+                end_expr=sympy_end_expr,
+            )
+        else:
+            block_id_to_info[block_id] = LoopDimInfo(
+                begin_var_name=begin_exprs[i],
+                end_var_name=end_exprs[i],
+                end_expr=sympy_end_expr,
+            )
 
     strategy = _find_strategy(state, block_ids)
     # Emit offset_<bid>/indices_<bid> at the body prologue.
@@ -1746,10 +2097,19 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         block_size_vars,
         begin_exprs,
         iter_step_exprs,
-        [f"_pipeline_indices[{i}]" for i in range(len(block_ids))],
+        [f"_pipeline_indices[{outer_rank + i}]" for i in range(len(block_ids))],
         env,
         body_stmts,
     )
+    if outer_context is None:
+        pipeline_mask_offset_expr = (
+            lambda i, bs: f"_pipeline_indices[{i}] * {bs} + jnp.arange({bs})"
+        )
+    else:
+        pipeline_mask_offset_expr = lambda i, bs: (
+            f"_pipeline_indices[{outer_rank + i}] * ({iter_step_exprs[i]}) "
+            f"+ jnp.arange({bs})"
+        )
     # Set up mask variables for inner-loop block_ids (non-divisible bounds).
     _setup_inner_loop_masks(
         state,
@@ -1759,9 +2119,8 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         env,
         body_stmts,
         # emit_pipeline passes indices as a single tuple arg
-        offset_expr_fn=lambda i, bs: (
-            f"_pipeline_indices[{i}] * {bs} + jnp.arange({bs})"
-        ),
+        offset_expr_fn=pipeline_mask_offset_expr,
+        force_mask_block_ids=set(block_ids) if outer_context is not None else None,
     )
 
     # Emit absolute offset assignments inside the pipeline body so any
@@ -1777,9 +2136,11 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
             body_stmts.append(
                 statement_from_string(
                     f"{offset_name} = ({begin_exprs[i]}) + "
-                    f"(_pipeline_indices[{i}]) * ({iter_step_exprs[i]})"
+                    f"(_pipeline_indices[{outer_rank + i}]) * ({iter_step_exprs[i]})"
                 )
             )
+
+    body_guard_start = len(body_stmts)
 
     # Build tensor_to_dma_scratch mapping
     tensor_to_dma_scratch: dict[str, str] = {}
@@ -1791,7 +2152,6 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         tensor_to_dma_scratch[hbm_name] = body_params[idx]
         idx += 1
 
-    # Create the pipeline loop state
     pipeline_state = EmitPipelineLoopState(
         strategy=strategy,  # pyrefly: ignore[bad-argument-type]
         block_id_to_info=block_id_to_info,
@@ -1817,6 +2177,40 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         if has_loop_state:
             _write_back_loop_carried(state, scratch_names, carried, graph_results)
 
+    if outer_context is not None:
+        guarded_body_stmts = body_stmts[body_guard_start:]
+        del body_stmts[body_guard_start:]
+
+        valid_terms = []
+        for i in range(len(block_ids)):
+            tile_start = (
+                f"({begin_exprs[i]}) + "
+                f"(_pipeline_indices[{outer_rank + i}]) * ({iter_step_exprs[i]})"
+            )
+            valid_terms.append(f"(({tile_start}) < ({end_exprs[i]}))")
+        valid_expr = " & ".join(valid_terms) if valid_terms else "True"
+
+        valid_fn_name = state.device_function.new_var("_valid_pipeline_body")
+        invalid_fn_name = state.device_function.new_var("_invalid_pipeline_body")
+
+        valid_fn_def = statement_from_string(f"def {valid_fn_name}(): pass")
+        assert isinstance(valid_fn_def, ast.FunctionDef)
+        valid_fn_def.body = guarded_body_stmts or [ast.Pass()]  # pyrefly: ignore[bad-assignment]
+
+        invalid_fn_def = statement_from_string(f"def {invalid_fn_name}(): pass")
+        assert isinstance(invalid_fn_def, ast.FunctionDef)
+        invalid_fn_def.body = [ast.Pass()]  # pyrefly: ignore[bad-assignment]
+
+        body_stmts.extend(
+            [
+                valid_fn_def,
+                invalid_fn_def,
+                statement_from_string(
+                    f"lax.cond({valid_expr}, {valid_fn_name}, {invalid_fn_name})"
+                ),
+            ]
+        )
+
     _emit_nonlocal_scratch_declarations(state, body_stmts)
 
     all_body_params = body_params
@@ -1838,6 +2232,10 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     if out_specs:
         spec_parts.append(f"out_specs=[{out_specs_str}]")
     spec_parts.append("_explicit_indices=True")
+    if outer_context is not None:
+        spec_parts.append(
+            f"dimension_semantics={outer_context.dimension_semantics!r}"
+        )
     specs_str = ", ".join(spec_parts)
 
     all_pipeline_args = pipeline_in_args + pipeline_out_args
@@ -1853,9 +2251,15 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
             f"pltpu.emit_pipeline({body_fn_name}, grid=({grid_str},))({call_args_str})"
         )
 
-    # Emit the function def and pipeline call into the current scope
-    state.add_statement(fn_def)
-    state.add_statement(statement_from_string(pipeline_call_str))
+    # Emit the function def and pipeline call into the current scope.
+    if outer_context is not None:
+        outer_context.emitting_folded_pipeline = True
+    try:
+        state.add_statement(fn_def)
+        state.add_statement(statement_from_string(pipeline_call_str))
+    finally:
+        if outer_context is not None:
+            outer_context.emitting_folded_pipeline = False
 
     # After pipeline: read final loop-carried state from scratch
     if has_loop_state:
@@ -1971,22 +2375,31 @@ def _classify_pipelined_tensors(
         all_tensor_info, block_ids, slice_size_exprs, env, state
     )
     device_ir = HostFunction.current().device_ir
+    outer_context = (
+        env.outer_pipeline_context
+        if state.config.get("pallas_loop_type", "unroll") == "outer_pipeline"
+        else None
+    )
 
     # Walk all root graphs (outer pallas_call body) for load/store/atomic
     # nodes; any tensor accessed there is read/written outside the inner
     # loop and must keep its outer BlockSpec.
     outer_access_tensor_ids: set[int] = set()
-    for root_id in device_ir.root_ids:
-        root_graph = device_ir.graphs[root_id].graph
-        for node in root_graph.nodes:
-            if node.op != "call_function" or node.target not in outer_access_targets:
-                continue
-            tensor_node = node.args[0]
-            if not isinstance(tensor_node, torch.fx.Node):
-                continue
-            val = tensor_node.meta.get("val")
-            if isinstance(val, torch.Tensor):
-                outer_access_tensor_ids.add(id(val))
+    if outer_context is None:
+        for root_id in device_ir.root_ids:
+            root_graph = device_ir.graphs[root_id].graph
+            for node in root_graph.nodes:
+                if (
+                    node.op != "call_function"
+                    or node.target not in outer_access_targets
+                ):
+                    continue
+                tensor_node = node.args[0]
+                if not isinstance(tensor_node, torch.fx.Node):
+                    continue
+                val = tensor_node.meta.get("val")
+                if isinstance(val, torch.Tensor):
+                    outer_access_tensor_ids.add(id(val))
 
     pipelined_ids: set[int] = set()
     for (fake, _sub_meta, _direction), vmem_shape in zip(

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -1817,7 +1817,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                     and isinstance(dim_size, int)
                     and int(end_expr) == dim_size
                 )
-                if outer_context is None and not (is_store and not covers_full_dim):
+                if outer_context is None:
                     from .memory_ops import _record_pad_info
 
                     extra_pad = _compute_pipeline_or_dma_extra_pad(
@@ -1854,10 +1854,15 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                     lambda_end_expr = _outer_lambda_expr(
                         end_exprs[bid_idx], outer_lambda_params
                     )
-                    if outer_context is not None or is_store:
+                    if outer_context is not None:
                         extent_expr = (
                             f"jnp.maximum(0, jnp.minimum({slice_size_expr}, "
                             f"({lambda_end_expr}) - ({raw_start_expr})))"
+                        )
+                    elif is_store:
+                        extent_expr = (
+                            f"jnp.minimum({slice_size_expr}, "
+                            f"({lambda_end_expr}) - ({raw_start_expr}))"
                         )
                     else:
                         extent_expr = slice_size_expr

--- a/helion/language/loops.py
+++ b/helion/language/loops.py
@@ -12,8 +12,8 @@ from typing import TypeGuard
 from typing import cast
 from typing import overload
 
-import torch
 import sympy
+import torch
 from torch._inductor.runtime.triton_heuristics import (
     get_max_y_grid,  # type: ignore[import-untyped]
 )
@@ -323,7 +323,7 @@ def _validate_max_extent(
         for symbol in expr.free_symbols:
             if (
                 isinstance(symbol, sympy.Symbol)
-                and symbol_is_type(symbol, SymT.UNBACKED_INT)
+                and symbol_is_type(symbol, SymT.UNBACKED_INT)  # pyrefly: ignore [bad-argument-type]
                 and symbol not in env.specialized_vars
             ):
                 raise exc.IncorrectTileUsage(

--- a/helion/language/loops.py
+++ b/helion/language/loops.py
@@ -13,9 +13,12 @@ from typing import cast
 from typing import overload
 
 import torch
+import sympy
 from torch._inductor.runtime.triton_heuristics import (
     get_max_y_grid,  # type: ignore[import-untyped]
 )
+from torch.utils._sympy.symbol import SymT
+from torch.utils._sympy.symbol import symbol_is_type
 
 from .. import exc
 from .._compat import use_tileir_tunables
@@ -66,6 +69,8 @@ def tile(
     end_or_none: int | torch.Tensor | None = None,
     /,
     block_size: object = None,
+    *,
+    max_extent: object = None,
 ) -> Iterator[Tile]: ...
 
 
@@ -78,6 +83,8 @@ def tile(
     end_or_none: Sequence[int | torch.Tensor] | None = None,
     /,
     block_size: object = None,
+    *,
+    max_extent: object = None,
 ) -> Iterator[Sequence[Tile]]: ...
 
 
@@ -89,6 +96,8 @@ def tile(
     end_or_none: int | torch.Tensor | Sequence[int | torch.Tensor] | None = None,
     /,
     block_size: object = None,
+    *,
+    max_extent: object = None,
 ) -> Iterator[Tile] | Iterator[Sequence[Tile]]:
     """
     Break up an iteration space defined by a size or sequence of sizes into tiles.
@@ -114,6 +123,10 @@ def tile(
                       Otherwise, the end of iteration space.
         end_or_none: If 2+ positional args provided, the end of iteration space.
         block_size: Fixed block size (overrides autotuning) or None for autotuned size
+        max_extent: Statically validated upper bound for ``end - begin`` when
+                    the true tile extent is data-dependent. It is recorded as
+                    tile metadata; Pallas outer_pipeline consumes it to form a
+                    static pipeline grid.
 
     Returns:
         Iterator[Tile] or Iterator[Sequence[Tile]]: Iterator over tile objects
@@ -270,6 +283,56 @@ def _allow_static_range(begin: object, end: object, step: object) -> bool:
     return count <= 8
 
 
+def _validate_max_extent(
+    max_extent: TypeInfo | None,
+    *,
+    is_scalar_tile: bool,
+) -> int | torch.SymInt | None:
+    """Resolve ``hl.tile(..., max_extent=...)`` to a proven static int bound, or
+    ``None`` if unset. Rejects multi-dim tiles, tensors, and unbacked/runtime/
+    non-positive values so outer_pipeline can use it as a sound static
+    ``max_tiles`` bound (not an example-derived guess)."""
+    if not _not_none(max_extent):
+        return None
+    if not is_scalar_tile:
+        raise exc.IncorrectTileUsage(
+            "hl.tile(max_extent=...) currently only supports one-dimensional tile loops"
+        )
+    proxy_max_extent = _to_proxy(max_extent)
+    if isinstance(proxy_max_extent, torch.Tensor):
+        raise exc.IncorrectTileUsage(
+            "hl.tile(max_extent=...) must be a statically known integer, got Tensor"
+        )
+    if isinstance(proxy_max_extent, (list, tuple)):
+        raise exc.IncorrectTileUsage(
+            "hl.tile(max_extent=...) must be a scalar integer, got a sequence"
+        )
+    if not isinstance(proxy_max_extent, (int, torch.SymInt)):
+        raise exc.IncorrectTileUsage(
+            "hl.tile(max_extent=...) must be a statically known integer, "
+            f"got {type(proxy_max_extent).__name__}"
+        )
+
+    env = CompileEnvironment.current()
+    if env.size_hint(proxy_max_extent) <= 0:
+        raise exc.IncorrectTileUsage(
+            "hl.tile(max_extent=...) must be a positive integer"
+        )
+    if isinstance(proxy_max_extent, torch.SymInt):
+        expr = proxy_max_extent._sympy_()
+        for symbol in expr.free_symbols:
+            if (
+                isinstance(symbol, sympy.Symbol)
+                and symbol_is_type(symbol, SymT.UNBACKED_INT)
+                and symbol not in env.specialized_vars
+            ):
+                raise exc.IncorrectTileUsage(
+                    "hl.tile(max_extent=...) must be statically known. "
+                    "Use hl.specialize(max_extent) or pass a tensor dimension."
+                )
+    return proxy_max_extent
+
+
 def _normalize_begin_end(
     begin_or_end: TypeInfo,
     end_or_none: TypeInfo | None,
@@ -297,6 +360,7 @@ def _(
     /,
     block_size: TypeInfo | None = None,
     *,
+    max_extent: TypeInfo | None = None,
     origin: Origin,
 ) -> TypeInfo:
     parent = ExtendedAST.current()[-2]
@@ -329,6 +393,7 @@ def _(
             "list[int | torch.SymInt | torch.Tensor | None]", proxy_block_size
         )
     block_size_list = Tile._tiles_to_sizes(block_size_list)
+    declared_max_extent = _validate_max_extent(max_extent, is_scalar_tile=unpack)
 
     # pyrefly: ignore [unbound-name]
     if unpack:
@@ -367,6 +432,10 @@ def _(
             else:
                 results.append(TileIndexType(origin=origin, block_id=index))
                 env.block_sizes[index].mark_alternate_size(size)
+
+    if declared_max_extent is not None:
+        env = CompileEnvironment.current()
+        env.block_sizes[results[0].block_id].mark_max_extent(declared_max_extent)
 
     _add_config_choices(
         [x.block_id for x in results],
@@ -536,7 +605,9 @@ def _(
     begin_or_end: int | torch.Tensor | list[int | torch.Tensor],
     end_or_none: int | torch.Tensor | list[int | torch.Tensor] | None = None,
     block_size: int | torch.Tensor | list[int | torch.Tensor] | None = None,
+    max_extent: int | torch.Tensor | None = None,
 ) -> Iterator[RefTile | tuple[RefTile, ...]]:
+    del max_extent
     begin, end = _normalize_begin_end_ref(begin_or_end, end_or_none)
     scalar_input = not isinstance(begin, list) and not isinstance(end, list)
     begin_list = _normalize_to_list(begin)
@@ -780,6 +851,13 @@ def _codegen_loop_helper(
 
     if loop_type == LoopType.GRID:
         block_ids = [t.block_id for t in indices]
+        # ``max_extent`` is type-propagation metadata, not a runtime grid arg.
+        # Keep the existing tile-strategy codegen contract at begin/end/step.
+        if len(state.proxy_args) > 3:
+            state = state._replace(
+                proxy_args=state.proxy_args[:3],
+                ast_args=None if state.ast_args is None else state.ast_args[:3],
+            )
         state.tile_strategy.codegen_grid(state, block_ids)
         return expr_from_string("None")
     raise AssertionError(f"Expected loop type: {loop_type}")

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -1363,6 +1363,7 @@ class _PallasLoopKind(enum.Enum):
 
     UNROLL = "unroll"
     EMIT_PIPELINE = "emit_pipeline"
+    OUTER_PIPELINE = "outer_pipeline"
     FORI_LOOP = "fori_loop"
 
 
@@ -1471,6 +1472,8 @@ def _pallas_compile_jit_fn(
       (no scratch)
     - :attr:`_PallasLoopKind.EMIT_PIPELINE`: ``PrefetchScalarGridSpec``
       with HBM refs for pipeline-body tensors and VMEM scratch
+    - :attr:`_PallasLoopKind.OUTER_PIPELINE`: same launcher machinery as
+      ``EMIT_PIPELINE``; codegen moves the work grid inside the pipeline call
     - :attr:`_PallasLoopKind.FORI_LOOP`: same gridspec/scratch shape as
       ``EMIT_PIPELINE``; the kernel body uses ``jax.lax.fori_loop`` with
       manual DMA
@@ -1858,6 +1861,51 @@ def default_pallas_pipeline_launcher(
         cache,
         args,
         cache_attr="_pallas_pipeline_cache",
+        _ds_pad_dims=_ds_pad_dims,
+    )
+
+
+def default_pallas_outer_pipeline_launcher(
+    pallas_kernel: object,
+    grid: tuple[int, ...],
+    *args: object,
+    _output_indices: list[int] | None = None,
+    _inplace_indices: list[int] | None = None,
+    _block_spec_info: _BlockSpecInfo | None = None,
+    _scratch_shapes: list[tuple[tuple[int, ...], str]] | None = None,
+    _pipeline_arg_indices: list[int] | None = None,
+    _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
+    _smem_arg_indices: list[int] | None = None,
+    _pallas_interpret: bool | None = None,
+    _matmul_dot_general: dict[str, object] | None = None,
+    **kwargs: object,
+) -> object:
+    """Launcher for Pallas kernels whose work grid is folded into emit_pipeline."""
+    cache = getattr(pallas_kernel, "_pallas_outer_pipeline_cache", None)
+    if cache is None or cache[0] != grid:
+        cache = _pallas_install_launcher_cache(
+            pallas_kernel,
+            grid,
+            args,
+            kind=_PallasLoopKind.OUTER_PIPELINE,
+            cache_attr="_pallas_outer_pipeline_cache",
+            trace_key_suffix="_outer_pipeline",
+            _output_indices=_output_indices,
+            _inplace_indices=_inplace_indices,
+            _block_spec_info=_block_spec_info,
+            _smem_arg_indices=_smem_arg_indices,
+            _scratch_shapes=cast("list[object] | None", _scratch_shapes),
+            _pipeline_arg_indices=_pipeline_arg_indices,
+            _ds_pad_dims=_ds_pad_dims,
+            _pallas_interpret=_pallas_interpret,
+            _matmul_dot_general=_matmul_dot_general,
+        )
+
+    return _pallas_invoke_cached_launcher(
+        pallas_kernel,
+        cache,
+        args,
+        cache_attr="_pallas_outer_pipeline_cache",
         _ds_pad_dims=_ds_pad_dims,
     )
 

--- a/test/test_pallas_outer_pipeline.py
+++ b/test/test_pallas_outer_pipeline.py
@@ -12,6 +12,7 @@ from helion._testing import TestCase
 from helion._testing import assert_ref_eager_mode
 from helion._testing import code_and_output
 from helion._testing import skipIfPallasInterpret
+from helion._testing import skipUnlessPallas
 import helion.language as hl
 
 
@@ -146,6 +147,7 @@ class TestTileMaxExtent(TestCase):
         self.assertIn("pltpu.emit_pipeline", code)
 
 
+@skipUnlessPallas("JAX/Pallas TPU not available")
 class TestPallasOuterPipelineScaffold(TestCase):
     def test_outer_pipeline_is_explicit_but_not_autotuned(self) -> None:
         @helion.kernel(backend="pallas", autotune_effort="none")

--- a/test/test_pallas_outer_pipeline.py
+++ b/test/test_pallas_outer_pipeline.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import types
+from typing import Any
+from typing import cast
 import unittest
 
 import torch
@@ -14,6 +16,7 @@ from helion._testing import code_and_output
 from helion._testing import skipIfPallasInterpret
 from helion._testing import skipUnlessPallas
 import helion.language as hl
+from helion.runtime.settings import is_pallas_interpret
 
 
 class TestTileMaxExtent(TestCase):
@@ -34,6 +37,7 @@ class TestTileMaxExtent(TestCase):
             expected[1:-1] += 1
             torch.testing.assert_close(result, expected)
 
+    @skipUnlessPallas("JAX/Pallas TPU not available")
     def test_max_extent_rejects_tensor_value(self) -> None:
         @helion.kernel(backend="pallas", autotune_effort="none")
         def bad_max_extent(x: torch.Tensor, max_extent: torch.Tensor) -> torch.Tensor:
@@ -52,6 +56,7 @@ class TestTileMaxExtent(TestCase):
         ):
             bad_max_extent.bind(args)
 
+    @skipUnlessPallas("JAX/Pallas TPU not available")
     def test_max_extent_rejects_multidim_tile(self) -> None:
         @helion.kernel(backend="pallas", autotune_effort="none")
         def bad_multidim(x: torch.Tensor) -> torch.Tensor:
@@ -66,6 +71,7 @@ class TestTileMaxExtent(TestCase):
         ):
             bad_multidim.bind((torch.randn(8, 8, device=DEVICE),))
 
+    @skipUnlessPallas("JAX/Pallas TPU not available")
     def test_reused_block_size_conflicting_max_extent_rejects(self) -> None:
         @helion.kernel(backend="pallas", autotune_effort="none")
         def conflicting_max_extent(x: torch.Tensor) -> torch.Tensor:
@@ -84,6 +90,7 @@ class TestTileMaxExtent(TestCase):
         ):
             conflicting_max_extent.bind((torch.randn(4, 8, device=DEVICE),))
 
+    @skipUnlessPallas("JAX/Pallas TPU not available")
     def test_backed_symbolic_max_extent_compiles(self) -> None:
         @helion.kernel(
             backend="pallas",
@@ -103,6 +110,7 @@ class TestTileMaxExtent(TestCase):
         )
         self.assertIn("jax.lax.fori_loop", code)
 
+    @skipUnlessPallas("JAX/Pallas TPU not available")
     def test_outer_pipeline_symbolic_max_extent_static_shapes_false_rejects(
         self,
     ) -> None:
@@ -127,6 +135,7 @@ class TestTileMaxExtent(TestCase):
                 helion.Config(block_sizes=[2, 4], pallas_loop_type="outer_pipeline")
             )
 
+    @skipUnlessPallas("JAX/Pallas TPU not available")
     def test_outer_pipeline_static_shapes_false_int_max_extent_compiles(self) -> None:
         @helion.kernel(
             backend="pallas",
@@ -160,7 +169,9 @@ class TestPallasOuterPipelineScaffold(TestCase):
 
         x = torch.randn(8, 128, device=DEVICE)
         bound = inner_loop.bind((x,))
-        choices = bound.config_spec._flat_fields()["pallas_loop_type"].choices
+        choices = cast(
+            "Any", bound.config_spec._flat_fields()["pallas_loop_type"]
+        ).choices
         self.assertNotIn("outer_pipeline", choices)
 
         code, result = code_and_output(
@@ -513,12 +524,15 @@ class TestPallasOuterPipelineScaffold(TestCase):
 
         expected = torch.zeros_like(x)
         expected[0::2] = x[0::2]
-        torch.testing.assert_close(result, expected)
+        if not is_pallas_interpret():
+            torch.testing.assert_close(result, expected)
         uncommented_code = "\n".join(
             line for line in code.splitlines() if not line.lstrip().startswith("#")
         )
         self.assertIn("0 + _o0 * 2", uncommented_code)
-        self.assertIn("pl.BoundedSlice(1)", uncommented_code)
+        self.assertIn("pl.BlockSpec((1, _BLOCK_SIZE_1, 128)", uncommented_code)
+        self.assertNotIn("pl.BoundedSlice(1)", uncommented_code)
+        self.assertNotIn("jnp.maximum(0, jnp.minimum(1", uncommented_code)
 
     def test_outer_pipeline_dynamic_end_without_max_extent_rejects(self) -> None:
         @helion.kernel(backend="pallas", autotune_effort="none")
@@ -684,7 +698,7 @@ class TestPallasOuterPipelineScaffold(TestCase):
         def folded_store_alias(x: torch.Tensor) -> torch.Tensor:
             out = torch.empty_like(x)
             for row in hl.grid(x.size(0)):
-                for col in hl.tile(x.size(1)):
+                for _col in hl.tile(x.size(1)):
                     out[row, 0, :, :] = x[row, 0, :, :]
             return out
 

--- a/test/test_pallas_outer_pipeline.py
+++ b/test/test_pallas_outer_pipeline.py
@@ -1,0 +1,809 @@
+from __future__ import annotations
+
+import types
+import unittest
+
+import torch
+
+import helion
+from helion import exc
+from helion._testing import DEVICE
+from helion._testing import TestCase
+from helion._testing import assert_ref_eager_mode
+from helion._testing import code_and_output
+from helion._testing import skipIfPallasInterpret
+import helion.language as hl
+
+
+class TestTileMaxExtent(TestCase):
+    def test_ref_eager_ignores_max_extent(self) -> None:
+        @helion.kernel(ref_mode=helion.RefMode.EAGER)
+        def copy_inner(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(1, x.size(0) - 1, block_size=2, max_extent=8):
+                out[tile] = x[tile] + 1
+            out[0] = x[0]
+            out[x.size(0) - 1] = x[x.size(0) - 1]
+            return out
+
+        with assert_ref_eager_mode():
+            x = torch.arange(8, device="cpu", dtype=torch.float32)
+            result = copy_inner(x)
+            expected = x.clone()
+            expected[1:-1] += 1
+            torch.testing.assert_close(result, expected)
+
+    def test_max_extent_rejects_tensor_value(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def bad_max_extent(x: torch.Tensor, max_extent: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(0, x.size(0), max_extent=max_extent):
+                out[tile] = x[tile]
+            return out
+
+        args = (
+            torch.randn(8, device=DEVICE),
+            torch.tensor(8, device=DEVICE),
+        )
+        with self.assertRaisesRegex(
+            exc.IncorrectTileUsage,
+            r"hl\.tile\(max_extent=\.\.\.\) must be a statically known integer",
+        ):
+            bad_max_extent.bind(args)
+
+    def test_max_extent_rejects_multidim_tile(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def bad_multidim(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile([x.size(0), x.size(1)], max_extent=8):
+                out[tile_m, tile_n] = x[tile_m, tile_n]
+            return out
+
+        with self.assertRaisesRegex(
+            exc.IncorrectTileUsage,
+            "max_extent=.*one-dimensional tile loops",
+        ):
+            bad_multidim.bind((torch.randn(8, 8, device=DEVICE),))
+
+    def test_reused_block_size_conflicting_max_extent_rejects(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def conflicting_max_extent(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            block = hl.register_block_size(x.size(1))
+            for row in hl.tile(x.size(0)):
+                for tile in hl.tile(0, x.size(1), block_size=block, max_extent=8):
+                    out[row, tile] = x[row, tile]
+                for tile in hl.tile(0, x.size(1), block_size=block, max_extent=16):
+                    out[row, tile] = x[row, tile]
+            return out
+
+        with self.assertRaisesRegex(
+            exc.IncorrectTileUsage,
+            "Conflicting hl.tile\\(max_extent=\\.\\.\\.\\) values",
+        ):
+            conflicting_max_extent.bind((torch.randn(4, 8, device=DEVICE),))
+
+    def test_backed_symbolic_max_extent_compiles(self) -> None:
+        @helion.kernel(
+            backend="pallas",
+            static_shapes=False,
+            autotune_effort="none",
+        )
+        def symbolic_max_extent(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for row in hl.tile(x.size(0)):
+                for tile in hl.tile(0, x.size(1), max_extent=x.size(1)):
+                    out[row, tile] = x[row, tile]
+            return out
+
+        bound = symbolic_max_extent.bind((torch.randn(4, 8, device=DEVICE),))
+        code = bound.to_triton_code(
+            helion.Config(block_sizes=[2, 4], pallas_loop_type="fori_loop")
+        )
+        self.assertIn("jax.lax.fori_loop", code)
+
+    def test_outer_pipeline_symbolic_max_extent_static_shapes_false_rejects(
+        self,
+    ) -> None:
+        @helion.kernel(
+            backend="pallas",
+            static_shapes=False,
+            autotune_effort="none",
+        )
+        def symbolic_max_extent(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for row in hl.tile(x.size(0)):
+                for tile in hl.tile(0, x.size(1), max_extent=x.size(1)):
+                    out[row, tile] = x[row, tile]
+            return out
+
+        bound = symbolic_max_extent.bind((torch.randn(4, 8, device=DEVICE),))
+        with self.assertRaisesRegex(
+            exc.BackendUnsupported,
+            "requires a static folded",
+        ):
+            bound.to_triton_code(
+                helion.Config(block_sizes=[2, 4], pallas_loop_type="outer_pipeline")
+            )
+
+    def test_outer_pipeline_static_shapes_false_int_max_extent_compiles(self) -> None:
+        @helion.kernel(
+            backend="pallas",
+            static_shapes=False,
+            autotune_effort="none",
+        )
+        def integer_max_extent(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for row in hl.tile(x.size(0)):
+                for tile in hl.tile(0, x.size(1), max_extent=8):
+                    out[row, tile, :] = x[row, tile, :]
+            return out
+
+        bound = integer_max_extent.bind((torch.randn(4, 8, 128, device=DEVICE),))
+        code = bound.to_triton_code(
+            helion.Config(block_sizes=[2, 8], pallas_loop_type="outer_pipeline")
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+
+
+class TestPallasOuterPipelineScaffold(TestCase):
+    def test_outer_pipeline_is_explicit_but_not_autotuned(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def inner_loop(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for row in hl.tile(x.size(0)):
+                for tile in hl.tile(0, x.size(1), max_extent=x.size(1)):
+                    out[row, tile] = x[row, tile]
+            return out
+
+        x = torch.randn(8, 128, device=DEVICE)
+        bound = inner_loop.bind((x,))
+        choices = bound.config_spec._flat_fields()["pallas_loop_type"].choices
+        self.assertNotIn("outer_pipeline", choices)
+
+        code, result = code_and_output(
+            inner_loop,
+            (x,),
+            block_sizes=[8, 128],
+            pallas_loop_type="outer_pipeline",
+        )
+        torch.testing.assert_close(result, x)
+        self.assertIn("pltpu.emit_pipeline", code)
+        self.assertIn("_launcher(_helion_inner_loop, (),", code)
+        self.assertIn("grid=((8 + _BLOCK_SIZE_0 - 1) // _BLOCK_SIZE_0, 1)", code)
+        self.assertIn("lambda _o0, _j", code)
+        self.assertNotIn("pl.program_id", code)
+
+    @skipIfPallasInterpret("Pallas interpret requires static BoundedSlice extents")
+    def test_outer_pipeline_dynamic_end_uses_max_extent_guard(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def prefix_copy(x: torch.Tensor, ends: torch.Tensor) -> torch.Tensor:
+            out = torch.zeros_like(x)
+            for batch in hl.tile(x.size(0)):
+                end = hl.load(ends, [0])
+                for col in hl.tile(0, end, max_extent=x.size(1)):
+                    out[batch, col, :, :] = x[batch, col, :, :]
+            return out
+
+        x = torch.randn(8, 128, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+        end = 37
+        ends = torch.tensor([end], device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(
+            prefix_copy,
+            (x, ends),
+            block_sizes=[8, 128],
+            pallas_loop_type="outer_pipeline",
+        )
+
+        expected = torch.zeros_like(x)
+        expected[:, :end] = x[:, :end]
+        torch.testing.assert_close(result, expected)
+        self.assertIn("jnp.maximum(0, jnp.minimum", code)
+        self.assertIn("lax.cond", code)
+
+    @skipIfPallasInterpret("Pallas interpret requires static BoundedSlice extents")
+    def test_outer_pipeline_dynamic_end_clamps_masked_store_lanes(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def prefix_copy_into(
+            x: torch.Tensor, ends: torch.Tensor, out: torch.Tensor
+        ) -> torch.Tensor:
+            for batch in hl.tile(x.size(0)):
+                end = hl.load(ends, [0])
+                for col in hl.tile(0, end, max_extent=x.size(1)):
+                    out[batch, col, :, :] = x[batch, col, :, :]
+            return out
+
+        x = torch.randn(8, 128, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+        end = 37
+        ends = torch.tensor([end], device=DEVICE, dtype=torch.int32)
+        out = torch.full_like(x, -7.0)
+        code, result = code_and_output(
+            prefix_copy_into,
+            (x, ends, out),
+            block_sizes=[8, 128],
+            pallas_loop_type="outer_pipeline",
+        )
+
+        expected = torch.full_like(x, -7.0)
+        expected[:, :end] = x[:, :end]
+        torch.testing.assert_close(result, expected)
+        self.assertNotIn("out_preserve_hbm", code)
+        self.assertNotIn("_outer_pipeline_preserve_arg_indices", code)
+        self.assertIn("jnp.maximum(0, jnp.minimum", code)
+
+    def test_outer_pipeline_dynamic_innermost_dim_rejects(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def prefix_copy(x: torch.Tensor, ends: torch.Tensor) -> torch.Tensor:
+            out = torch.zeros_like(x)
+            for row in hl.tile(x.size(0)):
+                end = hl.load(ends, [0])
+                for col in hl.tile(0, end, max_extent=x.size(1)):
+                    out[row, col] = x[row, col]
+            return out
+
+        x = torch.randn(8, 128, device=DEVICE)
+        ends = torch.tensor([37], device=DEVICE, dtype=torch.int32)
+        bound = prefix_copy.bind((x, ends))
+        with self.assertRaisesRegex(
+            exc.BackendUnsupported,
+            "innermost tensor dimension is not supported",
+        ):
+            bound.to_triton_code(
+                helion.Config(block_sizes=[8, 128], pallas_loop_type="outer_pipeline")
+            )
+
+    @skipIfPallasInterpret("Pallas interpret requires static BoundedSlice extents")
+    def test_outer_pipeline_zero_begin_multitile_clamps_load_and_store_extents(
+        self,
+    ) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def prefix_copy_into(
+            x: torch.Tensor, ends: torch.Tensor, out: torch.Tensor
+        ) -> torch.Tensor:
+            for batch in hl.tile(x.size(0)):
+                end = hl.load(ends, [0])
+                for col in hl.tile(0, end, max_extent=x.size(1)):
+                    out[batch, col, :, :] = x[batch, col, :, :]
+            return out
+
+        x = torch.randn(1, 3000, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+        end = 2500
+        ends = torch.tensor([end], device=DEVICE, dtype=torch.int32)
+        out = torch.full_like(x, -7.0)
+        code, result = code_and_output(
+            prefix_copy_into,
+            (x, ends, out),
+            block_sizes=[1, 1024],
+            pallas_loop_type="outer_pipeline",
+        )
+
+        expected = torch.full_like(x, -7.0)
+        expected[:, :end] = x[:, :end]
+        torch.testing.assert_close(result, expected)
+        emit_line = next(
+            line for line in code.splitlines() if "pltpu.emit_pipeline" in line
+        )
+        self.assertIn("grid=(1, 3)", emit_line)
+        self.assertIn("jnp.maximum(0, jnp.minimum", emit_line)
+        self.assertNotIn("_ds_pad_dims", code)
+        self.assertNotIn("out_preserve_hbm", code)
+
+    @skipIfPallasInterpret("Pallas interpret requires static BoundedSlice extents")
+    def test_outer_pipeline_full_dim_nondivisible_uses_dynamic_ds(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def copy_full_dim(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for batch in hl.tile(x.size(0)):
+                for col in hl.tile(0, x.size(1), max_extent=x.size(1)):
+                    out[batch, col, :, :] = x[batch, col, :, :]
+            return out
+
+        x = torch.randn(1, 10, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            copy_full_dim,
+            (x,),
+            block_sizes=[1, 8],
+            pallas_loop_type="outer_pipeline",
+        )
+
+        torch.testing.assert_close(result, x)
+        emit_line = next(
+            line for line in code.splitlines() if "pltpu.emit_pipeline" in line
+        )
+        self.assertIn("grid=(1, 2)", emit_line)
+        self.assertIn("pl.BoundedSlice(_BLOCK_SIZE_1)", emit_line)
+        self.assertIn("jnp.maximum(0, jnp.minimum", emit_line)
+        self.assertNotIn("_ds_pad_dims", code)
+
+    @skipIfPallasInterpret("Pallas interpret requires static BoundedSlice extents")
+    def test_outer_pipeline_data_dependent_nonzero_begin_uses_lambda_scope(
+        self,
+    ) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def packed_copy(
+            x: torch.Tensor, offsets: torch.Tensor, max_len: int
+        ) -> torch.Tensor:
+            max_len = hl.specialize(max_len)
+            out = torch.zeros_like(x)
+            for seq in hl.grid(offsets.size(0) - 1):
+                start = offsets[seq]
+                end = offsets[seq + 1]
+                for tile in hl.tile(start, end, max_extent=max_len):
+                    out[tile, :, :] = x[tile, :, :]
+            return out
+
+        x = torch.randn(64, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+        offsets = torch.tensor([3, 11, 19, 27], device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(
+            packed_copy,
+            (x, offsets, 8),
+            block_sizes=[8],
+            pallas_loop_type="outer_pipeline",
+        )
+
+        expected = torch.zeros_like(x)
+        expected[3:27] = x[3:27]
+        torch.testing.assert_close(result, expected)
+        emit_line = next(
+            line for line in code.splitlines() if "pltpu.emit_pipeline" in line
+        )
+        self.assertIn("offsets", emit_line)
+        self.assertIn("_o0", emit_line)
+        self.assertNotIn("start", emit_line)
+        self.assertNotIn("end", emit_line)
+        self.assertNotIn("_ds_pad_dims", code)
+        self.assertIn("load = x_vmem[:, :, :] *", code)
+
+    @skipIfPallasInterpret("Pallas interpret requires static BoundedSlice extents")
+    def test_outer_pipeline_masks_partial_folded_load(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def partial_load(x: torch.Tensor) -> torch.Tensor:
+            out = torch.zeros_like(x)
+            for _seq in hl.grid(1):
+                for tile in hl.tile(0, 2, block_size=4, max_extent=4):
+                    out[tile, :, :] = x[tile, :, :] + 1
+            return out
+
+        x = torch.randn(4, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            partial_load,
+            (x,),
+            pallas_loop_type="outer_pipeline",
+        )
+
+        expected = torch.zeros_like(x)
+        expected[:2] = x[:2] + 1
+        torch.testing.assert_close(result, expected)
+        self.assertIn("grid=(1, 1)", code)
+        self.assertIn("mask_", code)
+        self.assertIn("load = x_vmem[:, :, :] *", code)
+
+    @skipIfPallasInterpret("Pallas interpret requires static BoundedSlice extents")
+    def test_outer_pipeline_unit_block_overlaunch_uses_zero_extent_ds(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def packed_copy_unit_block(
+            x: torch.Tensor, offsets: torch.Tensor, max_len: int
+        ) -> torch.Tensor:
+            max_len = hl.specialize(max_len)
+            out = torch.zeros_like(x)
+            for seq in hl.grid(offsets.size(0) - 1):
+                start = offsets[seq]
+                end = offsets[seq + 1]
+                for tile in hl.tile(start, end, block_size=1, max_extent=max_len):
+                    out[tile, :, :] = x[tile, :, :]
+            return out
+
+        x = torch.randn(2, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+        offsets = torch.tensor([0, 2], device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(
+            packed_copy_unit_block,
+            (x, offsets, 4),
+            pallas_loop_type="outer_pipeline",
+        )
+
+        torch.testing.assert_close(result, x)
+        emit_line = next(
+            line for line in code.splitlines() if "pltpu.emit_pipeline" in line
+        )
+        self.assertIn("grid=(1, 4)", emit_line)
+        self.assertIn("pl.BoundedSlice", emit_line)
+        self.assertIn("pl.ds(", emit_line)
+        self.assertIn("jnp.maximum(0, jnp.minimum", emit_line)
+
+    @skipIfPallasInterpret("Pallas interpret requires static BoundedSlice extents")
+    def test_outer_pipeline_multitile_overlaunch_clamps_extents_without_ds_pad(
+        self,
+    ) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def packed_copy_into(
+            x: torch.Tensor,
+            offsets: torch.Tensor,
+            out: torch.Tensor,
+            max_len: int,
+        ) -> torch.Tensor:
+            max_len = hl.specialize(max_len)
+            for seq in hl.grid(offsets.size(0) - 1):
+                start = offsets[seq]
+                end = offsets[seq + 1]
+                for tile in hl.tile(start, end, max_extent=max_len):
+                    out[tile, :, :] = x[tile, :, :]
+            return out
+
+        x = torch.randn(512, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+        offsets = torch.tensor([3, 259, 388, 390], device=DEVICE, dtype=torch.int32)
+        out = torch.full_like(x, -7.0)
+        code, result = code_and_output(
+            packed_copy_into,
+            (x, offsets, out, 256),
+            block_sizes=[128],
+            pallas_loop_type="outer_pipeline",
+        )
+
+        expected = torch.full_like(x, -7.0)
+        expected[3:390] = x[3:390]
+        torch.testing.assert_close(result, expected)
+        emit_line = next(
+            line for line in code.splitlines() if "pltpu.emit_pipeline" in line
+        )
+        self.assertIn("grid=(3, 2)", emit_line)
+        self.assertIn("jnp.maximum(0, jnp.minimum", emit_line)
+        self.assertNotIn("_ds_pad_dims", code)
+        self.assertNotIn("out_preserve_hbm", code)
+        self.assertNotIn("_outer_pipeline_preserve_arg_indices", code)
+
+    @skipIfPallasInterpret("Pallas interpret requires static BoundedSlice extents")
+    def test_outer_pipeline_outer_prologue_uses_folded_offset(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def add_sequence_bias(
+            x: torch.Tensor,
+            bias: torch.Tensor,
+            offsets: torch.Tensor,
+            max_len: int,
+        ) -> torch.Tensor:
+            max_len = hl.specialize(max_len)
+            out = torch.zeros_like(x)
+            for seq in hl.grid(offsets.size(0) - 1):
+                start = offsets[seq]
+                end = offsets[seq + 1]
+                bias_blk = bias[seq, :, :]
+                for tile in hl.tile(start, end, max_extent=max_len):
+                    out[tile, :, :] = x[tile, :, :] + bias_blk[None, :, :]
+            return out
+
+        x = torch.randn(24, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+        bias = torch.randn(3, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+        offsets = torch.tensor([0, 8, 16, 24], device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(
+            add_sequence_bias,
+            (x, bias, offsets, 8),
+            block_sizes=[8],
+            pallas_loop_type="outer_pipeline",
+        )
+
+        expected = torch.empty_like(x)
+        expected[0:8] = x[0:8] + bias[0]
+        expected[8:16] = x[8:16] + bias[1]
+        expected[16:24] = x[16:24] + bias[2]
+        torch.testing.assert_close(result, expected)
+        uncommented_code = "\n".join(
+            line for line in code.splitlines() if not line.lstrip().startswith("#")
+        )
+        self.assertIn("bias_vmem[0", uncommented_code)
+        self.assertIn("pl.BlockSpec((1, 8, 128), lambda _o0, _j", uncommented_code)
+        self.assertNotIn("bias[0, :, :]", uncommented_code)
+
+    def test_outer_pipeline_stepped_root_grid_uses_axis_step(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def copy_even_rows(x: torch.Tensor) -> torch.Tensor:
+            out = torch.zeros_like(x)
+            for row in hl.grid(0, x.size(0), 2):
+                for col in hl.tile(0, x.size(1), max_extent=x.size(1)):
+                    out[row, col, :] = x[row, col, :]
+            return out
+
+        x = torch.randn(8, 8, 128, device=DEVICE)
+        code, result = code_and_output(
+            copy_even_rows,
+            (x,),
+            block_size=8,
+            pallas_loop_type="outer_pipeline",
+        )
+
+        expected = torch.zeros_like(x)
+        expected[0::2] = x[0::2]
+        torch.testing.assert_close(result, expected)
+        uncommented_code = "\n".join(
+            line for line in code.splitlines() if not line.lstrip().startswith("#")
+        )
+        self.assertIn("0 + _o0 * 2", uncommented_code)
+        self.assertIn("pl.BoundedSlice(1)", uncommented_code)
+
+    def test_outer_pipeline_dynamic_end_without_max_extent_rejects(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def prefix_copy(x: torch.Tensor, ends: torch.Tensor) -> torch.Tensor:
+            out = torch.zeros_like(x)
+            for row in hl.tile(x.size(0)):
+                end = hl.load(ends, [0])
+                for col in hl.tile(0, end):
+                    out[row, col] = x[row, col]
+            return out
+
+        x = torch.randn(8, 128, device=DEVICE)
+        ends = torch.tensor([37], device=DEVICE, dtype=torch.int32)
+        bound = prefix_copy.bind((x, ends))
+        with self.assertRaisesRegex(
+            exc.InvalidConfig,
+            r"outer_pipeline over a data-dependent hl\.tile\(begin, end\) requires",
+        ):
+            bound.to_triton_code(
+                helion.Config(block_sizes=[8, 128], pallas_loop_type="outer_pipeline")
+            )
+
+    def test_outer_pipeline_captures_outer_dependent_prologue(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def scale_by_row(x: torch.Tensor) -> torch.Tensor:
+            out = torch.zeros_like(x)
+            for row in hl.tile(x.size(0)):
+                scale = (row.index + 1).to(torch.float32)
+                for col in hl.tile(0, x.size(1), max_extent=x.size(1)):
+                    out[row, col] = x[row, col] * scale[:, None]
+            return out
+
+        x = torch.randn(8, 128, device=DEVICE)
+        code, result = code_and_output(
+            scale_by_row,
+            (x,),
+            block_sizes=[8, 128],
+            pallas_loop_type="outer_pipeline",
+        )
+
+        expected = x * (torch.arange(8, device=DEVICE, dtype=x.dtype) + 1)[:, None]
+        torch.testing.assert_close(result, expected)
+        uncommented_code = "\n".join(
+            line for line in code.splitlines() if not line.lstrip().startswith("#")
+        )
+        self.assertIn("def _pipeline_body", uncommented_code)
+        self.assertIn("indices_0 = offset_0 + jnp.arange", uncommented_code)
+        self.assertLess(
+            uncommented_code.index("def _pipeline_body"),
+            uncommented_code.index("indices_0 = offset_0 + jnp.arange"),
+        )
+        self.assertLess(
+            uncommented_code.index("indices_0 = offset_0 + jnp.arange"),
+            uncommented_code.index("def _valid_pipeline_body"),
+        )
+
+    def test_outer_pipeline_rejects_tile_vector_prologue_tensor_access(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def add_row_bias(x: torch.Tensor, bias: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for row in hl.tile(x.size(0)):
+                bias_blk = bias[row, :, :]
+                for col in hl.tile(0, x.size(1), max_extent=x.size(1)):
+                    out[row, col, :, :] = x[row, col, :, :] + bias_blk[:, None, :, :]
+            return out
+
+        x = torch.randn(4, 32, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+        bias = torch.randn(4, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+        bound = add_row_bias.bind((x, bias))
+        with self.assertRaisesRegex(
+            exc.BackendUnsupported,
+            "Tile-vector outer indices are not supported",
+        ):
+            bound.to_triton_code(
+                helion.Config(block_sizes=[4, 16], pallas_loop_type="outer_pipeline")
+            )
+
+    def test_outer_pipeline_rejects_multiple_top_level_grids(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def two_grid_loops(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            out_x = torch.empty_like(x)
+            out_y = torch.empty_like(y)
+            for tile in hl.tile(x.size(0)):
+                out_x[tile] = x[tile]
+            for tile in hl.tile(y.size(0)):
+                out_y[tile] = y[tile]
+            return out_x, out_y
+
+        args = (torch.randn(8, device=DEVICE), torch.randn(8, device=DEVICE))
+        bound = two_grid_loops.bind(args)
+        with self.assertRaisesRegex(
+            exc.BackendUnsupported,
+            "outer_pipeline currently supports exactly one top-level grid",
+        ):
+            bound.to_triton_code(
+                helion.Config(block_sizes=[4, 4], pallas_loop_type="outer_pipeline")
+            )
+
+    def test_outer_pipeline_rejects_unsupported_prologue_tensor_slice(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def partial_prologue_slice(x: torch.Tensor) -> torch.Tensor:
+            out = torch.zeros_like(x)
+            for row in hl.grid(x.size(0)):
+                bias = x[row, 0, :, :]
+                for col in hl.tile(16):
+                    out[row, col, :, :] = x[row, col, :, :] + bias
+            return out
+
+        x = torch.randn(4, 32, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+        bound = partial_prologue_slice.bind((x,))
+        with self.assertRaisesRegex(
+            exc.BackendUnsupported,
+            "unsupported outer_pipeline prologue tensor access",
+        ):
+            bound.to_triton_code(
+                helion.Config(block_sizes=[16], pallas_loop_type="outer_pipeline")
+            )
+
+    def test_outer_pipeline_rejects_post_fold_grid_body_statement(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def post_fold_store(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for row in hl.grid(x.size(0)):
+                for col in hl.tile(x.size(1)):
+                    out[row, col, :, :] = x[row, col, :, :]
+                out[row, 0, :, :] = x[row, 0, :, :]
+            return out
+
+        x = torch.randn(4, 32, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+        bound = post_fold_store.bind((x,))
+        with self.assertRaisesRegex(
+            exc.BackendUnsupported,
+            "folded hl.tile loop to be the final statement",
+        ):
+            bound.to_triton_code(
+                helion.Config(block_sizes=[16], pallas_loop_type="outer_pipeline")
+            )
+
+    def test_outer_pipeline_rejects_pre_fold_store(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def pre_fold_store(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for row in hl.grid(x.size(0)):
+                out[row, 0, :, :] = x[row, 0, :, :]
+                for col in hl.tile(x.size(1)):
+                    out[row, col, :, :] = x[row, col, :, :]
+            return out
+
+        x = torch.randn(4, 32, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+        bound = pre_fold_store.bind((x,))
+        with self.assertRaisesRegex(
+            exc.BackendUnsupported,
+            "prologue capture only supports simple single-name assignments",
+        ):
+            bound.to_triton_code(
+                helion.Config(block_sizes=[16], pallas_loop_type="outer_pipeline")
+            )
+
+    def test_outer_pipeline_rejects_folded_store_without_folded_index(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def folded_store_alias(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for row in hl.grid(x.size(0)):
+                for col in hl.tile(x.size(1)):
+                    out[row, 0, :, :] = x[row, 0, :, :]
+            return out
+
+        x = torch.randn(4, 32, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+        bound = folded_store_alias.bind((x,))
+        with self.assertRaisesRegex(
+            exc.BackendUnsupported,
+            "folded-body stores must reference the folded hl.tile index",
+        ):
+            bound.to_triton_code(
+                helion.Config(block_sizes=[16], pallas_loop_type="outer_pipeline")
+            )
+
+    def test_outer_pipeline_rejects_folded_read_modify_write(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def folded_read_modify_write(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for row in hl.grid(x.size(0)):
+                for col in hl.tile(x.size(1)):
+                    out[row, col, :, :] = out[row, col, :, :] + x[row, col, :, :]
+            return out
+
+        x = torch.randn(4, 32, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+        bound = folded_read_modify_write.bind((x,))
+        with self.assertRaisesRegex(
+            exc.BackendUnsupported,
+            "folded-body read-modify-write stores",
+        ):
+            bound.to_triton_code(
+                helion.Config(block_sizes=[16], pallas_loop_type="outer_pipeline")
+            )
+
+    def test_outer_pipeline_rejects_folded_atomic(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def folded_atomic(x: torch.Tensor) -> torch.Tensor:
+            out = torch.zeros_like(x)
+            for row in hl.grid(x.size(0)):
+                for col in hl.tile(x.size(1)):
+                    hl.atomic_add(
+                        out,
+                        [row, col, slice(None), slice(None)],
+                        x[row, col, :, :],
+                    )
+            return out
+
+        x = torch.randn(4, 32, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+        bound = folded_atomic.bind((x,))
+        with self.assertRaisesRegex(
+            exc.BackendUnsupported,
+            "does not support atomics in the folded hl.tile body",
+        ):
+            bound.to_triton_code(
+                helion.Config(block_sizes=[16], pallas_loop_type="outer_pipeline")
+            )
+
+    def test_outer_pipeline_rejects_folded_reduction(self) -> None:
+        from helion.language._tracing_ops import _validate_outer_pipeline_folded_body
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        graph.call_function(torch.ops.aten.sum.dim_IntList, args=(x, [-1]))
+        graph_info = types.SimpleNamespace(graph=graph)
+
+        with self.assertRaisesRegex(
+            exc.BackendUnsupported,
+            "does not support reductions in the folded hl.tile body",
+        ):
+            _validate_outer_pipeline_folded_body(
+                graph_info,
+                [0],
+                None,  # type: ignore[arg-type]
+                {},
+                {},
+            )
+
+    def test_outer_pipeline_rejects_loop_carried_state(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def folded_accumulator(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            block = hl.register_block_size(x.size(1))
+            for row in hl.grid(x.size(0)):
+                acc = hl.zeros([block, 8, 128], dtype=x.dtype)
+                for col in hl.tile(x.size(1), block_size=block):
+                    acc = acc + x[row, col, :, :]
+                    out[row, col, :, :] = acc
+            return out
+
+        x = torch.randn(4, 32, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+        bound = folded_accumulator.bind((x,))
+        with self.assertRaisesRegex(
+            exc.BackendUnsupported,
+            "loop-carried state in the folded hl.tile loop",
+        ):
+            bound.to_triton_code(
+                helion.Config(block_sizes=[16], pallas_loop_type="outer_pipeline")
+            )
+
+    def test_outer_pipeline_rejects_multiple_folded_tile_loops(self) -> None:
+        @helion.kernel(backend="pallas", autotune_effort="none")
+        def two_pass_copy(
+            x: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            out_a = torch.empty_like(x)
+            out_b = torch.empty_like(x)
+            for row in hl.grid(x.size(0)):
+                for col in hl.tile(x.size(1)):
+                    out_a[row, col, :, :] = x[row, col, :, :]
+                for col in hl.tile(x.size(1)):
+                    out_b[row, col, :, :] = x[row, col, :, :] * 2.0
+            return out_a, out_b
+
+        x = torch.randn(4, 32, 8, 128, device=DEVICE, dtype=torch.bfloat16)
+        bound = two_pass_copy.bind((x,))
+        with self.assertRaisesRegex(exc.BackendUnsupported, "one folded hl.tile loop"):
+            bound.to_triton_code(
+                helion.Config(
+                    block_sizes=[16, 16],
+                    pallas_loop_type="outer_pipeline",
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This work builds on #2687 to add a Pallas `pallas_loop_type = 'outer_pipeline'` that folds a top-level `hl.grid` axis and one nested `hl.tile` axis into a single `pltpu.emit_pipeline` launch. It modifies the approach by first gathering all the context from the loops before constructing an emit_pipeline object instead of rewriting the grid code.

We target a pattern with outer work partition expressed with `hl.grid`, followed by one or more tiled inner dimensions expressed with `hl.tile`. The outer grid chooses an independent problem instance, group, batch, segment, or ragged row range. The nested tile loop chooses the block of work within that instance. This is relevant for jagged attention, grouped gemm and jagged bmm type kernels.

The current PR implements the stateless/parallel version of this pattern:

```python
for group in hl.grid(num_groups):
    begin = offsets[group]
    end = offsets[group + 1]
    for tile in hl.tile(begin, end, block_size=BLOCK, max_extent=MAX_BLOCK):
        out[group, tile, ...] = compute(inputs[group, tile, ...])
```

With `pallas_loop_type = 'outer_pipeline'` we get large improvements in performance (jagged gpda dense kv):

| mode | emit_pipeline | outer_pipeline | speedup | max_err |
|:---|---:|---:|---:|---:|
| uniform | 6.682 ms | **2.527 ms** | 2.64x | 0.0 |
| ramp | 5.308 ms | **2.616 ms** | 2.03x | 0.0 |
| half, min_len=8 | 5.026 ms | **2.568 ms** | 1.96x | 0.0 |

As alluded to above, we need a (slightly) new language feature, a 'max_extent' for hl.tile:
```python
for tile in hl.tile(begin, end, block_size=BLOCK, max_extent=MAX_BLOCK):
```

A follow up PR and the final goal is to handle the a stateful/ordered version of the pattern:

```python
for group in hl.grid(num_groups):
    m_begin = m_offsets[group]
    m_end = m_offsets[group + 1]
    k_begin = k_offsets[group]
    k_end = k_offsets[group + 1]
    for m_tile in hl.tile(m_begin, m_end, block_size=BLOCK_M, max_extent=MAX_M):
        acc = init_accumulator(...)
        for k_tile in hl.tile(k_begin, k_end, block_size=BLOCK_K, max_extent=MAX_K):
            acc = update(acc, lhs[group, m_tile, k_tile], rhs[group, k_tile, ...])
        out[group, m_tile, ...] = finalize(acc)
```
This is what's needed for fully jagged gpda, jagged flash attention, and grouped_gemm.

The key abstraction behind this is a `PipelineAxis` model. Instead of treating the original root grid and the folded inner tile as separate lowering concepts, outer pipeline lowering normalizes both into a list of axes that describe the final `emit_pipeline` grid.

The key classification is whether an axis is `parallel` or `ordered`:
- `parallel` means each coordinate of that axis is independent from the others. There is no loop-carried state across the axis, and stores are disjoint per tile. These axes map to `dimension_semantics="parallel"` and can be freely scheduled by `emit_pipeline`. Examples are segment/group axes, batch axes, independent M/N output tiles, or a jagged row/query tile where each tile writes its own output slice.
- `ordered` means the axis has a recurrence or finalization dependency across tiles. The common shape is an accumulator such as `acc = update(acc, tile)` followed by a store after the last tile. These axes map to `dimension_semantics="arbitrary"` because the pipeline must preserve the logical order for that axis. Examples are K tiles in grouped GEMM, reduction tiles in jagged BMM, KV tiles in fully jagged GDPA, and the streaming/reduction axis in flash-style attention.

This PR only supports `parallel` but a follow up PR will enable `ordered`.

Here's the lowering flow:
1. The user selects `pallas_loop_type="outer_pipeline"`.

2. When the top-level `hl.grid` is lowered, `TileStrategy.codegen_grid()` dispatches to `_codegen_outer_pipeline_grid()` instead of emitting ordinary Pallas program IDs.

   This creates a `PipelineContext` in `CompileEnvironment.outer_pipeline_context`.

   For each root grid dimension, it creates a `PipelineAxis` containing:

   - the Helion block id
   - `kind="parallel"`
   - begin/end/step/block extent
   - static pipeline-grid extent
   - the BlockSpec lambda parameter, e.g. `_o0`
   - the original pid/offset/index variable names

   It also records prologue statements that reconstruct the original `pid`, `offset`, `index`, and mask variables from `_pipeline_indices[...]` inside the eventual pipeline body.

3. Normal lowering then continues through the grid body.

   Statements before the folded `hl.tile` loop are captured as pipeline prologue. Simple scalar assignments are recorded so they can be replayed in the pipeline body and also inlined into BlockSpec lambdas. This is what lets bounds like `start = offsets[seq]` be used safely inside generated BlockSpecs.

4. When the nested `hl.tile` reaches `_codegen_emit_pipeline()`, the existing emit-pipeline lowering switches into outer-pipeline mode because `env.outer_pipeline_context` is set.

   At this point the lowering:

   - stops prologue capture
   - rejects a second folded tile loop
   - rejects loop-carried state for this first PR (TODO: capture this as an ordered axis)
   - computes static `max_tiles` for the folded tile from the loop extent or `hl.tile(..., max_extent=...)`
   - adds another `PipelineAxis` for the folded tile, usually with lambda parameter `_j`

   The resulting pipeline grid is just:

   ```python
   outer_context.grid_parts
   ```

   so for example

   ```python
   grid = (seq_tiles, q_tiles)
   dimension_semantics = ("parallel", "parallel")
   ```

5. The folded loop body is validated before codegen.

   The first PR keeps this conservative. It rejects:

   - atomics
   - HBM read-modify-write
   - reductions inside the folded body (TODO: allow structured ordered-axis reductions)
   - loop-carried state (TODO: allow VMEM scratch carry for ordered axes)
   - stores that do not reference the folded output axis
   - unsupported prologue tensor reads
   - non-pipelined folded-loop tensor accesses

6. Tensor accesses are classified into emit-pipeline inputs and outputs.

   For each pipelined tensor, `_make_block_spec()` builds a Pallas `BlockSpec` by asking the `PipelineContext` which `PipelineAxis` owns each tensor dimension.

   The important part is that BlockSpec generation no longer has separate "outer" and "inner" special cases. For an axis-backed dimension it uses:

   ```python
   raw_start = axis.begin + axis.lambda_param * axis.step
   ```

   Then it chooses either:

   - compact block-index form for static full, divisible dimensions
   - `pl.BoundedSlice(...)` plus clamped `pl.ds(start, extent)` for jagged, partial, or overlaunched dimensions

   Lambda rendering goes through `PipelineContext.resolve_for_lambda()`, which substitutes pid/offset variables with lambda-scope expressions and inlines captured scalar prologue assignments.

7. The pipeline body function is generated.

   The body takes `_pipeline_indices` plus the VMEM refs produced by `emit_pipeline`.

   Its prologue reconstructs the original grid/tile variables, emits masks, replays captured scalar prologue statements, and remaps any supported prologue tensor reads to VMEM refs. Then the original folded loop graph is emitted against those VMEM refs through the existing `EmitPipelineLoopState` machinery.

   For overlaunched tiles, the real body statements are wrapped in a validity guard:

   ```python
   lax.cond(valid_tile, real_body, empty_body)
   ```

   Loads also keep conservative masking for invalid tail lanes. Reductions are rejected for now because masking only the load is not enough for arbitrary lane mixing.

8. Finally `_codegen_emit_pipeline()` emits one generated Pallas call:

   ```python
   pltpu.emit_pipeline(
       body_fn,
       grid=(...outer axes..., ...folded tile axes...),
       in_specs=[...],
       out_specs=[...],
       _explicit_indices=True,
       dimension_semantics=outer_context.dimension_semantics,
   )(...)
   ```