### PR TITLE
Honor Pallas shared-output BlockSpec metadata

### DIFF
--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -208,7 +208,10 @@ def _pallas_make_block_spec(
     jnp: object,
     pltpu: object,
     tensor: torch.Tensor,
-    entry: tuple[tuple[int | None, ...], tuple[int | tuple[int, int, int] | None, ...]]
+    entry: tuple[
+        tuple[int | None, ...],
+        tuple[int | _PallasFlatGridDim | None, ...],
+    ]
     | None,
     should_use_smem: bool = False,
 ) -> object:
@@ -237,15 +240,18 @@ def _pallas_make_block_spec(
 
     def _index_for_dim(
         grid_args: tuple[object, ...],
-        g: int | tuple[int, int, int] | None,
+        g: int | _PallasFlatGridDim | None,
         jnp: object = jnp,
     ) -> object:
         if g is None:
             return jnp.int32(0)  # pyrefly: ignore[missing-attribute]
         if isinstance(g, tuple):
-            # Flat grid decomposition: (grid_dim, stride, num_blocks)
-            grid_dim, stride, num_blocks = g
+            # Flat grid decomposition:
+            # (grid_dim, stride, num_blocks[, start[, total]])
+            grid_dim, stride, num_blocks, *start = g
             val = grid_args[grid_dim]
+            if start:
+                val = val - start[0]  # type: ignore[operator]
             if stride > 1:
                 val = val // stride  # type: ignore[operator]
             val = val % num_blocks  # type: ignore[operator]
@@ -254,7 +260,7 @@ def _pallas_make_block_spec(
 
     def index_map(
         *grid_args: object,
-        _grid_dims: tuple[int | tuple[int, int, int] | None, ...] = grid_dims,
+        _grid_dims: tuple[int | _PallasFlatGridDim | None, ...] = grid_dims,
     ) -> tuple[object, ...]:
         return tuple(_index_for_dim(grid_args, g) for g in _grid_dims)
 
@@ -390,10 +396,19 @@ def _estimate_pallas_vmem_bytes(
 # Per-tensor block spec info: see ``_pallas_make_block_spec``.
 # grid_dims entries are int (direct grid dim), tuple (flat decomposition),
 # or None (untiled dim).
+_PallasFlatGridDim = (
+    tuple[int, int, int] | tuple[int, int, int, int] | tuple[int, int, int, int, int]
+)
 _BlockSpecInfo = list[
-    tuple[tuple[int | None, ...], tuple[int | tuple[int, int, int] | None, ...]] | None
+    tuple[
+        tuple[int | None, ...],
+        tuple[int | _PallasFlatGridDim | None, ...],
+    ]
+    | None
 ]
-_PallasCopyGuards = dict[int, tuple[int, ...]]
+_PallasFlatCopyGuard = tuple[int, int, int, tuple[tuple[int, int], ...]]
+_PallasCopyGuard = tuple[tuple[int, ...], tuple[_PallasFlatCopyGuard, ...]]
+_PallasCopyGuards = dict[int, _PallasCopyGuard]
 _PallasDimensionSemantic = Literal["parallel", "arbitrary"]
 
 
@@ -407,7 +422,8 @@ def _pallas_tensor_pos_map(
 
 def _pallas_grid_dims_used_by_block_spec(
     block_info: tuple[
-        tuple[int | None, ...], tuple[int | tuple[int, int, int] | None, ...]
+        tuple[int | None, ...],
+        tuple[int | _PallasFlatGridDim | None, ...],
     ],
 ) -> set[int]:
     used: set[int] = set()
@@ -418,6 +434,31 @@ def _pallas_grid_dims_used_by_block_spec(
         elif isinstance(grid_dim, tuple):
             used.add(grid_dim[0])
     return used
+
+
+def _pallas_flat_shared_groups(
+    block_info: tuple[
+        tuple[int | None, ...],
+        tuple[int | _PallasFlatGridDim | None, ...],
+    ],
+) -> tuple[tuple[int, int, int, tuple[tuple[int, int], ...]], ...]:
+    """Return flat grid groups whose logical subdimensions are only partly tiled."""
+    _, grid_dims = block_info
+    groups: dict[tuple[int, int, int], set[tuple[int, int]]] = {}
+    for grid_dim in grid_dims:
+        if not isinstance(grid_dim, tuple) or len(grid_dim) < 5:
+            continue
+        dim, stride, num_blocks, start, total = grid_dim[:5]
+        groups.setdefault((dim, start, total), set()).add((stride, num_blocks))
+
+    result: list[tuple[int, int, int, tuple[tuple[int, int], ...]]] = []
+    for (dim, _start, total), used_dims in groups.items():
+        used = 1
+        for _stride, num_blocks in used_dims:
+            used *= num_blocks
+        if used < total:
+            result.append((dim, _start, total, tuple(sorted(used_dims))))
+    return tuple(result)
 
 
 def _pallas_shared_output_plan(
@@ -452,12 +493,31 @@ def _pallas_shared_output_plan(
         shared_dims = tuple(
             dim for dim, size in enumerate(grid) if size > 1 and dim not in used_dims
         )
-        if not shared_dims:
-            continue
-        copy_guards[orig_pos] = shared_dims
+        flat_groups = _pallas_flat_shared_groups(block_info)
+        if shared_dims or flat_groups:
+            flat_guards = tuple(
+                (dim, start, total, used_dims)
+                for dim, start, total, used_dims in flat_groups
+            )
+            copy_guards[orig_pos] = (shared_dims, flat_guards)
         for dim in shared_dims:
             dim_semantics[dim] = "arbitrary"
+        for dim, _start, _total, _used_dims in flat_groups:
+            dim_semantics[dim] = "arbitrary"
     return copy_guards, tuple(dim_semantics)
+
+
+def _pallas_apply_arbitrary_grid_dims(
+    dimension_semantics: tuple[_PallasDimensionSemantic, ...],
+    arbitrary_grid_dims: tuple[int, ...] | None,
+) -> tuple[_PallasDimensionSemantic, ...]:
+    if not arbitrary_grid_dims:
+        return dimension_semantics
+    result: list[_PallasDimensionSemantic] = list(dimension_semantics)
+    for dim in arbitrary_grid_dims:
+        if 0 <= dim < len(result):
+            result[dim] = "arbitrary"
+    return tuple(result)
 
 
 def _pallas_build_block_specs(
@@ -1092,12 +1152,26 @@ def _pallas_inplace_copy(in_ref: object, out_ref: object, *, is_smem: bool) -> N
         out_ref[...] = in_ref[...]  # type: ignore[index]
 
 
-def _pallas_copy_guard(dims: tuple[int, ...]) -> bool | jax.Array:
+def _pallas_copy_guard(guard: _PallasCopyGuard) -> bool | jax.Array:
     from jax.experimental import pallas as pl
 
+    direct_dims, flat_guards = guard
     should_copy = True
-    for dim in dims:
+    for dim in direct_dims:
         should_copy = should_copy & (pl.program_id(dim) == 0)
+    for dim, start, total, used_dims in flat_guards:
+        local_pid = pl.program_id(dim) - start
+        rebuilt_pid = 0
+        for stride, num_blocks in used_dims:
+            coord = local_pid
+            if stride > 1:
+                coord = coord // stride  # type: ignore[operator]
+            coord = coord % num_blocks  # type: ignore[operator]
+            if stride > 1:
+                coord = coord * stride  # type: ignore[operator]
+            rebuilt_pid = rebuilt_pid + coord
+        in_group = (local_pid >= 0) & (local_pid < total)
+        should_copy = should_copy & ((~in_group) | (local_pid == rebuilt_pid))
     return should_copy
 
 
@@ -1155,7 +1229,7 @@ def _pallas_make_reordered_kernel(
                     should_copy = _pallas_copy_guard(copy_guard_dims)
 
                     @pl.when(should_copy)
-                    def _copy_shared_output(
+                    def _copy_inplace_output(
                         out_ref: object = out_ref,
                         in_ref: object = in_ref,
                         is_smem: bool = is_smem,
@@ -1474,6 +1548,7 @@ def _pallas_compile_jit_fn(
     _pipeline_arg_indices: list[int] | None,
     _matmul_dot_general: dict[str, object] | None,
     interpret: bool,
+    _pallas_arbitrary_grid_dims: tuple[int, ...] | None = None,
 ) -> _PallasCompileResult:
     """Build the ``pl.pallas_call`` jit_fn shared by all Pallas launchers.
 
@@ -1522,6 +1597,9 @@ def _pallas_compile_jit_fn(
         _output_indices,
         inplace_positions,
         _block_spec_info,
+    )
+    dimension_semantics = _pallas_apply_arbitrary_grid_dims(
+        dimension_semantics, _pallas_arbitrary_grid_dims
     )
 
     if kind is _PallasLoopKind.UNROLL:
@@ -1655,6 +1733,7 @@ def _pallas_install_launcher_cache(
     _ds_pad_dims: list[tuple[int, int, int, int]] | None,
     _pallas_interpret: bool | None,
     _matmul_dot_general: dict[str, object] | None = None,
+    _pallas_arbitrary_grid_dims: tuple[int, ...] | None = None,
 ) -> tuple[object, ...]:
     """Cache-miss path shared by all three torch-tensor Pallas launchers.
 
@@ -1695,6 +1774,7 @@ def _pallas_install_launcher_cache(
         _pipeline_arg_indices=_pipeline_arg_indices,
         _matmul_dot_general=_matmul_dot_general,
         interpret=interpret,
+        _pallas_arbitrary_grid_dims=_pallas_arbitrary_grid_dims,
     )
 
     jax_callable = _pallas_build_callable(
@@ -1781,6 +1861,7 @@ def default_pallas_launcher(
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _pallas_interpret: bool | None = None,
     _matmul_dot_general: dict[str, object] | None = None,
+    _pallas_arbitrary_grid_dims: tuple[int, ...] | None = None,
     **kwargs: object,
 ) -> object:
     """Default launcher for Pallas kernels on TPU (or CPU with interpret=True).
@@ -1813,6 +1894,7 @@ def default_pallas_launcher(
             _ds_pad_dims=_ds_pad_dims,
             _pallas_interpret=_pallas_interpret,
             _matmul_dot_general=_matmul_dot_general,
+            _pallas_arbitrary_grid_dims=_pallas_arbitrary_grid_dims,
         )
 
     return _pallas_invoke_cached_launcher(
@@ -1837,6 +1919,7 @@ def default_pallas_pipeline_launcher(
     _smem_arg_indices: list[int] | None = None,
     _pallas_interpret: bool | None = None,
     _matmul_dot_general: dict[str, object] | None = None,
+    _pallas_arbitrary_grid_dims: tuple[int, ...] | None = None,
     **kwargs: object,
 ) -> object:
     """Launcher for Pallas kernels using PrefetchScalarGridSpec with scratch memory.
@@ -1863,6 +1946,7 @@ def default_pallas_pipeline_launcher(
             _ds_pad_dims=_ds_pad_dims,
             _pallas_interpret=_pallas_interpret,
             _matmul_dot_general=_matmul_dot_general,
+            _pallas_arbitrary_grid_dims=_pallas_arbitrary_grid_dims,
         )
 
     return _pallas_invoke_cached_launcher(
@@ -1885,6 +1969,7 @@ def default_pallas_fori_launcher(
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _smem_arg_indices: list[int] | None = None,
     _pallas_interpret: bool | None = None,
+    _pallas_arbitrary_grid_dims: tuple[int, ...] | None = None,
     **kwargs: object,
 ) -> object:
     """Launcher for Pallas kernels using fori_loop with manual DMA.
@@ -1914,6 +1999,7 @@ def default_pallas_fori_launcher(
             ),
             _ds_pad_dims=_ds_pad_dims,
             _pallas_interpret=_pallas_interpret,
+            _pallas_arbitrary_grid_dims=_pallas_arbitrary_grid_dims,
         )
 
     return _pallas_invoke_cached_launcher(

--- a/helion/runtime/pallas_jax_export.py
+++ b/helion/runtime/pallas_jax_export.py
@@ -264,6 +264,7 @@ def default_pallas_jax_launcher(
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _smem_arg_indices: list[int] | None = None,
     _pallas_interpret: bool | None = None,
+    _pallas_arbitrary_grid_dims: tuple[int, ...] | None = None,
     _kind: _PallasLoopKind | None = None,
     **kwargs: object,
 ) -> object:
@@ -357,6 +358,7 @@ def default_pallas_jax_launcher(
             _pipeline_arg_indices=_pipeline_arg_indices,
             _matmul_dot_general=None,
             interpret=interpret,
+            _pallas_arbitrary_grid_dims=_pallas_arbitrary_grid_dims,
         )
 
     jax_inputs = [

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -376,22 +376,6 @@ def pallas_stack_sum(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
-def pallas_jagged_segment_add(x: torch.Tensor, offsets: torch.Tensor) -> torch.Tensor:
-    """Outer grid over jagged segments + an inner ``hl.tile(start, end)`` loop
-    whose begin (``offsets[g]``) is an arbitrary runtime offset. A
-    block-aligned BlockSpec index can only address starts that are multiples of
-    the block size, so the emit_pipeline path must slice the segment with a
-    dynamic ``pl.ds`` (``pl.BoundedSlice`` block)."""
-    out = torch.empty_like(x)
-    for g in hl.grid(offsets.size(0) - 1):
-        start = offsets[g]
-        end = offsets[g + 1]
-        for tile in hl.tile(start, end):
-            out[tile, :] = x[tile, :] + 1.0
-    return out
-
-
-@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_add_3d(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     """Kernel with an outer grid loop and a 2D inner device loop."""
     b, m, n = x.size()
@@ -3034,13 +3018,15 @@ class TestPallas(TestCase):
             return x
 
         x = torch.randn(32, 256, device=DEVICE, dtype=torch.float32)
-        code, _ = code_and_output(
+        expected = x.cpu().clone()
+        code, result = code_and_output(
             fn,
             (x,),
             block_sizes=[16, 128],
             pallas_loop_type="emit_pipeline",
         )
         self.assertIn("pltpu.emit_pipeline", code)
+        torch.testing.assert_close(result.cpu(), expected)
 
     def test_stack_lowering(self) -> None:
         x = torch.randn(8, 128, device=DEVICE, dtype=torch.float32)
@@ -3121,29 +3107,118 @@ class TestPallas(TestCase):
         are exact multiples of the block size). Regression test for the
         "emit_pipeline fails on unaligned dims" limitation.
         """
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def segment_add(
+            x: torch.Tensor, offsets: torch.Tensor, values: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for g in hl.grid(offsets.size(0) - 1):
+                start = offsets[g]
+                end = offsets[g + 1]
+                value = values[g]
+                for tile in hl.tile(start, end):
+                    out[tile, :, :] = x[tile, :, :] + value
+            return out
+
         # Arbitrary, deliberately non-block-aligned segment bounds covering
-        # [0, 48) so the output is fully written (out = x + 1 everywhere).
-        offsets = torch.tensor([0, 10, 31, 48], device=DEVICE, dtype=torch.int32)
-        x = torch.randn(48, 128, device=DEVICE, dtype=torch.float32)
+        # [0, 48). Segment-specific values make an overrun observable.
+        offset_values = [0, 10, 31, 48]
+        offsets = torch.tensor(offset_values, device=DEVICE, dtype=torch.int32)
+        values = torch.tensor([1.0, 3.0, 7.0], device=DEVICE, dtype=torch.float32)
+        x = torch.randn(48, 4, 128, device=DEVICE, dtype=torch.float32)
         code, result = code_and_output(
-            pallas_jagged_segment_add,
-            (x, offsets),
+            segment_add,
+            (x, offsets, values),
             block_sizes=[16],
             pallas_loop_type="emit_pipeline",
         )
         self.assertIn("pltpu.emit_pipeline", code)
-        # The fix: dynamic ds slice + BoundedSlice block for the runtime begin.
+        # Dynamic begin stays in the output BlockSpec, and its extent is
+        # clamped so a short final tile cannot overrun into the next segment.
         self.assertIn("pl.BoundedSlice", code)
-        self.assertIn("pl.ds(", code)
-        # Load/store asymmetry: the input spec reads a full block (the over-read
-        # past ``end`` is zeroed by the mask), while the output spec clamps its
-        # extent to min(block, end - offset) so a short final tile writes only
-        # its valid rows instead of overrunning into the next segment.
-        in_part, _, out_part = code.partition("out_specs=")
-        self.assertIn("in_specs=", in_part)
-        self.assertNotIn("jnp.minimum", in_part)  # input: full block
-        self.assertIn("jnp.minimum", out_part)  # output: clamped extent
-        torch.testing.assert_close(result, x + 1.0, rtol=1e-5, atol=1e-5)
+        self.assertIn("out_specs=", code)
+        out_specs = code.split("out_specs=", 1)[1].split("compiler_params=", 1)[0]
+        self.assertIn("pl.ds(", out_specs)
+        self.assertIn("jnp.minimum(", out_specs)
+        self.assertRegex(out_specs.split("jnp.minimum(", 1)[1], r"end\s*-")
+        self.assertRegex(code, r"\bout_vmem(?:\[[^\n]*\])?\s*=")
+        self.assertNotRegex(code, r"out\[\s*pl\.ds\(")
+        expected = x.clone()
+        for g in range(len(offset_values) - 1):
+            start, end = offset_values[g], offset_values[g + 1]
+            expected[start:end] = x[start:end] + values[g]
+        torch.testing.assert_close(result, expected, rtol=1e-5, atol=1e-5)
+
+    def test_ordered_carry_marks_group_grid_arbitrary(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def jagged_bmm(
+            offsets: torch.Tensor, x: torch.Tensor, w: torch.Tensor
+        ) -> torch.Tensor:
+            length, d = x.size()
+            k = w.size(1)
+            out = torch.empty([length, k], dtype=x.dtype, device=x.device)
+            for group in hl.grid(offsets.size(0) - 1):
+                start = offsets[group]
+                end = offsets[group + 1]
+                for rows in hl.tile(start, end):
+                    for cols in hl.tile(k):
+                        acc = hl.zeros([rows, cols], dtype=torch.float32)
+                        for reduction in hl.tile(d):
+                            acc = acc + torch.matmul(
+                                x[rows, reduction], w[reduction, cols]
+                            )
+                        out[rows, cols] = acc.to(out.dtype)
+            return out
+
+        offsets = torch.tensor([0, 10, 33, 40], device=DEVICE, dtype=torch.int32)
+        x = torch.randn(40, 16, device=DEVICE, dtype=torch.float32)
+        w = torch.randn(16, 16, device=DEVICE, dtype=torch.float32)
+        bound = jagged_bmm.bind((offsets, x, w))
+        code = bound.to_code(
+            helion.Config(block_sizes=[16, 16, 16], pallas_loop_type="emit_pipeline")
+        )
+
+        self.assertIn("_scratch_shapes=", code)
+        self.assertIn("_pallas_arbitrary_grid_dims=(0,)", code)
+
+    def test_ordered_carry_dma_aligned_output_uses_vmem_relative_save(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def jagged_bmm(
+            offsets: torch.Tensor, x: torch.Tensor, w: torch.Tensor
+        ) -> torch.Tensor:
+            length, d = x.size()
+            k = w.size(1)
+            out = torch.empty([length, k], dtype=x.dtype, device=x.device)
+            for group in hl.grid(offsets.size(0) - 1):
+                start = offsets[group]
+                end = offsets[group + 1]
+                for rows, cols in hl.tile([start, 0], [end, k]):
+                    acc = hl.zeros([rows, cols], dtype=torch.float32)
+                    for reduction in hl.tile(d):
+                        acc = acc + torch.matmul(x[rows, reduction], w[reduction, cols])
+                    out[rows, cols] = acc.to(out.dtype)
+            return out
+
+        offsets = torch.tensor([0, 10, 33, 40], device=DEVICE, dtype=torch.int32)
+        x = torch.randn(40, 16, device=DEVICE, dtype=torch.float32)
+        w = torch.randn(16, 128, device=DEVICE, dtype=torch.float32)
+        code = jagged_bmm.bind((offsets, x, w)).to_code(
+            helion.Config(block_sizes=[16, 128, 16], pallas_loop_type="emit_pipeline")
+        )
+
+        self.assertIn("out_vmem", code)
+        self.assertIn("_pallas_arbitrary_grid_dims=(0,)", code)
+        carry_save_lines = [
+            line
+            for line in code.splitlines()
+            if "jnp.where" in line and "out_vmem[" in line
+        ]
+        self.assertTrue(carry_save_lines, "expected carry save from out_vmem")
+        self.assertTrue(
+            any(" - offset_" in line and "), :]" in line for line in carry_save_lines),
+            "\n".join(carry_save_lines),
+        )
 
     def test_emit_pipeline_static_begin_keeps_block_index(self) -> None:
         """Control: a static (zero-begin) inner loop must NOT switch to the
@@ -6045,33 +6120,34 @@ class TestPallas(TestCase):
                     )
             return out
 
-        def normalized_block_sizes_and_code(max_m: int) -> tuple[list[int], str]:
+        def normalized_config(max_m: int) -> tuple[Any, helion.Config]:
             feature_counts = torch.randint(
                 1, max_m + 1, (32,), device=DEVICE, dtype=torch.int32
             )
             bound = k.bind((feature_counts, max_m))
             config = helion.Config(block_sizes=[16, 8])
             bound.config_spec.normalize(config)
-            try:
-                code = bound.to_triton_code(config)
-            except Exception as error:
-                if "torch._inductor.codegen.pallas" not in str(error):
-                    raise
-                code = ""
+            return bound, config
+
+        def normalized_block_sizes(config: helion.Config) -> list[int]:
             block_sizes = config["block_sizes"]
             assert isinstance(block_sizes, list)
-            return cast("list[int]", block_sizes), code
+            return cast("list[int]", block_sizes)
 
-        small_block_sizes, small_code = normalized_block_sizes_and_code(8)
+        small_bound, small_config = normalized_config(8)
+        small_block_sizes = normalized_block_sizes(small_config)
         self.assertEqual(small_block_sizes, [32, 8])
-        if small_code:
-            self.assertIn(
-                "pl.ds(pl.multiple_of(offset_1, 128), _BLOCK_SIZE_1)",
-                small_code,
-            )
+        small_code = small_bound.to_triton_code(small_config)
+        self.assertIn(
+            "pl.ds(pl.multiple_of(offset_1, 128), _BLOCK_SIZE_1)",
+            small_code,
+        )
 
-        large_block_sizes, _large_code = normalized_block_sizes_and_code(256)
+        large_bound, large_config = normalized_config(256)
+        large_block_sizes = normalized_block_sizes(large_config)
         self.assertEqual(large_block_sizes, [32, 128])
+        large_code = large_bound.to_triton_code(large_config)
+        self.assertIsInstance(large_code, str)
 
     def test_jagged_tile_alignment_cap_specializes_symbolic_host_dim(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=False)
@@ -6179,10 +6255,15 @@ class TestPallas(TestCase):
         config = Config(pallas_loop_type="fori_loop")
         code = kernel_with_0d_arg.bind((x, scalar, y)).to_code(config)
 
-        self.assertIn(
-            "_block_spec_info=[((128, 128), (0, 1)), None, ((128, 128), (0, 1)), ((128, 128), (0, 1))]",
-            code,
-        )
+        match = re.search(r"_block_spec_info=(\[[^\]]*\])", code)
+        self.assertIsNotNone(match, "expected _block_spec_info in launcher call")
+        block_spec_info = ast.literal_eval(match.group(1))
+        tensor_block_spec = ((128, 128), (0, 1))
+        self.assertEqual(len(block_spec_info), 4)
+        self.assertEqual(block_spec_info[0], tensor_block_spec)
+        self.assertIsNone(block_spec_info[1])
+        self.assertEqual(block_spec_info[2], tensor_block_spec)
+        self.assertEqual(block_spec_info[3], tensor_block_spec)
 
 
 @skipUnlessPallas("JAX/Pallas TPU not available")


### PR DESCRIPTION
Stacked PRs:
 * #2936
 * #2935
 * __->__#2934
 * #2933
 * #2932
 * #2931
 * #2930
 * #2929
 * #2928
 * #2927
 * #2926
 * #2925
 * #2924
 * #2923
 * #2922
 * #2921
 * #2920
 * #2919
 * #2918
 * #2917


--- --- ---

### Honor Pallas shared-output BlockSpec metadata


No new example is flipped directly. Runtime shared-output planning now understands flattened ForEach `BlockSpec` decompositions, marks partially shared grid dimensions as arbitrary, and guards the initial in-place copy so only the owning logical program seeds a shared output tile.