### PR TITLE
[triton][AMD] Enable store cache modifier autotuning

### DIFF
--- a/helion/_compiler/_inductor/template_buffer.py
+++ b/helion/_compiler/_inductor/template_buffer.py
@@ -687,6 +687,7 @@ class HelionTemplateBuffer(TemplateBuffer):
         subscript: list[object],
         value: ast.expr,
         extra_mask: ast.expr | None,
+        cache_modifier: ast.expr | None,
         codegen_store: Callable[..., ast.expr],
     ) -> ast.expr:
         """Emit per-epilogue index definitions + ``<STORE_OUTPUT_{i}>`` placeholder.
@@ -719,7 +720,9 @@ class HelionTemplateBuffer(TemplateBuffer):
         param_name = state.device_function.tensor_arg(tensor).name
         epilogue_idx = self._fusion_metadata.epilogue_idx_by_param.get(param_name)
         if epilogue_idx is None:
-            return codegen_store(state, tensor, [*subscript], value, extra_mask)
+            return codegen_store(
+                state, tensor, [*subscript], value, extra_mask, cache_modifier
+            )
 
         kernel_val_name = f"_kernel_val_{epilogue_idx}"
 
@@ -790,7 +793,12 @@ class HelionTemplateBuffer(TemplateBuffer):
             state.add_statement(
                 ast.Expr(
                     value=codegen_store(
-                        state, tensor, [*subscript], store_val, extra_mask
+                        state,
+                        tensor,
+                        [*subscript],
+                        store_val,
+                        extra_mask,
+                        cache_modifier,
                     )
                 )
             )

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -977,7 +977,7 @@ class TritonBackend(Backend):
         return host_str
 
     def supports_config_key(self, key: str) -> bool:
-        if key == "load_cache_modifiers":
+        if key in ("load_cache_modifiers", "store_cache_modifiers"):
             return True
         if key == "waves_per_eu":
             from .._compat import is_hip

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -323,6 +323,7 @@ class DeviceFunction:
         self.device_load_index = 0
         self.device_load_cache_modifier_index = 0
         self.device_store_index = 0
+        self.device_store_cache_modifier_index = 0
         # Single counter for both loads and stores for indexing assignment
         self.device_memory_op_index = 0
         self.epilogue_subtile_store_indices: dict[str, int] = {}

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -2822,6 +2822,7 @@ def _register_load_store_tunables(
     total_load_count: int,
     loads_without_eviction_policy: int,
     loads_without_cache_modifier: int,
+    stores_without_cache_modifier: int,
     store_indices: list[int],
 ) -> None:
     """Register list-based tunables for device loads and stores.
