### PR TITLE
Track Pallas pipeline access block metadata

### DIFF
--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -305,6 +305,9 @@ class CompileEnvironment:
             default=None,
         )
         self.cute_resolved_wrapper_plans: list[dict[str, object]] = []
+        self.input_alias_groups: dict[int, frozenset[int]] = {}
+        self.input_alias_group_sizes: dict[int, int] = {}
+        self.disable_pallas_dma_for_untracked_aliases = False
         self.block_sizes: list[BlockSizeInfo] = []
         self.debug_shape_renames: dict[sympy.Basic, sympy.Basic] = {}
         try:

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -13,6 +13,7 @@ from helion._compiler.ast_extension import expr_from_string
 from helion._compiler.compile_environment import CompileEnvironment
 from helion._compiler.pallas.vmem_scalar_load import classify_vmem_scalar_load
 from helion._compiler.pallas.vmem_scalar_load import emit_vmem_scalar_load
+from helion._utils import is_scalar_index
 
 _FULL_LOAD_SELECT_MAX_BYTES = 256 << 10
 
@@ -23,7 +24,8 @@ if TYPE_CHECKING:
 
     from helion._compiler.aten_lowering import LoweringContext
     from helion._compiler.inductor_lowering import CodegenState
-    from helion._compiler.tile_strategy import DeviceLoopOrGridState
+    from helion._compiler.tile_strategy import EmitPipelineLoopState
+    from helion._compiler.tile_strategy import ForiLoopState
 
 
 def _select_mask_dtype(dtype: torch.dtype) -> str | None:
@@ -884,41 +886,25 @@ def _load_mask_expr(
 
 def _iter_dma_scratch_loops(
     state: CodegenState, name: str
-) -> Iterator[tuple[DeviceLoopOrGridState, str]]:
-    """Yield ``(loop, scratch_ref_name)`` for every active loop that DMA-routes
-    ``name`` through a VMEM scratch."""
+) -> Iterator[tuple[EmitPipelineLoopState | ForiLoopState, str]]:
+    """Yield active DMA routes for ``name``, innermost loop first."""
     from helion._compiler.tile_strategy import EmitPipelineLoopState
     from helion._compiler.tile_strategy import ForiLoopState
 
-    for loops in state.codegen.active_device_loops.values():
-        for loop in loops:
-            if isinstance(loop, (EmitPipelineLoopState, ForiLoopState)):
-                mapping = getattr(loop, "_tensor_to_dma_scratch", None)
-                if mapping and name in mapping:
-                    yield loop, mapping[name]
+    for loop in reversed(state.codegen._active_loop_stack()):
+        if isinstance(loop, (EmitPipelineLoopState, ForiLoopState)):
+            mapping = loop._tensor_to_dma_scratch
+            if name in mapping:
+                yield loop, mapping[name]
 
 
 def _find_dma_scratch_loop(
     state: CodegenState, name: str
-) -> tuple[DeviceLoopOrGridState | None, str]:
+) -> tuple[EmitPipelineLoopState | ForiLoopState | None, str]:
     """Find the active loop that DMA-routes ``name`` and its scratch ref.
 
-    Returns ``(loop, scratch_ref_name)`` for the first matching active loop, or
+    Returns ``(loop, scratch_ref_name)`` for the innermost matching loop, or
     ``(None, name)`` when the tensor is not scratch-routed.
-
-    TODO: this returns the *first* matching active loop, which is wrong
-    when nested fori_loops scratch-route the *same* tensor at multiple levels --
-    a body access should resolve to the innermost (current) loop's scratch, not
-    the first.  It silently miscompiles e.g.::
-
-        for tile_m in hl.tile(m):
-            out[tile_m, :] = x[tile_m, :] + 1.0
-            for tile_n in hl.tile(n):
-                out[tile_m, tile_n] = out[tile_m, tile_n] + 2.0
-
-    where the inner RMW's load/store bind to the outer loop's scratch while its
-    DMA uses the inner loop's scratch, producing wrong results with no error.
-    This can be fixed by resolving against the current loop instead of first-match.
     """
     return next(_iter_dma_scratch_loops(state, name), (None, name))
 
@@ -927,6 +913,17 @@ def _tensor_routed_to_dma_scratch(state: CodegenState, tensor: torch.Tensor) -> 
     name = state.codegen.device_function.tensor_arg(tensor).name
     loop, _ref = _find_dma_scratch_loop(state, name)
     return loop is not None
