### PR TITLE
[cute] Persist autotune winner from memory instead of recompiling

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -384,8 +384,9 @@ class Backend(abc.ABC):
         backend has no ephemeral-cache behavior.
 
         Autotuning compiles many candidate configs; without this they would
-        pollute the persistent cache.  The winning config is recompiled into
-        the real cache afterward (see :meth:`finalize_ephemeral_cache`).
+        pollute the persistent cache.  The winning config's artifact is
+        restored into the real cache afterward (see
+        :meth:`finalize_ephemeral_cache`).
         """
         return None
 
@@ -404,8 +405,10 @@ class Backend(abc.ABC):
     ) -> None:
         """Post-autotune cleanup after running inside an ephemeral cache.
 
-        Evicts the winning config's in-memory compiled artifact so the next
-        call recompiles it into the real (persistent) cache.  No-op by default.
+        Restores the winning config's artifact into the real (persistent)
+        cache: CuTe re-persists the in-memory compiled module directly;
+        Triton evicts the in-memory artifact so the next call recompiles
+        into the real cache.  No-op by default.
         """
         return None
 
@@ -3308,8 +3311,8 @@ class CuteBackend(Backend):
         """Redirect the CuTe DSL on-disk cache to a temporary dir during
         autotuning so candidate compilations don't pollute the real cache.
 
