### PR TITLE
[CI] Add no-ci label to skip PR CI

### DIFF
--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -2,6 +2,9 @@ name: Test Documentation
 
 on:
   pull_request:
+    # `labeled`/`unlabeled` so adding the `no-ci` label skips CI and removing
+    # it re-runs CI.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches:
       - main
@@ -11,6 +14,8 @@ permissions:
 
 jobs:
   docs-test:
+    # Skip CI when the PR carries the `no-ci` label.
+    if: ${{ !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'no-ci')) }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on:
   pull_request:
+    # `labeled`/`unlabeled` so adding the `no-ci` label skips CI and removing
+    # it re-runs CI.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches:
       - main
@@ -12,6 +15,8 @@ permissions:
 
 jobs:
   lint:
+    # Skip CI when the PR carries the `no-ci` label.
+    if: ${{ !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'no-ci')) }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Tests
 
 on:
   pull_request:
+    # `labeled`/`unlabeled` so adding the `no-ci` label cancels in-flight runs
+    # (via concurrency below) and removing it re-runs CI.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches:
       - main
@@ -16,6 +19,9 @@ permissions:
 
 jobs:
   load-matrix:
+    # Skip all CI when the PR carries the `no-ci` label. The `test` job depends
+    # on this one via `needs`, so it is skipped too.
+    if: ${{ !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'no-ci')) }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -370,6 +376,7 @@ jobs:
           pytest $PARALLEL -rf --timeout=$TIMEOUT --reruns=2 --timeout-method=thread $EXTRA_FLAGS $TEST_PATH | tee >(eval $SKIP_CHECK)
 
   test-notebooks:
+    if: ${{ !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'no-ci')) }}
     name: test-notebooks-cu130-py3.12-pytorch-2.9-a10g
 
     container:


### PR DESCRIPTION
Gate the PR-triggered workflows (tests, lint, docs-test) on the absence of a `no-ci` label so that adding the label to a PR skips CI and removing it re-runs CI. Motivation: avoid wasting CI resources on large stacks of WIP PRs.

Also add `labeled`/`unlabeled` to the pull_request trigger types so that toggling the label re-evaluates the workflows.