### PR TITLE
[autotuner] mem_op_id: cache-robustness (structural fingerprint + AOT length guard)

### DIFF
--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -78,7 +78,9 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
     from collections.abc import Sequence
 
+    from ..autotuner.config_fragment import ListOf
     from ..autotuner.config_spec import AccumulatorFact
+    from ..autotuner.config_spec import ConfigSpec
     from ..autotuner.config_spec import MemoryOpFact
     from .compile_environment import BlockSizeInfo
     from .cute.layout import CuTeGridExecutionPlan
@@ -2975,6 +2977,52 @@ def _register_load_store_tunables(
         )
 
 
+def _apply_mem_op_slot_signatures(config_spec: ConfigSpec) -> None:
+    """Fold the per-slot buffer-identity signature into the four mem-op ListOf fingerprints (C1).
+
+    A saved/pretuned config is accepted as cache-compatible only if the structural fingerprint
+    matches. ``ListOf.fingerprint`` was length-only, so a same-length REORDER of the id->slot map
+    would pass undetected and silently mis-map every per-op knob. We attach, per namespace, the
+    ordered access-site buffer identity (origin path) of the op at each slot; a real reorder now busts
+    the hash. Buffer identity (not raw line numbers) keeps the signature stable across benign edits.
+    """
+    smap = config_spec.mem_op_slot_map
+    if smap is None:
+        return
+
+    def apply(slot_dict: dict[MemOpId, int], listof: ListOf) -> None:
+        if listof.length == 0:
+            return
+        # Per-slot identity = buffer origin path + (line RELATIVE to the kernel's first memory op) +
+        # column span. (buffer, rel_line, colno, end_colno) uniquely identifies every distinct source
+        # op, so any reorder of the slot->op map busts the cache hash — including two ops on the SAME
+        # buffer (e.g. aligned ``a = x[...]`` / ``b = x[...]``). Using the RELATIVE line (not the raw
+        # line number) keeps the hash stable when unrelated edits shift the whole kernel up/down.
+        linenos = [
+            key[0][1]
+            for key in slot_dict
+            if key[0] is not None and key[0][1] is not None
+        ]
+        anchor = min(linenos) if linenos else 0
+
+        def sig(mem_op_id: MemOpId) -> tuple[object, ...]:
+            loc, buffer = mem_op_id
+            if loc is None:
+                return (buffer or "", -1, -1, -1)
+            rel_line = (loc[1] - anchor) if loc[1] is not None else -1
+            return (buffer or "", rel_line, loc[2], loc[4])
+
+        slot_to_sig = {slot: sig(key) for key, slot in slot_dict.items()}
+        listof.slot_signature = tuple(
+            slot_to_sig.get(i, ("", -1, -1, -1)) for i in range(listof.length)
+        )
+
+    apply(smap.indexing, config_spec.indexing)
+    apply(smap.eviction, config_spec.load_eviction_policies)
+    apply(smap.cache, config_spec.load_cache_modifiers)
+    apply(smap.atomic, config_spec.atomic_indexing)
+
+
 def _register_atomic_tunables(atomic_count: int) -> None:
     """Register atomic_indexing tunable for all atomic operations."""
     if atomic_count == 0:
@@ -3192,6 +3240,9 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
             )
             _register_atomic_tunables(_count_device_atomics(device_ir))
         _register_tensor_descriptor_layout_guards(device_ir)
+        # Fold the per-slot id signature into the tunable fingerprints so a reordered slot map busts
+        # the cache hash (C1) rather than silently mis-mapping a saved config.
+        _apply_mem_op_slot_signatures(config_spec)
 
         # Accumulator facts are a standalone, reduction-agnostic fact layer (any heuristic
         # may read them), so build them independently of the reduction facts. Must run

--- a/helion/autotuner/aot_cache.py
+++ b/helion/autotuner/aot_cache.py
@@ -51,8 +51,43 @@ if TYPE_CHECKING:
     from typing import Callable
 
     from .base_search import BaseSearch
+    from .config_spec import ConfigSpec
 
 log: logging.Logger = logging.getLogger(__name__)
