### PR TITLE
[autotuner] composed-fact seed for fused matmul + reduction-epilogue

### DIFF
--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -17,6 +17,7 @@ from .cute import CuteTileVecWarpReduceHeuristic
 from .pallas import PallasMatmulF32NoTilingSeedHeuristic
 from .pallas import PallasMatmulNoTilingSeedHeuristic
 from .triton import TritonB200MatmulHeuristic
+from .triton import TritonMatmulReductionEpilogueHeuristic
 from .triton import TritonSkinnyGemmHeuristic
 from .triton import TritonSplitJoinRotateHeuristic
 from .triton import TritonStandardReductionHeuristic
@@ -45,6 +46,7 @@ HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
     "triton": (
         TritonSkinnyGemmHeuristic,
         TritonB200MatmulHeuristic,
+        TritonMatmulReductionEpilogueHeuristic,
         TritonSplitJoinRotateHeuristic,
         TritonStandardReductionHeuristic,
         TritonUserTiledReductionHeuristic,

--- a/helion/_compiler/autotuner_heuristics/triton.py
+++ b/helion/_compiler/autotuner_heuristics/triton.py
@@ -959,3 +959,129 @@ class TritonUserTiledReductionHeuristic(_TritonReductionSeedBase):
             if ev is not None:
                 seed["load_eviction_policies"] = ev
         return Config(**seed)
+
+
+class TritonMatmulReductionEpilogueHeuristic(AutotunerHeuristic):
+    """Seed for a fused matmul + reduction-over-output-axis epilogue (matmul_rms_norm /
+    matmul_layernorm / matmul_softmax / matmul_l2_normalize / matmul_sum / ...): a single
+    grid loop over M does an inner K-loop ``addmm`` into a register-resident ``[M_BLOCK, N]``
+    fp32 accumulator, then reduces over the matmul's N (output) axis on that accumulator. N
+    is ``hl.specialize``'d (never tiled), so BOTH the ``[M_BLOCK, N]`` accumulator AND the
+    ``[K_BLOCK, N]`` y-operand tile scale with N -> the kernel is SMEM/register-footprint
+    bound and the win regime is small N (where a productive tile fits).
+
+    Fires on the composed ``MatmulWithReductionEpilogueFact`` (a MatmulFact + an epilogue
+    ReductionFact in one kernel) -- never on a pure matmul or a pure reduction, so those stay
+    byte-identical. This sizes M_BLOCK by the resident fp32-accumulator footprint.
+    """
+
+    name = "triton_matmul_reduction_epilogue"
+    backend = "triton"
+    HARDWARE_TARGETS = (("cuda", "sm90"),)
+
+    # The resident [M_BLOCK, N] fp32 accumulator must fit a per-program byte budget; M_BLOCK is the
+    # largest pow2 under it, capped at MAX_M_BLOCK (an occupancy/register ceiling). ~128 KiB gives
+    # the answer-key tile: M_BLOCK=64 at N<=512, 32 at N=1024, 16 at N=2048 (where the win vanishes).
+    ACC_BUDGET_BYTES = 131072
+    MAX_M_BLOCK = 64
+    # Inner K tile (min 16 by the matmul min_dot_size; normalize clamps to <=K).
+    K_BLOCK = 32
+    # num_stages: pipeline the K-loop addmm (a matmul knob; the answer key uses 3).
+    NUM_STAGES = 3
+    # num_warps ramps with the resident accumulator elements (M_BLOCK * N).
+    NUM_WARPS_ELEM_BREAK = 16384
+    # Staged matmul-operand SMEM budget (sm90/H100 has ~227 KiB/SM). The [K_BLOCK, N]
+    # y-operand x num_stages must fit this; past it the shipped [.,32]/st3 OOMs.
+    # Calibrated to the measured feasibility boundary (KB=32/st3 fits N<=1024 bf16 /
+    # N<=512 fp32; KB=16/st3 fits N<=2048 / N<=1024). The byte-cap (get_seed_config)
+    # drops K_BLOCK 32->16 FIRST -- it halves the staged bytes AND avoids the measured
+    # non-monotonic KB=32 ptxas cliffs -- keeping full stages; only past KB=16/st3 does
+    # it drop num_stages (cliff-free once KB=16).
+    SMEM_STAGED_BUDGET_BYTES = 196608  # 192 KiB
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        if not matches_hardware(env, cls.HARDWARE_TARGETS):
+            return False
+        # Resident-only: fire when the composed fact's N axis is hl.specialize'd
+        # (n_block_id is None). The looped/tiled-N shape is left to the default config.
+        facts = env.config_spec.matmul_reduction_epilogue_facts
+        return len(facts) == 1 and facts[0].matmul.n_block_id is None
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        if not matches_hardware(env, cls.HARDWARE_TARGETS):
+            return None
+        from ..._utils import prev_power_of_2
+
+        spec = env.config_spec
+        fact = spec.matmul_reduction_epilogue_facts[0]
+        n = max(1, fact.n_extent)
+        # Per-program row ceiling: MAX_M_BLOCK at 2 bytes (bf16/fp16 tensor core),
+        # scaled DOWN as the input dtype widens (fp32 = ~2x regs/elem -> //2 -> 32).
+        # The factor only lowers the ceiling; MAX_M_BLOCK is the hard occupancy cap,
+        # so a 1-byte dtype (fp8) is pinned to it by min(), not pushed above it.
+        input_itemsize = fact.matmul.lhs_dtype.itemsize
+        max_m = max(1, min(cls.MAX_M_BLOCK, cls.MAX_M_BLOCK * 2 // input_itemsize))
+
+        # Resident N (hl.specialize'd, n_block_id is None -- guaranteed by is_eligible):
+        # M_BLOCK = largest pow2 [M_BLOCK, N] fp32 accumulator under the ACC budget, capped
+        # at max_m. The staged [K_BLOCK, N] operand is bounded separately by the SMEM
+        # byte-cap below, which is what sets the feasible-N ceiling.
+        m_block = max(
+            1, min(max_m, prev_power_of_2(max(1, cls.ACC_BUDGET_BYTES // (n * 4))))
+        )
+        num_warps = 4 if m_block * n <= cls.NUM_WARPS_ELEM_BREAK else 8
+
+        # K_BLOCK + num_stages via a priority-ordered footprint byte-cap. The staged
+        # [K_BLOCK, N] y-operand (x num_stages) must fit SMEM; in the shipped small-N
+        # regime [K_BLOCK=32, num_stages=3] fits, but past it (large N) it overflows.
+        # Reduce K_BLOCK 32->16 FIRST -- it halves the staged bytes AND avoids the measured
+        # non-monotonic K_BLOCK=32 ptxas cliffs, while keeping full stages -- then, only if
+        # [16, st=3] still overflows (very large N), drop num_stages (cliff-free once
+        # K_BLOCK=16). This EXTENDS the feasible N (KB=32/st3 to N<=1024 bf16, then KB=16/st3
+        # to N<=2048) instead of OOMing into the bad default; small-N stays byte-identical.
+        k_hint = next(
+            (
+                cast("BlockSizeSpec", spec.block_sizes[i]).size_hint
+                for i in range(len(spec.block_sizes))
+                if cast("BlockSizeSpec", spec.block_sizes[i]).block_id
+                == fact.k_block_id
+            ),
+            cls.K_BLOCK,
+        )
+        k_block = min(cls.K_BLOCK, k_hint)
+        num_stages = cls.NUM_STAGES
+        if num_stages * k_block * n * input_itemsize > cls.SMEM_STAGED_BUDGET_BYTES:
+            k_block = min(k_block, 16)
+            while (
+                num_stages > 1
+                and num_stages * k_block * n * input_itemsize
+                > cls.SMEM_STAGED_BUDGET_BYTES
+            ):
+                num_stages -= 1
+
+        block_sizes: list[int] = []
+        for i in range(len(spec.block_sizes)):
+            bs_spec = cast("BlockSizeSpec", spec.block_sizes[i])
+            bid = bs_spec.block_id
+            if bid == fact.m_block_id:
+                block_sizes.append(max(bs_spec.min_size, m_block))
+            elif bid == fact.k_block_id:
+                block_sizes.append(
+                    max(bs_spec.min_size, min(k_block, bs_spec.size_hint))
+                )
+            else:
+                block_sizes.append(max(1, bs_spec.min_size, bs_spec.autotuner_min))
+
+        seed: dict[str, Any] = {
+            "block_sizes": block_sizes,
+            # The epilogue reduction is materialized on the resident accumulator, so
+            # there is no reduction_loops knob to set.
+            "reduction_loops": [],
+            "num_warps": num_warps,
+            "num_stages": num_stages,
+        }
+        return Config(**seed)

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -1234,6 +1234,33 @@ class DeviceIR:
                 memory_op_facts, accumulator_facts, liveness_by_axis
             )
 
+    def build_matmul_reduction_epilogue_facts(self) -> None:
+        """Phase 4: compose a ``MatmulWithReductionEpilogueFact`` for a fused matmul +
+        reduction-over-output-axis epilogue. Fires iff exactly one ``MatmulFact`` AND
+        one ``ReductionFact`` (the epilogue reduction from
+        ``register_user_tiled_reductions``'s materialized branch); holds the two facts
+        plus the N-extent the seed keys on. Pure-matmul kernels have no epilogue
+        ReductionFact and pure-reduction kernels no MatmulFact, so the composed fact
+        fires ONLY on the fused family.
+        """
+        env = CompileEnvironment.current()
+        spec = env.config_spec
+        from ..autotuner.config_spec import MatmulWithReductionEpilogueFact
+
+        if len(spec.matmul_facts) != 1 or len(spec.reduction_facts) != 1:
+            return
+        matmul = spec.matmul_facts[0]
+        reduction = spec.reduction_facts[0]
+        spec.matmul_reduction_epilogue_facts.append(
+            MatmulWithReductionEpilogueFact(
+                matmul=matmul,
+                reduction=reduction,
+                n_extent=reduction.size_hint,
+                m_block_id=matmul.m_block_id,
+                k_block_id=matmul.k_block_id,
+            )
+        )
+
     def build_accumulator_facts(self) -> list[AccumulatorFact]:
         """One ``AccumulatorFact`` per loop-carried tensor accumulator in any loop —
         reduction-AGNOSTIC, so it is built independently of (and before) the reduction
@@ -3309,6 +3336,9 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
         # Phase 3: build the ReductionFacts (standard from the stashed rollable rdims, then user-tiled
         # if none fired); liveness_by_axis supplies each fact's body_live_tiles slice.
         device_ir.build_reduction_facts(memory_op_facts, liveness_by_axis)
+        # Phase 4: compose a matmul + reduction-over-output epilogue fact when a matmul AND a
+        # register-resident epilogue reduction co-occur (matmul_rms_norm etc.).
+        device_ir.build_matmul_reduction_epilogue_facts()
 
         return device_ir
 

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -174,6 +174,30 @@ class ReductionFact(NamedTuple):
     per_feature_accumulator: bool = False
 
 
+class MatmulWithReductionEpilogueFact(NamedTuple):
+    """A fused matmul + reduction-over-output-axis epilogue, recorded when a ``MatmulFact`` and
+    a register-resident epilogue ``ReductionFact`` co-occur in one kernel (e.g.
+    ``matmul_rms_norm``: ``acc = x @ y`` then a reduction over N on the carried ``[M_BLOCK,
+    N]`` accumulator, then write-back). A COMPOSED fact: it holds the two existing facts plus
+    the few derived fields the seed keys on. ``TritonMatmulReductionEpilogueHeuristic``
+    branches on it.
+
+    - ``matmul`` / ``reduction``: the composed sub-facts (the matmul + the epilogue reduction).
+    - ``n_extent``: the specialized output width N (= ``reduction.size_hint``); N is
+      ``hl.specialize``'d (never tiled), so both the ``[M_BLOCK, N]`` accumulator and the
+      ``[K_BLOCK, N]`` operand tile scale with N — the resident-footprint signal the
+      footprint-aware tile chooser keys on.
+    - ``m_block_id`` / ``k_block_id``: the grid M tile and the K tile the seed sizes
+      (there is no ``n_block_id`` — N is specialized, not a block_size).
+    """
+
+    matmul: MatmulFact
+    reduction: ReductionFact
+    n_extent: int
+    m_block_id: int | None
+    k_block_id: int | None
+
+
 class MemoryOpFact(NamedTuple):
     """Metadata linking one ``Config.indexing`` slot to its graph memory op, one entry per
     load/store in graph-traversal order (so ``memory_op_facts[i]`` describes ``config.indexing[i]``).
@@ -512,6 +536,7 @@ class ConfigSpec:
         self.autotuner_heuristics: list[str] = []
         self.matmul_facts: list[MatmulFact] = []
         self.reduction_facts: list[ReductionFact] = []
+        self.matmul_reduction_epilogue_facts: list[MatmulWithReductionEpilogueFact] = []
         self.accumulator_facts: list[AccumulatorFact] = []
         self.store_indices: list[int] = []
         self.memory_op_facts: list[MemoryOpFact] = []


### PR DESCRIPTION
Stacked PRs:
 * __->__#2846
 * #2830
 * #2829
 * #2828


--- --- ---

### [autotuner] composed-fact seed for fused matmul + reduction-epilogue


The first **composed** fact. `MatmulWithReductionEpilogueFact` holds a `MatmulFact` + the
over-output-axis epilogue `ReductionFact` for a fused matmul + reduction (`matmul_rms_norm` /
`matmul_layernorm` / `matmul_softmax` / `matmul_l2_normalize` / `matmul_logsumexp` / ...).
`build_matmul_reduction_epilogue_facts` composes the two when exactly one of each co-occurs;
`TritonMatmulReductionEpilogueHeuristic` then seeds a footprint-aware tile. Fires **only** on the
fused family — a pure matmul and a pure reduction do not compose, so the reduction curriculum stays
byte-identical.

**Resident (row-in-registers) only.** The seed assumes the whole reduced row lives in the
register-resident `[M_BLOCK, N]` fp32 accumulator (N is `hl.specialize`'d → `n_block_id is None`);
`is_eligible` fires only on that shape. The earlier looped/tiled-N branch (perf-unverified) was
removed per review.

**Depends on #2829 (stage 2a) — this is the first consumer of its aperture.** 2a removed the
`if spec.matmul_facts: return` guard in `register_user_tiled_reductions`, which lets the materialized
branch register the over-N epilogue reduction even when a matmul is present. Without that, the
composed fact never forms. It does **not** depend on 2b/#2830's `per_feature_accumulator` (stacked on
#2830 for ordering; re-parentable to #2829).

## What changes
- **`config_spec.py`** — `MatmulWithReductionEpilogueFact` (composes the two sub-facts + `n_extent` +
  `m`/`k_block_id`; holds them, does not re-derive).
- **`device_ir.py`** — `build_matmul_reduction_epilogue_facts` (Phase 4): composes iff exactly 1
  `MatmulFact` + 1 `ReductionFact`.
- **`triton.py`** — `TritonMatmulReductionEpilogueHeuristic`: footprint-aware `M_BLOCK` (largest pow2
  whose `[M_BLOCK, N]` fp32 accumulator fits `ACC_BUDGET_BYTES=128 KiB`, dtype-scaled, capped at 64),
  `K_BLOCK=32`, `num_stages=3`, `num_warps` ramp, plus a staged-SMEM byte-cap that extends the
  feasible-N range (below).
- **`__init__.py`** — registers the heuristic. Reduction heuristics gate on `not matmul_facts`, so the
  fused family is seeded by this one alone; pure matmul keeps its skinny-gemm seed.

## Staged-SMEM byte-cap (feasible-N extension)
The resident kernel's SMEM is dominated by the staged `[K_BLOCK, N]` y-operand
(`num_stages·K_BLOCK·N·itemsize`); past the small-N range `[K_BLOCK=32, num_stages=3]` overflows it.
The seed caps that footprint to `SMEM_STAGED_BUDGET_BYTES=192 KiB`: when over, drop **`K_BLOCK 32→16`
first** (halves the staged bytes *and* sidesteps a measured non-monotonic `K_BLOCK=32` ptxas cliff),
then drop `num_stages` only if still over. Small-N stays **byte-identical** (the cap doesn't fire).
Because `n_extent` is the next power of two of `N`, the emitted bands are `KB32/st3` → `KB16/st3` →
`KB16/st1` (the `KB16/st2` band never occurs).

Net: the seed compiles to **N≤4096 bf16 / N≤2048 fp32** — roughly **2× the default's wall**
(N≤2048 / N≤1024) — and **fails closed** beyond (clean `OutOfResources` → the autotuner falls back;
the seed is never the forced default, `promote_seed_to_default=False`). Where the default OOMs but the
seed still compiles (bf16 N=3072/4096, fp32 N=1536/2048, the 2048³ fp32 square), the seed is a
**feasibility rescue**.

## Performance
H100 sm90, fwd-only, **cold-L2 CUDA-graph device time** (256 MiB L2 flush per replay), accuracy-gated
(relerr vs an fp32 reference). `seed` = the heuristic's emitted config (extracted faithfully via
`kernel.bind` → `get_seed_config`); `default` = `config_spec.default_config()` (the bar); `tc` =
`torch.compile` with native-dtype matmul + fp32 accumulate. `>1` = seed faster. "rescue" = default
uncompilable (OOM), seed runs. The seed is epilogue-blind, so the 5 kernels track each other at
matched shapes.

| kernel | (M, K, N) | dtype | regime | seed/default | seed/tc |
|---|---|---|---|---|---|
| layernorm | 131072, 512, 512 | bf16 | small-N | 1.82× | 1.15× |
| layernorm | 131072, 512, 512 | fp32 | small-N | 1.55× | 2.92× |
| layernorm | 131072, 512, 2048 | bf16 | larger-N | 14.57× | 0.37× |
| layernorm | 131072, 512, 4096 | bf16 | larger-N | rescue | 0.13× |
| layernorm | 131072, 4096, 2048 | bf16 | larger-K | 13.65× | 0.19× |
| layernorm | 512³ | bf16 | square | 1.72× | 0.59× |
| layernorm | 1024³ | bf16 | square | 5.95× | 0.34× |
| layernorm | 1024³ | fp32 | square | 26.94× | 0.99× |
| layernorm | 2048³ | fp32 | square | rescue | 0.77× |
| rmsnorm | 1024³ | bf16 | square | 5.69× | 0.34× |
| rmsnorm | 131072, 512, 4096 | bf16 | larger-N | rescue | 0.12× |
| rmsnorm | 131072, 8192, 2048 | bf16 | larger-K | 12.34× | 0.15× |
| softmax | 1024³ | fp32 | square | 29.69× | 0.98× |
| softmax | 131072, 512, 2048 | fp32 | larger-N | rescue | 1.22× |
| softmax | 131072, 2048, 2048 | bf16 | larger-K | 13.63× | 0.23× |
| l2_normalize | 2048³ | bf16 | square | 13.88× | 0.18× |
| l2_normalize | 131072, 512, 4096 | bf16 | larger-N | rescue | 0.12× |
| l2_normalize | 131072, 6144, 1024 | bf16 | larger-K | 3.31× | 0.39× |
| logsumexp | 1024³ | bf16 | square | 5.54× | 0.36× |
| logsumexp | 131072, 512, 4096 | bf16 | larger-N | rescue | 0.10× |
| logsumexp | 131072, 3072, 2048 | bf16 | larger-K | 3.63× | 0.19× |

**vs the Helion default (the bar): geomean 6.93× over the 15 both-compile cells (1.55–29.69×), no
regressions, plus 6 feasibility rescues.** The default is catastrophic at large N/K — it spills the
huge fp32 accumulator to local memory (e.g. 257 ms / 509 ms at K=4096/8192 vs the seed's 19 / 41 ms),
or OOMs outright — which the seed's `num_warps` ramp + byte-cap avoid.

**vs torch.compile: fp32 is competitive-to-winning (0.77–2.92×; the softmax N=2048 fp32 rescue beats
it 1.22× while the default can't even run); bf16 loses at high arithmetic intensity** (large-N /
large-K / squares, 0.10–0.59×, where cuBLAS bf16 tensor-core GEMM dominates) and wins only at small N.
This is the expected, documented regime: the resident matmul+epilogue is GEMM/occupancy-bound at large
N, so the seed's role is to be a far better *seed and feasibility backstop than the Helion default*
(which it is everywhere), not to beat cuBLAS.

## Scope / limitations
- **Resident structure → feasibility is N-bounded** (seed N≤4096 bf16 / N≤2048 fp32; fails closed
  beyond, autotuner falls back). Large-square / large-N is occupancy- and GEMM-bound and loses to
  cuBLAS — a structural ceiling of the resident pattern (documented in the table), not a seed defect;
  a competitive large-N kernel needs a tiled/looped 2D-GEMM structure (separate work).

## Disjointness / no-regression
- Composed fact fires only on the fused family: fused → `composed=1`; pure matmul → 0 (keeps
  skinny-gemm); pure reduction → 0. The 9 reduction + 8 transfer curriculum kernels have no matmul, so
  the fact never forms — config_recorder byte-identical. Small-N matmul+epilogue configs are
  byte-identical with/without the byte-cap (it doesn't fire there).
