### PR TITLE
[autotuner] reduction seed: budgeted r_block + liveness-aware persistent/looped decision

### DIFF
--- a/helion/_compiler/autotuner_heuristics/triton.py
+++ b/helion/_compiler/autotuner_heuristics/triton.py
@@ -331,18 +331,17 @@ def _grid_rows(env: CompileEnvironment, m_block_ids: tuple[int, ...]) -> int:
 class _TritonReductionSeedBase(AutotunerHeuristic):
     """Shared base for the two Triton inner-reduction seed heuristics. Both share the
     workload facts (``ReductionFact``), the M_BLOCK-aware reduction-block lever
-    (``_reduction_rblock``, from which each track derives ``persistent``), the
-    ``num_warps`` ramp, eviction provenance, and the block-size builders; the subclasses
-    differ only in mapping that decision onto knobs:
+    (``_reduction_rblock``, from which each track derives ``persistent``), the ``num_warps``
+    ramp, eviction provenance, and the block-size builders; the subclasses differ only in
+    mapping that decision onto knobs:
 
-    - **standard** (:class:`TritonStandardReductionHeuristic`): Helion rolls the rdim
-      into a ``reduction_loops`` loop.
-    - **user-tiled** (:class:`TritonUserTiledReductionHeuristic`): the user hand-writes
-      the ``hl.tile`` loop, so the reduction axis is a ``block_sizes`` entry (plain
-      user-tiled softmax, Band-B kl_div/jsd, Band-C welford).
+    - **standard** (:class:`TritonStandardReductionHeuristic`): Helion rolls the rdim into
+      a ``reduction_loops`` loop.
+    - **user-tiled** (:class:`TritonUserTiledReductionHeuristic`): the user hand-writes the
+      ``hl.tile`` loop, so the reduction axis is a ``block_sizes`` entry (plain user-tiled
+      softmax, carried-2-D-tile kl_div/jsd, reduce-then-apply welford).
 
-    Cloned from ``cute.CuteReductionTileHeuristic`` for triton (drops the CuTe-only
-    knobs, adds ``num_warps`` / ``num_stages``). Not registered; only the subclasses are.
+    Not registered; only the subclasses are.
     """
 
     backend = "triton"
@@ -352,10 +351,9 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
     # residency budget. ``_reduction_rblock`` shrinks it when a raised M_BLOCK divides the
     # footprint budget below it; at M_BLOCK==1 it is used as-is.
     LOOPED_CHUNK = 16384
-    # Band-B (user-tiled, carrying [M_BLOCK, R_BLOCK] 2-D accumulators: kl_div, jsd) R_BLOCK
-    # cap, as a per-program footprint R_BLOCK * itemsize * n_carried; in bytes (via itemsize)
-    # for dtype-generality.
-    BANDB_R_BLOCK_BYTES = 16384
+    # Per-program byte budget for LOOP-CARRIED 2-D accumulator tiles ([M_BLOCK, R_BLOCK], e.g.
+    # kl_div/jsd): caps R_BLOCK via num_carried_2d_tiles. Tightest budget -- resident the whole loop.
+    CARRIED_TILE_MAX_BYTES = 16384
     # Per-program persistent byte ceiling. The resident reduction tile is [M_BLOCK, R_BLOCK]
     # in BOTH tracks (the persistent load and the looped accumulator both carry the M_BLOCK
     # dim), so the per-program footprint is ``m_block * r_block * itemsize`` and every cap
@@ -368,6 +366,9 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
     # M_BLOCK-aware; gates only full_width_output rows, steering half-precision full-width
     # standard rows onto the looped path.
     FULL_WIDTH_PERSIST_MAX_ELEMS = 81920
+    # Max resident bytes a PERSISTENT reduction body (body_live_tiles full-width tiles) may hold
+    # before catastrophic register spill. Only REMOVES persistence from a heavy body, never grows it.
+    LIVE_PERSIST_BUDGET = 3 * 245760
     # No welford "structured-combine floor": welford is memory-bound (profiler-confirmed),
     # so a wide combine tile only spills — register-residency via the reduction footprint cap
     # is what matters. The apply/normalize tile gets the SAME M_BLOCK-aware footprint cap as
@@ -387,14 +388,15 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
     NARROW_W1_OCC_BYTE_LIMIT = 262144
 
     @classmethod
