### PR TITLE
[cute] Reject over-budget K-thread split in scalar-fallback matmul

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -4468,39 +4468,30 @@ class CuteBackend(Backend):
         # from the SIMT thread-axis counts (the latter being how many
         # threads the user-visible per-element loops would expect). The
         # tcgen05 code paths know which lanes are alive on their own.
-        # Also skip when the kernel has any matmul / MMA call (addmm,
-        # baddbmm, mm, bmm, or hl.dot): those paths cooperate within a
-        # warp through CUTLASS MMA intrinsics that don't depend on the
-        # SIMT axis layout, so the strategy can intentionally launch
-        # fewer threads on a reduction axis (e.g. K) than the codegen
-        # "references" through the strategy's per-block thread count.
-        from ..language._decorators import is_api_func
+        # Also skip when the kernel has any matmul / MMA call (checks for
+        # cute.gemm calls): those paths cooperate within a warp through
+        # CUTLASS MMA intrinsics that don't depend on the SIMT axis layout,
+        # so the strategy can intentionally launch fewer threads on a
+        # reduction axis (e.g. K) than the codegen "references" through the
+        # strategy's per-block thread count.
         from .cute.thread_budget import check_thread_limit
 
-        _matmul_targets = {
-            torch.ops.aten.mm.default,
-            torch.ops.aten.addmm.default,
-            torch.ops.aten.bmm.default,
-            torch.ops.aten.baddbmm.default,
-        }
-
-        def _has_matmul_call() -> bool:
-            for graph_info in device_function.codegen.codegen_graphs:
-                graph = getattr(graph_info, "graph", None)
-                if not isinstance(graph, torch.fx.Graph):
-                    continue
-                for node in graph.nodes:
-                    if node.op != "call_function":
-                        continue
-                    if node.target in _matmul_targets:
-                        return True
-                    if is_api_func(node.target) and (
-                        getattr(node.target, "__name__", "") == "dot"
-                    ):
-                        return True
+        def _emits_cute_gemm(stmt: ast.AST) -> bool:
+            for sub in ast.walk(stmt):
+                if (
+                    isinstance(sub, ast.Call)
+                    and isinstance(sub.func, ast.Attribute)
+                    and sub.func.attr == "gemm"
+                    and isinstance(sub.func.value, ast.Name)
+                    and sub.func.value.id == "cute"
+                ):
+                    return True
             return False
 
