### PR TITLE
Reduce Triton kernel launch overhead: fast dispatch + direct launch

### DIFF
--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -115,6 +115,25 @@ def my_kernel(x: torch.Tensor) -> torch.Tensor:
 
    Reserve this many streaming multiprocessors when launching persistent kernels. Default is ``0`` (use all SMs).
    Configure globally with ``HELION_PERSISTENT_RESERVED_SMS`` or per-kernel via ``@helion.kernel(..., persistent_reserved_sms=N)``.
+
+.. autoattribute:: Settings.triton_direct_launch
+
+   If ``True`` (default), repeat launches of an already-compiled Triton specialization skip
+   ``JITFunction.run`` and invoke the cached compiled kernel directly, substantially reducing
+   per-call launch overhead. Triton-only; the setting is accepted but ignored on other backends.
+   Disable per-kernel with ``@helion.kernel(triton_direct_launch=False)`` or globally with
+   ``HELION_TRITON_DIRECT_LAUNCH=0``.
+
+   The direct path automatically falls back to the full ``JITFunction.run`` path whenever it
+   cannot guarantee an identical launch: unaligned (non-16-byte) tensor pointer arguments,
+   mutated ``used_global_vals`` (globals captured by the generated kernel), extra launch kwargs
+   such as ``ptx_options``, Triton launch/pre-run hooks or debug/instrumentation knobs active
+   when the kernel is first launched, and ``torch.compile`` tracing all take the slow path.
+
+   One case is *not* auto-detected and requires opting out: Triton launch/pre-run hooks or
+   knobs registered *after* a kernel's first launch are not re-checked on each call, so a
+   profiler that attaches launch hooks mid-run will not observe direct launches. Set
+   ``triton_direct_launch=False`` for kernels that must always be visible to such hooks.
 ```
 
 ### Autotuning Settings
@@ -320,6 +339,7 @@ Built-in values for ``HELION_AUTOTUNER`` include ``"LFBOTreeSearch"`` (default),
 | ``HELION_STATIC_SHAPES`` | ``static_shapes`` | Set to ``0``/``false`` to disable global static shape specialization. |
 | ``HELION_FAST_MATH`` | ``fast_math`` | Set to ``1`` to enable fast math approximations (Helion-level and Inductor-level). May reduce numerical precision. |
 | ``HELION_PERSISTENT_RESERVED_SMS`` | ``persistent_reserved_sms`` | Reserve this many streaming multiprocessors when launching persistent kernels (``0`` uses all available SMs). |
+| ``HELION_TRITON_DIRECT_LAUNCH`` | ``triton_direct_launch`` | Set to ``0`` to disable the Triton direct-launch fast path and route every launch through ``JITFunction.run``. |
 | ``HELION_FORCE_AUTOTUNE`` | ``force_autotune`` | Force the autotuner to run even when explicit configs are provided. The result is saved to the cache. |
 | ``HELION_AUTOTUNE_FORCE_PERSISTENT`` | ``autotune_force_persistent`` | Restrict ``pid_type`` to persistent kernel strategies during config search. |
 | ``HELION_DISALLOW_AUTOTUNING`` | ``check_autotuning_disabled`` | Hard-disable autotuning; kernels must supply explicit configs when this is ``1``. |

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1131,10 +1131,10 @@ class TritonBackend(Backend):
         )
         if triton_jit_fn is not None and hasattr(triton_jit_fn, "device_caches"):
             triton_jit_fn.device_caches.clear()
-            # The fast-launch cache (helion.runtime.default_launcher) also
+            # The direct-launch cache (helion.runtime.default_launcher) also
             # holds the compiled binary; drop it so the recompile isn't
             # bypassed by a direct launch of the ephemeral artifact.
-            triton_jit_fn.__dict__.pop("_helion_fast_launch", None)
+            triton_jit_fn.__dict__.pop("_helion_direct_launch", None)
 
     def compiled_cache_key(
         self, bound_kernel: BoundKernel[Any], compiled_fn: object
@@ -1291,6 +1291,18 @@ class TritonBackend(Backend):
 
     @property
     def library_imports(self) -> dict[str, str]:
+        from .compile_environment import CompileEnvironment
+        from .compile_environment import NoCurrentEnvironment
+
+        # The triton_direct_launch setting is resolved here, at codegen time,
+        # so the per-call path pays no cost for the choice: opted-out kernels
+        # import the always-slow launcher as _default_launcher.
+        launcher = "default_launcher"
+        try:
+            if not CompileEnvironment.current().settings.triton_direct_launch:
+                launcher = "default_slow_launcher"
+        except NoCurrentEnvironment:
+            pass
         return {
             "math": "import math",
             "operator": "import operator",
@@ -1302,7 +1314,7 @@ class TritonBackend(Backend):
             "triton_helpers": "from torch._inductor.runtime import triton_helpers",
             "tl_math": "from torch._inductor.runtime.triton_helpers import math as tl_math",
             "libdevice": "from torch._inductor.runtime.triton_compat import libdevice",
-            "_default_launcher": "from helion.runtime import default_launcher as _default_launcher",
+            "_default_launcher": f"from helion.runtime import {launcher} as _default_launcher",
             "fast_dividef": "from triton.language.extra.libdevice import fast_dividef",
             "fast_expf": "from triton.language.extra.libdevice import fast_expf",
         }

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1131,6 +1131,10 @@ class TritonBackend(Backend):
         )
         if triton_jit_fn is not None and hasattr(triton_jit_fn, "device_caches"):
             triton_jit_fn.device_caches.clear()
+            # The fast-launch cache (helion.runtime.default_launcher) also
+            # holds the compiled binary; drop it so the recompile isn't
+            # bypassed by a direct launch of the ephemeral artifact.
+            triton_jit_fn.__dict__.pop("_helion_fast_launch", None)
 
     def compiled_cache_key(
         self, bound_kernel: BoundKernel[Any], compiled_fn: object

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -5,7 +5,6 @@ from contextlib import suppress
 import contextvars
 from dataclasses import dataclass
 import enum
-import functools
 import hashlib
 import importlib
 import inspect
@@ -184,9 +183,14 @@ def get_num_sm(device: torch.device, *, reserved_sms: int = 0) -> int:
 # re-validates everything) whenever it cannot guarantee an identical launch:
 # unseen argument metadata (dtype, scalar value, or 16-byte pointer alignment
 # -- all part of the cache key, so Triton's per-argument specialization axes
-# are covered), mutated ``used_global_vals``, extra launch kwargs, active
-# Triton hooks/knobs at prime time, torch.compile tracing, or any exception
-# while building the key.  The one intentional gap: Triton launch/pre-run
+# are covered), mutated ``used_global_vals`` (current global values are key
+# elements too, so a mutation is just a cache miss), extra launch kwargs,
+# active Triton hooks/knobs at prime time, torch.compile tracing, or any
+# exception while building the key.  These hazards cannot be caught *after*
+# a bad launch -- a misaligned launch surfaces as an asynchronous CUDA error
+# that poisons the context, and a stale captured global silently computes
+# wrong values -- so they are folded into the key and prevented up front
+# rather than detected afterwards.  The one intentional gap: Triton launch/pre-run
 # hooks and debug/instrumentation knobs are checked when a specialization is
 # first cached, not per call, so a profiler that registers launch hooks
 # *after* a kernel's first launch will not observe direct launches.  Set
@@ -255,39 +259,40 @@ def _direct_launch_populate(
     """Cache a compiled specialization for direct launching.
 
     The cache key is every launch argument (tensors contribute their dtype
-    and a 16-byte pointer-alignment bit, scalars their value) plus launch
-    options and device.  Scalar values are strictly finer than the buckets
-    Triton specializes on (divisible-by-16, equals-1); dtype covers
+    and a 16-byte pointer-alignment bit, scalars their value) plus the
+    current value of every global Triton captured at compile time, plus
+    launch options and device.  Scalar values are strictly finer than the
+    buckets Triton specializes on (divisible-by-16, equals-1); dtype covers
     pointer-type specialization when one ``JITFunction`` serves several
     dtypes (``PyCodeCache`` dedups identical generated source, e.g. a
     dtype-agnostic add kernel for bf16 and fp16); the alignment bit covers
     Triton's pointer-alignment specialization, so an unaligned view arriving
-    after an aligned prime misses the cache and takes the slow path.
+    after an aligned prime misses the cache and takes the slow path; global
+    values cover ``used_global_vals``, so a mutated global misses the cache
+    and the slow path raises Triton's own RuntimeError.
     """
     if not _triton_direct_launch_ok(triton_kernel):
         return
     state = triton_kernel.__dict__.get("_helion_direct_launch")
     if state is None:
         # Argument layout (which positions are tensors) is fixed per generated
-        # kernel, so record the tensor/scalar split once here and let the hot
-        # path build keys with no per-element type checks.
-        tensor_idx = tuple(
-            i for i, a in enumerate(args) if isinstance(a, torch.Tensor)
-        )
+        # kernel, so bake the tensor/scalar split and the captured-globals
+        # lookups into a single compiled key function here; the hot path then
+        # builds the full key with no per-element type checks and no separate
+        # globals-guard loop.
+        tensor_idx = tuple(i for i, a in enumerate(args) if isinstance(a, torch.Tensor))
         scalar_idx = tuple(
             i for i in range(len(args)) if i not in frozenset(tensor_idx)
         )
-        make_key = functools.partial(_direct_launch_args_key, tensor_idx, scalar_idx)
-        # Snapshot of the globals Triton captured at compile time; compared
-        # (by value, like JITFunction.run does) before every direct launch.
         globals_guard = tuple(
-            (gdict, name, val)
-            for (name, _), (val, gdict) in triton_kernel.used_global_vals.items()
+            (gdict, name)
+            for (name, _), (_val, gdict) in triton_kernel.used_global_vals.items()
         )
-        state = (make_key, globals_guard, {})
+        make_key = _direct_launch_make_key_fn(tensor_idx, scalar_idx, globals_guard)
+        state = (make_key, {})
         # pyrefly: ignore [missing-attribute]
         triton_kernel._helion_direct_launch = state
-    state[2][(*key, *state[0](args))] = (
+    state[1][(*key, *state[0](args))] = (
         compiled.run,
         compiled.function,
         compiled.packed_metadata,
@@ -295,28 +300,35 @@ def _direct_launch_populate(
     )
 
 
-def _direct_launch_args_key(
+def _direct_launch_make_key_fn(
     tensor_idx: tuple[int, ...],
     scalar_idx: tuple[int, ...],
-    args: tuple[object, ...],
-) -> tuple[object, ...]:
-    """Direct-launch key: scalar values followed by per-tensor
-    ``(dtype, aligned)`` pairs, using index positions recorded at first
-    launch.
+    globals_guard: tuple[tuple[dict[str, object], str], ...],
+) -> Callable[[tuple[object, ...]], tuple[object, ...]]:
+    """Compile a flat key builder: scalar values, per-tensor dtype and
+    16-byte-alignment bit, then the current value of each captured global.
 
-    Concatenating the two groups (rather than interleaving in argument order)
-    keeps the key unique because the tensor/scalar split is fixed per kernel.
-    If a later call passes a tensor where a scalar was seen (or vice versa),
-    ``data_ptr``/hashing raises or the key won't match, so the call safely
-    falls back to the slow path.
+    Compiling one expression per kernel (Triton's ``binder`` does the same)
+    roughly halves key-build time versus a generic generator plus a separate
+    globals-guard loop.  Concatenating the groups (rather than interleaving
+    in argument order) keeps the key unique because the tensor/scalar split
+    is fixed per generated kernel.  Every hazard is a key element, so any
+    deviation -- unseen scalar, new dtype, unaligned pointer, mutated or
+    deleted captured global, tensor/scalar mismatch (attribute error or an
+    identity-hashed tensor) -- is a cache miss that falls back to the slow
+    path; nothing needs to be caught after the launch (misalignment would be
+    an async CUDA error, a stale global would be silently wrong numerics).
     """
-    return (
-        *(args[i] for i in scalar_idx),
-        *(
-            (t.dtype, t.data_ptr() % 16 == 0)  # type: ignore[union-attr]
-            for t in (args[i] for i in tensor_idx)
-        ),
-    )
+    namespace: dict[str, object] = {"_MISSING": _MISSING_GLOBAL}
+    parts = [f"a[{i}]" for i in scalar_idx]
+    for i in tensor_idx:
+        parts.extend((f"a[{i}].dtype", f"not a[{i}].data_ptr() & 15"))
+    for j, (gdict, name) in enumerate(globals_guard):
+        namespace[f"_g{j}"] = gdict
+        parts.append(f"_g{j}.get({name!r}, _MISSING)")
+    if not parts:
+        return lambda a: ()
+    return eval(f"lambda a: ({', '.join(parts)},)", namespace)
 
 
 def default_launcher(
@@ -350,7 +362,7 @@ def default_launcher(
                 active = _triton_driver().active
                 # pyrefly: ignore [missing-attribute]
                 device = active.get_current_device()
-                make_key, globals_guard, cache = state
+                make_key, cache = state
                 cached = cache.get(
                     (
                         device,
@@ -361,11 +373,6 @@ def default_launcher(
                     )
                 )
                 if cached is not None:
-                    for gdict, name, val in globals_guard:
-                        if gdict.get(name, _MISSING_GLOBAL) != val:
-                            # Mutated captured global: the slow path re-checks
-                            # and raises Triton's own RuntimeError.
-                            raise LookupError
                     # pyrefly: ignore [missing-attribute]
                     stream = active.get_current_stream(device)
                     kernel_run, kernel_function, packed_metadata, compiled = cached
@@ -384,10 +391,11 @@ def default_launcher(
                     )
                     return compiled
             except Exception:
-                # Unseen specialization, mutated global, stale cache entry
-                # (device reset, ...), or bad launch args: fall through to
-                # JITFunction.run, which re-validates and raises a proper
-                # error if the launch is genuinely broken.
+                # Unhashable key element, stale cache entry (device reset,
+                # ...), or bad launch args: fall through to JITFunction.run,
+                # which re-validates and raises a proper error if the launch
+                # is genuinely broken.  (Unseen specializations and mutated
+                # captured globals are ordinary cache misses, not exceptions.)
                 pass
 
     compiled = default_slow_launcher(

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -172,40 +172,30 @@ def get_num_sm(device: torch.device, *, reserved_sms: int = 0) -> int:
     return max(available_sms - reserved_sms, 1)
 
 
-# Fast launch mode (on by default, set HELION_FAST_LAUNCH=0 to disable).
+# Direct launch (controlled by the ``triton_direct_launch`` kernel setting,
+# on by default; see helion/runtime/settings.py for the full documentation).
 #
 # After a specialization has been compiled once through the regular
 # ``JITFunction.run`` path, repeat launches call the cached ``CompiledKernel``
 # handle directly, skipping option parsing, argument re-specialization,
 # cache-key stringification, hook dispatch, and launch-metadata construction.
 #
-# Fast mode intentionally does NOT support (use HELION_FAST_LAUNCH=0 if you
-# need any of these):
-#
-# - Triton launch/pre-run hooks or knobs registered *after* a kernel's first
-#   launch: ``triton.knobs.runtime.launch_enter_hook/launch_exit_hook``,
-#   ``JITFunction.pre_run_hooks``, ``add_stages_inspection_hook``, and the
-#   ``debug`` / ``instrumentation_mode`` knobs are checked once when a
-#   specialization is first cached, not on every call.  Profilers (e.g.
-#   proton) that register launch hooks mid-run will not see fast-path
-#   launches.  Hooks active at first launch disable the fast path for that
-#   kernel, so registering hooks before any kernel runs still works.
-# - Changing tensor-argument pointer alignment between calls: Triton
-#   specializes on 16-byte pointer alignment, but the fast path keys only on
-#   the non-tensor (scalar) arguments.  Two calls whose tensors have the same
-#   dtype/shape/strides but different data-pointer alignment (e.g. an offset
-#   slice of a larger buffer) reuse the first call's compiled binary.  Plain
-#   PyTorch allocations are always sufficiently aligned; only offset views
-#   can be misaligned.
-# - Mutating ``used_global_vals``: ``JITFunction.run`` re-checks on every
-#   call that module-level globals captured by the kernel are unchanged; the
-#   fast path checks nothing.  (Helion-generated kernels do not capture
-#   mutable globals.)
-_FAST_LAUNCH: bool = os.environ.get("HELION_FAST_LAUNCH", "1") == "1"
+# The direct path automatically falls back to ``JITFunction.run`` (which
+# re-validates everything) whenever it cannot guarantee an identical launch:
+# unseen argument metadata (dtype, scalar value, or 16-byte pointer alignment
+# -- all part of the cache key, so Triton's per-argument specialization axes
+# are covered), mutated ``used_global_vals``, extra launch kwargs, active
+# Triton hooks/knobs at prime time, torch.compile tracing, or any exception
+# while building the key.  The one intentional gap: Triton launch/pre-run
+# hooks and debug/instrumentation knobs are checked when a specialization is
+# first cached, not per call, so a profiler that registers launch hooks
+# *after* a kernel's first launch will not observe direct launches.  Set
+# ``triton_direct_launch=False`` (or HELION_TRITON_DIRECT_LAUNCH=0) to keep
+# every launch on the full ``JITFunction.run`` path.
 
 
-def _triton_fast_launch_ok(triton_kernel: JITFunction[object]) -> bool:
-    """One-time (per specialization) check that the fast launch path is safe.
+def _triton_direct_launch_ok(triton_kernel: JITFunction[object]) -> bool:
+    """One-time (per specialization) check that direct launching is safe.
 
     Verifies no hook that ``JITFunction.run`` would have invoked is active
     and no knob that feeds into launch behavior is set.  Called when caching
@@ -226,7 +216,7 @@ def _triton_fast_launch_ok(triton_kernel: JITFunction[object]) -> bool:
     return not knobs.compilation.instrumentation_mode
 
 
-def _default_launcher_slow(
+def _jit_function_run(
     triton_kernel: JITFunction[object],
     *args: object,
     **run_kwargs: object,
@@ -240,7 +230,23 @@ def _default_launcher_slow(
         raise
 
 
-def _fast_launch_populate(
+_MISSING_GLOBAL = object()
+_TRITON_DRIVER: object = None
+
+
+def _triton_driver() -> object:
+    """Cache the Triton ``driver`` module so the direct-launch hot path
+    avoids a fresh ``from triton.runtime import driver`` import lookup on
+    every call."""
+    global _TRITON_DRIVER
+    if _TRITON_DRIVER is None:
+        from triton.runtime import driver
+
+        _TRITON_DRIVER = driver
+    return _TRITON_DRIVER
+
+
+def _direct_launch_populate(
     triton_kernel: JITFunction[object],
     compiled: CompiledKernel,
     key: tuple[object, ...],
@@ -248,28 +254,40 @@ def _fast_launch_populate(
 ) -> None:
     """Cache a compiled specialization for direct launching.
 
-    The cache key is every launch argument (tensors contribute their dtype,
-    scalars their value) plus launch options and device.  Scalar values are
-    strictly finer than the buckets Triton specializes on (divisible-by-16,
-    equals-1), and tensor dtype covers pointer-type specialization when one
-    ``JITFunction`` serves several dtypes (``PyCodeCache`` dedups identical
-    generated source, e.g. a dtype-agnostic add kernel for bf16 and fp16).
-    The only Triton specialization axis not covered is tensor pointer
-    *alignment*, which fast mode does not support (see ``_FAST_LAUNCH``
-    above).
+    The cache key is every launch argument (tensors contribute their dtype
+    and a 16-byte pointer-alignment bit, scalars their value) plus launch
+    options and device.  Scalar values are strictly finer than the buckets
+    Triton specializes on (divisible-by-16, equals-1); dtype covers
+    pointer-type specialization when one ``JITFunction`` serves several
+    dtypes (``PyCodeCache`` dedups identical generated source, e.g. a
+    dtype-agnostic add kernel for bf16 and fp16); the alignment bit covers
+    Triton's pointer-alignment specialization, so an unaligned view arriving
+    after an aligned prime misses the cache and takes the slow path.
     """
-    if not _triton_fast_launch_ok(triton_kernel):
+    if not _triton_direct_launch_ok(triton_kernel):
         return
-    state = triton_kernel.__dict__.get("_helion_fast_launch")
+    state = triton_kernel.__dict__.get("_helion_direct_launch")
     if state is None:
-        tensor_idx = frozenset(
+        # Argument layout (which positions are tensors) is fixed per generated
+        # kernel, so record the tensor/scalar split once here and let the hot
+        # path build keys with no per-element type checks.
+        tensor_idx = tuple(
             i for i, a in enumerate(args) if isinstance(a, torch.Tensor)
         )
-        make_key = functools.partial(_fast_launch_args_key, tensor_idx)
-        state = (make_key, {})
+        scalar_idx = tuple(
+            i for i in range(len(args)) if i not in frozenset(tensor_idx)
+        )
+        make_key = functools.partial(_direct_launch_args_key, tensor_idx, scalar_idx)
+        # Snapshot of the globals Triton captured at compile time; compared
+        # (by value, like JITFunction.run does) before every direct launch.
+        globals_guard = tuple(
+            (gdict, name, val)
+            for (name, _), (val, gdict) in triton_kernel.used_global_vals.items()
+        )
+        state = (make_key, globals_guard, {})
         # pyrefly: ignore [missing-attribute]
-        triton_kernel._helion_fast_launch = state
-    state[1][(*key, state[0](args))] = (
+        triton_kernel._helion_direct_launch = state
+    state[2][(*key, *state[0](args))] = (
         compiled.run,
         compiled.function,
         compiled.packed_metadata,
@@ -277,19 +295,27 @@ def _fast_launch_populate(
     )
 
 
-def _fast_launch_args_key(
-    tensor_idx: frozenset[int], args: tuple[object, ...]
+def _direct_launch_args_key(
+    tensor_idx: tuple[int, ...],
+    scalar_idx: tuple[int, ...],
+    args: tuple[object, ...],
 ) -> tuple[object, ...]:
-    """Per-argument fast-launch key: dtype for tensors, value for scalars.
+    """Direct-launch key: scalar values followed by per-tensor
+    ``(dtype, aligned)`` pairs, using index positions recorded at first
+    launch.
 
-    ``tensor_idx`` is recorded at first launch; if a later call passes a
-    tensor where a scalar was seen (or vice versa) the key simply won't
-    match a cached entry (tensors aren't hashable by value here, and a
-    dtype never equals a scalar), so the call takes the slow path.
+    Concatenating the two groups (rather than interleaving in argument order)
+    keeps the key unique because the tensor/scalar split is fixed per kernel.
+    If a later call passes a tensor where a scalar was seen (or vice versa),
+    ``data_ptr``/hashing raises or the key won't match, so the call safely
+    falls back to the slow path.
     """
-    return tuple(
-        a.dtype if i in tensor_idx and isinstance(a, torch.Tensor) else a  # type: ignore[union-attr]
-        for i, a in enumerate(args)
+    return (
+        *(args[i] for i in scalar_idx),
+        *(
+            (t.dtype, t.data_ptr() % 16 == 0)  # type: ignore[union-attr]
+            for t in (args[i] for i in tensor_idx)
+        ),
     )
 
 
@@ -305,32 +331,44 @@ def default_launcher(
 ) -> object:
     """Default launcher function that executes the kernel immediately.
 
-    Repeat launches of an already-compiled specialization take a fast path
-    that calls the cached ``CompiledKernel`` directly (see the
-    ``_FAST_LAUNCH`` comment above for what fast mode does not support).
-    Any exception on the fast path falls back to the full
-    ``JITFunction.run`` path, which re-validates everything.
+    Repeat launches of an already-compiled specialization call the cached
+    ``CompiledKernel`` directly (see the direct-launch comment above).  Any
+    unsupported case or exception on the direct path falls back to the full
+    ``JITFunction.run`` path, which re-validates everything.  Kernels with
+    ``triton_direct_launch=False`` never reach this function; codegen binds
+    them to :func:`default_slow_launcher` instead.
     """
-    if _FAST_LAUNCH and ptx_options is None and not kwargs and type(grid) is tuple:
-        state = triton_kernel.__dict__.get("_helion_fast_launch")  # type: ignore[union-attr]
+    if (
+        ptx_options is None
+        and not kwargs
+        and type(grid) is tuple
+        and not torch.compiler.is_compiling()
+    ):
+        state = triton_kernel.__dict__.get("_helion_direct_launch")  # type: ignore[union-attr]
         if state is not None:
             try:
-                from triton.runtime import driver
-
-                active = driver.active
-                device = active.get_current_device()  # pyrefly: ignore [missing-attribute]
-                cached = state[1].get(
+                active = _triton_driver().active
+                # pyrefly: ignore [missing-attribute]
+                device = active.get_current_device()
+                make_key, globals_guard, cache = state
+                cached = cache.get(
                     (
                         device,
                         num_warps,
                         num_stages,
                         launch_cooperative_grid,
-                        state[0](args),
+                        *make_key(args),
                     )
                 )
                 if cached is not None:
+                    for gdict, name, val in globals_guard:
+                        if gdict.get(name, _MISSING_GLOBAL) != val:
+                            # Mutated captured global: the slow path re-checks
+                            # and raises Triton's own RuntimeError.
+                            raise LookupError
+                    # pyrefly: ignore [missing-attribute]
+                    stream = active.get_current_stream(device)
                     kernel_run, kernel_function, packed_metadata, compiled = cached
-                    stream = active.get_current_stream(device)  # pyrefly: ignore [missing-attribute]
                     grid_size = len(grid)
                     kernel_run(
                         grid[0],
@@ -346,11 +384,61 @@ def default_launcher(
                     )
                     return compiled
             except Exception:
-                # Stale cache entry (device reset, ...) or bad launch args:
-                # fall through to JITFunction.run, which re-validates and
-                # raises a proper error if the launch is genuinely broken.
+                # Unseen specialization, mutated global, stale cache entry
+                # (device reset, ...), or bad launch args: fall through to
+                # JITFunction.run, which re-validates and raises a proper
+                # error if the launch is genuinely broken.
                 pass
 
+    compiled = default_slow_launcher(
+        triton_kernel,
+        grid,
+        *args,
+        num_warps=num_warps,
+        num_stages=num_stages,
+        ptx_options=ptx_options,
+        launch_cooperative_grid=launch_cooperative_grid,
+        **kwargs,
+    )
+    if (
+        compiled is not None
+        and ptx_options is None
+        and not kwargs
+        and type(grid) is tuple
+        and not torch.compiler.is_compiling()
+    ):
+        # Population is best-effort: a failure (exotic args, driver quirk)
+        # only means later calls stay on the slow path.
+        with suppress(Exception):
+            # pyrefly: ignore [missing-attribute]
+            device = _triton_driver().active.get_current_device()
+            _direct_launch_populate(
+                # pyrefly: ignore [bad-argument-type]
+                triton_kernel,
+                # pyrefly: ignore [bad-argument-type]
+                compiled,
+                (device, num_warps, num_stages, launch_cooperative_grid),
+                args,
+            )
+    return compiled
+
+
+def default_slow_launcher(
+    triton_kernel: object,
+    grid: tuple[int, ...],
+    *args: object,
+    num_warps: int,
+    num_stages: int,
+    ptx_options: str | None = None,
+    launch_cooperative_grid: bool = False,
+    **kwargs: dict,
+) -> object:
+    """Launcher that always takes the full ``JITFunction.run`` path.
+
+    Kernels compiled with ``triton_direct_launch=False`` import this as
+    their ``_default_launcher`` (see ``TritonBackend.library_imports``), so
+    no direct-launch logic runs on their call path at all.
+    """
     # For both CUDA and MTIA, use the same kernel execution
     run_kwargs: dict = {
         "grid": grid,
@@ -363,29 +451,7 @@ def default_launcher(
     if ptx_options is not None:
         run_kwargs["ptx_options"] = ptx_options
     # pyrefly: ignore [bad-argument-type]
-    compiled = _default_launcher_slow(triton_kernel, *args, **run_kwargs)
-    if (
-        _FAST_LAUNCH
-        and compiled is not None
-        and ptx_options is None
-        and not kwargs
-        and type(grid) is tuple
-    ):
-        try:
-            from triton.runtime import driver
-
-            device = driver.active.get_current_device()  # pyrefly: ignore [missing-attribute]
-            _fast_launch_populate(
-                # pyrefly: ignore [bad-argument-type]
-                triton_kernel,
-                # pyrefly: ignore [bad-argument-type]
-                compiled,
-                (device, num_warps, num_stages, launch_cooperative_grid),
-                args,
-            )
-        except Exception:
-            pass
-    return compiled
+    return _jit_function_run(triton_kernel, *args, **run_kwargs)
 
 
 def _pallas_make_block_spec(

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -5,6 +5,7 @@ from contextlib import suppress
 import contextvars
 from dataclasses import dataclass
 import enum
+import functools
 import hashlib
 import importlib
 import inspect
@@ -36,6 +37,8 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     import jax
+    from triton.compiler import CompiledKernel
+    from triton.runtime.jit import JITFunction
 
 log: logging.Logger = logging.getLogger(__name__)
 
@@ -169,6 +172,127 @@ def get_num_sm(device: torch.device, *, reserved_sms: int = 0) -> int:
     return max(available_sms - reserved_sms, 1)
 
 
+# Fast launch mode (on by default, set HELION_FAST_LAUNCH=0 to disable).
+#
+# After a specialization has been compiled once through the regular
+# ``JITFunction.run`` path, repeat launches call the cached ``CompiledKernel``
+# handle directly, skipping option parsing, argument re-specialization,
+# cache-key stringification, hook dispatch, and launch-metadata construction.
+#
+# Fast mode intentionally does NOT support (use HELION_FAST_LAUNCH=0 if you
+# need any of these):
+#
+# - Triton launch/pre-run hooks or knobs registered *after* a kernel's first
+#   launch: ``triton.knobs.runtime.launch_enter_hook/launch_exit_hook``,
+#   ``JITFunction.pre_run_hooks``, ``add_stages_inspection_hook``, and the
+#   ``debug`` / ``instrumentation_mode`` knobs are checked once when a
+#   specialization is first cached, not on every call.  Profilers (e.g.
+#   proton) that register launch hooks mid-run will not see fast-path
+#   launches.  Hooks active at first launch disable the fast path for that
+#   kernel, so registering hooks before any kernel runs still works.
+# - Changing tensor-argument pointer alignment between calls: Triton
+#   specializes on 16-byte pointer alignment, but the fast path keys only on
+#   the non-tensor (scalar) arguments.  Two calls whose tensors have the same
+#   dtype/shape/strides but different data-pointer alignment (e.g. an offset
+#   slice of a larger buffer) reuse the first call's compiled binary.  Plain
+#   PyTorch allocations are always sufficiently aligned; only offset views
+#   can be misaligned.
+# - Mutating ``used_global_vals``: ``JITFunction.run`` re-checks on every
+#   call that module-level globals captured by the kernel are unchanged; the
+#   fast path checks nothing.  (Helion-generated kernels do not capture
+#   mutable globals.)
+_FAST_LAUNCH: bool = os.environ.get("HELION_FAST_LAUNCH", "1") == "1"
+
+
+def _triton_fast_launch_ok(triton_kernel: JITFunction[object]) -> bool:
+    """One-time (per specialization) check that the fast launch path is safe.
+
+    Verifies no hook that ``JITFunction.run`` would have invoked is active
+    and no knob that feeds into launch behavior is set.  Called when caching
+    a compiled specialization, never on the per-launch hot path.
+    """
+    if triton_kernel.pre_run_hooks or triton_kernel.debug:
+        return False
+    import triton.knobs as knobs
+
+    rt = knobs.runtime
+    if rt.add_stages_inspection_hook is not None or rt.debug:
+        return False
+    for hook in (rt.launch_enter_hook, rt.launch_exit_hook):
+        # HookChain with empty ``calls`` is inactive; a plain user callable
+        # is always treated as active.
+        if hook is not None and getattr(hook, "calls", True):
+            return False
+    return not knobs.compilation.instrumentation_mode
+
+
+def _default_launcher_slow(
+    triton_kernel: JITFunction[object],
+    *args: object,
+    **run_kwargs: object,
+) -> object:
+    try:
+        return triton_kernel.run(*args, **run_kwargs)
+    except Exception as error:
+        message = str(error)
+        if "Cannot make_shape_compatible: incompatible dimensions" in message:
+            raise exc.ShapeMismatch("kernel operands", message) from error
+        raise
+
+
+def _fast_launch_populate(
+    triton_kernel: JITFunction[object],
+    compiled: CompiledKernel,
+    key: tuple[object, ...],
+    args: tuple[object, ...],
+) -> None:
+    """Cache a compiled specialization for direct launching.
+
+    The cache key is every launch argument (tensors contribute their dtype,
+    scalars their value) plus launch options and device.  Scalar values are
+    strictly finer than the buckets Triton specializes on (divisible-by-16,
+    equals-1), and tensor dtype covers pointer-type specialization when one
+    ``JITFunction`` serves several dtypes (``PyCodeCache`` dedups identical
+    generated source, e.g. a dtype-agnostic add kernel for bf16 and fp16).
+    The only Triton specialization axis not covered is tensor pointer
+    *alignment*, which fast mode does not support (see ``_FAST_LAUNCH``
+    above).
+    """
+    if not _triton_fast_launch_ok(triton_kernel):
+        return
+    state = triton_kernel.__dict__.get("_helion_fast_launch")
+    if state is None:
+        tensor_idx = frozenset(
+            i for i, a in enumerate(args) if isinstance(a, torch.Tensor)
+        )
+        make_key = functools.partial(_fast_launch_args_key, tensor_idx)
+        state = (make_key, {})
+        # pyrefly: ignore [missing-attribute]
+        triton_kernel._helion_fast_launch = state
+    state[1][(*key, state[0](args))] = (
+        compiled.run,
+        compiled.function,
+        compiled.packed_metadata,
+        compiled,
+    )
+
+
+def _fast_launch_args_key(
+    tensor_idx: frozenset[int], args: tuple[object, ...]
+) -> tuple[object, ...]:
+    """Per-argument fast-launch key: dtype for tensors, value for scalars.
+
+    ``tensor_idx`` is recorded at first launch; if a later call passes a
+    tensor where a scalar was seen (or vice versa) the key simply won't
+    match a cached entry (tensors aren't hashable by value here, and a
+    dtype never equals a scalar), so the call takes the slow path.
+    """
+    return tuple(
+        a.dtype if i in tensor_idx and isinstance(a, torch.Tensor) else a  # type: ignore[union-attr]
+        for i, a in enumerate(args)
+    )
+
+
 def default_launcher(
     triton_kernel: object,
     grid: tuple[int, ...],
@@ -179,7 +303,54 @@ def default_launcher(
     launch_cooperative_grid: bool = False,
     **kwargs: dict,
 ) -> object:
-    """Default launcher function that executes the kernel immediately."""
+    """Default launcher function that executes the kernel immediately.
+
+    Repeat launches of an already-compiled specialization take a fast path
+    that calls the cached ``CompiledKernel`` directly (see the
+    ``_FAST_LAUNCH`` comment above for what fast mode does not support).
+    Any exception on the fast path falls back to the full
+    ``JITFunction.run`` path, which re-validates everything.
+    """
+    if _FAST_LAUNCH and ptx_options is None and not kwargs and type(grid) is tuple:
+        state = triton_kernel.__dict__.get("_helion_fast_launch")  # type: ignore[union-attr]
+        if state is not None:
+            try:
+                from triton.runtime import driver
+
+                active = driver.active
+                device = active.get_current_device()  # pyrefly: ignore [missing-attribute]
+                cached = state[1].get(
+                    (
+                        device,
+                        num_warps,
+                        num_stages,
+                        launch_cooperative_grid,
+                        state[0](args),
+                    )
+                )
+                if cached is not None:
+                    kernel_run, kernel_function, packed_metadata, compiled = cached
+                    stream = active.get_current_stream(device)  # pyrefly: ignore [missing-attribute]
+                    grid_size = len(grid)
+                    kernel_run(
+                        grid[0],
+                        grid[1] if grid_size > 1 else 1,
+                        grid[2] if grid_size > 2 else 1,
+                        stream,
+                        kernel_function,
+                        packed_metadata,
+                        None,  # launch_metadata (only consumed by launch hooks)
+                        None,  # launch_enter_hook
+                        None,  # launch_exit_hook
+                        *args,
+                    )
+                    return compiled
+            except Exception:
+                # Stale cache entry (device reset, ...) or bad launch args:
+                # fall through to JITFunction.run, which re-validates and
+                # raises a proper error if the launch is genuinely broken.
+                pass
+
     # For both CUDA and MTIA, use the same kernel execution
     run_kwargs: dict = {
         "grid": grid,
@@ -191,16 +362,30 @@ def default_launcher(
     }
     if ptx_options is not None:
         run_kwargs["ptx_options"] = ptx_options
-    try:
-        return triton_kernel.run(  # type: ignore[union-attr]
-            *args,
-            **run_kwargs,
-        )
-    except Exception as error:
-        message = str(error)
-        if "Cannot make_shape_compatible: incompatible dimensions" in message:
-            raise exc.ShapeMismatch("kernel operands", message) from error
-        raise
+    # pyrefly: ignore [bad-argument-type]
+    compiled = _default_launcher_slow(triton_kernel, *args, **run_kwargs)
+    if (
+        _FAST_LAUNCH
+        and compiled is not None
+        and ptx_options is None
+        and not kwargs
+        and type(grid) is tuple
+    ):
+        try:
+            from triton.runtime import driver
+
+            device = driver.active.get_current_device()  # pyrefly: ignore [missing-attribute]
+            _fast_launch_populate(
+                # pyrefly: ignore [bad-argument-type]
+                triton_kernel,
+                # pyrefly: ignore [bad-argument-type]
+                compiled,
+                (device, num_warps, num_stages, launch_cooperative_grid),
+                args,
+            )
+        except Exception:
+            pass
+    return compiled
 
 
 def _pallas_make_block_spec(

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -192,6 +192,10 @@ class Kernel(Generic[_R]):
             for config in configs or []
         ]
         self._bound_kernels: dict[BoundKernelInMemoryCacheKey, BoundKernel] = {}
+        # Fast dispatch cache: maps a cheap, fine-grained argument key (exact
+        # dtype/shape/stride/device per tensor) directly to a BoundKernel,
+        # skipping the full specialization-key machinery on repeat calls.
+        self._dispatch_cache: dict[Hashable, BoundKernel] = {}
         self._specialize_extra: dict[
             Hashable, list[Callable[[Sequence[object]], Hashable]]
         ] = {}
@@ -272,6 +276,52 @@ class Kernel(Generic[_R]):
         self._specialize_extra[signature] = extra_fns = bound_kernel._specialize_extra()
         extra_results: tuple[Hashable, ...] = tuple([s(args) for s in extra_fns])
         return BoundKernelInMemoryCacheKey(signature, extra_results)
+
+    def _fast_dispatch_key(self, args: tuple[object, ...]) -> Hashable | None:
+        """
+        Build a cheap dispatch key for the fast-path cache in ``__call__``.
+
+        The key records exact per-argument metadata (dtype/shape/stride/device
+        for tensors, type and value for scalars), which is strictly finer than
+        the full specialization key: any two argument lists that produce
+        different full keys also produce different fast keys.  That makes it
+        safe to map a fast key directly to the BoundKernel that a full
+        ``bind()`` resolved for the same arguments.
+
+        Returns None when an argument type is not handled (tensor subclasses,
+        containers, ...), or when there is no tensor argument to pin down the
+        device; callers must then take the regular ``bind()`` path.
+        """
+        key: list[Hashable] = []
+        has_tensor = False
+        for a in args:
+            t = type(a)
+            if t is torch.Tensor or t is torch.nn.Parameter:
+                tensor = cast("torch.Tensor", a)
+                has_tensor = True
+                si = getattr(tensor, "_dynamo_static_indices", None)
+                key.append(
+                    (
+                        tensor.dtype,
+                        tensor.shape,
+                        tensor.stride(),
+                        tensor.device,
+                        None if si is None else frozenset(si),
+                    )
+                )
+            elif t is int or t is float or t is bool or t is str:
+                key.append((t, a))
+            elif a is None:
+                key.append(None)
+            elif t is torch.dtype or t is torch.device:
+                key.append(a)
+            else:
+                return None
+        if not has_tensor:
+            return None
+        if self._key_fn is not None:
+            key.append(self._key_fn(*args))
+        return tuple(key)
 
     def bind(self, args: tuple[object, ...]) -> BoundKernel[_R]:
         """
@@ -440,6 +490,17 @@ class Kernel(Generic[_R]):
         """
         if kwargs:
             args = self.normalize_args(*args, **kwargs)
+        elif self._dispatch_cache:
+            # Fast path: repeat call with argument metadata seen before. The
+            # cache is only populated by calls that already took the slow
+            # path below, so hitting it cannot skip autotuning/compilation.
+            # (The cache stays empty under TPU compile capture, so this
+            # cannot bypass auto_capture_call below.)
+            fast_key = self._fast_dispatch_key(args)
+            if fast_key is not None:
+                bound = self._dispatch_cache.get(fast_key)
+                if bound is not None and bound._run is not None:
+                    return bound._run(*args)
         if self.settings.backend == "pallas" and _TPU_COMPILE_CAPTURE:
             # Local import: _tpu_compile_capture pulls in the dynamo HOP machinery,
             # not ready when kernel.py first loads during ``import helion``.
@@ -449,7 +510,14 @@ class Kernel(Generic[_R]):
             result = auto_capture_call(self, args)
             if result is not RUN_NORMAL:
                 return cast("_R", result)
-        return self.bind(args)(*args)
+            return self.bind(args)(*args)
+        bound = self.bind(args)
+        result = bound(*args)
+        if bound._run is not None:
+            fast_key = self._fast_dispatch_key(args)
+            if fast_key is not None:
+                self._dispatch_cache[fast_key] = bound
+        return result
 
     def reset(self) -> None:
         """
@@ -457,6 +525,7 @@ class Kernel(Generic[_R]):
         recompile and re-autotune.
         """
         self._bound_kernels.clear()
+        self._dispatch_cache.clear()
 
     @property
     def jax_fn(self) -> Callable[..., Any]:

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -595,6 +595,11 @@ class _Settings:
             _env_get_bool, "HELION_TRITON_DO_NOT_SPECIALIZE", False
         )
     )
+    triton_direct_launch: bool = dataclasses.field(
+        default_factory=functools.partial(
+            _env_get_bool, "HELION_TRITON_DIRECT_LAUNCH", True
+        )
+    )
 
 
 class Settings(_Settings):
@@ -697,6 +702,22 @@ class Settings(_Settings):
             "memory-bound kernels (vectorized loads rely on inner stride being "
             "specialized to constexpr 1). Only takes effect when static_shapes=False. "
             "Set HELION_TRITON_DO_NOT_SPECIALIZE=1 to enable globally."
+        ),
+        "triton_direct_launch": (
+            "If True (default), repeat launches of an already-compiled Triton "
+            "specialization skip JITFunction.run and call the cached compiled "
+            "kernel directly, substantially reducing per-call launch overhead. "
+            "Triton-only; accepted but ignored on other backends. The direct "
+            "path automatically falls back to the full JITFunction.run path "
+            "when it cannot guarantee an identical launch: unaligned (non-16-"
+            "byte) tensor pointer arguments, mutated used_global_vals, extra "
+            "launch kwargs (e.g. ptx_options), active Triton launch/pre-run "
+            "hooks or debug/instrumentation knobs, and torch.compile tracing "
+            "all take the slow path. Not supported (use "
+            "triton_direct_launch=False or HELION_TRITON_DIRECT_LAUNCH=0): "
+            "Triton launch hooks or knobs registered *after* a kernel's first "
+            "launch are not re-checked per call, so profilers attaching "
+            "mid-run will miss direct launches."
         ),
         "print_output_code": "If True, print the output code of the kernel to stderr.",
         "print_repro": "If True, print Helion kernel code, config, and caller code to stderr as a standalone repro script.",

--- a/pretuned_kernels/per_token_group_fp8_quant/per_token_group_fp8_quant.py
+++ b/pretuned_kernels/per_token_group_fp8_quant/per_token_group_fp8_quant.py
@@ -11,6 +11,8 @@ converted from vLLM's per-hardware config JSON).
 from __future__ import annotations
 
 import torch
+import triton
+import triton.language as tl
 
 import helion
 import helion.experimental
@@ -125,6 +127,95 @@ def _per_token_group_fp8_quant_vllm(
     )
 
 
+@triton.jit
+def _per_token_group_quant_fp8(
+    # Pointers to inputs and output
+    y_ptr,
+    y_q_ptr,
+    y_s_ptr,
+    group_size,
+    # Num columns of y
+    y_num_columns,
+    y_row_stride,
+    # Avoid to divide zero
+    eps,
+    # Information for float8
+    fp8_min: tl.constexpr,
+    fp8_max: tl.constexpr,
+    use_ue8m0: tl.constexpr,
+    # Meta-parameters
+    BLOCK: tl.constexpr,
+):
+    """A Triton-accelerated function to perform per-token-group
+    quantization on a tensor.
+    This function converts the tensor values into float8 values.
+    """
+    groups_per_row = y_num_columns // group_size
+
+    # Map the program id to the row of X and Y it should compute.
+    g_id = tl.program_id(0)
+    row = g_id // groups_per_row
+    row_g_id = g_id % groups_per_row
+
+    # Ensure offset calculations use int64 to prevent overflow
+    y_ptr_offset = (row.to(tl.int64) * y_row_stride) + (
+        row_g_id.to(tl.int64) * group_size
+    )
+    y_ptr += y_ptr_offset
+
+    y_q_ptr_offset = g_id.to(tl.int64) * group_size
+    y_q_ptr += y_q_ptr_offset
+    y_s_ptr += g_id
+
+    cols = tl.arange(0, BLOCK)  # N <= BLOCK
+    mask = cols < group_size
+
+    y = tl.load(y_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+    # Quant
+    # Use multiply-by-reciprocal instead of division to match PyTorch's
+    # tensor/scalar division precision (GPU fast-division for constexpr
+    # divisors can introduce 1-ULP error that flips FP8 quantization at
+    # representable-value boundaries).
+    _absmax = tl.maximum(tl.max(tl.abs(y)), eps)
+    scale_raw = _absmax * (1.0 / fp8_max)
+    y_s = tl.math.exp2(tl.ceil(tl.log2(scale_raw))) if use_ue8m0 else scale_raw
+    y_q = tl.clamp(y / y_s, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
+
+    tl.store(y_q_ptr + cols, y_q, mask=mask)
+    tl.store(y_s_ptr, y_s)
+
+
+def _per_token_group_fp8_quant_triton(
+    input: torch.Tensor,  # noqa: A002
+    output_q: torch.Tensor,
+    output_s: torch.Tensor,
+    group_size: int,
+    eps: float,
+    fp8_min: float,
+    fp8_max: float,
+    scale_ue8m0: bool,
+    dummy_is_scale_transposed: bool = False,
+    dummy_is_tma_aligned: bool = False,
+) -> None:
+    """vLLM's Triton per-token-group FP8 quant kernel (mutates outputs)."""
+    num_tokens, hidden_size = input.shape
+    num_groups = num_tokens * (hidden_size // group_size)
+    block = triton.next_power_of_2(group_size)
+    _per_token_group_quant_fp8[(num_groups,)](
+        input,
+        output_q,
+        output_s,
+        group_size,
+        hidden_size,
+        input.stride(0),
+        eps,
+        fp8_min=fp8_min,
+        fp8_max=fp8_max,
+        use_ue8m0=scale_ue8m0,
+        BLOCK=block,
+    )
+
+
 def _baselines() -> list[tuple[str, object]]:
     """Baselines main() benchmarks against (torch always; vLLM when installed).
 
@@ -134,6 +225,7 @@ def _baselines() -> list[tuple[str, object]]:
     out: list[tuple[str, object]] = [
         ("torch", _per_token_group_fp8_quant_torch),
         ("torch_compile", torch.compile(_per_token_group_fp8_quant_torch)),
+        ("triton", _per_token_group_fp8_quant_triton),
     ]
     if _HAS_VLLM:
         out.append(("vllm", _per_token_group_fp8_quant_vllm))
@@ -162,7 +254,11 @@ def correctness_check() -> None:
     torch.testing.assert_close(oq.float(), oq_ref.float(), rtol=0.2, atol=0.2)
 
 
-def main(verbose: bool = True) -> dict:
+def main(
+    verbose: bool = True,
+    cudagraph: bool | None = None,
+    limit: int | None = None,
+) -> dict:
     import os
     import sys
 
@@ -178,6 +274,8 @@ def main(verbose: bool = True) -> dict:
     hidden_sizes = [2048, 4096, 5120]
     num_tokens_list = [1, 4, 16, 64, 256, 1024, 2048, 8192]
     shapes = [(t, h) for h in hidden_sizes for t in num_tokens_list]
+    if limit is not None:
+        shapes = shapes[:limit]
     baselines = _baselines()
 
     def make_calls(shape: tuple) -> tuple:
@@ -227,11 +325,26 @@ def main(verbose: bool = True) -> dict:
     return run_sweep(
         shapes,
         make_calls,
-        use_cudagraph=use_cudagraph(),
+        use_cudagraph=use_cudagraph() if cudagraph is None else cudagraph,
         verbose=verbose,
         shape_header=f"{'tokens':>7s}  {'hidden':>6s}  {'group':>6s}",
     )
 
 
 if __name__ == "__main__":
-    main()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--no-cudagraph",
+        action="store_true",
+        help="benchmark with plain do_bench instead of CUDA graphs",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="only run the first N shapes of the sweep",
+    )
+    cli_args = parser.parse_args()
+    main(cudagraph=not cli_args.no_cudagraph, limit=cli_args.limit)

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1290,6 +1290,14 @@ class TestLauncher(TestCase):
         torch.accelerator.synchronize()
         torch.testing.assert_close(out, unaligned + unaligned)
 
+        # Interleave the two alignments: once both variants have been seen,
+        # repeat calls (which may each hit a cached fast path keyed on
+        # alignment) must keep dispatching to the right specialization.
+        for _ in range(3):
+            torch.testing.assert_close(add(aligned, aligned), aligned + aligned)
+            torch.testing.assert_close(add(unaligned, unaligned), unaligned + unaligned)
+        torch.accelerator.synchronize()
+
     def test_unaligned_writes_to_user_out_arg_land_on_original(self) -> None:
         """If the kernel writes to an unaligned user-supplied output
         buffer, those writes must land on the user's tensor (not on
@@ -1330,9 +1338,11 @@ class TestLauncher(TestCase):
         "exist in ref-eager mode"
     )
     def test_used_global_vals_mutation_raises(self) -> None:
-        """Mutating a tracked global (e.g. a ``_BLOCK_SIZE_*``
-        constexpr captured via ``used_global_vals``) between calls
-        must trigger ``RuntimeError`` from Triton's own guard."""
+        """Mutating or deleting a tracked global (e.g. a
+        ``_BLOCK_SIZE_*`` constexpr captured via ``used_global_vals``)
+        between calls must trigger ``RuntimeError`` from Triton's own
+        guard, and restoring the original value must return the kernel
+        to a working (and numerically correct) state."""
 
         @helion.kernel(
             static_shapes=True,
@@ -1360,13 +1370,81 @@ class TestLauncher(TestCase):
 
         (name, _gid), (val, gdict) = next(iter(ugv.items()))
         original = gdict[name]
-        gdict[name] = "MUTATED_NOPE"
         try:
+            gdict[name] = "MUTATED_NOPE"
+            with self.assertRaises(RuntimeError):
+                add(x, x)
+                torch.accelerator.synchronize()
+
+            del gdict[name]
             with self.assertRaises(RuntimeError):
                 add(x, x)
                 torch.accelerator.synchronize()
         finally:
             gdict[name] = original
+
+        # Restoring the original value must fully recover: repeated calls
+        # (which may hit a cached fast path) stay numerically correct.
+        for _ in range(2):
+            out = add(x, x)
+            torch.accelerator.synchronize()
+            torch.testing.assert_close(out, x + x)
+
+    @skipIfRefEager(
+        "Inspects the bound kernel's Triton JITFunction, which doesn't "
+        "exist in ref-eager mode"
+    )
+    def test_direct_launch_cache_engages(self) -> None:
+        """With ``triton_direct_launch`` on (the default), the first
+        launch must populate the direct-launch cache with one entry per
+        distinct specialization, so repeat calls skip
+        ``JITFunction.run``.  This is the perf half of the contract:
+        the other tests prove fallback correctness, this one proves the
+        fast path actually engages."""
+
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[1024], num_warps=4, num_stages=2),
+        )
+        def add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for i in hl.tile(out.size(0)):
+                out[i] = x[i] + y[i]
+            return out
+
+        n = 1024
+        base = torch.randn(n + 4, device=DEVICE, dtype=torch.float32)
+        aligned = base[:n]
+        unaligned = base[1 : n + 1]
+
+        add(aligned, aligned)
+        torch.accelerator.synchronize()
+
+        from triton.runtime.jit import JITFunction
+
+        bound = next(iter(add._bound_kernels.values()))  # type: ignore[attr-defined]
+        jit_fn = next(
+            v for v in bound._run.__globals__.values() if isinstance(v, JITFunction)
+        )
+        state = jit_fn.__dict__.get("_helion_direct_launch")
+        if state is None:
+            self.skipTest(
+                "Direct launch did not engage (disabled via setting/env, or "
+                "hooks/knobs active in this run)"
+            )
+        _make_key, cache = state
+        self.assertEqual(len(cache), 1)
+
+        # A repeat call with the same specialization must reuse the entry...
+        torch.testing.assert_close(add(aligned, aligned), aligned + aligned)
+        torch.accelerator.synchronize()
+        self.assertEqual(len(cache), 1)
+
+        # ...while a second specialization (unaligned pointers) gets its own
+        # entry after its slow-path prime, keyed apart by the alignment bit.
+        torch.testing.assert_close(add(unaligned, unaligned), unaligned + unaligned)
+        torch.accelerator.synchronize()
+        self.assertEqual(len(cache), 2)
 
     def test_correct_result_on_each_cuda_device(self) -> None:
         """The same kernel called on ``cuda:0`` then ``cuda:1`` must


### PR DESCRIPTION
## Motivation

`python pretuned_kernels/per_token_group_fp8_quant/per_token_group_fp8_quant.py --no-cudagraph`
benchmarks Helion against the Triton baseline in eager mode. With cudagraphs
Helion already wins, so the gap is pure host-side launch overhead, not GPU
kernel time. Before this PR a Helion kernel call cost **~57µs** on H100 vs
**~16µs** for the raw Triton baseline wrapper:

| Component | Cost |
|---|---|
| `Kernel.__call__` → `bind()` (specialization key build + lookup) | ~23µs |
| `BoundKernel.__call__` → generated `_run` wrapper | ~2µs |
| `default_launcher` → `JITFunction.run` host work (option parsing, arg re-specialization, cache-key stringification, hook dispatch, launch-metadata construction) | ~11µs |
| `CompiledKernel.run` floor (packing + `cuLaunchKernel`) | ~5.6µs |
| misc (device/stream queries, tuple building) | remainder |

After this PR the same call takes **~12µs** (launcher path alone ~9.7µs), and
the benchmark geomean vs the best baseline went from **0.575x to 1.21x**
(18/24 shapes win vs the Triton baseline, 24/24 vs vLLM). The optimization
works for interleaved calls with different shapes/dtypes/alignments, not just
repeated identical calls — every distinct specialization gets its own cache
entry.

## Design

Two independent caching layers, one per dispatch level:

### 1. Fast dispatch cache (`helion/runtime/kernel.py`)

`Kernel.__call__` previously computed the full specialization key
(`_specialization_key` per arg + `_specialize_extra` extractors) on every
call to find the `BoundKernel`. Now `Kernel` keeps a `_dispatch_cache` that
maps a cheap, exact per-argument key — `(dtype, shape, stride, device,
_dynamo_static_indices)` for tensors, `(type, value)` for scalars — directly
to the `BoundKernel` a prior full `bind()` resolved for the same arguments.

The fast key is strictly *finer* than the full specialization key: any two
argument lists that differ under the full key also differ under the fast key,
so a hit can never dispatch to the wrong `BoundKernel`. Unhandled argument
types (tensor subclasses, containers), kwargs, or a missing tensor argument
return `None` and take the regular `bind()` path. The cache is only populated
after a successful slow-path call (so it can never skip autotuning or
compilation), is bypassed under TPU compile capture, respects user
`key=` functions, and is cleared by `Kernel.reset()`.

### 2. Direct launch (`helion/runtime/__init__.py`), exposed as the `triton_direct_launch` setting

After a specialization has compiled once through the regular
`JITFunction.run` path, `default_launcher` caches `(compiled.run,
compiled.function, compiled.packed_metadata)` and repeat launches invoke the
compiled kernel directly — skipping all of `JITFunction.run`'s per-call host
work.

**Setting** (follows the `fast_math`/`static_shapes` pattern in
`helion/runtime/settings.py`):

- `triton_direct_launch: bool = True`; opt out per-kernel with
  `@helion.kernel(triton_direct_launch=False)` or globally with
  `HELION_TRITON_DIRECT_LAUNCH=0`.
- Triton-only; accepted but ignored on other backends.
- Resolved **once at codegen time**: `TritonBackend.library_imports` emits
  `from helion.runtime import default_slow_launcher as _default_launcher`
  for opted-out kernels, so the per-call path pays zero cost for the choice.

**Correctness model — hazards are cache-key elements, not runtime checks.**
The two launch hazards cannot be caught after the fact: a misaligned launch
into an alignment-specialized binary surfaces as an *asynchronous* CUDA error
that poisons the context, and a stale captured global silently computes wrong
numerics. So instead of guarding the launch, every hazard is folded into the
cache key, making any deviation an ordinary cache miss that falls back to the
slow path (which re-validates everything and raises proper errors):

- **scalar values** — strictly finer than Triton's specialization buckets
  (divisible-by-16, equals-1);
- **tensor dtypes** — one `JITFunction` can serve several dtypes because
  `PyCodeCache` dedups identical generated source (e.g. a dtype-agnostic add
  kernel for bf16/fp16);
- **16-byte pointer alignment bit per tensor** — covers Triton's
  pointer-alignment specialization; an unaligned view arriving after an
  aligned prime misses the cache;
- **current value of every captured global** (`used_global_vals`) — a mutated
  or deleted `_BLOCK_SIZE_*` constexpr misses the cache and the slow path
  raises Triton's own `RuntimeError`;
- **device, num_warps, num_stages, launch_cooperative_grid** — key prefix.

On first launch the key builder is compiled per kernel with `eval` (the same
technique as Triton's own `binder`), e.g.:

```python
lambda a: (a[3], a[4], a[0].dtype, not a[0].data_ptr() & 15,
           a[1].dtype, not a[1].data_ptr() & 15,
           _g0.get('_BLOCK_SIZE_0', _MISSING))
