### PR TITLE
[Pallas] compact_worklist lowers the ordered inner loop via emit_pipeline

### DIFF
--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -254,10 +254,13 @@ def _(state: CodegenState) -> object:
     if pallas_loop_type == "fori_loop":
         return _codegen_fori_loop(state)
     if pallas_loop_type == "compact_worklist":
-        # The compacted tile becomes the grid (no loop); the ordered inner tile
-        # (fully jagged) and the single-iteration compact tile both lower through
-        # the fori path with begin/end remapped to metadata refs (see
-        # _compact_worklist_bounds).
+        # The compact tile becomes the grid (no loop).  The ordered inner tile
+        # (fully jagged carried reduction) lowers via emit_pipeline for
+        # pl.Buffered double-buffering; the single-iteration compact tile lowers
+        # through the fori path.  Both have begin/end remapped to metadata refs
+        # (see _compact_worklist_bounds).
+        if _is_compact_ordered_inner_loop(state):
+            return _codegen_emit_pipeline(state)
         return _codegen_fori_loop(state)
     # unroll: fall through to common codegen path
     # pyrefly: ignore[bad-return]
@@ -275,7 +278,13 @@ def _(state: CodegenState) -> None:
     if pallas_loop_type in ("fori_loop", "compact_worklist"):
         # Route compact_worklist through the same lowering as _for_loop so the
         # compact metadata (begin/end remap, synthetic compact tile) is applied
-        # rather than falling through to the common (non-compact) codegen.
+        # rather than falling through to the common (non-compact) codegen.  The
+        # ordered inner tile uses emit_pipeline for double-buffering.
+        if pallas_loop_type == "compact_worklist" and _is_compact_ordered_inner_loop(
+            state
+        ):
+            _codegen_emit_pipeline(state)
+            return None
         _codegen_fori_loop(state)
         return None
     # pyrefly: ignore[bad-return]
