### PR TITLE
[skills] Add bench-regression skill for dashboard investigations

### DIFF
--- a/.claude/skills/bench-regression/SKILL.md
+++ b/.claude/skills/bench-regression/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: bench-regression
+description: Investigate a Helion benchmark dashboard regression (helionlang.com/dashboard) — find the cause and classify it. Auto-activate when the user reports a perf drop/spike on a dashboard platform (e.g. b200 cute) around a given date.
+---
+
+Goal: explain a dashboard move and sort it into one of four causes — **real regression**, **benchmark method change**, **hardware issue**, or **noise**. Don't blame a commit until the data points at one.
+
+**1. Pull the data, isolate the platform.** Numbers are per-nightly, not live — fetch the JSON, don't WebFetch the page (too big to page through):
+
+```bash
+curl -s https://helionlang.com/dashboard/dashboard-data.json -o /tmp/dash.json
+```
+
+Each `summary[]` entry has `platform_short` (e.g. `b200_cute`) and a `history[]` of nightlies with `helion_speedup_geomean`, `triton_speedup_geomean`, `torch_compile_speedup_geomean`, `helion_latency_avg_ms`, `sha`. Filter to the platform+kernel and print the series around the date.
+
+For the **Pretuned** tab, use the sibling URL — same structure, different `summary[]` fields (`geomean`, `best_speedup`, `helion_wins`/`total`, `baselines`, `cudagraph`):
+
+```bash
+curl -s https://helionlang.com/dashboard/pretuned-dashboard-data.json -o /tmp/pretuned.json
+```
+
+**2. Classify** — read the whole series, not one point, and sort the move into one of four causes:
+- **Real regression** → Helion genuinely got slower. A code change made the kernel (or the config the autotuner picks) worse. Find the commit (step 3).
+- **Benchmark method change** → the kernel is unchanged; how it's *measured* changed. A change to the harness, timer, launcher, autotune settings, input shapes, or baseline flips the reported number without touching real performance. The pre- or post-change value is an artifact — decide which is the honest one.
+- **Hardware issue** → the environment changed, not Helion. Runner swap, GPU/driver change, thermal throttling — affects everything running on that machine, not just Helion.
+- **Noise** → nothing changed; it's measurement scatter. The move isn't a persistent step, just normal run-to-run variance.
+
+Useful cross-checks when deciding: is the move Helion-only or shared with `triton_*`/`torch_compile_*` (shared → environment/baseline, not Helion)? Does it persist or revert (revert → noise)? Do independent metrics agree — e.g. `helion_latency_avg_ms` and speedup come from *different timers* (speedup uses `--cudagraph`; latency uses `--latency-measure-mode triton_do_bench`, see `benchmark.yml`), so if one moves and the other doesn't, suspect a measurement change, not real perf. Don't reconstruct `baseline = speedup * latency` — they're different modes; the product is meaningless.
+
+**3. Find the commit** (real regression only). Window = between last-good and first-bad nightly `sha`:
+
+```bash
+git log --first-parent --pretty="%h %cI %s" <good_sha>..<bad_sha>
+```
+
+Match the suspect to the affected slice: a `b200_cute`-only drop comes from a `[cute]` commit, not Pallas/Triton/TPU. Check which kernels the platform runs (`kernels_cute` default in `.github/workflows/benchmark_dispatch.yml`) and whether they keep `--cudagraph` (`remove_flags` in `benchmarks/run.py`) before trusting the cudagraph-timed speedup. Confirm by reading the diff for a plausible mechanism.
+
+**Report:** the cause (one of the four), the first-bad sha + culprit commit if real, and the true speedup.


### PR DESCRIPTION
## Summary

Adds a Claude Code skill, **`bench-regression`**, that guides investigation of a movement on the benchmark dashboard and sorts it into one of four causes — **real regression**, **benchmark method change**, **hardware issue**, or **noise** — before ever blaming a commit.

The skill:
1. Pulls the per-nightly dashboard JSON (`dashboard-data.json` / `pretuned-dashboard-data.json`) and isolates the platform + kernel series.
2. Classifies by reading the *whole* series, not one point — e.g. variance collapse or a speedup step while `helion_latency_avg_ms` stays flat indicates a benchmark method change; all impls moving together indicates a hardware/runner shift; only `helion_*` stepping and persisting with rising latency indicates a real regression.
3. Only hunts for a culprit commit (via `git log --first-parent` over the last-good..first-bad `sha` window) when the data actually points at a real regression, matching the affected slice to the commit scope (e.g. a `b200_cute`-only drop → a `[cute]` commit).

## Example output

Running the skill on *"investigate the regression on B200 Cute after June 17"* produced:

> ### Verdict: **Benchmark method change** — not a regression.
>
> **What moved:** On `b200_cute`, the kernels that "moved" after June 17 are `vector_add`, `vector_exp`, and (more mildly) `rms_norm`. The tell is that their **variance collapses** at the June 18→19 boundary rather than stepping to a new level:
>
> | kernel | speedup std **before** | speedup std **after** | latency before | latency after |
> |---|---|---|---|---|
> | vector_add | **0.54** (0.69–2.49) | **0.034** (0.78–0.87) | bimodal 0.020↔0.040 | locked 0.040 |
> | vector_exp | 0.23 (0.66–1.39) | 0.035 (0.72–0.83) | 0.032–0.043 | locked 0.033 |
> | rms_norm | 0.19 (3.26–4.07) | 0.071 | 0.022↔0.044 | locked 0.040 |
>
> The pre-change readings were the **artifact**: wildly scattered speedups and a **bimodal latency toggling on a clean 2× ratio** (0.020 vs 0.040 ms). `triton_*` and `torch_compile_*` never budged (rules out a hardware/runner shift), and `layer_norm`/`sum` were always stable — so this is isolated to the noisy cute launch path.
>
> **Mechanism (confirmed in the diff):** The transition sits between nightly `468b0002` (Jun 18) and `98f5ee77` (Jun 19). The culprit is **`62e9166b` — `[cute] Sample CUDA stream per launch to fix empty-graph capture (#2817)`**. Before this fix, the cute launcher baked the CUDA stream into its cached launch args during eager warmup; under CUDA-graph capture (`--cudagraph`, the timer the speedup metric uses) the current stream is redirected to a capture stream, so the kernel launched on the stale eager stream, **the graph recorded no work, and replayed as a no-op**. The benchmark was timing an empty graph on a random subset of nightlies. The fix samples the stream fresh on every launch, so the graph now captures real work.
>
> **True speedups (post-fix, stable values):**
> - vector_add ≈ **0.84**, vector_exp ≈ **0.78**
> - rms_norm ≈ **4.03** (the true value is actually *higher* and now steady)
> - layer_norm (~1.25) and sum (~1.17) were correct all along.
>
> **Bottom line:** No action needed on Helion performance. The apparent "regression" is the dashboard finally showing the *correct* (sub-1.0) speedup once #2817 stopped the cudagraph timer from measuring empty-graph no-op replays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
