### PR TITLE
Fix invalid Python in hl.tile matmul docstring example

### DIFF
--- a/helion/language/loops.py
+++ b/helion/language/loops.py
@@ -149,8 +149,7 @@ def tile(
                         acc = torch.addmm(acc, x[tile_m, tile_k], y[tile_k, tile_n])
                     out[tile_m, tile_n] = acc
 
-
-            return out
+                return out
 
         Fixed block size:
 


### PR DESCRIPTION
## Summary

The multi-dimensional matmul example in the `hl.tile` docstring
(`helion/language/loops.py`) has `return out` dedented to module level
(12 spaces, after two blank lines), so the documented example is invalid
Python — copy-pasting it raises `SyntaxError: 'return' outside function`.
The sibling examples in the same docstring place `return` at the
function-body indent.

Reindent `return out` to 16 spaces and drop the stray blank line so the
example is valid and consistent with the others. Docstring text only; no
functional change.
