### PR TITLE
Fix broadcast store placement in looped reduction

### DIFF
--- a/helion/_compiler/roll_reduction.py
+++ b/helion/_compiler/roll_reduction.py
@@ -172,6 +172,8 @@ class ReductionRoller:
             target, index_arg, value, *_ = node.args
             if isinstance(value, torch.fx.Node):
                 num_rdims = self._count_rdim_axes_in_val(value.meta["val"])
+                if num_rdims == 0:
+                    num_rdims = self._count_rdim_axes_in_subscript(target, index_arg)
             else:
                 # When the stored value is a Python scalar (broadcast across
                 # the indexed slice), it carries no shape, so the LHS

--- a/helion/_compiler/roll_reduction.py
+++ b/helion/_compiler/roll_reduction.py
@@ -174,7 +174,9 @@ class ReductionRoller:
                 num_rdims = self._count_rdim_axes_in_val(value.meta["val"])
                 if num_rdims == 0:
                     val = value.meta["val"]
-                    if isinstance(val, torch.Tensor) and any(s == 1 for s in val.size()):
+                    if isinstance(val, torch.Tensor) and any(
+                        s == 1 for s in val.size()
+                    ):
                         num_rdims = self._count_rdim_axes_in_subscript(
                             target, index_arg
                         )

--- a/helion/_compiler/roll_reduction.py
+++ b/helion/_compiler/roll_reduction.py
@@ -173,7 +173,11 @@ class ReductionRoller:
             if isinstance(value, torch.fx.Node):
                 num_rdims = self._count_rdim_axes_in_val(value.meta["val"])
                 if num_rdims == 0:
-                    num_rdims = self._count_rdim_axes_in_subscript(target, index_arg)
+                    val = value.meta["val"]
+                    if isinstance(val, torch.Tensor) and any(s == 1 for s in val.size()):
+                        num_rdims = self._count_rdim_axes_in_subscript(
+                            target, index_arg
+                        )
             else:
                 # When the stored value is a Python scalar (broadcast across
                 # the indexed slice), it carries no shape, so the LHS

--- a/helion/_compiler/roll_reduction.py
+++ b/helion/_compiler/roll_reduction.py
@@ -171,9 +171,9 @@ class ReductionRoller:
             # atomic_add(target, index, value, sem)
             target, index_arg, value, *_ = node.args
             if isinstance(value, torch.fx.Node):
-                num_rdims = self._count_rdim_axes_in_val(value.meta["val"])
+                val = value.meta["val"]
+                num_rdims = self._count_rdim_axes_in_val(val)
                 if num_rdims == 0:
-                    val = value.meta["val"]
                     if isinstance(val, torch.Tensor) and any(
                         s == 1 for s in val.size()
                     ):

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -405,6 +405,27 @@ class TestReductions(RefEagerTestBase, TestCase):
         )
         torch.testing.assert_close(output, args[0].sum(-1), rtol=1e-04, atol=1e-04)
 
+    def test_broadcast_store_looped_reduction(self):
+        @helion.kernel(autotune_effort="none")
+        def sum_and_broadcast(
+            x: torch.Tensor, bias: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            m, n = x.size()
+            s = torch.empty([m], dtype=x.dtype, device=x.device)
+            out = torch.empty([m, n], dtype=x.dtype, device=x.device)
+            for tile_m in hl.tile(m):
+                s[tile_m] = torch.sum(x[tile_m, :], dim=-1)
+                out[tile_m, :] = bias[tile_m].unsqueeze(-1)
+            return s, out
+
+        x = torch.randn(16, 64, device=DEVICE)
+        bias = torch.arange(16, dtype=torch.float32, device=DEVICE)
+        _, (s, out) = code_and_output(
+            sum_and_broadcast, (x, bias), block_size=16, reduction_loop=16
+        )
+        torch.testing.assert_close(s, x.sum(-1), rtol=1e-4, atol=1e-4)
+        torch.testing.assert_close(out, bias[:, None].expand(16, 64))
+
     @skipUnlessTensorDescriptor("Tensor descriptor support is required")
     def test_argmin_argmax_looped(self):
         for fn in (torch.argmin, torch.argmax):

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -405,6 +405,7 @@ class TestReductions(RefEagerTestBase, TestCase):
         )
         torch.testing.assert_close(output, args[0].sum(-1), rtol=1e-04, atol=1e-04)
 
+    @skipIfPallas("Pallas does not support broadcasting on store")
     def test_broadcast_store_looped_reduction(self):
         @helion.kernel(autotune_effort="none")
         def sum_and_broadcast(


### PR DESCRIPTION
Fixes: #3001 

## Summary
- Broadcast tensor stores (e.g. `bias[tile_m].unsqueeze(-1)`) were placed outside the reduction loop, writing only one chunk instead of all columns
- Fix: fall back to LHS subscript check when value has no rdim axes, matching the existing scalar store path

## Test plan
- Added `test_broadcast_store_looped_reduction` in `test/test_reductions.py`