### PR TITLE
[Pallas] Defer tile load masks past transposes onto the sublane axis

### DIFF
--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -54,6 +54,7 @@ from .inductor_lowering import prepare_graph_lowerings
 from .loop_dependency_checker import LoopDependencyChecker
 from .matmul_utils import tensor_matmul_replacement
 from .matmul_utils import torch_matmul_replacement
+from .node_masking import defer_pallas_load_masks
 from .node_masking import remove_unnecessary_masking
 from .roll_reduction import ReductionRoller
 from .source_location import current_location
@@ -2959,10 +2960,13 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
                 promote_cute_root_graph_host_tensors(device_ir.graphs, promotions)
         for graph in device_ir.graphs:
             prepare_graph_lowerings(graph.graph)
+        defer_load_masks = CompileEnvironment.current().backend.name == "pallas"
         for graph in device_ir.graphs:
             validate_host_tensor_usage(graph.graph)
             add_tile_with_offset_metadata(graph)
             remove_unnecessary_tile_index(graph.graph)
+            if defer_load_masks:
+                defer_pallas_load_masks(graph.graph)
             remove_unnecessary_masking(graph.graph)
 
         # TODO(hinriksnaer): extract into a separate step? everything below

--- a/helion/_compiler/node_masking.py
+++ b/helion/_compiler/node_masking.py
@@ -29,6 +29,39 @@ if TYPE_CHECKING:
     ValueRangesAny = ValueRanges[Any]
 
 
