### PR TITLE
Support bounded Pallas inner block specs

### DIFF
--- a/examples/mamba2_chunk_scan.py
+++ b/examples/mamba2_chunk_scan.py
@@ -19,13 +19,14 @@ from helion._testing import DEVICE
 from helion._testing import HALF_DTYPE
 from helion._testing import run_example
 import helion.language as hl
+from helion.runtime.settings import _get_backend
 
 
 # %%
 # Helion Kernel Implementation
 # ----------------------------
 @helion.kernel()
-def helion_mamba2_chunk_scan_kernel(
+def _helion_mamba2_chunk_scan_kernel_scalar(
     cb: torch.Tensor,
     x: torch.Tensor,
     dt: torch.Tensor,
@@ -141,6 +142,151 @@ def helion_mamba2_chunk_scan_kernel(
         ] = acc_o.to(dtype=dtype)
 
     return out
+
+
+@helion.kernel()
+def _helion_mamba2_chunk_scan_kernel_pallas(
+    cb: torch.Tensor,
+    x: torch.Tensor,
+    dt: torch.Tensor,
+    dA_cumsum: torch.Tensor,
+    C: torch.Tensor,
+    prev_states: torch.Tensor,
+    D: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Pallas implementation that computes an aligned block of heads per program.
+
+    TPU Mosaic cannot lower bf16 stores to a scalar middle ``nheads`` lane.
+    Owning a head block keeps the output store structural while preserving the
+    scalar-head implementation for non-Pallas backends.
+    """
+
+    batch, nchunks, ngroups, chunk_size, _ = cb.shape
+    _, seqlen, nheads, headdim = x.shape
+    _, _, _, dstate = C.shape
+    assert nchunks == (seqlen + chunk_size - 1) // chunk_size
+    assert nheads % ngroups == 0
+
+    nheads = hl.specialize(nheads)
+    ngroups = hl.specialize(ngroups)
+    heads_per_group = hl.specialize(nheads // ngroups)
+    block_h_value = min(8, heads_per_group)
+    assert ngroups == 1 or heads_per_group % 8 == 0
+
+    block_h = hl.register_block_size(block_h_value)
+    block_m = hl.register_block_size(chunk_size)
+    block_n = hl.register_block_size(headdim)
+    block_k = hl.register_block_size(64, 64)
+    dstate = hl.specialize(dstate)
+
+    assert cb.shape == (batch, nchunks, ngroups, chunk_size, chunk_size)
+    assert x.shape == (batch, seqlen, nheads, headdim)
+    assert dt.shape == (batch, nheads, nchunks, chunk_size)
+    assert dA_cumsum.shape == (batch, nheads, nchunks, chunk_size)
+    assert C.shape == (batch, seqlen, ngroups, dstate)
+    assert prev_states.shape == (batch, nchunks, nheads, headdim, dstate)
+    assert D.shape == (nheads,)
+
+    dtype = cb.dtype
+    accum_dtype = torch.float32
+    assert (
+        x.dtype
+        == dt.dtype
+        == dA_cumsum.dtype
+        == C.dtype
+        == prev_states.dtype
+        == D.dtype
+        == dtype
+    )
+
+    out = torch.empty_like(x)
+
+    p = 1.44269504
+
+    for tile_g, tile_h, tile_m, tile_n, tile_b, tile_c in hl.tile(
+        [ngroups, heads_per_group, chunk_size, headdim, batch, nchunks],
+        block_size=[1, block_h, block_m, block_n, 1, 1],
+    ):
+        heads = tile_g.begin * heads_per_group + tile_h.index
+        acc_o = hl.zeros([tile_h, tile_m, tile_n], dtype=accum_dtype)
+        dA_cumsum_local_m = dA_cumsum[tile_b.begin, heads, tile_c.begin, tile_m].to(
+            accum_dtype
+        )
+        scale_m_local = torch.exp2(dA_cumsum_local_m * p)
+
+        C_local = C[
+            tile_b.begin,
+            tile_m.index + tile_c.begin * chunk_size,
+            tile_g.begin,
+            :,
+        ]
+        C_local = C_local[None, :, :] + hl.zeros([tile_h, tile_m, dstate], dtype=dtype)
+        prev_states_local = prev_states[tile_b.begin, tile_c.begin, heads, tile_n, :]
+        acc_o = acc_o + torch.bmm(
+            C_local.to(accum_dtype),
+            prev_states_local.transpose(1, 2).to(accum_dtype),
+        )
+        acc_o *= scale_m_local[:, :, None]
+
+        for tile_k in hl.tile((tile_m.id + 1) * block_m, block_size=block_k):
+            cb_local = cb[
+                tile_b.begin,
+                tile_c.begin,
+                tile_g.begin,
+                tile_m,
+                tile_k,
+            ]
+            cb_local = cb_local[None, :, :] + hl.zeros(
+                [tile_h, tile_m, tile_k], dtype=dtype
+            )
+            dA_cumsum_local_k = dA_cumsum[tile_b.begin, heads, tile_c.begin, tile_k].to(
+                accum_dtype
+            )
+            cb_local *= torch.exp2(
+                dA_cumsum_local_m[:, :, None] * p - dA_cumsum_local_k[:, None, :] * p
+            )
+            dt_local = dt[tile_b.begin, heads, tile_c.begin, tile_k].to(accum_dtype)
+            cb_local = (cb_local * dt_local[:, None, :]).to(dtype)
+            pred = (tile_m.index + 0)[:, None] >= (tile_k.index + 0)[None, :]
+            cb_local = torch.where(
+                pred[None, :, :], cb_local, torch.zeros_like(cb_local)
+            )
+            x_local = x[
+                tile_b.begin,
+                tile_c.begin * chunk_size + tile_k.index,
+                heads,
+                tile_n,
+            ].transpose(0, 1)
+            acc_o = acc_o + torch.bmm(cb_local.to(accum_dtype), x_local.to(accum_dtype))
+
+        D_local = D[heads].to(accum_dtype)
+        x_residual = (
+            x[
+                tile_b.begin,
+                tile_c.begin * chunk_size + tile_m.index,
+                heads,
+                tile_n,
+            ]
+            .transpose(0, 1)
+            .to(accum_dtype)
+        )
+        acc_o += x_residual * D_local[:, None, None]
+        out[
+            tile_b.begin,
+            tile_c.begin * chunk_size + tile_m.index,
+            heads,
+            tile_n,
+        ] = acc_o.transpose(0, 1).to(dtype=dtype)
+
+    return out
+
+
+helion_mamba2_chunk_scan_kernel = (
+    _helion_mamba2_chunk_scan_kernel_pallas
+    if _get_backend() == "pallas"
+    else _helion_mamba2_chunk_scan_kernel_scalar
+)
 
 
 # %%

--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -203,7 +203,30 @@ scalar_tensor_lowering = register_lowering(
 )
 
 
-where_lowering = register_lowering(torch.ops.aten.where.self)
+_UNKNOWN_MASKED_VALUE = object()
+
+
+def _where_masked_value(node: Node) -> float | bool | None:
+    def branch_value(arg: object) -> object:
+        if isinstance(arg, Node):
+            value = cached_masked_value(arg)
+            return _UNKNOWN_MASKED_VALUE if value is None else value
+        if isinstance(arg, (int, float, bool)):
+            return arg
+        return _UNKNOWN_MASKED_VALUE
+
+    x_value = branch_value(node.args[1])
+    y_value = branch_value(node.args[2])
+    if x_value is not _UNKNOWN_MASKED_VALUE and x_value == y_value:
+        assert isinstance(x_value, (int, float, bool))
+        return x_value
+    return None
+
+
+where_lowering = register_lowering(
+    torch.ops.aten.where.self,
+    masked_value_fn=_where_masked_value,
+)
 
 
 @where_lowering.register_codegen("common")
@@ -247,6 +270,91 @@ def codegen_where_cute(ctx: LoweringContext, node: Node) -> object:
     return expr_from_string(
         env.backend.where_expr("{cond}", "{x}", "{y}"),
         cond=ensure_ast(cond),
+        x=x_ast,
+        y=y_ast,
+    )
+
+
+@where_lowering.register_codegen("pallas")
+def codegen_where_pallas(ctx: LoweringContext, node: Node) -> object:
+    env = CompileEnvironment.current()
+    cond, x, y = map_arg(node.args, lambda arg: _env_arg(ctx, arg))
+
+    def ensure_ast(value: object) -> ast.AST:
+        if isinstance(value, ast.AST):
+            return value
+        if isinstance(value, (int, float, bool)):
+            return expr_from_string(constant_repr(value))
+        raise AssertionError(f"unsupported where operand: {type(value)!r}")
+
+    cond_ast = ensure_ast(cond)
+    x_ast = ensure_ast(x)
+    y_ast = ensure_ast(y)
+
+    ShapeDim = int | torch.SymInt
+
+    def tensor_shape(arg: object) -> tuple[ShapeDim, ...] | None:
+        if isinstance(arg, Node):
+            value = arg.meta.get("val")
+            if isinstance(value, torch.Tensor):
+                return cast("tuple[ShapeDim, ...]", tuple(value.size()))
+        return None
+
+    def shapes_match(
+        lhs: tuple[ShapeDim, ...] | None, rhs: tuple[ShapeDim, ...]
+    ) -> bool:
+        if lhs is None or len(lhs) != len(rhs):
+            return False
+        for left, right in zip(lhs, rhs, strict=True):
+            if not env.known_equal(left, right):
+                return False
+        return True
+
+    cond_arg = node.args[0]
+    output_val = node.meta.get("val")
+    if isinstance(cond_arg, Node) and isinstance(output_val, torch.Tensor):
+        cond_val = cond_arg.meta.get("val")
+        # Anchor boolean tensor layout before lowering to a numeric-mask select.
+        if isinstance(cond_val, torch.Tensor) and cond_val.dtype is torch.bool:
+            from .pallas import codegen as pallas_codegen
+
+            output_shape = cast("tuple[ShapeDim, ...]", tuple(output_val.size()))
+            branch_asts = ((node.args[1], x_ast), (node.args[2], y_ast))
+            layout_anchor = x_ast
+            for branch_arg, branch_ast in branch_asts:
+                if shapes_match(tensor_shape(branch_arg), output_shape):
+                    layout_anchor = branch_ast
+                    break
+            else:
+                for branch_arg, branch_ast in branch_asts:
+                    if tensor_shape(branch_arg) is not None:
+                        layout_anchor = branch_ast
+                        break
+
+            numeric_select = pallas_codegen.numeric_where_expr(
+                cond_ast,
+                x_ast,
+                y_ast,
+                output_val.dtype,
+                layout_anchor,
+            )
+            if numeric_select is not None:
+                return numeric_select
+            if not shapes_match(tuple(cond_val.size()), output_shape):
+                cond_ast = pallas_codegen.layout_tied_bf16_mask_expr(
+                    cond_ast,
+                    layout_anchor,
+                )
+                cond_ast = expr_from_string(
+                    "({cond}) == jnp.array(1, dtype=jnp.bfloat16)",
+                    cond=cond_ast,
+                )
+            else:
+                cond_ast = expr_from_string("({cond}) != 0", cond=cond_ast)
+
+    return expr_from_string(
+        env.backend.where_expr("{cond}", "{x}", "{y}"),
+        cond=cond_ast,
         x=x_ast,
         y=y_ast,
     )
@@ -301,20 +409,40 @@ unsqueeze_lowering = register_lowering(
 
 
 def _pallas_bool_safe_singleton_index(
-    tensor: ast.AST, input_val: torch.Tensor, args: list[str]
+    tensor: ast.AST,
+    input_val: torch.Tensor,
+    args: list[str],
+    singleton_shape: str | None = None,
 ) -> ast.AST:
     index = ", ".join(args)
     if input_val.dtype is torch.bool and "None" in args:
+        from .pallas import codegen as pallas_codegen
+
         # Mosaic cannot reshape bool vectors directly:
         # https://github.com/jax-ml/jax/issues/37370
+        if singleton_shape is not None:
+            return pallas_codegen.numeric_mask_reshape_expr(tensor, singleton_shape)
+        tensor = pallas_codegen.numeric_mask_expr(tensor)
         return expr_from_string(
-            f"(({{tensor}}).astype(jnp.int32)[{index}] != 0)",
+            f"{{tensor}}[{index}]",
             tensor=tensor,
         )
     return expr_from_string(
         f"{{tensor}}[{index}]",
         tensor=tensor,
     )
+
+
+def _pallas_singleton_shape(
+    input_val: torch.Tensor,
+    args: list[str],
+    ctx: LoweringContext,
+) -> str:
+    input_dims = iter(input_val.size())
+    shape: list[int | torch.SymInt] = []
+    for arg in args:
+        shape.append(1 if arg == "None" else next(input_dims))
+    return ctx.cg.device_function.tile_strategy.shape_str(shape)
 
 
 @unsqueeze_lowering.register_codegen("common")
@@ -352,7 +480,8 @@ def codegen_unsqueeze_pallas(ctx: LoweringContext, node: Node) -> object:
     assert 0 <= dim <= ndim, f"Invalid dim {dim} for tensor with {ndim} dims"
     args = [":"] * ndim
     args.insert(dim, "None")
-    return _pallas_bool_safe_singleton_index(tensor, input_val, args)
+    singleton_shape = _pallas_singleton_shape(input_val, args, ctx)
+    return _pallas_bool_safe_singleton_index(tensor, input_val, args, singleton_shape)
 
 
 @unsqueeze_lowering.register_codegen("cute")
@@ -662,10 +791,13 @@ def codegen_view_pallas(ctx: LoweringContext, node: Node) -> object:
     if isinstance(input_node, Node):
         input_val = input_node.meta.get("val")
         if isinstance(input_val, torch.Tensor) and input_val.dtype is torch.bool:
+            from .pallas import codegen as pallas_codegen
+
             # Mosaic cannot reshape bool vectors directly:
             # https://github.com/jax-ml/jax/issues/37370
+            tensor = pallas_codegen.numeric_mask_expr(tensor)
             return expr_from_string(
-                f"(jnp.reshape(({{tensor}}).astype(jnp.int32), {shape_str}) != 0)",
+                f"jnp.reshape({{tensor}}, {shape_str})",
                 tensor=tensor,
             )
     return expr_from_string(f"jnp.reshape({{tensor}}, {shape_str})", tensor=tensor)
@@ -995,7 +1127,14 @@ def codegen_expand_pallas(ctx: LoweringContext, node: Node) -> object:
             tuple(input_val.shape), tuple(shape)
         )
         if broadcasting:
-            tensor = _pallas_bool_safe_singleton_index(tensor, input_val, broadcasting)
+            singleton_shape = _pallas_singleton_shape(input_val, broadcasting, ctx)
+            tensor = _pallas_bool_safe_singleton_index(
+                tensor, input_val, broadcasting, singleton_shape
+            )
+    elif input_val.dtype is torch.bool:
+        from .pallas import codegen as pallas_codegen
+
+        tensor = pallas_codegen.numeric_mask_expr(tensor)
     shape_str = ctx.cg.device_function.tile_strategy.shape_str(shape)
     return expr_from_string(
         f"jnp.broadcast_to({{tensor}}, {shape_str})",

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -38,7 +38,6 @@ from helion._testing import skipIfTileIR
 from helion._testing import skipIfXPU
 from helion._testing import xfailIfPallas
 from helion._testing import xfailIfPallasInterpret
-from helion._testing import xfailIfPallasTpu
 from helion.runtime.config import Config
 from helion.runtime.ref_mode import is_ref_mode_enabled
 
@@ -1414,8 +1413,8 @@ class TestExamples(RefEagerTestBase, TestCase):
         """Test combined backward pass for layer norm with bias."""
         self._run_layernorm_bwd(batch_size=32, dim=64)
 
-    @xfailIfPallas("VMEM OOM: untiled block specs load full tensors")
     @skipIfA10G("accuracy check fails on A10G GPUs")
+    @xfailIfPallasInterpret("large-batch backward has interpret-mode drift")
     def test_layernorm_bwd_large_batch(self):
         """Regression test: large batch, small dim."""
         self._run_layernorm_bwd(batch_size=1152 * 1000, dim=16, seed=1)
@@ -2626,7 +2625,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             rtol=0.1,
         )
 
-    @xfailIfPallasTpu("BlockSpec tiling failure")
     def test_mamba2_chunk_scan(self):
         batch, nheads, ngroups, seqlen, chunk_size, headdim, dstate = (
             2,

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -704,6 +704,49 @@ def kernel_tile_begin_plus_offset_is_elementwise(
 @onlyBackends(["triton", "pallas"])
 @skipUnlessPallas("JAX/Pallas TPU not available")
 class TestPallas(TestCase):
+    def _assert_shape_safe_numeric_mask(self, code: str) -> None:
+        self.assertNotRegex(
+            code,
+            r"jnp\.where\([^\n]*(?:"
+            r"jnp\.ones_like[^\n]*jnp\.zeros_like|"
+            r"jnp\.zeros_like[^\n]*jnp\.ones_like"
+            r")",
+        )
+        self.assertNotRegex(
+            code,
+            r"\.astype\(jnp\.int32\)\[[^\]]*\bNone\b",
+        )
+        self.assertNotRegex(
+            code,
+            r"lax\.convert_element_type\([^\n]*\)\[None",
+        )
+        self.assertNotIn("optimization_barrier", code)
+
+    def _assert_numeric_mask_reshape(self, code: str, shape_pattern: str) -> None:
+        bool_to_int = r"[^\n,]+\.astype\(jnp\.int32\)"
+        one_int32 = r"jnp\.array\(1, dtype=jnp\.int32\)"
+        patterns = [
+            rf"jnp\.reshape\({bool_to_int}, {shape_pattern}",
+            (
+                rf"jnp\.reshape\(jnp\.minimum\({bool_to_int}, {one_int32}\), "
+                rf"{shape_pattern}"
+            ),
+        ]
+        if not any(re.search(pattern, code) for pattern in patterns):
+            self.fail(
+                "expected numeric mask reshape to use direct bool-to-int "
+                "conversion, optionally clamped with jnp.minimum"
+            )
+
+    def _assert_layout_tied_numeric_mask_bits(self, code: str) -> None:
+        self.assertRegex(
+            code,
+            r"lax\.convert_element_type\("
+            r"jnp\.ones_like\([^\n]+,\s*dtype=jnp\.bfloat16\)\s*\*\s*"
+            r"lax\.convert_element_type\([^\n]+,\s*jnp\.bfloat16\),\s*"
+            r"jnp\.(?:u?int(?:8|16|32))\)",
+        )
+
     def test_slice_addressing_classification(self) -> None:
         """_slice_addressing: major dim -> DIRECT; f32 single-lane-tile sublane
         -> DIRECT; bf16 / wide-lane / unknown-lane sublane -> ALIGNED."""
@@ -1411,6 +1454,29 @@ class TestPallas(TestCase):
         torch.testing.assert_close(result, x + offsets[None, :])
         self.assertIn("jnp.arange", code)
 
+    def test_bool_relayout_store(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def pallas_bool_relayout_store(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty([m, n], dtype=torch.bool, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                mask = (x[tile_m, 0] > 0).view(tile_m.block_size)
+                mask_2d = mask[:, None].expand(tile_m.block_size, tile_n.block_size)
+                out[tile_m, tile_n] = mask_2d
+            return out
+
+        x = torch.randn(16, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_bool_relayout_store,
+            (x,),
+            block_sizes=[16, 128],
+        )
+
+        expected = (x[:, :1] > 0).expand_as(result)
+        torch.testing.assert_close(result, expected)
+        self._assert_numeric_mask_reshape(code, r"\[[^\]]*, 1\]")
+        self.assertRegex(code, r"lax\.convert_element_type\([^\n]+, jnp\.bool_\)")
+
     def test_bool_view_expand_where(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def pallas_bool_view_expand_where(x: torch.Tensor) -> torch.Tensor:
@@ -1433,7 +1499,11 @@ class TestPallas(TestCase):
 
         expected = torch.where(x[:, :1] > 0, x, torch.zeros_like(x))
         torch.testing.assert_close(result, expected)
-        self.assertIn("astype(jnp.int32)", code)
+        self.assertIn(".astype(jnp.int32)", code)
+        self.assertIn("jnp.int32", code)
+        self._assert_shape_safe_numeric_mask(code)
+        self._assert_layout_tied_numeric_mask_bits(code)
+        self.assertNotIn("optimization_barrier", code)
 
     def test_bool_expand_inserted_broadcast_dim_where(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
@@ -1457,7 +1527,42 @@ class TestPallas(TestCase):
         expected = torch.where(x[:1, :] < 0, x, torch.zeros_like(x))
         torch.testing.assert_close(result, expected)
         self.assertIn("jnp.broadcast_to", code)
-        self.assertIn("astype(jnp.int32)[None, :]", code)
+        self._assert_numeric_mask_reshape(code, r"\[1,")
+        self.assertNotRegex(
+            code,
+            r"\.astype\(jnp\.int32\)\[None",
+        )
+        self._assert_shape_safe_numeric_mask(code)
+        self._assert_layout_tied_numeric_mask_bits(code)
+        self.assertNotIn("optimization_barrier", code)
+
+    def test_bool_broadcast_where_preserves_inactive_nan(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def pallas_bool_broadcast_where_preserves_inactive_nan(
+            x: torch.Tensor, gates: torch.Tensor
+        ) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile([m, n]):
+                mask = (gates[0, tile_n] > 0).expand(
+                    tile_m.block_size, tile_n.block_size
+                )
+                out[tile_m, tile_n] = torch.where(mask, x[tile_m, tile_n], 0.0)
+            return out
+
+        x = torch.full((16, 128), float("nan"), device=DEVICE, dtype=torch.bfloat16)
+        gates = torch.full((1, 128), -1.0, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_bool_broadcast_where_preserves_inactive_nan,
+            (x, gates),
+            block_sizes=[16, 128],
+        )
+
+        torch.testing.assert_close(result, torch.zeros_like(x))
+        self.assertIn("jnp.bitwise_and", code)
+        self.assertIn("lax.bitcast_convert_type", code)
+        self._assert_shape_safe_numeric_mask(code)
+        self._assert_layout_tied_numeric_mask_bits(code)
 
     def test_bool_subscript_broadcast_where(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
@@ -1481,8 +1586,15 @@ class TestPallas(TestCase):
         expected_mask = (x[:, :1] > 0) & (x[:1, :] < 0)
         expected = torch.where(expected_mask, x, torch.zeros_like(x))
         torch.testing.assert_close(result, expected)
-        self.assertIn("astype(jnp.int32)[:, None]", code)
-        self.assertIn("astype(jnp.int32)[None, :]", code)
+        self._assert_numeric_mask_reshape(code, r"\[[^\]]*, 1\]")
+        self._assert_numeric_mask_reshape(code, r"\[1,")
+        self.assertNotRegex(
+            code,
+            r"\.astype\(jnp\.int32\)\[(None|:)",
+        )
+        self._assert_shape_safe_numeric_mask(code)
+        self._assert_layout_tied_numeric_mask_bits(code)
+        self.assertNotIn("optimization_barrier", code)
 
         @helion.kernel(backend="pallas", static_shapes=True)
         def pallas_bool_unsqueeze_broadcast_where(x: torch.Tensor) -> torch.Tensor:
@@ -1502,8 +1614,192 @@ class TestPallas(TestCase):
         )
 
         torch.testing.assert_close(result, expected)
-        self.assertIn("astype(jnp.int32)[:, None]", code)
-        self.assertIn("astype(jnp.int32)[None, :]", code)
+        self._assert_numeric_mask_reshape(code, r"\[[^\]]*, 1\]")
+        self._assert_numeric_mask_reshape(code, r"\[1,")
+        self.assertNotRegex(
+            code,
+            r"\.astype\(jnp\.int32\)\[(None|:)",
+        )
+        self._assert_shape_safe_numeric_mask(code)
+        self._assert_layout_tied_numeric_mask_bits(code)
+        self.assertNotIn("optimization_barrier", code)
+
+    def test_bool_leading_singleton_broadcast_where(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def pallas_bool_leading_singleton_broadcast_where(
+            x: torch.Tensor,
+        ) -> torch.Tensor:
+            h, m, n = x.size()
+            out = torch.empty_like(x)
+            for tile_h, tile_m, tile_n in hl.tile([h, m, n]):
+                mask = tile_m.index[:, None] >= tile_n.index[None, :]
+                value = x[tile_h, tile_m, tile_n]
+                out[tile_h, tile_m, tile_n] = torch.where(
+                    mask[None, :, :],
+                    value,
+                    torch.zeros_like(value),
+                )
+            return out
+
+        x = torch.randn(8, 64, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_bool_leading_singleton_broadcast_where,
+            (x,),
+            block_sizes=[8, 64, 128],
+        )
+
+        rows = torch.arange(64, device=DEVICE)[:, None]
+        cols = torch.arange(128, device=DEVICE)[None, :]
+        expected = torch.where((rows >= cols)[None, :, :], x, torch.zeros_like(x))
+        torch.testing.assert_close(result, expected)
+        self._assert_numeric_mask_reshape(code, r"\[1,")
+        self.assertNotRegex(
+            code,
+            r"\.astype\(jnp\.int32\)\[None",
+        )
+        self._assert_shape_safe_numeric_mask(code)
+        self._assert_layout_tied_numeric_mask_bits(code)
+        self.assertNotIn("jnp.where(subscript != 0", code)
+        self.assertNotIn("optimization_barrier", code)
+
+    def test_bool_leading_singleton_broadcast_where_fori_loop(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def pallas_bool_leading_singleton_broadcast_where_fori_loop(
+            x: torch.Tensor,
+        ) -> torch.Tensor:
+            h, m, n = x.size()
+            out = torch.empty_like(x)
+            for tile_h in hl.tile(h):
+                for tile_m, tile_n in hl.tile([m, n]):
+                    mask = tile_m.index[:, None] >= tile_n.index[None, :]
+                    value = x[tile_h, tile_m, tile_n]
+                    out[tile_h, tile_m, tile_n] = torch.where(
+                        mask[None, :, :],
+                        value,
+                        torch.zeros_like(value),
+                    )
+            return out
+
+        x = torch.randn(8, 128, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_bool_leading_singleton_broadcast_where_fori_loop,
+            (x,),
+            block_sizes=[8, 64, 128],
+            pallas_loop_type="fori_loop",
+        )
+
+        rows = torch.arange(128, device=DEVICE)[:, None]
+        cols = torch.arange(128, device=DEVICE)[None, :]
+        expected = torch.where((rows >= cols)[None, :, :], x, torch.zeros_like(x))
+        torch.testing.assert_close(result, expected)
+        self.assertIn("jax.lax.fori_loop", code)
+        self._assert_numeric_mask_reshape(code, r"\[1,")
+        self.assertNotRegex(
+            code,
+            r"\.astype\(jnp\.int32\)\[None",
+        )
+        self._assert_shape_safe_numeric_mask(code)
+        self._assert_layout_tied_numeric_mask_bits(code)
+        self.assertNotIn("jnp.where(subscript != 0", code)
+        self.assertNotIn("optimization_barrier", code)
+
+    def test_bool_leading_singleton_broadcast_where_bf16_fori_loop(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def pallas_bool_leading_singleton_broadcast_where_bf16_fori_loop(
+            x: torch.Tensor,
+        ) -> torch.Tensor:
+            h, m, n = x.size()
+            out = torch.empty_like(x)
+            for tile_h in hl.tile(h):
+                for tile_m, tile_n in hl.tile([m, n]):
+                    mask = tile_m.index[:, None] >= tile_n.index[None, :]
+                    value = x[tile_h, tile_m, tile_n]
+                    out[tile_h, tile_m, tile_n] = torch.where(
+                        mask[None, :, :],
+                        value,
+                        torch.zeros_like(value),
+                    )
+            return out
+
+        x = torch.randn(8, 128, 128, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            pallas_bool_leading_singleton_broadcast_where_bf16_fori_loop,
+            (x,),
+            block_sizes=[8, 64, 128],
+            pallas_loop_type="fori_loop",
+        )
+
+        rows = torch.arange(128, device=DEVICE)[:, None]
+        cols = torch.arange(128, device=DEVICE)[None, :]
+        expected = torch.where((rows >= cols)[None, :, :], x, torch.zeros_like(x))
+        torch.testing.assert_close(result, expected)
+        self.assertIn("jax.lax.fori_loop", code)
+        self._assert_numeric_mask_reshape(code, r"\[1,")
+        self.assertNotRegex(
+            code,
+            r"\.astype\(jnp\.int32\)\[None",
+        )
+        self._assert_shape_safe_numeric_mask(code)
+        self._assert_layout_tied_numeric_mask_bits(code)
+        self.assertNotIn("jnp.where(subscript != 0", code)
+        self.assertNotIn("optimization_barrier", code)
+
+    def test_bool_leading_singleton_broadcast_where_bf16_broadcast_value_fori_loop(
+        self,
+    ) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def pallas_bool_leading_singleton_broadcast_where_bf16_broadcast_value_fori_loop(
+            rows: torch.Tensor,
+            cols: torch.Tensor,
+        ) -> torch.Tensor:
+            h, m = rows.size()
+            n = cols.size(1)
+            out = torch.empty([h, m, n], device=rows.device, dtype=rows.dtype)
+            for tile_h in hl.tile(h):
+                for tile_m, tile_n in hl.tile([m, n]):
+                    row_values = rows[tile_h, tile_m].to(torch.float32)
+                    col_values = cols[tile_h, tile_n].to(torch.float32)
+                    value = torch.exp2(
+                        row_values[:, :, None] - col_values[:, None, :]
+                    ).to(rows.dtype)
+                    mask = tile_m.index[:, None] >= tile_n.index[None, :]
+                    out[tile_h, tile_m, tile_n] = torch.where(
+                        mask[None, :, :],
+                        value,
+                        torch.zeros_like(value),
+                    )
+            return out
+
+        rows_arg = torch.randn(8, 64, device=DEVICE, dtype=torch.bfloat16)
+        cols_arg = torch.randn(8, 128, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            pallas_bool_leading_singleton_broadcast_where_bf16_broadcast_value_fori_loop,
+            (rows_arg, cols_arg),
+            block_sizes=[8, 64, 128],
+            pallas_loop_type="fori_loop",
+        )
+
+        row_values = rows_arg.float()[:, :, None]
+        col_values = cols_arg.float()[:, None, :]
+        rows = torch.arange(64, device=DEVICE)[:, None]
+        cols = torch.arange(128, device=DEVICE)[None, :]
+        expected = torch.where(
+            (rows >= cols)[None, :, :],
+            torch.exp2(row_values - col_values).to(rows_arg.dtype),
+            torch.zeros([8, 64, 128], device=DEVICE, dtype=rows_arg.dtype),
+        )
+        torch.testing.assert_close(result, expected)
+        self.assertIn("jax.lax.fori_loop", code)
+        self._assert_numeric_mask_reshape(code, r"\[1,")
+        self._assert_shape_safe_numeric_mask(code)
+        self._assert_layout_tied_numeric_mask_bits(code)
+        self.assertNotRegex(
+            code,
+            r"jnp\.sum\(jnp\.where\([^\n]*\.astype\(jnp\.bfloat16\)"
+            r"[^\n]*!= 0",
+        )
+        self.assertNotIn("jnp.where(subscript != 0", code)
+        self.assertNotIn("optimization_barrier", code)
 
     def test_indirect_gather_with_tiled_dim(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
@@ -4032,6 +4328,24 @@ class TestPallas(TestCase):
         self.assertIn("_pipeline_arg_indices=[1]", code)
         self.assertNotIn("pltpu.make_async_copy", code)
 
+    def test_pallas_loop_prefixed_row_slab_f32_d64_no_dma(self) -> None:
+        x = torch.randn(2, 48, 4, 64, device=DEVICE, dtype=torch.float32)
+        offsets = torch.tensor([0, 11, 37], device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(
+            pallas_owner_prefixed_row_slab_sum,
+            (x, offsets),
+            block_sizes=[8],
+            pallas_loop_type="fori_loop",
+        )
+        self.assertIn("jax.lax.fori_loop", code)
+        self.assertNotIn("_pipeline_arg_indices=", code)
+        self.assertNotIn("pltpu.make_async_copy", code)
+        self.assertIn("pl.ds(", code)
+        ref = torch.stack(
+            [x[g, int(offsets[g]) : int(offsets[g + 1])].sum(dim=0) for g in range(2)]
+        )
+        torch.testing.assert_close(result, ref, rtol=1e-3, atol=1e-3)
+
     def test_tile_id_per_block_accumulator(self) -> None:
         """Writing to ``out[tile.id, :]`` stores one row per outer grid iter.
 
@@ -4249,6 +4563,126 @@ class TestPallas(TestCase):
             all(extra_pad == 0 for *_, extra_pad in pad_dims),
             f"block-aligned begin should skip the pad (extra_pad==0), got {pad_dims}",
         )
+
+    def test_bounded_inner_tile_uses_outer_blockspec_local_ds(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            m = x.size(0)
+            m_block = hl.register_block_size(m)
+            out = torch.empty_like(x)
+            for mb_cta in hl.tile(m, block_size=m_block):
+                for mb in hl.tile(mb_cta.begin, mb_cta.end):
+                    out[mb, :] = x[mb, :] * 2
+            return out
+
+        x = torch.randn(128, 16, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            fn,
+            (x,),
+            block_sizes=[64, 32],
+            pallas_loop_type="fori_loop",
+        )
+        match = re.search(r"_block_spec_info=(\[[^\]]*\])", code)
+        self.assertIsNotNone(match, "expected _block_spec_info in launcher call")
+        block_spec_info = ast.literal_eval(match.group(1))
+        self.assertEqual(
+            block_spec_info,
+            [((64, None), (0, None)), ((64, None), (0, None))],
+        )
+        self.assertRegex(
+            code,
+            r"pl\.ds\(pl\.multiple_of\(offset_\d+ - offset_\d+, "
+            r"_BLOCK_SIZE_\d+\), _BLOCK_SIZE_\d+\)",
+        )
+        torch.testing.assert_close(result, x * 2)
+
+    def test_packed_owner_relative_metadata_alone_requires_store_clamp(self) -> None:
+        from types import SimpleNamespace
+
+        from helion.language._tracing_ops import _store_dim_requires_extent_clamp
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(
+            x: torch.Tensor, offsets: torch.Tensor, values: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for g in hl.grid(offsets.size(0) - 1):
+                start = offsets[g]
+                end = offsets[g + 1]
+                for parent in hl.tile(start, end):
+                    for child in hl.tile(parent.begin, parent.end):
+                        out[child, :] = x[child, :] + values[g]
+            return out
+
+        offsets = torch.tensor([0, 10, 31, 48], device=DEVICE, dtype=torch.int32)
+        x = torch.randn(48, 128, device=DEVICE, dtype=torch.float32)
+        values = torch.tensor([1.0, 3.0, 7.0], device=DEVICE, dtype=torch.float32)
+        bound = fn.bind((x, offsets, values))
+        child_spec = next(
+            spec
+            for spec in bound.config_spec.block_sizes
+            if spec.owner_relative_bounded_by_block_id is not None
+        )
+        parent_block_id = child_spec.owner_relative_bounded_by_block_id
+        self.assertIsNotNone(parent_block_id)
+
+        state = cast(
+            "Any",
+            SimpleNamespace(
+                proxy_args=[None, [offsets[0]], [offsets[1]]],
+                codegen=SimpleNamespace(active_device_loops={}),
+            ),
+        )
+        env = cast(
+            "Any",
+            SimpleNamespace(
+                config_spec=bound.config_spec,
+                known_equal=lambda _a, _b: False,
+                is_jagged_tile=lambda _block_id: False,
+            ),
+        )
+        self.assertTrue(
+            _store_dim_requires_extent_clamp(
+                state,
+                0,
+                x.shape[0],
+                env,
+                child_spec.block_id,
+                {0: child_spec.block_id},
+            )
+        )
+
+    def test_extent_bounded_inner_tile_is_not_owner_relative(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.shape
+            m_block = hl.register_block_size(m)
+            num_blocks = (m + m_block - 1) // m_block
+            out = x.new_empty([num_blocks, 64, n])
+            for mb_cta in hl.tile(m, block_size=m_block):
+                for mb in hl.tile(m_block):
+                    out[mb_cta.id, mb, :] = x[mb, :]
+            return out
+
+        x = torch.randn(128, 16, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            fn,
+            (x,),
+            block_sizes=[64, 32],
+            pallas_loop_type="fori_loop",
+        )
+        match = re.search(r"_block_spec_info=(\[[^\]]*\])", code)
+        self.assertIsNotNone(match, "expected _block_spec_info in launcher call")
+        block_spec_info = ast.literal_eval(match.group(1))
+        self.assertEqual(block_spec_info[0], ((None, None), (None, None)))
+        self.assertEqual(block_spec_info[1], ((None, None, None), (None, None, None)))
+        self.assertNotRegex(
+            code,
+            r"pl\.ds\(pl\.multiple_of\(offset_\d+ - offset_\d+, "
+            r"_BLOCK_SIZE_\d+\)",
+        )
+        expected = torch.stack([x[:64], x[:64]])
+        torch.testing.assert_close(result, expected)
 
     def test_squeeze_slice_access(self) -> None:
         """Test for the [None, :] indexing pattern (subscript index for slice >= tensor_ndim)"""
@@ -5032,8 +5466,8 @@ class TestPallas(TestCase):
 
     def test_transpose_dot_defers_pallas_load_mask(self) -> None:
         """A masked load consumed via ``transpose`` -> dot defers its mask to the
-        consumer layout: a raw load + a post-transpose ``jnp.where``, not an eager
-        multiplicative load mask.
+        consumer layout: a raw load + a post-transpose mask, not an eager load
+        mask.
 
         The deferral is an FX-graph pass, so it is independent of the pallas loop
         type -- asserted here for both ``fori_loop`` and ``compact_worklist`` on a
@@ -5075,13 +5509,13 @@ class TestPallas(TestCase):
                     block_sizes=[block],
                     pallas_loop_type=loop_type,
                 )
-                # x's masked load is raw (no eager ``* mask``), feeds a transpose,
-                # and the mask reappears as a post-transpose ``jnp.where``.
+                # x's masked load is raw, feeds a transpose, and the mask
+                # reappears in the post-transpose layout.
                 producer = self._transpose_operand_producer(code)
                 self.assertIsNotNone(producer)
                 self.assertRegex(producer, r"= x\[")
                 self.assertNotIn("* mask", producer)
-                self.assertIn("jnp.where", code)
+                self.assertRegex(code, r"_mask_to = .*bitcast_convert_type")
                 # compact_worklist matches the eager reference on the partial
                 # tiles.  fori_loop miscompiles jagged tiles in pallas interpret
                 # (a pre-existing, unrelated issue), so it is not a sound numeric
@@ -5127,8 +5561,8 @@ class TestPallas(TestCase):
         # Eager mask retained on the direct dot input; nothing to defer past.
         self.assertRegex(
             code,
-            r"(y\[[^\n]*\][^\n]*\*\s*mask_\d+\.astype|"
-            r"mask_\d+\.astype[^\n]*\*[^\n]*y\[)",
+            r"(\by(?:_buf)?\[[^\n]*\][^\n]*\*\s*mask_\d+\.astype|"
+            r"mask_\d+\.astype[^\n]*\*[^\n]*\by(?:_buf)?\[)",
         )
         self.assertNotRegex(code, r"jnp\.transpose\(")
 
@@ -5692,6 +6126,32 @@ class TestPallas(TestCase):
         ref = torch.zeros_like(x)
         ref[:, :, 16:, :] = x[:, :, 16:, :]
         torch.testing.assert_close(result, ref)
+
+    def test_emit_pipeline_suffix_store_ending_at_tensor_dim_not_clamped(
+        self,
+    ) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def high_rank_suffix_store(x: torch.Tensor) -> torch.Tensor:
+            B, H, M, D = x.size()
+            out = torch.empty_like(x)
+            for tile_b, tile_h in hl.tile([B, H], block_size=[1, 1]):
+                b_idx = tile_b.begin
+                h_idx = tile_h.begin
+                for tile_m in hl.tile(16, M, block_size=128):
+                    out[b_idx, h_idx, tile_m, :] = x[b_idx, h_idx, tile_m, :]
+            return out
+
+        x = torch.randn(2, 8, 250, 128, device=DEVICE, dtype=torch.bfloat16)
+        code = high_rank_suffix_store.bind((x,)).to_code(
+            helion.Config(pallas_loop_type="emit_pipeline")
+        )
+
+        self.assertIn("pltpu.emit_pipeline", code)
+        self.assertIn("out_specs=", code)
+        out_specs = code.split("out_specs=", 1)[1].split("compiler_params=", 1)[0]
+        self.assertIn("pl.BoundedSlice", out_specs)
+        self.assertIn("pl.ds(", out_specs)
+        self.assertNotIn("jnp.minimum(", out_specs)
 
     def test_pallas_0d_tensor_arg(self) -> None:
         """0D tensor arguments shouldn't cause positional argument shift in block specs."""


### PR DESCRIPTION
Stacked PRs:
 * #2879
 * __->__#2878
 * #2877
 * #2876
 * #2875
 * #2874
 * #2873
 * #2872
 * #2871
 * #2870


--- --- ---

### Examples fixed

`examples/mamba2_chunk_scan.py` is the primary gate for bounded inner-loop BlockSpecs. The same compiler path also fixes Pallas execution for `examples/flex_attention.py` and `examples/segment_reduction.py`, where dynamic bounded loads need legal Mosaic alignment. The alignment fix is inherited by the next PR's `examples/split_k_barrier.py` gates.

### Compiler side

This PR generalizes nested Pallas tile handling so an inner BlockSpec can be bounded by its owning outer tile without materializing a full outer ref. The compiler records loop begin/end and offset-alignment metadata, then uses that metadata when deciding whether a `pl.ds` access needs padding, a `multiple_of` hint, or scratch-DMA writeback.

Dynamic inner loads that cannot prove Mosaic alignment can now load the full backing ref and select the requested tile when the widened value fits the VMEM budget. The budget models the actual widened tile by replacing the affected block axis with the full tensor dimension, rather than multiplying the whole tile shape by that dimension. Static nonzero loop begins also contribute their `gcd(begin, block_size)` alignment, which proves common suffix offsets without special-casing shapes.

Store handling now shares one extent-clamp predicate across `fori_loop` and `emit_pipeline`. Full-dim stores, suffix stores that end at the backing tensor dimension, current-tile stores, and jagged parent-scoped stores avoid unsupported lane/sublane clamps; true partial stores still clamp or reject. The pipeline classifier also keeps original per-store subscripts separate from merged BlockSpec metadata, so disjoint partial stores cannot be mistaken for a full overwrite of an initialized or input-backed output.

Masked indirect gathers are lifted once before layout-tied numeric selection. That keeps generated Pallas code compact and stable when a masked gather is used as the select layout anchor.