### PR TITLE
[cute] Fix flaky test_tcgen05_fused_gelu_exact_runtime_correctness

### DIFF
--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -7702,6 +7702,9 @@ class TestCuteLowerings(unittest.TestCase):
     def test_tcgen05_fused_gelu_exact_runtime_correctness(self) -> None:
         """Default ``F.gelu`` maps to the exact erf-based CuTe epilogue step."""
 
+        import os
+        import tempfile
+
         import cutlass.cute as cute
 
         from helion._compiler.cute.mma_support import get_cute_mma_support
@@ -7730,7 +7733,15 @@ class TestCuteLowerings(unittest.TestCase):
             pid_type="persistent_interleaved",
         )
         bound.set_config(cfg)
+        # The packed-helper mocks only fire during CuTe DSL *tracing*: a warm
+        # on-disk compile cache reloads the cubin without tracing and the
+        # call counts stay 0 even though the kernel is correct. Redirect
+        # CUTE_DSL_CACHE_DIR to a fresh tempdir so this launch always
+        # compiles (the cache key excludes the cache *location*, so this
+        # does not perturb other tests' cache entries).
         with (
+            tempfile.TemporaryDirectory() as fresh_cache_dir,
+            patch.dict(os.environ, {"CUTE_DSL_CACHE_DIR": fresh_cache_dir}),
             patch(
                 "cutlass.cute.arch.fma_packed_f32x2",
                 wraps=cute.arch.fma_packed_f32x2,


### PR DESCRIPTION
Stacked PRs:
 * __->__#2781
 * #2780
 * #2779
 * #2778


--- --- ---

### [cute] Fix flaky test_tcgen05_fused_gelu_exact_runtime_correctness


The test asserts the exact-GELU epilogue routes through the packed f32x2
helpers by mocking ``cute.arch.fma_packed_f32x2`` /
``cute.arch.mul_packed_f32x2`` (with ``wraps=``) and checking their
call_count > 0. But those mocks only fire during CuTe DSL *tracing*: when
the kernel is already in the on-disk compile cache (CUTE_DSL_CACHE_DIR),
the launch reloads the cubin without tracing, so both call counts stay 0
and the test fails -- even though the kernel is compiled and correct. The
failure is therefore cache-state-dependent (passes cold, fails warm), which
is why it surfaces intermittently in the suite.

Fix: wrap the launch in a fresh ``tempfile.TemporaryDirectory`` bound to
CUTE_DSL_CACHE_DIR via ``patch.dict(os.environ, ...)``, so this launch
always compiles (and thus traces) regardless of prior cache state. The
cache key excludes the cache *location*, so this does not perturb other
tests' cache entries. Verified passing on consecutive runs (warm and cold).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>