### PR TITLE
Install a per-spec fast launcher that bypasses Triton's JITFunction.run

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1332,7 +1332,17 @@ class TritonBackend(Backend):
             f"tl.full([{', '.join(shape_dims)}], {value_expr}, {self.dtype_str(dtype)})"
         )
 
-    def launcher_keyword_args(self, config: Config, *, has_barrier: bool) -> list[str]:
+    def launcher_runtime_kwargs(
+        self, config: Config, *, has_barrier: bool
+    ) -> dict[str, object]:
+        """Return the launcher kwargs as a ``dict`` of runtime values.
+
+        Used by both :meth:`launcher_keyword_args` (which formats the dict
+        as source strings for codegen) and
+        :func:`helion.runtime.build_fast_launcher` (which bakes the dict
+        into a closure at :meth:`BoundKernel.set_config` time so the hot
+        launch path doesn't have to allocate a per-call kwargs dict).
+        """
         from .._compat import supports_maxnreg
 
         # Workaround for triton bug: warp_specialize requires at least 4 warps
@@ -1341,31 +1351,45 @@ class TritonBackend(Backend):
         if any(config.range_warp_specializes):
             num_warps = max(4, num_warps)
 
-        args = [
-            f"num_warps={num_warps}",
-            f"num_stages={config.num_stages}",
-            *(["launch_cooperative_grid=True"] if has_barrier else []),
-        ] + [
-            f"{x.removeprefix('_triton_config_')}={config[x]}"
-            for x in config
-            if x.startswith("_triton_config_")
-        ]
+        kwargs: dict[str, object] = {
+            "num_warps": num_warps,
+            "num_stages": config.num_stages,
+        }
+        if has_barrier:
+            kwargs["launch_cooperative_grid"] = True
+        for x in config:
+            if x.startswith("_triton_config_"):
+                kwargs[x.removeprefix("_triton_config_")] = config[x]
 
         from ..autotuner.config_spec import _get_backend_tunable_keys
 
         for key in _get_backend_tunable_keys():
             if key in config:
-                args.append(f"{key}={config[key]!r}")
+                kwargs[key] = config[key]
 
         if "maxnreg" in config and config["maxnreg"] is not None and supports_maxnreg():
-            args.append(f"maxnreg={config['maxnreg']}")
+            kwargs["maxnreg"] = config["maxnreg"]
 
         advanced_controls_file = config.advanced_controls_file
         if advanced_controls_file:
-            ptx_option = f"--apply-controls {advanced_controls_file}"
-            args.append(f"ptx_options={ptx_option!r}")
+            kwargs["ptx_options"] = f"--apply-controls {advanced_controls_file}"
 
-        return args
+        return kwargs
+
+    def launcher_keyword_args(self, config: Config, *, has_barrier: bool) -> list[str]:
+        from ..autotuner.config_spec import _get_backend_tunable_keys
+
+        backend_tunable_keys = _get_backend_tunable_keys()
+        kwargs = self.launcher_runtime_kwargs(config, has_barrier=has_barrier)
+        # Backend tunable keys (typically strings) and ptx_options use repr;
+        # everything else (num_warps, num_stages, ints, bools) renders plain.
+        out: list[str] = []
+        for k, v in kwargs.items():
+            if k in backend_tunable_keys or k == "ptx_options":
+                out.append(f"{k}={v!r}")
+            else:
+                out.append(f"{k}={v}")
+        return out
 
     def grid_barrier_stmt(self, sem_arg: str) -> str:
         return f"triton_helpers.x_grid_barrier({sem_arg})"

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -25,6 +25,9 @@ from .._compiler.cute.strategies import tcgen05_default_epilogue_tile_expr
 from .._compiler.cute.strategies import tcgen05_explicit_d_store_tile_expr
 from .._compiler.cute.strategies import tcgen05_smem_layout_expr
 from .._utils import triton_is_available
+from ._fast_launcher import _FastLauncher as _FastLauncher
+from ._fast_launcher import build_fast_launcher as build_fast_launcher
+from ._fast_launcher import default_launcher as default_launcher
 from .config import Config as Config
 from .kernel import Kernel as Kernel
 from .kernel import kernel as kernel
@@ -157,40 +160,6 @@ def get_num_sm(device: torch.device, *, reserved_sms: int = 0) -> int:
     if reserved_sms <= 0:
         return available_sms
     return max(available_sms - reserved_sms, 1)
