### PR TITLE
Cancel CI jobs on PR close

### DIFF
--- a/.github/workflows/cancel-on-close.yml
+++ b/.github/workflows/cancel-on-close.yml
@@ -1,0 +1,32 @@
+name: Cancel CI on PR close
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  actions: write
+
+jobs:
+  cancel:
+    # Only cancel for PRs that were closed without merging. Merged PRs delete
+    # their branch and let in-flight runs finish on their own.
+    if: github.event.pull_request.merged == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel in-progress runs for this PR's branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          for wf in test.yml lint.yml docs-test.yml; do
+            for status in in_progress queued; do
+              gh run list --repo "$REPO" --workflow "$wf" --branch "$BRANCH" \
+                --status "$status" --json databaseId -q '.[].databaseId' |
+              while read -r id; do
+                echo "Cancelling run $id ($wf, $status)"
+                gh run cancel "$id" --repo "$REPO" || true
+              done
+            done
+          done


### PR DESCRIPTION
as title, cancel CI jobs when we close a PR. gated with ` github.event.pull_request.merged == false` so CI on merged PR still continues.


why do we need it:

observe that closed stack: `pallas-examples-stack/{14,15,16,21,22,29,30,32,40,42,44,45,47,50,51,52,53,54,58,59,60,61,62,63,64,65,68,69}` has a long job queue that prevent other PR's CI jobs from running.