### PR TITLE
[xpu] Update pinned triton commit to align with pytorch

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -103,7 +103,7 @@
       "alias": "xpu",
       "backend": "triton",
       "triton-repo": "https://github.com/intel/intel-xpu-backend-for-triton.git",
-      "triton-pin": "8997b14d4d6580c401c842ea4fded92cdf7adaa8"
+      "triton-pin": "5fcc14d918045eb2c866336b55229d1253d6d60c"
     },
     {
       "runner": "linux.rocm.gpu.ecosystem.gfx950.1",


### PR DESCRIPTION
This PR updates the pinned triton commit to be the same with PyTorch