### PR TITLE
[autotuner] Reduction fact layer: ReductionFact + AccumulatorFact + enriched MemoryOpFact

### DIFF
--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -31,6 +31,7 @@ from .. import Config
 from .. import exc
 from .. import language as hl
 from ..autotuner.config_spec import CuteVectorWidthSpec
+from ..autotuner.config_spec import ReductionFact
 from ..autotuner.config_spec import ReductionLoopSpec
 from ..language import _tracing_ops
 from ..language._decorators import args_to_proxies
@@ -77,7 +78,9 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
     from collections.abc import Sequence
 
+    from ..autotuner.config_spec import AccumulatorFact
     from ..autotuner.config_spec import MemoryOpFact
+    from .compile_environment import BlockSizeInfo
     from .cute.layout import CuTeGridExecutionPlan
 
     class _TLS(Protocol):
@@ -643,18 +646,74 @@ def _fx_trace_tensor_arg_rw_names(
     return out2
 
 
+def _classify_load_dataflow(
+    load_node: torch.fx.Node, redset: set[int], env: CompileEnvironment
+) -> tuple[set[int], tuple[tuple[int | None, ...], ...]]:
+    """Trace a load's value forward over ``node.users``, cutting at BOTH reductions and
+    stores, and record the sinks it reaches:
+
+    - ``reductions_fed``: the ``redset`` reduction ids the value flows into (recorded,
+      not traversed through — we want where the row goes, not the reduced result).
+    - ``stores_fed``: the stores the value reaches WITHOUT passing through a reduction,
+      each keyed by the store's full subscript-axis tuple (``store[tile_m, tile_n]`` ->
+      ``(id_m, id_n)``). A non-empty set means the row is live across the reduction.
+    """
+    from ..language.memory_ops import store as _store_op
+
+    reductions_fed: set[int] = set()
+    stores_fed: set[tuple[int | None, ...]] = set()
+    seen: set[int] = set()
+    stack = list(load_node.users)
+    while stack:
+        u = stack.pop()
+        if id(u) in redset:
+            reductions_fed.add(id(u))
+            continue  # do not traverse THROUGH the reduction
+        if id(u) in seen:
+            continue
+        seen.add(id(u))
+        if u.op == "call_function" and u.target is _store_op:
+            stores_fed.add(_store_axis_key(env, u))
+            continue  # do not traverse THROUGH the store
+        stack.extend(u.users)
+    # deterministic order (None sorts low); only non-emptiness is consumed today
+    stores_sorted = tuple(
+        sorted(stores_fed, key=lambda t: tuple(-1 if b is None else b for b in t))
+    )
+    return reductions_fed, stores_sorted
+
+
+def _store_axis_key(
+    env: CompileEnvironment, store_node: torch.fx.Node
+) -> tuple[int | None, ...]:
+    """Full subscript-axis key of a store: the block-id each non-bare-int subscript indexes
+    (the faithful subscript provenance, falling back to the shape-resolved id for a plain-slice
+    subscript), one entry per dim. E.g. ``store[tile_m, tile_n]`` -> ``(id_m, id_n)``;
+    ``out[tile_m, :]`` -> ``(id_m, <shape-resolved id>)``."""
+    fake = _accessed_tensor_fake(store_node)
+    index_list = store_node.args[1] if len(store_node.args) >= 2 else None
+    if fake is None or not isinstance(index_list, (list, tuple)):
+        return ()
+    key: list[int | None] = []
+    for pos, sub in enumerate(index_list):
+        if isinstance(sub, int) or pos >= fake.ndim:
+            continue
+        bid = _subscript_block_id(env, sub)
+        if bid is None:
+            bid = env.resolve_block_id(fake.shape[pos])
+        key.append(bid)
+    return tuple(key)
+
+
 def _reduction_fx_inter_loop_rw_names(
     graph: torch.fx.Graph,
     host: HostFunction,
 ) -> tuple[frozenset[str], frozenset[str]]:
     """Infer host buffer names read/written in a rolled reduction FX subgraph.
 
-    Walks every hl.load / hl.store / atomic_* node in ``graph`` and resolves
-    its tensor argument back to host-named buffers via
-    :func:`_fx_trace_tensor_arg_rw_names`.  Buffers that don't resolve to a
-    host name are device-internal temporaries and don't participate in
-    cross-wavefront global coherence, so they're correctly excluded from the
-    returned sets.
+    Resolves every hl.load / hl.store / atomic_* tensor arg back to host-named buffers.
+    Args not resolving to a host name are device-internal temporaries (no cross-wavefront
+    coherence) and are excluded.
     """
     from ..language import atomic_add
     from ..language import atomic_and
@@ -710,6 +769,12 @@ class DeviceIR:
         self.rolled_reductions: list[RolledReductionInfo] = []
         self.phases: list[KernelPhase] = []
         self.grid_block_ids: list[list[int]] = []
+        # Owning HostFunction (captured in ``lower_to_device_ir``).
+        self.host_function: HostFunction | None = None
+        # Phase-1 stash: each rollable (standard) rdim + the graph ids using it. The
+        # ReductionFact is built later in ``build_reduction_facts`` (after
+        # ``_collect_memory_op_facts``) so it can read the enriched ``memory_op_facts``.
+        self._rollable_reduction_records: list[tuple[BlockSizeInfo, set[int]]] = []
 
     def __str__(self) -> str:
         return "\n\n".join(map(str, self.graphs))
@@ -913,6 +978,8 @@ class DeviceIR:
                         size_hint=rdim.size_hint(),
                     )
                 )
