### PR TITLE
[benchmarks] Skip custom autotune baseline on TPU

### DIFF
--- a/benchmarks/run_tpu.py
+++ b/benchmarks/run_tpu.py
@@ -1382,6 +1382,11 @@ def run_kernel_inner(name: str) -> KernelResult:
                     attr = getattr(mod, attr_name)
                     if isinstance(attr, _HelionKernel):
                         attr.reset()
+                        # A custom autotune_baseline_fn (e.g. attention's, added
+                        # in #2833) can fail on TPU/XLA and hard-fail autotune.
+                        # Clear it so TPU uses the default-config baseline;
+                        # final accuracy is still checked below.
+                        attr.settings.autotune_baseline_fn = None
                         if os.environ.get("HELION_AUTOTUNE_EFFORT", "") != "none":
                             if not attr.configs:
                                 attr.settings.force_autotune = True


### PR DESCRIPTION

#2833 added `autotune_baseline_fn=_attention_baseline` to
examples/attention.py. On the TPU/XLA backend that reference (SDPA plus
a log-sum-exp loop) raises while computing the baseline, so autotuning
hard-fails with "Custom baseline function failed while computing
baseline" and flash_attention reports FAIL for every TPU shape.

The hard-fail is intentional on GPU (see
test_autotune_baseline_fn_raises_on_failure), so instead of changing
that contract, clear the custom baseline on TPU in the benchmark
harness. Autotuning then falls back to the default-config baseline --
exactly the path flash_attention used on TPU from #2354 until #2833.
Final accuracy is still validated against the KERNEL_MAPPINGS
baseline_fn (torch SDPA).
