### PR TITLE
Fix pyrefly errors from torch SymInt._sympy_() -> sympy.Basic

### DIFF
--- a/examples/grouped_gemm.py
+++ b/examples/grouped_gemm.py
@@ -179,6 +179,7 @@ def grouped_gemm_jagged_persistent(
                         # Convert linear tile index to 2D (M, N) tile coordinates
                         # pyrefly: ignore[unsupported-operation]
                         m_tile_idx = tile_in_group % num_m_tiles
+                        # pyrefly: ignore[unsupported-operation]
                         n_tile_idx = tile_in_group // num_m_tiles
 
                         # Compute global memory indices for current tile

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -4659,7 +4659,7 @@ class CuteBackend(Backend):
             ) -> bool:
                 if known_equal is not None:
                     return known_equal(lhs, rhs)
-                return lhs == rhs
+                return bool(lhs == rhs)
 
             nd_block_size = [bs.from_config_assert(config) for bs in block_size_infos]
             original_num_threads_config = list(num_threads_config)

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -251,7 +251,7 @@ class CompileEnvironment:
         self.fake_mode = FakeTensorMode(shape_env=self.shape_env)
         self.input_sources: dict[torch.Tensor, Source] = {}
         self.block_sizes: list[BlockSizeInfo] = []
-        self.debug_shape_renames: dict[sympy.Expr, sympy.Expr] = {}
+        self.debug_shape_renames: dict[sympy.Basic, sympy.Basic] = {}
         self.config_spec = ConfigSpec(
             backend=self.backend,
             target_device_capability=target_device_capability(device),
@@ -675,7 +675,9 @@ class CompileEnvironment:
             # TODO(jansel): I was hoping the above would work, seems like some decomps require concrete values
             #               to determine zeroness.  Figure out a better way to do this.
 
-            shape_env_var_hints(self.shape_env)[sym._sympy_()] = sympy.Integer(hint)
+            shape_env_var_hints(self.shape_env)[_symint_sympy_symbol(sym)] = (
+                sympy.Integer(hint)
+            )
         assert isinstance(sym._sympy_(), sympy.Symbol)
         self.debug_shape_renames[sym._sympy_()] = sympy.Symbol(debug_name, integer=True)
         return sym
@@ -800,7 +802,7 @@ class CompileEnvironment:
         specialized_shape: list[int | torch.SymInt] = []
         for dim in output_shape:
             if isinstance(dim, torch.SymInt):
-                expr = self.specialize_expr(dim._sympy_())
+                expr = self.specialize_expr(_symint_sympy_expr(dim))
                 if not expr.free_symbols:
                     with contextlib.suppress(TypeError, ValueError):
                         specialized_shape.append(int(expr))
@@ -829,7 +831,7 @@ class CompileEnvironment:
                 except NotImplementedError:
                     pass
                 else:
-                    self.shape_env.var_to_sources[sym._sympy_()] = [source]
+                    self.shape_env.var_to_sources[_symint_sympy_symbol(sym)] = [source]
                 return sym
             if isinstance(obj, float):
                 with self.shape_env.ignore_fresh_unbacked_symbols():
@@ -908,7 +910,9 @@ class CompileEnvironment:
         outer_se = s.node.shape_env
         if outer_se is self.shape_env:
             return s
+        assert outer_se is not None
         expr = s.node.expr
+        assert isinstance(expr, sympy.Expr)
         cache_key = (id(outer_se), expr)
         cached = self._foreign_symint_cache.get(cache_key)
         if cached is not None:
@@ -916,6 +920,7 @@ class CompileEnvironment:
         if free_unbacked_symbols(expr):
             result = self.create_unbacked_symint()
         else:
+            assert isinstance(expr, sympy.Symbol)
             hint = int(shape_env_var_hints(outer_se)[expr])
             new_expr = self.shape_env.create_symbol(
                 hint, source, dynamic_dim=DimDynamic.DYNAMIC
@@ -923,7 +928,6 @@ class CompileEnvironment:
             result = self.shape_env.create_symintnode(
                 new_expr, hint=hint, source=source
             )
-        # pyrefly: ignore [unsupported-operation]
         self._foreign_symint_cache[cache_key] = result
         return result
 
@@ -1047,7 +1051,7 @@ class CompileEnvironment:
         """Deprecated alias for index_type()."""
         return self.index_type()
 
-    def sympy_debug(self, expr: sympy.Expr) -> str:
+    def sympy_debug(self, expr: sympy.Basic) -> str:
         return str(expr.xreplace(self.debug_shape_renames))
 
     def __enter__(self) -> Self:
@@ -1343,7 +1347,7 @@ class BlockSizeInfo:
         expr = _symint_expr(self.var)
         if isinstance(expr, sympy.Symbol):
             return expr
-        return self.var._sympy_()
+        return _symint_sympy_symbol(self.var)
 
     def from_config(self, config: Config) -> int | torch.SymInt | None:
         value = self.block_size_source.from_config(config, self)
@@ -1439,9 +1443,33 @@ def warning(warning: exc.BaseWarning | type[exc.BaseWarning]) -> None:
         print(f"WARNING[{type(warning).__name__}]: {warning.args[0]}", file=sys.stderr)
 
 
+def _symint_sympy_expr(x: torch.SymInt) -> sympy.Expr:
+    """Narrow ``x._sympy_()`` to ``sympy.Expr``.
+
+    A ``torch.SymInt`` is always backed by a ``sympy.Expr`` at runtime.  Newer
+    torch annotates ``_sympy_()`` as returning the wider ``sympy.Basic``, so this
+    re-establishes the narrower type the rest of the compiler relies on.
+    """
+    expr = x._sympy_()
+    assert isinstance(expr, sympy.Expr)
+    return expr
+
+
+def _symint_sympy_symbol(x: torch.SymInt) -> sympy.Symbol:
+    """Narrow ``x._sympy_()`` to ``sympy.Symbol`` for sites keyed by a bare symbol."""
+    sym = x._sympy_()
+    assert isinstance(sym, sympy.Symbol)
+    return sym
+
+
+def _symint_free_symbols(x: torch.SymInt) -> set[sympy.Symbol]:
+    """Return the free symbols of ``x._sympy_()`` narrowed to ``set[sympy.Symbol]``."""
+    return {s for s in x._sympy_().free_symbols if isinstance(s, sympy.Symbol)}
+
+
 def _to_sympy(x: int | torch.SymInt | sympy.Expr) -> sympy.Expr:
     if isinstance(x, torch.SymInt):
-        return x._sympy_()
+        return _symint_sympy_expr(x)
     if isinstance(x, int):
         return sympy.Integer(x)
     if isinstance(x, sympy.Expr):
@@ -1455,11 +1483,11 @@ def _symint_expr(x: torch.SymInt) -> sympy.Expr | None:
     if isinstance(expr, sympy.Expr):
         return expr
     with contextlib.suppress(Exception):
-        return x._sympy_()
+        return _symint_sympy_expr(x)
     return None
 
 
-def _has_unbacked(expr: sympy.Expr) -> bool:
+def _has_unbacked(expr: sympy.Basic) -> bool:
     # pyrefly: ignore [missing-attribute]
     return any(n.name.startswith("u") for n in expr.free_symbols)
 

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -88,7 +88,6 @@ def find_block_size_symbols(
     non_block_size_symbols = set()
 
     for symbol in expr.free_symbols:
-        # pyrefly: ignore [no-matching-overload, bad-argument-type]
         origin_info = hf.expr_to_origin.get(symbol)
         if origin_info is None or not isinstance(origin_info.origin, BlockSizeOrigin):
             # pyrefly: ignore [bad-argument-type]
@@ -573,6 +572,8 @@ class DeviceFunction:
 
     def literal_expr(self, expr: object) -> str:
         if isinstance(expr, (torch.SymInt, torch.SymFloat, torch.SymBool)):
+            # SymBool's `_sympy_()` is a boolean, not an Expr that sympy_expr wants.
+            # pyrefly: ignore [bad-argument-type]
             return self.sympy_expr(expr._sympy_())
         if isinstance(expr, sympy.Expr):
             return self.sympy_expr(expr)

--- a/helion/_compiler/host_function.py
+++ b/helion/_compiler/host_function.py
@@ -95,7 +95,7 @@ class CompilerState:
     consumed by code generation.
     """
 
-    expr_to_origin: dict[sympy.Expr, SymbolOrigin] = dataclasses.field(
+    expr_to_origin: dict[sympy.Basic, SymbolOrigin] = dataclasses.field(
         default_factory=dict
     )
     tensor_to_origin: dict[torch.Tensor, Origin] = dataclasses.field(
@@ -173,7 +173,7 @@ class HostFunction:
         self._device_ir = value
 
     @property
-    def expr_to_origin(self) -> dict[sympy.Expr, SymbolOrigin]:
+    def expr_to_origin(self) -> dict[sympy.Basic, SymbolOrigin]:
         return self.compiler_state.expr_to_origin
 
     @property
@@ -275,6 +275,8 @@ class HostFunction:
 
     def literal_expr(self, expr: object) -> str:
         if isinstance(expr, (torch.SymInt, torch.SymFloat, torch.SymBool)):
+            # SymBool's `_sympy_()` is a boolean, not an Expr that sympy_expr wants.
+            # pyrefly: ignore [bad-argument-type]
             return self.sympy_expr(expr._sympy_())
         if isinstance(expr, sympy.Expr):
             return self.sympy_expr(expr)

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -52,6 +52,7 @@ from .aten_lowering import aten_lowering_dispatch
 from .compile_environment import CompileEnvironment
 from .compile_environment import FixedBlockSizeSource
 from .compile_environment import _symint_expr
+from .compile_environment import _symint_sympy_expr
 from .device_function import VarInfo
 from .device_function import contains_only_block_size_symbols
 from .node_masking import inductor_masked_value
@@ -137,6 +138,8 @@ def prepare_node_lowering(
     if isinstance(
         val := node.meta["val"], (torch.SymInt, torch.SymFloat, torch.SymBool)
     ):
+        # SymBool's `_sympy_()` is a boolean rather than the Expr the field holds.
+        # pyrefly: ignore [bad-argument-type]
         node.meta["lowering"] = SympyExprLowering(val._sympy_())
         return
 
@@ -368,7 +371,7 @@ def to_symint(x: object) -> torch.SymInt | int:
 
 def _unpack_symint(x: torch.SymInt | int) -> sympy.Expr:
     if isinstance(x, torch.SymInt):
-        return x._sympy_()
+        return _symint_sympy_expr(x)
     if isinstance(x, int):
         # type: ignore [bad-return]
         return sympy.sympify(x)

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -500,6 +500,7 @@ def _maybe_get_tile_begin_with_offset_info(
                 return None
             offset += int(f_value)
         else:
+            # pyrefly: ignore [bad-argument-type]
             offset = torch.SymInt(arg)
             break
 

--- a/helion/_compiler/tile_dispatch.py
+++ b/helion/_compiler/tile_dispatch.py
@@ -7,6 +7,7 @@ import torch
 
 from .._compat import shape_env_size_hint
 from .compile_environment import CompileEnvironment
+from .compile_environment import _symint_sympy_expr
 from .cute.layout import CuTeGridExecutionPlan
 from .device_function import DeviceFunction
 from .device_ir import ForLoopGraphInfo
@@ -180,7 +181,7 @@ class TileStrategyDispatch:
         """Get string representation of a shape"""
         # Extract sympy expression
         if isinstance(shape, torch.SymInt):
-            expr = shape._sympy_()
+            expr = _symint_sympy_expr(shape)
         elif isinstance(shape, sympy.Expr):
             expr = shape
         else:

--- a/helion/_compiler/type_info.py
+++ b/helion/_compiler/type_info.py
@@ -846,6 +846,8 @@ class NumericType(TypeInfo):
         self.value = value
 
     def to_sympy(self) -> sympy.Expr:
+        # value may be a SymBool whose `_sympy_()` is a boolean rather than Expr.
+        # pyrefly: ignore [bad-return]
         return self.value._sympy_()
 
     @property

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -17,6 +17,7 @@ from .._compiler.ast_extension import create
 from .._compiler.ast_extension import expr_from_string
 from .._compiler.ast_extension import statement_from_string
 from .._compiler.compile_environment import CompileEnvironment
+from .._compiler.compile_environment import _symint_sympy_expr
 from .._compiler.dtype_utils import cast_ast
 from .._compiler.host_function import HostFunction
 from .._compiler.variable_origin import BlockSizeOrigin
@@ -47,6 +48,19 @@ def is_for_loop_target(target: object) -> bool:
     return target in (_for_loop, _for_loop_step)
 
 
+def _val_to_sympy(val: torch.SymInt | torch.SymFloat | torch.SymBool) -> sympy.Expr:
+    """Resolve a sym value to its sympy expression, preferring the cached node expr.
+
+    A ``SymBool`` resolves to a sympy boolean rather than an ``Expr``; that case is
+    not expected on the symnode codegen paths below but is accepted by the type.
+    """
+    sym_expr = getattr(getattr(val, "node", None), "_expr", None)
+    if isinstance(sym_expr, sympy.Expr):
+        return sym_expr
+    # pyrefly: ignore [bad-return]
+    return val._sympy_()
+
+
 @_decorators.api()
 def _get_symnode(debug_name: str) -> int:
     """FX requires a torch.SymInt to come from an op. This is a fake op is added lazily to work around this."""
@@ -63,9 +77,7 @@ def _(state: CodegenState) -> ast.AST:
         return expr_from_string(str(val))
 
     assert isinstance(val, (torch.SymInt, torch.SymFloat, torch.SymBool)), val
-    sym_expr = getattr(getattr(val, "node", None), "_expr", None)
-    if not isinstance(sym_expr, sympy.Expr):
-        sym_expr = val._sympy_()
+    sym_expr = _val_to_sympy(val)
     origin_info = HostFunction.current().expr_to_origin.get(sym_expr)
 
     if origin_info is not None and isinstance(origin_info.origin, BlockSizeOrigin):
@@ -91,9 +103,7 @@ def _(state: CodegenState) -> ast.AST:
         return expr_from_string(str(val))
 
     assert isinstance(val, (torch.SymInt, torch.SymFloat, torch.SymBool)), val
-    sym_expr = getattr(getattr(val, "node", None), "_expr", None)
-    if not isinstance(sym_expr, sympy.Expr):
-        sym_expr = val._sympy_()
+    sym_expr = _val_to_sympy(val)
     origin_info = HostFunction.current().expr_to_origin.get(sym_expr)
     if origin_info is not None and isinstance(origin_info.origin, BlockSizeOrigin):
         block_size_var = state.device_function.block_size_var(
@@ -1502,7 +1512,7 @@ def _(state: CodegenState) -> ast.AST:
     tensor_ast = state.ast_arg(0)
     target_size = state.proxy_arg(1)
     if isinstance(target_size, torch.SymInt):
-        target_expr = state.sympy_expr(target_size._sympy_())
+        target_expr = state.sympy_expr(_symint_sympy_expr(target_size))
         block_id = CompileEnvironment.current().get_block_id(target_size)
         bs_var = (
             state.device_function.block_size_var(block_id)

--- a/helion/language/constexpr.py
+++ b/helion/language/constexpr.py
@@ -89,6 +89,7 @@ def specialize(value: _T) -> _T:
 @_decorators.type_propagation(specialize)
 def _(value: TypeInfo, *, origin: Origin) -> TypeInfo:
     from .._compiler.compile_environment import CompileEnvironment
+    from .._compiler.compile_environment import _symint_free_symbols
 
     if origin.is_device():
         raise exc.SpecializeOnDevice
@@ -97,7 +98,7 @@ def _(value: TypeInfo, *, origin: Origin) -> TypeInfo:
     env = CompileEnvironment.current()
 
     def handle_symint(symint: torch.SymInt) -> int:
-        syms = symint._sympy_().free_symbols
+        syms = _symint_free_symbols(symint)
         env.specialized_vars.update(syms)
         # Track stride specializations
         for sym in syms:
@@ -118,11 +119,12 @@ def _(value: TypeInfo, *, origin: Origin) -> TypeInfo:
 @_decorators.register_fake(specialize)
 def _(value: _T) -> _T:
     from .._compiler.compile_environment import CompileEnvironment
+    from .._compiler.compile_environment import _symint_free_symbols
 
     env = CompileEnvironment.current()
 
     def handle_symint(symint: torch.SymInt) -> torch.SymInt:
-        syms = symint._sympy_().free_symbols
+        syms = _symint_free_symbols(symint)
         env.specialized_vars.update(syms)
         for sym in syms:
             for source in env.shape_env.var_to_sources.get(sym, []):

--- a/helion/language/random_ops.py
+++ b/helion/language/random_ops.py
@@ -111,6 +111,7 @@ def _explicit_offset_from_shape(
             view_shape: list[_ShapeDim] = [1] * ndim
             view_shape[dim] = shape[dim]
             index = index.reshape(view_shape)
+        # pyrefly: ignore [unsupported-operation]
         offset = cast("torch.Tensor", offset + index * stride)
     return offset
 

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -44,6 +44,7 @@ from .._compiler.ast_extension import unparse
 from .._compiler.autotuner_heuristics import compiler_seed_configs
 from .._compiler.compile_environment import CompileEnvironment
 from .._compiler.compile_environment import TensorDescriptorLayoutGuard
+from .._compiler.compile_environment import _symint_free_symbols
 from .._compiler.compile_environment import (
     tensor_descriptor_layout_signature_from_strides,
 )
@@ -661,7 +662,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                 for dim in getattr(arg, "_dynamo_static_indices", ()):
                     size = fake_arg.size(dim)
                     if isinstance(size, torch.SymInt):
-                        self.env.specialized_vars.update(size._sympy_().free_symbols)
+                        self.env.specialized_vars.update(_symint_free_symbols(size))
 
     @property
     def env(self) -> CompileEnvironment:


### PR DESCRIPTION
Newer torch annotates SymInt._sympy_() as returning sympy.Basic instead of sympy.Expr, surfacing ~40 pyrefly errors. This PR (1) widens the few internal sinks that genuinely accept Basic (expr_to_origin, debug_shape_renames, _has_unbacked, sympy_debug) and (2) adds assert-based _symint_sympy_expr/ _symint_sympy_symbol/_symint_free_symbols helpers for the true Expr/Symbol sinks (incl. torch-owned Symbol-keyed dicts). Scoped ignores remain only for genuine SymBool->Expr boundaries and unrelated torch-stub gaps.