### PR TITLE
Use backend worker count for grouped GEMM

### DIFF
--- a/examples/grouped_gemm.py
+++ b/examples/grouped_gemm.py
@@ -130,15 +130,8 @@ def grouped_gemm_jagged_persistent(
     Returns:
         Output tensor of shape ``[sum(M_i), N]``.
     """
-    # Set worker count to match GPU streaming multiprocessor count
-    device = A_packed.device
-    if device.type == "xpu":
-        # TODO(EikanWang): gpu_subslice_count is an out-of-date term. we will update it to XeCore number.
-        num_workers = torch.xpu.get_device_properties(device.index).gpu_subslice_count
-    else:
-        num_workers = torch.cuda.get_device_properties(
-            device.index
-        ).multi_processor_count
+    # Set worker count to match the backend's persistent worker abstraction.
+    num_workers = helion.runtime.get_num_sm(A_packed.device)
 
     # Define tunable block sizes for M, N dimensions (auto-tuned at runtime)
     BLOCK_M = hl.register_block_size(32, 128)

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -126,6 +126,13 @@ def get_num_sm(device: torch.device, *, reserved_sms: int = 0) -> int:
         for any reserved SMs. Always at least 1.
     """
     available_sms: int
+    if device.type == "cpu":
+        if not _module_is_pallas_interpret():
+            raise AssertionError("TODO: implement for other devices")
+        return 1
+    if device.type == "tpu":
+        return 1
+
     assert device.type in [
         "cuda",
         "xpu",

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1667,7 +1667,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             fn_name="grouped_gemm_jagged",
         )
 
-    @xfailIfPallas("CUDA-specific code paths")
+    @xfailIfPallas("Pallas scatter: multiple indirect dims are not supported")
     def test_grouped_gemm_jagged_persistent(self):
         # Build small jagged grouped GEMM inputs
         torch.manual_seed(0)

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+import unittest
+from unittest.mock import patch
+
+import torch
+
+import helion.runtime
+
+
+def _tpu_device() -> torch.device:
+    try:
+        return torch.device("tpu")
+    except RuntimeError:
+        return cast("torch.device", SimpleNamespace(type="tpu", index=None))
+
+
+class TestRuntimeGetNumSm(unittest.TestCase):
+    def test_pallas_interpret_cpu_returns_one(self) -> None:
+        with patch("helion.runtime._module_is_pallas_interpret", return_value=True):
+            self.assertEqual(helion.runtime.get_num_sm(torch.device("cpu")), 1)
+            self.assertEqual(
+                helion.runtime.get_num_sm(torch.device("cpu"), reserved_sms=8),
+                1,
+            )
+
+    def test_normal_cpu_still_unsupported(self) -> None:
+        with (
+            patch("helion.runtime._module_is_pallas_interpret", return_value=False),
+            self.assertRaisesRegex(
+                AssertionError,
+                "TODO: implement for other devices",
+            ),
+        ):
+            helion.runtime.get_num_sm(torch.device("cpu"))
+
+    def test_tpu_returns_one(self) -> None:
+        device = _tpu_device()
+
+        self.assertEqual(helion.runtime.get_num_sm(device), 1)
+        self.assertEqual(helion.runtime.get_num_sm(device, reserved_sms=8), 1)


### PR DESCRIPTION
Stacked PRs:
 * #2916
 * #2915
 * #2914
 * #2913
 * #2912
 * #2911
 * #2910
 * __->__#2909
 * #2908
 * #2907
 * #2906
 * #2905
 * #2904
 * #2903
 * #2902
 * #2901
 * #2900


--- --- ---

### Use backend worker count for grouped GEMM


This fixes the CUDA/XPU-only worker-count assumption in `grouped_gemm_jagged_persistent`. The example now asks `helion.runtime.get_num_sm()` for the backend persistent-worker abstraction, with TPU and Pallas interpret returning a compatible single-worker grid.