### PR TITLE
Use plain tuple keys for the in-memory bound-kernel cache

### DIFF
--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -185,7 +185,10 @@ class Kernel(Generic[_R]):
             Config(**config) if isinstance(config, dict) else config
             for config in configs or []
         ]
-        self._bound_kernels: dict[BoundKernelInMemoryCacheKey, BoundKernel] = {}
+        # Keyed by ``(signature, extra_results)`` tuples — the tuple form of
+        # ``BoundKernelInMemoryCacheKey``, kept plain for cheap per-call
+        # construction in ``bind``.
+        self._bound_kernels: dict[Hashable, BoundKernel] = {}
         self._specialize_extra: dict[
             Hashable, list[Callable[[Sequence[object]], Hashable]]
         ] = {}
@@ -226,13 +229,15 @@ class Kernel(Generic[_R]):
 
     def _get_bound_kernel_cache_key(
         self, args: tuple[object, ...], signature: tuple[Hashable, ...]
-    ) -> BoundKernelInMemoryCacheKey | None:
-        from ..autotuner.base_cache import BoundKernelInMemoryCacheKey
-
+    ) -> tuple[Hashable, ...] | None:
+        # Plain tuples keep the per-call dispatch path free of dataclass
+        # construction; `_create_bound_kernel_cache_key` provides the
+        # `BoundKernelInMemoryCacheKey` form for the autotuner caches.
         extra_fns = self._specialize_extra.get(signature)
         if extra_fns is not None:
-            extra_results: tuple[Hashable, ...] = tuple([s(args) for s in extra_fns])
-            return BoundKernelInMemoryCacheKey(signature, extra_results)
+            if extra_fns:
+                return (signature, tuple([s(args) for s in extra_fns]))
+            return (signature, ())
         return None
 
     def _create_bound_kernel_cache_key(
@@ -278,9 +283,10 @@ class Kernel(Generic[_R]):
                 else:
                     bound_kernel = BoundKernel(self, args)
                 if cache_key is None:
-                    cache_key = self._create_bound_kernel_cache_key(
+                    full_key = self._create_bound_kernel_cache_key(
                         bound_kernel, args, signature
                     )
+                    cache_key = (full_key.specialization_key, full_key.extra_results)
                 self._bound_kernels[cache_key] = bound_kernel
             return bound_kernel
 


### PR DESCRIPTION
Stacked PRs:
 * #2749
 * #2748
 * #2752
 * __->__#2747
 * #2746


--- --- ---

### Use plain tuple keys for the in-memory bound-kernel cache


Kernel.bind runs on every kernel call and the cache *hit* is the
steady state, so the per-call lookup key should be as cheap to build
as possible.

_get_bound_kernel_cache_key constructed a frozen-dataclass
BoundKernelInMemoryCacheKey on every call: a lazy
`from ..autotuner.base_cache import ...` import, a dataclass __init__,
two frozen-field object.__setattr__ overrides, and a generated
__hash__ that re-walks the fields. The in-memory _bound_kernels dict
only needs *some* hashable key, so the per-call path now uses the
equivalent plain (signature, extra_results) tuple. In isolation this
drops _get_bound_kernel_cache_key from ~0.93us to ~0.22us per call.

The dataclass form is still produced by _create_bound_kernel_cache_key
for the autotuner caches (LocalAutotuneCache / AOTAutotuneCache
subclass it into LooseAutotuneCacheKey); only the in-memory dict
switches to tuple keys. On the compile (cache-miss) path the dataclass
key is built once and unpacked into its (specialization_key,
extra_results) tuple form so the in-memory dict and the autotuner
caches stay keyed on the same value.

Also drops one extra-results tuple allocation when a kernel has no
hl.specialize() extras (the common case): the empty extra_fns list
short-circuits to a shared () literal instead of tuple([]).

Safety: cache-key *contents* are unchanged -- same signature tuple,
same extra results, same specialization axes (dtype, shape bucket,
device type+capability, ConstExpr values, key= fn, hl.specialize
extras); the tuple is just the dataclass's two fields in order, with
identical hash/equality. Verified by test_misc, test_config_api,
test_cache, test_specialize (132 passed), plus
dtype/shape/ConstExpr/specialize rebinding spot-checks.

Benchmark (B200, end-to-end wall time per call, add-style kernel,
N=4096 fp32, HELION_AUTOTUNE_EFFORT=none, steady state, 20k iters):

```
  n_args | baseline | prev commit | this commit
  -------+----------+-------------+------------
       2 | 24.14 us |    18.78 us |    16.41 us
       8 | 33.05 us |    27.77 us |    24.78 us
      16 | 43.56 us |    36.90 us |    35.24 us
```

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
