### PR TITLE
Support Pallas BlockSpec indexing metadata

### DIFF
--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -259,6 +259,8 @@ class CompileEnvironment:
     No config or codegen specific state should be stored here.
     """
 
+    tunable_symbols: dict[sympy.Symbol, str]
+
     def __init__(
         self,
         device: torch.device,
@@ -363,6 +365,7 @@ class CompileEnvironment:
         self._foreign_symint_cache: dict[
             tuple[int, sympy.Expr], int | torch.SymInt
         ] = {}
+        self.tunable_symbols = {}
         # The distributed restriction is deferred to
         # restrict_pid_types_for_persistent() so it can gate on a real per-kernel
         # signal after tracing rather than the process-global dist.is_initialized().

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -13,6 +13,7 @@ from typing import Any
 from typing import Callable
 from typing import cast
 
+import sympy
 import torch
 
 from ... import exc
@@ -24,7 +25,6 @@ from ..backend import dedupe_preserve_order
 from ..backend import read_launcher_source
 
 if TYPE_CHECKING:
-    import sympy
     from torch._inductor.ops_handler import OpsHandler
 
     from ...autotuner.config_fragment import ConfigSpecFragment
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from ..device_function import Argument
     from ..device_ir import GraphInfo
     from ..host_function import HostFunction
+    from ..program_id import PIDInfo
     from ..tile_dispatch import TileStrategyDispatch
     from .compact_worklist import CompactWorklistPlan
 
@@ -88,6 +89,176 @@ def _embed_source(source: str) -> str:
         if idx not in doc_lines and not line.strip().startswith("from __future__")
     ]
     return "\n".join(kept).strip("\n")
+
+
+@dataclasses.dataclass(frozen=True)
+class _PallasLaunchExpr:
+    code: str
+
+
+_PallasLaunchScalar = int | _PallasLaunchExpr
+_PallasLaunchValue = _PallasLaunchScalar | None
+_PallasFlatDecompValue = (
+    _PallasLaunchValue
+    | tuple[_PallasLaunchScalar, _PallasLaunchScalar, _PallasLaunchScalar]
+    | tuple[
+        _PallasLaunchScalar,
+        _PallasLaunchScalar,
+        _PallasLaunchScalar,
+        _PallasLaunchScalar,
+    ]
+)
+_PallasBlockSpecInfo = list[
+    tuple[tuple[_PallasLaunchValue, ...], tuple[_PallasFlatDecompValue, ...]] | None
+]
+
+
+def _format_pallas_launch_value(value: object) -> str:
+    if isinstance(value, _PallasLaunchExpr):
+        return value.code
+    if isinstance(value, tuple):
+        trailing = "," if len(value) == 1 else ""
+        return (
+            "("
+            + ", ".join(_format_pallas_launch_value(item) for item in value)
+            + trailing
+            + ")"
+        )
+    if isinstance(value, list):
+        return (
+            "[" + ", ".join(_format_pallas_launch_value(item) for item in value) + "]"
+        )
+    return repr(value)
+
+
+def _pallas_launch_code(value: _PallasLaunchScalar) -> str:
+    if isinstance(value, _PallasLaunchExpr):
+        return value.code
+    return repr(value)
+
+
+def _pallas_mul_launch_values(
+    lhs: _PallasLaunchScalar, rhs: _PallasLaunchScalar
+) -> _PallasLaunchScalar:
+    if isinstance(lhs, int) and isinstance(rhs, int):
+        return lhs * rhs
+    if lhs == 1:
+        return rhs
+    if rhs == 1:
+        return lhs
+    return _PallasLaunchExpr(
+        f"({_pallas_launch_code(lhs)}) * ({_pallas_launch_code(rhs)})"
+    )
+
+
+def _pallas_add_launch_values(
+    lhs: _PallasLaunchScalar, rhs: _PallasLaunchScalar
+) -> _PallasLaunchScalar:
+    if isinstance(lhs, int) and isinstance(rhs, int):
+        return lhs + rhs
+    if lhs == 0:
+        return rhs
+    if rhs == 0:
+        return lhs
+    return _PallasLaunchExpr(
+        f"({_pallas_launch_code(lhs)}) + ({_pallas_launch_code(rhs)})"
+    )
+
+
+def _pallas_safe_launch_radix(value: _PallasLaunchScalar) -> _PallasLaunchScalar:
+    """Clamp a flattened-grid radix to one without changing its case size."""
+    if isinstance(value, int):
+        return max(value, 1)
+    return _PallasLaunchExpr(f"max({_pallas_launch_code(value)}, 1)")
+
+
+def _pallas_cdiv_launch_values(
+    numerator: _PallasLaunchScalar, denominator: _PallasLaunchScalar
+) -> _PallasLaunchScalar:
+    if isinstance(numerator, int) and isinstance(denominator, int):
+        return -(-numerator // denominator)
+    n_code = _pallas_launch_code(numerator)
+    d_code = _pallas_launch_code(denominator)
+    return _PallasLaunchExpr(f"(({n_code}) + ({d_code}) - 1) // ({d_code})")
+
+
+def _pallas_host_launch_value(
+    value: int | torch.SymInt | sympy.Expr,
+    config: Config,
+) -> _PallasLaunchScalar:
+    if isinstance(value, int):
+        return value
+
+    from ..compile_environment import CompileEnvironment
+    from ..host_function import HostFunction
+
+    env = CompileEnvironment.current()
+    expr = value._sympy_() if isinstance(value, torch.SymInt) else value
+    assert isinstance(expr, sympy.Expr)
+    substitutions = {
+        symbol: config[tunable_name]
+        for symbol, tunable_name in env.tunable_symbols.items()
+        if isinstance(config.get(tunable_name), int)
+    }
+    if substitutions:
+        expr = expr.subs(substitutions)
+        assert isinstance(expr, sympy.Expr)
+    if not expr.free_symbols:
+        return int(expr)
+    return _PallasLaunchExpr(HostFunction.current().sympy_expr(expr))
+
+
+def _pallas_configured_block_size(
+    block_id: int,
+    config: Config,
+    *,
+    launch_context: str = "Pallas launch",
+) -> _PallasLaunchScalar:
+    from ..compile_environment import CompileEnvironment
+
+    value = CompileEnvironment.current().block_sizes[block_id].from_config(config)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, torch.SymInt):
+        return _pallas_host_launch_value(value, config)
+    raise NotImplementedError(f"{launch_context} requires concrete block sizes")
+
+
+def _pallas_block_numel(
+    block_id: int,
+    config: Config,
+    *,
+    launch_context: str = "Pallas launch",
+) -> _PallasLaunchScalar:
+    from ..compile_environment import CompileEnvironment
+
+    size = CompileEnvironment.current().block_sizes[block_id].size
+    if isinstance(size, (int, torch.SymInt)):
+        return _pallas_host_launch_value(size, config)
+    raise NotImplementedError(f"{launch_context} requires concrete block extents")
+
+
+def _pallas_pid_num_blocks(
+    pid_info: PIDInfo,
+    config: Config,
+    *,
+    launch_context: str = "Pallas launch",
+) -> _PallasLaunchScalar:
+    """Return one PID axis count using that case's exact loop extent."""
+    if isinstance(pid_info.numel, str):
+        numel: _PallasLaunchScalar = _PallasLaunchExpr(pid_info.numel)
+    else:
+        numel = _pallas_host_launch_value(pid_info.numel, config)
+    if pid_info.block_size_var == "1":
+        return numel
+    return _pallas_cdiv_launch_values(
+        numel,
+        _pallas_configured_block_size(
+            pid_info.block_id,
+            config,
+            launch_context=launch_context,
+        ),
+    )
 
 
 # Mapping from torch dtype to JAX dtype string (e.g., "jnp.float32")
