### PR TITLE
[cute] Benchmark: fp8 scaled_mm small-grid shape with the bm=128 2-CTA config

### DIFF
--- a/benchmarks/cute/fp8_scaled_mm_small_grid.py
+++ b/benchmarks/cute/fp8_scaled_mm_small_grid.py
@@ -1,0 +1,214 @@
+"""fp8 rowwise-scaled matmul on a small-grid shape: bm=128 2-CTA family demo.
+
+Shape M=512, K=6144, N=2048, fp8e4m3 -> bf16, rowwise scales:
+
+    out[m, n] = scale_a[m] * scale_b[n] * sum_k(a[m, k] * b[k, n])
+
+This is the validation benchmark for the bm=128 CtaGroup.TWO tcgen05 family.
+The shape has only (512/128) x (2048/128) = 4 x 16 = 64 output tiles at the
+(128, 128) MMA tiler, far fewer than the 148 SMs on a B200, so large-tile
+configs badly underutilize the machine. The 2-CTA MMA at CTA tile 64x128 with
+B multicast across each CTA pair is the fastest expressible Helion config on
+this shape; it beats every 1-CTA config, the bm=256 2-CTA config, and aten
+``torch._scaled_mm`` (see FINDINGS_512_SHAPE.md).
+
+The config below is a *plain Helion config* -- no hand-edited generated code --
+that codegens the bm=128 2-CTA family after the two optimization commits on
+this branch (the 2-CTA-at-bm=128 MMA family and the pre-wait rowvec hoist).
+
+Methodology: CUDA graphs with 50 back-to-back launches captured per graph,
+median of 100 whole-graph replays via CUDA events, divided by 50. A thermal
+warmup runs before timing. Wall-clock (non-graph) is dominated by ~25 us/launch
+of Helion host overhead at this tiny kernel time, so always graph-time it.
+
+Run:  HELION_BACKEND=cute python benchmarks/cute/fp8_scaled_mm_small_grid.py
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Callable
+
+os.environ.setdefault("HELION_BACKEND", "cute")
+
+import torch
+
+import helion
+from helion import Config
+import helion.language as hl
+
+M, K, N = 512, 6144, 2048
+FLOP = 2 * M * N * K
+
+
+# ---------------------------------------------------------------------------
+# Best config for this shape (bm=128 2-CTA, fp8). The non-shape knobs match
+# the 4096^3-tuned tcgen05 fp8 config; the levers that matter here are
+# block_sizes=[128, 128, 128] + tcgen05_cluster_m=2 (which select the new
+# bm=128 CtaGroup.TWO family) and the static-persistent blocked schedule.
+# ---------------------------------------------------------------------------
+BEST_CONFIG = Config(
+    indexing=["tensor_descriptor"] * 5,
+    block_sizes=[128, 128, 128],
+    pid_type="persistent_blocked",
+    tcgen05_persistence_model="static_persistent",
+    tcgen05_cluster_m=2,
+    tcgen05_cluster_n=1,
+    tcgen05_ab_stages=8,
+    tcgen05_acc_stages=2,
+    tcgen05_c_stages=2,
+    tcgen05_l2_swizzle_size=8,
+    tcgen05_num_epi_warps=4,
+    tcgen05_strategy="role_local_monolithic",
+)
+
+
+@helion.kernel(backend="cute")
+def scaled_mm(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_a2d: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> torch.Tensor:
+    m, k = x.size()
+    k2, n = y.size()
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    for tm, tn in hl.tile([m, n]):
+        acc = hl.zeros([tm, tn], dtype=torch.float32)
+        for tk in hl.tile(k):
+            acc = hl.dot(x[tm, tk], y[tk, tn], acc=acc)
+        out[tm, tn] = (acc * scale_a2d[tm, tn] * scale_b[tn]).to(torch.bfloat16)
+    return out
+
+
+def _make_inputs() -> tuple[torch.Tensor, ...]:
+    torch.manual_seed(0)
+    x = (torch.randn(M, K, device="cuda") * 0.4).to(torch.float8_e4m3fn)
+    # K-major (column-major / K-contiguous) B, as the tcgen05 fp8 TMA path
+    # prefers for B.
+    y = (torch.randn(N, K, device="cuda") * 0.4).to(torch.float8_e4m3fn).t()
+    scale_a = (torch.rand(M, device="cuda") + 0.5).float()
+    scale_b = (torch.rand(N, device="cuda") + 0.5).float()
+    scale_a2d = scale_a[:, None].expand(M, N)
+    return x, y, scale_a, scale_b, scale_a2d
+
+
+def _graph_time_us(
+    fn: Callable[[], object], iters: int = 50, replays: int = 100
+) -> float:
+    """Median per-launch time (us) over a captured CUDA graph of ``iters``.
+
+    Each measurement event-times one whole-graph replay (``iters`` launches)
+    with a single device sync per replay batch -- no per-launch sync inside
+    the captured graph, so the measured time is the steady-state back-to-back
+    kernel time, not launch latency.
+    """
+    # Warmup + capture.
+    for _ in range(3):
+        fn()
+    torch.cuda.synchronize()
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        for _ in range(iters):
+            fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    times = []
+    for _ in range(replays):
+        start.record()
+        g.replay()
+        end.record()
+        end.synchronize()
+        times.append(start.elapsed_time(end) / iters)  # ms per launch
+    times.sort()
+    return times[len(times) // 2] * 1e3  # -> us
+
+
+def _sm_clock_mhz() -> tuple[int, int] | None:
+    """Return (current_sm_mhz, max_sm_mhz), or None if nvidia-smi is absent.
+
+    fp8 TFLOP/s scales ~linearly with SM clock; absolute numbers are only
+    comparable to the FINDINGS reference (1540 TF/s helion / 1209 TF/s aten)
+    when the GPU runs at its max SM clock. A clocked-down GPU (common on
+    shared/locked hosts) inflates both kernels' us uniformly, so the *ratio*
+    stays valid while the absolute TF/s is depressed. Printed so the reader
+    can tell which regime they are in.
+    """
+    import shutil
+    import subprocess
+
+    if shutil.which("nvidia-smi") is None:
+        return None
+    out = subprocess.check_output(
+        [
+            "nvidia-smi",
+            "--query-gpu=clocks.sm,clocks.max.sm",
+            "--format=csv,noheader,nounits",
+        ]
+    ).decode()
+    cur, mx = (int(v) for v in out.strip().splitlines()[0].split(","))
+    return cur, mx
+
+
+def main() -> None:
+    name = torch.cuda.get_device_name(0)
+    print(f"GPU: {name}")
+    clocks = _sm_clock_mhz()
+    if clocks is not None:
+        cur, mx = clocks
+        note = "" if cur >= int(0.95 * mx) else "  (clocked DOWN -> TF/s depressed)"
+        print(f"SM clock: {cur}/{mx} MHz{note}")
+    print(f"Shape M={M} K={K} N={N}, fp8e4m3 -> bf16, rowwise scales")
+
+    x, y, scale_a, scale_b, scale_a2d = _make_inputs()
+
+    bound = scaled_mm.bind((x, y, scale_a2d, scale_b))
+    bound.set_config(BEST_CONFIG)
+    helion_fn = bound.compile_config(BEST_CONFIG)
+
+    out = helion_fn(x, y, scale_a2d, scale_b)
+    torch.cuda.synchronize()
+    ref = (x.float() @ y.float()) * scale_a2d.float() * scale_b.float()
+    err = (out.float() - ref).abs().max().item()
+    rel = ((out.float() - ref).abs() / (ref.abs() + 1e-6)).max().item()
+    nan = int(out.float().isnan().sum().item())
+    print(f"correctness: max_abs_err={err:.4f} max_rel_err={rel:.4f} nan={nan}")
+
+    # Thermal warmup.
+    warm = torch.randn(4096, 4096, device="cuda", dtype=torch.bfloat16)
+    for _ in range(60):
+        warm @ warm
+    torch.cuda.synchronize()
+
+    def _scaled_mm_aten() -> torch.Tensor:
+        return torch._scaled_mm(
+            x,
+            y,
+            scale_a=scale_a[:, None],
+            scale_b=scale_b[None, :],
+            out_dtype=torch.bfloat16,
+        )
+
+    helion_us = _graph_time_us(lambda: helion_fn(x, y, scale_a2d, scale_b))
+    aten_us = _graph_time_us(_scaled_mm_aten)
+
+    def tflops(us: float) -> float:
+        return FLOP / (us * 1e-6) / 1e12
+
+    print("\n50 kernels/graph, median of 100 replays")
+    print(
+        f"  helion bm=128 2-CTA   {helion_us:7.2f} us  ({tflops(helion_us):6.0f} TF/s)"
+    )
+    print(f"  aten _scaled_mm       {aten_us:7.2f} us  ({tflops(aten_us):6.0f} TF/s)")
+    print(f"\n  speedup vs aten: {aten_us / helion_us:.2f}x")
+    print(
+        "\n  reference (max SM clock, FINDINGS_512_SHAPE.md):\n"
+        "    helion bm=128 2-CTA      8.37 us  ( 1540 TF/s)\n"
+        "    cute standalone 128x128  8.48 us  ( 1518 TF/s)\n"
+        "    aten _scaled_mm         10.65 us  ( 1209 TF/s)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -55,6 +55,7 @@ from .strategies import smem_swizzle_min_major_mode_bytes
 from .strategies import tcgen05_default_epilogue_tile_expr
 from .strategies import tcgen05_explicit_epilogue_tile_expr
 from .strategies import tcgen05_smem_layout_expr
+from .strategies import tcgen05_two_cta_m128_epilogue_tile_expr
 from .strategies import warp_spec_from_config
 from .tcgen05_constants import TCGEN05_AB_CONSUMER_PHASE_MODE_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_AB_CONSUMER_PHASE_MODE_NORMAL
@@ -2002,7 +2003,9 @@ def _emit_mma_pipeline(
         )
     tcgen05_pid_is_persistent = _is_persistent_pid_config(df.config)
     tcgen05_requested_two_cta = _tcgen05_use_2cta_instrs(
-        bm=bm, cluster_m=tcgen05_cluster_m
+        bm=bm,
+        cluster_m=tcgen05_cluster_m,
+        input_is_fp8=input_dtype == torch.float8_e4m3fn,
     )
     tcgen05_cluster_n_requested = _tcgen05_cluster_n(df.config)
     tcgen05_static_output_tiles = m_size % bm == 0 and n_size % bn == 0
@@ -3139,6 +3142,7 @@ def _emit_mma_pipeline(
                 bn,
                 tcgen05_cluster_m=tcgen05_cluster_m,
                 b_k_major=tcgen05_b_k_major,
+                tcgen05_use_2cta_instrs=tcgen05_is_two_cta,
             )
         )
     else:
@@ -3315,6 +3319,7 @@ def _emit_mma_pipeline(
                     bn,
                     tcgen05_cluster_m=tcgen05_cluster_m,
                     b_k_major=tcgen05_b_k_major,
+                    tcgen05_use_2cta_instrs=tcgen05_is_two_cta,
                 )
             )
         else:
@@ -3333,6 +3338,7 @@ def _emit_mma_pipeline(
                     bn,
                     tcgen05_cluster_m=tcgen05_cluster_m,
                     b_k_major=tcgen05_b_k_major,
+                    tcgen05_use_2cta_instrs=tcgen05_is_two_cta,
                 )
             )
     if mma_impl == "tcgen05":
@@ -3968,6 +3974,15 @@ def _emit_mma_pipeline(
                 "k_total_size": k_total_size,
                 "kernel_args": [tma_atom_a, tma_tensor_a, tma_atom_b, tma_tensor_b],
             }
+            # The bm=128 CtaGroup.TWO family cannot be derived from
+            # ``bm == 256`` by the host wrapper, so record the resolved 2-CTA
+            # decision on the plan. Only recorded for this family (where the
+            # wrapper's legacy ``bm == 256`` derivation would be wrong); the
+            # bm=256 path leaves the key absent so its golden wrapper-plan
+            # literal stays byte-identical and the wrapper falls back to the
+            # derivation. See ``_tcgen05_use_2cta_instrs``.
+            if tcgen05_is_two_cta and bm != TCGEN05_TWO_CTA_BLOCK_M:
+                ab_tma_plan["use_2cta_instrs"] = True
             # K-major (column-major / K-contiguous) B. Only recorded when True
             # so MN-major (row-major B) wrapper-plan literals stay byte-identical
             # to the golden.
@@ -5190,12 +5205,23 @@ def _tcgen05_large_bn_proof_shape(
     )
 
 
-def _tcgen05_use_2cta_instrs(*, bm: int, cluster_m: int) -> bool:
+def _tcgen05_use_2cta_instrs(
+    *, bm: int, cluster_m: int, input_is_fp8: bool = False
+) -> bool:
     # Match Quack/CUTLASS SM100: clustered kernels are not automatically the
-    # tcgen05 "CTA pair" instruction family. The special 2-CTA instructions only
-    # apply to the 256-wide M tiler. Our current legal Helion family still uses
-    # CTA-local M=128 tiles, even when the cluster shape is (2, 1, 1).
-    return cluster_m == 2 and bm == TCGEN05_TWO_CTA_BLOCK_M
+    # tcgen05 "CTA pair" instruction family. CUTLASS admits the 2-CTA MMA for
+    # mma_m in {128, 256} (CTA tile m of 64 or 128). bm=256 is the legacy
+    # validated family. bm=128 (CTA tile 64xbn) is the small-grid family
+    # validated for fp8 on the 512x6144x2048 scaled_mm shape, where it beats
+    # both the bm=256 2-CTA and every 1-CTA config; it is fp8-gated because
+    # the f16/bf16 bm=128 + cluster_m=2 config point is owned by the legacy
+    # clustered CTA-local CtaGroup.ONE family (guarded diagnostic bridge and
+    # multi-tile runtime guard).
+    if cluster_m != 2:
+        return False
+    if bm == TCGEN05_TWO_CTA_BLOCK_M:
+        return True
+    return bm == 128 and input_is_fp8
 
 
 def _tcgen05_epi_warp_count(
@@ -5365,6 +5391,7 @@ def _make_tiled_mma_setup(
     *,
     tcgen05_cluster_m: int = 1,
     b_k_major: bool = False,
+    tcgen05_use_2cta_instrs: bool | None = None,
 ) -> list[ast.AST]:
     if mma_impl == "warp":
         tiled_mma_expr = (
@@ -5381,6 +5408,7 @@ def _make_tiled_mma_setup(
             bn,
             tcgen05_cluster_m=tcgen05_cluster_m,
             b_k_major=b_k_major,
+            use_2cta_instrs=tcgen05_use_2cta_instrs,
         )
     else:
         assert mma_thread_linear
@@ -5410,9 +5438,16 @@ def _tcgen05_tiled_mma_expr(
     *,
     tcgen05_cluster_m: int = 1,
     b_k_major: bool = False,
+    use_2cta_instrs: bool | None = None,
 ) -> str:
+    # ``use_2cta_instrs`` lets the caller thread the resolved CtaGroup decision
+    # (which depends on the input dtype, not just bm/cluster_m) instead of
+    # re-deriving it here without dtype context. When omitted, fall back to the
+    # bm/cluster_m derivation for the legacy bm=256 family and non-fp8 callers.
+    if use_2cta_instrs is None:
+        use_2cta_instrs = _tcgen05_use_2cta_instrs(bm=bm, cluster_m=tcgen05_cluster_m)
     cta_group_expr = "cute.nvgpu.tcgen05.CtaGroup.ONE"
-    if _tcgen05_use_2cta_instrs(bm=bm, cluster_m=tcgen05_cluster_m):
+    if use_2cta_instrs:
         cta_group_expr = "cute.nvgpu.tcgen05.CtaGroup.TWO"
     # A is always K-major. B is MN-major for row-major (N-contiguous) B and
     # K-major for column-major (K-contiguous) B.
@@ -5492,13 +5527,25 @@ def _make_tcgen05_layout_plan_setup(
             "cute",
             "explicit tcgen05 epilogue tile requires both tile dimensions",
         )
-    epi_tile_expr = (
-        tcgen05_explicit_epilogue_tile_expr(explicit_epi_tile_m, explicit_epi_tile_n)
-        if explicit_epi_tile_m is not None and explicit_epi_tile_n is not None
-        else tcgen05_default_epilogue_tile_expr(
+    # The bm=128 CtaGroup.TWO family uses the per-CTA epilogue tile (m of 64,
+    # ``use_2cta=True``, no-source) -- see
+    # ``tcgen05_two_cta_m128_epilogue_tile_expr``. ``get_tmem_load_op`` and the
+    # SMEM staging on this path must also see the per-CTA M of ``bm // 2``;
+    # the legacy bm=256/bm=128-1CTA paths keep the full ``bm``.
+    two_cta_m128 = is_two_cta and bm == 128
+    epi_tile_m = bm // 2 if two_cta_m128 else bm
+    if explicit_epi_tile_m is not None and explicit_epi_tile_n is not None:
+        epi_tile_expr = tcgen05_explicit_epilogue_tile_expr(
+            explicit_epi_tile_m, explicit_epi_tile_n
+        )
+    elif two_cta_m128:
+        epi_tile_expr = tcgen05_two_cta_m128_epilogue_tile_expr(
             bm, bn, epi_elem_dtype_str, c_layout=plan.c_layout
         )
-    )
+    else:
+        epi_tile_expr = tcgen05_default_epilogue_tile_expr(
+            bm, bn, epi_elem_dtype_str, c_layout=plan.c_layout
+        )
     return [
         statement_from_string(
             f"{plan.smem_a_layout} = "
@@ -5514,7 +5561,7 @@ def _make_tcgen05_layout_plan_setup(
         statement_from_string(f"{plan.epi_tile} = {epi_tile_expr}"),
         statement_from_string(
             f"{plan.tmem_load_atom} = cutlass.utils.blackwell_helpers.get_tmem_load_op("
-            f"({bm}, {bn}, {bk}), {plan.c_layout}, "
+            f"({epi_tile_m}, {bn}, {bk}), {plan.c_layout}, "
             f"{acc_dtype_str}, {acc_dtype_str}, {plan.epi_tile}, {is_two_cta!s})"
         ),
         statement_from_string(

--- a/helion/_compiler/cute/strategies.py
+++ b/helion/_compiler/cute/strategies.py
@@ -717,6 +717,35 @@ def tcgen05_default_epilogue_tile_expr(
     )
 
 
+def tcgen05_two_cta_m128_epilogue_tile_expr(
+    bm: int, bn: int, elem_dtype: str, *, c_layout: str
+) -> str:
+    """Epilogue tile for the bm=128 CtaGroup.TWO family (per-CTA tile 64xbn).
+
+    The bm=256 2-CTA path and the bm=128 1-CTA path both build the epilogue
+    tile from the full ``(bm, bn)`` shape, where the per-CTA and full-CTA
+    conventions produce identical tiles, so the legacy form is kept there for
+    golden-output stability; at bm=128 they diverge: the per-CTA tile m of 64
+    selects the 2-CTA ``(2, 2)`` epilogue warp grid, whose tile is **N-mode
+    permuted** (e.g. ``[64:1;(16,2):(1,64)]``). Every consumer of this tile --
+    the matmul-plan ``tcgen05_epi_tile``, the store-side
+    ``tcgen05_store_epi_tile``, the SMEM staging layouts, and the host-side
+    TMA store atom in ``helion/runtime/__init__.py`` -- must use this same
+    expression; building any of them from a plain ``(m, n)`` tile silently
+    permutes the output through SMEM (wrong values + torn bf16 pairs).
+
+    The no-source form (no ``elem_ty_c``) is deliberate: this family has no
+    residual-C epilogue input, and the with-source sizing would halve
+    ``tile_n`` (32 vs 64), doubling epilogue iterations for nothing
+    (~4% measured on the 512x6144x2048 fp8 scaled_mm shape).
+    """
+    assert bm == 128, bm
+    return (
+        "cutlass.utils.blackwell_helpers.compute_epilogue_tile_shape("
+        f"({bm // 2}, {bn}), True, {c_layout}, {elem_dtype})"
+    )
+
+
 def tcgen05_explicit_d_store_tile_expr(tile_m: int, d_store_box_n: int) -> str:
     """Return the CuTe expression for a validated explicit D-store box.
 

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -24,6 +24,7 @@ from .._compiler.cute.cute_fx_walk import reach_tcgen05_matmul_anchors
 from .._compiler.cute.cutedsl_compat import emit_pipeline_advance
 from .._compiler.cute.strategies import tcgen05_default_epilogue_tile_expr
 from .._compiler.cute.strategies import tcgen05_explicit_d_store_tile_expr
