### PR TITLE
Support Pallas barrier phase launches

### DIFF
--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -1016,6 +1016,23 @@ class DeviceFunction:
         assert isinstance(call_statement, ExtendedAST)
         # Mark the kernel call so we can find it in codegen_precompile_def
         call_statement._is_kernel_call = True
+        phase_host_var = getattr(self.codegen, "_pallas_barrier_phase_host_var", None)
+        if (
+            env.backend.name == "pallas"
+            and env.has_barrier
+            and phase_host_var is not None
+            and len(self.codegen.host_function.device_ir.phases) > 1
+        ):
+            return create(
+                ast.For,
+                target=create(ast.Name, id=phase_host_var, ctx=ast.Store()),
+                iter=expr_from_string(
+                    f"range({len(self.codegen.host_function.device_ir.phases)})"
+                ),
+                body=[call_statement],
+                orelse=[],
+                type_comment=None,
+            )
         return call_statement
 
     def dead_code_elimination(self) -> None:

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -21,12 +21,14 @@ from .ast_extension import NodeVisitor
 from .ast_extension import create
 from .ast_extension import expr_from_string
 from .ast_extension import statement_from_string
+from .ast_read_writes import ReadWrites
 from .ast_read_writes import dead_assignment_elimination
 from .ast_read_writes import dead_expression_elimination
 from .ast_read_writes import definitely_does_not_have_side_effects
 from .compile_environment import CompileEnvironment
 from .device_function import ConstExprArg
 from .device_function import DeviceFunction
+from .device_function import SymbolArgument
 from .helper_function import CodegenInterface
 from .inductor_lowering import CodegenState
 from .inductor_lowering import codegen_call_with_graph
@@ -137,6 +139,24 @@ class GenerateAST(NodeVisitor, CodegenInterface):
             self,
         )
         CodegenInterface.__init__(self, self.device_function)
+        self._pallas_barrier_phase_arg: str | None = None
+        self._pallas_barrier_phase_host_var: str | None = None
+        if (
+            CompileEnvironment.current().backend.name == "pallas"
+            and len(func.device_ir.phases) > 1
+        ):
+            self._pallas_barrier_phase_arg = self.device_function.new_var(
+                "helion_phase"
+            )
+            self._pallas_barrier_phase_host_var = self.device_function.new_var(
+                "helion_phase_host"
+            )
+            self.device_function.arguments.append(
+                SymbolArgument(
+                    self._pallas_barrier_phase_arg,
+                    self._pallas_barrier_phase_host_var,
+                )
+            )
 
         # Decide once which sibling for-loops need a tl.debug_barrier()
         # to make global writes visible to subsequent reads.
@@ -159,6 +179,54 @@ class GenerateAST(NodeVisitor, CodegenInterface):
     def _phase_checker(self, root_id: int) -> LoopDependencyChecker:
         phase_idx = self.host_function.device_ir.phase_for_root(root_id)
         return self.host_function.device_ir.phases[phase_idx].loop_dependency_checker
