### PR TITLE
[cute] Unified rolled TMA producer + hoisted K-loop predicates for tcgen05

### DIFF
--- a/helion/_compiler/cute/cute_fx_walk.py
+++ b/helion/_compiler/cute/cute_fx_walk.py
@@ -225,6 +225,21 @@ def aux_tensor_load_kind(
       row 0 of the aux to every output row. The splice site builds
       the same stride-``(0, 1)`` 2-D view as the trailing-axis
       rowvec form (row 0 reused across M).
+    - ``("broadcast", 2)``: a per-row column-vector broadcast aux
+      load (``scale_a[tile_m, tile_n]`` where ``scale_a`` is a full
+      ``(M, N)`` view with **stride 0 on the trailing (N) axis** — an
+      ``unsqueeze(1).expand(M, N)`` of a per-row ``(M,)`` vector). The
+      underlying tensor's rank is 2 with the carrier's global shape,
+      the load result shape equals the carrier tile shape, and the
+      load's two index symbols are exactly ``carrier_tile_index_nodes``
+      in order. Its value depends only on ``m``, so it is uniform over
+      each thread's N fragment in the T2R epilogue: the splice reads it
+      as a single **scalar** per subtile (``tTR_gAux[(0,0,0,s)]``)
+      rather than a vector ``.load()``, avoiding a redundant N-wide
+      read. Tried before ``("exact", None)`` because a stride-0-N aux
+      still has the full ``(M, N)`` underlying shape; a genuine 2-D
+      residual has a non-zero trailing stride and falls through to the
+      exact matcher.
 
     The classifier returns ``None`` for everything else: 3-D
     underlying tensors with a static collapse
@@ -309,6 +324,18 @@ def aux_tensor_load_kind(
     # Higher-rank carriers fall through to the loud-failure backstop.
     if len(carrier_tile_shape) != 2:
         return None
+
+    colvec = _matches_colvec_broadcast(
+        aux_shape=aux_shape,
+        aux_tensor_shape=aux_tensor_shape,
+        aux_tensor_val=aux_tensor_val,
+        index_list=index_list,
+        carrier_tile_shape=carrier_tile_shape,
+        carrier_tile_index_nodes=carrier_tile_index_nodes,
+        carrier_global_shape=carrier_global_shape,
+    )
+    if colvec is not None:
+        return colvec
 
     if _matches_exact(
         aux_shape=aux_shape,
@@ -488,6 +515,61 @@ def _matches_leading_broadcast(
         if aux_tensor_shape[1] != carrier_global_shape[1]:
             return None
     return ("broadcast", 0)
+
+
+def _matches_colvec_broadcast(
+    *,
+    aux_shape: tuple[object, ...],
+    aux_tensor_shape: tuple[object, ...],
+    aux_tensor_val: torch.Tensor,
+    index_list: Sequence[object],
+    carrier_tile_shape: tuple[object, ...],
+    carrier_tile_index_nodes: tuple[torch.fx.Node, ...] | None,
+    carrier_global_shape: tuple[object, ...] | None,
+) -> tuple[str, int] | None:
+    """Check whether a load is a per-row column-vector broadcast and
+    return ``("broadcast", 2)`` on success.
+
+    The accepted form is ``scale_a[tile_m, tile_n]`` where ``scale_a`` is a
+    full ``(M, N)`` view with **stride 0 on the trailing (N) axis** — i.e. an
+    ``unsqueeze(1).expand(M, N)`` of a per-row ``(M,)`` vector. Its value
+    depends only on ``m``, so it is *uniform over each thread's N fragment*
+    in the tcgen05 T2R epilogue. The splice therefore reads it as a single
+    **scalar** per subtile (matching CUTLASS's ``sa = tTR_gSA[(0,0,0,s)]``)
+    rather than a vector ``.load()``, avoiding a redundant N-wide read.
+
+    This must be tried *before* ``_matches_exact`` (a stride-0-N aux still
+    has the full ``(M, N)`` underlying shape, so the exact matcher would
+    otherwise claim it and emit a vector read). A genuine 2-D residual has a
+    non-zero trailing stride and falls through to ``_matches_exact``.
+    """
+    if (
+        len(aux_tensor_shape) != 2
+        or len(aux_shape) != 2
+        or len(index_list) != 2
+        or len(carrier_tile_shape) != 2
+    ):
+        return None
+    if carrier_tile_index_nodes is None or len(carrier_tile_index_nodes) != 2:
+        return None
+    for idx, expected in zip(index_list, carrier_tile_index_nodes, strict=True):
+        if idx is not expected:
+            return None
+    for aux_dim, carrier_dim in zip(aux_shape, carrier_tile_shape, strict=True):
+        if aux_dim != carrier_dim:
+            return None
+    if carrier_global_shape is not None:
+        if len(carrier_global_shape) != 2:
+            return None
+        if tuple(aux_tensor_shape) != tuple(carrier_global_shape):
+            return None
+    stride = aux_tensor_val.stride()
+    # Uniform over N (trailing stride 0) and varying over M (leading stride
+    # non-zero) — the column-vector broadcast. A real (M, N) tensor has
+    # trailing stride 1 and is left for the exact-shape matcher.
+    if len(stride) != 2 or stride[1] != 0 or stride[0] == 0:
+        return None
+    return ("broadcast", 2)
 
 
 def _matches_exact(

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -1826,13 +1826,36 @@ def _emit_mma_pipeline(
     epi_elem_dtype_str = (
         _dtype_map[epi_elem_dtype] if epi_elem_dtype is not None else input_dtype_str
     )
-    tcgen05_use_tma = (
-        input_dtype in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
-        and lhs_fake.is_contiguous()
-        and rhs_fake.is_contiguous()
+
+    def _tcgen05_tma_2d_major(t: torch.Tensor) -> str | None:
+        # A 2D operand is TMA-eligible if it is contiguous in EITHER axis.
+        # Returns "row" (last-dim contiguous), "col" (first-dim contiguous),
+        # or None (neither -> not TMA-eligible). Row-major contiguous returns
+        # "row"; a transposed/column-major view returns "col".
+        if t.dim() != 2:
+            return "row" if t.is_contiguous() else None
+        s = t.stride()
+        if s[1] == 1:
+            return "row"
+        if s[0] == 1:
+            return "col"
+        return None
+
+    _dtype_tma_ok = input_dtype in (
+        torch.float16,
+        torch.bfloat16,
+        torch.float8_e4m3fn,
     )
-    tcgen05_use_tma_a = tcgen05_use_tma
-    tcgen05_use_tma_b = tcgen05_use_tma
+    _lhs_major = _tcgen05_tma_2d_major(lhs_fake)
+    _rhs_major = _tcgen05_tma_2d_major(rhs_fake)
+    # A must be row-major (M,K) K-contiguous == "row"; the K-major A SMEM
+    # layout Helion emits expects the standard row-major A. Only B's major
+    # mode is made layout-aware here.
+    tcgen05_use_tma_a = _dtype_tma_ok and _lhs_major == "row"
+    tcgen05_use_tma_b = _dtype_tma_ok and _rhs_major in ("row", "col")
+    # B is K-major when its (K, N) storage is K-contiguous (column-major),
+    # i.e. stride[0] == 1 -> _rhs_major == "col".
+    tcgen05_b_k_major = _rhs_major == "col"
     tcgen05_use_tma = tcgen05_use_tma_a or tcgen05_use_tma_b
     tcgen05_use_tma_pipeline = tcgen05_use_tma_a and tcgen05_use_tma_b
     tcgen05_requested_pure_matmul_role_lifecycle = is_pure_matmul_role_lifecycle_config(
@@ -3115,6 +3138,7 @@ def _emit_mma_pipeline(
                 bm,
                 bn,
                 tcgen05_cluster_m=tcgen05_cluster_m,
+                b_k_major=tcgen05_b_k_major,
             )
         )
     else:
@@ -3290,6 +3314,7 @@ def _emit_mma_pipeline(
                     bm,
                     bn,
                     tcgen05_cluster_m=tcgen05_cluster_m,
+                    b_k_major=tcgen05_b_k_major,
                 )
             )
         else:
@@ -3307,6 +3332,7 @@ def _emit_mma_pipeline(
                     bm,
                     bn,
                     tcgen05_cluster_m=tcgen05_cluster_m,
+                    b_k_major=tcgen05_b_k_major,
                 )
             )
     if mma_impl == "tcgen05":
@@ -3335,6 +3361,7 @@ def _emit_mma_pipeline(
                 smem_swizzle_b=tcgen05_smem_swizzle_b,
                 explicit_epi_tile_m=tcgen05_explicit_epi_tile_m,
                 explicit_epi_tile_n=tcgen05_explicit_epi_tile_n,
+                b_k_major=tcgen05_b_k_major,
             )
         )
         prefix.append(
@@ -3941,6 +3968,11 @@ def _emit_mma_pipeline(
                 "k_total_size": k_total_size,
                 "kernel_args": [tma_atom_a, tma_tensor_a, tma_atom_b, tma_tensor_b],
             }
+            # K-major (column-major / K-contiguous) B. Only recorded when True
+            # so MN-major (row-major B) wrapper-plan literals stay byte-identical
+            # to the golden.
+            if tcgen05_b_k_major:
+                ab_tma_plan["b_k_major"] = True
             # ``smem_swizzle_*`` overrides are recorded only when codegen
             # selected an explicit SMEM atom kind (either from a user
             # override or the scalar-edge fallback workaround). Keeping
@@ -5332,6 +5364,7 @@ def _make_tiled_mma_setup(
     bn: int,
     *,
     tcgen05_cluster_m: int = 1,
+    b_k_major: bool = False,
 ) -> list[ast.AST]:
     if mma_impl == "warp":
         tiled_mma_expr = (
@@ -5347,6 +5380,7 @@ def _make_tiled_mma_setup(
             bm,
             bn,
             tcgen05_cluster_m=tcgen05_cluster_m,
+            b_k_major=b_k_major,
         )
     else:
         assert mma_thread_linear
@@ -5375,16 +5409,24 @@ def _tcgen05_tiled_mma_expr(
     bn: int,
     *,
     tcgen05_cluster_m: int = 1,
+    b_k_major: bool = False,
 ) -> str:
     cta_group_expr = "cute.nvgpu.tcgen05.CtaGroup.ONE"
     if _tcgen05_use_2cta_instrs(bm=bm, cluster_m=tcgen05_cluster_m):
         cta_group_expr = "cute.nvgpu.tcgen05.CtaGroup.TWO"
+    # A is always K-major. B is MN-major for row-major (N-contiguous) B and
+    # K-major for column-major (K-contiguous) B.
+    b_major_expr = (
+        "cute.nvgpu.OperandMajorMode.K"
+        if b_k_major
+        else "cute.nvgpu.OperandMajorMode.MN"
+    )
     return (
         "cutlass.utils.blackwell_helpers.make_trivial_tiled_mma("
         f"{input_dtype_str}, "
         f"{input_dtype_str}, "
         "cute.nvgpu.OperandMajorMode.K, "
-        "cute.nvgpu.OperandMajorMode.MN, "
+        f"{b_major_expr}, "
         f"{acc_dtype_str}, "
         f"{cta_group_expr}, "
         f"({bm}, {bn}), "
@@ -5431,6 +5473,7 @@ def _make_tcgen05_layout_plan_setup(
     smem_swizzle_b: int | None = None,
     explicit_epi_tile_m: int | None = None,
     explicit_epi_tile_n: int | None = None,
+    b_k_major: bool = False,
 ) -> list[ast.AST]:
     # `compute_epilogue_tile_shape` must receive `elem_ty_d` and `elem_ty_c`
     # equal to the eventual D-output dtype so the helper takes the
@@ -5463,7 +5506,7 @@ def _make_tcgen05_layout_plan_setup(
         ),
         statement_from_string(
             f"{plan.smem_b_layout} = "
-            f"{tcgen05_smem_layout_expr(tiled_mma=tiled_mma, bm=bm, bn=bn, bk=bk, dtype_str=input_dtype_str, num_stages=ab_stage_count, operand='b', swizzle_override=smem_swizzle_b)}"
+            f"{tcgen05_smem_layout_expr(tiled_mma=tiled_mma, bm=bm, bn=bn, bk=bk, dtype_str=input_dtype_str, num_stages=ab_stage_count, operand='b', swizzle_override=smem_swizzle_b, b_k_major=b_k_major)}"
         ),
         statement_from_string(
             f"{plan.c_layout} = cutlass.utils.layout.LayoutEnum.ROW_MAJOR"

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import ast
 from dataclasses import dataclass
+from dataclasses import replace as dataclass_replace
 import os
 import textwrap
 from typing import TYPE_CHECKING
@@ -1060,6 +1061,10 @@ class _PerKiterTmaArgs:
     # (cute_plan.md §6.12.7). Default 1 preserves byte-identity for the
     # validated cluster_m=2 cluster_n=1 path.
     cluster_n: int = 1
+    # Optional name of a hoisted ``make_warp_uniform(block_idx_in_cluster())``
+    # local; when set, owner predicates compare against it instead of
+    # re-deriving the cluster rank inline at every K-loop gate.
+    cluster_rank_var: str = ""
     # Static-full one-CTA pipelined TMA loops can drop the per-K runtime
     # full-tile branch and scalar fallback. Non-pipelined/asymmetric or two-CTA
     # TMA paths must keep the guarded fallback path.
@@ -1107,6 +1112,7 @@ def _tcgen05_two_cta_owner_predicate(
     is_two_cta: bool,
     gate_exec_warp: bool,
     cluster_n: int = 1,
+    cluster_rank_var: str = "",
 ) -> str | None:
     """Owner-of-the-V-pair predicate for AB consumer release / MMA issuance.
 
@@ -1124,7 +1130,18 @@ def _tcgen05_two_cta_owner_predicate(
     if gate_exec_warp:
         predicate_terms.append(exec_active)
     if is_two_cta:
-        if cluster_n > 1:
+        if cluster_rank_var:
+            # Caller hoisted ``make_warp_uniform(block_idx_in_cluster())``
+            # into a per-kernel local; reuse it instead of re-deriving the
+            # rank at every gate (the inline form costs S2UR+IMAD per use
+            # inside the K loop).
+            if cluster_n > 1:
+                predicate_terms.append(
+                    f"{cluster_rank_var} % cutlass.Int32(2) == cutlass.Int32(0)"
+                )
+            else:
+                predicate_terms.append(f"{cluster_rank_var} == cutlass.Int32(0)")
+        elif cluster_n > 1:
             predicate_terms.append(_TCGEN05_V_LEADER_PREDICATE)
         else:
             predicate_terms.append(_TCGEN05_CLUSTER_LEADER_PREDICATE)
@@ -1190,20 +1207,58 @@ def _build_kloop_pipeline_producer_if(
     return statement_from_string(src)
 
 
-def _build_kloop_pipeline_consumer_if(
+def _build_unified_tma_producer_stmts(args: _PerKiterTmaArgs) -> list[ast.stmt]:
+    """Unified per-K-tile TMA producer body (CUTLASS reference shape).
+
+    One body for ALL K tiles: ``try_acquire``-peeked ``producer_acquire``
+    blocks once the AB ring is full, so the same statements serve prologue
+    (ring filling) and steady state (ring reuse) — no separate unrolled
+    warm-up chain and no ``+ab_stage_count`` K offset. Only valid under
+    static-full tiles (no full/next-tile predicates needed) inside the
+    role-local producer's own K loop (blocking acquire cannot stall the MMA
+    or epilogue warps).
+    """
+    assert args.use_tma_a and args.use_tma_b, (
+        "pipelined branch requires both A and B to be TMA-loaded"
+    )
+    assert not args.skip_producer_acquire and not args.skip_producer_advance, (
+        "diagnostic acquire/advance skips keep the unrolled prologue path"
+    )
+    copy_a_src = _kloop_tma_copy_a_src(args, k_offset=args.tma_k_tile)
+    copy_b_src = _kloop_tma_copy_b_src(args, k_offset=args.tma_k_tile)
+    return [
+        statement_from_string(line)
+        for line in (
+            f"{args.tma_pipeline}.producer_acquire({args.tma_producer_state})",
+            f"{args.tma_barrier_ptr} = "
+            f"{args.tma_pipeline}.producer_get_barrier({args.tma_producer_state})",
+            copy_a_src.strip(),
+            copy_b_src.strip(),
+            f"{args.tma_pipeline}.producer_commit({args.tma_producer_state})",
+            emit_pipeline_advance(args.tma_producer_state),
+        )
+    ]
+
+
+def _build_kloop_pipeline_consumer_stmts(
     args: _PerKiterTmaArgs,
     *,
     gate_exec_warp: bool = True,
     include_scalar_fallback: bool = True,
     use_existing_try_token: bool = False,
     sync_before_scalar_fallback: bool = False,
-) -> ast.stmt:
-    """Per-K-iter TMA consumer / scalar-fallback ``if`` for the pipelined branch."""
+) -> list[ast.stmt]:
+    """Per-K-iter TMA consumer / scalar-fallback statements (pipelined branch).
+
+    Every form emits a single statement except the ungated static-full
+    try-wait + wait pair, which emits two siblings.
+    """
     if args.static_full_tiles:
-        assert not args.is_two_cta, (
-            "static-full fast path is only valid for one-CTA pipelined TMA loops"
-        )
-        assert gate_exec_warp, "static-full fast path requires an exec-warp gate"
+        # One-CTA inline callers keep the exec-warp gate; the role-local
+        # separate exec loop passes ``gate_exec_warp=False`` because the
+        # loop already lives inside the MMA-exec role block (two-CTA adds
+        # the V/cluster-leader owner predicate below).
+        assert gate_exec_warp or not args.is_two_cta or args.cluster_n >= 1
         assert not include_scalar_fallback, (
             "static-full fast path has no scalar fallback branch"
         )
@@ -1223,18 +1278,28 @@ def _build_kloop_pipeline_consumer_if(
             f"{args.tma_pipeline}.consumer_wait("
             f"{args.tma_consumer_state}, {args.tma_consumer_try_token})"
         )
+    consumer_gate = _tcgen05_two_cta_owner_predicate(
+        args.exec_active,
+        is_two_cta=args.is_two_cta,
+        gate_exec_warp=gate_exec_warp,
+        cluster_n=args.cluster_n,
+        cluster_rank_var=args.cluster_rank_var,
+    )
+    if args.static_full_tiles and consumer_gate is None:
+        # Ungated static-full form: emit the (possibly multi-line) wait
+        # sequence as sibling statements with no wrapper.
+        return [
+            statement_from_string(line)
+            for line in consumer_src.splitlines()
+            if line.strip()
+        ]
     full_tile_src = _tcgen05_emit_optional_gate(
         consumer_src,
-        _tcgen05_two_cta_owner_predicate(
-            args.exec_active,
-            is_two_cta=args.is_two_cta,
-            gate_exec_warp=gate_exec_warp,
-            cluster_n=args.cluster_n,
-        ),
+        consumer_gate,
         indent="" if args.static_full_tiles else "    ",
     )
     if args.static_full_tiles:
-        return statement_from_string(full_tile_src)
+        return [statement_from_string(full_tile_src)]
     fallback_src = ""
     if include_scalar_fallback:
         scalar_load_a_src = textwrap.indent(ast.unparse(args.scalar_load_a), "    ")
@@ -1250,7 +1315,26 @@ def _build_kloop_pipeline_consumer_if(
             "    cute.arch.sync_threads()"
         )
     src = f"if {args.tma_full_tile}:\n{full_tile_src}{fallback_src}"
-    return statement_from_string(src)
+    return [statement_from_string(src)]
+
+
+def _build_kloop_pipeline_consumer_if(
+    args: _PerKiterTmaArgs,
+    *,
+    gate_exec_warp: bool = True,
+    include_scalar_fallback: bool = True,
+    use_existing_try_token: bool = False,
+    sync_before_scalar_fallback: bool = False,
+) -> ast.stmt:
+    """Single-statement form of :func:`_build_kloop_pipeline_consumer_stmts`."""
+    (stmt,) = _build_kloop_pipeline_consumer_stmts(
+        args,
+        gate_exec_warp=gate_exec_warp,
+        include_scalar_fallback=include_scalar_fallback,
+        use_existing_try_token=use_existing_try_token,
+        sync_before_scalar_fallback=sync_before_scalar_fallback,
+    )
+    return stmt
 
 
 def _build_kloop_pipeline_consumer_prefetch_stmts(
@@ -1266,6 +1350,7 @@ def _build_kloop_pipeline_consumer_prefetch_stmts(
         is_two_cta=args.is_two_cta,
         gate_exec_warp=gate_exec_warp,
         cluster_n=args.cluster_n,
+        cluster_rank_var=args.cluster_rank_var,
     )
     if owner_predicate is not None:
         predicate = f"{predicate} and {owner_predicate}"
@@ -1279,13 +1364,13 @@ def _build_kloop_pipeline_consumer_prefetch_stmts(
     ]
 
 
-def _build_kloop_pipeline_release_if(
+def _build_kloop_pipeline_release_stmts(
     args: _PerKiterTmaArgs,
     *,
     gate_exec_warp: bool = True,
     include_scalar_fallback: bool = True,
-) -> ast.stmt:
-    """Per-K-iter consumer release ``if`` for the pipelined branch.
+) -> list[ast.stmt]:
+    """Per-K-iter consumer release statements for the pipelined branch.
 
     Producer-state advance lives in the producer block (one per
     commit), so only the consumer-state advance is emitted here. In
@@ -1295,10 +1380,9 @@ def _build_kloop_pipeline_release_if(
     multicast mask; separate peer arrivals over-count the empty barrier.
     """
     if args.static_full_tiles:
-        assert not args.is_two_cta, (
-            "static-full fast path is only valid for one-CTA pipelined TMA loops"
-        )
-        assert gate_exec_warp, "static-full fast path requires an exec-warp gate"
+        # See the consumer-if note: one-CTA inline callers keep the exec-warp
+        # gate; the role-local separate exec loop drops it (two-CTA keeps the
+        # leader owner predicate below).
         assert not include_scalar_fallback, (
             "static-full fast path has no scalar fallback branch"
         )
@@ -1308,6 +1392,7 @@ def _build_kloop_pipeline_release_if(
         is_two_cta=args.is_two_cta,
         gate_exec_warp=gate_exec_warp,
         cluster_n=args.cluster_n,
+        cluster_rank_var=args.cluster_rank_var,
     )
     advance_src = emit_pipeline_advance(args.tma_consumer_state)
     indent = "" if args.static_full_tiles else "    "
@@ -1315,22 +1400,38 @@ def _build_kloop_pipeline_release_if(
         # With gate_exec_warp=False the caller is already inside the
         # role-local exec loop, so every iteration can advance local state.
         advance_gate = args.exec_active if gate_exec_warp else None
+        if args.static_full_tiles:
+            # No full-tile wrapper: the two gated blocks are siblings.
+            return [
+                statement_from_string(
+                    _tcgen05_emit_optional_gate(release_src, release_gate, indent="")
+                ),
+                statement_from_string(
+                    _tcgen05_emit_optional_gate(advance_src, advance_gate, indent="")
+                ),
+            ]
         full_tile_src = (
             _tcgen05_emit_optional_gate(release_src, release_gate, indent=indent)
             + "\n"
             + _tcgen05_emit_optional_gate(advance_src, advance_gate, indent=indent)
         )
     else:
+        if args.static_full_tiles and release_gate is None:
+            # Ungated static-full form: two sibling statements, no wrapper.
+            return [
+                statement_from_string(release_src),
+                statement_from_string(advance_src),
+            ]
         full_tile_src = _tcgen05_emit_optional_gate(
             release_src + "\n" + advance_src, release_gate, indent=indent
         )
     if args.static_full_tiles:
-        return statement_from_string(full_tile_src)
+        return [statement_from_string(full_tile_src)]
     fallback_src = (
         "\nelse:\n    cute.arch.sync_threads()" if include_scalar_fallback else ""
     )
     src = f"if {args.tma_full_tile}:\n{full_tile_src}{fallback_src}"
-    return statement_from_string(src)
+    return [statement_from_string(src)]
 
 
 def _build_tcgen05_mma_accumulate_reset_stmt(
@@ -1340,6 +1441,7 @@ def _build_tcgen05_mma_accumulate_reset_stmt(
     gate_exec_warp: bool = True,
     is_two_cta: bool = False,
     cluster_n: int = 1,
+    cluster_rank_var: str = "",
 ) -> ast.stmt:
     reset_src = f"{tiled_mma}.set(cute.nvgpu.tcgen05.Field.ACCUMULATE, False)"
     predicate = _tcgen05_two_cta_owner_predicate(
@@ -1347,6 +1449,7 @@ def _build_tcgen05_mma_accumulate_reset_stmt(
         is_two_cta=is_two_cta,
         gate_exec_warp=gate_exec_warp,
         cluster_n=cluster_n,
+        cluster_rank_var=cluster_rank_var,
     )
     if predicate is None:
         return statement_from_string(reset_src)
@@ -1364,6 +1467,7 @@ def _build_tcgen05_mma_issue_stmt(
     gate_exec_warp: bool = True,
     is_two_cta: bool = False,
     cluster_n: int = 1,
+    cluster_rank_var: str = "",
 ) -> ast.stmt:
     issue_src = (
         f"for _tcgen05_kblk_idx in range(cute.size({tcgen05_frag_a}, mode=[2])):\n"
@@ -1381,6 +1485,7 @@ def _build_tcgen05_mma_issue_stmt(
         is_two_cta=is_two_cta,
         gate_exec_warp=gate_exec_warp,
         cluster_n=cluster_n,
+        cluster_rank_var=cluster_rank_var,
     )
     if predicate is not None:
         issue_src = f"if {predicate}:\n{textwrap.indent(issue_src, '    ')}"
@@ -2377,6 +2482,32 @@ def _emit_mma_pipeline(
             f"{TCGEN05_AB_CONSUMER_PHASE_MODE_PHASE1!r} requires the guarded "
             "cluster_m=2, CtaGroup.ONE, 128x256x128 bridge shape",
         )
+    # Unified TMA producer (CUTLASS reference shape): one rolled K loop over
+    # ALL K tiles where ``producer_acquire`` blocks once the AB ring is
+    # full — pipelining comes from the mbarrier handshake, not from a
+    # separate unrolled warm-up prologue plus an ``+ab_stages``-offset
+    # steady-state loop. Requires static-full tiles (every prologue/tail
+    # predicate is a compile-time truth) and the role-local separate
+    # producer loop (the producer warp owns its own K loop, so blocking in
+    # ``producer_acquire`` cannot stall MMA or epilogue work). The
+    # unrolled-prologue form at ab_stages=8 put 24 static UTMALDG sites in
+    # SASS (vs the reference's 2) and re-derived loop-invariant full-tile
+    # predicates per stage and per K iteration.
+    tcgen05_use_unified_tma_producer = (
+        tcgen05_static_full_tiles
+        and tcgen05_use_tma_pipeline
+        and tcgen05_use_separate_tma_producer
+        and not tcgen05_role_local_uses_k_tail_tma
+        and not tcgen05_role_local_double_edge_tma
+        and not tcgen05_role_local_m_edge_tma
+        and not tcgen05_role_local_n_edge_tma
+        # Bridge diagnostics address individual acquire/advance edges of the
+        # unrolled prologue + offset steady-state form; keep that form when
+        # any of them is requested.
+        and not diagnose_skip_ab_producer_acquire
+        and not diagnose_skip_initial_ab_producer_acquire
+        and not diagnose_skip_ab_producer_advance
+    )
     # Static-full CtaGroup.TWO keeps a prefetched AB consumer token live
     # across the accumulator acquire and each K-loop issue. CtaGroup.ONE
     # keeps the older adjacent try-wait/wait sequence.
@@ -4275,28 +4406,32 @@ def _emit_mma_pipeline(
                     skip_producer_acquire=diagnose_skip_ab_producer_acquire,
                     skip_producer_advance=diagnose_skip_ab_producer_advance,
                 )
-                _emit_per_tile(
-                    f"{tma_initial_full_tile} = "
-                    + _tcgen05_tma_tile_predicate(
-                        k_tile_start_expr="cutlass.Int32(0)",
-                        full_tile_end_expr=f"cutlass.Int32({bk})",
-                    ),
-                    tma_load=tcgen05_use_role_local_tma_producer,
-                )
-                stage0_prefetch = _build_initial_prefetch_if(
-                    prefetch_args,
-                    full_tile_gates=[tma_initial_full_tile],
-                    k_offset="cutlass.Int32(0)",
-                    skip_producer_acquire=(
-                        diagnose_skip_ab_producer_acquire
-                        or diagnose_skip_initial_ab_producer_acquire
-                    ),
-                )
-                prefix.append(stage0_prefetch)
-                per_tile_stmts.append(stage0_prefetch)
-                if tcgen05_use_role_local_tma_producer:
-                    tma_load_role_stmts.append(stage0_prefetch)
-                if tcgen05_ab_stage_count_value > 1:
+                if not tcgen05_use_unified_tma_producer:
+                    _emit_per_tile(
+                        f"{tma_initial_full_tile} = "
+                        + _tcgen05_tma_tile_predicate(
+                            k_tile_start_expr="cutlass.Int32(0)",
+                            full_tile_end_expr=f"cutlass.Int32({bk})",
+                        ),
+                        tma_load=tcgen05_use_role_local_tma_producer,
+                    )
+                    stage0_prefetch = _build_initial_prefetch_if(
+                        prefetch_args,
+                        full_tile_gates=[tma_initial_full_tile],
+                        k_offset="cutlass.Int32(0)",
+                        skip_producer_acquire=(
+                            diagnose_skip_ab_producer_acquire
+                            or diagnose_skip_initial_ab_producer_acquire
+                        ),
+                    )
+                    prefix.append(stage0_prefetch)
+                    per_tile_stmts.append(stage0_prefetch)
+                    if tcgen05_use_role_local_tma_producer:
+                        tma_load_role_stmts.append(stage0_prefetch)
+                if (
+                    not tcgen05_use_unified_tma_producer
+                    and tcgen05_ab_stage_count_value > 1
+                ):
                     # Warm every stage 1..ab_stage_count-1; each gated by
                     # an ``i+1``-k_tile fits-in-K predicate. The old
                     # two-call pattern only covered stages 0 and N-1
@@ -4613,6 +4748,15 @@ def _emit_mma_pipeline(
                 scalar_load_b=scalar_load_b,
                 cluster_n=tcgen05_cluster_n,
                 static_full_tiles=tcgen05_static_full_tma_fast_path,
+                # The hoisted rank local is emitted in the prefix under the
+                # same condition (see ``tma_cta_rank_in_cluster`` above), so
+                # per-K owner gates can reuse it instead of re-deriving the
+                # cluster rank each iteration.
+                cluster_rank_var=(
+                    tma_cta_rank_in_cluster
+                    if (tcgen05_cluster_m > 1 or tcgen05_is_two_cta)
+                    else ""
+                ),
             )
             if tcgen05_use_tma_pipeline:
                 if tcgen05_use_separate_tma_producer:
@@ -4621,30 +4765,35 @@ def _emit_mma_pipeline(
                             f"{tma_k_tile} = {k_offset_var} // cutlass.Int32({bk})"
                         )
                     ]
-                    if not tcgen05_static_full_tma_fast_path:
-                        assert tma_full_tile_predicate_src is not None
-                        producer_loop_body.append(
-                            statement_from_string(
-                                f"{tma_full_tile} = " + tma_full_tile_predicate_src
-                            )
+                    if tcgen05_use_unified_tma_producer:
+                        producer_loop_body.extend(
+                            _build_unified_tma_producer_stmts(tma_kloop_args)
                         )
-                    producer_loop_body.extend(
-                        [
-                            statement_from_string(
-                                f"{tma_next_full_tile} = "
-                                + _tcgen05_tma_tile_predicate(
-                                    k_tile_start_expr=f"{k_offset_var} + cutlass.Int32({bk * tcgen05_ab_stage_count_value})",
-                                    full_tile_end_expr=f"{k_offset_var} + cutlass.Int32({bk * (tcgen05_ab_stage_count_value + 1)})",
+                    else:
+                        if not tcgen05_static_full_tma_fast_path:
+                            assert tma_full_tile_predicate_src is not None
+                            producer_loop_body.append(
+                                statement_from_string(
+                                    f"{tma_full_tile} = " + tma_full_tile_predicate_src
                                 )
-                            ),
-                            statement_from_string(
-                                f"{tma_producer_try_token} = cutlass.Boolean(0)"
-                            ),
-                            _build_kloop_pipeline_producer_if(
-                                tma_kloop_args, gate_tma_warp=False
-                            ),
-                        ]
-                    )
+                            )
+                        producer_loop_body.extend(
+                            [
+                                statement_from_string(
+                                    f"{tma_next_full_tile} = "
+                                    + _tcgen05_tma_tile_predicate(
+                                        k_tile_start_expr=f"{k_offset_var} + cutlass.Int32({bk * tcgen05_ab_stage_count_value})",
+                                        full_tile_end_expr=f"{k_offset_var} + cutlass.Int32({bk * (tcgen05_ab_stage_count_value + 1)})",
+                                    )
+                                ),
+                                statement_from_string(
+                                    f"{tma_producer_try_token} = cutlass.Boolean(0)"
+                                ),
+                                _build_kloop_pipeline_producer_if(
+                                    tma_kloop_args, gate_tma_warp=False
+                                ),
+                            ]
+                        )
                     producer_loop = _clone_k_loop_with_body(
                         device_loop,
                         producer_loop_body,
@@ -4667,12 +4816,25 @@ def _emit_mma_pipeline(
                     assert mma_stage_stmt is not None
                     assert smem_a_mma_stmt is not None
                     assert smem_b_mma_stmt is not None
+                    # Under the unified producer the exec K loop also drops
+                    # its per-iteration full-tile predicate: static-full means
+                    # every K tile is full, so consumer wait/release run
+                    # unconditionally (their two-CTA owner gates remain).
+                    exec_static_full = (
+                        tcgen05_static_full_tma_fast_path
+                        or tcgen05_use_unified_tma_producer
+                    )
+                    exec_kloop_args = (
+                        dataclass_replace(tma_kloop_args, static_full_tiles=True)
+                        if tcgen05_use_unified_tma_producer
+                        else tma_kloop_args
+                    )
                     exec_loop_body: list[ast.stmt] = [
                         mma_stage_stmt,
                         smem_a_mma_stmt,
                         smem_b_mma_stmt,
                     ]
-                    if not tcgen05_static_full_tma_fast_path:
+                    if not exec_static_full:
                         assert tma_full_tile_stmt is not None
                         exec_loop_body.append(tma_full_tile_stmt)
                     if tcgen05_use_role_local_ab_consumer_prefetch:
@@ -4691,9 +4853,9 @@ def _emit_mma_pipeline(
                                 f"{tma_consumer_try_token} = cutlass.Boolean(0)"
                             )
                         )
-                    exec_loop_body.append(
-                        _build_kloop_pipeline_consumer_if(
-                            tma_kloop_args,
+                    exec_loop_body.extend(
+                        _build_kloop_pipeline_consumer_stmts(
+                            exec_kloop_args,
                             # Static-full pipeline builders require their
                             # internal exec gate to keep emitting a single
                             # statement. The outer wrapper below makes the
@@ -4724,11 +4886,12 @@ def _emit_mma_pipeline(
                                 gate_exec_warp=tcgen05_static_full_tma_fast_path,
                                 is_two_cta=tcgen05_is_two_cta,
                                 cluster_n=tcgen05_cluster_n,
+                                cluster_rank_var=tma_kloop_args.cluster_rank_var,
                             )
                         )
-                    exec_loop_body.append(
-                        _build_kloop_pipeline_release_if(
-                            tma_kloop_args,
+                    exec_loop_body.extend(
+                        _build_kloop_pipeline_release_stmts(
+                            exec_kloop_args,
                             # See the consumer wait comment above.
                             gate_exec_warp=tcgen05_static_full_tma_fast_path,
                             include_scalar_fallback=False,
@@ -4884,19 +5047,23 @@ def _emit_mma_pipeline(
                             mma_stage=mma_stage,
                             is_two_cta=tcgen05_is_two_cta,
                             cluster_n=tcgen05_cluster_n,
+                            cluster_rank_var=(
+                                tma_kloop_args.cluster_rank_var
+                                if tcgen05_use_tma and tma_kloop_args is not None
+                                else ""
+                            ),
                         )
                     )
                 if tcgen05_use_tma:
                     assert tma_kloop_args is not None
                     if tcgen05_use_tma_pipeline:
-                        cg.add_statement(
-                            _build_kloop_pipeline_release_if(
-                                tma_kloop_args,
-                                include_scalar_fallback=(
-                                    not tcgen05_static_full_tma_fast_path
-                                ),
-                            )
-                        )
+                        for release_stmt in _build_kloop_pipeline_release_stmts(
+                            tma_kloop_args,
+                            include_scalar_fallback=(
+                                not tcgen05_static_full_tma_fast_path
+                            ),
+                        ):
+                            cg.add_statement(release_stmt)
                     else:
                         cg.add_statement(
                             _build_kloop_non_pipeline_release_if(tma_kloop_args)

--- a/helion/_compiler/cute/strategies.py
+++ b/helion/_compiler/cute/strategies.py
@@ -389,6 +389,7 @@ def tcgen05_smem_layout_expr(
     num_stages: int,
     operand: str,
     swizzle_override: int | None,
+    b_k_major: bool = False,
 ) -> str:
     """Emit the CuTe expression that builds the staged SMEM layout for A or B.
 
@@ -439,6 +440,17 @@ def tcgen05_smem_layout_expr(
             "order=(1, 2, 3))"
         )
     assert operand == "b", f"unexpected operand {operand!r}"
+    if b_k_major:
+        # K-major (column-major / K-contiguous) B. Delegate to CuTe's helper
+        # with ``is_k_major=True`` so the SMEM atom selection mirrors the
+        # K-major A path exactly; the smem_swizzle_b override knob is not
+        # plumbed through this path (correctness-first), which is fine
+        # since the fp8 default path uses swizzle_override=None.
+        return (
+            "cutlass.utils.blackwell_helpers.make_smem_layout_b("
+            f"{tiled_mma}, ({bm}, {bn}, {bk}), {dtype_str}, {num_stages}, "
+            "is_k_major=True)"
+        )
     if swizzle_override is None:
         return (
             "cutlass.utils.blackwell_helpers.make_smem_layout_b("

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -945,6 +945,105 @@ class CuteTcgen05Config:
             and block_sizes[1] == TCGEN05_TWO_CTA_BLOCK_N
         )
 
+    @staticmethod
+    def _get_dtype_ab_stages_hard_cap(dtype_bytes: int) -> int:
+        """Get hardware-validated maximum ab_stages for a dtype.
+
+        The maximum practical ab_stages depends on dtype size because
+        smaller dtypes fit more pipeline stages in the same SMEM budget:
+        - FP8 (1 byte): 12 stages - validated on B200, fits 2x bf16
+        - FP16/BF16 (2 bytes): 6 stages - TVM-FFI seed validated
+        - FP32 (4 bytes): 3 stages - baseline for larger dtypes
+
+        Args:
+            dtype_bytes: Size of data type in bytes
+
+        Returns:
+            Maximum ab_stages for this dtype, or 0 if invalid
+        """
+        if dtype_bytes <= 0:
+            return 0
+        if dtype_bytes == 1:  # FP8
+            return 12
+        if dtype_bytes == 2:  # FP16/BF16
+            return 6
+        # FP32 or larger
+        return 3
+
+    def max_ab_stages_that_fit(
+        self,
+        *,
+        bm: int,
+        bn: int,
+        bk: int,
+        cluster_m: int,
+        hard_cap: int | None = None,
+    ) -> int:
+        """Compute maximum ab_stages that fits in per-CTA SMEM budget.
+
+        Mirrors CUTLASS's ``_compute_stages``: fill SMEM with as many AB
+        pipeline stages as fit the hardware budget. Uses direct calculation
+        since SMEM usage scales linearly with ab_stages.
+
+        For FP8 (1-byte operands), this enables ~2x deeper staging than
+        BF16 (2-byte), which is critical for hiding K-loop TMA latency
+        in compute-bound kernels.
+
+        Args:
+            bm: Block size in M dimension
+            bn: Block size in N dimension
+            bk: Block size in K dimension
+            cluster_m: CTA cluster size (1 or 2)
+            hard_cap: Optional maximum stages override. If None, uses
+                dtype-specific default (12 for FP8, 6 for FP16, 3 for FP32)
+
+        Returns:
+            Maximum valid ab_stages in [1, hard_cap], or 0 if constraints
+            are unknown or configuration is invalid (e.g., ab_stages=1
+            doesn't fit budget).
+
+        Example:
+            >>> # FP8 256x256x64 cluster_m=2
+            >>> config.max_ab_stages_that_fit(bm=256, bn=256, bk=64, cluster_m=2)
+            8  # FP8 fits 8 stages
+
+            >>> # BF16 same tile (2x larger per stage)
+            >>> config.max_ab_stages_that_fit(bm=256, bn=256, bk=64, cluster_m=2)
+            4  # BF16 fits only 4 stages
+        """
+        constraints = self.ab_stages_three_search_constraints
+        if constraints is None or bm <= 0 or bn <= 0 or bk <= 0:
+            return 0
+        if cluster_m not in (1, 2):
+            return 0
+
+        # Calculate SMEM cost for ab_stages=1 (baseline)
+        bytes_per_stage = tcgen05_ab_smem_bytes_per_cta(
+            bm=bm,
+            bn=bn,
+            bk=bk,
+            dtype_bytes=constraints.dtype_bytes,
+            ab_stages=1,
+            cluster_m=cluster_m,
+        )
+
+        # Edge cases: invalid calculation or even ab_stages=1 doesn't fit
+        if bytes_per_stage <= 0:
+            return 0
+        if bytes_per_stage > constraints.per_cta_smem_budget_bytes:
+            return 0
+
+        # Direct calculation: SMEM usage scales linearly with ab_stages
+        # Solve: N * bytes_per_stage <= budget
+        max_from_budget = constraints.per_cta_smem_budget_bytes // bytes_per_stage
+
+        # Apply hard cap (dtype-specific default if not provided)
+        if hard_cap is None:
+            hard_cap = self._get_dtype_ab_stages_hard_cap(constraints.dtype_bytes)
+
+        # Return clamped value: at least 1, at most hard_cap or budget limit
+        return max(1, min(max_from_budget, hard_cap))
+
     def _fix_ab_stages_three_search_config(self, config: dict[str, object]) -> None:
         if self.ab_stages_three_search_constraints is None:
             return
@@ -1224,10 +1323,33 @@ class CuteTcgen05Config:
             )
         ):
             return
+        # FP8 (1-byte) operands fit a deeper AB pipeline than the bf16-tuned
+        # cap of 3; admit ab_stages > 3 for fp8 as long as the AB SMEM fits the
+        # per-CTA budget. This lets Helion emit the same deeply-pipelined
+        # CtaGroup.TWO kernel CUTLASS uses for fp8 compute-bound GEMMs.
+        constraints = self.ab_stages_three_search_constraints
+        if constraints is not None and constraints.dtype_bytes == 1:  # FP8
+            block_sizes = cast("list[int]", config.get("block_sizes"))
+            cluster_m = cast("int", config.get("tcgen05_cluster_m", 1))
+            if isinstance(block_sizes, list) and len(block_sizes) >= 3:
+                fit_max = self.max_ab_stages_that_fit(
+                    bm=block_sizes[0],
+                    bn=block_sizes[1],
+                    bk=block_sizes[2],
+                    cluster_m=cluster_m,
+                )
+                if fit_max > 0 and ab_stages <= fit_max:
+                    return
+                if fix_invalid and fit_max > 0:
+                    config["tcgen05_ab_stages"] = fit_max
+                    return
         if fix_invalid:
             config["tcgen05_ab_stages"] = 3
             return
-        raise InvalidConfig("tcgen05_ab_stages > 3 is not supported")
+        raise InvalidConfig(
+            "tcgen05_ab_stages > 3 is only supported by the validated "
+            "Target1 TVM-FFI seed (or fp8 within the SMEM budget)"
+        )
 
     def _is_validated_clc_persistence_search_candidate(
         self, config: dict[str, object]
@@ -1678,6 +1800,15 @@ class CuteTcgen05Config:
             # SEARCH stays capped at 3 (budget-aware) since the generalized seed
             # runs at ab=3 and deeper pipelines are not worth searching.
             ab_stages_max = 6 if self.full_tile_direct_entry_seed_eligible() else 3
+            # FP8 (1-byte) operands fit a deeper AB pipeline than the bf16-tuned
+            # cap; admit a frozen deep-staged fp8 config on the validation
+            # surface too (``_validate_target1_ab_stage_envelope`` clamps it to
+            # the actual per-CTA SMEM budget for the chosen block sizes).
+            constraints = self.ab_stages_three_search_constraints
+            if constraints is not None and constraints.dtype_bytes == 1:  # FP8
+                ab_stages_max = self._get_dtype_ab_stages_hard_cap(
+                    constraints.dtype_bytes
+                )
         elif self.ab_stages_three_search_constraints is not None:
             # Cycle 97: make ab=3 BUDGET-AWARE-SEARCHABLE. Where the device/dtype
             # admits ab=3 at all (the SMEM-budget constraints were recorded by
@@ -1689,6 +1820,15 @@ class CuteTcgen05Config:
             # cluster_m=1 256x256 overflows bare-AB) before codegen, so admission is
             # free but an overflowing kernel is never generated.
             ab_stages_max = 3
+            # FP8 (1-byte) operands fit a deeper AB pipeline; widen the
+            # validation range so an explicit deep-staged fp8 config is
+            # accepted (``_validate_target1_ab_stage_envelope`` clamps it to
+            # the actual per-CTA SMEM budget for the chosen block sizes).
+            constraints = self.ab_stages_three_search_constraints
+            if constraints is not None and constraints.dtype_bytes == 1:  # FP8
+                ab_stages_max = self._get_dtype_ab_stages_hard_cap(
+                    constraints.dtype_bytes
+                )
         else:
             ab_stages_max = 2
         if for_search:

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import ast
 import builtins
-from collections.abc import Iterable
 import contextlib
 import copy
 import dataclasses

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -30,7 +30,6 @@ from .device_function import DeviceFunction
 from .helper_function import CodegenInterface
 from .inductor_lowering import CodegenState
 from .inductor_lowering import codegen_call_with_graph
-from .loop_dependency_checker import LoopDependencyChecker
 from .output_header import get_needed_import_lines
 from .program_id import ForEachProgramID
 from .tile_strategy import DeviceGridState

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -2647,9 +2647,12 @@ def _codegen_cute_store_tcgen05_tile(
         # Broadcast aux steps need a fresh AST var for the 2-D view
         # of the rank-1 underlying tensor (stride 0 on the orthogonal
         # axis). Exact-shape aux steps leave ``aux_view2d`` as None.
+        # broadcast_axis 0/1 build a stride-0 2-D view of a rank-1 tensor;
+        # the colvec form (2) reuses the exact-shape pipeline over its own
+        # (M, N) stride-(1,0) view, so it needs no separate ``aux_view2d``.
         aux_view2d = (
             df.new_var(f"tcgen05_aux_view2d_{aux_idx}")
-            if aux_step.broadcast_axis is not None
+            if aux_step.broadcast_axis in (0, 1)
             else None
         )
         aux_step_records.append(
@@ -2826,6 +2829,10 @@ def _codegen_cute_store_tcgen05_tile(
         aux_pipeline_uses_tma_load = False
         aux_ring_smem_names = tuple(None for _ in aux_step_records)
 
+    # Row-vector aux (``bias[n]`` / rowwise ``scale_b[n]``) reads stay
+    # per-subtile (the generic ``ttr_aux_subtile.load()`` path below, placed
+    # after the c_pipeline acquire / acc ``consumer_wait`` / T2R prefix per the
+    # cycle-69 placement).
     rowvec_aux_stage_records: list[_RowvecAuxStageRecord | None] = []
     for aux_idx, rec in enumerate(aux_step_records):
         copy_bits = 128
@@ -3102,9 +3109,11 @@ def _codegen_cute_store_tcgen05_tile(
                 )
                 continue
 
-            if rec.broadcast_axis is None:
-                # Exact-shape rank-2 aux: slice the per-tile region
-                # of the underlying 2-D tensor directly.
+            if rec.broadcast_axis is None or rec.broadcast_axis == 2:
+                # Exact-shape rank-2 aux (or the colvec form, which is a full
+                # (M, N) stride-(1,0) view): slice the per-tile region of the
+                # underlying 2-D tensor directly. The colvec's per-subtile read
+                # is specialized to a scalar in ``_aux_subtile_load_source``.
                 source_for_local_tile = rec.aux_tensor_name
                 aux_tile_is_local = False
             elif rowvec_stage is not None:
@@ -3405,6 +3414,18 @@ def _codegen_cute_store_tcgen05_tile(
                     f"cute.filter_zeros({rec.ttr_aux_subtile}), "
                     f"cute.filter_zeros({rec.aux_rmem}))\n"
                     f"{prelude_indent}{rec.aux_loaded} = {rec.aux_rmem}.load()\n"
+                )
+                continue
+            if rec.broadcast_axis == 2:
+                # Column-vector (per-row) aux: uniform over each thread's N
+                # fragment, so read a single SCALAR per subtile (T2R index
+                # (0,0,0)) instead of a redundant N-wide vector ``.load()``.
+                # Matches CUTLASS's ``sa = tTR_gSA[(0,0,0,subtile)]``; the
+                # scalar broadcasts in the ``acc * aux`` chain multiply.
+                lines.append(
+                    f"{prelude_indent}{rec.aux_loaded} = "
+                    f"{rec.ttr_aux_grouped}"
+                    f"[(0, 0, 0, cutlass.Int32(_tcgen05_subtile))]\n"
                 )
                 continue
             lines.extend(

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -2177,6 +2177,9 @@ def _append_cute_wrapper_plan(
     smem_swizzle_b: int | None = (
         int(smem_swizzle_b_raw) if isinstance(smem_swizzle_b_raw, int) else None
     )
+    # K-major (column-major / K-contiguous) B. Absent on the MN-major
+    # (row-major B) default path.
+    b_k_major = bool(plan.get("b_k_major"))
     kernel_args = [str(arg) for arg in cast("list[object]", plan["kernel_args"])]
     assert len(kernel_args) == 4
     tma_atom_a, tma_tensor_a, tma_atom_b, tma_tensor_b = kernel_args
@@ -2218,6 +2221,7 @@ def _append_cute_wrapper_plan(
         num_stages=ab_stage_count,
         operand="b",
         swizzle_override=smem_swizzle_b,
+        b_k_major=b_k_major,
     )
     body.extend(
         (
@@ -2226,8 +2230,12 @@ def _append_cute_wrapper_plan(
                 f"{input_dtype}, "
                 f"{input_dtype}, "
                 "cute.nvgpu.OperandMajorMode.K, "
-                "cute.nvgpu.OperandMajorMode.MN, "
-                f"{acc_dtype}, "
+                + (
+                    "cute.nvgpu.OperandMajorMode.K, "
+                    if b_k_major
+                    else "cute.nvgpu.OperandMajorMode.MN, "
+                )
+                + f"{acc_dtype}, "
                 f"{cta_group}, "
                 f"({bm}, {bn}), "
                 "cute.nvgpu.tcgen05.OperandSource.SMEM)"
@@ -2245,7 +2253,10 @@ def _append_cute_wrapper_plan(
                 f"(arg{rhs_idx}_shape1, arg{rhs_idx}_shape0), "
                 f"stride=(arg{rhs_idx}_stride1, arg{rhs_idx}_stride0)))"
             ),
-            f"    {rhs_tma}.mark_layout_dynamic(leading_dim=0)",
+            # B is viewed as (N, K). For row-major B (MN-major) the N axis
+            # (position 0) is contiguous; for column-major B (K-major, native
+            # fp8 layout) the K axis (position 1) is contiguous.
+            f"    {rhs_tma}.mark_layout_dynamic(leading_dim={1 if b_k_major else 0})",
             # ``make_tiled_tma_atom_A`` vs ``_B`` asymmetry:
             # - ``_B`` always passes ``cluster_layout_vmnk.shape`` as
             #   its trailing arg (CuTe's signature for B requires the

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -1071,7 +1071,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
 
                 with self.assertRaisesRegex(
                     helion.exc.InvalidConfig,
-                    "tcgen05_ab_stages > 3 is not supported",
+                    "tcgen05_ab_stages > 3 is only supported",
                 ):
                     bound.config_spec.normalize(
                         _non_seed_stage_config(requested_ab_stages)
@@ -1106,7 +1106,7 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
             **{TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY: True},
         )
         with self.assertRaisesRegex(
-            helion.exc.InvalidConfig, "tcgen05_ab_stages > 3 is not supported"
+            helion.exc.InvalidConfig, "tcgen05_ab_stages > 3 is only supported"
         ):
             bound.config_spec.normalize(ffi_direct_entry_ab6_bk128)
 

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -1247,6 +1247,32 @@ class TestCuteBackend(TestCase):
         self.assertIn("cute.nvgpu.tcgen05", code)
         self.assertIn("cute.gemm(", code)
 
+    def test_matmul_mma_tcgen05_fp8_col_major_b(self) -> None:
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = (torch.randn(256, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        # Column-major (K-contiguous) B. Helion must emit a K-major B operand
+        # (OperandMajorMode.K for B) and a matching K-major B SMEM layout,
+        # rather than forcing the slow non-TMA fallback.
+        y = (torch.randn(128, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = y.T.contiguous().T
+        self.assertFalse(y.is_contiguous())
+        code, out = code_and_output(
+            cute_matmul_mma_fp8, (x, y), block_sizes=[128, 128, 128]
+        )
+        ref = x.float() @ y.float()
+        torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+        # B is emitted K-major: both A and B operand major modes are K, so
+        # OperandMajorMode.K appears at least twice (A + B); the MN-major B
+        # spelling must be absent.
+        self.assertIn("cutlass.Float8E4M3FN", code)
+        self.assertIn("cute.nvgpu.tcgen05", code)
+        self.assertGreaterEqual(code.count("cute.nvgpu.OperandMajorMode.K"), 2)
+        self.assertNotIn("cute.nvgpu.OperandMajorMode.MN", code)
+
     def test_matmul_mma_tcgen05_fp8_rowvec_scale(self) -> None:
         support = get_cute_mma_support()
         if not support.tcgen05_f8:

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -1319,6 +1319,56 @@ class TestCuteBackend(TestCase):
         self.assertIn("(2, 1, 1)", code)  # cluster_m=2
         self.assertIn("StaticPersistentTileScheduler", code)
 
+    def test_matmul_mma_tcgen05_fp8_deep_ab_staging_6(self) -> None:
+        """Test FP8 with ab_stages=6 (mid-depth staging)."""
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = (torch.randn(512, 1024, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = (torch.randn(1024, 1024, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        # cluster_m=2 requires a persistent pid_type; block_m=256 engages the
+        # validated two-CTA role-local path.
+        code, out = code_and_output(
+            cute_matmul_mma_fp8,
+            (x, y),
+            block_sizes=[256, 128, 64],
+            tcgen05_ab_stages=6,
+            tcgen05_cluster_m=2,
+            pid_type="persistent_blocked",
+        )
+        ref = x.float() @ y.float()
+        torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+        # Verify deep staging config is in generated code
+        self.assertIn("cutlass.Float8E4M3FN", code)
+        self.assertIn("cute.nvgpu.tcgen05", code)
+
+    def test_matmul_mma_tcgen05_fp8_deep_ab_staging_8(self) -> None:
+        """Test FP8 with ab_stages=8 (sweet spot from benchmarks)."""
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = (torch.randn(256, 1024, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = (torch.randn(1024, 1024, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        # cluster_m=2 requires a persistent pid_type; block_m=256 engages the
+        # validated two-CTA role-local path.
+        code, out = code_and_output(
+            cute_matmul_mma_fp8,
+            (x, y),
+            block_sizes=[256, 128, 64],
+            tcgen05_ab_stages=8,
+            tcgen05_cluster_m=2,
+            pid_type="persistent_blocked",
+        )
+        ref = x.float() @ y.float()
+        torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+        # Verify deep staging is used
+        self.assertIn("cutlass.Float8E4M3FN", code)
+        self.assertIn("cute.nvgpu.tcgen05", code)
+
     def test_matmul_dot_out_dtype_falls_back_from_mma(self) -> None:
         args = (
             torch.randn(16, 64, device=DEVICE, dtype=HALF_DTYPE),

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -49,7 +49,7 @@ from helion._compiler.cute.cute_mma import _build_kloop_non_pipeline_release_if
 from helion._compiler.cute.cute_mma import _build_kloop_pipeline_consumer_if
 from helion._compiler.cute.cute_mma import _build_kloop_pipeline_consumer_prefetch_stmts
 from helion._compiler.cute.cute_mma import _build_kloop_pipeline_producer_if
-from helion._compiler.cute.cute_mma import _build_kloop_pipeline_release_if
+from helion._compiler.cute.cute_mma import _build_kloop_pipeline_release_stmts
 from helion._compiler.cute.cute_mma import _build_tcgen05_mma_accumulate_reset_stmt
 from helion._compiler.cute.cute_mma import _build_tcgen05_mma_issue_stmt
 from helion._compiler.cute.cute_mma import _choose_mma_impl
@@ -238,6 +238,18 @@ from helion.language.memory_ops import _maybe_codegen_cute_packed_affine_lhs_loa
 from helion.language.memory_ops import _tcgen05_rowvec_aux_stage_copy_elems
 from helion.language.memory_ops import load
 from helion.runtime import _append_cute_wrapper_plan
+
+
+def _build_kloop_pipeline_release_if(*args: object, **kwargs: object) -> ast.stmt:
+    """Single-statement shim over the list-returning release builder.
+
+    Every non-static-full form still emits exactly one statement; the
+    static-full two-CTA form returns two sibling gated statements and is
+    asserted directly against ``_build_kloop_pipeline_release_stmts``.
+    """
+    (stmt,) = _build_kloop_pipeline_release_stmts(*args, **kwargs)  # pyrefly: ignore
+    return stmt
+
 
 # The legacy ``T1`` direct-entry seed (1024x4096x1024, bk=64) used a deep
 # (ab=6, c=4) A/B pipeline. The per-target constants were removed when the
@@ -4760,15 +4772,16 @@ class TestCuteLowerings(unittest.TestCase):
                 self.assertIn("pid_0 = virtual_pid % num_blocks_0", role_src)
                 self.assertIn("tile_offset_0 = pid_0 * _BLOCK_SIZE_0", role_src)
                 self.assertIn("for tile_offset_2 in range", role_src)
+                # Static-full role-local configs emit the unified producer:
+                # an unconditional blocking acquire + copy pair per K tile
+                # with no full-tile predicates or per-stage prologue chain.
                 self.assertIn(
-                    "if tcgen05_tma_full_tile and tcgen05_tma_next_full_tile",
+                    "tcgen05_ab_pipeline.producer_acquire(tcgen05_ab_producer_state)",
                     role_src,
                 )
-                self.assertNotIn(
-                    "tcgen05_tma_full_tile and tcgen05_tma_warp and "
-                    "tcgen05_tma_next_full_tile",
-                    role_src,
-                )
+                self.assertIn("tma_gA[None, tcgen05_tma_k_tile]", role_src)
+                self.assertNotIn("tcgen05_tma_full_tile", role_src)
+                self.assertNotIn("tcgen05_tma_warp and", role_src)
                 found_role_local_producer_loop = True
 
         for node in ast.walk(tree):
@@ -6133,11 +6146,14 @@ class TestCuteLowerings(unittest.TestCase):
         seeded inputs, executing the kernel, and asserting closeness
         against the torch reference. See ``cute_plan.md §6.9.1``.
 
-        Pinned codegen markers (``num_stages=3``, intermediate-stage
-        gate variable, per-stage prefetch ``k_offset=0,1,2``) are also
-        checked so a producer-side regression that codegens fine but
-        re-introduces the prefetch gap fails fast at the codegen layer
-        before consuming the runtime budget.
+        Static-full role-local configs (this one) now emit the unified
+        TMA producer — one rolled K loop whose blocking
+        ``producer_acquire`` fills every stage in order, so the
+        stage-gap deadlock is structurally impossible. The pinned
+        codegen markers assert that unified shape (``num_stages=3``,
+        a single ``tma_gA[None, tcgen05_tma_k_tile]`` issue site, no
+        per-stage prefetch chain); the runtime check still defends the
+        end-to-end behaviour.
         """
 
         from helion._compiler.cute.mma_support import get_cute_mma_support
@@ -6178,16 +6194,18 @@ class TestCuteLowerings(unittest.TestCase):
                         tcgen05_ab_stages=3,
                     )
                     code = bound.to_triton_code(cfg)
-                    # Codegen markers: pipeline depth + per-stage prefetch.
+                    # Codegen markers: pipeline depth + the unified rolled
+                    # producer (single un-offset TMA issue site, no unrolled
+                    # per-stage prefetch chain).
                     self.assertIn("PipelineTmaUmma.create(num_stages=3", code)
-                    for k_offset in (0, 1, 2):
-                        self.assertIn(f"tma_gA[None, cutlass.Int32({k_offset})]", code)
-                        self.assertIn(f"tma_gB[None, cutlass.Int32({k_offset})]", code)
-                    self.assertIn(
+                    self.assertIn("tma_gA[None, tcgen05_tma_k_tile]", code)
+                    self.assertIn("tma_gB[None, tcgen05_tma_k_tile]", code)
+                    self.assertNotIn("tma_gA[None, cutlass.Int32(0)]", code)
+                    self.assertNotIn(
                         "tma_gA[None, tcgen05_tma_k_tile + cutlass.Int32(3)]",
                         code,
                     )
-                    self.assertIn("tcgen05_tma_initial_stage_1_full_tile", code)
+                    self.assertNotIn("tcgen05_tma_initial_stage_1_full_tile", code)
                     bound.set_config(cfg)
                     out = bound(*args)
                 # If the deadlock regresses, the kernel hangs (CI test
@@ -9563,12 +9581,19 @@ class TestCuteLowerings(unittest.TestCase):
                     self.assertIn("tcgen05_ab_consumer_state.advance()", role_src)
                     release_pos = role_src.index("tcgen05_ab_pipeline.consumer_release")
                     advance_pos = role_src.index("tcgen05_ab_consumer_state.advance()")
+                    # Per-K gates reuse the hoisted cluster-rank local
+                    # (``tcgen05_cta_rank_in_cluster``); per-tile gates keep
+                    # the inline ``make_warp_uniform(...)`` leader form.
+                    hoisted_leader = "tcgen05_cta_rank_in_cluster == cutlass.Int32(0)"
                     next_ab_peek_blocks = [
                         ast.unparse(child)
                         for child in ast.walk(node)
                         if isinstance(child, ast.If)
                         and "tcgen05_tma_next_consumer_tile" in ast.unparse(child.test)
-                        and _TCGEN05_CLUSTER_LEADER_PREDICATE in ast.unparse(child.test)
+                        and (
+                            _TCGEN05_CLUSTER_LEADER_PREDICATE in ast.unparse(child.test)
+                            or hoisted_leader in ast.unparse(child.test)
+                        )
                     ]
                     self.assertTrue(
                         next_ab_peek_blocks,
@@ -9589,7 +9614,10 @@ class TestCuteLowerings(unittest.TestCase):
                         ast.unparse(child)
                         for child in ast.walk(node)
                         if isinstance(child, ast.If)
-                        and _TCGEN05_CLUSTER_LEADER_PREDICATE in ast.unparse(child.test)
+                        and (
+                            _TCGEN05_CLUSTER_LEADER_PREDICATE in ast.unparse(child.test)
+                            or hoisted_leader in ast.unparse(child.test)
+                        )
                     ]
                     self.assertTrue(
                         any(
@@ -19525,20 +19553,32 @@ class TestPerKiterTmaBuilders(unittest.TestCase):
         with self.assertRaisesRegex(AssertionError, "scalar fallback"):
             _build_kloop_pipeline_release_if(args)
 
+        # The per-K-iter producer-if never serves two-CTA static-full (the
+        # unified rolled producer loop replaces it there); consumer wait /
+        # release DO serve it from the role-local exec loop, emitting
+        # leader-gated statements with no full-tile wrapper.
         two_cta_args = self._make_args(is_two_cta=True, static_full_tiles=True)
-        for builder in (
-            _build_kloop_pipeline_producer_if,
-            _build_kloop_pipeline_consumer_if,
-            _build_kloop_pipeline_release_if,
-        ):
-            with (
-                self.subTest(builder=builder.__name__),
-                self.assertRaisesRegex(AssertionError, "one-CTA"),
-            ):
-                if builder is _build_kloop_pipeline_producer_if:
-                    builder(two_cta_args)
-                else:
-                    builder(two_cta_args, include_scalar_fallback=False)
+        with self.assertRaisesRegex(AssertionError, "one-CTA"):
+            _build_kloop_pipeline_producer_if(two_cta_args)
+        two_cta_consumer = _build_kloop_pipeline_consumer_if(
+            two_cta_args,
+            gate_exec_warp=False,
+            include_scalar_fallback=False,
+        )
+        self.assertIsInstance(two_cta_consumer, ast.If)
+        self.assertEqual(
+            ast.unparse(two_cta_consumer.test), _TCGEN05_CLUSTER_LEADER_PREDICATE
+        )
+        release_stmt, advance_stmt = _build_kloop_pipeline_release_stmts(
+            two_cta_args,
+            gate_exec_warp=False,
+            include_scalar_fallback=False,
+        )
+        self.assertIsInstance(release_stmt, ast.If)
+        self.assertEqual(
+            ast.unparse(release_stmt.test), _TCGEN05_CLUSTER_LEADER_PREDICATE
+        )
+        self.assertEqual(self._stmt_kinds([advance_stmt]), ["advance"])
 
     def test_non_pipeline_builders_reject_static_full_fast_path(self) -> None:
         args = self._make_args(static_full_tiles=True)

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -13827,6 +13827,197 @@ class TestCuteLowerings(unittest.TestCase):
         )
         self.assertIsNone(_trace_mma_to_store_dtype(mma_node, []))
 
+    def _build_aux_load_node(
+        self,
+        *,
+        aux_tensor: torch.Tensor,
+        load_shape: tuple[int, ...],
+        index_nodes: tuple[torch.fx.Node, ...],
+        extra_mask: object = None,
+        eviction_policy: object = None,
+        kwargs: dict[str, object] | None = None,
+    ) -> tuple[torch.fx.Node, tuple[torch.fx.Node, ...]]:
+        """Build a synthetic ``helion.language.memory_ops.load`` FX node for
+        the aux-tensor classifier (``aux_tensor_load_kind``).
+
+        ``aux_tensor`` is the underlying tensor whose ``.shape`` / ``.stride()``
+        drive classification (use ``.expand(...)`` to get the stride-0
+        broadcast axes). ``load_shape`` is the per-tile load result shape.
+        ``index_nodes`` is the index list passed to ``load`` — pass the same
+        carrier tile-id nodes to mimic ``aux[tile_m, tile_n]``. Returns the
+        load node and the carrier tile-id index nodes.
+        """
+        from helion.language import memory_ops
+
+        graph = Graph()
+        tensor_node = graph.call_function(_tracing_ops._new_var, args=())
+        tensor_node.meta["val"] = aux_tensor
+        args: tuple[object, ...] = (
+            tensor_node,
+            list(index_nodes),
+            extra_mask,
+            eviction_policy,
+        )
+        load_node = graph.call_function(memory_ops.load, args=args, kwargs=kwargs or {})
+        load_node.meta["val"] = torch.empty(load_shape, dtype=aux_tensor.dtype)
+        return load_node, index_nodes
+
+    def _carrier_index_nodes(self) -> tuple[torch.fx.Node, ...]:
+        """Two distinct FX nodes standing in for the carrier's
+        ``(tile_m, tile_n)`` tile-id symbols."""
+        g = Graph()
+        m = g.call_function(_tracing_ops._new_var, args=())
+        n = g.call_function(_tracing_ops._new_var, args=())
+        return (m, n)
+
+    def test_aux_load_kind_colvec_stride_1_0_is_broadcast_2(self) -> None:
+        """A full ``(M, N)`` aux with trailing stride 0 (the
+        ``unsqueeze(1).expand(M, N)`` per-row column vector) classifies as
+        ``("broadcast", 2)`` so the epilogue reads it as a scalar per
+        subtile instead of a redundant N-wide vector load."""
+        from helion._compiler.cute.cute_fx_walk import aux_tensor_load_kind
+
+        idx = self._carrier_index_nodes()
+        colvec = torch.empty(4, dtype=torch.float32).unsqueeze(1).expand(4, 4)
+        self.assertEqual(colvec.stride(), (1, 0))
+        load_node, _ = self._build_aux_load_node(
+            aux_tensor=colvec,
+            load_shape=(4, 4),
+            index_nodes=idx,
+        )
+        self.assertEqual(
+            aux_tensor_load_kind(
+                load_node,
+                carrier_tile_shape=(4, 4),
+                carrier_tile_index_nodes=idx,
+                carrier_global_shape=(4, 4),
+            ),
+            ("broadcast", 2),
+        )
+
+    def test_aux_load_kind_exact_tensor_is_not_colvec(self) -> None:
+        """A genuine dense ``(M, N)`` aux (trailing stride 1) must fall
+        through the colvec matcher to ``("exact", None)`` — the colvec
+        path only claims trailing-stride-0 views."""
+        from helion._compiler.cute.cute_fx_walk import aux_tensor_load_kind
+
+        idx = self._carrier_index_nodes()
+        exact = torch.empty(4, 4, dtype=torch.float32)
+        self.assertEqual(exact.stride(), (4, 1))
+        load_node, _ = self._build_aux_load_node(
+            aux_tensor=exact,
+            load_shape=(4, 4),
+            index_nodes=idx,
+        )
+        self.assertEqual(
+            aux_tensor_load_kind(
+                load_node,
+                carrier_tile_shape=(4, 4),
+                carrier_tile_index_nodes=idx,
+                carrier_global_shape=(4, 4),
+            ),
+            ("exact", None),
+        )
+
+    def test_aux_load_kind_rowvec_1n_is_not_colvec(self) -> None:
+        """The explicit ``(1, N)`` leading-broadcast row vector (unit
+        leading axis, contiguous trailing) is ``("broadcast", 0)``, never
+        the colvec form — colvec requires a full ``(M, N)`` view with
+        trailing stride 0 and non-zero leading stride."""
+        from helion._compiler.cute.cute_fx_walk import aux_tensor_load_kind
+
+        idx = self._carrier_index_nodes()
+        # Underlying ``(1, N)`` tensor; the per-tile load result is (M, N).
+        rowvec = torch.empty(1, 4, dtype=torch.float32)
+        self.assertEqual(rowvec.stride(), (4, 1))
+        load_node, _ = self._build_aux_load_node(
+            aux_tensor=rowvec,
+            load_shape=(4, 4),
+            index_nodes=idx,
+        )
+        self.assertEqual(
+            aux_tensor_load_kind(
+                load_node,
+                carrier_tile_shape=(4, 4),
+                carrier_tile_index_nodes=idx,
+                carrier_global_shape=(4, 4),
+            ),
+            ("broadcast", 0),
+        )
+
+    def test_aux_load_kind_colvec_rejected_when_index_order_mismatches(
+        self,
+    ) -> None:
+        """The colvec matcher requires the load index list to be the
+        carrier tile-id nodes in order; a swapped/foreign index must not
+        be claimed as ``("broadcast", 2)``."""
+        from helion._compiler.cute.cute_fx_walk import aux_tensor_load_kind
+
+        idx = self._carrier_index_nodes()
+        colvec = torch.empty(4, dtype=torch.float32).unsqueeze(1).expand(4, 4)
+        # Swap the index order so it no longer matches the carrier nodes.
+        load_node, _ = self._build_aux_load_node(
+            aux_tensor=colvec,
+            load_shape=(4, 4),
+            index_nodes=(idx[1], idx[0]),
+        )
+        self.assertNotEqual(
+            aux_tensor_load_kind(
+                load_node,
+                carrier_tile_shape=(4, 4),
+                carrier_tile_index_nodes=idx,
+                carrier_global_shape=(4, 4),
+            ),
+            ("broadcast", 2),
+        )
+
+    def test_aux_load_kind_colvec_rejected_when_global_shape_mismatches(
+        self,
+    ) -> None:
+        """When the underlying ``(M, N)`` view does not match the carrier's
+        global output shape, the colvec matcher bails (returns ``None``
+        rather than ``("broadcast", 2)``)."""
+        from helion._compiler.cute.cute_fx_walk import aux_tensor_load_kind
+
+        idx = self._carrier_index_nodes()
+        colvec = torch.empty(4, dtype=torch.float32).unsqueeze(1).expand(4, 4)
+        result = aux_tensor_load_kind(
+            self._build_aux_load_node(
+                aux_tensor=colvec,
+                load_shape=(4, 4),
+                index_nodes=idx,
+            )[0],
+            carrier_tile_shape=(4, 4),
+            carrier_tile_index_nodes=idx,
+            carrier_global_shape=(8, 8),  # mismatched global shape
+        )
+        self.assertNotEqual(result, ("broadcast", 2))
+
+    def test_aux_load_kind_colvec_rejected_with_extra_mask(self) -> None:
+        """A present ``extra_mask`` arg disqualifies the load entirely
+        (the splice emits a plain ``.load()`` with no mask), so even a
+        colvec-shaped aux returns ``None``."""
+        from helion._compiler.cute.cute_fx_walk import aux_tensor_load_kind
+
+        idx = self._carrier_index_nodes()
+        colvec = torch.empty(4, dtype=torch.float32).unsqueeze(1).expand(4, 4)
+        mask_graph = Graph()
+        mask_node = mask_graph.call_function(_tracing_ops._new_var, args=())
+        load_node, _ = self._build_aux_load_node(
+            aux_tensor=colvec,
+            load_shape=(4, 4),
+            index_nodes=idx,
+            extra_mask=mask_node,
+        )
+        self.assertIsNone(
+            aux_tensor_load_kind(
+                load_node,
+                carrier_tile_shape=(4, 4),
+                carrier_tile_index_nodes=idx,
+                carrier_global_shape=(4, 4),
+            )
+        )
+
     def test_emit_sched_pipeline_setup_round_trips_pipeline_async(self) -> None:
         """``_emit_sched_pipeline_setup`` emits the
         ``cutlass.pipeline.PipelineAsync.create`` wrapper used to

--- a/test/test_deep_ab_staging.py
+++ b/test/test_deep_ab_staging.py
@@ -1,0 +1,262 @@
+"""
+Test suite for deep AB staging functionality (commit 1573e3d2).
+
+Tests the improved implementation of max_ab_stages_that_fit and related
+deep staging logic for FP8 dtypes.
+"""
+
+from __future__ import annotations
+
+from helion._testing import TestCase
+
+
+class TestDeepABStagingHelpers(TestCase):
+    """Test helper methods for deep staging."""
+
+    def test_get_dtype_ab_stages_hard_cap(self) -> None:
+        """Test dtype-specific hard cap calculation."""
+        from helion._compiler.cute.tcgen05_config import CuteTcgen05Config
+
+        # FP8 (1 byte) -> 12 stages
+        self.assertEqual(CuteTcgen05Config._get_dtype_ab_stages_hard_cap(1), 12)
+
+        # FP16/BF16 (2 bytes) -> 6 stages
+        self.assertEqual(CuteTcgen05Config._get_dtype_ab_stages_hard_cap(2), 6)
+
+        # FP32 (4 bytes) -> 3 stages
+        self.assertEqual(CuteTcgen05Config._get_dtype_ab_stages_hard_cap(4), 3)
+
+        # Larger dtypes -> 3 stages (baseline)
+        self.assertEqual(CuteTcgen05Config._get_dtype_ab_stages_hard_cap(8), 3)
+
+        # Invalid input
+        self.assertEqual(CuteTcgen05Config._get_dtype_ab_stages_hard_cap(0), 0)
+        self.assertEqual(CuteTcgen05Config._get_dtype_ab_stages_hard_cap(-1), 0)
+
+
+class TestMaxABStagesThatFit(TestCase):
+    """Test max_ab_stages_that_fit computation."""
+
+    def test_fp8_vs_bf16_capacity(self) -> None:
+        """Test that FP8 fits ~2x more stages than BF16 for same tile."""
+        from helion._compiler.backend import CuteBackend
+        from helion._compiler.cute.tcgen05_config import CuteTcgen05Config
+        from helion._compiler.cute.tcgen05_config import (
+            Tcgen05AbStagesThreeSearchConstraints,
+        )
+        from helion.autotuner.config_spec import ConfigSpec
+
+        # Use realistic B200 SMEM budget (232KB after reservations)
+        smem_budget = 232 * 1024
+
+        # FP8 config (1 byte per element)
+        fp8_config = CuteTcgen05Config(ConfigSpec(backend=CuteBackend()))
+        fp8_config.ab_stages_three_search_constraints = (
+            Tcgen05AbStagesThreeSearchConstraints(
+                dtype_bytes=1,
+                per_cta_smem_budget_bytes=smem_budget,
+            )
+        )
+        fp8_config.search_enabled = True
+
+        # BF16 config (2 bytes per element)
+        bf16_config = CuteTcgen05Config(ConfigSpec(backend=CuteBackend()))
+        bf16_config.ab_stages_three_search_constraints = (
+            Tcgen05AbStagesThreeSearchConstraints(
+                dtype_bytes=2,
+                per_cta_smem_budget_bytes=smem_budget,
+            )
+        )
+        bf16_config.search_enabled = True
+
+        # Test with 256x256x64 cluster_m=2 (common config)
+        tile_params = {"bm": 256, "bn": 256, "bk": 64, "cluster_m": 2}
+
+        fp8_max = fp8_config.max_ab_stages_that_fit(**tile_params)
+        bf16_max = bf16_config.max_ab_stages_that_fit(**tile_params)
+
+        # FP8 should fit more stages
+        self.assertGreater(fp8_max, bf16_max, "FP8 should fit more stages than BF16")
+
+        # FP8 should support deep staging (>6 stages)
+        self.assertGreater(fp8_max, 6, "FP8 should enable deep staging")
+
+        # BF16 should be limited
+        self.assertLessEqual(bf16_max, 6, "BF16 should cap at 6 or less")
+
+        # Ratio should be roughly 2x (within overhead tolerance)
+        if bf16_max > 0:
+            ratio = fp8_max / bf16_max
+            self.assertGreater(ratio, 1.5, "FP8 should fit at least 1.5x BF16 stages")
+            self.assertLess(ratio, 2.5, "Ratio should be roughly 2x (within overhead)")
+
+    def test_invalid_tile_dimensions(self) -> None:
+        """Test that invalid tile dimensions return 0."""
+        from helion._compiler.backend import CuteBackend
+        from helion._compiler.cute.tcgen05_config import CuteTcgen05Config
+        from helion._compiler.cute.tcgen05_config import (
+            Tcgen05AbStagesThreeSearchConstraints,
+        )
+        from helion.autotuner.config_spec import ConfigSpec
+
+        config = CuteTcgen05Config(ConfigSpec(backend=CuteBackend()))
+        config.ab_stages_three_search_constraints = (
+            Tcgen05AbStagesThreeSearchConstraints(
+                dtype_bytes=1,
+                per_cta_smem_budget_bytes=100000,
+            )
+        )
+        config.search_enabled = True
+
+        # bm = 0
+        self.assertEqual(
+            config.max_ab_stages_that_fit(bm=0, bn=256, bk=64, cluster_m=1), 0
+        )
+
+        # bn = -1
+        self.assertEqual(
+            config.max_ab_stages_that_fit(bm=256, bn=-1, bk=64, cluster_m=1), 0
+        )
+
+        # bk = 0
+        self.assertEqual(
+            config.max_ab_stages_that_fit(bm=256, bn=256, bk=0, cluster_m=1), 0
+        )
+
+    def test_invalid_cluster_m(self) -> None:
+        """Test that invalid cluster_m values return 0."""
+        from helion._compiler.backend import CuteBackend
+        from helion._compiler.cute.tcgen05_config import CuteTcgen05Config
+        from helion._compiler.cute.tcgen05_config import (
+            Tcgen05AbStagesThreeSearchConstraints,
+        )
+        from helion.autotuner.config_spec import ConfigSpec
+
+        config = CuteTcgen05Config(ConfigSpec(backend=CuteBackend()))
+        config.ab_stages_three_search_constraints = (
+            Tcgen05AbStagesThreeSearchConstraints(
+                dtype_bytes=1,
+                per_cta_smem_budget_bytes=100000,
+            )
+        )
+        config.search_enabled = True
+
+        # cluster_m = 0 (invalid)
+        self.assertEqual(
+            config.max_ab_stages_that_fit(bm=256, bn=256, bk=64, cluster_m=0), 0
+        )
+
+        # cluster_m = 3 (not supported)
+        self.assertEqual(
+            config.max_ab_stages_that_fit(bm=256, bn=256, bk=64, cluster_m=3), 0
+        )
+
+        # cluster_m = -1 (invalid)
+        self.assertEqual(
+            config.max_ab_stages_that_fit(bm=256, bn=256, bk=64, cluster_m=-1), 0
+        )
+
+    def test_no_constraints_returns_zero(self) -> None:
+        """Test that missing constraints return 0."""
+        from helion._compiler.backend import CuteBackend
+        from helion._compiler.cute.tcgen05_config import CuteTcgen05Config
+        from helion.autotuner.config_spec import ConfigSpec
+
+        config = CuteTcgen05Config(ConfigSpec(backend=CuteBackend()))
+        config.ab_stages_three_search_constraints = None
+        config.search_enabled = True
+
+        result = config.max_ab_stages_that_fit(bm=256, bn=256, bk=64, cluster_m=1)
+        self.assertEqual(result, 0, "Should return 0 when constraints are None")
+
+    def test_cluster_m_scaling(self) -> None:
+        """Test that cluster_m=2 fits more stages than cluster_m=1."""
+        from helion._compiler.backend import CuteBackend
+        from helion._compiler.cute.tcgen05_config import CuteTcgen05Config
+        from helion._compiler.cute.tcgen05_config import (
+            Tcgen05AbStagesThreeSearchConstraints,
+        )
+        from helion.autotuner.config_spec import ConfigSpec
+
+        config = CuteTcgen05Config(ConfigSpec(backend=CuteBackend()))
+        config.ab_stages_three_search_constraints = (
+            Tcgen05AbStagesThreeSearchConstraints(
+                dtype_bytes=1,
+                per_cta_smem_budget_bytes=150000,
+            )
+        )
+        config.search_enabled = True
+
+        tile_params = {"bm": 256, "bn": 256, "bk": 64}
+
+        stages_cluster1 = config.max_ab_stages_that_fit(**tile_params, cluster_m=1)
+        stages_cluster2 = config.max_ab_stages_that_fit(**tile_params, cluster_m=2)
+
+        # cluster_m=2 partitions operands across 2 CTAs, so per-CTA SMEM is halved
+        self.assertGreater(
+            stages_cluster2,
+            stages_cluster1,
+            "cluster_m=2 should fit more stages (per-CTA SMEM is halved)",
+        )
+
+        # Should be roughly 2x (within overhead)
+        if stages_cluster1 > 0:
+            ratio = stages_cluster2 / stages_cluster1
+            self.assertGreater(ratio, 1.5, "Should be at least 1.5x")
+            self.assertLess(ratio, 2.5, "Should be at most 2.5x")
+
+    def test_hard_cap_enforcement(self) -> None:
+        """Test that hard_cap parameter is respected."""
+        from helion._compiler.backend import CuteBackend
+        from helion._compiler.cute.tcgen05_config import CuteTcgen05Config
+        from helion._compiler.cute.tcgen05_config import (
+            Tcgen05AbStagesThreeSearchConstraints,
+        )
+        from helion.autotuner.config_spec import ConfigSpec
+
+        # Config with huge budget (should hit hard cap, not budget)
+        config = CuteTcgen05Config(ConfigSpec(backend=CuteBackend()))
+        config.ab_stages_three_search_constraints = (
+            Tcgen05AbStagesThreeSearchConstraints(
+                dtype_bytes=1,
+                per_cta_smem_budget_bytes=10000000,  # 10MB (unrealistic)
+            )
+        )
+        config.search_enabled = True
+
+        # Without explicit hard cap, should hit dtype default (12 for FP8)
+        max_default = config.max_ab_stages_that_fit(bm=64, bn=64, bk=32, cluster_m=2)
+        self.assertLessEqual(max_default, 12, "Should hit FP8 default cap of 12")
+
+        # With explicit hard cap of 5
+        max_capped = config.max_ab_stages_that_fit(
+            bm=64, bn=64, bk=32, cluster_m=2, hard_cap=5
+        )
+        self.assertEqual(max_capped, 5, "Should respect explicit hard cap")
+
+    def test_returns_at_least_one_when_valid(self) -> None:
+        """Test that result is at least 1 when ab_stages=1 fits."""
+        from helion._compiler.backend import CuteBackend
+        from helion._compiler.cute.tcgen05_config import CuteTcgen05Config
+        from helion._compiler.cute.tcgen05_config import (
+            Tcgen05AbStagesThreeSearchConstraints,
+        )
+        from helion.autotuner.config_spec import ConfigSpec
+
+        # Small budget that only fits ab_stages=1 or 2
+        config = CuteTcgen05Config(ConfigSpec(backend=CuteBackend()))
+        config.ab_stages_three_search_constraints = (
+            Tcgen05AbStagesThreeSearchConstraints(
+                dtype_bytes=2,  # BF16
+                per_cta_smem_budget_bytes=50000,  # Tight budget
+            )
+        )
+        config.search_enabled = True
+
+        # Large tile
+        result = config.max_ab_stages_that_fit(bm=256, bn=256, bk=128, cluster_m=1)
+
+        # Should return at least 1 if ab_stages=1 fits, or 0 if it doesn't
+        self.assertIn(result, [0, 1, 2, 3], "Result should be in valid range")
+        if result > 0:
+            self.assertGreaterEqual(result, 1, "Should return at least 1 if valid")

--- a/test/test_matmul.py
+++ b/test/test_matmul.py
@@ -206,6 +206,71 @@ class TestMatmul(RefEagerTestBase, TestCase):
             self.assertNotIn("cute.gemm", code)
             self.assertNotIn("permute_smem", code)
 
+    def test_tcgen05_fused_colvec_scale_emits_scalar_read(self):
+        """End-to-end: a per-row column-vector scale spelled explicitly as
+        ``scale_a.unsqueeze(1).expand(m, n)`` (a full ``(M, N)`` view with
+        trailing stride 0) classifies as ``("broadcast", 2)`` and the
+        generated cute epilogue reads it as a SCALAR per subtile
+        (``aux_loaded = ttr_aux_grouped[(0, 0, 0, subtile)]``) instead of a
+        redundant N-wide vector ``.load()`` — matching CUTLASS's
+        ``sa = tTR_gSA[(0,0,0,subtile)]``. Numerics are checked on every
+        backend; the scalar-read codegen pin is cute-only.
+        """
+        if _get_backend() != "cute":
+            self.skipTest("colvec scalar-read codegen is cute-specific")
+
+        from helion._compiler.cute.mma_support import get_cute_mma_support
+
+        if not get_cute_mma_support().tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        @helion.kernel(backend="cute")
+        def cute_matmul_colvec_scale(
+            x: torch.Tensor, y: torch.Tensor, scale_a: torch.Tensor
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
+                # Explicit per-row column-vector broadcast over N.
+                out[tile_m, tile_n] = (acc * scale_a[tile_m, tile_n]).to(x.dtype)
+            return out
+
+        x = torch.randn(128, 128, dtype=torch.bfloat16, device=DEVICE)
+        y = torch.randn(128, 128, dtype=torch.bfloat16, device=DEVICE)
+        scale_a_vec = torch.randn(128, dtype=torch.float32, device=DEVICE)
+        # ``(M,) -> (M, N)`` with trailing stride 0: the colvec form.
+        scale_a = scale_a_vec.unsqueeze(1).expand(128, 128)
+        self.assertEqual(scale_a.stride(), (1, 0))
+
+        code, output = code_and_output(
+            cute_matmul_colvec_scale,
+            (x, y, scale_a),
+            block_sizes=[128, 128, 32],
+            pid_type="persistent_interleaved",
+        )
+
+        # Codegen pin: the colvec aux is read as a scalar (T2R index
+        # (0, 0, 0) plus the subtile) with NO trailing ``.load()`` — that
+        # is the whole point of the ``("broadcast", 2)`` classification.
+        scalar_read = (
+            "tcgen05_aux_loaded_0 = tcgen05_tTR_gAux_grouped_0"
+            "[0, 0, 0, cutlass.Int32(_tcgen05_subtile)]"
+        )
+        self.assertIn(scalar_read, code)
+        # It must NOT fall back to the N-wide vector load the rowvec /
+        # exact forms use.
+        self.assertNotIn(
+            "tcgen05_aux_loaded_0 = tcgen05_tTR_gAux_grouped_0.load()", code
+        )
+
+        # Numerics: the scalar broadcast must compute acc * scale_a[m].
+        ref = (x.float() @ y.float()) * scale_a_vec.unsqueeze(1)
+        torch.testing.assert_close(output.float(), ref, atol=1.0, rtol=1e-1)
+
     @skipIfNotTriton("block_ptr is triton-only")
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
     @skipIfTileIR("TileIR does not support block_ptr indexing")


### PR DESCRIPTION
Stacked PRs:
 * __->__#2754
 * #2742
 * #2741
 * #2740


--- --- ---

### [cute] Unified rolled TMA producer + hoisted K-loop predicates for tcgen05


Static-full role-local tcgen05 configs now emit the CUTLASS reference
producer shape: ONE rolled K loop in the TMA-load warp whose blocking
producer_acquire fills the AB ring - pipelining comes from the mbarrier
handshake, not from codegen structure. This replaces, per work tile, the
fully unrolled ab_stages-deep warm-up prologue (8 guarded
acquire/copy/commit blocks at ab=8, each re-computing a compile-time-true
per-stage predicate) and the separate steady-state producer loop with
per-iteration full-tile predicate recomputation.

The MMA-exec K loop drops its per-iteration full-tile predicate the same
way (static-full means every K tile is full), and all per-K-iter owner
gates now reuse a hoisted tcgen05_cta_rank_in_cluster local instead of
re-deriving make_warp_uniform(block_idx_in_cluster()) at every gate - the
inline form cost an S2UR+IMAD pair per use and was the single largest
instruction-count delta vs the reference (+508k dynamic IMAD).

NCU on 4096x4096x4096 fp8 e4m3 -> bf16 plain matmul, B200,
block_sizes=[256,128,128], ab_stages=8, cluster_m=2:

                              before        after       standalone
  warp instructions / SMSP    5820          4711        4866
  static UTMALDG sites        24            2           2
  dynamic SYNCS (barriers)    533k          507k        470k

Helion now executes FEWER warp-instructions per SMSP than the CUTLASS
standalone; the remaining duration gap is no longer
instruction-count-bound.

Scope and fallbacks:
  * The unified producer requires static-full tiles + the role-local
    separate producer loop. Edge/K-tail families and the bridge
    diagnostics that skip individual acquire/advance edges keep the
    unrolled-prologue form.
  * _build_kloop_pipeline_consumer_if/_release_if become list-returning
    _stmts builders so the ungated static-full forms can emit sibling
    statements without an artificial wrapper; single-statement shims keep
    the old call shape where the gated form is still used.
  * The ab_stages=3 stage-gap deadlock (cute_plan.md 6.9.1) is
    structurally impossible in the unified form: the blocking acquire
    fills every stage in order.

Test updates: tests that pinned the old per-stage prefetch markers,
inline cluster-leader predicates, and the producer-if's full-tile gate
now pin the unified/hoisted forms.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
