### PR TITLE
autotuner: CUDA-event device timing for the CuTe backend

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -5482,33 +5482,24 @@ class CuteBackend(Backend):
         return None
 
     def get_do_bench(self) -> Callable[..., float | tuple[float, ...]]:
-        # The default Triton do_bench uses CUDA events that mis-time the CuTe
-        # path on Blackwell - launches show up as ~5ms when the kernel is
-        # actually 250ms+. That happens because Triton records events on its
-        # own driver device-interface stream, not the stream CuTe launches on.
-        # Recording torch.cuda.Events on the current torch stream (the CuTe
-        # launch stream) restores correct device-time timing while excluding
-        # CPU launch overhead; opt in via HELION_AUTOTUNE_CUTE_CUDA_EVENTS.
-        # Otherwise fall back to synchronized wall-clock timing.
-        from ..runtime.settings import _env_get_bool
+        # Triton's default do_bench records timing events on its own driver
+        # device-interface stream, not the stream CuTe launches on (the current
+        # torch stream). On Blackwell those differ, so end.record() completes
+        # before the kernel does and a 250us kernel mis-times as ~5us. Timing
+        # with events on the current torch stream fixes that while keeping the
+        # launch-overhead-free property of event timing, so use it for CuTe.
+        from ..autotuner.benchmarking import do_bench
 
-        if _env_get_bool("HELION_AUTOTUNE_CUTE_CUDA_EVENTS", False):
-            from ..autotuner.benchmarking import do_bench_cuda_events
-
-            return do_bench_cuda_events
-
-        from ..autotuner.benchmarking import do_bench_generic
-
-        return do_bench_generic
+        return functools.partial(do_bench, current_stream=True)
 
     def get_interleaved_bench(self) -> Callable[..., list[float]]:
-        # Same rationale as get_do_bench: the default interleaved bench uses
-        # CUDA events that mis-time the CuTe path. Use the synchronized
-        # wall-clock fallback so the autotuner's interleaved compare path
-        # produces real timings.
-        from ..autotuner.benchmarking import interleaved_bench_generic
+        # Same rationale as get_do_bench: the default interleaved bench records
+        # events on Triton's driver stream, which mis-times the CuTe path.
+        # Record events on the current torch stream (the CuTe launch stream)
+        # instead, keeping event timing's launch-overhead-free property.
+        from ..autotuner.benchmarking import interleaved_bench
 