-    def _bandb_r_block_cap(cls, fact: ReductionFact) -> int:
-        """Pow2 R_BLOCK ceiling for a Band-B (carried 2-D tile) reduction: the per-program
-        footprint ``BANDB_R_BLOCK_BYTES`` split across the accumulator itemsize and the
-        carried-tile count. ``max(1, ..)`` guards a zero itemsize / tile count.
+    def _carried_tile_r_block_cap(cls, fact: ReductionFact) -> int:
+        """Pow2 R_BLOCK ceiling for a reduction carrying loop-resident 2-D accumulator tiles
+        (kl_div, jsd): the per-program byte budget ``CARRIED_TILE_MAX_BYTES`` split across the
+        accumulator itemsize and the carried-tile count. ``max(1, ..)`` guards a zero itemsize
+        or tile count.
         """
         from ..._utils import next_power_of_2 as _np2
 
-        cap = cls.BANDB_R_BLOCK_BYTES // (
+        cap = cls.CARRIED_TILE_MAX_BYTES // (
             max(1, fact.itemsize) * max(1, fact.num_carried_2d_tiles)
         )
         return _np2(max(1, cap))
@@ -424,7 +426,8 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
         if have_enough_information:
             occ = grid_rows // num_sm
             if (
-                fact.num_carried_2d_tiles == 0  # not Band-B (kl_div/jsd)
+                fact.num_carried_2d_tiles
+                == 0  # not a carried-2-D-tile reduction (kl_div/jsd)
                 and row_bytes <= cls.NARROW_W1_MAX_BYTES
                 and occ * row_bytes <= cls.NARROW_W1_OCC_BYTE_LIMIT
             ):
@@ -448,16 +451,45 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
         return max(1, bs_spec.min_size, bs_spec.autotuner_min)
 
     @classmethod
+    def _m_block_cap(cls, fact: ReductionFact) -> int:
+        """Upper bound on M_BLOCK (rows/program) for a FULL-WIDTH-output reduction, so a huge-M
+        grid-size ``autotuner_min`` raise cannot force an occupancy-starving M_BLOCK on a
+        memory-bound held-row reduction. A seed below ``autotuner_min`` (raised only to cap the
+        grid) is still valid -- it survives ``normalize``.
+
+        The cap keeps the resident ``[M_BLOCK, rdim]`` live set inside the per-program register
+        budget: ``M_BLOCK <= ROW_PERSIST_MAX_BYTES / (rdim * itemsize * body_live_tiles)``.
+        Applied only via ``min`` with ``_block_floor`` (only ever LOWERS an over-raised floor)
+        and only for full-width output -- streamed/scalar reductions ride occupancy on the
+        chunk, not M_BLOCK, so they are uncapped.
+        """
+        from ..._utils import prev_power_of_2
+
+        if not fact.full_width_output:
+            return (
+                1 << 30
+            )  # no cap: scalar/streamed occupancy rides the reduction chunk
+        live = max(1, fact.body_live_tiles)
+        isz = max(1, fact.itemsize)
+        sh = max(1, fact.size_hint)
+        return max(
+            1, prev_power_of_2(max(1, cls.ROW_PERSIST_MAX_BYTES // (sh * isz * live)))
+        )
+
+    @classmethod
     def _m_block_product(cls, spec: ConfigSpec, fact: ReductionFact) -> int:
-        """Product of the seed's floored M-axis (grid) block sizes — the number of rows each
-        program processes (1 unless a huge-M shape raised ``autotuner_min``). Shared by the
-        apply-loop stream cap (``_build_block_sizes``) and the Band-C combine cap so they read
-        the same M_BLOCK.
+        """Product of the seed's floored M-axis (grid) block sizes -- the number of rows each
+        program processes (1 unless a huge-M shape raised ``autotuner_min``, capped by
+        ``_m_block_cap`` for full-width reductions). Shared by the apply-loop stream cap
+        (``_build_block_sizes``) and the Band-C combine cap so they read the same M_BLOCK.
         """
         m_block = 1
+        cap = cls._m_block_cap(fact)
         for mbid in fact.m_block_ids:
             m_idx = spec.block_sizes.block_id_to_index(mbid)
-            m_block *= cls._block_floor(cast("BlockSizeSpec", spec.block_sizes[m_idx]))
+            m_block *= min(
+                cls._block_floor(cast("BlockSizeSpec", spec.block_sizes[m_idx])), cap
+            )
         return m_block
 
     @classmethod
@@ -510,6 +542,10 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
                 out.append(cast("int", red_value))
             elif bs_spec.block_id in non_reduction_loop_ids and loop_block is not None:
                 out.append(loop_block)
+            elif bs_spec.block_id in fact.m_block_ids:
+                # M (grid) axis: floor it, but cap a full-width reduction's M_BLOCK by the
+                # register budget (_m_block_cap) so a huge-M grid raise can't starve occupancy.
+                out.append(min(cls._block_floor(bs_spec), cls._m_block_cap(fact)))
             else:
                 out.append(cls._block_floor(bs_spec))
         return out
@@ -552,19 +588,26 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
         env: CompileEnvironment,
         fact: ReductionFact,
         m_block: int,
-    ) -> int:
-        """The reduction-axis chunk (pow2), shared by both tracks, using the M_BLOCK-aware
-        footprint cap (see ``ROW_PERSIST_MAX_BYTES``).
+        footprint_factor: int = 1,
+    ) -> tuple[int, bool]:
+        """The reduction-axis chunk (pow2) AND the persistent verdict, decided together in one
+        budgeted formula and shared by both tracks. Returns ``(r_block, persistent)``.
 
