### PR TITLE
Fix Pyrefly bad-override in _dynamo call_function for torch nightly

### DIFF
--- a/helion/_compiler/_dynamo/variables.py
+++ b/helion/_compiler/_dynamo/variables.py
@@ -28,7 +28,7 @@ from helion.runtime.kernel import Kernel
 _SYM_SCALAR_TYPES = (torch.SymInt, torch.SymFloat)
 
 if TYPE_CHECKING:
-    from torch._dynamo.symbolic_convert import InstructionTranslator
+    from torch._dynamo.symbolic_convert import InstructionTranslatorBase
 
 
 def _detect_mutated_inputs(body: list[ast.stmt], param_names: set[str]) -> list[str]:
@@ -326,7 +326,7 @@ class HelionKernelVariable(VariableTracker):
 
     def call_function(
         self,
-        tx: InstructionTranslator,
+        tx: InstructionTranslatorBase,
         args: Sequence[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:


### PR DESCRIPTION
## What

Lint (Pyrefly) is failing on `main` — e.g. [run 28606369098](https://github.com/pytorch/helion/actions/runs/28606369098):

```
ERROR Class member `HelionKernelVariable.call_function` overrides parent class
`VariableTracker` in an inconsistent manner [bad-override]
   --> helion/_compiler/_dynamo/variables.py:327:9
```

## Root cause

Not a Helion code change — an upstream **PyTorch nightly** signature change. PyTorch widened `VariableTracker.call_function`'s `tx` parameter from `InstructionTranslator` to the base `InstructionTranslatorBase` (and widened the `_call_function_and_unflatten_output` helper the same way).

`HelionKernelVariable.call_function` kept the narrower `InstructionTranslator`. Narrowing a parameter in an override violates Liskov substitution (parameters must be the same or wider), so Pyrefly flags `[bad-override]`.

## Fix

Widen the override's `tx` annotation to `InstructionTranslatorBase` to match the parent contract. Annotation-only change (lazy via `from __future__ import annotations`), so there is no runtime effect. `args: Sequence[VariableTracker]` is left as-is — it is already wider than the parent's `list[...]`, a valid contravariant widening.

## Verification

Reproduced CI locally with **torch `2.14.0.dev20260702+cu130`** (the nightly from the CI run date) + **pyrefly `1.1.1`** (CI's pinned version):

- Original signature (`InstructionTranslator`) → reproduces the exact CI `bad-override` at `variables.py:327:9`.
- This fix (`InstructionTranslatorBase`) → **0 errors**.

`ruff check` and `ruff format --check` also pass.