### PR TITLE
Support Pallas padded loads and scalar widening

### DIFF
--- a/examples/gdn_fwd_h.py
+++ b/examples/gdn_fwd_h.py
@@ -99,6 +99,21 @@ def helion_gdn_fwd_h_tb(
     return lambda: helion_gdn_fwd_h(k, w, u, g, chunk_size)
 
 
+def _orthogonalize_w(w: torch.Tensor) -> torch.Tensor:
+    """Build the constrained ``w`` test input without relying on TPU SVD."""
+    device = w.device
+    w_svd = w.permute(0, 1, 3, 2, 4)
+    if w_svd.device.type == "tpu":
+        w_svd = w_svd.cpu()
+    wu, _, wv = torch.linalg.svd(w_svd, full_matrices=False)
+    w = torch.einsum("bnhik,bnhkj->bnhij", wu, wv)
+    return (
+        w.permute(0, 1, 3, 2, 4)
+        .reshape(w.shape[0], w.shape[1] * w.shape[3], w.shape[2], w.shape[4])
+        .to(device=device, dtype=torch.bfloat16)
+    )
+
+
 # %%
 # Reference Function
 # -------------
@@ -180,13 +195,7 @@ def test(
         device=DEVICE,
     )
     # w = torch.nn.functional.rms_norm(w.to(torch.bfloat16), (dhead,))
-    wu, ws, wv = torch.linalg.svd(w.permute(0, 1, 3, 2, 4), full_matrices=False)
-    w = torch.einsum("bnhik,bnhkj->bnhij", wu, wv)
-    w = (
-        w.permute(0, 1, 3, 2, 4)
-        .reshape(batch, seqlen, nheads, dhead)
-        .to(torch.bfloat16)
-    )
+    w = _orthogonalize_w(w)
     u = torch.randn(batch, seqlen, nheads, dstate, dtype=torch.bfloat16, device=DEVICE)
     u = torch.nn.functional.rms_norm(u, [dstate])
     g = torch.cumsum(

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1838,12 +1838,24 @@ class PallasBackend(Backend):
         if isinstance(arg, (SymbolArgument, TensorSizeArg, TensorStrideArg)):
             from .compile_environment import CompileEnvironment
 
+            fallback_device = (
+                "'cpu'"
+                if CompileEnvironment.current().settings.pallas_interpret
+                else "'tpu'"
+            )
             if tensor_host_args:
-                device_expr = f"{tensor_host_args[0]}.device"
-            elif CompileEnvironment.current().settings.pallas_interpret:
-                device_expr = "'cpu'"
+                tensor_devices = ", ".join(
+                    f"{tensor_arg}.device" for tensor_arg in tensor_host_args
+                )
+                if len(tensor_host_args) == 1:
+                    tensor_devices += ","
+                device_expr = (
+                    "next((device for device in "
+                    f"({tensor_devices}) if device.type != 'meta'), "
+                    f"{fallback_device})"
+                )
             else:
-                device_expr = "'tpu'"
+                device_expr = fallback_device
             # Scalars are passed as 1-dim tensors (shape [1]) rather than
             # 0-dim tensors (shape []) because TPU Pallas Mosaic lowering
             # requires rank >= 1 for all block specs.  A 0-dim input causes:
@@ -2049,9 +2061,13 @@ class PallasBackend(Backend):
         ``min(block_size, tensor_dim)`` which equals the full array
         dimension -- always valid per TPU rules.
         """
+        from torch._inductor.runtime.runtime_utils import next_power_of_2
+
         from ..autotuner.config_spec import BlockSizeSpec
         from .ast_extension import ExtendedAST
         from .compile_environment import BlockSizeInfo
+        from .compile_environment import CompileEnvironment
+        from .compile_environment import _symint_free_symbols
         from helion._compiler.compile_environment import _to_sympy
         from helion._compiler.host_function import HostFunction
         from helion._compiler.type_info import SequenceType
@@ -2116,6 +2132,9 @@ class PallasBackend(Backend):
                     required_alignment = self.backend._get_pallas_required_alignment(
                         dim_from_end, tensor.ndim, bitwidth
                     )
+                    required_alignment = self.cap_alignment_to_tensor_dim(
+                        tensor, accessed_dim, required_alignment
+                    )
                     self.maybe_update_required_alignment(bid, required_alignment)
 
             def maybe_update_required_alignment(
@@ -2127,6 +2146,55 @@ class PallasBackend(Backend):
                     self.required_alignments[bid] = max(
                         self.required_alignments[bid], required_alignment
                     )
+
+            def cap_alignment_to_tensor_dim(
+                self,
+                tensor: torch.Tensor,
+                accessed_dim: int,
+                required_alignment: int,
+            ) -> int:
+                from torch._dynamo.source import TensorProperty
+                from torch._dynamo.source import TensorPropertySource
+
+                if accessed_dim < 0 or accessed_dim >= tensor.ndim:
+                    return required_alignment
+                dim = tensor.size(accessed_dim)
+                env = CompileEnvironment.current()
+                if isinstance(dim, int):
+                    dim_size = next_power_of_2(max(dim, 1))
+                    if dim_size < required_alignment and not env.settings.static_shapes:
+                        return required_alignment
+                    return min(required_alignment, dim_size)
+                if not isinstance(dim, torch.SymInt):
+                    return required_alignment
+                dim_expr = env.shape_env.replace(dim._sympy_())
+                specialized = env.specialize_expr(dim_expr)
+                if (
+                    not specialized.free_symbols
+                    and getattr(specialized, "is_integer", None) is True
+                ):
+                    dim_size = next_power_of_2(max(int(specialized), 1))
+                    return min(required_alignment, dim_size)
+                symbols = _symint_free_symbols(dim)
+                sources_by_symbol = [
+                    env.shape_env.var_to_sources.get(symbol, ()) for symbol in symbols
+                ]
+                if not symbols or any(not sources for sources in sources_by_symbol):
+                    return required_alignment
+                if any(
+                    isinstance(source, TensorPropertySource)
+                    and source.prop == TensorProperty.SIZE
+                    for sources in sources_by_symbol
+                    for source in sources
+                ):
+                    return required_alignment
+                if not env._is_static_kernel_shape_expr(dim_expr):
+                    return required_alignment
+                dim_hint = env.size_hint(dim)
+                dim_size = next_power_of_2(max(dim_hint, 1))
+                if dim_size < required_alignment:
+                    env.specialized_vars.update(symbols)
+                return min(required_alignment, dim_size)
 
             def update_requirements_from_fake_tensor_loads(self) -> None:
                 # When tensors are indexed within external lambdas called by the kernel,
@@ -2150,6 +2218,9 @@ class PallasBackend(Backend):
                                         dim_from_end, tensor.ndim, bitwidth
                                     )
                                 )
+                                required_alignment = self.cap_alignment_to_tensor_dim(
+                                    tensor, dim, required_alignment
+                                )
                                 self.maybe_update_required_alignment(
                                     info.block_id, required_alignment
                                 )
@@ -2157,8 +2228,6 @@ class PallasBackend(Backend):
         analyzer = TensorTiledAccessAnalyzer(self)
         for stmt in host_func.body:
             analyzer.visit(stmt)
-
-        from torch._inductor.runtime.runtime_utils import next_power_of_2
 
         if block_sizes is not None and kernel_tensor_sizes is not None:
             for shape in kernel_tensor_sizes:

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -2663,6 +2663,53 @@ def _subscript_block_id(env: CompileEnvironment, sub: object) -> int | None:
     return None
 
 
+def _maybe_specialize_pallas_matmul_alignment_dim(
+    fake: torch.Tensor,
+    tensor_dim: int,
+    subscript: object,
+    env: CompileEnvironment,
+) -> None:
+    """Specialize small dynamic matmul dims that need Pallas one-tile alignment."""
+    if env.backend_name != "pallas":
+        return
+    dim_size = fake.shape[tensor_dim]
+    if not isinstance(dim_size, torch.SymInt):
+        return
+    block_id = _subscript_block_id(env, subscript)
+    if block_id is None:
+        return
+    block_info = env.block_sizes[block_id]
+    block_size = block_info.size
+    if not isinstance(block_size, torch.SymInt):
+        return
+    if env.shape_env.replace(block_size._sympy_()) != env.shape_env.replace(
+        dim_size._sympy_()
+    ):
+        return
+
+    try:
+        block_spec = env.config_spec.block_sizes.block_id_lookup(block_id)
+    except KeyError:
+        return
+
+    dim_hint = env.size_hint(dim_size)
+    if dim_hint <= 0 or dim_hint > block_spec.max_size:
+        return
+
+    from .backend import PallasBackend
+    from .compile_environment import _symint_free_symbols
+
+    backend = env.backend
+    assert isinstance(backend, PallasBackend)
+    dim_from_end = fake.ndim - tensor_dim - 1
+    bitwidth = fake.dtype.itemsize * 8
+    required = backend._get_pallas_required_alignment(dim_from_end, fake.ndim, bitwidth)
+    if dim_hint >= required:
+        return
+
+    env.specialized_vars.update(_symint_free_symbols(dim_size))
+
+
 def _collect_memory_op_facts(device_ir: DeviceIR) -> list[MemoryOpFact]:
     """Walk every device graph once and record per-load/store metadata.
 
@@ -2795,6 +2842,18 @@ def _collect_memory_op_facts(device_ir: DeviceIR) -> list[MemoryOpFact]:
                 )
             )
             memory_op_index += 1
