### PR TITLE
[cute] Enable N-axis cluster (cluster_n=2, cluster_m=1) A-multicast for tiny-M fp8

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -1070,6 +1070,13 @@ class _PerKiterTmaArgs:
     # (cute_plan.md §6.12.7). Default 1 preserves byte-identity for the
     # validated cluster_m=2 cluster_n=1 path.
     cluster_n: int = 1
+    # When True the A ``cute.copy`` passes ``mcast_mask`` even though this is
+    # not a two-cta loop. Set by the N-only CtaGroup.ONE A-multicast cluster
+    # (cluster_m=1, cluster_n=2), where A is multicast across the 2 N-CTAs but
+    # the mainloop stays flat / owner-ungated. Defaults False so all existing
+    # non-cluster and two-cta call sites keep their byte-identical emission
+    # (the two-cta path drives the A mask via ``is_two_cta`` below).
+    use_tma_a_mcast_mask: bool = False
     # Static-full one-CTA pipelined TMA loops can drop the per-K runtime
     # full-tile branch and scalar fallback. Non-pipelined/asymmetric or two-CTA
     # TMA paths must keep the guarded fallback path.
@@ -1084,7 +1091,8 @@ def _kloop_tma_copy_a_src(args: _PerKiterTmaArgs, *, k_offset: str) -> str:
     """
     if not args.use_tma_a:
         return ""
-    mcast = f", mcast_mask={args.tma_a_mcast_mask}" if args.is_two_cta else ""
+    a_mcast = args.is_two_cta or args.use_tma_a_mcast_mask
+    mcast = f", mcast_mask={args.tma_a_mcast_mask}" if a_mcast else ""
     return (
         f"    cute.copy({args.tma_atom_a}, "
         f"{args.tma_gA}[None, {k_offset}], "
@@ -1530,6 +1538,10 @@ class _InitialPrefetchTmaArgs:
     use_tma_b_mcast_mask: bool
     skip_producer_acquire: bool
     skip_producer_advance: bool
+    # See ``_PerKiterTmaArgs.use_tma_a_mcast_mask``: drives the A multicast for
+    # the N-only CtaGroup.ONE cluster. Defaults False so two-cta and
+    # non-cluster prefetch call sites stay byte-identical.
+    use_tma_a_mcast_mask: bool = False
 
 
 def _initial_prefetch_copy_a_src(
@@ -1542,7 +1554,8 @@ def _initial_prefetch_copy_a_src(
     ``test_mcast_mask_asymmetry_between_a_and_b`` for the per-K-iter
     builders.
     """
