### PR TITLE
Honor Pallas shared-output BlockSpec metadata

### DIFF
--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -168,6 +168,10 @@ class GenerateAST(NodeVisitor, CodegenInterface):
             self,
         )
         CodegenInterface.__init__(self, self.device_function)
+        self._pallas_direct_cases = (
+            CompileEnvironment.current().backend.name == "pallas"
+            and len(func.device_ir.root_ids) > 1
+        )
 
         # Decide once which sibling for-loops need a tl.debug_barrier()
         # to make global writes visible to subsequent reads.
@@ -214,6 +218,54 @@ class GenerateAST(NodeVisitor, CodegenInterface):
         if loops := self.active_device_loops[block_idx]:
             return loops[-1].strategy.mask_var(block_idx)
         return None
+
+    def _wrap_pallas_direct_case_body(
+        self,
+        root_id: int,
+        body: list[ast.AST],
+    ) -> None:
+        """Guard each Pallas root body by its immutable launch PID range."""
+        if not self._pallas_direct_cases:
+            return
+        fn_name = self.device_function.new_var(f"helion_case_root_{root_id}")
+        pid = self.device_function.pid
+        assert isinstance(pid, ForEachProgramID)
+        assert root_id < len(pid.cases), "missing Pallas direct case PID metadata"
+        case = pid.cases[root_id]
+        # ``pl.when`` traces inactive bodies. A zero-sized case uses safe,
+        # nonzero PID radices, so tracing its logical empty store against that
+        # physical ref would produce mismatched shapes.
+        if any(info.numel == 0 for info in case.pid_info):
+            case_body = [create(ast.Pass)]
+        else:
+            case_body = list(body) or [create(ast.Pass)]
+        cdivs = [case.total_pids_expr(is_device=True) for case in pid.cases]
+        start = "0" if root_id == 0 else " + ".join(cdivs[:root_id])
+        end = " + ".join(cdivs[: root_id + 1])
+        condition = (
+            f"({pid.shared_pid_var} >= ({start})) & ({pid.shared_pid_var} < ({end}))"
+        )
+        body[:] = [
+            create(
+                ast.FunctionDef,
+                name=fn_name,
+                args=create(
+                    ast.arguments,
+                    posonlyargs=[],
+                    args=[],
+                    vararg=None,
+                    kwonlyargs=[],
+                    kw_defaults=[],
+                    kwarg=None,
+                    defaults=[],
+                ),
+                body=case_body,
+                decorator_list=[expr_from_string(f"pl.when({condition})")],
+                type_comment=None,
+                returns=None,
+                type_params=[],
+            )
+        ]
 
     def _phase_checker(self, root_id: int) -> LoopDependencyChecker:
         phase_idx = self.host_function.device_ir.phase_for_root(root_id)
@@ -1035,13 +1087,17 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                     self.device_function.set_pid(
                         ForEachProgramID(
                             self.device_function.new_var("pid_shared", dce=False),
+                            pallas_direct_cases=self._pallas_direct_cases,
                         )
                     )
                     self.device_function.body.extend(
                         # pyrefly: ignore [missing-attribute]
                         self.device_function.pid.codegen_pid_init()
                     )
-                if node._root_id < len(self.host_function.device_ir.root_ids) - 1:
+                if (
+                    self._pallas_direct_cases
+                    or node._root_id < len(self.host_function.device_ir.root_ids) - 1
+                ):
                     body = []
                 else:
                     # This is the last top level for, dont emit more if statements
@@ -1139,9 +1195,13 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                         self.host_function.device_ir.phase_for_root(node._root_id)
                     )
 
+                self._wrap_pallas_direct_case_body(node._root_id, body)
+
                 # If we are in a multi top level loop, for all loops except for the last one
                 # emit ifthenelse blocks
-                if node._root_id < len(self.host_function.device_ir.root_ids) - 1:
+                if self._pallas_direct_cases:
+                    self.device_function.body.extend(body)
+                elif node._root_id < len(self.host_function.device_ir.root_ids) - 1:
                     block = (
                         self.device_function.body
                         if self.next_else_block is None

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -108,6 +108,13 @@ _PallasFlatDecompValue = (
         _PallasLaunchScalar,
         _PallasLaunchScalar,
     ]
+    | tuple[
+        _PallasLaunchScalar,
+        _PallasLaunchScalar,
+        _PallasLaunchScalar,
+        _PallasLaunchScalar,
+        _PallasLaunchScalar,
+    ]
 )
 
 
@@ -1265,6 +1272,7 @@ class PallasBackend(Backend):
                         bid_stride,
                         safe_num_blocks,
                         case_start,
+                        case_total,
                     )
                 case_start = _pallas_add_launch_values(case_start, case_total)
 
@@ -1623,11 +1631,6 @@ class PallasBackend(Backend):
             # Tensor-index atomic_add lowers to a local read/modify/write. It is
             # correct across programs only when the launcher can serialize every
             # program sharing the target BlockSpec tile.
-            if any(config.flatten_loops):
-                raise NotImplementedError(
-                    "Pallas tensor-indexed atomic_add does not support flattened "
-                    "loops without shared-output BlockSpec metadata"
-                )
             if sorted_args is None or block_spec_info is None:
                 raise NotImplementedError(
                     "Pallas tensor-indexed atomic_add requires block spec info "
@@ -1660,11 +1663,14 @@ class PallasBackend(Backend):
                         "for shared-output serialization"
                     )
                 _block_shape, grid_dims = block_info
-                if any(isinstance(grid_dim, tuple) for grid_dim in grid_dims):
+                if any(
+                    isinstance(grid_dim, tuple) and len(grid_dim) >= 4
+                    for grid_dim in grid_dims
+                ):
                     raise NotImplementedError(
                         "Pallas tensor-indexed atomic_add does not support "
-                        "ForEach or flattened grid decompositions without "
-                        "shared-output BlockSpec metadata"
+                        "ForEach grids because the current launcher cannot "
+                        "isolate case-specific output stores"
                     )
         if block_spec_info is not None:
             if has_rng_ops:

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -316,12 +316,29 @@ class ProgramIDs(abc.ABC):
         self, pid_var: str, state: CodegenState
     ) -> list[ast.stmt]:
         """Generate statements to decompose a single PID variable into multiple PID components."""
+        device_pid = state.device_function.pid
+        use_safe_radices = (
+            isinstance(device_pid, ForEachProgramID)
+            and device_pid._uses_pallas_direct_cases()
+        )
+
+        def num_blocks_expr(pid: PIDInfo) -> str:
+            expr = pid.num_pids_expr(is_device=True)
+            if not use_safe_radices:
+                return expr
+            # JAX traces a ``pl.when`` body even when this case has no work.
+            # Keep its PID arithmetic defined while the case guard/grid retain
+            # the exact zero-sized extent.
+            return CompileEnvironment.current().backend.where_expr(
+                f"({expr}) > 0", expr, "1"
+            )
+
         num_blocks = [
             state.device_function.new_var(f"num_blocks_{i}")
             for i in range(len(self.pid_info[:-1]))
         ]
         statements = [
-            statement_from_string(f"{num_block} = {pid.num_pids_expr(is_device=True)}")
+            statement_from_string(f"{num_block} = {num_blocks_expr(pid)}")
             for num_block, pid in zip(num_blocks, self.pid_info[:-1], strict=True)
         ]
         for i, pid in enumerate(self.pid_info):
