### PR TITLE
[cute] Reuse reduction thread axis for free hl.arange in sibling branches

### DIFF
--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -110,6 +110,15 @@ class GenerateAST(NodeVisitor, CodegenInterface):
         self._cute_synthetic_arange_axis_branch_paths: dict[
             int, list[list[tuple[int, int]]]
         ] = {}
+        # Records the branch path under which a strategy (e.g. a reduction) claimed
+        # a thread axis. A free ``hl.arange`` in a branch mutually-exclusive with
+        # every recorded user of a strategy axis may reuse that axis instead of
+        # claiming a fresh one (which would silently widen the launch block and
+        # turn the strategy's single-axis shared-memory reduction into a cross-axis
+        # race). Mirrors ``_cute_synthetic_arange_axis_branch_paths``.
+        self._cute_strategy_axis_branch_paths: dict[
+            int, list[list[tuple[int, int]]]
+        ] = {}
         # CuTe only: free ``hl.arange`` dims whose (joint) thread count would
         # exceed the 1024-thread budget are chunked onto a sequential lane loop
         # instead of claiming a fresh thread axis. Maps the per-arange ``key`` to
@@ -615,13 +624,43 @@ class GenerateAST(NodeVisitor, CodegenInterface):
         if current not in paths:
             paths.append(current)
 
+    def record_cute_strategy_axis_branch_path(self, axis: int) -> None:
+        """Remember the current branch path for a strategy (e.g. reduction) axis.
+
+        Called from reduction codegen while the dynamic ``_if`` branch scope is
+        live, so a free ``hl.arange`` in a mutually-exclusive sibling branch can
+        reuse this axis rather than claiming a fresh one. Recording only happens
+        inside a branch (an unbranched strategy axis is always co-live and must
+        never be reused).
+        """
+        if not self._cute_branch_path:
+            return
+        paths = self._cute_strategy_axis_branch_paths.setdefault(axis, [])
+        current = list(self._cute_branch_path)
+        if current not in paths:
+            paths.append(current)
+
     def _mutually_exclusive_synthetic_axis(self) -> int | None:
-        """Find a synthetic axis whose every arange is in a branch that can never
-        co-execute with the current branch path, so it can be safely reused."""
+        """Find a thread axis whose every recorded use is in a branch that can
+        never co-execute with the current branch path, so it can be safely reused.
+
+        Considers both synthetic ``hl.arange`` axes and strategy (reduction) axes:
+        a free arange in one grid branch may reuse the axis a reduction claimed in
+        a sibling branch when the two can never run together. An axis recorded in
+        BOTH maps must be mutually exclusive across all of its recorded paths.
+        """
         if not self._cute_branch_path:
             return None
         current = list(self._cute_branch_path)
-        for axis, paths in self._cute_synthetic_arange_axis_branch_paths.items():
+        candidate_axes = (
+            self._cute_synthetic_arange_axis_branch_paths.keys()
+            | self._cute_strategy_axis_branch_paths.keys()
+        )
+        for axis in sorted(candidate_axes):
+            paths = [
+                *self._cute_synthetic_arange_axis_branch_paths.get(axis, []),
+                *self._cute_strategy_axis_branch_paths.get(axis, []),
+            ]
             if paths and all(
                 self._cute_branch_paths_mutually_exclusive(current, path)
                 for path in paths

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -964,6 +964,13 @@ class PersistentReductionStrategy(ReductionStrategy):
     ) -> ast.AST:
         env = CompileEnvironment.current()
         backend = env.backend
+        # Record (for the CuTe backend) the branch path under which this reduction
+        # claims its thread axis, so a free ``hl.arange`` in a mutually-exclusive
+        # sibling grid branch reuses this axis instead of claiming a fresh one that
+        # would widen the launch block and race this single-axis reduction. No-op
+        # outside a dynamic ``_if`` branch.
+        if backend.name == "cute":
+            state.codegen.record_cute_strategy_axis_branch_path(self._get_thread_axis())
         numel = env.block_sizes[self.block_index].numel
         if isinstance(numel, sympy.Integer) and numel == 0:
             default = ir.Reduction.default_accumulator(reduction_type, fake_input.dtype)