-        Returns the full pow2 rdim when that footprint fits the residency budget (the caller
-        derives ``persistent := r_block >= next_pow2(size_hint)``), else the byte-preserving
-        looped chunk ``min(LOOPED_CHUNK, budget // m_block)`` — exactly ``LOOPED_CHUNK`` at
-        M_BLOCK==1, shrunk only when a raised M_BLOCK tightens the budget (huge-M).
+        ``footprint_factor`` = how many resident rdim-shaped tiles one program holds live at
+        the peak (1 = a single result tile). It bounds the decision two ways:
+        - PERSISTENT additionally requires (besides ``row_reread`` and no carried 2-D tile) the
+          single resident tile to fit ``ROW_PERSIST_MAX_BYTES`` AND the full
+          ``footprint_factor``-tile resident set to fit ``LIVE_PERSIST_BUDGET`` (the multi-tile
+          spill ceiling). This liveness term only ever REMOVES persistence from a heavy body.
+        - the LOOPED chunk is shrunk by ``footprint_factor`` so a heavy body gets a smaller
+          chunk, keeping the looped resident set inside the register budget.
 
-        No welford "structured-combine floor": keeping the chunk register-resident (the
-        footprint cap) is what matters. welford is memory-bound and a wide combine tile only
-        spills register/SMEM (profiler-confirmed; the count/mean/M2 recurrence is off the
-        critical path).
+        The standard track passes ``footprint_factor=body_live_tiles``; the user-tiled track
+        keeps the default ``1`` (where ``LIVE_PERSIST_BUDGET`` collapses to the base byte cap,
+        a no-op). The carried-2-D-tile cap (kl_div/jsd) is folded into the chunk decision.
+
+        No welford "structured-combine floor": register-residency via the footprint cap is what
+        matters; welford is memory-bound and a wide combine tile only spills.
         """
         from ..._utils import next_power_of_2 as _np2
         from ..._utils import prev_power_of_2
@@ -572,27 +615,44 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
         rdim = _np2(fact.size_hint)
         itemsize = max(1, fact.itemsize)
         m = max(1, m_block)
-        # Persistent iff the full-rdim [M_BLOCK, rdim] tile fits ALL footprint caps: the element
-        # compile limit, the per-program byte ceiling, AND — for a full_width_output row — the
-        # fp32-promoted element ceiling (the input-byte cap undercounts it 2x at half precision).
+        ff = max(1, footprint_factor)
+        # Persistent iff (a) a SINGLE result tile fits the per-program caps (the element compile
+        # limit element_cap AND the ROW_PERSIST_MAX_BYTES single-tile byte cap), AND (b) the full
+        # ff-tile resident set fits LIVE_PERSIST_BUDGET. (b) is the liveness ceiling: it only
+        # removes persistence from a heavy body, never grants it (no-op at ff==1).
         element_cap = env.backend.max_tensor_numel
-        can_persist = (
-            (element_cap is None or fact.size_hint <= element_cap)
+        # Hold the full extent one-shot iff it clears every per-program ceiling (element compile
+        # limit element_cap, ROW_PERSIST_MAX_BYTES byte cap, LIVE_PERSIST_BUDGET live-set cap) AND
+        # there is NO carried 2-D accumulator -- a [M_BLOCK, R_BLOCK] tile carried across the loop
+        # is too heavy to hold, so stream.
+        extent_held = (
+            # Persist captures a re-read prize iff looping would RE-READ the row: a full-width apply
+            # (rms/layer_norm/softmax/welford) or a second reduction needing the first's result
+            # (cross_entropy's logsumexp -- which full_width_output misses). row_reread catches both;
+            # num_carried_2d_tiles == 0 keeps kl_div/jsd off persist (they re-read regardless).
+            fact.row_reread
+            and fact.num_carried_2d_tiles == 0
+            and (element_cap is None or fact.size_hint <= element_cap)
             and (m * fact.size_hint * itemsize <= cls.ROW_PERSIST_MAX_BYTES)
-            and (
-                not fact.full_width_output
-                or m * fact.size_hint <= cls.FULL_WIDTH_PERSIST_MAX_ELEMS
-            )
+            and (ff * m * fact.size_hint * itemsize <= cls.LIVE_PERSIST_BUDGET)
         )
-        if can_persist:
-            rblock = rdim
+        if extent_held:
+            r_block = rdim
         else:
-            # Looped: LOOPED_CHUNK, shrunk to the largest pow2 the M_BLOCK-aware byte budget
-            # allows. At M_BLOCK==1 the budget exceeds LOOPED_CHUNK -> chunk == LOOPED_CHUNK;
-            # a raised M_BLOCK divides the budget below it.
-            budget = cls.ROW_PERSIST_MAX_BYTES // (m * itemsize)
-            rblock = min(cls.LOOPED_CHUNK, prev_power_of_2(budget))
-        return max(1, rblock)
+            # Can't hold the extent -> stream it at the occupancy-optimal LOOPED_CHUNK (M_BLOCK- and
+            # liveness-shrunk); a capacity-sized chunk would re-read AND lower occupancy.
+            budget = cls.ROW_PERSIST_MAX_BYTES // (m * itemsize * ff)
+            r_block = min(cls.LOOPED_CHUNK, prev_power_of_2(budget))
+            # Carried 2-D accumulators (kl_div, jsd) always reach this branch; cap R_BLOCK by its tighter
+            # byte budget to avoid catastrophic register spills. No-op when num_carried_2d_tiles == 0.
+            if fact.num_carried_2d_tiles >= 1:
+                r_block = min(r_block, cls._carried_tile_r_block_cap(fact))
+        # Never size the chunk past the (padded) extent: clamp to rdim so a sub-cap-N carried reduction
+        # matches the old held branch and keeps `persistent` below correct.
+        r_block = max(1, min(r_block, rdim))
+        # `persistent` is READ OFF the final chunk -- held iff the chunk reached the extent
+        # (reduction_loops=[None] standard, or R_BLOCK == rdim user-tiled), never set separately.
+        return r_block, r_block >= rdim
 
 
 class TritonStandardReductionHeuristic(_TritonReductionSeedBase):
@@ -647,18 +707,20 @@ class TritonStandardReductionHeuristic(_TritonReductionSeedBase):
         if not matches_hardware(env, cls.HARDWARE_TARGETS):
             # Off the H100-validated target: keep the upstream conservative seed.
             return cls._narrow_seed(env)
-        from ..._utils import next_power_of_2 as _np2
         from ...runtime import get_num_sm
 
         spec = env.config_spec
         fact = spec.reduction_facts[0]
-        # standard rides persistent-vs-looped on `reduction_loops`. The shared lever sizes the
-        # reduction chunk (M_BLOCK-aware footprint); `persistent` is derived from it. num_sm +
-        # grid_rows feed the occupancy-gated narrow-row w1 branch in _num_warps (grid_rows =
-        # product of static M extents, a pure fn of m_block_ids + env).
+        # standard rides persistent-vs-looped on reduction_loops (sized by the shared _reduction_rblock).
+        # footprint_factor=body_live_tiles routes a heavy body that would overflow the register file
+        # persistent (e.g. fused_linear_jsd) to the looped path instead.
         m_block = cls._m_block_product(spec, fact)
-        r_block = cls._reduction_rblock(env, fact, m_block)
-        persistent = r_block >= _np2(fact.size_hint)
+        r_block, persistent = cls._reduction_rblock(
+            env,
+            fact,
+            m_block,
+            footprint_factor=fact.body_live_tiles,
+        )
         num_warps = cls._num_warps(
             fact, max(1, get_num_sm(env.device)), _grid_rows(env, fact.m_block_ids)
         )
@@ -703,23 +765,21 @@ class TritonStandardReductionHeuristic(_TritonReductionSeedBase):
 
 
 class TritonUserTiledReductionHeuristic(_TritonReductionSeedBase):
-    """user-tiled inner-reduction seed: fires on a user-tiled reduction (the user
-    hand-writes the ``hl.tile`` loop over the reduction axis, so the rdim is an ordinary
-    ``block_sizes`` entry, i.e. a user ``hl.tile(n, block_size=R_BLOCK)``), which the
-    upstream gate rejects entirely.
+    """user-tiled inner-reduction seed: fires when the user hand-writes the ``hl.tile`` loop
+    over the reduction axis (so the rdim is an ordinary ``block_sizes`` entry, e.g.
+    ``hl.tile(n, block_size=R_BLOCK)``), which the upstream gate rejects entirely.
     R_BLOCK starts at the shared ``_reduction_rblock`` (M_BLOCK-aware footprint cap), then
     INDEPENDENT band predicates layer on via ``min`` (a kernel gets every cap it matches;
     today's kernels each match exactly one):
 
-    - **plain user-tiled** (softmax_two_pass): no extra cap — persistent full-pow2 R_BLOCK,
+    - **plain user-tiled** (softmax_two_pass): no extra cap -- persistent full-pow2 R_BLOCK,
       standard-style reread-eviction for wide looped rows.
-    - **Band B** (kl_div, jsd): carries ``[M_BLOCK, R_BLOCK]`` 2-D tiles, so a full-N
-      R_BLOCK spills — cap by ``BANDB_R_BLOCK_BYTES / (itemsize * num_carried_2d_tiles)``.
-    - **Band C** (welford, ``non_reduction_loop_block_ids`` non-empty): reduce-then-apply — no
-      combine floor (welford is memory-bound; a wide combine only spills). Its normalize/apply
-      tile starts at the reduction tile and gets the SAME M_BLOCK-aware footprint cap (NOT a
-      flat per-row cap, which needlessly narrowed the memory-bound apply pass); see
-      ``_build_block_sizes``.
+    - **carried 2-D tiles** (kl_div, jsd): carry ``[M_BLOCK, R_BLOCK]`` accumulator tiles
+      across the loop, so R_BLOCK is capped by ``CARRIED_TILE_MAX_BYTES / (itemsize *
+      num_carried_2d_tiles)`` -- folded into the shared ``_reduction_rblock`` decision.
+    - **reduce-then-apply** (welford, ``non_reduction_loop_block_ids`` non-empty): no combine
+      floor. Its normalize/apply tile starts at the reduction tile and gets the SAME
+      M_BLOCK-aware footprint cap; see ``_build_block_sizes``.
 
     TODO(reductions): as more structured families land, promote each band into its own
     fact-keyed ``AutotunerHeuristic`` subclass rather than growing this method.
@@ -748,17 +808,11 @@ class TritonUserTiledReductionHeuristic(_TritonReductionSeedBase):
         non_reduction_loop_ids = set(fact.non_reduction_loop_block_ids)
         m_block = cls._m_block_product(spec, fact)
 
-        # user-tiled: the rdim IS a block_sizes entry (no reduction_loops knob); persistent ==
-        # R_BLOCK >= next_pow2(N). Other axes stay at floor (keeps Band-B M_BLOCK at 1, required
-        # by the u0*u1 <= 2**20 constraint). The band caps are INDEPENDENT predicates composed
-        # by min: the shared lever applies the M_BLOCK-aware footprint cap; the carried-2D cap
-        # (Band B) layers on top. welford (Band C) needs no extra cap — the footprint cap
-        # already keeps its combine tile register-resident (a wider tile only spills).
-        r_block = cls._reduction_rblock(env, fact, m_block)
-        if fact.num_carried_2d_tiles >= 1:
-            # Band B (kl_div, jsd): a carried [M_BLOCK, R_BLOCK] tile spills a full-N R_BLOCK, so
-            # cap the footprint (R_BLOCK * itemsize * n_carried) via _bandb_r_block_cap.
-            r_block = min(r_block, cls._bandb_r_block_cap(fact))
+        # user-tiled: rdim IS a block_sizes entry (no reduction_loops knob); persistent == R_BLOCK >=
+        # next_pow2(N), other axes floored (u0*u1 <= 2**20). The shared lever sizes R_BLOCK from
+        # residency (single-tile footprint + the folded-in carried-2-D cap for kl_div/jsd) and returns
+        # it directly; _persistent is unused on this track.
+        r_block, _persistent = cls._reduction_rblock(env, fact, m_block)
         num_warps = cls._num_warps(
             fact, max(1, get_num_sm(env.device)), _grid_rows(env, fact.m_block_ids)
         )

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -1062,6 +1062,7 @@ class DeviceIR:
         self,
         memory_op_facts: list[MemoryOpFact],
         accumulator_facts: list[AccumulatorFact],
+        liveness_by_axis: dict[int, int] | None = None,
     ) -> None:
         """Register a ReductionFact for a user-tiled inner reduction.
 
@@ -1137,20 +1138,25 @@ class DeviceIR:
                 all_graph_ids,
                 memory_op_facts,
                 accumulator_facts,
+                liveness_by_axis or {},
             )
         )
 
