### PR TITLE
[TEMP][DO NOT MERGE] debug flaky test_example_softmax worker crash

### DIFF
--- a/helion/_compat.py
+++ b/helion/_compat.py
@@ -565,6 +565,30 @@ def _supports_maxnreg() -> bool:
     )
 
 
+def fp8_block_ptr_padding_broken() -> bool:
+    # call private func we can patch in testing
+    return _fp8_block_ptr_padding_broken()
+
+
+@functools.cache
+def _fp8_block_ptr_padding_broken() -> bool:
+    """Whether a block-pointer ``tl.load`` with ``padding_option='zero'`` fails to
+    compile for FP8 tensors.
+
+    Regression from triton-lang/triton#9668 ("Rewrite block pointer to be
+    python-only"), tracked in triton-lang/triton#10751: the python lowering emits
+    an ``int`` zero for ``other``, which Triton cannot cast to FP8. Present in the
+    triton 3.8 series; gated by version so the workaround drops automatically once
+    a fix ships in a later release. See ``BlockPtrIndexingStrategy.codegen_load``.
+    """
+    if not triton_is_available():
+        return False
+    import triton
+
+    triton_version = version.parse(triton.__version__)
+    return version.parse("3.8.0") <= triton_version < version.parse("3.9.0")
+
+
 @functools.cache
 def _regs_per_block() -> int:
     """Max 32-bit registers per block on the current CUDA device."""

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1228,7 +1228,12 @@ class TritonBackend(Backend):
         return f"tl.arange(0, {block_size_var}).to({dtype})"
 
     def reduction_index_zero_expr(self, dtype: str) -> str:
-        return f"tl.zeros([0], {dtype})"
+        # Triton requires block shapes to be powers of 2. As of triton 3.8.0
+        # (triton-lang/triton#10687, 2026-06), is_power_of_two(0) returns False,
+        # so validate_block_shape rejects a length-0 tensor. Emit a length-1
+        # index instead -- the accompanying ``index < 0`` mask is all-False, so
+        # nothing is ever loaded/stored for the empty reduction dimension.
+        return f"tl.zeros([1], {dtype})"
 
     def next_power_of_2_host_expr(self, expr: str) -> str:
         return f"triton.next_power_of_2({expr})"

--- a/helion/_compiler/indexing_strategy.py
+++ b/helion/_compiler/indexing_strategy.py
@@ -13,6 +13,7 @@ from torch._inductor.utils import triton_type
 from torch._prims_common import compute_required_storage_length
 
 from .. import exc
+from .._compat import fp8_block_ptr_padding_broken
 from .._compat import get_tensor_descriptor_fn_name
 from .._utils import next_power_of_2
 from .ast_extension import expr_from_string
@@ -754,7 +755,20 @@ class BlockPtrIndexingStrategy(IndexingStrategy):
         eviction_policy: ast.AST | None,
         cache_modifier: ast.AST | None,
     ) -> ast.AST:
