### PR TITLE
[autotune] Fix pyrefly missing-attribute on L2 cache-clear calls

### DIFF
--- a/helion/autotuner/benchmarking.py
+++ b/helion/autotuner/benchmarking.py
@@ -49,10 +49,10 @@ def _make_l2_cache_clearer() -> Callable[[], None]:
     from triton import runtime
 
     active = runtime.driver.active  # type: ignore[attr-defined]
-    cache = active.get_empty_cache_for_benchmark()
+    cache = active.get_empty_cache_for_benchmark()  # type: ignore[attr-defined]
 
     def clear() -> None:
-        active.clear_cache(cache)
+        active.clear_cache(cache)  # type: ignore[attr-defined]
 
     return clear
 


### PR DESCRIPTION
## Summary

`_make_l2_cache_clearer` (added in #2815) suppressed the `# type: ignore[attr-defined]` only on the `active = runtime.driver.active` assignment, leaving the two follow-up calls unsuppressed:

```python
active = runtime.driver.active  # type: ignore[attr-defined]
cache = active.get_empty_cache_for_benchmark()  # ERROR: DriverBase has no attribute
...
    active.clear_cache(cache)                    # ERROR: DriverBase has no attribute
```

`active` is typed as `DriverBase`, which does not declare these Triton-driver methods, so pyrefly flagged both calls (`missing-attribute`). This surfaced in the lint job of stacked PRs merging into main.

## Fix

Put the suppression on each offending line, matching how every other `runtime.driver.active.*` call in this file is already annotated. No behavior change.

## Test

`pyrefly check helion/autotuner/benchmarking.py` no longer reports the two `DriverBase` `missing-attribute` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)