### PR TITLE
[cute] Vectorize padded-M aux (scale) load in tcgen05 store epilogue

### DIFF
--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -3825,6 +3825,44 @@ def _codegen_cute_store_tcgen05_tile(
             if rowvec_stage is None and (
                 safe_direct_aux_with_full_tile or not tcgen05_aux_use_tma_store_epilogue
             ):
+                if tcgen05_value.flat_m_edge:
+                    # Padded single-M-tile (block_m > real M, N divides bn): the
+                    # ``if full_tile`` fast path is statically dead (a full M tile
+                    # can never form) and the only out-of-bounds aux coordinate is
+                    # the M row, so the per-element 2-D ``elem_less`` scalar loop is
+                    # pure overhead. Mirror the leaner store path
+                    # (``tcgen05_value.flat_m_edge`` branch in the SIMT store) and
+                    # emit ONE vectorized ``logical_divide`` predicated copy with an
+                    # M-only row predicate. Same masking semantics (padded rows read
+                    # 0 and are dropped by the M-predicated store), far fewer scalar
+                    # ops / live registers on the streaming epilogue warps.
+                    include_coord_setup = not force_simt_edge_coord_emitted
+                    force_simt_edge_coord_emitted = True
+                    flat_edge_atom = df.new_var(f"{rec.aux_rmem}_edge_atom")
+                    lines.append(
+                        f"{prelude_indent}{flat_edge_atom} = "
+                        f"cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), "
+                        f"{rec.aux_dtype})\n"
+                        f"{prelude_indent}{rec.ttr_aux_subtile} = "
+                        f"{rec.ttr_aux_grouped}"
+                        f"[(None, None, None, cutlass.Int32(_tcgen05_subtile))]\n"
+                        f"{prelude_indent}{rec.aux_rmem} = "
+                        f"cute.make_rmem_tensor({rec.ttr_aux_subtile}.shape, "
+                        f"{rec.aux_dtype})\n"
+                        f"{prelude_indent}{rec.aux_rmem}.fill(0)\n"
+                        + _simt_edge_logical_divide_copy_source(
+                            prelude_indent,
+                            rec.ttr_aux_subtile,
+                            rec.aux_rmem,
+                            include_coord_setup=include_coord_setup,
+                            var_prefix=f"{rec.aux_rmem}_edge",
+                            copy_atom=flat_edge_atom,
+                            m_only_pred=True,
+                        )
+                        + f"{prelude_indent}{rec.aux_loaded} = "
+                        f"{rec.aux_rmem}.load()\n"
+                    )
+                    continue
                 lines.append(
                     f"{prelude_indent}{rec.ttr_aux_subtile} = "
                     f"{rec.ttr_aux_grouped}"


### PR DESCRIPTION
Stacked PRs:
 * #2854
 * #2853
 * __->__#2852
 * #2845
 * #2844
 * #2843
 * #2840


--- --- ---

### [cute] Vectorize padded-M aux (scale) load in tcgen05 store epilogue


The rowwise-scale epilogue was the dominant remaining cost for tiny-M fp8
GEMM, not the mainloop (pure matmul already streams at ~6.2 TB/s, at parity
with torch). On the padded single-M-tile SIMT-store path the per-row /
per-column scale (aux) operands were loaded via a statically-dead
`if full_tile: .load()` branch followed by a scalar per-element fallback:
`for _edge_i: if cute.elem_less(coord,(m,n)): aux[i]=src[i]`. That scalar
masked loop cost ~1.5us and inflated register pressure, capping DRAM streaming
density.

Fix (memory_ops.py `_aux_subtile_load_source`): for the `flat_m_edge` case
(padded single M tile, N divisible by bn) emit one vectorized logical_divide
predicated copy with an M-only row predicate (`coord[0] < m_size`) per aux,
exactly mirroring the leaner SIMT *store* that already uses the same
`flat_m_edge` + M-only-predicate path. N divides bn so the dropped N-predicate
term guarded nothing; padded rows read 0 and are discarded by the M-predicated
store, so masking semantics are identical.

Measured (B200, M=16 K=4096 N=14336, cluster_n=2 ab8, warm-L2 do_bench_wrapper):
14.71us/4.03 TB/s -> 12.86us/4.61 TB/s (1.14x; 0.69x -> 0.79x of torch).
NCU: DRAM cycles-active 30.0% -> 32.2%, identical 59.8M DRAM bytes.

Correctness: 25 runs x 8 seeds deterministic at fp8 floor (relerr 1.66e-3),
all rows correct, no zero rows/NaN, cute.nvgpu.tcgen05 present. cute test
suite 115 passed; no-crash sweep static_m{16,32,64} x block_m{64,128} x
cluster_n{1,2} all correct.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