+
+
+def _stale_mem_op_list(config: Config, spec: ConfigSpec) -> str | None:
+    """Return a description of the first per-op tunable list whose length disagrees with ``spec``.
+
+    The per-memory-op list lengths (``indexing`` / ``load_eviction_policies`` /
+    ``load_cache_modifiers`` / ``atomic_indexing``) are shape-INDEPENDENT (one slot per distinct
+    memory op), so a length mismatch means the AOT heuristic file predates a spec change (e.g. the
+    mem-op slot collapse) and must not be applied to the current numbering. ``None`` if every
+    present list matches. Absent lists are fine (``normalize`` fills the default).
+
+    Scope: this is a LENGTH guard — it catches the collapse churn (which changes list lengths) and
+    any other op-count change. It does NOT catch a SAME-length slot REORDER (e.g. a future library
+    refactor that reorders memory ops without changing their count): the AOT heuristic file carries
+    no per-slot structural signature today (only the local cache fingerprint does, via
+    ``ConfigSpec.structural_fingerprint``). Folding that signature into the AOT file + checking it
+    here is a deferred hardening — see _lab/MEMORY_OP_IMPL_JOURNAL.md (perf-only; the eviction/cache/
+    indexing knobs are hints/strategies, never numerical correctness, which the re-keyed TD-guards
+    protect).
+    """
+    for name, fragment in (
+        ("indexing", spec.indexing),
+        ("load_eviction_policies", spec.load_eviction_policies),
+        ("load_cache_modifiers", spec.load_cache_modifiers),
+        ("atomic_indexing", spec.atomic_indexing),
+    ):
+        value = config.config.get(name)
+        if not isinstance(value, list):
+            continue
+        expected = fragment.length if fragment is not None else 0
+        if len(value) != expected:
+            return f"{name} (length {len(value)}, expected {expected})"
+    return None
+
 
 # Environment variable to control AOT mode
 AOT_MODE_ENV = "HELION_AOT_MODE"
@@ -768,6 +803,25 @@ class AOTAutotuneCache(AutotuneCacheBase):
                     # No user key: pass raw args to heuristic
                     config_dict = autotune_fn(*args)
                 config = Config(**config_dict)
+
+            # Guard against a STALE (wrong-length) per-op tunable list silently misapplying to a
+            # changed numbering (e.g. after the mem-op slot collapse). The AOT path matches by
+            # (source, name, shapes) only — no structural-fingerprint check — and normalize() does
+            # not length-validate the indexing / eviction / cache / atomic lists, so a stale list
+            # would otherwise be applied verbatim (indexing the wrong op, or silently dropping the
+            # tail). The op-list lengths are shape-INDEPENDENT, so a mismatch means the heuristic
+            # file predates a spec change: fall back (return None -> default config) instead.
+            if config is not None:
+                stale = _stale_mem_op_list(config, self.autotuner.config_spec)
+                if stale is not None:
+                    log.warning(
+                        "AOT heuristic for %s has a stale %s; falling back to the default "
+                        "config. Regenerate pretuned configs "
+                        "(python -m helion.experimental.aot_runner).",
+                        kernel_name,
+                        stale,
+                    )
+                    return None
 
             # Cache the result
             if config is not None:

--- a/helion/autotuner/config_fragment.py
+++ b/helion/autotuner/config_fragment.py
@@ -92,8 +92,11 @@ class ConfigSpecFragment:
         """
         return (1, False)
 
-    def fingerprint(self) -> tuple[int, ...]:
-        """Return structural metadata for this fragment used in ConfigSpec fingerprinting."""
+    def fingerprint(self) -> tuple[object, ...]:
+        """Return structural metadata for this fragment used in ConfigSpec fingerprinting.
+
+        Elements are hashable + repr-able (ints, or the per-slot identity strings ``ListOf`` folds in).
+        """
         return ()
 
     def get_minimum(self) -> int:
@@ -388,6 +391,14 @@ class ListOf(ConfigSpecFragment):
 
     inner: ConfigSpecFragment
     length: int
+    # Optional ordered per-slot structural signature (one entry per slot, in slot order) folded into
+    # the cache-compatibility fingerprint. For the per-memory-op tunables each entry is the access-site
+    # buffer identity (origin path) + column span of the op at each slot, so a same-length REORDER of
+    # the slot map busts the cache hash instead of silently mis-mapping a saved config (no raw line
+    # numbers, which would churn the hash on benign edits). Excluded from dataclass eq/repr.
+    slot_signature: tuple[object, ...] | None = dataclasses.field(
+        default=None, compare=False, repr=False
+    )
 
     def default(self) -> list[object]:
         """Return a list of default values."""
@@ -422,8 +433,10 @@ class ListOf(ConfigSpecFragment):
             for i in range(self.length)
         ]
 
-    def fingerprint(self) -> tuple[int, ...]:
-        return (self.length,)
+    def fingerprint(self) -> tuple[object, ...]:
+        if self.slot_signature is None:
+            return (self.length,)
+        return (self.length, *self.slot_signature)
 
     def dim(self) -> int:
         return self.length * self.inner.dim()

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -1621,15 +1621,15 @@ class ConfigSpec:
 
     def structural_fingerprint(
         self, *, advanced_controls_files: list[str] | None = None
-    ) -> tuple[tuple[str | int, ...], ...]:
+    ) -> tuple[tuple[object, ...], ...]:
         """Return a hashable structural description of this ConfigSpec's search space.
 
         Captures field names, sequence lengths, per-item block_ids lengths