@@ -2830,6 +2831,7 @@ def _register_load_store_tunables(
         total_load_count: Total number of loads (for indexing tunable)
         loads_without_eviction_policy: Number of loads that need eviction policy tuning
         loads_without_cache_modifier: Number of loads that need cache modifier tuning
+        stores_without_cache_modifier: Number of stores that need cache modifier tuning
         store_indices: Positions of store ops in the combined indexing list
     """
     store_count = len(store_indices)
@@ -2842,6 +2844,7 @@ def _register_load_store_tunables(
     from ..autotuner.config_fragment import ListOf
     from ..autotuner.config_spec import get_valid_eviction_policies
     from ..autotuner.config_spec import get_valid_load_cache_modifiers
+    from ..autotuner.config_spec import get_valid_store_cache_modifiers
 
     # Register eviction policies only for loads without explicit eviction_policy
     if loads_without_eviction_policy > 0:
@@ -2857,6 +2860,15 @@ def _register_load_store_tunables(
         env.config_spec.load_cache_modifiers = ListOf(
             EnumFragment(choices=load_cache_modifier_choices),
             length=loads_without_cache_modifier,
+        )
+
+    # Register cache modifiers for stores when the backend has a non-trivial
+    # search space.
+    store_cache_modifier_choices = get_valid_store_cache_modifiers(env.backend_name)
+    if stores_without_cache_modifier > 0 and len(store_cache_modifier_choices) > 1:
+        env.config_spec.store_cache_modifiers = ListOf(
+            EnumFragment(choices=store_cache_modifier_choices),
+            length=stores_without_cache_modifier,
         )
 
     # Indexing applies to ALL loads and stores
@@ -3021,6 +3033,7 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
             sum(f.eviction_index is not None for f in memory_op_facts),
             # cache_modifier is tuned for every load (no per-load override)
             load_count,
+            sum(f.kind == "store" for f in memory_op_facts),
             [f.indexing_index for f in memory_op_facts if f.kind == "store"],
         )
         _register_atomic_tunables(_count_device_atomics(device_ir))

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -208,6 +208,7 @@ class IndexingStrategy:
         subscript: list[object],
         value: ast.AST,
         extra_mask: ast.AST | None,
+        cache_modifier: ast.AST | None,
     ) -> ast.AST:
         raise NotImplementedError
 
@@ -635,6 +636,7 @@ class PointerIndexingStrategy(IndexingStrategy):
         subscript: list[object],
         value: ast.AST,
         extra_mask: ast.AST | None,
+        cache_modifier: ast.AST | None,
     ) -> ast.AST:
         indexing = SubscriptIndexing.create(state, fake_tensor, subscript, extra_mask)
         name = state.device_function.tensor_arg(fake_tensor).name
@@ -707,11 +709,17 @@ class PointerIndexingStrategy(IndexingStrategy):
             broadcast = backend.broadcast_to_expr("{offset}", shape_str)
             offset_expr = expr_from_string(broadcast, offset=offset_expr)
 
+        extra = ", cache_modifier={cm}" if cache_modifier is not None else ""
+        store_placeholders: dict[str, ast.AST] = {
+            "value": value,
+            "offset": offset_expr,
+            "mask": indexing.mask_expr,
+        }
+        if cache_modifier is not None:
+            store_placeholders["cm"] = cache_modifier
         return expr_from_string(
-            f"tl.store({name} + {{offset}}, {{value}}, {{mask}})",
-            value=value,
-            offset=offset_expr,
-            mask=indexing.mask_expr,
+            f"tl.store({name} + {{offset}}, {{value}}, {{mask}}{extra})",
+            **store_placeholders,
         )
 
     def codegen_atomic(
@@ -790,20 +798,27 @@ class BlockPtrIndexingStrategy(IndexingStrategy):
         subscript: list[object],
         value: ast.AST,
         extra_mask: ast.AST | None,
+        cache_modifier: ast.AST | None,
     ) -> ast.AST:
         if extra_mask is not None or not BlockedSubscriptIndexing.is_supported(
             state, fake_tensor, subscript
         ):
             return PointerIndexingStrategy().codegen_store(
-                state, fake_tensor, subscript, value, extra_mask
+                state, fake_tensor, subscript, value, extra_mask, cache_modifier
             )
         indexing = BlockedSubscriptIndexing.create(state, fake_tensor, subscript)
         store_value = indexing.reshape_store(state, value)
         store_value = cast_ast(store_value, fake_tensor.dtype)
+        extra = ", cache_modifier={cm}" if cache_modifier is not None else ""
+        placeholders: dict[str, ast.AST] = {
+            "block_ptr": indexing.make_block_ptr(state),
+            "value": store_value,
+        }
+        if cache_modifier is not None:
+            placeholders["cm"] = cache_modifier
         return expr_from_string(
-            f"tl.store({{block_ptr}}, {{value}}, boundary_check={indexing.boundary_check(state)})",
-            block_ptr=indexing.make_block_ptr(state),
-            value=store_value,
+            f"tl.store({{block_ptr}}, {{value}}, boundary_check={indexing.boundary_check(state)}{extra})",
+            **placeholders,
         )
 
 
@@ -999,12 +1014,13 @@ class TensorDescriptorIndexingStrategy(IndexingStrategy):
         subscript: list[object],
         value: ast.AST,
         extra_mask: ast.AST | None,
+        cache_modifier: ast.AST | None,
     ) -> ast.AST:
         if extra_mask is not None or not self.is_supported(
             state, fake_tensor, subscript
         ):
             return PointerIndexingStrategy().codegen_store(
-                state, fake_tensor, subscript, value, extra_mask
+                state, fake_tensor, subscript, value, extra_mask, cache_modifier
             )
         indexing = BlockedSubscriptIndexing.create(state, fake_tensor, subscript)
 
@@ -1209,6 +1225,7 @@ class StackIndexingStrategy:
         subscript: list[object],
         value: ast.AST,
         extra_mask: ast.AST | None,
+        cache_modifier: ast.AST | None,
     ) -> ast.AST:
         tensor_like, dev_ptrs = stack_tensor
         indexing = SubscriptIndexing.create(state, tensor_like, subscript, extra_mask)
@@ -1228,12 +1245,18 @@ class StackIndexingStrategy:
         )
 
         dtype = triton_type(tensor_like.dtype)
+        extra = ", cache_modifier={cm}" if cache_modifier is not None else ""
+        placeholders: dict[str, ast.AST] = {
+            "base": dev_ptrs_ast,
+            "value": value,
+            "offset": indexing.index_expr,
+            "mask": mask_expr,
+        }
+        if cache_modifier is not None:
+            placeholders["cm"] = cache_modifier
         return expr_from_string(
-            f"tl.store({{base}}.to(tl.pointer_type({dtype})){stack_broadcast} + ({{offset}}){tensor_broadcast}, {{value}}, {{mask}})",
-            base=dev_ptrs_ast,
-            value=value,
-            offset=indexing.index_expr,
-            mask=mask_expr,
+            f"tl.store({{base}}.to(tl.pointer_type({dtype})){stack_broadcast} + ({{offset}}){tensor_broadcast}, {{value}}, {{mask}}{extra})",
+            **placeholders,
         )
 
 

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -260,6 +260,7 @@ BACKEND_SPECIFIC_KEYS: frozenset[str] = (
         "num_threads",
         "cute_vector_widths",
         "load_cache_modifiers",
+        "store_cache_modifiers",
         "pallas_loop_type",
         "pallas_pre_broadcast",
     }
@@ -287,6 +288,7 @@ VALID_KEYS: frozenset[str] = frozenset(
         "atomic_indexing",
         "load_eviction_policies",
         "load_cache_modifiers",
+        "store_cache_modifiers",
         "pallas_loop_type",
         "pallas_pre_broadcast",
         "cute_vector_widths",
@@ -361,6 +363,12 @@ def get_valid_load_cache_modifiers(backend_name: str) -> tuple[str, ...]:
     return ("",)
 
 
+def get_valid_store_cache_modifiers(backend_name: str) -> tuple[str, ...]:
+    if backend_name == "triton" and supports_amd_cdna_tunables():
+        return ("", ".cs", ".wt")
+    return ("",)
+
+
 class ConfigSpec:
     def __init__(
         self,
@@ -424,6 +432,10 @@ class ConfigSpec:
         )
         self.load_cache_modifiers = ListOf(
             EnumFragment(choices=get_valid_load_cache_modifiers(self.backend_name)),
+            length=0,
+        )
+        self.store_cache_modifiers = ListOf(
+            EnumFragment(choices=get_valid_store_cache_modifiers(self.backend_name)),
             length=0,
         )
         self.indexing = ListOf(
@@ -1104,6 +1116,7 @@ class ConfigSpec:
             "static_ranges",
             "load_eviction_policies",
             "load_cache_modifiers",
+            "store_cache_modifiers",
             "indexing",
             "atomic_indexing",
         ):
@@ -1116,6 +1129,7 @@ class ConfigSpec:
             "num_stages",
             "load_eviction_policies",
             "load_cache_modifiers",
+            "store_cache_modifiers",
             "indexing",
             "atomic_indexing",
             "pid_type",
@@ -1139,6 +1153,13 @@ class ConfigSpec:
         ):
             config.setdefault(
                 "load_cache_modifiers", self.load_cache_modifiers.default()
+            )
+        if (
+            self.supports_config_key("store_cache_modifiers")
+            and self.store_cache_modifiers.length > 0
+        ):
+            config.setdefault(
+                "store_cache_modifiers", self.store_cache_modifiers.default()
             )
         if self.supports_config_key("indexing"):
             config.setdefault("indexing", self.indexing.default())
@@ -1564,6 +1585,11 @@ class ConfigSpec:
             and self.load_cache_modifiers.length > 0
         ):
             fields["load_cache_modifiers"] = self.load_cache_modifiers
+        if (
+            self.supports_config_key("store_cache_modifiers")
+            and self.store_cache_modifiers.length > 0
+        ):
+            fields["store_cache_modifiers"] = self.store_cache_modifiers
         if self.supports_config_key("num_threads"):
             fields["num_threads"] = self.num_threads
         if is_tileir:
@@ -1691,6 +1717,7 @@ class ConfigSpec:
             "static_ranges",
             "load_eviction_policies",
             "load_cache_modifiers",
+            "store_cache_modifiers",
             "indexing",
             "atomic_indexing",
         ):

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -256,6 +256,13 @@ def _(state: CodegenState) -> ast.AST:
                 epilogue_subtile_group_id
             ]
         strategy = device_fn.get_indexing_strategy(indexing_idx)
+        cache_modifier = None
+        if state.codegen.on_device:
+            modifier_idx = device_fn.device_store_cache_modifier_index
+            device_fn.device_store_cache_modifier_index += 1
+            modifiers = state.config.store_cache_modifiers
+            if modifier_idx < len(modifiers) and modifiers[modifier_idx]:
+                cache_modifier = ast.Constant(value=modifiers[modifier_idx])
 
         if state.codegen.store_transform is not None:
             return state.codegen.store_transform(
@@ -264,21 +271,33 @@ def _(state: CodegenState) -> ast.AST:
                 [*subscript],
                 value,
                 extra_mask,
+                cache_modifier,
                 strategy.codegen_store,
             )
 
-        return strategy.codegen_store(state, tensor, [*subscript], value, extra_mask)
+        return strategy.codegen_store(
+            state, tensor, [*subscript], value, extra_mask, cache_modifier
+        )
     if isinstance(tensor, tuple):
         from .._compiler.indexing_strategy import StackIndexingStrategy
 
         # Fusion is not supported for stack stores (multi-tensor device pointers);
         # fall through to the unfused path regardless of store_transform.
+        device_fn = state.device_function
+        device_fn.allocate_store_index()
+        cache_modifier = None
+        if state.codegen.on_device:
+            modifier_idx = device_fn.device_store_cache_modifier_index
+            device_fn.device_store_cache_modifier_index += 1
+            modifiers = state.config.store_cache_modifiers
+            if modifier_idx < len(modifiers) and modifiers[modifier_idx]:
+                cache_modifier = ast.Constant(value=modifiers[modifier_idx])
         stack_tensor_ast = state.ast_args[0]
         assert isinstance(stack_tensor_ast, tuple)
         assert len(stack_tensor_ast) == 2
         _tensor_like_ast, dev_ptrs_ast = stack_tensor_ast
         return StackIndexingStrategy.codegen_store(
-            state, tensor, dev_ptrs_ast, [*subscript], value, extra_mask
+            state, tensor, dev_ptrs_ast, [*subscript], value, extra_mask, cache_modifier
         )
     raise NotImplementedError(f"Cannot store to type: {type(tensor)}")
 
@@ -5999,7 +6018,9 @@ def _(state: CodegenState) -> ast.AST:
         indexing_idx = device_fn.device_memory_op_index
         device_fn.device_memory_op_index += 1
         strategy = device_fn.get_indexing_strategy(indexing_idx)
-        return strategy.codegen_store(state, tensor, [*subscript], value, extra_mask)
+        return strategy.codegen_store(
+            state, tensor, [*subscript], value, extra_mask, None
+        )
     raise exc.BackendUnsupported("metal", f"store target type: {type(tensor)}")
 
 

--- a/helion/runtime/config.py
+++ b/helion/runtime/config.py
@@ -18,6 +18,7 @@ PidTypeLiteral = Literal[
 ]
 EvictionPolicyLiteral = Literal["", "first", "last"]
 LoadCacheModifierLiteral = Literal["", ".cg"]
+StoreCacheModifierLiteral = Literal["", ".cs", ".wt"]
 NumSmMultiplierLiteral = Literal[1, 2, 4, 8]
 MaxnregLiteral = Literal[32, 64, 128, 256] | None
 
@@ -43,6 +44,7 @@ class Config(Mapping[str, object]):
         static_ranges: list[bool] | None = None,
         load_eviction_policies: list[EvictionPolicyLiteral] | None = None,
         load_cache_modifiers: list[LoadCacheModifierLiteral] | None = None,
+        store_cache_modifiers: list[StoreCacheModifierLiteral] | None = None,
         num_warps: int | None = None,
         num_stages: int | None = None,
         pid_type: PidTypeLiteral | None = None,
@@ -72,6 +74,7 @@ class Config(Mapping[str, object]):
             static_ranges: Whether to use tl.static_range instead tl.range.
             load_eviction_policies: Eviction policies for load operations ("", "first", "last").
             load_cache_modifiers: Cache modifiers for load operations ("", ".cg").
+            store_cache_modifiers: Cache modifiers for store operations ("", ".cs", ".wt").
             num_warps: Number of warps per block.
             num_stages: Number of stages for software pipelining.
             pid_type: Program ID type strategy ("flat", "xyz", "persistent_blocked", "persistent_interleaved").
@@ -111,6 +114,7 @@ class Config(Mapping[str, object]):
             "static_ranges": static_ranges,
             "load_eviction_policies": load_eviction_policies,
             "load_cache_modifiers": load_cache_modifiers,
+            "store_cache_modifiers": store_cache_modifiers,
             "num_warps": num_warps,
             "num_stages": num_stages,
             "indexing": indexing,
@@ -315,6 +319,13 @@ class Config(Mapping[str, object]):
         return cast(
             "list[LoadCacheModifierLiteral]",
             self.config.get("load_cache_modifiers", []),
+        )
+
+    @property
+    def store_cache_modifiers(self) -> list[StoreCacheModifierLiteral]:
+        return cast(
+            "list[StoreCacheModifierLiteral]",
+            self.config.get("store_cache_modifiers", []),
         )
 
     @property

--- a/test/test_cache_modifier.py
+++ b/test/test_cache_modifier.py
@@ -47,6 +47,32 @@ class TestCacheModifier(RefEagerTestBase, TestCase):
 
     @skipIfRefEager("Config spec inspection not applicable in ref eager mode")
     @skipIfTileIR("tileir backend will ignore `cache_modifier` hint")
+    def test_autotune_store_cache_modifier_registered_for_amd(self):
+        @helion.kernel
+        def kernel_with_stores(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out0 = torch.empty_like(x)
+            out1 = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                val = hl.load(x, [tile]) + hl.load(y, [tile])
+                hl.store(out0, [tile], val)
+                hl.store(out1, [tile], val)
+            return out0 + out1
+
+        x = torch.randn([128], device=DEVICE, dtype=torch.float32)
+        y = torch.randn([128], device=DEVICE, dtype=torch.float32)
+
+        with mock.patch(
+            "helion.autotuner.config_spec.supports_amd_cdna_tunables",
+            return_value=True,
+        ):
+            bound_kernel = kernel_with_stores.bind((x, y))
+
+        fragment = bound_kernel.config_spec.store_cache_modifiers
+        self.assertEqual(fragment.length, 2)
+        self.assertEqual(fragment.inner.choices, ("", ".cs", ".wt"))
+
+    @skipIfRefEager("Config spec inspection not applicable in ref eager mode")
+    @skipIfTileIR("tileir backend will ignore `cache_modifier` hint")
     def test_load_cache_modifier_not_registered_without_backend_choices(self):
         @helion.kernel
         def kernel_with_loads(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
@@ -97,6 +123,38 @@ class TestCacheModifier(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, x + y)
         self.assertIn("cache_modifier", code)
         self.assertIn(".cg", code)
+        self.assertNotIn("cache_modifier=''", code)
+
+    @skipIfTileIR("tileir backend will ignore `cache_modifier` hint")
+    def test_configured_store_cache_modifier_emitted(self):
+        @helion.kernel(
+            config={
+                "block_size": 16,
+                "indexing": "pointer",
+                "store_cache_modifiers": [".cs", ".wt"],
+            }
+        )
+        def kernel_with_configured_store_modifier(x: torch.Tensor) -> torch.Tensor:
+            out0 = torch.empty_like(x)
+            out1 = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                val = hl.load(x, [tile])
+                hl.store(out0, [tile], val)
+                hl.store(out1, [tile], val)
+            return out0 + out1
+
+        x = torch.randn([128], device=DEVICE, dtype=torch.float32)
+
+        with mock.patch(
+            "helion.autotuner.config_spec.supports_amd_cdna_tunables",
+            return_value=True,
+        ):
+            code, result = code_and_output(kernel_with_configured_store_modifier, (x,))
+
+        torch.testing.assert_close(result, x + x)
+        self.assertIn("cache_modifier", code)
+        self.assertIn(".cs", code)
+        self.assertIn(".wt", code)
         self.assertNotIn("cache_modifier=''", code)
 
     @skipIfTileIR("tileir backend will ignore `cache_modifier` hint")

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -86,6 +86,9 @@ def _known_keys_strategy() -> st.SearchStrategy[dict[str, Any]]:
                 st.sampled_from(["", "first", "last"]), max_size=4
             ),
             "load_cache_modifiers": st.lists(st.sampled_from(["", ".cg"]), max_size=4),
+            "store_cache_modifiers": st.lists(
+                st.sampled_from(["", ".cs", ".wt"]), max_size=4
+            ),
             "num_warps": st.integers(min_value=1, max_value=64),
             "num_stages": st.integers(min_value=1, max_value=16),
             "pid_type": st.sampled_from(
@@ -118,6 +121,7 @@ def _unknown_keys_strategy() -> st.SearchStrategy[dict[str, Any]]:
                     "static_ranges",
                     "load_eviction_policies",
                     "load_cache_modifiers",
+                    "store_cache_modifiers",
                     "num_warps",
                     "num_stages",
                     "pid_type",
@@ -179,6 +183,7 @@ class TestConfigAPI(TestCase):
             "static_ranges",
             "load_eviction_policies",
             "load_cache_modifiers",
+            "store_cache_modifiers",
             "num_warps",
             "num_stages",
             "pid_type",
@@ -753,6 +758,28 @@ class TestHardwareConfigSpecRanges(TestCase):
         ):
             nvidia_spec = ConfigSpec(backend=TritonBackend())
         self.assertEqual(nvidia_spec.load_cache_modifiers.inner.choices, ("",))
+
+    def test_store_cache_modifier_choices_do_not_leak_mocked_amd_state(self) -> None:
+        """Mocked AMD capability detection should not poison later Triton specs."""
+        from helion._compiler.backend import TritonBackend
+        from helion.autotuner.config_spec import ConfigSpec
+
+        with patch(
+            "helion.autotuner.config_spec.supports_amd_cdna_tunables",
+            return_value=True,
+        ):
+            amd_spec = ConfigSpec(backend=TritonBackend())
+        self.assertEqual(
+            amd_spec.store_cache_modifiers.inner.choices,
+            ("", ".cs", ".wt"),
+        )
+
+        with patch(
+            "helion.autotuner.config_spec.supports_amd_cdna_tunables",
+            return_value=False,
+        ):
+            nvidia_spec = ConfigSpec(backend=TritonBackend())
+        self.assertEqual(nvidia_spec.store_cache_modifiers.inner.choices, ("",))
 
 
 class TestCuteTcgen05ConfigSpecSplit(TestCase):


### PR DESCRIPTION
In #2712, we saw that enabling auto-tuning for cache_modifiers of `tl.load` was very useful for AMD. We also see that auto-tuning for store cache modifiers is also useful. Not as much as load_cache_modifiers, but it still makes an impact.

Similarly to load_cache_modifiers, we gate this only to AMD and also we only expose the following options:
* `""`: default
* `.cs`: cache streaming, avoid cache pollution for stores that are unlikely to be read again
* `.wt`: write through, write directly to L2 and bypass L1.


Here are some benchmarks for our RoPE kernel. default best mus measures microseconds when we fix store_cache_modifiers to default value -- best us is microseconds if we relax this:
| shape | default best us | best store mods | best us | speedup |
|:---|---:|:---|---:|---:|
| H8192_T1024 | 14.360 | [".wt", ".cs"] | 13.040 | 1.101x |
| H8192_T2048 | 22.960 | [".wt", ".wt"] | 21.640 | 1.061x |
| H8192_T4096 | 35.800 | [".wt", ".wt"] | 33.600 | 1.065x |
| H8192_T8192 | 93.921 | [".cs", ""] | 90.321 | 1.040x |
| H8192_T16384 | 129.921 | [".cs", ".wt"] | 122.921 | 1.057x |
| H512_T2048 | 8.200 | ["", ".cs"] | 8.040 | 1.020x |
| H2048_T2048 | 12.440 | [".wt", ".wt"] | 12.001 | 1.037x |