### PR TITLE
[pallas] Fix ragged/data-dependent fori_loop stores

### DIFF
--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -10,7 +10,10 @@ import torch
 from helion._compiler.ast_extension import expr_from_string
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from helion._compiler.inductor_lowering import CodegenState
+    from helion._compiler.tile_strategy import DeviceLoopOrGridState
 
 
 def load_expr(
@@ -122,6 +125,56 @@ def _load_mask_expr(
     return "*".join(mask_exprs)
 
 
+def _iter_dma_scratch_loops(
+    state: CodegenState, name: str
+) -> Iterator[tuple[DeviceLoopOrGridState, str]]:
+    """Yield ``(loop, scratch_ref_name)`` for every active loop that DMA-routes
+    ``name`` through a VMEM scratch."""
+    from helion._compiler.tile_strategy import EmitPipelineLoopState
+    from helion._compiler.tile_strategy import ForiLoopState
+
+    for loops in state.codegen.active_device_loops.values():
+        for loop in loops:
+            if isinstance(loop, (EmitPipelineLoopState, ForiLoopState)):
+                mapping = getattr(loop, "_tensor_to_dma_scratch", None)
+                if mapping and name in mapping:
+                    yield loop, mapping[name]
+
+
+def _find_dma_scratch_loop(
+    state: CodegenState, name: str
+) -> tuple[DeviceLoopOrGridState | None, str]:
+    """Find the active loop that DMA-routes ``name`` and its scratch ref.
+
+    Returns ``(loop, scratch_ref_name)`` for the first matching active loop, or
+    ``(None, name)`` when the tensor is not scratch-routed.
+
+    TODO: this returns the *first* matching active loop, which is wrong
+    when nested fori_loops scratch-route the *same* tensor at multiple levels --
+    a body access should resolve to the innermost (current) loop's scratch, not
+    the first.  It silently miscompiles e.g.::
+
+        for tile_m in hl.tile(m):
+            out[tile_m, :] = x[tile_m, :] + 1.0
+            for tile_n in hl.tile(n):
+                out[tile_m, tile_n] = out[tile_m, tile_n] + 2.0
+
+    where the inner RMW's load/store bind to the outer loop's scratch while its
+    DMA uses the inner loop's scratch, producing wrong results with no error.
+    This can be fixed by resolving against the current loop instead of first-match.
+    """
+    return next(_iter_dma_scratch_loops(state, name), (None, name))
+
+
+def _tensor_routed_to_fori_scratch(state: CodegenState, tensor: torch.Tensor) -> bool:
+    """True if ``tensor``'s store destination ref is a fori_loop DMA scratch."""
+    from helion._compiler.tile_strategy import ForiLoopState
+
+    name = state.codegen.device_function.tensor_arg(tensor).name
+    loop, _ref = _find_dma_scratch_loop(state, name)
+    return isinstance(loop, ForiLoopState)
+
+
 def sliced_value_for_store(
     state: CodegenState,
     tensor: torch.Tensor,
@@ -139,6 +192,10 @@ def sliced_value_for_store(
     This only applies to grid-tiled dimensions that produce ``:`` in the
     generated Pallas index.  Dimensions indexed via ``pl.ds()`` are padded
     instead of clamped, so they must keep their full block-size value.
+
+    fori_loop-scratch stores are exempt: their destination is a block-sized
+    VMEM scratch (not a clamped ref), so the value stays block-shaped and the
+    writeback DMA clamps the extent instead (see ``_build_dma_slices``).
     """
     from helion._compiler.compile_environment import CompileEnvironment
     from helion._compiler.pallas.plan_tiling import TilePattern
@@ -146,6 +203,9 @@ def sliced_value_for_store(
     assert state.fx_node is not None
     patterns = state.fx_node.meta.get("indexing_patterns")
     if patterns is None:
+        return value
+
+    if _tensor_routed_to_fori_scratch(state, tensor):
         return value
 
     env = CompileEnvironment.current()
@@ -254,9 +314,6 @@ def index_parts(
     Also returns positions of ``None`` indices so the caller can apply
     ``jnp.expand_dims`` after loading.
     """
-    from helion._compiler.tile_strategy import EmitPipelineLoopState
-    from helion._compiler.tile_strategy import ForiLoopState
-
     if not subscript:
         return ["..."], []
 
@@ -268,14 +325,9 @@ def index_parts(
     tensor_name = state.codegen.device_function.tensor_arg(tensor).name
     in_pipeline = False
     pipeline_block_ids: set[int] = set()
-    for loops in state.codegen.active_device_loops.values():
-        for loop in loops:
-            if (
-                isinstance(loop, (EmitPipelineLoopState, ForiLoopState))
-                and tensor_name in loop._tensor_to_dma_scratch
-            ):
-                in_pipeline = True
-                pipeline_block_ids.update(loop.block_ids)
+    for loop, _ref in _iter_dma_scratch_loops(state, tensor_name):
+        in_pipeline = True
+        pipeline_block_ids.update(loop.block_ids)
 
     # Use pre-computed indexing patterns from plan_tiling analysis
     indexing_patterns = _get_indexing_patterns(state, tensor)
@@ -665,13 +717,5 @@ def _loop_offset_alignment(
 
 def vmem_name(state: CodegenState, name: str) -> str:
     """Remap a tensor name to its VMEM ref name when inside emit_pipeline or fori_loop."""
-    from helion._compiler.tile_strategy import EmitPipelineLoopState
-    from helion._compiler.tile_strategy import ForiLoopState
-
-    for loops in state.codegen.active_device_loops.values():
-        for loop in loops:
-            if isinstance(loop, (EmitPipelineLoopState, ForiLoopState)):
-                mapping = getattr(loop, "_tensor_to_dma_scratch", None)
-                if mapping and name in mapping:
-                    return mapping[name]
-    return name
+    _loop, ref = _find_dma_scratch_loop(state, name)
+    return ref

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -2427,14 +2427,31 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         _tensor_to_sem=tensor_to_sem,
     )
 
-    def _build_hbm_dma_slice(
-        fake: torch.Tensor, hbm_name: str, subscript_meta: list[object]
-    ) -> str:
-        """Build an HBM ref slicing expression for DMA with loop variable."""
+    def _build_dma_slices(
+        fake: torch.Tensor,
+        vmem_name: str,
+        hbm_name: str,
+        subscript_meta: list[object],
+        *,
+        clamp: bool,
+    ) -> tuple[str, str]:
+        """Build (vmem_ref, hbm_ref) ref slices for a DMA copy with loop variable.
+
+        The HBM ref is sliced to this iteration's tile.  With ``clamp=True``
+        (ragged stores) a leading tiled dim is trimmed to its live extent
+        ``min(block_size, end - offset)`` and the VMEM side sliced to match, so
+        only live rows are written instead of overrunning adjacent regions
+        packed in the same tensor; with ``clamp=False`` (loads, dense stores)
+        the VMEM side stays the bare buffer.
+        """
+        from helion._compiler.pallas.ordered_carry import is_dynamic_bound_tile
+
         dim_to_bid = _get_dim_block_ids(subscript_meta, env)
         shape = fake.shape
-        parts: list[str] = []
-        needs_slice = False
+        hbm_parts: list[str] = []
+        vmem_parts: list[str] = []
+        hbm_needs_slice = False
+        vmem_needs_slice = False
         for dim_idx in range(len(shape)):
             bid = dim_to_bid.get(dim_idx)
             if bid is not None and bid in block_ids:
@@ -2443,10 +2460,29 @@ def _codegen_fori_loop(state: CodegenState) -> object:
                 iter_step_expr = iter_step_exprs[bid_idx]
                 slice_size_expr = slice_size_exprs[bid_idx]
                 dim_idx_expr = dim_idx_exprs[bid_idx]
-                parts.append(
-                    f"pl.ds(({begin_expr}) + ({dim_idx_expr}) * ({iter_step_expr}), {slice_size_expr})"
-                )
-                needs_slice = True
+                offset_expr = f"({begin_expr}) + ({dim_idx_expr}) * ({iter_step_expr})"
+                # Mosaic requires the lane (/128) and sublane (/8) VMEM dims to
+                # stay tile-aligned, so only clamp dims outside the last two; a
+                # ragged store on a last-two dim can't clamp and is rejected.
+                if clamp and dim_idx < len(shape) - 2:
+                    end_expr = _get_loop_begin_and_end(state, bid_idx)[1]
+                    slice_size_expr = f"jnp.minimum({slice_size_expr}, ({end_expr}) - ({offset_expr}))"
+                    vmem_parts.append(f"pl.ds(0, {slice_size_expr})")
+                    vmem_needs_slice = True
+                elif clamp and is_dynamic_bound_tile(state, bid):
+                    raise NotImplementedError(
+                        "Pallas: a ragged (data-dependent) store whose tiled "
+                        "dimension is one of the last two (lane/sublane) "
+                        "dimensions is not supported. Mosaic tile alignment "
+                        "forbids clamping there, so a partial tile would "
+                        "silently overrun adjacent rows. Move the ragged "
+                        "dimension to a leading position, e.g. "
+                        "[tokens, heads, head_dim]."
+                    )
+                else:
+                    vmem_parts.append(":")
+                hbm_parts.append(f"pl.ds({offset_expr}, {slice_size_expr})")
+                hbm_needs_slice = True
                 from .memory_ops import _record_pad_info
 
                 extra_pad = _compute_pipeline_or_dma_extra_pad(
@@ -2460,12 +2496,13 @@ def _codegen_fori_loop(state: CodegenState) -> object:
                     offset = state.codegen.offset_var(bid)
                     bs_var = state.device_function.block_size_var(bid)
                     if bs_var:
-                        parts.append(f"pl.ds({offset}, {bs_var})")
-                        needs_slice = True
+                        hbm_parts.append(f"pl.ds({offset}, {bs_var})")
+                        hbm_needs_slice = True
                     else:
-                        parts.append(":")
+                        hbm_parts.append(":")
                 else:
-                    parts.append(":")
+                    hbm_parts.append(":")
+                vmem_parts.append(":")
             else:
                 idx_meta = (
                     subscript_meta[dim_idx]
@@ -2476,13 +2513,21 @@ def _codegen_fori_loop(state: CodegenState) -> object:
 
                 if is_scalar_index(idx_meta):
                     offset_expr = state.device_function.literal_expr(idx_meta)
-                    parts.append(f"pl.ds({offset_expr}, 1)")
-                    needs_slice = True
+                    hbm_parts.append(f"pl.ds({offset_expr}, 1)")
+                    hbm_needs_slice = True
                 else:
-                    parts.append(":")
-        if not needs_slice:
-            return hbm_name
-        return f"{hbm_name}.at[{', '.join(parts)}]"
+                    hbm_parts.append(":")
+                vmem_parts.append(":")
+        # ``.at[]`` (Ref transform), not ``[]`` which would materialize a
+        # dynamically-shaped array; make_async_copy operates on Refs.  Each side
+        # falls back to the bare ref when it has no slices.
+        hbm = f"{hbm_name}.at[{', '.join(hbm_parts)}]" if hbm_needs_slice else hbm_name
+        vmem = (
+            f"{vmem_name}.at[{', '.join(vmem_parts)}]"
+            if vmem_needs_slice
+            else vmem_name
+        )
+        return vmem, hbm
 
     # For loop-carried state, remap args to scratch reads inside the body
     body_args = (
@@ -2495,7 +2540,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     with state.codegen.add_fori_loop(fori_state):
         # Non-DMA tensors keep their outer BlockSpec (whole-shape VMEM ref)
         # and need an absolute offset for ``pl.ds()`` indexing in the body.
-        # DMA copies build their own absolute slice via _build_hbm_dma_slice,
+        # DMA copies build their own absolute slice via _build_dma_slices,
         # so this offset is dead when every tensor is DMA'd.
         if len(tensor_to_dma_scratch) < len(all_tensor_info):
             for i, bid in enumerate(block_ids):
@@ -2512,11 +2557,13 @@ def _codegen_fori_loop(state: CodegenState) -> object:
                 continue
             vmem_name = tensor_to_dma_scratch[hbm_name]
             sem_name = tensor_to_sem[hbm_name]
-            src_slice = _build_hbm_dma_slice(fake, hbm_name, sub_meta)
+            vmem_ref, hbm_ref = _build_dma_slices(
+                fake, vmem_name, hbm_name, sub_meta, clamp=False
+            )
             copy_var = state.device_function.new_var("_copy")
             state.codegen.add_statement(
                 statement_from_string(
-                    f"{copy_var} = pltpu.make_async_copy({src_slice}, {vmem_name}, {sem_name})"
+                    f"{copy_var} = pltpu.make_async_copy({hbm_ref}, {vmem_ref}, {sem_name})"
                 )
             )
             state.codegen.add_statement(statement_from_string(f"{copy_var}.start()"))
@@ -2535,11 +2582,13 @@ def _codegen_fori_loop(state: CodegenState) -> object:
                 continue
             vmem_name = tensor_to_dma_scratch[hbm_name]
             sem_name = tensor_to_sem[hbm_name]
-            dst_slice = _build_hbm_dma_slice(fake, hbm_name, sub_meta)
+            vmem_ref, hbm_ref = _build_dma_slices(
+                fake, vmem_name, hbm_name, sub_meta, clamp=True
+            )
             copy_out_var = state.device_function.new_var("_copy_out")
             state.codegen.add_statement(
                 statement_from_string(
-                    f"{copy_out_var} = pltpu.make_async_copy({vmem_name}, {dst_slice}, {sem_name})"
+                    f"{copy_out_var} = pltpu.make_async_copy({vmem_ref}, {hbm_ref}, {sem_name})"
                 )
             )
             state.codegen.add_statement(

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -812,6 +812,125 @@ class TestPallas(TestCase):
         self.assertNotIn("[:64, :32]", code)
         torch.testing.assert_close(result, torch.ones_like(x))
 
+    @skipIfPallasInterpret(
+        "data-dependent writeback clamp emits a dynamic-size DMA slice "
+        "(pl.ds with a traced size) that JAX interpret mode cannot discharge"
+    )
+    def test_fori_loop_ragged_sub_block_store(self) -> None:
+        """fori_loop store from a data-dependent ``hl.tile(start, end)`` whose
+        per-sequence extent is smaller than the block, with several sequences
+        packed into one output (the ragged/paged-attention decode shape).
+
+        Regression test for two coupled issues in the fori_loop store path:
+
+        * ``sliced_value_for_store`` clamped the value to ``out.shape[0]`` (the
+          whole token dim) on the block-sized VMEM scratch store, so when total
+          tokens < block the in-body store raised
+          ``Invalid shape for `swap``` (block-sized ref vs sliced value).
+        * the writeback DMA copied a full block from each sequence's
+          data-dependent begin, overrunning into adjacent sequences' rows; the
+          fix clamps the writeback to the per-tile extent.
+
+        The store dim is the *leading* (outer) dim of a 3D tensor, matching the
+        ``[tokens, heads, head_dim]`` layout where clamping is alignment-legal.
+        """
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def ragged_add1(x: torch.Tensor, cu_seqlens: torch.Tensor) -> torch.Tensor:
+            n_seq = cu_seqlens.size(0) - 1
+            out = torch.empty_like(x)
+            for s in hl.grid(n_seq):
+                start = cu_seqlens[s]
+                end = cu_seqlens[s + 1]
+                for tile in hl.tile(start, end):
+                    out[tile, :, :] = x[tile, :, :] + 1.0
+            return out
+
+        # Sequence lengths 1, 7, 4, 13 -> total 25 < block 32, so every tile is
+        # a sub-block partial that exercises the scratch-store + writeback clamp.
+        cu = torch.tensor([0, 1, 8, 12, 25], dtype=torch.int32, device=DEVICE)
+        total = int(cu[-1].item())
+        x = torch.randn(total, 8, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            ragged_add1,
+            (x, cu),
+            block_sizes=[32],
+            pallas_loop_type="fori_loop",
+        )
+        self.assertIn("jax.lax.fori_loop", code)
+        self.assertIn("pltpu.make_async_copy", code)
+        torch.testing.assert_close(result, x + 1.0)
+
+    def test_fori_loop_last_two_dim_ragged_store_rejected(self) -> None:
+        """A ragged (data-dependent) store whose tiled dim is one of the last two
+        (lane/sublane) dims is rejected with a clear error.
+
+        Mosaic tile alignment forbids a dynamic-size clamp on the last two dims,
+        so such a store would fall back to a full-block writeback from the
+        data-dependent begin and silently overrun adjacent rows. Rather than
+        emit that, codegen raises; the user should move the ragged dimension
+        to a leading position, e.g. ``[tokens, heads, head_dim]``.
+        """
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def ragged_last_two_dim(
+            x: torch.Tensor, starts: torch.Tensor, ends: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.empty_like(x)
+            n = starts.size(0)
+            for g in hl.grid(n):
+                st = starts[g]
+                en = ends[g]
+                for tile in hl.tile(st, en):
+                    out[tile, :] = x[tile, :] + 1.0
+            return out
+
+        # 2D tensor -> dim 0 is len(shape)-2 (a last-two dim), and the tile bounds
+        # are loaded at runtime (data-dependent), so the store is rejected.
+        x = torch.randn(8, 128, device=DEVICE, dtype=torch.float32)
+        starts = torch.tensor([0, 4], dtype=torch.int32, device=DEVICE)
+        ends = torch.tensor([4, 8], dtype=torch.int32, device=DEVICE)
+        with self.assertRaisesRegex(Exception, "lane/sublane"):
+            code_and_output(
+                ragged_last_two_dim,
+                (x, starts, ends),
+                block_sizes=[8],
+                pallas_loop_type="fori_loop",
+            )
+
+    @unittest.expectedFailure  # nested-scratch resolution bug; see _find_dma_scratch_loop TODO
+    def test_fori_loop_nested_same_tensor_scratch_miscompiles(self) -> None:
+        """Nested fori_loops that scratch-route the same tensor miscompile.
+
+        ``out`` is DMA-routed by both the outer ``tile_m`` loop (full row) and
+        the inner ``tile_n`` loop (column slice).  The inner RMW's load/store
+        bind to the *first* matching scratch (the outer loop's) via
+        ``_find_dma_scratch_loop``, while its DMA uses the inner loop's scratch,
+        so each inner iteration adds to the whole-row buffer -- producing a wrong
+        result (x + 5 instead of x + 3) with no error.  xpasses once scratch
+        resolution picks the innermost (current) loop instead of first-match.
+        """
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def nested_same_output(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            for _ in hl.grid(1):
+                for tile_m in hl.tile(m):
+                    out[tile_m, :] = x[tile_m, :] + 1.0
+                    for tile_n in hl.tile(n):
+                        out[tile_m, tile_n] = out[tile_m, tile_n] + 2.0
+            return out
+
+        x = torch.randn(128, 256, device=DEVICE, dtype=torch.float32)
+        _, out = code_and_output(
+            nested_same_output,
+            (x,),
+            block_sizes=[128, 128],
+            pallas_loop_type="fori_loop",
+        )
+        torch.testing.assert_close(out, x + 3.0)
+
     def test_add_does_not_donate_inputs(self) -> None:
         """Verify that read-only inputs are not donated by the kernel.
 


### PR DESCRIPTION
**Problem:**

On the Pallas fori_loop path, a store from a data-dependent `hl.tile(start, end)` whose extent is smaller than the block size (e.g. for the ragged paged-attention decode case) failed to compile with "Invalid shape for swap", and a full-block writeback could overrun adjacent sequences packed in the same output tensor. Ex:
```python
@helion.kernel(backend="pallas", static_shapes=True)
def ragged_add1(x: torch.Tensor, cu_seqlens: torch.Tensor) -> torch.Tensor:
    n_seq = cu_seqlens.size(0) - 1
    out = torch.empty_like(x)
    for s in hl.grid(n_seq):
        start = cu_seqlens[s]
        end = cu_seqlens[s + 1]
        for tile in hl.tile(start, end):
            out[tile, :, :] = x[tile, :, :] + 1.0
        return out

device = torch.device("tpu")
cu = torch.tensor([0, 1, 8, 12, 25], dtype=torch.int32, device=device)
total = int(cu[-1].item())
x = torch.randn(total, 8, 128, device=device, dtype=torch.float32)
ragged_add1(x, cu)
```
```
 ValueError: Invalid shape for `swap`. Ref shape: (32, 8, 128). Expected shape: (32, 8, 128). Value
  shape: (25, 8, 128). Transforms: (NDIndexer(indices=(Slice(start=0, size=32, stride=1), Slice(start=0,
  size=8, stride=1), Slice(start=0, size=128, stride=1)), shape=(32, 8, 128), int_indexer_shape=(),
  validate=False),).
```

**Root cause**: `sliced_value_for_store` applied the unroll BlockSpec-clamp model (slice the value down to the ref) to fori_loop stores, whose in-body destination is a block-sized VMEM scratch, not a clamped ref.

**Fix**:
- `sliced_value_for_store`: skip the clamp-slice for fori_loop-scratch stores so the value stays block-shaped.
- `_build_hbm_dma_slice` -> `_build_dma_slices`, now with `clamp=True`, trim a leading tiled dim's writeback to `min(block, end - offset)` so ragged stores copy only live rows (lane/sublane dims must stay tile-aligned, so only dims outside the last two are clamped). Loads and dense stores use `clamp=False` and are unchanged.
