### PR TITLE
[autotuner] specialize the M-reduction seeds via per_feature_accumulator (occupancy + byte-cap)

### DIFF
--- a/helion/_compiler/autotuner_heuristics/triton.py
+++ b/helion/_compiler/autotuner_heuristics/triton.py
@@ -370,6 +370,12 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
     # Max resident bytes a PERSISTENT reduction body (body_live_tiles full-width tiles) may hold
     # before catastrophic register spill. Only REMOVES persistence from a heavy body, never grows it.
     LIVE_PERSIST_BUDGET = 3 * 245760
+    # M-COLLAPSE (grad-parameter reduction, e.g. bias_grad): max rows one CTA reduces in a single
+    # in-register inner tile, capped so the reduction tree + [rows, feature] tile don't spill.
+    M_COLLAPSE_MAX_CTA = 256
+    # M-COLLAPSE inner reduction tile byte budget: a grad-parameter collapse is memory-bound, so
+    # the inner [rows, feature] tile wants the SMALLEST footprint (~2-8 rows) for CTA occupancy.
+    M_COLLAPSE_TILE_BYTES = 32768
     # No welford "structured-combine floor": welford is memory-bound (profiler-confirmed),
     # so a wide combine tile only spills — register-residency via the reduction footprint cap
     # is what matters. The apply/normalize tile gets the SAME M_BLOCK-aware footprint cap as
@@ -655,6 +661,41 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
         # (reduction_loops=[None] standard, or R_BLOCK == rdim user-tiled), never set separately.
         return r_block, r_block >= rdim
 
