### PR TITLE
[pallas] ci: temporarily freeze PyTorch wheel version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,8 +128,10 @@ jobs:
             VERSION="${VERSION#pytorch-}"
             uv pip install -U "torch==${VERSION}.*" --index-url https://download.pytorch.org/whl/${{ matrix.runtime-version }}
           elif [[ "${{ matrix.runtime-version }}" == "tpu" ]]; then
-            # TPU: install CPU-only PyTorch nightly (torch_tpu provides TPU backend)
-            uv pip install -U --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
+            # TODO: TorchTPU needs to catch up with a recent PyTorch change:
+            #   https://github.com/pytorch/pytorch/pull/186928
+            # In the meantime, use a PyTorch wheel that does not contain that change.
+            uv pip install -U --pre "torch==2.13.0.dev20260609" --index-url https://download.pytorch.org/whl/nightly/cpu
           else
             # Default to nightly
             # On OSDC, route nightly through the pypi-cache /whl proxy (deps stay reachable behind the egress firewall) and clear the cache index vars so it wins over the cache default; off OSDC PYPI_CACHE_WHL_URL is unset so we hit download.pytorch.org.


### PR DESCRIPTION
To let TorchTPU catch up with PyTorch HEAD.