+                # Stash (rdim, used_graphs) for build_reduction_facts (see the field def).
+                self._rollable_reduction_records.append((rdim, used_graphs))
                 if env.backend_name == "cute":
                     env.config_spec.cute_vector_widths.append(
                         CuteVectorWidthSpec(
@@ -988,6 +1055,325 @@ class DeviceIR:
                     size_hint=size_hint_val,
                 )
             )
+
+    def register_user_tiled_reductions(
+        self,
+        memory_op_facts: list[MemoryOpFact],
+        accumulator_facts: list[AccumulatorFact],
+    ) -> None:
+        """Register a ReductionFact for a user-tiled inner reduction.
+
+        user-tiled = a hand-written nested ``hl.tile`` over the reduction axis: no
+        ``reduction=True`` block, so both axes are ordinary ``block_sizes`` entries.
+        Caller-guarded (``if not reduction_loops``) so standard vs user-tiled are mutually
+        exclusive. Finds the axis by collecting every ``ReductionLowering.block_index`` and
+        dropping the grid axes (so a dead ``amax(dim=0)`` over the grid tile is ignored);
+        registers only if exactly one inner axis survives.
+
+        Built in Phase 3 (after ``_collect_memory_op_facts``), so the per-op-dataflow
+        fields are derived from ``memory_op_facts``/``accumulator_facts``.
+        """
+        from .inductor_lowering import ReductionLowering
+
+        env = CompileEnvironment.current()
+        spec = env.config_spec
+        # A matmul kernel is out of scope (its carried 2D accumulators have a static
+        # int last-dim the reduction-axis walk does not expect). Decline before walking.
+        if spec.matmul_facts:
+            return
+        grid_ids = {b for bids in self.grid_block_ids for b in bids}
+
+        red_block_ids: set[int] = set()
+        for graph_info in self.graphs:
+            for node in graph_info.graph.nodes:
+                lowering = node.meta.get("lowering")
+                if isinstance(lowering, ReductionLowering):
+                    bid = getattr(lowering, "block_index", None)
+                    if bid is not None:
+                        red_block_ids.add(bid)
+        # Drop the grid axis (a dead reduction over the grid/M tile, etc.).
+        inner_red = [b for b in red_block_ids if b not in grid_ids]
+        if len(inner_red) != 1:
+            return
+        red_block_id = inner_red[0]
+        # The reduction axis must be a user tile in the block_sizes spec.
+        if red_block_id not in spec.block_sizes.valid_block_ids():
+            return
+        try:
+            block_info = env.block_sizes[red_block_id]
+        except (IndexError, KeyError):
+            return
+        # The reduction axis must have a resolvable extent: a dynamic/jagged dim has
+        # ``size=None``, for which the extent-keyed lever is undefined; decline there.
+        if not isinstance(block_info.size, (int, torch.SymInt)):
+            return
+
+        # Additional non-grid, non-reduction tile loop(s) (beyond the reduction axis).
+        # Each must span the reduction extent with a resolvable static size, else
+        # ``all_qualified`` is False and the structured seed is undefined (decline).
+        non_reduction_loop_block_ids, all_qualified = (
+            self._non_reduction_loop_candidates(red_block_id, grid_ids)
+        )
+        if not all_qualified:
+            return
+
+        # The kept (non-reduction) axes are the grid block_ids — the "rows".
+        m_block_ids = tuple(sorted(grid_ids))
+        size_hint = block_info.size_hint()
+        static_rnumel = block_info.size if isinstance(block_info.size, int) else None
+        # user-tiled digests over ALL device graphs (the manual inner loop body lives in
+        # the main device graph, not a roller subgraph), so num_load scopes to every
+        # graph_id.
+        all_graph_ids = set(range(len(self.graphs)))
+        spec.reduction_facts.append(
+            self._assemble_reduction_fact(
+                red_block_id,
+                size_hint,
+                static_rnumel,
+                m_block_ids,
+                non_reduction_loop_block_ids,
+                all_graph_ids,
+                memory_op_facts,
+                accumulator_facts,
+            )
+        )
+
+    def build_reduction_facts(self, memory_op_facts: list[MemoryOpFact]) -> None:
+        """Phase 3: build the ``ReductionFact``s now that ``_collect_memory_op_facts`` has
+        produced the enriched ``memory_op_facts``.
+
+        Reads the already-built ``spec.accumulator_facts``, then builds each stashed
+        standard fact, then — only when no standard rollable reduction was registered —
+        the user-tiled fact.
+        """
+        env = CompileEnvironment.current()
+        spec = env.config_spec
+        accumulator_facts = spec.accumulator_facts
+        # standard (rollable): one fact per stashed (rdim, used_graphs). num_load scopes
+        # to the rdim's ORIGINAL graphs (used_graphs), so the rolled-subgraph copies of a
+        # standard rdim load are not double-counted (device_ir.graphs is a superset of any
+        # one config's graphs).
+        for rdim, used_graphs in self._rollable_reduction_records:
+            grid_ids = {b for bids in self.grid_block_ids for b in bids}
+            m_block_ids = tuple(sorted(grid_ids))
+            static_rnumel = rdim.size if isinstance(rdim.size, int) else None
+            non_reduction_loop_block_ids, _all_qualified = (
+                self._non_reduction_loop_candidates(rdim.block_id, grid_ids)
+            )
+            spec.reduction_facts.append(
+                self._assemble_reduction_fact(
+                    rdim.block_id,
+                    rdim.size_hint(),
+                    static_rnumel,
+                    m_block_ids,
+                    non_reduction_loop_block_ids,
+                    used_graphs,
+                    memory_op_facts,
+                    accumulator_facts,
+                )
+            )
+        # user-tiled: mutually exclusive with standard — only when no reduction_loops spec
+        # was registered.
+        if not spec.reduction_loops:
+            self.register_user_tiled_reductions(memory_op_facts, accumulator_facts)
+
+    def build_accumulator_facts(self) -> list[AccumulatorFact]:
+        """One ``AccumulatorFact`` per loop-carried tensor accumulator in any loop —
+        reduction-AGNOSTIC, so it is built independently of (and before) the reduction
+        facts: a standalone fact layer any heuristic can read off
+        ``ConfigSpec.accumulator_facts``. Run unconditionally (matmul/elementwise kernels
+        simply get a list with no rdim-shaped tile). ``ReductionLoopGraphInfo`` is a
+        ``ForLoopGraphInfo`` subclass, so this also reaches standard's rolled loops (whose
+        ``[M_BLOCK]`` scalar carry yields ``num_carried_2d_tiles == 0`` naturally). Must
+        run after the reduction rolling so the rolled subgraphs exist.
+        """
+        from ..autotuner.config_spec import AccumulatorFact
+
+        env = CompileEnvironment.current()
+        facts: list[AccumulatorFact] = []
+        for gi in self.graphs:
+            if not isinstance(gi, ForLoopGraphInfo):
+                continue
+            for outer_node in gi.node_args:
+                val = getattr(outer_node, "meta", {}).get("val")
+                if isinstance(val, torch.Tensor):
+                    facts.append(
+                        AccumulatorFact(
+                            dim_block_ids=tuple(
+                                env.resolve_block_id(s) for s in val.shape
+                            ),
+                            itemsize=val.element_size(),
+                        )
+                    )
+        return facts
+
+    def _reduction_input_itemsize(self, red_block_id: int) -> int:
+        """Element size (bytes) of the tensor reduced over ``red_block_id`` — read from the
+        reduction node's INPUT (not its ``meta['val']`` output, which may differ in dtype,
+        e.g. argmax). Helion fp32-promotes the norm/softmax family, so this is 4 at both
+        bf16 and fp32 there. All reductions over one rdim share an input element size (last
+        wins). The byte caps key on ``size_hint * itemsize``.
+        """
+        from .inductor_lowering import ReductionLowering
+
+        itemsize = 0
+        for graph_info in self.graphs:
+            for node in graph_info.graph.nodes:
+                lowering = node.meta.get("lowering")
+                if (
+                    isinstance(lowering, ReductionLowering)
+                    and getattr(lowering, "block_index", None) == red_block_id
+                ):
+                    for inp in node.all_input_nodes:
+                        in_val = inp.meta.get("val")
+                        if isinstance(in_val, torch.Tensor):
+                            itemsize = in_val.element_size()
+                            break
+        return itemsize
+
+    def _assemble_reduction_fact(
+        self,
+        red_block_id: int,
+        size_hint: int,
+        static_rnumel: int | None,
+        m_block_ids: tuple[int, ...],
+        non_reduction_loop_block_ids: tuple[int, ...],
+        load_graph_ids: set[int],
+        memory_op_facts: list[MemoryOpFact],
+        accumulator_facts: list[AccumulatorFact],
+    ) -> ReductionFact:
+        """Build one ``ReductionFact`` for axis ``red_block_id`` from the enriched
+        ``memory_op_facts`` + ``accumulator_facts`` (no bespoke graph walk). Shared by the
+        standard and user-tiled paths; only ``load_graph_ids`` differs (standard: the
+        rdim's original graphs; user-tiled: every graph).
+        """
+        # num_load: every load in the reduction's graphs (the stream-eviction == 1 gate).
+        # Scoped by graph_id so rolled-subgraph copies of a standard rdim load are excluded.
+        num_load = sum(
+            1
+            for f in memory_op_facts
+            if f.kind == "load" and f.graph_id in load_graph_ids
+        )
+        # num_carried_2d_tiles: carried [.., R_BLOCK] tiles whose last dim is the rdim
+        # (standard's [M_BLOCK] scalar carry -> 0).
+        num_carried_2d_tiles = sum(
+            1
+            for a in accumulator_facts
+            if len(a.dim_block_ids) >= 2 and a.dim_block_ids[-1] == red_block_id
+        )
+        # row_reread + reread_eviction_index: the FIRST load live across the reduction
+        # boundary (feeds >= 2 reductions on this axis, or one + a bypass store); the slot
+        # is read straight from MemoryOpFact (no per-config re-walk).
+        row_reread = False
+        reread_eviction_index: int | None = None
+        for f in memory_op_facts:
+            if f.kind != "load":
+                continue
+            cnt = next((c for ax, c in f.reductions_fed if ax == red_block_id), 0)
+            if cnt >= 2 or (cnt >= 1 and f.stores_fed):
+                row_reread = True
+                reread_eviction_index = f.eviction_index
+                break
+        # full_width_output: a rank>=2 store whose inner dim is the reduction-extent AXIS
+        # ({rdim} ∪ normalize loops), keyed on the store's inner SUBSCRIPT block-id
+        # (reduction-agnostic) or, for the standard ``out[tile_m, :]`` plain slice, the
+        # shape-resolved indexed_block_ids fallback. Match on axis, not size, so a
+        # non-reduction dim that merely equals the extent is not full-width.
+        extent_axes = {red_block_id, *non_reduction_loop_block_ids}
+        full_width_output = any(
+            f.kind == "store"
+            and f.ndim >= 2
+            and (
+                (f.subscript_block_ids and f.subscript_block_ids[-1] in extent_axes)
+                or (f.indexed_block_ids and f.indexed_block_ids[-1] in extent_axes)
+            )
+            for f in memory_op_facts
+        )
+        # input_load_itemsize: min element size over reduction-fed loads (the streamed
+        # row), with a Band-B fallback to rank>=2 row loads of the reduction extent.
+        fed_sizes = [
+            f.dtype.itemsize
+            for f in memory_op_facts
+            if f.kind == "load"
+            and f.dtype is not None
+            and any(ax == red_block_id for ax, _ in f.reductions_fed)
+        ]
+        if fed_sizes:
+            input_load_itemsize = min(fed_sizes)
+        else:
+            # Band-B fallback: rank>=2 row loads whose inner subscript IS the reduction
+            # AXIS (block-id). Needed because accumulator-carried reductions feed a loop
+            # `+=`, not a ReductionLowering, so the row load is invisible to reductions_fed
+            # (fed_sizes empty); this structural axis-match recovers it.
+            row_sizes = [
+                f.dtype.itemsize
+                for f in memory_op_facts
+                if f.kind == "load"
+                and f.dtype is not None
+                and (
+                    (
+                        f.subscript_block_ids
+                        and f.subscript_block_ids[-1] == red_block_id
+                    )
+                    or (f.indexed_block_ids and f.indexed_block_ids[-1] == red_block_id)
+                )
+            ]
+            input_load_itemsize = min(row_sizes) if row_sizes else 0
+
+        return ReductionFact(
+            block_id=red_block_id,
+            size_hint=size_hint,
+            m_block_ids=m_block_ids,
+            static_rnumel=static_rnumel,
+            itemsize=self._reduction_input_itemsize(red_block_id),
+            num_load=num_load,
+            num_carried_2d_tiles=num_carried_2d_tiles,
+            non_reduction_loop_block_ids=non_reduction_loop_block_ids,
+            row_reread=row_reread,
+            reread_eviction_index=reread_eviction_index,
+            full_width_output=full_width_output,
+            input_load_itemsize=input_load_itemsize,
+        )
+
+    def _non_reduction_loop_candidates(
+        self, red_block_id: int, grid_ids: set[int]
+    ) -> tuple[tuple[int, ...], bool]:
+        """Identify non-reduction loop tiles for ``red_block_id`` — non-grid
+        ``block_sizes`` loops that are NOT the reduction axis. Shared by the standard and
+        user-tiled fact builders.
+
+        Returns ``(qualifying, all_qualified)``: ``qualifying`` (block_sizes order) are the
+        candidate loops spanning the reduction extent with a resolvable static size — the
+        seed widens these to ``next_pow2`` of that extent. ``all_qualified`` is False iff
+        some candidate did NOT qualify (extent unresolvable or != the reduction extent),
+        where the structured seed is undefined so a caller must decline.
+        """
+        try:
+            red_info = CompileEnvironment.current().block_sizes[red_block_id]
+        except (IndexError, KeyError):
+            return (), True
+        if not isinstance(red_info.size, (int, torch.SymInt)):
+            return (), True
+        red_size_hint = red_info.size_hint()
+
+        env = CompileEnvironment.current()
+        qualifying: list[int] = []
+        all_qualified = True
+        for bid in env.config_spec.block_sizes.valid_block_ids():
+            if bid in grid_ids or bid == red_block_id:
+                continue
+            try:
+                info = env.block_sizes[bid]
+            except (IndexError, KeyError):
+                all_qualified = False
+                continue
+            if not isinstance(info.size, (int, torch.SymInt)) or (
+                info.size_hint() != red_size_hint
+            ):
+                all_qualified = False
+                continue
+            qualifying.append(bid)
+        return tuple(qualifying), all_qualified
 
     def build_codegen_graphs(self, config: Config) -> list[GraphInfo]:
         """Build and return graph copies with reduction rolling and epilogue subtiling applied.
@@ -2254,6 +2640,21 @@ def _accessed_tensor_fake(node: torch.fx.Node) -> torch.Tensor | None:
     return None
 
 
+def _subscript_block_id(env: CompileEnvironment, sub: object) -> int | None:
+    """Block-id a subscript expression INDEXES, from the index node's own provenance (tile/offset
+    meta, else its block-var SymInt). Reduction-AGNOSTIC (resolves a tile var regardless of the
+    block's ``reduction`` flag, unlike a shape-size resolve). ``None`` for a plain slice / scalar."""
+    if not isinstance(sub, torch.fx.Node):
+        return None
+    two = sub.meta.get("tile_with_offset")
+    if isinstance(two, dict) and two.get("block_id") is not None:
+        return two["block_id"]
+    val = sub.meta.get("val")
+    if val is not None:
+        return env.resolve_block_id(val)
+    return None
+
+
 def _collect_memory_op_facts(device_ir: DeviceIR) -> list[MemoryOpFact]:
     """Walk every device graph once and record per-load/store metadata.
 
@@ -2261,14 +2662,22 @@ def _collect_memory_op_facts(device_ir: DeviceIR) -> list[MemoryOpFact]:
     ``Config.indexing``, so ``memory_op_facts[i]`` describes
     ``config.indexing[i]``. This is the single source of truth for load/store
     counts, eviction slots, and ``store_indices`` (all derived from the result).
+
+    The per-op enrichment fields (``reductions_fed``/``stores_fed``/
+    ``indexed_block_ids``/``inner_extent``/``graph_id``) are computed here so the
+    reduction-fact builders can derive their per-op-dataflow properties without a
+    bespoke graph walk. ``reductions_fed`` runs ``_classify_load_dataflow`` once over ALL
+    reduction axes, grouped by axis.
     """
     from ..autotuner.config_spec import MemoryOpFact
     from ..language import memory_ops
+    from .inductor_lowering import ReductionLowering
 
     load_op = memory_ops.load
     store_op = memory_ops.store
     operand_positions = _matmul_operand_positions()
 
+    env = CompileEnvironment.current()
     host = HostFunction.current()
     # Matmul operands always precede their matmul in graph order, so `operands` is
     # complete by the time we apply it to the (operand-less) facts below.
@@ -2278,7 +2687,17 @@ def _collect_memory_op_facts(device_ir: DeviceIR) -> list[MemoryOpFact]:
     eviction_index = 0
 
     for graph_info in device_ir.graphs:
-        for node in graph_info.graph.nodes:
+        graph = graph_info.graph
+        # Axis (block_index) of every ReductionLowering node in this graph — the cut set
+        # for the dataflow classification, so a fed reduction maps to its axis.
+        red_axis_by_id: dict[int, int] = {
+            id(node): node.meta["lowering"].block_index
+            for node in graph.nodes
+            if isinstance(node.meta.get("lowering"), ReductionLowering)
+            and isinstance(getattr(node.meta["lowering"], "block_index", None), int)
+        }
+        redset = set(red_axis_by_id)
+        for node in graph.nodes:
             if node.op != "call_function":
                 continue
 
@@ -2305,6 +2724,47 @@ def _collect_memory_op_facts(device_ir: DeviceIR) -> list[MemoryOpFact]:
 
             fake = _accessed_tensor_fake(node)
             origin = host.tensor_to_origin.get(fake) if fake is not None else None
+
+            # reductions_fed (loads): per-axis count of the reductions this load's value
+            # flows into; stores_fed: the stores it reaches without passing a reduction,
+            # keyed by full axis tuple. Both reduction-AGNOSTIC (all axes at once).
+            reductions_fed: tuple[tuple[int, int], ...] = ()
+            stores_fed: tuple[tuple[int | None, ...], ...] = ()
+            if is_load:
+                feeds, stores_fed = _classify_load_dataflow(node, redset, env)
+                per_axis: dict[int, int] = {}
+                for fed_id in feeds:
+                    axis = red_axis_by_id[fed_id]
+                    per_axis[axis] = per_axis.get(axis, 0) + 1
+                reductions_fed = tuple(sorted(per_axis.items()))
+
+            # indexed_block_ids: shape-resolved block-id per non-bare-int subscript (None
+            # where unresolvable; the fallback). subscript_block_ids: the index-subscript
+            # block-id (the faithful axis key). inner_extent: inner-dim extent.
+            indexed_block_ids: tuple[int | None, ...] = ()
+            subscript_block_ids: tuple[int | None, ...] = ()
+            inner_extent: int | None = None
+            if fake is not None:
+                index_list = node.args[1] if len(node.args) >= 2 else None
+                if isinstance(index_list, (list, tuple)):
+                    # same positions for both tuples so [-1] aligns (drop bare-int / OOB)
+                    positions = [
+                        pos
+                        for pos, sub in enumerate(index_list)
+                        if not isinstance(sub, int) and pos < fake.ndim
+                    ]
+                    indexed_block_ids = tuple(
+                        env.resolve_block_id(fake.shape[pos]) for pos in positions
+                    )
+                    subscript_block_ids = tuple(
+                        _subscript_block_id(env, index_list[pos]) for pos in positions
+                    )
+                if fake.ndim >= 2:
+                    # size_hint (not int()): int() would guard a SymInt inner dim to a
+                    # constant, over-specializing dynamic-shape kernels. inner_extent is a
+                    # heuristic signal, so a hint is sufficient and must not specialize.
+                    inner_extent = env.size_hint(fake.shape[-1])
+
             records.append(
                 (
                     node,
@@ -2317,6 +2777,12 @@ def _collect_memory_op_facts(device_ir: DeviceIR) -> list[MemoryOpFact]:
                         ndim=fake.ndim if fake is not None else 0,
                         num_reuses=len(node.users) if is_load else 0,
                         matmul_operand=None,
+                        graph_id=graph_info.graph_id,
+                        reductions_fed=reductions_fed,
+                        stores_fed=stores_fed,
+                        indexed_block_ids=indexed_block_ids,
+                        inner_extent=inner_extent,
+                        subscript_block_ids=subscript_block_ids,
                     ),
                 )
             )
