### PR TITLE
Support bounded Pallas inner block specs

### DIFF
--- a/examples/mamba2_chunk_scan.py
+++ b/examples/mamba2_chunk_scan.py
@@ -19,13 +19,14 @@ from helion._testing import DEVICE
 from helion._testing import HALF_DTYPE
 from helion._testing import run_example
 import helion.language as hl
+from helion.runtime.settings import _get_backend
 
 
 # %%
 # Helion Kernel Implementation
 # ----------------------------
 @helion.kernel()
-def helion_mamba2_chunk_scan_kernel(
+def _helion_mamba2_chunk_scan_kernel_scalar(
     cb: torch.Tensor,
     x: torch.Tensor,
     dt: torch.Tensor,
@@ -121,7 +122,7 @@ def helion_mamba2_chunk_scan_kernel(
                 torch.float32
             )
             cb_local = (cb_local * dt_local[None, :]).to(dtype)
-            pred = (tile_m.index + 0)[:, None] >= (tile_k.index + 0)[None, :]
+            pred = tile_m.index[:, None] >= tile_k.index[None, :]
             cb_local = torch.where(pred, cb_local, torch.zeros_like(cb_local))
             x_local = x[
                 tile_b.begin,
@@ -141,6 +142,152 @@ def helion_mamba2_chunk_scan_kernel(
         ] = acc_o.to(dtype=dtype)
 
     return out
+
+
+@helion.kernel()
+def _helion_mamba2_chunk_scan_kernel_pallas(
+    cb: torch.Tensor,
+    x: torch.Tensor,
+    dt: torch.Tensor,
+    dA_cumsum: torch.Tensor,
+    C: torch.Tensor,
+    prev_states: torch.Tensor,
+    D: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Pallas implementation that computes an aligned block of heads per program.
+
+    TPU Mosaic cannot lower bf16 stores to a scalar middle ``nheads`` lane.
+    Owning a head block keeps the output store structural while preserving the
+    scalar-head implementation for non-Pallas backends.
+    """
+
+    batch, nchunks, ngroups, chunk_size, _ = cb.shape
+    _, seqlen, nheads, headdim = x.shape
+    _, _, _, dstate = C.shape
+    assert nchunks == (seqlen + chunk_size - 1) // chunk_size
+    assert nheads % ngroups == 0
+
+    nheads = hl.specialize(nheads)
+    ngroups = hl.specialize(ngroups)
+    heads_per_group = hl.specialize(nheads // ngroups)
+    assert heads_per_group >= 8 and heads_per_group % 8 == 0, (
+        "Pallas Mamba2 chunk scan requires heads_per_group >= 8 and divisible by 8"
+    )
+
+    block_h = hl.register_block_size(8)
+    block_m = hl.register_block_size(chunk_size)
+    block_n = hl.register_block_size(headdim)
+    block_k = hl.register_block_size(64, 64)
+    dstate = hl.specialize(dstate)
+
+    assert cb.shape == (batch, nchunks, ngroups, chunk_size, chunk_size)
+    assert x.shape == (batch, seqlen, nheads, headdim)
+    assert dt.shape == (batch, nheads, nchunks, chunk_size)
+    assert dA_cumsum.shape == (batch, nheads, nchunks, chunk_size)
+    assert C.shape == (batch, seqlen, ngroups, dstate)
+    assert prev_states.shape == (batch, nchunks, nheads, headdim, dstate)
+    assert D.shape == (nheads,)
+
+    dtype = cb.dtype
+    accum_dtype = torch.float32
+    assert (
+        x.dtype
+        == dt.dtype
+        == dA_cumsum.dtype
+        == C.dtype
+        == prev_states.dtype
+        == D.dtype
+        == dtype
+    )
+
+    out = torch.empty_like(x)
+
+    p = 1.44269504
+
+    for tile_g, tile_h, tile_m, tile_n, tile_b, tile_c in hl.tile(
+        [ngroups, heads_per_group, chunk_size, headdim, batch, nchunks],
+        block_size=[1, block_h, block_m, block_n, 1, 1],
+    ):
+        heads = tile_g.begin * heads_per_group + tile_h.index
+        acc_o = hl.zeros([tile_h, tile_m, tile_n], dtype=accum_dtype)
+        dA_cumsum_local_m = dA_cumsum[tile_b.begin, heads, tile_c.begin, tile_m].to(
+            accum_dtype
+        )
+        scale_m_local = torch.exp2(dA_cumsum_local_m * p)
+
+        C_local = C[
+            tile_b.begin,
+            tile_m.index + tile_c.begin * chunk_size,
+            tile_g.begin,
+            :,
+        ]
+        C_local = C_local[None, :, :] + hl.zeros([tile_h, tile_m, dstate], dtype=dtype)
+        prev_states_local = prev_states[tile_b.begin, tile_c.begin, heads, tile_n, :]
+        acc_o = acc_o + torch.bmm(
+            C_local.to(accum_dtype),
+            prev_states_local.transpose(1, 2).to(accum_dtype),
+        )
+        acc_o *= scale_m_local[:, :, None]
+
+        for tile_k in hl.tile((tile_m.id + 1) * block_m, block_size=block_k):
+            cb_local = cb[
+                tile_b.begin,
+                tile_c.begin,
+                tile_g.begin,
+                tile_m,
+                tile_k,
+            ]
+            cb_local = cb_local[None, :, :] + hl.zeros(
+                [tile_h, tile_m, tile_k], dtype=dtype
+            )
+            dA_cumsum_local_k = dA_cumsum[tile_b.begin, heads, tile_c.begin, tile_k].to(
+                accum_dtype
+            )
+            cb_local *= torch.exp2(
+                dA_cumsum_local_m[:, :, None] * p - dA_cumsum_local_k[:, None, :] * p
+            )
+            dt_local = dt[tile_b.begin, heads, tile_c.begin, tile_k].to(accum_dtype)
+            cb_local = (cb_local * dt_local[:, None, :]).to(dtype)
+            pred = tile_m.index[:, None] >= tile_k.index[None, :]
+            cb_local = torch.where(
+                pred[None, :, :], cb_local, torch.zeros_like(cb_local)
+            )
+            x_local = x[
+                tile_b.begin,
+                tile_c.begin * chunk_size + tile_k.index,
+                heads,
+                tile_n,
+            ].transpose(0, 1)
+            acc_o = acc_o + torch.bmm(cb_local.to(accum_dtype), x_local.to(accum_dtype))
+
+        D_local = D[heads].to(accum_dtype)
+        x_residual = (
+            x[
+                tile_b.begin,
+                tile_c.begin * chunk_size + tile_m.index,
+                heads,
+                tile_n,
+            ]
+            .transpose(0, 1)
+            .to(accum_dtype)
+        )
+        acc_o += x_residual * D_local[:, None, None]
+        out[
+            tile_b.begin,
+            tile_c.begin * chunk_size + tile_m.index,
+            heads,
+            tile_n,
+        ] = acc_o.transpose(0, 1).to(dtype=dtype)
+
+    return out
+
+
+helion_mamba2_chunk_scan_kernel = (
+    _helion_mamba2_chunk_scan_kernel_pallas
+    if _get_backend() == "pallas"
+    else _helion_mamba2_chunk_scan_kernel_scalar
+)
 
 
 # %%

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -1081,14 +1081,14 @@ class PallasBackend(Backend):
             if bid not in analyzer.required_alignments:
                 continue
             requirement_alignment = analyzer.required_alignments[bid]
-            dim_size = next_power_of_2(max(spec.size_hint, 1))
-            # Cap the alignment requirement by the tensor lane dim: when
-            # the dim is smaller than the requirement, the full-dim access
-            # is always aligned at offset 0 so block_size = dim_size is
-            # safe.  When the dim is at least as big as the requirement,
-            # ``min`` returns ``requirement_alignment`` and the strict
-            # floor still applies (used by aot_example.sum_aot, n=256).
-            spec.update_min(min(requirement_alignment, dim_size))
+            if spec.bounded_by_block_id is None:
+                dim_size = next_power_of_2(max(spec.size_hint, 1))
+                # Ordinary dimensions can use their full extent when it is
+                # smaller than the native alignment. Bounded tiles have a
+                # placeholder size_hint of 0; their requirement was already
+                # capped against the backing tensor by the access analyzer.
+                requirement_alignment = min(requirement_alignment, dim_size)
+            spec.update_min(requirement_alignment)
 
         # Propagate alignment minimums from inner tiles to their bounding outer tiles.
         block_specs_by_id = {
@@ -1096,13 +1096,19 @@ class PallasBackend(Backend):
             for spec in block_specs
             if isinstance(spec, BlockSizeSpec)
         }
-        for spec in block_specs_by_id.values():
-            bounded_by = spec.bounded_by_block_id
-            if bounded_by is None:
-                continue
-            outer_spec = block_specs_by_id.get(bounded_by)
-            if outer_spec is not None:
+        changed = True
+        while changed:
+            changed = False
+            for spec in block_specs_by_id.values():
+                bounded_by = spec.bounded_by_block_id
+                if bounded_by is None:
+                    continue
+                outer_spec = block_specs_by_id.get(bounded_by)
+                if outer_spec is None:
+                    continue
+                previous_min = outer_spec.min_size
                 outer_spec.update_min(spec.min_size)
+                changed |= outer_spec.min_size != previous_min
 
     def tunable_fragments(self) -> dict[str, ConfigSpecFragment]:
         return {}

--- a/helion/_compiler/pallas/plan_tiling.py
+++ b/helion/_compiler/pallas/plan_tiling.py
@@ -286,6 +286,33 @@ def _detect_indexing_pattern(
     raise AssertionError(f"Unrecognized indexing pattern for pallas backend {idx}")
 
 
+def _block_spec_alignment_extent(
+    block_id: int,
+    env: CompileEnvironment,
+    config: Config,
+) -> int | None:
+    """Return the Pallas BlockSpec extent used for alignment checks."""
+
+    owner_block_id = block_id
+    seen: set[int] = set()
+    while owner_block_id not in seen:
+        seen.add(owner_block_id)
+        try:
+            spec = env.config_spec.block_sizes.block_id_lookup(owner_block_id)
+        except KeyError:
+            break
+        owner = spec.owner_relative_bounded_by_block_id
+        if owner is None:
+            break
+        owner_block_id = owner
+    else:
+        # Cycle guard: refuse to infer an alignment extent from owner loops.
+        return None
+
+    block_size = env.block_sizes[owner_block_id].from_config(config)
+    return block_size if isinstance(block_size, int) else None
+
+
 def _update_tiling_decision(
     tensor: torch.Tensor,
     pattern: IndexingPattern,
@@ -346,8 +373,8 @@ def _update_tiling_decision(
         pass
 
     if isinstance(pattern, (TilePattern, TileBeginWithOffsetPattern)):
-        block_size = env.block_sizes[pattern.block_id].from_config(config)
-        if isinstance(block_size, int):
+        alignment_extent = _block_spec_alignment_extent(pattern.block_id, env, config)
+        if alignment_extent is not None:
             from ..compile_environment import CompileEnvironment
 
             backend = CompileEnvironment.current().backend
@@ -360,10 +387,10 @@ def _update_tiling_decision(
             required_alignment = backend._get_pallas_required_alignment(
                 dim_from_end, tensor.ndim, bitwidth
             )
+            dim_size = tensor.shape[tensor_dim]
 
-            if (
-                block_size < tensor.shape[tensor_dim]
-                and block_size % required_alignment != 0
+            if alignment_extent % required_alignment != 0 and (
+                not isinstance(dim_size, int) or alignment_extent < dim_size
             ):
                 _disallow_tiling()
 

--- a/helion/_compiler/pallas/vmem_scalar_load.py
+++ b/helion/_compiler/pallas/vmem_scalar_load.py
@@ -74,10 +74,14 @@ def _resident_extent(state: CodegenState, tensor: torch.Tensor, dim: int) -> int
 
     tiling = state.device_function.pallas_tensor_dim_tilings[id(tensor)][dim]
     if tiling.can_tile and len(tiling.block_ids) == 1:
+        block_id = tiling.block_ids[0]
+        from helion._compiler.pallas.codegen import _bounded_local_owner_block_id
+
+        owner_block_id = _bounded_local_owner_block_id(state, block_id, tensor, dim)
+        if owner_block_id is not None:
+            block_id = owner_block_id
         block_size = (
-            CompileEnvironment.current()
-            .block_sizes[tiling.block_ids[0]]
-            .from_config(state.config)
+            CompileEnvironment.current().block_sizes[block_id].from_config(state.config)
         )
         if not isinstance(block_size, int):
             raise NotImplementedError(

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -41,7 +41,6 @@ from helion._testing import skipIfXPU
 from helion._testing import skipUnlessTensorDescriptor
 from helion._testing import xfailIfPallas
 from helion._testing import xfailIfPallasInterpret
-from helion._testing import xfailIfPallasTpu
 from helion.runtime.config import Config
 from helion.runtime.ref_mode import is_ref_mode_enabled
 
@@ -2711,8 +2710,8 @@ class TestExamples(RefEagerTestBase, TestCase):
     def test_mamba2_chunk_state(self):
         batch, nheads, ngroups, seqlen, chunk_size, headdim, dstate = (
             2,
-            8,
-            1,
+            16,
+            2,
             256,
             64,
             32,
@@ -2741,7 +2740,6 @@ class TestExamples(RefEagerTestBase, TestCase):
             rtol=0.1,
         )
 
-    @xfailIfPallasTpu("BlockSpec tiling failure")
     def test_mamba2_chunk_scan(self):
         batch, nheads, ngroups, seqlen, chunk_size, headdim, dstate = (
             2,
@@ -2753,7 +2751,9 @@ class TestExamples(RefEagerTestBase, TestCase):
             16,
         )
         nchunks = seqlen // chunk_size
-        cb = torch.zeros(
+        torch.manual_seed(0)
+        # Keep the upper triangle nonzero so a missing causal mask is observable.
+        cb = 0.05 + 0.05 * torch.rand(
             batch,
             nchunks,
             ngroups,
@@ -2762,18 +2762,19 @@ class TestExamples(RefEagerTestBase, TestCase):
             dtype=HALF_DTYPE,
             device=DEVICE,
         )
-        torch.manual_seed(0)
-        x = torch.zeros(batch, seqlen, nheads, headdim, dtype=HALF_DTYPE, device=DEVICE)
-        dt = torch.zeros(
+        x = 0.25 + 0.25 * torch.rand(
+            batch, seqlen, nheads, headdim, dtype=HALF_DTYPE, device=DEVICE
+        )
+        dt = 0.4 + 0.2 * torch.rand(
             batch, nheads, nchunks, chunk_size, dtype=HALF_DTYPE, device=DEVICE
         )
-        dA_cumsum = torch.zeros(
+        dA_cumsum = 0.02 * torch.randn(
             batch, nheads, nchunks, chunk_size, dtype=HALF_DTYPE, device=DEVICE
         )
-        # Keep the recurrence path deterministic and non-zero so backend bugs
-        # cannot hide behind allocator state when output buffers are recycled.
-        C = torch.randn(batch, seqlen, ngroups, dstate, dtype=HALF_DTYPE, device=DEVICE)
-        prev_states = torch.randn(
+        C = 0.1 * torch.randn(
+            batch, seqlen, ngroups, dstate, dtype=HALF_DTYPE, device=DEVICE
+        )
+        prev_states = 0.1 * torch.randn(
             batch,
             nchunks,
             nheads,
@@ -2782,19 +2783,51 @@ class TestExamples(RefEagerTestBase, TestCase):
             dtype=HALF_DTYPE,
             device=DEVICE,
         )
-        D_param = torch.zeros(nheads, dtype=HALF_DTYPE, device=DEVICE)
+        D_param = torch.linspace(0.6, 1.0, nheads, dtype=HALF_DTYPE, device=DEVICE)
         args = (cb, x, dt, dA_cumsum, C, prev_states, D_param)
 
         mod = import_path(EXAMPLES_DIR / "mamba2_chunk_scan.py")
         expected = mod.ref_chunk_scan(*args)
+        atol = 0.1
+        rtol = 0.1
+        expected_without_scan = mod.ref_chunk_scan(
+            torch.zeros_like(cb),
+            x,
+            dt,
+            dA_cumsum,
+            C,
+            prev_states,
+            D_param,
+        )
+        expected_without_residual = mod.ref_chunk_scan(
+            cb,
+            x,
+            dt,
+            dA_cumsum,
+            C,
+            prev_states,
+            torch.zeros_like(D_param),
+        )
+        assert not torch.allclose(
+            expected.float(),
+            expected_without_scan.float(),
+            atol=atol,
+            rtol=rtol,
+        ), "test data must fail when the chunk scan contribution is zeroed"
+        assert not torch.allclose(
+            expected.float(),
+            expected_without_residual.float(),
+            atol=atol,
+            rtol=rtol,
+        ), "test data must fail when the residual contribution is zeroed"
 
         check_example(
             "mamba2_chunk_scan",
             args,
             expected,
             fn_name="helion_mamba2_chunk_scan_kernel",
-            atol=0.1,
-            rtol=0.1,
+            atol=atol,
+            rtol=rtol,
         )
 
     @skipIfRocm("failure on rocm")

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1919,6 +1919,30 @@ class TestPallas(TestCase):
         torch.testing.assert_close(result, x + offsets[None, :])
         self.assertIn("jnp.arange", code)
 
+    @xfailIfPallasTpu("Mosaic does not support DMA for bool outputs")
+    def test_bool_relayout_store(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def pallas_bool_relayout_store(x: torch.Tensor) -> torch.Tensor:
+            m, n = x.size()
+            out = torch.empty([m, n], dtype=torch.bool, device=x.device)
+            for tile_m, tile_n in hl.tile([m, n]):
+                mask = (x[tile_m, 0] > 0).view(tile_m.block_size)
+                mask_2d = mask[:, None].expand(tile_m.block_size, tile_n.block_size)
+                out[tile_m, tile_n] = mask_2d
+            return out
+
+        x = torch.randn(16, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_bool_relayout_store,
+            (x,),
+            block_sizes=[16, 128],
+        )
+
+        expected = (x[:, :1] > 0).expand_as(result)
+        torch.testing.assert_close(result, expected)
+        self._assert_numeric_mask_reshape(code, r"\[[^\]]*, 1\]")
+        self.assertRegex(code, r"lax\.convert_element_type\([^\n]+, jnp\.bool_\)")
+
     def test_bool_view_expand_where(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def pallas_bool_view_expand_where(x: torch.Tensor) -> torch.Tensor:
@@ -6044,6 +6068,24 @@ class TestPallas(TestCase):
         self.assertNotIn((0, 0, 32, 0), pad_dims)
         self.assertNotIn((1, 0, 32, 0), pad_dims)
 
+    def test_pallas_loop_prefixed_row_slab_f32_d64_no_dma(self) -> None:
+        x = torch.randn(2, 48, 4, 64, device=DEVICE, dtype=torch.float32)
+        offsets = torch.tensor([0, 11, 37], device=DEVICE, dtype=torch.int32)
+        code, result = code_and_output(
+            pallas_owner_prefixed_row_slab_sum,
+            (x, offsets),
+            block_sizes=[8],
+            pallas_loop_type="fori_loop",
+        )
+        self.assertIn("jax.lax.fori_loop", code)
+        self.assertNotIn("_pipeline_arg_indices=", code)
+        self.assertNotIn("pltpu.make_async_copy", code)
+        self.assertIn("pl.ds(", code)
+        ref = torch.stack(
+            [x[g, int(offsets[g]) : int(offsets[g + 1])].sum(dim=0) for g in range(2)]
+        )
+        torch.testing.assert_close(result, ref, rtol=1e-3, atol=1e-3)
+
     def test_tile_id_per_block_accumulator(self) -> None:
         """Writing to ``out[tile.id, :]`` stores one row per outer grid iter.
 
@@ -6504,6 +6546,27 @@ class TestPallas(TestCase):
             r"_BLOCK_SIZE_\d+\), _BLOCK_SIZE_\d+\)",
         )
         torch.testing.assert_close(result, x * 2)
+
+    def test_nested_bounded_tiles_propagate_alignment_minimum_to_root(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=False)
+        def fn(x: torch.Tensor) -> torch.Tensor:
+            m = x.size(0)
+            outer_block = hl.register_block_size(m)
+            out = torch.empty_like(x)
+            for outer in hl.tile(m, block_size=outer_block):
+                for middle in hl.tile(outer.begin, outer.end):
+                    for inner in hl.tile(middle.begin, middle.end):
+                        out[inner, :] = x[inner, :] * 2
+            return out
+
+        x = torch.randn(65, 128, device=DEVICE, dtype=torch.float32)
+        config = helion.Config(
+            block_sizes=[1, 8, 8],
+            pallas_loop_type="fori_loop",
+        )
+        bound = fn.bind((x,))
+        bound.config_spec.normalize(config)
+        self.assertEqual(config["block_sizes"], [8, 8, 8])
 
     def test_squeeze_slice_access(self) -> None:
         """Test for the [None, :] indexing pattern (subscript index for slice >= tensor_ndim)"""
@@ -7996,6 +8059,32 @@ class TestPallas(TestCase):
         )
 
         torch.testing.assert_close(result[:, :, 16:, :], x[:, :, 16:, :])
+
+    def test_emit_pipeline_suffix_store_ending_at_tensor_dim_not_clamped(
+        self,
+    ) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def high_rank_suffix_store(x: torch.Tensor) -> torch.Tensor:
+            B, H, M, D = x.size()
+            out = torch.empty_like(x)
+            for tile_b, tile_h in hl.tile([B, H], block_size=[1, 1]):
+                b_idx = tile_b.begin
+                h_idx = tile_h.begin
+                for tile_m in hl.tile(16, M, block_size=128):
+                    out[b_idx, h_idx, tile_m, :] = x[b_idx, h_idx, tile_m, :]
+            return out
+
+        x = torch.randn(2, 8, 250, 128, device=DEVICE, dtype=torch.bfloat16)
+        code = high_rank_suffix_store.bind((x,)).to_code(
+            helion.Config(pallas_loop_type="emit_pipeline")
+        )
+
+        self.assertIn("pltpu.emit_pipeline", code)
+        self.assertIn("out_specs=", code)
+        out_specs = code.split("out_specs=", 1)[1].split("compiler_params=", 1)[0]
+        self.assertIn("pl.BoundedSlice", out_specs)
+        self.assertIn("pl.ds(", out_specs)
+        self.assertNotIn("jnp.minimum(", out_specs)
 
     def test_pallas_0d_tensor_arg(self) -> None:
         """0D tensor arguments shouldn't cause positional argument shift in block specs."""

--- a/test/test_pallas_load_store.py
+++ b/test/test_pallas_load_store.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import patch
+
 import torch
 from torch.testing._internal.common_utils import instantiate_parametrized_tests
 from torch.testing._internal.common_utils import parametrize
@@ -618,6 +621,51 @@ class TestPallasVmemScalarLoad(TestCase):
         code, result = code_and_output(row_flip_load, (source.to(DEVICE),))
         self.assertNotIn("pltpu.roll", code)
         torch.testing.assert_close(result, source.flip(0).to(DEVICE))
+
+    def test_runtime_negative_row_index_32bit(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def negative_row_load(x: torch.Tensor) -> torch.Tensor:
+            rows, _cols = x.shape
+            out = torch.empty_like(x)
+            for row in hl.grid(rows):
+                out[row, :] = x[row - rows, :]
+            return out
+
+        source = torch.arange(17 * 65, dtype=torch.float32).reshape(17, 65)
+        code, result = code_and_output(negative_row_load, (source.to(DEVICE),))
+        self.assertNotIn("pltpu.roll", code)
+        self.assertIn("jnp.where", code)
+        torch.testing.assert_close(result, source.to(DEVICE))
+
+    def test_bounded_owner_sets_resident_extent(self) -> None:
+        from helion._compiler.compile_environment import CompileEnvironment
+        from helion._compiler.pallas.vmem_scalar_load import _resident_extent
+
+        tensor = torch.empty((128, 64), dtype=torch.bfloat16)
+        dim_tilings = [
+            SimpleNamespace(can_tile=True, block_ids=[1]),
+            SimpleNamespace(can_tile=False, block_ids=[]),
+        ]
+        state = SimpleNamespace(
+            config=object(),
+            device_function=SimpleNamespace(
+                pallas_tensor_dim_tilings={id(tensor): dim_tilings}
+            ),
+        )
+        env = SimpleNamespace(
+            block_sizes=[
+                SimpleNamespace(from_config=lambda config: 64),
+                SimpleNamespace(from_config=lambda config: 32),
+            ]
+        )
+        with (
+            patch.object(CompileEnvironment, "current", return_value=env),
+            patch(
+                "helion._compiler.pallas.codegen._bounded_local_owner_block_id",
+                return_value=0,
+            ),
+        ):
+            self.assertEqual(_resident_extent(state, tensor, 0), 64)  # type: ignore[arg-type]
 
     @parametrize(
         "dtype",


### PR DESCRIPTION
Stacked PRs:
 * #2962
 * #2957
 * #2956
 * #2955
 * __->__#2954
 * #2953
 * #2952
 * #2951
 * #2949
 * #2948
 * #2947
 * #2946
 * #2945
 * #2944
 * #2943
 * #2942


--- --- ---

### Support bounded Pallas inner block specs


Example fixed: mamba2_chunk_scan under Pallas, plus bounded jagged row-store patterns.

Compiler/runtime side: add the Pallas Mamba head-block variant and focused regression coverage for bounded owner-relative BlockSpec addressing, exact row stores, and bool-mask selection behavior enabled by the earlier compiler commits in this stack.

Why needed: the Mamba scan needs an 8-aligned grouped-head contract on Pallas rather than unsafe scalar-head bf16 stores, and the bounded inner-tile tests keep the owner-relative BlockSpec behavior from regressing.
