### PR TITLE
[cute] Pre-wait rowvec aux register hoist for the bm=128 2-CTA family

### DIFF
--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -120,6 +120,11 @@ class _AuxStepRecord:
     aux_rmem: str
     aux_loaded: str
     aux_view2d: str | None
+    # Pre-wait register hoist (bm=128 2-CTA family only): name of the
+    # whole-fragment register tensor filled by ``autovec_copy`` BEFORE the
+    # accumulator ``consumer_wait`` so the rowvec GMEM latency hides under
+    # the MMA wait. ``None`` keeps the per-subtile GMEM load.
+    aux_rmem_full: str | None = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -2821,6 +2826,30 @@ def _codegen_cute_store_tcgen05_tile(
                 aux_rmem=df.new_var(f"tcgen05_aux_rmem_{aux_idx}"),
                 aux_loaded=df.new_var(f"tcgen05_aux_loaded_{aux_idx}"),
                 aux_view2d=aux_view2d,
+                # Pre-wait whole-fragment register hoist of N-broadcast
+                # (rowvec) aux on the bm=128 2-CTA full-tile TMA-store path.
+                # The fragment there is small (2 subtiles x epi-tile N of 64
+                # at bn=128 = a handful of fp32 registers per thread), so the
+                # whole-fragment LDG fits without spills and hides its GMEM
+                # latency under the MMA wait (standalone CUTLASS does the
+                # same; ~2% on the 512x6144x2048 fp8 scaled_mm shape). It is
+                # deliberately NOT applied to the bm=256 family: its larger
+                # whole-tile fragment regressed via register spills (see the
+                # fp8_gap_v2 history of the rowvec hoist removal at bn=128/
+                # epi-32 -- 409k LDL/STL on the 4096^3 shape).
+                aux_rmem_full=(
+                    df.new_var(f"tcgen05_aux_rmem_full_{aux_idx}")
+                    if (
+                        aux_step.broadcast_axis in (0, 1)
+                        and tcgen05_is_two_cta_m128(
+                            is_two_cta=tcgen05_lifecycle.is_two_cta,
+                            bm=tcgen05_value.bm,
+                        )
+                        and tcgen05_value.use_tma_store_epilogue
+                        and not tcgen05_value.partial_output_tma_store
+                    )
+                    else None
+                ),
             )
         )
 
@@ -3346,6 +3375,26 @@ def _codegen_cute_store_tcgen05_tile(
                         f"{rec.ttr_aux_grouped} = cute.group_modes("
                         f"{rec.ttr_aux}, 3, cute.rank({rec.ttr_aux}))"
                     ),
+                    # Pre-wait hoist: one cooperative LDG of the whole rowvec
+                    # fragment, issued here (before the accumulator
+                    # consumer_wait downstream) so the GMEM latency overlaps
+                    # the MMA wait. Per-subtile reads then come from
+                    # registers. See the ``aux_rmem_full`` field docs for the
+                    # family gate.
+                    *(
+                        [
+                            (
+                                f"{rec.aux_rmem_full} = cute.make_rmem_tensor("
+                                f"{rec.ttr_aux_grouped}.shape, {rec.aux_dtype})"
+                            ),
+                            (
+                                f"cute.autovec_copy({rec.ttr_aux_grouped}, "
+                                f"{rec.aux_rmem_full})"
+                            ),
+                        ]
+                        if rec.aux_rmem_full is not None and not force_gmem_aux
+                        else []
+                    ),
                 ]
             )
         return lines