+
+
+def mark_dma_scratch_initialized(
+    state: CodegenState,
+    tensor: torch.Tensor,
+) -> None:
+    """Record that codegen emitted a full store into the active tensor scratch."""
+    name = state.codegen.device_function.tensor_arg(tensor).name
+    loop, _ref = _find_dma_scratch_loop(state, name)
+    if loop is not None:
+        loop._initialized_dma_scratch.add(name)
 
 
 def sliced_value_for_store(
@@ -1081,11 +1078,18 @@ def index_parts(
     # routed through the inner DMA / Buffered BlockSpec.  Others stay on
     # their outer BlockSpec and fall through to pl.ds().
     tensor_name = state.codegen.device_function.tensor_arg(tensor).name
-    in_pipeline = False
-    pipeline_block_ids: set[int] = set()
-    for loop, _ref in _iter_dma_scratch_loops(state, tensor_name):
-        in_pipeline = True
-        pipeline_block_ids.update(loop.block_ids)
+    dma_loop, _ref = _find_dma_scratch_loop(state, tensor_name)
+    in_pipeline = dma_loop is not None
+    dma_block_ids = (
+        dma_loop._tensor_to_dma_block_ids[tensor_name]
+        if dma_loop is not None
+        else set()
+    )
+    dma_subscript_meta = (
+        dma_loop._tensor_to_dma_subscript_meta[tensor_name]
+        if dma_loop is not None
+        else None
+    )
 
     # Use pre-computed indexing patterns from plan_tiling analysis
     indexing_patterns = _get_indexing_patterns(state, tensor)
@@ -1104,7 +1108,15 @@ def index_parts(
 
         # Generate code based on the pattern type
         index_code = _generated_index_code(
-            pattern, idx, state, tensor, i, tensor_dim, in_pipeline, pipeline_block_ids
+            pattern,
+            idx,
+            state,
+            tensor,
+            i,
+            tensor_dim,
+            in_pipeline,
+            dma_block_ids,
+            dma_subscript_meta,
         )
         parts.append(index_code)
 
@@ -1123,16 +1135,32 @@ def _get_indexing_patterns(state: CodegenState, tensor: torch.Tensor) -> list[ob
     return patterns
 
 
+def _pipeline_scalar_dim_is_local(
+    dma_subscript_meta: list[object],
+    tensor_dim: int,
+) -> bool:
+    """Whether a DMA/Buffered ref shrank this scalar dimension to extent one."""
+    tensor_subscripts = [idx for idx in dma_subscript_meta if idx is not None]
+    merged_index = (
+        tensor_subscripts[tensor_dim]
+        if tensor_dim < len(tensor_subscripts)
+        else slice(None)
+    )
+    return is_scalar_index(merged_index)
+
+
 def _arbitrary_index_pattern_code(
-    pattern: object,
     idx: object,
     state: CodegenState,
     subscript_index: int,
-    in_pipeline: bool,
+    tensor_dim: int,
+    dma_subscript_meta: list[object] | None,
 ) -> str:
-    from helion._utils import is_scalar_index
-
-    if in_pipeline and is_scalar_index(idx):
+    if (
+        dma_subscript_meta is not None
+        and is_scalar_index(idx)
+        and _pipeline_scalar_dim_is_local(dma_subscript_meta, tensor_dim)
+    ):
         return "0"
     if isinstance(idx, int):
         return str(idx)
@@ -1147,7 +1175,8 @@ def _generated_index_code(
     subscript_index: int,
     tensor_dim: int,
     in_pipeline: bool,
-    pipeline_block_ids: set[int],
+    dma_block_ids: set[int],
+    dma_subscript_meta: list[object] | None,
 ) -> str:
     """Generate index code based on the indexing pattern."""
     from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
@@ -1159,17 +1188,17 @@ def _generated_index_code(
 
     if isinstance(pattern, TilePattern):
         return _tile_pattern_code(
-            pattern, idx, state, tensor, tensor_dim, in_pipeline, pipeline_block_ids
+            pattern, idx, state, tensor, tensor_dim, in_pipeline, dma_block_ids
         )
 
     if isinstance(pattern, TileIndexWithOffsetPattern):
         return _tile_index_with_offset_pattern_code(
-            pattern, state, tensor, tensor_dim, in_pipeline, pipeline_block_ids
+            pattern, state, tensor, tensor_dim, in_pipeline, dma_block_ids
         )
 
     if isinstance(pattern, TileBeginWithOffsetPattern):
         return _tile_begin_with_offset_pattern_code(
-            pattern, state, subscript_index, tensor_dim, in_pipeline, pipeline_block_ids
+            pattern, state, subscript_index, tensor_dim, in_pipeline, dma_block_ids
         )
 
     if isinstance(pattern, ArbitrarySlicePattern):
@@ -1177,7 +1206,7 @@ def _generated_index_code(
 
     if isinstance(pattern, ArbitraryIndexPattern):
         return _arbitrary_index_pattern_code(
-            pattern, idx, state, subscript_index, in_pipeline
+            idx, state, subscript_index, tensor_dim, dma_subscript_meta
         )
 
     if isinstance(pattern, TensorIndexPattern):
@@ -1208,7 +1237,7 @@ def _tile_pattern_code(
     tensor: torch.Tensor,
     tensor_dim: int,
     in_pipeline: bool,
-    pipeline_block_ids: set[int],
+    dma_block_ids: set[int],
 ) -> str:
     from helion._compiler.pallas.plan_tiling import TilePattern
     from helion._compiler.tile_strategy import DeviceLoopState
@@ -1225,7 +1254,7 @@ def _tile_pattern_code(
     # TODO(yifeixu): the long-term fix is making ``can_tile`` per-loop-scope
     # instead of per-tensor-dim so the planner doesn't mark this dim
     # untileable in pipeline mode in the first place.
-    if in_pipeline:
+    if in_pipeline and block_id in dma_block_ids:
         return ":"
 
     can_tile = _can_tile_dimension(state, tensor_dim)
@@ -1250,7 +1279,7 @@ def _tile_index_with_offset_pattern_code(
     tensor: torch.Tensor,
     tensor_dim: int,
     in_pipeline: bool,
-    pipeline_block_ids: set[int],
+    dma_block_ids: set[int],
 ) -> str:
     from helion._compiler.pallas.plan_tiling import TileIndexWithOffsetPattern
 
@@ -1267,7 +1296,7 @@ def _tile_begin_with_offset_pattern_code(
     subscript_index: int,
     tensor_dim: int,
     in_pipeline: bool,
-    pipeline_block_ids: set[int],
+    dma_block_ids: set[int],
 ) -> str:
     from helion._compiler.pallas.plan_tiling import TileBeginWithOffsetPattern
     from helion._compiler.tile_strategy import DeviceLoopState
@@ -1277,7 +1306,7 @@ def _tile_begin_with_offset_pattern_code(
     block_id = pattern.block_id
     offset_str = state.device_function.literal_expr(pattern.offset)
 
-    if in_pipeline and block_id in pipeline_block_ids:
+    if in_pipeline and block_id in dma_block_ids:
         return offset_str
 
     can_tile = _can_tile_dimension(state, tensor_dim)

--- a/helion/_compiler/pallas/memory_ops.py
+++ b/helion/_compiler/pallas/memory_ops.py
@@ -55,13 +55,16 @@ def _(state: CodegenState) -> None:
     from .ordered_carry import emit_carry_store
 
     if not is_scatter and state.device_function.carry_tiles:
-        if emit_carry_store(state, tensor, subscript, name, idx_str, value):
+        if emit_carry_store(state, tensor, subscript, name, parts, value):
+            pallas_codegen.mark_dma_scratch_initialized(state, tensor)
             return
     if tensor.dtype is torch.bool:
         value = CompileEnvironment.current().backend.cast_ast(value, torch.bool)
     state.codegen.add_statement(
         statement_from_string(f"{name}[{idx_str}] = {{value}}", value=value)
     )
+    if not is_scatter:
+        pallas_codegen.mark_dma_scratch_initialized(state, tensor)
 
 
 @_decorators.codegen(load, "pallas")

--- a/helion/_compiler/pallas/ordered_carry.py
+++ b/helion/_compiler/pallas/ordered_carry.py
@@ -18,6 +18,9 @@ import dataclasses
 from typing import TYPE_CHECKING
 from typing import NamedTuple
 
+from helion._compiler.tile_strategy import EmitPipelineLoopState
+from helion._compiler.tile_strategy import ForiLoopState
+
 if TYPE_CHECKING:
     import torch
 
@@ -209,12 +212,52 @@ def _carry_store_plan(
     )
 
 
+def _dma_ref_block_ids_for_name(state: CodegenState, name: str) -> set[int]:
+    """Block IDs already made local by the DMA/Buffered ref named ``name``."""
+    block_ids: set[int] = set()
+    seen: set[int] = set()
+    for loops in state.codegen.active_device_loops.values():
+        for loop in loops:
+            if id(loop) in seen:
+                continue
+            seen.add(id(loop))
+            if not isinstance(loop, (EmitPipelineLoopState, ForiLoopState)):
+                continue
+            for hbm_name, ref_name in loop._tensor_to_dma_scratch.items():
+                if ref_name != name:
+                    continue
+                block_ids.update(loop._tensor_to_dma_block_ids[hbm_name])
+    return block_ids
+
+
+def _zero_begin_emit_pipeline_index(state: CodegenState, block_id: int) -> str | None:
+    """Return the compatible pipeline tile ordinal for ``block_id``."""
+    seen: set[int] = set()
+    for loops in state.codegen.active_device_loops.values():
+        for loop in loops:
+            if id(loop) in seen:
+                continue
+            seen.add(id(loop))
+            if not isinstance(loop, EmitPipelineLoopState):
+                continue
+            ordered_block_ids = list(loop.block_id_to_info)
+            if block_id not in ordered_block_ids:
+                continue
+            info = loop.block_id_to_info.get(block_id)
+            if info is None or info.begin_expr != 0:
+                continue
+            return (
+                f"_helion_compat_pipeline_indices[{ordered_block_ids.index(block_id)}]"
+            )
+    return None
+
+
 def emit_carry_store(
     state: CodegenState,
     tensor: torch.Tensor,
     subscript: list[object] | tuple[object, ...],
     name: str,
-    idx_str: str,
+    idx_parts: list[str],
     value: object,
 ) -> bool:
     """Store a jagged row tile, stitching the boundary two groups share.
@@ -268,11 +311,30 @@ def emit_carry_store(
         f"(({row_off} == {a_start}) & ({begin} % {S} != 0) & (pl.program_id(0) != 0))"
     )
     save_guard = f"(({row_off} + {block_row} >= {a_end}) & ({end} % {S} != 0))"
-    col_sub = f"pl.multiple_of(({col_off}) // {block_col} * {S}, {S})"
+    col_index = _zero_begin_emit_pipeline_index(state, col_block_id)
+    if col_index is None:
+        col_index = f"({col_off}) // {block_col}"
+    col_sub = f"pl.multiple_of(({col_index}) * {S}, {S})"
     carry_slice = f"{carry}[pl.ds({col_sub}, {S}), :]"
-    # Group's last row block: S-aligned, within [0, block_row - S].
-    last_off = f"pl.multiple_of({a_end} - {S} - ({row_off}), {S})"
-    out_last = f"{name}[pl.ds({last_off}, {S}), :]"
+    local_block_ids = _dma_ref_block_ids_for_name(state, name)
+    local_row_ref = row_block_id in local_block_ids
+    store_parts = [*idx_parts]
+    store_parts[0] = (
+        f"pl.ds(0, {block_row})"
+        if local_row_ref
+        else f"pl.ds(pl.multiple_of({row_off}, {S}), {block_row})"
+    )
+    idx_str = ", ".join(store_parts)
+    raw_last_off = f"({a_end} - {S})"
+    last_off = f"pl.multiple_of({raw_last_off}, {S})"
+    if local_row_ref:
+        last_off = f"pl.multiple_of(({raw_last_off}) - ({row_off}), {S})"
+    out_col = (
+        ":"
+        if col_block_id in local_block_ids
+        else f"pl.ds(pl.multiple_of({col_off}, {block_col}), {block_col})"
+    )
+    out_last = f"{name}[pl.ds({last_off}, {S}), {out_col}]"
 
     # Pad the [S, block_col] carry to a full [block_row, block_col] tile (carry on
     # top, zeros below): Pallas rejects a partial write to the double-buffered out.

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -56,8 +56,13 @@ class ArbitrarySlicePattern(IndexingPattern):
     slice: slice
 
 
-def _is_full_slice(idx: slice) -> bool:
-    return idx.start is None and idx.stop is None and idx.step in (None, 1)
+def _is_full_slice(idx: object) -> bool:
+    return (
+        isinstance(idx, slice)
+        and idx.start is None
+        and idx.stop is None
+        and idx.step in (None, 1)
+    )
 
 
 @dataclass

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -38,6 +38,7 @@ from ..compile_environment import CompileEnvironment
 from ..compile_environment import _symint_sympy_expr
 from ..device_function import find_block_size_symbols
 from ..host_function import HostFunction
+from .plan_tiling import _is_full_slice
 
 log = logging.getLogger(__name__)
 
@@ -49,6 +50,8 @@ if TYPE_CHECKING:
     from ...runtime.config import Config
     from ..generate_ast import ResidentPrepLowering
     from ..inductor_lowering import CodegenState
+    from ..tile_strategy import EmitPipelineLoopState
+    from ..tile_strategy import ForiLoopState
     from ..tile_strategy import LoopDimInfo
     from ..tile_strategy import TileStrategy
     from .compact_worklist import ResidentPrepHoist
@@ -236,36 +239,29 @@ def _(state: CodegenState) -> object:
 
 
 @_decorators.codegen(_for_loop_step, "pallas")
-def _(state: CodegenState) -> None:
+def _(state: CodegenState) -> object:
     """Emit inner stepped device loops for Pallas/TPU."""
     config = state.config
     pallas_loop_type = config.get("pallas_loop_type", "unroll")
     if CompileEnvironment.current().compact_worklist_plan is not None:
         if _is_compact_ordered_inner_loop(state):
             if pallas_loop_type == "unroll":
-                _codegen_resident_cache(state)
-                return None
+                return _codegen_resident_cache(state)
             if pallas_loop_type == "emit_pipeline":
-                _codegen_emit_pipeline(state)
-                return None
+                return _codegen_emit_pipeline(state)
             assert pallas_loop_type == "fori_loop"
         if _is_compact_tile_loop(state):
             plan = CompileEnvironment.current().compact_worklist_plan
             assert plan is not None
             if plan.grouping == 2:
-                _codegen_grouped_compact_tile(state)
-                return None
-        _codegen_fori_loop(state)
-        return None
+                return _codegen_grouped_compact_tile(state)
+        return _codegen_fori_loop(state)
     if pallas_loop_type == "emit_pipeline":
-        _codegen_emit_pipeline(state)
-        return None
+        return _codegen_emit_pipeline(state)
     if pallas_loop_type == "fori_loop":
-        _codegen_fori_loop(state)
-        return None
+        return _codegen_fori_loop(state)
     if _has_supported_dependent_tile_end(state):
-        _codegen_dynamic_unroll(state)
-        return None
+        return _codegen_dynamic_unroll(state)
     if _has_dynamic_unroll_bound(state):
         _raise_unsupported_dynamic_unroll()
     # pyrefly: ignore[bad-return]
@@ -552,12 +548,21 @@ def _emit_resident_prep_refill_once(
     state.codegen.grouped_resident_prep_refill_cache[refill_key] = "emitted"
 
 
+LoadedTensorInfo = tuple[torch.Tensor, torch.fx.Node, list[object]]
+StoredTensorInfo = tuple[
+    torch.Tensor,
+    torch.fx.Node,
+    list[object],
+    list[list[object]],
+]
+
+
 def _classify_loop_tensors(
     graph_info: object,
     state: object,
 ) -> tuple[
-    dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
-    dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
+    dict[int, LoadedTensorInfo],
+    dict[int, StoredTensorInfo],
 ]:
     """Classify tensors accessed in an inner loop body into loaded/stored.
 
@@ -565,6 +570,7 @@ def _classify_loop_tensors(
     """
     from ...language.memory_ops import load as _load_op
     from ...language.memory_ops import store as _store_op
+    from .plan_tiling import TensorIndexPattern
 
     host_tensor_nodes: dict[torch.fx.Node, torch.Tensor] = {}
     for node in graph_info.graph.nodes:  # type: ignore[union-attr]
@@ -572,8 +578,8 @@ def _classify_loop_tensors(
             if "val" in node.meta and isinstance(node.meta["val"], torch.Tensor):
                 host_tensor_nodes[node] = node.meta["val"]
 
-    loaded_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]] = {}
-    stored_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]] = {}
+    loaded_tensors: dict[int, LoadedTensorInfo] = {}
+    stored_tensors: dict[int, StoredTensorInfo] = {}
 
     for node in graph_info.graph.nodes:  # type: ignore[union-attr]
         if node.op != "call_function":
@@ -587,9 +593,16 @@ def _classify_loop_tensors(
             ):
                 fake = host_tensor_nodes[tensor_node]
                 key = id(fake)
+                sub_vals = _extract_subscript_vals(subscript)
                 if key not in loaded_tensors:
-                    sub_vals = _extract_subscript_vals(subscript)
                     loaded_tensors[key] = (fake, tensor_node, sub_vals)
+                else:
+                    prev_fake, prev_node, prev_sub_vals = loaded_tensors[key]
+                    loaded_tensors[key] = (
+                        prev_fake,
+                        prev_node,
+                        _merge_subscript_meta(prev_fake, prev_sub_vals, sub_vals),
+                    )
         elif node.target is _store_op:
             tensor_node = node.args[0]
             subscript = node.args[1]
@@ -599,9 +612,41 @@ def _classify_loop_tensors(
             ):
                 fake = host_tensor_nodes[tensor_node]
                 key = id(fake)
+                sub_vals = _extract_subscript_vals(subscript)
                 if key not in stored_tensors:
-                    sub_vals = _extract_subscript_vals(subscript)
-                    stored_tensors[key] = (fake, tensor_node, sub_vals)
+                    stored_tensors[key] = (fake, tensor_node, sub_vals, [sub_vals])
+                else:
+                    prev_fake, prev_node, prev_sub_vals, prev_store_sub_vals = (
+                        stored_tensors[key]
+                    )
+                    stored_tensors[key] = (
+                        prev_fake,
+                        prev_node,
+                        _merge_subscript_meta(prev_fake, prev_sub_vals, sub_vals),
+                        [*prev_store_sub_vals, sub_vals],
+                    )
+                # Scatter preserves untouched target rows by reading the old
+                # block, so it is a read-modify-write rather than store-only.
+                if any(
+                    isinstance(pattern, TensorIndexPattern)
+                    for pattern in node.meta.get("indexing_patterns", ())
+                ):
+                    if key not in loaded_tensors:
+                        loaded_tensors[key] = (fake, tensor_node, sub_vals)
+                    else:
+                        prev_fake, prev_node, prev_sub_vals = loaded_tensors[key]
+                        loaded_tensors[key] = (
+                            prev_fake,
+                            prev_node,
+                            _merge_subscript_meta(prev_fake, prev_sub_vals, sub_vals),
+                        )
+
+    for key in loaded_tensors.keys() & stored_tensors.keys():
+        loaded_fake, loaded_node, loaded_sub_vals = loaded_tensors[key]
+        stored_fake, stored_node, stored_sub_vals, store_sub_vals = stored_tensors[key]
+        merged = _merge_subscript_meta(loaded_fake, loaded_sub_vals, stored_sub_vals)
+        loaded_tensors[key] = (loaded_fake, loaded_node, merged)
+        stored_tensors[key] = (stored_fake, stored_node, merged, store_sub_vals)
 
     return loaded_tensors, stored_tensors
 
@@ -613,6 +658,95 @@ def _tensor_dim_subscripts(subscript_meta: list[object]) -> list[object]:
 
 def _subscript_at_dim(subscripts: list[object], dim: int) -> object:
     return subscripts[dim] if dim < len(subscripts) else slice(None)
+
+
+def _same_subscript_index(
+    left: object,
+    right: object,
+    env: CompileEnvironment,
+) -> bool:
+    if left is right:
+        return True
+    if isinstance(left, int) and isinstance(right, int):
+        return left == right
+    if isinstance(left, torch.SymInt) and isinstance(right, torch.SymInt):
+        return env.known_equal(left, right)
+    if isinstance(left, slice) and isinstance(right, slice):
+        return all(
+            lpart is None
+            and rpart is None
+            or lpart is not None
+            and rpart is not None
+            and _same_subscript_index(lpart, rpart, env)
+            for lpart, rpart in zip(
+                (left.start, left.stop, left.step),
+                (right.start, right.stop, right.step),
+                strict=True,
+            )
+        )
+    return False
+
+
+def _subscript_meta_equal(
+    fake: torch.Tensor,
+    lhs: list[object],
+    rhs: list[object],
+) -> bool:
+    env = CompileEnvironment.current()
+    lhs_dims = _tensor_dim_subscripts(lhs)
+    rhs_dims = _tensor_dim_subscripts(rhs)
+    return all(
+        _same_subscript_index(
+            _subscript_at_dim(lhs_dims, dim),
+            _subscript_at_dim(rhs_dims, dim),
+            env,
+        )
+        for dim in range(fake.ndim)
+    )
+
+
+def _subscript_meta_contains(
+    fake: torch.Tensor,
+    outer: list[object],
+    inner: list[object],
+) -> bool:
+    """Whether an enclosing DMA window contains every inner access dimension."""
+    env = CompileEnvironment.current()
+    outer_dims = _tensor_dim_subscripts(outer)
+    inner_dims = _tensor_dim_subscripts(inner)
+    for dim in range(fake.ndim):
+        outer_index = _subscript_at_dim(outer_dims, dim)
+        inner_index = _subscript_at_dim(inner_dims, dim)
+        if _is_full_slice(outer_index):
+            continue
+        if not _same_subscript_index(outer_index, inner_index, env):
+            return False
+    return True
+
+
+def _merge_subscript_meta(
+    fake: torch.Tensor,
+    lhs: list[object],
+    rhs: list[object],
+) -> list[object]:
+    """Merge accesses into a conservative per-tensor-dimension DMA shape."""
+    env = CompileEnvironment.current()
+    lhs_dims = _tensor_dim_subscripts(lhs)
+    rhs_dims = _tensor_dim_subscripts(rhs)
+
+    merged: list[object] = []
+    for dim in range(fake.ndim):
+        left = _subscript_at_dim(lhs_dims, dim)
+        right = _subscript_at_dim(rhs_dims, dim)
+        if _is_full_slice(left) or _is_full_slice(right):
+            merged.append(slice(None))
+        elif _same_subscript_index(left, right, env):
+            merged.append(left)
+        else:
+            # Sharing symbolic provenance is insufficient: accesses using the
+            # same tile with different offsets cover different HBM regions.
+            merged.append(slice(None))
+    return merged
 
 
 def _get_dim_block_ids(
@@ -631,6 +765,47 @@ def _get_dim_block_ids(
         elif isinstance(idx, slice) and idx == slice(None):
             pass
     return dim_to_bid
+
+
+def _dma_ref_block_ids(
+    subscript_meta: list[object],
+    block_ids: list[int],
+    env: CompileEnvironment,
+    state: CodegenState,
+    extra_block_ids: set[int] | None = None,
+) -> set[int]:
+    """Return block IDs whose slicing is already handled by a DMA-backed ref."""
+    from helion._compiler.pallas.ordered_carry import is_dynamic_bound_tile
+
+    extra = extra_block_ids or set()
+    return {
+        block_id
+        for block_id in _get_dim_block_ids(subscript_meta, env).values()
+        if block_id in block_ids
+        or block_id in extra
+        or is_dynamic_bound_tile(state, block_id)
+        or state.codegen.active_device_loops.get(block_id)
+    }
+
+
+def _active_dma_route(
+    state: CodegenState,
+    tensor_name: str,
+    storage_id: int,
+) -> tuple[EmitPipelineLoopState | ForiLoopState, str] | None:
+    """Return the innermost enclosing route for this tensor or its storage."""
+    from ..tile_strategy import EmitPipelineLoopState
+    from ..tile_strategy import ForiLoopState
+
+    for loop in reversed(state.codegen._active_loop_stack()):
+        if not isinstance(loop, (EmitPipelineLoopState, ForiLoopState)):
+            continue
+        if tensor_name in loop._tensor_to_dma_scratch:
+            return loop, tensor_name
+        for owner_name, owner_storage_id in loop._tensor_to_dma_storage_id.items():
+            if owner_storage_id == storage_id:
+                return loop, owner_name
+    return None
 
 
 def _find_strategy(
@@ -713,7 +888,7 @@ def _is_compact_tile_loop(state: CodegenState) -> bool:
         return False
     if graph_info.block_ids != [plan.compact_axis.block_id]:
         return False
-    args = state.proxy_args[-1]
+    args = state.proxy_args[3]
     return isinstance(args, list) and not _loop_carried_indices(state, len(args))
 
 
@@ -2180,8 +2355,8 @@ def _aligned_dim(
     state: CodegenState,
     env: CompileEnvironment,
     block_ids: list[int],
-    loaded_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
-    stored_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
+    loaded_tensors: dict[int, LoadedTensorInfo],
+    stored_tensors: dict[int, StoredTensorInfo],
 ) -> dict[int, int]:
     """Jagged row tiles (runtime end) that read an aligned-enclosing window.
 
@@ -2208,7 +2383,14 @@ def _aligned_dim(
 
     # Strictest addressing each row needs over the tensors it slices.
     addressing: dict[int, SliceAddressing] = {}
-    for fake, _node, sub_meta in (*loaded_tensors.values(), *stored_tensors.values()):
+    tensor_accesses = [
+        *loaded_tensors.values(),
+        *(
+            (fake, node, sub_meta)
+            for fake, node, sub_meta, _store_sub_metas in stored_tensors.values()
+        ),
+    ]
+    for fake, _node, sub_meta in tensor_accesses:
         if not (isinstance(fake, torch.Tensor) and fake.is_floating_point()):
             continue
         dim_to_bid = _get_dim_block_ids(sub_meta, env)
@@ -2268,12 +2450,12 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     block_ids = graph_info.block_ids
     env = CompileEnvironment.current()
 
-    args = state.ast_args[-1]
+    args = state.ast_args[3]
     assert isinstance(args, list)
     assert all(isinstance(x, ast.AST) for x in args)
 
     # Check if we have loop-carried state (accumulators etc.)
-    proxy_args = state.proxy_args[-1]
+    proxy_args = state.proxy_args[3]
     assert isinstance(proxy_args, list)
     has_loop_state = len(args) > 0
 
@@ -2294,7 +2476,13 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     # BlockSpec; the rest stay on the outer pallas_call BlockSpec
     # (escape clause `bs == as`) and are closure-read from the body.
     all_tensor_info, _vmem_shapes, pipelined_tensor_ids = _classify_pipelined_tensors(
-        loaded_tensors, stored_tensors, block_ids, slice_size_exprs, env, state
+        loaded_tensors,
+        stored_tensors,
+        block_ids,
+        slice_size_exprs,
+        env,
+        state,
+        copy_in_read_write=False,
     )
 
     # Build in_specs and out_specs
@@ -2305,6 +2493,11 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     body_params: list[str] = []
     pipeline_in_args: list[str] = []
     pipeline_out_args: list[str] = []
+    tensor_to_dma_block_ids: dict[str, set[int]] = {}
+    tensor_to_dma_subscript_meta: dict[str, list[object]] = {}
+    tensor_to_dma_storage_id: dict[str, int] = {}
+    tensor_to_dma_access: dict[str, str] = {}
+    initialized_dma_scratch: set[str] = set()
 
     # Map outer grid block_ids to program_id variable names.
     # Compute program_ids before emit_pipeline so the BlockSpec lambda
@@ -2570,7 +2763,7 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     for fake, _tensor_node, _sub_meta in loaded_tensors.values():
         if id(fake) in pipelined_tensor_ids:
             state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
-    for fake, _tensor_node, _sub_meta in stored_tensors.values():
+    for fake, _tensor_node, _sub_meta, _store_sub_metas in stored_tensors.values():
         if id(fake) in pipelined_tensor_ids:
             state.device_function.pallas_memory_space[id(fake)] = PallasMemorySpace.HBM
 
@@ -2587,8 +2780,19 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         in_specs.append(_make_load_block_spec(fake, sub_meta))
         body_params.append(vmem_name)
         pipeline_in_args.append(_make_hbm_slice(fake, hbm_name, sub_meta))
+        tensor_to_dma_block_ids[hbm_name] = _dma_ref_block_ids(
+            sub_meta,
+            block_ids,
+            env,
+            state,
+            set(_bid_to_pid_var),
+        )
+        tensor_to_dma_subscript_meta[hbm_name] = sub_meta
+        tensor_to_dma_storage_id[hbm_name] = id(fake.untyped_storage())
+        tensor_to_dma_access[hbm_name] = "load"
+        initialized_dma_scratch.add(hbm_name)
 
-    for fake, _tensor_node, sub_meta in stored_tensors.values():
+    for fake, _tensor_node, sub_meta, _store_sub_metas in stored_tensors.values():
         if id(fake) not in pipelined_tensor_ids:
             continue
         hbm_name = state.device_function.tensor_arg(fake).name
@@ -2599,6 +2803,16 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         out_specs.append(_make_store_block_spec(fake, sub_meta))
         body_params.append(vmem_name)
         pipeline_out_args.append(_make_hbm_slice(fake, hbm_name, sub_meta))
+        tensor_to_dma_block_ids[hbm_name] = _dma_ref_block_ids(
+            sub_meta,
+            block_ids,
+            env,
+            state,
+            set(_bid_to_pid_var),
+        )
+        tensor_to_dma_subscript_meta[hbm_name] = sub_meta
+        tensor_to_dma_storage_id[hbm_name] = id(fake.untyped_storage())
+        tensor_to_dma_access[hbm_name] = "store"
 
     # Build the body function
     body_fn_name = state.device_function.new_var("_pipeline_body")
@@ -2679,6 +2893,10 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
     for _fake, hbm_name in out_tensors:
         tensor_to_dma_scratch[hbm_name] = body_params[idx]
         idx += 1
+    assert tensor_to_dma_scratch.keys() == tensor_to_dma_block_ids.keys()
+    assert tensor_to_dma_scratch.keys() == tensor_to_dma_subscript_meta.keys()
+    assert tensor_to_dma_scratch.keys() == tensor_to_dma_storage_id.keys()
+    assert tensor_to_dma_scratch.keys() == tensor_to_dma_access.keys()
 
     # Create the pipeline loop state
     pipeline_state = EmitPipelineLoopState(
@@ -2687,6 +2905,11 @@ def _codegen_emit_pipeline(state: CodegenState) -> object:
         body_fn_name=body_fn_name,
         inner_statements=body_stmts,
         _tensor_to_dma_scratch=tensor_to_dma_scratch,
+        _tensor_to_dma_block_ids=tensor_to_dma_block_ids,
+        _tensor_to_dma_subscript_meta=tensor_to_dma_subscript_meta,
+        _tensor_to_dma_storage_id=tensor_to_dma_storage_id,
+        _tensor_to_dma_access=tensor_to_dma_access,
+        _initialized_dma_scratch=initialized_dma_scratch,
     )
 
     # For loop-carried state, remap args to scratch reads inside the body
@@ -2900,13 +3123,154 @@ def _compute_vmem_shapes(
     return vmem_shapes
 
 
+def _storage_has_globally_compatible_loop_accesses(
+    storage_id: int,
+    env: CompileEnvironment,
+    state: CodegenState,
+    *,
+    copy_in_read_write: bool,
+) -> bool:
+    """Whether every graph using a shared storage can use one global HBM route."""
+    from ..device_ir import ForLoopGraphInfo
+
+    if env.disable_pallas_dma_for_untracked_aliases:
+        return False
+
+    device_ir = HostFunction.current().device_ir
+    loop_candidates: list[bool] = []
+    alias_storages = env.input_alias_groups.get(storage_id, frozenset((storage_id,)))
+    alias_group_size = env.input_alias_group_sizes.get(storage_id, 1)
+    accessed_alias_storages: set[int] = set()
+    has_stores = False
+    has_non_loop_access = False
+    matching_loop_count = 0
+    has_read_write = False
+
+    def matches_storage(fake: torch.Tensor) -> bool:
+        return id(fake.untyped_storage()) in alias_storages
+
+    for graph_info in device_ir.graphs:
+        loaded, stored = _classify_loop_tensors(graph_info, state)
+        matching_loaded = {
+            key: info for key, info in loaded.items() if matches_storage(info[0])
+        }
+        matching_stored = {
+            key: info for key, info in stored.items() if matches_storage(info[0])
+        }
+        if not matching_loaded and not matching_stored:
+            continue
+        accessed_alias_storages.update(
+            id(info[0].untyped_storage()) for info in matching_loaded.values()
+        )
+        accessed_alias_storages.update(
+            id(info[0].untyped_storage()) for info in matching_stored.values()
+        )
+        has_stores = has_stores or bool(matching_stored)
+        if not isinstance(graph_info, ForLoopGraphInfo):
+            has_non_loop_access = True
+            continue
+        matching_loop_count += 1
+        if len(matching_loaded.keys() | matching_stored.keys()) != 1:
+            loop_candidates.append(False)
+            continue
+
+        all_tensor_info: list[tuple[torch.Tensor, list[object], str]] = []
+        for key, (fake, _node, sub_meta) in matching_loaded.items():
+            if key not in matching_stored:
+                all_tensor_info.append((fake, sub_meta, "load"))
+        for key, (fake, _node, sub_meta, store_metas) in matching_stored.items():
+            widened_store = any(
+                not _subscript_meta_equal(fake, sub_meta, store_meta)
+                for store_meta in store_metas
+            )
+            unsafe_read_write = key in matching_loaded and not copy_in_read_write
+            has_read_write = has_read_write or key in matching_loaded
+            if widened_store or unsafe_read_write:
+                loop_candidates.append(False)
+                continue
+            all_tensor_info.append((fake, sub_meta, "store"))
+
+        block_sizes: list[int] = []
+        for block_id in graph_info.block_ids:
+            block_size = state.device_function.resolved_block_size(block_id)
+            if not isinstance(block_size, int):
+                loop_candidates.append(False)
+                break
+            block_sizes.append(block_size)
+        else:
+            step_variants: list[list[object]] = []
+            for caller_info in device_ir.graphs:
+                for node in caller_info.graph.nodes:
+                    if (
+                        node.op != "call_function"
+                        or node.target not in (_for_loop, _for_loop_step)
+                        or not node.args
+                        or node.args[0] != graph_info.graph_id
+                    ):
+                        continue
+                    if node.target is _for_loop:
+                        step_variants.append([None] * len(graph_info.block_ids))
+                    else:
+                        step_variants.append(_extract_subscript_vals(node.args[4]))
+            if not step_variants:
+                step_variants.append([None] * len(graph_info.block_ids))
+
+            for steps in step_variants:
+                if len(steps) != len(graph_info.block_ids):
+                    loop_candidates.append(False)
+                    continue
+                slice_size_exprs = [
+                    str(block_size) if _is_default_pallas_loop_step(step) else "1"
+                    for block_size, step in zip(block_sizes, steps, strict=True)
+                ]
+                vmem_shapes = _compute_vmem_shapes(
+                    all_tensor_info,
+                    graph_info.block_ids,
+                    slice_size_exprs,
+                    env,
+                    state,
+                )
+                loop_candidates.extend(map(_check_dma_alignment, vmem_shapes))
+
+    if alias_group_size > 1 and has_stores:
+        raise BackendUnsupported(
+            "pallas",
+            "mutating aliased tensor arguments across device loops is not supported",
+        )
+    if len(accessed_alias_storages) > 1 or has_non_loop_access:
+        return False
+    if (
+        env.compact_worklist_plan is not None
+        and matching_loop_count > 1
+        and has_read_write
+    ):
+        return False
+    # A single loop can still use the current call's row-slab exception. Shared
+    # storage needs the standard alignment in every loop so routing is global.
+    return len(loop_candidates) <= 1 or all(loop_candidates)
+
+
+def _is_default_pallas_loop_step(step: object) -> bool:
+    if isinstance(step, torch.fx.Node):
+        step = step.meta.get("val", step)
+    if step is None:
+        return True
+    try:
+        value = sympy.sympify(step)
+    except (TypeError, ValueError, sympy.SympifyError):
+        return False
+    return value in (sympy.Integer(0), sympy.Integer(1))
+
+
 def _classify_pipelined_tensors(
-    loaded_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
-    stored_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
+    loaded_tensors: dict[int, LoadedTensorInfo],
+    stored_tensors: dict[int, StoredTensorInfo],
     block_ids: list[int],
     slice_size_exprs: list[str],
     env: CompileEnvironment,
     state: CodegenState,
+    *,
+    copy_in_read_write: bool,
 ) -> tuple[
     list[tuple[torch.Tensor, list[object], str]], list[tuple[int, ...]], set[int]
 ]:
@@ -2945,7 +3309,7 @@ def _classify_pipelined_tensors(
     # Walk all root graphs (outer pallas_call body) for load/store/atomic
     # nodes; any tensor accessed there is read/written outside the inner
     # loop and must keep its outer BlockSpec.
-    outer_access_tensor_ids: set[int] = set()
+    outer_access_storages: set[int] = set()
     for root_id in device_ir.root_ids:
         root_graph = device_ir.graphs[root_id].graph
         for node in root_graph.nodes:
@@ -2956,7 +3320,36 @@ def _classify_pipelined_tensors(
                 continue
             val = tensor_node.meta.get("val")
             if isinstance(val, torch.Tensor):
-                outer_access_tensor_ids.add(id(val))
+                outer_access_storages.add(id(val.untyped_storage()))
+    outer_access_storages = {
+        alias_storage
+        for storage in outer_access_storages
+        for alias_storage in env.input_alias_groups.get(storage, (storage,))
+    }
+
+    # emit_pipeline outputs are not copied in before their body runs. Its
+    # read-modify-write tensors must therefore remain on their outer refs. Manual
+    # fori DMA does copy them in, so widening there is initialized and safe.
+    unsafe_store_ids = {
+        key
+        for key, (fake, _node, merged_meta, store_metas) in stored_tensors.items()
+        if (key in loaded_tensors and not copy_in_read_write)
+        or any(
+            not _subscript_meta_equal(fake, merged_meta, store_meta)
+            for store_meta in store_metas
+        )
+    }
+
+    inner_ids_by_storage: dict[int, set[int]] = {}
+    for key, (fake, _node, _sub_meta) in loaded_tensors.items():
+        inner_ids_by_storage.setdefault(id(fake.untyped_storage()), set()).add(key)
+    for key, (fake, _node, _sub_meta, _store_sub_metas) in stored_tensors.items():
+        inner_ids_by_storage.setdefault(id(fake.untyped_storage()), set()).add(key)
+    aliased_inner_storages = {
+        storage
+        for storage, fake_ids in inner_ids_by_storage.items()
+        if len(fake_ids) > 1
+    }
 
     # Pallas lowers atomics as direct load/compute/store operations on their
     # tensor ref. Such a tensor cannot simultaneously be remapped to the
@@ -2972,26 +3365,80 @@ def _classify_pipelined_tensors(
             val = tensor_node.meta.get("val")
             if isinstance(val, torch.Tensor):
                 atomic_storages.add(id(val.untyped_storage()))
+    atomic_storages = {
+        alias_storage
+        for storage in atomic_storages
+        for alias_storage in env.input_alias_groups.get(storage, (storage,))
+    }
 
     pipelined_ids: set[int] = set()
     for (fake, sub_meta, direction), vmem_shape in zip(
         all_tensor_info, vmem_shapes, strict=True
     ):
+        tensor_name = state.device_function.tensor_arg(fake).name
+        storage_id = id(fake.untyped_storage())
+        enclosing_route = _active_dma_route(state, tensor_name, storage_id)
+        if enclosing_route is not None:
+            enclosing_loop, owner_name = enclosing_route
+            if owner_name != tensor_name:
+                raise BackendUnsupported(
+                    "pallas",
+                    "a nested device loop accesses an enclosing DMA tensor "
+                    "through a different alias or view",
+                )
+            enclosing_meta = enclosing_loop._tensor_to_dma_subscript_meta[owner_name]
+            if not _subscript_meta_contains(fake, enclosing_meta, sub_meta):
+                raise BackendUnsupported(
+                    "pallas",
+                    "a nested device loop accesses a tensor outside its enclosing "
+                    "DMA scratch window",
+                )
+            current_reads = direction == "load" or id(fake) in loaded_tensors
+            current_writes = direction == "store"
+            enclosing_access = enclosing_loop._tensor_to_dma_access[owner_name]
+            if (
+                current_reads
+                and owner_name not in enclosing_loop._initialized_dma_scratch
+            ):
+                raise BackendUnsupported(
+                    "pallas",
+                    "a nested device loop reads an enclosing output scratch "
+                    "before it is initialized",
+                )
+            if current_writes and enclosing_access not in ("store", "read_write"):
+                raise BackendUnsupported(
+                    "pallas",
+                    "a nested device loop writes an enclosing input-only DMA scratch",
+                )
+            # Reuse the enclosing scratch. This preserves pending writes and lets
+            # its owner perform the single HBM writeback after the nested loop.
+            continue
         if not _can_stream_inner_tile(
             fake, sub_meta, direction, block_ids, vmem_shape, env, state
         ):
             continue
-        if id(fake) in outer_access_tensor_ids:
+        if not _storage_has_globally_compatible_loop_accesses(
+            storage_id,
+            env,
+            state,
+            copy_in_read_write=copy_in_read_write,
+        ):
             continue
-        if id(fake.untyped_storage()) in atomic_storages:
+        if id(fake) in unsafe_store_ids:
+            continue
+        if storage_id in outer_access_storages:
+            continue
+        if storage_id in aliased_inner_storages:
+            continue
+        if storage_id in atomic_storages:
             continue
         pipelined_ids.add(id(fake))
     return all_tensor_info, vmem_shapes, pipelined_ids
 
 
 def _resident_loop_tensor_info(
-    loaded_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
-    stored_tensors: dict[int, tuple[torch.Tensor, torch.fx.Node, list[object]]],
+    loaded_tensors: dict[int, LoadedTensorInfo],
+    stored_tensors: dict[int, StoredTensorInfo],
 ) -> list[tuple[torch.Tensor, list[object], str]]:
     """Tensor access records needed by optional resident prep lowering."""
     result = [
@@ -3001,7 +3448,7 @@ def _resident_loop_tensor_info(
     ]
     result.extend(
         (fake, sub_meta, "store")
-        for fake, _tensor_node, sub_meta in stored_tensors.values()
+        for fake, _tensor_node, sub_meta, _store_sub_metas in stored_tensors.values()
     )
     return result
 
@@ -3022,7 +3469,7 @@ def _codegen_dynamic_unroll(state: CodegenState) -> object:
             "dynamic pallas unroll currently supports one inner tile dimension"
         )
 
-    args = state.ast_args[-1]
+    args = state.ast_args[3]
     assert isinstance(args, list)
     assert all(isinstance(arg, ast.AST) for arg in args)
 
@@ -3158,11 +3605,11 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     block_ids = graph_info.block_ids
     env = CompileEnvironment.current()
 
-    args = state.ast_args[-1]
+    args = state.ast_args[3]
     assert isinstance(args, list)
     assert all(isinstance(x, ast.AST) for x in args)
 
-    proxy_args = state.proxy_args[-1]
+    proxy_args = state.proxy_args[3]
     assert isinstance(proxy_args, list)
     has_loop_state = len(args) > 0
 
@@ -3202,7 +3649,13 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     # non-pipelined tensor is present (which would load full outer-block
     # tiles into VMEM and may OOM at large shapes).
     all_tensor_info, vmem_shapes, pipelined_tensor_ids = _classify_pipelined_tensors(
-        loaded_tensors, stored_tensors, block_ids, slice_size_exprs, env, state
+        loaded_tensors,
+        stored_tensors,
+        block_ids,
+        slice_size_exprs,
+        env,
+        state,
+        copy_in_read_write=True,
     )
 
     # Compact worklist: the compact-tile aligned_load and exact_store tensors use
@@ -3251,6 +3704,11 @@ def _codegen_fori_loop(state: CodegenState) -> object:
     from ..device_function import PallasMemorySpace
 
     tensor_to_dma_scratch: dict[str, str] = {}
+    tensor_to_dma_block_ids: dict[str, set[int]] = {}
+    tensor_to_dma_subscript_meta: dict[str, list[object]] = {}
+    tensor_to_dma_storage_id: dict[str, int] = {}
+    tensor_to_dma_access: dict[str, str] = {}
+    initialized_dma_scratch: set[str] = set()
     tensor_to_sem: dict[str, str] = {}
     prefetched_load_tensors: set[str] = set()
     prefetched_loads: list[tuple[torch.Tensor, list[object], str, str]] = []
@@ -3270,7 +3728,8 @@ def _codegen_fori_loop(state: CodegenState) -> object:
             id(input_tensor.untyped_storage()), []
         ).append(input_slot)
     stored_tensor_storages = {
-        id(fake.untyped_storage()) for fake, _node, _sub_meta in stored_tensors.values()
+        id(fake.untyped_storage())
+        for fake, _node, _sub_meta, _store_sub_metas in stored_tensors.values()
     }
 
     for (fake, sub_meta, direction), vmem_shape in zip(
@@ -3326,10 +3785,30 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         else:
             vmem_name, sem_name = cached_resource
         tensor_to_dma_scratch[hbm_name] = vmem_name
+        tensor_to_dma_block_ids[hbm_name] = _dma_ref_block_ids(
+            sub_meta,
+            block_ids,
+            env,
+            state,
+        )
+        tensor_to_dma_subscript_meta[hbm_name] = sub_meta
+        tensor_to_dma_storage_id[hbm_name] = storage_id
+        access = (
+            "read_write"
+            if direction == "store" and id(fake) in loaded_tensors
+            else direction
+        )
+        tensor_to_dma_access[hbm_name] = access
+        if access != "store":
+            initialized_dma_scratch.add(hbm_name)
         tensor_to_sem[hbm_name] = sem_name
         if uses_load_prefetch:
             prefetched_load_tensors.add(hbm_name)
             prefetched_loads.append((fake, sub_meta, vmem_name, sem_name))
+    assert tensor_to_dma_scratch.keys() == tensor_to_dma_block_ids.keys()
+    assert tensor_to_dma_scratch.keys() == tensor_to_dma_subscript_meta.keys()
+    assert tensor_to_dma_scratch.keys() == tensor_to_dma_storage_id.keys()
+    assert tensor_to_dma_scratch.keys() == tensor_to_dma_access.keys()
 
     # Build the body function
     body_stmts: list[ast.AST] = []
@@ -3390,6 +3869,11 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         loop_var_name=loop_vars[-1],
         inner_statements=body_stmts,
         _tensor_to_dma_scratch=tensor_to_dma_scratch,
+        _tensor_to_dma_block_ids=tensor_to_dma_block_ids,
+        _tensor_to_dma_subscript_meta=tensor_to_dma_subscript_meta,
+        _tensor_to_dma_storage_id=tensor_to_dma_storage_id,
+        _tensor_to_dma_access=tensor_to_dma_access,
+        _initialized_dma_scratch=initialized_dma_scratch,
         _tensor_to_sem=tensor_to_sem,
         _prefetched_load_tensors=prefetched_load_tensors,
     )
@@ -3652,7 +4136,7 @@ def _codegen_fori_loop(state: CodegenState) -> object:
         if has_loop_state:
             _write_back_loop_carried(state, scratch_names, carried, graph_results)
 
-        for fake, _tensor_node, sub_meta in stored_tensors.values():
+        for fake, _tensor_node, sub_meta, _store_sub_metas in stored_tensors.values():
             hbm_name = state.device_function.tensor_arg(fake).name
             if hbm_name not in tensor_to_dma_scratch:
                 continue

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -1862,6 +1862,15 @@ class EmitPipelineLoopState(DeviceLoopOrGridState):
     outer_prefix: list[ast.AST] = dataclasses.field(default_factory=list)
     outer_suffix: list[ast.AST] = dataclasses.field(default_factory=list)
     _tensor_to_dma_scratch: dict[str, str] = dataclasses.field(default_factory=dict)
+    _tensor_to_dma_block_ids: dict[str, set[int]] = dataclasses.field(
+        default_factory=dict
+    )
+    _tensor_to_dma_subscript_meta: dict[str, list[object]] = dataclasses.field(
+        default_factory=dict
+    )
+    _tensor_to_dma_storage_id: dict[str, int] = dataclasses.field(default_factory=dict)
+    _tensor_to_dma_access: dict[str, str] = dataclasses.field(default_factory=dict)
+    _initialized_dma_scratch: set[str] = dataclasses.field(default_factory=set)
 
 
 @dataclasses.dataclass
@@ -1882,6 +1891,15 @@ class ForiLoopState(DeviceLoopOrGridState):
     outer_prefix: list[ast.AST] = dataclasses.field(default_factory=list)
     outer_suffix: list[ast.AST] = dataclasses.field(default_factory=list)
     _tensor_to_dma_scratch: dict[str, str] = dataclasses.field(default_factory=dict)
+    _tensor_to_dma_block_ids: dict[str, set[int]] = dataclasses.field(
+        default_factory=dict
+    )
+    _tensor_to_dma_subscript_meta: dict[str, list[object]] = dataclasses.field(
+        default_factory=dict
+    )
+    _tensor_to_dma_storage_id: dict[str, int] = dataclasses.field(default_factory=dict)
+    _tensor_to_dma_access: dict[str, str] = dataclasses.field(default_factory=dict)
+    _initialized_dma_scratch: set[str] = dataclasses.field(default_factory=set)
     _tensor_to_sem: dict[str, str] = dataclasses.field(default_factory=dict)
     _prefetched_load_tensors: set[str] = dataclasses.field(default_factory=set)
 

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -72,6 +72,7 @@ from .settings import Settings
 if TYPE_CHECKING:
     from collections.abc import Generator
     from collections.abc import Hashable
+    from collections.abc import Iterator
 
     from torch._guards import Source
 
@@ -82,6 +83,81 @@ if TYPE_CHECKING:
     ConfigLike = Config | dict[str, object]
 
 log: logging.Logger = logging.getLogger(__name__)
+
+
+def _iter_argument_tensor_paths(
+    obj: object,
+    path: str = "",
+    *,
+    include_function_closures: bool = False,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Yield tensor paths in the deterministic order used by specialization."""
+    if isinstance(obj, torch.Tensor):
+        yield path, obj
+    elif type(obj) is list or type(obj) is tuple:
+        for index, item in enumerate(obj):
+            yield from _iter_argument_tensor_paths(
+                item,
+                f"{path}[{index}]",
+                include_function_closures=include_function_closures,
+            )
+    elif type(obj) is dict:
+        for key in sorted(obj):
+            yield from _iter_argument_tensor_paths(
+                obj[key],
+                f"{path}[{key!r}]",
+                include_function_closures=include_function_closures,
+            )
+    elif isinstance(obj, tuple) and hasattr(obj, "_fields"):
+        # pyrefly: ignore[missing-attribute]
+        for key, value in sorted(obj._asdict().items()):
+            yield from _iter_argument_tensor_paths(
+                value,
+                f"{path}[{key!r}]",
+                include_function_closures=include_function_closures,
+            )
+    elif dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        for field in sorted(dataclasses.fields(obj), key=lambda field: field.name):
+            yield from _iter_argument_tensor_paths(
+                getattr(obj, field.name),
+                f"{path}[{field.name!r}]",
+                include_function_closures=include_function_closures,
+            )
+    elif include_function_closures and isinstance(obj, types.FunctionType):
+        for index, cell in enumerate(obj.__closure__ or ()):
+            yield from _iter_argument_tensor_paths(
+                cell.cell_contents,
+                f"{path}.__closure__[{index}].cell_contents",
+                include_function_closures=True,
+            )
+
+
+def _iter_argument_tensors(
+    obj: object,
+    *,
+    include_function_closures: bool = False,
+) -> Iterator[torch.Tensor]:
+    for _path, tensor in _iter_argument_tensor_paths(
+        obj, include_function_closures=include_function_closures
+    ):
+        yield tensor
+
+
+def _tensor_alias_signature(args: Sequence[object]) -> tuple[int, ...]:
+    """Canonical storage-alias groups for tensor leaves in specialization order."""
+    representatives: list[torch.Tensor] = []
+    result: list[int] = []
+    for tensor in _iter_argument_tensors(tuple(args), include_function_closures=True):
+        for group, representative in enumerate(representatives):
+            if torch._C._is_alias_of(  # pyrefly: ignore[missing-attribute]
+                tensor, representative
+            ):
+                result.append(group)
+                break
+        else:
+            result.append(len(representatives))
+            representatives.append(tensor)
+    return tuple(result)
 
 
 def _indexing_config_uses_tensor_descriptor(indexing: object, index: int) -> bool:
@@ -414,6 +490,14 @@ class Kernel(Generic[_R]):
             and (self.settings.distributed or self._declares_process_group)
         )
 
+    def _input_alias_signature(self, args: Sequence[object]) -> tuple[int, ...]:
+        # Only Pallas DMA planning consumes input alias metadata. Keeping it out
+        # of other backends' keys also avoids tracing storage introspection in
+        # their torch.compile fast path.
+        if self.settings.backend != "pallas":
+            return ()
+        return _tensor_alias_signature(args)
+
     def _fast_dispatch_key(self, args: tuple[object, ...]) -> Hashable | None:
         """
         Build a cheap dispatch key for the fast-path cache in ``__call__``.
@@ -460,7 +544,9 @@ class Kernel(Generic[_R]):
                 return None
         if not has_tensor:
             return None
-        key.append(self._compute_is_distributed(args))
+        key.extend(
+            (self._compute_is_distributed(args), self._input_alias_signature(args))
+        )
         signature = (
             self._base_specialization_key(args)
             if self._has_specialization_extras
@@ -500,18 +586,15 @@ class Kernel(Generic[_R]):
                 raise TypeError(
                     f"Too many arguments passed to the kernel, expected: {self._num_params} got: {len(args)}."
                 )
+            if len(args) < self._num_params:
+                args = self.normalize_args(*args)
             signature = self._base_specialization_key(args)
             cache_key = self._get_bound_kernel_cache_key(args, signature)
             bound_kernel = (
                 None if cache_key is None else self._bound_kernels.get(cache_key, None)
             )
             if bound_kernel is None:
-                normalized_args: tuple[object, ...] = self.normalize_args(*args)
-                if len(normalized_args) != len(args):
-                    # we had default args that needed to be applied
-                    bound_kernel = self.bind(normalized_args)
-                else:
-                    bound_kernel = BoundKernel(self, args)
+                bound_kernel = BoundKernel(self, args)
                 if cache_key is None:
                     cache_key = self._create_bound_kernel_cache_key(
                         bound_kernel, args, signature
@@ -537,15 +620,23 @@ class Kernel(Generic[_R]):
                 result.append(self._specialization_key(value))
         device_type, device_capability = _device_specialization_key(args)
         is_distributed = self._compute_is_distributed(args)
+        alias_signature = self._input_alias_signature(args)
         if self._key_fn is not None:
             return (
                 *result,
                 device_type,
                 device_capability,
                 is_distributed,
+                alias_signature,
                 self._key_fn(*args),
             )
-        return (*result, device_type, device_capability, is_distributed)
+        return (
+            *result,
+            device_type,
+            device_capability,
+            is_distributed,
+            alias_signature,
+        )
 
     def specialization_key(self, args: Sequence[object]) -> tuple[Hashable, ...]:
         """
@@ -910,7 +1001,9 @@ class Kernel(Generic[_R]):
         """
         if kwargs:
             args = self.normalize_args(*args, **kwargs)
-        elif self._dispatch_cache:
+        elif len(args) < self._num_params:
+            args = self.normalize_args(*args)
+        if self._dispatch_cache:
             # Fast path: repeat call with argument metadata seen before. The
             # cache is only populated by calls that already took the slow
             # path below, so hitting it cannot skip autotuning/compilation.
@@ -1039,6 +1132,9 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             assert len(args) == len(self.kernel.signature.parameters)
             self.fake_args: list[object] = []
             constexpr_args = {}
+            real_storage_to_fake_storages: dict[int, list[int]] = {}
+            real_storage_member_counts: dict[int, int] = {}
+            real_storage_tracked_counts: dict[int, int] = {}
             for name, arg, annotation in zip(
                 self.kernel.signature.parameters,
                 args,
@@ -1058,7 +1154,49 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
                     self.fake_args.append(arg)
                     constexpr_args[name] = arg
                 else:
-                    self.fake_args.append(self.env.to_fake(arg, ArgumentOrigin(name)))
+                    for tensor in _iter_argument_tensors(
+                        arg, include_function_closures=True
+                    ):
+                        storage_id = id(tensor.untyped_storage())
+                        real_storage_member_counts[storage_id] = (
+                            real_storage_member_counts.get(storage_id, 0) + 1
+                        )
+                    fake_arg = self.env.to_fake(arg, ArgumentOrigin(name))
+                    # Lifted helper closures are populated lazily during tracing,
+                    # so their tensor leaves cannot be paired at bind time.
+                    real_tensors = (
+                        []
+                        if isinstance(fake_arg, types.FunctionType)
+                        else list(_iter_argument_tensors(arg))
+                    )
+                    fake_tensors = list(_iter_argument_tensors(fake_arg))
+                    assert len(real_tensors) == len(fake_tensors)
+                    for real_tensor, fake_tensor in zip(
+                        real_tensors, fake_tensors, strict=True
+                    ):
+                        real_storage_to_fake_storages.setdefault(
+                            id(real_tensor.untyped_storage()), []
+                        ).append(id(fake_tensor.untyped_storage()))
+                        real_storage_id = id(real_tensor.untyped_storage())
+                        real_storage_tracked_counts[real_storage_id] = (
+                            real_storage_tracked_counts.get(real_storage_id, 0) + 1
+                        )
+                    self.fake_args.append(fake_arg)
+
+            for real_storage_id, fake_storages in real_storage_to_fake_storages.items():
+                if len(fake_storages) < 2:
+                    continue
+                group = frozenset(fake_storages)
+                group_size = real_storage_member_counts[real_storage_id]
+                for storage_id in group:
+                    self.env.input_alias_groups[storage_id] = group
+                    self.env.input_alias_group_sizes[storage_id] = group_size
+
+            self.env.disable_pallas_dma_for_untracked_aliases = any(
+                member_count > 1
+                and real_storage_tracked_counts.get(real_storage_id, 0) < member_count
+                for real_storage_id, member_count in real_storage_member_counts.items()
+            )
 
             self._apply_mark_static(args)
 

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -276,8 +276,8 @@ class TestConfigAPI(TestCase):
         ):
             sm100_key = device_key_kernel._base_specialization_key((device,))
 
-        self.assertEqual(sm90_key[-3:], ("cuda", (9, 0), False))
-        self.assertEqual(sm100_key[-3:], ("cuda", (10, 0), False))
+        self.assertEqual(sm90_key[-4:], ("cuda", (9, 0), False, ()))
+        self.assertEqual(sm100_key[-4:], ("cuda", (10, 0), False, ()))
         self.assertNotEqual(sm90_key, sm100_key)
 
     def test_config_constructor_signature_contains_expected_kwargs(self) -> None:

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -2246,6 +2246,9 @@ class TestExamples(RefEagerTestBase, TestCase):
     @skipIfCudaSharedMemoryLessThan(
         131072, reason="block sizes exceed device shared memory limit"
     )
+    @xfailIfPallasInterpret(
+        "JAX interpret mode cannot discharge the emit_pipeline VMEM refs"
+    )
     @skipIfXPU("Squeeze-and-excitation network not supported on XPU")
     def test_squeeze_and_excitation_net_fwd(self):
         m, n, k = 128, 128, 128
@@ -2314,7 +2317,10 @@ class TestExamples(RefEagerTestBase, TestCase):
             atol=0.3,
         )
 
-    @xfailIfPallas("tensor accessed with conflicting tiling patterns")
+    @xfailIfPallasInterpret(
+        "pl.program_id captured into emit_pipeline body is not supported in "
+        "JAX interpret mode (program_id_p.bind asserts during trace)"
+    )
     @skipIfA10G("failure on a10g")
     @skipIfTileIR("accuracy failure")
     @skipIfXPU("ocloc compilation failure with 256-GRF kernel on XPU backend")
@@ -2358,6 +2364,9 @@ class TestExamples(RefEagerTestBase, TestCase):
             atol=0.3,
         )
 
+    @xfailIfPallasInterpret(
+        "JAX interpret mode cannot discharge the emit_pipeline VMEM refs"
+    )
     @skipIfA10G("failure on a10g")
     @skipIfTileIR("accuracy failure")
     @skipIfXPU("ocloc compilation failure with 256-GRF kernel on XPU backend")

--- a/test/test_fast_dispatch_key.py
+++ b/test/test_fast_dispatch_key.py
@@ -17,6 +17,7 @@ These tests pin down:
 3. The documented ``None`` returns: unhandled argument types and the
    no-tensor-to-pin-the-device case.
 4. ``key=`` functions feed into the fast key.
+5. Pallas tensor alias relationships participate in both specialization paths.
 
 The key is pure argument-metadata bookkeeping, so it needs no compilation and
 runs on CPU-only bots.
@@ -24,7 +25,9 @@ runs on CPU-only bots.
 
 from __future__ import annotations
 
+import dataclasses
 import unittest
+from unittest.mock import Mock
 
 import torch
 
@@ -53,6 +56,14 @@ def _dynamic_add_scalar(x: torch.Tensor, s: int) -> torch.Tensor:
     out = torch.empty_like(x)
     for tile in hl.tile(x.size(0)):
         out[tile] = x[tile] + s
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def _pallas_static_add_tensors(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size(0)):
+        out[tile] = x[tile] + y[tile]
     return out
 
 
@@ -121,6 +132,133 @@ class TestFastDispatchKey(unittest.TestCase):
             _dynamic_add1._fast_dispatch_key(a),
             _dynamic_add1._fast_dispatch_key(b),
         )
+
+    def test_tensor_aliasing_is_part_of_both_keys(self) -> None:
+        x = torch.empty(64, dtype=torch.float32)
+        alias = x.view_as(x)
+        independent = torch.empty_like(x)
+        aliased_args = (x, alias)
+        independent_args = (x, independent)
+        fresh_x = torch.empty_like(x)
+        fresh_aliased_args = (fresh_x, fresh_x.view_as(fresh_x))
+        fresh_independent_args = (fresh_x, torch.empty_like(fresh_x))
+
+        aliased_full = _pallas_static_add_tensors.specialization_key(aliased_args)
+        independent_full = _pallas_static_add_tensors.specialization_key(
+            independent_args
+        )
+        aliased_fast = _pallas_static_add_tensors._fast_dispatch_key(aliased_args)
+        independent_fast = _pallas_static_add_tensors._fast_dispatch_key(
+            independent_args
+        )
+        self.assertNotEqual(aliased_full, independent_full)
+        self.assertNotEqual(aliased_fast, independent_fast)
+        self.assertEqual(
+            aliased_full,
+            _pallas_static_add_tensors.specialization_key(fresh_aliased_args),
+        )
+        self.assertEqual(
+            independent_full,
+            _pallas_static_add_tensors.specialization_key(fresh_independent_args),
+        )
+        self.assertEqual(
+            aliased_fast,
+            _pallas_static_add_tensors._fast_dispatch_key(fresh_aliased_args),
+        )
+        self.assertEqual(
+            independent_fast,
+            _pallas_static_add_tensors._fast_dispatch_key(fresh_independent_args),
+        )
+
+    def test_container_aliasing_uses_specialization_order(self) -> None:
+        @dataclasses.dataclass
+        class TensorBundle:
+            a: torch.Tensor
+            b: torch.Tensor
+            c: torch.Tensor
+
+        x = torch.empty(64, dtype=torch.float32)
+        y = torch.empty_like(x)
+        containers = (
+            (
+                {"a": x, "b": x, "c": y},
+                {"a": x, "c": x, "b": y},
+            ),
+            (
+                TensorBundle(a=x, b=x, c=y),
+                TensorBundle(a=x, b=y, c=x),
+            ),
+        )
+        for first, second in containers:
+            with self.subTest(container_type=type(first).__name__):
+                self.assertNotEqual(
+                    _pallas_static_add_tensors.specialization_key((first,)),
+                    _pallas_static_add_tensors.specialization_key((second,)),
+                )
+
+    def test_tensor_aliasing_does_not_require_view_base(self) -> None:
+        x = torch.empty(64, dtype=torch.float32)
+        detached = x.detach()
+        explicit_storage_alias = torch.empty(0, dtype=x.dtype).set_(
+            x.untyped_storage(), 0, x.size(), x.stride()
+        )
+        expected_full = _pallas_static_add_tensors.specialization_key((x, x.view_as(x)))
+        expected_fast = _pallas_static_add_tensors._fast_dispatch_key((x, x.view_as(x)))
+
+        for alias in (detached, explicit_storage_alias):
+            with self.subTest(alias=alias):
+                self.assertIsNone(alias._base)
+                self.assertEqual(
+                    _pallas_static_add_tensors.specialization_key((x, alias)),
+                    expected_full,
+                )
+                self.assertEqual(
+                    _pallas_static_add_tensors._fast_dispatch_key((x, alias)),
+                    expected_fast,
+                )
+
+    def test_tensor_aliasing_in_function_closure_is_specialized(self) -> None:
+        def make_helper(captured: torch.Tensor):
+            def helper(value: torch.Tensor) -> torch.Tensor:
+                return value + captured
+
+            return helper
+
+        x = torch.empty(64, dtype=torch.float32)
+        independent = torch.empty_like(x)
+        self.assertNotEqual(
+            _pallas_static_add_tensors.specialization_key((x, make_helper(x))),
+            _pallas_static_add_tensors.specialization_key(
+                (x, make_helper(independent))
+            ),
+        )
+
+    def test_tensor_default_is_normalized_before_fast_dispatch(self) -> None:
+        default = torch.empty(64, dtype=torch.float32)
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def with_default(x: torch.Tensor, y: torch.Tensor = default) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] + y[tile]
+            return out
+
+        independent = torch.empty_like(default)
+        independent_args = with_default.normalize_args(independent)
+        aliased_args = with_default.normalize_args(default)
+        self.assertNotEqual(
+            with_default.specialization_key(independent_args),
+            with_default.specialization_key(aliased_args),
+        )
+
+        fast_key = with_default._fast_dispatch_key(independent_args)
+        assert fast_key is not None
+        sentinel = object()
+        bound = Mock()
+        bound._run = Mock(return_value=sentinel)
+        with_default._dispatch_cache[fast_key] = bound
+        self.assertIs(with_default(independent), sentinel)
+        bound._run.assert_called_once_with(*independent_args)
 
     def test_fast_key_records_exact_tensor_metadata(self) -> None:
         """The per-tensor entry is exactly (dtype, shape, stride, device,

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -345,10 +345,6 @@ class TestGrid(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, expected)
 
     @skipIfMetal("Metal does not support loop_index_expr for grid loops")
-    @xfailIfPallas(
-        "range(begin, end, step) lowers to _for_loop_step which has no "
-        "emit_pipeline codegen"
-    )
     def test_range_with_step(self):
         """Test that range(begin, end, step) works as alias for hl.grid(begin, end, step)."""
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -395,6 +395,19 @@ def pallas_inner_loop_add_with_scalar_access(
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
+def pallas_inner_loop_add_with_nonzero_scalar_access(
+    x: torch.Tensor, y: torch.Tensor
+) -> torch.Tensor:
+    """Pipeline-tiled tensor with a scalar read that must keep its index."""
+    m, n = x.size()
+    out = torch.empty_like(x)
+    for tile_m in hl.tile(m):
+        for tile_n in hl.tile(n):
+            out[tile_m, tile_n] = x[tile_m, tile_n] + y[tile_m, tile_n] + x[1, 7]
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
 def pallas_jagged_segment_add(x: torch.Tensor, offsets: torch.Tensor) -> torch.Tensor:
     """Outer grid over jagged segments + an inner ``hl.tile(start, end)`` loop
     whose begin (``offsets[g]``) is an arbitrary runtime offset. A
@@ -1253,18 +1266,8 @@ class TestPallas(TestCase):
                 pallas_loop_type="fori_loop",
             )
 
-    @unittest.expectedFailure  # nested-scratch resolution bug; see _find_dma_scratch_loop TODO
-    def test_fori_loop_nested_same_tensor_scratch_miscompiles(self) -> None:
-        """Nested fori_loops that scratch-route the same tensor miscompile.
-
-        ``out`` is DMA-routed by both the outer ``tile_m`` loop (full row) and
-        the inner ``tile_n`` loop (column slice).  The inner RMW's load/store
-        bind to the *first* matching scratch (the outer loop's) via
-        ``_find_dma_scratch_loop``, while its DMA uses the inner loop's scratch,
-        so each inner iteration adds to the whole-row buffer -- producing a wrong
-        result (x + 5 instead of x + 3) with no error.  xpasses once scratch
-        resolution picks the innermost (current) loop instead of first-match.
-        """
+    def test_fori_loop_nested_same_tensor_scratch(self) -> None:
+        """A nested RMW reuses its enclosing DMA scratch without a second route."""
 
         @helion.kernel(backend="pallas", static_shapes=True)
         def nested_same_output(x: torch.Tensor) -> torch.Tensor:
@@ -1278,12 +1281,14 @@ class TestPallas(TestCase):
             return out
 
         x = torch.randn(128, 256, device=DEVICE, dtype=torch.float32)
-        _, out = code_and_output(
+        code, out = code_and_output(
             nested_same_output,
             (x,),
             block_sizes=[128, 128],
             pallas_loop_type="fori_loop",
         )
+        self.assertEqual(code.count("pltpu.make_async_copy"), 2)
+        self.assertIn("_hbm_arg_indices=[0, 1]", code)
         torch.testing.assert_close(out, x + 3.0)
 
     def test_add_does_not_donate_inputs(self) -> None:
@@ -2553,6 +2558,386 @@ class TestPallas(TestCase):
         expected = torch.bmm(a.float(), b.float()).to(torch.bfloat16)
         torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
 
+    def test_full_slice_and_tile_share_dimension(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile([m, n]):
+                out[tile_m, tile_n] = x[tile_m, tile_n] + x[tile_m, :].sum(
+                    dim=1,
+                    keepdim=True,
+                )
+            return out
+
+        x = torch.randn(32, 256, device=DEVICE, dtype=torch.float32)
+        _code, result = code_and_output(fn, (x,), block_sizes=[16, 128])
+        torch.testing.assert_close(result, x + x.sum(dim=1, keepdim=True))
+
+    def test_full_slice_and_tile_share_dimension_with_newaxis(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(m):
+                for tile_n in hl.tile(n):
+                    x_tile = x[None, tile_m, tile_n].squeeze(0)
+                    row_sum = x[None, tile_m, :].sum(dim=-1, keepdim=True).squeeze(0)
+                    out[tile_m, tile_n] = x_tile + row_sum
+            return out
+
+        x = torch.randn(32, 256, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            fn,
+            (x,),
+            block_sizes=[16, 128],
+            pallas_loop_type="emit_pipeline",
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+        self.assertIn("_hbm_arg_indices=[0", code)
+        torch.testing.assert_close(result, x + x.sum(dim=1, keepdim=True))
+
+    def test_step_one_slice_is_full_pipeline_access(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(m):
+                for tile_n in hl.tile(n):
+                    row_sum = x[tile_m, ::1].sum(dim=1, keepdim=True)
+                    out[tile_m, tile_n] = x[tile_m, tile_n] + row_sum
+            return out
+
+        x = torch.randn(32, 256, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            fn,
+            (x,),
+            block_sizes=[16, 128],
+            pallas_loop_type="emit_pipeline",
+        )
+        self.assertIn("_hbm_arg_indices=[0", code)
+        torch.testing.assert_close(result, x + x.sum(dim=1, keepdim=True))
+
+    def test_pipeline_accesses_same_tile_at_distinct_offsets(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            half = n // 2
+            out = torch.empty([m, half], dtype=x.dtype, device=x.device)
+            for tile_m in hl.tile(m):
+                for tile_n in hl.tile(half):
+                    out[tile_m, tile_n] = (
+                        x[tile_m, tile_n] + x[tile_m, tile_n.index + half]
+                    )
+            return out
+
+        x = torch.randn(16, 256, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            fn,
+            (x,),
+            block_sizes=[8, 128],
+            pallas_loop_type="emit_pipeline",
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+        self.assertIn("_hbm_arg_indices=[0", code)
+        torch.testing.assert_close(result, x[:, :128] + x[:, 128:])
+
+    def test_outer_alias_disables_inner_dma(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor, alias: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            alias_view = alias.view_as(alias)
+            out = torch.empty_like(x)
+            for _ in hl.grid(1):
+                bias = alias_view[0, 0]
+                for tile_m in hl.tile(m):
+                    for tile_n in hl.tile(n):
+                        out[tile_m, tile_n] = x[tile_m, tile_n] + bias
+            return out
+
+        x = torch.randn(16, 256, device=DEVICE, dtype=torch.float32)
+        alias = x.view_as(x)
+        code, result = code_and_output(
+            fn,
+            (x, alias),
+            block_sizes=[8, 128],
+            pallas_loop_type="fori_loop",
+        )
+        self.assertNotIn("make_async_copy(x.at[", code)
+        torch.testing.assert_close(result, x + x[0, 0])
+
+    def test_sibling_loops_use_one_global_memory_route(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            broadcast = torch.empty_like(x)
+            for _ in hl.grid(1):
+                for tile_m in hl.tile(m):
+                    for tile_n in hl.tile(n):
+                        out[tile_m, tile_n] = x[tile_m, tile_n] + 1.0
+                    for tile_n in hl.tile(n):
+                        broadcast[tile_m, tile_n] = x[tile_m, 0][:, None] + hl.zeros(
+                            [tile_m, tile_n], dtype=x.dtype
+                        )
+            return out, broadcast
+
+        x = torch.randn(16, 256, device=DEVICE, dtype=torch.float32)
+        code, (out, broadcast) = code_and_output(
+            fn,
+            (x,),
+            block_sizes=[8, 128, 128],
+            pallas_loop_type="fori_loop",
+        )
+        self.assertNotIn("make_async_copy(x.at[", code)
+        torch.testing.assert_close(out, x + 1.0)
+        torch.testing.assert_close(broadcast, x[:, :1].expand_as(x))
+
+    def test_stepped_sibling_disables_shared_dma_route(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+            n = x.size(0)
+            out = torch.empty_like(x)
+            summary = torch.empty([1], dtype=x.dtype, device=x.device)
+            for _ in hl.grid(1):
+                for tile in hl.tile(n):
+                    out[tile] = x[tile] + 1.0
+                acc = hl.zeros([1], dtype=x.dtype)
+                for index in hl.grid(n, step=128):
+                    acc = acc + x[index]
+                summary[:] = acc
+            return out, summary
+
+        x = torch.randn(256, device=DEVICE, dtype=torch.float32)
+        code, (out, summary) = code_and_output(
+            fn,
+            (x,),
+            block_sizes=[128],
+            pallas_loop_type="fori_loop",
+        )
+        self.assertNotIn("make_async_copy(x", code)
+        torch.testing.assert_close(out, x + 1.0)
+        torch.testing.assert_close(summary, x[::128].sum().reshape(1))
+
+    def test_nested_store_rejects_input_only_scratch(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            for _ in hl.grid(1):
+                for tile_m in hl.tile(m):
+                    out[tile_m, :] = x[tile_m, :]
+                    for tile_n in hl.tile(n):
+                        x[tile_m, tile_n] = x[tile_m, tile_n] + 1.0
+            return out
+
+        x = torch.randn(16, 256, device=DEVICE, dtype=torch.float32)
+        with self.assertRaisesRegex(Exception, "input-only DMA scratch"):
+            code_and_output(
+                fn,
+                (x,),
+                block_sizes=[8, 128],
+                pallas_loop_type="fori_loop",
+            )
+
+    def test_nested_load_rejects_uninitialized_output_scratch(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            for _ in hl.grid(1):
+                for tile_m in hl.tile(m):
+                    for tile_n in hl.tile(n):
+                        out[tile_m, tile_n] = x[tile_m, tile_n] + 1.0
+                    x[tile_m, :] = 0.0
+            return out
+
+        x = torch.randn(16, 256, device=DEVICE, dtype=torch.float32)
+        with self.assertRaisesRegex(Exception, "before it is initialized"):
+            code_and_output(
+                fn,
+                (x,),
+                block_sizes=[8, 128],
+                pallas_loop_type="fori_loop",
+            )
+
+    def test_nested_mutating_aliases_are_rejected(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor, alias: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            for _ in hl.grid(1):
+                for tile_m in hl.tile(m):
+                    x[tile_m, :] = x[tile_m, :] + 1.0
+                    for tile_n in hl.tile(n):
+                        alias[tile_m, tile_n] = alias[tile_m, tile_n] + 2.0
+            return x
+
+        x = torch.randn(16, 256, device=DEVICE, dtype=torch.float32)
+        alias = x.view_as(x)
+        with self.assertRaisesRegex(Exception, "mutating aliased tensor arguments"):
+            code_and_output(
+                fn,
+                (x, alias),
+                block_sizes=[8, 128],
+                pallas_loop_type="fori_loop",
+            )
+
+    def test_dynamic_sibling_mutating_aliases_are_rejected(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=False)
+        def fn(x: torch.Tensor, alias: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            for tile_m in hl.tile(m):
+                for tile_n in hl.tile(n):
+                    x[tile_m, tile_n] = x[tile_m, tile_n] + 1.0
+                for tile_n in hl.tile(n):
+                    alias[tile_m, tile_n] = alias[tile_m, tile_n] + 2.0
+            return x
+
+        x = torch.randn(16, 256, device=DEVICE, dtype=torch.float32)
+        alias = x.view_as(x)
+        with self.assertRaisesRegex(Exception, "mutating aliased tensor arguments"):
+            code_and_output(
+                fn,
+                (x, alias),
+                block_sizes=[8, 128, 128],
+                pallas_loop_type="fori_loop",
+            )
+
+    def test_atomic_alias_disables_inner_dma(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor, alias: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(m):
+                for tile_n in hl.tile(n):
+                    out[tile_m, tile_n] = x[tile_m, tile_n] + 1.0
+                for tile_n in hl.tile(n):
+                    hl.atomic_add(
+                        alias,
+                        [tile_m, tile_n],
+                        hl.zeros([tile_m, tile_n], dtype=alias.dtype),
+                    )
+            return out
+
+        x = torch.randn(16, 256, device=DEVICE, dtype=torch.float32)
+        alias = x.view_as(x)
+        code, result = code_and_output(
+            fn,
+            (x, alias),
+            block_sizes=[8, 128, 128],
+            pallas_loop_type="fori_loop",
+        )
+        self.assertNotIn("make_async_copy(x.at[", code)
+        torch.testing.assert_close(result, x + 1.0)
+
+    def test_scatter_store_inside_device_loop(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(values: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
+            m, n = values.size()
+            out = torch.zeros_like(values)
+            for tile_n in hl.tile(n):
+                for tile_m in hl.tile(m):
+                    out[indices[tile_m], tile_n] = values[tile_m, tile_n]
+            return out
+
+        values = torch.randn(16, 128, device=DEVICE, dtype=torch.float32)
+        indices = torch.randperm(16, device=DEVICE).to(torch.int32)
+        expected = torch.zeros_like(values)
+        expected[indices.to(torch.int64)] = values
+        for loop_type in ("emit_pipeline", "fori_loop"):
+            with self.subTest(pallas_loop_type=loop_type):
+                code, result = code_and_output(
+                    fn,
+                    (values, indices),
+                    block_sizes=[128, 4],
+                    pallas_loop_type=loop_type,
+                )
+                self.assertIn("jnp.where", code)
+                if loop_type == "emit_pipeline":
+                    self.assertNotIn("out_vmem", code)
+                else:
+                    self.assertIn("make_async_copy(out.at[", code)
+                torch.testing.assert_close(result, expected)
+
+    def test_emit_pipeline_full_slice_and_outer_tile_share_dimension(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            k = y.size(1)
+            out = torch.empty([n, k], dtype=torch.float32, device=x.device)
+            for tile_n, tile_k in hl.tile([n, k]):
+                acc = hl.zeros([tile_n, tile_k], dtype=torch.float32)
+                for tile_m in hl.tile(m):
+                    row_sum = x[tile_m, :].sum(dim=1, keepdim=True)
+                    weighted = y[tile_m, tile_k] * row_sum
+                    acc = torch.addmm(acc, x[tile_m, tile_n].T, weighted)
+                out[tile_n, tile_k] = acc
+            return out
+
+        x = torch.randn(128, 256, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(128, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            fn,
+            (x, y),
+            block_sizes=[128, 128, 64],
+            pallas_loop_type="emit_pipeline",
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+        self.assertIn("_hbm_arg_indices=[0", code)
+        expected = x.T @ (y * x.sum(dim=1, keepdim=True))
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=0.3)
+
+    def test_emit_pipeline_tile_first_then_full_slice_same_dimension(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            k = y.size(1)
+            out = torch.empty([n, k], dtype=torch.float32, device=x.device)
+            for tile_n, tile_k in hl.tile([n, k]):
+                acc = hl.zeros([tile_n, tile_k], dtype=torch.float32)
+                for tile_m in hl.tile(m):
+                    x_tile = x[tile_m, tile_n]
+                    row_sum = x[tile_m, :].sum(dim=1, keepdim=True)
+                    acc = torch.addmm(acc, x_tile.T, y[tile_m, tile_k] * row_sum)
+                out[tile_n, tile_k] = acc
+            return out
+
+        x = torch.randn(128, 256, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(128, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            fn,
+            (x, y),
+            block_sizes=[128, 128, 64],
+            pallas_loop_type="emit_pipeline",
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+        self.assertIn("_hbm_arg_indices=[0", code)
+        expected = x.T @ (y * x.sum(dim=1, keepdim=True))
+        torch.testing.assert_close(result, expected, rtol=1e-2, atol=0.3)
+
+    def test_emit_pipeline_rmw_uses_outer_ref(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            for tile_m in hl.tile(m):
+                for tile_n in hl.tile(n):
+                    x_tile = x[tile_m, tile_n]
+                    row_zero = x[tile_m, :].sum(dim=1, keepdim=True) * 0.0
+                    x[tile_m, tile_n] = x_tile + row_zero
+            return x
+
+        x = torch.randn(32, 256, device=DEVICE, dtype=torch.float32)
+        expected = x.cpu().clone()
+        code, result = code_and_output(
+            fn,
+            (x,),
+            block_sizes=[16, 128],
+            pallas_loop_type="emit_pipeline",
+        )
+        self.assertIn("pltpu.emit_pipeline", code)
+        self.assertNotIn("pl.Buffered", code)
+        torch.testing.assert_close(result.cpu(), expected)
+
     @xfailIfPallas("Non-zero begin K reduction: DMA offset not tile-aligned")
     def test_bmm_nonzero_k_begin(self) -> None:
         """BMM with K reduction starting at non-zero offset, across all loop types."""
@@ -2967,7 +3352,6 @@ class TestPallas(TestCase):
         self.assertEqual(code.count("((2,), None, 'dma_semaphore')"), 2)
         torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
 
-    @xfailIfPallas("Pipeline + scalar access codegen not yet supported")
     def test_pipeline_tensor_with_scalar_access(self) -> None:
         """A pipeline tensor with scalar access should keep HBM, not be overridden to SMEM."""
         args = (
@@ -2984,6 +3368,32 @@ class TestPallas(TestCase):
         self.assertIn("pltpu.emit_pipeline", code)
         self.assertIn("_hbm_arg_indices=", code)
         torch.testing.assert_close(result, expected)
+
+    def test_pipeline_tensor_with_nonzero_scalar_access(self) -> None:
+        """Scalar reads on non-DMA dims keep their original index."""
+        args = (
+            torch.randn(64, 128, device=DEVICE, dtype=torch.float32),
+            torch.randn(64, 128, device=DEVICE, dtype=torch.float32),
+        )
+        expected = args[0] + args[1] + args[0][1, 7]
+        for loop_type, marker in (
+            ("emit_pipeline", "pltpu.emit_pipeline"),
+            ("fori_loop", "pltpu.make_async_copy"),
+        ):
+            with self.subTest(pallas_loop_type=loop_type):
+                code, result = code_and_output(
+                    pallas_inner_loop_add_with_nonzero_scalar_access,
+                    args,
+                    block_sizes=[8, 128],
+                    pallas_loop_type=loop_type,
+                    pallas_load_buffer_count=[2, 1],
+                )
+                self.assertIn(marker, code)
+                self.assertIn("_hbm_arg_indices=", code)
+                self.assertIn("[1, 7]", code)
+                if loop_type == "fori_loop":
+                    self.assertIn("def _prime_fori_loads", code)
+                torch.testing.assert_close(result, expected)
 
     def test_invalid_pallas_loop_type_raises(self) -> None:
         """Invalid pallas_loop_type values must raise instead of silently falling back."""


### PR DESCRIPTION
Stacked PRs:
 * #2962
 * #2957
 * #2956
 * #2955
 * #2954
 * #2953
 * #2952
 * #2951
 * #2949
 * #2948
 * #2947
 * #2946
 * __->__#2945
 * #2944
 * #2943
 * #2942


--- --- ---

### Track Pallas pipeline access block metadata


Example fixed: none directly; this prepares pipeline and DMA examples that mix full-slice and tiled tensor access.

Compiler/runtime side: track which block ids each per-tensor pipeline or DMA ref already covers, merge full-slice and tiled subscript metadata, and use that metadata in Pallas indexing and ordered-carry stores.

Why needed: without per-ref block metadata, generated kernels can slice a pipeline ref twice or treat an HBM/DMA-backed tensor as if it still used the outer `BlockSpec`.