+    @classmethod
+    def _m_collapse_grid_block(
+        cls, env: CompileEnvironment, fact: ReductionFact, cap: int | None = None
+    ) -> int:
+        """Occupancy-sized grid M block for a grad-parameter M-collapse (rms/ln/instance/group
+        backward on the standard track; bias_grad/dyt on the user-tiled track). The
+        grad-parameter (``grad_weight[N]`` / ``grad_bias[N]``) is summed across the grid rows
+        into a per-CTA partial finalized by a cross-CTA ``sum(0)``; with the block floored to 1
+        that is a grid-wide M-way collapse (one partial/row), so size it to ~one SM wave
+        (``next_pow2(grid_rows // num_sm)``) to cut it to ~``num_sm`` partials.
+
+        ``cap`` bounds the block when it ALSO bears the reduction slab (user-tiled pure
+        collapse, capped at ``M_COLLAPSE_MAX_CTA``); the standard track leaves it uncapped
+        because the resident ``[inner, feature]`` set rides a separate inner re-tile, not this
+        block. A dynamic/unbacked grid (``grid_rows == 0``) collapses to 1.
+        """
+        from ..._utils import next_power_of_2 as _np2
+        from ...runtime import get_num_sm
+
+        grid_rows = _grid_rows(env, fact.m_block_ids)
+        num_sm = max(1, get_num_sm(env.device))
+        block = _np2(max(1, grid_rows // num_sm))
+        return max(1, block if cap is None else min(cap, block))
+
+    @classmethod
+    def _m_collapse_inner_byte_cap(cls, feat_bytes: int) -> int:
+        """Largest pow2 inner reduction tile whose resident ``[inner, feature]`` fp32 set fits
+        ``M_COLLAPSE_TILE_BYTES``, given the per-row feature footprint ``feat_bytes``. Both
+        M-collapse tracks pass ``fact.feature_footprint * itemsize`` (the PRODUCT of the
+        materialized feature axes); for a 2-D norm that product is the single feature axis.
+        """
+        from ..._utils import next_power_of_2 as _np2
+
+        return max(1, _np2(max(1, cls.M_COLLAPSE_TILE_BYTES // max(1, feat_bytes))))
+
 
 class TritonStandardReductionHeuristic(_TritonReductionSeedBase):
     """standard (Helion-rolled rdim) inner-reduction seed: Helion rolls the reduction axis
@@ -745,6 +786,40 @@ class TritonStandardReductionHeuristic(_TritonReductionSeedBase):
         block_sizes = cls._build_block_sizes(
             spec, fact, None, None, non_reduction_loop_ids=non_reduction_loop_ids
         )
+        # Dual-axis grad-parameter M-collapse (rms/ln/instance/group bwd): the grid M block is re-tiled
+        # by an inner loop and feeds a per-feature grad accumulator finalized across CTAs.
+        # _build_block_sizes floors it to 1 (leaving a grid-wide finalize); size it for occupancy so the
+        # finalize shrinks to ~num_sm partials. Gated on per_feature_accumulator, which is False for the
+        # 9 standard + 8 transfer kernels, so their seeds stay byte-identical.
+        if fact.per_feature_accumulator:
+            # The lever needs the grow-grid / byte-cap-inner decomposition to exist: a non-grid
+            # inner tile bearing residency. per_feature_accumulator implies a device carry loop
+            # (not the grid or rdim) that appears in inner_tile_ids, so an EMPTY inner_tile_ids
+            # means no inner re-tile -- skip the lever and keep the base materialized seed.
+            grid_ids = {b for bids in device_ir.grid_block_ids for b in bids}
+            inner_tile_ids = [
+                b
+                for b in spec.block_sizes.valid_block_ids()
+                if b not in grid_ids
+                and b != fact.block_id
+                and b not in non_reduction_loop_ids
+            ]
+            if inner_tile_ids:
+                # Occupancy-size the grid M block (the dominant lever), byte-cap the inner
+                # re-tile to the feature footprint, and drop the narrow-w1 warps lever: it keys
+                # on rdim extent alone, but the resident tile here is [inner, feature]-wide, so
+                # the plain extent ramp (>=4 warps) is faithful. Only instance_norm is affected.
+                m_cta = cls._m_collapse_grid_block(env, fact)
+                for mbid in fact.m_block_ids:
+                    block_sizes[spec.block_sizes.block_id_to_index(mbid)] = m_cta
+                inner = cls._m_collapse_inner_byte_cap(
+                    max(1, fact.feature_footprint) * max(1, fact.itemsize)
+                )
+                for bid in inner_tile_ids:
+                    block_sizes[spec.block_sizes.block_id_to_index(bid)] = inner
+                num_warps = cls._num_warps(
+                    fact
+                )  # num_sm/grid_rows default 0 -> no narrow-w1
         seed: dict[str, Any] = {
             "block_sizes": block_sizes,
             "reduction_loops": reduction_loops,
@@ -821,6 +896,34 @@ class TritonUserTiledReductionHeuristic(_TritonReductionSeedBase):
         # residency (single-tile footprint + the folded-in carried-2-D cap for kl_div/jsd) and returns
         # it directly; _persistent is unused on this track.
         r_block, _persistent = cls._reduction_rblock(env, fact, m_block)
+        # M-COLLAPSE (grad-parameter reduction, e.g. bias_grad/dyt): collapse the grid/row axis into a
+        # per-feature accumulator, sizing the grid CTA for occupancy instead of T2's floored grid.
+        m_collapse_block: int | None = None
+        # Faithful signature: per_feature_accumulator -- a loop-carried accumulator over ALL
+        # the materialized feature axis (bias_grad/dyt); per-row / 2-D accumulators are excluded.
+        is_m_collapse = fact.per_feature_accumulator
+        if is_m_collapse:
+            # (a) grid CTA -> OCCUPANCY (_m_collapse_grid_block), capped at M_COLLAPSE_MAX_CTA since the
+            #     grid block also bears the reduction slab (sum(0) finalize over ~num_sm partials). An
+            #     unbacked/AOT grid (grid_rows == 0) falls through to block 1 -- a worse seed, not a bug.
+            m_collapse_block = cls._m_collapse_grid_block(
+                env, fact, cap=cls.M_COLLAPSE_MAX_CTA
+            )
+            # (b) inner reduction tile: depends on whether the collapse has PER-ROW WORK,
+            #     which ``body_live_tiles`` measures (peak simultaneously-live full-width tiles).
+            if fact.body_live_tiles <= 1:
+                # PURE collapse (bias_grad: read + sum, ONE resident tile): a big inner tile is
+                # cheap and cuts loop overhead, so reduce the whole CTA wave in one slab (bounded
+                # by the grid block + 256 cap).
+                r_block = m_collapse_block
+            else:
+                # Collapse WITH per-row work (dyt: full-width grad_x store + tanh intermediates):
+                # a big inner tile spills, so byte-cap the resident [inner, feature] footprint
+                # tight (~2-8 rows) for occupancy.
+                feat_bytes = max(1, fact.feature_footprint) * max(1, fact.itemsize)
+                inner_cap = cls._m_collapse_inner_byte_cap(feat_bytes)
+                r_block = max(1, min(m_collapse_block, inner_cap))
+
         num_warps = cls._num_warps(
             fact, max(1, get_num_sm(env.device)), _grid_rows(env, fact.m_block_ids)
         )
@@ -832,6 +935,12 @@ class TritonUserTiledReductionHeuristic(_TritonReductionSeedBase):
             r_block,
             non_reduction_loop_ids=non_reduction_loop_ids,
         )
+        if m_collapse_block is not None:
+            # Raise the grid CTA tile(s) from the floor to the occupancy block (the reduction
+            # tile was already set to m_collapse_block via r_block above).
+            for mbid in fact.m_block_ids:
+                idx = spec.block_sizes.block_id_to_index(mbid)
+                block_sizes[idx] = m_collapse_block
         seed: dict[str, Any] = {
             "block_sizes": block_sizes,
             "num_warps": num_warps,

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -109,8 +109,8 @@ class MatmulFact(NamedTuple):
 
 
 class ReductionFact(NamedTuple):
-    """Workload facts for one inner reduction dim, recorded at compile time (analogous
-    to ``MatmulFact``) so the seed heuristic branches on workload properties, not kernel
+    """Workload facts for one inner reduction dim, recorded at compile time (like
+    ``MatmulFact``) so the seed heuristic branches on workload properties, not kernel
     identity. Exactly one per seeded kernel; built in device_ir's
     ``register_rollable_reductions`` (standard) or ``register_user_tiled_reductions``
     (user-tiled).
@@ -129,8 +129,7 @@ class ReductionFact(NamedTuple):
     - ``row_reread``: True iff the reduction-input row is live across the loop boundary
       (risks spilling). Gates the persist byte cap + re-read eviction. From ``MemoryOpFact``.
     - ``reread_eviction_index``: ``load_eviction_policies`` slot of the re-read load
-      (``None`` unless ``row_reread``), read from that load's
-      ``MemoryOpFact.eviction_index`` — no re-walk.
+      (``None`` unless ``row_reread``), read from that load's ``MemoryOpFact.eviction_index``.
     - ``full_width_output``: True iff a store writes the result back over the reduction
       axis ([M, N], e.g. layer_norm), False for a per-row scalar ([M], e.g. sum) —
       full-width is store/occupancy-bound, scalar-output reduction-tree-bound (opposite
@@ -138,27 +137,21 @@ class ReductionFact(NamedTuple):
     - ``input_load_itemsize``: element size of the HBM input row load — the dtype-faithful
       per-byte signal, distinct from ``itemsize`` (fp32-promoted = 4 at both dtypes). 0
       when no single reduction-fed row load exists.
-    - ``body_live_tiles``: peak number of simultaneously-live rdim-shaped tensor values in the
-      reduction body — the liveness signal that bounds the persistent resident footprint. A
-      heavy body (e.g. fused_linear_jsd's softmax->log_softmax->KL->grad chain holds ~7 live
-      ``[M_BLOCK, rdim]`` fp32 tiles) spills the register file when held persistent, so the
-      standard track uses it as ``footprint_factor`` to route such reductions to the looped
-      path. Derived (read off the walker liveness slice for this axis); a conservative
-      over-count (all rdim-shaped values live at a point; register rematerialization may reduce
-      true pressure) so it errs toward looping, never toward an unsafe persistent spill.
-      Defaults to 1 (single resident tile) for facts built without the liveness slice.
+    - ``body_live_tiles``: peak count of simultaneously-live rdim-shaped values in the
+      reduction body — the liveness signal bounding the persistent resident footprint. A
+      heavy body spills the register file when held persistent, so the standard track passes
+      it as ``footprint_factor`` to route such reductions to the looped path. A conservative
+      over-count (errs toward looping, never an unsafe spill); defaults to 1.
     - ``per_feature_accumulator``: the faithful M-collapse discriminator — True iff a
       loop-carried accumulator exists whose dims are ALL the materialized feature axis (the
       grad-parameter buffer, e.g. ``grad_bias[N]`` / ``grad_weight[N]``), read from
       accumulator provenance. The user-tiled seed keys ``is_m_collapse`` on it. False for
-      per-row or 2-D accumulators (softmax_two_pass/kl_div/welford/...). Populated here in
-      stage2a (the recognizer); first consumed by the M-collapse specialization in a later
-      commit. Defaults to False.
+      per-row or 2-D accumulators (softmax_two_pass/kl_div/welford/...).
     - ``feature_footprint``: the PRODUCT of the materialized feature-axis extents — the
       resident ``[inner, *features]`` per-row footprint a grad-parameter M-collapse byte-caps
       its inner reduction tile against (``feature_footprint * itemsize``). For a 2-D norm this
-      is ``N``; for a 3-D norm the full ``C*S``. Defaults to 1 when no materialized feature
-      axis exists.
+      is ``N``; for a 3-D norm the full ``C*S`` (a per-axis MAX under-counts and spills). Used
+      by both M-collapse tracks; 1 when no materialized feature axis exists.
 
     ``grid_rows`` is NOT stored — a pure function of ``m_block_ids`` + env, computed on
     demand by its one consumer (the narrow-row ``num_warps`` lever).


### PR DESCRIPTION
Stacked PRs:
 * #2846
 * __->__#2830
 * #2829
 * #2828


--- --- ---

### [autotuner] specialize the M-reduction seeds via per_feature_accumulator (occupancy + byte-cap)


Stage 2, part (b) of 3. Stage2a got all 6 backward kernels **firing**; this commit
**specializes** the block sizes / num_warps for the grad-parameter M-collapse so they recover
good perf.

## What changes

New faithful fact `per_feature_accumulator` (+ `feature_footprint`), populated in `device_ir`
/ `config_spec`: True iff a loop-carried accumulator's dims are **all** the materialized
feature axis (`grad_bias[N]` / `grad_weight[N]`) — the structural definition of a
grad-parameter collapse, read from accumulator provenance (not a symptom proxy). It is False
for all 9 core + 8 transfer kernels, so their seeds stay byte-identical.

Gated on `per_feature_accumulator`, both reduction heuristics add an M-collapse specialization
(the `if per_feature_accumulator:` branch that is the heart of the commit):

- **standard track** (rms/layer_norm/instance/group_norm backward): occupancy-size the grid M
  block (`_m_collapse_grid_block`) + byte-cap the inner re-tile so the M-way `grad_w` finalize
  shrinks to ~`num_sm` partials.
- **user-tiled track** (bias_grad/dyt): occupancy grid CTA (capped `M_COLLAPSE_MAX_CTA`) +
  inner reduction tile = occupancy slab (pure collapse, bias_grad) or a 32KiB byte-cap (dyt).

## Performance

Geomean `G = torch.compile_us / helion_us` (>1 = Helion faster). H100 80GB SXM5, cold-L2
`do_bench`, accuracy-gated. `(2a)` = before this commit; `(2b)` = after.

`n` = # shapes benchmarked per kernel (each timed at both bf16 and fp32).

```
  kernel          n   dtype   (2a) before     (2b) after     note
  bias_grad       7   bf16    0.649           1.580          the specialization is the ENTIRE win
  bias_grad       7   fp32    0.698           1.634          for bias_grad/dyt (0->2a was a no-op)
  dyt             7   bf16    0.522           1.017
  dyt             7   fp32    0.691           1.404
  rms_norm_bwd    8   bf16    1.724           1.901
  rms_norm_bwd    8   fp32    1.305           1.290
  layer_norm_bwd  8   bf16    1.406           1.895
  layer_norm_bwd  8   fp32    1.304           1.901
  group_norm      5   bf16    0.283           0.282          see limitation below
  group_norm      5   fp32    0.338           0.353
  instance_norm   5   bf16    0.189           0.302
  instance_norm   5   fp32    0.167           0.228
```

**Takeaway:** `bias_grad`/`dyt` — whose config was unchanged through stage2a — get their
entire win here (bias_grad ~+2.4x to beat torch; dyt ~+1.4-2x). `rms_norm_bwd`/`layer_norm_bwd`
improve further on top of the stage2a firing (layer_norm_bwd fp32 1.30 -> 1.90).

## Limitation — group_norm / instance_norm

The geomeans for these two stay below torch.compile, but that aggregate is misleading: **it is
dominated by a few really-bad shapes.** The per-shape spread (stage2b, fp32):

```
  group_norm:    worst (24,512,512,32) G=0.061  ...  best (768,128,64,32) G=3.38   (median 0.31)
  instance_norm: worst (24,512,512)    G=0.056  ...  best (768,64,128)    G=1.67   (median 0.21)
```

The bad shapes share one trait: a huge per-row feature footprint `C*S` with a **small grid**
(few rows). On an H100 (132 SMs) the grid alone can't fill the machine — the seed leaves most
SMs idle (measured ~0.02-0.14 TB/s, ~1-4% of HBM peak), so it is an **occupancy cliff, not a
codegen problem**: torch holds ~flat (~140us, ~0.3 TB/s) on the same shapes, and the *same*
Helion kernel beats torch when the grid is full. The small-footprint shapes already beat torch
(up to 3.4x). Closing the big-3D-footprint shapes needs the seed to split the feature/spatial
axis across more CTAs (or a hard byte-cap that forces looping before the resident tile gets
huge — the 524288-feature shapes currently hit a compile cliff); that is follow-up work, not
in this stack.

Invariant held: the 9 core + 8 transfer kernels remain byte-identical
(`per_feature_accumulator` is False for every one of them).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
