### PR TITLE
[cute] Coalesced TMA store for padded-M tcgen05 tiles with m_size>=32

### DIFF
--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -2506,6 +2506,42 @@ def _emit_mma_pipeline(
         or tcgen05_role_local_n_edge_tma
         or tcgen05_role_local_double_edge_tma
     ) and tcgen05_output_edge_tma_store_fits_smem
+    # Flat (cluster_m=1, non-persistent) tiny-M single padded tile: route the
+    # padded-M output store through the SAME coalesced SMEM-staged TMA bulk
+    # store the static-full flat path uses (T2R -> R2S into the C-ring SMEM ->
+    # ``cute.copy(CopyBulkTensorTileS2GOp, sD, gD)`` via PipelineTmaStore),
+    # instead of the uncoalesced per-thread register->global predicated SIMT
+    # store. The host TMA-store descriptor is built from the REAL output shape
+    # (``arg{d_idx}.shape``; see ``append_tcgen05_epilogue_tma_wrapper``), so the
+    # bulk store of the bm-row box at tile origin is HARDWARE bounds-clamped to
+    # the real ``m_size`` rows -- the partial M rows are never written OOB, with
+    # zero device-side row predicate. This is the exact OOB-suppression the
+    # ``tcgen05_partial_output_tma_store`` aux-TMA edge family already relies on
+    # (CuTe TMA descriptor bounds checks), applied to the no-aux flat tiny-M
+    # case. Gated to the single-padded-tile envelope (``m_size <= bm``, N%bn==0,
+    # K%bk==0, cluster_n in {1,2}, CtaGroup.ONE) where there is no genuine full
+    # M tile to regress, and to the same AB-stage SMEM budget as the role-local
+    # edge TMA store.
+    #
+    # SMEM budget: this flat one-CTA padded tile has the IDENTICAL epilogue SMEM
+    # footprint as the flat static-full path (same bm x bn block, same AB-stage
+    # count, same C-stage count, same ``make_smem_layout_epi`` D buffer), which
+    # is already validated at this shape and AB-stage count (the M=64 / M%bm==0
+    # case at the same block_sizes/ab_stages reaches the static-full TMA-store
+    # epilogue). The ``tcgen05_output_edge_tma_store_fits_smem`` cap is the
+    # 2-CTA output-edge family's separate, more constrained budget (extra D tile
+    # alongside larger 2-CTA AB stages) and does NOT bound this one-CTA path.
+    # Measured on B200: the SMEM-staged TMA-store epilogue beats the predicated
+    # SIMT register->global store for padded tiles with m_size >= 32 (it removes
+    # the uncoalesced SIMT stores whose count grows with real M), but its
+    # staging/pipeline setup is NOT amortized at the very smallest m_size=16,
+    # where the SIMT store is faster. Gate the TMA store on m_size >= 32 so the
+    # tiniest-M tile keeps the cheaper SIMT store.
+    tcgen05_flat_m_edge_tma_store = (
+        tcgen05_flat_m_edge_single_tile
+        and not tcgen05_is_two_cta
+        and m_size >= 32
+    )
     # Flat kernels process one output tile per CTA, so the c_pipeline stage is
     # just the subtile index. Persistent kernels use a role-local tile counter
     # to rotate c_pipeline stages across work tiles. Static-full CtaGroup.TWO
@@ -2521,6 +2557,7 @@ def _emit_mma_pipeline(
             tcgen05_static_full_tiles
             or tcgen05_role_local_k_tail_tma
             or tcgen05_use_output_edge_tma_store_for_full_tiles
+            or tcgen05_flat_m_edge_tma_store
         )
         and tcgen05_role_local_codegen_allowed
         and (not _is_persistent_pid_config(df.config) or tcgen05_use_role_local_epi)
