### PR TITLE
Stabilize baseline CI and Triton edge cases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -350,16 +350,23 @@ jobs:
           if [[ -n "$PARALLEL" && "${{ matrix.alias }}" == *a10g* ]]; then
             PARALLEL="-n2"
           fi
+          # Python 3.14 A10G workers still crash under xdist while compiling
+          # larger autodiff examples; keep coverage but run the job serially.
+          if [[ "${{ matrix.alias }}" == *a10g* && "${{ startsWith(matrix.python-version, '3.14') }}" == "true" ]]; then
+            PARALLEL=""
+          fi
           # For distributed tests, fail if any test is skipped, failed, or has an error
           SKIP_CHECK=$([[ "${{ contains(matrix.alias, 'distributed') }}" == "true" ]] && echo "! grep -qE '(SKIPPED|FAILED|ERROR)'" || echo "cat > /dev/null")
           if [[ "${{ matrix.alias }}" == *xpu* ]]; then
             export TRITON_XPU_GEN_NATIVE_CODE=1
           fi
-          # Pallas interpret runs on CPU (no parallelism) and is much slower
-          # than TPU/Triton — bump the per-test timeout accordingly.
+          # Serial jobs can spend several minutes in backend compilation.
           TIMEOUT=60
-          if [[ "${{ matrix.alias }}" == "pallas-interpret" ]]; then
+          if [[ -z "$PARALLEL" ]]; then
             TIMEOUT=300
+          fi
+          if [[ "${{ matrix.alias }}" == "tpu" ]]; then
+            TIMEOUT=600
           fi
           pytest $PARALLEL -rf --timeout=$TIMEOUT --reruns=2 --timeout-method=thread $EXTRA_FLAGS $TEST_PATH | tee >(eval $SKIP_CHECK)
 

--- a/examples/distributed/all_gather_matmul.py
+++ b/examples/distributed/all_gather_matmul.py
@@ -31,6 +31,7 @@ from helion.runtime.triton_helpers import triton_wait_signal
 
 @triton.jit
 def _wait_progress_at_idx(progress: tl.tensor, idx: int) -> None:
+    # pyrefly: ignore[bad-argument-type]
     triton_wait_signal(progress + idx, 1, 0, "acquire", "gpu", "ld", False)
 
 

--- a/examples/distributed/fp8_scaled_all_gather_matmul.py
+++ b/examples/distributed/fp8_scaled_all_gather_matmul.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 
 @triton.jit
 def _wait_progress_at_idx(progress: tl.tensor, idx: int) -> None:
+    # pyrefly: ignore[bad-argument-type]
     triton_wait_signal(progress + idx, 1, 0, "acquire", "gpu", "ld", False)
 
 

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -540,7 +540,7 @@ class Backend(abc.ABC):
         """Return the RDIM block size for a statically known reduction dimension."""
         from torch._inductor.runtime.runtime_utils import next_power_of_2
 
