### PR TITLE
testing: reject @skipIfFn calls without parentheses

### DIFF
--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -114,6 +114,12 @@ def skipIfFn(
     wraps setUp to check the skip condition before each test runs.
     """
 
+    if not isinstance(reason, str):
+        raise TypeError(
+            f"Decorator using skipIfFn requires a reason string argument, got {type(reason).__name__}. "
+            "Make sure to call the decorator with parentheses, e.g. @decorator('reason') or @decorator()"
+        )
+
     def decorator(test_item: Callable) -> Callable:
         if isinstance(test_item, type):
             # For classes: wrap setUp to check skip condition at test execution time


### PR DESCRIPTION
These can result in a test passing without actually running the test. Without this check, we end up running the decorator function as the test, NOT the test body. In doing so we get the following warning:

```
DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method skipIfFn.<locals>.decorator of <test.test_foo.TestFoo testMethod=test_bar
_with_post_reduction_op>>)
    return self.run(*args, **kwds)
```