### PR TITLE
Add fast dispatch cache to Kernel.__call__

### DIFF
--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -192,6 +192,10 @@ class Kernel(Generic[_R]):
             for config in configs or []
         ]
         self._bound_kernels: dict[BoundKernelInMemoryCacheKey, BoundKernel] = {}
+        # Fast dispatch cache: maps a cheap, fine-grained argument key (exact
+        # dtype/shape/stride/device per tensor) directly to a BoundKernel,
+        # skipping the full specialization-key machinery on repeat calls.
+        self._dispatch_cache: dict[Hashable, BoundKernel] = {}
         self._specialize_extra: dict[
             Hashable, list[Callable[[Sequence[object]], Hashable]]
         ] = {}
@@ -272,6 +276,52 @@ class Kernel(Generic[_R]):
         self._specialize_extra[signature] = extra_fns = bound_kernel._specialize_extra()
         extra_results: tuple[Hashable, ...] = tuple([s(args) for s in extra_fns])
         return BoundKernelInMemoryCacheKey(signature, extra_results)
+
+    def _fast_dispatch_key(self, args: tuple[object, ...]) -> Hashable | None:
+        """
+        Build a cheap dispatch key for the fast-path cache in ``__call__``.
+
+        The key records exact per-argument metadata (dtype/shape/stride/device
+        for tensors, type and value for scalars), which is strictly finer than
+        the full specialization key: any two argument lists that produce
+        different full keys also produce different fast keys.  That makes it
+        safe to map a fast key directly to the BoundKernel that a full
+        ``bind()`` resolved for the same arguments.
+
+        Returns None when an argument type is not handled (tensor subclasses,
+        containers, ...), or when there is no tensor argument to pin down the
+        device; callers must then take the regular ``bind()`` path.
+        """
+        key: list[Hashable] = []
+        has_tensor = False
+        for a in args:
+            t = type(a)
+            if t is torch.Tensor or t is torch.nn.Parameter:
+                tensor = cast("torch.Tensor", a)
+                has_tensor = True
+                si = getattr(tensor, "_dynamo_static_indices", None)
+                key.append(
+                    (
+                        tensor.dtype,
+                        tensor.shape,
+                        tensor.stride(),
+                        tensor.device,
+                        None if si is None else frozenset(si),
+                    )
+                )
+            elif t is int or t is float or t is bool or t is str:
+                key.append((t, a))
+            elif a is None:
+                key.append(None)
+            elif t is torch.dtype or t is torch.device:
+                key.append(a)
+            else:
+                return None
+        if not has_tensor:
+            return None
+        if self._key_fn is not None:
+            key.append(self._key_fn(*args))
+        return tuple(key)
 
     def bind(self, args: tuple[object, ...]) -> BoundKernel[_R]:
         """
@@ -440,6 +490,17 @@ class Kernel(Generic[_R]):
         """
         if kwargs:
             args = self.normalize_args(*args, **kwargs)
+        elif self._dispatch_cache:
+            # Fast path: repeat call with argument metadata seen before. The
+            # cache is only populated by calls that already took the slow
+            # path below, so hitting it cannot skip autotuning/compilation.
+            # (The cache stays empty under TPU compile capture, so this
+            # cannot bypass auto_capture_call below.)
+            fast_key = self._fast_dispatch_key(args)
+            if fast_key is not None:
+                bound = self._dispatch_cache.get(fast_key)
+                if bound is not None and bound._run is not None:
+                    return bound._run(*args)
         if self.settings.backend == "pallas" and _TPU_COMPILE_CAPTURE:
             # Local import: _tpu_compile_capture pulls in the dynamo HOP machinery,
             # not ready when kernel.py first loads during ``import helion``.
@@ -449,7 +510,14 @@ class Kernel(Generic[_R]):
             result = auto_capture_call(self, args)
             if result is not RUN_NORMAL:
                 return cast("_R", result)
-        return self.bind(args)(*args)
+            return self.bind(args)(*args)
+        bound = self.bind(args)
+        result = bound(*args)
+        if bound._run is not None:
+            fast_key = self._fast_dispatch_key(args)
+            if fast_key is not None:
+                self._dispatch_cache[fast_key] = bound
+        return result
 
     def reset(self) -> None:
         """
@@ -457,6 +525,7 @@ class Kernel(Generic[_R]):
         recompile and re-autotune.
         """
         self._bound_kernels.clear()
+        self._dispatch_cache.clear()
 
     @property
     def jax_fn(self) -> Callable[..., Any]:

