### PR TITLE
[autotuner] reduction seed heuristic: one budget allocator over a Stage-1 reduction fact

### DIFF
--- a/helion/_compiler/autotuner_heuristics/triton.py
+++ b/helion/_compiler/autotuner_heuristics/triton.py
@@ -2,27 +2,37 @@ from __future__ import annotations
 
 import functools
 import json
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import NamedTuple
 from typing import cast
 
 import torch
 
 from ...autotuner.config_fragment import EnumFragment
+from ...autotuner.config_spec import FULL_EXTENT_CATEGORIES
+from ...autotuner.config_spec import SIZED_REDUCTION_CATEGORIES
+from ...autotuner.config_spec import ReductionCategory
 from ...runtime.config import Config
 from .common import clamp_block_size_targets
 from .common import matches_hardware
 from .registry import AutotunerHeuristic
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from ...autotuner.config_spec import BlockSizeSpec
     from ...autotuner.config_spec import ConfigSpec
     from ...autotuner.config_spec import MatmulFact
-    from ...autotuner.config_spec import ReductionFact
+    from ...autotuner.config_spec import ReductionDescriptor
+    from ...autotuner.config_spec import ReductionKernelFact
     from ..compile_environment import CompileEnvironment
     from ..device_ir import DeviceIR
 
+
+log = logging.getLogger(__name__)
 
 _B200_MATMUL_HEURISTICS_PATH = Path(__file__).resolve().parent / "matmul_b200.json"
 
@@ -412,48 +422,106 @@ class TritonPointwiseSeedHeuristic(AutotunerHeuristic):
 
 
 def _triton_reduction_eligible(env: CompileEnvironment, device_ir: DeviceIR) -> bool:
-    """Gate: exactly one ``ReductionFact`` and no ``matmul_facts``. Admits both tracks
-    (standard rollable, user-tiled); excludes GEMMs and multi-axis manual reductions."""
+    """Gate: the kernel has >= 1 SIZED reduction and no ``matmul_facts`` (GEMMs route to the matmul
+    seeds). Admits both tracks (standard rollable, user-tiled), including a multi-reduction kernel.
+    A reduction with no sized member (only GRID_TILE / DECLINED) declines.
+
+    Keyed purely on the Stage-1 kernel fact. ``build_reduction_kernel_fact`` runs on every live
+    compile, so the fact is absent only for a bare-spec unit test or a kernel with genuinely no
+    reduction; both correctly decline.
+    """
     spec = env.config_spec