-    def build_reduction_facts(self, memory_op_facts: list[MemoryOpFact]) -> None:
-        """Phase 3: build the ``ReductionFact``s now that ``_collect_memory_op_facts`` has
-        produced the enriched ``memory_op_facts``.
+    def build_reduction_facts(
+        self,
+        memory_op_facts: list[MemoryOpFact],
+        liveness_by_axis: dict[int, int] | None = None,
+    ) -> None:
+        """Phase 3: build the ``ReductionFact``s now that ``_collect_memory_op_facts``
+        produced the enriched ``memory_op_facts`` (and the per-axis liveness slice).
 
-        Reads the already-built ``spec.accumulator_facts``, then builds each stashed
-        standard fact, then — only when no standard rollable reduction was registered —
-        the user-tiled fact.
+        Reads ``spec.accumulator_facts``, builds each stashed standard fact, then --
+        only when no standard rollable reduction was registered -- the user-tiled fact.
         """
         env = CompileEnvironment.current()
         spec = env.config_spec
         accumulator_facts = spec.accumulator_facts
+        liveness_by_axis = liveness_by_axis or {}
         # standard (rollable): one fact per stashed (rdim, used_graphs). num_load scopes
         # to the rdim's ORIGINAL graphs (used_graphs), so the rolled-subgraph copies of a
         # standard rdim load are not double-counted (device_ir.graphs is a superset of any
@@ -1172,12 +1178,15 @@ class DeviceIR:
                     used_graphs,
                     memory_op_facts,
                     accumulator_facts,
+                    liveness_by_axis,
                 )
             )
         # user-tiled: mutually exclusive with standard — only when no reduction_loops spec
         # was registered.
         if not spec.reduction_loops:
-            self.register_user_tiled_reductions(memory_op_facts, accumulator_facts)
+            self.register_user_tiled_reductions(
+                memory_op_facts, accumulator_facts, liveness_by_axis
+            )
 
     def build_accumulator_facts(self) -> list[AccumulatorFact]:
         """One ``AccumulatorFact`` per loop-carried tensor accumulator in any loop —
