### PR TITLE
Enable Pallas HSTU example

### DIFF
--- a/examples/jagged_hstu_attn.py
+++ b/examples/jagged_hstu_attn.py
@@ -20,6 +20,7 @@ import helion
 from helion._testing import DEVICE
 from helion._testing import run_example
 import helion.language as hl
+from helion.runtime.settings import _get_backend
 
 try:
     # pyrefly: ignore [missing-import]
@@ -91,7 +92,7 @@ def reference_jagged_hstu_kernel_pytorch(
 
 # %%
 @helion.kernel()
-def _helion_jagged_attention_kernel(
+def _helion_jagged_attention_kernel_scalar(
     max_seq_len: int,
     alpha: float,
     q: torch.Tensor,
@@ -147,6 +148,57 @@ def _helion_jagged_attention_kernel(
             out[tile_q.index + starts, tile_h.begin, :] = acc.to(out.dtype)
 
     return out
+
+
+@helion.kernel()
+def _helion_jagged_attention_kernel_pallas(
+    max_seq_len: int,
+    alpha: float,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    seq_offsets: torch.Tensor,
+) -> torch.Tensor:
+    """Pallas implementation of HSTU jagged attention, tiled over all heads."""
+    scale = 1.0 / max_seq_len
+    num_heads = hl.specialize(q.size(1))
+    num_batches = hl.specialize(seq_offsets.size(0) - 1)
+    dimV = hl.specialize(v.size(2))
+
+    out = torch.zeros_like(v)
+
+    # Tile each packed sequence's real row range; each program computes all heads.
+    for seq_idx in hl.grid(num_batches):
+        start = seq_offsets[seq_idx]
+        end = seq_offsets[seq_idx + 1]
+
+        for tile_q in hl.tile(start, end):
+            q_blk = q[tile_q, :, :].transpose(0, 1)
+            acc = hl.zeros([num_heads, tile_q, dimV], dtype=torch.float32)
+
+            # Causal attention: only attend through the current query position.
+            for tile_kv in hl.tile(start, end):
+                k_blk = k[tile_kv, :, :].transpose(0, 1)
+                v_blk = v[tile_kv, :, :].transpose(0, 1)
+
+                scores = torch.bmm(q_blk, k_blk.transpose(-2, -1)) * alpha
+                scores = torch.nn.functional.silu(scores) * scale
+
+                causal_mask = tile_q.index.unsqueeze(1) >= tile_kv.index.unsqueeze(0)
+                scores = torch.where(causal_mask[None, :, :], scores, 0.0)
+
+                acc = acc + torch.bmm(scores.to(v.dtype), v_blk)
+
+            out[tile_q, :, :] = acc.transpose(0, 1).to(out.dtype)
+
+    return out
+
+
+_helion_jagged_attention_kernel = (
+    _helion_jagged_attention_kernel_pallas
+    if _get_backend() == "pallas"
+    else _helion_jagged_attention_kernel_scalar
+)
 
 
 # %%
@@ -210,7 +262,7 @@ def test(
     seq_offsets = torch.cat(
         [
             torch.tensor([0], dtype=torch.int32, device=device),
-            torch.cumsum(seq_lengths, dim=0),
+            torch.cumsum(seq_lengths, dim=0).to(torch.int32),
         ]
     )
     total_seq_len = int(seq_offsets[-1].item())

--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -300,6 +300,23 @@ unsqueeze_lowering = register_lowering(
 )
 
 
+def _pallas_bool_safe_singleton_index(
+    tensor: ast.AST, input_val: torch.Tensor, args: list[str]
+) -> ast.AST:
+    index = ", ".join(args)
+    if input_val.dtype is torch.bool and "None" in args:
+        # Mosaic cannot reshape bool vectors directly:
+        # https://github.com/jax-ml/jax/issues/37370
+        return expr_from_string(
+            f"(({{tensor}}).astype(jnp.int32)[{index}] != 0)",
+            tensor=tensor,
+        )
+    return expr_from_string(
+        f"{{tensor}}[{index}]",
+        tensor=tensor,
+    )
+
+
 @unsqueeze_lowering.register_codegen("common")
 def codegen_unsqueeze(ctx: LoweringContext, node: Node) -> object:
     assert not node.kwargs, "getitem kwargs not supported"
@@ -317,6 +334,25 @@ def codegen_unsqueeze(ctx: LoweringContext, node: Node) -> object:
         f"{{tensor}}[{', '.join(args)}]",
         tensor=tensor,
     )
+
+
+@unsqueeze_lowering.register_codegen("pallas")
+def codegen_unsqueeze_pallas(ctx: LoweringContext, node: Node) -> object:
+    assert not node.kwargs, "unsqueeze kwargs not supported"
+    tensor, dim = map_arg(node.args, lambda arg: _env_arg(ctx, arg))
+    assert isinstance(tensor, ast.AST)
+    assert isinstance(dim, int)
+    input_node = node.args[0]
+    assert isinstance(input_node, Node)
+    input_val = input_node.meta["val"]
+    assert isinstance(input_val, torch.Tensor)
+    ndim = input_val.ndim
+    if dim < 0:
+        dim += ndim + 1
+    assert 0 <= dim <= ndim, f"Invalid dim {dim} for tensor with {ndim} dims"
+    args = [":"] * ndim
+    args.insert(dim, "None")
+    return _pallas_bool_safe_singleton_index(tensor, input_val, args)
 
 
 @unsqueeze_lowering.register_codegen("cute")
@@ -952,15 +988,14 @@ def codegen_expand_pallas(ctx: LoweringContext, node: Node) -> object:
     shape = [*val.size()]
     # pyrefly: ignore [missing-attribute]
     input_val = node.args[0].meta["val"]
+    assert isinstance(input_val, torch.Tensor)
     if input_val.ndim != len(shape):
         tile_strategy = ctx.cg.device_function.tile_strategy
         broadcasting = tile_strategy.broadcast_expand_dims(
             tuple(input_val.shape), tuple(shape)
         )
         if broadcasting:
-            tensor = expr_from_string(
-                f"{{tensor}}[{', '.join(broadcasting)}]", tensor=tensor
-            )
+            tensor = _pallas_bool_safe_singleton_index(tensor, input_val, broadcasting)
     shape_str = ctx.cg.device_function.tile_strategy.shape_str(shape)
     return expr_from_string(
         f"jnp.broadcast_to({{tensor}}, {shape_str})",

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1489,27 +1489,23 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[16, 8, 16, 16],
         )
 
-    @xfailIfPallas("Mosaic unsupported mask shape cast in HSTU")
     @skipIfXPU("Jagged tensor operations not fully supported on XPU")
     def test_jagged_hstu_attn(self):
-        batch_size = 4
+        torch.manual_seed(0)
         max_seq_len = 64
         heads = 8
         head_dim = 32
 
-        # Generate random sequence lengths
-        min_seq_len = max_seq_len // 2
-        seq_lengths = torch.randint(
-            min_seq_len,
-            max_seq_len + 1,
-            (batch_size,),
+        # Fixed partial tiles ensure padded lanes would overlap following sequences.
+        seq_lengths = torch.tensor(
+            [33, 34, 35, 36],
             dtype=torch.int32,
             device=DEVICE,
         )
         seq_offsets = torch.cat(
             [
                 torch.tensor([0], dtype=torch.int32, device=DEVICE),
-                torch.cumsum(seq_lengths, dim=0),
+                torch.cumsum(seq_lengths, dim=0).to(torch.int32),
             ]
         )
         total_seq_len = int(seq_offsets[-1].item())

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1407,6 +1407,76 @@ class TestPallas(TestCase):
         torch.testing.assert_close(result, expected)
         self.assertIn("astype(jnp.int32)", code)
 
+    def test_bool_expand_inserted_broadcast_dim_where(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def pallas_bool_expand_inserted_broadcast_dim_where(
+            x: torch.Tensor,
+        ) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile([m, n]):
+                mask = (x[0, tile_n] < 0).expand(tile_m.block_size, tile_n.block_size)
+                out[tile_m, tile_n] = torch.where(mask, x[tile_m, tile_n], 0.0)
+            return out
+
+        x = torch.randn(16, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_bool_expand_inserted_broadcast_dim_where,
+            (x,),
+            block_sizes=[16, 128],
+        )
+
+        expected = torch.where(x[:1, :] < 0, x, torch.zeros_like(x))
+        torch.testing.assert_close(result, expected)
+        self.assertIn("jnp.broadcast_to", code)
+        self.assertIn("astype(jnp.int32)[None, :]", code)
+
+    def test_bool_subscript_broadcast_where(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def pallas_bool_subscript_broadcast_where(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile([m, n]):
+                row_mask = x[tile_m, 0] > 0
+                col_mask = x[0, tile_n] < 0
+                mask = row_mask[:, None] & col_mask[None, :]
+                out[tile_m, tile_n] = torch.where(mask, x[tile_m, tile_n], 0.0)
+            return out
+
+        x = torch.randn(16, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_bool_subscript_broadcast_where,
+            (x,),
+            block_sizes=[16, 128],
+        )
+
+        expected_mask = (x[:, :1] > 0) & (x[:1, :] < 0)
+        expected = torch.where(expected_mask, x, torch.zeros_like(x))
+        torch.testing.assert_close(result, expected)
+        self.assertIn("astype(jnp.int32)[:, None]", code)
+        self.assertIn("astype(jnp.int32)[None, :]", code)
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def pallas_bool_unsqueeze_broadcast_where(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile([m, n]):
+                row_mask = x[tile_m, 0] > 0
+                col_mask = x[0, tile_n] < 0
+                mask = row_mask.unsqueeze(1) & col_mask.unsqueeze(0)
+                out[tile_m, tile_n] = torch.where(mask, x[tile_m, tile_n], 0.0)
+            return out
+
+        code, result = code_and_output(
+            pallas_bool_unsqueeze_broadcast_where,
+            (x,),
+            block_sizes=[16, 128],
+        )
+
+        torch.testing.assert_close(result, expected)
+        self.assertIn("astype(jnp.int32)[:, None]", code)
+        self.assertIn("astype(jnp.int32)[None, :]", code)
+
     def test_indirect_gather_with_tiled_dim(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def pallas_indirect_gather_with_tiled_dim(


### PR DESCRIPTION
Stacked PRs:
 * #2899
 * #2898
 * #2897
 * #2896
 * #2895
 * #2894
 * __->__#2893
 * #2892
 * #2891
 * #2890
 * #2889
 * #2888
 * #2887
 * #2886
 * #2885
 * #2884
 * #2883


--- --- ---

### Enable Pallas HSTU example


This enables the Pallas `jagged_hstu_attn` example. The example selects a Pallas-compatible full-head structural kernel with int32 sequence offsets, while the compiler lowers bool singleton expand and unsqueeze through int32 so Mosaic does not have to reshape raw bool vectors.