### PR TITLE
Fix Pyrefly constexpr signal calls

### DIFF
--- a/examples/distributed/all_gather_matmul.py
+++ b/examples/distributed/all_gather_matmul.py
@@ -31,6 +31,7 @@ from helion.runtime.triton_helpers import triton_wait_signal
 
 @triton.jit
 def _wait_progress_at_idx(progress: tl.tensor, idx: int) -> None:
+    # pyrefly: ignore[bad-argument-type]
     triton_wait_signal(progress + idx, 1, 0, "acquire", "gpu", "ld", False)
 
 

--- a/examples/distributed/fp8_scaled_all_gather_matmul.py
+++ b/examples/distributed/fp8_scaled_all_gather_matmul.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 
 @triton.jit
 def _wait_progress_at_idx(progress: tl.tensor, idx: int) -> None:
+    # pyrefly: ignore[bad-argument-type]
     triton_wait_signal(progress + idx, 1, 0, "acquire", "gpu", "ld", False)
 
 

--- a/helion/runtime/dist_utils.py
+++ b/helion/runtime/dist_utils.py
@@ -154,8 +154,14 @@ def _symm_mem_sync_cuda(
         tl.debug_barrier()
 
     if flat_tid < world_size:
-        _send_signal(send_addrs, "release" if hasPreviousMemAccess else "relaxed")
-        _wait_signal(wait_addrs, "acquire" if hasSubsequentMemAccess else "relaxed")
+        if hasPreviousMemAccess:
+            _send_signal(send_addrs, "release")  # pyrefly: ignore[bad-argument-type]
+        else:
+            _send_signal(send_addrs, "relaxed")  # pyrefly: ignore[bad-argument-type]
+        if hasSubsequentMemAccess:
+            _wait_signal(wait_addrs, "acquire")  # pyrefly: ignore[bad-argument-type]
+        else:
+            _wait_signal(wait_addrs, "relaxed")  # pyrefly: ignore[bad-argument-type]
 
     if hasSubsequentMemAccess:
         tl.debug_barrier()


### PR DESCRIPTION
Stacked PRs:
 * #2957
 * #2956
 * #2955
 * #2954
 * #2953
 * #2952
 * #2951
 * #2950
 * #2949
 * #2948
 * #2947
 * #2946
 * #2945
 * #2944
 * #2943
 * #2942
 * #2941
 * #2940
 * #2939
 * #2938
 * __->__#2937

--- --- ---

### Fix Pyrefly constexpr signal calls

Example fixed: No example is directly enabled by this PR.

Compiler side: this moves the Pyrefly suppressions for Triton `tl.constexpr` signal-call wrappers to the start of the stack. Triton treats those JIT-time arguments as constexpr values, while Pyrefly checks the Python call surface before Triton specializes it. Keeping the suppression next to the wrapper calls lets the later compiler and example PRs pass full-project lint without weakening runtime behavior.

Why needed: several later PRs rely on a clean lint baseline. Without this ordering fix, early stack PRs fail before reviewers reach the Pallas changes they are meant to evaluate.
