### PR TITLE
Support Pallas BlockSpec indexing metadata

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -65,6 +65,149 @@ if TYPE_CHECKING:
 log: logging.Logger = logging.getLogger(__name__)
 
 
+@dataclasses.dataclass(frozen=True)
+class _PallasLaunchExpr:
+    code: str
+
+
+_PallasLaunchValue = int | None | _PallasLaunchExpr
+_PallasFlatDecompValue = (
+    _PallasLaunchValue
+    | tuple[_PallasLaunchValue, _PallasLaunchValue, _PallasLaunchValue]
+    | tuple[
+        _PallasLaunchValue,
+        _PallasLaunchValue,
+        _PallasLaunchValue,
+        _PallasLaunchValue,
+        _PallasLaunchValue,
+    ]
+    | None
+)
+_PallasBlockSpecInfo = list[
+    tuple[tuple[_PallasLaunchValue, ...], tuple[_PallasFlatDecompValue, ...]] | None
+]
+
+
+def _format_pallas_launch_value(value: object) -> str:
+    if isinstance(value, _PallasLaunchExpr):
+        return value.code
+    if isinstance(value, tuple):
+        trailing = "," if len(value) == 1 else ""
+        return (
+            "("
+            + ", ".join(_format_pallas_launch_value(item) for item in value)
+            + trailing
+            + ")"
+        )
+    if isinstance(value, list):
+        return (
+            "[" + ", ".join(_format_pallas_launch_value(item) for item in value) + "]"
+        )
+    return repr(value)
+
+
+def _pallas_launch_code(value: _PallasLaunchValue) -> str:
+    if isinstance(value, _PallasLaunchExpr):
+        return value.code
+    return repr(value)
+
+
+def _pallas_mul_launch_values(
+    lhs: _PallasLaunchValue, rhs: _PallasLaunchValue
+) -> _PallasLaunchValue:
+    if isinstance(lhs, int) and isinstance(rhs, int):
+        return lhs * rhs
+    if lhs == 1:
+        return rhs
+    if rhs == 1:
+        return lhs
+    return _PallasLaunchExpr(
+        f"({_pallas_launch_code(lhs)}) * ({_pallas_launch_code(rhs)})"
+    )
+
+
+def _pallas_add_launch_values(
+    lhs: _PallasLaunchValue, rhs: _PallasLaunchValue
+) -> _PallasLaunchValue:
+    if isinstance(lhs, int) and isinstance(rhs, int):
+        return lhs + rhs
+    if lhs == 0:
+        return rhs
+    if rhs == 0:
+        return lhs
+    return _PallasLaunchExpr(
+        f"({_pallas_launch_code(lhs)}) + ({_pallas_launch_code(rhs)})"
+    )
+
+
+def _pallas_cdiv_launch_values(
+    numerator: _PallasLaunchValue, denominator: _PallasLaunchValue
+) -> _PallasLaunchValue:
+    if isinstance(numerator, int) and isinstance(denominator, int):
+        return -(-numerator // denominator)
+    n_code = _pallas_launch_code(numerator)
+    d_code = _pallas_launch_code(denominator)
+    return _PallasLaunchExpr(f"(({n_code}) + ({d_code}) - 1) // ({d_code})")
+
+
+def _pallas_host_launch_value(
+    value: int | torch.SymInt | sympy.Expr,
+    config: Config,
+) -> _PallasLaunchValue:
+    if isinstance(value, int):
+        return value
+
+    from .compile_environment import CompileEnvironment
+    from .host_function import HostFunction
+
+    env = CompileEnvironment.current()
+    expr = value._sympy_() if isinstance(value, torch.SymInt) else value
+    assert isinstance(expr, sympy.Expr)
+    substitutions = {
+        symbol: config[tunable_name]
+        for symbol, tunable_name in env.tunable_symbols.items()
+        if isinstance(config.get(tunable_name), int)
+    }
+    if substitutions:
+        expr = expr.subs(substitutions)
+        assert isinstance(expr, sympy.Expr)
+    if not expr.free_symbols:
+        return int(str(expr))
+    return _PallasLaunchExpr(HostFunction.current().sympy_expr(expr))
+
+
+def _pallas_configured_block_size(
+    block_id: int,
+    config: Config,
+    *,
+    launch_context: str = "Pallas launch",
+) -> _PallasLaunchValue:
+    from .compile_environment import CompileEnvironment
+
+    env = CompileEnvironment.current()
+    value = env.block_sizes[block_id].from_config(config)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, torch.SymInt):
+        return _pallas_host_launch_value(value, config)
+    raise NotImplementedError(f"{launch_context} requires concrete block sizes")
+
+
+def _pallas_block_numel(
+    block_id: int,
+    config: Config,
+    *,
+    launch_context: str = "Pallas launch",
+) -> _PallasLaunchValue:
+    from .compile_environment import CompileEnvironment
+
+    env = CompileEnvironment.current()
+    size = env.block_sizes[block_id].size
+    if isinstance(size, (int, torch.SymInt)):
+        return _pallas_host_launch_value(size, config)
+    raise NotImplementedError(f"{launch_context} requires concrete block extents")
+
+
 class FlashSearchSurface(NamedTuple):
     head_dim: int
     num_kv: int