-        (for PermutationFragment), ListOf inner lengths, and optional ACF slot
-        presence.  Two ConfigSpecs with the same fingerprint can safely exchange
+        (for PermutationFragment), ListOf inner lengths + per-slot mem-op id signatures, and
+        optional ACF slot presence.  Two ConfigSpecs with the same fingerprint can safely exchange
         FlatConfig values.
         """
-        result: list[tuple[str | int, ...]] = [
+        result: list[tuple[object, ...]] = [
             (key, *field.fingerprint()) for key, field in self._flat_fields().items()
         ]
         acf_fragment = self._advanced_controls_file_fragment(advanced_controls_files)

--- a/test/test_memory_op_slots.py
+++ b/test/test_memory_op_slots.py
@@ -183,6 +183,31 @@ class TestMemoryOpSlots(RefEagerTestBase, TestCase):
         last_l, first_l = evict_counts([16] * rl_len)
         self.assertEqual((last_l, first_l), (2, 0))
 
+    def test_aot_stale_length_guard(self):
+        """A stale (wrong-length) per-op list is detected so the AOT path falls back instead of
+        silently mis-applying it to the collapsed numbering (the AOT cache has no fingerprint check
+        and ``normalize`` does not length-validate these lists)."""
+        from helion.autotuner.aot_cache import _stale_mem_op_list
+
+        bk = reread_reduce.bind((_dev(256, 512),))
+        spec = bk.config_spec
+        good = spec.default_config()
+        self.assertIsNone(_stale_mem_op_list(good, spec))
+
+        # A union-length (stale) indexing / eviction list is flagged.
+        stale_idx = helion.Config.from_dict(
+            {**good.config, "indexing": ["pointer"] * (spec.indexing.length + 4)}
+        )
+        self.assertIsNotNone(_stale_mem_op_list(stale_idx, spec))
+        stale_ev = helion.Config.from_dict(
+            {
+                **good.config,
+                "load_eviction_policies": ["first"]
+                * (spec.load_eviction_policies.length + 3),
+            }
+        )
+        self.assertIsNotNone(_stale_mem_op_list(stale_ev, spec))
+
     def test_uniform_membership_stack_load_inert_slot(self):
         """Source-based membership: every load/store gets an indexing slot, including a stack load
         (whose slot is inert). store_strategy_slots holds only real-tensor store slots, so the inert


### PR DESCRIPTION
[autotuner] mem_op_id: cache-robustness (structural fingerprint + AOT length guard)

Defense-in-depth for the id-keyed slot map (previous commit):

- structural fingerprint: fold a per-slot buffer-identity signature into ListOf.fingerprint
  (_apply_mem_op_slot_signatures) so a same-length slot-map REORDER busts the local autotune
  cache hash instead of silently mis-mapping a saved config.
- AOT length guard: aot_cache._stale_mem_op_list rejects a stale (wrong-length) pretuned/AOT
  config (the AOT path has no spec hash and normalize() does not length-validate these lists),
  falling back to the default config instead of indexing the wrong op.

Codegen-neutral: changes only the cache-compatibility fingerprint + AOT acceptance, never
generated Triton.