### PR TITLE
[cute] 2-CTA MMA at bm=128 (CTA tile 64xbn) for fp8 tcgen05

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -52,8 +52,8 @@ from .strategies import is_pure_matmul_role_lifecycle_config
 from .strategies import l2_swizzle_size_from_config
 from .strategies import layout_overrides_from_config
 from .strategies import smem_swizzle_min_major_mode_bytes
-from .strategies import tcgen05_default_epilogue_tile_expr
 from .strategies import tcgen05_explicit_epilogue_tile_expr
+from .strategies import tcgen05_resolve_epilogue_tile
 from .strategies import tcgen05_smem_layout_expr
 from .strategies import warp_spec_from_config
 from .tcgen05_constants import TCGEN05_AB_CONSUMER_PHASE_MODE_CONFIG_KEY
@@ -2002,7 +2002,9 @@ def _emit_mma_pipeline(
         )
     tcgen05_pid_is_persistent = _is_persistent_pid_config(df.config)
     tcgen05_requested_two_cta = _tcgen05_use_2cta_instrs(
-        bm=bm, cluster_m=tcgen05_cluster_m
+        bm=bm,
+        cluster_m=tcgen05_cluster_m,
+        input_dtype=input_dtype,
     )
     tcgen05_cluster_n_requested = _tcgen05_cluster_n(df.config)
     tcgen05_static_output_tiles = m_size % bm == 0 and n_size % bn == 0
@@ -3139,6 +3141,7 @@ def _emit_mma_pipeline(
                 bn,
                 tcgen05_cluster_m=tcgen05_cluster_m,
                 b_k_major=tcgen05_b_k_major,
+                tcgen05_use_2cta_instrs=tcgen05_is_two_cta,
             )
         )
     else:
@@ -3315,6 +3318,7 @@ def _emit_mma_pipeline(
                     bn,
                     tcgen05_cluster_m=tcgen05_cluster_m,
                     b_k_major=tcgen05_b_k_major,
+                    tcgen05_use_2cta_instrs=tcgen05_is_two_cta,
                 )
             )
         else:
@@ -3333,6 +3337,7 @@ def _emit_mma_pipeline(
                     bn,
                     tcgen05_cluster_m=tcgen05_cluster_m,
                     b_k_major=tcgen05_b_k_major,
+                    tcgen05_use_2cta_instrs=tcgen05_is_two_cta,
                 )
             )
     if mma_impl == "tcgen05":
@@ -3968,6 +3973,15 @@ def _emit_mma_pipeline(
                 "k_total_size": k_total_size,
                 "kernel_args": [tma_atom_a, tma_tensor_a, tma_atom_b, tma_tensor_b],
             }
+            # The bm=128 CtaGroup.TWO family cannot be derived from
+            # ``bm == 256`` by the host wrapper, so record the resolved 2-CTA
+            # decision on the plan. Only recorded for this family (where the
+            # wrapper's legacy ``bm == 256`` derivation would be wrong); the
+            # bm=256 path leaves the key absent so its golden wrapper-plan
+            # literal stays byte-identical and the wrapper falls back to the
+            # derivation. See ``_tcgen05_use_2cta_instrs``.
+            if tcgen05_is_two_cta and bm != TCGEN05_TWO_CTA_BLOCK_M:
+                ab_tma_plan["use_2cta_instrs"] = True
             # K-major (column-major / K-contiguous) B. Only recorded when True
             # so MN-major (row-major B) wrapper-plan literals stay byte-identical
             # to the golden.
@@ -5190,12 +5204,24 @@ def _tcgen05_large_bn_proof_shape(
     )
 
 
-def _tcgen05_use_2cta_instrs(*, bm: int, cluster_m: int) -> bool:
+def _tcgen05_use_2cta_instrs(
+    *, bm: int, cluster_m: int, input_dtype: torch.dtype | str | None = None
+) -> bool:
     # Match Quack/CUTLASS SM100: clustered kernels are not automatically the