@@ -1395,6 +1402,11 @@ class LoopedReductionStrategy(ReductionStrategy):
         fake_output: torch.Tensor,
     ) -> ast.AST:
         _log_cute_reduction_layout(state)
+        # See ``PersistentReductionStrategy.codegen_reduction``: record the branch
+        # path of this reduction's thread axis so a mutually-exclusive sibling
+        # branch's free ``hl.arange`` can reuse the axis (CuTe backend only).
+        if CompileEnvironment.current().backend.name == "cute":
+            state.codegen.record_cute_strategy_axis_branch_path(self._get_thread_axis())
         with install_inductor_kernel_handlers(state.codegen, {}):
             env = CompileEnvironment.current()
             backend = env.backend

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -2417,6 +2417,34 @@ def _cute_combined_mask(
                     block_id = bid
                     break
         elif isinstance(idx, torch.Tensor):
+            # A free ``hl.arange`` mapped onto a synthetic thread axis carries no
+            # block id, so the loops below add no bound for it. Emit its lane
+            # bound explicitly to mask the out-of-bounds lanes a wider sibling
+            # branch can introduce on a shared axis.
+            arange_bound = _cute_synthetic_arange_lane_bound(
+                state, pos, tensor, tensor_dim
+            )
+            if arange_bound is not None and arange_bound not in terms:
+                terms.append(arange_bound)
+            # A reduction/grid dim mapped onto a thread axis can be *widened*
+            # beyond its own extent by a mutually-exclusive sibling branch that
+            # reuses the same axis (the launch block is sized to the widest
+            # user). When this access addresses such a dim per-lane, bound the
+            # lane to its own dim size so the surplus lanes a wider sibling adds
+            # do not load/store out of bounds. ``active_local_coord`` is the
+            # per-lane in-axis coordinate; ``< dim_size`` is a no-op when the
+            # axis already matches this dim.
+            if tensor is not None and tensor_dim < tensor.ndim:
+                for bid in _matching_block_ids(env, tensor.shape[tensor_dim]):
+                    local_coord = active_local_coord(bid)
+                    if local_coord is not None:
+                        lane_bound = (
+                            f"({local_coord}) < "
+                            f"{_cute_tensor_dim_size_expr(state, tensor, tensor_dim)}"
+                        )
+                        if lane_bound not in terms:
+                            terms.append(lane_bound)
+                        break
             if not include_tensor_index_masks:
                 for dim_size in idx.shape:
                     for bid in _matching_block_ids(env, dim_size):
@@ -2459,6 +2487,83 @@ def _cute_combined_mask(
     if not terms:
         return None
     return " and ".join(f"({term})" for term in terms)
+
+
+def _cute_synthetic_arange_lane_bound(
+    state: CodegenState,
+    subscript_pos: int,
+    tensor: torch.Tensor | None,
+    tensor_dim: int,
+) -> str | None:
+    """Bounds mask for a free ``hl.arange`` index mapped onto a synthetic CUDA
+    thread axis (CuTe backend).
+
+    The launch block is sized to the *widest* arange across all (mutually
+    exclusive) grid branches that share a thread axis. A narrower arange in
+    another branch -- e.g. ``hl.arange(0, 32)`` sharing a 64-wide axis with a
+    sibling's ``hl.arange(0, 64)`` -- therefore addresses lanes beyond its own
+    extent. Those extra lanes carry a coordinate ``thread_idx()[axis] >= size``
+    and, without this mask, perform out-of-bounds loads/stores. Returns the term
+    ``(thread_idx()[axis]) < length`` (a no-op when the block matches the arange
+    exactly), or ``None`` when this index is not such a synthetic arange.
+
+    The synthetic-axis coordinate is the arange's *position* ``0..length-1``
+    regardless of ``start``/``step`` (the ``start + step *`` wrapping is applied
+    separately), so the surplus lanes a wider sibling adds are exactly those with
+    position ``>= length``. Bounding to the arange's own ``length`` is therefore
+    correct for canonical and non-canonical (non-zero start / non-unit step)
+    arange dims alike.
+    """
+    if tensor is None or tensor_dim >= tensor.ndim:
+        return None
+    cg = state.codegen
+    # A free arange maps onto a synthetic thread axis either directly
+    # (``cute_synthetic_arange_axes`` key -> axis, coord ``thread_idx()[axis]``)
+    # or, when it overflows the thread budget, onto a lane loop whose coordinate
+    # is cached in ``cute_synthetic_arange_lane_exprs``.
+    axes = getattr(cg, "cute_synthetic_arange_axes", None) or {}
+    lane_exprs = getattr(cg, "cute_synthetic_arange_lane_exprs", None) or {}
+    if not axes and not lane_exprs:
+        return None
+    fx_node = getattr(state, "fx_node", None)
+    if fx_node is None or len(fx_node.args) < 2:
+        return None
+    subscript_arg = fx_node.args[1]
+    if not isinstance(subscript_arg, (list, tuple)) or subscript_pos >= len(
+        subscript_arg
+    ):
+        return None
+    idx_node = subscript_arg[subscript_pos]
+    if not isinstance(idx_node, torch.fx.Node):
+        return None
+    from .._compiler.cute.iota_utils import cute_free_arange_indexed_dim_key
+
+    dim_key = cute_free_arange_indexed_dim_key(idx_node, cg)
+    if dim_key is None:
+        return None
+
+    # ``key`` is ``(dim_key, length, start, step)``. The bound masks lanes beyond
+    # this arange's own extent, which is its ``length`` -- independent of
+    # ``start``/``step`` -- so match purely on ``dim_key``.
+    def _match(key: object) -> bool:
+        return isinstance(key, tuple) and len(key) == 4 and key[0] == dim_key
+
+    coord = None
+    length: object = None
+    for key, axis in axes.items():
+        if _match(key):
+            coord = f"cutlass.Int32(cute.arch.thread_idx()[{axis}])"
+            length = key[1]
+            break
+    if coord is None:
+        for key, expr in lane_exprs.items():
+            if _match(key):
+                coord = expr
+                length = key[1]
+                break
+    if coord is None:
+        return None
+    return f"({coord}) < {length}"
 
 
 def _cute_tensor_dim_size_expr(

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -2269,6 +2269,202 @@ class TestCuteBackend(TestCase):
         self.assertIn("group_span=32", code)
         self.assertNotIn("_cute_grouped_reduce_shared_two_stage", code)
 
+    def test_branch_free_arange_reuses_reduction_thread_axis(self) -> None:
+        """A free ``hl.arange`` in a grid branch must reuse the thread axis a
+        reduction claimed in a mutually-exclusive sibling branch, not claim a
+        fresh one.
+
+        Branches ``pid==0`` / ``pid==1`` reduce over a free ``hl.arange`` (their
+        lane dim binds to reduction thread axis 0); the branch-only ``pid==2``
+        uses a free ``hl.arange`` with no reduction. Because the three branches
+        are mutually exclusive, ``pid==2`` can reuse axis 0. If it instead grabs
+        a second thread axis, the launch block becomes 2D (e.g. ``(64, 16, 1)``)
+        and the 16 extra lanes re-run ``pid==1``'s single-axis shared-memory
+        reduction redundantly, racing on the same SMEM slots and producing
+        intermittently wrong output (uninitialized memory leaks through on the
+        first launch). Assert the deterministic codegen decision -- a 1-D launch
+        block and the ``pid==2`` store indexing thread axis 0 -- which catches the
+        race at compile time without depending on the timing-sensitive failure.
+        """
+        t = 4
+        a = torch.randn(t, 8, 32, device=DEVICE, dtype=torch.bfloat16)
+        b = torch.randn(t, 8, 64, device=DEVICE, dtype=torch.bfloat16)
+        c = torch.randn(t, 12, 16, device=DEVICE, dtype=torch.bfloat16)
+        code, (out_a, out_b, out_c) = code_and_output(
+            cute_branch_free_arange_reduction, (a, b, c)
+        )
+
+        # Correctness: every output row must be written (a dropped/raced store
+        # leaves uninitialized memory that diverges from the reference).
+        a_ref = a.float()
+        a_scale = torch.rsqrt(
+            torch.sum(a_ref * a_ref, dim=-1, keepdim=True) / 32 + 1e-6
+        )
+        b_ref = b.float()
+        b_scale = torch.amax(torch.abs(b_ref), dim=-1, keepdim=True)
+        torch.testing.assert_close(out_a, a_ref * a_scale, rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(out_b, b_ref / b_scale, rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(out_c, c.float() + 1.0, rtol=1e-2, atol=1e-2)
+
+        # Deterministic codegen guard: the branch-only free arange reused the
+        # reduction's thread axis, so the launch block stays 1-D and every store
+        # indexes thread axis 0. A regression re-introduces a second thread axis
+        # (a 2-D ``block=(.., N, 1)`` with ``N > 1``) and a ``thread_idx()[1]``
+        # store index.
+        import re as _re
+
+        block_match = _re.search(r"block=\((\d+),\s*(\d+),\s*(\d+)\)", code)
+        self.assertIsNotNone(block_match, f"no launch block found in:\n{code}")
+        assert block_match is not None
+        bx, by, bz = (int(g) for g in block_match.groups())
+        self.assertEqual(
+            (by, bz),
+            (1, 1),
+            f"expected a 1-D launch block (free arange reused reduction axis 0) "
+            f"but got block=({bx}, {by}, {bz}); the branch-only arange claimed a "
+            f"spurious second thread axis, racing the single-axis reduction",
+        )
+        self.assertNotIn(
+            "thread_idx()[1]",
+            code,
+            "a store indexes thread axis 1; the branch-only free arange must "
+            "reuse the reduction's axis 0 in mutually-exclusive branches",
+        )
+
+        # Lane-bound guard: the launch block is sized to the widest branch
+        # (pid==1, db=64), so the narrower branches must mask their surplus
+        # thread lanes to their own dim size. Without this, pid==0's reduction
+        # store (da=32) and pid==2's free-arange store (dc=16) run lanes 32..63 /
+        # 16..63 out of bounds, corrupting the sibling pid==1 reduction's output.
+        self.assertIn(
+            "cute.arch.thread_idx()[0]) < 32",
+            code,
+            "pid==0's per-lane access (reduction dim da=32) is not bounded to its "
+            "lane extent on the shared 64-wide axis -- lanes 32..63 go OOB",
+        )
+        self.assertIn(
+            "cute.arch.thread_idx()[0]) < 16",
+            code,
+            "pid==2's per-lane free-arange access (dc=16) is not bounded to its "
+            "lane extent on the shared 64-wide axis -- lanes 16..63 go OOB",
+        )
+
+    def test_branch_noncanonical_free_arange_lane_bound(self) -> None:
+        """A non-canonical free ``hl.arange`` (non-zero start / non-unit step)
+        that reuses a wider sibling's thread axis must still mask its surplus
+        lanes to its own length.
+
+        ``pid==0`` reduces over a 64-wide free arange (claims thread axis 0);
+        ``pid==1`` uses ``hl.arange(8, 24)`` -- length 16, start 8 -- which reuses
+        axis 0 (the branches are mutually exclusive). The launch block is sized to
+        the wider branch (64), so ``pid==1``'s lanes 16..63 are surplus and must be
+        masked. The bound is on the arange's *lane position* (``thread_idx()[axis]
+        < length``), independent of the start offset -- ``< 16``, not the dim size
+        (32) and not the addressed value range (8..23). The earlier canonical-only
+        masking emitted no bound here, so those surplus lanes went out of bounds.
+        """
+        t = 4
+        a = torch.randn(t, 8, 32, device=DEVICE, dtype=torch.bfloat16)
+        b = torch.randn(t, 8, 64, device=DEVICE, dtype=torch.bfloat16)
+        code, (out_a, out_b) = code_and_output(
+            cute_branch_noncanonical_free_arange, (a, b)
+        )
+
+        # Correctness: the written slice (positions 8..23) matches the reference,
+        # and the sibling reduction output is intact (surplus lanes did not race).
+        torch.testing.assert_close(
+            out_a[:, :, 8:24], a.float()[:, :, 8:24] + 1.0, rtol=1e-2, atol=1e-2
+        )
+        b_ref = b.float()
+        b_scale = torch.amax(torch.abs(b_ref), dim=-1, keepdim=True)
+        torch.testing.assert_close(out_b, b_ref / b_scale, rtol=1e-2, atol=1e-2)
+
+        # The branch reused axis 0, so the launch block stays 1-D.
+        import re as _re
+
+        block_match = _re.search(r"block=\((\d+),\s*(\d+),\s*(\d+)\)", code)
+        self.assertIsNotNone(block_match, f"no launch block found in:\n{code}")
+        assert block_match is not None
+        bx, by, bz = (int(g) for g in block_match.groups())
+        self.assertEqual((by, bz), (1, 1), f"expected 1-D block, got {(bx, by, bz)}")
+
+        # The non-canonical arange's surplus lanes are bounded to its length (16),
+        # NOT the dim size (32). Without the generalized bound (canonical-only),
+        # this access emitted no lane mask and lanes 16..63 went out of bounds.
+        self.assertIn(
+            "cute.arch.thread_idx()[0]) < 16",
+            code,
+            "pid==1's non-canonical free arange (hl.arange(8, 24), length 16) is "
+            "not bounded to its lane extent on the shared 64-wide axis",
+        )
+        self.assertNotIn(
+            "cute.arch.thread_idx()[0]) < 32",
+            code,
+            "the non-canonical arange must be bounded by its length (16), not the "
+            "dim size (32)",
+        )
+
+
+@helion.kernel(backend="cute", static_shapes=False)
+def cute_branch_free_arange_reduction(
+    a: torch.Tensor, b: torch.Tensor, c: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    t = a.size(0)
+    ha = hl.specialize(a.shape[1])
+    hc = hl.specialize(c.shape[1])
+    hmax = hl.specialize(max(a.shape[1], c.shape[1]))
+    da = hl.specialize(a.shape[2])
+    db = hl.specialize(b.shape[2])
+    dc = hl.specialize(c.shape[2])
+    out_a = torch.empty_like(a, dtype=torch.float32)
+    out_b = torch.empty_like(b, dtype=torch.float32)
+    out_c = torch.empty_like(c, dtype=torch.float32)
+    for pid, tile_t, tile_h in hl.grid([3, t, hmax]):
+        if pid == 0:
+            if tile_h < ha:
+                ao = hl.arange(0, da)
+                av = a[tile_t, tile_h, ao].to(torch.float32)
+                asc = torch.rsqrt(torch.sum(av * av, dim=-1) / da + 1.0e-6)
+                out_a[tile_t, tile_h, ao] = av * asc
+        elif pid == 1:
+            if tile_h < ha:
+                bo = hl.arange(0, db)
+                bv = b[tile_t, tile_h, bo].to(torch.float32)
+                bsc = torch.amax(torch.abs(bv), dim=-1)
+                out_b[tile_t, tile_h, bo] = bv / bsc
+        elif pid == 2:
+            if tile_h < hc:
+                co = hl.arange(0, dc)
+                cv = c[tile_t, tile_h, co].to(torch.float32)
+                out_c[tile_t, tile_h, co] = cv + 1.0
+    return out_a, out_b, out_c
+
+
+@helion.kernel(backend="cute", static_shapes=False)
+def cute_branch_noncanonical_free_arange(
+    a: torch.Tensor, b: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    t = a.size(0)
+    ha = hl.specialize(a.shape[1])
+    hmax = hl.specialize(max(a.shape[1], b.shape[1]))
+    db = hl.specialize(b.shape[2])
+    out_a = torch.empty_like(a, dtype=torch.float32)
+    out_b = torch.empty_like(b, dtype=torch.float32)
+    for pid, tile_t, tile_h in hl.grid([2, t, hmax]):
+        if pid == 0:
+            if tile_h < ha:
+                bo = hl.arange(0, db)
+                bv = b[tile_t, tile_h, bo].to(torch.float32)
+                bsc = torch.amax(torch.abs(bv), dim=-1)
+                out_b[tile_t, tile_h, bo] = bv / bsc
+        elif pid == 1:
+            if tile_h < ha:
+                # Non-canonical free arange: start=8, length=16 (positions 8..23).
+                ao = hl.arange(8, 24)
+                av = a[tile_t, tile_h, ao].to(torch.float32)
+                out_a[tile_t, tile_h, ao] = av + 1.0
+    return out_a, out_b
+
 
 @helion.kernel(backend="cute")
 def _cute_2d_tile_reduction_kernel(x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION

A free ``hl.arange`` index dim used in a grid branch is mapped onto a CUDA
thread axis by the synthetic-arange allocator. The reuse logic
(``_mutually_exclusive_synthetic_axis``) only considered *other synthetic*
arange axes, so it was blind to a thread axis claimed by a *reduction
strategy* in a mutually-exclusive sibling branch. A branch-only arange would
therefore grab a fresh axis instead of reusing the reduction's.

Concretely, for a ``hl.grid([3, ...])`` kernel with ``if pid==0 / elif
pid==1 / elif pid==2`` where pid==0/1 reduce over a free arange (binding the
lane dim to reduction thread axis 0) and pid==2 uses a free arange with no
reduction: pid==2 claimed thread axis 1, widening the launch block from
``(64, 1, 1)`` to ``(64, 16, 1)``. The 16 spurious lanes re-ran pid==1's
single-axis ``_cute_grouped_reduce_shared_two_stage`` reduction redundantly,
racing on the same shared-memory slots. The result was intermittently wrong
output (uninitialized output memory leaking through on the first launch when
SMEM was freshly dirty) -- e.g. ~half a row of one output tensor off. The
failure was timing-sensitive (passed on warm reruns) and only surfaced
intermittently in CI.

Fix (axis reuse): reductions now record (CuTe only) the branch path under
which they claim a thread axis (``record_cute_strategy_axis_branch_path``), and
``_mutually_exclusive_synthetic_axis`` considers both synthetic-arange and
strategy axes. A free arange in a branch mutually exclusive with every recorded
user of an axis reuses it, keeping the block 1-D and the reduction single-axis.
The recording no-ops outside a dynamic ``_if`` branch and on non-CuTe backends
(``_cute_branch_path`` is only populated by the cute ``_if`` codegen), so
f16/bf16/triton/pallas codegen is unchanged.

Fix (surplus-lane masking): even on the now-shared 1-D axis the branches differ
in width -- the launch block is sized to the *widest* user, so a narrower
branch (e.g. pid==0's ``arange(0, 32)`` or pid==2's ``arange(0, 16)`` sharing a
64-wide axis) addresses lanes beyond its own extent. ``_cute_combined_mask``
now emits a per-lane bound (``_cute_synthetic_arange_lane_bound`` for free
aranges, plus an ``active_local_coord < dim_size`` term for reduction/grid dims)
so those surplus lanes do not load/store out of bounds and corrupt a sibling's
output.

The lane bound is on the arange's *position* (``thread_idx()[axis]``), which is
``0..length-1`` independent of ``start``/``step`` (the ``start + step *``
wrapping is applied separately to the index). It is therefore bounded by the
arange's own ``length`` -- correct for canonical and non-canonical (non-zero
start / non-unit step) aranges alike, and one-sided: the lane index has a hard
floor of 0, so only the high surplus lanes need masking. The earlier version
restricted this to canonical ``arange(0, N)`` and bounded by the tensor dim
size; a non-canonical free arange reusing a widened axis was left unmasked and
went out of bounds.

Tests assert the deterministic codegen decision (1-D launch block, no
``thread_idx()[1]`` store index, the per-branch ``thread_idx()[axis] < length``
bounds) so they catch the regression at compile time without depending on the
timing-sensitive race; verified the axis-reuse assertion fails on the pre-fix
code (``block=(64, 16, 1)``) and passes after. A second test covers a
non-canonical free arange (``hl.arange(8, 24)``) reusing a wider sibling's axis,
asserting it is bounded by its length (16) and not the dim size (32). Also
stress-tested the runtime race directly (dirty-SMEM first-launch repro): 9/40
failures before, 0/40 after. Full cute + triton
control_flow/reductions/indexing/loops suites pass on B200.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
