### PR TITLE
Align Pallas dot precision and example tolerances

### DIFF
--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -94,11 +94,11 @@ def my_kernel(x: torch.Tensor) -> torch.Tensor:
 
    Supported values depend on the backend:
    - Triton (GPU): ``"tf32"``, ``"tf32x3"``, ``"ieee"``
-   - Pallas (TPU): ``"default"`` (forces JAX default, typically bfloat16), ``"high"``, ``"highest"`` (float32 emulation).
+   - Pallas (TPU): ``"default"``, ``"high"``, ``"highest"`` and portable Triton aliases are accepted.
 
-   However, unified mappings exist so you can use any value on any backend. They map to the closest equivalent of equal or higher precision:
+   However, unified mappings exist so you can use any value on any backend:
    - On Triton: ``"default"`` maps to ``"tf32"``, ``"high"`` maps to ``"tf32x3"``, and ``"highest"`` maps to ``"ieee"``.
-   - On Pallas: ``"tf32"``, ``"tf32x3"`` and ``"ieee"`` all map to ``"highest"``.
+   - On Pallas/TPU: all values currently emit JAX default precision. JAX ``"high"``/``"highest"`` fp32 dot precision is not used because it is less compatible with PyTorch eager references on the supported TPU stack.
 
 .. autoattribute:: Settings.static_shapes
 
@@ -315,7 +315,7 @@ Built-in values for ``HELION_AUTOTUNER`` include ``"LFBOTreeSearch"`` (default),
 | Environment Variable | Maps To | Description |
 |----------------------|---------|-------------|
 | ``TRITON_F32_DEFAULT`` | ``dot_precision`` | Sets default floating-point precision for Triton dot products (``"tf32"``, ``"tf32x3"``, ``"ieee"``). This variable does not apply to the Pallas backend. |
-| ``JAX_DEFAULT_MATMUL_PRECISION`` | ``dot_precision`` | Sets default matmul precision for Pallas dot products (JAX values: ``"default"``, ``"high"``, ``"highest"``, etc., mapped to Helion ``DotPrecision``). This variable does not apply to the Triton backend. |
+| ``JAX_DEFAULT_MATMUL_PRECISION`` | ``dot_precision`` | Accepts JAX matmul precision values for Pallas dot products (``"default"``, ``"high"``, ``"highest"``, etc., mapped to Helion ``DotPrecision``). On TPU these values emit Pallas default precision. This variable does not apply to the Triton backend. |
 | ``HELION_INDEX_DTYPE`` | ``index_dtype`` | Choose the index dtype (accepts any ``torch.<dtype>`` name, e.g. ``int64``), or set to ``auto``/unset to allow Helion to pick ``int32`` vs ``int64`` based on input sizes. |
 | ``HELION_STATIC_SHAPES`` | ``static_shapes`` | Set to ``0``/``false`` to disable global static shape specialization. |
 | ``HELION_FAST_MATH`` | ``fast_math`` | Set to ``1`` to enable fast math approximations (Helion-level and Inductor-level). May reduce numerical precision. |

--- a/examples/bf16xint16_gemm.py
+++ b/examples/bf16xint16_gemm.py
@@ -145,6 +145,7 @@ def check(m: int, k: int, n: int) -> None:
     # fp32, while torch.matmul uses a single full-K dot. The different
     # accumulation order can move a few outputs across a bf16 rounding boundary.
     max_mismatch_pct = 1e-4 if _get_backend() == "pallas" else None
+    max_mismatched_abs_diff = 0.5 if max_mismatch_pct is not None else None
 
     x = torch.randn([m, k], device=DEVICE, dtype=torch.bfloat16)
     w = torch.randint(-(2**15), 2**15 - 1, (k, n), device=DEVICE, dtype=torch.int16)
@@ -155,6 +156,7 @@ def check(m: int, k: int, n: int) -> None:
         rtol=1e-2,
         atol=1e-2,
         max_mismatch_pct=max_mismatch_pct,
