### PR TITLE
[autotuner][sm100] dedicated B200 reduction seed heuristics

### DIFF
--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -21,7 +21,9 @@ from .triton import TritonMatmulReductionEpilogueHeuristic
 from .triton import TritonPointwiseSeedHeuristic
 from .triton import TritonSkinnyGemmHeuristic
 from .triton import TritonStandardReductionHeuristic
+from .triton import TritonStandardReductionHeuristicSM100
 from .triton import TritonUserTiledReductionHeuristic
+from .triton import TritonUserTiledReductionHeuristicSM100
 
 if TYPE_CHECKING:
     from ...runtime.config import Config
@@ -48,7 +50,9 @@ HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
         TritonB200MatmulHeuristic,
         TritonMatmulReductionEpilogueHeuristic,
         TritonStandardReductionHeuristic,
+        TritonStandardReductionHeuristicSM100,
         TritonUserTiledReductionHeuristic,
+        TritonUserTiledReductionHeuristicSM100,
         TritonPointwiseSeedHeuristic,
     ),
     "pallas": (

--- a/helion/_compiler/autotuner_heuristics/triton.py
+++ b/helion/_compiler/autotuner_heuristics/triton.py
@@ -6,6 +6,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import ClassVar
 from typing import NamedTuple
 from typing import cast
 
@@ -30,6 +31,7 @@ if TYPE_CHECKING:
     from ...autotuner.config_spec import ReductionKernelFact
     from ..compile_environment import CompileEnvironment
     from ..device_ir import DeviceIR
+    from .common import HardwareTarget
 
 
 log = logging.getLogger(__name__)
@@ -527,7 +529,8 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
     """
 
     backend = "triton"
-    HARDWARE_TARGETS = (("cuda", "sm90"),)
+    # Widen the declared type so the sm100 subclass can retarget it (the base is sm90-only).
+    HARDWARE_TARGETS: ClassVar[tuple[HardwareTarget, ...]] = (("cuda", "sm90"),)
 
     # ----- THE BUDGET (a register/byte capacity; everything else is a per-axis desire) -----
     # Per-program persistent byte ceiling: the group's resident working set — the sum over its live
@@ -668,6 +671,14 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
             and not f.reductions_fed
             for f in facts
         )
+
+    @classmethod
+    def non_reduction_loop_block_cap(
+        cls, spec: ConfigSpec, pd: ReductionDescriptor
+    ) -> int | None:
+        """Optional element cap for a non-reduction apply loop. ``None`` = no extra cap beyond the
+        shared ``loop_budget`` (sm90/H100 unchanged); a subclass may return a smaller budget."""
+        return None
 
     # =============================== scalar levers (outside the budget) ===================== #
     @classmethod
@@ -1091,6 +1102,8 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
         # in a group's reduction tile (a separate sequential pass), so each gets a FRESH budget
         # against its own extent capped by the streamed ROW budget.
         loop_budget = _pp2(max(1, cls.ROW_PERSIST_MAX_BYTES // itemsize))
+        # Optional tighter cap for a non-reduction apply loop (None on the base; set by sm100).
+        loop_cap = cls.non_reduction_loop_block_cap(spec, pd)
         for i in range(len(spec.block_sizes)):
             bs_spec = cast("BlockSizeSpec", spec.block_sizes[i])
             bid = bs_spec.block_id
@@ -1099,7 +1112,10 @@ class _TritonReductionSeedBase(AutotunerHeuristic):
             if bid in non_reduction_loop_ids or bid not in seated:
                 # a non-reduction apply loop OR an independent standalone tiled loop: size it to
                 # its own extent capped by the headroom (flooring it to 1 would serialize the pass).
-                sizes[bid] = max(1, min(extent_of(bid), loop_budget))
+                budget = loop_budget
+                if loop_cap is not None and bid in non_reduction_loop_ids:
+                    budget = min(budget, loop_cap)
+                sizes[bid] = max(1, min(extent_of(bid), budget))
 
         # ---- assemble the full block_sizes vector ----
         block_sizes: list[int] = []
@@ -1172,7 +1188,11 @@ class TritonStandardReductionHeuristic(_TritonReductionSeedBase):
         cls, env: CompileEnvironment, device_ir: DeviceIR
     ) -> Config | None:
         if not matches_hardware(env, cls.HARDWARE_TARGETS):
-            # Off the H100-validated target: keep the upstream conservative seed.
+            # sm100 has its own subclass (``TritonStandardReductionHeuristicSM100``); decline here so
+            # exactly one reduction seed fires on B200.
+            if matches_hardware(env, (("cuda", "sm100"),)):
+                return None
+            # Off any other target: keep the upstream conservative seed.
             return cls._narrow_seed(env)
         spec = env.config_spec
         pd = _primary_descriptor_selected(env)
@@ -1308,6 +1328,112 @@ class TritonUserTiledReductionHeuristic(_TritonReductionSeedBase):
             if ev is not None:
                 seed["load_eviction_policies"] = ev
         return Config(**seed)
+
+
+def _config_with_num_warps(cfg: Config, num_warps: int) -> Config:
+    """Return a copy of ``cfg`` with ``num_warps`` overridden (the reduction seeds always set
+    num_warps, so this replaces the existing value)."""
+    merged: dict[str, Any] = {**cfg.config, "num_warps": num_warps}
+    return Config(**merged)
+
+
+# ============================ sm100 (B200) dedicated subclasses ============================ #
+# Re-target the sm90 reduction seeds at sm100 via a subclass that overrides only the hardware gate +
+# B200 constants; the sm90/H100 emit is a separate class + gate, so it stays frozen.
+class _TritonReductionSeedSM100(_TritonReductionSeedBase):
+    """sm100 (B200) constant/gate carrier for the two reduction seed tracks. Overrides the hardware
+    gate and re-tunes constants (as class attributes) only where a B200 measurement demands it. Not
+    registered; the two concrete subclasses below are.
+
+    ``promote_seed_to_default`` is left at the base default (``False``) here: the sm100 reduction
+    seed is still contributed as an autotuner seed, but is NOT promoted to the compiler default until
+    a later change flips it on (together with the config-validity fixes that make promotion safe)."""
+
+    HARDWARE_TARGETS = (("cuda", "sm100"),)
+    # --- B200 constant overrides (re-tuned during the climb; unset = direct port of H100) ---
+    # Load-traffic ceiling (bytes) below which a light streamed row drops to nw8 (see _b200_num_warps).
+    NW8_MAX_ROW_TRAFFIC = 64 * 1024
+    # Element cap for a non-reduction apply loop (see non_reduction_loop_block_cap).
+    NON_REDUCTION_LOOP_MAX_ELEMS = 4096
+
+    @classmethod
+    def non_reduction_loop_block_cap(
+        cls, spec: ConfigSpec, pd: ReductionDescriptor
+    ) -> int | None:
+        # Cap EVERY non-reduction apply loop (relieves register pressure on B200).
+        return cls.NON_REDUCTION_LOOP_MAX_ELEMS
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        # Fire the inherited rich seed ONLY on sm100; decline elsewhere so this promoted class never
+        # overrides the frozen sm90/H100 default.
+        if not matches_hardware(env, cls.HARDWARE_TARGETS):
+            return None
+        cfg = super().get_seed_config(env, device_ir)
+        if cfg is None:
+            return None
+        # Re-tune num_warps by the load-traffic key (both tracks, one place); see _b200_num_warps.
+        pd = _primary_descriptor_selected(env)
+        if pd is not None:
+            nw = cls._b200_num_warps(env.config_spec, pd, cfg)
+            if nw is not None:
+                cfg = _config_with_num_warps(cfg, nw)
+        return cfg
+
+    @classmethod
+    def _b200_num_warps(
+        cls, spec: ConfigSpec, pd: ReductionDescriptor, cfg: Config
+    ) -> int | None:
+        """The B200 warp count for a light-traffic PERSISTENT streamed row (8, or 4 at small extent),
+        or None to leave the base ramp untouched. Purely additive: only lowers, never raises."""
+        # Skip M-collapse (grad-parameter .sum(0)): a cross-warp accumulate, not a streamed row.
+        if cls._has_reduced_away_grid(spec):
+            return None
+        # Skip reduce-then-apply (welford / rms_norm_per_block): its reread lives on the non-reduction
+        # loop, not in ``num_load``, so the traffic key can't see it.
+        if cls._non_reduction_loop_ids(spec):
+            return None
+        # Restrict to a single sized reduction: a second one adds cross-warp compute the traffic key
+        # can't see, with a non-monotonic warp optimum.
+        kf = spec.reduction_kernel_fact
+        if (
+            kf is None
+            or sum(1 for d in kf.reductions if d.category in SIZED_REDUCTION_CATEGORIES)
+            != 1
+        ):
+            return None
+        # Skip LOOPED reductions (positive ``reduction_loops`` chunk): they keep the base ramp.
+        loops = cfg.config.get("reduction_loops")
+        if isinstance(loops, (list, tuple)) and any(isinstance(x, int) for x in loops):
+            return None
+        # Load traffic per row = elems × load-width × #loads.
+        traffic = pd.size_hint * max(1, pd.input_load_itemsize) * max(1, pd.num_load)
+        if traffic <= cls.NW8_MAX_ROW_TRAFFIC:
+            # keep the base's small-extent 4-warp floor (<=1024 elems); else 8.
+            return 4 if pd.size_hint <= 1024 else 8
+        return None  # heavy-traffic streamed row -> base ramp (16/32) is right
+
+
+class TritonStandardReductionHeuristicSM100(
+    _TritonReductionSeedSM100, TritonStandardReductionHeuristic
+):
+    """standard (Helion-rolled rdim) inner-reduction seed for sm100/B200: the rich
+    :class:`TritonStandardReductionHeuristic` allocator with B200 constants from
+    :class:`_TritonReductionSeedSM100`."""
+
+    name = "triton_reduction_tile_sm100"
+
+
+class TritonUserTiledReductionHeuristicSM100(
+    _TritonReductionSeedSM100, TritonUserTiledReductionHeuristic
+):
+    """user-tiled inner-reduction seed for sm100/B200: the rich
+    :class:`TritonUserTiledReductionHeuristic` allocator with B200 constants from
+    :class:`_TritonReductionSeedSM100`."""
+
+    name = "triton_reduction_user_tile_sm100"
 
 
 class TritonMatmulReductionEpilogueHeuristic(AutotunerHeuristic):

--- a/test/test_autotuner_heuristics.py
+++ b/test/test_autotuner_heuristics.py
@@ -944,9 +944,17 @@ class TestTritonStandardReductionHeuristic(TestCase):
                 red.env, red.host_function.device_ir
             )
         )
-        seed = TritonStandardReductionHeuristic.get_seed_config(
-            red.env, red.host_function.device_ir
-        )
+        # Pin the sm90/H100 target so the tuned seed path runs regardless of the CI runner's
+        # GPU: on sm100 (B200) this class declines (returns None) so the dedicated
+        # ``TritonStandardReductionHeuristicSM100`` subclass is the sole reduction seed, so an
+        # unpatched call would return None on a B200 runner.
+        with (
+            patch("helion._hardware.get_hardware_info", return_value=HOPPER_HARDWARE),
+            patch("helion.runtime.get_num_sm", return_value=132),
+        ):
+            seed = TritonStandardReductionHeuristic.get_seed_config(
+                red.env, red.host_function.device_ir
+            )
         self.assertEqual(seed.config["block_sizes"], [1])
         self.assertEqual(seed.config["reduction_loops"], [None])
 


### PR DESCRIPTION
Stacked PRs:
 * #3036
 * #3035
 * __->__#2997
 * #2996


--- --- ---

### [autotuner][sm100] dedicated B200 reduction seed heuristics


Stacked on #2996 (the reduction-seed budget allocator). This PR re-targets that
allocator at **sm100 (B200)** via two dedicated subclasses
(`TritonStandardReductionHeuristicSM100` / `TritonUserTiledReductionHeuristicSM100`,
sharing the `_TritonReductionSeedSM100` constant/gate carrier). They inherit the rich
allocator + emission bodies unchanged and re-tune only what B200's memory hierarchy
demands. The sm90/H100 path is a separate class + gate and stays **byte-identical**
(freeze-verified: 0/40 seed rows change under an sm90 spoof; no `*_sm100` heuristic
fires off sm100).

Two B200-only levers sit on top of the direct port:

- **num_warps lever** — on a light-traffic (load traffic = `size_hint ×
  input_load_itemsize × num_load` ≤ 64 KiB), persistent, single-sized-reduction,
  non-M-collapse, non-reduce-then-apply row, lower `num_warps` to 8 (the base ramp
  gives 16/32). Purely additive (only ever lowers), fenced by four `None`-guards so it
  cannot regress the excluded regimes.
- **non-reduction apply-loop cap** — cap every non-reduction apply loop at 4096 elems
  to relieve register pressure on B200 (helps the vLLM quant kernels).

## Perf (B200 sm100)

Per-`(kernel, dtype)` geomeans. `G > 1.0` = Helion seed is faster.

### `examples/` kernels — vs `torch.compile()` and vs Helion default

| kernel | dtype | G vs torch.compile | G vs default |
|---|---|---:|---:|
| cross_entropy | bf16 | 1.324 | 1.094 |
| cross_entropy | fp32 | 1.164 | 1.438 |
| jsd | bf16 | 0.893 | 4.659 |
| jsd | fp32 | 0.941 | 5.168 |
| kl_div | bf16 | 1.199 | 8.891 |
| kl_div | fp32 | 1.258 | 13.078 |
| layer_norm | bf16 | 0.983 | 1.029 |
| layer_norm | fp32 | 0.989 | 1.029 |
| long_sum | bf16 | 0.878 | 3.579 |
| long_sum | fp32 | 0.736 | 3.298 |
| rms_norm | bf16 | 0.914 | 1.007 |
| rms_norm | fp32 | 1.022 | 1.038 |
| softmax | bf16 | 1.271 | 5.271 |
| softmax | fp32 | 1.130 | 5.869 |
| sum | bf16 | 0.990 | 1.165 |
| sum | fp32 | 0.959 | 1.123 |
| welford | bf16 | 0.910 | 3.186 |
| welford | fp32 | 0.869 | 2.757 |

### vLLM kernels — vs vLLM's seeded configs and vs Helion default

| kernel | G vs vLLM | G vs default |
|---|---:|---:|
| dynamic_per_token_scaled_fp8_quant | 1.036 | 2.649 |
| per_token_group_fp8_quant | 0.814 | 0.856 |
| rms_norm_dynamic_per_token_quant | 1.019 | 7.310 |
| rms_norm_per_block_quant | 1.016 | 1.554 |
| silu_mul_fp8 | 1.081 | 1.029 |

**Notes on accuracy-gated cells (perf still measured honestly):**
- `welford` bf16 and `sum` bf16 accumulate in bf16, so wide reductions trip the fixed
  tolerance while the value is numerically fine. Where the seed and default fail the
  gate *identically* the perf comparison is still valid and is included; `sum` bf16 drops
  2 asymmetric (seed-degraded / default-ok) cells (both were ~1.0 perf-only anyway).
- `per_token_group_fp8_quant` (G vs vLLM 0.814) is dragged down by one shape
  (`8192×4096×128`, ~0.50) — a known seed grid-M-widen robustness issue flagged for
  follow-up; the other shapes are 0.92–0.98. All 3 sub-cells are `both_fail` vs the vLLM
  reference (the reference quantizes differently), so they're included as perf-only.
- `silu_mul_fp8` uses vLLM's h200 fallback config (no `nvidia_b200.json` shipped).

Benched on B200 (sm100), forced-seed vs `torch.compile(mode="max-autotune")`, Helion
default, and (for the vLLM kernels) vLLM's shipped seeded configs. A subset of cells was
re-benched fresh at this commit and reproduced the reported ratios within measurement
noise.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>