### PR TITLE
Support Pallas numeric masks and scalar predicates

### DIFF
--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -363,6 +363,7 @@ class ReductionLoopGraphInfo(ForLoopGraphInfo):
 @dataclasses.dataclass
 class IfGraphInfo(NodeArgsGraphInfo):
     predicate_is_tensor: bool = False
+    predicate_tensor_numel: int | torch.SymInt | None = None
     else_branch: ElseGraphInfo | None = None
 
     if_arg_names: list[str] | None = None
@@ -382,6 +383,7 @@ class IfGraphInfo(NodeArgsGraphInfo):
         return {
             **super().kwargs(),
             "predicate_is_tensor": self.predicate_is_tensor,
+            "predicate_tensor_numel": self.predicate_tensor_numel,
             "else_branch": self.else_branch,
             "if_arg_names": self.if_arg_names,
             "else_arg_names": self.else_arg_names,
@@ -2015,10 +2017,13 @@ class WalkDeviceAST(NodeVisitor):
         body: list[ast.stmt],
         orelse: list[ast.stmt],
     ) -> int:
-        # Track whether the predicate is a tensor with numel > 1
-        predicate_is_tensor = (
-            isinstance(test_proxy, torch.Tensor) and math.prod(test_proxy.shape) > 1
+        predicate_tensor_numel: int | torch.SymInt | None
+        predicate_tensor_numel = (
+            math.prod(test_proxy.shape)
+            if isinstance(test_proxy, torch.Tensor)
+            else None
         )
+        predicate_is_tensor = predicate_tensor_numel is not None
 
         if_branch_rw: ReadWrites = ReadWrites.from_list(body)
         else_branch_rw: ReadWrites = ReadWrites.from_list(orelse)
@@ -2048,6 +2053,7 @@ class WalkDeviceAST(NodeVisitor):
             functools.partial(build_body, stmts=body, rw=if_branch_rw),
             graph_info_cls=IfGraphInfo,
             predicate_is_tensor=predicate_is_tensor,
+            predicate_tensor_numel=predicate_tensor_numel,
             else_branch=else_graph_idx,
         )
         if_graph = cast("IfGraphInfo", self.device_ir.graphs[if_graph_idx])

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -17,6 +17,148 @@ if TYPE_CHECKING:
     from helion._compiler.tile_strategy import DeviceLoopOrGridState
 
 
