### PR TITLE
Fix Docker CuTe install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,15 +54,15 @@ RUN python -m pip install \
     python -m pip install -e /workspace/quack && \
     SETUPTOOLS_SCM_PRETEND_VERSION_FOR_HELION=0.0+docker \
     python -m pip install \
-        -e '.[dev,cute-cu13]' \
+        -e '.[dev]' \
         absl-py \
         cffi \
-        apache-tvm-ffi \
         jax \
         packaging \
         pytest-xdist \
         pyrefly==1.1.1 \
         ruff==0.15.0 && \
+    ./scripts/install_cute.sh && \
     if [ -d .git ]; then \
         pre-commit install-hooks; \
     else \


### PR DESCRIPTION
## Summary

- Install Helion dev deps in Docker with `.[dev]` instead of the removed `cute-cu13` extra.
- Run `./scripts/install_cute.sh` so the image follows the documented CuTe install path and preserves the libs-cu13 reinstall ordering.

## Why

`cute-cu13` used to be a valid extra, but CuTe support was later consolidated under `cute`. pip only warns for unknown extras, so the Docker image can build without installing `nvidia-cutlass-dsl`.

## Testing

- `python3 -c 'import tomllib; ...'` to confirm `cute` exists and `cute-cu13` does not.
- `bash -n scripts/install_cute.sh`
- `rg -n "cute-cu13|cute-cu12" Dockerfile pyproject.toml README.md docs/installation.md scripts .github`
- `git diff --check -- Dockerfile`
- `python3 -m pip install --dry-run --break-system-packages --disable-pip-version-check -e '.[dev]'`

I also tried `docker build --check .`, but the local Docker/OrbStack daemon was not running.