@@ -1243,11 +1252,12 @@ class DeviceIR:
         load_graph_ids: set[int],
         memory_op_facts: list[MemoryOpFact],
         accumulator_facts: list[AccumulatorFact],
+        liveness_by_axis: dict[int, int] | None = None,
     ) -> ReductionFact:
         """Build one ``ReductionFact`` for axis ``red_block_id`` from the enriched
-        ``memory_op_facts`` + ``accumulator_facts`` (no bespoke graph walk). Shared by the
-        standard and user-tiled paths; only ``load_graph_ids`` differs (standard: the
-        rdim's original graphs; user-tiled: every graph).
+        ``memory_op_facts`` + ``accumulator_facts`` + per-axis liveness slice. Shared
+        by the standard and user-tiled paths; only ``load_graph_ids`` differs
+        (standard: the rdim's original graphs; user-tiled: every graph).
         """
         # num_load: every load in the reduction's graphs (the stream-eviction == 1 gate).
         # Scoped by graph_id so rolled-subgraph copies of a standard rdim load are excluded.
@@ -1322,6 +1332,10 @@ class DeviceIR:
             ]
             input_load_itemsize = min(row_sizes) if row_sizes else 0
 
+        # body_live_tiles: peak simultaneously-live rdim-shaped tiles in the reduction body, read off
+        # the walker liveness slice for this axis (default 1).
+        body_live_tiles = max(1, (liveness_by_axis or {}).get(red_block_id, 1))
+
         return ReductionFact(
             block_id=red_block_id,
             size_hint=size_hint,
@@ -1335,6 +1349,7 @@ class DeviceIR:
             reread_eviction_index=reread_eviction_index,
             full_width_output=full_width_output,
             input_load_itemsize=input_load_itemsize,
+            body_live_tiles=body_live_tiles,
         )
 
     def _non_reduction_loop_candidates(
@@ -2657,19 +2672,68 @@ def _subscript_block_id(env: CompileEnvironment, sub: object) -> int | None:
     return None
 
 
-def _collect_memory_op_facts(device_ir: DeviceIR) -> list[MemoryOpFact]:
+def _graph_peak_live_by_axis(
+    graph: torch.fx.Graph, env: CompileEnvironment
+) -> dict[int, int]:
+    """Peak count of simultaneously-live tensor values whose shape spans each
+    block-id axis, over ONE graph -- a liveness sweep in FX topo order.
+    Consumer-AGNOSTIC per-axis provenance keyed by block_id; the derived
+    ``ReductionFact`` reads its own axis slice (``body_live_tiles``).
+
+    A value is live from definition through its last use in the graph. At each
+    step the sweep counts live values whose ``meta['val'].shape`` includes an axis
+    and tracks the per-axis peak. A CONSERVATIVE over-count of register pressure
+    (no remat / reuse beyond last-use modeled), so a heavy body is never
+    under-counted into an unsafe persistent spill.
+    """
+    nodes = list(graph.nodes)
+    last_use: dict[torch.fx.Node, int] = {}
+    for i, node in enumerate(nodes):
+        for inp in node.all_input_nodes:
+            last_use[inp] = i
+    axes_of: dict[torch.fx.Node, frozenset[int]] = {}
+    for node in nodes:
+        val = node.meta.get("val")
+        if isinstance(val, torch.Tensor):
+            axes = {
+                bid for s in val.shape if (bid := env.resolve_block_id(s)) is not None
+            }
+            if axes:
+                axes_of[node] = frozenset(axes)
+    peak: dict[int, int] = {}
+    live: set[torch.fx.Node] = set()
+    for i, node in enumerate(nodes):
+        if node in axes_of:
+            live.add(node)
+        per_axis: dict[int, int] = {}
+        for v in live:
+            for a in axes_of[v]:
+                per_axis[a] = per_axis.get(a, 0) + 1
+        for a, c in per_axis.items():
+            if c > peak.get(a, 0):
+                peak[a] = c
+        live = {v for v in live if last_use.get(v, -1) > i}
+    return peak
+
+
+def _collect_memory_op_facts(
+    device_ir: DeviceIR,
+) -> tuple[list[MemoryOpFact], dict[int, int]]:
     """Walk every device graph once and record per-load/store metadata.
 
-    Produces one ``MemoryOpFact`` per load/store in the same order used to size
-    ``Config.indexing``, so ``memory_op_facts[i]`` describes
-    ``config.indexing[i]``. This is the single source of truth for load/store
-    counts, eviction slots, and ``store_indices`` (all derived from the result).
+    Produces one ``MemoryOpFact`` per load/store in the order used to size
+    ``Config.indexing``, so ``memory_op_facts[i]`` describes ``config.indexing[i]``.
+    Single source of truth for load/store counts, eviction slots, and
+    ``store_indices`` (all derived from the result).
 
-    The per-op enrichment fields (``reductions_fed``/``stores_fed``/
+    Per-op enrichment fields (``reductions_fed``/``stores_fed``/
     ``indexed_block_ids``/``inner_extent``/``graph_id``) are computed here so the
-    reduction-fact builders can derive their per-op-dataflow properties without a
-    bespoke graph walk. ``reductions_fed`` runs ``_classify_load_dataflow`` once over ALL
-    reduction axes, grouped by axis.
+    reduction-fact builders need no bespoke walk. ``reductions_fed`` runs
+    ``_classify_load_dataflow`` once over ALL reduction axes, grouped by axis.
+
+    Returns ``(memory_op_facts, liveness_by_axis)`` -- the second is the per-axis
+    peak simultaneously-live rdim-shaped tile count (max over graphs), computed in
+    this SAME pass so ``ReductionFact.body_live_tiles`` reads a slice.
     """
     from ..autotuner.config_spec import MemoryOpFact
     from ..language import memory_ops
@@ -2687,9 +2751,15 @@ def _collect_memory_op_facts(device_ir: DeviceIR) -> list[MemoryOpFact]:
     records: list[tuple[torch.fx.Node, MemoryOpFact]] = []
     memory_op_index = 0
     eviction_index = 0
+    liveness_by_axis: dict[int, int] = {}
 
     for graph_info in device_ir.graphs:
         graph = graph_info.graph
+        # Reduction-body liveness (per-axis peak live tiles), merged max over graphs — part of
+        # this single collect pass, not a second traversal.
+        for axis, peak in _graph_peak_live_by_axis(graph, env).items():
+            if peak > liveness_by_axis.get(axis, 0):
+                liveness_by_axis[axis] = peak
         # Axis (block_index) of every ReductionLowering node in this graph — the cut set
         # for the dataflow classification, so a fed reduction maps to its axis.
         red_axis_by_id: dict[int, int] = {
@@ -2790,7 +2860,8 @@ def _collect_memory_op_facts(device_ir: DeviceIR) -> list[MemoryOpFact]:
             )
             memory_op_index += 1
 
-    return [fact._replace(matmul_operand=operands.get(node)) for node, fact in records]
+    facts = [fact._replace(matmul_operand=operands.get(node)) for node, fact in records]
+    return facts, liveness_by_axis
 
 
 def _indexing_uses_tensor_descriptor(
@@ -3081,9 +3152,9 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
                     )
                 config_spec.allowed_pid_types = non_persistent_pid_types
 
-        # Collect per-load/store metadata once; derive the load/store tunables
-        # from it so heuristics can map each Config.indexing slot to its graph op.
-        memory_op_facts = _collect_memory_op_facts(device_ir)
+        # Collect per-load/store metadata once so heuristics can map each Config.indexing slot to its
+        # graph op; the same pass returns the reduction-body liveness (per-axis peak live tiles).
+        memory_op_facts, liveness_by_axis = _collect_memory_op_facts(device_ir)
         config_spec.memory_op_facts = memory_op_facts
         load_count = sum(f.kind == "load" for f in memory_op_facts)
         _register_load_store_tunables(
@@ -3101,10 +3172,9 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
         # may read them), so build them independently of the reduction facts. Must run
         # after the rolling (it walks the rolled loop subgraphs).
         config_spec.accumulator_facts = device_ir.build_accumulator_facts()
-        # Phase 3: build the ReductionFacts (standard from the stashed rollable rdims, then
-        # user-tiled when no standard fired) now that memory_op_facts + accumulator_facts
-        # exist.
-        device_ir.build_reduction_facts(memory_op_facts)
+        # Phase 3: build the ReductionFacts (standard from the stashed rollable rdims, then user-tiled
+        # if none fired); liveness_by_axis supplies each fact's body_live_tiles slice.
+        device_ir.build_reduction_facts(memory_op_facts, liveness_by_axis)
 
         return device_ir
 

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -138,6 +138,15 @@ class ReductionFact(NamedTuple):
     - ``input_load_itemsize``: element size of the HBM input row load — the dtype-faithful
       per-byte signal, distinct from ``itemsize`` (fp32-promoted = 4 at both dtypes). 0
       when no single reduction-fed row load exists.
+    - ``body_live_tiles``: peak number of simultaneously-live rdim-shaped tensor values in the
+      reduction body — the liveness signal that bounds the persistent resident footprint. A
+      heavy body (e.g. fused_linear_jsd's softmax->log_softmax->KL->grad chain holds ~7 live
+      ``[M_BLOCK, rdim]`` fp32 tiles) spills the register file when held persistent, so the
+      standard track uses it as ``footprint_factor`` to route such reductions to the looped
+      path. Derived (read off the walker liveness slice for this axis); a conservative
+      over-count (all rdim-shaped values live at a point; register rematerialization may reduce
+      true pressure) so it errs toward looping, never toward an unsafe persistent spill.
+      Defaults to 1 (single resident tile) for facts built without the liveness slice.
 
     ``grid_rows`` is NOT stored — a pure function of ``m_block_ids`` + env, computed on
     demand by its one consumer (the narrow-row ``num_warps`` lever).
@@ -155,6 +164,7 @@ class ReductionFact(NamedTuple):
     reread_eviction_index: int | None = None
     full_width_output: bool = True
     input_load_itemsize: int = 0
+    body_live_tiles: int = 1
 
 
 class MemoryOpFact(NamedTuple):

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -761,6 +761,7 @@ class TestTritonStandardReductionHeuristic(TestCase):
         reduction_size_hint: int,
         num_load: int = 1,
         itemsize: int = 4,
+        row_reread: bool = False,
     ) -> ConfigSpec:
         spec = ConfigSpec(backend=TritonBackend())
         spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=1024))
