### PR TITLE
[pretuned_kernels] add torch.compile baseline to all kernels

### DIFF
--- a/pretuned_kernels/README.md
+++ b/pretuned_kernels/README.md
@@ -58,6 +58,13 @@ At runtime Helion picks the file matching the current GPU.
 | `silu_and_mul_per_block_quant` | vLLM `(num_tokens, intermediate, group)` shapes | torch-native silu-and-mul + per-block fp8 quant |
 | `fused_qk_norm_rope` | vLLM `(num_tokens, q_heads, kv_heads)` shapes | torch-native fused QK-RMSNorm + RoPE |
 
+Every kernel additionally benchmarks against `torch.compile` of the listed
+PyTorch baseline (a speedup-comparison baseline only -- correctness is checked
+against the eager reference). The headline speedup is Helion vs the *fastest*
+available baseline, and the dashboard's per-kernel dropdown breaks down Helion's
+speedup over each baseline (`torch`, `torch_compile`, and the vLLM op when
+installed in the nightly).
+
 The kernels ported from vLLM (`vllm/kernels/helion/ops`) benchmark each fused
 Helion kernel under CUDA graphs against a torch-native (unfused, eager)
 reference; `silu_mul_fp8` ships an `sm90` heuristic only, the rest ship both

--- a/pretuned_kernels/cross_entropy/cross_entropy.py
+++ b/pretuned_kernels/cross_entropy/cross_entropy.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-import math
-
 import torch
 import torch.nn.functional as F
-import triton.testing as tt
 
 import helion
 import helion.experimental