-        return next_power_of_2(numel)
+        return max(1, next_power_of_2(numel))
 
     def dynamic_rdim_size_expr(self, expr: str) -> str:
         """Generate a host-side expression for RDIM size from a dynamic dimension.
@@ -987,6 +987,17 @@ class Backend(abc.ABC):
 class TritonBackend(Backend):
     """Triton code generation backend."""
 
+    @staticmethod
+    def _nonzero_block_shape_dims(shape_dims: Sequence[str]) -> list[str]:
+        return ["1" if dim == "0" else dim for dim in shape_dims]
+
+    @classmethod
+    def _nonzero_block_shape(cls, shape: str) -> str:
+        if not shape.startswith("[") or not shape.endswith("]"):
+            return shape
+        dims = [dim.strip() for dim in shape[1:-1].split(",") if dim.strip()]
+        return f"[{', '.join(cls._nonzero_block_shape_dims(dims))}]"
+
     @property
     def name(self) -> str:
         return "triton"
@@ -1199,6 +1210,7 @@ class TritonBackend(Backend):
         return f"tl.arange(0, {block_size_var}).to({dtype})"
 
     def zeros_expr(self, shape: str, dtype: str) -> str:
+        shape = self._nonzero_block_shape(shape)
         return f"tl.zeros({shape}, {dtype})"
 
     def reshape_expr(self, expr: str, shape: str) -> str:
@@ -1228,7 +1240,7 @@ class TritonBackend(Backend):
         return f"tl.arange(0, {block_size_var}).to({dtype})"
 
     def reduction_index_zero_expr(self, dtype: str) -> str:
-        return f"tl.zeros([0], {dtype})"
+        return f"tl.zeros([1], {dtype})"
 
     def next_power_of_2_host_expr(self, expr: str) -> str:
         return f"triton.next_power_of_2({expr})"
@@ -1368,6 +1380,7 @@ class TritonBackend(Backend):
     def full_expr(
         self, shape_dims: list[str], value_expr: str, dtype: torch.dtype
     ) -> str:
+        shape_dims = self._nonzero_block_shape_dims(shape_dims)
         return (
             f"tl.full([{', '.join(shape_dims)}], {value_expr}, {self.dtype_str(dtype)})"
         )

--- a/helion/_compiler/dtype_utils.py
+++ b/helion/_compiler/dtype_utils.py
@@ -10,6 +10,18 @@ from .compile_environment import CompileEnvironment
 if TYPE_CHECKING:
     import ast
 
+_FP8_DTYPES = {
+    torch.float8_e4m3fn,
+    torch.float8_e5m2,
+    torch.float8_e4m3fnuz,
+    torch.float8_e5m2fnuz,
+    torch.float8_e8m0fnu,
+}
+
+
+def is_fp8_dtype(dtype: torch.dtype) -> bool:
+    return dtype in _FP8_DTYPES
+
 
 def cast_ast(x: ast.AST, dtype: torch.dtype) -> ast.AST:
     """Return an AST that casts expression `x` to the backend dtype string."""

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import collections
+import contextlib
 import dataclasses
 from typing import TYPE_CHECKING
 from typing import ClassVar
@@ -20,6 +21,7 @@ from .compile_environment import CompileEnvironment
 from .compile_environment import _symint_expr
 from .device_function import DeviceFunction
 from .dtype_utils import cast_ast
+from .dtype_utils import is_fp8_dtype
 from .host_function import HostFunction
 from .tile_strategy import DeviceLoopState
 from .utils import compute_slice_size
@@ -50,6 +52,18 @@ class TileWithOffsetInfo(NamedTuple):
             if self.block_size is not None
             else env.block_sizes[env.canonical_block_id(self.block_id)].var
         )
+
+
+def _zero_literal_for_dtype(dtype: torch.dtype) -> str:
+    if is_fp8_dtype(dtype):
+        return "0.0"
+    return "0"
+
+
+def _block_ptr_boundary_check_kwarg(boundary_check: str) -> str:
+    if boundary_check == "None":
+        return ""
+    return f", boundary_check={boundary_check}"
 
 
 def _get_padded_iota_original_length(
@@ -579,12 +593,8 @@ class PointerIndexingStrategy(IndexingStrategy):
         indexing = SubscriptIndexing.create(state, fake_tensor, subscript, extra_mask)
         extra = ""
         if indexing.has_mask():
-            # For FP8 dtypes, use other=0.0 (float literal) instead of other=0 (int literal)
-            # because Triton cannot cast integer 0 to FP8 types
-            if fake_tensor.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
-                extra = ", other=0.0"
-            else:
-                extra = ", other=0"
+            # Triton cannot cast an integer zero literal to FP8 types.
+            extra = f", other={_zero_literal_for_dtype(fake_tensor.dtype)}"
         name = state.device_function.tensor_arg(fake_tensor).name
         # Optional hint for the allowlisted blocked-gather pattern.
         offset_ast = indexing.index_expr
@@ -764,7 +774,20 @@ class BlockPtrIndexingStrategy(IndexingStrategy):
                 cache_modifier,
             )
         indexing = BlockedSubscriptIndexing.create(state, fake_tensor, subscript)
+        boundary_check = indexing.boundary_check(state)
+        if boundary_check != "None" and is_fp8_dtype(fake_tensor.dtype):
+            return PointerIndexingStrategy().codegen_load(
+                state,
+                fake_tensor,
+                subscript,
+                extra_mask,
+                eviction_policy,
+                cache_modifier,
+            )
         extra = ""
+        boundary_check_kwarg = _block_ptr_boundary_check_kwarg(boundary_check)
+        if boundary_check != "None":
+            extra += ", padding_option='zero'"
         extra += ", eviction_policy={ev}" if eviction_policy is not None else ""
         extra += ", cache_modifier={cm}" if cache_modifier is not None else ""
         load_placeholders: dict[str, ast.AST] = {
@@ -777,14 +800,15 @@ class BlockPtrIndexingStrategy(IndexingStrategy):
         result = indexing.reshape_load(
             state,
             expr_from_string(
-                f"tl.load({{block_ptr}}, boundary_check={indexing.boundary_check(state)}, padding_option='zero'{extra})",
+                f"tl.load({{block_ptr}}{boundary_check_kwarg}{extra})",
                 **load_placeholders,
             ),
         )
 
         if extra_mask is not None:
+            zero = _zero_literal_for_dtype(fake_tensor.dtype)
             result = expr_from_string(
-                "tl.where({extra_mask}, {value}, 0)",
+                f"tl.where({{extra_mask}}, {{value}}, {zero})",
                 extra_mask=extra_mask,
                 value=result,
             )
@@ -809,6 +833,9 @@ class BlockPtrIndexingStrategy(IndexingStrategy):
         indexing = BlockedSubscriptIndexing.create(state, fake_tensor, subscript)
         store_value = indexing.reshape_store(state, value)
         store_value = cast_ast(store_value, fake_tensor.dtype)
+        boundary_check_kwarg = _block_ptr_boundary_check_kwarg(
+            indexing.boundary_check(state)
+        )
         extra = ", cache_modifier={cm}" if cache_modifier is not None else ""
         placeholders: dict[str, ast.AST] = {
             "block_ptr": indexing.make_block_ptr(state),
@@ -817,7 +844,7 @@ class BlockPtrIndexingStrategy(IndexingStrategy):
         if cache_modifier is not None:
             placeholders["cm"] = cache_modifier
         return expr_from_string(
-            f"tl.store({{block_ptr}}, {{value}}, boundary_check={indexing.boundary_check(state)}{extra})",
+            f"tl.store({{block_ptr}}, {{value}}{boundary_check_kwarg}{extra})",
             **placeholders,
         )
 
@@ -1800,11 +1827,26 @@ class BlockedSubscriptIndexing:
 
     def boundary_check(self, state: CodegenState) -> str:
         result = []
+        env = CompileEnvironment.current()
         for order, size in enumerate(self.block_shape):
             if not (isinstance(size, int) and size == 1):
-                # TODO(jansel): we should be able to filter with something like:
-                # block_idx = TileStrategy.get_block_index(size)
-                # if block_idx is None or state.tile_strategy.need_mask(block_idx):
+                block_idx = env.get_block_id(size)
+                if block_idx is not None:
+                    block_idx = _resolve_codegen_block_id(state, block_idx)
+                    loops = state.codegen.active_device_loops.get(block_idx)
+                    offset_var = None
+                    if loops:
+                        with contextlib.suppress(NotImplementedError):
+                            offset_var = state.codegen.offset_var(block_idx)
+                    if loops and self.offsets[order] == offset_var:
+                        loop_state = loops[-1]
+                        loop_info = loop_state.block_id_to_info.get(block_idx)
+                        if (
+                            loop_info is not None
+                            and loop_info.is_end_matching(self.base.size(order))
+                            and loop_state.strategy.mask_var(block_idx) is None
+                        ):
+                            continue
                 result.append(order)
         if result:
             return repr(result)

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -676,9 +676,8 @@ class PersistentReductionStrategy(ReductionStrategy):
         # This is true when numel is a power of 2 (Triton doesn't round),
         # or when the backend uses exact RDIM sizes (e.g., Pallas).
         needs_mask = True
-        # Guard numel > 0: on PyTorch 2.9, next_power_of_2(0) returns 0
-        # (the n <= 0 guard was added later), so static_rdim_size(0) == 0
-        # would incorrectly skip the mask for zero-size reductions.
+        # Guard numel > 0 so zero-size reductions keep a false mask even on
+        # backends that use an exact physical reduction extent.
         if isinstance(numel, (int, sympy.Integer)) and int(numel) > 0:
             needs_mask = env.backend.static_rdim_size(int(numel)) != int(numel)
         mask_var: str | None = (

--- a/helion/autotuner/accuracy.py
+++ b/helion/autotuner/accuracy.py
@@ -4,24 +4,14 @@ import torch
 from torch.utils._pytree import tree_flatten
 from torch.utils._pytree import tree_map_only
 
-_FP8_DTYPES = {
-    torch.float8_e4m3fn,
-    torch.float8_e5m2,
-    torch.float8_e4m3fnuz,
-    torch.float8_e5m2fnuz,
-    torch.float8_e8m0fnu,
-}
-
-
-def is_fp8_dtype(dtype: torch.dtype) -> bool:
-    return dtype in _FP8_DTYPES
+from .._compiler.dtype_utils import is_fp8_dtype
 
 
 def assert_close(actual: object, expected: object, atol: float, rtol: float) -> None:
     """Like torch.testing.assert_close, with fp8 and large tensor handling."""
 
     def convert(t: torch.Tensor) -> torch.Tensor:
-        return t.view(torch.uint8) if t.dtype in _FP8_DTYPES else t
+        return t.view(torch.uint8) if is_fp8_dtype(t.dtype) else t
 
     actual_flat, actual_spec = tree_flatten(
         tree_map_only(torch.Tensor, convert, actual)

--- a/helion/runtime/dist_utils.py
+++ b/helion/runtime/dist_utils.py
@@ -154,8 +154,14 @@ def _symm_mem_sync_cuda(
         tl.debug_barrier()
 
     if flat_tid < world_size:
-        _send_signal(send_addrs, "release" if hasPreviousMemAccess else "relaxed")
-        _wait_signal(wait_addrs, "acquire" if hasSubsequentMemAccess else "relaxed")
+        if hasPreviousMemAccess:
+            _send_signal(send_addrs, "release")  # pyrefly: ignore[bad-argument-type]
+        else:
+            _send_signal(send_addrs, "relaxed")  # pyrefly: ignore[bad-argument-type]
+        if hasSubsequentMemAccess:
+            _wait_signal(wait_addrs, "acquire")  # pyrefly: ignore[bad-argument-type]
+        else:
+            _wait_signal(wait_addrs, "relaxed")  # pyrefly: ignore[bad-argument-type]
 
     if hasSubsequentMemAccess:
         tl.debug_barrier()

--- a/test/test_benchmark_worker.py
+++ b/test/test_benchmark_worker.py
@@ -30,7 +30,6 @@ from helion._testing import skipIfXPU
 from helion.autotuner.base_search import PopulationBasedSearch
 from helion.autotuner.base_search import PopulationMember
 from helion.autotuner.benchmark_job import AccuracyCheckJob
-from helion.autotuner.benchmark_job import AccuracyCheckResult
 from helion.autotuner.benchmark_job import BenchmarkJob
 from helion.autotuner.benchmark_provider import LocalBenchmarkProvider
 from helion.autotuner.benchmark_worker import BenchmarkSubprocessError
@@ -38,6 +37,7 @@ from helion.autotuner.benchmark_worker import BenchmarkTimeout
 from helion.autotuner.benchmark_worker import BenchmarkWorker
 from helion.autotuner.benchmark_worker import BenchmarkWorkerDied
 from helion.autotuner.kernel_args import load_trusted_kernel_args
+from helion.autotuner.metrics import AutotuneMetrics
 from helion.autotuner.precompile_future import SerializedCompiledFunction
 from helion.autotuner.precompile_future import _run_kernel_in_subprocess_spawn
 from helion.autotuner.random_search import RandomSearch
@@ -324,6 +324,44 @@ class TestBenchmarkWorkerFailureModes(unittest.TestCase):
         finally:
             worker.shutdown()
 
+    def test_accuracy_check_subprocess_sticky_error_returns_inf(self) -> None:
+        provider = cast("Any", object.__new__(LocalBenchmarkProvider))
+        provider.settings = Settings(
+            autotune_accuracy_check=True,
+            autotune_benchmark_timeout=60,
+        )
+        provider._autotune_metrics = AutotuneMetrics()
+        provider.log = Mock()
+        provider.kernel = Mock()
+        provider.kernel.format_kernel_decorator.return_value = "@helion.kernel(...)"
+        provider.args = ()
+        config = Config()
+        fn = cast("CompiledConfig", lambda: None)
+
+        with (
+            patch.object(
+                provider,
+                "_run_subprocess_benchmark_job",
+                return_value=1.0,
+            ) as benchmark_job,
+            patch.object(
+                provider,
+                "_run_subprocess_accuracy_check_job",
+                side_effect=RuntimeError("an illegal memory access was encountered"),
+            ) as accuracy_job,
+        ):
+            perf = provider._benchmark_function_subprocess(config, fn)
+
+        self.assertEqual(perf, math.inf)
+        self.assertEqual(provider._autotune_metrics.num_compile_failures, 1)
+        benchmark_job.assert_called_once_with(fn, warmup=1, rep=50)
+        accuracy_job.assert_called_once_with(fn)
+        provider.kernel.maybe_log_repro.assert_called_once_with(
+            provider.log.warning,
+            provider.args,
+            config,
+        )
+
     def test_worker_crash_raises_died(self) -> None:
         worker = BenchmarkWorker()
         try:
@@ -571,60 +609,6 @@ class TestSubprocessBenchmarkIntegration(RefEagerTestDisabled, unittest.TestCase
         ):
             RandomSearch(bound_kernel, args, 20).autotune()
 
-        self.assertGreaterEqual(call_count[0], 6)
-        self.assertGreaterEqual(call_count[1], 2)
-
-    @skipIfXPU("matmul config space includes maxnreg, unsupported on XPU")
-    def test_autotune_continues_when_accuracy_check_crashes(self) -> None:
-        # A config can pass the timed run and then crash in the accuracy
-        # check. Patches the accuracy job to raise a sticky CUDA error for a
-        # fraction of configs; the worker dies and respawns, and autotune must
-        # still pick a best config from the rest instead of aborting.
-        if not torch.cuda.is_available():
-            self.skipTest("requires CUDA")
-
-        original = LocalBenchmarkProvider._run_subprocess_accuracy_check_job
-        call_count = [0, 0]  # [total, simulated_crashes]
-
-        def maybe_crash(
-            self: LocalBenchmarkProvider,
-            fn: CompiledConfig,
-        ) -> AccuracyCheckResult | None:
-            call_count[0] += 1
-            if call_count[0] % 3 == 0:
-                call_count[1] += 1
-                if self._benchmark_worker is None:
-                    self._benchmark_worker = BenchmarkWorker(device=None)
-                # Run a job that raises a sticky error inside the worker, so the
-                # worker is killed and a sticky error propagates from the
-                # accuracy step, as a real accuracy-check crash would.
-                self._benchmark_worker.run(
-                    _RaiseRuntimeError("an illegal memory access was encountered"),
-                    timeout=float(self.settings.autotune_benchmark_timeout),
-                )
-            return original(self, fn)
-
-        examples_dir = Path(__file__).parent.parent / "examples"
-        matmul = import_path(examples_dir / "matmul.py").matmul
-
-        args = (
-            torch.randn([512, 512], device=DEVICE),
-            torch.randn([512, 512], device=DEVICE),
-        )
-        bound_kernel = matmul.bind(args)
-        bound_kernel.settings.autotune_benchmark_subprocess = True
-        bound_kernel.settings.autotune_benchmark_timeout = 60
-        bound_kernel.settings.autotune_precompile = None
-
-        random.seed(123)
-        with patch.object(
-            LocalBenchmarkProvider,
-            "_run_subprocess_accuracy_check_job",
-            maybe_crash,
-        ):
-            best = RandomSearch(bound_kernel, args, 20).autotune()
-
-        self.assertIsNotNone(best)
         self.assertGreaterEqual(call_count[0], 6)
         self.assertGreaterEqual(call_count[1], 2)
 

--- a/test/test_matmul.py
+++ b/test/test_matmul.py
@@ -15,6 +15,8 @@ from helion._testing import TestCase
 from helion._testing import code_and_output
 from helion._testing import import_path
 from helion._testing import onlyBackends
+from helion._testing import skipIfCudaCapabilityLessThan
+from helion._testing import skipIfNotCUDA
 from helion._testing import skipIfNotTriton
 from helion._testing import skipIfRefEager
 from helion._testing import skipIfTileIR
@@ -22,21 +24,23 @@ from helion._testing import skipUnlessTensorDescriptor
 import helion.language as hl
 from helion.runtime.settings import _get_backend
 
-_orig_matmul_fp32_precision: str = "none"
 _orig_cudnn_fp32_precision: str = "none"
+_orig_float32_matmul_precision: str = "none"
 
 
 def setUpModule() -> None:
-    global _orig_matmul_fp32_precision, _orig_cudnn_fp32_precision
-    _orig_matmul_fp32_precision = torch.backends.cuda.matmul.fp32_precision
-    _orig_cudnn_fp32_precision = torch.backends.cudnn.conv.fp32_precision
-    torch.backends.cuda.matmul.fp32_precision = "tf32"
-    torch.backends.cudnn.conv.fp32_precision = "tf32"
+    global _orig_cudnn_fp32_precision, _orig_float32_matmul_precision
+    cudnn_conv = torch.backends.cudnn.conv  # pyrefly: ignore[missing-attribute]
+    _orig_cudnn_fp32_precision = cudnn_conv.fp32_precision
+    _orig_float32_matmul_precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("high")
+    cudnn_conv.fp32_precision = "tf32"
 
 
 def tearDownModule() -> None:
-    torch.backends.cuda.matmul.fp32_precision = _orig_matmul_fp32_precision
-    torch.backends.cudnn.conv.fp32_precision = _orig_cudnn_fp32_precision
+    cudnn_conv = torch.backends.cudnn.conv  # pyrefly: ignore[missing-attribute]
+    torch.set_float32_matmul_precision(_orig_float32_matmul_precision)
+    cudnn_conv.fp32_precision = _orig_cudnn_fp32_precision
 
 
 examples_dir = Path(__file__).parent.parent / "examples"
@@ -90,6 +94,20 @@ def matmul_static_shapes(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         for tile_k in hl.tile(k):
             acc += torch.matmul(x[tile_m, tile_k], y[tile_k, tile_n])
         out[tile_m, tile_n] = acc
+    return out
+
+
+@helion.kernel(static_shapes=True)
+def matmul_fp8_bf16(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    m, k = x.size()
+    k2, n = y.size()
+    assert k == k2, f"size mismatch {k} != {k2}"
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+        out[tile_m, tile_n] = acc.to(torch.bfloat16)
     return out
 
 
@@ -273,6 +291,7 @@ class TestMatmul(RefEagerTestBase, TestCase):
 
     @skipIfNotTriton("block_ptr is triton-only")
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
+    @skipIfRefEager("checks generated Triton code")
     @skipIfTileIR("TileIR does not support block_ptr indexing")
     def test_matmul_block_ptr(self):
         args = (
@@ -288,6 +307,76 @@ class TestMatmul(RefEagerTestBase, TestCase):
         )
         torch.testing.assert_close(output, args[0] @ args[1], atol=1e-1, rtol=1e-2)
         self.assertIn("tl.make_block_ptr", code)
+        self.assertNotIn("boundary_check=None", code)
+        block_ptr_load_lines = [
+            line for line in code.splitlines() if "tl.load(tl.make_block_ptr" in line
+        ]
+        self.assertGreater(len(block_ptr_load_lines), 0)
+        for line in block_ptr_load_lines:
+            self.assertNotIn("boundary_check=", line)
+        block_ptr_store_lines = [
+            line for line in code.splitlines() if "tl.store(tl.make_block_ptr" in line
+        ]
+        self.assertGreater(len(block_ptr_store_lines), 0)
+        for line in block_ptr_store_lines:
+            self.assertNotIn("boundary_check=", line)
+
+    @skipIfNotTriton("block_ptr is triton-only")
+    @skipIfNotCUDA()
+    @skipIfCudaCapabilityLessThan((9, 0), reason="FP8 requires CUDA capability >= 9.0")
+    @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
+    @skipIfTileIR("TileIR does not support block_ptr indexing")
+    def test_fp8_matmul_block_ptr_omits_zero_padding(self):
+        args = (
+            torch.randn([128, 128], device=DEVICE, dtype=torch.float32).to(
+                torch.float8_e4m3fn
+            ),
+            torch.randn([128, 256], device=DEVICE, dtype=torch.float32)
+            .to(torch.float8_e4m3fn)
+            .T.contiguous()
+            .T,
+        )
+        code, output = code_and_output(
+            matmul_fp8_bf16,
+            args,
+            block_sizes=[128, 256, 128],
+            indexing="block_ptr",
+        )
+        expected = (args[0].to(torch.float32) @ args[1].to(torch.float32)).to(
+            torch.bfloat16
+        )
+        torch.testing.assert_close(output, expected, atol=1.0, rtol=1e-1)
+        self.assertIn("tl.make_block_ptr", code)
+        self.assertNotIn("padding_option='zero'", code)
+
+    @skipIfNotTriton("block_ptr is triton-only")
+    @skipIfNotCUDA()
+    @skipIfCudaCapabilityLessThan((9, 0), reason="FP8 requires CUDA capability >= 9.0")
+    @patch.object(_compat, "_supports_tensor_descriptor", lambda: False)
+    @skipIfTileIR("TileIR does not support block_ptr indexing")
+    def test_fp8_matmul_block_ptr_uses_pointer_for_padded_edges(self):
+        args = (
+            torch.randn([130, 128], device=DEVICE, dtype=torch.float32).to(
+                torch.float8_e4m3fn
+            ),
+            torch.randn([128, 256], device=DEVICE, dtype=torch.float32)
+            .to(torch.float8_e4m3fn)
+            .T.contiguous()
+            .T,
+        )
+        code, output = code_and_output(
+            matmul_fp8_bf16,
+            args,
+            block_sizes=[128, 256, 128],
+            indexing="block_ptr",
+        )
+        expected = (args[0].to(torch.float32) @ args[1].to(torch.float32)).to(
+            torch.bfloat16
+        )
+        torch.testing.assert_close(output, expected, atol=1.0, rtol=1e-1)
+        self.assertIn("tl.make_block_ptr", code)
+        self.assertIn("other=0.0", code)
+        self.assertNotIn("padding_option='zero'", code)
 
     @skipIfNotTriton("tensor_descriptor is triton-only")
     @skipUnlessTensorDescriptor("TensorDescriptor not supported")


### PR DESCRIPTION
Stacked PRs:
 * #2960
 * #2957
 * #2956
 * #2955
 * #2954
 * #2953
 * #2952
 * #2951
 * #2950
 * #2949
 * #2948
 * #2947
 * #2946
 * #2945
 * #2944
 * #2943
 * #2942
 * #2941
 * __->__#2959


--- --- ---

### Stabilize baseline CI and Triton edge cases


Fold the Pyrefly constexpr signal suppressions, CI/benchmark worker stability, FP8 block-pointer padding, and Triton zero-size physical extents into the stack baseline. These are prerequisite CI cleanups and do not enable a Pallas example directly.

stack-info: folded commits 86aab625 960c528e 35501d29 03364814