### PR TITLE
Apply LFBO neighbor caps to tree search

### DIFF
--- a/helion/autotuner/surrogate_pattern_search.py
+++ b/helion/autotuner/surrogate_pattern_search.py
@@ -162,6 +162,7 @@ class LFBOPatternSearch(PatternSearch):
     def get_kwargs_from_profile(
         cls, profile: AutotuneEffortProfile, settings: Settings
     ) -> dict[str, object]:
+        from ..runtime.settings import _env_get_int
         from ..runtime.settings import _get_initial_population_strategy
 
         assert profile.lfbo_pattern_search is not None
@@ -175,6 +176,7 @@ class LFBOPatternSearch(PatternSearch):
             "max_generations": profile.lfbo_pattern_search.max_generations,
             "initial_population_strategy": strategy,
             "best_available_pad_random": profile.lfbo_pattern_search.best_available_pad_random,
+            "num_neighbors_cap": _env_get_int("HELION_CAP_AUTOTUNE_NUM_NEIGHBORS", -1),
             **PopulationBasedSearch.get_kwargs_from_profile(profile, settings),
         }
 
@@ -693,6 +695,8 @@ class LFBOTreeSearch(LFBOPatternSearch):
             FROM_BEST_AVAILABLE uses cached configs from prior runs, and fills the
             remainder with random configs when best_available_pad_random is True.
             Can be overridden by HELION_AUTOTUNER_INITIAL_POPULATION env var.
