### PR TITLE
Polish Pallas stack imports and comments

### DIFF
--- a/helion/_compiler/type_info.py
+++ b/helion/_compiler/type_info.py
@@ -40,6 +40,8 @@ from .variable_origin import GridOrigin
 from .variable_origin import Origin
 from .variable_origin import TensorSizeOrigin
 from .variable_origin import TensorStrideOrigin
+from .variable_origin import TileBeginOrigin
+from .variable_origin import TileEndOrigin
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -1063,9 +1065,6 @@ def _detect_outer_block_bound(
     that tile's block_id.  Used to cap inner-tile block sizes to the enclosing
     outer tile's extent (e.g. ``hl.tile(outer.begin, outer.end)``).
     """
-    from .variable_origin import TileBeginOrigin
-    from .variable_origin import TileEndOrigin
-
     # Direct match: numel is another block's var.
     direct = env.get_block_id(numel)
     if direct is not None:
@@ -1119,8 +1118,6 @@ def _detect_owner_relative_outer_block_bound(
     end: object,
 ) -> int | None:
     """Return the owner block when bounds are exactly ``owner.begin/end``."""
-    from .variable_origin import TileBeginOrigin
-    from .variable_origin import TileEndOrigin
 
     def exact_origin(value: object) -> Origin | None:
         if not isinstance(value, torch.SymInt):

--- a/helion/runtime/pallas/launcher.py
+++ b/helion/runtime/pallas/launcher.py
@@ -1195,6 +1195,7 @@ def _pallas_prepare_args(
     - arg_to_tensor_pos: mapping from original position to tensor-only position
     - inplace_positions: positions that are both input and output
     - out_shapes: JAX placeholders for output shapes
+    - pallas_aliases: mapping from tensor input positions to output tuple indices
     """
     # Default to the torch-free jax placeholder; the torch launcher injects its
     # torch_tpu placeholder. ``interpret`` is retained for signature stability.


### PR DESCRIPTION
Stacked PRs:
 * __->__#2962
 * #2957
 * #2956
 * #2955
 * #2954
 * #2953
 * #2952
 * #2951
 * #2949
 * #2948
 * #2947
 * #2946
 * #2945
 * #2944
 * #2943
 * #2942


--- --- ---

### Polish Pallas stack imports and comments


Example fixed: none directly; this is review polish for the Pallas stack.

Compiler/runtime side: move non-optional imports to module scope where appropriate, remove stale or overly specific comments, and keep the remaining comments focused on invariants reviewers need for the Pallas lowering paths.

Why needed: after the stack was split into reviewable PRs, this keeps the code easier to review without changing backend behavior.
