### PR TITLE
Handle FP8 padding in Triton block pointer loads

### DIFF
--- a/helion/_compiler/dtype_utils.py
+++ b/helion/_compiler/dtype_utils.py
@@ -10,6 +10,18 @@ from .compile_environment import CompileEnvironment
 if TYPE_CHECKING:
     import ast
 
+_FP8_DTYPES = {
+    torch.float8_e4m3fn,
+    torch.float8_e5m2,
+    torch.float8_e4m3fnuz,
+    torch.float8_e5m2fnuz,
+    torch.float8_e8m0fnu,
+}
+
+
+def is_fp8_dtype(dtype: torch.dtype) -> bool:
+    return dtype in _FP8_DTYPES
+
 
 def cast_ast(x: ast.AST, dtype: torch.dtype) -> ast.AST:
     """Return an AST that casts expression `x` to the backend dtype string."""

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import collections
+import contextlib
 import dataclasses
 from typing import TYPE_CHECKING
 from typing import ClassVar
@@ -20,6 +21,7 @@ from .compile_environment import CompileEnvironment
 from .compile_environment import _symint_expr
 from .device_function import DeviceFunction
 from .dtype_utils import cast_ast
+from .dtype_utils import is_fp8_dtype
 from .host_function import HostFunction
 from .tile_strategy import DeviceLoopState
 from .utils import compute_slice_size
@@ -50,6 +52,18 @@ class TileWithOffsetInfo(NamedTuple):
             if self.block_size is not None
             else env.block_sizes[env.canonical_block_id(self.block_id)].var
         )
+
+
+def _zero_literal_for_dtype(dtype: torch.dtype) -> str:
+    if is_fp8_dtype(dtype):
+        return "0.0"
+    return "0"
+
+
+def _block_ptr_boundary_check_kwarg(boundary_check: str) -> str:
+    if boundary_check == "None":
+        return ""
+    return f", boundary_check={boundary_check}"
 
 
 def _get_padded_iota_original_length(
@@ -579,12 +593,8 @@ class PointerIndexingStrategy(IndexingStrategy):
         indexing = SubscriptIndexing.create(state, fake_tensor, subscript, extra_mask)
         extra = ""
         if indexing.has_mask():
-            # For FP8 dtypes, use other=0.0 (float literal) instead of other=0 (int literal)
-            # because Triton cannot cast integer 0 to FP8 types
-            if fake_tensor.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
-                extra = ", other=0.0"
-            else:
-                extra = ", other=0"
+            # Triton cannot cast an integer zero literal to FP8 types.
+            extra = f", other={_zero_literal_for_dtype(fake_tensor.dtype)}"
         name = state.device_function.tensor_arg(fake_tensor).name
         # Optional hint for the allowlisted blocked-gather pattern.
         offset_ast = indexing.index_expr
@@ -764,7 +774,20 @@ class BlockPtrIndexingStrategy(IndexingStrategy):
                 cache_modifier,
             )
         indexing = BlockedSubscriptIndexing.create(state, fake_tensor, subscript)
+        boundary_check = indexing.boundary_check(state)
+        if boundary_check != "None" and is_fp8_dtype(fake_tensor.dtype):
+            return PointerIndexingStrategy().codegen_load(
+                state,
+                fake_tensor,
+                subscript,
+                extra_mask,
+                eviction_policy,
+                cache_modifier,
+            )
         extra = ""
