### PR TITLE
Support Pallas segment reduction primitives

### DIFF
--- a/examples/segment_reduction.py
+++ b/examples/segment_reduction.py
@@ -15,13 +15,20 @@ Code based on https://github.com/pytorch/helion/issues/237
 from __future__ import annotations
 
 import torch
-import triton
-import triton.language as tl
 
 import helion
 from helion._testing import DEVICE
 from helion._testing import run_example
 import helion.language as hl
+
+try:
+    import triton
+    import triton.language as tl
+except ModuleNotFoundError as exc:
+    if exc.name not in {"triton", "triton.language"}:
+        raise
+    triton = None
+    tl = None
 
 # %%
 # Helion Implementation
@@ -98,119 +105,132 @@ def segmented_reduction_helion(
 
 
 # %%
-@triton.jit
-def combine_fn_triton(
-    left_values: tl.tensor,
-    left_indices: tl.tensor,
-    right_values: tl.tensor,
-    right_indices: tl.tensor,
-) -> tuple[tl.tensor, tl.tensor]:
-    """
-    Combine function for associative scan in Triton implementation.
+if triton is not None and tl is not None:
+    _HAS_TRITON = True
 
-    Adds values when indices match (same segment), otherwise takes the right value.
+    @triton.jit
+    def combine_fn_triton(
+        left_values: tl.tensor,
+        left_indices: tl.tensor,
+        right_values: tl.tensor,
+        right_indices: tl.tensor,
+    ) -> tuple[tl.tensor, tl.tensor]:
+        """
+        Combine function for associative scan in Triton implementation.
 
-    Args:
-        left_values: Values from the left side of the scan
-        left_indices: Indices from the left side of the scan
-        right_values: Values from the right side of the scan
-        right_indices: Indices from the right side of the scan
+        Adds values when indices match (same segment), otherwise takes the right value.
 
-    Returns:
-        Tuple of (combined_values, combined_indices)
-    """
-    same_segment = left_indices == right_indices
-    combined_values = tl.where(same_segment, left_values + right_values, right_values)
-    combined_indices = right_indices
-    return combined_values, combined_indices
+        Args:
+            left_values: Values from the left side of the scan
+            left_indices: Indices from the left side of the scan
+            right_values: Values from the right side of the scan
+            right_indices: Indices from the right side of the scan
 
-
-@triton.autotune(
-    configs=[
-        triton.Config(
-            {"BLOCK_SIZE": bs},
+        Returns:
+            Tuple of (combined_values, combined_indices)
+        """
+        same_segment = left_indices == right_indices
+        combined_values = tl.where(
+            same_segment, left_values + right_values, right_values
         )
-        for bs in [8, 16, 32, 64, 128]
-    ],
-    key=["C"],
-    restore_value=["out_ptr"],
-)
-@triton.jit
-def _segmented_reduction_triton(
-    index: tl.tensor,  # the input index tensor
-    in_ptr: tl.tensor,  # the input tensor
-    out_ptr: tl.tensor,  # the output value tensor
-    E: tl.constexpr,  # Number of elements in the input tensor (1d)
-    C: tl.constexpr,  # Number of features in the input tensor (2d)
-    BLOCK_SIZE: tl.constexpr,  # Block size for the scan
-) -> None:
-    """
-    Triton kernel for segmented reduction.
+        combined_indices = right_indices
+        return combined_values, combined_indices
 
-    Uses associative scan to efficiently perform segmented reduction.
-
-    Args:
-        index: Input index tensor
-        in_ptr: Input data tensor
-        out_ptr: Output tensor
-        E: Number of elements in the input tensor
-        C: Number of features in the input tensor
-        BLOCK_SIZE: Block size for the scan
-    """
-    # Triton version adapted from
-    # https://github.com/fishmingyu/GeoT/blob/main/geot/triton/seg_reduction.py
-    pid = tl.program_id(axis=0)
-    offset_pid = pid // C
-    feature_id = pid % C
-    offsets = offset_pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    mask = offsets < E
-
-    # Load input data
-    vals = tl.load(in_ptr + offsets * C + feature_id, mask=mask)
-    idxs = tl.load(index + offsets, mask=mask)
-    idxs_next = tl.load(index + offsets + 1, offsets < E - 1)
-
-    # Perform an inclusive scan using tl.associative_scan
-    result_values, _ = tl.associative_scan(
-        (
-            vals,
-            idxs,
-        ),
-        axis=0,
-        combine_fn=combine_fn_triton,
+    @triton.autotune(
+        configs=[
+            triton.Config(
+                {"BLOCK_SIZE": bs},
+            )
+            for bs in [8, 16, 32, 64, 128]
+        ],
+        key=["C"],
+        restore_value=["out_ptr"],
     )
-    # if offset % BLOCK_SIZE == -1, it means the last element of the segment
-    segment_start = (idxs != idxs_next) | (offsets % BLOCK_SIZE == BLOCK_SIZE - 1)
-    tl.atomic_add(out_ptr + idxs * C + feature_id, result_values, mask & segment_start)
+    @triton.jit
+    def _segmented_reduction_triton(
+        index: tl.tensor,  # the input index tensor
+        in_ptr: tl.tensor,  # the input tensor
+        out_ptr: tl.tensor,  # the output value tensor
+        E: tl.constexpr,  # Number of elements in the input tensor (1d)
+        C: tl.constexpr,  # Number of features in the input tensor (2d)
+        BLOCK_SIZE: tl.constexpr,  # Block size for the scan
+    ) -> None:
+        """
+        Triton kernel for segmented reduction.
 
+        Uses associative scan to efficiently perform segmented reduction.
 
-def segmented_reduction_triton(
-    indices: torch.Tensor, input_data: torch.Tensor, num_nodes: int
-) -> torch.Tensor:
-    """
-    Performs segmented reduction using Triton.
+        Args:
+            index: Input index tensor
+            in_ptr: Input data tensor
+            out_ptr: Output tensor
+            E: Number of elements in the input tensor
+            C: Number of features in the input tensor
+            BLOCK_SIZE: Block size for the scan
+        """
+        # Triton version adapted from
+        # https://github.com/fishmingyu/GeoT/blob/main/geot/triton/seg_reduction.py
+        pid = tl.program_id(axis=0)
+        offset_pid = pid // C
+        feature_id = pid % C
+        offsets = offset_pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < E
 
-    Wrapper function for the Triton kernel implementation.
+        # Load input data
+        vals = tl.load(in_ptr + offsets * C + feature_id, mask=mask)
+        idxs = tl.load(index + offsets, mask=mask)
+        idxs_next = tl.load(index + offsets + 1, offsets < E - 1)
 
-    Args:
-        indices: Tensor of segment indices for each element
-        input_data: Input tensor of shape [num_elements, num_features]
-        num_nodes: Number of output nodes/segments
+        # Perform an inclusive scan using tl.associative_scan
+        result_values, _ = tl.associative_scan(
+            (
+                vals,
+                idxs,
+            ),
+            axis=0,
+            combine_fn=combine_fn_triton,
+        )
+        # if offset % BLOCK_SIZE == -1, it means the last element of the segment
+        segment_start = (idxs != idxs_next) | (offsets % BLOCK_SIZE == BLOCK_SIZE - 1)
+        tl.atomic_add(
+            out_ptr + idxs * C + feature_id, result_values, mask & segment_start
+        )
 
-    Returns:
-        Output tensor of shape [num_nodes, num_features] with reduced values
-    """
-    E, C = input_data.shape
-    output = torch.zeros(
-        (num_nodes, C), dtype=input_data.dtype, device=input_data.device
-    )
+    def segmented_reduction_triton(
+        indices: torch.Tensor, input_data: torch.Tensor, num_nodes: int
+    ) -> torch.Tensor:
+        """
+        Performs segmented reduction using Triton.
 
-    def grid(META: dict[str, int]) -> tuple[int, ...]:
-        # Cast to int to satisfy type checker; Triton may return constexpr
-        return (int(triton.cdiv(E, META["BLOCK_SIZE"]) * C),)
+        Wrapper function for the Triton kernel implementation.
 
-    _segmented_reduction_triton[grid](indices, input_data, output, E, C)
-    return output
+        Args:
+            indices: Tensor of segment indices for each element
+            input_data: Input tensor of shape [num_elements, num_features]
+            num_nodes: Number of output nodes/segments
+
+        Returns:
+            Output tensor of shape [num_nodes, num_features] with reduced values
+        """
+        E, C = input_data.shape
+        output = torch.zeros(
+            (num_nodes, C), dtype=input_data.dtype, device=input_data.device
+        )
+
+        def grid(META: dict[str, int]) -> tuple[int, ...]:
+            # Cast to int to satisfy type checker; Triton may return constexpr
+            return (int(triton.cdiv(E, META["BLOCK_SIZE"]) * C),)
+
+        _segmented_reduction_triton[grid](indices, input_data, output, E, C)
+        return output
+
+else:
+    _HAS_TRITON = False
+
+    def segmented_reduction_triton(
+        indices: torch.Tensor, input_data: torch.Tensor, num_nodes: int
+    ) -> torch.Tensor:
+        raise RuntimeError("Triton is required for the Triton reference")
 
 
 # %%
@@ -269,13 +289,12 @@ def main() -> None:
     indices = torch.randint(0, num_nodes, (num_edges,), device=DEVICE).sort()[0]
     input_data = torch.randn(num_edges, num_features, device=DEVICE, dtype=dtype)
 
+    reference_fns = {"pytorch": segmented_reduction_pytorch}
+    if _HAS_TRITON:
+        reference_fns["triton"] = segmented_reduction_triton
+
     run_example(
-        segmented_reduction_helion,
-        {
-            "triton": segmented_reduction_triton,
-            "pytorch": segmented_reduction_pytorch,
-        },
-        (indices, input_data, num_nodes),
+        segmented_reduction_helion, reference_fns, (indices, input_data, num_nodes)
     )
 
 

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -2838,6 +2838,40 @@ class PallasBackend(Backend):
         )
 
         block_spec_info = self._compute_block_spec_info(sorted_args, config)
