### PR TITLE
Fix UnicodeEncodeError in codegen under ASCII locale

### DIFF
--- a/test/test_autodiff.py
+++ b/test/test_autodiff.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import locale
 import operator
 import unittest
 
@@ -13,6 +14,15 @@ from helion._testing import skipIfMTIA
 from helion._testing import skipIfNotTriton
 from helion._testing import skipIfXPU
 import helion.language as hl
+
+# Triton writes its generated launcher source with the process locale encoding;
+# force a UTF-8 locale so a non-UTF-8 worker doesn't fail to encode non-ASCII bytes.
+for _utf8_locale in ("C.UTF-8", "en_US.UTF-8", "C.utf8", "en_US.utf8"):
+    try:
+        locale.setlocale(locale.LC_CTYPE, _utf8_locale)
+        break
+    except locale.Error:
+        continue
 
 
 @skipIfMTIA("autodiff not tested on MTIA")


### PR DESCRIPTION
Fix UnicodeEncodeError in codegen under ASCII locale

`test_example_attention_non_divisible_seqlen` failed in internal CI with `UnicodeEncodeError: '\u2014'` on a cold-cache compile, Triton writes its generated launcher with the process locale encoding, which fails on a non-UTF-8 CI worker. Fix forces a UTF-8 locale in the test so the write succeeds regardless of worker environment.