### PR TITLE
Prefix amd-do- to ROCm ecosystem runner labels

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -106,7 +106,7 @@
       "triton-pin": "8997b14d4d6580c401c842ea4fded92cdf7adaa8"
     },
     {
-      "runner": "linux.rocm.gpu.ecosystem.gfx950.1",
+      "runner": "amd-do-linux.rocm.gpu.ecosystem.gfx950.1",
       "python-version": "3.12",
       "ref-eager": false,
       "image": "rocm/dev-ubuntu-24.04:7.0-complete",

--- a/.github/workflows/benchmark_dispatch.yml
+++ b/.github/workflows/benchmark_dispatch.yml
@@ -161,7 +161,7 @@ jobs:
       id-token: write
       contents: read
     with:
-      runner: linux.rocm.gpu.ecosystem.gfx950.1
+      runner: amd-do-linux.rocm.gpu.ecosystem.gfx950.1
       python-version: "3.12"
       image: rocm/dev-ubuntu-24.04:7.1.1-complete
       runtime-version: rocm7.1


### PR DESCRIPTION
## Summary

Prepends the literal prefix `amd-do-` to every runner label that currently starts with `linux.rocm.gpu.ecosystem`, as part of a runner label migration. The label suffix (e.g. `.gfx950.1`) is preserved, so `linux.rocm.gpu.ecosystem.gfx950.1` becomes `amd-do-linux.rocm.gpu.ecosystem.gfx950.1`.

Changed occurrences:
- `.github/matrix.json` (the MI350x ecosystem matrix entry `runner`)
- `.github/workflows/benchmark_dispatch.yml` (the mi350x dispatch job `runner`)

## Test plan

- [ ] `.github/matrix.json` remains valid JSON (`python -m json.tool .github/matrix.json`).
- [ ] CI scheduling resolves jobs to the renamed `amd-do-linux.rocm.gpu.ecosystem.gfx950.1` runners once the migrated runners are registered with the new label.

Made with Cursor