### PR TITLE
[Pallas] Add xsa to TPU benchmark sweep

### DIFF
--- a/benchmarks/run_tpu.py
+++ b/benchmarks/run_tpu.py
@@ -825,6 +825,33 @@ def _kl_div_shapes(
     return out
 
 
+def _xsa_shapes(
+    num_shapes: int | None = None,
+) -> list[tuple[str, tuple[Any, ...]]]:
+    # (B, H, T, D). One shape only: larger shapes default-config-OOM the
+    # scoped VMEM at this kernel's structure (head_dim=64 < 128-element
+    # lane rule keeps inputs on the VMEM-resident block_spec path).
+    configs = [(2, 32, 1024, 64)]
+    if num_shapes is not None:
+        configs = configs[:num_shapes]
+    out: list[tuple[str, tuple[Any, ...]]] = []
+    for b, h, t, d in configs:
+        q = torch.randn(b, h, t, d, device=DEVICE, dtype=torch.float16)
+        k = torch.randn(b, h, t, d, device=DEVICE, dtype=torch.float16)
+        v = torch.randn(b, h, t, d, device=DEVICE, dtype=torch.float16)
+        out.append((f"[{b},{h},{t},{d}]", (q, k, v)))
+    return out
+
+
+def _xsa_baseline(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+    # Lazy import so collection works without torch_tpu present at module
+    # load. ref_xsa is the manual matmul+softmax+epilogue reference; matches
+    # what test_examples checks against.
+    from examples.xsa import ref_xsa
+
+    return ref_xsa(q, k, v)
+
+
 # Kernel mappings for TPU/Pallas benchmarks.
 # Format: kernel_name -> (module_file, kernel_fn_name, baseline_fn, shapes_fn,
 #                         max_mismatch_pct)
@@ -1047,6 +1074,13 @@ KERNEL_MAPPINGS: dict[str, KernelMapping] = {
         "matmul_bias_residual_gelu_cast",
         _epilogue_subtiling_residual_gelu_baseline,
         _epilogue_subtiling_shapes,
+        None,
+    ),
+    "xsa": (
+        "xsa",
+        "xsa_kernel",
+        _xsa_baseline,
+        _xsa_shapes,
         None,
     ),
 }

--- a/benchmarks/run_tpu.py
+++ b/benchmarks/run_tpu.py
@@ -828,10 +828,11 @@ def _kl_div_shapes(
 def _xsa_shapes(
     num_shapes: int | None = None,
 ) -> list[tuple[str, tuple[Any, ...]]]:
-    # (B, H, T, D). One shape only: larger shapes default-config-OOM the
-    # scoped VMEM at this kernel's structure (head_dim=64 < 128-element
-    # lane rule keeps inputs on the VMEM-resident block_spec path).
-    configs = [(2, 32, 1024, 64)]
+    # (B, H, T, D). head_dim=256 matches production TPU attention workloads
+    # (matches `flash_attention` in the sweep) and sidesteps a Mosaic
+    # "Invalid vector type for load" bug that the autotune-baseline path
+    # hit at head_dim=64.
+    configs = [(2, 32, 1024, 256), (4, 32, 2048, 256)]
     if num_shapes is not None:
         configs = configs[:num_shapes]
     out: list[tuple[str, tuple[Any, ...]]] = []

--- a/examples/xsa.py
+++ b/examples/xsa.py
@@ -50,6 +50,13 @@ import helion.language as hl
 @helion.kernel(
     # Static shapes provides a speedup for attention.
     static_shapes=True,
+    # Use the manual matmul+softmax reference as autotune's correctness anchor.
+    # Otherwise `_compute_baseline` compiles Helion's default config, which OOMs
+    # VMEM on TPU at large shapes (V is left as a VMEM ref because of the
+    # outer-scope epilogue read, forcing a full-tensor BlockSpec). Wrap in a
+    # lambda so the `ref_xsa` name is looked up at call time (it's defined
+    # further down the file).
+    autotune_baseline_fn=lambda q, k, v, eps=1e-6: ref_xsa(q, k, v, eps),
 )
 def xsa_kernel(
     q_in: torch.Tensor,


### PR DESCRIPTION
## Summary

Adds `xsa` (fused exclusive self-attention from `examples/xsa.py`) to `benchmarks/run_tpu.py::KERNEL_MAPPINGS` so the full TPU sweep covers it. Two shapes at head_dim=256 (aligned with the sweep's `flash_attention` row):

| Shape | Baseline |
|---|---|
| `[B=2, H=32, T=1024, D=256]` | `examples.xsa.ref_xsa` |
| `[B=4, H=32, T=2048, D=256]` | `examples.xsa.ref_xsa` |

## Why `head_dim=256` (up from the example's default of 64)

The autotune-baseline path at `head_dim=64` hit a Mosaic *"Invalid vector type for load"* codegen mismatch in `_compute_baseline`. `head_dim=256` sidesteps this — 256 is aligned to the 128-lane MXU tile, and the specific vector-type pattern doesn't recur. `head_dim=256` also matches the head dim used by `flash_attention` in the same sweep so the two rows are directly comparable. The xsa kernel itself is head_dim-generic (`hl.specialize(q_in.size(-1))`), so this is purely a benchmark-config change.

## Why `autotune_baseline_fn=ref_xsa`

At these shapes, Helion's default heuristic config for `xsa_kernel` estimates 134 MB scoped VMEM — over TPU v7's 64 MB cap. Autotune's `_compute_baseline` compiles that default config as its correctness anchor and dies before exploring any candidate. Wiring `autotune_baseline_fn=lambda q, k, v, eps=1e-6: ref_xsa(q, k, v, eps)` decouples the anchor from the default-config compile, so autotune is free to discover a config that actually fits VMEM.

Root cause (out of scope for this PR): xsa reads V twice — inside the inner K-loop under `emit_pipeline` (V read #1) and again in the outer epilogue (V read #2 for the L2-normalize / subtract). `_classify_pipelined_tensors` sees the outer-scope epilogue access and refuses to move V to an HBM ref (Pallas can't `pl.ds` an HBM ref), so V gets a VMEM BlockSpec. With `_block_spec_info=(16, None, None)` the `None` dims expand to the full tensor `(16, 8192, 256)` = 64 MB, and the estimator's ×2 double-buffer bump lands at 134 MB. Follow-up codegen fix is to tighten the BlockSpec when the outer-scope access is a block-slice keyed to the outer grid coord; once that lands, this `autotune_baseline_fn` override can be dropped.

## Verification

Full autotune verified on TPU v7:
- `[2,32,1024,256]`: 225 s, best `block_sizes=[4,256,1024]` unroll `pb=False`, Helion median **0.508 ms**
- `[4,32,2048,256]`: 257 s, best `block_sizes=[2,1024,1024]` unroll `pb=False`, Helion median **1.332 ms**

`test/test_examples.py::TestExamples::test_xsa` and `test_xsa_near_zero_v` pass under Pallas.