+
+    for node, _fact in records:
+        if operands.get(node) is None:
+            continue
+        fake = _accessed_tensor_fake(node)
+        index_list = node.args[1] if len(node.args) >= 2 else None
+        if fake is None or not isinstance(index_list, (list, tuple)):
+            continue
+        for pos, sub in enumerate(index_list):
+            if isinstance(sub, int) or pos >= fake.ndim:
+                continue
+            _maybe_specialize_pallas_matmul_alignment_dim(fake, pos, sub, env)
 
     return [fact._replace(matmul_operand=operands.get(node)) for node, fact in records]
 

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -10,6 +10,8 @@ import torch
 
 from helion._compiler.ast_extension import expr_from_string
 
+_FULL_LOAD_SELECT_MAX_BYTES = 256 << 10
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -178,19 +180,541 @@ def load_expr(
     patterns = state.fx_node.meta.get("indexing_patterns") or ()
     for pattern in patterns:
         if isinstance(pattern, IndirectGatherPattern):
-            return emit_gather(state, pattern.plan, name)
+            result = emit_gather(state, pattern.plan, name)
+            if (mask_expr := _indirect_gather_mask_expr(state, tensor)) is not None:
+                dtype_str = _pallas_dtype_str(tensor)
+                # Bind the gather once before using it as a layout anchor.
+                result = state.codegen.lift(result, dce=True, prefix="gather")
+                result = numeric_mask_select_expr(
+                    expr_from_string(mask_expr),
+                    result,
+                    expr_from_string(f"jnp.array(0, dtype={dtype_str})"),
+                    tensor.dtype,
+                )
+            return result
 
-    idx_str, none_dims = index_str(state, subscript, tensor)
+    parts, none_dims = index_parts(state, subscript, tensor)
+    parts, post_load_takes = _widen_unaligned_tile_load_indices(
+        state, subscript, tensor, parts
+    )
+    parts, post_load_selects, post_load_rank = _widen_small_aligned_scalar_load_indices(
+        state, subscript, tensor, parts
+    )
+    idx_str = ", ".join(parts)
     mask_expr = _load_mask_expr(state, subscript, tensor)
+    result = expr_from_string(f"{name}[{idx_str}]")
+    result = _pad_clamped_load_expr(state, subscript, tensor, parts, result)
+    promoted_scalar_dtype = _widened_scalar_load_promotion_dtype(
+        state, tensor, post_load_selects, post_load_rank
+    )
+    result = _select_widened_scalar_load_indices(
+        result, post_load_selects, post_load_rank, promoted_scalar_dtype
+    )
+    result = _select_unaligned_tile_load_indices(result, post_load_takes)
     if mask_expr is not None:
-        result = expr_from_string(f"{name}[{idx_str}] * ({mask_expr})")
-    else:
-        result = expr_from_string(f"{name}[{idx_str}]")
+        result = expr_from_string(f"{{result}} * ({mask_expr})", result=result)
     for dim in none_dims:
         result = expr_from_string(
             f"jnp.expand_dims({{result}}, axis={dim})", result=result
         )
     return result
+
+
+def _widen_unaligned_tile_load_indices(
+    state: CodegenState,
+    subscript: list[object],
+    tensor: torch.Tensor,
+    index_parts: list[str],
+) -> tuple[list[str], list[tuple[int, str, str, torch.dtype, int]]]:
+    """Load small unaligned tile dims as full refs, then select lanes."""
+    if _tensor_routed_to_dma_scratch(state, tensor):
+        return index_parts, []
+
+    from helion._compiler.device_function import PallasMemorySpace
+
+    if (
+        state.device_function.pallas_memory_space.get(id(tensor))
+        == PallasMemorySpace.SMEM
+    ):
+        return index_parts, []
+
+    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
+    from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
+    from helion._compiler.pallas.plan_tiling import TilePattern
+
+    adjusted = list(index_parts)
+    takes: list[tuple[int, str]] = []
+    value_dim = 0
+    tensor_dim = 0
+    index_part_idx = 0
+
+    for idx, pattern in zip(
+        subscript, _get_indexing_patterns(state, tensor), strict=True
+    ):
+        if idx is None:
+            continue
+
+        index_part = adjusted[index_part_idx]
+        should_widen_unaligned = (
+            not takes
+            and isinstance(
+                pattern,
+                (TilePattern, TileIndexWithOffsetPattern, TileBeginWithOffsetPattern),
+            )
+            and _should_select_unaligned_tile_axis_from_full_load(
+                state, tensor, tensor_dim, pattern, index_part
+            )
+        )
+        if should_widen_unaligned:
+            adjusted[index_part_idx] = ":"
+            takes.append((value_dim, _tile_lane_index_expr(state, pattern)))
+
+        if _index_part_produces_value_dim(adjusted[index_part_idx]):
+            value_dim += 1
+        tensor_dim += 1
+        index_part_idx += 1
+
+    dtype_str = _pallas_dtype_str(tensor)
+    return adjusted, [
+        (axis, index, dtype_str, tensor.dtype, value_dim) for axis, index in takes
+    ]
+
+
+def _should_select_unaligned_tile_axis_from_full_load(
+    state: CodegenState,
+    tensor: torch.Tensor,
+    tensor_dim: int,
+    pattern: object,
+    index_part: str,
+) -> bool:
+    """True when a small full-ref load can avoid an unaligned ``pl.ds``.
+
+    Mosaic only needs extra proof for the last two VMEM dimensions.  When a
+    dynamic ``pl.ds`` offset on such a dimension is not provably aligned, a
+    small full-tensor load plus a register select is safer than asserting an
+    alignment Helion cannot prove.
+    """
+
+    if not index_part.startswith("pl.ds("):
+        return False
+
+    from helion._compiler.backend import PallasBackend
+    from helion._compiler.compile_environment import CompileEnvironment
+    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
+    from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
+    from helion._compiler.pallas.plan_tiling import TilePattern
+
+    assert isinstance(
+        pattern, (TilePattern, TileIndexWithOffsetPattern, TileBeginWithOffsetPattern)
+    )
+    dim_size = tensor.shape[tensor_dim]
+    if not isinstance(dim_size, int):
+        return False
+
+    env = CompileEnvironment.current()
+    block_size = env.block_sizes[pattern.block_id].from_config(state.config)
+    if not isinstance(block_size, int) or block_size <= 0:
+        return False
+
+    backend = env.backend
+    assert isinstance(backend, PallasBackend)
+    dim_from_end = tensor.ndim - tensor_dim - 1
+    bitwidth = tensor.dtype.itemsize * 8
+    required = backend._get_pallas_required_alignment(
+        dim_from_end, tensor.ndim, bitwidth
+    )
+    if required <= 1:
+        return False
+    local_owner = _bounded_local_owner_block_id(
+        state, pattern.block_id, tensor, tensor_dim
+    )
+    alignment = (
+        state.device_function.resolved_block_size(pattern.block_id)
+        if local_owner is not None
+        else _loop_offset_alignment(pattern.block_id, state)
+    )
+    if (
+        isinstance(pattern, (TileIndexWithOffsetPattern, TileBeginWithOffsetPattern))
+        and pattern.offset != 0
+    ):
+        alignment = None
+    if alignment is not None and alignment % required == 0:
+        return False
+
+    expanded_elements = _full_load_selection_budget_elements(
+        state, dim_size, block_size
+    )
+    return (
+        expanded_elements is not None
+        and expanded_elements * tensor.dtype.itemsize <= _FULL_LOAD_SELECT_MAX_BYTES
+    )
+
+
+def _full_load_selection_budget_elements(
+    state: CodegenState, dim_size: int, block_size: int
+) -> int | None:
+    """Return the widened load element budget for full-ref selection.
+
+    The fallback replaces one tile axis in the load result with the full tensor
+    dimension.  Budget that widened value as ``output_elements / block_size *
+    dim_size`` instead of multiplying by ``dim_size`` again.
+    """
+
+    if block_size <= 0:
+        return None
+
+    from helion._compiler.compile_environment import CompileEnvironment
+
+    assert state.fx_node is not None
+    output_val = state.fx_node.meta.get("val")
+    if not isinstance(output_val, torch.Tensor):
+        return None
+
+    env = CompileEnvironment.current()
+    elements = 1
+    for size in output_val.size():
+        if not isinstance(size, int):
+            block_id = env.resolve_block_id(size)
+            if block_id is None:
+                return None
+            resolved = env.block_sizes[block_id].from_config(state.config)
+            if not isinstance(resolved, int):
+                return None
+            size = resolved
+        elements *= size
+    if elements % block_size != 0:
+        return None
+    return elements // block_size * dim_size
+
+
+def _tile_lane_index_expr(state: CodegenState, pattern: object) -> str:
+    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
+    from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
+    from helion._compiler.pallas.plan_tiling import TilePattern
+
+    assert isinstance(
+        pattern, (TilePattern, TileIndexWithOffsetPattern, TileBeginWithOffsetPattern)
+    )
+    index = state.codegen.index_var(pattern.block_id)
+    if (
+        isinstance(pattern, (TileIndexWithOffsetPattern, TileBeginWithOffsetPattern))
+        and pattern.offset != 0
+    ):
+        offset = state.device_function.literal_expr(pattern.offset)
+        return f"{index} + {offset}"
+    return index
+
+
+def _select_unaligned_tile_load_indices(
+    value: ast.AST, takes: list[tuple[int, str, str, torch.dtype, int]]
+) -> ast.AST:
+    """Select requested tiles from widened full-ref loads without bool relayout."""
+    result = value
+    for axis, index_expr, dtype_str, dtype, rank in takes:
+        if axis == 0:
+            mask_expr = (
+                f"(({index_expr})[..., None] == "
+                f"jnp.arange({{result}}.shape[0], dtype=({index_expr}).dtype))"
+                f".astype({dtype_str})"
+            )
+            for _ in range(rank - 1):
+                mask_expr = f"jnp.expand_dims({mask_expr}, axis=-1)"
+            selected = numeric_mask_select_expr(
+                expr_from_string(mask_expr, result=result),
+                result,
+                expr_from_string(f"jnp.array(0, dtype={dtype_str})"),
+                dtype,
+            )
+            result = expr_from_string(
+                (
+                    "jnp.sum({selected}, axis=jnp.ndim("
+                    f"{index_expr})).astype({dtype_str})"
+                ),
+                selected=selected,
+            )
+            continue
+        mask_expr = (
+            f"(({index_expr})[:, None] == "
+            f"jnp.arange({{result}}.shape[{axis}], dtype=({index_expr}).dtype))"
+            f".astype({dtype_str})"
+        )
+        for _ in range(axis):
+            mask_expr = f"jnp.expand_dims({mask_expr}, axis=0)"
+        for _ in range(rank - axis - 1):
+            mask_expr = f"jnp.expand_dims({mask_expr}, axis=-1)"
+        true_value = expr_from_string(
+            f"jnp.expand_dims({{result}}, axis={axis})",
+            result=result,
+        )
+        selected = numeric_mask_select_expr(
+            expr_from_string(mask_expr, result=result),
+            true_value,
+            expr_from_string(f"jnp.array(0, dtype={dtype_str})"),
+            dtype,
+            true_value,
+        )
+        result = expr_from_string(
+            f"jnp.sum({{selected}}, axis={axis + 1}).astype({dtype_str})",
+            selected=selected,
+        )
+    return result
+
+
+def _pallas_dtype_str(tensor: torch.Tensor) -> str:
+    from helion._compiler.compile_environment import CompileEnvironment
+
+    return CompileEnvironment.current().backend.dtype_str(tensor.dtype)
+
+
+def _indirect_gather_mask_expr(state: CodegenState, tensor: torch.Tensor) -> str | None:
+    """Mask tensor-indexed gather outputs in their result layout."""
+    from helion._compiler.compile_environment import CompileEnvironment
+
+    assert state.fx_node is not None
+    output_val = state.fx_node.meta.get("val")
+    if not isinstance(output_val, torch.Tensor):
+        return None
+
+    env = CompileEnvironment.current()
+    output_sizes = [*output_val.size()]
+    dtype_str = _pallas_dtype_str(tensor)
+    mask_exprs: list[str] = []
+    for dim, size in enumerate(output_sizes):
+        block_id = env.resolve_block_id(size)
+        if block_id is None or (mask_var := state.codegen.mask_var(block_id)) is None:
+            continue
+        if env.is_jagged_tile(block_id):
+            mask_shape = env.jagged_tile_mask_shapes[block_id]
+            expand = state.tile_strategy.jagged_tile_expand_str(
+                mask_shape, output_sizes
+            )
+        else:
+            expand = state.tile_strategy.expand_str(output_sizes, dim)
+        expr = f"({mask_var}.astype({dtype_str}){expand})"
+        if expr not in mask_exprs:
+            mask_exprs.append(expr)
+
+    if not mask_exprs:
+        return None
+    return "*".join(mask_exprs)
+
+
+def _index_part_produces_value_dim(index_part: str) -> bool:
+    return index_part == ":" or index_part.startswith(("pl.ds(", "slice("))
+
+
+def _widen_small_aligned_scalar_load_indices(
+    state: CodegenState,
+    subscript: list[object],
+    tensor: torch.Tensor,
+    index_parts: list[str],
+) -> tuple[list[str], list[tuple[int, str, int]], int]:
+    """Load small scalar-indexed VMEM dims as full dims, then select in registers."""
+    value_rank = sum(
+        _index_part_produces_value_dim(index_part) for index_part in index_parts
+    )
+    if _tensor_routed_to_dma_scratch(state, tensor):
+        return index_parts, [], value_rank
+
+    from helion._compiler.device_function import PallasMemorySpace
+
+    if (
+        state.device_function.pallas_memory_space.get(id(tensor))
+        == PallasMemorySpace.SMEM
+    ):
+        return index_parts, [], value_rank
+
+    from helion._compiler.backend import PallasBackend
+    from helion._compiler.compile_environment import CompileEnvironment
+    from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
+    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
+
+    backend = CompileEnvironment.current().backend
+    assert isinstance(backend, PallasBackend)
+    patterns = _get_indexing_patterns(state, tensor)
+    adjusted = list(index_parts)
+    widened_selects: list[tuple[int, str, int]] = []
+    value_dim = 0
+    tensor_dim = 0
+    index_part_idx = 0
+
+    for idx, pattern in zip(subscript, patterns, strict=True):
+        if idx is None:
+            continue
+
+        index_part = adjusted[index_part_idx]
+        dim_size = tensor.shape[tensor_dim]
+        is_scalar = not _index_part_produces_value_dim(index_part)
+        can_widen = False
+        if (
+            is_scalar
+            and isinstance(dim_size, int)
+            and dim_size > 0
+            and isinstance(pattern, (ArbitraryIndexPattern, TileBeginWithOffsetPattern))
+        ):
+            dim_from_end = tensor.ndim - tensor_dim - 1
+            bitwidth = tensor.dtype.itemsize * 8
+            required_alignment = backend._get_pallas_required_alignment(
+                dim_from_end, tensor.ndim, bitwidth
+            )
+            can_widen = required_alignment > 1 and dim_size <= required_alignment
+            if can_widen:
+                index_part = _normalize_static_scalar_index(index_part, dim_size)
+                can_widen = index_part is not None
+
+        if can_widen:
+            adjusted[index_part_idx] = ":"
+            assert index_part is not None
+            widened_selects.append((value_dim, index_part, dim_size))
+            value_dim += 1
+        elif index_part is not None and _index_part_produces_value_dim(index_part):
+            value_dim += 1
+
+        tensor_dim += 1
+        index_part_idx += 1
+
+    return adjusted, widened_selects, value_dim
+
+
+def _normalize_static_scalar_index(index_part: str, dim_size: int) -> str | None:
+    try:
+        index = int(index_part)
+    except ValueError:
+        return index_part
+    if index < 0:
+        index += dim_size
+    if 0 <= index < dim_size:
+        return str(index)
+    return None
+
+
+def _select_widened_scalar_load_indices(
+    value: ast.AST,
+    widened_selects: list[tuple[int, str, int]],
+    rank: int,
+    scalar_result_dtype: str | None = None,
+) -> ast.AST:
+    result = value
+    for axis, index_expr, dim_size in sorted(widened_selects, reverse=True):
+        if rank == 1 and scalar_result_dtype is not None:
+            result = expr_from_string(
+                f"{{result}}.astype({scalar_result_dtype})",
+                result=result,
+            )
+        lane_index = [":"] * rank
+        lane_index[axis] = "0"
+        selected = expr_from_string(
+            f"{{result}}[{', '.join(lane_index)}]",
+            result=result,
+        )
+        for lane in range(1, dim_size):
+            lane_index[axis] = str(lane)
+            lane_value = expr_from_string(
+                f"{{result}}[{', '.join(lane_index)}]",
+                result=result,
+            )
+            selected = expr_from_string(
+                f"jnp.where(({index_expr}) == {lane}, {{lane_value}}, {{selected}})",
+                lane_value=lane_value,
+                selected=selected,
+            )
+        result = selected
+        rank -= 1
+    return result
+
+
+def _widened_scalar_load_promotion_dtype(
+    state: CodegenState,
+    tensor: torch.Tensor,
+    widened_selects: list[tuple[int, str, int]],
+    rank: int,
+) -> str | None:
+    """Return fp32 when a widened sub-32-bit scalar load feeds only fp32 casts."""
+    if tensor.dtype.itemsize >= 4 or rank != len(widened_selects):
+        return None
+    if not _load_feeds_only_immediate_fp32_converts(state):
+        return None
+    from helion._compiler.compile_environment import CompileEnvironment
+
+    return CompileEnvironment.current().backend.dtype_str(torch.float32)
+
+
+def _load_feeds_only_immediate_fp32_converts(state: CodegenState) -> bool:
+    node = state.fx_node
+    if node is None:
+        return False
+    users = list(node.users)
+    if not users:
+        return False
+    convert = torch.ops.prims.convert_element_type.default
+    for user in users:
+        if (
+            user.op != "call_function"
+            or user.target is not convert
+            or len(user.args) < 2
+            or user.args[0] is not node
+            or user.args[1] is not torch.float32
+        ):
+            return False
+    return True
+
+
+def _pad_clamped_load_expr(
+    state: CodegenState,
+    subscript: list[object],
+    tensor: torch.Tensor,
+    index_parts: list[str],
+    value: ast.AST,
+) -> ast.AST:
+    """Pad BlockSpec-clamped Pallas loads back to their logical tile shape."""
+    from helion._compiler.compile_environment import CompileEnvironment
+    from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
+    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
+    from helion._compiler.pallas.plan_tiling import TilePattern
+
+    if _tensor_routed_to_dma_scratch(state, tensor):
+        return value
+
+    env = CompileEnvironment.current()
+    indexing_patterns = _get_indexing_patterns(state, tensor)
+    pads: list[tuple[int, int]] = []
+    needs_pad = False
+    tensor_dim = 0
+    index_part_idx = 0
+
+    for idx, pattern in zip(subscript, indexing_patterns, strict=True):
+        if idx is None:
+            continue
+
+        index_part = index_parts[index_part_idx]
+        index_part_idx += 1
+
+        if isinstance(pattern, TilePattern) and index_part == ":":
+            block_size = env.block_sizes[pattern.block_id].from_config(state.config)
+            dim_size = tensor.shape[tensor_dim]
+            if (
+                isinstance(block_size, int)
+                and isinstance(dim_size, int)
+                and 1 < dim_size < block_size
+            ):
+                pads.append((0, block_size - dim_size))
+                needs_pad = True
+            else:
+                pads.append((0, 0))
+        else:
+            produces_value_dim = index_part == ":" or index_part.startswith("pl.ds(")
+            produces_value_dim = produces_value_dim or not isinstance(
+                pattern, (ArbitraryIndexPattern, TileBeginWithOffsetPattern)
+            )
+            if produces_value_dim:
+                pads.append((0, 0))
+
+        tensor_dim += 1
+
+    if not needs_pad:
+        return value
+
+    return expr_from_string(f"jnp.pad({{value}}, {pads!r})", value=value)
 
 
 def _load_mask_expr(
@@ -314,13 +838,10 @@ def _find_dma_scratch_loop(
     return next(_iter_dma_scratch_loops(state, name), (None, name))
 
 
-def _tensor_routed_to_fori_scratch(state: CodegenState, tensor: torch.Tensor) -> bool:
-    """True if ``tensor``'s store destination ref is a fori_loop DMA scratch."""
-    from helion._compiler.tile_strategy import ForiLoopState
-
+def _tensor_routed_to_dma_scratch(state: CodegenState, tensor: torch.Tensor) -> bool:
     name = state.codegen.device_function.tensor_arg(tensor).name
     loop, _ref = _find_dma_scratch_loop(state, name)
-    return isinstance(loop, ForiLoopState)
+    return loop is not None
 
 
 def sliced_value_for_store(
@@ -341,9 +862,9 @@ def sliced_value_for_store(
     generated Pallas index.  Dimensions indexed via ``pl.ds()`` are padded
     instead of clamped, so they must keep their full block-size value.
 
-    fori_loop-scratch stores are exempt: their destination is a block-sized
+    Pipeline/DMA scratch stores are exempt: their destination is a block-sized
     VMEM scratch (not a clamped ref), so the value stays block-shaped and the
-    writeback DMA clamps the extent instead (see ``_build_dma_slices``).
+    writeback path clamps the HBM extent instead.
     """
     from helion._compiler.compile_environment import CompileEnvironment
     from helion._compiler.pallas.plan_tiling import TilePattern
@@ -353,7 +874,7 @@ def sliced_value_for_store(
     if patterns is None:
         return value
 
-    if _tensor_routed_to_fori_scratch(state, tensor):
+    if _tensor_routed_to_dma_scratch(state, tensor):
         return value
 
     env = CompileEnvironment.current()

--- a/helion/_compiler/pallas/gather.py
+++ b/helion/_compiler/pallas/gather.py
@@ -165,6 +165,16 @@ def emit_gather(
     from . import codegen as pallas_codegen
 
     parts, _ = pallas_codegen.index_parts(state, subscript, tensor)
+    parts, widened_selects, table_rank = (
+        pallas_codegen._widen_small_aligned_scalar_load_indices(
+            state, list(subscript), tensor, parts
+        )
+    )
+    table_indirect_axis = _table_indirect_axis(subscript, parts, plan.indirect_pos)
+    gather_rank = table_rank + plan.index_ndim - 1
+    widened_selects = _remap_widened_selects_after_gather(
+        widened_selects, table_indirect_axis, plan.index_ndim
+    )
     base_index = ", ".join(parts)
     table_expr = f"{name}[{base_index}]"
 
@@ -172,12 +182,17 @@ def emit_gather(
         mask_expr = (
             f"jax.nn.one_hot({idx_name}[...], {name}.shape[0], dtype={plan.jnp_dtype})"
         )
-        for _ in range(plan.table_ndim - 1):
+        for _ in range(table_rank - 1):
             mask_expr = f"jnp.expand_dims({mask_expr}, axis=-1)"
         result = expr_from_string(
             f"jnp.sum({table_expr} * {mask_expr}, "
             f"axis=jnp.ndim({idx_name}[...])"
             f").astype({plan.jnp_dtype})"
+        )
+        if widened_selects:
+            result = state.codegen.lift(result, dce=True, prefix="gather")
+        result = pallas_codegen._select_widened_scalar_load_indices(
+            result, widened_selects, gather_rank
         )
         for dim in plan.none_dims:
             result = expr_from_string(
@@ -194,28 +209,70 @@ def emit_gather(
         table_dot_expr = table_expr
         precision_arg = ""
 
-    p = plan.indirect_pos
     result = expr_from_string(
         "jax.lax.dot_general("
-        f"jax.nn.one_hot({idx_name}[...], {name}.shape[{p}], dtype={oh_dtype}), "
+        f"jax.nn.one_hot({idx_name}[...], "
+        f"{name}.shape[{plan.indirect_pos}], dtype={oh_dtype}), "
         f"{table_dot_expr}, "
-        f"(((jnp.ndim({idx_name}[...]),), ({p},)), ((), ())), "
+        f"(((jnp.ndim({idx_name}[...]),), ({table_indirect_axis},)), ((), ())), "
         "preferred_element_type=jnp.float32, "
         f"{precision_arg}"
         f").astype({plan.jnp_dtype})"
     )
-    if p > 0:
+    if table_indirect_axis > 0:
         n = plan.index_ndim
-        src = tuple(range(n, n + p))
-        dst = tuple(range(p))
+        src = tuple(range(n, n + table_indirect_axis))
+        dst = tuple(range(table_indirect_axis))
         result = expr_from_string(
             f"jnp.moveaxis({{result}}, {src}, {dst})", result=result
         )
+    if widened_selects:
+        result = state.codegen.lift(result, dce=True, prefix="gather")
+    result = pallas_codegen._select_widened_scalar_load_indices(
+        result, widened_selects, gather_rank
+    )
     for dim in plan.none_dims:
         result = expr_from_string(
             f"jnp.expand_dims({{result}}, axis={dim})", result=result
         )
     return result
+
+
+def _table_indirect_axis(
+    subscript: list[object] | tuple[object, ...],
+    parts: list[str],
+    indirect_pos: int,
+) -> int:
+    from . import codegen as pallas_codegen
+
+    axis = 0
+    part_idx = 0
+    for pos, idx in enumerate(subscript):
+        if idx is None:
+            continue
+        part = parts[part_idx]
+        if pos == indirect_pos:
+            return axis
+        if pallas_codegen._index_part_produces_value_dim(part):
+            axis += 1
+        part_idx += 1
+    raise AssertionError(f"indirect position {indirect_pos} not found in subscript")
+
+
+def _remap_widened_selects_after_gather(
+    widened_selects: list[tuple[int, str, int]],
+    table_indirect_axis: int,
+    index_ndim: int,
+) -> list[tuple[int, str, int]]:
+    remapped: list[tuple[int, str, int]] = []
+    for axis, index_expr, dim_size in widened_selects:
+        assert axis != table_indirect_axis
+        if axis < table_indirect_axis:
+            remapped_axis = axis
+        else:
+            remapped_axis = axis + index_ndim - 1
+        remapped.append((remapped_axis, index_expr, dim_size))
+    return remapped
 
 
 def _scatter_one_hot_name(

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -129,10 +129,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             args[0] @ args[1],
         )
 
-    @xfailIfPallas(
-        "Pallas TPU clamps the N block to the lane width (128) which does"
-        " not match the test's N=96 bias dimension"
-    )
+    @xfailIfPallasInterpret("dynamic epilogue bias slices need real TPU Pallas")
     def test_matmul_bias_epilogue_wrapper(self):
         from typing import Any
         from typing import Callable
@@ -2514,7 +2511,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             indexing="block_ptr",
         )
 
-    @xfailIfPallasTpu("operation not supported on TPU")
     def test_gdn_fwd_h(self):
         """Test gated delta net forward h kernel."""
         batch = 2
@@ -2537,13 +2533,8 @@ class TestExamples(RefEagerTestBase, TestCase):
             dtype=torch.float32,
             device=DEVICE,
         )
-        wu, ws, wv = torch.linalg.svd(w.permute(0, 1, 3, 2, 4), full_matrices=False)
-        w = torch.einsum("bnhik,bnhkj->bnhij", wu, wv)
-        w = (
-            w.permute(0, 1, 3, 2, 4)
-            .reshape(batch, seqlen, nheads, dhead)
-            .to(torch.bfloat16)
-        )
+        mod = import_path(EXAMPLES_DIR / "gdn_fwd_h.py")
+        w = mod._orthogonalize_w(w)
         u = torch.randn(
             batch, seqlen, nheads, dstate, dtype=torch.bfloat16, device=DEVICE
         )
@@ -2557,8 +2548,6 @@ class TestExamples(RefEagerTestBase, TestCase):
 
         args = (k, w, u, g, chunk_size)
 
-        # Import and use the reference implementation
-        mod = import_path(EXAMPLES_DIR / "gdn_fwd_h.py")
         expected = mod.ref_gdn_fwd_h(*args)
 
         check_example(
@@ -2613,9 +2602,6 @@ class TestExamples(RefEagerTestBase, TestCase):
         expected = torch.nn.functional.scaled_dot_product_attention(q, k, v)
         torch.testing.assert_close(out, expected, atol=1e-1, rtol=1e-1)
 
-    @xfailIfPallasTpu(
-        "dA_cumsum has mixed scalar+slice access (VMEM), but Mosaic requires 32-bit for VMEM scalar extracts"
-    )
     def test_mamba2_chunk_state(self):
         batch, nheads, ngroups, seqlen, chunk_size, headdim, dstate = (
             2,

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -2845,6 +2845,57 @@ class TestPallas(TestCase):
         expected = x + x[:, -1:]
         torch.testing.assert_close(result, expected)
 
+    def _check_small_middle_scalar_load_in_loop(self, loop_type: str) -> None:
+        """Small scalar-indexed middle dims load aligned and select in registers."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def middle_scalar_load(x: torch.Tensor) -> torch.Tensor:
+            batch, seqlen, nheads, _dhead = x.shape
+            out = torch.empty(
+                [batch, nheads, seqlen, _dhead], dtype=x.dtype, device=x.device
+            )
+            for tile_b, tile_h in hl.tile([batch, nheads], block_size=[1, 1]):
+                i_b = tile_b.id
+                i_h = tile_h.id
+                for tile_s in hl.tile(seqlen, block_size=64):
+                    out[i_b, i_h, tile_s, :] = x[i_b, tile_s, i_h, :] + 1.0
+            return out
+
+        x = torch.randn(2, 128, 4, 16, device=DEVICE, dtype=torch.bfloat16)
+        _code, result = code_and_output(
+            middle_scalar_load,
+            (x,),
+            pallas_loop_type=loop_type,
+        )
+        torch.testing.assert_close(result, (x + 1.0).permute(0, 2, 1, 3))
+
+    def test_small_middle_scalar_load_in_emit_pipeline(self) -> None:
+        self._check_small_middle_scalar_load_in_loop("emit_pipeline")
+
+    def test_small_middle_scalar_load_in_fori_loop(self) -> None:
+        self._check_small_middle_scalar_load_in_loop("fori_loop")
+
+    def test_small_middle_negative_scalar_load(self) -> None:
+        """Static negative scalar indices preserve Python indexing semantics."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def negative_scalar_load(x: torch.Tensor) -> torch.Tensor:
+            batch, seqlen, _nheads, dhead = x.shape
+            out = torch.empty([batch, seqlen, dhead], dtype=x.dtype, device=x.device)
+            for tile_b in hl.tile(batch, block_size=1):
+                i_b = tile_b.id
+                for tile_s in hl.tile(seqlen, block_size=64):
+                    out[i_b, tile_s, :] = x[i_b, tile_s, -1, :]
+            return out
+
+        x = torch.randn(2, 128, 4, 16, device=DEVICE, dtype=torch.bfloat16)
+        _code, result = code_and_output(
+            negative_scalar_load,
+            (x,),
+            pallas_loop_type="emit_pipeline",
+        )
+        torch.testing.assert_close(result, x[:, :, -1, :])
+
     @xfailIfPallasTpu(
         "Mixed scalar write + slice needs tensor duplication into SMEM and VMEM"
     )
@@ -3202,8 +3253,9 @@ class TestPallas(TestCase):
         self.assertIn("jax.lax.fori_loop", code)
         self.assertNotIn("pltpu.make_async_copy", code)
         self.assertIn("pl.ds(", code)
-        # Block size 64 < 128 alignment — hint should NOT be applied
-        self.assertNotIn("pl.multiple_of(", code)
+        # The last dim is a one-tile dense slice, so its dynamic fori offset is
+        # provably zero and can carry the 128-element Mosaic alignment hint.
+        self.assertIn("pl.ds(pl.multiple_of(offset_1, 128), _BLOCK_SIZE_1)", code)
         torch.testing.assert_close(result, args[0] + args[1])
 
     def test_fori_loop_no_dma_multidim_unaligned(self) -> None:
@@ -4241,8 +4293,8 @@ class TestPallas(TestCase):
 
     def test_transpose_dot_defers_pallas_load_mask(self) -> None:
         """A masked load consumed via ``transpose`` -> dot defers its mask to the
-        consumer layout: a raw load + a post-transpose ``jnp.where``, not an eager
-        multiplicative load mask.
+        consumer layout: a raw load + a post-transpose mask, not an eager load
+        mask.
 
         The deferral is an FX-graph pass, so it is independent of the pallas loop
         type -- asserted here for both ``fori_loop`` and ``compact_worklist`` on a
@@ -4385,7 +4437,6 @@ class TestPallas(TestCase):
         ref[s:e] = torch.bmm(y[s:e].transpose(0, 1), w).transpose(0, 1) + y[s:e]
         torch.testing.assert_close(out.cpu(), ref.cpu(), rtol=2e-2, atol=2e-2)
 
-    @xfailIfPallasTpu("opposite-direction transpose needs padded-load widening")
     def test_opposite_direction_transpose_keeps_eager_mask(self) -> None:
         """Mirror image of the deferral win.  Here the masked Q axis is already in
         the last-two (sublane) dims at the load and the transpose moves it to a
@@ -4416,9 +4467,10 @@ class TestPallas(TestCase):
             block_sizes=[16],
             pallas_loop_type="fori_loop",
         )
-        # Masked axis is sublane at the load -> eager mask is cheap; deferring
-        # would move it to the major axis, so the gate keeps the eager load mask.
-        self.assertRegex(code, r"= y\[[^\n]*\] \* mask_\d+\.astype")
+        # Masked axis is sublane at the load -> eager mask is cheap; even when
+        # the load is widened for Mosaic alignment, the mask stays on yj before
+        # the transpose/bmm path can move that axis to a major dimension.
+        self.assertRegex(code, r"yj = [^\n]*\* mask_\d+\.astype")
 
         s, e = 0, 10
         ref = torch.bmm(y[:, s:e, :].transpose(0, 1), y[:, s:e, :].permute(1, 2, 0))

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -297,7 +297,6 @@ class TestViews(RefEagerTestBase, TestCase):
         expected = torch.matmul(x, y)
         torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
 
-    @xfailIfPallas("Pallas pads tiles before reshape until tiled loads land")
     def test_reshape_sum(self):
         @helion.kernel(static_shapes=True)
         def fn(x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Stacked PRs:
 * #2936
 * #2935
 * #2934
 * #2933
 * #2932
 * #2931
 * #2930
 * #2929
 * #2928
 * #2927
 * #2926
 * #2925
 * #2924
 * __->__#2923
 * #2922
 * #2921
 * #2920
 * #2919
 * #2918
 * #2917


--- --- ---

### Support Pallas padded loads and scalar widening


This enables examples including `gdn_fwd_h`, `mamba2_chunk_state`, the Pallas matmul bias epilogue, and Pallas `reshape_sum`. Pallas load code now widens small or alignment-hostile scalar and tile loads to a legal full-ref load, selects the requested lanes afterward, pads clamped loads back to logical tile shape, and specializes small symbolic matmul dimensions when needed.