### PR TITLE
Enable Pallas HSTU example

### DIFF
--- a/examples/jagged_hstu_attn.py
+++ b/examples/jagged_hstu_attn.py
@@ -20,6 +20,7 @@ import helion
 from helion._testing import DEVICE
 from helion._testing import run_example
 import helion.language as hl
+from helion.runtime.settings import _get_backend
 
 try:
     # pyrefly: ignore [missing-import]
@@ -91,7 +92,7 @@ def reference_jagged_hstu_kernel_pytorch(
 
 # %%
 @helion.kernel()
-def _helion_jagged_attention_kernel(
+def _helion_jagged_attention_kernel_scalar(
     max_seq_len: int,
     alpha: float,
     q: torch.Tensor,
@@ -147,6 +148,57 @@ def _helion_jagged_attention_kernel(
             out[tile_q.index + starts, tile_h.begin, :] = acc.to(out.dtype)
 
     return out
+
+
+@helion.kernel()
+def _helion_jagged_attention_kernel_pallas(
+    max_seq_len: int,
+    alpha: float,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    seq_offsets: torch.Tensor,
+) -> torch.Tensor:
+    """Pallas implementation of HSTU jagged attention, tiled over all heads."""
+    scale = 1.0 / max_seq_len
+    num_heads = hl.specialize(q.size(1))
+    num_batches = hl.specialize(seq_offsets.size(0) - 1)
+    dimV = hl.specialize(v.size(2))
+
+    out = torch.zeros_like(v)
+
+    # Tile each packed sequence's real row range; each program computes all heads.
+    for seq_idx in hl.grid(num_batches):
+        start = seq_offsets[seq_idx]
+        end = seq_offsets[seq_idx + 1]
+
+        for tile_q in hl.tile(start, end):
+            q_blk = q[tile_q, :, :].transpose(0, 1)
+            acc = hl.zeros([num_heads, tile_q, dimV], dtype=torch.float32)
+
+            # Causal attention: only attend through the current query position.
+            for tile_kv in hl.tile(start, end):
+                k_blk = k[tile_kv, :, :].transpose(0, 1)
+                v_blk = v[tile_kv, :, :].transpose(0, 1)
+
+                scores = torch.bmm(q_blk, k_blk.transpose(-2, -1)) * alpha
+                scores = torch.nn.functional.silu(scores) * scale
+
+                causal_mask = tile_q.index.unsqueeze(1) >= tile_kv.index.unsqueeze(0)
+                scores = torch.where(causal_mask[None, :, :], scores, 0.0)
+
+                acc = acc + torch.bmm(scores.to(v.dtype), v_blk)
+
+            out[tile_q, :, :] = acc.transpose(0, 1).to(out.dtype)
+
+    return out
+
+
+_helion_jagged_attention_kernel = (
+    _helion_jagged_attention_kernel_pallas
+    if _get_backend() == "pallas"
+    else _helion_jagged_attention_kernel_scalar
+)
 
 
 # %%
@@ -210,7 +262,7 @@ def test(
     seq_offsets = torch.cat(
         [
             torch.tensor([0], dtype=torch.int32, device=device),
-            torch.cumsum(seq_lengths, dim=0),
+            torch.cumsum(seq_lengths, dim=0).to(torch.int32),
         ]
     )
     total_seq_len = int(seq_offsets[-1].item())

--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -300,6 +300,42 @@ unsqueeze_lowering = register_lowering(
 )
 
 
+def _pallas_bool_safe_singleton_index(
+    tensor: ast.AST,
+    input_val: torch.Tensor,
+    args: list[str],
+    singleton_shape: str | None = None,
+) -> ast.AST:
+    index = ", ".join(args)
+    if input_val.dtype is torch.bool and "None" in args:
+        # Mosaic cannot reshape bool vectors directly:
+        # https://github.com/jax-ml/jax/issues/37370
+        if singleton_shape is not None:
+            from .pallas import codegen as pallas_codegen
+
+            return pallas_codegen.numeric_mask_reshape_expr(tensor, singleton_shape)
+        return expr_from_string(
+            f"(({{tensor}}).astype(jnp.int32)[{index}] != 0)",
+            tensor=tensor,
+        )
+    return expr_from_string(
+        f"{{tensor}}[{index}]",
+        tensor=tensor,
+    )
+
+
+def _pallas_singleton_shape(
+    input_val: torch.Tensor,
+    args: list[str],
+    ctx: LoweringContext,
+) -> str:
+    input_dims = iter(input_val.size())
+    shape: list[int | torch.SymInt] = []
+    for arg in args:
+        shape.append(1 if arg == "None" else next(input_dims))
+    return ctx.cg.device_function.tile_strategy.shape_str(shape)
+
+
 @unsqueeze_lowering.register_codegen("common")
 def codegen_unsqueeze(ctx: LoweringContext, node: Node) -> object:
     assert not node.kwargs, "getitem kwargs not supported"
@@ -317,6 +353,26 @@ def codegen_unsqueeze(ctx: LoweringContext, node: Node) -> object:
         f"{{tensor}}[{', '.join(args)}]",
         tensor=tensor,
     )
+
+
+@unsqueeze_lowering.register_codegen("pallas")
+def codegen_unsqueeze_pallas(ctx: LoweringContext, node: Node) -> object:
+    assert not node.kwargs, "unsqueeze kwargs not supported"
+    tensor, dim = map_arg(node.args, lambda arg: _env_arg(ctx, arg))
+    assert isinstance(tensor, ast.AST)
+    assert isinstance(dim, int)
+    input_node = node.args[0]
+    assert isinstance(input_node, Node)
+    input_val = input_node.meta["val"]
+    assert isinstance(input_val, torch.Tensor)
+    ndim = input_val.ndim
+    if dim < 0:
+        dim += ndim + 1
+    assert 0 <= dim <= ndim, f"Invalid dim {dim} for tensor with {ndim} dims"
+    args = [":"] * ndim
+    args.insert(dim, "None")
+    singleton_shape = _pallas_singleton_shape(input_val, args, ctx)
+    return _pallas_bool_safe_singleton_index(tensor, input_val, args, singleton_shape)
 
 
 @unsqueeze_lowering.register_codegen("cute")
@@ -952,15 +1008,14 @@ def codegen_expand_pallas(ctx: LoweringContext, node: Node) -> object:
     shape = [*val.size()]
     # pyrefly: ignore [missing-attribute]
     input_val = node.args[0].meta["val"]
+    assert isinstance(input_val, torch.Tensor)
     if input_val.ndim != len(shape):
         tile_strategy = ctx.cg.device_function.tile_strategy
         broadcasting = tile_strategy.broadcast_expand_dims(
             tuple(input_val.shape), tuple(shape)
         )
         if broadcasting:
-            tensor = expr_from_string(
-                f"{{tensor}}[{', '.join(broadcasting)}]", tensor=tensor
-            )
+            tensor = _pallas_bool_safe_singleton_index(tensor, input_val, broadcasting)
     shape_str = ctx.cg.device_function.tile_strategy.shape_str(shape)
     return expr_from_string(
         f"jnp.broadcast_to({{tensor}}, {shape_str})",

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1489,27 +1489,23 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[16, 8, 16, 16],
         )
 
-    @xfailIfPallas("Mosaic unsupported mask shape cast in HSTU")
     @skipIfXPU("Jagged tensor operations not fully supported on XPU")
     def test_jagged_hstu_attn(self):
-        batch_size = 4
+        torch.manual_seed(0)
         max_seq_len = 64
         heads = 8
         head_dim = 32
 
-        # Generate random sequence lengths
-        min_seq_len = max_seq_len // 2
-        seq_lengths = torch.randint(
-            min_seq_len,
-            max_seq_len + 1,
-            (batch_size,),
+        # Fixed partial tiles ensure padded lanes would overlap following sequences.
+        seq_lengths = torch.tensor(
+            [33, 34, 35, 36],
             dtype=torch.int32,
             device=DEVICE,
         )
         seq_offsets = torch.cat(
             [
                 torch.tensor([0], dtype=torch.int32, device=DEVICE),
-                torch.cumsum(seq_lengths, dim=0),
+                torch.cumsum(seq_lengths, dim=0).to(torch.int32),
             ]
         )
         total_seq_len = int(seq_offsets[-1].item())

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -676,6 +676,22 @@ def kernel_tile_begin_plus_offset_is_elementwise(
 @onlyBackends(["triton", "pallas"])
 @skipUnlessPallas("JAX/Pallas TPU not available")
 class TestPallas(TestCase):
+    def _assert_numeric_mask_reshape(self, code: str, shape_pattern: str) -> None:
+        bool_to_int = r"[^\n,]+\.astype\(jnp\.int32\)"
+        one_int32 = r"jnp\.array\(1, dtype=jnp\.int32\)"
+        patterns = [
+            rf"jnp\.reshape\({bool_to_int}, {shape_pattern}",
+            (
+                rf"jnp\.reshape\(jnp\.minimum\({bool_to_int}, {one_int32}\), "
+                rf"{shape_pattern}"
+            ),
+        ]
+        if not any(re.search(pattern, code) for pattern in patterns):
+            self.fail(
+                "expected numeric mask reshape to use direct bool-to-int "
+                "conversion, optionally clamped with jnp.minimum"
+            )
+
     def test_slice_addressing_classification(self) -> None:
         """_slice_addressing: major dim -> DIRECT; f32 single-lane-tile sublane
         -> DIRECT; bf16 / wide-lane / unknown-lane sublane -> ALIGNED."""
@@ -1406,6 +1422,76 @@ class TestPallas(TestCase):
         expected = torch.where(x[:, :1] > 0, x, torch.zeros_like(x))
         torch.testing.assert_close(result, expected)
         self.assertIn("astype(jnp.int32)", code)
+
+    def test_bool_expand_inserted_broadcast_dim_where(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def pallas_bool_expand_inserted_broadcast_dim_where(
+            x: torch.Tensor,
+        ) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile([m, n]):
+                mask = (x[0, tile_n] < 0).expand(tile_m.block_size, tile_n.block_size)
+                out[tile_m, tile_n] = torch.where(mask, x[tile_m, tile_n], 0.0)
+            return out
+
+        x = torch.randn(16, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_bool_expand_inserted_broadcast_dim_where,
+            (x,),
+            block_sizes=[16, 128],
+        )
+
+        expected = torch.where(x[:1, :] < 0, x, torch.zeros_like(x))
+        torch.testing.assert_close(result, expected)
+        self.assertIn("jnp.broadcast_to", code)
+        self.assertIn("astype(jnp.int32)[None, :]", code)
+
+    def test_bool_subscript_broadcast_where(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def pallas_bool_subscript_broadcast_where(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile([m, n]):
+                row_mask = x[tile_m, 0] > 0
+                col_mask = x[0, tile_n] < 0
+                mask = row_mask[:, None] & col_mask[None, :]
+                out[tile_m, tile_n] = torch.where(mask, x[tile_m, tile_n], 0.0)
+            return out
+
+        x = torch.randn(16, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_bool_subscript_broadcast_where,
+            (x,),
+            block_sizes=[16, 128],
+        )
+
+        expected_mask = (x[:, :1] > 0) & (x[:1, :] < 0)
+        expected = torch.where(expected_mask, x, torch.zeros_like(x))
+        torch.testing.assert_close(result, expected)
+        self._assert_numeric_mask_reshape(code, r"\[[^\]]*, 1\]")
+        self._assert_numeric_mask_reshape(code, r"\[1,")
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def pallas_bool_unsqueeze_broadcast_where(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile([m, n]):
+                row_mask = x[tile_m, 0] > 0
+                col_mask = x[0, tile_n] < 0
+                mask = row_mask.unsqueeze(1) & col_mask.unsqueeze(0)
+                out[tile_m, tile_n] = torch.where(mask, x[tile_m, tile_n], 0.0)
+            return out
+
+        code, result = code_and_output(
+            pallas_bool_unsqueeze_broadcast_where,
+            (x,),
+            block_sizes=[16, 128],
+        )
+
+        torch.testing.assert_close(result, expected)
+        self._assert_numeric_mask_reshape(code, r"\[[^\]]*, 1\]")
+        self._assert_numeric_mask_reshape(code, r"\[1,")
 
     def test_indirect_gather_with_tiled_dim(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)


### PR DESCRIPTION
Stacked PRs:
 * #2936
 * #2935
 * #2934
 * #2933
 * #2932
 * #2931
 * __->__#2930
 * #2929
 * #2928
 * #2927
 * #2926
 * #2925
 * #2924
 * #2923
 * #2922
 * #2921
 * #2920
 * #2919
 * #2918
 * #2917


--- --- ---

### Enable Pallas HSTU example


This enables the Pallas `jagged_hstu_attn` example. The example selects a Pallas-compatible full-head structural kernel with int32 sequence offsets, while the compiler lowers bool singleton expand and unsqueeze through int32 so Mosaic does not have to reshape raw bool vectors.