### PR TITLE
Raise TPU CI pytest timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -367,6 +367,9 @@ jobs:
             # worker gets killed mid-compile. Give it headroom.
             TIMEOUT=180
           fi
+          if [[ "${{ matrix.alias }}" == "tpu" ]]; then
+            TIMEOUT=300
+          fi
           pytest $PARALLEL -rf --timeout=$TIMEOUT --reruns=2 --timeout-method=thread $EXTRA_FLAGS $TEST_PATH | tee >(eval $SKIP_CHECK)
 
   test-notebooks:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -355,10 +355,10 @@ jobs:
           if [[ "${{ matrix.alias }}" == *xpu* ]]; then
             export TRITON_XPU_GEN_NATIVE_CODE=1
           fi
-          # Pallas interpret runs on CPU (no parallelism) and is much slower
-          # than TPU/Triton — bump the per-test timeout accordingly.
           TIMEOUT=60
-          if [[ "${{ matrix.alias }}" == "pallas-interpret" ]]; then
+          if [[ "${{ matrix.alias }}" == "tpu" ]]; then
+            TIMEOUT=300
+          elif [[ "${{ matrix.alias }}" == "pallas-interpret" ]]; then
             TIMEOUT=300
           elif [[ "${{ matrix.alias }}" == *a10g* ]]; then
             # A10G (sm86) ptxas cold-compiles some backward kernels slowly
@@ -366,9 +366,6 @@ jobs:
             # per-test timeout false-positives on a cold Triton cache and the
             # worker gets killed mid-compile. Give it headroom.
             TIMEOUT=180
-          fi
-          if [[ "${{ matrix.alias }}" == "tpu" ]]; then
-            TIMEOUT=300
           fi
           pytest $PARALLEL -rf --timeout=$TIMEOUT --reruns=2 --timeout-method=thread $EXTRA_FLAGS $TEST_PATH | tee >(eval $SKIP_CHECK)
 


### PR DESCRIPTION
Stacked PRs:
 * #2962
 * #2957
 * #2956
 * #2955
 * #2954
 * #2953
 * #2952
 * #2951
 * #2950
 * #2949
 * #2948
 * #2947
 * #2946
 * #2945
 * #2944
 * #2943
 * #2942
 * #2941
 * __->__#2982


--- --- ---

### Raise TPU CI pytest timeout


Increase the TPU test shard pytest timeout to 300s so long-running Pallas example coverage does not false-timeout in CI. This keeps the baseline PR focused on the TPU CI budget needed by the Pallas stack.