@@ -374,17 +383,20 @@ def _find_strategy(
     return strategy
 
 
-def _compact_worklist_bounds(
-    state: CodegenState, loop_dim_index: int
-) -> tuple[str, str] | None:
-    """Metadata-ref begin/end for a compact/ordered tile, else None."""
+def _compact_axis_kind(state: CodegenState, loop_dim_index: int) -> str | None:
+    """Classify a loop dim under ``compact_worklist`` as the compact tile, the
+    ordered inner (carried) tile, or neither.
+
+    Single source of truth shared by the loop-type dispatch
+    (:func:`_is_compact_ordered_inner_loop`) and the begin/end remap
+    (:func:`_compact_worklist_bounds`), so the two can never disagree on which
+    axis a loop is.
+    """
     env = CompileEnvironment.current()
     plan = env.compact_worklist_plan
     if plan is None:
         return None
     from .._compiler.device_ir import ForLoopGraphInfo
-    from .._compiler.pallas.compact_worklist import compact_ref_names
-    from .._compiler.pallas.compact_worklist import ordered_ref_names
 
     graph_info = state.get_graph(state.proxy_arg(0))
     if not isinstance(graph_info, ForLoopGraphInfo):
@@ -394,13 +406,47 @@ def _compact_worklist_bounds(
         return None
     block_id = block_ids[loop_dim_index]
     if block_id == plan.compact_axis.block_id:
-        begin_ref, extent_ref = (f"{n}_ref" for n in compact_ref_names(plan))
-        return f"{begin_ref}[_wid]", f"{begin_ref}[_wid] + {extent_ref}[_wid]"
+        return "compact"
     ordered = plan.ordered_axis
     if ordered is not None and block_id == ordered.block_id:
-        begin_ref, len_ref = (f"{n}_ref" for n in ordered_ref_names(plan))
-        return f"{begin_ref}[_wid]", f"{begin_ref}[_wid] + {len_ref}[_wid]"
+        return "ordered"
     return None
+
+
+def _is_compact_ordered_inner_loop(state: CodegenState) -> bool:
+    """True if this ``_for_loop`` is the compact-worklist ordered inner tile.
+
+    The ordered tile is the carried inner reduction (e.g. the KV loop in fully
+    jagged attention); it is the only compact-worklist loop routed to
+    ``_codegen_emit_pipeline`` (for ``pl.Buffered`` double-buffering).  The owner
+    grid and the single-iteration compact tile stay on the fori path.
+    """
+    from .._compiler.device_ir import ForLoopGraphInfo
+
+    graph_info = state.get_graph(state.proxy_arg(0))
+    if not isinstance(graph_info, ForLoopGraphInfo):
+        return False
+    return any(
+        _compact_axis_kind(state, i) == "ordered"
+        for i in range(len(graph_info.block_ids))
+    )
+
+
+def _compact_worklist_bounds(
+    state: CodegenState, loop_dim_index: int
+) -> tuple[str, str] | None:
+    """Metadata-ref begin/end for a compact/ordered tile, else None."""
+    kind = _compact_axis_kind(state, loop_dim_index)
+    if kind is None:
+        return None
+    from .._compiler.pallas.compact_worklist import compact_ref_names
+    from .._compiler.pallas.compact_worklist import ordered_ref_names
+
+    plan = CompileEnvironment.current().compact_worklist_plan
+    assert plan is not None
+    ref_names = compact_ref_names if kind == "compact" else ordered_ref_names
+    begin_ref, extent_ref = (f"{n}_ref" for n in ref_names(plan))
+    return f"{begin_ref}[_wid]", f"{begin_ref}[_wid] + {extent_ref}[_wid]"
 
 
 def _get_loop_begin_and_end(
@@ -413,9 +459,10 @@ def _get_loop_begin_and_end(
     ``tile_starts_ref[_wid]``, end =
     ``tile_starts_ref[_wid] + tile_extents_ref[_wid]`` (and likewise the ordered
     axis -> ``range_start_ref``/``range_len_ref``).  Every downstream consumer
-    (numel -> fori trip count, offset, masks) then composes unchanged, so
-    ``_codegen_fori_loop`` runs a single iteration for the compact tile
-    (``tile_extent <= BLOCK``).
+    (trip count, offset, masks) then composes unchanged: ``_codegen_fori_loop``
+    runs a single iteration for the compact tile (``tile_extent <= BLOCK``),
+    while the ordered axis -- lowered via ``_codegen_emit_pipeline`` -- uses the
+    same remapped bounds for its pipeline grid and per-iteration offsets.
     """
     remap = _compact_worklist_bounds(state, loop_dim_index)
     if remap is not None:
@@ -2697,7 +2744,8 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     # item, since the builder guarantees extent <= BLOCK), so emit the body
     # straight-line with the loop var bound to 0 -- no fori_loop wrapper (which
     # would add control-flow overhead and block pipelining for the common
-    # dense-KV case).  The ordered inner tile still lowers as a fori_loop.
+    # dense-KV case).  The ordered inner tile does not reach here: it lowers
+    # separately via emit_pipeline (see the _for_loop pallas dispatch).
     plan = CompileEnvironment.current().compact_worklist_plan
     is_compact_tile = (
         plan is not None

--- a/test/test_pallas_compact_worklist.py
+++ b/test/test_pallas_compact_worklist.py
@@ -865,13 +865,20 @@ class TestStreamingClassification(unittest.TestCase):
             helion.Config(block_sizes=[8, 8], pallas_loop_type="compact_worklist")
         )
 
+        # Ordered K/V stream from HBM via a nested emit_pipeline with double
+        # buffering -- reusing _pipeline_arg_indices, no new launcher API.
         self.assertIn("_pipeline_arg_indices=", code)
-        self.assertIn("pltpu.make_async_copy(k.at[pl.ds(kv_begin_ref[_wid]", code)
-        self.assertIn("pltpu.make_async_copy(v.at[pl.ds(kv_begin_ref[_wid]", code)
+        self.assertIn("pltpu.emit_pipeline(", code)
+        self.assertIn("pl.ds(kv_begin_ref[_wid]", code)
+        self.assertIn("pl.BoundedSlice(", code)
+        self.assertIn("pl.Buffered(buffer_count=2)", code)
         self.assertIn("_compact_aligned_arg_indices=", code)
-        self.assertNotIn("pltpu.make_async_copy(q.at", code)
-        self.assertNotIn("pltpu.make_async_copy(out.at", code)
-        self.assertNotIn("pl.multiple_of(kv_begin_ref[_wid]", code)
+        # The pipeline streams exactly the ordered K/V tensors (q/out are the
+        # compact tile -- aligned load / exact store -- and stay out of it).
+        self.assertIn(")(k, v)", code)
+        # No manual fori DMA, and the compact tile stays straight-line.
+        self.assertNotIn("pltpu.make_async_copy", code)
+        self.assertNotIn("lax.fori_loop", code)
 
     def test_dense_kv_owner_indexed_tensors_do_not_stream(self):
         qo = _offsets([12, 20, 5, 30])
@@ -888,6 +895,8 @@ class TestStreamingClassification(unittest.TestCase):
 
         self.assertNotIn("_pipeline_arg_indices=", code)
         self.assertNotIn("pltpu.make_async_copy", code)
+        # Dense-KV has no ordered axis, so no inner pipeline either.
+        self.assertNotIn("pltpu.emit_pipeline", code)
 
     def test_kv_owned_backward_shape_streams_ordered_q_like_loads(self):
         qo = _offsets([12, 20, 5, 30])
@@ -904,12 +913,16 @@ class TestStreamingClassification(unittest.TestCase):
             helion.Config(block_sizes=[8, 8], pallas_loop_type="compact_worklist")
         )
 
+        # Here the ordered axis is the q-like loop, so q and dO stream via the
+        # nested emit_pipeline; out is the compact exact-store and stays out.
         self.assertIn("_pipeline_arg_indices=", code)
-        self.assertIn("pltpu.make_async_copy(q.at[pl.ds(q_begin_ref[_wid]", code)
-        self.assertIn("pltpu.make_async_copy(dO.at[pl.ds(q_begin_ref[_wid]", code)
+        self.assertIn("pltpu.emit_pipeline(", code)
+        self.assertIn("pl.ds(q_begin_ref[_wid]", code)
+        self.assertIn("pl.Buffered(buffer_count=2)", code)
         self.assertIn("_compact_aligned_arg_indices=", code)
-        self.assertNotIn("pltpu.make_async_copy(out.at", code)
-        self.assertNotIn("pl.multiple_of(q_begin_ref[_wid]", code)
+        self.assertIn(")(q, dO)", code)
+        self.assertNotIn("pltpu.make_async_copy", code)
+        self.assertNotIn("lax.fori_loop", code)
 
 
 def _eager_dense_kv(q, k, v, qo):
@@ -1057,15 +1070,15 @@ class TestCompactWorklistNumerics(unittest.TestCase):
     """Device/interpret numerics for compact_worklist vs an eager ground truth.
 
     These are the device-side guards the host tests can't give: compact_worklist's
-    masked full-block ordered-overwrite store and its ordered inner ``fori`` loop
-    must reproduce the exact result of a plain per-sequence torch computation.
-    Runs on real TPU in CI and, via ``@skipUnlessPallas``, in pallas interpret
-    mode on CPU.
+    masked full-block ordered-overwrite store and its ordered inner loop (lowered
+    via ``emit_pipeline``) must reproduce the exact result of a plain per-sequence
+    torch computation.  Dense-KV (no ordered axis) runs in pallas interpret on
+    CPU; the fully-jagged ordered-loop cases are TPU-only (see per-test skips).
 
-    NB: the comparison is against an INDEPENDENT eager reference, not the
-    ``fori_loop`` lowering -- ``fori_loop`` miscompiles these jagged patterns in
-    interpret mode (verified: ~64.0 abs error vs eager), so it is not a sound
-    oracle here.  compact_worklist matches eager to float32 roundoff.
+    NB: the comparison is against an INDEPENDENT eager reference.  The ordered
+    inner loop's lowering miscompiles these jagged patterns in interpret mode
+    (verified: large abs error vs eager), so interpret is not a sound oracle for
+    it.  On real TPU, compact_worklist matches eager to bf16-matmul roundoff.
     """
 
     def test_dense_kv_unaligned_matches_eager(self):
@@ -1110,8 +1123,8 @@ class TestCompactWorklistNumerics(unittest.TestCase):
         self.assertEqual(tuple(out.shape), (0, H, D))
 
     @skipIfPallasInterpret(
-        "fori inner-loop (used by the ordered KV axis) miscompiles in pallas "
-        "interpret mode; this path is validated on real TPU"
+        "the ordered KV axis (emit_pipeline) miscompiles in pallas interpret "
+        "mode; this path is validated on real TPU"
     )
     def test_fully_jagged_with_empty_kv_matches_eager(self):
         # Ordered inner KV loop + an empty KV range (seq 2: kv_len==0) to exercise
@@ -1132,6 +1145,39 @@ class TestCompactWorklistNumerics(unittest.TestCase):
         )
         ref = _eager_fully_jagged(q.cpu(), k.cpu(), v.cpu(), qo, kvo)
         torch.testing.assert_close(out.cpu(), ref, rtol=2e-2, atol=2e-2)
+
+    @skipIfPallasInterpret(
+        "the ordered KV axis (emit_pipeline) miscompiles in pallas interpret "
+        "mode; this path is validated on real TPU"
+    )
+    def test_fully_jagged_long_kv_matches_eager(self):
+        # Long, jagged KV with several kvblock trips and non-divisible final
+        # tiles per sequence: exercises the double-buffered emit_pipeline
+        # accumulating carried state across many ordered iterations, with K/V
+        # streamed from HBM ([total_kv, H, D], D=128 lane-aligned).
+        #
+        # Compared by RELATIVE L2 (not element-wise assert_close): the long
+        # accumulation makes the output large-magnitude, so individual bf16
+        # elements drift O(1) in absolute terms and near-zero outputs blow up the
+        # pointwise rtol, while the normalized error stays at the bf16-matmul
+        # floor (~0.003).  A structural bug would be O(1) relative, not ~1e-3.
+        H, D, qblock, kvblock = 4, 128, 128, 64
+        qo = _offsets([130, 257, 64, 400])
+        kvo = _offsets([300, 191, 512, 33])  # 5/3/8/1 kvblock trips
+        lq, lkv = int(qo[-1]), int(kvo[-1])
+        torch.manual_seed(0)
+        q = torch.randn(lq, H, D, device=DEVICE, dtype=torch.bfloat16)
+        k = torch.randn(lkv, H, D, device=DEVICE, dtype=torch.bfloat16)
+        v = torch.randn(lkv, H, D, device=DEVICE, dtype=torch.bfloat16)
+        _, out = code_and_output(
+            _fully_jagged_kernel,
+            (q, k, v, qo.to(DEVICE), kvo.to(DEVICE)),
+            block_sizes=[qblock, kvblock],
+            pallas_loop_type="compact_worklist",
+        )
+        ref = _eager_fully_jagged(q.cpu(), k.cpu(), v.cpu(), qo, kvo).float()
+        rel_l2 = ((out.cpu().float() - ref).norm() / ref.norm()).item()
+        self.assertLess(rel_l2, 1e-2, f"relative L2 {rel_l2} exceeds 1e-2")
 
 
 @unittest.skipUnless(HAS_JAX, "jax not available")


### PR DESCRIPTION
Route the compact_worklist ordered inner loop (the carried KV reduction in fully-jagged attention) through `_codegen_emit_pipeline` instead of `_codegen_fori_loop`, so it gets `pl.Buffered(buffer_count=2)` double-buffered DMA instead of manual make_async_copy.

The dispatch is a small, local change: a shared `_compact_axis_kind()` classifier (used by both the dispatch and the existing _compact_worklist_bounds begin/end remap, so they can't disagree) and a `_is_compact_ordered_inner_loop()` predicate. Axes are either ordered or compact. Compact axes are flattened into the grid, only the ordered axis is re-routed.

We see substantial improvements in TFLOPs for long KV shapes, and no regressions for short KV

fully jagged gpda, long KV (q = kv len ~3000):

| Shape | dist | fori | emit_pipeline | speedup |
|:---|:---|---:|---:|---:|
| B=256 | uniform | 179.1 | 279.2 | 1.56× |
| B=256 | random | 138.9 | 211.4 | 1.52× |
| B=768 | uniform | 181.6 | 286.1 | 1.58× |
| B=768 | random | 141.5 | 218.6 | 1.55× |

jagged gpda, short KV (kv len = 512 < q len)

| Shape | dist | fori | emit_pipeline | speedup |
|:---|:---|---:|---:|---:|
| A (B=256) | uniform | 185.6 | 184.8 | 1.00× |
| A (B=256) | random | 112.9 | 113.3 | 1.00× |
| B (B=768) | uniform | 185.6 | 183.2 | 0.99× |
| B (B=768) | random | 110.7 | 111.2 | 1.00× |