### PR TITLE
[cute] Record measured-good B200 config for the fp8 scaled_mm example

### DIFF
--- a/benchmarks/cute/compare_matmul_backends.py
+++ b/benchmarks/cute/compare_matmul_backends.py
@@ -192,6 +192,10 @@ MATMUL_EPILOGUES = (
     "silu",
     "gelu",
     "residual_add",
+    # FP8 RowWise scaled_mm: out = scale_a[m] * scale_b[n] * (a_fp8 @ b_fp8).
+    # The rowwise scale is fused into the epilogue. Intended for --dtype
+    # float8_e4m3fn; the reference is torch._scaled_mm.
+    "scaled_mm",
 )
 QUACK_TUNE_CHOICES = ("off", "brief")
 # Brief tuning covers the documented default, larger cluster/swizzle variants,
@@ -725,7 +729,12 @@ def _dtype_from_name(name: str) -> torch.dtype:
         "float16": torch.float16,
         "bfloat16": torch.bfloat16,
         "float32": torch.float32,
+        "float8_e4m3fn": torch.float8_e4m3fn,
     }[name]
+
+
+def _is_fp8(dtype: torch.dtype) -> bool:
+    return dtype == torch.float8_e4m3fn
 
 
 def _tflops(m: int, n: int, k: int, ms: float) -> float:
