### PR TITLE
[autotuner][sm100] B200 matmul: subsume the table with the general formula

### DIFF
--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -16,6 +16,7 @@ from .cute import CuteTileVecWarpPerRowHeuristic
 from .cute import CuteTileVecWarpReduceHeuristic
 from .pallas import PallasMatmulF32NoTilingSeedHeuristic
 from .pallas import PallasMatmulNoTilingSeedHeuristic
+from .triton import TritonB200FormulaMatmulHeuristic
 from .triton import TritonB200MatmulHeuristic
 from .triton import TritonH100MatmulHeuristic
 from .triton import TritonMatmulReductionEpilogueHeuristic
@@ -54,6 +55,9 @@ HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
         TritonH100MatmulHeuristic,
         TritonSkinnyGemmHeuristic,
         TritonB200MatmulHeuristic,
+        # The sm100 formula, promoted; registered after the table so it wins the
+        # last-promote-wins compiler_default_config loop.
+        TritonB200FormulaMatmulHeuristic,
         TritonMatmulReductionEpilogueHeuristic,
         TritonStandardReductionHeuristicSM90,
         TritonStandardReductionHeuristicSM100,

--- a/helion/_compiler/autotuner_heuristics/triton.py
+++ b/helion/_compiler/autotuner_heuristics/triton.py
@@ -39,6 +39,9 @@ log = logging.getLogger(__name__)
 
 _B200_MATMUL_HEURISTICS_PATH = Path(__file__).resolve().parent / "matmul_b200.json"
 
+# Stand-in ceiling for an arch with no TMEM (sm90): makes a TMEM fit-check vacuously true.
+_INF = float("inf")
+
 
 # Heuristic was originally contributed by @umechand-amd
 # in https://github.com/pytorch/helion/pull/2357.
@@ -136,6 +139,45 @@ def _single_2d_static_matmul_fact(config_spec: ConfigSpec) -> MatmulFact | None:
     if fact.static_m is None or fact.static_n is None or fact.static_k is None:
         return None
     if (fact.m_block_id, fact.n_block_id, fact.k_block_id) != (0, 1, 2):
+        return None
+    return fact
+
+
+def _batched_static_matmul_fact(config_spec: ConfigSpec) -> MatmulFact | None:
+    """The H100 eligibility precondition — broader than the 2-D-only
+    ``_single_2d_static_matmul_fact``: it admits an arbitrary, possibly **BATCHED** matmul. The
+    requirements:
+      - exactly one ``MatmulFact`` with **static** M/N/K (the dot's own dims) and three distinct
+        M/N/K block-ids that are real tunable axes;
+      - every **other** tunable block axis is a BATCH / OUTER grid axis (present in
+        ``grid_block_ids``) — a no-data-reuse parallel axis the seed pins to 1
+        (``_h100_build_block_sizes`` floors every non-M/N/K axis), which is exactly what keeps the
+        register-budget tile valid for a batched dot (the fp32 accumulator is
+        ``[batch_blocks…, bm, bn]``; the budget sizes ``bm·bn`` assuming each batch block is 1).
+    An extra tunable axis that is NEITHER M/N/K nor a grid axis (some inner loop we do not model)
+    ⇒ decline, so the seed never mis-pins an axis it does not understand. The dot's ndim is NOT
+    constrained (a 2-D ``matmul`` and a 3-D ``baddbmm`` are both fine), only the block-axis ROLES.
+
+    Fires on: plain ``matmul`` / ``fp8_gemm``; ``broadcast_matmul`` (batch folded into M);
+    ``mamba2_chunk_state`` (batch pre-pinned to 1 by the author — its batch axes aren't tunable);
+    and ``bmm`` / any static batched dot that leaves its batch axis tunable. Declines a dynamic
+    (``static_shapes=False``) or jagged kernel (no static M/N/K) — e.g. ``grouped_gemm``.
+    """
+    facts = config_spec.matmul_facts
+    if len(facts) != 1:
+        return None
+    fact = facts[0]
+    if fact.static_m is None or fact.static_n is None or fact.static_k is None:
+        return None
+    mnk = (fact.m_block_id, fact.n_block_id, fact.k_block_id)
+    if None in mnk or len(set(mnk)) != 3:
+        return None
+    valid = set(config_spec.block_sizes.valid_block_ids())
+    if not set(mnk) <= valid:
+        return None
+    # Every tunable axis must be the dot's M/N/K or a batch/outer grid axis (pinnable to 1).
+    allowed = set(mnk) | set(config_spec.grid_block_ids)
+    if any(bid not in allowed for bid in valid):
         return None
     return fact
 
@@ -260,9 +302,12 @@ def _seed_config_for_config_spec(config_spec: ConfigSpec) -> Config | None:
 
 
 class TritonB200MatmulHeuristic(AutotunerHeuristic):
+    # DEMOTED (promote=False): the general TritonB200FormulaMatmulHeuristic subsumes this table
+    # (faster on every shape the table fires on, and covers the shapes it declines). Kept as an
+    # unpromoted search seed.
     name = "triton_b200_matmul"
     backend = "triton"
-    promote_seed_to_default = True
+    promote_seed_to_default = False
     HARDWARE_TARGETS = (("cuda", "sm100"),)
 
     @classmethod
@@ -280,6 +325,649 @@ class TritonB200MatmulHeuristic(AutotunerHeuristic):
         device_ir: DeviceIR,
     ) -> Config | None:
         return _seed_config_for_config_spec(env.config_spec)