+from .._compiler.cute.strategies import tcgen05_two_cta_m128_epilogue_tile_expr
 from .._compiler.cute.tcgen05_constants import (
     TCGEN05_ACC_WAIT_PLACEMENT_BEFORE_SUBTILE_LOOP,
 )
@@ -3531,6 +3532,14 @@ def _codegen_cute_store_tcgen05_tile(
                 tcgen05_value.role_local_tile_counter,
                 increment_per_tile=not tcgen05_value.tma_store_full_tiles_only,
             )
+        # The bm=128 CtaGroup.TWO family's epilogue tile is N-mode permuted
+        # (see ``tcgen05_two_cta_m128_epilogue_tile_expr``); the host TMA-store
+        # atom must be built from this *exact* device-side expression, not from
+        # the plain ``epi_tile_m/n`` integer keys (which build an unpermuted
+        # ``(m, n)`` tile and silently scramble the output -- the correctness
+        # bug §7 in FINDINGS_512_SHAPE.md). ``epi_tile_raw_expr`` carries the
+        # verbatim device expression to the wrapper.
+        d_two_cta_m128 = tcgen05_lifecycle.is_two_cta and tcgen05_value.bm == 128
         d_tma_plan: dict[str, object] = {
             "kind": "tcgen05_d_tma",
             "d_name": tensor_name,
@@ -3542,6 +3551,18 @@ def _codegen_cute_store_tcgen05_tile(
                 tcgen05_value.tma_store_atom,
                 tcgen05_value.tma_store_tensor,
             ],
+            **(
+                {
+                    "epi_tile_raw_expr": tcgen05_two_cta_m128_epilogue_tile_expr(
+                        tcgen05_value.bm,
+                        tcgen05_value.bn,
+                        target_dtype,
+                        c_layout="cutlass.utils.layout.LayoutEnum.ROW_MAJOR",
+                    )
+                }
+                if d_two_cta_m128 and not tcgen05_value.has_explicit_epilogue_tile
+                else {}
+            ),
             **(
                 {
                     "epi_tile_m": tcgen05_value.explicit_epi_tile_m,
@@ -3561,6 +3582,13 @@ def _codegen_cute_store_tcgen05_tile(
     tcgen05_c_stage_count = tcgen05_value.c_stage_count
     tcgen05_is_two_cta = tcgen05_lifecycle.is_two_cta
     tcgen05_thr_mma = tcgen05_value.thr_mma
+    # The bm=128 CtaGroup.TWO family stores through the per-CTA epilogue tile
+    # (m of 64, ``use_2cta=True``, no-source) so the store-side
+    # ``tcgen05_store_epi_tile``, the ``kernel_desc.cta_tile_shape_mnk``, and
+    # the host TMA-store atom all match the device-side N-mode-permuted tile.
+    # See ``tcgen05_two_cta_m128_epilogue_tile_expr``.
+    tcgen05_two_cta_m128 = tcgen05_is_two_cta and tcgen05_bm == 128
+    tcgen05_store_tile_m = tcgen05_bm // 2 if tcgen05_two_cta_m128 else tcgen05_bm
     full_tile_expr = (
         f"({base_indices[0]}) + cutlass.Int32({tcgen05_bm}) <= {m_size} "
         f"and ({base_indices[1]}) + cutlass.Int32({tcgen05_bn}) <= {n_size}"
@@ -3569,18 +3597,26 @@ def _codegen_cute_store_tcgen05_tile(
     def store_common_setup(
         gmem_tensor: str, *, include_full_tile: bool
     ) -> tuple[list[str], list[str]]:
-        epi_tile_expr = tcgen05_explicit_store_tile_expr or (
-            tcgen05_default_epilogue_tile_expr(
+        if tcgen05_explicit_store_tile_expr is not None:
+            epi_tile_expr = tcgen05_explicit_store_tile_expr
+        elif tcgen05_two_cta_m128:
+            epi_tile_expr = tcgen05_two_cta_m128_epilogue_tile_expr(
                 tcgen05_bm,
                 tcgen05_bn,
                 target_dtype,
                 c_layout="cutlass.utils.layout.LayoutEnum.ROW_MAJOR",
             )
-        )
+        else:
+            epi_tile_expr = tcgen05_default_epilogue_tile_expr(
+                tcgen05_bm,
+                tcgen05_bn,
+                target_dtype,
+                c_layout="cutlass.utils.layout.LayoutEnum.ROW_MAJOR",
+            )
         static_setup = [
             (
                 f"{kernel_desc} = type('Tcgen05KernelDesc', (), {{"
-                f"'cta_tile_shape_mnk': ({tcgen05_bm}, {tcgen05_bn}, {tcgen05_bk}), "
+                f"'cta_tile_shape_mnk': ({tcgen05_store_tile_m}, {tcgen05_bn}, {tcgen05_bk}), "
                 "'c_layout': cutlass.utils.layout.LayoutEnum.ROW_MAJOR, "
                 f"'c_dtype': {target_dtype}, "
                 "'acc_dtype': cutlass.Float32, "

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -119,6 +119,11 @@ class _AuxStepRecord:
     aux_rmem: str
     aux_loaded: str
     aux_view2d: str | None
+    # Pre-wait register hoist (bm=128 2-CTA family only): name of the
+    # whole-fragment register tensor filled by ``autovec_copy`` BEFORE the
+    # accumulator ``consumer_wait`` so the rowvec GMEM latency hides under
+    # the MMA wait. ``None`` keeps the per-subtile GMEM load.
+    aux_rmem_full: str | None = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -2681,6 +2686,28 @@ def _codegen_cute_store_tcgen05_tile(
                 aux_rmem=df.new_var(f"tcgen05_aux_rmem_{aux_idx}"),
                 aux_loaded=df.new_var(f"tcgen05_aux_loaded_{aux_idx}"),
                 aux_view2d=aux_view2d,
+                # Pre-wait whole-fragment register hoist of N-broadcast
+                # (rowvec) aux on the bm=128 2-CTA full-tile TMA-store path.
+                # The fragment there is small (2 subtiles x epi-tile N of 64
+                # at bn=128 = a handful of fp32 registers per thread), so the
+                # whole-fragment LDG fits without spills and hides its GMEM
+                # latency under the MMA wait (standalone CUTLASS does the
+                # same; ~2% on the 512x6144x2048 fp8 scaled_mm shape). It is
+                # deliberately NOT applied to the bm=256 family: its larger
+                # whole-tile fragment regressed via register spills (see the
+                # fp8_gap_v2 history of the rowvec hoist removal at bn=128/
+                # epi-32 -- 409k LDL/STL on the 4096^3 shape).
+                aux_rmem_full=(
+                    df.new_var(f"tcgen05_aux_rmem_full_{aux_idx}")
+                    if (
+                        aux_step.broadcast_axis in (0, 1)
+                        and tcgen05_lifecycle.is_two_cta
+                        and tcgen05_value.bm == 128
+                        and tcgen05_value.use_tma_store_epilogue
+                        and not tcgen05_value.partial_output_tma_store
+                    )
+                    else None
+                ),
             )
         )
 
@@ -3206,6 +3233,26 @@ def _codegen_cute_store_tcgen05_tile(
                         f"{rec.ttr_aux_grouped} = cute.group_modes("
                         f"{rec.ttr_aux}, 3, cute.rank({rec.ttr_aux}))"
                     ),
+                    # Pre-wait hoist: one cooperative LDG of the whole rowvec
+                    # fragment, issued here (before the accumulator
+                    # consumer_wait downstream) so the GMEM latency overlaps
+                    # the MMA wait. Per-subtile reads then come from
+                    # registers. See the ``aux_rmem_full`` field docs for the
+                    # family gate.
+                    *(
+                        [
+                            (
+                                f"{rec.aux_rmem_full} = cute.make_rmem_tensor("
+                                f"{rec.ttr_aux_grouped}.shape, {rec.aux_dtype})"
+                            ),
+                            (
+                                f"cute.autovec_copy({rec.ttr_aux_grouped}, "
+                                f"{rec.aux_rmem_full})"
+                            ),
+                        ]
+                        if rec.aux_rmem_full is not None and not force_gmem_aux
+                        else []
+                    ),
                 ]
             )
         return lines
@@ -3427,6 +3474,16 @@ def _codegen_cute_store_tcgen05_tile(
                     f"{prelude_indent}{rec.aux_loaded} = "
                     f"{rec.ttr_aux_grouped}"
                     f"[(0, 0, 0, cutlass.Int32(_tcgen05_subtile))]\n"
+                )
+                continue
+            if rec.aux_rmem_full is not None:
+                # Pre-wait hoisted rowvec: the whole fragment is already in
+                # registers (loaded before the accumulator consumer_wait by
+                # ``_aux_tile_setup_lines``); slice the active subtile.
+                lines.append(
+                    f"{prelude_indent}{rec.aux_loaded} = "
+                    f"{rec.aux_rmem_full}"
+                    f"[(None, None, None, cutlass.Int32(_tcgen05_subtile))].load()\n"
                 )
                 continue
             lines.extend(

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -2043,6 +2043,11 @@ def _append_cute_wrapper_plan(
         assert value is None or isinstance(value, int)
         return value
 
+    def plan_optional_str(key: str) -> str | None:
+        value = plan.get(key)
+        assert value is None or isinstance(value, str)
+        return value
+
     def require_positive_int(value: int | None, name: str) -> int:
         assert type(value) is int, name
         assert value > 0, name
@@ -2060,12 +2065,21 @@ def _append_cute_wrapper_plan(
         epi_tile_m: int | None = None,
         epi_tile_n: int | None = None,
         d_store_box_n: int | None = None,
+        epi_tile_raw_expr: str | None = None,
     ) -> None:
         assert len(kernel_args) == 2
         explicit_epi_tile = any(
             value is not None for value in (epi_tile_m, epi_tile_n, d_store_box_n)
         )
-        if explicit_epi_tile:
+        if epi_tile_raw_expr is not None:
+            # The bm=128 CtaGroup.TWO family threads the device-exact (N-mode
+            # permuted) epilogue-tile expression verbatim so the host TMA-store
+            # atom is built from the same layout the device r2s copy writes
+            # through. The plain ``epi_tile_m/n`` integer keys cannot express
+            # the permutation. See ``tcgen05_two_cta_m128_epilogue_tile_expr``.
+            assert not explicit_epi_tile
+            epi_tile_expr = epi_tile_raw_expr
+        elif explicit_epi_tile:
             checked_epi_tile_m = require_positive_int(epi_tile_m, "epi_tile_m")
             checked_epi_tile_n = require_positive_int(epi_tile_n, "epi_tile_n")
             checked_d_store_box_n = require_positive_int(d_store_box_n, "d_store_box_n")
@@ -2130,6 +2144,7 @@ def _append_cute_wrapper_plan(
             epi_tile_m=plan_optional_int("epi_tile_m"),
             epi_tile_n=plan_optional_int("epi_tile_n"),
             d_store_box_n=plan_optional_int("d_store_box_n"),
+            epi_tile_raw_expr=plan_optional_str("epi_tile_raw_expr"),
         )
         return
     if kind == "tcgen05_aux_tma":
@@ -2191,9 +2206,20 @@ def _append_cute_wrapper_plan(
     # cluster_m=2 cluster_n=1 but rejects the canonical Quack-best
     # cluster_m=2 cluster_n=2 4-CTA cluster (product=4). Use
     # ``cluster_m == 2`` directly so cluster_n=2 keeps CtaGroup.TWO.
+    #
+    # The bm=128 CtaGroup.TWO family (fp8 small-grid) cannot be derived from
+    # ``bm == 256`` here, so the device codegen records the resolved decision
+    # on the plan as ``use_2cta_instrs``. Honor it when present; fall back to
+    # the legacy bm==256 derivation for golden-stable older plans.
+    plan_use_2cta = plan.get("use_2cta_instrs")
+    if plan_use_2cta is not None:
+        assert isinstance(plan_use_2cta, bool)
+        use_2cta_instrs = plan_use_2cta
+    else:
+        use_2cta_instrs = cluster_m == 2 and bm == 256
     cta_group = (
         "cute.nvgpu.tcgen05.CtaGroup.TWO"
-        if cluster_m == 2 and bm == 256
+        if use_2cta_instrs
         else "cute.nvgpu.tcgen05.CtaGroup.ONE"
     )
     cluster_shape = f"({cluster_m}, {cluster_n}, 1)"

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -1392,6 +1392,52 @@ class TestCuteBackend(TestCase):
         self.assertIn("cute.nvgpu.tcgen05.CtaGroup.TWO", code)
         self.assertIn("compute_epilogue_tile_shape((64, 128), True", code)
 
+    def test_matmul_mma_tcgen05_fp8_two_cta_m128_rowvec_prewait_hoist(self) -> None:
+        """The bm=128 2-CTA family pre-hoists rowvec aux above the acc wait.
+
+        One whole-fragment ``autovec_copy`` into registers is emitted in the
+        per-tile setup (before the accumulator ``consumer_wait``) so the
+        rowvec GMEM latency hides under the MMA wait; the per-subtile loop
+        slices the register tensor instead of issuing per-subtile LDGs.
+        bm=256 must keep the per-subtile GMEM load (the whole-tile hoist
+        historically caused register spills there).
+        """
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = (torch.randn(256, 512, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = (torch.randn(512, 256, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        scale_n = torch.rand(256, device=DEVICE) + 0.5
+        code, out = code_and_output(
+            cute_matmul_mma_fp8_rowvec_scale,
+            (x, y, scale_n),
+            block_sizes=[128, 128, 128],
+            tcgen05_cluster_m=2,
+            pid_type="persistent_blocked",
+        )
+        ref = (x.float() @ y.float()) * scale_n.float()
+        torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+        # Whole-fragment register hoist present...
+        self.assertIn("tcgen05_aux_rmem_full_", code)
+        hoist_pos = code.index("cute.autovec_copy(tcgen05_tTR_gAux_grouped_")
+        # ...and emitted before the accumulator consumer_wait.
+        acc_wait_pos = code.index(".consumer_wait(tcgen05_acc_consumer_state)")
+        self.assertLess(hoist_pos, acc_wait_pos)
+        # The subtile loop reads the register tensor, not per-subtile GMEM.
+        self.assertNotIn("tcgen05_tTR_gAux_subtile_", code)
+
+        # bm=256 keeps the per-subtile GMEM load (no whole-fragment hoist).
+        code256 = cute_matmul_mma_fp8_rowvec_scale.bind((x, y, scale_n)).to_triton_code(
+            helion.Config(
+                block_sizes=[256, 128, 128],
+                tcgen05_cluster_m=2,
+                pid_type="persistent_blocked",
+            )
+        )
+        self.assertNotIn("tcgen05_aux_rmem_full_", code256)
+
     def test_matmul_mma_tcgen05_f16_m128_cluster_m2_keeps_cta_group_one(
         self,
     ) -> None:

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -1319,6 +1319,104 @@ class TestCuteBackend(TestCase):
         self.assertIn("(2, 1, 1)", code)  # cluster_m=2
         self.assertIn("StaticPersistentTileScheduler", code)
 
+    def test_matmul_mma_tcgen05_fp8_two_cta_m128_codegen_and_correctness(
+        self,
+    ) -> None:
+        """bm=128 + cluster_m=2 on fp8 selects the 2-CTA MMA (CTA tile 64xbn).
+
+        The epilogue must use the per-CTA tile convention throughout:
+        ``compute_epilogue_tile_shape((64, bn), True, ...)`` (whose tile is
+        N-mode permuted), a kernel_desc with ``cta_tile_shape_mnk`` of
+        ``(64, bn, bk)``, and a host TMA store atom built from the same
+        expression via the ``epi_tile_raw_expr`` wrapper-plan key. A plain
+        ``(m, n)`` tile on any side silently permutes the output.
+        """
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = (torch.randn(256, 512, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = (torch.randn(512, 384, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        code, out = code_and_output(
+            cute_matmul_mma_fp8,
+            (x, y),
+            block_sizes=[128, 128, 128],
+            tcgen05_cluster_m=2,
+            pid_type="persistent_blocked",
+        )
+        ref = x.float() @ y.float()
+        torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+        self.assertFalse(out.float().isnan().any().item())
+        # 2-CTA MMA at the (128, bn) MMA tiler.
+        self.assertIn("cute.nvgpu.tcgen05.CtaGroup.TWO", code)
+        self.assertNotIn("cute.nvgpu.tcgen05.CtaGroup.ONE", code)
+        # Per-CTA epilogue tile convention: (64, bn) + use_2cta=True, and the
+        # kernel_desc carries the per-CTA tile.
+        self.assertIn(
+            "compute_epilogue_tile_shape((64, 128), True",
+            code,
+        )
+        self.assertIn("'cta_tile_shape_mnk': (64, 128, 128)", code)
+        self.assertIn("get_tmem_load_op((64, 128, 128)", code)
+        # Host TMA store atom is built from the device-exact tile expression.
+        self.assertIn("'epi_tile_raw_expr'", code)
+        # The resolved CtaGroup decision is recorded for the host wrapper.
+        self.assertIn("'use_2cta_instrs': True", code)
+
+    def test_matmul_mma_tcgen05_fp8_two_cta_m128_rowvec_scale(self) -> None:
+        """Fused rowvec-scale epilogue on the bm=128 2-CTA family.
+
+        The rowvec aux fragment is partitioned through the same N-mode
+        permuted epilogue tile as the accumulator; a convention mismatch
+        shows up as scrambled (not just scaled-wrong) output.
+        """
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = (torch.randn(256, 512, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = (torch.randn(512, 256, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        scale_n = torch.rand(256, device=DEVICE) + 0.5
+        code, out = code_and_output(
+            cute_matmul_mma_fp8_rowvec_scale,
+            (x, y, scale_n),
+            block_sizes=[128, 128, 128],
+            tcgen05_cluster_m=2,
+            pid_type="persistent_blocked",
+        )
+        ref = (x.float() @ y.float()) * scale_n.float()
+        torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+        self.assertFalse(out.float().isnan().any().item())
+        self.assertIn("cute.nvgpu.tcgen05.CtaGroup.TWO", code)
+        self.assertIn("compute_epilogue_tile_shape((64, 128), True", code)
+
+    def test_matmul_mma_tcgen05_f16_m128_cluster_m2_keeps_cta_group_one(
+        self,
+    ) -> None:
+        """f16/bf16 bm=128 + cluster_m=2 stays on the legacy CTA-local family.
+
+        That config point is owned by the guarded CtaGroup.ONE diagnostic
+        bridge and the multi-tile runtime guard; the fp8-only gate on the
+        bm=128 2-CTA family must not change f16 codegen.
+        """
+        support = get_cute_mma_support()
+        if not support.tcgen05_f16bf16:
+            self.skipTest("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        x = torch.randn(256, 64, device=DEVICE, dtype=torch.float16)
+        y = torch.randn(64, 256, device=DEVICE, dtype=torch.float16)
+        code = cute_matmul_mma.bind((x, y)).to_triton_code(
+            helion.Config(
+                block_sizes=[128, 128, 16],
+                tcgen05_cluster_m=2,
+                pid_type="persistent_blocked",
+            )
+        )
+        self.assertNotIn("cute.nvgpu.tcgen05.CtaGroup.TWO", code)
+
     def test_matmul_mma_tcgen05_fp8_deep_ab_staging_6(self) -> None:
         """Test FP8 with ab_stages=6 (mid-depth staging)."""
         support = get_cute_mma_support()


### PR DESCRIPTION
Stacked PRs:
 * #2781
 * __->__#2780
 * #2779
 * #2778


--- --- ---

### [cute] Benchmark: fp8 scaled_mm small-grid shape with the bm=128 2-CTA config


Adds benchmarks/cute/fp8_scaled_mm_small_grid.py: the kernel, the best
config, and a CUDA-graph benchmark for the 512x6144x2048 fp8 rowwise-scaled
matmul that the bm=128 CtaGroup.TWO family targets.

The kernel is the plain Helion fused scaled-mm (acc * scale_a * scale_b ->
bf16). BEST_CONFIG is a pure Helion config -- no hand-edited generated code
-- that, on top of the two preceding commits, codegens the bm=128 2-CTA
family: block_sizes=[128, 128, 128] + tcgen05_cluster_m=2 select the
CtaGroup.TWO MMA at CTA tile 64x128, with a static-persistent blocked
schedule and the 4096^3-tuned non-shape knobs.

Why this shape: it has only 4x16 = 64 output tiles at the 128x128 MMA tiler
on a 148-SM B200, so large-tile configs underutilize the machine. The 2-CTA
MMA at the small CTA tile (B multicast across each CTA pair) is the fastest
expressible Helion config here.

Benchmark methodology (FINDINGS_512_SHAPE.md): CUDA graphs, 50 launches per
graph, median of 100 event-timed replays, thermal warmup, vs
torch._scaled_mm. The script prints the SM clock and, when the GPU is
clocked below max, flags that absolute TF/s is depressed (it scales ~linear
with SM clock) while the ratio stays valid; it also prints the max-clock
reference numbers from the findings.

Reference result (max SM clock, B200):
  helion bm=128 2-CTA      8.37 us  (1540 TF/s)  -- correct, deterministic
  cute standalone 128x128  8.48 us  (1518 TF/s)
  aten _scaled_mm         10.65 us  (1209 TF/s)
i.e. ~1.27x over aten and parity-to-slightly-ahead of the standalone CUTLASS
128x128 reference. The current host is locked to 900/1965 MHz so the live
run reports ~17 us / 752 TF/s (helion) vs ~21 us / 606 TF/s (aten), 1.24x --
the same ratio at half the clock. Correctness on the live run: max rel err
0.4%, zero NaN.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>