### PR TITLE
[cute] Add CuteFp8GemmSkinnyMHeuristic autotuner seed for skinny-M FP8 GEMM

### DIFF
--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from .common import dedupe_configs
+from .cute import CuteFp8GemmSkinnyMHeuristic
 from .cute import CuteReductionTileHeuristic
 from .cute import CuteReductionWideChunkHeuristic
 from .cute import CuteTcgen05ClusterM2FfiHeuristic
@@ -28,6 +29,7 @@ if TYPE_CHECKING:
 # All active heuristics by backend
 HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
     "cute": (
+        CuteFp8GemmSkinnyMHeuristic,
         CuteTcgen05ClusterM2FfiHeuristic,
         CuteTcgen05ClusterM2Heuristic,
         CuteReductionTileHeuristic,

--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -608,6 +608,68 @@ class CuteTcgen05ClusterM2Heuristic(AutotunerHeuristic):
         return None
 
 
+class CuteFp8GemmSkinnyMHeuristic(AutotunerHeuristic):
+    """Seed config for skinny-M FP8 GEMM kernels.
+
+    For small M (1-16) the optimal config is very different from a large GEMM:
+    a single row per grid block (``block_sizes[0]=1``), a modest N tile, a warp
+    of threads on the N axis, and a wide FP8 vector load. Seeding this anchors
+    the autotuner in the valid small-tile region instead of letting the random
+    population burn its budget on configs like ``block_sizes=[4096, 2048]`` or
+    1024-thread launches that are structurally wrong for a 1-row problem (and
+    frequently overflow shared memory).
+
+    A/B benchmark (helion benchmarks/run.py, fp8_gemm, CuTe, 120s budget):
+    on M=1 shapes the search locks onto this seed and produces a 1.8-2.0x
+    faster kernel than with heuristics disabled, with ~25% fewer wasted
+    compile failures.
+
+    Seeds ``block_sizes=[1, 256]``, ``num_threads=[0, 32]``,
+    ``cute_vector_widths=[4, 8]`` (the autotune-winning config for
+    M=1, K=4096, N=4096).
+    """
+
+    name = "cute_fp8_gemm_skinny_m"
+    backend = "cute"
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        spec = env.config_spec
+        # Needs to be a matmul with FP8 inputs
+        if not spec.matmul_facts or len(spec.matmul_facts) != 1:
+            return False
+        fact = spec.matmul_facts[0]
+        # Check for FP8 dtypes
+        is_fp8 = fact.lhs_dtype in (
+            torch.float8_e4m3fn,
+            torch.float8_e5m2,
+        ) and fact.rhs_dtype in (
+            torch.float8_e4m3fn,
+            torch.float8_e5m2,
+        )
+        if not is_fp8:
+            return False
+        # Check for skinny M (small batch / decode scenario):
+        # M <= 16 is the skinny-M case.
+        return fact.static_m is not None and fact.static_m <= 16
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        # Best config from autotune benchmarks for M=1, K=4096, N=4096
+        # (1.5x speedup over baseline; the M=1 search reliably converges here).
+        seed: dict[str, Any] = {
+            "block_sizes": [1, 256],
+            "num_threads": [0, 32],
+            "cute_vector_widths": [4, 8],
+        }
+        try:
+            return Config(**seed)
+        except Exception:
+            return None
+
+
 class CuteTcgen05ClusterM2FfiHeuristic(CuteTcgen05ClusterM2Heuristic):
     """Generalized TVM-FFI seed for full-tile CtaGroup.TWO 16-bit GEMMs.
 

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -8,6 +8,7 @@ import torch
 
 import helion
 from helion._compiler.autotuner_heuristics import compiler_seed_configs
+from helion._compiler.autotuner_heuristics.cute import CuteFp8GemmSkinnyMHeuristic
 from helion._compiler.autotuner_heuristics.cute import CuteTcgen05ClusterM2Heuristic
 from helion._compiler.autotuner_heuristics.registry import AutotunerHeuristic
 from helion._compiler.autotuner_heuristics.triton import TritonSkinnyGemmHeuristic
@@ -18,6 +19,7 @@ from helion._compiler.autotuner_heuristics.triton import (
 from helion._compiler.autotuner_heuristics.triton import (
     TritonUserTiledReductionHeuristic,
 )
+from helion._compiler.backend import CuteBackend
 from helion._compiler.backend import TritonBackend
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_D_STORE_BOX_N_KEY
 from helion._compiler.cute.strategies import TCGEN05_LAYOUT_OVERRIDES_EPI_TILE_M_KEY
@@ -859,6 +861,166 @@ class TestTritonStandardReductionHeuristic(TestCase):
             TritonStandardReductionHeuristic.is_eligible(
                 mm.env, mm.host_function.device_ir
             )
+        )
+
+
+_FP8_SKINNY_M_SEED_BLOCK_SIZES = [1, 256]
+_FP8_SKINNY_M_SEED_NUM_THREADS = [0, 32]
+_FP8_SKINNY_M_SEED_VECTOR_WIDTHS = [4, 8]
+
+
+class TestCuteFp8GemmSkinnyMHeuristic(TestCase):
+    """Skinny-M FP8 GEMM heuristic: fires only for a single FP8 matmul with
+    static M <= 16 and seeds the [1, 256] / nt=[0, 32] / vec=[4, 8] config that
+    the full autotune converges to for the decode / small-batch regime.
+    """
+
+    def _make_cute_env(self) -> MagicMock:
+        spec = ConfigSpec(backend=CuteBackend())
+        env = MagicMock()
+        env.backend_name = "cute"
+        env.config_spec = spec
+        env.device = DEVICE
+        env.settings = Settings()
+        return env
+
+    def _matmul_fact(
+        self,
+        *,
+        static_m: int = 1,
+        static_n: int = 4096,
+        static_k: int = 4096,
+        lhs_dtype: torch.dtype = torch.float8_e4m3fn,
+        rhs_dtype: torch.dtype = torch.float8_e4m3fn,
+    ) -> MatmulFact:
+        return MatmulFact(
+            lhs_ndim=2,
+            rhs_ndim=2,
+            m_block_id=0,
+            n_block_id=1,
+            k_block_id=2,
+            static_m=static_m,
+            static_n=static_n,
+            static_k=static_k,
+            lhs_dtype=lhs_dtype,
+            rhs_dtype=rhs_dtype,
+        )
+
+    def test_eligibility_cases(self) -> None:
+        # (name, facts, expected_eligible)
+        cases = (
+            ("m1_fp8", [self._matmul_fact(static_m=1)], True),
+            ("m16_fp8", [self._matmul_fact(static_m=16)], True),
+            ("e5m2_fp8", [self._matmul_fact(lhs_dtype=torch.float8_e5m2)], True),
+            ("m17_too_large", [self._matmul_fact(static_m=17)], False),
+            ("m1024_gemm", [self._matmul_fact(static_m=1024)], False),
+            (
+                "bf16_not_fp8",
+                [self._matmul_fact(lhs_dtype=torch.bfloat16, rhs_dtype=torch.bfloat16)],
+                False,
+            ),
+            ("mixed_fp8_bf16", [self._matmul_fact(rhs_dtype=torch.bfloat16)], False),
+            ("dynamic_m", [self._matmul_fact(static_m=None)], False),
+            ("no_matmul", [], False),
+            ("two_matmuls", [self._matmul_fact(), self._matmul_fact()], False),
+        )
+        for name, facts, expected in cases:
+            env = self._make_cute_env()
+            env.config_spec.matmul_facts.extend(facts)
+            with self.subTest(name=name):
+                self.assertEqual(
+                    CuteFp8GemmSkinnyMHeuristic.is_eligible(env, MagicMock()),
+                    expected,
+                )
+
+    def test_seed_config_contents(self) -> None:
+        env = self._make_cute_env()
+        env.config_spec.matmul_facts.append(self._matmul_fact(static_m=1))
+        seed = CuteFp8GemmSkinnyMHeuristic.get_seed_config(env, MagicMock())
+        assert seed is not None
+        self.assertEqual(seed.config["block_sizes"], _FP8_SKINNY_M_SEED_BLOCK_SIZES)
+        self.assertEqual(seed.config["num_threads"], _FP8_SKINNY_M_SEED_NUM_THREADS)
+        self.assertEqual(
+            seed.config["cute_vector_widths"], _FP8_SKINNY_M_SEED_VECTOR_WIDTHS
+        )
+
+    def test_compiler_seed_configs_records_heuristic(self) -> None:
+        # The heuristic must be wired into the cute backend registry so the
+        # generic compiler_seed_configs() path emits its seed and records it.
+        env = self._make_cute_env()
+        env.config_spec.matmul_facts.append(self._matmul_fact(static_m=1))
+        configs = compiler_seed_configs(env, MagicMock())
+        self.assertIn(
+            _FP8_SKINNY_M_SEED_BLOCK_SIZES,
+            [config.config["block_sizes"] for config in configs],
+        )
+        self.assertIn(
+            CuteFp8GemmSkinnyMHeuristic.name,
+            env.config_spec.autotuner_heuristics,
+        )
+
+    def test_compiler_seed_configs_skips_large_m(self) -> None:
+        env = self._make_cute_env()
+        env.config_spec.matmul_facts.append(self._matmul_fact(static_m=1024))
+        configs = compiler_seed_configs(env, MagicMock())
+        self.assertNotIn(
+            CuteFp8GemmSkinnyMHeuristic.name,
+            env.config_spec.autotuner_heuristics,
+        )
+        self.assertNotIn(
+            _FP8_SKINNY_M_SEED_BLOCK_SIZES,
+            [config.config["block_sizes"] for config in configs],
+        )
+
+    @onlyBackends(["cute"])
+    @skipIfRefEager("Compiler seed configs are not generated in ref eager mode")
+    def test_seed_in_initial_population_for_skinny_m(self) -> None:
+        @helion.kernel(backend="cute", static_shapes=True)
+        def fp8_gemm_skinny_m(
+            x: torch.Tensor,
+            y: torch.Tensor,
+            scale_a: torch.Tensor,
+            scale_b: torch.Tensor,
+        ) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+            for tile_n in hl.tile(n):
+                acc = hl.zeros([m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    acc = hl.dot(x[:, tile_k], y[tile_k, tile_n], acc=acc)
+                acc = acc * scale_a[:, tile_n] * scale_b[tile_n]
+                out[:, tile_n] = acc.to(torch.bfloat16)
+            return out
+
+        m, k, n = 1, 4096, 4096
+        x = torch.randn([m, k], device=DEVICE, dtype=torch.float32).to(
+            torch.float8_e4m3fn
+        )
+        y = torch.randn([k, n], device=DEVICE, dtype=torch.float32).to(
+            torch.float8_e4m3fn
+        )
+        scale_a = torch.ones([m, n], device=DEVICE)
+        scale_b = torch.ones([n], device=DEVICE)
+
+        with patch_cute_mma_support():
+            bound = fp8_gemm_skinny_m.bind((x, y, scale_a, scale_b))
+
+        device_ir = bound.host_function.device_ir
+        self.assertTrue(CuteFp8GemmSkinnyMHeuristic.is_eligible(bound.env, device_ir))
+        self.assertIn(
+            CuteFp8GemmSkinnyMHeuristic.name,
+            bound.config_spec.autotuner_heuristics,
+        )
+        seed = CuteFp8GemmSkinnyMHeuristic.get_seed_config(bound.env, device_ir)
+        assert seed is not None
+        self.assertEqual(seed.config["block_sizes"], _FP8_SKINNY_M_SEED_BLOCK_SIZES)
+        self.assertIn(
+            _FP8_SKINNY_M_SEED_BLOCK_SIZES,
+            [
+                config.config["block_sizes"]
+                for config in bound.config_spec.compiler_seed_configs
+            ],
         )
 
 


### PR DESCRIPTION
Stacked PRs:
 * #2788
 * __->__#2808


--- --- ---

### [cute] Add CuteFp8GemmSkinnyMHeuristic autotuner seed for skinny-M FP8 GEMM


Add a CuTe autotuner heuristic that seeds a known-good config for
skinny-M FP8 GEMM kernels, so the search starts from a config that fits
the M<=16 decode / small-batch regime instead of rediscovering it from
a random population.

Problem
-------
On the CuTe backend, autotuning a skinny-M FP8 GEMM with M=1 (K=N=4096)
spends almost its entire budget in the initial random population (~590s
of a 600s budget at ~1.5 configs/s), reaching only generation 1 of the
tree search. The random configs are dominated by shapes that make no
sense for a 1-row problem -- e.g. block_sizes=[4096, 2048], num_threads
up to 1024 -- many of which overflow shared memory (0x40100 > 0x38c00
max) or hit the 30s benchmark timeout, so the budget is burned on
configs that were never viable.

Fix
---
CuteFp8GemmSkinnyMHeuristic fires when the kernel is a single FP8 matmul
(float8_e4m3fn / float8_e5m2 on both operands) with static M <= 16, and
seeds:

    block_sizes        = [1, 256]   # one row per block, modest N tile
    num_threads        = [0, 32]    # one warp on the N axis (0 = auto M)
    cute_vector_widths = [4, 8]     # wide FP8 vector load on the K axis

This is the config the full autotune converges to for M=1, K=N=4096, and
it anchors the search in the valid small-tile region.

I prototyped two sibling seeds (a wider-N tile and a multi-row variant
for 2<=M<=16) but dropped them: in the A/B benchmark below they were
break-even, not wins, so only the seed that measurably helped is kept.

Benchmarking
------------
helion benchmarks/run.py, op=fp8_gemm, --helion-backend cute,
--cudagraph, HELION_AUTOTUNE_BUDGET_SECONDS=120, HELION_FORCE_AUTOTUNE=1.
A/B = this heuristic ON (default) vs OFF
(HELION_DISABLE_AUTOTUNER_HEURISTICS=1). Latency is the final
tritonbench measurement (cudagraph + warmup + averaged); speedup is vs
the rowwise torch._scaled_mm baseline.

  Shape (m,k,n)    | ON latency | ON spd | OFF latency | OFF spd
  -----------------+------------+--------+-------------+--------
  (1, 4096, 4096)  | 0.01295 ms |  1.46x |  0.02342 ms |  0.83x
  (1, 4096, 256)   | 0.00806 ms |  1.99x |  0.01582 ms |  1.01x

Selected config, ON vs OFF:
  (1,4096,4096): [1,256] (=seed)        vs [16,1024] nt=[0,1024] epi=2
  (1,4096,256):  [1,256] (=seed)        vs [4,4096]  nt=[4,256]

On every M=1 shape the search locks onto the [1,256] seed and yields a
1.8-2.0x faster kernel, while the heuristics-off search wanders into
M=16 / M=4 blocks (heavy padding waste on a 1-row problem). Search
hygiene also improves: avg compile failures/shape 3.6 (ON) vs 4.8 (OFF),
18 vs 24 total over the 5-shape run.

Note: the autotuner's internal "Best Perf" column (e.g. 0.0509 ms) is
un-graphed single-config device time and is not comparable to the
cudagraph tritonbench latency above; the 0.01295 ms ON result matches
earlier standalone runs (0.01282 / 0.01350 ms) within noise.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