@@ -778,6 +779,7 @@ class TestTritonStandardReductionHeuristic(TestCase):
                 static_rnumel=reduction_size_hint,
                 itemsize=itemsize,
                 num_load=num_load,
+                row_reread=row_reread,
             )
         )
         return spec
@@ -843,9 +845,11 @@ class TestTritonStandardReductionHeuristic(TestCase):
         # a wide reduction (size_hint 32000) a sentinel < size_hint would decode
         # back to the SLOW looped family this heuristic exists to avoid; the
         # config_spec fix encodes None as the fragment's ``high`` (>= size_hint).
+        # row_reread=True makes the wide reduction persist under the read-once persist
+        # gate (read-once reductions deliberately loop), so there is a [None] to round-trip.
         from helion.autotuner.config_generation import ConfigGeneration
 
-        spec = self._reduction_spec(reduction_size_hint=32000)
+        spec = self._reduction_spec(reduction_size_hint=32000, row_reread=True)
         env = self._reduction_env(spec)
         # The mock env has no real GPU device, so patch hardware info / SM count (this
         # heuristic only fires on GPU in production and the SM count is irrelevant here).
@@ -4013,10 +4017,10 @@ class TestTritonReductionHeuristic(TestCase):
         self.assertEqual(len(seeds), 1)
         seed = seeds[0].config
         # Derive the expected R_BLOCK from the heuristic's OWN helper so the test tracks
