### PR TITLE
[cute] Sample CUDA stream per launch to fix empty-graph capture

### DIFF
--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -3207,6 +3207,20 @@ def _get_cute_launcher_imports() -> tuple[object, ...]:
     return cached
 
 
+def _cute_current_stream() -> object:
+    """Sample the *current* CUDA stream for a cute kernel launch.
+
+    Must be called fresh on every launch and never cached: under CUDA graph
+    capture ``torch.cuda.current_stream()`` is redirected to a dedicated capture
+    stream, so a stream baked into the cached launch args (during eager warmup)
+    would make the kernel launch on the wrong, non-capturing stream — the graph
+    then records no work and replays as a no-op (empty-graph capture). Sampling
+    here keeps the launch on whatever stream is current at call time.
+    """
+    _gmem, _make_ptr, current_stream_obj = _get_cute_launcher_imports()
+    return cast("Any", current_stream_obj)()
+
+
 # Keep the per-kernel launch-argument cache small: production kernels normally
 # relaunch one or two stable tensor signatures, while autotune may probe many.
 _CUTE_LAUNCH_ARG_CACHE_LIMIT = 8
@@ -3291,9 +3305,14 @@ def _build_cute_schema_and_args(
     grid: tuple[int, int, int],
     bake_tensor_shapes: bool = True,
 ) -> tuple[tuple[tuple[object, ...], ...], tuple[object, ...]]:
-    gmem_space, make_ptr_obj, current_stream_obj = _get_cute_launcher_imports()
+    # NOTE: the returned launch args deliberately EXCLUDE the CUDA stream. The
+    # stream is the only launch arg that is not a pure function of
+    # (grid, tensor metadata, scalars), so it must not be baked into the cached
+    # args — the caller appends a freshly sampled ``_cute_current_stream()`` on
+    # every launch (see ``default_cute_launcher``). Caching the stream would
+    # break CUDA graph capture (empty-graph / no-op replay).
+    gmem_space, make_ptr_obj, _current_stream_obj = _get_cute_launcher_imports()
     make_ptr = cast("Any", make_ptr_obj)
-    current_stream = cast("Any", current_stream_obj)
     constexpr_flags = _cute_kernel_param_is_constexpr(cute_kernel)
     # Kernels that emit cute MMA ops (universal matmul fallback or tcgen05
     # TMA wrapper plans) need runtime tensor layouts: the wrapper's
