### PR TITLE
[Pallas] gate strict 128-alignment on tensor lane dim

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1927,11 +1927,14 @@ class PallasBackend(Backend):
             if bid not in analyzer.required_alignments:
                 continue
             requirement_alignment = analyzer.required_alignments[bid]
-            if requirement_alignment >= 128:
-                spec.update_min(requirement_alignment)
-            else:
-                dim_size = next_power_of_2(max(spec.size_hint, 1))
-                spec.update_min(min(requirement_alignment, dim_size))
+            dim_size = next_power_of_2(max(spec.size_hint, 1))
+            # Cap the alignment requirement by the tensor lane dim: when
+            # the dim is smaller than the requirement, the full-dim access
+            # is always aligned at offset 0 so block_size = dim_size is
+            # safe.  When the dim is at least as big as the requirement,
+            # ``min`` returns ``requirement_alignment`` and the strict
+            # floor still applies (used by aot_example.sum_aot, n=256).
+            spec.update_min(min(requirement_alignment, dim_size))
 
         # Propagate alignment minimums from inner tiles to their bounding outer tiles.
         block_specs_by_id = {


### PR DESCRIPTION
#2753 introduced spec.update_min(requirement_alignment) unconditionally when requirement_alignment >= 128.  Because BlockSizeSpec.update_min raises max_size to match the new min, the autotuner gets locked to block_size=128 even for tensors whose lane dim is smaller (e.g. D=32 or D=64).  The kernel then computes a (4, 64) value but writes into a (4, 128) scratch and we get TypeError: ... incompatible shapes for broadcasting: (4, 128), (4, 64) at runtime.

Gate the strict pin on dim_size >= requirement_alignment so it only fires when the lane dim is actually big enough to take a 128-element block.  Smaller cases fall back to the pre-#2753 cap (update_min of min(req, dim_size)).  aot_example.sum_aot keeps working since its n=256 satisfies dim_size >= 128.

Locally verified all unit tests that pass before this one still passed. The 13 are pre-preexisting breakages that we should look into separately.