-        # the real rule (pow2 of BANDB_R_BLOCK_BYTES / (itemsize * num_carried_2d_tiles)),
+        # the real rule (pow2 of CARRIED_TILE_MAX_BYTES / (itemsize * num_carried_2d_tiles)),
         # not a hand-rolled formula that drops `* num_carried_2d_tiles` and the next_pow2
         # rounding (it would mis-predict jsd, which carries 2 tiles).
-        expected_cap = TritonUserTiledReductionHeuristic._bandb_r_block_cap(fact)
+        expected_cap = TritonUserTiledReductionHeuristic._carried_tile_r_block_cap(fact)
         # Concrete anchor: kl_div carries 1 fp32 tile -> 16384 // 4 = 4096 (already pow2).
         self.assertEqual(expected_cap, 4096)
         # block_sizes is [R_BLOCK, M_BLOCK]; the reduction axis is capped well
@@ -4026,7 +4030,7 @@ class TestTritonReductionHeuristic(TestCase):
         # rnumel 131072 > the 16384 warps-32 breakpoint -> 32 warps.
         self.assertEqual(seed["num_warps"], 32)
         self.assertEqual(seed["num_stages"], 1)
-        # Band B must NOT use the standard reduction_loops knob.
+        # The carried-tile path must NOT use the standard reduction_loops knob.
         self.assertNotIn("reduction_loops", seed)
 
     @onlyBackends(["triton"])


