### PR TITLE
Support integer tunables as symbolic extents

### DIFF
--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -766,6 +766,10 @@ class ReductionLowering(InductorLowering):
         env = CompileEnvironment.current()
         if isinstance(reduction_size, sympy.Symbol):
             block_index: int | None = env.get_block_id(reduction_size)
+            if block_index is None and reduction_size in env.tunable_symbols:
+                block_index = env.allocate_reduction_dimension(
+                    to_symint(reduction_size)
+                ).block_id
         elif isinstance(reduction_size, (int, sympy.Integer)):
             # Allocate or find a reduction dimension matching this size.
             # Convert to a SymInt when needed.

--- a/helion/language/tunable_ops.py
+++ b/helion/language/tunable_ops.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import sympy
 import torch
 from torch._inductor.codegen.simd import constant_repr
 from torch._inductor.runtime.runtime_utils import next_power_of_2
@@ -175,9 +176,19 @@ def _register_tunable_type(
     # register the value for tuning
     env.config_spec.user_defined_tunables[name_val] = fragment_val
 
-    python_type = type(fragment_val.default())
+    default = fragment_val.default()
+    python_type = type(default)
     if not issubclass(python_type, (int, float, bool)):
         raise exc.TunableTypeNotSupported(python_type)
+    if python_type is int:
+        from .._compiler.type_info import SymIntType
+
+        assert isinstance(default, int)
+        value = env.create_unbacked_symint(hint=default)
+        expr = value._sympy_()
+        if isinstance(expr, sympy.Symbol):
+            env.tunable_symbols[expr] = name_val
+        return SymIntType(origin, value)
     return NumericType.subtype(python_type).new_unbacked(origin)
 
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -26,6 +26,8 @@ from helion._testing import skipUnlessPallas
 from helion._testing import xfailIfPallas
 from helion._testing import xfailIfPallasInterpret
 from helion._testing import xfailIfPallasTpu
+from helion.autotuner import IntegerFragment
+from helion.autotuner import PowerOfTwoFragment
 import helion.language as hl
 
 if TYPE_CHECKING:
@@ -508,6 +510,25 @@ def pallas_reduce_non_pow2(x: torch.Tensor) -> torch.Tensor:
         max_val = torch.amax(row, dim=-1, keepdim=True)
         exp_val = torch.exp(row - max_val)
         out[tile_n, :] = exp_val / torch.sum(exp_val, dim=-1, keepdim=True)
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_integer_tunable_scale(x: torch.Tensor) -> torch.Tensor:
+    scale = hl.register_tunable("scale", IntegerFragment(1, 8, 3))
+    out = torch.empty_like(x)
+    for tile_m in hl.tile(x.size(0)):
+        out[tile_m] = x[tile_m] * scale
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_tunable_prefix_reduction(x: torch.Tensor) -> torch.Tensor:
+    width = hl.register_tunable("width", PowerOfTwoFragment(4, 16, 8))
+    tmp = torch.zeros([x.size(0), width], dtype=x.dtype, device=x.device)
+    out = torch.empty([x.size(0)], dtype=x.dtype, device=x.device)
+    for tile_m in hl.tile(x.size(0)):
+        out[tile_m] = torch.sum(tmp[tile_m, :] + x[tile_m, None], dim=-1)
     return out
 
 
@@ -3705,6 +3726,26 @@ class TestPallas(TestCase):
         code, result = code_and_output(pallas_reduce_non_pow2, (x,), block_size=128)
         expected = torch.nn.functional.softmax(x, dim=-1)
         torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
+
+    def test_integer_tunable_non_reduction(self) -> None:
+        x = torch.randn(32, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_integer_tunable_scale,
+            (x,),
+            block_size=8,
+            scale=5,
+        )
+        torch.testing.assert_close(result, x * 5)
+
+    def test_tunable_reduction_extent(self) -> None:
+        x = torch.randn(12, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_tunable_prefix_reduction,
+            (x,),
+            block_size=4,
+            width=8,
+        )
+        torch.testing.assert_close(result, x * 8)
 
     def test_scalar_access_1D_constexpr(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True, config=helion.Config())


### PR DESCRIPTION
Stacked PRs:
 * #2936
 * __->__#2935
 * #2934
 * #2933
 * #2932
 * #2931
 * #2930
 * #2929
 * #2928
 * #2927
 * #2926
 * #2925
 * #2924
 * #2923
 * #2922
 * #2921
 * #2920
 * #2919
 * #2918
 * #2917


--- --- ---

### Support integer tunables as symbolic extents


No user example is flipped directly. Integer `hl.register_tunable` values now propagate as SymInt-like symbolic values, and reduction lowering can allocate dimensions from tunable symbols, so tunables can safely size temporary tensors and reduction extents in Pallas kernels.