### PR TITLE
Track Pallas pipeline access block metadata

### DIFF
--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -993,10 +993,14 @@ def index_parts(
     # their outer BlockSpec and fall through to pl.ds().
     tensor_name = state.codegen.device_function.tensor_arg(tensor).name
     in_pipeline = False
-    pipeline_block_ids: set[int] = set()
+    dma_block_ids: set[int] = set()
     for loop, _ref in _iter_dma_scratch_loops(state, tensor_name):
         in_pipeline = True
-        pipeline_block_ids.update(loop.block_ids)
+        block_id_mapping = getattr(loop, "_tensor_to_dma_block_ids", None)
+        if block_id_mapping and tensor_name in block_id_mapping:
+            dma_block_ids.update(block_id_mapping[tensor_name])
+        else:
+            dma_block_ids.update(loop.block_ids)
 
     # Use pre-computed indexing patterns from plan_tiling analysis
     indexing_patterns = _get_indexing_patterns(state, tensor)
@@ -1015,7 +1019,7 @@ def index_parts(
 
         # Generate code based on the pattern type
         index_code = _generated_index_code(
-            pattern, idx, state, tensor, i, tensor_dim, in_pipeline, pipeline_block_ids
+            pattern, idx, state, tensor, i, tensor_dim, in_pipeline, dma_block_ids
         )
         parts.append(index_code)
 
@@ -1057,7 +1061,7 @@ def _generated_index_code(
     subscript_index: int,
     tensor_dim: int,
     in_pipeline: bool,
-    pipeline_block_ids: set[int],
+    dma_block_ids: set[int],
 ) -> str:
     """Generate index code based on the indexing pattern."""
     from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
@@ -1070,17 +1074,17 @@ def _generated_index_code(
 
     if isinstance(pattern, TilePattern):
         return _tile_pattern_code(
-            pattern, idx, state, tensor, tensor_dim, in_pipeline, pipeline_block_ids
+            pattern, idx, state, tensor, tensor_dim, in_pipeline, dma_block_ids
         )
 
     if isinstance(pattern, TileIndexWithOffsetPattern):
         return _tile_index_with_offset_pattern_code(
-            pattern, state, tensor, tensor_dim, in_pipeline, pipeline_block_ids
+            pattern, state, tensor, tensor_dim, in_pipeline, dma_block_ids
         )
 
     if isinstance(pattern, TileBeginWithOffsetPattern):
         return _tile_begin_with_offset_pattern_code(
-            pattern, state, subscript_index, tensor_dim, in_pipeline, pipeline_block_ids
+            pattern, state, subscript_index, tensor_dim, in_pipeline, dma_block_ids
         )
 
     if isinstance(pattern, ArbitrarySlicePattern):
@@ -1117,7 +1121,7 @@ def _tile_pattern_code(
     tensor: torch.Tensor,
     tensor_dim: int,
     in_pipeline: bool,
-    pipeline_block_ids: set[int],
+    dma_block_ids: set[int],
 ) -> str:
     from helion._compiler.pallas.plan_tiling import TilePattern
     from helion._compiler.tile_strategy import DeviceLoopState
@@ -1134,7 +1138,7 @@ def _tile_pattern_code(
     # TODO(yifeixu): the long-term fix is making ``can_tile`` per-loop-scope
     # instead of per-tensor-dim so the planner doesn't mark this dim
     # untileable in pipeline mode in the first place.
-    if in_pipeline:
+    if in_pipeline and block_id in dma_block_ids:
         return ":"
 
     can_tile = _can_tile_dimension(state, tensor_dim)
@@ -1159,7 +1163,7 @@ def _tile_index_with_offset_pattern_code(
     tensor: torch.Tensor,
     tensor_dim: int,
     in_pipeline: bool,
-    pipeline_block_ids: set[int],
+    dma_block_ids: set[int],
 ) -> str:
     from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
 
@@ -1176,7 +1180,7 @@ def _tile_begin_with_offset_pattern_code(
     subscript_index: int,
     tensor_dim: int,
     in_pipeline: bool,
-    pipeline_block_ids: set[int],
+    dma_block_ids: set[int],
 ) -> str:
     from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
     from helion._compiler.tile_strategy import DeviceLoopState
@@ -1186,7 +1190,7 @@ def _tile_begin_with_offset_pattern_code(
     block_id = pattern.block_id
     offset_str = state.device_function.literal_expr(pattern.offset)
 
-    if in_pipeline and block_id in pipeline_block_ids:
+    if in_pipeline and block_id in dma_block_ids:
         return offset_str
 
     can_tile = _can_tile_dimension(state, tensor_dim)

--- a/helion/_compiler/pallas/ordered_carry.py
+++ b/helion/_compiler/pallas/ordered_carry.py
@@ -18,6 +18,8 @@ import dataclasses
 from typing import TYPE_CHECKING
 from typing import NamedTuple
 
+from helion._compiler.tile_strategy import EmitPipelineLoopState
+
 if TYPE_CHECKING:
     import torch
 
@@ -213,12 +215,51 @@ def _carry_store_plan(
     )
 
 
+def _dma_ref_block_ids_for_name(state: CodegenState, name: str) -> set[int]:
+    """Block IDs already made local by the DMA/Buffered ref named ``name``."""
+    block_ids: set[int] = set()
+    for loops in state.codegen.active_device_loops.values():
+        for loop in loops:
+            mapping = getattr(loop, "_tensor_to_dma_scratch", None)
+            if not mapping:
+                continue
+            for hbm_name, ref_name in mapping.items():
+                if ref_name != name:
+                    continue
+                block_id_mapping = getattr(loop, "_tensor_to_dma_block_ids", None)
+                if block_id_mapping and hbm_name in block_id_mapping:
+                    block_ids.update(block_id_mapping[hbm_name])
+                else:
+                    block_ids.update(loop.block_ids)
+    return block_ids
+
+
+def _zero_begin_emit_pipeline_index(state: CodegenState, block_id: int) -> str | None:
+    """Return ``_pipeline_indices[i]`` when it is the tile ordinal for block_id."""
+    seen: set[int] = set()
+    for loops in state.codegen.active_device_loops.values():
+        for loop in loops:
+            if id(loop) in seen:
+                continue
+            seen.add(id(loop))
+            if not isinstance(loop, EmitPipelineLoopState):
+                continue
+            ordered_block_ids = list(loop.block_id_to_info)
+            if block_id not in ordered_block_ids:
+                continue
+            info = loop.block_id_to_info.get(block_id)
+            if info is None or info.begin_expr != 0:
+                continue
+            return f"_pipeline_indices[{ordered_block_ids.index(block_id)}]"
+    return None
+
+
 def emit_carry_store(
     state: CodegenState,
     tensor: torch.Tensor,
     subscript: list[object] | tuple[object, ...],
     name: str,
-    idx_str: str,
+    idx_parts: list[str],
     value: object,
 ) -> bool:
     """Store a jagged row tile, stitching the boundary two groups share.
@@ -272,11 +313,30 @@ def emit_carry_store(
         f"(({row_off} == {a_start}) & ({begin} % {S} != 0) & (pl.program_id(0) != 0))"
     )
     save_guard = f"(({row_off} + {block_row} >= {a_end}) & ({end} % {S} != 0))"
-    col_sub = f"pl.multiple_of(({col_off}) // {block_col} * {S}, {S})"
+    col_index = _zero_begin_emit_pipeline_index(state, col_block_id)
+    if col_index is None:
+        col_index = f"({col_off}) // {block_col}"
+    col_sub = f"pl.multiple_of(({col_index}) * {S}, {S})"
     carry_slice = f"{carry}[pl.ds({col_sub}, {S}), :]"
-    # Group's last row block: S-aligned, within [0, block_row - S].
-    last_off = f"pl.multiple_of({a_end} - {S} - ({row_off}), {S})"
-    out_last = f"{name}[pl.ds({last_off}, {S}), :]"
+    local_block_ids = _dma_ref_block_ids_for_name(state, name)
+    local_row_ref = row_block_id in local_block_ids
+    store_parts = [*idx_parts]
+    store_parts[0] = (
+        f"pl.ds(0, {block_row})"
+        if local_row_ref
+        else f"pl.ds(pl.multiple_of({row_off}, {S}), {block_row})"
+    )
+    idx_str = ", ".join(store_parts)
+    raw_last_off = f"({a_end} - {S})"
+    last_off = f"pl.multiple_of({raw_last_off}, {S})"
+    if local_row_ref:
+        last_off = f"pl.multiple_of(({raw_last_off}) - ({row_off}), {S})"
+    out_col = (
+        ":"
+        if col_block_id in local_block_ids
+        else f"pl.ds(pl.multiple_of({col_off}, {block_col}), {block_col})"
+    )
+    out_last = f"{name}[pl.ds({last_off}, {S}), {out_col}]"
 
     # Pad the [S, block_col] carry to a full [block_row, block_col] tile (carry on
     # top, zeros below): Pallas rejects a partial write to the double-buffered out.

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -1862,6 +1862,9 @@ class EmitPipelineLoopState(DeviceLoopOrGridState):
     outer_prefix: list[ast.AST] = dataclasses.field(default_factory=list)
     outer_suffix: list[ast.AST] = dataclasses.field(default_factory=list)
     _tensor_to_dma_scratch: dict[str, str] = dataclasses.field(default_factory=dict)
+    _tensor_to_dma_block_ids: dict[str, set[int]] = dataclasses.field(
+        default_factory=dict
+    )
 
 
 @dataclasses.dataclass
@@ -1880,6 +1883,9 @@ class ForiLoopState(DeviceLoopOrGridState):
     outer_prefix: list[ast.AST] = dataclasses.field(default_factory=list)
     outer_suffix: list[ast.AST] = dataclasses.field(default_factory=list)
     _tensor_to_dma_scratch: dict[str, str] = dataclasses.field(default_factory=dict)
+    _tensor_to_dma_block_ids: dict[str, set[int]] = dataclasses.field(
+        default_factory=dict
+    )
     _tensor_to_sem: dict[str, str] = dataclasses.field(default_factory=dict)
 
 

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -296,7 +296,7 @@ def _classify_loop_tensors(
     state: object,
 ) -> tuple[
     dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
-    dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
+    dict[int, tuple[torch.Tensor, torch.fx.Node, list[object], list[list[object]]]],
 ]:
     """Classify tensors accessed in an inner loop body into loaded/stored.
 
@@ -312,7 +312,9 @@ def _classify_loop_tensors(
                 host_tensor_nodes[node] = node.meta["val"]
 
     loaded_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]] = {}
-    stored_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]] = {}
+    stored_tensors: dict[
+        int, tuple[torch.Tensor, torch.fx.Node, list[object], list[list[object]]]
+    ] = {}
 
     for node in graph_info.graph.nodes:  # type: ignore[union-attr]
         if node.op != "call_function":
@@ -326,9 +328,16 @@ def _classify_loop_tensors(
             ):
                 fake = host_tensor_nodes[tensor_node]
                 key = id(fake)
+                sub_vals = _extract_subscript_vals(subscript)
                 if key not in loaded_tensors:
-                    sub_vals = _extract_subscript_vals(subscript)
                     loaded_tensors[key] = (fake, tensor_node, sub_vals)
+                else:
+                    prev_fake, prev_node, prev_sub_vals = loaded_tensors[key]
+                    loaded_tensors[key] = (
+                        prev_fake,
+                        prev_node,
+                        _merge_subscript_meta(prev_fake, prev_sub_vals, sub_vals),
+                    )
         elif node.target is _store_op:
             tensor_node = node.args[0]
             subscript = node.args[1]
@@ -338,9 +347,26 @@ def _classify_loop_tensors(
             ):
                 fake = host_tensor_nodes[tensor_node]
                 key = id(fake)
+                sub_vals = _extract_subscript_vals(subscript)
                 if key not in stored_tensors:
-                    sub_vals = _extract_subscript_vals(subscript)
-                    stored_tensors[key] = (fake, tensor_node, sub_vals)
+                    stored_tensors[key] = (fake, tensor_node, sub_vals, [sub_vals])
+                else:
+                    prev_fake, prev_node, prev_sub_vals, prev_store_sub_vals = (
+                        stored_tensors[key]
+                    )
+                    stored_tensors[key] = (
+                        prev_fake,
+                        prev_node,
+                        _merge_subscript_meta(prev_fake, prev_sub_vals, sub_vals),
+                        [*prev_store_sub_vals, sub_vals],
+                    )
+
+    for key in loaded_tensors.keys() & stored_tensors.keys():
+        loaded_fake, loaded_node, loaded_sub_vals = loaded_tensors[key]
+        stored_fake, stored_node, stored_sub_vals, store_sub_vals = stored_tensors[key]
+        merged = _merge_subscript_meta(loaded_fake, loaded_sub_vals, stored_sub_vals)
+        loaded_tensors[key] = (loaded_fake, loaded_node, merged)
+        stored_tensors[key] = (stored_fake, stored_node, merged, store_sub_vals)
 
     return loaded_tensors, stored_tensors
 
@@ -361,6 +387,71 @@ def _get_dim_block_ids(
         elif isinstance(idx, slice) and idx == slice(None):
             pass
     return dim_to_bid
+
+
+def _merge_subscript_meta(
+    fake: torch.Tensor,
+    lhs: list[object],
+    rhs: list[object],
+) -> list[object]:
+    """Merge multiple accesses into one conservative DMA/BlockSpec shape."""
+    env = CompileEnvironment.current()
+
+    def idx_at(meta: list[object], dim: int) -> object:
+        return meta[dim] if dim < len(meta) else slice(None)
+
+    def is_full_slice(idx: object) -> bool:
+        return isinstance(idx, slice) and idx == slice(None)
+
+    def block_id(idx: object) -> int | None:
+        if isinstance(idx, torch.SymInt):
+            return env.get_block_id(idx)
+        return None
+
+    merged: list[object] = []
+    for dim in range(fake.ndim):
+        lidx = idx_at(lhs, dim)
+        ridx = idx_at(rhs, dim)
+        if is_full_slice(lidx) or is_full_slice(ridx):
+            merged.append(slice(None))
+            continue
+        lbid = block_id(lidx)
+        rbid = block_id(ridx)
+        if lbid is not None and rbid is not None and lbid == rbid:
+            merged.append(lidx)
+            continue
+        if lbid is not None or rbid is not None:
+            merged.append(slice(None))
+            continue
+        if isinstance(lidx, (int, slice)) and lidx == ridx:
+            merged.append(lidx)
+        else:
+            merged.append(slice(None))
+    return merged
+
+
+def _dma_ref_block_ids(
+    subscript_meta: list[object],
+    block_ids: list[int],
+    env: CompileEnvironment,
+    state: CodegenState,
+    extra_block_ids: set[int] | None = None,
+) -> set[int]:
+    """Block IDs already handled by a DMA/Buffered ref for this subscript."""
+    from helion._compiler.pallas.ordered_carry import is_dynamic_bound_tile
+
+    extra = extra_block_ids or set()
+    handled: set[int] = set()
+    dim_to_bid = _get_dim_block_ids(subscript_meta, env)
+    for bid in dim_to_bid.values():
+        if (
+            bid in block_ids
+            or bid in extra
+            or is_dynamic_bound_tile(state, bid)
+            or state.codegen.active_device_loops.get(bid)
+        ):
+            handled.add(bid)
+    return handled
 
 
 def _find_strategy(
@@ -570,6 +661,12 @@ def _pallas_loop_begin_and_step_exprs(
         slice_size_exprs.append(slice_size_expr)
 
     return begin_exprs, iter_step_exprs, slice_size_exprs
+
+
+def _static_loop_begin_expr(begin_expr: str) -> sympy.Expr | None:
+    if begin_expr.lstrip("-").isdigit():
+        return sympy.Integer(int(begin_expr))
+    return None
 
 
 def _pipeline_begin_alignment(
@@ -1618,7 +1715,9 @@ def _aligned_dim(
     env: CompileEnvironment,
     block_ids: list[int],
     loaded_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
-    stored_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
+    stored_tensors: dict[
+        int, tuple[torch.Tensor, torch.fx.Node, list[object], list[list[object]]]
+    ],
 ) -> dict[int, int]:
     """Jagged row tiles (runtime end) that read an aligned-enclosing window.
 
@@ -1645,7 +1744,14 @@ def _aligned_dim(
 
     # Strictest addressing each row needs over the tensors it slices.
     addressing: dict[int, SliceAddressing] = {}
-    for fake, _node, sub_meta in (*loaded_tensors.values(), *stored_tensors.values()):
+    tensor_accesses = [
+        *(loaded_tensors.values()),
+        *(
+            (fake, node, sub_meta)
+            for fake, node, sub_meta, _store_sub_metas in stored_tensors.values()
+        ),
+    ]
+    for fake, _node, sub_meta in tensor_accesses:
         if not (isinstance(fake, torch.Tensor) and fake.is_floating_point()):
             continue
         dim_to_bid = _get_dim_block_ids(sub_meta, env)
@@ -1743,6 +1849,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     body_params: list[str] = []
     pipeline_in_args: list[str] = []
     pipeline_out_args: list[str] = []
+    tensor_to_dma_block_ids: dict[str, set[int]] = {}
 
     # Map outer grid block_ids to program_id variable names.
     # Compute program_ids before emit_pipeline so the BlockSpec lambda
@@ -1997,7 +2104,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     for fake, _tensor_node, _sub_meta in loaded_tensors.values():
         if id(fake) in pipelined_tensor_ids:
             state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
-    for fake, _tensor_node, _sub_meta in stored_tensors.values():
+    for fake, _tensor_node, _sub_meta, _store_sub_metas in stored_tensors.values():
         if id(fake) in pipelined_tensor_ids:
             state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
 
@@ -2014,8 +2121,15 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         in_specs.append(_make_load_block_spec(fake, sub_meta))
         body_params.append(vmem_name)
         pipeline_in_args.append(_make_hbm_slice(fake, hbm_name, sub_meta))
+        tensor_to_dma_block_ids[hbm_name] = _dma_ref_block_ids(
+            sub_meta,
+            block_ids,
+            env,
+            state,
+            set(_bid_to_pid_var),
+        )
 
-    for fake, _tensor_node, sub_meta in stored_tensors.values():
+    for fake, _tensor_node, sub_meta, _store_sub_metas in stored_tensors.values():
         if id(fake) not in pipelined_tensor_ids:
             continue
         hbm_name = state.device_function.tensor_arg(fake).name
@@ -2026,6 +2140,13 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         out_specs.append(_make_store_block_spec(fake, sub_meta))
         body_params.append(vmem_name)
         pipeline_out_args.append(_make_hbm_slice(fake, hbm_name, sub_meta))
+        tensor_to_dma_block_ids[hbm_name] = _dma_ref_block_ids(
+            sub_meta,
+            block_ids,
+            env,
+            state,
+            set(_bid_to_pid_var),
+        )
 
     # Build the body function
     body_fn_name = state.device_function.new_var("_pipeline_body")
@@ -2033,11 +2154,12 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
 
     # Build block_id_to_info for the pipeline state
     block_id_to_info: dict[int, LoopDimInfo] = {}
-    for block_id in block_ids:
+    for i, block_id in enumerate(block_ids):
         block_size = env.block_sizes[block_id]
         # when the block_size.size is None, we cannot form a SymPy expr for the numel
         sympy_end_expr = block_size.numel if block_size.size is not None else None
         block_id_to_info[block_id] = LoopDimInfo(
+            begin_expr=_static_loop_begin_expr(begin_exprs[i]),
             end_var_name=None,
             end_expr=sympy_end_expr,
         )
@@ -2104,6 +2226,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         body_fn_name=body_fn_name,
         inner_statements=body_stmts,
         _tensor_to_dma_scratch=tensor_to_dma_scratch,
+        _tensor_to_dma_block_ids=tensor_to_dma_block_ids,
     )
 
     # For loop-carried state, remap args to scratch reads inside the body
@@ -2316,9 +2439,34 @@ def _compute_vmem_shapes(
     return vmem_shapes
 
 
+def _outer_access_tensor_ids() -> set[int]:
+    """Tensor ids accessed by the outer pallas_call body around inner loops."""
+    from .atomic_ops import ATOMIC_OPS
+    from .memory_ops import load as _load_op
+    from .memory_ops import store as _store_op
+
+    outer_access_targets = ATOMIC_OPS | {_load_op, _store_op}
+    device_ir = HostFunction.current().device_ir
+    result: set[int] = set()
+    for root_id in device_ir.root_ids:
+        root_graph = device_ir.graphs[root_id].graph
+        for node in root_graph.nodes:
+            if node.op != "call_function" or node.target not in outer_access_targets:
+                continue
+            tensor_node = node.args[0]
+            if not isinstance(tensor_node, torch.fx.Node):
+                continue
+            val = tensor_node.meta.get("val")
+            if isinstance(val, torch.Tensor):
+                result.add(id(val))
+    return result
+
+
 def _classify_pipelined_tensors(
     loaded_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
-    stored_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
+    stored_tensors: dict[
+        int, tuple[torch.Tensor, torch.fx.Node, list[object], list[list[object]]]
+    ],
     block_ids: list[int],
     slice_size_exprs: list[str],
     env: CompileEnvironment,
@@ -2346,38 +2494,23 @@ def _classify_pipelined_tensors(
     Tensors that fail any check stay on their outer BlockSpec and are
     closure-read from the body.
     """
-    from .atomic_ops import ATOMIC_OPS
-    from .memory_ops import load as _load_op
-    from .memory_ops import store as _store_op
-
-    outer_access_targets = ATOMIC_OPS | {_load_op, _store_op}
-
     all_tensor_info: list[tuple[torch.Tensor, list[object], str]] = []
     for key, (fake, _tensor_node, sub_meta) in loaded_tensors.items():
         if key not in stored_tensors:
             all_tensor_info.append((fake, sub_meta, "load"))
-    for fake, _tensor_node, sub_meta in stored_tensors.values():
+    for key, (
+        fake,
+        _tensor_node,
+        sub_meta,
+        _store_sub_metas,
+    ) in stored_tensors.items():
+        if key in loaded_tensors:
+            sub_meta = _merge_subscript_meta(fake, loaded_tensors[key][2], sub_meta)
         all_tensor_info.append((fake, sub_meta, "store"))
     vmem_shapes = _compute_vmem_shapes(
         all_tensor_info, block_ids, slice_size_exprs, env, state
     )
-    device_ir = HostFunction.current().device_ir
-
-    # Walk all root graphs (outer pallas_call body) for load/store/atomic
-    # nodes; any tensor accessed there is read/written outside the inner
-    # loop and must keep its outer BlockSpec.
-    outer_access_tensor_ids: set[int] = set()
-    for root_id in device_ir.root_ids:
-        root_graph = device_ir.graphs[root_id].graph
-        for node in root_graph.nodes:
-            if node.op != "call_function" or node.target not in outer_access_targets:
-                continue
-            tensor_node = node.args[0]
-            if not isinstance(tensor_node, torch.fx.Node):
-                continue
-            val = tensor_node.meta.get("val")
-            if isinstance(val, torch.Tensor):
-                outer_access_tensor_ids.add(id(val))
+    outer_access_tensor_ids = _outer_access_tensor_ids()
 
     pipelined_ids: set[int] = set()
     for (fake, sub_meta, direction), vmem_shape in zip(
@@ -2486,6 +2619,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     from .._compiler.device_function import PallasMemorySpace
 
     tensor_to_dma_scratch: dict[str, str] = {}
+    tensor_to_dma_block_ids: dict[str, set[int]] = {}
     tensor_to_sem: dict[str, str] = {}
     for (fake, _sub_meta, _direction), vmem_shape in zip(
         all_tensor_info, vmem_shapes, strict=True
@@ -2503,6 +2637,12 @@ def _codegen_fori_loop(state: CodegenState) -> object:
             name_hint=hbm_name.replace("_hbm", "") + "_sem",
         )
         tensor_to_dma_scratch[hbm_name] = vmem_name
+        tensor_to_dma_block_ids[hbm_name] = _dma_ref_block_ids(
+            _sub_meta,
+            block_ids,
+            env,
+            state,
+        )
         tensor_to_sem[hbm_name] = sem_name
 
     # Build the body function
@@ -2526,11 +2666,12 @@ def _codegen_fori_loop(state: CodegenState) -> object:
 
     # Build block_id_to_info
     block_id_to_info: dict[int, LoopDimInfo] = {}
-    for block_id in block_ids:
+    for i, block_id in enumerate(block_ids):
         block_size = env.block_sizes[block_id]
         # when the block_size.size is None, we cannot form a SymPy expr for the numel
         sympy_end_expr = block_size.numel if block_size.size is not None else None
         block_id_to_info[block_id] = LoopDimInfo(
+            begin_expr=_static_loop_begin_expr(begin_exprs[i]),
             end_var_name=None,
             end_expr=sympy_end_expr,
         )
@@ -2568,6 +2709,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         loop_var_name=loop_vars[0],
         inner_statements=body_stmts,
         _tensor_to_dma_scratch=tensor_to_dma_scratch,
+        _tensor_to_dma_block_ids=tensor_to_dma_block_ids,
         _tensor_to_sem=tensor_to_sem,
     )
 
@@ -2720,7 +2862,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         if has_loop_state:
             _write_back_loop_carried(state, scratch_names, carried, graph_results)
 
-        for fake, _tensor_node, sub_meta in stored_tensors.values():
+        for fake, _tensor_node, sub_meta, _store_sub_metas in stored_tensors.values():
             hbm_name = state.device_function.tensor_arg(fake).name
             if hbm_name not in tensor_to_dma_scratch:
                 continue

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -374,7 +374,7 @@ def _(state: CodegenState) -> None:
     from .._compiler.pallas.ordered_carry import emit_carry_store
 
     if not scatter_patterns and state.device_function.carry_tiles:
-        if emit_carry_store(state, tensor, subscript, name, idx_str, value):
+        if emit_carry_store(state, tensor, subscript, name, parts, value):
             return
     if tensor.dtype is torch.bool:
         value = CompileEnvironment.current().backend.cast_ast(value, torch.bool)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -2121,6 +2121,96 @@ class TestPallas(TestCase):
         expected = torch.bmm(a.float(), b.float()).to(torch.bfloat16)
         torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
 
+    def test_full_slice_and_tile_share_dimension(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile([m, n]):
+                out[tile_m, tile_n] = x[tile_m, tile_n] + x[tile_m, :].sum(
+                    dim=1,
+                    keepdim=True,
+                )
+            return out
+
+        x = torch.randn(32, 256, device=DEVICE, dtype=torch.float32)
+        _code, result = code_and_output(fn, (x,), block_sizes=[16, 128])
+        torch.testing.assert_close(result, x + x.sum(dim=1, keepdim=True))
+
+    def test_emit_pipeline_full_slice_and_outer_tile_share_dimension(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            k = y.size(1)
+            out = torch.empty([n, k], dtype=torch.float32, device=x.device)
+            for tile_n, tile_k in hl.tile([n, k]):
+                acc = hl.zeros([tile_n, tile_k], dtype=torch.float32)
+                for tile_m in hl.tile(m):
+                    row_sum = x[tile_m, :].sum(dim=1, keepdim=True)
+                    weighted = y[tile_m, tile_k] * row_sum
+                    acc = torch.addmm(acc, x[tile_m, tile_n].T, weighted)
+                out[tile_n, tile_k] = acc
+            return out
+
+        x = torch.randn(128, 256, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(128, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            fn,
+            (x, y),
+            block_sizes=[128, 128, 64],
+            pallas_loop_type="emit_pipeline",
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+        expected = x.T @ (y * x.sum(dim=1, keepdim=True))
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=0.3)
+
+    def test_emit_pipeline_tile_first_then_full_slice_same_dimension(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            k = y.size(1)
+            out = torch.empty([n, k], dtype=torch.float32, device=x.device)
+            for tile_n, tile_k in hl.tile([n, k]):
+                acc = hl.zeros([tile_n, tile_k], dtype=torch.float32)
+                for tile_m in hl.tile(m):
+                    x_tile = x[tile_m, tile_n]
+                    row_sum = x[tile_m, :].sum(dim=1, keepdim=True)
+                    acc = torch.addmm(acc, x_tile.T, y[tile_m, tile_k] * row_sum)
+                out[tile_n, tile_k] = acc
+            return out
+
+        x = torch.randn(128, 256, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(128, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            fn,
+            (x, y),
+            block_sizes=[128, 128, 64],
+            pallas_loop_type="emit_pipeline",
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+        expected = x.T @ (y * x.sum(dim=1, keepdim=True))
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=0.3)
+
+    def test_emit_pipeline_rmw_merges_full_slice_metadata(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            for tile_m in hl.tile(m):
+                for tile_n in hl.tile(n):
+                    x_tile = x[tile_m, tile_n]
+                    row_zero = x[tile_m, :].sum(dim=1, keepdim=True) * 0.0
+                    x[tile_m, tile_n] = x_tile + row_zero
+            return x
+
+        x = torch.randn(32, 256, device=DEVICE, dtype=torch.float32)
+        code, _ = code_and_output(
+            fn,
+            (x,),
+            block_sizes=[16, 128],
+            pallas_loop_type="emit_pipeline",
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+
     @xfailIfPallas("Non-zero begin K reduction: DMA offset not tile-aligned")
     def test_bmm_nonzero_k_begin(self) -> None:
         """BMM with K reduction starting at non-zero offset, across all loop types."""
@@ -2338,7 +2428,6 @@ class TestPallas(TestCase):
         expected = x - x.mean(dim=-1, keepdim=True)
         torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
 
-    @xfailIfPallas("Pipeline + scalar access codegen not yet supported")
     def test_pipeline_tensor_with_scalar_access(self) -> None:
         """A pipeline tensor with scalar access should keep HBM, not be overridden to SMEM."""
         args = (


### PR DESCRIPTION
Stacked PRs:
 * #2936
 * #2935
 * #2934
 * #2933
 * #2932
 * #2931
 * #2930
 * #2929
 * #2928
 * #2927
 * #2926
 * #2925
 * __->__#2924
 * #2923
 * #2922
 * #2921
 * #2920
 * #2919
 * #2918
 * #2917


--- --- ---

### Track Pallas pipeline access block metadata


No example is flipped directly here. The compiler tracks which block ids each per-tensor pipeline or DMA ref already covers, merges full-slice and tiled subscript metadata, and uses that metadata in Pallas indexing and ordered-carry stores so tensors with mixed full-slice and tiled access do not get sliced twice or addressed as the wrong ref.