+
+
+def _h100_build_block_sizes(
+    spec: ConfigSpec, fact: MatmulFact, bm: int, bn: int, bk: int
+) -> list[int]:
+    """Map ``(bm, bn, bk)`` onto the spec's block_sizes by the fact's M/N/K block-ids,
+    clamping each to its valid [min, max] (other axes — none for a clean 2-D fact — floored)."""
+    targets = {fact.m_block_id: bm, fact.n_block_id: bn, fact.k_block_id: bk}
+    out: list[int] = []
+    for i in range(len(spec.block_sizes)):
+        bs_spec = cast("BlockSizeSpec", spec.block_sizes[i])
+        v = targets.get(bs_spec.block_id)
+        if v is None:
+            v = max(1, bs_spec.min_size, bs_spec.autotuner_min)
+        v = max(v, bs_spec.min_size, bs_spec.autotuner_min)
+        v = min(v, bs_spec.max_size)
+        out.append(v)
+    return out
+
+
+def _h100_pinned_grid(env: CompileEnvironment, fact: MatmulFact) -> int:
+    """Product of any PINNED (block_size=1) grid axes other than the dot's M/N tiles — 1 for a
+    bare GEMM, ``batch·nchunks·nheads`` for mamba's fused dot. These already saturate the SMs, so
+    the occupancy fill counts them (else it shrinks an already-grid-saturated dot's tile) and the
+    num_stages cap keys on them (the batched-dot signature)."""
+    pinned_grid = 1
+    for bid in env.config_spec.grid_block_ids:
+        if bid in (fact.m_block_id, fact.n_block_id):
+            continue
+        size = env.block_sizes[bid].size
+        if isinstance(size, (int, torch.SymInt)):
+            pinned_grid *= max(1, env.size_hint(size))
+    return pinned_grid
+
+
+def _h100_config(
+    spec: ConfigSpec,
+    fact: MatmulFact,
+    bm: int,
+    bn: int,
+    bk: int,
+    num_warps: int,
+    num_stages: int,
+    l2_grouping: int = 1,
+    extra: dict[str, Any] | None = None,
+) -> Config:
+    """Assemble a Config from a tile tuple (emit l2_groupings only when grouping > 1).
+    ``extra`` carries any subclass-emitted fields (e.g. the sm100 Blackwell levers:
+    epilogue_subtile / indexing / range_warp_specializes) merged on top."""
+    cfg: dict[str, Any] = {
+        "block_sizes": _h100_build_block_sizes(spec, fact, bm, bn, bk),
+        "num_warps": num_warps,
+        "num_stages": num_stages,
+    }
+    if l2_grouping > 1:
+        cfg["l2_groupings"] = [l2_grouping]
+    if extra:
+        cfg.update(extra)
+    return Config(**cfg)
+
+
+class TritonH100MatmulHeuristic(AutotunerHeuristic):
+    """H100 (sm90) seed for any static (possibly batched) ``MatmulFact`` — a budget/roofline
+    ``_matmul_tile`` FORMULA (no lookup) so real GEMMs don't fall back to the catastrophic
+    ``[16,16,16]`` default. Fires on every ``_batched_static_matmul_fact`` (matmul / fp8_gemm /
+    bmm / mamba's fused dot / …) and pins every batch/outer axis to 1, so a batched dot and a bare
+    GEMM are the same case (the pinned grid then drives the saturation levers).
+
+    ``promote_seed_to_default=True``: the budget formula owns the no-autotune compiler default (as
+    well as seeding the autotuner), so a real GEMM never falls back to the ``[16,16,16]`` fragment
+    default on either sm90 or sm100 — the sm100 subclass inherits this promotion unchanged. Budget
+    constants are class attributes so a hardware-specific subclass can re-tune them (and add emission
+    via ``_extra_config_fields``) without touching this sm90 path."""
+
+    name = "triton_h100_matmul"
+    backend = "triton"
+    promote_seed_to_default = True
+    # Annotated so a hardware-specific subclass may override the arch (e.g. sm100).
+    HARDWARE_TARGETS: ClassVar[tuple[tuple[str, str], ...]] = (("cuda", "sm90"),)
+
+    # --- budget/roofline constants (the re-tune surface; a subclass overrides for other hardware) ---
+    # Accumulator budget = capacity of wherever the fp32 [bm,bn] accumulator lives. On sm90 it's the
+    # register file (32768 = 128 regs/thread × 256), which is why H100 caps the tile at [128,256]. On
+    # sm100 the accumulator lives in tensor memory instead, so the tile is grown against TMEM_BUDGET
+    # (step 2.7) rather than this.
+    ACC_BUDGET = 32768  # fp32 [bm,bn] accumulator elems, register-file capacity
+    SMEM_BUDGET = 228 * 1024  # per-CTA shared memory ceiling (bytes)
+    DOT_MIN = 16  # tl.dot min M/N
+    BASE_BM_CAP = 128  # base clamp on bm (wide-N aspect: bn = 2*bm, N is the coalesced store axis)
+    BASE_BN_CAP = 256  # base clamp on bn
+    WARPS_HI_ELEMS = 16384  # tile elems at/above which num_warps ramps 4 -> 8
+    SAT_WAVES = (
+        4  # pinned grid >= SAT_WAVES*num_sm SM-waves = occupancy-saturated batched dot
+    )
+    SAT_TILE_BM = 64  # saturated batched-dot occupancy tile cap (bm)
+    SAT_TILE_BN = 128  # saturated batched-dot occupancy tile cap (bn)
+    SAT_NUM_WARPS = (
+        None  # sm100 forces min-warps on a saturated tiny tile (None = use the ramp)
+    )
+    SAT_MAX_STAGES = (
+        2  # num_stages ceiling for a saturated batched dot (occupancy-bound)
+    )
+    WAVE_FILL_FLOOR = (
+        64  # min tile-axis size during wave-fill shrink (DOT_MIN for tiny-M decode)
+    )
+    WAVE_FULL = (
+        0.8  # wave-quant occupancy target; below it, shrink tile to fill the machine
+    )
+    WAVE_FILL_STRICT = False  # sm100 requires a STRICT weff gain to shrink; H100 keeps >= (see shrink loop)
+    # --- conservative resource accounting ---
+    # Bytes/element of the SMEM buffer the epilogue stages the fp32 accumulator through on its way to
+    # registers (see _smem_bytes). This is NOT Blackwell-specific: measured on an sm90 target, a
+    # [128,256,64] bf16 dot with an fp32 output reports shared=131072 == bm*bn*4, exactly as sm100 does.
+    # It is set here on the base for that reason, and it is a NO-OP on sm90 in practice: sm90's
+    # accumulator lives in the register file (ACC_BUDGET=32768), so the largest tile it can emit is
+    # bm*bn=32768 -> 131072 B = 56% of the 232448 B cap. Binding would need bm*bn > 58112, which sm90
+    # cannot reach; verified 0/21294 emitted sm90 configs are affected. sm100 binds only because
+    # TMEM_BUDGET doubles the reachable tile to bm*bn=65536 (262144 B > cap) -- a bigger tile, not a
+    # different epilogue.
+    EPILOGUE_ACC_ITEMSIZE = 4
+    # Whether to ENFORCE the SMEM budget by shrinking the tile (steps 4'/5' and the alt-1 gate).
+    # Separate from the term above, and deliberately OFF on sm90: there `_smem_bytes` reduces to the
+    # operand ring charged at full num_stages, which OVER-estimates -- its worst case [16,2048,16] fp32
+    # computes 264192 but the hardware measures 132096 and fits. Enforcing would shrink tiles for a
+    # phantom overflow and break the sm90 byte-identical freeze.
+    ENFORCE_SMEM_BUDGET = False
+    # Slack for allocations too small to model individually (mbarriers are 8B each). Measured: an
+    # otherwise-exact bound is violated by exactly 16 B, so a formula must not be tight to the byte.
+    SMEM_SLACK = 0
+    # Per-CTA tensor-memory ceiling in BYTES. None = no tensor memory on this arch.
+    TMEM_BUDGET = None
+    # Smallest block_m that lowers to tcgen05 (below it the dot uses a non-TMEM path, so TMEM is free).
+    TCGEN05_MIN_BM = 64
+    BK_CAP = (
+        256  # max block_k (deep K amortizes small-M; past this returns vanish / spill)
+    )
+    PIPE = 4  # baseline K-loop pipeline depth (bk sized to fit >= this many stages)
+    MAX_STAGES = 6  # num_stages ceiling for the latency-bound (non-saturated) regime
+    L2_TALL_RATIO = (
+        3  # l2_grouping=2 when the tile-grid is tall (grid_m >= this * grid_n)
+    )
+
+    @classmethod
+    def _extra_config_fields(
+        cls,
+        m: int,
+        n: int,
+        k: int,
+        itemsize: int,
+        bm: int,
+        bn: int,
+        bk: int,
+        num_warps: int,
+        num_stages: int,
+        l2_grouping: int,
+        pinned_grid: int,
+        num_sm: int,
+    ) -> dict[str, Any]:
+        """Hook for hardware-specific extra Config fields (e.g. sm100 Blackwell levers). The sm90
+        base emits none — only block_sizes/num_warps/num_stages/l2_groupings."""
+        return {}
+
+    @classmethod
+    def _tmem_bytes(cls, bm: int, bn: int, bk: int, itemsize: int) -> int:
+        """Tensor-memory BYTES to reserve for a ``[bm,bn,bk]`` tile -- the TMEM analogue of
+        ``_smem_bytes``, checked against ``TMEM_BUDGET`` the same way. 0 when the arch has no TMEM.
+
+        Deliberately a crude OVER-estimate rather than a model of where Triton places things:
+
+            fp32 accumulator [bm,bn]  +  A operand [bm,bk] at its input dtype
+
+        A is charged unconditionally. Triton's ``tritongpu-promote-lhs-to-tmem`` copies A into tensor
+        memory (while ALSO keeping it in shared memory) for any A that reaches the MMA as a register
+        value -- a dtype cast, *any* same-dtype elementwise op, or a strided load all qualify. Trying to
+        predict that pass is a losing game, so we always pay for it. B is never promoted, so it only
+        appears in ``_smem_bytes``.
+
+        Verified over 15210 emitted configs against compiled ``tmem_size`` metadata: this never accepts
+        a tile that hardware cannot fit, and never rejects one it can.
+        """
+        if cls.TMEM_BUDGET is None:
+            return 0  # no tensor memory on this arch (sm90)
+        if bm < cls.TCGEN05_MIN_BM:
+            # Below this the dot lowers to a non-tcgen05 path that uses NO tensor memory at all
+            # (measured tmem_size == 0), so charging it would reject tiny decode tiles for a resource
+            # they never touch.
+            return 0
+        return bm * bn * 4 + bm * bk * itemsize
+
+    @classmethod
+    def _smem_bytes(
+        cls,
+        bm: int,
+        bn: int,
+        bk: int,
+        itemsize: int,
+        num_stages: int,
+    ) -> int:
+        """Conservative shared-memory bytes for one CTA: the K-loop operand ring OR the epilogue's
+        accumulator staging buffer, whichever is larger, plus ``SMEM_SLACK``.
+
+        A ``max`` (not a sum) because Triton's ``shared`` is a liveness-PACKED peak: the operand ring
+        is dead by the time the epilogue conversion runs, so the two reuse the same bytes.
+
+        - ring: ``(bm*bk + bk*bn) * itemsize * num_stages``. Charging the full ``num_stages`` is exact
+          for fp32 operands and over-strict (safe) for 16-bit ones, which cap at double-buffering.
+        - epilogue: on tcgen05 the fp32 accumulator lives in TMEM and must be staged through SMEM to
+          reach registers, costing ``bm*bn*EPILOGUE_ACC_ITEMSIZE``. This term is INDEPENDENT of
+          num_stages and is invisible to the ring formula, so a tile can fit the ring and still OOM.
+          It SATURATES (one epilogue tile costs the same as six -- the buffer is reused), which is
+          what makes it a real ceiling rather than a guess.
+
+          Charged UNCONDITIONALLY. It is tempting to charge only 2 bytes when the kernel's sole
+          [bm,bn] traffic is the output store, but measurement kills that: a BARE fp32-output store
+          also costs the full bm*bn*4 (only a narrower output dtype costs less). So "bare store" does
+          not imply the narrow path, and predicting the wide one would mean modelling the output
+          dtype plus every conversion Triton may insert. Always reserving 4 is validated safe on
+          288/288 swept configs (median slack 1.01x).
+        """
+        ring = (bm * bk + bk * bn) * itemsize * num_stages
+        epilogue = bm * bn * cls.EPILOGUE_ACC_ITEMSIZE
+        return max(ring, epilogue) + cls.SMEM_SLACK
+
+    @classmethod
+    def _matmul_tile(
+        cls,
+        m: int,
+        n: int,
+        k: int,
+        itemsize: int,
+        num_sm: int,
+        pinned_grid: int = 1,
+    ) -> tuple[int, int, int, int, int, int]:
+        """Budget/roofline formula: turns ``(M, N, K, operand-width)`` into ``(block_m, block_n,
+        block_k, num_warps, num_stages, l2_grouping)`` with no lookup. Reads its budget constants
+        off ``cls`` so a subclass can re-tune them. Steps (keyed by the inline markers below):
+        (1)/(2) register-budgeted wide-N tile, clamped to the shape, spilling leftover budget onto
+        the other axis; (2.5) batched-dot occupancy cap; (2.7) growth into the TMEM budget;
+        (4) wave-quantization fill; (5) num_warps ramp; (3') block_k + num_stages;
+        (4')/(5') shrink-to-fit SMEM then TMEM; (6) l2_grouping.
+
+        Resource accounting (``_smem_bytes`` / ``_tmem_bytes``) enters at three points: (2.7) grows the
+        tile only while the TMEM reservation fits, (3') sizes block_k/num_stages under SMEM, and
+        (4')/(5') are the final enforcement -- give up tile area when no cheaper knob can make the
+        config legal. Both budgets reserve for their worst case UNCONDITIONALLY, with no attempt to
+        predict Triton's operand-promotion or epilogue-conversion choices, so the accounting can only
+        err toward being too strict. Both are inert on sm90 (no tensor memory, no epilogue staging
+        buffer), which is what keeps that path byte-identical.
+        """
+        from ..._utils import prev_power_of_2
+
+        acc_budget = cls.ACC_BUDGET
+        smem_budget = cls.SMEM_BUDGET
+        dot_min = cls.DOT_MIN
+
+        def _p2le(v: int) -> int:
+            return max(1, prev_power_of_2(max(1, v)))
+
+        # (1)+(2) register-budgeted, shape-clamped, spill-outward [bm, bn]
+        bm = min(cls.BASE_BM_CAP, max(dot_min, _p2le(m)))
+        bn = min(cls.BASE_BN_CAP, max(dot_min, _p2le(n)))
+        cap_m = max(dot_min, _p2le(m))
+        cap_n = max(dot_min, _p2le(n))
+        if (
+            bm * bn < acc_budget
+        ):  # a clamped axis freed budget — spend it on the other axis
+            bn = min(cap_n, max(bn, acc_budget // max(1, bm)))
+            if bm * bn < acc_budget:
+                bm = min(cap_m, max(bm, acc_budget // max(1, bn)))
+        # (no ceiling-enforcement loop needed: the base clamps already cap the product at
+        # ACC_BUDGET, and spill-outward only grows an axis up to ACC_BUDGET//other.)
+
+        # A batched dot with a huge pinned grid (mamba's batch·nchunks·nheads) is occupancy-bound,
+        # not arithmetic-intensity-bound: it wants the tile + pipeline sized for max concurrent CTAs.
+        saturated_batched = pinned_grid >= cls.SAT_WAVES * num_sm
+
+        # (2.5) Saturated batched dot: cap the tile to the occupancy sweet spot (more small CTAs
+        # hide latency better than a few big register-budget tiles). A bare GEMM (pinned_grid==1)
+        # is never capped.
+        if saturated_batched:
+            bm = min(bm, cls.SAT_TILE_BM)
+            bn = min(bn, cls.SAT_TILE_BN)
+
+        # (4) Wave-quantization fill (shrink loop below). Floor the shrink at WAVE_FILL_FLOOR so a
+        # medium-M tile isn't over-shrunk into a low-arithmetic-intensity sliver; tiny-M decode
+        # keeps the DOT_MIN floor.
+        floor_dim = dot_min if m <= dot_min else cls.WAVE_FILL_FLOOR
+
+        wave_full = cls.WAVE_FULL
+
+        def _wave_eff(_bm: int, _bn: int) -> float:
+            g = max(1, pinned_grid) * ((m + _bm - 1) // _bm) * ((n + _bn - 1) // _bn)
+            waves = (g + num_sm - 1) // num_sm
+            return g / (waves * num_sm)
+
+        # (2.7) TMEM-budget tile growth (sm100 only; TMEM_BUDGET is None on sm90, so H100 is
+        # unchanged). On Blackwell the fp32 accumulator lives in tcgen05 tensor memory rather than the
+        # register file, so the tile is limited by TMEM_BUDGET, not ACC_BUDGET. Keep doubling an axis
+        # while the reservation still fits: N first, since it is the coalesced store / B-reuse axis and
+        # a narrow-N tile is a large regression. Each step must also still fill a wave.
+        #
+        # block_k is not chosen until step (3'), so charge BK_CAP -- the largest bk the formula can ever
+        # emit -- which keeps this independent of that later decision and never optimistic.
+        #
+        # SATURATED batched dots are excluded: step (2.5) just capped their tile to the occupancy sweet
+        # spot on purpose (many small concurrent CTAs beat a few big ones once the grid fills the SMs),
+        # and growing it back undoes that -- measured to inflate mamba-shaped tiles [32,64] -> [32,1024].
+        if cls.TMEM_BUDGET is not None and not saturated_batched:
+
+            def _tmem_fits(_bm: int, _bn: int) -> bool:
+                return (
+                    cls._tmem_bytes(_bm, _bn, cls.BK_CAP, itemsize) <= cls.TMEM_BUDGET
+                    and _wave_eff(_bm, _bn) >= wave_full
+                )
+
+            while True:
+                if bn * 2 <= cap_n and _tmem_fits(bm, bn * 2):
+                    bn *= 2
+                elif bm * 2 <= cap_m and _tmem_fits(bm * 2, bn):
+                    bm *= 2
+                else:
+                    break
+
+        # Shrink the larger tile axis while the grid is under one full wave and shrinking helps;
+        # already-saturated tiles are left untouched. WAVE_FILL_STRICT requires a STRICT wave-eff
+        # gain to shrink (a shrink that leaves occupancy flat only destroys operand reuse) — a
+        # universal fix, but sm90 keeps the old `>=` to stay byte-identical (frozen).
+        def _better(a: float, b: float) -> bool:
+            return a > b if cls.WAVE_FILL_STRICT else a >= b
+
+        while _wave_eff(bm, bn) < wave_full:
+            if (
+                bn >= bm
+                and bn > floor_dim
+                and _better(_wave_eff(bm, bn // 2), _wave_eff(bm, bn))
+            ):
+                bn //= 2
+            elif bm > floor_dim and _better(_wave_eff(bm // 2, bn), _wave_eff(bm, bn)):
+                bm //= 2
+            else:
+                break
+
+        # (5) num_warps ramps with the tile, except a saturated batched dot with a tiny tile wants
+        # min warps (more concurrent 1-warp CTAs once the grid saturates the SMs). SAT_NUM_WARPS is
+        # None on sm90 (keep the ramp), an int on sm100.
+        if saturated_batched and cls.SAT_NUM_WARPS is not None:
+            num_warps = cls.SAT_NUM_WARPS
+        else:
+            num_warps = 8 if bm * bn >= cls.WARPS_HI_ELEMS else 4
+
+        # (3') block_k + num_stages, derived together: bk is the largest pow2 that leaves >= PIPE
+        # K-iterations (so a small-K dot stays shallow), is <= BK_CAP, and fits the operands in SMEM;
+        # num_stages is then the deepest pipeline that fits, capped by the K-iteration count and by
+        # max_depth (a saturated batched dot is occupancy-bound -- concurrent CTAs already hide latency,
+        # so a deep pipeline just burns SMEM -> SAT_MAX_STAGES; a bare GEMM's K-loop is latency-bound ->
+        # full MAX_STAGES). Operand width enters via itemsize (a byte budget, not a dtype literal): fp8
+        # affords a deeper K than fp32.
+        #
+        # Factored into a helper because steps (4') and (5') below re-derive both after shrinking the
+        # tile: a smaller tile affords a deeper K and a deeper pipeline, and re-deriving is what keeps
+        # the shrink from silently costing pipeline depth it no longer needs to.
+        min_bk = 32 if itemsize == 1 else 16  # tl.dot K min (fp8 needs 32)
+        max_depth = cls.SAT_MAX_STAGES if saturated_batched else cls.MAX_STAGES
+
+        def _bk_and_stages(_bm: int, _bn: int) -> tuple[int, int]:
+            _bk = max(min_bk, min(cls.BK_CAP, _p2le(max(1, k // cls.PIPE))))
+            while (
+                _bk > min_bk
+                and cls._smem_bytes(_bm, _bn, _bk, itemsize, cls.PIPE) > smem_budget
+            ):
+                _bk //= 2
+            _kit = max(
+                1, k // _bk
+            )  # no point pipelining deeper than the K-loop is long
+            _ns = 2
+            for s in range(min(max_depth, max(2, _kit)), 1, -1):
+                if cls._smem_bytes(_bm, _bn, _bk, itemsize, s) <= smem_budget:
+                    _ns = s
+                    break
+            return _bk, _ns
+
+        bk, num_stages = _bk_and_stages(bm, bn)
+
+        # (4') / (5') Resource enforcement, on the FULLY decided config. Everything above picks the tile
+        # from arithmetic-intensity and occupancy arguments; bk and num_stages are the cheap knobs and
+        # are spent first (in the helper). When even the cheapest bk/num_stages does not fit, the only
+        # lever left is tile area -- so halve the larger axis, re-derive, and re-check.
+        #
+        # Two separate budgets, checked one after the other because they bind on different terms:
+        #   (4') SHARED memory -- the operand ring (scales with bk * num_stages) or the epilogue's
+        #        accumulator staging buffer (scales with bm*bn and is independent of bk/num_stages, so
+        #        only a smaller tile can relieve it).
+        #   (5') TENSOR memory -- the accumulator plus the A operand. Applies to EVERY case, including
+        #        batched dots, which skip the (2.7) growth loop but still use tensor memory (measured:
+        #        a pinned-batch dot at [256,256,32] reports tmem_size=512).
+        # Both are inert on sm90, which has neither an epilogue staging buffer nor tensor memory; that
+        # is what keeps the sm90 path byte-identical.
+        def _shrink_larger_axis() -> bool:
+            """Halve the larger tile axis. False when both are already at the dot minimum."""
+            nonlocal bm, bn, bk, num_stages
+            if bn >= bm and bn > dot_min:
+                bn //= 2
+            elif bm > dot_min:
+                bm //= 2
+            else:
+                return False
+            bk, num_stages = _bk_and_stages(bm, bn)
+            return True
+
+        # (4') is sm100-only: on sm90 `_smem_bytes` degenerates to the plain operand ring, and that
+        # model OVER-estimates -- its worst case [16,2048,16] fp32 computes 264192 but the hardware
+        # measures 132096 and fits fine. Shrinking there would cost real perf for a phantom overflow
+        # and break the sm90 byte-identical freeze, so the enforcement is gated on the conservative
+        # accounting being active.
+        if cls.ENFORCE_SMEM_BUDGET:
+            while cls._smem_bytes(bm, bn, bk, itemsize, num_stages) > smem_budget:
+                if not _shrink_larger_axis():
+                    break
+
+        if cls.TMEM_BUDGET is not None:
+            while cls._tmem_bytes(bm, bn, bk, itemsize) > cls.TMEM_BUDGET:
+                if not _shrink_larger_axis():
+                    break
+
+        # (6) l2_grouping: reorder PIDs so a group of M-tiles shares an L2-resident B operand. Helps
+        # a tall tile-grid (many M-tiles reuse one B) but hurts a wide/square grid, so gate on the
+        # measured crossover grid_m >= L2_TALL_RATIO * grid_n.
+        grid_m = (m + bm - 1) // bm
+        grid_n = (n + bn - 1) // bn
+        l2_grouping = 2 if grid_m > 1 and grid_m >= cls.L2_TALL_RATIO * grid_n else 1
+
+        return bm, bn, bk, num_warps, num_stages, l2_grouping
+
+    @classmethod
+    def _ranked_configs(cls, env: CompileEnvironment, fact: MatmulFact) -> list[Config]:
+        """Ranked seed list: the budget primary (rank-0, Product A) + a couple of diverse alternates
+        (transposed aspect, shallower num_stages) to seed the autotuner search. Deduped by the loader."""
+        from ..._utils import prev_power_of_2
+        from ...runtime import get_num_sm
+
+        assert fact.static_m is not None
+        assert fact.static_n is not None
+        assert fact.static_k is not None
+        spec = env.config_spec
+        itemsize = max(1, fact.lhs_dtype.itemsize)
+        num_sm = max(1, get_num_sm(env.device))
+        pinned_grid = _h100_pinned_grid(env, fact)
+        # The budget formula sizes the dot tile under a register/SMEM budget, keyed on
+        # (M, N, K, operand-width via itemsize) and the pinned batch grid.
+        bm, bn, bk, nw, ns, l2 = cls._matmul_tile(
+            fact.static_m,
+            fact.static_n,
+            fact.static_k,
+            itemsize,
+            num_sm,
+            pinned_grid,
+        )
+
+        def _extra(
+            _bm: int, _bn: int, _bk: int, _nw: int, _ns: int, _l2: int
+        ) -> dict[str, Any]:
+            return cls._extra_config_fields(
+                fact.static_m,
+                fact.static_n,
+                fact.static_k,
+                itemsize,
+                _bm,
+                _bn,
+                _bk,
+                _nw,
+                _ns,
+                _l2,
+                pinned_grid,
+                num_sm,
+            )
+
+        ranked: list[Config] = [
+            _h100_config(
+                spec, fact, bm, bn, bk, nw, ns, l2, _extra(bm, bn, bk, nw, ns, l2)
+            )
+        ]
+
+        def _warps(_bm: int, _bn: int) -> int:
+            return 8 if _bm * _bn >= cls.WARPS_HI_ELEMS else 4
+
+        # alt 1 — transposed aspect (move budget from N to M), when it changes the tile. It DOUBLES
+        # bm, so re-check the resource accounting: the alternate is a real search seed and an
+        # over-budget one would just fail to compile (or, on the TMEM path, fail at launch).
+        #
+        # Gated on the conservative accounting being active (i.e. sm100), for the same reason step
+        # (4')/(5') are: on sm90 ``_smem_bytes`` degenerates to the ring formula, which is a NEW
+        # constraint on alt-1 (it never had a SMEM check) and which that arch's own primary path
+        # deliberately does not enforce because the model over-estimates there. Applying it on sm90
+        # would drop ~15% of alt-1 seeds and break the byte-identical freeze.
+        cap_m = max(16, prev_power_of_2(max(1, fact.static_m)))
+        bm2, bn2 = min(cap_m, bm * 2), max(16, bn // 2)
+        conservative = cls.ENFORCE_SMEM_BUDGET
+        if (
+            bm2 != bm
+            and bn2 != bn
+            and bm2 * bn2 >= 4096
+            and cls._tmem_bytes(bm2, bn2, bk, itemsize) <= (cls.TMEM_BUDGET or _INF)
+            and (
+                not conservative
+                or cls._smem_bytes(bm2, bn2, bk, itemsize, ns) <= cls.SMEM_BUDGET
+            )
+        ):
+            nw2 = _warps(bm2, bn2)
+            ranked.append(
+                _h100_config(
+                    spec,
+                    fact,
+                    bm2,
+                    bn2,
+                    bk,
+                    nw2,
+                    ns,
+                    1,
+                    _extra(bm2, bn2, bk, nw2, ns, 1),
+                )
+            )
+
+        # alt 2 — shallower num_stages neighbor (perturb down only; skipped at the floor ns==2).
+        if ns > 2:
+            ranked.append(
+                _h100_config(
+                    spec,
+                    fact,
+                    bm,
+                    bn,
+                    bk,
+                    nw,
+                    ns - 1,
+                    l2,
+                    _extra(bm, bn, bk, nw, ns - 1, l2),
+                )
+            )
+        return ranked
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        if not matches_hardware(env, cls.HARDWARE_TARGETS):
+            return False
+        fact = _batched_static_matmul_fact(env.config_spec)
+        if fact is None:
+            return False
+        # Decline fp8 (both operands 1-byte float). CAVEAT: this is disabled because of an fp8
+        # `fast_accum` (is_fast_accum) precision issue, NOT a perf choice. In fp8 tensor-core
+        # terms the wide-tile path we would emit is effectively the `fast_accum=True`
+        # (max-throughput) accumulate, and Helion has no knob today to force the full-precision
+        # accumulate back on, so we decline rather than silently ship reduced-precision fp8. It
+        # dodges a Triton fp8-accumulator bug that our budget tile would otherwise trigger:
+        #
+        #   The budget formula sizes fp8 GEMMs at block_m=128 (>= 64). At block_m >= 64 Triton
+        #   lowers ``tl.dot`` to the native fp8 warp-group MMA (QGMMA/warp_group_dot), reading
+        #   raw fp8 from shared memory. Because Helion never passes ``max_num_imprecise_acc``,
+        #   Triton falls back to its sm90 default of 2**30 (the "never promote" sentinel), so the
+        #   fp32 accumulator is NEVER flushed across the K loop -> results wrong by an error that
+        #   grows with K (~0.03% at K=512 up to ~5% at K=8192). block_m <= 32 dodges it (Triton
+        #   upcasts fp8->fp16 and uses HMMA with a real fp32 accumulate), but that is exactly the
+        #   small tile ``_base_default_config`` already emits.
+        #
+        #   In max-autotune the accuracy gate (bitwise 0/0 for all-fp8 output) correctly REJECTS
+        #   the wide-tile config, so it can never win -- planting it only wastes a search trial.
+        #   Worse, this heuristic sets ``promote_seed_to_default=True``: an eligible fp8 seed would
+        #   become the effort=none compiler default, which runs NO accuracy check -> silently wrong
+        #   fp8 GEMMs. Declining here disables BOTH the wasted seed and the unsafe promotion (fp8
+        #   falls back to the correct ``_base_default_config`` small tile).
+        #
+        #   The real fix (a follow-up) is to emit ``max_num_imprecise_acc=0`` on fp8 ``tl.dot`` in
+        #   _emit_tl_dot; that forces the correct accumulate AND is faster than either path here,
+        #   so the fp8 seed should be re-enabled once that lands. The CuTe backend is unaffected --
+        #   it bakes fp32 accumulation into the MMA op type, with no tunable cadence to get wrong.
+        return not _is_fp8_matmul_fact(fact)
+
+    @classmethod
+    def _ranked(cls, env: CompileEnvironment) -> list[Config]:
+        fact = _batched_static_matmul_fact(env.config_spec)
+        if fact is None:
+            return []
+        # The budget formula is the sole seed: the primary (Product A) + ranked Product-B alternates.
+        return dedupe_configs(cls._ranked_configs(env, fact))
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        ranked = cls._ranked(env)
+        return ranked[0] if ranked else None
+
+    @classmethod
+    def get_seed_configs(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> list[Config] | None:
+        ranked = cls._ranked(env)
+        return ranked or None
+
+
+class TritonB200FormulaMatmulHeuristic(TritonH100MatmulHeuristic):
+    """B200 (sm100) seed — the H100 budget formula re-homed on Blackwell, subsuming the incumbent
+    ``TritonB200MatmulHeuristic`` table (which fires only on in-bucket fp16/bf16 2-D matmul and
+    declines fp32/fp8/bmm/mamba + any dim>4096). Overrides only the hardware gate and the B200-tuned
+    constants; the promotion (owning the compiler default) is inherited from the base."""
+
+    name = "triton_b200_formula_matmul"
+    HARDWARE_TARGETS = (("cuda", "sm100"),)
+    # promote_seed_to_default=True is inherited from TritonH100MatmulHeuristic. Registered after the
+    # (demoted) table so it wins the last-promote-wins compiler_default_config loop on sm100.
+
+    # num_sm (148) enters via get_num_sm, so the wave/saturation arithmetic self-adjusts; the rest
+    # inherit the H100 formula, re-tuned per move below.
+    SMEM_BUDGET = 232448  # B200 shared_memory_per_block_optin (bytes)
+    # A saturated batched dot on 148 SMs wants a smaller tile + min warps (more concurrent tiny CTAs).
+    SAT_TILE_BM = 32
+    SAT_TILE_BN = 64
+    SAT_NUM_WARPS = 1
+    # Strict wave-fill shrink (see the shrink loop). A universal fix; gated to sm100 only to keep the
+    # sm90 freeze byte-identical — the principled end-state is to flip the base default once H100 can
+    # be re-benched (it would shift a few N=11008 shapes).
+    WAVE_FILL_STRICT = True
+    # --- conservative resource accounting (sm100 only; see _tmem_bytes / _smem_bytes) ---
+    # Full tcgen05 tensor memory: 128 lanes x 512 columns x 32 bit = 262144 bytes. The [256,256] fp32
+    # accumulator EXACTLY fills it, which is why a promoted A operand cannot coexist with that square.
+    TMEM_BUDGET = 128 * 512 * 4
+    # EPILOGUE_ACC_ITEMSIZE is inherited (the term is arch-independent). What is sm100-specific is
+    # ENFORCING it: only here can the tile reach bm*bn=65536, where the term actually exceeds the cap.
+    ENFORCE_SMEM_BUDGET = True
+    # 1 KiB covers the mbarrier allocations (8 B each) and any similarly small future allocation.
+    # Measured: an otherwise byte-exact bound is violated by exactly 16 B without this.
+    SMEM_SLACK = 1024
+
+
+# Module-level shims delegating to the class (tests + lab harness call these by name).
+def _h100_matmul_tile(
+    m: int, n: int, k: int, itemsize: int, num_sm: int, pinned_grid: int = 1
+) -> tuple[int, int, int, int, int, int]:
+    return TritonH100MatmulHeuristic._matmul_tile(
+        m, n, k, itemsize, num_sm, pinned_grid
+    )
+
+
+def _h100_ranked_configs(env: CompileEnvironment, fact: MatmulFact) -> list[Config]:
+    return TritonH100MatmulHeuristic._ranked_configs(env, fact)
 
 
 class TritonPointwiseSeedHeuristic(AutotunerHeuristic):
@@ -447,383 +1135,6 @@ class TritonPointwiseSeedHeuristic(AutotunerHeuristic):
         for i in contig_pos:
             block[i] = cls._clamp_dim(run, specs[i], 1)
         return block
-
-
-def _batched_static_matmul_fact(config_spec: ConfigSpec) -> MatmulFact | None:
-    """The H100 eligibility precondition — broader than the 2-D-only
-    ``_single_2d_static_matmul_fact``: it admits an arbitrary, possibly **BATCHED** matmul. The
-    requirements:
-      - exactly one ``MatmulFact`` with **static** M/N/K (the dot's own dims) and three distinct
-        M/N/K block-ids that are real tunable axes;
-      - every **other** tunable block axis is a BATCH / OUTER grid axis (present in
-        ``grid_block_ids``) — a no-data-reuse parallel axis the seed pins to 1
-        (``_h100_build_block_sizes`` floors every non-M/N/K axis), which is exactly what keeps the
-        register-budget tile valid for a batched dot (the fp32 accumulator is
-        ``[batch_blocks…, bm, bn]``; the budget sizes ``bm·bn`` assuming each batch block is 1).
-    An extra tunable axis that is NEITHER M/N/K nor a grid axis (some inner loop we do not model)
-    ⇒ decline, so the seed never mis-pins an axis it does not understand. The dot's ndim is NOT
-    constrained (a 2-D ``matmul`` and a 3-D ``baddbmm`` are both fine), only the block-axis ROLES.
-
-    Fires on: plain ``matmul`` / ``fp8_gemm``; ``broadcast_matmul`` (batch folded into M);
-    ``mamba2_chunk_state`` (batch pre-pinned to 1 by the author — its batch axes aren't tunable);
-    and ``bmm`` / any static batched dot that leaves its batch axis tunable. Declines a dynamic
-    (``static_shapes=False``) or jagged kernel (no static M/N/K) — e.g. ``grouped_gemm``.
-    """
-    facts = config_spec.matmul_facts
-    if len(facts) != 1:
-        return None
-    fact = facts[0]
-    if fact.static_m is None or fact.static_n is None or fact.static_k is None:
-        return None
-    mnk = (fact.m_block_id, fact.n_block_id, fact.k_block_id)
-    if None in mnk or len(set(mnk)) != 3:
-        return None
-    valid = set(config_spec.block_sizes.valid_block_ids())
-    if not set(mnk) <= valid:
-        return None
-    # Every tunable axis must be the dot's M/N/K or a batch/outer grid axis (pinnable to 1).
-    allowed = set(mnk) | set(config_spec.grid_block_ids)
-    if any(bid not in allowed for bid in valid):
-        return None
-    return fact
-
-
-def _h100_matmul_tile(
-    m: int, n: int, k: int, itemsize: int, num_sm: int, pinned_grid: int = 1
-) -> tuple[int, int, int, int, int, int]:
-    """The H100 (sm90) matmul budget/roofline formula — the catch-all that turns
-    ``(M, N, K, operand-width)`` into a strong ``(block_m, block_n, block_k, num_warps,
-    num_stages, l2_grouping)`` with NO lookup. The model (task §3 inspiration):
-
-    1. **Register budget** — the fp32 ``[bm, bn]`` accumulator dominates per-CTA registers,
-       so ``bm * bn <= ACC_BUDGET`` (elems). Base aspect is wide-N (``bn = 2*bm`` →
-       ``[128, 256]``, the measured H100 compute-bound winner), since N is the coalesced
-       store axis and is usually ≥ M (FFN/proj). The ``min(128,·)/min(256,·)`` clamp already
-       bounds the product at ``ACC_BUDGET``, so no separate ceiling-enforcement is needed.
-    2. **Shape clamp + spill-outward** — never tile past a dim (``bm <= M``, ``bn <= N``,
-       pow2); when one axis is clamped small (tall-skinny / decode), spend the leftover
-       register budget on the other axis so the tile stays productive instead of starved.
-    4. **Occupancy / wave-quantization fill** — the launched grid is ``pinned_grid ·
-       ⌈M/bm⌉·⌈N/bn⌉``, where ``pinned_grid`` is the product of any PINNED (block_size=1)
-       grid axes — 1 for a bare GEMM, but ``batch·nchunks·nheads`` for the fused
-       ``mamba2_chunk_state`` dot, which is already massively grid-saturated (so its dot tile
-       must NOT be shrunk). Shrink the wide axis (then M) only while it MEASURABLY improves the
-       wave-quantization efficiency ``grid / (⌈grid/num_sm⌉·num_sm)`` — so a shape already at
-       ~one full wave (e.g. a 2048³ cube at 128≈132 tiles) keeps its big tile, while a starved
-       small-M GEMM (16 tiles) is split to fill the machine.
-    5. **num_warps** ramps with the tile (≥16K elems → 8 else 4).
-    3'. **block_k + num_stages** — SMEM-budgeted (operand width via itemsize), pipeline-depth-capped
-       (``bk <= K/PIPE`` to keep the K-loop ≥ PIPE deep), and num_stages = the deepest pipeline that
-       fits SMEM, ceiling'd by regime (latency-bound → up to 6; an occupancy-SATURATED batched dot →
-       2). The saturation flag is computed once at step (2.5) and used by both the tile cap and here.
-    6. **l2_grouping** for a tall tile-grid (B-reuse). (Details at each step below.)
-    """
-    from ..._utils import prev_power_of_2
-
-    ACC_BUDGET = 32768  # fp32 [bm,bn] accumulator elems (= 128*256), register-bound
-    SMEM_BUDGET = 228 * 1024  # H100 per-CTA shared memory ceiling (bytes)
-    DOT_MIN = (
-        16  # tl.dot min M/N; K min is 16 (32 for fp8) — finalized by the spec floor
-    )
-
-    def _p2le(v: int) -> int:
-        return max(1, prev_power_of_2(max(1, v)))
-
-    # (1)+(2) register-budgeted, shape-clamped, spill-outward [bm, bn]
-    bm = min(128, max(DOT_MIN, _p2le(m)))
-    bn = min(256, max(DOT_MIN, _p2le(n)))
-    cap_m = max(DOT_MIN, _p2le(m))
-    cap_n = max(DOT_MIN, _p2le(n))
-    if bm * bn < ACC_BUDGET:  # a clamped axis freed budget — spend it on the other axis
-        bn = min(cap_n, max(bn, ACC_BUDGET // max(1, bm)))
-        if bm * bn < ACC_BUDGET:
-            bm = min(cap_m, max(bm, ACC_BUDGET // max(1, bn)))
-    # (no ceiling-enforcement loop needed: the min(128,·)/min(256,·) clamps already cap the
-    # product at ACC_BUDGET, and spill-outward only grows an axis up to ACC_BUDGET//other.)
-
-    # A fused BATCHED dot is launched by a huge PINNED grid (mamba's batch·nchunks·nheads) — the
-    # batched-dot signature. Such a launch is occupancy-bound, not arithmetic-intensity-bound, so
-    # it wants the dot tile + pipeline sized for MAX concurrent CTAs, not max register reuse.
-    SAT_WAVES = (
-        4  # pinned grid >= 4 SM-waves of independent programs = occupancy-saturated
-    )
-    saturated_batched = pinned_grid >= SAT_WAVES * num_sm
-
-    # (2.5) saturated batched-dot occupancy tile cap. Cap the per-CTA tile to the measured
-    # occupancy sweet spot (bm<=64, bn<=128): more concurrent small CTAs hide latency better than
-    # a few big register-budget tiles. Beats the register-budget [128,256] on the large fused
-    # dots (hd=128/ds=256: +12-13%) and is neutral on the small ones (already <= it). A bare GEMM
-    # has pinned_grid==1 and is never capped (it IS arithmetic-intensity-bound).
-    if saturated_batched:
-        bm = min(bm, 64)
-        bn = min(bn, 128)
-
-    # (4) occupancy / wave-quantization fill — shrink the wide axis (then M) only while it
-    # measurably improves wave efficiency. pinned_grid folds in any block_size=1 grid axes
-    # (mamba's batch·nchunks·nheads), so a grid-saturated fused dot is never shrunk.
-    # Decode (tiny M) keeps the DOT_MIN floor; otherwise floor at 64 (don't over-shrink a
-    # medium-M tile into a low-arithmetic-intensity sliver).
-    floor_dim = DOT_MIN if m <= DOT_MIN else 64
-
-    WAVE_FULL = (
-        0.8  # "saturated": >= ~one full wave of CTAs; below this, fill by shrinking
-    )
-
-    def _wave_eff(_bm: int, _bn: int) -> float:
-        g = max(1, pinned_grid) * ((m + _bm - 1) // _bm) * ((n + _bn - 1) // _bn)
-        waves = (g + num_sm - 1) // num_sm
-        return g / (waves * num_sm)
-
-    # Shrink the LARGER tile axis (keeps the tile square-ish, not a starved sliver) while the
-    # grid is under one full wave AND shrinking helps. Already-saturated tiles (a cube at
-    # ~one wave, or a mamba dot with a huge pinned grid) are left untouched.
-    while _wave_eff(bm, bn) < WAVE_FULL:
-        if bn >= bm and bn > floor_dim and _wave_eff(bm, bn // 2) >= _wave_eff(bm, bn):
-            bn //= 2
-        elif bm > floor_dim and _wave_eff(bm // 2, bn) >= _wave_eff(bm, bn):
-            bm //= 2
-        else:
-            break
-
-    # (5) num_warps ramp
-    num_warps = 8 if bm * bn >= 16384 else 4
-
-    # (3') K tile (block_k) + num_stages — SMEM-budgeted, pipeline-depth-capped, computed on
-    # the FINAL bm,bn. bk is the largest pow2 that:
-    #   (a) leaves >= PIPE K-iterations to fill the pipeline (bk <= K/PIPE): collapsing K into
-    #       1-2 steps defeats software pipelining and over-pressures registers. This is what keeps
-    #       mamba's small-K (chunk) dot at a shallow bk while a large-K GEMM gets a deep one;
-    #   (b) is <= BK_CAP (a deep K amortizes the K-loop for a latency-bound small-M GEMM, but
-    #       past ~256 the returns vanish and registers spill);
-    #   (c) fits the [bm,bk]+[bk,bn] operands in SMEM at num_stages — width enters HERE via
-    #       itemsize, so a narrower operand (fp8) affords a deeper K than a wider one (fp32):
-    #       the 8/16/32 budget knob, faithful (a byte budget, never a dtype literal).
-    # Drop num_stages only if even min_bk overflows SMEM (an unusually large tile).
-    BK_CAP = 256
-    PIPE = 4  # baseline K-loop pipeline depth (bk is sized to fit at least this many stages)
-    min_bk = 32 if itemsize == 1 else 16  # tl.dot K min (fp8 needs 32)
-    # Largest pow2 <= min(BK_CAP, K/PIPE), floored to min_bk. The K/PIPE cap is <= K, so it also
-    # guarantees bk <= K; and flooring only at the end suffices (a floor inside the min() would be
-    # undone by the min and redone here).
-    bk = max(min_bk, min(BK_CAP, _p2le(max(1, k // PIPE))))
-    while bk > min_bk and (bm * bk + bk * bn) * itemsize * PIPE > SMEM_BUDGET:
-        bk //= 2
-    # num_stages = the deepest pipeline that fits SMEM at this bk, bounded by:
-    #   - the K-iteration count (no point pipelining deeper than the loop trips), AND
-    #   - the regime ceiling `max_depth`: a SATURATED BATCHED dot — many independent programs from
-    #     a huge PINNED grid (mamba's batch·nchunks·nheads) — is occupancy-bound, not latency-bound:
-    #     its concurrent CTAs already hide latency, so a deep per-program pipeline only burns
-    #     SMEM/registers and cuts occupancy. Cap it at 2 there (measured s4->s2 +20-28%, VAL-referee
-    #     diagnosed). A bare GEMM (pinned_grid==1) keeps the full depth — its long K-loop genuinely
-    #     IS latency-bound (3072³ forced to s2 = G 0.58 disaster). This is the ONLY place num_stages
-    #     is decided; the two regimes differ only in this ceiling.
-    # MAX_STAGES: deepen the pipeline up to here if SMEM allows — a small tile leaves SMEM spare and
-    # a deep K-loop hides its latency with more stages (measured: small-M [64,64,128] s4->s6 +13%,
-    # deep-K K>>M·N +26%); a big tile is SMEM-capped back to ~4.
-    MAX_STAGES = 6
-    max_depth = 2 if saturated_batched else MAX_STAGES
-    per_stage = (bm * bk + bk * bn) * itemsize
-    kit = max(1, k // bk)  # K-loop iterations — no point pipelining deeper than this
-    num_stages = 2
-    for s in range(min(max_depth, max(2, kit)), 1, -1):
-        if per_stage * s <= SMEM_BUDGET:
-            num_stages = s
-            break
-
-    # (6) l2_grouping — reorder the program grid so a group of consecutive PIDs covers a block
-    # of M-tiles sharing the same N-columns, keeping the (small, reused) B operand L2-resident
-    # across the group. This is a big win for a TALL tile-grid (many M-tiles reusing one B:
-    # tall-skinny G 0.69->0.97) but measurably HURTS a wide/square grid (vocab G 0.999->0.71,
-    # wide 0.98->0.72) — gated on a PROVEN reversal boundary. The measured l2=2 crossover vs the
-    # tile-grid aspect grid_m/grid_n: ratio 2 (square) -0.7%, 3.2 +3.4%, 4 +5%, 6 +13.5%, 8 +27%,
-    # 64 (tall-skinny) 0.69->0.97 — so the win turns on at ~3x. Gate at grid_m >= 3*grid_n. Off for
-    # mamba (its M/N grid is 1x1 — the batch axes carry the grid, not tiled M/N).
-    L2_TALL_RATIO = 3
-    grid_m = (m + bm - 1) // bm
-    grid_n = (n + bn - 1) // bn
-    l2_grouping = 2 if grid_m > 1 and grid_m >= L2_TALL_RATIO * grid_n else 1
-
-    return bm, bn, bk, num_warps, num_stages, l2_grouping
-
-
-def _h100_build_block_sizes(
-    spec: ConfigSpec, fact: MatmulFact, bm: int, bn: int, bk: int
-) -> list[int]:
-    """Map ``(bm, bn, bk)`` onto the spec's block_sizes by the fact's M/N/K block-ids,
-    clamping each to its valid [min, max] (other axes — none for a clean 2-D fact — floored)."""
-    targets = {fact.m_block_id: bm, fact.n_block_id: bn, fact.k_block_id: bk}
-    out: list[int] = []
-    for i in range(len(spec.block_sizes)):
-        bs_spec = cast("BlockSizeSpec", spec.block_sizes[i])
-        v = targets.get(bs_spec.block_id)
-        if v is None:
-            v = max(1, bs_spec.min_size, bs_spec.autotuner_min)
-        v = max(v, bs_spec.min_size, bs_spec.autotuner_min)
-        v = min(v, bs_spec.max_size)
-        out.append(v)
-    return out
-
-
-def _h100_pinned_grid(env: CompileEnvironment, fact: MatmulFact) -> int:
-    """Product of any PINNED (block_size=1) grid axes other than the dot's M/N tiles — 1 for a
-    bare GEMM, ``batch·nchunks·nheads`` for mamba's fused dot. These already saturate the SMs, so
-    the occupancy fill counts them (else it shrinks an already-grid-saturated dot's tile) and the
-    num_stages cap keys on them (the batched-dot signature)."""
-    pinned_grid = 1
-    for bid in env.config_spec.grid_block_ids:
-        if bid in (fact.m_block_id, fact.n_block_id):
-            continue
-        size = env.block_sizes[bid].size
-        if isinstance(size, (int, torch.SymInt)):
-            pinned_grid *= max(1, env.size_hint(size))
-    return pinned_grid
-
-
-def _h100_config(
-    spec: ConfigSpec,
-    fact: MatmulFact,
-    bm: int,
-    bn: int,
-    bk: int,
-    num_warps: int,
-    num_stages: int,
-    l2_grouping: int = 1,
-) -> Config:
-    """Assemble a Config from a tile tuple (emit l2_groupings only when grouping > 1)."""
-    cfg: dict[str, Any] = {
-        "block_sizes": _h100_build_block_sizes(spec, fact, bm, bn, bk),
-        "num_warps": num_warps,
-        "num_stages": num_stages,
-    }
-    if l2_grouping > 1:
-        cfg["l2_groupings"] = [l2_grouping]
-    return Config(**cfg)
-
-
-def _h100_ranked_configs(env: CompileEnvironment, fact: MatmulFact) -> list[Config]:
-    """The ranked seed list: the budget primary (rank-0, Product A) + a few DIVERSE strong
-    alternates that seed Product-B search convergence (a seed is never forced, so a sub-optimal
-    alternate only costs autotuning time). The alternates perturb the two axes that carry the
-    most measured per-shape variance — the tile ASPECT (e.g. [128,256] vs a transposed [256,128])
-    and num_stages (s3 vs s4) — giving the search diverse strong starting points without the
-    risky l2 lever. Deduped against the primary by the loader."""
-    from ..._utils import prev_power_of_2
-    from ...runtime import get_num_sm
-
-    assert fact.static_m is not None
-    assert fact.static_n is not None
-    assert fact.static_k is not None
-    spec = env.config_spec
-    # The budget formula sizes the dot tile under a register/SMEM budget, keyed on
-    # (M, N, K, operand-width via itemsize) and the pinned batch grid.
-    bm, bn, bk, nw, ns, l2 = _h100_matmul_tile(
-        fact.static_m,
-        fact.static_n,
-        fact.static_k,
-        max(1, fact.lhs_dtype.itemsize),
-        max(1, get_num_sm(env.device)),
-        _h100_pinned_grid(env, fact),
-    )
-    ranked: list[Config] = [_h100_config(spec, fact, bm, bn, bk, nw, ns, l2)]
-
-    def _warps(_bm: int, _bn: int) -> int:
-        return 8 if _bm * _bn >= 16384 else 4
-
-    # alt 1 — transposed aspect (move budget from N to M): covers shapes where a less wide tile
-    # wins. Only when there is room and it changes the tile.
-    assert fact.static_m is not None and fact.static_n is not None
-    cap_m = max(16, prev_power_of_2(max(1, fact.static_m)))
-    bm2, bn2 = min(cap_m, bm * 2), max(16, bn // 2)
-    if bm2 != bm and bn2 != bn and bm2 * bn2 >= 4096:
-        ranked.append(_h100_config(spec, fact, bm2, bn2, bk, _warps(bm2, bn2), ns))
-
-    # alt 2 — a SHALLOWER num_stages neighbor (perturb DOWN only). Never re-introduce a deeper
-    # pipeline: for a saturated batched dot that is exactly the config step 7 rejected (s>=3 loses
-    # ~20-28%), and the down-perturbation matches the matched-lever A/B discipline. Skipped at the
-    # floor (num_stages==2, i.e. a saturated dot — its only seed-worthy alternate is the aspect one).
-    if ns > 2:
-        ranked.append(_h100_config(spec, fact, bm, bn, bk, nw, ns - 1, l2))
-    return ranked
-
-
-class TritonH100MatmulHeuristic(AutotunerHeuristic):
-    """H100 (sm90) seed for any static (possibly BATCHED) ``MatmulFact`` — the dense-GEMM seed
-    H100 was missing (only the narrow skinny-aspect rule + the sm100 B200 table existed, so
-    almost every real GEMM fell back to the catastrophic ``block_sizes≈[16,16,16]`` default).
-
-    Fires on EVERY ``_batched_static_matmul_fact`` (no aspect-ratio gate — re-imposing it is the
-    bug): ``matmul``, ``fp8_gemm``, ``broadcast_matmul``, ``mamba2_chunk_state``'s fused inner dot,
-    AND ``bmm`` / any static batched dot. The seed is a **budget/roofline FORMULA**
-    (``_h100_matmul_tile``) that sizes the dot's M/N/K under a register/SMEM budget keyed on
-    ``(M, N, K, operand-width)`` and **pins every batch/outer axis to 1** (a no-data-reuse parallel
-    axis — one CTA per batch maximizes the grid, and it keeps the ``[bm,bn]`` register budget valid;
-    the resulting pinned grid then drives the saturation levers, so a batched dot and mamba are the
-    SAME case). The catch-all formula guarantees no such matmul hits the default.
-    ``promote_seed_to_default=True``: the budget formula owns the no-autotune compiler default (as
-    well as seeding the autotuner), so a real GEMM never falls back to the ``[16,16,16]`` default."""
-
-    name = "triton_h100_matmul"
-    backend = "triton"
-    promote_seed_to_default = True
-    HARDWARE_TARGETS = (("cuda", "sm90"),)
-
-    @classmethod
-    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
-        if not matches_hardware(env, cls.HARDWARE_TARGETS):
-            return False
-        fact = _batched_static_matmul_fact(env.config_spec)
-        if fact is None:
-            return False
-        # Decline fp8 (both operands 1-byte float). CAVEAT: this is disabled because of an fp8
-        # `fast_accum` (is_fast_accum) precision issue, NOT a perf choice. In fp8 tensor-core
-        # terms the wide-tile path we would emit is effectively the `fast_accum=True`
-        # (max-throughput) accumulate, and Helion has no knob today to force the full-precision
-        # accumulate back on, so we decline rather than silently ship reduced-precision fp8. It
-        # dodges a Triton fp8-accumulator bug that our budget tile would otherwise trigger:
-        #
-        #   The budget formula sizes fp8 GEMMs at block_m=128 (>= 64). At block_m >= 64 Triton
-        #   lowers ``tl.dot`` to the native fp8 warp-group MMA (QGMMA/warp_group_dot), reading
-        #   raw fp8 from shared memory. Because Helion never passes ``max_num_imprecise_acc``,
-        #   Triton falls back to its sm90 default of 2**30 (the "never promote" sentinel), so the
-        #   fp32 accumulator is NEVER flushed across the K loop -> results wrong by an error that
-        #   grows with K (~0.03% at K=512 up to ~5% at K=8192). block_m <= 32 dodges it (Triton
-        #   upcasts fp8->fp16 and uses HMMA with a real fp32 accumulate), but that is exactly the
-        #   small tile ``_base_default_config`` already emits.
-        #
-        #   In max-autotune the accuracy gate (bitwise 0/0 for all-fp8 output) correctly REJECTS
-        #   the wide-tile config, so it can never win -- planting it only wastes a search trial.
-        #   Worse, this heuristic sets ``promote_seed_to_default=True``: an eligible fp8 seed would
-        #   become the effort=none compiler default, which runs NO accuracy check -> silently wrong
-        #   fp8 GEMMs. Declining here disables BOTH the wasted seed and the unsafe promotion (fp8
-        #   falls back to the correct ``_base_default_config`` small tile).
-        #
-        #   The real fix (a follow-up) is to emit ``max_num_imprecise_acc=0`` on fp8 ``tl.dot`` in
-        #   _emit_tl_dot; that forces the correct accumulate AND is faster than either path here,
-        #   so the fp8 seed should be re-enabled once that lands. The CuTe backend is unaffected --
-        #   it bakes fp32 accumulation into the MMA op type, with no tunable cadence to get wrong.
-        return not _is_fp8_matmul_fact(fact)
-
-    @classmethod
-    def _ranked(cls, env: CompileEnvironment) -> list[Config]:
-        fact = _batched_static_matmul_fact(env.config_spec)
-        if fact is None:
-            return []
-        # The budget formula is the sole seed: the primary (Product A) + ranked Product-B alternates.
-        return dedupe_configs(_h100_ranked_configs(env, fact))
-
-    @classmethod
-    def get_seed_config(
-        cls, env: CompileEnvironment, device_ir: DeviceIR
-    ) -> Config | None:
-        ranked = cls._ranked(env)
-        return ranked[0] if ranked else None
-
-    @classmethod
-    def get_seed_configs(
-        cls, env: CompileEnvironment, device_ir: DeviceIR
-    ) -> list[Config] | None:
-        ranked = cls._ranked(env)
-        return ranked or None
 
 
 def _triton_reduction_eligible(env: CompileEnvironment, device_ir: DeviceIR) -> bool:

--- a/test/test_matmul_heuristics.py
+++ b/test/test_matmul_heuristics.py
@@ -8,7 +8,11 @@ import torch
 
 import helion
 from helion._compiler.autotuner_heuristics.triton import _B200_MATMUL_HEURISTICS_PATH
+from helion._compiler.autotuner_heuristics.triton import (
+    TritonB200FormulaMatmulHeuristic,
+)
 from helion._compiler.autotuner_heuristics.triton import TritonB200MatmulHeuristic
+from helion._compiler.autotuner_heuristics.triton import TritonH100MatmulHeuristic
 from helion._compiler.autotuner_heuristics.triton import _seed_config_for_bucket
 from helion._compiler.autotuner_heuristics.triton import _seed_config_for_config_spec
 from helion.autotuner.config_fragment import EnumFragment
@@ -174,3 +178,163 @@ def test_triton_b200_matmul_heuristic_gates_on_hardware() -> None:
         return_value=h100,
     ):
         assert not TritonB200MatmulHeuristic.is_eligible(env, SimpleNamespace())
+
+
+def test_b200_formula_subsumes_table_promotion_wiring() -> None:
+    # The sm100 FORMULA owns the compiler default; the TABLE is demoted to a search seed.
+    assert TritonB200FormulaMatmulHeuristic.promote_seed_to_default is True
+    assert TritonB200MatmulHeuristic.promote_seed_to_default is False
+    assert TritonB200FormulaMatmulHeuristic.HARDWARE_TARGETS == (("cuda", "sm100"),)
+    # The formula is a subclass of the H100 budget formula (inherits _matmul_tile).
+    assert issubclass(TritonB200FormulaMatmulHeuristic, TritonH100MatmulHeuristic)
+    # Registered AFTER the table so it wins the last-promote-wins default loop.
+    from helion._compiler.autotuner_heuristics import get_heuristics
+
+    order = [h.__name__ for h in get_heuristics("triton")]
+    assert order.index("TritonB200FormulaMatmulHeuristic") > order.index(
+        "TritonB200MatmulHeuristic"
+    )
+
+
+def test_h100_base_tile_is_unchanged_by_tmem_budget() -> None:
+    # TMEM_BUDGET is None on the sm90 base (no tensor memory), so the TMEM growth step is skipped and
+    # the H100 formula stays byte-identical: a big compute-bound cube keeps the register-budget wide-N
+    # [128, 256, 64] w8 s4 tile (num_sm=132).
+    assert TritonH100MatmulHeuristic.TMEM_BUDGET is None
+    assert TritonH100MatmulHeuristic._matmul_tile(4096, 4096, 4096, 2, 132, 1) == (
+        128,
+        256,
+        64,
+        8,
+        4,
+        1,
+    )
+
+
+def test_b200_tile_grows_to_fill_tmem_budget() -> None:
+    # On sm100 the tile is grown against the TENSOR-MEMORY budget (the accumulator lives there, not in
+    # registers): double whichever axis still fits, N first since it is the coalesced store axis. The
+    # reservation includes the A operand at the largest bk the formula can emit, so the [256,256] fp32
+    # accumulator -- which alone exactly fills tensor memory -- can never be reached, and the wide
+    # [128,256] tile is the largest that fits.
+    cls = TritonB200FormulaMatmulHeuristic
+    sm = 148
+    for m, n, k in ((2048, 2048, 2048), (4096, 4096, 4096), (8192, 8192, 8192)):
+        assert cls._matmul_tile(m, n, k, 2, sm, 1)[:2] == (128, 256), (m, n, k)
+    # Non-saturated batched dots grow too -- tensor memory is theirs to use as well.
+    assert cls._matmul_tile(4096, 4096, 4096, 2, sm, 4)[:2] == (128, 256)
+    # ...but a SATURATED batched dot keeps the small occupancy tile step (2.5) chose for it; growing it
+    # back would undo that (measured: it inflates mamba-shaped tiles from [32,64] to [32,1024]).
+    bm, bn = cls._matmul_tile(32, 1024, 4096, 2, sm, 1000)[:2]
+    assert bm <= cls.SAT_TILE_BM and bn <= cls.SAT_TILE_BN, (bm, bn)
+
+
+def test_b200_tmem_budget_matches_measured_hardware() -> None:
+    # _tmem_bytes is a deliberate OVER-estimate in BYTES, checked against TMEM_BUDGET exactly like
+    # _smem_bytes is checked against SMEM_BUDGET. Hardware reports tensor memory in COLUMNS (limit
+    # 512), so the ground truth below is measured tmem_size in columns and what must agree is the
+    # VERDICT: fits / does not fit. Ground truth is tmem_size read off compiled sm100 kernel metadata
+    # in the worst case, i.e. with the A operand promoted into tensor memory.
+    cls = TritonB200FormulaMatmulHeuristic
+    hw_columns = {  # (bm, bn, bk) bf16 -> measured tmem columns, A promoted; hardware limit is 512
+        (64, 64, 16): 128,
+        (64, 128, 16): 256,
+        (64, 256, 16): 512,
+        (64, 512, 16): 512,
+        (64, 1024, 16): 520,
+        (128, 128, 16): 256,
+        (128, 256, 16): 512,
+        (128, 512, 16): 520,
+        (128, 512, 32): 528,
+        (128, 512, 64): 544,
+        (128, 1024, 16): 1032,
+        (256, 128, 16): 512,
+        (256, 256, 16): 528,
+        (
+            256,
+            256,
+            32,
+        ): 544,  # the CI failure: 512 for the acc + 32 for the promoted A operand
+        (256, 256, 64): 576,
+        (256, 256, 128): 640,
+        (256, 512, 16): 1040,
+    }
+    for (bm, bn, bk), cols in hw_columns.items():
+        fits_model = cls._tmem_bytes(bm, bn, bk, 2) <= cls.TMEM_BUDGET
+        fits_hardware = cols <= 512
+        assert fits_model == fits_hardware, (bm, bn, bk, cols)
+    # Specifically: the [256,256] square is rejected, the wide [128,256] tile accepted.
+    assert cls._tmem_bytes(256, 256, 16, 2) > cls.TMEM_BUDGET
+    assert cls._tmem_bytes(128, 256, 64, 2) <= cls.TMEM_BUDGET
+    # The budget is the real capacity: 128 lanes x 512 columns x 32 bit.
+    assert cls.TMEM_BUDGET == 128 * 512 * 4
+    # ...and a [256,256] fp32 accumulator alone exactly fills it, which is why no promoted A operand
+    # can ever coexist with that square.
+    assert cls.TMEM_BUDGET == 256 * 256 * 4
+    # A tile too small for tcgen05 uses no tensor memory at all (measured tmem_size == 0), so it must
+    # be charged nothing -- otherwise tiny decode tiles get rejected for a resource they never touch.
+    assert cls._tmem_bytes(32, 4096, 16, 2) == 0
+    assert cls._tmem_bytes(16, 512, 32, 4) == 0
+
+
+def test_b200_smem_bytes_bounds_measured_hardware() -> None:
+    # The epilogue's accumulator staging buffer (bm*bn*4) is invisible to the operand-ring formula and
+    # is independent of num_stages, so a tile can fit the ring and still exceed SMEM. Values are
+    # measured `shared` from compiled sm100 metadata; the model must be an UPPER bound on each.
+    cls = TritonB200FormulaMatmulHeuristic
+    # (bm, bn, bk, itemsize, num_stages) -> measured shared bytes (worst case over epilogue variants)
+    measured = {
+        (64, 64, 64, 2, 6): 32784,
+        (128, 128, 64, 2, 6): 65552,
+        (128, 256, 64, 2, 6): 131072,
+        (256, 128, 32, 2, 6): 131072,
+        (256, 256, 32, 2, 6): 262144,
+        (
+            256,
+            256,
+            16,
+            2,
+            6,
+        ): 262144,  # ring shrinks with bk, the epilogue term does NOT
+        (128, 128, 128, 4, 6): 786448,
+    }
+    for (bm, bn, bk, itemsize, ns), shared in measured.items():
+        assert cls._smem_bytes(bm, bn, bk, itemsize, ns) >= shared, (bm, bn, bk, ns)
+    # [256,256] is rejected by the epilogue term alone, at ANY bk -- the ring cannot rescue it.
+    for bk in (16, 32, 64):
+        assert cls._smem_bytes(256, 256, bk, 2, 1) > cls.SMEM_BUDGET
+    # The slack is load-bearing: without it an otherwise-exact bound misses by the 16-byte mbarriers.
+    assert cls.SMEM_SLACK >= 16
+
+
+def test_sm90_conservative_accounting_is_inert() -> None:
+    # sm90 must stay byte-identical, but NOT because the epilogue term is Blackwell-specific -- it is
+    # not. Measured on an sm90 target, a [128,256,64] bf16 dot with an fp32 output reports
+    # shared=131072 == bm*bn*4, exactly as sm100 does, so EPILOGUE_ACC_ITEMSIZE is set on the base.
+    # What is sm100-only is ENFORCING the budget by shrinking the tile.
+    cls = TritonH100MatmulHeuristic
+    assert cls.TMEM_BUDGET is None  # no tensor memory on sm90
+    assert cls._tmem_bytes(256, 256, 32, 2) == 0
+    assert cls.EPILOGUE_ACC_ITEMSIZE == 4  # the term is arch-independent...
+    assert (
+        cls.ENFORCE_SMEM_BUDGET is False
+    )  # ...but sm90 does not enforce it (model over-estimates)
+    assert cls.SMEM_SLACK == 0
+
+    # The epilogue term is a NO-OP on sm90 for an arithmetic reason: the accumulator lives in the
+    # register file, so ACC_BUDGET caps the emittable tile at bm*bn == ACC_BUDGET. Binding would need
+    # bm*bn * 4 > SMEM_BUDGET -- unreachable. Pin both halves of that argument so a future ACC_BUDGET
+    # bump cannot silently make the term start binding on sm90 unnoticed.
+    assert cls.ACC_BUDGET * cls.EPILOGUE_ACC_ITEMSIZE <= cls.SMEM_BUDGET
+    emitted = {
+        cls._matmul_tile(m, n, k, itemsize, 132, pinned_grid)[:2]
+        for m in (1, 16, 256, 4096, 65536)
+        for n in (1, 16, 256, 4096, 65536)
+        for k in (16, 256, 4096)
+        for itemsize in (1, 2, 4)
+        for pinned_grid in (1, 4, 1000)
+    }
+    assert max(bm * bn for bm, bn in emitted) <= cls.ACC_BUDGET
+
+    # And the sm90 tile is unchanged: still the register-budget [128, 256].
+    assert cls._matmul_tile(4096, 4096, 4096, 2, 132, 1)[:3] == (128, 256, 64)


### PR DESCRIPTION
---

## UPDATE — conservative resource accounting (supersedes the `[256,256]` square below)

CI caught a real bug: `test_bf16xint16` failed with
`OutOfResources: tensor memory, Required: 544, Hardware limit: 512`. Blackwell has **two** hard
per-CTA limits, and Triton enforces both at kernel **LOAD** time (`CompiledKernel._init_handles`), so
an over-budget config compiles fine and then fails to launch. Since this seed owns the
`effort=none` compiler default — where there is no fallback — it must never emit one.

**Root cause.** `_int16xbf16_gemm` casts its **LHS**, and `tritongpu-promote-lhs-to-tmem` then copies
A into tensor memory *on top of* a `[256,256]` fp32 accumulator that already exactly fills it
(512 of 512 columns) → 544. Note the sibling `_bf16xint16_gemm`, which casts the **RHS**, passes with
the identical tile: only the A operand is ever promoted.

**Fix — two budgets, both deliberately crude over-estimates** rather than models of where Triton
places things:

```
_tmem_bytes = bm*bn*4 (fp32 accumulator)  +  bm*bk*itemsize (A operand)
_smem_bytes = max(operand ring * num_stages,  bm*bn*4)  +  slack
```

Both charge their worst case **unconditionally**. Measurement showed no predicate is safe here:
promotion fires for a dtype cast, **any** same-dtype elementwise op, *and* a strided load; and on the
SMEM side a **bare fp32-output store** already costs the full `bm*bn*4`, so "nothing but the store
touches the tile" does not imply the narrow path. Predicting a Triton MLIR pass we do not control is a
losing game, so we always reserve for it. B is never promoted (shared memory only).

The tile is now **grown to fill the tensor-memory budget** rather than pinned to a hardcoded square,
and two shrink-to-fit loops at the end give up tile area whenever no cheaper knob — `block_k`, then
`num_stages` — can make the config legal. Both are re-derived after each shrink, so a smaller tile
immediately gets the deeper pipeline it can now afford.

`TMEM_ACC_BUDGET` is gone, replaced by `TMEM_BUDGET` (a plain byte budget, symmetric with
`SMEM_BUDGET`). All new terms are `None`/`0` on the sm90 base, so that path stays byte-identical.

### Verification (B200, sm100)

| check | result |
| --- | --- |
| Budget violations over 86,640 emitted configs | **0** |
| Launch failures, 2016 + 540 seed × kernel-variant combos vs real hardware limits | **0** |
| sm90 seed lists byte-identical (primary + both alternates), 10,368 shapes | **0 diffs** |
| `test_bf16xint16` (the CI failure) | **passes** |
| `test_examples.py` + `test_autotuner.py` + `test_config_api.py` | 292 passed |
| Golden-file churn | **none** |

### Perf impact

The head-to-head table below still holds directionally (**geomean 1.19× vs the incumbent table**), but
its `[256,256,32]` rows are no longer the emitted tile. Relative to this PR's earlier square, the
conservative accounting costs **0.3% geomean** (cold-L2, median-of-15, bf16):

| shape | new/old | | shape | new/old |
| --- | --- | --- | --- | --- |
| 2048³ | **1.18×** | | 4096³ | 0.91× |
| 1024³ | **1.21×** | | 8192³ | 0.88× |
| 3584³ | **1.09×** | | 3072³ | 0.89× |

Large cubes give up ~9–12%; smaller and rectangular shapes gain. This is an **accepted trade** — the
square cannot be emitted safely. `[128,256,64]` was also confirmed to be the *best* tile that fits the
budget: every alternative measured worse (`[256,128,64]` 0.76×, `[128,256,32]` ns=6 0.77×) or failed to
compile.

*(The sections below predate this change. Where they describe the `[256,256]` TMEM square or
`TMEM_ACC_BUDGET`, the text above supersedes them; the broad 48-shape characterization and the
"why the table is worth replacing" argument are unaffected.)*


# [autotuner][sm100] B200 matmul: subsume the table with the general formula

## What

Re-homes the H100 matmul budget-formula (`TritonH100MatmulHeuristic`, the parent PR) on Blackwell
as `TritonB200FormulaMatmulHeuristic` (sm100), and **promotes it as the sm100 compiler default in
place of the incumbent `TritonB200MatmulHeuristic` table**. The table is demoted to an unpromoted
search seed (kept, harmless).

To make the formula subclass-tunable, this PR first refactors it: the budget constants are lifted
from function-locals into class attributes, `_h100_matmul_tile` becomes the `_matmul_tile`
classmethod (reading `cls.*`), and an `_extra_config_fields` hook is added. **The sm90 path is
byte-identical** (constants unchanged, `TMEM_ACC_BUDGET`/`SAT_NUM_WARPS` default to `None`,
`WAVE_FILL_STRICT` to `False`) — verified: config emission is unchanged across the curriculum and
the sm90 unit tests still pass.

## Why the incumbent table is worth replacing

The table (`matmul_b200.json`) fires only on **in-bucket fp16/bf16 2-D matmul** and declines fp32,
fp8, bmm, mamba, and any dim > 4096 — those fall back to the catastrophic `~[16,16,16]` default. The
general formula covers all of them, and (below) is also **faster on the table's own shapes**.

## The 4 B200 deltas (each keyed on a hardware property, sm100-gated)

1. **`TMEM_ACC_BUDGET = 65536`** — tcgen05 holds the fp32 accumulator in tensor memory (128×512×32b),
   double the register budget, so a single-GEMM tile grows to the `[256,256]` square that fills it
   (256 = √65536, derived). Gated on `pinned_grid==1` (only the un-batched-GEMM codegen path uses the
   TMEM accumulator) and on the square still filling a wave.
2. **`SMEM_BUDGET = 232448`** — B200's real per-CTA opt-in (the H100 228 KiB was ~1 KiB too large).
3. **`SAT_TILE_*` + `SAT_NUM_WARPS=1`** — a saturated batched dot on 148 SMs wants a smaller
   `[32,64]` tile with 1 warp (more concurrent CTAs). Lifts mamba.
4. **`WAVE_FILL_STRICT`** — require a strict wave-efficiency gain to shrink a tile (a shrink that
   leaves occupancy flat only destroys operand reuse). Rescues wide-N tiny-M shapes. Universal fix,
   gated to sm100 only to keep the sm90 freeze byte-identical.


## Perf — broad B200 characterization (48 shapes, cold-L2, no autotuning)

The previous numbers here covered only the handful of aligned shapes where the incumbent table also
fires. This is a **broad, honest sweep** (the sm100 analog of #3006's H100 run): 48 shapes across 4
kernels on a **B200 SXM** (sm100, torch 2.12.0+cu132, triton 3.7.0), 3 arms — this **seed** (the
promoted no-autotune default) vs. the old `[16,16,16]` **default** vs. **`torch.compile(max-autotune-no-cudagraphs)`**
(best-of-cuBLAS+Triton) — timed cold-L2 with CUDA-graph device time (512 MiB L2 flush = 4× the
126.5 MiB B200 L2; triton's built-in 256 MiB does *not* evict on Blackwell). Every shape reported,
nothing dropped; the hard shapes (non-pow2, prime, deep-K, tall-skinny, decode) are first-class.
Numbers are the **geomean of the per-shape ratios**:

| kernel | shapes | vs. `[16,16,16]` default | vs. `torch.compile` max-autotune |
| --- | --- | --- | --- |
| `matmul` (bf16) | 22 | 12.7× | 0.74 |
| `fp8_gemm` (e4m3) | 10 | 25.5× | 0.70 |
| `bmm` (bf16) | 8 | 14.1× | 0.53 |
| **GEMM (matmul+fp8+bmm)** | **40** | **15.5×** | **0.68** |
| `mamba2_chunk_state` (bf16) † | 8 | 6.5× | 1.61 |

`vs. default` = `default_time / seed_time`; `vs. tc` = `tc_time / seed_time` (>1 = seed faster).
`torch.compile` selected cuBLAS/cuBLASLt on **39/40 GEMM cells** (CUDA-profiler-verified — only the
`matmul` M=1 decode shape picked a Triton GEMV; every `fp8_gemm` and `bmm` cell, incl. the tiny ones,
is genuine cuBLAS/cuBLASLt). The **`vs. default`** column is the real story on B200: the incumbent
table declines fp8, bmm, mamba, and any dim > 4096 → those fall to the catastrophic `[16,16,16]`
default (up to **135 ms** on the vocab GEMM), which the formula rescues by 6–50× per cell.

† `mamba2_chunk_state` has no cuBLAS analog (fused batched GEMM + state decay), so its `torch.compile`
arm is a **Triton** kernel; the seed beats best-Triton by 1.6×. Kept in its own row, never folded into
the GEMM-vs-cuBLAS aggregate.

**Aligned vs. adversarial (GEMM):** 0.71 on aligned/pow2 shapes vs. 0.66 on the adversarial
non-pow2/prime/deep-K/tall/wide set — the seed degrades gracefully, with two named weak spots surfaced
not hidden: `8191³` prime (0.17, a Triton static-shape tail-mask ceiling) and `256×16384×256` deep-K
(0.26, occupancy-starved). `bmm` (0.53) is the weakest family — a batched-dot *lowering* ceiling, not
a formula one.

**Full detail — per-shape tables, raw per-round data, methodology, an adversarial self-audit, and the
head-to-head-table re-verification below:**
https://github.com/calebmkim/helion/tree/matmul-perf-char-b200/_lab/matmul-perf-char
(`results/summary.md` = the report, `results/results.jsonl` = machine-readable raw, `README.md` = reproduce).

## Head-to-head vs. the incumbent table on its own shapes (secondary)

The broad table above is the headline. But the incumbent is a *narrow tuned table* — it fires only on
in-bucket fp16/bf16 2-D matmul (6 of the 48 shapes above), whereas the formula fires on **all 48**. So
the fair "beat it on its own turf" test is the shapes where **both** heuristics fire — the table's
tuned cubes plus its own PR #2428 shapes. Both arms are the raw seed config, cold-L2, median-of-15;
`new/old > 1` = the formula is faster.

| shape (M,N,K) | dtype | old tile (table) | old µs | new tile (formula) | new µs | new/old |
| --- | --- | --- | --- | --- | --- | --- |
| (2048, 2048, 2048) | bf16 | [128,128,64] | 28.70 | [128,256,64] | 22.72 | **1.26×** |
| (3072, 3072, 3072) | bf16 | [128,128,64] | 64.42 | [256,256,32] | 45.18 | **1.43×** |
| (3584, 3584, 3584) | bf16 | [128,128,64] | 101.47 | [128,256,64] | 84.00 | **1.21×** |
| (4096, 4096, 4096) | bf16 | [128,128,64] | 139.30 | [256,256,32] | 111.58 | **1.25×** |
| (512, 512, 512)    | bf16 | [16,64,128]  | 9.18  | [64,64,128]  | 9.22  | 1.00× |
| (1024, 1024, 1024) | bf16 | [128,64,64]  | 15.30 | [128,64,128] | 11.33 | **1.35×** |
| (4096, 2048, 2048) | bf16 | [256,256,32] | 35.78 | [256,256,32] | 33.70 | 1.06× |
| (1024, 8192, 1024) | bf16 | [256,256,32] | 25.57 | [256,256,32] | 23.46 | 1.09× |
| (8192, 2048, 2048) | bf16 | [256,256,32] | 63.55 | [256,256,32] | 60.51 | 1.05× |
| (2048, 2048, 2048) | fp16 | [128,128,64] | 28.80 | [128,256,64] | 23.39 | **1.23×** |
| (3072, 3072, 3072) | fp16 | [128,128,64] | 64.54 | [256,256,32] | 46.08 | **1.40×** |
| (3584, 3584, 3584) | fp16 | [128,128,64] | 105.44 | [128,256,64] | 85.28 | **1.24×** |
| (4096, 4096, 4096) | fp16 | [128,128,64] | 144.32 | [256,256,32] | 113.73 | **1.27×** |
| (512, 512, 512)    | fp16 | [16,64,128]  | 9.18  | [64,64,128]  | 9.18  | 1.00× |
| (1024, 1024, 1024) | fp16 | [128,64,64]  | 15.30 | [128,64,128] | 11.36 | **1.35×** |
| (4096, 2048, 2048) | fp16 | [256,256,32] | 35.74 | [256,256,32] | 33.70 | 1.06× |
| (1024, 8192, 1024) | fp16 | [256,256,32] | 25.60 | [256,256,32] | 23.46 | 1.09× |
| (8192, 2048, 2048) | fp16 | [256,256,32] | 64.45 | [256,256,32] | 62.43 | 1.03× |

**Geomean 1.19× faster than the incumbent; no regression on any cell** (the 512³ tie is a sub-10µs
noise-floor shape). The cubes get the big wins (the `[256,256]` TMEM square); on the rectangular /
skinny shapes both pick the same `[256,256,32]` tile and the formula edges it on num_stages. An
independent re-run of this exact table reproduces it (geomean 1.20×, no regression), and extends it to
**all 10 of the incumbent table's tuned buckets** — the formula wins or ties every one (see
`results/verify_pr3007_table.json` and `results/pr3007_table_full_coverage.md` in the link above).

## Tests

`test_matmul_heuristics.py`: promotion/subsumption wiring, sm90 byte-identical, and the TMEM-square /
batched-dot-excluded / small-M-no-grow behaviors.


---
**Stack (via stack-pr):**
- #3006 H100 matmul seed (base)
- #3007 B200 matmul: subsume the table ⬅ (this PR, top)