### PR TITLE
[CI] Fix rocm CI 

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -111,7 +111,7 @@
       "ref-eager": false,
       "image": "rocm/dev-ubuntu-24.04:7.0-complete",
       "runtime-version": "rocm7.0",
-      "container-options": "--device=/dev/kfd --device=/dev/dri",
+      "container-options": "--device=/dev/kfd --device=/dev/dri -e HIP_VISIBLE_DEVICES=0 -e ROCR_VISIBLE_DEVICES=0",
       "pytorch-version": "pytorch-nightly",
       "alias": "mi350x",
       "backend": "triton"

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1235,6 +1235,14 @@ class TritonBackend(Backend):
         # nothing is ever loaded/stored for the empty reduction dimension.
         return f"tl.zeros([1], {dtype})"
 
+    def static_rdim_size(self, numel: int) -> int:
+        # Pair with reduction_index_zero_expr: an empty (length-0) axis uses a
+        # length-1 index, so its block extent must also be 1, not 0. Triton
+        # rejects length-0 block shapes (is_power_of_two(0) is False), and a
+        # 0-extent value would also mismatch the length-1 index shape in the
+        # generated tl.store/tl.load. The all-False mask keeps it a no-op.
+        return max(super().static_rdim_size(numel), 1)
+
     def next_power_of_2_host_expr(self, expr: str) -> str:
         return f"triton.next_power_of_2({expr})"
 


### PR DESCRIPTION
Failing run:  https://github.com/pytorch/helion/actions/runs/28206097006/job/8360191494

The runner linux.rocm.gpu.ecosystem.gfx950.1 is a single-GPU slot (.1), but its container options
  --device=/dev/kfd --device=/dev/dri expose all physical GPUs of the host. The host went from 1→8
  visible GPUs (an infra change), which flipped torch.cuda.device_count() from 1 to 8. That made
  skip_if_lt_x_gpu(4) stop skipping the 6 multi-process distributed tests, which then spawn a 4-rank
  world and fail because the container has only the default 64 MB /dev/shm (no --ipc=host) — too small
  for RCCL/NCCL shared-memory segments. 