### PR TITLE
[CI] Fix reduction_index_zero_expr for triton nightly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -360,6 +360,12 @@ jobs:
           TIMEOUT=60
           if [[ "${{ matrix.alias }}" == "pallas-interpret" ]]; then
             TIMEOUT=300
+          elif [[ "${{ matrix.alias }}" == *a10g* ]]; then
+            # A10G (sm86) ptxas cold-compiles some backward kernels slowly
+            # (~75s for the softmax autodiff backward), so the default 60s
+            # per-test timeout false-positives on a cold Triton cache and the
+            # worker gets killed mid-compile. Give it headroom.
+            TIMEOUT=180
           fi
           pytest $PARALLEL -rf --timeout=$TIMEOUT --reruns=2 --timeout-method=thread $EXTRA_FLAGS $TEST_PATH | tee >(eval $SKIP_CHECK)
 

--- a/helion/_compat.py
+++ b/helion/_compat.py
@@ -565,6 +565,30 @@ def _supports_maxnreg() -> bool:
     )
 
 
+def fp8_block_ptr_padding_broken() -> bool:
+    # call private func we can patch in testing
+    return _fp8_block_ptr_padding_broken()
+
+
+@functools.cache
+def _fp8_block_ptr_padding_broken() -> bool:
+    """Whether a block-pointer ``tl.load`` with ``padding_option='zero'`` fails to
+    compile for FP8 tensors.
+
+    Regression from triton-lang/triton#9668 ("Rewrite block pointer to be
+    python-only"), tracked in triton-lang/triton#10751: the python lowering emits
+    an ``int`` zero for ``other``, which Triton cannot cast to FP8. Present in the
+    triton 3.8 series; gated by version so the workaround drops automatically once
+    a fix ships in a later release. See ``BlockPtrIndexingStrategy.codegen_load``.
+    """
+    if not triton_is_available():
+        return False
+    import triton
+
+    triton_version = version.parse(triton.__version__)
+    return version.parse("3.8.0") <= triton_version < version.parse("3.9.0")
+
+
 @functools.cache
 def _regs_per_block() -> int:
     """Max 32-bit registers per block on the current CUDA device."""

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1228,7 +1228,12 @@ class TritonBackend(Backend):
         return f"tl.arange(0, {block_size_var}).to({dtype})"
 
     def reduction_index_zero_expr(self, dtype: str) -> str:
-        return f"tl.zeros([0], {dtype})"
+        # Triton requires block shapes to be powers of 2. As of triton 3.8.0
+        # (triton-lang/triton#10687, 2026-06), is_power_of_two(0) returns False,
+        # so validate_block_shape rejects a length-0 tensor. Emit a length-1
+        # index instead -- the accompanying ``index < 0`` mask is all-False, so
+        # nothing is ever loaded/stored for the empty reduction dimension.
+        return f"tl.zeros([1], {dtype})"
 
     def next_power_of_2_host_expr(self, expr: str) -> str:
         return f"triton.next_power_of_2({expr})"

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -13,6 +13,7 @@ from torch._inductor.utils import triton_type
 from torch._prims_common import compute_required_storage_length
 
 from .. import exc
+from .._compat import fp8_block_ptr_padding_broken
 from .._compat import get_tensor_descriptor_fn_name
 from .._utils import next_power_of_2
 from .ast_extension import expr_from_string
@@ -754,7 +755,20 @@ class BlockPtrIndexingStrategy(IndexingStrategy):
         eviction_policy: ast.AST | None,
         cache_modifier: ast.AST | None,
     ) -> ast.AST:
-        if not BlockedSubscriptIndexing.is_supported(state, fake_tensor, subscript):
+        # Triton's python-only block-pointer rewrite (triton-lang/triton#9668,
+        # in the triton 3.8 series) lowers a block-pointer load with
+        # padding_option='zero' to a masked load whose `other` is the integer
+        # literal 0, which Triton cannot cast to FP8 (triton-lang/triton#10751).
+        # Fall back to pointer indexing, which uses other=0.0 for FP8. Gated on the
+        # affected Triton version so the fallback drops once upstream is fixed.
+        fp8_block_ptr_unsupported = (
+            fake_tensor.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+            and fp8_block_ptr_padding_broken()
+        )
+        if (
+            not BlockedSubscriptIndexing.is_supported(state, fake_tensor, subscript)
+            or fp8_block_ptr_unsupported
+        ):
             return PointerIndexingStrategy().codegen_load(
                 state,
                 fake_tensor,

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import collections
 import dataclasses
+import logging
 from typing import TYPE_CHECKING
 from typing import ClassVar
 from typing import NamedTuple
@@ -37,6 +38,9 @@ if TYPE_CHECKING:
 
     SymIntLike = torch.SymInt | int
     ShapeLike = Sequence[SymIntLike]
+
+
+log = logging.getLogger(__name__)
 
 
 class TileWithOffsetInfo(NamedTuple):
@@ -769,6 +773,13 @@ class BlockPtrIndexingStrategy(IndexingStrategy):
             not BlockedSubscriptIndexing.is_supported(state, fake_tensor, subscript)
             or fp8_block_ptr_unsupported
         ):
