### PR TITLE
[autotuner] scope 32-finalist final rebenchmark to cute; restore top_k=8 elsewhere

### DIFF
--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -77,7 +77,12 @@ def _warn_dataset_without_log(log: AutotuningLogger) -> None:
 _SUSPICIOUS_REBENCHMARK_WARMUP = 25
 _SUSPICIOUS_REBENCHMARK_REP = 100
 _FINAL_REBENCHMARK_TOP_K_ENV = "HELION_AUTOTUNE_FINAL_REBENCHMARK_TOP_K"
-_FINAL_REBENCHMARK_TOP_K_DEFAULT = 32
+_FINAL_REBENCHMARK_TOP_K_DEFAULT = 8
+# The cute/flash-attention search surface has a wide config space where verifying
+# more finalists materially improves the final pick. Other backends do not need
+# the extra rebenchmark cost (it ~2.5x'd autotune wall-time on cheap kernels), so
+# the larger finalist set is scoped to cute only.
+_FINAL_REBENCHMARK_TOP_K_CUTE = 32
 _FINAL_REBENCHMARK_TARGET_MS_ENV = "HELION_AUTOTUNE_FINAL_REBENCHMARK_TARGET_MS"
 _FINAL_REBENCHMARK_TARGET_MS_DEFAULT = 5000.0
 _FINAL_REBENCHMARK_TARGET_MS_MAX = 60000.0
@@ -1117,18 +1122,25 @@ class PopulationBasedSearch(BaseSearch):
         for config in configs:
             self.pin_finalist_config(config)
 
+    def _final_rebenchmark_top_k_default(self) -> int:
+        backend_name = getattr(getattr(self, "config_spec", None), "backend_name", None)
+        if backend_name == "cute":
+            return _FINAL_REBENCHMARK_TOP_K_CUTE
+        return _FINAL_REBENCHMARK_TOP_K_DEFAULT
+
     def _final_rebenchmark_top_k(self) -> int:
+        default = self._final_rebenchmark_top_k_default()
         raw = os.getenv(_FINAL_REBENCHMARK_TOP_K_ENV)
         if raw is None:
-            return _FINAL_REBENCHMARK_TOP_K_DEFAULT
+            return default
         try:
             return max(0, int(raw))
         except ValueError:
             self.log.warning(
                 f"Ignoring invalid {_FINAL_REBENCHMARK_TOP_K_ENV}={raw!r}; "
-                f"using {_FINAL_REBENCHMARK_TOP_K_DEFAULT}."
+                f"using {default}."
             )
-            return _FINAL_REBENCHMARK_TOP_K_DEFAULT
+            return default
 
     def _final_rebenchmark_target_ms(self) -> float:
         raw = os.getenv(_FINAL_REBENCHMARK_TARGET_MS_ENV)

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -2703,6 +2703,27 @@ class TestAutotuner(RefEagerTestDisabled, TestCase):
         ):
             self.assertEqual(search._final_rebenchmark_pinned_tolerance(), 0.0)
 
+    def test_final_rebenchmark_top_k_default_scoped_to_cute(self) -> None:
+        settings = Settings(autotune_log_level=logging.CRITICAL)
+        search = PopulationBasedSearch.__new__(PopulationBasedSearch)
+        search.settings = settings
+        search.log = AutotuningLogger(settings)
+
+        with clean_final_rebenchmark_env():
+            # The larger finalist set is scoped to cute; other backends use the
+            # cheaper default so autotune wall-time is not inflated.
+            search.config_spec = SimpleNamespace(backend_name="cute")
+            self.assertEqual(search._final_rebenchmark_top_k(), 32)
+            search.config_spec = SimpleNamespace(backend_name="triton")
+            self.assertEqual(search._final_rebenchmark_top_k(), 8)
+            search.config_spec = SimpleNamespace(backend_name="pallas")
+            self.assertEqual(search._final_rebenchmark_top_k(), 8)
+
+        # An explicit env override wins regardless of backend.
+        with clean_final_rebenchmark_env(HELION_AUTOTUNE_FINAL_REBENCHMARK_TOP_K="2"):
+            search.config_spec = SimpleNamespace(backend_name="cute")
+            self.assertEqual(search._final_rebenchmark_top_k(), 2)
+
     def test_final_rebenchmark_prefers_faster_generated_config_by_default(
         self,
     ) -> None:


### PR DESCRIPTION
## What

`_FINAL_REBENCHMARK_TOP_K_DEFAULT` was raised from 8 → 32

## Impact (nightly benchmark dashboard)

softmax autotune/compile time jumped ~2.5× on **b200, h100, and tpu**
simultaneously on the Jun-24 nightly:

| platform | softmax compile_time | latency |
|---|---|---|
| b200 | 165s → **404s** (×2.5) | unchanged |
| h100 | → 971s | unchanged |
| tpu  | 41s → 114s | unchanged |

It was also a contributing factor to the mi350x softmax job exceeding the
6h CI budget.

## Fix

The wide finalist set is only motivated by the cute/flash-attention search
surface (wide config space), so scope 32 to `backend_name == "cute"` and
restore the cheaper 8 everywhere else. The
`HELION_AUTOTUNE_FINAL_REBENCHMARK_TOP_K` env override still wins for both.