+        target_ids = device_fn.pallas_tensor_index_atomic_target_ids
+        if target_ids:
+            # Tensor-index atomic_add lowers to a local one-hot accumulation
+            # plus RMW store.  It is correct across Pallas programs only when
+            # the runtime can derive shared-output serialization from
+            # BlockSpec metadata for the in-place output.
+            if sorted_args is None or block_spec_info is None:
+                raise NotImplementedError(
+                    "Pallas tensor-indexed atomic_add requires block spec info "
+                    "for shared-output serialization"
+                )
+            target_positions = [
+                i
+                for i, arg in enumerate(sorted_args)
+                if isinstance(arg, TensorArg) and id(arg.fake_value) in target_ids
+            ]
+            if len(target_positions) != len(target_ids):
+                raise NotImplementedError(
+                    "Pallas tensor-indexed atomic_add target was not found in "
+                    "launcher arguments"
+                )
+            output_set = set(output_indices)
+            inplace_set = set(inplace_indices)
+            for pos in target_positions:
+                if pos not in output_set or pos not in inplace_set:
+                    raise NotImplementedError(
+                        "Pallas tensor-indexed atomic_add requires an in-place "
+                        "output so shared-output serialization can guard the RMW"
+                    )
+                if pos >= len(block_spec_info) or block_spec_info[pos] is None:
+                    raise NotImplementedError(
+                        "Pallas tensor-indexed atomic_add requires block spec info "
+                        "for shared-output serialization"
+                    )
         if block_spec_info is not None:
             if has_rng_ops:
                 block_spec_info.append(None)  # RNG seed buffer is untiled

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -345,6 +345,10 @@ class DeviceFunction:
         # Pallas: id(fake_tensor) → {dim: (block_id, extra_pad)} for dims
         # using pl.ds() that may need host-side padding.
         self.pallas_pad_info: dict[int, dict[int, tuple[int, int]]] = {}
