### PR TITLE
[pallas] fix boundary mask with squeezed leading dimensions

### DIFF
--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -1094,7 +1094,7 @@ class CompileEnvironment:
                 BlockSizeOrigin,
             ):
                 return origin_info.origin.block_id
-            if origin_info is not None and type(origin_info.origin) is GridOrigin:
+            if origin_info is not None and isinstance(origin_info.origin, GridOrigin):
                 return origin_info.origin.block_id
         return None
 

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -65,6 +65,9 @@ def _load_mask_expr(
     cause a shape mismatch against the smaller ref.
     """
     from helion._compiler.compile_environment import CompileEnvironment
+    from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
+    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
+    from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
     from helion._compiler.pallas.plan_tiling import TilePattern
 
     assert state.fx_node is not None
@@ -79,6 +82,12 @@ def _load_mask_expr(
     dtype_str: str | None = None
     out_dim = 0
     tensor_dim = 0
+
+    squeezing_patterns = (
+        ArbitraryIndexPattern,
+        TileIndexWithOffsetPattern,
+        TileBeginWithOffsetPattern,
+    )
 
     for idx, pattern in zip(subscript, indexing_patterns, strict=True):
         if idx is None:
@@ -104,7 +113,8 @@ def _load_mask_expr(
 
         # TODO(dunfanlu): Do other patterns beside TilePattern require masking?
 
-        out_dim += 1
+        if not isinstance(pattern, squeezing_patterns):
+            out_dim += 1
         tensor_dim += 1
 
     if not mask_exprs:

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -2587,7 +2587,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             rtol=0.1,
         )
 
-    @xfailIfPallas("BlockSpec tiling failure")
+    @xfailIfPallasTpu("BlockSpec tiling failure")
     def test_mamba2_chunk_scan(self):
         batch, nheads, ngroups, seqlen, chunk_size, headdim, dstate = (
             2,

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -4101,6 +4101,32 @@ class TestPallas(TestCase):
         inner_min = spec.block_sizes[1].min_size
         self.assertGreaterEqual(outer_min, inner_min)
 
+    @xfailIfPallasInterpret("numerical mismatch in JAX interpret mode")
+    def test_boundary_mask_with_squeezed_leading_dims(self) -> None:
+        """Boundary mask generation succeeds when leading dimensions are squeezed."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def high_rank_kernel(x: torch.Tensor) -> torch.Tensor:
+            B, H, M, D = x.size()
+            out = torch.zeros_like(x)
+            for tile_b, tile_h in hl.tile([B, H], block_size=[1, 1]):
+                b_idx = tile_b.begin
+                h_idx = tile_h.begin
+                for tile_m in hl.tile(16, M, block_size=128):
+                    slice_x = x[b_idx, h_idx, tile_m, :]
+                    out[b_idx, h_idx, tile_m, :] = slice_x
+            return out
+
+        B, H, M, D = 2, 8, 250, 128
+        x = torch.randn(B, H, M, D, device=DEVICE, dtype=torch.bfloat16)
+        _code, result = code_and_output(
+            high_rank_kernel, (x,), pallas_loop_type="fori_loop"
+        )
+
+        ref = torch.zeros_like(x)
+        ref[:, :, 16:, :] = x[:, :, 16:, :]
+        torch.testing.assert_close(result, ref)
+
     def test_pallas_0d_tensor_arg(self) -> None:
         """0D tensor arguments shouldn't cause positional argument shift in block specs."""
 


### PR DESCRIPTION
Stacked PRs:
 * #2785
 * __->__#2784


--- --- ---

### [pallas] fix boundary mask with squeezed leading dimensions


When the leading dimensions are squeezed (e.g. `x[a, b, tile_m, :]`), we
are incorrectly incrementing the output dimension tracker for the squeezed
dimensions. This leads to errors since later we search for boundary
masks on non-existent dimensions. Fix it by ignoring squeezing patterns
when tracking output dimensions, and updating the block ID lookup
to handle subclasses of GridOrigin.
