### PR TITLE
Support Pallas numeric masks and scalar predicates

### DIFF
--- a/helion/_compiler/aten_lowering.py
+++ b/helion/_compiler/aten_lowering.py
@@ -151,7 +151,30 @@ scalar_tensor_lowering = register_lowering(
 )
 
 
-where_lowering = register_lowering(torch.ops.aten.where.self)
+_UNKNOWN_MASKED_VALUE = object()
+
+
+def _where_masked_value(node: Node) -> float | bool | None:
+    def branch_value(arg: object) -> object:
+        if isinstance(arg, Node):
+            value = cached_masked_value(arg)
+            return _UNKNOWN_MASKED_VALUE if value is None else value
+        if isinstance(arg, (int, float, bool)):
+            return arg
+        return _UNKNOWN_MASKED_VALUE
+
+    x_value = branch_value(node.args[1])
+    y_value = branch_value(node.args[2])
+    if x_value is not _UNKNOWN_MASKED_VALUE and x_value == y_value:
+        assert isinstance(x_value, (int, float, bool))
+        return x_value
+    return None
+
+
+where_lowering = register_lowering(
+    torch.ops.aten.where.self,
+    masked_value_fn=_where_masked_value,
+)
 
 
 @where_lowering.register_codegen("common")

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -1434,7 +1434,7 @@ def _trace_to_mma_operand(
     unwrapped_node, mask_to_node = _unwrap_zero_mask_to(node)
     grouped_k_mask = None
     collective_dependency_nodes: tuple[Node, ...] = ()
-    if allow_grouped_k_mask and unwrapped_node is not node:
+    if allow_grouped_k_mask:
         if (
             unwrapped_node.op == "call_function"
             and unwrapped_node.target is torch.ops.aten.where.self
@@ -1458,8 +1458,6 @@ def _trace_to_mma_operand(
                         k_index_node=indices[1],
                     )
                     if grouped_k_mask is not None:
-                        if mask_to_node is None:
-                            return None
                         collective_dependency_nodes = (
                             *grouped_k_mask.k_sizes_value_nodes,
                             grouped_k_mask.k_sizes_load,
@@ -1467,7 +1465,7 @@ def _trace_to_mma_operand(
                             grouped_k_mask.condition,
                             grouped_k_mask.zero,
                             grouped_k_mask.where,
-                            mask_to_node,
+                            *(() if mask_to_node is None else (mask_to_node,)),
                         )
                         return _MmaOperandInfo(
                             load=load_node,

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -373,6 +373,7 @@ class ReductionLoopGraphInfo(ForLoopGraphInfo):
 @dataclasses.dataclass
 class IfGraphInfo(NodeArgsGraphInfo):
     predicate_is_tensor: bool = False
+    predicate_tensor_numel: int | torch.SymInt | None = None
     else_branch: ElseGraphInfo | None = None
 
     if_arg_names: list[str] | None = None
@@ -392,6 +393,7 @@ class IfGraphInfo(NodeArgsGraphInfo):
         return {
             **super().kwargs(),
             "predicate_is_tensor": self.predicate_is_tensor,
+            "predicate_tensor_numel": self.predicate_tensor_numel,
             "else_branch": self.else_branch,
             "if_arg_names": self.if_arg_names,
             "else_arg_names": self.else_arg_names,
@@ -2549,10 +2551,13 @@ class WalkDeviceAST(NodeVisitor):
         body: list[ast.stmt],
         orelse: list[ast.stmt],
     ) -> int:
-        # Track whether the predicate is a tensor with numel > 1
-        predicate_is_tensor = (
-            isinstance(test_proxy, torch.Tensor) and math.prod(test_proxy.shape) > 1
+        predicate_tensor_numel: int | torch.SymInt | None
+        predicate_tensor_numel = (
+            math.prod(test_proxy.shape)
+            if isinstance(test_proxy, torch.Tensor)
+            else None
         )
+        predicate_is_tensor = predicate_tensor_numel is not None
 
         if_branch_rw: ReadWrites = ReadWrites.from_list(body)
         else_branch_rw: ReadWrites = ReadWrites.from_list(orelse)
@@ -2582,6 +2587,7 @@ class WalkDeviceAST(NodeVisitor):
             functools.partial(build_body, stmts=body, rw=if_branch_rw),
             graph_info_cls=IfGraphInfo,
             predicate_is_tensor=predicate_is_tensor,
+            predicate_tensor_numel=predicate_tensor_numel,
             else_branch=else_graph_idx,
         )
         if_graph = cast("IfGraphInfo", self.device_ir.graphs[if_graph_idx])

--- a/helion/_compiler/pallas/aten_lowering.py
+++ b/helion/_compiler/pallas/aten_lowering.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 from typing import cast
 
 import torch
+from torch._inductor.codegen.simd import constant_repr
 from torch.fx.node import Node
 from torch.fx.node import map_arg
 
@@ -39,10 +40,13 @@ from ..aten_lowering import reshape_lowering
 from ..aten_lowering import sort_lowering
 from ..aten_lowering import squeeze_lowering
 from ..aten_lowering import topk_lowering
+from ..aten_lowering import unsqueeze_lowering
 from ..aten_lowering import view_lowering
+from ..aten_lowering import where_lowering
 from ..compile_environment import CompileEnvironment
 from ..matmul_utils import _emit_pallas_matmul
 from ..matmul_utils import _needs_f32_accumulator
+from . import codegen as pallas_codegen
 
 if TYPE_CHECKING:
     from ..aten_lowering import LoweringContext
@@ -58,6 +62,144 @@ def codegen_argmin_pallas(ctx: LoweringContext, node: Node) -> ast.AST:
     return _pallas_argreduce(ctx, node, "argmin")
 
 
+@where_lowering.register_codegen("pallas")
+def codegen_where_pallas(ctx: LoweringContext, node: Node) -> object:
+    env = CompileEnvironment.current()
+    cond, x, y = map_arg(node.args, lambda arg: _env_arg(ctx, arg))
+
+    def ensure_ast(value: object) -> ast.AST:
+        if isinstance(value, ast.AST):
+            return value
+        if isinstance(value, (int, float, bool)):
+            return expr_from_string(constant_repr(value))
+        raise AssertionError(f"unsupported where operand: {type(value)!r}")
+
+    cond_ast = ensure_ast(cond)
+    x_ast = ensure_ast(x)
+    y_ast = ensure_ast(y)
+    ShapeDim = int | torch.SymInt
+
+    def tensor_shape(arg: object) -> tuple[ShapeDim, ...] | None:
+        if isinstance(arg, Node):
+            value = arg.meta.get("val")
+            if isinstance(value, torch.Tensor):
+                return cast("tuple[ShapeDim, ...]", tuple(value.size()))
+        return None
+
+    def shapes_match(
+        lhs: tuple[ShapeDim, ...] | None, rhs: tuple[ShapeDim, ...]
+    ) -> bool:
+        if lhs is None or len(lhs) != len(rhs):
+            return False
+        for left, right in zip(lhs, rhs, strict=True):
+            if not env.known_equal(left, right):
+                return False
+        return True
+
+    cond_arg = node.args[0]
+    output_val = node.meta.get("val")
+    if isinstance(cond_arg, Node) and isinstance(output_val, torch.Tensor):
+        cond_val = cond_arg.meta.get("val")
+        if isinstance(cond_val, torch.Tensor) and cond_val.dtype is torch.bool:
+            output_shape = cast("tuple[ShapeDim, ...]", tuple(output_val.size()))
+            branch_asts = ((node.args[1], x_ast), (node.args[2], y_ast))
+            layout_anchor = next(
+                (
+                    branch_ast
+                    for branch_arg, branch_ast in branch_asts
+                    if shapes_match(tensor_shape(branch_arg), output_shape)
+                ),
+                next(
+                    (
+                        branch_ast
+                        for branch_arg, branch_ast in branch_asts
+                        if tensor_shape(branch_arg) is not None
+                    ),
+                    x_ast,
+                ),
+            )
+            numeric_select = pallas_codegen.numeric_where_expr(
+                cond_ast,
+                x_ast,
+                y_ast,
+                output_val.dtype,
+                layout_anchor,
+            )
+            if numeric_select is not None:
+                return numeric_select
+            if not shapes_match(tuple(cond_val.size()), output_shape):
+                cond_ast = pallas_codegen.layout_tied_bf16_mask_expr(
+                    cond_ast,
+                    layout_anchor,
+                )
+                cond_ast = expr_from_string(
+                    "({cond}) == jnp.array(1, dtype=jnp.bfloat16)",
+                    cond=cond_ast,
+                )
+            else:
+                cond_ast = expr_from_string("({cond}) != 0", cond=cond_ast)
+
+    return expr_from_string(
+        env.backend.where_expr("{cond}", "{x}", "{y}"),
+        cond=cond_ast,
+        x=x_ast,
+        y=y_ast,
+    )
+
+
+def _pallas_bool_safe_singleton_index(
+    tensor: ast.AST,
+    input_val: torch.Tensor,
+    args: list[str],
+    singleton_shape: str | None = None,
+) -> ast.AST:
+    index = ", ".join(args)
+    if input_val.dtype is torch.bool and "None" in args:
+        # Mosaic cannot reshape bool vectors directly (jax-ml/jax#37370).
+        if singleton_shape is not None:
+            return pallas_codegen.numeric_mask_reshape_expr(tensor, singleton_shape)
+        tensor = pallas_codegen.numeric_mask_expr(tensor)
+    return expr_from_string(f"{{tensor}}[{index}]", tensor=tensor)
+
+
+def _pallas_singleton_shape(
+    input_val: torch.Tensor,
+    args: list[str],
+    ctx: LoweringContext,
+    *,
+    compacted_args: bool = False,
+) -> str:
+    tile_strategy = ctx.cg.device_function.tile_strategy
+    if compacted_args:
+        input_dims = iter(tile_strategy.shape_dims([*input_val.size()]))
+        shape_dims = ["1" if arg == "None" else next(input_dims) for arg in args]
+        return f"[{', '.join(shape_dims)}]"
+
+    input_dims = iter(input_val.size())
+    shape = [1 if arg == "None" else next(input_dims) for arg in args]
+    return tile_strategy.shape_str(shape)
+
+
+@unsqueeze_lowering.register_codegen("pallas")
+def codegen_unsqueeze_pallas(ctx: LoweringContext, node: Node) -> object:
+    assert not node.kwargs, "unsqueeze kwargs not supported"
+    tensor, dim = map_arg(node.args, lambda arg: _env_arg(ctx, arg))
+    assert isinstance(tensor, ast.AST)
+    assert isinstance(dim, int)
+    input_node = node.args[0]
+    assert isinstance(input_node, Node)
+    input_val = input_node.meta["val"]
+    assert isinstance(input_val, torch.Tensor)
+    ndim = input_val.ndim
+    if dim < 0:
+        dim += ndim + 1
+    assert 0 <= dim <= ndim, f"Invalid dim {dim} for tensor with {ndim} dims"
+    args = [":"] * ndim
+    args.insert(dim, "None")
+    singleton_shape = _pallas_singleton_shape(input_val, args, ctx)
+    return _pallas_bool_safe_singleton_index(tensor, input_val, args, singleton_shape)
+
+
 @squeeze_lowering.register_codegen("pallas")
 @view_lowering.register_codegen("pallas")
 @reshape_lowering.register_codegen("pallas")
@@ -71,12 +213,7 @@ def codegen_view_pallas(ctx: LoweringContext, node: Node) -> object:
     if isinstance(input_node, Node):
         input_val = input_node.meta.get("val")
         if isinstance(input_val, torch.Tensor) and input_val.dtype is torch.bool:
-            # Mosaic cannot reshape bool vectors directly:
-            # https://github.com/jax-ml/jax/issues/37370
-            return expr_from_string(
-                f"(jnp.reshape(({{tensor}}).astype(jnp.int32), {shape_str}) != 0)",
-                tensor=tensor,
-            )
+            tensor = pallas_codegen.numeric_mask_expr(tensor)
     return expr_from_string(f"jnp.reshape({{tensor}}, {shape_str})", tensor=tensor)
 
 
@@ -151,15 +288,21 @@ def codegen_expand_pallas(ctx: LoweringContext, node: Node) -> object:
     shape = [*val.size()]
     # pyrefly: ignore [missing-attribute]
     input_val = node.args[0].meta["val"]
+    assert isinstance(input_val, torch.Tensor)
     if input_val.ndim != len(shape):
         tile_strategy = ctx.cg.device_function.tile_strategy
         broadcasting = tile_strategy.broadcast_expand_dims(
             tuple(input_val.shape), tuple(shape)
         )
         if broadcasting:
-            tensor = expr_from_string(
-                f"{{tensor}}[{', '.join(broadcasting)}]", tensor=tensor
+            singleton_shape = _pallas_singleton_shape(
+                input_val, broadcasting, ctx, compacted_args=True
             )
+            tensor = _pallas_bool_safe_singleton_index(
+                tensor, input_val, broadcasting, singleton_shape
+            )
+    elif input_val.dtype is torch.bool:
+        tensor = pallas_codegen.numeric_mask_expr(tensor)
     shape_str = ctx.cg.device_function.tile_strategy.shape_str(shape)
     return expr_from_string(
         f"jnp.broadcast_to({{tensor}}, {shape_str})",

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import torch
 
 from helion._compiler.ast_extension import expr_from_string
+from helion._compiler.compile_environment import CompileEnvironment
 from helion._compiler.pallas.vmem_scalar_load import classify_vmem_scalar_load
 from helion._compiler.pallas.vmem_scalar_load import emit_vmem_scalar_load
 
@@ -20,6 +21,172 @@ if TYPE_CHECKING:
     from helion._compiler.aten_lowering import LoweringContext
     from helion._compiler.inductor_lowering import CodegenState
     from helion._compiler.tile_strategy import DeviceLoopOrGridState
+
+
+def _select_mask_dtype(dtype: torch.dtype) -> str | None:
+    if dtype.is_floating_point:
+        if dtype is torch.float64:
+            return None
+        if dtype.itemsize == 1:
+            return "jnp.uint8"
+        if dtype.itemsize == 2:
+            return "jnp.uint16"
+        if dtype.itemsize == 4:
+            return "jnp.uint32"
+        return None
+    if dtype is torch.int8:
+        return "jnp.int8"
+    if dtype is torch.int16:
+        return "jnp.int16"
+    if dtype is torch.int32:
+        return "jnp.int32"
+    if dtype is torch.uint8:
+        return "jnp.uint8"
+    if dtype is torch.uint32:
+        return "jnp.uint32"
+    return None
+
+
+def _mask_arithmetic_dtype(dtype: str) -> str:
+    if dtype == "jnp.uint8":
+        return "jnp.uint16"
+    if dtype == "jnp.int8":
+        return "jnp.int16"
+    return dtype
+
+
+def layout_tied_bf16_mask_expr(
+    mask: ast.AST,
+    layout_anchor: ast.AST,
+) -> ast.AST:
+    """Expand a numeric predicate through a value whose layout Mosaic already knows."""
+
+    mask_value = expr_from_string(
+        "lax.convert_element_type({mask}, jnp.bfloat16)",
+        mask=mask,
+    )
+    return expr_from_string(
+        "jnp.ones_like({layout_anchor}, dtype=jnp.bfloat16) * ({mask_value})",
+        mask_value=mask_value,
+        layout_anchor=layout_anchor,
+    )
+
+
+def numeric_mask_expr(mask: ast.AST, dtype: str = "jnp.int32") -> ast.AST:
+    """Materialize a predicate as a numeric 0/1 tensor before shape relayouts."""
+
+    return expr_from_string(
+        f"lax.convert_element_type(({{mask}}) != 0, {dtype})",
+        mask=mask,
+    )
+
+
+def numeric_mask_reshape_expr(
+    mask: ast.AST, shape: str, dtype: str = "jnp.int32"
+) -> ast.AST:
+    """Cast a predicate to numeric, then add singleton dimensions by reshape."""
+
+    return expr_from_string(
+        f"jnp.reshape({{mask}}, {shape})",
+        mask=numeric_mask_expr(mask, dtype),
+    )
+
+
+def numeric_where_expr(
+    mask: ast.AST,
+    true_value: ast.AST,
+    false_value: ast.AST,
+    output_dtype: torch.dtype,
+    layout_anchor: ast.AST | None = None,
+) -> ast.AST | None:
+    """Select with a layout-tied numeric bit mask on TPU."""
+
+    value_bit_dtype = _select_mask_dtype(output_dtype)
+    if value_bit_dtype is None:
+        return None
+    mask_dtype = _mask_arithmetic_dtype(value_bit_dtype)
+    value_dtype = CompileEnvironment.current().backend.dtype_str(output_dtype)
+    if layout_anchor is None:
+        layout_anchor = true_value
+    mask_value = (
+        "lax.convert_element_type("
+        "jnp.ones_like({layout_anchor}, dtype=jnp.bfloat16) * "
+        "lax.convert_element_type(({mask}) != 0, jnp.bfloat16), "
+        f"{mask_dtype})"
+    )
+    mask_bits = (
+        f"(jnp.zeros_like({{layout_anchor}}, dtype={mask_dtype}) - {mask_value})"
+    )
+    if output_dtype.is_floating_point:
+        true_bits = (
+            "lax.bitcast_convert_type("
+            f"lax.convert_element_type({{true_value}}, {value_dtype}), "
+            f"{value_bit_dtype})"
+        )
+        false_bits = (
+            "lax.bitcast_convert_type("
+            f"lax.convert_element_type({{false_value}}, {value_dtype}), "
+            f"{value_bit_dtype})"
+        )
+        if mask_dtype != value_bit_dtype:
+            true_bits = f"lax.convert_element_type({true_bits}, {mask_dtype})"
+            false_bits = f"lax.convert_element_type({false_bits}, {mask_dtype})"
+        selected_bits = (
+            "jnp.bitwise_or("
+            f"jnp.bitwise_and({mask_bits}, {true_bits}), "
+            f"jnp.bitwise_and(jnp.bitwise_not({mask_bits}), {false_bits})"
+            ")"
+        )
+        if mask_dtype != value_bit_dtype:
+            selected_bits = (
+                f"lax.convert_element_type({selected_bits}, {value_bit_dtype})"
+            )
+        return expr_from_string(
+            f"lax.bitcast_convert_type({selected_bits}, {value_dtype})",
+            mask=mask,
+            layout_anchor=layout_anchor,
+            true_value=true_value,
+            false_value=false_value,
+        )
+    true_bits = (
+        "lax.convert_element_type("
+        f"lax.convert_element_type({{true_value}}, {value_dtype}), {mask_dtype})"
+    )
+    false_bits = (
+        "lax.convert_element_type("
+        f"lax.convert_element_type({{false_value}}, {value_dtype}), {mask_dtype})"
+    )
+    return expr_from_string(
+        "lax.convert_element_type("
+        "jnp.bitwise_or("
+        f"jnp.bitwise_and({mask_bits}, {true_bits}), "
+        f"jnp.bitwise_and(jnp.bitwise_not({mask_bits}), {false_bits})"
+        f"), {value_dtype})",
+        mask=mask,
+        layout_anchor=layout_anchor,
+        true_value=true_value,
+        false_value=false_value,
+    )
+
+
+def numeric_mask_select_expr(
+    mask: ast.AST,
+    true_value: ast.AST,
+    false_value: ast.AST,
+    output_dtype: torch.dtype,
+    layout_anchor: ast.AST | None = None,
+) -> ast.AST:
+    selected = numeric_where_expr(
+        mask, true_value, false_value, output_dtype, layout_anchor
+    )
+    if selected is not None:
+        return selected
+    return expr_from_string(
+        "jnp.where(({mask}) != 0, {true_value}, {false_value})",
+        mask=mask,
+        true_value=true_value,
+        false_value=false_value,
+    )
 
 
 def load_expr(

--- a/helion/_compiler/pallas/memory_ops.py
+++ b/helion/_compiler/pallas/memory_ops.py
@@ -17,6 +17,7 @@ from ...language.memory_ops import _maybe_materialize_tile_index_load
 from ...language.memory_ops import load
 from ...language.memory_ops import store
 from ..ast_extension import statement_from_string
+from ..compile_environment import CompileEnvironment
 from . import codegen as pallas_codegen
 
 if TYPE_CHECKING:
@@ -56,6 +57,8 @@ def _(state: CodegenState) -> None:
     if not is_scatter and state.device_function.carry_tiles:
         if emit_carry_store(state, tensor, subscript, name, idx_str, value):
             return
+    if tensor.dtype is torch.bool:
+        value = CompileEnvironment.current().backend.cast_ast(value, torch.bool)
     state.codegen.add_statement(
         statement_from_string(f"{name}[{idx_str}] = {{value}}", value=value)
     )

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -3748,13 +3748,24 @@ def _(state: CodegenState) -> list[object]:
     assert isinstance(state.codegen, GenerateAST)
 
     if graph_info.predicate_is_tensor:
-        raise BackendUnsupported(
-            "pallas",
-            "if-statements with tensor-derived predicates. "
-            "lax.cond requires a scalar predicate, but tensor loads produce "
-            "vectors on TPU due to hardware tiling constraints. "
-            "Use a scalar kernel argument for the condition instead.",
-        )
+        predicate_tensor_numel = graph_info.predicate_tensor_numel
+        assert predicate_tensor_numel is not None
+        if not CompileEnvironment.current().known_equal(predicate_tensor_numel, 1):
+            raise BackendUnsupported(
+                "pallas",
+                "if-statements with multi-element tensor-derived predicates "
+                f"(numel={predicate_tensor_numel}); lax.cond requires a scalar",
+            )
+        predicate_value = state.proxy_arg(0)
+        assert isinstance(predicate_value, torch.Tensor)
+        if predicate_value.dtype is torch.bool:
+            test = expr_from_string(
+                "lax.convert_element_type({test}, jnp.int32)", test=test
+            )
+        if predicate_value.ndim > 0:
+            index = ", ".join("0" for _ in range(predicate_value.ndim))
+            test = expr_from_string(f"{{test}}[{index}]", test=test)
+        test = expr_from_string("({test}) != 0", test=test)
 
     if_body_stmts: list[ast.AST] = []
     with state.codegen.set_statements(if_body_stmts):
@@ -3868,17 +3879,16 @@ def _(state: CodegenState) -> ast.AST:
         return state.ast_arg(0)
     # Combine float masks via multiplication (equivalent to bool AND).
     mask_expr = " * ".join(mask_exprs)
-    if len(mask_exprs) < len(input_sizes):
-        mask_expr = backend.broadcast_to_expr(
-            mask_expr, state.tile_strategy.shape_str(input_sizes)
-        )
-    # Ensure the masked value literal matches the tensor dtype
     input_dtype = tensor.dtype
+    # Ensure the masked value literal matches the tensor dtype.
     other_typed = expr_from_string(
         backend.full_expr([], constant_repr(other), input_dtype)
     )
-    return expr_from_string(
-        backend.where_expr(mask_expr, "{expr}", "{other}"),
-        expr=state.ast_arg(0),
-        other=other_typed,
+    from . import codegen as pallas_codegen
+
+    return pallas_codegen.numeric_mask_select_expr(
+        expr_from_string(mask_expr),
+        state.ast_arg(0),
+        other_typed,
+        input_dtype,
     )

--- a/helion/_compiler/pallas/view_ops.py
+++ b/helion/_compiler/pallas/view_ops.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import torch
+
+from ... import exc
 from ...language import _decorators
 from ...language.view_ops import join
 from ...language.view_ops import split
+from ...language.view_ops import subscript
 from ..ast_extension import expr_from_string
+from . import codegen as pallas_codegen
 
 if TYPE_CHECKING:
     import ast
@@ -30,4 +35,32 @@ def _(state: CodegenState) -> ast.AST:
         "jnp.stack(jnp.broadcast_arrays({tensor0}, {tensor1}), axis=-1)",
         tensor0=state.ast_arg(0),
         tensor1=state.ast_arg(1),
+    )
+
+
+@_decorators.codegen(subscript, "pallas")
+def codegen_subscript_pallas(state: CodegenState) -> ast.AST:
+    output_keys: list[str] = []
+    has_new_axis = False
+    indices = state.proxy_arg(1)
+    assert isinstance(indices, (list, tuple))
+    for value in indices:
+        if value is None:
+            output_keys.append("None")
+            has_new_axis = True
+        elif isinstance(value, slice) and value == slice(None):
+            output_keys.append(":")
+        else:
+            raise exc.InvalidIndexingType(repr(value))
+
+    tensor = state.proxy_arg(0)
+    if has_new_axis and isinstance(tensor, torch.Tensor) and tensor.dtype is torch.bool:
+        output = state.fake_value
+        assert isinstance(output, torch.Tensor)
+        shape = state.tile_strategy.shape_str([*output.size()])
+        return pallas_codegen.numeric_mask_reshape_expr(state.ast_arg(0), shape)
+
+    return expr_from_string(
+        f"{{base}}[{', '.join(output_keys)}]",
+        base=state.ast_arg(0),
     )

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1693,7 +1693,7 @@ class TestExamples(RefEagerTestBase, TestCase):
                     rtol=rtol,
                 )
 
-    @xfailIfPallasTpu("tensor-derived if-predicates not supported")
+    @xfailIfPallasTpu("requires padded scalar/tile load widening")
     def test_grouped_gemm_jagged(self):
         # Build small jagged grouped GEMM inputs
         torch.manual_seed(0)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -23,6 +23,7 @@ from helion._testing import _bound_test_config
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
 from helion._testing import skipIfPallasInterpret
+from helion._testing import skipIfRefEager
 from helion._testing import skipUnlessPallas
 from helion._testing import xfailIfPallas
 from helion._testing import xfailIfPallasInterpret
@@ -731,6 +732,43 @@ def _constant_pad_neg_inf_pallas_kernel(x: torch.Tensor) -> torch.Tensor:
     return out
 
 
+class TestPallasBoolExpandCodegen(TestCase):
+    @skipIfRefEager("Pallas codegen inspection requires compilation")
+    @skipUnlessPallas("JAX/Pallas not available")
+    def test_bool_expand_leading_singleton_uses_compacted_source_shape(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def pallas_bool_expand_leading_singleton_where(
+            x: torch.Tensor, y: torch.Tensor
+        ) -> torch.Tensor:
+            m, n, k_dim = x.size()
+            out = torch.empty_like(y)
+            for tile_m, tile_n in hl.tile([m, n]):
+                mask = x[tile_m, tile_n, :] > 0
+                mask = mask.expand(
+                    y.size(0), tile_m.block_size, tile_n.block_size, k_dim
+                )
+                out[:, tile_m, tile_n, :] = torch.where(
+                    mask, y[:, tile_m, tile_n, :], 0.0
+                )
+            return out
+
+        x = torch.randn(16, 128, 4)
+        y = torch.randn(2, 16, 128, 4)
+
+        code = pallas_bool_expand_leading_singleton_where.bind((x, y)).to_code(
+            helion.Config(block_sizes=[16, 128], flatten_loop=True)
+        )
+
+        self.assertRegex(
+            code,
+            r"jnp\.reshape\([^\n]+, \[1, _BLOCK_SIZE_0_1, 4\]\)",
+        )
+        self.assertNotRegex(
+            code,
+            r"jnp\.reshape\([^\n]+, \[1, _BLOCK_SIZE_0_1\]\)",
+        )
+
+
 @onlyBackends(["triton", "pallas"])
 @skipUnlessPallas("JAX/Pallas TPU not available")
 class TestPallas(TestCase):
@@ -1348,7 +1386,10 @@ class TestPallas(TestCase):
 
         expected = torch.where(x[:, :1] > 0, x, torch.zeros_like(x))
         torch.testing.assert_close(result, expected)
-        self.assertIn("astype(jnp.int32)", code)
+        self.assertRegex(
+            code,
+            r"(?:\.astype\(jnp\.int32\)|lax\.convert_element_type\([^\n]+,\s*jnp\.int32\))",
+        )
 
     def test_indirect_gather_with_tiled_dim(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
@@ -5073,13 +5114,13 @@ class TestPallas(TestCase):
                     pallas_loop_type=loop_type,
                     pallas_worklist_grouping=grouping,
                 )
-                # x's masked load is raw (no eager ``* mask``), feeds a transpose,
-                # and the mask reappears as a post-transpose ``jnp.where``.
+                # x's masked load is raw, feeds a transpose, and the mask
+                # reappears in the post-transpose layout.
                 producer = self._transpose_operand_producer(code)
                 self.assertIsNotNone(producer)
                 self.assertRegex(producer, r"= x\[")
                 self.assertNotIn("* mask", producer)
-                self.assertIn("jnp.where", code)
+                self.assertRegex(code, r"_mask_to = .*bitcast_convert_type")
                 # Worklist flattening matches the eager reference on the partial
                 # tiles. fori_loop miscompiles jagged tiles in pallas interpret
                 # (a pre-existing, unrelated issue), so it is not a sound numeric

--- a/test/test_pallas_worklist.py
+++ b/test/test_pallas_worklist.py
@@ -2525,7 +2525,7 @@ class TestResidentPrepHoistCodegen(unittest.TestCase):
                 score_masks = [
                     line
                     for line in code.splitlines()
-                    if "jnp.where" in line and ", scores" in line
+                    if "_mask_to_" in line and "zeros_like(scores" in line
                 ]
                 self.assertEqual(score_masks, [])
                 self.assertEqual(code.count("lax.dot_general(scores"), grouping)
@@ -2537,16 +2537,17 @@ class TestResidentPrepHoistCodegen(unittest.TestCase):
         score_masks = [
             line
             for line in code.splitlines()
-            if "jnp.where" in line and ", scores" in line
+            if "_mask_to_" in line and "zeros_like(scores" in line
         ]
         self.assertEqual(len(score_masks), 1)
+        self.assertIn("jnp.full([], 0, jnp.float32)", score_masks[0])
         self.assertNotIn("lax.dot_general(scores", code)
 
     def test_flash_resident_prep_keeps_softmax_neg_inf_mask(self):
         # Flash's fill-0 K/V load masks elide (prep cache zeroed), but the amax
         # reduction's softmax mask fills -inf (!= the cache's 0 tail) and is downstream
-        # of the dot, so it is preserved.  Assert the score mask specifically: a
-        # jnp.where whose fill is a -inf full (not merely the m_i init's -inf full).
+        # of the dot, so it is preserved. Assert that the numeric mask feeding amax
+        # contains the -inf fill (not merely the m_i init's -inf full).
         kernel = helion.kernel(
             _flash_prep_kernel.fn,
             backend="pallas",
@@ -2557,13 +2558,17 @@ class TestResidentPrepHoistCodegen(unittest.TestCase):
             _worklist_config([8, 8])
         )
         self.assertIn("_rc_prep_refill", code)  # prep cache installed
-        self.assertRegex(code, r"jnp\.where\([^\n]*jnp\.full\(\[\], float\('-inf'\)")
+        self.assertRegex(
+            code,
+            r"(_mask_to_\d+) = [^\n]*jnp\.full\(\[\], float\('-inf'\)[^\n]*"
+            r"\n\s*amax = [^\n]*jnp\.max\(\1,",
+        )
 
     def test_prep_fallback_leaves_load_masks_intact(self):
         # If prep lowerings are not installed (a fallback), elision must not fire: no
         # cache is zero-filled, so the per-tile masks are still required.  Patch the
         # prep-lowering install to return [] (the shape of every fallback branch) and
-        # confirm no prep cache is read and the reduction keeps its jnp.where masks.
+        # confirm no prep cache is read and the reduction keeps its numeric masks.
         with patch(
             "helion._compiler.pallas.tracing_ops._prepare_resident_prep_lowerings",
             return_value=[],
@@ -2572,7 +2577,11 @@ class TestResidentPrepHoistCodegen(unittest.TestCase):
                 _worklist_config([8, 8])
             )
         self.assertNotIn("_prep[", code)  # no prep cache installed -> none read
-        self.assertIn("jnp.where", code)  # per-tile masks preserved
+        self.assertRegex(
+            code,
+            r"_mask_to_\d+ = [^\n]*mask_2\.astype\(jnp\.float32\)[^\n]*"
+            r"jnp\.full\(\[\], 0,",
+        )
 
     def test_four_dim_resident_prep_tail_mask_tracks_ordered_axis(self):
         qo = _offsets([12, 20, 5, 30])

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -62,6 +62,24 @@ class TestViews(RefEagerTestBase, TestCase):
             result, torch.nn.functional.softmax(x, dim=1), rtol=1e-2, atol=1e-1
         )
 
+    @onlyBackends(["pallas"])
+    def test_pallas_bool_unsqueeze_where_mask(self):
+        @helion.kernel(static_shapes=True)
+        def row_mask(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile(x.size()):
+                mask = (x[tile_m, 0] > 0).unsqueeze(1)
+                out[tile_m, tile_n] = torch.where(mask, x[tile_m, tile_n], 0.0)
+            return out
+
+        x = torch.arange(-8, 8, device=DEVICE, dtype=torch.float32).reshape(4, 4)
+        code, result = code_and_output(row_mask, (x,), block_sizes=[4, 4])
+
+        self.assertIn("jnp.reshape(lax.convert_element_type", code)
+        self.assertIn("!= 0", code)
+        expected = torch.where((x[:, 0] > 0)[:, None], x, torch.zeros_like(x))
+        torch.testing.assert_close(result, expected)
+
     def test_softmax_view_reshape(self):
         @helion.kernel(config={"block_size": 1})
         def softmax(x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Stacked PRs:
 * #2962
 * #2957
 * #2956
 * #2955
 * #2954
 * #2953
 * #2952
 * #2951
 * #2949
 * #2948
 * #2947
 * #2946
 * #2945
 * #2944
 * __->__#2943
 * #2942


--- --- ---

### Support Pallas numeric masks and scalar predicates


Example fixed: grouped_gemm_jagged under Pallas, plus later jagged examples that branch on scalar tensor predicates.

Compiler/runtime side: lower TPU boolean masks through numeric select and bit-mask forms, support singleton tensor predicates in `lax.cond`, and keep bool reshapes and broadcasts legal under Mosaic.

Why needed: Mosaic rejects several raw bool vector layouts, and scalar tensor predicates must lower as JAX control-flow operands rather than Python booleans.