+        max_mismatched_abs_diff=max_mismatched_abs_diff,
     )
 
     x_int16 = torch.randint(
@@ -168,6 +170,7 @@ def check(m: int, k: int, n: int) -> None:
         rtol=1e-2,
         atol=1e-2,
         max_mismatch_pct=max_mismatch_pct,
+        max_mismatched_abs_diff=max_mismatched_abs_diff,
     )
 
 

--- a/examples/distributed/all_gather_matmul.py
+++ b/examples/distributed/all_gather_matmul.py
@@ -31,6 +31,7 @@ from helion.runtime.triton_helpers import triton_wait_signal
 
 @triton.jit
 def _wait_progress_at_idx(progress: tl.tensor, idx: int) -> None:
+    # pyrefly: ignore[bad-argument-type]
     triton_wait_signal(progress + idx, 1, 0, "acquire", "gpu", "ld", False)
 
 

--- a/examples/distributed/fp8_scaled_all_gather_matmul.py
+++ b/examples/distributed/fp8_scaled_all_gather_matmul.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 
 @triton.jit
 def _wait_progress_at_idx(progress: tl.tensor, idx: int) -> None:
+    # pyrefly: ignore[bad-argument-type]
     triton_wait_signal(progress + idx, 1, 0, "acquire", "gpu", "ld", False)
 
 

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1554,20 +1554,12 @@ class PallasBackend(Backend):
     def map_dot_precision(precision: DotPrecision) -> str:
         """Map Helion dot precision to Pallas-specific precision string.
 
-        Pallas/TPU has limited support for different precisions, often
-        falling back to the highest available precision.
+        Pallas/TPU does not support Triton-style TF32/IEEE controls.  On the
+        current TPU stack, JAX ``high``/``highest`` fp32 dot precision is less
+        compatible with PyTorch eager references than JAX default precision, so
+        all Helion aliases intentionally lower to the Pallas default.
         """
-        pallas_precision_by_dot_precision = {
-            "default": "default",
-            # "high" is mapped to "highest" because Pallas/Mosaic doesn't yet
-            # support it on TPU.
-            "high": "highest",
-            "highest": "highest",
-            "tf32": "highest",
-            "tf32x3": "highest",
-            "ieee": "highest",
-        }
-        return pallas_precision_by_dot_precision.get(precision, "default")
+        return "default"
 
     @property
     def max_tensor_numel(self) -> int | None:

--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -448,6 +448,13 @@ def float32_matmul_precision(precision: str) -> Generator[None, None, None]:
         torch.set_float32_matmul_precision(original_precision)
 
 
+def get_test_float32_matmul_precision() -> str:
+    """Return the PyTorch fp32 matmul precision used for test references."""
+    if _get_backend() == "pallas":
+        return "medium"
+    return "high"
+
+
 def skipIfNotTriton(reason: str) -> Callable[[Callable], Callable]:
     """Skip test when backend is not Triton (e.g. cute, pallas)."""
     return skipIfFn(lambda: _get_backend() != "triton", reason)
@@ -1118,37 +1125,27 @@ def _as_tensors(result: object) -> list[torch.Tensor]:
 
 
 def _with_tf32_precision(fn: Callable[_P, _R]) -> Callable[_P, _R]:
-    """Run a test helper with TF32 enabled, restoring prior precision settings."""
+    """Run a test helper with backend-aligned fp32 matmul precision."""
 
     @functools.wraps(fn)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
-        orig_matmul_fp32_precision: str | None = None
         orig_cudnn_fp32_precision: str | None = None
-        orig_float32_matmul_precision: str | None = None
+        orig_float32_matmul_precision = torch.get_float32_matmul_precision()
+        torch.set_float32_matmul_precision(get_test_float32_matmul_precision())
         try:
             cudnn_conv = torch.backends.cudnn.conv  # pyrefly: ignore[missing-attribute]