@@ -2460,6 +2926,7 @@ def _register_tensor_descriptor_layout_guards(device_ir: DeviceIR) -> None:
 
 def lower_to_device_ir(func: HostFunction) -> DeviceIR:
     device_ir = DeviceIR()
+    device_ir.host_function = func
     with func, device_ir, compile_lock:
         visitor = WalkHostAST(device_ir)
         for stmt in func.body:
@@ -2512,8 +2979,10 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
         config_spec.epilogue_subtile_k_hint = 0
         config_spec.epilogue_subtile_autotune_choices = None
 
+        # Phase 1: roll + register the reduction_loops spec and stash the rollable
+        # (standard) rdims. ReductionFacts are built in Phase 3 (build_reduction_facts,
+        # after _collect_memory_op_facts) so they read the enriched memory_op_facts.
         device_ir.register_rollable_reductions()
-        config_spec = CompileEnvironment.current().config_spec
         config_spec.raise_grid_block_minimums()
         if len(device_ir.root_ids) > 1:
             # xyz is not supported with shared program IDs. Non-tcgen05
@@ -2552,6 +3021,15 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
         )
         _register_atomic_tunables(_count_device_atomics(device_ir))
         _register_tensor_descriptor_layout_guards(device_ir)
+
+        # Accumulator facts are a standalone, reduction-agnostic fact layer (any heuristic
+        # may read them), so build them independently of the reduction facts. Must run
+        # after the rolling (it walks the rolled loop subgraphs).
+        config_spec.accumulator_facts = device_ir.build_accumulator_facts()
+        # Phase 3: build the ReductionFacts (standard from the stashed rollable rdims, then
+        # user-tiled when no standard fired) now that memory_op_facts + accumulator_facts
+        # exist.
+        device_ir.build_reduction_facts(memory_op_facts)
 
         return device_ir
 

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -85,17 +85,62 @@ class MatmulFact(NamedTuple):
     rhs_dtype: torch.dtype
 
 
