### PR TITLE
Support Pallas barrier phase launches

### DIFF
--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -343,9 +343,9 @@ class DeviceFunction:
         # dict would then need to support multiple entries per tensor
         # or the tensor would get distinct arg IDs per memory space.
         self.pallas_memory_space: dict[int, PallasMemorySpace] = {}
-        # Pallas: id(fake_tensor) → {dim: (block_id, extra_pad)} for dims
-        # using pl.ds() that may need host-side padding.
-        self.pallas_pad_info: dict[int, dict[int, tuple[int, int]]] = {}
+        # Pallas: id(fake_tensor) -> {dim: [(block_id, extra_pad), ...]} for
+        # dims using pl.ds() that may need host-side padding.
+        self.pallas_pad_info: dict[int, dict[int, list[tuple[int, int]]]] = {}
         # Pallas tensor-index atomic_add targets use a local RMW update.  Their
         # indirect output dimensions must be covered by shared-output
         # serialization in the launcher.
@@ -1078,6 +1078,18 @@ class DeviceFunction:
         assert isinstance(call_statement, ExtendedAST)
         # Mark the kernel call so we can find it in codegen_precompile_def
         call_statement._is_kernel_call = True
+        phase_host_var = getattr(self.codegen, "_pallas_barrier_phase_host_var", None)
+        if env.backend.name == "pallas" and phase_host_var is not None:
+            return create(
+                ast.For,
+                target=create(ast.Name, id=phase_host_var, ctx=ast.Store()),
+                iter=expr_from_string(
+                    f"range({len(self.codegen.host_function.device_ir.phases)})"
+                ),
+                body=[call_statement],
+                orelse=[],
+                type_comment=None,
+            )
         return call_statement
 
     def dead_code_elimination(self) -> None:
@@ -1173,8 +1185,14 @@ class DeviceFunction:
             shape, None, name_hint=name_hint, scratch_type="dma_semaphore"
         )
 
-    def get_tensor_read_write_names(self) -> tuple[set[str], set[str]]:
-        """Returns AST names of read and written tensors"""
+    def get_tensor_read_write_names(
+        self, *, register_missing: bool = True
+    ) -> tuple[set[str], set[str]]:
+        """Returns AST names of read and written tensors.
+
+        Set ``register_missing`` to false when this runs after device DCE, so
+        inspecting the original FX graphs does not recreate removed arguments.
+        """
         from helion.language import memory_ops
         from helion.language import tile_index
         from helion.language.atomic_ops import ATOMIC_OPS
@@ -1200,7 +1218,11 @@ class DeviceFunction:
                         return None
                     tensor_val = tensor_arg.meta.get("val")
                     assert isinstance(tensor_val, torch.Tensor)
-                    return self.tensor_arg(tensor_val).name
+                    if tensor_val not in self._tensor_args:
+                        if not register_missing:
+                            return None
+                        return self.tensor_arg(tensor_val).name
+                    return self._tensor_args[tensor_val].name
 
                 if node.target is memory_ops.load:
                     name = _get_tensor_name(node)

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -28,6 +28,7 @@ from .ast_read_writes import definitely_does_not_have_side_effects
 from .compile_environment import CompileEnvironment
 from .device_function import ConstExprArg
 from .device_function import DeviceFunction
+from .device_function import SymbolArgument
 from .helper_function import CodegenInterface
 from .inductor_lowering import CodegenState
 from .inductor_lowering import codegen_call_with_graph
@@ -48,7 +49,6 @@ if TYPE_CHECKING:
     from ..runtime import Config
     from .device_ir import GraphInfo
     from .host_function import HostFunction
-    from .loop_dependency_checker import LoopDependencyChecker
     from .pallas.compact_worklist import ResidentPrepHoist
     from .tile_strategy import DeviceLoopOrGridState
     from .type_info import TensorType
@@ -172,6 +172,21 @@ class GenerateAST(NodeVisitor, CodegenInterface):
             CompileEnvironment.current().backend.name == "pallas"
             and len(func.device_ir.root_ids) > 1
         )
+        self._pallas_barrier_phase_arg: str | None = None
+        self._pallas_barrier_phase_host_var: str | None = None
+        if self._pallas_direct_cases and len(func.device_ir.phases) > 1:
+            self._pallas_barrier_phase_arg = self.device_function.new_var(
+                "helion_phase"
+            )
+            self._pallas_barrier_phase_host_var = self.device_function.new_var(
+                "helion_phase_host"
+            )
+            self.device_function.arguments.append(
+                SymbolArgument(
+                    self._pallas_barrier_phase_arg,
+                    self._pallas_barrier_phase_host_var,
+                )
+            )
 
         # Decide once which sibling for-loops need a tl.debug_barrier()
         # to make global writes visible to subsequent reads.
@@ -224,10 +239,15 @@ class GenerateAST(NodeVisitor, CodegenInterface):
         root_id: int,
         body: list[ast.AST],
     ) -> None:
-        """Guard each Pallas root body by its immutable launch PID range."""
+        """Guard each Pallas root body by its launch case and optional phase."""
         if not self._pallas_direct_cases:
             return
-        fn_name = self.device_function.new_var(f"helion_case_root_{root_id}")
+        phase = self.host_function.device_ir.phase_for_root(root_id)
+        fn_name = self.device_function.new_var(
+            f"helion_phase_{phase}_root_{root_id}"
+            if self._pallas_barrier_phase_arg is not None
+            else f"helion_case_root_{root_id}"
+        )
         pid = self.device_function.pid
         assert isinstance(pid, ForEachProgramID)
         assert root_id < len(pid.cases), "missing Pallas direct case PID metadata"
@@ -245,6 +265,8 @@ class GenerateAST(NodeVisitor, CodegenInterface):
         condition = (
             f"({pid.shared_pid_var} >= ({start})) & ({pid.shared_pid_var} < ({end}))"
         )
+        if self._pallas_barrier_phase_arg is not None:
+            condition = f"({self._pallas_barrier_phase_arg} == {phase}) & ({condition})"
         body[:] = [
             create(
                 ast.FunctionDef,
@@ -266,10 +288,6 @@ class GenerateAST(NodeVisitor, CodegenInterface):
                 type_params=[],
             )
         ]
-
-    def _phase_checker(self, root_id: int) -> LoopDependencyChecker:
-        phase_idx = self.host_function.device_ir.phase_for_root(root_id)
-        return self.host_function.device_ir.phases[phase_idx].loop_dependency_checker
 
     def _compute_inter_loop_barriers(self) -> None:
         """Walk every codegen graph; for each pair of consecutive sibling
@@ -1074,15 +1092,12 @@ class GenerateAST(NodeVisitor, CodegenInterface):
             assert not node.orelse
 
             assert node._root_id is not None
-            # Loop dependency checks were already run during lowering; phase checker kept for symmetry/debug.
-            self._phase_checker(node._root_id)
 
             if len(self.host_function.device_ir.root_ids) == 1:
                 body = self.device_function.body
             else:
                 assert len(self.host_function.device_ir.root_ids) > 1
                 # Multiple top level for loops
-
                 if node._root_id == 0:
                     self.device_function.set_pid(
                         ForEachProgramID(
@@ -1459,7 +1474,9 @@ def generate_ast(
         env = CompileEnvironment.current()
         env.cute_resolved_wrapper_plans = []
         if len(func.device_ir.phases) > 1:
-            if not str(config.pid_type).startswith("persistent"):
+            if CompileEnvironment.current().backend.name != "pallas" and not str(
+                config.pid_type
+            ).startswith("persistent"):
                 raise exc.BarrierRequiresPersistent(config.pid_type)
         codegen = GenerateAST(
             func,

--- a/helion/_compiler/pallas/_codegen_modules.py
+++ b/helion/_compiler/pallas/_codegen_modules.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from . import aten_lowering  # noqa: F401
 from . import atomic_ops  # noqa: F401
+from . import barrier  # noqa: F401
 from . import creation_ops  # noqa: F401
 from . import gelu_tanh_approx  # noqa: F401
 from . import matmul_ops  # noqa: F401

--- a/helion/_compiler/pallas/backend.py
+++ b/helion/_compiler/pallas/backend.py
@@ -1328,6 +1328,56 @@ class PallasBackend(Backend):
             result.append((tuple(block_shape), tuple(grid_dims)))
         return result
 
+    def _pallas_phase_case_metadata(
+        self,
+        sorted_args: list[Argument] | None,
+        config: Config,
+    ) -> (
+        tuple[int, tuple[tuple[int, _PallasLaunchScalar, _PallasLaunchScalar], ...]]
+        | None
+    ):
+        """Return the phase argument position and each Pallas case PID range."""
+        if sorted_args is None:
+            return None
+
+        from ..device_function import DeviceFunction
+        from ..device_function import SymbolArgument
+        from ..program_id import ForEachProgramID
+
+        device_fn = DeviceFunction.current()
+        phase_arg = getattr(device_fn.codegen, "_pallas_barrier_phase_arg", None)
+        if phase_arg is None or not isinstance(device_fn.pid, ForEachProgramID):
+            return None
+
+        phase_arg_index = next(
+            (
+                i
+                for i, arg in enumerate(sorted_args)
+                if isinstance(arg, SymbolArgument) and arg.name == phase_arg
+            ),
+            None,
+        )
+        if phase_arg_index is None:
+            raise NotImplementedError(
+                "Pallas direct case launches require the phase argument in "
+                "launcher args"
+            )
+        if len(device_fn.pid.case_phases) != len(device_fn.pid.cases):
+            raise NotImplementedError(
+                "Pallas direct case launches require one phase entry per ForEach case"
+            )
+
+        ranges: list[tuple[int, _PallasLaunchScalar, _PallasLaunchScalar]] = []
+        start: _PallasLaunchScalar = 0
+        for phase, case in zip(
+            device_fn.pid.case_phases, device_fn.pid.cases, strict=True
+        ):
+            total = _PallasLaunchExpr(case.total_pids_expr(is_device=False))
+            end = _pallas_add_launch_values(start, total)
+            ranges.append((phase, start, end))
+            start = end
+        return phase_arg_index, tuple(ranges)
+
     def _compute_pad_info(
         self,
         sorted_args: list[Argument] | None,
@@ -1340,8 +1390,9 @@ class PallasBackend(Backend):
         empty resident operand needs (see :meth:`_zero_row_resident_pad_info`).
 
         Returns ``[(arg_index, tensor_dim, block_size, extra_pad), ...]``
-        or ``None``.  The launcher computes the actual pad amount at runtime
-        as ``(-tensor.shape[dim]) % block_size + extra_pad``.
+        or ``None``.  The launcher computes each requirement at runtime as
+        ``(-tensor.shape[dim]) % block_size + extra_pad`` and applies the
+        maximum required pad per ``(arg_index, tensor_dim)``.
 
         ``extra_pad`` is 0 when the tile loop starts at offset 0,
         ``begin % block_size`` for a constant begin offset, or
@@ -1357,19 +1408,26 @@ class PallasBackend(Backend):
         env = CompileEnvironment.current()
         device_fn = DeviceFunction.current()
 
-        result: list[tuple[int, int, int, int]] = []
-        if device_fn.pallas_pad_info:
-            for i, arg in enumerate(sorted_args):
-                if not isinstance(arg, TensorArg):
-                    continue
-                dims_info = device_fn.pallas_pad_info.get(id(arg.fake_value))
-                if dims_info is not None:
-                    for dim, (block_id, extra_pad) in dims_info.items():
+        result_by_key: dict[tuple[int, int, int], int] = {}
+        for i, arg in enumerate(sorted_args):
+            if not isinstance(arg, TensorArg):
+                continue
+            dims_info = device_fn.pallas_pad_info.get(id(arg.fake_value))
+            if dims_info is not None:
+                for dim, entries in dims_info.items():
+                    for block_id, extra_pad in entries:
                         bsi = env.block_sizes[block_id]
                         bs = bsi.from_config(config)
                         if isinstance(bs, int) and bs > 1:
-                            result.append((i, dim, bs, extra_pad))
+                            key = (i, dim, bs)
+                            result_by_key[key] = max(
+                                result_by_key.get(key, 0), extra_pad
+                            )
 
+        result = [
+            (arg_index, dim, bs, extra_pad)
+            for (arg_index, dim, bs), extra_pad in result_by_key.items()
+        ]
         result.extend(self._zero_row_resident_pad_info(sorted_args))
         return result or None
 
@@ -1576,7 +1634,9 @@ class PallasBackend(Backend):
         if sorted_args is not None:
             env = CompileEnvironment.current()
             host_fn = HostFunction.current()
-            read_names, write_names = device_fn.get_tensor_read_write_names()
+            read_names, write_names = device_fn.get_tensor_read_write_names(
+                register_missing=False
+            )
             mutated_params = write_names & {a.arg for a in host_fn.args.args}
             input_storages = {id(t.untyped_storage()) for t in env.input_sources}
             # Only tensors allocated with torch.empty/empty_like/new_empty can be
@@ -1603,7 +1663,7 @@ class PallasBackend(Backend):
                     output_indices.append(i)
                     inplace_indices.append(i)
 
-        if isinstance(device_fn.pid, ForEachProgramID):
+        if has_barrier or isinstance(device_fn.pid, ForEachProgramID):
             # A ForEach launch flattens disjoint case ranges. Programs outside
             # an output's case must preserve its current tile.
             inplace_indices = list(output_indices)
@@ -1679,6 +1739,13 @@ class PallasBackend(Backend):
                 block_spec_info.append(None)  # RNG seed buffer is untiled
             launcher_args.append(
                 f"_block_spec_info={_format_pallas_launch_value(block_spec_info)}"
+            )
+
+        phase_case_metadata = self._pallas_phase_case_metadata(sorted_args, config)
+        if phase_case_metadata is not None:
+            launcher_args.append(
+                "_pallas_phase_case_metadata="
+                f"{_format_pallas_launch_value(phase_case_metadata)}"
             )
 
         pad_info = self._compute_pad_info(sorted_args, config)
@@ -1899,6 +1966,8 @@ class PallasBackend(Backend):
     ) -> None:
         from ...autotuner.config_spec import VALID_PALLAS_WORKLIST_GROUPINGS
         from ..compile_environment import CompileEnvironment
+        from ..device_function import DeviceFunction
+        from ..host_function import HostFunction
         from .plan_tiling import plan_tiling
         from .tensorcore_plan import build_tensorcore_plans
 
@@ -1916,6 +1985,55 @@ class PallasBackend(Backend):
         plan_tiling(graphs, config, tile_strategy)
         _disable_partial_initialized_store_tiling(graphs)
         build_tensorcore_plans(graphs, config)
+
+        device_ir = HostFunction.current().device_ir
+        if len(device_ir.grid_block_ids) > 1:
+            for block_ids in device_ir.grid_block_ids:
+                if len(block_ids) > 1 and env.block_sizes[block_ids[0]].is_flattened(
+                    config
+                ):
+                    raise exc.InvalidConfig(
+                        "Pallas ForEach launches do not support multi-axis "
+                        "flattened grids; set flatten_loops=False"
+                    )
+
+            block_id_root_counts: dict[int, int] = {}
+            for block_ids in device_ir.grid_block_ids:
+                for block_id in set(block_ids):
+                    block_id_root_counts[block_id] = (
+                        block_id_root_counts.get(block_id, 0) + 1
+                    )
+            reused_block_ids = {
+                block_id
+                for block_id, count in block_id_root_counts.items()
+                if count > 1
+            }
+            if reused_block_ids:
+
+                def is_owned_by_reused_grid(block_id: int) -> bool:
+                    seen: set[int] = set()
+                    while block_id not in seen:
+                        if block_id in reused_block_ids:
+                            return True
+                        seen.add(block_id)
+                        try:
+                            spec = env.config_spec.block_sizes.block_id_lookup(block_id)
+                        except KeyError:
+                            return False
+                        owner = spec.owner_relative_bounded_by_block_id
+                        if owner is None:
+                            return False
+                        block_id = owner
+                    return False
+
+                device_fn = DeviceFunction.current()
+                for dim_tilings in device_fn.pallas_tensor_dim_tilings.values():
+                    for dim_tiling in dim_tilings:
+                        if any(
+                            is_owned_by_reused_grid(block_id)
+                            for block_id in dim_tiling.block_ids
+                        ):
+                            dim_tiling.can_tile = False
 
         # compact_worklist_* is per-CONFIG state, but one CompileEnvironment is
         # reused across all configs of a BoundKernel (see CompileEnvironment's

--- a/helion/_compiler/pallas/barrier.py
+++ b/helion/_compiler/pallas/barrier.py
@@ -1,0 +1,18 @@
+"""Pallas-backend codegen for ``helion.language.barrier``."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ...language import _decorators
+from ...language.barrier import barrier
+from ..ast_extension import expr_from_string
+
+if TYPE_CHECKING:
+    from ..inductor_lowering import CodegenState
+
+
+@_decorators.codegen(barrier, "pallas")
+def _(state: CodegenState) -> object:
+    # Pallas implements grid barriers as sequential host launches.
+    return expr_from_string("None")

