### PR TITLE
Cache CUDA device capability lookups on the kernel dispatch hot path

### DIFF
--- a/helion/_compat.py
+++ b/helion/_compat.py
@@ -353,11 +353,22 @@ def target_device_capability(
     """Return CUDA compute capability, or None for non-CUDA/unavailable targets."""
     if device is not None and device.type != "cuda":
         return None
+    if device is not None and device.index is not None:
+        return _target_device_capability(device.index)
     if not torch.cuda.is_available():
         return None
-    if device is None:
-        return torch.cuda.get_device_capability(torch.cuda.current_device())
-    return torch.cuda.get_device_capability(device)
+    # device=None means the current device; resolve it per call so a later
+    # set_device is not frozen under one cache key.
+    return _target_device_capability(torch.cuda.current_device())
+
+
+@functools.cache
+def _target_device_capability(index: int) -> tuple[int, int] | None:
+    # Memoize per index (capability is fixed per device). Tests patch the
+    # public wrapper above, mirroring is_hip / _is_hip.
+    if not torch.cuda.is_available():
+        return None
+    return torch.cuda.get_device_capability(index)
 
 
 def min_dot_size(

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -1863,11 +1863,32 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         with (
             patch_cute_mma_support(),
             patch("torch.cuda.get_device_capability", return_value=(10, 0)),
+            # target_device_capability is memoized (is_hip / _is_hip pattern),
+            # so torch.cuda.get_device_capability alone no longer reaches its
+            # consumers. Patch each seam the bind path reads: the bound-kernel
+            # cache key (runtime.kernel) and the ConfigSpec arch capability,
+            # which CompileEnvironment captures onto config_spec at build time.
+            patch(
+                "helion.runtime.kernel.target_device_capability",
+                return_value=(10, 0),
+            ),
+            patch(
+                "helion._compiler.compile_environment.target_device_capability",
+                return_value=(10, 0),
+            ),
         ):
             bound = cute_matmul_bias_residual_gelu.bind(args)
         with (
             patch_cute_mma_support(),
             patch("torch.cuda.get_device_capability", return_value=(9, 0)),
+            patch(
+                "helion.runtime.kernel.target_device_capability",
+                return_value=(9, 0),
+            ),
+            patch(
+                "helion._compiler.compile_environment.target_device_capability",
+                return_value=(9, 0),
+            ),
         ):
             sm90_bound = cute_matmul_bias_residual_gelu.bind(args)
         self.assertIsNot(sm90_bound, bound)

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -144,14 +144,17 @@ class TestConfigAPI(TestCase):
             pass
 
         device = torch.device("cuda:0")
-        with (
-            patch("torch.cuda.is_available", return_value=True),
-            patch("torch.cuda.get_device_capability", return_value=(9, 0)),
+        # Patch the helion seam (target_device_capability, imported into
+        # runtime.kernel) rather than torch.cuda.get_device_capability: the
+        # latter is memoized behind _target_device_capability, mirroring the
+        # is_hip / _is_hip pattern where tests mock the public wrapper, not
+        # the cached inner query.
+        with patch(
+            "helion.runtime.kernel.target_device_capability", return_value=(9, 0)
         ):
             sm90_key = device_key_kernel._base_specialization_key((device,))
-        with (
-            patch("torch.cuda.is_available", return_value=True),
-            patch("torch.cuda.get_device_capability", return_value=(10, 0)),
+        with patch(
+            "helion.runtime.kernel.target_device_capability", return_value=(10, 0)
         ):
             sm100_key = device_key_kernel._base_specialization_key((device,))
 
@@ -874,7 +877,14 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
         with (
             patch("torch.cuda.is_available", return_value=True),
             patch("torch.cuda.current_device", return_value=0),
-            patch("torch.cuda.get_device_capability", return_value=(9, 0)),
+            # Patch the helion seam: torch.cuda.get_device_capability is
+            # memoized behind _target_device_capability (is_hip / _is_hip
+            # pattern), so config_spec's get_target_device_capability() must
+            # be patched at the wrapper, not the cached torch query.
+            patch(
+                "helion.autotuner.config_spec.get_target_device_capability",
+                return_value=(9, 0),
+            ),
         ):
             spec = self._make_cute_tcgen05_spec()
 


### PR DESCRIPTION
Stacked PRs:
 * #2749
 * #2759
 * #2752
 * __->__#2746


--- --- ---

### Cache CUDA device capability lookups on the kernel dispatch hot path


Every Helion kernel call recomputes the bound-kernel cache key, which
includes the device's compute capability via target_device_capability().
That function called torch.cuda.is_available() plus
torch.cuda.get_device_capability() on every single kernel launch,
costing ~2.8us/call of pure Python/CUDA-runtime overhead -- the single
largest line item in Helion-side dispatch.

A physical device's compute capability cannot change within a process,
so the lookup is memoized per device index, following the existing
is_hip / _is_hip split in this file: the public
target_device_capability is a thin wrapper, and the @functools.cache
lives on a private _target_device_capability(index) helper. A concrete
device index goes straight to the cache, so the steady-state hot path
makes no torch.cuda calls at all. device=None means the *current*
device (which moves with torch.cuda.set_device); it is resolved to a
concrete index per call before the cached lookup, so it is never frozen
under a single key. The availability check lives inside the cached
helper (like _is_hip), so an unavailable runtime caches None and a warm
device skips the ~2us is_available() probe entirely.

Tests that simulate other architectures now patch the helion seam
(target_device_capability / its get_target_device_capability alias in
config_spec) instead of torch.cuda.get_device_capability, exactly as
tests mock is_hip rather than the cached _is_hip. Two such tests are
updated: test_config_api's sm90-vs-sm100 cache-key test and the direct
CuTe arch-gate test.

Benchmark (B200, end-to-end wall time per call, add-style kernel,
N=4096 fp32, HELION_AUTOTUNE_EFFORT=none, steady state, 20k iters):

```
  n_args |   before |    after |  delta
  -------+----------+----------+-------
       2 | 24.14 us | 18.78 us |   -22%
       8 | 33.05 us | 27.77 us |   -16%
      16 | 43.56 us | 36.90 us |   -15%
```

Benchmark script (used for this and the follow-up launch-overhead
commits; wall-clock around the Python call deliberately captures
CPU-side dispatch cost, which CUDA-event timing excludes -- the kernel
is tiny, so the loop is CPU-bound and measures per-call issue cost):

```python
import os, sys
os.environ.setdefault("HELION_AUTOTUNE_EFFORT", "none")
import time, torch, helion, helion.language as hl

# Write kernels to a real module file: helion needs
# inspect.getsource, so exec()'d kernels don't work.
mod_src = ["import torch, helion, helion.language as hl\n"]
for n_args in (2, 8, 16):
    src_args = ", ".join(f"t{i}" for i in range(n_args))
    mod_src.append(f'''
@helion.kernel(config=helion.Config(block_sizes=[128], num_warps=4, num_stages=2))
def k{n_args}({src_args}):
    out = torch.empty_like(t0)
    for tile in hl.tile(t0.size(0)):
        out[tile] = {' + '.join(f't{i}[tile]' for i in range(n_args))}
    return out
''')
open("/tmp/bench_kernels.py", "w").write("\n".join(mod_src))
sys.path.insert(0, "/tmp")
import bench_kernels

def bench(n_args, n=20000):
    k = getattr(bench_kernels, f"k{n_args}")
    ts = [torch.randn(4096, device="cuda") for _ in range(n_args)]
    for _ in range(50):  # warmup: compile + prime launcher
        k(*ts)
    torch.cuda.synchronize()
    t0 = time.perf_counter()
    for _ in range(n):
        k(*ts)
    dt = (time.perf_counter() - t0) / n * 1e6
    torch.cuda.synchronize()
    return dt

for n_args in (2, 8, 16):
    print(f"n_args={n_args:3d}: {bench(n_args):6.2f} us/call")
```

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