-        kernel_has_mma = _has_matmul_call()
+        kernel_has_mma = any(
+            _emits_cute_gemm(stmt)
+            for stmt in [*device_function.preamble, *device_function.body]
+        )
         if (
             tcgen05_compact_dims is None
             and not specialized_root_tcgen05

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -2998,6 +2998,31 @@ def _cute_2d_tile_reduction_kernel(x: torch.Tensor) -> torch.Tensor:
     return out
 
 
+@helion.kernel(backend="cute", static_shapes=True)
+def _cute_fp8_gemm_skinny_m(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> torch.Tensor:
+    """Skinny-M fp8 GEMM: full M kept resident, grid over N, reduce over K.
+
+    Used by the thread-budget rejection tests: an explicit ``num_threads``
+    split on the K (contraction) axis whose joint thread count exceeds the
+    1024-thread CTA budget must be rejected rather than silently miscompiled.
+    """
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    for tile_n in hl.tile(n):
+        acc = hl.zeros([m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[:, tile_k], y[tile_k, tile_n], acc=acc)
+        acc = acc * scale_a[:, tile_n] * scale_b[tile_n]
+        out[:, tile_n] = acc.to(torch.bfloat16)
+    return out
+
+
 @onlyBackends(["cute"])
 class TestCuteThreadBudgetRejection(TestCase):
     """The CuTe launcher raises ``BackendUnsupported`` when a config
@@ -3041,6 +3066,60 @@ class TestCuteThreadBudgetRejection(TestCase):
         )
         ref = torch.nn.functional.softmax(x, dim=1)
         torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+    def test_skinny_fp8_gemm_overbudget_k_threads_rejected(self) -> None:
+        """A skinny-M fp8 GEMM whose ``num_threads`` splits the K
+        (contraction) axis so the joint CTA thread count exceeds 1024 MUST
+        raise ``BackendUnsupported`` instead of silently miscompiling.
+
+        Regression for the skinny-M fp8 miscompile: a config like
+        ``block_sizes=[4, 16384], num_threads=[0, 1024]`` (block_n=4,
+        K threaded by 1024) commits the grouped K-reduction to a
+        4 * 1024 = 4096-thread span, but the launcher caps at 1024 and
+        silently drops the K thread axis — the reduction then reads phantom
+        lanes and the output came out ~1e4x too large. The truncation guard
+        (in ``CuteBackend.launcher_keyword_args``) now also fires for matmul
+        kernels that lowered ``hl.dot`` to the scalar grouped-reduce path
+        (no ``cute.gemm`` intrinsic), rejecting such configs cleanly. The same
+        over-budget decomposition is reachable with an in-range block_k too.
+        """
+        torch.manual_seed(0)
+        m, k, n = 16, 4096, 512
+        x = torch.randn(m, k, device=DEVICE).to(torch.float8_e4m3fn)
+        y = torch.randn(k, n, device=DEVICE).to(torch.float8_e4m3fn)
+        scale_a = torch.ones(m, n, device=DEVICE, dtype=torch.float32)
+        scale_b = torch.ones(n, device=DEVICE, dtype=torch.float32)
+        with pytest.raises(BackendUnsupported):
+            code_and_output(
+                _cute_fp8_gemm_skinny_m,
+                (x, y, scale_a, scale_b),
+                block_sizes=[4, 16384],
+                cute_vector_widths=[8, 1],
+                epilogue_subtile=2,
+                num_threads=[0, 1024],
+            )
+
+    def test_skinny_fp8_gemm_in_budget_is_correct(self) -> None:
+        """A valid skinny-M fp8 GEMM config (joint threads within budget)
+        must compile and produce numerically correct output.
+
+        Uses identity scales and range-filling fp8 inputs so the reference
+        ``x.float() @ y.float()`` is O(1) and any miscompile is visible (the
+        original bug was masked by degenerate near-zero benchmark inputs).
+        """
+        torch.manual_seed(0)
+        m, k, n = 16, 4096, 512
+        x = torch.randn(m, k, device=DEVICE).to(torch.float8_e4m3fn)
+        y = torch.randn(k, n, device=DEVICE).to(torch.float8_e4m3fn)
+        scale_a = torch.ones(m, n, device=DEVICE, dtype=torch.float32)
+        scale_b = torch.ones(n, device=DEVICE, dtype=torch.float32)
+        _, out = code_and_output(
+            _cute_fp8_gemm_skinny_m,
+            (x, y, scale_a, scale_b),
+            block_sizes=[256, 64],
+        )
+        ref = x.float() @ y.float()
+        torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
 
 
 @onlyBackends(["cute"])


### PR DESCRIPTION
    [cute] Reject over-budget K-thread split in scalar-fallback matmul
    
    A skinny-M fp8 GEMM (full M resident, grid over N, reduce over K) could
    silently miscompile — output ~1e4x too large — under a `num_threads` config
    that splits the K (contraction) axis so the joint CTA thread count exceeds
    the 1024-thread limit, e.g.
    `block_sizes=[4, N], num_threads=[0, 1024]` (block_n=4 → 4 threads, K → 1024
    threads, joint = 4096).
    
    Root cause: codegen lowers such a `hl.dot` to the scalar grouped-reduce
    path (`_cute_grouped_reduce_shared_two_stage`, no `cute.gemm` intrinsic),
    whose reduction `group_span` is sized from the per-axis thread extents the
    strategy committed to. The launcher then clamps the launch shape down to fit
    1024 threads, dropping the K thread axis. The already-emitted reduction
    still spans the larger (un-launched) thread count, so it reads phantom lanes
    and produces garbage.
    
    `CuteBackend.launcher_keyword_args` already has a silent-truncation guard
    (raises `BackendUnsupported` when the launch under-dimensions
    `referenced_thread_block_dims` past the 1024 budget), but it deliberately
    skipped every kernel containing a matmul/dot graph node so real `cute.gemm`
    MMA kernels (which legitimately launch fewer K threads) aren't rejected. The
    problem is that matmul nodes may not lower to `cute.gemm`: a `hl.dot` can
    fall back to the scalar grouped-reduce path, which is exactly as vulnerable
    to the truncation as a plain reduction kernel.
    
    Fix: gate the skip on whether a real `cute.gemm` was emitted rather than on
    the presence of a matmul graph node, so the scalar-fallback matmul goes
    through the truncation guard and the over-budget config is rejected cleanly.
    The emitted intrinsic is detected by walking the kernel AST for a
    `cute.gemm` call (robust against docstrings/string literals, which a
    substring scan would spuriously match).