### PR TITLE
Fix broadcast axis mapping for non-last tile dimensions

### DIFF
--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -891,21 +891,23 @@ expand_lowering = register_lowering(
 
 @expand_lowering.register_codegen("triton")
 def codegen_expand(ctx: LoweringContext, node: Node) -> object:
-    assert not node.kwargs, "getitem kwargs not supported"
+    assert not node.kwargs, "expand kwargs not supported"
     tensor, _ = map_arg(node.args, lambda arg: _env_arg(ctx, arg))
     assert isinstance(tensor, ast.AST)
     val = node.meta["val"]
     assert isinstance(val, torch.Tensor)
     shape = [*val.size()]
     # pyrefly: ignore [missing-attribute]
-    if node.args[0].meta["val"].ndim != len(shape):
-        broadcasting = [":"] * len(shape)
-        # pyrefly: ignore [missing-attribute]
-        for i in range(len(shape) - node.args[0].meta["val"].ndim):
-            broadcasting[i] = "None"
-        tensor = expr_from_string(
-            f"{{tensor}}[{', '.join(broadcasting)}]", tensor=tensor
+    input_val = node.args[0].meta["val"]
+    if input_val.ndim != len(shape):
+        tile_strategy = ctx.cg.device_function.tile_strategy
+        broadcasting = tile_strategy.broadcast_expand_dims(
+            tuple(input_val.shape), tuple(shape)
         )
+        if broadcasting:
+            tensor = expr_from_string(
+                f"{{tensor}}[{', '.join(broadcasting)}]", tensor=tensor
+            )
     shape_str = ctx.cg.device_function.tile_strategy.shape_str(shape)
     return expr_from_string(
         f"tl.broadcast_to({{tensor}}, {shape_str})",
@@ -921,14 +923,16 @@ def codegen_expand_pallas(ctx: LoweringContext, node: Node) -> object:
     assert isinstance(val, torch.Tensor)
     shape = [*val.size()]
     # pyrefly: ignore [missing-attribute]
-    if node.args[0].meta["val"].ndim != len(shape):
-        broadcasting = [":"] * len(shape)
-        # pyrefly: ignore [missing-attribute]
-        for i in range(len(shape) - node.args[0].meta["val"].ndim):
-            broadcasting[i] = "None"
-        tensor = expr_from_string(
-            f"{{tensor}}[{', '.join(broadcasting)}]", tensor=tensor
+    input_val = node.args[0].meta["val"]
+    if input_val.ndim != len(shape):
+        tile_strategy = ctx.cg.device_function.tile_strategy
+        broadcasting = tile_strategy.broadcast_expand_dims(
+            tuple(input_val.shape), tuple(shape)
         )
+        if broadcasting:
+            tensor = expr_from_string(
+                f"{{tensor}}[{', '.join(broadcasting)}]", tensor=tensor
+            )
     shape_str = ctx.cg.device_function.tile_strategy.shape_str(shape)
     return expr_from_string(
         f"jnp.broadcast_to({{tensor}}, {shape_str})",

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -389,16 +389,15 @@ class InductorLowering(Lowering):
             if isinstance(fake_val := n.meta["val"], torch.Tensor):
                 # Don't expand scalars (0-D tensors) - let Triton handle broadcasting naturally
                 # Expanding scalars with [None, None] creates incorrect broadcast shapes
-                if (
-                    ctx.cg.device_function.tile_strategy.supports_index_rank_expansion()
-                    and fake_val.ndim < ndim
-                    and fake_val.ndim > 0
-                ):
-                    # Broadcast to force ranks to match (but only for non-scalar tensors)
-                    expand = ["None"] * (ndim - fake_val.ndim) + [":"] * fake_val.ndim
-                    ast_val = expr_from_string(
-                        "{tensor}[" + ", ".join(expand) + "]", tensor=ast_val
+                if fake_val.ndim < ndim and fake_val.ndim > 0:
+                    expand = tile_strategy.broadcast_expand_dims(
+                        tuple(fake_val.shape), output_shape
                     )
+                    if expand:
+                        ast_val = expr_from_string(
+                            "{tensor}[" + ", ".join(expand) + "]",
+                            tensor=ast_val,
+                        )
             if (
                 isinstance(ast_val, ast.Name)
                 and ast_val.id in device_function._constexpr_args
@@ -415,7 +414,11 @@ class InductorLowering(Lowering):
                 input_asts.append(ast_val)
 
         device_function: DeviceFunction = ctx.cg.device_function
-        ndim: int = max([x.ndim for x in self.input_fake_tensors(node)] or (0,))
+        tile_strategy = device_function.tile_strategy
+        output_shape: tuple[int | torch.SymInt, ...] = tuple(
+            map(to_symint, self.buffer.get_size())
+        )
+        ndim: int = len(output_shape)
         input_asts: list[ast.AST] = []
         # _extra_deps should not be included in the inductor node inputs
         map_arg((node.args, {**node.kwargs, "_extra_deps": None}), visit)

--- a/helion/_compiler/tile_dispatch.py
+++ b/helion/_compiler/tile_dispatch.py
@@ -639,6 +639,83 @@ class TileStrategyDispatch:
 
         return "".join(parts)
 
+    def broadcast_expand_dims(
+        self,
+        input_shape: ShapeLike,
+        output_shape: ShapeLike,
+    ) -> list[str]:
+        """Return subscript list to broadcast input_shape into output_shape.
+
+        Examples:
+            (bid=0,)    -> (bid=0, bid=1)    => [":", "None"]
+            (bid=1,)    -> (bid=0, bid=1)    => ["None", ":"]
+            (bid=0, K)  -> (bid=0, bid=1, K) => [":", "None", ":"]
+        """
+        if not self.supports_index_rank_expansion():
+            return []
+        if len(input_shape) == 0 or len(input_shape) == len(output_shape):
+            return []
+
+        env = CompileEnvironment.current()
+        src_compacted = self._compact_shape(input_shape)
+        dst_compacted = self._compact_shape(output_shape)
+
+        # Map each source compacted dim to a destination compacted dim.
+        src_to_dst: list[int] = []
+        used_dst: set[int] = set()
+        for src_dim in src_compacted:
+            match: int | None = None
+            src_bids = [env.canonical_block_id(bid) for bid in src_dim.block_ids]
+            if src_bids:
+                # Tile dim: match by canonical block_id
+                for dst_i, dst_dim in enumerate(dst_compacted):
+                    if dst_i in used_dst:
+                        continue
+                    dst_bids = [
+                        env.canonical_block_id(bid) for bid in dst_dim.block_ids
+                    ]
+                    if src_bids == dst_bids:
+                        match = dst_i
+                        break
+            else:
+                # Non-tile dim: match by size using known_equal on the
+                # original (non-compacted) shape elements.
+                for dst_i, dst_dim in enumerate(dst_compacted):
+                    if dst_i in used_dst:
+                        continue
+                    if dst_dim.block_ids:
+                        continue
+                    if len(src_dim.user_indices) == len(dst_dim.user_indices):
+                        if all(
+                            env.known_equal(input_shape[si], output_shape[di])
+                            for si, di in zip(
+                                src_dim.user_indices,
+                                dst_dim.user_indices,
+                                strict=True,
+                            )
+                        ):
+                            match = dst_i
+                            break
+            if match is None:
+                # Fallback: right-align unmatched non-tile dims
+                for dst_i in range(len(dst_compacted) - 1, -1, -1):
+                    if dst_i not in used_dst:
+                        match = dst_i
+                        break
+            assert match is not None, (
+                f"Cannot map input dim (block_ids={src_dim.block_ids}, "
+                f"size={src_dim.size_str}) into output shape {output_shape} "
+                f"from input shape {input_shape}"
+            )
+            src_to_dst.append(match)
+            used_dst.add(match)
+
+        keep = set(src_to_dst)
+        result = [":" if i in keep else "None" for i in range(len(dst_compacted))]
+        if all(r == ":" for r in result):
+            return []
+        return result
+
     def expand_dims_str(self, shape: ShapeLike, start_idx: int, num_dims: int) -> str:
         """Generate expansion string for multi-dimensional tensor indexers.
 

--- a/test/test_broadcasting.py
+++ b/test/test_broadcasting.py
@@ -161,6 +161,90 @@ class TestBroadcasting(RefEagerTestBase, TestCase):
         code, out = code_and_output(fn, args, block_sizes=[16, 16])
         torch.testing.assert_close(out, expected)
 
+    @skipIfRefEager("ref-eager does not support non-last-dim implicit broadcast")
+    def test_implicit_broadcast_first_dim(self):
+        """b[tile0] in a 2D tile should broadcast as b[:, None]."""
+
+        @helion.kernel
+        def fn(a, b):
+            out = torch.empty_like(a)
+            for tile0, tile1 in hl.tile(a.size()):
+                out[tile0, tile1] = a[tile0, tile1] + b[tile0]
+            return out
+
+        args = (torch.randn(512, 512, device=DEVICE), torch.randn(512, device=DEVICE))
+        code, out = code_and_output(fn, args, block_sizes=[16, 16])
+        torch.testing.assert_close(out, args[0] + args[1][:, None])
+
+    @skipIfRefEager("ref-eager does not support non-last-dim implicit broadcast")
+    def test_implicit_broadcast_both_dims(self):
+        """row_bias[tile0] + col_scale[tile1] in same expression."""
+
+        @helion.kernel
+        def fn(a, row_bias, col_scale):
+            out = torch.empty_like(a)
+            for tile0, tile1 in hl.tile(a.size()):
+                out[tile0, tile1] = a[tile0, tile1] * col_scale[tile1] + row_bias[tile0]
+            return out
+
+        a = torch.randn(128, 256, device=DEVICE)
+        row_bias = torch.randn(128, device=DEVICE)
+        col_scale = torch.randn(256, device=DEVICE)
+        code, out = code_and_output(fn, (a, row_bias, col_scale), block_sizes=[64, 64])
+        torch.testing.assert_close(out, a * col_scale + row_bias[:, None])
+
+    @skipIfRefEager("ref-eager does not support non-last-dim implicit broadcast")
+    def test_implicit_broadcast_3d_middle_dim(self):
+        """b[tile1] in 3D tile should broadcast along the middle dimension."""
+
+        @helion.kernel
+        def fn(a, b):
+            out = torch.empty_like(a)
+            for tile0, tile1, tile2 in hl.tile(a.size()):
+                out[tile0, tile1, tile2] = a[tile0, tile1, tile2] + b[tile1]
+            return out
+
+        a = torch.randn(4, 32, 32, device=DEVICE)
+        b = torch.randn(32, device=DEVICE)
+        code, out = code_and_output(fn, (a, b), block_sizes=[4, 32, 32])
+        torch.testing.assert_close(out, a + b[None, :, None])
+
+    @skipIfRefEager("ref-eager does not support non-last-dim implicit broadcast")
+    @xfailIfPallas("scatter: only indirect dim 0 is supported")
+    def test_implicit_broadcast_mixed_tile_and_slice(self):
+        """b[tile0, 0:K] broadcast into a[tile0, tile1, 0:K]."""
+
+        @helion.kernel
+        def fn(a, b):
+            k = a.size(2)
+            out = torch.empty_like(a)
+            for tile0, tile1 in hl.tile([a.size(0), a.size(1)]):
+                out[tile0, tile1, 0:k] = a[tile0, tile1, 0:k] + b[tile0, 0:k]
+            return out
+
+        a = torch.randn(8, 16, 2, device=DEVICE)
+        b = torch.randn(8, 4, device=DEVICE)
+        code, out = code_and_output(fn, (a, b), block_sizes=[8, 16])
+        torch.testing.assert_close(out, a + b[:, 0:2].unsqueeze(1))
+
+    @skipIfRefEager("ref-eager does not support non-last-dim implicit broadcast")
+    def test_expand_as_first_dim(self):
+        """scale[tile0].expand_as(a) exercises codegen_expand path."""
+
+        @helion.kernel
+        def fn(a, scale):
+            out = torch.empty_like(a)
+            for tile0, tile1 in hl.tile(a.size()):
+                loaded = a[tile0, tile1]
+                s = scale[tile0].expand_as(loaded)
+                out[tile0, tile1] = loaded * s
+            return out
+
+        a = torch.randn(256, 128, device=DEVICE)
+        scale = torch.randn(256, device=DEVICE)
+        code, out = code_and_output(fn, (a, scale), block_sizes=[64, 64])
+        torch.testing.assert_close(out, a * scale[:, None])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

The codegen broadcast expansion used NumPy-style right-aligned
dimension prepending, which produced wrong results when a tensor
was indexed by a non-last tile dimension (e.g. scale[tile0] in a
2D tile loop generated scale[None, :] instead of scale[:, None]).

Add broadcast_expand_dims() to TileStrategyDispatch that matches
input dimensions to output dimensions by block_id via _compact_shape,
falling back to known_equal for non-tile dimensions. Update
InductorLowering.input_asts() and both codegen_expand variants to
use it instead of the naive prepend logic.