-            orig_matmul_fp32_precision = cast(
-                "str", torch.backends.cuda.matmul.fp32_precision
-            )
             orig_cudnn_fp32_precision = cast("str", cudnn_conv.fp32_precision)
-            torch.backends.cuda.matmul.fp32_precision = "tf32"
             cudnn_conv.fp32_precision = "tf32"
         except AttributeError:  # No cudnn available
-            orig_float32_matmul_precision = torch.get_float32_matmul_precision()
-            torch.set_float32_matmul_precision("high")  # older deprecated API
+            pass
 
         try:
             return fn(*args, **kwargs)
         finally:
-            if (
-                orig_matmul_fp32_precision is not None
-                and orig_cudnn_fp32_precision is not None
-            ):
+            torch.set_float32_matmul_precision(orig_float32_matmul_precision)
+            if orig_cudnn_fp32_precision is not None:
                 cudnn_conv = torch.backends.cudnn.conv  # pyrefly: ignore[missing-attribute]
-                torch.backends.cuda.matmul.fp32_precision = orig_matmul_fp32_precision
                 cudnn_conv.fp32_precision = orig_cudnn_fp32_precision
-            elif orig_float32_matmul_precision is not None:
-                torch.set_float32_matmul_precision(orig_float32_matmul_precision)
 
     return wrapper
 
