### PR TITLE
Support Pallas stack lowering for int4 GEMM

### DIFF
--- a/examples/int4_gemm.py
+++ b/examples/int4_gemm.py
@@ -77,9 +77,10 @@ def matmul_bf16_int4(A: Tensor, B: Tensor) -> Tensor:
             # subtract 16 when the sign bit is set) rather than via ``(x << 4) >> 4``;
             # the explicit arithmetic form is portable across backends and avoids
             # relying on narrow-int (int8) shift truncation semantics.
-            b_lo_raw = (b_tile & 0xF).to(torch.int32)
+            b_i32 = b_tile.to(torch.int32)
+            b_lo_raw = b_i32 & 0xF
             b_lo = torch.where(b_lo_raw >= 8, b_lo_raw - 16, b_lo_raw)  # low 4 bits
-            b_hi = (b_tile >> 4).to(torch.int32)  # high 4 bits (arithmetic >>)
+            b_hi = b_i32 >> 4  # high 4 bits (arithmetic >>)
 
             # Stack and reshape to interleave low and high bits.
             # Stack along a new dimension to get [BLOCK_SIZE_K//2, 2, BLOCK_SIZE_N],

--- a/helion/_compiler/pallas/aten_lowering.py
+++ b/helion/_compiler/pallas/aten_lowering.py
@@ -20,6 +20,7 @@ from torch._inductor.codegen.simd import constant_repr
 from torch.fx.node import Node
 from torch.fx.node import map_arg
 
+from ... import exc
 from ..ast_extension import expr_from_string
 from ..ast_extension import statement_from_string
 from ..aten_lowering import _env_arg
@@ -39,6 +40,7 @@ from ..aten_lowering import permute_lowering
 from ..aten_lowering import reshape_lowering
 from ..aten_lowering import sort_lowering
 from ..aten_lowering import squeeze_lowering
+from ..aten_lowering import stack_lowering
 from ..aten_lowering import topk_lowering
 from ..aten_lowering import unsqueeze_lowering
 from ..aten_lowering import view_lowering
@@ -276,6 +278,40 @@ def codegen_permute_pallas(ctx: LoweringContext, node: Node) -> object:
     return expr_from_string(
         f"jnp.transpose({{tensor}}, {dims!r})",
         tensor=tensor,
+    )
+
+
+@stack_lowering.register_codegen("pallas")
+def codegen_stack_pallas(ctx: LoweringContext, node: Node) -> object:
+    tensors = node.args[0]
+    dim = node.args[1] if len(node.args) > 1 else node.kwargs.get("dim", 0)
+
+    assert isinstance(tensors, (list, tuple))
+    if not tensors:
+        raise ValueError("Cannot stack empty tensor list")
+    if not all(isinstance(tensor, Node) for tensor in tensors):
+        raise exc.BackendUnsupported("pallas", "stack inputs")
+    assert isinstance(dim, int)
+
+    tensor_nodes = cast("list[Node] | tuple[Node, ...]", tensors)
+    tensor_asts = [ctx.env[tensor] for tensor in tensor_nodes]
+    output_val = node.meta.get("val")
+    numeric_bool_stack = (
+        isinstance(output_val, torch.Tensor) and output_val.dtype is torch.bool
+    )
+    args: dict[str, ast.AST] = {}
+    items: list[str] = []
+    for i, tensor in enumerate(tensor_asts):
+        assert isinstance(tensor, ast.AST)
+        if numeric_bool_stack:
+            tensor = pallas_codegen.numeric_mask_expr(tensor)
+        name = f"tensor_{i}"
+        args[name] = tensor
+        items.append(f"{{{name}}}")
+
+    return expr_from_string(
+        f"jnp.stack([{', '.join(items)}], axis={dim})",
+        **args,
     )
 
 

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1896,7 +1896,7 @@ class TestExamples(RefEagerTestBase, TestCase):
     def test_gather_gemv_half(self):
         self._check_gather_gemv(HALF_DTYPE, atol=0.2, rtol=0.2)
 
