### PR TITLE
Support Pallas padded loads and scalar widening

### DIFF
--- a/examples/gdn_fwd_h.py
+++ b/examples/gdn_fwd_h.py
@@ -99,6 +99,21 @@ def helion_gdn_fwd_h_tb(
     return lambda: helion_gdn_fwd_h(k, w, u, g, chunk_size)
 
 
+def _orthogonalize_w(w: torch.Tensor) -> torch.Tensor:
+    """Build the constrained ``w`` test input without relying on TPU SVD."""
+    device = w.device
+    w_svd = w.permute(0, 1, 3, 2, 4)
+    if w_svd.device.type == "tpu":
+        w_svd = w_svd.cpu()
+    wu, _, wv = torch.linalg.svd(w_svd, full_matrices=False)
+    w = torch.einsum("bnhik,bnhkj->bnhij", wu, wv)
+    return (
+        w.permute(0, 1, 3, 2, 4)
+        .reshape(w.shape[0], w.shape[1] * w.shape[3], w.shape[2], w.shape[4])
+        .to(device=device, dtype=torch.bfloat16)
+    )
+
+
 # %%
 # Reference Function
 # -------------
@@ -180,13 +195,7 @@ def test(
         device=DEVICE,
     )
     # w = torch.nn.functional.rms_norm(w.to(torch.bfloat16), (dhead,))
-    wu, ws, wv = torch.linalg.svd(w.permute(0, 1, 3, 2, 4), full_matrices=False)
-    w = torch.einsum("bnhik,bnhkj->bnhij", wu, wv)
-    w = (
-        w.permute(0, 1, 3, 2, 4)
-        .reshape(batch, seqlen, nheads, dhead)
-        .to(torch.bfloat16)
-    )
+    w = _orthogonalize_w(w)
     u = torch.randn(batch, seqlen, nheads, dstate, dtype=torch.bfloat16, device=DEVICE)
     u = torch.nn.functional.rms_norm(u, [dstate])
     g = torch.cumsum(

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -386,6 +386,16 @@ class Backend(abc.ABC):
         """Called during `type_propagation` when processing a `load` memory op on fake tensors"""
         return
 
+    def maybe_specialize_matmul_alignment_dim(
+        self,
+        fake: torch.Tensor,
+        tensor_dim: int,
+        block_id: int | None,
+        env: CompileEnvironment,
+    ) -> None:
+        """Specialize a symbolic matmul dimension for backend alignment, if needed."""
+        return
+
     def adjust_block_size_constraints(
         self,
         block_specs: list[object],

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -3506,6 +3506,27 @@ def _collect_memory_op_facts(
             )
             memory_op_index += 1
 
+    for node, _fact in records:
+        if operands.get(node) is None:
+            continue
+        fake = _accessed_tensor_fake(node)
+        index_list = node.args[1] if len(node.args) >= 2 else None
+        if fake is None or not isinstance(index_list, (list, tuple)):
+            continue
+        tensor_dim = 0
+        for sub in index_list:
+            if sub is None:
+                continue
+            if tensor_dim >= fake.ndim:
+                break
+            if isinstance(sub, int):
+                tensor_dim += 1
+                continue
+            env.backend.maybe_specialize_matmul_alignment_dim(
+                fake, tensor_dim, _subscript_block_id(env, sub), env
+            )
+            tensor_dim += 1
+
     facts = [fact._replace(matmul_operand=operands.get(node)) for node, fact in records]
     return facts, liveness_by_axis
 

--- a/helion/_compiler/pallas/atomic_ops.py
+++ b/helion/_compiler/pallas/atomic_ops.py
@@ -27,6 +27,7 @@ from ..ast_extension import expr_from_string
 from ..ast_extension import statement_from_string
 from ..compile_environment import CompileEnvironment
 from ..host_function import HostFunction
+from . import codegen as pallas_codegen
 
 if TYPE_CHECKING:
     import ast
@@ -36,59 +37,63 @@ if TYPE_CHECKING:
 
 def _pallas_atomic_load_prev(
     state: CodegenState,
-) -> tuple[str, str, str]:
+) -> tuple[str, list[str], str, str]:
     """Load previous value for a Pallas atomic op.
 
     On TPU, each kernel instance has exclusive access to its tile, so
     atomics are implemented as regular load-compute-store sequences.
 
-    Returns (tensor_name, index_str, prev_var_name).
+    Returns (tensor_name, index_parts, index_str, prev_var_name).
     """
-    from . import codegen as pallas_codegen
-
     target = state.proxy_arg(0)
     index = state.proxy_arg(1)
     assert isinstance(target, torch.Tensor)
     assert isinstance(index, (list, tuple))
+    index = list(index)
 
     host_function = HostFunction.current()
     if target not in host_function.tensor_to_origin:
         raise exc.AtomicOnDeviceTensor("pallas atomic")
 
     name = state.device_function.tensor_arg(target).name
-    index_str, _ = pallas_codegen.index_str(state, index, target)
+    name = pallas_codegen.vmem_name(state, name)
+    index_parts, _ = pallas_codegen.index_parts(state, index, target)
+    index_str = ", ".join(index_parts)
 
     prev_var = state.device_function.new_var("_prev", dce=True)
-    state.codegen.add_statement(
-        statement_from_string(f"{prev_var} = {name}[{index_str}]")
+    prev = expr_from_string(f"{name}[{index_str}]")
+    prev = pallas_codegen._pad_clamped_load_expr(
+        state, index, target, index_parts, prev
     )
-    return name, index_str, prev_var  # pyrefly: ignore[bad-return]
+    state.codegen.add_statement(
+        statement_from_string(f"{prev_var} = {{prev}}", prev=prev)
+    )
+    return name, index_parts, index_str, prev_var
 
 
-def _clamp_atomic_value(state: CodegenState, value_ast: ast.AST) -> ast.AST:
-    """Slice an atomic value operand to the clamped store ref.
-
-    The RMW reads ``_prev`` and stores directly to the (possibly clamped) ref,
-    both dim-shaped, but the loaded value operand is padded to block shape by
-    ``load_expr``.  Slice it back to match, mirroring ``sliced_value_for_store``
-    on the normal store path.  A no-op when the ref is not clamped.
-    """
-    from . import codegen as pallas_codegen
-
+def _pallas_store_update(
+    state: CodegenState,
+    name: str,
+    index_parts: list[str],
+    index_str: str,
+    value: ast.AST,
+) -> None:
     target = state.proxy_arg(0)
     index = state.proxy_arg(1)
     assert isinstance(target, torch.Tensor)
     assert isinstance(index, (list, tuple))
-    parts, _ = pallas_codegen.index_parts(state, list(index), target)
-    return pallas_codegen.sliced_value_for_store(
-        state, target, list(index), parts, value_ast
+    value = pallas_codegen.sliced_value_for_store(
+        state, target, index, index_parts, value
+    )
+    state.codegen.add_statement(
+        statement_from_string(f"{name}[{index_str}] = {{value}}", value=value)
     )
 
 
 @_decorators.codegen(atomic_add, "pallas")
 def _(state: CodegenState) -> ast.AST:
-    name, index_str, prev_var = _pallas_atomic_load_prev(state)
-    value_ast = _clamp_atomic_value(state, _to_ast_values([state.ast_args[2]])[0])
+    name, index_parts, index_str, prev_var = _pallas_atomic_load_prev(state)
+    value_ast = _to_ast_values([state.ast_args[2]])[0]
     target = state.proxy_arg(0)
     assert isinstance(target, torch.Tensor)
     backend = CompileEnvironment.current().backend
@@ -96,113 +101,107 @@ def _(state: CodegenState) -> ast.AST:
     # Cast the sum to the target dtype so the store doesn't fail when
     # the value dtype differs (e.g. float32 accumulator into bfloat16 ref).
     cast = backend.cast_expr(f"{prev_var} + {{value}}", target_dtype)
-    state.codegen.add_statement(
-        statement_from_string(f"{name}[{index_str}] = {cast}", value=value_ast)
+    _pallas_store_update(
+        state,
+        name,
+        index_parts,
+        index_str,
+        expr_from_string(cast, value=value_ast),
     )
     return expr_from_string(prev_var)
 
 
 @_decorators.codegen(atomic_xchg, "pallas")
 def _(state: CodegenState) -> ast.AST:
-    name, index_str, prev_var = _pallas_atomic_load_prev(state)
-    value_ast = _clamp_atomic_value(state, _to_ast_values([state.ast_args[2]])[0])
-    state.codegen.add_statement(
-        statement_from_string(f"{name}[{index_str}] = {{value}}", value=value_ast)
-    )
+    name, index_parts, index_str, prev_var = _pallas_atomic_load_prev(state)
+    value_ast = _to_ast_values([state.ast_args[2]])[0]
+    _pallas_store_update(state, name, index_parts, index_str, value_ast)
     return expr_from_string(prev_var)
 
 
 @_decorators.codegen(atomic_and, "pallas")
 def _(state: CodegenState) -> ast.AST:
-    name, index_str, prev_var = _pallas_atomic_load_prev(state)
-    value_ast = _clamp_atomic_value(state, _to_ast_values([state.ast_args[2]])[0])
-    state.codegen.add_statement(
-        statement_from_string(
-            f"{name}[{index_str}] = {prev_var} & {{value}}", value=value_ast
-        )
+    name, index_parts, index_str, prev_var = _pallas_atomic_load_prev(state)
+    value_ast = _to_ast_values([state.ast_args[2]])[0]
+    _pallas_store_update(
+        state,
+        name,
+        index_parts,
+        index_str,
+        expr_from_string(f"{prev_var} & {{value}}", value=value_ast),
     )
     return expr_from_string(prev_var)
 
 
 @_decorators.codegen(atomic_or, "pallas")
 def _(state: CodegenState) -> ast.AST:
-    name, index_str, prev_var = _pallas_atomic_load_prev(state)
-    value_ast = _clamp_atomic_value(state, _to_ast_values([state.ast_args[2]])[0])
-    state.codegen.add_statement(
-        statement_from_string(
-            f"{name}[{index_str}] = {prev_var} | {{value}}", value=value_ast
-        )
+    name, index_parts, index_str, prev_var = _pallas_atomic_load_prev(state)
+    value_ast = _to_ast_values([state.ast_args[2]])[0]
+    _pallas_store_update(
+        state,
+        name,
+        index_parts,
+        index_str,
+        expr_from_string(f"{prev_var} | {{value}}", value=value_ast),
     )
     return expr_from_string(prev_var)
 
 
 @_decorators.codegen(atomic_xor, "pallas")
 def _(state: CodegenState) -> ast.AST:
-    name, index_str, prev_var = _pallas_atomic_load_prev(state)
-    value_ast = _clamp_atomic_value(state, _to_ast_values([state.ast_args[2]])[0])
-    state.codegen.add_statement(
-        statement_from_string(
-            f"{name}[{index_str}] = {prev_var} ^ {{value}}", value=value_ast
-        )
+    name, index_parts, index_str, prev_var = _pallas_atomic_load_prev(state)
+    value_ast = _to_ast_values([state.ast_args[2]])[0]
+    _pallas_store_update(
+        state,
+        name,
+        index_parts,
+        index_str,
+        expr_from_string(f"{prev_var} ^ {{value}}", value=value_ast),
     )
     return expr_from_string(prev_var)
 
 
 @_decorators.codegen(atomic_max, "pallas")
 def _(state: CodegenState) -> ast.AST:
-    name, index_str, prev_var = _pallas_atomic_load_prev(state)
-    value_ast = _clamp_atomic_value(state, _to_ast_values([state.ast_args[2]])[0])
-    state.codegen.add_statement(
-        statement_from_string(
-            f"{name}[{index_str}] = jnp.maximum({prev_var}, {{value}})",
-            value=value_ast,
-        )
+    name, index_parts, index_str, prev_var = _pallas_atomic_load_prev(state)
+    value_ast = _to_ast_values([state.ast_args[2]])[0]
+    _pallas_store_update(
+        state,
+        name,
+        index_parts,
+        index_str,
+        expr_from_string(f"jnp.maximum({prev_var}, {{value}})", value=value_ast),
     )
     return expr_from_string(prev_var)
 
 
 @_decorators.codegen(atomic_min, "pallas")
 def _(state: CodegenState) -> ast.AST:
-    name, index_str, prev_var = _pallas_atomic_load_prev(state)
-    value_ast = _clamp_atomic_value(state, _to_ast_values([state.ast_args[2]])[0])
-    state.codegen.add_statement(
-        statement_from_string(
-            f"{name}[{index_str}] = jnp.minimum({prev_var}, {{value}})",
-            value=value_ast,
-        )
+    name, index_parts, index_str, prev_var = _pallas_atomic_load_prev(state)
+    value_ast = _to_ast_values([state.ast_args[2]])[0]
+    _pallas_store_update(
+        state,
+        name,
+        index_parts,
+        index_str,
+        expr_from_string(f"jnp.minimum({prev_var}, {{value}})", value=value_ast),
     )
     return expr_from_string(prev_var)
 
 
 @_decorators.codegen(atomic_cas, "pallas")
 def _(state: CodegenState) -> ast.AST:
-    from . import codegen as pallas_codegen
-
-    target = state.proxy_arg(0)
-    index = state.proxy_arg(1)
-    assert isinstance(target, torch.Tensor)
-    assert isinstance(index, (list, tuple))
-
-    host_function = HostFunction.current()
-    if target not in host_function.tensor_to_origin:
-        raise exc.AtomicOnDeviceTensor("pallas atomic_cas")
-
-    name = state.device_function.tensor_arg(target).name
-    index_str, _ = pallas_codegen.index_str(state, index, target)
-
-    prev_var = state.device_function.new_var("_prev", dce=True)
-    state.codegen.add_statement(
-        statement_from_string(f"{prev_var} = {name}[{index_str}]")
-    )
-
+    name, index_parts, index_str, prev_var = _pallas_atomic_load_prev(state)
     exp_ast, val_ast = _to_ast_values([state.ast_args[2], state.ast_args[3]])
-    exp_ast = _clamp_atomic_value(state, exp_ast)
-    val_ast = _clamp_atomic_value(state, val_ast)
-    state.codegen.add_statement(
-        statement_from_string(
-            f"{name}[{index_str}] = jnp.where({prev_var} == {{exp}}, {{val}}, {prev_var})",
+    _pallas_store_update(
+        state,
+        name,
+        index_parts,
+        index_str,
+        expr_from_string(
+            f"jnp.where({prev_var} == {{exp}}, {{val}}, {prev_var})",
             exp=exp_ast,
             val=val_ast,
-        )
+        ),
     )
     return expr_from_string(prev_var)

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from ...runtime.config import Config
     from ...runtime.kernel import BoundKernel
     from ...runtime.settings import DotPrecision
+    from ..compile_environment import CompileEnvironment
     from ..device_function import Argument
     from ..device_ir import GraphInfo
     from ..host_function import HostFunction
@@ -108,6 +109,101 @@ _PallasFlatDecompValue = (
         _PallasLaunchScalar,
     ]
 )
+
+
+def _pallas_empty_allocated_vars(body: list[ast.stmt]) -> set[str]:
+    """Return names allocated by top-level empty/empty_like/new_empty calls."""
+    result: set[str] = set()
+    for stmt in body:
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and isinstance(stmt.value, ast.Call)
+            and isinstance(stmt.value.func, ast.Attribute)
+            and stmt.value.func.attr in ("empty", "empty_like", "new_empty")
+        ):
+            result.add(stmt.targets[0].id)
+    return result
+
+
+def _disable_partial_initialized_store_tiling(graphs: list[GraphInfo]) -> None:
+    """Keep initialized output regions outside a partial grid well-defined."""
+    from ...language.atomic_ops import ATOMIC_OPS
+    from ...language.memory_ops import store
+    from ..compile_environment import CompileEnvironment
+    from ..device_function import DeviceFunction
+    from ..host_function import HostFunction
+    from .plan_tiling import NonePattern
+    from .plan_tiling import TileBeginWithOffsetPattern
+    from .plan_tiling import TilePattern
+
+    env = CompileEnvironment.current()
+    device_fn = DeviceFunction.current()
+    host_fn = HostFunction.current()
+    input_names = {arg.arg for arg in host_fn.args.args}
+    empty_names = _pallas_empty_allocated_vars(host_fn.body)
+
+    def outer_block_id(block_id: int) -> int | None:
+        seen: set[int] = set()
+        while block_id not in seen:
+            seen.add(block_id)
+            try:
+                spec = env.config_spec.block_sizes.block_id_lookup(block_id)
+            except KeyError:
+                # Fixed-size tiles have BlockSizeInfo but no tunable spec.
+                return block_id
+            owner = spec.owner_relative_bounded_by_block_id
+            if owner is None:
+                return block_id
+            block_id = owner
+        return None
+
+    for graph_info in graphs:
+        for node in graph_info.graph.nodes:
+            if node.op != "call_function" or node.target not in ATOMIC_OPS | {store}:
+                continue
+            tensor_node = node.args[0]
+            if not isinstance(tensor_node, torch.fx.Node):
+                continue
+            tensor = tensor_node.meta.get("val")
+            if not isinstance(tensor, torch.Tensor):
+                continue
+
+            origin = host_fn.tensor_to_origin.get(tensor)
+            name = origin.root_rw_name() if origin is not None else None
+            if name is not None and name not in input_names and name in empty_names:
+                continue
+
+            dim_tilings = device_fn.pallas_tensor_dim_tilings.get(id(tensor))
+            patterns = node.meta.get("indexing_patterns")
+            if dim_tilings is None or not isinstance(patterns, (list, tuple)):
+                continue
+
+            tensor_dim = 0
+            for pattern in patterns:
+                if isinstance(pattern, NonePattern):
+                    continue
+                if tensor_dim >= tensor.ndim:
+                    break
+                if isinstance(pattern, (TilePattern, TileBeginWithOffsetPattern)):
+                    owner = outer_block_id(pattern.block_id)
+                    owner_info = (
+                        env.block_sizes[owner]
+                        if owner is not None and owner < len(env.block_sizes)
+                        else None
+                    )
+                    dim_size = tensor.shape[tensor_dim]
+                    if not (
+                        owner_info is not None
+                        and isinstance(owner_info.size, (int, torch.SymInt))
+                        and isinstance(dim_size, (int, torch.SymInt))
+                        and env.known_equal(owner_info.size, dim_size)
+                    ):
+                        dim_tilings[tensor_dim].can_tile = False
+                tensor_dim += 1
+
+
 _PallasBlockSpecInfo = list[
     tuple[tuple[_PallasLaunchValue, ...], tuple[_PallasFlatDecompValue, ...]] | None
 ]
@@ -534,12 +630,24 @@ class PallasBackend(Backend):
         if isinstance(arg, (SymbolArgument, TensorSizeArg, TensorStrideArg)):
             from ..compile_environment import CompileEnvironment
 
+            fallback_device = (
+                "'cpu'"
+                if CompileEnvironment.current().settings.pallas_interpret
+                else "'tpu'"
+            )
             if tensor_host_args:
-                device_expr = f"{tensor_host_args[0]}.device"
-            elif CompileEnvironment.current().settings.pallas_interpret:
-                device_expr = "'cpu'"
+                tensor_devices = ", ".join(
+                    f"{tensor_arg}.device" for tensor_arg in tensor_host_args
+                )
+                if len(tensor_host_args) == 1:
+                    tensor_devices += ","
+                device_expr = (
+                    "next((device for device in "
+                    f"({tensor_devices}) if device.type != 'meta'), "
+                    f"{fallback_device})"
+                )
             else:
-                device_expr = "'tpu'"
+                device_expr = fallback_device
             # Scalars are passed as 1-dim tensors (shape [1]) rather than
             # 0-dim tensors (shape []) because TPU Pallas Mosaic lowering
             # requires rank >= 1 for all block specs.  A 0-dim input causes:
@@ -723,6 +831,49 @@ class PallasBackend(Backend):
             self.fake_tensor_loads = []
         self.fake_tensor_loads.append((tensor, index))
 
+    def maybe_specialize_matmul_alignment_dim(
+        self,
+        fake: torch.Tensor,
+        tensor_dim: int,
+        block_id: int | None,
+        env: CompileEnvironment,
+    ) -> None:
+        """Specialize small dynamic matmul dims that need one-tile alignment."""
+        if block_id is None:
+            return
+        dim_size = fake.shape[tensor_dim]
+        if not isinstance(dim_size, torch.SymInt):
+            return
+        block_info = env.block_sizes[block_id]
+        block_size = block_info.size
+        if not isinstance(block_size, torch.SymInt):
+            return
+        if env.shape_env.replace(block_size._sympy_()) != env.shape_env.replace(
+            dim_size._sympy_()
+        ):
+            return
+
+        try:
+            block_spec = env.config_spec.block_sizes.block_id_lookup(block_id)
+        except KeyError:
+            return
+
+        dim_hint = env.size_hint(dim_size)
+        if dim_hint <= 0 or dim_hint > block_spec.max_size:
+            return
+
+        dim_from_end = fake.ndim - tensor_dim - 1
+        bitwidth = fake.dtype.itemsize * 8
+        required = self._get_pallas_required_alignment(
+            dim_from_end, fake.ndim, bitwidth
+        )
+        if dim_hint >= required:
+            return
+
+        from ..compile_environment import _symint_free_symbols
+
+        env.specialized_vars.update(_symint_free_symbols(dim_size))
+
     def adjust_block_size_constraints(
         self,
         block_specs: list[object],
@@ -745,14 +896,18 @@ class PallasBackend(Backend):
         ``min(block_size, tensor_dim)`` which equals the full array
         dimension -- always valid per TPU rules.
         """
+        from torch._inductor.runtime.runtime_utils import next_power_of_2
+
         from ...autotuner.config_spec import BlockSizeSpec
         from ..ast_extension import ExtendedAST
         from ..compile_environment import BlockSizeInfo
-        from helion._compiler.compile_environment import _to_sympy
-        from helion._compiler.host_function import HostFunction
-        from helion._compiler.type_info import SequenceType
-        from helion._compiler.type_info import TensorType
-        from helion._compiler.type_info import TileIndexType
+        from ..compile_environment import CompileEnvironment
+        from ..compile_environment import _symint_free_symbols
+        from ..compile_environment import _to_sympy
+        from ..host_function import HostFunction
+        from ..type_info import SequenceType
+        from ..type_info import TensorType
+        from ..type_info import TileIndexType
 
         host_func = HostFunction.current()
 
@@ -812,6 +967,9 @@ class PallasBackend(Backend):
                     required_alignment = self.backend._get_pallas_required_alignment(
                         dim_from_end, tensor.ndim, bitwidth
                     )
+                    required_alignment = self.cap_alignment_to_tensor_dim(
+                        tensor, accessed_dim, required_alignment
+                    )
                     self.maybe_update_required_alignment(bid, required_alignment)
 
             def maybe_update_required_alignment(
@@ -823,6 +981,54 @@ class PallasBackend(Backend):
                     self.required_alignments[bid] = max(
                         self.required_alignments[bid], required_alignment
                     )
+
+            def cap_alignment_to_tensor_dim(
+                self,
+                tensor: torch.Tensor,
+                accessed_dim: int,
+                required_alignment: int,
+            ) -> int:
+                from torch._dynamo.source import TensorProperty
+                from torch._dynamo.source import TensorPropertySource
+
+                if accessed_dim < 0 or accessed_dim >= tensor.ndim:
+                    return required_alignment
+                dim = tensor.size(accessed_dim)
+                env = CompileEnvironment.current()
+                if isinstance(dim, int):
+                    dim_size = next_power_of_2(max(dim, 1))
+                    if dim_size < required_alignment and not env.settings.static_shapes:
+                        return required_alignment
+                    return min(required_alignment, dim_size)
+                if not isinstance(dim, torch.SymInt):
+                    return required_alignment
+                dim_expr = env.shape_env.replace(dim._sympy_())
+                specialized = env.specialize_expr(dim_expr)
+                if (
+                    not specialized.free_symbols
+                    and getattr(specialized, "is_integer", None) is True
+                ):
+                    dim_size = next_power_of_2(max(int(specialized), 1))
+                    return min(required_alignment, dim_size)
+                symbols = _symint_free_symbols(dim)
+                sources_by_symbol = [
+                    env.shape_env.var_to_sources.get(symbol, ()) for symbol in symbols
+                ]
+                if not symbols or any(not sources for sources in sources_by_symbol):
+                    return required_alignment
+                if any(
+                    isinstance(source, TensorPropertySource)
+                    and source.prop == TensorProperty.SIZE
+                    for sources in sources_by_symbol
+                    for source in sources
+                ):
+                    return required_alignment
+                if not env._is_static_kernel_shape_expr(dim_expr):
+                    return required_alignment
+                dim_size = next_power_of_2(max(env.size_hint(dim), 1))
+                if dim_size < required_alignment:
+                    env.specialized_vars.update(symbols)
+                return min(required_alignment, dim_size)
 
             def update_requirements_from_fake_tensor_loads(self) -> None:
                 # When tensors are indexed within external lambdas called by the kernel,
@@ -846,6 +1052,9 @@ class PallasBackend(Backend):
                                         dim_from_end, tensor.ndim, bitwidth
                                     )
                                 )
+                                required_alignment = self.cap_alignment_to_tensor_dim(
+                                    tensor, dim, required_alignment
+                                )
                                 self.maybe_update_required_alignment(
                                     info.block_id, required_alignment
                                 )
@@ -853,8 +1062,6 @@ class PallasBackend(Backend):
         analyzer = TensorTiledAccessAnalyzer(self)
         for stmt in host_func.body:
             analyzer.visit(stmt)
-
-        from torch._inductor.runtime.runtime_utils import next_power_of_2
 
         if block_sizes is not None and kernel_tensor_sizes is not None:
             for shape in kernel_tensor_sizes:
@@ -1665,6 +1872,7 @@ class PallasBackend(Backend):
         env = CompileEnvironment.current()
 
         plan_tiling(graphs, config, tile_strategy)
+        _disable_partial_initialized_store_tiling(graphs)
         build_tensorcore_plans(graphs, config)
 
         # compact_worklist_* is per-CONFIG state, but one CompileEnvironment is

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -8,10 +8,13 @@ from typing import TYPE_CHECKING
 
 import torch
 
+from helion import exc
 from helion._compiler.ast_extension import expr_from_string
 from helion._compiler.compile_environment import CompileEnvironment
 from helion._compiler.pallas.vmem_scalar_load import classify_vmem_scalar_load
 from helion._compiler.pallas.vmem_scalar_load import emit_vmem_scalar_load
+
+_FULL_LOAD_SELECT_MAX_BYTES = 256 << 10
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -209,16 +212,33 @@ def load_expr(
     patterns = list(state.fx_node.meta.get("indexing_patterns") or ())
     plan = state.fx_node.meta.get(TENSORCORE_PLAN_META)
     if isinstance(plan, OneHotGatherPlan):
-        return emit_gather(state, plan.plan, name)
+        result = emit_gather(state, plan.plan, name)
+        if (mask_expr := _indirect_gather_mask_expr(state, tensor)) is not None:
+            dtype_str = _pallas_dtype_str(tensor)
+            # Bind the gather once before using it as a layout anchor.
+            result = state.codegen.lift(result, dce=True, prefix="gather")
+            result = numeric_mask_select_expr(
+                expr_from_string(mask_expr),
+                result,
+                expr_from_string(f"jnp.array(0, dtype={dtype_str})"),
+                tensor.dtype,
+            )
+        return result
 
     parts, none_dims = index_parts(state, subscript, tensor)
+    parts, post_load_takes = _widen_unaligned_tile_load_indices(
+        state, subscript, tensor, parts
+    )
     scalar_load = classify_vmem_scalar_load(state, tensor, parts, patterns)
     if scalar_load is None:
         result = expr_from_string(f"{name}[{', '.join(parts)}]")
-        result = _padded_value_for_load(state, tensor, subscript, parts, result)
     else:
         result = emit_vmem_scalar_load(tensor, name, parts, scalar_load)
     mask_expr = _load_mask_expr(state, subscript, tensor)
+    result = _pad_clamped_load_expr(state, subscript, tensor, parts, result)
+    if post_load_takes:
+        result = state.codegen.lift(result, dce=True, prefix="widened_load")
+    result = _select_unaligned_tile_load_indices(result, post_load_takes)
     if mask_expr is not None:
         result = expr_from_string(
             "{result} * ({mask})", result=result, mask=expr_from_string(mask_expr)
@@ -266,6 +286,514 @@ def maybe_codegen_resident_prep_cache_read(
     window_elts.extend(":" for _ in range(rank - 1))
     read = f"{lowering.cache_name}[{', '.join(window_elts[p] for p in lowering.hoist.perm)}]"
     return expr_from_string(read)
+
+
+def _widen_unaligned_tile_load_indices(
+    state: CodegenState,
+    subscript: list[object],
+    tensor: torch.Tensor,
+    index_parts: list[str],
+) -> tuple[list[str], list[tuple[int, str, str, torch.dtype, int]]]:
+    """Load small unaligned tile dims as full refs, then select lanes."""
+    if _tensor_routed_to_dma_scratch(state, tensor):
+        return index_parts, []
+
+    from helion._compiler.device_function import PallasMemorySpace
+
+    if (
+        state.device_function.pallas_memory_space.get(id(tensor))
+        == PallasMemorySpace.SMEM
+    ):
+        return index_parts, []
+
+    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
+    from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
+    from helion._compiler.pallas.plan_tiling import TilePattern
+
+    adjusted = list(index_parts)
+    takes: list[tuple[int, str]] = []
+    widened_elements = _load_output_num_elements(state)
+    value_dim = 0
+    tensor_dim = 0
+    index_part_idx = 0
+
+    for idx, pattern in zip(
+        subscript, _get_indexing_patterns(state, tensor), strict=True
+    ):
+        if idx is None:
+            continue
+
+        index_part = adjusted[index_part_idx]
+        axis_dimensions = None
+        if isinstance(
+            pattern,
+            (TilePattern, TileIndexWithOffsetPattern, TileBeginWithOffsetPattern),
+        ):
+            axis_dimensions = _unaligned_tile_axis_full_load_dimensions(
+                state, tensor, tensor_dim, pattern, index_part
+            )
+        if axis_dimensions is not None:
+            dim_size, block_size, local_owner = axis_dimensions
+            if widened_elements is None or widened_elements % block_size != 0:
+                raise exc.BackendUnsupported(
+                    "pallas", "unaligned tile load with dynamic result shape"
+                )
+            candidate_elements = widened_elements // block_size * dim_size
+            if candidate_elements * tensor.dtype.itemsize > _FULL_LOAD_SELECT_MAX_BYTES:
+                raise exc.BackendUnsupported(
+                    "pallas", "unaligned tile load exceeds full-load selection budget"
+                )
+            adjusted[index_part_idx] = ":"
+            takes.append(
+                (value_dim, _tile_lane_index_expr(state, pattern, local_owner))
+            )
+            widened_elements = candidate_elements
+
+        if _index_part_produces_value_dim(adjusted[index_part_idx]):
+            value_dim += 1
+        tensor_dim += 1
+        index_part_idx += 1
+
+    dtype_str = _pallas_dtype_str(tensor)
+    return adjusted, [
+        (axis, index, dtype_str, tensor.dtype, value_dim) for axis, index in takes
+    ]
+
+
+def _unaligned_tile_axis_full_load_dimensions(
+    state: CodegenState,
+    tensor: torch.Tensor,
+    tensor_dim: int,
+    pattern: object,
+    index_part: str,
+) -> tuple[int, int, int | None] | None:
+    """Return full-load metadata for an unsafe unaligned tile axis.
+
+    Mosaic only needs extra proof for the last two VMEM dimensions.  When a
+    dynamic ``pl.ds`` offset on such a dimension is not provably aligned, a
+    small full-tensor load plus a register select is safer than asserting an
+    alignment Helion cannot prove.
+    """
+
+    if not index_part.startswith("pl.ds("):
+        return None
+    if index_part.startswith("pl.ds(pl.multiple_of("):
+        return None
+
+    from helion._compiler.pallas.backend import PallasBackend
+    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
+    from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
+    from helion._compiler.pallas.plan_tiling import TilePattern
+
+    assert isinstance(
+        pattern, (TilePattern, TileIndexWithOffsetPattern, TileBeginWithOffsetPattern)
+    )
+    env = CompileEnvironment.current()
+    backend = env.backend
+    assert isinstance(backend, PallasBackend)
+    dim_from_end = tensor.ndim - tensor_dim - 1
+    bitwidth = tensor.dtype.itemsize * 8
+    required = backend._get_pallas_required_alignment(
+        dim_from_end, tensor.ndim, bitwidth
+    )
+    if required <= 1:
+        return None
+    local_owner = _bounded_local_owner_block_id(
+        state, pattern.block_id, tensor, tensor_dim
+    )
+    alignment = (
+        state.device_function.resolved_block_size(pattern.block_id)
+        if local_owner is not None
+        else _loop_offset_alignment(pattern.block_id, state)
+    )
+    if (
+        isinstance(pattern, (TileIndexWithOffsetPattern, TileBeginWithOffsetPattern))
+        and pattern.offset != 0
+    ):
+        alignment = None
+    if alignment is not None and alignment % required == 0:
+        return None
+
+    dim_size = (
+        env.block_sizes[local_owner].from_config(state.config)
+        if local_owner is not None
+        else tensor.shape[tensor_dim]
+    )
+    block_size = env.block_sizes[pattern.block_id].from_config(state.config)
+    if not isinstance(dim_size, int) or not isinstance(block_size, int):
+        return None
+    if block_size <= 0:
+        raise exc.BackendUnsupported(
+            "pallas", "unaligned tile load with invalid block size"
+        )
+
+    return dim_size, block_size, local_owner
+
+
+def _load_output_num_elements(state: CodegenState) -> int | None:
+    """Return the current load result element count for full-ref selection."""
+
+    assert state.fx_node is not None
+    output_val = state.fx_node.meta.get("val")
+    if not isinstance(output_val, torch.Tensor):
+        return None
+
+    env = CompileEnvironment.current()
+    elements = 1
+    for size in output_val.size():
+        if not isinstance(size, int):
+            block_id = env.resolve_block_id(size)
+            if block_id is None:
+                return None
+            resolved = env.block_sizes[block_id].from_config(state.config)
+            if not isinstance(resolved, int):
+                return None
+            size = resolved
+        elements *= size
+    return elements
+
+
+def _tile_lane_index_expr(
+    state: CodegenState, pattern: object, local_owner: int | None = None
+) -> str:
+    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
+    from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
+    from helion._compiler.pallas.plan_tiling import TilePattern
+
+    assert isinstance(
+        pattern, (TilePattern, TileIndexWithOffsetPattern, TileBeginWithOffsetPattern)
+    )
+    index = state.codegen.index_var(pattern.block_id)
+    if (
+        isinstance(pattern, (TileIndexWithOffsetPattern, TileBeginWithOffsetPattern))
+        and pattern.offset != 0
+    ):
+        offset = state.device_function.literal_expr(pattern.offset)
+        index = f"({index}) + ({offset})"
+    if local_owner is not None:
+        owner_offset = state.codegen.offset_var(local_owner)
+        index = f"({index}) - ({owner_offset})"
+    return index
+
+
+def _select_unaligned_tile_load_indices(
+    value: ast.AST, takes: list[tuple[int, str, str, torch.dtype, int]]
+) -> ast.AST:
+    """Select requested tiles from widened full-ref loads without bool relayout."""
+    result = value
+    for axis, index_expr, dtype_str, dtype, rank in takes:
+        if axis == 0:
+            mask_expr = (
+                f"(({index_expr})[..., None] == "
+                f"jnp.arange({{result}}.shape[0], dtype=({index_expr}).dtype))"
+                f".astype({dtype_str})"
+            )
+            for _ in range(rank - 1):
+                mask_expr = f"jnp.expand_dims({mask_expr}, axis=-1)"
+            selected = numeric_mask_select_expr(
+                expr_from_string(mask_expr, result=result),
+                result,
+                expr_from_string(f"jnp.array(0, dtype={dtype_str})"),
+                dtype,
+            )
+            result = expr_from_string(
+                (
+                    "jnp.sum({selected}, axis=jnp.ndim("
+                    f"{index_expr})).astype({dtype_str})"
+                ),
+                selected=selected,
+            )
+            continue
+        mask_expr = (
+            f"(({index_expr})[:, None] == "
+            f"jnp.arange({{result}}.shape[{axis}], dtype=({index_expr}).dtype))"
+            f".astype({dtype_str})"
+        )
+        for _ in range(axis):
+            mask_expr = f"jnp.expand_dims({mask_expr}, axis=0)"
+        for _ in range(rank - axis - 1):
+            mask_expr = f"jnp.expand_dims({mask_expr}, axis=-1)"
+        true_value = expr_from_string(
+            f"jnp.expand_dims({{result}}, axis={axis})",
+            result=result,
+        )
+        selected = numeric_mask_select_expr(
+            expr_from_string(mask_expr, result=result),
+            true_value,
+            expr_from_string(f"jnp.array(0, dtype={dtype_str})"),
+            dtype,
+            true_value,
+        )
+        result = expr_from_string(
+            f"jnp.sum({{selected}}, axis={axis + 1}).astype({dtype_str})",
+            selected=selected,
+        )
+    return result
+
+
+def _pallas_dtype_str(tensor: torch.Tensor) -> str:
+    from helion._compiler.compile_environment import CompileEnvironment
+
+    return CompileEnvironment.current().backend.dtype_str(tensor.dtype)
+
+
+def _indirect_gather_mask_expr(state: CodegenState, tensor: torch.Tensor) -> str | None:
+    """Mask tensor-indexed gather outputs in their result layout."""
+    from helion._compiler.compile_environment import CompileEnvironment
+
+    assert state.fx_node is not None
+    output_val = state.fx_node.meta.get("val")
+    if not isinstance(output_val, torch.Tensor):
+        return None
+
+    env = CompileEnvironment.current()
+    output_sizes = [*output_val.size()]
+    dtype_str = _pallas_dtype_str(tensor)
+    mask_exprs: list[str] = []
+    for dim, size in enumerate(output_sizes):
+        block_id = env.resolve_block_id(size)
+        if block_id is None or (mask_var := state.codegen.mask_var(block_id)) is None:
+            continue
+        if env.is_jagged_tile(block_id):
+            mask_shape = env.jagged_tile_mask_shapes[block_id]
+            expand = state.tile_strategy.jagged_tile_expand_str(
+                mask_shape, output_sizes
+            )
+        else:
+            expand = state.tile_strategy.expand_str(output_sizes, dim)
+        expr = f"({mask_var}.astype({dtype_str}){expand})"
+        if expr not in mask_exprs:
+            mask_exprs.append(expr)
+
+    if not mask_exprs:
+        return None
+    return "*".join(mask_exprs)
+
+
+def _index_part_produces_value_dim(index_part: str) -> bool:
+    return index_part == ":" or index_part.startswith(("pl.ds(", "slice("))
+
+
+def _widen_small_aligned_scalar_load_indices(
+    state: CodegenState,
+    subscript: list[object],
+    tensor: torch.Tensor,
+    index_parts: list[str],
+) -> tuple[list[str], list[tuple[int, str, int]], int]:
+    """Load small scalar-indexed VMEM dims as full dims, then select in registers."""
+    value_rank = sum(
+        _index_part_produces_value_dim(index_part) for index_part in index_parts
+    )
+    if _tensor_routed_to_dma_scratch(state, tensor):
+        return index_parts, [], value_rank
+
+    from helion._compiler.device_function import PallasMemorySpace
+
+    if (
+        state.device_function.pallas_memory_space.get(id(tensor))
+        == PallasMemorySpace.SMEM
+    ):
+        return index_parts, [], value_rank
+
+    from helion._compiler.compile_environment import CompileEnvironment
+    from helion._compiler.pallas.backend import PallasBackend
+    from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
+    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
+
+    backend = CompileEnvironment.current().backend
+    assert isinstance(backend, PallasBackend)
+    patterns = _get_indexing_patterns(state, tensor)
+    adjusted = list(index_parts)
+    widened_selects: list[tuple[int, str, int]] = []
+    value_dim = 0
+    tensor_dim = 0
+    index_part_idx = 0
+
+    for idx, pattern in zip(subscript, patterns, strict=True):
+        if idx is None:
+            continue
+
+        index_part = adjusted[index_part_idx]
+        dim_size = tensor.shape[tensor_dim]
+        is_scalar = not _index_part_produces_value_dim(index_part)
+        can_widen = False
+        if (
+            is_scalar
+            and isinstance(dim_size, int)
+            and dim_size > 0
+            and isinstance(pattern, (ArbitraryIndexPattern, TileBeginWithOffsetPattern))
+        ):
+            dim_from_end = tensor.ndim - tensor_dim - 1
+            bitwidth = tensor.dtype.itemsize * 8
+            required_alignment = backend._get_pallas_required_alignment(
+                dim_from_end, tensor.ndim, bitwidth
+            )
+            # Packed dtypes need a whole native sublane for a second-minor load.
+            widening_extent = (
+                backend.sublane_tiling(tensor.dtype)
+                if dim_from_end == 1
+                else required_alignment
+            )
+            can_widen = required_alignment > 1 and dim_size <= widening_extent
+            if can_widen:
+                index_part = _normalize_widened_scalar_index(index_part, dim_size)
+                can_widen = index_part is not None
+
+        if can_widen:
+            adjusted[index_part_idx] = ":"
+            assert index_part is not None
+            widened_selects.append((value_dim, index_part, dim_size))
+            value_dim += 1
+        elif index_part is not None and _index_part_produces_value_dim(index_part):
+            value_dim += 1
+
+        tensor_dim += 1
+        index_part_idx += 1
+
+    return adjusted, widened_selects, value_dim
+
+
+def _normalize_widened_scalar_index(index_part: str, dim_size: int) -> str | None:
+    try:
+        index = int(index_part)
+    except ValueError:
+        return (
+            f"jnp.where(({index_part}) < 0, ({index_part}) + {dim_size}, {index_part})"
+        )
+    if index < 0:
+        index += dim_size
+    if 0 <= index < dim_size:
+        return str(index)
+    return None
+
+
+def _select_widened_scalar_load_indices(
+    value: ast.AST,
+    widened_selects: list[tuple[int, str, int]],
+    rank: int,
+    scalar_result_dtype: str | None = None,
+) -> ast.AST:
+    result = value
+    for axis, index_expr, dim_size in sorted(widened_selects, reverse=True):
+        if rank == 1 and scalar_result_dtype is not None:
+            result = expr_from_string(
+                f"{{result}}.astype({scalar_result_dtype})",
+                result=result,
+            )
+        lane_index = [":"] * rank
+        lane_index[axis] = "0"
+        selected = expr_from_string(
+            f"jnp.zeros_like({{result}}[{', '.join(lane_index)}])",
+            result=result,
+        )
+        for lane in range(dim_size):
+            lane_index[axis] = str(lane)
+            lane_value = expr_from_string(
+                f"{{result}}[{', '.join(lane_index)}]",
+                result=result,
+            )
+            selected = expr_from_string(
+                f"jnp.where(({index_expr}) == {lane}, {{lane_value}}, {{selected}})",
+                lane_value=lane_value,
+                selected=selected,
+            )
+        result = selected
+        rank -= 1
+    return result
+
+
+def _widened_scalar_load_promotion_dtype(
+    state: CodegenState,
+    tensor: torch.Tensor,
+    widened_selects: list[tuple[int, str, int]],
+    rank: int,
+) -> str | None:
+    """Return fp32 when a widened sub-32-bit scalar load feeds only fp32 casts."""
+    if tensor.dtype.itemsize >= 4 or rank != len(widened_selects):
+        return None
+    if not _load_feeds_only_immediate_fp32_converts(state):
+        return None
+    from helion._compiler.compile_environment import CompileEnvironment
+
+    return CompileEnvironment.current().backend.dtype_str(torch.float32)
+
+
+def _load_feeds_only_immediate_fp32_converts(state: CodegenState) -> bool:
+    node = state.fx_node
+    if node is None:
+        return False
+    users = list(node.users)
+    if not users:
+        return False
+    convert = torch.ops.prims.convert_element_type.default
+    for user in users:
+        if (
+            user.op != "call_function"
+            or user.target is not convert
+            or len(user.args) < 2
+            or user.args[0] is not node
+            or user.args[1] is not torch.float32
+        ):
+            return False
+    return True
+
+
+def _pad_clamped_load_expr(
+    state: CodegenState,
+    subscript: list[object],
+    tensor: torch.Tensor,
+    index_parts: list[str],
+    value: ast.AST,
+) -> ast.AST:
+    """Pad BlockSpec-clamped Pallas loads back to their logical tile shape."""
+    from helion._compiler.compile_environment import CompileEnvironment
+    from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
+    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
+    from helion._compiler.pallas.plan_tiling import TilePattern
+
+    if _tensor_routed_to_dma_scratch(state, tensor):
+        return value
+
+    env = CompileEnvironment.current()
+    indexing_patterns = _get_indexing_patterns(state, tensor)
+    pads: list[tuple[int, int]] = []
+    needs_pad = False
+    tensor_dim = 0
+    index_part_idx = 0
+
+    for idx, pattern in zip(subscript, indexing_patterns, strict=True):
+        if idx is None:
+            continue
+
+        index_part = index_parts[index_part_idx]
+        index_part_idx += 1
+
+        if isinstance(pattern, TilePattern) and index_part == ":":
+            block_size = env.block_sizes[pattern.block_id].from_config(state.config)
+            dim_size = tensor.shape[tensor_dim]
+            if (
+                isinstance(block_size, int)
+                and isinstance(dim_size, int)
+                and 1 < dim_size < block_size
+            ):
+                pads.append((0, block_size - dim_size))
+                needs_pad = True
+            else:
+                pads.append((0, 0))
+        else:
+            produces_value_dim = index_part == ":" or index_part.startswith("pl.ds(")
+            produces_value_dim = produces_value_dim or not isinstance(
+                pattern, (ArbitraryIndexPattern, TileBeginWithOffsetPattern)
+            )
+            if produces_value_dim:
+                pads.append((0, 0))
+
+        tensor_dim += 1
+
+    if not needs_pad:
+        return value
+
+    return expr_from_string(f"jnp.pad({{value}}, {pads!r})", value=value)
 
 
 def _load_mask_expr(
@@ -395,79 +923,10 @@ def _find_dma_scratch_loop(
     return next(_iter_dma_scratch_loops(state, name), (None, name))
 
 
-def _tensor_routed_to_fori_scratch(state: CodegenState, tensor: torch.Tensor) -> bool:
-    """True if ``tensor``'s store destination ref is a fori_loop DMA scratch."""
-    from helion._compiler.tile_strategy import ForiLoopState
-
+def _tensor_routed_to_dma_scratch(state: CodegenState, tensor: torch.Tensor) -> bool:
     name = state.codegen.device_function.tensor_arg(tensor).name
     loop, _ref = _find_dma_scratch_loop(state, name)
-    return isinstance(loop, ForiLoopState)
-
-
-def _clamped_dims(
-    state: CodegenState,
-    tensor: torch.Tensor,
-    subscript: list[object] | tuple[object, ...],
-    index_parts: list[str],
-) -> list[tuple[int, int] | None]:
-    """Per consumed tensor dim: ``(dim_size, block_size)`` where the launcher's
-    BlockSpec clamp makes the kernel ref smaller than the tile, else ``None``.
-
-    The launcher clamps each BlockSpec dimension to
-    ``min(block_size, tensor.shape[d])``.  Only grid-tiled dimensions that
-    produce ``:`` in the generated Pallas index are affected; dimensions
-    indexed via ``pl.ds()`` are ds-padded instead of clamped.
-    """
-    from helion._compiler.compile_environment import CompileEnvironment
-    from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
-    from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
-    from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
-    from helion._compiler.pallas.plan_tiling import TilePattern
-
-    assert state.fx_node is not None
-    patterns = state.fx_node.meta.get("indexing_patterns")
-    if patterns is None:
-        return []
-
-    # Patterns that consume a tensor dim without it surviving into the value's
-    # shape (a scalar/offset index squeezes that dim) get no clamp entry -- the
-    # value has no such dimension to slice or pad.
-    squeezing_patterns = (
-        ArbitraryIndexPattern,
-        TileIndexWithOffsetPattern,
-        TileBeginWithOffsetPattern,
-    )
-
-    env = CompileEnvironment.current()
-    clamps: list[tuple[int, int] | None] = []
-    tensor_dim = 0
-    index_part_idx = 0
-
-    for idx, pattern in zip(subscript, patterns, strict=True):
-        if idx is None:
-            continue
-
-        index_part = index_parts[index_part_idx]
-        index_part_idx += 1
-        if isinstance(pattern, squeezing_patterns):
-            tensor_dim += 1
-            continue
-
-        clamp = None
-        if isinstance(pattern, TilePattern) and index_part == ":":
-            block_size = env.block_sizes[pattern.block_id].from_config(state.config)
-            dim_size = tensor.shape[tensor_dim]
-            if (
-                isinstance(block_size, int)
-                and isinstance(dim_size, int)
-                and dim_size < block_size
-            ):
-                clamp = (dim_size, block_size)
-
-        clamps.append(clamp)
-        tensor_dim += 1
-
-    return clamps
+    return loop is not None
 
 
 def sliced_value_for_store(
@@ -488,51 +947,57 @@ def sliced_value_for_store(
     generated Pallas index.  Dimensions indexed via ``pl.ds()`` are padded
     instead of clamped, so they must keep their full block-size value.
 
-    fori_loop-scratch stores are exempt: their destination is a block-sized
+    Pipeline/DMA scratch stores are exempt: their destination is a block-sized
     VMEM scratch (not a clamped ref), so the value stays block-shaped and the
-    writeback DMA clamps the extent instead (see ``_build_dma_slices``).
+    writeback path clamps the HBM extent instead.
     """
-    if _tensor_routed_to_fori_scratch(state, tensor):
+    from helion._compiler.compile_environment import CompileEnvironment
+    from helion._compiler.pallas.plan_tiling import TilePattern
+
+    assert state.fx_node is not None
+    patterns = state.fx_node.meta.get("indexing_patterns")
+    if patterns is None:
         return value
 
-    clamps = _clamped_dims(state, tensor, subscript, index_parts)
-    if not any(clamps):
+    if _tensor_routed_to_dma_scratch(state, tensor):
         return value
 
-    slices = [":" if c is None else f":{c[0]}" for c in clamps]
+    env = CompileEnvironment.current()
+    slices: list[str] = []
+    needs_slice = False
+    tensor_dim = 0
+    index_part_idx = 0
+    for idx, pattern in zip(subscript, patterns, strict=True):
+        if idx is None:
+            slices.append(":")
+            continue
+
+        index_part = index_parts[index_part_idx]
+        index_part_idx += 1
+        if not _index_part_produces_value_dim(index_part):
+            tensor_dim += 1
+            continue
+
+        value_slice = ":"
+        if isinstance(pattern, TilePattern) and index_part == ":":
+            block_size = env.block_sizes[pattern.block_id].from_config(state.config)
+            dim_size = tensor.shape[tensor_dim]
+            if (
+                isinstance(block_size, int)
+                and isinstance(dim_size, int)
+                and dim_size < block_size
+            ):
+                value_slice = f":{dim_size}"
+                needs_slice = True
+
+        slices.append(value_slice)
+        tensor_dim += 1
+
+    if not needs_slice:
+        return value
+
     return expr_from_string(
         f"{{value}}[{', '.join(slices)}]",
-        value=value,
-    )
-
-
-def _padded_value_for_load(
-    state: CodegenState,
-    tensor: torch.Tensor,
-    subscript: list[object],
-    index_parts: list[str],
-    value: ast.AST,
-) -> ast.AST:
-    """Zero-pad loads from clamped refs (see ``_clamped_dims``) to block
-    shape, so they compose with block-shaped values and OOB positions read 0.
-
-    Exempt: scratch-routed tensors (pipeline/fori DMA scratches are
-    block-sized, not clamped) and size-1 dims (they broadcast; zero-padding
-    would break that).
-    """
-    name = state.codegen.device_function.tensor_arg(tensor).name
-    if _find_dma_scratch_loop(state, name)[0] is not None:
-        return value
-
-    clamps = _clamped_dims(state, tensor, subscript, index_parts)
-    pads = [
-        "(0, 0)" if c is None or c[0] <= 1 else f"(0, {c[1] - c[0]})" for c in clamps
-    ]
-    if all(p == "(0, 0)" for p in pads):
-        return value
-
-    return expr_from_string(
-        f"jnp.pad({{value}}, ({', '.join(pads)},))",
         value=value,
     )
 
@@ -643,7 +1108,8 @@ def index_parts(
         )
         parts.append(index_code)
 
-        out_pos += 1
+        if _index_part_produces_value_dim(index_code):
+            out_pos += 1
         tensor_dim += 1
 
     return parts, none_dims
@@ -1005,7 +1471,7 @@ def _ds_expr(
                 dim_from_end, tensor.ndim, bitwidth
             )
             if alignment is not None and alignment % required == 0:
-                hint = required
+                hint = alignment
                 bs_value = state.device_function.resolved_block_size(block_id)
                 if isinstance(bs_value, int) and alignment % bs_value == 0:
                     hint = block_size

--- a/helion/_compiler/pallas/gather.py
+++ b/helion/_compiler/pallas/gather.py
@@ -31,7 +31,7 @@ _GATHER_VMEM_THRESHOLD_BYTES: int = 16 << 20  # 16 MiB
 @dataclass(frozen=True)
 class GatherPlan:
     indirect_pos: int
-    none_dims: tuple[int, ...]
+    indirect_tensor_dim: int
     jnp_dtype: str
     table_ndim: int
     index_ndim: int
@@ -42,6 +42,7 @@ class GatherPlan:
 @dataclass(frozen=True)
 class ScatterPlan:
     indirect_pos: int
+    indirect_tensor_dim: int
     jnp_dtype: str
     target_ndim: int
     index_ndim: int
@@ -63,8 +64,9 @@ def build_gather_plan(
             "Pallas gather: multiple indirect dims are not supported"
         )
     indirect_pos = indirect_positions[0]
+    indirect_tensor_dim = _tensor_dim_for_subscript_position(subscript, indirect_pos)
     emit_select = not tensor.dtype.is_floating_point
-    if emit_select and indirect_pos != 0:
+    if emit_select and indirect_tensor_dim != 0:
         raise NotImplementedError(
             "Pallas gather: integer table gather on non-zero dim is not yet supported"
         )
@@ -88,14 +90,13 @@ def build_gather_plan(
     # MXU truncates fp32 to bf16 without HIGHEST. For bf16/fp16 the truncation is a no-op.
     use_highest = tensor.dtype not in (torch.bfloat16, torch.float16)
 
-    none_dims = tuple(i for i, idx in enumerate(subscript) if idx is None)
     jnp_dtype = CompileEnvironment.current().backend.dtype_str(tensor.dtype)
     idx_element = subscript[indirect_pos]
     index_ndim = idx_element.meta["val"].ndim  # type: ignore[union-attr]
 
     return GatherPlan(
         indirect_pos=indirect_pos,
-        none_dims=none_dims,
+        indirect_tensor_dim=indirect_tensor_dim,
         jnp_dtype=jnp_dtype,
         table_ndim=tensor.ndim,
         index_ndim=index_ndim,
@@ -122,7 +123,8 @@ def build_scatter_plan(
             "Pallas scatter: multiple indirect dims are not supported"
         )
     indirect_pos = indirect_positions[0]
-    if indirect_pos != 0:
+    indirect_tensor_dim = _tensor_dim_for_subscript_position(subscript, indirect_pos)
+    if indirect_tensor_dim != 0:
         raise NotImplementedError("Pallas scatter: only indirect dim 0 is supported")
     idx_element = subscript[indirect_pos]
     index_ndim = idx_element.meta["val"].ndim  # type: ignore[union-attr]
@@ -133,6 +135,7 @@ def build_scatter_plan(
     jnp_dtype = CompileEnvironment.current().backend.dtype_str(tensor.dtype)
     return ScatterPlan(
         indirect_pos=indirect_pos,
+        indirect_tensor_dim=indirect_tensor_dim,
         jnp_dtype=jnp_dtype,
         target_ndim=tensor.ndim,
         index_ndim=index_ndim,
@@ -164,7 +167,25 @@ def emit_gather(
 
     from . import codegen as pallas_codegen
 
-    parts, _ = pallas_codegen.index_parts(state, subscript, tensor)
+    parts, none_dims = pallas_codegen.index_parts(state, subscript, tensor)
+    none_dims = [
+        dim + (plan.index_ndim - 1 if pos > plan.indirect_pos else 0)
+        for pos, dim in zip(
+            (pos for pos, index in enumerate(subscript) if index is None),
+            none_dims,
+            strict=True,
+        )
+    ]
+    parts, widened_selects, table_rank = (
+        pallas_codegen._widen_small_aligned_scalar_load_indices(
+            state, list(subscript), tensor, parts
+        )
+    )
+    table_indirect_axis = _table_indirect_axis(subscript, parts, plan.indirect_pos)
+    gather_rank = table_rank + plan.index_ndim - 1
+    widened_selects = _remap_widened_selects_after_gather(
+        widened_selects, table_indirect_axis, plan.index_ndim
+    )
     base_index = ", ".join(parts)
     table_expr = f"{name}[{base_index}]"
 
@@ -172,14 +193,19 @@ def emit_gather(
         mask_expr = (
             f"jax.nn.one_hot({idx_name}[...], {name}.shape[0], dtype={plan.jnp_dtype})"
         )
-        for _ in range(plan.table_ndim - 1):
+        for _ in range(table_rank - 1):
             mask_expr = f"jnp.expand_dims({mask_expr}, axis=-1)"
         result = expr_from_string(
             f"jnp.sum({table_expr} * {mask_expr}, "
             f"axis=jnp.ndim({idx_name}[...])"
             f").astype({plan.jnp_dtype})"
         )
-        for dim in plan.none_dims:
+        if widened_selects:
+            result = state.codegen.lift(result, dce=True, prefix="gather")
+        result = pallas_codegen._select_widened_scalar_load_indices(
+            result, widened_selects, gather_rank
+        )
+        for dim in none_dims:
             result = expr_from_string(
                 f"jnp.expand_dims({{result}}, axis={dim})", result=result
             )
@@ -194,28 +220,77 @@ def emit_gather(
         table_dot_expr = table_expr
         precision_arg = ""
 
-    p = plan.indirect_pos
     result = expr_from_string(
         "jax.lax.dot_general("
-        f"jax.nn.one_hot({idx_name}[...], {name}.shape[{p}], dtype={oh_dtype}), "
+        f"jax.nn.one_hot({idx_name}[...], "
+        f"({table_expr}).shape[{table_indirect_axis}], dtype={oh_dtype}), "
         f"{table_dot_expr}, "
-        f"(((jnp.ndim({idx_name}[...]),), ({p},)), ((), ())), "
+        f"(((jnp.ndim({idx_name}[...]),), ({table_indirect_axis},)), ((), ())), "
         "preferred_element_type=jnp.float32, "
         f"{precision_arg}"
         f").astype({plan.jnp_dtype})"
     )
-    if p > 0:
+    if table_indirect_axis > 0:
         n = plan.index_ndim
-        src = tuple(range(n, n + p))
-        dst = tuple(range(p))
+        src = tuple(range(n, n + table_indirect_axis))
+        dst = tuple(range(table_indirect_axis))
         result = expr_from_string(
             f"jnp.moveaxis({{result}}, {src}, {dst})", result=result
         )
-    for dim in plan.none_dims:
+    if widened_selects:
+        result = state.codegen.lift(result, dce=True, prefix="gather")
+    result = pallas_codegen._select_widened_scalar_load_indices(
+        result, widened_selects, gather_rank
+    )
+    for dim in none_dims:
         result = expr_from_string(
             f"jnp.expand_dims({{result}}, axis={dim})", result=result
         )
     return result
+
+
+def _table_indirect_axis(
+    subscript: list[object] | tuple[object, ...],
+    parts: list[str],
+    indirect_pos: int,
+) -> int:
+    from . import codegen as pallas_codegen
+
+    axis = 0
+    part_idx = 0
+    for pos, idx in enumerate(subscript):
+        if idx is None:
+            continue
+        part = parts[part_idx]
+        if pos == indirect_pos:
+            return axis
+        if pallas_codegen._index_part_produces_value_dim(part):
+            axis += 1
+        part_idx += 1
+    raise AssertionError(f"indirect position {indirect_pos} not found in subscript")
+
+
+def _tensor_dim_for_subscript_position(
+    subscript: list[object] | tuple[object, ...], position: int
+) -> int:
+    """Map a subscript-list position to the consumed tensor dimension."""
+    return sum(index is not None for index in subscript[:position])
+
+
+def _remap_widened_selects_after_gather(
+    widened_selects: list[tuple[int, str, int]],
+    table_indirect_axis: int,
+    index_ndim: int,
+) -> list[tuple[int, str, int]]:
+    remapped: list[tuple[int, str, int]] = []
+    for axis, index_expr, dim_size in widened_selects:
+        assert axis != table_indirect_axis
+        if axis < table_indirect_axis:
+            remapped_axis = axis
+        else:
+            remapped_axis = axis + index_ndim - 1
+        remapped.append((remapped_axis, index_expr, dim_size))
+    return remapped
 
 
 def _scatter_one_hot_name(
@@ -231,7 +306,8 @@ def _scatter_one_hot_name(
     # TODO(tcombes): investigate making the metadata into dtype,
     # currently hitting Mosaic issues with bf16 mask.
     return (
-        f"jax.nn.one_hot({idx_name}[...], {name}.shape[{plan.indirect_pos}], "
+        f"jax.nn.one_hot({idx_name}[...], "
+        f"{name}.shape[{plan.indirect_tensor_dim}], "
         "dtype=jnp.float32)"
     )
 
@@ -242,6 +318,7 @@ def emit_scatter_store(
     name: str,
     base_index: str,
     value: ast.AST,
+    none_dims: list[int],
 ) -> ast.AST:
     """Emit one Pallas program's tensor-indexed store block.
 
@@ -262,6 +339,8 @@ def emit_scatter_store(
     this Pallas program; duplicate writes from different programs have the same
     unspecified winner semantics as regular parallel stores in other backends.
     """
+    for dim in reversed(none_dims):
+        value = expr_from_string(f"jnp.squeeze({{value}}, axis={dim})", value=value)
     oh = _scatter_one_hot_name(state, plan, name)
     m = f"jnp.shape({oh})[0]"
     eye = f"jnp.eye({m}, dtype=jnp.float32)"

--- a/helion/_compiler/pallas/memory_ops.py
+++ b/helion/_compiler/pallas/memory_ops.py
@@ -39,7 +39,7 @@ def _(state: CodegenState) -> None:
     device_fn = state.device_function
     device_fn.device_store_index += 1
     device_fn.device_memory_op_index += 1
-    parts, _ = pallas_codegen.index_parts(state, subscript, tensor)
+    parts, none_dims = pallas_codegen.index_parts(state, subscript, tensor)
     value = pallas_codegen.sliced_value_for_store(
         state, tensor, subscript, parts, value
     )
@@ -51,7 +51,7 @@ def _(state: CodegenState) -> None:
     plan = state.fx_node.meta.get(TENSORCORE_PLAN_META) if state.fx_node else None
     is_scatter = isinstance(plan, OneHotScatterPlan)
     if is_scatter:
-        value = emit_scatter_store(state, plan.plan, name, idx_str, value)
+        value = emit_scatter_store(state, plan.plan, name, idx_str, value, none_dims)
     from .ordered_carry import emit_carry_store
 
     if not is_scatter and state.device_function.carry_tiles:

--- a/helion/_compiler/pallas/vmem_scalar_load.py
+++ b/helion/_compiler/pallas/vmem_scalar_load.py
@@ -5,8 +5,8 @@ project a runtime scalar index out of either one directly. For 32-bit dtypes
 a dynamic index on the second-minor dimension is legal in the ref subscript
 itself (``ref[i, :]``); the lane dimension is then selected with a static
 index after the load. Packed dtypes and dynamic lane indices instead load
-the window, pad it to the physical tile, rotate the requested element to
-index zero, widen to a 32-bit register type, and extract statically.
+the window, widen to a 32-bit register type, pad it to the physical tile,
+rotate the requested element to index zero, and extract statically.
 
 ``classify_vmem_scalar_load`` decides whether a load needs this lowering;
 ``emit_vmem_scalar_load`` generates it.
@@ -95,6 +95,11 @@ def _static_index(index: str, extent: int) -> int | None:
         return None
 
 
+def _normalized_runtime_index(index: str, extent: int) -> str:
+    """Normalize a runtime negative index against its logical extent."""
+    return f"jnp.where(({index}) < 0, ({index}) + {extent}, {index})"
+
+
 def classify_vmem_scalar_load(
     state: CodegenState,
     tensor: torch.Tensor,
@@ -161,6 +166,9 @@ def _sublane_load_expr(
     """Emit the ref load with the runtime sublane index in the subscript."""
     lane = tensor.ndim - 1
     parts = [*index_parts]
+    for dim in load.scalar_dims:
+        if load.static_indices[dim] is None:
+            parts[dim] = _normalized_runtime_index(parts[dim], load.extents[dim])
     lane_index = load.static_indices.get(lane)
     if lane_index is not None:
         parts[lane] = ":"
@@ -176,7 +184,7 @@ def _roll_load_expr(
     index_parts: list[str],
     load: VmemScalarLoad,
 ) -> ast.AST:
-    """Emit load, pad, roll to index zero, widen, and static extraction."""
+    """Emit load, widen, pad, roll to index zero, and static extraction."""
     from helion._compiler.backend import PallasBackend
     from helion._compiler.compile_environment import CompileEnvironment
 
@@ -204,6 +212,9 @@ def _roll_load_expr(
     # operations instead of treating predicates as packed 8-bit values.
     if tensor.dtype == torch.bool:
         value = f"lax.convert_element_type({value}, jnp.int32)"
+    elif tensor.dtype.itemsize < 4:
+        widen_dtype = "jnp.float32" if tensor.dtype.is_floating_point else "jnp.int32"
+        value = f"lax.convert_element_type({value}, {widen_dtype})"
 
     selectors = [":"] * (len(window_dims) + axis_offset)
     pads = [(0, 0)] * len(selectors)
@@ -219,7 +230,8 @@ def _roll_load_expr(
         alignment = 128 if dim == tensor.ndim - 1 else sublane_tiling
         padded_extent = load.extents[dim] + (-load.extents[dim]) % alignment
         pads[axis] = (0, padded_extent - load.extents[dim])
-        rolls.append((axis, f"-({index_parts[dim]}) % {padded_extent}"))
+        index = _normalized_runtime_index(index_parts[dim], load.extents[dim])
+        rolls.append((axis, f"-({index}) % {padded_extent}"))
         selectors[axis] = "0"
     if expand_leading and rolls:
         pads[0] = (0, sublane_tiling - 1)
@@ -228,9 +240,6 @@ def _roll_load_expr(
         value = f"jnp.pad({value}, {tuple(pads)!r})"
     for axis, shift in rolls:
         value = f"pltpu.roll({value}, {shift}, axis={axis})"
-    if tensor.dtype != torch.bool and tensor.dtype.itemsize < 4:
-        widen_dtype = "jnp.float32" if tensor.dtype.is_floating_point else "jnp.int32"
-        value = f"lax.convert_element_type({value}, {widen_dtype})"
 
     result = f"{value}[{', '.join(selectors)}]"
     if _is_32bit(tensor.dtype):

--- a/test/test_broadcasting.py
+++ b/test/test_broadcasting.py
@@ -15,7 +15,6 @@ from helion._testing import onlyBackends
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
 from helion._testing import skipIfXPU
-from helion._testing import xfailIfPallas
 import helion.language as hl
 from helion.runtime.settings import _get_backend
 
@@ -89,7 +88,6 @@ class TestBroadcasting(RefEagerTestBase, TestCase):
         if _get_backend() == "triton":
             self.assertIn("tl.make_block_ptr", code)
 
-    @xfailIfPallas("constexpr scalar + None-broadcast unsupported")
     def test_constexpr_index(self):
         @helion.kernel
         def fn(a, idx1):

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1693,7 +1693,6 @@ class TestExamples(RefEagerTestBase, TestCase):
                     rtol=rtol,
                 )
 
-    @xfailIfPallasTpu("requires padded scalar/tile load widening")
     def test_grouped_gemm_jagged(self):
         # Build small jagged grouped GEMM inputs
         torch.manual_seed(0)
@@ -2599,7 +2598,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             indexing="block_ptr",
         )
 
-    @xfailIfPallasTpu("operation not supported on TPU")
     def test_gdn_fwd_h(self):
         """Test gated delta net forward h kernel."""
         batch = 2
@@ -2622,13 +2620,8 @@ class TestExamples(RefEagerTestBase, TestCase):
             dtype=torch.float32,
             device=DEVICE,
         )
-        wu, ws, wv = torch.linalg.svd(w.permute(0, 1, 3, 2, 4), full_matrices=False)
-        w = torch.einsum("bnhik,bnhkj->bnhij", wu, wv)
-        w = (
-            w.permute(0, 1, 3, 2, 4)
-            .reshape(batch, seqlen, nheads, dhead)
-            .to(torch.bfloat16)
-        )
+        mod = import_path(EXAMPLES_DIR / "gdn_fwd_h.py")
+        w = mod._orthogonalize_w(w)
         u = torch.randn(
             batch, seqlen, nheads, dstate, dtype=torch.bfloat16, device=DEVICE
         )
@@ -2642,8 +2635,6 @@ class TestExamples(RefEagerTestBase, TestCase):
 
         args = (k, w, u, g, chunk_size)
 
-        # Import and use the reference implementation
-        mod = import_path(EXAMPLES_DIR / "gdn_fwd_h.py")
         expected = mod.ref_gdn_fwd_h(*args)
 
         check_example(
@@ -2676,10 +2667,6 @@ class TestExamples(RefEagerTestBase, TestCase):
         )
 
     @skipIfRefEager("scalar_prefetch indexing not supported in ref interpreter")
-    @xfailIfPallasTpu(
-        "unaligned data-dependent tile load; fixed later in the stack by Pallas "
-        "padded-load support (#2944)"
-    )
     def test_flex_attention(self):
         z, h, n_ctx, head_dim = 2, 4, 256, 64
         q, k, v = [

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -29,6 +29,7 @@ from helion._testing import xfailIfPallas
 from helion._testing import xfailIfPallasInterpret
 from helion._testing import xfailIfPallasTpu
 import helion.language as hl
+from helion.runtime.settings import is_pallas_interpret
 
 if TYPE_CHECKING:
     from helion.autotuner.base_search import PopulationBasedSearch
@@ -1432,6 +1433,44 @@ class TestPallas(TestCase):
                 self.assertIn("jnp.where", code)
                 self.assertIn("dot_general", code)
 
+    def test_scatter_store_newaxis_before_indirect_dim(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def scatter(values: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
+            out = torch.zeros_like(values)
+            for tile_m, tile_n in hl.tile(values.size()):
+                out[None, indices[tile_m], tile_n] = values[None, tile_m, tile_n]
+            return out
+
+        values = torch.randn(16, 8, device=DEVICE, dtype=torch.float32)
+        indices = torch.randperm(16, device=DEVICE).to(torch.int32)
+        code, result = code_and_output(scatter, (values, indices), block_sizes=[16, 8])
+
+        expected = torch.zeros_like(values)
+        expected[indices.to(torch.int64)] = values
+        torch.testing.assert_close(result, expected)
+        self.assertIn("one_hot", code)
+
+    def test_scatter_store_scalar_before_newaxis(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def scatter(values: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
+            out = torch.zeros(
+                [values.size(0), 1, values.size(1)],
+                dtype=values.dtype,
+                device=values.device,
+            )
+            for tile_m, tile_n in hl.tile(values.size()):
+                out[indices[tile_m], 0, None, tile_n] = values[tile_m, None, tile_n]
+            return out
+
+        values = torch.randn(16, 8, device=DEVICE, dtype=torch.float32)
+        indices = torch.randperm(16, device=DEVICE).to(torch.int32)
+        code, result = code_and_output(scatter, (values, indices), block_sizes=[16, 8])
+
+        expected = torch.zeros([16, 1, 8], device=DEVICE, dtype=values.dtype)
+        expected[indices.to(torch.int64), 0] = values
+        torch.testing.assert_close(result, expected)
+        self.assertIn("one_hot", code)
+
     def test_scatter_store_duplicate_indices(self) -> None:
         values = torch.randn(16, 8, device=DEVICE, dtype=torch.float32)
         indices = torch.tensor(
@@ -1677,6 +1716,35 @@ class TestPallas(TestCase):
         torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
         # The bias block_spec_info must have None for dim 0 (not a grid index).
         self.assertIn("(None, 1)", code)
+
+    def test_matmul_alignment_specialization_skips_newaxis(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=False)
+        def matmul_with_newaxis(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, k = x.size()
+            _, n = y.size()
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+                for tile_k in hl.tile(k):
+                    product = torch.matmul(
+                        x[None, tile_m, tile_k],
+                        y[None, tile_k, tile_n],
+                    ).squeeze(0)
+                    acc += product
+                out[tile_m, tile_n] = acc.to(x.dtype)
+            return out
+
+        x = torch.empty(16, 4, device=DEVICE, dtype=torch.bfloat16)
+        y = torch.empty(4, 128, device=DEVICE, dtype=torch.bfloat16)
+        bound = matmul_with_newaxis.bind((x, y))
+        fake_x = bound.fake_args[0]
+        assert isinstance(fake_x, torch.Tensor)
+        reduction_dim = fake_x.shape[1]
+        assert isinstance(reduction_dim, torch.SymInt)
+        self.assertLessEqual(
+            reduction_dim._sympy_().free_symbols,
+            bound.env.specialized_vars,
+        )
 
     def test_pallas_launcher_fast_path_hits_on_repeat_invocations(self) -> None:
         """Repeat calls on a cached static-shape kernel take the launcher fast path.
@@ -3506,6 +3574,64 @@ class TestPallas(TestCase):
         )
         torch.testing.assert_close(result, x * 2.0)
 
+    def _check_small_middle_scalar_load_in_loop(self, loop_type: str) -> None:
+        """Small scalar-indexed middle dims load aligned and select in registers."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def middle_scalar_load(x: torch.Tensor) -> torch.Tensor:
+            batch, seqlen, nheads, _dhead = x.shape
+            out = torch.empty(
+                [batch, nheads, seqlen, _dhead], dtype=x.dtype, device=x.device
+            )
+            for tile_b, tile_h in hl.tile([batch, nheads], block_size=[1, 1]):
+                i_b = tile_b.id
+                i_h = tile_h.id
+                for tile_s in hl.tile(seqlen, block_size=64):
+                    out[i_b, i_h, tile_s, :] = x[i_b, tile_s, i_h, :] + 1.0
+            return out
+
+        x = torch.randn(2, 128, 16, 32, device=DEVICE, dtype=torch.bfloat16)
+        code, result = code_and_output(
+            middle_scalar_load,
+            (x,),
+            pallas_loop_type=loop_type,
+        )
+        self.assertRegex(code, r"(?m)^    pid_0 = pl\.program_id\(0\)$")
+        self.assertRegex(code, r"(?m)^    pid_1 = pl\.program_id\(1\)$")
+        self.assertRegex(
+            code,
+            r"pltpu\.roll\(lax\.convert_element_type\(x\[[^\n]*, :, :\], "
+            r"jnp\.float32\)",
+        )
+        torch.testing.assert_close(result, (x + 1.0).permute(0, 2, 1, 3))
+
+    def test_small_middle_scalar_load_in_emit_pipeline(self) -> None:
+        self._check_small_middle_scalar_load_in_loop("emit_pipeline")
+
+    def test_small_middle_scalar_load_in_fori_loop(self) -> None:
+        self._check_small_middle_scalar_load_in_loop("fori_loop")
+
+    def test_small_middle_negative_scalar_load(self) -> None:
+        """Static negative scalar indices preserve Python indexing semantics."""
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def negative_scalar_load(x: torch.Tensor) -> torch.Tensor:
+            batch, seqlen, _nheads, dhead = x.shape
+            out = torch.empty([batch, seqlen, dhead], dtype=x.dtype, device=x.device)
+            for tile_b in hl.tile(batch, block_size=1):
+                i_b = tile_b.id
+                for tile_s in hl.tile(seqlen, block_size=64):
+                    out[i_b, tile_s, :] = x[i_b, tile_s, -1, :]
+            return out
+
+        x = torch.randn(2, 128, 4, 16, device=DEVICE, dtype=torch.bfloat16)
+        _code, result = code_and_output(
+            negative_scalar_load,
+            (x,),
+            pallas_loop_type="emit_pipeline",
+        )
+        torch.testing.assert_close(result, x[:, :, -1, :])
+
     @xfailIfPallasTpu(
         "Mixed scalar write + slice needs tensor duplication into SMEM and VMEM"
     )
@@ -3951,6 +4077,23 @@ class TestPallas(TestCase):
         self.assertGreaterEqual(code.count("jax.lax.fori_loop"), 2)
         self.assertNotIn("pltpu.make_async_copy", code)
         self.assertIn("pl.ds(", code)
+        torch.testing.assert_close(result, args[0] + args[1])
+
+    def test_fori_loop_widens_all_unaligned_last_two_load_axes(self) -> None:
+        """A load with both last-two tile axes unaligned widens both axes."""
+        args = (
+            torch.randn(1, 4, 64, device=DEVICE, dtype=torch.float32),
+            torch.randn(1, 4, 64, device=DEVICE, dtype=torch.float32),
+        )
+        code, result = code_and_output(
+            pallas_add_3d,
+            args,
+            block_sizes=[1, 4, 64],
+            pallas_loop_type="fori_loop",
+        )
+        self.assertIn("jax.lax.fori_loop", code)
+        self.assertNotIn("x[:, :, pl.ds", code)
+        self.assertNotIn("y[:, :, pl.ds", code)
         torch.testing.assert_close(result, args[0] + args[1])
 
     def test_fori_loop_static_begin_leading_token_load_stays_resident(self) -> None:
@@ -4952,6 +5095,60 @@ class TestPallas(TestCase):
         )
         torch.testing.assert_close(result, ref, rtol=1e-3, atol=1e-3)
 
+    def test_fp8_numeric_mask_select_uses_wide_mask_arithmetic(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def masked_fp8_tail(values: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(values)
+            for tile in hl.tile(values.size(0)):
+                values_fp8 = values[tile].to(torch.float8_e4m3fn)
+                out[tile] = torch.where(
+                    tile.index < values.size(0) - 1, values_fp8, 0.0
+                ).to(torch.float32)
+            return out
+
+        values = torch.arange(128, device=DEVICE, dtype=torch.float32)
+        code = masked_fp8_tail.bind((values,)).to_code(helion.Config(block_sizes=[64]))
+
+        self.assertRegex(code, r"zeros_like\([^\n]*dtype=jnp\.uint16\)\s*-")
+        self.assertNotRegex(code, r"zeros_like\([^\n]*dtype=jnp\.uint8\)\s*-")
+        if is_pallas_interpret():
+            self.skipTest("torch.float8_e4m3fn execution needs real TPU Pallas")
+
+        code, result = code_and_output(masked_fp8_tail, (values,), block_sizes=[64])
+
+        self.assertRegex(code, r"zeros_like\([^\n]*dtype=jnp\.uint16\)\s*-")
+        self.assertNotRegex(code, r"zeros_like\([^\n]*dtype=jnp\.uint8\)\s*-")
+        expected = torch.where(
+            torch.arange(values.numel(), device=DEVICE) < values.numel() - 1,
+            values.to(torch.float8_e4m3fn).to(torch.float32),
+            torch.zeros((), device=DEVICE, dtype=torch.float32),
+        )
+        torch.testing.assert_close(result, expected)
+
+    def test_widened_scalar_load_dynamic_negative_index(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def dynamic_column(values: torch.Tensor) -> torch.Tensor:
+            out = torch.empty(
+                [values.size(0)], dtype=values.dtype, device=values.device
+            )
+            width = hl.specialize(values.size(1))
+            for tile in hl.tile(values.size(0), block_size=128):
+                col = tile.begin % width - 1
+                out[tile] = values[tile, col]
+            return out
+
+        values = torch.arange(256 * 4, device=DEVICE, dtype=torch.float32).reshape(
+            256, 4
+        )
+        code, result = code_and_output(dynamic_column, (values,))
+
+        self.assertRegex(code, r"jnp\.where\([^\n]*< 0, [^\n]*\+ 4,")
+        expected = torch.empty([values.size(0)], device=DEVICE, dtype=values.dtype)
+        for begin in range(0, values.size(0), 128):
+            end = min(begin + 128, values.size(0))
+            expected[begin:end] = values[begin:end, begin % values.size(1) - 1]
+        torch.testing.assert_close(result, expected)
+
     def test_nested_fori_loop_scratch_scoping(self) -> None:
         """Nested hl.tile(start, end) with inner accumulator"""
 
@@ -5070,8 +5267,8 @@ class TestPallas(TestCase):
     )
     def test_transpose_dot_defers_pallas_load_mask(self) -> None:
         """A masked load consumed via ``transpose`` -> dot defers its mask to the
-        consumer layout: a raw load + a post-transpose ``jnp.where``, not an eager
-        multiplicative load mask.
+        consumer layout: a raw load + a post-transpose mask, not an eager load
+        mask.
 
         The deferral is an FX-graph pass, so it is independent of worklist
         flattening -- asserted here for ordinary ``fori_loop`` and flattened
@@ -5166,8 +5363,8 @@ class TestPallas(TestCase):
         # Eager mask retained on the direct dot input; nothing to defer past.
         self.assertRegex(
             code,
-            r"(y\[[^\n]*\][^\n]*\*\s*mask_\d+\.astype|"
-            r"mask_\d+\.astype[^\n]*\*[^\n]*y\[)",
+            r"(\bload(?:_\d+)? = [^\n]*\*\s*mask_\d+\.astype|"
+            r"\bload(?:_\d+)? = mask_\d+\.astype[^\n]*\*)",
         )
         self.assertNotRegex(code, r"jnp\.transpose\(")
 
@@ -5215,10 +5412,6 @@ class TestPallas(TestCase):
         ref[s:e] = torch.bmm(y[s:e].transpose(0, 1), w).transpose(0, 1) + y[s:e]
         torch.testing.assert_close(out.cpu(), ref.cpu(), rtol=2e-2, atol=2e-2)
 
-    @xfailIfPallasTpu(
-        "unaligned data-dependent tile load; fixed later in the stack by Pallas "
-        "padded-load support (#2944)"
-    )
     def test_opposite_direction_transpose_keeps_eager_mask(self) -> None:
         """Mirror image of the deferral win.  Here the masked Q axis is already in
         the last-two (sublane) dims at the load and the transpose moves it to a
@@ -5249,9 +5442,10 @@ class TestPallas(TestCase):
             block_sizes=[16],
             pallas_loop_type="fori_loop",
         )
-        # Masked axis is sublane at the load -> eager mask is cheap; deferring
-        # would move it to the major axis, so the gate keeps the eager load mask.
-        self.assertRegex(code, r"= y\[[^\n]*\] \* mask_\d+\.astype")
+        # Masked axis is sublane at the load -> eager mask is cheap; even when
+        # the load is widened for Mosaic alignment, the mask stays on yj before
+        # the transpose/bmm path can move that axis to a major dimension.
+        self.assertRegex(code, r"yj = [^\n]*\* mask_\d+\.astype")
 
         s, e = 0, 10
         ref = torch.bmm(y[:, s:e, :].transpose(0, 1), y[:, s:e, :].permute(1, 2, 0))
@@ -5705,6 +5899,71 @@ class TestPallasIndirectGather(TestCase):
         self.assertIn("dot_general", code)
         self.assertIn("moveaxis", code)
         torch.testing.assert_close(result, table[:, indices.long(), :])
+
+    @parametrize("static_shapes", (True, False))
+    def test_gather_newaxis_before_indirect_dim(self, static_shapes: bool) -> None:
+        """A newaxis does not advance the tensor dimension being gathered."""
+
+        @helion.kernel(backend="pallas", static_shapes=static_shapes)
+        def gather(indices: torch.Tensor, table: torch.Tensor) -> torch.Tensor:
+            out = torch.empty(
+                [1, indices.size(0), table.size(1)],
+                dtype=table.dtype,
+                device=table.device,
+            )
+            for tile_b, tile_e in hl.tile([indices.size(0), table.size(1)]):
+                out[:, tile_b, tile_e] = table[None, indices[tile_b], tile_e]
+            return out
+
+        table = torch.randn(16, 64, device=DEVICE, dtype=torch.bfloat16)
+        indices = torch.randint(0, 16, (128,), device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(gather, (indices, table), block_sizes=[128, 64])
+        self.assertIn("one_hot", code)
+        torch.testing.assert_close(result, table[None, indices.long(), :])
+
+    @parametrize("static_shapes", (True, False))
+    def test_gather_newaxis_after_rank_two_index(self, static_shapes: bool) -> None:
+        @helion.kernel(backend="pallas", static_shapes=static_shapes)
+        def gather(indices: torch.Tensor, table: torch.Tensor) -> torch.Tensor:
+            b, s = indices.size()
+            e = table.size(1)
+            out = torch.empty([b, s, 1, e], dtype=table.dtype, device=table.device)
+            for tile_b, tile_s, tile_e in hl.tile([b, s, e]):
+                out[tile_b, tile_s, :, tile_e] = table[
+                    indices[tile_b, tile_s], None, tile_e
+                ]
+            return out
+
+        table = torch.randn(16, 64, device=DEVICE, dtype=torch.bfloat16)
+        indices = torch.randint(0, 16, (8, 16), device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(
+            gather,
+            (indices, table),
+            block_sizes=[8, 16, 64],
+        )
+        self.assertIn("one_hot", code)
+        torch.testing.assert_close(result, table[indices.long(), None, :])
+
+    @parametrize("static_shapes", (True, False))
+    def test_gather_scalar_before_newaxis(self, static_shapes: bool) -> None:
+        @helion.kernel(backend="pallas", static_shapes=static_shapes)
+        def gather(indices: torch.Tensor, table: torch.Tensor) -> torch.Tensor:
+            b = indices.size(0)
+            e = table.size(2)
+            out = torch.empty([1, b, e], dtype=table.dtype, device=table.device)
+            for tile_b, tile_e in hl.tile([b, e]):
+                out[:, tile_b, tile_e] = table[0, None, indices[tile_b], tile_e]
+            return out
+
+        table = torch.randn(1, 16, 64, device=DEVICE, dtype=torch.bfloat16)
+        indices = torch.randint(0, 16, (32,), device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(
+            gather,
+            (indices, table),
+            block_sizes=[32, 64],
+        )
+        self.assertIn("one_hot", code)
+        torch.testing.assert_close(result, table[0, None, indices.long(), :])
 
 
 instantiate_parametrized_tests(TestPallasIndirectGather)


### PR DESCRIPTION
Stacked PRs:
 * #2962
 * #2957
 * #2956
 * #2955
 * #2954
 * #2953
 * #2952
 * #2951
 * #2949
 * #2948
 * #2947
 * #2946
 * #2945
 * __->__#2944
 * #2943
 * #2942


--- --- ---

### Support Pallas padded loads and scalar widening


Example fixed: gdn_fwd_h, mamba2_chunk_state, matmul_bias_epilogue_wrapper, and reshape_sum under Pallas.

Compiler/runtime side: widen small or alignment-hostile scalar and tile loads to legal full-ref loads, select requested lanes afterward, pad clamped loads back to logical tile shape, and specialize small symbolic matmul dimensions when needed.

Why needed: TPU Mosaic requires stronger alignment and shape proofs than the original scalar/sliced load forms provided, especially for fp8 masks, dynamic negative scalar indices, and short symbolic dimensions.
