### PR TITLE
Support Pallas stack lowering for int4 GEMM

### DIFF
--- a/examples/int4_gemm.py
+++ b/examples/int4_gemm.py
@@ -77,9 +77,10 @@ def matmul_bf16_int4(A: Tensor, B: Tensor) -> Tensor:
             # subtract 16 when the sign bit is set) rather than via ``(x << 4) >> 4``;
             # the explicit arithmetic form is portable across backends and avoids
             # relying on narrow-int (int8) shift truncation semantics.
-            b_lo_raw = (b_tile & 0xF).to(torch.int32)
+            b_i32 = b_tile.to(torch.int32)
+            b_lo_raw = b_i32 & 0xF
             b_lo = torch.where(b_lo_raw >= 8, b_lo_raw - 16, b_lo_raw)  # low 4 bits
-            b_hi = (b_tile >> 4).to(torch.int32)  # high 4 bits (arithmetic >>)
+            b_hi = b_i32 >> 4  # high 4 bits (arithmetic >>)
 
             # Stack and reshape to interleave low and high bits.
             # Stack along a new dimension to get [BLOCK_SIZE_K//2, 2, BLOCK_SIZE_N],

--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -846,6 +846,34 @@ def codegen_stack(ctx: LoweringContext, node: Node) -> object:
     return expr_from_string(result)
 
 
+@stack_lowering.register_codegen("pallas")
+def codegen_stack_pallas(ctx: LoweringContext, node: Node) -> object:
+    tensors = node.args[0]
+    dim = node.args[1] if len(node.args) > 1 else node.kwargs.get("dim", 0)
+
+    assert isinstance(tensors, (list, tuple))
+    if not tensors:
+        raise ValueError("Cannot stack empty tensor list")
+    if not all(isinstance(tensor, Node) for tensor in tensors):
+        raise exc.BackendUnsupported("pallas", "stack inputs")
+    assert isinstance(dim, int)
+
+    tensor_nodes = cast("list[Node] | tuple[Node, ...]", tensors)
+    tensor_asts = [ctx.env[tensor] for tensor in tensor_nodes]
+    args: dict[str, ast.AST] = {}
+    items: list[str] = []
+    for i, tensor in enumerate(tensor_asts):
+        assert isinstance(tensor, ast.AST)
+        name = f"tensor_{i}"
+        args[name] = tensor
+        items.append(f"{{{name}}}")
+
+    return expr_from_string(
+        f"jnp.stack([{', '.join(items)}], axis={dim})",
+        **args,
+    )
+
+
 @stack_lowering.register_codegen("cute")
 def codegen_stack_cute(ctx: LoweringContext, node: Node) -> object:
     tensors = node.args[0]

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1842,7 +1842,7 @@ class TestExamples(RefEagerTestBase, TestCase):
     def test_gather_gemv_half(self):
         self._check_gather_gemv(HALF_DTYPE)
 
-    @xfailIfPallas("int4 unpacking not supported on pallas")
+    @xfailIfPallasInterpret("Pallas interpret does not support the int4 dot path")
     def test_int4_gemm(self):
         # Matrix dimensions
         M, K, N = 256, 512, 256

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -338,6 +338,16 @@ def pallas_inner_loop_add_with_scalar_access(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_stack_sum(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    m, n = x.size()
+    for tile_m, tile_n in hl.tile([m, n]):
+        stacked = torch.stack([x[tile_m, tile_n], y[tile_m, tile_n]], dim=1)
+        out[tile_m, tile_n] = torch.sum(stacked, dim=1)
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_jagged_segment_add(x: torch.Tensor, offsets: torch.Tensor) -> torch.Tensor:
     """Outer grid over jagged segments + an inner ``hl.tile(start, end)`` loop
     whose begin (``offsets[g]``) is an arbitrary runtime offset. A
@@ -2484,6 +2494,17 @@ class TestPallas(TestCase):
             pallas_loop_type="emit_pipeline",
         )
         self.assertIn("pltpu.emit_pipeline", code)
+
+    def test_stack_lowering(self) -> None:
+        x = torch.randn(8, 128, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(8, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_stack_sum,
+            (x, y),
+            block_sizes=[8, 128],
+        )
+        self.assertIn("jnp.stack", code)
+        torch.testing.assert_close(result, x + y)
 
     @xfailIfPallas("Non-zero begin K reduction: DMA offset not tile-aligned")
     def test_bmm_nonzero_k_begin(self) -> None:

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -15,6 +15,7 @@ from helion._testing import onlyBackends
 from helion._testing import skipIfRefEager
 from helion._testing import skipUnlessTensorDescriptor
 from helion._testing import xfailIfPallas
+from helion._testing import xfailIfPallasInterpret
 import helion.language as hl
 from helion.runtime.settings import _get_backend
 
@@ -313,7 +314,6 @@ class TestViews(RefEagerTestBase, TestCase):
         expected = x.sum(dim=(1, 2))
         torch.testing.assert_close(result, expected)
 
-    @xfailIfPallas("torch.stack not supported on pallas")
     def test_stack_power_of_2(self):
         @helion.kernel(autotune_effort="none", static_shapes=True)
         def test_stack_power_of_2_kernel(
@@ -352,7 +352,7 @@ class TestViews(RefEagerTestBase, TestCase):
         expected[1::2] = b  # Every 2nd row starting from 1
         torch.testing.assert_close(result, expected, rtol=1e-5, atol=1e-5)
 
-    @xfailIfPallas("torch.stack not supported on pallas")
+    @xfailIfPallasInterpret("torch.stack lowering needs real TPU Pallas")
     def test_stack_non_power_of_2(self):
         @helion.kernel(autotune_effort="none", static_shapes=True)
         def test_stack_non_power_of_2_kernel(


### PR DESCRIPTION
Stacked PRs:
 * #2916
 * #2915
 * #2914
 * #2913
 * #2912
 * #2911
 * #2910
 * #2909
 * #2908
 * __->__#2907
 * #2906
 * #2905
 * #2904
 * #2903
 * #2902
 * #2901
 * #2900


--- --- ---

### Support Pallas stack lowering for int4 GEMM


This enables the Pallas `int4_gemm` example. Pallas lowering now emits `jnp.stack` for stack nodes, and the example widens packed int4 data to int32 before bit operations so unpacking has backend-portable shift and sign-extension semantics.