### PR TITLE
Support Pallas block-shaped pipeline stores

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -243,6 +243,22 @@ def _triton_jit_supports_do_not_specialize() -> bool:
     return "do_not_specialize" in params and "do_not_specialize_on_alignment" in params
 
 
+def _pallas_empty_allocated_vars(body: list[ast.stmt]) -> set[str]:
+    """Return names allocated by top-level empty/empty_like/new_empty calls."""
+    result: set[str] = set()
+    for stmt in body:
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and isinstance(stmt.value, ast.Call)
+            and isinstance(stmt.value.func, ast.Attribute)
+            and stmt.value.func.attr in ("empty", "empty_like", "new_empty")
+        ):
+            result.add(stmt.targets[0].id)
+    return result
+
+
 class Backend(abc.ABC):
     """Abstract base class for Helion code generation backends.
 
@@ -2761,26 +2777,6 @@ class PallasBackend(Backend):
 
         device_fn = DeviceFunction.current()
 
-        def _empty_allocated_vars(body: list[ast.stmt]) -> set[str]:
-            """Return names of variables allocated with torch.empty/empty_like/new_empty.
-
-            Only checks top-level assignments; allocations nested inside
-            if/with/try are conservatively missed (treated as needing input,
-            which is correct but suboptimal).
-            """
-            result: set[str] = set()
-            for stmt in body:
-                if (
-                    isinstance(stmt, ast.Assign)
-                    and len(stmt.targets) == 1
-                    and isinstance(stmt.targets[0], ast.Name)
-                    and isinstance(stmt.value, ast.Call)
-                    and isinstance(stmt.value.func, ast.Attribute)
-                    and stmt.value.func.attr in ("empty", "empty_like", "new_empty")
-                ):
-                    result.add(stmt.targets[0].id)
-            return result
-
         output_indices: list[int] = []
         # Indices of output tensors that are also read by the kernel
         # (inplace-mutated params or body-created tensors the kernel reads).
@@ -2798,7 +2794,7 @@ class PallasBackend(Backend):
             # to use HBM BlockSpecs.  Tensors allocated with torch.zeros_like,
             # torch.full, etc. have meaningful initial values that must be
             # preserved via VMEM BlockSpecs.
-            empty_vars = _empty_allocated_vars(host_fn.body)
+            empty_vars = _pallas_empty_allocated_vars(host_fn.body)
             for i, arg in enumerate(sorted_args):
                 if not isinstance(arg, TensorArg):
                     continue

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -49,6 +49,10 @@ if TYPE_CHECKING:
     ShapeLike = Sequence[SymIntLike]
 
 
+def _ceil_sympy_expr(expr: sympy.Expr) -> sympy.Expr:
+    return cast("sympy.Expr", sympy.ceiling(expr))
+
+
 class ThreadAxisTracker:
     """Tracks thread axis assignments for block dimensions during codegen."""
 
@@ -2607,7 +2611,7 @@ class FlattenedTileStrategy(BlockSizeTileStrategy):
                 f"({self._expr_str(step)}) - 1) // ({self._expr_str(step)})"
             )
         if diff_expr is not None:
-            return sympy.ceiling(sympy.Mul(diff_expr, sympy.Pow(step_expr, -1)))
+            return _ceil_sympy_expr(sympy.Mul(diff_expr, sympy.Pow(step_expr, -1)))
         return (
             f"((({self._expr_str(end)}) - ({self._expr_str(begin)})) + "
             f"({self._expr_str(step)}) - 1) // ({self._expr_str(step)})"
@@ -3224,7 +3228,7 @@ class _BaseNDTileStrategy(BlockSizeTileStrategy):
                 f"({self._expr_str(step)}) - 1) // ({self._expr_str(step)})"
             )
         if diff_expr is not None:
-            return sympy.ceiling(sympy.Mul(diff_expr, sympy.Pow(step_expr, -1)))
+            return _ceil_sympy_expr(sympy.Mul(diff_expr, sympy.Pow(step_expr, -1)))
         return (
             f"((({self._expr_str(end)}) - ({self._expr_str(begin)})) + "
             f"({self._expr_str(step)}) - 1) // ({self._expr_str(step)})"

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -21,6 +21,8 @@ from .._compiler.compile_environment import _symint_sympy_expr
 from .._compiler.dtype_utils import cast_ast
 from .._compiler.host_function import HostFunction
 from .._compiler.variable_origin import BlockSizeOrigin
+from .._compiler.variable_origin import TileBeginOrigin
+from .._compiler.variable_origin import TileEndOrigin
 from ..exc import BackendUnsupported
 from ..exc import NotInsideKernel
 from . import _decorators
@@ -371,6 +373,86 @@ def _classify_loop_tensors(
     return loaded_tensors, stored_tensors
 
 
+def _store_value_matches_destination_shape(
+    fake: torch.Tensor,
+    subscript_meta: list[object],
+    value: object,
+    env: CompileEnvironment,
+) -> bool:
+    if isinstance(value, torch.fx.Node):
+        value = value.meta.get("val")
+    if not isinstance(value, torch.Tensor):
+        return False
+    if not isinstance(subscript_meta, (list, tuple)):
+        return False
+
+    from helion._utils import is_scalar_index
+
+    expected: list[int | torch.SymInt] = []
+    tensor_dim = 0
+    for idx in subscript_meta:
+        if idx is None or tensor_dim >= fake.ndim:
+            return False
+        if is_scalar_index(idx):
+            tensor_dim += 1
+            continue
+        if isinstance(idx, torch.SymInt):
+            expected.append(idx)
+        elif isinstance(idx, slice) and idx == slice(None):
+            expected_size = fake.shape[tensor_dim]
+            if not isinstance(expected_size, (int, torch.SymInt)):
+                return False
+            expected.append(expected_size)
+        else:
+            return False
+        tensor_dim += 1
+    for expected_size in fake.shape[tensor_dim:]:
+        if not isinstance(expected_size, (int, torch.SymInt)):
+            return False
+        expected.append(expected_size)
+
+    if len(expected) != value.ndim:
+        return False
+    for actual, expected_size in zip(value.size(), expected, strict=True):
+        if not env.known_equal(actual, expected_size):
+            return False
+    return True
+
+
+def _loop_exact_store_value_ids(
+    graph_info: object, env: CompileEnvironment
+) -> set[int]:
+    """Return tensor ids whose stores all use exact-shaped RHS values."""
+    from .memory_ops import store as _store_op
+
+    host_tensor_nodes: dict[torch.fx.Node, torch.Tensor] = {}
+    for node in graph_info.graph.nodes:  # type: ignore[union-attr]
+        if node.op == "call_function" and node.target is _host_tensor:
+            if "val" in node.meta and isinstance(node.meta["val"], torch.Tensor):
+                host_tensor_nodes[node] = node.meta["val"]
+
+    exact_value_ids: set[int] = set()
+    inexact_value_ids: set[int] = set()
+    for node in graph_info.graph.nodes:  # type: ignore[union-attr]
+        if node.op != "call_function" or node.target is not _store_op:
+            continue
+        tensor_node = node.args[0]
+        if not isinstance(tensor_node, torch.fx.Node):
+            continue
+        fake = host_tensor_nodes.get(tensor_node)
+        if fake is None:
+            continue
+        key = id(fake)
+        subscript = _extract_subscript_vals(node.args[1] if len(node.args) >= 2 else ())
+        if len(node.args) >= 3 and _store_value_matches_destination_shape(
+            fake, subscript, node.args[2], env
+        ):
+            exact_value_ids.add(key)
+        else:
+            inexact_value_ids.add(key)
+    return exact_value_ids - inexact_value_ids
+
+
 def _get_dim_block_ids(
     subscript_meta: list[object],
     env: CompileEnvironment,
@@ -576,21 +658,6 @@ def _get_loop_numel(state: CodegenState, loop_dim_index: int) -> str:
     return f"(({end}) - ({begin}))"
 
 
-def _is_static_int(expr: str) -> bool:
-    """True if a begin/end expression string is a compile-time integer constant.
-
-    Used to decide whether a tile loop's ``[begin, end)`` extent is statically
-    known. When it is not (data-dependent bounds — a jagged ``hl.tile(start,
-    end)`` or even ``hl.tile(0, dynamic_end)``), the final tile may be a partial
-    sub-range of the backing tensor, so an output store must clamp its extent.
-    """
-    try:
-        int(expr)
-    except (TypeError, ValueError):
-        return False
-    return True
-
-
 def _compute_grid_and_block_sizes(
     state: CodegenState,
     block_ids: list[int],
@@ -667,6 +734,22 @@ def _static_loop_begin_expr(begin_expr: str) -> sympy.Expr | None:
     if begin_expr.lstrip("-").isdigit():
         return sympy.Integer(int(begin_expr))
     return None
+
+
+def _inner_loop_offset_alignment(
+    begin_expr: str,
+    iter_step_expr: str,
+    block_id: int,
+    state: CodegenState,
+) -> int | None:
+    block_value = state.device_function.resolved_block_size(block_id)
+    if not isinstance(block_value, int):
+        return None
+    if not _expr_proven_multiple(begin_expr, block_value, state):
+        return None
+    if not _expr_proven_multiple(iter_step_expr, block_value, state, block_id=block_id):
+        return None
+    return block_value
 
 
 def _pipeline_begin_alignment(
@@ -1695,19 +1778,347 @@ def _lane_tile(
     return last if isinstance(last, int) else None
 
 
+def _loop_bound_value(
+    state: CodegenState,
+    bounds_arg_index: int,
+    loop_dim_index: int,
+    default: object,
+) -> object:
+    if len(state.proxy_args) <= bounds_arg_index:
+        return default
+    bounds = state.proxy_args[bounds_arg_index]
+    if isinstance(bounds, (list, tuple)):
+        return bounds[loop_dim_index] if loop_dim_index < len(bounds) else default
+    if loop_dim_index == 0:
+        return bounds
+    return default
+
+
 def _loop_dim_is_dynamic(state: CodegenState, i: int) -> bool:
     """Whether loop dim ``i`` has a runtime begin and end (a fully-dynamic jagged
     tile).  The tracing-time form of is_dynamic_bound_tile, used here because the
     device loops are not registered yet.
     """
-    begins, ends = state.proxy_args[1], state.proxy_args[2]
-    if not isinstance(begins, (list, tuple)) or not isinstance(ends, (list, tuple)):
-        return False
-    begin = begins[i] if i < len(begins) else 0
-    end = ends[i] if i < len(ends) else 0
+    begin = _loop_bound_value(state, 1, i, 0)
+    end = _loop_bound_value(state, 2, i, 0)
     return not isinstance(begin, (int, torch.SymInt)) and not isinstance(
         end, (int, torch.SymInt)
     )
+
+
+def _loop_dim_covers_full_tensor_dim(
+    state: CodegenState,
+    loop_dim_index: int,
+    dim_size: object,
+    env: CompileEnvironment,
+) -> bool:
+    """Whether loop dim ``i`` is proven to cover exactly ``[0, dim_size)``."""
+    if not isinstance(dim_size, (int, torch.SymInt)):
+        return False
+    begin = _loop_bound_value(state, 1, loop_dim_index, 0)
+    end = _loop_bound_value(state, 2, loop_dim_index, 0)
+    if not isinstance(begin, (int, torch.SymInt)) or not env.known_equal(begin, 0):
+        return False
+    if not isinstance(end, (int, torch.SymInt)):
+        return False
+    if env.known_equal(end, dim_size):
+        return True
+    if isinstance(dim_size, int) and isinstance(end, torch.SymInt):
+        end_block_id = env.get_block_id(end)
+        if end_block_id is not None:
+            end_block_size = state.device_function.resolved_block_size(end_block_id)
+            return isinstance(end_block_size, int) and end_block_size == dim_size
+    return False
+
+
+def _loop_dim_ends_at_tensor_dim(
+    state: CodegenState,
+    loop_dim_index: int,
+    dim_size: object,
+    env: CompileEnvironment,
+) -> bool:
+    """Whether loop dim ``i`` is proven to end at ``dim_size``.
+
+    Store loops over a suffix ``[begin, dim_size)`` do not need extent clamping:
+    any full-block spill from the final iteration lands in Helion's ds-padding,
+    and the untouched prefix is either preserved by an in-place/initialized
+    output or intentionally undefined for empty outputs.
+    """
+    if not isinstance(dim_size, (int, torch.SymInt)):
+        return False
+    end = _loop_bound_value(state, 2, loop_dim_index, 0)
+    return isinstance(end, (int, torch.SymInt)) and env.known_equal(end, dim_size)
+
+
+def _symint_origin(value: object) -> object | None:
+    if not isinstance(value, torch.SymInt):
+        return None
+    origin_info = HostFunction.current().expr_to_origin.get(_val_to_sympy(value))
+    return origin_info.origin if origin_info is not None else None
+
+
+def _block_id_is_active_outer_scope(state: CodegenState, block_id: int) -> bool:
+    if state.codegen.active_device_loops.get(block_id):
+        return True
+    grid_state = state.codegen.current_grid_state
+    return grid_state is not None and block_id in grid_state.block_ids
+
+
+def _block_id_has_static_extent(state: CodegenState, block_id: int) -> bool:
+    loops = state.codegen.active_device_loops.get(block_id)
+    if loops:
+        info = loops[-1].block_id_to_info.get(block_id)
+        return (
+            info is not None
+            and info.begin_expr is not None
+            and info.end_expr is not None
+        )
+    grid_state = state.codegen.current_grid_state
+    if grid_state is not None and block_id in grid_state.block_ids:
+        info = grid_state.block_id_to_info.get(block_id)
+        return (
+            info is not None
+            and info.begin_expr is not None
+            and info.end_expr is not None
+        )
+    return False
+
+
+def _loop_dim_is_current_tile_extent(
+    state: CodegenState,
+    loop_dim_index: int,
+    block_id: int,
+    env: CompileEnvironment,
+) -> bool:
+    """Whether this inner loop is exactly bounded by an enclosing tile."""
+    begin = _loop_bound_value(state, 1, loop_dim_index, 0)
+    end = _loop_bound_value(state, 2, loop_dim_index, 0)
+    begin_origin = _symint_origin(begin)
+    end_origin = _symint_origin(end)
+    return (
+        isinstance(begin_origin, TileBeginOrigin)
+        and isinstance(end_origin, TileEndOrigin)
+        and begin_origin.block_id == end_origin.block_id
+        and _block_id_has_static_extent(state, begin_origin.block_id)
+    )
+
+
+def _store_dim_is_jagged_parent_scoped(
+    state: CodegenState,
+    block_id: int,
+    dim_to_bid: dict[int, int],
+    env: CompileEnvironment,
+) -> bool:
+    if not env.is_jagged_tile(block_id):
+        return False
+    present = set(dim_to_bid.values())
+    return all(
+        parent in present and _block_id_is_active_outer_scope(state, parent)
+        for parent in env.jagged_tile_parent_ids[block_id]
+    )
+
+
+def _store_dim_requires_extent_clamp(
+    state: CodegenState,
+    loop_dim_index: int,
+    dim_size: object,
+    env: CompileEnvironment,
+    block_id: int,
+    dim_to_bid: dict[int, int],
+) -> bool:
+    """True when a tiled store cannot prove it writes the full backing dim."""
+    return not (
+        _loop_dim_covers_full_tensor_dim(state, loop_dim_index, dim_size, env)
+        or _loop_dim_ends_at_tensor_dim(state, loop_dim_index, dim_size, env)
+        or _loop_dim_is_current_tile_extent(state, loop_dim_index, block_id, env)
+        or _store_dim_is_jagged_parent_scoped(state, block_id, dim_to_bid, env)
+    )
+
+
+def _block_id_covers_full_tensor_dim(
+    state: CodegenState,
+    block_id: int,
+    dim_size: object,
+) -> bool:
+    """Whether an active outer/grid block id spans ``[0, dim_size)``."""
+    loops = state.codegen.active_device_loops.get(block_id)
+    if loops:
+        info = loops[-1].block_id_to_info.get(block_id)
+        return (
+            info is not None
+            and info.begin_expr in (0, sympy.Integer(0))
+            and isinstance(dim_size, (int, torch.SymInt))
+            and info.is_end_matching(dim_size)
+        )
+    grid_state = state.codegen.current_grid_state
+    if grid_state is not None and block_id in grid_state.block_ids:
+        info = grid_state.block_id_to_info.get(block_id)
+        return (
+            info is not None
+            and info.begin_expr in (0, sympy.Integer(0))
+            and isinstance(dim_size, (int, torch.SymInt))
+            and info.is_end_matching(dim_size)
+        )
+    return False
+
+
+def _store_access_covers_full_tensor(
+    state: CodegenState,
+    fake: torch.Tensor,
+    sub_meta: list[object],
+    block_ids: list[int],
+    env: CompileEnvironment,
+) -> bool:
+    """Whether all elements of ``fake`` are overwritten by this store family."""
+    from helion._utils import is_scalar_index
+
+    dim_to_bid = _get_dim_block_ids(sub_meta, env)
+    for dim_idx, dim_size in enumerate(fake.shape):
+        bid = dim_to_bid.get(dim_idx)
+        if bid is not None and bid in block_ids:
+            if not _loop_dim_covers_full_tensor_dim(
+                state,
+                block_ids.index(bid),
+                dim_size,
+                env,
+            ):
+                return False
+            continue
+        if bid is not None:
+            if not _block_id_covers_full_tensor_dim(state, bid, dim_size):
+                return False
+            continue
+        idx_meta = sub_meta[dim_idx] if dim_idx < len(sub_meta) else slice(None)
+        if is_scalar_index(idx_meta) or idx_meta != slice(None):
+            return False
+    return True
+
+
+def _store_needs_initial_value_preserved(
+    state: CodegenState,
+    fake: torch.Tensor,
+    store_sub_metas: list[list[object]],
+    block_ids: list[int],
+    env: CompileEnvironment,
+) -> bool:
+    # Merged metadata can widen disjoint partial stores to ":".
+    if any(
+        _store_access_covers_full_tensor(state, fake, sub_meta, block_ids, env)
+        for sub_meta in store_sub_metas
+    ):
+        return False
+
+    from .._compiler.backend import _pallas_empty_allocated_vars
+
+    host_fn = HostFunction.current()
+    tensor_arg = state.device_function.tensor_arg(fake)
+    input_names = {arg.arg for arg in host_fn.args.args}
+    empty_vars = _pallas_empty_allocated_vars(host_fn.body)
+    return (
+        tensor_arg.host_str() in input_names or tensor_arg.host_str() not in empty_vars
+    )
+
+
+def _exact_dma_store_tensor_ids(
+    state: CodegenState,
+    graph_info: object,
+    loaded_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
+    stored_tensors: dict[
+        int, tuple[torch.Tensor, torch.fx.Node, list[object], list[list[object]]]
+    ],
+    block_ids: list[int],
+    env: CompileEnvironment,
+) -> set[int]:
+    """Find output-only stores that can use exact scratch-DMA writeback."""
+    from .._compiler.backend import _pallas_empty_allocated_vars
+
+    read_names, write_names = state.device_function.get_tensor_read_write_names()
+    host_fn = HostFunction.current()
+    input_names = {arg.arg for arg in host_fn.args.args}
+    empty_vars = _pallas_empty_allocated_vars(host_fn.body)
+    exact_value_store_ids = _loop_exact_store_value_ids(graph_info, env)
+    result: set[int] = set()
+    for key, (fake, _tensor_node, sub_meta, _store_sub_metas) in stored_tensors.items():
+        if key in loaded_tensors:
+            continue
+        tensor_arg = state.device_function.tensor_arg(fake)
+        tensor_names = {tensor_arg.name, tensor_arg.host_str()}
+        if (
+            not tensor_names.isdisjoint(read_names)
+            or tensor_names.isdisjoint(write_names)
+            or tensor_arg.host_str() in input_names
+            or tensor_arg.host_str() not in empty_vars
+            or key not in exact_value_store_ids
+        ):
+            continue
+        dim_to_bid = _get_dim_block_ids(sub_meta, env)
+        needs_second_last_clamp = False
+        unsafe_last_dim_clamp = False
+        for dim_idx, bid in dim_to_bid.items():
+            if bid not in block_ids:
+                continue
+            needs_clamp = _store_dim_requires_extent_clamp(
+                state,
+                block_ids.index(bid),
+                fake.shape[dim_idx],
+                env,
+                bid,
+                dim_to_bid,
+            )
+            if not needs_clamp:
+                continue
+            if dim_idx == fake.ndim - 2:
+                needs_second_last_clamp = True
+            elif dim_idx == fake.ndim - 1:
+                unsafe_last_dim_clamp = True
+        if needs_second_last_clamp and not unsafe_last_dim_clamp:
+            result.add(id(fake))
+    return result
+
+
+def _partial_last_two_store_error() -> NotImplementedError:
+    return NotImplementedError(
+        "Pallas: a partial store whose tiled dimension is one of "
+        "the last two (lane/sublane) dimensions is not supported. "
+        "Mosaic tile alignment forbids clamping there, so a "
+        "partial tile would silently overrun adjacent rows. Move "
+        "the partial dimension to a leading position, e.g. "
+        "[tokens, heads, head_dim]."
+    )
+
+
+def _reject_partial_last_two_dim_stores(
+    state: CodegenState,
+    stored_tensors: dict[
+        int, tuple[torch.Tensor, torch.fx.Node, list[object], list[list[object]]]
+    ],
+    block_ids: list[int],
+    env: CompileEnvironment,
+    aligned_dim: dict[int, int] | None = None,
+    *,
+    safe_pipelined_store_tensor_ids: set[int] | None = None,
+) -> None:
+    aligned_dim = aligned_dim or {}
+    safe_pipelined_store_tensor_ids = safe_pipelined_store_tensor_ids or set()
+    for fake, _tensor_node, sub_meta, _store_sub_metas in stored_tensors.values():
+        if id(fake) in safe_pipelined_store_tensor_ids:
+            continue
+        dim_to_bid = _get_dim_block_ids(sub_meta, env)
+        for dim_idx, bid in dim_to_bid.items():
+            if bid not in block_ids or dim_idx < fake.ndim - 2:
+                continue
+            if bid in aligned_dim and bid in state.device_function.carry_tiles:
+                # emit_pipeline's aligned-enclosing row path handles this case.
+                continue
+            if _store_dim_requires_extent_clamp(
+                state,
+                block_ids.index(bid),
+                fake.shape[dim_idx],
+                env,
+                bid,
+                dim_to_bid,
+            ):
+                raise _partial_last_two_store_error()
 
 
 def _aligned_dim(
@@ -1838,7 +2249,33 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     # BlockSpec; the rest stay on the outer pallas_call BlockSpec
     # (escape clause `bs == as`) and are closure-read from the body.
     all_tensor_info, _vmem_shapes, pipelined_tensor_ids = _classify_pipelined_tensors(
-        loaded_tensors, stored_tensors, block_ids, slice_size_exprs, env, state
+        loaded_tensors,
+        stored_tensors,
+        block_ids,
+        begin_exprs,
+        iter_step_exprs,
+        slice_size_exprs,
+        env,
+        state,
+        allow_row_slab_store=True,
+        require_aligned_offsets=False,
+    )
+    # RMW pipeline args use HBM refs and skip the wrapper's initial in-place
+    # copy, so their output ref may not contain the old tensor contents.
+    pipelined_tensor_ids.difference_update(
+        loaded_tensors.keys() & stored_tensors.keys()
+    )
+    safe_pipelined_store_candidates = _exact_dma_store_tensor_ids(
+        state, graph_info, loaded_tensors, stored_tensors, block_ids, env
+    )
+    safe_pipelined_store_ids = pipelined_tensor_ids & safe_pipelined_store_candidates
+    _reject_partial_last_two_dim_stores(
+        state,
+        stored_tensors,
+        block_ids,
+        env,
+        aligned_dim,
+        safe_pipelined_store_tensor_ids=safe_pipelined_store_ids,
     )
 
     # Build in_specs and out_specs
@@ -1905,30 +2342,15 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                 )
                 _record_pad_info(state, fake, dim_idx, bid, extra_pad)
                 begin_is_zero = begin_expr == "0"
-                end_expr = end_exprs[bid_idx]
                 dim_size = shape[dim_idx]
-                # Whether this loop spans the ENTIRE backing tensor dim, i.e.
-                # ``[0, dim_size)`` with a compile-time-constant extent. Only
-                # then is a full-block store safe: a partial final tile overruns
-                # past ``dim_size`` into padding, which the host-side pad handles.
-                # For any sub-range -- a jagged ``hl.tile(start, end)``, a
-                # ``hl.tile(0, dynamic_end)``, or even a static ``hl.tile(0, k)``
-                # with ``k < dim_size`` -- a full-block store would overrun into
-                # live rows of the tensor, so the extent must be clamped.
-                covers_full_dim = (
-                    begin_is_zero
-                    and _is_static_int(end_expr)
-                    and isinstance(dim_size, int)
-                    and int(end_expr) == dim_size
+                store_requires_clamp = is_store and _store_dim_requires_extent_clamp(
+                    state, bid_idx, dim_size, env, bid, dim_to_bid
                 )
                 # Loads need a dynamic ``pl.ds`` only for a non-zero begin (a
                 # block-aligned index can't express an arbitrary start; the
                 # over-read past ``end`` is zeroed by the inner-loop mask).
-                # Stores need it whenever they target a sub-range (not the full
-                # dim), so the extent can be clamped and a partial final tile
-                # does not overrun live rows. Full-dim, from-zero loops keep the
-                # original block-index codegen (no change).
-                if not begin_is_zero or (is_store and not covers_full_dim):
+                # Stores need it only when their extent must be clamped.
+                if not begin_is_zero or store_requires_clamp:
                     # Dynamic ``pl.ds`` at the true element offset, with a
                     # ``pl.BoundedSlice`` block shape (required for ds-style
                     # index maps). Lifts the "emit_pipeline fails on unaligned
@@ -1938,7 +2360,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
                         f"({begin_expr}) + ({lambda_params[bid_idx]}) "
                         f"* ({iter_step_expr})"
                     )
-                    if is_store:
+                    if store_requires_clamp:
                         # Clamp the store extent to min(block, end - offset) so a
                         # short final tile writes only its valid rows
                         # [begin, end) instead of overrunning into the next
@@ -2158,10 +2580,16 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         block_size = env.block_sizes[block_id]
         # when the block_size.size is None, we cannot form a SymPy expr for the numel
         sympy_end_expr = block_size.numel if block_size.size is not None else None
+        offset_alignment: int | None = None
+        if block_id in aligned_dim and _expr_proven_multiple(
+            iter_step_exprs[i], aligned_dim[block_id], state, block_id=block_id
+        ):
+            offset_alignment = aligned_dim[block_id]
         block_id_to_info[block_id] = LoopDimInfo(
             begin_expr=_static_loop_begin_expr(begin_exprs[i]),
             end_var_name=None,
             end_expr=sympy_end_expr,
+            offset_alignment=offset_alignment,
         )
 
     strategy = _find_strategy(state, block_ids)
@@ -2319,8 +2747,10 @@ def _is_supported_contiguous_row_slab_dma(
     vmem_shape: tuple[int, ...],
     env: CompileEnvironment,
     state: CodegenState,
+    *,
+    require_aligned_lane: bool = True,
 ) -> bool:
-    """Whether an otherwise-unaligned load is a contiguous row-slab DMA.
+    """Whether an otherwise-unaligned access is a contiguous row-slab transfer.
 
     ``_check_dma_alignment`` is conservative for shapes like
     ``[TOKEN_BLOCK, H=4, D=128]`` because the second-to-last logical dim is not a
@@ -2328,9 +2758,11 @@ def _is_supported_contiguous_row_slab_dma(
     for row-slab layouts: rows are page-addressed and the full suffix is
     contiguous with an aligned lane dimension.
 
-    Keep this exception narrow: load-only caller, one dynamic-begin/end
-    current-loop row tile, only scalar-selected prefix dims, full-slice suffix,
-    no gathers/scatters/stores.
+    Keep this exception narrow: one dynamic-begin/end current-loop row tile,
+    only scalar-selected prefix dims, full-slice suffix, no gathers/scatters.
+    ``fori_loop``/manual DMA uses it for loads only; emit_pipeline also opts
+    output row-slab stores into the Buffered BlockSpec path so its out_spec can
+    clamp the live extent.
     """
     if not fake.is_floating_point():
         return False
