### PR TITLE
[autotuner] Triton reduction seed heuristic (generalizable core)

### DIFF
--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -14,9 +14,10 @@ from .cute import CuteTileVecWarpReduceHeuristic
 from .pallas import PallasMatmulF32NoTilingSeedHeuristic
 from .pallas import PallasMatmulNoTilingSeedHeuristic
 from .triton import TritonB200MatmulHeuristic
-from .triton import TritonReductionTileHeuristic
 from .triton import TritonSkinnyGemmHeuristic
 from .triton import TritonSplitJoinRotateHeuristic
+from .triton import TritonStandardReductionHeuristic
+from .triton import TritonUserTiledReductionHeuristic
 
 if TYPE_CHECKING:
     from ...runtime.config import Config
@@ -39,7 +40,8 @@ HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
         TritonSkinnyGemmHeuristic,
         TritonB200MatmulHeuristic,
         TritonSplitJoinRotateHeuristic,
-        TritonReductionTileHeuristic,
+        TritonStandardReductionHeuristic,
+        TritonUserTiledReductionHeuristic,
     ),
     "pallas": (
         PallasMatmulNoTilingSeedHeuristic,

--- a/helion/_compiler/autotuner_heuristics/triton.py
+++ b/helion/_compiler/autotuner_heuristics/triton.py
@@ -7,18 +7,21 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
 
+import torch
+
 from ...autotuner.config_fragment import EnumFragment
 from ...runtime.config import Config
 from .common import REDUCTION_TARGET_NAMES
 from .common import clamp_block_size_targets
-from .common import is_canonical_row_reduction
 from .common import matches_hardware
 from .common import op_name_parts
 from .registry import AutotunerHeuristic
 
 if TYPE_CHECKING:
+    from ...autotuner.config_spec import BlockSizeSpec
     from ...autotuner.config_spec import ConfigSpec
     from ...autotuner.config_spec import MatmulFact
+    from ...autotuner.config_spec import ReductionFact
     from ..compile_environment import CompileEnvironment
     from ..device_ir import DeviceIR
 
@@ -295,28 +298,332 @@ class TritonSplitJoinRotateHeuristic(AutotunerHeuristic):
         return Config(block_sizes=[1] * len(env.config_spec.block_sizes))
 
 
-# Triton analog of ``CuteReductionTileHeuristic``.
-class TritonReductionTileHeuristic(AutotunerHeuristic):
-    """Seed the "one row per program, persistent reduction" config for reductions.
+def _triton_reduction_eligible(env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+    """Gate: exactly one ``ReductionFact`` and no ``matmul_facts``. Admits both tracks
+    (standard rollable, user-tiled); excludes GEMMs and multi-axis manual reductions."""
+    spec = env.config_spec
+    return len(spec.reduction_facts) == 1 and not spec.matmul_facts
 
-    For canonical row reductions (softmax, rms_norm, layer_norm, cross_entropy)
-    LFBO converges on the same family across widths; this supplies it as a
-    search seed (a starting point, not a forced config):
-    ``block_sizes=[1]`` (one row per program), ``reduction_loops=[None]`` (a
-    single persistent pass, not the looped family the LLM cold-guesses), and
-    ``load_eviction_policies=['last']`` where the backend supports it. Gated by
-    ``is_canonical_row_reduction``, shared with ``CuteReductionTileHeuristic``.
+
+def _is_standard_reduction(spec: ConfigSpec, fact: ReductionFact) -> bool:
+    """standard vs user-tiled discriminator: standard iff the rdim is a rollable
+    ``reduction_loops`` entry, else user-tiled (a ``block_sizes`` entry). Exhaustive over
+    eligible reductions (the two device_ir populators are mutually exclusive).
+    """
+    return fact.block_id in spec.reduction_loops.valid_block_ids()
+
+
+def _grid_rows(env: CompileEnvironment, m_block_ids: tuple[int, ...]) -> int:
+    """Product of the static M-axis (non-reduction grid) extents — the program count the
+    reduction launches, the numerator of the occupancy ``grid_rows // num_sm``. Returns 0
+    if any extent is not a statically-resolvable size (a dynamic grid has no compile-time
+    occupancy, so the occupancy-gated narrow-w1 lever declines).
+    """
+    grid_rows = 1
+    for mbid in m_block_ids:
+        size = env.block_sizes[mbid].size
+        if not isinstance(size, (int, torch.SymInt)):
+            return 0
+        grid_rows *= env.size_hint(size)
+    return grid_rows
+
+
+class _TritonReductionSeedBase(AutotunerHeuristic):
+    """Shared base for the two Triton inner-reduction seed heuristics. Both share the
+    workload facts (``ReductionFact``), the M_BLOCK-aware reduction-block lever
+    (``_reduction_rblock``, from which each track derives ``persistent``), the
+    ``num_warps`` ramp, eviction provenance, and the block-size builders; the subclasses
+    differ only in mapping that decision onto knobs:
+
+    - **standard** (:class:`TritonStandardReductionHeuristic`): Helion rolls the rdim
+      into a ``reduction_loops`` loop.
+    - **user-tiled** (:class:`TritonUserTiledReductionHeuristic`): the user hand-writes
+      the ``hl.tile`` loop, so the reduction axis is a ``block_sizes`` entry (plain
+      user-tiled softmax, Band-B kl_div/jsd, Band-C welford).
+
+    Cloned from ``cute.CuteReductionTileHeuristic`` for triton (drops the CuTe-only
+    knobs, adds ``num_warps`` / ``num_stages``). Not registered; only the subclasses are.
+    """
+
+    backend = "triton"
+    HARDWARE_TARGETS = (("cuda", "sm90"),)
+
+    # Looped-fallback reduction chunk (pow2) for a row that does not fit the persistent
+    # residency budget. ``_reduction_rblock`` shrinks it when a raised M_BLOCK divides the
+    # footprint budget below it; at M_BLOCK==1 it is used as-is.
+    LOOPED_CHUNK = 16384
+    # Band-B (user-tiled, carrying [M_BLOCK, R_BLOCK] 2-D accumulators: kl_div, jsd) R_BLOCK
+    # cap, as a per-program footprint R_BLOCK * itemsize * n_carried; in bytes (via itemsize)
+    # for dtype-generality.
+    BANDB_R_BLOCK_BYTES = 16384
+    # Per-program persistent byte ceiling. The resident reduction tile is [M_BLOCK, R_BLOCK]
+    # in BOTH tracks (the persistent load and the looped accumulator both carry the M_BLOCK
+    # dim), so the per-program footprint is ``m_block * r_block * itemsize`` and every cap
+    # below divides the budget by M_BLOCK. Above it a wide resident tile spills register/SMEM,
+    # so the reduction loops a chunk instead. ~240 KiB, just over H100 SMEM.
+    ROW_PERSIST_MAX_BYTES = 245760
+    # Per-program ELEMENT ceiling for a FULL-WIDTH-output row (stores the whole [M, N] row
+    # back): its resident tile is fp32-promoted, so it spills at a WIDTH independent of input
+    # dtype, which the byte cap above (input bytes) undercounts 2x for a half-precision row.
+    # M_BLOCK-aware; gates only full_width_output rows, steering half-precision full-width
+    # standard rows onto the looped path.
+    FULL_WIDTH_PERSIST_MAX_ELEMS = 81920
+    # No welford "structured-combine floor": welford is memory-bound (profiler-confirmed),
+    # so a wide combine tile only spills — register-residency via the reduction footprint cap
+    # is what matters. The apply/normalize tile gets the SAME M_BLOCK-aware footprint cap as
+    # the reduction tile, NOT a flat per-row cap (which needlessly narrowed the memory-bound
+    # apply pass); applied inline in ``_build_block_sizes``.
+
+    # NARROW-row single-warp (occupancy-gated): a narrow reduction extent wants ONE warp (the
+    # cross-warp reduction tree is pure overhead; w1 reduces in-register via shuffle). The win
+    # inverts past an occupancy ceiling (the SMs saturate), so it is gated on a row-byte cap
+    # AND an occupancy cap, both keyed on input_load_itemsize (the HBM-load element width —
+    # faithful and dtype-agnostic, unlike the fp32-promoted accumulator itemsize which is 4 at
+    # both dtypes):
+    #   - row cap: rnumel * input_load_itemsize <= NARROW_W1_MAX_BYTES.
+    #   - occ cap: occ * row_bytes <= NARROW_W1_OCC_BYTE_LIMIT (a wider row saturates at lower
+    #     occupancy, so the ceiling is on the product, not a flat occ).
+    NARROW_W1_MAX_BYTES = 2048
+    NARROW_W1_OCC_BYTE_LIMIT = 262144
+
+    @classmethod
+    def _bandb_r_block_cap(cls, fact: ReductionFact) -> int:
+        """Pow2 R_BLOCK ceiling for a Band-B (carried 2-D tile) reduction: the per-program
+        footprint ``BANDB_R_BLOCK_BYTES`` split across the accumulator itemsize and the
+        carried-tile count. ``max(1, ..)`` guards a zero itemsize / tile count.
+        """
+        from ..._utils import next_power_of_2 as _np2
+
+        cap = cls.BANDB_R_BLOCK_BYTES // (
+            max(1, fact.itemsize) * max(1, fact.num_carried_2d_tiles)
+        )
+        return _np2(max(1, cap))
+
+    @classmethod
+    def _num_warps(
+        cls, fact: ReductionFact, num_sm: int = 0, grid_rows: int = 0
+    ) -> int:
+        """Scale num_warps with the reduction extent (pow2, per NumWarpsFragment):
+        rnumel <= 1024 -> 4, <= 4096 -> 8, <= 16384 -> 16, > 16384 -> 32. Too few
+        under-occupies the SM, too many wastes the reduction tree.
+
+        NARROW-row single-warp refinement at the LOW end (the occupancy-gated lever): a
+        narrow row at low/moderate occupancy wants ONE warp (the cross-warp reduction tree
+        is pure overhead — see ``NARROW_W1_MAX_BYTES``). Fires only when the row-byte cap AND
+        the resident-pressure cap (``occ * row_bytes <= NARROW_W1_OCC_BYTE_LIMIT``) hold; both
+        key on ``input_load_itemsize`` (faithful, no dtype-kind branch) and the occ ceiling
+        scales DOWN as the row grows (a wider row cliffs at lower occupancy). Needs ``num_sm``
+        (0 disables it, e.g. an off-device caller). Disjoint from the wide-row branch below
+        (``NARROW_W1_MAX_BYTES`` << the rnumel>16384 region), so the two never interact.
+        """
+        rnumel = fact.size_hint
+        ils = fact.input_load_itemsize
+        row_bytes = rnumel * ils
+        # NARROW-row single-warp (see NARROW_W1_MAX_BYTES); needs a known device + static grid.
+        have_enough_information = num_sm > 0 and ils > 0 and grid_rows > 0
+        if have_enough_information:
+            occ = grid_rows // num_sm
+            if (
+                fact.num_carried_2d_tiles == 0  # not Band-B (kl_div/jsd)
+                and row_bytes <= cls.NARROW_W1_MAX_BYTES
+                and occ * row_bytes <= cls.NARROW_W1_OCC_BYTE_LIMIT
+            ):
+                return 1
+        # >16384 (not >=) so a 16384-wide row stays w16, excluding the w32 regression there.
+        warps32_min_elems = 16384
+        if rnumel > warps32_min_elems:
+            return 32
+        if rnumel <= 1024:
+            return 4
+        if rnumel <= 4096:
+            return 8
+        return 16
+
+    @classmethod
+    def _block_floor(cls, bs_spec: BlockSizeSpec) -> int:
+        """The smallest valid block size for an entry, used for every non-reduction axis
+        the seed does not widen. Prefers one row/program but honors a raised
+        ``autotuner_min`` (large-M shapes) rather than emitting an invalid ``block_size=1``.
+        """
+        return max(1, bs_spec.min_size, bs_spec.autotuner_min)
+
+    @classmethod
+    def _m_block_product(cls, spec: ConfigSpec, fact: ReductionFact) -> int:
+        """Product of the seed's floored M-axis (grid) block sizes — the number of rows each
+        program processes (1 unless a huge-M shape raised ``autotuner_min``). Shared by the
+        apply-loop stream cap (``_build_block_sizes``) and the Band-C combine cap so they read
+        the same M_BLOCK.
+        """
+        m_block = 1
+        for mbid in fact.m_block_ids:
+            m_idx = spec.block_sizes.block_id_to_index(mbid)
+            m_block *= cls._block_floor(cast("BlockSizeSpec", spec.block_sizes[m_idx]))
+        return m_block
+
+    @classmethod
+    def _build_block_sizes(
+        cls,
+        spec: ConfigSpec,
+        fact: ReductionFact,
+        red_block_id: int | None,
+        red_value: int | None,
+        non_reduction_loop_ids: frozenset[int] | set[int] = frozenset(),
+    ) -> list[int]:
+        """Build the ``block_sizes`` list: the reduction axis gets ``red_value``, each
+        non-reduction loop tile (``non_reduction_loop_ids``, disjoint from the reduction
+        block_id) gets ``loop_block``, every other axis its ``_block_floor``.
+        ``red_block_id`` is None for standard (the reduction rides ``reduction_loops``, not
+        a block_sizes entry).
+
+        The non-reduction loop tile matches the reduction tile — ``red_value`` (user-tiled)
+        or ``next_pow2(size_hint)`` (standard, where ``red_value`` is None). The normalize
+        pass carries no accumulator, so this tile is a pure seed (a sane non-size-1 start,
+        never a correctness constraint); the autotuner refines it from there.
+        """
+        from ..._utils import next_power_of_2 as _np2
+        from ..._utils import prev_power_of_2
+
+        loop_block: int | None = None
+        if non_reduction_loop_ids:
+            # The apply/normalize tile starts at the reduction tile — red_value (user-tiled) or
+            # next_pow2(size_hint) (standard, where red_value is None)...
+            loop_block = red_value if red_value is not None else _np2(fact.size_hint)
+            # ...then is clamped to the same M_BLOCK-aware footprint cap as the reduction
+            # tile (the apply tile is [M_BLOCK, loop_block] resident, so a wide one spills).
+            # Only the Band-C reduce-then-apply kernels (welford, groupnorm) have a normalize
+            # loop, so everything else is byte-identical (no non_reduction_loop_ids). The cap
+            # clamps an otherwise-spilling apply pass back to register residency; the pass is
+            # memory-bound so this is a net win. A flat per-row cap always narrowed it.
+            m_block = cls._m_block_product(spec, fact)
+            budget = cls.ROW_PERSIST_MAX_BYTES // (m_block * max(1, fact.itemsize))
+            loop_block = min(loop_block, prev_power_of_2(budget))
+
+        red_idx = (
+            spec.block_sizes.block_id_to_index(red_block_id)
+            if red_block_id is not None
+            else None
+        )
+        out: list[int] = []
+        for i in range(len(spec.block_sizes)):
+            bs_spec = cast("BlockSizeSpec", spec.block_sizes[i])
+            if i == red_idx:
+                out.append(cast("int", red_value))
+            elif bs_spec.block_id in non_reduction_loop_ids and loop_block is not None:
+                out.append(loop_block)
+            else:
+                out.append(cls._block_floor(bs_spec))
+        return out
+
+    @classmethod
+    def _eviction_policies(
+        cls,
+        env: CompileEnvironment,
+        kind: str,
+        reread_slot: int | None = None,
+    ) -> list[str] | None:
+        """``load_eviction_policies`` list (spec length), keyed on per-load residency;
+        None leaves the autotuner default.
+
+        - ``"stream"`` — single streamed input (``num_load == 1``: sum, long_sum), read
+          once: every load -> ``'first'`` (frees L2).
+        - ``"reread"`` — the row is re-read across passes: its first load -> ``'last'``
+          (L2-resident), rest -> ``'first'``. ``reread_slot`` is that load's actual slot,
+          read directly from ``ReductionFact.reread_eviction_index`` (the re-read load's
+          ``MemoryOpFact.eviction_index``), not guessed or re-walked per config.
+
+        Other kinds leave the default until a per-slot win is confirmed.
+        """
+        n = env.config_spec.load_eviction_policies.length
+        if n <= 0:
+            return None
+        if kind == "stream":
+            return ["first"] * n
+        if kind == "reread":
+            if reread_slot is None or not 0 <= reread_slot < n:
+                return None
+            policy = ["first"] * n
+            policy[reread_slot] = "last"
+            return policy
+        return None
+
+    @classmethod
+    def _reduction_rblock(
+        cls,
+        env: CompileEnvironment,
+        fact: ReductionFact,
+        m_block: int,
+    ) -> int:
+        """The reduction-axis chunk (pow2), shared by both tracks, using the M_BLOCK-aware
+        footprint cap (see ``ROW_PERSIST_MAX_BYTES``).
+
+        Returns the full pow2 rdim when that footprint fits the residency budget (the caller
+        derives ``persistent := r_block >= next_pow2(size_hint)``), else the byte-preserving
+        looped chunk ``min(LOOPED_CHUNK, budget // m_block)`` — exactly ``LOOPED_CHUNK`` at
+        M_BLOCK==1, shrunk only when a raised M_BLOCK tightens the budget (huge-M).
+
+        No welford "structured-combine floor": keeping the chunk register-resident (the
+        footprint cap) is what matters. welford is memory-bound and a wide combine tile only
+        spills register/SMEM (profiler-confirmed; the count/mean/M2 recurrence is off the
+        critical path).
+        """
+        from ..._utils import next_power_of_2 as _np2
+        from ..._utils import prev_power_of_2
+
+        rdim = _np2(fact.size_hint)
+        itemsize = max(1, fact.itemsize)
+        m = max(1, m_block)
+        # Persistent iff the full-rdim [M_BLOCK, rdim] tile fits ALL footprint caps: the element
+        # compile limit, the per-program byte ceiling, AND — for a full_width_output row — the
+        # fp32-promoted element ceiling (the input-byte cap undercounts it 2x at half precision).
+        element_cap = env.backend.max_tensor_numel
+        can_persist = (
+            (element_cap is None or fact.size_hint <= element_cap)
+            and (m * fact.size_hint * itemsize <= cls.ROW_PERSIST_MAX_BYTES)
+            and (
+                not fact.full_width_output
+                or m * fact.size_hint <= cls.FULL_WIDTH_PERSIST_MAX_ELEMS
+            )
+        )
+        if can_persist:
+            rblock = rdim
+        else:
+            # Looped: LOOPED_CHUNK, shrunk to the largest pow2 the M_BLOCK-aware byte budget
+            # allows. At M_BLOCK==1 the budget exceeds LOOPED_CHUNK -> chunk == LOOPED_CHUNK;
+            # a raised M_BLOCK divides the budget below it.
+            budget = cls.ROW_PERSIST_MAX_BYTES // (m * itemsize)
+            rblock = min(cls.LOOPED_CHUNK, prev_power_of_2(budget))
+        return max(1, rblock)
+
+
+class TritonStandardReductionHeuristic(_TritonReductionSeedBase):
+    """standard (Helion-rolled rdim) inner-reduction seed: Helion rolls the reduction axis
+    into a ``reduction_loops`` loop from a single ``.sum(-1)``-style op — sum, long_sum,
+    rms_norm, layer_norm, softmax-row, cross_entropy. Triton analog of
+    ``CuteReductionTileHeuristic`` (keeps its registry name), deepening the original
+    one-row/persistent/``['last']`` seed with the num_warps ramp, persistent-vs-looped,
+    and per-slot eviction.
+
+    Gated by ``_triton_reduction_eligible`` (standard track) — broader than upstream
+    ``is_canonical_row_reduction`` (also multi-axis rollable rows and raised-``autotuner_min``
+    large-M shapes). Off sm90 the H100-tuned levers are unvalidated, so it falls back to
+    ``_narrow_seed`` (pre-existing behavior preserved).
     """
 
     name = "triton_reduction_tile"
-    backend = "triton"
 
     @classmethod
     def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
-        return is_canonical_row_reduction(env)
+        if not _triton_reduction_eligible(env, device_ir):
+            return False
+        spec = env.config_spec
+        return _is_standard_reduction(spec, spec.reduction_facts[0])
 
     @classmethod
-    def get_seed_config(cls, env: CompileEnvironment, device_ir: DeviceIR) -> Config:
+    def _narrow_seed(cls, env: CompileEnvironment) -> Config:
+        """The upstream conservative standard seed (one row/program, single persistent pass,
+        ``['last']`` eviction where supported). A verbatim port used off sm90 so non-sm90
+        behavior is unchanged.
+        """
         spec = env.config_spec
         seed: dict[str, Any] = {
             "block_sizes": [1],
@@ -331,4 +638,152 @@ class TritonReductionTileHeuristic(AutotunerHeuristic):
             and "last" in eviction.inner.choices
         ):
             seed["load_eviction_policies"] = ["last"] * eviction.length
+        return Config(**seed)
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        if not matches_hardware(env, cls.HARDWARE_TARGETS):
+            # Off the H100-validated target: keep the upstream conservative seed.
+            return cls._narrow_seed(env)
+        from ..._utils import next_power_of_2 as _np2
+        from ...runtime import get_num_sm
+
+        spec = env.config_spec
+        fact = spec.reduction_facts[0]
+        # standard rides persistent-vs-looped on `reduction_loops`. The shared lever sizes the
+        # reduction chunk (M_BLOCK-aware footprint); `persistent` is derived from it. num_sm +
+        # grid_rows feed the occupancy-gated narrow-row w1 branch in _num_warps (grid_rows =
+        # product of static M extents, a pure fn of m_block_ids + env).
+        m_block = cls._m_block_product(spec, fact)
+        r_block = cls._reduction_rblock(env, fact, m_block)
+        persistent = r_block >= _np2(fact.size_hint)
+        num_warps = cls._num_warps(
+            fact, max(1, get_num_sm(env.device)), _grid_rows(env, fact.m_block_ids)
+        )
+
+        # A standard reduction may be followed by a normalize loop (e.g. `s = x.sum(); out =
+        # x/s`); its extra block_sizes tile(s) are sized by _build_block_sizes (matched to
+        # the reduction tile). Only a seed (a worse tile costs autotuning time, never
+        # correctness), so emit and let the autotuner refine.
+        non_reduction_loop_ids = set(fact.non_reduction_loop_block_ids)
+
+        # red_block_id=None: the rdim is not a block_sizes entry, so every entry is a
+        # grid axis (floored) or a normalize loop tile (sized to the reduction tile). None
+        # loop => the single grid block at its floor, as before.
+        reduction_loops: list[int | None] = [None] if persistent else [r_block]
+        seed: dict[str, Any] = {
+            "block_sizes": cls._build_block_sizes(
+                spec, fact, None, None, non_reduction_loop_ids=non_reduction_loop_ids
+            ),
+            "reduction_loops": reduction_loops,
+            "num_warps": num_warps,
+            "num_stages": 1,
+            # 'flat': these reductions are grid-saturated at the M-grid.
+            "pid_type": "flat",
+        }
+        # Eviction: streamed input -> 'first' everywhere; looped re-read -> first load
+        # 'last', rest 'first'. PERSISTENT rows are left at default ON PURPOSE (the `not
+        # persistent` gate below): a rolled persistent reduction fuses the reduce + apply to a
+        # SINGLE HBM load of the row (profiler-confirmed), so a 'last' hint is a no-op and
+        # actually regresses wide rows by pinning x and evicting weight/store lines. This is
+        # the opposite of the user-tiled track, where softmax_two_pass has two PHYSICAL
+        # reduction loops (two loads) so 'last' helps even when persistent.
+        evict = None
+        if fact.num_load == 1:
+            evict = cls._eviction_policies(env, "stream")
+        elif fact.row_reread and not persistent:
+            # Re-read row's eviction slot read directly from the fact (its load's
+            # MemoryOpFact.eviction_index), not a per-config codegen re-walk.
+            evict = cls._eviction_policies(env, "reread", fact.reread_eviction_index)
+        if evict is not None:
+            seed["load_eviction_policies"] = evict
+        return Config(**seed)
+
+
+class TritonUserTiledReductionHeuristic(_TritonReductionSeedBase):
+    """user-tiled inner-reduction seed: fires on a user-tiled reduction (the user
+    hand-writes the ``hl.tile`` loop over the reduction axis, so the rdim is an ordinary
+    ``block_sizes`` entry, i.e. a user ``hl.tile(n, block_size=R_BLOCK)``), which the
+    upstream gate rejects entirely.
+    R_BLOCK starts at the shared ``_reduction_rblock`` (M_BLOCK-aware footprint cap), then
+    INDEPENDENT band predicates layer on via ``min`` (a kernel gets every cap it matches;
+    today's kernels each match exactly one):
+
+    - **plain user-tiled** (softmax_two_pass): no extra cap — persistent full-pow2 R_BLOCK,
+      standard-style reread-eviction for wide looped rows.
+    - **Band B** (kl_div, jsd): carries ``[M_BLOCK, R_BLOCK]`` 2-D tiles, so a full-N
+      R_BLOCK spills — cap by ``BANDB_R_BLOCK_BYTES / (itemsize * num_carried_2d_tiles)``.
+    - **Band C** (welford, ``non_reduction_loop_block_ids`` non-empty): reduce-then-apply — no
+      combine floor (welford is memory-bound; a wide combine only spills). Its normalize/apply
+      tile starts at the reduction tile and gets the SAME M_BLOCK-aware footprint cap (NOT a
+      flat per-row cap, which needlessly narrowed the memory-bound apply pass); see
+      ``_build_block_sizes``.
+
+    TODO(reductions): as more structured families land, promote each band into its own
+    fact-keyed ``AutotunerHeuristic`` subclass rather than growing this method.
+    """
+
+    name = "triton_reduction_user_tile"
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        if not _triton_reduction_eligible(env, device_ir):
+            return False
+        spec = env.config_spec
+        return not _is_standard_reduction(spec, spec.reduction_facts[0])
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        if not matches_hardware(env, cls.HARDWARE_TARGETS):
+            # Off sm90: upstream never fired on user-tiled, so no prior seed to preserve. Decline.
+            return None
+        from ...runtime import get_num_sm
+
+        spec = env.config_spec
+        fact = spec.reduction_facts[0]
+        non_reduction_loop_ids = set(fact.non_reduction_loop_block_ids)
+        m_block = cls._m_block_product(spec, fact)
+
+        # user-tiled: the rdim IS a block_sizes entry (no reduction_loops knob); persistent ==
+        # R_BLOCK >= next_pow2(N). Other axes stay at floor (keeps Band-B M_BLOCK at 1, required
+        # by the u0*u1 <= 2**20 constraint). The band caps are INDEPENDENT predicates composed
+        # by min: the shared lever applies the M_BLOCK-aware footprint cap; the carried-2D cap
+        # (Band B) layers on top. welford (Band C) needs no extra cap — the footprint cap
+        # already keeps its combine tile register-resident (a wider tile only spills).
+        r_block = cls._reduction_rblock(env, fact, m_block)
+        if fact.num_carried_2d_tiles >= 1:
+            # Band B (kl_div, jsd): a carried [M_BLOCK, R_BLOCK] tile spills a full-N R_BLOCK, so
+            # cap the footprint (R_BLOCK * itemsize * n_carried) via _bandb_r_block_cap.
+            r_block = min(r_block, cls._bandb_r_block_cap(fact))
+        num_warps = cls._num_warps(
+            fact, max(1, get_num_sm(env.device)), _grid_rows(env, fact.m_block_ids)
+        )
+
+        seed: dict[str, Any] = {
+            "block_sizes": cls._build_block_sizes(
+                spec,
+                fact,
+                fact.block_id,
+                r_block,
+                non_reduction_loop_ids=non_reduction_loop_ids,
+            ),
+            "num_warps": num_warps,
+            "num_stages": 1,
+            "pid_type": "flat",  # see the standard branch.
+        }
+        # Reread eviction: keep the re-read row L2-resident ('last' on its load slot) whenever
+        # it is re-read — welford (reduce-then-apply across combine + normalize) AND plain
+        # user-tiled (softmax_two_pass loads x twice). Applies even when PERSISTENT: the second
+        # pass still re-fetches x from HBM (profiler-confirmed), so 'last' cuts that re-read
+        # traffic. kl_div/jsd (row_reread=False) unaffected.
+        if non_reduction_loop_ids or fact.row_reread:
+            # Re-read row's eviction slot read directly from the fact (its load's
+            # MemoryOpFact.eviction_index), not a per-config codegen re-walk.
+            ev = cls._eviction_policies(env, "reread", fact.reread_eviction_index)
+            if ev is not None:
+                seed["load_eviction_policies"] = ev
         return Config(**seed)

--- a/helion/_utils.py
+++ b/helion/_utils.py
@@ -24,6 +24,14 @@ def next_power_of_2(n: int) -> int:
     return 1 << (n - 1).bit_length()
 
 
+def prev_power_of_2(n: int) -> int:
+    """Return the largest power of 2 <= n (>= 1). Use this to floor a budget to a valid
+    pow2 tile: ``next_power_of_2`` would round UP past the budget."""
+    if n <= 1:
+        return 1
+    return 1 << (n.bit_length() - 1)
+
+
 @functools.cache
 def triton_is_available() -> bool:
     """Return True if triton is installed and importable."""

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -10,9 +10,14 @@ import helion
 from helion._compiler.autotuner_heuristics import compiler_seed_configs
 from helion._compiler.autotuner_heuristics.cute import CuteTcgen05ClusterM2Heuristic
 from helion._compiler.autotuner_heuristics.registry import AutotunerHeuristic
-from helion._compiler.autotuner_heuristics.triton import TritonReductionTileHeuristic
 from helion._compiler.autotuner_heuristics.triton import TritonSkinnyGemmHeuristic
 from helion._compiler.autotuner_heuristics.triton import TritonSplitJoinRotateHeuristic
+from helion._compiler.autotuner_heuristics.triton import (
+    TritonStandardReductionHeuristic,
+)
+from helion._compiler.autotuner_heuristics.triton import (
+    TritonUserTiledReductionHeuristic,
+)
 from helion._compiler.backend import TritonBackend
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY
@@ -105,6 +110,7 @@ from helion.autotuner import IntegerFragment
 from helion.autotuner.config_spec import BlockSizeSpec
 from helion.autotuner.config_spec import ConfigSpec
 from helion.autotuner.config_spec import MatmulFact
+from helion.autotuner.config_spec import ReductionFact
 from helion.autotuner.config_spec import ReductionLoopSpec
 from helion.autotuner.pattern_search import InitialPopulationStrategy
 from helion.autotuner.pattern_search import PatternSearch
@@ -679,47 +685,94 @@ class TestTritonSplitJoinRotateHeuristic(TestCase):
         )
 
 
-class TestTritonReductionTileHeuristic(TestCase):
-    """Triton row-reduction heuristic: seeds the "one row per program,
-    persistent reduction" skeleton, fires only for a canonical row reduction,
-    and its persistent seed survives flatten/unflatten (the config_spec
-    sentinel round-trip fix).
+class TestTritonStandardReductionHeuristic(TestCase):
+    """Triton standard row-reduction heuristic: seeds the "one row per program"
+    skeleton with an rnumel-scaled ``num_warps`` ramp and faithful per-slot load
+    eviction, fires only for a canonical row reduction, and its persistent seed
+    survives flatten/unflatten (the config_spec sentinel round-trip fix).
     """
 
-    def _reduction_spec(self, *, reduction_size_hint: int) -> ConfigSpec:
+    def _reduction_spec(
+        self,
+        *,
+        reduction_size_hint: int,
+        num_load: int = 1,
+        itemsize: int = 4,
+    ) -> ConfigSpec:
         spec = ConfigSpec(backend=TritonBackend())
         spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=1024))
         spec.reduction_loops.append(
             ReductionLoopSpec(block_id=1, size_hint=reduction_size_hint)
         )
+        # The deepened heuristic reads a ReductionFact (the workload facts it keys
+        # the warp ramp / eviction / persist decision on); the reduction axis is
+        # block_id=1 (the rolled reduction loop above), the row axis block_id=0.
+        spec.reduction_facts.append(
+            ReductionFact(
+                block_id=1,
+                size_hint=reduction_size_hint,
+                m_block_ids=(0,),
+                static_rnumel=reduction_size_hint,
+                itemsize=itemsize,
+                num_load=num_load,
+            )
+        )
         return spec
 
-    def test_seed_is_persistent_one_row(self) -> None:
-        # The structural seed: one row per program + persistent reduction. Warp
-        # count is left to the autotuner, not seeded.
+    def _reduction_env(self, spec: ConfigSpec) -> MagicMock:
+        # The deepened heuristic reads env.backend.max_tensor_numel (the structural
+        # persistent cap) — provide the real Triton cap so a sub-cap rnumel stays
+        # persistent.
+        from helion.autotuner.config_generation import TRITON_MAX_TENSOR_NUMEL
+
         env = MagicMock()
-        env.config_spec = self._reduction_spec(reduction_size_hint=1024)
-        seed = TritonReductionTileHeuristic.get_seed_config(env, MagicMock())
+        env.backend_name = "triton"
+        env.backend.max_tensor_numel = TRITON_MAX_TENSOR_NUMEL
+        env.config_spec = spec
+        env.device = DEVICE
+        return env
+
+    def test_seed_is_persistent_one_row(self) -> None:
+        # The structural seed: one row per program + persistent reduction. The
+        # deepened heuristic ALSO seeds num_warps via the rnumel ramp (rnumel=1024
+        # -> 4 warps) and num_stages=1, rather than leaving them to the autotuner.
+        env = self._reduction_env(self._reduction_spec(reduction_size_hint=1024))
+        # The mock env has no real GPU device, so patch hardware info / SM count (this
+        # heuristic only fires on GPU in production and the SM count is irrelevant here).
+        with (
+            patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE),
+            patch("helion.runtime.get_num_sm", return_value=132),
+        ):
+            seed = TritonStandardReductionHeuristic.get_seed_config(env, MagicMock())
         self.assertEqual(seed.config["block_sizes"], [1])
         self.assertEqual(seed.config["reduction_loops"], [None])