@@ -3366,7 +3385,8 @@ def _build_cute_schema_and_args(
             launch_args.append(scalar_value)
 
     launch_args.extend(grid)
-    launch_args.append(current_stream())
+    # The stream is intentionally NOT appended here; it is sampled fresh per
+    # launch by the caller so CUDA graph capture sees the capture stream.
     return tuple(schema), tuple(launch_args)
 
 
@@ -3456,7 +3476,10 @@ def default_cute_launcher(
         compile_options=cute_compile_options,
         arch_args=args_tuple,
     )
-    return cast("Any", compiled)(*launch_args)
+    # Append the CUDA stream fresh on every launch (never cached): under CUDA
+    # graph capture the current stream is the capture stream, so the kernel must
+    # be issued there and not on a stale stream baked into the cached args.
+    return cast("Any", compiled)(*launch_args, _cute_current_stream())
 
 
 def default_metal_launcher(

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -18,6 +18,7 @@ from helion._testing import onlyBackends
 from helion.exc import BackendUnsupported
 from helion.exc import CuteBackendUnavailable
 import helion.language as hl
+from helion.runtime import _build_cute_schema_and_args
 from helion.runtime import _cute_cluster_shape
 from helion.runtime import _cute_cluster_shape_from_wrapper_plans
 from helion.runtime import _ensure_cute_dsl_arch_env
@@ -2131,6 +2132,7 @@ class TestCuteBackend(TestCase):
 
         with (
             patch("helion.runtime._build_cute_schema_and_args", side_effect=fake_build),
+            patch("helion.runtime._cute_current_stream", return_value="stream"),
             patch(
                 "helion.runtime._get_compiled_cute_launcher",
                 return_value=FakeCompiled(),
@@ -2141,17 +2143,112 @@ class TestCuteBackend(TestCase):
             third = default_cute_launcher(cute_kernel, (2,), 8, block=(32, 1, 1))
 
         self.assertEqual(build_calls, [((7,), (2, 1, 1)), ((8,), (2, 1, 1))])
+        # The stream is appended fresh per launch (never cached), so it trails
+        # the cached launch args on every call.
         self.assertEqual(
             launched_args,
             [
-                ("launch-arg", 7, 2, 1, 1),
-                ("launch-arg", 7, 2, 1, 1),
-                ("launch-arg", 8, 2, 1, 1),
+                ("launch-arg", 7, 2, 1, 1, "stream"),
+                ("launch-arg", 7, 2, 1, 1, "stream"),
+                ("launch-arg", 8, 2, 1, 1, "stream"),
             ],
         )
-        self.assertEqual(first, ("launched", ("launch-arg", 7, 2, 1, 1)))
+        self.assertEqual(first, ("launched", ("launch-arg", 7, 2, 1, 1, "stream")))
         self.assertEqual(second, first)
-        self.assertEqual(third, ("launched", ("launch-arg", 8, 2, 1, 1)))
+        self.assertEqual(third, ("launched", ("launch-arg", 8, 2, 1, 1, "stream")))
+
+    def test_cute_launcher_samples_stream_fresh_per_launch(self) -> None:
+        # The CUDA stream must NOT be cached: on a launch-arg cache HIT the
+        # stream still has to be re-sampled, otherwise a kernel launched during
+        # CUDA graph capture would run on a stale (eager) stream and the graph
+        # would capture no work (empty-graph / no-op replay). Here the build is
+        # cached after the first call (same signature), but the current stream
+        # changes between launches and must be reflected each time.
+        cute_kernel = type("DummyCuteKernel", (), {})()
+        build_calls: list[tuple[object, ...]] = []
+        launched_args: list[tuple[object, ...]] = []
+        streams = iter(["stream-A", "stream-B", "stream-C"])
+
+        class FakeCompiled:
+            def __call__(self, *args: object) -> tuple[str, tuple[object, ...]]:
+                launched_args.append(args)
+                return ("launched", args)
+
+        def fake_build(
+            _cute_kernel: object,
+            args: tuple[object, ...],
+            _grid: tuple[int, int, int],
+        ) -> tuple[tuple[tuple[object, ...], ...], tuple[object, ...]]:
+            build_calls.append(args)
+            # Note: no stream baked into the returned launch args.
+            return (("scalar", "int"),), ("launch-arg",)
+
+        with (
+            patch("helion.runtime._build_cute_schema_and_args", side_effect=fake_build),
+            patch(
+                "helion.runtime._cute_current_stream", side_effect=lambda: next(streams)
+            ),
+            patch(
+                "helion.runtime._get_compiled_cute_launcher",
+                return_value=FakeCompiled(),
+            ),
+        ):
+            first = default_cute_launcher(cute_kernel, (1,), 7, block=(32, 1, 1))
+            second = default_cute_launcher(cute_kernel, (1,), 7, block=(32, 1, 1))
+            third = default_cute_launcher(cute_kernel, (1,), 7, block=(32, 1, 1))
+
+        # Build (and thus the cached args) happens once; the stream is appended
+        # fresh on each of the three launches.
+        self.assertEqual(build_calls, [(7,)])
+        self.assertEqual(
+            launched_args,
+            [
+                ("launch-arg", "stream-A"),
+                ("launch-arg", "stream-B"),
+                ("launch-arg", "stream-C"),
+            ],
+        )
+        self.assertEqual(first, ("launched", ("launch-arg", "stream-A")))
+        self.assertEqual(second, ("launched", ("launch-arg", "stream-B")))
+        self.assertEqual(third, ("launched", ("launch-arg", "stream-C")))
+
+    def test_cute_build_schema_excludes_stream_from_cached_args(self) -> None:
+        # The stream must never be part of the cached launch args produced by
+        # ``_build_cute_schema_and_args`` (it is appended per launch instead).
+        # Patch the cute imports so the builder runs without a real cutlass
+        # install; the sentinel stream must NOT appear in the returned args.
+        sentinel_stream = object()
+
+        def fake_imports() -> tuple[object, ...]:
+            gmem = object()
+
+            def make_ptr(*_a: object, **_k: object) -> str:
+                return "ptr"
+
+            def current_stream() -> object:
+                return sentinel_stream
+
+            return (gmem, make_ptr, current_stream)
+
+        def cute_kernel(alpha: int) -> None:
+            pass
+
+        with (
+            patch(
+                "helion.runtime._get_cute_launcher_imports", side_effect=fake_imports
+            ),
+            patch(
+                "helion.runtime._cute_kernel_param_is_constexpr", return_value=(False,)
+            ),
+        ):
+            schema, launch_args = _build_cute_schema_and_args(
+                cute_kernel, (7,), (2, 1, 1)
+            )
+
+        # Args end with the grid; the stream is not baked in.
+        self.assertEqual(launch_args, (7, 2, 1, 1))
+        self.assertNotIn(sentinel_stream, launch_args)
+        self.assertEqual(schema, (("scalar", "int"),))
 
     def test_cute_launcher_launch_arg_cache_distinguishes_signed_zero(
         self,
@@ -2175,6 +2272,7 @@ class TestCuteBackend(TestCase):
 
         with (
             patch("helion.runtime._build_cute_schema_and_args", side_effect=fake_build),
+            patch("helion.runtime._cute_current_stream", return_value="stream"),
             patch(
                 "helion.runtime._get_compiled_cute_launcher",
                 return_value=FakeCompiled(),
@@ -2184,9 +2282,9 @@ class TestCuteBackend(TestCase):
             negative = default_cute_launcher(cute_kernel, (1,), -0.0)
 
         self.assertEqual(build_calls, [(0.0,), (-0.0,)])
-        self.assertEqual(launched_args, [("float-1",), ("float-2",)])
-        self.assertEqual(positive, ("launched", ("float-1",)))
-        self.assertEqual(negative, ("launched", ("float-2",)))
+        self.assertEqual(launched_args, [("float-1", "stream"), ("float-2", "stream")])
+        self.assertEqual(positive, ("launched", ("float-1", "stream")))
+        self.assertEqual(negative, ("launched", ("float-2", "stream")))
 
     def test_cute_launcher_sets_arch_env_only_before_first_compile(self) -> None:
         cute_kernel = type("DummyCuteKernel", (), {})()
@@ -2200,6 +2298,7 @@ class TestCuteBackend(TestCase):
                 "helion.runtime._build_cute_schema_and_args",
                 return_value=((("scalar", "int"),), ("launch-arg",)),
             ),
+            patch("helion.runtime._cute_current_stream", return_value="stream"),
             patch("helion.runtime._create_cute_wrapper", return_value="jit-wrapper"),
             patch("helion.runtime._ensure_cute_dsl_arch_env") as ensure_arch,
             patch("cutlass.cute.compile", return_value=FakeCompiled()),
@@ -2208,7 +2307,7 @@ class TestCuteBackend(TestCase):
             second = default_cute_launcher(cute_kernel, (1,), 7, block=(32, 1, 1))
 
         self.assertEqual(ensure_arch.call_count, 1)
-        self.assertEqual(first, ("launched", ("launch-arg",)))
+        self.assertEqual(first, ("launched", ("launch-arg", "stream")))
         self.assertEqual(second, first)
 
     def test_cute_launcher_constexpr_float_cache_distinguishes_signed_zero(
@@ -2235,6 +2334,7 @@ class TestCuteBackend(TestCase):
             patch(
                 "helion.runtime._create_cute_wrapper", side_effect=fake_create_wrapper
             ),
+            patch("helion.runtime._cute_current_stream", return_value="stream"),
             patch("helion.runtime._ensure_cute_dsl_arch_env"),
             patch("cutlass.cute.compile", return_value=FakeCompiled()),
         ):
@@ -2245,6 +2345,8 @@ class TestCuteBackend(TestCase):
         self.assertNotEqual(created_schema_keys[0], created_schema_keys[1])
         self.assertEqual(positive[0], "launched")
         self.assertEqual(positive[1][:3], (1, 1, 1))
+        # Stream is appended fresh as the trailing launch arg.
+        self.assertEqual(positive[1][-1], "stream")
         self.assertEqual(negative, positive)
 
     def test_cute_launcher_launch_arg_cache_misses_on_tensor_pointer_change(
@@ -2272,6 +2374,7 @@ class TestCuteBackend(TestCase):
 
         with (
             patch("helion.runtime._build_cute_schema_and_args", side_effect=fake_build),
+            patch("helion.runtime._cute_current_stream", return_value="stream"),
             patch(
                 "helion.runtime._get_compiled_cute_launcher",
                 return_value=FakeCompiled(),
@@ -2282,9 +2385,12 @@ class TestCuteBackend(TestCase):
             third = default_cute_launcher(cute_kernel, (1,), other_tensor)
 
         self.assertEqual(build_calls, [tensor.data_ptr(), other_tensor.data_ptr()])
-        self.assertEqual(launched_args, [("ptr-1",), ("ptr-1",), ("ptr-2",)])
+        self.assertEqual(
+            launched_args,
+            [("ptr-1", "stream"), ("ptr-1", "stream"), ("ptr-2", "stream")],
+        )
         self.assertEqual(first, second)
-        self.assertEqual(third, ("launched", ("ptr-2",)))
+        self.assertEqual(third, ("launched", ("ptr-2", "stream")))
 
     def test_cute_cluster_shape_from_wrapper_plans(self) -> None:
         self.assertIsNone(_cute_cluster_shape_from_wrapper_plans([]))


### PR DESCRIPTION
Stacked PRs:
 * #2788
 * __->__#2817


--- --- ---

### [cute] Sample CUDA stream per launch to fix empty-graph capture


The cute launcher baked the CUDA stream into its cached launch args, which
broke CUDA graph capture: kernels launched during capture ran on a stale
(eager) stream, so the graph recorded no work and replayed as a no-op.

Symptom
-------
Benchmarking a cute kernel under `--cudagraph` (e.g. fp8_gemm at M=512 via the
tcgen05 path) produced nonsensical results: ~0.000008 ms latencies (8 ns for a
512x2048x2048 FP8 GEMM is physically impossible), negative latencies, and
absurd speedups (1850x / -1636x). The PyTorch warning "The CUDA Graph is empty.
This usually means that the graph was attempted to be captured on wrong device
or stream." fired during capture.

Root cause
----------
`_build_cute_schema_and_args` appended `current_stream()` to the launch args,
and `_build_cached_cute_schema_and_args` cached the whole arg tuple keyed on
(grid, per-tensor device/dtype/shape/stride, scalars) — NOT the stream. So:

1. Warmup launches (eager, default stream) populate the cache with launch args
   carrying the default stream.
2. `torch.cuda.graph()` capture redirects `torch.cuda.current_stream()` to a
   dedicated capture stream (verified: capture stream != default stream).
3. On the cache hit during capture, the launcher reuses the cached args with
   the stale default stream, so CUTLASS issues the kernel on the non-capturing
   stream. The graph records nothing -> empty graph -> ~0 ns replay -> bogus
   speedup ratio (baseline / ~0).

The stream is the only launch arg that is not a pure function of
(grid, tensor metadata, scalars), so it should never have been cached.

Fix
---
- Add `_cute_current_stream()` that samples `current_stream()` fresh, with a
  docstring explaining it must never be cached.
- `_build_cute_schema_and_args` no longer appends the stream to the returned
  (cached) launch args.
- `default_cute_launcher` appends `_cute_current_stream()` as the trailing
  positional arg on every launch, after the cached args. The generated wrapper
  signature `(...args, grid_x, grid_y, grid_z, stream)` is unchanged.

Verification
------------
M=512 fp8_gemm repro under cudagraph:
- before: cudagraph latency 0.000777 ms + "CUDA Graph is empty" warning
- after:  cudagraph latency 0.022689 ms, no warning, output correct and fully
          populated (faster than the 0.135 ms eager path, as expected since
          cudagraph removes launch overhead)

Tests (test/test_cute_backend.py)
---------------------------------
- New `test_cute_launcher_samples_stream_fresh_per_launch`: on a launch-arg
  cache HIT (build runs once for a stable signature) the stream is still
  re-sampled per launch (stream-A/B/C), proving it is not cached.
- New `test_cute_build_schema_excludes_stream_from_cached_args`: the builder's
  cached args end at the grid; the sentinel stream is absent.
- Updated 6 existing launcher tests to expect the stream as the trailing
  per-launch arg.

Impact
------
Pure measurement-correctness fix for CUDA-graph capture; real kernel behaviour
(eager path) was already correct. Any cute kernel benchmarked via a
capture-stream cudagraph harness was at risk of mis-timing until now.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