+# Relayout ops a load's out-of-bounds mask may be deferred *through*: the mask is
+# re-materialized later, in the consumer's layout, by a downstream ``_mask_to``
+# (see ``defer_pallas_load_masks``).
+#
+# Restricted to ops that permute tile axes WITHOUT regrouping the masked
+# dimension's elements, so the masked dimension's set of valid/invalid lanes is
+# preserved exactly (only its axis position changes).  ``permute`` is the only
+# such op needed today -- ``transpose``/``.T`` lower to it.
+#
+# Deliberately NOT included:
+#   * ``view``/``reshape``: even when the masked block id still appears exactly
+#     once in the output shape, a reshape can regroup elements so the new
+#     per-axis mask (``arange < extent``) selects different flat positions than
+#     the eager load mask did -- e.g. a ``[B, 2]`` tile with 3 valid rows
+#     reshaped to ``[2, B]`` (old invalid flat lanes 6,7 -> new mask zeroes 3,7,
+#     dropping valid data and leaking invalid data).  "the dim survives once" is
+#     necessary but NOT sufficient; admitting these needs a stride/lane-set
+#     equivalence proof, not just a dim-count check.
+#   * ``expand``/``stack``/``gather``: pass the masked *value* through but can
+#     replicate or relocate padded lanes into valid ones.
+#   * ``squeeze``/``unsqueeze``/``alias``: safe in principle (no regrouping) but
+#     left out until they have their own deferral tests.
+#
+# IMPORTANT: every op here must be RANK-PRESERVING.  ``defer_pallas_load_masks``
+# relies on that: its profitability gate (masked axis is a major dim at the load
+# but a last-two dim at the consumer) doubles as the old "a relayout actually
+# moved the axis" check *only* because a same-shape direct ``_mask_to`` cannot put
+# an axis in both positions at once.  A rank-changing op (squeeze/unsqueeze/view/
+# reshape) would break that, and an explicit relayout-crossed check would need to
+# be reinstated.
+_RELAYOUT_TARGETS = frozenset({torch.ops.aten.permute.default})
+
+
 def mask_node_inputs(
     node: torch.fx.Node,
     other: float | bool = 0,
@@ -182,6 +215,163 @@ def recompute_masked_values(graph: torch.fx.Graph) -> None:
         if node.op != "placeholder" and node.meta.get("masked_value") is not None:
             del node.meta["masked_value"]
             node.meta["masked_value"] = cached_masked_value(node)
+
+
+def defer_pallas_load_masks(graph: torch.fx.Graph) -> None:
+    """Defer a Pallas load's eager out-of-bounds mask to a downstream ``_mask_to``.
+
+    Pallas load codegen materializes a tile's out-of-bounds mask multiplicatively
+    in the load's own layout (``ref[idx] * mask``).  When the loaded value is only
+    *relayouted* (an axis permutation; see ``_RELAYOUT_TARGETS``) and then consumed
+    by a dot or reduction, that consumer already inserts a ``_mask_to(x, 0)`` which
+    can re-materialize the same mask in the consumer's layout.  The mask is dynamic
+    (``arange < extent``), so it cannot be elided even when logically all-true;
+    applying it in the pre-relayout layout therefore keeps a live op on the path
+    into the relayout.
+
+    For each load whose masked tile dim is provably re-masked downstream, we:
+
+    * record the deferred block ids on the load so Pallas load codegen skips the
+      eager mask for those dims, and
+    * mark the load's masked value unknown so ``remove_unnecessary_masking`` keeps
+      the downstream ``_mask_to`` (it is no longer redundant once the load is not
+      pre-masked).
+
+    Correctness rests on a single dataflow fact: *every* use of the load reaches a
+    ``_mask_to(_, 0)`` crossing only ``_RELAYOUT_TARGETS`` ops, with the masked
+    dim still present as a standalone tile dim at each step.  Because those ops
+    only permute axes (they do not regroup the masked dim's elements), the later
+    per-axis mask covers exactly the lanes the eager mask would have.  The
+    standalone-dim check is necessary but not sufficient on its own -- the
+    correctness guarantee comes from restricting the crossed ops to pure axis
+    permutations (so e.g. ``reshape`` is excluded; see ``_RELAYOUT_TARGETS``).  A
+    use that does not re-mask (store, elementwise, reduction without a mask) keeps
+    the eager load mask.
+
+    Profitability is a *positional* gate on top of that correctness proof.  A mask
+    on an axis inside the last-two (sublane/lane) dims is a vectorized per-register
+    op, while a mask on a major (outer) axis is applied per outer row and is much
+    more work.  So defer only when the masked axis is a major dim at the load and
+    the relayout carries it into the last-two dims at the consumer ``_mask_to``;
+    deferring in the reverse direction would move the mask onto the more expensive
+    axis, so it is not done.  This gate also subsumes the "a relayout actually
+    moved the axis" requirement (see the loop body).
+
+    Pallas-only: Triton masks loads as real data (``tl.load(..., other=0)``), so
+    relayout never moves unmasked lanes and there is nothing to defer.
+    """
+    from ..language.memory_ops import load as load_op
+    from .aten_lowering import passthrough_masked_value
+    from .compile_environment import CompileEnvironment
+
+    env = CompileEnvironment.current()
+
+    def dim_index(node: torch.fx.Node, block_id: int) -> int | None:
+        """Index of ``block_id`` in ``node``'s value, or None unless it appears as
+        exactly one standalone dimension (this doubles as the survives-uniquely
+        check)."""
+        val = node.meta.get("val")
+        if not isinstance(val, torch.Tensor):
+            return None
+        hits = [
+            i
+            for i, size in enumerate(val.size())
+            if env.resolve_block_id(size) == block_id
+        ]
+        return hits[0] if len(hits) == 1 else None
+
+    def is_major_dim(node: torch.fx.Node, block_id: int) -> bool:
+        # An outer dim, outside the last-two (sublane, lane) vreg tile, where a
+        # mask is applied per outer row rather than as a per-register op.
+        idx = dim_index(node, block_id)
+        return idx is not None and idx < node.meta["val"].ndim - 2
+
+    def is_last_two_dim(node: torch.fx.Node, block_id: int) -> bool:
+        # Inside the last-two (sublane/lane) vreg tile, where a mask is a
+        # vectorized per-register op.
+        idx = dim_index(node, block_id)
+        return idx is not None and idx >= node.meta["val"].ndim - 2
+
+    def is_relayout(node: torch.fx.Node) -> bool:
+        if node.op != "call_function" or node.target not in _RELAYOUT_TARGETS:
+            return False
+        lowering = node.meta.get("lowering")
+        return getattr(lowering, "masked_value_fn", None) is passthrough_masked_value
+
+    def is_remask(node: torch.fx.Node, src: torch.fx.Node, block_id: int) -> bool:
+        # A zero-fill ``_mask_to`` on ``src`` that re-masks ``block_id`` with that
+        # axis in the last-two dims (the profitable place to apply the mask).
+        # ``bool(...)``: ``node.args[1] == 0`` is typed as ``Argument`` (the fill is
+        # always a scalar here, but the static type is a union), so coerce to bool.
+        return bool(
+            node.op == "call_function"
+            and node.target is _mask_to
+            and node.args[0] is src
+            and node.args[1] == 0
+            and is_last_two_dim(node, block_id)
+        )
+
+    def all_uses_remask(
+        node: torch.fx.Node, block_id: int, memo: dict[torch.fx.Node, bool]
+    ) -> bool:
+        cached = memo.get(node)
+        if cached is not None:
+            return cached
+        memo[node] = False  # conservative guard against revisiting mid-walk
+        users = list(node.users)
+        result = bool(users)
+        for user in users:
+            if is_remask(user, node, block_id):
+                continue
+            if (
+                is_relayout(user)
+                and dim_index(user, block_id) is not None
+                and all_uses_remask(user, block_id, memo)
+            ):
+                continue
+            result = False
+            break
+        memo[node] = result
+        return result
+
+    changed = False
+    for node in graph.find_nodes(op="call_function", target=load_op):
+        val = node.meta.get("val")
+        if not isinstance(val, torch.Tensor):
+            continue
+        candidates = {
+            block_id
+            for size in val.size()
+            if (block_id := env.resolve_block_id(size)) is not None
+        }
+        deferred: set[int] = set()
+        for block_id in candidates:
+            # Profitability gate: defer only when the masked axis is a major/outer
+            # dim at the load and a relayout carries it into the last-two
+            # (vreg-tile) dims at the consumer ``_mask_to``.  A mask on a last-two
+            # axis is a per-register op; a mask on a major axis is applied per
+            # outer row, so this is the only direction that moves the mask onto a
+            # cheaper axis (the reverse would move it onto a more expensive one).
+            #
+            # This also subsumes the "must cross >=1 relayout" check: with a
+            # rank-preserving relayout set, a direct ``_mask_to`` shares the load's
+            # shape, so ``block_id`` cannot be both major at the load and last-two
+            # at the consumer (see the note on ``_RELAYOUT_TARGETS``).
+            if not is_major_dim(node, block_id):
+                continue
+            if not node.users:
+                continue
+            if all_uses_remask(node, block_id, {}):
+                deferred.add(block_id)
+        if deferred:
+            node.meta["pallas_deferred_mask_block_ids"] = frozenset(deferred)
+            node.meta["masked_value"] = None
+            changed = True
+
+    if changed:
+        # Drop stale masked-value caches that assumed the load was pre-masked, so
+        # the surviving ``_mask_to`` nodes are not wrongly judged redundant.
+        recompute_masked_values(graph)
 
 
 def getitem_masked_value(

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -78,6 +78,9 @@ def _load_mask_expr(
     indexing_patterns = _get_indexing_patterns(state, tensor)
     env = CompileEnvironment.current()
     output_sizes = [*output_val.size()]
+    # Dims whose mask has been deferred to a downstream ``_mask_to`` by
+    # ``defer_pallas_load_masks`` -- masked later in the consumer layout instead.
+    deferred = state.fx_node.meta.get("pallas_deferred_mask_block_ids") or frozenset()
     mask_exprs: list[str] = []
     dtype_str: str | None = None
     out_dim = 0
@@ -100,8 +103,10 @@ def _load_mask_expr(
             # always valid, and applying a block-sized mask would broadcast
             # the dim from 1 to block_size, causing shape mismatches.
             dim_size = tensor.shape[tensor_dim]
-            if (not isinstance(dim_size, int) or dim_size > 1) and _tile_needs_mask(
-                state, block_id, tensor, tensor_dim
+            if (
+                block_id not in deferred
+                and (not isinstance(dim_size, int) or dim_size > 1)
+                and _tile_needs_mask(state, block_id, tensor, tensor_dim)
             ):
                 mask_var = state.codegen.mask_var(block_id)
                 if mask_var is not None:

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -3951,6 +3951,209 @@ class TestPallas(TestCase):
             ref[i] = (x[s:e] @ y[s:e].T).sum()
         torch.testing.assert_close(result, ref, rtol=1e-2, atol=1e-2)
 
+    @staticmethod
+    def _transpose_operand_producer(code: str) -> str | None:
+        """The source line producing the operand fed to the first
+        ``jnp.transpose(...)``, or None if there is no transpose."""
+        m = re.search(r"\b\w+ = jnp\.transpose\((\w+),", code)
+        if m is None:
+            return None
+        producer = re.search(
+            rf"^[ \t]*{re.escape(m.group(1))} = .*$", code, re.MULTILINE
+        )
+        return producer.group(0) if producer else None
+
+    def test_relayout_targets_exclude_reshape(self) -> None:
+        """Guard: ``view``/``reshape`` must NOT be deferrable relayouts.  They can
+        regroup the masked dim's elements (e.g. ``[B, 2]`` -> ``[2, B]``), so a
+        consumer-layout mask would select different lanes than the load mask; only
+        pure axis permutations are safe to defer through."""
+        from helion._compiler.node_masking import _RELAYOUT_TARGETS
+
+        self.assertIn(torch.ops.aten.permute.default, _RELAYOUT_TARGETS)
+        self.assertNotIn(torch.ops.aten.view.default, _RELAYOUT_TARGETS)
+        self.assertNotIn(torch.ops.aten.reshape.default, _RELAYOUT_TARGETS)
+
+    def test_transpose_dot_defers_pallas_load_mask(self) -> None:
+        """A masked load consumed via ``transpose`` -> dot defers its mask to the
+        consumer layout: a raw load + a post-transpose ``jnp.where``, not an eager
+        multiplicative load mask.
+
+        The deferral is an FX-graph pass, so it is independent of the pallas loop
+        type -- asserted here for both ``fori_loop`` and ``compact_worklist`` on a
+        generic (non-attention) per-token jagged projection whose partial tiles
+        make the mask load-bearing.
+        """
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def jagged_proj(
+            x: torch.Tensor, w: torch.Tensor, offsets: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for seg in hl.grid(offsets.size(0) - 1):
+                wb = w[:, :, :]
+                for tile in hl.tile(offsets[seg], offsets[seg + 1]):
+                    # masked load -> transpose -> dot: the deferral target.
+                    xb = x[tile, :, :].transpose(0, 1)
+                    out[tile, :, :] = torch.bmm(xb, wb).transpose(0, 1)
+            return out
+
+        H, D, block = 2, 16, 16
+        # Packed jagged offsets with partial final tiles (none a multiple of the
+        # block; one < block) so the deferred mask is load-bearing.
+        offsets = torch.tensor([0, 10, 33, 40, 80], device=DEVICE, dtype=torch.int32)
+        torch.manual_seed(0)
+        x = torch.randn(80, H, D, device=DEVICE, dtype=torch.bfloat16)
+        w = torch.randn(H, D, D, device=DEVICE, dtype=torch.bfloat16)
+
+        ref = torch.empty_like(x)
+        for i in range(offsets.size(0) - 1):
+            s, e = int(offsets[i]), int(offsets[i + 1])
+            ref[s:e] = torch.bmm(x[s:e].transpose(0, 1), w).transpose(0, 1)
+
+        for loop_type in ("fori_loop", "compact_worklist"):
+            with self.subTest(loop_type=loop_type):
+                code, out = code_and_output(
+                    jagged_proj,
+                    (x, w, offsets),
+                    block_sizes=[block],
+                    pallas_loop_type=loop_type,
+                )
+                # x's masked load is raw (no eager ``* mask``), feeds a transpose,
+                # and the mask reappears as a post-transpose ``jnp.where``.
+                producer = self._transpose_operand_producer(code)
+                self.assertIsNotNone(producer)
+                self.assertRegex(producer, r"= x\[")
+                self.assertNotIn("* mask", producer)
+                self.assertIn("jnp.where", code)
+                # compact_worklist matches the eager reference on the partial
+                # tiles.  fori_loop miscompiles jagged tiles in pallas interpret
+                # (a pre-existing, unrelated issue), so it is not a sound numeric
+                # oracle here; for it we assert only the codegen above.
+                if loop_type == "compact_worklist":
+                    torch.testing.assert_close(
+                        out.cpu(), ref.cpu(), rtol=2e-2, atol=2e-2
+                    )
+
+    def test_direct_dot_input_keeps_eager_load_mask(self) -> None:
+        """A masked load consumed directly by a dot (no relayout) is not
+        deferred: it keeps the eager multiplicative load mask."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def direct_dot(
+            y: torch.Tensor, w: torch.Tensor, offsets: torch.Tensor
+        ) -> torch.Tensor:
+            num_segs = offsets.size(0) - 1
+            d = w.size(1)
+            out = torch.zeros([num_segs, d], dtype=y.dtype, device=y.device)
+            for seg in hl.grid(num_segs):
+                start = offsets[seg]
+                end = offsets[seg + 1]
+                acc = hl.zeros([d], dtype=y.dtype)
+                for tile_j in hl.tile(start, end):
+                    # y[tile_j, :] is the lhs of the dot with no relayout.
+                    acc = acc + torch.matmul(y[tile_j, :], w[:, :]).sum(dim=0)
+                out[seg, :] = acc
+            return out
+
+        N, D, P = 128, 96, 48
+        y = torch.randn(N, D, device=DEVICE, dtype=torch.float32)
+        w = torch.randn(D, P, device=DEVICE, dtype=torch.float32)
+        offsets = torch.tensor([0, 50], device=DEVICE, dtype=torch.int32)
+
+        code, result = code_and_output(
+            direct_dot,
+            (y, w, offsets),
+            block_sizes=[32],
+            pallas_loop_type="fori_loop",
+        )
+
+        # Eager mask retained on the direct dot input; nothing to defer past.
+        self.assertRegex(code, r"= y\[[^\n]*\] \* mask_\d+\.astype")
+        self.assertNotRegex(code, r"jnp\.transpose\(")
+
+        s, e = 0, 50
+        ref = (y[s:e] @ w).sum(dim=0).reshape(1, P)
+        torch.testing.assert_close(result, ref, rtol=1e-2, atol=1e-2)
+
+    def test_multi_consumer_load_keeps_eager_mask(self) -> None:
+        """A 3-D masked load whose Q axis is major (so the positional gate would
+        otherwise allow deferral) but which ALSO feeds a non-re-masking consumer
+        (an elementwise add) must keep its eager mask: the traversal finds a use
+        that never reaches a ``_mask_to`` and refuses to defer."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def proj_plus_skip(
+            y: torch.Tensor, w: torch.Tensor, offsets: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.empty_like(y)
+            for seg in hl.grid(offsets.size(0) - 1):
+                wb = w[:, :, :]
+                for tile in hl.tile(offsets[seg], offsets[seg + 1]):
+                    yj = y[tile, :, :]  # [tile, H, D]; tile is the major axis
+                    proj = torch.bmm(yj.transpose(0, 1), wb).transpose(0, 1)
+                    # yj is used transposed (-> bmm) AND directly (elementwise add).
+                    out[tile, :, :] = (proj + yj).to(out.dtype)
+            return out
+
+        H, D = 4, 16
+        offsets = torch.tensor([0, 50], device=DEVICE, dtype=torch.int32)
+        torch.manual_seed(0)
+        y = torch.randn(50, H, D, device=DEVICE, dtype=torch.bfloat16)
+        w = torch.randn(H, D, D, device=DEVICE, dtype=torch.bfloat16)
+
+        code, out = code_and_output(
+            proj_plus_skip,
+            (y, w, offsets),
+            block_sizes=[32],
+            pallas_loop_type="fori_loop",
+        )
+        # Not deferred (the elementwise consumer doesn't re-mask) -> eager mask kept.
+        self.assertRegex(code, r"= y\[[^\n]*\] \* mask_\d+\.astype")
+
+        ref = torch.empty_like(y)
+        s, e = 0, 50
+        ref[s:e] = torch.bmm(y[s:e].transpose(0, 1), w).transpose(0, 1) + y[s:e]
+        torch.testing.assert_close(out.cpu(), ref.cpu(), rtol=2e-2, atol=2e-2)
+
+    def test_opposite_direction_transpose_keeps_eager_mask(self) -> None:
+        """Mirror image of the deferral win.  Here the masked Q axis is already in
+        the last-two (sublane) dims at the load and the transpose moves it to a
+        major dim, so deferring would relocate the mask onto the more expensive
+        axis.  The positional gate must NOT defer -- the eager (sublane) load mask
+        is kept."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def opposite(y: torch.Tensor, offsets: torch.Tensor) -> torch.Tensor:
+            h = y.size(0)
+            out = torch.empty([y.size(1), h, h], dtype=y.dtype, device=y.device)
+            for seg in hl.grid(offsets.size(0) - 1):
+                for tile in hl.tile(offsets[seg], offsets[seg + 1]):
+                    yj = y[:, tile, :]  # [H, tile, D]; tile is a last-two (sublane) dim
+                    a = yj.transpose(0, 1)  # [tile, H, D]; tile -> major
+                    b = yj.permute(1, 2, 0)  # [tile, D, H]; tile -> major
+                    out[tile, :, :] = torch.bmm(a, b).to(out.dtype)
+            return out
+
+        H, D = 4, 16
+        offsets = torch.tensor([0, 10], device=DEVICE, dtype=torch.int32)
+        torch.manual_seed(0)
+        y = torch.randn(H, 10, D, device=DEVICE, dtype=torch.bfloat16)
+
+        code, out = code_and_output(
+            opposite,
+            (y, offsets),
+            block_sizes=[16],
+            pallas_loop_type="fori_loop",
+        )
+        # Masked axis is sublane at the load -> eager mask is cheap; deferring
+        # would move it to the major axis, so the gate keeps the eager load mask.
+        self.assertRegex(code, r"= y\[[^\n]*\] \* mask_\d+\.astype")
+
+        s, e = 0, 10
+        ref = torch.bmm(y[:, s:e, :].transpose(0, 1), y[:, s:e, :].permute(1, 2, 0))
+        torch.testing.assert_close(out.cpu(), ref.cpu(), rtol=2e-2, atol=2e-2)
+
     def test_if_branch_intermediate_outputs(self) -> None:
         """Branch intermediates must survive in _if output list."""
 


### PR DESCRIPTION
A Pallas tiled load masks out-of-bounds lanes multiplicatively in the load's own layout (ref[idx] * mask). When the value is only relayouted by an axis permutation (transpose / .T) before a dot or reduction, that consumer already inserts _mask_to(x, 0), which re-materializes the mask in the consumer layout. 

In general, we see that masking on the sublane axis is much cheaper, while masking on a major axis adds a lot of vector load overhead. This informs our optimization: we defer loads only when the masked axis is a major/outer dim at the load (eager mask is expensive there) and the permutation moves it into the last-two (sublane/lane) dims at the consumer (mask is cheap there). We don't defer for other types of ops (view reshape etc). If the permutation moves the mask from sublane/lane to major axis, deferring can make things slower, so this gate is important.

Before:
```python
  mask_1 = offset < tile_start + tile_extent
  load_4 = q[pl.ds(0, BLOCK), :, :] * mask_1.astype(jnp.bfloat16)[:, None, None]
  qbk    = jnp.transpose(load_4, [1, 0, 2])
  scores = lax.dot_general(qbk, k_t, ...)
```
  
After:
```python
  mask_1  = offset < tile_start + tile_extent
  load_4  = q[pl.ds(0, BLOCK), :, :]
  qbk     = jnp.transpose(load_4, [1, 0, 2])                      
  _mask_to = jnp.where(mask_1.astype(jnp.float32)[None, :, None], qbk, 0)   # mask in consumer layout
  scores  = lax.dot_general(_mask_to, k_t, ...)
```

Performance on jagged gdpa dense kv (bf16). same shapes as in:#2782 

| shape | dist | block | baseline TFLOP/s | with fix TFLOP/s | speedup |
|:---|:---|:---|---:|---:|---:|
| A (B=256) | uniform | q4096 | 200 | **257** | 1.29× |
| A | ramp | q1024 | 142 | **158** | 1.11× |
| A | random | q4096 | 150 | **189** | 1.27× |
| B (B=768) | uniform | q4096 | 213 | **281** | 1.32× |
| B | ramp | q1024 | 156 | **176** | 1.13× |
| B | random | q4096 | 159 | **210** | 1.32× |

New FX graph pass defer_pallas_load_masks (Pallas-only, run just before remove_unnecessary_masking). For each load whose masked tile dim is provably re-masked downstream, it records the deferred block ids and marks the load's masked value unknown so the _mask_to survives; load codegen then skips the eager mask for those dims and the mask is materialized after the transpose.                                                                                                                                                                        
                                                                                                                                                                                        
Correctness rests on a dataflow proof: every use of the load reaches a _mask_to(_, 0) crossing only pure axis-permutation ops (aten.permute.default), with the masked dim surviving as a unique tile dim at each step. Only gated to pallas + major to sublane/lane permutes.