@@ -1163,6 +1160,7 @@ def run_example(
     rtol: float = 1e-2,
     atol: float = 1e-1,
     max_mismatch_pct: float | None = None,
+    max_mismatched_abs_diff: float | None = None,
     bwd: bool = False,
     trace_path: str | None = None,
     process_group_name: str | None = None,
@@ -1183,6 +1181,8 @@ def run_example(
         atol: Absolute tolerance for correctness check (default: 1e-1)
         max_mismatch_pct: If set, use assert_close_with_mismatch_tolerance with this mismatch
             fraction tolerance instead of strict assert_close (default: None)
+        max_mismatched_abs_diff: If set with max_mismatch_pct, bound the largest
+            absolute difference among mismatched elements.
         bwd: Whether to also test backward pass (default: False)
         trace_path: if not None, do profiling and save trace to this path
     """
@@ -1216,6 +1216,7 @@ def run_example(
                         atol=atol,
                         rtol=rtol,
                         max_mismatch_pct=max_mismatch_pct,
+                        max_mismatched_abs_diff=max_mismatched_abs_diff,
                     )
                 else:
                     torch.testing.assert_close(
@@ -1380,6 +1381,8 @@ def _assert_example_result_close(
     skip_accuracy: bool,
     atol: float,
     rtol: float,
+    max_mismatch_pct: float | None = None,
+    max_mismatched_abs_diff: float | None = None,
     cos_sim: CosSimilarity | tuple[int, float] | None = None,
 ) -> None:
     if skip_accuracy:
@@ -1406,12 +1409,22 @@ def _assert_example_result_close(
                 f"Cosine similarity {sim.mean().item()} is less than {min_sim}"
             )
 
-        torch.testing.assert_close(
-            got_f32,
-            exp_f32,
-            atol=atol,
-            rtol=rtol,
-        )
+        if max_mismatch_pct is not None:
+            assert_close_with_mismatch_tolerance(
+                got_f32,
+                exp_f32,
+                atol=atol,
+                rtol=rtol,
+                max_mismatch_pct=max_mismatch_pct,
+                max_mismatched_abs_diff=max_mismatched_abs_diff,
+            )
+        else:
+            torch.testing.assert_close(
+                got_f32,
+                exp_f32,
+                atol=atol,
+                rtol=rtol,
+            )
 
     tree_map(assert_close_fn, result, expected)
 
@@ -1437,6 +1450,8 @@ def check_example(
     static_shapes: bool | None = None,
     atol: float = 1e-1,
     rtol: float = 1e-2,
+    max_mismatch_pct: float | None = None,
+    max_mismatched_abs_diff: float | None = None,
     emit_code: bool = True,
     cos_sim: CosSimilarity | tuple[int, float] | None = None,
     **kwargs: object,
@@ -1463,6 +1478,8 @@ def check_example(
         skip_accuracy=skip_accuracy,
         atol=atol,
         rtol=rtol,
+        max_mismatch_pct=max_mismatch_pct,
+        max_mismatched_abs_diff=max_mismatched_abs_diff,
         cos_sim=cos_sim,
     )
     return code
@@ -1829,6 +1846,7 @@ def assert_close_with_mismatch_tolerance(
     atol: float = 1e-4,
     rtol: float = 1e-4,
     max_mismatch_pct: float = 0.01,
+    max_mismatched_abs_diff: float | None = None,
     max_abs_diff: float | None = None,
     max_rel_diff: float | None = None,
 ) -> None:
@@ -1841,6 +1859,8 @@ def assert_close_with_mismatch_tolerance(
 
     - *max_mismatch_pct*: maximum allowed fraction of mismatched elements
       (default 1%).  Always checked.
+    - *max_mismatched_abs_diff*: if not None, the greatest absolute
+      difference among mismatched elements must not exceed this value.
     - *max_abs_diff*: if not None, the greatest absolute difference across
       all elements must not exceed this value.
     - *max_rel_diff*: if not None, the greatest relative difference
@@ -1858,12 +1878,23 @@ def assert_close_with_mismatch_tolerance(
             autotune_baseline_accuracy_check_fn=partial(
                 assert_close_with_mismatch_tolerance,
                 max_mismatch_pct=0.05,
+                max_mismatched_abs_diff=1.0,
                 max_abs_diff=10.0,
                 max_rel_diff=15.0,
             ),
         )
         def my_kernel(...): ...
     """
+    if isinstance(actual, torch.Tensor) and isinstance(expected, torch.Tensor):
+        if actual.shape != expected.shape:
+            torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+
+        actual_finite = torch.isfinite(actual)
+        expected_finite = torch.isfinite(expected)
+        if not (actual_finite.all() and expected_finite.all()):
+            nonfinite = (~actual_finite | ~expected_finite).sum().item()
+            raise AssertionError(f"Non-finite values found: {nonfinite}")
+
     try:
         torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
         return
@@ -1878,13 +1909,22 @@ def assert_close_with_mismatch_tolerance(
 
     # Use the same mismatch definition as torch.testing.assert_close:
     # an element is mismatched when |actual - expected| > atol + rtol * |expected|
-    mismatched = (abs_diff > atol + rtol * expected.abs()).sum().item()
+    mismatch_mask = abs_diff > atol + rtol * expected.abs()
+    mismatched = mismatch_mask.sum().item()
     mismatch_pct = mismatched / total if total > 0 else 0.0
 
     if mismatch_pct > max_mismatch_pct:
         raise AssertionError(
             f"Too many mismatches: {mismatch_pct:.4%} > {max_mismatch_pct:.4%}"
         )
+
+    if max_mismatched_abs_diff is not None and mismatched:
+        worst_mismatched_abs = abs_diff[mismatch_mask].max().item()
+        if worst_mismatched_abs > max_mismatched_abs_diff:
+            raise AssertionError(
+                "Mismatched absolute diff too large: "
+                f"{worst_mismatched_abs} > {max_mismatched_abs_diff}"
+            )
 
     if max_abs_diff is not None:
         worst_abs = abs_diff.max().item()

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -1346,6 +1346,7 @@ def _build_matmul_dot_general_jit_fn(
             tensor_inputs[lhs_idx],
             tensor_inputs[rhs_idx],
             dimension_numbers=(((1,), (0,)), ((), ())),
+            precision="default",
             preferred_element_type=preferred,
         )
         if needs_cast:

--- a/helion/runtime/dist_utils.py
+++ b/helion/runtime/dist_utils.py
@@ -154,8 +154,14 @@ def _symm_mem_sync_cuda(
         tl.debug_barrier()
 
     if flat_tid < world_size:
-        _send_signal(send_addrs, "release" if hasPreviousMemAccess else "relaxed")
-        _wait_signal(wait_addrs, "acquire" if hasSubsequentMemAccess else "relaxed")
+        if hasPreviousMemAccess:
+            _send_signal(send_addrs, "release")  # pyrefly: ignore[bad-argument-type]
+        else:
+            _send_signal(send_addrs, "relaxed")  # pyrefly: ignore[bad-argument-type]
+        if hasSubsequentMemAccess:
+            _wait_signal(wait_addrs, "acquire")  # pyrefly: ignore[bad-argument-type]
+        else:
+            _wait_signal(wait_addrs, "relaxed")  # pyrefly: ignore[bad-argument-type]
 
     if hasSubsequentMemAccess:
         tl.debug_barrier()

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -339,8 +339,8 @@ def _get_dot_precision() -> DotPrecision:
                 "high": "high",
                 "highest": "highest",
                 "bfloat16": "default",
-                "tensorfloat32": "high",
-                "float32": "highest",
+                "tensorfloat32": "default",
+                "float32": "default",
             },
         )
 
@@ -617,7 +617,7 @@ class Settings(_Settings):
             "The dtype to use for index variables. Default auto-selects torch.int32 or torch.int64 based on input sizes. "
             "Override with HELION_INDEX_DTYPE=<dtype> (or set to 'auto')."
         ),
-        "dot_precision": "Precision for dot products. For Triton backend, see `triton.language.dot` (can be 'tf32', 'tf32x3', 'ieee'). For JAX/Pallas backend, can be 'default', 'high', 'highest' (mapped to JAX precision). Unified mappings exist so that any value can be used on any backend.",
+        "dot_precision": "Precision for dot products. For Triton backend, see `triton.language.dot` (can be 'tf32', 'tf32x3', 'ieee'). For JAX/Pallas backend, accepted values emit Pallas default precision on TPU. Unified mappings exist so that any value can be used on any backend.",
         "fast_math": (
             "If True, enable fast math approximations (Helion-level and Inductor-level). "
             "May reduce numerical precision. Set HELION_FAST_MATH=1 to enable."

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -128,6 +128,42 @@ class RecordingRandomSearch(RandomSearch):
         return super()._autotune()
 
 
+class TestMismatchTolerance(TestCase):
+    def test_assert_close_with_mismatch_tolerance_rejects_nonfinite(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "Non-finite values found"):
+            assert_close_with_mismatch_tolerance(
+                torch.tensor([float("nan"), 1.0], device=DEVICE),
+                torch.tensor([1.0, 1.0], device=DEVICE),
+                max_mismatch_pct=1.0,
+            )
+
+        with self.assertRaisesRegex(AssertionError, "Non-finite values found"):
+            assert_close_with_mismatch_tolerance(
+                torch.tensor([float("inf")], device=DEVICE),
+                torch.tensor([float("inf")], device=DEVICE),
+                max_mismatch_pct=1.0,
+            )
+
+    def test_assert_close_with_mismatch_tolerance_rejects_shape_mismatch(self) -> None:
+        with self.assertRaises(AssertionError):
+            assert_close_with_mismatch_tolerance(
+                torch.ones([2, 1], device=DEVICE),
+                torch.ones([2], device=DEVICE),
+                max_mismatch_pct=1.0,
+            )
+
+    def test_assert_close_with_mismatch_tolerance_bounds_mismatches(self) -> None:
+        with self.assertRaisesRegex(
+            AssertionError, "Mismatched absolute diff too large"
+        ):
+            assert_close_with_mismatch_tolerance(
+                torch.tensor([10.0, 1.0, 1.0, 1.0], device=DEVICE),
+                torch.tensor([1.0, 1.0, 1.0, 1.0], device=DEVICE),
+                max_mismatch_pct=0.5,
+                max_mismatched_abs_diff=5.0,
+            )
+
+
 @onlyBackends(["triton"])
 class TestAutotuneIgnoreErrors(TestCase):
     def _make_search(

--- a/test/test_dot.py
+++ b/test/test_dot.py
@@ -1253,8 +1253,8 @@ class TestDotPrecision(TestCase):
             ("pallas", "JAX_DEFAULT_MATMUL_PRECISION", "high", "high"),
             ("pallas", "JAX_DEFAULT_MATMUL_PRECISION", "highest", "highest"),
             ("pallas", "JAX_DEFAULT_MATMUL_PRECISION", "bfloat16", "default"),
-            ("pallas", "JAX_DEFAULT_MATMUL_PRECISION", "tensorfloat32", "high"),
-            ("pallas", "JAX_DEFAULT_MATMUL_PRECISION", "float32", "highest"),
+            ("pallas", "JAX_DEFAULT_MATMUL_PRECISION", "tensorfloat32", "default"),
+            ("pallas", "JAX_DEFAULT_MATMUL_PRECISION", "float32", "default"),
         ],
     )
     def test_env_var_overrides(
@@ -1291,7 +1291,6 @@ class TestDotPrecision(TestCase):
     _PR_TF32x3 = "input_precision='tf32x3'"
     _PR_IEEE = "input_precision='ieee'"
     _PR_DEFAULT = "precision='default'"
-    _PR_HIGHEST = "precision='highest'"
 
     @skipIfRocm("No support for tf32x3 and no tf32 in some ROCm hardware")
     @skipIfRefEager("Codegen inspection not applicable in ref eager mode")
@@ -1299,11 +1298,11 @@ class TestDotPrecision(TestCase):
         "helion_precision, expected_triton, expected_pallas",
         [
             ("default", _PR_TF32, _PR_DEFAULT),
-            ("high", _PR_TF32x3, _PR_HIGHEST),
-            ("highest", _PR_IEEE, _PR_HIGHEST),
-            ("tf32", _PR_TF32, _PR_HIGHEST),
-            ("tf32x3", _PR_TF32x3, _PR_HIGHEST),
-            ("ieee", _PR_IEEE, _PR_HIGHEST),
+            ("high", _PR_TF32x3, _PR_DEFAULT),
+            ("highest", _PR_IEEE, _PR_DEFAULT),
+            ("tf32", _PR_TF32, _PR_DEFAULT),
+            ("tf32x3", _PR_TF32x3, _PR_DEFAULT),
+            ("ieee", _PR_IEEE, _PR_DEFAULT),
         ],
     )
     def test_dot_precision_codegen(

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -22,6 +22,7 @@ from helion._testing import TestCase
 from helion._testing import _get_backend
 from helion._testing import check_example
 from helion._testing import float32_matmul_precision
+from helion._testing import get_test_float32_matmul_precision
 from helion._testing import import_path
 from helion._testing import onlyBackends
 from helion._testing import skipIfA10G
@@ -41,8 +42,8 @@ from helion._testing import xfailIfPallasTpu
 from helion.runtime.config import Config
 from helion.runtime.ref_mode import is_ref_mode_enabled
 
-_orig_matmul_fp32_precision: str = "none"
 _orig_cudnn_fp32_precision: str = "none"
+_orig_float32_matmul_precision: str = "none"
 
 
 def _compile_only(
@@ -69,16 +70,18 @@ def _compile_only(
 
 
 def setUpModule() -> None:
-    global _orig_matmul_fp32_precision, _orig_cudnn_fp32_precision
-    _orig_matmul_fp32_precision = torch.backends.cuda.matmul.fp32_precision
-    _orig_cudnn_fp32_precision = torch.backends.cudnn.conv.fp32_precision
-    torch.backends.cuda.matmul.fp32_precision = "tf32"
-    torch.backends.cudnn.conv.fp32_precision = "tf32"
+    global _orig_cudnn_fp32_precision, _orig_float32_matmul_precision
+    cudnn_conv = torch.backends.cudnn.conv  # pyrefly: ignore[missing-attribute]
+    _orig_cudnn_fp32_precision = cudnn_conv.fp32_precision
+    _orig_float32_matmul_precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision(get_test_float32_matmul_precision())
+    cudnn_conv.fp32_precision = "tf32"
 
 
 def tearDownModule() -> None:
-    torch.backends.cuda.matmul.fp32_precision = _orig_matmul_fp32_precision
-    torch.backends.cudnn.conv.fp32_precision = _orig_cudnn_fp32_precision
+    cudnn_conv = torch.backends.cudnn.conv  # pyrefly: ignore[missing-attribute]
+    torch.set_float32_matmul_precision(_orig_float32_matmul_precision)
+    cudnn_conv.fp32_precision = _orig_cudnn_fp32_precision
 
 
 @onlyBackends(["triton", "cute", "pallas"])
@@ -682,7 +685,6 @@ class TestExamples(RefEagerTestBase, TestCase):
         "65536x1024x1280 GEMM is too slow under CPU interpret -- it exceeds the "
         "300s per-test timeout and (thread timeout method) kills the whole job"
     )
-    @xfailIfPallasTpu("precision differences with bf16xint16 operations on pallas")
     @skipIfTileIR("precision differences with bf16xint16 operations on tileir")
     @skipIfRocm("precision differences with bf16xint16 operations on rocm")
     @skipIfXPU("precision differences with bf16xint16 operations on xpu")
@@ -711,22 +713,22 @@ class TestExamples(RefEagerTestBase, TestCase):
             else:
                 x_f32 = xt.float()
                 w_f32 = wt.to(torch.bfloat16).float()
-            prev = torch.backends.cuda.matmul.fp32_precision
-            torch.backends.cuda.matmul.fp32_precision = "ieee"
-            try:
+            with float32_matmul_precision("highest"):
                 out = torch.matmul(x_f32, w_f32)
-            finally:
-                torch.backends.cuda.matmul.fp32_precision = prev
             return out.to(torch.bfloat16)
 
         x = torch.randn([m, k], device=DEVICE, dtype=torch.bfloat16)
         w = torch.randint(-(2**15), 2**15 - 1, (k, n), device=DEVICE, dtype=torch.int16)
+        max_mismatch_pct = 1e-4 if _get_backend() == "pallas" else None
+        max_mismatched_abs_diff = 0.5 if max_mismatch_pct is not None else None
 
         check_example(
             "bf16xint16_gemm",
             (x, w),
             expected(x, w, False),
             fn_name="_bf16xint16_gemm",
+            max_mismatch_pct=max_mismatch_pct,
+            max_mismatched_abs_diff=max_mismatched_abs_diff,
         )
 
         x_int16 = torch.randint(
@@ -739,6 +741,8 @@ class TestExamples(RefEagerTestBase, TestCase):
             (x_int16, w_bf16),
             expected(x_int16, w_bf16, True),
             fn_name="_int16xbf16_gemm",
+            max_mismatch_pct=max_mismatch_pct,
+            max_mismatched_abs_diff=max_mismatched_abs_diff,
         )
 
     def test_rms_norm_fwd(self):
@@ -1567,12 +1571,9 @@ class TestExamples(RefEagerTestBase, TestCase):
     @parametrize(
         "helion_precision,torch_precision,atol,rtol",
         [
-            ("highest", "highest", 1e-2, 1e-2),
+            ("highest", "medium", 1.5, 5e-2),
             ("default", "medium", 1.5, 5e-2),
         ],
-    )
-    @xfailIfPallasInterpret(
-        "The get/set_float32_matmul_precision API needs an actual backend"
     )
     @onlyBackends(["pallas"])
     def test_jagged_hstu_attn_2(self, helion_precision, torch_precision, atol, rtol):

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -7,6 +7,7 @@ import re
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
+from typing import cast
 import unittest
 
 from examples.geglu import _geglu_pallas as _geglu_pallas_example
@@ -2047,6 +2048,37 @@ class TestPallas(TestCase):
             5e-2,
             f"dot_general output diverged from pallas_call by {max_abs_diff}",
         )
+
+    def test_pallas_matmul_dot_general_lowering_pins_default_precision(self) -> None:
+        """The no-tiling dot-general shortcut must not inherit JAX global precision."""
+        from unittest.mock import patch
+
+        import jax
+        import jax.numpy as jnp
+
+        from helion import runtime as helion_runtime
+
+        spec: dict[str, object] = {
+            "lhs_tensor_arg_index": 0,
+            "rhs_tensor_arg_index": 1,
+            "out_dtype": "jnp.float32",
+            "f32_accumulator": False,
+        }
+        with (
+            patch.object(jax, "jit", lambda fn: fn),
+            patch.object(jax.lax, "dot_general", wraps=jax.lax.dot_general) as dot_spy,
+        ):
+            fn = helion_runtime._build_matmul_dot_general_jit_fn(spec)
+            result = cast(
+                "Any",
+                fn(
+                    jnp.ones((2, 3), dtype=jnp.float32),
+                    jnp.ones((3, 4), dtype=jnp.float32),
+                ),
+            )
+
+        self.assertEqual(result.shape, (2, 4))
+        self.assertEqual(dot_spy.call_args.kwargs["precision"], "default")
 
     def test_bmm(self) -> None:
         """Test BMM with default config — exercises size_matches fix.
@@ -4302,7 +4334,11 @@ class TestPallas(TestCase):
         )
 
         # Eager mask retained on the direct dot input; nothing to defer past.
-        self.assertRegex(code, r"= y\[[^\n]*\] \* mask_\d+\.astype")
+        self.assertRegex(
+            code,
+            r"(y\[[^\n]*\][^\n]*\*\s*mask_\d+\.astype|"
+            r"mask_\d+\.astype[^\n]*\*[^\n]*y\[)",
+        )
         self.assertNotRegex(code, r"jnp\.transpose\(")
 
         s, e = 0, 50

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -297,7 +297,7 @@ class TestViews(RefEagerTestBase, TestCase):
         expected = torch.matmul(x, y)
         torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
 
-    @xfailIfPallas("triton.next_power_of_2 in generated host code crashes pallas")
+    @xfailIfPallas("Pallas pads tiles before reshape until tiled loads land")
     def test_reshape_sum(self):
         @helion.kernel(static_shapes=True)
         def fn(x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Stacked PRs:
 * #2936
 * #2935
 * #2934
 * #2933
 * #2932
 * #2931
 * #2930
 * #2929
 * #2928
 * #2927
 * #2926
 * #2925
 * #2924
 * #2923
 * #2922
 * #2921
 * __->__#2920
 * #2919
 * #2918
 * #2917


--- --- ---

### Align Pallas dot precision and example tolerances


Compiler/runtime side: map Pallas dot precision aliases to JAX default precision and pin the no-tiling dot_general shortcut to precision='default', matching TPU reference behavior instead of inheriting global high/highest settings.

Test harness side: choose backend-aware PyTorch fp32 reference precision and add bounded mismatch tolerance checks for cases where Pallas/JAX accumulation order can drift within a bounded absolute error.

Test side: update dot precision expectations, Pallas dot_general coverage, example tolerances, and distributed pyrefly ignores. This unblocks precision-sensitive Pallas examples such as bf16xint16_gemm and distributed all-gather matmul while keeping settings accepted across backends.