### PR TITLE
Scale mm cute m=16

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -2863,6 +2863,7 @@ def _detect_specialized_mma_loop(
     from .compile_environment import CompileEnvironment
     from .cute.cute_mma import _choose_mma_impl
     from .cute.cute_mma import _mma_active_n_threads
+    from .cute.cute_mma import _static_mma_shape
     from .cute.cute_mma import _tcgen05_root_m_threads
     from .cute.cute_mma import can_codegen_cute_mma_aten
     from .cute.cute_mma import can_codegen_cute_mma_dot
@@ -2953,13 +2954,27 @@ def _detect_specialized_mma_loop(
                 torch.ops.aten.baddbmm.default,
             ) and can_codegen_cute_mma_aten(node, with_acc=True):
                 lhs_node = node.args[1]
-                if not isinstance(lhs_node, torch.fx.Node):
+                rhs_node = node.args[2]
+                if not isinstance(lhs_node, torch.fx.Node) or not isinstance(
+                    rhs_node, torch.fx.Node
+                ):
                     continue
                 lhs_val = lhs_node.meta.get("val")
-                if not isinstance(lhs_val, torch.Tensor):
+                rhs_val = rhs_node.meta.get("val")
+                if not isinstance(lhs_val, torch.Tensor) or not isinstance(
+                    rhs_val, torch.Tensor
+                ):
                     continue
+                static_m, static_n, static_k = _static_mma_shape(lhs_val, rhs_val)
                 mma_impl = _choose_mma_impl(
-                    lhs_val.dtype, bm=bm, bn=bn, bk=bk, config=config
+                    lhs_val.dtype,
+                    bm=bm,
+                    bn=bn,
+                    bk=bk,
+                    static_m=static_m,
+                    static_n=static_n,
+                    static_k=static_k,
+                    config=config,
                 )
                 if mma_impl != "universal" and root_threads_support_impl(mma_impl):
                     return True
@@ -2970,13 +2985,27 @@ def _detect_specialized_mma_loop(
                 and can_codegen_cute_mma_dot(node)
             ):
                 lhs_node = node.args[0]
-                if not isinstance(lhs_node, torch.fx.Node):
+                rhs_node = node.args[1]
+                if not isinstance(lhs_node, torch.fx.Node) or not isinstance(
+                    rhs_node, torch.fx.Node
+                ):
                     continue
                 lhs_val = lhs_node.meta.get("val")
-                if not isinstance(lhs_val, torch.Tensor):
+                rhs_val = rhs_node.meta.get("val")
+                if not isinstance(lhs_val, torch.Tensor) or not isinstance(
+                    rhs_val, torch.Tensor
+                ):
                     continue
+                static_m, static_n, static_k = _static_mma_shape(lhs_val, rhs_val)
                 mma_impl = _choose_mma_impl(
-                    lhs_val.dtype, bm=bm, bn=bn, bk=bk, config=config
+                    lhs_val.dtype,
+                    bm=bm,
+                    bn=bn,
+                    bk=bk,
+                    static_m=static_m,
+                    static_n=static_n,
+                    static_k=static_k,
+                    config=config,
                 )
                 if mma_impl != "universal" and root_threads_support_impl(mma_impl):
                     return True
@@ -4918,6 +4947,7 @@ def _kernel_specialized_mma_impl(
     from ..language._decorators import is_api_func
     from .compile_environment import CompileEnvironment
     from .cute.cute_mma import _choose_mma_impl
+    from .cute.cute_mma import _static_mma_shape
     from .cute.cute_mma import can_codegen_cute_mma_aten
     from .cute.cute_mma import can_codegen_cute_mma_dot
     from .device_ir import ForLoopGraphInfo
@@ -4959,6 +4989,7 @@ def _kernel_specialized_mma_impl(
                 torch.ops.aten.baddbmm.default,
             ) and can_codegen_cute_mma_aten(node, with_acc=True):
                 lhs_node = node.args[1]
+                rhs_node = node.args[2]
             elif (
                 callable(node.target)
                 and is_api_func(node.target)
@@ -4966,15 +4997,29 @@ def _kernel_specialized_mma_impl(
                 and can_codegen_cute_mma_dot(node)
             ):
                 lhs_node = node.args[0]
+                rhs_node = node.args[1]
             else:
                 continue
-            if not isinstance(lhs_node, torch.fx.Node):
+            if not isinstance(lhs_node, torch.fx.Node) or not isinstance(
+                rhs_node, torch.fx.Node
+            ):
                 continue
             lhs_val = lhs_node.meta.get("val")
-            if not isinstance(lhs_val, torch.Tensor):
+            rhs_val = rhs_node.meta.get("val")
+            if not isinstance(lhs_val, torch.Tensor) or not isinstance(
+                rhs_val, torch.Tensor
+            ):
                 continue
+            static_m, static_n, static_k = _static_mma_shape(lhs_val, rhs_val)
             mma_impl = _choose_mma_impl(
-                lhs_val.dtype, bm=bm, bn=bn, bk=bk, config=config
+                lhs_val.dtype,
+                bm=bm,
+                bn=bn,
+                bk=bk,
+                static_m=static_m,
+                static_n=static_n,
+                static_k=static_k,
+                config=config,
             )
             if mma_impl != "universal":
                 return mma_impl

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -1375,10 +1375,24 @@ class BlockSizeInfo:
         with contextlib.suppress(KeyError):
             spec.block_sizes.block_id_lookup(self.block_id).update_min(value)
 
-    def update_max_block(self, value: int) -> None:
+    def update_max_block(self, value: int, *, allow_raise: bool = False) -> None:
+        """Constrain this block's autotune max size.
+
+        By default ``update_max`` can only *lower* the max (it is clamped to the
+        existing ``next_power_of_2(size_hint)`` ceiling). Pass ``allow_raise=True``
+        to instead allow raising the ceiling ABOVE the size hint -- needed for a
+        matmul M axis whose ``block_m`` may legally exceed the (tiny) static M and
+        run on a larger padded/masked tcgen05 tile. This is scoped to the matmul
+        M axis by its single caller in ``matmul_ops.py``; ordinary tile dims keep
+        the size-hint ceiling so the search space does not explode.
+        """
         spec = CompileEnvironment.current().config_spec
         with contextlib.suppress(KeyError):
-            spec.block_sizes.block_id_lookup(self.block_id).update_max(value)
+            block_spec = spec.block_sizes.block_id_lookup(self.block_id)
+            if allow_raise:
+                block_spec.raise_max(value)
+            else:
+                block_spec.update_max(value)
 
 
 class BlockSizeSource:

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -96,6 +96,7 @@ from .tcgen05_constants import TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
 from .tcgen05_constants import TCGEN05_TWO_CTA_EDGE_TMA_STORE_MAX_AB_STAGES
+from .tcgen05_constants import tcgen05_static_shape_eligible
 from .tcgen05_lifecycle import Tcgen05LifecycleContext
 from .tcgen05_pure_matmul import Tcgen05PureMatmulObjectModel
 
@@ -979,9 +980,17 @@ def prepare_cute_collective_lane_loop_suppression(
                     bk = int(bs)
         if bm is None or bn is None or bk is None:
             continue
+        static_m, static_n, static_k = _static_mma_shape(lhs_fake, rhs_fake)
         if (
             _choose_mma_impl(
-                lhs_fake.dtype, bm=bm, bn=bn, bk=bk, config=cg.device_function.config
+                lhs_fake.dtype,
+                bm=bm,
+                bn=bn,
+                bk=bk,
+                static_m=static_m,
+                static_n=static_n,
+                static_k=static_k,
+                config=cg.device_function.config,
             )
             != "tcgen05"
         ):
@@ -1976,7 +1985,16 @@ def _emit_mma_pipeline(
             f"pid_type={TCGEN05_LARGE_BN_PROOF_PID_TYPE!r}",
         )
 
-    mma_impl = _choose_mma_impl(input_dtype, bm=bm, bn=bn, bk=bk, config=df.config)
+    mma_impl = _choose_mma_impl(
+        input_dtype,
+        bm=bm,
+        bn=bn,
+        bk=bk,
+        static_m=m_size,
+        static_n=n_size,
+        static_k=k_total_size,
+        config=df.config,
+    )
     zero_acc_expr = acc_expr is not None and _is_zero_acc_expr(acc_expr)
     if (
         not zero_acc_expr
@@ -5270,6 +5288,35 @@ def _tcgen05_epi_warp_count(
     return min(cta_warp_count, max(1, warp_spec.epi_warps))
 
 
+def _static_mma_dim(dim: object) -> int | None:
+    """Return a shape dim as a concrete int, or None for a dynamic (symbolic) one.
+
+    A ``None`` extent means a dynamic shape and leaves tcgen05 eligible (the
+    config-spec resolves a size hint in that case), matching
+    ``tcgen05_static_shape_eligible``.
+    """
+    return dim if isinstance(dim, int) else None
+
+
+def _static_mma_shape(
+    lhs_fake: torch.Tensor, rhs_fake: torch.Tensor
+) -> tuple[int | None, int | None, int | None]:
+    """Static (real problem) M, N, K of a matmul, each None if dynamic.
+
+    Used to gate tcgen05 MMA-impl selection on the same static extents the
+    autotune config-spec uses to register the ``tcgen05_*`` keys (so the two
+    can never diverge). Indexes from the trailing dims so batched operands
+    (baddbmm ``[B, M, K]`` / ``[B, K, N]``) resolve the same way as plain 2D:
+    M = LHS ``[-2]``, K = LHS ``[-1]``, N = RHS ``[-1]``.
+    """
+    if lhs_fake.ndim < 2 or rhs_fake.ndim < 2:
+        return None, None, None
+    static_m = _static_mma_dim(lhs_fake.shape[-2])
+    static_k = _static_mma_dim(lhs_fake.shape[-1])
+    static_n = _static_mma_dim(rhs_fake.shape[-1])
+    return static_m, static_n, static_k
+
+
 def _mma_impl_matches_problem_shape(
     mma_impl: str,
     input_dtype: torch.dtype,
@@ -5277,11 +5324,27 @@ def _mma_impl_matches_problem_shape(
     bm: int,
     bn: int,
     bk: int,
+    static_m: int | None = None,
+    static_n: int | None = None,
+    static_k: int | None = None,
     tcgen05_cluster_m: int = 1,
     tcgen05_large_bn_proof: bool = False,
 ) -> bool:
     if mma_impl == "universal":
         return True
+    # The autotune config-spec only registers the ``tcgen05_*`` config keys for
+    # static (real problem) shapes that pass ``tcgen05_static_shape_eligible``
+    # (see ``matmul_ops.py`` eligibility gate). ``block_m``/``block_n`` can
+    # legally exceed the static M/N for tiny GEMMs (e.g. M=16/32 with
+    # block_m=128), so selecting tcgen05 on block size alone would commit
+    # codegen to a path whose config keys were never registered -> hard
+    # ``KeyError`` in ``_emit_mma_pipeline``. Gate tcgen05 on the same shared
+    # predicate so codegen and config-spec can never diverge; below it, fall
+    # back to warp/universal.
+    if mma_impl == "tcgen05" and not tcgen05_static_shape_eligible(
+        input_dtype, static_m=static_m, static_n=static_n, static_k=static_k
+    ):
+        return False
     is_fp8 = input_dtype == torch.float8_e4m3fn
     if (
         input_dtype not in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
@@ -5344,6 +5407,9 @@ def _choose_mma_impl(
     bm: int,
     bn: int,
     bk: int,
+    static_m: int | None = None,
+    static_n: int | None = None,
+    static_k: int | None = None,
     config: object | None = None,
 ) -> str:
     tcgen05_cluster_m = 1
@@ -5367,6 +5433,9 @@ def _choose_mma_impl(
             bm=bm,
             bn=bn,
             bk=bk,
+            static_m=static_m,
+            static_n=static_n,
+            static_k=static_k,
             tcgen05_cluster_m=tcgen05_cluster_m,
             tcgen05_large_bn_proof=tcgen05_large_bn_proof,
         ):
@@ -5378,6 +5447,9 @@ def _choose_mma_impl(
         bm=bm,
         bn=bn,
         bk=bk,
+        static_m=static_m,
+        static_n=static_n,
+        static_k=static_k,
         tcgen05_cluster_m=tcgen05_cluster_m,
         tcgen05_large_bn_proof=tcgen05_large_bn_proof,
     ):
@@ -6218,11 +6290,15 @@ def codegen_cute_mma_direct_mm(
     if load_plan is None:
         return None
 
+    static_m, static_n, static_k = _static_mma_shape(lhs_fake, rhs_fake)
     mma_impl = _choose_mma_impl(
         lhs_fake.dtype,
         bm=plan.bm,
         bn=plan.bn,
         bk=plan.bk,
+        static_m=static_m,
+        static_n=static_n,
+        static_k=static_k,
         config=ctx.cg.device_function.config,
     )
     # The grouped-N direct path only emits warp MMA. Auto-selection prefers

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -2051,6 +2051,14 @@ def _emit_mma_pipeline(
         and n_size % bn == 0
         and k_total_size % bk == 0
     )
+    # The leaner SIMT-store optimization (drop the full-tile fast path, emit a
+    # single M-only predicated copy) is only valid when there is exactly ONE
+    # padded M tile -- i.e. the real M does not even fill one ``bm`` tile, so the
+    # full-tile predicate ``m_offset + bm <= m_size`` is statically unsatisfiable.
+    # When ``m_size > bm`` (multiple M tiles, the last one partial) the first M
+    # tile IS a genuine full tile and must keep its unpredicated vectorized store,
+    # so only the load-side TMA relaxation (``tcgen05_flat_m_edge_tma``) applies.
+    tcgen05_flat_m_edge_single_tile = tcgen05_flat_m_edge_tma and m_size <= bm
     tcgen05_double_edge_tma = (
         mma_impl == "tcgen05"
         and tcgen05_use_tma_pipeline
@@ -5143,6 +5151,7 @@ def _emit_mma_pipeline(
                 use_tma_store_epilogue=tcgen05_use_tma_store_epilogue,
                 tma_store_full_tiles_only=tcgen05_tma_store_full_tiles_only,
                 partial_output_tma_store=tcgen05_partial_output_tma_store,
+                flat_m_edge=tcgen05_flat_m_edge_single_tile,
                 # Mirror the value passed to `_make_tcgen05_layout_plan_setup`
                 # above; the store path compares this against `target_dtype`
                 # to enforce the kernel/store equality contract on

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -2506,6 +2506,42 @@ def _emit_mma_pipeline(
         or tcgen05_role_local_n_edge_tma
         or tcgen05_role_local_double_edge_tma
     ) and tcgen05_output_edge_tma_store_fits_smem
+    # Flat (cluster_m=1, non-persistent) tiny-M single padded tile: route the
+    # padded-M output store through the SAME coalesced SMEM-staged TMA bulk
+    # store the static-full flat path uses (T2R -> R2S into the C-ring SMEM ->
+    # ``cute.copy(CopyBulkTensorTileS2GOp, sD, gD)`` via PipelineTmaStore),
+    # instead of the uncoalesced per-thread register->global predicated SIMT
+    # store. The host TMA-store descriptor is built from the REAL output shape
+    # (``arg{d_idx}.shape``; see ``append_tcgen05_epilogue_tma_wrapper``), so the
+    # bulk store of the bm-row box at tile origin is HARDWARE bounds-clamped to
+    # the real ``m_size`` rows -- the partial M rows are never written OOB, with
+    # zero device-side row predicate. This is the exact OOB-suppression the
+    # ``tcgen05_partial_output_tma_store`` aux-TMA edge family already relies on
+    # (CuTe TMA descriptor bounds checks), applied to the no-aux flat tiny-M
+    # case. Gated to the single-padded-tile envelope (``m_size <= bm``, N%bn==0,
+    # K%bk==0, cluster_n in {1,2}, CtaGroup.ONE) where there is no genuine full
+    # M tile to regress, and to the same AB-stage SMEM budget as the role-local
+    # edge TMA store.
+    #
+    # SMEM budget: this flat one-CTA padded tile has the IDENTICAL epilogue SMEM
+    # footprint as the flat static-full path (same bm x bn block, same AB-stage
+    # count, same C-stage count, same ``make_smem_layout_epi`` D buffer), which
+    # is already validated at this shape and AB-stage count (the M=64 / M%bm==0
+    # case at the same block_sizes/ab_stages reaches the static-full TMA-store
+    # epilogue). The ``tcgen05_output_edge_tma_store_fits_smem`` cap is the
+    # 2-CTA output-edge family's separate, more constrained budget (extra D tile
+    # alongside larger 2-CTA AB stages) and does NOT bound this one-CTA path.
+    # Measured on B200: the SMEM-staged TMA-store epilogue beats the predicated
+    # SIMT register->global store for padded tiles with m_size >= 32 (it removes
+    # the uncoalesced SIMT stores whose count grows with real M), but its
+    # staging/pipeline setup is NOT amortized at the very smallest m_size=16,
+    # where the SIMT store is faster. Gate the TMA store on m_size >= 32 so the
+    # tiniest-M tile keeps the cheaper SIMT store.
+    tcgen05_flat_m_edge_tma_store = (
+        tcgen05_flat_m_edge_single_tile
+        and not tcgen05_is_two_cta
+        and m_size >= 32
+    )
     # Flat kernels process one output tile per CTA, so the c_pipeline stage is
     # just the subtile index. Persistent kernels use a role-local tile counter
     # to rotate c_pipeline stages across work tiles. Static-full CtaGroup.TWO
@@ -2521,6 +2557,7 @@ def _emit_mma_pipeline(
             tcgen05_static_full_tiles
             or tcgen05_role_local_k_tail_tma
             or tcgen05_use_output_edge_tma_store_for_full_tiles
+            or tcgen05_flat_m_edge_tma_store
         )
         and tcgen05_role_local_codegen_allowed
         and (not _is_persistent_pid_config(df.config) or tcgen05_use_role_local_epi)
@@ -3825,7 +3862,22 @@ def _emit_mma_pipeline(
                 # enabled for the output-edge family, which routes partial tiles
                 # through either the full/edge split or the bounds-checked
                 # partial-output TMA-store path.
-                tma_store_handles_partial_tiles = tcgen05_use_tma_store_epilogue
+                #
+                # The flat-M-edge TMA store (``tcgen05_flat_m_edge_tma_store``)
+                # is deliberately EXCLUDED here: it is validated only for the
+                # no-aux and SIMT-predicated-aux store paths (the aux M-row
+                # predicate in ``_codegen_cute_store_tcgen05_tile`` masks the
+                # padded rows of an exact-shape rank-2 aux read). Letting it set
+                # ``tma_store_handles_partial_tiles`` would suppress the
+                # ``aux_load_mode=tma`` + partial-output rejection below and
+                # silently route a TMA-staged aux through an uncovered combo.
+                # Keep that rejection firing exactly as on the SIMT-store
+                # baseline; the flat tiny-M store optimization does not depend on
+                # aux-TMA.
+                tma_store_handles_partial_tiles = (
+                    tcgen05_use_tma_store_epilogue
+                    and not tcgen05_flat_m_edge_tma_store
+                )
                 aux_tma_needs_edge_routing = (
                     tcgen05_aux_tma_requested
                     and not tcgen05_static_output_tiles

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -2110,6 +2110,25 @@ def _emit_mma_pipeline(
         and not tcgen05_pid_is_persistent
         and tcgen05_cluster_m == 1
     )
+    # For the single-padded-M-tile flat edge case the per-K full-tile predicate
+    # ``tcgen05_tma_full_tile`` is statically TRUE on every launched tile and K
+    # iteration: M is a single tile so ``m_offset`` is always 0 (``0 < m_size``),
+    # N divides ``bn`` (and ``2*bn`` under the N-only cluster) so every launched
+    # N tile is full, and K divides ``bk`` (``flat_m_edge_tma`` requires
+    # ``k_total_size % bk == 0``) so every K iter is full. The TMA descriptor is
+    # built with the real ``m_size`` and bounds-clamps the padded A stripe, so
+    # TMA carries the WHOLE mainloop. The per-K ``else:`` scalar-AB-fallback
+    # branch (a 4096/8192-element predicated scalar load loop) plus its two extra
+    # in-loop ``sync_threads()`` barriers are therefore provably DEAD code that
+    # only adds control flow and barrier stalls to the hot K-loop. Suppress that
+    # dead ``else`` emission while keeping the ``if tcgen05_tma_full_tile:`` taken
+    # path -- producer TMA (incl. the cluster_n=2 A multicast), consumer wait,
+    # MMA issue, and consumer release -- byte-identical. This does NOT switch to
+    # ``tcgen05_static_full_tma_fast_path`` (which drops the full-tile wrapper and
+    # is gated on ``tcgen05_static_full_tiles``, false here), so it leaves
+    # ``tcgen05_mixed_tma_scalar_fallback`` / the TMA-keep guard / the N-only
+    # A-multicast cluster (``tcgen05_n_only_cluster``) all untouched.
+    tcgen05_flat_m_edge_no_scalar_fallback = tcgen05_flat_m_edge_single_tile
     tcgen05_edge_scalar_fallback_needs_inter_smem_a = (
         tcgen05_mixed_tma_scalar_fallback
         and bk >= 128
@@ -2538,9 +2557,7 @@ def _emit_mma_pipeline(
     # where the SIMT store is faster. Gate the TMA store on m_size >= 32 so the
     # tiniest-M tile keeps the cheaper SIMT store.
     tcgen05_flat_m_edge_tma_store = (
-        tcgen05_flat_m_edge_single_tile
-        and not tcgen05_is_two_cta
-        and m_size >= 32
+        tcgen05_flat_m_edge_single_tile and not tcgen05_is_two_cta and m_size >= 32
     )
     # Flat kernels process one output tile per CTA, so the c_pipeline stage is
     # just the subtile index. Persistent kernels use a role-local tile counter
@@ -3875,8 +3892,7 @@ def _emit_mma_pipeline(
                 # baseline; the flat tiny-M store optimization does not depend on
                 # aux-TMA.
                 tma_store_handles_partial_tiles = (
-                    tcgen05_use_tma_store_epilogue
-                    and not tcgen05_flat_m_edge_tma_store
+                    tcgen05_use_tma_store_epilogue and not tcgen05_flat_m_edge_tma_store
                 )
                 aux_tma_needs_edge_routing = (
                     tcgen05_aux_tma_requested
@@ -5030,10 +5046,12 @@ def _emit_mma_pipeline(
                             tma_kloop_args,
                             include_scalar_fallback=(
                                 not tcgen05_static_full_tma_fast_path
+                                and not tcgen05_flat_m_edge_no_scalar_fallback
                             ),
                             sync_before_scalar_fallback=(
                                 tcgen05_sync_before_scalar_fallback
                                 and not tcgen05_static_full_tma_fast_path
+                                and not tcgen05_flat_m_edge_no_scalar_fallback
                             ),
                         )
                     )
@@ -5146,6 +5164,7 @@ def _emit_mma_pipeline(
                                 tma_kloop_args,
                                 include_scalar_fallback=(
                                     not tcgen05_static_full_tma_fast_path
+                                    and not tcgen05_flat_m_edge_no_scalar_fallback
                                 ),
                             )
                         )

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -1070,6 +1070,13 @@ class _PerKiterTmaArgs:
     # (cute_plan.md §6.12.7). Default 1 preserves byte-identity for the
     # validated cluster_m=2 cluster_n=1 path.
     cluster_n: int = 1
+    # When True the A ``cute.copy`` passes ``mcast_mask`` even though this is
+    # not a two-cta loop. Set by the N-only CtaGroup.ONE A-multicast cluster
+    # (cluster_m=1, cluster_n=2), where A is multicast across the 2 N-CTAs but
+    # the mainloop stays flat / owner-ungated. Defaults False so all existing
+    # non-cluster and two-cta call sites keep their byte-identical emission
+    # (the two-cta path drives the A mask via ``is_two_cta`` below).
+    use_tma_a_mcast_mask: bool = False
     # Static-full one-CTA pipelined TMA loops can drop the per-K runtime
     # full-tile branch and scalar fallback. Non-pipelined/asymmetric or two-CTA
     # TMA paths must keep the guarded fallback path.
@@ -1084,7 +1091,8 @@ def _kloop_tma_copy_a_src(args: _PerKiterTmaArgs, *, k_offset: str) -> str:
     """
     if not args.use_tma_a:
         return ""
-    mcast = f", mcast_mask={args.tma_a_mcast_mask}" if args.is_two_cta else ""
+    a_mcast = args.is_two_cta or args.use_tma_a_mcast_mask
+    mcast = f", mcast_mask={args.tma_a_mcast_mask}" if a_mcast else ""
     return (
         f"    cute.copy({args.tma_atom_a}, "
         f"{args.tma_gA}[None, {k_offset}], "
@@ -1530,6 +1538,10 @@ class _InitialPrefetchTmaArgs:
     use_tma_b_mcast_mask: bool
     skip_producer_acquire: bool
     skip_producer_advance: bool
+    # See ``_PerKiterTmaArgs.use_tma_a_mcast_mask``: drives the A multicast for
+    # the N-only CtaGroup.ONE cluster. Defaults False so two-cta and
+    # non-cluster prefetch call sites stay byte-identical.
+    use_tma_a_mcast_mask: bool = False
 
 
 def _initial_prefetch_copy_a_src(
@@ -1542,7 +1554,8 @@ def _initial_prefetch_copy_a_src(
     ``test_mcast_mask_asymmetry_between_a_and_b`` for the per-K-iter
     builders.
     """
-    mcast = f", mcast_mask={args.tma_a_mcast_mask}" if args.is_two_cta else ""
+    a_mcast = args.is_two_cta or args.use_tma_a_mcast_mask
+    mcast = f", mcast_mask={args.tma_a_mcast_mask}" if a_mcast else ""
     return (
         f"    cute.copy({args.tma_atom_a}, "
         f"{args.tma_gA}[None, {k_offset}], "
@@ -2046,7 +2059,11 @@ def _emit_mma_pipeline(
         and tcgen05_use_tma_pipeline
         and not tcgen05_pid_is_persistent
         and tcgen05_cluster_m == 1
-        and tcgen05_cluster_n_requested == 1
+        # cluster_n=1 is the plain flat path; cluster_n=2 is the N-only
+        # A-multicast cluster, which keeps the identical flat M-edge
+        # output-tile predicate (each CTA still owns one bm x bn tile and
+        # masks the padded M rows). The cluster only changes the A TMA load.
+        and tcgen05_cluster_n_requested in (1, 2)
         and m_size % bm != 0
         and n_size % bn == 0
         and k_total_size % bk == 0
@@ -2191,19 +2208,56 @@ def _emit_mma_pipeline(
     # this validated pairing demote to cluster_n=1 instead of throwing —
     # explicit user configs hit the BackendUnsupported gate, and autotune
     # stays narrowed to the validated subset.
+    # cluster_n=2 has two validated codegen envelopes:
+    #   1. cluster_m=2, use_2cta=True (V=2): the canonical Quack 4-CTA cluster.
+    #   2. cluster_m=1, CtaGroup.ONE: the N-only A-multicast cluster for the
+    #      tiny-M padded tcgen05 fp8 path. Two CTAs each own their own N output
+    #      tile and run the flat (non-persistent, monolithic) mainloop
+    #      independently; the cluster exists ONLY to TMA-multicast the shared A
+    #      operand along the N axis. This mirrors torch's ``_scaled_mm`` CUTLASS
+    #      ClusterShape<1,2,1> selection at M<=64,N>=3072 and is the right lever
+    #      for the memory-bound tiny-M shape (cluster_m=2 has nothing to share
+    #      along M). See cute_plan.md §6.12 for envelope 1.
+    # Restricted to a SINGLE M-tile (``m_size <= bm``): the flat grid maps
+    # consecutive grid_x ids to adjacent N-tiles of m_tile 0, so a 2-CTA
+    # cluster along grid_x always pairs two N-tiles that share the SAME A
+    # rows. With multiple M-tiles a cluster pair could straddle an
+    # m_tile boundary (different A rows), and each CTA's multicast A copy
+    # would clobber its peer's SMEM A -> wrong output. The target tiny-M
+    # shapes (M<=64 on a 64/128-row tile) are exactly the single-M-tile
+    # case, which is also what torch's _scaled_mm pads M to.
+    tcgen05_n_only_cluster = (
+        mma_impl == "tcgen05"
+        and tcgen05_cluster_n_requested == 2
+        and tcgen05_cluster_m == 1
+        and not tcgen05_requested_two_cta
+        and tcgen05_use_tma_pipeline
+        and not tcgen05_pid_is_persistent
+        and m_size <= bm
+        and n_size % (bn * tcgen05_cluster_n_requested) == 0
+        and k_total_size % bk == 0
+    )
     if tcgen05_cluster_n_requested > 1 and not (
-        mma_impl == "tcgen05" and tcgen05_is_two_cta and tcgen05_cluster_m == 2
+        (mma_impl == "tcgen05" and tcgen05_is_two_cta and tcgen05_cluster_m == 2)
+        or tcgen05_n_only_cluster
     ):
         if mma_impl == "tcgen05" and tcgen05_cluster_n_requested == 2:
             raise exc.BackendUnsupported(
                 "cute",
-                "tcgen05_cluster_n=2 requires tcgen05_cluster_m=2 with "
-                "use_2cta=True (bm=256). See cute_plan.md §6.12 for the "
-                "validated 4-CTA cluster envelope.",
+                "tcgen05_cluster_n=2 requires either tcgen05_cluster_m=2 with "
+                "use_2cta=True (bm=256, the 4-CTA cluster; cute_plan.md §6.12) "
+                "or tcgen05_cluster_m=1 with a flat non-persistent TMA pipeline "
+                "and an N extent divisible by 2*block_n (the N-only A-multicast "
+                "cluster). For the latter K must divide block_k.",
             )
         tcgen05_cluster_n = 1
     else:
         tcgen05_cluster_n = tcgen05_cluster_n_requested
+    # The N-only cluster reuses the same per-CTA multicast machinery as the
+    # 2-CTA path for A (mcast atom + mask + cta-layout slices + arrive count),
+    # but keeps the flat owner-ungated mainloop: each CTA is its own MMA owner
+    # (CtaGroup.ONE => every CTA is a cluster leader), so no V-leader gating.
+    tcgen05_a_mcast_cluster = tcgen05_is_two_cta or tcgen05_n_only_cluster
     tcgen05_role_local_k_tail_tma = (
         tcgen05_preserve_tma_for_two_cta_k_tail
         and tcgen05_is_two_cta
@@ -2722,7 +2776,20 @@ def _emit_mma_pipeline(
     mma_physical_m_threads = _grid_thread_extent(cg, m_block_id)
     tcgen05_cta_thread_count = _grid_cta_thread_count(cg)
     if mma_impl == "tcgen05" and tcgen05_cluster_m * tcgen05_cluster_n > 1:
-        df.cute_state.cluster_shape = (tcgen05_cluster_m, tcgen05_cluster_n, 1)
+        # The launch cluster dims map (m, n, k) -> physical grid (x, y, z).
+        # The persistent two-cta paths lay the grid out so cluster_m clusters
+        # along grid_x (e.g. (2,1,1)) and cluster_n along grid_y. The N-only
+        # flat path uses a SINGLE flat grid dimension (grid_x = total tiles,
+        # grid_y=grid_z=1) with consecutive grid_x tiles being adjacent
+        # N-tiles of the one M-tile, so its 2-CTA cluster must run ALONG
+        # grid_x: launch cluster (cluster_n, 1, 1). The kernel-internal
+        # cluster_layout_vmnk stays the logical (cluster_m, cluster_n, 1) =
+        # (1, 2, 1) so the A mcast mask (mode 2 = N) and block_idx_in_cluster
+        # -> N-coord mapping remain correct.
+        if tcgen05_n_only_cluster:
+            df.cute_state.cluster_shape = (tcgen05_cluster_n, 1, 1)
+        else:
+            df.cute_state.cluster_shape = (tcgen05_cluster_m, tcgen05_cluster_n, 1)
     tcgen05_acc_stage_count_value = _tcgen05_config_int(
         df.config, "tcgen05_acc_stages", _tcgen05_acc_stage_count(bn)
     )
@@ -2743,10 +2810,15 @@ def _emit_mma_pipeline(
     #   - cluster_m=2 cluster_n=2 V=2: 2 + 1 - 1 = 2 (the cluster_n=2 fix)
     #   - cluster_m=1 cluster_n=1 V=1 (no use_2cta): 1 (collapses to single
     #     CTA; no multicast)
-    if tcgen05_is_two_cta and tcgen05_cluster_n > 1:
+    #   - cluster_m=1 cluster_n=2 V=1 (N-only CtaGroup.ONE A-multicast):
+    #     num_mcast_ctas_a = cluster_n = 2, num_mcast_ctas_b = cluster_m / 1 =
+    #     1 -> 2 + 1 - 1 = 2. Both N-CTAs receive the multicast A and each
+    #     arrives once on the AB empty barrier; the producer waits for 2.
+    if (tcgen05_is_two_cta or tcgen05_n_only_cluster) and tcgen05_cluster_n > 1:
         # V=2 absorbs cluster_m into the cluster_layout_vmnk V dim; the
         # post-V CTAs along M (= cluster_m // V) carry the B multicast,
-        # while cluster_n CTAs along N carry the A multicast.
+        # while cluster_n CTAs along N carry the A multicast. CtaGroup.ONE
+        # keeps V=1, so cluster_m // V = cluster_m.
         v_for_mcast = 2 if tcgen05_is_two_cta else 1
         num_mcast_ctas_a = tcgen05_cluster_n
         num_mcast_ctas_b = max(1, tcgen05_cluster_m // v_for_mcast)
@@ -4160,6 +4232,10 @@ def _emit_mma_pipeline(
             tcgen05_use_tma_b_mcast_mask = (
                 tcgen05_use_tma_b_peer_mcast or tcgen05_use_tma_b_self_mcast
             )
+            # The N-only CtaGroup.ONE cluster (cluster_m=1, cluster_n=2)
+            # multicasts ONLY A across its 2 N-CTAs (mcast_mode=2). B is not
+            # multicast (cluster_m=1 => no M peers), so B keeps the plain
+            # per-CTA coord/layout (coord 0, make_layout(1)) and no B mask.
             if tcgen05_is_two_cta:
                 prefix.append(
                     statement_from_string(
@@ -4175,11 +4251,26 @@ def _emit_mma_pipeline(
                         "(0, None, 0, 0)).shape)"
                     )
                 )
+            elif tcgen05_n_only_cluster:
+                # A multicasts along the N axis (mode 2). The N-slice keeps
+                # the rank-4 (V,M,N,K) cluster_layout's N mode free; same
+                # spelling as the two-cta A path (the V mode is size 1 under
+                # CtaGroup.ONE). B uses the plain non-cluster layout.
+                prefix.append(
+                    statement_from_string(
+                        f"{tma_a_cta_layout} = cute.make_layout("
+                        f"cute.slice_({tcgen05_cluster_layout_vmnk}, "
+                        "(0, 0, None, 0)).shape)"
+                    )
+                )
+                prefix.append(
+                    statement_from_string(f"{tma_cta_layout} = cute.make_layout(1)")
+                )
             else:
                 prefix.append(
                     statement_from_string(f"{tma_cta_layout} = cute.make_layout(1)")
                 )
-            if tcgen05_cluster_m > 1 or tcgen05_is_two_cta:
+            if tcgen05_cluster_m > 1 or tcgen05_a_mcast_cluster:
                 prefix.append(
                     statement_from_string(
                         f"{tma_cta_rank_in_cluster} = cute.arch.make_warp_uniform("
@@ -4203,7 +4294,14 @@ def _emit_mma_pipeline(
                             f"{tma_b_cta_coord} = {tma_block_in_cluster_coord_vmnk}[1]"
                         )
                     )
-                if tcgen05_is_two_cta:
+                elif tcgen05_n_only_cluster:
+                    # A's coord is its N position in the cluster (mode 2).
+                    prefix.append(
+                        statement_from_string(
+                            f"{tma_a_cta_coord} = {tma_block_in_cluster_coord_vmnk}[2]"
+                        )
+                    )
+                if tcgen05_a_mcast_cluster:
                     prefix.append(
                         statement_from_string(
                             f"{tma_a_mcast_mask} = cute.nvgpu.cpasync.create_tma_multicast_mask("
@@ -4222,10 +4320,13 @@ def _emit_mma_pipeline(
                     )
             # tma_partition consumes the per-tile gA_part / gB_part, so the
             # resulting (tma_sA, tma_gA) / (tma_sB, tma_gB) are also per-tile.
-            tma_a_cta_coord_expr = tma_a_cta_coord if tcgen05_is_two_cta else "0"
+            # A uses the cluster coord/layout whenever it multicasts (two-cta
+            # OR the N-only cluster); B uses the cluster coord/layout only in
+            # the two-cta path (it is non-multicast in the N-only cluster).
+            tma_a_cta_coord_expr = tma_a_cta_coord if tcgen05_a_mcast_cluster else "0"
             tma_b_cta_coord_expr = tma_b_cta_coord if tcgen05_is_two_cta else "0"
             tma_a_cta_layout_expr = (
-                tma_a_cta_layout if tcgen05_is_two_cta else tma_cta_layout
+                tma_a_cta_layout if tcgen05_a_mcast_cluster else tma_cta_layout
             )
             tma_b_cta_layout_expr = (
                 tma_b_cta_layout if tcgen05_is_two_cta else tma_cta_layout
@@ -4341,6 +4442,7 @@ def _emit_mma_pipeline(
                     tma_b_mcast_mask=tma_b_mcast_mask,
                     is_two_cta=tcgen05_is_two_cta,
                     use_tma_b_mcast_mask=tcgen05_use_tma_b_mcast_mask,
+                    use_tma_a_mcast_mask=tcgen05_n_only_cluster,
                     skip_producer_acquire=diagnose_skip_ab_producer_acquire,
                     skip_producer_advance=diagnose_skip_ab_producer_advance,
                 )
@@ -4681,6 +4783,7 @@ def _emit_mma_pipeline(
                 scalar_load_a=scalar_load_a,
                 scalar_load_b=scalar_load_b,
                 cluster_n=tcgen05_cluster_n,
+                use_tma_a_mcast_mask=tcgen05_n_only_cluster,
                 static_full_tiles=tcgen05_static_full_tma_fast_path,
             )
             if tcgen05_use_tma_pipeline:

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -92,6 +92,7 @@ from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_CLUSTER_M
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_PID_TYPE
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_PROBLEM_SHAPE
+from .tcgen05_constants import TCGEN05_MIN_BLOCK_M
 from .tcgen05_constants import TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from .tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
@@ -2030,6 +2031,26 @@ def _emit_mma_pipeline(
     tcgen05_has_k_tail = k_total_size > bk and k_total_size % bk != 0
     tcgen05_k_tail_only = tcgen05_static_output_tiles and tcgen05_has_k_tail
     tcgen05_double_edge_output = m_size % bm != 0 and n_size % bn != 0
+    # Flat (cluster_m=1, non-persistent) M-edge-only case: the M tile exceeds the
+    # real M (e.g. M=16 on a 64/128-row tile) but N and K divide cleanly. This is
+    # the tiny-M GEMM that pads/masks M onto a tcgen05 tile, the way CUTLASS' SM100
+    # fp8 kernel does. TMA's descriptor (built with the real m_size) bounds-clamps
+    # the partial A stripe, so TMA can be kept for the WHOLE mainloop instead of
+    # falling to the per-element scalar AB load on every K iteration (the
+    # ``tcgen05_mixed_tma_scalar_fallback`` path would otherwise serialize the
+    # entire B read -- ~100x slower). The store side is already SIMT-predicated for
+    # the partial M rows, so only the A/B LOAD output-tile predicate is relaxed (M
+    # term becomes ``m_offset < m_size`` instead of ``m_offset + bm <= m_size``).
+    tcgen05_flat_m_edge_tma = (
+        mma_impl == "tcgen05"
+        and tcgen05_use_tma_pipeline
+        and not tcgen05_pid_is_persistent
+        and tcgen05_cluster_m == 1
+        and tcgen05_cluster_n_requested == 1
+        and m_size % bm != 0
+        and n_size % bn == 0
+        and k_total_size % bk == 0
+    )
     tcgen05_double_edge_tma = (
         mma_impl == "tcgen05"
         and tcgen05_use_tma_pipeline
@@ -3903,6 +3924,14 @@ def _emit_mma_pipeline(
                 f"{m_offset_var} + cutlass.Int32({bm}) <= cutlass.Int32({m_size}) "
                 f"and {n_offset_var} < cutlass.Int32({n_size}) "
             )
+        if tcgen05_flat_m_edge_tma:
+            # Flat M-edge (padded-M tcgen05 tile): TMA's m_size-clamped descriptor
+            # loads the partial A stripe, N divides bn, so only the M term relaxes
+            # to ``m_offset < m_size`` -- every in-bounds tile is "full" for TMA.
+            return (
+                f"{m_offset_var} < cutlass.Int32({m_size}) "
+                f"and {n_offset_var} + cutlass.Int32({bn}) <= cutlass.Int32({n_size}) "
+            )
         return (
             f"{m_offset_var} + cutlass.Int32({bm}) <= cutlass.Int32({m_size}) "
             f"and {n_offset_var} + cutlass.Int32({bn}) <= cutlass.Int32({n_size}) "
@@ -4792,12 +4821,25 @@ def _emit_mma_pipeline(
                     if tcgen05_use_role_local_mma_exec:
                         mma_exec_role_stmts.append(exec_loop)
                 else:
+                    # Use the shared output-tile predicate so the flat M-edge
+                    # relaxation (M term ``m_offset < m_size``) reaches the
+                    # steady-state prefetch look-ahead too -- otherwise the
+                    # producer's ``and tma_next_full_tile`` gate would be
+                    # permanently false for a padded-M tile and the mainloop
+                    # would never prefetch past the prologue.
                     cg.add_statement(
                         statement_from_string(
                             f"{tma_next_full_tile} = "
-                            f"{m_offset_var} + cutlass.Int32({bm}) <= cutlass.Int32({m_size}) "
-                            f"and {n_offset_var} + cutlass.Int32({bn}) <= cutlass.Int32({n_size}) "
-                            f"and {k_offset_var} + cutlass.Int32({bk * (tcgen05_ab_stage_count_value + 1)}) <= cutlass.Int32({k_total_size})"
+                            + _tcgen05_tma_tile_predicate(
+                                k_tile_start_expr=(
+                                    f"{k_offset_var} + cutlass.Int32("
+                                    f"{bk * tcgen05_ab_stage_count_value})"
+                                ),
+                                full_tile_end_expr=(
+                                    f"{k_offset_var} + cutlass.Int32("
+                                    f"{bk * (tcgen05_ab_stage_count_value + 1)})"
+                                ),
+                            )
                         )
                     )
                     cg.add_statement(
@@ -5332,17 +5374,20 @@ def _mma_impl_matches_problem_shape(
 ) -> bool:
     if mma_impl == "universal":
         return True
-    # The autotune config-spec only registers the ``tcgen05_*`` config keys for
-    # static (real problem) shapes that pass ``tcgen05_static_shape_eligible``
-    # (see ``matmul_ops.py`` eligibility gate). ``block_m``/``block_n`` can
-    # legally exceed the static M/N for tiny GEMMs (e.g. M=16/32 with
-    # block_m=128), so selecting tcgen05 on block size alone would commit
-    # codegen to a path whose config keys were never registered -> hard
-    # ``KeyError`` in ``_emit_mma_pipeline``. Gate tcgen05 on the same shared
-    # predicate so codegen and config-spec can never diverge; below it, fall
-    # back to warp/universal.
+    # Codegen/config-spec consistency via one shared predicate
+    # (``tcgen05_static_shape_eligible``). The config-spec (matmul_ops.py)
+    # registers the ``tcgen05_*`` config keys exactly when this predicate passes;
+    # codegen must select tcgen05 on the SAME predicate or the two diverge and
+    # the warp-spec lookup in ``_emit_mma_pipeline`` hits a hard ``KeyError``.
+    # The predicate gates M on ``block_m`` (the chosen tile), NOT the static M:
+    # ``block_m`` may legally EXCEED the real problem M for tiny-M GEMMs (e.g.
+    # M=16 on a 64/128-row padded tile, masking the rows beyond the real M,
+    # exactly as CUTLASS' SM100 fp8 kernel does). A sub-tile ``block_m`` (<
+    # ``TCGEN05_MIN_BLOCK_M``) has no tcgen05 atom and falls back to
+    # warp/universal. N/K gate on their static extents. ``static_m`` is retained
+    # in the signature for callers/diagnostics but no longer gates selection.
     if mma_impl == "tcgen05" and not tcgen05_static_shape_eligible(
-        input_dtype, static_m=static_m, static_n=static_n, static_k=static_k
+        input_dtype, block_m=bm, static_n=static_n, static_k=static_k
     ):
         return False
     is_fp8 = input_dtype == torch.float8_e4m3fn

--- a/helion/_compiler/cute/device_state.py
+++ b/helion/_compiler/cute/device_state.py
@@ -46,6 +46,21 @@ class CuteTcgen05StoreValue:
     use_tma_store_epilogue: bool = False
     tma_store_full_tiles_only: bool = False
     partial_output_tma_store: bool = False
+    # Single padded-M tcgen05 tile: the real problem M does not even fill one
+    # ``bm`` tile (``m_size <= bm``, e.g. M=16 on a 64/128-row tile) while N
+    # divides ``bn`` and K divides ``bk`` cleanly, so the ONLY masked output
+    # boundary is the M rows AND there is exactly one M tile. The full-tile
+    # predicate is then statically false (``m_offset + bm <= m_size`` can never
+    # hold), so the SIMT edge store always runs; the edge branch can drop the
+    # dead full-tile fast path and use a single vectorized ``logical_divide``
+    # predicated copy with an M-only row predicate (one boolean mask + one
+    # ``cute.copy``) instead of the per-element scalar ``elem_less``/``if`` loop,
+    # cutting epilogue issue overhead on the streaming warps. Set from
+    # ``tcgen05_flat_m_edge_single_tile`` in ``_emit_mma_pipeline`` (note this is
+    # narrower than the load-side ``tcgen05_flat_m_edge_tma``, which also relaxes
+    # the AB-load predicate for the multi-M-tile ``m_size > bm`` edge case where
+    # the first tile is a genuine full tile and must keep its plain store).
+    flat_m_edge: bool = False
     # Output element dtype (cutlass type string, e.g. "cutlass.BFloat16")
     # used when computing the tcgen05 epilogue tile.
     epi_elem_dtype_str: str = ""

--- a/helion/_compiler/cute/strategies.py
+++ b/helion/_compiler/cute/strategies.py
@@ -1236,11 +1236,32 @@ def validate_tcgen05_strategy_invariants(
             f"at tcgen05_cluster_n in {sorted(supported_cluster_n)!r}; "
             f"got tcgen05_cluster_n={cluster_n}"
         )
-    if cluster_n > 1 and cluster_m != 2:
+    # cluster_n=2 has two validated envelopes:
+    #   - cluster_m=2 use_2cta=True: the canonical Quack-best 4-CTA cluster
+    #     (cute_plan.md §6.12).
+    #   - cluster_m=1 CtaGroup.ONE: the N-only A-multicast cluster for the
+    #     tiny-M padded tcgen05 fp8 path. Two CTAs each own their own N
+    #     output tile; the cluster exists only to TMA-multicast the shared A
+    #     operand along the N axis (mcast_mode=2). This is what torch's
+    #     ``_scaled_mm`` CUTLASS kernel selects at M<=64,N>=3072
+    #     (ClusterShape<1,2,1>). Only ``ROLE_LOCAL_MONOLITHIC`` with the flat
+    #     NON_PERSISTENT grid lowers this shape today (the WITH_SCHEDULER / CLC
+    #     and persistent topologies have not been generalized to the N-only
+    #     multicast, so they stay on the cluster_m=2 envelope). The flat grid
+    #     is what makes consecutive grid_x CTAs adjacent N-tiles of the single
+    #     padded M-tile, which is the cluster's A-sharing precondition.
+    n_only_cluster_ok = (
+        cluster_m == 1
+        and strategy is Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC
+        and persistence_model is Tcgen05PersistenceModel.NON_PERSISTENT
+    )
+    if cluster_n > 1 and cluster_m != 2 and not n_only_cluster_ok:
         errors.append(
             f"tcgen05_cluster_n={cluster_n} requires tcgen05_cluster_m=2 "
             f"with use_2cta=True (the validated 4-CTA cluster envelope; "
-            f"cute_plan.md §6.12); got tcgen05_cluster_m={cluster_m}"
+            f"cute_plan.md §6.12) or tcgen05_cluster_m=1 with "
+            f"ROLE_LOCAL_MONOLITHIC (the N-only A-multicast cluster); "
+            f"got tcgen05_cluster_m={cluster_m}, strategy={strategy.value!r}"
         )
 
     # (strategy, persistence_model) paired cluster_n accept set.

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import torch
+
 # Validated CtaGroup.TWO autotune/runtime envelope for the B200 CuTe path.
 # Re-verify the K-cap runtime and guard-boundary tests before raising the
 # K-tile threshold or broadening the tile shape.
@@ -441,3 +443,61 @@ TCGEN05_CLUSTER_M2_ONE_CTA_ROLE_LOCAL_CONFIG_KEY = (
 # CtaGroup.ONE tcgen05 MMA covers 64/128 M tiles; 256 M tiles are validated only
 # after projecting onto the CtaGroup.TWO path.
 TCGEN05_ONE_CTA_MAX_BLOCK_M = 128
+
+# Minimum static (real problem) M extent for which the autotune config-spec
+# registers the ``tcgen05_*`` config keys (see ``matmul_ops.py`` eligibility
+# gate). Codegen MMA-impl selection (``cute_mma.py`` ``_choose_mma_impl`` /
+# ``_mma_impl_matches_problem_shape``) MUST gate tcgen05 on the same threshold:
+# otherwise a kernel whose static M is below this floor but whose chosen
+# ``block_m`` is >= 64 commits codegen to the tcgen05 path while the config-spec
+# never registered the ``tcgen05_warp_spec_*`` keys, producing a hard ``KeyError``
+# at codegen time. Selecting on block size alone (which can exceed static M for
+# tiny-M GEMMs) is what let the two diverge.
+TCGEN05_MIN_STATIC_M = 64
+
+# Minimum static N for tcgen05 (the MMA N tile is a multiple of 8). Same
+# divergence risk as M: ``block_n`` can exceed the static N, so codegen must
+# gate on the static extent, not the block size.
+TCGEN05_MIN_STATIC_N = 8
+
+
+def tcgen05_mma_k(input_dtype: torch.dtype) -> int:
+    """tcgen05 MMA-K granularity: 32 elements for fp8-e4m3, 16 for fp16/bf16."""
+    return 32 if input_dtype == torch.float8_e4m3fn else 16
+
+
+def tcgen05_static_shape_eligible(
+    input_dtype: torch.dtype,
+    *,
+    static_m: int | None,
+    static_n: int | None,
+    static_k: int | None,
+) -> bool:
+    """Whether a matmul's *static* (real problem) shape admits the tcgen05 path.
+
+    Single source of truth shared by the autotune config-spec (which decides
+    whether to register the ``tcgen05_*`` config keys, in ``matmul_ops.py``) and
+    codegen MMA-impl selection (``cute_mma.py``). Both MUST agree: if codegen
+    commits to tcgen05 for a shape the config-spec rejected, the ``tcgen05_*``
+    keys were never registered and ``_emit_mma_pipeline`` dies with a hard
+    ``KeyError``.
+
+    Gates only on the *static* extents (not block sizes): ``block_m``/``block_n``
+    can legally exceed the real M/N for tiny GEMMs, so block-size checks alone
+    let the two callers diverge. A ``None`` extent is a dynamic shape and stays
+    eligible (the config-spec resolves a size hint in that case). Dtype and the
+    per-axis tcgen05 minimums (M>=64, N>=8, K>=mma_k) are checked here; block-
+    size-specific validation (e.g. ``bn % 8``, ``bm`` tile family) stays in
+    ``_mma_impl_matches_problem_shape``.
+    """
+    if input_dtype not in (
+        torch.float16,
+        torch.bfloat16,
+        torch.float8_e4m3fn,
+    ):
+        return False
+    if static_m is not None and static_m < TCGEN05_MIN_STATIC_M:
+        return False
+    if static_n is not None and static_n < TCGEN05_MIN_STATIC_N:
+        return False
+    return not (static_k is not None and static_k < tcgen05_mma_k(input_dtype))

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -444,20 +444,30 @@ TCGEN05_CLUSTER_M2_ONE_CTA_ROLE_LOCAL_CONFIG_KEY = (
 # after projecting onto the CtaGroup.TWO path.
 TCGEN05_ONE_CTA_MAX_BLOCK_M = 128
 
-# Minimum static (real problem) M extent for which the autotune config-spec
-# registers the ``tcgen05_*`` config keys (see ``matmul_ops.py`` eligibility
-# gate). Codegen MMA-impl selection (``cute_mma.py`` ``_choose_mma_impl`` /
-# ``_mma_impl_matches_problem_shape``) MUST gate tcgen05 on the same threshold:
-# otherwise a kernel whose static M is below this floor but whose chosen
-# ``block_m`` is >= 64 commits codegen to the tcgen05 path while the config-spec
-# never registered the ``tcgen05_warp_spec_*`` keys, producing a hard ``KeyError``
-# at codegen time. Selecting on block size alone (which can exceed static M for
-# tiny-M GEMMs) is what let the two diverge.
-TCGEN05_MIN_STATIC_M = 64
+# Smallest legal tcgen05 CtaGroup.ONE M tile. A tcgen05 MMA always processes a
+# full 64- or 128-row M tile (the atom has no sub-64 M mode), so this is also the
+# minimum ``block_m`` the autotune config-spec searches for the matmul M axis and
+# the minimum ``block_m`` codegen will accept on the tcgen05 path.
+#
+# IMPORTANT — codegen/config-spec consistency. ``block_m`` may legally EXCEED the
+# real problem M (e.g. M=16 run on a 64- or 128-row tile, padding/masking the
+# rows beyond the real M, exactly as CUTLASS' SM100 fp8 kernel does). What the
+# config-spec eligibility gate (``matmul_ops.py``) and codegen MMA-impl selection
+# (``cute_mma.py`` ``_choose_mma_impl`` / ``_mma_impl_matches_problem_shape``)
+# MUST agree on is whether the tcgen05 ``tcgen05_*`` config keys were registered.
+# Both key that decision on ``block_m`` being a legal tcgen05 M tile (>=
+# ``TCGEN05_MIN_BLOCK_M``), NOT on the static M, so they can never diverge — the
+# original divergence (config-spec gated on static M >= 64, codegen selected on
+# block size alone) is what produced the hard ``KeyError`` in
+# ``_emit_mma_pipeline``.
+TCGEN05_MIN_BLOCK_M = 64
 
-# Minimum static N for tcgen05 (the MMA N tile is a multiple of 8). Same
-# divergence risk as M: ``block_n`` can exceed the static N, so codegen must
-# gate on the static extent, not the block size.
+# Deprecated alias kept for any external reference. The contract is now expressed
+# as a minimum ``block_m`` (above), since a small static M can be covered by a
+# legal padded/masked M tile.
+TCGEN05_MIN_STATIC_M = TCGEN05_MIN_BLOCK_M
+
+# Minimum static N for tcgen05 (the MMA N tile is a multiple of 8).
 TCGEN05_MIN_STATIC_N = 8
 
 
@@ -469,11 +479,11 @@ def tcgen05_mma_k(input_dtype: torch.dtype) -> int:
 def tcgen05_static_shape_eligible(
     input_dtype: torch.dtype,
     *,
-    static_m: int | None,
+    block_m: int | None,
     static_n: int | None,
     static_k: int | None,
 ) -> bool:
-    """Whether a matmul's *static* (real problem) shape admits the tcgen05 path.
+    """Whether a matmul shape admits the tcgen05 path.
 
     Single source of truth shared by the autotune config-spec (which decides
     whether to register the ``tcgen05_*`` config keys, in ``matmul_ops.py``) and
@@ -482,12 +492,12 @@ def tcgen05_static_shape_eligible(
     keys were never registered and ``_emit_mma_pipeline`` dies with a hard
     ``KeyError``.
 
-    Gates only on the *static* extents (not block sizes): ``block_m``/``block_n``
-    can legally exceed the real M/N for tiny GEMMs, so block-size checks alone
-    let the two callers diverge. A ``None`` extent is a dynamic shape and stays
-    eligible (the config-spec resolves a size hint in that case). Dtype and the
-    per-axis tcgen05 minimums (M>=64, N>=8, K>=mma_k) are checked here; block-
-    size-specific validation (e.g. ``bn % 8``, ``bm`` tile family) stays in
+    The M axis gates on ``block_m`` (the chosen tile), NOT the static M: a tiny
+    real M is covered by a legal padded/masked ``block_m`` >= ``TCGEN05_MIN_BLOCK_M``
+    tile (CUTLASS-style M padding). N and K gate on their static extents (the MMA
+    N tile is a multiple of 8; K must reach one mma-k). A ``None`` extent is a
+    dynamic shape and stays eligible (the config-spec resolves a size hint).
+    Block-size-specific validation (e.g. ``bn % 8``, ``bm`` tile family) stays in
     ``_mma_impl_matches_problem_shape``.
     """
     if input_dtype not in (
@@ -496,7 +506,7 @@ def tcgen05_static_shape_eligible(
         torch.float8_e4m3fn,
     ):
         return False
-    if static_m is not None and static_m < TCGEN05_MIN_STATIC_M:
+    if block_m is not None and block_m < TCGEN05_MIN_BLOCK_M:
         return False
     if static_n is not None and static_n < TCGEN05_MIN_STATIC_N:
         return False

--- a/helion/autotuner/aot_cache.py
+++ b/helion/autotuner/aot_cache.py
@@ -243,6 +243,10 @@ def compute_tensor_hash(tensor: torch.Tensor) -> str:
     # Convert dtypes not supported by numpy (e.g., bfloat16)
     if tensor.dtype == torch.bfloat16:
         tensor = tensor.to(torch.float32)
+    # fp8 (and other sub-byte-named) dtypes have no numpy equivalent; hash the
+    # raw bytes by viewing as uint8 (fp8_e4m3fn / fp8_e5m2 are 1 byte each).
+    elif tensor.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+        tensor = tensor.view(torch.uint8)
     return hashlib.sha256(tensor.numpy().tobytes()).hexdigest()[:8]
 
 

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -2255,6 +2255,17 @@ class BlockSizeSpec(_PowerOfTwoBlockIdItem):
         clamped = max(value, 1)
         self.max_size = assert_integer_power_of_two(min(clamped, self.max_size))
 
+    def raise_max(self, value: int) -> None:
+        """Raise the autotune max ABOVE the size-hint-derived ceiling.
+
+        Unlike ``update_max`` (which can only lower the ceiling), this lets a
+        block search block sizes larger than ``next_power_of_2(size_hint)``. It
+        is used only for a matmul M axis whose ``block_m`` may legally exceed the
+        (small) static M and run on a larger padded/masked tcgen05 tile; ordinary
+        tiles never call it, so the generic search space is unchanged.
+        """
+        self.max_size = assert_integer_power_of_two(max(value, self.max_size))
+
     def update_hint(self, value: int) -> None:
         self.size_hint = value
         self.update_max(next_power_of_2(max(value, 1)))

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -25,6 +25,8 @@ from .._compiler.cute.matmul_utils import cute_resolve_active_matmul_k_block_id
 from .._compiler.cute.matmul_utils import cute_static_k_invariant_extent
 from .._compiler.cute.strategies import is_pure_matmul_role_lifecycle_config
 from .._compiler.cute.tcgen05_constants import TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY
+from .._compiler.cute.tcgen05_constants import TCGEN05_MIN_BLOCK_M
+from .._compiler.cute.tcgen05_constants import TCGEN05_ONE_CTA_MAX_BLOCK_M
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_MIN_DIM
@@ -334,8 +336,19 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
         and static_m is not None
         and static_n is not None
         and static_k is not None
+        # ``block_m`` may legally exceed the real problem M: a tiny-M GEMM
+        # (e.g. M=16) runs on a full 64- or 128-row tcgen05 M tile, padding /
+        # masking the rows beyond the real M (the SIMT edge epilogue and the
+        # bounds-clamped TMA loads already handle this single all-M partial
+        # tile, exactly like CUTLASS' SM100 fp8 kernel). So at config-spec time
+        # the M floor is ``1`` (any positive M can be covered by a 64/128 tile)
+        # -- the shared predicate is called with ``block_m=None`` (the tile is
+        # chosen later) and codegen re-checks the SAME predicate with the
+        # resolved ``block_m``, so the ``tcgen05_*`` keys are registered exactly
+        # when codegen will select tcgen05 (no KeyError).
+        and static_m >= 1
         and tcgen05_static_shape_eligible(
-            lhs.dtype, static_m=static_m, static_n=static_n, static_k=static_k
+            lhs.dtype, block_m=None, static_n=static_n, static_k=static_k
         )
     ):
         from .._compiler.cute.mma_support import get_cute_mma_support
@@ -354,10 +367,30 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
             # BF16/FP16, 32 for FP8). Cap at 128 to keep AB SMEM staging
             # budget sane.
             max_tcgen05_k = min(128, pow2_floor_at_least(static_k, mma_k))
-            max_search_m = min(max_tcgen05_m, pow2_floor_at_least(static_m, 64))
+            # ``block_m`` is allowed to exceed the real M up to a legal padded
+            # tcgen05 M tile. When the static M is below the smallest legal tile
+            # (``TCGEN05_MIN_BLOCK_M``), search the full CtaGroup.ONE tile range
+            # {64, 128} (CUTLASS' SM100 fp8 kernel uses a 64-row tile for tiny
+            # M); the partial all-M tile is padded/masked at codegen time. When
+            # the static M is large enough to floor the tile, keep the original
+            # ``pow2_floor_at_least`` sizing so normal GEMMs are unaffected.
+            small_static_m = static_m < TCGEN05_MIN_BLOCK_M
+            if small_static_m:
+                max_search_m = min(max_tcgen05_m, TCGEN05_ONE_CTA_MAX_BLOCK_M)
+            else:
+                max_search_m = min(max_tcgen05_m, pow2_floor_at_least(static_m, 64))
             max_search_n = max_tcgen05_n
             max_search_k = max_tcgen05_k
             min_search_m = 128 if max_tcgen05_m >= 256 else 64
+            if small_static_m:
+                # Do NOT force the M-block min up to a tcgen05 tile when the real
+                # M is below it: that would delete the smaller warp/universal
+                # block_m candidates (e.g. bf16 block_m=16 -> warp MmaF16BF16Op)
+                # from the search, leaving only padded tcgen05 tiles. Keep the
+                # min at the natural size so the autotuner can weigh warp /
+                # universal against the padded tcgen05 64/128 tiles. The max was
+                # already raised above so 64/128 ARE searchable.
+                min_search_m = min(min_search_m, pow2_floor_at_least(static_m, 1))
             two_cta_m_edge = static_m % TCGEN05_TWO_CTA_BLOCK_M != 0
             two_cta_n_edge = static_n % TCGEN05_TWO_CTA_BLOCK_N != 0
             two_cta_k_tail = static_k % max_search_k != 0
@@ -521,7 +554,15 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
                 env.block_sizes[block_idx].update_min_block(
                     min_size, allow_flattened=True
                 )
-                env.block_sizes[block_idx].update_max_block(max_size)
+                # The M axis is the only one whose search max may need to go
+                # ABOVE ``next_power_of_2(size_hint)``: for a tiny static M the
+                # legal padded tcgen05 tile (64/128) exceeds the size hint, and
+                # ``update_max`` would otherwise clamp the ceiling back down to
+                # the hint. ``allow_raise`` is scoped to the matmul M axis so the
+                # generic (N/K and non-matmul) search space is unchanged.
+                env.block_sizes[block_idx].update_max_block(
+                    max_size, allow_raise=(axis_name == "m" and small_static_m)
+                )
 
     # Triton only supports 2D dot operations.  When the operands are 3D
     # (batched matmul), constrain the batch dimension block size to 1 so

--- a/helion/language/matmul_ops.py
+++ b/helion/language/matmul_ops.py
@@ -31,6 +31,8 @@ from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_MIN_D
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_M
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_FP8_SMALL_GRID_BLOCK_N
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_MAX_K_TILES
+from .._compiler.cute.tcgen05_constants import tcgen05_mma_k
+from .._compiler.cute.tcgen05_constants import tcgen05_static_shape_eligible
 from .._compiler.matmul_utils import _compute_out_dtype
 from .._compiler.matmul_utils import _emit_pallas_matmul
 from .._compiler.matmul_utils import _emit_tl_dot_scaled
@@ -323,19 +325,18 @@ def enforce_dot_requirements(lhs: torch.Tensor, rhs: torch.Tensor) -> None:
     # tcgen05 MMA-K is 16 elements for BF16/FP16 but 32 for FP8 (e4m3); the
     # block_k search granularity and minimum must follow the active dtype.
     is_fp8 = lhs.dtype == torch.float8_e4m3fn
-    mma_k = 32 if is_fp8 else 16
+    mma_k = tcgen05_mma_k(lhs.dtype)
     if (
         env.backend_name == "cute"
         and lhs.ndim == 2
         and rhs.ndim == 2
-        and lhs.dtype in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
         and rhs.dtype == lhs.dtype
         and static_m is not None
         and static_n is not None
         and static_k is not None
-        and static_m >= 64
-        and static_n >= 8
-        and static_k >= mma_k
+        and tcgen05_static_shape_eligible(
+            lhs.dtype, static_m=static_m, static_n=static_n, static_k=static_k
+        )
     ):
         from .._compiler.cute.mma_support import get_cute_mma_support
 

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -3391,15 +3391,27 @@ def _codegen_cute_store_tcgen05_tile(
         include_coord_setup: bool = True,
         var_prefix: str = "tcgen05_edge",
         copy_atom: str | None = None,
+        m_only_pred: bool = False,
     ) -> str:
         # Shared edge-only vector copy emitter. The make_layout(1) retile gives
         # cute.copy a per-element predicate, while var_prefix/copy_atom let the
         # same shape drive D stores or exact-aux G2R register loads.
+        #
+        # ``m_only_pred`` is the padded-M tcgen05 fast path: when N divides ``bn``
+        # cleanly the only out-of-bounds output coordinate is the M row, so the
+        # predicate collapses from the 2-D ``cute.elem_less(coord, (m, n))`` to a
+        # single ``coord[0] < m_size`` row test. Fewer live registers / scalar
+        # ops on the epilogue warps for the tiny-M streaming case.
         copy_atom = copy_atom or simt_atom
         edge_src = df.new_var(f"{var_prefix}_src")
         edge_dst = df.new_var(f"{var_prefix}_dst")
         edge_coord = df.new_var(f"{var_prefix}_coord")
         edge_pred = df.new_var(f"{var_prefix}_pred")
+        pred_rhs = (
+            f"_coord[0] < cutlass.Int32({m_size})"
+            if m_only_pred
+            else f"cute.elem_less(_coord, ({m_size}, {n_size}))"
+        )
         return (
             (_simt_edge_coord_subtile_source(indent) if include_coord_setup else "")
             + f"{indent}{edge_src} = cute.logical_divide({src}, cute.make_layout(1))\n"
@@ -3408,7 +3420,7 @@ def _codegen_cute_store_tcgen05_tile(
             f"{indent}{edge_pred} = cute.make_rmem_tensor((1, {edge_src}.shape[1]), cutlass.Boolean)\n"
             f"{indent}for _edge_i in range(cute.size({edge_src}.shape[1])):\n"
             f"{indent}    _coord = {edge_coord}[0, _edge_i]\n"
-            f"{indent}    {edge_pred}[0, _edge_i] = cute.elem_less(_coord, ({m_size}, {n_size}))\n"
+            f"{indent}    {edge_pred}[0, _edge_i] = {pred_rhs}\n"
             f"{indent}cute.copy({copy_atom}, {edge_src}, {edge_dst}, pred={edge_pred})\n"
         )
 
@@ -4176,6 +4188,21 @@ def _codegen_cute_store_tcgen05_tile(
             ttr_rd,
             ttr_gc_subtile,
             include_coord_setup=not simt_store_edge_coord_preloaded,
+        )
+    elif tcgen05_value.flat_m_edge:
+        # Padded-M tcgen05 tile (block_m > real M, N divides bn). The full-tile
+        # predicate ``m_offset + bm <= m_size`` is statically unsatisfiable here
+        # (there is a single padded M tile), so the ``if full_tile`` fast path is
+        # dead code and the scalar per-element ``elem_less``/``if`` edge loop runs
+        # every subtile -- inflating epilogue register pressure / issue overhead
+        # on the streaming warps. Emit ONLY the vectorized predicated copy with an
+        # M-only row predicate (N is in-bounds because it divides bn): one boolean
+        # mask + one ``cute.copy`` per subtile, no scalar branch per element.
+        simt_store_copy_source = _simt_edge_logical_divide_copy_source(
+            "        ",
+            ttr_rd,
+            ttr_gc_subtile,
+            m_only_pred=True,
         )
     else:
         simt_store_copy_source = (

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -3844,6 +3844,44 @@ def _codegen_cute_store_tcgen05_tile(
             if rowvec_stage is None and (
                 safe_direct_aux_with_full_tile or not tcgen05_aux_use_tma_store_epilogue
             ):
+                if tcgen05_value.flat_m_edge:
+                    # Padded single-M-tile (block_m > real M, N divides bn): the
+                    # ``if full_tile`` fast path is statically dead (a full M tile
+                    # can never form) and the only out-of-bounds aux coordinate is
+                    # the M row, so the per-element 2-D ``elem_less`` scalar loop is
+                    # pure overhead. Mirror the leaner store path
+                    # (``tcgen05_value.flat_m_edge`` branch in the SIMT store) and
+                    # emit ONE vectorized ``logical_divide`` predicated copy with an
+                    # M-only row predicate. Same masking semantics (padded rows read
+                    # 0 and are dropped by the M-predicated store), far fewer scalar
+                    # ops / live registers on the streaming epilogue warps.
+                    include_coord_setup = not force_simt_edge_coord_emitted
+                    force_simt_edge_coord_emitted = True
+                    flat_edge_atom = df.new_var(f"{rec.aux_rmem}_edge_atom")
+                    lines.append(
+                        f"{prelude_indent}{flat_edge_atom} = "
+                        f"cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), "
+                        f"{rec.aux_dtype})\n"
+                        f"{prelude_indent}{rec.ttr_aux_subtile} = "
+                        f"{rec.ttr_aux_grouped}"
+                        f"[(None, None, None, cutlass.Int32(_tcgen05_subtile))]\n"
+                        f"{prelude_indent}{rec.aux_rmem} = "
+                        f"cute.make_rmem_tensor({rec.ttr_aux_subtile}.shape, "
+                        f"{rec.aux_dtype})\n"
+                        f"{prelude_indent}{rec.aux_rmem}.fill(0)\n"
+                        + _simt_edge_logical_divide_copy_source(
+                            prelude_indent,
+                            rec.ttr_aux_subtile,
+                            rec.aux_rmem,
+                            include_coord_setup=include_coord_setup,
+                            var_prefix=f"{rec.aux_rmem}_edge",
+                            copy_atom=flat_edge_atom,
+                            m_only_pred=True,
+                        )
+                        + f"{prelude_indent}{rec.aux_loaded} = "
+                        f"{rec.aux_rmem}.load()\n"
+                    )
+                    continue
                 lines.append(
                     f"{prelude_indent}{rec.ttr_aux_subtile} = "
                     f"{rec.ttr_aux_grouped}"

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -3841,47 +3841,72 @@ def _codegen_cute_store_tcgen05_tile(
                     f"{rec.aux_rmem}.load()\n"
                 )
                 continue
+            if rowvec_stage is None and tcgen05_value.flat_m_edge:
+                # Padded single-M-tile (block_m > real M, N divides bn): the
+                # ``if full_tile`` fast path is statically dead (a full M tile
+                # can never form) and the only out-of-bounds aux coordinate is
+                # the M row, so the per-element 2-D ``elem_less`` scalar loop is
+                # pure overhead. Mirror the leaner store path
+                # (``tcgen05_value.flat_m_edge`` branch in the SIMT store) and
+                # emit ONE vectorized ``logical_divide`` predicated copy with an
+                # M-only row predicate. Same masking semantics (padded rows read
+                # 0 and are dropped by the M-clamped store), far fewer scalar
+                # ops / live registers on the streaming epilogue warps.
+                #
+                # This M-row predicate is MANDATORY for the padded tile
+                # regardless of the output store mechanism: an exact-shape rank-2
+                # aux (e.g. ``scale_a[m, n]``) is allocated with only the real M
+                # rows, so an unpredicated direct ``ttr_aux_subtile.load()`` of
+                # the bm-row padded tile reads aux rows ``m_size..bm-1`` OUT OF
+                # BOUNDS. The SIMT-store path reached this branch via
+                # ``not use_tma_store_epilogue``; the flat-M-edge TMA-store path
+                # (where ``use_tma_store_epilogue`` is now True but there is no
+                # aux-TMA producer, so ``safe_direct_aux_with_full_tile`` is
+                # False) MUST take the same predicated read -- gating it on the
+                # store epilogue would fall through to the OOB direct load.
+                include_coord_setup = not force_simt_edge_coord_emitted
+                force_simt_edge_coord_emitted = True
+                flat_edge_atom = df.new_var(f"{rec.aux_rmem}_edge_atom")
+                # Size the predicated-copy destination to the CARRIER layout, not
+                # the raw ``ttr_aux_subtile`` layout. In the SIMT-store path the
+                # carrier (``ttr_racc``) and ``ttr_aux_subtile`` share the flat
+                # T2R value layout, so this is byte-identical to the prior
+                # ``ttr_aux_subtile.shape`` form. In the flat-M-edge TMA-store
+                # path the carrier is the R2S-retiled ``trs_racc`` (the aux
+                # partition is retiled via ``retile_for_r2s``), so the chain step
+                # ``acc_loaded * aux_loaded`` must see matching value profiles --
+                # building ``aux_rmem`` against the carrier shape keeps
+                # ``aux_loaded`` shaped like ``carrier.load()``. The predicated
+                # ``logical_divide(..., make_layout(1))`` copy is over the
+                # flattened value mode, so it stays valid as long as the total
+                # element counts match (they do: same per-thread T2R fragment).
+                lines.append(
+                    f"{prelude_indent}{flat_edge_atom} = "
+                    f"cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), "
+                    f"{rec.aux_dtype})\n"
+                    f"{prelude_indent}{rec.ttr_aux_subtile} = "
+                    f"{rec.ttr_aux_grouped}"
+                    f"[(None, None, None, cutlass.Int32(_tcgen05_subtile))]\n"
+                    f"{prelude_indent}{rec.aux_rmem} = "
+                    f"cute.make_rmem_tensor(cute.make_layout({carrier_name}.shape), "
+                    f"{rec.aux_dtype})\n"
+                    f"{prelude_indent}{rec.aux_rmem}.fill(0)\n"
+                    + _simt_edge_logical_divide_copy_source(
+                        prelude_indent,
+                        rec.ttr_aux_subtile,
+                        rec.aux_rmem,
+                        include_coord_setup=include_coord_setup,
+                        var_prefix=f"{rec.aux_rmem}_edge",
+                        copy_atom=flat_edge_atom,
+                        m_only_pred=True,
+                    )
+                    + f"{prelude_indent}{rec.aux_loaded} = "
+                    f"{rec.aux_rmem}.load()\n"
+                )
+                continue
             if rowvec_stage is None and (
                 safe_direct_aux_with_full_tile or not tcgen05_aux_use_tma_store_epilogue
             ):
-                if tcgen05_value.flat_m_edge:
-                    # Padded single-M-tile (block_m > real M, N divides bn): the
-                    # ``if full_tile`` fast path is statically dead (a full M tile
-                    # can never form) and the only out-of-bounds aux coordinate is
-                    # the M row, so the per-element 2-D ``elem_less`` scalar loop is
-                    # pure overhead. Mirror the leaner store path
-                    # (``tcgen05_value.flat_m_edge`` branch in the SIMT store) and
-                    # emit ONE vectorized ``logical_divide`` predicated copy with an
-                    # M-only row predicate. Same masking semantics (padded rows read
-                    # 0 and are dropped by the M-predicated store), far fewer scalar
-                    # ops / live registers on the streaming epilogue warps.
-                    include_coord_setup = not force_simt_edge_coord_emitted
-                    force_simt_edge_coord_emitted = True
-                    flat_edge_atom = df.new_var(f"{rec.aux_rmem}_edge_atom")
-                    lines.append(
-                        f"{prelude_indent}{flat_edge_atom} = "
-                        f"cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), "
-                        f"{rec.aux_dtype})\n"
-                        f"{prelude_indent}{rec.ttr_aux_subtile} = "
-                        f"{rec.ttr_aux_grouped}"
-                        f"[(None, None, None, cutlass.Int32(_tcgen05_subtile))]\n"
-                        f"{prelude_indent}{rec.aux_rmem} = "
-                        f"cute.make_rmem_tensor({rec.ttr_aux_subtile}.shape, "
-                        f"{rec.aux_dtype})\n"
-                        f"{prelude_indent}{rec.aux_rmem}.fill(0)\n"
-                        + _simt_edge_logical_divide_copy_source(
-                            prelude_indent,
-                            rec.ttr_aux_subtile,
-                            rec.aux_rmem,
-                            include_coord_setup=include_coord_setup,
-                            var_prefix=f"{rec.aux_rmem}_edge",
-                            copy_atom=flat_edge_atom,
-                            m_only_pred=True,
-                        )
-                        + f"{prelude_indent}{rec.aux_loaded} = "
-                        f"{rec.aux_rmem}.load()\n"
-                    )
-                    continue
                 lines.append(
                     f"{prelude_indent}{rec.ttr_aux_subtile} = "
                     f"{rec.ttr_aux_grouped}"

--- a/pretuned_kernels/README.md
+++ b/pretuned_kernels/README.md
@@ -29,6 +29,7 @@ pretuned_kernels/
 ├── cross_entropy/
 ├── rope/
 ├── scaled_mm/
+├── scale_mm_cute/                    # B200 CuTe (tcgen05) rowwise FP8 GEMM
 ├── silu_mul_fp8/                     # ported from vLLM (vllm/kernels/helion/ops)
 ├── dynamic_per_token_scaled_fp8_quant/
 ├── per_token_group_fp8_quant/
@@ -50,6 +51,7 @@ At runtime Helion picks the file matching the current GPU.
 | `cross_entropy` | TritonBench/Liger token-vocab sweep + realistic LLM vocabulary shapes | `F.cross_entropy` |
 | `rope` | TritonBench RoPE `(H, T)` defaults with exact shape buckets and `H8192_T2048` fallback | eager RoPE reference |
 | `scaled_mm` | vLLM Qwen3 FP8 `(K, N)` weight shapes at small token counts `M in {16, 64}` | `torch._scaled_mm` |
+| `scale_mm_cute` | Skinny-M FP8 decode + decoder-layer FP8 W8A8 serving `(M, K, N)` shapes (B200 CuTe backend only) | `torch._scaled_mm` (rowwise) + vLLM CUTLASS |
 | `silu_mul_fp8` | vLLM `(num_tokens, intermediate)` decode shapes | torch-native silu-and-mul + fp8 quant |
 | `dynamic_per_token_scaled_fp8_quant` | vLLM `(num_tokens, hidden)` shapes | torch-native per-token fp8 quant |
 | `per_token_group_fp8_quant` | vLLM `(num_tokens, hidden, group)` shapes | torch-native per-group fp8 quant |

--- a/pretuned_kernels/run.py
+++ b/pretuned_kernels/run.py
@@ -41,6 +41,7 @@ KERNELS = [
     "layer_norm",
     "softmax",
     "scaled_mm",
+    "scale_mm_cute",
     "cross_entropy",
     # Ported from vLLM (vllm/kernels/helion/ops); torch-native baselines.
     "silu_mul_fp8",

--- a/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
+++ b/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
@@ -101,18 +101,20 @@ _CONFIGS_scale_mm_cute = [
     # Cold-L2 cudagraph vs best baseline (torch): 0.86x -> 0.91x on B200.
     {'block_sizes': [128, 128, 128], 'l2_groupings': [1], 'num_warps': 8, 'num_stages': 4, 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_interleaved', 'tcgen05_cluster_m': 2, 'tcgen05_cluster_n': 1, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_ab_stages': 12, 'tcgen05_num_epi_warps': 4, 'tcgen05_persistence_model': 'static_persistent'},
     # (M, K, N) = (16, 2048, 4096)
-    # Padded-M tcgen05 (stack #2840-#2854): block_m=128 padded from the real
-    # M=16 with N-axis cluster_n=2 A-multicast (#2843/#2845). Seed-level config
-    # (pre-autotune) from the full-stack sweep -- ~14.9us cold-L2 cudagraph =
-    # 0.60x vs torch (was 68us / 0.13x on the pre-stack tiny-tile path).
-    {'block_sizes': [128, 128, 128], 'cute_vector_widths': [1, 1, 1], 'loop_orders': [[0, 1]], 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 2, 'tcgen05_ab_stages': 6, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4},
+    # Padded-M tcgen05 (stack #2840-#2854): block_m=64 padded from real M=16,
+    # block_n=128 (CTA-count sweet spot), N-axis cluster_n=2 A-multicast. Tuned
+    # cold-L2 cudagraph: block_m=64/bn=128 (11.1us) beats the block_m=128 seed
+    # (14.7us) and the bn=256 variant (18us).
+    {'block_sizes': [64, 128, 128], 'cute_vector_widths': [1, 1, 1], 'loop_orders': [[0, 1]], 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 2, 'tcgen05_ab_stages': 6, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4},
     # (M, K, N) = (16, 2048, 12288)  hand-tuned padded-M tcgen05; ~15.9us (0.67x
     # vs torch, 1.6 TB/s). block_n=128 is the CTA-count sweet spot (96 CTAs);
     # smaller bn adds CTAs but loses tile efficiency, larger bn under-fills SMs.
     {'block_sizes': [64, 128, 128], 'cute_vector_widths': [1, 1, 1], 'loop_orders': [[0, 1]], 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 2, 'tcgen05_ab_stages': 6, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4},
-    # (M, K, N) = (16, 4096, 6144)  padded-M tcgen05 seed; ~26.6us (0.47x vs torch)
-    {'block_sizes': [64, 256, 128], 'cute_vector_widths': [1, 1, 1], 'loop_orders': [[0, 1]], 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 2, 'tcgen05_ab_stages': 3, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4},
-    # (M, K, N) = (16, 4096, 24576)  padded-M tcgen05 seed; ~37.8us (0.79x vs torch)
+    # (M, K, N) = (16, 4096, 6144)  tuned: block_m=64/bn=128 (16.4us) beats the
+    # bn=256 seed (26.5us) and block_m=128 (25.8us) cold-L2.
+    {'block_sizes': [64, 128, 128], 'cute_vector_widths': [1, 1, 1], 'loop_orders': [[0, 1]], 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 2, 'tcgen05_ab_stages': 6, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4},
+    # (M, K, N) = (16, 4096, 24576)  bn=256 wins at the largest N (39.5us) vs
+    # bn=128 (51.8us) cold-L2 -- kept.
     {'block_sizes': [64, 256, 128], 'cute_vector_widths': [1, 1, 1], 'loop_orders': [[0, 1]], 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 2, 'tcgen05_ab_stages': 3, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4},
 ]
 

--- a/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
+++ b/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
@@ -6,7 +6,15 @@ RowWise-scaled FP8 GEMM pretuned on NVIDIA B200 (sm100) for the Helion CuTe
 (tcgen05) backend. Configs were autotuned under CUDA-graph benchmarking (how
 these decode / small-batch GEMMs are actually invoked); each shape keeps its
 own best config (best of the wall-clock and cudagraph autotune sweeps, chosen
-by a per-shape cudagraph microbenchmark).
+by a per-shape cudagraph microbenchmark). Benchmarks clear the L2 cache before
+every replay (cold L2), matching pretuned_kernels/_bench.py.
+
+The two 512-M shapes were re-tuned (ncu-guided, not autotune) onto the fp8
+small-grid 2-CTA cluster (bm=128, cluster_m=2, deep ab=12): NCU showed the old
+cluster_m=1 bm=128 tile ran at 0.86 waves (128 tiles on 148 SMs) and was
+barrier/occupancy bound; cluster_m=2 doubles the CTA count and multicasts A
+across the CTA pair (halving its cold DRAM read), lifting 512x2048x4096 from
+0.73x to 0.80x and 512x2048x2048 from 0.86x to 0.91x vs the best baseline.
 
 Each tuned (M, K, N) maps to its own config; an unseen shape falls back to the
 nearest tuned (M, K, N) (smallest sum of absolute log-ratios over M, K, N).
@@ -77,9 +85,17 @@ _CONFIGS_scale_mm_cute = [
     # (M, K, N) = (4096, 4096, 4096)
     {'block_sizes': [256, 256, 128], 'l2_groupings': [4], 'indexing': ['pointer', 'pointer', 'pointer', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_interleaved', 'tcgen05_cluster_m': 2, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 6, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 8, 'tcgen05_strategy': 'role_local_monolithic', 'tcgen05_layout_strategy': 'default', 'tcgen05_warp_spec_mma_warps': 1, 'tcgen05_warp_spec_ab_load_warps': 1, 'tcgen05_warp_spec_epi_load_warps': 0, 'tcgen05_warp_spec_scheduler_warps': 0, 'tcgen05_warp_spec_c_input_warps': 0, 'tcgen05_warp_spec_store_warps': 0, 'tcgen05_warp_spec_register_decrease': 120, 'tcgen05_warp_spec_register_increase': 256, 'cute_vector_widths': [1, 1, 1], 'tcgen05_persistence_model': 'static_persistent', 'tcgen05_layout_overrides_epi_tile_m': None, 'tcgen05_layout_overrides_epi_tile_n': None, 'tcgen05_layout_overrides_smem_swizzle_a': None, 'tcgen05_layout_overrides_smem_swizzle_b': None, 'tcgen05_layout_overrides_d_store_box_n': None},
     # (M, K, N) = (512, 2048, 4096)
-    {'block_sizes': [128, 128, 128], 'l2_groupings': [1], 'indexing': ['tensor_descriptor', 'pointer', 'pointer', 'pointer', 'tensor_descriptor'], 'pid_type': 'flat', 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 6, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 4, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 1, 'tcgen05_strategy': 'role_local_monolithic', 'tcgen05_layout_strategy': 'default', 'tcgen05_warp_spec_mma_warps': 1, 'tcgen05_warp_spec_ab_load_warps': 1, 'tcgen05_warp_spec_epi_load_warps': 0, 'tcgen05_warp_spec_scheduler_warps': 0, 'tcgen05_warp_spec_c_input_warps': 0, 'tcgen05_warp_spec_store_warps': 0, 'tcgen05_warp_spec_register_decrease': 120, 'tcgen05_warp_spec_register_increase': 256, 'cute_vector_widths': [1, 1, 1], 'tcgen05_persistence_model': 'non_persistent', 'tcgen05_layout_overrides_epi_tile_m': None, 'tcgen05_layout_overrides_epi_tile_n': None, 'tcgen05_layout_overrides_smem_swizzle_a': None, 'tcgen05_layout_overrides_smem_swizzle_b': None, 'tcgen05_layout_overrides_d_store_box_n': None},
+    # Re-tuned to the fp8 small-grid 2-CTA cluster (bm=128, cluster_m=2, per-CTA
+    # 64xbn) with a deep ab=12 prefetch. cluster_m=2 doubles the CTA count to 256
+    # (fills the 148-SM B200; the old cluster_m=1 bm=128 tile ran at 0.86 waves)
+    # and multicasts A across the CTA pair, halving its cold DRAM read. Cold-L2
+    # cudagraph vs best baseline (cutlass): 0.73x -> 0.80x on B200.
+    {'block_sizes': [128, 128, 128], 'l2_groupings': [1], 'num_warps': 8, 'num_stages': 4, 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_interleaved', 'tcgen05_cluster_m': 2, 'tcgen05_cluster_n': 1, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_ab_stages': 12, 'tcgen05_num_epi_warps': 4, 'tcgen05_persistence_model': 'static_persistent'},
     # (M, K, N) = (512, 2048, 2048)
-    {'block_sizes': [128, 64, 128], 'l2_groupings': [2], 'indexing': ['pointer', 'tensor_descriptor', 'pointer', 'pointer', 'tensor_descriptor'], 'pid_type': 'flat', 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 8, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 1, 'tcgen05_strategy': 'role_local_monolithic', 'tcgen05_layout_strategy': 'default', 'tcgen05_warp_spec_mma_warps': 1, 'tcgen05_warp_spec_ab_load_warps': 1, 'tcgen05_warp_spec_epi_load_warps': 0, 'tcgen05_warp_spec_scheduler_warps': 0, 'tcgen05_warp_spec_c_input_warps': 0, 'tcgen05_warp_spec_store_warps': 0, 'tcgen05_warp_spec_register_decrease': 120, 'tcgen05_warp_spec_register_increase': 256, 'cute_vector_widths': [1, 1, 1], 'tcgen05_persistence_model': 'non_persistent', 'tcgen05_layout_overrides_epi_tile_m': None, 'tcgen05_layout_overrides_epi_tile_n': None, 'tcgen05_layout_overrides_smem_swizzle_a': None, 'tcgen05_layout_overrides_smem_swizzle_b': None, 'tcgen05_layout_overrides_d_store_box_n': None},
+    # Same fp8 small-grid 2-CTA cluster as (512, 2048, 4096): device-filling
+    # cluster_m=2 + A-multicast + deep ab=12 beats the old cluster_m=1 bn=64 tile.
+    # Cold-L2 cudagraph vs best baseline (torch): 0.86x -> 0.91x on B200.
+    {'block_sizes': [128, 128, 128], 'l2_groupings': [1], 'num_warps': 8, 'num_stages': 4, 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_interleaved', 'tcgen05_cluster_m': 2, 'tcgen05_cluster_n': 1, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_ab_stages': 12, 'tcgen05_num_epi_warps': 4, 'tcgen05_persistence_model': 'static_persistent'},
 ]
 
 

--- a/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
+++ b/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
@@ -79,6 +79,10 @@ _KEYS_scale_mm_cute = [
     (4096, 4096, 4096),
     (512, 2048, 4096),
     (512, 2048, 2048),
+    (16, 2048, 4096),
+    (16, 2048, 12288),
+    (16, 4096, 6144),
+    (16, 4096, 24576),
 ]
 
 _CONFIGS_scale_mm_cute = [
@@ -96,6 +100,18 @@ _CONFIGS_scale_mm_cute = [
     # cluster_m=2 + A-multicast + deep ab=12 beats the old cluster_m=1 bn=64 tile.
     # Cold-L2 cudagraph vs best baseline (torch): 0.86x -> 0.91x on B200.
     {'block_sizes': [128, 128, 128], 'l2_groupings': [1], 'num_warps': 8, 'num_stages': 4, 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_interleaved', 'tcgen05_cluster_m': 2, 'tcgen05_cluster_n': 1, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_ab_stages': 12, 'tcgen05_num_epi_warps': 4, 'tcgen05_persistence_model': 'static_persistent'},
+    # (M, K, N) = (16, 2048, 4096)
+    # Tiny-M (M=16) normal-kernel autotune (full effort, ~640 configs, cold-L2
+    # cudagraph). Collapses to tiny tiles (block_m<=4) because the pre-#2840 CuTe
+    # backend crashed on any block_m>=64 tcgen05 config at static M<64, so the
+    # real MMA path was unreachable -- ~0.13x vs torch. Checkpoint before #2840.
+    {'block_sizes': [4, 64, 2048], 'num_threads': [0, 64, 1], 'loop_orders': [[0, 1]], 'cute_vector_widths': [2, 4, 8]},
+    # (M, K, N) = (16, 2048, 12288)  (~0.06x vs torch)
+    {'block_sizes': [2, 64, 2048], 'num_threads': [2, 0, 1], 'loop_orders': [[0, 1]], 'cute_vector_widths': [2, 4, 8]},
+    # (M, K, N) = (16, 4096, 6144)  (~0.06x vs torch)
+    {'block_sizes': [1, 32, 4096], 'num_threads': [1, 0, 1], 'loop_orders': [[0, 1]], 'epilogue_subtile': 2, 'cute_vector_widths': [8, 1, 8]},
+    # (M, K, N) = (16, 4096, 24576)  (~0.05x vs torch)
+    {'block_sizes': [2, 64, 1024], 'num_threads': [2, 0, 1], 'loop_orders': [[0, 1]], 'epilogue_subtile': 2, 'cute_vector_widths': [1, 2, 8]},
 ]
 
 

--- a/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
+++ b/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
@@ -1,0 +1,93 @@
+"""
+Auto-generated heuristic for kernels: scale_mm_cute, scale_mm_cute_skinny_m
+Backend: explicit per-shape table (exact (M, K, N) -> tuned config)
+
+RowWise-scaled FP8 GEMM pretuned on NVIDIA B200 (sm100) for the Helion CuTe
+(tcgen05) backend. Configs were autotuned under CUDA-graph benchmarking (how
+these decode / small-batch GEMMs are actually invoked); each shape keeps its
+own best config (best of the wall-clock and cudagraph autotune sweeps, chosen
+by a per-shape cudagraph microbenchmark).
+
+Each tuned (M, K, N) maps to its own config; an unseen shape falls back to the
+nearest tuned (M, K, N) (smallest sum of absolute log-ratios over M, K, N).
+
+Provides, for each kernel <k>:
+- key_<k>(*args): config index (also the runtime cache key)
+- autotune_<k>(*args): config dict for the given arguments
+"""
+
+import math
+
+import torch
+
+
+def _mkn(args):
+    """(M, K, N) from raw kernel args: x[M, K], y[K, N]."""
+    x, y = args[0], args[1]
+    return int(x.shape[0]), int(x.shape[1]), int(y.shape[1])
+
+
+def _select(keys, mkn):
+    """Exact (M, K, N) match if tuned, else the nearest tuned shape."""
+    for i, k in enumerate(keys):
+        if tuple(k) == mkn:
+            return i
+    best_i, best_d = 0, float('inf')
+    for i, k in enumerate(keys):
+        d = sum(abs(math.log(max(a, 1)) - math.log(max(b, 1))) for a, b in zip(k, mkn))
+        if d < best_d:
+            best_i, best_d = i, d
+    return best_i
+
+
+# === Kernel: scale_mm_cute_skinny_m ===
+# Tuned (M, K, N) shapes, parallel to _CONFIGS_scale_mm_cute_skinny_m.
+_KEYS_scale_mm_cute_skinny_m = [
+    (1, 4096, 4096),
+    (1, 4096, 256),
+]
+
+_CONFIGS_scale_mm_cute_skinny_m = [
+    # (M, K, N) = (1, 4096, 4096)
+    {'block_sizes': [1, 512], 'num_threads': [0, 32], 'cute_vector_widths': [1, 8]},
+    # (M, K, N) = (1, 4096, 256)
+    {'block_sizes': [1, 256], 'num_threads': [0, 32], 'cute_vector_widths': [8, 8]},
+]
+
+
+def key_scale_mm_cute_skinny_m(*args) -> int:
+    """Config index for the given args (also the cache key)."""
+    return _select(_KEYS_scale_mm_cute_skinny_m, _mkn(args))
+
+
+def autotune_scale_mm_cute_skinny_m(*args) -> dict:
+    """Config dict for the given args."""
+    return _CONFIGS_scale_mm_cute_skinny_m[key_scale_mm_cute_skinny_m(*args)]
+
+
+# === Kernel: scale_mm_cute ===
+# Tuned (M, K, N) shapes, parallel to _CONFIGS_scale_mm_cute.
+_KEYS_scale_mm_cute = [
+    (4096, 4096, 4096),
+    (512, 2048, 4096),
+    (512, 2048, 2048),
+]
+
+_CONFIGS_scale_mm_cute = [
+    # (M, K, N) = (4096, 4096, 4096)
+    {'block_sizes': [256, 256, 128], 'l2_groupings': [4], 'indexing': ['pointer', 'pointer', 'pointer', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_interleaved', 'tcgen05_cluster_m': 2, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 6, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 8, 'tcgen05_strategy': 'role_local_monolithic', 'tcgen05_layout_strategy': 'default', 'tcgen05_warp_spec_mma_warps': 1, 'tcgen05_warp_spec_ab_load_warps': 1, 'tcgen05_warp_spec_epi_load_warps': 0, 'tcgen05_warp_spec_scheduler_warps': 0, 'tcgen05_warp_spec_c_input_warps': 0, 'tcgen05_warp_spec_store_warps': 0, 'tcgen05_warp_spec_register_decrease': 120, 'tcgen05_warp_spec_register_increase': 256, 'cute_vector_widths': [1, 1, 1], 'tcgen05_persistence_model': 'static_persistent', 'tcgen05_layout_overrides_epi_tile_m': None, 'tcgen05_layout_overrides_epi_tile_n': None, 'tcgen05_layout_overrides_smem_swizzle_a': None, 'tcgen05_layout_overrides_smem_swizzle_b': None, 'tcgen05_layout_overrides_d_store_box_n': None},
+    # (M, K, N) = (512, 2048, 4096)
+    {'block_sizes': [128, 128, 128], 'l2_groupings': [1], 'indexing': ['tensor_descriptor', 'pointer', 'pointer', 'pointer', 'tensor_descriptor'], 'pid_type': 'flat', 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 6, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 4, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 1, 'tcgen05_strategy': 'role_local_monolithic', 'tcgen05_layout_strategy': 'default', 'tcgen05_warp_spec_mma_warps': 1, 'tcgen05_warp_spec_ab_load_warps': 1, 'tcgen05_warp_spec_epi_load_warps': 0, 'tcgen05_warp_spec_scheduler_warps': 0, 'tcgen05_warp_spec_c_input_warps': 0, 'tcgen05_warp_spec_store_warps': 0, 'tcgen05_warp_spec_register_decrease': 120, 'tcgen05_warp_spec_register_increase': 256, 'cute_vector_widths': [1, 1, 1], 'tcgen05_persistence_model': 'non_persistent', 'tcgen05_layout_overrides_epi_tile_m': None, 'tcgen05_layout_overrides_epi_tile_n': None, 'tcgen05_layout_overrides_smem_swizzle_a': None, 'tcgen05_layout_overrides_smem_swizzle_b': None, 'tcgen05_layout_overrides_d_store_box_n': None},
+    # (M, K, N) = (512, 2048, 2048)
+    {'block_sizes': [128, 64, 128], 'l2_groupings': [2], 'indexing': ['pointer', 'tensor_descriptor', 'pointer', 'pointer', 'tensor_descriptor'], 'pid_type': 'flat', 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 1, 'tcgen05_ab_stages': 8, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4, 'tcgen05_l2_swizzle_size': 1, 'tcgen05_strategy': 'role_local_monolithic', 'tcgen05_layout_strategy': 'default', 'tcgen05_warp_spec_mma_warps': 1, 'tcgen05_warp_spec_ab_load_warps': 1, 'tcgen05_warp_spec_epi_load_warps': 0, 'tcgen05_warp_spec_scheduler_warps': 0, 'tcgen05_warp_spec_c_input_warps': 0, 'tcgen05_warp_spec_store_warps': 0, 'tcgen05_warp_spec_register_decrease': 120, 'tcgen05_warp_spec_register_increase': 256, 'cute_vector_widths': [1, 1, 1], 'tcgen05_persistence_model': 'non_persistent', 'tcgen05_layout_overrides_epi_tile_m': None, 'tcgen05_layout_overrides_epi_tile_n': None, 'tcgen05_layout_overrides_smem_swizzle_a': None, 'tcgen05_layout_overrides_smem_swizzle_b': None, 'tcgen05_layout_overrides_d_store_box_n': None},
+]
+
+
+def key_scale_mm_cute(*args) -> int:
+    """Config index for the given args (also the cache key)."""
+    return _select(_KEYS_scale_mm_cute, _mkn(args))
+
+
+def autotune_scale_mm_cute(*args) -> dict:
+    """Config dict for the given args."""
+    return _CONFIGS_scale_mm_cute[key_scale_mm_cute(*args)]

--- a/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
+++ b/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
@@ -106,8 +106,10 @@ _CONFIGS_scale_mm_cute = [
     # (pre-autotune) from the full-stack sweep -- ~14.9us cold-L2 cudagraph =
     # 0.60x vs torch (was 68us / 0.13x on the pre-stack tiny-tile path).
     {'block_sizes': [128, 128, 128], 'cute_vector_widths': [1, 1, 1], 'loop_orders': [[0, 1]], 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 2, 'tcgen05_ab_stages': 6, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4},
-    # (M, K, N) = (16, 2048, 12288)  padded-M tcgen05 seed; ~19.9us (0.55x vs torch)
-    {'block_sizes': [64, 256, 128], 'cute_vector_widths': [1, 1, 1], 'loop_orders': [[0, 1]], 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 2, 'tcgen05_ab_stages': 3, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4},
+    # (M, K, N) = (16, 2048, 12288)  hand-tuned padded-M tcgen05; ~15.9us (0.67x
+    # vs torch, 1.6 TB/s). block_n=128 is the CTA-count sweet spot (96 CTAs);
+    # smaller bn adds CTAs but loses tile efficiency, larger bn under-fills SMs.
+    {'block_sizes': [64, 128, 128], 'cute_vector_widths': [1, 1, 1], 'loop_orders': [[0, 1]], 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 2, 'tcgen05_ab_stages': 6, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4},
     # (M, K, N) = (16, 4096, 6144)  padded-M tcgen05 seed; ~26.6us (0.47x vs torch)
     {'block_sizes': [64, 256, 128], 'cute_vector_widths': [1, 1, 1], 'loop_orders': [[0, 1]], 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 2, 'tcgen05_ab_stages': 3, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4},
     # (M, K, N) = (16, 4096, 24576)  padded-M tcgen05 seed; ~37.8us (0.79x vs torch)

--- a/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
+++ b/pretuned_kernels/scale_mm_cute/_helion_aot_scale_mm_cute_cuda_sm100.py
@@ -101,17 +101,17 @@ _CONFIGS_scale_mm_cute = [
     # Cold-L2 cudagraph vs best baseline (torch): 0.86x -> 0.91x on B200.
     {'block_sizes': [128, 128, 128], 'l2_groupings': [1], 'num_warps': 8, 'num_stages': 4, 'indexing': ['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], 'pid_type': 'persistent_interleaved', 'tcgen05_cluster_m': 2, 'tcgen05_cluster_n': 1, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_ab_stages': 12, 'tcgen05_num_epi_warps': 4, 'tcgen05_persistence_model': 'static_persistent'},
     # (M, K, N) = (16, 2048, 4096)
-    # Tiny-M (M=16) normal-kernel autotune (full effort, ~640 configs, cold-L2
-    # cudagraph). Collapses to tiny tiles (block_m<=4) because the pre-#2840 CuTe
-    # backend crashed on any block_m>=64 tcgen05 config at static M<64, so the
-    # real MMA path was unreachable -- ~0.13x vs torch. Checkpoint before #2840.
-    {'block_sizes': [4, 64, 2048], 'num_threads': [0, 64, 1], 'loop_orders': [[0, 1]], 'cute_vector_widths': [2, 4, 8]},
-    # (M, K, N) = (16, 2048, 12288)  (~0.06x vs torch)
-    {'block_sizes': [2, 64, 2048], 'num_threads': [2, 0, 1], 'loop_orders': [[0, 1]], 'cute_vector_widths': [2, 4, 8]},
-    # (M, K, N) = (16, 4096, 6144)  (~0.06x vs torch)
-    {'block_sizes': [1, 32, 4096], 'num_threads': [1, 0, 1], 'loop_orders': [[0, 1]], 'epilogue_subtile': 2, 'cute_vector_widths': [8, 1, 8]},
-    # (M, K, N) = (16, 4096, 24576)  (~0.05x vs torch)
-    {'block_sizes': [2, 64, 1024], 'num_threads': [2, 0, 1], 'loop_orders': [[0, 1]], 'epilogue_subtile': 2, 'cute_vector_widths': [1, 2, 8]},
+    # Padded-M tcgen05 (stack #2840-#2854): block_m=128 padded from the real
+    # M=16 with N-axis cluster_n=2 A-multicast (#2843/#2845). Seed-level config
+    # (pre-autotune) from the full-stack sweep -- ~14.9us cold-L2 cudagraph =
+    # 0.60x vs torch (was 68us / 0.13x on the pre-stack tiny-tile path).
+    {'block_sizes': [128, 128, 128], 'cute_vector_widths': [1, 1, 1], 'loop_orders': [[0, 1]], 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 2, 'tcgen05_ab_stages': 6, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4},
+    # (M, K, N) = (16, 2048, 12288)  padded-M tcgen05 seed; ~19.9us (0.55x vs torch)
+    {'block_sizes': [64, 256, 128], 'cute_vector_widths': [1, 1, 1], 'loop_orders': [[0, 1]], 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 2, 'tcgen05_ab_stages': 3, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4},
+    # (M, K, N) = (16, 4096, 6144)  padded-M tcgen05 seed; ~26.6us (0.47x vs torch)
+    {'block_sizes': [64, 256, 128], 'cute_vector_widths': [1, 1, 1], 'loop_orders': [[0, 1]], 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 2, 'tcgen05_ab_stages': 3, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4},
+    # (M, K, N) = (16, 4096, 24576)  padded-M tcgen05 seed; ~37.8us (0.79x vs torch)
+    {'block_sizes': [64, 256, 128], 'cute_vector_widths': [1, 1, 1], 'loop_orders': [[0, 1]], 'tcgen05_cluster_m': 1, 'tcgen05_cluster_n': 2, 'tcgen05_ab_stages': 3, 'tcgen05_acc_stages': 2, 'tcgen05_c_stages': 2, 'tcgen05_num_epi_warps': 4},
 ]
 
 

--- a/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
+++ b/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import math
 
 import torch
-import triton.testing as tt
 
 import helion.experimental
 import helion.language as hl
@@ -150,8 +149,9 @@ def _baselines() -> list[tuple[str, object]]:
 def use_cudagraph() -> bool:
     """Whether main() benchmarks under CUDA graphs (read by pretuned_kernels/run.py).
 
-    True: main() times these decode / small-batch GEMMs with do_bench_cudagraph
-    (how vLLM invokes the kernel), which removes per-call host launch overhead.
+    True: main() times these decode / small-batch GEMMs under CUDA graphs (how
+    vLLM invokes the kernel), which removes per-call host launch overhead. The
+    shared _bench loop clears the L2 cache before every replay (cold L2).
     """
     return True
 
@@ -182,95 +182,37 @@ def _make_inputs(
 
 
 def main(verbose: bool = True) -> dict:
-    def _p(*args: object) -> None:
-        if verbose:
-            print(*args)
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from _bench import run_sweep
 
     baselines = _baselines()
-    names = [n for n, _ in baselines]
-    _p(
-        f"GPU: {torch.cuda.get_device_name()} "
-        f"(baselines: {', '.join(names)}; SUMMARY vs best/fastest baseline)"
-    )
-    base_hdr = "  ".join(f"{n + ' (us)':>12s}" for n in names)
-    _p(
-        f"{'M':>6s}  {'K':>6s}  {'N':>6s}  {'helion (us)':>12s}  "
-        f"{base_hdr}  {'speedup':>8s}"
-    )
-    _p("-" * (45 + 14 * len(names)))
 
-    speedups_by_base: dict[str, list[float]] = {n: [] for n in names}
-    best_speedups: list[float] = []  # helion vs the fastest baseline each shape
-    helion_wins = 0
-    best_speedup = 0.0
-    best_shape = (0, 0, 0)
-    for M, K, N in SHAPES:
+    def make_calls(shape: tuple[int, int, int]) -> tuple:
+        M, K, N = shape
         x, y, scale_a, scale_b = _make_inputs(M, K, N)
 
-        _scale_mm_cute(x, y, scale_a, scale_b)  # warmup / compile
-        ms_helion = tt.do_bench_cudagraph(
-            lambda x=x, y=y, sa=scale_a, sb=scale_b: _scale_mm_cute(x, y, sa, sb),
-            rep=100,
-            return_mode="median",
-        )
-        base_ms: dict[str, float] = {}
-        for name, fn in baselines:
-            base_ms[name] = tt.do_bench_cudagraph(
-                lambda fn=fn, x=x, y=y, sa=scale_a, sb=scale_b: fn(x, y, sa, sb),
-                rep=100,
-                return_mode="median",
-            )
-            speedups_by_base[name].append(
-                base_ms[name] / ms_helion if ms_helion > 0 else float("nan")
-            )
-        best_base = min(base_ms, key=base_ms.get)  # fastest baseline this shape
-        speedup = base_ms[best_base] / ms_helion if ms_helion > 0 else float("nan")
-        best_speedups.append(speedup)
-        if speedup > 1.0:
-            helion_wins += 1
-        if speedup > best_speedup:
-            best_speedup = speedup
-            best_shape = (M, K, N)
-        base_cols = "  ".join(f"{base_ms[n] * 1000:>12.2f}" for n in names)
-        _p(
-            f"{M:>6d}  {K:>6d}  {N:>6d}  {ms_helion * 1000:>12.2f}  "
-            f"{base_cols}  {speedup:>7.2f}x  (vs {best_base})"
-        )
+        def helion_call() -> None:
+            _scale_mm_cute(x, y, scale_a, scale_b)
 
-    def _geomean(vals: list[float]) -> float:
-        pos = [s for s in vals if s > 0]
-        return math.exp(sum(math.log(s) for s in pos) / max(len(pos), 1))
+        base_calls = [
+            (name, (lambda fn=fn: fn(x, y, scale_a, scale_b))) for name, fn in baselines
+        ]
+        return helion_call, base_calls, f"{M:>6d}  {K:>6d}  {N:>6d}"
 
-    # Per-baseline breakdown (helion speedup over each specific baseline),
-    # consumed by pretuned_kernels/run.py for the dashboard's per-kernel dropdown.
-    per_baseline = {
-        name: {
-            "wins": sum(1 for s in speedups_by_base[name] if s > 1.0),
-            "total": len(speedups_by_base[name]),
-            "geomean": round(_geomean(speedups_by_base[name]), 4),
-            "best_speedup": round(max(speedups_by_base[name], default=0.0), 4),
-        }
-        for name in names
-    }
-    for name in names:
-        m = per_baseline[name]
-        _p(
-            f"vs {name}: wins={m['wins']}/{m['total']} "
-            f"geomean={m['geomean']:.3f}x best={m['best_speedup']:.2f}x"
-        )
-    geomean = _geomean(best_speedups)
-    _p(
-        f"\nHelion faster on {helion_wins}/{len(SHAPES)} shapes vs the best "
-        f"baseline; geomean speedup {geomean:.3f}x; "
-        f"best speedup {best_speedup:.2f}x at (M, K, N)={best_shape}."
+    # run_sweep benchmarks under CUDA graphs (how these decode / small-batch GEMMs
+    # are invoked; removes per-call host launch overhead) with L2 cache clearing
+    # before every replay (see _bench) -- the fp8 configs are tuned for this
+    # cold-L2 regime (PR #2821: the 2-CTA A-multicast win only shows cold).
+    return run_sweep(
+        SHAPES,
+        make_calls,
+        use_cudagraph=use_cudagraph(),
+        verbose=verbose,
+        shape_header=f"{'M':>6s}  {'K':>6s}  {'N':>6s}",
     )
-    return {
-        "helion_wins": helion_wins,
-        "total": len(SHAPES),
-        "geomean": round(geomean, 4),
-        "best_speedup": round(best_speedup, 4),
-        "baselines": per_baseline,
-    }
 
 
 if __name__ == "__main__":

--- a/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
+++ b/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
@@ -1,0 +1,277 @@
+"""RowWise-scaled FP8 GEMM for the B200 CuTe (tcgen05) backend.
+
+``out = (scale_a * (x @ y)) * scale_b`` with a per-row ``scale_a`` and a
+per-column ``scale_b``, accumulating in FP32 and returning BF16.
+
+The kernel is ported from https://github.com/pytorch/helion/pull/2788/
+(``examples/fp8_gemm.py``).  It runs on Helion's CuTe (tcgen05) backend and is
+pretuned for the skinny-M (decode / small-batch) and small decoder-layer FP8
+W8A8 serving shapes that back the nightly B200 CuTe benchmark dashboard.
+
+Two kernels ship:
+
+* :func:`scale_mm_cute` tiles over both M and N.
+* :func:`scale_mm_cute_skinny_m` keeps the full (small) M resident and tiles
+  only over N, which the CuTe backend runs faster for tiny M.
+
+:func:`_scale_mm_cute` dispatches to the skinny-M kernel when ``M <= 16``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import triton.testing as tt
+
+import helion.experimental
+import helion.language as hl
+
+# M at or below this uses the skinny-M kernel (mirrors examples/fp8_gemm.py).
+_SKINNY_M_MAX = 16
+
+
+@helion.experimental.aot_kernel(backend="cute", static_shapes=True)
+def scale_mm_cute(
+    x: torch.Tensor,  # [M, K] fp8
+    y: torch.Tensor,  # [K, N] fp8
+    scale_a: torch.Tensor,  # [M, N] per-row scale broadcast to [M, N]
+    scale_b: torch.Tensor,  # [N] per-column scale
+) -> torch.Tensor:
+    """RowWise-scaled FP8 GEMM (tiled over M and N). Returns BF16 [M, N]."""
+    m, k = x.size()
+    k2, n = y.size()
+    assert k == k2, f"size mismatch {k} != {k2}"
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[tile_m, tile_k], y[tile_k, tile_n], acc=acc)
+        # RowWise scale in the epilogue (per-row scale_a x per-column scale_b).
+        acc = acc * scale_a[tile_m, tile_n] * scale_b[tile_n]
+        out[tile_m, tile_n] = acc.to(torch.bfloat16)
+    return out
+
+
+@helion.experimental.aot_kernel(backend="cute", static_shapes=True)
+def scale_mm_cute_skinny_m(
+    x: torch.Tensor,  # [M, K] fp8
+    y: torch.Tensor,  # [K, N] fp8
+    scale_a: torch.Tensor,  # [M, N] per-row scale broadcast to [M, N]
+    scale_b: torch.Tensor,  # [N] per-column scale
+) -> torch.Tensor:
+    """Skinny-M variant of :func:`scale_mm_cute` for the CuTe (tcgen05) backend.
+
+    Keeps the full (small) M dimension resident and tiles only over N, which the
+    CuTe backend runs faster than the [M, N]-tiled kernel when M is tiny (decode
+    / small-batch). Same RowWise-scale layout and BF16 output.
+    """
+    m, k = x.size()
+    k2, n = y.size()
+    assert k == k2, f"size mismatch {k} != {k2}"
+    out = torch.empty([m, n], dtype=torch.bfloat16, device=x.device)
+    for tile_n in hl.tile(n):
+        acc = hl.zeros([m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = hl.dot(x[:, tile_k], y[tile_k, tile_n], acc=acc)
+        acc = acc * scale_a[:, tile_n] * scale_b[tile_n]
+        out[:, tile_n] = acc.to(torch.bfloat16)
+    return out
+
+
+def _scale_mm_cute(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> torch.Tensor:
+    """Dispatch to the skinny-M kernel for small M, else the [M, N]-tiled one."""
+    if x.size(0) <= _SKINNY_M_MAX:
+        return scale_mm_cute_skinny_m(x, y, scale_a, scale_b)
+    return scale_mm_cute(x, y, scale_a, scale_b)
+
+
+def _scale_mm_torch(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_a: torch.Tensor,  # [M, N] broadcast view of the per-row scale
+    scale_b: torch.Tensor,  # [N] per-column scale
+) -> torch.Tensor:
+    """RowWise baseline via torch._scaled_mm (per-row [M, 1] / per-col [1, N])."""
+    sa = scale_a[:, :1].contiguous()
+    sb = scale_b.reshape(1, -1)
+    # torch._scaled_mm requires a column-major second operand.
+    if y.stride(0) == 1 and y.stride(1) > 1:
+        y_col_major = y
+    else:
+        y_col_major = y.T.contiguous().T
+    return torch._scaled_mm(
+        x, y_col_major, sa, sb, use_fast_accum=False, out_dtype=torch.bfloat16
+    )
+
+
+# Optional vLLM CUTLASS baseline (the production FP8 GEMM this is benchmarked
+# against). The pretuned test env has only torch + helion (guarded import); the
+# nightly benchmark workflow installs vLLM, so main() then compares against it.
+try:
+    from vllm import _custom_ops as _vllm_ops
+
+    _HAS_VLLM = hasattr(_vllm_ops, "cutlass_scaled_mm")
+except ImportError:
+    _vllm_ops = None
+    _HAS_VLLM = False
+
+
+def _scale_mm_cutlass(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    scale_a: torch.Tensor,  # [M, N] broadcast view of the per-row scale
+    scale_b: torch.Tensor,  # [N] per-column scale
+) -> torch.Tensor:
+    """vLLM CUTLASS RowWise baseline (ops.cutlass_scaled_mm)."""
+    sa = scale_a[:, :1].contiguous()
+    sb = scale_b.reshape(-1, 1).contiguous()
+    return _vllm_ops.cutlass_scaled_mm(x, y, sa, sb, torch.bfloat16, None)
+
+
+def _baselines() -> list[tuple[str, object]]:
+    """Baselines main() benchmarks helion against.
+
+    torch._scaled_mm is always available; vLLM's CUTLASS kernel is added when
+    vLLM is installed (the nightly benchmark env). The SUMMARY speedup is helion
+    vs the best (fastest) available baseline.
+    """
+    baselines: list[tuple[str, object]] = [("torch", _scale_mm_torch)]
+    if _HAS_VLLM:
+        baselines.append(("cutlass", _scale_mm_cutlass))
+    return baselines
+
+
+def use_cudagraph() -> bool:
+    """Whether main() benchmarks under CUDA graphs (read by pretuned_kernels/run.py).
+
+    True: main() times these decode / small-batch GEMMs with do_bench_cudagraph
+    (how vLLM invokes the kernel), which removes per-call host launch overhead.
+    """
+    return True
+
+
+# Skinny-M (decode / small-batch) + small decoder-layer FP8 W8A8 serving shapes
+# that back the nightly B200 CuTe dashboard (benchmarks/run.py, PR #2788).
+SHAPES = [  # (M, K, N)
+    (1, 4096, 4096),
+    (4096, 4096, 4096),
+    (1, 4096, 256),
+    (512, 2048, 4096),
+    (512, 2048, 2048),
+]
+
+
+def _make_inputs(
+    m: int, k: int, n: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    scale = 1.0 / math.sqrt(k)
+    x = (scale * torch.randn(m, k, device="cuda")).to(torch.float8_e4m3fn)
+    # y in [k, n] with a column-major (k contiguous) layout, as torch._scaled_mm
+    # and cutlass_scaled_mm want for the second operand.
+    y = (scale * torch.randn(k, n, device="cuda")).to(torch.float8_e4m3fn)
+    y = y.T.contiguous().T
+    scale_a = (torch.rand(m, 1, device="cuda") + 0.5).expand(m, n)
+    scale_b = torch.rand(n, device="cuda") + 0.5
+    return x, y, scale_a, scale_b
+
+
+def main(verbose: bool = True) -> dict:
+    def _p(*args: object) -> None:
+        if verbose:
+            print(*args)
+
+    baselines = _baselines()
+    names = [n for n, _ in baselines]
+    _p(
+        f"GPU: {torch.cuda.get_device_name()} "
+        f"(baselines: {', '.join(names)}; SUMMARY vs best/fastest baseline)"
+    )
+    base_hdr = "  ".join(f"{n + ' (us)':>12s}" for n in names)
+    _p(
+        f"{'M':>6s}  {'K':>6s}  {'N':>6s}  {'helion (us)':>12s}  "
+        f"{base_hdr}  {'speedup':>8s}"
+    )
+    _p("-" * (45 + 14 * len(names)))
+
+    speedups_by_base: dict[str, list[float]] = {n: [] for n in names}
+    best_speedups: list[float] = []  # helion vs the fastest baseline each shape
+    helion_wins = 0
+    best_speedup = 0.0
+    best_shape = (0, 0, 0)
+    for M, K, N in SHAPES:
+        x, y, scale_a, scale_b = _make_inputs(M, K, N)
+
+        _scale_mm_cute(x, y, scale_a, scale_b)  # warmup / compile
+        ms_helion = tt.do_bench_cudagraph(
+            lambda x=x, y=y, sa=scale_a, sb=scale_b: _scale_mm_cute(x, y, sa, sb),
+            rep=100,
+            return_mode="median",
+        )
+        base_ms: dict[str, float] = {}
+        for name, fn in baselines:
+            base_ms[name] = tt.do_bench_cudagraph(
+                lambda fn=fn, x=x, y=y, sa=scale_a, sb=scale_b: fn(x, y, sa, sb),
+                rep=100,
+                return_mode="median",
+            )
+            speedups_by_base[name].append(
+                base_ms[name] / ms_helion if ms_helion > 0 else float("nan")
+            )
+        best_base = min(base_ms, key=base_ms.get)  # fastest baseline this shape
+        speedup = base_ms[best_base] / ms_helion if ms_helion > 0 else float("nan")
+        best_speedups.append(speedup)
+        if speedup > 1.0:
+            helion_wins += 1
+        if speedup > best_speedup:
+            best_speedup = speedup
+            best_shape = (M, K, N)
+        base_cols = "  ".join(f"{base_ms[n] * 1000:>12.2f}" for n in names)
+        _p(
+            f"{M:>6d}  {K:>6d}  {N:>6d}  {ms_helion * 1000:>12.2f}  "
+            f"{base_cols}  {speedup:>7.2f}x  (vs {best_base})"
+        )
+
+    def _geomean(vals: list[float]) -> float:
+        pos = [s for s in vals if s > 0]
+        return math.exp(sum(math.log(s) for s in pos) / max(len(pos), 1))
+
+    # Per-baseline breakdown (helion speedup over each specific baseline),
+    # consumed by pretuned_kernels/run.py for the dashboard's per-kernel dropdown.
+    per_baseline = {
+        name: {
+            "wins": sum(1 for s in speedups_by_base[name] if s > 1.0),
+            "total": len(speedups_by_base[name]),
+            "geomean": round(_geomean(speedups_by_base[name]), 4),
+            "best_speedup": round(max(speedups_by_base[name], default=0.0), 4),
+        }
+        for name in names
+    }
+    for name in names:
+        m = per_baseline[name]
+        _p(
+            f"vs {name}: wins={m['wins']}/{m['total']} "
+            f"geomean={m['geomean']:.3f}x best={m['best_speedup']:.2f}x"
+        )
+    geomean = _geomean(best_speedups)
+    _p(
+        f"\nHelion faster on {helion_wins}/{len(SHAPES)} shapes vs the best "
+        f"baseline; geomean speedup {geomean:.3f}x; "
+        f"best speedup {best_speedup:.2f}x at (M, K, N)={best_shape}."
+    )
+    return {
+        "helion_wins": helion_wins,
+        "total": len(SHAPES),
+        "geomean": round(geomean, 4),
+        "best_speedup": round(best_speedup, 4),
+        "baselines": per_baseline,
+    }
+
+
+if __name__ == "__main__":
+    main()

--- a/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
+++ b/pretuned_kernels/scale_mm_cute/scale_mm_cute.py
@@ -14,7 +14,7 @@ Two kernels ship:
 * :func:`scale_mm_cute_skinny_m` keeps the full (small) M resident and tiles
   only over N, which the CuTe backend runs faster for tiny M.
 
-:func:`_scale_mm_cute` dispatches to the skinny-M kernel when ``M <= 16``.
+:func:`_scale_mm_cute` dispatches to the skinny-M kernel when ``M <= 1``.
 """
 
 from __future__ import annotations
@@ -27,7 +27,7 @@ import helion.experimental
 import helion.language as hl
 
 # M at or below this uses the skinny-M kernel (mirrors examples/fp8_gemm.py).
-_SKINNY_M_MAX = 16
+_SKINNY_M_MAX = 1
 
 
 @helion.experimental.aot_kernel(backend="cute", static_shapes=True)

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -4177,39 +4177,68 @@ class TestCuteBackend(TestCase):
         self.assertIn("cute.nvgpu.tcgen05", code)
         self.assertIn("cute.gemm(", code)
 
-    def test_matmul_mma_fp8_small_static_m_does_not_crash(self) -> None:
-        """Regression for the small-static-M fp8 codegen crash.
+    def test_matmul_mma_fp8_small_static_m_padded_tile(self) -> None:
+        """Small-static-M fp8 now runs on a padded/masked tcgen05 M tile.
 
-        When the real problem M is < 64 but ``block_m`` is chosen >= 64, the
-        autotune config-spec did NOT register the ``tcgen05_*`` config keys
-        (its eligibility gate requires ``static_m >= TCGEN05_MIN_STATIC_M``),
-        yet codegen's ``_choose_mma_impl`` selected the tcgen05 path purely
-        from the block sizes. That mismatch raised
+        Background: when the real problem M is < 64 but ``block_m`` is chosen
+        >= 64, the autotune config-spec once did NOT register the ``tcgen05_*``
+        config keys (its eligibility gate required ``static_m >= 64``), yet
+        codegen's ``_choose_mma_impl`` selected the tcgen05 path purely from the
+        block sizes. That mismatch raised
         ``KeyError: 'tcgen05_warp_spec_ab_load_warps'`` at codegen time.
 
-        Codegen now gates tcgen05 on the same static-M threshold, so small-M
-        fp8 matmuls compile to a working path instead of crashing. M=16 and
-        M=32 must compile, run, and be numerically correct; M=64 must still
-        reach tcgen05.
+        Both sides now key the tcgen05 decision on ``block_m`` being a legal
+        tcgen05 M tile (64/128), NOT on the static M -- so they can never
+        diverge (no KeyError) AND a tiny-M GEMM runs on a padded/masked 64- or
+        128-row M tile (rows beyond the real M are masked off by the SIMT edge
+        epilogue / bounds-clamped TMA loads), exactly like CUTLASS' SM100 fp8
+        kernel. This is the win that lets M=16 reach the tensor-core path.
+
+        Asserts: M=16 and M=32 with block_m in {64, 128} compile WITHOUT the
+        KeyError crash, select tcgen05, and produce numerically correct output
+        (only the real M rows are written). M=64 (full tile) still reaches
+        tcgen05 as the control.
         """
         support = get_cute_mma_support()
         if not support.tcgen05_f8:
             self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
 
         torch.manual_seed(0)
+        # block_m > static_m (padded/masked M tile). Non-degenerate fp8 inputs
+        # spanning the e4m3 range so a masking bug is not hidden by ~0 outputs.
         for m in (16, 32):
-            x = (torch.randn(m, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
-            y = (torch.randn(128, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
-            # Must compile and run (no codegen crash) and be numerically correct.
-            _, out = code_and_output(
-                cute_matmul_mma_fp8, (x, y), block_sizes=[128, 128, 128]
-            )
-            ref = x.float() @ y.float()
-            torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+            for bm in (64, 128):
+                x = (
+                    (torch.randn(m, 128, device=DEVICE) * 4.0)
+                    .clamp(-400, 400)
+                    .to(torch.float8_e4m3fn)
+                )
+                y = (
+                    (torch.randn(128, 128, device=DEVICE) * 4.0)
+                    .clamp(-400, 400)
+                    .to(torch.float8_e4m3fn)
+                )
+                # Must not raise KeyError: 'tcgen05_warp_spec_ab_load_warps'.
+                code, out = code_and_output(
+                    cute_matmul_mma_fp8, (x, y), block_sizes=[bm, 128, 128]
+                )
+                ref = x.float() @ y.float()
+                self.assertEqual(tuple(out.shape), (m, 128))
+                torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+                # Padded M tile uses the validated tcgen05 tensor-core path.
+                self.assertIn("cute.nvgpu.tcgen05", code)
 
-        # Control: static M == 64 stays on the tcgen05 path.
-        x = (torch.randn(64, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
-        y = (torch.randn(128, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        # Control: static M == 64 (full tile) stays on the tcgen05 path.
+        x = (
+            (torch.randn(64, 128, device=DEVICE) * 4.0)
+            .clamp(-400, 400)
+            .to(torch.float8_e4m3fn)
+        )
+        y = (
+            (torch.randn(128, 128, device=DEVICE) * 4.0)
+            .clamp(-400, 400)
+            .to(torch.float8_e4m3fn)
+        )
         code, out = code_and_output(
             cute_matmul_mma_fp8, (x, y), block_sizes=[128, 128, 128]
         )

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -4246,6 +4246,67 @@ class TestCuteBackend(TestCase):
         torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
         self.assertIn("cute.nvgpu.tcgen05", code)
 
+    def test_matmul_mma_fp8_tiny_m_cluster_n2_a_multicast(self) -> None:
+        """Tiny-M padded tcgen05 fp8 with the N-only A-multicast cluster.
+
+        ``tcgen05_cluster_n=2`` with the default ``cluster_m=1`` builds a
+        (1,2,1) CtaGroup.ONE cluster: two CTAs each own their own N output
+        tile and run the flat non-persistent monolithic mainloop, sharing
+        only the A operand via a TMA multicast along N (mcast_mode=2). This
+        mirrors torch's ``_scaled_mm`` CUTLASS ClusterShape<1,2,1> selection
+        at M<=64, N>=3072 and is the right memory-bandwidth lever for tiny M
+        (cluster_m=2 has nothing to share along M).
+
+        Asserts the cluster_n=2 kernel: (1) compiles+runs without a hang or
+        InvalidClusterSize, (2) is numerically correct on multiple seeds at
+        the fp8 rounding floor for EVERY row (a multicast bug commonly drops
+        half the output or one CTA of the pair), (3) selects tcgen05, and
+        (4) launches a 2-CTA cluster (``_helion_cute_cluster_shape = (2, 1,
+        1)`` along the flat grid_x). Cross-checked against the cluster_n=1
+        baseline so the multicast cannot silently change the answer.
+        """
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        # N must be divisible by 2*block_n so the flat grid_x (n_tiles) is
+        # even and the (2,1,1) launch cluster divides it. block_n=128 -> N=512
+        # gives 4 N-tiles. M=16 padded onto a 64-row tile (single M-tile).
+        m, k, n = 16, 256, 512
+        bm, bn, bk = 64, 128, 64
+        for seed in range(3):
+            torch.manual_seed(seed)
+            x = (
+                (torch.randn(m, k, device=DEVICE) * 3.0)
+                .clamp(-448, 448)
+                .to(torch.float8_e4m3fn)
+            )
+            y = (
+                (torch.randn(k, n, device=DEVICE) * 3.0)
+                .clamp(-448, 448)
+                .to(torch.float8_e4m3fn)
+            )
+            ref = x.float() @ y.float()
+            base_cfg = {"block_sizes": [bm, bn, bk], "tcgen05_ab_stages": 8}
+            # Baseline (no cluster) for cross-check.
+            _, out_base = code_and_output(cute_matmul_mma_fp8, (x, y), **base_cfg)
+            # N-only A-multicast cluster.
+            code, out_cn2 = code_and_output(
+                cute_matmul_mma_fp8, (x, y), **base_cfg, tcgen05_cluster_n=2
+            )
+            self.assertEqual(tuple(out_cn2.shape), (m, n))
+            self.assertIn("cute.nvgpu.tcgen05", code)
+            # The 2-CTA cluster launches along the flat grid_x: (cluster_n,1,1).
+            self.assertIn("_helion_cute_cluster_shape = (2, 1, 1)", code)
+            # Every row at the fp8 floor (no dropped/half output).
+            torch.testing.assert_close(
+                out_cn2.float(), ref, atol=1.0, rtol=1e-1
+            )
+            # Multicast must not change the answer vs the non-clustered path.
+            torch.testing.assert_close(
+                out_cn2.float(), out_base.float(), atol=0.5, rtol=1e-2
+            )
+
     def test_matmul_mma_tcgen05_fp8_col_major_b(self) -> None:
         support = get_cute_mma_support()
         if not support.tcgen05_f8:

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -4177,6 +4177,46 @@ class TestCuteBackend(TestCase):
         self.assertIn("cute.nvgpu.tcgen05", code)
         self.assertIn("cute.gemm(", code)
 
+    def test_matmul_mma_fp8_small_static_m_does_not_crash(self) -> None:
+        """Regression for the small-static-M fp8 codegen crash.
+
+        When the real problem M is < 64 but ``block_m`` is chosen >= 64, the
+        autotune config-spec did NOT register the ``tcgen05_*`` config keys
+        (its eligibility gate requires ``static_m >= TCGEN05_MIN_STATIC_M``),
+        yet codegen's ``_choose_mma_impl`` selected the tcgen05 path purely
+        from the block sizes. That mismatch raised
+        ``KeyError: 'tcgen05_warp_spec_ab_load_warps'`` at codegen time.
+
+        Codegen now gates tcgen05 on the same static-M threshold, so small-M
+        fp8 matmuls compile to a working path instead of crashing. M=16 and
+        M=32 must compile, run, and be numerically correct; M=64 must still
+        reach tcgen05.
+        """
+        support = get_cute_mma_support()
+        if not support.tcgen05_f8:
+            self.skipTest("tcgen05 FP8 MMA is not supported on this machine")
+
+        torch.manual_seed(0)
+        for m in (16, 32):
+            x = (torch.randn(m, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+            y = (torch.randn(128, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+            # Must compile and run (no codegen crash) and be numerically correct.
+            _, out = code_and_output(
+                cute_matmul_mma_fp8, (x, y), block_sizes=[128, 128, 128]
+            )
+            ref = x.float() @ y.float()
+            torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+
+        # Control: static M == 64 stays on the tcgen05 path.
+        x = (torch.randn(64, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        y = (torch.randn(128, 128, device=DEVICE) * 0.4).to(torch.float8_e4m3fn)
+        code, out = code_and_output(
+            cute_matmul_mma_fp8, (x, y), block_sizes=[128, 128, 128]
+        )
+        ref = x.float() @ y.float()
+        torch.testing.assert_close(out.float(), ref, atol=1.0, rtol=1e-1)
+        self.assertIn("cute.nvgpu.tcgen05", code)
+
     def test_matmul_mma_tcgen05_fp8_col_major_b(self) -> None:
         support = get_cute_mma_support()
         if not support.tcgen05_f8:

--- a/test/test_dot_requirements.py
+++ b/test/test_dot_requirements.py
@@ -2512,8 +2512,10 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
         )
         self.assertEqual(errors, [], msg=str(errors))
 
-        # cluster_n=2 with cluster_m=1: rejected (requires the 4-CTA
-        # V=2 cluster).
+        # cluster_n=2 with cluster_m=1 under a PERSISTENT pid: rejected
+        # (the N-only A-multicast cluster only lowers on the flat
+        # NON_PERSISTENT grid; persistent grids have no cluster_m=1
+        # cluster_n=2 path).
         errors = validate_tcgen05_strategy_invariants(
             strategy=Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC,
             persistence_model=Tcgen05PersistenceModel.STATIC_PERSISTENT,
@@ -2528,6 +2530,23 @@ class TestDotRequirements(RefEagerTestDisabled, TestCase):
             any("requires tcgen05_cluster_m=2" in e for e in errors),
             msg=str(errors),
         )
+
+        # cluster_n=2 with cluster_m=1 under the flat NON_PERSISTENT grid:
+        # ACCEPTED. This is the N-only A-multicast cluster for the tiny-M
+        # padded tcgen05 fp8 path (mirrors torch's _scaled_mm
+        # ClusterShape<1,2,1> at M<=64,N>=3072). Two CtaGroup.ONE CTAs each
+        # own their own N output tile and TMA-multicast the shared A operand.
+        errors = validate_tcgen05_strategy_invariants(
+            strategy=Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC,
+            persistence_model=Tcgen05PersistenceModel.NON_PERSISTENT,
+            layout_strategy=Tcgen05LayoutStrategy.DEFAULT,
+            warp_spec=ROLE_LOCAL_MONOLITHIC_DEFAULT_WARP_SPEC,
+            layout_overrides=Tcgen05LayoutOverrides(),
+            pid_type="flat",
+            cluster_m=1,
+            cluster_n=2,
+        )
+        self.assertEqual(errors, [], msg=str(errors))
 
         # cluster_n=2 under ROLE_LOCAL_WITH_SCHEDULER: ACCEPTED
         # in cycle 33 (the scheduler-broadcast topology generalizes


### PR DESCRIPTION
```
  ┌─────────────────┬─────────────────┬───────────────────────────┬─────────┬───────────────┐
  │  Shape (M,K,N)  │ pre-stack tuned │ full-stack seed (untuned) │  torch  │ seed vs torch │
  ├─────────────────┼─────────────────┼───────────────────────────┼─────────┼───────────────┤
  │ 16, 2048, 4096  │ 68.0 µs         │ [128,128,128] 14.9 µs     │ 8.9 µs  │ 0.60×         │
  ├─────────────────┼─────────────────┼───────────────────────────┼─────────┼───────────────┤
  │ 16, 2048, 12288 │ 176.8 µs        │ [64,256,128] 19.9 µs      │ 11.0 µs │ 0.55×         │
  ├─────────────────┼─────────────────┼───────────────────────────┼─────────┼───────────────┤
  │ 16, 4096, 6144  │ 203.9 µs        │ [64,256,128] 26.6 µs      │ 12.4 µs │ 0.47×         │
  ├─────────────────┼─────────────────┼───────────────────────────┼─────────┼───────────────┤
  │ 16, 4096, 24576 │ 649.9 µs        │ [64,256,128] 37.8 µs      │ 30.0 µs │ 0.79×         │
  └─────────────────┴─────────────────┴───────────────────────────┴─────────┴───────────────┘
```