-        self.assertNotIn("num_warps", seed.config)
+        # rnumel ramp: 1024 falls in the <=1024 band -> 4 warps.
+        self.assertEqual(seed.config["num_warps"], 4)
+        self.assertEqual(seed.config["num_stages"], 1)
 
-    def test_seed_broadcasts_last_eviction_over_load_slots(self) -> None:
-        # Streaming reductions want 'last' eviction, broadcast over the spec's
-        # load slots. Build the fragment explicitly so the test does not depend
-        # on the host backend's eviction choices.
+    def test_single_load_seeds_stream_eviction_over_load_slots(self) -> None:
+        # A single-load streaming reduction (num_load==1: e.g. sum) is read once
+        # and never reused, so every load slot -> 'first' (evict_first frees L2),
+        # broadcast over the spec's load slots. Build the fragment explicitly so
+        # the test does not depend on the host backend's eviction choices.
         from helion.autotuner.config_fragment import EnumFragment
         from helion.autotuner.config_fragment import ListOf
 
-        env = MagicMock()
-        spec = self._reduction_spec(reduction_size_hint=1024)
+        spec = self._reduction_spec(reduction_size_hint=1024, num_load=1)
         spec.load_eviction_policies = ListOf(
             EnumFragment(choices=("", "first", "last")), length=4
         )