@@ -2365,16 +2797,140 @@ def _is_supported_contiguous_row_slab_dma(
 
     for dim_idx in range(row_dim + 1, fake.ndim):
         idx_meta = sub_meta[dim_idx] if dim_idx < len(sub_meta) else slice(None)
-        if idx_meta != slice(None):
-            return False
         if dim_idx in dim_to_bid:
+            suffix_bid = dim_to_bid[dim_idx]
+            dim_size = fake.shape[dim_idx]
+            block_value = state.device_function.resolved_block_size(suffix_bid)
+            if (
+                suffix_bid not in block_ids
+                and _block_id_is_active_outer_scope(state, suffix_bid)
+                and isinstance(dim_size, int)
+                and block_value == dim_size
+            ):
+                continue
+            return False
+        if idx_meta != slice(None):
             return False
         dim_size = fake.shape[dim_idx]
         if not isinstance(dim_size, int) or vmem_shape[dim_idx] != dim_size:
             return False
 
     lane_dim = fake.shape[-1]
-    return isinstance(lane_dim, int) and lane_dim % 128 == 0
+    if not isinstance(lane_dim, int):
+        return False
+    if lane_dim % 128 == 0:
+        return True
+    return not require_aligned_lane and fake.dtype == torch.float32
+
+
+def _dma_dim_required_alignment(vmem_shape: tuple[int, ...], dim_idx: int) -> int:
+    if len(vmem_shape) >= 2:
+        if dim_idx == len(vmem_shape) - 1:
+            return 128
+        if dim_idx == len(vmem_shape) - 2:
+            return 8
+    elif len(vmem_shape) == 1 and dim_idx == 0:
+        return 128
+    return 1
+
+
+def _expr_proven_multiple(
+    expr: str,
+    required: int,
+    state: CodegenState,
+    *,
+    block_id: int | None = None,
+) -> bool:
+    if required <= 1 or expr == "0":
+        return True
+    try:
+        value = sympy.sympify(expr)
+    except (sympy.SympifyError, TypeError):
+        value = None
+    if isinstance(value, sympy.Integer):
+        return int(value) % required == 0
+    if isinstance(value, sympy.Expr):
+        try:
+            remainder = sympy.simplify(sympy.Mod(value, required))
+        except TypeError:
+            remainder = None
+        if remainder == 0:
+            return True
+    if block_id is not None and expr == state.device_function.block_size_var(block_id):
+        block_value = state.device_function.resolved_block_size(block_id)
+        return isinstance(block_value, int) and block_value % required == 0
+    alignment = _pipeline_begin_alignment(expr, state)
+    return alignment is not None and alignment % required == 0
+
+
+def _dma_offsets_are_aligned(
+    fake: torch.Tensor,
+    sub_meta: list[object],
+    block_ids: list[int],
+    vmem_shape: tuple[int, ...],
+    begin_exprs: list[str],
+    iter_step_exprs: list[str],
+    env: CompileEnvironment,
+    state: CodegenState,
+) -> bool:
+    dim_to_bid = _get_dim_block_ids(sub_meta, env)
+    for dim_idx in range(fake.ndim):
+        required = _dma_dim_required_alignment(vmem_shape, dim_idx)
+        if required <= 1:
+            continue
+        bid = dim_to_bid.get(dim_idx)
+        if bid is not None and bid in block_ids:
+            bid_idx = block_ids.index(bid)
+            if not _expr_proven_multiple(
+                begin_exprs[bid_idx], required, state, block_id=bid
+            ):
+                return False
+            if not _expr_proven_multiple(
+                iter_step_exprs[bid_idx], required, state, block_id=bid
+            ):
+                return False
+            continue
+        if bid is not None:
+            grid_loops = state.codegen.active_device_loops.get(bid)
+            if grid_loops and not _expr_proven_multiple(
+                state.codegen.offset_var(bid), required, state, block_id=bid
+            ):
+                return False
+            continue
+
+        idx_meta = sub_meta[dim_idx] if dim_idx < len(sub_meta) else slice(None)
+        from helion._utils import is_scalar_index
+
+        if is_scalar_index(idx_meta):
+            offset_expr = state.device_function.literal_expr(idx_meta)
+            if not _expr_proven_multiple(offset_expr, required, state):
+                return False
+    return True
+
+
+def _can_stream_exact_dma_store(
+    fake: torch.Tensor,
+    sub_meta: list[object],
+    block_ids: list[int],
+    vmem_shape: tuple[int, ...],
+    begin_exprs: list[str],
+    iter_step_exprs: list[str],
+    env: CompileEnvironment,
+    state: CodegenState,
+) -> bool:
+    if _check_dma_alignment(vmem_shape) and _dma_offsets_are_aligned(
+        fake, sub_meta, block_ids, vmem_shape, begin_exprs, iter_step_exprs, env, state
+    ):
+        return True
+    return _is_supported_contiguous_row_slab_dma(
+        fake,
+        sub_meta,
+        block_ids,
+        vmem_shape,
+        env,
+        state,
+        require_aligned_lane=False,
+    )
 
 
 def _can_stream_inner_tile(
@@ -2383,13 +2939,29 @@ def _can_stream_inner_tile(
     direction: str,
     block_ids: list[int],
     vmem_shape: tuple[int, ...],
+    begin_exprs: list[str],
+    iter_step_exprs: list[str],
     env: CompileEnvironment,
     state: CodegenState,
+    *,
+    allow_row_slab_store: bool = False,
+    require_aligned_offsets: bool = True,
 ) -> bool:
     """Return whether a loop-local tensor should use the inner streaming path."""
     if _check_dma_alignment(vmem_shape):
-        return True
-    if direction != "load":
+        if not require_aligned_offsets:
+            return True
+        return _dma_offsets_are_aligned(
+            fake,
+            sub_meta,
+            block_ids,
+            vmem_shape,
+            begin_exprs,
+            iter_step_exprs,
+            env,
+            state,
+        )
+    if direction != "load" and not (allow_row_slab_store and direction == "store"):
         return False
     return _is_supported_contiguous_row_slab_dma(
         fake, sub_meta, block_ids, vmem_shape, env, state
@@ -2468,20 +3040,28 @@ def _classify_pipelined_tensors(
         int, tuple[torch.Tensor, torch.fx.Node, list[object], list[list[object]]]
     ],
     block_ids: list[int],
+    begin_exprs: list[str],
+    iter_step_exprs: list[str],
     slice_size_exprs: list[str],
     env: CompileEnvironment,
     state: CodegenState,
+    *,
+    allow_row_slab_store: bool = False,
+    require_aligned_offsets: bool = True,
 ) -> tuple[
     list[tuple[torch.Tensor, list[object], str]], list[tuple[int, ...]], set[int]
 ]:
     """Build (all_tensor_info, vmem_shapes, pipelined_ids) for an inner loop.
 
-    A tensor is eligible for the inner-DMA path (HBM ref + small VMEM scratch
-    in fori_loop, or ``pl.Buffered`` BlockSpec in emit_pipeline) when:
+    A tensor is eligible for the inner streaming path (HBM ref + small VMEM
+    scratch in fori_loop, or ``pl.Buffered`` BlockSpec in emit_pipeline) when:
 
     * Its inner-block ``vmem_shape`` passes the standard TPU DMA alignment check,
-      or it is a load-only contiguous row-slab layout covered by
-      ``_is_supported_contiguous_row_slab_dma``.
+      or it is a contiguous row-slab layout covered by
+      ``_is_supported_contiguous_row_slab_dma`` (loads by default; stores only
+      when the caller opts in).  Manual fori_loop DMA also requires aligned
+      offsets; emit_pipeline's BlockSpec path can express dynamic ``pl.ds``
+      offsets directly.
     * It is not also accessed at outer scope (i.e. in a root graph,
       between/before/after inner loops).  Pipelining replaces the tensor's
       outer BlockSpec with ``pltpu.HBM`` so the inner loop's BlockSpec can
@@ -2495,6 +3075,7 @@ def _classify_pipelined_tensors(
     closure-read from the body.
     """
     all_tensor_info: list[tuple[torch.Tensor, list[object], str]] = []
+    store_sub_metas: dict[int, list[list[object]]] = {}
     for key, (fake, _tensor_node, sub_meta) in loaded_tensors.items():
         if key not in stored_tensors:
             all_tensor_info.append((fake, sub_meta, "load"))
@@ -2502,11 +3083,12 @@ def _classify_pipelined_tensors(
         fake,
         _tensor_node,
         sub_meta,
-        _store_sub_metas,
+        original_sub_metas,
     ) in stored_tensors.items():
         if key in loaded_tensors:
             sub_meta = _merge_subscript_meta(fake, loaded_tensors[key][2], sub_meta)
         all_tensor_info.append((fake, sub_meta, "store"))
+        store_sub_metas[id(fake)] = original_sub_metas
     vmem_shapes = _compute_vmem_shapes(
         all_tensor_info, block_ids, slice_size_exprs, env, state
     )
@@ -2516,8 +3098,26 @@ def _classify_pipelined_tensors(
     for (fake, sub_meta, direction), vmem_shape in zip(
         all_tensor_info, vmem_shapes, strict=True
     ):
+        if direction == "store" and _store_needs_initial_value_preserved(
+            state,
+            fake,
+            store_sub_metas[id(fake)],
+            block_ids,
+            env,
+        ):
+            continue
         if not _can_stream_inner_tile(
-            fake, sub_meta, direction, block_ids, vmem_shape, env, state
+            fake,
+            sub_meta,
+            direction,
+            block_ids,
+            vmem_shape,
+            begin_exprs,
+            iter_step_exprs,
+            env,
+            state,
+            allow_row_slab_store=allow_row_slab_store,
+            require_aligned_offsets=require_aligned_offsets,
         ):
             continue
         if id(fake) in outer_access_tensor_ids:
@@ -2591,7 +3191,14 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     # non-pipelined tensor is present (which would load full outer-block
     # tiles into VMEM and may OOM at large shapes).
     all_tensor_info, vmem_shapes, pipelined_tensor_ids = _classify_pipelined_tensors(
-        loaded_tensors, stored_tensors, block_ids, slice_size_exprs, env, state
+        loaded_tensors,
+        stored_tensors,
+        block_ids,
+        begin_exprs,
+        iter_step_exprs,
+        slice_size_exprs,
+        env,
+        state,
     )
 
     # Compact worklist: the compact-tile aligned_load and exact_store tensors use
@@ -2674,6 +3281,9 @@ def _codegen_fori_loop(state: CodegenState) -> object:
             begin_expr=_static_loop_begin_expr(begin_exprs[i]),
             end_var_name=None,
             end_expr=sympy_end_expr,
+            offset_alignment=_inner_loop_offset_alignment(
+                begin_exprs[i], iter_step_exprs[i], block_id, state
+            ),
         )
 
     # Emit offset_<bid>/indices_<bid> at the body prologue.
@@ -2978,8 +3588,12 @@ def _(state: CodegenState) -> list[object]:
 
     JAX's tracing model does not support Python ``if`` on traced values.
     We use ``lax.cond(pred, true_fn, false_fn)`` which requires a scalar
-    predicate. Tensor-derived predicates (from tensor loads) are unsupported
-    because TPU block shapes make them vectors at runtime.
+    predicate. Tensor-derived predicates are accepted only when Helion proves
+    they have one element; already-scalar predicates are passed through, and
+    one-element arrays are indexed to scalar form. Bool arrays are widened before
+    indexing because Mosaic cannot squeeze bool vectors directly. Multi-element
+    tensor predicates are rejected because ``lax.cond`` cannot branch
+    elementwise.
     """
     from .._compiler.ast_extension import statement_from_string
     from .._compiler.device_ir import ElseGraphInfo

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1027,7 +1027,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[1, 64, 32],
         )
 
-    @xfailIfPallas("slice-based stores not yet supported")
     def test_concat_simple(self):
         args = (
             torch.randn(512, 500, device=DEVICE),
@@ -1052,7 +1051,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             fn_name="concat2d_dim1",
         )
 
-    @xfailIfPallas("BlockSpec tiling failure")
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
     @skipIfTileIR("TileIR does not support block_ptr indexing")
     def test_concat_block_ptr(self):
@@ -1416,8 +1414,8 @@ class TestExamples(RefEagerTestBase, TestCase):
         """Test combined backward pass for layer norm with bias."""
         self._run_layernorm_bwd(batch_size=32, dim=64)
 
-    @xfailIfPallas("VMEM OOM: untiled block specs load full tensors")
     @skipIfA10G("accuracy check fails on A10G GPUs")
+    @xfailIfPallasInterpret("large-batch backward has interpret-mode drift")
     def test_layernorm_bwd_large_batch(self):
         """Regression test: large batch, small dim."""
         self._run_layernorm_bwd(batch_size=1152 * 1000, dim=16, seed=1)
@@ -2180,7 +2178,10 @@ class TestExamples(RefEagerTestBase, TestCase):
             atol=0.15,
         )
 
-    @xfailIfPallas("conflicting tiling patterns")
+    @xfailIfPallasInterpret(
+        "pl.program_id captured into emit_pipeline body is not supported in "
+        "JAX interpret mode (program_id_p.bind asserts during trace)"
+    )
     @skipIfA10G("failure on a10g")
     @skipIfXPU("Squeeze-and-excitation network not supported on XPU")
     @skipIfTileIR("accuracy failure")
@@ -2201,17 +2202,10 @@ class TestExamples(RefEagerTestBase, TestCase):
         # Create gradient for backward pass
         grad_out = torch.randn([m, n], device=DEVICE, dtype=HALF_DTYPE)
 
-        # Compute expected gradients with PyTorch autograd
-        x_torch = x.detach().clone().requires_grad_(True)
-        a_torch = a.detach().clone().requires_grad_(True)
-        b_torch = b.detach().clone().requires_grad_(True)
-        out_torch = torch.mul(
-            x_torch, torch.sigmoid(torch.relu(x_torch @ a_torch) @ b_torch)
-        )
-        out_torch.backward(grad_out)
-
         args = (grad_out, x, a, b, c, d)
-        expected = x_torch.grad
+        grad_to_d = grad_out * x * d * (1.0 - d)
+        grad_to_c = (grad_to_d @ b.T) * (c > 0)
+        expected = grad_out * d + grad_to_c @ a.T
 
         check_example(
             "squeeze_and_excitation_net",
@@ -2224,7 +2218,10 @@ class TestExamples(RefEagerTestBase, TestCase):
             atol=0.3,
         )
 
-    @xfailIfPallas("tensor accessed with conflicting tiling patterns")
+    @xfailIfPallasInterpret(
+        "pl.program_id captured into emit_pipeline body is not supported in "
+        "JAX interpret mode (program_id_p.bind asserts during trace)"
+    )
     @skipIfA10G("failure on a10g")
     @skipIfTileIR("accuracy failure")
     @skipIfXPU("ocloc compilation failure with 256-GRF kernel on XPU backend")
@@ -2245,17 +2242,10 @@ class TestExamples(RefEagerTestBase, TestCase):
         # Create gradient for backward pass
         grad_out = torch.randn([m, n], device=DEVICE, dtype=HALF_DTYPE)
 
-        # Compute expected gradients with PyTorch autograd
-        x_torch = x.detach().clone().requires_grad_(True)
-        a_torch = a.detach().clone().requires_grad_(True)
-        b_torch = b.detach().clone().requires_grad_(True)
-        out_torch = torch.mul(
-            x_torch, torch.sigmoid(torch.relu(x_torch @ a_torch) @ b_torch)
-        )
-        out_torch.backward(grad_out)
-
         args = (grad_out, x, b, c, d)
-        expected = a_torch.grad
+        grad_to_d = grad_out * x * d * (1.0 - d)
+        grad_to_c = (grad_to_d @ b.T) * (c > 0)
+        expected = x.T @ grad_to_c
 
         check_example(
             "squeeze_and_excitation_net",
@@ -2381,7 +2371,9 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[4, 16, 16],
         )
 
-    @xfailIfPallas("InductorLoweringError")
+    @xfailIfPallasInterpret(
+        "emit_pipeline BlockSpec with dynamic shapes is unsupported in interpret mode"
+    )
     def test_grpo_loss_bwd(self):
         """Test backward pass for GRPO loss."""
         B, L, V = 2, 64, 128
@@ -2395,6 +2387,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             [B, L + 1, V], device=DEVICE, dtype=torch.bfloat16, requires_grad=True
         )
         completion_ids = torch.randint(0, V, (B, L), device=DEVICE, dtype=torch.int64)
+        completion_ids_kernel = completion_ids.to(LONG_INT_TYPE)
         old_logp = torch.randn(B, L, device=DEVICE, dtype=torch.float32)
         ref_logp = torch.randn(B, L, device=DEVICE, dtype=torch.float32)
         advantages = torch.randn(B, device=DEVICE, dtype=torch.float32)
@@ -2453,7 +2446,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             grad_output,
             logits,
             selected_logits,
-            completion_ids,
+            completion_ids_kernel,
             old_logp,
             ref_logp,
             advantages,

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -2121,6 +2121,19 @@ class TestPallas(TestCase):
         expected = torch.bmm(a.float(), b.float()).to(torch.bfloat16)
         torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
 
+    @xfailIfPallasInterpret("emit_pipeline dynamic slices need real TPU Pallas")
+    def test_emit_pipeline_store_keeps_block_sized_outer_tile(self) -> None:
+        x = torch.randn(2, 8, 128, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(2, 8, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_add_3d,
+            (x, y),
+            block_sizes=[4, 8, 128],
+            pallas_loop_type="emit_pipeline",
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+        torch.testing.assert_close(result, x + y)
+
     def test_full_slice_and_tile_share_dimension(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def fn(x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Stacked PRs:
 * #2899
 * #2898
 * #2897
 * #2896
 * #2895
 * #2894
 * #2893
 * #2892
 * #2891
 * #2890
 * #2889
 * __->__#2888
 * #2887
 * #2886
 * #2885
 * #2884
 * #2883


--- --- ---

### Support Pallas block-shaped pipeline stores


This enables Pallas coverage for `concatenate`, large `layer_norm_bwd`, `squeeze_and_excitation_net` backward variants, and `grpo_loss_bwd` paths that need block-shaped output stores. The compiler classifies exact-shaped store values, distinguishes output-only empty allocations from initialized outputs, and routes eligible stores through Pallas pipeline `BlockSpec` output refs instead of forcing unsafe whole-output VMEM behavior.