+
+    def _wrap_pallas_barrier_phase_body(
+        self,
+        root_id: int,
+        body: list[ast.AST],
+    ) -> None:
+        """Guard each root body so one Pallas callable covers all barrier phases."""
+        if self._pallas_barrier_phase_arg is None:
+            return
+        phase = self.host_function.device_ir.phase_for_root(root_id)
+        fn_name = self.device_function.new_var(f"helion_phase_{phase}_root_{root_id}")
+        phase_body = list(body) or [create(ast.Pass)]
+        condition = f"({self._pallas_barrier_phase_arg} == {phase})"
+        pid = self.device_function.pid
+        if isinstance(pid, ForEachProgramID) and root_id < len(pid.cases):
+            cdivs = [case.total_pids_expr(is_device=True) for case in pid.cases]
+            start = "0" if root_id == 0 else " + ".join(cdivs[:root_id])
+            end = " + ".join(cdivs[: root_id + 1])
+            condition = (
+                f"({condition}) & ({pid.shared_pid_var} >= ({start})) "
+                f"& ({pid.shared_pid_var} < ({end}))"
+            )
+            if pid.shared_pid_var in ReadWrites.from_list(phase_body).writes:
+                phase_body = [
+                    create(ast.Nonlocal, names=[pid.shared_pid_var]),
+                    *phase_body,
+                ]
+        body[:] = [
+            create(
+                ast.FunctionDef,
+                name=fn_name,
+                args=create(
+                    ast.arguments,
+                    posonlyargs=[],
+                    args=[],
+                    vararg=None,
+                    kwonlyargs=[],
+                    kw_defaults=[],
+                    kwarg=None,
+                    defaults=[],
+                ),
+                body=phase_body,
+                decorator_list=[expr_from_string(f"pl.when({condition})")],
+                type_comment=None,
+                returns=None,
+                type_params=[],
+            )
+        ]
 
     def _compute_inter_loop_barriers(self) -> None:
         """Walk every codegen graph; for each pair of consecutive sibling
@@ -923,18 +991,23 @@ class GenerateAST(NodeVisitor, CodegenInterface):
             else:
                 assert len(self.host_function.device_ir.root_ids) > 1
                 # Multiple top level for loops
+                pallas_phase_launch = self._pallas_barrier_phase_arg is not None
 
                 if node._root_id == 0:
                     self.device_function.set_pid(
                         ForEachProgramID(
                             self.device_function.new_var("pid_shared", dce=False),
+                            pallas_host_phases=pallas_phase_launch,
                         )
                     )
                     self.device_function.body.extend(
                         # pyrefly: ignore [missing-attribute]
                         self.device_function.pid.codegen_pid_init()
                     )
-                if node._root_id < len(self.host_function.device_ir.root_ids) - 1:
+                if (
+                    pallas_phase_launch
+                    or node._root_id < len(self.host_function.device_ir.root_ids) - 1
+                ):
                     body = []
                 else:
                     # This is the last top level for, dont emit more if statements
@@ -1027,9 +1100,13 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                         self.host_function.device_ir.phase_for_root(node._root_id)
                     )
 
+                self._wrap_pallas_barrier_phase_body(node._root_id, body)
+
                 # If we are in a multi top level loop, for all loops except for the last one
                 # emit ifthenelse blocks
-                if node._root_id < len(self.host_function.device_ir.root_ids) - 1:
+                if self._pallas_barrier_phase_arg is not None:
+                    self.device_function.body.extend(body)
+                elif node._root_id < len(self.host_function.device_ir.root_ids) - 1:
                     block = (
                         self.device_function.body
                         if self.next_else_block is None
@@ -1300,7 +1377,9 @@ def generate_ast(
 ) -> ast.Module:
     with func:
         if len(func.device_ir.phases) > 1:
-            if not str(config.pid_type).startswith("persistent"):
+            if CompileEnvironment.current().backend.name != "pallas" and not str(
+                config.pid_type
+            ).startswith("persistent"):
                 raise exc.BarrierRequiresPersistent(config.pid_type)
         codegen = GenerateAST(
             func,

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -5,15 +5,35 @@ from __future__ import annotations
 import ast
 import math
 from typing import TYPE_CHECKING
+from typing import cast
 
+import sympy
 import torch
 
 from helion._compiler.ast_extension import expr_from_string
+from helion._compiler.backend import PallasBackend
+from helion._compiler.compile_environment import CompileEnvironment
+from helion._compiler.device_function import PallasMemorySpace
+from helion._compiler.host_function import HostFunction
+from helion._compiler.pallas.gather import emit_gather
+from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
+from helion._compiler.pallas.plan_tiling import ArbitrarySlicePattern
+from helion._compiler.pallas.plan_tiling import DimensionTiling
+from helion._compiler.pallas.plan_tiling import IndirectGatherPattern
+from helion._compiler.pallas.plan_tiling import IndirectScatterPattern
+from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
+from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
+from helion._compiler.pallas.plan_tiling import TilePattern
+from helion._compiler.tile_strategy import DeviceGridState
+from helion._compiler.tile_strategy import DeviceLoopState
+from helion._compiler.tile_strategy import EmitPipelineLoopState
+from helion._compiler.tile_strategy import ForiLoopState
 
 _FULL_LOAD_SELECT_MAX_BYTES = 256 << 10
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from typing import SupportsInt
 
     from helion._compiler.inductor_lowering import CodegenState
     from helion._compiler.tile_strategy import DeviceLoopOrGridState
@@ -88,8 +108,6 @@ def numeric_where_expr(
     layout_anchor: ast.AST | None = None,
 ) -> ast.AST | None:
     """Select with a layout-tied numeric bit mask on TPU."""
-
-    from helion._compiler.compile_environment import CompileEnvironment
 
     mask_dtype = _select_mask_dtype(output_dtype)
     if mask_dtype is None:
@@ -167,8 +185,6 @@ def load_expr(
     tensor: torch.Tensor,
 ) -> ast.AST:
     """Pallas load codegen: normal path, or indirect gather if ``plan_tiling`` flagged it."""
-    from helion._compiler.pallas.gather import emit_gather
-    from helion._compiler.pallas.plan_tiling import IndirectGatherPattern
 
     name = state.device_function.tensor_arg(tensor).name
     name = vmem_name(state, name)
@@ -230,17 +246,11 @@ def _widen_unaligned_tile_load_indices(
     if _tensor_routed_to_dma_scratch(state, tensor):
         return index_parts, []
 
-    from helion._compiler.device_function import PallasMemorySpace
-
     if (
         state.device_function.pallas_memory_space.get(id(tensor))
         == PallasMemorySpace.SMEM
     ):
         return index_parts, []
-
-    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
-    from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
-    from helion._compiler.pallas.plan_tiling import TilePattern
 
     adjusted = list(index_parts)
     takes: list[tuple[int, str]] = []
@@ -297,12 +307,6 @@ def _should_select_unaligned_tile_axis_from_full_load(
 
     if not index_part.startswith("pl.ds("):
         return False
-
-    from helion._compiler.backend import PallasBackend
-    from helion._compiler.compile_environment import CompileEnvironment
-    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
-    from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
-    from helion._compiler.pallas.plan_tiling import TilePattern
 
     assert isinstance(
         pattern, (TilePattern, TileIndexWithOffsetPattern, TileBeginWithOffsetPattern)
@@ -363,8 +367,6 @@ def _full_load_selection_budget_elements(
     if block_size <= 0:
         return None
 
-    from helion._compiler.compile_environment import CompileEnvironment
-
     assert state.fx_node is not None
     output_val = state.fx_node.meta.get("val")
     if not isinstance(output_val, torch.Tensor):
@@ -388,10 +390,6 @@ def _full_load_selection_budget_elements(
 
 
 def _tile_lane_index_expr(state: CodegenState, pattern: object) -> str:
-    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
-    from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
-    from helion._compiler.pallas.plan_tiling import TilePattern
-
     assert isinstance(
         pattern, (TilePattern, TileIndexWithOffsetPattern, TileBeginWithOffsetPattern)
     )
@@ -461,14 +459,11 @@ def _select_unaligned_tile_load_indices(
 
 
 def _pallas_dtype_str(tensor: torch.Tensor) -> str:
-    from helion._compiler.compile_environment import CompileEnvironment
-
     return CompileEnvironment.current().backend.dtype_str(tensor.dtype)
 
 
 def _indirect_gather_mask_expr(state: CodegenState, tensor: torch.Tensor) -> str | None:
     """Mask tensor-indexed gather outputs in their result layout."""
-    from helion._compiler.compile_environment import CompileEnvironment
 
     assert state.fx_node is not None
     output_val = state.fx_node.meta.get("val")
@@ -516,18 +511,11 @@ def _widen_small_aligned_scalar_load_indices(
     if _tensor_routed_to_dma_scratch(state, tensor):
         return index_parts, [], value_rank
 
-    from helion._compiler.device_function import PallasMemorySpace
-
     if (
         state.device_function.pallas_memory_space.get(id(tensor))
         == PallasMemorySpace.SMEM
     ):
         return index_parts, [], value_rank
-
-    from helion._compiler.backend import PallasBackend
-    from helion._compiler.compile_environment import CompileEnvironment
-    from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
-    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
 
     backend = CompileEnvironment.current().backend
     assert isinstance(backend, PallasBackend)
@@ -634,9 +622,168 @@ def _widened_scalar_load_promotion_dtype(
         return None
     if not _load_feeds_only_immediate_fp32_converts(state):
         return None
-    from helion._compiler.compile_environment import CompileEnvironment
 
     return CompileEnvironment.current().backend.dtype_str(torch.float32)
+
+
+def widen_barrier_temp_store_indices(
+    state: CodegenState,
+    tensor: torch.Tensor,
+    subscript: list[object] | tuple[object, ...],
+    index_parts: list[str],
+    value: ast.AST,
+    name: str,
+) -> tuple[list[str], ast.AST]:
+    """Store one scalar minor dim of a cross-phase temporary via a masked axis."""
+    if not _is_pallas_barrier_temp_store(state, tensor):
+        return index_parts, value
+    if _tensor_routed_to_dma_scratch(state, tensor):
+        return index_parts, value
+
+    if (
+        state.device_function.pallas_memory_space.get(id(tensor))
+        == PallasMemorySpace.SMEM
+    ):
+        return index_parts, value
+
+    patterns = _get_indexing_patterns(state, tensor)
+    if any(isinstance(pattern, IndirectScatterPattern) for pattern in patterns):
+        return index_parts, value
+
+    env = CompileEnvironment.current()
+    backend = env.backend
+    assert isinstance(backend, PallasBackend)
+
+    adjusted = list(index_parts)
+    widened: tuple[int, str, int] | None = None
+    value_dim = 0
+    tensor_dim = 0
+    index_part_idx = 0
+
+    for idx, pattern in zip(subscript, patterns, strict=True):
+        if idx is None:
+            continue
+
+        index_part = adjusted[index_part_idx]
+        dim_size = _concrete_barrier_temp_dim_size(state, tensor.shape[tensor_dim])
+        is_scalar = not _index_part_produces_value_dim(index_part)
+        can_widen = False
+        if is_scalar and dim_size is not None and dim_size > 0:
+            dim_from_end = tensor.ndim - tensor_dim - 1
+            required_alignment = backend._get_pallas_required_alignment(
+                dim_from_end,
+                tensor.ndim,
+                tensor.dtype.itemsize * 8,
+            )
+            can_widen = required_alignment > 1 and dim_size <= required_alignment
+            if can_widen:
+                index_part = _normalize_static_scalar_index(index_part, dim_size)
+                can_widen = index_part is not None
+
+        if can_widen:
+            if (
+                widened is not None
+                or tensor_dim != tensor.ndim - 1
+                or not isinstance(pattern, ArbitraryIndexPattern)
+            ):
+                return index_parts, value
+            adjusted[index_part_idx] = ":"
+            assert index_part is not None
+            assert dim_size is not None
+            widened = (value_dim, index_part, dim_size)
+            value_dim += 1
+        elif index_part is not None and _index_part_produces_value_dim(index_part):
+            value_dim += 1
+
+        tensor_dim += 1
+        index_part_idx += 1
+
+    if widened is None:
+        return index_parts, value
+
+    widened_elements = _store_value_numel(state)
+    axis, index_expr, dim_size = widened
+    widened_elements *= dim_size
+    if widened_elements * tensor.dtype.itemsize > _FULL_LOAD_SELECT_MAX_BYTES:
+        return index_parts, value
+
+    current = expr_from_string(f"{name}[{', '.join(adjusted)}]")
+    store_value = expr_from_string(
+        f"jnp.expand_dims({{value}}, axis={axis})",
+        value=value,
+    )
+
+    dtype_str = _pallas_dtype_str(tensor)
+    mask = (
+        f"(({index_expr}) == jnp.arange({dim_size}, dtype=jnp.int32))"
+        f".astype({dtype_str})"
+    )
+    for _ in range(axis):
+        mask = f"jnp.expand_dims({mask}, axis=0)"
+    for _ in range(value_dim - axis - 1):
+        mask = f"jnp.expand_dims({mask}, axis=-1)"
+    value = numeric_mask_select_expr(
+        expr_from_string(mask),
+        store_value,
+        current,
+        tensor.dtype,
+        store_value,
+    )
+    return adjusted, value
+
+
+def _is_pallas_barrier_temp_store(state: CodegenState, tensor: torch.Tensor) -> bool:
+    env = CompileEnvironment.current()
+    if not env.has_barrier or len(HostFunction.current().device_ir.phases) <= 1:
+        return False
+    input_storages = {id(t.untyped_storage()) for t in env.input_sources}
+    if id(tensor.untyped_storage()) in input_storages:
+        return False
+    origin = HostFunction.current().tensor_to_origin.get(tensor)
+    name = origin.root_rw_name() if origin is not None else None
+    if name is None:
+        return False
+    read_names, write_names = state.device_function.get_tensor_read_write_names()
+    return name in read_names and name in write_names
+
+
+def _concrete_barrier_temp_dim_size(state: CodegenState, dim: object) -> int | None:
+    if isinstance(dim, int):
+        return dim
+    if not isinstance(dim, torch.SymInt):
+        return None
+
+    env = CompileEnvironment.current()
+    expr = dim._sympy_()
+
+    if isinstance(expr, sympy.Symbol):
+        tunable_name = env.tunable_symbols.get(expr)
+        if tunable_name is not None:
+            value = state.config.get(tunable_name)
+            if isinstance(value, int):
+                return value
+    if not expr.free_symbols:
+        return int(cast("SupportsInt", expr))
+    if env.settings.static_shapes:
+        return env.size_hint(dim)
+    return None
+
+
+def _store_value_numel(state: CodegenState) -> int:
+    if state.fx_node is None or len(state.fx_node.args) < 3:
+        return 1
+    value_arg = state.fx_node.args[2]
+    if not isinstance(value_arg, torch.fx.Node):
+        return 1
+    value = value_arg.meta.get("val")
+    if not isinstance(value, torch.Tensor):
+        return 1
+    elements = 1
+    for size in value.shape:
+        if not isinstance(size, int):
+            return 1
+        elements *= size
+    return elements
 
 
 def _load_feeds_only_immediate_fp32_converts(state: CodegenState) -> bool:
@@ -667,10 +814,6 @@ def _pad_clamped_load_expr(
     value: ast.AST,
 ) -> ast.AST:
     """Pad BlockSpec-clamped Pallas loads back to their logical tile shape."""
-    from helion._compiler.compile_environment import CompileEnvironment
-    from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
-    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
-    from helion._compiler.pallas.plan_tiling import TilePattern
 
     if _tensor_routed_to_dma_scratch(state, tensor):
         return value
@@ -734,11 +877,6 @@ def _load_mask_expr(
     ref to the actual remainder are not masked — a block-sized mask would
     cause a shape mismatch against the smaller ref.
     """