### PR DESCRIPTION
Stacked PRs:
 * #2846
 * #2830
 * #2829
 * __->__#2828


--- --- ---

### [autotuner] reduction seed: budgeted r_block + liveness-aware persistent/looped decision


Stage 1 of 3 in the reduction-seed heuristic stack. This is the "tighten what already
works" stage: the merged reduction seed (#2762) already produces good configs for the 9
core reduction kernels and transfers cleanly to unseen kernels, so most of this commit is
cleanliness + robustness hardening, with **one** behavioral change that matters (a liveness
analysis that loops instead of persists when a reduction body would spill).

## What changes

1. Fold the reduction-chunk size AND the persistent/looped verdict into one budgeted
   `_reduction_rblock` -> `(r_block, persistent)`. Behavior-preserving (zero config diff for
   the 9+8 kernels below); just removes a duplicated budget computation.
2. Rename "Band B" -> a descriptive name (the accumulator-residency band); no behavior change.
3. A full-width `M_BLOCK` persist-cap (`_m_block_cap`) so a huge-M grid-size `autotuner_min`
   raise can no longer starve occupancy. This cap only ever **lowers** an over-raised floor
   and fires on very few shapes — it is mainly **defensive** for future kernels/shapes, not a
   tuned win on today's curriculum.
4. The one real behavioral change — a conservative looping bias driven by a new walker
   liveness fact `ReductionFact.body_live_tiles` (peak simultaneously-live rdim-shaped tiles,
   computed once in the collect pass):
   - Err toward **looping** over **persistent** when the two are ~equivalent. Persistent had
     been chosen on near-ties, but staying persistent risks a register spill with a large perf
     cliff, whereas looping is safe — so ties now go to looping.
   - A multi-tile spill ceiling: when a body holds many live full-width tiles, persisting
     spills the register file. The liveness fact routes such bodies to a looped reduction.

   This is chiefly for `fused_linear_jsd`, whose softmax->log_softmax->KL->grad chain holds
   ~7 live full-width fp32 tiles; persisting spilled (n_spills 480 -> 0 after looping).

The 9 core + 8 robustness kernels are byte-identical across this commit, **except**
`fused_linear_jsd` (the liveness change above) — see the tables. This PR does not modify
`examples/` (welford is left at base).

## Robustness / transfer kernels (8)

Beyond the 9 core reduction kernels, the heuristic was stress-tested on 8 kernels it was
**not** tuned on (a genuine transfer test). Two are in this repo's `examples/`; the other six
live in the lab harness on the fork
([transfer_kernels.py](https://github.com/calebmkim/helion/blob/reduction-3stage-stack/_lab/transfer/transfer_kernels.py)):

```
  fused_linear_jsd        examples/fused_linear_jsd.py
  grpo                    examples/grpo_loss.py
  fused_add_rmsnorm       _lab/transfer/transfer_kernels.py   (fork @ reduction-3stage-stack)
  fused_add_layernorm     _lab/transfer/transfer_kernels.py   (same)
  gated_rmsnorm           _lab/transfer/transfer_kernels.py   (same)
  scaled_masked_softmax   _lab/transfer/transfer_kernels.py   (same)
  cross_entropy_ls_zloss  _lab/transfer/transfer_kernels.py   (same)
  dynamic_quant           _lab/transfer/transfer_kernels.py   (same)
```

## Performance

Geomean `G = torch.compile_us / helion_us` across the shape suite (>1 = Helion faster). H100
80GB SXM5, cold-L2 `do_bench` median-of-11, accuracy-gated before timing. `n` = # shapes
benchmarked per kernel (each timed at both bf16 and fp32). **`=` in the "after" column means
the emitted config is byte-identical to *before* (so the kernel and its perf are unchanged)** —
the point of these tables is that almost everything is `=`.

9 core reduction kernels (test split), before (BASE) -> after (stage1):

```
  kernel          n    bf16              fp32
  rms_norm        8    1.036 -> =        1.014 -> =
  layer_norm      8    1.041 -> =        1.017 -> =
  softmax         8    1.352 -> =        1.158 -> =
  sum             7    1.050 -> 1.049    0.995 -> 0.995   (N>=18432 flips persistent->looped, perf ~unchanged)
  long_sum        7    0.925 -> =        0.926 -> =
  cross_entropy   7    1.143 -> =        0.826 -> =
  kl_div          7    1.088 -> =        1.086 -> =
  jsd             7    0.802 -> =        1.037 -> =
```

8 transfer / robustness kernels (all shapes), before (BASE) -> after (stage1):

```
  kernel                   n    bf16              fp32
  fused_add_rmsnorm        12   0.993 -> =        1.012 -> =
  fused_add_layernorm      12   1.085 -> =        0.986 -> =
  gated_rmsnorm            12   1.015 -> =        1.000 -> =
  scaled_masked_softmax    11   1.110 -> =        1.003 -> =
  cross_entropy_ls_zloss   11   1.014 -> =        1.075 -> =
  dynamic_quant            8    1.131 -> =        1.058 -> =
  grpo                     7    1.253 -> =        1.023 -> =
  fused_linear_jsd         7    0.609 -> 0.835    0.857 -> 1.141   <-- the liveness/looping change
```

**Takeaway:** 16 of 17 kernels are byte-identical before/after (perf unchanged, as intended
for a cleanliness stage). The one **perf** win is `fused_linear_jsd` from the liveness analysis
(bf16 +37%, fp32 +33%).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