--- a/test/test_fast_dispatch_key.py
+++ b/test/test_fast_dispatch_key.py
@@ -1,0 +1,186 @@
+"""Tests for ``Kernel._fast_dispatch_key``, the cheap dispatch key that backs
+the ``Kernel.__call__`` fast-path cache (``_dispatch_cache``).
+
+The correctness argument for the cache is that the fast key is *strictly finer*
+than the full specialization key: any two argument lists that produce different
+full keys also produce different fast keys, so a fast-key hit can never dispatch
+to a BoundKernel that a full ``bind()`` would not have resolved for those
+arguments. "Strictly" finer because the converse fails -- the fast key
+distinguishes argument lists (e.g. scalar values, or dynamic-shape sizes that
+bucket together) that the full key deliberately collapses.
+
+These tests pin down:
+1. Refinement: across a matrix of dtype/shape/stride variants, distinct full
+   keys always imply distinct fast keys.
+2. Strictness under two witnesses that share a full key but not a fast key:
+   scalar value (full key records only ``type``) and dynamic-shape bucketing.
+3. The documented ``None`` returns: unhandled argument types and the
+   no-tensor-to-pin-the-device case.
+4. ``key=`` functions feed into the fast key.
+
+The key is pure argument-metadata bookkeeping, so it needs no compilation and
+runs on CPU-only bots.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+import helion
+import helion.language as hl
+
+
+@helion.kernel(static_shapes=True)
+def _static_add1(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size(0)):
+        out[tile] = x[tile] + 1
+    return out
+
+
+@helion.kernel(static_shapes=False)
+def _dynamic_add1(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size(0)):
+        out[tile] = x[tile] + 1
+    return out
+
+
+@helion.kernel(static_shapes=False)
+def _dynamic_add_scalar(x: torch.Tensor, s: int) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size(0)):
+        out[tile] = x[tile] + s
+    return out
+
+
+class TestFastDispatchKey(unittest.TestCase):
+    def test_refinement_across_dtype_shape_stride(self) -> None:
+        """Every pair of argument lists with different *full* keys must also
+        have different *fast* keys -- the property that makes a fast-key hit
+        safe to dispatch directly to a previously-bound BoundKernel."""
+        variants = {
+            "f32_64": (torch.empty(64, dtype=torch.float32),),
+            "f64_64": (torch.empty(64, dtype=torch.float64),),
+            "f32_128": (torch.empty(128, dtype=torch.float32),),
+            "f32_8x16T": (torch.empty(8, 16, dtype=torch.float32).transpose(0, 1),),
+            "f32_8x16": (torch.empty(8, 16, dtype=torch.float32),),
+        }
+        full = {
+            name: _static_add1.specialization_key(a) for name, a in variants.items()
+        }
+        fast = {
+            name: _static_add1._fast_dispatch_key(a) for name, a in variants.items()
+        }
+
+        names = list(variants)
+        # There must be at least one distinct pair, else the test is vacuous.
+        saw_distinct_full = False
+        for i in range(len(names)):
+            for j in range(i + 1, len(names)):
+                a, b = names[i], names[j]
+                if full[a] != full[b]:
+                    saw_distinct_full = True
+                    self.assertNotEqual(
+                        fast[a],
+                        fast[b],
+                        msg=f"{a} vs {b}: full keys differ but fast keys collide",
+                    )
+        self.assertTrue(saw_distinct_full)
+
+    def test_strictly_finer_via_scalar_value(self) -> None:
+        """Witness that the fast key is *strictly* finer: two calls whose only
+        difference is a scalar's value share a full key (which records only the
+        scalar's ``type``) but get distinct fast keys (which record its value).
+        """
+        x = torch.empty(64, dtype=torch.float32)
+        a = (x, 1)
+        b = (x, 2)
+        self.assertEqual(
+            _dynamic_add_scalar.specialization_key(a),
+            _dynamic_add_scalar.specialization_key(b),
+        )
+        self.assertNotEqual(
+            _dynamic_add_scalar._fast_dispatch_key(a),
+            _dynamic_add_scalar._fast_dispatch_key(b),
+        )
+
+    def test_strictly_finer_via_dynamic_shape_bucketing(self) -> None:
+        """Second strictness witness: under ``static_shapes=False`` two nearby
+        sizes bucket to the same full key, but the fast key records the exact
+        shape and keeps them apart."""
+        a = (torch.empty(4096, dtype=torch.float32),)
+        b = (torch.empty(4097, dtype=torch.float32),)
+        self.assertEqual(
+            _dynamic_add1.specialization_key(a),
+            _dynamic_add1.specialization_key(b),
+        )
+        self.assertNotEqual(
+            _dynamic_add1._fast_dispatch_key(a),
+            _dynamic_add1._fast_dispatch_key(b),
+        )
+
+    def test_fast_key_records_exact_tensor_metadata(self) -> None:
+        """The per-tensor entry is exactly (dtype, shape, stride, device,
+        static-indices) with the raw ``torch.Size`` -- i.e. finer than any
+        bucketed/normalized form."""
+        x = torch.empty(64, dtype=torch.float32)
+        key = _static_add1._fast_dispatch_key((x,))
+        assert isinstance(key, tuple)
+        entry = key[0]
+        self.assertEqual(
+            entry,
+            (x.dtype, x.shape, x.stride(), x.device, None),
+        )
+        self.assertIs(type(entry[1]), torch.Size)
+
+    def test_returns_none_for_unhandled_arg_type(self) -> None:
+        """A container / unsupported argument type forces the slow ``bind()``
+        path by returning ``None``."""
+        x = torch.empty(64, dtype=torch.float32)
+        self.assertIsNone(_static_add1._fast_dispatch_key((x, [1, 2, 3])))
+        self.assertIsNone(_static_add1._fast_dispatch_key((x, object())))
+
+    def test_returns_none_without_tensor_to_pin_device(self) -> None:
+        """With no tensor argument there is nothing to pin the device, so the
+        key is ``None`` even though the scalars are individually handled."""
+        self.assertIsNone(_dynamic_add_scalar._fast_dispatch_key((1, 2)))
+        self.assertIsNone(_dynamic_add_scalar._fast_dispatch_key(()))
+
+    def test_scalar_and_none_entries(self) -> None:
+        """Handled non-tensor arguments contribute (type, value) for scalars
+        and a bare ``None`` for ``None``, provided a tensor pins the device."""
+        x = torch.empty(64, dtype=torch.float32)
+        key = _dynamic_add_scalar._fast_dispatch_key((x, 7))
+        assert isinstance(key, tuple)
+        self.assertEqual(key[1], (int, 7))
+
+        none_key = _static_add1._fast_dispatch_key((x, None))
+        assert isinstance(none_key, tuple)
+        self.assertIsNone(none_key[1])
+
+    def test_key_fn_feeds_into_fast_key(self) -> None:
+        """A user ``key=`` function participates in the fast key, so two calls
+        the user marks distinct get distinct fast keys."""
+
+        state = {"v": 0}
+
+        @helion.kernel(static_shapes=True, key=lambda x: state["v"])
+        def _with_key(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] + 1
+            return out
+
+        x = torch.empty(64, dtype=torch.float32)
+        state["v"] = 0
+        k0 = _with_key._fast_dispatch_key((x,))
+        state["v"] = 1
+        k1 = _with_key._fast_dispatch_key((x,))
+        self.assertNotEqual(k0, k1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked PRs:
 * #3017
 * #3015
 * #3012
 * #3010
 * __->__#3009
 * #3008


--- --- ---

### Add fast dispatch cache to Kernel.__call__


Repeat calls previously recomputed the full specialization key
(per-argument _specialization_extractors dispatch plus any
_specialize_extra extractors discovered during compilation) on every
invocation just to locate the BoundKernel. This adds a Kernel-level
_dispatch_cache mapping a cheap, exact argument key
(dtype/shape/stride/device/_dynamo_static_indices per tensor, type and
value per scalar) directly to the BoundKernel a prior bind() resolved.

The fast key is strictly finer than the full specialization key: any two
argument lists that produce different full keys also produce different
fast keys, so a hit can never dispatch to the wrong BoundKernel. The
cache is only populated after a successful slow-path bind()+run (so it
cannot skip autotuning/compilation), is bypassed under TPU compile
capture, respects user key= functions, returns None for unhandled
argument types or when no tensor pins the device, and is cleared by
Kernel.reset(). Backend-agnostic: helps Triton, Pallas, and CUTLASS.

test/test_fast_dispatch_key.py covers the strictly-finer invariant
(distinct full keys imply distinct fast keys across a dtype/shape/stride
matrix), strictness witnesses (scalar values and dynamic-shape bucketing
share a full key but split fast keys), None returns for unhandled arg
types or no tensor argument, and key= participation. CPU-only: the key
is pure argument-metadata bookkeeping with no compilation.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
