### PR TITLE
Change docker back to NV container

### DIFF
--- a/.github/workflows/benchmark_dispatch.yml
+++ b/.github/workflows/benchmark_dispatch.yml
@@ -81,7 +81,7 @@ jobs:
     with:
       runner: mt-l-x86iamx-22-225-h100
       python-version: "3.12"
-      image: pytorch/pytorch:2.11.0-cuda13.0-cudnn9-devel
+      image: nvidia/cuda:13.0.0-devel-ubuntu24.04
       runtime-version: cu130
       container-options: --gpus all
       alias: h100


### PR DESCRIPTION
Assuming ARC no longer needs python available by default