### PR TITLE
[pallas] test_examples: enable on Pallas

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -2527,7 +2527,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             reduction_loops=[32768],
         )
 
-    @skipIfPallas("flex_attention requires torch.compile and closures")
     @skipIfRefEager("scalar_prefetch indexing not supported in ref interpreter")
     def test_flex_attention(self):
         z, h, n_ctx, head_dim = 2, 4, 256, 64


### PR DESCRIPTION
Stacked PRs:
 * __->__#2785
 * #2784


--- --- ---

### [pallas] test_examples: enable on Pallas


Running the example directly does not work yet because TorchTPU does
not yet support torch.nn.attention.flex_attention, which is used
by the reference implementation. However the test from
test_examples does not use torch.nn,.attention.flex_attention as
the reference, and therefore we can enable it now on Pallas.