+        boundary_check_kwarg = _block_ptr_boundary_check_kwarg(boundary_check)
+        if boundary_check != "None":
+            extra += ", padding_option='zero'"
         extra += ", eviction_policy={ev}" if eviction_policy is not None else ""
         extra += ", cache_modifier={cm}" if cache_modifier is not None else ""
         load_placeholders: dict[str, ast.AST] = {
@@ -777,14 +800,15 @@ class BlockPtrIndexingStrategy(IndexingStrategy):
         result = indexing.reshape_load(
             state,
             expr_from_string(
-                f"tl.load({{block_ptr}}, boundary_check={indexing.boundary_check(state)}, padding_option='zero'{extra})",
+                f"tl.load({{block_ptr}}{boundary_check_kwarg}{extra})",
                 **load_placeholders,
             ),
         )
 
         if extra_mask is not None:
+            zero = _zero_literal_for_dtype(fake_tensor.dtype)
             result = expr_from_string(
-                "tl.where({extra_mask}, {value}, 0)",
+                f"tl.where({{extra_mask}}, {{value}}, {zero})",
                 extra_mask=extra_mask,
                 value=result,
             )
@@ -809,6 +833,9 @@ class BlockPtrIndexingStrategy(IndexingStrategy):
         indexing = BlockedSubscriptIndexing.create(state, fake_tensor, subscript)
         store_value = indexing.reshape_store(state, value)
         store_value = cast_ast(store_value, fake_tensor.dtype)
+        boundary_check_kwarg = _block_ptr_boundary_check_kwarg(
+            indexing.boundary_check(state)
+        )
         extra = ", cache_modifier={cm}" if cache_modifier is not None else ""
         placeholders: dict[str, ast.AST] = {
             "block_ptr": indexing.make_block_ptr(state),
@@ -817,7 +844,7 @@ class BlockPtrIndexingStrategy(IndexingStrategy):
         if cache_modifier is not None:
             placeholders["cm"] = cache_modifier
         return expr_from_string(
-            f"tl.store({{block_ptr}}, {{value}}, boundary_check={indexing.boundary_check(state)}{extra})",
+            f"tl.store({{block_ptr}}, {{value}}{boundary_check_kwarg}{extra})",
             **placeholders,
         )
 
@@ -1800,11 +1827,26 @@ class BlockedSubscriptIndexing:
 
     def boundary_check(self, state: CodegenState) -> str:
         result = []
+        env = CompileEnvironment.current()
         for order, size in enumerate(self.block_shape):
             if not (isinstance(size, int) and size == 1):
-                # TODO(jansel): we should be able to filter with something like:
-                # block_idx = TileStrategy.get_block_index(size)
-                # if block_idx is None or state.tile_strategy.need_mask(block_idx):
+                block_idx = env.get_block_id(size)
+                if block_idx is not None:
+                    block_idx = _resolve_codegen_block_id(state, block_idx)
+                    loops = state.codegen.active_device_loops.get(block_idx)
+                    offset_var = None
+                    if loops:
+                        with contextlib.suppress(NotImplementedError):
+                            offset_var = state.codegen.offset_var(block_idx)
+                    if loops and self.offsets[order] == offset_var:
+                        loop_state = loops[-1]
+                        loop_info = loop_state.block_id_to_info.get(block_idx)
+                        if (
+                            loop_info is not None
+                            and loop_info.is_end_matching(self.base.size(order))
+                            and loop_state.strategy.mask_var(block_idx) is None
+                        ):
+                            continue
                 result.append(order)
         if result:
             return repr(result)

--- a/helion/autotuner/accuracy.py
+++ b/helion/autotuner/accuracy.py
@@ -4,24 +4,14 @@ import torch
 from torch.utils._pytree import tree_flatten
 from torch.utils._pytree import tree_map_only
 
-_FP8_DTYPES = {
-    torch.float8_e4m3fn,
-    torch.float8_e5m2,
-    torch.float8_e4m3fnuz,
-    torch.float8_e5m2fnuz,
-    torch.float8_e8m0fnu,
-}
-
-
-def is_fp8_dtype(dtype: torch.dtype) -> bool:
-    return dtype in _FP8_DTYPES
+from .._compiler.dtype_utils import is_fp8_dtype
 
 
 def assert_close(actual: object, expected: object, atol: float, rtol: float) -> None:
     """Like torch.testing.assert_close, with fp8 and large tensor handling."""
 
     def convert(t: torch.Tensor) -> torch.Tensor:
-        return t.view(torch.uint8) if t.dtype in _FP8_DTYPES else t
+        return t.view(torch.uint8) if is_fp8_dtype(t.dtype) else t
 
     actual_flat, actual_spec = tree_flatten(
         tree_map_only(torch.Tensor, convert, actual)

--- a/test/test_matmul.py
+++ b/test/test_matmul.py
@@ -15,6 +15,8 @@ from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import import_path
 from helion._testing import onlyBackends
+from helion._testing import skipIfCudaCapabilityLessThan
+from helion._testing import skipIfNotCUDA
 from helion._testing import skipIfNotTriton
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
@@ -22,21 +24,23 @@ from helion._testing import skipUnlessTensorDescriptor
 import helion.language as hl
 from helion.runtime.settings import _get_backend
 
-_orig_matmul_fp32_precision: str = "none"
 _orig_cudnn_fp32_precision: str = "none"
+_orig_float32_matmul_precision: str = "none"
 
 
 def setUpModule() -> None:
-    global _orig_matmul_fp32_precision, _orig_cudnn_fp32_precision
-    _orig_matmul_fp32_precision = torch.backends.cuda.matmul.fp32_precision
-    _orig_cudnn_fp32_precision = torch.backends.cudnn.conv.fp32_precision
-    torch.backends.cuda.matmul.fp32_precision = "tf32"
-    torch.backends.cudnn.conv.fp32_precision = "tf32"
+    global _orig_cudnn_fp32_precision, _orig_float32_matmul_precision
+    cudnn_conv = torch.backends.cudnn.conv  # pyrefly: ignore[missing-attribute]
+    _orig_cudnn_fp32_precision = cudnn_conv.fp32_precision
+    _orig_float32_matmul_precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("high")
+    cudnn_conv.fp32_precision = "tf32"
 
 
 def tearDownModule() -> None:
-    torch.backends.cuda.matmul.fp32_precision = _orig_matmul_fp32_precision
-    torch.backends.cudnn.conv.fp32_precision = _orig_cudnn_fp32_precision
+    cudnn_conv = torch.backends.cudnn.conv  # pyrefly: ignore[missing-attribute]
+    torch.set_float32_matmul_precision(_orig_float32_matmul_precision)
+    cudnn_conv.fp32_precision = _orig_cudnn_fp32_precision
 
 
 examples_dir = Path(__file__).parent.parent / "examples"
@@ -90,6 +94,20 @@ def matmul_static_shapes(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         for tile_k in hl.tile(k):
             acc += torch.matmul(x[tile_m, tile_k], y[tile_k, tile_n])
         out[tile_m, tile_n] = acc
+    return out
+
+
+@helion.kernel(static_shapes=True)
+def matmul_fp8_bf16(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    m, k = x.size()
+    k2, n = y.size()
+    assert k == k2, f"size mismatch {k} != {k2}"
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+        out[tile_m, tile_n] = acc.to(torch.bfloat16)
     return out
 
 
@@ -273,6 +291,7 @@ class TestMatmul(RefEagerTestBase, TestCase):
 
     @skipIfNotTriton("block_ptr is triton-only")
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
+    @skipIfRefEager("checks generated Triton code")
     @skipIfTileIR("TileIR does not support block_ptr indexing")
     def test_matmul_block_ptr(self):
         args = (
@@ -288,6 +307,76 @@ class TestMatmul(RefEagerTestBase, TestCase):
         )
         torch.testing.assert_close(output, args[0] @ args[1], atol=1e-1, rtol=1e-2)
         self.assertIn("tl.make_block_ptr", code)
+        self.assertNotIn("boundary_check=None", code)
+        block_ptr_load_lines = [
+            line for line in code.splitlines() if "tl.load(tl.make_block_ptr" in line
+        ]
+        self.assertGreater(len(block_ptr_load_lines), 0)
+        for line in block_ptr_load_lines:
+            self.assertNotIn("boundary_check=", line)
+        block_ptr_store_lines = [
+            line for line in code.splitlines() if "tl.store(tl.make_block_ptr" in line
+        ]
+        self.assertGreater(len(block_ptr_store_lines), 0)
+        for line in block_ptr_store_lines:
+            self.assertNotIn("boundary_check=", line)
+
+    @skipIfNotTriton("block_ptr is triton-only")
+    @skipIfNotCUDA()
+    @skipIfCudaCapabilityLessThan((9, 0), reason="FP8 requires CUDA capability >= 9.0")
+    @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
+    @skipIfTileIR("TileIR does not support block_ptr indexing")
+    def test_fp8_matmul_block_ptr_omits_zero_padding(self):
+        args = (
+            torch.randn([128, 128], device=DEVICE, dtype=torch.float32).to(
+                torch.float8_e4m3fn
+            ),
+            torch.randn([128, 256], device=DEVICE, dtype=torch.float32)
+            .to(torch.float8_e4m3fn)
+            .T.contiguous()
+            .T,
+        )
+        code, output = code_and_output(
+            matmul_fp8_bf16,
+            args,
+            block_sizes=[128, 256, 128],
+            indexing="block_ptr",
+        )
+        expected = (args[0].to(torch.float32) @ args[1].to(torch.float32)).to(
+            torch.bfloat16
+        )
+        torch.testing.assert_close(output, expected, atol=1.0, rtol=1e-1)
+        self.assertIn("tl.make_block_ptr", code)
+        self.assertNotIn("padding_option='zero'", code)
+
+    @skipIfNotTriton("block_ptr is triton-only")
+    @skipIfNotCUDA()
+    @skipIfCudaCapabilityLessThan((9, 0), reason="FP8 requires CUDA capability >= 9.0")
+    @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
+    @skipIfTileIR("TileIR does not support block_ptr indexing")
+    def test_fp8_matmul_block_ptr_uses_pointer_for_padded_edges(self):
+        args = (
+            torch.randn([130, 128], device=DEVICE, dtype=torch.float32).to(
+                torch.float8_e4m3fn
+            ),
+            torch.randn([128, 256], device=DEVICE, dtype=torch.float32)
+            .to(torch.float8_e4m3fn)
+            .T.contiguous()
+            .T,
+        )
+        code, output = code_and_output(
+            matmul_fp8_bf16,
+            args,
+            block_sizes=[128, 256, 128],
+            indexing="block_ptr",
+        )
+        expected = (args[0].to(torch.float32) @ args[1].to(torch.float32)).to(
+            torch.bfloat16
+        )
+        torch.testing.assert_close(output, expected, atol=1.0, rtol=1e-1)
+        self.assertIn("tl.make_block_ptr", code)
+        self.assertIn("other=0.0", code)
+        self.assertNotIn("padding_option='zero'", code)
 
     @skipIfNotTriton("tensor_descriptor is triton-only")
     @skipUnlessTensorDescriptor("TensorDescriptor not supported")


### PR DESCRIPTION
Stacked PRs:
 * #2936
 * #2935
 * #2934
 * #2933
 * #2932
 * #2931
 * #2930
 * #2929
 * #2928
 * #2927
 * #2926
 * #2925
 * #2924
 * #2923
 * #2922
 * #2921
 * #2920
 * #2919
 * __->__#2918
 * #2917


--- --- ---

### Handle FP8 padding in Triton block pointer loads


Compiler side: share FP8 dtype detection with autotuner accuracy checks, use FP8-safe zero literals for masked loads, omit boundary_check=None in generated block_ptr calls, and fall back to pointer loads when FP8 padded edges would otherwise require Triton zero padding.

Test side: add matmul codegen coverage for block_ptr boundary emission and FP8 padded-edge cases. This unblocks Triton FP8/block_ptr matmul coverage while keeping the change local to dtype and indexing support.