### PR TITLE
Add Vertex AI provider for LLM-guided autotuning

### DIFF
--- a/docs/api/autotuner.md
+++ b/docs/api/autotuner.md
@@ -4,6 +4,16 @@ The `helion.autotuner` module provides automatic optimization of kernel configur
 
 Autotuning effort can be adjusted via :attr:`helion.Settings.autotune_effort`, which configures how much each algorithm explores (``"none"`` disables autotuning, ``"quick"`` runs a smaller search, ``"full"`` uses the full search budget). Users may still override individual autotuning parameters if they need finer control.
 
+```{note}
+**Guard your entry script with `if __name__ == "__main__":`.** By default Helion
+benchmarks (and may precompile) candidate configs in a *spawned* subprocess,
+which re-imports your entry module. If the top-level kernel call is not under an
+`if __name__ == "__main__":` guard, the worker re-runs it on import and
+autotuning aborts with `NoConfigFound` (often with `failed to send job to
+worker`). Either add the guard, or set `HELION_AUTOTUNE_BENCHMARK_SUBPROCESS=0`
+to benchmark in-process.
+```
+
 ```{eval-rst}
 .. currentmodule:: helion.autotuner
 
@@ -70,10 +80,13 @@ across multiple refinement rounds.
 
 | Variable | Default | Description |
 |---|---|---|
-| `HELION_LLM_PROVIDER` | | LLM provider: `anthropic` or `openai` |
+| `HELION_LLM_PROVIDER` | | LLM provider: `anthropic`, `openai`, `bedrock`, or `vertex` |
 | `HELION_LLM_MODEL` | | Model name (e.g. `claude-opus-4-7`, `gpt-4o`) |
-| `HELION_LLM_API_KEY` | | API key (falls back to `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`) |
+| `HELION_LLM_API_KEY` | | API key (falls back to `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`). Optional for `vertex`/`bedrock`, which authenticate by client identity. |
 | `HELION_LLM_API_BASE` | | Custom API base URL |
+| `HELION_LLM_VERTEX_PROJECT` | | Cloud project id for the `vertex` provider (falls back to `ANTHROPIC_VERTEX_PROJECT_ID`) |
+| `HELION_LLM_VERTEX_LOCATION` | `global` | Vertex AI location for the `vertex` provider (falls back to `CLOUD_ML_REGION`) |
+| `HELION_LLM_EXTRA_HEADERS` | | Extra HTTP headers as a JSON object or newline-separated `Header: value` lines (for gateways that require custom routing/identity headers) |
 | `HELION_LLM_COMPILE_TIMEOUT_S` | `15` | Compile timeout (seconds) for LLM-proposed configs |
 | `HELION_LLM_CA_BUNDLE` | | Custom CA bundle path (for corporate proxies that do TLS inspection) |
 | `HELION_LLM_CLIENT_CERT` | | Client certificate path (for proxies requiring mutual TLS) |
@@ -81,6 +94,26 @@ across multiple refinement rounds.
 
 The proxy/TLS variables are only needed in corporate environments where a proxy intercepts
 HTTPS traffic. Most users connecting directly to the LLM API can ignore them.
+
+The `vertex` provider talks to Anthropic models hosted on Google
+[Vertex AI](https://docs.anthropic.com/en/api/claude-on-vertex-ai) (the publisher
+`rawPredict` endpoint). It is the analog of `bedrock`: the model is named in the
+URL and authentication is by client identity (a bearer token via
+`HELION_LLM_API_KEY`, and/or mTLS via the client-cert variables), so it also
+works behind an API-compatible gateway. The endpoint, project, and location each
+fall back to the standard Anthropic-on-Vertex SDK variables
+(`ANTHROPIC_VERTEX_BASE_URL`, `ANTHROPIC_VERTEX_PROJECT_ID`, `CLOUD_ML_REGION`)
+when the helion-specific knob is unset, so an environment already configured for
+Anthropic-on-Vertex needs only `HELION_LLM_PROVIDER=vertex` and a model. Example:
+
+```bash
+export HELION_AUTOTUNER=LLMGuidedSearch
+export HELION_LLM_PROVIDER=vertex
+export HELION_LLM_MODEL=claude-sonnet-4-5
+export HELION_LLM_API_BASE=https://<your-vertex-endpoint>/v1
+export HELION_LLM_VERTEX_PROJECT=<your-project>
+export HELION_LLM_VERTEX_LOCATION=us-east5  # optional, default: global
+```
 
 ### LLM-Seeded Search (Hybrid)
 

--- a/helion/autotuner/llm/transport.py
+++ b/helion/autotuner/llm/transport.py
@@ -57,6 +57,10 @@ _PROVIDER_ALIASES = {
     "bedrock": "bedrock",
     "aws_bedrock": "bedrock",
     "aws-bedrock": "bedrock",
+    "vertex": "vertex",
+    "vertex_anthropic": "vertex",
+    "vertex-anthropic": "vertex",
+    "google_vertex": "vertex",
 }
 
 
@@ -67,7 +71,7 @@ def normalize_provider(provider: str) -> str:
         return resolved
     raise ValueError(
         f"Unsupported LLM provider {provider!r}. "
-        "Valid providers are: anthropic, openai, openai_responses, bedrock."
+        "Valid providers are: anthropic, openai, openai_responses, bedrock, vertex."
     )
 
 
@@ -76,12 +80,13 @@ def infer_provider(model: str, provider: str | None = None) -> str:
     if provider is not None:
         return normalize_provider(provider)
     normalized = model.lower()
-    # Bedrock must be opted into explicitly with a `bedrock/` prefix (e.g.
-    # `bedrock/us.anthropic.claude-sonnet-4-6`), or via HELION_LLM_PROVIDER=bedrock.
-    # A bare region-prefixed id like `us.anthropic.claude-...` is NOT auto-routed
-    # to Bedrock, since the same model string can be served by the direct API.
+    # Bedrock and Vertex serve the same Anthropic model ids as the direct API, so
+    # they must be opted into explicitly with a `bedrock/` / `vertex/` prefix
+    # (e.g. `vertex/claude-sonnet-4-5`) or via HELION_LLM_PROVIDER.
     if normalized.startswith("bedrock/"):
         return "bedrock"
+    if normalized.startswith("vertex/"):
+        return "vertex"
     if normalized.startswith(("claude", "anthropic/")):
         return "anthropic"
     if normalized.startswith(
@@ -93,7 +98,7 @@ def infer_provider(model: str, provider: str | None = None) -> str:
 
 def strip_provider_prefix(model: str) -> str:
     """Remove a provider prefix before sending the model name to the API."""
-    for prefix in ("anthropic/", "openai/", "bedrock/"):
+    for prefix in ("anthropic/", "openai/", "bedrock/", "vertex/"):
         if model.startswith(prefix):
             return model.removeprefix(prefix)
     return model
@@ -523,6 +528,29 @@ def _load_json_response(
         return json.load(response)
 
 
+def _extra_headers() -> dict[str, str]:
+    """Optional extra HTTP headers for gateways/proxies that require them.
+
+    Read from ``HELION_LLM_EXTRA_HEADERS`` as either a JSON object
+    (``{"X-Header": "value"}``) or newline-separated ``Header: value`` lines.
+    Useful when an API-compatible gateway needs custom routing/identity headers
+    on top of the standard auth headers.
+    """
+    raw = os.environ.get("HELION_LLM_EXTRA_HEADERS")
+    if not raw:
+        return {}
+    raw = raw.strip()
+    if raw.startswith("{"):
+        parsed = json.loads(raw)
+        return {str(k): str(v) for k, v in parsed.items()}
+    headers: dict[str, str] = {}
+    for line in raw.splitlines():
+        if ":" in line:
+            name, value = line.split(":", 1)
+            headers[name.strip()] = value.strip()
+    return headers
+
+
 def _post_json(
     url: str,
     payload: dict[str, Any],
@@ -534,7 +562,7 @@ def _post_json(
     request = urllib_request.Request(
         url=url,
         data=json.dumps(payload).encode("utf-8"),
-        headers=headers,
+        headers={**headers, **_extra_headers()},
         method="POST",
     )
     try:
@@ -634,6 +662,88 @@ def _call_bedrock(
     return extract_anthropic_text(body)
 
 
+# Anthropic-on-Vertex-AI names the model in the URL (not the body) and requires
+# this version string in the request body, mirroring the Bedrock convention.
+_VERTEX_ANTHROPIC_VERSION = "vertex-2023-10-16"
+_DEFAULT_VERTEX_LOCATION = "global"
+
+
+def _call_vertex(
+    *,
+    model: str,
+    api_base: str | None,
+    api_key: str | None,
+    messages: list[dict[str, str]],
+    max_output_tokens: int,
+    request_timeout_s: float,
+    effort_level: str | None,
+    fast_mode: bool,
+) -> str:
+    """Invoke Anthropic-on-Vertex-AI over HTTPS, reusing the Anthropic codecs.
+
+    Vertex AI hosts Anthropic models under the publisher ``rawPredict`` endpoint.
+    The request body is the same Anthropic Messages payload used by the direct
+    API, but the model is named in the URL (not the body) and a Vertex
+    ``anthropic_version`` replaces it. Auth is carried by the SSL context (mTLS)
+    and/or an ``Authorization: Bearer`` token, so an API key is optional --
+    useful behind a gateway that authenticates the caller by client identity.
+
+    Configure with ``HELION_LLM_PROVIDER=vertex``, ``HELION_LLM_API_BASE`` (the
+    endpoint base), ``HELION_LLM_VERTEX_PROJECT`` (project id), and optionally
+    ``HELION_LLM_VERTEX_LOCATION`` (default ``global``). Each falls back to the
+    standard Anthropic-on-Vertex SDK variable when its helion-specific knob is
+    unset: ``ANTHROPIC_VERTEX_BASE_URL``, ``ANTHROPIC_VERTEX_PROJECT_ID``, and
+    ``CLOUD_ML_REGION`` respectively -- so an environment already set up for
+    Anthropic-on-Vertex needs only ``HELION_LLM_PROVIDER=vertex`` and a model.
+
+    Request/response format follows the Anthropic-on-Vertex reference:
+    https://docs.anthropic.com/en/api/claude-on-vertex-ai
+    """
+    # Resolve endpoint/project/location from helion's own knobs first, then fall
+    # back to the standard Anthropic-on-Vertex SDK variables so an environment
+    # already configured for Anthropic-on-Vertex works without extra setup.
+    base = (
+        api_base
+        or os.environ.get("HELION_LLM_API_BASE")
+        or os.environ.get("ANTHROPIC_VERTEX_BASE_URL")
+    )
+    if not base:
+        raise RuntimeError(
+            "Vertex provider requires the endpoint base URL via api_base, "
+            "HELION_LLM_API_BASE, or ANTHROPIC_VERTEX_BASE_URL."
+        )
+    project = os.environ.get("HELION_LLM_VERTEX_PROJECT") or os.environ.get(
+        "ANTHROPIC_VERTEX_PROJECT_ID"
+    )
+    if not project:
+        raise RuntimeError(
+            "Vertex provider requires the project id via "
+            "HELION_LLM_VERTEX_PROJECT or ANTHROPIC_VERTEX_PROJECT_ID."
+        )
+    location = (
+        os.environ.get("HELION_LLM_VERTEX_LOCATION")
+        or os.environ.get("CLOUD_ML_REGION")
+        or _DEFAULT_VERTEX_LOCATION
+    )
+    named_model = strip_provider_prefix(model)
+    url = (
+        f"{base.rstrip('/')}/projects/{project}/locations/{location}"
+        f"/publishers/anthropic/models/{named_model}:rawPredict"
+    )
+    payload = _anthropic_payload(
+        model, messages, max_output_tokens, effort_level, fast_mode
+    )
+    # The model is in the URL on Vertex; the body carries the version instead.
+    payload.pop("model", None)
+    payload["anthropic_version"] = _VERTEX_ANTHROPIC_VERSION
+    headers = {"content-type": "application/json"}
+    key = api_key or os.environ.get("HELION_LLM_API_KEY")
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    response = _post_json(url, payload, headers, request_timeout_s=request_timeout_s)
+    return extract_anthropic_text(response)
+
+
 def call_provider(
     provider: str,
     *,
@@ -648,6 +758,19 @@ def call_provider(
 ) -> str:
     """Resolve credentials, send one request, and extract text from the response."""
     normalized_provider = normalize_provider(provider)
+    if normalized_provider == "vertex":
+        # Vertex names the model in the URL and authenticates by SSL/bearer, so
+        # it bypasses the api-key-required _ProviderConfig path (like Bedrock).
+        return _call_vertex(
+            model=model,
+            api_base=api_base,
+            api_key=api_key,
+            messages=messages,
+            max_output_tokens=max_output_tokens,
+            request_timeout_s=request_timeout_s,
+            effort_level=effort_level,
+            fast_mode=fast_mode,
+        )
     if normalized_provider == "bedrock":
         # Bedrock uses boto3/SigV4 instead of an HTTP+api-key transport, so it
         # bypasses the _ProviderConfig path entirely.

--- a/test/test_llm_autotuner.py
+++ b/test/test_llm_autotuner.py
@@ -524,6 +524,106 @@ class TestLLMTransport(TestCase):
             return {"output": [{"content": [{"type": "text", "text": text}]}]}
         return {"content": [{"type": "text", "text": text}]}
 
+    def test_vertex_provider_request_shape(self):
+        """The vertex provider posts a model-less Anthropic body to the Vertex
+        publisher rawPredict URL, and extra headers parse from JSON / lines."""
+        from helion.autotuner.llm.transport import _extra_headers
+        from helion.autotuner.llm.transport import call_provider
+        from helion.autotuner.llm.transport import infer_provider
+        from helion.autotuner.llm.transport import normalize_provider
+
+        self.assertEqual(normalize_provider("vertex"), "vertex")
+        self.assertEqual(infer_provider("vertex/claude-sonnet-4-5"), "vertex")
+
+        captured = {}
+
+        def fake_post_json(url, payload, headers, *, request_timeout_s):
+            del request_timeout_s
+            captured.update(url=url, payload=payload, headers=headers)
+            return self._response_payload("anthropic")
+
+        env = {
+            "HELION_LLM_VERTEX_PROJECT": "proj-123",
+            "HELION_LLM_VERTEX_LOCATION": "us-east5",
+            "HELION_LLM_EXTRA_HEADERS": '{"X-Gateway": "abc"}',
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with patch(
+                "helion.autotuner.llm.transport._post_json",
+                side_effect=fake_post_json,
+            ):
+                text = call_provider(
+                    "vertex",
+                    model="vertex/claude-sonnet-4-5",
+                    api_base="https://gw.example/v1",
+                    api_key="tok",
+                    messages=[{"role": "user", "content": "suggest configs"}],
+                    max_output_tokens=256,
+                    request_timeout_s=60.0,
+                )
+            self.assertEqual(text, '{"configs": []}')
+            self.assertEqual(
+                captured["url"],
+                "https://gw.example/v1/projects/proj-123/locations/us-east5"
+                "/publishers/anthropic/models/claude-sonnet-4-5:rawPredict",
+            )
+            self.assertNotIn("model", captured["payload"])
+            self.assertEqual(
+                captured["payload"]["anthropic_version"], "vertex-2023-10-16"
+            )
+            self.assertEqual(captured["headers"]["Authorization"], "Bearer tok")
+            self.assertEqual(_extra_headers(), {"X-Gateway": "abc"})
+
+        with patch.dict(
+            os.environ,
+            {"HELION_LLM_EXTRA_HEADERS": "X-One: 1\nX-Two: two"},
+            clear=False,
+        ):
+            self.assertEqual(_extra_headers(), {"X-One": "1", "X-Two": "two"})
+
+    def test_vertex_provider_standard_env_fallback(self):
+        """With the helion-specific knobs unset, the vertex provider resolves the
+        endpoint/project/location from the standard Anthropic-on-Vertex SDK env
+        vars (so a pre-configured environment needs no extra setup)."""
+        from helion.autotuner.llm.transport import call_provider
+
+        captured = {}
+
+        def fake_post_json(url, payload, headers, *, request_timeout_s):
+            captured.update(url=url, payload=payload, headers=headers)
+            return self._response_payload("anthropic")
+
+        env = {
+            "ANTHROPIC_VERTEX_BASE_URL": "https://std.example/v1",
+            "ANTHROPIC_VERTEX_PROJECT_ID": "std-proj",
+            "CLOUD_ML_REGION": "global",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            for stale in (
+                "HELION_LLM_API_BASE",
+                "HELION_LLM_VERTEX_PROJECT",
+                "HELION_LLM_VERTEX_LOCATION",
+            ):
+                os.environ.pop(stale, None)
+            with patch(
+                "helion.autotuner.llm.transport._post_json",
+                side_effect=fake_post_json,
+            ):
+                call_provider(
+                    "vertex",
+                    model="vertex/claude-sonnet-4-5",
+                    api_base=None,
+                    api_key=None,
+                    messages=[{"role": "user", "content": "suggest configs"}],
+                    max_output_tokens=256,
+                    request_timeout_s=60.0,
+                )
+            self.assertEqual(
+                captured["url"],
+                "https://std.example/v1/projects/std-proj/locations/global"
+                "/publishers/anthropic/models/claude-sonnet-4-5:rawPredict",
+            )
+
     def test_transport_helpers_and_http_request_shapes(self):
         """Provider helpers build the expected request/response shapes for each backend."""
         from helion.autotuner.llm.transport import _resolve_api_base


### PR DESCRIPTION
LLM-guided autotuning (`HELION_AUTOTUNER=LLMGuidedSearch`) previously supported only the direct Anthropic/OpenAI APIs and AWS Bedrock. This adds a `vertex` provider for Anthropic models hosted on Google Vertex AI.

To use these paths, set these env vars (see P2393394484 if you are a meta employee):
```
export HELION_AUTOTUNER=LLMGuidedSearch          # or LLMSeededLFBOTreeSearch
export HELION_LLM_PROVIDER=vertex
export HELION_LLM_MODEL=claude-sonnet-4-6

export HELION_LLM_API_BASE= <your API base URL>
export HELION_LLM_VERTEX_PROJECT=<your vertex project name>
export HELION_LLM_VERTEX_LOCATION=global

export HELION_LLM_CLIENT_CERT= <path to .pem file>
export HELION_LLM_CLIENT_KEY=$HELION_LLM_CLIENT_CERT

export NO_PROXY=<gateway>,$NO_PROXY
```

And then run a kernel with `@helion.kernel(autotune_effort="full")`