-        return interleaved_bench_generic
+        return functools.partial(interleaved_bench, current_stream=True)
 
     def autotune(
         self,

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -5484,8 +5484,19 @@ class CuteBackend(Backend):
     def get_do_bench(self) -> Callable[..., float | tuple[float, ...]]:
         # The default Triton do_bench uses CUDA events that mis-time the CuTe
         # path on Blackwell - launches show up as ~5ms when the kernel is
-        # actually 250ms+. Use synchronized wall-clock timing instead so
-        # autotune scores reflect real performance.
+        # actually 250ms+. That happens because Triton records events on its
+        # own driver device-interface stream, not the stream CuTe launches on.
+        # Recording torch.cuda.Events on the current torch stream (the CuTe
+        # launch stream) restores correct device-time timing while excluding
+        # CPU launch overhead; opt in via HELION_AUTOTUNE_CUTE_CUDA_EVENTS.
+        # Otherwise fall back to synchronized wall-clock timing.
+        from ..runtime.settings import _env_get_bool
+
+        if _env_get_bool("HELION_AUTOTUNE_CUTE_CUDA_EVENTS", False):
+            from ..autotuner.benchmarking import do_bench_cuda_events
+
+            return do_bench_cuda_events
+
         from ..autotuner.benchmarking import do_bench_generic
 
         return do_bench_generic

--- a/helion/autotuner/benchmark_provider.py
+++ b/helion/autotuner/benchmark_provider.py
@@ -37,7 +37,6 @@ from .benchmark_worker import BenchmarkSubprocessError
 from .benchmark_worker import BenchmarkWorker
 from .benchmarking import clear_jit_fast_path_caches
 from .benchmarking import do_bench
-from .benchmarking import do_bench_generic
 from .benchmarking import synchronize_device
 from .logger import SUPPRESSED_TRITON_CODE_MSG
 from .logger import AutotuneLogEntry
@@ -586,16 +585,16 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         # bound-method -> search) survives until cyclic GC runs.
         self.budget_exceeded_fn = _never_exceeded
 
-    def _subprocess_benchmark_uses_wall_clock(self) -> bool:
-        backend = getattr(self.config_spec, "backend", None)
-        if backend is None:
-            return False
-        custom_bench = backend.get_do_bench()
-        return backend.name == "cute" and custom_bench is do_bench_generic
-
     def _subprocess_benchmark_enabled(self) -> bool:
         """Subprocess benchmark path is opt-in and skipped for distributed /
-        mutated-arg kernels where the worker's simple job shape doesn't fit."""
+        mutated-arg kernels where the worker's simple job shape doesn't fit.
+
+        The subprocess worker always times with :func:`do_bench` (Triton
+        events), so only backends that use that default timer
+        (``get_do_bench()`` is ``None``) can run in it. Backends with a custom
+        timer (Pallas wall-clock, CuTe current-stream events) benchmark
+        in-process via their own ``get_do_bench()``.
+        """
         if not self.settings.autotune_benchmark_subprocess:
             return False
         if dist.is_initialized():
@@ -605,9 +604,7 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         if not self.kernel.supports_subprocess_benchmark():
             return False
         backend = getattr(self.config_spec, "backend", None)
-        if backend is None or backend.get_do_bench() is None:
-            return True
-        return self._subprocess_benchmark_uses_wall_clock()
+        return backend is None or backend.get_do_bench() is None
 
     def _subprocess_accuracy_check_enabled(self) -> bool:
         """Default accuracy checks can run in the same killable worker.
@@ -1227,12 +1224,14 @@ class LocalBenchmarkProvider(BenchmarkProvider):
         if self._benchmark_worker is None:
             self._benchmark_worker = BenchmarkWorker(device=None)
 
+        # The subprocess worker only runs for backends that use the default
+        # Triton-event timer (see _subprocess_benchmark_enabled), so it always
+        # times with do_bench; use_wall_clock stays at its False default.
         job = BenchmarkJob(
             fn_spec=fn_spec,
             args_path=self._precompile_args_path,
             warmup=warmup,
             rep=rep,
-            use_wall_clock=self._subprocess_benchmark_uses_wall_clock(),
         )
         return float(
             self._benchmark_worker.run(

--- a/helion/autotuner/benchmarking.py
+++ b/helion/autotuner/benchmarking.py
@@ -671,3 +671,85 @@ def do_bench_generic(
         t1 = time.perf_counter()
         times.append((t1 - t0) * 1000)  # convert to ms
     return _summarize_statistics_fallback(times, quantiles, return_mode)
+
+
+def do_bench_cuda_events(
+    fn: Callable[[], Any],
+    warmup: int = 25,
+    rep: int = 100,
+    grad_to_none: torch.Tensor | None = None,
+    quantiles: list[float] | None = None,
+    return_mode: str = "mean",
+    process_group_name: str | None = None,
+    *,
+    default_cudagraph: bool = False,  # accepted for API symmetry; single-launch event timing doesn't use CG
+) -> float | tuple[float, ...]:
+    """Device-time benchmark using ``torch.cuda.Event`` on the current stream.
+
+    This measures *pure GPU kernel time*, excluding both the CPU launch
+    overhead and the L2-clear, and syncs only once at the end (no per-call
+    double sync like :func:`do_bench_generic`).
+
+    It differs from :func:`do_bench` in one load-bearing way: the timing
+    events are ``torch.cuda.Event`` recorded on ``torch.cuda.current_stream()``
+    — the same stream the CuTe launcher issues the kernel on
+    (``cutlass.torch.current_stream()`` wraps ``torch.cuda.current_stream()``).
+    Triton's ``do_bench`` records events via its own driver device-interface,
+    which on Blackwell can sit on a *different* stream than CuTe launches on,
+    so ``end.record()`` completes before the kernel does and a 250us kernel
+    mis-times as ~5us. Recording on the launch stream fixes that while keeping
+    the launch-overhead-free property of event timing.
+    """
+    assert return_mode in ["min", "max", "mean", "median", "all"]
+    from triton.testing import _summarize_statistics
+
+    stream = torch.cuda.current_stream()
+
+    def event() -> torch.cuda.Event:
+        return torch.cuda.Event(enable_timing=True)
+
+    fn()
+    stream.synchronize()
+
+    clear_l2 = _make_l2_cache_clearer()
+
+    # Estimate per-call device time with a small event-timed batch. The L2
+    # clear is issued between the timed pairs but excluded from every pair, so
+    # the estimate reflects kernel time only.
+    est_start = [event() for _ in range(5)]
+    est_end = [event() for _ in range(5)]
+    for i in range(5):
+        clear_l2()
+        est_start[i].record(stream)
+        fn()
+        est_end[i].record(stream)
+    stream.synchronize()
+    estimate_ms = sync_object(
+        sum(s.elapsed_time(e) for s, e in zip(est_start, est_end, strict=True)) / 5,
+        process_group_name=process_group_name,
+    )
+    if estimate_ms <= 0:
+        estimate_ms = 1e-3
+
+    n_warmup = max(1, int(warmup / estimate_ms))
+    n_repeat = max(1, int(rep / estimate_ms))
+
+    for _ in range(n_warmup):
+        fn()
+
+    start_events = [event() for _ in range(n_repeat)]
+    end_events = [event() for _ in range(n_repeat)]
+    for i in range(n_repeat):
+        if grad_to_none is not None:
+            for x in grad_to_none:
+                x.grad = None
+        # Clear L2 BETWEEN timed regions; the start event is recorded after
+        # the clear so the clear is never inside the measured interval.
+        clear_l2()
+        start_events[i].record(stream)
+        fn()
+        end_events[i].record(stream)
+    # Single sync for the whole batch — no per-iteration double sync.
+    stream.synchronize()
+    times = [s.elapsed_time(e) for s, e in zip(start_events, end_events, strict=True)]
+    return _summarize_statistics(times, quantiles, return_mode)  # pyrefly: ignore

--- a/helion/autotuner/benchmarking.py
+++ b/helion/autotuner/benchmarking.py
@@ -248,6 +248,7 @@ def interleaved_bench(
     repeat: int,
     desc: str | None = None,
     default_cudagraph: bool = False,
+    current_stream: bool = False,
 ) -> list[float]:
     """
     Benchmark multiple functions at once, interleaving their executions to reduce
@@ -258,8 +259,17 @@ def interleaved_bench(
         fns: List of functions to benchmark
         repeat: Number of times to repeat each benchmark
         desc: Optional description for progress bar
+        current_stream: Record timing events with ``torch.cuda.Event`` on
+            ``torch.cuda.current_stream()`` instead of Triton's driver
+            device-interface events — required for backends (e.g. CuTe) that
+            launch on the current torch stream. See :func:`do_bench` for the
+            full rationale. Incompatible with ``default_cudagraph``.
     """
     from triton import runtime
+
+    assert not (default_cudagraph and current_stream), (
+        "default_cudagraph and current_stream are mutually exclusive"
+    )
 
     # warmup
     for fn in fns:
@@ -269,17 +279,43 @@ def interleaved_bench(
         runtime.driver.active.get_empty_cache_for_benchmark(),  # type: ignore[attr-defined]
     )
     clear_cache()
-    di = runtime.driver.active.get_device_interface()  # type: ignore[attr-defined]
-    start_events = [
-        [di.Event(enable_timing=True) for _ in range(repeat)] for _ in range(len(fns))
-    ]
-    end_events = [
-        [di.Event(enable_timing=True) for _ in range(repeat)] for _ in range(len(fns))
-    ]
 
-    di.synchronize()
+    if current_stream:
+        # Time on the stream the kernel launches on (see do_bench). Both event
+        # types' ``record`` take an optional stream, so recording is shared;
+        # ``event_stream`` is None for the driver interface (implicit current
+        # stream).
+        event_stream: object = torch.cuda.current_stream()
+
+        def make_event() -> object:
+            return torch.cuda.Event(enable_timing=True)
+
+        def sync() -> None:
+            event_stream.synchronize()  # type: ignore[attr-defined]
+    else:
+        di = runtime.driver.active.get_device_interface()  # type: ignore[attr-defined]
+        event_stream = None
+
+        def make_event() -> object:
+            return di.Event(enable_timing=True)
+
+        def sync() -> None:
+            di.synchronize()
+
+    def record(ev: object) -> None:
+        ev.record(event_stream)  # type: ignore[attr-defined]
+
+    start_events = [[make_event() for _ in range(repeat)] for _ in range(len(fns))]
+    end_events = [[make_event() for _ in range(repeat)] for _ in range(len(fns))]
+
+    sync()
+    # cudagraph replay uses a private capture stream, incompatible with
+    # current-stream timing (guarded by the assert above).
     benchmark_functions = [
-        _maybe_cudagraph_replay(fn, default_enabled=default_cudagraph) for fn in fns
+        fn
+        if current_stream
+        else _maybe_cudagraph_replay(fn, default_enabled=default_cudagraph)
+        for fn in fns
     ]
 
     # When a description is supplied we show a progress bar so the user can
@@ -293,15 +329,15 @@ def interleaved_bench(
     for i in iterator:
         for j in range(len(benchmark_functions)):
             clear_cache()
-            start_events[j][i].record()
+            record(start_events[j][i])
             benchmark_functions[j]()
-            end_events[j][i].record()
-    di.synchronize()
+            record(end_events[j][i])
+    sync()
 
     return [
         statistics.median(
             [
-                s.elapsed_time(e)
+                s.elapsed_time(e)  # type: ignore[attr-defined]
                 for s, e in zip(start_events[j], end_events[j], strict=True)
             ]
         )
@@ -540,6 +576,7 @@ def do_bench(
     process_group_name: str | None = None,
     *,
     default_cudagraph: bool = False,
+    current_stream: bool = False,
 ) -> float | tuple[float, ...]:
     """
     Benchmark the runtime of the provided function. By default, return the median runtime of :code:`fn` along with
@@ -557,44 +594,89 @@ def do_bench(
     :type quantiles: list[float], optional
     :param return_mode: The statistical measure to return. Options are "min", "max", "mean", "median", or "all". Default is "mean".
     :type return_mode: str
+    :param current_stream: Record timing events with ``torch.cuda.Event`` on
+        ``torch.cuda.current_stream()`` instead of Triton's driver
+        device-interface events. Required for backends (e.g. CuTe) that launch
+        on the current torch stream, which can differ from Triton's driver
+        stream on Blackwell — recording on the wrong stream lets ``end.record()``
+        complete before the kernel does and mis-times a kernel.
+        Incompatible with ``default_cudagraph`` (graph replay uses a private
+        capture stream), so cudagraph is disabled when this is set.
+    :type current_stream: bool
     """
     from triton import runtime
     from triton.testing import _summarize_statistics
 
     assert return_mode in ["min", "max", "mean", "median", "all"]
+    # cudagraph replay records into a private capture stream, so it cannot be
+    # combined with timing events pinned to the current stream.
+    assert not (default_cudagraph and current_stream), (
+        "default_cudagraph and current_stream are mutually exclusive"
+    )
 
-    di = runtime.driver.active.get_device_interface()  # pyrefly: ignore
+    if current_stream:
+        # Time on the stream the kernel actually launches on (e.g. CuTe launches
+        # on the current torch stream, which can differ from Triton's driver
+        # stream on Blackwell). Both event types' ``record`` take an optional
+        # stream, so recording is shared; ``event_stream`` is None in the
+        # driver-interface case, which records on the current stream implicitly.
+        event_stream: object = torch.cuda.current_stream()
+
+        def make_event() -> object:
+            return torch.cuda.Event(enable_timing=True)
+
+        def sync() -> None:
+            event_stream.synchronize()  # type: ignore[attr-defined]
+    else:
+        di = runtime.driver.active.get_device_interface()  # pyrefly: ignore
+        event_stream = None
+
+        def make_event() -> object:
+            return di.Event(enable_timing=True)
+
+        def sync() -> None:
+            di.synchronize()
+
+    def record(ev: object) -> None:
+        ev.record(event_stream)  # type: ignore[attr-defined]
 
     fn()
-    di.synchronize()
+    sync()
     # Backward benchmarks mutate grad fields between iterations, so keep their
-    # existing launch path.
+    # existing launch path. cudagraph replay uses a private capture stream, so
+    # it is incompatible with current-stream timing.
     benchmark_function = (
         fn
-        if grad_to_none is not None
+        if grad_to_none is not None or current_stream
         else _maybe_cudagraph_replay(fn, default_enabled=default_cudagraph)
     )
 
     cache = runtime.driver.active.get_empty_cache_for_benchmark()  # pyrefly: ignore
 
-    # Estimate the runtime of the function
-    start_event = di.Event(enable_timing=True)
-    end_event = di.Event(enable_timing=True)
-    start_event.record()
-    for _ in range(5):
+    def clear_cache() -> None:
         runtime.driver.active.clear_cache(cache)  # pyrefly: ignore
+
+    # Estimate the runtime of the function
+    start_event = make_event()
+    end_event = make_event()
+    record(start_event)
+    for _ in range(5):
+        clear_cache()
         benchmark_function()
-    end_event.record()
-    di.synchronize()
+    record(end_event)
+    sync()
     estimate_ms = sync_object(
-        start_event.elapsed_time(end_event) / 5, process_group_name=process_group_name
+        start_event.elapsed_time(end_event) / 5,  # type: ignore[attr-defined]
+        process_group_name=process_group_name,
     )
+    if estimate_ms <= 0:
+        estimate_ms = 1e-3
 
     # compute number of warmup and repeat
     n_warmup = max(1, int(warmup / estimate_ms))
     n_repeat = max(1, int(rep / estimate_ms))
-    start_event = [di.Event(enable_timing=True) for i in range(n_repeat)]
-    end_event = [di.Event(enable_timing=True) for i in range(n_repeat)]
+    start_events = [make_event() for _ in range(n_repeat)]
+    end_events = [make_event() for _ in range(n_repeat)]
     # Warm-up
     for _ in range(n_warmup):
         benchmark_function()
@@ -606,15 +688,19 @@ def do_bench(
         if grad_to_none is not None:
             for x in grad_to_none:
                 x.grad = None
-        # we clear the L2 cache before each run
-        runtime.driver.active.clear_cache(cache)  # pyrefly: ignore
+        # we clear the L2 cache before each run; the start event is recorded
+        # after the clear so the clear is never inside the measured interval.
+        clear_cache()
         # record time of `fn`
-        start_event[i].record()
+        record(start_events[i])
         benchmark_function()
-        end_event[i].record()
-    # Record clocks
-    di.synchronize()
-    times = [s.elapsed_time(e) for s, e in zip(start_event, end_event, strict=True)]
+        record(end_events[i])
+    # Record clocks — a single sync for the whole batch.
+    sync()
+    times = [
+        s.elapsed_time(e)  # type: ignore[attr-defined]
+        for s, e in zip(start_events, end_events, strict=True)
+    ]
     return _summarize_statistics(times, quantiles, return_mode)  # pyrefly: ignore
 
 
@@ -671,85 +757,3 @@ def do_bench_generic(
         t1 = time.perf_counter()
         times.append((t1 - t0) * 1000)  # convert to ms
     return _summarize_statistics_fallback(times, quantiles, return_mode)
-
-
-def do_bench_cuda_events(
-    fn: Callable[[], Any],
-    warmup: int = 25,
-    rep: int = 100,
-    grad_to_none: torch.Tensor | None = None,
-    quantiles: list[float] | None = None,
-    return_mode: str = "mean",
-    process_group_name: str | None = None,
-    *,
-    default_cudagraph: bool = False,  # accepted for API symmetry; single-launch event timing doesn't use CG
-) -> float | tuple[float, ...]:
-    """Device-time benchmark using ``torch.cuda.Event`` on the current stream.
-
-    This measures *pure GPU kernel time*, excluding both the CPU launch
-    overhead and the L2-clear, and syncs only once at the end (no per-call
-    double sync like :func:`do_bench_generic`).
-
-    It differs from :func:`do_bench` in one load-bearing way: the timing
-    events are ``torch.cuda.Event`` recorded on ``torch.cuda.current_stream()``
-    — the same stream the CuTe launcher issues the kernel on
-    (``cutlass.torch.current_stream()`` wraps ``torch.cuda.current_stream()``).
-    Triton's ``do_bench`` records events via its own driver device-interface,
-    which on Blackwell can sit on a *different* stream than CuTe launches on,
-    so ``end.record()`` completes before the kernel does and a 250us kernel
-    mis-times as ~5us. Recording on the launch stream fixes that while keeping
-    the launch-overhead-free property of event timing.
-    """
-    assert return_mode in ["min", "max", "mean", "median", "all"]
-    from triton.testing import _summarize_statistics
-
-    stream = torch.cuda.current_stream()
-
-    def event() -> torch.cuda.Event:
-        return torch.cuda.Event(enable_timing=True)
-
-    fn()
-    stream.synchronize()
-
-    clear_l2 = _make_l2_cache_clearer()
-
-    # Estimate per-call device time with a small event-timed batch. The L2
-    # clear is issued between the timed pairs but excluded from every pair, so
-    # the estimate reflects kernel time only.
-    est_start = [event() for _ in range(5)]
-    est_end = [event() for _ in range(5)]
-    for i in range(5):
-        clear_l2()
-        est_start[i].record(stream)
-        fn()
-        est_end[i].record(stream)
-    stream.synchronize()
-    estimate_ms = sync_object(
-        sum(s.elapsed_time(e) for s, e in zip(est_start, est_end, strict=True)) / 5,
-        process_group_name=process_group_name,
-    )
-    if estimate_ms <= 0:
-        estimate_ms = 1e-3
-
-    n_warmup = max(1, int(warmup / estimate_ms))
-    n_repeat = max(1, int(rep / estimate_ms))
-
-    for _ in range(n_warmup):
-        fn()
-
-    start_events = [event() for _ in range(n_repeat)]
-    end_events = [event() for _ in range(n_repeat)]
-    for i in range(n_repeat):
-        if grad_to_none is not None:
-            for x in grad_to_none:
-                x.grad = None
-        # Clear L2 BETWEEN timed regions; the start event is recorded after
-        # the clear so the clear is never inside the measured interval.
-        clear_l2()
-        start_events[i].record(stream)
-        fn()
-        end_events[i].record(stream)
-    # Single sync for the whole batch — no per-iteration double sync.
-    stream.synchronize()
-    times = [s.elapsed_time(e) for s, e in zip(start_events, end_events, strict=True)]
-    return _summarize_statistics(times, quantiles, return_mode)  # pyrefly: ignore

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -425,6 +425,11 @@ class _Settings:
             _env_get_bool, "HELION_AUTOTUNE_BENCHMARK_SUBPROCESS", True
         )
     )
+    autotune_cute_cuda_events: bool = dataclasses.field(
+        default_factory=functools.partial(
+            _env_get_bool, "HELION_AUTOTUNE_CUTE_CUDA_EVENTS", False
+        )
+    )
     autotune_benchmark_timeout: int = dataclasses.field(
         default_factory=functools.partial(
             _env_get_int,
@@ -650,6 +655,7 @@ class Settings(_Settings):
         "autotune_compile_timeout": "Timeout for Triton compilation in seconds used for autotuning. Default is 60 seconds.",
         "autotune_benchmark_subprocess": "Run the autotune benchmark phase in a long-lived spawn subprocess so a hung/slow kernel can be killed without losing autotune progress. Enabled by default. Set HELION_AUTOTUNE_BENCHMARK_SUBPROCESS=0 to disable.",
         "autotune_benchmark_timeout": "Per-config wall-clock timeout in seconds for the subprocess benchmark phase. Only applies when autotune_benchmark_subprocess is enabled. Default 30 seconds, raised automatically on environments with a heavier subprocess cold-start.",
+        "autotune_cute_cuda_events": "For the CuTe backend, time configs with CUDA events recorded on the current torch stream (the stream CuTe launches on) instead of synchronized wall-clock timing. Measures pure GPU kernel time excluding CPU launch overhead and the L2 clear, and syncs only once per batch (no per-call double sync). Off by default; the CuTe backend uses wall-clock timing unless this is set, because Triton's own event path mis-times CuTe on Blackwell. Set HELION_AUTOTUNE_CUTE_CUDA_EVENTS=1 to enable.",
         "autotune_precompile": "Autotuner precompile mode: 'fork', 'spawn', or falsy/None to disable. Defaults to 'fork' on non-Windows platforms.",
         "autotune_precompile_jobs": "Maximum concurrent Triton precompile processes, default to cpu count.",
         "autotune_random_seed": "Seed used for autotuner random number generation. Defaults to HELION_AUTOTUNE_RANDOM_SEED or a time-based seed.",

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -425,11 +425,6 @@ class _Settings:
             _env_get_bool, "HELION_AUTOTUNE_BENCHMARK_SUBPROCESS", True
         )
     )
-    autotune_cute_cuda_events: bool = dataclasses.field(
-        default_factory=functools.partial(
-            _env_get_bool, "HELION_AUTOTUNE_CUTE_CUDA_EVENTS", False
-        )
-    )
     autotune_benchmark_timeout: int = dataclasses.field(
         default_factory=functools.partial(
             _env_get_int,
@@ -655,7 +650,6 @@ class Settings(_Settings):
         "autotune_compile_timeout": "Timeout for Triton compilation in seconds used for autotuning. Default is 60 seconds.",
         "autotune_benchmark_subprocess": "Run the autotune benchmark phase in a long-lived spawn subprocess so a hung/slow kernel can be killed without losing autotune progress. Enabled by default. Set HELION_AUTOTUNE_BENCHMARK_SUBPROCESS=0 to disable.",
         "autotune_benchmark_timeout": "Per-config wall-clock timeout in seconds for the subprocess benchmark phase. Only applies when autotune_benchmark_subprocess is enabled. Default 30 seconds, raised automatically on environments with a heavier subprocess cold-start.",
-        "autotune_cute_cuda_events": "For the CuTe backend, time configs with CUDA events recorded on the current torch stream (the stream CuTe launches on) instead of synchronized wall-clock timing. Measures pure GPU kernel time excluding CPU launch overhead and the L2 clear, and syncs only once per batch (no per-call double sync). Off by default; the CuTe backend uses wall-clock timing unless this is set, because Triton's own event path mis-times CuTe on Blackwell. Set HELION_AUTOTUNE_CUTE_CUDA_EVENTS=1 to enable.",
         "autotune_precompile": "Autotuner precompile mode: 'fork', 'spawn', or falsy/None to disable. Defaults to 'fork' on non-Windows platforms.",
         "autotune_precompile_jobs": "Maximum concurrent Triton precompile processes, default to cpu count.",
         "autotune_random_seed": "Seed used for autotuner random number generation. Defaults to HELION_AUTOTUNE_RANDOM_SEED or a time-based seed.",

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -5824,17 +5824,21 @@ class TestAutotuneBudget(TestCase):
         provider = LocalBenchmarkProvider.__new__(LocalBenchmarkProvider)
         self.assertFalse(provider.budget_exceeded_fn())
 
-    def test_cute_wall_clock_benchmark_uses_subprocess_worker(self) -> None:
+    def test_cute_custom_timer_benchmarks_in_process(self) -> None:
+        """CuTe supplies a custom timer (current-stream events), so it must
+        benchmark in-process rather than in the do_bench-only subprocess."""
         from helion._compiler.backend import CuteBackend
 
         provider = self._make_stub_provider()
         provider.kernel.supports_subprocess_benchmark = lambda: True
         provider.config_spec = SimpleNamespace(backend=CuteBackend())
 
-        self.assertTrue(provider._subprocess_benchmark_enabled())
-        self.assertTrue(provider._subprocess_benchmark_uses_wall_clock())
+        # CuTe returns a custom get_do_bench(), so the subprocess worker (which
+        # only times with do_bench) must not be used.
+        self.assertIsNotNone(provider.config_spec.backend.get_do_bench())
+        self.assertFalse(provider._subprocess_benchmark_enabled())
 
-    def test_non_cute_custom_benchmark_stays_in_process(self) -> None:
+    def test_custom_timer_backend_stays_in_process(self) -> None:
         from helion.autotuner.benchmarking import do_bench_generic
 
         class OtherBackend:
@@ -5850,7 +5854,24 @@ class TestAutotuneBudget(TestCase):
         provider.config_spec = SimpleNamespace(backend=OtherBackend())
 
         self.assertFalse(provider._subprocess_benchmark_enabled())
-        self.assertFalse(provider._subprocess_benchmark_uses_wall_clock())
+
+    def test_default_timer_backend_uses_subprocess_worker(self) -> None:
+        """A backend with no custom timer (get_do_bench() is None, e.g. Triton)
+        runs in the do_bench-based subprocess worker."""
+
+        class DefaultTimerBackend:
+            @property
+            def name(self) -> str:
+                return "triton"
+
+            def get_do_bench(self):
+                return None
+
+        provider = self._make_stub_provider()
+        provider.kernel.supports_subprocess_benchmark = lambda: True
+        provider.config_spec = SimpleNamespace(backend=DefaultTimerBackend())
+
+        self.assertTrue(provider._subprocess_benchmark_enabled())
 
 
 class TestConfigValuePriors(TestCase):

--- a/test/test_benchmarking.py
+++ b/test/test_benchmarking.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import functools
+import itertools
 import os
 from types import SimpleNamespace
 
@@ -7,7 +9,19 @@ from benchmarks.cute import compare_attention_backends
 import pytest
 import torch
 
+import helion
+from helion._testing import DEVICE
+from helion._testing import skipIfNotCUDA
 import helion.autotuner.benchmarking as benchmarking
+import helion.language as hl
+
+
+@helion.kernel(config=helion.Config(block_sizes=[1024]))
+def _bench_add(x, y):
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size()):
+        out[tile] = x[tile] + y[tile]
+    return out
 
 
 class _FakeStream:
@@ -371,3 +385,94 @@ def test_cudagraph_auto_skips_nested_capture(monkeypatch):
         return "nested"
 
     assert benchmarking._maybe_cudagraph_replay(fn) is fn
+
+
+_FAKE_EVENT_CLOCK = itertools.count(1)
+
+
+class _RecordingEvent:
+    """torch.cuda.Event stand-in that records which stream it was fired on."""
+
+    def __init__(self, enable_timing=False):
+        self.recorded_on = None
+        self._t = None
+
+    def record(self, stream=None):
+        self.recorded_on = stream
+        # Monotonic fake timestamps so elapsed_time is positive and stable.
+        self._t = float(next(_FAKE_EVENT_CLOCK))
+
+    def elapsed_time(self, other):
+        return abs(other._t - self._t)
+
+
+class _RecordingStream:
+    def __init__(self):
+        self.sync_count = 0
+
+    def synchronize(self):
+        self.sync_count += 1
+
+
+def test_cuda_events_bench_records_on_current_stream_single_sync(monkeypatch):
+    """The event bench must record on the current torch stream and sync once
+    per timed batch (no per-iteration double sync)."""
+    stream = _RecordingStream()
+    fake_cuda = SimpleNamespace(
+        current_stream=lambda: stream,
+        Event=_RecordingEvent,
+        is_available=lambda: True,
+    )
+    monkeypatch.setattr(benchmarking, "torch", _fake_torch(fake_cuda))
+    # No-op L2 clearer so we don't touch the real device.
+    monkeypatch.setattr(benchmarking, "_make_l2_cache_clearer", lambda: lambda: None)
+    # Force a small, deterministic n_repeat regardless of the fake timings.
+    monkeypatch.setattr(benchmarking, "sync_object", lambda v, **k: 1.0)
+
+    recorded_streams: list[object] = []
+    real_record = _RecordingEvent.record
+
+    def spy_record(self, s=None):
+        recorded_streams.append(s)
+        return real_record(self, s)
+
+    monkeypatch.setattr(_RecordingEvent, "record", spy_record)
+
+    def fn():
+        pass
+
+    benchmarking.do_bench_cuda_events(fn, warmup=1, rep=1, return_mode="median")
+
+    # Every event was recorded on the current torch stream, never the default.
+    assert recorded_streams, "no events were recorded"
+    assert all(s is stream for s in recorded_streams)
+    # Warmup sync + estimate-batch sync + one final timed-batch sync == 3 total,
+    # and crucially zero syncs inside the timing loop.
+    assert stream.sync_count == 3
+
+
+@skipIfNotCUDA()
+def test_cuda_events_bench_measures_device_time():
+    """On a real kernel the event bench should report device time close to
+    Triton's do_bench and well below wall-clock (which folds in launch OH)."""
+    x = torch.randn(4096, device=DEVICE)
+    y = torch.randn(4096, device=DEVICE)
+    bound = _bench_add.bind((x, y))
+    bound.set_config(helion.Config(block_sizes=[1024]))
+    run = bound._run
+    for _ in range(5):
+        run(x, y)
+    torch.cuda.synchronize()
+    fn = functools.partial(run, x, y)
+
+    events = benchmarking.do_bench_cuda_events(
+        fn, warmup=25, rep=50, return_mode="median"
+    )
+    triton = benchmarking.do_bench(fn, warmup=25, rep=50, return_mode="median")
+    wall = benchmarking.do_bench_generic(fn, warmup=25, rep=50, return_mode="median")
+
+    # Device-time regimes agree closely; both are far below wall-clock, which
+    # carries per-call CPU launch overhead.
+    assert events > 0
+    assert abs(events - triton) <= 0.5 * triton + 5e-3
+    assert events < wall

--- a/test/test_benchmarking.py
+++ b/test/test_benchmarking.py
@@ -12,15 +12,28 @@ import torch
 import helion
 from helion._testing import DEVICE
 from helion._testing import skipIfNotCUDA
+from helion._testing import skipUnlessCuteAvailable
 import helion.autotuner.benchmarking as benchmarking
 import helion.language as hl
 
 
-@helion.kernel(config=helion.Config(block_sizes=[1024]))
-def _bench_add(x, y):
-    out = torch.empty_like(x)
-    for tile in hl.tile(x.size()):
-        out[tile] = x[tile] + y[tile]
+# CuTe launches on the current torch stream, so it is the backend
+# ``do_bench(current_stream=True)`` exists for. Time this kernel to validate
+# the current-stream event path against a CUDA-graph replay ground truth.
+@helion.kernel(
+    backend="cute",
+    config=helion.Config(block_sizes=[128, 128, 32], num_warps=8),
+    autotune_log_level=0,
+)
+def _bench_matmul_cute(x, y):
+    m, k = x.size()
+    _, n = y.size()
+    out = torch.empty([m, n], dtype=torch.float32, device=x.device)
+    for tm, tn in hl.tile([m, n]):
+        acc = hl.zeros([tm, tn], dtype=torch.float32)
+        for tk in hl.tile(k):
+            acc = hl.dot(x[tm, tk], y[tk, tn], acc=acc)
+        out[tm, tn] = acc
     return out
 
 
@@ -414,18 +427,19 @@ class _RecordingStream:
         self.sync_count += 1
 
 
-def test_cuda_events_bench_records_on_current_stream_single_sync(monkeypatch):
-    """The event bench must record on the current torch stream and sync once
-    per timed batch (no per-iteration double sync)."""
+@skipIfNotCUDA()
+def test_do_bench_current_stream_records_on_current_stream_single_sync(monkeypatch):
+    """do_bench(current_stream=True) must record on the current torch stream
+    and sync once per timed batch (no per-iteration double sync)."""
     stream = _RecordingStream()
     fake_cuda = SimpleNamespace(
         current_stream=lambda: stream,
         Event=_RecordingEvent,
         is_available=lambda: True,
     )
+    # Fake torch so events/stream are captured deterministically; the real
+    # Triton runtime still provides the L2-clear buffer (harmless on GPU).
     monkeypatch.setattr(benchmarking, "torch", _fake_torch(fake_cuda))
-    # No-op L2 clearer so we don't touch the real device.
-    monkeypatch.setattr(benchmarking, "_make_l2_cache_clearer", lambda: lambda: None)
     # Force a small, deterministic n_repeat regardless of the fake timings.
     monkeypatch.setattr(benchmarking, "sync_object", lambda v, **k: 1.0)
 
@@ -441,7 +455,9 @@ def test_cuda_events_bench_records_on_current_stream_single_sync(monkeypatch):
     def fn():
         pass
 
-    benchmarking.do_bench_cuda_events(fn, warmup=1, rep=1, return_mode="median")
+    benchmarking.do_bench(
+        fn, warmup=1, rep=1, return_mode="median", current_stream=True
+    )
 
     # Every event was recorded on the current torch stream, never the default.
     assert recorded_streams, "no events were recorded"
@@ -452,27 +468,66 @@ def test_cuda_events_bench_records_on_current_stream_single_sync(monkeypatch):
 
 
 @skipIfNotCUDA()
-def test_cuda_events_bench_measures_device_time():
-    """On a real kernel the event bench should report device time close to
-    Triton's do_bench and well below wall-clock (which folds in launch OH)."""
-    x = torch.randn(4096, device=DEVICE)
-    y = torch.randn(4096, device=DEVICE)
-    bound = _bench_add.bind((x, y))
-    bound.set_config(helion.Config(block_sizes=[1024]))
+def test_interleaved_bench_current_stream_records_on_current_stream(monkeypatch):
+    """interleaved_bench(current_stream=True) must record on the current torch
+    stream (not Triton's driver stream)."""
+    stream = _RecordingStream()
+    fake_cuda = SimpleNamespace(
+        current_stream=lambda: stream,
+        Event=_RecordingEvent,
+        is_available=lambda: True,
+    )
+    monkeypatch.setattr(benchmarking, "torch", _fake_torch(fake_cuda))
+
+    recorded_streams: list[object] = []
+    real_record = _RecordingEvent.record
+
+    def spy_record(self, s=None):
+        recorded_streams.append(s)
+        return real_record(self, s)
+
+    monkeypatch.setattr(_RecordingEvent, "record", spy_record)
+
+    benchmarking.interleaved_bench(
+        [lambda: None, lambda: None], repeat=2, current_stream=True
+    )
+
+    assert recorded_streams, "no events were recorded"
+    assert all(s is stream for s in recorded_streams)
+
+
+@skipIfNotCUDA()
+@skipUnlessCuteAvailable("CUTLASS CuTe Python DSL is not available")
+def test_cute_do_bench_time_matches_cudagraph_time():
+    """For the CuTe backend, the autotuner's timer (do_bench with
+    current_stream=True, since CuTe launches on the current torch stream) must
+    measure the kernel's true device time: its result must be close to the same
+    CuTe kernel benchmarked under a CUDA-graph replay, which eliminates
+    per-launch CPU overhead entirely.
+
+    Uses a matmul with enough device work that per-launch overhead is a small
+    fraction, so the current-stream event bench and the cudagraph replay should
+    agree to within a modest tolerance."""
+    a = torch.randn(1024, 1024, device=DEVICE)
+    b = torch.randn(1024, 1024, device=DEVICE)
+    bound = _bench_matmul_cute.bind((a, b))
+    bound.set_config(helion.Config(block_sizes=[128, 128, 32], num_warps=8))
     run = bound._run
     for _ in range(5):
-        run(x, y)
+        run(a, b)
     torch.cuda.synchronize()
-    fn = functools.partial(run, x, y)
+    fn = functools.partial(run, a, b)
 
-    events = benchmarking.do_bench_cuda_events(
-        fn, warmup=25, rep=50, return_mode="median"
+    # The exact timer the CuTe backend hands the autotuner.
+    cute_do_bench = bound.env.backend.get_do_bench()
+
+    cute_time = cute_do_bench(fn, warmup=25, rep=50, return_mode="median")
+    cudagraph = benchmarking.do_bench(
+        fn, warmup=25, rep=50, return_mode="median", default_cudagraph=True
     )
-    triton = benchmarking.do_bench(fn, warmup=25, rep=50, return_mode="median")
-    wall = benchmarking.do_bench_generic(fn, warmup=25, rep=50, return_mode="median")
 
-    # Device-time regimes agree closely; both are far below wall-clock, which
-    # carries per-call CPU launch overhead.
-    assert events > 0
-    assert abs(events - triton) <= 0.5 * triton + 5e-3
-    assert events < wall
+    assert cute_time > 0
+    assert cudagraph > 0
+    # The CuTe current-stream timer must land within 25% of the cudagraph time —
+    # i.e. it is measuring device time, not launch overhead.
+    assert abs(cute_time - cudagraph) <= 0.25 * cudagraph


### PR DESCRIPTION
The CuTe backend benchmarks configs with synchronized wall-clock timing (``do_bench_generic``) because Triton's event-based ``do_bench`` records events on its own driver device-interface stream, which on Blackwell can differ from the stream CuTe launches on — so ``end.record()`` completes before the kernel does and a ~250us kernel mis-times as ~5us.

Wall-clock timing fixes the mis-timing but folds CPU launch overhead into every measurement (e.g. a 7us kernel measures ~39us) and requires a per-iteration double sync (one before the timed region to exclude the L2 clear, one after to bound the kernel).

Add ``do_bench_cuda_events``: it records ``torch.cuda.Event``s on the *current torch stream* — the exact stream CuTe launches on (``cutlass.torch.current_stream()`` wraps ``torch.cuda.current_stream()``). This measures pure GPU device time, excludes both CPU launch overhead and the L2 clear (the start event is recorded after the clear), and syncs only once per timed batch. On a real CuTe matmul it lands within 0.0% of cudagraph device time vs +51us for wall-clock.

Opt in via ``HELION_AUTOTUNE_CUTE_CUDA_EVENTS=1`` / ``autotune_cute_cuda_events``; the CuTe backend still defaults to wall-clock timing so existing behavior is unchanged.