@@ -3567,6 +3616,16 @@ def _codegen_cute_store_tcgen05_tile(
                     f"{prelude_indent}{rec.aux_loaded} = "
                     f"{rec.ttr_aux_grouped}"
                     f"[(0, 0, 0, cutlass.Int32(_tcgen05_subtile))]\n"
+                )
+                continue
+            if rec.aux_rmem_full is not None:
+                # Pre-wait hoisted rowvec: the whole fragment is already in
+                # registers (loaded before the accumulator consumer_wait by
+                # ``_aux_tile_setup_lines``); slice the active subtile.
+                lines.append(
+                    f"{prelude_indent}{rec.aux_loaded} = "
+                    f"{rec.aux_rmem_full}"
+                    f"[(None, None, None, cutlass.Int32(_tcgen05_subtile))].load()\n"
                 )
                 continue
             lines.extend(

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -1392,6 +1392,52 @@ class TestCuteBackend(TestCase):
         self.assertIn("cute.nvgpu.tcgen05.CtaGroup.TWO", code)
         self.assertIn("compute_epilogue_tile_shape((64, 128), True", code)
 
+    def test_matmul_mma_tcgen05_fp8_two_cta_m128_rowvec_prewait_hoist(self) -> None:
+        """The bm=128 2-CTA family pre-hoists rowvec aux above the acc wait.
+
+        One whole-fragment ``autovec_copy`` into registers is emitted in the
+        per-tile setup (before the accumulator ``consumer_wait``) so the
+        rowvec GMEM latency hides under the MMA wait; the per-subtile loop
+        slices the register tensor instead of issuing per-subtile LDGs.
+        bm=256 must keep the per-subtile GMEM load (the whole-tile hoist
+        historically caused register spills there).
+        """
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = (torch.randn(256, 512, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = (torch.randn(512, 256, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        scale_n = torch.rand(256, device=DEVICE) + 0.5
+        code, out = code_and_output(
+            cute_matmul_mma_fp8_rowvec_scale,
+            (x, y, scale_n),
+            block_sizes=[128, 128, 128],
+            tcgen05_cluster_m=2,
+            pid_type="persistent_blocked",
+        )
+        ref = (x.float() @ y.float()) * scale_n.float()
+        torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+        # Whole-fragment register hoist present...
+        self.assertIn("tcgen05_aux_rmem_full_", code)
+        hoist_pos = code.index("cute.autovec_copy(tcgen05_tTR_gAux_grouped_")
+        # ...and emitted before the accumulator consumer_wait.
+        acc_wait_pos = code.index(".consumer_wait(tcgen05_acc_consumer_state)")
+        self.assertLess(hoist_pos, acc_wait_pos)
+        # The subtile loop reads the register tensor, not per-subtile GMEM.
+        self.assertNotIn("tcgen05_tTR_gAux_subtile_", code)
+
+        # bm=256 keeps the per-subtile GMEM load (no whole-fragment hoist).
+        code256 = cute_matmul_mma_fp8_rowvec_scale.bind((x, y, scale_n)).to_triton_code(
+            helion.Config(
+                block_sizes=[256, 128, 128],
+                tcgen05_cluster_m=2,
+                pid_type="persistent_blocked",
+            )
+        )
+        self.assertNotIn("tcgen05_aux_rmem_full_", code256)
+
     def test_matmul_mma_tcgen05_f16_m128_cluster_m2_keeps_cta_group_one(
         self,
     ) -> None:


### PR DESCRIPTION

On the bm=128 CtaGroup.TWO fp8 family, the fused per-column (rowvec /
scale_b) aux was loaded from GMEM per epilogue subtile, *after* the
accumulator consumer_wait -- so the GMEM latency was exposed in series with
the MMA wait. The standalone CUTLASS kernel instead autovec_copies the
entire rowvec fragment to registers *before* the wait, hiding the load
under the MMA. This adds that hoist to codegen (~2% on the 512x6144x2048
fp8 scaled_mm shape, FINDINGS_512_SHAPE.md §5).

The hoist is deliberately tile-size-conditional. The fp8_gap_v2
investigation *removed* the whole-fragment rowvec hoist for the bm=256 /
4096^3 shape because its larger fragment (bn=128, epi tile_n=32) caused
409k LDL/STL register spills. At the bm=128 family the fragment is tiny (2
subtiles x epi tile_n=64 = a handful of fp32 registers per thread) and fits
without spills, so the hoist is a clean win. Gating it to the bm=128 2-CTA
full-tile TMA-store path keeps the bm=256 family on the per-subtile load.

Mechanics (memory_ops.py):
- New ``aux_rmem_full`` field on ``_AuxStepRecord``, set only for the
  N-broadcast (rowvec) aux step when the store value is bm=128 + is_two_cta
  + use_tma_store_epilogue + not partial_output_tma_store.
- ``_aux_tile_setup_lines`` emits, right after the ``ttr_aux_grouped``
  partition, a whole-fragment ``make_rmem_tensor`` + ``autovec_copy`` -- this
  block lands before the accumulator ``consumer_wait`` downstream.
- The per-subtile aux-load source slices the register tensor
  (``aux_rmem_full[(None,None,None,subtile)].load()``) instead of issuing a
  per-subtile GMEM ``ttr_aux_subtile.load()``.

Validated on B200: the 512x6144x2048 kernel still correct (rel err 0.4%,
zero NaN, deterministic), the per-subtile GMEM rowvec load is gone, and the
hoist is emitted before the acc wait. A new test asserts the hoist ordering
and that bm=256 keeps the per-subtile load; the rowvec/scale/aux lowerings
tests pass.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