-        env.config_spec = spec
-        seed = TritonReductionTileHeuristic.get_seed_config(env, MagicMock())
+        env = self._reduction_env(spec)
+        # The mock env has no real GPU device, so patch hardware info / SM count (this
+        # heuristic only fires on GPU in production and the SM count is irrelevant here).
+        with (
+            patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE),
+            patch("helion.runtime.get_num_sm", return_value=132),
+        ):
+            seed = TritonStandardReductionHeuristic.get_seed_config(env, MagicMock())
         self.assertEqual(
-            seed.config["load_eviction_policies"], ["last", "last", "last", "last"]
+            seed.config["load_eviction_policies"],
+            ["first", "first", "first", "first"],
         )
 
     def test_persistent_seed_round_trips_through_config_generation(self) -> None:
@@ -729,10 +782,15 @@ class TestTritonReductionTileHeuristic(TestCase):
         # config_spec fix encodes None as the fragment's ``high`` (>= size_hint).
         from helion.autotuner.config_generation import ConfigGeneration
 
-        env = MagicMock()
         spec = self._reduction_spec(reduction_size_hint=32000)
-        env.config_spec = spec
-        seed = TritonReductionTileHeuristic.get_seed_config(env, MagicMock())
+        env = self._reduction_env(spec)
+        # The mock env has no real GPU device, so patch hardware info / SM count (this
+        # heuristic only fires on GPU in production and the SM count is irrelevant here).
+        with (
+            patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE),
+            patch("helion.runtime.get_num_sm", return_value=132),
+        ):
+            seed = TritonStandardReductionHeuristic.get_seed_config(env, MagicMock())
         spec.compiler_seed_configs = [seed]
         pairs = ConfigGeneration(spec).seed_flat_config_pairs()
         self.assertEqual(len(pairs), 1)