@@ -43,15 +40,33 @@ def cross_entropy(
     return losses.mean()
 
 
+def _cross_entropy_torch(logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+    return F.cross_entropy(logits, labels)
+
+
+def _baselines() -> list[tuple[str, object]]:
+    """Baselines main() benchmarks against.
+
+    ``torch_compile`` is ``torch.compile`` of the torch reference -- a
+    speedup-comparison baseline only (not checked for accuracy).
+    """
+    return [
+        ("torch", _cross_entropy_torch),
+        ("torch_compile", torch.compile(_cross_entropy_torch)),
+    ]
+
+
 def use_cudagraph() -> bool:
     """Whether main() benchmarks under CUDA graphs (read by pretuned_kernels/run.py)."""
     return False
 
 
 def main(verbose: bool = True) -> dict:
-    def _p(*args: object) -> None:
-        if verbose:
-            print(*args)
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from _bench import run_sweep
 
     tritonbench_shapes = [
         (2048, 32000),
@@ -79,60 +94,28 @@ def main(verbose: bool = True) -> dict:
         (2048, 256000),
     ]
     shapes = list(dict.fromkeys(tritonbench_shapes + realistic_shapes))
+    baselines = _baselines()
 
-    _p(f"GPU: {torch.cuda.get_device_name()}")
-    _p(
-        f"{'tokens':>8s}  {'vocab':>8s}  {'helion (ms)':>12s}  "
-        f"{'torch (ms)':>12s}  {'speedup':>8s}"
-    )
-    _p("-" * 67)
-
-    speedups: list[float] = []
-    helion_wins = 0
-    best_speedup = 0.0
-    best_shape = (0, 0)
-    for tokens, vocab in shapes:
+    def make_calls(shape: tuple[int, int]) -> tuple:
+        tokens, vocab = shape
         logits = torch.randn([tokens, vocab], device="cuda", dtype=torch.bfloat16)
         labels = torch.randint(0, vocab, [tokens], device="cuda", dtype=torch.int64)
-        cross_entropy(logits, labels)  # warmup
-        ms_helion = tt.do_bench(
-            lambda logits=logits, labels=labels: cross_entropy(logits, labels),
-            warmup=25,
-            rep=100,
-            return_mode="median",
-        )
-        ms_torch = tt.do_bench(
-            lambda logits=logits, labels=labels: F.cross_entropy(logits, labels),
-            warmup=25,
-            rep=100,
-            return_mode="median",
-        )
-        speedup = ms_torch / ms_helion if ms_helion > 0 else float("nan")
-        speedups.append(speedup)
-        if speedup > 1.0:
-            helion_wins += 1
-        if speedup > best_speedup:
-            best_speedup = speedup
-            best_shape = (tokens, vocab)
-        _p(
-            f"{tokens:>8d}  {vocab:>8d}  {ms_helion:>12.4f}  "
-            f"{ms_torch:>12.4f}  {speedup:>7.2f}x"
-        )
 
-    geomean = math.exp(
-        sum(math.log(s) for s in speedups if s > 0) / max(len(speedups), 1)
+        def helion_call() -> torch.Tensor:
+            return cross_entropy(logits, labels)
+
+        base_calls = [
+            (name, (lambda fn=fn: fn(logits, labels))) for name, fn in baselines
+        ]
+        return helion_call, base_calls, f"{tokens:>8d}  {vocab:>8d}"
+
+    return run_sweep(
+        shapes,
+        make_calls,
+        use_cudagraph=use_cudagraph(),
+        verbose=verbose,
+        shape_header=f"{'tokens':>8s}  {'vocab':>8s}",
     )
-    _p(
-        f"\nHelion faster on {helion_wins}/{len(shapes)} shapes; "
-        f"geomean speedup {geomean:.3f}x; "
-        f"best speedup {best_speedup:.2f}x at (tokens, vocab)={best_shape}."
-    )
-    return {
-        "helion_wins": helion_wins,
-        "total": len(shapes),
-        "geomean": round(geomean, 4),
-        "best_speedup": round(best_speedup, 4),
-    }
 
 
 if __name__ == "__main__":

--- a/pretuned_kernels/dynamic_per_token_scaled_fp8_quant/dynamic_per_token_scaled_fp8_quant.py
+++ b/pretuned_kernels/dynamic_per_token_scaled_fp8_quant/dynamic_per_token_scaled_fp8_quant.py
@@ -109,9 +109,17 @@ def _dynamic_per_token_scaled_fp8_quant_vllm(
 
 
 def _baselines() -> list[tuple[str, object]]:
-    """Baselines main() benchmarks against (torch always; vLLM when installed)."""
+    """Baselines main() benchmarks against (torch always; vLLM when installed).
+
+    ``torch_compile`` is ``torch.compile`` of the torch reference -- a
+    speedup-comparison baseline only (not checked for accuracy).
+    """
     out: list[tuple[str, object]] = [
-        ("torch", _dynamic_per_token_scaled_fp8_quant_torch)
+        ("torch", _dynamic_per_token_scaled_fp8_quant_torch),
+        (
+            "torch_compile",
+            torch.compile(_dynamic_per_token_scaled_fp8_quant_torch),
+        ),
     ]
     if _HAS_VLLM:
         out.append(("vllm", _dynamic_per_token_scaled_fp8_quant_vllm))

--- a/pretuned_kernels/fused_qk_norm_rope/fused_qk_norm_rope.py
+++ b/pretuned_kernels/fused_qk_norm_rope/fused_qk_norm_rope.py
@@ -228,8 +228,15 @@ def _fused_qk_norm_rope_vllm(
 
 
 def _baselines() -> list[tuple[str, object]]:
-    """Baselines main() benchmarks against (torch always; vLLM when installed)."""
-    out: list[tuple[str, object]] = [("torch", _fused_qk_norm_rope_torch)]
+    """Baselines main() benchmarks against (torch always; vLLM when installed).
+
+    ``torch_compile`` is ``torch.compile`` of the torch reference -- a
+    speedup-comparison baseline only (not checked for accuracy).
+    """
+    out: list[tuple[str, object]] = [
+        ("torch", _fused_qk_norm_rope_torch),
+        ("torch_compile", torch.compile(_fused_qk_norm_rope_torch)),
+    ]
     if _HAS_VLLM:
         out.append(("vllm", _fused_qk_norm_rope_vllm))
     return out

--- a/pretuned_kernels/layer_norm/layer_norm.py
+++ b/pretuned_kernels/layer_norm/layer_norm.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-import math
-
 import torch
 import torch.nn.functional as F
-import triton.testing as tt
 
 import helion.experimental
 import helion.language as hl
@@ -31,15 +28,35 @@ def layer_norm(
     return out
 
 
+def _layer_norm_torch(
+    x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor
+) -> torch.Tensor:
+    return F.layer_norm(x, [x.size(1)], weight, bias, eps=1e-5)
+
+
+def _baselines() -> list[tuple[str, object]]:
+    """Baselines main() benchmarks against.
+
+    ``torch_compile`` is ``torch.compile`` of the torch reference -- a
+    speedup-comparison baseline only (not checked for accuracy).
+    """
+    return [
+        ("torch", _layer_norm_torch),
+        ("torch_compile", torch.compile(_layer_norm_torch)),
+    ]
+
+
 def use_cudagraph() -> bool:
     """Whether main() benchmarks under CUDA graphs (read by pretuned_kernels/run.py)."""
     return False
 
 
 def main(verbose: bool = True) -> dict:
-    def _p(*args: object) -> None:
-        if verbose:
-            print(*args)
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from _bench import run_sweep
 
     triton_tutorial_shapes = [(4096, 512 * i) for i in range(2, 32)]
     realistic_shapes = [
@@ -53,61 +70,29 @@ def main(verbose: bool = True) -> dict:
         (1152, 36864),
     ]
     shapes = list(dict.fromkeys(triton_tutorial_shapes + realistic_shapes))
+    baselines = _baselines()
 
-    _p(f"GPU: {torch.cuda.get_device_name()}")
-    _p(
-        f"{'M':>5s}  {'N':>6s}  {'helion (us)':>12s}  "
-        f"{'torch (us)':>12s}  {'speedup':>8s}"
-    )
-    _p("-" * 60)
-
-    speedups: list[float] = []
-    helion_wins = 0
-    best_speedup = 0.0
-    best_shape = (0, 0)
-    for M, N in shapes:
+    def make_calls(shape: tuple[int, int]) -> tuple:
+        M, N = shape
         x = torch.randn([M, N], device="cuda", dtype=torch.float16)
         w = torch.randn([N], device="cuda", dtype=torch.float16)
         b = torch.randn([N], device="cuda", dtype=torch.float16)
-        layer_norm(x, w, b)  # warmup
-        ms_helion = tt.do_bench(
-            lambda x=x, w=w, b=b: layer_norm(x, w, b),
-            warmup=50,
-            rep=200,
-            return_mode="median",
-        )
-        ms_torch = tt.do_bench(
-            lambda x=x, N=N, w=w, b=b: F.layer_norm(x, [N], w, b, eps=1e-5),
-            warmup=50,
-            rep=200,
-            return_mode="median",
-        )
-        speedup = ms_torch / ms_helion if ms_helion > 0 else float("nan")
-        speedups.append(speedup)
-        if speedup > 1.0:
-            helion_wins += 1
-        if speedup > best_speedup:
-            best_speedup = speedup
-            best_shape = (M, N)
-        _p(
-            f"{M:>5d}  {N:>6d}  {ms_helion * 1000:>12.2f}  "
-            f"{ms_torch * 1000:>12.2f}  {speedup:>7.2f}x"
-        )
 
-    geomean = math.exp(
-        sum(math.log(s) for s in speedups if s > 0) / max(len(speedups), 1)
+        def helion_call() -> torch.Tensor:
+            return layer_norm(x, w, b)
+
+        base_calls = [(name, (lambda fn=fn: fn(x, w, b))) for name, fn in baselines]
+        return helion_call, base_calls, f"{M:>5d}  {N:>6d}"
+
+    return run_sweep(
+        shapes,
+        make_calls,
+        use_cudagraph=use_cudagraph(),
+        warmup=50,
+        rep=200,
+        verbose=verbose,
+        shape_header=f"{'M':>5s}  {'N':>6s}",
     )
-    _p(
-        f"\nHelion faster on {helion_wins}/{len(shapes)} shapes; "
-        f"geomean speedup {geomean:.3f}x; "
-        f"best speedup {best_speedup:.2f}x at (M, N)={best_shape}."
-    )
-    return {
-        "helion_wins": helion_wins,
-        "total": len(shapes),
-        "geomean": round(geomean, 4),
-        "best_speedup": round(best_speedup, 4),
-    }
 
 
 if __name__ == "__main__":

--- a/pretuned_kernels/per_token_group_fp8_quant/per_token_group_fp8_quant.py
+++ b/pretuned_kernels/per_token_group_fp8_quant/per_token_group_fp8_quant.py
@@ -126,8 +126,15 @@ def _per_token_group_fp8_quant_vllm(
 
 
 def _baselines() -> list[tuple[str, object]]:
-    """Baselines main() benchmarks against (torch always; vLLM when installed)."""
-    out: list[tuple[str, object]] = [("torch", _per_token_group_fp8_quant_torch)]
+    """Baselines main() benchmarks against (torch always; vLLM when installed).
+
+    ``torch_compile`` is ``torch.compile`` of the torch reference -- a
+    speedup-comparison baseline only (not checked for accuracy).
+    """
+    out: list[tuple[str, object]] = [
+        ("torch", _per_token_group_fp8_quant_torch),
+        ("torch_compile", torch.compile(_per_token_group_fp8_quant_torch)),
+    ]
     if _HAS_VLLM:
         out.append(("vllm", _per_token_group_fp8_quant_vllm))
     return out

--- a/pretuned_kernels/rms_norm/rms_norm.py
+++ b/pretuned_kernels/rms_norm/rms_norm.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-import math
-
 import torch
 import torch.nn.functional as F
-import triton.testing as tt
 
 import helion.experimental
 import helion.language as hl
@@ -32,15 +29,29 @@ def _rms_norm_torch(
     return F.rms_norm(x, [x.size(1)], weight, eps=eps)
 
 
+def _baselines() -> list[tuple[str, object]]:
+    """Baselines main() benchmarks against.
+
+    ``torch_compile`` is ``torch.compile`` of the torch reference -- a
+    speedup-comparison baseline only (not checked for accuracy).
+    """
+    return [
+        ("torch", _rms_norm_torch),
+        ("torch_compile", torch.compile(_rms_norm_torch)),
+    ]
+
+
 def use_cudagraph() -> bool:
     """Whether main() benchmarks under CUDA graphs (read by pretuned_kernels/run.py)."""
     return False
 
 
 def main(verbose: bool = True) -> dict:
-    def _p(*args: object) -> None:
-        if verbose:
-            print(*args)
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from _bench import run_sweep
 
     tritonbench_shapes = [
         (2048, 1024),
@@ -81,60 +92,26 @@ def main(verbose: bool = True) -> dict:
     shapes = list(
         dict.fromkeys(tritonbench_shapes + tritonbench_npot_shapes + realistic_shapes)
     )
+    baselines = _baselines()
 
-    _p(f"GPU: {torch.cuda.get_device_name()}")
-    _p(
-        f"{'M':>8s}  {'N':>6s}  {'helion (us)':>12s}  "
-        f"{'torch (us)':>12s}  {'speedup':>8s}"
-    )
-    _p("-" * 63)
-
-    speedups: list[float] = []
-    helion_wins = 0
-    best_speedup = 0.0
-    best_shape = (0, 0)
-    for M, N in shapes:
+    def make_calls(shape: tuple[int, int]) -> tuple:
+        M, N = shape
         x = torch.randn([M, N], device="cuda", dtype=torch.bfloat16)
         weight = torch.randn([N], device="cuda", dtype=torch.bfloat16)
-        rms_norm(x, weight)  # warmup
-        ms_helion = tt.do_bench(
-            lambda x=x, weight=weight: rms_norm(x, weight),
-            warmup=25,
-            rep=100,
-            return_mode="median",
-        )
-        ms_torch = tt.do_bench(
-            lambda x=x, weight=weight: _rms_norm_torch(x, weight),
-            warmup=25,
-            rep=100,
-            return_mode="median",
-        )
-        speedup = ms_torch / ms_helion if ms_helion > 0 else float("nan")
-        speedups.append(speedup)
-        if speedup > 1.0:
-            helion_wins += 1
-        if speedup > best_speedup:
-            best_speedup = speedup
-            best_shape = (M, N)
-        _p(
-            f"{M:>8d}  {N:>6d}  {ms_helion * 1000:>12.2f}  "
-            f"{ms_torch * 1000:>12.2f}  {speedup:>7.2f}x"
-        )
 
-    geomean = math.exp(
-        sum(math.log(s) for s in speedups if s > 0) / max(len(speedups), 1)
+        def helion_call() -> torch.Tensor:
+            return rms_norm(x, weight)
+
+        base_calls = [(name, (lambda fn=fn: fn(x, weight))) for name, fn in baselines]
+        return helion_call, base_calls, f"{M:>8d}  {N:>6d}"
+
+    return run_sweep(
+        shapes,
+        make_calls,
+        use_cudagraph=use_cudagraph(),
+        verbose=verbose,
+        shape_header=f"{'M':>8s}  {'N':>6s}",
     )
-    _p(
-        f"\nHelion faster on {helion_wins}/{len(shapes)} shapes; "
-        f"geomean speedup {geomean:.3f}x; "
-        f"best speedup {best_speedup:.2f}x at (M, N)={best_shape}."
-    )
-    return {
-        "helion_wins": helion_wins,
-        "total": len(shapes),
-        "geomean": round(geomean, 4),
-        "best_speedup": round(best_speedup, 4),
-    }
 
 
 if __name__ == "__main__":

--- a/pretuned_kernels/rms_norm_dynamic_per_token_quant/rms_norm_dynamic_per_token_quant.py
+++ b/pretuned_kernels/rms_norm_dynamic_per_token_quant/rms_norm_dynamic_per_token_quant.py
@@ -180,8 +180,18 @@ def _rms_norm_dynamic_per_token_quant_vllm(
 
 
 def _baselines() -> list[tuple[str, object]]:
-    """Baselines main() benchmarks against (torch always; vLLM when installed)."""
-    out: list[tuple[str, object]] = [("torch", _rms_norm_dynamic_per_token_quant_torch)]
+    """Baselines main() benchmarks against (torch always; vLLM when installed).
+
+    ``torch_compile`` is ``torch.compile`` of the torch reference -- a
+    speedup-comparison baseline only (not checked for accuracy).
+    """
+    out: list[tuple[str, object]] = [
+        ("torch", _rms_norm_dynamic_per_token_quant_torch),
+        (
+            "torch_compile",
+            torch.compile(_rms_norm_dynamic_per_token_quant_torch),
+        ),
+    ]
     if _HAS_VLLM:
         out.append(("vllm", _rms_norm_dynamic_per_token_quant_vllm))
     return out

--- a/pretuned_kernels/rms_norm_per_block_quant/rms_norm_per_block_quant.py
+++ b/pretuned_kernels/rms_norm_per_block_quant/rms_norm_per_block_quant.py
@@ -220,8 +220,15 @@ def _rms_norm_per_block_quant_vllm(
 
 
 def _baselines() -> list[tuple[str, object]]:
-    """Baselines main() benchmarks against (torch always; vLLM when installed)."""
-    out: list[tuple[str, object]] = [("torch", _rms_norm_per_block_quant_torch)]
+    """Baselines main() benchmarks against (torch always; vLLM when installed).
+
+    ``torch_compile`` is ``torch.compile`` of the torch reference -- a
+    speedup-comparison baseline only (not checked for accuracy).
+    """
+    out: list[tuple[str, object]] = [
+        ("torch", _rms_norm_per_block_quant_torch),
+        ("torch_compile", torch.compile(_rms_norm_per_block_quant_torch)),
+    ]
     if _HAS_VLLM:
         out.append(("vllm", _rms_norm_per_block_quant_vllm))
     return out

--- a/pretuned_kernels/rope/rope.py
+++ b/pretuned_kernels/rope/rope.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
-import math
 from typing import Any
 from typing import Callable
-from typing import cast
 
 import torch
-import triton.testing as tt
 
 import helion.experimental
 import helion.language as hl
@@ -264,15 +261,29 @@ def _make_inputs(
     return q, k, torch.cos(angles), torch.sin(angles)
 
 
+def _baselines() -> list[tuple[str, object]]:
+    """Baselines main() benchmarks against.
+
+    ``torch_compile`` is ``torch.compile`` of the torch reference -- a
+    speedup-comparison baseline only (not checked for accuracy).
+    """
+    return [
+        ("torch", rope_pytorch),
+        ("torch_compile", torch.compile(rope_pytorch)),
+    ]
+
+
 def use_cudagraph() -> bool:
     """Whether main() benchmarks under CUDA graphs (read by pretuned_kernels/run.py)."""
     return False
 
 
 def main(verbose: bool = True) -> dict:
-    def _p(*args: object) -> None:
-        if verbose:
-            print(*args)
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from _bench import run_sweep
 
     shapes = [
         (8192, 1024),
@@ -283,63 +294,27 @@ def main(verbose: bool = True) -> dict:
         (512, 2048),
         (2048, 2048),
     ]
+    baselines = _baselines()
 
-    _p(f"GPU: {torch.cuda.get_device_name()}")
-    _p(
-        f"{'H':>6s}  {'T':>6s}  {'helion (us)':>12s}  "
-        f"{'torch (us)':>12s}  {'speedup':>8s}"
-    )
-    _p("-" * 60)
-
-    speedups: list[float] = []
-    helion_wins = 0
-    best_speedup = 0.0
-    best_shape = (0, 0)
-    for hidden_size, seq_length in shapes:
+    def make_calls(shape: tuple[int, int]) -> tuple:
+        hidden_size, seq_length = shape
         q, k, cos, sin = _make_inputs(hidden_size, seq_length)
-        rope(q, k, cos, sin)
-        ms_helion = cast(
-            "float",
-            tt.do_bench(
-                lambda q=q, k=k, cos=cos, sin=sin: rope(q, k, cos, sin),
-                warmup=25,
-                rep=100,
-            ),
-        )
-        ms_torch = cast(
-            "float",
-            tt.do_bench(
-                lambda q=q, k=k, cos=cos, sin=sin: rope_pytorch(q, k, cos, sin),
-                warmup=25,
-                rep=100,
-            ),
-        )
-        speedup = ms_torch / ms_helion if ms_helion > 0 else float("nan")
-        speedups.append(speedup)
-        if speedup > 1.0:
-            helion_wins += 1
-        if speedup > best_speedup:
-            best_speedup = speedup
-            best_shape = (hidden_size, seq_length)
-        _p(
-            f"{hidden_size:>6d}  {seq_length:>6d}  {ms_helion * 1000:>12.2f}  "
-            f"{ms_torch * 1000:>12.2f}  {speedup:>7.2f}x"
-        )
 
-    geomean = math.exp(
-        sum(math.log(s) for s in speedups if s > 0) / max(len(speedups), 1)
+        def helion_call() -> tuple[torch.Tensor, torch.Tensor]:
+            return rope(q, k, cos, sin)
+
+        base_calls = [
+            (name, (lambda fn=fn: fn(q, k, cos, sin))) for name, fn in baselines
+        ]
+        return helion_call, base_calls, f"{hidden_size:>6d}  {seq_length:>6d}"
+
+    return run_sweep(
+        shapes,
+        make_calls,
+        use_cudagraph=use_cudagraph(),
+        verbose=verbose,
+        shape_header=f"{'H':>6s}  {'T':>6s}",
     )
-    _p(
-        f"\nHelion faster on {helion_wins}/{len(shapes)} shapes; "
-        f"geomean speedup {geomean:.3f}x; "
-        f"best speedup {best_speedup:.2f}x at (H, T)={best_shape}."
-    )
-    return {
-        "helion_wins": helion_wins,
-        "total": len(shapes),
-        "geomean": round(geomean, 4),
-        "best_speedup": round(best_speedup, 4),
-    }
 
 
 if __name__ == "__main__":

--- a/pretuned_kernels/scaled_mm/scaled_mm.py
+++ b/pretuned_kernels/scaled_mm/scaled_mm.py
@@ -136,6 +136,10 @@ def _baselines() -> list[tuple[str, object]]:
     torch._scaled_mm is always available; vLLM's CUTLASS kernel is added when
     vLLM is installed (the nightly benchmark env). The SUMMARY speedup is helion
     vs the best (fastest) available baseline.
+
+    No torch.compile baseline here: the torch reference is a single opaque GEMM
+    (torch._scaled_mm -> cuBLAS/cutlass), which torch.compile just re-dispatches
+    to the same kernel -- a redundant, not-faster baseline.
     """
     baselines: list[tuple[str, object]] = [("torch", _scaled_mm_torch)]
     if _HAS_VLLM:

--- a/pretuned_kernels/silu_and_mul_per_block_quant/silu_and_mul_per_block_quant.py
+++ b/pretuned_kernels/silu_and_mul_per_block_quant/silu_and_mul_per_block_quant.py
@@ -169,8 +169,15 @@ def _silu_and_mul_per_block_quant_vllm(
 
 
 def _baselines() -> list[tuple[str, object]]:
-    """Baselines main() benchmarks against (torch always; vLLM when installed)."""
-    out: list[tuple[str, object]] = [("torch", _silu_and_mul_per_block_quant_torch)]
+    """Baselines main() benchmarks against (torch always; vLLM when installed).
+
+    ``torch_compile`` is ``torch.compile`` of the torch reference -- a
+    speedup-comparison baseline only (not checked for accuracy).
+    """
+    out: list[tuple[str, object]] = [
+        ("torch", _silu_and_mul_per_block_quant_torch),
+        ("torch_compile", torch.compile(_silu_and_mul_per_block_quant_torch)),
+    ]
     if _HAS_VLLM:
         out.append(("vllm", _silu_and_mul_per_block_quant_vllm))
     return out

--- a/pretuned_kernels/silu_mul_fp8/silu_mul_fp8.py
+++ b/pretuned_kernels/silu_mul_fp8/silu_mul_fp8.py
@@ -78,8 +78,15 @@ def _silu_mul_fp8_vllm(input: torch.Tensor, scale: torch.Tensor) -> torch.Tensor
 
 
 def _baselines() -> list[tuple[str, object]]:
-    """Baselines main() benchmarks against (torch always; vLLM when installed)."""
-    out: list[tuple[str, object]] = [("torch", _silu_mul_fp8_torch)]
+    """Baselines main() benchmarks against (torch always; vLLM when installed).
+
+    ``torch_compile`` is ``torch.compile`` of the torch reference -- a
+    speedup-comparison baseline only (not checked for accuracy).
+    """
+    out: list[tuple[str, object]] = [
+        ("torch", _silu_mul_fp8_torch),
+        ("torch_compile", torch.compile(_silu_mul_fp8_torch)),
+    ]
     if _HAS_VLLM:
         out.append(("vllm", _silu_mul_fp8_vllm))
     return out

--- a/pretuned_kernels/softmax/softmax.py
+++ b/pretuned_kernels/softmax/softmax.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-import math
-
 import torch
 import torch.nn.functional as F
-import triton.testing as tt
 
 import helion.experimental
 import helion.language as hl
@@ -21,15 +18,33 @@ def softmax(x: torch.Tensor) -> torch.Tensor:
     return out
 
 
+def _softmax_torch(x: torch.Tensor) -> torch.Tensor:
+    return F.softmax(x, dim=1)
+
+
+def _baselines() -> list[tuple[str, object]]:
+    """Baselines main() benchmarks against.
+
+    ``torch_compile`` is ``torch.compile`` of the torch reference -- a
+    speedup-comparison baseline only (not checked for accuracy).
+    """
+    return [
+        ("torch", _softmax_torch),
+        ("torch_compile", torch.compile(_softmax_torch)),
+    ]
+
+
 def use_cudagraph() -> bool:
     """Whether main() benchmarks under CUDA graphs (read by pretuned_kernels/run.py)."""
     return False
 
 
 def main(verbose: bool = True) -> dict:
-    def _p(*args: object) -> None:
-        if verbose:
-            print(*args)
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from _bench import run_sweep
 
     triton_tutorial_shapes = [(4096, 128 * i) for i in range(2, 100)]
     realistic_shapes = [
@@ -37,59 +52,27 @@ def main(verbose: bool = True) -> dict:
         (2048, 32768),
     ]
     shapes = list(dict.fromkeys(triton_tutorial_shapes + realistic_shapes))
+    baselines = _baselines()
 
-    _p(f"GPU: {torch.cuda.get_device_name()}")
-    _p(
-        f"{'M':>5s}  {'N':>6s}  {'helion (us)':>12s}  "
-        f"{'torch (us)':>12s}  {'speedup':>8s}"
-    )
-    _p("-" * 60)
-
-    speedups: list[float] = []
-    helion_wins = 0
-    best_speedup = 0.0
-    best_shape = (0, 0)
-    for M, N in shapes:
+    def make_calls(shape: tuple[int, int]) -> tuple:
+        M, N = shape
         x = torch.randn([M, N], device="cuda", dtype=torch.float16)
-        softmax(x)  # warmup
-        ms_helion = tt.do_bench(
-            lambda x=x: softmax(x),
-            warmup=50,
-            rep=200,
-            return_mode="median",
-        )
-        ms_torch = tt.do_bench(
-            lambda x=x: F.softmax(x, dim=1),
-            warmup=50,
-            rep=200,
-            return_mode="median",
-        )
-        speedup = ms_torch / ms_helion if ms_helion > 0 else float("nan")
-        speedups.append(speedup)
-        if speedup > 1.0:
-            helion_wins += 1
-        if speedup > best_speedup:
-            best_speedup = speedup
-            best_shape = (M, N)
-        _p(
-            f"{M:>5d}  {N:>6d}  {ms_helion * 1000:>12.2f}  "
-            f"{ms_torch * 1000:>12.2f}  {speedup:>7.2f}x"
-        )
 
-    geomean = math.exp(
-        sum(math.log(s) for s in speedups if s > 0) / max(len(speedups), 1)
+        def helion_call() -> torch.Tensor:
+            return softmax(x)
+
+        base_calls = [(name, (lambda fn=fn: fn(x))) for name, fn in baselines]
+        return helion_call, base_calls, f"{M:>5d}  {N:>6d}"
+
+    return run_sweep(
+        shapes,
+        make_calls,
+        use_cudagraph=use_cudagraph(),
+        warmup=50,
+        rep=200,
+        verbose=verbose,
+        shape_header=f"{'M':>5s}  {'N':>6s}",
     )
-    _p(
-        f"\nHelion faster on {helion_wins}/{len(shapes)} shapes; "
-        f"geomean speedup {geomean:.3f}x; "
-        f"best speedup {best_speedup:.2f}x at (M, N)={best_shape}."
-    )
-    return {
-        "helion_wins": helion_wins,
-        "total": len(shapes),
-        "geomean": round(geomean, 4),
-        "best_speedup": round(best_speedup, 4),
-    }
 
 
 if __name__ == "__main__":

--- a/pretuned_kernels/vector_add/vector_add.py
+++ b/pretuned_kernels/vector_add/vector_add.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-import math
-
 import torch
-import triton.testing as tt
 
 import helion.experimental
 import helion.language as hl
@@ -19,73 +16,54 @@ def vector_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     return out
 
 
+def _vector_add_torch(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    return torch.add(x, y)
+
+
+def _baselines() -> list[tuple[str, object]]:
+    """Baselines main() benchmarks against.
+
+    No torch.compile baseline: the reference is a single memory-bandwidth-bound
+    elementwise add, which torch.compile cannot fuse or speed up -- a redundant,
+    not-faster baseline.
+    """
+    return [("torch", _vector_add_torch)]
+
+
 def use_cudagraph() -> bool:
     """Whether main() benchmarks under CUDA graphs (read by pretuned_kernels/run.py)."""
     return False
 
 
 def main(verbose: bool = True) -> dict:
-    def _p(*args: object) -> None:
-        if verbose:
-            print(*args)
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from _bench import run_sweep
 
     shapes = [2**i for i in range(19, 29)]
+    baselines = _baselines()
 
-    _p(f"GPU: {torch.cuda.get_device_name()}")
-    _p(
-        f"{'N':>10s}  {'helion (us)':>12s}  {'torch (us)':>12s}  "
-        f"{'speedup':>8s}  {'winner':>8s}"
-    )
-    _p("-" * 60)
-
-    speedups: list[float] = []
-    helion_wins = 0
-    best_speedup = 0.0
-    best_n = 0
-    for n in shapes:
+    def make_calls(n: int) -> tuple:
         x = torch.randn(n, device="cuda", dtype=torch.float32)
         y = torch.randn(n, device="cuda", dtype=torch.float32)
-        vector_add(x, y)  # warmup
-        ms_helion = tt.do_bench(
-            lambda x=x, y=y: vector_add(x, y),
-            warmup=50,
-            rep=200,
-            return_mode="median",
-        )
-        ms_torch = tt.do_bench(
-            lambda x=x, y=y: x + y,
-            warmup=50,
-            rep=200,
-            return_mode="median",
-        )
-        speedup = ms_torch / ms_helion if ms_helion > 0 else float("nan")
-        speedups.append(speedup)
-        winner = "helion" if speedup > 1.0 else "torch" if speedup < 1.0 else "tie"
-        if speedup > 1.0:
-            helion_wins += 1
-        if speedup > best_speedup:
-            best_speedup = speedup
-            best_n = n
-        _p(
-            f"{n:>10d}  {ms_helion * 1000:>12.2f}  "
-            f"{ms_torch * 1000:>12.2f}  {speedup:>7.3f}x  {winner:>8s}"
-        )
 
-    geomean = math.exp(
-        sum(math.log(s) for s in speedups if s > 0) / max(len(speedups), 1)
+        def helion_call() -> torch.Tensor:
+            return vector_add(x, y)
+
+        base_calls = [(name, (lambda fn=fn: fn(x, y))) for name, fn in baselines]
+        return helion_call, base_calls, f"{n:>10d}"
+
+    return run_sweep(
+        shapes,
+        make_calls,
+        use_cudagraph=use_cudagraph(),
+        warmup=50,
+        rep=200,
+        verbose=verbose,
+        shape_header=f"{'N':>10s}",
     )
-    _p(
-        f"\nHelion faster on {helion_wins}/{len(shapes)} shapes; "
-        f"geomean speedup {geomean:.3f}x; "
-        f"best speedup {best_speedup:.2f}x at N={best_n}."
-    )
-    # Machine-parseable summary line consumed by test/test_pretuned_kernels.py.
-    return {
-        "helion_wins": helion_wins,
-        "total": len(shapes),
-        "geomean": round(geomean, 4),
-        "best_speedup": round(best_speedup, 4),
-    }
 
 
 if __name__ == "__main__":

--- a/test/test_pretuned_kernels.py
+++ b/test/test_pretuned_kernels.py
@@ -240,85 +240,63 @@ class ExpectedPerf:
     wins_slack: int | None
 
 
-# Sampled on B200 with the checked-in heuristic. ``wins_slack`` lets that
-# many near-noise-band shapes flip without failing; ``None`` disables the
-# wins gate for kernels with several expected near-parity shapes.
+# helion-vs-best-baseline targets. Every kernel's baselines now include
+# ``torch_compile`` (torch.compile of the torch reference), which competes to be
+# the fastest baseline -- so these numbers are helion vs the best of {torch,
+# torch_compile} (the perf test env has no vLLM). ``wins_slack`` lets that many
+# near-noise-band shapes flip without failing; ``None`` disables the wins gate
+# for kernels with several expected near-parity shapes.
+#
+# sm90 sampled on H100. sm100 perf gating is deferred until a B200 nightly
+# recalibrates it against the torch_compile baseline (the perf test skips
+# compute capabilities absent from this map -- so sm100 runs correctness only
+# for now).
 _EXPECTED_PERF: dict[str, dict[str, ExpectedPerf]] = {
     "vector_add": {
-        "sm100": ExpectedPerf(
-            helion_wins=5,
-            total=10,
-            geomean=1.009,
-            wins_slack=None,
-        ),
         "sm90": ExpectedPerf(
             helion_wins=5,
             total=10,
-            geomean=0.99,
+            geomean=0.97,
             wins_slack=None,
         ),
     },
     "softmax": {
-        "sm100": ExpectedPerf(
-            helion_wins=100,
-            total=100,
-            geomean=2.304,
-            wins_slack=2,
-        ),
         "sm90": ExpectedPerf(
-            helion_wins=97,
+            helion_wins=99,
             total=100,
-            geomean=1.78,
+            geomean=1.50,
             wins_slack=7,
         ),
     },
     "layer_norm": {
-        "sm100": ExpectedPerf(
-            helion_wins=38,
-            total=38,
-            geomean=1.55,
-            wins_slack=1,
-        ),
         "sm90": ExpectedPerf(
             helion_wins=37,
             total=38,
-            geomean=1.39,
+            geomean=1.29,
             wins_slack=2,
         ),
     },
     "rms_norm": {
-        "sm100": ExpectedPerf(
-            helion_wins=30,
-            total=30,
-            geomean=1.605,
-            wins_slack=6,
-        ),
         "sm90": ExpectedPerf(
-            helion_wins=23,
+            helion_wins=28,
             total=30,
-            geomean=1.17,
+            geomean=1.18,
             wins_slack=5,
         ),
     },
     "cross_entropy": {
-        "sm100": ExpectedPerf(
-            helion_wins=21,
-            total=21,
-            geomean=1.698,
-            wins_slack=1,
-        ),
         "sm90": ExpectedPerf(
             helion_wins=21,
             total=21,
-            geomean=2.35,
+            geomean=1.68,
             wins_slack=1,
         ),
     },
     "rope": {
         "sm90": ExpectedPerf(
-            helion_wins=7,
+            helion_wins=6,
             total=7,
-            geomean=5.0,
+            geomean=1.45,
             wins_slack=1,
         ),
     },
@@ -336,30 +314,31 @@ _EXPECTED_PERF: dict[str, dict[str, ExpectedPerf]] = {
         ),
     },
     # vLLM-ported kernels (vllm/kernels/helion/ops): each benchmarks its fused
-    # Helion kernel under CUDA graphs against a torch-native (unfused, eager)
-    # reference, so speedups are large. sm90 numbers measured on H100; sm100
-    # gating is added once a B200 nightly has calibrated it (the perf test
-    # skips compute capabilities absent from this map).
+    # Helion kernel under CUDA graphs against a torch-native reference and its
+    # torch.compile, so speedups are still large vs the best of the two. sm90
+    # numbers measured on H100; sm100 gating is added once a B200 nightly has
+    # calibrated it (the perf test skips compute capabilities absent from this
+    # map).
     "silu_mul_fp8": {
-        "sm90": ExpectedPerf(helion_wins=36, total=36, geomean=6.0, wins_slack=3),
+        "sm90": ExpectedPerf(helion_wins=21, total=36, geomean=1.15, wins_slack=3),
     },
     "dynamic_per_token_scaled_fp8_quant": {
-        "sm90": ExpectedPerf(helion_wins=24, total=24, geomean=13.9, wins_slack=2),
+        "sm90": ExpectedPerf(helion_wins=24, total=24, geomean=1.67, wins_slack=2),
     },
     "per_token_group_fp8_quant": {
-        "sm90": ExpectedPerf(helion_wins=24, total=24, geomean=12.3, wins_slack=2),
+        "sm90": ExpectedPerf(helion_wins=24, total=24, geomean=2.95, wins_slack=2),
     },
     "rms_norm_dynamic_per_token_quant": {
-        "sm90": ExpectedPerf(helion_wins=36, total=36, geomean=18.0, wins_slack=3),
+        "sm90": ExpectedPerf(helion_wins=36, total=36, geomean=1.70, wins_slack=3),
     },
     "rms_norm_per_block_quant": {
-        "sm90": ExpectedPerf(helion_wins=24, total=24, geomean=18.0, wins_slack=2),
+        "sm90": ExpectedPerf(helion_wins=24, total=24, geomean=3.95, wins_slack=2),
     },
     "silu_and_mul_per_block_quant": {
-        "sm90": ExpectedPerf(helion_wins=24, total=24, geomean=16.1, wins_slack=2),
+        "sm90": ExpectedPerf(helion_wins=24, total=24, geomean=3.55, wins_slack=2),
     },
     "fused_qk_norm_rope": {
-        "sm90": ExpectedPerf(helion_wins=21, total=21, geomean=25.5, wins_slack=2),
+        "sm90": ExpectedPerf(helion_wins=21, total=21, geomean=8.6, wins_slack=2),
     },
 }
 


### PR DESCRIPTION
Every pretuned kernel now benchmarks Helion against torch.compile of its torch reference, in addition to eager torch (and the vLLM op when installed). torch.compile competes to be the fastest baseline, so the headline speedup is Helion vs the best of {torch, torch_compile}. This is a speedup-comparison baseline only -- correctness is still checked against the eager reference.

- Multi-baseline kernels: add ("torch_compile", torch.compile(ref)) to _baselines().
- Single-baseline kernels (vector_add, softmax, layer_norm, rms_norm, cross_entropy, rope): converted to the shared run_sweep multi-baseline pattern so they emit the per-baseline breakdown (dashboard dropdown) too.
- Re-measured _EXPECTED_PERF sm90 targets on H100 (vLLM disabled, to match the perf test env). sm100 perf gating is deferred until a B200 nightly recalibrates it against the torch_compile baseline (perf test skips compute capabilities absent from the map; sm100 runs correctness only for now).
- README: document the torch.compile baseline.


Example successful run: https://github.com/pytorch/helion/actions/runs/28487661269/job/84441041141