### PR TITLE
[Pallas] Enable row-slab streaming for compact jagged loads

### DIFF
--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -2142,6 +2142,90 @@ def _check_dma_alignment(vmem_shape: tuple[int, ...]) -> bool:
     return True
 
 
+def _is_supported_contiguous_row_slab_dma(
+    fake: torch.Tensor,
+    sub_meta: list[object],
+    block_ids: list[int],
+    vmem_shape: tuple[int, ...],
+    env: CompileEnvironment,
+    state: CodegenState,
+) -> bool:
+    """Whether an otherwise-unaligned load is a contiguous row-slab DMA.
+
+    ``_check_dma_alignment`` is conservative for shapes like
+    ``[TOKEN_BLOCK, H=4, D=128]`` because the second-to-last logical dim is not a
+    multiple of 8.  TPU7x accepts HBM copies from arbitrary dynamic row offsets
+    for row-slab layouts: rows are page-addressed and the full suffix is
+    contiguous with an aligned lane dimension.
+
+    Keep this exception narrow: load-only caller, one dynamic-begin/end
+    current-loop row tile, only scalar-selected prefix dims, full-slice suffix,
+    no gathers/scatters/stores.
+    """
+    if not fake.is_floating_point():
+        return False
+    if fake.ndim < 2:
+        return False
+    if not fake.is_contiguous():
+        return False
+    if len(vmem_shape) != fake.ndim:
+        return False
+
+    dim_to_bid = _get_dim_block_ids(sub_meta, env)
+    inner_dims = [dim for dim, bid in dim_to_bid.items() if bid in block_ids]
+    if len(inner_dims) != 1:
+        return False
+    row_dim = inner_dims[0]
+    if row_dim == fake.ndim - 1:
+        return False
+    row_bid = dim_to_bid[row_dim]
+    if not _loop_dim_is_dynamic(state, block_ids.index(row_bid)):
+        return False
+
+    from helion._utils import is_scalar_index
+
+    for dim_idx in range(row_dim):
+        idx_meta = sub_meta[dim_idx] if dim_idx < len(sub_meta) else slice(None)
+        if vmem_shape[dim_idx] != 1:
+            return False
+        if dim_idx in dim_to_bid:
+            continue
+        if not is_scalar_index(idx_meta):
+            return False
+
+    for dim_idx in range(row_dim + 1, fake.ndim):
+        idx_meta = sub_meta[dim_idx] if dim_idx < len(sub_meta) else slice(None)
+        if idx_meta != slice(None):
+            return False
+        if dim_idx in dim_to_bid:
+            return False
+        dim_size = fake.shape[dim_idx]
+        if not isinstance(dim_size, int) or vmem_shape[dim_idx] != dim_size:
+            return False
+
+    lane_dim = fake.shape[-1]
+    return isinstance(lane_dim, int) and lane_dim % 128 == 0
+
+
+def _can_stream_inner_tile(
+    fake: torch.Tensor,
+    sub_meta: list[object],
+    direction: str,
+    block_ids: list[int],
+    vmem_shape: tuple[int, ...],
+    env: CompileEnvironment,
+    state: CodegenState,
+) -> bool:
+    """Return whether a loop-local tensor should use the inner streaming path."""
+    if _check_dma_alignment(vmem_shape):
+        return True
+    if direction != "load":
+        return False
+    return _is_supported_contiguous_row_slab_dma(
+        fake, sub_meta, block_ids, vmem_shape, env, state
+    )
+
+
 def _compute_vmem_shapes(
     all_tensor_info: list[tuple[torch.Tensor, list[object], str]],
     block_ids: list[int],
@@ -2200,8 +2284,9 @@ def _classify_pipelined_tensors(
     A tensor is eligible for the inner-DMA path (HBM ref + small VMEM scratch
     in fori_loop, or ``pl.Buffered`` BlockSpec in emit_pipeline) when:
 
-    * Its inner-block ``vmem_shape`` passes ``_check_dma_alignment`` -- a TPU
-      DMA hardware constraint.
+    * Its inner-block ``vmem_shape`` passes the standard TPU DMA alignment check,
+      or it is a load-only contiguous row-slab layout covered by
+      ``_is_supported_contiguous_row_slab_dma``.
     * It is not also accessed at outer scope (i.e. in a root graph,
       between/before/after inner loops).  Pipelining replaces the tensor's
       outer BlockSpec with ``pltpu.HBM`` so the inner loop's BlockSpec can
@@ -2248,10 +2333,12 @@ def _classify_pipelined_tensors(
                 outer_access_tensor_ids.add(id(val))
 
     pipelined_ids: set[int] = set()
-    for (fake, _sub_meta, _direction), vmem_shape in zip(
+    for (fake, sub_meta, direction), vmem_shape in zip(
         all_tensor_info, vmem_shapes, strict=True
     ):
-        if not _check_dma_alignment(vmem_shape):
+        if not _can_stream_inner_tile(
+            fake, sub_meta, direction, block_ids, vmem_shape, env, state
+        ):
             continue
         if id(fake) in outer_access_tensor_ids:
             continue

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -366,6 +366,54 @@ def pallas_add_3d(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_leading_token_sum(x: torch.Tensor) -> torch.Tensor:
+    H = hl.specialize(x.size(1))
+    D = hl.specialize(x.size(2))
+    out = torch.empty([1, H, D], dtype=torch.float32, device=x.device)
+    for owner in hl.grid(1):
+        acc = hl.zeros([H, D], dtype=torch.float32)
+        for tile in hl.tile(x.size(0)):
+            acc = acc + x[tile, :, :].to(torch.float32).sum(dim=0)
+        out[owner, :, :] = acc
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_owner_prefixed_row_slab_sum(
+    x: torch.Tensor, offsets: torch.Tensor
+) -> torch.Tensor:
+    G = offsets.size(0) - 1
+    H = hl.specialize(x.size(2))
+    D = hl.specialize(x.size(3))
+    out = torch.empty([G, H, D], dtype=torch.float32, device=x.device)
+    for g in hl.grid(G):
+        start = offsets[g]
+        end = offsets[g + 1]
+        acc = hl.zeros([H, D], dtype=torch.float32)
+        for tile in hl.tile(start, end):
+            acc = acc + x[g, tile, :, :].to(torch.float32).sum(dim=0)
+        out[g, :, :] = acc
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_literal_prefixed_row_slab_sum(
+    x: torch.Tensor, offsets: torch.Tensor
+) -> torch.Tensor:
+    H = hl.specialize(x.size(2))
+    D = hl.specialize(x.size(3))
+    out = torch.empty([1, H, D], dtype=torch.float32, device=x.device)
+    for owner in hl.grid(1):
+        start = offsets[0]
+        end = offsets[1]
+        acc = hl.zeros([H, D], dtype=torch.float32)
+        for tile in hl.tile(start, end):
+            acc = acc + x[1, tile, :, :].to(torch.float32).sum(dim=0)
+        out[owner, :, :] = acc
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_attention(
     q_in: torch.Tensor, k_in: torch.Tensor, v_in: torch.Tensor
 ) -> torch.Tensor:
@@ -3028,6 +3076,72 @@ class TestPallas(TestCase):
         self.assertNotIn("pltpu.make_async_copy", code)
         self.assertIn("pl.ds(", code)
         torch.testing.assert_close(result, args[0] + args[1])
+
+    def test_fori_loop_static_begin_leading_token_load_stays_resident(self) -> None:
+        """Static-begin packed-token rows keep the existing non-DMA behavior."""
+        x = torch.randn(64, 4, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_leading_token_sum,
+            (x,),
+            block_sizes=[16],
+            pallas_loop_type="fori_loop",
+        )
+        self.assertNotIn("pltpu.make_async_copy", code)
+        self.assertNotIn("_pipeline_arg_indices=", code)
+        torch.testing.assert_close(
+            result, x.sum(dim=0, keepdim=True), rtol=1e-3, atol=1e-3
+        )
+
+    def test_pallas_loop_prefixed_row_slab_streams(self) -> None:
+        x = torch.randn(2, 48, 4, 128, device=DEVICE, dtype=torch.float32)
+        offsets = torch.tensor([0, 11, 37], device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(
+            pallas_owner_prefixed_row_slab_sum,
+            (x, offsets),
+            block_sizes=[8],
+            pallas_loop_type="fori_loop",
+        )
+        self.assertIn("_pipeline_arg_indices=", code)
+        self.assertIn("pltpu.make_async_copy(x.at", code)
+        ref = torch.stack(
+            [x[g, int(offsets[g]) : int(offsets[g + 1])].sum(dim=0) for g in range(2)]
+        )
+        torch.testing.assert_close(result, ref, rtol=1e-3, atol=1e-3)
+
+        code = pallas_owner_prefixed_row_slab_sum.bind((x, offsets)).to_triton_code(
+            helion.Config(block_sizes=[8], pallas_loop_type="emit_pipeline")
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+        self.assertIn("pl.BoundedSlice", code)
+        self.assertIn("pipeline_mode=pl.Buffered", code)
+        self.assertIn("_pipeline_arg_indices=[1]", code)
+        self.assertNotIn("pltpu.make_async_copy", code)
+
+        offsets = torch.tensor([3, 29], device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(
+            pallas_literal_prefixed_row_slab_sum,
+            (x, offsets),
+            block_sizes=[8],
+            pallas_loop_type="fori_loop",
+        )
+        self.assertIn("_pipeline_arg_indices=", code)
+        self.assertIn("pltpu.make_async_copy(x.at", code)
+        torch.testing.assert_close(
+            result,
+            x[1, int(offsets[0]) : int(offsets[1])].sum(dim=0, keepdim=True),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+        code = pallas_literal_prefixed_row_slab_sum.bind((x, offsets)).to_triton_code(
+            helion.Config(block_sizes=[8], pallas_loop_type="emit_pipeline")
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+        self.assertIn("pl.BlockSpec((1, pl.BoundedSlice", code)
+        self.assertIn("lambda _j: (1, pl.ds(start + _j * _BLOCK_SIZE_1", code)
+        self.assertIn("pipeline_mode=pl.Buffered", code)
+        self.assertIn("_pipeline_arg_indices=[1]", code)
+        self.assertNotIn("pltpu.make_async_copy", code)
 
     def test_tile_id_per_block_accumulator(self) -> None:
         """Writing to ``out[tile.id, :]`` stores one row per outer grid iter.

--- a/test/test_pallas_compact_worklist.py
+++ b/test/test_pallas_compact_worklist.py
@@ -358,6 +358,25 @@ def _fully_jagged_kernel(q, k, v, q_offsets, kv_offsets):
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def _kv_owned_jagged_kernel(q, dO, kv_template, q_offsets, kv_offsets):
+    num_sequences = q_offsets.size(0) - 1
+    out = torch.empty_like(kv_template)
+    for seq_idx in hl.grid(num_sequences):
+        q_start = q_offsets[seq_idx]
+        q_end = q_offsets[seq_idx + 1]
+        kv_start = kv_offsets[seq_idx]
+        kv_end = kv_offsets[seq_idx + 1]
+        for tile_kv in hl.tile(kv_start, kv_end):
+            acc = kv_template[tile_kv, :, :].transpose(0, 1).to(torch.float32)
+            for tile_q in hl.tile(q_start, q_end):
+                q_blk = q[tile_q, :, :].transpose(0, 1)
+                do_blk = dO[tile_q, :, :].transpose(0, 1)
+                acc = acc + (q_blk + do_blk).sum(dim=1, keepdim=True)
+            out[tile_kv, :, :] = acc.transpose(0, 1).to(out.dtype)
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def _add_kernel(x, y):
     out = torch.empty_like(x)
     for tile in hl.tile(out.size()):
@@ -827,6 +846,70 @@ class TestNoSilentFallback(unittest.TestCase):
         with self.assertRaises(exc.InvalidConfig):
             bound.ensure_config_exists(args)
             bound.to_triton_code(bound._config)
+
+
+@onlyBackends(["pallas"])
+class TestStreamingClassification(unittest.TestCase):
+    def test_fully_jagged_ordered_kv_streams_without_new_launcher_api(self):
+        qo = _offsets([12, 20, 5, 30])
+        kvo = _offsets([13, 7, 19, 11])
+        lq, lkv = int(qo[-1]), int(kvo[-1])
+        args = (
+            torch.randn(lq, 4, 128),
+            torch.randn(lkv, 4, 128),
+            torch.randn(lkv, 4, 128),
+            qo,
+            kvo,
+        )
+        code = _fully_jagged_kernel.bind(args).to_triton_code(
+            helion.Config(block_sizes=[8, 8], pallas_loop_type="compact_worklist")
+        )
+
+        self.assertIn("_pipeline_arg_indices=", code)
+        self.assertIn("pltpu.make_async_copy(k.at[pl.ds(kv_begin_ref[_wid]", code)
+        self.assertIn("pltpu.make_async_copy(v.at[pl.ds(kv_begin_ref[_wid]", code)
+        self.assertIn("_compact_aligned_arg_indices=", code)
+        self.assertNotIn("pltpu.make_async_copy(q.at", code)
+        self.assertNotIn("pltpu.make_async_copy(out.at", code)
+        self.assertNotIn("pl.multiple_of(kv_begin_ref[_wid]", code)
+
+    def test_dense_kv_owner_indexed_tensors_do_not_stream(self):
+        qo = _offsets([12, 20, 5, 30])
+        lq = int(qo[-1])
+        args = (
+            torch.randn(lq, 4, 128),
+            torch.randn(4, 16, 4, 128),
+            torch.randn(4, 16, 4, 128),
+            qo,
+        )
+        code = _dense_kv_kernel.bind(args).to_triton_code(
+            helion.Config(block_sizes=[8], pallas_loop_type="compact_worklist")
+        )
+
+        self.assertNotIn("_pipeline_arg_indices=", code)
+        self.assertNotIn("pltpu.make_async_copy", code)
+
+    def test_kv_owned_backward_shape_streams_ordered_q_like_loads(self):
+        qo = _offsets([12, 20, 5, 30])
+        kvo = _offsets([13, 7, 19, 11])
+        lq, lkv = int(qo[-1]), int(kvo[-1])
+        args = (
+            torch.randn(lq, 4, 128),
+            torch.randn(lq, 4, 128),
+            torch.randn(lkv, 4, 128),
+            qo,
+            kvo,
+        )
+        code = _kv_owned_jagged_kernel.bind(args).to_triton_code(
+            helion.Config(block_sizes=[8, 8], pallas_loop_type="compact_worklist")
+        )
+
+        self.assertIn("_pipeline_arg_indices=", code)
+        self.assertIn("pltpu.make_async_copy(q.at[pl.ds(q_begin_ref[_wid]", code)
+        self.assertIn("pltpu.make_async_copy(dO.at[pl.ds(q_begin_ref[_wid]", code)
+        self.assertIn("_compact_aligned_arg_indices=", code)
+        self.assertNotIn("pltpu.make_async_copy(out.at", code)
+        self.assertNotIn("pl.multiple_of(q_begin_ref[_wid]", code)
 
 
 def _eager_dense_kv(q, k, v, qo):


### PR DESCRIPTION
Add a narrow fallback that streams dynamic row-slab loads through the existing Pallas pipeline path, which would've been otherwise rejected by `_check_dma_alignment`.

For jagged-attention reduction loops, the K/V (or Q/dO) inner tile is [BLOCK, H, D]. When H % 8 != 0 (e.g. H=4), the check fails and  the tensor falls back to resident. This means the entire packed tensor is placed in VMEM which causes OOM. Smaller block sizes don't help: the tensor is handed in as a full VMEM ref regardless of block size.                                                                                  

This PR enables streaming for a narrow case:
```python
x[prefix_scalar..., row_start : row_start + block, :, ...]
```
All conditions need to be met:
  - row start is dynamic (the jagged/data-dependent inner loop; static-begin loops stay on the existing resident path, unchanged),
  - exactly one inner-loop-tiled row dim, with size-1 (scalar/block) prefix dims,
  - all suffix dims are full contiguous slices,                                              
  - the innermost lane dim is statically % 128.

This actually applies pretty broadly to a lot of jagged kernels including jagged flash attention, jagged gdpa, jagged attention backward kernels, grouped_gemm, etc.

Before:
```python
k_ref = k_ref[pl.ds(kv_begin_ref[_wid] + _j * _BLOCK_SIZE, _BLOCK_SIZE), :, :]
```
After:                                                                                                                                                                                
fori_loop streams eligible ordered jagged loads with existing explicit DMA:                                                                                                           
```python                                                                                                                                                                                        
  _copy = pltpu.make_async_copy(                                                                                                                                                        
      k.at[pl.ds(kv_begin_ref[_wid] + _j * _BLOCK_SIZE, _BLOCK_SIZE), :, :],                                                                                                            
      k_buf,                                                                                                                                                                            
      k_sem,                                                                                                                                                                            
  )                                                                                                                                                                                     
  _copy.start()                                                                                                                                                                         
  _copy.wait()                                                                                                                                                                          
```                                                                                                                                                                       
  emit_pipeline uses the same classification to produce a buffered HBM BlockSpec:                                                                                                       
```python                                                                                                                                                                                   
  pltpu.emit_pipeline(                                                                                                                                                                  
      _pipeline_body,                                                                                                                                                                   
      grid=(...),                                                                                                                                                                       
      in_specs=[                                                                                                                                                                        
          pl.BlockSpec(                                                                                                                                                                 
              (1, pl.BoundedSlice(_BLOCK_SIZE_1), 4, 128),                                                                                                                              
              lambda _j: (                                                                                                                                                              
                  1,                                                                                                                                                                    
                  pl.ds(start + _j * _BLOCK_SIZE_1, _BLOCK_SIZE_1),                                                                                                                     
                  0,                                                                                                                                                                    
                  0,                                                                                                                                                                    
              ),                                                                                                                                                                        
              pipeline_mode=pl.Buffered(buffer_count=2),                                                                                                                                
          )                                                                                                                                                                             
      ],                                                                                                                                                                                
      _explicit_indices=True,                                                                                                                                                           
  )(x)   
```

This now enables Helion for kernels with longer sequence lengths. For below, all of these cases would otherwise OOM. We test for uniform and random seq lengths (to make sure this will work for un-algined case).

seq=4096, H=4, D=128, bf16
| Kernel | Loop type | Best cfg (q/kv) | Uniform TFLOPs | Random TFLOPs|
|:---|:---|:---|---:|---:|
| GDPA fwd, dense-KV (N=4096) | compact_worklist | 1024 / 2048 | 263 | 219 |
| GDPA bwd dK (N=512) | emit_pipeline | 1024 | 135 | 111 |
| GDPA bwd dV (N=512) | emit_pipeline | 1024 | 134 | 112 |
| JFA flash (non-causal) | compact_worklist | 1024 / 2048 | 160 | 105 |
| HSTU (causal) | compact_worklist | 2048 / 512 | 84 | 59 |

- Purely additive: _can_stream_inner_tile returns true if _check_dma_alignment passes or the row-slab fallback matches, so existing kernels are byte-for-byte unchanged. Standard multi-head shapes (H a multiple of 8) already streamed; this extends streaming to the low-head-count regime (H=4, GQA/MQA-style) that otherwise can't fit large K/V in VMEM.
- Load-only; stores are unaffected.