### PR TITLE
Support integer tunables as symbolic extents

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -617,7 +617,7 @@ class Backend(abc.ABC):
         """Return the RDIM block size for a statically known reduction dimension."""
         from torch._inductor.runtime.runtime_utils import next_power_of_2
 
-        return next_power_of_2(numel)
+        return max(next_power_of_2(numel), 1)
 
     def dynamic_rdim_size_expr(self, expr: str) -> str:
         """Generate a host-side expression for RDIM size from a dynamic dimension.
@@ -625,7 +625,7 @@ class Backend(abc.ABC):
         By default delegates to next_power_of_2_host_expr. Backends like Pallas
         that need exact sizes can override to return the expression unchanged.
         """
-        return self.next_power_of_2_host_expr(expr)
+        return f"max({self.next_power_of_2_host_expr(expr)}, 1)"
 
     def lane_index_expr(
         self, offset_var: str, elements_per_thread: int, *, axis: int

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -30,8 +30,6 @@ import torch.distributed as dist
 from torch.fx.experimental.symbolic_shapes import DimDynamic
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols
-from torch.utils._sympy.symbol import SymT
-from torch.utils._sympy.symbol import symbol_is_type
 
 from .. import exc
 from .._compat import shape_env_size_hint
@@ -842,19 +840,16 @@ class CompileEnvironment:
                 block_idx = origin_info.origin.block_id
                 existing_block = self.block_sizes[block_idx]
 
-        def _is_unbacked_symint(x: int | torch.SymInt) -> bool:
+        def _has_unbacked_symint(x: int | torch.SymInt) -> bool:
             if not isinstance(x, torch.SymInt):
                 return False
-            expr = x._sympy_()
-            if isinstance(expr, sympy.Symbol):
-                return symbol_is_type(expr, SymT.UNBACKED_INT)
-            return False
+            return bool(free_unbacked_symbols(x._sympy_()))
 
         # Check for existing reduction dimensions with the same size
         for rdim in self.block_sizes:
             if not rdim.reduction or not isinstance(rdim.size, (int, torch.SymInt)):
                 continue
-            if _is_unbacked_symint(rdim.size) and _is_unbacked_symint(size):
+            if _has_unbacked_symint(rdim.size) or _has_unbacked_symint(size):
                 if self.known_equal(rdim.size, size):
                     return rdim
             elif rdim.size == size:
@@ -1251,6 +1246,10 @@ class CompileEnvironment:
                 # This preserves the original value passed to the kernel.
                 if expr in var_hints:
                     return int(var_hints[expr])
+                with contextlib.suppress(TypeError, ValueError):
+                    hinted_expr = expr.xreplace(var_hints)
+                    if not hinted_expr.free_symbols:
+                        return int(typing.cast("typing.SupportsInt", hinted_expr))
                 # Fall back to default hint if not found
                 return 8192
 
@@ -1667,12 +1666,50 @@ class ReductionLoopBlockSizeSource(BlockSizeSource):
             len(config.reduction_loops) <= self.reduction_loop
             or config.reduction_loops[self.reduction_loop] is None
         ):
-            size = max(1, block_size_info.size_hint())
             # Backends override static_rdim_size to control whether the
             # persistent-reduction extent is rounded up to a power of two
             # (Triton/CuTe) or kept exact (Pallas).
-            return CompileEnvironment.current().backend.static_rdim_size(size)
+            env = CompileEnvironment.current()
+            size = _size_hint_with_tunable_config(block_size_info.size, config, env)
+            return env.backend.static_rdim_size(size)
         return config.reduction_loops[self.reduction_loop]
+
+
+def _size_hint_with_tunable_config(
+    size: int | torch.SymInt | AutoSize | None,
+    config: Config,
+    env: CompileEnvironment,
+) -> int:
+    if not isinstance(size, (int, torch.SymInt)):
+        return 1
+    if isinstance(size, int):
+        return max(1, size)
+
+    expr = _symint_sympy_expr(size)
+    substitutions: dict[sympy.Symbol, int | sympy.Expr] = {
+        symbol: value
+        for symbol, tunable_name in env.tunable_symbols.items()
+        if type(value := config.get(tunable_name)) is int
+    }
+    for block_size_info in env.block_sizes:
+        if block_size_info.reduction:
+            continue
+        symbol = block_size_info.symbol()
+        if symbol not in expr.free_symbols:
+            continue
+        value = block_size_info.from_config(config)
+        if type(value) is int:
+            substitutions[symbol] = value
+        elif isinstance(value, torch.SymInt):
+            substitutions[symbol] = _symint_sympy_expr(value)
+    if substitutions:
+        substituted_expr = expr.subs(substitutions)
+        assert isinstance(substituted_expr, sympy.Expr)
+        expr = substituted_expr
+    extent = shape_env_size_hint(env.shape_env, expr)
+    if extent < 0:
+        raise exc.InvalidConfig(f"Tunable reduction extent evaluated to {extent}")
+    return max(1, extent)
 
 
 def warning(warning: exc.BaseWarning | type[exc.BaseWarning]) -> None:

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -13,6 +13,7 @@ import re
 import textwrap
 import threading
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import Callable
 from typing import Iterator
 from typing import NamedTuple
@@ -20,6 +21,7 @@ from typing import Protocol
 from typing import cast
 from unittest.mock import patch
 
+import sympy
 import torch
 from torch._dynamo.convert_frame import compile_lock
 from torch._inductor.decomposition import select_decomp_table
@@ -27,10 +29,14 @@ from torch.fx._lazy_graph_module import _LazyGraphModule
 from torch.fx.experimental import proxy_tensor
 from torch.fx.traceback import preserve_node_meta
 from torch.utils import _pytree as pytree
+from torch.utils._sympy.value_ranges import ValueRanges
+from torch.utils._sympy.value_ranges import bound_sympy
 
 from .. import Config
 from .. import exc
 from .. import language as hl
+from ..autotuner.config_fragment import BaseIntegerFragment
+from ..autotuner.config_fragment import EnumFragment
 from ..autotuner.config_spec import FULL_EXTENT_CATEGORIES
 from ..autotuner.config_spec import SIZED_REDUCTION_CATEGORIES
 from ..autotuner.config_spec import CoResidencyGroup
@@ -40,6 +46,7 @@ from ..autotuner.config_spec import ReductionCategory
 from ..autotuner.config_spec import ReductionDescriptor
 from ..autotuner.config_spec import ReductionKernelFact
 from ..autotuner.config_spec import ReductionLoopSpec
+from ..autotuner.config_spec import TunableReductionExtent
 from ..language import _tracing_ops
 from ..language._decorators import args_to_proxies
 from ..language._decorators import get_device_func_replacement
@@ -52,7 +59,9 @@ from .ast_extension import NodeVisitor
 from .ast_extension import create
 from .ast_extension import expr_from_string
 from .ast_read_writes import ReadWrites
+from .compile_environment import BlockSizeInfo
 from .compile_environment import CompileEnvironment
+from .compile_environment import FixedBlockSizeSource
 from .host_function import HostFunction
 from .indexing_strategy import subscript_index_scale
 from .indexing_strategy import subscript_tile_info