-    mcast = f", mcast_mask={args.tma_a_mcast_mask}" if args.is_two_cta else ""
+    a_mcast = args.is_two_cta or args.use_tma_a_mcast_mask
+    mcast = f", mcast_mask={args.tma_a_mcast_mask}" if a_mcast else ""
     return (
         f"    cute.copy({args.tma_atom_a}, "
         f"{args.tma_gA}[None, {k_offset}], "
@@ -2046,7 +2059,11 @@ def _emit_mma_pipeline(
         and tcgen05_use_tma_pipeline
         and not tcgen05_pid_is_persistent
         and tcgen05_cluster_m == 1
-        and tcgen05_cluster_n_requested == 1
+        # cluster_n=1 is the plain flat path; cluster_n=2 is the N-only
+        # A-multicast cluster, which keeps the identical flat M-edge
+        # output-tile predicate (each CTA still owns one bm x bn tile and
+        # masks the padded M rows). The cluster only changes the A TMA load.
+        and tcgen05_cluster_n_requested in (1, 2)
         and m_size % bm != 0
         and n_size % bn == 0
         and k_total_size % bk == 0
@@ -2191,19 +2208,56 @@ def _emit_mma_pipeline(
     # this validated pairing demote to cluster_n=1 instead of throwing —
     # explicit user configs hit the BackendUnsupported gate, and autotune
     # stays narrowed to the validated subset.
+    # cluster_n=2 has two validated codegen envelopes:
+    #   1. cluster_m=2, use_2cta=True (V=2): the canonical Quack 4-CTA cluster.
+    #   2. cluster_m=1, CtaGroup.ONE: the N-only A-multicast cluster for the
+    #      tiny-M padded tcgen05 fp8 path. Two CTAs each own their own N output
+    #      tile and run the flat (non-persistent, monolithic) mainloop
+    #      independently; the cluster exists ONLY to TMA-multicast the shared A
+    #      operand along the N axis. This mirrors torch's ``_scaled_mm`` CUTLASS
+    #      ClusterShape<1,2,1> selection at M<=64,N>=3072 and is the right lever
+    #      for the memory-bound tiny-M shape (cluster_m=2 has nothing to share
+    #      along M). See cute_plan.md §6.12 for envelope 1.
+    # Restricted to a SINGLE M-tile (``m_size <= bm``): the flat grid maps
+    # consecutive grid_x ids to adjacent N-tiles of m_tile 0, so a 2-CTA
+    # cluster along grid_x always pairs two N-tiles that share the SAME A
+    # rows. With multiple M-tiles a cluster pair could straddle an
+    # m_tile boundary (different A rows), and each CTA's multicast A copy
+    # would clobber its peer's SMEM A -> wrong output. The target tiny-M
+    # shapes (M<=64 on a 64/128-row tile) are exactly the single-M-tile
+    # case, which is also what torch's _scaled_mm pads M to.
+    tcgen05_n_only_cluster = (
+        mma_impl == "tcgen05"
+        and tcgen05_cluster_n_requested == 2
+        and tcgen05_cluster_m == 1
+        and not tcgen05_requested_two_cta
+        and tcgen05_use_tma_pipeline
+        and not tcgen05_pid_is_persistent
+        and m_size <= bm
+        and n_size % (bn * tcgen05_cluster_n_requested) == 0
+        and k_total_size % bk == 0
+    )
     if tcgen05_cluster_n_requested > 1 and not (
-        mma_impl == "tcgen05" and tcgen05_is_two_cta and tcgen05_cluster_m == 2
+        (mma_impl == "tcgen05" and tcgen05_is_two_cta and tcgen05_cluster_m == 2)
+        or tcgen05_n_only_cluster
     ):
         if mma_impl == "tcgen05" and tcgen05_cluster_n_requested == 2:
             raise exc.BackendUnsupported(
                 "cute",
-                "tcgen05_cluster_n=2 requires tcgen05_cluster_m=2 with "
-                "use_2cta=True (bm=256). See cute_plan.md §6.12 for the "
-                "validated 4-CTA cluster envelope.",
+                "tcgen05_cluster_n=2 requires either tcgen05_cluster_m=2 with "
+                "use_2cta=True (bm=256, the 4-CTA cluster; cute_plan.md §6.12) "
+                "or tcgen05_cluster_m=1 with a flat non-persistent TMA pipeline "
+                "and an N extent divisible by 2*block_n (the N-only A-multicast "
+                "cluster). For the latter K must divide block_k.",
             )
         tcgen05_cluster_n = 1
     else:
         tcgen05_cluster_n = tcgen05_cluster_n_requested
+    # The N-only cluster reuses the same per-CTA multicast machinery as the
+    # 2-CTA path for A (mcast atom + mask + cta-layout slices + arrive count),
+    # but keeps the flat owner-ungated mainloop: each CTA is its own MMA owner
+    # (CtaGroup.ONE => every CTA is a cluster leader), so no V-leader gating.
+    tcgen05_a_mcast_cluster = tcgen05_is_two_cta or tcgen05_n_only_cluster
     tcgen05_role_local_k_tail_tma = (
         tcgen05_preserve_tma_for_two_cta_k_tail
         and tcgen05_is_two_cta
@@ -2722,7 +2776,20 @@ def _emit_mma_pipeline(
     mma_physical_m_threads = _grid_thread_extent(cg, m_block_id)
     tcgen05_cta_thread_count = _grid_cta_thread_count(cg)
     if mma_impl == "tcgen05" and tcgen05_cluster_m * tcgen05_cluster_n > 1:
-        df.cute_state.cluster_shape = (tcgen05_cluster_m, tcgen05_cluster_n, 1)
+        # The launch cluster dims map (m, n, k) -> physical grid (x, y, z).
+        # The persistent two-cta paths lay the grid out so cluster_m clusters
+        # along grid_x (e.g. (2,1,1)) and cluster_n along grid_y. The N-only
+        # flat path uses a SINGLE flat grid dimension (grid_x = total tiles,
+        # grid_y=grid_z=1) with consecutive grid_x tiles being adjacent
+        # N-tiles of the one M-tile, so its 2-CTA cluster must run ALONG
+        # grid_x: launch cluster (cluster_n, 1, 1). The kernel-internal
+        # cluster_layout_vmnk stays the logical (cluster_m, cluster_n, 1) =
+        # (1, 2, 1) so the A mcast mask (mode 2 = N) and block_idx_in_cluster
+        # -> N-coord mapping remain correct.
+        if tcgen05_n_only_cluster:
+            df.cute_state.cluster_shape = (tcgen05_cluster_n, 1, 1)
+        else:
+            df.cute_state.cluster_shape = (tcgen05_cluster_m, tcgen05_cluster_n, 1)
     tcgen05_acc_stage_count_value = _tcgen05_config_int(
         df.config, "tcgen05_acc_stages", _tcgen05_acc_stage_count(bn)
     )
@@ -2743,10 +2810,15 @@ def _emit_mma_pipeline(
     #   - cluster_m=2 cluster_n=2 V=2: 2 + 1 - 1 = 2 (the cluster_n=2 fix)
     #   - cluster_m=1 cluster_n=1 V=1 (no use_2cta): 1 (collapses to single
     #     CTA; no multicast)
-    if tcgen05_is_two_cta and tcgen05_cluster_n > 1:
+    #   - cluster_m=1 cluster_n=2 V=1 (N-only CtaGroup.ONE A-multicast):
+    #     num_mcast_ctas_a = cluster_n = 2, num_mcast_ctas_b = cluster_m / 1 =
+    #     1 -> 2 + 1 - 1 = 2. Both N-CTAs receive the multicast A and each
+    #     arrives once on the AB empty barrier; the producer waits for 2.
+    if (tcgen05_is_two_cta or tcgen05_n_only_cluster) and tcgen05_cluster_n > 1:
         # V=2 absorbs cluster_m into the cluster_layout_vmnk V dim; the
         # post-V CTAs along M (= cluster_m // V) carry the B multicast,
-        # while cluster_n CTAs along N carry the A multicast.
+        # while cluster_n CTAs along N carry the A multicast. CtaGroup.ONE
+        # keeps V=1, so cluster_m // V = cluster_m.
         v_for_mcast = 2 if tcgen05_is_two_cta else 1
         num_mcast_ctas_a = tcgen05_cluster_n
         num_mcast_ctas_b = max(1, tcgen05_cluster_m // v_for_mcast)
@@ -4160,6 +4232,10 @@ def _emit_mma_pipeline(
             tcgen05_use_tma_b_mcast_mask = (
                 tcgen05_use_tma_b_peer_mcast or tcgen05_use_tma_b_self_mcast
             )
+            # The N-only CtaGroup.ONE cluster (cluster_m=1, cluster_n=2)
+            # multicasts ONLY A across its 2 N-CTAs (mcast_mode=2). B is not
+            # multicast (cluster_m=1 => no M peers), so B keeps the plain
+            # per-CTA coord/layout (coord 0, make_layout(1)) and no B mask.
             if tcgen05_is_two_cta:
                 prefix.append(
                     statement_from_string(
@@ -4175,11 +4251,26 @@ def _emit_mma_pipeline(
                         "(0, None, 0, 0)).shape)"
                     )
                 )
+            elif tcgen05_n_only_cluster:
+                # A multicasts along the N axis (mode 2). The N-slice keeps
+                # the rank-4 (V,M,N,K) cluster_layout's N mode free; same
+                # spelling as the two-cta A path (the V mode is size 1 under
+                # CtaGroup.ONE). B uses the plain non-cluster layout.
+                prefix.append(
+                    statement_from_string(
+                        f"{tma_a_cta_layout} = cute.make_layout("
+                        f"cute.slice_({tcgen05_cluster_layout_vmnk}, "
+                        "(0, 0, None, 0)).shape)"
+                    )
+                )
+                prefix.append(
+                    statement_from_string(f"{tma_cta_layout} = cute.make_layout(1)")
+                )
             else:
                 prefix.append(
                     statement_from_string(f"{tma_cta_layout} = cute.make_layout(1)")
                 )
-            if tcgen05_cluster_m > 1 or tcgen05_is_two_cta:
+            if tcgen05_cluster_m > 1 or tcgen05_a_mcast_cluster:
                 prefix.append(
                     statement_from_string(
                         f"{tma_cta_rank_in_cluster} = cute.arch.make_warp_uniform("
@@ -4203,7 +4294,14 @@ def _emit_mma_pipeline(
                             f"{tma_b_cta_coord} = {tma_block_in_cluster_coord_vmnk}[1]"
                         )
                     )
-                if tcgen05_is_two_cta:
+                elif tcgen05_n_only_cluster:
+                    # A's coord is its N position in the cluster (mode 2).
+                    prefix.append(
+                        statement_from_string(
+                            f"{tma_a_cta_coord} = {tma_block_in_cluster_coord_vmnk}[2]"
+                        )
+                    )
+                if tcgen05_a_mcast_cluster:
                     prefix.append(
                         statement_from_string(
                             f"{tma_a_mcast_mask} = cute.nvgpu.cpasync.create_tma_multicast_mask("
@@ -4222,10 +4320,13 @@ def _emit_mma_pipeline(
                     )
             # tma_partition consumes the per-tile gA_part / gB_part, so the
             # resulting (tma_sA, tma_gA) / (tma_sB, tma_gB) are also per-tile.
-            tma_a_cta_coord_expr = tma_a_cta_coord if tcgen05_is_two_cta else "0"
+            # A uses the cluster coord/layout whenever it multicasts (two-cta
+            # OR the N-only cluster); B uses the cluster coord/layout only in
+            # the two-cta path (it is non-multicast in the N-only cluster).
+            tma_a_cta_coord_expr = tma_a_cta_coord if tcgen05_a_mcast_cluster else "0"
             tma_b_cta_coord_expr = tma_b_cta_coord if tcgen05_is_two_cta else "0"
             tma_a_cta_layout_expr = (
-                tma_a_cta_layout if tcgen05_is_two_cta else tma_cta_layout
+                tma_a_cta_layout if tcgen05_a_mcast_cluster else tma_cta_layout
             )
             tma_b_cta_layout_expr = (
                 tma_b_cta_layout if tcgen05_is_two_cta else tma_cta_layout
@@ -4341,6 +4442,7 @@ def _emit_mma_pipeline(
                     tma_b_mcast_mask=tma_b_mcast_mask,
                     is_two_cta=tcgen05_is_two_cta,
                     use_tma_b_mcast_mask=tcgen05_use_tma_b_mcast_mask,
+                    use_tma_a_mcast_mask=tcgen05_n_only_cluster,
                     skip_producer_acquire=diagnose_skip_ab_producer_acquire,
                     skip_producer_advance=diagnose_skip_ab_producer_advance,
                 )
@@ -4681,6 +4783,7 @@ def _emit_mma_pipeline(
                 scalar_load_a=scalar_load_a,
                 scalar_load_b=scalar_load_b,
                 cluster_n=tcgen05_cluster_n,
+                use_tma_a_mcast_mask=tcgen05_n_only_cluster,
                 static_full_tiles=tcgen05_static_full_tma_fast_path,
             )
             if tcgen05_use_tma_pipeline:

--- a/helion/_compiler/cute/strategies.py
+++ b/helion/_compiler/cute/strategies.py
@@ -1236,11 +1236,32 @@ def validate_tcgen05_strategy_invariants(
             f"at tcgen05_cluster_n in {sorted(supported_cluster_n)!r}; "
             f"got tcgen05_cluster_n={cluster_n}"
         )
-    if cluster_n > 1 and cluster_m != 2:
+    # cluster_n=2 has two validated envelopes:
+    #   - cluster_m=2 use_2cta=True: the canonical Quack-best 4-CTA cluster
+    #     (cute_plan.md §6.12).
+    #   - cluster_m=1 CtaGroup.ONE: the N-only A-multicast cluster for the
+    #     tiny-M padded tcgen05 fp8 path. Two CTAs each own their own N
+    #     output tile; the cluster exists only to TMA-multicast the shared A
+    #     operand along the N axis (mcast_mode=2). This is what torch's
+    #     ``_scaled_mm`` CUTLASS kernel selects at M<=64,N>=3072
+    #     (ClusterShape<1,2,1>). Only ``ROLE_LOCAL_MONOLITHIC`` with the flat
+    #     NON_PERSISTENT grid lowers this shape today (the WITH_SCHEDULER / CLC
+    #     and persistent topologies have not been generalized to the N-only
+    #     multicast, so they stay on the cluster_m=2 envelope). The flat grid
+    #     is what makes consecutive grid_x CTAs adjacent N-tiles of the single
+    #     padded M-tile, which is the cluster's A-sharing precondition.
+    n_only_cluster_ok = (
+        cluster_m == 1
+        and strategy is Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC
+        and persistence_model is Tcgen05PersistenceModel.NON_PERSISTENT
+    )
+    if cluster_n > 1 and cluster_m != 2 and not n_only_cluster_ok:
         errors.append(
             f"tcgen05_cluster_n={cluster_n} requires tcgen05_cluster_m=2 "
             f"with use_2cta=True (the validated 4-CTA cluster envelope; "
-            f"cute_plan.md §6.12); got tcgen05_cluster_m={cluster_m}"
+            f"cute_plan.md §6.12) or tcgen05_cluster_m=1 with "
+            f"ROLE_LOCAL_MONOLITHIC (the N-only A-multicast cluster); "
+            f"got tcgen05_cluster_m={cluster_m}, strategy={strategy.value!r}"
         )
 
     # (strategy, persistence_model) paired cluster_n accept set.

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -4246,6 +4246,67 @@ class TestCuteBackend(TestCase):
         torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
         self.assertIn("cute.nvgpu.tcgen05", code)
 
+    def test_matmul_mma_fp8_tiny_m_cluster_n2_a_multicast(self) -> None:
+        """Tiny-M padded tcgen05 fp8 with the N-only A-multicast cluster.
+
+        ``tcgen05_cluster_n=2`` with the default ``cluster_m=1`` builds a
+        (1,2,1) CtaGroup.ONE cluster: two CTAs each own their own N output
+        tile and run the flat non-persistent monolithic mainloop, sharing
+        only the A operand via a TMA multicast along N (mcast_mode=2). This
+        mirrors torch's ``_scaled_mm`` CUTLASS ClusterShape<1,2,1> selection
+        at M<=64, N>=3072 and is the right memory-bandwidth lever for tiny M
+        (cluster_m=2 has nothing to share along M).
+
+        Asserts the cluster_n=2 kernel: (1) compiles+runs without a hang or
+        InvalidClusterSize, (2) is numerically correct on multiple seeds at
+        the fp8 rounding floor for EVERY row (a multicast bug commonly drops
+        half the output or one CTA of the pair), (3) selects tcgen05, and
+        (4) launches a 2-CTA cluster (``_helion_cute_cluster_shape = (2, 1,
+        1)`` along the flat grid_x). Cross-checked against the cluster_n=1
+        baseline so the multicast cannot silently change the answer.
+        """
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        # N must be divisible by 2*block_n so the flat grid_x (n_tiles) is
+        # even and the (2,1,1) launch cluster divides it. block_n=128 -> N=512
+        # gives 4 N-tiles. M=16 padded onto a 64-row tile (single M-tile).
+        m, k, n = 16, 256, 512
+        bm, bn, bk = 64, 128, 64
+        for seed in range(3):
+            torch.manual_seed(seed)
+            x = (
+                (torch.randn(m, k, device=DEVICE) * 3.0)
+                .clamp(-448, 448)
+                .to(torch.float8_e4m3fn)
+            )
+            y = (
+                (torch.randn(k, n, device=DEVICE) * 3.0)
+                .clamp(-448, 448)
+                .to(torch.float8_e4m3fn)
+            )
+            ref = x.float() @ y.float()
+            base_cfg = {"block_sizes": [bm, bn, bk], "tcgen05_ab_stages": 8}
+            # Baseline (no cluster) for cross-check.
+            _, out_base = code_and_output(cute_matmul_mma_fp8, (x, y), **base_cfg)
+            # N-only A-multicast cluster.
+            code, out_cn2 = code_and_output(
+                cute_matmul_mma_fp8, (x, y), **base_cfg, tcgen05_cluster_n=2
+            )
+            self.assertEqual(tuple(out_cn2.shape), (m, n))
+            self.assertIn("cute.nvgpu.tcgen05", code)
+            # The 2-CTA cluster launches along the flat grid_x: (cluster_n,1,1).
+            self.assertIn("_helion_cute_cluster_shape = (2, 1, 1)", code)
+            # Every row at the fp8 floor (no dropped/half output).
+            torch.testing.assert_close(
+                out_cn2.float(), ref, atol=1.0, rtol=1e-1
+            )
+            # Multicast must not change the answer vs the non-clustered path.
+            torch.testing.assert_close(
+                out_cn2.float(), out_base.float(), atol=0.5, rtol=1e-2
+            )
+
     def test_matmul_mma_tcgen05_fp8_col_major_b(self) -> None:
         support = get_cute_mma_support()
         if not support.tcgen05_f8:

--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -2506,8 +2506,10 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         )
         self.assertEqual(errors, [], msg=str(errors))
 
-        # cluster_n=2 with cluster_m=1: rejected (requires the 4-CTA
-        # V=2 cluster).
+        # cluster_n=2 with cluster_m=1 under a PERSISTENT pid: rejected
+        # (the N-only A-multicast cluster only lowers on the flat
+        # NON_PERSISTENT grid; persistent grids have no cluster_m=1
+        # cluster_n=2 path).
         errors = validate_tcgen05_strategy_invariants(
             strategy=Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC,
             persistence_model=Tcgen05PersistenceModel.STATIC_PERSISTENT,
@@ -2522,6 +2524,23 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
             any("requires tcgen05_cluster_m=2" in e for e in errors),
             msg=str(errors),
         )
+
+        # cluster_n=2 with cluster_m=1 under the flat NON_PERSISTENT grid:
+        # ACCEPTED. This is the N-only A-multicast cluster for the tiny-M
+        # padded tcgen05 fp8 path (mirrors torch's _scaled_mm
+        # ClusterShape<1,2,1> at M<=64,N>=3072). Two CtaGroup.ONE CTAs each
+        # own their own N output tile and TMA-multicast the shared A operand.
+        errors = validate_tcgen05_strategy_invariants(
+            strategy=Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC,
+            persistence_model=Tcgen05PersistenceModel.NON_PERSISTENT,
+            layout_strategy=Tcgen05LayoutStrategy.DEFAULT,
+            warp_spec=ROLE_LOCAL_MONOLITHIC_DEFAULT_WARP_SPEC,
+            layout_overrides=Tcgen05LayoutOverrides(),
+            pid_type="flat",
+            cluster_m=1,
+            cluster_n=2,
+        )
+        self.assertEqual(errors, [], msg=str(errors))
 
         # cluster_n=2 under ROLE_LOCAL_WITH_SCHEDULER: ACCEPTED
         # in cycle 33 (the scheduler-broadcast topology generalizes


### PR DESCRIPTION
Stacked PRs:
 * #2854
 * #2853
 * #2852
 * __->__#2845
 * #2844
 * #2843
 * #2840


--- --- ---

### [cute] Enable N-axis cluster (cluster_n=2, cluster_m=1) A-multicast for tiny-M fp8


For a tiny-M fp8 GEMM (M<=64) the tcgen05 path runs one M tile across many N
tiles (e.g. M=16, N=14336 => 112 N tiles), and each N-tile CTA re-reads the
same small A operand (M x K) from DRAM. NVIDIA's torch._scaled_mm CUTLASS
kernel handles exactly this case by selecting an N-axis 2-CTA cluster: see
aten/src/ATen/native/cuda/RowwiseScaledMM.cu, where M=16,N>=3072 dispatches
ClusterShape <1,2,1>. Two CTAs covering adjacent N tiles form a cluster and
TMA-multicast the shared A operand, cutting A traffic and improving B-stream
efficiency. (Clustering along M is useless here -- there is only one M tile;
an earlier cluster_m=2 attempt regressed for that reason.)

Helion previously allowed cluster_n>1 only inside the 4-CTA envelope
(cluster_m=2 AND cluster_n=2, CtaGroup.TWO). This enables a standalone
cluster_m=1, cluster_n=2, CtaGroup.ONE configuration where each CTA still owns
its own 64x128 output tile and the cluster exists solely to multicast A.

Changes:
- cute_mma.py: accept an n-only cluster (cluster_m=1, cluster_n=2, flat TMA
  pipeline, non-persistent, single M tile m_size<=bm, N % (2*bn) == 0,
  K % bk == 0) as a second cluster_n=2 envelope alongside the 4-CTA one. Build
  the A TMA multicast atom + mcast_mode=2 mask and set the AB-pipeline consumer
  arrive count to num_mcast_ctas_a + num_mcast_ctas_b - 1 = 2 for this case
  (B stays per-CTA: cluster_m=1 means no M peers to share B). Launch
  cluster=(cluster_n,1,1) along the flat grid_x (consecutive grid_x = adjacent
  N tiles) while keeping the logical (1,2,1) cluster_layout_vmnk so the A mask
  (mode 2 = N) and block_idx_in_cluster->N-coord mapping are correct. The
  mainloop stays flat/owner-ungated (CtaGroup.ONE => every CTA is a cluster
  leader); the padded-M masked store is unchanged.
- strategies.py: relax the config-spec invariant so cluster_n=2 with
  cluster_m=1 is admitted under role_local_monolithic + non_persistent, keeping
  codegen and config-spec consistent.

Verification (B200 sm_100, M=16 K=4096 N=14336, fp8 e4m3):
- Correctness with range-filling fp8 + identity scales vs a float32 matmul:
  relerr ~1.7e-3 (fp8 floor), identical to the cluster_n=1 baseline, across 3
  seeds; per-row relerr uniform over all 16 rows, zero all-zero rows (no
  half-output/missing-CTA bug); left/right N halves equally correct.
  cute.nvgpu.tcgen05 present. No-crash sweep static_m in {16,32,64} x block_m
  in {64,128} x cluster_n in {1,2} all pass.
- Performance (warm-L2, do_bench_wrapper, cudagraph, A/B in one session):
  cluster_n=1 16.27us / 3.64 TB/s -> cluster_n=2 14.87us / 3.99 TB/s (~1.1x;
  larger at locked/idle clocks). torch._scaled_mm 9.68us / 6.12 TB/s.
- NCU: launch__cluster_dim_x=2 (cluster active), L2 read hit 11.0% -> 14.4%,
  DRAM %peak 42.2% -> 43.7%, registers/thread unchanged at 68 (no regression,
  unlike the cluster_m=2 attempt which rose to 96).

Adds test_matmul_mma_fp8_tiny_m_cluster_n2_a_multicast (3 seeds, per-row check,
asserts cluster shape (2,1,1), cross-checks vs the cluster_n=1 baseline) and
dot-requirements coverage for the newly accepted/rejected cluster configs.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