@@ -745,12 +803,12 @@ class TestTritonReductionTileHeuristic(TestCase):
         spec = ConfigSpec(backend=TritonBackend())
         spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=1024))
         env.config_spec = spec
-        self.assertFalse(TritonReductionTileHeuristic.is_eligible(env, MagicMock()))
+        self.assertFalse(TritonStandardReductionHeuristic.is_eligible(env, MagicMock()))
         # A matmul fact disqualifies even a 1-tile/1-reduction shape.
         spec_mm = self._reduction_spec(reduction_size_hint=1024)
         spec_mm.matmul_facts = [MagicMock()]
         env.config_spec = spec_mm
-        self.assertFalse(TritonReductionTileHeuristic.is_eligible(env, MagicMock()))
+        self.assertFalse(TritonStandardReductionHeuristic.is_eligible(env, MagicMock()))
 
     @onlyBackends(["triton"])
     @skipIfRefEager("Compiler heuristics are not collected in ref eager mode")
@@ -781,11 +839,11 @@ class TestTritonReductionTileHeuristic(TestCase):
             (torch.randn(1024, 1024, device=DEVICE, dtype=HALF_DTYPE),)
         )
         self.assertTrue(
-            TritonReductionTileHeuristic.is_eligible(
+            TritonStandardReductionHeuristic.is_eligible(
                 red.env, red.host_function.device_ir
             )
         )
-        seed = TritonReductionTileHeuristic.get_seed_config(
+        seed = TritonStandardReductionHeuristic.get_seed_config(
             red.env, red.host_function.device_ir
         )
         self.assertEqual(seed.config["block_sizes"], [1])
@@ -798,7 +856,9 @@ class TestTritonReductionTileHeuristic(TestCase):
             )
         )
         self.assertFalse(
-            TritonReductionTileHeuristic.is_eligible(mm.env, mm.host_function.device_ir)
+            TritonStandardReductionHeuristic.is_eligible(
+                mm.env, mm.host_function.device_ir
+            )
         )
 
 