@@ -3825,7 +3862,22 @@ def _emit_mma_pipeline(
                 # enabled for the output-edge family, which routes partial tiles
                 # through either the full/edge split or the bounds-checked
                 # partial-output TMA-store path.
-                tma_store_handles_partial_tiles = tcgen05_use_tma_store_epilogue
+                #
+                # The flat-M-edge TMA store (``tcgen05_flat_m_edge_tma_store``)
+                # is deliberately EXCLUDED here: it is validated only for the
+                # no-aux and SIMT-predicated-aux store paths (the aux M-row
+                # predicate in ``_codegen_cute_store_tcgen05_tile`` masks the
+                # padded rows of an exact-shape rank-2 aux read). Letting it set
+                # ``tma_store_handles_partial_tiles`` would suppress the
+                # ``aux_load_mode=tma`` + partial-output rejection below and
+                # silently route a TMA-staged aux through an uncovered combo.
+                # Keep that rejection firing exactly as on the SIMT-store
+                # baseline; the flat tiny-M store optimization does not depend on
+                # aux-TMA.
+                tma_store_handles_partial_tiles = (
+                    tcgen05_use_tma_store_epilogue
+                    and not tcgen05_flat_m_edge_tma_store
+                )
                 aux_tma_needs_edge_routing = (
                     tcgen05_aux_tma_requested
                     and not tcgen05_static_output_tiles

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -3822,47 +3822,72 @@ def _codegen_cute_store_tcgen05_tile(
                     f"{rec.aux_rmem}.load()\n"
                 )
                 continue
+            if rowvec_stage is None and tcgen05_value.flat_m_edge:
+                # Padded single-M-tile (block_m > real M, N divides bn): the
+                # ``if full_tile`` fast path is statically dead (a full M tile
+                # can never form) and the only out-of-bounds aux coordinate is
+                # the M row, so the per-element 2-D ``elem_less`` scalar loop is
+                # pure overhead. Mirror the leaner store path
+                # (``tcgen05_value.flat_m_edge`` branch in the SIMT store) and
+                # emit ONE vectorized ``logical_divide`` predicated copy with an
+                # M-only row predicate. Same masking semantics (padded rows read
+                # 0 and are dropped by the M-clamped store), far fewer scalar
+                # ops / live registers on the streaming epilogue warps.
+                #
+                # This M-row predicate is MANDATORY for the padded tile
+                # regardless of the output store mechanism: an exact-shape rank-2
+                # aux (e.g. ``scale_a[m, n]``) is allocated with only the real M
+                # rows, so an unpredicated direct ``ttr_aux_subtile.load()`` of
+                # the bm-row padded tile reads aux rows ``m_size..bm-1`` OUT OF
+                # BOUNDS. The SIMT-store path reached this branch via
+                # ``not use_tma_store_epilogue``; the flat-M-edge TMA-store path
+                # (where ``use_tma_store_epilogue`` is now True but there is no
+                # aux-TMA producer, so ``safe_direct_aux_with_full_tile`` is
+                # False) MUST take the same predicated read -- gating it on the
+                # store epilogue would fall through to the OOB direct load.
+                include_coord_setup = not force_simt_edge_coord_emitted
+                force_simt_edge_coord_emitted = True
+                flat_edge_atom = df.new_var(f"{rec.aux_rmem}_edge_atom")
+                # Size the predicated-copy destination to the CARRIER layout, not
+                # the raw ``ttr_aux_subtile`` layout. In the SIMT-store path the
+                # carrier (``ttr_racc``) and ``ttr_aux_subtile`` share the flat
+                # T2R value layout, so this is byte-identical to the prior
+                # ``ttr_aux_subtile.shape`` form. In the flat-M-edge TMA-store
+                # path the carrier is the R2S-retiled ``trs_racc`` (the aux
+                # partition is retiled via ``retile_for_r2s``), so the chain step
+                # ``acc_loaded * aux_loaded`` must see matching value profiles --
+                # building ``aux_rmem`` against the carrier shape keeps
+                # ``aux_loaded`` shaped like ``carrier.load()``. The predicated
+                # ``logical_divide(..., make_layout(1))`` copy is over the
+                # flattened value mode, so it stays valid as long as the total
+                # element counts match (they do: same per-thread T2R fragment).
+                lines.append(
+                    f"{prelude_indent}{flat_edge_atom} = "
+                    f"cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), "
+                    f"{rec.aux_dtype})\n"
+                    f"{prelude_indent}{rec.ttr_aux_subtile} = "
+                    f"{rec.ttr_aux_grouped}"
+                    f"[(None, None, None, cutlass.Int32(_tcgen05_subtile))]\n"
+                    f"{prelude_indent}{rec.aux_rmem} = "
+                    f"cute.make_rmem_tensor(cute.make_layout({carrier_name}.shape), "
+                    f"{rec.aux_dtype})\n"
+                    f"{prelude_indent}{rec.aux_rmem}.fill(0)\n"
+                    + _simt_edge_logical_divide_copy_source(
+                        prelude_indent,
+                        rec.ttr_aux_subtile,
+                        rec.aux_rmem,
+                        include_coord_setup=include_coord_setup,
+                        var_prefix=f"{rec.aux_rmem}_edge",
+                        copy_atom=flat_edge_atom,
+                        m_only_pred=True,
+                    )
+                    + f"{prelude_indent}{rec.aux_loaded} = "
+                    f"{rec.aux_rmem}.load()\n"
+                )
+                continue
             if rowvec_stage is None and (
                 safe_direct_aux_with_full_tile or not tcgen05_aux_use_tma_store_epilogue
             ):
-                if tcgen05_value.flat_m_edge:
-                    # Padded single-M-tile (block_m > real M, N divides bn): the
-                    # ``if full_tile`` fast path is statically dead (a full M tile
-                    # can never form) and the only out-of-bounds aux coordinate is
-                    # the M row, so the per-element 2-D ``elem_less`` scalar loop is
-                    # pure overhead. Mirror the leaner store path
-                    # (``tcgen05_value.flat_m_edge`` branch in the SIMT store) and
-                    # emit ONE vectorized ``logical_divide`` predicated copy with an
-                    # M-only row predicate. Same masking semantics (padded rows read
-                    # 0 and are dropped by the M-predicated store), far fewer scalar
-                    # ops / live registers on the streaming epilogue warps.
-                    include_coord_setup = not force_simt_edge_coord_emitted
-                    force_simt_edge_coord_emitted = True
-                    flat_edge_atom = df.new_var(f"{rec.aux_rmem}_edge_atom")
-                    lines.append(
-                        f"{prelude_indent}{flat_edge_atom} = "
-                        f"cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), "
-                        f"{rec.aux_dtype})\n"
-                        f"{prelude_indent}{rec.ttr_aux_subtile} = "
-                        f"{rec.ttr_aux_grouped}"
-                        f"[(None, None, None, cutlass.Int32(_tcgen05_subtile))]\n"
-                        f"{prelude_indent}{rec.aux_rmem} = "
-                        f"cute.make_rmem_tensor({rec.ttr_aux_subtile}.shape, "
-                        f"{rec.aux_dtype})\n"
-                        f"{prelude_indent}{rec.aux_rmem}.fill(0)\n"
-                        + _simt_edge_logical_divide_copy_source(
-                            prelude_indent,
-                            rec.ttr_aux_subtile,
-                            rec.aux_rmem,
-                            include_coord_setup=include_coord_setup,
-                            var_prefix=f"{rec.aux_rmem}_edge",
-                            copy_atom=flat_edge_atom,
-                            m_only_pred=True,
-                        )
-                        + f"{prelude_indent}{rec.aux_loaded} = "
-                        f"{rec.aux_rmem}.load()\n"
-                    )
-                    continue
                 lines.append(
                     f"{prelude_indent}{rec.ttr_aux_subtile} = "
                     f"{rec.ttr_aux_grouped}"


### PR DESCRIPTION
Stacked PRs:
 * #2854
 * __->__#2853
 * #2852
 * #2845
 * #2844
 * #2843
 * #2840


--- --- ---

### [cute] Coalesced TMA store for padded-M tcgen05 tiles with m_size>=32


The padded-M (flat_m_edge) output store used a predicated register->global
SIMT copy (CopyR2GOp). NCU showed it stores at 25% coalescing (8/32 bytes per
sector) with a SIMT store count that grows linearly with real M, whereas the
static-full M=64 path stores via a fully-coalesced SMEM-staged TMA bulk store
(PipelineTmaStore, zero SIMT stores, M-independent). That uncoalesced store was
the dominant tiny-M epilogue inefficiency and the source of the latency growth
with real M.

Route the flat single-padded-tile store (m_size <= bm, cluster_m=1, not 2-CTA)
through the same SMEM-staged TMA bulk store the static-full path uses:
T2R -> R2S into the C-ring SMEM -> cute.copy(CopyBulkTensorTileS2GOp). The host
TMA-store descriptor is built from the real output shape, so the bm-row box is
hardware bounds-clamped to the real m_size rows -- no OOB write, no device-side
M predicate needed on the store. The rowwise-scale aux load DOES still need its
M-row predicate (hoisted so it fires regardless of store mechanism; without it
the TMA path read aux rows m_size..bm-1 -> illegal access).

Gated to m_size >= 32: measured on B200, the TMA store beats SIMT for m_size in
{32,48} (removes the M-growing uncoalesced stores) but its staging/pipeline
setup is not amortized at m_size=16, where SIMT is faster. So m_size=16 keeps
the SIMT store, m_size in [32,bm] uses the TMA store -- each at its optimum.

Measured (B200, K=4096 N=14336, cluster_n=2 ab8, warm-L2 do_bench_wrapper),
helion vs torch._scaled_mm:
  M=16: 11.90us (unchanged, SIMT path) 0.81x
  M=32: 12.66 -> 11.73us  0.81x
  M=48: 13.35 -> 11.76us  0.82x
  M=64:  9.24us (unchanged, already TMA) 1.05x
NCU (M=32): SIMT global store sectors -> 0, M-growth flattened.

Correctness: per-row relerr fp8 floor for all real M rows, M in {16,32,48,64} x
block_m {64,128} x cluster_n {1,2}, identity + non-trivial scales; output
bit-identical to baseline; guard-row check confirms no OOB write beyond m_size;
20-run deterministic; cute.nvgpu.tcgen05 present. cute test suite 115 passed;
no-crash sweep static_m {16,32,48,64,80} all correct.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