@@ -337,16 +354,33 @@ class ProgramIDs(abc.ABC):
 
 @dataclasses.dataclass
 class ForEachProgramID(ProgramIDs):
-    """
-    Represent multiple top level for loops in the Helion kernel.  Turns into `if` statements in generated code.
+    """Represent multiple top-level loops in one flattened launch grid.
+
+    Pallas direct cases materialize the full grid so each root can be guarded
+    without mutating its launch PID. Consequently they bypass persistent
+    scheduling and cannot be combined with compact worklists or in-place HBM
+    outputs; those combinations are rejected by the Pallas launcher.
     """
 
     # pyrefly: ignore [bad-override]
     shared_pid_var: str
     cases: list[ProgramIDs] = dataclasses.field(default_factory=list)
     case_phases: list[int] = dataclasses.field(default_factory=list)
+    pallas_direct_cases: bool = False
     pid_info: list[PIDInfo] = dataclasses.field(default_factory=list, init=False)
     barrier_after_root: set[int] = dataclasses.field(default_factory=set)
+
+    def _uses_pallas_direct_cases(self) -> bool:
+        return (
+            CompileEnvironment.current().backend.name == "pallas"
+            and self.pallas_direct_cases
+        )
+
+    def case_pid_var(self, device_function: DeviceFunction) -> str:
+        """Return the PID variable a newly generated ForEach case should use."""
+        if self._uses_pallas_direct_cases():
+            return device_function.new_var("pid_case")
+        return self.shared_pid_var
 
     def codegen_pid_init(self) -> list[ast.stmt]:
         # Check if persistent kernels are enabled in config - if so, skip regular initialization
@@ -355,7 +389,11 @@ class ForEachProgramID(ProgramIDs):
 
         current_device_fn = DeviceFunction.current()
         pid_type = current_device_fn.config.get("pid_type", "flat")
-        if isinstance(pid_type, str) and pid_type.startswith("persistent"):
+        if (
+            isinstance(pid_type, str)
+            and pid_type.startswith("persistent")
+            and not self._uses_pallas_direct_cases()
+        ):
             return []
         return [statement_from_string(f"{self.shared_pid_var} = {typed_program_id(0)}")]
 
@@ -379,6 +417,11 @@ class ForEachProgramID(ProgramIDs):
         self, device_function: DeviceFunction, total_pids_expr: str | None = None
     ) -> list[ast.stmt] | None:
         total_expr = self.total_pids_expr(is_device=True)
+        # Pallas direct case launches materialize the complete flattened grid,
+        # so they must not also wrap that grid in a persistent worker loop.
+        if self._uses_pallas_direct_cases():
+            return None
+
         # If there is only one phase, fall back to existing behavior.
         has_phases = len(set(self.case_phases)) > 1
 
@@ -416,6 +459,21 @@ class ForEachProgramID(ProgramIDs):
 
     def codegen(self, state: CodegenState) -> None:
         blocks = self._get_cdiv_blocks(state, exclude_last=True)
+        if self._uses_pallas_direct_cases():
+            case_pid_var = self.cases[-1].shared_pid_var
+            assert case_pid_var is not None and case_pid_var != self.shared_pid_var
+            value = self.shared_pid_var
+            if blocks:
+                env = CompileEnvironment.current()
+                block_expr = env.backend.cast_expr(
+                    f"({'+ '.join(blocks)})", env.index_type()
+                )
+                value = f"{value} - {block_expr}"
+            state.codegen.statements_stack[-1].insert(
+                0,
+                statement_from_string(f"{case_pid_var} = {value}"),
+            )
+            return
         if blocks:
             env = CompileEnvironment.current()
             block_expr = env.backend.cast_expr(
@@ -428,7 +486,7 @@ class ForEachProgramID(ProgramIDs):
 
     def codegen_grid(self) -> ast.AST:
         # Check if any of the pids is a persistent strategy
-        if self.cases[0]._is_persistent():
+        if self.cases[0]._is_persistent() and not self._uses_pallas_direct_cases():
             # Use SM count grid for persistent kernels
             return self.cases[0].codegen_grid()
 
@@ -753,8 +811,8 @@ class L2GroupingProgramIDs(ProgramIDs):
                 terms.append(f"{typed_program_id(i)} * ({multiplier})")
             pid = " + ".join(terms)
         elif isinstance(state.device_function.pid, ForEachProgramID):
-            # For ForEachProgramID, use the shared PID variable
-            pid = state.device_function.pid.shared_pid_var
+            # Pallas direct cases have an immutable-launch-PID-derived local PID.
+            pid = self.shared_pid_var or state.device_function.pid.shared_pid_var
         else:
             # For other strategies (Flat, Persistent), use the virtual_program_id
             pid = self.virtual_program_id

--- a/helion/_compiler/tile_strategy.py
+++ b/helion/_compiler/tile_strategy.py
@@ -2846,7 +2846,9 @@ class FlattenedTileStrategy(BlockSizeTileStrategy):
                 self._setup_block_size_constexpr(state, block_size_var, self.block_size)
                 pids = self.select_pid_strategy()
                 if isinstance(state.device_function.pid, ForEachProgramID):
-                    pids.shared_pid_var = state.device_function.pid.shared_pid_var
+                    pids.shared_pid_var = state.device_function.pid.case_pid_var(
+                        state.device_function
+                    )
                 pids.append(PIDInfo(pid_var, block_size_var, trip_count, block_id))
                 state.add_statement(
                     env.backend.arange_expr(
@@ -2907,7 +2909,9 @@ class FlattenedTileStrategy(BlockSizeTileStrategy):
         pid_var = state.device_function.new_var("pid_flat", dce=True)
         pids = self.select_pid_strategy()
         if isinstance(state.device_function.pid, ForEachProgramID):
-            pids.shared_pid_var = state.device_function.pid.shared_pid_var
+            pids.shared_pid_var = state.device_function.pid.case_pid_var(
+                state.device_function
+            )
 
         pids.append(PIDInfo(pid_var, block_size_var, total_numel, self.block_ids[0]))
 
@@ -3261,7 +3265,9 @@ class _BaseNDTileStrategy(BlockSizeTileStrategy):
         assert len(block_sizes) == len(block_ids)
         pids = self.select_pid_strategy()
         if isinstance(state.device_function.pid, ForEachProgramID):
-            pids.shared_pid_var = state.device_function.pid.shared_pid_var
+            pids.shared_pid_var = state.device_function.pid.case_pid_var(
+                state.device_function
+            )
         elif (
             isinstance(pids, FlatProgramIDs)
             and env.backend.name == "pallas"
@@ -3853,7 +3859,9 @@ class CuteNDTileStrategy(NDTileStrategy):
         assert len(block_sizes) == len(block_ids)
         pids = self.select_pid_strategy()
         if isinstance(state.device_function.pid, ForEachProgramID):
-            pids.shared_pid_var = state.device_function.pid.shared_pid_var
+            pids.shared_pid_var = state.device_function.pid.case_pid_var(
+                state.device_function
+            )
 
         assert state.ast_args is None
         assert len(state.proxy_args) == 3
@@ -4318,7 +4326,9 @@ class CuteFlattenedTileStrategy(FlattenedTileStrategy):
         pid_var = state.device_function.new_var("pid_flat", dce=True)
         pids = self.select_pid_strategy()
         if isinstance(state.device_function.pid, ForEachProgramID):
-            pids.shared_pid_var = state.device_function.pid.shared_pid_var
+            pids.shared_pid_var = state.device_function.pid.case_pid_var(
+                state.device_function
+            )
         pids.append(PIDInfo(pid_var, block_size_var, total_numel, self.block_ids[0]))
         axis = self._flat_thread_axis()
         state.add_statement(

--- a/helion/runtime/pallas/launcher.py
+++ b/helion/runtime/pallas/launcher.py
@@ -131,19 +131,18 @@ def _pallas_make_block_spec(
         if isinstance(g, tuple):
             # Flat grid decomposition:
             # (grid_dim, stride, num_blocks) or
-            # (grid_dim, stride, num_blocks, case_start)
+            # (grid_dim, stride, num_blocks, case_start[, case_total])
             if len(g) == 3:
                 grid_dim, stride, num_blocks = g
                 case_start = 0
             else:
-                grid_dim, stride, num_blocks, case_start = g
-            val = grid_args[grid_dim]
-            if case_start:
-                val = val - case_start  # type: ignore[operator]
+                grid_dim, stride, num_blocks, case_start, *_ = g
+            val = grid_args[grid_dim] - case_start  # type: ignore[operator]
             if stride > 1:
                 val = val // stride  # type: ignore[operator]
             val = val % num_blocks  # type: ignore[operator]
             return jnp.int32(val)  # pyrefly: ignore[missing-attribute]
+        assert isinstance(g, int)
         return jnp.minimum(  # pyrefly: ignore[missing-attribute]
             jnp.int32(grid_args[g]),  # pyrefly: ignore[missing-attribute]
             max_block_index[d],
@@ -425,7 +424,9 @@ def _estimate_pallas_vmem_bytes(
 # Per-tensor block spec info: see ``_pallas_make_block_spec``.
 # grid_dims entries are int (direct grid dim), tuple (flat decomposition),
 # or None (untiled dim).
-_PallasFlatGridDim = tuple[int, int, int] | tuple[int, int, int, int]
+_PallasFlatGridDim = (
+    tuple[int, int, int] | tuple[int, int, int, int] | tuple[int, int, int, int, int]
+)
 _BlockSpecInfo = list[
     tuple[
         tuple[int | None, ...],
@@ -433,8 +434,11 @@ _BlockSpecInfo = list[
     ]
     | None
 ]
-_PallasCopyGuards = dict[int, tuple[int, ...]]
+_PallasFlatCopyGuard = tuple[int, int, int, tuple[tuple[int, int], ...]]
+_PallasCopyGuard = tuple[tuple[int, ...], tuple[_PallasFlatCopyGuard, ...]]
+_PallasCopyGuards = dict[int, _PallasCopyGuard]
 _PallasDimensionSemantic = Literal["parallel", "arbitrary"]
+_PallasLauncherCacheKey = tuple[tuple[int, ...], tuple[object, ...] | None]
 
 
 def _pallas_tensor_pos_map(
@@ -461,19 +465,38 @@ def _pallas_grid_dims_used_by_block_spec(
     return used
 
 
-def _pallas_foreach_grid_dims_by_block_spec(
+def _pallas_flat_shared_groups(
+    grid: tuple[int, ...],
     block_info: tuple[
         tuple[int | None, ...],
         tuple[int | _PallasFlatGridDim | None, ...],
     ],
-) -> set[int]:
-    """Return flat launch dims whose index map is limited to one ForEach case."""
-    used: set[int] = set()
+) -> tuple[_PallasFlatCopyGuard, ...]:
+    """Return flat grid groups whose logical subdimensions are only partly tiled."""
+    groups: dict[tuple[int, int, int], set[tuple[int, int]]] = {}
     _, grid_dims = block_info
     for grid_dim in grid_dims:
-        if isinstance(grid_dim, tuple) and len(grid_dim) == 4:
-            used.add(grid_dim[0])
-    return used
+        if not isinstance(grid_dim, tuple):
+            continue
+        dim, stride, num_blocks, *range_info = grid_dim
+        if len(range_info) >= 2:
+            start, total = range_info[:2]
+        elif range_info:
+            start = range_info[0]
+            total = grid[dim] - start
+        else:
+            start = 0
+            total = grid[dim]
+        groups.setdefault((dim, start, total), set()).add((stride, num_blocks))
+
+    result: list[_PallasFlatCopyGuard] = []
+    for (dim, start, total), used_dims in groups.items():
+        used = 1
+        for _stride, num_blocks in used_dims:
+            used *= num_blocks
+        if start != 0 or start + total < grid[dim] or used < total:
+            result.append((dim, start, total, tuple(sorted(used_dims))))
+    return tuple(result)
 
 
 def _pallas_shared_output_plan(
@@ -489,34 +512,53 @@ def _pallas_shared_output_plan(
     copy_guards: _PallasCopyGuards = {}
     if not output_indices or not grid:
         return copy_guards, tuple(dim_semantics)
-    if block_spec_info is None:
-        return copy_guards, tuple(dim_semantics)
 
     arg_to_tpos = _pallas_tensor_pos_map(tensor_arg_indices, output_only_indices)
+    all_shared_dims = tuple(dim for dim, size in enumerate(grid) if size > 1)
     for orig_pos in output_indices:
         if orig_pos not in inplace_indices:
             continue
         tensor_pos = arg_to_tpos.get(orig_pos)
-        if tensor_pos is None or tensor_pos >= len(block_spec_info):
-            continue
-        block_info = block_spec_info[tensor_pos]
-        if block_info is None:
-            continue
-        for dim in _pallas_foreach_grid_dims_by_block_spec(block_info):
-            if dim < len(grid) and grid[dim] > 1:
-                dim_semantics[dim] = "arbitrary"
-        used_dims = _pallas_grid_dims_used_by_block_spec(block_info)
-        # These programs update the same output tile and must observe one
-        # shared accumulator, not a freshly preloaded copy per program.
-        shared_dims = tuple(
-            dim for dim, size in enumerate(grid) if size > 1 and dim not in used_dims
+        block_info = (
+            block_spec_info[tensor_pos]
+            if block_spec_info is not None
+            and tensor_pos is not None
+            and tensor_pos < len(block_spec_info)
+            else None
         )
-        if not shared_dims:
-            continue
-        copy_guards[orig_pos] = shared_dims
+        if block_info is None:
+            # A full-array or scalar BlockSpec is shared by every physical
+            # program. Missing metadata must be treated the same way rather
+            # than letting each program reseed an inplace accumulator.
+            shared_dims = all_shared_dims
+            flat_groups: tuple[_PallasFlatCopyGuard, ...] = ()
+        else:
+            used_dims = _pallas_grid_dims_used_by_block_spec(block_info)
+            # These programs update the same output tile and must observe one
+            # shared accumulator, not a freshly preloaded copy per program.
+            shared_dims = tuple(
+                dim
+                for dim, size in enumerate(grid)
+                if size > 1 and dim not in used_dims
+            )
+            flat_groups = _pallas_flat_shared_groups(grid, block_info)
+        if shared_dims or flat_groups:
+            copy_guards[orig_pos] = (shared_dims, flat_groups)
         for dim in shared_dims:
             dim_semantics[dim] = "arbitrary"
+        for dim, _start, _total, _used_dims in flat_groups:
+            dim_semantics[dim] = "arbitrary"
     return copy_guards, tuple(dim_semantics)
+
+
+def _pallas_launcher_cache_key(
+    grid: tuple[int, ...], block_spec_info: _BlockSpecInfo | None
+) -> _PallasLauncherCacheKey:
+    """Return compile-relevant launch metadata for the shared cache."""
+    frozen_block_spec_info = (
+        tuple(block_spec_info) if block_spec_info is not None else None
+    )
+    return grid, cast("tuple[object, ...] | None", frozen_block_spec_info)
 
 
 def _pallas_build_block_specs(
@@ -1184,12 +1226,34 @@ def _pallas_inplace_copy(in_ref: object, out_ref: object, *, is_smem: bool) -> N
         out_ref[...] = in_ref[...]  # type: ignore[index]
 
 
-def _pallas_copy_guard(dims: tuple[int, ...]) -> bool | jax.Array:
+def _pallas_copy_guard(guard: _PallasCopyGuard) -> bool | jax.Array:
     from jax.experimental import pallas as pl
 
-    should_copy = True
-    for dim in dims:
+    direct_dims, flat_guards = guard
+    should_copy: bool | jax.Array = True
+    for dim in direct_dims:
         should_copy = should_copy & (pl.program_id(dim) == 0)
+    flat_dim_guards: dict[int, bool | jax.Array] = {}
+    for dim, start, total, used_dims in flat_guards:
+        local_pid = pl.program_id(dim) - start
+        rebuilt_pid: int | jax.Array = 0
+        for stride, num_blocks in used_dims:
+            coord: int | jax.Array = local_pid
+            if stride > 1:
+                coord = coord // stride  # type: ignore[operator]
+            coord = coord % num_blocks  # type: ignore[operator]
+            if stride > 1:
+                coord = coord * stride  # type: ignore[operator]
+            rebuilt_pid = rebuilt_pid + coord
+        in_group = (local_pid >= 0) & (local_pid < total)
+        flat_guard = in_group & (local_pid == rebuilt_pid)
+        flat_dim_guards[dim] = (
+            flat_guard
+            if dim not in flat_dim_guards
+            else flat_dim_guards[dim] | flat_guard
+        )
+    for flat_guard in flat_dim_guards.values():
+        should_copy = should_copy & flat_guard
     return should_copy
 
 
@@ -1693,9 +1757,7 @@ def _pallas_compile_jit_fn(
         placeholder_fn=placeholder_fn,
     )
 
-    # Only the copy guards are consumed; the dimension semantics are implied
-    # by emit_pipeline's sequential in-order grid execution.
-    copy_guards, _ = _pallas_shared_output_plan(
+    copy_guards, dimension_semantics = _pallas_shared_output_plan(
         grid,
         tensor_arg_indices,
         output_only_indices,
@@ -1747,6 +1809,19 @@ def _pallas_compile_jit_fn(
         scratch_shapes = []
         skip_inplace_copy = set()
 
+    effective_copy_guards = {
+        orig_pos: guard
+        for orig_pos, guard in copy_guards.items()
+        if orig_pos not in skip_inplace_copy
+    }
+    use_direct_call = bool(effective_copy_guards)
+    unsupported_hbm_direct_outputs = inplace_positions & skip_inplace_copy
+    if use_direct_call and unsupported_hbm_direct_outputs:
+        raise NotImplementedError(
+            "Pallas direct launches do not support in-place HBM outputs: "
+            f"{sorted(unsupported_hbm_direct_outputs)}"
+        )
+
     reordered_kernel = _pallas_make_reordered_kernel(
         pallas_kernel,
         args,
@@ -1759,7 +1834,7 @@ def _pallas_compile_jit_fn(
         n_extra_refs=len(scratch_shapes),
         skip_inplace_copy=skip_inplace_copy,
         _smem_arg_indices=_smem_arg_indices,
-        _copy_guards=copy_guards,
+        _copy_guards=effective_copy_guards,
     )
 
     out_shape_arg = out_shapes if len(out_shapes) > 1 else out_shapes[0]
@@ -1778,7 +1853,14 @@ def _pallas_compile_jit_fn(
             args,
             tensor_arg_indices,
             _output_indices,
-            pallas_aliases,
+            # Direct pallas_call keeps distinct input/output refs alive for the
+            # explicit seed copy even when the outer JaxCallable donates them.
+            None if use_direct_call else pallas_aliases,
+        )
+
+    if _matmul_dot_general is not None and use_direct_call:
+        raise NotImplementedError(
+            "Pallas direct launches cannot use dot_general lowering"
         )
 
     if _matmul_dot_general is not None:
@@ -1786,6 +1868,34 @@ def _pallas_compile_jit_fn(
         # no-tiling matmul configs so XLA sees a regular ``dot`` and
         # can attach ``cross_program_prefetch_index``.
         jit_fn = _build_matmul_dot_general_jit_fn(_matmul_dot_general)
+    elif use_direct_call:
+        pallas_call_kwargs: dict[str, object] = {"out_shape": out_shape_arg}
+        if needs_pipeline_specs:
+            pallas_call_kwargs["grid_spec"] = pltpu.PrefetchScalarGridSpec(  # type: ignore[union-attr]
+                num_scalar_prefetch=0,
+                in_specs=in_specs,
+                out_specs=out_specs,
+                scratch_shapes=scratch_shapes,  # pyrefly: ignore[bad-argument-type]
+                grid=grid,
+            )
+            pallas_call_kwargs["compiler_params"] = pltpu.CompilerParams(  # pyrefly: ignore[bad-instantiation]
+                dimension_semantics=dimension_semantics,
+            )
+        else:
+            pallas_call_kwargs["grid"] = grid
+            if in_specs is not None:
+                pallas_call_kwargs["in_specs"] = in_specs
+                pallas_call_kwargs["out_specs"] = out_specs
+            if any(sem != "parallel" for sem in dimension_semantics):
+                pallas_call_kwargs["compiler_params"] = pltpu.CompilerParams(  # pyrefly: ignore[bad-instantiation]
+                    dimension_semantics=dimension_semantics,
+                )
+        if interpret:
+            pallas_call_kwargs["interpret"] = True
+        jit_fn = pl.pallas_call(  # type: ignore[union-attr]
+            reordered_kernel,  # pyrefly: ignore[bad-argument-type]
+            **pallas_call_kwargs,  # type: ignore[arg-type]
+        )
     else:
         # emit_pipeline needs concrete specs: build whole-array specs when
         # the builders returned None (no tiling info or empty grid).  The
@@ -1964,6 +2074,7 @@ def _pallas_install_launcher_cache(
         _ensure_cpu_tpu_info()
 
     output_indices = _output_indices if _output_indices is not None else []
+    launcher_cache_key = _pallas_launcher_cache_key(grid, _block_spec_info)
 
     # Build the pallas specs from ds-padded shapes on a throwaway copy so
     # ``args`` stays unpadded for the shared invoke below to pad fresh.
@@ -1999,7 +2110,7 @@ def _pallas_install_launcher_cache(
         result.tensor_arg_indices,
         cache_attr=_PALLAS_CACHE_ATTR,
         call_aliases=result.pallas_aliases,
-        trace_key_suffix="",
+        trace_key_suffix=f"_{launcher_cache_key[1]!r}",
         interpret=interpret,
     )
 
@@ -2016,6 +2127,7 @@ def _pallas_install_launcher_cache(
         result.arg_to_tensor_pos,
         fast_path,
         None,
+        launcher_cache_key,
     )
     setattr(pallas_kernel, _PALLAS_CACHE_ATTR, cache)
     return cache
@@ -2036,6 +2148,7 @@ def _pallas_invoke_cached_launcher(
     arg_to_tensor_pos = cast("dict[int, int]", cache[3])
     fast_path = cast("_LauncherFastPath", cache[4])
     direct_call = cast("_DirectCallKernel | None", cache[5])
+    launcher_cache_key = cast("_PallasLauncherCacheKey", cache[6])
     if direct_call is None:
         # Lazily lift the direct-call kernel off the JaxCallable subclass.
         direct_call = getattr(jax_callable, "_helion_direct_call", None)
@@ -2047,6 +2160,7 @@ def _pallas_invoke_cached_launcher(
                 arg_to_tensor_pos,
                 fast_path,
                 direct_call,
+                launcher_cache_key,
             )
             setattr(pallas_kernel, cache_attr, cache)
 
@@ -2129,7 +2243,8 @@ def default_pallas_launcher(
             _compact_ordered_window,
         )
     cache = getattr(pallas_kernel, _PALLAS_CACHE_ATTR, None)
-    if cache is None or cache[0] != grid:
+    launcher_cache_key = _pallas_launcher_cache_key(grid, _block_spec_info)
+    if cache is None or cache[6] != launcher_cache_key:
         if _compact_build_worklist is not None:
             cache = _pallas_install_compact_launcher_cache(
                 pallas_kernel,
@@ -2592,6 +2707,7 @@ def _pallas_install_compact_launcher_cache(
     if interpret:
         _ensure_cpu_tpu_info()
     output_indices = _output_indices if _output_indices is not None else []
+    launcher_cache_key = _pallas_launcher_cache_key(grid, _block_spec_info)
 
     spec_args = args
     if _ds_pad_dims:
@@ -2633,7 +2749,7 @@ def _pallas_install_compact_launcher_cache(
         result.tensor_arg_indices,
         cache_attr=_PALLAS_CACHE_ATTR,
         call_aliases=result.pallas_aliases,
-        trace_key_suffix="",
+        trace_key_suffix=f"_{launcher_cache_key[1]!r}",
         interpret=interpret,
     )
     fast_path = _LauncherFastPath(
@@ -2649,6 +2765,7 @@ def _pallas_install_compact_launcher_cache(
         result.arg_to_tensor_pos,
         fast_path,
         None,
+        launcher_cache_key,
     )
     setattr(pallas_kernel, _PALLAS_CACHE_ATTR, cache)
     return cache

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -4,11 +4,14 @@ import ast
 import math
 import os
 import re
+import sys
+import types
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import cast
 import unittest
+from unittest.mock import patch
 
 from examples.geglu import _geglu_pallas as _geglu_pallas_example
 from examples.swiglu import _swiglu_fwd_pallas as _swiglu_fwd_pallas_example
@@ -29,6 +32,9 @@ from helion._testing import xfailIfPallas
 from helion._testing import xfailIfPallasInterpret
 from helion._testing import xfailIfPallasTpu
 import helion.language as hl
+from helion.runtime.pallas.launcher import _pallas_copy_guard
+from helion.runtime.pallas.launcher import _pallas_launcher_cache_key
+from helion.runtime.pallas.launcher import _pallas_shared_output_plan
 from helion.runtime.settings import is_pallas_interpret
 
 if TYPE_CHECKING:
@@ -95,6 +101,19 @@ def pallas_foreach_output_only(x: torch.Tensor) -> tuple[torch.Tensor, torch.Ten
     for tile in hl.tile(x.size(0)):
         out2[tile] = x[tile] * 2.0
     return out1, out2
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_foreach_unequal_outputs(
+    x: torch.Tensor, y: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    out_x = torch.empty_like(x)
+    out_y = torch.empty_like(y)
+    for tile_x in hl.tile(x.size(0)):
+        out_x[tile_x] = x[tile_x] + 1.0
+    for tile_y in hl.tile(y.size(0)):
+        out_y[tile_y] = y[tile_y] * 2.0
+    return out_x, out_y
 
 
 @helion.kernel(backend="pallas", static_shapes=True)
@@ -434,22 +453,6 @@ def pallas_inner_loop_add_with_nonzero_scalar_access(
     for tile_m in hl.tile(m):
         for tile_n in hl.tile(n):
             out[tile_m, tile_n] = x[tile_m, tile_n] + y[tile_m, tile_n] + x[1, 7]
-    return out
-
-
-@helion.kernel(backend="pallas", static_shapes=True)
-def pallas_jagged_segment_add(x: torch.Tensor, offsets: torch.Tensor) -> torch.Tensor:
-    """Outer grid over jagged segments + an inner ``hl.tile(start, end)`` loop
-    whose begin (``offsets[g]``) is an arbitrary runtime offset. A
-    block-aligned BlockSpec index can only address starts that are multiples of
-    the block size, so the emit_pipeline path must slice the segment with a
-    dynamic ``pl.ds`` (``pl.BoundedSlice`` block)."""
-    out = torch.empty_like(x)
-    for g in hl.grid(offsets.size(0) - 1):
-        start = offsets[g]
-        end = offsets[g + 1]
-        for tile in hl.tile(start, end):
-            out[tile, :] = x[tile, :] + 1.0
     return out
 
 
@@ -843,6 +846,163 @@ def kernel_tile_begin_plus_offset_is_elementwise(
     for tile_m in hl.tile(seq_len):
         out[tile_m.begin + 5] = x[tile_m.begin + 5] + 1.0
     return out
+
+
+class TestPallasSharedOutputPlan(TestCase):
+    def test_shared_output_plan_guards_missing_block_spec_info(self) -> None:
+        copy_guards, dimension_semantics = _pallas_shared_output_plan(
+            grid=(2, 3),
+            tensor_arg_indices=[0],
+            output_only_indices=[],
+            output_indices=[0],
+            inplace_indices={0},
+            block_spec_info=None,
+        )
+
+        self.assertEqual(copy_guards, {0: ((0, 1), ())})
+        self.assertEqual(dimension_semantics, ("arbitrary", "arbitrary"))
+
+    def test_shared_output_plan_guards_scalar_block_spec(self) -> None:
+        copy_guards, dimension_semantics = _pallas_shared_output_plan(
+            grid=(2,),
+            tensor_arg_indices=[0, 1],
+            output_only_indices=[],
+            output_indices=[1],
+            inplace_indices={1},
+            block_spec_info=[((128,), (0,)), None],
+        )
+
+        self.assertEqual(copy_guards, {1: ((0,), ())})
+        self.assertEqual(dimension_semantics, ("arbitrary",))
+
+    def test_shared_output_plan_normalizes_partial_flat_group(self) -> None:
+        copy_guards, dimension_semantics = _pallas_shared_output_plan(
+            grid=(8,),
+            tensor_arg_indices=[0],
+            output_only_indices=[],
+            output_indices=[0],
+            inplace_indices={0},
+            block_spec_info=[((1,), ((0, 1, 2),))],
+        )
+
+        self.assertEqual(copy_guards, {0: ((), ((0, 0, 8, ((1, 2),)),))})
+        self.assertEqual(dimension_semantics, ("arbitrary",))
+
+    def test_shared_output_plan_skips_complete_flat_decomposition(self) -> None:
+        copy_guards, dimension_semantics = _pallas_shared_output_plan(
+            grid=(8,),
+            tensor_arg_indices=[0],
+            output_only_indices=[],
+            output_indices=[0],
+            inplace_indices={0},
+            block_spec_info=[((1, 1), ((0, 1, 2), (0, 2, 4)))],
+        )
+
+        self.assertEqual(copy_guards, {})
+        self.assertEqual(dimension_semantics, ("parallel",))
+
+    def test_shared_output_plan_reconstructs_stride_gapped_flat_group(self) -> None:
+        copy_guards, dimension_semantics = _pallas_shared_output_plan(
+            grid=(8,),
+            tensor_arg_indices=[0],
+            output_only_indices=[],
+            output_indices=[0],
+            inplace_indices={0},
+            block_spec_info=[((1, 1), ((0, 1, 2), (0, 4, 2)))],
+        )
+
+        guard = copy_guards[0]
+        for pid in range(8):
+            with self.subTest(pid=pid):
+                self.assertEqual(
+                    self._copy_guard_value(guard, {0: pid}),
+                    pid in (0, 1, 4, 5),
+                )
+        self.assertEqual(dimension_semantics, ("arbitrary",))
+
+    def test_copy_guard_ors_same_dim_groups_and_rejects_out_of_group(self) -> None:
+        guard = (
+            (),
+            (
+                (0, 0, 4, ((1, 2),)),
+                (0, 4, 4, ((1, 2),)),
+            ),
+        )
+
+        self.assertTrue(self._copy_guard_value(guard, {0: 1}))
+        self.assertTrue(self._copy_guard_value(guard, {0: 5}))
+        self.assertFalse(self._copy_guard_value(guard, {0: 2}))
+        self.assertFalse(self._copy_guard_value(guard, {0: 8}))
+
+    def test_shared_output_plan_honors_exact_five_tuple_case_ranges(self) -> None:
+        for start, total in ((0, 4), (4, 5)):
+            with self.subTest(start=start, total=total):
+                copy_guards, dimension_semantics = _pallas_shared_output_plan(
+                    grid=(9,),
+                    tensor_arg_indices=[0],
+                    output_only_indices=[],
+                    output_indices=[0],
+                    inplace_indices={0},
+                    block_spec_info=[
+                        ((1,), ((0, 1, total, start, total),)),
+                    ],
+                )
+
+                self.assertEqual(
+                    copy_guards,
+                    {0: ((), ((0, start, total, ((1, total),)),))},
+                )
+                self.assertEqual(dimension_semantics, ("arbitrary",))
+                guard = copy_guards[0]
+                self.assertTrue(self._copy_guard_value(guard, {0: start}))
+                self.assertTrue(self._copy_guard_value(guard, {0: start + total - 1}))
+                self.assertFalse(
+                    self._copy_guard_value(guard, {0: (start + total) % 9})
+                )
+
+    def test_launcher_cache_key_includes_foreach_case_metadata(self) -> None:
+        first = [
+            ((128,), ((0, 1, 1, 0),)),
+            ((128,), ((0, 1, 2, 1),)),
+        ]
+        second = [
+            ((128,), ((0, 1, 2, 0),)),
+            ((128,), ((0, 1, 1, 2),)),
+        ]
+
+        self.assertEqual(
+            _pallas_launcher_cache_key((3,), first),
+            _pallas_launcher_cache_key((3,), list(first)),
+        )
+        self.assertNotEqual(
+            _pallas_launcher_cache_key((3,), first),
+            _pallas_launcher_cache_key((3,), second),
+        )
+
+    def _copy_guard_value(self, guard: Any, pid_by_dim: dict[int, int]) -> bool:
+        jax_mod = types.ModuleType("jax")
+        experimental_mod = types.ModuleType("jax.experimental")
+        pallas_mod = types.ModuleType("jax.experimental.pallas")
+
+        def program_id(dim: int) -> int:
+            return pid_by_dim[dim]
+
+        pallas_module = cast("Any", pallas_mod)
+        experimental_module = cast("Any", experimental_mod)
+        jax_module = cast("Any", jax_mod)
+        pallas_module.program_id = program_id
+        experimental_module.pallas = pallas_mod
+        jax_module.experimental = experimental_mod
+
+        with patch.dict(
+            sys.modules,
+            {
+                "jax": jax_mod,
+                "jax.experimental": experimental_mod,
+                "jax.experimental.pallas": pallas_mod,
+            },
+        ):
+            return bool(_pallas_copy_guard(guard))
 
 
 # Module-level (Helion reads it as a constant, not a closure) so torch.topk's k
@@ -2493,6 +2653,25 @@ class TestPallas(TestCase):
         self.assertIn("one_hot", code)
         self.assertIn("_inplace_indices=", code)
 
+    @xfailIfPallasTpu("Mosaic does not support DMA for scalar outputs")
+    def test_scalar_atomic_add_shared_output_tiles(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def scalar_atomic_sum(values: torch.Tensor) -> torch.Tensor:
+            out = torch.zeros([], device=values.device, dtype=values.dtype)
+            for rows in hl.tile(values.size(0)):
+                hl.atomic_add(out, [], values[rows, 0].sum())
+            return out
+
+        values = torch.ones(256, 128, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            scalar_atomic_sum,
+            (values,),
+            block_sizes=[128],
+        )
+
+        torch.testing.assert_close(result, values[:, 0].sum())
+        self.assertIn("_block_spec_info=", code)
+
     def test_tensor_index_atomic_add_scalar_middle_dim(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def atomic_add_scalar_middle_dim(
@@ -2557,17 +2736,17 @@ class TestPallas(TestCase):
             for first_m, first_n in hl.tile(values.size()):
                 hl.atomic_add(
                     out,
-                    [indices[first_m], first_n],
+                    [indices[first_m, 0], first_n],
                     values[first_m, first_n],
                 )
             for second_m, second_n in hl.tile(values.size()):
                 other[second_m, second_n] = values[second_m, second_n]
             return out, other
 
-        values = torch.randn(16, 256, device=DEVICE, dtype=torch.float32)
-        indices = torch.zeros(16, device=DEVICE, dtype=torch.int32)
+        values = torch.randn(64, 256, device=DEVICE, dtype=torch.float32)
+        indices = torch.zeros(64, 128, device=DEVICE, dtype=torch.int32)
 
-        with self.assertRaisesRegex(helion.exc.InternalError, "ForEach"):
+        with self.assertRaisesRegex(helion.exc.InternalError, "ForEach grids"):
             code_and_output(
                 foreach_atomic_add,
                 (values, indices),
@@ -4573,29 +4752,83 @@ class TestPallas(TestCase):
         are exact multiples of the block size). Regression test for the
         "emit_pipeline fails on unaligned dims" limitation.
         """
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def segment_add(
+            x: torch.Tensor, offsets: torch.Tensor, values: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for group in hl.grid(offsets.size(0) - 1):
+                start = offsets[group]
+                end = offsets[group + 1]
+                value = values[group]
+                for tile in hl.tile(start, end):
+                    out[tile, :, :] = x[tile, :, :] + value
+            return out
+
         # Arbitrary, deliberately non-block-aligned segment bounds covering
-        # [0, 48) so the output is fully written (out = x + 1 everywhere).
-        offsets = torch.tensor([0, 10, 31, 48], device=DEVICE, dtype=torch.int32)
-        x = torch.randn(48, 128, device=DEVICE, dtype=torch.float32)
+        # [0, 48). Segment-specific values make an overrun observable.
+        offset_values = [0, 10, 31, 48]
+        offsets = torch.tensor(offset_values, device=DEVICE, dtype=torch.int32)
+        values = torch.tensor([1.0, 3.0, 7.0], device=DEVICE, dtype=torch.float32)
+        x = torch.randn(48, 4, 128, device=DEVICE, dtype=torch.float32)
         code, result = code_and_output(
-            pallas_jagged_segment_add,
-            (x, offsets),
+            segment_add,
+            (x, offsets, values),
             block_sizes=[16],
             pallas_loop_type="emit_pipeline",
         )
         self.assertIn("pltpu.emit_pipeline", code)
-        # The fix: dynamic ds slice + BoundedSlice block for the runtime begin.
         self.assertIn("pl.BoundedSlice", code)
-        self.assertIn("pl.ds(", code)
-        # Load/store asymmetry: the input spec reads a full block (the over-read
-        # past ``end`` is zeroed by the mask), while the output spec clamps its
-        # extent to min(block, end - offset) so a short final tile writes only
-        # its valid rows instead of overrunning into the next segment.
-        in_part, _, out_part = code.partition("out_specs=")
-        self.assertIn("in_specs=", in_part)
-        self.assertNotIn("jnp.minimum", in_part)  # input: full block
-        self.assertIn("jnp.minimum", out_part)  # output: clamped extent
-        torch.testing.assert_close(result, x + 1.0, rtol=1e-5, atol=1e-5)
+        self.assertIn("out_specs=", code)
+        out_specs = code.split("out_specs=", 1)[1].split("compiler_params=", 1)[0]
+        self.assertIn("pl.ds(", out_specs)
+        self.assertIn("jnp.minimum(", out_specs)
+        self.assertRegex(out_specs.split("jnp.minimum(", 1)[1], r"end\s*-")
+        self.assertRegex(code, r"\bout_vmem(?:\[[^\n]*\])?\s*=")
+        self.assertNotRegex(code, r"out\[\s*pl\.ds\(")
+        expected = x.clone()
+        for group in range(len(offset_values) - 1):
+            start, end = offset_values[group], offset_values[group + 1]
+            expected[start:end] = x[start:end] + values[group]
+        torch.testing.assert_close(result, expected, rtol=1e-5, atol=1e-5)
+
+    def test_ordered_carry_dma_aligned_output_uses_vmem_relative_save(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def jagged_bmm(
+            offsets: torch.Tensor, x: torch.Tensor, w: torch.Tensor
+        ) -> torch.Tensor:
+            length, reduction_size = x.size()
+            output_size = w.size(1)
+            out = torch.empty([length, output_size], dtype=x.dtype, device=x.device)
+            for group in hl.grid(offsets.size(0) - 1):
+                start = offsets[group]
+                end = offsets[group + 1]
+                for rows, cols in hl.tile([start, 0], [end, output_size]):
+                    acc = hl.zeros([rows, cols], dtype=torch.float32)
+                    for reduction in hl.tile(reduction_size):
+                        acc = acc + torch.matmul(x[rows, reduction], w[reduction, cols])
+                    out[rows, cols] = acc.to(out.dtype)
+            return out
+
+        offsets = torch.tensor([0, 10, 33, 40], device=DEVICE, dtype=torch.int32)
+        x = torch.randn(40, 16, device=DEVICE, dtype=torch.float32)
+        w = torch.randn(16, 128, device=DEVICE, dtype=torch.float32)
+        code = jagged_bmm.bind((offsets, x, w)).to_code(
+            helion.Config(block_sizes=[16, 128, 16], pallas_loop_type="emit_pipeline")
+        )
+
+        self.assertIn("out_vmem", code)
+        carry_save_lines = [
+            line
+            for line in code.splitlines()
+            if "jnp.where" in line and "out_vmem[" in line
+        ]
+        self.assertTrue(carry_save_lines, "expected carry save from out_vmem")
+        self.assertTrue(
+            any(" - offset_" in line and "), :]" in line for line in carry_save_lines),
+            "\n".join(carry_save_lines),
+        )
 
     def test_emit_pipeline_static_begin_keeps_block_index(self) -> None:
         """Control: a static (zero-begin) inner loop must NOT switch to the
@@ -5734,32 +5967,74 @@ class TestPallas(TestCase):
         self.assertIn("out1, out2 = _launcher(", code)
 
     def test_foreach_outputs_stay_inplace_and_ordered(self) -> None:
+        config = helion.Config(block_sizes=[128, 128])
         x = torch.randn(256, device=DEVICE, dtype=torch.float32)
-        code = pallas_foreach_output_only.bind((x,)).to_triton_code(
-            helion.Config(block_sizes=[128, 128])
-        )
+        y = torch.randn(384, device=DEVICE, dtype=torch.float32)
+        code = pallas_foreach_unequal_outputs.bind((x, y)).to_triton_code(config)
 
-        self.assertIn("_output_indices=[1, 2]", code)
-        self.assertIn("_inplace_indices=[1, 2]", code)
+        self.assertIn("_output_indices=[1, 3]", code)
+        self.assertIn("_inplace_indices=[1, 3]", code)
         self.assertNotIn("device='meta'", code)
-        self.assertIn("((0, 1, 2, 0),)", code)
-        self.assertIn("((0, 1, 2, 2),)", code)
+        self.assertIn("((0, 1, 2, 0, 2),)", code)
+        self.assertIn("((0, 1, 3, 2, 3),)", code)
+        self.assertGreaterEqual(code.count("@pl.when("), 2)
+        self.assertNotIn("if pid_shared", code)
+        self.assertNotIn("pid_shared -=", code)
 
-        from helion.runtime.pallas.launcher import _pallas_shared_output_plan
+        module = ast.parse(code)
+        shared_pid_stores = [
+            node
+            for node in ast.walk(module)
+            if isinstance(node, ast.Name)
+            and isinstance(node.ctx, ast.Store)
+            and node.id.startswith("pid_shared")
+        ]
+        self.assertEqual(len(shared_pid_stores), 1)
+        case_guards = [
+            ast.unparse(node.decorator_list[0].args[0])
+            for node in ast.walk(module)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and "helion_case_root_" in node.name
+            and node.decorator_list
+            and isinstance(node.decorator_list[0], ast.Call)
+        ]
+        self.assertEqual(len(case_guards), 2)
+        self.assertTrue(all("pid_shared" in guard for guard in case_guards))
 
-        _copy_guards, dim_semantics = _pallas_shared_output_plan(
-            (4,),
-            [0, 1, 2],
+        copy_guards, dim_semantics = _pallas_shared_output_plan(
+            (5,),
+            [0, 1, 2, 3],
             [],
-            [1, 2],
-            {1, 2},
+            [1, 3],
+            {1, 3},
             [
-                ((None,), (None,)),
-                ((128,), ((0, 1, 2, 0),)),
-                ((128,), ((0, 1, 2, 2),)),
+                ((128,), ((0, 1, 2, 0, 2),)),
+                ((128,), ((0, 1, 2, 0, 2),)),
+                ((128,), ((0, 1, 3, 2, 3),)),
+                ((128,), ((0, 1, 3, 2, 3),)),
             ],
         )
+        self.assertEqual(
+            copy_guards,
+            {
+                1: ((), ((0, 0, 2, ((1, 2),)),)),
+                3: ((), ((0, 2, 3, ((1, 3),)),)),
+            },
+        )
         self.assertEqual(dim_semantics, ("arbitrary",))
+
+    def test_foreach_outputs_execute(self) -> None:
+        config = helion.Config(block_sizes=[128, 128])
+        x = torch.randn(256, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(384, device=DEVICE, dtype=torch.float32)
+        compiled = pallas_foreach_unequal_outputs.bind((x, y)).compile_config(config)
+        for seed in range(3):
+            torch.manual_seed(seed)
+            current_x = torch.randn(256, device=DEVICE, dtype=torch.float32)
+            current_y = torch.randn(384, device=DEVICE, dtype=torch.float32)
+            out_x, out_y = compiled(current_x, current_y)
+            torch.testing.assert_close(out_x, current_x + 1.0)
+            torch.testing.assert_close(out_y, current_y * 2.0)
 
     def test_fori_loop_multidim(self) -> None:
         """Test fori_loop with a 2D inner loop (nested iteration)."""
@@ -6485,9 +6760,6 @@ class TestPallas(TestCase):
         with self.assertRaisesRegex(helion.exc.BackendUnsupported, "lane/sublane"):
             fn.bind((x,)).to_code(helion.Config(pallas_loop_type="fori_loop"))
 
-    @xfailIfPallasInterpret(
-        "outer BlockSpec plus inner pipeline uses a dynamic DMA slice in interpret mode"
-    )
     def test_exact_block_subrange_last_two_dim_direct_store_allowed(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def fn(x: torch.Tensor) -> torch.Tensor:
@@ -8112,10 +8384,15 @@ class TestPallas(TestCase):
         config = Config(pallas_loop_type="fori_loop")
         code = kernel_with_0d_arg.bind((x, scalar, y)).to_code(config)
 
-        self.assertIn(
-            "_block_spec_info=[((128, 128), (0, 1)), None, ((128, 128), (0, 1)), ((128, 128), (0, 1))]",
-            code,
-        )
+        match = re.search(r"_block_spec_info=(\[[^\]]*\])", code)
+        self.assertIsNotNone(match, "expected _block_spec_info in launcher call")
+        block_spec_info = ast.literal_eval(match.group(1))
+        tensor_block_spec = ((128, 128), (0, 1))
+        self.assertEqual(len(block_spec_info), 4)
+        self.assertEqual(block_spec_info[0], tensor_block_spec)
+        self.assertIsNone(block_spec_info[1])
+        self.assertEqual(block_spec_info[2], tensor_block_spec)
+        self.assertEqual(block_spec_info[3], tensor_block_spec)
 
 
 @skipUnlessPallas("JAX/Pallas TPU not available")


### PR DESCRIPTION
Stacked PRs:
 * #2962
 * #2957
 * #2956
 * __->__#2955
 * #2954
 * #2953
 * #2952
 * #2951
 * #2949
 * #2948
 * #2947
 * #2946
 * #2945
 * #2944
 * #2943
 * #2942


--- --- ---

### Honor Pallas shared-output BlockSpec metadata


Example fixed: none directly; this is shared-output runtime infrastructure for later segmented and barrier-style kernels.

Compiler/runtime side: teach shared-output planning about flattened ForEach `BlockSpec` decompositions, mark partially shared grid dimensions as arbitrary, and guard the initial in-place copy so only the owning logical program seeds a shared output tile.

Why needed: shared outputs can span multiple physical Pallas programs; without owner-aware copy guards, non-owning programs can reseed or clobber another program's tile.