@@ -2104,16 +2247,7 @@ class PallasBackend(Backend):
         self,
         sorted_args: list[Argument] | None,
         config: Config,
-    ) -> (
-        list[
-            tuple[
-                tuple[int | None, ...],
-                tuple[int | tuple[int, int, int] | None, ...],
-            ]
-            | None
-        ]
-        | None
-    ):
+    ) -> _PallasBlockSpecInfo | None:
         """Compute per-tensor ``(block_shape, grid_dims)`` from codegen tiling info.
 
         Uses ``DeviceFunction.pallas_tensor_dim_tilings`` (recorded during
@@ -2131,6 +2265,7 @@ class PallasBackend(Backend):
         from .device_function import TensorStrideArg
         from .host_function import HostFunction
         from .program_id import FlatProgramIDs
+        from .program_id import ForEachProgramID
 
         env = CompileEnvironment.current()
         device_fn = DeviceFunction.current()
@@ -2140,15 +2275,52 @@ class PallasBackend(Backend):
         # so pid_info[g].block_id is the block_id assigned to grid dim g.
         if device_fn.pid is None:
             return None
-        flat_grid_block_ids = [pid.block_id for pid in device_fn.pid.pid_info]
+        if isinstance(device_fn.pid, ForEachProgramID):
+            flat_grid_block_ids = [
+                pid_info.block_id
+                for case in device_fn.pid.cases
+                for pid_info in case.pid_info
+            ]
+        else:
+            flat_grid_block_ids = [pid.block_id for pid in device_fn.pid.pid_info]
         block_id_to_grid_dim = {bid: g for g, bid in enumerate(flat_grid_block_ids)}
         known_block_ids = set(block_id_to_grid_dim)
+
+        def block_spec_grid_block_id(block_id: int) -> int | None:
+            """Map an indexed block id to the pallas_call grid block that owns it."""
+            seen: set[int] = set()
+            while block_id not in seen:
+                if block_id in known_block_ids:
+                    return block_id
+                seen.add(block_id)
+                try:
+                    spec = env.config_spec.block_sizes.block_id_lookup(block_id)
+                except KeyError:
+                    return None
+                bounded_by = spec.owner_relative_bounded_by_block_id
+                if bounded_by is None:
+                    return None
+                block_id = bounded_by
+            return None
 
         # FlattenedTileStrategy collapses all block_ids into a single
         # pid_info entry, but the full set lives in device_ir.grid_block_ids.
         # Recover them so we can build flat decomposition and so downstream
         # checks (e.g. 1D tensor validation) see every block_id.
-        flat_decomp: dict[int, tuple[int, int, int]] | None = None
+        flat_decomp: (
+            dict[
+                int,
+                tuple[_PallasLaunchValue, _PallasLaunchValue, _PallasLaunchValue]
+                | tuple[
+                    _PallasLaunchValue,
+                    _PallasLaunchValue,
+                    _PallasLaunchValue,
+                    _PallasLaunchValue,
+                    _PallasLaunchValue,
+                ],
+            ]
+            | None
+        ) = None
         if isinstance(device_fn.pid, FlatProgramIDs):
             device_ir = HostFunction.current().device_ir
             all_grid_block_ids = [
@@ -2157,29 +2329,43 @@ class PallasBackend(Backend):
             known_block_ids.update(all_grid_block_ids)
 
             if len(all_grid_block_ids) > 1:
-                import sympy
-
                 stride = 1
                 flat_decomp = {}
                 for bid in all_grid_block_ids:
-                    bs = env.block_sizes[bid].from_config(config)
-                    numel = env.block_sizes[bid].numel
-                    if not isinstance(bs, int) or isinstance(numel, str):
-                        return None
-                    try:
-                        numel_val = (
-                            int(numel) if isinstance(numel, sympy.Expr) else numel
-                        )
-                    except (TypeError, ValueError):
-                        return None
-                    num_blocks = -(-numel_val // bs)  # cdiv
+                    bs = _pallas_configured_block_size(bid, config)
+                    num_blocks = _pallas_cdiv_launch_values(
+                        _pallas_block_numel(bid, config), bs
+                    )
                     flat_decomp[bid] = (0, stride, num_blocks)
-                    stride *= num_blocks
+                    stride = _pallas_mul_launch_values(stride, num_blocks)
+        elif isinstance(device_fn.pid, ForEachProgramID):
+            flat_decomp = {}
+            case_start: _PallasLaunchValue = 0
+            for case in device_fn.pid.cases:
+                stride: _PallasLaunchValue = 1
+                case_entries: list[
+                    tuple[int, _PallasLaunchValue, _PallasLaunchValue]
+                ] = []
+                for pid_info in case.pid_info:
+                    bid = pid_info.block_id
+                    bs = _pallas_configured_block_size(bid, config)
+                    num_blocks = _pallas_cdiv_launch_values(
+                        _pallas_block_numel(bid, config), bs
+                    )
+                    case_entries.append((bid, stride, num_blocks))
+                    stride = _pallas_mul_launch_values(stride, num_blocks)
+                case_total = stride
+                for bid, bid_stride, num_blocks in case_entries:
+                    flat_decomp[bid] = (
+                        0,
+                        bid_stride,
+                        num_blocks,
+                        case_start,
+                        case_total,
+                    )
+                case_start = _pallas_add_launch_values(case_start, case_total)
 
-        result: list[
-            tuple[tuple[int | None, ...], tuple[int | tuple[int, int, int] | None, ...]]
-            | None
-        ] = []
+        result: _PallasBlockSpecInfo = []
 
         for arg in sorted_args:
             if isinstance(arg, (SymbolArgument, TensorSizeArg, TensorStrideArg)):
@@ -2195,9 +2381,20 @@ class PallasBackend(Backend):
             if dim_tilings is None:
                 # this means this tensor isn't accessed at all in the kernel
                 result.append(None)
-                return None
-            block_shape: list[int | None] = []
-            grid_dims: list[int | tuple[int, int, int] | None] = []
+                continue
+            block_shape: list[_PallasLaunchValue] = []
+            grid_dims: list[
+                _PallasLaunchValue
+                | tuple[_PallasLaunchValue, _PallasLaunchValue, _PallasLaunchValue]
+                | tuple[
+                    _PallasLaunchValue,
+                    _PallasLaunchValue,
+                    _PallasLaunchValue,
+                    _PallasLaunchValue,
+                    _PallasLaunchValue,
+                ]
+                | None
+            ] = []
             for d in range(tensor.ndim):
                 dim_tiling = dim_tilings[d]
                 if not dim_tiling.can_tile or len(dim_tiling.block_ids) == 0:
@@ -2206,27 +2403,96 @@ class PallasBackend(Backend):
                     continue
                 assert len(dim_tiling.block_ids) == 1
                 bid = dim_tiling.block_ids[0]
-                if bid is not None and bid in known_block_ids:
-                    bs = env.block_sizes[bid].from_config(config)
-                    if isinstance(bs, int):
-                        block_shape.append(bs)
-                        dim_size = tensor.shape[d]
-                        # When the block covers the entire tensor
-                        # dimension there is only one tile, so the grid
-                        # index must be constant 0 — iterating would
-                        # read out-of-bounds (e.g. bias [1, N] with
-                        # block_size > 1).
-                        if isinstance(dim_size, int) and dim_size <= bs:
-                            grid_dims.append(None)
-                        elif flat_decomp is not None and bid in flat_decomp:
-                            grid_dims.append(flat_decomp[bid])
-                        else:
-                            grid_dims.append(block_id_to_grid_dim[bid])
-                        continue
+                grid_bid = block_spec_grid_block_id(bid)
+                if grid_bid is not None:
+                    bs = _pallas_configured_block_size(grid_bid, config)
+                    block_shape.append(bs)
+                    dim_size = tensor.shape[d]
+                    # When the block covers the entire tensor dimension there
+                    # is only one tile, so the grid index must be constant 0.
+                    if (
+                        isinstance(bs, int)
+                        and isinstance(dim_size, int)
+                        and dim_size <= bs
+                    ):
+                        grid_dims.append(None)
+                    elif flat_decomp is not None and grid_bid in flat_decomp:
+                        grid_dims.append(flat_decomp[grid_bid])
+                    else:
+                        grid_dims.append(block_id_to_grid_dim[grid_bid])
+                    continue
                 block_shape.append(None)
                 grid_dims.append(None)
             result.append((tuple(block_shape), tuple(grid_dims)))
         return result
+
+    def _pallas_phase_case_metadata(
+        self,
+        sorted_args: list[Argument] | None,
+        config: Config,
+    ) -> (
+        tuple[int, tuple[tuple[int, _PallasLaunchValue, _PallasLaunchValue], ...]]
+        | None
+    ):
+        """Return phase arg position plus global PID ranges for Pallas phases."""
+        if sorted_args is None:
+            return None
+
+        from .device_function import DeviceFunction
+        from .device_function import SymbolArgument
+        from .program_id import ForEachProgramID
+
+        device_fn = DeviceFunction.current()
+        phase_arg = getattr(device_fn.codegen, "_pallas_barrier_phase_arg", None)
+        if (
+            phase_arg is None
+            or not isinstance(device_fn.pid, ForEachProgramID)
+            or len(set(device_fn.pid.case_phases)) <= 1
+        ):
+            return None
+
+        phase_arg_index = next(
+            (
+                i
+                for i, arg in enumerate(sorted_args)
+                if isinstance(arg, SymbolArgument) and arg.name == phase_arg
+            ),
+            None,
+        )
+        if phase_arg_index is None:
+            raise NotImplementedError(
+                "Pallas phase launches require the phase argument in launcher args"
+            )
+        if len(device_fn.pid.case_phases) != len(device_fn.pid.cases):
+            raise NotImplementedError(
+                "Pallas phase launches require one phase entry per ForEach case"
+            )
+
+        ranges: list[tuple[int, _PallasLaunchValue, _PallasLaunchValue]] = []
+        start: _PallasLaunchValue = 0
+        for phase, case in zip(
+            device_fn.pid.case_phases, device_fn.pid.cases, strict=True
+        ):
+            total: _PallasLaunchValue = 1
+            for pid_info in case.pid_info:
+                bs = _pallas_configured_block_size(
+                    pid_info.block_id,
+                    config,
+                    launch_context="Pallas phase launches",
+                )
+                num_blocks = _pallas_cdiv_launch_values(
+                    _pallas_block_numel(
+                        pid_info.block_id,
+                        config,
+                        launch_context="Pallas phase launches",
+                    ),
+                    bs,
+                )
+                total = _pallas_mul_launch_values(total, num_blocks)
+            end = _pallas_add_launch_values(start, total)
+            ranges.append((phase, start, end))
+            start = end
+        return phase_arg_index, tuple(ranges)
 
     def _compute_pad_info(
         self,
@@ -2482,6 +2748,11 @@ class PallasBackend(Backend):
                     output_indices.append(i)
                     inplace_indices.append(i)
 
+        if has_barrier:
+            # Pallas barriers run as multiple host launches. Keep every output
+            # as an in-place tensor so host temporaries survive across phases.
+            inplace_indices = list(output_indices)
+
         # Collect output-only tensor names so codegen can retarget their
         # allocations to ``device='meta'`` and capture the launcher return.
         output_only_set = set(output_indices) - set(inplace_indices)
@@ -2505,7 +2776,20 @@ class PallasBackend(Backend):
         if block_spec_info is not None:
             if has_rng_ops:
                 block_spec_info.append(None)  # RNG seed buffer is untiled
-            launcher_args.append(f"_block_spec_info={block_spec_info!r}")
+            launcher_args.append(
+                f"_block_spec_info={_format_pallas_launch_value(block_spec_info)}"
+            )
+
+        phase_case_metadata = (
+            self._pallas_phase_case_metadata(sorted_args, config)
+            if has_barrier
+            else None
+        )
+        if phase_case_metadata is not None:
+            launcher_args.append(
+                "_pallas_phase_case_metadata="
+                f"{_format_pallas_launch_value(phase_case_metadata)}"
+            )
 
         pad_info = self._compute_pad_info(sorted_args, config)
         if pad_info:

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -215,6 +215,8 @@ class CompileEnvironment:
     No config or codegen specific state should be stored here.
     """
 
