### PR TITLE
[cute] Clear L2 in the generic autotune benchmark loops, which is used by cute backend

### DIFF
--- a/helion/autotuner/benchmarking.py
+++ b/helion/autotuner/benchmarking.py
@@ -31,6 +31,32 @@ _log = logging.getLogger(__name__)
 _BENCHMARK_CUDAGRAPH_ENV = "HELION_BENCHMARK_CUDAGRAPH"
 
 
+def _make_l2_cache_clearer() -> Callable[[], None]:
+    """Return a callable that flushes the GPU L2 cache, or a no-op.
+
+    The generic (wall-clock) bench used by the CuTe backend otherwise times
+    kernels with the operands resident in L2 (warm), biasing the autotuner
+    toward shallow-prefetch configs that starve the pipeline in the cold-L2 /
+    streamed-once regime that deployment and tritonbench (which clears L2 by
+    default) actually measure. Flushing L2 between timed calls makes the
+    autotune regime match the deployment regime.
+
+    Uses Triton's CUDA-only cache-clear primitive. Returns a no-op when not on
+    CUDA (e.g. TPU/Pallas backends that also use the generic bench).
+    """
+    if not torch.cuda.is_available() or getattr(torch.version, "hip", None) is not None:
+        return lambda: None
+    from triton import runtime
+
+    active = runtime.driver.active  # type: ignore[attr-defined]
+    cache = active.get_empty_cache_for_benchmark()
+
+    def clear() -> None:
+        active.clear_cache(cache)
+
+    return clear
+
+
 def _cudagraph_unavailable_reason() -> str | None:
     if getattr(torch.version, "hip", None) is not None:
         return "CUDA graph benchmarking is only enabled for NVIDIA CUDA"
@@ -200,8 +226,10 @@ def compute_repeat_generic(
     out = fn()
     synchronize_device(out)
 
+    clear_l2 = _make_l2_cache_clearer()
     start = time.perf_counter()
     for _ in range(estimate_runs):
+        clear_l2()
         out = fn()
     synchronize_device(out)
     end = time.perf_counter()
@@ -298,6 +326,7 @@ def interleaved_bench_generic(
         out = fn()
     synchronize_device(out)
 
+    clear_l2 = _make_l2_cache_clearer()
     all_times: list[list[float]] = [[] for _ in range(len(fns))]
 
     iterator = iter_with_progress(
@@ -308,6 +337,7 @@ def interleaved_bench_generic(
     )
     for _i in iterator:
         for j in range(len(fns)):
+            clear_l2()
             synchronize_device(out)
             start = time.perf_counter()
             out = fns[j]()
@@ -607,10 +637,13 @@ def do_bench_generic(
     out = fn()
     synchronize_device(out)
 
+    clear_l2 = _make_l2_cache_clearer()
+
     # Estimate the runtime of the function
     synchronize_device(out)
     start = time.perf_counter()
     for _ in range(5):
+        clear_l2()
         out = fn()
     synchronize_device(out)
     end = time.perf_counter()
@@ -630,6 +663,7 @@ def do_bench_generic(
         if grad_to_none is not None:
             for x in grad_to_none:
                 x.grad = None
+        clear_l2()
         synchronize_device(out)
         t0 = time.perf_counter()
         out = fn()


### PR DESCRIPTION

The CuTe backend overrides the autotuner's benchmark function to the
wall-clock `interleaved_bench_generic` / `do_bench_generic` (CUDA events
mis-time the CuTe launch path). Those generic functions never flushed the
L2 cache between timed calls, so the autotuner scored every candidate with
the operands resident in L2 (warm-L2). The event-based `do_bench` /
`interleaved_bench` used by the Triton backend already cleared L2; only the
CuTe/generic path was warm.

Consequence: the autotuner's selection regime did not match the deployment /
dashboard regime (tritonbench clears L2 by default), so it over-valued
shallow-prefetch configs that are free when data is already in L2 but starve
the TMA->MMA pipeline when it is cold.

Fix: add `_make_l2_cache_clearer()` and call it before each timed iteration
in `compute_repeat_generic`, `interleaved_bench_generic`, and
`do_bench_generic` (the subprocess worker in benchmark_job.py calls the same
functions, so both autotune bench paths are covered). Guards:
- CUDA-only (Triton's `get_empty_cache_for_benchmark` / `clear_cache`); no-op
  on TPU/Pallas, which share these generic functions and lack the primitive,
  and no-op on ROCm/when CUDA is unavailable.

Benchmark (fp8_gemm 512x2048x4096, fp8 e4m3 -> bf16, rowwise scales, B200
sm_100; cold-L2 / CUDA-graph, sustained 1965 MHz). With the fix the autotuner
autonomously switches from `tcgen05_ab_stages=4` + `role_local_with_scheduler`
to `ab_stages=8` (deep prefetch) + `role_local_monolithic` +
`scheduler_warps=0` + `c_input_warps=0`:

  autotuner pick                                 cold-L2    vs torch._scaled_mm
  ------------------------------------------------------------------------------
  before (warm-tuned: ab_stages=4)               13.32 us   0.70x
  after  (cold-tuned: ab_stages=8, monolithic)   10.40 us   0.90x

+28% cold-L2 throughput, gap to torch closed 0.70x -> 0.90x, numerics
unchanged (relerr 6.2e-6).

NCU root-cause (cold-L2, lineinfo): the old config stalled 70% on a block
barrier (`cute.arch.sync_threads()` at the mainloop->epilogue boundary,
366/609 samples) and executed 2.97x more instructions than a hand-written
CUTLASS reference; DRAM traffic was identical (10.5 MB), so the kernel was
synchronization-bound, not memory-bound. Deepening the AB ring is the
dominant lever for this small-tile shape.

Tests: test_benchmarking.py, test_benchmark_worker.py, and the autotuner
bench/cache tests pass.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