+            log.debug(
+                "block_ptr indexing requested but unsupported for this load (%s); "
+                "falling back to pointer indexing",
+                "FP8 block-pointer padding broken on this Triton version"
+                if fp8_block_ptr_unsupported
+                else "unsupported access pattern",
+            )
             return PointerIndexingStrategy().codegen_load(
                 state,
                 fake_tensor,


### PR DESCRIPTION
Nightly triton example failing job: https://github.com/pytorch/helion/actions/runs/28391201482/job/84118569738?pr=2865


Problem 1:

CI installs triton==3.8.0+git43422b04, which includes triton-lang/triton#10687
  (https://github.com/triton-lang/triton/pull/10687) (landed 2026-06-20). That PR fixed is_power_of_two so it now correctly returns False for 0:

  -    return (x & (x - 1)) == 0          # 0 & -1 == 0 → wrongly True
  +    return x > 0 and (x & (x - 1)) == 0

  Triton's validate_block_shape now rejects any block dimension that isn't a power of 2, including 0. For zero-size tensors, Helion's Triton backend emitted tl.zeros([0], tl.int32) as the index for an empty reduction/slice
  dimension, which now raises ValueError: Shape element 0 must be a power of 2. This broke test_zero_size.py::test_local_zero_width_allocation and test_reduce_zero_inner_dim.
  
  
Problem  2. FP8 block-pointer load with padding_option='zero' fails to compile

  Symptom: test_fp8_scaled_all_gather_matmul (and any FP8 matmul using indexing="block_ptr") fails with:
  cannot cast int32[constexpr[128], constexpr[128]] to <['128', '128'], fp8e4nv>

  Root cause: triton-lang/triton#9668 (https://github.com/triton-lang/triton/pull/9668) ("Rewrite block pointer 
  to be python-only") changed block-pointer loads to lower padding_option='zero' to a masked load whose other is
  the integer literal 0. Triton then casts other to the pointee dtype, and there is no int → fp8 cast, so
  compilation asserts. Tracked upstream in triton-lang/triton#10751
  (https://github.com/triton-lang/triton/issues/10751). (FP8 block-pointer stores are unaffected — they take no
  padding_option.)

  Fix: In BlockPtrIndexingStrategy.codegen_load, fall back to pointer indexing for FP8 loads, which already use
  other=0.0 (a valid float → fp8 cast). The fallback is gated on the affected Triton version
  (_compat.fp8_block_ptr_padding_broken(), 3.8.0 ≤ v < 3.9.0) so it auto-disables once Triton ships a fix. A
  log.debug records every block-ptr→pointer fallback (and its reason) for diagnosability via HELION_LOGS.

  Files: helion/_compiler/indexing_strategy.py, helion/_compat.py

  Problem  3. A10G per-test timeout too short for slow sm86 cold compiles

  Symptom: test_autodiff.py::test_example_softmax flakily fails as worker 'gw3' crashed / node down: Not properly
  terminated — which looks like a crash/OOM but isn't.

  Root cause: On the A10G (sm86) runner, ptxas cold-compiles the softmax autodiff backward kernel slowly — ~73 s
  on a cold Triton cache. The default 60 s per-test timeout fires, and pytest-timeout (--timeout-method=thread)
  os._exit()s the xdist worker mid-compile, surfacing as "node down." It's pure compile time, not memory: peak
  GPU use for the test is ~1 MB, and it reproduces under -n1 (no concurrency / no host-RAM pressure). Confirmed
  by 60s → FAIL (73s), 180s → PASS (73.66s).

  Fix: Raise the per-test timeout to 180 s for A10G jobs only (sm86 cold compiles need the headroom); all other
  jobs keep 60 s.

  Files: .github/workflows/test.yml
  
  