### PR TITLE
[cute] Allow block_m > static_m with padded-M tcgen05 for tiny-M fp8/bf16 GEMM

### DIFF
--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -1375,10 +1375,24 @@ class BlockSizeInfo:
         with contextlib.suppress(KeyError):
             spec.block_sizes.block_id_lookup(self.block_id).update_min(value)
 
-    def update_max_block(self, value: int) -> None:
+    def update_max_block(self, value: int, *, allow_raise: bool = False) -> None:
+        """Constrain this block's autotune max size.
+
+        By default ``update_max`` can only *lower* the max (it is clamped to the
+        existing ``next_power_of_2(size_hint)`` ceiling). Pass ``allow_raise=True``
+        to instead allow raising the ceiling ABOVE the size hint -- needed for a
+        matmul M axis whose ``block_m`` may legally exceed the (tiny) static M and
+        run on a larger padded/masked tcgen05 tile. This is scoped to the matmul
+        M axis by its single caller in ``matmul_ops.py``; ordinary tile dims keep
+        the size-hint ceiling so the search space does not explode.
+        """
         spec = CompileEnvironment.current().config_spec
         with contextlib.suppress(KeyError):
-            spec.block_sizes.block_id_lookup(self.block_id).update_max(value)
+            block_spec = spec.block_sizes.block_id_lookup(self.block_id)
+            if allow_raise:
+                block_spec.raise_max(value)
+            else:
+                block_spec.update_max(value)
 
 
 class BlockSizeSource:

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -92,6 +92,7 @@ from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_CLUSTER_M
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_PID_TYPE
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_PROBLEM_SHAPE
+from .tcgen05_constants import TCGEN05_MIN_BLOCK_M
 from .tcgen05_constants import TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
