### PR TITLE
Fix pyrefly type errors in distributed examples

### DIFF
--- a/examples/distributed/all_gather_matmul.py
+++ b/examples/distributed/all_gather_matmul.py
@@ -53,7 +53,7 @@ def copy_engine_all_gather_w_progress(
     Returns:
         torch.cuda.Stream: The CUDA stream used for the operation.
     """
-    backend_stream = symm_mem._get_backend_stream(priority=-1)
+    backend_stream = symm_mem._get_backend_stream(priority=-1)  # pyrefly: ignore [bad-assignment]
     assert inp.is_contiguous()
     symm_mem_group = dist.group.WORLD
     if symm_mem_group is None:
@@ -69,7 +69,7 @@ def copy_engine_all_gather_w_progress(
     assert list(output.shape) == output_shape, (list(output.shape), output_shape)
     chunks = output.chunk(world_size * splits_per_rank)
     symm_mem_hdl.barrier()
-    backend_stream.wait_stream(torch.cuda.current_stream())
+    backend_stream.wait_stream(torch.cuda.current_stream())  # pyrefly: ignore [missing-attribute]
     with torch.cuda.stream(backend_stream):
         for step in range(world_size):
             src_rank = (rank + step + 1) % world_size
@@ -85,7 +85,7 @@ def copy_engine_all_gather_w_progress(
                     val=1,
                 )
         symm_mem_hdl.barrier()
-    return backend_stream
+    return backend_stream  # pyrefly: ignore [bad-return]
 
 
 # %%

--- a/examples/distributed/fp8_scaled_all_gather_matmul.py
+++ b/examples/distributed/fp8_scaled_all_gather_matmul.py
@@ -120,7 +120,7 @@ def copy_engine_all_gather_w_progress(
         splits_per_rank (int): The number of splits per rank for progress tracking.
         backend_stream (torch.cuda.Stream, optional): The CUDA stream to use for the operation. If None, a new stream will be created.
     """
-    backend_stream = dist._symmetric_memory._get_backend_stream(priority=-1)
+    backend_stream = dist._symmetric_memory._get_backend_stream(priority=-1)  # pyrefly: ignore [bad-assignment]
     assert inp.is_contiguous(), "Input tensor 'inp' must be contiguous"
 
     if group is None:
@@ -144,7 +144,7 @@ def copy_engine_all_gather_w_progress(
     chunks = output.chunk(world_size * splits_per_rank)
 
     # symm_mem.barrier()
-    backend_stream.wait_stream(torch.cuda.current_stream())
+    backend_stream.wait_stream(torch.cuda.current_stream())  # pyrefly: ignore [missing-attribute]
 
     with torch.cuda.stream(backend_stream):
         for step in range(world_size):
@@ -164,7 +164,7 @@ def copy_engine_all_gather_w_progress(
                 )
         # symm_mem.barrier()
 
-    return backend_stream
+    return backend_stream  # pyrefly: ignore [bad-return]
 
 
 def _helion_all_gather_fp8_matmul_runtime(


### PR DESCRIPTION
Suppress 6 pyrefly 1.0.0 errors in all_gather_matmul.py and fp8_scaled_all_gather_matmul.py caused by torch._C.Stream vs torch.cuda.Stream type mismatch from _get_backend_stream().