-    from helion._compiler.compile_environment import CompileEnvironment
-    from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
-    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
-    from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
-    from helion._compiler.pallas.plan_tiling import TilePattern
 
     assert state.fx_node is not None
     output_val = state.fx_node.meta.get("val")
@@ -802,8 +940,6 @@ def _iter_dma_scratch_loops(
 ) -> Iterator[tuple[DeviceLoopOrGridState, str]]:
     """Yield ``(loop, scratch_ref_name)`` for every active loop that DMA-routes
     ``name`` through a VMEM scratch."""
-    from helion._compiler.tile_strategy import EmitPipelineLoopState
-    from helion._compiler.tile_strategy import ForiLoopState
 
     for loops in state.codegen.active_device_loops.values():
         for loop in loops:
@@ -866,8 +1002,6 @@ def sliced_value_for_store(
     VMEM scratch (not a clamped ref), so the value stays block-shaped and the
     writeback path clamps the HBM extent instead.
     """
-    from helion._compiler.compile_environment import CompileEnvironment
-    from helion._compiler.pallas.plan_tiling import TilePattern
 
     assert state.fx_node is not None
     patterns = state.fx_node.meta.get("indexing_patterns")
@@ -949,7 +1083,6 @@ def _can_tile_dimension(state: CodegenState, tensor_dim: int) -> bool:
     dim_tilings = state.device_function.pallas_tensor_dim_tilings.get(id(tensor_val))
     assert isinstance(dim_tilings, list)
     assert tensor_dim < len(dim_tilings)
-    from helion._compiler.pallas.plan_tiling import DimensionTiling
 
     assert isinstance(dim_tilings[tensor_dim], DimensionTiling)
     return dim_tilings[tensor_dim].can_tile
@@ -1064,13 +1197,6 @@ def _generated_index_code(
     dma_block_ids: set[int],
 ) -> str:
     """Generate index code based on the indexing pattern."""
-    from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
-    from helion._compiler.pallas.plan_tiling import ArbitrarySlicePattern
-    from helion._compiler.pallas.plan_tiling import IndirectGatherPattern
-    from helion._compiler.pallas.plan_tiling import IndirectScatterPattern
-    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
-    from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
-    from helion._compiler.pallas.plan_tiling import TilePattern
 
     if isinstance(pattern, TilePattern):
         return _tile_pattern_code(
@@ -1123,10 +1249,6 @@ def _tile_pattern_code(
     in_pipeline: bool,
     dma_block_ids: set[int],
 ) -> str:
-    from helion._compiler.pallas.plan_tiling import TilePattern
-    from helion._compiler.tile_strategy import DeviceLoopState
-    from helion._compiler.tile_strategy import EmitPipelineLoopState
-    from helion._compiler.tile_strategy import ForiLoopState
 
     assert isinstance(pattern, TilePattern)
 
@@ -1165,7 +1287,6 @@ def _tile_index_with_offset_pattern_code(
     in_pipeline: bool,
     dma_block_ids: set[int],
 ) -> str:
-    from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
 
     assert isinstance(pattern, TileIndexWithOffsetPattern)
 
@@ -1182,8 +1303,6 @@ def _tile_begin_with_offset_pattern_code(
     in_pipeline: bool,
     dma_block_ids: set[int],
 ) -> str:
-    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
-    from helion._compiler.tile_strategy import DeviceLoopState
 
     assert isinstance(pattern, TileBeginWithOffsetPattern)
 
@@ -1226,9 +1345,6 @@ def _slice_code(
     tensor: torch.Tensor,
     tensor_dim: int,
 ) -> str:
-    from helion._compiler.compile_environment import CompileEnvironment
-    from helion._compiler.pallas.plan_tiling import ArbitrarySlicePattern
-    from helion._compiler.tile_strategy import DeviceLoopState
 
     assert isinstance(pattern, ArbitrarySlicePattern)
     slice_idx = pattern.slice
@@ -1276,7 +1392,6 @@ def _is_compact_aligned_load(
     double-buffers the load's prefetch and the store's write-back), so the body
     accesses the whole sliced block at local offset 0.
     """
-    from helion._compiler.compile_environment import CompileEnvironment
 
     if tensor is None:
         return False
@@ -1346,8 +1461,6 @@ def _ds_expr(
             # jax-ml/jax@33c38f50b): only apply when the hint meets Mosaic's
             # requirement, otherwise it could replace a stronger proof Mosaic
             # already has.
-            from helion._compiler.backend import PallasBackend
-            from helion._compiler.compile_environment import CompileEnvironment
 
             backend = CompileEnvironment.current().backend
             assert isinstance(backend, PallasBackend)
@@ -1378,10 +1491,6 @@ def _bounded_local_owner_block_id(
     """Return the outer grid block that owns a bounded inner tile's BlockSpec."""
     if tensor is None or tensor_dim is None:
         return None
-
-    from helion._compiler.compile_environment import CompileEnvironment
-    from helion._compiler.device_function import PallasMemorySpace
-    from helion._compiler.tile_strategy import DeviceGridState
 
     if (
         state.device_function.pallas_memory_space.get(id(tensor))
@@ -1424,7 +1533,6 @@ def _loop_begin_extra_pad(block_id: int, state: CodegenState) -> int:
     loop starts at 0, ``begin % block_size`` for a provably constant begin,
     or ``block_size - 1`` for a data-dependent begin.
     """
-    import sympy
 
     bs_value = state.device_function.resolved_block_size(block_id)
     if not isinstance(bs_value, int):
@@ -1459,7 +1567,6 @@ def _loop_offset_alignment(
     A loop with step ``block_size`` produces offsets ``begin + i * block_size``.
     Returns a proven divisor of that offset expression when available.
     """
-    import sympy
 
     bs_value = state.device_function.resolved_block_size(block_id)
     if not isinstance(bs_value, int):
@@ -1490,9 +1597,6 @@ def _is_zero_begin_single_tile_dim(
     tensor_dim: int,
 ) -> bool:
     """True when a zero-begin loop has only one in-bounds concrete tensor tile."""
-    import sympy
-
-    from helion._compiler.compile_environment import CompileEnvironment
 
     bs_value = state.device_function.resolved_block_size(block_id)
     if not isinstance(bs_value, int):

--- a/helion/_compiler/pallas/gather.py
+++ b/helion/_compiler/pallas/gather.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING
 import torch
 
 from ..ast_extension import expr_from_string
+from ..compile_environment import CompileEnvironment
+from .plan_tiling import resident_block_elements
 
 if TYPE_CHECKING:
     from ...runtime.config import Config
@@ -55,8 +57,6 @@ def build_gather_plan(
     config: Config,
 ) -> GatherPlan:
     """Validate the gather site and return its plan. Runs during plan_tiling."""
-    from ..compile_environment import CompileEnvironment
-    from .plan_tiling import resident_block_elements
 
     if len(indirect_positions) > 1:
         raise NotImplementedError(
@@ -110,7 +110,6 @@ def build_scatter_plan(
     indirect_positions: list[int],
 ) -> ScatterPlan:
     """Validate a Pallas scatter site and return its one-hot plan."""
-    from ..compile_environment import CompileEnvironment
 
     if not tensor.dtype.is_floating_point:
         raise NotImplementedError(
@@ -298,7 +297,6 @@ def _scatter_source_mask_expr(
     plan: ScatterPlan,
 ) -> str | None:
     """Return a float mask for valid tensor-index source lanes."""
-    from ..compile_environment import CompileEnvironment
 
     subscript = state.proxy_arg(1)
     assert isinstance(subscript, (list, tuple))

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -13,11 +13,22 @@ from typing import TYPE_CHECKING
 import sympy
 import torch
 
+from helion._compiler.backend import PallasBackend
+from helion._compiler.compile_environment import CompileEnvironment
+from helion._compiler.compile_environment import _symint_expr
+from helion._compiler.device_function import DeviceFunction
+from helion._compiler.device_function import PallasMemorySpace
+from helion._compiler.host_function import HostFunction
+from helion._compiler.host_function import SymbolOrigin
+from helion._compiler.indexing_strategy import _get_tile_with_offset_info
+from helion._compiler.variable_origin import GridOrigin
+from helion._compiler.variable_origin import TileBeginOrigin
+from helion._compiler.variable_origin import TileEndOrigin
+from helion._compiler.variable_origin import TileIdOrigin
+
 if TYPE_CHECKING:
     from ...runtime.config import Config
-    from ..compile_environment import CompileEnvironment
     from ..device_ir import GraphInfo
-    from ..host_function import SymbolOrigin
     from ..tile_dispatch import TileStrategyDispatch
     from .gather import GatherPlan
     from .gather import ScatterPlan
@@ -153,8 +164,6 @@ def _analyze_indexing(node: torch.fx.Node, config: Config) -> None:
     tensor_val = tensor_arg.meta.get("val")
     assert isinstance(tensor_val, torch.Tensor)
 
-    from helion._compiler.device_function import DeviceFunction
-
     device_fn = DeviceFunction.current()
     if id(tensor_val) not in device_fn.pallas_tensor_dim_tilings:
         device_fn.pallas_tensor_dim_tilings[id(tensor_val)] = [
@@ -181,8 +190,6 @@ def _analyze_indexing(node: torch.fx.Node, config: Config) -> None:
     # mixed tensors in VMEM. This is correct for the common cases
     # (scalar-only → SMEM, mixed scalar-read + slice → VMEM) but
     # over-allocates SMEM for scalar-read-only tensors.
-    from ..device_function import PallasMemorySpace
-
     is_all_scalar = all(
         isinstance(p, (ArbitraryIndexPattern, TileBeginWithOffsetPattern, NonePattern))
         for p in indexing_patterns
@@ -211,7 +218,6 @@ def _analyze_subscript_patterns(
     config: Config,
 ) -> list[IndexingPattern]:
     """Analyze subscript patterns and create indexing pattern metadata."""
-    from ..compile_environment import CompileEnvironment
 
     env = CompileEnvironment.current()
     patterns: list[IndexingPattern] = []
@@ -249,8 +255,6 @@ def _detect_indexing_pattern(
     env: CompileEnvironment,
 ) -> IndexingPattern:
     """Detect the specific indexing pattern for a subscript element."""
-    from ..indexing_strategy import _get_tile_with_offset_info
-    from ..variable_origin import GridOrigin
 
     if isinstance(idx, torch.fx.Node):
         idx_val = idx.meta.get("val")
@@ -361,10 +365,7 @@ def _update_tiling_decision(
     if isinstance(pattern, (TilePattern, TileBeginWithOffsetPattern)):
         block_size = env.block_sizes[pattern.block_id].from_config(config)
         if isinstance(block_size, int):
-            from ..compile_environment import CompileEnvironment
-
             backend = CompileEnvironment.current().backend
-            from helion._compiler.backend import PallasBackend
 
             assert isinstance(backend, PallasBackend)
 
@@ -399,7 +400,6 @@ def resident_block_elements(
 
     Returns ``None`` if any consumed dim is symbolic.
     """
-    from ..compile_environment import CompileEnvironment
 
     env = CompileEnvironment.current()
     elements = 1
@@ -472,8 +472,6 @@ def _resolve_tensor_index_patterns(
 # Helper functions moved from memory_ops.py
 def _maybe_get_symbol_origin(idx: object) -> SymbolOrigin | None:
     """Get symbol origin for a subscript element."""
-    from ..compile_environment import _symint_expr
-    from ..host_function import HostFunction
 
     if not isinstance(idx, torch.SymInt):
         return None
@@ -492,14 +490,6 @@ def _maybe_get_tile_begin_with_offset_info(
     full loop extent (e.g. ``tile.begin``, ``tile.end - 1``, or affine
     combinations of those with integer constants).
     """
-    from ..compile_environment import CompileEnvironment
-    from ..compile_environment import _symint_expr
-    from ..host_function import HostFunction
-    from ..host_function import SymbolOrigin
-    from ..variable_origin import GridOrigin
-    from ..variable_origin import TileBeginOrigin
-    from ..variable_origin import TileEndOrigin
-    from ..variable_origin import TileIdOrigin
 
     idx_symbol_origin = _maybe_get_symbol_origin(idx)
     if isinstance(idx_symbol_origin, SymbolOrigin):

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -323,8 +323,14 @@ class ForEachProgramID(ProgramIDs):
     shared_pid_var: str
     cases: list[ProgramIDs] = dataclasses.field(default_factory=list)
     case_phases: list[int] = dataclasses.field(default_factory=list)
+    pallas_host_phases: bool = False
     pid_info: list[PIDInfo] = dataclasses.field(default_factory=list, init=False)
     barrier_after_root: set[int] = dataclasses.field(default_factory=set)
+
+    def _uses_pallas_host_phases(self) -> bool:
+        return CompileEnvironment.current().backend.name == "pallas" and (
+            self.pallas_host_phases or len(set(self.case_phases)) > 1
+        )
 
     def codegen_pid_init(self) -> list[ast.stmt]:
         # Check if persistent kernels are enabled in config - if so, skip regular initialization
@@ -333,7 +339,11 @@ class ForEachProgramID(ProgramIDs):
 
         current_device_fn = DeviceFunction.current()
         pid_type = current_device_fn.config.get("pid_type", "flat")
-        if isinstance(pid_type, str) and pid_type.startswith("persistent"):
+        if (
+            isinstance(pid_type, str)
+            and pid_type.startswith("persistent")
+            and not self._uses_pallas_host_phases()
+        ):
             return []
         return [statement_from_string(f"{self.shared_pid_var} = {typed_program_id(0)}")]
 
@@ -359,6 +369,8 @@ class ForEachProgramID(ProgramIDs):
         total_expr = self.total_pids_expr(is_device=True)
         # If there is only one phase, fall back to existing behavior.
         has_phases = len(set(self.case_phases)) > 1
+        if has_phases and CompileEnvironment.current().backend.name == "pallas":
+            return None
 
         def _base_strategy(pid: ProgramIDs) -> ProgramIDs:
             from .tile_strategy import L2GroupingProgramIDs
@@ -406,7 +418,7 @@ class ForEachProgramID(ProgramIDs):
 
     def codegen_grid(self) -> ast.AST:
         # Check if any of the pids is a persistent strategy
-        if self.cases[0]._is_persistent():
+        if self.cases[0]._is_persistent() and not self._uses_pallas_host_phases():
             # Use SM count grid for persistent kernels
             return self.cases[0].codegen_grid()
 

--- a/helion/language/barrier.py
+++ b/helion/language/barrier.py
@@ -57,6 +57,12 @@ def _(state: CodegenState) -> object:
     return expr_from_string("None")
 
 
+@_decorators.codegen(barrier, "pallas")
+def _(state: CodegenState) -> object:
+    # Pallas uses host-side multi-launch phase splitting for grid barriers.
+    return expr_from_string("None")
+
+
 @_decorators.ref(barrier)
 def _() -> None:
     # No-op in ref/interpret mode

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -354,6 +354,9 @@ def _(state: CodegenState) -> None:
     value = pallas_codegen.sliced_value_for_store(
         state, tensor, subscript, parts, value
     )
+    parts, value = pallas_codegen.widen_barrier_temp_store_indices(
+        state, tensor, subscript, parts, value, name
+    )
     idx_str = ", ".join(parts)
     patterns = state.fx_node.meta.get("indexing_patterns") if state.fx_node else ()
     from .._compiler.pallas.gather import emit_scatter_store

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -410,6 +410,7 @@ _PallasFlatCopyGuard = tuple[int, int, int, tuple[tuple[int, int], ...]]
 _PallasCopyGuard = tuple[tuple[int, ...], tuple[_PallasFlatCopyGuard, ...]]
 _PallasCopyGuards = dict[int, _PallasCopyGuard]
 _PallasDimensionSemantic = Literal["parallel", "arbitrary"]
+_PallasPhaseCaseMetadata = tuple[int, tuple[tuple[int, int, int], ...]]
 
 
 def _pallas_tensor_pos_map(
@@ -1152,13 +1153,45 @@ def _pallas_inplace_copy(in_ref: object, out_ref: object, *, is_smem: bool) -> N
         out_ref[...] = in_ref[...]  # type: ignore[index]
 
 
-def _pallas_copy_guard(guard: _PallasCopyGuard) -> bool | jax.Array:
+def _pallas_phase_case_leader_guard(
+    metadata: _PallasPhaseCaseMetadata,
+    refs: tuple[object, ...],
+    arg_to_tensor_pos: dict[int, int],
+) -> bool | jax.Array:
+    from jax.experimental import pallas as pl
+
+    phase_arg_index, case_ranges = metadata
+    phase_ref_pos = arg_to_tensor_pos.get(phase_arg_index)
+    if phase_ref_pos is None:
+        raise RuntimeError("Pallas phase argument is missing from tensor refs")
+    phase_value = refs[phase_ref_pos][0]  # type: ignore[index]
+    pid0 = pl.program_id(0)
+    is_leader = False
+    for phase, start, _end in case_ranges:
+        is_leader = is_leader | ((phase_value == phase) & (pid0 == start))
+    return is_leader
+
+
+def _pallas_copy_guard(
+    guard: _PallasCopyGuard,
+    phase_case_metadata: _PallasPhaseCaseMetadata | None,
+    refs: tuple[object, ...],
+    arg_to_tensor_pos: dict[int, int],
+) -> bool | jax.Array:
     from jax.experimental import pallas as pl
 
     direct_dims, flat_guards = guard
     should_copy = True
+    phase_leader_guard = None
     for dim in direct_dims:
-        should_copy = should_copy & (pl.program_id(dim) == 0)
+        if dim == 0 and phase_case_metadata is not None:
+            if phase_leader_guard is None:
+                phase_leader_guard = _pallas_phase_case_leader_guard(
+                    phase_case_metadata, refs, arg_to_tensor_pos
+                )
+            should_copy = should_copy & phase_leader_guard
+        else:
+            should_copy = should_copy & (pl.program_id(dim) == 0)
     for dim, start, total, used_dims in flat_guards:
         local_pid = pl.program_id(dim) - start
         rebuilt_pid = 0
@@ -1175,6 +1208,28 @@ def _pallas_copy_guard(guard: _PallasCopyGuard) -> bool | jax.Array:
     return should_copy
 
 
+def _pallas_phase_case_guard(
+    metadata: _PallasPhaseCaseMetadata | None,
+    refs: tuple[object, ...],
+    arg_to_tensor_pos: dict[int, int],
+) -> bool | jax.Array | None:
+    if metadata is None:
+        return None
+
+    from jax.experimental import pallas as pl
+
+    phase_arg_index, case_ranges = metadata
+    phase_ref_pos = arg_to_tensor_pos.get(phase_arg_index)
+    if phase_ref_pos is None:
+        raise RuntimeError("Pallas phase argument is missing from tensor refs")
+    phase_value = refs[phase_ref_pos][0]  # type: ignore[index]
+    pid0 = pl.program_id(0)
+    active = False
+    for phase, start, end in case_ranges:
+        active = active | ((phase_value == phase) & (pid0 >= start) & (pid0 < end))
+    return active
+
+
 def _pallas_make_reordered_kernel(
     pallas_kernel: object,
     args: tuple[object, ...],
@@ -1188,6 +1243,7 @@ def _pallas_make_reordered_kernel(
     skip_inplace_copy: set[int] | None = None,
     _smem_arg_indices: list[int] | None = None,
     _copy_guards: _PallasCopyGuards | None = None,
+    _phase_case_metadata: _PallasPhaseCaseMetadata | None = None,
 ) -> object:
     """Create a wrapper kernel that reorders pallas_call refs to the original arg order.
 
@@ -1211,6 +1267,9 @@ def _pallas_make_reordered_kernel(
     def reordered_kernel(*refs: object) -> None:
         from jax.experimental import pallas as pl
 
+        active_guard = _pallas_phase_case_guard(
+            _phase_case_metadata, refs, arg_to_tensor_pos
+        )
         n_kernel_params = len(args)
         original_order: list[object] = [None] * n_kernel_params
         for tensor_pos, orig_pos in enumerate(tensor_arg_indices):
@@ -1225,8 +1284,18 @@ def _pallas_make_reordered_kernel(
                     _smem_arg_indices is not None and orig_pos in _smem_arg_indices
                 )
                 copy_guard_dims = copy_guards.get(orig_pos)
+                should_copy = active_guard
                 if copy_guard_dims:
-                    should_copy = _pallas_copy_guard(copy_guard_dims)
+                    dims_guard = _pallas_copy_guard(
+                        copy_guard_dims,
+                        _phase_case_metadata,
+                        refs,
+                        arg_to_tensor_pos,
+                    )
+                    should_copy = (
+                        dims_guard if should_copy is None else should_copy & dims_guard
+                    )
+                if should_copy is not None:
 
                     @pl.when(should_copy)
                     def _copy_inplace_output(
@@ -1240,7 +1309,17 @@ def _pallas_make_reordered_kernel(
                     _pallas_inplace_copy(in_ref, out_ref, is_smem=is_smem)
             original_order[orig_pos] = out_ref
         extra_refs = refs[n_tensor_inputs + len(_output_indices) :]
-        pallas_kernel(*original_order, *extra_refs)  # type: ignore[operator]
+        if active_guard is not None:
+
+            @pl.when(active_guard)
+            def _run_active_phase_case(
+                original_order: list[object] = original_order,
+                extra_refs: tuple[object, ...] = extra_refs,
+            ) -> None:
+                pallas_kernel(*original_order, *extra_refs)  # type: ignore[operator]
+
+        else:
+            pallas_kernel(*original_order, *extra_refs)  # type: ignore[operator]
 
     return reordered_kernel
 
@@ -1547,6 +1626,7 @@ def _pallas_compile_jit_fn(
     _scratch_shapes: list[object] | None,
     _pipeline_arg_indices: list[int] | None,
     _matmul_dot_general: dict[str, object] | None,
+    _pallas_phase_case_metadata: _PallasPhaseCaseMetadata | None,
     interpret: bool,
     _pallas_arbitrary_grid_dims: tuple[int, ...] | None = None,
 ) -> _PallasCompileResult:
@@ -1650,6 +1730,7 @@ def _pallas_compile_jit_fn(
         skip_inplace_copy=skip_inplace_copy,
         _smem_arg_indices=_smem_arg_indices,
         _copy_guards=copy_guards,
+        _phase_case_metadata=_pallas_phase_case_metadata,
     )
 
     out_shape_arg = out_shapes if len(out_shapes) > 1 else out_shapes[0]
@@ -1733,6 +1814,7 @@ def _pallas_install_launcher_cache(
     _ds_pad_dims: list[tuple[int, int, int, int]] | None,
     _pallas_interpret: bool | None,
     _matmul_dot_general: dict[str, object] | None = None,
+    _pallas_phase_case_metadata: _PallasPhaseCaseMetadata | None = None,
     _pallas_arbitrary_grid_dims: tuple[int, ...] | None = None,
 ) -> tuple[object, ...]:
     """Cache-miss path shared by all three torch-tensor Pallas launchers.
@@ -1773,6 +1855,7 @@ def _pallas_install_launcher_cache(
         _scratch_shapes=_scratch_shapes,
         _pipeline_arg_indices=_pipeline_arg_indices,
         _matmul_dot_general=_matmul_dot_general,
+        _pallas_phase_case_metadata=_pallas_phase_case_metadata,
         interpret=interpret,
         _pallas_arbitrary_grid_dims=_pallas_arbitrary_grid_dims,
     )
@@ -1861,6 +1944,7 @@ def default_pallas_launcher(
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _pallas_interpret: bool | None = None,
     _matmul_dot_general: dict[str, object] | None = None,
+    _pallas_phase_case_metadata: _PallasPhaseCaseMetadata | None = None,
     _pallas_arbitrary_grid_dims: tuple[int, ...] | None = None,
     **kwargs: object,
 ) -> object:
@@ -1894,6 +1978,7 @@ def default_pallas_launcher(
             _ds_pad_dims=_ds_pad_dims,
             _pallas_interpret=_pallas_interpret,
             _matmul_dot_general=_matmul_dot_general,
+            _pallas_phase_case_metadata=_pallas_phase_case_metadata,
             _pallas_arbitrary_grid_dims=_pallas_arbitrary_grid_dims,
         )
 
@@ -1919,6 +2004,7 @@ def default_pallas_pipeline_launcher(
     _smem_arg_indices: list[int] | None = None,
     _pallas_interpret: bool | None = None,
     _matmul_dot_general: dict[str, object] | None = None,
+    _pallas_phase_case_metadata: _PallasPhaseCaseMetadata | None = None,
     _pallas_arbitrary_grid_dims: tuple[int, ...] | None = None,
     **kwargs: object,
 ) -> object:
@@ -1946,6 +2032,7 @@ def default_pallas_pipeline_launcher(
             _ds_pad_dims=_ds_pad_dims,
             _pallas_interpret=_pallas_interpret,
             _matmul_dot_general=_matmul_dot_general,
+            _pallas_phase_case_metadata=_pallas_phase_case_metadata,
             _pallas_arbitrary_grid_dims=_pallas_arbitrary_grid_dims,
         )
 
@@ -1969,6 +2056,7 @@ def default_pallas_fori_launcher(
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _smem_arg_indices: list[int] | None = None,
     _pallas_interpret: bool | None = None,
+    _pallas_phase_case_metadata: _PallasPhaseCaseMetadata | None = None,
     _pallas_arbitrary_grid_dims: tuple[int, ...] | None = None,
     **kwargs: object,
 ) -> object:
@@ -1999,6 +2087,7 @@ def default_pallas_fori_launcher(
             ),
             _ds_pad_dims=_ds_pad_dims,
             _pallas_interpret=_pallas_interpret,
+            _pallas_phase_case_metadata=_pallas_phase_case_metadata,
             _pallas_arbitrary_grid_dims=_pallas_arbitrary_grid_dims,
         )
 

--- a/helion/runtime/pallas_jax_export.py
+++ b/helion/runtime/pallas_jax_export.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
 
     from . import _BlockSpecInfo
     from . import _PallasLoopKind
+    from . import _PallasPhaseCaseMetadata
     from .kernel import Kernel
 
 
@@ -264,6 +265,7 @@ def default_pallas_jax_launcher(
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _smem_arg_indices: list[int] | None = None,
     _pallas_interpret: bool | None = None,
+    _pallas_phase_case_metadata: _PallasPhaseCaseMetadata | None = None,
     _pallas_arbitrary_grid_dims: tuple[int, ...] | None = None,
     _kind: _PallasLoopKind | None = None,
     **kwargs: object,
@@ -357,6 +359,7 @@ def default_pallas_jax_launcher(
             _scratch_shapes=_scratch_shapes,
             _pipeline_arg_indices=_pipeline_arg_indices,
             _matmul_dot_general=None,
+            _pallas_phase_case_metadata=_pallas_phase_case_metadata,
             interpret=interpret,
             _pallas_arbitrary_grid_dims=_pallas_arbitrary_grid_dims,
         )

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -28,6 +28,7 @@ from helion._testing import onlyBackends
 from helion._testing import skipIfA10G
 from helion._testing import skipIfCudaCapabilityLessThan
 from helion._testing import skipIfCudaSharedMemoryLessThan
+from helion._testing import skipIfCute
 from helion._testing import skipIfFn
 from helion._testing import skipIfNotCUDA
 from helion._testing import skipIfPallas
@@ -186,7 +187,8 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[64, 64, 32],
         )
 
-    @xfailIfPallas("missing barrier implementation")
+    @xfailIfPallasInterpret("barrier phase launches require TPU Pallas runtime")
+    @skipIfCute("split-K barrier config is Triton/Pallas-specific")
     @skipIfTileIR("PassManager::run failed")
     @skipIfXPU("Split-K barrier not supported on XPU backend")
     def test_split_k_barrier(self):
@@ -205,7 +207,8 @@ class TestExamples(RefEagerTestBase, TestCase):
             split_k=64,
         )
 
-    @xfailIfPallas("missing barrier implementation")
+    @xfailIfPallasInterpret("barrier phase launches require TPU Pallas runtime")
+    @skipIfCute("split-K barrier config is Triton/Pallas-specific")
     @skipIfTileIR("PassManager::run failed")
     @skipIfRefEager("Test requires compiled kernel with specific config")
     def test_split_k_barrier_accuracy(self):

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -9,6 +9,7 @@ from typing import Any
 from typing import Callable
 from typing import cast
 import unittest
+from unittest.mock import patch
 
 from examples.geglu import _geglu_pallas as _geglu_pallas_example
 from examples.swiglu import _swiglu_fwd_pallas as _swiglu_fwd_pallas_example
@@ -17,6 +18,7 @@ from torch.testing._internal.common_utils import instantiate_parametrized_tests
 from torch.testing._internal.common_utils import parametrize
 
 import helion
+from helion._compiler.backend import PallasBackend
 from helion._testing import DEVICE
 from helion._testing import TestCase
 from helion._testing import code_and_output
@@ -529,6 +531,24 @@ def pallas_tunable_prefix_reduction(x: torch.Tensor) -> torch.Tensor:
     out = torch.empty([x.size(0)], dtype=x.dtype, device=x.device)
     for tile_m in hl.tile(x.size(0)):
         out[tile_m] = torch.sum(tmp[tile_m, :] + x[tile_m, None], dim=-1)
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_barrier_scalar_minor_temp(x: torch.Tensor) -> torch.Tensor:
+    m = x.size(0)
+    n = hl.specialize(x.size(1))
+    width = hl.register_tunable("width", PowerOfTwoFragment(4, 16, 8))
+    tmp = torch.zeros([m, n, width], dtype=x.dtype, device=x.device)
+    out = torch.empty_like(x)
+
+    for tile_m, tile_w in hl.tile([m, width], block_size=[None, 1]):
+        tmp[tile_m, :, tile_w.id] = x[tile_m, :] + tile_w.id
+
+    hl.barrier()
+
+    for tile_m in hl.tile(m, block_size=4):
+        out[tile_m, :] = torch.sum(tmp[tile_m, :, :], dim=-1)
     return out
 
 
@@ -3746,6 +3766,45 @@ class TestPallas(TestCase):
             width=8,
         )
         torch.testing.assert_close(result, x * 8)
+
+    def test_barrier_phase_codegen_initializes_shared_pid_for_persistent_phase_launch(
+        self,
+    ) -> None:
+        original_supports_config_key = PallasBackend.supports_config_key
+
+        def supports_pid_type(backend: PallasBackend, key: str) -> bool:
+            return key == "pid_type" or original_supports_config_key(backend, key)
+
+        x = torch.empty((17, 128), dtype=torch.float32)
+        config = helion.Config(
+            block_sizes=[16],
+            pid_type="persistent_blocked",
+            width=8,
+        )
+        with patch.object(PallasBackend, "supports_config_key", supports_pid_type):
+            code = pallas_barrier_scalar_minor_temp.bind((x,)).to_code(config)
+
+        init = "pid_shared = pl.program_id(0)"
+        self.assertIn(init, code)
+        self.assertLess(code.index(init), code.index("@pl.when"))
+
+    @xfailIfPallasInterpret("barrier phase launches require TPU Pallas runtime")
+    def test_barrier_scalar_minor_temp_repeated_calls(self) -> None:
+        width = 8
+        config = helion.Config(
+            block_sizes=[16],
+            pid_type="persistent_blocked",
+            width=width,
+        )
+        x0 = torch.randn(17, 128, device=DEVICE, dtype=torch.float32)
+        compiled = pallas_barrier_scalar_minor_temp.bind((x0,)).compile_config(config)
+
+        for seed in range(3):
+            torch.manual_seed(seed)
+            x = torch.randn(17, 128, device=DEVICE, dtype=torch.float32)
+            result = compiled(x)
+            expected = x * width + (width * (width - 1) // 2)
+            torch.testing.assert_close(result, expected)
 
     def test_scalar_access_1D_constexpr(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True, config=helion.Config())


### PR DESCRIPTION
Stacked PRs:
 * __->__#2936
 * #2935
 * #2934
 * #2933
 * #2932
 * #2931
 * #2930
 * #2929
 * #2928
 * #2927
 * #2926
 * #2925
 * #2924
 * #2923
 * #2922
 * #2921
 * #2920
 * #2919
 * #2918
 * #2917


--- --- ---

### Support Pallas barrier phase launches


This enables Pallas `split_k_barrier` coverage. Barriers lower as host-side phase relaunches: codegen adds a phase scalar argument, wraps each root body in `pl.when` guards, runtime passes phase and case metadata into `pallas_call`, and shared-output copy guards use phase leaders so cross-phase temporaries survive repeated launches.

Persistent phase kernels also mark host-phase intent before PID initialization, so `pid_shared = pl.program_id(0)` is emitted before any phase predicate can reference the shared program id.