@@ -2030,6 +2031,26 @@ def _emit_mma_pipeline(
     tcgen05_has_k_tail = k_total_size > bk and k_total_size % bk != 0
     tcgen05_k_tail_only = tcgen05_static_output_tiles and tcgen05_has_k_tail
     tcgen05_double_edge_output = m_size % bm != 0 and n_size % bn != 0
+    # Flat (cluster_m=1, non-persistent) M-edge-only case: the M tile exceeds the
+    # real M (e.g. M=16 on a 64/128-row tile) but N and K divide cleanly. This is
+    # the tiny-M GEMM that pads/masks M onto a tcgen05 tile, the way CUTLASS' SM100
+    # fp8 kernel does. TMA's descriptor (built with the real m_size) bounds-clamps
+    # the partial A stripe, so TMA can be kept for the WHOLE mainloop instead of
+    # falling to the per-element scalar AB load on every K iteration (the
+    # ``tcgen05_mixed_tma_scalar_fallback`` path would otherwise serialize the
+    # entire B read -- ~100x slower). The store side is already SIMT-predicated for
+    # the partial M rows, so only the A/B LOAD output-tile predicate is relaxed (M
+    # term becomes ``m_offset < m_size`` instead of ``m_offset + bm <= m_size``).
+    tcgen05_flat_m_edge_tma = (
+        mma_impl == "tcgen05"
+        and tcgen05_use_tma_pipeline
+        and not tcgen05_pid_is_persistent
+        and tcgen05_cluster_m == 1
+        and tcgen05_cluster_n_requested == 1
+        and m_size % bm != 0
+        and n_size % bn == 0
+        and k_total_size % bk == 0
+    )
     tcgen05_double_edge_tma = (
         mma_impl == "tcgen05"
         and tcgen05_use_tma_pipeline
@@ -3903,6 +3924,14 @@ def _emit_mma_pipeline(
                 f"{m_offset_var} + cutlass.Int32({bm}) <= cutlass.Int32({m_size}) "
                 f"and {n_offset_var} < cutlass.Int32({n_size}) "
             )
+        if tcgen05_flat_m_edge_tma:
+            # Flat M-edge (padded-M tcgen05 tile): TMA's m_size-clamped descriptor
+            # loads the partial A stripe, N divides bn, so only the M term relaxes
+            # to ``m_offset < m_size`` -- every in-bounds tile is "full" for TMA.
+            return (
+                f"{m_offset_var} < cutlass.Int32({m_size}) "
+                f"and {n_offset_var} + cutlass.Int32({bn}) <= cutlass.Int32({n_size}) "
+            )
         return (
             f"{m_offset_var} + cutlass.Int32({bm}) <= cutlass.Int32({m_size}) "
             f"and {n_offset_var} + cutlass.Int32({bn}) <= cutlass.Int32({n_size}) "
@@ -4792,12 +4821,25 @@ def _emit_mma_pipeline(
                     if tcgen05_use_role_local_mma_exec:
                         mma_exec_role_stmts.append(exec_loop)
                 else:
+                    # Use the shared output-tile predicate so the flat M-edge
+                    # relaxation (M term ``m_offset < m_size``) reaches the
+                    # steady-state prefetch look-ahead too -- otherwise the
+                    # producer's ``and tma_next_full_tile`` gate would be
+                    # permanently false for a padded-M tile and the mainloop
+                    # would never prefetch past the prologue.
                     cg.add_statement(
                         statement_from_string(
                             f"{tma_next_full_tile} = "
-                            f"{m_offset_var} + cutlass.Int32({bm}) <= cutlass.Int32({m_size}) "
-                            f"and {n_offset_var} + cutlass.Int32({bn}) <= cutlass.Int32({n_size}) "
-                            f"and {k_offset_var} + cutlass.Int32({bk * (tcgen05_ab_stage_count_value + 1)}) <= cutlass.Int32({k_total_size})"
+                            + _tcgen05_tma_tile_predicate(
+                                k_tile_start_expr=(
+                                    f"{k_offset_var} + cutlass.Int32("
+                                    f"{bk * tcgen05_ab_stage_count_value})"
+                                ),
+                                full_tile_end_expr=(
+                                    f"{k_offset_var} + cutlass.Int32("
+                                    f"{bk * (tcgen05_ab_stage_count_value + 1)})"
+                                ),
+                            )
                         )
                     )
                     cg.add_statement(
@@ -5317,17 +5359,20 @@ def _mma_impl_matches_problem_shape(
 ) -> bool:
     if mma_impl == "universal":
         return True
-    # The autotune config-spec only registers the ``tcgen05_*`` config keys for
-    # static (real problem) shapes that pass ``tcgen05_static_shape_eligible``
-    # (see ``matmul_ops.py`` eligibility gate). ``block_m``/``block_n`` can
-    # legally exceed the static M/N for tiny GEMMs (e.g. M=16/32 with
-    # block_m=128), so selecting tcgen05 on block size alone would commit
-    # codegen to a path whose config keys were never registered -> hard
-    # ``KeyError`` in ``_emit_mma_pipeline``. Gate tcgen05 on the same shared
-    # predicate so codegen and config-spec can never diverge; below it, fall
-    # back to warp/universal.
+    # Codegen/config-spec consistency via one shared predicate
+    # (``tcgen05_static_shape_eligible``). The config-spec (matmul_ops.py)
+    # registers the ``tcgen05_*`` config keys exactly when this predicate passes;
+    # codegen must select tcgen05 on the SAME predicate or the two diverge and
+    # the warp-spec lookup in ``_emit_mma_pipeline`` hits a hard ``KeyError``.
+    # The predicate gates M on ``block_m`` (the chosen tile), NOT the static M:
+    # ``block_m`` may legally EXCEED the real problem M for tiny-M GEMMs (e.g.
+    # M=16 on a 64/128-row padded tile, masking the rows beyond the real M,
+    # exactly as CUTLASS' SM100 fp8 kernel does). A sub-tile ``block_m`` (<
+    # ``TCGEN05_MIN_BLOCK_M``) has no tcgen05 atom and falls back to
+    # warp/universal. N/K gate on their static extents. ``static_m`` is retained
+    # in the signature for callers/diagnostics but no longer gates selection.
     if mma_impl == "tcgen05" and not tcgen05_static_shape_eligible(
-        input_dtype, static_m=static_m, static_n=static_n, static_k=static_k
+        input_dtype, block_m=bm, static_n=static_n, static_k=static_k
     ):
         return False
     is_fp8 = input_dtype == torch.float8_e4m3fn

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -444,20 +444,30 @@ TCGEN05_CLUSTER_M2_ONE_CTA_ROLE_LOCAL_CONFIG_KEY = (
 # after projecting onto the CtaGroup.TWO path.
 TCGEN05_ONE_CTA_MAX_BLOCK_M = 128
 
-# Minimum static (real problem) M extent for which the autotune config-spec
-# registers the ``tcgen05_*`` config keys (see ``matmul_ops.py`` eligibility
-# gate). Codegen MMA-impl selection (``cute_mma.py`` ``_choose_mma_impl`` /
-# ``_mma_impl_matches_problem_shape``) MUST gate tcgen05 on the same threshold:
-# otherwise a kernel whose static M is below this floor but whose chosen
-# ``block_m`` is >= 64 commits codegen to the tcgen05 path while the config-spec
-# never registered the ``tcgen05_warp_spec_*`` keys, producing a hard ``KeyError``
-# at codegen time. Selecting on block size alone (which can exceed static M for
-# tiny-M GEMMs) is what let the two diverge.
-TCGEN05_MIN_STATIC_M = 64
+# Smallest legal tcgen05 CtaGroup.ONE M tile. A tcgen05 MMA always processes a
+# full 64- or 128-row M tile (the atom has no sub-64 M mode), so this is also the
+# minimum ``block_m`` the autotune config-spec searches for the matmul M axis and
+# the minimum ``block_m`` codegen will accept on the tcgen05 path.
+#
+# IMPORTANT — codegen/config-spec consistency. ``block_m`` may legally EXCEED the
+# real problem M (e.g. M=16 run on a 64- or 128-row tile, padding/masking the
+# rows beyond the real M, exactly as CUTLASS' SM100 fp8 kernel does). What the
+# config-spec eligibility gate (``matmul_ops.py``) and codegen MMA-impl selection
+# (``cute_mma.py`` ``_choose_mma_impl`` / ``_mma_impl_matches_problem_shape``)
+# MUST agree on is whether the tcgen05 ``tcgen05_*`` config keys were registered.
+# Both key that decision on ``block_m`` being a legal tcgen05 M tile (>=
+# ``TCGEN05_MIN_BLOCK_M``), NOT on the static M, so they can never diverge — the
+# original divergence (config-spec gated on static M >= 64, codegen selected on
+# block size alone) is what produced the hard ``KeyError`` in
+# ``_emit_mma_pipeline``.
+TCGEN05_MIN_BLOCK_M = 64
 
-# Minimum static N for tcgen05 (the MMA N tile is a multiple of 8). Same
-# divergence risk as M: ``block_n`` can exceed the static N, so codegen must
-# gate on the static extent, not the block size.
+# Deprecated alias kept for any external reference. The contract is now expressed
+# as a minimum ``block_m`` (above), since a small static M can be covered by a
+# legal padded/masked M tile.
+TCGEN05_MIN_STATIC_M = TCGEN05_MIN_BLOCK_M
+
+# Minimum static N for tcgen05 (the MMA N tile is a multiple of 8).
 TCGEN05_MIN_STATIC_N = 8
 
 
@@ -469,11 +479,11 @@ def tcgen05_mma_k(input_dtype: torch.dtype) -> int:
 def tcgen05_static_shape_eligible(
     input_dtype: torch.dtype,
     *,
-    static_m: int | None,
+    block_m: int | None,
     static_n: int | None,
     static_k: int | None,
 ) -> bool:
-    """Whether a matmul's *static* (real problem) shape admits the tcgen05 path.
+    """Whether a matmul shape admits the tcgen05 path.
 
     Single source of truth shared by the autotune config-spec (which decides
     whether to register the ``tcgen05_*`` config keys, in ``matmul_ops.py``) and
@@ -482,12 +492,12 @@ def tcgen05_static_shape_eligible(
     keys were never registered and ``_emit_mma_pipeline`` dies with a hard
     ``KeyError``.
 
-    Gates only on the *static* extents (not block sizes): ``block_m``/``block_n``
-    can legally exceed the real M/N for tiny GEMMs, so block-size checks alone
-    let the two callers diverge. A ``None`` extent is a dynamic shape and stays
-    eligible (the config-spec resolves a size hint in that case). Dtype and the
-    per-axis tcgen05 minimums (M>=64, N>=8, K>=mma_k) are checked here; block-
-    size-specific validation (e.g. ``bn % 8``, ``bm`` tile family) stays in
+    The M axis gates on ``block_m`` (the chosen tile), NOT the static M: a tiny
+    real M is covered by a legal padded/masked ``block_m`` >= ``TCGEN05_MIN_BLOCK_M``
+    tile (CUTLASS-style M padding). N and K gate on their static extents (the MMA
+    N tile is a multiple of 8; K must reach one mma-k). A ``None`` extent is a
+    dynamic shape and stays eligible (the config-spec resolves a size hint).
+    Block-size-specific validation (e.g. ``bn % 8``, ``bm`` tile family) stays in
     ``_mma_impl_matches_problem_shape``.
     """
     if input_dtype not in (
@@ -496,7 +506,7 @@ def tcgen05_static_shape_eligible(
         torch.float8_e4m3fn,
     ):
         return False
-    if static_m is not None and static_m < TCGEN05_MIN_STATIC_M:
+    if block_m is not None and block_m < TCGEN05_MIN_BLOCK_M:
         return False
     if static_n is not None and static_n < TCGEN05_MIN_STATIC_N:
         return False

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -2186,6 +2186,17 @@ class BlockSizeSpec(_PowerOfTwoBlockIdItem):
         clamped = max(value, 1)
         self.max_size = assert_integer_power_of_two(min(clamped, self.max_size))
 
+    def raise_max(self, value: int) -> None:
+        """Raise the autotune max ABOVE the size-hint-derived ceiling.
+
+        Unlike ``update_max`` (which can only lower the ceiling), this lets a
+        block search block sizes larger than ``next_power_of_2(size_hint)``. It
+        is used only for a matmul M axis whose ``block_m`` may legally exceed the
+        (small) static M and run on a larger padded/masked tcgen05 tile; ordinary
+        tiles never call it, so the generic search space is unchanged.
+        """
+        self.max_size = assert_integer_power_of_two(max(value, self.max_size))
+
     def update_hint(self, value: int) -> None:
         self.size_hint = value
         self.update_max(next_power_of_2(max(value, 1)))

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -25,6 +25,8 @@ from .._compiler.cute.matmul_utils import cute_resolve_active_matmul_k_block_id
 from .._compiler.cute.matmul_utils import cute_static_k_invariant_extent
 from .._compiler.cute.strategies import is_pure_matmul_role_lifecycle_config
 from .._compiler.cute.tcgen05_constants import TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY
+from .._compiler.cute.tcgen05_constants import TCGEN05_MIN_BLOCK_M
+from .._compiler.cute.tcgen05_constants import TCGEN05_ONE_CTA_MAX_BLOCK_M
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_MIN_DIM
@@ -334,8 +336,19 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
         and static_m is not None
         and static_n is not None
         and static_k is not None
+        # ``block_m`` may legally exceed the real problem M: a tiny-M GEMM
+        # (e.g. M=16) runs on a full 64- or 128-row tcgen05 M tile, padding /
+        # masking the rows beyond the real M (the SIMT edge epilogue and the
+        # bounds-clamped TMA loads already handle this single all-M partial
+        # tile, exactly like CUTLASS' SM100 fp8 kernel). So at config-spec time
+        # the M floor is ``1`` (any positive M can be covered by a 64/128 tile)
+        # -- the shared predicate is called with ``block_m=None`` (the tile is
+        # chosen later) and codegen re-checks the SAME predicate with the
+        # resolved ``block_m``, so the ``tcgen05_*`` keys are registered exactly
+        # when codegen will select tcgen05 (no KeyError).
+        and static_m >= 1
         and tcgen05_static_shape_eligible(
-            lhs.dtype, static_m=static_m, static_n=static_n, static_k=static_k
+            lhs.dtype, block_m=None, static_n=static_n, static_k=static_k
         )
     ):
         from .._compiler.cute.mma_support import get_cute_mma_support
@@ -354,10 +367,30 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
             # BF16/FP16, 32 for FP8). Cap at 128 to keep AB SMEM staging
             # budget sane.
             max_tcgen05_k = min(128, pow2_floor_at_least(static_k, mma_k))
-            max_search_m = min(max_tcgen05_m, pow2_floor_at_least(static_m, 64))
+            # ``block_m`` is allowed to exceed the real M up to a legal padded
+            # tcgen05 M tile. When the static M is below the smallest legal tile
+            # (``TCGEN05_MIN_BLOCK_M``), search the full CtaGroup.ONE tile range
+            # {64, 128} (CUTLASS' SM100 fp8 kernel uses a 64-row tile for tiny
+            # M); the partial all-M tile is padded/masked at codegen time. When
+            # the static M is large enough to floor the tile, keep the original
+            # ``pow2_floor_at_least`` sizing so normal GEMMs are unaffected.
+            small_static_m = static_m < TCGEN05_MIN_BLOCK_M
+            if small_static_m:
+                max_search_m = min(max_tcgen05_m, TCGEN05_ONE_CTA_MAX_BLOCK_M)
+            else:
+                max_search_m = min(max_tcgen05_m, pow2_floor_at_least(static_m, 64))
             max_search_n = max_tcgen05_n
             max_search_k = max_tcgen05_k
             min_search_m = 128 if max_tcgen05_m >= 256 else 64
+            if small_static_m:
+                # Do NOT force the M-block min up to a tcgen05 tile when the real
+                # M is below it: that would delete the smaller warp/universal
+                # block_m candidates (e.g. bf16 block_m=16 -> warp MmaF16BF16Op)
+                # from the search, leaving only padded tcgen05 tiles. Keep the
+                # min at the natural size so the autotuner can weigh warp /
+                # universal against the padded tcgen05 64/128 tiles. The max was
+                # already raised above so 64/128 ARE searchable.
+                min_search_m = min(min_search_m, pow2_floor_at_least(static_m, 1))
             two_cta_m_edge = static_m % TCGEN05_TWO_CTA_BLOCK_M != 0
             two_cta_n_edge = static_n % TCGEN05_TWO_CTA_BLOCK_N != 0
             two_cta_k_tail = static_k % max_search_k != 0
@@ -521,7 +554,15 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
                 env.block_sizes[block_idx].update_min_block(
                     min_size, allow_flattened=True
                 )
-                env.block_sizes[block_idx].update_max_block(max_size)
+                # The M axis is the only one whose search max may need to go
+                # ABOVE ``next_power_of_2(size_hint)``: for a tiny static M the
+                # legal padded tcgen05 tile (64/128) exceeds the size hint, and
+                # ``update_max`` would otherwise clamp the ceiling back down to
+                # the hint. ``allow_raise`` is scoped to the matmul M axis so the
+                # generic (N/K and non-matmul) search space is unchanged.
+                env.block_sizes[block_idx].update_max_block(
+                    max_size, allow_raise=(axis_name == "m" and small_static_m)
+                )
 
     # Triton only supports 2D dot operations.  When the operands are 3D
     # (batched matmul), constrain the batch dimension block size to 1 so

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -4177,39 +4177,68 @@ class TestCuteBackend(TestCase):
         self.assertIn("cute.nvgpu.tcgen05", code)
         self.assertIn("cute.gemm(", code)
 
-    def test_matmul_mma_fp8_small_static_m_does_not_crash(self) -> None:
-        """Regression for the small-static-M fp8 codegen crash.
+    def test_matmul_mma_fp8_small_static_m_padded_tile(self) -> None:
+        """Small-static-M fp8 now runs on a padded/masked tcgen05 M tile.
 
-        When the real problem M is < 64 but ``block_m`` is chosen >= 64, the
-        autotune config-spec did NOT register the ``tcgen05_*`` config keys
-        (its eligibility gate requires ``static_m >= TCGEN05_MIN_STATIC_M``),
-        yet codegen's ``_choose_mma_impl`` selected the tcgen05 path purely
-        from the block sizes. That mismatch raised
+        Background: when the real problem M is < 64 but ``block_m`` is chosen
+        >= 64, the autotune config-spec once did NOT register the ``tcgen05_*``
+        config keys (its eligibility gate required ``static_m >= 64``), yet
+        codegen's ``_choose_mma_impl`` selected the tcgen05 path purely from the
+        block sizes. That mismatch raised
         ``KeyError: 'tcgen05_warp_spec_ab_load_warps'`` at codegen time.
 
-        Codegen now gates tcgen05 on the same static-M threshold, so small-M
-        fp8 matmuls compile to a working path instead of crashing. M=16 and
-        M=32 must compile, run, and be numerically correct; M=64 must still
-        reach tcgen05.
+        Both sides now key the tcgen05 decision on ``block_m`` being a legal
+        tcgen05 M tile (64/128), NOT on the static M -- so they can never
+        diverge (no KeyError) AND a tiny-M GEMM runs on a padded/masked 64- or
+        128-row M tile (rows beyond the real M are masked off by the SIMT edge
+        epilogue / bounds-clamped TMA loads), exactly like CUTLASS' SM100 fp8
+        kernel. This is the win that lets M=16 reach the tensor-core path.
+
+        Asserts: M=16 and M=32 with block_m in {64, 128} compile WITHOUT the
+        KeyError crash, select tcgen05, and produce numerically correct output
+        (only the real M rows are written). M=64 (full tile) still reaches
+        tcgen05 as the control.
         """
         support = get_cute_mma_support()
         if not support.tcgen05_f8:
             self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
 
         torch.manual_seed(0)
+        # block_m > static_m (padded/masked M tile). Non-degenerate fp8 inputs
+        # spanning the e4m3 range so a masking bug is not hidden by ~0 outputs.
         for m in (16, 32):
-            x = (torch.randn(m, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
-            y = (torch.randn(128, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
-            # Must compile and run (no codegen crash) and be numerically correct.
-            _, out = code_and_output(
-                cute_matmul_mma_fp8, (x, y), block_sizes=[128, 128, 128]
-            )
-            ref = x.float() @ y.float()
-            torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+            for bm in (64, 128):
+                x = (
+                    (torch.randn(m, 128, device=DEVICE) * 4.0)
+                    .clamp(-400, 400)
+                    .to(torch.float8_e4m3fn)
+                )
+                y = (
+                    (torch.randn(128, 128, device=DEVICE) * 4.0)
+                    .clamp(-400, 400)
+                    .to(torch.float8_e4m3fn)
+                )
+                # Must not raise KeyError: 'tcgen05_warp_spec_ab_load_warps'.
+                code, out = code_and_output(
+                    cute_matmul_mma_fp8, (x, y), block_sizes=[bm, 128, 128]
+                )
+                ref = x.float() @ y.float()
+                self.assertEqual(tuple(out.shape), (m, 128))
+                torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+                # Padded M tile uses the validated tcgen05 tensor-core path.
+                self.assertIn("cute.nvgpu.tcgen05", code)
 
-        # Control: static M == 64 stays on the tcgen05 path.
-        x = (torch.randn(64, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
-        y = (torch.randn(128, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        # Control: static M == 64 (full tile) stays on the tcgen05 path.
+        x = (
+            (torch.randn(64, 128, device=DEVICE) * 4.0)
+            .clamp(-400, 400)
+            .to(torch.float8_e4m3fn)
+        )
+        y = (
+            (torch.randn(128, 128, device=DEVICE) * 4.0)
+            .clamp(-400, 400)
+            .to(torch.float8_e4m3fn)
+        )
         code, out = code_and_output(
             cute_matmul_mma_fp8, (x, y), block_sizes=[128, 128, 128]
         )


### PR DESCRIPTION
Stacked PRs:
 * #2854
 * #2853
 * #2852
 * #2845
 * #2844
 * __->__#2843
 * #2840


--- --- ---

### [cute] Allow block_m > static_m with padded-M tcgen05 for tiny-M fp8/bf16 GEMM


Tiny-M GEMMs (e.g. decode/serving shapes with M=16) could not use the
tcgen05 tensor-core MMA path, because the smallest validated tcgen05 M tile
is 64. They fell back to a serialized scalar per-element K reduction that ran
~100x slower than torch._scaled_mm. NVIDIA's CUTLASS sm_100 fp8 kernel handles
this by running a full 64- or 128-row M tile and predicating the rows beyond
the real M (masked loads, valid-row-only stores). This change lets Helion do
the same: block_m may exceed static_m, padding/masking the M boundary so the
tensor-core path runs on tiny M.

Three coordinated pieces:

1. Make block_m > static_m searchable (matmul M axis only).
   `BlockSizeSpec.update_max` could only LOWER the ceiling (clamped to
   next_power_of_2(size_hint)), so at M=16 the M block fragment topped out at
   16 and 64/128 were never tried. Add `BlockSizeSpec.raise_max` and an
   `allow_raise` flag on `BlockSizeInfo.update_max_block`. The matmul tcgen05
   search loop in matmul_ops.py passes `allow_raise=True` ONLY for the M axis
   and ONLY when static_m < 64 (identified via the existing MatmulFact
   machinery). N/K and every non-matmul tile keep the size-hint ceiling, so
   the generic search space is unchanged. For small M the M range becomes
   [natural_size .. 128] so warp (block_m=16) and tcgen05 (64/128) candidates
   all compete; the min is NOT forced to 64 (that would delete the
   warp/universal fallbacks).

2. Padded/predicated-M codegen.
   Output stores were already SIMT row-predicated
   (`cute.elem_less(coord, (m_size, n_size))`) and the TMA load descriptor is
   built with the real m_size, so out-of-bounds A rows are bounds-clamped --
   correctness needed no new masking. Performance did: the flat cluster_m=1
   mainloop gated TMA on a FULL M tile (`m_offset + bm <= m_size`), which is
   always false for a padded-M tile, so every K iteration fell to a
   per-element scalar AB load (the slow path). Add `tcgen05_flat_m_edge_tma`
   (gated to cluster_m=1, non-persistent, n % bn == 0, k % bk == 0) that
   relaxes only the M term of the output-tile predicate to
   `m_offset < m_size`, keeping bounds-clamped TMA for the whole mainloop.
   The inline steady-state `tma_next_full_tile` look-ahead is routed through
   the same shared predicate (it had a hardcoded unrelaxed copy) so prefetch
   is not permanently gated off.

3. Keep codegen and config-spec consistent (no KeyError regression).
   Rename `TCGEN05_MIN_STATIC_M` -> `TCGEN05_MIN_BLOCK_M` (alias kept). Both
   sides now key on block_m, not static M: the config-spec registers the
   tcgen05_* keys for any eligible matmul (static_m >= 1) and codegen's
   `_mma_impl_matches_problem_shape` selects tcgen05 only when
   `bm >= TCGEN05_MIN_BLOCK_M` (the authoritative bm in {64, 128} gate). So
   "codegen selects tcgen05" implies "keys registered" -- the divergence that
   caused `KeyError: tcgen05_warp_spec_ab_load_warps` cannot recur.

Verification (B200, M=16 K=4096 N=14336, fp8 e4m3):
- Correctness with range-filling fp8 inputs + identity scales vs a float32
  matmul: block_m=64 and block_m=128 both emit `cute.nvgpu.tcgen05` and give
  relerr ~1.7e-3 (fp8 rounding); output shape (16, N) confirms padded rows are
  not written. No-crash sweep over static_m in {16,32,48,64} x block_m in
  {16,32,64,128} all pass.
- Performance (warm-L2, tritonbench do_bench_wrapper, cudagraph): block_m=64
  config ~24 us / ~2.45 TB/s -- ~66x faster than the ~1600 us scalar baseline
  (~2.4x off torch._scaled_mm at ~10 us; further block-shape tuning is future
  work).

The regression test `test_matmul_mma_fp8_small_static_m_does_not_crash` is
renamed to `..._padded_tile` and strengthened: M=16/32 with block_m in
{64,128} must compile without the KeyError, select tcgen05, and be numerically
correct (wider-range inputs so masking bugs can't hide), with the M=64 control
retained.

Limitations: the flat M-edge TMA fast path requires n % bn == 0 and
k % bk == 0; a tiny-M GEMM with an N-edge or K-tail still computes correctly
but falls back to the slower scalar AB path.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