@@ -772,16 +943,7 @@ class PallasBackend(Backend):
         self,
         sorted_args: list[Argument] | None,
         config: Config,
-    ) -> (
-        list[
-            tuple[
-                tuple[int | None, ...],
-                tuple[int | tuple[int, int, int] | None, ...],
-            ]
-            | None
-        ]
-        | None
-    ):
+    ) -> _PallasBlockSpecInfo | None:
         """Compute per-tensor ``(block_shape, grid_dims)`` from codegen tiling info.
 
         Uses ``DeviceFunction.pallas_tensor_dim_tilings`` (recorded during
@@ -799,6 +961,7 @@ class PallasBackend(Backend):
         from ..device_function import TensorStrideArg
         from ..host_function import HostFunction
         from ..program_id import FlatProgramIDs
+        from ..program_id import ForEachProgramID
 
         env = CompileEnvironment.current()
         device_fn = DeviceFunction.current()
@@ -808,15 +971,39 @@ class PallasBackend(Backend):
         # so pid_info[g].block_id is the block_id assigned to grid dim g.
         if device_fn.pid is None:
             return None
-        flat_grid_block_ids = [pid.block_id for pid in device_fn.pid.pid_info]
+        if isinstance(device_fn.pid, ForEachProgramID):
+            flat_grid_block_ids = [
+                pid_info.block_id
+                for case in device_fn.pid.cases
+                for pid_info in case.pid_info
+            ]
+        else:
+            flat_grid_block_ids = [pid.block_id for pid in device_fn.pid.pid_info]
         block_id_to_grid_dim = {bid: g for g, bid in enumerate(flat_grid_block_ids)}
         known_block_ids = set(block_id_to_grid_dim)
+
+        def block_spec_grid_block_id(block_id: int) -> int | None:
+            """Map an indexed block id to the Pallas grid block that owns it."""
+            seen: set[int] = set()
+            while block_id not in seen:
+                if block_id in known_block_ids:
+                    return block_id
+                seen.add(block_id)
+                try:
+                    spec = env.config_spec.block_sizes.block_id_lookup(block_id)
+                except KeyError:
+                    return None
+                bounded_by = spec.owner_relative_bounded_by_block_id
+                if bounded_by is None:
+                    return None
+                block_id = bounded_by
+            return None
 
         # FlattenedTileStrategy collapses all block_ids into a single
         # pid_info entry, but the full set lives in device_ir.grid_block_ids.
         # Recover them so we can build flat decomposition and so downstream
         # checks (e.g. 1D tensor validation) see every block_id.
-        flat_decomp: dict[int, tuple[int, int, int]] | None = None
+        flat_decomp: dict[int, _PallasFlatDecompValue] | None = None
         if isinstance(device_fn.pid, FlatProgramIDs):
             device_ir = HostFunction.current().device_ir
             all_grid_block_ids = [
@@ -825,29 +1012,50 @@ class PallasBackend(Backend):
             known_block_ids.update(all_grid_block_ids)
 
             if len(all_grid_block_ids) > 1:
-                import sympy
-
-                stride = 1
+                stride: _PallasLaunchScalar = 1
                 flat_decomp = {}
                 for bid in all_grid_block_ids:
-                    bs = env.block_sizes[bid].from_config(config)
-                    numel = env.block_sizes[bid].numel
-                    if not isinstance(bs, int) or isinstance(numel, str):
-                        return None
-                    try:
-                        numel_val = (
-                            int(numel) if isinstance(numel, sympy.Expr) else numel
-                        )
-                    except (TypeError, ValueError):
-                        return None
-                    num_blocks = -(-numel_val // bs)  # cdiv
+                    bs = _pallas_configured_block_size(bid, config)
+                    num_blocks = _pallas_cdiv_launch_values(
+                        _pallas_block_numel(bid, config), bs
+                    )
                     flat_decomp[bid] = (0, stride, num_blocks)
-                    stride *= num_blocks
+                    stride = _pallas_mul_launch_values(stride, num_blocks)
+        elif isinstance(device_fn.pid, ForEachProgramID):
+            flat_decomp = {}
+            case_start: _PallasLaunchScalar = 0
+            for case in device_fn.pid.cases:
+                if not case.pid_info:
+                    # L2GroupingProgramIDs stores PIDInfo on its parent. Pallas
+                    # currently rejects l2_groupings, so fail clearly if that
+                    # wrapper reaches this future-facing path.
+                    raise NotImplementedError(
+                        "Pallas ForEach block specs require direct PIDInfo"
+                    )
+                case_total: _PallasLaunchScalar = 1
+                safe_stride: _PallasLaunchScalar = 1
+                case_entries: list[
+                    tuple[int, _PallasLaunchScalar, _PallasLaunchScalar]
+                ] = []
+                for pid_info in case.pid_info:
+                    bid = pid_info.block_id
+                    num_blocks = _pallas_pid_num_blocks(pid_info, config)
+                    safe_num_blocks = _pallas_safe_launch_radix(num_blocks)
+                    case_entries.append((bid, safe_stride, safe_num_blocks))
+                    case_total = _pallas_mul_launch_values(case_total, num_blocks)
+                    safe_stride = _pallas_mul_launch_values(
+                        safe_stride, safe_num_blocks
+                    )
+                for bid, bid_stride, safe_num_blocks in case_entries:
+                    flat_decomp[bid] = (
+                        0,
+                        bid_stride,
+                        safe_num_blocks,
+                        case_start,
+                    )
+                case_start = _pallas_add_launch_values(case_start, case_total)
 
-        result: list[
-            tuple[tuple[int | None, ...], tuple[int | tuple[int, int, int] | None, ...]]
-            | None
-        ] = []
+        result: _PallasBlockSpecInfo = []
 
         for arg in sorted_args:
             if isinstance(arg, (SymbolArgument, TensorSizeArg, TensorStrideArg)):
@@ -863,9 +1071,9 @@ class PallasBackend(Backend):
             if dim_tilings is None:
                 # this means this tensor isn't accessed at all in the kernel
                 result.append(None)
-                return None
-            block_shape: list[int | None] = []
-            grid_dims: list[int | tuple[int, int, int] | None] = []
+                continue
+            block_shape: list[_PallasLaunchValue] = []
+            grid_dims: list[_PallasFlatDecompValue] = []
             for d in range(tensor.ndim):
                 dim_tiling = dim_tilings[d]
                 if not dim_tiling.can_tile or len(dim_tiling.block_ids) == 0:
@@ -874,23 +1082,24 @@ class PallasBackend(Backend):
                     continue
                 assert len(dim_tiling.block_ids) == 1
                 bid = dim_tiling.block_ids[0]
-                if bid is not None and bid in known_block_ids:
-                    bs = env.block_sizes[bid].from_config(config)
-                    if isinstance(bs, int):
-                        block_shape.append(bs)
-                        dim_size = tensor.shape[d]
-                        # When the block covers the entire tensor
-                        # dimension there is only one tile, so the grid
-                        # index must be constant 0 — iterating would
-                        # read out-of-bounds (e.g. bias [1, N] with
-                        # block_size > 1).
-                        if isinstance(dim_size, int) and dim_size <= bs:
-                            grid_dims.append(None)
-                        elif flat_decomp is not None and bid in flat_decomp:
-                            grid_dims.append(flat_decomp[bid])
-                        else:
-                            grid_dims.append(block_id_to_grid_dim[bid])
-                        continue
+                grid_bid = block_spec_grid_block_id(bid)
+                bs = (
+                    _pallas_configured_block_size(grid_bid, config)
+                    if grid_bid is not None
+                    else None
+                )
+                # Symbolic block sizes can resolve to TPU-illegal small/rank-1
+                # shapes. Keep those dimensions untiled in the outer BlockSpec.
+                if grid_bid is not None and isinstance(bs, int):
+                    block_shape.append(bs)
+                    dim_size = tensor.shape[d]
+                    if isinstance(dim_size, int) and dim_size <= bs:
+                        grid_dims.append(None)
+                    elif flat_decomp is not None and grid_bid in flat_decomp:
+                        grid_dims.append(flat_decomp[grid_bid])
+                    else:
+                        grid_dims.append(block_id_to_grid_dim[grid_bid])
+                    continue
                 block_shape.append(None)
                 grid_dims.append(None)
             result.append((tuple(block_shape), tuple(grid_dims)))
@@ -1131,6 +1340,7 @@ class PallasBackend(Backend):
         from ..device_function import DeviceFunction
         from ..device_function import TensorArg
         from ..host_function import HostFunction
+        from ..program_id import ForEachProgramID
 
         device_fn = DeviceFunction.current()
 
@@ -1190,6 +1400,11 @@ class PallasBackend(Backend):
                     output_indices.append(i)
                     inplace_indices.append(i)
 
+        if isinstance(device_fn.pid, ForEachProgramID):
+            # A ForEach launch flattens disjoint case ranges. Programs outside
+            # an output's case must preserve its current tile.
+            inplace_indices = list(output_indices)
+
         # Collect output-only tensor names so codegen can retarget their
         # allocations to ``device='meta'`` and capture the launcher return.
         output_only_set = set(output_indices) - set(inplace_indices)
@@ -1213,7 +1428,9 @@ class PallasBackend(Backend):
         if block_spec_info is not None:
             if has_rng_ops:
                 block_spec_info.append(None)  # RNG seed buffer is untiled
-            launcher_args.append(f"_block_spec_info={block_spec_info!r}")
+            launcher_args.append(
+                f"_block_spec_info={_format_pallas_launch_value(block_spec_info)}"
+            )
 
         pad_info = self._compute_pad_info(sorted_args, config)
         if pad_info:

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import math
 from typing import TYPE_CHECKING
 
 import torch
@@ -796,37 +797,103 @@ def _ds_expr(
         assert decision.resident_key_fields == ("range_start",)
         begin_ref = f"{metadata_ref_for_field(plan, 'range_start')}[_wid]"
         return f"pl.ds(({offset}) - ({begin_ref}), {block_size})"
+    local_owner_block_id = (
+        _bounded_local_owner_block_id(state, block_id, tensor, tensor_dim)
+        if tensor is not None and tensor_dim is not None
+        else None
+    )
+    if local_owner_block_id is not None:
+        owner_offset = state.codegen.offset_var(local_owner_block_id)
+        offset = f"({offset}) - ({owner_offset})"
     if tensor is not None and tensor_dim is not None:
         from helion.language.memory_ops import _record_pad_info
 
-        extra_pad = _loop_begin_extra_pad(block_id, state)
-        _record_pad_info(state, tensor, tensor_dim, block_id, extra_pad)
+        pad_block_id = (
+            local_owner_block_id if local_owner_block_id is not None else block_id
+        )
+        extra_pad = _loop_begin_extra_pad(pad_block_id, state)
+        _record_pad_info(state, tensor, tensor_dim, pad_block_id, extra_pad)
 
         # Skip when tile_offset is set (e.g. offset + 64) — the shift
         # means the full expression may not be a multiple of block_size.
         if not tile_offset:
-            alignment = _loop_offset_alignment(block_id, state)
-            if alignment is not None:
-                # Workaround for JAX <= 0.10.0 where AssumeMultipleOp
-                # short-circuits divisibility analysis (fixed in
-                # jax-ml/jax@33c38f50b): only apply when alignment meets
-                # Mosaic's requirement, otherwise the hint could replace
-                # a stronger proof Mosaic already has.
-                from helion._compiler.backend import PallasBackend
-                from helion._compiler.compile_environment import CompileEnvironment
+            alignment = (
+                state.device_function.resolved_block_size(block_id)
+                if local_owner_block_id is not None
+                else _loop_offset_alignment(block_id, state)
+            )
+            # Workaround for JAX <= 0.10.0 where AssumeMultipleOp
+            # short-circuits divisibility analysis (fixed in
+            # jax-ml/jax@33c38f50b): only apply when the hint meets Mosaic's
+            # requirement, otherwise it could replace a stronger proof Mosaic
+            # already has.
+            from helion._compiler.compile_environment import CompileEnvironment
+            from helion._compiler.pallas.backend import PallasBackend
 
-                backend = CompileEnvironment.current().backend
-                assert isinstance(backend, PallasBackend)
-                dim_from_end = tensor.ndim - 1 - tensor_dim
-                bitwidth = tensor.dtype.itemsize * 8
-                required = backend._get_pallas_required_alignment(
-                    dim_from_end, tensor.ndim, bitwidth
-                )
-                if alignment % required == 0:
-                    # e.g. pl.ds(pl.multiple_of(offset_3, _BLOCK_SIZE_3), _BLOCK_SIZE_3)
-                    offset = f"pl.multiple_of({offset}, {block_size})"
+            backend = CompileEnvironment.current().backend
+            assert isinstance(backend, PallasBackend)
+            dim_from_end = tensor.ndim - 1 - tensor_dim
+            bitwidth = tensor.dtype.itemsize * 8
+            required = backend._get_pallas_required_alignment(
+                dim_from_end, tensor.ndim, bitwidth
+            )
+            if alignment is not None and alignment % required == 0:
+                hint = required
+                bs_value = state.device_function.resolved_block_size(block_id)
+                if isinstance(bs_value, int) and alignment % bs_value == 0:
+                    hint = block_size
+                # e.g. pl.ds(pl.multiple_of(offset_3, _BLOCK_SIZE_3), _BLOCK_SIZE_3)
+                offset = f"pl.multiple_of({offset}, {hint})"
+            elif _is_zero_begin_single_tile_dim(block_id, state, tensor, tensor_dim):
+                offset = f"pl.multiple_of({offset}, {required})"
 
     return f"pl.ds({offset}, {block_size})"
+
+
+def _bounded_local_owner_block_id(
+    state: CodegenState,
+    block_id: int,
+    tensor: torch.Tensor | None,
+    tensor_dim: int | None,
+) -> int | None:
+    """Return the outer grid block that owns a bounded inner tile's BlockSpec."""
+    if tensor is None or tensor_dim is None:
+        return None
+
+    from helion._compiler.compile_environment import CompileEnvironment
+    from helion._compiler.device_function import PallasMemorySpace
+    from helion._compiler.tile_strategy import DeviceGridState
+
+    if (
+        state.device_function.pallas_memory_space.get(id(tensor))
+        == PallasMemorySpace.HBM
+    ):
+        return None
+
+    dim_tilings = state.device_function.pallas_tensor_dim_tilings.get(id(tensor))
+    if dim_tilings is None or tensor_dim >= len(dim_tilings):
+        return None
+    dim_tiling = dim_tilings[tensor_dim]
+    if not dim_tiling.can_tile or dim_tiling.block_ids != [block_id]:
+        return None
+
+    env = CompileEnvironment.current()
+    seen: set[int] = set()
+    current = block_id
+    while current not in seen:
+        seen.add(current)
+        try:
+            spec = env.config_spec.block_sizes.block_id_lookup(current)
+        except KeyError:
+            return None
+        parent = spec.owner_relative_bounded_by_block_id
+        if parent is None:
+            return None
+        loops = state.codegen.active_device_loops.get(parent)
+        if loops and any(isinstance(loop, DeviceGridState) for loop in loops):
+            return parent
+        current = parent
+    return None
 
 
 def _loop_begin_extra_pad(block_id: int, state: CodegenState) -> int:
@@ -849,10 +916,15 @@ def _loop_begin_extra_pad(block_id: int, state: CodegenState) -> int:
         return 0
 
     info = loops[-1].block_id_to_info.get(block_id)
-    if info is None or info.begin_expr is None:
+    if info is None:
         return 0
 
     begin = info.begin_expr
+    if begin is None:
+        alignment = info.offset_alignment
+        if isinstance(alignment, int) and alignment > 0:
+            return (bs_value - math.gcd(bs_value, alignment)) % bs_value
+        return bs_value - 1
     if isinstance(begin, (int, sympy.Integer)):
         return int(begin) % bs_value
 
@@ -865,9 +937,8 @@ def _loop_offset_alignment(
 ) -> int | None:
     """Return the proven alignment of a loop's offset for *block_id*, or ``None``.
 
-    A loop with step ``block_size`` produces offsets ``begin + i * block_size``,
-    which are multiples of ``block_size`` iff ``begin`` is.  Returns
-    ``block_size`` (int) when provable, ``None`` otherwise.
+    A loop with step ``block_size`` produces offsets ``begin + i * block_size``.
+    Returns a proven divisor of that offset expression when available.
     """
     import sympy
 
@@ -875,18 +946,62 @@ def _loop_offset_alignment(
     if not isinstance(bs_value, int):
         return None
 
-    # Check that the loop begins at a multiple of block_size.
     loops = state.codegen.active_device_loops.get(block_id)
     if loops:
         info = loops[-1].block_id_to_info.get(block_id)
-        if info is not None and info.begin_expr is not None:
-            begin = info.begin_expr
-            if not isinstance(begin, (int, sympy.Integer)):
-                return None  # symbolic begin — can't prove alignment
-            if int(begin) % bs_value != 0:
-                return None
+        if info is None:
+            return None
+        offset_alignment = info.offset_alignment
+        if isinstance(offset_alignment, int) and offset_alignment > 0:
+            return offset_alignment
+        begin = info.begin_expr
+        if begin is None:
+            return None
+        if not isinstance(begin, (int, sympy.Integer)):
+            return None  # symbolic begin — can't prove alignment
+        return math.gcd(abs(int(begin)), bs_value)
 
     return bs_value
+
+
+def _is_zero_begin_single_tile_dim(
+    block_id: int,
+    state: CodegenState,
+    tensor: torch.Tensor,
+    tensor_dim: int,
+) -> bool:
+    """True when a zero-begin loop has only one in-bounds concrete tensor tile."""
+    import sympy
+
+    from helion._compiler.compile_environment import CompileEnvironment
+
+    bs_value = state.device_function.resolved_block_size(block_id)
+    if not isinstance(bs_value, int):
+        return False
+
+    loops = state.codegen.active_device_loops.get(block_id)
+    if not loops:
+        return False
+
+    info = loops[-1].block_id_to_info.get(block_id)
+    if info is None or info.begin_expr not in (0, sympy.Integer(0)):
+        return False
+
+    env = CompileEnvironment.current()
+    dim_size = tensor.shape[tensor_dim]
+    if isinstance(dim_size, int):
+        return env.settings.static_shapes and dim_size <= bs_value
+    if not isinstance(dim_size, torch.SymInt):
+        return False
+
+    dim_expr = env.shape_env.replace(dim_size._sympy_())
+    if not dim_expr.free_symbols <= env.specialized_vars:
+        return False
+    dim_expr = env.specialize_expr(dim_expr)
+    if dim_expr.free_symbols or getattr(dim_expr, "is_integer", None) is not True:
+        return False
+    dim_value = int(dim_expr)
+    return dim_value <= bs_value
 
 
 def vmem_name(state: CodegenState, name: str) -> str:

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -56,6 +56,10 @@ class ArbitrarySlicePattern(IndexingPattern):
     slice: slice
 
 
+def _is_full_slice(idx: slice) -> bool:
+    return idx.start is None and idx.stop is None and idx.step in (None, 1)
+
+
 @dataclass
 class ArbitraryIndexPattern(IndexingPattern):
     index: int | torch.SymInt | object | None
@@ -77,10 +81,12 @@ class DimensionTiling:
 
     can_tile: whether or not we can tile this dimension
     block_ids: which which block_ids we are indexing this dimension (there can be multiple, in which case we mustn't tile)
+    needs_full_slice: whether this dimension is also read as a full slice
     """
 
     can_tile: bool = True
     block_ids: list[int] = field(default_factory=list)
+    needs_full_slice: bool = False
 
 
 def plan_tiling(
@@ -297,6 +303,13 @@ def _update_tiling_decision(
                 # we already need to tile this dim using a different block_id
                 # so fallback to no-tiling so that we can access using both tiles
                 _disallow_tiling()
+        if curr_dim_tiling.needs_full_slice:
+            _disallow_tiling()
+
+    def _record_full_slice() -> None:
+        curr_dim_tiling.needs_full_slice = True
+        if curr_dim_tiling.block_ids:
+            _disallow_tiling()
 
     if isinstance(pattern, TilePattern):
         _try_set_tiling_block_id(pattern.block_id)
@@ -315,8 +328,10 @@ def _update_tiling_decision(
                 _disallow_tiling()
 
     elif isinstance(pattern, ArbitrarySlicePattern):
-        if pattern.slice != slice(None):
-            # bounded slice: fixed subrange of the dim, must stay untiled
+        if _is_full_slice(pattern.slice):
+            _record_full_slice()
+        else:
+            # A bounded slice is a fixed subrange of the dim and stays untiled.
             _disallow_tiling()
 
     elif isinstance(pattern, (ArbitraryIndexPattern, TensorIndexPattern)):
@@ -331,7 +346,7 @@ def _update_tiling_decision(
             from ..compile_environment import CompileEnvironment
 
             backend = CompileEnvironment.current().backend
-            from helion._compiler.backend import PallasBackend
+            from helion._compiler.pallas.backend import PallasBackend
 
             assert isinstance(backend, PallasBackend)
 

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -1048,6 +1048,28 @@ def _pallas_loop_begin_and_step_exprs(
     return begin_exprs, iter_step_exprs, slice_size_exprs
 
 
+def _static_loop_begin_expr(begin_expr: str) -> sympy.Expr | None:
+    if begin_expr.lstrip("-").isdigit():
+        return sympy.Integer(int(begin_expr))
+    return None
+
+
+def _inner_loop_offset_alignment(
+    begin_expr: str,
+    iter_step_expr: str,
+    block_id: int,
+    state: CodegenState,
+) -> int | None:
+    block_value = state.device_function.resolved_block_size(block_id)
+    if not isinstance(block_value, int):
+        return None
+    if not _expr_proven_multiple(begin_expr, block_value, state):
+        return None
+    if not _expr_proven_multiple(iter_step_expr, block_value, state, block_id=block_id):
+        return None
+    return block_value
+
+
 def _pipeline_begin_alignment(
     begin_expr: str,
     state: CodegenState,
@@ -1109,6 +1131,35 @@ def _active_loop_begin_expr(state: CodegenState, block_id: int) -> str:
     if info.begin_expr is not None:
         return str(info.begin_expr)
     return info.begin_var_name or "0"
+
+
+def _expr_proven_multiple(
+    expr: str,
+    required: int,
+    state: CodegenState,
+    *,
+    block_id: int | None = None,
+) -> bool:
+    if required <= 1 or expr == "0":
+        return True
+    try:
+        value = sympy.sympify(expr)
+    except (AttributeError, sympy.SympifyError, TypeError):
+        value = None
+    if isinstance(value, sympy.Integer):
+        return int(value) % required == 0
+    if isinstance(value, sympy.Expr):
+        try:
+            remainder = sympy.simplify(sympy.Mod(value, required))
+        except TypeError:
+            remainder = None
+        if remainder == 0:
+            return True
+    if block_id is not None and expr == state.device_function.block_size_var(block_id):
+        block_value = state.device_function.resolved_block_size(block_id)
+        return isinstance(block_value, int) and block_value % required == 0
+    alignment = _pipeline_begin_alignment(expr, state)
+    return alignment is not None and alignment % required == 0
 
 
 def _scratch_read(state: CodegenState, sname: str) -> str:
@@ -2566,6 +2617,13 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
 
     # Build block_id_to_info for the pipeline state
     block_id_to_info = _loop_dim_infos(state, block_ids, env)
+    for i, block_id in enumerate(block_ids):
+        info = block_id_to_info[block_id]
+        info.begin_expr = _static_loop_begin_expr(begin_exprs[i])
+        if block_id in aligned_dim and _expr_proven_multiple(
+            iter_step_exprs[i], aligned_dim[block_id], state, block_id=block_id
+        ):
+            info.offset_alignment = aligned_dim[block_id]
 
     strategy = _find_strategy(state, block_ids)
     # Emit offset_<bid>/indices_<bid> at the body prologue.
@@ -2998,9 +3056,17 @@ def _codegen_dynamic_unroll(state: CodegenState) -> object:
     )
 
     body_fn_name = state.device_function.new_var("_dynamic_unroll_body")
+    block_id_to_info = _loop_dim_infos(state, block_ids, env)
+    for i, block_id in enumerate(block_ids):
+        info = block_id_to_info[block_id]
+        info.begin_expr = _static_loop_begin_expr(begin_exprs[i])
+        info.offset_alignment = _inner_loop_offset_alignment(
+            begin_exprs[i], iter_step_exprs[i], block_id, state
+        )
+
     fori_state = ForiLoopState(
         strategy=strategy,  # pyrefly: ignore[bad-argument-type]
-        block_id_to_info=_loop_dim_infos(state, block_ids, env),
+        block_id_to_info=block_id_to_info,
         body_fn_name=body_fn_name,
         loop_var_name=loop_var,
         inner_statements=body_stmts,
@@ -3286,6 +3352,12 @@ def _codegen_fori_loop(state: CodegenState) -> object:
 
     # Build block_id_to_info
     block_id_to_info = _loop_dim_infos(state, block_ids, env)
+    for i, block_id in enumerate(block_ids):
+        info = block_id_to_info[block_id]
+        info.begin_expr = _static_loop_begin_expr(begin_exprs[i])
+        info.offset_alignment = _inner_loop_offset_alignment(
+            begin_exprs[i], iter_step_exprs[i], block_id, state
+        )
 
     # Emit offset_<bid>/indices_<bid> at the body prologue.
     _emit_inner_loop_offset_indices(

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -1804,6 +1804,7 @@ class LoopDimInfo:
     begin_expr: sympy.Expr | None = None
     end_var_name: str | None = None
     end_expr: sympy.Expr | None = None
+    offset_alignment: int | None = None
 
     def is_end_matching(self, size: int | torch.SymInt) -> bool:
         expected = _to_sympy(size)

--- a/helion/_compiler/type_info.py
+++ b/helion/_compiler/type_info.py
@@ -1114,6 +1114,34 @@ def _detect_outer_block_bound(
     return None
 
 
+def _detect_owner_relative_outer_block_bound(
+    begin: object,
+    end: object,
+) -> int | None:
+    """Return the owner block when bounds are exactly ``owner.begin/end``."""
+    from .variable_origin import TileBeginOrigin
+    from .variable_origin import TileEndOrigin
+
+    def exact_origin(value: object) -> Origin | None:
+        if not isinstance(value, torch.SymInt):
+            return None
+        expr = _symint_expr(value)
+        if expr is None:
+            return None
+        symbol_origin = HostFunction.current().expr_to_origin.get(expr)
+        return symbol_origin.origin if symbol_origin is not None else None
+
+    begin_origin = exact_origin(begin)
+    end_origin = exact_origin(end)
+    if (
+        isinstance(begin_origin, TileBeginOrigin)
+        and isinstance(end_origin, TileEndOrigin)
+        and begin_origin.block_id == end_origin.block_id
+    ):
+        return begin_origin.block_id
+    return None
+
+
 class TileIndexType(TypeInfo):
     block_id: int
 
@@ -1141,12 +1169,14 @@ class TileIndexType(TypeInfo):
         numel: int | torch.SymInt | AutoSize | None,
         origin: Origin,
         block_size: int | torch.SymInt | None = None,
+        owner_relative_bounded_by_block_id: int | None = None,
     ) -> TileIndexType:
         env = CompileEnvironment.current()
         if block_size is None:
             block_id = env.allocate_block_size(numel, source=LoopSpecBlockSizeSource())
             outer_max: int | None = None
             bounded_by: int | None = None
+            owner_relative_bounded_by: int | None = None
             if isinstance(numel, torch.SymInt):
                 maybe_bounded_by = _detect_outer_block_bound(numel, env)
                 if maybe_bounded_by is not None:
@@ -1159,12 +1189,15 @@ class TileIndexType(TypeInfo):
                     else:
                         bounded_by = maybe_bounded_by
                         outer_max = outer_spec.max_size
+                        if owner_relative_bounded_by_block_id == maybe_bounded_by:
+                            owner_relative_bounded_by = maybe_bounded_by
             env.config_spec.block_sizes.append(
                 BlockSizeSpec(
                     block_id=block_id,
                     size_hint=_get_hint(numel),
                     max_size=outer_max,
                     bounded_by_block_id=bounded_by,
+                    owner_relative_bounded_by_block_id=owner_relative_bounded_by,
                 )
             )
             if env.config_spec.supports_config_key("num_threads"):

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -2717,6 +2717,7 @@ class BlockSizeSpec(_PowerOfTwoBlockIdItem):
         min_size: int = 1,
         max_size: int | None = None,
         bounded_by_block_id: int | None = None,
+        owner_relative_bounded_by_block_id: int | None = None,
     ) -> None:
         super().__init__([block_id])
         self.size_hint = size_hint
@@ -2740,6 +2741,10 @@ class BlockSizeSpec(_PowerOfTwoBlockIdItem):
         self.max_size: int = self.dim_max_size
         # Outer block_id whose tile extent caps this block's size in normalize().
         self.bounded_by_block_id: int | None = bounded_by_block_id
+        # Outer block_id whose tile begin/end are this tile's actual address base.
+        self.owner_relative_bounded_by_block_id: int | None = (
+            owner_relative_bounded_by_block_id
+        )
         if self.max_size < self.min_size:
             self.max_size = self.min_size
         assert self.min_size <= self.max_size
@@ -2752,6 +2757,7 @@ class BlockSizeSpec(_PowerOfTwoBlockIdItem):
             ("min_size", 1),
             ("max_size", next_power_of_2(self.size_hint)),
             ("bounded_by_block_id", None),
+            ("owner_relative_bounded_by_block_id", None),
         ):
             value = getattr(self, field)
             if value != default:

--- a/helion/language/loops.py
+++ b/helion/language/loops.py
@@ -32,6 +32,7 @@ from .._compiler.type_info import SequenceType
 from .._compiler.type_info import TensorType
 from .._compiler.type_info import TileIndexType
 from .._compiler.type_info import TypeInfo
+from .._compiler.type_info import _detect_owner_relative_outer_block_bound
 from .._compiler.variable_origin import GetItemOrigin
 from ..autotuner.config_spec import ConfigSpec
 from ..autotuner.config_spec import FlattenLoopSpec
@@ -355,7 +356,15 @@ def _(
         if isinstance(begin_part, torch.SymInt) or isinstance(end_part, torch.SymInt):
             has_symbolic_bounds = True
         if bs is None:
-            results.append(TileIndexType.allocate(size, origin))
+            results.append(
+                TileIndexType.allocate(
+                    size,
+                    origin,
+                    owner_relative_bounded_by_block_id=(
+                        _detect_owner_relative_outer_block_bound(begin_part, end_part)
+                    ),
+                )
+            )
         elif isinstance(bs, int):
             results.append(TileIndexType.allocate(size, origin, bs))
         elif isinstance(bs, torch.SymInt):

--- a/helion/runtime/pallas/launcher.py
+++ b/helion/runtime/pallas/launcher.py
@@ -83,7 +83,10 @@ def _pallas_make_block_spec(
     jnp: object,
     pltpu: object,
     tensor: _TorchTensorOrJaxArray,
-    entry: tuple[tuple[int | None, ...], tuple[int | tuple[int, int, int] | None, ...]]
+    entry: tuple[
+        tuple[int | None, ...],
+        tuple[int | _PallasFlatGridDim | None, ...],
+    ]
     | None,
     should_use_smem: bool = False,
 ) -> object:
@@ -119,16 +122,24 @@ def _pallas_make_block_spec(
 
     def _index_for_dim(
         grid_args: tuple[object, ...],
-        g: int | tuple[int, int, int] | None,
+        g: int | _PallasFlatGridDim | None,
         d: int,
         jnp: object = jnp,
     ) -> object:
         if g is None:
             return jnp.int32(0)  # pyrefly: ignore[missing-attribute]
         if isinstance(g, tuple):
-            # Flat grid decomposition: (grid_dim, stride, num_blocks)
-            grid_dim, stride, num_blocks = g
+            # Flat grid decomposition:
+            # (grid_dim, stride, num_blocks) or
+            # (grid_dim, stride, num_blocks, case_start)
+            if len(g) == 3:
+                grid_dim, stride, num_blocks = g
+                case_start = 0
+            else:
+                grid_dim, stride, num_blocks, case_start = g
             val = grid_args[grid_dim]
+            if case_start:
+                val = val - case_start  # type: ignore[operator]
             if stride > 1:
                 val = val // stride  # type: ignore[operator]
             val = val % num_blocks  # type: ignore[operator]
@@ -140,7 +151,7 @@ def _pallas_make_block_spec(
 
     def index_map(
         *grid_args: object,
-        _grid_dims: tuple[int | tuple[int, int, int] | None, ...] = grid_dims,
+        _grid_dims: tuple[int | _PallasFlatGridDim | None, ...] = grid_dims,
     ) -> tuple[object, ...]:
         return tuple(_index_for_dim(grid_args, g, d) for d, g in enumerate(_grid_dims))
 
@@ -414,8 +425,13 @@ def _estimate_pallas_vmem_bytes(
 # Per-tensor block spec info: see ``_pallas_make_block_spec``.
 # grid_dims entries are int (direct grid dim), tuple (flat decomposition),
 # or None (untiled dim).
+_PallasFlatGridDim = tuple[int, int, int] | tuple[int, int, int, int]
 _BlockSpecInfo = list[
-    tuple[tuple[int | None, ...], tuple[int | tuple[int, int, int] | None, ...]] | None
+    tuple[
+        tuple[int | None, ...],
+        tuple[int | _PallasFlatGridDim | None, ...],
+    ]
+    | None
 ]
 _PallasCopyGuards = dict[int, tuple[int, ...]]
 _PallasDimensionSemantic = Literal["parallel", "arbitrary"]
@@ -431,7 +447,8 @@ def _pallas_tensor_pos_map(
 
 def _pallas_grid_dims_used_by_block_spec(
     block_info: tuple[
-        tuple[int | None, ...], tuple[int | tuple[int, int, int] | None, ...]
+        tuple[int | None, ...],
+        tuple[int | _PallasFlatGridDim | None, ...],
     ],
 ) -> set[int]:
     used: set[int] = set()
@@ -440,6 +457,21 @@ def _pallas_grid_dims_used_by_block_spec(
         if isinstance(grid_dim, int):
             used.add(grid_dim)
         elif isinstance(grid_dim, tuple):
+            used.add(grid_dim[0])
+    return used
+
+
+def _pallas_foreach_grid_dims_by_block_spec(
+    block_info: tuple[
+        tuple[int | None, ...],
+        tuple[int | _PallasFlatGridDim | None, ...],
+    ],
+) -> set[int]:
+    """Return flat launch dims whose index map is limited to one ForEach case."""
+    used: set[int] = set()
+    _, grid_dims = block_info
+    for grid_dim in grid_dims:
+        if isinstance(grid_dim, tuple) and len(grid_dim) == 4:
             used.add(grid_dim[0])
     return used
 
@@ -470,6 +502,9 @@ def _pallas_shared_output_plan(
         block_info = block_spec_info[tensor_pos]
         if block_info is None:
             continue
+        for dim in _pallas_foreach_grid_dims_by_block_spec(block_info):
+            if dim < len(grid) and grid[dim] > 1:
+                dim_semantics[dim] = "arbitrary"
         used_dims = _pallas_grid_dims_used_by_block_spec(block_info)
         # These programs update the same output tile and must observe one
         # shared accumulator, not a freshly preloaded copy per program.

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1471,8 +1471,8 @@ class TestExamples(RefEagerTestBase, TestCase):
         """Test combined backward pass for layer norm with bias."""
         self._run_layernorm_bwd(batch_size=32, dim=64)
 
-    @xfailIfPallas("VMEM OOM: untiled block specs load full tensors")
     @skipIfA10G("accuracy check fails on A10G GPUs")
+    @xfailIfPallasInterpret("large-batch backward has interpret-mode drift")
     def test_layernorm_bwd_large_batch(self):
         """Regression test: large batch, small dim."""
         self._run_layernorm_bwd(batch_size=1152 * 1000, dim=16, seed=1)
@@ -2676,6 +2676,10 @@ class TestExamples(RefEagerTestBase, TestCase):
         )
 
     @skipIfRefEager("scalar_prefetch indexing not supported in ref interpreter")
+    @xfailIfPallasTpu(
+        "unaligned data-dependent tile load; fixed later in the stack by Pallas "
+        "padded-load support (#2944)"
+    )
     def test_flex_attention(self):
         z, h, n_ctx, head_dim = 2, 4, 256, 64
         q, k, v = [

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -85,6 +85,17 @@ def pallas_sigmoid(x: torch.Tensor) -> torch.Tensor:
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_foreach_output_only(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    out1 = torch.empty_like(x)
+    out2 = torch.empty_like(x)
+    for tile in hl.tile(x.size(0)):
+        out1[tile] = x[tile] + 1.0
+    for tile in hl.tile(x.size(0)):
+        out2[tile] = x[tile] * 2.0
+    return out1, out2
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_pointwise_chain(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     out = torch.empty_like(x)
     for tile in hl.tile(out.size()):
@@ -455,6 +466,15 @@ def pallas_literal_prefixed_row_slab_sum(
         for tile in hl.tile(start, end):
             acc = acc + x[1, tile, :, :].to(torch.float32).sum(dim=0)
         out[owner, :, :] = acc
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_owner_relative_inner_leading_dim(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for outer in hl.tile(x.size(0)):
+        for inner in hl.tile(outer.begin, outer.end):
+            out[inner, :, :] = x[inner, :, :] + 1.0
     return out
 
 
@@ -3732,6 +3752,34 @@ class TestPallas(TestCase):
         self.assertIn("device='meta'", code)
         self.assertIn("out1, out2 = _launcher(", code)
 
+    def test_foreach_outputs_stay_inplace_and_ordered(self) -> None:
+        x = torch.randn(256, device=DEVICE, dtype=torch.float32)
+        code = pallas_foreach_output_only.bind((x,)).to_triton_code(
+            helion.Config(block_sizes=[128, 128])
+        )
+
+        self.assertIn("_output_indices=[1, 2]", code)
+        self.assertIn("_inplace_indices=[1, 2]", code)
+        self.assertNotIn("device='meta'", code)
+        self.assertIn("((0, 1, 2, 0),)", code)
+        self.assertIn("((0, 1, 2, 2),)", code)
+
+        from helion.runtime.pallas.launcher import _pallas_shared_output_plan
+
+        _copy_guards, dim_semantics = _pallas_shared_output_plan(
+            (4,),
+            [0, 1, 2],
+            [],
+            [1, 2],
+            {1, 2},
+            [
+                ((None,), (None,)),
+                ((128,), ((0, 1, 2, 0),)),
+                ((128,), ((0, 1, 2, 2),)),
+            ],
+        )
+        self.assertEqual(dim_semantics, ("arbitrary",))
+
     def test_fori_loop_multidim(self) -> None:
         """Test fori_loop with a 2D inner loop (nested iteration)."""
         args = (
@@ -3837,7 +3885,9 @@ class TestPallas(TestCase):
         self.assertIn("jax.lax.fori_loop", code)
         self.assertNotIn("pltpu.make_async_copy", code)
         self.assertIn("pl.ds(", code)
-        self.assertNotIn("pl.multiple_of(", code)
+        # The last dim is a one-tile dense slice, so its dynamic fori offset is
+        # provably zero and can carry the 128-element Mosaic alignment hint.
+        self.assertIn("pl.ds(pl.multiple_of(offset_1, 128), _BLOCK_SIZE_1)", code)
         torch.testing.assert_close(result, args[0] + args[1])
 
     def test_fori_loop_no_dma_multidim_unaligned(self) -> None:
@@ -3952,6 +4002,25 @@ class TestPallas(TestCase):
         self.assertIn("pipeline_mode=pl.Buffered", code)
         self.assertIn("_hbm_arg_indices=[1]", code)
         self.assertNotIn("pltpu.make_async_copy", code)
+
+    def test_owner_relative_padding_uses_blockspec_owner_block(self) -> None:
+        x = torch.randn(96, 4, 128, device=DEVICE, dtype=torch.float32)
+        code = pallas_owner_relative_inner_leading_dim.bind((x,)).to_triton_code(
+            helion.Config(block_sizes=[64, 32], pallas_loop_type="fori_loop")
+        )
+
+        self.assertIn(
+            "x[pl.ds(pl.multiple_of(offset_1 - offset_0, _BLOCK_SIZE_1), "
+            "_BLOCK_SIZE_1), :, :]",
+            code,
+        )
+        match = re.search(r"_ds_pad_dims=(\[[^\]]*\])", code)
+        self.assertIsNotNone(match, "expected owner-relative pl.ds pad dims")
+        pad_dims = ast.literal_eval(match.group(1))
+        self.assertIn((0, 0, 64, 0), pad_dims)
+        self.assertIn((1, 0, 64, 0), pad_dims)
+        self.assertNotIn((0, 0, 32, 0), pad_dims)
+        self.assertNotIn((1, 0, 32, 0), pad_dims)
 
     def test_tile_id_per_block_accumulator(self) -> None:
         """Writing to ``out[tile.id, :]`` stores one row per outer grid iter.
@@ -5105,6 +5174,10 @@ class TestPallas(TestCase):
         ref[s:e] = torch.bmm(y[s:e].transpose(0, 1), w).transpose(0, 1) + y[s:e]
         torch.testing.assert_close(out.cpu(), ref.cpu(), rtol=2e-2, atol=2e-2)
 
+    @xfailIfPallasTpu(
+        "unaligned data-dependent tile load; fixed later in the stack by Pallas "
+        "padded-load support (#2944)"
+    )
     def test_opposite_direction_transpose_keeps_eager_mask(self) -> None:
         """Mirror image of the deferral win.  Here the masked Q axis is already in
         the last-two (sublane) dims at the load and the transpose moves it to a


### PR DESCRIPTION
Stacked PRs:
 * #2962
 * #2957
 * #2956
 * #2955
 * #2954
 * #2953
 * #2952
 * #2951
 * #2949
 * #2948
 * #2947
 * #2946
 * #2945
 * #2944
 * #2943
 * __->__#2942


--- --- ---

### Support Pallas BlockSpec indexing metadata


Example fixed: none directly; this is metadata infrastructure for later Pallas examples with nontrivial launch grids.

Compiler/runtime side: describe symbolic block sizes, flattened ForEach PID decompositions, and owner-relative bounded inner tiles so runtime `BlockSpec` index maps address the right logical tile.

Why needed: later pipeline, bounded-tile, and shared-output PRs need metadata that matches Helion's logical tile ownership across flattened or nested grids.