```

This bakes the tensor/scalar split and the globals lookups into one flat
expression — no per-element type checks, no separate globals-guard loop —
roughly halving key-build time (~1.9µs → ~1.0µs including the dict lookup)
versus a generic generator plus guard loop.

**Auto-fallback cases** (fast path silently defers to `JITFunction.run`):

- unaligned (non-16-byte) tensor pointer arguments
- mutated or deleted `used_global_vals`
- unseen scalar value / dtype / device / launch-option combination
- extra launch kwargs (e.g. `ptx_options`), non-tuple grids
- `torch.compile` tracing (`torch.compiler.is_compiling()` bail-out — dynamo
  cannot trace `__dict__.get` on a `JITFunction`)
- Triton launch/pre-run hooks, `debug`, `add_stages_inspection_hook`, or
  `instrumentation_mode` active when a specialization is first cached
- any exception while building the key (e.g. tensor passed where a scalar was
  seen) — the whole fast path sits in one `try/except` that falls through to
  the slow path

**The one intentional gap** (documented; requires opting out): Triton launch
hooks or knobs registered *after* a kernel's first launch are not re-checked
per call, so a profiler attaching launch hooks mid-run will not observe
direct launches. Use `triton_direct_launch=False` for kernels that must
always be visible to such hooks.

**Cache invalidation:** `_clear_triton_jit_cache` (post-autotune recompile
from the ephemeral cache dir) also drops `_helion_direct_launch`, so the
direct-launch cache can never pin an ephemeral autotuning binary.

## Performance accounting

Measured on H100, `BoundKernel` call path for a 1-tensor add kernel:

| Version | Launcher path |
|---|---|
| unsafe first cut (no alignment/globals/dtype handling — had CI failures) | ~15.5µs full-call equivalent |
| correctness fixes, generator key + guard loop | ~12.4µs |
| this PR (codegen'd flat key) | **~9.7µs** |

The `t.data_ptr()` call per tensor (~96ns) is irreducible: alignment
genuinely varies per call with tensor storage, and the failure mode of
skipping it is an async CUDA error. `not ptr & 15` avoids the modulo.

## CI fixes folded in

The initial direct-launch commit caused three CI failure classes, all fixed
by the key design above:

1. **`CUDA error: misaligned address`** across hundreds of tests — the key
   ignored pointer alignment, so an unaligned view reused an
   alignment-specialized binary. Fixed by the per-tensor alignment bit.
2. **`test_used_global_vals_mutation_raises`** — the direct path skipped
   Triton's captured-globals check, so mutating `_BLOCK_SIZE_*` no longer
   raised. Fixed by putting current global values in the key.
3. **XPU `torch._dynamo.exc.Unsupported: ... __dict__ get`** — dynamo cannot
   trace the cache lookup. Fixed by the `torch.compiler.is_compiling()`
   guard.

## Tests

`test/test_misc.py::TestLauncher` — launcher-agnostic contract tests:

- `test_unaligned_input_produces_correct_output` — unaligned tensor after an
  aligned prime stays correct, including interleaved aligned/unaligned calls
  once both specializations are cached.
- `test_unaligned_writes_to_user_out_arg_land_on_original` — writes to an
  unaligned user-supplied output buffer land on the user's tensor.
- `test_used_global_vals_mutation_raises` — mutating **or deleting** a
  captured global raises Triton's `RuntimeError`; restoring the original
  value fully recovers (repeat calls hit the cached fast path and stay
  numerically correct).
- `test_direct_launch_cache_engages` — the perf half of the contract: the
  cache populates on first launch (one entry), a repeat call reuses it (still
  one entry), and an unaligned call adds a second entry. Catches a silent
  every-call-takes-the-slow-path regression that correctness tests cannot.
  Skips itself when the setting is off or hooks are active.
- `test_correct_result_on_each_cuda_device` — per-device correctness on
  multi-GPU hosts.

## Docs

- `docs/api/settings.md`: `Settings.triton_direct_launch` autoattribute
  (default, Triton-only scope, auto-fallback list, the not-auto-detected
  hook case) plus a `HELION_TRITON_DIRECT_LAUNCH` row in the env-var table.
- `helion/runtime/settings.py`: matching `__slots__` docstring entry.
- `helion/runtime/__init__.py`: module-level design comment covering the
  direct-launch mechanism and its fallback semantics.

## Files changed

| File | Change |
|---|---|
| `helion/runtime/kernel.py` | `_dispatch_cache` + `_fast_dispatch_key` fast dispatch in `Kernel.__call__`; cleared in `reset()` |
| `helion/runtime/__init__.py` | direct-launch machinery: `default_launcher` fast path, `default_slow_launcher`, `_direct_launch_populate`, compiled per-kernel key builder, hook/knob prime-time checks |
| `helion/runtime/settings.py` | `triton_direct_launch` setting + docs |
| `helion/_compiler/backend.py` | codegen-time launcher selection in `library_imports`; direct-launch cache invalidation in `_clear_triton_jit_cache` |
| `docs/api/settings.md` | setting documentation + env-var table row |
| `test/test_misc.py` | `TestLauncher` contract tests |
| `pretuned_kernels/per_token_group_fp8_quant/per_token_group_fp8_quant.py` | benchmark used to drive/validate the work |