+        # Pallas tensor-index atomic_add targets use a local RMW update.  Their
+        # indirect output dimensions must be covered by shared-output
+        # serialization in the launcher.
+        self.pallas_tensor_index_atomic_target_ids: set[int] = set()
         # Pallas ordered carry: jagged row block_id -> CarryBoundaryTile.  Filled by
         # the emit_pipeline codegen when the tile is a legal map axis; read by
         # the store codegen to stitch the boundary across neighbouring groups.

--- a/helion/_compiler/pallas/gather.py
+++ b/helion/_compiler/pallas/gather.py
@@ -293,6 +293,52 @@ def _scatter_one_hot_name(
     )
 
 
+def _scatter_source_mask_expr(
+    state: CodegenState,
+    plan: ScatterPlan,
+) -> str | None:
+    """Return a float mask for valid tensor-index source lanes."""
+    from ..compile_environment import CompileEnvironment
+
+    subscript = state.proxy_arg(1)
+    assert isinstance(subscript, (list, tuple))
+    index = subscript[plan.indirect_pos]
+    if not isinstance(index, torch.Tensor):
+        return None
+
+    env = CompileEnvironment.current()
+    index_shape = [*index.size()]
+    mask_exprs: list[str] = []
+    for dim, size in enumerate(index_shape):
+        block_id = env.resolve_block_id(size)
+        if block_id is None or (mask_var := state.codegen.mask_var(block_id)) is None:
+            continue
+        if env.is_jagged_tile(block_id):
+            mask_shape = env.jagged_tile_mask_shapes[block_id]
+            expand = state.tile_strategy.jagged_tile_expand_str(mask_shape, index_shape)
+        else:
+            expand = state.tile_strategy.expand_str(index_shape, dim)
+        expr = f"({mask_var}.astype(jnp.float32){expand})"
+        if expr not in mask_exprs:
+            mask_exprs.append(expr)
+
+    if not mask_exprs:
+        return None
+    return "*".join(mask_exprs)
+
+
+def _scatter_masked_one_hot(
+    state: CodegenState,
+    plan: ScatterPlan,
+    name: str,
+) -> str:
+    oh = _scatter_one_hot_name(state, plan, name)
+    source_mask = _scatter_source_mask_expr(state, plan)
+    if source_mask is None:
+        return oh
+    return f"({oh}) * (({source_mask})[..., None])"
+
+
 def emit_scatter_store(
     state: CodegenState,
     plan: ScatterPlan,
@@ -319,7 +365,7 @@ def emit_scatter_store(
     this Pallas program; duplicate writes from different programs have the same
     unspecified winner semantics as regular parallel stores in other backends.
     """
-    oh = _scatter_one_hot_name(state, plan, name)
+    oh = _scatter_masked_one_hot(state, plan, name)
     m = f"jnp.shape({oh})[0]"
     eye = f"jnp.eye({m}, dtype=jnp.float32)"
     is_lane_j_after_i = f"jnp.triu(jnp.ones(({m}, {m}), dtype=jnp.float32), k=1)"
@@ -354,4 +400,37 @@ def emit_scatter_store(
         f"jnp.where({mask_expr}, {{updates}}, {name}[{base_index}])",
         updates=updates,
         value=value,
+    )
+
+
+def emit_scatter_add(
+    state: CodegenState,
+    plan: ScatterPlan,
+    name: str,
+    base_index: str,
+    value: ast.AST,
+) -> ast.AST:
+    """Emit one Pallas program's tensor-indexed add update block.
+
+    ``base_index`` is the target block with the indirect dimension replaced by
+    ``:``. The lowering projects all source lanes to target rows with
+    ``one_hot(idx).T @ value``. Duplicate source indices within this program are
+    summed by the dot, unlike scatter-store's last-writer-wins projection.
+    """
+    oh = _scatter_masked_one_hot(state, plan, name)
+    updates = expr_from_string(
+        "jax.lax.dot_general("
+        f"jnp.swapaxes({oh}, 0, 1), "
+        "{value}.astype(jnp.float32), "
+        "(((1,), (0,)), "
+        "((), ())), "
+        "preferred_element_type=jnp.float32, "
+        "precision=jax.lax.Precision.HIGHEST"
+        ")",
+        value=value,
+    )
+    return expr_from_string(
+        f"({name}[{base_index}].astype(jnp.float32) + {{updates}}).astype("
+        f"{plan.jnp_dtype})",
+        updates=updates,
     )

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -453,6 +453,16 @@ def _resolve_tensor_index_patterns(
             patterns[i] = IndirectScatterPattern(plan=plan)
         return
 
+    from ...language.atomic_ops import atomic_add
+
+    if node.target is atomic_add:
+        from .gather import build_scatter_plan
+
+        plan = build_scatter_plan(tensor, subscript, positions)
+        for i in positions:
+            patterns[i] = IndirectScatterPattern(plan=plan)
+        return
+
     op_name = getattr(node.target, "__name__", str(node.target))
     raise NotImplementedError(
         f"Pallas: tensor-indexed memory op is not supported for op={op_name}."

--- a/helion/language/atomic_ops.py
+++ b/helion/language/atomic_ops.py
@@ -824,6 +824,33 @@ def _pallas_atomic_load_prev(
     return name, index_str, prev_var  # pyrefly: ignore[bad-return]
 
 
+def _validate_pallas_tensor_index_atomic_add_shape(
+    state: CodegenState,
+    target: torch.Tensor,
+    index: list[object] | tuple[object, ...],
+    value: object,
+) -> None:
+    """Reject tensor-indexed Pallas atomic_add shapes we cannot lower."""
+    if not isinstance(value, torch.Tensor):
+        raise exc.BackendUnsupported("pallas", "tensor-indexed atomic_add tensor value")
+    expected_shape = SubscriptIndexing.compute_shape(target, [*index], state)
+    if value.ndim != len(expected_shape):
+        raise exc.BackendUnsupported(
+            "pallas",
+            "tensor-indexed atomic_add value shape must match indexed target shape",
+        )
+
+    from .._compiler.compile_environment import CompileEnvironment
+
+    env = CompileEnvironment.current()
+    for actual, expected in zip(value.shape, expected_shape, strict=True):
+        if not env.known_equal(actual, expected):
+            raise exc.BackendUnsupported(
+                "pallas",
+                "tensor-indexed atomic_add value shape must match indexed target shape",
+            )
+
+
 def _to_ast_values(values: list[object]) -> list[ast.AST]:
     out: list[ast.AST] = []
     for v in values:
@@ -1057,6 +1084,47 @@ def _(state: CodegenState) -> ast.AST:
 def _(state: CodegenState) -> ast.AST:
     from .._compiler.ast_extension import statement_from_string
     from .._compiler.compile_environment import CompileEnvironment
+    from .._compiler.pallas import codegen as pallas_codegen
+    from .._compiler.pallas.gather import emit_scatter_add
+    from .._compiler.pallas.plan_tiling import IndirectScatterPattern
+
+    patterns = state.fx_node.meta.get("indexing_patterns") if state.fx_node else ()
+    scatter_patterns = [
+        pattern
+        for pattern in patterns or ()
+        if isinstance(pattern, IndirectScatterPattern)
+    ]
+    assert len(scatter_patterns) <= 1, (
+        "Pallas atomic_add expected at most one indirect scatter pattern"
+    )
+    if scatter_patterns:
+        if state.fx_node is not None and len(state.fx_node.users) > 0:
+            raise NotImplementedError(
+                "Pallas tensor-indexed atomic_add does not support returning "
+                "previous values"
+            )
+        target = state.proxy_arg(0)
+        index = state.proxy_arg(1)
+        assert isinstance(target, torch.Tensor)
+        assert isinstance(index, (list, tuple))
+        value_proxy = state.proxy_arg(2)
+        plan = scatter_patterns[0].plan
+        _validate_pallas_tensor_index_atomic_add_shape(
+            state, target, index, value_proxy
+        )
+        state.device_function.pallas_tensor_index_atomic_target_ids.add(id(target))
+        host_function = HostFunction.current()
+        if target not in host_function.tensor_to_origin:
+            raise exc.AtomicOnDeviceTensor("pallas atomic")
+        value_ast = _to_ast_values([state.ast_args[2]])[0]
+        name = state.device_function.tensor_arg(target).name
+        index_parts, _ = pallas_codegen.index_parts(state, index, target)
+        index_str = ", ".join(index_parts)
+        update = emit_scatter_add(state, plan, name, index_str, value_ast)
+        state.codegen.add_statement(
+            statement_from_string(f"{name}[{index_str}] = {{update}}", update=update)
+        )
+        return ast.Constant(value=None)
 
     name, index_str, prev_var = _pallas_atomic_load_prev(state)
     value_ast = _to_ast_values([state.ast_args[2]])[0]

--- a/helion/language/scan_ops.py
+++ b/helion/language/scan_ops.py
@@ -498,6 +498,262 @@ def _(state: CodegenState) -> ast.AST | list[ast.AST]:
     return expr_from_string(acc)
 
 
+@_decorators.codegen(_associative_scan, "pallas")
+def _(state: CodegenState) -> ast.AST | list[ast.AST]:
+    """Generate a conservative static serial Pallas/JAX scan."""
+    from .._compiler.device_ir import HelperFunctionGraphInfo
+
+    combine_graph_id = cast("int", state.proxy_arg(0))
+    dim = cast("int", state.proxy_arg(2))
+    reverse = bool(state.proxy_arg(3))
+    is_tuple_input = bool(state.proxy_arg(4))
+    if reverse:
+        raise exc.BackendUnsupported("pallas", "reverse associative_scan")
+
+    helper_graph_info = state.get_graph(combine_graph_id)
+    assert isinstance(helper_graph_info, HelperFunctionGraphInfo)
+
+    input_values, input_asts = _pallas_scan_inputs(state, is_tuple_input)
+    result_exprs = _pallas_emit_serial_scan(
+        state,
+        helper_graph_info,
+        input_values,
+        input_asts,
+        dim,
+    )
+    return result_exprs if is_tuple_input else result_exprs[0]
+
+
+def _pallas_scan_inputs(
+    state: CodegenState, is_tuple_input: bool
+) -> tuple[list[torch.Tensor], list[ast.AST]]:
+    input_proxy = state.proxy_arg(1)
+    raw_input_ast = state.ast_args[1]
+
+    if is_tuple_input:
+        if not isinstance(input_proxy, (tuple, list)) or not isinstance(
+            raw_input_ast, (tuple, list)
+        ):
+            raise exc.BackendUnsupported("pallas", "tuple associative_scan input")
+        input_values = list(input_proxy)
+        input_asts = list(raw_input_ast)
+    else:
+        input_values = [input_proxy]
+        input_asts = [state.ast_arg(1)]
+
+    if not input_values or not all(isinstance(t, torch.Tensor) for t in input_values):
+        raise exc.BackendUnsupported("pallas", "associative_scan input")
+    if not all(isinstance(arg, ast.AST) for arg in input_asts):
+        raise exc.BackendUnsupported("pallas", "associative_scan input expression")
+    return (
+        cast("list[torch.Tensor]", input_values),
+        cast("list[ast.AST]", input_asts),
+    )
+
+
+def _pallas_emit_serial_scan(
+    state: CodegenState,
+    helper_graph_info: HelperFunctionGraphInfo,
+    input_values: list[torch.Tensor],
+    input_asts: list[ast.AST],
+    dim: int,
+) -> list[ast.AST]:
+    """Emit a static JAX loop, inline the combine graph, and stack per-step items."""
+    from .._compiler.ast_extension import expr_from_string
+    from .._compiler.ast_extension import statement_from_string
+    from .._compiler.compile_environment import CompileEnvironment
+
+    first = input_values[0]
+    ndim = first.ndim
+    if ndim == 0:
+        raise exc.BackendUnsupported("pallas", "scalar associative_scan input")
+    if dim < 0:
+        dim += ndim
+    if not (0 <= dim < ndim):
+        raise exc.BackendUnsupported("pallas", "associative_scan dim")
+
+    first_shape = tuple(str(s) for s in first.shape)
+    for value in input_values:
+        if value.ndim != ndim or tuple(str(s) for s in value.shape) != first_shape:
+            raise exc.BackendUnsupported("pallas", "tuple associative_scan shapes")
+
+    env = CompileEnvironment.current()
+    fake_extent: object = first.shape[dim]
+    if isinstance(fake_extent, torch.SymInt):
+        fake_extent = env.size_hint(fake_extent)
+    if not isinstance(fake_extent, int) or fake_extent <= 0:
+        raise exc.BackendUnsupported("pallas", "dynamic associative_scan extent")
+
+    input_names = [
+        state.codegen.lift(input_ast, dce=True, prefix="scan_input").id
+        for input_ast in input_asts
+    ]
+    result_vars = [state.device_function.new_var("scan_out") for _ in input_names]
+    acc_vars = [state.device_function.new_var("scan_acc") for _ in input_names]
+    item_vars = [state.device_function.new_var("scan_items") for _ in input_names]
+    extent_var = state.device_function.new_var("scan_extent")
+
+    state.codegen.add_statement(
+        statement_from_string(f"{extent_var} = {input_names[0]}.shape[{dim}]")
+    )
+    for item_var in item_vars:
+        state.codegen.add_statement(
+            statement_from_string(f"{item_var} = [None] * {extent_var}")
+        )
+
+    seed_index = _pallas_scan_index(ndim, dim, "0")
+    for acc_var, item_var, input_name in zip(
+        acc_vars, item_vars, input_names, strict=True
+    ):
+        state.codegen.add_statement(
+            statement_from_string(f"{acc_var} = {input_name}[{seed_index}]")
+        )
+        state.codegen.add_statement(statement_from_string(f"{item_var}[0] = {acc_var}"))
+
+    scan_i = state.device_function.new_var("scan_i")
+    value_index = _pallas_scan_index(ndim, dim, scan_i)
+    value_exprs = [f"{input_name}[{value_index}]" for input_name in input_names]
+    combine_exprs = _pallas_combine_result_expressions(
+        helper_graph_info, [*acc_vars, *value_exprs]
+    )
+    if len(combine_exprs) != len(acc_vars):
+        raise exc.BackendUnsupported("pallas", "associative_scan combine output")
+    next_vars = [state.device_function.new_var("scan_next") for _ in acc_vars]
+    lines = [f"for {scan_i} in range(1, {extent_var}):"]
+    lines.extend(
+        f"    {next_var} = {combine_expr}"
+        for next_var, combine_expr in zip(next_vars, combine_exprs, strict=True)
+    )
+    lines.extend(
+        f"    {acc_var} = {next_var}"
+        for acc_var, next_var in zip(acc_vars, next_vars, strict=True)
+    )
+    lines.extend(
+        f"    {item_var}[{scan_i}] = {acc_var}"
+        for item_var, acc_var in zip(item_vars, acc_vars, strict=True)
+    )
+    state.codegen.add_statement(statement_from_string("\n".join(lines)))
+
+    for result_var, item_var in zip(result_vars, item_vars, strict=True):
+        state.codegen.add_statement(
+            statement_from_string(f"{result_var} = jnp.stack({item_var}, axis={dim})")
+        )
+
+    return [expr_from_string(result_var) for result_var in result_vars]
+
+
+def _pallas_scan_index(ndim: int, dim: int, pos: str) -> str:
+    parts = [":" for _ in range(ndim)]
+    parts[dim] = pos
+    return ", ".join(parts)
+
+
+def _pallas_combine_result_expressions(
+    helper_graph_info: HelperFunctionGraphInfo,
+    arg_exprs: list[str],
+) -> list[str]:
+    """Inline the combine graph as JAX expressions for Pallas serial scan."""
+    import operator as operator_mod
+
+    graph = helper_graph_info.graph
+    placeholders = [n for n in graph.nodes if n.op == "placeholder"]
+    if len(placeholders) != len(arg_exprs):
+        raise exc.BackendUnsupported("pallas", "associative_scan combine arity")
+
+    binary_ops: dict[object, str] = {
+        operator_mod.add: "+",
+        torch.add: "+",
+        torch.ops.aten.add.Tensor: "+",
+        torch.ops.aten.add.Scalar: "+",
+        operator_mod.sub: "-",
+        torch.sub: "-",
+        torch.ops.aten.sub.Tensor: "-",
+        torch.ops.aten.sub.Scalar: "-",
+        operator_mod.mul: "*",
+        torch.mul: "*",
+        torch.ops.aten.mul.Tensor: "*",
+        torch.ops.aten.mul.Scalar: "*",
+        operator_mod.eq: "==",
+        torch.ops.aten.eq.Tensor: "==",
+        torch.ops.aten.eq.Scalar: "==",
+        operator_mod.ne: "!=",
+        torch.ops.aten.ne.Tensor: "!=",
+        torch.ops.aten.ne.Scalar: "!=",
+        operator_mod.lt: "<",
+        torch.ops.aten.lt.Tensor: "<",
+        torch.ops.aten.lt.Scalar: "<",
+        operator_mod.gt: ">",
+        torch.ops.aten.gt.Tensor: ">",
+        torch.ops.aten.gt.Scalar: ">",
+        operator_mod.le: "<=",
+        torch.ops.aten.le.Tensor: "<=",
+        torch.ops.aten.le.Scalar: "<=",
+        operator_mod.ge: ">=",
+        torch.ops.aten.ge.Tensor: ">=",
+        torch.ops.aten.ge.Scalar: ">=",
+    }
+    min_ops = (torch.minimum, torch.ops.aten.minimum.default)
+    max_ops = (torch.maximum, torch.ops.aten.maximum.default)
+    where_ops = (torch.where, torch.ops.aten.where.self)
+
+    env_map: dict[object, str] = dict(zip(placeholders, arg_exprs, strict=True))
+
+    def operand(value: object) -> str:
+        if isinstance(value, torch.fx.Node):
+            if value not in env_map:
+                raise exc.BackendUnsupported(
+                    "pallas", f"associative_scan combine dependency: {value}"
+                )
+            return env_map[value]
+        if isinstance(value, bool):
+            return "True" if value else "False"
+        if isinstance(value, (int, float)):
+            return repr(value)
+        raise exc.BackendUnsupported(
+            "pallas", f"associative_scan combine operand {value!r}"
+        )
+
+    for node in graph.nodes:
+        if node.op in ("placeholder", "output"):
+            continue
+        if node.op != "call_function":
+            raise exc.BackendUnsupported(
+                "pallas", f"associative_scan combine op {node.op}"
+            )
+        target = node.target
+        if target in binary_ops:
+            lhs = operand(node.args[0])
+            rhs = operand(node.args[1])
+            env_map[node] = f"(({lhs}) {binary_ops[target]} ({rhs}))"
+        elif target in where_ops:
+            cond = operand(node.args[0])
+            tval = operand(node.args[1])
+            fval = operand(node.args[2])
+            env_map[node] = f"jnp.where({cond}, {tval}, {fval})"
+        elif target in min_ops:
+            lhs = operand(node.args[0])
+            rhs = operand(node.args[1])
+            env_map[node] = f"jnp.minimum({lhs}, {rhs})"
+        elif target in max_ops:
+            lhs = operand(node.args[0])
+            rhs = operand(node.args[1])
+            env_map[node] = f"jnp.maximum({lhs}, {rhs})"
+        elif target is torch.ops.prims.convert_element_type.default:
+            env_map[node] = operand(node.args[0])
+        else:
+            raise exc.BackendUnsupported(
+                "pallas", f"associative_scan combine function: {target}"
+            )
+
+    output_nodes = [n for n in graph.nodes if n.op == "output"]
+    if len(output_nodes) != 1:
+        raise exc.BackendUnsupported("pallas", "associative_scan combine output")
+    outputs = output_nodes[0].args[0]
+    if not isinstance(outputs, (tuple, list)):
+        outputs = [outputs]
+    return [operand(o) for o in outputs]
+
+
 def _cute_recover_scan_load(node: object) -> tuple[object, object] | None:
     """Walk back from a scan tuple-element node to its ``CuteSortableLoad``.
 

--- a/test/test_atomic_ops.py
+++ b/test/test_atomic_ops.py
@@ -306,7 +306,6 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
         expected = torch.ones(8, device=DEVICE)
         torch.testing.assert_close(result, expected)
 
-    @xfailIfPallas("Integer indexing not supported on Pallas")
     def test_atomic_add_1d_tensor(self):
         M, N = 32, 64
         x = torch.randn(M, N, device=DEVICE, dtype=torch.float32)

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1206,7 +1206,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[16, 8, 16],
         )
 
-    @xfailIfPallas("requires triton module")
+    @skipIfPallasInterpret("CPU Pallas interpret job does not install Triton")
     @skipIfRefEager(
         "torch._higher_order_ops.associative_scan with tuple arg is not supported by ref eager mode yet"
     )
@@ -1217,7 +1217,9 @@ class TestExamples(RefEagerTestBase, TestCase):
         dtype = torch.float32
 
         # Create sorted indices for segmented reduction
-        indices = torch.randint(0, num_nodes, (num_edges,), device=DEVICE).sort()[0]
+        indices = torch.randint(
+            0, num_nodes, (num_edges,), device=DEVICE, dtype=LONG_INT_TYPE
+        ).sort()[0]
         input_data = torch.randn(num_edges, num_features, device=DEVICE, dtype=dtype)
 
         args = (indices, input_data, num_nodes)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -280,6 +280,34 @@ def pallas_scatter_store(values: torch.Tensor, indices: torch.Tensor) -> torch.T
     return out
 
 
+def pallas_segmented_scan_combine(
+    left_values: torch.Tensor,
+    left_indices: torch.Tensor,
+    right_values: torch.Tensor,
+    right_indices: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    same_segment = left_indices == right_indices
+    combined_values = torch.where(
+        same_segment, left_values + right_values, right_values
+    )
+    return combined_values, right_indices
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_tuple_associative_scan(
+    values: torch.Tensor, indices: torch.Tensor
+) -> torch.Tensor:
+    out = torch.empty_like(values)
+    for tile_m, tile_n in hl.tile(values.size()):
+        vals = values[tile_m, tile_n]
+        idxs = indices[tile_m].float().unsqueeze(1).expand_as(vals)
+        out_vals, _ = hl.associative_scan(
+            pallas_segmented_scan_combine, (vals, idxs), dim=0
+        )
+        out[tile_m, tile_n] = out_vals
+    return out
+
+
 @helion.kernel(backend="pallas", static_shapes=True)
 def pallas_inner_loop_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     """Kernel with an outer grid loop and an inner device loop."""
@@ -1533,7 +1561,7 @@ class TestPallas(TestCase):
         expected[indices.to(torch.int64)] = values
         torch.testing.assert_close(result, expected)
 
-    def test_tensor_index_atomic_add_raises(self) -> None:
+    def test_tensor_index_atomic_add(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def atomic_add_tensor_index(
             values: torch.Tensor, indices: torch.Tensor
@@ -1544,17 +1572,117 @@ class TestPallas(TestCase):
             return out
 
         values = torch.randn(16, device=DEVICE, dtype=torch.float32)
-        indices = torch.randperm(16, device=DEVICE).to(torch.int32)
+        indices = torch.tensor(
+            [0, 1, 1, 2, 4, 4, 4, 8, 8, 9, 10, 10, 12, 13, 14, 14],
+            device=DEVICE,
+            dtype=torch.int32,
+        )
+
+        code, result = code_and_output(
+            atomic_add_tensor_index,
+            (values, indices),
+            block_size=16,
+        )
+
+        expected = torch.zeros_like(values)
+        expected.scatter_add_(0, indices.to(torch.int64), values)
+        torch.testing.assert_close(result, expected)
+        self.assertIn("one_hot", code)
+        self.assertIn("swapaxes", code)
+        self.assertIn("dot_general", code)
+
+    def test_tensor_index_atomic_add_shared_output_tiles(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def atomic_add_shared_output_tiles(
+            values: torch.Tensor, indices: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.zeros(
+                [1, values.size(1)], device=values.device, dtype=values.dtype
+            )
+            for tile_m, tile_n in hl.tile(values.size()):
+                hl.atomic_add(out, [indices[tile_m], tile_n], values[tile_m, tile_n])
+            return out
+
+        values = torch.randn(64, 8, device=DEVICE, dtype=torch.float32)
+        indices = torch.zeros(64, device=DEVICE, dtype=torch.int32)
+
+        code, result = code_and_output(
+            atomic_add_shared_output_tiles,
+            (values, indices),
+            block_sizes=[16, 8],
+        )
+
+        torch.testing.assert_close(result, values.sum(dim=0, keepdim=True))
+        self.assertIn("one_hot", code)
+        self.assertIn("_inplace_indices=", code)
+
+    def test_tensor_index_atomic_add_value_shape_raises(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def atomic_add_bad_value_shape(
+            values: torch.Tensor, indices: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.zeros_like(values)
+            for tile_m, tile_n in hl.tile(values.size()):
+                hl.atomic_add(out, [indices[tile_m], tile_n], values[tile_m, 0])
+            return out
+
+        values = torch.randn(16, 4, device=DEVICE, dtype=torch.float32)
+        indices = torch.arange(16, device=DEVICE, dtype=torch.int32)
 
         with self.assertRaisesRegex(
-            NotImplementedError,
-            "tensor-indexed memory op is not supported for op=atomic_add",
+            helion.exc.BackendUnsupported,
+            "value shape must match indexed target shape",
         ):
             code_and_output(
-                atomic_add_tensor_index,
+                atomic_add_bad_value_shape,
                 (values, indices),
-                block_size=16,
+                block_sizes=[16, 4],
             )
+
+    def test_associative_scan_reverse_raises(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def reverse_scan(values: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(values)
+            for tile_m, tile_n in hl.tile(values.size()):
+                out[tile_m, tile_n] = hl.associative_scan(
+                    torch.add, values[tile_m, tile_n], dim=0, reverse=True
+                )
+            return out
+
+        values = torch.randn(16, 4, device=DEVICE, dtype=torch.float32)
+
+        with self.assertRaisesRegex(
+            helion.exc.BackendUnsupported,
+            "reverse associative_scan",
+        ):
+            code_and_output(reverse_scan, (values,), block_sizes=[16, 4])
+
+    def test_tuple_associative_scan_segmented(self) -> None:
+        values = torch.randn(16, 4, device=DEVICE, dtype=torch.float32)
+        indices = torch.tensor(
+            [0, 0, 1, 1, 1, 3, 4, 4, 6, 7, 7, 7, 8, 10, 10, 11],
+            device=DEVICE,
+            dtype=torch.int32,
+        )
+
+        code, result = code_and_output(
+            pallas_tuple_associative_scan,
+            (values, indices),
+            block_sizes=[16, 4],
+        )
+
+        expected = torch.empty_like(values)
+        host_indices = indices.cpu()
+        for i in range(values.size(0)):
+            if i == 0 or host_indices[i].item() != host_indices[i - 1].item():
+                expected[i] = values[i]
+            else:
+                expected[i] = expected[i - 1] + values[i]
+        torch.testing.assert_close(result, expected)
+        self.assertIn("jnp.stack", code)
+        self.assertIn(".shape[0]", code)
+        self.assertNotIn(".at[", code)
+        self.assertIn("jnp.where", code)
 
     def test_scatter_store_multiple_tensor_indices_raises(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)


### PR DESCRIPTION
Stacked PRs:
 * #2879
 * #2878
 * __->__#2877
 * #2876
 * #2875
 * #2874
 * #2873
 * #2872
 * #2871
 * #2870


--- --- ---

### Example fixed

`examples/segment_reduction.py` now runs on real Pallas TPU. Pallas interpret skips this example because that CI job does not install Triton, which the example can use for its optional reference path.

### Compiler side

Pallas `atomic_add` now supports tensor-indexed update patterns through a masked one-hot scatter-add for the supported shapes. That covers the segment-reduction update pattern without adding broad, unsafe scatter semantics.

The PR also adds a conservative serial Pallas lowering for `hl.associative_scan` tuple scans. It emits a static JAX loop, inlines the combine graph, and stacks the per-step values into the result. The example makes Triton optional and keeps PyTorch as the portable reference.