+def _select_mask_dtype(dtype: torch.dtype) -> str | None:
+    if dtype.is_floating_point:
+        if dtype is torch.float64:
+            return None
+        if dtype.itemsize == 1:
+            return "jnp.uint8"
+        if dtype.itemsize == 2:
+            return "jnp.uint16"
+        if dtype.itemsize == 4:
+            return "jnp.uint32"
+        return None
+    if dtype is torch.int8:
+        return "jnp.int8"
+    if dtype is torch.int16:
+        return "jnp.int16"
+    if dtype is torch.int32:
+        return "jnp.int32"
+    if dtype is torch.uint8:
+        return "jnp.uint8"
+    if dtype is torch.uint32:
+        return "jnp.uint32"
+    return None
+
+
+def layout_tied_bf16_mask_expr(
+    mask: ast.AST,
+    layout_anchor: ast.AST,
+) -> ast.AST:
+    """Expand a numeric predicate through a value whose layout Mosaic already knows."""
+
+    mask_value = expr_from_string(
+        "lax.convert_element_type({mask}, jnp.bfloat16)",
+        mask=mask,
+    )
+    return expr_from_string(
+        "jnp.ones_like({layout_anchor}, dtype=jnp.bfloat16) * ({mask_value})",
+        mask_value=mask_value,
+        layout_anchor=layout_anchor,
+    )
+
+
+def numeric_mask_expr(mask: ast.AST, dtype: str = "jnp.int32") -> ast.AST:
+    """Materialize a predicate as a numeric 0/1 tensor before shape relayouts."""
+
+    return expr_from_string(
+        f"jnp.minimum(({{mask}}).astype({dtype}), jnp.array(1, dtype={dtype}))",
+        mask=mask,
+    )
+
+
+def numeric_mask_reshape_expr(
+    mask: ast.AST, shape: str, dtype: str = "jnp.int32"
+) -> ast.AST:
+    """Cast a predicate to numeric, then add singleton dimensions by reshape."""
+
+    return expr_from_string(
+        f"jnp.reshape({{mask}}, {shape})",
+        mask=numeric_mask_expr(mask, dtype),
+    )
+
+
+def numeric_where_expr(
+    mask: ast.AST,
+    true_value: ast.AST,
+    false_value: ast.AST,
+    output_dtype: torch.dtype,
+    layout_anchor: ast.AST | None = None,
+) -> ast.AST | None:
+    """Select with a layout-tied numeric bit mask on TPU."""
+
+    from helion._compiler.compile_environment import CompileEnvironment
+
+    mask_dtype = _select_mask_dtype(output_dtype)
+    if mask_dtype is None:
+        return None
+    value_dtype = CompileEnvironment.current().backend.dtype_str(output_dtype)
+    if layout_anchor is None:
+        layout_anchor = true_value
+    mask_value = (
+        "lax.convert_element_type("
+        "jnp.ones_like({layout_anchor}, dtype=jnp.bfloat16) * "
+        "lax.convert_element_type({mask}, jnp.bfloat16), "
+        f"{mask_dtype})"
+    )
+    mask_bits = (
+        f"(jnp.zeros_like({{layout_anchor}}, dtype={mask_dtype}) - {mask_value})"
+    )
+    if output_dtype.is_floating_point:
+        true_bits = (
+            "lax.bitcast_convert_type("
+            f"lax.convert_element_type({{true_value}}, {value_dtype}), {mask_dtype})"
+        )
+        false_bits = (
+            "lax.bitcast_convert_type("
+            f"lax.convert_element_type({{false_value}}, {value_dtype}), {mask_dtype})"
+        )
+        return expr_from_string(
+            "lax.bitcast_convert_type("
+            "jnp.bitwise_or("
+            f"jnp.bitwise_and({mask_bits}, {true_bits}), "
+            f"jnp.bitwise_and(jnp.bitwise_not({mask_bits}), {false_bits})"
+            f"), {value_dtype})",
+            mask=mask,
+            layout_anchor=layout_anchor,
+            true_value=true_value,
+            false_value=false_value,
+        )
+    return expr_from_string(
+        "lax.convert_element_type("
+        "jnp.bitwise_or("
+        f"jnp.bitwise_and({mask_bits}, "
+        f"lax.convert_element_type({{true_value}}, {value_dtype})), "
+        f"jnp.bitwise_and(jnp.bitwise_not({mask_bits}), "
+        f"lax.convert_element_type({{false_value}}, {value_dtype}))"
+        f"), {value_dtype})",
+        mask=mask,
+        layout_anchor=layout_anchor,
+        true_value=true_value,
+        false_value=false_value,
+    )
+
+
+def numeric_mask_select_expr(
+    mask: ast.AST,
+    true_value: ast.AST,
+    false_value: ast.AST,
+    output_dtype: torch.dtype,
+    layout_anchor: ast.AST | None = None,
+) -> ast.AST:
+    selected = numeric_where_expr(
+        mask, true_value, false_value, output_dtype, layout_anchor
+    )
+    if selected is not None:
+        return selected
+    return expr_from_string(
+        "jnp.where(({mask}) != 0, {true_value}, {false_value})",
+        mask=mask,
+        true_value=true_value,
+        false_value=false_value,
+    )
+
+
 def load_expr(
     state: CodegenState,
     subscript: list[object],

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -2860,13 +2860,28 @@ def _(state: CodegenState) -> list[object]:
     assert isinstance(state.codegen, GenerateAST)
 
     if graph_info.predicate_is_tensor:
-        raise BackendUnsupported(
-            "pallas",
-            "if-statements with tensor-derived predicates. "
-            "lax.cond requires a scalar predicate, but tensor loads produce "
-            "vectors on TPU due to hardware tiling constraints. "
-            "Use a scalar kernel argument for the condition instead.",
-        )
+        predicate_tensor_numel = graph_info.predicate_tensor_numel
+        assert predicate_tensor_numel is not None
+        if not CompileEnvironment.current().known_equal(predicate_tensor_numel, 1):
+            raise BackendUnsupported(
+                "pallas",
+                "if-statements with multi-element tensor-derived predicates "
+                f"(numel={predicate_tensor_numel}). "
+                "lax.cond requires a scalar predicate.",
+            )
+        predicate_value = state.proxy_arg(0)
+        assert isinstance(predicate_value, torch.Tensor)
+        if predicate_value.ndim > 0:
+            index = ", ".join("0" for _ in range(predicate_value.ndim))
+            if predicate_value.dtype is torch.bool:
+                test = expr_from_string(
+                    f"({{test}}).astype(jnp.int32)[{index}] != 0",
+                    test=test,
+                )
+            else:
+                test = expr_from_string(f"{{test}}[{index}]", test=test)
+        if predicate_value.dtype is not torch.bool:
+            test = expr_from_string("({test}) != 0", test=test)
 
     if_body_stmts: list[ast.AST] = []
     with state.codegen.set_statements(if_body_stmts):
@@ -3298,15 +3313,22 @@ def _(state: CodegenState) -> ast.AST:
         return state.ast_arg(0)
     # Combine float masks via multiplication (equivalent to bool AND).
     mask_expr = " * ".join(mask_exprs)
-    if len(mask_exprs) < len(input_sizes):
-        mask_expr = backend.broadcast_to_expr(
-            mask_expr, state.tile_strategy.shape_str(input_sizes)
-        )
-    # Ensure the masked value literal matches the tensor dtype
     input_dtype = tensor.dtype
+    # Ensure the masked value literal matches the tensor dtype
     other_typed = expr_from_string(
         backend.full_expr([], constant_repr(other), input_dtype)
     )
+    from .._compiler.pallas import codegen as pallas_codegen
+
+    numeric_select = pallas_codegen.numeric_where_expr(
+        expr_from_string(mask_expr),
+        state.ast_arg(0),
+        other_typed,
+        input_dtype,
+    )
+    if numeric_select is not None:
+        return numeric_select
+    mask_expr = f"({mask_expr}) != 0"
     return expr_from_string(
         backend.where_expr(mask_expr, "{expr}", "{other}"),
         expr=state.ast_arg(0),

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -61,7 +61,6 @@ from .._compiler.host_function import HostFunction
 from .._compiler.indexing_strategy import SubscriptIndexing
 from .._compiler.indexing_strategy import TileWithOffsetInfo
 from .._compiler.indexing_strategy import _get_tile_with_offset_info
-from .._compiler.pallas import codegen as pallas_codegen
 from .._compiler.utils import compute_slice_size
 from .._compiler.variable_origin import GridOrigin
 from .._compiler.variable_origin import TileBeginOrigin
@@ -338,6 +337,8 @@ def _maybe_get_symbol_origin(idx: object) -> SymbolOrigin | None:
 
 @_decorators.codegen(store, "pallas")
 def _(state: CodegenState) -> None:
+    from .._compiler.pallas import codegen as pallas_codegen
+
     tensor = state.proxy_arg(0)
     subscript = state.proxy_arg(1)
     assert isinstance(subscript, (list, tuple))
@@ -375,6 +376,8 @@ def _(state: CodegenState) -> None:
     if not scatter_patterns and state.device_function.carry_tiles:
         if emit_carry_store(state, tensor, subscript, name, idx_str, value):
             return
+    if tensor.dtype is torch.bool:
+        value = CompileEnvironment.current().backend.cast_ast(value, torch.bool)
     state.codegen.add_statement(
         statement_from_string(f"{name}[{idx_str}] = {{value}}", value=value)
     )
@@ -6806,6 +6809,8 @@ def _(state: CodegenState) -> ast.AST:
 
 @_decorators.codegen(load, "pallas")
 def _(state: CodegenState) -> ast.AST:
+    from .._compiler.pallas import codegen as pallas_codegen
+
     tensor = state.proxy_arg(0)
     subscript = state.proxy_arg(1)
     assert isinstance(tensor, torch.Tensor)

--- a/helion/language/view_ops.py
+++ b/helion/language/view_ops.py
@@ -106,6 +106,38 @@ def _(state: CodegenState) -> ast.AST:
     )
 
 
+@_decorators.codegen(subscript, "pallas")
+def _(state: CodegenState) -> ast.AST:
+    output_keys = []
+    has_new_axis = False
+    # pyrefly: ignore [not-iterable]
+    for val in state.proxy_arg(1):
+        if val is None:
+            output_keys.append("None")
+            has_new_axis = True
+        elif isinstance(val, slice) and repr(val) == "slice(None, None, None)":
+            output_keys.append(":")
+        else:
+            raise exc.InvalidIndexingType(repr(val))
+
+    output_index = ", ".join(output_keys)
+    tensor = state.proxy_arg(0)
+    if has_new_axis and isinstance(tensor, torch.Tensor) and tensor.dtype is torch.bool:
+        from .._compiler.pallas import codegen as pallas_codegen
+
+        # Mosaic cannot reshape bool vectors directly. Keep shaped masks numeric
+        # until a predicate consumer needs bool.
+        output = state.fake_value
+        assert isinstance(output, torch.Tensor)
+        shape = state.tile_strategy.shape_str([*output.size()])
+        return pallas_codegen.numeric_mask_reshape_expr(state.ast_arg(0), shape)
+
+    return expr_from_string(
+        f"{{base}}[{output_index}]",
+        base=state.ast_arg(0),
+    )
+
+
 @_decorators.codegen(subscript, "cute")
 def _(state: CodegenState) -> ast.AST:
     # CuTe kernels currently execute scalarized pointwise code, so shape-only

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1641,7 +1641,6 @@ class TestExamples(RefEagerTestBase, TestCase):
                     rtol=rtol,
                 )
 