-
-
-def default_launcher(
-    triton_kernel: object,
-    grid: tuple[int, ...],
-    *args: object,
-    num_warps: int,
-    num_stages: int,
-    ptx_options: str | None = None,
-    launch_cooperative_grid: bool = False,
-    **kwargs: dict,
-) -> object:
-    """Default launcher function that executes the kernel immediately."""
-    # For both CUDA and MTIA, use the same kernel execution
-    run_kwargs: dict = {
-        "grid": grid,
-        "warmup": False,
-        "num_warps": num_warps,
-        "num_stages": num_stages,
-        "launch_cooperative_grid": launch_cooperative_grid,
-        **kwargs,
-    }
-    if ptx_options is not None:
-        run_kwargs["ptx_options"] = ptx_options
-    try:
-        return triton_kernel.run(  # type: ignore[union-attr]
-            *args,
-            **run_kwargs,
-        )
-    except Exception as error:
-        message = str(error)
-        if "Cannot make_shape_compatible: incompatible dimensions" in message:
-            raise exc.ShapeMismatch("kernel operands", message) from error
-        raise
 
 
 def _pallas_make_block_spec(

--- a/helion/runtime/_fast_launcher.py
+++ b/helion/runtime/_fast_launcher.py
@@ -1,0 +1,581 @@
+"""Per-spec fast launcher that bypasses Triton's ``JITFunction.run``.
+
+Public entry points re-exported from :mod:`helion.runtime`:
+
+* :func:`default_launcher` — Triton's full per-call pipeline. Used as
+  the fallback when the fast path can't (or shouldn't) engage, and as
+  the codegen wrapper's ``_launcher`` kwdefault before
+  :meth:`BoundKernel.set_config` installs a fast launcher.
+* :class:`_FastLauncher` — closure that caches Triton's per-call
+  bookkeeping across multiple ``_spec`` keys.
+* :func:`build_fast_launcher` — factory used by
+  ``BoundKernel._install_fast_launcher``.
+
+The ``_FastLauncher`` docstring explains the multi-spec cache and
+which parts of Triton's per-call pipeline it skips.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING
+
+import torch
+
+from .. import exc
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Hashable
+
+
+def default_launcher(
+    triton_kernel: object,
+    grid: tuple[int, ...],
+    *args: object,
+    num_warps: int,
+    num_stages: int,
+    ptx_options: str | None = None,
+    launch_cooperative_grid: bool = False,
+    **kwargs: dict,
+) -> object:
+    """Default launcher function that executes the kernel immediately."""
+    # For both CUDA and MTIA, use the same kernel execution
+    run_kwargs: dict = {
+        "grid": grid,
+        "warmup": False,
+        "num_warps": num_warps,
+        "num_stages": num_stages,
+        "launch_cooperative_grid": launch_cooperative_grid,
+        **kwargs,
+    }
+    if ptx_options is not None:
+        run_kwargs["ptx_options"] = ptx_options
+    try:
+        return triton_kernel.run(  # type: ignore[union-attr]
+            *args,
+            **run_kwargs,
+        )
+    except Exception as error:
+        message = str(error)
+        if "Cannot make_shape_compatible: incompatible dimensions" in message:
+            raise exc.ShapeMismatch("kernel operands", message) from error
+        raise
+
+
+class _SpecEntry:  # noqa: B903 - explicit __slots__ for hot-path attribute access
+    """Per-Triton-spec compiled-kernel state.
+
+    One instance lives in ``_FastLauncher._spec_cache`` for each distinct
+    Triton specialization (pointer alignment + scalar specialization +
+    binary-affecting knob state) we have ever launched. Each entry holds
+    everything the C launcher needs plus a snapshot of
+    ``used_global_vals`` taken at compile time for this binary.
+    """
+
+    __slots__ = (
+        "compiled_run",
+        "kernel_launch_metadata",
+        "packed_metadata",
+        "triton_function",
+        "used_global_checks",
+    )
+
+    def __init__(
+        self,
+        *,
+        compiled_run: Callable[..., object],
+        triton_function: object,
+        packed_metadata: object,
+        kernel_launch_metadata: Callable[..., object],
+        used_global_checks: tuple[tuple[dict, str, object], ...],
+    ) -> None:
+        self.compiled_run = compiled_run
+        self.triton_function = triton_function
+        self.packed_metadata = packed_metadata
+        self.kernel_launch_metadata = kernel_launch_metadata
+        self.used_global_checks = used_global_checks
+
+
+class _FastLauncher:
+    """Multi-spec fast launcher that bypasses Triton's ``JITFunction.run``.
+
+    The first call primes the launcher: captures Triton's active driver,
+    device, knob namespaces, and identifies which positional args are
+    tensor pointers and which are value-specialized int scalars (so we
+    can compute both specializations inline on every subsequent call
+    instead of invoking Triton's binder).
+
+    Every call computes a tiny *spec key* — alignment bits + int-scalar
+    specialization buckets + the binary-affecting knob state (``debug``,
+    ``instrumentation_mode``, ``add_stages_inspection_hook``) — and
+    dict-looks-up a cached :class:`_SpecEntry`. On hit, dispatches
+    straight into the C launcher. On miss, compiles (via Triton) for
+    that spec, caches the resulting entry, and dispatches.
+
+    Helion's :class:`BoundKernel` already specializes on the *Helion*
+    axes (dtype, shape, stride, device type), so the only per-call
+    specialization left to Triton is pointer alignment, int-scalar
+    value specialization (``== 1`` constant-fold + divisibility-by-16),
+    and per-call knob state — which we encode in the spec key.
+
+    Compared to a full ``JITFunction.run`` round-trip we skip:
+    * Triton's binder (we compute alignment inline ~6x cheaper)
+    * ``compute_cache_key`` + ``kernel_cache.get`` (replaced by a tuple
+      hash + dict lookup on our own ``_spec_cache``)
+    * The always-on ``kernel.launch_metadata`` call when no profiler
+      hooks are attached
+    * The whole ``JITFunction.run`` Python frame, kwargs munging, and
+      per-call device/binder unpacks.
+
+    If priming or any per-spec compile fails, we transparently fall
+    back to :func:`default_launcher` for that launch so the kernel
+    still runs.
+    """
+
+    __slots__ = (
+        "_active_driver",
+        "_device",
+        "_get_current_stream",
+        "_init_failed",
+        "_knobs_compilation",
+        "_knobs_runtime",
+        "_launch_cooperative_grid",
+        "_num_warps",
+        "_num_stages",
+        "_prime_lock",
+        "_primed",
+        "_ptx_options",
+        "_run_kwargs",
+        "_spec_cache",
+        "_int_arg_specs",
+        "_tensor_arg_indices",
+    )
+
+    def __init__(
+        self,
+        *,
+        num_warps: int,
+        num_stages: int,
+        launch_cooperative_grid: bool = False,
+        ptx_options: str | None = None,
+        extra_kwargs: dict | None = None,
+    ) -> None:
+        self._num_warps = num_warps
+        self._num_stages = num_stages
+        self._launch_cooperative_grid = launch_cooperative_grid
+        self._ptx_options = ptx_options
+        # Pre-built kwargs dict for warmup AND the fallback path. Stored
+        # once so the hot path doesn't have to build a fresh kwargs dict
+        # per launch.
+        run_kwargs: dict = {
+            "num_warps": num_warps,
+            "num_stages": num_stages,
+            "launch_cooperative_grid": launch_cooperative_grid,
+        }
+        if extra_kwargs:
+            run_kwargs.update(extra_kwargs)
+        if ptx_options is not None:
+            run_kwargs["ptx_options"] = ptx_options
+        self._run_kwargs = run_kwargs
+
+        # Serializes both the one-time priming (see :meth:`_prime`) AND
+        # the per-spec compile-on-miss in :meth:`__call__`. Concurrent
+        # first-of-spec callers must not redundantly compile, so they
+        # use double-checked locking against ``_spec_cache``.
+        self._prime_lock = threading.Lock()
+        # Per-launcher state, set once by :meth:`_prime` on the first call.
+        self._primed = False
+        self._init_failed = False
+        self._active_driver: object = None
+        self._device: object = None
+        self._get_current_stream: Callable[[object], object] | None = None
+        self._knobs_runtime: object = None
+        self._knobs_compilation: object = None
+        # Positions of ``*args`` that are torch.Tensor pointers — used by
+        # the hot path to compute the alignment portion of the spec key
+        # without invoking Triton's binder.
+        self._tensor_arg_indices: tuple[int, ...] = ()
+        # ``(arg_index, specialize_on_alignment)`` for every positional
+        # int arg Triton *value*-specializes (``== 1`` constant-fold +
+        # divisibility-by-16). Walked by the hot path to fold scalar
+        # specialization into the spec key — without it, a binary
+        # compiled for one scalar value (e.g. the constant-folded
+        # ``s == 1``) would be silently reused for another.
+        self._int_arg_specs: tuple[tuple[int, bool], ...] = ()
+        # Per-spec compiled-kernel cache, keyed on ``(align_bits,
+        # int_buckets, debug, instrumentation_mode, stages_hook_id)``.
+        # Each entry is a :class:`_SpecEntry` holding the compiled
+        # binary's ``run``, function handle, packed metadata,
+        # launch_metadata builder, and ``used_global_vals`` snapshot.
+        self._spec_cache: dict[Hashable, _SpecEntry] = {}
+
+    def _prime(self, triton_kernel: object, args: tuple[object, ...]) -> None:
+        """One-time launcher setup. Captures driver/knob references and
+        identifies which positional args are tensor pointers.
+
+        Called once on the first invocation, under ``self._prime_lock``.
+        Also runs Triton's binder ONCE to verify that
+        ``tuple(bound_args.values()) == args`` (so we can pass ``args``
+        directly to the C launcher in every subsequent call, skipping
+        the binder entirely on the hot path).
+
+        On any failure we set ``_init_failed = True`` so subsequent
+        calls fall through to :func:`default_launcher`. ``_primed=True``
+        is set last via the outer ``finally`` so any caller waiting on
+        the prime lock sees either fully-published state or a clean
+        ``_init_failed=True`` sentinel — never a half-written mix.
+        """
+        try:
+            try:
+                import triton
+                from triton.runtime.driver import driver
+            except ImportError:
+                self._init_failed = True
+                return
+
+            try:
+                active_driver = driver.active
+                # pyrefly: ignore[missing-attribute]
+                device = active_driver.get_current_device()
+                # Unpack mirrors jit.py:720; we consume only the binder
+                # for the one-time bind-skip-safe probe below.
+                (
+                    _kernel_cache,
+                    _kernel_key_cache,
+                    _target,
+                    _backend,
+                    binder,
+                    # pyrefly: ignore[missing-attribute]
+                ) = triton_kernel.device_caches[device]
+                # Verify that ``tuple(bound_args.values()) == args``. This
+                # has to hold for every call we want to keep on the fast
+                # path, since the hot path passes ``args`` straight to
+                # the C launcher without re-invoking the binder. Helion's
+                # generated wrapper hands the launcher the kernel's
+                # positional args in declaration order, so this is the
+                # common case; if it doesn't hold for *this* kernel
+                # signature, we permanently fall back.
+                bound_args, _spec, _opts = binder(*args, **self._run_kwargs)
+                bound_values = tuple(bound_args.values())
+                if not (
+                    len(bound_values) == len(args)
+                    and all(b is a for b, a in zip(bound_values, args, strict=True))
+                ):
+                    self._init_failed = True
+                    return
+
+                # Per-launcher state — constant across every launch.
+                tensor_indices = tuple(
+                    i for i, a in enumerate(args) if isinstance(a, torch.Tensor)
+                )
+                # Identify positional int args Triton *value*-specializes,
+                # mirroring ``create_function_from_signature`` (jit.py): a
+                # param is value-specialized unless it is ``constexpr``,
+                # ``do_not_specialize``, or annotated as a float/bool type.
+                # ``bool`` is excluded explicitly — Triton maps it to
+                # ``u1`` (not constant-folded) even though ``True == 1`` in
+                # Python. The alignment (divisibility-by-16) portion is
+                # dropped when ``do_not_specialize_on_alignment`` is set.
+                # pyrefly: ignore[missing-attribute]
+                params = getattr(triton_kernel, "params", None)
+                int_arg_specs: list[tuple[int, bool]] = []
+                if params is not None:
+                    for i, a in enumerate(args):
+                        if type(a) is not int or i >= len(params):
+                            continue
+                        p = params[i]
+                        if getattr(p, "is_constexpr", False) or getattr(
+                            p, "do_not_specialize", False
+                        ):
+                            continue
+                        ann = getattr(p, "annotation_type", None)
+                        if isinstance(ann, str) and (
+                            ann == "u1" or ann[:2] in ("fp", "bf")
+                        ):
+                            continue
+                        align = not getattr(p, "do_not_specialize_on_alignment", False)
+                        int_arg_specs.append((i, align))
+                self._active_driver = active_driver
+                self._device = device
+                # pyrefly: ignore[missing-attribute]
+                self._get_current_stream = active_driver.get_current_stream
+                self._knobs_runtime = triton.knobs.runtime
+                self._knobs_compilation = triton.knobs.compilation
+                self._tensor_arg_indices = tensor_indices
+                self._int_arg_specs = tuple(int_arg_specs)
+            except Exception:
+                self._init_failed = True
+        finally:
+            # Publish ``_primed`` last so threads waiting on the lock
+            # either see a fully-set-up launcher or a clean
+            # ``_init_failed`` sentinel — never a half-written mix.
+            self._primed = True
+
+    def _materialize_spec(
+        self,
+        triton_kernel: object,
+        grid: tuple[int, ...],
+        args: tuple[object, ...],
+    ) -> _SpecEntry | None:
+        """Compile (or fetch from Triton's cache) the binary for the
+        current spec and return a fully-populated :class:`_SpecEntry`.
+
+        Called by :meth:`__call__` on a ``_spec_cache`` miss, under
+        ``self._prime_lock``. Invokes Triton's full pipeline once: this
+        is the "cold" path where we accept the binder + compile + cache
+        lookup costs, knowing every subsequent call with this spec_key
+        will dispatch directly via the cached entry.
+        """
+        try:
+            warmup_kwargs = {**self._run_kwargs, "grid": grid, "warmup": True}
+            # pyrefly: ignore[missing-attribute]
+            compiled_kernel = triton_kernel.run(*args, **warmup_kwargs)
+            if compiled_kernel is None:
+                return None
+            # Access ``.run`` FIRST so ``_init_handles()`` populates
+            # ``.function`` etc. before we read them.
+            run_fn = compiled_kernel.run
+            triton_function = compiled_kernel.function
+            packed_metadata = compiled_kernel.packed_metadata
+            kernel_launch_metadata = compiled_kernel.launch_metadata
+            # Snapshot ``used_global_vals`` at this binary's compile
+            # time. Each spec entry has its own snapshot — different
+            # binaries may pin different globals.
+            ugv = getattr(triton_kernel, "used_global_vals", None)
+            used_global_checks: tuple[tuple[dict, str, object], ...] = ()
+            if ugv:
+                used_global_checks = tuple(
+                    (gdict, name, val) for (name, _gid), (val, gdict) in ugv.items()
+                )
+            return _SpecEntry(
+                compiled_run=run_fn,
+                triton_function=triton_function,
+                packed_metadata=packed_metadata,
+                kernel_launch_metadata=kernel_launch_metadata,
+                used_global_checks=used_global_checks,
+            )
+        except Exception:
+            return None
+
+    def __call__(
+        self,
+        triton_kernel: object,
+        grid: tuple[int, ...],
+        *args: object,
+        # Spell out the kwargs the generated wrapper always passes so
+        # CPython binds them positionally into local slots rather than
+        # packing them into a per-call **kwargs dict. The closure already
+        # has the runtime values baked in; these parameter names exist
+        # solely to absorb the wrapper's keyword arguments cheaply, and
+        # are otherwise unused.
+        num_warps: int | None = None,
+        num_stages: int | None = None,
+        launch_cooperative_grid: bool = False,
+        **kwargs: object,
+    ) -> object:
+        # Under torch.compile / Dynamo tracing, defer to ``default_launcher``
+        # which routes through ``triton_kernel.run`` and is captured by
+        # Dynamo's ``triton_kernel_wrapper_mutation`` HOP handler. (Same
+        # reason as in the single-spec design — the fast path's direct
+        # ``_cuda_getCurrentRawStream`` call returns ``int`` and trips
+        # Dynamo's "non-Tensor return" check.)
+        if torch.compiler.is_compiling():
+            return default_launcher(
+                triton_kernel,
+                grid,
+                *args,
+                **self._run_kwargs,
+            )
+
+        if not self._primed:
+            # Double-checked locking: the unsynchronized read above is
+            # the fast path; the lock-guarded re-check below serializes
+            # concurrent first calls so only one thread runs ``_prime``.
+            with self._prime_lock:
+                if not self._primed:
+                    self._prime(triton_kernel, args)
+        if self._init_failed:
+            return default_launcher(
+                triton_kernel,
+                grid,
+                *args,
+                **self._run_kwargs,
+            )
+
+        # Multi-device guard. The cached driver/stream getter were
+        # captured against the priming device; if the caller has since
+        # switched CUDA devices, fall back to ``default_launcher`` which
+        # dispatches via Triton's per-device ``device_caches``.
+        active_driver = self._active_driver
+        if (
+            active_driver is not None
+            # pyrefly: ignore[missing-attribute]
+            and active_driver.get_current_device() != self._device
+        ):
+            return default_launcher(
+                triton_kernel,
+                grid,
+                *args,
+                **self._run_kwargs,
+            )
+
+        # Read knob state once. The binary-affecting knobs go into the
+        # spec key (so toggling them just lands on a different cache
+        # entry rather than forcing a fallback). The launch hooks are
+        # passed straight through to the C launcher per-call so a
+        # profiler attaching after priming still fires.
+        knobs_runtime = self._knobs_runtime
+        knobs_compilation = self._knobs_compilation
+        runtime_debug = getattr(knobs_runtime, "debug", False)
+        instr_mode = getattr(knobs_compilation, "instrumentation_mode", "")
+        stages_hook = getattr(knobs_runtime, "add_stages_inspection_hook", None)
+
+        # Compute the spec key INLINE — no Triton binder call. Helion's
+        # ``BoundKernel`` already specializes on dtype/shape/stride/device
+        # via its own bind cache, so the remaining Triton-level
+        # specialization for this kernel is pointer alignment and the
+        # binary-affecting knob state. ``_tensor_arg_indices`` is the
+        # precomputed list of positions of tensor pointer args
+        # (captured at priming), so the loop walks just those args.
+        align_bits = 0
+        for i in self._tensor_arg_indices:
+            # pyrefly: ignore[missing-attribute]
+            if args[i].data_ptr() & 15 == 0:
+                align_bits |= 1 << i
+        # Bucket each value-specialized int arg exactly as Triton's
+        # ``native_specialize_impl`` does: ``1`` is constant-folded into
+        # the binary (bucket ``1``), a value divisible by 16 gets the
+        # "divisible" attribute (bucket ``2``), everything else is plain
+        # (bucket ``0``). Two int values in the same bucket share a
+        # binary; differing buckets must not. Folding this into the key
+        # is what keeps a kernel primed with ``s == 1`` from silently
+        # reusing the constant-folded binary for ``s == 5``.
+        int_bucket_list = []
+        for i, align in self._int_arg_specs:
+            v = args[i]
+            if v == 1:
+                int_bucket_list.append(1)
+            # pyrefly: ignore[unsupported-operation]
+            elif align and v % 16 == 0:
+                int_bucket_list.append(2)
+            else:
+                int_bucket_list.append(0)
+        int_buckets = tuple(int_bucket_list)
+        spec_key = (
+            align_bits,
+            int_buckets,
+            runtime_debug,
+            instr_mode,
+            id(stages_hook) if stages_hook is not None else 0,
+        )
+
+        # Cache lookup. On miss we acquire the lock to serialize
+        # compile-on-miss for concurrent first-of-spec callers, then
+        # re-check the cache (another thread may have compiled while
+        # we waited) before invoking the cold path.
+        spec_cache = self._spec_cache
+        entry = spec_cache.get(spec_key)
+        if entry is None:
+            with self._prime_lock:
+                entry = spec_cache.get(spec_key)
+                if entry is None:
+                    entry = self._materialize_spec(triton_kernel, grid, args)
+                    if entry is None:
+                        return default_launcher(
+                            triton_kernel,
+                            grid,
+                            *args,
+                            **self._run_kwargs,
+                        )
+                    spec_cache[spec_key] = entry
+
+        # Per-spec ``used_global_vals`` check. Each spec entry has its
+        # own snapshot; a mutation that would have caused Triton to
+        # raise ``RuntimeError`` is detected here and we fall back so
+        # the user sees Triton's own error from ``JITFunction.run``.
+        for gdict, name, expected in entry.used_global_checks:
+            if gdict.get(name) != expected:
+                return default_launcher(
+                    triton_kernel,
+                    grid,
+                    *args,
+                    **self._run_kwargs,
+                )
+
+        # All fallback conditions are now ruled out — commit to the
+        # fast path. Fire ``pre_run_hooks`` inline (mirrors
+        # jit.py:717-718). Hooks don't affect the binary, so doing this
+        # here is safe; doing it later than the fallback conditions
+        # avoids double-firing if any condition above had tripped.
+        pre_run_hooks = getattr(triton_kernel, "pre_run_hooks", None)
+        if pre_run_hooks:
+            hook_kwargs = {
+                **self._run_kwargs,
+                "debug": runtime_debug,
+                "instrumentation_mode": instr_mode,
+            }
+            for hook in pre_run_hooks:
+                hook(*args, **hook_kwargs)
+
+        try:
+            grid_size = len(grid)
+            grid_0 = grid[0]
+            grid_1 = grid[1] if grid_size > 1 else 1
+            grid_2 = grid[2] if grid_size > 2 else 1
+            # pyrefly: ignore[not-callable]
+            stream = self._get_current_stream(self._device)
+            # Re-read launch hooks per-call so a profiler attached
+            # after priming still fires. Skip ``launch_metadata`` when
+            # no hook will actually consume it (the common case; this
+            # is one of our biggest wins vs ``JITFunction.run``).
+            enter_hook = getattr(knobs_runtime, "launch_enter_hook", None)
+            exit_hook = getattr(knobs_runtime, "launch_exit_hook", None)
+            if (enter_hook is None or getattr(enter_hook, "calls", None) == []) and (
+                exit_hook is None or getattr(exit_hook, "calls", None) == []
+            ):
+                launch_metadata = None
+            else:
+                launch_metadata = entry.kernel_launch_metadata(grid, stream, *args)
+            return entry.compiled_run(
+                grid_0,
+                grid_1,
+                grid_2,
+                stream,
+                entry.triton_function,
+                entry.packed_metadata,
+                launch_metadata,
+                enter_hook,
+                exit_hook,
+                *args,
+            )
+        except Exception as error:
+            message = str(error)
+            if "Cannot make_shape_compatible: incompatible dimensions" in message:
+                raise exc.ShapeMismatch("kernel operands", message) from error
+            raise
+
+
+def build_fast_launcher(
+    *,
+    num_warps: int,
+    num_stages: int,
+    launch_cooperative_grid: bool = False,
+    ptx_options: str | None = None,
+    extra_kwargs: dict | None = None,
+) -> _FastLauncher:
+    """Build a :class:`_FastLauncher` closure with config baked in.
+
+    Invoked from :meth:`BoundKernel.set_config` after the generated Triton
+    kernel is compiled. The returned object's ``__call__`` signature
+    matches :func:`default_launcher`, so the generated wrapper can use it
+    as a drop-in replacement (threaded through as ``_launcher=`` by the
+    bound-kernel-level wrapper installed in ``set_config``).
+    """
+    return _FastLauncher(
+        num_warps=num_warps,
+        num_stages=num_stages,
+        launch_cooperative_grid=launch_cooperative_grid,
+        ptx_options=ptx_options,
+        extra_kwargs=extra_kwargs,
+    )

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -928,11 +928,108 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             config: The configuration to set.
         """
         config = self._normalize_config(config)
-        self._run = self.compile_config(config)
+        compiled = self.compile_config(config)
+        # Clone the compiled function so each BoundKernel has its own
+        # ``__kwdefaults__`` to mutate. ``compile_config`` returns functions
+        # loaded via ``PyCodeCache``, which keys on source hash — two
+        # BoundKernels for the same kernel (e.g. cuda:0 vs cuda:1) can
+        # generate IDENTICAL Triton source, share a function object, and an
+        # in-place ``__kwdefaults__["_launcher"] = ...`` in
+        # :meth:`_install_fast_launcher` would clobber the earlier
+        # BoundKernel's launcher.
+        run = types.FunctionType(
+            compiled.__code__,
+            compiled.__globals__,
+            compiled.__name__,
+            compiled.__defaults__,
+            compiled.__closure__,
+        )
+        if compiled.__kwdefaults__ is not None:
+            run.__kwdefaults__ = dict(compiled.__kwdefaults__)
+        self._install_fast_launcher(run, config)
+        self._run = run
         self._config = config
         counters["best_config_decorator"][
             self.format_kernel_decorator(config, self.settings)
         ] = 1
+
+    def _install_fast_launcher(
+        self,
+        compiled: CompiledConfig,
+        config: Config,
+    ) -> None:
+        """Re-point ``compiled``'s ``_launcher`` kwarg default at a fast closure.
+
+        The generated host wrapper declares
+        ``def add(x, y, *, _launcher=_default_launcher)``; Python stores the
+        ``_default_launcher`` value in ``compiled.__kwdefaults__``. By
+        overwriting that entry with a :class:`helion.runtime._FastLauncher`
+        closure (built once with this config's ``num_warps`` / ``num_stages``
+        / etc. baked in), every direct call to ``compiled(*args)`` —
+        including from ``BoundKernel.__call__`` on the steady-state hot
+        path — uses the fast launcher with no extra Python wrapping.
+
+        The autotune trial harness and any external caller that explicitly
+        passes ``_launcher=`` overrides the kwdefault automatically, so
+        this is safe.
+
+        Non-Triton backends and any priming failure cause the kwdefault to
+        be left at :func:`default_launcher`. Setting the env var
+        ``HELION_SKIP_FAST_LAUNCHER=1`` (or ``true`` / ``yes``) is an
+        escape hatch: the fast launcher is not installed and every
+        Helion call goes through ``default_launcher`` (= Triton's
+        ``JITFunction.run``). Useful for quickly bisecting whether a
+        bug is in the fast launcher itself.
+        """
+        import os
+
+        from .._compiler.backend import TritonBackend
+        from ._fast_launcher import build_fast_launcher
+
+        if os.environ.get("HELION_SKIP_FAST_LAUNCHER", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        ):
+            return
+
+        backend = self.env.backend
+        if not isinstance(backend, TritonBackend):
+            return
+        kwdefaults = getattr(compiled, "__kwdefaults__", None)
+        if not kwdefaults or "_launcher" not in kwdefaults:
+            # No ``_launcher`` kwonly default — nothing to wire up.
+            # (Should not happen for Helion-compiled Triton kernels.)
+            return
+
+        try:
+            kwargs = backend.launcher_runtime_kwargs(
+                config, has_barrier=self._env.has_barrier
+            )
+        except Exception:
+            log.debug(
+                "FastLauncher disabled: backend.launcher_runtime_kwargs raised",
+                exc_info=True,
+            )
+            return
+
+        num_warps = cast("int", kwargs.pop("num_warps"))
+        num_stages = cast("int", kwargs.pop("num_stages"))
+        launch_cooperative_grid = cast(
+            "bool", kwargs.pop("launch_cooperative_grid", False)
+        )
+        ptx_options = cast("str | None", kwargs.pop("ptx_options", None))
+        # Anything left in kwargs (backend tunable keys, maxnreg,
+        # _triton_config_*) is forwarded as ``extra_kwargs`` to be baked
+        # into the closure.
+        fast_launcher = build_fast_launcher(
+            num_warps=num_warps,
+            num_stages=num_stages,
+            launch_cooperative_grid=launch_cooperative_grid,
+            ptx_options=ptx_options,
+            extra_kwargs=kwargs or None,
+        )
+        kwdefaults["_launcher"] = fast_launcher
 
     def _specialize_extra(self) -> list[Callable[[Sequence[object]], Hashable]]:
         """

--- a/test/test_dot.py
+++ b/test/test_dot.py
@@ -1100,6 +1100,52 @@ class TestDot(RefEagerTestBase, TestCase):
             lambda acc, a, b: acc + torch.matmul(a, b), rtol=1e-2, atol=5e-2
         )
 
+    @skipIfNotTriton("scalar-arg Triton specialization is Triton-specific")
+    @skipIfRefEager("launcher specialization not applicable in ref eager mode")
+    def test_scalar_arg_specialization_not_reused_across_values(self):
+        """A runtime scalar epilogue arg must not poison later calls.
+
+        ``s`` is a non-constexpr scalar threaded straight to the Triton
+        launcher. Triton constant-folds a scalar arg equal to ``1`` into
+        the compiled binary, but Helion reuses a single ``BoundKernel``
+        across every value of ``s`` (only dtype/shape/stride/device feed
+        the bind cache key). Whichever ``s`` value first primes a given
+        Triton spec bakes its specialized binary in; a launcher whose
+        spec key omits scalar specialization reuses that binary for
+        every later call sharing the same tensor-pointer alignment -- so
+        a kernel primed with ``s == 1`` silently returns ``x @ y + 1``
+        for ``s == 5``.
+        """
+
+        @helion.kernel(
+            config=helion.Config(block_sizes=[32, 32, 32]),
+            dot_precision=get_test_dot_precision(),
+        )
+        def scaled_dot(x: torch.Tensor, y: torch.Tensor, s: int) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=x.dtype)
+                for tile_k in hl.tile(k):
+                    acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+                out[tile_m, tile_n] = acc + s
+            return out
+
+        x = torch.randn(64, 64, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(64, 64, device=DEVICE, dtype=torch.float32)
+        baseline = x @ y
+
+        # Prime the launcher with the ``== 1`` specialization. Same
+        # tensor alignment + knob state on both calls, so the only thing
+        # that may differ is the scalar specialization.
+        torch.testing.assert_close(
+            scaled_dot(x, y, 1), baseline + 1, rtol=1e-2, atol=1e-1
+        )
+        torch.testing.assert_close(
+            scaled_dot(x, y, 5), baseline + 5, rtol=1e-2, atol=1e-1
+        )
+
 
 # Define ref mode test failures
 REF_EAGER_TEST_FAILURES = {

--- a/test/test_fast_launcher.py
+++ b/test/test_fast_launcher.py
@@ -1,0 +1,413 @@
+from __future__ import annotations
+
+import unittest
+
+import pytest
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import RefEagerTestDisabled
+from helion._testing import TestCase
+from helion._testing import skipIfFn
+from helion._testing import skipIfNotCUDA
+from helion._testing import skipIfNotTriton
+import helion.language as hl
+from helion.runtime import _FastLauncher
+from helion.runtime.kernel import _tensor_key
+
+triton = pytest.importorskip("triton")
+from triton.runtime.driver import driver  # noqa: E402
+
+
+def _get_jit_function(kernel: helion.Kernel) -> object:
+    """Return the underlying ``triton.JITFunction`` behind a primed Helion kernel.
+
+    The generated host wrapper closes over the JITFunction as
+    ``_helion_<name>`` in its ``__globals__``. We scan for the unique
+    JITFunction instance there so tests can install Triton-side hooks
+    (e.g. ``pre_run_hooks``) on a real kernel without patching.
+    """
+    from triton.runtime.jit import JITFunction
+
+    bound = next(iter(kernel._bound_kernels.values()))  # type: ignore[attr-defined]
+    return next(
+        v for v in bound._run.__globals__.values() if isinstance(v, JITFunction)
+    )
+
+
+@helion.kernel(config={"block_size": 16})
+def _fast_launcher_add_one(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size()):
+        out[tile] = x[tile] + 1
+    return out
+
+
+# Large block size + 2 stages makes Triton emit vectorized 16-byte loads,
+# which exposes the launcher's per-call spec lookup gap loudly (misaligned
+# pointer → CUDA misaligned-address error) rather than as a silent numeric
+# drift.
+@helion.kernel(
+    static_shapes=True,
+    config=helion.Config(block_sizes=[1024], num_warps=4, num_stages=2),
+)
+def _fast_launcher_add_vectorized(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for i in hl.tile(out.size(0)):
+        out[i] = x[i] + y[i]
+    return out
+
+
+@skipIfNotTriton("fast launcher is Triton-specific")
+class TestFastLauncher(RefEagerTestDisabled, TestCase):
+    @skipIfNotCUDA()
+    @skipIfFn(
+        lambda: torch.cuda.device_count() < 2,
+        "test requires at least two CUDA devices",
+    )
+    def test_fast_launcher_uses_current_call_device(self) -> None:
+        """The cached launcher must not reuse cuda:0 launch state for cuda:1."""
+        _fast_launcher_add_one.reset()
+        old_device = torch.cuda.current_device()
+        try:
+            cuda0 = torch.device("cuda:0")
+            cuda1 = torch.device("cuda:1")
+            with torch.cuda.device(0):
+                x0 = torch.arange(16, device=cuda0, dtype=torch.float32)
+                y0 = _fast_launcher_add_one(x0)
+                torch.cuda.synchronize(0)
+                torch.testing.assert_close(y0, x0 + 1)
+
+            with torch.cuda.device(1):
+                x1 = torch.arange(16, device=cuda1, dtype=torch.float32)
+                y1 = _fast_launcher_add_one(x1)
+                torch.cuda.synchronize(1)
+                torch.testing.assert_close(y1, x1 + 1)
+                self.assertEqual(y1.device, cuda1)
+        finally:
+            torch.cuda.set_device(old_device)
+            _fast_launcher_add_one.reset()
+
+    @skipIfNotCUDA()
+    def test_binder_spec_differs_for_aligned_vs_unaligned_pointers(self) -> None:
+        """Pre-condition for the alignment correctness gap.
+
+        Helion's tensor key only tracks dtype/shape/stride, so two
+        views with the same shape but different pointer alignment
+        share one ``BoundKernel``. Yet Triton's binder reports
+        distinct specializations for them. The multi-spec
+        ``_FastLauncher`` keys its ``_spec_cache`` on the alignment
+        bitmask exactly to handle this: aligned and unaligned land
+        on different cache entries (i.e. different compiled binaries).
+        This test pins down the underlying Triton-binder distinction
+        — if a future Triton change collapses these specs, alignment
+        bitmask differentiation would become unnecessary.
+        """
+        _fast_launcher_add_vectorized.reset()
+        n = 1024
+        base = torch.randn(n + 4, device=DEVICE, dtype=torch.float32)
+        aligned = base[:n]
+        unaligned = base[1 : n + 1]
+        out_buf = torch.empty_like(aligned)
+
+        self.assertEqual(aligned.data_ptr() % 16, 0)
+        self.assertNotEqual(unaligned.data_ptr() % 16, 0)
+        self.assertEqual(
+            _tensor_key(_fast_launcher_add_vectorized, aligned),
+            _tensor_key(_fast_launcher_add_vectorized, unaligned),
+        )
+
+        # Run once to ensure ``set_config`` has installed a fast launcher.
+        _fast_launcher_add_vectorized(aligned, aligned)
+        bound = _fast_launcher_add_vectorized.bind((aligned, aligned))
+        compiled = bound._run
+        self.assertIsNotNone(compiled)
+        launcher = compiled.__kwdefaults__.get("_launcher")
+        if not isinstance(launcher, _FastLauncher) or not launcher._primed:
+            self.skipTest(
+                "fast launcher not installed (non-Triton backend or unsupported Triton)"
+            )
+
+        # Fetch the binder from Triton's per-device cache directly —
+        # the fast launcher no longer keeps a reference because it
+        # computes the alignment bits inline instead of calling the
+        # binder on every launch.
+        jit_fn = _get_jit_function(_fast_launcher_add_vectorized)
+        dev = driver.active.get_current_device()
+        binder = jit_fn.device_caches[dev][4]  # pyrefly: ignore[missing-attribute]
+        _, spec_aligned, _ = binder(aligned, aligned, out_buf, **launcher._run_kwargs)
+        _, spec_unaligned, _ = binder(
+            unaligned, unaligned, out_buf, **launcher._run_kwargs
+        )
+        self.assertNotEqual(spec_aligned, spec_unaligned)
+
+    @skipIfNotCUDA()
+    def test_pre_run_hook_installed_after_priming_fires_on_real_kernel(
+        self,
+    ) -> None:
+        """A ``pre_run_hook`` installed after priming must fire on the next call.
+
+        ``JITFunction.run`` iterates ``self.pre_run_hooks`` at the top
+        of every launch (jit.py:717-718). The fast launcher's
+        C-launcher hot path doesn't go through ``JITFunction.run``, so
+        an attached profiler / autotune-timer would silently miss
+        every Helion launch unless we mirror that loop ourselves.
+        We invoke the hooks inline on the hot path with the same
+        ``args`` + ``kwargs`` Triton would, so installing a hook
+        after priming keeps the launcher on the fast path AND fires
+        the hook. We also check the kwargs include the live
+        ``debug``/``instrumentation_mode`` values matching Triton's
+        contract.
+        """
+        _fast_launcher_add_one.reset()
+        self.addCleanup(_fast_launcher_add_one.reset)
+        x = torch.arange(16, device=DEVICE, dtype=torch.float32)
+
+        torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+        jit_fn = _get_jit_function(_fast_launcher_add_one)
+        calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+        self.addCleanup(jit_fn.pre_run_hooks.clear)  # pyrefly: ignore[missing-attribute]
+        jit_fn.pre_run_hooks.append(  # pyrefly: ignore[missing-attribute]
+            lambda *a, **kw: calls.append((a, kw))
+        )
+        torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+        self.assertEqual(len(calls), 1)
+        _, kw = calls[0]
+        self.assertIn("debug", kw)
+        self.assertIn("instrumentation_mode", kw)
+        self.assertIn("num_warps", kw)
+        self.assertIn("num_stages", kw)
+
+    @skipIfNotCUDA()
+    def test_used_global_vals_mutation_surfaces_to_user_on_real_kernel(
+        self,
+    ) -> None:
+        """Mutating a tracked global must surface as a Triton ``RuntimeError``.
+
+        Helion-generated Triton kernels reference codegen constants
+        (e.g. ``_BLOCK_SIZE_0``) as module-level ``constexpr`` globals;
+        Triton tracks them in ``used_global_vals`` and raises if the
+        value changes between launches — the cached binary has the
+        old value baked into codegen, so silently reusing it would
+        produce wrong output. The fast launcher's snapshot+equality
+        check on every call mirrors that semantic. Without it, the
+        Helion kernel would skip Triton's mismatch check entirely.
+
+        This test also verifies the snapshot check does not
+        false-positive: ``used_global_vals`` is non-empty on every
+        Helion kernel, so a naive non-empty test would defeat the
+        fast path. We assert that no recompile happens on a
+        non-mutation call (kernel_cache unchanged) and that the fast
+        path is restored after the global is reverted.
+        """
+        _fast_launcher_add_one.reset()
+        self.addCleanup(_fast_launcher_add_one.reset)
+        x = torch.arange(16, device=DEVICE, dtype=torch.float32)
+
+        torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+        jit_fn = _get_jit_function(_fast_launcher_add_one)
+        (name, _gid), (compile_value, gdict) = next(
+            iter(jit_fn.used_global_vals.items())  # pyrefly: ignore[missing-attribute]
+        )
+        dev = driver.active.get_current_device()
+        kernel_cache = jit_fn.device_caches[dev][0]  # pyrefly: ignore[missing-attribute]
+
+        # No-mutation call: cache unchanged (proves no false-positive
+        # fallback / recompile despite ``used_global_vals`` being
+        # non-empty).
+        cache_size = len(kernel_cache)
+        torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+        self.assertEqual(len(kernel_cache), cache_size)
+
+        # Mutation: hot path's per-entry equality check detects the
+        # change, falls back to ``default_launcher`` -> ``JITFunction.run``
+        # which raises rather than silently using the stale binary.
+        # Register restore via addCleanup so a mid-test crash cannot
+        # leave the global mutated.
+        import triton.language as tl
+
+        self.addCleanup(gdict.__setitem__, name, compile_value)
+        gdict[name] = tl.constexpr(8)
+        with self.assertRaises(RuntimeError):
+            _fast_launcher_add_one(x)
+        gdict[name] = compile_value
+
+        # Restore: fast path is usable again; still no recompile.
+        cache_size = len(kernel_cache)
+        torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+        self.assertEqual(len(kernel_cache), cache_size)
+
+    @skipIfNotCUDA()
+    def test_knobs_runtime_debug_set_after_priming_compiles_new_binary_on_real_kernel(
+        self,
+    ) -> None:
+        """Enabling ``knobs.runtime.debug`` mid-run must trigger Triton recompile.
+
+        ``JITFunction.run`` ORs ``knobs.runtime.debug`` into the per-call
+        ``debug`` kwarg, which becomes part of Triton's cache key.
+        Setting ``debug=True`` after priming needs a different compiled
+        binary than the one we primed with. The fast launcher's hot
+        path inspects the knob per call and falls back when set; this
+        gives ``JITFunction.run`` the chance to compile and cache the
+        debug binary. We assert the kernel_cache grew end-to-end.
+        """
+        _fast_launcher_add_one.reset()
+        self.addCleanup(_fast_launcher_add_one.reset)
+        x = torch.arange(16, device=DEVICE, dtype=torch.float32)
+        old_debug = triton.knobs.runtime.debug
+        self.addCleanup(lambda: setattr(triton.knobs.runtime, "debug", old_debug))
+        triton.knobs.runtime.debug = False
+
+        torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+        jit_fn = _get_jit_function(_fast_launcher_add_one)
+        dev = driver.active.get_current_device()
+        kernel_cache = jit_fn.device_caches[dev][0]  # pyrefly: ignore[missing-attribute]
+        cache_size = len(kernel_cache)
+
+        triton.knobs.runtime.debug = True
+        torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+        self.assertGreater(len(kernel_cache), cache_size)
+
+    @skipIfNotCUDA()
+    def test_launch_hooks_installed_after_priming_fire_on_real_kernel(
+        self,
+    ) -> None:
+        """``launch_enter_hook`` / ``launch_exit_hook`` installed after priming must fire.
+
+        The Triton C launcher invokes both hooks with a ``launch_metadata``
+        argument. The fast launcher used to snapshot the hook references
+        at priming, so profilers attaching afterwards were silently
+        dropped. The hot path now re-reads them from
+        ``triton.knobs.runtime`` per call — we assert the hooks fire on
+        a real kernel here.
+        """
+        _fast_launcher_add_one.reset()
+        self.addCleanup(_fast_launcher_add_one.reset)
+        x = torch.arange(16, device=DEVICE, dtype=torch.float32)
+        old_enter = triton.knobs.runtime.launch_enter_hook
+        old_exit = triton.knobs.runtime.launch_exit_hook
+
+        def restore_launch_hooks() -> None:
+            triton.knobs.runtime.launch_enter_hook = old_enter
+            triton.knobs.runtime.launch_exit_hook = old_exit
+
+        self.addCleanup(restore_launch_hooks)
+        triton.knobs.runtime.launch_enter_hook = None
+        triton.knobs.runtime.launch_exit_hook = None
+
+        torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+        enter_md: list[object] = []
+        exit_md: list[object] = []
+        triton.knobs.runtime.launch_enter_hook = lambda md: enter_md.append(md)
+        triton.knobs.runtime.launch_exit_hook = lambda md: exit_md.append(md)
+        torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+        self.assertEqual(len(enter_md), 1)
+        self.assertEqual(len(exit_md), 1)
+
+    @skipIfNotCUDA()
+    def test_unaligned_call_after_aligned_priming_matches_reference(self) -> None:
+        """Aligned-then-unaligned call should still produce correct output.
+
+        Before the multi-spec design, the second call launched the
+        binary compiled for the aligned spec (vectorized 16-byte loads)
+        and tripped ``CUDA error: misaligned address``. The multi-spec
+        :class:`_FastLauncher` keys its ``_spec_cache`` on the
+        alignment bitmask, so aligned and unaligned land on separate
+        cache entries and each gets its own correctly-compiled binary.
+        """
+        _fast_launcher_add_vectorized.reset()
+        n = 1024
+        base = torch.randn(n + 4, device=DEVICE, dtype=torch.float32)
+        aligned = base[:n]
+        unaligned = base[1 : n + 1]
+
+        torch.testing.assert_close(
+            _fast_launcher_add_vectorized(aligned, aligned), aligned + aligned
+        )
+        torch.testing.assert_close(
+            _fast_launcher_add_vectorized(unaligned, unaligned), unaligned + unaligned
+        )
+
+    @skipIfNotCUDA()
+    def test_alternating_specs_both_take_fast_path(self) -> None:
+        """Two different alignment specs should each land on the fast path.
+
+        The multi-spec ``_FastLauncher`` caches one compiled binary per
+        spec key (alignment + knob state), so a call site that
+        alternates between aligned and unaligned tensors has BOTH
+        binaries in ``_spec_cache`` after the first call of each. Every
+        subsequent call hits the cache and uses the fast path; there is
+        no fallback to ``default_launcher`` for either spec.
+
+        This is the user-visible win over the single-spec design: a
+        legitimately multi-spec call site no longer pays the
+        ``default_launcher`` Python-overhead penalty on every other call.
+        """
+        _fast_launcher_add_vectorized.reset()
+        n = 1024
+        base = torch.randn(n + 4, device=DEVICE, dtype=torch.float32)
+        aligned = base[:n]
+        unaligned = base[1 : n + 1]
+
+        # First call of each spec → cache miss → compile → cache hit
+        torch.testing.assert_close(
+            _fast_launcher_add_vectorized(aligned, aligned), aligned + aligned
+        )
+        torch.testing.assert_close(
+            _fast_launcher_add_vectorized(unaligned, unaligned),
+            unaligned + unaligned,
+        )
+
+        bound = _fast_launcher_add_vectorized.bind((aligned, aligned))
+        launcher = bound._run.__kwdefaults__.get("_launcher")
+        self.assertIsInstance(launcher, _FastLauncher)
+        self.assertEqual(len(launcher._spec_cache), 2)
+
+        # Alternating calls — each spec hits its own cache entry; cache
+        # size stays at 2.
+        for _ in range(3):
+            torch.testing.assert_close(
+                _fast_launcher_add_vectorized(aligned, aligned), aligned + aligned
+            )
+            torch.testing.assert_close(
+                _fast_launcher_add_vectorized(unaligned, unaligned),
+                unaligned + unaligned,
+            )
+        self.assertEqual(len(launcher._spec_cache), 2)
+
+    @skipIfNotCUDA()
+    def test_skip_fast_launcher_env_var_disables_install(self) -> None:
+        """``HELION_SKIP_FAST_LAUNCHER=1`` should bypass the fast launcher.
+
+        Useful as a quick escape hatch when debugging: every Helion
+        call routes through ``default_launcher`` (Triton's
+        ``JITFunction.run``) and the per-spec cache layer is never
+        installed. We verify the kwdefault on the generated wrapper
+        is the plain ``default_launcher`` function, not a
+        ``_FastLauncher`` instance.
+        """
+        import os
+
+        _fast_launcher_add_one.reset()
+        self.addCleanup(_fast_launcher_add_one.reset)
+        old = os.environ.get("HELION_SKIP_FAST_LAUNCHER")
+        self.addCleanup(
+            lambda: (
+                os.environ.__setitem__("HELION_SKIP_FAST_LAUNCHER", old)
+                if old is not None
+                else os.environ.pop("HELION_SKIP_FAST_LAUNCHER", None)
+            )
+        )
+        os.environ["HELION_SKIP_FAST_LAUNCHER"] = "1"
+
+        x = torch.arange(16, device=DEVICE, dtype=torch.float32)
+        torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+
+        bound = next(iter(_fast_launcher_add_one._bound_kernels.values()))
+        launcher = bound._run.__kwdefaults__.get("_launcher")
+        self.assertNotIsInstance(launcher, _FastLauncher)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked PRs:
 * __->__#2749
 * #2793


--- --- ---

### Install a per-spec fast launcher that bypasses Triton's JITFunction.run


Every Helion kernel launch went through Triton's full JITFunction.run
pipeline (~9.3us): per-call device + stream proxy resolution, the
argument binder, compute_cache_key, kernel-cache lookup, the
used_global_vals walk, launch_metadata construction (even with no
profiler attached), and the kwargs-dict munging around all of it. For
a Helion kernel almost all of that is redundant: BoundKernel has
already specialized on dtype/shape/stride/device, so the only
Triton-level specialization left at launch time is pointer alignment,
int-scalar value specialization, and binary-affecting knob state.

This ports the _FastLauncher design from upstream PR #2565 (plus the
set_config function-clone fix from PR #2635) onto main:

 * helion/runtime/_fast_launcher.py -- default_launcher moves here
   unchanged (still re-exported from helion.runtime), joined by
   _FastLauncher: a multi-spec launcher primed on first call. The hot
   path computes a tiny spec key inline -- an alignment bitmask over
   the tensor args (data_ptr() & 15), per-int-arg value specialization
   buckets (== 1 constant-fold + divisibility-by-16, mirroring Triton's
   native_specialize_impl), plus debug/instrumentation_mode/
   stages-hook knob state -- dict-looks-up the compiled binary for
   that spec, and jumps straight into Triton's C launcher
   (CompiledKernel.run). Spec misses compile through Triton's full
   pipeline once and are cached, so call sites alternating aligned/
   unaligned tensors stay on the fast path for both.

 * BoundKernel.set_config clones the PyCodeCache'd host function
   (PyCodeCache keys on source hash, so two BoundKernels can share one
   function object) and re-points its _launcher kwdefault at a
   _FastLauncher with the config's num_warps/num_stages/etc. baked in.
   Explicit _launcher= callers (the autotune trial harness) override
   the kwdefault naturally.

 * TritonBackend.launcher_runtime_kwargs factors the runtime kwarg
   values out of launcher_keyword_args so codegen strings and the
   launcher closure share one source of truth.

Safety / correctness guards, each pinned by a test in
test/test_fast_launcher.py:
 * Alignment is part of the spec key, so an unaligned tensor after an
   aligned prime gets its own correctly-compiled binary -- never the
   vectorized aligned binary (which would fault), and never a clone
   (which would silently drop writes to output args).
 * Int-scalar value specialization is part of the spec key, so a kernel
   primed with a value Triton constant-folds (s == 1) gets a fresh
   correctly-compiled binary for a later differing value (s == 5)
   instead of silently reusing the folded-in constant. Pinned by
   test_dot.py::test_scalar_arg_specialization_not_reused_across_values.
 * used_global_vals snapshot per spec entry; any mutation falls back
   to JITFunction.run so Triton's own RuntimeError surfaces instead of
   silently launching a stale binary.
 * torch.compile tracing routes through default_launcher so Dynamo's
   triton_kernel_wrapper_mutation HOP rules apply.
 * Multi-device guard: a current-device change after priming falls
   back to Triton's per-device dispatch.
 * launch_enter/exit hooks are re-read per call (a profiler attached
   after priming still fires; launch_metadata is built only when a
   hook will consume it); pre_run_hooks fire inline; flipping
   knobs.runtime.debug lands on a new spec entry and recompiles.
 * Any priming/compile failure, and HELION_SKIP_FAST_LAUNCHER=1, fall
   back to default_launcher permanently.

Verified: test_fast_launcher + test_misc (51 passed), and full runs of
test_torch_compile (244), test_examples (96), test_autotuner (122),
test_indexing, test_loops, test_grid, test_ref_eager, test_specialize,
test_config_api, test_cache earlier on this branch.

Benchmark (B200, end-to-end wall time per call, add-style kernel,
N=4096 fp32, HELION_AUTOTUNE_EFFORT=none, steady state, 20k iters/rep,
median of 3 reps). Baseline is this same commit with
HELION_SKIP_FAST_LAUNCHER=1 (every launch routed through Triton's
JITFunction.run); the only difference is the env-var escape hatch, so
this isolates the launcher itself. The fast launcher was confirmed
engaged (primed, no fallback) for every row:

```
  n_args | baseline | fast launcher | saved   | total
  -------+----------+---------------+---------+------
       2 | 17.93 us |      13.95 us | 3.98 us |  -22%
       8 | 24.14 us |      19.43 us | 4.71 us |  -20%
      16 | 33.17 us |      26.21 us | 6.96 us |  -21%
```

The fast path removes ~4-7 us of CPU-side launch overhead per call
(growing with arg count as the binder/kwargs munging it skips scales),
a consistent ~20% reduction in end-to-end per-call wall time. (The
earlier -44% figure compared against a further-back point in the
stack; measured like-for-like against this commit's own fallback path
the win is ~20%, since the env-var baseline still benefits from this
commit's other steady-state changes.)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