+class ReductionFact(NamedTuple):
+    """Workload facts for one inner reduction dim, recorded at compile time (analogous
+    to ``MatmulFact``) so the seed heuristic branches on workload properties, not kernel
+    identity. Exactly one per seeded kernel; built in device_ir's
+    ``register_rollable_reductions`` (standard) or ``register_user_tiled_reductions``
+    (user-tiled).
+
+    - ``block_id`` / ``size_hint``: the reduction axis and its extent (rnumel).
+    - ``m_block_ids``: the non-reduction (kept) tile block_ids.
+    - ``static_rnumel``: the extent if statically known, else None.
+    - ``itemsize``: bytes/element of the reduced tensor; byte caps key on
+      ``size_hint * itemsize``.
+    - ``num_load``: device loads over this rdim (the ``== 1`` stream-eviction gate).
+    - ``num_carried_2d_tiles``: 2-D [M_BLOCK, R_BLOCK] tiles carried across the inner
+      loop (the Band-B signal). Derived from ``AccumulatorFact``.
+    - ``non_reduction_loop_block_ids``: non-grid loop tiles over the extent that are NOT
+      the rdim (an apply/normalize pass); ``len(...) >= 1`` is the reduce-then-apply
+      (Band-C) signal.
+    - ``row_reread``: True iff the reduction-input row is live across the loop boundary
+      (risks spilling). Gates the persist byte cap + re-read eviction. From ``MemoryOpFact``.
+    - ``reread_eviction_index``: ``load_eviction_policies`` slot of the re-read load
+      (``None`` unless ``row_reread``), read from that load's
+      ``MemoryOpFact.eviction_index`` — no re-walk.
+    - ``full_width_output``: True iff a store writes the result back over the reduction
+      axis ([M, N], e.g. layer_norm), False for a per-row scalar ([M], e.g. sum) —
+      full-width is store/occupancy-bound, scalar-output reduction-tree-bound (opposite
+      num_warps).
+    - ``input_load_itemsize``: element size of the HBM input row load — the dtype-faithful
+      per-byte signal, distinct from ``itemsize`` (fp32-promoted = 4 at both dtypes). 0
+      when no single reduction-fed row load exists.
+
+    ``grid_rows`` is NOT stored — a pure function of ``m_block_ids`` + env, computed on
+    demand by its one consumer (the narrow-row ``num_warps`` lever).
+    """
+
+    block_id: int
+    size_hint: int
+    m_block_ids: tuple[int, ...]
+    static_rnumel: int | None
+    itemsize: int
+    num_load: int
+    num_carried_2d_tiles: int = 0
+    non_reduction_loop_block_ids: tuple[int, ...] = ()
+    row_reread: bool = False
+    reread_eviction_index: int | None = None
+    full_width_output: bool = True
+    input_load_itemsize: int = 0
+
+
 class MemoryOpFact(NamedTuple):
