### PR TITLE
Fix pyrefly bad-argument-type errors from triton nightly constexpr args

### DIFF
--- a/examples/distributed/all_gather_matmul.py
+++ b/examples/distributed/all_gather_matmul.py
@@ -31,7 +31,7 @@ from helion.runtime.triton_helpers import triton_wait_signal
 
 @triton.jit
 def _wait_progress_at_idx(progress: tl.tensor, idx: int) -> None:
-    triton_wait_signal(progress + idx, 1, 0, "acquire", "gpu", "ld", False)
+    triton_wait_signal(progress + idx, 1, 0, "acquire", "gpu", "ld", False)  # pyrefly: ignore [bad-argument-type]
 
 
 # %%

--- a/examples/distributed/fp8_scaled_all_gather_matmul.py
+++ b/examples/distributed/fp8_scaled_all_gather_matmul.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
 @triton.jit
 def _wait_progress_at_idx(progress: tl.tensor, idx: int) -> None:
-    triton_wait_signal(progress + idx, 1, 0, "acquire", "gpu", "ld", False)
+    triton_wait_signal(progress + idx, 1, 0, "acquire", "gpu", "ld", False)  # pyrefly: ignore [bad-argument-type]
 
 
 # Use hardcoded config in CI to avoid autotuning overhead.

--- a/helion/runtime/dist_utils.py
+++ b/helion/runtime/dist_utils.py
@@ -154,8 +154,8 @@ def _symm_mem_sync_cuda(
         tl.debug_barrier()
 
     if flat_tid < world_size:
-        _send_signal(send_addrs, "release" if hasPreviousMemAccess else "relaxed")
-        _wait_signal(wait_addrs, "acquire" if hasSubsequentMemAccess else "relaxed")
+        _send_signal(send_addrs, "release" if hasPreviousMemAccess else "relaxed")  # pyrefly: ignore [bad-argument-type]
+        _wait_signal(wait_addrs, "acquire" if hasSubsequentMemAccess else "relaxed")  # pyrefly: ignore [bad-argument-type]
 
     if hasSubsequentMemAccess:
         tl.debug_barrier()


### PR DESCRIPTION
Example lint failure: https://github.com/pytorch/helion/actions/runs/28400084381/job/84148799551?pr=2963

The latest triton nightly types JITFunction.__call__ params (expect, update, sem, scope, op, skip_sync) as `constexpr`, so pyrefly now rejects passing plain literals to triton_wait_signal / _send_signal / _wait_signal. Suppress with `# pyrefly: ignore [bad-argument-type]`, matching the pattern from #2801.
