### PR TITLE
[test] Restore mutated kernel configs/settings in test_examples to stop leaks

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -251,8 +251,16 @@ class TestExamples(RefEagerTestBase, TestCase):
     def test_matmul_bwd(self):
         """Test backward pass for matmul via matmul_autograd."""
         mod = import_path(EXAMPLES_DIR / "matmul.py")
-        # Set a fixed config to avoid autotuning in CI
+        # Set a fixed config to avoid autotuning in CI.  ``import_path`` caches
+        # the module in ``sys.modules``, so ``mod.matmul`` is a process-wide
+        # singleton shared with every other test that imports the matmul
+        # example.  Restore ``configs`` on teardown so this mutation does not
+        # leak: a leaked non-empty ``configs`` makes the kernel skip autotuning
+        # entirely, which e.g. breaks ``test_cache``'s cache-miss assertions
+        # when that test later runs the same singleton on the same worker.
         config = helion.Config(block_sizes=[16, 16, 16])
+        original_configs = mod.matmul.configs
+        self.addCleanup(setattr, mod.matmul, "configs", original_configs)
         mod.matmul.configs = [config]
 
         mat1 = torch.randn(
@@ -278,8 +286,14 @@ class TestExamples(RefEagerTestBase, TestCase):
     def test_addmm_bwd(self):
         """Test backward pass for addmm via addmm_autograd."""
         mod = import_path(EXAMPLES_DIR / "matmul.py")
-        # Set a fixed config to avoid autotuning in CI
+        # Set a fixed config to avoid autotuning in CI.  ``mod.matmul`` is a
+        # process-wide singleton (``import_path`` caches the module), so
+        # restore ``configs`` on teardown to avoid leaking the mutation into
+        # other tests (a non-empty ``configs`` makes the kernel skip
+        # autotuning).  See ``test_matmul_bwd``.
         config = helion.Config(block_sizes=[16, 16, 16])
+        original_configs = mod.matmul.configs
+        self.addCleanup(setattr, mod.matmul, "configs", original_configs)
         mod.matmul.configs = [config]
 
         bias = torch.randn(
@@ -1982,7 +1996,16 @@ class TestExamples(RefEagerTestBase, TestCase):
 
         mod = import_path(EXAMPLES_DIR / "fused_linear_jsd.py")
         # Pin jsd_kernel's config so we skip autotune (CI speed). Block size 16
-        # is a small safe pick across backends.
+        # is a small safe pick across backends.  ``mod.jsd_kernel`` is a
+        # process-wide singleton (``import_path`` caches the module); restore
+        # the mutated ``configs`` / ``settings.static_shapes`` on teardown so
+        # the changes don't leak into other tests.
+        original_configs = mod.jsd_kernel.configs
+        original_static_shapes = mod.jsd_kernel.settings.static_shapes
+        self.addCleanup(setattr, mod.jsd_kernel, "configs", original_configs)
+        self.addCleanup(
+            setattr, mod.jsd_kernel.settings, "static_shapes", original_static_shapes
+        )
         mod.jsd_kernel.settings.static_shapes = True
         mod.jsd_kernel.configs = [helion.Config(block_sizes=[16])]
         result = mod.fused_linear_jsd_fwd(
@@ -2514,8 +2537,15 @@ class TestExamples(RefEagerTestBase, TestCase):
         ]
 
         mod = import_path(EXAMPLES_DIR / "flex_attention.py")
-        # Set a fixed config to skip autotuning (exceeds CI timeout)
+        # Set a fixed config to skip autotuning (exceeds CI timeout).
+        # ``mod.helion_flex_attention_kernel`` is a process-wide singleton
+        # (``import_path`` caches the module); restore ``configs`` on teardown
+        # so the mutation doesn't leak into other tests.
         config = helion.Config(block_sizes=[64, 64])
+        original_configs = mod.helion_flex_attention_kernel.configs
+        self.addCleanup(
+            setattr, mod.helion_flex_attention_kernel, "configs", original_configs
+        )
         mod.helion_flex_attention_kernel.configs = [config]
         out = mod.helion_flex_attention(q, k, v)
         expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)


### PR DESCRIPTION

Several tests in ``test_examples.py`` pin a fixed config (to skip autotuning
in CI) by mutating an imported example kernel:

    mod = import_path(EXAMPLES_DIR / "matmul.py")
    mod.matmul.configs = [config]

``import_path`` caches the module in ``sys.modules``, so ``mod.matmul`` (etc.)
is a process-wide singleton shared with every other test that imports the same
example.  These tests never restored the mutation, so it leaked across tests:
a kernel with a non-empty ``configs`` skips autotuning entirely.

When ``test_cache.py::TestCache::test_kernel[matmul]`` later ran the leaked
matmul singleton on the same xdist worker, ``kernel.reset()`` cleared the
bound kernels but NOT ``configs``, so the kernel skipped autotuning and the
autotune-cache path was never entered — failing the test's
``cache_miss == 1`` assertion with ``0 != 1``.  The failure was
order-dependent (only when both tests landed on the same worker), which is
why it surfaced intermittently and looked unrelated to the change under test.

Save and restore the mutated attributes via ``addCleanup`` so each test's
mutation is local to it.  Fixes all four leaking sites:

  - ``test_matmul_bwd``   -> ``matmul.configs``
  - ``test_addmm_bwd``    -> ``matmul.configs`` (same singleton as above)
  - ``test_jsd`` (fused_linear_jsd) -> ``jsd_kernel.configs`` and
    ``jsd_kernel.settings.static_shapes``
  - ``test_flex_attention`` -> ``helion_flex_attention_kernel.configs``

Reproduce the ORIGINAL failure (before this fix): run a leaking matmul test
and the cache test in the SAME process so they share the ``mod.matmul``
singleton, the leaking test first:

    HELION_BACKEND=cute python -m pytest \
        "test/test_examples.py::TestExamples::test_matmul_bwd" \
        "test/test_cache.py::TestCache::test_kernel_name_matmul" \
        -p no:randomly -q

Without the fix this fails with:

    test/test_cache.py:243: AssertionError
    E   AssertionError: 0 != 1      # counters["autotune"]["cache_miss"]

With the fix both tests pass.  (``test_addmm_bwd`` reproduces it identically;
either test alone passes regardless — the bug only appears when a leaking test
runs first in the same process.)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