-    """Metadata linking one ``Config.indexing`` slot to its graph memory op.
+    """Metadata linking one ``Config.indexing`` slot to its graph memory op, one entry per
+    load/store in graph-traversal order (so ``memory_op_facts[i]`` describes ``config.indexing[i]``).
+    Lets heuristics reason about *which* load/store a slot is, not a bare positional index.
 
-    One entry per load/store, recorded in the same graph-traversal order that
-    sizes ``Config.indexing`` / ``Config.load_eviction_policies`` (see
-    ``_collect_memory_op_facts`` in ``device_ir``), so
-    ``memory_op_facts[i].indexing_index == i`` describes ``config.indexing[i]``.
-
-    Autotuner heuristics use this to reason about *which* load/store a slot is
-    (the row load, a matmul operand, a reused buffer, ...) instead of guessing
-    from a bare positional index.
+    The reduction-fact builders consume the enrichment fields below (all reduction-AGNOSTIC — no
+    notion of which axis is "the" reduction; the builders index them by the reduction's ``block_id``).
     """
 
     indexing_index: int  # slot in Config.indexing (== position in this list)
@@ -106,6 +151,37 @@ class MemoryOpFact(NamedTuple):
     ndim: int  # rank of the accessed tensor
     num_reuses: int  # downstream FX consumers of the load (0 for stores)
     matmul_operand: str | None  # matmul/dot operand: "lhs" | "rhs" | None
+    # --- reduction-fact enrichment (reduction-agnostic; () / False / None for stores) ---
+    # device_ir.graphs index this op lives in (scopes per-graph counts).
+    graph_id: int = -1
+    # per-axis count of reductions this load FEEDS: ((reduction_axis_block_id, count), ...).
+    reductions_fed: tuple[tuple[int, int], ...] = ()
+    # stores the load's value reaches WITHOUT passing through a reduction, each keyed by the
+    # store's full subscript-axis tuple (store[tile_m, tile_n] -> (id_m, id_n)); the forward
+    # walk cuts at both reductions and stores. Empty == value never bypasses a reduction.
+    stores_fed: tuple[tuple[int | None, ...], ...] = ()
+    # block-id per non-bare-int subscript, from the accessed tensor's SHAPE dims (``None`` where
+    # unresolvable). Shape-resolved fallback for the gates below (the plain-slice case,
+    # e.g. ``out[tile_m, :]``).
+    indexed_block_ids: tuple[int | None, ...] = ()
+    # inner-dim extent for a rank>=2 op (legacy reduction-width signal; gates use subscript_block_ids).
+    inner_extent: int | None = None
+    # AXIS the op's INDEX subscripts address (block-id per non-bare-int position, from the tile/offset
+    # subscript so it is reduction-AGNOSTIC; ``None`` for a plain slice). The faithful axis key for
+    # the full_width_output / input_load_itemsize gates.
+    subscript_block_ids: tuple[int | None, ...] = ()
+
+
+class AccumulatorFact(NamedTuple):
+    """One loop-carried tensor accumulator in a reduction loop, recorded at compile time.
+    Reduction-AGNOSTIC (like ``MemoryOpFact``): ``dim_block_ids`` is the per-dim block-id
+    provenance (``None`` for a static dim), ``itemsize`` the element size.
+    ``ReductionFact.num_carried_2d_tiles`` counts accumulators whose last dim is the rdim
+    (a 1-D [M_BLOCK] scalar accumulator counts as 0).
+    """
+
+    dim_block_ids: tuple[int | None, ...]
+    itemsize: int
 
 
 def shrink_block_sizes_for_numel_constraints(
@@ -368,6 +444,8 @@ class ConfigSpec:
         self.compiler_seed_configs: list[helion.Config] = []
         self.autotuner_heuristics: list[str] = []
         self.matmul_facts: list[MatmulFact] = []
+        self.reduction_facts: list[ReductionFact] = []
+        self.accumulator_facts: list[AccumulatorFact] = []
         self.store_indices: list[int] = []
         self.memory_op_facts: list[MemoryOpFact] = []
         self.backend_tunable_fragments = self.backend.tunable_fragments()

--- a/test/test_barrier.py
+++ b/test/test_barrier.py
@@ -217,6 +217,9 @@ class TestBarrier(RefEagerTestBase, TestCase):
         class _FakeRDim:
             block_id = 7
             reduction = True
+            # A static reduction extent so register_rollable_reductions can build a
+            # ReductionFact (static_rnumel reads rdim.size).
+            size = 16
 
             def size_hint(self) -> int:
                 return 16
@@ -261,7 +264,7 @@ class TestBarrier(RefEagerTestBase, TestCase):
 
         fake_env = SimpleNamespace(
             block_sizes=[_FakeRDim()],
-            config_spec=SimpleNamespace(reduction_loops=[]),
+            config_spec=SimpleNamespace(reduction_loops=[], reduction_facts=[]),
             backend_name="triton",
         )
 

--- a/test/test_memory_op_facts.py
+++ b/test/test_memory_op_facts.py
@@ -33,6 +33,15 @@ def matmul_kernel(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     return out
 
 
+@helion.kernel
+def row_sum_kernel(x: torch.Tensor) -> torch.Tensor:
+    m, _ = x.shape
+    out = torch.empty([m], dtype=x.dtype, device=x.device)
+    for tile_m in hl.tile(m):
+        out[tile_m] = x[tile_m, :].sum(-1)
+    return out
+
+
 @skipIfRefEager("config spec inspection is not applicable in ref eager mode")
 class TestMemoryOpFacts(RefEagerTestBase, TestCase):
     def test_specs_align_with_indexing_list(self):
@@ -53,6 +62,39 @@ class TestMemoryOpFacts(RefEagerTestBase, TestCase):
             spec.load_eviction_policies.length,
             sum(1 for s in specs if s.eviction_index is not None),
         )
+
+    @skipIfNotCUDA()
+    @onlyBackends(["triton"])
+    def test_reduction_fact_indexing_slot_invariant(self):
+        """The ReductionFact is built after _collect_memory_op_facts, but the collector
+        still runs after the reduction rolling, so every rolled-subgraph load/store keeps
+        its ``Config.indexing`` slot and the ``memory_op_facts[i].indexing_index == i``
+        invariant holds. Collecting before the rolling would desync ``Config.indexing``
+        from codegen."""
+        x = torch.randn([256, 512], device=DEVICE, dtype=torch.float32)
+        spec = row_sum_kernel.bind((x,)).config_spec
+        specs = spec.memory_op_facts
+
+        # The reorder must not change the indexing-slot alignment / length.
+        self.assertEqual(len(specs), spec.indexing.length)
+        self.assertEqual([s.indexing_index for s in specs], list(range(len(specs))))
+        self.assertEqual(
+            spec.load_eviction_policies.length,
+            sum(1 for s in specs if s.eviction_index is not None),
+        )
+
+        # Exactly one ReductionFact, derived from the enriched facts.
+        self.assertEqual(len(spec.reduction_facts), 1)
+        fact = spec.reduction_facts[0]
+        # num_load scopes to the rdim's original graph(s) (one streamed input row), so the
+        # rolled-subgraph copy is not double-counted.
+        self.assertEqual(fact.num_load, 1)
+
+        # The collector ran after the rolling, so the rolled reduction subgraph's load
+        # copy is accounted for: a load fact lives in a later graph than the root, and the
+        # full set has > 1 load fact even though num_load == 1.
+        self.assertTrue(any(s.graph_id > 0 for s in specs if s.kind == "load"))
+        self.assertGreater(sum(1 for s in specs if s.kind == "load"), fact.num_load)
 
     def test_load_store_metadata(self):
         x = torch.randn([256, 256], device=DEVICE, dtype=torch.float32)


### PR DESCRIPTION
Stacked PRs:
 * #2762
 * __->__#2761
 * #2760


--- --- ---

### [autotuner] Reduction fact layer: ReductionFact + AccumulatorFact + enriched MemoryOpFact


Add the reduction fact layer the Triton reduction seed heuristic will read, built in
the compiler fact pass. No heuristic yet — that lands in the next PR; these facts are
populated but not consumed here.

- helion/autotuner/config_spec.py: ReductionFact, AccumulatorFact, enriched
  MemoryOpFact (per-op provenance), and the fact storage fields on ConfigSpec.
- helion/_compiler/device_ir.py: a 3-phase fact build (roll reductions, collect
  enriched memory-op facts after rolling, derive reduction/accumulator facts) that
  replaces bespoke per-config graph walks.
- full_width_output / input_load_itemsize key on the reduction AXIS via a new
  MemoryOpFact.subscript_block_ids (block-id read from the index subscript, resolved
  reduction-agnostically) rather than an inner_extent==size_hint size-match — faithful
  for user-tiled (T2) reductions whose reduction block is reduction=False, and immune to
  a non-reduction dim coincidentally equal to the reduction extent. Byte-identical seed
  configs across the curriculum (no size coincidences existed).
- test/test_memory_op_facts.py: fact coverage incl. the indexing-slot invariant.
- test/test_barrier.py: update the rdim / config_spec fakes for the new fact build.