### PR TITLE
Support Pallas segment reduction primitives

### DIFF
--- a/examples/segment_reduction.py
+++ b/examples/segment_reduction.py
@@ -14,14 +14,24 @@ Code based on https://github.com/pytorch/helion/issues/237
 # %%
 from __future__ import annotations
 
+from typing import cast
+
 import torch
-import triton
-import triton.language as tl
 
 import helion
 from helion._testing import DEVICE
+from helion._testing import LONG_INT_TYPE
 from helion._testing import run_example
 import helion.language as hl
+
+try:
+    import triton
+    import triton.language as tl
+except ModuleNotFoundError as exc:
+    if exc.name not in {"triton", "triton.language"}:
+        raise
+    triton = None
+    tl = None
 
 # %%
 # Helion Implementation
@@ -55,6 +65,30 @@ def combine_fn_helion(
     return combined_values, right_indices
 
 
+def _segmented_scan_helion(
+    vals: torch.Tensor, idxs: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    tuple_in = (vals, idxs.unsqueeze(1).expand_as(vals))
+    return cast(
+        "tuple[torch.Tensor, torch.Tensor]",
+        hl.associative_scan(combine_fn_helion, tuple_in, dim=0),
+    )
+
+
+@helion.kernel()
+def segmented_scan_helion(
+    indices: torch.Tensor, input_data: torch.Tensor
+) -> torch.Tensor:
+    """Expose the integer segmented scan used by the reduction kernel."""
+    output = torch.empty_like(input_data)
+    for tile_e, tile_f in hl.tile(input_data.size()):
+        out_vals, _ = _segmented_scan_helion(
+            input_data[tile_e, tile_f], indices[tile_e]
+        )
+        output[tile_e, tile_f] = out_vals
+    return output
+
+
 @helion.kernel()
 def segmented_reduction_helion(
     indices: torch.Tensor, input_data: torch.Tensor, num_nodes: int
@@ -82,10 +116,11 @@ def segmented_reduction_helion(
         idxs_next = hl.load(
             indices, [tile_e.index + 1], extra_mask=tile_e.index < num_elements - 1
         )
-        tuple_in = (vals, idxs.float().unsqueeze(1).expand_as(vals))
-        out_vals, _ = hl.associative_scan(combine_fn_helion, tuple_in, dim=0)
-        mask = (idxs != idxs_next) | (
-            tile_e.index % tile_e.block_size == tile_e.block_size - 1
+        out_vals, _ = _segmented_scan_helion(vals, idxs)
+        mask = (
+            (idxs != idxs_next)
+            | (tile_e.index % tile_e.block_size == tile_e.block_size - 1)
+            | (tile_e.index == num_elements - 1)
         )
         segment_vals = torch.where(mask.unsqueeze(1), out_vals, 0.0)
         hl.atomic_add(output, [idxs, tile_f], segment_vals)
@@ -98,119 +133,132 @@ def segmented_reduction_helion(
 
 
 # %%
-@triton.jit
-def combine_fn_triton(
-    left_values: tl.tensor,
-    left_indices: tl.tensor,
-    right_values: tl.tensor,
-    right_indices: tl.tensor,
-) -> tuple[tl.tensor, tl.tensor]:
-    """
-    Combine function for associative scan in Triton implementation.
+if triton is not None and tl is not None:
+    _HAS_TRITON = DEVICE.type == "cuda"
 
-    Adds values when indices match (same segment), otherwise takes the right value.
+    @triton.jit
+    def combine_fn_triton(
+        left_values: tl.tensor,
+        left_indices: tl.tensor,
+        right_values: tl.tensor,
+        right_indices: tl.tensor,
+    ) -> tuple[tl.tensor, tl.tensor]:
+        """
+        Combine function for associative scan in Triton implementation.
 
-    Args:
-        left_values: Values from the left side of the scan
-        left_indices: Indices from the left side of the scan
-        right_values: Values from the right side of the scan
-        right_indices: Indices from the right side of the scan
+        Adds values when indices match (same segment), otherwise takes the right value.
 
-    Returns:
-        Tuple of (combined_values, combined_indices)
-    """
-    same_segment = left_indices == right_indices
-    combined_values = tl.where(same_segment, left_values + right_values, right_values)
-    combined_indices = right_indices
-    return combined_values, combined_indices
+        Args:
+            left_values: Values from the left side of the scan
+            left_indices: Indices from the left side of the scan
+            right_values: Values from the right side of the scan
+            right_indices: Indices from the right side of the scan
 
-
-@triton.autotune(
-    configs=[
-        triton.Config(
-            {"BLOCK_SIZE": bs},
+        Returns:
+            Tuple of (combined_values, combined_indices)
+        """
+        same_segment = left_indices == right_indices
+        combined_values = tl.where(
+            same_segment, left_values + right_values, right_values
         )
-        for bs in [8, 16, 32, 64, 128]
-    ],
-    key=["C"],
-    restore_value=["out_ptr"],
-)
-@triton.jit
-def _segmented_reduction_triton(
-    index: tl.tensor,  # the input index tensor
-    in_ptr: tl.tensor,  # the input tensor
-    out_ptr: tl.tensor,  # the output value tensor
-    E: tl.constexpr,  # Number of elements in the input tensor (1d)
-    C: tl.constexpr,  # Number of features in the input tensor (2d)
-    BLOCK_SIZE: tl.constexpr,  # Block size for the scan
-) -> None:
-    """
-    Triton kernel for segmented reduction.
+        combined_indices = right_indices
+        return combined_values, combined_indices
 
-    Uses associative scan to efficiently perform segmented reduction.
-
-    Args:
-        index: Input index tensor
-        in_ptr: Input data tensor
-        out_ptr: Output tensor
-        E: Number of elements in the input tensor
-        C: Number of features in the input tensor
-        BLOCK_SIZE: Block size for the scan
-    """
-    # Triton version adapted from
-    # https://github.com/fishmingyu/GeoT/blob/main/geot/triton/seg_reduction.py
-    pid = tl.program_id(axis=0)
-    offset_pid = pid // C
-    feature_id = pid % C
-    offsets = offset_pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    mask = offsets < E
-
-    # Load input data
-    vals = tl.load(in_ptr + offsets * C + feature_id, mask=mask)
-    idxs = tl.load(index + offsets, mask=mask)
-    idxs_next = tl.load(index + offsets + 1, offsets < E - 1)
-
-    # Perform an inclusive scan using tl.associative_scan
-    result_values, _ = tl.associative_scan(
-        (
-            vals,
-            idxs,
-        ),
-        axis=0,
-        combine_fn=combine_fn_triton,
+    @triton.autotune(
+        configs=[
+            triton.Config(
+                {"BLOCK_SIZE": bs},
+            )
+            for bs in [8, 16, 32, 64, 128]
+        ],
+        key=["C"],
+        restore_value=["out_ptr"],
     )
-    # if offset % BLOCK_SIZE == -1, it means the last element of the segment
-    segment_start = (idxs != idxs_next) | (offsets % BLOCK_SIZE == BLOCK_SIZE - 1)
-    tl.atomic_add(out_ptr + idxs * C + feature_id, result_values, mask & segment_start)
+    @triton.jit
+    def _segmented_reduction_triton(
+        index: tl.tensor,  # the input index tensor
+        in_ptr: tl.tensor,  # the input tensor
+        out_ptr: tl.tensor,  # the output value tensor
+        E: tl.constexpr,  # Number of elements in the input tensor (1d)
+        C: tl.constexpr,  # Number of features in the input tensor (2d)
+        BLOCK_SIZE: tl.constexpr,  # Block size for the scan
+    ) -> None:
+        """
+        Triton kernel for segmented reduction.
 
+        Uses associative scan to efficiently perform segmented reduction.
 
-def segmented_reduction_triton(
-    indices: torch.Tensor, input_data: torch.Tensor, num_nodes: int
-) -> torch.Tensor:
-    """
-    Performs segmented reduction using Triton.
+        Args:
+            index: Input index tensor
+            in_ptr: Input data tensor
+            out_ptr: Output tensor
+            E: Number of elements in the input tensor
+            C: Number of features in the input tensor
+            BLOCK_SIZE: Block size for the scan
+        """
+        # Triton version adapted from
+        # https://github.com/fishmingyu/GeoT/blob/main/geot/triton/seg_reduction.py
+        pid = tl.program_id(axis=0)
+        offset_pid = pid // C
+        feature_id = pid % C
+        offsets = offset_pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < E
 
-    Wrapper function for the Triton kernel implementation.
+        # Load input data
+        vals = tl.load(in_ptr + offsets * C + feature_id, mask=mask)
+        idxs = tl.load(index + offsets, mask=mask)
+        idxs_next = tl.load(index + offsets + 1, offsets < E - 1)
 
-    Args:
-        indices: Tensor of segment indices for each element
-        input_data: Input tensor of shape [num_elements, num_features]
-        num_nodes: Number of output nodes/segments
+        # Perform an inclusive scan using tl.associative_scan
+        result_values, _ = tl.associative_scan(
+            (
+                vals,
+                idxs,
+            ),
+            axis=0,
+            combine_fn=combine_fn_triton,
+        )
+        # Flush segment boundaries and the final lane of each scan tile.
+        segment_start = (idxs != idxs_next) | (offsets % BLOCK_SIZE == BLOCK_SIZE - 1)
+        tl.atomic_add(
+            out_ptr + idxs * C + feature_id, result_values, mask & segment_start
+        )
 
-    Returns:
-        Output tensor of shape [num_nodes, num_features] with reduced values
-    """
-    E, C = input_data.shape
-    output = torch.zeros(
-        (num_nodes, C), dtype=input_data.dtype, device=input_data.device
-    )
+    def segmented_reduction_triton(
+        indices: torch.Tensor, input_data: torch.Tensor, num_nodes: int
+    ) -> torch.Tensor:
+        """
+        Performs segmented reduction using Triton.
 
-    def grid(META: dict[str, int]) -> tuple[int, ...]:
-        # Cast to int to satisfy type checker; Triton may return constexpr
-        return (int(triton.cdiv(E, META["BLOCK_SIZE"]) * C),)
+        Wrapper function for the Triton kernel implementation.
 
-    _segmented_reduction_triton[grid](indices, input_data, output, E, C)
-    return output
+        Args:
+            indices: Tensor of segment indices for each element
+            input_data: Input tensor of shape [num_elements, num_features]
+            num_nodes: Number of output nodes/segments
+
+        Returns:
+            Output tensor of shape [num_nodes, num_features] with reduced values
+        """
+        E, C = input_data.shape
+        output = torch.zeros(
+            (num_nodes, C), dtype=input_data.dtype, device=input_data.device
+        )
+
+        def grid(META: dict[str, int]) -> tuple[int, ...]:
+            # Cast to int to satisfy type checker; Triton may return constexpr
+            return (int(triton.cdiv(E, META["BLOCK_SIZE"]) * C),)
+
+        _segmented_reduction_triton[grid](indices, input_data, output, E, C)
+        return output
+
+else:
+    _HAS_TRITON = False
+
+    def segmented_reduction_triton(
+        indices: torch.Tensor, input_data: torch.Tensor, num_nodes: int
+    ) -> torch.Tensor:
+        raise RuntimeError("Triton is required for the Triton reference")
 
 
 # %%
@@ -237,11 +285,26 @@ def segmented_reduction_pytorch(
     """
     # Run PyTorch reference (scatter_add equivalent)
     num_features = input_data.size(1)
+    if input_data.device.type == "tpu":
+        host_input = input_data.cpu()
+        host_indices = indices.cpu()
+        host_output = torch.zeros(
+            num_nodes,
+            num_features,
+            device=host_input.device,
+            dtype=input_data.dtype,
+        )
+        host_output.scatter_add_(
+            0,
+            host_indices.to(torch.int64).unsqueeze(1).expand(-1, num_features),
+            host_input,
+        )
+        return host_output.to(input_data.device)
     pytorch_output = torch.zeros(
         num_nodes, num_features, device=input_data.device, dtype=input_data.dtype
     )
     pytorch_output.scatter_add_(
-        0, indices.unsqueeze(1).expand(-1, num_features), input_data
+        0, indices.to(torch.int64).unsqueeze(1).expand(-1, num_features), input_data
     )
     return pytorch_output
 
@@ -266,16 +329,17 @@ def main() -> None:
     dtype = torch.float32
 
     # Create sorted indices for segmented reduction
-    indices = torch.randint(0, num_nodes, (num_edges,), device=DEVICE).sort()[0]
+    indices = torch.randint(
+        0, num_nodes, (num_edges,), device=DEVICE, dtype=LONG_INT_TYPE
+    ).sort()[0]
     input_data = torch.randn(num_edges, num_features, device=DEVICE, dtype=dtype)
 
+    reference_fns = {"pytorch": segmented_reduction_pytorch}
+    if _HAS_TRITON:
+        reference_fns["triton"] = segmented_reduction_triton
+
     run_example(
-        segmented_reduction_helion,
-        {
-            "triton": segmented_reduction_triton,
-            "pytorch": segmented_reduction_pytorch,
-        },
-        (indices, input_data, num_nodes),
+        segmented_reduction_helion, reference_fns, (indices, input_data, num_nodes)
     )
 
 

--- a/helion/_compiler/cute/scan_ops.py
+++ b/helion/_compiler/cute/scan_ops.py
@@ -17,6 +17,21 @@ import torch
 from ... import exc
 from ...language import _decorators
 from ...language.scan_ops import _associative_scan
+from ..scan_ops import SCAN_ARITHMETIC_OPS
+from ..scan_ops import SCAN_ATEN_COMPARISON_OPS
+from ..scan_ops import SCAN_CAST_OP
+from ..scan_ops import SCAN_MAX_OPS
+from ..scan_ops import SCAN_MIN_OPS
+from ..scan_ops import SCAN_WHERE_OPS
+from ..scan_ops import scan_combine_arg
+from ..scan_ops import scan_combine_binary_expression
+from ..scan_ops import scan_combine_check_extra_args
+from ..scan_ops import scan_combine_check_kwargs
+
+_CUTE_SCAN_BINARY_OPS: dict[object, str] = {
+    **SCAN_ARITHMETIC_OPS,
+    **SCAN_ATEN_COMPARISON_OPS,
+}
 
 if TYPE_CHECKING:
     import ast
@@ -163,7 +178,7 @@ def _cute_recover_scan_load(node: object) -> tuple[object, object] | None:
     from .indexing import CuteSortableLoad
     from .indexing import is_cute_shape_chain_target
 
-    passthrough_targets = (torch.ops.prims.convert_element_type.default,)
+    passthrough_targets = (SCAN_CAST_OP,)
     current = node
     seen: set[Node] = set()
     while isinstance(current, Node) and current not in seen:
@@ -231,8 +246,6 @@ def _cute_inline_combine_graph(
     assignment statements (to be spliced inside the scan ``for`` loop) and
     ``out_exprs`` are the output expression strings, one per tuple element.
     """
-    import operator as operator_mod
-
     from ..compile_environment import CompileEnvironment
     from ..device_ir import HelperFunctionGraphInfo
 
@@ -247,36 +260,6 @@ def _cute_inline_combine_graph(
     )
     # Unpacked layout: (left_e0, left_e1, ..., right_e0, right_e1, ...)
     arg_vars = [*left_vars, *right_vars]
-
-    binary_ops: dict[object, str] = {
-        operator_mod.add: "+",
-        torch.add: "+",
-        torch.ops.aten.add.Tensor: "+",
-        torch.ops.aten.add.Scalar: "+",
-        operator_mod.sub: "-",
-        torch.sub: "-",
-        torch.ops.aten.sub.Tensor: "-",
-        torch.ops.aten.sub.Scalar: "-",
-        operator_mod.mul: "*",
-        torch.mul: "*",
-        torch.ops.aten.mul.Tensor: "*",
-        torch.ops.aten.mul.Scalar: "*",
-        torch.ops.aten.eq.Tensor: "==",
-        torch.ops.aten.eq.Scalar: "==",
-        torch.ops.aten.ne.Tensor: "!=",
-        torch.ops.aten.ne.Scalar: "!=",
-        torch.ops.aten.lt.Tensor: "<",
-        torch.ops.aten.lt.Scalar: "<",
-        torch.ops.aten.gt.Tensor: ">",
-        torch.ops.aten.gt.Scalar: ">",
-        torch.ops.aten.le.Tensor: "<=",
-        torch.ops.aten.le.Scalar: "<=",
-        torch.ops.aten.ge.Tensor: ">=",
-        torch.ops.aten.ge.Scalar: ">=",
-    }
-    min_ops = (torch.minimum, torch.ops.aten.minimum.default)
-    max_ops = (torch.maximum, torch.ops.aten.maximum.default)
-    where_ops = (torch.where, torch.ops.aten.where.self)
 
     env_map: dict[object, str] = dict(zip(placeholders, arg_vars, strict=True))
 
@@ -307,27 +290,49 @@ def _cute_inline_combine_graph(
                 "cute", f"associative_scan combine op {node.op}"
             )
         target = node.target
-        if target in binary_ops:
-            lhs = operand(node.args[0])
-            rhs = operand(node.args[1])
-            emit(node, f"({lhs}) {binary_ops[target]} ({rhs})")
-        elif target in where_ops:
-            cond = operand(node.args[0])
-            tval = operand(node.args[1])
-            fval = operand(node.args[2])
+        if target in _CUTE_SCAN_BINARY_OPS:
+            lhs = operand(scan_combine_arg(node, 0, "input", "cute"))
+            rhs = operand(scan_combine_arg(node, 1, "other", "cute"))
+            emit(
+                node,
+                scan_combine_binary_expression(
+                    node, _CUTE_SCAN_BINARY_OPS[target], lhs, rhs, operand, "cute"
+                ),
+            )
+        elif target in SCAN_WHERE_OPS:
+            scan_combine_check_extra_args(node, 3, "cute")
+            scan_combine_check_kwargs(node, "cute", ("condition", "input", "other"))
+            cond = operand(scan_combine_arg(node, 0, "condition", "cute"))
+            tval = operand(scan_combine_arg(node, 1, "input", "cute"))
+            fval = operand(scan_combine_arg(node, 2, "other", "cute"))
             emit(node, env.backend.where_expr(cond, tval, fval))
-        elif target in min_ops:
-            lhs = operand(node.args[0])
-            rhs = operand(node.args[1])
+        elif target in SCAN_MIN_OPS:
+            scan_combine_check_extra_args(node, 2, "cute")
+            scan_combine_check_kwargs(node, "cute", ("input", "other"))
+            lhs = operand(scan_combine_arg(node, 0, "input", "cute"))
+            rhs = operand(scan_combine_arg(node, 1, "other", "cute"))
             emit(node, f"({lhs}) if ({lhs}) < ({rhs}) else ({rhs})")
-        elif target in max_ops:
-            lhs = operand(node.args[0])
-            rhs = operand(node.args[1])
+        elif target in SCAN_MAX_OPS:
+            scan_combine_check_extra_args(node, 2, "cute")
+            scan_combine_check_kwargs(node, "cute", ("input", "other"))
+            lhs = operand(scan_combine_arg(node, 0, "input", "cute"))
+            rhs = operand(scan_combine_arg(node, 1, "other", "cute"))
             emit(node, f"({lhs}) if ({lhs}) > ({rhs}) else ({rhs})")
-        elif target is torch.ops.prims.convert_element_type.default:
-            # Per-lane scalars are already in their storage dtype; treat the
-            # cast as a pass-through (matches the load/store scalar pipeline).
-            env_map[node] = operand(node.args[0])
+        elif target is SCAN_CAST_OP:
+            scan_combine_check_extra_args(node, 2, "cute")
+            scan_combine_check_kwargs(node, "cute", ("a", "dtype"))
+            dtype = scan_combine_arg(node, 1, "dtype", "cute")
+            if not isinstance(dtype, torch.dtype):
+                raise exc.BackendUnsupported(
+                    "cute", f"associative_scan combine dtype {dtype!r}"
+                )
+            emit(
+                node,
+                env.backend.cast_expr(
+                    operand(scan_combine_arg(node, 0, "a", "cute")),
+                    env.backend.dtype_str(dtype),
+                ),
+            )
         else:
             raise exc.BackendUnsupported(
                 "cute", f"associative_scan combine function: {target}"

--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -346,6 +346,10 @@ class DeviceFunction:
         # Pallas: id(fake_tensor) → {dim: (block_id, extra_pad)} for dims
         # using pl.ds() that may need host-side padding.
         self.pallas_pad_info: dict[int, dict[int, tuple[int, int]]] = {}
+        # Pallas tensor-index atomic_add targets use a local RMW update.  Their
+        # indirect output dimensions must be covered by shared-output
+        # serialization in the launcher.
+        self.pallas_tensor_index_atomic_target_ids: set[int] = set()
         # Pallas ordered carry: jagged row block_id -> CarryBoundaryTile.  Filled by
         # the emit_pipeline codegen when the tile is a legal map axis; read by
         # the store codegen to stitch the boundary across neighbouring groups.

--- a/helion/_compiler/pallas/_codegen_modules.py
+++ b/helion/_compiler/pallas/_codegen_modules.py
@@ -18,5 +18,6 @@ from . import creation_ops  # noqa: F401
 from . import gelu_tanh_approx  # noqa: F401
 from . import matmul_ops  # noqa: F401
 from . import memory_ops  # noqa: F401
+from . import scan_ops  # noqa: F401
 from . import tracing_ops  # noqa: F401
 from . import view_ops  # noqa: F401

--- a/helion/_compiler/pallas/atomic_ops.py
+++ b/helion/_compiler/pallas/atomic_ops.py
@@ -8,6 +8,7 @@ same eager timing as before.
 
 from __future__ import annotations
 
+import ast
 from typing import TYPE_CHECKING
 
 import torch
@@ -27,11 +28,13 @@ from ..ast_extension import expr_from_string
 from ..ast_extension import statement_from_string
 from ..compile_environment import CompileEnvironment
 from ..host_function import HostFunction
+from ..indexing_strategy import SubscriptIndexing
 from . import codegen as pallas_codegen
+from .gather import emit_scatter_add
+from .tensorcore_plan import TENSORCORE_PLAN_META
+from .tensorcore_plan import OneHotScatterPlan
 
 if TYPE_CHECKING:
-    import ast
-
     from ..inductor_lowering import CodegenState
 
 
@@ -90,8 +93,69 @@ def _pallas_store_update(
     )
 
 
+def _validate_pallas_tensor_index_atomic_add_shape(
+    state: CodegenState,
+    target: torch.Tensor,
+    index: list[object] | tuple[object, ...],
+    value: object,
+) -> None:
+    """Reject tensor-indexed Pallas atomic_add shapes we cannot lower."""
+    if not isinstance(value, torch.Tensor):
+        raise exc.BackendUnsupported("pallas", "tensor-indexed atomic_add tensor value")
+    expected_shape = SubscriptIndexing.compute_shape(target, [*index], state)
+    if value.ndim != len(expected_shape):
+        raise exc.BackendUnsupported(
+            "pallas",
+            "tensor-indexed atomic_add value shape must match indexed target shape",
+        )
+
+    env = CompileEnvironment.current()
+    for actual, expected in zip(value.shape, expected_shape, strict=True):
+        if not env.known_equal(actual, expected):
+            raise exc.BackendUnsupported(
+                "pallas",
+                "tensor-indexed atomic_add value shape must match indexed target shape",
+            )
+
+
 @_decorators.codegen(atomic_add, "pallas")
 def _(state: CodegenState) -> ast.AST:
+    tensorcore_plan = (
+        state.fx_node.meta.get(TENSORCORE_PLAN_META) if state.fx_node else None
+    )
+    if isinstance(tensorcore_plan, OneHotScatterPlan):
+        if state.fx_node is not None and len(state.fx_node.users) > 0:
+            raise NotImplementedError(
+                "Pallas tensor-indexed atomic_add does not support returning "
+                "previous values"
+            )
+        target = state.proxy_arg(0)
+        index = state.proxy_arg(1)
+        assert isinstance(target, torch.Tensor)
+        assert isinstance(index, (list, tuple))
+        value_proxy = state.proxy_arg(2)
+        plan = tensorcore_plan.plan
+        _validate_pallas_tensor_index_atomic_add_shape(
+            state, target, index, value_proxy
+        )
+        state.device_function.pallas_tensor_index_atomic_target_ids.add(id(target))
+        host_function = HostFunction.current()
+        if target not in host_function.tensor_to_origin:
+            raise exc.AtomicOnDeviceTensor("pallas atomic")
+        value_ast = _to_ast_values([state.ast_args[2]])[0]
+        name = state.device_function.tensor_arg(target).name
+        name = pallas_codegen.vmem_name(state, name)
+        index_parts, none_dims = pallas_codegen.index_parts(state, index, target)
+        value_ast = pallas_codegen.sliced_value_for_store(
+            state, target, index, index_parts, value_ast
+        )
+        index_str = ", ".join(index_parts)
+        update = emit_scatter_add(state, plan, name, index_str, value_ast, none_dims)
+        state.codegen.add_statement(
+            statement_from_string(f"{name}[{index_str}] = {{update}}", update=update)
+        )
+        return ast.Constant(value=None)
+
     name, index_parts, index_str, prev_var = _pallas_atomic_load_prev(state)
     value_ast = _to_ast_values([state.ast_args[2]])[0]
     target = state.proxy_arg(0)

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -1612,6 +1612,54 @@ class PallasBackend(Backend):
         )
 
         block_spec_info = self._compute_block_spec_info(sorted_args, config)
+        target_ids = device_fn.pallas_tensor_index_atomic_target_ids
+        if target_ids:
+            # Tensor-index atomic_add lowers to a local read/modify/write. It is
+            # correct across programs only when the launcher can serialize every
+            # program sharing the target BlockSpec tile.
+            if any(config.flatten_loops):
+                raise NotImplementedError(
+                    "Pallas tensor-indexed atomic_add does not support flattened "
+                    "loops without shared-output BlockSpec metadata"
+                )
+            if sorted_args is None or block_spec_info is None:
+                raise NotImplementedError(
+                    "Pallas tensor-indexed atomic_add requires block spec info "
+                    "for shared-output serialization"
+                )
+            target_positions = [
+                i
+                for i, arg in enumerate(sorted_args)
+                if isinstance(arg, TensorArg) and id(arg.fake_value) in target_ids
+            ]
+            if len(target_positions) != len(target_ids):
+                raise NotImplementedError(
+                    "Pallas tensor-indexed atomic_add target was not found in "
+                    "launcher arguments"
+                )
+            output_set = set(output_indices)
+            inplace_set = set(inplace_indices)
+            for pos in target_positions:
+                if pos not in output_set or pos not in inplace_set:
+                    raise NotImplementedError(
+                        "Pallas tensor-indexed atomic_add requires an in-place "
+                        "output so shared-output serialization can guard the RMW"
+                    )
+                block_info = (
+                    block_spec_info[pos] if pos < len(block_spec_info) else None
+                )
+                if block_info is None:
+                    raise NotImplementedError(
+                        "Pallas tensor-indexed atomic_add requires block spec info "
+                        "for shared-output serialization"
+                    )
+                _block_shape, grid_dims = block_info
+                if any(isinstance(grid_dim, tuple) for grid_dim in grid_dims):
+                    raise NotImplementedError(
+                        "Pallas tensor-indexed atomic_add does not support "
+                        "ForEach or flattened grid decompositions without "
+                        "shared-output BlockSpec metadata"
+                    )
         if block_spec_info is not None:
             if has_rng_ops:
                 block_spec_info.append(None)  # RNG seed buffer is untiled

--- a/helion/_compiler/pallas/gather.py
+++ b/helion/_compiler/pallas/gather.py
@@ -303,12 +303,107 @@ def _scatter_one_hot_name(
     ast_idx = ast_subscripts[plan.indirect_pos]
     assert isinstance(ast_idx, ast.AST)
     idx_name = state.codegen.lift(ast_idx, dce=False, prefix="index").id
+    extent = f"{name}.shape[{plan.indirect_tensor_dim}]"
+    raw_index = f"{idx_name}[...]"
+    normalized_index = (
+        f"jnp.where((({raw_index}) < 0) & (({raw_index}) >= -({extent})), "
+        f"({raw_index}) + ({extent}), ({raw_index}))"
+    )
     # TODO(tcombes): investigate making the metadata into dtype,
     # currently hitting Mosaic issues with bf16 mask.
-    return (
-        f"jax.nn.one_hot({idx_name}[...], "
-        f"{name}.shape[{plan.indirect_tensor_dim}], "
-        "dtype=jnp.float32)"
+    return f"jax.nn.one_hot({normalized_index}, {extent}, dtype=jnp.float32)"
+
+
+def _scatter_source_mask_expr(
+    state: CodegenState,
+    plan: ScatterPlan,
+) -> str | None:
+    """Return a float mask for valid tensor-index source lanes."""
+    from ..compile_environment import CompileEnvironment
+
+    subscript = state.proxy_arg(1)
+    assert isinstance(subscript, (list, tuple))
+    index = subscript[plan.indirect_pos]
+    if not isinstance(index, torch.Tensor):
+        return None
+
+    env = CompileEnvironment.current()
+    index_shape = [*index.size()]
+    mask_exprs: list[str] = []
+    for dim, size in enumerate(index_shape):
+        block_id = env.resolve_block_id(size)
+        if block_id is None or (mask_var := state.codegen.mask_var(block_id)) is None:
+            continue
+        if env.is_jagged_tile(block_id):
+            mask_shape = env.jagged_tile_mask_shapes[block_id]
+            expand = state.tile_strategy.jagged_tile_expand_str(mask_shape, index_shape)
+        else:
+            expand = state.tile_strategy.expand_str(index_shape, dim)
+        expr = f"({mask_var}.astype(jnp.float32){expand})"
+        if expr not in mask_exprs:
+            mask_exprs.append(expr)
+
+    if not mask_exprs:
+        return None
+    return "*".join(mask_exprs)
+
+
+def _scatter_masked_one_hot(
+    state: CodegenState,
+    plan: ScatterPlan,
+    name: str,
+) -> str:
+    oh = _scatter_one_hot_name(state, plan, name)
+    source_mask = _scatter_source_mask_expr(state, plan)
+    if source_mask is None:
+        return oh
+    return f"({oh}) * (({source_mask})[..., None])"
+
+
+def _scatter_dot(mapping: str, value: ast.AST) -> ast.AST:
+    return expr_from_string(
+        "jax.lax.dot_general("
+        f"{mapping}, "
+        "{value}.astype(jnp.float32), "
+        "(((1,), (0,)), ((), ())), "
+        "preferred_element_type=jnp.float32, "
+        "precision=jax.lax.Precision.HIGHEST)",
+        value=value,
+    )
+
+
+def _scatter_add_updates(mapping: str, value: ast.AST) -> ast.AST:
+    """Project additive updates without zero-times-nonfinite contamination."""
+    value_f32 = expr_from_string("{value}.astype(jnp.float32)", value=value)
+    finite_value = expr_from_string(
+        "jnp.where(jnp.isfinite({value}), {value}, jnp.array(0, dtype=jnp.float32))",
+        value=value_f32,
+    )
+    nan_value = expr_from_string(
+        "jnp.isnan({value}).astype(jnp.float32)", value=value_f32
+    )
+    posinf_value = expr_from_string(
+        "jnp.isposinf({value}).astype(jnp.float32)", value=value_f32
+    )
+    neginf_value = expr_from_string(
+        "jnp.isneginf({value}).astype(jnp.float32)", value=value_f32
+    )
+    finite_updates = _scatter_dot(mapping, finite_value)
+    nan_hits = _scatter_dot(mapping, nan_value)
+    posinf_hits = _scatter_dot(mapping, posinf_value)
+    neginf_hits = _scatter_dot(mapping, neginf_value)
+    return expr_from_string(
+        "jnp.where(({nan_hits} > 0) | "
+        "(({posinf_hits} > 0) & ({neginf_hits} > 0)), "
+        "jnp.array(jnp.nan, dtype=jnp.float32), "
+        "jnp.where({posinf_hits} > 0, "
+        "jnp.array(jnp.inf, dtype=jnp.float32), "
+        "jnp.where({neginf_hits} > 0, "
+        "jnp.array(-jnp.inf, dtype=jnp.float32), {finite_updates})))",
+        nan_hits=nan_hits,
+        posinf_hits=posinf_hits,
+        neginf_hits=neginf_hits,
+        finite_updates=finite_updates,
     )
 
 
@@ -341,7 +436,7 @@ def emit_scatter_store(
     """
     for dim in reversed(none_dims):
         value = expr_from_string(f"jnp.squeeze({{value}}, axis={dim})", value=value)
-    oh = _scatter_one_hot_name(state, plan, name)
+    oh = _scatter_masked_one_hot(state, plan, name)
     m = f"jnp.shape({oh})[0]"
     eye = f"jnp.eye({m}, dtype=jnp.float32)"
     is_lane_j_after_i = f"jnp.triu(jnp.ones(({m}, {m}), dtype=jnp.float32), k=1)"
@@ -355,15 +450,8 @@ def emit_scatter_store(
         "(((1,), (0,)), ((), ())))"
     )
     updates = expr_from_string(
-        "jax.lax.dot_general("
-        f"{row_to_lane}, "
-        "{value}.astype(jnp.float32), "
-        "(((1,), (0,)), "
-        "((), ())), "
-        "preferred_element_type=jnp.float32, "
-        "precision=jax.lax.Precision.HIGHEST"
-        f").astype({plan.jnp_dtype})",
-        value=value,
+        f"{{updates}}.astype({plan.jnp_dtype})",
+        updates=_scatter_add_updates(row_to_lane, value),
     )
     mask_expr = (
         "jax.lax.dot_general("
@@ -376,4 +464,25 @@ def emit_scatter_store(
         f"jnp.where({mask_expr}, {{updates}}, {name}[{base_index}])",
         updates=updates,
         value=value,
+    )
+
+
+def emit_scatter_add(
+    state: CodegenState,
+    plan: ScatterPlan,
+    name: str,
+    base_index: str,
+    value: ast.AST,
+    none_dims: list[int],
+) -> ast.AST:
+    """Emit one Pallas program's tensor-indexed additive update block."""
+    for dim in reversed(none_dims):
+        value = expr_from_string(f"jnp.squeeze({{value}}, axis={dim})", value=value)
+    oh = _scatter_masked_one_hot(state, plan, name)
+    mapping = f"jnp.swapaxes({oh}, 0, 1)"
+    updates = _scatter_add_updates(mapping, value)
+    return expr_from_string(
+        f"({name}[{base_index}].astype(jnp.float32) + {{updates}}).astype("
+        f"{plan.jnp_dtype})",
+        updates=updates,
     )

--- a/helion/_compiler/pallas/scan_ops.py
+++ b/helion/_compiler/pallas/scan_ops.py
@@ -1,0 +1,276 @@
+"""Pallas-backend codegen for associative scan operations."""
+
+from __future__ import annotations
+
+import ast
+from typing import TYPE_CHECKING
+from typing import cast
+
+import torch
+
+from ... import exc
+from ...language import _decorators
+from ...language.scan_ops import _associative_scan
+from ..ast_extension import expr_from_string
+from ..ast_extension import statement_from_string
+from ..compile_environment import CompileEnvironment
+from ..scan_ops import SCAN_ARITHMETIC_OPS
+from ..scan_ops import SCAN_ATEN_COMPARISON_OPS
+from ..scan_ops import SCAN_CAST_OP
+from ..scan_ops import SCAN_MAX_OPS
+from ..scan_ops import SCAN_MIN_OPS
+from ..scan_ops import SCAN_PYTHON_COMPARISON_OPS
+from ..scan_ops import SCAN_WHERE_OPS
+from ..scan_ops import scan_combine_arg
+from ..scan_ops import scan_combine_binary_expression
+from ..scan_ops import scan_combine_check_extra_args
+from ..scan_ops import scan_combine_check_kwargs
+from .backend import _JAX_UNSUPPORTED_DTYPES
+
+if TYPE_CHECKING:
+    from ..device_ir import HelperFunctionGraphInfo
+    from ..inductor_lowering import CodegenState
+
+
+_PALLAS_SCAN_BINARY_OPS: dict[object, str] = {
+    **SCAN_ARITHMETIC_OPS,
+    **SCAN_PYTHON_COMPARISON_OPS,
+    **SCAN_ATEN_COMPARISON_OPS,
+}
+
+
+@_decorators.codegen(_associative_scan, "pallas")
+def _(state: CodegenState) -> ast.AST | list[ast.AST]:
+    """Generate a conservative static serial Pallas/JAX scan."""
+    from ..device_ir import HelperFunctionGraphInfo
+
+    combine_graph_id = cast("int", state.proxy_arg(0))
+    dim = cast("int", state.proxy_arg(2))
+    reverse = bool(state.proxy_arg(3))
+    is_tuple_input = bool(state.proxy_arg(4))
+    if reverse:
+        raise exc.BackendUnsupported("pallas", "reverse associative_scan")
+
+    helper_graph_info = state.get_graph(combine_graph_id)
+    assert isinstance(helper_graph_info, HelperFunctionGraphInfo)
+
+    input_values, input_asts = _pallas_scan_inputs(state, is_tuple_input)
+    result_exprs = _pallas_emit_serial_scan(
+        state,
+        helper_graph_info,
+        input_values,
+        input_asts,
+        dim,
+    )
+    return result_exprs if is_tuple_input else result_exprs[0]
+
+
+def _pallas_scan_inputs(
+    state: CodegenState, is_tuple_input: bool
+) -> tuple[list[torch.Tensor], list[ast.AST]]:
+    input_proxy = state.proxy_arg(1)
+    raw_input_ast = state.ast_args[1]
+
+    if is_tuple_input:
+        if not isinstance(input_proxy, (tuple, list)) or not isinstance(
+            raw_input_ast, (tuple, list)
+        ):
+            raise exc.BackendUnsupported("pallas", "tuple associative_scan input")
+        input_values = list(input_proxy)
+        input_asts = list(raw_input_ast)
+    else:
+        input_values = [input_proxy]
+        input_asts = [state.ast_arg(1)]
+
+    if not input_values or not all(isinstance(t, torch.Tensor) for t in input_values):
+        raise exc.BackendUnsupported("pallas", "associative_scan input")
+    if not all(isinstance(arg, ast.AST) for arg in input_asts):
+        raise exc.BackendUnsupported("pallas", "associative_scan input expression")
+    return (
+        cast("list[torch.Tensor]", input_values),
+        cast("list[ast.AST]", input_asts),
+    )
+
+
+def _pallas_emit_serial_scan(
+    state: CodegenState,
+    helper_graph_info: HelperFunctionGraphInfo,
+    input_values: list[torch.Tensor],
+    input_asts: list[ast.AST],
+    dim: int,
+) -> list[ast.AST]:
+    """Emit a static JAX loop, inline the combine graph, and stack its items."""
+    first = input_values[0]
+    ndim = first.ndim
+    if ndim == 0:
+        raise exc.BackendUnsupported("pallas", "scalar associative_scan input")
+    if dim < 0:
+        dim += ndim
+    if not (0 <= dim < ndim):
+        raise exc.BackendUnsupported("pallas", "associative_scan dim")
+
+    first_shape = tuple(str(s) for s in first.shape)
+    for value in input_values:
+        if value.ndim != ndim or tuple(str(s) for s in value.shape) != first_shape:
+            raise exc.BackendUnsupported("pallas", "tuple associative_scan shapes")
+
+    env = CompileEnvironment.current()
+    fake_extent: object = first.shape[dim]
+    if isinstance(fake_extent, torch.SymInt):
+        fake_extent = env.size_hint(fake_extent)
+    if not isinstance(fake_extent, int) or fake_extent <= 0:
+        raise exc.BackendUnsupported("pallas", "dynamic associative_scan extent")
+
+    input_names = [
+        state.codegen.lift(input_ast, dce=True, prefix="scan_input").id
+        for input_ast in input_asts
+    ]
+    result_vars = [state.device_function.new_var("scan_out") for _ in input_names]
+    acc_vars = [state.device_function.new_var("scan_acc") for _ in input_names]
+    item_vars = [state.device_function.new_var("scan_items") for _ in input_names]
+    extent_var = state.device_function.new_var("scan_extent")
+
+    state.codegen.add_statement(
+        statement_from_string(f"{extent_var} = {input_names[0]}.shape[{dim}]")
+    )
+    for item_var in item_vars:
+        state.codegen.add_statement(
+            statement_from_string(f"{item_var} = [None] * {extent_var}")
+        )
+
+    seed_index = _pallas_scan_index(ndim, dim, "0")
+    for acc_var, item_var, input_name in zip(
+        acc_vars, item_vars, input_names, strict=True
+    ):
+        state.codegen.add_statement(
+            statement_from_string(f"{acc_var} = {input_name}[{seed_index}]")
+        )
+        state.codegen.add_statement(statement_from_string(f"{item_var}[0] = {acc_var}"))
+
+    scan_i = state.device_function.new_var("scan_i")
+    value_index = _pallas_scan_index(ndim, dim, scan_i)
+    value_exprs = [f"{input_name}[{value_index}]" for input_name in input_names]
+    combine_exprs = _pallas_combine_result_expressions(
+        helper_graph_info, [*acc_vars, *value_exprs]
+    )
+    if len(combine_exprs) != len(acc_vars):
+        raise exc.BackendUnsupported("pallas", "associative_scan combine output")
+    next_vars = [state.device_function.new_var("scan_next") for _ in acc_vars]
+    lines = [f"for {scan_i} in range(1, {extent_var}):"]
+    lines.extend(
+        f"    {next_var} = {combine_expr}"
+        for next_var, combine_expr in zip(next_vars, combine_exprs, strict=True)
+    )
+    lines.extend(
+        f"    {acc_var} = {next_var}"
+        for acc_var, next_var in zip(acc_vars, next_vars, strict=True)
+    )
+    lines.extend(
+        f"    {item_var}[{scan_i}] = {acc_var}"
+        for item_var, acc_var in zip(item_vars, acc_vars, strict=True)
+    )
+    state.codegen.add_statement(statement_from_string("\n".join(lines)))
+
+    for result_var, item_var in zip(result_vars, item_vars, strict=True):
+        state.codegen.add_statement(
+            statement_from_string(f"{result_var} = jnp.stack({item_var}, axis={dim})")
+        )
+
+    return [expr_from_string(result_var) for result_var in result_vars]
+
+
+def _pallas_scan_index(ndim: int, dim: int, pos: str) -> str:
+    parts = [":" for _ in range(ndim)]
+    parts[dim] = pos
+    return ", ".join(parts)
+
+
+def _pallas_combine_result_expressions(
+    helper_graph_info: HelperFunctionGraphInfo,
+    arg_exprs: list[str],
+) -> list[str]:
+    """Inline the combine graph as JAX expressions for Pallas serial scan."""
+    env = CompileEnvironment.current()
+    graph = helper_graph_info.graph
+    placeholders = [n for n in graph.nodes if n.op == "placeholder"]
+    if len(placeholders) != len(arg_exprs):
+        raise exc.BackendUnsupported("pallas", "associative_scan combine arity")
+
+    env_map: dict[object, str] = dict(zip(placeholders, arg_exprs, strict=True))
+
+    def operand(value: object) -> str:
+        if isinstance(value, torch.fx.Node):
+            if value not in env_map:
+                raise exc.BackendUnsupported(
+                    "pallas", f"associative_scan combine dependency: {value}"
+                )
+            return env_map[value]
+        if isinstance(value, bool):
+            return "True" if value else "False"
+        if isinstance(value, (int, float)):
+            return repr(value)
+        raise exc.BackendUnsupported(
+            "pallas", f"associative_scan combine operand {value!r}"
+        )
+
+    for node in graph.nodes:
+        if node.op in ("placeholder", "output"):
+            continue
+        if node.op != "call_function":
+            raise exc.BackendUnsupported(
+                "pallas", f"associative_scan combine op {node.op}"
+            )
+        target = node.target
+        if target in _PALLAS_SCAN_BINARY_OPS:
+            lhs = operand(scan_combine_arg(node, 0, "input", "pallas"))
+            rhs = operand(scan_combine_arg(node, 1, "other", "pallas"))
+            env_map[node] = scan_combine_binary_expression(
+                node, _PALLAS_SCAN_BINARY_OPS[target], lhs, rhs, operand, "pallas"
+            )
+        elif target in SCAN_WHERE_OPS:
+            scan_combine_check_extra_args(node, 3, "pallas")
+            scan_combine_check_kwargs(node, "pallas", ("condition", "input", "other"))
+            cond = operand(scan_combine_arg(node, 0, "condition", "pallas"))
+            tval = operand(scan_combine_arg(node, 1, "input", "pallas"))
+            fval = operand(scan_combine_arg(node, 2, "other", "pallas"))
+            env_map[node] = f"jnp.where({cond}, {tval}, {fval})"
+        elif target in SCAN_MIN_OPS:
+            scan_combine_check_extra_args(node, 2, "pallas")
+            scan_combine_check_kwargs(node, "pallas", ("input", "other"))
+            lhs = operand(scan_combine_arg(node, 0, "input", "pallas"))
+            rhs = operand(scan_combine_arg(node, 1, "other", "pallas"))
+            env_map[node] = f"jnp.minimum({lhs}, {rhs})"
+        elif target in SCAN_MAX_OPS:
+            scan_combine_check_extra_args(node, 2, "pallas")
+            scan_combine_check_kwargs(node, "pallas", ("input", "other"))
+            lhs = operand(scan_combine_arg(node, 0, "input", "pallas"))
+            rhs = operand(scan_combine_arg(node, 1, "other", "pallas"))
+            env_map[node] = f"jnp.maximum({lhs}, {rhs})"
+        elif target is SCAN_CAST_OP:
+            scan_combine_check_extra_args(node, 2, "pallas")
+            scan_combine_check_kwargs(node, "pallas", ("a", "dtype"))
+            dtype = scan_combine_arg(node, 1, "dtype", "pallas")
+            if not isinstance(dtype, torch.dtype):
+                raise exc.BackendUnsupported(
+                    "pallas", f"associative_scan combine dtype {dtype!r}"
+                )
+            if dtype in _JAX_UNSUPPORTED_DTYPES:
+                raise exc.BackendUnsupported(
+                    "pallas", f"associative_scan combine dtype {dtype!r}"
+                )
+            env_map[node] = env.backend.cast_expr(
+                operand(scan_combine_arg(node, 0, "a", "pallas")),
+                env.backend.dtype_str(dtype),
+            )
+        else:
+            raise exc.BackendUnsupported(
+                "pallas", f"associative_scan combine function: {target}"
+            )
+
+    output_nodes = [n for n in graph.nodes if n.op == "output"]
+    if len(output_nodes) != 1:
+        raise exc.BackendUnsupported("pallas", "associative_scan combine output")
+    outputs = output_nodes[0].args[0]
+    if not isinstance(outputs, (tuple, list)):
+        outputs = [outputs]
+    return [operand(output) for output in outputs]

--- a/helion/_compiler/pallas/tensorcore_plan.py
+++ b/helion/_compiler/pallas/tensorcore_plan.py
@@ -81,6 +81,11 @@ def select_tensorcore_plan(
         return _one_hot_gather(access, positions, config)
     if access.kind is MemoryAccessKind.STORE:
         return _one_hot_scatter(access, positions, config)
+    if access.kind is MemoryAccessKind.ATOMIC:
+        from ...language.atomic_ops import atomic_add
+
+        if access.node.target is atomic_add:
+            return _one_hot_scatter(access, positions, config)
     op = access.node.target
     op_name = getattr(op, "__name__", str(op))
     raise NotImplementedError(

--- a/helion/_compiler/pallas/tracing_ops.py
+++ b/helion/_compiler/pallas/tracing_ops.py
@@ -574,7 +574,8 @@ def _classify_loop_tensors(
     """
     from ...language.memory_ops import load as _load_op
     from ...language.memory_ops import store as _store_op
-    from .plan_tiling import TensorIndexPattern
+    from .tensorcore_plan import TENSORCORE_PLAN_META
+    from .tensorcore_plan import OneHotScatterPlan
 
     host_tensor_nodes: dict[torch.fx.Node, torch.Tensor] = {}
     for node in graph_info.graph.nodes:  # type: ignore[union-attr]
@@ -631,10 +632,7 @@ def _classify_loop_tensors(
                     )
                 # Scatter preserves untouched target rows by reading the old
                 # block, so it is a read-modify-write rather than store-only.
-                if any(
-                    isinstance(pattern, TensorIndexPattern)
-                    for pattern in node.meta.get("indexing_patterns", ())
-                ):
+                if isinstance(node.meta.get(TENSORCORE_PLAN_META), OneHotScatterPlan):
                     if key not in loaded_tensors:
                         loaded_tensors[key] = (fake, tensor_node, sub_vals)
                     else:

--- a/helion/_compiler/scan_ops.py
+++ b/helion/_compiler/scan_ops.py
@@ -1,0 +1,111 @@
+"""Backend-neutral helpers for associative-scan combine graphs."""
+
+from __future__ import annotations
+
+import operator
+from typing import TYPE_CHECKING
+
+import torch
+
+from .. import exc
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+SCAN_ARITHMETIC_OPS: dict[object, str] = {
+    operator.add: "+",
+    torch.add: "+",
+    torch.ops.aten.add.Tensor: "+",
+    torch.ops.aten.add.Scalar: "+",
+    operator.sub: "-",
+    torch.sub: "-",
+    torch.ops.aten.sub.Tensor: "-",
+    torch.ops.aten.sub.Scalar: "-",
+    operator.mul: "*",
+    torch.mul: "*",
+    torch.ops.aten.mul.Tensor: "*",
+    torch.ops.aten.mul.Scalar: "*",
+}
+SCAN_PYTHON_COMPARISON_OPS: dict[object, str] = {
+    operator.eq: "==",
+    operator.ne: "!=",
+    operator.lt: "<",
+    operator.gt: ">",
+    operator.le: "<=",
+    operator.ge: ">=",
+}
+SCAN_ATEN_COMPARISON_OPS: dict[object, str] = {
+    torch.ops.aten.eq.Tensor: "==",
+    torch.ops.aten.eq.Scalar: "==",
+    torch.ops.aten.ne.Tensor: "!=",
+    torch.ops.aten.ne.Scalar: "!=",
+    torch.ops.aten.lt.Tensor: "<",
+    torch.ops.aten.lt.Scalar: "<",
+    torch.ops.aten.gt.Tensor: ">",
+    torch.ops.aten.gt.Scalar: ">",
+    torch.ops.aten.le.Tensor: "<=",
+    torch.ops.aten.le.Scalar: "<=",
+    torch.ops.aten.ge.Tensor: ">=",
+    torch.ops.aten.ge.Scalar: ">=",
+}
+SCAN_MIN_OPS = (torch.minimum, torch.ops.aten.minimum.default)
+SCAN_MAX_OPS = (torch.maximum, torch.ops.aten.maximum.default)
+SCAN_WHERE_OPS = (torch.where, torch.ops.aten.where.self)
+SCAN_CAST_OP = torch.ops.prims.convert_element_type.default
+
+
+def scan_combine_arg(
+    node: torch.fx.Node, index: int, kwarg: str, backend_name: str
+) -> object:
+    if len(node.args) > index:
+        return node.args[index]
+    if kwarg in node.kwargs:
+        return node.kwargs[kwarg]
+    raise exc.BackendUnsupported(
+        backend_name, f"associative_scan combine missing argument {kwarg!r}"
+    )
+
+
+def scan_combine_check_extra_args(
+    node: torch.fx.Node, max_args: int, backend_name: str
+) -> None:
+    if len(node.args) > max_args:
+        raise exc.BackendUnsupported(
+            backend_name, f"associative_scan combine args {node.args!r}"
+        )
+
+
+def scan_combine_check_kwargs(
+    node: torch.fx.Node, backend_name: str, allowed: tuple[str, ...] = ()
+) -> None:
+    unexpected = set(node.kwargs) - set(allowed)
+    if unexpected:
+        raise exc.BackendUnsupported(
+            backend_name,
+            f"associative_scan combine kwargs {sorted(unexpected)!r}",
+        )
+
+
+def scan_combine_binary_expression(
+    node: torch.fx.Node,
+    op: str,
+    lhs: str,
+    rhs: str,
+    operand: Callable[[object], str],
+    backend_name: str,
+) -> str:
+    alpha: object = 1
+    max_args = 2
+    if op in {"+", "-"}:
+        if len(node.args) > 2:
+            alpha = node.args[2]
+            max_args = 3
+        elif "alpha" in node.kwargs:
+            alpha = node.kwargs["alpha"]
+        scan_combine_check_kwargs(node, backend_name, ("input", "other", "alpha"))
+    else:
+        scan_combine_check_kwargs(node, backend_name, ("input", "other"))
+    scan_combine_check_extra_args(node, max_args, backend_name)
+    if not isinstance(alpha, (int, float)) or alpha != 1:
+        rhs = f"({rhs}) * ({operand(alpha)})"
+    return f"(({lhs}) {op} ({rhs}))"

--- a/helion/language/scan_ops.py
+++ b/helion/language/scan_ops.py
@@ -175,14 +175,12 @@ def _(
     )
 
     # Create fake inputs for the combine function
-    fake_inputs = []
-    for tensor in input_tensor if is_tuple_input else [input_tensor]:
-        fake_inputs.extend(
-            [
-                torch.empty([1], dtype=tensor.dtype, device=tensor.device),
-                torch.empty([1], dtype=tensor.dtype, device=tensor.device),
-            ]
-        )
+    input_leaves = list(input_tensor) if is_tuple_input else [input_tensor]
+    fake_inputs = [
+        torch.empty([1], dtype=tensor.dtype, device=tensor.device)
+        for _side in range(2)
+        for tensor in input_leaves
+    ]
 
     combine_graph = proxy_tensor.make_fx(
         combine_fn, decomposition_table=select_decomp_table()

--- a/test/test_associative_scan.py
+++ b/test/test_associative_scan.py
@@ -38,6 +38,10 @@ def min_combine_fn(x, y):
     return torch.minimum(x, y)
 
 
+def cast_add_combine_fn(x, y):
+    return (x.to(torch.int32) + y.to(torch.int32)).to(torch.float32)
+
+
 def helion_combine_fn(left_values, left_indices, right_values, right_indices):
     """Tuple combine function with unpacked arguments (matching GitHub issue example)."""
     # Segmented scan: if indices are the same, add values; otherwise, take right values (reset)
@@ -137,6 +141,37 @@ class TestAssociativeScan(RefEagerTestBase, TestCase):
             self.assertIn("def add_combine_fn_", code)
             self.assertIn("param_0 + param_1", code)
             self.assertIn("tl.associative_scan", code)
+
+    @skipIfRefEager("CuTe codegen regression")
+    def test_cute_associative_scan_combine_casts(self):
+        if _get_backend() != "cute":
+            self.skipTest("CuTe-specific combine cast regression")
+
+        @helion.kernel(autotune_effort="none")
+        def scan_cast_kernel(x: torch.Tensor) -> torch.Tensor:
+            result = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile(x.size()):
+                result[tile_m, tile_n] = hl.associative_scan(
+                    cast_add_combine_fn, x[tile_m, tile_n], dim=0
+                )
+            return result
+
+        x = torch.tensor(
+            [
+                [1.0, 2.0, 3.0, 4.0],
+                [2.6, 3.6, 4.6, 5.6],
+                [3.6, 4.6, 5.6, 6.6],
+                [4.6, 5.6, 6.6, 7.6],
+            ],
+            device=DEVICE,
+            dtype=torch.float32,
+        )
+        code, result = code_and_output(scan_cast_kernel, (x,), block_sizes=[4, 4])
+
+        expected = torch.cumsum(x.to(torch.int32).to(torch.float32), dim=0)
+        torch.testing.assert_close(result, expected)
+        self.assertIn("cutlass.Int32", code)
+        self.assertIn("cutlass.Float32", code)
 
     def test_associative_scan_maximum(self):
         """Test associative_scan with maximum combine function."""

--- a/test/test_atomic_ops.py
+++ b/test/test_atomic_ops.py
@@ -157,6 +157,38 @@ def atomic_add_tensor_index_kernel(
     return out
 
 
+@helion.kernel()
+def atomic_add_tensor_index_clamped_feature_kernel(
+    values: torch.Tensor, indices: torch.Tensor, num_nodes: int
+) -> torch.Tensor:
+    num_features = values.size(1)
+    out = torch.zeros(
+        [num_nodes, num_features], dtype=values.dtype, device=values.device
+    )
+    for tile_m, tile_n in hl.tile(values.size()):
+        hl.atomic_add(out, [indices[tile_m], tile_n], values[tile_m, tile_n])
+    return out
+
+
+def _scatter_add_dim0_expected(
+    values: torch.Tensor, indices: torch.Tensor, num_rows: int
+) -> torch.Tensor:
+    ref_values = values.cpu() if values.device.type == "tpu" else values
+    ref_indices = indices.cpu() if values.device.type == "tpu" else indices
+    output = torch.zeros(
+        (num_rows, *values.shape[1:]),
+        device=ref_values.device,
+        dtype=values.dtype,
+    )
+    scatter_indices = (
+        ref_indices.to(torch.int64)
+        .reshape(-1, *([1] * (values.ndim - 1)))
+        .expand_as(ref_values)
+    )
+    output.scatter_add_(0, scatter_indices, ref_values)
+    return output.to(values.device) if values.device.type == "tpu" else output
+
+
 # New kernels for other atomics
 
 
@@ -305,7 +337,6 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
         expected = torch.ones(8, device=DEVICE)
         torch.testing.assert_close(result, expected)
 
-    @xfailIfPallas("Integer indexing not supported on Pallas")
     def test_atomic_add_1d_tensor(self):
         M, N = 32, 64
         x = torch.randn(M, N, device=DEVICE, dtype=torch.float32)
@@ -322,8 +353,6 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
         torch.testing.assert_close(result, expected)
 
     def test_atomic_add_tensor_index(self):
-        if _get_backend() == "pallas":
-            self.skipTest("Pallas/TPU does not support integer tensor indexing")
         values = torch.randn(64, device=DEVICE, dtype=torch.float32)
         indices = torch.randperm(64, device=DEVICE, dtype=LONG_INT_TYPE)
 
@@ -333,9 +362,41 @@ class TestAtomicOperations(RefEagerTestBase, TestCase):
             block_sizes=[32],
         )
 
-        expected = torch.zeros(64, device=DEVICE, dtype=values.dtype)
-        expected.scatter_add_(0, indices, values)
+        expected = _scatter_add_dim0_expected(values, indices, 64)
         torch.testing.assert_close(result, expected)
+
+    @onlyBackends(["pallas"])
+    def test_pallas_atomic_add_tensor_index_clamped_feature_value(self):
+        values = torch.randn(16, 17, device=DEVICE, dtype=torch.float32)
+        indices = torch.randint(0, 12, (16,), device=DEVICE, dtype=LONG_INT_TYPE)
+
+        code, result = code_and_output(
+            atomic_add_tensor_index_clamped_feature_kernel,
+            (values, indices, 12),
+            block_sizes=[16, 32],
+        )
+
+        expected = _scatter_add_dim0_expected(values, indices, 12)
+        torch.testing.assert_close(result, expected)
+        self.assertIn("one_hot", code)
+        self.assertIn("dot_general", code)
+
+    @onlyBackends(["pallas"])
+    @skipIfRefEager("Pallas-specific codegen inspection")
+    def test_pallas_tensor_index_atomic_add_one_hot_dot_lowering(self):
+        values = torch.randn(64, device=DEVICE, dtype=torch.float32)
+        indices = torch.arange(64, device=DEVICE, dtype=LONG_INT_TYPE) // 2
+
+        code, result = code_and_output(
+            atomic_add_tensor_index_kernel,
+            (values, indices),
+            block_sizes=[32],
+        )
+
+        expected = _scatter_add_dim0_expected(values, indices, 64)
+        torch.testing.assert_close(result, expected)
+        self.assertIn("one_hot", code)
+        self.assertIn("dot_general", code)
 
     def test_atomic_add_1d_tensor_with_offset_arange(self):
         if _get_backend() != "cute":

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1273,18 +1273,18 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[16, 8, 16],
         )
 
-    @xfailIfPallas("requires triton module")
     @skipIfRefEager(
         "torch._higher_order_ops.associative_scan with tuple arg is not supported by ref eager mode yet"
     )
     def test_segment_reduction(self):
-        num_nodes = 100
-        num_edges = 1000
-        num_features = 32
+        num_nodes = 4
+        num_edges = 19
+        num_features = 8
         dtype = torch.float32
 
-        # Create sorted indices for segmented reduction
-        indices = torch.randint(0, num_nodes, (num_edges,), device=DEVICE).sort()[0]
+        # Index zero matches the masked next-index value, so only the explicit
+        # final-element boundary flushes the last partial scan tile.
+        indices = torch.zeros(num_edges, device=DEVICE, dtype=LONG_INT_TYPE)
         input_data = torch.randn(num_edges, num_features, device=DEVICE, dtype=dtype)
 
         args = (indices, input_data, num_nodes)
@@ -1298,6 +1298,27 @@ class TestExamples(RefEagerTestBase, TestCase):
             args,
             expected,
             fn_name="segmented_reduction_helion",
+            block_sizes=[16, 8],
+        )
+
+    @skipIfRefEager(
+        "torch._higher_order_ops.associative_scan with tuple arg is not supported by ref eager mode yet"
+    )
+    def test_segment_reduction_scan_preserves_large_indices(self) -> None:
+        indices = torch.arange(
+            2**24,
+            2**24 + 128,
+            device=DEVICE,
+            dtype=LONG_INT_TYPE,
+        )
+        input_data = torch.randn(128, 8, device=DEVICE)
+
+        check_example(
+            "segment_reduction",
+            (indices, input_data),
+            input_data,
+            fn_name="segmented_scan_helion",
+            block_sizes=[128, 8],
         )
 
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -294,6 +294,36 @@ def pallas_scatter_store(values: torch.Tensor, indices: torch.Tensor) -> torch.T
     return out
 
 
+def pallas_segmented_scan_combine(
+    left_values: torch.Tensor,
+    left_indices: torch.Tensor,
+    right_values: torch.Tensor,
+    right_indices: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    same_segment = left_indices == right_indices
+    combined_values = torch.where(
+        same_segment, left_values + right_values, right_values
+    )
+    return combined_values, right_indices
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_tuple_associative_scan(
+    values: torch.Tensor, indices: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    out_values = torch.empty_like(values)
+    out_indices = torch.empty(values.size(), dtype=indices.dtype, device=values.device)
+    for tile_m, tile_n in hl.tile(values.size()):
+        vals = values[tile_m, tile_n]
+        idxs = indices[tile_m].unsqueeze(1).expand_as(vals)
+        out_vals, out_idxs = hl.associative_scan(
+            pallas_segmented_scan_combine, (vals, idxs), dim=0
+        )
+        out_values[tile_m, tile_n] = out_vals
+        out_indices[tile_m, tile_n] = out_idxs
+    return out_values, out_indices
+
+
 @helion.kernel(backend="pallas", static_shapes=True)
 def pallas_inner_loop_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     """Kernel with an outer grid loop and an inner device loop."""
@@ -579,6 +609,65 @@ def pallas_reduce_non_pow2(x: torch.Tensor) -> torch.Tensor:
         max_val = torch.amax(row, dim=-1, keepdim=True)
         exp_val = torch.exp(row - max_val)
         out[tile_n, :] = exp_val / torch.sum(exp_val, dim=-1, keepdim=True)
+    return out
+
+
+def _scatter_add_dim0_expected(
+    values: torch.Tensor, indices: torch.Tensor, num_rows: int
+) -> torch.Tensor:
+    ref_values = values.cpu() if values.device.type == "tpu" else values
+    ref_indices = indices.cpu() if values.device.type == "tpu" else indices
+    ref_indices = torch.where(ref_indices < 0, ref_indices + num_rows, ref_indices)
+    output = torch.zeros(
+        (num_rows, *values.shape[1:]),
+        device=ref_values.device,
+        dtype=values.dtype,
+    )
+    scatter_indices = (
+        ref_indices.to(torch.int64)
+        .reshape(-1, *([1] * (values.ndim - 1)))
+        .expand_as(ref_values)
+    )
+    output.scatter_add_(0, scatter_indices, ref_values)
+    return output.to(values.device) if values.device.type == "tpu" else output
+
+
+def pallas_scan_cast_kwargs_combine(
+    left_values: torch.Tensor,
+    right_values: torch.Tensor,
+) -> torch.Tensor:
+    right_values_f32 = right_values.to(torch.float32)
+    return (
+        torch.add(left_values.to(torch.float32), right_values_f32, alpha=2)
+        .sub(right_values_f32)
+        .to(torch.int32)
+    )
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_associative_scan_cast_kwargs(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile_m, tile_n in hl.tile(x.size()):
+        out[tile_m, tile_n] = hl.associative_scan(
+            pallas_scan_cast_kwargs_combine, x[tile_m, tile_n], dim=0
+        )
+    return out
+
+
+def pallas_scan_int64_roundtrip_combine(
+    left_values: torch.Tensor,
+    right_values: torch.Tensor,
+) -> torch.Tensor:
+    return (left_values + right_values).to(torch.int64).to(torch.int32)
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_associative_scan_int64_roundtrip(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile_m, tile_n in hl.tile(x.size()):
+        out[tile_m, tile_n] = hl.associative_scan(
+            pallas_scan_int64_roundtrip_combine, x[tile_m, tile_n], dim=0
+        )
     return out
 
 
@@ -2183,7 +2272,7 @@ class TestPallas(TestCase):
         expected[indices.to(torch.int64)] = values
         torch.testing.assert_close(result, expected)
 
-    def test_tensor_index_atomic_add_raises(self) -> None:
+    def test_tensor_index_atomic_add(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def atomic_add_tensor_index(
             values: torch.Tensor, indices: torch.Tensor
@@ -2194,16 +2283,377 @@ class TestPallas(TestCase):
             return out
 
         values = torch.randn(16, device=DEVICE, dtype=torch.float32)
-        indices = torch.randperm(16, device=DEVICE).to(torch.int32)
+        indices = torch.tensor(
+            [0, 1, 1, 2, 4, 4, 4, 8, 8, 9, 10, 10, 12, 13, 14, 14],
+            device=DEVICE,
+            dtype=torch.int32,
+        )
+
+        code, result = code_and_output(
+            atomic_add_tensor_index,
+            (values, indices),
+            block_size=16,
+        )
+
+        expected = _scatter_add_dim0_expected(values, indices, values.size(0))
+        torch.testing.assert_close(result, expected)
+        self.assertIn("one_hot", code)
+        self.assertIn("swapaxes", code)
+        self.assertIn("dot_general", code)
+
+    def test_tensor_index_atomic_add_negative_indices_partial_source(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def atomic_add_tensor_index(
+            values: torch.Tensor, indices: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.zeros_like(values)
+            for tile in hl.tile(values.size(0)):
+                hl.atomic_add(out, [indices[tile]], values[tile])
+            return out
+
+        values = torch.arange(1, 18, device=DEVICE, dtype=torch.float32)
+        indices = torch.tensor(
+            [-1, -17, -16, -2, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+            device=DEVICE,
+            dtype=torch.int32,
+        )
+
+        code, result = code_and_output(
+            atomic_add_tensor_index,
+            (values, indices),
+            block_size=32,
+        )
+
+        expected = _scatter_add_dim0_expected(values, indices, values.size(0))
+        torch.testing.assert_close(result, expected)
+        self.assertIn("jnp.arange", code)
+        self.assertIn("< 17", code)
+
+    def test_tensor_index_atomic_add_nonfinite_values(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def atomic_add_tensor_index(
+            values: torch.Tensor, indices: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.zeros_like(values)
+            for tile in hl.tile(values.size(0)):
+                hl.atomic_add(out, [indices[tile]], values[tile])
+            return out
+
+        values = torch.tensor(
+            [
+                float("nan"),
+                2.0,
+                float("inf"),
+                -float("inf"),
+                float("inf"),
+                1.0,
+                -float("inf"),
+                3.0,
+                4.0,
+                5.0,
+                6.0,
+                7.0,
+                8.0,
+                9.0,
+                10.0,
+                11.0,
+            ],
+            device=DEVICE,
+            dtype=torch.float32,
+        )
+        indices = torch.tensor(
+            [0, 1, 2, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+            device=DEVICE,
+            dtype=torch.int32,
+        )
+
+        _, result = code_and_output(
+            atomic_add_tensor_index,
+            (values, indices),
+            block_size=16,
+        )
+
+        expected = _scatter_add_dim0_expected(values, indices, values.size(0))
+        torch.testing.assert_close(result, expected, equal_nan=True)
+
+    def test_tensor_index_atomic_add_leading_none_dim(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def atomic_add_leading_none(
+            values: torch.Tensor, indices: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.zeros_like(values)
+            for tile_m, tile_n in hl.tile(values.size()):
+                hl.atomic_add(
+                    out,
+                    [None, indices[tile_m], tile_n],
+                    values[None, tile_m, tile_n],
+                )
+            return out
+
+        values = torch.randn(16, 17, device=DEVICE, dtype=torch.float32)
+        indices = torch.tensor(
+            [0, 1, 1, 2, 4, 4, 4, 8, 8, 9, 10, 10, 12, 13, 14, 14],
+            device=DEVICE,
+            dtype=torch.int32,
+        )
+
+        code, result = code_and_output(
+            atomic_add_leading_none,
+            (values, indices),
+            block_sizes=[16, 32],
+        )
+
+        expected = _scatter_add_dim0_expected(values, indices, values.size(0))
+        torch.testing.assert_close(result, expected)
+        self.assertIn("jnp.squeeze", code)
+
+    def test_tensor_index_atomic_add_scalar_before_none_dim(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def atomic_add_scalar_before_none(
+            values: torch.Tensor, indices: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.zeros(
+                [values.size(0), 1, values.size(1)],
+                dtype=values.dtype,
+                device=values.device,
+            )
+            for tile_m, tile_n in hl.tile(values.size()):
+                hl.atomic_add(
+                    out,
+                    [indices[tile_m], 0, None, tile_n],
+                    values[tile_m, None, tile_n],
+                )
+            return out
+
+        values = torch.randn(16, 17, device=DEVICE, dtype=torch.float32)
+        indices = torch.tensor(
+            [0, 1, 1, 2, 4, 4, 4, 8, 8, 9, 10, 10, 12, 13, 14, 14],
+            device=DEVICE,
+            dtype=torch.int32,
+        )
+
+        code, result = code_and_output(
+            atomic_add_scalar_before_none,
+            (values, indices),
+            block_sizes=[16, 32],
+        )
+
+        expected = _scatter_add_dim0_expected(
+            values.unsqueeze(1), indices, values.size(0)
+        )
+        torch.testing.assert_close(result, expected)
+        self.assertIn("jnp.squeeze", code)
+
+    def test_tensor_index_atomic_add_shared_output_tiles(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def atomic_add_shared_output_tiles(
+            values: torch.Tensor, indices: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.zeros(
+                [1, values.size(1)], device=values.device, dtype=values.dtype
+            )
+            for tile_m, tile_n in hl.tile(values.size()):
+                hl.atomic_add(out, [indices[tile_m], tile_n], values[tile_m, tile_n])
+            return out
+
+        values = torch.randn(64, 8, device=DEVICE, dtype=torch.float32)
+        indices = torch.zeros(64, device=DEVICE, dtype=torch.int32)
+
+        code, result = code_and_output(
+            atomic_add_shared_output_tiles,
+            (values, indices),
+            block_sizes=[16, 8],
+        )
+
+        torch.testing.assert_close(result, values.sum(dim=0, keepdim=True))
+        self.assertIn("one_hot", code)
+        self.assertIn("_inplace_indices=", code)
+
+    def test_tensor_index_atomic_add_scalar_middle_dim(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def atomic_add_scalar_middle_dim(
+            values: torch.Tensor, indices: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.zeros(
+                [12, 1, values.size(1)], device=values.device, dtype=values.dtype
+            )
+            for tile_m, tile_n in hl.tile(values.size()):
+                hl.atomic_add(
+                    out,
+                    [indices[tile_m], 0, tile_n],
+                    values[tile_m, tile_n],
+                )
+            return out
+
+        values = torch.randn(16, 17, device=DEVICE, dtype=torch.float32)
+        indices = torch.randint(0, 12, (16,), device=DEVICE, dtype=torch.int32)
+
+        code, result = code_and_output(
+            atomic_add_scalar_middle_dim,
+            (values, indices),
+            block_sizes=[16, 32],
+        )
+
+        expected = _scatter_add_dim0_expected(values.unsqueeze(1), indices, 12)
+        torch.testing.assert_close(result, expected)
+        self.assertIn("one_hot", code)
+        self.assertIn("dot_general", code)
+        self.assertNotIn("value[:, :, :17]", code)
+
+    def test_tensor_index_atomic_add_value_shape_raises(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def atomic_add_bad_value_shape(
+            values: torch.Tensor, indices: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.zeros_like(values)
+            for tile_m, tile_n in hl.tile(values.size()):
+                hl.atomic_add(out, [indices[tile_m], tile_n], values[tile_m, 0])
+            return out
+
+        values = torch.randn(16, 4, device=DEVICE, dtype=torch.float32)
+        indices = torch.arange(16, device=DEVICE, dtype=torch.int32)
 
         with self.assertRaisesRegex(
-            NotImplementedError,
-            "tensor-indexed memory op is not supported for op=atomic_add",
+            helion.exc.BackendUnsupported,
+            "value shape must match indexed target shape",
         ):
             code_and_output(
-                atomic_add_tensor_index,
+                atomic_add_bad_value_shape,
                 (values, indices),
-                block_size=16,
+                block_sizes=[16, 4],
+            )
+
+    def test_tensor_index_atomic_add_foreach_raises(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def foreach_atomic_add(
+            values: torch.Tensor, indices: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            out = torch.zeros_like(values)
+            other = torch.empty_like(values)
+            for first_m, first_n in hl.tile(values.size()):
+                hl.atomic_add(
+                    out,
+                    [indices[first_m], first_n],
+                    values[first_m, first_n],
+                )
+            for second_m, second_n in hl.tile(values.size()):
+                other[second_m, second_n] = values[second_m, second_n]
+            return out, other
+
+        values = torch.randn(16, 256, device=DEVICE, dtype=torch.float32)
+        indices = torch.zeros(16, device=DEVICE, dtype=torch.int32)
+
+        with self.assertRaisesRegex(helion.exc.InternalError, "ForEach"):
+            code_and_output(
+                foreach_atomic_add,
+                (values, indices),
+                block_sizes=[16, 128, 16, 128],
+            )
+
+    def test_associative_scan_reverse_raises(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def reverse_scan(values: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(values)
+            for tile_m, tile_n in hl.tile(values.size()):
+                out[tile_m, tile_n] = hl.associative_scan(
+                    torch.add, values[tile_m, tile_n], dim=0, reverse=True
+                )
+            return out
+
+        values = torch.randn(16, 4, device=DEVICE, dtype=torch.float32)
+
+        with self.assertRaisesRegex(
+            helion.exc.BackendUnsupported,
+            "reverse associative_scan",
+        ):
+            code_and_output(reverse_scan, (values,), block_sizes=[16, 4])
+
+    def test_tuple_associative_scan_segmented(self) -> None:
+        values = torch.randn(16, 4, device=DEVICE, dtype=torch.float32)
+        indices = torch.tensor(
+            [0, 0, 1, 1, 1, 3, 4, 4, 6, 7, 7, 7, 8, 10, 10, 11],
+            device=DEVICE,
+            dtype=torch.int32,
+        )
+
+        code, (result_values, result_indices) = code_and_output(
+            pallas_tuple_associative_scan,
+            (values, indices),
+            block_sizes=[16, 4],
+        )
+
+        host_values = values.cpu()
+        host_indices = indices.cpu()
+        expected_values = torch.empty_like(host_values)
+        for i in range(values.size(0)):
+            if i == 0 or host_indices[i].item() != host_indices[i - 1].item():
+                expected_values[i] = host_values[i]
+            else:
+                expected_values[i] = expected_values[i - 1] + host_values[i]
+        expected_indices = host_indices.unsqueeze(1).expand_as(host_values)
+        torch.testing.assert_close(result_values.cpu(), expected_values)
+        torch.testing.assert_close(result_indices.cpu(), expected_indices)
+        self.assertIn("jnp.stack", code)
+        self.assertIn(".shape[0]", code)
+        self.assertNotIn(".at[", code)
+        self.assertIn("jnp.where", code)
+
+    def test_associative_scan_nonzero_and_negative_dims(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def scan_dim_one(values: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(values)
+            for tile_m, tile_n in hl.tile(values.size()):
+                out[tile_m, tile_n] = hl.associative_scan(
+                    torch.add, values[tile_m, tile_n], dim=1
+                )
+            return out
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def scan_dim_negative_one(values: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(values)
+            for tile_m, tile_n in hl.tile(values.size()):
+                out[tile_m, tile_n] = hl.associative_scan(
+                    torch.add, values[tile_m, tile_n], dim=-1
+                )
+            return out
+
+        for shape in ((8, 4), (8, 1)):
+            values = torch.randn(*shape, device=DEVICE)
+            expected = torch.cumsum(values, dim=1)
+            for kernel in (scan_dim_one, scan_dim_negative_one):
+                with self.subTest(shape=shape, kernel=kernel.fn.__name__):
+                    _code, result = code_and_output(
+                        kernel,
+                        (values,),
+                        block_sizes=list(shape),
+                    )
+                    torch.testing.assert_close(result, expected)
+
+    def test_associative_scan_combine_preserves_casts_and_kwargs(self) -> None:
+        values = torch.arange(1, 65, device=DEVICE, dtype=torch.int32).reshape(16, 4)
+
+        code, result = code_and_output(
+            pallas_associative_scan_cast_kwargs,
+            (values,),
+            block_sizes=[16, 4],
+        )
+
+        expected = torch.cumsum(values, dim=0).to(values.dtype)
+        torch.testing.assert_close(result, expected)
+        self.assertIn("lax.convert_element_type", code)
+        self.assertIn("* 2", code)
+
+    def test_associative_scan_combine_int64_cast_raises(self) -> None:
+        values = torch.arange(1, 65, device=DEVICE, dtype=torch.int32).reshape(16, 4)
+
+        with self.assertRaisesRegex(
+            helion.exc.BackendUnsupported,
+            "associative_scan combine dtype torch.int64",
+        ):
+            code_and_output(
+                pallas_associative_scan_int64_roundtrip,
+                (values,),
+                block_sizes=[16, 4],
             )
 
     def test_scatter_store_multiple_tensor_indices_raises(self) -> None:


### PR DESCRIPTION
Stacked PRs:
 * #2962
 * #2957
 * #2956
 * #2955
 * #2954
 * __->__#2953
 * #2952
 * #2951
 * #2949
 * #2948
 * #2947
 * #2946
 * #2945
 * #2944
 * #2943
 * #2942


--- --- ---

### Support Pallas segment reduction primitives


Example fixed: segment_reduction under Pallas.

Compiler/runtime side: add Pallas tuple `associative_scan` lowering for the segmented combine pattern and lower tensor-indexed `atomic_add` through one-hot scatter-add plus guarded read/modify/write serialization using `BlockSpec` metadata.

Why needed: segment reductions need both tuple scan state and indexed accumulation, and Pallas cannot use the existing Triton-style atomic path directly.