-        The winning config is recompiled into the real cache afterward (see
-        :meth:`finalize_ephemeral_cache`).
+        The winning config's artifact is re-persisted from memory into the
+        real cache afterward (see :meth:`finalize_ephemeral_cache`).
         """
         saved = os.environ.get("CUTE_DSL_CACHE_DIR")
         with tempfile.TemporaryDirectory(prefix="helion_cute_autotune_") as ephemeral:
@@ -3326,33 +3329,43 @@ class CuteBackend(Backend):
     def finalize_ephemeral_cache(
         self, bound_kernel: BoundKernel[Any], config: Config
     ) -> None:
+        """Persist the winning config's compiled artifact into the real cache.
+
+        Candidate artifacts died with the ephemeral dir, but the winner's
+        launcher still holds the compiled module in memory and the disk-cache
+        key excludes ``CUTE_DSL_CACHE_DIR``, so re-persisting from memory
+        writes the exact artifact a later process will look up.  Launchers and
+        compile-cache entries are kept so the winner launches without
+        recompiling.
+        """
         from ..runtime.config import Config
 
         compiled_fn = bound_kernel._compile_cache.get(config)
-        evict = config
         if compiled_fn is None:
+            # The autotuner may return a minimized config (default values
+            # stripped); the compiled entry is keyed by the full config.
             default = bound_kernel.config_spec.default_config()
             # pyrefly: ignore [bad-argument-type]
-            evict = Config(**(default.config | config.config))
-            compiled_fn = bound_kernel._compile_cache.get(evict)
-        # Drop in-memory compiled launchers so the winning config recompiles
-        # (and persists its artifact into the real, non-ephemeral cache dir)
-        # on its next launch.  PyCodeCache returns the same generated module
-        # object, so clearing the launcher dict on it is what forces the
-        # recompile + persist.
-        if compiled_fn is not None:
-            cute_kernel = compiled_fn.__globals__.get(  # type: ignore[attr-defined]
-                f"_helion_{bound_kernel.kernel.name}"
-            )
-            launchers = getattr(cute_kernel, "_helion_cute_compiled_launchers", None)
-            if launchers is not None:
-                launchers.clear()
-        # Pop the compile-cache entry so compile_config re-runs
-        # setup_compile_cache_dir (pointing CUTE_DSL_CACHE_DIR at the real dir).
-        bound_kernel._compile_cache.pop(config, None)
-        bound_kernel._compile_cache.pop(evict, None)
-        bound_kernel._cache_path_map.pop(config, None)
-        bound_kernel._cache_path_map.pop(evict, None)
+            full_config = Config(**(default.config | config.config))
+            compiled_fn = bound_kernel._compile_cache.get(full_config)
+        if compiled_fn is None:
+            return
+        cute_kernel = compiled_fn.__globals__.get(  # type: ignore[attr-defined]
+            f"_helion_{bound_kernel.kernel.name}"
+        )
+        launchers = getattr(cute_kernel, "_helion_cute_compiled_launchers", None)
+        if not launchers:
+            return
+        device_index = (
+            bound_kernel.env.device.index
+            if bound_kernel.env.device.index is not None
+            else 0
+        )
+        # The ephemeral context restored CUTE_DSL_CACHE_DIR on exit; this sets
+        # the real per-device dir when the user did not provide one.
+        self.setup_compile_cache_dir(device_index)
+        for launcher in launchers.values():
+            launcher.persist_compiled()
 
     def compiled_cache_key(
         self, bound_kernel: BoundKernel[Any], compiled_fn: object

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -2536,6 +2536,17 @@ class _CompiledCuteLauncher:
             self._compiled = compiled
         return cast("Any", compiled)(*args)
 
+    def persist_compiled(self) -> None:
+        """Persist the already-compiled module into the current on-disk cache dir.
+
+        Used by ``finalize_ephemeral_cache``: the artifact written during
+        autotuning died with the ephemeral dir, but the compiled module is
+        still in memory and ``_cache_file_paths`` resolves the destination
+        from the (now restored) ``CUTE_DSL_CACHE_DIR`` at call time.
+        """
+        if self._cache_key is not None and self._compiled is not None:
+            self._persist_to_disk(self._compiled)
+
     def _cache_file_paths(self) -> tuple[str, str, str]:
         from cutlass.base_dsl.cache_helpers import get_default_generated_ir_path
 

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -10,6 +10,7 @@ import importlib
 import inspect
 import json
 import linecache
+import logging
 import os
 import sys
 from typing import TYPE_CHECKING
@@ -35,6 +36,8 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     import jax
+
+log: logging.Logger = logging.getLogger(__name__)
 
 _CUTLASS_SHUTDOWN_PATCHED = False
 
@@ -2556,7 +2559,7 @@ class _CompiledCuteLauncher:
         return cache_dir, mlir, meta
 
     def _persist_to_disk(self, compiled: object) -> None:
-        with suppress(Exception):
+        try:
             from cutlass.base_dsl.cache_helpers import save_ir
             from cutlass.base_dsl.cache_helpers import write_bytecode_with_crc32
 
@@ -2588,6 +2591,13 @@ class _CompiledCuteLauncher:
                     f,
                 )
             os.replace(tmp, meta)
+        except Exception:
+            # A failed persist only costs a recompile in a later process.
+            log.debug(
+                "CuTe disk-cache persist failed for key %s",
+                self._cache_key,
+                exc_info=True,
+            )
 
     def _reload_from_disk(self) -> object:
         try:

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -2591,8 +2591,8 @@ class _CompiledCuteLauncher:
                     f,
                 )
             os.replace(tmp, meta)
-        except Exception:
-            # A failed persist only costs a recompile in a later process.
+        except (ImportError, OSError):
+            # Old cutlass or an unwritable cache dir; just recompile next time.
             log.debug(
                 "CuTe disk-cache persist failed for key %s",
                 self._cache_key,

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -750,6 +750,20 @@ class TestCache(RefEagerTestDisabled, TestCase):
                 result = kernel(*args_a)
             torch.testing.assert_close(result, result_a, rtol=1e-2, atol=5e-2)
 
+            # Force the disk-reload path: with the in-memory launchers cleared,
+            # a successful launch must come from the persisted artifact.
+            config = bound._require_implicit_config()
+            compiled_fn = bound._compile_cache[config]
+            cute_kernel = compiled_fn.__globals__[f"_helion_{bound.kernel.name}"]
+            cute_kernel._helion_cute_compiled_launchers.clear()
+            with patch.object(
+                cute,
+                "compile",
+                side_effect=AssertionError("reload should hit the persisted artifact"),
+            ):
+                result = kernel(*args_a)
+            torch.testing.assert_close(result, result_a, rtol=1e-2, atol=5e-2)
+
 
 instantiate_parametrized_tests(TestCache)
 

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -707,6 +707,49 @@ class TestCache(RefEagerTestDisabled, TestCase):
             self.assertIsNotNone(cache_key)
             self.assertTrue(_backend_cache_artifact(backend_cache, cache_key).exists())
 
+    def test_ephemeral_cache_winner_persisted_at_finalize(self):
+        """CuTe finalize re-persists the winner from memory: the artifact lands
+        in the real cache dir at autotune time (before any post-autotune
+        launch) and the first launch does not recompile."""
+        if not _is_cute():
+            self.skipTest("cute-only: finalize persists from memory")
+
+        env_name = _backend_cache_dir_env()
+        subdir = _backend_cache_subdir()
+
+        kernel, args_a, result_a, _args_b, _result_b = KERNELS["add"]()
+        kernel.reset()
+        kernel.settings.autotuner_fn = StrictLocalAutotuneCache[MultiConfigSearch]
+
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch.dict(os.environ, {"HELION_CACHE_DIR": tmp}),
+        ):
+            os.environ.pop(env_name, None)
+            bound = kernel.bind(args_a)
+            bound.autotune(args_a)
+
+            cache_key = bound.backend_cache_key()
+            self.assertIsNotNone(cache_key)
+            backend_cache = Path(tmp) / subdir / "0"
+            artifact = _backend_cache_artifact(backend_cache, cache_key)
+            self.assertTrue(artifact.is_file())
+            sidecar = backend_cache / f"cute_dsl_{cache_key}.json"
+            self.assertTrue(sidecar.is_file())
+            # Only the winner's artifact pair was persisted.
+            entries = [p for p in backend_cache.iterdir() if not p.name.startswith(".")]
+            self.assertEqual(len(entries), 2)
+
+            import cutlass.cute as cute
+
+            with patch.object(
+                cute,
+                "compile",
+                side_effect=AssertionError("winner should not recompile"),
+            ):
+                result = kernel(*args_a)
+            torch.testing.assert_close(result, result_a, rtol=1e-2, atol=5e-2)
+
 
 instantiate_parametrized_tests(TestCache)
 


### PR DESCRIPTION
The on-disk cache key deliberately excludes CUTE_DSL_CACHE_DIR, so the winner's still-in-memory ir_module can be re-persisted directly into the real cache dir under the exact filename a later process looks up.
Replaces finalize's evict-and-recompile: saves one cute.compile per autotune, keeps the winner hot in memory, and persists the artifact even when the tuning process never launches the kernel afterward.