--- a/helion/_compiler/pallas/codegen.py
+++ b/helion/_compiler/pallas/codegen.py
@@ -723,6 +723,189 @@ def _widened_scalar_load_promotion_dtype(
     return CompileEnvironment.current().backend.dtype_str(torch.float32)
 
 
+def widen_barrier_temp_store_indices(
+    state: CodegenState,
+    tensor: torch.Tensor,
+    subscript: list[object] | tuple[object, ...],
+    index_parts: list[str],
+    value: ast.AST,
+    name: str,
+) -> tuple[list[str], ast.AST]:
+    """Widen a scalar minor-dim temporary store to an aligned full-axis RMW."""
+    if not _is_pallas_barrier_temp_store(state, tensor):
+        return index_parts, value
+    if _tensor_routed_to_dma_scratch(state, tensor):
+        return index_parts, value
+
+    from helion._compiler.device_function import PallasMemorySpace
+
+    if (
+        state.device_function.pallas_memory_space.get(id(tensor))
+        == PallasMemorySpace.SMEM
+    ):
+        return index_parts, value
+
+    from helion._compiler.pallas.plan_tiling import ArbitraryIndexPattern
+    from helion._compiler.pallas.tensorcore_plan import TENSORCORE_PLAN_META
+    from helion._compiler.pallas.tensorcore_plan import OneHotScatterPlan
+
+    patterns = _get_indexing_patterns(state, tensor)
+    plan = state.fx_node.meta.get(TENSORCORE_PLAN_META) if state.fx_node else None
+    if isinstance(plan, OneHotScatterPlan):
+        return index_parts, value
+
+    from helion._compiler.pallas.backend import PallasBackend
+
+    backend = CompileEnvironment.current().backend
+    assert isinstance(backend, PallasBackend)
+
+    adjusted = list(index_parts)
+    widened: tuple[int, str, int] | None = None
+    value_dim = 0
+    tensor_dim = 0
+    index_part_idx = 0
+
+    for idx, pattern in zip(subscript, patterns, strict=True):
+        if idx is None:
+            continue
+
+        index_part = adjusted[index_part_idx]
+        dim_size = _concrete_barrier_temp_dim_size(state, tensor.shape[tensor_dim])
+        is_scalar = not _index_part_produces_value_dim(index_part)
+        can_widen = False
+        if is_scalar and dim_size is not None and dim_size > 0:
+            dim_from_end = tensor.ndim - tensor_dim - 1
+            required_alignment = backend._get_pallas_required_alignment(
+                dim_from_end,
+                tensor.ndim,
+                tensor.dtype.itemsize * 8,
+            )
+            can_widen = required_alignment > 1 and dim_size <= required_alignment
+            if can_widen:
+                normalized_index = _normalize_widened_scalar_index(index_part, dim_size)
+                can_widen = normalized_index is not None
+                if normalized_index is not None:
+                    index_part = normalized_index
+
+        if can_widen:
+            if (
+                widened is not None
+                or tensor_dim != tensor.ndim - 1
+                or not isinstance(pattern, ArbitraryIndexPattern)
+            ):
+                return index_parts, value
+            adjusted[index_part_idx] = ":"
+            assert dim_size is not None
+            widened = (value_dim, index_part, dim_size)
+            value_dim += 1
+        elif _index_part_produces_value_dim(index_part):
+            value_dim += 1
+
+        tensor_dim += 1
+        index_part_idx += 1
+
+    if widened is None:
+        return index_parts, value
+
+    value_elements = _store_value_numel(state)
+    axis, index_expr, dim_size = widened
+    if (
+        value_elements is None
+        or value_elements * dim_size * tensor.dtype.itemsize
+        > _FULL_LOAD_SELECT_MAX_BYTES
+    ):
+        return index_parts, value
+
+    current = expr_from_string(f"{name}[{', '.join(adjusted)}]")
+    store_value = expr_from_string(
+        f"jnp.expand_dims({{value}}, axis={axis})",
+        value=value,
+    )
+
+    dtype_str = _pallas_dtype_str(tensor)
+    mask = (
+        f"(({index_expr}) == jnp.arange({dim_size}, dtype=jnp.int32))"
+        f".astype({dtype_str})"
+    )
+    for _ in range(axis):
+        mask = f"jnp.expand_dims({mask}, axis=0)"
+    for _ in range(value_dim - axis - 1):
+        mask = f"jnp.expand_dims({mask}, axis=-1)"
+    value = numeric_mask_select_expr(
+        expr_from_string(mask),
+        store_value,
+        current,
+        tensor.dtype,
+        store_value,
+    )
+    return adjusted, value
+
+
+def _is_pallas_barrier_temp_store(state: CodegenState, tensor: torch.Tensor) -> bool:
+    env = CompileEnvironment.current()
+    if not env.has_barrier:
+        return False
+
+    from helion._compiler.host_function import HostFunction
+
+    host_function = HostFunction.current()
+    if len(host_function.device_ir.phases) <= 1:
+        return False
+    input_storages = {id(t.untyped_storage()) for t in env.input_sources}
+    if id(tensor.untyped_storage()) in input_storages:
+        return False
+    origin = host_function.tensor_to_origin.get(tensor)
+    name = origin.root_rw_name() if origin is not None else None
+    if name is None:
+        return False
+    read_names, write_names = state.device_function.get_tensor_read_write_names()
+    return name in read_names and name in write_names
+
+
+def _concrete_barrier_temp_dim_size(state: CodegenState, dim: object) -> int | None:
+    if isinstance(dim, int):
+        return dim
+    if not isinstance(dim, torch.SymInt):
+        return None
+
+    env = CompileEnvironment.current()
+    expr = _symint_sympy_expr(dim)
+    substitutions = {
+        symbol: value
+        for symbol, tunable_name in env.tunable_symbols.items()
+        if symbol in expr.free_symbols
+        and isinstance((value := state.config.get(tunable_name)), int)
+    }
+    if substitutions:
+        expr = expr.subs(substitutions)
+        assert isinstance(expr, sympy.Expr)
+    if not expr.free_symbols:
+        return int(expr)
+    if env.settings.static_shapes:
+        from helion._compiler.compile_environment import _size_hint_with_tunable_config
+
+        return _size_hint_with_tunable_config(dim, state.config, env)
+    return None
+
+
+def _store_value_numel(state: CodegenState) -> int | None:
+    if state.fx_node is None or len(state.fx_node.args) < 3:
+        return 1
+    value_arg = state.fx_node.args[2]
+    if not isinstance(value_arg, torch.fx.Node):
+        return 1
+    value = value_arg.meta.get("val")
+    if not isinstance(value, torch.Tensor):
+        return 1
+    elements = 1
+    for size in value.shape:
+        concrete_size = _concrete_barrier_temp_dim_size(state, size)
+        if concrete_size is None:
+            return None
+        elements *= concrete_size
+    return elements
+
+
 def _load_feeds_only_immediate_fp32_converts(state: CodegenState) -> bool:
     node = state.fx_node
     if node is None:

--- a/helion/_compiler/pallas/memory_ops.py
+++ b/helion/_compiler/pallas/memory_ops.py
@@ -43,6 +43,9 @@ def _(state: CodegenState) -> None:
     value = pallas_codegen.sliced_value_for_store(
         state, tensor, subscript, parts, value
     )
+    parts, value = pallas_codegen.widen_barrier_temp_store_indices(
+        state, tensor, subscript, parts, value, name
+    )
     idx_str = ", ".join(parts)
     from .gather import emit_scatter_store
     from .tensorcore_plan import TENSORCORE_PLAN_META

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -235,15 +235,17 @@ def _record_pad_info(
     at offset 0, ``begin % block_size`` for a constant begin, or
     ``block_size - 1`` for a data-dependent begin.
 
-    Note: stores one entry per (tensor, dim).  If two inner loops tile the
-    same dim with different block_ids, the last one wins.  This is fine when
-    both loops use the same block size (the common case).
+    A tensor dimension can be sliced by multiple loops with different block
+    sizes, so keep every distinct requirement.
     """
     pad_info = state.device_function.pallas_pad_info
     tensor_id = id(tensor)
     if tensor_id not in pad_info:
         pad_info[tensor_id] = {}
-    pad_info[tensor_id][tensor_dim] = (block_id, extra_pad)
+    entries = pad_info[tensor_id].setdefault(tensor_dim, [])
+    entry = (block_id, extra_pad)
+    if entry not in entries:
+        entries.append(entry)
 
 
 def _maybe_get_symbol_origin(idx: object) -> SymbolOrigin | None:

--- a/helion/runtime/pallas/jax_export.py
+++ b/helion/runtime/pallas/jax_export.py
@@ -14,7 +14,7 @@ that wrapper unchanged on JAX inputs, we wrap each input in a
 ``device='meta'`` (so torch operations only touch shape/dtype) but
 which carries the underlying JAX array on the side.  Operations the
 wrapper performs that *return a tensor we will later read back into
-JAX* — ``reshape`` / ``view`` / ``empty_like`` / ``F.pad`` — must be
+JAX* - ``reshape`` / ``view`` / tensor creation factories / ``F.pad`` - must be
 intercepted via ``__torch_function__`` so the JAX side stays in sync.
 Pure-shape introspection (``.size()``, ``.shape``, ``.ndim``,
 ``.dim()``) is left to the meta storage (it carries shape).  Anything
@@ -31,6 +31,7 @@ JAX side correctly.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
@@ -39,16 +40,18 @@ import torch
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from collections.abc import Iterator
 
     from ..kernel import Kernel
     from .launcher import _BlockSpecInfo
+    from .launcher import _PallasPhaseCaseMetadata
 
 
-_TORCH_TO_JNP_DTYPE: dict[torch.dtype, object] | None = None
-_JNP_TO_TORCH_DTYPE: dict[object, torch.dtype] | None = None
+_TORCH_TO_JNP_DTYPE: dict[torch.dtype, Any] | None = None
+_JNP_TO_TORCH_DTYPE: dict[Any, torch.dtype] | None = None
 
 
-def _build_dtype_maps() -> tuple[dict[torch.dtype, object], dict[object, torch.dtype]]:
+def _build_dtype_maps() -> tuple[dict[torch.dtype, Any], dict[Any, torch.dtype]]:
     """Return cached torch<->jnp dtype maps, building them on first use.
 
     Built lazily so importing this module never imports JAX (which is
@@ -59,7 +62,7 @@ def _build_dtype_maps() -> tuple[dict[torch.dtype, object], dict[object, torch.d
         return _TORCH_TO_JNP_DTYPE, _JNP_TO_TORCH_DTYPE
     import jax.numpy as jnp
 
-    pairs: list[tuple[torch.dtype, object]] = [
+    pairs: list[tuple[torch.dtype, Any]] = [
         (torch.float32, jnp.float32.dtype),
         (torch.float64, jnp.float64.dtype),
         (torch.float16, jnp.float16.dtype),
@@ -69,7 +72,10 @@ def _build_dtype_maps() -> tuple[dict[torch.dtype, object], dict[object, torch.d
         (torch.int32, jnp.int32.dtype),
         (torch.int64, jnp.int64.dtype),
         (torch.uint8, jnp.uint8.dtype),
+        (torch.uint32, jnp.uint32.dtype),
         (torch.bool, jnp.bool_.dtype),
+        (torch.complex64, jnp.complex64.dtype),
+        (torch.complex128, jnp.complex128.dtype),
     ]
     _TORCH_TO_JNP_DTYPE = dict(pairs)
     _JNP_TO_TORCH_DTYPE = {j: t for t, j in pairs}
@@ -81,6 +87,10 @@ def _jnp_to_torch_dtype(jnp_dtype: object) -> torch.dtype:
     return j2t[jnp_dtype]
 
 
+def _to_int(value: object) -> int:
+    return int(cast("Any", value))
+
+
 class _JaxExportTensor(torch.Tensor):
     """A ``torch.Tensor`` subclass that carries a JAX array on the side.
 
@@ -88,8 +98,8 @@ class _JaxExportTensor(torch.Tensor):
     invoked by the Helion-generated wrapper see correct shape/dtype but
     perform no real compute on the torch side.  ``__torch_function__``
     intercepts the small set of operations the wrapper actually uses
-    (``reshape``/``view``/``empty_like``/``F.pad``) and mirrors them on
-    the JAX array so the JAX side stays in sync.
+    (``reshape``/``view``/tensor creation factories/``F.pad``) and
+    mirrors them on the JAX array so the JAX side stays in sync.
 
     Use ``_JaxExportTensor.from_jax(arr, device=...)`` to construct one;
     use ``adapter._jax_arr`` (or :func:`_unwrap_jax` on a result) to
@@ -130,20 +140,50 @@ class _JaxExportTensor(torch.Tensor):
         if kwargs is None:
             kwargs = {}
 
-        # ``torch.empty_like(adapter, device='meta')`` shows up in
-        # generated wrappers when the kernel allocates an output-only
-        # tensor.  Allocate a JAX-side empty with matching shape/dtype
-        # so the export launcher can use the JAX array as the output
-        # placeholder.
-        if func is torch.empty_like:
+        # Like factories show up in generated wrappers when a kernel allocates
+        # an output or a cross-phase temporary. Mirror the allocation in JAX.
+        like_factories = {
+            torch.empty_like: "empty",
+            torch.zeros_like: "zeros",
+            torch.ones_like: "ones",
+            torch.full_like: "full",
+        }
+        if func in like_factories:
             template = args[0] if args else kwargs.get("input")
             assert isinstance(template, _JaxExportTensor)
-            import jax.numpy as jnp
 
-            new_jax = jnp.empty(
-                tuple(int(s) for s in template._jax_arr.shape),  # type: ignore[union-attr]
-                dtype=template._jax_arr.dtype,  # type: ignore[union-attr]
+            shape = tuple(int(s) for s in template._jax_arr.shape)  # type: ignore[union-attr]
+            dtype_arg = kwargs.get("dtype")
+            if dtype_arg is None:
+                dtype = template._jax_arr.dtype  # type: ignore[union-attr]
+            else:
+                assert isinstance(dtype_arg, torch.dtype)
+                dtype = _torch_to_jnp_dtype(dtype_arg)
+            kind = like_factories[func]
+            fill_value = args[1] if len(args) > 1 else kwargs.get("fill_value")
+            new_jax = _new_jax_array(kind, shape, dtype, fill_value)
+            return cls.from_jax(new_jax, device=template._declared_device)
+
+        new_factories = {
+            torch.Tensor.new_empty: "empty",
+            torch.Tensor.new_zeros: "zeros",
+            torch.Tensor.new_ones: "ones",
+            torch.Tensor.new_full: "full",
+        }
+        if func in new_factories:
+            template = args[0]
+            assert isinstance(template, _JaxExportTensor)
+            kind = new_factories[func]
+            shape_args = args[1:2] if kind == "full" else args[1:]
+            shape = _normalize_creation_shape(shape_args, kwargs)
+            dtype_arg = kwargs.get("dtype")
+            dtype = (
+                template._jax_arr.dtype  # type: ignore[union-attr]
+                if dtype_arg is None
+                else _torch_to_jnp_dtype(cast("torch.dtype", dtype_arg))
             )
+            fill_value = args[2] if len(args) > 2 else kwargs.get("fill_value")
+            new_jax = _new_jax_array(kind, shape, dtype, fill_value)
             return cls.from_jax(new_jax, device=template._declared_device)
 
         # ``q_view = q_in.reshape([...])`` and ``out.view(...)`` are
@@ -221,6 +261,114 @@ def _normalize_shape(
     return rest
 
 
+def _normalize_creation_shape(
+    args: tuple[object, ...], kwargs: dict[str, object]
+) -> tuple[int, ...]:
+    if "size" in kwargs:
+        candidate = kwargs["size"]
+        if isinstance(candidate, (list, tuple, torch.Size)):
+            return tuple(_to_int(s) for s in candidate)
+        return (_to_int(candidate),)
+    if len(args) == 1 and isinstance(args[0], (list, tuple, torch.Size)):
+        return tuple(_to_int(s) for s in args[0])
+    return tuple(_to_int(s) for s in args)
+
+
+def _torch_to_jnp_dtype(torch_dtype: torch.dtype) -> object:
+    t2j, _ = _build_dtype_maps()
+    return t2j[torch_dtype]
+
+
+def _new_jax_array(
+    kind: str,
+    shape: tuple[int, ...],
+    dtype: object,
+    fill_value: object | None = None,
+) -> object:
+    import jax.numpy as jnp
+
+    if kind == "zeros":
+        return jnp.zeros(shape, dtype=cast("Any", dtype))
+    if kind == "ones":
+        return jnp.ones(shape, dtype=cast("Any", dtype))
+    if kind == "full":
+        assert fill_value is not None
+        return jnp.full(shape, cast("Any", fill_value), dtype=cast("Any", dtype))
+    assert kind == "empty"
+    return jnp.empty(shape, dtype=cast("Any", dtype))
+
+
+class _JaxExportAllocationMode(torch.overrides.TorchFunctionMode):
+    """Route wrapper allocations to JAX without patching global torch APIs."""
+
+    _declared_device: torch.device
+
+    def __init__(self, declared_device: torch.device) -> None:
+        super().__init__()
+        self._declared_device = declared_device  # pyrefly: ignore[read-only]
+
+    def _device_matches(self, device: object) -> bool:
+        if device is None or not isinstance(device, (torch.device, int, str)):
+            return False
+        candidate = torch.device(device)
+        return candidate.type == self._declared_device.type and (
+            candidate.index == self._declared_device.index
+            or candidate.index is None
+            or self._declared_device.index is None
+        )
+
+    def __torch_function__(
+        self,
+        func: Callable[..., object],
+        types: tuple[type, ...],
+        args: tuple[object, ...] = (),
+        kwargs: dict[str, object] | None = None,
+    ) -> object:
+        if kwargs is None:
+            kwargs = {}
+        factories = {
+            torch.empty: "empty",
+            torch.zeros: "zeros",
+            torch.ones: "ones",
+            torch.full: "full",
+        }
+        if func in factories and kwargs.get("out") is None:
+            if self._device_matches(kwargs.get("device")):
+                kind = factories[func]
+                fill_value = (
+                    args[1]
+                    if kind == "full" and len(args) > 1
+                    else kwargs.get("fill_value")
+                )
+                dtype = kwargs.get("dtype")
+                if dtype is None:
+                    dtype = (
+                        torch.tensor(fill_value, device="meta").dtype
+                        if kind == "full"
+                        else torch.get_default_dtype()
+                    )
+                assert isinstance(dtype, torch.dtype)
+                shape_args = args[:1] if kind == "full" else args
+                shape = _normalize_creation_shape(shape_args, kwargs)
+                jax_arr = _new_jax_array(
+                    kind,
+                    shape,
+                    _torch_to_jnp_dtype(dtype),
+                    fill_value,
+                )
+                return _JaxExportTensor.from_jax(jax_arr, device=self._declared_device)
+        return func(*args, **kwargs)
+
+
+@contextmanager
+def _torch_allocation_patch_for_jax_export(
+    declared_device: torch.device,
+) -> Iterator[None]:
+    """Route torch allocations in generated wrappers to JAX-backed adapters."""
+    with _JaxExportAllocationMode(declared_device):
+        yield
+
+
 def _unwrap_jax(obj: object) -> object:
     """Recursively unwrap ``_JaxExportTensor`` instances to JAX arrays."""
     if isinstance(obj, _JaxExportTensor):
@@ -265,7 +413,10 @@ def _tensor_arg_to_jax(arg: object) -> object:
     if isinstance(arg, torch.Tensor):
         import jax.numpy as jnp
 
-        return jnp.asarray(arg.detach().cpu().numpy())
+        return jnp.asarray(
+            arg.detach().cpu().tolist(),
+            dtype=cast("Any", _torch_to_jnp_dtype(arg.dtype)),
+        )
     return arg
 
 
@@ -281,6 +432,7 @@ def default_pallas_jax_launcher(
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _smem_arg_indices: list[int] | None = None,
     _pallas_interpret: bool | None = None,
+    _pallas_phase_case_metadata: _PallasPhaseCaseMetadata | None = None,
     **kwargs: object,
 ) -> object:
     """Pallas launcher used when running a Helion kernel inside ``jax.jit``.
@@ -309,6 +461,7 @@ def default_pallas_jax_launcher(
     # calls ``F.pad`` on each entry, which the adapter intercepts and
     # mirrors on the JAX side, so no JAX-side duplicate is needed here.
     orig_shapes: dict[int, tuple[int, ...]] = {}
+    orig_output_adapters: dict[int, _JaxExportTensor] = {}
     if _ds_pad_dims:
         for arg_idx, _, _, _ in _ds_pad_dims:
             if arg_idx in orig_shapes:
@@ -317,7 +470,14 @@ def default_pallas_jax_launcher(
             if isinstance(a, _JaxExportTensor):
                 orig_shapes[arg_idx] = tuple(int(s) for s in a._jax_arr.shape)  # type: ignore[union-attr]
 
-        args, _ = _pallas_apply_ds_padding(args, output_indices, _ds_pad_dims)
+        args, orig_output_tensors = _pallas_apply_ds_padding(
+            args, output_indices, _ds_pad_dims
+        )
+        orig_output_adapters = {
+            idx: tensor
+            for idx, tensor in orig_output_tensors.items()
+            if isinstance(tensor, _JaxExportTensor)
+        }
 
     device = next(
         (a._declared_device for a in args if isinstance(a, _JaxExportTensor)),
@@ -338,6 +498,10 @@ def default_pallas_jax_launcher(
     # at trace time); the caller must ensure every ordered range <= C.
     compact_build_worklist = kwargs.get("_compact_build_worklist")
     compact: dict[str, object] | None = None
+    if compact_build_worklist is not None and _pallas_phase_case_metadata is not None:
+        raise NotImplementedError(
+            "Pallas direct case launches cannot use compact worklists"
+        )
     if compact_build_worklist is not None:
         compact = {
             "build_worklist": compact_build_worklist,
@@ -356,6 +520,13 @@ def default_pallas_jax_launcher(
             "ordered_window": kwargs.get("_compact_ordered_window", 0),
         }
 
+    def _update_inplace_adapter(orig_pos: int, value: object) -> None:
+        adapter = orig_output_adapters.get(orig_pos)
+        if adapter is None and isinstance(args[orig_pos], _JaxExportTensor):
+            adapter = cast("_JaxExportTensor", args[orig_pos])
+        if adapter is not None:
+            adapter._jax_arr = value
+
     output_results = _pallas_jax_call(
         pallas_kernel,
         grid,
@@ -367,9 +538,11 @@ def default_pallas_jax_launcher(
         hbm_arg_indices=_hbm_arg_indices,
         smem_arg_indices=_smem_arg_indices,
         interpret=interpret,
+        phase_case_metadata=_pallas_phase_case_metadata,
         compact=compact,
         orig_shapes=orig_shapes,
         ds_pad_dims=_ds_pad_dims,
+        inplace_result_callback=_update_inplace_adapter,
     )
 
     if len(output_results) == 1:
@@ -426,7 +599,8 @@ def make_jax_fn(kernel: Kernel) -> Callable[..., Any]:
                 **cast("dict[str, Any]", launch_kwargs),
             )
 
-        result = compiled(*adapter_args, _launcher=_launcher)
+        with _torch_allocation_patch_for_jax_export(device):
+            result = compiled(*adapter_args, _launcher=_launcher)
         return _unwrap_jax(result)
 
     return _runtime_call

--- a/helion/runtime/pallas/launcher.py
+++ b/helion/runtime/pallas/launcher.py
@@ -438,7 +438,12 @@ _PallasFlatCopyGuard = tuple[int, int, int, tuple[tuple[int, int], ...]]
 _PallasCopyGuard = tuple[tuple[int, ...], tuple[_PallasFlatCopyGuard, ...]]
 _PallasCopyGuards = dict[int, _PallasCopyGuard]
 _PallasDimensionSemantic = Literal["parallel", "arbitrary"]
-_PallasLauncherCacheKey = tuple[tuple[int, ...], tuple[object, ...] | None]
+_PallasPhaseCaseMetadata = tuple[int, tuple[tuple[int, int, int], ...]]
+_PallasLauncherCacheKey = tuple[
+    tuple[int, ...],
+    tuple[object, ...] | None,
+    _PallasPhaseCaseMetadata | None,
+]
 
 
 def _pallas_tensor_pos_map(
@@ -552,13 +557,19 @@ def _pallas_shared_output_plan(
 
 
 def _pallas_launcher_cache_key(
-    grid: tuple[int, ...], block_spec_info: _BlockSpecInfo | None
+    grid: tuple[int, ...],
+    block_spec_info: _BlockSpecInfo | None,
+    phase_case_metadata: _PallasPhaseCaseMetadata | None = None,
 ) -> _PallasLauncherCacheKey:
     """Return compile-relevant launch metadata for the shared cache."""
     frozen_block_spec_info = (
         tuple(block_spec_info) if block_spec_info is not None else None
     )
-    return grid, cast("tuple[object, ...] | None", frozen_block_spec_info)
+    return (
+        grid,
+        cast("tuple[object, ...] | None", frozen_block_spec_info),
+        phase_case_metadata,
+    )
 
 
 def _pallas_build_block_specs(
@@ -719,7 +730,10 @@ def _pallas_jnp_dtype_map() -> dict[str, object]:
         "jnp.int16": jnp.int16,
         "jnp.int8": jnp.int8,
         "jnp.uint8": jnp.uint8,
+        "jnp.uint32": jnp.uint32,
         "jnp.bool_": jnp.bool_,
+        "jnp.complex64": jnp.complex64,
+        "jnp.complex128": jnp.complex128,
     }
 
 
@@ -920,7 +934,9 @@ def _pallas_padded_output_dims_by_arg(
     padded_dims_by_arg: dict[int, list[int]] = {}
     for arg_idx, dim, _bs, _extra in _ds_pad_dims:
         if arg_idx in output_arg_set:
-            padded_dims_by_arg.setdefault(arg_idx, []).append(dim)
+            dims = padded_dims_by_arg.setdefault(arg_idx, [])
+            if dim not in dims:
+                dims.append(dim)
     return padded_dims_by_arg
 
 
@@ -1043,6 +1059,26 @@ def _pallas_collect_outputs(
     return tuple(output_only_results)
 
 
+def _pallas_ds_pad_amounts(
+    args: tuple[object, ...],
+    _ds_pad_dims: list[tuple[int, int, int, int]],
+) -> list[tuple[int, int, int]]:
+    """Compute max required ds-padding per ``(arg, dim)`` from original shapes."""
+    pad_by_key: dict[tuple[int, int], int] = {}
+    for arg_idx, dim, block_size, extra_pad in _ds_pad_dims:
+        a = args[arg_idx]
+        if not isinstance(a, torch.Tensor):
+            continue
+        pad_amount = (-a.shape[dim]) % block_size + extra_pad
+        if pad_amount == 0:
+            continue
+        key = (arg_idx, dim)
+        pad_by_key[key] = max(pad_by_key.get(key, 0), pad_amount)
+    return [
+        (arg_idx, dim, pad_amount) for (arg_idx, dim), pad_amount in pad_by_key.items()
+    ]
+
+
 def _pallas_apply_ds_padding_fast(
     args: tuple[object, ...],
     _ds_pad_dims: list[tuple[int, int, int, int]],
@@ -1053,12 +1089,9 @@ def _pallas_apply_ds_padding_fast(
     args_list: list[object] | None = None
     orig_output_tensors: dict[int, torch.Tensor] | None = None
     any_padding = False
-    for arg_idx, dim, block_size, extra_pad in _ds_pad_dims:
+    for arg_idx, dim, pad_amount in _pallas_ds_pad_amounts(args, _ds_pad_dims):
         a = args[arg_idx] if args_list is None else args_list[arg_idx]
         if not isinstance(a, torch.Tensor):
-            continue
-        pad_amount = (-a.shape[dim]) % block_size + extra_pad
-        if pad_amount == 0:
             continue
         any_padding = True
         if args_list is None:
@@ -1257,6 +1290,28 @@ def _pallas_copy_guard(guard: _PallasCopyGuard) -> bool | jax.Array:
     return should_copy
 
 
+def _pallas_phase_case_guard(
+    metadata: _PallasPhaseCaseMetadata | None,
+    refs: tuple[object, ...],
+    arg_to_tensor_pos: dict[int, int],
+) -> bool | jax.Array | None:
+    if metadata is None:
+        return None
+
+    from jax.experimental import pallas as pl
+
+    phase_arg_index, case_ranges = metadata
+    phase_ref_pos = arg_to_tensor_pos.get(phase_arg_index)
+    if phase_ref_pos is None:
+        raise RuntimeError("Pallas phase argument is missing from tensor refs")
+    phase_value = refs[phase_ref_pos][0]  # type: ignore[index]
+    pid0 = pl.program_id(0)
+    active: bool | jax.Array = False
+    for phase, start, end in case_ranges:
+        active = active | ((phase_value == phase) & (pid0 >= start) & (pid0 < end))
+    return active
+
+
 def _pallas_make_reordered_kernel(
     pallas_kernel: object,
     args: tuple[object, ...],
@@ -1270,6 +1325,7 @@ def _pallas_make_reordered_kernel(
     skip_inplace_copy: set[int] | None = None,
     _smem_arg_indices: list[int] | None = None,
     _copy_guards: _PallasCopyGuards | None = None,
+    _phase_case_metadata: _PallasPhaseCaseMetadata | None = None,
 ) -> object:
     """Create a wrapper kernel that reorders pallas_call refs to the original arg order.
 
@@ -1293,6 +1349,9 @@ def _pallas_make_reordered_kernel(
     def reordered_kernel(*refs: object) -> None:
         from jax.experimental import pallas as pl
 
+        active_guard = _pallas_phase_case_guard(
+            _phase_case_metadata, refs, arg_to_tensor_pos
+        )
         n_kernel_params = len(args)
         original_order: list[object] = [None] * n_kernel_params
         for tensor_pos, orig_pos in enumerate(tensor_arg_indices):
@@ -1322,7 +1381,17 @@ def _pallas_make_reordered_kernel(
                     _pallas_inplace_copy(in_ref, out_ref, is_smem=is_smem)
             original_order[orig_pos] = out_ref
         extra_refs = refs[n_tensor_inputs + len(_output_indices) :]
-        pallas_kernel(*original_order, *extra_refs)  # type: ignore[operator]
+        if active_guard is not None:
+
+            @pl.when(active_guard)
+            def _run_active_phase_case(
+                original_order: list[object] = original_order,
+                extra_refs: tuple[object, ...] = extra_refs,
+            ) -> None:
+                pallas_kernel(*original_order, *extra_refs)  # type: ignore[operator]
+
+        else:
+            pallas_kernel(*original_order, *extra_refs)  # type: ignore[operator]
 
     return reordered_kernel
 
@@ -1452,8 +1521,8 @@ def _pallas_apply_ds_padding(
     """Pad tensor args so ``pl.ds(offset, block_size)`` never reads OOB.
 
     ``_ds_pad_dims`` contains ``(arg_index, dim, block_size, extra_pad)``
-    tuples.  The pad amount is ``(-tensor.shape[dim]) % block_size +
-    extra_pad``, where *extra_pad* accounts for non-zero loop begins.
+    tuples.  Multiple requirements for one ``(arg, dim)`` are canonicalized
+    against the original tensor shape before padding is applied.
 
     Returns the padded args tuple and a dict mapping output arg indices
     to their original (unpadded) tensors for post-call copy-back.
@@ -1461,12 +1530,9 @@ def _pallas_apply_ds_padding(
     args_list = list(args)
     orig_output_tensors: dict[int, torch.Tensor] = {}
     output_set = set(_output_indices)
-    for arg_idx, dim, block_size, extra_pad in _ds_pad_dims:
+    for arg_idx, dim, pad_amount in _pallas_ds_pad_amounts(args, _ds_pad_dims):
         a = args_list[arg_idx]
         if not isinstance(a, torch.Tensor):
-            continue
-        pad_amount = (-a.shape[dim]) % block_size + extra_pad
-        if pad_amount == 0:
             continue
         if arg_idx in output_set and arg_idx not in orig_output_tensors:
             orig_output_tensors[arg_idx] = a
@@ -1706,9 +1772,10 @@ def _pallas_compile_jit_fn(
     _hbm_arg_indices: list[int] | None,
     _matmul_dot_general: dict[str, object] | None,
     interpret: bool,
+    _pallas_phase_case_metadata: _PallasPhaseCaseMetadata | None = None,
     placeholder_fn: Callable[[object], object] | None = None,
 ) -> _PallasCompileResult:
-    """Build the ``pl.kernel`` jit_fn used by the Pallas launcher.
+    """Build the JAX callable used by the Pallas launcher.
 
     The kernel loop shape is driven entirely by the launcher-observable
     inputs:
@@ -1732,6 +1799,11 @@ def _pallas_compile_jit_fn(
     builds specs from the post-pad shapes.  Returns a
     :class:`_PallasCompileResult` so the torch launcher can wrap the
     jit_fn in a JaxCallable while the JAX-export path calls it directly.
+
+    Pallas multi-root cases and shared in-place output tiles use direct
+    ``pl.pallas_call``. A guarded body inside ``emit_pipeline`` is insufficient
+    because inactive or repeated grid steps still copy their output buffers
+    back to HBM and can overwrite an active update.
     """
     from jax.experimental import pallas as pl
     from jax.experimental.pallas import tpu as pltpu
@@ -1814,7 +1886,9 @@ def _pallas_compile_jit_fn(
         for orig_pos, guard in copy_guards.items()
         if orig_pos not in skip_inplace_copy
     }
-    use_direct_call = bool(effective_copy_guards)
+    use_direct_call = _pallas_phase_case_metadata is not None or bool(
+        effective_copy_guards
+    )
     unsupported_hbm_direct_outputs = inplace_positions & skip_inplace_copy
     if use_direct_call and unsupported_hbm_direct_outputs:
         raise NotImplementedError(
@@ -1835,6 +1909,7 @@ def _pallas_compile_jit_fn(
         skip_inplace_copy=skip_inplace_copy,
         _smem_arg_indices=_smem_arg_indices,
         _copy_guards=effective_copy_guards,
+        _phase_case_metadata=_pallas_phase_case_metadata,
     )
 
     out_shape_arg = out_shapes if len(out_shapes) > 1 else out_shapes[0]
@@ -1965,9 +2040,11 @@ def _pallas_jax_call(
     hbm_arg_indices: list[int] | None,
     smem_arg_indices: list[int] | None,
     interpret: bool,
+    phase_case_metadata: _PallasPhaseCaseMetadata | None = None,
     compact: dict[str, object] | None = None,
     orig_shapes: dict[int, tuple[int, ...]] | None = None,
     ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
+    inplace_result_callback: Callable[[int, object], None] | None = None,
 ) -> list[object]:
     """Drive the shared compile core (``pl.kernel``) + jit_fn on raw ``jax.Array``s
     and return the output JAX array(s).
@@ -1977,6 +2054,10 @@ def _pallas_jax_call(
     and the jax_fn precompiled standalone -- neither touches torch. ``compact``
     carries the compact-worklist kwargs when the kernel uses that lowering.
     """
+    if compact is not None and phase_case_metadata is not None:
+        raise NotImplementedError(
+            "Pallas direct case launches cannot use compact worklists"
+        )
     if compact is not None:
         result = _pallas_compile_compact_jit_fn(
             pallas_kernel,
@@ -2003,6 +2084,7 @@ def _pallas_jax_call(
             _hbm_arg_indices=hbm_arg_indices,
             _matmul_dot_general=None,
             interpret=interpret,
+            _pallas_phase_case_metadata=phase_case_metadata,
         )
 
     jax_inputs = [jax_args[i] for i in result.tensor_arg_indices]
@@ -2019,23 +2101,46 @@ def _pallas_jax_call(
     if not descriptors:
         descriptors = tuple(enumerate(output_indices))
 
-    output_results: list[object] = [jax_results[out_idx] for out_idx, _ in descriptors]
-    output_orig_pos: list[int] = [orig_pos for _, orig_pos in descriptors]
-
     # Slice padded outputs back to their original shapes (ds-pad), reusing the
     # torch fast-path's arg->padded-dims grouping; JAX arrays index identically.
+    padded_dims_by_arg: dict[int, list[int]] = {}
     if ds_pad_dims and orig_shapes:
         padded_dims_by_arg = _pallas_padded_output_dims_by_arg(
             ds_pad_dims, set(orig_shapes.keys())
         )
-        for i, orig_pos in enumerate(output_orig_pos):
-            dims = padded_dims_by_arg.get(orig_pos)
-            orig_shape = orig_shapes.get(orig_pos)
-            if dims and orig_shape is not None:
-                output_results[i] = _pallas_slice_to_orig(
-                    cast("torch.Tensor", output_results[i]),
-                    dims,
-                    cast("torch.Size", orig_shape),
+
+    def _slice_output(out: object, orig_pos: int) -> object:
+        dims = padded_dims_by_arg.get(orig_pos)
+        orig_shape = (orig_shapes or {}).get(orig_pos)
+        if dims and orig_shape is not None:
+            return _pallas_slice_to_orig(
+                cast("torch.Tensor", out),
+                dims,
+                cast("torch.Size", orig_shape),
+            )
+        return out
+
+    output_results = [
+        _slice_output(jax_results[out_idx], orig_pos)
+        for out_idx, orig_pos in descriptors
+    ]
+
+    if inplace_result_callback is not None:
+        output_idx_by_orig_pos = {
+            orig_pos: out_idx for out_idx, orig_pos in enumerate(output_indices)
+        }
+        for orig_pos in result.inplace_positions:
+            tensor_pos = result.arg_to_tensor_pos.get(orig_pos)
+            out_idx = (
+                result.pallas_aliases.get(tensor_pos)
+                if tensor_pos is not None
+                else None
+            )
+            if out_idx is None:
+                out_idx = output_idx_by_orig_pos.get(orig_pos)
+            if out_idx is not None:
+                inplace_result_callback(
+                    orig_pos, _slice_output(jax_results[out_idx], orig_pos)
                 )
 
     return output_results
@@ -2055,13 +2160,13 @@ def _pallas_install_launcher_cache(
     _ds_pad_dims: list[tuple[int, int, int, int]] | None,
     _pallas_interpret: bool | None,
     _matmul_dot_general: dict[str, object] | None = None,
+    _pallas_phase_case_metadata: _PallasPhaseCaseMetadata | None = None,
 ) -> tuple[object, ...]:
     """Cache-miss path shared by all Pallas launchers.
 
-    Builds the ``pl.kernel`` jit_fn via :func:`_pallas_compile_jit_fn`
-    (whose shape is fully determined by the passed-in kwargs — no loop-type
-    discriminator), wraps it in a ``JaxCallable`` (or interpret-mode shim),
-    seeds the ``_LauncherFastPath`` slot, stores the result on
+    Builds the JAX callable via :func:`_pallas_compile_jit_fn` (whose shape is
+    fully determined by the passed-in kwargs), wraps it in a ``JaxCallable``
+    (or interpret-mode shim), seeds the ``_LauncherFastPath`` slot, stores it on
     ``pallas_kernel._pallas_cache``, and returns the freshly-installed cache
     tuple so the caller can fall straight through to the shared invoke.
     """
@@ -2074,7 +2179,9 @@ def _pallas_install_launcher_cache(
         _ensure_cpu_tpu_info()
 
     output_indices = _output_indices if _output_indices is not None else []
-    launcher_cache_key = _pallas_launcher_cache_key(grid, _block_spec_info)
+    launcher_cache_key = _pallas_launcher_cache_key(
+        grid, _block_spec_info, _pallas_phase_case_metadata
+    )
 
     # Build the pallas specs from ds-padded shapes on a throwaway copy so
     # ``args`` stays unpadded for the shared invoke below to pad fresh.
@@ -2096,6 +2203,7 @@ def _pallas_install_launcher_cache(
         _hbm_arg_indices=_hbm_arg_indices,
         _matmul_dot_general=_matmul_dot_general,
         interpret=interpret,
+        _pallas_phase_case_metadata=_pallas_phase_case_metadata,
         placeholder_fn=functools.partial(
             _pallas_torch_placeholder, interpret=interpret
         ),
@@ -2110,7 +2218,7 @@ def _pallas_install_launcher_cache(
         result.tensor_arg_indices,
         cache_attr=_PALLAS_CACHE_ATTR,
         call_aliases=result.pallas_aliases,
-        trace_key_suffix=f"_{launcher_cache_key[1]!r}",
+        trace_key_suffix=f"_{launcher_cache_key[1:]!r}",
         interpret=interpret,
     )
 
@@ -2190,6 +2298,7 @@ def default_pallas_launcher(
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _pallas_interpret: bool | None = None,
     _matmul_dot_general: dict[str, object] | None = None,
+    _pallas_phase_case_metadata: _PallasPhaseCaseMetadata | None = None,
     _compact_build_worklist: Callable[..., object] | None = None,
     _compact_offset_arg_indices: list[int] | None = None,
     _compact_metadata_fields: list[str] | None = None,
@@ -2229,6 +2338,10 @@ def default_pallas_launcher(
     are excluded from pallas_call inputs to save VMEM.  Their results are
     returned as torch tensors.
     """
+    if _compact_build_worklist is not None and _pallas_phase_case_metadata is not None:
+        raise NotImplementedError(
+            "Pallas direct case launches cannot use compact worklists"
+        )
     if _compact_build_worklist is not None:
         # Resident-cache correctness backstop: runs EVERY call (the offset arrays are
         # runtime data even when the compiled kernel is cached for this grid), raising
@@ -2243,7 +2356,9 @@ def default_pallas_launcher(
             _compact_ordered_window,
         )
     cache = getattr(pallas_kernel, _PALLAS_CACHE_ATTR, None)
-    launcher_cache_key = _pallas_launcher_cache_key(grid, _block_spec_info)
+    launcher_cache_key = _pallas_launcher_cache_key(
+        grid, _block_spec_info, _pallas_phase_case_metadata
+    )
     if cache is None or cache[6] != launcher_cache_key:
         if _compact_build_worklist is not None:
             cache = _pallas_install_compact_launcher_cache(
@@ -2284,6 +2399,7 @@ def default_pallas_launcher(
                 _ds_pad_dims=_ds_pad_dims,
                 _pallas_interpret=_pallas_interpret,
                 _matmul_dot_general=_matmul_dot_general,
+                _pallas_phase_case_metadata=_pallas_phase_case_metadata,
             )
 
     return _pallas_invoke_cached_launcher(
@@ -2749,7 +2865,7 @@ def _pallas_install_compact_launcher_cache(
         result.tensor_arg_indices,
         cache_attr=_PALLAS_CACHE_ATTR,
         call_aliases=result.pallas_aliases,
-        trace_key_suffix=f"_{launcher_cache_key[1]!r}",
+        trace_key_suffix=f"_{launcher_cache_key[1:]!r}",
         interpret=interpret,
     )
     fast_path = _LauncherFastPath(
@@ -2781,5 +2897,16 @@ def _torch_to_jax(t: torch.Tensor) -> object:
 def _jax_to_torch(
     arr: object, *, device: torch.device, dtype: torch.dtype
 ) -> torch.Tensor:
-    """Convert a JAX array back to a torch.Tensor via DLPack (for interpret mode on CPU)."""
+    """Convert a JAX interpret result back to a torch tensor."""
+    jax_arr = cast("Any", arr)
+    if any(jax_device.platform == "tpu" for jax_device in jax_arr.devices()):
+        # Output-only interpret calls have no input to pin JAX to CPU. On a TPU
+        # host their result can therefore land on TPU, whose arrays do not
+        # support DLPack; stage that uncommon result through a CPU JAX array.
+        # Keeping the host value in JAX preserves dtypes such as bfloat16 that
+        # torch.from_numpy() cannot consume.
+        import jax
+
+        host_arr = jax.device_put(jax.device_get(jax_arr), jax.devices("cpu")[0])
+        return torch.from_dlpack(host_arr).to(dtype=dtype, device=device)
     return torch.from_dlpack(arr).to(dtype=dtype, device=device)

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -192,7 +192,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             block_sizes=[64, 64, 32],
         )
 
-    @xfailIfPallas("missing barrier implementation")
+    @xfailIfPallasInterpret("barrier phase launches require TPU Pallas runtime")
     @skipIfTileIR("PassManager::run failed")
     @skipIfXPU("Split-K barrier not supported on XPU backend")
     def test_split_k_barrier(self):
@@ -212,7 +212,7 @@ class TestExamples(RefEagerTestBase, TestCase):
             split_k=64,
         )
 
-    @xfailIfPallas("missing barrier implementation")
+    @xfailIfPallasInterpret("barrier phase launches require TPU Pallas runtime")
     @skipIfTileIR("PassManager::run failed")
     @skipIfRefEager("Test requires compiled kernel with specific config")
     def test_split_k_barrier_accuracy(self):

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -9,6 +9,7 @@ import types
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
+from typing import NamedTuple
 from typing import cast
 import unittest
 from unittest.mock import patch
@@ -34,9 +35,15 @@ from helion._testing import xfailIfPallasTpu
 from helion.autotuner import IntegerFragment
 from helion.autotuner import PowerOfTwoFragment
 import helion.language as hl
+from helion.runtime.pallas.jax_export import _JaxExportTensor
+from helion.runtime.pallas.jax_export import _torch_allocation_patch_for_jax_export
+from helion.runtime.pallas.jax_export import default_pallas_jax_launcher
+from helion.runtime.pallas.launcher import _pallas_compile_jit_fn
 from helion.runtime.pallas.launcher import _pallas_copy_guard
 from helion.runtime.pallas.launcher import _pallas_launcher_cache_key
+from helion.runtime.pallas.launcher import _pallas_phase_case_guard
 from helion.runtime.pallas.launcher import _pallas_shared_output_plan
+from helion.runtime.pallas.launcher import _PallasCompileResult
 from helion.runtime.settings import is_pallas_interpret
 
 if TYPE_CHECKING:
@@ -113,6 +120,19 @@ def pallas_foreach_unequal_outputs(
     out_y = torch.empty_like(y)
     for tile_x in hl.tile(x.size(0)):
         out_x[tile_x] = x[tile_x] + 1.0
+    for tile_y in hl.tile(y.size(0)):
+        out_y[tile_y] = y[tile_y] * 2.0
+    return out_x, out_y
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_foreach_empty_axis_outputs(
+    x: torch.Tensor, y: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    out_x = torch.empty_like(x)
+    out_y = torch.empty_like(y)
+    for tile_m, tile_n in hl.tile(x.size()):
+        out_x[tile_m, tile_n] = x[tile_m, tile_n] + 1.0
     for tile_y in hl.tile(y.size(0)):
         out_y[tile_y] = y[tile_y] * 2.0
     return out_x, out_y
@@ -705,6 +725,87 @@ def pallas_integer_tunable_prefix_reduction(x: torch.Tensor) -> torch.Tensor:
     return out
 
 
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_barrier_scalar_minor_temp(x: torch.Tensor) -> torch.Tensor:
+    m = x.size(0)
+    n = hl.specialize(x.size(1))
+    width = hl.register_tunable("width", PowerOfTwoFragment(4, 16, 8))
+    tmp = torch.zeros([m, n, width], dtype=x.dtype, device=x.device)
+    out = torch.empty_like(x)
+
+    for tile_m, tile_w in hl.tile([m, width], block_size=[None, 1]):
+        tmp[tile_m, :, tile_w.id] = x[tile_m, :] + tile_w.id
+
+    hl.barrier()
+
+    for tile_m in hl.tile(m, block_size=4):
+        out[tile_m, :] = torch.sum(tmp[tile_m, :, :], dim=-1)
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_barrier_four_roots(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    m = x.size(0)
+    left = torch.empty_like(x)
+    right = torch.empty_like(y)
+    combined = torch.empty_like(x)
+    out = torch.empty_like(x)
+
+    for tile_m in hl.tile(m, block_size=4):
+        left[tile_m, :] = x[tile_m, :] + 1
+    for tile_m in hl.tile(m, block_size=4):
+        right[tile_m, :] = y[tile_m, :] + 2
+
+    hl.barrier()
+
+    for tile_m in hl.tile(m, block_size=4):
+        combined[tile_m, :] = left[tile_m, :] + right[tile_m, :]
+
+    hl.barrier()
+
+    for tile_m in hl.tile(m, block_size=4):
+        out[tile_m, :] = combined[tile_m, :] * 2
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_barrier_reused_grid_block(x: torch.Tensor) -> torch.Tensor:
+    m = x.size(0)
+    block_m = hl.register_block_size(m)
+    first = torch.empty_like(x)
+    second = torch.empty_like(x)
+    out = torch.empty_like(x)
+
+    for tile_m in hl.tile(m, block_size=block_m):
+        first[tile_m, :, :] = x[tile_m, :, :] + 1
+
+    hl.barrier()
+
+    for tile_m in hl.tile(m // 2, block_size=block_m):
+        second[tile_m, :, :] = first[tile_m, :, :] + 2
+
+    hl.barrier()
+
+    for tile_m in hl.tile(m // 4, block_size=block_m):
+        out[tile_m, :, :] = second[tile_m, :, :] * 3
+    return out
+
+
+@helion.kernel(backend="pallas", static_shapes=True)
+def pallas_barrier_full_temp(x: torch.Tensor) -> torch.Tensor:
+    tmp = torch.full(x.shape, 3.0, dtype=x.dtype, device=x.device)
+    out = x.new_empty(x.shape)
+
+    for tile in hl.tile(x.size(), block_size=[4, 128]):
+        tmp[tile] = tmp[tile] + x[tile]
+
+    hl.barrier()
+
+    for tile in hl.tile(x.size(), block_size=[4, 128]):
+        out[tile] = tmp[tile] * 2
+    return out
+
+
 def _cumsum_broadcast_ref(
     a: torch.Tensor, b: torch.Tensor, block_k: int = 128
 ) -> torch.Tensor:
@@ -991,6 +1092,11 @@ class TestPallasSharedOutputPlan(TestCase):
                     self._copy_guard_value(guard, {0: (start + total) % 9})
                 )
 
+    def test_copy_guard_rejects_empty_group_with_safe_radix(self) -> None:
+        guard = ((), ((0, 0, 0, ((1, 1),)),))
+
+        self.assertFalse(self._copy_guard_value(guard, {0: 0}))
+
     def test_launcher_cache_key_includes_foreach_case_metadata(self) -> None:
         first = [
             ((128,), ((0, 1, 1, 0),)),
@@ -1010,7 +1116,45 @@ class TestPallasSharedOutputPlan(TestCase):
             _pallas_launcher_cache_key((3,), second),
         )
 
-    def _copy_guard_value(self, guard: Any, pid_by_dim: dict[int, int]) -> bool:
+    def test_launcher_cache_key_includes_phase_case_metadata(self) -> None:
+        first = (3, ((0, 0, 4), (0, 4, 7), (1, 7, 9)))
+        second = (3, ((0, 0, 4), (1, 4, 7), (1, 7, 9)))
+
+        self.assertEqual(
+            _pallas_launcher_cache_key((9,), None, first),
+            ((9,), None, first),
+        )
+        self.assertNotEqual(
+            _pallas_launcher_cache_key((9,), None, first),
+            _pallas_launcher_cache_key((9,), None, second),
+        )
+
+    def test_phase_case_guard_supports_multiple_roots_in_same_phase(self) -> None:
+        metadata = (3, ((0, 0, 4), (0, 4, 7), (1, 7, 9)))
+
+        for phase, pid, expected in (
+            (0, 0, True),
+            (0, 3, True),
+            (0, 4, True),
+            (0, 6, True),
+            (0, 7, False),
+            (1, 4, False),
+            (1, 7, True),
+            (1, 8, True),
+        ):
+            with self.subTest(phase=phase, pid=pid):
+                self.assertEqual(
+                    self._phase_case_guard_value(
+                        metadata,
+                        phase,
+                        {0: pid},
+                    ),
+                    expected,
+                )
+
+    def _fake_pallas_modules(
+        self, pid_by_dim: dict[int, int]
+    ) -> dict[str, types.ModuleType]:
         jax_mod = types.ModuleType("jax")
         experimental_mod = types.ModuleType("jax.experimental")
         pallas_mod = types.ModuleType("jax.experimental.pallas")
@@ -1024,16 +1168,24 @@ class TestPallasSharedOutputPlan(TestCase):
         pallas_module.program_id = program_id
         experimental_module.pallas = pallas_mod
         jax_module.experimental = experimental_mod
+        return {
+            "jax": jax_mod,
+            "jax.experimental": experimental_mod,
+            "jax.experimental.pallas": pallas_mod,
+        }
 
-        with patch.dict(
-            sys.modules,
-            {
-                "jax": jax_mod,
-                "jax.experimental": experimental_mod,
-                "jax.experimental.pallas": pallas_mod,
-            },
-        ):
+    def _copy_guard_value(self, guard: Any, pid_by_dim: dict[int, int]) -> bool:
+        with patch.dict(sys.modules, self._fake_pallas_modules(pid_by_dim)):
             return bool(_pallas_copy_guard(guard))
+
+    def _phase_case_guard_value(
+        self,
+        metadata: Any,
+        phase: int,
+        pid_by_dim: dict[int, int],
+    ) -> bool:
+        with patch.dict(sys.modules, self._fake_pallas_modules(pid_by_dim)):
+            return bool(_pallas_phase_case_guard(metadata, ([phase],), {3: 0}))
 
 
 # Module-level (Helion reads it as a constant, not a closure) so torch.topk's k
@@ -1508,10 +1660,12 @@ class TestPallas(TestCase):
                 out[tile] = hl.full([tile], 1.0, dtype=x.dtype)
             return out
 
-        x = torch.randn(1024, device=DEVICE, dtype=torch.float32)
-        code, result = code_and_output(fill_kernel, (x,), block_size=4096)
-        self.assertIn("[:1024]", code)
-        torch.testing.assert_close(result, torch.ones_like(x))
+        for dtype in (torch.float32, torch.bfloat16):
+            with self.subTest(dtype=dtype):
+                x = torch.randn(1024, device=DEVICE, dtype=dtype)
+                code, result = code_and_output(fill_kernel, (x,), block_size=4096)
+                self.assertIn("[:1024]", code)
+                torch.testing.assert_close(result, torch.ones_like(x))
 
     def test_store_slice_2d(self) -> None:
         """Store value sliced on the dim where block_size > tensor dim (2D)."""
@@ -4059,6 +4213,48 @@ class TestPallas(TestCase):
         self.assertNotIn("make_async_copy(x.at[", code)
         torch.testing.assert_close(result, x + x[0, 0])
 
+    def test_lifted_callable_wrapper_uses_conservative_alias_route(self) -> None:
+        class AddBias(NamedTuple):
+            bias: torch.Tensor
+
+            @property
+            def fn(
+                self,
+            ) -> Callable[[torch.Tensor, tuple[torch.Tensor, ...]], torch.Tensor]:
+                bias = self.bias
+
+                def add_bias(
+                    value: torch.Tensor, tile: tuple[torch.Tensor, ...]
+                ) -> torch.Tensor:
+                    return value + bias[tile]
+
+                return add_bias
+
+            def __call__(
+                self, value: torch.Tensor, tile: tuple[torch.Tensor, ...]
+            ) -> torch.Tensor:
+                return self.fn(value, tile)
+
+            @property
+            def __closure__(self) -> tuple[object, ...] | None:
+                return self.fn.__closure__
+
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def fn(x: torch.Tensor, add_bias: AddBias) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile(x.size()):
+                tile = (tile_m, tile_n)
+                out[tile] = add_bias(x[tile], tile)
+            return out
+
+        x = torch.randn(16, 128, device=DEVICE, dtype=torch.float32)
+        args = (x, AddBias(x))
+        bound = fn.bind(args)
+        self.assertIsInstance(bound.fake_args[1], types.FunctionType)
+        self.assertTrue(bound.env.disable_pallas_dma_for_untracked_aliases)
+        _code, result = code_and_output(fn, args, block_sizes=[8, 128])
+        torch.testing.assert_close(result, x + x)
+
     def test_sibling_loops_use_one_global_memory_route(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def fn(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
@@ -4076,15 +4272,22 @@ class TestPallas(TestCase):
             return out, broadcast
 
         x = torch.randn(16, 256, device=DEVICE, dtype=torch.float32)
-        code, (out, broadcast) = code_and_output(
-            fn,
-            (x,),
-            block_sizes=[8, 128, 128],
-            pallas_loop_type="fori_loop",
+        loop_types = (
+            ("fori_loop",) if is_pallas_interpret() else ("fori_loop", "emit_pipeline")
         )
-        self.assertNotIn("make_async_copy(x.at[", code)
-        torch.testing.assert_close(out, x + 1.0)
-        torch.testing.assert_close(broadcast, x[:, :1].expand_as(x))
+        for loop_type in loop_types:
+            with self.subTest(loop_type=loop_type):
+                code, (out, broadcast) = code_and_output(
+                    fn,
+                    (x,),
+                    block_sizes=[8, 128, 128],
+                    pallas_loop_type=loop_type,
+                )
+                self.assertNotIn("make_async_copy(x.at[", code)
+                if loop_type == "emit_pipeline":
+                    self.assertNotIn("_hbm_arg_indices=[0", code)
+                torch.testing.assert_close(out, x + 1.0)
+                torch.testing.assert_close(broadcast, x[:, :1].expand_as(x))
 
     def test_fori_loop_sibling_stores_use_outer_output_route(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
@@ -4959,12 +5162,13 @@ class TestPallas(TestCase):
         ``pallas_loop_type='emit_pipeline'``.
         """
         x = torch.randn(256, 128, device=DEVICE, dtype=torch.float32)
-        _code, result = code_and_output(
+        code, result = code_and_output(
             pallas_two_pass_reduction,
             (x,),
             block_sizes=[128, 128, 128],
             pallas_loop_type="emit_pipeline",
         )
+        self.assertIn("_hbm_arg_indices=[0", code)
         expected = x - x.mean(dim=-1, keepdim=True)
         torch.testing.assert_close(result, expected, rtol=1e-4, atol=1e-4)
 
@@ -5466,6 +5670,272 @@ class TestPallas(TestCase):
         )
         torch.testing.assert_close(result, x * 7)
         self.assertIn("width = 7", code)
+
+    def test_barrier_phase_codegen_emits_host_relaunch_and_guards(self) -> None:
+        x = torch.empty((17, 128), dtype=torch.float32)
+        config = helion.Config(block_sizes=[16], width=8)
+        code = pallas_barrier_scalar_minor_temp.bind((x,)).to_code(config)
+
+        init = "pid_shared = pl.program_id(0)"
+        self.assertIn(init, code)
+        self.assertLess(code.index(init), code.index("@pl.when"))
+
+        module = ast.parse(code)
+        phase_loops = [
+            node
+            for node in ast.walk(module)
+            if isinstance(node, ast.For)
+            and isinstance(node.target, ast.Name)
+            and "helion_phase_host" in node.target.id
+            and ast.unparse(node.iter) == "range(2)"
+        ]
+        self.assertEqual(len(phase_loops), 1)
+
+        launcher_calls = [
+            node
+            for node in ast.walk(phase_loops[0])
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_launcher"
+        ]
+        self.assertEqual(len(launcher_calls), 1)
+        metadata = next(
+            (
+                keyword.value
+                for keyword in launcher_calls[0].keywords
+                if keyword.arg == "_pallas_phase_case_metadata"
+            ),
+            None,
+        )
+        self.assertIsNotNone(metadata)
+        assert isinstance(metadata, ast.Tuple)
+        self.assertEqual(len(metadata.elts), 2)
+        ranges = metadata.elts[1]
+        assert isinstance(ranges, ast.Tuple)
+        self.assertEqual(len(ranges.elts), 2)
+        self.assertTrue(all(isinstance(case, ast.Tuple) for case in ranges.elts))
+        cases = tuple(cast("ast.Tuple", case) for case in ranges.elts)
+        self.assertEqual(
+            [ast.literal_eval(case.elts[0]) for case in cases],
+            [0, 1],
+        )
+        self.assertEqual(ast.literal_eval(cases[0].elts[1]), 0)
+        self.assertEqual(ast.dump(cases[0].elts[2]), ast.dump(cases[1].elts[1]))
+
+        phase_guards = {
+            node.name: ast.unparse(node.decorator_list[0].args[0])
+            for node in ast.walk(module)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and "helion_phase_" in node.name
+            and node.decorator_list
+            and isinstance(node.decorator_list[0], ast.Call)
+        }
+        self.assertEqual(len(phase_guards), 2)
+        conditions = tuple(phase_guards.values())
+        self.assertTrue(any(re.search(r"helion_phase\w* == 0", c) for c in conditions))
+        self.assertTrue(any(re.search(r"helion_phase\w* == 1", c) for c in conditions))
+        for condition in conditions:
+            self.assertIn("pid_shared", condition)
+
+    def test_barrier_phase_codegen_keeps_shared_pid_immutable(self) -> None:
+        x = torch.empty((17, 128), dtype=torch.float32)
+        y = torch.empty_like(x)
+        code = pallas_barrier_four_roots.bind((x, y)).to_code(helion.Config())
+        module = ast.parse(code)
+
+        shared_init = next(
+            node
+            for node in ast.walk(module)
+            if isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and "pid_shared" in node.targets[0].id
+            and ast.unparse(node.value) == "pl.program_id(0)"
+        )
+        shared_pid = cast("ast.Name", shared_init.targets[0]).id
+        shared_pid_stores = [
+            node
+            for node in ast.walk(module)
+            if isinstance(node, ast.Name)
+            and isinstance(node.ctx, ast.Store)
+            and node.id == shared_pid
+        ]
+        self.assertEqual(len(shared_pid_stores), 1)
+        self.assertFalse(
+            any(
+                isinstance(node, ast.Nonlocal) and shared_pid in node.names
+                for node in ast.walk(module)
+            )
+        )
+
+        phase_functions = [
+            node
+            for node in ast.walk(module)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and "helion_phase_" in node.name
+        ]
+        self.assertEqual(len(phase_functions), 4)
+        for phase_function in phase_functions:
+            case_pid_assignments = [
+                node
+                for node in ast.walk(phase_function)
+                if isinstance(node, ast.Assign)
+                and any(
+                    isinstance(target, ast.Name) and target.id.startswith("pid_case")
+                    for target in node.targets
+                )
+            ]
+            self.assertEqual(len(case_pid_assignments), 1)
+
+        metadata = next(
+            keyword.value
+            for keyword in ast.walk(module)
+            if isinstance(keyword, ast.keyword)
+            and keyword.arg == "_pallas_phase_case_metadata"
+        )
+        assert isinstance(metadata, ast.Tuple)
+        ranges = metadata.elts[1]
+        assert isinstance(ranges, ast.Tuple)
+        self.assertEqual(
+            [ast.literal_eval(cast("ast.Tuple", case).elts[0]) for case in ranges.elts],
+            [0, 0, 1, 2],
+        )
+
+    def test_barrier_phase_rejects_multiaxis_flattened_foreach(self) -> None:
+        @helion.kernel(backend="pallas", static_shapes=True)
+        def multiaxis_barrier(x: torch.Tensor) -> torch.Tensor:
+            tmp = torch.empty_like(x)
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile(x.size()):
+                tmp[tile_m, tile_n] = x[tile_m, tile_n] + 1
+            hl.barrier()
+            for tile_m, tile_n in hl.tile(x.size()):
+                out[tile_m, tile_n] = tmp[tile_m, tile_n] * 2
+            return out
+
+        x = torch.empty((17, 128), dtype=torch.float32)
+        config = helion.Config(
+            block_sizes=[4, 128, 4, 128],
+            flatten_loops=[True, False],
+        )
+        with self.assertRaisesRegex(
+            helion.exc.InvalidConfig,
+            "multi-axis flattened grids",
+        ):
+            multiaxis_barrier.bind((x,)).to_code(config)
+
+    def test_barrier_phase_reused_grid_block_codegen(self) -> None:
+        x = torch.empty((16, 1, 128), dtype=torch.float32)
+        code = pallas_barrier_reused_grid_block.bind((x,)).to_code(
+            helion.Config(block_sizes=[4])
+        )
+        module = ast.parse(code)
+
+        metadata = next(
+            keyword.value
+            for keyword in ast.walk(module)
+            if isinstance(keyword, ast.keyword)
+            and keyword.arg == "_pallas_phase_case_metadata"
+        )
+        assert isinstance(metadata, ast.Tuple)
+        ranges = metadata.elts[1]
+        assert isinstance(ranges, ast.Tuple)
+        cases = [cast("ast.Tuple", case) for case in ranges.elts]
+        self.assertEqual(
+            [ast.literal_eval(case.elts[0]) for case in cases],
+            [0, 1, 2],
+        )
+        self.assertEqual(len(cases), 3)
+
+        totals: list[ast.expr] = []
+        for index, case in enumerate(cases):
+            start = case.elts[1]
+            end = case.elts[2]
+            if index == 0:
+                totals.append(cast("ast.expr", end))
+                continue
+            assert isinstance(end, ast.BinOp)
+            self.assertIsInstance(end.op, ast.Add)
+            self.assertEqual(ast.dump(end.left), ast.dump(start))
+            totals.append(end.right)
+        self.assertEqual(len({ast.unparse(total) for total in totals}), 3)
+        self.assertIn("pl.ds(", code)
+
+    def test_barrier_phase_rejects_inplace_hbm_output(self) -> None:
+        prepared_args = (
+            [0, 1],
+            [],
+            {},
+            2,
+            {0: 0, 1: 1},
+            {0},
+            (object(),),
+            {0: 0},
+        )
+        with (
+            patch(
+                "helion.runtime.pallas.launcher._pallas_prepare_args",
+                return_value=prepared_args,
+            ),
+            patch(
+                "helion.runtime.pallas.launcher._pallas_build_pipeline_specs",
+                return_value=([], []),
+            ),
+            self.assertRaisesRegex(
+                NotImplementedError,
+                r"direct launches do not support in-place HBM outputs: \[0\]",
+            ),
+        ):
+            _pallas_compile_jit_fn(
+                object(),
+                (1,),
+                (object(), object()),
+                _output_indices=[0],
+                _inplace_indices=[0],
+                _block_spec_info=[None, None],
+                _smem_arg_indices=None,
+                _scratch_shapes=None,
+                _hbm_arg_indices=[0],
+                _matmul_dot_general=None,
+                interpret=False,
+                _pallas_phase_case_metadata=(1, ((0, 0, 1),)),
+            )
+
+    @xfailIfPallasInterpret("barrier phase launches require TPU Pallas runtime")
+    def test_barrier_scalar_minor_temp_repeated_calls(self) -> None:
+        width = 8
+        config = helion.Config(
+            block_sizes=[16],
+            width=width,
+        )
+        x0 = torch.randn(17, 128, device=DEVICE, dtype=torch.float32)
+        compiled = pallas_barrier_scalar_minor_temp.bind((x0,)).compile_config(config)
+
+        for seed in range(3):
+            torch.manual_seed(seed)
+            x = torch.randn(17, 128, device=DEVICE, dtype=torch.float32)
+            result = compiled(x)
+            expected = x * width + (width * (width - 1) // 2)
+            torch.testing.assert_close(result, expected)
+
+    @xfailIfPallasInterpret("barrier phase launches require TPU Pallas runtime")
+    def test_barrier_four_roots(self) -> None:
+        x = torch.randn(17, 128, device=DEVICE, dtype=torch.float32)
+        y = torch.randn_like(x)
+        compiled = pallas_barrier_four_roots.bind((x, y)).compile_config(
+            helion.Config()
+        )
+        result = compiled(x, y)
+        torch.testing.assert_close(result, (x + y + 3) * 2)
+
+    @xfailIfPallasInterpret("barrier phase launches require TPU Pallas runtime")
+    def test_barrier_reused_grid_block(self) -> None:
+        x = torch.randn(16, 1, 128, device=DEVICE, dtype=torch.float32)
+        compiled = pallas_barrier_reused_grid_block.bind((x,)).compile_config(
+            helion.Config(block_sizes=[4])
+        )
+        result = compiled(x)
+        torch.testing.assert_close(result[:4], (x[:4] + 3) * 3)
 
     def test_scalar_access_1D_constexpr(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True, config=helion.Config())
@@ -6032,13 +6502,15 @@ class TestPallas(TestCase):
         config = helion.Config(block_sizes=[128, 128])
         x = torch.randn(256, device=DEVICE, dtype=torch.float32)
         y = torch.randn(384, device=DEVICE, dtype=torch.float32)
-        code = pallas_foreach_unequal_outputs.bind((x, y)).to_triton_code(config)
+        bound = pallas_foreach_unequal_outputs.bind((x, y))
+        code = bound.to_triton_code(config)
 
         self.assertIn("_output_indices=[1, 3]", code)
         self.assertIn("_inplace_indices=[1, 3]", code)
         self.assertNotIn("device='meta'", code)
         self.assertIn("((0, 1, 2, 0, 2),)", code)
         self.assertIn("((0, 1, 3, 2, 3),)", code)
+        self.assertNotIn("_pallas_phase_case_metadata=", code)
         self.assertGreaterEqual(code.count("@pl.when("), 2)
         self.assertNotIn("if pid_shared", code)
         self.assertNotIn("pid_shared -=", code)
@@ -6052,6 +6524,12 @@ class TestPallas(TestCase):
             and node.id.startswith("pid_shared")
         ]
         self.assertEqual(len(shared_pid_stores), 1)
+        self.assertFalse(
+            any(
+                isinstance(node, ast.If) and "pid_shared" in ast.unparse(node.test)
+                for node in ast.walk(module)
+            )
+        )
         case_guards = [
             ast.unparse(node.decorator_list[0].args[0])
             for node in ast.walk(module)
@@ -6062,6 +6540,7 @@ class TestPallas(TestCase):
         ]
         self.assertEqual(len(case_guards), 2)
         self.assertTrue(all("pid_shared" in guard for guard in case_guards))
+        self.assertTrue(all("helion_phase" not in guard for guard in case_guards))
 
         copy_guards, dim_semantics = _pallas_shared_output_plan(
             (5,),
@@ -6084,6 +6563,47 @@ class TestPallas(TestCase):
             },
         )
         self.assertEqual(dim_semantics, ("arbitrary",))
+
+    def test_foreach_empty_case_prunes_args_and_body(self) -> None:
+        config = helion.Config(block_sizes=[128, 128, 128])
+        x = torch.empty((0, 256), device=DEVICE, dtype=torch.float32)
+        y = torch.randn(256, device=DEVICE, dtype=torch.float32)
+        code = pallas_foreach_empty_axis_outputs.bind((x, y)).to_triton_code(config)
+
+        # The empty case keeps its control-flow slot, but its unused tensors are
+        # absent from both the device signature and launcher metadata.
+        module = ast.parse(code)
+        device_function = next(
+            node
+            for node in module.body
+            if isinstance(node, ast.FunctionDef) and node.name.startswith("_helion_")
+        )
+        self.assertEqual(
+            [arg.arg for arg in device_function.args.args],
+            ["y", "out_y"],
+        )
+        block_spec_info_node = next(
+            keyword.value
+            for keyword in ast.walk(module)
+            if isinstance(keyword, ast.keyword) and keyword.arg == "_block_spec_info"
+        )
+        block_spec_info = ast.literal_eval(block_spec_info_node)
+        self.assertEqual(
+            block_spec_info,
+            [
+                ((128,), ((0, 1, 2, 0, 2),)),
+                ((128,), ((0, 1, 2, 0, 2),)),
+            ],
+        )
+        self.assertIn("_output_indices=[1]", code)
+        self.assertIn("_inplace_indices=[1]", code)
+        empty_case = next(
+            node
+            for node in ast.walk(module)
+            if isinstance(node, ast.FunctionDef) and node.name.endswith("case_root_0")
+        )
+        self.assertEqual(len(empty_case.body), 1)
+        self.assertIsInstance(empty_case.body[0], ast.Pass)
 
     def test_foreach_outputs_execute(self) -> None:
         config = helion.Config(block_sizes=[128, 128])
@@ -6825,14 +7345,14 @@ class TestPallas(TestCase):
     def test_exact_block_subrange_last_two_dim_direct_store_allowed(self) -> None:
         @helion.kernel(backend="pallas", static_shapes=True)
         def fn(x: torch.Tensor) -> torch.Tensor:
-            out = torch.zeros_like(x)
+            out = torch.full_like(x, -7.0)
             for tile_m in hl.tile(0, 64, block_size=16):
                 for tile_n in hl.tile(x.size(2), block_size=128):
                     out[:, tile_m, tile_n] = x[:, tile_m, tile_n] + 1.0
             return out
 
         x = torch.randn(4, 65, 128, device=DEVICE, dtype=torch.float32)
-        expected = torch.zeros_like(x)
+        expected = torch.full_like(x, -7.0)
         expected[:, :64, :] = x[:, :64, :] + 1.0
         for loop_type in ("emit_pipeline", "fori_loop"):
             with self.subTest(loop_type=loop_type):
@@ -6847,6 +7367,12 @@ class TestPallas(TestCase):
                 else:
                     self.assertIn("jax.lax.fori_loop", code)
                     self.assertNotIn("pltpu.make_async_copy(out", code)
+                match = re.search(r"_block_spec_info=(\[[^\]]*\])", code)
+                self.assertIsNotNone(match)
+                block_spec_info = ast.literal_eval(match.group(1))
+                self.assertEqual(block_spec_info[0][0][1], 16)
+                self.assertIsNone(block_spec_info[1][0][1])
+                self.assertRegex(code, r"out\[:, pl\.ds\([^\n]*_BLOCK_SIZE_0\)")
                 torch.testing.assert_close(result, expected)
 
     def test_bounded_inner_tile_uses_outer_blockspec_local_ds(self) -> None:
@@ -8765,6 +9291,356 @@ class TestPallasJaxFn(TestCase):
         import jax.numpy as jnp
 
         return jax, jnp
+
+    def test_jax_export_launcher_accepts_generated_scalar_tensors(self) -> None:
+        jax, jnp = self._import_jax()
+
+        adapter = _JaxExportTensor.from_jax(
+            jnp.ones((1,), dtype=jnp.float32), device=torch.device("cpu")
+        )
+        phase = torch.tensor([1], dtype=torch.int32)
+
+        def fake_compile(*_args: object, **_kwargs: object) -> _PallasCompileResult:
+            def fake_jit_fn(data: Any, phase_arg: Any) -> Any:
+                return data + phase_arg.astype(data.dtype)
+
+            return _PallasCompileResult(
+                jit_fn=fake_jit_fn,
+                tensor_arg_indices=[0, 1],
+                output_only_indices=[],
+                arg_to_tensor_pos={0: 0, 1: 1},
+                inplace_positions={0},
+                pallas_aliases={0: 0},
+            )
+
+        with patch(
+            "helion.runtime.pallas.launcher._pallas_compile_jit_fn", fake_compile
+        ):
+            result = default_pallas_jax_launcher(
+                object(),
+                (1,),
+                adapter,
+                phase,
+                _output_indices=[0],
+                _inplace_indices=[0],
+                _pallas_interpret=True,
+            )
+
+        self.assertIsInstance(result, _JaxExportTensor)
+        out = jax.block_until_ready(result._jax_arr)
+        carried = jax.block_until_ready(adapter._jax_arr)
+        self.assertEqual(float(out[0]), 2.0)
+        self.assertEqual(float(carried[0]), 2.0)
+
+    def test_jax_export_like_allocations_honor_dtype(self) -> None:
+        _jax, jnp = self._import_jax()
+
+        adapter = _JaxExportTensor.from_jax(
+            jnp.ones((4,), dtype=jnp.float32), device=torch.device("cpu")
+        )
+
+        empty = torch.empty_like(adapter, dtype=torch.int32)
+        zeros = torch.zeros_like(adapter, dtype=torch.int32)
+
+        self.assertIsInstance(empty, _JaxExportTensor)
+        self.assertIsInstance(zeros, _JaxExportTensor)
+        self.assertEqual(empty._jax_arr.dtype, jnp.int32)
+        self.assertEqual(zeros._jax_arr.dtype, jnp.int32)
+        self.assertEqual(zeros.dtype, torch.int32)
+
+        uint_adapter = _JaxExportTensor.from_jax(
+            jnp.ones((4,), dtype=jnp.uint32), device=torch.device("cpu")
+        )
+        self.assertEqual(uint_adapter.dtype, torch.uint32)
+        uint_zeros = torch.zeros_like(uint_adapter)
+        self.assertEqual(uint_zeros.dtype, torch.uint32)
+        self.assertEqual(uint_zeros._jax_arr.dtype, jnp.uint32)
+
+        complex_adapter = _JaxExportTensor.from_jax(
+            jnp.ones((4,), dtype=jnp.complex64), device=torch.device("cpu")
+        )
+        self.assertEqual(complex_adapter.dtype, torch.complex64)
+        complex_zeros = torch.zeros_like(complex_adapter)
+        self.assertEqual(complex_zeros.dtype, torch.complex64)
+        self.assertEqual(complex_zeros._jax_arr.dtype, jnp.complex64)
+
+    def test_jax_export_allocation_mode_is_scoped_to_declared_device(self) -> None:
+        jax, jnp = self._import_jax()
+        declared_device = torch.device("cpu")
+        original_empty = torch.empty
+        original_zeros = torch.zeros
+
+        before = torch.zeros((2,), dtype=torch.int32, device=declared_device)
+        self.assertNotIsInstance(before, _JaxExportTensor)
+
+        with _torch_allocation_patch_for_jax_export(declared_device):
+            self.assertIs(torch.empty, original_empty)
+            self.assertIs(torch.zeros, original_zeros)
+
+            empty = torch.empty(
+                2,
+                3,
+                dtype=torch.int32,
+                device=declared_device,
+            )
+            zeros = torch.zeros(
+                size=(2, 3),
+                dtype=torch.float32,
+                device="cpu",  # @ignore-device-lint
+            )
+            nonmatching = torch.zeros(
+                (2,),
+                dtype=torch.int32,
+                device="meta",  # @ignore-device-lint
+            )
+
+            self.assertIsInstance(empty, _JaxExportTensor)
+            self.assertIsInstance(zeros, _JaxExportTensor)
+            self.assertEqual(empty.shape, torch.Size((2, 3)))
+            self.assertEqual(empty.dtype, torch.int32)
+            self.assertEqual(empty._jax_arr.dtype, jnp.int32)
+            self.assertEqual(zeros.shape, torch.Size((2, 3)))
+            self.assertEqual(zeros.dtype, torch.float32)
+            self.assertEqual(zeros._jax_arr.dtype, jnp.float32)
+            self.assertTrue(bool(jnp.all(jax.block_until_ready(zeros._jax_arr) == 0)))
+            self.assertNotIsInstance(nonmatching, _JaxExportTensor)
+            self.assertEqual(nonmatching.device.type, "meta")
+
+        self.assertIs(torch.empty, original_empty)
+        self.assertIs(torch.zeros, original_zeros)
+        after = torch.zeros((2,), dtype=torch.int32, device=declared_device)
+        self.assertNotIsInstance(after, _JaxExportTensor)
+        self.assertTrue(bool(torch.equal(after, torch.zeros_like(after))))
+
+    def test_jax_export_extended_factories(self) -> None:
+        jax, jnp = self._import_jax()
+        declared_device = torch.device("cpu")
+        adapter = _JaxExportTensor.from_jax(
+            jnp.zeros((2, 3), dtype=jnp.float32),
+            device=declared_device,
+        )
+
+        allocations = (
+            (torch.ones_like(adapter, dtype=torch.int32), 1),
+            (torch.full_like(adapter, 2, dtype=torch.int32), 2),
+            (adapter.new_empty(2, 3, dtype=torch.int32), None),
+            (adapter.new_zeros(2, 3, dtype=torch.int32), 0),
+            (adapter.new_ones((2, 3), dtype=torch.int32), 1),
+            (adapter.new_full((2, 3), 4, dtype=torch.int32), 4),
+            (
+                adapter.new_full(
+                    size=(2, 3),
+                    fill_value=5,
+                    dtype=torch.int32,
+                ),
+                5,
+            ),
+        )
+        for allocation, expected in allocations:
+            with self.subTest(expected=expected):
+                self.assertIsInstance(allocation, _JaxExportTensor)
+                self.assertEqual(allocation.shape, torch.Size((2, 3)))
+                self.assertEqual(allocation.dtype, torch.int32)
+                if expected is not None:
+                    value = jax.block_until_ready(allocation._jax_arr)
+                    self.assertTrue(bool(jnp.all(value == expected)))
+
+        with _torch_allocation_patch_for_jax_export(declared_device):
+            ones = torch.ones(
+                2,
+                3,
+                dtype=torch.int32,
+                device="cpu",  # @ignore-device-lint
+            )
+            full = torch.full(
+                (2, 3),
+                6,
+                dtype=torch.int32,
+                device="cpu",  # @ignore-device-lint
+            )
+            full_kw = torch.full(
+                size=(2, 3),
+                fill_value=7,
+                dtype=torch.int32,
+                device="cpu",  # @ignore-device-lint
+            )
+            out = torch.empty((2, 3), dtype=torch.int32)
+            out_result = torch.ones(
+                (2, 3),
+                out=out,
+                device="cpu",  # @ignore-device-lint
+            )
+
+        for allocation, expected in ((ones, 1), (full, 6), (full_kw, 7)):
+            with self.subTest(bare_expected=expected):
+                self.assertIsInstance(allocation, _JaxExportTensor)
+                value = jax.block_until_ready(allocation._jax_arr)
+                self.assertTrue(bool(jnp.all(value == expected)))
+        self.assertIs(out_result, out)
+        self.assertNotIsInstance(out_result, _JaxExportTensor)
+        self.assertTrue(bool(torch.equal(out_result, torch.ones_like(out))))
+
+    def test_jax_export_updates_alias_with_fresh_output(self) -> None:
+        jax, jnp = self._import_jax()
+
+        adapter = _JaxExportTensor.from_jax(
+            jnp.ones((2,), dtype=jnp.float32), device=torch.device("cpu")
+        )
+        fresh = _JaxExportTensor.from_jax(
+            jnp.zeros((2,), dtype=jnp.float32), device=torch.device("cpu")
+        )
+
+        def fake_compile(*_args: object, **_kwargs: object) -> _PallasCompileResult:
+            def fake_jit_fn(data: Any) -> Any:
+                return data + 1, data + 2
+
+            return _PallasCompileResult(
+                jit_fn=fake_jit_fn,
+                tensor_arg_indices=[0],
+                output_only_indices=[1],
+                arg_to_tensor_pos={0: 0},
+                inplace_positions={0},
+                pallas_aliases={0: 0},
+            )
+
+        with patch(
+            "helion.runtime.pallas.launcher._pallas_compile_jit_fn", fake_compile
+        ):
+            result = default_pallas_jax_launcher(
+                object(),
+                (1,),
+                adapter,
+                fresh,
+                _output_indices=[0, 1],
+                _inplace_indices=[0],
+                _pallas_interpret=True,
+            )
+
+        self.assertIsInstance(result, _JaxExportTensor)
+        returned = jax.block_until_ready(result._jax_arr)
+        carried = jax.block_until_ready(adapter._jax_arr)
+        self.assertTrue(bool(jnp.allclose(returned, jnp.full((2,), 3.0))))
+        self.assertTrue(bool(jnp.allclose(carried, jnp.full((2,), 2.0))))
+
+    def test_jax_export_updates_pre_padding_adapter(self) -> None:
+        jax, jnp = self._import_jax()
+
+        adapter = _JaxExportTensor.from_jax(
+            jnp.ones((3,), dtype=jnp.float32), device=torch.device("cpu")
+        )
+
+        def fake_compile(
+            *compile_args: object, **_kwargs: object
+        ) -> _PallasCompileResult:
+            padded = cast("tuple[object, ...]", compile_args[2])
+            self.assertEqual(cast("Any", padded[0]).shape, (4,))
+
+            def fake_jit_fn(data: Any) -> Any:
+                return data + 1
+
+            return _PallasCompileResult(
+                jit_fn=fake_jit_fn,
+                tensor_arg_indices=[0],
+                output_only_indices=[],
+                arg_to_tensor_pos={0: 0},
+                inplace_positions={0},
+                pallas_aliases={0: 0},
+            )
+
+        with patch(
+            "helion.runtime.pallas.launcher._pallas_compile_jit_fn", fake_compile
+        ):
+            result = default_pallas_jax_launcher(
+                object(),
+                (1,),
+                adapter,
+                _output_indices=[0],
+                _inplace_indices=[0],
+                _ds_pad_dims=[(0, 0, 4, 0)],
+                _pallas_interpret=True,
+            )
+
+        self.assertIsInstance(result, _JaxExportTensor)
+        returned = jax.block_until_ready(result._jax_arr)
+        carried = jax.block_until_ready(adapter._jax_arr)
+        self.assertEqual(returned.shape, (3,))
+        self.assertEqual(carried.shape, (3,))
+        self.assertTrue(bool(jnp.allclose(returned, jnp.full((3,), 2.0))))
+        self.assertTrue(bool(jnp.allclose(carried, jnp.full((3,), 2.0))))
+
+    @skipIfPallasInterpret("barrier phase launches require TPU Pallas runtime")
+    def test_jax_fn_barrier_kernel(self) -> None:
+        jax, jnp = self._import_jax()
+        width = 8
+        config = helion.Config(
+            block_sizes=[16],
+            width=width,
+        )
+        barrier_kernel = helion.kernel(
+            pallas_barrier_scalar_minor_temp.fn,
+            backend="pallas",
+            static_shapes=True,
+            config=config,
+        )
+
+        x = jnp.arange(17 * 128, dtype=jnp.float32).reshape(17, 128)
+        result = jax.block_until_ready(jax.jit(barrier_kernel.jax_fn)(x))
+
+        expected = x * width + (width * (width - 1) // 2)
+        self.assertTrue(bool(jnp.allclose(result, expected)))
+
+    @skipIfPallasInterpret("barrier phase launches require TPU Pallas runtime")
+    def test_jax_fn_barrier_full_and_new_empty_factories(self) -> None:
+        jax, jnp = self._import_jax()
+        x = jnp.arange(17 * 128, dtype=jnp.float32).reshape(17, 128)
+        barrier_kernel = helion.kernel(
+            pallas_barrier_full_temp.fn,
+            backend="pallas",
+            static_shapes=True,
+            config=helion.Config(),
+        )
+
+        result = jax.block_until_ready(jax.jit(barrier_kernel.jax_fn)(x))
+
+        self.assertTrue(bool(jnp.allclose(result, (x + 3) * 2)))
+
+    def test_jax_fn_foreach_outputs(self) -> None:
+        jax, jnp = self._import_jax()
+        foreach_kernel = helion.kernel(
+            pallas_foreach_output_only.fn,
+            backend="pallas",
+            static_shapes=True,
+            config=helion.Config(block_sizes=[128, 128]),
+        )
+        x = jnp.arange(256, dtype=jnp.float32)
+
+        out1, out2 = jax.jit(foreach_kernel.jax_fn)(x)
+        out1 = jax.block_until_ready(out1)
+        out2 = jax.block_until_ready(out2)
+
+        self.assertTrue(bool(jnp.allclose(out1, x + 1.0)))
+        self.assertTrue(bool(jnp.allclose(out2, x * 2.0)))
+
+    @skipIfPallasInterpret(
+        "emit_pipeline requires >1D values after empty-output pruning"
+    )
+    def test_jax_fn_foreach_empty_and_nonempty_outputs(self) -> None:
+        jax, jnp = self._import_jax()
+        foreach_kernel = helion.kernel(
+            pallas_foreach_empty_axis_outputs.fn,
+            backend="pallas",
+            static_shapes=True,
+            config=helion.Config(block_sizes=[128, 128, 128]),
+        )
+        x = jnp.empty((0, 256), dtype=jnp.float32)
+        y = jnp.arange(256, dtype=jnp.float32)
+
+        out_x, out_y = jax.jit(foreach_kernel.jax_fn)(x, y)
+        out_x = jax.block_until_ready(out_x)
+        out_y = jax.block_until_ready(out_y)
+
+        self.assertEqual(out_x.shape, (0, 256))
+        self.assertTrue(bool(jnp.allclose(out_y, y * 2.0)))
 
     def test_jax_fn_emit_pipeline(self) -> None:
         """jax_fn drives an emit_pipeline kernel inside ``jax.jit``."""


### PR DESCRIPTION
Stacked PRs:
 * #2962
 * __->__#2957
 * #2956
 * #2955
 * #2954
 * #2953
 * #2952
 * #2951
 * #2949
 * #2948
 * #2947
 * #2946
 * #2945
 * #2944
 * #2943
 * #2942


--- --- ---

### Support Pallas barrier phase launches


Example fixed: split_k_barrier and split_k_barrier_accuracy under Pallas.

Compiler/runtime side: lower barriers as host-side phase relaunches by adding a phase scalar argument, wrapping root bodies in `pl.when` guards, passing phase/case metadata into `pallas_call`, and using phase-leader copy guards so cross-phase temporaries survive repeated launches. Runtime Pallas padding now keeps multiple `pl.ds` requirements per tensor dimension and canonicalizes them from original shapes before applying one pad. The JAX export adapter also normalizes torch allocation shapes/devices and casts JAX dtype objects at API boundaries so the wrapper remains type-checkable without importing JAX globally.

Why needed: Pallas has no single-kernel grid-wide barrier for these kernels, so the runtime has to relaunch phases explicitly while preserving shared outputs and scratch temporaries across launches.