-    # tcgen05 "CTA pair" instruction family. The special 2-CTA instructions only
-    # apply to the 256-wide M tiler. Our current legal Helion family still uses
-    # CTA-local M=128 tiles, even when the cluster shape is (2, 1, 1).
-    return cluster_m == 2 and bm == TCGEN05_TWO_CTA_BLOCK_M
+    # tcgen05 "CTA pair" instruction family. CUTLASS admits the 2-CTA MMA for
+    # mma_m in {128, 256} (CTA tile m of 64 or 128). bm=256 is the legacy
+    # validated family. bm=128 (CTA tile 64xbn) is the small-grid family
+    # validated for fp8 on the 512x6144x2048 scaled_mm shape, where it beats
+    # both the bm=256 2-CTA and every 1-CTA config; it is fp8-gated because
+    # the f16/bf16 bm=128 + cluster_m=2 config point is owned by the legacy
+    # clustered CTA-local CtaGroup.ONE family (guarded diagnostic bridge and
+    # multi-tile runtime guard).
+    if cluster_m != 2:
+        return False
+    if bm == TCGEN05_TWO_CTA_BLOCK_M:
+        return True
+    is_fp8 = input_dtype == torch.float8_e4m3fn or input_dtype == "cutlass.Float8E4M3FN"
+    return bm == 128 and is_fp8
 
 
 def _tcgen05_epi_warp_count(
@@ -5365,6 +5391,7 @@ def _make_tiled_mma_setup(
     *,
     tcgen05_cluster_m: int = 1,
     b_k_major: bool = False,
+    tcgen05_use_2cta_instrs: bool | None = None,
 ) -> list[ast.AST]:
     if mma_impl == "warp":
         tiled_mma_expr = (
@@ -5381,6 +5408,7 @@ def _make_tiled_mma_setup(
             bn,
             tcgen05_cluster_m=tcgen05_cluster_m,
             b_k_major=b_k_major,
+            use_2cta_instrs=tcgen05_use_2cta_instrs,
         )
     else:
         assert mma_thread_linear
@@ -5410,9 +5438,18 @@ def _tcgen05_tiled_mma_expr(
     *,
     tcgen05_cluster_m: int = 1,
     b_k_major: bool = False,
+    use_2cta_instrs: bool | None = None,
 ) -> str:
+    # ``use_2cta_instrs`` lets the caller thread the resolved CtaGroup decision
+    # (which depends on the input dtype, not just bm/cluster_m) instead of
+    # re-deriving it here without dtype context. When omitted, fall back to the
+    # bm/cluster_m derivation for the legacy bm=256 family and non-fp8 callers.
+    if use_2cta_instrs is None:
+        use_2cta_instrs = _tcgen05_use_2cta_instrs(
+            bm=bm, cluster_m=tcgen05_cluster_m, input_dtype=input_dtype_str
+        )
     cta_group_expr = "cute.nvgpu.tcgen05.CtaGroup.ONE"
-    if _tcgen05_use_2cta_instrs(bm=bm, cluster_m=tcgen05_cluster_m):
+    if use_2cta_instrs:
         cta_group_expr = "cute.nvgpu.tcgen05.CtaGroup.TWO"
     # A is always K-major. B is MN-major for row-major (N-contiguous) B and
     # K-major for column-major (K-contiguous) B.
@@ -5492,12 +5529,25 @@ def _make_tcgen05_layout_plan_setup(
             "cute",
             "explicit tcgen05 epilogue tile requires both tile dimensions",
         )
-    epi_tile_expr = (
+    # The bm=128 CtaGroup.TWO family uses the per-CTA epilogue tile (m of 64,
+    # ``use_2cta=True``, no-source) -- see
+    # ``tcgen05_two_cta_m128_epilogue_tile_expr``. ``get_tmem_load_op`` and the
+    # SMEM staging on this path must also see the per-CTA M of ``bm // 2``;
+    # the legacy bm=256/bm=128-1CTA paths keep the full ``bm``. Resolved through
+    # the shared helper so this device-side ``(epi_tile_m, epi_tile_expr)`` pair
+    # stays identical to the store side in ``memory_ops.py``.
+    explicit_epi_tile_expr = (
         tcgen05_explicit_epilogue_tile_expr(explicit_epi_tile_m, explicit_epi_tile_n)
         if explicit_epi_tile_m is not None and explicit_epi_tile_n is not None
-        else tcgen05_default_epilogue_tile_expr(
-            bm, bn, epi_elem_dtype_str, c_layout=plan.c_layout
-        )
+        else None
+    )
+    epi_tile_m, epi_tile_expr = tcgen05_resolve_epilogue_tile(
+        bm=bm,
+        bn=bn,
+        is_two_cta=is_two_cta,
+        elem_dtype=epi_elem_dtype_str,
+        c_layout=plan.c_layout,
+        explicit_expr=explicit_epi_tile_expr,
     )
     return [
         statement_from_string(
@@ -5514,7 +5564,7 @@ def _make_tcgen05_layout_plan_setup(
         statement_from_string(f"{plan.epi_tile} = {epi_tile_expr}"),
         statement_from_string(
             f"{plan.tmem_load_atom} = cutlass.utils.blackwell_helpers.get_tmem_load_op("
-            f"({bm}, {bn}, {bk}), {plan.c_layout}, "
+            f"({epi_tile_m}, {bn}, {bk}), {plan.c_layout}, "
             f"{acc_dtype_str}, {acc_dtype_str}, {plan.epi_tile}, {is_two_cta!s})"
         ),
         statement_from_string(

--- a/helion/_compiler/cute/strategies.py
+++ b/helion/_compiler/cute/strategies.py
@@ -717,6 +717,91 @@ def tcgen05_default_epilogue_tile_expr(
     )
 
 
+def tcgen05_two_cta_m128_epilogue_tile_expr(
+    bm: int, bn: int, elem_dtype: str, *, c_layout: str
+) -> str:
+    """Epilogue tile for the bm=128 CtaGroup.TWO family (per-CTA tile 64xbn).
+
+    The bm=256 2-CTA path and the bm=128 1-CTA path both build the epilogue
+    tile from the full ``(bm, bn)`` shape, where the per-CTA and full-CTA
+    conventions produce identical tiles, so the legacy form is kept there for
+    golden-output stability; at bm=128 they diverge: the per-CTA tile m of 64
+    selects the 2-CTA ``(2, 2)`` epilogue warp grid, whose tile is **N-mode
+    permuted** (e.g. ``[64:1;(16,2):(1,64)]``). Every consumer of this tile --
+    the matmul-plan ``tcgen05_epi_tile``, the store-side
+    ``tcgen05_store_epi_tile``, the SMEM staging layouts, and the host-side
+    TMA store atom in ``helion/runtime/__init__.py`` -- must use this same
+    expression; building any of them from a plain ``(m, n)`` tile silently
+    permutes the output through SMEM (wrong values + torn bf16 pairs).
+
+    The no-source form (no ``elem_ty_c``) is deliberate: this family has no
+    residual-C epilogue input, and the with-source sizing would halve
+    ``tile_n`` (32 vs 64), doubling epilogue iterations for nothing
+    (~4% measured on the 512x6144x2048 fp8 scaled_mm shape).
+    """
+    assert bm == 128, bm
+    return (
+        "cutlass.utils.blackwell_helpers.compute_epilogue_tile_shape("
+        f"({bm // 2}, {bn}), True, {c_layout}, {elem_dtype})"
+    )
+
+
+def tcgen05_is_two_cta_m128(*, is_two_cta: bool, bm: int) -> bool:
+    """True for the bm=128 CtaGroup.TWO family (per-CTA tile, N-mode permuted).
+
+    ``is_two_cta`` is True for *both* 2-CTA families -- the legacy bm=256 path
+    (full-(bm, bn) tile, per-CTA and full-CTA conventions coincide) and this
+    bm=128 small-grid path (per-CTA tile m of ``bm // 2``, N-mode permuted) --
+    so the extra ``bm == 128`` check is what separates the two from each other,
+    not the 2-CTA case from the 1-CTA case. Only this family must thread the
+    permuted ``tcgen05_two_cta_m128_epilogue_tile_expr`` to every consumer; the
+    bm=256 path keeps the legacy full-tile form. The fp8 gate that makes this
+    branch reachable lives in ``_tcgen05_use_2cta_instrs`` (the f16/bf16
+    bm=128 + cluster_m=2 point is owned by the legacy CtaGroup.ONE family), so
+    this predicate stays dtype-agnostic and tracks only the structural family.
+    """
+    return is_two_cta and bm == 128
+
+
+def tcgen05_resolve_epilogue_tile(
+    *,
+    bm: int,
+    bn: int,
+    is_two_cta: bool,
+    elem_dtype: str,
+    c_layout: str,
+    explicit_expr: str | None = None,
+) -> tuple[int, str]:
+    """Resolve ``(epi_tile_m, epi_tile_expr)`` for a tcgen05 store.
+
+    Single source of truth for the bm=128 CtaGroup.TWO per-CTA tile (m of
+    ``bm // 2``, N-mode permuted -- see
+    ``tcgen05_two_cta_m128_epilogue_tile_expr``) vs the legacy full-``(bm, bn)``
+    tile. The layout-plan setup in ``cute_mma.py`` and the store side in
+    ``memory_ops.py`` must produce identical ``epi_tile_m`` / ``epi_tile_expr``
+    pairs or the device r2s SMEM copy and the host TMA store atom disagree and
+    the output is silently scrambled, so both call here.
+
+    ``explicit_expr`` is the pre-built CuTe expression for a user-supplied
+    explicit epilogue tile (the integer-keyed
+    ``tcgen05_explicit_epilogue_tile_expr`` on the layout-plan side, the
+    plan-recorded store-tile string on the store side); when present it wins
+    over the family-derived expression but ``epi_tile_m`` still follows the
+    per-CTA convention.
+    """
+    two_cta_m128 = tcgen05_is_two_cta_m128(is_two_cta=is_two_cta, bm=bm)
+    epi_tile_m = bm // 2 if two_cta_m128 else bm
+    if explicit_expr is not None:
+        return epi_tile_m, explicit_expr
+    if two_cta_m128:
+        return epi_tile_m, tcgen05_two_cta_m128_epilogue_tile_expr(
+            bm, bn, elem_dtype, c_layout=c_layout
+        )
+    return epi_tile_m, tcgen05_default_epilogue_tile_expr(
+        bm, bn, elem_dtype, c_layout=c_layout
+    )
+
+
 def tcgen05_explicit_d_store_tile_expr(tile_m: int, d_store_box_n: int) -> str:
     """Return the CuTe expression for a validated explicit D-store box.
 

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -22,8 +22,10 @@ from .._compiler.cute.cute_epilogue import _AuxiliaryTensorStep
 from .._compiler.cute.cute_epilogue import analyze_tcgen05_unary_epilogue_chain
 from .._compiler.cute.cute_fx_walk import reach_tcgen05_matmul_anchors
 from .._compiler.cute.cutedsl_compat import emit_pipeline_advance
-from .._compiler.cute.strategies import tcgen05_default_epilogue_tile_expr
 from .._compiler.cute.strategies import tcgen05_explicit_d_store_tile_expr
+from .._compiler.cute.strategies import tcgen05_is_two_cta_m128
+from .._compiler.cute.strategies import tcgen05_resolve_epilogue_tile
+from .._compiler.cute.strategies import tcgen05_two_cta_m128_epilogue_tile_expr
 from .._compiler.cute.tcgen05_constants import (
     TCGEN05_ACC_WAIT_PLACEMENT_BEFORE_SUBTILE_LOOP,
 )
@@ -3531,6 +3533,16 @@ def _codegen_cute_store_tcgen05_tile(
                 tcgen05_value.role_local_tile_counter,
                 increment_per_tile=not tcgen05_value.tma_store_full_tiles_only,
             )
+        # The bm=128 CtaGroup.TWO family's epilogue tile is N-mode permuted
+        # (see ``tcgen05_two_cta_m128_epilogue_tile_expr``); the host TMA-store
+        # atom must be built from this *exact* device-side expression, not from
+        # the plain ``epi_tile_m/n`` integer keys (which build an unpermuted
+        # ``(m, n)`` tile and silently scramble the output -- the correctness
+        # bug §7 in FINDINGS_512_SHAPE.md). ``epi_tile_raw_expr`` carries the
+        # verbatim device expression to the wrapper.
+        d_two_cta_m128 = tcgen05_is_two_cta_m128(
+            is_two_cta=tcgen05_lifecycle.is_two_cta, bm=tcgen05_value.bm
+        )
         d_tma_plan: dict[str, object] = {
             "kind": "tcgen05_d_tma",
             "d_name": tensor_name,
@@ -3542,6 +3554,18 @@ def _codegen_cute_store_tcgen05_tile(
                 tcgen05_value.tma_store_atom,
                 tcgen05_value.tma_store_tensor,
             ],
+            **(
+                {
+                    "epi_tile_raw_expr": tcgen05_two_cta_m128_epilogue_tile_expr(
+                        tcgen05_value.bm,
+                        tcgen05_value.bn,
+                        target_dtype,
+                        c_layout="cutlass.utils.layout.LayoutEnum.ROW_MAJOR",
+                    )
+                }
+                if d_two_cta_m128 and not tcgen05_value.has_explicit_epilogue_tile
+                else {}
+            ),
             **(
                 {
                     "epi_tile_m": tcgen05_value.explicit_epi_tile_m,
@@ -3561,6 +3585,20 @@ def _codegen_cute_store_tcgen05_tile(
     tcgen05_c_stage_count = tcgen05_value.c_stage_count
     tcgen05_is_two_cta = tcgen05_lifecycle.is_two_cta
     tcgen05_thr_mma = tcgen05_value.thr_mma
+    # The bm=128 CtaGroup.TWO family stores through the per-CTA epilogue tile
+    # (m of 64, ``use_2cta=True``, no-source) so the store-side
+    # ``tcgen05_store_epi_tile``, the ``kernel_desc.cta_tile_shape_mnk``, and
+    # the host TMA-store atom all match the device-side N-mode-permuted tile.
+    # Resolved through the shared helper so this ``(store_tile_m, epi_tile_expr)``
+    # pair stays identical to the layout-plan side in ``cute_mma.py``.
+    tcgen05_store_tile_m, tcgen05_store_epi_tile_expr = tcgen05_resolve_epilogue_tile(
+        bm=tcgen05_bm,
+        bn=tcgen05_bn,
+        is_two_cta=tcgen05_is_two_cta,
+        elem_dtype=target_dtype,
+        c_layout="cutlass.utils.layout.LayoutEnum.ROW_MAJOR",
+        explicit_expr=tcgen05_explicit_store_tile_expr,
+    )
     full_tile_expr = (
         f"({base_indices[0]}) + cutlass.Int32({tcgen05_bm}) <= {m_size} "
         f"and ({base_indices[1]}) + cutlass.Int32({tcgen05_bn}) <= {n_size}"
@@ -3569,18 +3607,11 @@ def _codegen_cute_store_tcgen05_tile(
     def store_common_setup(
         gmem_tensor: str, *, include_full_tile: bool
     ) -> tuple[list[str], list[str]]:
-        epi_tile_expr = tcgen05_explicit_store_tile_expr or (
-            tcgen05_default_epilogue_tile_expr(
-                tcgen05_bm,
-                tcgen05_bn,
-                target_dtype,
-                c_layout="cutlass.utils.layout.LayoutEnum.ROW_MAJOR",
-            )
-        )
+        epi_tile_expr = tcgen05_store_epi_tile_expr
         static_setup = [
             (
                 f"{kernel_desc} = type('Tcgen05KernelDesc', (), {{"
-                f"'cta_tile_shape_mnk': ({tcgen05_bm}, {tcgen05_bn}, {tcgen05_bk}), "
+                f"'cta_tile_shape_mnk': ({tcgen05_store_tile_m}, {tcgen05_bn}, {tcgen05_bk}), "
                 "'c_layout': cutlass.utils.layout.LayoutEnum.ROW_MAJOR, "
                 f"'c_dtype': {target_dtype}, "
                 "'acc_dtype': cutlass.Float32, "

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -2043,6 +2043,11 @@ def _append_cute_wrapper_plan(
         assert value is None or isinstance(value, int)
         return value
 
+    def plan_optional_str(key: str) -> str | None:
+        value = plan.get(key)
+        assert value is None or isinstance(value, str)
+        return value
+
     def require_positive_int(value: int | None, name: str) -> int:
         assert type(value) is int, name
         assert value > 0, name
@@ -2060,12 +2065,21 @@ def _append_cute_wrapper_plan(
         epi_tile_m: int | None = None,
         epi_tile_n: int | None = None,
         d_store_box_n: int | None = None,
+        epi_tile_raw_expr: str | None = None,
     ) -> None:
         assert len(kernel_args) == 2
         explicit_epi_tile = any(
             value is not None for value in (epi_tile_m, epi_tile_n, d_store_box_n)
         )
-        if explicit_epi_tile:
+        if epi_tile_raw_expr is not None:
+            # The bm=128 CtaGroup.TWO family threads the device-exact (N-mode
+            # permuted) epilogue-tile expression verbatim so the host TMA-store
+            # atom is built from the same layout the device r2s copy writes
+            # through. The plain ``epi_tile_m/n`` integer keys cannot express
+            # the permutation. See ``tcgen05_two_cta_m128_epilogue_tile_expr``.
+            assert not explicit_epi_tile
+            epi_tile_expr = epi_tile_raw_expr
+        elif explicit_epi_tile:
             checked_epi_tile_m = require_positive_int(epi_tile_m, "epi_tile_m")
             checked_epi_tile_n = require_positive_int(epi_tile_n, "epi_tile_n")
             checked_d_store_box_n = require_positive_int(d_store_box_n, "d_store_box_n")
@@ -2130,6 +2144,7 @@ def _append_cute_wrapper_plan(
             epi_tile_m=plan_optional_int("epi_tile_m"),
             epi_tile_n=plan_optional_int("epi_tile_n"),
             d_store_box_n=plan_optional_int("d_store_box_n"),
+            epi_tile_raw_expr=plan_optional_str("epi_tile_raw_expr"),
         )
         return
     if kind == "tcgen05_aux_tma":
@@ -2191,9 +2206,20 @@ def _append_cute_wrapper_plan(
     # cluster_m=2 cluster_n=1 but rejects the canonical Quack-best
     # cluster_m=2 cluster_n=2 4-CTA cluster (product=4). Use
     # ``cluster_m == 2`` directly so cluster_n=2 keeps CtaGroup.TWO.
+    #
+    # The bm=128 CtaGroup.TWO family (fp8 small-grid) cannot be derived from
+    # ``bm == 256`` here, so the device codegen records the resolved decision
+    # on the plan as ``use_2cta_instrs``. Honor it when present; fall back to
+    # the legacy bm==256 derivation for golden-stable older plans.
+    plan_use_2cta = plan.get("use_2cta_instrs")
+    if plan_use_2cta is not None:
+        assert isinstance(plan_use_2cta, bool)
+        use_2cta_instrs = plan_use_2cta
+    else:
+        use_2cta_instrs = cluster_m == 2 and bm == 256
     cta_group = (
         "cute.nvgpu.tcgen05.CtaGroup.TWO"
-        if cluster_m == 2 and bm == 256
+        if use_2cta_instrs
         else "cute.nvgpu.tcgen05.CtaGroup.ONE"
     )
     cluster_shape = f"({cluster_m}, {cluster_n}, 1)"

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -1319,6 +1319,104 @@ class TestCuteBackend(TestCase):
         self.assertIn("(2, 1, 1)", code)  # cluster_m=2
         self.assertIn("StaticPersistentTileScheduler", code)
 
+    def test_matmul_mma_tcgen05_fp8_two_cta_m128_codegen_and_correctness(
+        self,
+    ) -> None:
+        """bm=128 + cluster_m=2 on fp8 selects the 2-CTA MMA (CTA tile 64xbn).
+
+        The epilogue must use the per-CTA tile convention throughout:
+        ``compute_epilogue_tile_shape((64, bn), True, ...)`` (whose tile is
+        N-mode permuted), a kernel_desc with ``cta_tile_shape_mnk`` of
+        ``(64, bn, bk)``, and a host TMA store atom built from the same
+        expression via the ``epi_tile_raw_expr`` wrapper-plan key. A plain
+        ``(m, n)`` tile on any side silently permutes the output.
+        """
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = (torch.randn(256, 512, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = (torch.randn(512, 384, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        code, out = code_and_output(
+            cute_matmul_mma_fp8,
+            (x, y),
+            block_sizes=[128, 128, 128],
+            tcgen05_cluster_m=2,
+            pid_type="persistent_blocked",
+        )
+        ref = x.float() @ y.float()
+        torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+        self.assertFalse(out.float().isnan().any().item())
+        # 2-CTA MMA at the (128, bn) MMA tiler.
+        self.assertIn("cute.nvgpu.tcgen05.CtaGroup.TWO", code)
+        self.assertNotIn("cute.nvgpu.tcgen05.CtaGroup.ONE", code)
+        # Per-CTA epilogue tile convention: (64, bn) + use_2cta=True, and the
+        # kernel_desc carries the per-CTA tile.
+        self.assertIn(
+            "compute_epilogue_tile_shape((64, 128), True",
+            code,
+        )
+        self.assertIn("'cta_tile_shape_mnk': (64, 128, 128)", code)
+        self.assertIn("get_tmem_load_op((64, 128, 128)", code)
+        # Host TMA store atom is built from the device-exact tile expression.
+        self.assertIn("'epi_tile_raw_expr'", code)
+        # The resolved CtaGroup decision is recorded for the host wrapper.
+        self.assertIn("'use_2cta_instrs': True", code)
+
+    def test_matmul_mma_tcgen05_fp8_two_cta_m128_rowvec_scale(self) -> None:
+        """Fused rowvec-scale epilogue on the bm=128 2-CTA family.
+
+        The rowvec aux fragment is partitioned through the same N-mode
+        permuted epilogue tile as the accumulator; a convention mismatch
+        shows up as scrambled (not just scaled-wrong) output.
+        """
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = (torch.randn(256, 512, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = (torch.randn(512, 256, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        scale_n = torch.rand(256, device=DEVICE) + 0.5
+        code, out = code_and_output(
+            cute_matmul_mma_fp8_rowvec_scale,
+            (x, y, scale_n),
+            block_sizes=[128, 128, 128],
+            tcgen05_cluster_m=2,
+            pid_type="persistent_blocked",
+        )
+        ref = (x.float() @ y.float()) * scale_n.float()
+        torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+        self.assertFalse(out.float().isnan().any().item())
+        self.assertIn("cute.nvgpu.tcgen05.CtaGroup.TWO", code)
+        self.assertIn("compute_epilogue_tile_shape((64, 128), True", code)
+
+    def test_matmul_mma_tcgen05_f16_m128_cluster_m2_keeps_cta_group_one(
+        self,
+    ) -> None:
+        """f16/bf16 bm=128 + cluster_m=2 stays on the legacy CTA-local family.
+
+        That config point is owned by the guarded CtaGroup.ONE diagnostic
+        bridge and the multi-tile runtime guard; the fp8-only gate on the
+        bm=128 2-CTA family must not change f16 codegen.
+        """
+        support = get_cute_mma_support()
+        if not support.tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = torch.randn(256, 64, device=DEVICE, dtype=torch.float16)
+        y = torch.randn(64, 256, device=DEVICE, dtype=torch.float16)
+        code = cute_matmul_mma.bind((x, y)).to_triton_code(
+            helion.Config(
+                block_sizes=[128, 128, 16],
+                tcgen05_cluster_m=2,
+                pid_type="persistent_blocked",
+            )
+        )
+        self.assertNotIn("cute.nvgpu.tcgen05.CtaGroup.TWO", code)
+
     def test_matmul_mma_tcgen05_fp8_deep_ab_staging_6(self) -> None:
         """Test FP8 with ab_stages=6 (mid-depth staging)."""
         support = get_cute_mma_support()


### PR DESCRIPTION
Stacked PRs:
 * #2779
 * __->__#2778


--- --- ---

### [cute] 2-CTA MMA at bm=128 (CTA tile 64xbn) for fp8 tcgen05


Adds a new tcgen05 MMA family: bm=128 + tcgen05_cluster_m=2 on fp8 inputs
now emits the CtaGroup.TWO ("CTA pair") MMA at the (128, bn) MMA tiler --
CTA tile 64xbn, B fetched once per CTA pair via multicast. Previously only
bm=256 reached CtaGroup.TWO; bm=128 + cluster_m=2 fell back to the 1-CTA
atom, which on small-grid shapes (few output tiles vs SM count) badly
underutilizes the machine.

On the 512x6144x2048 fp8 rowwise-scaled matmul (only 4x16=64 output tiles
at the 128x128 MMA tiler on a 148-SM B200), this family is ~20% faster
than the best previously-expressible Helion config and beats the standalone
CUTLASS 128x128 reference (see FINDINGS_512_SHAPE.md and the follow-up
benchmark commit).

Why fp8-gated: CUTLASS admits the 2-CTA MMA for mma_m in {128, 256}, but
the f16/bf16 bm=128 + cluster_m=2 config point is already owned by the
legacy clustered CTA-local CtaGroup.ONE family (guarded diagnostic bridge
and multi-tile runtime guard). Gating the new family to fp8 keeps f16/bf16
codegen byte-identical. bm=256 is unchanged on all dtypes.

The correctness-critical piece is the epilogue tile. At CTA tile 64xbn with
use_2cta=True, compute_epilogue_tile_shape returns an N-mode-permuted tile
(e.g. [64:1;(16,2):(1,64)]); at bm=256 the per-CTA and full-CTA conventions
coincide, which is why the validated path never exercised the permutation.
Every consumer must use the SAME permuted expression or the r2s SMEM copy
and the host TMA store atom disagree and the output is silently scrambled
(wrong values + torn bf16 pairs). The changes thread one tile expression to
all four consumers:

- cute_mma.py: _tcgen05_use_2cta_instrs gains an input_is_fp8 gate and
  admits bm=128. The resolved CtaGroup decision is threaded to the
  tiled-MMA emission (new use_2cta_instrs param on _tcgen05_tiled_mma_expr /
  _make_tiled_mma_setup) instead of being re-derived without dtype context.
  The layout-plan setup emits the per-CTA epilogue tile and a per-CTA
  get_tmem_load_op((bm//2, bn, bk), ...). The ab_tma wrapper plan records
  use_2cta_instrs for this family (absent on bm=256 for golden stability).
- strategies.py: new tcgen05_two_cta_m128_epilogue_tile_expr helper --
  per-CTA (bm//2, bn) + use_2cta=True, no-source form (no elem_ty_c, so the
  larger tile_n=64 is kept instead of the wasteful with-source tile_n=32),
  with a docstring describing the N-mode permutation contract.
- memory_ops.py: the store-side kernel_desc cta_tile_shape_mnk and
  tcgen05_store_epi_tile use the per-CTA convention for this family; the
  d_tma wrapper plan records epi_tile_raw_expr so the host TMA store atom is
  built from the device-exact permuted expression (the plain epi_tile_m/n
  integer keys cannot express the permutation).
- runtime/__init__.py: the wrapper honors a plan-recorded use_2cta_instrs
  (falling back to the legacy bm==256 derivation when absent) and an
  epi_tile_raw_expr passthrough for the host TMA store atom.

Validated on B200: the 512x6144x2048 config compiles, runs, and is correct
(rel err 0.4%, 100% elements close, zero NaN, deterministic across
launches). Three new tests in test_cute_backend.py cover codegen markers +
runtime correctness for the plain and rowvec-scale fp8 kernels, plus a
guard that f16 bm=128 + cluster_m=2 stays on CtaGroup.ONE. The full tcgen05
lowerings suite (221 tests) passes unchanged.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