-    @xfailIfPallasTpu("tensor-derived if-predicates not supported")
     def test_grouped_gemm_jagged(self):
         # Build small jagged grouped GEMM inputs
         torch.manual_seed(0)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -4284,13 +4284,13 @@ class TestPallas(TestCase):
                     block_sizes=[block],
                     pallas_loop_type=loop_type,
                 )
-                # x's masked load is raw (no eager ``* mask``), feeds a transpose,
-                # and the mask reappears as a post-transpose ``jnp.where``.
+                # x's masked load is raw, feeds a transpose, and the mask
+                # reappears in the post-transpose layout.
                 producer = self._transpose_operand_producer(code)
                 self.assertIsNotNone(producer)
                 self.assertRegex(producer, r"= x\[")
                 self.assertNotIn("* mask", producer)
-                self.assertIn("jnp.where", code)
+                self.assertRegex(code, r"_mask_to = .*bitcast_convert_type")
                 # compact_worklist matches the eager reference on the partial
                 # tiles.  fori_loop miscompiles jagged tiles in pallas interpret
                 # (a pre-existing, unrelated issue), so it is not a sound numeric
@@ -4597,7 +4597,6 @@ class TestPallas(TestCase):
         inner_min = spec.block_sizes[1].min_size
         self.assertGreaterEqual(outer_min, inner_min)
 
-    @xfailIfPallasInterpret("numerical mismatch in JAX interpret mode")
     def test_boundary_mask_with_squeezed_leading_dims(self) -> None:
         """Boundary mask generation succeeds when leading dimensions are squeezed."""
 


### PR DESCRIPTION
Stacked PRs:
 * #2899
 * #2898
 * #2897
 * #2896
 * #2895
 * #2894
 * #2893
 * #2892
 * #2891
 * #2890
 * #2889
 * #2888
 * #2887
 * #2886
 * __->__#2885
 * #2884
 * #2883


--- --- ---

### Support Pallas numeric masks and scalar predicates


This enables the Pallas `grouped_gemm_jagged` path and unlocks later jagged examples that branch on scalar tensor values. The compiler lowers TPU boolean masks through numeric select and bit-mask forms, supports singleton tensor predicates in `lax.cond`, and keeps bool reshapes and broadcasts legal under Mosaic.