-    return len(spec.reduction_facts) == 1 and not spec.matmul_facts
+    if spec.matmul_facts:
+        return False
+    kf = spec.reduction_kernel_fact
+    if kf is None:
+        return False
+    return any(d.category in SIZED_REDUCTION_CATEGORIES for d in kf.reductions)
 
 
-def _is_standard_reduction(spec: ConfigSpec, fact: ReductionFact) -> bool:
-    """standard vs user-tiled discriminator: standard iff the rdim is NOT a ``block_sizes``
-    entry. Covers a roller-rolled rdim (a ``reduction_loops`` entry) AND a MATERIALIZED rdim
-    (an inner ``reduction=True`` axis the roller declined to roll, in NEITHER spec --
-    rms/ln/instance backward); user-tiled is the rdim-is-a-block_sizes case.
+def _primary_descriptor_selected(env: CompileEnvironment) -> ReductionDescriptor | None:
+    """The primary reduction descriptor: max ROW-BYTES (``size_hint * input_load_itemsize``) over
+    the backed sized descriptors (not category tier-order, which would mis-rank the group-quant
+    kernels). ``None`` if there is no sized reduction / no kernel fact.
+
+    This is the single Stage-1 source the reduction tracks read every scalar lever off (num_warps
+    / persistence / footprint caps). On the live compile path the kernel fact is present whenever
+    there is a sized reduction, so ``None`` is the test-only / no-sized-reduction case.
     """
-    return fact.block_id not in spec.block_sizes.valid_block_ids()
+    from torch._inductor.utils import free_unbacked_symbols
 
+    kf = env.config_spec.reduction_kernel_fact
+    if kf is None:
+        return None
+    sized = [d for d in kf.reductions if d.category in SIZED_REDUCTION_CATEGORIES]
+    if not sized:
+        return None
 
-def _grid_rows(env: CompileEnvironment, m_block_ids: tuple[int, ...]) -> int:
-    """Product of the static M-axis (non-reduction grid) extents — the program count the
-    reduction launches, the numerator of the occupancy ``grid_rows // num_sm``. Returns 0
-    if any extent is not a statically-resolvable size (a dynamic grid has no compile-time
-    occupancy, so the occupancy-gated narrow-w1 lever declines).
-    """
-    grid_rows = 1
-    for mbid in m_block_ids:
-        size = env.block_sizes[mbid].size
+    def _is_backed(d: ReductionDescriptor) -> bool:
+        size = env.block_sizes[d.block_id].size
+        # A concrete int or SymInt with no free unbacked symbols is backed; a non-int/SymInt
+        # size (AutoSize / None) is treated as unbacked (conservative — same as today, where a
+        # symbolic size makes ``free_unbacked_symbols`` truthy and drops it from ``backed``).
         if not isinstance(size, (int, torch.SymInt)):
-            return 0
-        grid_rows *= env.size_hint(size)
-    return grid_rows
+            return False
+        return not free_unbacked_symbols(size)
+
+    backed = [d for d in sized if _is_backed(d)]
+    pool = backed or sized
+    return max(
+        pool, key=lambda d: (d.size_hint * max(1, d.input_load_itemsize), d.size_hint)
+    )
+
+
+def _is_standard_reduction(pd: ReductionDescriptor) -> bool:
+    """Standard vs user-tiled discriminator, keyed on the primary reduction's category: standard
+    iff FULL_SLICE (a rolled rdim or a materialized full-width rdim the roller declined) or
+    FULL_GRID; user-tiled is the USER_TILE case (the rdim is a ``block_sizes`` entry).
+    """
+    return pd.category in FULL_EXTENT_CATEGORIES
+
+
+class _TileAllocation(NamedTuple):
+    """The result of :meth:`_TritonReductionSeedBase.size_reduction_tiles` — the single
+    per-co-residency-group budget allocation that produces every tile size the seed emits.
+
+    Per co-residency group the allocator forms a register/byte capacity, then seats axes in
+    priority order (full-extent reductions → user-tile reductions → grid-tile reductions → the
+    grid-M rows), each taking first crack then floored by the budget remaining after everything
+    already seated. Earlier groups' assignments are held fixed as inputs to later groups; the
+    non-reduction loops are sized last against the remaining headroom. Floor-vs-resident and
+    collapse-vs-widen are budget outcomes, not separate branches.
+
+    - ``block_sizes``: the full ``Config.block_sizes`` vector — every tunable axis sized.
+    - ``block_sizes_red_values``: ``{block_id -> r_block}`` for every tunable sized reduction that
+      rides a ``block_sizes`` slot (the user-tiled track's reductions, including its primary). The
+      standard track's rolled primary rides ``reduction_loops`` instead, surfaced via
+      ``primary_r_block``/``persistent`` — so the name is about the emission target (block_sizes
+      slot), not "secondary". Emission routing is the only standard-vs-user difference; every
+      reduction gets a size from the same budget.
+    - ``primary_r_block`` / ``persistent``: the primary reduction's chunk + persistence verdict
+      (the byte budget admits the full extent AND the row is re-read).
+    - ``rolled_loop_sizes``: ``{block_id -> (r_block, persistent)}`` for every rolled reduction axis
+      OTHER than the primary (a kernel that rolls >1 reduction into separate ``reduction_loops``
+      subgraphs). Empty unless a kernel rolls more than one reduction.
+    """
+
+    block_sizes: list[int]
+    block_sizes_red_values: dict[int, int]
+    primary_r_block: int
+    persistent: bool
+    rolled_loop_sizes: dict[int, tuple[int, bool]]
 
 
 class _TritonReductionSeedBase(AutotunerHeuristic):
-    """Shared base for the two Triton inner-reduction seed heuristics. Both share the
-    workload facts (``ReductionFact``), the M_BLOCK-aware reduction-block lever
-    (``_reduction_rblock``, from which each track derives ``persistent``), the ``num_warps``
-    ramp, eviction provenance, and the block-size builders; the subclasses differ only in
-    mapping that decision onto knobs:
+    """Shared base for the two Triton inner-reduction seed heuristics. Both consume the Stage-1
+    ``ReductionKernelFact`` through ONE budget allocator (:meth:`size_reduction_tiles`); the
+    subclasses differ ONLY in how they map the allocation onto knobs (EMISSION routing):
 
-    - **standard** (:class:`TritonStandardReductionHeuristic`): Helion rolls the rdim into
-      a ``reduction_loops`` loop.
+    - **standard** (:class:`TritonStandardReductionHeuristic`): Helion rolls the rdim into a
+      ``reduction_loops`` loop, so the primary reduction's size lands on that knob.
     - **user-tiled** (:class:`TritonUserTiledReductionHeuristic`): the user hand-writes the
-      ``hl.tile`` loop, so the reduction axis is a ``block_sizes`` entry (plain user-tiled
-      softmax, carried-2-D-tile kl_div/jsd, reduce-then-apply welford).
+      ``hl.tile`` loop, so each reduction axis is a ``block_sizes`` entry.
 
     Not registered; only the subclasses are.
     """
@@ -461,98 +529,152 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
     backend = "triton"
     HARDWARE_TARGETS = (("cuda", "sm90"),)
 
-    # Looped-fallback reduction chunk (pow2) for a row that does not fit the persistent
-    # residency budget. ``_reduction_rblock`` shrinks it when a raised M_BLOCK divides the
-    # footprint budget below it; at M_BLOCK==1 it is used as-is.
-    LOOPED_CHUNK = 16384
-    # Per-program byte budget for LOOP-CARRIED 2-D accumulator tiles ([M_BLOCK, R_BLOCK], e.g.
-    # kl_div/jsd): caps R_BLOCK via num_carried_2d_tiles. Tightest budget -- resident the whole loop.
-    CARRIED_TILE_MAX_BYTES = 16384
-    # Per-program persistent byte ceiling. The resident reduction tile is [M_BLOCK, R_BLOCK]
-    # in BOTH tracks (the persistent load and the looped accumulator both carry the M_BLOCK
-    # dim), so the per-program footprint is ``m_block * r_block * itemsize`` and every cap
-    # below divides the budget by M_BLOCK. Above it a wide resident tile spills register/SMEM,
-    # so the reduction loops a chunk instead. ~240 KiB, just over H100 SMEM.
+    # ----- THE BUDGET (a register/byte capacity; everything else is a per-axis desire) -----
+    # Per-program persistent byte ceiling: the group's resident working set — the sum over its live
+    # tiles of ``itemsize × ∏(tile dims)`` — must fit this, else a tile floors. ~240 KiB, just over
+    # H100 SMEM.
     ROW_PERSIST_MAX_BYTES = 245760
-    # Per-program ELEMENT ceiling for a FULL-WIDTH-output row (stores the whole [M, N] row
-    # back): its resident tile is fp32-promoted, so it spills at a WIDTH independent of input
-    # dtype, which the byte cap above (input bytes) undercounts 2x for a half-precision row.
-    # M_BLOCK-aware; gates only full_width_output rows, steering half-precision full-width
-    # standard rows onto the looped path.
-    FULL_WIDTH_PERSIST_MAX_ELEMS = 81920
-    # Max resident bytes a PERSISTENT reduction body (body_live_tiles full-width tiles) may hold
-    # before catastrophic register spill. Only REMOVES persistence from a heavy body, never grows it.
-    LIVE_PERSIST_BUDGET = 3 * 245760
-    # M-COLLAPSE (grad-parameter reduction, e.g. bias_grad): max rows one CTA reduces in a single
-    # in-register inner tile, capped so the reduction tree + [rows, feature] tile don't spill.
-    M_COLLAPSE_MAX_CTA = 256
-    # M-COLLAPSE inner reduction tile byte budget: a grad-parameter collapse is memory-bound, so
-    # the inner [rows, feature] tile wants the SMALLEST footprint (~2-8 rows) for CTA occupancy.
-    M_COLLAPSE_TILE_BYTES = 32768
-    # No welford "structured-combine floor": welford is memory-bound (profiler-confirmed),
-    # so a wide combine tile only spills — register-residency via the reduction footprint cap
-    # is what matters. The apply/normalize tile gets the SAME M_BLOCK-aware footprint cap as
-    # the reduction tile, NOT a flat per-row cap (which needlessly narrowed the memory-bound
-    # apply pass); applied inline in ``_build_block_sizes``.
+    # The tighter byte ceiling for a CARRIED reduction (an accumulator whose last dim is the rdim,
+    # e.g. kl_div/jsd's ``[grid_M, R]``): that tile is held resident across the whole inner loop
+    # rather than streamed-and-released, a heavier steady-state pressure, so the chunk sharing SRAM
+    # with it wants a smaller extent. Half of ROW_PERSIST. This is the only place the
+    # carried-vs-streamed distinction lives.
+    CARRIED_PERSIST_MAX_BYTES = 245760 // 2
+    # The PERSISTENCE-HOLD ceiling — the byte watermark under which a re-read row may hold its FULL
+    # extent (vs the chunk budget, which sizes a streamed/looped tile). Only ``row_reread AND
+    # carried_2d_count == 0`` reductions reach the hold, so a carried tile never loosens. The true
+    # cutoff is not a single faithful byte budget (e.g. softmax flips at ~128-160 KiB, cross_entropy
+    # at ~256-384 KiB with the same footprint), so these are two calibrated buckets selected by
+    # ``_has_store_only_row_reread`` — a coarse proxy for whether persist's avoided HBM re-read lives
+    # in the small L2 working set (tighter ceiling) or the large register file (looser ceiling):
+    #  - no store-only re-read (cross_entropy/sum): reuse is register-resident, so holding a high
+    #    watermark wins far out. 3x ROW.
+    #  - a store-only re-reading pass exists (softmax/rms/layer_norm/welford): the row is re-swept
+    #    from L2, so past ~a few KiB/row streaming beats holding it. ~1.2x ROW.
+    PERSIST_HOLD_MAX_BYTES = 3 * 245760
+    USER_TILE_PERSIST_HOLD_MAX_BYTES = 294912
+    # Looped-fallback reduction chunk (pow2) for a row that does not fit the persistent budget.
+    LOOPED_CHUNK = 16384
+    # Occupancy floor for the grid-M widen: keep the post-tile grid >= num_sm * MIN_WAVES so
+    # collapsing a fan-out sibling never under-occupies (mirrors the pointwise seed's MIN_WAVES).
+    MIN_WAVES = 8
+    # Diminishing-returns ceiling on the grid-M widen (rows/program): a memory-bound reduction does
+    # not amortize past a handful of batched rows, and widening only trades away grid parallelism.
+    # Bounds the widen the byte/occupancy caps alone would permit on a small-row huge-M kernel. Does
+    # NOT bound the grad-param COLLAPSE branch (which intentionally batches rows to cut the
+    # cross-grid finalize) nor a raised autotuner_min floor (max(floor, ...) still wins).
+    WIDEN_MAX_ROWS = 8
 
-    # NARROW-row single-warp (occupancy-gated): a narrow reduction extent wants ONE warp (the
-    # cross-warp reduction tree is pure overhead; w1 reduces in-register via shuffle). The win
-    # inverts past an occupancy ceiling (the SMs saturate), so it is gated on a row-byte cap
-    # AND an occupancy cap, both keyed on input_load_itemsize (the HBM-load element width —
-    # faithful and dtype-agnostic, unlike the fp32-promoted accumulator itemsize which is 4 at
-    # both dtypes):
-    #   - row cap: rnumel * input_load_itemsize <= NARROW_W1_MAX_BYTES.
-    #   - occ cap: occ * row_bytes <= NARROW_W1_OCC_BYTE_LIMIT (a wider row saturates at lower
-    #     occupancy, so the ceiling is on the product, not a flat occ).
-    NARROW_W1_MAX_BYTES = 2048
-    NARROW_W1_OCC_BYTE_LIMIT = 262144
+    # num_warps ramp: keyed on the primary reduction extent (see ``_num_warps``).
+
+    # =============================== Stage-1 fact accessors ================================= #
+    @classmethod
+    def _non_reduction_loop_ids(cls, spec: ConfigSpec) -> tuple[int, ...]:
+        """The non-reduction user-tiled loops (welford's normalize pass) -- sized as a separate
+        apply pass, NOT reduction-sized. Read off ``ReductionKernelFact.non_reduction_loop_block_ids``.
+        """
+        kf = spec.reduction_kernel_fact
+        assert kf is not None
+        return kf.non_reduction_loop_block_ids
 
     @classmethod
-    def _carried_tile_r_block_cap(cls, fact: ReductionFact) -> int:
-        """Pow2 R_BLOCK ceiling for a reduction carrying loop-resident 2-D accumulator tiles
-        (kl_div, jsd): the per-program byte budget ``CARRIED_TILE_MAX_BYTES`` split across the
-        accumulator itemsize and the carried-tile count. ``max(1, ..)`` guards a zero itemsize
-        or tile count.
-        """
-        from ..._utils import next_power_of_2 as _np2
+    def _resident_block_ids(cls, spec: ConfigSpec) -> set[int]:
+        """The union of block_ids that appear (as a resolved dim) in some co-residency group's
+        live-tile set — the "is this axis register-resident?" test. The single definition of
+        residency, shared by the grid-M widen (a resident grid axis widens into the byte budget; a
+        non-resident one is reduced away -> collapses) and ``_has_reduced_away_grid``. Empty if no
+        kernel fact (a bare-spec unit test)."""
+        kf = spec.reduction_kernel_fact
+        if kf is None:
+            return set()
+        resident: set[int] = set()
+        for g in kf.coresidency_groups:
+            for tile in g.live_tiles:
+                resident.update(d for d in tile if d is not None)
+        return resident
 
-        cap = cls.CARRIED_TILE_MAX_BYTES // (
-            max(1, fact.itemsize) * max(1, fact.num_carried_2d_tiles)
+    @classmethod
+    def _has_reduced_away_grid(cls, spec: ConfigSpec) -> bool:
+        """True iff some grid axis is REDUCED AWAY — a grid block_id that appears in NO live tile,
+        i.e. a sequential cross-grid reduction loop whose partial is finalized by a later
+        ``.sum(0)`` (the grad-parameter M-collapse idiom). Uses the shared ``_resident_block_ids``
+        residency test. False if no kernel fact."""
+        kf = spec.reduction_kernel_fact
+        if kf is None:
+            return False
+        resident = cls._resident_block_ids(spec)
+        return any(g not in resident for g in kf.grid_axis_block_ids)
+
+    @staticmethod
+    def _max_group_footprint(
+        kf: ReductionKernelFact,
+        axis: int,
+        footprint_terms: Callable[
+            [tuple[tuple[int | None, ...], ...], int], tuple[int, int]
+        ],
+        default_tiles: tuple[tuple[int | None, ...], ...],
+    ) -> tuple[int, int]:
+        """The ``(scale, flat)`` footprint for sizing ``axis``, taken from the heaviest co-residency
+        group that spans it (largest ``scale``). A reduction axis is tiled the same width
+        everywhere, so it must fit the worst group that uses it. ``flat`` comes from that same max
+        group (mixing scale/flat across groups breaks the chunk solve). If the axis spans no group's
+        tiles (a bare-spec / degenerate case), fall back to ``default_tiles`` (this descriptor's own
+        group)."""
+        best = None
+        for g in kf.coresidency_groups:
+            if not any(axis in t for t in g.live_tiles):
+                continue
+            scale, flat = footprint_terms(g.live_tiles, axis)
+            if best is None or scale > best[0]:
+                best = (scale, flat)
+        return best if best is not None else footprint_terms(default_tiles, axis)
+
+    @classmethod
+    def _has_store_only_row_reread(
+        cls, spec: ConfigSpec, pd: ReductionDescriptor
+    ) -> bool:
+        """True iff the primary reduction's row tensor is ALSO loaded by a store-only pass — a load
+        of that tensor that feeds a store and no reduction (``stores_fed and not reductions_fed``).
+
+        This selects the persist-hold ceiling. The physical question it stands in for is whether
+        persistence's benefit (avoiding the row's HBM re-read) is served from the small L2 working
+        set (tighter ceiling) or the large register file (looser ceiling). That quantity is not
+        cleanly recoverable from any seed-time signal — kernels with the same byte footprint, load
+        count, and output width can flip persist->chunk at ~2x-different points — so this is an
+        ADMITTED PROXY: it classifies the tested kernels correctly but is not a faithful measure of
+        the underlying cache-tier question and can be fooled (e.g. a 2-pass kernel whose 2nd pass
+        reduces instead of storing re-reads the row identically but reads as False). If a kernel
+        regresses on the persist ceiling, this proxy is the first suspect.
+
+        Detected from the walker ``MemoryOpFact`` list (no re-walk). Not the same as
+        ``non_reduction_loop_block_ids`` (a 2nd pass that reduces over the same axis leaves that set
+        empty). Empty facts / no kernel fact -> False."""
+        facts = spec.memory_op_facts
+        if not facts:
+            return False
+        red_tensors = {
+            f.tensor_name
+            for f in facts
+            if f.kind == "load"
+            and f.tensor_name is not None
+            and any(ax == pd.block_id for ax, _ in f.reductions_fed)
+        }
+        if not red_tensors:
+            return False
+        return any(
+            f.kind == "load"
+            and f.tensor_name in red_tensors
+            and f.stores_fed
+            and not f.reductions_fed
+            for f in facts
         )
-        return _np2(max(1, cap))
 
+    # =============================== scalar levers (outside the budget) ===================== #
     @classmethod
-    def _num_warps(
-        cls, fact: ReductionFact, num_sm: int = 0, grid_rows: int = 0
-    ) -> int:
-        """Scale num_warps with the reduction extent (pow2, per NumWarpsFragment):
-        rnumel <= 1024 -> 4, <= 4096 -> 8, <= 16384 -> 16, > 16384 -> 32. Too few
-        under-occupies the SM, too many wastes the reduction tree.
-
-        NARROW-row single-warp refinement at the LOW end (the occupancy-gated lever): a
-        narrow row at low/moderate occupancy wants ONE warp (the cross-warp reduction tree
-        is pure overhead — see ``NARROW_W1_MAX_BYTES``). Fires only when the row-byte cap AND
-        the resident-pressure cap (``occ * row_bytes <= NARROW_W1_OCC_BYTE_LIMIT``) hold; both
-        key on ``input_load_itemsize`` (faithful, no dtype-kind branch) and the occ ceiling
-        scales DOWN as the row grows (a wider row cliffs at lower occupancy). Needs ``num_sm``
-        (0 disables it, e.g. an off-device caller). Disjoint from the wide-row branch below
-        (``NARROW_W1_MAX_BYTES`` << the rnumel>16384 region), so the two never interact.
-        """
-        rnumel = fact.size_hint
-        ils = fact.input_load_itemsize
-        row_bytes = rnumel * ils
-        # NARROW-row single-warp (see NARROW_W1_MAX_BYTES); needs a known device + static grid.
-        have_enough_information = num_sm > 0 and ils > 0 and grid_rows > 0
-        if have_enough_information:
-            occ = grid_rows // num_sm
-            if (
-                fact.num_carried_2d_tiles
-                == 0  # not a carried-2-D-tile reduction (kl_div/jsd)
-                and row_bytes <= cls.NARROW_W1_MAX_BYTES
-                and occ * row_bytes <= cls.NARROW_W1_OCC_BYTE_LIMIT
-            ):
-                return 1
-        # >16384 (not >=) so a 16384-wide row stays w16, excluding the w32 regression there.
+    def _num_warps(cls, pd: ReductionDescriptor) -> int:
+        """Scale num_warps with the reduction extent (pow2): rnumel <= 1024 -> 4, <= 4096 -> 8,
+        <= 16384 -> 16, > 16384 -> 32."""
+        rnumel = pd.size_hint
         warps32_min_elems = 16384
         if rnumel > warps32_min_elems:
             return 32
@@ -564,111 +686,33 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
 
     @classmethod
     def _block_floor(cls, bs_spec: BlockSizeSpec) -> int:
-        """The smallest valid block size for an entry, used for every non-reduction axis
-        the seed does not widen. Prefers one row/program but honors a raised
-        ``autotuner_min`` (large-M shapes) rather than emitting an invalid ``block_size=1``.
-        """
+        """The smallest valid block size for an entry (honors a raised ``autotuner_min`` for
+        large-M shapes rather than emitting an invalid ``block_size=1``)."""
         return max(1, bs_spec.min_size, bs_spec.autotuner_min)
 
     @classmethod
-    def _m_block_cap(cls, fact: ReductionFact) -> int:
-        """Upper bound on M_BLOCK (rows/program) for a FULL-WIDTH-output reduction, so a huge-M
-        grid-size ``autotuner_min`` raise cannot force an occupancy-starving M_BLOCK on a
-        memory-bound held-row reduction. A seed below ``autotuner_min`` (raised only to cap the
-        grid) is still valid -- it survives ``normalize``.
-
-        The cap keeps the resident ``[M_BLOCK, rdim]`` live set inside the per-program register
-        budget: ``M_BLOCK <= ROW_PERSIST_MAX_BYTES / (rdim * itemsize * body_live_tiles)``.
-        Applied only via ``min`` with ``_block_floor`` (only ever LOWERS an over-raised floor)
-        and only for full-width output -- streamed/scalar reductions ride occupancy on the
-        chunk, not M_BLOCK, so they are uncapped.
-        """
-        from ..._utils import prev_power_of_2
-
-        if not fact.full_width_output:
-            return (
-                1 << 30
-            )  # no cap: scalar/streamed occupancy rides the reduction chunk
-        live = max(1, fact.body_live_tiles)
-        isz = max(1, fact.itemsize)
-        sh = max(1, fact.size_hint)
-        return max(
-            1, prev_power_of_2(max(1, cls.ROW_PERSIST_MAX_BYTES // (sh * isz * live)))
-        )
-
-    @classmethod
-    def _m_block_product(cls, spec: ConfigSpec, fact: ReductionFact) -> int:
-        """Product of the seed's floored M-axis (grid) block sizes -- the number of rows each
-        program processes (1 unless a huge-M shape raised ``autotuner_min``, capped by
-        ``_m_block_cap`` for full-width reductions). Shared by the apply-loop stream cap
-        (``_build_block_sizes``) and the Band-C combine cap so they read the same M_BLOCK.
-        """
-        m_block = 1
-        cap = cls._m_block_cap(fact)
-        for mbid in fact.m_block_ids:
+    def _m_axis_block_size(cls, spec: ConfigSpec, mbid: int) -> int:
+        """Seed block size (rows/program) for one M-axis (grid) block_id, whether or not it is a
+        tunable ``block_sizes`` entry. A grid-PINNED axis (``hl.tile(M, block_size=1)``) has no
+        tunable slot and lives solely on the program grid -- read its FIXED value off
+        ``env.block_sizes`` (the grid-pinned-M idiom every vLLM quant kernel uses)."""
+        if mbid in spec.block_sizes.valid_block_ids():
             m_idx = spec.block_sizes.block_id_to_index(mbid)
-            m_block *= min(
-                cls._block_floor(cast("BlockSizeSpec", spec.block_sizes[m_idx])), cap
-            )
-        return m_block
+            return cls._block_floor(cast("BlockSizeSpec", spec.block_sizes[m_idx]))
+        from ...runtime.config import Config as _Config
+        from ..compile_environment import CompileEnvironment
 
-    @classmethod
-    def _build_block_sizes(
-        cls,
-        spec: ConfigSpec,
-        fact: ReductionFact,
-        red_block_id: int | None,
-        red_value: int | None,
-        non_reduction_loop_ids: frozenset[int] | set[int] = frozenset(),
-    ) -> list[int]:
-        """Build the ``block_sizes`` list: the reduction axis gets ``red_value``, each
-        non-reduction loop tile (``non_reduction_loop_ids``, disjoint from the reduction
-        block_id) gets ``loop_block``, every other axis its ``_block_floor``.
-        ``red_block_id`` is None for standard (the reduction rides ``reduction_loops``, not
-        a block_sizes entry).
-
-        The non-reduction loop tile matches the reduction tile — ``red_value`` (user-tiled)
-        or ``next_pow2(size_hint)`` (standard, where ``red_value`` is None). The normalize
-        pass carries no accumulator, so this tile is a pure seed (a sane non-size-1 start,
-        never a correctness constraint); the autotuner refines it from there.
-        """
-        from ..._utils import next_power_of_2 as _np2
-        from ..._utils import prev_power_of_2
-
-        loop_block: int | None = None
-        if non_reduction_loop_ids:
-            # The apply/normalize tile starts at the reduction tile — red_value (user-tiled) or
-            # next_pow2(size_hint) (standard, where red_value is None)...
-            loop_block = red_value if red_value is not None else _np2(fact.size_hint)
-            # ...then is clamped to the same M_BLOCK-aware footprint cap as the reduction
-            # tile (the apply tile is [M_BLOCK, loop_block] resident, so a wide one spills).
-            # Only the Band-C reduce-then-apply kernels (welford, groupnorm) have a normalize
-            # loop, so everything else is byte-identical (no non_reduction_loop_ids). The cap
-            # clamps an otherwise-spilling apply pass back to register residency; the pass is
-            # memory-bound so this is a net win. A flat per-row cap always narrowed it.
-            m_block = cls._m_block_product(spec, fact)
-            budget = cls.ROW_PERSIST_MAX_BYTES // (m_block * max(1, fact.itemsize))
-            loop_block = min(loop_block, prev_power_of_2(budget))
-
-        red_idx = (
-            spec.block_sizes.block_id_to_index(red_block_id)
-            if red_block_id is not None
-            else None
+        env = CompileEnvironment.current()
+        value = env.block_sizes[mbid].from_config(_Config(block_sizes=[]))
+        if isinstance(value, (int, torch.SymInt)):
+            return max(1, int(value))
+        log.warning(
+            "reduction seed: M-axis block_id=%s resolved to a non-static block size %r; "
+            "falling back to block_size=1 (this should not happen for a pinned grid axis)",
+            mbid,
+            value,
         )
-        out: list[int] = []
-        for i in range(len(spec.block_sizes)):
-            bs_spec = cast("BlockSizeSpec", spec.block_sizes[i])
-            if i == red_idx:
-                out.append(cast("int", red_value))
-            elif bs_spec.block_id in non_reduction_loop_ids and loop_block is not None:
-                out.append(loop_block)
-            elif bs_spec.block_id in fact.m_block_ids:
-                # M (grid) axis: floor it, but cap a full-width reduction's M_BLOCK by the
-                # register budget (_m_block_cap) so a huge-M grid raise can't starve occupancy.
-                out.append(min(cls._block_floor(bs_spec), cls._m_block_cap(fact)))
-            else:
-                out.append(cls._block_floor(bs_spec))
-        return out
+        return 1
 
     @classmethod
     def _eviction_policies(
@@ -677,18 +721,10 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
         kind: str,
         reread_slot: int | None = None,
     ) -> list[str] | None:
-        """``load_eviction_policies`` list (spec length), keyed on per-load residency;
-        None leaves the autotuner default.
-
-        - ``"stream"`` — single streamed input (``num_load == 1``: sum, long_sum), read
-          once: every load -> ``'first'`` (frees L2).
+        """``load_eviction_policies`` list (spec length); None leaves the autotuner default.
+        - ``"stream"`` — single streamed input (read once): every load -> ``'first'`` (frees L2).
         - ``"reread"`` — the row is re-read across passes: its first load -> ``'last'``
-          (L2-resident), rest -> ``'first'``. ``reread_slot`` is that load's actual slot,
-          read directly from ``ReductionFact.reread_eviction_index`` (the re-read load's
-          ``MemoryOpFact.eviction_index``), not guessed or re-walked per config.
-
-        Other kinds leave the default until a per-slot win is confirmed.
-        """
+          (L2-resident), rest -> ``'first'``. ``reread_slot`` from ``reread_eviction_index``."""
         n = env.config_spec.load_eviction_policies.length
         if n <= 0:
             return None
@@ -702,112 +738,388 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
             return policy
         return None
 
+    # ================================ THE BUDGET ALLOCATOR ============================== #
     @classmethod
-    def _reduction_rblock(
+    def size_reduction_tiles(
         cls,
         env: CompileEnvironment,
-        fact: ReductionFact,
-        m_block: int,
-        footprint_factor: int = 1,
-    ) -> tuple[int, bool]:
-        """The reduction-axis chunk (pow2) AND the persistent verdict, decided together in one
-        budgeted formula and shared by both tracks. Returns ``(r_block, persistent)``.
+        spec: ConfigSpec,
+        device_ir: DeviceIR,
+        pd: ReductionDescriptor,
+    ) -> _TileAllocation:
+        """THE allocator: a per-co-residency-group BUDGET over the group's ACTUAL resident live
+        tiles (``CoResidencyGroup.live_tiles``) assigns every tile size, in TWO passes.
 
-        ``footprint_factor`` = how many resident rdim-shaped tiles one program holds live at
-        the peak (1 = a single result tile). It bounds the decision two ways:
-        - PERSISTENT additionally requires (besides ``row_reread`` and no carried 2-D tile) the
-          single resident tile to fit ``ROW_PERSIST_MAX_BYTES`` AND the full
-          ``footprint_factor``-tile resident set to fit ``LIVE_PERSIST_BUDGET`` (the multi-tile
-          spill ceiling). This liveness term only ever REMOVES persistence from a heavy body.
-        - the LOOPED chunk is shrunk by ``footprint_factor`` so a heavy body gets a smaller
-          chunk, keeping the looped resident set inside the register budget.
+        The footprint is faithful: ``resident_bytes = itemsize × Σ over the group's live tiles of
+        ∏(tile dim widths)``. Sizing an axis A splits that sum into ``(scale, flat)`` — tiles
+        CONTAINING A scale with ``block(A)``, tiles WITHOUT A are constant — and the budget test is
+        ``itemsize × (scale × block(A) + flat) <= budget`` (the constant term SUBTRACTED, never
+        divided). No ``num_live`` multiplier, no separate accumulator sum, no feature-extent
+        reconstruction: the live tiles ARE the resident set (accumulators captured inline at real
+        shape, scalar carries as rank-1 constant tiles).
 
-        The standard track passes ``footprint_factor=body_live_tiles``; the user-tiled track
-        keeps the default ``1`` (where ``LIVE_PERSIST_BUDGET`` collapses to the base byte cap,
-        a no-op). The carried-2-D-tile cap (kl_div/jsd) is folded into the chunk decision.
+        For each co-residency group:
 
-        No welford "structured-combine floor": register-residency via the footprint cap is what
-        matters; welford is memory-bound and a wide combine tile only spills.
+          PASS 1 — seat the reductions with the grid axes pinned at their FLOOR (full-extent ->
+            user-tile -> grid-tile). A re-read full-slice raises its floor to the full extent
+            (PERSISTENCE) iff its resident tile fits the budget; else it chunks to
+            ``min(LOOPED_CHUNK, byte budget, extent)``. A carried reduction (kl_div/norm-bwd) sizes
+            against the tighter ``CARRIED_PERSIST`` budget.
+
+          PASS 2 — the grid-M rows take the REMAINDER. A grid axis that is RESIDENT (appears in some
+            live tile -> its row co-occupies the working set) WIDENS into the byte remainder (capped
+            by occupancy + WIDEN_MAX_ROWS + extent) and FLOORS when the budget is spent. A grid axis
+            in NO live tile is REDUCED AWAY (a sequential cross-grid ``.sum(0)`` finalize, holds no
+            bytes) -> its floor raises to ``grid_rows / num_sm`` (collapse the finalize to ~1 SM
+            wave). Both are pure per-axis MEMBERSHIP outcomes — no ``cdiv`` branch, no recognizer.
+
+        Then the non-reduction loops LAST (welford's normalize, rms_norm_per_block's groups_per_row)
+        — a separate pass co-resident with nothing in the group, sized against its own headroom.
+
+        EMISSION is the ONLY standard-vs-user difference: a reduction's computed size is WRITTEN to
+        ``reduction_loops`` (rolled/standard) or a ``block_sizes`` slot (user-tiled). Every
+        reduction gets a size from the SAME budget; the split is codegen routing, not a different
+        way to compute.
         """
         from ..._utils import next_power_of_2 as _np2
-        from ..._utils import prev_power_of_2
-
-        rdim = _np2(fact.size_hint)
-        itemsize = max(1, fact.itemsize)
-        m = max(1, m_block)
-        ff = max(1, footprint_factor)
-        # Persistent iff (a) a SINGLE result tile fits the per-program caps (the element compile
-        # limit element_cap AND the ROW_PERSIST_MAX_BYTES single-tile byte cap), AND (b) the full
-        # ff-tile resident set fits LIVE_PERSIST_BUDGET. (b) is the liveness ceiling: it only
-        # removes persistence from a heavy body, never grants it (no-op at ff==1).
-        element_cap = env.backend.max_tensor_numel
-        # Hold the full extent one-shot iff it clears every per-program ceiling (element compile
-        # limit element_cap, ROW_PERSIST_MAX_BYTES byte cap, LIVE_PERSIST_BUDGET live-set cap) AND
-        # there is NO carried 2-D accumulator -- a [M_BLOCK, R_BLOCK] tile carried across the loop
-        # is too heavy to hold, so stream.
-        extent_held = (
-            # Persist captures a re-read prize iff looping would RE-READ the row: a full-width apply
-            # (rms/layer_norm/softmax/welford) or a second reduction needing the first's result
-            # (cross_entropy's logsumexp -- which full_width_output misses). row_reread catches both;
-            # num_carried_2d_tiles == 0 keeps kl_div/jsd off persist (they re-read regardless).
-            fact.row_reread
-            and fact.num_carried_2d_tiles == 0
-            and (element_cap is None or fact.size_hint <= element_cap)
-            and (m * fact.size_hint * itemsize <= cls.ROW_PERSIST_MAX_BYTES)
-            and (ff * m * fact.size_hint * itemsize <= cls.LIVE_PERSIST_BUDGET)
-        )
-        if extent_held:
-            r_block = rdim
-        else:
-            # Can't hold the extent -> stream it at the occupancy-optimal LOOPED_CHUNK (M_BLOCK- and
-            # liveness-shrunk); a capacity-sized chunk would re-read AND lower occupancy.
-            budget = cls.ROW_PERSIST_MAX_BYTES // (m * itemsize * ff)
-            r_block = min(cls.LOOPED_CHUNK, prev_power_of_2(budget))
-            # Carried 2-D accumulators (kl_div, jsd) always reach this branch; cap R_BLOCK by its tighter
-            # byte budget to avoid catastrophic register spills. No-op when num_carried_2d_tiles == 0.
-            if fact.num_carried_2d_tiles >= 1:
-                r_block = min(r_block, cls._carried_tile_r_block_cap(fact))
-        # Never size the chunk past the (padded) extent: clamp to rdim so a sub-cap-N carried reduction
-        # matches the old held branch and keeps `persistent` below correct.
-        r_block = max(1, min(r_block, rdim))
-        # `persistent` is READ OFF the final chunk -- held iff the chunk reached the extent
-        # (reduction_loops=[None] standard, or R_BLOCK == rdim user-tiled), never set separately.
-        return r_block, r_block >= rdim
-
-    @classmethod
-    def _m_collapse_grid_block(
-        cls, env: CompileEnvironment, fact: ReductionFact, cap: int | None = None
-    ) -> int:
-        """Occupancy-sized grid M block for a grad-parameter M-collapse (rms/ln/instance/group
-        backward on the standard track; bias_grad/dyt on the user-tiled track). The
-        grad-parameter (``grad_weight[N]`` / ``grad_bias[N]``) is summed across the grid rows
-        into a per-CTA partial finalized by a cross-CTA ``sum(0)``; with the block floored to 1
-        that is a grid-wide M-way collapse (one partial/row), so size it to ~one SM wave
-        (``next_pow2(grid_rows // num_sm)``) to cut it to ~``num_sm`` partials.
-
-        ``cap`` bounds the block when it ALSO bears the reduction slab (user-tiled pure
-        collapse, capped at ``M_COLLAPSE_MAX_CTA``); the standard track leaves it uncapped
-        because the resident ``[inner, feature]`` set rides a separate inner re-tile, not this
-        block. A dynamic/unbacked grid (``grid_rows == 0``) collapses to 1.
-        """
-        from ..._utils import next_power_of_2 as _np2
+        from ..._utils import prev_power_of_2 as _pp2
         from ...runtime import get_num_sm
 
-        grid_rows = _grid_rows(env, fact.m_block_ids)
         num_sm = max(1, get_num_sm(env.device))
-        block = _np2(max(1, grid_rows // num_sm))
-        return max(1, block if cap is None else min(cap, block))
+        occ_floor = num_sm * cls.MIN_WAVES
+        itemsize = max(1, pd.itemsize)
+        valid = set(spec.block_sizes.valid_block_ids())
+        kf = spec.reduction_kernel_fact
+        assert kf is not None
+        grid_ids = set(kf.grid_axis_block_ids)
+        non_reduction_loop_ids = set(cls._non_reduction_loop_ids(spec))
+        reduction_ids = {d.block_id for d in kf.reductions}
 
-    @classmethod
-    def _m_collapse_inner_byte_cap(cls, feat_bytes: int) -> int:
-        """Largest pow2 inner reduction tile whose resident ``[inner, feature]`` fp32 set fits
-        ``M_COLLAPSE_TILE_BYTES``, given the per-row feature footprint ``feat_bytes``. Both
-        M-collapse tracks pass ``fact.feature_footprint * itemsize`` (the PRODUCT of the
-        materialized feature axes); for a 2-D norm that product is the single feature axis.
-        """
-        from ..._utils import next_power_of_2 as _np2
+        # Extent (pow2-padded) per block_id, read from STORED hints. The reason these maps exist at
+        # all is TESTING: the reduction unit tests call ``get_seed_config`` on a bare spec OUTSIDE an
+        # active CompileEnvironment, where ``env.block_sizes[bid]`` is unavailable — so extents must
+        # come from data already persisted on the spec/fact. A reduction's extent is its descriptor
+        # ``size_hint``; a tunable axis's is its ``BlockSizeSpec.size_hint``. The third fallback
+        # (``env.block_sizes`` — a non-tunable pinned grid / materialized feature) is LIVE-PATH ONLY:
+        # in the no-env test path every axis is in ``_spec_extent`` or ``_desc_extent`` by
+        # construction, so that branch never executes (and would raise NoCurrentEnvironment if it did).
+        _desc_extent = {d.block_id: d.size_hint for d in kf.reductions}
+        _spec_extent = {
+            cast("BlockSizeSpec", spec.block_sizes[i]).block_id: cast(
+                "BlockSizeSpec", spec.block_sizes[i]
+            ).size_hint
+            for i in range(len(spec.block_sizes))
+        }
 
-        return max(1, _np2(max(1, cls.M_COLLAPSE_TILE_BYTES // max(1, feat_bytes))))
+        def extent_of(bid: int) -> int:
+            if bid in _spec_extent:
+                return _np2(_spec_extent[bid])
+            if bid in _desc_extent:
+                return _np2(_desc_extent[bid])
+            return _np2(env.block_sizes[bid].size_hint())
+
+        # The persistence/chunk budget a reduction sizes against — the only place the regime enters
+        # (the footprint formula is identical everywhere; only this number changes). Two budgets,
+        # keyed PER-REDUCTION on whether THIS reduction carries a >=2-D tile:
+        #  - CARRIED (``carried_2d_count > 0``): the reduction's own ``[grid_M, R]`` accumulator is
+        #    held resident across the whole inner loop, a heavier steady-state pressure than a
+        #    streamed row -> the tighter budget -> smaller chunk.
+        #  - STREAMED (``carried_2d_count == 0``): the ROW budget. Per-reduction, not kernel-wide: a
+        #    grad-parameter norm-bwd carries its N accumulator on the materialized N axis, but the
+        #    co-resident inner tile it sizes is itself non-carried and wants the looser ROW budget.
+        #    A per-row scalar carry (e.g. welford mean/M2 ``[grid_M]``) has c2d=0, so it stays STREAMED.
+        def persist_budget_for(d: ReductionDescriptor) -> int:
+            return (
+                cls.CARRIED_PERSIST_MAX_BYTES
+                if d.carried_2d_count > 0
+                else cls.ROW_PERSIST_MAX_BYTES
+            )
+
+        # The static grid-row count (program count before any widen), the occupancy numerator.
+        from ..compile_environment import NoCurrentEnvironment
+
+        grid_rows = 1
+        # The try/except is NECESSARY (not defensive noise): this block dereferences the live
+        # ``env`` (``env.block_sizes[gbid].size``, ``env.size_hint``), which the no-env unit-test
+        # path (see ``extent_of`` above) cannot provide -> ``NoCurrentEnvironment``; a dynamic/None
+        # grid size raises ``AttributeError``/``TypeError``. All three collapse to the SAME defined
+        # fallback ``grid_rows = 0`` = "no compile-time occupancy", which the pass-2 occupancy widen
+        # already handles (it simply does not fire). Scoped tightly to the env-touching loop so it
+        # cannot mask an unrelated bug.
+        try:
+            for gbid in grid_ids:
+                size = env.block_sizes[gbid].size
+                if isinstance(size, (int, torch.SymInt)):
+                    grid_rows *= env.size_hint(size)
+                else:
+                    grid_rows = 0  # dynamic grid -> no compile-time occupancy
+                    break
+        except (NoCurrentEnvironment, AttributeError, TypeError):
+            grid_rows = 0
+
+        # ``seated`` holds every tile assigned so far (held fixed for later sizing); ``sizes`` is
+        # the subset that lands in tunable ``block_sizes`` slots. PASS 1 seats every grid axis at
+        # its FLOOR; the reductions are sized against that floored grid, then PASS 2 widens the grid
+        # into whatever budget the seated reductions left (the two-pass structure — reductions
+        # first with the grid pinned low, then the grid).
+        seated: dict[int, int] = {}
+        for gbid in sorted(grid_ids):
+            seated[gbid] = cls._m_axis_block_size(spec, gbid)
+        sizes: dict[int, int] = {}
+        block_sizes_red_values: dict[int, int] = {}
+        rolled_loop_sizes: dict[int, tuple[int, bool]] = {}
+        primary_r_block = 1
+        persistent = False
+
+        # Which axes are register-resident (see ``_resident_block_ids``). A grid axis in a live tile
+        # widens into the byte budget; a grid axis in no live tile is reduced away by a later
+        # ``.sum(0)``, holds no bytes, and collapses to ~1 SM wave instead.
+        resident_block_ids = cls._resident_block_ids(spec)
+
+        # A kernel with a loop-carried >=2-D accumulator (``carried_2d_count >= 1`` on any reduction)
+        # pins that ``[grid_M, R]`` state in registers across the whole inner loop, so widening the
+        # resident grid is risky (it multiplies the pinned register footprint and trips the
+        # CTA-per-SM occupancy cliff). Such a kernel keeps its resident grid at FLOOR (no widen).
+        carried_kernel = any(d.carried_2d_count > 0 for d in kf.reductions)
+
+        def footprint_terms(
+            tiles: tuple[tuple[int | None, ...], ...],
+            axis: int,
+        ) -> tuple[int, int]:
+            """The group footprint as ``(scale, flat)``: resident bytes while sizing ``axis`` =
+            ``itemsize × (scale × block(axis) + flat)`` — an axis-scaling term plus a constant term,
+            kept separate (they ADD; folding the constant into a per-element coefficient over-counts
+            it and wrongly denies persistence). Sum ``∏(dim widths)`` over the group's live tiles: a
+            tile containing ``axis`` scales with it (its ``∏(other dims)`` adds to ``scale``), a tile
+            without ``axis`` is constant (adds to ``flat``). A ``None`` dim is a size-1 broadcast.
+            The tiles already ARE the resident set (loop-carried accumulators captured inline at
+            real shape), so no separate accumulator sum is needed."""
+            scale = 0
+            flat = 0
+            for tile in tiles:
+                contains_axis = axis in tile
+                prod = 1
+                for d in tile:
+                    if d is None or d == axis:
+                        continue
+                    prod *= conservatively_large_tile_width(d)
+                if contains_axis:
+                    scale += prod
+                else:
+                    flat += prod
+            return max(1, scale), flat
+
+        def conservatively_large_tile_width(bid: int) -> int:
+            """One resident dim's width for the footprint bound: its SEATED width if already chosen,
+            else its full extent. The full-extent fallback is safe BY SEATING ORDER, not a blind
+            assumption — grid axes are seated first (the pass-1 preamble above), and a not-yet-seated
+            *reduction* dim is later in the sizing ``order`` below, so over-approximating it at full
+            extent only makes the footprint LARGER, keeping the axis currently being sized
+            conservative (it can only end up smaller/safer, never over-sized into a spill). NB: the
+            footprint is therefore ORDER-DEPENDENT (a later-sized reduction sees an earlier one at its
+            seated width, but not vice-versa) — the ``order`` sort below is load-bearing for
+            correctness, not cosmetic."""
+            return max(1, seated.get(bid, extent_of(bid)))
+
+        # The persistence-hold ceiling (used once, at ``expand_to_persist`` in the loop below; kept
+        # here as it is loop-invariant — keyed on the primary ``pd``). Selects the SMALL vs BIG
+        # bucket via ``_has_store_only_row_reread`` (an admitted proxy — see that method and
+        # PERSIST_HOLD_MAX_BYTES).
+        hold_ceiling = (
+            cls.USER_TILE_PERSIST_HOLD_MAX_BYTES
+            if cls._has_store_only_row_reread(spec, pd)
+            else cls.PERSIST_HOLD_MAX_BYTES
+        )
+
+        for g in kf.coresidency_groups:
+            descs = [kf.reductions[i] for i in g.descriptor_indices]
+            sized = [d for d in descs if d.category in SIZED_REDUCTION_CATEGORIES]
+            if not sized:
+                continue
+            tiles = g.live_tiles
+
+            # ---- PASS 1: seat the reductions (full-extent -> user-tile -> grid-tile) against the
+            # group's live-tile footprint with the grid axes at their floor. ----
+            order = sorted(
+                sized,
+                key=lambda d: (
+                    0
+                    if d.category in FULL_EXTENT_CATEGORIES
+                    else (1 if d.category is ReductionCategory.USER_TILE else 2),
+                    -d.size_hint,
+                ),
+            )
+            # ``order`` is ``sized`` (SIZED_REDUCTION_CATEGORIES only): FULL_SLICE / FULL_GRID /
+            # USER_TILE. A GRID_TILE reduction (jsd's grid amax) is NOT sized here — it is a grid
+            # axis, seated at its floor in the grid loop above and widened in PASS 2 like any grid
+            # row. So this loop never sees a GRID_TILE.
+            for d in order:
+                raw_ext = d.size_hint  # the true reduction extent (NOT pow2-padded)
+                ext = extent_of(d.block_id)  # pow2-padded — the seated tile width
+                materialized_full_width = (
+                    d.category is ReductionCategory.FULL_SLICE
+                    and d.block_id not in valid
+                    and d.block_id not in spec.reduction_loops.valid_block_ids()
+                )
+                if d.category is ReductionCategory.FULL_GRID or materialized_full_width:
+                    # FULL_GRID (cdiv == 1) or a materialized full-width FULL_SLICE (the roller
+                    # declined to roll it and it has no tunable block_sizes slot — e.g. a
+                    # grad-parameter ``grad_weight[N]`` accumulator axis, or a specialized
+                    # ``group_size``): the whole axis is one program's tile, full-extent resident by
+                    # definition. Seat at the full extent, never chunk it through the byte budget — it
+                    # cannot be split across programs and has nowhere to emit a chunk. Seating it
+                    # full-width (not chunked to 1) is what lets the co-resident inner tile see the
+                    # real N (else the inner tile reads N as 1 and grows to full extent — a spill).
+                    seated[d.block_id] = ext
+                    if d.block_id == pd.block_id:
+                        primary_r_block = ext
+                        # Seated at its full extent (r == ext), so it is persistent under the same
+                        # ``persistent = (r >= ext)`` rule the normal sizing path uses.
+                        persistent = True
+                    if d.block_id in valid:
+                        block_sizes_red_values[d.block_id] = ext
+                    continue
+                # Resident bytes(R) = itemsize × (scale × R + flat) over the live tiles. A reduction
+                # axis is tiled the same width everywhere it appears, so it must fit the heaviest
+                # co-residency group that spans it — take the footprint from the max-``scale`` group
+                # over ``d.block_id``, not just this descriptor's own group. ``flat`` is taken from
+                # that same max group (mixing terms across groups breaks the chunk arithmetic).
+                scale, flat = cls._max_group_footprint(
+                    kf, d.block_id, footprint_terms, default_tiles=tiles
+                )
+                # Size a streamed/chunked R from the byte budget first: the largest pow2 R whose
+                # resident bytes fit, solving ``itemsize × (scale × R + flat) <= budget`` for R (the
+                # constant term is subtracted, not divided), capped by LOOPED_CHUNK and the extent. A
+                # carried reduction sizes against the tighter carried budget; a non-carried inner tile
+                # against ROW.
+                avail = persist_budget_for(d) // itemsize - flat
+                byte_budget = _pp2(max(1, avail // scale))
+                r = max(1, min(cls.LOOPED_CHUNK, byte_budget, ext))
+                # THEN EXPAND TO PERSISTENT: lift R to the full extent iff the row is re-read (a
+                # persistent pass fuses reduce+apply to one HBM load) AND there is no carried 2-D
+                # tile (a carried tile is held resident the whole loop — it chunks, never persists)
+                # AND the extent clears the per-program element limit AND the single resident tile
+                # fits the persist ``hold_ceiling`` (apply-reread-keyed, computed above). The byte
+                # test uses the RAW extent (true resident element count, not pow2-padded).
+                element_cap = env.backend.max_tensor_numel
+                expand_to_persist = (
+                    d.row_reread
+                    and d.carried_2d_count == 0
+                    and (element_cap is None or raw_ext <= element_cap)
+                    and itemsize * (scale * raw_ext + flat) <= hold_ceiling
+                )
+                if expand_to_persist:
+                    r = ext
+                seated[d.block_id] = r
+                # THREE independent routing checks (the block_sizes and reduction_loops namespaces
+                # are DISJOINT — an axis is a ``block_sizes`` tile XOR a rolled ``reduction_loops``
+                # axis, never both — so these are plain ``if``s, not an if/elif chain):
+                # (A) the PRIMARY's scalar levers (num_warps ramp + standard-track reduction_loops).
+                if d.block_id == pd.block_id:
+                    primary_r_block = r
+                    persistent = r >= ext and d.category in FULL_EXTENT_CATEGORIES
+                # (B) a tunable ``block_sizes`` reduction (user-tiled) -> its block_sizes slot.
+                if d.block_id in valid:
+                    block_sizes_red_values[d.block_id] = r
+                # (C) a ROLLED NON-primary reduction -> surface its size for the standard track's
+                # reduction_loops emission. ``!= pd.block_id`` excludes the ROLLED PRIMARY (whose
+                # size is emitted via ``primary_r_block`` in (A) instead — it would otherwise be
+                # double-routed here). Only reached by a kernel that rolls >1 reduction.
+                if (
+                    d.block_id != pd.block_id
+                    and d.block_id in spec.reduction_loops.valid_block_ids()
+                ):
+                    rolled_loop_sizes[d.block_id] = (
+                        r,
+                        r >= ext and d.category in FULL_EXTENT_CATEGORIES,
+                    )
+
+            # ---- PASS 2: the grid-M rows take the remainder (widen / floor / collapse). ----
+            for mbid in sorted(grid_ids):
+                if mbid not in valid:
+                    continue  # a grid-PINNED axis (FixedBlockSizeSource) -> fixed, not sized.
+                ext = extent_of(mbid)
+                floor = cls._block_floor(
+                    cast(
+                        "BlockSizeSpec",
+                        spec.block_sizes[spec.block_sizes.block_id_to_index(mbid)],
+                    )
+                )
+                if mbid not in resident_block_ids:
+                    # a sequential cross-grid reduction loop (grad-param .sum(0)): in NO live tile ->
+                    # NOT resident, holds no bytes. The byte budget cannot size it; raise the floor
+                    # to ~1 SM wave to collapse the cross-grid finalize.
+                    collapse = _np2(max(1, grid_rows // num_sm)) if grid_rows > 0 else 1
+                    blk = max(floor, min(collapse, ext))
+                elif carried_kernel:
+                    # Register-occupancy guard (see ``carried_kernel`` above): the pinned
+                    # ``[grid_M, R]`` accumulator makes widening the grid trip the CTA-per-SM
+                    # occupancy cliff, which the leftover-byte widen and program-count ``occ_widen``
+                    # cannot see. So a carried kernel keeps its resident grid at FLOOR.
+                    blk = floor
+                else:
+                    # resident parallel rows: widen into the byte remainder (same faithful
+                    # ``scale × block + flat`` footprint over the live tiles — a wider grid row
+                    # scales every tile CONTAINING the grid axis), capped by occupancy (keep the
+                    # post-widen grid >= num_sm·MIN_WAVES), a diminishing-returns ROWS ceiling, and
+                    # the extent; floors when the budget is full.
+                    scale_w, flat_w = footprint_terms(tiles, mbid)
+                    avail_w = persist_budget_for(pd) // itemsize - flat_w
+                    byte_widen = _pp2(max(1, avail_w // scale_w))
+                    if grid_rows > 0:
+                        occ_widen = _pp2(max(1, grid_rows // occ_floor))
+                    else:
+                        occ_widen = (
+                            1  # dynamic grid -> no compile-time occupancy -> no widen
+                        )
+                    # ROWS ceiling: batching more than WIDEN_MAX_ROWS reduction ROWS/program only
+                    # trades away grid parallelism for a resident-row reduction (softmax/rms_norm:
+                    # memory-bound, does not amortize past ~8 rows). Does NOT apply when the primary
+                    # is FULL_GRID (the grid axis batches tiny grid-resident per-group reductions —
+                    # per_token_group's groups_per_row — which wants the wide occupancy-bound widen).
+                    rows_ceiling = (
+                        ext
+                        if pd.category is ReductionCategory.FULL_GRID
+                        else cls.WIDEN_MAX_ROWS
+                    )
+                    blk = max(floor, min(byte_widen, occ_widen, rows_ceiling, ext))
+                seated[mbid] = blk
+                sizes[mbid] = blk
+
+        # ---- the non-reduction / independent loops LAST (own budget vs the headroom) ----
+        # welford's normalize loop / rms_norm_per_block's groups_per_row. Co-resident with nothing
+        # in a group's reduction tile (a separate sequential pass), so each gets a FRESH budget
+        # against its own extent capped by the streamed ROW budget.
+        loop_budget = _pp2(max(1, cls.ROW_PERSIST_MAX_BYTES // itemsize))
+        for i in range(len(spec.block_sizes)):
+            bs_spec = cast("BlockSizeSpec", spec.block_sizes[i])
+            bid = bs_spec.block_id
+            if bid in block_sizes_red_values or bid in grid_ids or bid in reduction_ids:
+                continue
+            if bid in non_reduction_loop_ids or bid not in seated:
+                # a non-reduction apply loop OR an independent standalone tiled loop: size it to
+                # its own extent capped by the headroom (flooring it to 1 would serialize the pass).
+                sizes[bid] = max(1, min(extent_of(bid), loop_budget))
+
+        # ---- assemble the full block_sizes vector ----
+        block_sizes: list[int] = []
+        for i in range(len(spec.block_sizes)):
+            bs_spec = cast("BlockSizeSpec", spec.block_sizes[i])
+            bid = bs_spec.block_id
+            if bid in sizes:
+                block_sizes.append(sizes[bid])
+            elif bid in block_sizes_red_values:
+                block_sizes.append(block_sizes_red_values[bid])
+            else:
+                block_sizes.append(cls._block_floor(bs_spec))
+
+        return _TileAllocation(
+            block_sizes=block_sizes,
+            block_sizes_red_values=block_sizes_red_values,
+            primary_r_block=primary_r_block,
+            persistent=persistent,
+            rolled_loop_sizes=rolled_loop_sizes,
+        )
 
 
 class TritonStandardReductionHeuristic(_TritonReductionSeedBase):
@@ -830,8 +1142,8 @@ class TritonStandardReductionHeuristic(_TritonReductionSeedBase):
     def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
         if not _triton_reduction_eligible(env, device_ir):
             return False
-        spec = env.config_spec
-        return _is_standard_reduction(spec, spec.reduction_facts[0])
+        pd = _primary_descriptor_selected(env)
+        return pd is not None and _is_standard_reduction(pd)
 
     @classmethod
     def _narrow_seed(cls, env: CompileEnvironment) -> Config:
@@ -862,77 +1174,51 @@ class TritonStandardReductionHeuristic(_TritonReductionSeedBase):
         if not matches_hardware(env, cls.HARDWARE_TARGETS):
             # Off the H100-validated target: keep the upstream conservative seed.
             return cls._narrow_seed(env)
-        from ...runtime import get_num_sm
-
         spec = env.config_spec
-        fact = spec.reduction_facts[0]
-        # standard rides persistent-vs-looped on reduction_loops (sized by the shared _reduction_rblock).
-        # footprint_factor=body_live_tiles routes a heavy body that would overflow the register file
-        # persistent (e.g. fused_linear_jsd) to the looped path instead.
-        m_block = cls._m_block_product(spec, fact)
-        r_block, persistent = cls._reduction_rblock(
-            env,
-            fact,
-            m_block,
-            footprint_factor=fact.body_live_tiles,
-        )
-        num_warps = cls._num_warps(
-            fact, max(1, get_num_sm(env.device)), _grid_rows(env, fact.m_block_ids)
-        )
+        pd = _primary_descriptor_selected(env)
+        if pd is None:
+            return None
+        # The allocator sizes every axis from the per-co-residency-group budget: the reduction
+        # chunk(s), the grid M (the remainder — widen / floor / collapse), and the apply/independent
+        # loops, in one pass. The standard track maps that sizing onto the rolled ``reduction_loops``
+        # knob + the num_warps ramp + eviction below (emission routing only).
+        alloc = cls.size_reduction_tiles(env, spec, device_ir, pd)
+        block_sizes = alloc.block_sizes
+        r_block, persistent = alloc.primary_r_block, alloc.persistent
+        num_warps = cls._num_warps(pd)
+        # Grad-parameter M-collapse warp floor: a kernel that reduces its grid-M axis away (finalized
+        # by a later ``.sum(0)`` — a grid block_id in no live tile) batches many M-rows per program
+        # and accumulates a wide ``[inner, N]`` gradient. That cross-warp-parallelizable work wants
+        # >=8 warps even when the primary reduction's extent is small. A floor, so it never lowers a
+        # large-rdim ramp. Independent of co-residency, so not gated on a co-resident sibling.
+        if cls._has_reduced_away_grid(spec):
+            num_warps = max(8, num_warps)
 
-        # A standard reduction may be followed by a normalize loop (e.g. `s = x.sum(); out =
-        # x/s`); its extra block_sizes tile(s) are sized by _build_block_sizes (matched to
-        # the reduction tile). Only a seed (a worse tile costs autotuning time, never
-        # correctness), so emit and let the autotuner refine.
-        non_reduction_loop_ids = set(fact.non_reduction_loop_block_ids)
-
-        # red_block_id=None: rdim is not a block_sizes entry, so every entry is a grid axis (floored)
-        # or a normalize-loop tile. MATERIALIZED rdim (rms/ln/instance bwd, the roller declined to roll
-        # it): emit an EMPTY reduction_loops -- already full-width persistent, and a length-1 list would
-        # fail normalize against the 0-length spec.
-        is_materialized = fact.block_id not in spec.reduction_loops.valid_block_ids()
+        # standard rides persistent-vs-looped on the rolled ``reduction_loops`` knob (the primary
+        # rdim is NOT a block_sizes entry). MATERIALIZED rdim (rms/ln/instance bwd, the roller
+        # declined to roll it): emit an EMPTY reduction_loops -- already full-width persistent, and
+        # a length-1 list would fail normalize against the 0-length spec.
+        is_materialized = pd.block_id not in spec.reduction_loops.valid_block_ids()
         reduction_loops: list[int | None]
         if is_materialized:
             reduction_loops = []
-        else:
+        elif len(spec.reduction_loops) <= 1:
+            # Single rolled reduction (the common case).
             reduction_loops = [None] if persistent else [r_block]
-        block_sizes = cls._build_block_sizes(
-            spec, fact, None, None, non_reduction_loop_ids=non_reduction_loop_ids
-        )
-        # Dual-axis grad-parameter M-collapse (rms/ln/instance/group bwd): the grid M block is re-tiled
-        # by an inner loop and feeds a per-feature grad accumulator finalized across CTAs.
-        # _build_block_sizes floors it to 1 (leaving a grid-wide finalize); size it for occupancy so the
-        # finalize shrinks to ~num_sm partials. Gated on per_feature_accumulator, which is False for the
-        # 9 standard + 8 transfer kernels, so their seeds stay byte-identical.
-        if fact.per_feature_accumulator:
-            # The lever needs the grow-grid / byte-cap-inner decomposition to exist: a non-grid
-            # inner tile bearing residency. per_feature_accumulator implies a device carry loop
-            # (not the grid or rdim) that appears in inner_tile_ids, so an EMPTY inner_tile_ids
-            # means no inner re-tile -- skip the lever and keep the base materialized seed.
-            grid_ids = {b for bids in device_ir.grid_block_ids for b in bids}
-            inner_tile_ids = [
-                b
-                for b in spec.block_sizes.valid_block_ids()
-                if b not in grid_ids
-                and b != fact.block_id
-                and b not in non_reduction_loop_ids
-            ]
-            if inner_tile_ids:
-                # Occupancy-size the grid M block (the dominant lever), byte-cap the inner
-                # re-tile to the feature footprint, and drop the narrow-w1 warps lever: it keys
-                # on rdim extent alone, but the resident tile here is [inner, feature]-wide, so
-                # the plain extent ramp (>=4 warps) is faithful. Only instance_norm is affected.
-                m_cta = cls._m_collapse_grid_block(env, fact)
-                for mbid in fact.m_block_ids:
-                    block_sizes[spec.block_sizes.block_id_to_index(mbid)] = m_cta
-                inner = cls._m_collapse_inner_byte_cap(
-                    max(1, fact.feature_footprint) * max(1, fact.itemsize)
-                )
-                for bid in inner_tile_ids:
-                    block_sizes[spec.block_sizes.block_id_to_index(bid)] = inner
-                num_warps = cls._num_warps(
-                    fact
-                )  # num_sm/grid_rows default 0 -> no narrow-w1
+        else:
+            # Multiple rolled reductions (e.g. two sequential rolled reductions in separate graphs).
+            # One ``reduction_loops`` entry per spec in spec order: the primary spec uses
+            # (r_block, persistent); the other rolled specs use ``alloc.rolled_loop_sizes`` (each
+            # sized against its own extent — a rolled axis has no block_sizes slot, so the allocator
+            # surfaces it here rather than in block_sizes_red_values).
+            reduction_loops = []
+            for rl_spec in spec.reduction_loops:
+                bid = rl_spec.block_ids[0]
+                if bid == pd.block_id:
+                    reduction_loops.append(None if persistent else r_block)
+                else:
+                    rb, pers = alloc.rolled_loop_sizes[bid]
+                    reduction_loops.append(None if pers else rb)
         seed: dict[str, Any] = {
             "block_sizes": block_sizes,
             "reduction_loops": reduction_loops,
@@ -941,20 +1227,21 @@ class TritonStandardReductionHeuristic(_TritonReductionSeedBase):
             # 'flat': these reductions are grid-saturated at the M-grid.
             "pid_type": "flat",
         }
-        # Eviction: streamed input -> 'first' everywhere; looped re-read -> first load
-        # 'last', rest 'first'. PERSISTENT rows are left at default ON PURPOSE (the `not
-        # persistent` gate below): a rolled persistent reduction fuses the reduce + apply to a
-        # SINGLE HBM load of the row (profiler-confirmed), so a 'last' hint is a no-op and
-        # actually regresses wide rows by pinning x and evicting weight/store lines. This is
-        # the opposite of the user-tiled track, where softmax_two_pass has two PHYSICAL
-        # reduction loops (two loads) so 'last' helps even when persistent.
+        # Eviction: a streamed input -> 'first' everywhere; a re-read row reloaded across a
+        # grid-COLLAPSE loop -> pin it 'last' (first load), rest 'first'. Gated on
+        # ``_has_reduced_away_grid`` (the grad-parameter ``.sum(0)`` M-collapse idiom: the program
+        # batches many M-rows and re-fetches the row from L2 each row, so pinning it pays), not on
+        # ``not persistent`` — a single fused persistent row does not reload from L2, so pinning
+        # there only oversubscribes L2 and evicts store lines. Whether the row reloads is a
+        # structural property, not a byte threshold, so ``_has_reduced_away_grid`` is the
+        # discriminator. (A ``num_load == 1`` kernel hits the stream branch first.)
         evict = None
-        if fact.num_load == 1:
+        if pd.num_load == 1:
             evict = cls._eviction_policies(env, "stream")
-        elif fact.row_reread and not persistent:
-            # Re-read row's eviction slot read directly from the fact (its load's
+        elif pd.row_reread and cls._has_reduced_away_grid(spec):
+            # Re-read row's eviction slot read directly from the descriptor (its load's
             # MemoryOpFact.eviction_index), not a per-config codegen re-walk.
-            evict = cls._eviction_policies(env, "reread", fact.reread_eviction_index)
+            evict = cls._eviction_policies(env, "reread", pd.reread_eviction_index)
         if evict is not None:
             seed["load_eviction_policies"] = evict
         return Config(**seed)
@@ -964,21 +1251,15 @@ class TritonUserTiledReductionHeuristic(_TritonReductionSeedBase):
     """user-tiled inner-reduction seed: fires when the user hand-writes the ``hl.tile`` loop
     over the reduction axis (so the rdim is an ordinary ``block_sizes`` entry, e.g.
     ``hl.tile(n, block_size=R_BLOCK)``), which the upstream gate rejects entirely.
-    R_BLOCK starts at the shared ``_reduction_rblock`` (M_BLOCK-aware footprint cap), then
-    INDEPENDENT band predicates layer on via ``min`` (a kernel gets every cap it matches;
-    today's kernels each match exactly one):
 
-    - **plain user-tiled** (softmax_two_pass): no extra cap -- persistent full-pow2 R_BLOCK,
-      standard-style reread-eviction for wide looped rows.
-    - **carried 2-D tiles** (kl_div, jsd): carry ``[M_BLOCK, R_BLOCK]`` accumulator tiles
-      across the loop, so R_BLOCK is capped by ``CARRIED_TILE_MAX_BYTES / (itemsize *
-      num_carried_2d_tiles)`` -- folded into the shared ``_reduction_rblock`` decision.
-    - **reduce-then-apply** (welford, ``non_reduction_loop_block_ids`` non-empty): no combine
-      floor. Its normalize/apply tile starts at the reduction tile and gets the SAME
-      M_BLOCK-aware footprint cap; see ``_build_block_sizes``.
-
-    TODO(reductions): as more structured families land, promote each band into its own
-    fact-keyed ``AutotunerHeuristic`` subclass rather than growing this method.
+    Every axis (the reduction r_block(s), the grid rows, the apply loops) is sized by the shared
+    :meth:`size_reduction_tiles` ONE budget allocator — there are NO per-band branches. The kernel
+    families this track covers (plain user-tiled softmax, carried-2-D kl_div/jsd, reduce-then-apply
+    welford, grad-parameter bias_grad/dyt) differ only in their Stage-1 facts (carried accumulators,
+    non-reduction loops, materialized features), which the budget consumes uniformly; the
+    floor-vs-resident and chunk-vs-persistent decisions are budget OUTCOMES. This track maps the
+    allocation onto its knobs (every reduction axis is a ``block_sizes`` entry; no
+    ``reduction_loops``) + num_warps + reread eviction below.
     """
 
     name = "triton_reduction_user_tile"
@@ -987,8 +1268,8 @@ class TritonUserTiledReductionHeuristic(_TritonReductionSeedBase):
     def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
         if not _triton_reduction_eligible(env, device_ir):
             return False
-        spec = env.config_spec
-        return not _is_standard_reduction(spec, spec.reduction_facts[0])
+        pd = _primary_descriptor_selected(env)
+        return pd is not None and not _is_standard_reduction(pd)
 
     @classmethod
     def get_seed_config(
@@ -997,63 +1278,18 @@ class TritonUserTiledReductionHeuristic(_TritonReductionSeedBase):
         if not matches_hardware(env, cls.HARDWARE_TARGETS):
             # Off sm90: upstream never fired on user-tiled, so no prior seed to preserve. Decline.
             return None
-        from ...runtime import get_num_sm
-
         spec = env.config_spec
-        fact = spec.reduction_facts[0]
-        non_reduction_loop_ids = set(fact.non_reduction_loop_block_ids)
-        m_block = cls._m_block_product(spec, fact)
-
-        # user-tiled: rdim IS a block_sizes entry (no reduction_loops knob); persistent == R_BLOCK >=
-        # next_pow2(N), other axes floored (u0*u1 <= 2**20). The shared lever sizes R_BLOCK from
-        # residency (single-tile footprint + the folded-in carried-2-D cap for kl_div/jsd) and returns
-        # it directly; _persistent is unused on this track.
-        r_block, _persistent = cls._reduction_rblock(env, fact, m_block)
-        # M-COLLAPSE (grad-parameter reduction, e.g. bias_grad/dyt): collapse the grid/row axis into a
-        # per-feature accumulator, sizing the grid CTA for occupancy instead of T2's floored grid.
-        m_collapse_block: int | None = None
-        # Faithful signature: per_feature_accumulator -- a loop-carried accumulator over ALL
-        # the materialized feature axis (bias_grad/dyt); per-row / 2-D accumulators are excluded.
-        is_m_collapse = fact.per_feature_accumulator
-        if is_m_collapse:
-            # (a) grid CTA -> OCCUPANCY (_m_collapse_grid_block), capped at M_COLLAPSE_MAX_CTA since the
-            #     grid block also bears the reduction slab (sum(0) finalize over ~num_sm partials). An
-            #     unbacked/AOT grid (grid_rows == 0) falls through to block 1 -- a worse seed, not a bug.
-            m_collapse_block = cls._m_collapse_grid_block(
-                env, fact, cap=cls.M_COLLAPSE_MAX_CTA
-            )
-            # (b) inner reduction tile: depends on whether the collapse has PER-ROW WORK,
-            #     which ``body_live_tiles`` measures (peak simultaneously-live full-width tiles).
-            if fact.body_live_tiles <= 1:
-                # PURE collapse (bias_grad: read + sum, ONE resident tile): a big inner tile is
-                # cheap and cuts loop overhead, so reduce the whole CTA wave in one slab (bounded
-                # by the grid block + 256 cap).
-                r_block = m_collapse_block
-            else:
-                # Collapse WITH per-row work (dyt: full-width grad_x store + tanh intermediates):
-                # a big inner tile spills, so byte-cap the resident [inner, feature] footprint
-                # tight (~2-8 rows) for occupancy.
-                feat_bytes = max(1, fact.feature_footprint) * max(1, fact.itemsize)
-                inner_cap = cls._m_collapse_inner_byte_cap(feat_bytes)
-                r_block = max(1, min(m_collapse_block, inner_cap))
-
-        num_warps = cls._num_warps(
-            fact, max(1, get_num_sm(env.device)), _grid_rows(env, fact.m_block_ids)
-        )
-
-        block_sizes = cls._build_block_sizes(
-            spec,
-            fact,
-            fact.block_id,
-            r_block,
-            non_reduction_loop_ids=non_reduction_loop_ids,
-        )
-        if m_collapse_block is not None:
-            # Raise the grid CTA tile(s) from the floor to the occupancy block (the reduction
-            # tile was already set to m_collapse_block via r_block above).
-            for mbid in fact.m_block_ids:
-                idx = spec.block_sizes.block_id_to_index(mbid)
-                block_sizes[idx] = m_collapse_block
+        pd = _primary_descriptor_selected(env)
+        if pd is None:
+            return None
+        # The allocator sizes every axis from the per-co-residency-group budget: the user-tiled
+        # reduction chunk(s) on their block_sizes slots, the grid M (the remainder), and the apply
+        # loops, in one pass. The user-tiled track maps that sizing onto num_warps + eviction below
+        # (no reduction_loops knob; the rdim rides a block_sizes entry).
+        alloc = cls.size_reduction_tiles(env, spec, device_ir, pd)
+        block_sizes = alloc.block_sizes
+        num_warps = cls._num_warps(pd)
+        non_reduction_loop_ids = set(cls._non_reduction_loop_ids(spec))
         seed: dict[str, Any] = {
             "block_sizes": block_sizes,
             "num_warps": num_warps,
@@ -1065,10 +1301,10 @@ class TritonUserTiledReductionHeuristic(_TritonReductionSeedBase):
         # user-tiled (softmax_two_pass loads x twice). Applies even when PERSISTENT: the second
         # pass still re-fetches x from HBM (profiler-confirmed), so 'last' cuts that re-read
         # traffic. kl_div/jsd (row_reread=False) unaffected.
-        if non_reduction_loop_ids or fact.row_reread:
-            # Re-read row's eviction slot read directly from the fact (its load's
+        if non_reduction_loop_ids or pd.row_reread:
+            # Re-read row's eviction slot read directly from the descriptor (its load's
             # MemoryOpFact.eviction_index), not a per-config codegen re-walk.
-            ev = cls._eviction_policies(env, "reread", fact.reread_eviction_index)
+            ev = cls._eviction_policies(env, "reread", pd.reread_eviction_index)
             if ev is not None:
                 seed["load_eviction_policies"] = ev
         return Config(**seed)

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -31,8 +31,14 @@ from torch.utils import _pytree as pytree
 from .. import Config
 from .. import exc
 from .. import language as hl
+from ..autotuner.config_spec import FULL_EXTENT_CATEGORIES
+from ..autotuner.config_spec import SIZED_REDUCTION_CATEGORIES
+from ..autotuner.config_spec import CoResidencyGroup
 from ..autotuner.config_spec import CuteVectorWidthSpec
-from ..autotuner.config_spec import ReductionFact
+from ..autotuner.config_spec import MatmulWithReductionEpilogueFact
+from ..autotuner.config_spec import ReductionCategory
+from ..autotuner.config_spec import ReductionDescriptor
+from ..autotuner.config_spec import ReductionKernelFact
 from ..autotuner.config_spec import ReductionLoopSpec
 from ..language import _tracing_ops
 from ..language._decorators import args_to_proxies
@@ -83,7 +89,6 @@ if TYPE_CHECKING:
     from ..autotuner.config_spec import AccumulatorFact
     from ..autotuner.config_spec import ConfigSpec
     from ..autotuner.config_spec import MemoryOpFact
-    from .compile_environment import BlockSizeInfo
     from .cute.layout import CuTeGridExecutionPlan
 
     class _TLS(Protocol):
@@ -789,10 +794,6 @@ class DeviceIR:
         self.grid_block_ids: list[list[int]] = []
         # Owning HostFunction (captured in ``lower_to_device_ir``).
         self.host_function: HostFunction | None = None
-        # Phase-1 stash: each rollable (standard) rdim + the graph ids using it. The
-        # ReductionFact is built later in ``build_reduction_facts`` (after
-        # ``_collect_memory_op_facts``) so it can read the enriched ``memory_op_facts``.
-        self._rollable_reduction_records: list[tuple[BlockSizeInfo, set[int]]] = []
 
     def __str__(self) -> str:
         return "\n\n".join(map(str, self.graphs))
@@ -996,8 +997,6 @@ class DeviceIR:
                         size_hint=rdim.size_hint(),
                     )
                 )
-                # Stash (rdim, used_graphs) for build_reduction_facts (see the field def).
-                self._rollable_reduction_records.append((rdim, used_graphs))
                 if env.backend_name == "cute":
                     env.config_spec.cute_vector_widths.append(
                         CuteVectorWidthSpec(
@@ -1074,201 +1073,422 @@ class DeviceIR:
                 )
             )
 
-    def register_user_tiled_reductions(
+    def _original_graph_reductions(self) -> list[tuple[int, int]]:
+        """Every reduction OCCURRENCE on the ORIGINAL (pre-roll) device graphs as
+        ``(graph_id, block_id)`` pairs, de-duplicated within a graph (one descriptor per
+        distinct rdim per original graph).
+
+        Rolled ``ReductionLoopGraphInfo`` subgraphs are EXCLUDED: they are copies the roller
+        creates for one config, so their ``graph_id`` is contingent on the autotuner flipping a
+        ``reduction_loops`` knob. The original graphs carry the faithful co-residency structure
+        (PROMPT §2.2 / §2.7): two distinct rdims sharing an original graph were fused by the
+        compiler -> co-resident; the same rdim in two original graphs is two sequential passes
+        (jsd's two V-reductions). Verified against the IR (``_lab/redesign/ir_*.json``): rolled
+        subgraphs are exactly ``ReductionLoopGraphInfo``.
+        """
+        from .inductor_lowering import ReductionLowering
+
+        seen: set[tuple[int, int]] = set()
+        out: list[tuple[int, int]] = []
+        for gi in self.graphs:
+            if isinstance(gi, ReductionLoopGraphInfo):
+                continue
+            for node in gi.graph.nodes:
+                lowering = node.meta.get("lowering")
+                if not isinstance(lowering, ReductionLowering):
+                    continue
+                bid = getattr(lowering, "block_index", None)
+                if bid is None:
+                    continue
+                key = (gi.graph_id, bid)
+                if key not in seen:
+                    seen.add(key)
+                    out.append(key)
+        return out
+
+    def _categorize_reduction(
+        self, block_id: int, grid_ids: set[int]
+    ) -> ReductionCategory:
+        """Classify one reduction occurrence into the §2.1 taxonomy from FAITHFUL structure:
+        ``(block_size_source kind, on the grid?, cdiv==1?)``. The single categorization rule
+        the kernel-fact builder keys every reduction descriptor on.
+
+        - no static extent -> DECLINED (jagged).
+        - on the grid + fully resident (cdiv==1) -> FULL_GRID; on the grid + partial -> GRID_TILE.
+        - a tunable ``block_sizes`` entry, not on the grid -> USER_TILE.
+        - otherwise (rolled ``reduction_loops`` OR materialized full-width) -> FULL_SLICE.
+        """
+        env = CompileEnvironment.current()
+        info = env.block_sizes[block_id]
+        if not isinstance(info.size, (int, torch.SymInt)):
+            return ReductionCategory.DECLINED
+        if block_id in grid_ids:
+            if self._is_fully_resident_grid_axis(block_id):
+                return ReductionCategory.FULL_GRID
+            return ReductionCategory.GRID_TILE
+        if block_id in env.config_spec.block_sizes.valid_block_ids():
+            return ReductionCategory.USER_TILE
+        # FULL_SLICE is reached by elimination, so guard the structural invariant it relies on:
+        # a genuine full-slice reduction is one the compiler allocated a reduction dimension for,
+        # either ROLLED into reduction_loops (``ReductionLoopBlockSizeSource``) or MATERIALIZED
+        # full-width after the roller declined; a fully-resident specialized axis reduced over in
+        # one program is a ``FixedBlockSizeSource`` (rms_norm_per_block_quant's group_size=128 in a
+        # sequential graph -- on the grid only via a shared hl.tile, so absent from grid_ids here).
+        # ANY OTHER source landing here (e.g. a plain ``LoopSpecBlockSizeSource`` that should have
+        # been USER_TILE) means the kernel fell through for the WRONG reason and may be mis-sized.
+        # Debug-level (this fires on real corpus cells -- rms_norm_per_block_quant -- so it is not
+        # an anomaly, just an inspection hook), never crash.
+        from .compile_environment import FixedBlockSizeSource as _Fixed
+        from .compile_environment import ReductionLoopBlockSizeSource as _RedLoop
+
+        if not isinstance(info.block_size_source, (_RedLoop, _Fixed)):
+            log.debug(
+                "reduction block_id %s classified FULL_SLICE by fallthrough but carries "
+                "%s, not ReductionLoopBlockSizeSource or FixedBlockSizeSource -- the full-slice "
+                "sizing assumption (a compiler-allocated reduction dimension) may not hold",
+                block_id,
+                type(info.block_size_source).__name__,
+            )
+        return ReductionCategory.FULL_SLICE
+
+    def _group_live_tiles(
+        self, group_gids: list[int], env: CompileEnvironment
+    ) -> dict[int, list[tuple[int | None, ...]]]:
+        """Attribute the resident tile set to each co-residency group. Returns ``{group_gid:
+        [dim_block_ids, ...]}`` — the peak live set (``_graph_peak_live_tiles``) of the group's home
+        graph, combined with the for-loop bodies the group drives. Four attribution rules:
+
+        1. **Descend driven for-loop bodies to the ancestor group.** The heavy tiles often live in a
+           for-loop body the group's home graph drives (via a ``loop->child`` edge), not in the thin
+           home graph itself. A loop body is owned by the group whose reduction loops over its axis
+           (the loop's ``block_ids`` intersect the group's reduction axes).
+
+        2. **Skip ``ReductionLoopGraphInfo`` copies.** The roller's per-config duplicates carry a
+           strict subset of the original graph's pre-roll body, so the original graph the group is
+           keyed on already holds the peak.
+
+        3. **Do not cross ``_if`` edges.** If/Else branch subtrees are their own groups or mutually
+           exclusive with a sibling; a parent group never absorbs a branch's tiles. Branches combine
+           via rule 4's max, not by summing into an ancestor.
+
+        4. **Combine a group's owned graphs by max-by-profile, never sum.** Co-resident reductions
+           share one original graph by construction, so their simultaneous residency is already
+           inside that graph's peak snapshot. A group's other owned graphs are only ever nested
+           (home + driven body) or If/Else siblings (max picks the populated branch), never
+           simultaneously-additively resident, so max is both faithful and conservative.
+        """
+        from .inductor_lowering import ReductionLowering
+
+        def reds_in(gid: int) -> set[int]:
+            out: set[int] = set()
+            for node in self.graphs[gid].graph.nodes:
+                low = node.meta.get("lowering")
+                if isinstance(low, ReductionLowering) and isinstance(
+                    getattr(low, "block_index", None), int
+                ):
+                    out.add(low.block_index)
+            return out
+
+        # A group is keyed on its home (original) graph_id; its reduction axes come from that graph.
+        group_axes = {gid: reds_in(gid) for gid in group_gids}
+
+        # Peak live-tile snapshot per graph (skip rolled copies — rule 2).
+        peak_of: dict[int, list[tuple[int | None, ...]]] = {}
+        for gi in self.graphs:
+            if isinstance(gi, ReductionLoopGraphInfo):
+                continue
+            peak_of[gi.graph_id] = _graph_peak_live_tiles(gi.graph, env)
+
+        # For-loop child edges (loop->body), keyed by the loop's block_ids (rule 1). ``_if`` edges are
+        # deliberately NOT followed (rule 3) — see the helper.
+        child_loops = self._forloop_child_edges()
+
+        def max_by_profile(
+            a: list[tuple[int | None, ...]], b: list[tuple[int | None, ...]]
+        ) -> list[tuple[int | None, ...]]:
+            mr = max(
+                (_tile_rank(t) for t in a + b),
+                default=0,
+            )
+            ka = _tile_set_rank_profile(a, mr)
+            kb = _tile_set_rank_profile(b, mr)
+            return a if ka >= kb else b
+
+        group_key_set = set(group_gids)
+        result: dict[int, list[tuple[int | None, ...]]] = {}
+        for gid in group_gids:
+            axes = group_axes[gid]
+            tiles = list(peak_of.get(gid, []))
+            # Descend, transitively, the for-loop bodies this group drives (rule 1): a body whose
+            # loop axis is one of the group's reduction axes. Combine each by max-by-profile. Stop
+            # at any body that is itself another group's home (its own sequential group) and never
+            # cross ``_if`` (branch subtrees are handled by their own group keys — rule 3). A BFS so
+            # a home -> loop -> loop chain is fully covered, not just one level. ``not axes`` cannot
+            # happen for a real group key (its home graph holds >=1 reduction lowering).
+            seen_bodies: set[int] = {gid}
+            frontier = [gid]
+            while frontier:
+                cur = frontier.pop()
+                for body_gid, blk in child_loops.get(cur, []):
+                    if body_gid in seen_bodies or body_gid in group_key_set:
+                        continue
+                    if not axes or (blk & axes):
+                        seen_bodies.add(body_gid)
+                        tiles = max_by_profile(tiles, peak_of.get(body_gid, []))
+                        frontier.append(body_gid)
+            result[gid] = tiles
+        return result
+
+    def _forloop_child_edges(self) -> dict[int, list[tuple[int, frozenset[int]]]]:
+        """The for-loop child-edge map for ``_group_live_tiles`` rule 1: for each non-rolled graph,
+        the ``(body_graph_id, frozenset(body_block_ids))`` of every for-loop it drives. Keyed by the
+        parent graph_id; ``child_loops[gid] = [(body_gid, block_ids), ...]``.
+
+        A pure node scan over ``self.graphs`` (the SAME scan the CF walker uses): follows only
+        ``is_for_loop_target`` call_functions whose first arg is the body graph id. ``_if`` edges are
+        deliberately NOT collected (rule 3 — branch subtrees are their own groups). Rolled
+        (``ReductionLoopGraphInfo``) parents and bodies are skipped (rule 2)."""
+        n = len(self.graphs)
+        child_loops: dict[int, list[tuple[int, frozenset[int]]]] = {}
+        for gi in self.graphs:
+            if isinstance(gi, ReductionLoopGraphInfo):
+                continue
+            edges: list[tuple[int, frozenset[int]]] = []
+            for node in gi.graph.nodes:
+                if node.op != "call_function":
+                    continue
+                if (
+                    _tracing_ops.is_for_loop_target(node.target)
+                    and node.args
+                    and isinstance(node.args[0], int)
+                ):
+                    body_gid = node.args[0]
+                    if 0 <= body_gid < n and not isinstance(
+                        self.graphs[body_gid], ReductionLoopGraphInfo
+                    ):
+                        blk = frozenset(
+                            getattr(self.graphs[body_gid], "block_ids", []) or []
+                        )
+                        edges.append((body_gid, blk))
+            if edges:
+                child_loops[gi.graph_id] = edges
+        return child_loops
+
+    def build_reduction_kernel_fact(
         self,
         memory_op_facts: list[MemoryOpFact],
         accumulator_facts: list[AccumulatorFact],
         liveness_by_axis: dict[int, int] | None = None,
     ) -> None:
-        """Register a ReductionFact for an inner reduction the roller did NOT roll.
-        Owns the two non-rolled cases, keyed on whether the reduction axis is a
-        ``block_sizes`` entry:
-
-        - **USER-TILED (-> T2):** a hand-written nested ``hl.tile`` over the
-          reduction axis -- no ``reduction=True`` block, so the axis is an ordinary
-          ``block_sizes`` entry. Routes to the user-tiled track.
-        - **MATERIALIZED FEATURE (-> standard/T1):** a ``reduction=True`` axis the
-          roller declined to roll (``should_go_in_inner_graph`` raises "mixed
-          reduction dim usage"), left full-width in NEITHER ``block_sizes`` NOR
-          ``reduction_loops``. A standard reduction that could not be rolled, so it
-          routes to the standard track (``_is_standard_reduction`` keys on "not a
-          block_sizes entry").
-
-        Caller-guarded (``if not reduction_loops``) so standard-rollable and this
-        path are mutually exclusive. Finds the axis from every
-        ``ReductionLowering.block_index`` minus the grid axes. Built in Phase 3, so
-        per-op-dataflow fields derive from ``memory_op_facts``/``accumulator_facts``.
+        """Build the categorizing ``ReductionKernelFact`` — the list of reduction descriptors +
+        their ``graph_id`` co-residency groups + the non-reduction loops + the parallel grid axes.
+        The reduction seed + the Stage-2 allocator consume this fact directly.
         """
-        from .inductor_lowering import ReductionLowering
-
         env = CompileEnvironment.current()
         spec = env.config_spec
+        liveness_by_axis = liveness_by_axis or {}
         grid_ids = {b for bids in self.grid_block_ids for b in bids}
 
-        red_block_ids: set[int] = set()
-        for graph_info in self.graphs:
-            for node in graph_info.graph.nodes:
-                lowering = node.meta.get("lowering")
-                if isinstance(lowering, ReductionLowering):
-                    bid = getattr(lowering, "block_index", None)
-                    if bid is not None:
-                        red_block_ids.add(bid)
-        # Drop the grid axis (a dead reduction over the grid/M tile, etc.).
-        inner_red = [b for b in red_block_ids if b not in grid_ids]
-        bs_ids = spec.block_sizes.valid_block_ids()
-        rl_ids = spec.reduction_loops.valid_block_ids()
-        # Materialized axes (rms/ln/instance/group bwd): a ReductionLowering axis the roller left in
-        # neither block_sizes nor reduction_loops -> standard track. bias_grad/dyt have none (their [N]
-        # accumulator is never reduced over), so they fall to the block-tiled pool below.
-        materialized_reduction_axes = [
-            b
-            for b in inner_red
-            if self._is_materialized_axis(b, grid_ids, bs_ids, rl_ids)
-        ]
-        # Candidate pool: prefer the materialized reductions (-> standard track), else the
-        # remaining block-tiled inner reductions (-> user-tiled track). A pure matmul has no
-        # inner reduction so its pool is empty (declines); a matmul WITH a reduction rides
-        # the same path -- no special gate needed.
-        pool = materialized_reduction_axes or inner_red
-        # Drop dynamic-extent axes: a jagged/data-dependent reduction tile has ``size=None``
-        # (no static extent), so ``size_hint()`` would assert. The seed keys on a static
-        # resident footprint, so decline such axes here (mirrors the static-size guard below)
-        # rather than crash -- jagged kernels fall back to the default config as on main.
-        pool = [
-            b for b in pool if isinstance(env.block_sizes[b].size, (int, torch.SymInt))
-        ]
-        if not pool:
-            return
-        # Seed the DOMINANT reduction (largest extent -- drives the resident footprint). The pick is
-        # config-invariant for today's kernels but the axis-specific fact fields are not, so warn and
-        # revisit the tie-break if a seed lever starts consuming them.
-        red_block_id = max(pool, key=lambda b: env.block_sizes[b].size_hint())
-        if len(pool) > 1:
-            log.warning(
-                "inner-reduction seed: %d candidate inner reductions %s; "
-                "recording only the dominant axis %s as the ReductionFact",
-                len(pool),
-                {b: env.block_sizes[b].size_hint() for b in pool},
-                red_block_id,
-            )
-        # Widen genuine apply/normalize loops that span the reduction extent. Do NOT decline on a
-        # non-qualifying loop: a reduction can co-occur with other non-grid loops that must stay floored
-        # (a secondary reduction, or an apply loop at a different extent) -- warn instead of declining.
-        non_reduction_loop_block_ids = self._non_reduction_loop_candidates(
-            red_block_id, grid_ids
-        )
-        qualified = set(non_reduction_loop_block_ids)
-        for bid in bs_ids:
-            # Skip the grid axes, the widened apply loops, and the dominant reduction axis itself;
-            # everything else (including a secondary reduction axis, e.g. group_norm's block 2) is
-            # floored + warned.
-            if bid in grid_ids or bid in qualified or bid == red_block_id:
-                continue
-            log.warning(
-                "inner-reduction seed: block_sizes loop %s (size %s) is floored "
-                "(no widening rule for this loop shape yet)",
-                bid,
-                env.block_sizes[bid].size,
-            )
-        try:
-            block_info = env.block_sizes[red_block_id]
-        except (IndexError, KeyError):
-            return
-        # The reduction axis must have a resolvable extent: a dynamic/jagged dim has
-        # ``size=None``, for which the extent-keyed lever is undefined; decline there.
-        if not isinstance(block_info.size, (int, torch.SymInt)):
-            return
+        occurrences = self._original_graph_reductions()
+        # carried-2D tiles: count of accumulators whose last dim is the rdim (per block_id,
+        # kernel-wide -- an accumulator is carried across the whole inner loop, so it is not
+        # graph-scoped). A count (not a bool) is load-bearing: the carried byte cap divides the
+        # budget by it, so the descriptor must carry the multiplicity.
+        carried_2d_by_bid: dict[int, int] = {}
+        for a in accumulator_facts:
+            if len(a.dim_block_ids) >= 2 and a.dim_block_ids[-1] is not None:
+                carried_2d_by_bid[a.dim_block_ids[-1]] = (
+                    carried_2d_by_bid.get(a.dim_block_ids[-1], 0) + 1
+                )
 
-        # The kept (non-reduction) axes are the grid block_ids — the "rows".
-        m_block_ids = tuple(sorted(grid_ids))
-        size_hint = block_info.size_hint()
-        static_rnumel = block_info.size if isinstance(block_info.size, int) else None
-        # user-tiled digests over ALL device graphs (the manual inner loop body lives in
-        # the main device graph, not a roller subgraph), so num_load scopes to every
-        # graph_id.
-        all_graph_ids = set(range(len(self.graphs)))
-        spec.reduction_facts.append(
-            self._assemble_reduction_fact(
-                red_block_id,
-                size_hint,
-                static_rnumel,
-                m_block_ids,
-                non_reduction_loop_block_ids,
-                all_graph_ids,
-                memory_op_facts,
-                accumulator_facts,
-                liveness_by_axis or {},
+        descriptors: list[ReductionDescriptor] = []
+        for gid, bid in occurrences:
+            category = self._categorize_reduction(bid, grid_ids)
+            info = env.block_sizes[bid]
+            size_hint = (
+                info.size_hint() if isinstance(info.size, (int, torch.SymInt)) else 0
             )
-        )
-
-    def build_reduction_facts(
-        self,
-        memory_op_facts: list[MemoryOpFact],
-        liveness_by_axis: dict[int, int] | None = None,
-    ) -> None:
-        """Phase 3: build the ``ReductionFact``s now that ``_collect_memory_op_facts``
-        produced the enriched ``memory_op_facts`` (and the per-axis liveness slice).
-
-        Reads ``spec.accumulator_facts``, builds each stashed standard fact, then --
-        only when no standard rollable reduction was registered -- the user-tiled fact.
-        """
-        env = CompileEnvironment.current()
-        spec = env.config_spec
-        accumulator_facts = spec.accumulator_facts
-        liveness_by_axis = liveness_by_axis or {}
-        # standard (rollable): one fact per stashed (rdim, used_graphs). num_load scopes
-        # to the rdim's ORIGINAL graphs (used_graphs), so the rolled-subgraph copies of a
-        # standard rdim load are not double-counted (device_ir.graphs is a superset of any
-        # one config's graphs).
-        for rdim, used_graphs in self._rollable_reduction_records:
-            grid_ids = {b for bids in self.grid_block_ids for b in bids}
-            m_block_ids = tuple(sorted(grid_ids))
-            static_rnumel = rdim.size if isinstance(rdim.size, int) else None
-            non_reduction_loop_block_ids = self._non_reduction_loop_candidates(
-                rdim.block_id, grid_ids
+            per = self._per_reduction_memory_fields(
+                bid, gid, memory_op_facts, liveness_by_axis
             )
-            spec.reduction_facts.append(
-                self._assemble_reduction_fact(
-                    rdim.block_id,
-                    rdim.size_hint(),
-                    static_rnumel,
-                    m_block_ids,
-                    non_reduction_loop_block_ids,
-                    used_graphs,
-                    memory_op_facts,
-                    accumulator_facts,
-                    liveness_by_axis,
+            descriptors.append(
+                ReductionDescriptor(
+                    category=category,
+                    block_id=bid,
+                    graph_id=gid,
+                    size_hint=size_hint,
+                    itemsize=self._reduction_input_itemsize(bid),
+                    input_load_itemsize=per["input_load_itemsize"],
+                    carried_2d_count=carried_2d_by_bid.get(bid, 0),
+                    row_reread=per["row_reread"],
+                    reread_eviction_index=per["reread_eviction_index"],
+                    num_load=per["num_load"],
                 )
             )
-        # user-tiled: mutually exclusive with standard — only when no reduction_loops spec
-        # was registered.
-        if not spec.reduction_loops:
-            self.register_user_tiled_reductions(
-                memory_op_facts, accumulator_facts, liveness_by_axis
+
+        # Co-residency groups = original graph_id equivalence classes. The materialized-feature
+        # footprint a group byte-caps against is not stored here — the Stage-2 allocator derives it
+        # at the comparison site (each group can materialize different feature axes, so a kernel-wide
+        # value would be wrong for a multi-group kernel).
+        groups_by_gid: dict[int, list[int]] = {}
+        for idx, d in enumerate(descriptors):
+            groups_by_gid.setdefault(d.graph_id, []).append(idx)
+        # The per-group resident tile set: each group's peak live tiles, attributed home +
+        # driven-loop-bodies, max'd across If/Else. Consumed by the Stage-2 footprint (which sums
+        # ∏(dims) per actual tile).
+        #
+        # The try/except is NECESSARY: ``_group_live_tiles`` walks the graphs through ``env`` (block
+        # id resolution in ``_graph_peak_live_tiles``), which a bare-spec unit test builds the fact
+        # WITHOUT -> the walk raises before producing tiles. The fallback degrades to empty tiles
+        # (the Stage-2 allocator then falls back to its extent-based footprint), so a missing env
+        # yields a valid-but-coarser fact rather than a crash. Trade-off to be aware of: the broad
+        # catch also swallows a genuine graph-structure bug INSIDE the walk as a silent empty-tiles
+        # perf regression (not a crash) — acceptable because the walk is best-effort attribution, but
+        # if this ever needs tightening, catch ``NoCurrentEnvironment`` specifically (the real no-env
+        # trigger) rather than the broad trio.
+        try:
+            group_live = self._group_live_tiles(sorted(groups_by_gid), env)
+        except (KeyError, AttributeError, TypeError):
+            group_live = {}
+        coresidency_groups = tuple(
+            CoResidencyGroup(
+                graph_id=gid,
+                descriptor_indices=tuple(idxs),
+                live_tiles=tuple(group_live.get(gid, [])),
             )
+            for gid, idxs in sorted(groups_by_gid.items())
+        )
+
+        # non-reduction loops + parallel grid axes. The non-reduction loops are the union over the
+        # sized reductions' apply/normalize candidates; the grid axes are grid block_ids with no
+        # reduction sized over them.
+        sized_bids = {
+            d.block_id for d in descriptors if d.category in SIZED_REDUCTION_CATEGORIES
+        }
+        non_reduction_loops: set[int] = set()
+        for bid in sized_bids:
+            non_reduction_loops.update(
+                self._non_reduction_loop_candidates(bid, grid_ids)
+            )
+        non_reduction_loops -= sized_bids
+        grid_axis_block_ids = tuple(sorted(grid_ids - sized_bids))
+
+        spec.reduction_kernel_fact = ReductionKernelFact(
+            reductions=tuple(descriptors),
+            coresidency_groups=coresidency_groups,
+            non_reduction_loop_block_ids=tuple(sorted(non_reduction_loops)),
+            grid_axis_block_ids=grid_axis_block_ids,
+        )
+
+    def _per_reduction_memory_fields(
+        self,
+        red_block_id: int,
+        graph_id: int,
+        memory_op_facts: list[MemoryOpFact],
+        liveness_by_axis: dict[int, int],
+    ) -> dict:
+        """The memory-op-derived per-reduction fields, computed exactly as
+        ``_assemble_reduction_fact`` does (so a descriptor is field-equal to the legacy fact),
+        but SCOPED to this reduction's original graph for ``num_load`` (a co-resident pass loads
+        in its own graph). ``row_reread`` / ``input_load_itemsize`` are axis-keyed and
+        graph-agnostic (a re-read is global to the axis), matching the legacy computation.
+        """
+        num_load = sum(
+            1 for f in memory_op_facts if f.kind == "load" and f.graph_id == graph_id
+        )
+        row_reread = False
+        reread_eviction_index: int | None = None
+        for f in memory_op_facts:
+            if f.kind != "load":
+                continue
+            cnt = next((c for ax, c in f.reductions_fed if ax == red_block_id), 0)
+            if cnt >= 2 or (cnt >= 1 and f.stores_fed):
+                row_reread = True
+                reread_eviction_index = f.eviction_index
+                break
+        fed_sizes = [
+            f.dtype.itemsize
+            for f in memory_op_facts
+            if f.kind == "load"
+            and f.dtype is not None
+            and any(ax == red_block_id for ax, _ in f.reductions_fed)
+        ]
+        if fed_sizes:
+            input_load_itemsize = min(fed_sizes)
+        else:
+            row_sizes = [
+                f.dtype.itemsize
+                for f in memory_op_facts
+                if f.kind == "load"
+                and f.dtype is not None
+                and (
+                    (
+                        f.subscript_block_ids
+                        and f.subscript_block_ids[-1] == red_block_id
+                    )
+                    or (f.indexed_block_ids and f.indexed_block_ids[-1] == red_block_id)
+                )
+            ]
+            input_load_itemsize = min(row_sizes) if row_sizes else 0
+        return {
+            "num_load": num_load,
+            "row_reread": row_reread,
+            "reread_eviction_index": reread_eviction_index,
+            "input_load_itemsize": input_load_itemsize,
+        }
 
     def build_matmul_reduction_epilogue_facts(self) -> None:
         """Phase 4: compose a ``MatmulWithReductionEpilogueFact`` for a fused matmul +
-        reduction-over-output-axis epilogue. Fires iff exactly one ``MatmulFact`` AND
-        one ``ReductionFact`` (the epilogue reduction from
-        ``register_user_tiled_reductions``'s materialized branch); holds the two facts
-        plus the N-extent the seed keys on. Pure-matmul kernels have no epilogue
-        ReductionFact and pure-reduction kernels no MatmulFact, so the composed fact
-        fires ONLY on the fused family.
+        reduction-over-output-axis epilogue. Fires iff exactly one ``MatmulFact`` AND exactly
+        one SIZED full-extent reduction descriptor in a singleton co-residency group (the
+        epilogue reduction over the specialized output N); holds the matmul fact plus the
+        N-extent the seed keys on. Pure-matmul kernels have no epilogue reduction and
+        pure-reduction kernels no MatmulFact, so the composed fact fires ONLY on the fused
+        family.
+
+        CONSTRAINT (PROMPT §2.9 — must NOT inherit the relaxed reduction gate): the epilogue
+        seed is tuned for ONE specific reduction shape (a single full-extent reduction over the
+        specialized output N, no other reduction co-resident). Expressed in the Stage-1
+        vocabulary: exactly ONE sized reduction, FULL_SLICE/FULL_GRID, in a singleton
+        co-residency group. A MULTI-reduction matmul kernel must NOT compose this fact (its
+        bare ``reduction.size_hint`` would no longer be unambiguously the epilogue's N).
         """
         env = CompileEnvironment.current()
         spec = env.config_spec
-        from ..autotuner.config_spec import MatmulWithReductionEpilogueFact
 
-        if len(spec.matmul_facts) != 1 or len(spec.reduction_facts) != 1:
+        if len(spec.matmul_facts) != 1:
+            return
+        # §2.9 guard (Stage-1 vocabulary): the kernel's SIZED reductions must be exactly ONE
+        # full-extent reduction in a singleton co-residency group — a single epilogue reduction
+        # over the specialized output N, no other reduction co-resident. A MULTI-reduction matmul
+        # kernel must NOT compose this fact (its epilogue N would be ambiguous). This is the sole
+        # reduction gate (the legacy ``len(reduction_facts)==1`` check it replaced was strictly
+        # looser — this also rejects a co-resident second sized reduction).
+        kf = spec.reduction_kernel_fact
+        if kf is None:
+            return
+        sized = [d for d in kf.reductions if d.category in SIZED_REDUCTION_CATEGORIES]
+        if len(sized) != 1 or sized[0].category not in FULL_EXTENT_CATEGORIES:
+            return
+        group = next(
+            (
+                g
+                for g in kf.coresidency_groups
+                if any(
+                    kf.reductions[i].block_id == sized[0].block_id
+                    for i in g.descriptor_indices
+                )
+            ),
+            None,
+        )
+        if group is not None and len(group.descriptor_indices) != 1:
             return
         matmul = spec.matmul_facts[0]
-        reduction = spec.reduction_facts[0]
+        # N-extent = the epilogue reduction's extent (the specialized, hl.specialize'd output N).
         spec.matmul_reduction_epilogue_facts.append(
             MatmulWithReductionEpilogueFact(
                 matmul=matmul,
-                reduction=reduction,
-                n_extent=reduction.size_hint,
+                n_extent=sized[0].size_hint,
                 m_block_id=matmul.m_block_id,
                 k_block_id=matmul.k_block_id,
             )
@@ -1282,9 +1502,18 @@ class DeviceIR:
         compute dtype and the SFU op count. Runs last, after the other facts exist."""
         env = CompileEnvironment.current()
         spec = env.config_spec
+        from ..autotuner.config_spec import SIZED_REDUCTION_CATEGORIES
         from ..autotuner.config_spec import PointwiseElementwiseFact
 
-        if spec.reduction_facts or spec.matmul_facts or spec.accumulator_facts:
+        # Disjointness: a kernel with any SIZED reduction (the Stage-1 kernel fact's
+        # FULL_SLICE/FULL_GRID/USER_TILE descriptors — the faithful successor to a non-empty
+        # ``reduction_facts`` list), any matmul, or any loop-carried accumulator belongs to that
+        # family and gets NO pointwise fact.
+        kf = spec.reduction_kernel_fact
+        has_sized_reduction = kf is not None and any(
+            d.category in SIZED_REDUCTION_CATEGORIES for d in kf.reductions
+        )
+        if has_sized_reduction or spec.matmul_facts or spec.accumulator_facts:
             return
         if not spec.memory_op_facts or not spec.block_sizes:
             return
@@ -1476,172 +1705,40 @@ class DeviceIR:
                             break
         return itemsize
 
-    def _assemble_reduction_fact(
-        self,
-        red_block_id: int,
-        size_hint: int,
-        static_rnumel: int | None,
-        m_block_ids: tuple[int, ...],
-        non_reduction_loop_block_ids: tuple[int, ...],
-        load_graph_ids: set[int],
-        memory_op_facts: list[MemoryOpFact],
-        accumulator_facts: list[AccumulatorFact],
-        liveness_by_axis: dict[int, int] | None = None,
-    ) -> ReductionFact:
-        """Build one ``ReductionFact`` for axis ``red_block_id`` from the enriched
-        ``memory_op_facts`` + ``accumulator_facts`` + per-axis liveness slice. Shared
-        by the standard and user-tiled paths; only ``load_graph_ids`` differs
-        (standard: the rdim's original graphs; user-tiled: every graph).
+    def _is_fully_resident_grid_axis(self, block_id: int) -> bool:
+        """True iff a grid axis is tiled at its FULL extent (``block_size == extent`` =>
+        ``cdiv(extent, block) == 1`` => the whole axis is resident in each program). Such an axis
+        is on ``grid_block_ids`` only because it shares a combined ``hl.tile`` (per_token_group's
+        ``hl.specialize``'d ``group_size``); a reduction over it reduces the WHOLE extent in one
+        program, so its ``size_hint`` is a faithful per-program reduction extent and it is worth
+        seeding as a TILED reduction.
+
+        This is a PERF/SIZING eligibility gate, NOT a correctness guard: the seed only proposes a
+        starting config that the autotuner accuracy-gates, so it can neither make a correct kernel
+        wrong nor fix a wrong one. Its job is (a) to ADMIT a fully-resident grid reduction so it
+        FIRES and gets a sized seed (per_token_group; dropping this check un-fires it -> starved
+        default), and (b) to DECLINE a PARTIAL grid axis (``cdiv > 1``) whose whole-axis
+        ``size_hint`` is NOT what one program reduces -- feeding that lie to the footprint sizer
+        would mis-size. (A kernel that reduces over a partial grid axis WITHOUT a cross-CTA combine
+        is already miscompiled at every config including the default -- that is an upstream lowering
+        bug, unrelated to and unaffected by this seed-time classification.)
+
+        Reads the FIXED block size from ``env.block_sizes`` (keyed by all block_ids incl. grid);
+        a non-static extent or non-fixed source (a tunable grid tile) is never fully resident.
         """
-        # num_load: every load in the reduction's graphs (the stream-eviction == 1 gate).
-        # Scoped by graph_id so rolled-subgraph copies of a standard rdim load are excluded.
-        num_load = sum(
-            1
-            for f in memory_op_facts
-            if f.kind == "load" and f.graph_id in load_graph_ids
-        )
-        # num_carried_2d_tiles: carried [.., R_BLOCK] tiles whose last dim is the rdim
-        # (standard's [M_BLOCK] scalar carry -> 0).
-        num_carried_2d_tiles = sum(
-            1
-            for a in accumulator_facts
-            if len(a.dim_block_ids) >= 2 and a.dim_block_ids[-1] == red_block_id
-        )
-        # row_reread + reread_eviction_index: the FIRST load live across the reduction
-        # boundary (feeds >= 2 reductions on this axis, or one + a bypass store); the slot
-        # is read straight from MemoryOpFact (no per-config re-walk).
-        row_reread = False
-        reread_eviction_index: int | None = None
-        for f in memory_op_facts:
-            if f.kind != "load":
-                continue
-            cnt = next((c for ax, c in f.reductions_fed if ax == red_block_id), 0)
-            if cnt >= 2 or (cnt >= 1 and f.stores_fed):
-                row_reread = True
-                reread_eviction_index = f.eviction_index
-                break
-        # full_width_output: a rank>=2 store whose inner dim is the reduction-extent AXIS
-        # ({rdim} ∪ normalize loops), keyed on the store's inner SUBSCRIPT block-id
-        # (reduction-agnostic) or, for the standard ``out[tile_m, :]`` plain slice, the
-        # shape-resolved indexed_block_ids fallback. Match on axis, not size, so a
-        # non-reduction dim that merely equals the extent is not full-width.
-        extent_axes = {red_block_id, *non_reduction_loop_block_ids}
-        full_width_output = any(
-            f.kind == "store"
-            and f.ndim >= 2
-            and (
-                (f.subscript_block_ids and f.subscript_block_ids[-1] in extent_axes)
-                or (f.indexed_block_ids and f.indexed_block_ids[-1] in extent_axes)
-            )
-            for f in memory_op_facts
-        )
-        # input_load_itemsize: min element size over reduction-fed loads (the streamed
-        # row), with a Band-B fallback to rank>=2 row loads of the reduction extent.
-        fed_sizes = [
-            f.dtype.itemsize
-            for f in memory_op_facts
-            if f.kind == "load"
-            and f.dtype is not None
-            and any(ax == red_block_id for ax, _ in f.reductions_fed)
-        ]
-        if fed_sizes:
-            input_load_itemsize = min(fed_sizes)
-        else:
-            # Band-B fallback: rank>=2 row loads whose inner subscript IS the reduction
-            # AXIS (block-id). Needed because accumulator-carried reductions feed a loop
-            # `+=`, not a ReductionLowering, so the row load is invisible to reductions_fed
-            # (fed_sizes empty); this structural axis-match recovers it.
-            row_sizes = [
-                f.dtype.itemsize
-                for f in memory_op_facts
-                if f.kind == "load"
-                and f.dtype is not None
-                and (
-                    (
-                        f.subscript_block_ids
-                        and f.subscript_block_ids[-1] == red_block_id
-                    )
-                    or (f.indexed_block_ids and f.indexed_block_ids[-1] == red_block_id)
-                )
-            ]
-            input_load_itemsize = min(row_sizes) if row_sizes else 0
+        from .compile_environment import FixedBlockSizeSource
 
-        # body_live_tiles: peak simultaneously-live rdim-shaped tiles in the reduction body, read off
-        # the walker liveness slice for this axis (default 1).
-        body_live_tiles = max(1, (liveness_by_axis or {}).get(red_block_id, 1))
-
-        # feature_footprint: resident per-row feature footprint an M-collapse byte-caps its
-        # inner tile against -- the PRODUCT (not a per-axis max, else 3-D norms spill) of the
-        # materialized full-width feature axes. 1 when none. A structural read, no graph walk.
         env = CompileEnvironment.current()
-        bs_ids = env.config_spec.block_sizes.valid_block_ids()
-        rl_ids = env.config_spec.reduction_loops.valid_block_ids()
-        grid_ids = {b for bids in self.grid_block_ids for b in bids}
-        # Feature-footprint axes: full-width feature/output dims left materialized. NOTE
-        # bs.reduction is the dim's reduction ROLE at registration, not 'a reduction is lowered
-        # over it' (e.g. bias_grad's [N] output), so this set differs from the reduced-over set.
-        materialized_feature_axes = {
-            bs.block_id
-            for bs in env.block_sizes
-            if bs.reduction
-            and isinstance(bs.size, (int, torch.SymInt))
-            and self._is_materialized_axis(bs.block_id, grid_ids, bs_ids, rl_ids)
-        }
-        feature_footprint = 1
-        for b in materialized_feature_axes:
-            feature_footprint *= max(1, env.block_sizes[b].size_hint())
-        # per_feature_accumulator: the FAITHFUL M-collapse signature -- a loop-carried accumulator
-        # whose dims are ALL the materialized feature axis (e.g. grad_bias[N]). Per-row / 2-D
-        # accumulators (softmax/kl_div/jsd/welford/grpo) fail this test, excluded structurally.
-        per_feature_accumulator = any(
-            a.dim_block_ids
-            and all(d in materialized_feature_axes for d in a.dim_block_ids)
-            for a in accumulator_facts
-        )
-
-        return ReductionFact(
-            block_id=red_block_id,
-            size_hint=size_hint,
-            m_block_ids=m_block_ids,
-            static_rnumel=static_rnumel,
-            itemsize=self._reduction_input_itemsize(red_block_id),
-            num_load=num_load,
-            num_carried_2d_tiles=num_carried_2d_tiles,
-            non_reduction_loop_block_ids=non_reduction_loop_block_ids,
-            row_reread=row_reread,
-            reread_eviction_index=reread_eviction_index,
-            full_width_output=full_width_output,
-            input_load_itemsize=input_load_itemsize,
-            body_live_tiles=body_live_tiles,
-            feature_footprint=feature_footprint,
-            per_feature_accumulator=per_feature_accumulator,
-        )
-
-    def _is_materialized_axis(
-        self,
-        block_id: int,
-        grid_ids: set[int],
-        bs_ids: list[int],
-        rl_ids: list[int],
-    ) -> bool:
-        """A *materialized* axis: full-width because the roller declined it -- not the
-        grid, not a ``block_sizes`` tile, not a rolled ``reduction_loops`` axis. Two
-        callers pass DIFFERENT candidate sets to this shared predicate:
-
-        - REDUCED-OVER axes (``register_user_tiled_reductions``): the axis a
-          ``ReductionLowering`` is lowered over (``red_block_id``).
-        - FEATURE-FOOTPRINT axes (``_assemble_reduction_fact``): full-width
-          feature/output dims flagged ``bs.reduction`` at REGISTRATION, including a
-          grad-param output never reduced *over* (the resident ``feature_footprint``).
-
-        bias_grad's ``[N]`` is feature-footprint but not reduced-over -- the gap that
-        makes these two sets.
-        """
-        return (
-            block_id not in grid_ids
-            and block_id not in bs_ids
-            and block_id not in rl_ids
-        )
+        info = env.block_sizes[block_id]
+        if not isinstance(info.size, (int, torch.SymInt)):
+            return False
+        source = info.block_size_source
+        if not isinstance(source, FixedBlockSizeSource):
+            return False
+        block = source.value
+        if not isinstance(block, (int, torch.SymInt)):
+            return False
+        return bool(env.known_equal(block, info.size))
 
     def _non_reduction_loop_candidates(
         self, red_block_id: int, grid_ids: set[int]
@@ -2959,13 +3056,35 @@ def _subscript_block_id(env: CompileEnvironment, sub: object) -> int | None:
     return None
 
 
+def _tile_rank(dims: tuple[int | None, ...]) -> int:
+    """The number of BLOCK dims a tile spans (``None`` static/broadcast dims do not count) — the
+    block-size-free proxy for tile bytes used by the lexicographic peak selector."""
+    return sum(1 for d in dims if d is not None)
+
+
+def _tile_set_rank_profile(
+    tiles: list[tuple[int | None, ...]], max_rank: int
+) -> tuple[int, ...]:
+    """A tile set's RANK PROFILE as a lexicographic key over ABSOLUTE ranks, HIGHEST rank first:
+    index 0 is the count of rank-``max_rank`` tiles, ..., last is the count of rank-1 tiles. More
+    top-rank tiles wins; equal-top-rank falls through to the next rank down. Fixed length so the
+    same rank aligns when comparing two tile sets (a per-set-length key would compare one set's
+    rank-2 count against another's rank-1 count and mis-rank a scalar swarm as the winner)."""
+    by_rank: dict[int, int] = {}
+    for t in tiles:
+        r = _tile_rank(t)
+        if r:
+            by_rank[r] = by_rank.get(r, 0) + 1
+    return tuple(by_rank.get(k, 0) for k in range(max_rank, 0, -1))
+
+
 def _graph_peak_live_by_axis(
     graph: torch.fx.Graph, env: CompileEnvironment
 ) -> dict[int, int]:
     """Peak count of simultaneously-live tensor values whose shape spans each
     block-id axis, over ONE graph -- a liveness sweep in FX topo order.
-    Consumer-AGNOSTIC per-axis provenance keyed by block_id; the derived
-    ``ReductionFact`` reads its own axis slice (``body_live_tiles``).
+    Consumer-AGNOSTIC per-axis provenance keyed by block_id; a consumer reads its
+    own axis slice.
 
     A value is live from definition through its last use in the graph. At each
     step the sweep counts live values whose ``meta['val'].shape`` includes an axis
@@ -3003,6 +3122,67 @@ def _graph_peak_live_by_axis(
     return peak
 
 
+def _graph_peak_live_tiles(
+    graph: torch.fx.Graph, env: CompileEnvironment
+) -> list[tuple[int | None, ...]]:
+    """The per-tile shapes of the simultaneously-live tensors at the graph's peak-live step.
+
+    Each live tile is recorded as its ``dim_block_ids`` tuple (one entry per shape dim: the block
+    id it spans, or ``None`` for a non-block/constant dim), the same representation as
+    ``AccumulatorFact.dim_block_ids``, so a footprint can sum ``∏(dims)`` per actual tile shape
+    rather than assuming every live tile is full-rank over all axes.
+
+    Which step is "peak"? Register/SRAM pressure is maximized at the step holding the most bytes,
+    but tile bytes depend on the not-yet-chosen block sizes. Rank is the block-size-free proxy for
+    "big": a rank-2 ``[m, r]`` tile is ``m_block × r_block`` elements vs ``m_block`` for a rank-1
+    ``[m]``, so one higher-rank tile outweighs any number of lower-rank tiles. We pick the step
+    whose live set is lexicographically greatest by rank profile — the tuple ``(#rank-D tiles,
+    #rank-(D-1) tiles, ..., #rank-1 tiles)`` compared most-dims-first — so a step with one ``[m, r]``
+    beats a step with many scalar ``[m]`` carries. Maximizing the top-rank count first captures the
+    most heavy R-scaling tiles (the term that prevents spills); lower-rank ties break to more
+    next-heaviest, then to the first such step.
+
+    Returns the actual co-resident live set at that one real step (never a per-shape union across
+    steps, which would stitch together shapes that never coexist). The "1 higher-rank beats any
+    number of lower-rank" tie-rule is not byte-exact in a pathological extreme (hundreds of rank-n
+    tiles vs one rank-(n+1)), but a higher-rank tile contains a lower-rank one as a factor and the
+    miss errs toward a slightly larger R (bounded by the persistence/chunk math) — a stated
+    heuristic, not a random choice.
+    """
+    nodes = list(graph.nodes)
+    last_use: dict[torch.fx.Node, int] = {}
+    for i, node in enumerate(nodes):
+        for inp in node.all_input_nodes:
+            last_use[inp] = i
+    shape_of: dict[torch.fx.Node, tuple[int | None, ...]] = {}
+    for node in nodes:
+        val = node.meta.get("val")
+        if isinstance(val, torch.Tensor) and val.shape:
+            dims = tuple(env.resolve_block_id(s) for s in val.shape)
+            # only tiles that span at least one block axis are register-resident reduction tiles
+            if any(d is not None for d in dims):
+                shape_of[node] = dims
+
+    # Graph-wide max rank -> a FIXED-length, absolute-rank-indexed profile so the lexicographic
+    # comparison aligns the same rank across steps (a per-step-length key would compare a step's
+    # rank-2 count against another's rank-1 count and mis-rank the scalar swarm as the winner).
+    max_rank = max((_tile_rank(d) for d in shape_of.values()), default=0)
+
+    best_key: tuple[int, ...] = ()
+    best_tiles: list[tuple[int | None, ...]] = []
+    live: set[torch.fx.Node] = set()
+    for i, node in enumerate(nodes):
+        if node in shape_of:
+            live.add(node)
+        cur = [shape_of[v] for v in live]
+        key = _tile_set_rank_profile(cur, max_rank)
+        if key > best_key:
+            best_key = key
+            best_tiles = cur
+        live = {v for v in live if last_use.get(v, -1) > i}
+    return best_tiles
+
+
 def _collect_memory_op_facts(
     device_ir: DeviceIR,
 ) -> tuple[list[MemoryOpFact], dict[int, int]]:
@@ -3020,7 +3200,7 @@ def _collect_memory_op_facts(
 
     Returns ``(memory_op_facts, liveness_by_axis)`` -- the second is the per-axis
     peak simultaneously-live rdim-shaped tile count (max over graphs), computed in
-    this SAME pass so ``ReductionFact.body_live_tiles`` reads a slice.
+    this SAME pass so the kernel-fact builder can read a per-axis slice.
     """
     from ..autotuner.config_spec import MemoryOpFact
     from ..language import memory_ops
@@ -3417,9 +3597,9 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
         config_spec.epilogue_subtile_k_hint = 0
         config_spec.epilogue_subtile_autotune_choices = None
 
-        # Phase 1: roll + register the reduction_loops spec and stash the rollable
-        # (standard) rdims. ReductionFacts are built in Phase 3 (build_reduction_facts,
-        # after _collect_memory_op_facts) so they read the enriched memory_op_facts.
+        # Phase 1: roll + register the reduction_loops spec. The ReductionKernelFact is built
+        # in Phase 3 (build_reduction_kernel_fact, after _collect_memory_op_facts) so it can
+        # read the enriched memory_op_facts.
         device_ir.register_rollable_reductions()
         if CompileEnvironment.current().backend.name == "cute":
             _register_cute_lane_vector_width_specs(config_spec)
@@ -3485,9 +3665,12 @@ def lower_to_device_ir(func: HostFunction) -> DeviceIR:
         # may read them), so build them independently of the reduction facts. Must run
         # after the rolling (it walks the rolled loop subgraphs).
         config_spec.accumulator_facts = device_ir.build_accumulator_facts()
-        # Phase 3: build the ReductionFacts (standard from the stashed rollable rdims, then user-tiled
-        # if none fired); liveness_by_axis supplies each fact's body_live_tiles slice.
-        device_ir.build_reduction_facts(memory_op_facts, liveness_by_axis)
+        # Phase 3 (PROMPT §2.1/§2.2): build the categorizing ReductionKernelFact — the first-class
+        # reduction-descriptor list + co-residency groups the reduction seed + allocator consume.
+        # liveness_by_axis supplies each descriptor's per-axis liveness slice.
+        device_ir.build_reduction_kernel_fact(
+            memory_op_facts, config_spec.accumulator_facts, liveness_by_axis
+        )
         # Phase 4: compose a matmul + reduction-over-output epilogue fact when a matmul AND a
         # register-resident epilogue reduction co-occur (matmul_rms_norm etc.).
         device_ir.build_matmul_reduction_epilogue_facts()

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import enum
 import functools
 import hashlib
 import itertools
@@ -110,83 +111,119 @@ class MatmulFact(NamedTuple):
     rhs_dtype: torch.dtype
 
 
-class ReductionFact(NamedTuple):
-    """Workload facts for one inner reduction dim, recorded at compile time (like
-    ``MatmulFact``) so the seed heuristic branches on workload properties, not kernel
-    identity. Exactly one per seeded kernel; built in device_ir's
-    ``register_rollable_reductions`` (standard) or ``register_user_tiled_reductions``
-    (user-tiled).
+class ReductionCategory(enum.Enum):
+    """How a reduction axis maps onto the program grid — one category per reduction.
 
-    - ``block_id`` / ``size_hint``: the reduction axis and its extent (rnumel).
-    - ``m_block_ids``: the non-reduction (kept) tile block_ids.
-    - ``static_rnumel``: the extent if statically known, else None.
-    - ``itemsize``: bytes/element of the reduced tensor; byte caps key on
-      ``size_hint * itemsize``.
-    - ``num_load``: device loads over this rdim (the ``== 1`` stream-eviction gate).
-    - ``num_carried_2d_tiles``: 2-D [M_BLOCK, R_BLOCK] tiles carried across the inner
-      loop (the Band-B signal). Derived from ``AccumulatorFact``.
-    - ``non_reduction_loop_block_ids``: non-grid loop tiles over the extent that are NOT
-      the rdim (an apply/normalize pass); ``len(...) >= 1`` is the reduce-then-apply
-      (Band-C) signal.
-    - ``row_reread``: True iff the reduction-input row is live across the loop boundary
-      (risks spilling). Gates the persist byte cap + re-read eviction. From ``MemoryOpFact``.
-    - ``reread_eviction_index``: ``load_eviction_policies`` slot of the re-read load
-      (``None`` unless ``row_reread``), read from that load's ``MemoryOpFact.eviction_index``.
-    - ``full_width_output``: True iff a store writes the result back over the reduction
-      axis ([M, N], e.g. layer_norm), False for a per-row scalar ([M], e.g. sum) —
-      full-width is store/occupancy-bound, scalar-output reduction-tree-bound (opposite
-      num_warps).
-    - ``input_load_itemsize``: element size of the HBM input row load — the dtype-faithful
-      per-byte signal, distinct from ``itemsize`` (fp32-promoted = 4 at both dtypes). 0
-      when no single reduction-fed row load exists.
-    - ``body_live_tiles``: peak count of simultaneously-live rdim-shaped values in the
-      reduction body — the liveness signal bounding the persistent resident footprint. A
-      heavy body spills the register file when held persistent, so the standard track passes
-      it as ``footprint_factor`` to route such reductions to the looped path. A conservative
-      over-count (errs toward looping, never an unsafe spill); defaults to 1.
-    - ``per_feature_accumulator``: the faithful M-collapse discriminator — True iff a
-      loop-carried accumulator exists whose dims are ALL the materialized feature axis (the
-      grad-parameter buffer, e.g. ``grad_bias[N]`` / ``grad_weight[N]``), read from
-      accumulator provenance. The user-tiled seed keys ``is_m_collapse`` on it. False for
-      per-row or 2-D accumulators (softmax_two_pass/kl_div/welford/...).
-    - ``feature_footprint``: the PRODUCT of the materialized feature-axis extents — the
-      resident ``[inner, *features]`` per-row footprint a grad-parameter M-collapse byte-caps
-      its inner reduction tile against (``feature_footprint * itemsize``). For a 2-D norm this
-      is ``N``; for a 3-D norm the full ``C*S`` (a per-axis MAX under-counts and spills). Used
-      by both M-collapse tracks; 1 when no materialized feature axis exists.
-
-    ``grid_rows`` is NOT stored — a pure function of ``m_block_ids`` + env, computed on
-    demand by its one consumer (the narrow-row ``num_warps`` lever).
+    - ``FULL_SLICE`` — the whole axis is reduced within one program (``x[m, :]``); not on the grid.
+    - ``FULL_GRID`` — a full-extent axis on the grid, block == extent (fully resident per program).
+    - ``GRID_TILE`` — a grid axis reduced over but NOT full-extent: the grid parallelizes the
+      reduction across programs, so the whole-axis size is not a per-program extent.
+    - ``USER_TILE`` — an inner sequential ``hl.tile`` the user wrote over the reduction axis.
+    - ``DECLINED`` — no static extent (e.g. jagged / data-dependent); recorded but never sized.
     """
 
+    FULL_SLICE = "full_slice"
+    FULL_GRID = "full_grid"
+    GRID_TILE = "grid_tile"
+    USER_TILE = "user_tile"
+    DECLINED = "declined"
+
+
+# Categories the seed sizes a per-program reduction extent for. GRID_TILE (grid-parallelized
+# partial) stays a grid row and DECLINED (no static extent) falls back to the default, so neither
+# is sized as a reduction.
+SIZED_REDUCTION_CATEGORIES = frozenset(
+    {
+        ReductionCategory.FULL_SLICE,
+        ReductionCategory.FULL_GRID,
+        ReductionCategory.USER_TILE,
+    }
+)
+# Categories that occupy the full reduction extent within one program.
+FULL_EXTENT_CATEGORIES = frozenset(
+    {ReductionCategory.FULL_SLICE, ReductionCategory.FULL_GRID}
+)
+
+
+class ReductionDescriptor(NamedTuple):
+    """One reduction OCCURRENCE: a (``graph_id``, ``block_id``) reduction on the ORIGINAL
+    (pre-roll) device graphs. Stage 1 emits a list of these; the Stage-2 allocator consumes them.
+
+    A reduction axis may occur in more than one original graph (e.g. a kernel that reduces the
+    same axis in two separate passes) — each occurrence is its own descriptor, so sequential
+    passes over one axis are NOT collapsed.
+
+    Descriptors with the same ``graph_id`` are co-resident (the compiler fused them into one graph
+    -> shared resident working set). ``graph_id`` is read off the ORIGINAL graphs only (rolled
+    ``ReductionLoopGraphInfo`` subgraphs excluded), so it is invariant to the autotuner flipping a
+    ``reduction_loops`` knob.
+
+    Fields:
+    - ``category``: the :class:`ReductionCategory`.
+    - ``block_id`` / ``graph_id``: the reduction axis + its original-graph co-residency key.
+    - ``size_hint`` / ``itemsize`` / ``input_load_itemsize``: extent (element count), the
+      fp32-promoted accumulator itemsize, and the HBM-load element width feeding it.
+    - ``carried_2d_count``: the NUMBER of >=2-D ``[M_BLOCK, R_BLOCK]`` loop-carried accumulators
+      whose last dim is this rdim (e.g. kl_div=1, jsd=2); those tiles stay resident the whole loop.
+      A count (not a bool) because the carried byte cap divides the budget by it. 0 = none here.
+    - ``row_reread`` / ``reread_eviction_index`` / ``num_load``: per-reduction memory-op signals.
+    """
+
+    category: ReductionCategory
     block_id: int
+    graph_id: int
     size_hint: int
-    m_block_ids: tuple[int, ...]
-    static_rnumel: int | None
     itemsize: int
-    num_load: int
-    num_carried_2d_tiles: int = 0
-    non_reduction_loop_block_ids: tuple[int, ...] = ()
+    input_load_itemsize: int = 0
+    carried_2d_count: int = 0
     row_reread: bool = False
     reread_eviction_index: int | None = None
-    full_width_output: bool = True
-    input_load_itemsize: int = 0
-    body_live_tiles: int = 1
-    feature_footprint: int = 1
-    per_feature_accumulator: bool = False
+    num_load: int = 0
+
+
+class CoResidencyGroup(NamedTuple):
+    """A ``graph_id`` equivalence class of reductions whose working tiles are live at the same
+    time, so ONE budget must fit them all. ``descriptor_indices`` indexes into
+    ``ReductionKernelFact.reductions``.
+
+    ``live_tiles`` is the group's resident tile set — one ``dim_block_ids`` tuple per
+    register-resident tile (the block id each dim spans, ``None`` for a static/broadcast dim). It
+    is the peak live set of the group's home graph, combined with the for-loop bodies the group
+    drives and its If/Else branch siblings (see device_ir ``_group_live_tiles``). Each loop-carried
+    accumulator is captured inline at its real shape, so the Stage-2 footprint can sum ``∏(dim
+    widths)`` per actual tile. Empty when the fact is built without a live env (a bare-spec test).
+    """
+
+    graph_id: int
+    descriptor_indices: tuple[int, ...]
+    live_tiles: tuple[tuple[int | None, ...], ...] = ()
+
+
+class ReductionKernelFact(NamedTuple):
+    """The per-kernel Stage-1 product that Stage 2 consumes: the list of reduction descriptors,
+    their co-residency groups (``graph_id`` classes), the non-reduction user-tiled loops (sized as
+    a separate pass), and the parallel grid axes (rows with no reduction over them).
+
+    Built by ``build_reduction_kernel_fact``. ``reductions`` may be empty (a kernel with only
+    GRID_TILE / DECLINED reductions, or none) — the seed then declines.
+    """
+
+    reductions: tuple[ReductionDescriptor, ...]
+    coresidency_groups: tuple[CoResidencyGroup, ...]
+    non_reduction_loop_block_ids: tuple[int, ...] = ()
+    grid_axis_block_ids: tuple[int, ...] = ()
 
 
 class MatmulWithReductionEpilogueFact(NamedTuple):
     """A fused matmul + reduction-over-output-axis epilogue, recorded when a ``MatmulFact`` and
-    a register-resident epilogue ``ReductionFact`` co-occur in one kernel (e.g.
+    a register-resident epilogue reduction co-occur in one kernel (e.g.
     ``matmul_rms_norm``: ``acc = x @ y`` then a reduction over N on the carried ``[M_BLOCK,
-    N]`` accumulator, then write-back). A COMPOSED fact: it holds the two existing facts plus
-    the few derived fields the seed keys on. ``TritonMatmulReductionEpilogueHeuristic``
-    branches on it.
+    N]`` accumulator, then write-back). A COMPOSED fact: it holds the matmul fact plus the few
+    derived fields the seed keys on. ``TritonMatmulReductionEpilogueHeuristic`` branches on it.
 
-    - ``matmul`` / ``reduction``: the composed sub-facts (the matmul + the epilogue reduction).
-    - ``n_extent``: the specialized output width N (= ``reduction.size_hint``); N is
-      ``hl.specialize``'d (never tiled), so both the ``[M_BLOCK, N]`` accumulator and the
+    - ``matmul``: the composed matmul sub-fact.
+    - ``n_extent``: the specialized output width N (= the epilogue reduction's ``size_hint``); N
+      is ``hl.specialize``'d (never tiled), so both the ``[M_BLOCK, N]`` accumulator and the
       ``[K_BLOCK, N]`` operand tile scale with N — the resident-footprint signal the
       footprint-aware tile chooser keys on.
     - ``m_block_id`` / ``k_block_id``: the grid M tile and the K tile the seed sizes
@@ -194,7 +231,6 @@ class MatmulWithReductionEpilogueFact(NamedTuple):
     """
 
     matmul: MatmulFact
-    reduction: ReductionFact
     n_extent: int
     m_block_id: int | None
     k_block_id: int | None
@@ -230,7 +266,7 @@ class MemoryOpFact(NamedTuple):
     # unresolvable). Shape-resolved fallback for the gates below (the plain-slice case,
     # e.g. ``out[tile_m, :]``).
     indexed_block_ids: tuple[int | None, ...] = ()
-    # inner-dim extent for a rank>=2 op (legacy reduction-width signal; gates use subscript_block_ids).
+    # inner-dim extent for a rank>=2 op (a reduction-width signal; gates use subscript_block_ids).
     inner_extent: int | None = None
     # AXIS the op's INDEX subscripts address (block-id per non-bare-int position, from the tile/offset
     # subscript so it is reduction-AGNOSTIC; ``None`` for a plain slice). The faithful axis key for
@@ -254,9 +290,9 @@ class MemoryOpFact(NamedTuple):
 class AccumulatorFact(NamedTuple):
     """One loop-carried tensor accumulator in a reduction loop, recorded at compile time.
     Reduction-AGNOSTIC (like ``MemoryOpFact``): ``dim_block_ids`` is the per-dim block-id
-    provenance (``None`` for a static dim), ``itemsize`` the element size.
-    ``ReductionFact.num_carried_2d_tiles`` counts accumulators whose last dim is the rdim
-    (a 1-D [M_BLOCK] scalar accumulator counts as 0).
+    provenance (``None`` for a static dim), ``itemsize`` the element size. Accumulators whose last
+    dim is the reduction axis feed ``ReductionDescriptor.carried_2d_count`` (a 1-D ``[M_BLOCK]``
+    scalar accumulator counts as 0).
     """
 
     dim_block_ids: tuple[int | None, ...]
@@ -610,7 +646,8 @@ class ConfigSpec:
         self.compiler_seed_configs: list[helion.Config] = []
         self.autotuner_heuristics: list[str] = []
         self.matmul_facts: list[MatmulFact] = []
-        self.reduction_facts: list[ReductionFact] = []
+        # The Stage-1 categorizing product the reduction seed + allocator consume.
+        self.reduction_kernel_fact: ReductionKernelFact | None = None
         self.matmul_reduction_epilogue_facts: list[MatmulWithReductionEpilogueFact] = []
         self.accumulator_facts: list[AccumulatorFact] = []
         self.pointwise_facts: list[PointwiseElementwiseFact] = []
@@ -2054,9 +2091,7 @@ class ConfigSpec:
                 # ``pid_info[0]=M, pid_info[1]=N`` mapping for
                 # ``cluster_m`` / virtual-PID logic, so sampling
                 # ``loop_orders=[[1, 0]]`` there would steer cluster
-                # logic onto the wrong axis. Measured evidence for
-                # the non-tcgen05 widening lives in ``cute_plan.md``
-                # §7.0 "Recent landed work".
+                # logic onto the wrong axis.
                 if (
                     self.supports_config_key("loop_orders")
                     and len(self.loop_orders) > 0

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -142,8 +142,11 @@ from helion.autotuner import IntegerFragment
 from helion.autotuner.config_generation import ConfigGeneration
 from helion.autotuner.config_spec import BlockSizeSpec
 from helion.autotuner.config_spec import ConfigSpec
+from helion.autotuner.config_spec import CoResidencyGroup
 from helion.autotuner.config_spec import MatmulFact
-from helion.autotuner.config_spec import ReductionFact
+from helion.autotuner.config_spec import ReductionCategory
+from helion.autotuner.config_spec import ReductionDescriptor
+from helion.autotuner.config_spec import ReductionKernelFact
 from helion.autotuner.config_spec import ReductionLoopSpec
 from helion.autotuner.pattern_search import InitialPopulationStrategy
 from helion.autotuner.pattern_search import PatternSearch
@@ -769,19 +772,36 @@ class TestTritonStandardReductionHeuristic(TestCase):
         spec.reduction_loops.append(
             ReductionLoopSpec(block_id=1, size_hint=reduction_size_hint)
         )
-        # The deepened heuristic reads a ReductionFact (the workload facts it keys
-        # the warp ramp / eviction / persist decision on); the reduction axis is
-        # block_id=1 (the rolled reduction loop above), the row axis block_id=0.
-        spec.reduction_facts.append(
-            ReductionFact(
-                block_id=1,
-                size_hint=reduction_size_hint,
-                m_block_ids=(0,),
-                static_rnumel=reduction_size_hint,
-                itemsize=itemsize,
-                num_load=num_load,
-                row_reread=row_reread,
-            )
+        # The deepened heuristic reads the primary ReductionDescriptor (the workload facts it
+        # keys the warp ramp / eviction / persist decision on) off the ReductionKernelFact; the
+        # reduction axis is block_id=1 (the rolled reduction loop above, so a FULL_SLICE), the
+        # row/grid axis is block_id=0.
+        desc = ReductionDescriptor(
+            category=ReductionCategory.FULL_SLICE,
+            block_id=1,
+            graph_id=0,
+            size_hint=reduction_size_hint,
+            itemsize=itemsize,
+            input_load_itemsize=itemsize,
+            row_reread=row_reread,
+            num_load=num_load,
+        )
+        spec.reduction_kernel_fact = ReductionKernelFact(
+            reductions=(desc,),
+            coresidency_groups=(
+                CoResidencyGroup(
+                    graph_id=0,
+                    descriptor_indices=(0,),
+                    # The resident live tiles of a one-row reduction (softmax/rms_norm-like): the
+                    # ``[grid_M, rdim]`` read/compute tile + a ``[grid_M]`` scalar carry. The grid
+                    # axis (block_id 0) APPEARS in a live tile -> it is register-RESIDENT, so
+                    # ``_has_reduced_away_grid`` is False (it is NOT a grad-parameter ``.sum(0)``
+                    # collapse). Without this the grid axis is in no tile and the residency test
+                    # wrongly flags a collapse, tripping the num_warps>=8 grad-param floor.
+                    live_tiles=((0, 1), (0,)),
+                ),
+            ),
+            grid_axis_block_ids=(0,),
         )
         return spec
 
@@ -789,6 +809,8 @@ class TestTritonStandardReductionHeuristic(TestCase):
         # The deepened heuristic reads env.backend.max_tensor_numel (the structural
         # persistent cap) — provide the real Triton cap so a sub-cap rnumel stays
         # persistent.
+        from types import SimpleNamespace
+
         from helion.autotuner.config_generation import TRITON_MAX_TENSOR_NUMEL
 
         env = MagicMock()
@@ -796,6 +818,17 @@ class TestTritonStandardReductionHeuristic(TestCase):
         env.backend.max_tensor_numel = TRITON_MAX_TENSOR_NUMEL
         env.config_spec = spec
         env.device = DEVICE
+        # ``_primary_descriptor_selected`` filters the sized descriptors to the BACKED axes
+        # (``free_unbacked_symbols(env.block_sizes[bid].size)``), so the descriptor axes'
+        # ``env.block_sizes[bid].size`` must be a real (backed) int — a bare MagicMock can't be
+        # fed to sympy. Resolve each descriptor's block_id to its static ``size_hint``. For any
+        # OTHER block_id (the grid/M axis) keep a non-int so ``_grid_rows`` returns 0 (no static
+        # grid -> the occupancy-gated narrow-w1 warps lever stays disabled, as it was when the
+        # mock had no configured sizes at all).
+        sizes = {d.block_id: d.size_hint for d in spec.reduction_kernel_fact.reductions}
+        env.block_sizes.__getitem__.side_effect = lambda bid: SimpleNamespace(
+            size=sizes[bid] if bid in sizes else MagicMock()
+        )
         return env
 
     def test_seed_is_persistent_one_row(self) -> None:
@@ -3951,13 +3984,14 @@ class TestTritonReductionHeuristic(TestCase):
         with patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE):
             bound = kernel.bind(args)
 
-            # The reduction heuristic registered a single workload fact and fired.
-            self.assertEqual(len(bound.config_spec.reduction_facts), 1)
-            fact = bound.config_spec.reduction_facts[0]
-            self.assertEqual(fact.size_hint, n)
+            # The reduction heuristic registered a single reduction descriptor and fired.
+            kf = bound.config_spec.reduction_kernel_fact
+            self.assertIsNotNone(kf)
+            self.assertEqual(len(kf.reductions), 1)
+            self.assertEqual(kf.reductions[0].size_hint, n)
             # rms_norm has no separate apply/normalize loop (its apply is over the full
             # row in the reduction scope), so no reduce-then-apply tile is captured.
-            self.assertEqual(fact.non_reduction_loop_block_ids, ())
+            self.assertEqual(kf.non_reduction_loop_block_ids, ())
             self.assertIn(
                 TritonStandardReductionHeuristic.name,
                 bound.config_spec.autotuner_heuristics,
@@ -3998,12 +4032,14 @@ class TestTritonReductionHeuristic(TestCase):
         with patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE):
             bound = kernel.bind(args)
 
-            # Single workload fact carrying a 2D [M, R] tile -> Band B.
-            self.assertEqual(len(bound.config_spec.reduction_facts), 1)
-            fact = bound.config_spec.reduction_facts[0]
+            # Single reduction descriptor carrying a 2D [M, R] tile -> Band B.
+            kf = bound.config_spec.reduction_kernel_fact
+            self.assertIsNotNone(kf)
+            self.assertEqual(len(kf.reductions), 1)
+            fact = kf.reductions[0]
             self.assertEqual(fact.size_hint, n)
-            self.assertGreaterEqual(fact.num_carried_2d_tiles, 1)
-            self.assertEqual(fact.non_reduction_loop_block_ids, ())
+            self.assertGreaterEqual(fact.carried_2d_count, 1)
+            self.assertEqual(kf.non_reduction_loop_block_ids, ())
             self.assertIn(
                 TritonUserTiledReductionHeuristic.name,
                 bound.config_spec.autotuner_heuristics,
@@ -4012,22 +4048,26 @@ class TestTritonReductionHeuristic(TestCase):
                 heuristic.is_eligible(bound.env, bound.host_function.device_ir)
             )
 
-            # Exactly one seed; R_BLOCK is capped, NOT full-N persistent, and the
-            # grid (M) axis sits at its floor of 1.
+            # Exactly one seed; R_BLOCK is capped (NOT full-N persistent) by the ONE budget
+            # allocator, and the grid (M) axis sits at its floor of 1.
             seeds = compiler_seed_configs(bound.env, bound.host_function.device_ir)
         self.assertEqual(len(seeds), 1)
         seed = seeds[0].config
-        # Derive the expected R_BLOCK from the heuristic's OWN helper so the test tracks
-        # the real rule (pow2 of CARRIED_TILE_MAX_BYTES / (itemsize * num_carried_2d_tiles)),
-        # not a hand-rolled formula that drops `* num_carried_2d_tiles` and the next_pow2
-        # rounding (it would mis-predict jsd, which carries 2 tiles).
-        expected_cap = TritonUserTiledReductionHeuristic._carried_tile_r_block_cap(fact)
-        # Concrete anchor: kl_div carries 1 fp32 tile -> 16384 // 4 = 4096 (already pow2).
-        self.assertEqual(expected_cap, 4096)
-        # block_sizes is [R_BLOCK, M_BLOCK]; the reduction axis is capped well
-        # below next_pow2(131072) and M stays at 1.
-        self.assertEqual(seed["block_sizes"], [expected_cap, 1])
-        self.assertLess(expected_cap, n)
+        # The budget allocator sizes the carried [M_BLOCK, R_BLOCK] tile against ONE group budget
+        # (num_live × itemsize footprint vs the CARRIED budget), NOT a bespoke carried byte cap.
+        # The carried accumulator is live the whole loop with body_live_tiles copies, so the budget
+        # depletes to R_BLOCK = pow2(CARRIED_PERSIST_MAX_BYTES / (num_live × itemsize)). A carried
+        # reduction holds its [M, R] tile resident across the whole loop (not streamed-then-released),
+        # so it sizes against the TIGHTER CARRIED_PERSIST_MAX_BYTES (= ROW_PERSIST // 2 = 122880), a
+        # single budget CONSTANT — the footprint FORMULA is the same uniform num_live × ∏(working
+        # tile) as every other kernel (no buffer-count multiplier: body_live_tiles already counts the
+        # carried buffers). For kl_div (body_live_tiles == 6, fp32) that is pow2(122880 / (6 × 4)) =
+        # pow2(5120) = 4096 — capped well below next_pow2(131072) and M floored to 1 (budget spent).
+        # 4096 is the MEASURED optimum (~+2% vs the old 8192). Floor-vs-resident falls out of
+        # depletion: no carried recognizer, no separate CARRIED_TILE_MAX_BYTES.
+        r_block = seed["block_sizes"][0]
+        self.assertEqual(seed["block_sizes"], [4096, 1])
+        self.assertLess(r_block, n)
         # rnumel 131072 > the 16384 warps-32 breakpoint -> 32 warps.
         self.assertEqual(seed["num_warps"], 32)
         self.assertEqual(seed["num_stages"], 1)
@@ -4069,15 +4109,17 @@ class TestTritonReductionHeuristic(TestCase):
                 bound = t1_then_normalize.bind(
                     (torch.randn([m, n], device=DEVICE, dtype=torch.float32),)
                 )
-                # One workload fact: reduction axis + grid-only row axis + the normalize
-                # loop captured as a non-reduction loop tile (NOT a row axis).
-                self.assertEqual(len(bound.config_spec.reduction_facts), 1)
-                fact = bound.config_spec.reduction_facts[0]
+                # One reduction descriptor: reduction axis + grid-only row axis + the
+                # normalize loop captured as a non-reduction loop tile (NOT a row axis).
+                kf = bound.config_spec.reduction_kernel_fact
+                self.assertIsNotNone(kf)
+                self.assertEqual(len(kf.reductions), 1)
+                fact = kf.reductions[0]
                 self.assertEqual(fact.size_hint, n)
-                self.assertEqual(fact.m_block_ids, (0,))
-                self.assertEqual(len(fact.non_reduction_loop_block_ids), 1)
-                self.assertNotIn(fact.block_id, fact.non_reduction_loop_block_ids)
-                self.assertEqual(fact.num_carried_2d_tiles, 0)
+                self.assertEqual(kf.grid_axis_block_ids, (0,))
+                self.assertEqual(len(kf.non_reduction_loop_block_ids), 1)
+                self.assertNotIn(fact.block_id, kf.non_reduction_loop_block_ids)
+                self.assertEqual(fact.carried_2d_count, 0)
                 self.assertIn(
                     TritonStandardReductionHeuristic.name,
                     bound.config_spec.autotuner_heuristics,
@@ -4093,7 +4135,7 @@ class TestTritonReductionHeuristic(TestCase):
                 len(seed["block_sizes"]), len(bound.config_spec.block_sizes)
             )
             norm_idx = bound.config_spec.block_sizes.block_id_to_index(
-                fact.non_reduction_loop_block_ids[0]
+                kf.non_reduction_loop_block_ids[0]
             )
             self.assertGreater(seed["block_sizes"][norm_idx], 1)
             # Persistent (narrow row) -> reduction_loops=[None]; looped (wide row past
@@ -4128,13 +4170,12 @@ class TestTritonReductionHeuristic(TestCase):
         # wrongly declined into a wrong-length crash; now emits a widened looped seed).
         check(1024, 131072, expect_looped=True)
 
-    def test_dynamic_extent_normalize_tile_matches_reduction_tile(self) -> None:
-        # When the reduction extent is NOT statically known (static_rnumel is None,
-        # e.g. a dynamic/jagged reduce-then-apply reduction), the per-row-bytes cap has
-        # no extent to key on, so the non-reduction loop tile falls back to "match the
-        # reduction tile". This default is NOT tuned on any kernel (no example kernel
-        # has a dynamic-extent non-reduction loop); the test pins the fallback's two
-        # shapes.
+    def test_independent_loops_not_floored_by_budget_allocator(self) -> None:
+        # The ONE budget allocator (``size_reduction_tiles``) sizes a USER_TILE reduction
+        # axis AND a co-occurring non-reduction (normalize) loop / secondary reducing axis
+        # so neither FLOORS to 1 (the [..., 1] serialization catastrophe). No example
+        # kernel has a dynamic-extent non-reduction loop, so this pins the behavior on a
+        # constructed spec (bare-spec, no active env — the allocator reads stored hints).
         from helion.autotuner.config_spec import BlockSizeSpec
 
         H = TritonUserTiledReductionHeuristic
@@ -4150,35 +4191,59 @@ class TestTritonReductionHeuristic(TestCase):
             spec.block_sizes.append(
                 BlockSizeSpec(block_id=norm_bid, size_hint=size_hint)
             )
+            # USER_TILE reduction (rdim is a block_sizes entry), grid row block 0, and a
+            # non-reduction normalize loop ``norm_bid`` captured on the kernel fact.
+            desc = ReductionDescriptor(
+                category=ReductionCategory.USER_TILE,
+                block_id=reduction_bid,
+                graph_id=0,
+                size_hint=size_hint,
+                itemsize=4,
+                input_load_itemsize=4,
+                num_load=1,
+            )
+            spec.reduction_kernel_fact = ReductionKernelFact(
+                reductions=(desc,),
+                coresidency_groups=(
+                    CoResidencyGroup(graph_id=0, descriptor_indices=(0,)),
+                ),
+                non_reduction_loop_block_ids=(norm_bid,),
+                grid_axis_block_ids=(0,),
+            )
             return spec
 
-        def fact(block_id: int, norm_bid: int) -> ReductionFact:
-            return ReductionFact(
-                block_id=block_id,
+        def pd(reduction_bid: int) -> ReductionDescriptor:
+            return ReductionDescriptor(
+                category=ReductionCategory.USER_TILE,
+                block_id=reduction_bid,
+                graph_id=0,
                 size_hint=size_hint,
-                m_block_ids=(0,),
-                static_rnumel=None,  # <-- dynamic extent: triggers the fallback
                 itemsize=4,
+                input_load_itemsize=4,
                 num_load=1,
-                non_reduction_loop_block_ids=(norm_bid,),
             )
 
-        # user-tiled: the reduction axis IS a block_sizes entry (red_value given). The
-        # normalize tile matches that red_value (777, an arbitrary sentinel), NOT a
-        # byte-cap value.
+        # The allocator runs without an active CompileEnvironment (it reads stored hints);
+        # device_ir is only consulted for materialized features (none here), so a MagicMock
+        # whose attribute access yields empty iterables is fine.
+        from unittest.mock import MagicMock
+
+        # reduce-then-apply: the reduction axis is sized to its full extent (persistent /
+        # budget-admitted) and the normalize loop is sized to its own extent — NOT 1.
         spec = spec_with(reduction_bid=1, norm_bid=2)
-        bs = H._build_block_sizes(spec, fact(1, 2), 1, 777, non_reduction_loop_ids={2})
+        device_ir = MagicMock()
+        device_ir.grid_block_ids = []
+        with (
+            patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE),
+            patch("helion.runtime.get_num_sm", return_value=132),
+        ):
+            alloc = H.size_reduction_tiles(MagicMock(), spec, device_ir, pd(1))
         red_idx = spec.block_sizes.block_id_to_index(1)
         norm_idx = spec.block_sizes.block_id_to_index(2)
-        self.assertEqual(bs[red_idx], 777)
-        self.assertEqual(bs[norm_idx], 777)  # normalize tile == reduction tile
-
-        # standard: the reduction rides reduction_loops (red_block_id=None,
-        # red_value=None), so the normalize tile matches next_pow2(size_hint) instead —
-        # must NOT floor to 1.
-        bs_t1 = H._build_block_sizes(
-            spec, fact(1, 2), None, None, non_reduction_loop_ids={2}
-        )
-        self.assertEqual(bs_t1[norm_idx], 4096)  # next_pow2(4096)
-        self.assertNotEqual(bs_t1[norm_idx], 1)
-        self.assertEqual(bs_t1[0], H._block_floor(spec.block_sizes[0]))  # grid floored
+        self.assertEqual(alloc.block_sizes[red_idx], 4096)  # rdim sized to extent
+        self.assertEqual(
+            alloc.block_sizes[norm_idx], 4096
+        )  # normalize loop NOT floored
+        self.assertNotEqual(alloc.block_sizes[norm_idx], 1)
+        # grid (M) row axis floored (no widen headroom is required; it just must be valid).
+        self.assertGreaterEqual(alloc.block_sizes[0], 1)

--- a/test/test_barrier.py
+++ b/test/test_barrier.py
@@ -217,8 +217,8 @@ class TestBarrier(RefEagerTestBase, TestCase):
         class _FakeRDim:
             block_id = 7
             reduction = True
-            # A static reduction extent so register_rollable_reductions can build a
-            # ReductionFact (static_rnumel reads rdim.size).
+            # A static reduction extent so register_rollable_reductions can register the
+            # reduction_loops spec (reads rdim.size).
             size = 16
 
             def size_hint(self) -> int:
@@ -264,7 +264,7 @@ class TestBarrier(RefEagerTestBase, TestCase):
 
         fake_env = SimpleNamespace(
             block_sizes=[_FakeRDim()],
-            config_spec=SimpleNamespace(reduction_loops=[], reduction_facts=[]),
+            config_spec=SimpleNamespace(reduction_loops=[]),
             backend_name="triton",
         )
 

--- a/test/test_memory_op_facts.py
+++ b/test/test_memory_op_facts.py
@@ -66,7 +66,7 @@ class TestMemoryOpFacts(RefEagerTestBase, TestCase):
     @skipIfNotCUDA()
     @onlyBackends(["triton"])
     def test_reduction_fact_indexing_slot_invariant(self):
-        """The ReductionFact is built after _collect_memory_op_facts, but the collector
+        """The ReductionKernelFact is built after _collect_memory_op_facts, but the collector
         still runs after the reduction rolling, so every rolled-subgraph load/store keeps
         its ``Config.indexing`` slot and the ``memory_op_facts[i].indexing_index == i``
         invariant holds. Collecting before the rolling would desync ``Config.indexing``
@@ -83,9 +83,11 @@ class TestMemoryOpFacts(RefEagerTestBase, TestCase):
             sum(1 for s in specs if s.eviction_index is not None),
         )
 
-        # Exactly one ReductionFact, derived from the enriched facts.
-        self.assertEqual(len(spec.reduction_facts), 1)
-        fact = spec.reduction_facts[0]
+        # Exactly one reduction descriptor, derived from the enriched facts.
+        kf = spec.reduction_kernel_fact
+        self.assertIsNotNone(kf)
+        self.assertEqual(len(kf.reductions), 1)
+        fact = kf.reductions[0]
         # num_load scopes to the rdim's original graph(s) (one streamed input row), so the
         # rolled-subgraph copy is not double-counted.
         self.assertEqual(fact.num_load, 1)


### PR DESCRIPTION
Stacked PRs:
 * #3036
 * #3035
 * #2997
 * __->__#2996


--- --- ---

### [autotuner] reduction seed heuristic: one budget allocator over a Stage-1 reduction fact


Redesign of the Triton reduction seed. Adds a first-class Stage-1 categorizing fact
(ReductionKernelFact + ReductionDescriptor + CoResidencyGroup, built in device_ir's
build_reduction_kernel_fact) and a single budget allocator (size_reduction_tiles) that
sizes every axis — reduction chunk(s), grid-M rows (widen / floor / collapse), and
apply/independent loops — from one per-co-residency-group register/byte budget, replacing
the previous per-lever recognizers. The standard and user-tiled tracks differ only in
emission routing (rolled reduction_loops vs a block_sizes slot). Removes the legacy
ReductionFact in favor of the per-occurrence descriptor list.

Stacked on #2866 (pointwise seed); disjoint feature — a pointwise fact is defined by the
absence of a reduction fact, so the two coexist. Tests: test_autotuner_heuristics,
test_memory_op_facts, test_barrier green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>