### PR TITLE
autotuner: thread ir_graph through the autotune log sink

### DIFF
--- a/helion/autotuner/_metadata/__init__.py
+++ b/helion/autotuner/_metadata/__init__.py
@@ -1,0 +1,8 @@
+"""Metadata extractors for the autotuner cost-model dataset.
+
+Modules here derive config-independent, JSON-safe metadata
+for inclusion on the per-run ``.meta.jsonl`` record. They
+are read-only over the objects they inspect.
+"""
+
+from __future__ import annotations

--- a/helion/autotuner/_metadata/ir_features.py
+++ b/helion/autotuner/_metadata/ir_features.py
@@ -1,0 +1,454 @@
+"""Lossless dump of Helion device IR for the kernel-artifact dataset.
+
+Walks DeviceIR torch.fx graphs and emits one node-link graph per autotune run,
+inlined on the .meta.jsonl record under "ir_graph". Load with
+nx.node_link_graph(rec["ir_graph"], edges="edges").
+
+Edges:
+  data:    producer -> consumer from node.args/kwargs
+  region:  control-flow call (_for_loop, _for_loop_step, _if, _while_loop)
+           maps live args positionally to child-graph placeholders.
+HelperFunctionGraphInfo is emitted but not connected, helper calls have no
+region edges, so those subgraphs appear disconnected.
+
+Graph is directed, multigraph=False. No (source,target) collision: data edges
+target consuming nodes, region edges target placeholders only.
+
+Device IR is config-independent; host -> root edges are out of scope.
+Extraction is best-effort per node (unresolvable -> None). extract_ir_graph
+assumes well-formed DeviceIR; caller guards malformed case.
+
+String caps: scalar value and source_loc truncated to _MAX_VALUE_LEN.
+Shape/stride strings are uncapped, small by construction.
+
+Schema version lives on the ir_graph object::
+
+    ir = rec.get("ir_graph")
+    v = ir.get("schema_version", 0) if ir else 0
+    if v != IR_SCHEMA_VERSION:
+        ...
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+from typing import TypedDict
+from typing import TypeGuard
+from typing import cast
+
+import torch
+from torch.fx.node import map_arg
+
+from ...language._tracing_ops import _if
+from ...language._tracing_ops import _while_loop
+from ...language._tracing_ops import is_for_loop_target
+
+if TYPE_CHECKING:
+    from ..._compiler.device_ir import DeviceIR
+
+__all__ = [
+    "IR_SCHEMA_VERSION",
+    "IrEdge",
+    "IrGraphMeta",
+    "IrGraphRecord",
+    "IrNode",
+    "extract_ir_graph",
+]
+
+# Cap scalar strings and source locations to prevent JSON line bloat.
+_MAX_VALUE_LEN = 4096
+_TRUNCATION_SUFFIX = "...<truncated>"
+
+# Strip memory addresses to keep callable/partial strings deterministic across
+# processes.
+_ADDRESS_RE = re.compile(r" at 0x[0-9a-fA-F]+")
+
+# Kept as strings to avoid autotuner -> _compiler import cycle.
+_REDUCTION_LOWERING = "ReductionLowering"
+_POINTWISE_LOWERING = "PointwiseLowering"
+
+
+class ValFeatures(TypedDict):
+    """Features derived from a node's meta['val'] (tensor or sym scalar)."""
+
+    dtype: str | None
+    shape: list[str] | None
+    concrete_shape: list[int | None] | None
+    stride: list[str] | None
+    concrete_stride: list[int | None] | None
+    device: str | None
+    value: str | None
+
+
+class LoweringFeatures(TypedDict):
+    """Features derived from a node's meta['lowering']."""
+
+    lowering_class: str | None
+    reduction_type: str | None
+    reduction_ranges: list[str] | None
+    pointwise_ranges: list[str] | None
+    input_dtypes: list[str] | None
+    input_shapes: list[list[str]] | None
+
+
+class _NodeCore(TypedDict):
+    """Node fields that come from the fx node itself (not val/lowering)."""
+
+    id: str
+    graph_id: int
+    region_kind: str
+    block_ids: list[int]
+    op_kind: str
+    target: str
+    source_loc: str | None
+
+
+class IrNode(_NodeCore, ValFeatures, LoweringFeatures):
+    """Node-edge schema node. keys are disjoint union of the three bases."""
+
+
+class IrEdge(TypedDict):
+    """A dataflow or region edge (a node-edge edges entry)."""
+
+    source: str
+    target: str
+    edge_kind: str  # "data" | "region"
+    arg_positions: list[int]
+    dtype: str | None
+    shape: list[str] | None
+
+
+class GraphHierarchyEntry(TypedDict):
+    graph_id: int
+    region_kind: str
+    block_ids: list[int]
+
+
+class RolledReductionEntry(TypedDict):
+    original_graph_id: int
+    rolled_block_ids: list[int]
+    used_rdim: bool
+    can_be_rolled_by_caller: bool
+
+
+class IrGraphMeta(TypedDict):
+    """Structural graph metadata (networkx graph dict); run identity lives in
+    .meta.jsonl."""
+
+    num_graphs: int
+    root_ids: list[int]
+    graphs: list[GraphHierarchyEntry]
+    rolled_reductions: list[RolledReductionEntry]
+
+
+class IrGraphRecord(TypedDict):
+    """The per-run ir_graph value; loadable via nx.node_link_graph(.., edges="edges")."""
+
+    schema_version: int
+    directed: bool
+    multigraph: bool
+    graph: IrGraphMeta
+    nodes: list[IrNode]
+    edges: list[IrEdge]
+
+
+# Bump when the ir_graph record shape changes for consumers to detect format changes
+IR_SCHEMA_VERSION = 1
+
+
+def _is_graph_id(value: object) -> TypeGuard[int]:
+    """True for concrete int graph ids (not bool); narrows type via TypeGuard."""
+    return type(value) is int
+
+
+def _truncate(text: str) -> str:
+    """Strictly cap stringified values to _MAX_VALUE_LEN characters to prevent JSON
+    line bloat."""
+    if len(text) > _MAX_VALUE_LEN:
+        return text[: _MAX_VALUE_LEN - len(_TRUNCATION_SUFFIX)] + _TRUNCATION_SUFFIX
+    return text
+
+
+def _target_str(target: object) -> str:
+    """Returns a deterministic target string by stripping memory addresses from callables."""
+    if isinstance(target, str):
+        return target
+    name = getattr(target, "__qualname__", None) or getattr(target, "__name__", None)
+    if name:
+        module = getattr(target, "__module__", None)
+        return f"{module}.{name}" if module else name
+    return _ADDRESS_RE.sub("", str(target))
+
+
+def _concrete_dim(dim: object) -> int | None:
+    """Returns static ``int`` size for a dim; returns ``None`` for symbols to avoid shape
+    guard side effects."""
+    return dim if isinstance(dim, int) else None
+
+
+def _val_features(val: object) -> ValFeatures:
+    """Type/shape/stride features for ``node.meta['val']`` (tensor or sym scalar)."""
+    out: ValFeatures = {
+        "dtype": None,
+        "shape": None,
+        "concrete_shape": None,
+        "stride": None,
+        "concrete_stride": None,
+        "device": None,
+        "value": None,
+    }
+    if isinstance(val, torch.Tensor):
+        out["dtype"] = str(val.dtype)
+        out["shape"] = [str(d) for d in val.shape]
+        out["concrete_shape"] = [_concrete_dim(d) for d in val.shape]
+        stride = val.stride()
+        out["stride"] = [str(s) for s in stride]
+        out["concrete_stride"] = [_concrete_dim(s) for s in stride]
+        out["device"] = str(val.device)
+    elif val is not None:
+        # Symbolic scalars (SymInt/SymFloat/SymBool) and any other non-tensor
+        # value: record the type name and a length-capped stringified value.
+        out["dtype"] = type(val).__name__
+        out["value"] = _truncate(str(val))
+    return out
+
+
+def _lowering_features(node: torch.fx.Node) -> LoweringFeatures:
+    """Extracts node features from ``node.meta['lowering']`` by lowering class name."""
+    out: LoweringFeatures = {
+        "lowering_class": None,
+        "reduction_type": None,
+        "reduction_ranges": None,
+        "pointwise_ranges": None,
+        "input_dtypes": None,
+        "input_shapes": None,
+    }
+    lowering = node.meta.get("lowering")
+    if lowering is None:
+        return out
+    cls = type(lowering).__name__
+    out["lowering_class"] = cls
+    buffer = getattr(lowering, "buffer", None)
+    data = getattr(buffer, "data", None)
+    if cls == _REDUCTION_LOWERING:
+        # Read reduction_type from buffer data, bypassing the lowering getter assert.
+        # Allows malformed lowerings to safely degrade to None.
+        reduction_type = getattr(data, "reduction_type", None)
+        out["reduction_type"] = None if reduction_type is None else str(reduction_type)
+        ranges = getattr(data, "reduction_ranges", None)
+        if ranges is not None:
+            out["reduction_ranges"] = [str(r) for r in ranges]
+    elif cls == _POINTWISE_LOWERING:
+        ranges = getattr(data, "ranges", None)
+        if ranges is not None:
+            out["pointwise_ranges"] = [str(r) for r in ranges]
+    # Read ``input_fake_tensors`` only if a ``buffer`` is present.
+    # Guards the node.meta["val"] read best-effort.
+    if buffer is not None:
+        try:
+            fakes = type(lowering).input_fake_tensors(node)
+        except (KeyError, AttributeError, TypeError, RuntimeError):
+            fakes = None
+        if fakes is not None:
+            out["input_dtypes"] = [str(t.dtype) for t in fakes]
+            out["input_shapes"] = [[str(d) for d in t.shape] for t in fakes]
+    return out
+
+
+def _input_edges(node: torch.fx.Node) -> dict[torch.fx.Node, list[int]]:
+    """Map producers to their ordinal argument positions in node, preserving
+    multiplicity via map_arg."""
+    positions: dict[torch.fx.Node, list[int]] = {}
+    counter = 0
+
+    def visit(producer: torch.fx.Node) -> torch.fx.Node:
+        nonlocal counter
+        positions.setdefault(producer, []).append(counter)
+        counter += 1
+        return producer
+
+    map_arg((node.args, node.kwargs), visit)
+    return positions
+
+
+def _region_specs(node: torch.fx.Node) -> list[tuple[int, object]]:
+    """Safely extracts (child_graph_id, live_args_list) from for/if/while
+    control-flow nodes."""
+    target = node.target
+    args = node.args
+    # Graph ids must be concrete ints. A malformed or non-control-flow node
+    # returns [].
+    if is_for_loop_target(target):
+        if len(args) >= 4 and _is_graph_id(args[0]):
+            return [(args[0], args[3])]
+        return []
+    if target is _if:
+        if len(args) >= 5 and _is_graph_id(args[1]) and _is_graph_id(args[2]):
+            return [(args[1], args[3]), (args[2], args[4])]
+        return []
+    if target is _while_loop:
+        if len(args) >= 3 and _is_graph_id(args[0]) and _is_graph_id(args[1]):
+            specs: list[tuple[int, object]] = [(args[1], args[2]), (args[0], args[2])]
+            if len(args) > 3 and _is_graph_id(args[3]):
+                specs.append((args[3], args[2]))
+            return specs
+        return []
+    return []
+
+
+def _has_networkx_node_link() -> bool:
+    """Whether networkx>=3.4 (node_link_data's ``edges=`` kwarg) is available.
+
+    The single definition of the version requirement: ``extract_ir_graph`` uses it
+    to raise a clear error, and the test suite imports it for its skip gate, so both
+    agree on one capability check. A capability probe, not a version string -- the
+    ``edges=`` kwarg landed in networkx 3.4.
+    """
+    try:
+        import networkx as nx
+
+        nx.node_link_graph({"nodes": [], "edges": []}, edges="edges")
+    except (ImportError, TypeError):
+        return False
+    return True
+
+
+def _graph_meta(device_ir: DeviceIR) -> IrGraphMeta:
+    """Structural, graph-level metadata seeded onto ``G.graph`` (emitted verbatim
+    by ``node_link_data``); run identity lives in the .meta.jsonl record, not here."""
+    graphs = device_ir.graphs
+    return {
+        "num_graphs": len(graphs),
+        "root_ids": list(getattr(device_ir, "root_ids", []) or []),
+        # Per-graph region hierarchy (graph-level features for the GNN).
+        "graphs": [
+            {
+                "graph_id": gi.graph_id,
+                "region_kind": type(gi).__name__,
+                "block_ids": list(getattr(gi, "block_ids", []) or []),
+            }
+            for gi in graphs
+        ],
+        # Reduction loops are rolled alternates of an original graph, not called
+        # subgraphs; record that relationship structurally instead of as edges.
+        "rolled_reductions": [
+            {
+                "original_graph_id": info.original_graph_id,
+                "rolled_block_ids": list(info.rolled_block_ids),
+                "used_rdim": bool(info.used_rdim),
+                "can_be_rolled_by_caller": bool(info.can_be_rolled_by_caller),
+            }
+            for info in getattr(device_ir, "rolled_reductions", [])
+        ],
+    }
+
+
+def extract_ir_graph(device_ir: DeviceIR) -> IrGraphRecord:
+    """Returns a networkx-loadable node-link dict of structural DeviceIR metadata.
+
+    Builds a ``networkx.DiGraph`` and serializes it with ``node_link_data`` so the
+    node-link schema is correct by construction; ``schema_version`` is re-added at
+    the top.
+    """
+    if not _has_networkx_node_link():
+        raise ImportError(
+            "networkx>=3.4 is required to extract IR graphs "
+            "(node_link_data needs the `edges=` kwarg); "
+            "install with `pip install 'networkx>=3.4'`."
+        )
+    import networkx as nx
+
+    graphs = device_ir.graphs
+
+    # Pass 1: assign global IDs and precompute val features once (O(N), not O(N+E)).
+    graphs_by_id = {gi.graph_id: gi for gi in graphs}
+    node_id: dict[torch.fx.Node, str] = {}
+    val_by_node: dict[torch.fx.Node, ValFeatures] = {}
+    for graph_info in graphs:
+        gid = graph_info.graph_id
+        for node in graph_info.graph.nodes:
+            node_id[node] = f"g{gid}:{node.name}"
+            val_by_node[node] = _val_features(node.meta.get("val"))
+
+    nx_graph = nx.DiGraph()
+    nx_graph.graph.update(_graph_meta(device_ir))
+
+    # Pass 2: add every node first, so add_edge never auto-creates an
+    # attribute-less placeholder (region edges target child-graph placeholders
+    # that are visited in a later graph_info).
+    for graph_info in graphs:
+        gid = graph_info.graph_id
+        region_kind = type(graph_info).__name__
+        block_ids = list(getattr(graph_info, "block_ids", []) or [])
+        for node in graph_info.graph.nodes:
+            valf = val_by_node[node]
+            lowf = _lowering_features(node)
+            location = node.meta.get("location")
+            nx_graph.add_node(
+                node_id[node],
+                graph_id=gid,
+                region_kind=region_kind,
+                block_ids=block_ids,
+                op_kind=node.op,
+                target=_target_str(node.target),
+                lowering_class=lowf["lowering_class"],
+                dtype=valf["dtype"],
+                shape=valf["shape"],
+                concrete_shape=valf["concrete_shape"],
+                stride=valf["stride"],
+                concrete_stride=valf["concrete_stride"],
+                device=valf["device"],
+                value=valf["value"],
+                input_dtypes=lowf["input_dtypes"],
+                input_shapes=lowf["input_shapes"],
+                reduction_type=lowf["reduction_type"],
+                reduction_ranges=lowf["reduction_ranges"],
+                pointwise_ranges=lowf["pointwise_ranges"],
+                source_loc=None if location is None else _truncate(str(location)),
+            )
+
+    # Pass 3: add edges. multigraph=False is safe; data edges target consuming
+    # nodes and region edges target placeholders, so no (source, target) collides.
+    for graph_info in graphs:
+        for node in graph_info.graph.nodes:
+            # Data edges: producer -> this node, one edge per producer with the
+            # argument positions it feeds.
+            for producer, arg_positions in _input_edges(node).items():
+                producer_val = val_by_node[producer]
+                nx_graph.add_edge(
+                    node_id[producer],
+                    node_id[node],
+                    edge_kind="data",
+                    arg_positions=arg_positions,
+                    dtype=producer_val["dtype"],
+                    shape=producer_val["shape"],
+                )
+
+            # Region edges: from a live control-flow call node, the outer arg
+            # list maps positionally onto the child graph's placeholders.
+            for child_gid, live in _region_specs(node):
+                child = graphs_by_id.get(child_gid)
+                if child is None or not isinstance(live, (list, tuple)):
+                    continue
+                placeholders = list(child.graph.find_nodes(op="placeholder"))
+                # A child legitimately has more placeholders (induction/state)
+                # than passed args, so the positional zip is best-effort.
+                for placeholder, arg in zip(placeholders, live, strict=False):
+                    if (
+                        isinstance(arg, torch.fx.Node)
+                        and arg in node_id
+                        and placeholder in node_id
+                    ):
+                        arg_val = val_by_node[arg]
+                        nx_graph.add_edge(
+                            node_id[arg],
+                            node_id[placeholder],
+                            edge_kind="region",
+                            arg_positions=[],
+                            dtype=arg_val["dtype"],
+                            shape=arg_val["shape"],
+                        )
+
+    data = nx.node_link_data(nx_graph, edges="edges")
+    return cast("IrGraphRecord", {"schema_version": IR_SCHEMA_VERSION, **data})

