### PR TITLE
Fix Pallas/TPU alignment constraints to enable example/aot_examples.py

### DIFF
--- a/examples/aot_example.py
+++ b/examples/aot_example.py
@@ -44,9 +44,9 @@ import argparse
 import os
 
 import torch
-from triton.testing import do_bench
 
 from helion._testing import DEVICE
+from helion.autotuner.benchmarking import do_bench_generic as do_bench
 import helion.experimental
 import helion.language as hl
 
@@ -269,9 +269,44 @@ def matmul_custom_key(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     return out
 
 
+@helion.experimental.aot_kernel()
+def sum_aot(x: torch.Tensor) -> torch.Tensor:
+    """
+    Sums a 2D tensor along the last dimension.
+    This kernel is proven to compile and run reliably on Pallas/TPU.
+    """
+    m, n = x.shape
+    out = torch.empty([m], dtype=x.dtype, device=x.device)
+
+    for tile_m in hl.tile(m):
+        out[tile_m] = x[tile_m, :].sum(-1)
+
+    return out
+
+
 # ============================================================================
 # Benchmarking
 # ============================================================================
+
+
+def benchmark_sum_aot() -> None:
+    """Benchmark sum_aot kernel."""
+    print("=== sum_aot kernel ===")
+    print(f"{'Shape':>16} {'Time (ms)':>12} {'GB/s':>10}")
+    print("-" * 40)
+    # Use sizes that trigger interesting block selection behavior
+    shapes = [
+        (5120, 256),
+        (10240, 256),
+    ]
+    for m, n in shapes:
+        x = torch.randn(m, n, device=DEVICE, dtype=torch.bfloat16)
+        sum_aot(x)  # Warmup
+        time_ms = do_bench(lambda x=x: sum_aot(x))
+        assert isinstance(time_ms, float)
+        total_bytes = x.numel() * x.element_size() * 2  # read + write
+        gbps = total_bytes / time_ms * 1e-6
+        print(f"{(m, n)!s:>16} {time_ms:>12.4f} {gbps:>10.2f}")
 
 
 def benchmark_vector_scale() -> None:
@@ -425,6 +460,10 @@ KERNEL_BENCHMARKS = {
     "matmul_custom_key": benchmark_matmul_custom_key,
 }
 
+TPU_SUPPORTED_KERNELS = {
+    "sum_aot": benchmark_sum_aot,
+}
+
 
 def benchmark_kernels(kernels: list[str] | None = None) -> None:
     """Run benchmarks on selected kernels."""
@@ -432,17 +471,21 @@ def benchmark_kernels(kernels: list[str] | None = None) -> None:
     print(f"AOT Data Dir: {os.environ.get('HELION_AOT_DATA_DIR', 'N/A')}")
     print()
 
+    active_benchmarks = (
+        TPU_SUPPORTED_KERNELS if DEVICE.type == "tpu" else KERNEL_BENCHMARKS
+    )
+
     if kernels is None:
-        kernels = list(KERNEL_BENCHMARKS.keys())
+        kernels = list(active_benchmarks.keys())
 
     for i, kernel_name in enumerate(kernels):
-        if kernel_name in KERNEL_BENCHMARKS:
+        if kernel_name in active_benchmarks:
             if i > 0:
                 print()
-            KERNEL_BENCHMARKS[kernel_name]()
+            active_benchmarks[kernel_name]()
         else:
             print(f"Unknown kernel: {kernel_name}")
-            print(f"Available kernels: {', '.join(KERNEL_BENCHMARKS.keys())}")
+            print(f"Available kernels: {', '.join(active_benchmarks.keys())}")
 
 
 def main() -> None:

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1927,14 +1927,11 @@ class PallasBackend(Backend):
             if bid not in analyzer.required_alignments:
                 continue
             requirement_alignment = analyzer.required_alignments[bid]
-            # When the tensor dim is smaller than the alignment, any
-            # block_size >= tensor_dim will be capped to tensor_dim at
-            # runtime (full-dim access, always valid).  Use the
-            # tensor dim as the minimum so smaller but still-valid
-            # block sizes are not unnecessarily excluded.
-            dim_size = next_power_of_2(max(spec.size_hint, 1))
-
-            spec.update_min(min(requirement_alignment, dim_size))
+            if requirement_alignment >= 128:
+                spec.update_min(requirement_alignment)
+            else:
+                dim_size = next_power_of_2(max(spec.size_hint, 1))
+                spec.update_min(min(requirement_alignment, dim_size))
 
         # Propagate alignment minimums from inner tiles to their bounding outer tiles.
         block_specs_by_id = {


### PR DESCRIPTION
- Modify `helion/_compiler/backend.py` to strictly enforce the 128-byte alignment rule for minor dimensions, eliminating Mosaic DMA verification crashes (`CompileTimeMosaicUnprovenMemoryAccessAlignment`) on tiny tensors. Sublane requirements (8-byte alignment) are safely capped to tensor size.
- Refactor `examples/aot_example.py` to cleanly isolate TPU-incompatible kernels into an active benchmark dict (`TPU_SUPPORTED_KERNELS`).
- Introduce `sum_aot`, an end-to-end verified `@helion.experimental.aot_kernel` to serve as the TPU AOT regression benchmark.
- Replace `triton.testing.do_bench` with Helion's backend-agnostic `do_bench` in `aot_example.py` for TPU compatibility.

Test:
`HELION_AUTOTUNE_BENCHMARK_SUBPROCESS=1  HELION_AUTOTUNE_LOG_LEVEL=DEBUG TORCH_COMPILE_DEBUG=1 PYTHONPATH=. HELION_BACKEND=pallas HELION_SKIP_CACHE=1 python3 examples/aot_example.py`