@@ -832,9 +841,27 @@ def _make_inputs(
     seed: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     torch.manual_seed(seed)
+    if _is_fp8(dtype):
+        # fp8 has a tiny dynamic range, so build the operands in f32 and cast.
+        # b is laid out column-major (K-contiguous), the layout the tcgen05
+        # fp8 path and torch._scaled_mm expect for the second operand.
+        a = (torch.randn((m, k), device="cuda") * 0.4).to(dtype)
+        b = (torch.randn((k, n), device="cuda") * 0.4).to(dtype).T.contiguous().T
+        return a, b
     a = torch.randn((m, k), device="cuda", dtype=dtype)
     b = torch.randn((k, n), device="cuda", dtype=dtype) / math.sqrt(k)
     return a, b
+
+
+def _make_scales(
+    args: argparse.Namespace,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-row (scale_a [m,1]) and per-column (scale_b [1,n]) f32 rowwise scales
+    for the ``scaled_mm`` epilogue. Non-trivial (random) values so a broadcast
+    bug actually surfaces in the correctness check."""
+    scale_a = (torch.rand((args.m, 1), device="cuda") + 0.5).to(torch.float32)
+    scale_b = (torch.rand((1, args.n), device="cuda") + 0.5).to(torch.float32)
+    return scale_a, scale_b
 
 
 def _make_epilogue_inputs(
@@ -842,10 +869,13 @@ def _make_epilogue_inputs(
 ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
     bias = None
     residual = None
+    # fp8 epilogue aux tensors (bias/residual) are kept in the *output* dtype
+    # (bf16); only the matmul operands are fp8.
+    aux_dtype = torch.bfloat16 if _is_fp8(dtype) else dtype
     if args.epilogue in ("bias", "bias_relu", "bias_residual_gelu"):
-        bias = torch.randn((args.n,), device="cuda", dtype=dtype)
+        bias = torch.randn((args.n,), device="cuda", dtype=aux_dtype)
     if args.epilogue in ("bias_residual_gelu", "residual_add"):
-        residual = torch.randn((args.m, args.n), device="cuda", dtype=dtype)
+        residual = torch.randn((args.m, args.n), device="cuda", dtype=aux_dtype)
     return bias, residual
 
 
@@ -857,7 +887,18 @@ def _make_matmul_problem(
     dtype = _dtype_from_name(args.dtype)
     a, b = _make_inputs(args.m, args.n, args.k, dtype, seed=args.seed)
     bias, residual = _make_epilogue_inputs(args, dtype)
+    # Stash the rowwise scales on args so the (a, b, bias, residual) tuple
+    # threaded through every impl stays unchanged. Only the scaled_mm path reads
+    # them, via _scaled_mm_scales().
+    if args.epilogue == "scaled_mm":
+        args._scale_a, args._scale_b = _make_scales(args)
     return dtype, a, b, bias, residual
+
+
+def _scaled_mm_scales(
+    args: argparse.Namespace,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return args._scale_a, args._scale_b
 
 
 def _apply_epilogue(
@@ -889,6 +930,11 @@ def _apply_epilogue(
     if args.epilogue == "residual_add":
         assert residual is not None
         return acc + residual
+    if args.epilogue == "scaled_mm":
+        # out = scale_a[m] * scale_b[n] * acc, cast to bf16. The scale is folded
+        # on the f32 accumulator before the cast (matches the fused epilogue).
+        scale_a, scale_b = _scaled_mm_scales(args)
+        return (acc.float() * scale_a * scale_b).to(torch.bfloat16)
     raise AssertionError(f"unhandled epilogue {args.epilogue!r}")
 
 
@@ -900,7 +946,10 @@ def _matmul_expected(
     residual: torch.Tensor | None,
     dtype: torch.dtype,
 ) -> torch.Tensor:
-    return _apply_epilogue(args, a @ b, bias, residual, dtype)
+    # acc is f32; for fp8 inputs the product is computed in f32 to mirror the
+    # tensor-core accumulate before any epilogue (scaled_mm, activation, ...).
+    acc = (a.float() @ b.float()) if _is_fp8(dtype) else (a @ b)
+    return _apply_epilogue(args, acc, bias, residual, dtype)
 
 
 def _check_close(
@@ -908,6 +957,14 @@ def _check_close(
 ) -> None:
     if dtype == torch.float32:
         torch.testing.assert_close(actual, expected, atol=1e-4, rtol=1e-4)
+    elif _is_fp8(dtype):
+        # fp8 (e4m3) operands carry ~2 decimal digits, so the GEMM accumulates
+        # substantial quantization error; use a relative-error tolerance like
+        # the scaled_mm unit checks.
+        ref_max = expected.float().abs().max().item() + 1e-12
+        rel = (actual.float() - expected.float()).abs().max().item() / ref_max
+        if rel > 0.1:
+            raise AssertionError(f"fp8 mismatch: rel_err={rel:.4f} > 0.1")
     else:
         # bf16/fp16 GEMMs accumulate enough rounding noise that benchmark
         # smoke tests need a looser threshold than unit tests.
@@ -1020,7 +1077,17 @@ def _result(
 
 def _benchmark_aten(args: argparse.Namespace) -> dict[str, Any]:
     dtype, a, b, bias, residual = _make_matmul_problem(args)
-    fn = lambda: _apply_epilogue(args, a @ b, bias, residual, dtype)  # noqa: E731
+    if args.epilogue == "scaled_mm":
+        # ATen's fp8 rowwise GEMM is torch._scaled_mm — the SOTA baseline to
+        # time against (a dequantized f32 matmul would be a misleadingly slow
+        # reference). _apply_epilogue still owns the scaled_mm *semantics* for
+        # the correctness reference in _matmul_expected.
+        scale_a, scale_b = _scaled_mm_scales(args)
+        fn = lambda: torch._scaled_mm(  # noqa: E731
+            a, b, scale_a, scale_b, use_fast_accum=False, out_dtype=torch.bfloat16
+        )
+    else:
+        fn = lambda: _apply_epilogue(args, a @ b, bias, residual, dtype)  # noqa: E731
     stats = _bench_steady(
         fn,
         num_runs=args.num_runs,
@@ -1533,17 +1600,31 @@ def _helion_matmul_args(
     if args.epilogue == "residual_add":
         assert residual is not None
         return (a, b, ResidualAddEpilogue(residual))
+    if args.epilogue == "scaled_mm":
+        scale_a, scale_b = _scaled_mm_scales(args)
+        # examples/fp8_matmul.fp8_matmul takes (x, y, sa2d, sb1d) directly and
+        # bakes the scale in itself (not via an epilogue callable): scale_a as a
+        # (M, N) stride-(1,0) colvec view, scale_b as a rank-1 row vector.
+        scale_a2d = scale_a.reshape(args.m, 1).expand(args.m, args.n)
+        scale_b1d = scale_b.reshape(args.n)
+        return (a, b, scale_a2d, scale_b1d)
     raise AssertionError(f"unhandled epilogue {args.epilogue!r}")
 
 
 def _prepare_helion(args: argparse.Namespace) -> _PreparedHelion:
     backend = args.helion_backend
     os.environ["HELION_BACKEND"] = backend
-    from examples.matmul import matmul
 
     dtype, a, b, bias, residual = _make_matmul_problem(args)
     expected = _matmul_expected(args, a, b, bias, residual, dtype)
     kernel_args = _helion_matmul_args(args, a, b, bias, residual)
+
+    if args.epilogue == "scaled_mm":
+        # fp8 RowWise scaled_mm uses examples/fp8_matmul.py (hl.dot + fused
+        # rowwise scale); the example matmul's torch.addmm does not accept fp8.
+        from examples.fp8_matmul import fp8_matmul as matmul
+    else:
+        from examples.matmul import matmul
 
     bound = matmul.bind(kernel_args)
     config = _make_helion_config_from_args(args) if args.helion_force_config else None
@@ -5931,7 +6012,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--dtype",
-        choices=("float16", "bfloat16", "float32"),
+        choices=("float16", "bfloat16", "float32", "float8_e4m3fn"),
         default="bfloat16",
     )
     parser.add_argument("--num-runs", type=int, default=5)
@@ -6387,6 +6468,27 @@ def _uses_invalid_output_diagnostic_mode(args: argparse.Namespace) -> bool:
 
 
 def _validate_args(args: argparse.Namespace) -> None:
+    # fp8 + scaled_mm wiring. The scaled_mm epilogue is the fp8 RowWise path; it
+    # is only meaningful for fp8 inputs, and the only impls that implement it are
+    # ATen (torch._scaled_mm) and Helion. quack-direct/quack do not.
+    if args.epilogue == "scaled_mm" and args.dtype != "float8_e4m3fn":
+        raise SystemExit("--epilogue scaled_mm requires --dtype float8_e4m3fn")
+    if args.dtype == "float8_e4m3fn":
+        if args.epilogue != "scaled_mm":
+            raise SystemExit("--dtype float8_e4m3fn requires --epilogue scaled_mm")
+        impls = args.impls or list(DEFAULT_IMPLS)
+        requested = [args.impl] if args.impl != "all" else impls
+        bad = [i for i in requested if i in ("quack", "quack-direct")]
+        if bad:
+            raise SystemExit(
+                f"impl(s) {bad} do not support fp8 scaled_mm; use --impls with "
+                "aten and/or helion-cute (quack-direct has no fp8 rowwise GEMM here)"
+            )
+        if "helion-triton" in requested:
+            raise SystemExit(
+                "helion-triton does not support the fp8 tcgen05 path; "
+                "use --impls aten helion-cute"
+            )
     special_modes = (
         args.helion_two_cta_diagnostic_sweep,
         args.helion_two_cta_codegen_report,

--- a/examples/fp8_matmul.py
+++ b/examples/fp8_matmul.py
@@ -27,6 +27,56 @@ if TYPE_CHECKING:
 
 
 # %%
+# Measured-good config for this kernel on the CuTe backend (B200 / sm_100),
+# tuned at 4096x4096x4096 fp8 e4m3 -> bf16. Not pinned on the kernel decorator
+# because the tcgen05_* keys are CuTe-only (the Triton backend rejects them);
+# apply it explicitly when running on the CuTe backend:
+#
+#     bound = fp8_matmul.bind((x, y, scale_a2d, scale_b1d))
+#     bound.set_config(FP8_MATMUL_CUTE_B200_CONFIG)
+#
+# Why these values:
+#   * ``block_sizes=[256, 128, 128]``: bk=128 matches CUTLASS's fp8 K tile
+#     (4 x MMA-K of 32). bk=64 doubles TMA transactions / barrier phases per
+#     FLOP and leaves the single MMA warp issuing only ~52% of cycles
+#     (1711 vs 2422 peak TFLOP/s measured).
+#   * ``tcgen05_ab_stages=8``: 1-byte fp8 operands fit a deeper AB SMEM ring
+#     than bf16; the deep pipeline hides K-loop latency for the
+#     latency-sensitive fp8 MMA (CUTLASS's _compute_stages fills SMEM the
+#     same way).
+#   * ``tcgen05_cluster_m=2`` (CtaGroup.TWO) + persistent scheduling with the
+#     ``static_persistent`` model: the validated 2-CTA envelope.
+#   * ``indexing``: TMA tensor descriptors for the two scale operands feed
+#     the fused-rowwise-scale epilogue's aux path.
+#
+# Measured on B200 at 4096^3 (do_bench, device-side ~52.6 us):
+#   ~2100-2130 TFLOP/s vs torch._scaled_mm ~1860 and a hand-written CuTe DSL
+#   reference ~2330.
+FP8_MATMUL_CUTE_B200_CONFIG = helion.Config(
+    block_sizes=[256, 128, 128],
+    indexing=[
+        "pointer",  # x load
+        "pointer",  # y load
+        "pointer",  # out store
+        "tensor_descriptor",  # scale_a2d load
+        "tensor_descriptor",  # scale_b1d load
+    ],
+    l2_groupings=[4],
+    num_stages=4,
+    num_warps=8,
+    pid_type="persistent_blocked",
+    tcgen05_ab_stages=8,
+    tcgen05_acc_stages=2,
+    tcgen05_c_stages=2,
+    tcgen05_cluster_m=2,
+    tcgen05_cluster_n=1,
+    tcgen05_num_epi_warps=4,
+    tcgen05_persistence_model="static_persistent",
+    tcgen05_strategy="role_local_monolithic",
+)
+
+
+# %%
 @helion.kernel(static_shapes=True)
 def fp8_matmul(
     x: torch.Tensor,

--- a/examples/fp8_matmul.py
+++ b/examples/fp8_matmul.py
@@ -1,0 +1,126 @@
+"""
+Helion FP8 RowWise scaled_mm Example
+====================================
+FP8 (e4m3) RowWise scaled matrix multiplication on Helion:
+
+    out[m, n] = scale_a[m] * scale_b[n] * sum_k a[m, k] * b[k, n]
+
+``scale_a`` is passed as a ``(M, N)`` stride-(1,0) column-vector view (read as a
+scalar per subtile in the fused tcgen05 epilogue) and ``scale_b`` as a rank-1
+per-column row vector; this is the layout the CuTe backend's
+fused-rowwise-scale epilogue recognizes.
+"""
+
+# %%
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+import helion
+from helion._testing import DEVICE
+import helion.language as hl
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+# %%
+@helion.kernel(static_shapes=True)
+def fp8_matmul(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_a2d: torch.Tensor,
+    scale_b1d: torch.Tensor,
+) -> torch.Tensor:
+    """FP8 RowWise scaled_mm: ``out = scale_a[m] * scale_b[n] * (x @ y)`` in BF16.
+
+    Args:
+        x: Left input [m, k] in FP8 (e4m3), row-major.
+        y: Right input [k, n] in FP8 (e4m3), column-major (K-contiguous) preferred.
+        scale_a2d: Per-row scale as a ``(m, n)`` stride-(1,0) column-vector view.
+        scale_b1d: Per-column scale as a rank-1 ``(n,)`` row vector.
+
+    Returns:
+        Output [m, n] in BF16.
+    """
+    m, k = x.size()
+    k2, n = y.size()
+    assert k == k2, f"size mismatch {k} != {k2}"
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+        # Fold the rowwise scale on the f32 accumulator before the bf16 cast.
+        out[tile_m, tile_n] = (acc * scale_a2d[tile_m, tile_n] * scale_b1d[tile_n]).to(
+            torch.bfloat16
+        )
+    return out
+
+
+# %%
+def reference_scaled_mm(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> torch.Tensor:
+    """Reference using ``torch._scaled_mm`` (column-major second operand)."""
+    if y.stride(0) == 1 and y.stride(1) > 1:
+        y_col_major = y
+    else:
+        y_col_major = y.T.contiguous().T
+    return torch._scaled_mm(
+        x, y_col_major, scale_a, scale_b, use_fast_accum=False, out_dtype=torch.bfloat16
+    )
+
+
+# %%
+def fp8_matmul_tritonbench(
+    tb_op: object,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> Callable[[], torch.Tensor]:
+    """Wrapper for TritonBench: a [m, k] fp8, b [k, n] fp8 (col-major), rowwise
+    scales scale_a [m, 1], scale_b [1, n]."""
+    m, _ = a.size()
+    _, n = b.size()
+    scale_a2d = scale_a.reshape(m, 1).expand(m, n)
+    scale_b1d = scale_b.reshape(n)
+    return lambda: fp8_matmul(a, b, scale_a2d, scale_b1d)
+
+
+# %%
+def check(m: int, k: int, n: int) -> None:
+    """Validate fp8_matmul against the torch._scaled_mm reference."""
+    x = (torch.randn([m, k], device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+    y = (torch.randn([k, n], device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+    y = y.T.contiguous().T  # column-major (K-contiguous)
+    scale_a = (torch.rand([m, 1], device=DEVICE) + 0.5).to(torch.float32)
+    scale_b = (torch.rand([1, n], device=DEVICE) + 0.5).to(torch.float32)
+    scale_a2d = scale_a.reshape(m, 1).expand(m, n)
+    scale_b1d = scale_b.reshape(n)
+
+    from helion._testing import run_example
+
+    run_example(
+        lambda a, b: fp8_matmul(a, b, scale_a2d, scale_b1d),
+        lambda a, b: reference_scaled_mm(a, b, scale_a, scale_b),
+        (x, y),
+        atol=0.1,
+        rtol=0.1,
+    )
+
+
+# %%
+def main() -> None:
+    check(64, 2048, 2048)
+
+
+# %%
+if __name__ == "__main__":
+    main()

--- a/helion/_compat.py
+++ b/helion/_compat.py
@@ -353,11 +353,22 @@ def target_device_capability(
     """Return CUDA compute capability, or None for non-CUDA/unavailable targets."""
     if device is not None and device.type != "cuda":
         return None
+    if device is not None and device.index is not None:
+        return _target_device_capability(device.index)
     if not torch.cuda.is_available():
         return None
-    if device is None:
-        return torch.cuda.get_device_capability(torch.cuda.current_device())
-    return torch.cuda.get_device_capability(device)
+    # device=None means the current device; resolve it per call so a later
+    # set_device is not frozen under one cache key.
+    return _target_device_capability(torch.cuda.current_device())
+
+
+@functools.cache
+def _target_device_capability(index: int) -> tuple[int, int] | None:
+    # Memoize per index (capability is fixed per device). Tests patch the
+    # public wrapper above, mirroring is_hip / _is_hip.
+    if not torch.cuda.is_available():
+        return None
+    return torch.cuda.get_device_capability(index)
 
 
 def min_dot_size(

--- a/helion/_compat.py
+++ b/helion/_compat.py
@@ -347,42 +347,69 @@ def supports_tensor_descriptor() -> bool:
     return _supports_tensor_descriptor()
 
 
+# Per-device-index cache for ``target_device_capability``. A physical
+# device's compute capability cannot change within a process (torch itself
+# caches ``device_count`` behind ``is_available``), but the query costs
+# ~2.5us and sits on the per-call kernel dispatch path via
+# ``_device_specialization_key``. Entries are only read/written while
+# ``torch.cuda.is_available`` / ``torch.cuda.get_device_capability`` are
+# the original functions — tests patch them to simulate other
+# architectures, and the identity check below routes patched calls to the
+# uncached path.
+#
+# NB: a plain ``@functools.cache`` on this function is wrong on two counts,
+# which is why the cache is hand-rolled:
+#   1. It keys on the ``device`` argument, not on whether the torch
+#      functions are patched, so it cannot fall back to a live query.
+#      Tests that patch ``get_device_capability`` to return (9, 0) then
+#      (10, 0) for the same device (e.g. test_config_api's sm90-vs-sm100
+#      cache-key test) would get the first cached value both times.
+#   2. ``device=None`` means "the current device", which can change via
+#      ``torch.cuda.set_device``. functools.cache would freeze the first
+#      answer under the ``None`` key forever; here ``None`` is resolved to
+#      a concrete index per call before the cache lookup.
+_REAL_CUDA_IS_AVAILABLE: Callable[[], bool] = torch.cuda.is_available
+_REAL_CUDA_GET_CAPABILITY: Callable[..., tuple[int, int]] = (
+    torch.cuda.get_device_capability
+)
+_CUDA_CAPABILITY_CACHE: dict[int, tuple[int, int]] = {}
+_CUDA_AVAILABLE: bool | None = None
+
+
 def target_device_capability(
     device: torch.device | None = None,
 ) -> tuple[int, int] | None:
-    """Return CUDA compute capability, or None for non-CUDA/unavailable targets.
-
-    This sits on the per-call kernel dispatch path via
-    ``_device_specialization_key`` and its torch.cuda queries cost ~2.7us,
-    so the result is memoized per device index in
-    ``_target_device_capability``. Like ``is_hip`` / ``_is_hip``, the cache
-    lives in the private helper and this public wrapper is the seam tests
-    patch to simulate other architectures.
-
-    A concrete device index goes straight to the cached helper, so the
-    steady-state hot path makes no torch.cuda calls at all. ``device=None``
-    means the *current* device, which moves with ``torch.cuda.set_device``;
-    it is resolved to a concrete index per call (after an availability
-    check) so it is never frozen under a single cache key.
-    """
+    """Return CUDA compute capability, or None for non-CUDA/unavailable targets."""
     if device is not None and device.type != "cuda":
         return None
-    if device is not None and device.index is not None:
-        return _target_device_capability(device.index)
+    if (
+        torch.cuda.is_available is _REAL_CUDA_IS_AVAILABLE
+        and torch.cuda.get_device_capability is _REAL_CUDA_GET_CAPABILITY
+    ):
+        global _CUDA_AVAILABLE
+        if _CUDA_AVAILABLE is not True:
+            # Only cache the True result; an unavailable runtime has no GPU
+            # launches to speed up, so keep re-querying in that case.
+            if not _REAL_CUDA_IS_AVAILABLE():
+                return None
+            _CUDA_AVAILABLE = True
+        index = device.index if device is not None else None
+        if index is None:
+            # An index-less device refers to the *current* device, which can
+            # change between calls — resolve it each time (cheap), then hit
+            # the per-index cache.
+            index = torch.cuda.current_device()
+        capability = _CUDA_CAPABILITY_CACHE.get(index)
+        if capability is None:
+            _CUDA_CAPABILITY_CACHE[index] = capability = _REAL_CUDA_GET_CAPABILITY(
+                index
+            )
+        return capability
     if not torch.cuda.is_available():
         return None
-    return _target_device_capability(torch.cuda.current_device())
-
-
-@functools.cache
-def _target_device_capability(index: int) -> tuple[int, int] | None:
-    # A physical device's compute capability cannot change within a process,
-    # so memoize per device index; the availability check is inside the
-    # cache (like ``_is_hip``) so the hot path skips it once warm. Patched
-    # in tests via the public ``target_device_capability`` wrapper above.
-    if not torch.cuda.is_available():
-        return None
-    return torch.cuda.get_device_capability(index)
+    if device is None:
+        return torch.cuda.get_device_capability(torch.cuda.current_device())
+    return torch.cuda.get_device_capability(device)
 
 
 def min_dot_size(

--- a/helion/_compat.py
+++ b/helion/_compat.py
@@ -350,22 +350,36 @@ def supports_tensor_descriptor() -> bool:
 def target_device_capability(
     device: torch.device | None = None,
 ) -> tuple[int, int] | None:
-    """Return CUDA compute capability, or None for non-CUDA/unavailable targets."""
+    """Return CUDA compute capability, or None for non-CUDA/unavailable targets.
+
+    This sits on the per-call kernel dispatch path via
+    ``_device_specialization_key`` and its torch.cuda queries cost ~2.7us,
+    so the result is memoized per device index in
+    ``_target_device_capability``. Like ``is_hip`` / ``_is_hip``, the cache
+    lives in the private helper and this public wrapper is the seam tests
+    patch to simulate other architectures.
+
+    A concrete device index goes straight to the cached helper, so the
+    steady-state hot path makes no torch.cuda calls at all. ``device=None``
+    means the *current* device, which moves with ``torch.cuda.set_device``;
+    it is resolved to a concrete index per call (after an availability
+    check) so it is never frozen under a single cache key.
+    """
     if device is not None and device.type != "cuda":
         return None
     if device is not None and device.index is not None:
         return _target_device_capability(device.index)
     if not torch.cuda.is_available():
         return None
-    # device=None means the current device; resolve it per call so a later
-    # set_device is not frozen under one cache key.
     return _target_device_capability(torch.cuda.current_device())
 
 
 @functools.cache
 def _target_device_capability(index: int) -> tuple[int, int] | None:
-    # Memoize per index (capability is fixed per device). Tests patch the
-    # public wrapper above, mirroring is_hip / _is_hip.
+    # A physical device's compute capability cannot change within a process,
+    # so memoize per device index; the availability check is inside the
+    # cache (like ``_is_hip``) so the hot path skips it once warm. Patched
+    # in tests via the public ``target_device_capability`` wrapper above.
     if not torch.cuda.is_available():
         return None
     return torch.cuda.get_device_capability(index)

--- a/helion/_compile_time.py
+++ b/helion/_compile_time.py
@@ -253,6 +253,17 @@ def measure(name: str) -> contextlib.AbstractContextManager[None]:
     return _MeasureContext(name, get_tracker())
 
 
+def is_enabled() -> bool:
+    """Whether compile-time measurement is active.
+
+    Lets hot paths skip even entering a (disabled) ``measure()`` context
+    manager — the ``with`` protocol alone costs ~115ns/call, which is
+    significant on the per-call kernel dispatch path. ``enable()`` flips
+    this at runtime, so read it fresh rather than caching.
+    """
+    return _enabled
+
+
 def enable() -> None:
     """Enable compile-time measurement after this module has been imported."""
     global _enabled

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1316,7 +1316,17 @@ class TritonBackend(Backend):
             f"tl.full([{', '.join(shape_dims)}], {value_expr}, {self.dtype_str(dtype)})"
         )
 
-    def launcher_keyword_args(self, config: Config, *, has_barrier: bool) -> list[str]:
+    def launcher_runtime_kwargs(
+        self, config: Config, *, has_barrier: bool
+    ) -> dict[str, object]:
+        """Return the launcher kwargs as a ``dict`` of runtime values.
+
+        Used by both :meth:`launcher_keyword_args` (which formats the dict
+        as source strings for codegen) and
+        :func:`helion.runtime.build_fast_launcher` (which bakes the dict
+        into a closure at :meth:`BoundKernel.set_config` time so the hot
+        launch path doesn't have to allocate a per-call kwargs dict).
+        """
         from .._compat import supports_maxnreg
 
         # Workaround for triton bug: warp_specialize requires at least 4 warps
@@ -1325,31 +1335,45 @@ class TritonBackend(Backend):
         if any(config.range_warp_specializes):
             num_warps = max(4, num_warps)
 
-        args = [
-            f"num_warps={num_warps}",
-            f"num_stages={config.num_stages}",
-            *(["launch_cooperative_grid=True"] if has_barrier else []),
-        ] + [
-            f"{x.removeprefix('_triton_config_')}={config[x]}"
-            for x in config
-            if x.startswith("_triton_config_")
-        ]
+        kwargs: dict[str, object] = {
+            "num_warps": num_warps,
+            "num_stages": config.num_stages,
+        }
+        if has_barrier:
+            kwargs["launch_cooperative_grid"] = True
+        for x in config:
+            if x.startswith("_triton_config_"):
+                kwargs[x.removeprefix("_triton_config_")] = config[x]
 
         from ..autotuner.config_spec import _get_backend_tunable_keys
 
         for key in _get_backend_tunable_keys():
             if key in config:
-                args.append(f"{key}={config[key]!r}")
+                kwargs[key] = config[key]
 
         if "maxnreg" in config and config["maxnreg"] is not None and supports_maxnreg():
-            args.append(f"maxnreg={config['maxnreg']}")
+            kwargs["maxnreg"] = config["maxnreg"]
 
         advanced_controls_file = config.advanced_controls_file
         if advanced_controls_file:
-            ptx_option = f"--apply-controls {advanced_controls_file}"
-            args.append(f"ptx_options={ptx_option!r}")
+            kwargs["ptx_options"] = f"--apply-controls {advanced_controls_file}"
 
-        return args
+        return kwargs
+
+    def launcher_keyword_args(self, config: Config, *, has_barrier: bool) -> list[str]:
+        from ..autotuner.config_spec import _get_backend_tunable_keys
+
+        backend_tunable_keys = _get_backend_tunable_keys()
+        kwargs = self.launcher_runtime_kwargs(config, has_barrier=has_barrier)
+        # Backend tunable keys (typically strings) and ptx_options use repr;
+        # everything else (num_warps, num_stages, ints, bools) renders plain.
+        out: list[str] = []
+        for k, v in kwargs.items():
+            if k in backend_tunable_keys or k == "ptx_options":
+                out.append(f"{k}={v!r}")
+            else:
+                out.append(f"{k}={v}")
+        return out
 
     def grid_barrier_stmt(self, sem_arg: str) -> str:
         return f"triton_helpers.x_grid_barrier({sem_arg})"

--- a/helion/_compiler/cute/cute_fx_walk.py
+++ b/helion/_compiler/cute/cute_fx_walk.py
@@ -310,6 +310,18 @@ def aux_tensor_load_kind(
     if len(carrier_tile_shape) != 2:
         return None
 
+    colvec = _matches_colvec_broadcast(
+        aux_shape=aux_shape,
+        aux_tensor_shape=aux_tensor_shape,
+        aux_tensor_val=aux_tensor_val,
+        index_list=index_list,
+        carrier_tile_shape=carrier_tile_shape,
+        carrier_tile_index_nodes=carrier_tile_index_nodes,
+        carrier_global_shape=carrier_global_shape,
+    )
+    if colvec is not None:
+        return colvec
+
     if _matches_exact(
         aux_shape=aux_shape,
         aux_tensor_shape=aux_tensor_shape,
@@ -488,6 +500,61 @@ def _matches_leading_broadcast(
         if aux_tensor_shape[1] != carrier_global_shape[1]:
             return None
     return ("broadcast", 0)
+
+
+def _matches_colvec_broadcast(
+    *,
+    aux_shape: tuple[object, ...],
+    aux_tensor_shape: tuple[object, ...],
+    aux_tensor_val: torch.Tensor,
+    index_list: Sequence[object],
+    carrier_tile_shape: tuple[object, ...],
+    carrier_tile_index_nodes: tuple[torch.fx.Node, ...] | None,
+    carrier_global_shape: tuple[object, ...] | None,
+) -> tuple[str, int] | None:
+    """Check whether a load is a per-row column-vector broadcast and
+    return ``("broadcast", 2)`` on success.
+
+    The accepted form is ``scale_a[tile_m, tile_n]`` where ``scale_a`` is a
+    full ``(M, N)`` view with **stride 0 on the trailing (N) axis** — i.e. an
+    ``unsqueeze(1).expand(M, N)`` of a per-row ``(M,)`` vector. Its value
+    depends only on ``m``, so it is *uniform over each thread's N fragment*
+    in the tcgen05 T2R epilogue. The splice therefore reads it as a single
+    **scalar** per subtile (matching CUTLASS's ``sa = tTR_gSA[(0,0,0,s)]``)
+    rather than a vector ``.load()``, avoiding a redundant N-wide read.
+
+    This must be tried *before* ``_matches_exact`` (a stride-0-N aux still
+    has the full ``(M, N)`` underlying shape, so the exact matcher would
+    otherwise claim it and emit a vector read). A genuine 2-D residual has a
+    non-zero trailing stride and falls through to ``_matches_exact``.
+    """
+    if (
+        len(aux_tensor_shape) != 2
+        or len(aux_shape) != 2
+        or len(index_list) != 2
+        or len(carrier_tile_shape) != 2
+    ):
+        return None
+    if carrier_tile_index_nodes is None or len(carrier_tile_index_nodes) != 2:
+        return None
+    for idx, expected in zip(index_list, carrier_tile_index_nodes, strict=True):
+        if idx is not expected:
+            return None
+    for aux_dim, carrier_dim in zip(aux_shape, carrier_tile_shape, strict=True):
+        if aux_dim != carrier_dim:
+            return None
+    if carrier_global_shape is not None:
+        if len(carrier_global_shape) != 2:
+            return None
+        if tuple(aux_tensor_shape) != tuple(carrier_global_shape):
+            return None
+    stride = aux_tensor_val.stride()
+    # Uniform over N (trailing stride 0) and varying over M (leading stride
+    # non-zero) — the column-vector broadcast. A real (M, N) tensor has
+    # trailing stride 1 and is left for the exact-shape matcher.
+    if len(stride) != 2 or stride[1] != 0 or stride[0] == 0:
+        return None
+    return ("broadcast", 2)
 
 
 def _matches_exact(

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import ast
 from dataclasses import dataclass
+from dataclasses import replace as dataclass_replace
 import os
 import textwrap
 from typing import TYPE_CHECKING
@@ -1060,6 +1061,10 @@ class _PerKiterTmaArgs:
     # (cute_plan.md §6.12.7). Default 1 preserves byte-identity for the
     # validated cluster_m=2 cluster_n=1 path.
     cluster_n: int = 1
+    # Optional name of a hoisted ``make_warp_uniform(block_idx_in_cluster())``
+    # local; when set, owner predicates compare against it instead of
+    # re-deriving the cluster rank inline at every K-loop gate.
+    cluster_rank_var: str = ""
     # Static-full one-CTA pipelined TMA loops can drop the per-K runtime
     # full-tile branch and scalar fallback. Non-pipelined/asymmetric or two-CTA
     # TMA paths must keep the guarded fallback path.
@@ -1107,6 +1112,7 @@ def _tcgen05_two_cta_owner_predicate(
     is_two_cta: bool,
     gate_exec_warp: bool,
     cluster_n: int = 1,
+    cluster_rank_var: str = "",
 ) -> str | None:
     """Owner-of-the-V-pair predicate for AB consumer release / MMA issuance.
 
@@ -1124,7 +1130,18 @@ def _tcgen05_two_cta_owner_predicate(
     if gate_exec_warp:
         predicate_terms.append(exec_active)
     if is_two_cta:
-        if cluster_n > 1:
+        if cluster_rank_var:
+            # Caller hoisted ``make_warp_uniform(block_idx_in_cluster())``
+            # into a per-kernel local; reuse it instead of re-deriving the
+            # rank at every gate (the inline form costs S2UR+IMAD per use
+            # inside the K loop).
+            if cluster_n > 1:
+                predicate_terms.append(
+                    f"{cluster_rank_var} % cutlass.Int32(2) == cutlass.Int32(0)"
+                )
+            else:
+                predicate_terms.append(f"{cluster_rank_var} == cutlass.Int32(0)")
+        elif cluster_n > 1:
             predicate_terms.append(_TCGEN05_V_LEADER_PREDICATE)
         else:
             predicate_terms.append(_TCGEN05_CLUSTER_LEADER_PREDICATE)
@@ -1190,20 +1207,58 @@ def _build_kloop_pipeline_producer_if(
     return statement_from_string(src)
 
 
-def _build_kloop_pipeline_consumer_if(
+def _build_unified_tma_producer_stmts(args: _PerKiterTmaArgs) -> list[ast.stmt]:
+    """Unified per-K-tile TMA producer body (CUTLASS reference shape).
+
+    One body for ALL K tiles: ``try_acquire``-peeked ``producer_acquire``
+    blocks once the AB ring is full, so the same statements serve prologue
+    (ring filling) and steady state (ring reuse) — no separate unrolled
+    warm-up chain and no ``+ab_stage_count`` K offset. Only valid under
+    static-full tiles (no full/next-tile predicates needed) inside the
+    role-local producer's own K loop (blocking acquire cannot stall the MMA
+    or epilogue warps).
+    """
+    assert args.use_tma_a and args.use_tma_b, (
+        "pipelined branch requires both A and B to be TMA-loaded"
+    )
+    assert not args.skip_producer_acquire and not args.skip_producer_advance, (
+        "diagnostic acquire/advance skips keep the unrolled prologue path"
+    )
+    copy_a_src = _kloop_tma_copy_a_src(args, k_offset=args.tma_k_tile)
+    copy_b_src = _kloop_tma_copy_b_src(args, k_offset=args.tma_k_tile)
+    return [
+        statement_from_string(line)
+        for line in (
+            f"{args.tma_pipeline}.producer_acquire({args.tma_producer_state})",
+            f"{args.tma_barrier_ptr} = "
+            f"{args.tma_pipeline}.producer_get_barrier({args.tma_producer_state})",
+            copy_a_src.strip(),
+            copy_b_src.strip(),
+            f"{args.tma_pipeline}.producer_commit({args.tma_producer_state})",
+            emit_pipeline_advance(args.tma_producer_state),
+        )
+    ]
+
+
+def _build_kloop_pipeline_consumer_stmts(
     args: _PerKiterTmaArgs,
     *,
     gate_exec_warp: bool = True,
     include_scalar_fallback: bool = True,
     use_existing_try_token: bool = False,
     sync_before_scalar_fallback: bool = False,
-) -> ast.stmt:
-    """Per-K-iter TMA consumer / scalar-fallback ``if`` for the pipelined branch."""
+) -> list[ast.stmt]:
+    """Per-K-iter TMA consumer / scalar-fallback statements (pipelined branch).
+
+    Every form emits a single statement except the ungated static-full
+    try-wait + wait pair, which emits two siblings.
+    """
     if args.static_full_tiles:
-        assert not args.is_two_cta, (
-            "static-full fast path is only valid for one-CTA pipelined TMA loops"
-        )
-        assert gate_exec_warp, "static-full fast path requires an exec-warp gate"
+        # One-CTA inline callers keep the exec-warp gate; the role-local
+        # separate exec loop passes ``gate_exec_warp=False`` because the
+        # loop already lives inside the MMA-exec role block (two-CTA adds
+        # the V/cluster-leader owner predicate below).
+        assert gate_exec_warp or not args.is_two_cta or args.cluster_n >= 1
         assert not include_scalar_fallback, (
             "static-full fast path has no scalar fallback branch"
         )
@@ -1223,18 +1278,28 @@ def _build_kloop_pipeline_consumer_if(
             f"{args.tma_pipeline}.consumer_wait("
             f"{args.tma_consumer_state}, {args.tma_consumer_try_token})"
         )
+    consumer_gate = _tcgen05_two_cta_owner_predicate(
+        args.exec_active,
+        is_two_cta=args.is_two_cta,
+        gate_exec_warp=gate_exec_warp,
+        cluster_n=args.cluster_n,
+        cluster_rank_var=args.cluster_rank_var,
+    )
+    if args.static_full_tiles and consumer_gate is None:
+        # Ungated static-full form: emit the (possibly multi-line) wait
+        # sequence as sibling statements with no wrapper.
+        return [
+            statement_from_string(line)
+            for line in consumer_src.splitlines()
+            if line.strip()
+        ]
     full_tile_src = _tcgen05_emit_optional_gate(
         consumer_src,
-        _tcgen05_two_cta_owner_predicate(
-            args.exec_active,
-            is_two_cta=args.is_two_cta,
-            gate_exec_warp=gate_exec_warp,
-            cluster_n=args.cluster_n,
-        ),
+        consumer_gate,
         indent="" if args.static_full_tiles else "    ",
     )
     if args.static_full_tiles:
-        return statement_from_string(full_tile_src)
+        return [statement_from_string(full_tile_src)]
     fallback_src = ""
     if include_scalar_fallback:
         scalar_load_a_src = textwrap.indent(ast.unparse(args.scalar_load_a), "    ")
@@ -1250,7 +1315,26 @@ def _build_kloop_pipeline_consumer_if(
             "    cute.arch.sync_threads()"
         )
     src = f"if {args.tma_full_tile}:\n{full_tile_src}{fallback_src}"
-    return statement_from_string(src)
+    return [statement_from_string(src)]
+
+
+def _build_kloop_pipeline_consumer_if(
+    args: _PerKiterTmaArgs,
+    *,
+    gate_exec_warp: bool = True,
+    include_scalar_fallback: bool = True,
+    use_existing_try_token: bool = False,
+    sync_before_scalar_fallback: bool = False,
+) -> ast.stmt:
+    """Single-statement form of :func:`_build_kloop_pipeline_consumer_stmts`."""
+    (stmt,) = _build_kloop_pipeline_consumer_stmts(
+        args,
+        gate_exec_warp=gate_exec_warp,
+        include_scalar_fallback=include_scalar_fallback,
+        use_existing_try_token=use_existing_try_token,
+        sync_before_scalar_fallback=sync_before_scalar_fallback,
+    )
+    return stmt
 
 
 def _build_kloop_pipeline_consumer_prefetch_stmts(
@@ -1266,6 +1350,7 @@ def _build_kloop_pipeline_consumer_prefetch_stmts(
         is_two_cta=args.is_two_cta,
         gate_exec_warp=gate_exec_warp,
         cluster_n=args.cluster_n,
+        cluster_rank_var=args.cluster_rank_var,
     )
     if owner_predicate is not None:
         predicate = f"{predicate} and {owner_predicate}"
@@ -1279,13 +1364,13 @@ def _build_kloop_pipeline_consumer_prefetch_stmts(
     ]
 
 
-def _build_kloop_pipeline_release_if(
+def _build_kloop_pipeline_release_stmts(
     args: _PerKiterTmaArgs,
     *,
     gate_exec_warp: bool = True,
     include_scalar_fallback: bool = True,
-) -> ast.stmt:
-    """Per-K-iter consumer release ``if`` for the pipelined branch.
+) -> list[ast.stmt]:
+    """Per-K-iter consumer release statements for the pipelined branch.
 
     Producer-state advance lives in the producer block (one per
     commit), so only the consumer-state advance is emitted here. In
@@ -1295,10 +1380,9 @@ def _build_kloop_pipeline_release_if(
     multicast mask; separate peer arrivals over-count the empty barrier.
     """
     if args.static_full_tiles:
-        assert not args.is_two_cta, (
-            "static-full fast path is only valid for one-CTA pipelined TMA loops"
-        )
-        assert gate_exec_warp, "static-full fast path requires an exec-warp gate"
+        # See the consumer-if note: one-CTA inline callers keep the exec-warp
+        # gate; the role-local separate exec loop drops it (two-CTA keeps the
+        # leader owner predicate below).
         assert not include_scalar_fallback, (
             "static-full fast path has no scalar fallback branch"
         )
@@ -1308,6 +1392,7 @@ def _build_kloop_pipeline_release_if(
         is_two_cta=args.is_two_cta,
         gate_exec_warp=gate_exec_warp,
         cluster_n=args.cluster_n,
+        cluster_rank_var=args.cluster_rank_var,
     )
     advance_src = emit_pipeline_advance(args.tma_consumer_state)
     indent = "" if args.static_full_tiles else "    "
@@ -1315,22 +1400,38 @@ def _build_kloop_pipeline_release_if(
         # With gate_exec_warp=False the caller is already inside the
         # role-local exec loop, so every iteration can advance local state.
         advance_gate = args.exec_active if gate_exec_warp else None
+        if args.static_full_tiles:
+            # No full-tile wrapper: the two gated blocks are siblings.
+            return [
+                statement_from_string(
+                    _tcgen05_emit_optional_gate(release_src, release_gate, indent="")
+                ),
+                statement_from_string(
+                    _tcgen05_emit_optional_gate(advance_src, advance_gate, indent="")
+                ),
+            ]
         full_tile_src = (
             _tcgen05_emit_optional_gate(release_src, release_gate, indent=indent)
             + "\n"
             + _tcgen05_emit_optional_gate(advance_src, advance_gate, indent=indent)
         )
     else:
+        if args.static_full_tiles and release_gate is None:
+            # Ungated static-full form: two sibling statements, no wrapper.
+            return [
+                statement_from_string(release_src),
+                statement_from_string(advance_src),
+            ]
         full_tile_src = _tcgen05_emit_optional_gate(
             release_src + "\n" + advance_src, release_gate, indent=indent
         )
     if args.static_full_tiles:
-        return statement_from_string(full_tile_src)
+        return [statement_from_string(full_tile_src)]
     fallback_src = (
         "\nelse:\n    cute.arch.sync_threads()" if include_scalar_fallback else ""
     )
     src = f"if {args.tma_full_tile}:\n{full_tile_src}{fallback_src}"
-    return statement_from_string(src)
+    return [statement_from_string(src)]
 
 
 def _build_tcgen05_mma_accumulate_reset_stmt(
@@ -1340,6 +1441,7 @@ def _build_tcgen05_mma_accumulate_reset_stmt(
     gate_exec_warp: bool = True,
     is_two_cta: bool = False,
     cluster_n: int = 1,
+    cluster_rank_var: str = "",
 ) -> ast.stmt:
     reset_src = f"{tiled_mma}.set(cute.nvgpu.tcgen05.Field.ACCUMULATE, False)"
     predicate = _tcgen05_two_cta_owner_predicate(
@@ -1347,6 +1449,7 @@ def _build_tcgen05_mma_accumulate_reset_stmt(
         is_two_cta=is_two_cta,
         gate_exec_warp=gate_exec_warp,
         cluster_n=cluster_n,
+        cluster_rank_var=cluster_rank_var,
     )
     if predicate is None:
         return statement_from_string(reset_src)
@@ -1364,6 +1467,7 @@ def _build_tcgen05_mma_issue_stmt(
     gate_exec_warp: bool = True,
     is_two_cta: bool = False,
     cluster_n: int = 1,
+    cluster_rank_var: str = "",
 ) -> ast.stmt:
     issue_src = (
         f"for _tcgen05_kblk_idx in range(cute.size({tcgen05_frag_a}, mode=[2])):\n"
@@ -1381,6 +1485,7 @@ def _build_tcgen05_mma_issue_stmt(
         is_two_cta=is_two_cta,
         gate_exec_warp=gate_exec_warp,
         cluster_n=cluster_n,
+        cluster_rank_var=cluster_rank_var,
     )
     if predicate is not None:
         issue_src = f"if {predicate}:\n{textwrap.indent(issue_src, '    ')}"
@@ -2378,6 +2483,32 @@ def _emit_mma_pipeline(
             f"{TCGEN05_AB_CONSUMER_PHASE_MODE_PHASE1!r} requires the guarded "
             "cluster_m=2, CtaGroup.ONE, 128x256x128 bridge shape",
         )
+    # Unified TMA producer (CUTLASS reference shape): one rolled K loop over
+    # ALL K tiles where ``producer_acquire`` blocks once the AB ring is
+    # full — pipelining comes from the mbarrier handshake, not from a
+    # separate unrolled warm-up prologue plus an ``+ab_stages``-offset
+    # steady-state loop. Requires static-full tiles (every prologue/tail
+    # predicate is a compile-time truth) and the role-local separate
+    # producer loop (the producer warp owns its own K loop, so blocking in
+    # ``producer_acquire`` cannot stall MMA or epilogue work). The
+    # unrolled-prologue form at ab_stages=8 put 24 static UTMALDG sites in
+    # SASS (vs the reference's 2) and re-derived loop-invariant full-tile
+    # predicates per stage and per K iteration.
+    tcgen05_use_unified_tma_producer = (
+        tcgen05_static_full_tiles
+        and tcgen05_use_tma_pipeline
+        and tcgen05_use_separate_tma_producer
+        and not tcgen05_role_local_uses_k_tail_tma
+        and not tcgen05_role_local_double_edge_tma
+        and not tcgen05_role_local_m_edge_tma
+        and not tcgen05_role_local_n_edge_tma
+        # Bridge diagnostics address individual acquire/advance edges of the
+        # unrolled prologue + offset steady-state form; keep that form when
+        # any of them is requested.
+        and not diagnose_skip_ab_producer_acquire
+        and not diagnose_skip_initial_ab_producer_acquire
+        and not diagnose_skip_ab_producer_advance
+    )
     # Static-full CtaGroup.TWO keeps a prefetched AB consumer token live
     # across the accumulator acquire and each K-loop issue. CtaGroup.ONE
     # keeps the older adjacent try-wait/wait sequence.
@@ -4276,28 +4407,32 @@ def _emit_mma_pipeline(
                     skip_producer_acquire=diagnose_skip_ab_producer_acquire,
                     skip_producer_advance=diagnose_skip_ab_producer_advance,
                 )
-                _emit_per_tile(
-                    f"{tma_initial_full_tile} = "
-                    + _tcgen05_tma_tile_predicate(
-                        k_tile_start_expr="cutlass.Int32(0)",
-                        full_tile_end_expr=f"cutlass.Int32({bk})",
-                    ),
-                    tma_load=tcgen05_use_role_local_tma_producer,
-                )
-                stage0_prefetch = _build_initial_prefetch_if(
-                    prefetch_args,
-                    full_tile_gates=[tma_initial_full_tile],
-                    k_offset="cutlass.Int32(0)",
-                    skip_producer_acquire=(
-                        diagnose_skip_ab_producer_acquire
-                        or diagnose_skip_initial_ab_producer_acquire
-                    ),
-                )
-                prefix.append(stage0_prefetch)
-                per_tile_stmts.append(stage0_prefetch)
-                if tcgen05_use_role_local_tma_producer:
-                    tma_load_role_stmts.append(stage0_prefetch)
-                if tcgen05_ab_stage_count_value > 1:
+                if not tcgen05_use_unified_tma_producer:
+                    _emit_per_tile(
+                        f"{tma_initial_full_tile} = "
+                        + _tcgen05_tma_tile_predicate(
+                            k_tile_start_expr="cutlass.Int32(0)",
+                            full_tile_end_expr=f"cutlass.Int32({bk})",
+                        ),
+                        tma_load=tcgen05_use_role_local_tma_producer,
+                    )
+                    stage0_prefetch = _build_initial_prefetch_if(
+                        prefetch_args,
+                        full_tile_gates=[tma_initial_full_tile],
+                        k_offset="cutlass.Int32(0)",
+                        skip_producer_acquire=(
+                            diagnose_skip_ab_producer_acquire
+                            or diagnose_skip_initial_ab_producer_acquire
+                        ),
+                    )
+                    prefix.append(stage0_prefetch)
+                    per_tile_stmts.append(stage0_prefetch)
+                    if tcgen05_use_role_local_tma_producer:
+                        tma_load_role_stmts.append(stage0_prefetch)
+                if (
+                    not tcgen05_use_unified_tma_producer
+                    and tcgen05_ab_stage_count_value > 1
+                ):
                     # Warm every stage 1..ab_stage_count-1; each gated by
                     # an ``i+1``-k_tile fits-in-K predicate. The old
                     # two-call pattern only covered stages 0 and N-1
@@ -4614,6 +4749,15 @@ def _emit_mma_pipeline(
                 scalar_load_b=scalar_load_b,
                 cluster_n=tcgen05_cluster_n,
                 static_full_tiles=tcgen05_static_full_tma_fast_path,
+                # The hoisted rank local is emitted in the prefix under the
+                # same condition (see ``tma_cta_rank_in_cluster`` above), so
+                # per-K owner gates can reuse it instead of re-deriving the
+                # cluster rank each iteration.
+                cluster_rank_var=(
+                    tma_cta_rank_in_cluster
+                    if (tcgen05_cluster_m > 1 or tcgen05_is_two_cta)
+                    else ""
+                ),
             )
             if tcgen05_use_tma_pipeline:
                 if tcgen05_use_separate_tma_producer:
@@ -4622,30 +4766,35 @@ def _emit_mma_pipeline(
                             f"{tma_k_tile} = {k_offset_var} // cutlass.Int32({bk})"
                         )
                     ]
-                    if not tcgen05_static_full_tma_fast_path:
-                        assert tma_full_tile_predicate_src is not None
-                        producer_loop_body.append(
-                            statement_from_string(
-                                f"{tma_full_tile} = " + tma_full_tile_predicate_src
-                            )
+                    if tcgen05_use_unified_tma_producer:
+                        producer_loop_body.extend(
+                            _build_unified_tma_producer_stmts(tma_kloop_args)
                         )
-                    producer_loop_body.extend(
-                        [
-                            statement_from_string(
-                                f"{tma_next_full_tile} = "
-                                + _tcgen05_tma_tile_predicate(
-                                    k_tile_start_expr=f"{k_offset_var} + cutlass.Int32({bk * tcgen05_ab_stage_count_value})",
-                                    full_tile_end_expr=f"{k_offset_var} + cutlass.Int32({bk * (tcgen05_ab_stage_count_value + 1)})",
+                    else:
+                        if not tcgen05_static_full_tma_fast_path:
+                            assert tma_full_tile_predicate_src is not None
+                            producer_loop_body.append(
+                                statement_from_string(
+                                    f"{tma_full_tile} = " + tma_full_tile_predicate_src
                                 )
-                            ),
-                            statement_from_string(
-                                f"{tma_producer_try_token} = cutlass.Boolean(0)"
-                            ),
-                            _build_kloop_pipeline_producer_if(
-                                tma_kloop_args, gate_tma_warp=False
-                            ),
-                        ]
-                    )
+                            )
+                        producer_loop_body.extend(
+                            [
+                                statement_from_string(
+                                    f"{tma_next_full_tile} = "
+                                    + _tcgen05_tma_tile_predicate(
+                                        k_tile_start_expr=f"{k_offset_var} + cutlass.Int32({bk * tcgen05_ab_stage_count_value})",
+                                        full_tile_end_expr=f"{k_offset_var} + cutlass.Int32({bk * (tcgen05_ab_stage_count_value + 1)})",
+                                    )
+                                ),
+                                statement_from_string(
+                                    f"{tma_producer_try_token} = cutlass.Boolean(0)"
+                                ),
+                                _build_kloop_pipeline_producer_if(
+                                    tma_kloop_args, gate_tma_warp=False
+                                ),
+                            ]
+                        )
                     producer_loop = _clone_k_loop_with_body(
                         device_loop,
                         producer_loop_body,
@@ -4668,12 +4817,25 @@ def _emit_mma_pipeline(
                     assert mma_stage_stmt is not None
                     assert smem_a_mma_stmt is not None
                     assert smem_b_mma_stmt is not None
+                    # Under the unified producer the exec K loop also drops
+                    # its per-iteration full-tile predicate: static-full means
+                    # every K tile is full, so consumer wait/release run
+                    # unconditionally (their two-CTA owner gates remain).
+                    exec_static_full = (
+                        tcgen05_static_full_tma_fast_path
+                        or tcgen05_use_unified_tma_producer
+                    )
+                    exec_kloop_args = (
+                        dataclass_replace(tma_kloop_args, static_full_tiles=True)
+                        if tcgen05_use_unified_tma_producer
+                        else tma_kloop_args
+                    )
                     exec_loop_body: list[ast.stmt] = [
                         mma_stage_stmt,
                         smem_a_mma_stmt,
                         smem_b_mma_stmt,
                     ]
-                    if not tcgen05_static_full_tma_fast_path:
+                    if not exec_static_full:
                         assert tma_full_tile_stmt is not None
                         exec_loop_body.append(tma_full_tile_stmt)
                     if tcgen05_use_role_local_ab_consumer_prefetch:
@@ -4692,9 +4854,9 @@ def _emit_mma_pipeline(
                                 f"{tma_consumer_try_token} = cutlass.Boolean(0)"
                             )
                         )
-                    exec_loop_body.append(
-                        _build_kloop_pipeline_consumer_if(
-                            tma_kloop_args,
+                    exec_loop_body.extend(
+                        _build_kloop_pipeline_consumer_stmts(
+                            exec_kloop_args,
                             # Static-full pipeline builders require their
                             # internal exec gate to keep emitting a single
                             # statement. The outer wrapper below makes the
@@ -4725,11 +4887,12 @@ def _emit_mma_pipeline(
                                 gate_exec_warp=tcgen05_static_full_tma_fast_path,
                                 is_two_cta=tcgen05_is_two_cta,
                                 cluster_n=tcgen05_cluster_n,
+                                cluster_rank_var=tma_kloop_args.cluster_rank_var,
                             )
                         )
-                    exec_loop_body.append(
-                        _build_kloop_pipeline_release_if(
-                            tma_kloop_args,
+                    exec_loop_body.extend(
+                        _build_kloop_pipeline_release_stmts(
+                            exec_kloop_args,
                             # See the consumer wait comment above.
                             gate_exec_warp=tcgen05_static_full_tma_fast_path,
                             include_scalar_fallback=False,
@@ -4885,19 +5048,23 @@ def _emit_mma_pipeline(
                             mma_stage=mma_stage,
                             is_two_cta=tcgen05_is_two_cta,
                             cluster_n=tcgen05_cluster_n,
+                            cluster_rank_var=(
+                                tma_kloop_args.cluster_rank_var
+                                if tcgen05_use_tma and tma_kloop_args is not None
+                                else ""
+                            ),
                         )
                     )
                 if tcgen05_use_tma:
                     assert tma_kloop_args is not None
                     if tcgen05_use_tma_pipeline:
-                        cg.add_statement(
-                            _build_kloop_pipeline_release_if(
-                                tma_kloop_args,
-                                include_scalar_fallback=(
-                                    not tcgen05_static_full_tma_fast_path
-                                ),
-                            )
-                        )
+                        for release_stmt in _build_kloop_pipeline_release_stmts(
+                            tma_kloop_args,
+                            include_scalar_fallback=(
+                                not tcgen05_static_full_tma_fast_path
+                            ),
+                        ):
+                            cg.add_statement(release_stmt)
                     else:
                         cg.add_statement(
                             _build_kloop_non_pipeline_release_if(tma_kloop_args)

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -118,6 +118,21 @@ _TRACE_THROUGH_TARGETS = {
     # data shuffle.  Permuted operands fall back to scalar codegen.
 }
 
+# Extra forward-trace targets used ONLY for *output dtype* inference
+# (``_trace_mma_to_store_dtype``). These are the whitelisted fused-epilogue
+# aux-binary ops (e.g. the rowwise scale ``acc * scale[...]``). Tracing
+# through them only follows the chain to the store node and reads the store
+# *target tensor's* dtype, so it never changes the inferred dtype; it just
+# lets inference reach the store past a fused scale/bias step. This is needed
+# for fp8 inputs (whose ``input_dtype`` is never a valid epilogue output
+# dtype) so the plan picks up the real bf16/f16/f32 store dtype.
+_DTYPE_TRACE_EXTRA_TARGETS = {
+    torch.ops.aten.mul.Tensor,
+    torch.ops.aten.add.Tensor,
+    torch.ops.aten.sub.Tensor,
+    torch.ops.aten.div.Tensor,
+}
+
 # Register reallocation budget for tcgen05 warp-specialized kernels.
 # Producer warps (TMA loads, scheduler) only do address arithmetic and
 # barrier ops, so they can give back registers; consumer warps (MMA
@@ -443,7 +458,12 @@ def _has_mma_operands(lhs_node: Node, rhs_node: Node) -> bool:
         return False
     lhs_load, _, lhs_fake = lhs_info
     rhs_load, _, rhs_fake = rhs_info
-    supported = {torch.float16, torch.bfloat16, torch.float32}
+    supported = {
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+        torch.float8_e4m3fn,
+    }
     return (
         lhs_fake.dtype in supported
         and rhs_fake.dtype in supported
@@ -1726,6 +1746,7 @@ def _trace_mma_to_store_dtype(
                 or target is _tracing_ops._new_var
                 or target is operator.getitem
                 or target in _TRACE_THROUGH_TARGETS
+                or target in _DTYPE_TRACE_EXTRA_TARGETS
             ):
                 stack.append(user)
                 continue
@@ -1778,6 +1799,7 @@ def _emit_mma_pipeline(
         torch.float16: "cutlass.Float16",
         torch.bfloat16: "cutlass.BFloat16",
         torch.float32: "cutlass.Float32",
+        torch.float8_e4m3fn: "cutlass.Float8E4M3FN",
     }
     input_dtype_str = _dtype_map[input_dtype]
     acc_dtype_str = "cutlass.Float32"
@@ -1805,7 +1827,7 @@ def _emit_mma_pipeline(
         _dtype_map[epi_elem_dtype] if epi_elem_dtype is not None else input_dtype_str
     )
     tcgen05_use_tma = (
-        input_dtype in (torch.float16, torch.bfloat16)
+        input_dtype in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
         and lhs_fake.is_contiguous()
         and rhs_fake.is_contiguous()
     )
@@ -5187,7 +5209,12 @@ def _mma_impl_matches_problem_shape(
 ) -> bool:
     if mma_impl == "universal":
         return True
-    if input_dtype not in (torch.float16, torch.bfloat16) or bn < 8 or bn % 8 != 0:
+    is_fp8 = input_dtype == torch.float8_e4m3fn
+    if (
+        input_dtype not in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
+        or bn < 8
+        or bn % 8 != 0
+    ):
         return False
     if bn > 256 and (
         mma_impl != "tcgen05"
@@ -5201,16 +5228,21 @@ def _mma_impl_matches_problem_shape(
     ):
         return False
     if mma_impl == "warp":
-        # Warp MMA atom is fixed-K (16 elements per BF16/FP16 instruction).
+        # Warp MMA atom is fixed-K (16 elements per BF16/FP16 instruction);
+        # fp8 is only wired through tcgen05.
+        if is_fp8:
+            return False
         return bk == 16 and bm >= 16 and bm % 16 == 0 and bn == 8
     if mma_impl == "tcgen05":
-        # tcgen05 mma instruction K is 16 elements for BF16/FP16, but the
-        # tile's K can be any positive multiple of that (the inner cute.gemm
-        # loop just runs more instructions per K iteration). Larger tile_k
-        # roughly halves the per-K-iter overhead per doubling. Production
-        # remains capped at block_n=256 to keep AB SMEM staging budget sane;
-        # the explicit G4 proof key admits only the smallest 512-N candidate.
-        if bk < 16 or bk > 256 or bk % 16 != 0:
+        # tcgen05 mma instruction K is 16 elements for BF16/FP16 (32 for FP8),
+        # but the tile's K can be any positive multiple of that (the inner
+        # cute.gemm loop just runs more instructions per K iteration). Larger
+        # tile_k roughly halves the per-K-iter overhead per doubling.
+        # Production remains capped at block_n=256 to keep AB SMEM staging
+        # budget sane; the explicit G4 proof key admits only the smallest
+        # 512-N candidate.
+        mma_k = 32 if is_fp8 else 16
+        if bk < mma_k or bk > 256 or bk % mma_k != 0:
             return False
         if bm in (64, 128):
             return True
@@ -5276,7 +5308,12 @@ def _choose_mma_impl(
         tcgen05_cluster_m=tcgen05_cluster_m,
         tcgen05_large_bn_proof=tcgen05_large_bn_proof,
     ):
-        if support.tcgen05_f16bf16:
+        tcgen05_ok = (
+            support.tcgen05_f8
+            if input_dtype == torch.float8_e4m3fn
+            else support.tcgen05_f16bf16
+        )
+        if tcgen05_ok:
             return "tcgen05"
     if _mma_impl_matches_problem_shape("warp", input_dtype, bm=bm, bn=bn, bk=bk):
         if support.warp_f16bf16:

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -1826,13 +1826,36 @@ def _emit_mma_pipeline(
     epi_elem_dtype_str = (
         _dtype_map[epi_elem_dtype] if epi_elem_dtype is not None else input_dtype_str
     )
-    tcgen05_use_tma = (
-        input_dtype in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
-        and lhs_fake.is_contiguous()
-        and rhs_fake.is_contiguous()
+
+    def _tcgen05_tma_2d_major(t: torch.Tensor) -> str | None:
+        # A 2D operand is TMA-eligible if it is contiguous in EITHER axis.
+        # Returns "row" (last-dim contiguous), "col" (first-dim contiguous),
+        # or None (neither -> not TMA-eligible). Row-major contiguous returns
+        # "row"; a transposed/column-major view returns "col".
+        if t.dim() != 2:
+            return "row" if t.is_contiguous() else None
+        s = t.stride()
+        if s[1] == 1:
+            return "row"
+        if s[0] == 1:
+            return "col"
+        return None
+
+    _dtype_tma_ok = input_dtype in (
+        torch.float16,
+        torch.bfloat16,
+        torch.float8_e4m3fn,
     )
-    tcgen05_use_tma_a = tcgen05_use_tma
-    tcgen05_use_tma_b = tcgen05_use_tma
+    _lhs_major = _tcgen05_tma_2d_major(lhs_fake)
+    _rhs_major = _tcgen05_tma_2d_major(rhs_fake)
+    # A must be row-major (M,K) K-contiguous == "row"; the K-major A SMEM
+    # layout Helion emits expects the standard row-major A. Only B's major
+    # mode is made layout-aware here.
+    tcgen05_use_tma_a = _dtype_tma_ok and _lhs_major == "row"
+    tcgen05_use_tma_b = _dtype_tma_ok and _rhs_major in ("row", "col")
+    # B is K-major when its (K, N) storage is K-contiguous (column-major),
+    # i.e. stride[0] == 1 -> _rhs_major == "col".
+    tcgen05_b_k_major = _rhs_major == "col"
     tcgen05_use_tma = tcgen05_use_tma_a or tcgen05_use_tma_b
     tcgen05_use_tma_pipeline = tcgen05_use_tma_a and tcgen05_use_tma_b
     tcgen05_requested_pure_matmul_role_lifecycle = is_pure_matmul_role_lifecycle_config(
@@ -3115,6 +3138,7 @@ def _emit_mma_pipeline(
                 bm,
                 bn,
                 tcgen05_cluster_m=tcgen05_cluster_m,
+                b_k_major=tcgen05_b_k_major,
             )
         )
     else:
@@ -3290,6 +3314,7 @@ def _emit_mma_pipeline(
                     bm,
                     bn,
                     tcgen05_cluster_m=tcgen05_cluster_m,
+                    b_k_major=tcgen05_b_k_major,
                 )
             )
         else:
@@ -3307,6 +3332,7 @@ def _emit_mma_pipeline(
                     bm,
                     bn,
                     tcgen05_cluster_m=tcgen05_cluster_m,
+                    b_k_major=tcgen05_b_k_major,
                 )
             )
     if mma_impl == "tcgen05":
@@ -3335,6 +3361,7 @@ def _emit_mma_pipeline(
                 smem_swizzle_b=tcgen05_smem_swizzle_b,
                 explicit_epi_tile_m=tcgen05_explicit_epi_tile_m,
                 explicit_epi_tile_n=tcgen05_explicit_epi_tile_n,
+                b_k_major=tcgen05_b_k_major,
             )
         )
         prefix.append(
@@ -3941,6 +3968,11 @@ def _emit_mma_pipeline(
                 "k_total_size": k_total_size,
                 "kernel_args": [tma_atom_a, tma_tensor_a, tma_atom_b, tma_tensor_b],
             }
+            # K-major (column-major / K-contiguous) B. Only recorded when True
+            # so MN-major (row-major B) wrapper-plan literals stay byte-identical
+            # to the golden.
+            if tcgen05_b_k_major:
+                ab_tma_plan["b_k_major"] = True
             # ``smem_swizzle_*`` overrides are recorded only when codegen
             # selected an explicit SMEM atom kind (either from a user
             # override or the scalar-edge fallback workaround). Keeping
@@ -5332,6 +5364,7 @@ def _make_tiled_mma_setup(
     bn: int,
     *,
     tcgen05_cluster_m: int = 1,
+    b_k_major: bool = False,
 ) -> list[ast.AST]:
     if mma_impl == "warp":
         tiled_mma_expr = (
@@ -5347,6 +5380,7 @@ def _make_tiled_mma_setup(
             bm,
             bn,
             tcgen05_cluster_m=tcgen05_cluster_m,
+            b_k_major=b_k_major,
         )
     else:
         assert mma_thread_linear
@@ -5375,16 +5409,24 @@ def _tcgen05_tiled_mma_expr(
     bn: int,
     *,
     tcgen05_cluster_m: int = 1,
+    b_k_major: bool = False,
 ) -> str:
     cta_group_expr = "cute.nvgpu.tcgen05.CtaGroup.ONE"
     if _tcgen05_use_2cta_instrs(bm=bm, cluster_m=tcgen05_cluster_m):
         cta_group_expr = "cute.nvgpu.tcgen05.CtaGroup.TWO"
+    # A is always K-major. B is MN-major for row-major (N-contiguous) B and
+    # K-major for column-major (K-contiguous) B.
+    b_major_expr = (
+        "cute.nvgpu.OperandMajorMode.K"
+        if b_k_major
+        else "cute.nvgpu.OperandMajorMode.MN"
+    )
     return (
         "cutlass.utils.blackwell_helpers.make_trivial_tiled_mma("
         f"{input_dtype_str}, "
         f"{input_dtype_str}, "
         "cute.nvgpu.OperandMajorMode.K, "
-        "cute.nvgpu.OperandMajorMode.MN, "
+        f"{b_major_expr}, "
         f"{acc_dtype_str}, "
         f"{cta_group_expr}, "
         f"({bm}, {bn}), "
@@ -5431,6 +5473,7 @@ def _make_tcgen05_layout_plan_setup(
     smem_swizzle_b: int | None = None,
     explicit_epi_tile_m: int | None = None,
     explicit_epi_tile_n: int | None = None,
+    b_k_major: bool = False,
 ) -> list[ast.AST]:
     # `compute_epilogue_tile_shape` must receive `elem_ty_d` and `elem_ty_c`
     # equal to the eventual D-output dtype so the helper takes the
@@ -5463,7 +5506,7 @@ def _make_tcgen05_layout_plan_setup(
         ),
         statement_from_string(
             f"{plan.smem_b_layout} = "
-            f"{tcgen05_smem_layout_expr(tiled_mma=tiled_mma, bm=bm, bn=bn, bk=bk, dtype_str=input_dtype_str, num_stages=ab_stage_count, operand='b', swizzle_override=smem_swizzle_b)}"
+            f"{tcgen05_smem_layout_expr(tiled_mma=tiled_mma, bm=bm, bn=bn, bk=bk, dtype_str=input_dtype_str, num_stages=ab_stage_count, operand='b', swizzle_override=smem_swizzle_b, b_k_major=b_k_major)}"
         ),
         statement_from_string(
             f"{plan.c_layout} = cutlass.utils.layout.LayoutEnum.ROW_MAJOR"

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -1854,7 +1854,8 @@ def _emit_mma_pipeline(
     tcgen05_use_tma_a = _dtype_tma_ok and _lhs_major == "row"
     tcgen05_use_tma_b = _dtype_tma_ok and _rhs_major in ("row", "col")
     # B is K-major when its (K, N) storage is K-contiguous (column-major),
-    # i.e. stride[0] == 1 -> _rhs_major == "col".
+    # i.e. stride[0] == 1 -> _rhs_major == "col". This is the native fp8
+    # scaled_mm / torch._scaled_mm B layout.
     tcgen05_b_k_major = _rhs_major == "col"
     tcgen05_use_tma = tcgen05_use_tma_a or tcgen05_use_tma_b
     tcgen05_use_tma_pipeline = tcgen05_use_tma_a and tcgen05_use_tma_b
@@ -3968,9 +3969,9 @@ def _emit_mma_pipeline(
                 "k_total_size": k_total_size,
                 "kernel_args": [tma_atom_a, tma_tensor_a, tma_atom_b, tma_tensor_b],
             }
-            # K-major (column-major / K-contiguous) B. Only recorded when True
-            # so MN-major (row-major B) wrapper-plan literals stay byte-identical
-            # to the golden.
+            # K-major (column-major / K-contiguous) B -- the native fp8
+            # scaled_mm layout. Only recorded when True so MN-major (row-major
+            # B) wrapper-plan literals stay byte-identical to the golden.
             if tcgen05_b_k_major:
                 ab_tma_plan["b_k_major"] = True
             # ``smem_swizzle_*`` overrides are recorded only when codegen
@@ -5415,7 +5416,8 @@ def _tcgen05_tiled_mma_expr(
     if _tcgen05_use_2cta_instrs(bm=bm, cluster_m=tcgen05_cluster_m):
         cta_group_expr = "cute.nvgpu.tcgen05.CtaGroup.TWO"
     # A is always K-major. B is MN-major for row-major (N-contiguous) B and
-    # K-major for column-major (K-contiguous) B.
+    # K-major for column-major (K-contiguous) B -- the native fp8 scaled_mm /
+    # torch._scaled_mm layout.
     b_major_expr = (
         "cute.nvgpu.OperandMajorMode.K"
         if b_k_major

--- a/helion/_compiler/cute/mma_support.py
+++ b/helion/_compiler/cute/mma_support.py
@@ -11,6 +11,7 @@ class CuteMmaSupport:
     warp_f16bf16: bool
     warpgroup_f16bf16: bool
     tcgen05_f16bf16: bool
+    tcgen05_f8: bool = False
 
     @property
     def supported_impls(self) -> tuple[str, ...]:
@@ -91,6 +92,28 @@ def _probe_tcgen05_f16bf16() -> bool:
         return False
 
 
+def _probe_tcgen05_f8() -> tuple[bool, str | None]:
+    try:
+        import cutlass
+        from cutlass.cute.nvgpu import tcgen05
+
+        # fp8 (e4m3) MMA on tcgen05 uses the F8F6F4 op with MMA-K=32 (vs 16
+        # for BF16/FP16) and a separate a_dtype/b_dtype.
+        tcgen05.MmaF8F6F4Op(
+            cutlass.Float8E4M3FN,
+            cutlass.Float8E4M3FN,
+            cutlass.Float32,
+            (128, 8, 32),
+            tcgen05.CtaGroup.ONE,
+            tcgen05.OperandSource.SMEM,
+            tcgen05.OperandMajorMode.K,
+            tcgen05.OperandMajorMode.K,
+        )
+        return True, None
+    except Exception as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+
+
 def get_cute_mma_support() -> CuteMmaSupport:
     device = _current_cuda_device()
     if device is None:
@@ -99,15 +122,18 @@ def get_cute_mma_support() -> CuteMmaSupport:
             warp_f16bf16=False,
             warpgroup_f16bf16=False,
             tcgen05_f16bf16=False,
+            tcgen05_f8=False,
         )
 
     cutlass_arch = _current_cutlass_arch_name()
 
     # The universal atom is the only lowering Helion currently wires up end-to-end.
     universal = cutlass_arch is not None
+    tcgen05_f8_ok, _ = _probe_tcgen05_f8()
     return CuteMmaSupport(
         universal=universal,
         warp_f16bf16=_probe_warp_f16bf16(),
         warpgroup_f16bf16=_probe_warpgroup_f16bf16(),
         tcgen05_f16bf16=_probe_tcgen05_f16bf16(),
+        tcgen05_f8=tcgen05_f8_ok,
     )

--- a/helion/_compiler/cute/strategies.py
+++ b/helion/_compiler/cute/strategies.py
@@ -389,6 +389,7 @@ def tcgen05_smem_layout_expr(
     num_stages: int,
     operand: str,
     swizzle_override: int | None,
+    b_k_major: bool = False,
 ) -> str:
     """Emit the CuTe expression that builds the staged SMEM layout for A or B.
 
@@ -439,6 +440,17 @@ def tcgen05_smem_layout_expr(
             "order=(1, 2, 3))"
         )
     assert operand == "b", f"unexpected operand {operand!r}"
+    if b_k_major:
+        # K-major (column-major / K-contiguous) B. Delegate to CuTe's helper
+        # with ``is_k_major=True`` so the SMEM atom selection mirrors the
+        # K-major A path exactly; the smem_swizzle_b override knob is not
+        # plumbed through this path (correctness-first), which is fine
+        # since the fp8 default path uses swizzle_override=None.
+        return (
+            "cutlass.utils.blackwell_helpers.make_smem_layout_b("
+            f"{tiled_mma}, ({bm}, {bn}, {bk}), {dtype_str}, {num_stages}, "
+            "is_k_major=True)"
+        )
     if swizzle_override is None:
         return (
             "cutlass.utils.blackwell_helpers.make_smem_layout_b("

--- a/helion/_compiler/cute/strategies.py
+++ b/helion/_compiler/cute/strategies.py
@@ -441,7 +441,8 @@ def tcgen05_smem_layout_expr(
         )
     assert operand == "b", f"unexpected operand {operand!r}"
     if b_k_major:
-        # K-major (column-major / K-contiguous) B. Delegate to CuTe's helper
+        # K-major (column-major / K-contiguous) B -- the native fp8
+        # scaled_mm / torch._scaled_mm layout. Delegate to CuTe's helper
         # with ``is_k_major=True`` so the SMEM atom selection mirrors the
         # K-major A path exactly; the smem_swizzle_b override knob is not
         # plumbed through this path (correctness-first), which is fine

--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -945,6 +945,44 @@ class CuteTcgen05Config:
             and block_sizes[1] == TCGEN05_TWO_CTA_BLOCK_N
         )
 
+    def max_ab_stages_that_fit(
+        self,
+        *,
+        bm: int,
+        bn: int,
+        bk: int,
+        cluster_m: int,
+        hard_cap: int = 12,
+    ) -> int:
+        """Largest ``tcgen05_ab_stages`` whose AB SMEM fits the per-CTA budget.
+
+        Mirrors CUTLASS's ``_compute_stages`` (fill SMEM with as many AB
+        pipeline stages as fit). 1-byte fp8 operands fit ~2x more stages than
+        2-byte bf16, so the deeper pipeline that hides K-loop latency is only
+        reachable for fp8 once the bf16-tuned ``ab_stages<=3`` cap is lifted.
+        Returns at least 1; ``0`` when constraints are unknown.
+        """
+        constraints = self.ab_stages_three_search_constraints
+        if constraints is None or bm <= 0 or bn <= 0 or bk <= 0:
+            return 0
+        if cluster_m not in (1, 2):
+            return 0
+        best = 0
+        for ab_stages in range(1, hard_cap + 1):
+            bytes_per_cta = tcgen05_ab_smem_bytes_per_cta(
+                bm=bm,
+                bn=bn,
+                bk=bk,
+                dtype_bytes=constraints.dtype_bytes,
+                ab_stages=ab_stages,
+                cluster_m=cluster_m,
+            )
+            if bytes_per_cta <= constraints.per_cta_smem_budget_bytes:
+                best = ab_stages
+            else:
+                break
+        return best
+
     def _fix_ab_stages_three_search_config(self, config: dict[str, object]) -> None:
         if self.ab_stages_three_search_constraints is None:
             return
@@ -1224,10 +1262,33 @@ class CuteTcgen05Config:
             )
         ):
             return
+        # fp8 (1-byte) operands fit a deeper AB pipeline than the bf16-tuned
+        # cap of 3; admit ab_stages > 3 for fp8 as long as the AB SMEM fits the
+        # per-CTA budget. This lets Helion emit the same deeply-pipelined
+        # CtaGroup.TWO kernel CUTLASS uses for fp8 compute-bound GEMMs.
+        constraints = self.ab_stages_three_search_constraints
+        if constraints is not None and constraints.dtype_bytes < 2:
+            block_sizes = cast("list[int]", config.get("block_sizes"))
+            cluster_m = cast("int", config.get("tcgen05_cluster_m", 1))
+            if isinstance(block_sizes, list) and len(block_sizes) >= 3:
+                fit_max = self.max_ab_stages_that_fit(
+                    bm=block_sizes[0],
+                    bn=block_sizes[1],
+                    bk=block_sizes[2],
+                    cluster_m=cluster_m,
+                )
+                if fit_max > 0 and ab_stages <= fit_max:
+                    return
+                if fix_invalid and fit_max > 0:
+                    config["tcgen05_ab_stages"] = fit_max
+                    return
         if fix_invalid:
             config["tcgen05_ab_stages"] = 3
             return
-        raise InvalidConfig("tcgen05_ab_stages > 3 is not supported")
+        raise InvalidConfig(
+            "tcgen05_ab_stages > 3 is only supported by the validated "
+            "Target1 TVM-FFI seed (or fp8 within the SMEM budget)"
+        )
 
     def _is_validated_clc_persistence_search_candidate(
         self, config: dict[str, object]
@@ -1678,6 +1739,13 @@ class CuteTcgen05Config:
             # SEARCH stays capped at 3 (budget-aware) since the generalized seed
             # runs at ab=3 and deeper pipelines are not worth searching.
             ab_stages_max = 6 if self.full_tile_direct_entry_seed_eligible() else 3
+            # fp8 (1-byte) operands fit a deeper AB pipeline than the bf16-tuned
+            # cap; admit a frozen deep-staged fp8 config on the validation
+            # surface too (``_validate_target1_ab_stage_envelope`` clamps it to
+            # the actual per-CTA SMEM budget for the chosen block sizes).
+            constraints = self.ab_stages_three_search_constraints
+            if constraints is not None and constraints.dtype_bytes < 2:
+                ab_stages_max = 12
         elif self.ab_stages_three_search_constraints is not None:
             # Cycle 97: make ab=3 BUDGET-AWARE-SEARCHABLE. Where the device/dtype
             # admits ab=3 at all (the SMEM-budget constraints were recorded by
@@ -1689,6 +1757,13 @@ class CuteTcgen05Config:
             # cluster_m=1 256x256 overflows bare-AB) before codegen, so admission is
             # free but an overflowing kernel is never generated.
             ab_stages_max = 3
+            # fp8 (1-byte) operands fit a deeper AB pipeline; widen the
+            # validation range so an explicit deep-staged fp8 config is
+            # accepted (``_validate_target1_ab_stage_envelope`` clamps it to
+            # the actual per-CTA SMEM budget for the chosen block sizes).
+            constraints = self.ab_stages_three_search_constraints
+            if constraints is not None and constraints.dtype_bytes < 2:
+                ab_stages_max = 12
         else:
             ab_stages_max = 2
         if for_search:

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -4503,6 +4503,8 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             "cutlass.Boolean",
             "cutlass.Float16",
             "cutlass.Float32",
+            "cutlass.Float8E4M3FN",
+            "cutlass.Float8E5M2",
             "cutlass.Int32",
         }
     )

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -318,22 +318,28 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
             rhs_dtype=rhs.dtype,
         )
     )
+    # tcgen05 MMA-K is 16 elements for BF16/FP16 but 32 for FP8 (e4m3); the
+    # block_k search granularity and minimum must follow the active dtype.
+    is_fp8 = lhs.dtype == torch.float8_e4m3fn
+    mma_k = 32 if is_fp8 else 16
     if (
         env.backend_name == "cute"
         and lhs.ndim == 2
         and rhs.ndim == 2
-        and lhs.dtype in (torch.float16, torch.bfloat16)
+        and lhs.dtype in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
         and rhs.dtype == lhs.dtype
         and static_m is not None
         and static_n is not None
         and static_k is not None
         and static_m >= 64
         and static_n >= 8
-        and static_k >= 16
+        and static_k >= mma_k
     ):
         from .._compiler.cute.mma_support import get_cute_mma_support
 
-        if get_cute_mma_support().tcgen05_f16bf16:
+        support = get_cute_mma_support()
+        tcgen05_supported = support.tcgen05_f8 if is_fp8 else support.tcgen05_f16bf16
+        if tcgen05_supported:
 
             def pow2_floor_at_least(value: int, minimum: int) -> int:
                 return 1 << (max(minimum, value).bit_length() - 1)
@@ -342,8 +348,9 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
             max_tcgen05_m = 256 if max_tcgen05_n >= 128 and static_m >= 256 else 128
             # Larger tile_k packs more cute.gemm instructions per K loop
             # iteration on tcgen05 (mma instruction K is fixed at 16 for
-            # BF16/FP16). Cap at 128 to keep AB SMEM staging budget sane.
-            max_tcgen05_k = min(128, pow2_floor_at_least(static_k, 16))
+            # BF16/FP16, 32 for FP8). Cap at 128 to keep AB SMEM staging
+            # budget sane.
+            max_tcgen05_k = min(128, pow2_floor_at_least(static_k, mma_k))
             max_search_m = min(max_tcgen05_m, pow2_floor_at_least(static_m, 64))
             max_search_n = max_tcgen05_n
             max_search_k = max_tcgen05_k
@@ -475,7 +482,7 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
                 if block_idx is None:
                     continue
                 if axis_name == "k":
-                    min_size = 16
+                    min_size = mma_k
                 elif axis_name == "m":
                     min_size = min_search_m
                 else:

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -2829,41 +2829,19 @@ def _codegen_cute_store_tcgen05_tile(
         aux_pipeline_uses_tma_load = False
         aux_ring_smem_names = tuple(None for _ in aux_step_records)
 
-    # Row-vector register hoist (fp8 only). A rowvec aux (``bias[n]`` /
-    # rowwise ``scale_b[n]``) varies across each thread's N (vectorized
-    # epilogue) fragment, so the default per-subtile GMEM ``.load()`` issued
-    # AFTER the accumulator ``consumer_wait`` exposes its latency. CUTLASS's
-    # ``epilogue_tma_store_scaled`` instead reads the whole rowvec into
-    # registers ONCE (``cute.autovec_copy(tTR_gSB, tTR_rSB_full)``) BEFORE the
-    # acc wait so its latency overlaps the MMA. Mirror that here: hoist the
-    # per-tile rowvec LDG into a register tensor in the setup block (which
-    # runs before the subtile loop, hence before the acc wait), then read it
-    # per subtile from registers. fp8-gated because fp8 GEMMs are
-    # latency-bound at these compute-bound shapes (bf16's larger operands hide
-    # the load already, and the cycle-39/74 ablations found no bf16 win); the
-    # rowvec register tensor is small (1-D broadcast) so no spill risk. SMEM
-    # staging (``use_aux_smem_source``) owns its own ring, so skip there.
-    _ab_tma_plans_for_hoist = [
-        plan
-        for plan in state.codegen.cute_wrapper_plans
-        if plan.get("kind") == "tcgen05_ab_tma"
-    ]
-    aux_input_is_fp8 = (
-        len(_ab_tma_plans_for_hoist) == 1
-        and str(_ab_tma_plans_for_hoist[0].get("input_dtype")) == "cutlass.Float8E4M3FN"
-    )
-    aux_hoisted_vars: list[str | None] = []
-    for aux_idx, rec in enumerate(aux_step_records):
-        if (
-            aux_input_is_fp8
-            and rec.broadcast_axis == 1
-            and tcgen05_aux_use_tma_store_epilogue
-            and not use_aux_smem_source
-        ):
-            aux_hoisted_vars.append(df.new_var(f"tcgen05_aux_hoisted_{aux_idx}"))
-        else:
-            aux_hoisted_vars.append(None)
-
+    # Row-vector aux (``bias[n]`` / rowwise ``scale_b[n]``) reads stay
+    # per-subtile (the generic ``ttr_aux_subtile.load()`` path below, placed
+    # after the c_pipeline acquire / acc ``consumer_wait`` / T2R prefix per the
+    # cycle-69 placement). An earlier fp8-gated variant hoisted the WHOLE
+    # tile's rowvec fragment into a register tensor in the per-tile setup
+    # (mirroring CUTLASS's ``tTR_rSB_full`` whole-tile ``autovec_copy``) so the
+    # LDG latency overlapped the MMA. At ``bk=128`` that fragment — all
+    # subtiles' fp32 values live across the entire subtile loop on top of the
+    # accumulator and TMA-store state — pushed epilogue warps to the 255-reg
+    # cap and 409k dynamic LDL/STL local-memory spills (~10% kernel time:
+    # 57.8us vs 52.9us; 1915 vs 2105 TFLOP/s at 4096^3 fp8 scaled_mm). At
+    # ``bk=64`` the hoist measured neutral (1711 vs 1712 TFLOP/s). Per-subtile
+    # loads spill zero on both, so the hoist machinery was removed.
     rowvec_aux_stage_records: list[_RowvecAuxStageRecord | None] = []
     for aux_idx, rec in enumerate(aux_step_records):
         copy_bits = 128
@@ -3238,20 +3216,6 @@ def _codegen_cute_store_tcgen05_tile(
                     ),
                 ]
             )
-            hoisted = aux_hoisted_vars[aux_idx]
-            if hoisted is not None:
-                # Issue the whole-tile rowvec GMEM read into registers here
-                # (per-output-tile setup, before the subtile loop / acc wait)
-                # so its latency overlaps the MMA. See ``aux_hoisted_vars``.
-                lines.extend(
-                    [
-                        (
-                            f"{hoisted} = cute.make_rmem_tensor("
-                            f"{rec.ttr_aux_grouped}.shape, {rec.aux_dtype})"
-                        ),
-                        f"cute.autovec_copy({rec.ttr_aux_grouped}, {hoisted})",
-                    ]
-                )
         return lines
 
     def _aux_subtile_load_source(
@@ -3459,17 +3423,6 @@ def _codegen_cute_store_tcgen05_tile(
                     f"cute.filter_zeros({rec.ttr_aux_subtile}), "
                     f"cute.filter_zeros({rec.aux_rmem}))\n"
                     f"{prelude_indent}{rec.aux_loaded} = {rec.aux_rmem}.load()\n"
-                )
-                continue
-            hoisted = aux_hoisted_vars[aux_idx]
-            if hoisted is not None:
-                # Read the per-subtile slice from the register tensor the
-                # per-tile setup already loaded (latency overlapped the MMA),
-                # instead of issuing a fresh per-subtile GMEM ``.load()``.
-                lines.append(
-                    f"{prelude_indent}{rec.aux_loaded} = "
-                    f"{hoisted}[(None, None, None, "
-                    f"cutlass.Int32(_tcgen05_subtile))].load()\n"
                 )
                 continue
             if rec.broadcast_axis == 2:

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -2647,9 +2647,12 @@ def _codegen_cute_store_tcgen05_tile(
         # Broadcast aux steps need a fresh AST var for the 2-D view
         # of the rank-1 underlying tensor (stride 0 on the orthogonal
         # axis). Exact-shape aux steps leave ``aux_view2d`` as None.
+        # broadcast_axis 0/1 build a stride-0 2-D view of a rank-1 tensor;
+        # the colvec form (2) reuses the exact-shape pipeline over its own
+        # (M, N) stride-(1,0) view, so it needs no separate ``aux_view2d``.
         aux_view2d = (
             df.new_var(f"tcgen05_aux_view2d_{aux_idx}")
-            if aux_step.broadcast_axis is not None
+            if aux_step.broadcast_axis in (0, 1)
             else None
         )
         aux_step_records.append(
@@ -2825,6 +2828,41 @@ def _codegen_cute_store_tcgen05_tile(
         aux_consumer_state_name = ""
         aux_pipeline_uses_tma_load = False
         aux_ring_smem_names = tuple(None for _ in aux_step_records)
+
+    # Row-vector register hoist (fp8 only). A rowvec aux (``bias[n]`` /
+    # rowwise ``scale_b[n]``) varies across each thread's N (vectorized
+    # epilogue) fragment, so the default per-subtile GMEM ``.load()`` issued
+    # AFTER the accumulator ``consumer_wait`` exposes its latency. CUTLASS's
+    # ``epilogue_tma_store_scaled`` instead reads the whole rowvec into
+    # registers ONCE (``cute.autovec_copy(tTR_gSB, tTR_rSB_full)``) BEFORE the
+    # acc wait so its latency overlaps the MMA. Mirror that here: hoist the
+    # per-tile rowvec LDG into a register tensor in the setup block (which
+    # runs before the subtile loop, hence before the acc wait), then read it
+    # per subtile from registers. fp8-gated because fp8 GEMMs are
+    # latency-bound at these compute-bound shapes (bf16's larger operands hide
+    # the load already, and the cycle-39/74 ablations found no bf16 win); the
+    # rowvec register tensor is small (1-D broadcast) so no spill risk. SMEM
+    # staging (``use_aux_smem_source``) owns its own ring, so skip there.
+    _ab_tma_plans_for_hoist = [
+        plan
+        for plan in state.codegen.cute_wrapper_plans
+        if plan.get("kind") == "tcgen05_ab_tma"
+    ]
+    aux_input_is_fp8 = (
+        len(_ab_tma_plans_for_hoist) == 1
+        and str(_ab_tma_plans_for_hoist[0].get("input_dtype")) == "cutlass.Float8E4M3FN"
+    )
+    aux_hoisted_vars: list[str | None] = []
+    for aux_idx, rec in enumerate(aux_step_records):
+        if (
+            aux_input_is_fp8
+            and rec.broadcast_axis == 1
+            and tcgen05_aux_use_tma_store_epilogue
+            and not use_aux_smem_source
+        ):
+            aux_hoisted_vars.append(df.new_var(f"tcgen05_aux_hoisted_{aux_idx}"))
+        else:
+            aux_hoisted_vars.append(None)
 
     rowvec_aux_stage_records: list[_RowvecAuxStageRecord | None] = []
     for aux_idx, rec in enumerate(aux_step_records):
@@ -3102,9 +3140,11 @@ def _codegen_cute_store_tcgen05_tile(
                 )
                 continue
 
-            if rec.broadcast_axis is None:
-                # Exact-shape rank-2 aux: slice the per-tile region
-                # of the underlying 2-D tensor directly.
+            if rec.broadcast_axis is None or rec.broadcast_axis == 2:
+                # Exact-shape rank-2 aux (or the colvec form, which is a full
+                # (M, N) stride-(1,0) view): slice the per-tile region of the
+                # underlying 2-D tensor directly. The colvec's per-subtile read
+                # is specialized to a scalar in ``_aux_subtile_load_source``.
                 source_for_local_tile = rec.aux_tensor_name
                 aux_tile_is_local = False
             elif rowvec_stage is not None:
@@ -3198,6 +3238,20 @@ def _codegen_cute_store_tcgen05_tile(
                     ),
                 ]
             )
+            hoisted = aux_hoisted_vars[aux_idx]
+            if hoisted is not None:
+                # Issue the whole-tile rowvec GMEM read into registers here
+                # (per-output-tile setup, before the subtile loop / acc wait)
+                # so its latency overlaps the MMA. See ``aux_hoisted_vars``.
+                lines.extend(
+                    [
+                        (
+                            f"{hoisted} = cute.make_rmem_tensor("
+                            f"{rec.ttr_aux_grouped}.shape, {rec.aux_dtype})"
+                        ),
+                        f"cute.autovec_copy({rec.ttr_aux_grouped}, {hoisted})",
+                    ]
+                )
         return lines
 
     def _aux_subtile_load_source(
@@ -3405,6 +3459,29 @@ def _codegen_cute_store_tcgen05_tile(
                     f"cute.filter_zeros({rec.ttr_aux_subtile}), "
                     f"cute.filter_zeros({rec.aux_rmem}))\n"
                     f"{prelude_indent}{rec.aux_loaded} = {rec.aux_rmem}.load()\n"
+                )
+                continue
+            hoisted = aux_hoisted_vars[aux_idx]
+            if hoisted is not None:
+                # Read the per-subtile slice from the register tensor the
+                # per-tile setup already loaded (latency overlapped the MMA),
+                # instead of issuing a fresh per-subtile GMEM ``.load()``.
+                lines.append(
+                    f"{prelude_indent}{rec.aux_loaded} = "
+                    f"{hoisted}[(None, None, None, "
+                    f"cutlass.Int32(_tcgen05_subtile))].load()\n"
+                )
+                continue
+            if rec.broadcast_axis == 2:
+                # Column-vector (per-row) aux: uniform over each thread's N
+                # fragment, so read a single SCALAR per subtile (T2R index
+                # (0,0,0)) instead of a redundant N-wide vector ``.load()``.
+                # Matches CUTLASS's ``sa = tTR_gSA[(0,0,0,subtile)]``; the
+                # scalar broadcasts in the ``acc * aux`` chain multiply.
+                lines.append(
+                    f"{prelude_indent}{rec.aux_loaded} = "
+                    f"{rec.ttr_aux_grouped}"
+                    f"[(0, 0, 0, cutlass.Int32(_tcgen05_subtile))]\n"
                 )
                 continue
             lines.extend(

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -2177,6 +2177,9 @@ def _append_cute_wrapper_plan(
     smem_swizzle_b: int | None = (
         int(smem_swizzle_b_raw) if isinstance(smem_swizzle_b_raw, int) else None
     )
+    # K-major (column-major / K-contiguous) B. Absent on the MN-major
+    # (row-major B) default path.
+    b_k_major = bool(plan.get("b_k_major"))
     kernel_args = [str(arg) for arg in cast("list[object]", plan["kernel_args"])]
     assert len(kernel_args) == 4
     tma_atom_a, tma_tensor_a, tma_atom_b, tma_tensor_b = kernel_args
@@ -2218,6 +2221,7 @@ def _append_cute_wrapper_plan(
         num_stages=ab_stage_count,
         operand="b",
         swizzle_override=smem_swizzle_b,
+        b_k_major=b_k_major,
     )
     body.extend(
         (
@@ -2226,8 +2230,12 @@ def _append_cute_wrapper_plan(
                 f"{input_dtype}, "
                 f"{input_dtype}, "
                 "cute.nvgpu.OperandMajorMode.K, "
-                "cute.nvgpu.OperandMajorMode.MN, "
-                f"{acc_dtype}, "
+                + (
+                    "cute.nvgpu.OperandMajorMode.K, "
+                    if b_k_major
+                    else "cute.nvgpu.OperandMajorMode.MN, "
+                )
+                + f"{acc_dtype}, "
                 f"{cta_group}, "
                 f"({bm}, {bn}), "
                 "cute.nvgpu.tcgen05.OperandSource.SMEM)"
@@ -2245,7 +2253,10 @@ def _append_cute_wrapper_plan(
                 f"(arg{rhs_idx}_shape1, arg{rhs_idx}_shape0), "
                 f"stride=(arg{rhs_idx}_stride1, arg{rhs_idx}_stride0)))"
             ),
-            f"    {rhs_tma}.mark_layout_dynamic(leading_dim=0)",
+            # B is viewed as (N, K). For row-major B (MN-major) the N axis
+            # (position 0) is contiguous; for column-major B (K-major, native
+            # fp8 layout) the K axis (position 1) is contiguous.
+            f"    {rhs_tma}.mark_layout_dynamic(leading_dim={1 if b_k_major else 0})",
             # ``make_tiled_tma_atom_A`` vs ``_B`` asymmetry:
             # - ``_B`` always passes ``cluster_layout_vmnk.shape`` as
             #   its trailing arg (CuTe's signature for B requires the

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -25,6 +25,9 @@ from .._compiler.cute.strategies import tcgen05_default_epilogue_tile_expr
 from .._compiler.cute.strategies import tcgen05_explicit_d_store_tile_expr
 from .._compiler.cute.strategies import tcgen05_smem_layout_expr
 from .._utils import triton_is_available
+from ._fast_launcher import _FastLauncher as _FastLauncher
+from ._fast_launcher import build_fast_launcher as build_fast_launcher
+from ._fast_launcher import default_launcher as default_launcher
 from .config import Config as Config
 from .kernel import Kernel as Kernel
 from .kernel import kernel as kernel
@@ -157,40 +160,6 @@ def get_num_sm(device: torch.device, *, reserved_sms: int = 0) -> int:
     if reserved_sms <= 0:
         return available_sms
     return max(available_sms - reserved_sms, 1)
-
-
-def default_launcher(
-    triton_kernel: object,
-    grid: tuple[int, ...],
-    *args: object,
-    num_warps: int,
-    num_stages: int,
-    ptx_options: str | None = None,
-    launch_cooperative_grid: bool = False,
-    **kwargs: dict,
-) -> object:
-    """Default launcher function that executes the kernel immediately."""
-    # For both CUDA and MTIA, use the same kernel execution
-    run_kwargs: dict = {
-        "grid": grid,
-        "warmup": False,
-        "num_warps": num_warps,
-        "num_stages": num_stages,
-        "launch_cooperative_grid": launch_cooperative_grid,
-        **kwargs,
-    }
-    if ptx_options is not None:
-        run_kwargs["ptx_options"] = ptx_options
-    try:
-        return triton_kernel.run(  # type: ignore[union-attr]
-            *args,
-            **run_kwargs,
-        )
-    except Exception as error:
-        message = str(error)
-        if "Cannot make_shape_compatible: incompatible dimensions" in message:
-            raise exc.ShapeMismatch("kernel operands", message) from error
-        raise
 
 
 def _pallas_make_block_spec(

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -25,9 +25,6 @@ from .._compiler.cute.strategies import tcgen05_default_epilogue_tile_expr
 from .._compiler.cute.strategies import tcgen05_explicit_d_store_tile_expr
 from .._compiler.cute.strategies import tcgen05_smem_layout_expr
 from .._utils import triton_is_available
-from ._fast_launcher import _FastLauncher as _FastLauncher
-from ._fast_launcher import build_fast_launcher as build_fast_launcher
-from ._fast_launcher import default_launcher as default_launcher
 from .config import Config as Config
 from .kernel import Kernel as Kernel
 from .kernel import kernel as kernel
@@ -160,6 +157,40 @@ def get_num_sm(device: torch.device, *, reserved_sms: int = 0) -> int:
     if reserved_sms <= 0:
         return available_sms
     return max(available_sms - reserved_sms, 1)
+
+
+def default_launcher(
+    triton_kernel: object,
+    grid: tuple[int, ...],
+    *args: object,
+    num_warps: int,
+    num_stages: int,
+    ptx_options: str | None = None,
+    launch_cooperative_grid: bool = False,
+    **kwargs: dict,
+) -> object:
+    """Default launcher function that executes the kernel immediately."""
+    # For both CUDA and MTIA, use the same kernel execution
+    run_kwargs: dict = {
+        "grid": grid,
+        "warmup": False,
+        "num_warps": num_warps,
+        "num_stages": num_stages,
+        "launch_cooperative_grid": launch_cooperative_grid,
+        **kwargs,
+    }
+    if ptx_options is not None:
+        run_kwargs["ptx_options"] = ptx_options
+    try:
+        return triton_kernel.run(  # type: ignore[union-attr]
+            *args,
+            **run_kwargs,
+        )
+    except Exception as error:
+        message = str(error)
+        if "Cannot make_shape_compatible: incompatible dimensions" in message:
+            raise exc.ShapeMismatch("kernel operands", message) from error
+        raise
 
 
 def _pallas_make_block_spec(
@@ -2146,8 +2177,8 @@ def _append_cute_wrapper_plan(
     smem_swizzle_b: int | None = (
         int(smem_swizzle_b_raw) if isinstance(smem_swizzle_b_raw, int) else None
     )
-    # K-major (column-major / K-contiguous) B. Absent on the MN-major
-    # (row-major B) default path.
+    # K-major (column-major / K-contiguous) B -- native fp8 scaled_mm layout.
+    # Absent on the MN-major (row-major B) default path.
     b_k_major = bool(plan.get("b_k_major"))
     kernel_args = [str(arg) for arg in cast("list[object]", plan["kernel_args"])]
     assert len(kernel_args) == 4

--- a/helion/runtime/_fast_launcher.py
+++ b/helion/runtime/_fast_launcher.py
@@ -1,0 +1,523 @@
+"""Per-spec fast launcher that bypasses Triton's ``JITFunction.run``.
+
+Public entry points re-exported from :mod:`helion.runtime`:
+
+* :func:`default_launcher` — Triton's full per-call pipeline. Used as
+  the fallback when the fast path can't (or shouldn't) engage, and as
+  the codegen wrapper's ``_launcher`` kwdefault before
+  :meth:`BoundKernel.set_config` installs a fast launcher.
+* :class:`_FastLauncher` — closure that caches Triton's per-call
+  bookkeeping across multiple ``_spec`` keys.
+* :func:`build_fast_launcher` — factory used by
+  ``BoundKernel._install_fast_launcher``.
+
+The ``_FastLauncher`` docstring explains the multi-spec cache and
+which parts of Triton's per-call pipeline it skips.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING
+
+import torch
+
+from .. import exc
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Hashable
+
+
+def default_launcher(
+    triton_kernel: object,
+    grid: tuple[int, ...],
+    *args: object,
+    num_warps: int,
+    num_stages: int,
+    ptx_options: str | None = None,
+    launch_cooperative_grid: bool = False,
+    **kwargs: dict,
+) -> object:
+    """Default launcher function that executes the kernel immediately."""
+    # For both CUDA and MTIA, use the same kernel execution
+    run_kwargs: dict = {
+        "grid": grid,
+        "warmup": False,
+        "num_warps": num_warps,
+        "num_stages": num_stages,
+        "launch_cooperative_grid": launch_cooperative_grid,
+        **kwargs,
+    }
+    if ptx_options is not None:
+        run_kwargs["ptx_options"] = ptx_options
+    try:
+        return triton_kernel.run(  # type: ignore[union-attr]
+            *args,
+            **run_kwargs,
+        )
+    except Exception as error:
+        message = str(error)
+        if "Cannot make_shape_compatible: incompatible dimensions" in message:
+            raise exc.ShapeMismatch("kernel operands", message) from error
+        raise
+
+
+class _SpecEntry:  # noqa: B903 - explicit __slots__ for hot-path attribute access
+    """Per-Triton-spec compiled-kernel state.
+
+    One instance lives in ``_FastLauncher._spec_cache`` for each distinct
+    Triton specialization (pointer alignment + scalar specialization +
+    binary-affecting knob state) we have ever launched. Each entry holds
+    everything the C launcher needs plus a snapshot of
+    ``used_global_vals`` taken at compile time for this binary.
+    """
+
+    __slots__ = (
+        "compiled_run",
+        "kernel_launch_metadata",
+        "packed_metadata",
+        "triton_function",
+        "used_global_checks",
+    )
+
+    def __init__(
+        self,
+        *,
+        compiled_run: Callable[..., object],
+        triton_function: object,
+        packed_metadata: object,
+        kernel_launch_metadata: Callable[..., object],
+        used_global_checks: tuple[tuple[dict, str, object], ...],
+    ) -> None:
+        self.compiled_run = compiled_run
+        self.triton_function = triton_function
+        self.packed_metadata = packed_metadata
+        self.kernel_launch_metadata = kernel_launch_metadata
+        self.used_global_checks = used_global_checks
+
+
+class _FastLauncher:
+    """Multi-spec fast launcher that bypasses Triton's ``JITFunction.run``.
+
+    The first call primes the launcher: captures Triton's active driver,
+    device, knob namespaces, and identifies which positional args are
+    tensor pointers (so we can compute alignment specialization inline
+    on every subsequent call instead of invoking Triton's binder).
+
+    Every call computes a tiny *spec key* — alignment bits + the
+    binary-affecting knob state (``debug``, ``instrumentation_mode``,
+    ``add_stages_inspection_hook``) — and dict-looks-up a cached
+    :class:`_SpecEntry`. On hit, dispatches straight into the C launcher.
+    On miss, compiles (via Triton) for that spec, caches the resulting
+    entry, and dispatches.
+
+    Helion's :class:`BoundKernel` already specializes on the *Helion*
+    axes (dtype, shape, stride, device type), so the only per-call
+    specialization left to Triton is pointer alignment and per-call
+    knob state — which we encode in the spec key.
+
+    Compared to a full ``JITFunction.run`` round-trip we skip:
+    * Triton's binder (we compute alignment inline ~6x cheaper)
+    * ``compute_cache_key`` + ``kernel_cache.get`` (replaced by a tuple
+      hash + dict lookup on our own ``_spec_cache``)
+    * The always-on ``kernel.launch_metadata`` call when no profiler
+      hooks are attached
+    * The whole ``JITFunction.run`` Python frame, kwargs munging, and
+      per-call device/binder unpacks.
+
+    If priming or any per-spec compile fails, we transparently fall
+    back to :func:`default_launcher` for that launch so the kernel
+    still runs.
+    """
+
+    __slots__ = (
+        "_active_driver",
+        "_device",
+        "_get_current_stream",
+        "_init_failed",
+        "_knobs_compilation",
+        "_knobs_runtime",
+        "_launch_cooperative_grid",
+        "_num_warps",
+        "_num_stages",
+        "_prime_lock",
+        "_primed",
+        "_ptx_options",
+        "_run_kwargs",
+        "_spec_cache",
+        "_tensor_arg_indices",
+    )
+
+    def __init__(
+        self,
+        *,
+        num_warps: int,
+        num_stages: int,
+        launch_cooperative_grid: bool = False,
+        ptx_options: str | None = None,
+        extra_kwargs: dict | None = None,
+    ) -> None:
+        self._num_warps = num_warps
+        self._num_stages = num_stages
+        self._launch_cooperative_grid = launch_cooperative_grid
+        self._ptx_options = ptx_options
+        # Pre-built kwargs dict for warmup AND the fallback path. Stored
+        # once so the hot path doesn't have to build a fresh kwargs dict
+        # per launch.
+        run_kwargs: dict = {
+            "num_warps": num_warps,
+            "num_stages": num_stages,
+            "launch_cooperative_grid": launch_cooperative_grid,
+        }
+        if extra_kwargs:
+            run_kwargs.update(extra_kwargs)
+        if ptx_options is not None:
+            run_kwargs["ptx_options"] = ptx_options
+        self._run_kwargs = run_kwargs
+
+        # Serializes both the one-time priming (see :meth:`_prime`) AND
+        # the per-spec compile-on-miss in :meth:`__call__`. Concurrent
+        # first-of-spec callers must not redundantly compile, so they
+        # use double-checked locking against ``_spec_cache``.
+        self._prime_lock = threading.Lock()
+        # Per-launcher state, set once by :meth:`_prime` on the first call.
+        self._primed = False
+        self._init_failed = False
+        self._active_driver: object = None
+        self._device: object = None
+        self._get_current_stream: Callable[[object], object] | None = None
+        self._knobs_runtime: object = None
+        self._knobs_compilation: object = None
+        # Positions of ``*args`` that are torch.Tensor pointers — used by
+        # the hot path to compute the alignment portion of the spec key
+        # without invoking Triton's binder.
+        self._tensor_arg_indices: tuple[int, ...] = ()
+        # Per-spec compiled-kernel cache, keyed on
+        # ``(align_bits, debug, instrumentation_mode, stages_hook_id)``.
+        # Each entry is a :class:`_SpecEntry` holding the compiled
+        # binary's ``run``, function handle, packed metadata,
+        # launch_metadata builder, and ``used_global_vals`` snapshot.
+        self._spec_cache: dict[Hashable, _SpecEntry] = {}
+
+    def _prime(self, triton_kernel: object, args: tuple[object, ...]) -> None:
+        """One-time launcher setup. Captures driver/knob references and
+        identifies which positional args are tensor pointers.
+
+        Called once on the first invocation, under ``self._prime_lock``.
+        Also runs Triton's binder ONCE to verify that
+        ``tuple(bound_args.values()) == args`` (so we can pass ``args``
+        directly to the C launcher in every subsequent call, skipping
+        the binder entirely on the hot path).
+
+        On any failure we set ``_init_failed = True`` so subsequent
+        calls fall through to :func:`default_launcher`. ``_primed=True``
+        is set last via the outer ``finally`` so any caller waiting on
+        the prime lock sees either fully-published state or a clean
+        ``_init_failed=True`` sentinel — never a half-written mix.
+        """
+        try:
+            try:
+                import triton
+                from triton.runtime.driver import driver
+            except ImportError:
+                self._init_failed = True
+                return
+
+            try:
+                active_driver = driver.active
+                # pyrefly: ignore[missing-attribute]
+                device = active_driver.get_current_device()
+                # Unpack mirrors jit.py:720; we consume only the binder
+                # for the one-time bind-skip-safe probe below.
+                (
+                    _kernel_cache,
+                    _kernel_key_cache,
+                    _target,
+                    _backend,
+                    binder,
+                    # pyrefly: ignore[missing-attribute]
+                ) = triton_kernel.device_caches[device]
+                # Verify that ``tuple(bound_args.values()) == args``. This
+                # has to hold for every call we want to keep on the fast
+                # path, since the hot path passes ``args`` straight to
+                # the C launcher without re-invoking the binder. Helion's
+                # generated wrapper hands the launcher the kernel's
+                # positional args in declaration order, so this is the
+                # common case; if it doesn't hold for *this* kernel
+                # signature, we permanently fall back.
+                bound_args, _spec, _opts = binder(*args, **self._run_kwargs)
+                bound_values = tuple(bound_args.values())
+                if not (
+                    len(bound_values) == len(args)
+                    and all(b is a for b, a in zip(bound_values, args, strict=True))
+                ):
+                    self._init_failed = True
+                    return
+
+                # Per-launcher state — constant across every launch.
+                tensor_indices = tuple(
+                    i for i, a in enumerate(args) if isinstance(a, torch.Tensor)
+                )
+                self._active_driver = active_driver
+                self._device = device
+                # pyrefly: ignore[missing-attribute]
+                self._get_current_stream = active_driver.get_current_stream
+                self._knobs_runtime = triton.knobs.runtime
+                self._knobs_compilation = triton.knobs.compilation
+                self._tensor_arg_indices = tensor_indices
+            except Exception:
+                self._init_failed = True
+        finally:
+            # Publish ``_primed`` last so threads waiting on the lock
+            # either see a fully-set-up launcher or a clean
+            # ``_init_failed`` sentinel — never a half-written mix.
+            self._primed = True
+
+    def _materialize_spec(
+        self,
+        triton_kernel: object,
+        grid: tuple[int, ...],
+        args: tuple[object, ...],
+    ) -> _SpecEntry | None:
+        """Compile (or fetch from Triton's cache) the binary for the
+        current spec and return a fully-populated :class:`_SpecEntry`.
+
+        Called by :meth:`__call__` on a ``_spec_cache`` miss, under
+        ``self._prime_lock``. Invokes Triton's full pipeline once: this
+        is the "cold" path where we accept the binder + compile + cache
+        lookup costs, knowing every subsequent call with this spec_key
+        will dispatch directly via the cached entry.
+        """
+        try:
+            warmup_kwargs = {**self._run_kwargs, "grid": grid, "warmup": True}
+            # pyrefly: ignore[missing-attribute]
+            compiled_kernel = triton_kernel.run(*args, **warmup_kwargs)
+            if compiled_kernel is None:
+                return None
+            # Access ``.run`` FIRST so ``_init_handles()`` populates
+            # ``.function`` etc. before we read them.
+            run_fn = compiled_kernel.run
+            triton_function = compiled_kernel.function
+            packed_metadata = compiled_kernel.packed_metadata
+            kernel_launch_metadata = compiled_kernel.launch_metadata
+            # Snapshot ``used_global_vals`` at this binary's compile
+            # time. Each spec entry has its own snapshot — different
+            # binaries may pin different globals.
+            ugv = getattr(triton_kernel, "used_global_vals", None)
+            used_global_checks: tuple[tuple[dict, str, object], ...] = ()
+            if ugv:
+                used_global_checks = tuple(
+                    (gdict, name, val) for (name, _gid), (val, gdict) in ugv.items()
+                )
+            return _SpecEntry(
+                compiled_run=run_fn,
+                triton_function=triton_function,
+                packed_metadata=packed_metadata,
+                kernel_launch_metadata=kernel_launch_metadata,
+                used_global_checks=used_global_checks,
+            )
+        except Exception:
+            return None
+
+    def __call__(
+        self,
+        triton_kernel: object,
+        grid: tuple[int, ...],
+        *args: object,
+        # Spell out the kwargs the generated wrapper always passes so
+        # CPython binds them positionally into local slots rather than
+        # packing them into a per-call **kwargs dict. The closure already
+        # has the runtime values baked in; these parameter names exist
+        # solely to absorb the wrapper's keyword arguments cheaply, and
+        # are otherwise unused.
+        num_warps: int | None = None,
+        num_stages: int | None = None,
+        launch_cooperative_grid: bool = False,
+        **kwargs: object,
+    ) -> object:
+        # Under torch.compile / Dynamo tracing, defer to ``default_launcher``
+        # which routes through ``triton_kernel.run`` and is captured by
+        # Dynamo's ``triton_kernel_wrapper_mutation`` HOP handler. (Same
+        # reason as in the single-spec design — the fast path's direct
+        # ``_cuda_getCurrentRawStream`` call returns ``int`` and trips
+        # Dynamo's "non-Tensor return" check.)
+        if torch.compiler.is_compiling():
+            return default_launcher(
+                triton_kernel,
+                grid,
+                *args,
+                **self._run_kwargs,
+            )
+
+        if not self._primed:
+            # Double-checked locking: the unsynchronized read above is
+            # the fast path; the lock-guarded re-check below serializes
+            # concurrent first calls so only one thread runs ``_prime``.
+            with self._prime_lock:
+                if not self._primed:
+                    self._prime(triton_kernel, args)
+        if self._init_failed:
+            return default_launcher(
+                triton_kernel,
+                grid,
+                *args,
+                **self._run_kwargs,
+            )
+
+        # Multi-device guard. The cached driver/stream getter were
+        # captured against the priming device; if the caller has since
+        # switched CUDA devices, fall back to ``default_launcher`` which
+        # dispatches via Triton's per-device ``device_caches``.
+        active_driver = self._active_driver
+        if (
+            active_driver is not None
+            # pyrefly: ignore[missing-attribute]
+            and active_driver.get_current_device() != self._device
+        ):
+            return default_launcher(
+                triton_kernel,
+                grid,
+                *args,
+                **self._run_kwargs,
+            )
+
+        # Read knob state once. The binary-affecting knobs go into the
+        # spec key (so toggling them just lands on a different cache
+        # entry rather than forcing a fallback). The launch hooks are
+        # passed straight through to the C launcher per-call so a
+        # profiler attaching after priming still fires.
+        knobs_runtime = self._knobs_runtime
+        knobs_compilation = self._knobs_compilation
+        runtime_debug = getattr(knobs_runtime, "debug", False)
+        instr_mode = getattr(knobs_compilation, "instrumentation_mode", "")
+        stages_hook = getattr(knobs_runtime, "add_stages_inspection_hook", None)
+
+        # Compute the spec key INLINE — no Triton binder call. Helion's
+        # ``BoundKernel`` already specializes on dtype/shape/stride/device
+        # via its own bind cache, so the remaining Triton-level
+        # specialization for this kernel is pointer alignment and the
+        # binary-affecting knob state. ``_tensor_arg_indices`` is the
+        # precomputed list of positions of tensor pointer args
+        # (captured at priming), so the loop walks just those args.
+        align_bits = 0
+        for i in self._tensor_arg_indices:
+            # pyrefly: ignore[missing-attribute]
+            if args[i].data_ptr() & 15 == 0:
+                align_bits |= 1 << i
+        spec_key = (
+            align_bits,
+            runtime_debug,
+            instr_mode,
+            id(stages_hook) if stages_hook is not None else 0,
+        )
+
+        # Cache lookup. On miss we acquire the lock to serialize
+        # compile-on-miss for concurrent first-of-spec callers, then
+        # re-check the cache (another thread may have compiled while
+        # we waited) before invoking the cold path.
+        spec_cache = self._spec_cache
+        entry = spec_cache.get(spec_key)
+        if entry is None:
+            with self._prime_lock:
+                entry = spec_cache.get(spec_key)
+                if entry is None:
+                    entry = self._materialize_spec(triton_kernel, grid, args)
+                    if entry is None:
+                        return default_launcher(
+                            triton_kernel,
+                            grid,
+                            *args,
+                            **self._run_kwargs,
+                        )
+                    spec_cache[spec_key] = entry
+
+        # Per-spec ``used_global_vals`` check. Each spec entry has its
+        # own snapshot; a mutation that would have caused Triton to
+        # raise ``RuntimeError`` is detected here and we fall back so
+        # the user sees Triton's own error from ``JITFunction.run``.
+        for gdict, name, expected in entry.used_global_checks:
+            if gdict.get(name) != expected:
+                return default_launcher(
+                    triton_kernel,
+                    grid,
+                    *args,
+                    **self._run_kwargs,
+                )
+
+        # All fallback conditions are now ruled out — commit to the
+        # fast path. Fire ``pre_run_hooks`` inline (mirrors
+        # jit.py:717-718). Hooks don't affect the binary, so doing this
+        # here is safe; doing it later than the fallback conditions
+        # avoids double-firing if any condition above had tripped.
+        pre_run_hooks = getattr(triton_kernel, "pre_run_hooks", None)
+        if pre_run_hooks:
+            hook_kwargs = {
+                **self._run_kwargs,
+                "debug": runtime_debug,
+                "instrumentation_mode": instr_mode,
+            }
+            for hook in pre_run_hooks:
+                hook(*args, **hook_kwargs)
+
+        try:
+            grid_size = len(grid)
+            grid_0 = grid[0]
+            grid_1 = grid[1] if grid_size > 1 else 1
+            grid_2 = grid[2] if grid_size > 2 else 1
+            # pyrefly: ignore[not-callable]
+            stream = self._get_current_stream(self._device)
+            # Re-read launch hooks per-call so a profiler attached
+            # after priming still fires. Skip ``launch_metadata`` when
+            # no hook will actually consume it (the common case; this
+            # is one of our biggest wins vs ``JITFunction.run``).
+            enter_hook = getattr(knobs_runtime, "launch_enter_hook", None)
+            exit_hook = getattr(knobs_runtime, "launch_exit_hook", None)
+            if (enter_hook is None or getattr(enter_hook, "calls", None) == []) and (
+                exit_hook is None or getattr(exit_hook, "calls", None) == []
+            ):
+                launch_metadata = None
+            else:
+                launch_metadata = entry.kernel_launch_metadata(grid, stream, *args)
+            return entry.compiled_run(
+                grid_0,
+                grid_1,
+                grid_2,
+                stream,
+                entry.triton_function,
+                entry.packed_metadata,
+                launch_metadata,
+                enter_hook,
+                exit_hook,
+                *args,
+            )
+        except Exception as error:
+            message = str(error)
+            if "Cannot make_shape_compatible: incompatible dimensions" in message:
+                raise exc.ShapeMismatch("kernel operands", message) from error
+            raise
+
+
+def build_fast_launcher(
+    *,
+    num_warps: int,
+    num_stages: int,
+    launch_cooperative_grid: bool = False,
+    ptx_options: str | None = None,
+    extra_kwargs: dict | None = None,
+) -> _FastLauncher:
+    """Build a :class:`_FastLauncher` closure with config baked in.
+
+    Invoked from :meth:`BoundKernel.set_config` after the generated Triton
+    kernel is compiled. The returned object's ``__call__`` signature
+    matches :func:`default_launcher`, so the generated wrapper can use it
+    as a drop-in replacement (threaded through as ``_launcher=`` by the
+    bound-kernel-level wrapper installed in ``set_config``).
+    """
+    return _FastLauncher(
+        num_warps=num_warps,
+        num_stages=num_stages,
+        launch_cooperative_grid=launch_cooperative_grid,
+        ptx_options=ptx_options,
+        extra_kwargs=extra_kwargs,
+    )

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -186,7 +186,10 @@ class Kernel(Generic[_R]):
             Config(**config) if isinstance(config, dict) else config
             for config in configs or []
         ]
-        self._bound_kernels: dict[BoundKernelInMemoryCacheKey, BoundKernel] = {}
+        # Keyed by ``(signature, extra_results)`` tuples — the tuple form of
+        # ``BoundKernelInMemoryCacheKey``, kept plain for cheap per-call
+        # construction in ``bind``.
+        self._bound_kernels: dict[Hashable, BoundKernel] = {}
         self._specialize_extra: dict[
             Hashable, list[Callable[[Sequence[object]], Hashable]]
         ] = {}
@@ -267,13 +270,15 @@ class Kernel(Generic[_R]):
 
     def _get_bound_kernel_cache_key(
         self, args: tuple[object, ...], signature: tuple[Hashable, ...]
-    ) -> BoundKernelInMemoryCacheKey | None:
-        from ..autotuner.base_cache import BoundKernelInMemoryCacheKey
-
+    ) -> tuple[Hashable, ...] | None:
+        # Plain tuples keep the per-call dispatch path free of dataclass
+        # construction; `_create_bound_kernel_cache_key` provides the
+        # `BoundKernelInMemoryCacheKey` form for the autotuner caches.
         extra_fns = self._specialize_extra.get(signature)
         if extra_fns is not None:
-            extra_results: tuple[Hashable, ...] = tuple([s(args) for s in extra_fns])
-            return BoundKernelInMemoryCacheKey(signature, extra_results)
+            if extra_fns:
+                return (signature, tuple([s(args) for s in extra_fns]))
+            return (signature, ())
         return None
 
     def _create_bound_kernel_cache_key(
@@ -319,9 +324,10 @@ class Kernel(Generic[_R]):
                 else:
                     bound_kernel = BoundKernel(self, args)
                 if cache_key is None:
-                    cache_key = self._create_bound_kernel_cache_key(
+                    full_key = self._create_bound_kernel_cache_key(
                         bound_kernel, args, signature
                     )
+                    cache_key = (full_key.specialization_key, full_key.extra_results)
                 self._bound_kernels[cache_key] = bound_kernel
             return bound_kernel
 

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -4,7 +4,6 @@ import ast
 import contextlib
 import dataclasses
 import functools
-import hashlib
 import inspect
 import itertools
 import logging
@@ -38,6 +37,7 @@ from torch.utils.weak import WeakIdKeyDictionary
 
 from .. import exc
 from .._compat import target_device_capability
+from .._compile_time import is_enabled as _compile_time_enabled
 from .._compile_time import measure
 from .._compiler.ast_extension import unparse
 from .._compiler.autotuner_heuristics import compiler_seed_configs
@@ -186,10 +186,7 @@ class Kernel(Generic[_R]):
             Config(**config) if isinstance(config, dict) else config
             for config in configs or []
         ]
-        # Keyed by ``(signature, extra_results)`` tuples — the tuple form of
-        # ``BoundKernelInMemoryCacheKey``, kept plain for cheap per-call
-        # construction in ``bind``.
-        self._bound_kernels: dict[Hashable, BoundKernel] = {}
+        self._bound_kernels: dict[BoundKernelInMemoryCacheKey, BoundKernel] = {}
         self._specialize_extra: dict[
             Hashable, list[Callable[[Sequence[object]], Hashable]]
         ] = {}
@@ -228,57 +225,15 @@ class Kernel(Generic[_R]):
         self.__defaults__ = fn.__defaults__
         self.__kwdefaults__ = fn.__kwdefaults__
 
-    def _settings_signature(self) -> str:
-        """Return a stable string of settings that influence Triton codegen.
-
-        Mirrors the settings captured by
-        :meth:`BoundKernel.format_kernel_decorator` so the kernel id reflects
-        the same code-generation-affecting knobs.
-        """
-        parts = [f"static_shapes={self.settings.static_shapes}"]
-        if self.settings.index_dtype is not None:
-            parts.append(f"index_dtype={self.settings.index_dtype}")
-        return ", ".join(parts)
-
-    @functools.cache  # noqa: B019
-    def kernel_id(self) -> str:
-        """
-        Return a stable, content-derived identifier for this kernel.
-
-        The id is the SHA-256 hash of the kernel source together with the
-        settings that influence Triton code generation (see
-        :meth:`_settings_signature`). Because it is derived purely from content,
-        it is stable across processes and runs, making it suitable as a foreign
-        key for grouping telemetry rows by kernel during analysis.
-
-        Raises ``OSError`` if the source cannot be located (e.g. functions
-        defined in an interactive REPL or generated dynamically); see
-        :meth:`kernel_source`.
-        """
-        payload = self.kernel_source() + self._settings_signature()
-        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
-
-    @functools.cache  # noqa: B019
-    def kernel_source(self) -> str:
-        """
-        Return the kernel's source text.
-
-        This is the stable identifier across processes/runs, suitable for
-        grouping telemetry rows by kernel during analysis.
-        """
-        return inspect.getsource(self.fn)
-
     def _get_bound_kernel_cache_key(
         self, args: tuple[object, ...], signature: tuple[Hashable, ...]
-    ) -> tuple[Hashable, ...] | None:
-        # Plain tuples keep the per-call dispatch path free of dataclass
-        # construction; `_create_bound_kernel_cache_key` provides the
-        # `BoundKernelInMemoryCacheKey` form for the autotuner caches.
+    ) -> BoundKernelInMemoryCacheKey | None:
+        from ..autotuner.base_cache import BoundKernelInMemoryCacheKey
+
         extra_fns = self._specialize_extra.get(signature)
         if extra_fns is not None:
-            if extra_fns:
-                return (signature, tuple([s(args) for s in extra_fns]))
-            return (signature, ())
+            extra_results: tuple[Hashable, ...] = tuple([s(args) for s in extra_fns])
+            return BoundKernelInMemoryCacheKey(signature, extra_results)
         return None
 
     def _create_bound_kernel_cache_key(
@@ -303,33 +258,43 @@ class Kernel(Generic[_R]):
         Returns:
             BoundKernel: A BoundKernel object with the given arguments bound.
         """
-        with measure("Kernel.bind"):
-            if not isinstance(args, tuple):
-                assert isinstance(args, list), "args must be a tuple or list"
-                args = tuple(args)
-            if len(args) > self._num_params:
-                raise TypeError(
-                    f"Too many arguments passed to the kernel, expected: {self._num_params} got: {len(args)}."
-                )
-            signature = self._base_specialization_key(args)
-            cache_key = self._get_bound_kernel_cache_key(args, signature)
-            bound_kernel = (
-                None if cache_key is None else self._bound_kernels.get(cache_key, None)
+        # The "Kernel.bind" compile-time metric covers the whole bind body
+        # (key computation + cache lookup + any compile). But entering a
+        # context manager costs ~115ns even when measurement is disabled,
+        # which is significant on this per-call dispatch path, so only pay
+        # for it when measurement is actually on. Semantics are unchanged:
+        # when enabled, the same code runs under the same measure() scope.
+        if _compile_time_enabled():
+            with measure("Kernel.bind"):
+                return self._bind_impl(args)
+        return self._bind_impl(args)
+
+    def _bind_impl(self, args: tuple[object, ...]) -> BoundKernel[_R]:
+        if not isinstance(args, tuple):
+            assert isinstance(args, list), "args must be a tuple or list"
+            args = tuple(args)
+        if len(args) > self._num_params:
+            raise TypeError(
+                f"Too many arguments passed to the kernel, expected: {self._num_params} got: {len(args)}."
             )
-            if bound_kernel is None:
-                normalized_args: tuple[object, ...] = self.normalize_args(*args)
-                if len(normalized_args) != len(args):
-                    # we had default args that needed to be applied
-                    bound_kernel = self.bind(normalized_args)
-                else:
-                    bound_kernel = BoundKernel(self, args)
-                if cache_key is None:
-                    full_key = self._create_bound_kernel_cache_key(
-                        bound_kernel, args, signature
-                    )
-                    cache_key = (full_key.specialization_key, full_key.extra_results)
-                self._bound_kernels[cache_key] = bound_kernel
-            return bound_kernel
+        signature = self._base_specialization_key(args)
+        cache_key = self._get_bound_kernel_cache_key(args, signature)
+        bound_kernel = (
+            None if cache_key is None else self._bound_kernels.get(cache_key, None)
+        )
+        if bound_kernel is None:
+            normalized_args: tuple[object, ...] = self.normalize_args(*args)
+            if len(normalized_args) != len(args):
+                # we had default args that needed to be applied
+                bound_kernel = self.bind(normalized_args)
+            else:
+                bound_kernel = BoundKernel(self, args)
+            if cache_key is None:
+                cache_key = self._create_bound_kernel_cache_key(
+                    bound_kernel, args, signature
+                )
+            self._bound_kernels[cache_key] = bound_kernel
+        return bound_kernel
 
     def _base_specialization_key(self, args: Sequence[object]) -> tuple[Hashable, ...]:
         """
@@ -1446,8 +1411,7 @@ def _graph_module_key(fn: Kernel, obj: torch.fx.GraphModule) -> Hashable:
 
 
 _specialization_extractors: dict[
-    type[object] | str,
-    Callable[[Kernel, object], Hashable],
+    type[object] | str, Callable[[Kernel, object], Hashable]
     # pyrefly: ignore [bad-assignment]
 ] = {
     torch.Tensor: _tensor_key,

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -37,7 +37,6 @@ from torch.utils.weak import WeakIdKeyDictionary
 
 from .. import exc
 from .._compat import target_device_capability
-from .._compile_time import is_enabled as _compile_time_enabled
 from .._compile_time import measure
 from .._compiler.ast_extension import unparse
 from .._compiler.autotuner_heuristics import compiler_seed_configs
@@ -186,7 +185,10 @@ class Kernel(Generic[_R]):
             Config(**config) if isinstance(config, dict) else config
             for config in configs or []
         ]
-        self._bound_kernels: dict[BoundKernelInMemoryCacheKey, BoundKernel] = {}
+        # Keyed by ``(signature, extra_results)`` tuples — the tuple form of
+        # ``BoundKernelInMemoryCacheKey``, kept plain for cheap per-call
+        # construction in ``bind``.
+        self._bound_kernels: dict[Hashable, BoundKernel] = {}
         self._specialize_extra: dict[
             Hashable, list[Callable[[Sequence[object]], Hashable]]
         ] = {}
@@ -227,13 +229,15 @@ class Kernel(Generic[_R]):
 
     def _get_bound_kernel_cache_key(
         self, args: tuple[object, ...], signature: tuple[Hashable, ...]
-    ) -> BoundKernelInMemoryCacheKey | None:
-        from ..autotuner.base_cache import BoundKernelInMemoryCacheKey
-
+    ) -> tuple[Hashable, ...] | None:
+        # Plain tuples keep the per-call dispatch path free of dataclass
+        # construction; `_create_bound_kernel_cache_key` provides the
+        # `BoundKernelInMemoryCacheKey` form for the autotuner caches.
         extra_fns = self._specialize_extra.get(signature)
         if extra_fns is not None:
-            extra_results: tuple[Hashable, ...] = tuple([s(args) for s in extra_fns])
-            return BoundKernelInMemoryCacheKey(signature, extra_results)
+            if extra_fns:
+                return (signature, tuple([s(args) for s in extra_fns]))
+            return (signature, ())
         return None
 
     def _create_bound_kernel_cache_key(
@@ -258,18 +262,6 @@ class Kernel(Generic[_R]):
         Returns:
             BoundKernel: A BoundKernel object with the given arguments bound.
         """
-        # The "Kernel.bind" compile-time metric covers the whole bind body
-        # (key computation + cache lookup + any compile). But entering a
-        # context manager costs ~115ns even when measurement is disabled,
-        # which is significant on this per-call dispatch path, so only pay
-        # for it when measurement is actually on. Semantics are unchanged:
-        # when enabled, the same code runs under the same measure() scope.
-        if _compile_time_enabled():
-            with measure("Kernel.bind"):
-                return self._bind_impl(args)
-        return self._bind_impl(args)
-
-    def _bind_impl(self, args: tuple[object, ...]) -> BoundKernel[_R]:
         if not isinstance(args, tuple):
             assert isinstance(args, list), "args must be a tuple or list"
             args = tuple(args)
@@ -283,17 +275,19 @@ class Kernel(Generic[_R]):
             None if cache_key is None else self._bound_kernels.get(cache_key, None)
         )
         if bound_kernel is None:
-            normalized_args: tuple[object, ...] = self.normalize_args(*args)
-            if len(normalized_args) != len(args):
-                # we had default args that needed to be applied
-                bound_kernel = self.bind(normalized_args)
-            else:
-                bound_kernel = BoundKernel(self, args)
-            if cache_key is None:
-                cache_key = self._create_bound_kernel_cache_key(
-                    bound_kernel, args, signature
-                )
-            self._bound_kernels[cache_key] = bound_kernel
+            with measure("Kernel.bind"):
+                normalized_args: tuple[object, ...] = self.normalize_args(*args)
+                if len(normalized_args) != len(args):
+                    # we had default args that needed to be applied
+                    bound_kernel = self.bind(normalized_args)
+                else:
+                    bound_kernel = BoundKernel(self, args)
+                if cache_key is None:
+                    full_key = self._create_bound_kernel_cache_key(
+                        bound_kernel, args, signature
+                    )
+                    cache_key = (full_key.specialization_key, full_key.extra_results)
+                self._bound_kernels[cache_key] = bound_kernel
         return bound_kernel
 
     def _base_specialization_key(self, args: Sequence[object]) -> tuple[Hashable, ...]:
@@ -358,10 +352,8 @@ class Kernel(Generic[_R]):
                 extractor = _specialization_extractors[torch.fx.GraphModule]
             elif isinstance(obj, torch.Tensor):
                 # torch.Tensor subclasses (e.g. the JAX-export adapter)
-                # share the standard tensor specialization key. Use the
-                # SymInt-safe extractor: unlike exact ``torch.Tensor``,
-                # subclasses may carry symbolic sizes/strides.
-                extractor = _specialization_extractors["tensor_subclass"]
+                # share the standard tensor specialization key.
+                extractor = _specialization_extractors[torch.Tensor]
             elif isinstance(obj, tuple) and hasattr(obj, "_fields"):
                 # this is a namedtuple
                 extractor = _specialization_extractors["namedtuple"]
@@ -875,108 +867,11 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             config: The configuration to set.
         """
         config = self._normalize_config(config)
-        compiled = self.compile_config(config)
-        # Clone the compiled function so each BoundKernel has its own
-        # ``__kwdefaults__`` to mutate. ``compile_config`` returns functions
-        # loaded via ``PyCodeCache``, which keys on source hash — two
-        # BoundKernels for the same kernel (e.g. cuda:0 vs cuda:1) can
-        # generate IDENTICAL Triton source, share a function object, and an
-        # in-place ``__kwdefaults__["_launcher"] = ...`` in
-        # :meth:`_install_fast_launcher` would clobber the earlier
-        # BoundKernel's launcher.
-        run = types.FunctionType(
-            compiled.__code__,
-            compiled.__globals__,
-            compiled.__name__,
-            compiled.__defaults__,
-            compiled.__closure__,
-        )
-        if compiled.__kwdefaults__ is not None:
-            run.__kwdefaults__ = dict(compiled.__kwdefaults__)
-        self._install_fast_launcher(run, config)
-        self._run = run
+        self._run = self.compile_config(config)
         self._config = config
         counters["best_config_decorator"][
             self.format_kernel_decorator(config, self.settings)
         ] = 1
-
-    def _install_fast_launcher(
-        self,
-        compiled: CompiledConfig,
-        config: Config,
-    ) -> None:
-        """Re-point ``compiled``'s ``_launcher`` kwarg default at a fast closure.
-
-        The generated host wrapper declares
-        ``def add(x, y, *, _launcher=_default_launcher)``; Python stores the
-        ``_default_launcher`` value in ``compiled.__kwdefaults__``. By
-        overwriting that entry with a :class:`helion.runtime._FastLauncher`
-        closure (built once with this config's ``num_warps`` / ``num_stages``
-        / etc. baked in), every direct call to ``compiled(*args)`` —
-        including from ``BoundKernel.__call__`` on the steady-state hot
-        path — uses the fast launcher with no extra Python wrapping.
-
-        The autotune trial harness and any external caller that explicitly
-        passes ``_launcher=`` overrides the kwdefault automatically, so
-        this is safe.
-
-        Non-Triton backends and any priming failure cause the kwdefault to
-        be left at :func:`default_launcher`. Setting the env var
-        ``HELION_SKIP_FAST_LAUNCHER=1`` (or ``true`` / ``yes``) is an
-        escape hatch: the fast launcher is not installed and every
-        Helion call goes through ``default_launcher`` (= Triton's
-        ``JITFunction.run``). Useful for quickly bisecting whether a
-        bug is in the fast launcher itself.
-        """
-        import os
-
-        from .._compiler.backend import TritonBackend
-        from ._fast_launcher import build_fast_launcher
-
-        if os.environ.get("HELION_SKIP_FAST_LAUNCHER", "").lower() in (
-            "1",
-            "true",
-            "yes",
-        ):
-            return
-
-        backend = self.env.backend
-        if not isinstance(backend, TritonBackend):
-            return
-        kwdefaults = getattr(compiled, "__kwdefaults__", None)
-        if not kwdefaults or "_launcher" not in kwdefaults:
-            # No ``_launcher`` kwonly default — nothing to wire up.
-            # (Should not happen for Helion-compiled Triton kernels.)
-            return
-
-        try:
-            kwargs = backend.launcher_runtime_kwargs(
-                config, has_barrier=self._env.has_barrier
-            )
-        except Exception:
-            log.debug(
-                "FastLauncher disabled: backend.launcher_runtime_kwargs raised",
-                exc_info=True,
-            )
-            return
-
-        num_warps = cast("int", kwargs.pop("num_warps"))
-        num_stages = cast("int", kwargs.pop("num_stages"))
-        launch_cooperative_grid = cast(
-            "bool", kwargs.pop("launch_cooperative_grid", False)
-        )
-        ptx_options = cast("str | None", kwargs.pop("ptx_options", None))
-        # Anything left in kwargs (backend tunable keys, maxnreg,
-        # _triton_config_*) is forwarded as ``extra_kwargs`` to be baked
-        # into the closure.
-        fast_launcher = build_fast_launcher(
-            num_warps=num_warps,
-            num_stages=num_stages,
-            launch_cooperative_grid=launch_cooperative_grid,
-            ptx_options=ptx_options,
-            extra_kwargs=kwargs or None,
-        )
-        kwdefaults["_launcher"] = fast_launcher
 
     def _specialize_extra(self) -> list[Callable[[Sequence[object]], Hashable]]:
         """
@@ -1434,36 +1329,6 @@ def _hashable_dims(dims: Sequence[int | torch.SymInt]) -> tuple[Hashable, ...]:
     return tuple(_hashable_dim(s) for s in dims)
 
 
-def _concrete_tensor_key(fn: Kernel, obj: torch.Tensor) -> Hashable:
-    # Fast extractor for plain ``torch.Tensor`` / ``torch.nn.Parameter``:
-    # exact-type dispatch guarantees concrete int sizes/strides, so
-    # ``torch.Size`` and the stride tuple can be used directly (both are
-    # tuple subclasses that hash/compare identically to plain int tuples).
-    # The ``_hashable_dims`` wrap in ``_tensor_key`` exists only to
-    # normalize SymInts, which appear on FakeTensors during tracing.
-    si = getattr(obj, "_dynamo_static_indices", None)
-    static_indices = frozenset(si) if si is not None else _EMPTY_FROZENSET
-    if fn.settings.static_shapes:
-        return (obj.dtype, obj.size(), obj.stride(), static_indices)
-    bucketed = _bucketed_size(obj)
-    if fn.settings.index_dtype is None:
-        try:
-            needs_int64 = bool(obj.numel() > _INT32_INDEX_LIMIT)
-        except RuntimeError:
-            needs_int64 = True  # unbacked SymInt
-        return (
-            obj.dtype,
-            bucketed,
-            needs_int64,
-            static_indices,
-        )
-    return (
-        obj.dtype,
-        bucketed,
-        static_indices,
-    )
-
-
 def _tensor_key(fn: Kernel, obj: torch.Tensor) -> Hashable:
     si = getattr(obj, "_dynamo_static_indices", None)
     static_indices = frozenset(si) if si is not None else _EMPTY_FROZENSET
@@ -1543,17 +1408,9 @@ _specialization_extractors: dict[
     type[object] | str, Callable[[Kernel, object], Hashable]
     # pyrefly: ignore [bad-assignment]
 ] = {
-    # Exact-type dispatch (see ``_specialization_key``): plain tensors and
-    # Parameters always have concrete int sizes/strides and take the fast
-    # extractor. Subclasses (FakeTensor below, or anything hitting the
-    # ``isinstance`` fallback) go through SymInt-safe ``_tensor_key``.
-    torch.Tensor: _concrete_tensor_key,
-    torch.nn.Parameter: _concrete_tensor_key,
+    torch.Tensor: _tensor_key,
+    torch.nn.Parameter: _tensor_key,
     FakeTensor: _tensor_key,
-    # SymInt-safe extractor for torch.Tensor subclasses reached via the
-    # isinstance fallback in ``_specialization_key`` (string key so the
-    # fallback stays loosely typed, like "namedtuple" / "dataclass").
-    "tensor_subclass": _tensor_key,
     torch.dtype: lambda fn, x: x,
     torch.device: lambda fn, x: x,
     int: _number_key,

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -37,6 +37,7 @@ from torch.utils.weak import WeakIdKeyDictionary
 
 from .. import exc
 from .._compat import target_device_capability
+from .._compile_time import is_enabled as _compile_time_enabled
 from .._compile_time import measure
 from .._compiler.ast_extension import unparse
 from .._compiler.autotuner_heuristics import compiler_seed_configs
@@ -185,10 +186,7 @@ class Kernel(Generic[_R]):
             Config(**config) if isinstance(config, dict) else config
             for config in configs or []
         ]
-        # Keyed by ``(signature, extra_results)`` tuples — the tuple form of
-        # ``BoundKernelInMemoryCacheKey``, kept plain for cheap per-call
-        # construction in ``bind``.
-        self._bound_kernels: dict[Hashable, BoundKernel] = {}
+        self._bound_kernels: dict[BoundKernelInMemoryCacheKey, BoundKernel] = {}
         self._specialize_extra: dict[
             Hashable, list[Callable[[Sequence[object]], Hashable]]
         ] = {}
@@ -229,15 +227,13 @@ class Kernel(Generic[_R]):
 
     def _get_bound_kernel_cache_key(
         self, args: tuple[object, ...], signature: tuple[Hashable, ...]
-    ) -> tuple[Hashable, ...] | None:
-        # Plain tuples keep the per-call dispatch path free of dataclass
-        # construction; `_create_bound_kernel_cache_key` provides the
-        # `BoundKernelInMemoryCacheKey` form for the autotuner caches.
+    ) -> BoundKernelInMemoryCacheKey | None:
+        from ..autotuner.base_cache import BoundKernelInMemoryCacheKey
+
         extra_fns = self._specialize_extra.get(signature)
         if extra_fns is not None:
-            if extra_fns:
-                return (signature, tuple([s(args) for s in extra_fns]))
-            return (signature, ())
+            extra_results: tuple[Hashable, ...] = tuple([s(args) for s in extra_fns])
+            return BoundKernelInMemoryCacheKey(signature, extra_results)
         return None
 
     def _create_bound_kernel_cache_key(
@@ -262,6 +258,18 @@ class Kernel(Generic[_R]):
         Returns:
             BoundKernel: A BoundKernel object with the given arguments bound.
         """
+        # The "Kernel.bind" compile-time metric covers the whole bind body
+        # (key computation + cache lookup + any compile). But entering a
+        # context manager costs ~115ns even when measurement is disabled,
+        # which is significant on this per-call dispatch path, so only pay
+        # for it when measurement is actually on. Semantics are unchanged:
+        # when enabled, the same code runs under the same measure() scope.
+        if _compile_time_enabled():
+            with measure("Kernel.bind"):
+                return self._bind_impl(args)
+        return self._bind_impl(args)
+
+    def _bind_impl(self, args: tuple[object, ...]) -> BoundKernel[_R]:
         if not isinstance(args, tuple):
             assert isinstance(args, list), "args must be a tuple or list"
             args = tuple(args)
@@ -275,19 +283,17 @@ class Kernel(Generic[_R]):
             None if cache_key is None else self._bound_kernels.get(cache_key, None)
         )
         if bound_kernel is None:
-            with measure("Kernel.bind"):
-                normalized_args: tuple[object, ...] = self.normalize_args(*args)
-                if len(normalized_args) != len(args):
-                    # we had default args that needed to be applied
-                    bound_kernel = self.bind(normalized_args)
-                else:
-                    bound_kernel = BoundKernel(self, args)
-                if cache_key is None:
-                    full_key = self._create_bound_kernel_cache_key(
-                        bound_kernel, args, signature
-                    )
-                    cache_key = (full_key.specialization_key, full_key.extra_results)
-                self._bound_kernels[cache_key] = bound_kernel
+            normalized_args: tuple[object, ...] = self.normalize_args(*args)
+            if len(normalized_args) != len(args):
+                # we had default args that needed to be applied
+                bound_kernel = self.bind(normalized_args)
+            else:
+                bound_kernel = BoundKernel(self, args)
+            if cache_key is None:
+                cache_key = self._create_bound_kernel_cache_key(
+                    bound_kernel, args, signature
+                )
+            self._bound_kernels[cache_key] = bound_kernel
         return bound_kernel
 
     def _base_specialization_key(self, args: Sequence[object]) -> tuple[Hashable, ...]:

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -875,11 +875,108 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             config: The configuration to set.
         """
         config = self._normalize_config(config)
-        self._run = self.compile_config(config)
+        compiled = self.compile_config(config)
+        # Clone the compiled function so each BoundKernel has its own
+        # ``__kwdefaults__`` to mutate. ``compile_config`` returns functions
+        # loaded via ``PyCodeCache``, which keys on source hash — two
+        # BoundKernels for the same kernel (e.g. cuda:0 vs cuda:1) can
+        # generate IDENTICAL Triton source, share a function object, and an
+        # in-place ``__kwdefaults__["_launcher"] = ...`` in
+        # :meth:`_install_fast_launcher` would clobber the earlier
+        # BoundKernel's launcher.
+        run = types.FunctionType(
+            compiled.__code__,
+            compiled.__globals__,
+            compiled.__name__,
+            compiled.__defaults__,
+            compiled.__closure__,
+        )
+        if compiled.__kwdefaults__ is not None:
+            run.__kwdefaults__ = dict(compiled.__kwdefaults__)
+        self._install_fast_launcher(run, config)
+        self._run = run
         self._config = config
         counters["best_config_decorator"][
             self.format_kernel_decorator(config, self.settings)
         ] = 1
+
+    def _install_fast_launcher(
+        self,
+        compiled: CompiledConfig,
+        config: Config,
+    ) -> None:
+        """Re-point ``compiled``'s ``_launcher`` kwarg default at a fast closure.
+
+        The generated host wrapper declares
+        ``def add(x, y, *, _launcher=_default_launcher)``; Python stores the
+        ``_default_launcher`` value in ``compiled.__kwdefaults__``. By
+        overwriting that entry with a :class:`helion.runtime._FastLauncher`
+        closure (built once with this config's ``num_warps`` / ``num_stages``
+        / etc. baked in), every direct call to ``compiled(*args)`` —
+        including from ``BoundKernel.__call__`` on the steady-state hot
+        path — uses the fast launcher with no extra Python wrapping.
+
+        The autotune trial harness and any external caller that explicitly
+        passes ``_launcher=`` overrides the kwdefault automatically, so
+        this is safe.
+
+        Non-Triton backends and any priming failure cause the kwdefault to
+        be left at :func:`default_launcher`. Setting the env var
+        ``HELION_SKIP_FAST_LAUNCHER=1`` (or ``true`` / ``yes``) is an
+        escape hatch: the fast launcher is not installed and every
+        Helion call goes through ``default_launcher`` (= Triton's
+        ``JITFunction.run``). Useful for quickly bisecting whether a
+        bug is in the fast launcher itself.
+        """
+        import os
+
+        from .._compiler.backend import TritonBackend
+        from ._fast_launcher import build_fast_launcher
+
+        if os.environ.get("HELION_SKIP_FAST_LAUNCHER", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        ):
+            return
+
+        backend = self.env.backend
+        if not isinstance(backend, TritonBackend):
+            return
+        kwdefaults = getattr(compiled, "__kwdefaults__", None)
+        if not kwdefaults or "_launcher" not in kwdefaults:
+            # No ``_launcher`` kwonly default — nothing to wire up.
+            # (Should not happen for Helion-compiled Triton kernels.)
+            return
+
+        try:
+            kwargs = backend.launcher_runtime_kwargs(
+                config, has_barrier=self._env.has_barrier
+            )
+        except Exception:
+            log.debug(
+                "FastLauncher disabled: backend.launcher_runtime_kwargs raised",
+                exc_info=True,
+            )
+            return
+
+        num_warps = cast("int", kwargs.pop("num_warps"))
+        num_stages = cast("int", kwargs.pop("num_stages"))
+        launch_cooperative_grid = cast(
+            "bool", kwargs.pop("launch_cooperative_grid", False)
+        )
+        ptx_options = cast("str | None", kwargs.pop("ptx_options", None))
+        # Anything left in kwargs (backend tunable keys, maxnreg,
+        # _triton_config_*) is forwarded as ``extra_kwargs`` to be baked
+        # into the closure.
+        fast_launcher = build_fast_launcher(
+            num_warps=num_warps,
+            num_stages=num_stages,
+            launch_cooperative_grid=launch_cooperative_grid,
+            ptx_options=ptx_options,
+            extra_kwargs=kwargs or None,
+        )
+        kwdefaults["_launcher"] = fast_launcher
 
     def _specialize_extra(self) -> list[Callable[[Sequence[object]], Hashable]]:
         """

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -358,8 +358,10 @@ class Kernel(Generic[_R]):
                 extractor = _specialization_extractors[torch.fx.GraphModule]
             elif isinstance(obj, torch.Tensor):
                 # torch.Tensor subclasses (e.g. the JAX-export adapter)
-                # share the standard tensor specialization key.
-                extractor = _specialization_extractors[torch.Tensor]
+                # share the standard tensor specialization key. Use the
+                # SymInt-safe extractor: unlike exact ``torch.Tensor``,
+                # subclasses may carry symbolic sizes/strides.
+                extractor = _specialization_extractors["tensor_subclass"]
             elif isinstance(obj, tuple) and hasattr(obj, "_fields"):
                 # this is a namedtuple
                 extractor = _specialization_extractors["namedtuple"]
@@ -1335,6 +1337,36 @@ def _hashable_dims(dims: Sequence[int | torch.SymInt]) -> tuple[Hashable, ...]:
     return tuple(_hashable_dim(s) for s in dims)
 
 
+def _concrete_tensor_key(fn: Kernel, obj: torch.Tensor) -> Hashable:
+    # Fast extractor for plain ``torch.Tensor`` / ``torch.nn.Parameter``:
+    # exact-type dispatch guarantees concrete int sizes/strides, so
+    # ``torch.Size`` and the stride tuple can be used directly (both are
+    # tuple subclasses that hash/compare identically to plain int tuples).
+    # The ``_hashable_dims`` wrap in ``_tensor_key`` exists only to
+    # normalize SymInts, which appear on FakeTensors during tracing.
+    si = getattr(obj, "_dynamo_static_indices", None)
+    static_indices = frozenset(si) if si is not None else _EMPTY_FROZENSET
+    if fn.settings.static_shapes:
+        return (obj.dtype, obj.size(), obj.stride(), static_indices)
+    bucketed = _bucketed_size(obj)
+    if fn.settings.index_dtype is None:
+        try:
+            needs_int64 = bool(obj.numel() > _INT32_INDEX_LIMIT)
+        except RuntimeError:
+            needs_int64 = True  # unbacked SymInt
+        return (
+            obj.dtype,
+            bucketed,
+            needs_int64,
+            static_indices,
+        )
+    return (
+        obj.dtype,
+        bucketed,
+        static_indices,
+    )
+
+
 def _tensor_key(fn: Kernel, obj: torch.Tensor) -> Hashable:
     si = getattr(obj, "_dynamo_static_indices", None)
     static_indices = frozenset(si) if si is not None else _EMPTY_FROZENSET
@@ -1414,9 +1446,17 @@ _specialization_extractors: dict[
     type[object] | str, Callable[[Kernel, object], Hashable]
     # pyrefly: ignore [bad-assignment]
 ] = {
-    torch.Tensor: _tensor_key,
-    torch.nn.Parameter: _tensor_key,
+    # Exact-type dispatch (see ``_specialization_key``): plain tensors and
+    # Parameters always have concrete int sizes/strides and take the fast
+    # extractor. Subclasses (FakeTensor below, or anything hitting the
+    # ``isinstance`` fallback) go through SymInt-safe ``_tensor_key``.
+    torch.Tensor: _concrete_tensor_key,
+    torch.nn.Parameter: _concrete_tensor_key,
     FakeTensor: _tensor_key,
+    # SymInt-safe extractor for torch.Tensor subclasses reached via the
+    # isinstance fallback in ``_specialization_key`` (string key so the
+    # fallback stays loosely typed, like "namedtuple" / "dataclass").
+    "tensor_subclass": _tensor_key,
     torch.dtype: lambda fn, x: x,
     torch.device: lambda fn, x: x,
     int: _number_key,

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -1863,11 +1863,32 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
         with (
             patch_cute_mma_support(),
             patch("torch.cuda.get_device_capability", return_value=(10, 0)),
+            # target_device_capability is memoized (is_hip / _is_hip pattern),
+            # so torch.cuda.get_device_capability alone no longer reaches its
+            # consumers. Patch each seam the bind path reads: the bound-kernel
+            # cache key (runtime.kernel) and the ConfigSpec arch capability,
+            # which CompileEnvironment captures onto config_spec at build time.
+            patch(
+                "helion.runtime.kernel.target_device_capability",
+                return_value=(10, 0),
+            ),
+            patch(
+                "helion._compiler.compile_environment.target_device_capability",
+                return_value=(10, 0),
+            ),
         ):
             bound = cute_matmul_bias_residual_gelu.bind(args)
         with (
             patch_cute_mma_support(),
             patch("torch.cuda.get_device_capability", return_value=(9, 0)),
+            patch(
+                "helion.runtime.kernel.target_device_capability",
+                return_value=(9, 0),
+            ),
+            patch(
+                "helion._compiler.compile_environment.target_device_capability",
+                return_value=(9, 0),
+            ),
         ):
             sm90_bound = cute_matmul_bias_residual_gelu.bind(args)
         self.assertIsNot(sm90_bound, bound)

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -144,14 +144,17 @@ class TestConfigAPI(TestCase):
             pass
 
         device = torch.device("cuda:0")
-        with (
-            patch("torch.cuda.is_available", return_value=True),
-            patch("torch.cuda.get_device_capability", return_value=(9, 0)),
+        # Patch the helion seam (target_device_capability, imported into
+        # runtime.kernel) rather than torch.cuda.get_device_capability: the
+        # latter is memoized behind _target_device_capability, mirroring the
+        # is_hip / _is_hip pattern where tests mock the public wrapper, not
+        # the cached inner query.
+        with patch(
+            "helion.runtime.kernel.target_device_capability", return_value=(9, 0)
         ):
             sm90_key = device_key_kernel._base_specialization_key((device,))
-        with (
-            patch("torch.cuda.is_available", return_value=True),
-            patch("torch.cuda.get_device_capability", return_value=(10, 0)),
+        with patch(
+            "helion.runtime.kernel.target_device_capability", return_value=(10, 0)
         ):
             sm100_key = device_key_kernel._base_specialization_key((device,))
 
@@ -874,7 +877,14 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
         with (
             patch("torch.cuda.is_available", return_value=True),
             patch("torch.cuda.current_device", return_value=0),
-            patch("torch.cuda.get_device_capability", return_value=(9, 0)),
+            # Patch the helion seam: torch.cuda.get_device_capability is
+            # memoized behind _target_device_capability (is_hip / _is_hip
+            # pattern), so config_spec's get_target_device_capability() must
+            # be patched at the wrapper, not the cached torch query.
+            patch(
+                "helion.autotuner.config_spec.get_target_device_capability",
+                return_value=(9, 0),
+            ),
         ):
             spec = self._make_cute_tcgen05_spec()
 

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -458,6 +458,39 @@ def cute_matmul_mma(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     return out
 
 
+@helion.kernel(backend="cute", static_shapes=True)
+def cute_matmul_mma_fp8(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    # fp8 (e4m3) inputs, f32 accumulate, bf16 output -- the tcgen05 MMA atom
+    # for fp8 is MmaF8F6F4Op (MMA-K=32 vs 16 for bf16/fp16).
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+        out[tile_m, tile_n] = acc.to(torch.bfloat16)
+    return out
+
+
+@helion.kernel(backend="cute", static_shapes=True)
+def cute_matmul_mma_fp8_rowvec_scale(
+    x: torch.Tensor, y: torch.Tensor, scale_n: torch.Tensor
+) -> torch.Tensor:
+    # fp8 GEMM with a fused per-column (rowvec) scale in the epilogue.
+    # Exercises the rowvec aux chain on the tcgen05 fp8 path (and, for
+    # TMA-store configs, the register-hoist of the rowvec load).
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+        out[tile_m, tile_n] = (acc * scale_n[tile_n]).to(torch.bfloat16)
+    return out
+
+
 @helion.kernel(backend="cute")
 def cute_matmul_mma_epilogue(
     x: torch.Tensor, y: torch.Tensor, bias: torch.Tensor
@@ -1154,6 +1187,44 @@ class TestCuteBackend(TestCase):
             code,
         )
         self.assertIn("cutlass.pipeline.NamedBarrier(barrier_id=1", code)
+
+    def test_matmul_mma_tcgen05_fp8(self) -> None:
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = (torch.randn(256, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = (torch.randn(128, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        code, out = code_and_output(
+            cute_matmul_mma_fp8, (x, y), block_sizes=[128, 128, 128]
+        )
+        ref = x.float() @ y.float()
+        torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+        # fp8 routes through the tcgen05 F8F6F4 MMA atom (MMA-K=32).
+        self.assertIn("cutlass.utils.blackwell_helpers.make_trivial_tiled_mma", code)
+        self.assertIn("cutlass.Float8E4M3FN", code)
+        self.assertIn("cute.nvgpu.tcgen05", code)
+        self.assertIn("cute.gemm(", code)
+
+    def test_matmul_mma_tcgen05_fp8_rowvec_scale(self) -> None:
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = (torch.randn(256, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = (torch.randn(128, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        scale_n = torch.rand(128, device=DEVICE) + 0.5
+        code, out = code_and_output(
+            cute_matmul_mma_fp8_rowvec_scale,
+            (x, y, scale_n),
+            block_sizes=[128, 128, 128],
+        )
+        ref = (x.float() @ y.float()) * scale_n.float()
+        torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+        self.assertIn("cutlass.Float8E4M3FN", code)
+        self.assertIn("cute.nvgpu.tcgen05", code)
 
     def test_matmul_dot_out_dtype_falls_back_from_mma(self) -> None:
         args = (

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -1207,6 +1207,32 @@ class TestCuteBackend(TestCase):
         self.assertIn("cute.nvgpu.tcgen05", code)
         self.assertIn("cute.gemm(", code)
 
+    def test_matmul_mma_tcgen05_fp8_col_major_b(self) -> None:
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = (torch.randn(256, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        # Column-major (K-contiguous) B. Helion must emit a K-major B operand
+        # (OperandMajorMode.K for B) and a matching K-major B SMEM layout,
+        # rather than forcing the slow non-TMA fallback.
+        y = (torch.randn(128, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = y.T.contiguous().T
+        self.assertFalse(y.is_contiguous())
+        code, out = code_and_output(
+            cute_matmul_mma_fp8, (x, y), block_sizes=[128, 128, 128]
+        )
+        ref = x.float() @ y.float()
+        torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+        # B is emitted K-major: both A and B operand major modes are K, so
+        # OperandMajorMode.K appears at least twice (A + B); the MN-major B
+        # spelling must be absent.
+        self.assertIn("cutlass.Float8E4M3FN", code)
+        self.assertIn("cute.nvgpu.tcgen05", code)
+        self.assertGreaterEqual(code.count("cute.nvgpu.OperandMajorMode.K"), 2)
+        self.assertNotIn("cute.nvgpu.OperandMajorMode.MN", code)
+
     def test_matmul_mma_tcgen05_fp8_rowvec_scale(self) -> None:
         support = get_cute_mma_support()
         if not support.tcgen05_f8:

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -1214,7 +1214,8 @@ class TestCuteBackend(TestCase):
 
         torch.manual_seed(0)
         x = (torch.randn(256, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
-        # Column-major (K-contiguous) B. Helion must emit a K-major B operand
+        # Column-major (K-contiguous) B -- the native fp8 scaled_mm /
+        # torch._scaled_mm layout. Helion must emit a K-major B operand
         # (OperandMajorMode.K for B) and a matching K-major B SMEM layout,
         # rather than forcing the slow non-TMA fallback.
         y = (torch.randn(128, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -49,7 +49,7 @@ from helion._compiler.cute.cute_mma import _build_kloop_non_pipeline_release_if
 from helion._compiler.cute.cute_mma import _build_kloop_pipeline_consumer_if
 from helion._compiler.cute.cute_mma import _build_kloop_pipeline_consumer_prefetch_stmts
 from helion._compiler.cute.cute_mma import _build_kloop_pipeline_producer_if
-from helion._compiler.cute.cute_mma import _build_kloop_pipeline_release_if
+from helion._compiler.cute.cute_mma import _build_kloop_pipeline_release_stmts
 from helion._compiler.cute.cute_mma import _build_tcgen05_mma_accumulate_reset_stmt
 from helion._compiler.cute.cute_mma import _build_tcgen05_mma_issue_stmt
 from helion._compiler.cute.cute_mma import _choose_mma_impl
@@ -238,6 +238,18 @@ from helion.language.memory_ops import _maybe_codegen_cute_packed_affine_lhs_loa
 from helion.language.memory_ops import _tcgen05_rowvec_aux_stage_copy_elems
 from helion.language.memory_ops import load
 from helion.runtime import _append_cute_wrapper_plan
+
+
+def _build_kloop_pipeline_release_if(*args: object, **kwargs: object) -> ast.stmt:
+    """Single-statement shim over the list-returning release builder.
+
+    Every non-static-full form still emits exactly one statement; the
+    static-full two-CTA form returns two sibling gated statements and is
+    asserted directly against ``_build_kloop_pipeline_release_stmts``.
+    """
+    (stmt,) = _build_kloop_pipeline_release_stmts(*args, **kwargs)  # pyrefly: ignore
+    return stmt
+
 
 # The legacy ``T1`` direct-entry seed (1024x4096x1024, bk=64) used a deep
 # (ab=6, c=4) A/B pipeline. The per-target constants were removed when the
@@ -4760,15 +4772,17 @@ class TestCuteLowerings(unittest.TestCase):
                 self.assertIn("pid_0 = virtual_pid % num_blocks_0", role_src)
                 self.assertIn("tile_offset_0 = pid_0 * _BLOCK_SIZE_0", role_src)
                 self.assertIn("for tile_offset_2 in range", role_src)
+                # Static-full role-local configs emit the unified producer:
+                # an unconditional blocking acquire + copy pair per K tile
+                # with no full-tile predicates or per-stage prologue chain.
                 self.assertIn(
-                    "if tcgen05_tma_full_tile and tcgen05_tma_next_full_tile",
+                    "tcgen05_ab_pipeline.producer_acquire("
+                    "tcgen05_ab_producer_state)",
                     role_src,
                 )
-                self.assertNotIn(
-                    "tcgen05_tma_full_tile and tcgen05_tma_warp and "
-                    "tcgen05_tma_next_full_tile",
-                    role_src,
-                )
+                self.assertIn("tma_gA[None, tcgen05_tma_k_tile]", role_src)
+                self.assertNotIn("tcgen05_tma_full_tile", role_src)
+                self.assertNotIn("tcgen05_tma_warp and", role_src)
                 found_role_local_producer_loop = True
 
         for node in ast.walk(tree):
@@ -6133,11 +6147,14 @@ class TestCuteLowerings(unittest.TestCase):
         seeded inputs, executing the kernel, and asserting closeness
         against the torch reference. See ``cute_plan.md §6.9.1``.
 
-        Pinned codegen markers (``num_stages=3``, intermediate-stage
-        gate variable, per-stage prefetch ``k_offset=0,1,2``) are also
-        checked so a producer-side regression that codegens fine but
-        re-introduces the prefetch gap fails fast at the codegen layer
-        before consuming the runtime budget.
+        Static-full role-local configs (this one) now emit the unified
+        TMA producer — one rolled K loop whose blocking
+        ``producer_acquire`` fills every stage in order, so the
+        stage-gap deadlock is structurally impossible. The pinned
+        codegen markers assert that unified shape (``num_stages=3``,
+        a single ``tma_gA[None, tcgen05_tma_k_tile]`` issue site, no
+        per-stage prefetch chain); the runtime check still defends the
+        end-to-end behaviour.
         """
 
         from helion._compiler.cute.mma_support import get_cute_mma_support
@@ -6178,16 +6195,18 @@ class TestCuteLowerings(unittest.TestCase):
                         tcgen05_ab_stages=3,
                     )
                     code = bound.to_triton_code(cfg)
-                    # Codegen markers: pipeline depth + per-stage prefetch.
+                    # Codegen markers: pipeline depth + the unified rolled
+                    # producer (single un-offset TMA issue site, no unrolled
+                    # per-stage prefetch chain).
                     self.assertIn("PipelineTmaUmma.create(num_stages=3", code)
-                    for k_offset in (0, 1, 2):
-                        self.assertIn(f"tma_gA[None, cutlass.Int32({k_offset})]", code)
-                        self.assertIn(f"tma_gB[None, cutlass.Int32({k_offset})]", code)
-                    self.assertIn(
+                    self.assertIn("tma_gA[None, tcgen05_tma_k_tile]", code)
+                    self.assertIn("tma_gB[None, tcgen05_tma_k_tile]", code)
+                    self.assertNotIn("tma_gA[None, cutlass.Int32(0)]", code)
+                    self.assertNotIn(
                         "tma_gA[None, tcgen05_tma_k_tile + cutlass.Int32(3)]",
                         code,
                     )
-                    self.assertIn("tcgen05_tma_initial_stage_1_full_tile", code)
+                    self.assertNotIn("tcgen05_tma_initial_stage_1_full_tile", code)
                     bound.set_config(cfg)
                     out = bound(*args)
                 # If the deadlock regresses, the kernel hangs (CI test
@@ -9563,12 +9582,22 @@ class TestCuteLowerings(unittest.TestCase):
                     self.assertIn("tcgen05_ab_consumer_state.advance()", role_src)
                     release_pos = role_src.index("tcgen05_ab_pipeline.consumer_release")
                     advance_pos = role_src.index("tcgen05_ab_consumer_state.advance()")
+                    # Per-K gates reuse the hoisted cluster-rank local
+                    # (``tcgen05_cta_rank_in_cluster``); per-tile gates keep
+                    # the inline ``make_warp_uniform(...)`` leader form.
+                    hoisted_leader = (
+                        "tcgen05_cta_rank_in_cluster == cutlass.Int32(0)"
+                    )
                     next_ab_peek_blocks = [
                         ast.unparse(child)
                         for child in ast.walk(node)
                         if isinstance(child, ast.If)
                         and "tcgen05_tma_next_consumer_tile" in ast.unparse(child.test)
-                        and _TCGEN05_CLUSTER_LEADER_PREDICATE in ast.unparse(child.test)
+                        and (
+                            _TCGEN05_CLUSTER_LEADER_PREDICATE
+                            in ast.unparse(child.test)
+                            or hoisted_leader in ast.unparse(child.test)
+                        )
                     ]
                     self.assertTrue(
                         next_ab_peek_blocks,
@@ -9589,7 +9618,11 @@ class TestCuteLowerings(unittest.TestCase):
                         ast.unparse(child)
                         for child in ast.walk(node)
                         if isinstance(child, ast.If)
-                        and _TCGEN05_CLUSTER_LEADER_PREDICATE in ast.unparse(child.test)
+                        and (
+                            _TCGEN05_CLUSTER_LEADER_PREDICATE
+                            in ast.unparse(child.test)
+                            or hoisted_leader in ast.unparse(child.test)
+                        )
                     ]
                     self.assertTrue(
                         any(
@@ -19334,20 +19367,32 @@ class TestPerKiterTmaBuilders(unittest.TestCase):
         with self.assertRaisesRegex(AssertionError, "scalar fallback"):
             _build_kloop_pipeline_release_if(args)
 
+        # The per-K-iter producer-if never serves two-CTA static-full (the
+        # unified rolled producer loop replaces it there); consumer wait /
+        # release DO serve it from the role-local exec loop, emitting
+        # leader-gated statements with no full-tile wrapper.
         two_cta_args = self._make_args(is_two_cta=True, static_full_tiles=True)
-        for builder in (
-            _build_kloop_pipeline_producer_if,
-            _build_kloop_pipeline_consumer_if,
-            _build_kloop_pipeline_release_if,
-        ):
-            with (
-                self.subTest(builder=builder.__name__),
-                self.assertRaisesRegex(AssertionError, "one-CTA"),
-            ):
-                if builder is _build_kloop_pipeline_producer_if:
-                    builder(two_cta_args)
-                else:
-                    builder(two_cta_args, include_scalar_fallback=False)
+        with self.assertRaisesRegex(AssertionError, "one-CTA"):
+            _build_kloop_pipeline_producer_if(two_cta_args)
+        two_cta_consumer = _build_kloop_pipeline_consumer_if(
+            two_cta_args,
+            gate_exec_warp=False,
+            include_scalar_fallback=False,
+        )
+        self.assertIsInstance(two_cta_consumer, ast.If)
+        self.assertEqual(
+            ast.unparse(two_cta_consumer.test), _TCGEN05_CLUSTER_LEADER_PREDICATE
+        )
+        release_stmt, advance_stmt = _build_kloop_pipeline_release_stmts(
+            two_cta_args,
+            gate_exec_warp=False,
+            include_scalar_fallback=False,
+        )
+        self.assertIsInstance(release_stmt, ast.If)
+        self.assertEqual(
+            ast.unparse(release_stmt.test), _TCGEN05_CLUSTER_LEADER_PREDICATE
+        )
+        self.assertEqual(self._stmt_kinds([advance_stmt]), ["advance"])
 
     def test_non_pipeline_builders_reject_static_full_fast_path(self) -> None:
         args = self._make_args(static_full_tiles=True)

--- a/test/test_fast_launcher.py
+++ b/test/test_fast_launcher.py
@@ -1,0 +1,413 @@
+from __future__ import annotations
+
+import unittest
+
+import pytest
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import RefEagerTestDisabled
+from helion._testing import TestCase
+from helion._testing import skipIfFn
+from helion._testing import skipIfNotCUDA
+from helion._testing import skipIfNotTriton
+import helion.language as hl
+from helion.runtime import _FastLauncher
+from helion.runtime.kernel import _tensor_key
+
+triton = pytest.importorskip("triton")
+from triton.runtime.driver import driver  # noqa: E402
+
+
+def _get_jit_function(kernel: helion.Kernel) -> object:
+    """Return the underlying ``triton.JITFunction`` behind a primed Helion kernel.
+
+    The generated host wrapper closes over the JITFunction as
+    ``_helion_<name>`` in its ``__globals__``. We scan for the unique
+    JITFunction instance there so tests can install Triton-side hooks
+    (e.g. ``pre_run_hooks``) on a real kernel without patching.
+    """
+    from triton.runtime.jit import JITFunction
+
+    bound = next(iter(kernel._bound_kernels.values()))  # type: ignore[attr-defined]
+    return next(
+        v for v in bound._run.__globals__.values() if isinstance(v, JITFunction)
+    )
+
+
+@helion.kernel(config={"block_size": 16})
+def _fast_launcher_add_one(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size()):
+        out[tile] = x[tile] + 1
+    return out
+
+
+# Large block size + 2 stages makes Triton emit vectorized 16-byte loads,
+# which exposes the launcher's per-call spec lookup gap loudly (misaligned
+# pointer → CUDA misaligned-address error) rather than as a silent numeric
+# drift.
+@helion.kernel(
+    static_shapes=True,
+    config=helion.Config(block_sizes=[1024], num_warps=4, num_stages=2),
+)
+def _fast_launcher_add_vectorized(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for i in hl.tile(out.size(0)):
+        out[i] = x[i] + y[i]
+    return out
+
+
+@skipIfNotTriton("fast launcher is Triton-specific")
+class TestFastLauncher(RefEagerTestDisabled, TestCase):
+    @skipIfNotCUDA()
+    @skipIfFn(
+        lambda: torch.cuda.device_count() < 2,
+        "test requires at least two CUDA devices",
+    )
+    def test_fast_launcher_uses_current_call_device(self) -> None:
+        """The cached launcher must not reuse cuda:0 launch state for cuda:1."""
+        _fast_launcher_add_one.reset()
+        old_device = torch.cuda.current_device()
+        try:
+            cuda0 = torch.device("cuda:0")
+            cuda1 = torch.device("cuda:1")
+            with torch.cuda.device(0):
+                x0 = torch.arange(16, device=cuda0, dtype=torch.float32)
+                y0 = _fast_launcher_add_one(x0)
+                torch.cuda.synchronize(0)
+                torch.testing.assert_close(y0, x0 + 1)
+
+            with torch.cuda.device(1):
+                x1 = torch.arange(16, device=cuda1, dtype=torch.float32)
+                y1 = _fast_launcher_add_one(x1)
+                torch.cuda.synchronize(1)
+                torch.testing.assert_close(y1, x1 + 1)
+                self.assertEqual(y1.device, cuda1)
+        finally:
+            torch.cuda.set_device(old_device)
+            _fast_launcher_add_one.reset()
+
+    @skipIfNotCUDA()
+    def test_binder_spec_differs_for_aligned_vs_unaligned_pointers(self) -> None:
+        """Pre-condition for the alignment correctness gap.
+
+        Helion's tensor key only tracks dtype/shape/stride, so two
+        views with the same shape but different pointer alignment
+        share one ``BoundKernel``. Yet Triton's binder reports
+        distinct specializations for them. The multi-spec
+        ``_FastLauncher`` keys its ``_spec_cache`` on the alignment
+        bitmask exactly to handle this: aligned and unaligned land
+        on different cache entries (i.e. different compiled binaries).
+        This test pins down the underlying Triton-binder distinction
+        — if a future Triton change collapses these specs, alignment
+        bitmask differentiation would become unnecessary.
+        """
+        _fast_launcher_add_vectorized.reset()
+        n = 1024
+        base = torch.randn(n + 4, device=DEVICE, dtype=torch.float32)
+        aligned = base[:n]
+        unaligned = base[1 : n + 1]
+        out_buf = torch.empty_like(aligned)
+
+        self.assertEqual(aligned.data_ptr() % 16, 0)
+        self.assertNotEqual(unaligned.data_ptr() % 16, 0)
+        self.assertEqual(
+            _tensor_key(_fast_launcher_add_vectorized, aligned),
+            _tensor_key(_fast_launcher_add_vectorized, unaligned),
+        )
+
+        # Run once to ensure ``set_config`` has installed a fast launcher.
+        _fast_launcher_add_vectorized(aligned, aligned)
+        bound = _fast_launcher_add_vectorized.bind((aligned, aligned))
+        compiled = bound._run
+        self.assertIsNotNone(compiled)
+        launcher = compiled.__kwdefaults__.get("_launcher")
+        if not isinstance(launcher, _FastLauncher) or not launcher._primed:
+            self.skipTest(
+                "fast launcher not installed (non-Triton backend or unsupported Triton)"
+            )
+
+        # Fetch the binder from Triton's per-device cache directly —
+        # the fast launcher no longer keeps a reference because it
+        # computes the alignment bits inline instead of calling the
+        # binder on every launch.
+        jit_fn = _get_jit_function(_fast_launcher_add_vectorized)
+        dev = driver.active.get_current_device()
+        binder = jit_fn.device_caches[dev][4]  # pyrefly: ignore[missing-attribute]
+        _, spec_aligned, _ = binder(aligned, aligned, out_buf, **launcher._run_kwargs)
+        _, spec_unaligned, _ = binder(
+            unaligned, unaligned, out_buf, **launcher._run_kwargs
+        )
+        self.assertNotEqual(spec_aligned, spec_unaligned)
+
+    @skipIfNotCUDA()
+    def test_pre_run_hook_installed_after_priming_fires_on_real_kernel(
+        self,
+    ) -> None:
+        """A ``pre_run_hook`` installed after priming must fire on the next call.
+
+        ``JITFunction.run`` iterates ``self.pre_run_hooks`` at the top
+        of every launch (jit.py:717-718). The fast launcher's
+        C-launcher hot path doesn't go through ``JITFunction.run``, so
+        an attached profiler / autotune-timer would silently miss
+        every Helion launch unless we mirror that loop ourselves.
+        We invoke the hooks inline on the hot path with the same
+        ``args`` + ``kwargs`` Triton would, so installing a hook
+        after priming keeps the launcher on the fast path AND fires
+        the hook. We also check the kwargs include the live
+        ``debug``/``instrumentation_mode`` values matching Triton's
+        contract.
+        """
+        _fast_launcher_add_one.reset()
+        self.addCleanup(_fast_launcher_add_one.reset)
+        x = torch.arange(16, device=DEVICE, dtype=torch.float32)
+
+        torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+        jit_fn = _get_jit_function(_fast_launcher_add_one)
+        calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+        self.addCleanup(jit_fn.pre_run_hooks.clear)  # pyrefly: ignore[missing-attribute]
+        jit_fn.pre_run_hooks.append(  # pyrefly: ignore[missing-attribute]
+            lambda *a, **kw: calls.append((a, kw))
+        )
+        torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+        self.assertEqual(len(calls), 1)
+        _, kw = calls[0]
+        self.assertIn("debug", kw)
+        self.assertIn("instrumentation_mode", kw)
+        self.assertIn("num_warps", kw)
+        self.assertIn("num_stages", kw)
+
+    @skipIfNotCUDA()
+    def test_used_global_vals_mutation_surfaces_to_user_on_real_kernel(
+        self,
+    ) -> None:
+        """Mutating a tracked global must surface as a Triton ``RuntimeError``.
+
+        Helion-generated Triton kernels reference codegen constants
+        (e.g. ``_BLOCK_SIZE_0``) as module-level ``constexpr`` globals;
+        Triton tracks them in ``used_global_vals`` and raises if the
+        value changes between launches — the cached binary has the
+        old value baked into codegen, so silently reusing it would
+        produce wrong output. The fast launcher's snapshot+equality
+        check on every call mirrors that semantic. Without it, the
+        Helion kernel would skip Triton's mismatch check entirely.
+
+        This test also verifies the snapshot check does not
+        false-positive: ``used_global_vals`` is non-empty on every
+        Helion kernel, so a naive non-empty test would defeat the
+        fast path. We assert that no recompile happens on a
+        non-mutation call (kernel_cache unchanged) and that the fast
+        path is restored after the global is reverted.
+        """
+        _fast_launcher_add_one.reset()
+        self.addCleanup(_fast_launcher_add_one.reset)
+        x = torch.arange(16, device=DEVICE, dtype=torch.float32)
+
+        torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+        jit_fn = _get_jit_function(_fast_launcher_add_one)
+        (name, _gid), (compile_value, gdict) = next(
+            iter(jit_fn.used_global_vals.items())  # pyrefly: ignore[missing-attribute]
+        )
+        dev = driver.active.get_current_device()
+        kernel_cache = jit_fn.device_caches[dev][0]  # pyrefly: ignore[missing-attribute]
+
+        # No-mutation call: cache unchanged (proves no false-positive
+        # fallback / recompile despite ``used_global_vals`` being
+        # non-empty).
+        cache_size = len(kernel_cache)
+        torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+        self.assertEqual(len(kernel_cache), cache_size)
+
+        # Mutation: hot path's per-entry equality check detects the
+        # change, falls back to ``default_launcher`` -> ``JITFunction.run``
+        # which raises rather than silently using the stale binary.
+        # Register restore via addCleanup so a mid-test crash cannot
+        # leave the global mutated.
+        import triton.language as tl
+
+        self.addCleanup(gdict.__setitem__, name, compile_value)
+        gdict[name] = tl.constexpr(8)
+        with self.assertRaises(RuntimeError):
+            _fast_launcher_add_one(x)
+        gdict[name] = compile_value
+
+        # Restore: fast path is usable again; still no recompile.
+        cache_size = len(kernel_cache)
+        torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+        self.assertEqual(len(kernel_cache), cache_size)
+
+    @skipIfNotCUDA()
+    def test_knobs_runtime_debug_set_after_priming_compiles_new_binary_on_real_kernel(
+        self,
+    ) -> None:
+        """Enabling ``knobs.runtime.debug`` mid-run must trigger Triton recompile.
+
+        ``JITFunction.run`` ORs ``knobs.runtime.debug`` into the per-call
+        ``debug`` kwarg, which becomes part of Triton's cache key.
+        Setting ``debug=True`` after priming needs a different compiled
+        binary than the one we primed with. The fast launcher's hot
+        path inspects the knob per call and falls back when set; this
+        gives ``JITFunction.run`` the chance to compile and cache the
+        debug binary. We assert the kernel_cache grew end-to-end.
+        """
+        _fast_launcher_add_one.reset()
+        self.addCleanup(_fast_launcher_add_one.reset)
+        x = torch.arange(16, device=DEVICE, dtype=torch.float32)
+        old_debug = triton.knobs.runtime.debug
+        self.addCleanup(lambda: setattr(triton.knobs.runtime, "debug", old_debug))
+        triton.knobs.runtime.debug = False
+
+        torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+        jit_fn = _get_jit_function(_fast_launcher_add_one)
+        dev = driver.active.get_current_device()
+        kernel_cache = jit_fn.device_caches[dev][0]  # pyrefly: ignore[missing-attribute]
+        cache_size = len(kernel_cache)
+
+        triton.knobs.runtime.debug = True
+        torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+        self.assertGreater(len(kernel_cache), cache_size)
+
+    @skipIfNotCUDA()
+    def test_launch_hooks_installed_after_priming_fire_on_real_kernel(
+        self,
+    ) -> None:
+        """``launch_enter_hook`` / ``launch_exit_hook`` installed after priming must fire.
+
+        The Triton C launcher invokes both hooks with a ``launch_metadata``
+        argument. The fast launcher used to snapshot the hook references
+        at priming, so profilers attaching afterwards were silently
+        dropped. The hot path now re-reads them from
+        ``triton.knobs.runtime`` per call — we assert the hooks fire on
+        a real kernel here.
+        """
+        _fast_launcher_add_one.reset()
+        self.addCleanup(_fast_launcher_add_one.reset)
+        x = torch.arange(16, device=DEVICE, dtype=torch.float32)
+        old_enter = triton.knobs.runtime.launch_enter_hook
+        old_exit = triton.knobs.runtime.launch_exit_hook
+
+        def restore_launch_hooks() -> None:
+            triton.knobs.runtime.launch_enter_hook = old_enter
+            triton.knobs.runtime.launch_exit_hook = old_exit
+
+        self.addCleanup(restore_launch_hooks)
+        triton.knobs.runtime.launch_enter_hook = None
+        triton.knobs.runtime.launch_exit_hook = None
+
+        torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+        enter_md: list[object] = []
+        exit_md: list[object] = []
+        triton.knobs.runtime.launch_enter_hook = lambda md: enter_md.append(md)
+        triton.knobs.runtime.launch_exit_hook = lambda md: exit_md.append(md)
+        torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+        self.assertEqual(len(enter_md), 1)
+        self.assertEqual(len(exit_md), 1)
+
+    @skipIfNotCUDA()
+    def test_unaligned_call_after_aligned_priming_matches_reference(self) -> None:
+        """Aligned-then-unaligned call should still produce correct output.
+
+        Before the multi-spec design, the second call launched the
+        binary compiled for the aligned spec (vectorized 16-byte loads)
+        and tripped ``CUDA error: misaligned address``. The multi-spec
+        :class:`_FastLauncher` keys its ``_spec_cache`` on the
+        alignment bitmask, so aligned and unaligned land on separate
+        cache entries and each gets its own correctly-compiled binary.
+        """
+        _fast_launcher_add_vectorized.reset()
+        n = 1024
+        base = torch.randn(n + 4, device=DEVICE, dtype=torch.float32)
+        aligned = base[:n]
+        unaligned = base[1 : n + 1]
+
+        torch.testing.assert_close(
+            _fast_launcher_add_vectorized(aligned, aligned), aligned + aligned
+        )
+        torch.testing.assert_close(
+            _fast_launcher_add_vectorized(unaligned, unaligned), unaligned + unaligned
+        )
+
+    @skipIfNotCUDA()
+    def test_alternating_specs_both_take_fast_path(self) -> None:
+        """Two different alignment specs should each land on the fast path.
+
+        The multi-spec ``_FastLauncher`` caches one compiled binary per
+        spec key (alignment + knob state), so a call site that
+        alternates between aligned and unaligned tensors has BOTH
+        binaries in ``_spec_cache`` after the first call of each. Every
+        subsequent call hits the cache and uses the fast path; there is
+        no fallback to ``default_launcher`` for either spec.
+
+        This is the user-visible win over the single-spec design: a
+        legitimately multi-spec call site no longer pays the
+        ``default_launcher`` Python-overhead penalty on every other call.
+        """
+        _fast_launcher_add_vectorized.reset()
+        n = 1024
+        base = torch.randn(n + 4, device=DEVICE, dtype=torch.float32)
+        aligned = base[:n]
+        unaligned = base[1 : n + 1]
+
+        # First call of each spec → cache miss → compile → cache hit
+        torch.testing.assert_close(
+            _fast_launcher_add_vectorized(aligned, aligned), aligned + aligned
+        )
+        torch.testing.assert_close(
+            _fast_launcher_add_vectorized(unaligned, unaligned),
+            unaligned + unaligned,
+        )
+
+        bound = _fast_launcher_add_vectorized.bind((aligned, aligned))
+        launcher = bound._run.__kwdefaults__.get("_launcher")
+        self.assertIsInstance(launcher, _FastLauncher)
+        self.assertEqual(len(launcher._spec_cache), 2)
+
+        # Alternating calls — each spec hits its own cache entry; cache
+        # size stays at 2.
+        for _ in range(3):
+            torch.testing.assert_close(
+                _fast_launcher_add_vectorized(aligned, aligned), aligned + aligned
+            )
+            torch.testing.assert_close(
+                _fast_launcher_add_vectorized(unaligned, unaligned),
+                unaligned + unaligned,
+            )
+        self.assertEqual(len(launcher._spec_cache), 2)
+
+    @skipIfNotCUDA()
+    def test_skip_fast_launcher_env_var_disables_install(self) -> None:
+        """``HELION_SKIP_FAST_LAUNCHER=1`` should bypass the fast launcher.
+
+        Useful as a quick escape hatch when debugging: every Helion
+        call routes through ``default_launcher`` (Triton's
+        ``JITFunction.run``) and the per-spec cache layer is never
+        installed. We verify the kwdefault on the generated wrapper
+        is the plain ``default_launcher`` function, not a
+        ``_FastLauncher`` instance.
+        """
+        import os
+
+        _fast_launcher_add_one.reset()
+        self.addCleanup(_fast_launcher_add_one.reset)
+        old = os.environ.get("HELION_SKIP_FAST_LAUNCHER")
+        self.addCleanup(
+            lambda: (
+                os.environ.__setitem__("HELION_SKIP_FAST_LAUNCHER", old)
+                if old is not None
+                else os.environ.pop("HELION_SKIP_FAST_LAUNCHER", None)
+            )
+        )
+        os.environ["HELION_SKIP_FAST_LAUNCHER"] = "1"
+
+        x = torch.arange(16, device=DEVICE, dtype=torch.float32)
+        torch.testing.assert_close(_fast_launcher_add_one(x), x + 1)
+
+        bound = next(iter(_fast_launcher_add_one._bound_kernels.values()))
+        launcher = bound._run.__kwdefaults__.get("_launcher")
+        self.assertNotIsInstance(launcher, _FastLauncher)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_tensor_key_fast_path.py
+++ b/test/test_tensor_key_fast_path.py
@@ -1,0 +1,145 @@
+"""Tests for the ``_concrete_tensor_key`` specialization-key fast path.
+
+``torch.Tensor`` and ``torch.nn.Parameter`` are dispatched (by exact type)
+to ``_concrete_tensor_key``, which uses ``tensor.size()`` / ``tensor.stride()``
+directly instead of the ``_hashable_dims`` SymInt-normalization wrap that
+``_tensor_key`` applies. Anything that can carry a SymInt -- ``FakeTensor``
+and ``torch.Tensor`` *subclasses* reached via the ``isinstance`` fallback --
+still goes through ``_tensor_key``.
+
+These tests pin down:
+1. The fast-path key hashes and compares equal to the wrapped key, so
+   existing BoundKernel / on-disk caches don't silently miss.
+2. The dispatch table routes concrete tensors, FakeTensors, and the
+   subclass-fallback to the right extractor.
+3. Tensor subclasses take the SymInt-safe path without error.
+4. ``bind()`` still caches/distinguishes correctly across dtype and shape.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+import helion
+from helion._testing import DEVICE
+import helion.language as hl
+from helion.runtime.kernel import _concrete_tensor_key
+from helion.runtime.kernel import _specialization_extractors
+from helion.runtime.kernel import _tensor_key
+
+
+@helion.kernel(static_shapes=True)
+def _vector_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size(0)):
+        out[tile] = x[tile] + y[tile]
+    return out
+
+
+@helion.kernel(static_shapes=False)
+def _vector_add_dynamic(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size(0)):
+        out[tile] = x[tile] + y[tile]
+    return out
+
+
+class TestTensorKeyFastPath(unittest.TestCase):
+    def test_dispatch_routes_concrete_tensor_to_fast_path(self) -> None:
+        """``torch.Tensor`` / ``torch.nn.Parameter`` dispatch to the fast
+        extractor; ``FakeTensor`` and the subclass fallback keep the
+        SymInt-safe ``_tensor_key``."""
+        from torch._subclasses.fake_tensor import FakeTensor
+
+        self.assertIs(_specialization_extractors[torch.Tensor], _concrete_tensor_key)
+        self.assertIs(
+            _specialization_extractors[torch.nn.Parameter], _concrete_tensor_key
+        )
+        self.assertIs(_specialization_extractors[FakeTensor], _tensor_key)
+        # The fallback for torch.Tensor subclasses is registered under a
+        # string key so the dispatch site stays loosely typed.
+        self.assertIs(_specialization_extractors["tensor_subclass"], _tensor_key)
+
+    def test_fast_path_key_hash_matches_wrapped_static_shapes(self) -> None:
+        """Fast-path key must hash and compare identically to the wrapped
+        key under static_shapes=True; otherwise cache entries created under
+        one path silently miss under the other."""
+        x = torch.empty(4096, dtype=torch.float32)
+        fast = _concrete_tensor_key(_vector_add, x)
+        wrapped = _tensor_key(_vector_add, x)
+        self.assertEqual(hash(fast), hash(wrapped))
+        self.assertEqual(fast, wrapped)
+
+    def test_fast_path_key_hash_matches_wrapped_dynamic_shapes(self) -> None:
+        """Equivalence must also hold on the dynamic-shape (bucketed) path,
+        where the key carries the int32/int64 index-width bit."""
+        x = torch.empty(4096, dtype=torch.float32)
+        fast = _concrete_tensor_key(_vector_add_dynamic, x)
+        wrapped = _tensor_key(_vector_add_dynamic, x)
+        self.assertEqual(hash(fast), hash(wrapped))
+        self.assertEqual(fast, wrapped)
+
+    def test_fast_path_key_matches_wrapped_for_strided_tensor(self) -> None:
+        """A non-contiguous (transposed) tensor exercises the stride
+        component; the fast and wrapped keys must still agree."""
+        x = torch.empty(8, 16, dtype=torch.float32).transpose(0, 1)
+        self.assertFalse(x.is_contiguous())
+        fast = _concrete_tensor_key(_vector_add, x)
+        wrapped = _tensor_key(_vector_add, x)
+        self.assertEqual(hash(fast), hash(wrapped))
+        self.assertEqual(fast, wrapped)
+
+    def test_fast_path_uses_unwrapped_size_under_static_shapes(self) -> None:
+        """The size component is the raw ``torch.Size`` (the wrapped form is
+        always a plain tuple), confirming the fast path actually skips
+        ``_hashable_dims``."""
+        x = torch.empty(4096, dtype=torch.float32)
+        key = _concrete_tensor_key(_vector_add, x)
+        assert isinstance(key, tuple)
+        self.assertIs(type(key[1]), torch.Size)
+        self.assertEqual(tuple(key[1]), (4096,))
+        self.assertEqual(key[2], (1,))
+
+    def test_subclass_routes_to_symint_safe_extractor(self) -> None:
+        """A ``torch.Tensor`` subclass misses the exact-type dict and takes
+        the ``isinstance`` fallback -> ``_tensor_key`` (not the fast path).
+        The computed key must match the fast path for the same shape so a
+        subclass and a plain tensor share a BoundKernel."""
+
+        class MyTensor(torch.Tensor):
+            pass
+
+        base = torch.empty(64, dtype=torch.float32)
+        sub = base.as_subclass(MyTensor)
+        self.assertIsNot(type(sub), torch.Tensor)
+        # Goes through Kernel._specialization_key's isinstance fallback.
+        sub_key = _vector_add._specialization_key(sub)
+        plain_key = _vector_add._specialization_key(base)
+        self.assertEqual(sub_key, plain_key)
+        self.assertEqual(hash(sub_key), hash(plain_key))
+
+    def test_bind_caches_across_tensors_with_same_spec(self) -> None:
+        """``bind()`` reuses one BoundKernel for distinct tensor objects of
+        the same dtype/shape/stride."""
+        x1 = torch.randn(64, device=DEVICE)
+        y1 = torch.randn(64, device=DEVICE)
+        x2 = torch.randn(64, device=DEVICE)
+        y2 = torch.randn(64, device=DEVICE)
+        self.assertIs(_vector_add.bind((x1, y1)), _vector_add.bind((x2, y2)))
+
+    def test_bind_distinguishes_dtype_and_shape(self) -> None:
+        x_f32 = torch.randn(64, dtype=torch.float32, device=DEVICE)
+        x_f64 = torch.randn(64, dtype=torch.float64, device=DEVICE)
+        x_big = torch.randn(128, dtype=torch.float32, device=DEVICE)
+        self.assertIsNot(
+            _vector_add.bind((x_f32, x_f32)), _vector_add.bind((x_f64, x_f64))
+        )
+        self.assertIsNot(
+            _vector_add.bind((x_f32, x_f32)), _vector_add.bind((x_big, x_big))
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked PRs:
 * __->__#2756
 * #2755
 * #2754
 * #2742
 * #2741
 * #2740
 * #2739
 * #2736


--- --- ---

### [cute] Record measured-good B200 config for the fp8 scaled_mm example


Adds FP8_MATMUL_CUTE_B200_CONFIG to examples/fp8_matmul.py: the validated
CtaGroup.TWO config for the fused rowwise-scale fp8 GEMM on the CuTe
backend, tuned at 4096x4096x4096 fp8 e4m3 -> bf16 on B200.

Key choices (each measured):
  * block_sizes=[256, 128, 128] - bk=128 matches CUTLASS's fp8 K tile
    (4 x MMA-K of 32). bk=64 doubles TMA transactions and mbarrier phases
    per FLOP and leaves the single MMA warp issuing only ~52% of cycles:
    1711 vs 2422 peak TFLOP/s.
  * tcgen05_ab_stages=8 - 1-byte fp8 operands fit a deeper AB SMEM ring
    than bf16's tuned ab=3; the deep pipeline hides K-loop latency.
  * tcgen05_cluster_m=2 + persistent_blocked + static_persistent - the
    validated 2-CTA persistent envelope.
  * tensor_descriptor indexing on the two scale operands feeds the fused
    rowwise-scale epilogue's aux path.

Measured at 4096^3 with this config: ~2100-2280 TFLOP/s (do_bench, run to
run), device time ~52.6 us, relerr 0.0000 vs torch._scaled_mm. For
reference: torch._scaled_mm ~1860 TFLOP/s, hand-written CuTe DSL kernel
~2330 TFLOP/s at the same shape.

Recorded as a module-level constant rather than pinned on the kernel
decorator because the tcgen05_* keys are CuTe-only - the Triton backend
raises InvalidConfig on them - and the example/tritonbench wrapper is
backend-neutral.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>