+        num_neighbors_cap: Maximum number of neighbors to explore per generation.
+            -1 means no cap. Set HELION_CAP_AUTOTUNE_NUM_NEIGHBORS=N to override.
     """
 
     def __init__(
@@ -712,6 +716,7 @@ class LFBOTreeSearch(LFBOPatternSearch):
         similarity_penalty: float = 1.0,
         initial_population_strategy: InitialPopulationStrategy | None = None,
         best_available_pad_random: bool = PATTERN_SEARCH_DEFAULTS.best_available_pad_random,
+        num_neighbors_cap: int = -1,
         finishing_rounds: int = 0,
         compile_timeout_lower_bound: float = PATTERN_SEARCH_DEFAULTS.compile_timeout_lower_bound,
         compile_timeout_quantile: float = PATTERN_SEARCH_DEFAULTS.compile_timeout_quantile,
@@ -731,6 +736,7 @@ class LFBOTreeSearch(LFBOPatternSearch):
             similarity_penalty=similarity_penalty,
             initial_population_strategy=initial_population_strategy,
             best_available_pad_random=best_available_pad_random,
+            num_neighbors_cap=num_neighbors_cap,
             finishing_rounds=finishing_rounds,
             compile_timeout_lower_bound=compile_timeout_lower_bound,
             compile_timeout_quantile=compile_timeout_quantile,
@@ -862,4 +868,4 @@ class LFBOTreeSearch(LFBOPatternSearch):
             if current_flat != base_list:
                 all_results.append(list(current_flat))
 
-        return all_results
+        return self.shrink_neighbors(all_results)

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -1453,6 +1453,45 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             # Check boolean
             self.assertIn(neighbor[4], [True, False])
 
+    def test_lfbo_tree_search_generate_neighbors_cap(self):
+        """LFBOTreeSearch applies num_neighbors_cap in the tree-guided path."""
+
+        class MockEstimator:
+            tree_ = SimpleNamespace(feature=np.array([0], dtype=int))
+
+            def decision_path(self, _x):
+                return SimpleNamespace(indices=np.array([0], dtype=int))
+
+            def predict_proba(self, x):
+                scores = np.asarray(x)[:, 0]
+                probas = scores / np.max(scores)
+                return np.column_stack((1.0 - probas, probas))
+
+        spec = PowerOfTwoFragment(16, 128, 32)
+        search = LFBOTreeSearch.__new__(LFBOTreeSearch)
+        search.num_neighbors = 10
+        search.num_neighbors_cap = 3
+        search.radius = 2
+        search.surrogate = SimpleNamespace(estimators_=[MockEstimator()])
+        search._autotune_metrics = SimpleNamespace(num_generations=2)
+        search._encoded_to_flat_mapping = None
+        search.config_gen = SimpleNamespace(
+            flat_spec=[spec],
+            block_size_indices=[0],
+            num_warps_index=-1,
+            overridden_flat_indices=set(),
+            encode_config=lambda flat: spec.encode(flat[0]),
+        )
+
+        capped_neighbors = search._generate_neighbors([32])
+
+        search.num_neighbors_cap = -1
+        uncapped_neighbors = search._generate_neighbors([32])
+
+        self.assertEqual(len(capped_neighbors), 3)
+        self.assertEqual(len(uncapped_neighbors), 10)
+        self.assertTrue(all(neighbor != [32] for neighbor in capped_neighbors))
+
     def test_lfbo_pattern_search_surrogate_select_matches_legacy_prefix(self):
         """Top-k LFBO selection should match the legacy full-ranking implementation."""
 
@@ -2314,7 +2353,10 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         bound = add.bind(args)
 
         # Default: -1 (no cap)
-        with patch.dict(os.environ, {"HELION_AUTOTUNER": "PatternSearch"}):
+        with (
+            without_env_var("HELION_CAP_AUTOTUNE_NUM_NEIGHBORS"),
+            patch.dict(os.environ, {"HELION_AUTOTUNER": "PatternSearch"}),
+        ):
             autotuner = bound.settings.autotuner_fn(bound, args)
             self.assertEqual(autotuner.autotuner.num_neighbors_cap, -1)
 
@@ -2329,11 +2371,33 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
             autotuner = bound.settings.autotuner_fn(bound, args)
             self.assertEqual(autotuner.autotuner.num_neighbors_cap, 50)
 
+        # Env var also applies to LFBO-based pattern search.
+        with patch.dict(
+            os.environ,
+            {
+                "HELION_AUTOTUNER": "LFBOTreeSearch",
+                "HELION_CAP_AUTOTUNE_NUM_NEIGHBORS": "50",
+            },
+        ):
+            autotuner = bound.settings.autotuner_fn(bound, args)
+            self.assertEqual(autotuner.autotuner.num_neighbors_cap, 50)
+
         # Explicit constructor arg wins over env var
         with patch.dict(
             os.environ,
             {
                 "HELION_AUTOTUNER": "PatternSearch",
+                "HELION_CAP_AUTOTUNE_NUM_NEIGHBORS": "50",
+            },
+        ):
+            autotuner = bound.settings.autotuner_fn(bound, args, num_neighbors_cap=10)
+            self.assertEqual(autotuner.autotuner.num_neighbors_cap, 10)
+
+        # Explicit constructor arg wins over env var for LFBO-based search too.
+        with patch.dict(
+            os.environ,
+            {
+                "HELION_AUTOTUNER": "LFBOTreeSearch",
                 "HELION_CAP_AUTOTUNE_NUM_NEIGHBORS": "50",
             },
         ):


### PR DESCRIPTION
This PR makes the existing autotuner neighbor-cap setting apply to LFBO tree search as well as the base pattern-search path.

Compiler/autotuner changes:
- `LFBOPatternSearch.get_kwargs_from_profile()` now reads `HELION_CAP_AUTOTUNE_NUM_NEIGHBORS` and passes it through as `num_neighbors_cap`.
- `LFBOTreeSearch` exposes and forwards `num_neighbors_cap` to the shared `PatternSearch` base.
- The tree-guided neighbor generator applies the existing `shrink_neighbors()` helper before returning candidates, matching the random LFBO neighbor path.

Why this is needed:
The distributed autotuner tests already set `HELION_CAP_AUTOTUNE_NUM_NEIGHBORS=50`, but LFBO tree search was not honoring that cap in the tree-guided path. That can make CI spend far more time in autotuning than intended.

Example fixed: none directly. This is CI/autotuner stabilization, split out of the Pallas stack.

Validation:
- `ruff format helion/autotuner/surrogate_pattern_search.py test/test_autotuner.py`
- `ruff check helion/autotuner/surrogate_pattern_search.py test/test_autotuner.py`
- `python -m py_compile helion/autotuner/surrogate_pattern_search.py test/test_autotuner.py`
- `pytest test/test_autotuner.py::TestAutotuner::test_lfbo_tree_search_generate_neighbors_cap test/test_autotuner.py::TestAutotuner::test_num_neighbors_cap -q`