-    @xfailIfPallas("int4 unpacking not supported on pallas")
+    @xfailIfPallasInterpret("Pallas interpret does not support the int4 dot path")
     def test_int4_gemm(self):
         # Matrix dimensions
         M, K, N = 256, 512, 256

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -3401,6 +3401,103 @@ class TestPallas(TestCase):
         ):
             fn.bind((x,)).to_code(helion.Config(pallas_loop_type="emit_pipeline"))
 
+    def test_stack_lowering_axes_and_predicates(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def stack_dim0(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            m, n = x.size()
+            for tile_m, tile_n in hl.tile([m, n]):
+                stacked = torch.stack([x[tile_m, tile_n], y[tile_m, tile_n]], dim=0)
+                out[tile_m, tile_n] = torch.sum(stacked, dim=0)
+            return out
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def stack_dim1(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            m, n = x.size()
+            for tile_m, tile_n in hl.tile([m, n]):
+                stacked = torch.stack([x[tile_m, tile_n], y[tile_m, tile_n]], dim=1)
+                out[tile_m, tile_n] = torch.sum(stacked, dim=1)
+            return out
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def stack_negative_dim(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            m, n = x.size()
+            for tile_m, tile_n in hl.tile([m, n]):
+                stacked = torch.stack([x[tile_m, tile_n], y[tile_m, tile_n]], dim=-1)
+                out[tile_m, tile_n] = torch.sum(stacked, dim=-1)
+            return out
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def stack_predicates(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            m, n = x.size()
+            for tile_m, tile_n in hl.tile([m, n]):
+                stacked = torch.stack(
+                    [x[tile_m, tile_n] > 0, y[tile_m, tile_n] > 0], dim=1
+                )
+                out[tile_m, tile_n] = torch.where(stacked, 1.0, 0.0).sum(dim=1)
+            return out
+
+        x = torch.randn(8, 128, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(8, 128, device=DEVICE, dtype=torch.float32)
+        cases = (
+            (stack_dim0, "axis=0", x + y),
+            (stack_dim1, "axis=1", x + y),
+            (stack_negative_dim, "axis=-1", x + y),
+            (
+                stack_predicates,
+                "axis=1",
+                (x > 0).to(torch.float32) + (y > 0).to(torch.float32),
+            ),
+        )
+        for kernel, axis, expected in cases:
+            with self.subTest(axis=axis):
+                code, result = code_and_output(
+                    kernel,
+                    (x, y),
+                    block_sizes=[8, 128],
+                )
+                self.assertIn("jnp.stack", code)
+                self.assertIn(axis, code)
+                torch.testing.assert_close(result, expected)
+
+    def test_int4_unpack_all_bytes(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def unpack_int4(packed: torch.Tensor) -> torch.Tensor:
+            m, n = packed.size()
+            out = torch.empty([m, 2, n], dtype=torch.float32, device=packed.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                value = packed[tile_m, tile_n].to(torch.int32)
+                low_raw = value & 0xF
+                low = torch.where(low_raw >= 8, low_raw - 16, low_raw)
+                high = value >> 4
+                stacked = torch.stack([low, high], dim=1)
+                out[tile_m, :, tile_n] = stacked.to(torch.float32)
+            return out
+
+        packed = torch.arange(-128, 128, device=DEVICE, dtype=torch.int16).to(
+            torch.int8
+        )
+        packed = packed.repeat(4).reshape(8, 128)
+        value = packed.to(torch.int32)
+        low_raw = value & 0xF
+        low = torch.where(low_raw >= 8, low_raw - 16, low_raw)
+        expected = torch.stack([low, value >> 4], dim=1).to(torch.float32)
+
+        code, result = code_and_output(
+            unpack_int4,
+            (packed,),
+            block_sizes=[8, 128],
+        )
+        self.assertIn("jnp.stack", code)
+        self.assertRegex(
+            code,
+            r"(?:\.astype\(jnp\.int32\)|lax\.convert_element_type\([^\n]+,\s*jnp\.int32\))",
+        )
+        torch.testing.assert_close(result, expected)
+
     @xfailIfPallas("Non-zero begin K reduction: DMA offset not tile-aligned")
     def test_bmm_nonzero_k_begin(self) -> None:
         """BMM with K reduction starting at non-zero offset, across all loop types."""

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -15,9 +15,11 @@ from helion._testing import onlyBackends
 from helion._testing import skipIfRefEager
 from helion._testing import skipUnlessTensorDescriptor
 from helion._testing import xfailIfPallas
+from helion._testing import xfailIfPallasInterpret
 from helion._testing import xfailIfPallasTpu
 import helion.language as hl
 from helion.runtime.settings import _get_backend
+from helion.runtime.settings import is_pallas_interpret
 
 
 @onlyBackends(["triton", "pallas", "cute"])
@@ -330,7 +332,6 @@ class TestViews(RefEagerTestBase, TestCase):
         expected = x.sum(dim=(1, 2))
         torch.testing.assert_close(result, expected)
 
-    @xfailIfPallas("torch.stack not supported on pallas")
     def test_stack_power_of_2(self):
         @helion.kernel(autotune_effort="none", static_shapes=True)
         def test_stack_power_of_2_kernel(
@@ -363,13 +364,23 @@ class TestViews(RefEagerTestBase, TestCase):
         a = torch.randn(M, N, dtype=torch.float32, device=device)
         b = torch.randn(M, N, dtype=torch.float32, device=device)
 
-        result = test_stack_power_of_2_kernel(a, b)
+        if _get_backend() == "pallas" and is_pallas_interpret():
+            _code, result = code_and_output(
+                test_stack_power_of_2_kernel,
+                (a, b),
+                block_sizes=[32, 128],
+                pallas_loop_type="unroll",
+            )
+        else:
+            result = test_stack_power_of_2_kernel(a, b)
         expected = torch.zeros(M * 2, N, dtype=torch.float32, device=device)
         expected[0::2] = a  # Every 2nd row starting from 0
         expected[1::2] = b  # Every 2nd row starting from 1
         torch.testing.assert_close(result, expected, rtol=1e-5, atol=1e-5)
 
-    @xfailIfPallas("torch.stack not supported on pallas")
+    @xfailIfPallasInterpret(
+        "Pallas interpret cannot execute this non-power-of-2 padded stack store"
+    )
     def test_stack_non_power_of_2(self):
         @helion.kernel(autotune_effort="none", static_shapes=True)
         def test_stack_non_power_of_2_kernel(
@@ -451,7 +462,7 @@ class TestViews(RefEagerTestBase, TestCase):
         expected = x.view(x.numel() // 2, 2).sum(-1)
         torch.testing.assert_close(result, expected, rtol=1e-3, atol=1e-3)
 
-    @xfailIfPallas("torch.stack not supported on pallas")
+    @xfailIfPallas("Pallas dynamic/padded store for stack(dim=0) still fails")
     def test_stack_dim0(self):
         with torch._inductor.config.patch(
             {"use_static_cuda_launcher": False} if use_tileir_tunables() else {}


### PR DESCRIPTION
Stacked PRs:
 * #2962
 * #2957
 * #2956
 * #2955
 * #2954
 * #2953
 * #2952
 * #2951
 * #2949
 * __->__#2948
 * #2947
 * #2946
 * #2945
 * #2944
 * #2943
 * #2942


--- --- ---

### Support Pallas stack lowering for int4 GEMM


Example fixed: int4_gemm under Pallas.

Compiler/runtime side: emit `jnp.stack` for Pallas stack nodes and widen packed int4 data to int32 before bit operations so unpacking has backend-portable shift and sign-extension semantics.

Why needed: the int4 example builds packed values through stack and bit manipulation; Pallas needs both stack lowering and portable integer width to express that unpacking path reliably.
