### PR TITLE
[kernel-artifact-telemetry] CI: don't hardcode HELION_AUTOTUNE_LOG_DETAILS in benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -199,13 +199,14 @@ jobs:
             # Single inline pass (autotune + codegen + compile), so
             # --measure-compile-time is end-to-end. HELION_AUTOTUNE_LOG is
             # per-kernel (the sink appends, accumulating input shapes) and sits
-            # under $TEST_REPORTS_DIR, so its .csv/.log and the dataset .meta.jsonl
-            # ride out in the artifact. HELION_AUTOTUNE_LOG_DETAILS=1 opts into that
-            # .meta.jsonl (identity + configs keyed by config_id) inline.
+            # under $TEST_REPORTS_DIR, so its .csv/.log ride out in the
+            # artifact. The detailed dataset .meta.jsonl (identity + configs
+            # keyed by config_id) is opt-in via HELION_AUTOTUNE_LOG_DETAILS=1;
+            # set it manually when collecting the cost-model dataset. It is
+            # intentionally left off here to keep CI artifacts small.
             # --autotune-metrics-json: per-run summary, overwrite-safe.
             ${{ inputs.env-vars }} HELION_PRINT_OUTPUT_CODE=1 \
             HELION_AUTOTUNE_LOG="$TEST_REPORTS_DIR/autotune-$kernel" \
-            HELION_AUTOTUNE_LOG_DETAILS=1 \
             python benchmarks/run.py \
                 --op $kernel \
                 --helion-backend "${{ inputs.backend }}" \


### PR DESCRIPTION
## Summary

#2770 hardcoded `HELION_AUTOTUNE_LOG_DETAILS=1` in `.github/workflows/benchmark.yml`, so **every** benchmark CI job emits the heavy per-run dataset — `<base>.meta.jsonl`, which embeds the full generated kernel source plus a config map for every run. That's blowing up artifact storage on the CI server.

The detailed dataset is meant to be **opt-in / collected manually**, not on by default. This removes the hardcoded flag.

### Why this is sufficient (and safe)
- `autotune_log_details` defaults to `False` when `HELION_AUTOTUNE_LOG_DETAILS` is unset (`helion/runtime/settings.py:413`).
- The autotuner only collects the dataset when `autotune_log_details` is on (`base_search.py:520`), and the log sink only opens `<base>.meta.jsonl` when `collect_dataset` is true (`logger.py:372`) — so with the flag gone the file is never created.
- The lighter `.csv`/`.log` telemetry (gated by `HELION_AUTOTUNE_LOG`) is **unchanged**.
- Manual collection still works on demand by passing `HELION_AUTOTUNE_LOG_DETAILS=1` through the `benchmark_dispatch` `env_vars` input.

## Test plan
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/benchmark.yml'))"` — workflow YAML still parses.
- Verified no other CI source sets the flag: only the removed line was active; `inputs.env-vars` defaults to `""`; `benchmark_tpu.yml` never set it.
- A subsequent benchmark CI run should produce `autotune-<kernel>.csv`/`.log` but **no** `autotune-<kernel>.meta.jsonl` artifact.