### PR TITLE
[triton] Simplify floordiv/remainder for non-negative tile indicies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,7 @@ site
 tags
 TAGS
 torch
-triton
+/triton
 *.user
 uv.lock
 venv

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1245,9 +1245,9 @@ class TritonBackend(Backend):
         return f"triton.cdiv({numel}, {block_size})"
 
     def inductor_op_overrides(self) -> InductorOpOverrides:
-        from torch._inductor.codegen.triton import TritonOverrides
+        from .triton.overrides import HelionTritonOverrides
 
-        return TritonOverrides()
+        return HelionTritonOverrides()
 
     def grid_index_expr(
         self, offset_var: str, block_size_var: str, dtype: str, *, axis: int

--- a/helion/_compiler/triton/overrides.py
+++ b/helion/_compiler/triton/overrides.py
@@ -1,0 +1,141 @@
+"""HelionTritonOverrides -- subclass of Inductor's TritonOverrides."""
+
+from __future__ import annotations
+
+import torch
+from torch._inductor.codegen.triton import TritonOverrides
+from torch._inductor.virtualized import V
+
+from ...language._decorators import is_api_func
+
+# Tile API functions that always produce non-negative integer values.
+_NON_NEGATIVE_TILE_FUNCS = frozenset(
+    {
+        "tile_index",
+        "tile_begin",
+        "tile_end",
+        "tile_id",
+        "tile_count",
+        "tile_block_size",
+    }
+)
+
+
+def _is_provably_non_negative(
+    node: torch.fx.Node,
+    _visited: frozenset[torch.fx.Node] = frozenset(),
+) -> bool:
+    """Check if an FX node produces a provably non-negative integer value.
+
+    Recognized non-negative sources:
+    - Tile API calls (``tile_index``, ``tile_begin``, etc.): always >= 0
+    - ``prims.iota``: produces [0, 1, 2, ...]
+    - ``aten.div.Tensor_mode`` (floordiv) with non-negative dividend AND
+      positive divisor: result >= 0
+    - ``aten.remainder`` with non-negative dividend AND positive divisor:
+      result >= 0
+
+    Uses a visited set to guard against cycles in the FX graph.
+    """
+    if not isinstance(node, torch.fx.Node) or node.op != "call_function":
+        return False
+    if node in _visited:
+        return False
+    visited = _visited | {node}
+
+    target = node.target
+    name = getattr(target, "__name__", "")
+
+    # Tile API functions: offset + arange(0, BLOCK), always >= 0
+    if is_api_func(target) and name in _NON_NEGATIVE_TILE_FUNCS:
+        return True
+
+    # prims.iota (tl.arange): [0, 1, 2, ...]
+    if target is torch.ops.prims.iota.default:
+        return True
+
+    # floordiv / remainder: non-negative when dividend >= 0 AND divisor > 0
+    if target in (torch.ops.aten.div.Tensor_mode, torch.ops.aten.remainder.Scalar):
+        if len(node.args) >= 2:
+            dividend, divisor = node.args[0], node.args[1]
+            if (
+                isinstance(dividend, torch.fx.Node)
+                and _is_provably_non_negative(dividend, visited)
+                and _is_provably_positive_divisor(divisor)
+            ):
+                return True
+
+    return False
+
+
+def _is_provably_positive_divisor(node: object) -> bool:
+    """Check if a divisor operand is provably positive.
+
+    Recognizes:
+    - FX nodes whose ``meta["val"]`` is a ``SymInt`` (kernel size parameters
+      like ``M_cols``, ``KH * KW`` -- these represent dimensions and are
+      always positive)
+    - Positive integer constants
+    """
+    if isinstance(node, torch.fx.Node):
+        val = node.meta.get("val")
+        return isinstance(val, torch.SymInt)
+    if isinstance(node, int):
+        return node > 0
+    return False
+
+
+class HelionTritonOverrides(TritonOverrides):
+    """Helion Triton op overrides.
+
+    Inherits all expression generation from Inductor's TritonOverrides.
+    """
+
+    @staticmethod
+    def _can_simplify_div() -> bool:
+        """Check if the current floordiv/remainder can use simple ``//``/``%``.
+
+        Returns True when the dividend is provably non-negative (derived from
+        tile indices or prior non-negative arithmetic) AND the divisor is
+        provably positive (a SymInt size parameter or positive constant).
+
+        When both conditions hold, Triton's truncation ``//`` equals Python's
+        floor ``//``, and Triton's ``%`` equals Python's ``%``.
+        """
+        node = V.current_node
+        if node is None or len(node.args) < 2:
+            return False
+        val = node.meta.get("val")
+        if not isinstance(val, torch.Tensor) or val.dtype.is_floating_point:
+            return False
+        dividend, divisor = node.args[0], node.args[1]
+        return (
+            isinstance(dividend, torch.fx.Node)
+            and _is_provably_non_negative(dividend)
+            and _is_provably_positive_divisor(divisor)
+        )
+
+    @staticmethod
+    def floordiv(a: str, b: str) -> str:
+        """Simplified floor division for non-negative integer operands.
+
+        Triton's ``//`` is truncation division, which equals floor division
+        when both operands are non-negative.  Emits ``a // b`` directly
+        instead of Inductor's defensive sequence that handles negative
+        operands and division-by-zero.
+        """
+        if HelionTritonOverrides._can_simplify_div():
+            return f"{a} // {b}"
+        return TritonOverrides.floordiv(a, b)
+
+    @staticmethod
+    def remainder(a: str, b: str) -> str:
+        """Simplified remainder for non-negative integer operands.
+
+        For non-negative operands, Triton's ``%`` matches Python's ``%``.
+        Emits ``a % b`` directly instead of Inductor's defensive sequence
+        that handles negative operands.
+        """
+        if HelionTritonOverrides._can_simplify_div():
+            return f"{a} % {b}"
+        return TritonOverrides.remainder(a, b)

--- a/test/test_triton_overrides.py
+++ b/test/test_triton_overrides.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import torch
+
+import helion
+from helion._testing import DEVICE
+from helion._testing import TestCase
+from helion._testing import onlyBackends
+from helion._testing import skipIfRefEager
+import helion.language as hl
+
+
+@onlyBackends(["triton"])
+class TestTritonDivisionSimplification(TestCase):
+    @skipIfRefEager("to_triton_code() requires compilation")
+    def test_tile_index_divmod_simplified(self):
+
+        @helion.kernel(
+            config=helion.Config(block_sizes=[32, 32, 32], num_warps=4),
+            static_shapes=True,
+        )
+        def gather_kernel(
+            x: torch.Tensor,
+            w: torch.Tensor,
+            out: torch.Tensor,
+            M_cols: int,
+            K_b: int,
+        ) -> None:
+            M, N = out.size()
+            K = w.size(0)
+            for tile_m, tile_n in hl.tile([M, N]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(K):
+                    row = tile_m.index // M_cols
+                    a = tile_k.index // K_b
+                    b = tile_k.index % K_b
+                    flat_idx = row[:, None] * K + a[None, :] * K_b + b[None, :]
+                    a_tile = hl.load(x, [flat_idx])
+                    acc = torch.addmm(acc, a_tile, w[tile_k, tile_n])
+                out[tile_m, tile_n] = acc
+
+        M_rows, M_cols, K_a, K_b, N = 16, 16, 4, 8, 32
+        M, K = M_rows * M_cols, K_a * K_b
+
+        x = torch.randn(M_rows * K, device=DEVICE)
+        w = torch.randn(K, N, device=DEVICE)
+        out = torch.empty(M, N, device=DEVICE)
+
+        bound = gather_kernel.bind((x, w, out, M_cols, K_b))
+        code = bound.to_triton_code()
+
+        self.assertIn(" // ", code)
+        self.assertIn(" % ", code)
+        self.assertNotIn("signbit", code)
+        self.assertNotIn("bitwise_not", code)
+
+        gather_kernel(x, w, out, M_cols, K_b)
+        x_2d = x.view(M_rows, K)
+        idx = torch.arange(M, device=DEVICE)
+        rows = idx // M_cols
+        expected = x_2d[rows] @ w
+        torch.testing.assert_close(out, expected, rtol=1e-2, atol=1e-2)
+
+    @skipIfRefEager("to_triton_code() requires compilation")
+    def test_chained_divmod_simplified(self):
+
+        @helion.kernel(
+            config=helion.Config(block_sizes=[32], num_warps=4),
+            static_shapes=True,
+        )
+        def decompose_kernel(
+            out_row: torch.Tensor,
+            out_col: torch.Tensor,
+            W_out: int,
+        ) -> None:
+            (N,) = out_row.size()
+            for tile in hl.tile(N):
+                idx = tile.index
+                row = idx // W_out
+                col = idx % W_out
+                out_row[tile] = row
+                out_col[tile] = col
+
+        H_out_val = 8
+        W_out_val = 4
+        total = H_out_val * W_out_val
+
+        out_row = torch.empty(total, device=DEVICE, dtype=torch.int32)
+        out_col = torch.empty(total, device=DEVICE, dtype=torch.int32)
+
+        bound = decompose_kernel.bind((out_row, out_col, W_out_val))
+        code = bound.to_triton_code()
+
+        self.assertIn(" // ", code)
+        self.assertIn(" % ", code)
+        self.assertNotIn("signbit", code)
+
+        decompose_kernel(out_row, out_col, W_out_val)
+        expected_row = torch.arange(total, device=DEVICE) // W_out_val
+        expected_col = torch.arange(total, device=DEVICE) % W_out_val
+        torch.testing.assert_close(out_row, expected_row.to(torch.int32))
+        torch.testing.assert_close(out_col, expected_col.to(torch.int32))


### PR DESCRIPTION
Improve latency by emitting plain `a // b` or `a % b` for non-negative tile indices instead of Inductor's defensive sequence to handle negative cases. 