-        if not BlockedSubscriptIndexing.is_supported(state, fake_tensor, subscript):
+        # Triton's python-only block-pointer rewrite (triton-lang/triton#9668,
+        # in the triton 3.8 series) lowers a block-pointer load with
+        # padding_option='zero' to a masked load whose `other` is the integer
+        # literal 0, which Triton cannot cast to FP8 (triton-lang/triton#10751).
+        # Fall back to pointer indexing, which uses other=0.0 for FP8. Gated on the
+        # affected Triton version so the fallback drops once upstream is fixed.
+        fp8_block_ptr_unsupported = (
+            fake_tensor.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+            and fp8_block_ptr_padding_broken()
+        )
+        if (
+            not BlockedSubscriptIndexing.is_supported(state, fake_tensor, subscript)
+            or fp8_block_ptr_unsupported
+        ):
             return PointerIndexingStrategy().codegen_load(
                 state,
                 fake_tensor,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,27 @@
 from __future__ import annotations
 
+import glob
 import os
+from pathlib import Path
 import warnings
+
+
+def pytest_sessionfinish(session: object, exitstatus: object) -> None:
+    # TEMPORARY DEBUG (DO NOT MERGE): surface the per-worker softmax crash logs
+    # written by test/test_autodiff.py so they appear in CI output even when an
+    # xdist worker dies without returning its captured output. Remove with the
+    # debug block in test_autodiff.py once the flaky crash is root-caused.
+    debug_dir = os.environ.get("HELION_SOFTMAX_DEBUG_DIR", "/tmp")
+    for pattern in ("helion_softmax_debug_*.log", "helion_softmax_fault_*.log"):
+        for path in sorted(glob.glob(os.path.join(debug_dir, pattern))):
+            try:
+                data = Path(path).read_text().strip()
+            except OSError:
+                continue
+            if data:
+                print(
+                    f"\n===== {path} =====\n{data}\n===== end {path} =====", flush=True
+                )
 
 
 def pytest_configure() -> None:

--- a/test/test_autodiff.py
+++ b/test/test_autodiff.py
@@ -25,6 +25,65 @@ for _utf8_locale in ("C.UTF-8", "en_US.UTF-8", "C.utf8", "en_US.utf8"):
         continue
 
 
+# ===========================================================================
+# TEMPORARY DEBUG (DO NOT MERGE): diagnose the flaky xdist worker crash in
+# test_example_softmax on Python 3.14 / A10G. The worker dies with no traceback
+# ("node down: Not properly terminated"); we suspect an unsafe fork() from a
+# multi-threaded, CUDA-initialized process. This instrumentation:
+#   * dumps the native + all-thread Python stack on a fatal signal (SIGSEGV/...)
+#   * logs every os.fork() with thread count, CUDA-init state, and the call stack
+# Output is written to per-pid files under HELION_SOFTMAX_DEBUG_DIR (default /tmp)
+# AND to fd 2 (bypassing pytest capture). conftest.pytest_sessionfinish prints
+# the files so they survive a worker crash. Tracking: <fill in issue>.
+# Remove this whole block (and the conftest hook) once root-caused.
+# ===========================================================================
+import contextlib as _contextlib  # noqa: E402
+import faulthandler as _faulthandler  # noqa: E402
+import os as _os  # noqa: E402
+import threading as _threading  # noqa: E402
+import traceback as _traceback  # noqa: E402
+
+_SOFTMAX_DEBUG_DIR = _os.environ.get("HELION_SOFTMAX_DEBUG_DIR", "/tmp")
+
+
+def _softmax_debug(msg: str) -> None:
+    line = f"[SOFTMAX-DEBUG pid={_os.getpid()}] {msg}\n"
+    path = _os.path.join(_SOFTMAX_DEBUG_DIR, f"helion_softmax_debug_{_os.getpid()}.log")
+    with _contextlib.suppress(OSError), open(path, "a") as f:
+        f.write(line)
+        f.flush()
+    with _contextlib.suppress(OSError):
+        _os.write(2, line.encode())  # bypass pytest output capture
+
+
+try:
+    _softmax_fault_fp = open(
+        _os.path.join(_SOFTMAX_DEBUG_DIR, f"helion_softmax_fault_{_os.getpid()}.log"),
+        "w",
+    )
+    _faulthandler.enable(file=_softmax_fault_fp, all_threads=True)
+except OSError:
+    _faulthandler.enable(all_threads=True)
+
+
+def _softmax_debug_at_fork() -> None:
+    try:
+        import torch
+
+        cuda_state = f"initialized={torch.cuda.is_initialized()}"
+    except Exception as e:
+        cuda_state = f"unknown({e!r})"
+    threads = [t.name for t in _threading.enumerate()]
+    _softmax_debug(
+        f"os.fork() BEFORE: nthreads={len(threads)} cuda_{cuda_state} threads={threads}"
+    )
+    _softmax_debug("fork call stack:\n" + "".join(_traceback.format_stack()))
+
+
+_os.register_at_fork(before=_softmax_debug_at_fork)
+# ===================== END TEMPORARY DEBUG =====================
+
+
 @skipIfMTIA("autodiff not tested on MTIA")
 @skipIfNotTriton("autodiff not tested on non Triton backends")
 @skipIfXPU("autodiff scan-path backward aborts in torch scan-HOP autograd on XPU")
@@ -1211,13 +1270,23 @@ class TestAutodiff(RefEagerTestDisabled, TestCase):
     def test_example_softmax(self):
         from examples.softmax import softmax
 
-        # examples/softmax.py uses check(4096, 2560)
-        self._check_backward(
-            softmax,
-            lambda x: torch.nn.functional.softmax(x, dim=-1),
-            1,
-            shape=(256, 160),
+        # TEMPORARY DEBUG (DO NOT MERGE): see block at top of file.
+        _softmax_debug(
+            f"ENTER test_example_softmax: nthreads={_threading.active_count()} "
+            f"cuda_initialized={torch.cuda.is_initialized()} "
+            f"TORCHINDUCTOR_COMPILE_THREADS={_os.environ.get('TORCHINDUCTOR_COMPILE_THREADS')!r} "
+            f"start_method={__import__('multiprocessing').get_start_method(allow_none=True)!r}"
         )
+        try:
+            # examples/softmax.py uses check(4096, 2560)
+            self._check_backward(
+                softmax,
+                lambda x: torch.nn.functional.softmax(x, dim=-1),
+                1,
+                shape=(256, 160),
+            )
+        finally:
+            _softmax_debug("EXIT test_example_softmax (reached finally)")
 
     def test_example_batch_softmax(self):
         from examples.batch_softmax import batch_softmax


### PR DESCRIPTION
CI's py3.14 a10g job intermittently dies on test_example_softmax with "node down: Not properly terminated" (a worker segfault, no traceback). It passes in isolation and recovers on rerun, so it's a rare timing-dependent crash; suspected unsafe fork() from a multi-threaded, CUDA-initialized process under Python 3.14 + the new torch/triton nightly.

This temporary instrumentation (remove once root-caused):
- enables faulthandler (all threads -> per-pid file) to capture the native stack on a fatal signal even when the worker dies
- logs every os.fork() with thread count, CUDA-init state, and call stack via os.register_at_fork
- logs ENTER/EXIT around the test
- conftest.pytest_sessionfinish prints the per-pid debug/fault files so they survive an xdist worker crash and show up in CI logs

Writes under HELION_SOFTMAX_DEBUG_DIR (default /tmp).