@@ -3170,3 +3230,272 @@ class TestCuteTcgen05ClusterM2Heuristic(TestCase):
                 len(seed["indexing"]),
                 bound.config_spec.indexing.length,
             )
+
+
+class TestTritonReductionHeuristic(TestCase):
+    """Lock the reduction seed heuristics' branch decisions on two kernels, one per
+    track:
+
+    - rms_norm wide (rnumel=16384): the standard path
+      (``TritonStandardReductionHeuristic``) seeds a persistent reduction
+      (``reduction_loops=[None]``) with the rnumel-ramp warp count.
+    - kl_div wide (rnumel=131072): the Band-B (user-tiled) path
+      (``TritonUserTiledReductionHeuristic``) caps R_BLOCK by the accumulator footprint
+      instead of going full-N persistent, with M at floor 1.
+    """
+
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler reduction facts are not collected in ref eager mode")
+    def test_rms_norm_wide_seeds_persistent_with_warps(self) -> None:
+        from examples.rms_norm import rms_norm_fwd
+
+        m, n = 2048, 16384
+        args = (
+            torch.randn([m, n], device=DEVICE, dtype=torch.float32),
+            torch.randn([n], device=DEVICE, dtype=torch.float32),
+            1e-5,
+        )
+        heuristic = TritonStandardReductionHeuristic
+
+        # Pin the kernel to the triton backend: autotuner_heuristics is keyed on
+        # env.backend_name, and the tileir lane (where @onlyBackends(["triton"]) still
+        # runs) has no registered heuristics, so an unpinned kernel yields [] and the
+        # assertIn below fails. Pinning keeps backend_name "triton" on every lane.
+        kernel = helion.kernel(rms_norm_fwd.fn, backend="triton")
+
+        # Force the sm90 deep path so the test exercises the H100-tuned seed on any
+        # runner (off-sm90 the heuristic falls back to the conservative narrow seed).
+        with patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE):
+            bound = kernel.bind(args)
+
+            # The reduction heuristic registered a single workload fact and fired.
+            self.assertEqual(len(bound.config_spec.reduction_facts), 1)
+            fact = bound.config_spec.reduction_facts[0]
+            self.assertEqual(fact.size_hint, n)
+            # rms_norm has no separate apply/normalize loop (its apply is over the full
+            # row in the reduction scope), so no reduce-then-apply tile is captured.
+            self.assertEqual(fact.non_reduction_loop_block_ids, ())
+            self.assertIn(
+                TritonStandardReductionHeuristic.name,
+                bound.config_spec.autotuner_heuristics,
+            )
+            self.assertTrue(
+                heuristic.is_eligible(bound.env, bound.host_function.device_ir)
+            )
+
+            # Exactly one compiler seed, and it is the *persistent* standard config.
+            seeds = compiler_seed_configs(bound.env, bound.host_function.device_ir)
+        self.assertEqual(len(seeds), 1)
+        seed = seeds[0].config
+        # rnumel ramp: 16384 falls in the (4096, 16384] band -> 16 warps.
+        self.assertEqual(seed["block_sizes"], [1])
+        self.assertEqual(seed["reduction_loops"], [None])
+        self.assertEqual(seed["num_warps"], 16)
+        self.assertEqual(seed["num_stages"], 1)
+
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler reduction facts are not collected in ref eager mode")
+    def test_kl_div_wide_seeds_band_b_r_block_cap(self) -> None:
+        from examples.kl_div import kl_div_forward
+
+        m, n = 4096, 131072
+        log_q = torch.log_softmax(torch.randn([m, n], device=DEVICE), dim=-1)
+        p = torch.softmax(torch.randn([m, n], device=DEVICE), dim=-1)
+        args = (log_q, p)
+        heuristic = TritonUserTiledReductionHeuristic
+
+        # Pin the kernel to the triton backend: autotuner_heuristics is keyed on
+        # env.backend_name, and the tileir lane (where @onlyBackends(["triton"]) still
+        # runs) has no registered heuristics, so an unpinned kernel yields [] and the
+        # assertIn below fails. Pinning keeps backend_name "triton" on every lane.
+        kernel = helion.kernel(kl_div_forward.fn, backend="triton")
+
+        # Force the sm90 deep path so the Band-B seed is exercised on any runner
+        # (off-sm90 the heuristic declines to the conservative narrow seed).
+        with patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE):
+            bound = kernel.bind(args)
+
+            # Single workload fact carrying a 2D [M, R] tile -> Band B.
+            self.assertEqual(len(bound.config_spec.reduction_facts), 1)
+            fact = bound.config_spec.reduction_facts[0]
+            self.assertEqual(fact.size_hint, n)
+            self.assertGreaterEqual(fact.num_carried_2d_tiles, 1)
+            self.assertEqual(fact.non_reduction_loop_block_ids, ())
+            self.assertIn(
+                TritonUserTiledReductionHeuristic.name,
+                bound.config_spec.autotuner_heuristics,
+            )
+            self.assertTrue(
+                heuristic.is_eligible(bound.env, bound.host_function.device_ir)
+            )
+
+            # Exactly one seed; R_BLOCK is capped, NOT full-N persistent, and the
+            # grid (M) axis sits at its floor of 1.
+            seeds = compiler_seed_configs(bound.env, bound.host_function.device_ir)
+        self.assertEqual(len(seeds), 1)
+        seed = seeds[0].config
+        # Derive the expected R_BLOCK from the heuristic's OWN helper so the test tracks
+        # the real rule (pow2 of BANDB_R_BLOCK_BYTES / (itemsize * num_carried_2d_tiles)),
+        # not a hand-rolled formula that drops `* num_carried_2d_tiles` and the next_pow2
+        # rounding (it would mis-predict jsd, which carries 2 tiles).
+        expected_cap = TritonUserTiledReductionHeuristic._bandb_r_block_cap(fact)
+        # Concrete anchor: kl_div carries 1 fp32 tile -> 16384 // 4 = 4096 (already pow2).
+        self.assertEqual(expected_cap, 4096)
+        # block_sizes is [R_BLOCK, M_BLOCK]; the reduction axis is capped well
+        # below next_pow2(131072) and M stays at 1.
+        self.assertEqual(seed["block_sizes"], [expected_cap, 1])
+        self.assertLess(expected_cap, n)
+        # rnumel 131072 > the 16384 warps-32 breakpoint -> 32 warps.
+        self.assertEqual(seed["num_warps"], 32)
+        self.assertEqual(seed["num_stages"], 1)
+        # Band B must NOT use the standard reduction_loops knob.
+        self.assertNotIn("reduction_loops", seed)
+
+    @onlyBackends(["triton"])
+    @skipIfRefEager("Compiler reduction facts are not collected in ref eager mode")
+    def test_t1_reduction_then_normalize_loop_widens_tile(self) -> None:
+        # A standard rollable reduction (hl.sum over the full inner dim) IMMEDIATELY
+        # followed by a SEPARATE non-reduction hl.tile(n) loop that normalizes the row.
+        # No example kernel has this shape, so it pins the standard
+        # non-reduction-loop path:
+        # - the fact captures the normalize loop as non_reduction_loop_block_ids and
+        #   keeps m_block_ids grid-only (the normalize tile is NOT a row axis), and
+        # - the seed emits a full-length block_sizes with that tile widened (without it
+        #   the standard seed would emit a wrong-length [grid_floor] and crash) — for
+        #   BOTH the persistent and the looped (wide-N) reduction cases.
+        # NOTE: this standard+normalize seed is NOT performance-validated (no oracle);
+        # it is only a seed (worse tile => more autotuning, never wrong results), so the
+        # test asserts only that the emitted config is well-formed in both regimes.
+        @helion.kernel(backend="triton")
+        def t1_then_normalize(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(m):
+                s = torch.sum(x[tile_m, :], dim=-1)
+                for tile_n in hl.tile(n):
+                    out[tile_m, tile_n] = x[tile_m, tile_n] / s[:, None]
+            return out
+
+        def check(m: int, n: int, expect_looped: bool) -> None:
+            # Force the sm90 deep path so the standard+normalize seed is exercised on
+            # any runner (off-sm90 the heuristic falls back to the narrow seed, which
+            # does not widen the normalize tile).
+            with patch(
+                "helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE
+            ):
+                bound = t1_then_normalize.bind(
+                    (torch.randn([m, n], device=DEVICE, dtype=torch.float32),)
+                )
+                # One workload fact: reduction axis + grid-only row axis + the normalize
+                # loop captured as a non-reduction loop tile (NOT a row axis).
+                self.assertEqual(len(bound.config_spec.reduction_facts), 1)
+                fact = bound.config_spec.reduction_facts[0]
+                self.assertEqual(fact.size_hint, n)
+                self.assertEqual(fact.m_block_ids, (0,))
+                self.assertEqual(len(fact.non_reduction_loop_block_ids), 1)
+                self.assertNotIn(fact.block_id, fact.non_reduction_loop_block_ids)
+                self.assertEqual(fact.num_carried_2d_tiles, 0)
+                self.assertIn(
+                    TritonStandardReductionHeuristic.name,
+                    bound.config_spec.autotuner_heuristics,
+                )
+                # Exactly one seed; block_sizes has an entry per tiled dim (grid +
+                # normalize loop), the grid axis at its floor and the normalize tile
+                # widened (> 1), and it normalizes without error (the crux: a valid,
+                # full-length config).
+                seeds = compiler_seed_configs(bound.env, bound.host_function.device_ir)
+            self.assertEqual(len(seeds), 1)
+            seed = seeds[0].config
+            self.assertEqual(
+                len(seed["block_sizes"]), len(bound.config_spec.block_sizes)
+            )
+            norm_idx = bound.config_spec.block_sizes.block_id_to_index(
+                fact.non_reduction_loop_block_ids[0]
+            )
+            self.assertGreater(seed["block_sizes"][norm_idx], 1)
+            # Persistent (narrow row) -> reduction_loops=[None]; looped (wide row past
+            # the byte cap) -> reduction_loops=[LOOPED_CHUNK].
+            if expect_looped:
+                self.assertEqual(
+                    seed["reduction_loops"],
+                    [TritonStandardReductionHeuristic.LOOPED_CHUNK],
+                )
+                # At m_block==1 the normalize tile is clamped to the SAME ÷M_BLOCK
+                # register-resident footprint as the reduction tile, NOT left at
+                # next_pow2(N). With m_block==1 / fp32 the budget is prev_pow2(
+                # ROW_PERSIST_MAX_BYTES // (1 * 4)) == 32768, which is < next_pow2(131072).
+                # This is the only test cell that exercises the cap at M_BLOCK==1, so pin
+                # the value (a > 1 check would also pass on the OLD M_BLOCK>1-gated cap that
+                # left this tile uncapped).
+                from helion._utils import prev_power_of_2
+
+                expected_norm = prev_power_of_2(
+                    TritonStandardReductionHeuristic.ROW_PERSIST_MAX_BYTES // (1 * 4)
+                )
+                self.assertEqual(expected_norm, 32768)
+                self.assertEqual(seed["block_sizes"][norm_idx], expected_norm)
+            else:
+                self.assertEqual(seed["reduction_loops"], [None])
+            # The emitted seed must round-trip through normalize() without raising.
+            bound.config_spec.normalize(dict(seed))
+
+        # 1024x4096: 16 KB/row < 240 KB byte cap -> persistent.
+        check(1024, 4096, expect_looped=False)
+        # 1024x131072: 512 KB/row > 240 KB byte cap -> looped (the case the old guard
+        # wrongly declined into a wrong-length crash; now emits a widened looped seed).
+        check(1024, 131072, expect_looped=True)
+
+    def test_dynamic_extent_normalize_tile_matches_reduction_tile(self) -> None:
+        # When the reduction extent is NOT statically known (static_rnumel is None,
+        # e.g. a dynamic/jagged reduce-then-apply reduction), the per-row-bytes cap has
+        # no extent to key on, so the non-reduction loop tile falls back to "match the
+        # reduction tile". This default is NOT tuned on any kernel (no example kernel
+        # has a dynamic-extent non-reduction loop); the test pins the fallback's two
+        # shapes.
+        from helion.autotuner.config_spec import BlockSizeSpec
+
+        H = TritonUserTiledReductionHeuristic
+        size_hint = 4096  # next_pow2(size_hint) == 4096
+
+        def spec_with(reduction_bid: int, norm_bid: int) -> ConfigSpec:
+            spec = ConfigSpec(backend=TritonBackend())
+            # grid (block 0), reduction axis, normalize-loop axis — all block_sizes.
+            spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=1024))
+            spec.block_sizes.append(
+                BlockSizeSpec(block_id=reduction_bid, size_hint=size_hint)
+            )
+            spec.block_sizes.append(
+                BlockSizeSpec(block_id=norm_bid, size_hint=size_hint)
+            )
+            return spec
+
+        def fact(block_id: int, norm_bid: int) -> ReductionFact:
+            return ReductionFact(
+                block_id=block_id,
+                size_hint=size_hint,
+                m_block_ids=(0,),
+                static_rnumel=None,  # <-- dynamic extent: triggers the fallback
+                itemsize=4,
+                num_load=1,
+                non_reduction_loop_block_ids=(norm_bid,),
+            )
+
+        # user-tiled: the reduction axis IS a block_sizes entry (red_value given). The
+        # normalize tile matches that red_value (777, an arbitrary sentinel), NOT a
+        # byte-cap value.
+        spec = spec_with(reduction_bid=1, norm_bid=2)
+        bs = H._build_block_sizes(spec, fact(1, 2), 1, 777, non_reduction_loop_ids={2})
+        red_idx = spec.block_sizes.block_id_to_index(1)
+        norm_idx = spec.block_sizes.block_id_to_index(2)
+        self.assertEqual(bs[red_idx], 777)
+        self.assertEqual(bs[norm_idx], 777)  # normalize tile == reduction tile
+
+        # standard: the reduction rides reduction_loops (red_block_id=None,
+        # red_value=None), so the normalize tile matches next_pow2(size_hint) instead —
+        # must NOT floor to 1.
+        bs_t1 = H._build_block_sizes(
+            spec, fact(1, 2), None, None, non_reduction_loop_ids={2}
+        )
+        self.assertEqual(bs_t1[norm_idx], 4096)  # next_pow2(4096)
+        self.assertNotEqual(bs_t1[norm_idx], 1)
+        self.assertEqual(bs_t1[0], H._block_floor(spec.block_sizes[0]))  # grid floored

