### PR TITLE
[examples] Correctness fixes to reduction example kernels for the seed-heuristic curriculum

### DIFF
--- a/examples/jsd.py
+++ b/examples/jsd.py
@@ -67,6 +67,9 @@ def jsd_forward(
     Returns:
         loss: Scalar JSD loss
         dX: Gradient of loss wrt input
+
+    Precision note: use bf16 or fp32, NOT fp16, at realistic vocabularies — fp16 underflows
+    the ~1/V probabilities to 0, so log(M) = -inf and the row goes NaN.
     """
     BT, V = _input.shape
     assert target.shape == _input.shape, (
@@ -99,7 +102,10 @@ def jsd_forward(
                     dX[tile_bt, tile_X] = 0.0
                 continue
         intermediate_loss = hl.zeros([tile_bt, block_size_n], dtype=torch.float32)
-        intermediate_dX = hl.zeros([tile_bt, block_size_n], dtype=_input.dtype)
+        # Accumulate dX in fp32. The beta==1 branch adds the fp32 `intermediate_loss` into
+        # dX, so an _input.dtype (bf16/fp16) accumulator would mismatch the carried value at
+        # the branch merge (type propagation visits every beta branch). No-op at fp32.
+        intermediate_dX = hl.zeros([tile_bt, block_size_n], dtype=torch.float32)
         for tile_v in hl.tile(V, block_size=block_size_n):
             # Load log probabilities and convert to float32
             X = _input[tile_bt, tile_v]

--- a/examples/kl_div.py
+++ b/examples/kl_div.py
@@ -70,6 +70,9 @@ def kl_div_forward(
 
     Returns:
         loss: KL divergence loss
+
+    Precision note: use bf16 or fp32, NOT fp16, at realistic vocabularies — the ~1/V target
+    probabilities underflow fp16 to 0 for V >= ~30k, so log(0) = -inf and the row goes NaN.
     """
     BT, V = y_pred.shape
     assert y_true.shape == y_pred.shape, (

--- a/examples/welford.py
+++ b/examples/welford.py
@@ -49,7 +49,10 @@ def welford(
 
         for tile_n in hl.tile(n):
             chunk = x[tile_m, tile_n]
-            Tn = chunk.size(-1)
+            # Count of VALID columns (the divisor): use the true valid count, not the constexpr
+            # tile width (over-counts last-tile padding). Cast the mask to int32 BEFORE summing —
+            # a bool operand gives CuTe a saturating accumulator (-> NaN).
+            Tn = (tile_n.index < n).to(torch.int32).sum()
             sum_x = torch.sum(chunk, dim=-1)
             sum_x2 = torch.sum(chunk * chunk, dim=-1)
             mean_c = sum_x / Tn


### PR DESCRIPTION
Stacked PRs:
 * #2762
 * #2761
 * __->__#2760


--- --- ---

### [examples] Correctness fixes to reduction example kernels for the seed-heuristic curriculum


- jsd: declare the dX accumulator fp32 to fix a bf16/fp16 ControlFlowTensorMismatch.
  dX was _input.dtype, but the beta==1 branch folds the fp32 intermediate_loss into it,
  so the carried dtype mismatches at the branch merge (type propagation visits every
  beta branch). True no-op at fp32.
- welford: use the true valid-column count for the divisor instead of the constexpr tile
  width (which over-counts last-tile padding) -- fixes wrong results at non-divisor N.
- jsd / kl_div: document the fp16 wide-V NaN (out of scope; not fixed here).

The new sibling/probe kernels (argmax, groupnorm, l2_norm, log_softmax, logsumexp,
row_max) are intentionally excluded from this PR and kept on the lab branch for a later
standalone PR.