+    tunable_symbols: dict[sympy.Symbol, str]
+
     def __init__(
         self,
         device: torch.device,
@@ -289,6 +291,7 @@ class CompileEnvironment:
         self._foreign_symint_cache: dict[
             tuple[int, sympy.Expr], int | torch.SymInt
         ] = {}
+        self.tunable_symbols = {}
         if settings.autotune_force_persistent or dist.is_initialized():
             for pid_type in (
                 "flat",

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import math
 from typing import TYPE_CHECKING
 
 import torch
@@ -563,20 +564,40 @@ def _slice_code(
     from helion._compiler.tile_strategy import DeviceLoopState
 
     assert isinstance(pattern, ArbitrarySlicePattern)
+    slice_idx = pattern.slice
 
-    if idx != slice(None):
+    if slice_idx.step not in (None, 1):
         raise AssertionError(
-            f"Arbitrary slice expr {slice} not supported in Pallas backend yet"
+            f"Only unit-step slices are supported in Pallas, got {slice_idx}"
         )
+    full_slice = slice_idx.start is None and slice_idx.stop is None
 
     env = CompileEnvironment.current()
     block_id = env.resolve_block_id(tensor.shape[tensor_dim])
-    if block_id is not None:
+    if full_slice and block_id is not None:
         loops = state.codegen.active_device_loops.get(block_id)
         if loops and any(isinstance(loop, DeviceLoopState) for loop in loops):
             return _ds_expr(state, block_id, tensor=tensor, tensor_dim=tensor_dim)
 
-    return ":"
+    if full_slice:
+        return ":"
+
+    def bound_expr(value: object) -> str:
+        if value is None:
+            return "None"
+        if isinstance(value, int) and value >= 0:
+            return repr(value)
+        if isinstance(value, torch.SymInt):
+            expr = env.specialize_expr(env.shape_env.replace(value._sympy_()))
+            if not expr.free_symbols and getattr(expr, "is_integer", None) is True:
+                concrete = int(expr)
+                if concrete >= 0:
+                    return repr(concrete)
+        raise AssertionError(
+            f"Only static slice bounds are supported in Pallas, got {slice_idx}"
+        )
+
+    return f"slice({bound_expr(slice_idx.start)}, {bound_expr(slice_idx.stop)})"
 
 
 def _is_compact_aligned_load(
@@ -627,37 +648,104 @@ def _ds_expr(
     # sliced block at local offset 0, not the absolute tile_start.
     if not tile_offset and _is_compact_aligned_load(state, block_id, tensor):
         return f"pl.ds(0, {block_size})"
+    local_owner_block_id = (
+        _bounded_local_owner_block_id(state, block_id, tensor, tensor_dim)
+        if tensor is not None and tensor_dim is not None
+        else None
+    )
+    if local_owner_block_id is not None:
+        owner_offset = state.codegen.offset_var(local_owner_block_id)
+        offset = f"({offset}) - ({owner_offset})"
     if tensor is not None and tensor_dim is not None:
         from helion.language.memory_ops import _record_pad_info
 
-        extra_pad = _loop_begin_extra_pad(block_id, state)
+        extra_pad = (
+            0
+            if local_owner_block_id is not None
+            else _loop_begin_extra_pad(block_id, state)
+        )
         _record_pad_info(state, tensor, tensor_dim, block_id, extra_pad)
 
         # Skip when tile_offset is set (e.g. offset + 64) — the shift
         # means the full expression may not be a multiple of block_size.
         if not tile_offset:
-            alignment = _loop_offset_alignment(block_id, state)
-            if alignment is not None:
-                # Workaround for JAX <= 0.10.0 where AssumeMultipleOp
-                # short-circuits divisibility analysis (fixed in
-                # jax-ml/jax@33c38f50b): only apply when alignment meets
-                # Mosaic's requirement, otherwise the hint could replace
-                # a stronger proof Mosaic already has.
-                from helion._compiler.backend import PallasBackend
-                from helion._compiler.compile_environment import CompileEnvironment
+            alignment = (
+                state.device_function.resolved_block_size(block_id)
+                if local_owner_block_id is not None
+                else _loop_offset_alignment(block_id, state)
+            )
+            # Workaround for JAX <= 0.10.0 where AssumeMultipleOp
+            # short-circuits divisibility analysis (fixed in
+            # jax-ml/jax@33c38f50b): only apply when the hint meets Mosaic's
+            # requirement, otherwise it could replace a stronger proof Mosaic
+            # already has.
+            from helion._compiler.backend import PallasBackend
+            from helion._compiler.compile_environment import CompileEnvironment
 
-                backend = CompileEnvironment.current().backend
-                assert isinstance(backend, PallasBackend)
-                dim_from_end = tensor.ndim - 1 - tensor_dim
-                bitwidth = tensor.dtype.itemsize * 8
-                required = backend._get_pallas_required_alignment(
-                    dim_from_end, tensor.ndim, bitwidth
-                )
-                if alignment % required == 0:
-                    # e.g. pl.ds(pl.multiple_of(offset_3, _BLOCK_SIZE_3), _BLOCK_SIZE_3)
-                    offset = f"pl.multiple_of({offset}, {block_size})"
+            backend = CompileEnvironment.current().backend
+            assert isinstance(backend, PallasBackend)
+            dim_from_end = tensor.ndim - 1 - tensor_dim
+            bitwidth = tensor.dtype.itemsize * 8
+            required = backend._get_pallas_required_alignment(
+                dim_from_end, tensor.ndim, bitwidth
+            )
+            if alignment is not None and alignment % required == 0:
+                hint = required
+                bs_value = state.device_function.resolved_block_size(block_id)
+                if isinstance(bs_value, int) and alignment % bs_value == 0:
+                    hint = block_size
+                # e.g. pl.ds(pl.multiple_of(offset_3, _BLOCK_SIZE_3), _BLOCK_SIZE_3)
+                offset = f"pl.multiple_of({offset}, {hint})"
+            elif _is_zero_begin_single_tile_dim(block_id, state, tensor, tensor_dim):
+                offset = f"pl.multiple_of({offset}, {required})"
 
     return f"pl.ds({offset}, {block_size})"
+
+
+def _bounded_local_owner_block_id(
+    state: CodegenState,
+    block_id: int,
+    tensor: torch.Tensor | None,
+    tensor_dim: int | None,
+) -> int | None:
+    """Return the outer grid block that owns a bounded inner tile's BlockSpec."""
+    if tensor is None or tensor_dim is None:
+        return None
+
+    from helion._compiler.compile_environment import CompileEnvironment
+    from helion._compiler.device_function import PallasMemorySpace
+    from helion._compiler.tile_strategy import DeviceGridState
+
+    if (
+        state.device_function.pallas_memory_space.get(id(tensor))
+        == PallasMemorySpace.HBM
+    ):
+        return None
+
+    dim_tilings = state.device_function.pallas_tensor_dim_tilings.get(id(tensor))
+    if dim_tilings is None or tensor_dim >= len(dim_tilings):
+        return None
+    dim_tiling = dim_tilings[tensor_dim]
+    if not dim_tiling.can_tile or dim_tiling.block_ids != [block_id]:
+        return None
+
+    env = CompileEnvironment.current()
+    seen: set[int] = set()
+    current = block_id
+    while current not in seen:
+        seen.add(current)
+        try:
+            spec = env.config_spec.block_sizes.block_id_lookup(current)
+        except KeyError:
+            return None
+        parent = spec.owner_relative_bounded_by_block_id
+        if parent is None:
+            return None
+        loops = state.codegen.active_device_loops.get(parent)
+        if loops and any(isinstance(loop, DeviceGridState) for loop in loops):
+            return parent
+        current = parent
+    return None
 
 
 def _loop_begin_extra_pad(block_id: int, state: CodegenState) -> int:
@@ -680,10 +768,15 @@ def _loop_begin_extra_pad(block_id: int, state: CodegenState) -> int:
         return 0
 
     info = loops[-1].block_id_to_info.get(block_id)
-    if info is None or info.begin_expr is None:
+    if info is None:
         return 0
 
     begin = info.begin_expr
+    if begin is None:
+        alignment = info.offset_alignment
+        if isinstance(alignment, int) and alignment > 0:
+            return (bs_value - math.gcd(bs_value, alignment)) % bs_value
+        return bs_value - 1
     if isinstance(begin, (int, sympy.Integer)):
         return int(begin) % bs_value
 
@@ -696,9 +789,8 @@ def _loop_offset_alignment(
 ) -> int | None:
     """Return the proven alignment of a loop's offset for *block_id*, or ``None``.
 
-    A loop with step ``block_size`` produces offsets ``begin + i * block_size``,
-    which are multiples of ``block_size`` iff ``begin`` is.  Returns
-    ``block_size`` (int) when provable, ``None`` otherwise.
+    A loop with step ``block_size`` produces offsets ``begin + i * block_size``.
+    Returns a proven divisor of that offset expression when available.
     """
     import sympy
 
@@ -706,18 +798,62 @@ def _loop_offset_alignment(
     if not isinstance(bs_value, int):
         return None
 
-    # Check that the loop begins at a multiple of block_size.
     loops = state.codegen.active_device_loops.get(block_id)
     if loops:
         info = loops[-1].block_id_to_info.get(block_id)
-        if info is not None and info.begin_expr is not None:
-            begin = info.begin_expr
-            if not isinstance(begin, (int, sympy.Integer)):
-                return None  # symbolic begin — can't prove alignment
-            if int(begin) % bs_value != 0:
-                return None
+        if info is None:
+            return None
+        offset_alignment = info.offset_alignment
+        if isinstance(offset_alignment, int) and offset_alignment > 0:
+            return offset_alignment
+        begin = info.begin_expr
+        if begin is None:
+            return None
+        if not isinstance(begin, (int, sympy.Integer)):
+            return None  # symbolic begin — can't prove alignment
+        return math.gcd(abs(int(begin)), bs_value)
 
     return bs_value
+
+
+def _is_zero_begin_single_tile_dim(
+    block_id: int,
+    state: CodegenState,
+    tensor: torch.Tensor,
+    tensor_dim: int,
+) -> bool:
+    """True when a zero-begin loop has only one in-bounds concrete tensor tile."""
+    import sympy
+
+    from helion._compiler.compile_environment import CompileEnvironment
+
+    bs_value = state.device_function.resolved_block_size(block_id)
+    if not isinstance(bs_value, int):
+        return False
+
+    loops = state.codegen.active_device_loops.get(block_id)
+    if not loops:
+        return False
+
+    info = loops[-1].block_id_to_info.get(block_id)
+    if info is None or info.begin_expr not in (0, sympy.Integer(0)):
+        return False
+
+    env = CompileEnvironment.current()
+    dim_size = tensor.shape[tensor_dim]
+    if isinstance(dim_size, int):
+        return env.settings.static_shapes and dim_size <= bs_value
+    if not isinstance(dim_size, torch.SymInt):
+        return False
+
+    dim_expr = env.shape_env.replace(dim_size._sympy_())
+    if not dim_expr.free_symbols <= env.specialized_vars:
+        return False
+    dim_expr = env.specialize_expr(dim_expr)
+    if dim_expr.free_symbols or getattr(dim_expr, "is_integer", None) is not True:
+        return False
+    dim_value = int(dim_expr)
+    return dim_value <= bs_value
 
 
 def vmem_name(state: CodegenState, name: str) -> str:

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -56,6 +56,30 @@ class ArbitrarySlicePattern(IndexingPattern):
     slice: slice
 
 
+def _is_full_slice(idx: slice) -> bool:
+    return idx.start is None and idx.stop is None and idx.step in (None, 1)
+
+
+def _static_slice_bound(value: object, env: CompileEnvironment) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value if value >= 0 else None
+    if isinstance(value, torch.SymInt):
+        expr = env.specialize_expr(env.shape_env.replace(value._sympy_()))
+        if isinstance(expr, sympy.Integer) and expr >= 0:
+            return int(expr)
+    return None
+
+
+def _is_static_contiguous_slice(idx: slice, env: CompileEnvironment) -> bool:
+    if idx.step not in (None, 1):
+        return False
+    return (idx.start is None or _static_slice_bound(idx.start, env) is not None) and (
+        idx.stop is None or _static_slice_bound(idx.stop, env) is not None
+    )
+
+
 @dataclass
 class ArbitraryIndexPattern(IndexingPattern):
     index: int | torch.SymInt | object | None
@@ -91,10 +115,12 @@ class DimensionTiling:
 
     can_tile: whether or not we can tile this dimension
     block_ids: which which block_ids we are indexing this dimension (there can be multiple, in which case we mustn't tile)
+    needs_full_slice: whether this dimension is also read as a full slice
     """
 
     can_tile: bool = True
     block_ids: list[int] = field(default_factory=list)
+    needs_full_slice: bool = False
 
 
 def plan_tiling(
@@ -261,9 +287,9 @@ def _detect_indexing_pattern(
         return ArbitraryIndexPattern(idx)
 
     if isinstance(idx, slice):
-        if idx != slice(None):
+        if not _is_static_contiguous_slice(idx, env):
             raise AssertionError(
-                f"Arbitrary slice expr {slice} not supported in Pallas backend yet"
+                f"Only static contiguous slices are supported in Pallas backend, got {idx}"
             )
         return ArbitrarySlicePattern(idx)
 
@@ -295,6 +321,13 @@ def _update_tiling_decision(
                 # we already need to tile this dim using a different block_id
                 # so fallback to no-tiling so that we can access using both tiles
                 _disallow_tiling()
+        if curr_dim_tiling.needs_full_slice:
+            _disallow_tiling()
+
+    def _record_full_slice() -> None:
+        curr_dim_tiling.needs_full_slice = True
+        if curr_dim_tiling.block_ids:
+            _disallow_tiling()
 
     if isinstance(pattern, TilePattern):
         _try_set_tiling_block_id(pattern.block_id)
@@ -313,7 +346,9 @@ def _update_tiling_decision(
                 _disallow_tiling()
 
     elif isinstance(pattern, ArbitrarySlicePattern):
-        if pattern.slice != slice(None):
+        if _is_full_slice(pattern.slice):
+            _record_full_slice()
+        else:
             # fow now we only support the `[:]` slice pattern
             _disallow_tiling()
 

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -1804,6 +1804,7 @@ class LoopDimInfo:
     begin_expr: sympy.Expr | None = None
     end_var_name: str | None = None
     end_expr: sympy.Expr | None = None
+    offset_alignment: int | None = None
 
     def is_end_matching(self, size: int | torch.SymInt) -> bool:
         expected = _to_sympy(size)

--- a/helion/_compiler/type_info.py
+++ b/helion/_compiler/type_info.py
@@ -1055,6 +1055,34 @@ def _detect_outer_block_bound(
     return None
 
 
+def _detect_owner_relative_outer_block_bound(
+    begin: object,
+    end: object,
+) -> int | None:
+    """Return the owner block when bounds are exactly ``owner.begin/end``."""
+    from .variable_origin import TileBeginOrigin
+    from .variable_origin import TileEndOrigin
+
+    def exact_origin(value: object) -> Origin | None:
+        if not isinstance(value, torch.SymInt):
+            return None
+        expr = _symint_expr(value)
+        if expr is None:
+            return None
+        symbol_origin = HostFunction.current().expr_to_origin.get(expr)
+        return symbol_origin.origin if symbol_origin is not None else None
+
+    begin_origin = exact_origin(begin)
+    end_origin = exact_origin(end)
+    if (
+        isinstance(begin_origin, TileBeginOrigin)
+        and isinstance(end_origin, TileEndOrigin)
+        and begin_origin.block_id == end_origin.block_id
+    ):
+        return begin_origin.block_id
+    return None
+
+
 class TileIndexType(TypeInfo):
     block_id: int
 
@@ -1082,12 +1110,14 @@ class TileIndexType(TypeInfo):
         numel: int | torch.SymInt | AutoSize | None,
         origin: Origin,
         block_size: int | torch.SymInt | None = None,
+        owner_relative_bounded_by_block_id: int | None = None,
     ) -> TileIndexType:
         env = CompileEnvironment.current()
         if block_size is None:
             block_id = env.allocate_block_size(numel, source=LoopSpecBlockSizeSource())
             outer_max: int | None = None
             bounded_by: int | None = None
+            owner_relative_bounded_by: int | None = None
             if isinstance(numel, torch.SymInt):
                 maybe_bounded_by = _detect_outer_block_bound(numel, env)
                 if maybe_bounded_by is not None:
@@ -1100,12 +1130,15 @@ class TileIndexType(TypeInfo):
                     else:
                         bounded_by = maybe_bounded_by
                         outer_max = outer_spec.max_size
+                        if owner_relative_bounded_by_block_id == maybe_bounded_by:
+                            owner_relative_bounded_by = maybe_bounded_by
             env.config_spec.block_sizes.append(
                 BlockSizeSpec(
                     block_id=block_id,
                     size_hint=_get_hint(numel),
                     max_size=outer_max,
                     bounded_by_block_id=bounded_by,
+                    owner_relative_bounded_by_block_id=owner_relative_bounded_by,
                 )
             )
             if env.config_spec.supports_config_key("num_threads"):

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -2161,6 +2161,7 @@ class BlockSizeSpec(_PowerOfTwoBlockIdItem):
         min_size: int = 1,
         max_size: int | None = None,
         bounded_by_block_id: int | None = None,
+        owner_relative_bounded_by_block_id: int | None = None,
     ) -> None:
         super().__init__([block_id])
         self.size_hint = size_hint
@@ -2180,6 +2181,10 @@ class BlockSizeSpec(_PowerOfTwoBlockIdItem):
         )
         # Outer block_id whose tile extent caps this block's size in normalize().
         self.bounded_by_block_id: int | None = bounded_by_block_id
+        # Outer block_id whose tile begin/end are this tile's actual address base.
+        self.owner_relative_bounded_by_block_id: int | None = (
+            owner_relative_bounded_by_block_id
+        )
         if self.max_size < self.min_size:
             self.max_size = self.min_size
         assert self.min_size <= self.max_size
@@ -2192,6 +2197,7 @@ class BlockSizeSpec(_PowerOfTwoBlockIdItem):
             ("min_size", 1),
             ("max_size", next_power_of_2(self.size_hint)),
             ("bounded_by_block_id", None),
+            ("owner_relative_bounded_by_block_id", None),
         ):
             value = getattr(self, field)
             if value != default:

--- a/helion/language/loops.py
+++ b/helion/language/loops.py
@@ -32,6 +32,7 @@ from .._compiler.type_info import SequenceType
 from .._compiler.type_info import TensorType
 from .._compiler.type_info import TileIndexType
 from .._compiler.type_info import TypeInfo
+from .._compiler.type_info import _detect_owner_relative_outer_block_bound
 from .._compiler.variable_origin import GetItemOrigin
 from ..autotuner.config_spec import ConfigSpec
 from ..autotuner.config_spec import FlattenLoopSpec
@@ -355,7 +356,15 @@ def _(
         if isinstance(begin_part, torch.SymInt) or isinstance(end_part, torch.SymInt):
             has_symbolic_bounds = True
         if bs is None:
-            results.append(TileIndexType.allocate(size, origin))
+            results.append(
+                TileIndexType.allocate(
+                    size,
+                    origin,
+                    owner_relative_bounded_by_block_id=(
+                        _detect_owner_relative_outer_block_bound(begin_part, end_part)
+                    ),
+                )
+            )
         elif isinstance(bs, int):
             results.append(TileIndexType.allocate(size, origin, bs))
         elif isinstance(bs, torch.SymInt):


### PR DESCRIPTION
Stacked PRs:
 * #2899
 * #2898
 * #2897
 * #2896
 * #2895
 * #2894
 * #2893
 * #2892
 * #2891
 * #2890
 * #2889
 * #2888
 * #2887
 * #2886
 * #2885
 * __->__#2884
 * #2883


--- --- ---

### Support Pallas BlockSpec indexing metadata


No example is enabled directly by this commit. It teaches Pallas launch metadata to describe symbolic block sizes, flattened ForEach PID decompositions, and owner-relative bounded inner tiles so runtime `BlockSpec` index maps can address the right logical tile instead of assuming a direct grid-dimension mapping.