--- a/test/test_best_available.py
+++ b/test/test_best_available.py
@@ -324,6 +324,63 @@ class TestBestAvailable(unittest.TestCase):
         roundtripped = config_gen.flatten(config)
         self.assertEqual(roundtripped, default_flat)
 
+    def test_flatten_persistent_reduction_loop_roundtrip_large_rnumel(self):
+        """Persistent (None) must round-trip through flatten/unflatten for rnumel>4096.
+
+        Regression guard: the encode sentinel must be the fragment max
+        (``.high`` == next_power_of_2(size_hint)) so it decodes back to None for every
+        size_hint. The fragment default is capped at max_reduction_loop (4096), which is
+        < size_hint when rnumel>4096 and would degrade [None] to a looped chunk. The
+        <=4096 cases guard that the fix keeps the already-working path.
+        """
+        # rnumel>4096: the broken cases (encode default capped at 4096 < hint).
+        for size_hint in (8192, 65536, 262144):
+            config_spec = ConfigSpec(backend=TritonBackend())
+            config_spec.block_sizes.append(
+                BlockSizeSpec(block_id=0, size_hint=64, min_size=16, max_size=256)
+            )
+            config_spec.reduction_loops.append(
+                ReductionLoopSpec(block_id=1, size_hint=size_hint)
+            )
+            config_gen = ConfigGeneration(config_spec)
+
+            config = config_spec.default_config()
+            config.config["reduction_loops"] = [None]  # persistent
+            config_spec.normalize(config.config)
+
+            flat = config_gen.flatten(config)
+            restored = config_gen.unflatten(flat)
+            self.assertEqual(
+                restored.config["reduction_loops"],
+                [None],
+                f"persistent must round-trip for rnumel={size_hint} "
+                f"(got {restored.config['reduction_loops']})",
+            )
+            # flatten/unflatten is idempotent at the flat level too.
+            self.assertEqual(config_gen.flatten(restored), flat)
+
+        # rnumel<=4096: guard that the fix keeps the already-working path.
+        for size_hint in (256, 4096):
+            config_spec = ConfigSpec(backend=TritonBackend())
+            config_spec.block_sizes.append(
+                BlockSizeSpec(block_id=0, size_hint=64, min_size=16, max_size=256)
+            )
+            config_spec.reduction_loops.append(
+                ReductionLoopSpec(block_id=1, size_hint=size_hint)
+            )
+            config_gen = ConfigGeneration(config_spec)
+
+            config = config_spec.default_config()
+            config.config["reduction_loops"] = [None]
+            config_spec.normalize(config.config)
+
+            restored = config_gen.unflatten(config_gen.flatten(config))
+            self.assertEqual(
+                restored.config["reduction_loops"],
+                [None],
+                f"persistent must still round-trip for rnumel={size_hint}",
+            )
+
 
 class TestCacheMatching(unittest.TestCase):
     """Tests for cache file matching in warm start."""


### PR DESCRIPTION
Stacked PRs:
 * __->__#2762
 * #2761
 * #2760


--- --- ---

### [autotuner] Triton reduction seed heuristic (generalizable core)


Add the Triton inner-reduction seed heuristic, reading the reduction facts from the
previous PR.

- TritonReductionTileHeuristic (T1: rollable rdim — sum, rms_norm, layer_norm,
  softmax-row, cross_entropy) and TritonReductionUserTileHeuristic (T2: user-tiled —
  softmax_two_pass, kl_div, jsd, welford/groupnorm). Persistent-vs-looped element/byte
  spill caps, the rnumel num_warps ramp, Band-B R_BLOCK + Band-C combine footprint
  caps, the narrow-row w1 occupancy gate, the M_BLOCK>1 apply-loop stream cap,
  per-slot stream/re-read eviction, off-sm90 conservative fallback. This is the pruned
  generalizable core — the over-fit dtype tail is intentionally deferred.
- helion/_compiler/autotuner_heuristics/__init__.py: register the two heuristics.
- test/test_autotuner_heuristics.py, test/test_best_available.py: heuristic decisions
  + reduction-loop config round-trip coverage.