@@ -127,6 +136,120 @@ def _get_custom_decomp_table() -> dict[torch._ops.OpOverload, Callable[..., obje
     # default decomp expands the polynomial form and breaks the chain.
     install_gelu_decomp(decomp_table)
     return decomp_table
+
+
+def _reduction_loop_spec(
+    env: CompileEnvironment, rdim: BlockSizeInfo
+) -> ReductionLoopSpec:
+    size_hint = rdim.size_hint()
+    max_size_hint = size_hint
+    tunable_extent: TunableReductionExtent | None = None
+    if isinstance(rdim.size, torch.SymInt):
+        expression = rdim.size._sympy_()
+        assert isinstance(expression, sympy.Expr)
+        expression_symbols = {
+            symbol
+            for symbol in expression.free_symbols
+            if isinstance(symbol, sympy.Symbol)
+        }
+        assert len(expression_symbols) == len(expression.free_symbols)
+        symbol_names = tuple(
+            sorted(
+                (
+                    (symbol, name)
+                    for symbol, name in env.tunable_symbols.items()
+                    if symbol in expression_symbols
+                ),
+                key=operator.itemgetter(1),
+            )
+        )
+        if symbol_names:
+            accounted_symbols = {symbol for symbol, _ in symbol_names}
+            block_symbol_ids: list[tuple[sympy.Symbol, int]] = []
+            fixed_substitutions: dict[sympy.Symbol, int] = {}
+            default_substitutions: dict[sympy.Symbol, int] = {}
+            for symbol, name in symbol_names:
+                default = env.config_spec.user_defined_tunables[name].default()
+                assert type(default) is int
+                default_substitutions[symbol] = default
+            symbol_ranges: dict[sympy.Symbol, ValueRanges[sympy.Expr]] = {}
+            for symbol, name in symbol_names:
+                fragment = env.config_spec.user_defined_tunables[name]
+                if isinstance(fragment, BaseIntegerFragment):
+                    symbol_ranges[symbol] = ValueRanges(fragment.low, fragment.high)
+                elif isinstance(fragment, EnumFragment) and all(
+                    type(choice) is int for choice in fragment.choices
+                ):
+                    choices = cast("tuple[int, ...]", fragment.choices)
+                    symbol_ranges[symbol] = ValueRanges(min(choices), max(choices))
+            configured_block_ids = set(env.config_spec.block_sizes.valid_block_ids())
+            for symbol in sorted(
+                expression_symbols - accounted_symbols,
+                key=sympy.default_sort_key,
+            ):
+                if (block_id := env.get_block_id(symbol)) is None:
+                    break
+                if block_id in configured_block_ids:
+                    block_symbol_ids.append((symbol, block_id))
+                    block_spec = env.config_spec.block_sizes.block_id_lookup(block_id)
+                    block_default = block_spec._fragment(env.config_spec).default()
+                    assert type(block_default) is int
+                    default_substitutions[symbol] = block_default
+                    symbol_ranges[symbol] = ValueRanges(
+                        block_spec.min_size, block_spec.max_size
+                    )
+                else:
+                    source = env.block_sizes[block_id].block_size_source
+                    if not (
+                        isinstance(source, FixedBlockSizeSource)
+                        and isinstance(source.value, int)
+                    ):
+                        break
+                    fixed_substitutions[symbol] = source.value
+                    default_substitutions[symbol] = source.value
+                accounted_symbols.add(symbol)
+            if expression_symbols != accounted_symbols:
+                if env.backend_name == "cute":
+                    raise exc.InvalidConfig(
+                        "A CuTe tunable reduction extent may only depend on integer "
+                        "tunables and compile-time block sizes"
+                    )
+                return ReductionLoopSpec(
+                    block_id=rdim.block_id,
+                    size_hint=size_hint,
+                )
+
+            resolved_expression = expression.xreplace(fixed_substitutions)
+            assert isinstance(resolved_expression, sympy.Expr)
+            tunable_extent = TunableReductionExtent(
+                resolved_expression,
+                symbol_names,
+                tuple(block_symbol_ids),
+            )
+            default_extent = expression.xreplace(default_substitutions)
+            if not getattr(default_extent, "free_symbols", ()):
+                size_hint = max(1, int(cast("Any", default_extent)))
+                max_size_hint = size_hint
+
+            upper = bound_sympy(resolved_expression, symbol_ranges).upper
+            if not isinstance(upper, (int, sympy.Integer)):
+                if env.backend_name == "cute":
+                    raise exc.InvalidConfig(
+                        "A CuTe tunable reduction extent must have a finite integer "
+                        "bound"
+                    )
+                return ReductionLoopSpec(
+                    block_id=rdim.block_id,
+                    size_hint=size_hint,
+                )
+            max_size_hint = max(max_size_hint, int(cast("Any", upper)))
+
+    return ReductionLoopSpec(
+        block_id=rdim.block_id,
+        size_hint=size_hint,
+        max_size_hint=max_size_hint,
+        tunable_extent=tunable_extent,
+    )
 
 
 def _make_fx(fn: Callable[..., object], *args: object) -> torch.fx.Graph:
@@ -995,12 +1118,7 @@ class DeviceIR:
             if used_graphs & graphs_with_rolled_rdim:
                 continue
             if env.backend_name != "pallas":
-                env.config_spec.reduction_loops.append(
-                    ReductionLoopSpec(
-                        block_id=rdim.block_id,
-                        size_hint=rdim.size_hint(),
-                    )
-                )
+                env.config_spec.reduction_loops.append(_reduction_loop_spec(env, rdim))
                 if env.backend_name == "cute":
                     env.config_spec.cute_vector_widths.append(
                         CuteVectorWidthSpec(

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -56,6 +56,7 @@ from .compile_environment import _symint_sympy_expr
 from .cute.cutedsl_compat import cute_math_min_max_available
 from .device_function import VarInfo
 from .device_function import contains_only_block_size_symbols
+from .device_function import find_block_size_symbols
 from .node_masking import inductor_masked_value
 from .node_masking import mask_node_inputs
 
@@ -377,6 +378,13 @@ def _unpack_symint(x: torch.SymInt | int) -> sympy.Expr:
         # type: ignore [bad-return]
         return sympy.sympify(x)
     raise TypeError(f"Expected SymInt or int, got {type(x)}")
+
+
+def _contains_only_block_size_or_tunable_symbols(
+    expr: sympy.Expr, env: CompileEnvironment
+) -> bool:
+    _, non_block_symbols = find_block_size_symbols(expr)
+    return non_block_symbols <= set(env.tunable_symbols)
 
 
 @dataclasses.dataclass
@@ -767,14 +775,18 @@ class ReductionLowering(InductorLowering):
         env = CompileEnvironment.current()
         if isinstance(reduction_size, sympy.Symbol):
             block_index: int | None = env.get_block_id(reduction_size)
+            if block_index is None and reduction_size in env.tunable_symbols:
+                block_index = env.allocate_reduction_dimension(
+                    to_symint(reduction_size)
+                ).block_id
         elif isinstance(reduction_size, (int, sympy.Integer)):
             # Allocate or find a reduction dimension matching this size.
             # Convert to a SymInt when needed.
             size_symint_or_int = to_symint(reduction_size)
             block_index = env.allocate_reduction_dimension(size_symint_or_int).block_id
         elif isinstance(reduction_size, sympy.Expr):
-            # Handle symbolic expressions (including those with only block size symbols)
-            if contains_only_block_size_symbols(reduction_size):
+            # Handle symbolic expressions whose free symbols are config-time values.
+            if _contains_only_block_size_or_tunable_symbols(reduction_size, env):
                 size_symint = to_symint(reduction_size)
                 block_index = env.allocate_reduction_dimension(size_symint).block_id
             else:

--- a/helion/_compiler/node_masking.py
+++ b/helion/_compiler/node_masking.py
@@ -22,6 +22,7 @@ from ..language._tracing_ops import _if
 from ..language._tracing_ops import _mask_to
 from ..language._tracing_ops import _phi
 from ..language._tracing_ops import is_for_loop_target
+from .compile_environment import CompileEnvironment
 
 if TYPE_CHECKING:
     from .inductor_lowering import InductorLowering
@@ -143,24 +144,38 @@ def remove_unnecessary_masking(graph: torch.fx.Graph) -> None:
         downstream_reduction_cache[node] = result
         return result
 
+    def masks_tunable_reduction_extent(node: torch.fx.Node) -> bool:
+        """Return true when this mask bounds a tunable reduction extent."""
+        val = node.meta.get("val")
+        if not isinstance(val, torch.Tensor):
+            return False
+        env = CompileEnvironment.current()
+        tunable_symbols = set(env.tunable_symbols)
+        if not tunable_symbols:
+            return False
+        for size in val.size():
+            block_id = env.resolve_block_id(size)
+            if block_id is None:
+                continue
+            info = env.block_sizes[env.canonical_block_id(block_id)]
+            if not info.reduction or not isinstance(info.size, (int, torch.SymInt)):
+                continue
+            if info.numel.free_symbols & tunable_symbols:
+                return True
+        return False
+
     for node in graph.find_nodes(op="call_function", target=_mask_to):
         input_node, masked_value0 = node.args
         assert isinstance(input_node, torch.fx.Node)
         masked_value1 = cached_masked_value(input_node)
         if masked_value0 == masked_value1:
-            # If the value feeds a reduction and depends on a reduction output,
-            # we must preserve the mask to zero-out padded lanes. For example, in
-            # `test_layer_norm_nonpow2_reduction`, the 1536-wide reduction tile is padded to
-            # the next power of two; the mask keeps those extra lanes at the
-            # neutral value so the mean/variance sums stay correct. Rolled
-            # reductions similarly insert a mask right before the final sum to
-            # discard zero-padded iterations. We need to keep the mask in these
-            # cases otherwise the padded lanes would contribute irrelevant data and
-            # corrupt the reduction result.
-            if feeds_reduction_input(input_node) and depends_on_reduction_output(
-                input_node
-            ):
-                continue
+            # Keep masks that protect padded reduction lanes, including tunable
+            # extents whose storage may be larger than the selected config.
+            if feeds_reduction_input(input_node):
+                if depends_on_reduction_output(input_node):
+                    continue
+                if masks_tunable_reduction_extent(node):
+                    continue
             node.replace_all_uses_with(  # pyrefly: ignore [missing-attribute]
                 input_node
             )
@@ -262,7 +277,6 @@ def defer_pallas_load_masks(graph: torch.fx.Graph) -> None:
     """
     from ..language.memory_ops import load as load_op
     from .aten_lowering import passthrough_masked_value
-    from .compile_environment import CompileEnvironment
 
     env = CompileEnvironment.current()
 

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -787,11 +787,13 @@ class PallasBackend(Backend):
 
     def static_rdim_size(self, numel: int) -> int:
         # Pallas block refs use exact tensor dimensions, so RDIM_SIZE must
-        # match (no power-of-2 rounding that would exceed the block ref).
-        return numel
+        # match (no power-of-2 rounding that would exceed the block ref). Empty
+        # refs are the exception: the runtime represents them with one masked
+        # lane because Pallas cannot construct a zero-sized block.
+        return max(numel, 1)
 
     def dynamic_rdim_size_expr(self, expr: str) -> str:
-        return expr
+        return f"max({expr}, 1)"
 
     def _get_pallas_required_alignment(
         self, dim_from_end: int, tensor_ndim: int, bitwidth: int

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -693,7 +693,22 @@ class PersistentReductionStrategy(ReductionStrategy):
         self.offset_vars[block_index] = "0"
         # Compute thread count for warp-level reductions
         max_threads = env.backend.max_reduction_threads()
+        size_hint = 0
         if max_threads is not None:
+            block_info = env.block_sizes[block_index]
+            hint_numel: int | sympy.Expr = numel
+            if numel.free_symbols & set(env.tunable_symbols):
+                # Shape-env hints use a tunable's default, but thread groups and
+                # synthetic lanes must follow the value selected by this config.
+                configured_numel = block_info.from_config(fn.config)
+                if isinstance(configured_numel, int):
+                    hint_numel = configured_numel
+            if isinstance(hint_numel, (int, sympy.Integer)):
+                size_hint = int(hint_numel)
+            elif isinstance(hint_numel, sympy.Expr):
+                size_hint = shape_env_size_hint(env.shape_env, hint_numel)
+            else:
+                size_hint = env.size_hint(hint_numel)
             if env.backend.name == "cute":
                 max_threads = cute_live_reduction_threads(max_threads)
                 # Indexed reductions (argmin/argmax) on CuTe only have a
@@ -703,12 +718,6 @@ class PersistentReductionStrategy(ReductionStrategy):
                 # ``cute.arch.warp_reduction`` is correct.
                 if _block_has_indexed_reduction(fn, block_index):
                     max_threads = min(max_threads, _CUTE_WARP_REDUCTION_THREADS)
-            if isinstance(numel, (int, sympy.Integer)):
-                size_hint = int(numel)
-            elif isinstance(numel, sympy.Expr):
-                size_hint = shape_env_size_hint(env.shape_env, numel)
-            else:
-                size_hint = env.size_hint(numel)
             self._thread_count = next_power_of_2(min(size_hint, max_threads))
         else:
             self._thread_count = 0
@@ -738,12 +747,6 @@ class PersistentReductionStrategy(ReductionStrategy):
             for graph in fn.codegen.codegen_graphs
         )
         if self._thread_count > 0:
-            if isinstance(numel, (int, sympy.Integer)):
-                size_hint = int(numel)
-            elif isinstance(numel, sympy.Expr):
-                size_hint = shape_env_size_hint(env.shape_env, numel)
-            else:
-                size_hint = env.size_hint(numel)
             # For a non-graph-reduction dim we always try to recover the
             # full extent through a synthetic lane loop. For a graph
             # reduction dim we only need the synthetic lane loop when

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -67,6 +67,7 @@ from ..runtime.triton.launcher import get_num_xcd
 from .block_id_sequence import BlockIdSequence
 from .block_id_sequence import _BlockIdItem
 from .block_id_sequence import _PowerOfTwoBlockIdItem
+from .config_fragment import BaseIntegerFragment
 from .config_fragment import BlockSizeFragment
 from .config_fragment import BooleanFragment
 from .config_fragment import ConfigSpecFragment
@@ -85,6 +86,8 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
     from collections.abc import Sequence
 
+    import sympy
+
     from .._compiler.backend import Backend
     from ..runtime.config import IndexingLiteral
     from ..runtime.config import PidTypeLiteral
@@ -101,6 +104,53 @@ class TensorNumelConstraint(NamedTuple):
     check_fn: Callable[..., bool]
     block_indices: tuple[int, ...]
     expr_str: str
+
+
+class TunableReductionExtent(NamedTuple):
+    """A reduction extent expression backed by tunables and block sizes."""
+
+    expression: sympy.Expr
+    symbol_names: tuple[tuple[sympy.Symbol, str], ...]
+    block_symbol_ids: tuple[tuple[sympy.Symbol, int], ...]
+
+    def evaluate(
+        self,
+        config: Mapping[str, object],
+        fragments: Mapping[str, ConfigSpecFragment],
+        block_specs: BlockIdSequence[BlockSizeSpec],
+    ) -> int:
+        substitutions = {}
+        for symbol, name in self.symbol_names:
+            value = config.get(name, fragments[name].default())
+            if type(value) is not int:
+                raise InvalidConfig(
+                    f"config[{name!r}] must be an integer, got {value!r}"
+                )
+            substitutions[symbol] = value
+        block_sizes = config.get("block_sizes")
+        if not isinstance(block_sizes, list):
+            raise InvalidConfig(
+                "block_sizes must be normalized before reduction extents"
+            )
+        for symbol, block_id in self.block_symbol_ids:
+            value = block_specs.config_get(block_sizes, block_id)
+            if type(value) is not int:
+                raise InvalidConfig(
+                    f"Could not resolve block size {block_id} in reduction extent"
+                )
+            substitutions[symbol] = value
+        value = self.expression.xreplace(substitutions)
+        if getattr(value, "free_symbols", ()):
+            raise InvalidConfig(
+                f"Could not resolve tunable reduction extent {self.expression!s}"
+            )
+        extent = int(cast("Any", value))
+        if extent < 0:
+            raise InvalidConfig(
+                f"Tunable reduction extent {self.expression!s} evaluated to {extent}"
+            )
+        # A zero-length logical reduction still needs one masked backend lane.
+        return max(1, extent)
 
 
 class MatmulFact(NamedTuple):
@@ -1597,6 +1647,44 @@ class ConfigSpec:
     def is_supported_config(self, config: Mapping[str, object]) -> bool:
         return not self.unsupported_config_keys(config)
 
+    def _validate_user_defined_tunables(self, config: Mapping[str, object]) -> None:
+        for name, fragment in self.user_defined_tunables.items():
+            if name not in config:
+                continue
+            value = config[name]
+            if isinstance(fragment, BaseIntegerFragment):
+                if type(value) is not int or not fragment.low <= value <= fragment.high:
+                    raise InvalidConfig(
+                        f"config[{name!r}] must be an integer in "
+                        f"[{fragment.low}, {fragment.high}], got {value!r}"
+                    )
+                if isinstance(fragment, PowerOfTwoFragment):
+                    try:
+                        assert_integer_power_of_two(value)
+                    except InvalidConfig:
+                        raise InvalidConfig(
+                            f"config[{name!r}] must be a power of two, got {value!r}"
+                        ) from None
+            elif isinstance(fragment, EnumFragment):
+                valid = any(
+                    type(value) is type(choice) and value == choice
+                    for choice in fragment.choices
+                )
+                if not valid:
+                    raise InvalidConfig(
+                        f"config[{name!r}] must be one of {fragment.choices!r}, "
+                        f"got {value!r}"
+                    )
+
+    def _configured_reduction_extent(
+        self, spec: ReductionLoopSpec, config: Mapping[str, object]
+    ) -> int:
+        if spec.tunable_extent is None:
+            return spec.size_hint
+        return spec.tunable_extent.evaluate(
+            config, self.user_defined_tunables, self.block_sizes
+        )
+
     def normalize(
         self, config: helion.Config | dict[str, object], *, _fix_invalid: bool = False
     ) -> None:
@@ -1688,6 +1776,8 @@ class ConfigSpec:
                 name, config.get(name, ()), flatten=flatten
             )
 
+        self._validate_user_defined_tunables(config)
+
         # Clamp inner block sizes that are bounded by an outer block
         # (e.g. ``hl.tile(outer.begin, outer.end)``): at this point the
         # outer's concrete block size for this config is known, and the
@@ -1741,6 +1831,21 @@ class ConfigSpec:
                         new_num_threads[i] = max(num_thread, 1)
                     config["num_threads"] = new_num_threads
 
+        reduction_loops = config.get("reduction_loops")
+        if isinstance(reduction_loops, list):
+            normalized_loops = list(reduction_loops)
+            changed = False
+            for i, spec in enumerate(self.reduction_loops):
+                if i >= len(normalized_loops):
+                    break
+                loop = normalized_loops[i]
+                extent = self._configured_reduction_extent(spec, config)
+                if isinstance(loop, int) and loop >= extent:
+                    normalized_loops[i] = None
+                    changed = True
+            if changed:
+                config["reduction_loops"] = normalized_loops
+
         if self.supports_config_key("num_threads"):
             num_threads = cast("list[int]", config.get("num_threads", []))
             if all(value == 0 for value in num_threads):
@@ -1761,6 +1866,7 @@ class ConfigSpec:
                 for i, spec in enumerate(self.reduction_loops):
                     if i >= len(new_loops):
                         break
+                    extent = self._configured_reduction_extent(spec, config)
                     # Indexed reductions (argmin/argmax) on CuTe must keep
                     # the persistent thread count or rolled chunk within a
                     # single warp, since cute.arch.warp_reduction only
@@ -1771,8 +1877,8 @@ class ConfigSpec:
                         and spec.block_id in self.cute_indexed_reduction_block_ids
                     ):
                         block_threshold = min(block_threshold, 32)
-                    if new_loops[i] is None and spec.size_hint > block_threshold:
-                        new_loops[i] = min(spec.size_hint, block_threshold)
+                    if new_loops[i] is None and extent > block_threshold:
+                        new_loops[i] = min(extent, block_threshold)
                         changed = True
                     elif (
                         new_loops[i] is not None
@@ -1826,7 +1932,8 @@ class ConfigSpec:
                 for i, spec in enumerate(self.reduction_loops):
                     if i >= len(new_loops):
                         break
-                    if new_loops[i] is None and spec.size_hint > available:
+                    extent = self._configured_reduction_extent(spec, config)
+                    if new_loops[i] is None and extent > available:
                         # When other_threads consumes the entire CuTe 1024 thread
                         # budget there is no thread budget left for the reduction
                         # axis. A chunk of 1 is invalid (LoopedReductionStrategy
@@ -1840,7 +1947,7 @@ class ConfigSpec:
                                 f"{other_threads} of {self.max_reduction_threads} "
                                 f"threads)."
                             )
-                        chunk = min(spec.size_hint, available)
+                        chunk = min(extent, available)
                         if self.max_reduction_loop is not None:
                             chunk = min(chunk, self.max_reduction_loop)
                         new_loops[i] = chunk
@@ -2306,6 +2413,16 @@ class ConfigSpec:
         key: str,
         config: dict[str, object],
     ) -> tuple[bool, object]:
+        if key == "reduction_loops" and self.reduction_loops:
+            normalized = dict(config)
+            if "block_size" not in normalized and "block_sizes" not in normalized:
+                normalized["block_sizes"] = self.block_sizes._flat_config(
+                    self, lambda fragment: fragment.default()
+                )
+            if "reduction_loop" not in normalized:
+                normalized["reduction_loops"] = [None] * len(self.reduction_loops)
+            self.normalize(normalized, _fix_invalid=True)
+            return True, normalized["reduction_loops"]
         if self.backend_name == "cute":
             if self.cute_flash_search_enabled and key == FLASH_PIPELINE_FAMILY_KEY:
                 return True, self._resolve_cute_flash_config(config).pipeline_family
@@ -2869,23 +2986,29 @@ class ReductionLoopSpec(_PowerOfTwoBlockIdItem):
         *,
         block_id: int,
         size_hint: int,
+        max_size_hint: int | None = None,
+        tunable_extent: TunableReductionExtent | None = None,
     ) -> None:
         super().__init__([block_id])
         self.size_hint = size_hint
+        self.max_size_hint = max(size_hint, max_size_hint or size_hint)
+        self.tunable_extent = tunable_extent
 
     def _flat_fragment(self, base: ConfigSpec) -> BlockSizeFragment:
         # Shared by both directions:
         # - unflatten: flat integer -> Config value via _flat_config()
         # - flatten: Config value -> flat integer via _encode_flat_value()
         low = 8  # TODO(jansel): is smaller needed?
-        high = next_power_of_2(max(low, self.size_hint))
-        default = min(high, 4096)
+        high = next_power_of_2(max(low, self.max_size_hint))
+        default = min(next_power_of_2(max(low, self.size_hint)), 4096)
         # Cap default at the backend's max reduction loop so that
         # large reductions default to looped rather than persistent.
         if base.max_reduction_loop is not None:
             force_threshold = base.reduction_loop_force_threshold
             if force_threshold is not None and self.size_hint > force_threshold:
                 default = min(default, base.max_reduction_loop)
+        if self.tunable_extent is not None and default >= self.size_hint:
+            default = high
         return BlockSizeFragment(low, high, default)
 
     def _flat_config(
@@ -2900,7 +3023,10 @@ class ReductionLoopSpec(_PowerOfTwoBlockIdItem):
             raise InvalidConfig(
                 f"Invalid value for reduction loop {low} <= {value} <= {high}"
             )
-        if value >= self.size_hint:
+        if self.tunable_extent is not None:
+            if value == high:
+                return None
+        elif value >= self.size_hint:
             return None  # max size becomes persistent reduction
         return value
 
@@ -2939,7 +3065,11 @@ class ReductionLoopSpec(_PowerOfTwoBlockIdItem):
         # two reductions).  Collapsing to ``None`` here matches the
         # ``_flat_config`` behaviour and keeps the persistent/loop choice in
         # sync regardless of how the value was generated.
-        if isinstance(normalized, int) and normalized >= self.size_hint:
+        if (
+            self.tunable_extent is None
+            and isinstance(normalized, int)
+            and normalized >= self.size_hint
+        ):
             return None
         return normalized
 

--- a/helion/language/tunable_ops.py
+++ b/helion/language/tunable_ops.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from typing import cast
 
+import sympy
 import torch
 from torch._inductor.codegen.simd import constant_repr
 from torch._inductor.runtime.runtime_utils import next_power_of_2
@@ -16,6 +18,7 @@ from .._compiler.type_info import TypeInfo
 from .._compiler.type_info import _to_proxy
 from ..autotuner.config_fragment import BaseIntegerFragment
 from ..autotuner.config_fragment import ConfigSpecFragment
+from ..autotuner.config_fragment import EnumFragment
 from ..autotuner.config_fragment import assert_integer_power_of_two
 from ..autotuner.config_spec import VALID_KEYS
 from ..exc import NotInsideKernel
@@ -175,9 +178,35 @@ def _register_tunable_type(
     # register the value for tuning
     env.config_spec.user_defined_tunables[name_val] = fragment_val
 
-    python_type = type(fragment_val.default())
+    default = fragment_val.default()
+    python_type = type(default)
     if not issubclass(python_type, (int, float, bool)):
         raise exc.TunableTypeNotSupported(python_type)
+    if python_type is int:
+        from .._compiler.type_info import SymIntType
+
+        assert isinstance(default, int)
+        value = env.create_unbacked_symint(hint=default)
+        expr = value._sympy_()
+        assert isinstance(expr, sympy.Symbol), (
+            "integer tunables must be represented by a bare symbol"
+        )
+        env.tunable_symbols[expr] = name_val
+        if isinstance(fragment_val, BaseIntegerFragment):
+            env.shape_env.constrain_symbol_range(
+                expr, fragment_val.low, fragment_val.high
+            )
+        elif isinstance(fragment_val, EnumFragment) and all(
+            type(choice) is int for choice in fragment_val.choices
+        ):
+            choices = cast("tuple[int, ...]", fragment_val.choices)
+            assert choices
+            env.shape_env.constrain_symbol_range(
+                expr,
+                min(choices),
+                max(choices),
+            )
+        return SymIntType(origin, value)
     return NumericType.subtype(python_type).new_unbacked(origin)
 
 

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -715,6 +715,178 @@ class TestSettingsEnv(TestCase):
         self.assertEqual(config["block_sizes"][:2], [64, 64])
         self.assertEqual(config["num_threads"][:2], [64, 64])
 
+    def test_cute_tunable_reduction_uses_selected_extent(self) -> None:
+        import sympy
+
+        from helion._compiler.backend import CuteBackend
+        from helion.autotuner import PowerOfTwoFragment
+        from helion.autotuner.config_generation import ConfigGeneration
+        from helion.autotuner.config_spec import BlockSizeSpec
+        from helion.autotuner.config_spec import NumThreadsSpec
+        from helion.autotuner.config_spec import ReductionLoopSpec
+        from helion.autotuner.config_spec import TunableReductionExtent
+
+        width = sympy.Symbol("width", integer=True)
+        spec = ConfigSpec(
+            backend=CuteBackend(),
+            user_defined_tunables={
+                "width": PowerOfTwoFragment(16, 512, 64),
+            },
+        )
+        for block_id, size_hint in enumerate((1, 1, 16, 1, 1)):
+            spec.block_sizes.append(
+                BlockSizeSpec(block_id=block_id, size_hint=size_hint)
+            )
+            spec.num_threads.append(
+                NumThreadsSpec(block_id=block_id, size_hint=size_hint)
+            )
+        reduction_spec = ReductionLoopSpec(
+            block_id=5,
+            size_hint=64,
+            max_size_hint=512,
+            tunable_extent=TunableReductionExtent(
+                width,
+                ((width, "width"),),
+                (),
+            ),
+        )
+        spec.reduction_loops.append(reduction_spec)
+
+        fragment = reduction_spec._flat_fragment(spec)
+        self.assertEqual(fragment.default(), 512)
+        self.assertEqual(fragment.high, 512)
+        self.assertEqual(reduction_spec._flat_config(spec, lambda _: 128), 128)
+        self.assertIsNone(reduction_spec._flat_config(spec, lambda _: 512))
+        config_generation = ConfigGeneration(spec)
+        default_flat = config_generation.default_flat()
+        self.assertEqual(
+            config_generation.flatten(config_generation.unflatten(default_flat)),
+            default_flat,
+        )
+        partial = helion.Config(
+            block_sizes=[1, 1, 16, 1, 1],
+            width=512,
+        )
+        partial_flat = config_generation.flatten(partial)
+        self.assertEqual(
+            config_generation.flatten(config_generation.unflatten(partial_flat)),
+            partial_flat,
+        )
+
+        selected_large = {
+            "block_sizes": [1, 1, 16, 1, 1],
+            "reduction_loops": [None],
+            "width": 512,
+        }
+        spec.normalize(selected_large)
+        self.assertEqual(selected_large["reduction_loops"], [64])
+
+        explicit_loop = {
+            "block_sizes": [1, 1, 16, 1, 1],
+            "reduction_loops": [64],
+            "width": 128,
+        }
+        spec.normalize(explicit_loop)
+        self.assertEqual(explicit_loop["reduction_loops"], [64])
+
+        selected_small = {
+            "block_sizes": [1, 1, 16, 1, 1],
+            "reduction_loops": [64],
+            "width": 32,
+        }
+        spec.normalize(selected_small)
+        self.assertEqual(selected_small["reduction_loops"], [None])
+
+        out_of_range = {
+            "block_sizes": [1, 1, 16, 1, 1],
+            "reduction_loops": [None],
+            "width": 1024,
+        }
+        with self.assertRaisesRegex(helion.exc.InvalidConfig, "width.*16, 512"):
+            spec.normalize(out_of_range)
+
+    def test_tunable_reduction_uses_clamped_inner_block_size(self) -> None:
+        import sympy
+
+        from helion.autotuner import IntegerFragment
+        from helion.autotuner.config_spec import BlockSizeSpec
+        from helion.autotuner.config_spec import ReductionLoopSpec
+        from helion.autotuner.config_spec import TunableReductionExtent
+
+        width = sympy.Symbol("width", integer=True)
+        inner = sympy.Symbol("inner", integer=True)
+        spec = ConfigSpec(
+            backend=TritonBackend(),
+            user_defined_tunables={"width": IntegerFragment(2, 8, 4)},
+        )
+        spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=16, max_size=16))
+        spec.block_sizes.append(
+            BlockSizeSpec(
+                block_id=1,
+                size_hint=64,
+                max_size=64,
+                bounded_by_block_id=0,
+            )
+        )
+        spec.reduction_loops.append(
+            ReductionLoopSpec(
+                block_id=2,
+                size_hint=68,
+                max_size_hint=72,
+                tunable_extent=TunableReductionExtent(
+                    inner + width,
+                    ((width, "width"),),
+                    ((inner, 1),),
+                ),
+            )
+        )
+
+        config = {
+            "block_sizes": [16, 64],
+            "reduction_loops": [32],
+            "width": 4,
+        }
+        spec.normalize(config)
+        self.assertEqual(config["block_sizes"], [16, 16])
+        self.assertEqual(config["reduction_loops"], [None])
+
+    def test_flatten_tunable_reduction_accepts_singular_aliases(self) -> None:
+        import sympy
+
+        from helion.autotuner import IntegerFragment
+        from helion.autotuner.config_generation import ConfigGeneration
+        from helion.autotuner.config_spec import BlockSizeSpec
+        from helion.autotuner.config_spec import ReductionLoopSpec
+        from helion.autotuner.config_spec import TunableReductionExtent
+
+        block = sympy.Symbol("block", integer=True)
+        width = sympy.Symbol("width", integer=True)
+        spec = ConfigSpec(
+            backend=TritonBackend(),
+            user_defined_tunables={"width": IntegerFragment(2, 8, 4)},
+        )
+        spec.block_sizes.append(BlockSizeSpec(block_id=0, size_hint=2, max_size=8))
+        spec.reduction_loops.append(
+            ReductionLoopSpec(
+                block_id=1,
+                size_hint=6,
+                max_size_hint=16,
+                tunable_extent=TunableReductionExtent(
+                    block + width,
+                    ((width, "width"),),
+                    ((block, 0),),
+                ),
+            )
+        )
+        generation = ConfigGeneration(spec)
+
+        for config in (
+            helion.Config(block_size=2, width=4),
+            helion.Config(block_size=8, reduction_loop=8, width=4),
+        ):
+            flat = generation.flatten(config)
+            self.assertEqual(generation.flatten(generation.unflatten(flat)), flat)
+
     def test_detect_outer_block_bound_requires_end_minus_begin(self) -> None:
         from types import SimpleNamespace
 

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -207,6 +207,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             expected,
             fn_name="split_k_matmul",
             block_sizes=[16, 8, 16, 16, 16],
+            reduction_loops=[4],
             pid_type="persistent_blocked",
             split_k=64,
         )
@@ -226,6 +227,7 @@ class TestExamples(RefEagerTestBase, TestCase):
         m, k, n = 64, 33, 64
         config = helion.Config(
             block_sizes=[16, 8, 16, 16, 16],
+            reduction_loops=[4],
             pid_type="persistent_blocked",
             split_k=32,
         )

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -31,6 +31,8 @@ from helion._testing import skipUnlessPallas
 from helion._testing import xfailIfPallas
 from helion._testing import xfailIfPallasInterpret
 from helion._testing import xfailIfPallasTpu
+from helion.autotuner import IntegerFragment
+from helion.autotuner import PowerOfTwoFragment
 import helion.language as hl
 from helion.runtime.pallas.launcher import _pallas_copy_guard
 from helion.runtime.pallas.launcher import _pallas_launcher_cache_key
@@ -671,6 +673,35 @@ def pallas_associative_scan_int64_roundtrip(x: torch.Tensor) -> torch.Tensor:
         out[tile_m, tile_n] = hl.associative_scan(
             pallas_scan_int64_roundtrip_combine, x[tile_m, tile_n], dim=0
         )
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_integer_tunable_scale(x: torch.Tensor) -> torch.Tensor:
+    scale = hl.register_tunable("scale", IntegerFragment(1, 8, 3))
+    out = torch.empty_like(x)
+    for tile_m in hl.tile(x.size(0)):
+        out[tile_m] = x[tile_m] * scale
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_tunable_prefix_reduction(x: torch.Tensor) -> torch.Tensor:
+    width = hl.register_tunable("width", PowerOfTwoFragment(4, 16, 8))
+    tmp = torch.zeros([x.size(0), width], dtype=x.dtype, device=x.device)
+    out = torch.empty([x.size(0)], dtype=x.dtype, device=x.device)
+    for tile_m in hl.tile(x.size(0)):
+        out[tile_m] = torch.sum(tmp[tile_m, :] + x[tile_m, None], dim=-1)
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_integer_tunable_prefix_reduction(x: torch.Tensor) -> torch.Tensor:
+    width = hl.register_tunable("width", IntegerFragment(3, 9, 5))
+    tmp = torch.zeros([x.size(0), width], dtype=x.dtype, device=x.device)
+    out = torch.empty([x.size(0)], dtype=x.dtype, device=x.device)
+    for tile_m in hl.tile(x.size(0)):
+        out[tile_m] = torch.sum(tmp[tile_m, :] + x[tile_m, None], dim=-1)
     return out
 
 
@@ -5404,6 +5435,37 @@ class TestPallas(TestCase):
         code, result = code_and_output(pallas_reduce_non_pow2, (x,), block_size=128)
         expected = torch.nn.functional.softmax(x, dim=-1)
         torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
+
+    def test_integer_tunable_non_reduction(self) -> None:
+        x = torch.randn(32, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_integer_tunable_scale,
+            (x,),
+            block_size=8,
+            scale=5,
+        )
+        torch.testing.assert_close(result, x * 5)
+
+    def test_tunable_reduction_extent(self) -> None:
+        x = torch.randn(12, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_tunable_prefix_reduction,
+            (x,),
+            block_size=4,
+            width=16,
+        )
+        torch.testing.assert_close(result, x * 16)
+
+    def test_integer_tunable_reduction_extent_uses_selected_config(self) -> None:
+        x = torch.randn(12, device=DEVICE, dtype=torch.float32)
+        code, result = code_and_output(
+            pallas_integer_tunable_prefix_reduction,
+            (x,),
+            block_size=4,
+            width=7,
+        )
+        torch.testing.assert_close(result, x * 7)
+        self.assertIn("width = 7", code)
 
     def test_scalar_access_1D_constexpr(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True, config=helion.Config())

--- a/test/test_register_tunable.py
+++ b/test/test_register_tunable.py
@@ -13,7 +13,9 @@ from helion._testing import RefEagerTestBase
 from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import onlyBackends
+from helion._testing import skipIfRefEager
 from helion._testing import skipIfSharedMemoryLessThan
+from helion._testing import xfailIfCute
 from helion.autotuner import EnumFragment
 from helion.autotuner import IntegerFragment
 from helion.autotuner import PowerOfTwoFragment
@@ -74,6 +76,199 @@ class TestRegisterTunable(RefEagerTestBase, TestCase):
         )
         self.assertIn("multiplier=3", default_config)
 
+    @skipIfRefEager("requires compiling a tunable reduction extent")
+    def test_tunable_reduction_extent_expressions(self):
+        @helion.kernel(autotune_effort="none")
+        def reduction_width_plus_one(x: torch.Tensor) -> torch.Tensor:
+            width = hl.register_tunable("width", IntegerFragment(2, 8, 4))
+            tmp = torch.zeros([x.size(0), width + 1], dtype=x.dtype, device=x.device)
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(x.size(0)):
+                out[tile_m] = torch.sum(tmp[tile_m, :] + x[tile_m, None], dim=-1)
+            return out
+
+        @helion.kernel(autotune_effort="none")
+        def reduction_twice_width(x: torch.Tensor) -> torch.Tensor:
+            width = hl.register_tunable("width", IntegerFragment(2, 8, 4))
+            tmp = torch.zeros([x.size(0), 2 * width], dtype=x.dtype, device=x.device)
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(x.size(0)):
+                out[tile_m] = torch.sum(tmp[tile_m, :] + x[tile_m, None], dim=-1)
+            return out
+
+        @helion.kernel(autotune_effort="none")
+        def reduction_two_tunables(x: torch.Tensor) -> torch.Tensor:
+            width = hl.register_tunable("width", IntegerFragment(2, 8, 4))
+            extra = hl.register_tunable("extra", IntegerFragment(1, 4, 2))
+            tmp = torch.zeros(
+                [x.size(0), width + extra], dtype=x.dtype, device=x.device
+            )
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(x.size(0)):
+                out[tile_m] = torch.sum(tmp[tile_m, :] + x[tile_m, None], dim=-1)
+            return out
+
+        x = torch.randn(16, device=DEVICE, dtype=torch.float32)
+        selected_width = 6
+        cases = (
+            ("width_plus_one", reduction_width_plus_one, selected_width + 1),
+            ("twice_width", reduction_twice_width, 2 * selected_width),
+        )
+        for name, kernel, scale in cases:
+            with self.subTest(kernel=name):
+                _code, result = code_and_output(
+                    kernel, (x,), block_size=8, width=selected_width
+                )
+                torch.testing.assert_close(result, x * scale)
+
+        _code, result = code_and_output(
+            reduction_two_tunables,
+            (x,),
+            block_size=8,
+            width=selected_width,
+            extra=3,
+        )
+        torch.testing.assert_close(result, x * (selected_width + 3))
+
+        reduction_specs = reduction_twice_width.bind((x,)).config_spec.reduction_loops
+        self.assertEqual(len(reduction_specs), 1)
+        self.assertEqual(reduction_specs[0].max_size_hint, 16)
+        self.assertIsNotNone(reduction_specs[0].tunable_extent)
+
+    @skipIfRefEager("requires compiling a tunable reduction extent")
+    def test_tunable_reduction_zero_and_negative_selected_extents(self) -> None:
+        @helion.kernel(autotune_effort="none")
+        def reduction_width(x: torch.Tensor) -> torch.Tensor:
+            width = hl.register_tunable("width", IntegerFragment(-2, 4, 2))
+            tmp = torch.zeros([x.size(0), width], dtype=x.dtype, device=x.device)
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(x.size(0)):
+                out[tile_m] = torch.sum(tmp[tile_m, :], dim=-1)
+            return out
+
+        x = torch.randn(16, device=DEVICE, dtype=torch.float32)
+        _code, result = code_and_output(
+            reduction_width,
+            (x,),
+            block_size=8,
+            width=0,
+        )
+        torch.testing.assert_close(result, torch.zeros_like(x))
+
+        with self.assertRaisesRegex(
+            helion.exc.InvalidConfig,
+            "Tunable reduction extent.*evaluated to -1",
+        ):
+            code_and_output(
+                reduction_width,
+                (x,),
+                block_size=8,
+                width=-1,
+            )
+
+    @xfailIfCute("CuTe thread axis collision with differently-sized reduction blocks")
+    def test_tunable_reduction_extent_does_not_alias_fixed_hint(self):
+        @helion.kernel(autotune_effort="none")
+        def mixed_reductions(
+            x: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            width = hl.register_tunable("width", IntegerFragment(2, 8, 4))
+            fixed = torch.zeros([x.size(0), 4], dtype=x.dtype, device=x.device)
+            tuned = torch.zeros([x.size(0), width], dtype=x.dtype, device=x.device)
+            fixed_out = torch.empty_like(x)
+            tuned_out = torch.empty_like(x)
+            for tile_m in hl.tile(x.size(0)):
+                fixed_out[tile_m] = torch.sum(
+                    fixed[tile_m, :] + x[tile_m, None], dim=-1
+                )
+                tuned_out[tile_m] = torch.sum(
+                    tuned[tile_m, :] + x[tile_m, None], dim=-1
+                )
+            return fixed_out, tuned_out
+
+        x = torch.randn(16, device=DEVICE, dtype=torch.float32)
+        _code, (fixed_out, tuned_out) = code_and_output(
+            mixed_reductions, (x,), block_size=8, width=6
+        )
+        torch.testing.assert_close(fixed_out, x * 4)
+        torch.testing.assert_close(tuned_out, x * 6)
+
+    @skipIfRefEager("requires compiling a tunable reduction extent")
+    def test_tunable_reduction_extent_with_block_symbol(self):
+        @helion.kernel(autotune_effort="none")
+        def mixed_extent(x: torch.Tensor) -> torch.Tensor:
+            block = hl.register_block_size(2, 16)
+            width = hl.register_tunable("width", IntegerFragment(2, 8, 4))
+            tmp = torch.zeros(
+                [x.size(0), block + width], dtype=x.dtype, device=x.device
+            )
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(x.size(0)):
+                out[tile_m] = torch.sum(tmp[tile_m, :] + x[tile_m, None], dim=-1)
+            return out
+
+        x = torch.randn(16, device=DEVICE, dtype=torch.float32)
+        bound = mixed_extent.bind((x,))
+        self.assertEqual(len(bound.config_spec.reduction_loops), 1)
+        extent = bound.config_spec.reduction_loops[0].tunable_extent
+        self.assertIsNotNone(extent)
+        assert extent is not None
+        self.assertEqual(len(extent.block_symbol_ids), 1)
+        self.assertEqual(bound.config_spec.reduction_loops[0].max_size_hint, 24)
+        bound.config_spec.default_config()
+
+        @helion.kernel(autotune_effort="none")
+        def fixed_block_extent(x: torch.Tensor) -> torch.Tensor:
+            width = hl.register_tunable("width", IntegerFragment(2, 8, 4))
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(x.size(0), block_size=8):
+                tmp = hl.zeros([tile_m.block_size + width], dtype=x.dtype)
+                out[tile_m] = x[tile_m] + torch.sum(tmp)
+            return out
+
+        fixed_bound = fixed_block_extent.bind((x,))
+        fixed_spec = fixed_bound.config_spec.reduction_loops[0]
+        fixed_extent = fixed_spec.tunable_extent
+        self.assertIsNotNone(fixed_extent)
+        assert fixed_extent is not None
+        self.assertEqual(fixed_extent.block_symbol_ids, ())
+        self.assertEqual(fixed_spec.max_size_hint, 16)
+        fixed_bound.config_spec.default_config()
+
+        @helion.kernel(autotune_effort="none")
+        def inverse_block_extent(x: torch.Tensor) -> torch.Tensor:
+            width = hl.register_tunable("width", IntegerFragment(2, 64, 4))
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(x.size(0)):
+                tmp = hl.zeros([2048 // tile_m.block_size + width], dtype=x.dtype)
+                out[tile_m] = x[tile_m] + torch.sum(tmp)
+            return out
+
+        inverse_bound = inverse_block_extent.bind((x,))
+        inverse_spec = inverse_bound.config_spec.reduction_loops[0]
+        self.assertEqual(inverse_spec.max_size_hint, 2112)
+        inverse_bound.config_spec.default_config()
+
+    def test_tunable_reduction_extent_with_dynamic_input_symbol(self):
+        @helion.kernel(
+            backend="triton",
+            static_shapes=False,
+            autotune_effort="none",
+        )
+        def dynamic_extent(x: torch.Tensor) -> torch.Tensor:
+            width = hl.register_tunable("width", IntegerFragment(2, 8, 4))
+            tmp = torch.zeros(
+                [x.size(0), x.size(1) + width], dtype=x.dtype, device=x.device
+            )
+            out = torch.empty([x.size(0)], dtype=x.dtype, device=x.device)
+            for tile_m in hl.tile(x.size(0)):
+                out[tile_m] = torch.sum(tmp[tile_m, :] + x[tile_m, 0, None], dim=-1)
+            return out
+
+        x = torch.randn(16, 7, device=DEVICE, dtype=torch.float32)
+        _code, result = code_and_output(dynamic_extent, (x,), block_size=8, width=6)
+        torch.testing.assert_close(result, x[:, 0] * 13)
+
     def test_enum_fragment(self):
         @helion.kernel(config={"operation": 2})
         def kernel_with_enum(x: torch.Tensor) -> torch.Tensor:
@@ -92,6 +287,23 @@ class TestRegisterTunable(RefEagerTestBase, TestCase):
         result = kernel_with_enum(x)
         expected = x * 2.0
         torch.testing.assert_close(result, expected)
+
+    @skipIfRefEager("requires compiling a tunable reduction extent")
+    def test_integer_enum_reduction_extent(self):
+        @helion.kernel(autotune_effort="none")
+        def enum_reduction(x: torch.Tensor) -> torch.Tensor:
+            width = hl.register_tunable("width", EnumFragment((4, 128)))
+            tmp = torch.zeros([x.size(0), width], dtype=x.dtype, device=x.device)
+            out = torch.empty_like(x)
+            for tile_m in hl.tile(x.size(0)):
+                out[tile_m] = torch.sum(tmp[tile_m, :] + x[tile_m, None], dim=-1)
+            return out
+
+        x = torch.randn(16, device=DEVICE, dtype=torch.float32)
+        _code, result = code_and_output(enum_reduction, (x,), block_size=8, width=128)
+        torch.testing.assert_close(result, x * 128)
+        spec = enum_reduction.bind((x,)).config_spec.reduction_loops[0]
+        self.assertEqual(spec.max_size_hint, 128)
 
     def test_tensor_allocated_with_block_size(self):
         @helion.kernel()


### PR DESCRIPTION
Stacked PRs:
 * #2962
 * #2957
 * __->__#2956
 * #2955
 * #2954
 * #2953
 * #2952
 * #2951
 * #2949
 * #2948
 * #2947
 * #2946
 * #2945
 * #2944
 * #2943
 * #2942


--- --- ---

### Support integer tunables as symbolic extents


Example fixed: none directly; this enables Pallas kernels that size temporary tensors or reductions from integer `hl.register_tunable` values.

Compiler/runtime side: propagate integer tunables as SymInt-like symbolic values and allow reduction lowering to allocate dimensions from selected tunable symbols instead of fragment defaults.

Why needed: autotuned Pallas kernels need the selected config value to define temporary extents consistently in tracing, codegen, and runtime lowering.