--- a/helion/autotuner/metrics.py
+++ b/helion/autotuner/metrics.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from ._metadata.ir_features import IrGraphRecord
+
 _post_autotune_hooks: list[Callable[[AutotuneMetrics], None]] = []
 
 
@@ -96,12 +98,14 @@ def _codegen_signature(settings: dict[str, object] | None) -> str:
 
 @dataclasses.dataclass
 class KernelMetadata:
-    """Per-run identity for the kernel being autotuned.
+    """Per-run identity (and the derived ir_graph artifact) for the autotuned kernel.
 
     Appended (one JSON record per run) to the ``<autotune_log>.meta.jsonl``
     sidecar that sits next to the per-config CSV telemetry. The CSV records each
     config and its result; this record provides the kernel context (source,
-    shapes, dtypes, hardware, settings) those rows join back to.
+    shapes, dtypes, hardware, settings) those rows join back to, plus the
+    config-independent ``ir_graph`` device-IR dump. ``ir_graph`` is a derived
+    artifact (a function of ``run_id``), so it is excluded from the ``run_id`` hash.
 
     ``run_id`` is the single foreign key for an autotune *invocation*: a direct
     content hash of ``(kernel_source, codegen-settings signature, input_shapes,
@@ -122,6 +126,12 @@ class KernelMetadata:
     dtypes: str = ""
     hardware: str = ""
     settings: dict[str, object] | None = None
+    # Config-independent device-IR dump; a derived artifact, NOT part of run_id.
+    # repr/compare/hash are off: the payload is large and derived, so it must not
+    # bloat repr or participate in dataclass equality/hashing.
+    ir_graph: IrGraphRecord | None = dataclasses.field(
+        default=None, repr=False, compare=False, hash=False
+    )
 
     @functools.cached_property
     def run_id(self) -> str:
@@ -132,6 +142,9 @@ class KernelMetadata:
         fields (so boundaries can't collide). Content-derived, so the same
         invocation yields the same ``run_id`` across processes and CI runs.
         """
+        # Hash exactly these five identity fields. ir_graph is intentionally NOT
+        # included: it is a derived artifact (a function of run_id), not identity,
+        # so hashing it would be circular and wrong.
         payload = (
             f"{self.kernel_source}\x00{_codegen_signature(self.settings)}\x00"
             f"{self.input_shapes}\x00{self.dtypes}\x00{self.hardware}"
@@ -147,4 +160,5 @@ class KernelMetadata:
             "dtypes": self.dtypes,
             "hardware": self.hardware,
             "settings": self.settings,
+            "ir_graph": self.ir_graph,
         }

--- a/test/test_ir_features.py
+++ b/test/test_ir_features.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import functools
+import json
+import types
+import unittest
+
+import torch
+
+from helion._testing import DEVICE
+from helion._testing import TestCase
+from helion._testing import skipIfRefEager
+from helion.autotuner._metadata import ir_features
+from helion.autotuner._metadata.ir_features import extract_ir_graph
+
+# Reuse the extractor's single capability check (networkx>=3.4, i.e.
+# node_link_data's `edges=` kwarg) so the skip gate and the producer agree on one
+# definition of "usable networkx" instead of duplicating the probe.
+_HAS_NETWORKX = ir_features._has_networkx_node_link()
+if _HAS_NETWORKX:
+    import networkx as nx
+else:
+    nx = None  # type: ignore[assignment]
+
+
+def _node_link_graph(data: dict[str, object]) -> nx.DiGraph:
+    """Load a node-link record using the supported networkx API."""
+    return nx.node_link_graph(data, edges="edges")
+
+
+def _extract(kernel: object, args: tuple[object, ...]) -> dict[str, object]:
+    bound = kernel.bind(args)  # type: ignore[attr-defined]
+    return extract_ir_graph(bound.host_function.device_ir)
+
+
+class TestIrFeatures(TestCase):
+    @skipIfRefEager("device IR is not built in ref eager mode")
+    @unittest.skipUnless(_HAS_NETWORKX, "networkx>=3.4 required")
+    def test_pointwise_dump_is_networkx_loadable(self) -> None:
+        """A pointwise kernel yields a node-link DiGraph with data-only edges."""
+        from examples.add import add
+
+        g = _extract(
+            add,
+            (
+                torch.randn(128, 128, device=DEVICE),
+                torch.randn(128, 128, device=DEVICE),
+            ),
+        )
+        self.assertIs(g["directed"], True)
+        self.assertIs(g["multigraph"], False)
+        self.assertTrue(g["nodes"])
+        self.assertTrue(g["edges"])
+        # Node ids are unique across the union of all graphs.
+        ids = [n["id"] for n in g["nodes"]]
+        self.assertEqual(len(ids), len(set(ids)))
+        # A pointwise node carries its lowering class and iteration ranges.
+        pointwise = [
+            n for n in g["nodes"] if n["lowering_class"] == "PointwiseLowering"
+        ]
+        self.assertTrue(pointwise)
+        self.assertIsNotNone(pointwise[0]["pointwise_ranges"])
+        # Reconstructs as a networkx DiGraph with no effort.
+        graph = _node_link_graph(json.loads(json.dumps(g)))
+        self.assertTrue(graph.is_directed())
+        self.assertEqual(graph.number_of_nodes(), len(g["nodes"]))
+        self.assertEqual(graph.number_of_edges(), len(g["edges"]))
+
+    @skipIfRefEager("device IR is not built in ref eager mode")
+    @unittest.skipUnless(_HAS_NETWORKX, "networkx>=3.4 required")
+    def test_reduction_records_rolled_metadata_not_fake_edges(self) -> None:
+        """Rolled reductions are captured as typed metadata, never as edges."""
+        from examples.softmax import softmax
+
+        g = _extract(softmax, (torch.randn(128, 128, device=DEVICE),))
+        rolled = g["graph"]["rolled_reductions"]
+        self.assertTrue(rolled, "softmax should record at least one rolled reduction")
+        entry = rolled[0]
+        self.assertIsInstance(entry["original_graph_id"], int)
+        self.assertIsInstance(entry["rolled_block_ids"], list)
+        self.assertIsInstance(entry["used_rdim"], bool)
+        self.assertIsInstance(entry["can_be_rolled_by_caller"], bool)
+        # A reduction node carries its reduction_type.
+        reductions = [
+            n for n in g["nodes"] if n["lowering_class"] == "ReductionLowering"
+        ]
+        self.assertTrue(reductions)
+        self.assertIsNotNone(reductions[0]["reduction_type"])
+        # We do NOT fabricate region edges for rolled reductions (no call node).
+        region_edges = [e for e in g["edges"] if e["edge_kind"] == "region"]
+        self.assertEqual(region_edges, [])
+
+    @skipIfRefEager("device IR is not built in ref eager mode")
+    @unittest.skipUnless(_HAS_NETWORKX, "networkx>=3.4 required")
+    def test_control_flow_yields_resolved_region_edges(self) -> None:
+        """An explicit _for_loop resolves live args into region edges."""
+        from examples.attention import attention
+
+        args = tuple(
+            torch.randn(1, 2, 128, 64, device=DEVICE, dtype=torch.float16)
+            for _ in range(3)
+        )
+        g = _extract(attention, args)
+        # The body graph is a ForLoopGraphInfo invoked from the root.
+        region_kinds = {gg["region_kind"] for gg in g["graph"]["graphs"]}
+        self.assertIn("ForLoopGraphInfo", region_kinds)
+        # Region edges must exist and resolve to real nodes in the union graph.
+        region_edges = [e for e in g["edges"] if e["edge_kind"] == "region"]
+        self.assertTrue(region_edges, "attention _for_loop should yield region edges")
+        node_ids = {n["id"] for n in g["nodes"]}
+        for edge in region_edges:
+            self.assertIn(edge["source"], node_ids)
+            self.assertIn(edge["target"], node_ids)
+            # A region edge always points into a child-graph placeholder.
+            target = next(n for n in g["nodes"] if n["id"] == edge["target"])
+            self.assertEqual(target["op_kind"], "placeholder")
+
+    @skipIfRefEager("device IR is not built in ref eager mode")
+    @unittest.skipUnless(_HAS_NETWORKX, "networkx>=3.4 required")
+    def test_symbolic_dims_not_specialized_to_concrete(self) -> None:
+        """Symbolic dims yield concrete_shape None (not specialized to a value)."""
+        from examples.add import add
+
+        g = _extract(
+            add,
+            (
+                torch.randn(128, 128, device=DEVICE),
+                torch.randn(128, 128, device=DEVICE),
+            ),
+        )
+        saw_symbolic = False
+        for n in g["nodes"]:
+            if n["shape"] is None:
+                continue
+            for sym, conc in zip(n["shape"], n["concrete_shape"], strict=True):
+                if sym.lstrip("-").isdigit():
+                    self.assertEqual(conc, int(sym))  # static dim -> its int
+                else:
+                    saw_symbolic = True
+                    self.assertIsNone(conc)  # symbolic dim -> None (no specialize)
+        self.assertTrue(saw_symbolic, "add should expose at least one symbolic dim")
+
+
+class TestIrFeaturesEdgeCases(TestCase):
+    """Negative / degenerate cases for the extractor helpers."""
+
+    def test_target_str_is_stable_and_address_free(self) -> None:
+        # String targets pass through (placeholder/output/get_attr).
+        self.assertEqual(ir_features._target_str("output"), "output")
+        # A function uses its qualified name, never an address (determinism).
+        text = ir_features._target_str(extract_ir_graph)
+        self.assertIn("extract_ir_graph", text)
+        self.assertNotIn("0x", text)
+        # functools.partial has no __qualname__/__name__; the str() fallback must
+        # still be address-free (deterministic across processes).
+        part = functools.partial(extract_ir_graph)
+        self.assertNotIn("0x", ir_features._target_str(part))
+        # An object with neither qualname nor name falls back to str().
+        self.assertEqual(ir_features._target_str(5), "5")
+
+    def test_concrete_dim_is_static_int_only(self) -> None:
+        """Concrete only for a static int; non-int (SymInt proxy) -> None."""
+        self.assertEqual(ir_features._concrete_dim(8), 8)
+        self.assertIsNone(ir_features._concrete_dim("s0"))
+        self.assertIsNone(ir_features._concrete_dim(None))
+
+    def test_input_edges_preserve_multiplicity_and_nesting(self) -> None:
+        """_input_edges walks fx containers and keeps every producer position."""
+        graph = torch.fx.Graph()
+        a = graph.placeholder("a")
+        b = graph.placeholder("b")
+        # a appears twice (direct + inside a nested list) -> two positions.
+        node = graph.call_function(torch.add, (a, [a, b]))
+        positions = ir_features._input_edges(node)
+        self.assertEqual(positions[a], [0, 1])
+        self.assertEqual(positions[b], [2])
+
+    def test_value_and_source_loc_are_length_capped(self) -> None:
+        """Large stringified values are truncated to exactly the cap."""
+        long = "x" * (ir_features._MAX_VALUE_LEN + 50)
+        capped = ir_features._truncate(long)
+        # A truncated result lands exactly at the cap (suffix included).
+        self.assertEqual(len(capped), ir_features._MAX_VALUE_LEN)
+        self.assertTrue(capped.endswith(ir_features._TRUNCATION_SUFFIX))
+        self.assertEqual(ir_features._truncate("short"), "short")
+        # A non-tensor scalar value is capped too.
+        feats = ir_features._val_features(long)
+        self.assertTrue(feats["value"].endswith(ir_features._TRUNCATION_SUFFIX))
+
+    def test_region_specs_if_resolves_both_branches(self) -> None:
+        """_if maps (if_graph_id, if_args) and (else_graph_id, else_args)."""
+        from helion.language._tracing_ops import _if
+
+        node = types.SimpleNamespace(target=_if, args=("test", 1, 2, ["a"], ["b"]))
+        self.assertEqual(ir_features._region_specs(node), [(1, ["a"]), (2, ["b"])])
+
+    def test_region_specs_while_loop_with_and_without_orelse(self) -> None:
+        """_while_loop maps body/cond (and orelse when present) to the same args."""
+        from helion.language._tracing_ops import _while_loop
+
+        no_orelse = types.SimpleNamespace(target=_while_loop, args=(3, 4, ["c"]))
+        self.assertEqual(ir_features._region_specs(no_orelse), [(4, ["c"]), (3, ["c"])])
+        with_orelse = types.SimpleNamespace(target=_while_loop, args=(3, 4, ["c"], 7))
+        self.assertEqual(
+            ir_features._region_specs(with_orelse),
+            [(4, ["c"]), (3, ["c"]), (7, ["c"])],
+        )
+
+    def test_region_specs_for_loop_step_uses_args_index_3(self) -> None:
+        """_for_loop_step(graph_id, begin, end, args, step) -> live args at index 3."""
+        from helion.language._tracing_ops import _for_loop_step
+
+        node = types.SimpleNamespace(
+            target=_for_loop_step, args=(5, [0], [10], ["x"], [1])
+        )
+        self.assertEqual(ir_features._region_specs(node), [(5, ["x"])])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_kernel_metadata.py
+++ b/test/test_kernel_metadata.py
@@ -43,8 +43,8 @@ _LEAN_CSV_HEADER = [
     "config",
 ]
 
-# Keys of one on-disk .meta.jsonl record: the KernelMetadata identity plus the
-# run's config_id -> config map.
+# Keys of one on-disk .meta.jsonl record: the KernelMetadata identity, the
+# config-independent device-IR dump, plus the run's config_id -> config map.
 _SIDECAR_KEYS = {
     "run_id",
     "kernel_name",
@@ -53,6 +53,7 @@ _SIDECAR_KEYS = {
     "dtypes",
     "hardware",
     "settings",
+    "ir_graph",
     "configs",
 }
 
@@ -178,6 +179,29 @@ class TestRunId(TestCase):
             with self.subTest(setting=name):
                 changed = {**base_settings, name: pairs[name][1]}
                 self.assertNotEqual(base_run_id, _run_id(changed), name)
+
+
+class TestKernelMetadataIrGraph(TestCase):
+    """ir_graph rides on KernelMetadata but is excluded from run_id."""
+
+    def test_run_id_excludes_ir_graph(self) -> None:
+        base = _metadata()
+        with_empty = _metadata()
+        with_empty.ir_graph = {}
+        with_populated = _metadata()
+        with_populated.ir_graph = {"schema_version": 1, "nodes": [{"id": "g0:a"}]}
+        # ir_graph (None vs {} vs populated) never changes run_id.
+        self.assertEqual(base.run_id, with_empty.run_id)
+        self.assertEqual(base.run_id, with_populated.run_id)
+        # Sanity: run_id IS sensitive to an identity field, so the test can fail.
+        changed = _metadata()
+        changed.kernel_source = base.kernel_source + " # edit"
+        self.assertNotEqual(base.run_id, changed.run_id)
+
+    def test_to_dict_includes_ir_graph_none_by_default(self) -> None:
+        d = _metadata().to_dict()
+        self.assertIn("ir_graph", d)
+        self.assertIsNone(d["ir_graph"])
 
 
 class TestAutotuneLogSink(TestCase):
@@ -311,6 +335,43 @@ class TestAutotuneDatasetE2E(TestCase):
         self.assertIn(data[0][header.index("run_id")], run_ids)
         decoded_config = helion.Config.from_json(json.dumps(configs_by_id[config_id]))
         self.assertIn(decoded_config.block_sizes, ([32], [64]))
+
+
+class TestIrGraphSidecar(TestCase):
+    def test_ir_graph_in_sidecar_schema(self) -> None:
+        """Device-free: a provided ir_graph round-trips into the .meta.jsonl record."""
+        config = helion.Config(block_sizes=[32], num_warps=4)
+        ir_graph = {
+            "schema_version": 1,
+            "directed": True,
+            "multigraph": False,
+            "graph": {"num_graphs": 0},
+            "nodes": [],
+            "edges": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            metadata = _metadata()
+            metadata.ir_graph = ir_graph
+            with AutotuneLogSink(f"{tmp}/run", metadata, collect_dataset=True) as sink:
+                sink.start_run()
+                config_id = sink.register_config(config)
+                assert config_id is not None
+                sink.record(
+                    AutotuneLogEntry(
+                        generation=0,
+                        status="ok",
+                        perf_ms=1.0,
+                        compile_time=0.5,
+                        config_id=config_id,
+                        config=config,
+                    )
+                )
+                sink.end_run()
+            sidecar = json.loads(
+                sink.meta_path.read_text(encoding="utf-8").splitlines()[0]
+            )
+        self.assertIn("ir_graph", sidecar)
+        self.assertEqual(sidecar["ir_graph"], ir_graph)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack 2/4. Depends on the extractor PR.

Threads ir_graph through the autotune dataset sidecar schema.

Test plan:
- python -m pytest test/test_ir_features.py test/test_kernel_metadata.py -q
- python -m pytest test/test_autotuner.py -k "ir_graph or log_sink" -q