### PR TITLE
[cute] Drop redundant leading sync_threads in tcgen05 store epilogue

### DIFF
--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -5496,8 +5496,20 @@ def _codegen_cute_store_tcgen05_tile(
                 sync_after_stmt,
             ]
     else:
+        # The matmul-loop suffix (`acc_pipeline.producer_commit` + advance)
+        # ends with a CTA-wide `cute.arch.sync_threads()` (the `sync_stmt`
+        # emitted in `_emit_mma_pipeline`), and only dead scalar epilogue
+        # ops + the acc-stage-index read sit between that barrier and this
+        # store block. A leading `sync_threads()` here is therefore a
+        # redundant back-to-back CTA barrier: the MMA->epi data dependency
+        # is carried by the acc_pipeline mbarrier (`consumer_wait` inside the
+        # store body), not by sync_threads, and the whole CTA already
+        # rendezvoused at the suffix barrier. Dropping it removes one of the
+        # per-tile CTA syncs that dominate the tiny-M barrier stall without
+        # weakening any ordering. The trailing `sync_threads()` is kept: it
+        # fences all epi warps' TMEM reads before the one-shot teardown frees
+        # the accumulator TMEM.
         store_body = [
-            "cute.arch.sync_threads()",
             *store_body_core,
             "cute.arch.sync_threads()",
         ]


### PR DESCRIPTION
Stacked PRs:
 * #2854
 * #2853
 * #2852
 * __->__#2851
 * #2845
 * #2844
 * #2843
 * #2840


--- --- ---

### [cute] Drop redundant leading sync_threads in tcgen05 store epilogue


The non-role-local tcgen05 store epilogue began with a CTA-wide
cute.arch.sync_threads() that was redundant: the MMA->epilogue data
dependency is carried by the acc_pipeline mbarrier (consumer_wait inside the
store body), not by the barrier. The trailing sync is kept (it fences epi-warp
TMEM reads before the one-shot teardown frees the accumulator TMEM).

Off the hot path (epilogue runs once per CTA, amortized over the 64-iter K
loop), so no measurable perf change, but it removes a needless full-block
barrier. Verified: 32 runs x 8 seeds deterministic at fp8 floor (relerr
1.66e-3), all rows correct, no-crash sweep static_m{16,32,64} x block_m{64,128}
x cluster_n{1,2}, cute test suite 557 passed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
