### PR TITLE
Use structural variants for Pallas jagged examples

### DIFF
--- a/examples/grouped_gemm.py
+++ b/examples/grouped_gemm.py
@@ -42,6 +42,7 @@ import helion
 from helion._testing import DEVICE
 from helion._testing import run_example
 import helion.language as hl
+from helion.runtime.settings import _get_backend
 
 # %%
 # Grouped GEMM Kernel - Basic Implementation
@@ -111,7 +112,7 @@ def grouped_gemm_jagged(
 
 # %%
 @helion.kernel(static_shapes=False)
-def grouped_gemm_jagged_persistent(
+def _grouped_gemm_jagged_persistent(
     A_packed: torch.Tensor,  # [total_M, K]
     B: torch.Tensor,  # [K, N]
     group_offsets: torch.Tensor,  # [G+1], row offsets into A_packed
@@ -223,6 +224,72 @@ def grouped_gemm_jagged_persistent(
                         )
 
     return out
+
+
+@helion.kernel(static_shapes=False)
+def _grouped_gemm_jagged_persistent_pallas(
+    A_packed: torch.Tensor,  # [total_M, K]
+    B: torch.Tensor,  # [K, N]
+    group_offsets: torch.Tensor,  # [G+1], row offsets into A_packed
+) -> torch.Tensor:
+    """
+    Pallas persistent grouped GEMM with structural output tiles.
+
+    Pallas does not support Cartesian tensor-indexed stores today, so this keeps
+    persistent worker assignment while using one indirect row dimension.
+    """
+    num_workers = helion.runtime.get_num_sm(A_packed.device)
+
+    BLOCK_M = hl.register_block_size(32, 128)
+    BLOCK_N = hl.register_block_size(32, 128)
+    total_M, K = A_packed.shape
+    K2, N = B.shape
+    assert K == K2
+
+    out = torch.zeros(
+        total_M,
+        N,
+        dtype=torch.promote_types(A_packed.dtype, B.dtype),
+        device=A_packed.device,
+    )
+
+    G = group_offsets.size(0) - 1
+
+    for worker_id in hl.grid(num_workers):
+        for g in hl.grid(G):
+            group_start = group_offsets[g]
+            group_end = group_offsets[g + 1]
+            m_size = group_end - group_start
+
+            if m_size > 0:
+                num_n_tiles = (N + BLOCK_N - 1) // BLOCK_N
+
+                for tile_m, tile_n in hl.tile(
+                    [m_size, N], block_size=[BLOCK_M, BLOCK_N]
+                ):
+                    # pyrefly: ignore[unsupported-operation]
+                    tile_in_group = tile_m.id * num_n_tiles + tile_n.id
+                    # pyrefly: ignore[unsupported-operation]
+                    rows = group_start + tile_m.index
+                    # pyrefly: ignore[unsupported-operation]
+                    if tile_in_group % num_workers == worker_id:
+                        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+
+                        for k_tile in hl.tile(K):
+                            a_blk = A_packed[rows, k_tile]
+                            b_blk = B[k_tile, tile_n]
+                            acc = torch.addmm(acc, a_blk, b_blk)
+
+                        out[rows, tile_n] = acc.to(out.dtype)
+
+    return out
+
+
+grouped_gemm_jagged_persistent = (
+    _grouped_gemm_jagged_persistent_pallas
+    if _get_backend() == "pallas"
+    else _grouped_gemm_jagged_persistent
+)
 
 
 # %%

--- a/examples/jagged_dense_bmm.py
+++ b/examples/jagged_dense_bmm.py
@@ -35,12 +35,14 @@ import torch
 
 import helion
 from helion._testing import DEVICE
+from helion._testing import LONG_INT_TYPE
 from helion._testing import run_example
 import helion.language as hl
+from helion.runtime.settings import _get_backend
 
 
 @helion.kernel()
-def jagged_dense_bmm(
+def _jagged_dense_bmm(
     seq_offsets: torch.Tensor,
     jagged: torch.Tensor,
     dense: torch.Tensor,
@@ -88,6 +90,45 @@ def jagged_dense_bmm(
     return output.reshape(L, K)
 
 
+@helion.kernel()
+def _jagged_dense_bmm_pallas(
+    seq_offsets: torch.Tensor,
+    jagged: torch.Tensor,
+    dense: torch.Tensor,
+    bias: torch.Tensor | None,
+) -> torch.Tensor:
+    """Tile real packed row ranges directly to avoid flat jagged scatter on Pallas."""
+    L, D = jagged.shape
+    B, D, K = dense.shape
+    dtype = torch.promote_types(jagged.dtype, dense.dtype)
+    device = jagged.device
+
+    # Keep logical rows/columns out of Mosaic's physical lane/sublane axes.
+    output_4d = torch.empty((L, K, 1, 1), dtype=dtype, device=device)
+    for b in hl.grid(B):
+        start = seq_offsets[b]
+        end = seq_offsets[b + 1]
+
+        for tile_rows in hl.tile(start, end):
+            for tile_k in hl.tile(0, K):
+                acc = hl.zeros([tile_rows, tile_k], dtype=dtype, device=device)
+                for tile_d in hl.tile(0, D):
+                    jagged_data = jagged[tile_rows, tile_d]
+                    dense_data = dense[b, tile_d, tile_k]
+                    acc = acc + torch.matmul(jagged_data, dense_data)
+
+                if bias is not None:
+                    acc = acc + bias[b, tile_k].unsqueeze(0)
+
+                output_4d[tile_rows, tile_k, 0, 0] = acc
+    return output_4d.reshape(L, K)
+
+
+jagged_dense_bmm = (
+    _jagged_dense_bmm_pallas if _get_backend() == "pallas" else _jagged_dense_bmm
+)
+
+
 def jagged_dense_bmm_reference(
     seq_offsets: torch.Tensor,
     jagged: torch.Tensor,
@@ -127,9 +168,11 @@ def random_input(
     max_seq_len: int = 3,
     dtype: torch.dtype = torch.float32,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    lengths = torch.randint(max_seq_len + 1, size=(batch_size,), device=DEVICE)
-    seq_offsets = torch.zeros((batch_size + 1,), dtype=torch.int64, device=DEVICE)
-    seq_offsets[1:] = torch.cumsum(lengths, dim=0)
+    lengths = torch.randint(
+        max_seq_len + 1, size=(batch_size,), device=DEVICE, dtype=LONG_INT_TYPE
+    )
+    seq_offsets = torch.zeros((batch_size + 1,), dtype=LONG_INT_TYPE, device=DEVICE)
+    seq_offsets[1:] = torch.cumsum(lengths, dim=0, dtype=LONG_INT_TYPE)
     jagged_size = int(seq_offsets[-1].item())
     jagged = (
         torch.empty((jagged_size, D), dtype=dtype, device=DEVICE)

--- a/examples/jagged_layer_norm.py
+++ b/examples/jagged_layer_norm.py
@@ -25,8 +25,10 @@ import torch
 
 import helion
 from helion._testing import DEVICE
+from helion._testing import LONG_INT_TYPE
 from helion._testing import run_example
 import helion.language as hl
+from helion.runtime.settings import _get_backend
 
 # %%
 # Jagged Layer Norm Kernel
@@ -35,7 +37,7 @@ import helion.language as hl
 
 # %%
 @helion.kernel(autotune_effort="none")
-def jagged_layer_norm_kernel(
+def _jagged_layer_norm_kernel_default(
     x_values: torch.Tensor,  # [total_L, M] - compressed values
     x_offsets: torch.Tensor,  # [B+1] - sequence start offsets
     eps: float = 1e-6,
@@ -117,6 +119,65 @@ def jagged_layer_norm_kernel(
     return out.reshape(total_L, M)
 
 
+@helion.kernel(autotune_effort="none")
+def _jagged_layer_norm_kernel_pallas(
+    x_values: torch.Tensor,  # [total_L, M] - compressed values
+    x_offsets: torch.Tensor,  # [B+1] - sequence start offsets
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    """
+    Compute jagged layer normalization with structural Pallas stores.
+
+    Pallas does not support the flat scatter pattern used by the default
+    implementation, so this variant tiles each packed sequence directly.
+    """
+    M = x_values.size(1)
+    B = x_offsets.size(0) - 1
+    out = torch.empty_like(x_values)
+
+    for b in hl.grid(B):
+        start = x_offsets[b]
+        end = x_offsets[b + 1]
+        seq_len = end - start
+
+        if seq_len != 0:
+            count = (seq_len * M).to(torch.float32)
+
+            mean_acc = hl.zeros([1], dtype=torch.float32)
+            for tile_k in hl.tile(start, end, block_size=16):
+                for tile_m in hl.tile(0, M):
+                    x_slice = x_values[tile_k, tile_m].to(torch.float32)
+                    mean_acc = mean_acc + x_slice.sum(dim=0).sum(dim=0).unsqueeze(0)
+            mean = mean_acc / count
+
+            var_acc = hl.zeros([1], dtype=torch.float32)
+            for tile_k in hl.tile(start, end, block_size=16):
+                for tile_m in hl.tile(0, M):
+                    x_slice = x_values[tile_k, tile_m].to(torch.float32)
+                    centered = x_slice - mean
+                    var_acc = var_acc + (centered * centered).sum(dim=0).sum(
+                        dim=0
+                    ).unsqueeze(0)
+            variance = var_acc / count
+            rstd = torch.rsqrt(variance + eps)
+
+            # One-row tiles keep writeback structural without a flat jagged scatter.
+            for tile_k in hl.tile(start, end, block_size=1):
+                for tile_m in hl.tile(0, M):
+                    x_slice = x_values[tile_k, tile_m].to(torch.float32)
+                    normalized = (x_slice - mean) * rstd
+                    out[tile_k, tile_m] = normalized.to(x_values.dtype)
+
+    return out
+
+
+jagged_layer_norm_kernel = (
+    _jagged_layer_norm_kernel_pallas
+    if _get_backend() == "pallas"
+    else _jagged_layer_norm_kernel_default
+)
+
+
 # %%
 # Reference Implementation
 # ------------------------
@@ -170,7 +231,7 @@ def jagged_layer_norm_tritonbench(
     """
     x_values = x._values
     # pyrefly: ignore [missing-attribute]
-    x_offsets = x._offsets
+    x_offsets = x._offsets.to(LONG_INT_TYPE)
 
     return lambda: jagged_layer_norm_kernel(x_values, x_offsets, eps=1e-6)
 
@@ -191,13 +252,15 @@ def create_test_jagged_tensor(
     """Create test jagged tensor data."""
 
     # Generate random sequence lengths
-    seq_lengths = torch.randint(1, max_seqlen + 1, (B,), device=device)
+    seq_lengths = torch.randint(
+        1, max_seqlen + 1, (B,), dtype=LONG_INT_TYPE, device=device
+    )
 
     # Create offsets
     x_offsets = torch.cat(
         [
-            torch.zeros(1, dtype=torch.long, device=device),
-            torch.cumsum(seq_lengths, dim=0),
+            torch.zeros(1, dtype=LONG_INT_TYPE, device=device),
+            torch.cumsum(seq_lengths, dim=0).to(LONG_INT_TYPE),
         ]
     )
 

--- a/examples/jagged_softmax.py
+++ b/examples/jagged_softmax.py
@@ -19,8 +19,10 @@ import torch
 
 import helion
 from helion._testing import DEVICE
+from helion._testing import LONG_INT_TYPE
 from helion._testing import run_example
 import helion.language as hl
+from helion.runtime.settings import _get_backend
 
 # %%
 # Reference Implementation
@@ -56,7 +58,7 @@ def reference_jagged_softmax_pytorch(
 
 # %%
 @helion.kernel()
-def jagged_softmax_kernel(
+def _jagged_softmax_kernel_default(
     x_data: torch.Tensor,
     x_offsets: torch.Tensor,
 ) -> torch.Tensor:
@@ -114,6 +116,56 @@ def jagged_softmax_kernel(
     return out.reshape(N, M)
 
 
+@helion.kernel()
+def _jagged_softmax_kernel_pallas(
+    x_data: torch.Tensor,
+    x_offsets: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Compute jagged softmax with structural row/column stores for Pallas.
+
+    Pallas does not support the flat multi-dimensional scatter pattern used by
+    the default kernel, so this variant tiles each packed sequence directly.
+    """
+    M = x_data.size(1)
+    num_rows = x_offsets.size(0) - 1
+    out = torch.empty_like(x_data)
+
+    for b in hl.grid(num_rows):
+        start = x_offsets[b]
+        end = x_offsets[b + 1]
+        seq_len = end - start
+
+        if seq_len != 0:
+            for tile_m in hl.tile(0, M):
+                block_max = hl.full([tile_m], float("-inf"), dtype=x_data.dtype)
+                normalizer = hl.full([tile_m], 0.0, dtype=x_data.dtype)
+
+                for tile_k in hl.tile(start, end):
+                    x_slice = x_data[tile_k, tile_m]
+                    slice_max = x_slice.amax(dim=0)
+                    block_new_max = torch.maximum(block_max, slice_max)
+                    normalizer *= torch.exp(block_max - block_new_max)
+                    normalizer += torch.exp(x_slice - block_new_max[None, :]).sum(dim=0)
+                    block_max = block_new_max
+
+                for tile_k in hl.tile(start, end):
+                    x_slice = x_data[tile_k, tile_m]
+                    block_out = (
+                        torch.exp(x_slice - block_max[None, :]) / normalizer[None, :]
+                    )
+                    out[tile_k, tile_m] = block_out
+
+    return out
+
+
+jagged_softmax_kernel = (
+    _jagged_softmax_kernel_pallas
+    if _get_backend() == "pallas"
+    else _jagged_softmax_kernel_default
+)
+
+
 # %%
 # Benchmark Wrapper
 # -----------------
@@ -138,7 +190,10 @@ def jagged_softmax_tritonbench(
         Callable that returns tensor of shape (N, M), where N = total number of rows in the jagged tensor
     """
     # pyrefly: ignore [missing-attribute]
-    return lambda: jagged_softmax_kernel(x._values, x._offsets)
+    x_values = x._values
+    # pyrefly: ignore [missing-attribute]
+    x_offsets = x._offsets.to(LONG_INT_TYPE)
+    return lambda: jagged_softmax_kernel(x_values, x_offsets)
 
 
 # %%
@@ -154,9 +209,14 @@ def main() -> None:
     num_rows, max_cols = 512, 64
     device = DEVICE
 
-    lengths = torch.randint(1, max_cols + 1, (num_rows,), device=device)
+    lengths = torch.randint(
+        1, max_cols + 1, (num_rows,), dtype=LONG_INT_TYPE, device=device
+    )
     x_offsets = torch.cat(
-        [torch.zeros(1, dtype=torch.long, device=device), torch.cumsum(lengths, dim=0)]
+        [
+            torch.zeros(1, dtype=LONG_INT_TYPE, device=device),
+            torch.cumsum(lengths, dim=0).to(LONG_INT_TYPE),
+        ]
     )
     nnz = int(x_offsets[-1])
     M = 128  # number of features

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1139,7 +1139,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             fn_name="jagged_dense_add_2d",
         )
 
-    @xfailIfPallas("Pallas rejects int64 inputs (jagged offsets)")
     @skipIfXPU("Jagged tensor operations not fully supported on XPU")
     @skipIfRefEager("hl.jagged_tile does not support ref mode yet")
     def test_jagged_dense_bmm(self):
@@ -1528,16 +1527,17 @@ class TestExamples(RefEagerTestBase, TestCase):
             num_stages=3,
         )
 
-    @xfailIfPallas("JAX tracer error with dynamic shapes")
     @skipIfRefEager("hl.jagged_tile does not support ref mode yet")
     def test_jagged_softmax(self):
         num_rows, max_cols = 128, 64
         M = 8  # number of features
-        lengths = torch.randint(1, max_cols + 1, (num_rows,), device=DEVICE)
+        lengths = torch.randint(
+            1, max_cols + 1, (num_rows,), dtype=LONG_INT_TYPE, device=DEVICE
+        )
         x_offsets = torch.cat(
             [
-                torch.zeros(1, dtype=torch.long, device=DEVICE),
-                torch.cumsum(lengths, dim=0),
+                torch.zeros(1, dtype=LONG_INT_TYPE, device=DEVICE),
+                torch.cumsum(lengths, dim=0).to(LONG_INT_TYPE),
             ]
         )
         nnz = int(x_offsets[-1])
@@ -1553,7 +1553,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             args,
             expected,
             fn_name="jagged_softmax_kernel",
-            block_sizes=[16, 8, 16, 16],
+            block_sizes=[8, 16, 16] if _get_backend() == "pallas" else [16, 8, 16, 16],
         )
 
     @skipIfXPU("Jagged tensor operations not fully supported on XPU")
@@ -1712,31 +1712,30 @@ class TestExamples(RefEagerTestBase, TestCase):
                     rtol=rtol,
                 )
 
-    def test_grouped_gemm_jagged(self):
-        # Build small jagged grouped GEMM inputs
+    def _grouped_gemm_jagged_args(
+        self,
+    ) -> tuple[tuple[torch.Tensor, torch.Tensor, torch.Tensor], torch.Tensor]:
         torch.manual_seed(0)
-        G = 3
-        K, N = 64, 64
+        k, n = 64, 70
         dtype = torch.bfloat16
         group_A = [
-            torch.randn(32 * (i + 1), K, device=DEVICE, dtype=dtype).contiguous()
-            for i in range(G)
+            torch.randn(m, k, device=DEVICE, dtype=dtype).contiguous()
+            for m in (0, 17, 65)
         ]
-        B_shared = torch.randn(K, N, device=DEVICE, dtype=dtype).contiguous()
+        B_shared = torch.randn(k, n, device=DEVICE, dtype=dtype).contiguous()
 
-        # Pack A and offsets
         M_sizes = [int(a.size(0)) for a in group_A]
         starts = [0]
         for m in M_sizes:
             starts.append(starts[-1] + m)
         group_offsets = torch.tensor(starts, device=DEVICE, dtype=torch.int32)
         A_packed = torch.cat(group_A, dim=0).contiguous()
-
-        # Reference result
-        expected = torch.cat([a @ B_shared for a in group_A], dim=0)
-
-        # Run kernel and check
         args = (A_packed, B_shared, group_offsets)
+        expected = torch.cat([a @ B_shared for a in group_A], dim=0)
+        return args, expected
+
+    def test_grouped_gemm_jagged(self):
+        args, expected = self._grouped_gemm_jagged_args()
         check_example(
             "grouped_gemm",
             args,
@@ -1744,36 +1743,8 @@ class TestExamples(RefEagerTestBase, TestCase):
             fn_name="grouped_gemm_jagged",
         )
 
-    @xfailIfPallas("Pallas scatter: multiple indirect dims are not supported")
     def test_grouped_gemm_jagged_persistent(self):
-        # Build small jagged grouped GEMM inputs
-        torch.manual_seed(0)
-        G = 3
-        K, N = 64, 64
-        dtype = torch.bfloat16
-        group_A = [
-            torch.randn(32 * (i + 1), K, device=DEVICE, dtype=dtype).contiguous()
-            for i in range(G)
-        ]
-        B_shared = torch.randn(K, N, device=DEVICE, dtype=dtype).contiguous()
-
-        # Pack A and offsets
-        M_sizes = [int(a.size(0)) for a in group_A]
-        starts = [0]
-        for m in M_sizes:
-            starts.append(starts[-1] + m)
-        group_offsets = torch.tensor(starts, device=DEVICE, dtype=torch.int32)
-        A_packed = torch.cat(group_A, dim=0).contiguous()
-
-        # Reference result
-        expected = torch.cat([a @ B_shared for a in group_A], dim=0)
-
-        # Run kernel and check
-        args = (
-            A_packed,
-            B_shared,
-            group_offsets,
-        )
+        args, expected = self._grouped_gemm_jagged_args()
         check_example(
             "grouped_gemm",
             args,
@@ -2205,16 +2176,17 @@ class TestExamples(RefEagerTestBase, TestCase):
         )
         torch.testing.assert_close(result, expected, atol=1e-1, rtol=1e-2)
 
-    @xfailIfPallas("JAX tracer error")
     @skipIfRefEager("hl.jagged_tile does not support ref mode yet")
     def test_jagged_layer_norm(self):
         num_rows, max_cols = 128, 64
         M = 8  # number of features
-        lengths = torch.randint(1, max_cols + 1, (num_rows,), device=DEVICE)
+        lengths = torch.randint(
+            1, max_cols + 1, (num_rows,), dtype=LONG_INT_TYPE, device=DEVICE
+        )
         x_offsets = torch.cat(
             [
-                torch.zeros(1, dtype=torch.long, device=DEVICE),
-                torch.cumsum(lengths, dim=0),
+                torch.zeros(1, dtype=LONG_INT_TYPE, device=DEVICE),
+                torch.cumsum(lengths, dim=0).to(LONG_INT_TYPE),
             ]
         )
         nnz = int(x_offsets[-1])
@@ -2231,7 +2203,9 @@ class TestExamples(RefEagerTestBase, TestCase):
             args,
             expected,
             fn_name="jagged_layer_norm_kernel",
-            block_sizes=[4, 8, 8, 8, 8, 8, 8],
+            block_sizes=[8, 8, 8]
+            if _get_backend() == "pallas"
+            else [4, 8, 8, 8, 8, 8, 8],
         )
 
     def test_exp_fwd(self):


### PR DESCRIPTION
Stacked PRs:
 * #2962
 * #2957
 * #2956
 * #2955
 * #2954
 * #2953
 * __->__#2952
 * #2951
 * #2949
 * #2948
 * #2947
 * #2946
 * #2945
 * #2944
 * #2943
 * #2942


--- --- ---

### Use structural variants for Pallas jagged examples


Example fixed: jagged_dense_bmm, grouped_gemm_jagged_persistent, jagged_softmax, and jagged_layer_norm under Pallas.

Compiler/runtime side: no shared compiler lowering changes; the examples keep existing non-Pallas kernels while Pallas uses structural row/column tile variants that avoid unsupported flat jagged scatters and Cartesian tensor-indexed stores.

Why needed: these examples need Pallas-friendly ownership shapes; encoding that structure in Pallas-specific variants is smaller and safer than making arbitrary flat jagged stores legal in the backend.
