### PR TITLE
Add triton_direct_launch setting for direct kernel launch

### DIFF
--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -115,6 +115,25 @@ def my_kernel(x: torch.Tensor) -> torch.Tensor:
 
    Reserve this many streaming multiprocessors when launching persistent kernels. Default is ``0`` (use all SMs).
    Configure globally with ``HELION_PERSISTENT_RESERVED_SMS`` or per-kernel via ``@helion.kernel(..., persistent_reserved_sms=N)``.
+
+.. autoattribute:: Settings.triton_direct_launch
+
+   If ``True`` (default), repeat launches of an already-compiled Triton specialization skip
+   ``JITFunction.run`` and invoke the cached compiled kernel directly, substantially reducing
+   per-call launch overhead. Triton-only; the setting is accepted but ignored on other backends.
+   Disable per-kernel with ``@helion.kernel(triton_direct_launch=False)`` or globally with
+   ``HELION_TRITON_DIRECT_LAUNCH=0``.
+
+   The direct path automatically falls back to the full ``JITFunction.run`` path whenever it
+   cannot guarantee an identical launch: unaligned (non-16-byte) tensor pointer arguments,
+   mutated ``used_global_vals`` (globals captured by the generated kernel), extra launch kwargs
+   such as ``ptx_options``, Triton launch/pre-run hooks or debug/instrumentation knobs active
+   when the kernel is first launched, and ``torch.compile`` tracing all take the slow path.
+
+   One case is *not* auto-detected and requires opting out: Triton launch/pre-run hooks or
+   knobs registered *after* a kernel's first launch are not re-checked on each call, so a
+   profiler that attaches launch hooks mid-run will not observe direct launches. Set
+   ``triton_direct_launch=False`` for kernels that must always be visible to such hooks.
 ```
 
 ### Autotuning Settings
@@ -320,6 +339,7 @@ Built-in values for ``HELION_AUTOTUNER`` include ``"LFBOTreeSearch"`` (default),
 | ``HELION_STATIC_SHAPES`` | ``static_shapes`` | Set to ``0``/``false`` to disable global static shape specialization. |
 | ``HELION_FAST_MATH`` | ``fast_math`` | Set to ``1`` to enable fast math approximations (Helion-level and Inductor-level). May reduce numerical precision. |
 | ``HELION_PERSISTENT_RESERVED_SMS`` | ``persistent_reserved_sms`` | Reserve this many streaming multiprocessors when launching persistent kernels (``0`` uses all available SMs). |
+| ``HELION_TRITON_DIRECT_LAUNCH`` | ``triton_direct_launch`` | Set to ``0`` to disable the Triton direct-launch fast path and route every launch through ``JITFunction.run``. |
 | ``HELION_FORCE_AUTOTUNE`` | ``force_autotune`` | Force the autotuner to run even when explicit configs are provided. The result is saved to the cache. |
 | ``HELION_AUTOTUNE_FORCE_PERSISTENT`` | ``autotune_force_persistent`` | Restrict ``pid_type`` to persistent kernel strategies during config search. |
 | ``HELION_DISALLOW_AUTOTUNING`` | ``check_autotuning_disabled`` | Hard-disable autotuning; kernels must supply explicit configs when this is ``1``. |

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1131,6 +1131,10 @@ class TritonBackend(Backend):
         )
         if triton_jit_fn is not None and hasattr(triton_jit_fn, "device_caches"):
             triton_jit_fn.device_caches.clear()
+            # The direct-launch cache (helion.runtime.default_launcher) also
+            # holds the compiled binary; drop it so the recompile isn't
+            # bypassed by a direct launch of the ephemeral artifact.
+            triton_jit_fn.__dict__.pop("_helion_direct_launch", None)
 
     def compiled_cache_key(
         self, bound_kernel: BoundKernel[Any], compiled_fn: object
@@ -1287,6 +1291,18 @@ class TritonBackend(Backend):
 
     @property
     def library_imports(self) -> dict[str, str]:
+        from .compile_environment import CompileEnvironment
+        from .compile_environment import NoCurrentEnvironment
+
+        # The triton_direct_launch setting is resolved here, at codegen time,
+        # so the per-call path pays no cost for the choice: opted-out kernels
+        # import the always-slow launcher as _default_launcher.
+        launcher = "default_launcher"
+        try:
+            if not CompileEnvironment.current().settings.triton_direct_launch:
+                launcher = "default_slow_launcher"
+        except NoCurrentEnvironment:
+            pass
         return {
             "math": "import math",
             "operator": "import operator",
@@ -1298,7 +1314,7 @@ class TritonBackend(Backend):
             "triton_helpers": "from torch._inductor.runtime import triton_helpers",
             "tl_math": "from torch._inductor.runtime.triton_helpers import math as tl_math",
             "libdevice": "from torch._inductor.runtime.triton_compat import libdevice",
-            "_default_launcher": "from helion.runtime import default_launcher as _default_launcher",
+            "_default_launcher": f"from helion.runtime import {launcher} as _default_launcher",
             "fast_dividef": "from triton.language.extra.libdevice import fast_dividef",
             "fast_expf": "from triton.language.extra.libdevice import fast_expf",
         }

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -36,6 +36,8 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     import jax
+    from triton.compiler import CompiledKernel
+    from triton.runtime.jit import JITFunction
 
 log: logging.Logger = logging.getLogger(__name__)
 
@@ -169,6 +171,166 @@ def get_num_sm(device: torch.device, *, reserved_sms: int = 0) -> int:
     return max(available_sms - reserved_sms, 1)
 
 
+# Direct launch (controlled by the ``triton_direct_launch`` kernel setting,
+# on by default; see helion/runtime/settings.py for the full documentation).
+#
+# After a specialization has been compiled once through the regular
+# ``JITFunction.run`` path, repeat launches call the cached ``CompiledKernel``
+# handle directly, skipping option parsing, argument re-specialization,
+# cache-key stringification, hook dispatch, and launch-metadata construction.
+#
+# The direct path automatically falls back to ``JITFunction.run`` (which
+# re-validates everything) whenever it cannot guarantee an identical launch:
+# unseen argument metadata (dtype, scalar value, or 16-byte pointer alignment
+# -- all part of the cache key, so Triton's per-argument specialization axes
+# are covered), mutated ``used_global_vals`` (current global values are key
+# elements too, so a mutation is just a cache miss), extra launch kwargs,
+# active Triton hooks/knobs at prime time, torch.compile tracing, or any
+# exception while building the key.  These hazards cannot be caught *after*
+# a bad launch -- a misaligned launch surfaces as an asynchronous CUDA error
+# that poisons the context, and a stale captured global silently computes
+# wrong values -- so they are folded into the key and prevented up front
+# rather than detected afterwards.  The one intentional gap: Triton launch/pre-run
+# hooks and debug/instrumentation knobs are checked when a specialization is
+# first cached, not per call, so a profiler that registers launch hooks
+# *after* a kernel's first launch will not observe direct launches.  Set
+# ``triton_direct_launch=False`` (or HELION_TRITON_DIRECT_LAUNCH=0) to keep
+# every launch on the full ``JITFunction.run`` path.
+
+
+def _triton_direct_launch_ok(triton_kernel: JITFunction[object]) -> bool:
+    """One-time (per specialization) check that direct launching is safe.
+
+    Verifies no hook that ``JITFunction.run`` would have invoked is active
+    and no knob that feeds into launch behavior is set.  Called when caching
+    a compiled specialization, never on the per-launch hot path.
+    """
+    if triton_kernel.pre_run_hooks or triton_kernel.debug:
+        return False
+    import triton.knobs as knobs
+
+    rt = knobs.runtime
+    if rt.add_stages_inspection_hook is not None or rt.debug:
+        return False
+    for hook in (rt.launch_enter_hook, rt.launch_exit_hook):
+        # HookChain with empty ``calls`` is inactive; a plain user callable
+        # is always treated as active.
+        if hook is not None and getattr(hook, "calls", True):
+            return False
+    return not knobs.compilation.instrumentation_mode
+
+
+def _jit_function_run(
+    triton_kernel: JITFunction[object],
+    *args: object,
+    **run_kwargs: object,
+) -> object:
+    try:
+        return triton_kernel.run(*args, **run_kwargs)
+    except Exception as error:
+        message = str(error)
+        if "Cannot make_shape_compatible: incompatible dimensions" in message:
+            raise exc.ShapeMismatch("kernel operands", message) from error
+        raise
+
+
+_MISSING_GLOBAL = object()
+_TRITON_DRIVER: object = None
+
+
+def _triton_driver() -> object:
+    """Cache the Triton ``driver`` module so the direct-launch hot path
+    avoids a fresh ``from triton.runtime import driver`` import lookup on
+    every call."""
+    global _TRITON_DRIVER
+    if _TRITON_DRIVER is None:
+        from triton.runtime import driver
+
+        _TRITON_DRIVER = driver
+    return _TRITON_DRIVER
+
+
+def _direct_launch_populate(
+    triton_kernel: JITFunction[object],
+    compiled: CompiledKernel,
+    key: tuple[object, ...],
+    args: tuple[object, ...],
+) -> None:
+    """Cache a compiled specialization for direct launching.
+
+    The cache key is every launch argument (tensors contribute their dtype
+    and a 16-byte pointer-alignment bit, scalars their value) plus the
+    current value of every global Triton captured at compile time, plus
+    launch options and device.  Scalar values are strictly finer than the
+    buckets Triton specializes on (divisible-by-16, equals-1); dtype covers
+    pointer-type specialization when one ``JITFunction`` serves several
+    dtypes (``PyCodeCache`` dedups identical generated source, e.g. a
+    dtype-agnostic add kernel for bf16 and fp16); the alignment bit covers
+    Triton's pointer-alignment specialization, so an unaligned view arriving
+    after an aligned prime misses the cache and takes the slow path; global
+    values cover ``used_global_vals``, so a mutated global misses the cache
+    and the slow path raises Triton's own RuntimeError.
+    """
+    if not _triton_direct_launch_ok(triton_kernel):
+        return
+    state = triton_kernel.__dict__.get("_helion_direct_launch")
+    if state is None:
+        # Argument layout (which positions are tensors) is fixed per generated
+        # kernel, so bake the tensor/scalar split and the captured-globals
+        # lookups into a single compiled key function here; the hot path then
+        # builds the full key with no per-element type checks and no separate
+        # globals-guard loop.
+        tensor_idx = tuple(i for i, a in enumerate(args) if isinstance(a, torch.Tensor))
+        scalar_idx = tuple(
+            i for i in range(len(args)) if i not in frozenset(tensor_idx)
+        )
+        globals_guard = tuple(
+            (gdict, name)
+            for (name, _), (_val, gdict) in triton_kernel.used_global_vals.items()
+        )
+        make_key = _direct_launch_make_key_fn(tensor_idx, scalar_idx, globals_guard)
+        state = (make_key, {})
+        # pyrefly: ignore [missing-attribute]
+        triton_kernel._helion_direct_launch = state
+    state[1][(*key, *state[0](args))] = (
+        compiled.run,
+        compiled.function,
+        compiled.packed_metadata,
+        compiled,
+    )
+
+
+def _direct_launch_make_key_fn(
+    tensor_idx: tuple[int, ...],
+    scalar_idx: tuple[int, ...],
+    globals_guard: tuple[tuple[dict[str, object], str], ...],
+) -> Callable[[tuple[object, ...]], tuple[object, ...]]:
+    """Compile a flat key builder: scalar values, per-tensor dtype and
+    16-byte-alignment bit, then the current value of each captured global.
+
+    Compiling one expression per kernel (Triton's ``binder`` does the same)
+    roughly halves key-build time versus a generic generator plus a separate
+    globals-guard loop.  Concatenating the groups (rather than interleaving
+    in argument order) keeps the key unique because the tensor/scalar split
+    is fixed per generated kernel.  Every hazard is a key element, so any
+    deviation -- unseen scalar, new dtype, unaligned pointer, mutated or
+    deleted captured global, tensor/scalar mismatch (attribute error or an
+    identity-hashed tensor) -- is a cache miss that falls back to the slow
+    path; nothing needs to be caught after the launch (misalignment would be
+    an async CUDA error, a stale global would be silently wrong numerics).
+    """
+    namespace: dict[str, object] = {"_MISSING": _MISSING_GLOBAL}
+    parts = [f"a[{i}]" for i in scalar_idx]
+    for i in tensor_idx:
+        parts.extend((f"a[{i}].dtype", f"not a[{i}].data_ptr() & 15"))
+    for j, (gdict, name) in enumerate(globals_guard):
+        namespace[f"_g{j}"] = gdict
+        parts.append(f"_g{j}.get({name!r}, _MISSING)")
+    if not parts:
+        return lambda a: ()
+    return eval(f"lambda a: ({', '.join(parts)},)", namespace)
+
+
 def default_launcher(
     triton_kernel: object,
     grid: tuple[int, ...],
@@ -179,7 +341,112 @@ def default_launcher(
     launch_cooperative_grid: bool = False,
     **kwargs: dict,
 ) -> object:
-    """Default launcher function that executes the kernel immediately."""
+    """Default launcher function that executes the kernel immediately.
+
+    Repeat launches of an already-compiled specialization call the cached
+    ``CompiledKernel`` directly (see the direct-launch comment above).  Any
+    unsupported case or exception on the direct path falls back to the full
+    ``JITFunction.run`` path, which re-validates everything.  Kernels with
+    ``triton_direct_launch=False`` never reach this function; codegen binds
+    them to :func:`default_slow_launcher` instead.
+    """
+    if (
+        ptx_options is None
+        and not kwargs
+        and type(grid) is tuple
+        and not torch.compiler.is_compiling()
+    ):
+        state = triton_kernel.__dict__.get("_helion_direct_launch")  # type: ignore[union-attr]
+        if state is not None:
+            try:
+                # pyrefly: ignore [missing-attribute]
+                active = _triton_driver().active
+                device = active.get_current_device()
+                make_key, cache = state
+                cached = cache.get(
+                    (
+                        device,
+                        num_warps,
+                        num_stages,
+                        launch_cooperative_grid,
+                        *make_key(args),
+                    )
+                )
+                if cached is not None:
+                    # pyrefly: ignore [missing-attribute]
+                    stream = active.get_current_stream(device)
+                    kernel_run, kernel_function, packed_metadata, compiled = cached
+                    grid_size = len(grid)
+                    kernel_run(
+                        grid[0],
+                        grid[1] if grid_size > 1 else 1,
+                        grid[2] if grid_size > 2 else 1,
+                        stream,
+                        kernel_function,
+                        packed_metadata,
+                        None,  # launch_metadata (only consumed by launch hooks)
+                        None,  # launch_enter_hook
+                        None,  # launch_exit_hook
+                        *args,
+                    )
+                    return compiled
+            except Exception:
+                # Unhashable key element, stale cache entry (device reset,
+                # ...), or bad launch args: fall through to JITFunction.run,
+                # which re-validates and raises a proper error if the launch
+                # is genuinely broken.  (Unseen specializations and mutated
+                # captured globals are ordinary cache misses, not exceptions.)
+                pass
+
+    compiled = default_slow_launcher(
+        triton_kernel,
+        grid,
+        *args,
+        num_warps=num_warps,
+        num_stages=num_stages,
+        ptx_options=ptx_options,
+        launch_cooperative_grid=launch_cooperative_grid,
+        **kwargs,
+    )
+    if (
+        compiled is not None
+        and ptx_options is None
+        and not kwargs
+        and type(grid) is tuple
+        and not torch.compiler.is_compiling()
+    ):
+        # Population is best-effort: a failure (exotic args, driver quirk)
+        # only means later calls stay on the slow path.
+        with suppress(Exception):
+            # pyrefly: ignore [missing-attribute]
+            device = _triton_driver().active.get_current_device()
+            _direct_launch_populate(
+                # pyrefly: ignore [bad-argument-type]
+                triton_kernel,
+                # pyrefly: ignore [bad-argument-type]
+                compiled,
+                (device, num_warps, num_stages, launch_cooperative_grid),
+                args,
+            )
+    return compiled
+
+
+def default_slow_launcher(
+    triton_kernel: object,
+    grid: tuple[int, ...],
+    *args: object,
+    num_warps: int,
+    num_stages: int,
+    ptx_options: str | None = None,
+    launch_cooperative_grid: bool = False,
+    **kwargs: dict,
+) -> object:
+    """Launcher that always takes the full ``JITFunction.run`` path.
+
+    Kernels compiled with ``triton_direct_launch=False`` import this as
+    their ``_default_launcher`` (see ``TritonBackend.library_imports``), so
+    no direct-launch logic runs on their call path at all.
+    """
     # For both CUDA and MTIA, use the same kernel execution
     run_kwargs: dict = {
         "grid": grid,
@@ -191,16 +458,8 @@ def default_launcher(
     }
     if ptx_options is not None:
         run_kwargs["ptx_options"] = ptx_options
-    try:
-        return triton_kernel.run(  # type: ignore[union-attr]
-            *args,
-            **run_kwargs,
-        )
-    except Exception as error:
-        message = str(error)
-        if "Cannot make_shape_compatible: incompatible dimensions" in message:
-            raise exc.ShapeMismatch("kernel operands", message) from error
-        raise
+    # pyrefly: ignore [bad-argument-type]
+    return _jit_function_run(triton_kernel, *args, **run_kwargs)
 
 
 def _pallas_make_block_spec(

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -192,6 +192,10 @@ class Kernel(Generic[_R]):
             for config in configs or []
         ]
         self._bound_kernels: dict[BoundKernelInMemoryCacheKey, BoundKernel] = {}
+        # Fast dispatch cache: maps a cheap, fine-grained argument key (exact
+        # dtype/shape/stride/device per tensor) directly to a BoundKernel,
+        # skipping the full specialization-key machinery on repeat calls.
+        self._dispatch_cache: dict[Hashable, BoundKernel] = {}
         self._specialize_extra: dict[
             Hashable, list[Callable[[Sequence[object]], Hashable]]
         ] = {}
@@ -272,6 +276,52 @@ class Kernel(Generic[_R]):
         self._specialize_extra[signature] = extra_fns = bound_kernel._specialize_extra()
         extra_results: tuple[Hashable, ...] = tuple([s(args) for s in extra_fns])
         return BoundKernelInMemoryCacheKey(signature, extra_results)
+
+    def _fast_dispatch_key(self, args: tuple[object, ...]) -> Hashable | None:
+        """
+        Build a cheap dispatch key for the fast-path cache in ``__call__``.
+
+        The key records exact per-argument metadata (dtype/shape/stride/device
+        for tensors, type and value for scalars), which is strictly finer than
+        the full specialization key: any two argument lists that produce
+        different full keys also produce different fast keys.  That makes it
+        safe to map a fast key directly to the BoundKernel that a full
+        ``bind()`` resolved for the same arguments.
+
+        Returns None when an argument type is not handled (tensor subclasses,
+        containers, ...), or when there is no tensor argument to pin down the
+        device; callers must then take the regular ``bind()`` path.
+        """
+        key: list[Hashable] = []
+        has_tensor = False
+        for a in args:
+            t = type(a)
+            if t is torch.Tensor or t is torch.nn.Parameter:
+                tensor = cast("torch.Tensor", a)
+                has_tensor = True
+                si = getattr(tensor, "_dynamo_static_indices", None)
+                key.append(
+                    (
+                        tensor.dtype,
+                        tensor.shape,
+                        tensor.stride(),
+                        tensor.device,
+                        None if si is None else frozenset(si),
+                    )
+                )
+            elif t is int or t is float or t is bool or t is str:
+                key.append((t, a))
+            elif a is None:
+                key.append(None)
+            elif t is torch.dtype or t is torch.device:
+                key.append(a)
+            else:
+                return None
+        if not has_tensor:
+            return None
+        if self._key_fn is not None:
+            key.append(self._key_fn(*args))
+        return tuple(key)
 
     def bind(self, args: tuple[object, ...]) -> BoundKernel[_R]:
         """
@@ -440,6 +490,17 @@ class Kernel(Generic[_R]):
         """
         if kwargs:
             args = self.normalize_args(*args, **kwargs)
+        elif self._dispatch_cache:
+            # Fast path: repeat call with argument metadata seen before. The
+            # cache is only populated by calls that already took the slow
+            # path below, so hitting it cannot skip autotuning/compilation.
+            # (The cache stays empty under TPU compile capture, so this
+            # cannot bypass auto_capture_call below.)
+            fast_key = self._fast_dispatch_key(args)
+            if fast_key is not None:
+                bound = self._dispatch_cache.get(fast_key)
+                if bound is not None and bound._run is not None:
+                    return bound._run(*args)
         if self.settings.backend == "pallas" and _TPU_COMPILE_CAPTURE:
             # Local import: _tpu_compile_capture pulls in the dynamo HOP machinery,
             # not ready when kernel.py first loads during ``import helion``.
@@ -449,7 +510,14 @@ class Kernel(Generic[_R]):
             result = auto_capture_call(self, args)
             if result is not RUN_NORMAL:
                 return cast("_R", result)
-        return self.bind(args)(*args)
+            return self.bind(args)(*args)
+        bound = self.bind(args)
+        result = bound(*args)
+        if bound._run is not None:
+            fast_key = self._fast_dispatch_key(args)
+            if fast_key is not None:
+                self._dispatch_cache[fast_key] = bound
+        return result
 
     def reset(self) -> None:
         """
@@ -457,6 +525,7 @@ class Kernel(Generic[_R]):
         recompile and re-autotune.
         """
         self._bound_kernels.clear()
+        self._dispatch_cache.clear()
 
     @property
     def jax_fn(self) -> Callable[..., Any]:

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -595,6 +595,11 @@ class _Settings:
             _env_get_bool, "HELION_TRITON_DO_NOT_SPECIALIZE", False
         )
     )
+    triton_direct_launch: bool = dataclasses.field(
+        default_factory=functools.partial(
+            _env_get_bool, "HELION_TRITON_DIRECT_LAUNCH", True
+        )
+    )
 
 
 class Settings(_Settings):
@@ -697,6 +702,22 @@ class Settings(_Settings):
             "memory-bound kernels (vectorized loads rely on inner stride being "
             "specialized to constexpr 1). Only takes effect when static_shapes=False. "
             "Set HELION_TRITON_DO_NOT_SPECIALIZE=1 to enable globally."
+        ),
+        "triton_direct_launch": (
+            "If True (default), repeat launches of an already-compiled Triton "
+            "specialization skip JITFunction.run and call the cached compiled "
+            "kernel directly, substantially reducing per-call launch overhead. "
+            "Triton-only; accepted but ignored on other backends. The direct "
+            "path automatically falls back to the full JITFunction.run path "
+            "when it cannot guarantee an identical launch: unaligned (non-16-"
+            "byte) tensor pointer arguments, mutated used_global_vals, extra "
+            "launch kwargs (e.g. ptx_options), active Triton launch/pre-run "
+            "hooks or debug/instrumentation knobs, and torch.compile tracing "
+            "all take the slow path. Not supported (use "
+            "triton_direct_launch=False or HELION_TRITON_DIRECT_LAUNCH=0): "
+            "Triton launch hooks or knobs registered *after* a kernel's first "
+            "launch are not re-checked per call, so profilers attaching "
+            "mid-run will miss direct launches."
         ),
         "print_output_code": "If True, print the output code of the kernel to stderr.",
         "print_repro": "If True, print Helion kernel code, config, and caller code to stderr as a standalone repro script.",

--- a/pretuned_kernels/_bench.py
+++ b/pretuned_kernels/_bench.py
@@ -16,6 +16,7 @@ and via run.py's importlib loader.
 from __future__ import annotations
 
 import math
+import time
 from typing import TYPE_CHECKING
 
 import torch
@@ -46,9 +47,48 @@ def bench_cudagraph(call: Callable[[], object], rep: int = 100) -> float:
     return _do_bench_cudagraph_with_cache_clear(call, rep=rep, return_mode="median")
 
 
+def bench_walltime(call: Callable[[], object], warmup: int, rep: int) -> float:
+    """Mean wall-clock latency (ms) including host-side dispatch time.
+
+    ``triton.testing.do_bench`` times GPU events, so Python/host launch
+    overhead is hidden whenever the CPU can run ahead of the GPU (its
+    per-iteration L2-cache clear gives ~100us of GPU work to hide behind).
+    This timer instead measures ``time.perf_counter`` across a batch of
+    back-to-back calls followed by one final sync, so it reports
+    max(host time, GPU time) per call -- the number a host-bound caller
+    (e.g. an eager serving loop) actually experiences.  Mirrors
+    tritonbench's ``do_bench_walltime``.
+    """
+    call()  # ensure compiled
+    torch.cuda.synchronize()
+    with_timer_start = time.perf_counter()
+    for _ in range(5):
+        call()
+    torch.cuda.synchronize()
+    estimate_ms = (time.perf_counter() - with_timer_start) * 1e3 / 5
+
+    n_warmup = max(1, int(warmup / estimate_ms)) if estimate_ms > 0 else 25
+    n_repeat = max(1, int(rep / estimate_ms)) if estimate_ms > 0 else 100
+    for _ in range(n_warmup):
+        call()
+    torch.cuda.synchronize()
+
+    start = time.perf_counter()
+    for _ in range(n_repeat):
+        call()
+    torch.cuda.synchronize()
+    return (time.perf_counter() - start) * 1e3 / n_repeat
+
+
 def _bench(
-    call: Callable[[], object], use_cudagraph: bool, warmup: int, rep: int
+    call: Callable[[], object],
+    use_cudagraph: bool,
+    warmup: int,
+    rep: int,
+    walltime: bool = False,
 ) -> float:
+    if walltime:
+        return bench_walltime(call, warmup=warmup, rep=rep)
     if use_cudagraph:
         return bench_cudagraph(call, rep=rep)
     return tt.do_bench(call, warmup=warmup, rep=rep, return_mode="median")
@@ -63,6 +103,7 @@ def run_sweep(
     warmup: int = 25,
     rep: int = 100,
     verbose: bool = True,
+    walltime: bool = False,
 ) -> dict:
     """Benchmark helion vs baselines over ``shapes``; return metrics (print if verbose).
 
@@ -71,6 +112,10 @@ def run_sweep(
     and ``shape_cells`` is the preformatted leading column(s) for the table row.
     The metrics dict is always returned; the per-shape table is printed only when
     ``verbose``.
+
+    ``walltime=True`` times each call with ``bench_walltime`` (host + GPU
+    wall clock) instead of GPU events / CUDA graphs, exposing host-side
+    dispatch overhead that ``do_bench`` hides.
     """
 
     def _p(*args: object) -> None:
@@ -94,10 +139,10 @@ def run_sweep(
             header_printed = True
 
         helion_call()  # warmup / compile
-        ms_helion = _bench(helion_call, use_cudagraph, warmup, rep)
+        ms_helion = _bench(helion_call, use_cudagraph, warmup, rep, walltime)
         base_ms: dict[str, float] = {}
         for name, call in baseline_calls:
-            base_ms[name] = _bench(call, use_cudagraph, warmup, rep)
+            base_ms[name] = _bench(call, use_cudagraph, warmup, rep, walltime)
             speedups_by_base[name].append(
                 base_ms[name] / ms_helion if ms_helion > 0 else float("nan")
             )

--- a/pretuned_kernels/per_token_group_fp8_quant/per_token_group_fp8_quant.py
+++ b/pretuned_kernels/per_token_group_fp8_quant/per_token_group_fp8_quant.py
@@ -11,6 +11,8 @@ converted from vLLM's per-hardware config JSON).
 from __future__ import annotations
 
 import torch
+import triton
+import triton.language as tl
 
 import helion
 import helion.experimental
@@ -125,6 +127,95 @@ def _per_token_group_fp8_quant_vllm(
     )
 
 
+@triton.jit
+def _per_token_group_quant_fp8(
+    # Pointers to inputs and output
+    y_ptr: tl.tensor,
+    y_q_ptr: tl.tensor,
+    y_s_ptr: tl.tensor,
+    group_size: int,
+    # Num columns of y
+    y_num_columns: int,
+    y_row_stride: int,
+    # Avoid to divide zero
+    eps: float,
+    # Information for float8
+    fp8_min: tl.constexpr,
+    fp8_max: tl.constexpr,
+    use_ue8m0: tl.constexpr,
+    # Meta-parameters
+    BLOCK: tl.constexpr,
+) -> None:
+    """A Triton-accelerated function to perform per-token-group
+    quantization on a tensor.
+    This function converts the tensor values into float8 values.
+    """
+    groups_per_row = y_num_columns // group_size
+
+    # Map the program id to the row of X and Y it should compute.
+    g_id = tl.program_id(0)
+    row = g_id // groups_per_row
+    row_g_id = g_id % groups_per_row
+
+    # Ensure offset calculations use int64 to prevent overflow
+    y_ptr_offset = (row.to(tl.int64) * y_row_stride) + (
+        row_g_id.to(tl.int64) * group_size
+    )
+    y_ptr += y_ptr_offset
+
+    y_q_ptr_offset = g_id.to(tl.int64) * group_size
+    y_q_ptr += y_q_ptr_offset
+    y_s_ptr += g_id
+
+    cols = tl.arange(0, BLOCK)  # N <= BLOCK
+    mask = cols < group_size
+
+    y = tl.load(y_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+    # Quant
+    # Use multiply-by-reciprocal instead of division to match PyTorch's
+    # tensor/scalar division precision (GPU fast-division for constexpr
+    # divisors can introduce 1-ULP error that flips FP8 quantization at
+    # representable-value boundaries).
+    _absmax = tl.maximum(tl.max(tl.abs(y)), eps)
+    scale_raw = _absmax * (1.0 / fp8_max)
+    y_s = tl.math.exp2(tl.ceil(tl.log2(scale_raw))) if use_ue8m0 else scale_raw
+    y_q = tl.clamp(y / y_s, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
+
+    tl.store(y_q_ptr + cols, y_q, mask=mask)
+    tl.store(y_s_ptr, y_s)
+
+
+def _per_token_group_fp8_quant_triton(
+    input: torch.Tensor,  # noqa: A002
+    output_q: torch.Tensor,
+    output_s: torch.Tensor,
+    group_size: int,
+    eps: float,
+    fp8_min: float,
+    fp8_max: float,
+    scale_ue8m0: bool,
+    dummy_is_scale_transposed: bool = False,
+    dummy_is_tma_aligned: bool = False,
+) -> None:
+    """vLLM's Triton per-token-group FP8 quant kernel (mutates outputs)."""
+    num_tokens, hidden_size = input.shape
+    num_groups = num_tokens * (hidden_size // group_size)
+    block = triton.next_power_of_2(group_size)
+    _per_token_group_quant_fp8[(num_groups,)](
+        input,
+        output_q,
+        output_s,
+        group_size,
+        hidden_size,
+        input.stride(0),
+        eps,
+        fp8_min=fp8_min,
+        fp8_max=fp8_max,
+        use_ue8m0=scale_ue8m0,
+        BLOCK=block,
+    )
+
+
 def _baselines() -> list[tuple[str, object]]:
     """Baselines main() benchmarks against (torch always; vLLM when installed).
 
@@ -134,6 +225,7 @@ def _baselines() -> list[tuple[str, object]]:
     out: list[tuple[str, object]] = [
         ("torch", _per_token_group_fp8_quant_torch),
         ("torch_compile", torch.compile(_per_token_group_fp8_quant_torch)),
+        ("triton", _per_token_group_fp8_quant_triton),
     ]
     if _HAS_VLLM:
         out.append(("vllm", _per_token_group_fp8_quant_vllm))
@@ -162,7 +254,12 @@ def correctness_check() -> None:
     torch.testing.assert_close(oq.float(), oq_ref.float(), rtol=0.2, atol=0.2)
 
 
-def main(verbose: bool = True) -> dict:
+def main(
+    verbose: bool = True,
+    cudagraph: bool | None = None,
+    limit: int | None = None,
+    walltime: bool = False,
+) -> dict:
     import os
     import sys
 
@@ -178,6 +275,8 @@ def main(verbose: bool = True) -> dict:
     hidden_sizes = [2048, 4096, 5120]
     num_tokens_list = [1, 4, 16, 64, 256, 1024, 2048, 8192]
     shapes = [(t, h) for h in hidden_sizes for t in num_tokens_list]
+    if limit is not None:
+        shapes = shapes[:limit]
     baselines = _baselines()
 
     def make_calls(shape: tuple) -> tuple:
@@ -227,11 +326,37 @@ def main(verbose: bool = True) -> dict:
     return run_sweep(
         shapes,
         make_calls,
-        use_cudagraph=use_cudagraph(),
+        use_cudagraph=use_cudagraph() if cudagraph is None else cudagraph,
         verbose=verbose,
         shape_header=f"{'tokens':>7s}  {'hidden':>6s}  {'group':>6s}",
+        walltime=walltime,
     )
 
 
 if __name__ == "__main__":
-    main()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--no-cudagraph",
+        action="store_true",
+        help="benchmark with plain do_bench instead of CUDA graphs",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="only run the first N shapes of the sweep",
+    )
+    parser.add_argument(
+        "--walltime",
+        action="store_true",
+        help="time full wall-clock per call (host dispatch + GPU) instead of "
+        "GPU events; exposes host launch overhead that do_bench hides",
+    )
+    cli_args = parser.parse_args()
+    main(
+        cudagraph=not cli_args.no_cudagraph,
+        limit=cli_args.limit,
+        walltime=cli_args.walltime,
+    )

--- a/test/test_fast_dispatch_key.py
+++ b/test/test_fast_dispatch_key.py
@@ -1,0 +1,186 @@
+"""Tests for ``Kernel._fast_dispatch_key``, the cheap dispatch key that backs
+the ``Kernel.__call__`` fast-path cache (``_dispatch_cache``).
+
+The correctness argument for the cache is that the fast key is *strictly finer*
+than the full specialization key: any two argument lists that produce different
+full keys also produce different fast keys, so a fast-key hit can never dispatch
+to a BoundKernel that a full ``bind()`` would not have resolved for those
+arguments. "Strictly" finer because the converse fails -- the fast key
+distinguishes argument lists (e.g. scalar values, or dynamic-shape sizes that
+bucket together) that the full key deliberately collapses.
+
+These tests pin down:
+1. Refinement: across a matrix of dtype/shape/stride variants, distinct full
+   keys always imply distinct fast keys.
+2. Strictness under two witnesses that share a full key but not a fast key:
+   scalar value (full key records only ``type``) and dynamic-shape bucketing.
+3. The documented ``None`` returns: unhandled argument types and the
+   no-tensor-to-pin-the-device case.
+4. ``key=`` functions feed into the fast key.
+
+The key is pure argument-metadata bookkeeping, so it needs no compilation and
+runs on CPU-only bots.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+import helion
+import helion.language as hl
+
+
+@helion.kernel(static_shapes=True)
+def _static_add1(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size(0)):
+        out[tile] = x[tile] + 1
+    return out
+
+
+@helion.kernel(static_shapes=False)
+def _dynamic_add1(x: torch.Tensor) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size(0)):
+        out[tile] = x[tile] + 1
+    return out
+
+
+@helion.kernel(static_shapes=False)
+def _dynamic_add_scalar(x: torch.Tensor, s: int) -> torch.Tensor:
+    out = torch.empty_like(x)
+    for tile in hl.tile(x.size(0)):
+        out[tile] = x[tile] + s
+    return out
+
+
+class TestFastDispatchKey(unittest.TestCase):
+    def test_refinement_across_dtype_shape_stride(self) -> None:
+        """Every pair of argument lists with different *full* keys must also
+        have different *fast* keys -- the property that makes a fast-key hit
+        safe to dispatch directly to a previously-bound BoundKernel."""
+        variants = {
+            "f32_64": (torch.empty(64, dtype=torch.float32),),
+            "f64_64": (torch.empty(64, dtype=torch.float64),),
+            "f32_128": (torch.empty(128, dtype=torch.float32),),
+            "f32_8x16T": (torch.empty(8, 16, dtype=torch.float32).transpose(0, 1),),
+            "f32_8x16": (torch.empty(8, 16, dtype=torch.float32),),
+        }
+        full = {
+            name: _static_add1.specialization_key(a) for name, a in variants.items()
+        }
+        fast = {
+            name: _static_add1._fast_dispatch_key(a) for name, a in variants.items()
+        }
+
+        names = list(variants)
+        # There must be at least one distinct pair, else the test is vacuous.
+        saw_distinct_full = False
+        for i in range(len(names)):
+            for j in range(i + 1, len(names)):
+                a, b = names[i], names[j]
+                if full[a] != full[b]:
+                    saw_distinct_full = True
+                    self.assertNotEqual(
+                        fast[a],
+                        fast[b],
+                        msg=f"{a} vs {b}: full keys differ but fast keys collide",
+                    )
+        self.assertTrue(saw_distinct_full)
+
+    def test_strictly_finer_via_scalar_value(self) -> None:
+        """Witness that the fast key is *strictly* finer: two calls whose only
+        difference is a scalar's value share a full key (which records only the
+        scalar's ``type``) but get distinct fast keys (which record its value).
+        """
+        x = torch.empty(64, dtype=torch.float32)
+        a = (x, 1)
+        b = (x, 2)
+        self.assertEqual(
+            _dynamic_add_scalar.specialization_key(a),
+            _dynamic_add_scalar.specialization_key(b),
+        )
+        self.assertNotEqual(
+            _dynamic_add_scalar._fast_dispatch_key(a),
+            _dynamic_add_scalar._fast_dispatch_key(b),
+        )
+
+    def test_strictly_finer_via_dynamic_shape_bucketing(self) -> None:
+        """Second strictness witness: under ``static_shapes=False`` two nearby
+        sizes bucket to the same full key, but the fast key records the exact
+        shape and keeps them apart."""
+        a = (torch.empty(4096, dtype=torch.float32),)
+        b = (torch.empty(4097, dtype=torch.float32),)
+        self.assertEqual(
+            _dynamic_add1.specialization_key(a),
+            _dynamic_add1.specialization_key(b),
+        )
+        self.assertNotEqual(
+            _dynamic_add1._fast_dispatch_key(a),
+            _dynamic_add1._fast_dispatch_key(b),
+        )
+
+    def test_fast_key_records_exact_tensor_metadata(self) -> None:
+        """The per-tensor entry is exactly (dtype, shape, stride, device,
+        static-indices) with the raw ``torch.Size`` -- i.e. finer than any
+        bucketed/normalized form."""
+        x = torch.empty(64, dtype=torch.float32)
+        key = _static_add1._fast_dispatch_key((x,))
+        assert isinstance(key, tuple)
+        entry = key[0]
+        self.assertEqual(
+            entry,
+            (x.dtype, x.shape, x.stride(), x.device, None),
+        )
+        self.assertIs(type(entry[1]), torch.Size)
+
+    def test_returns_none_for_unhandled_arg_type(self) -> None:
+        """A container / unsupported argument type forces the slow ``bind()``
+        path by returning ``None``."""
+        x = torch.empty(64, dtype=torch.float32)
+        self.assertIsNone(_static_add1._fast_dispatch_key((x, [1, 2, 3])))
+        self.assertIsNone(_static_add1._fast_dispatch_key((x, object())))
+
+    def test_returns_none_without_tensor_to_pin_device(self) -> None:
+        """With no tensor argument there is nothing to pin the device, so the
+        key is ``None`` even though the scalars are individually handled."""
+        self.assertIsNone(_dynamic_add_scalar._fast_dispatch_key((1, 2)))
+        self.assertIsNone(_dynamic_add_scalar._fast_dispatch_key(()))
+
+    def test_scalar_and_none_entries(self) -> None:
+        """Handled non-tensor arguments contribute (type, value) for scalars
+        and a bare ``None`` for ``None``, provided a tensor pins the device."""
+        x = torch.empty(64, dtype=torch.float32)
+        key = _dynamic_add_scalar._fast_dispatch_key((x, 7))
+        assert isinstance(key, tuple)
+        self.assertEqual(key[1], (int, 7))
+
+        none_key = _static_add1._fast_dispatch_key((x, None))
+        assert isinstance(none_key, tuple)
+        self.assertIsNone(none_key[1])
+
+    def test_key_fn_feeds_into_fast_key(self) -> None:
+        """A user ``key=`` function participates in the fast key, so two calls
+        the user marks distinct get distinct fast keys."""
+
+        state = {"v": 0}
+
+        @helion.kernel(static_shapes=True, key=lambda x: state["v"])
+        def _with_key(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.size(0)):
+                out[tile] = x[tile] + 1
+            return out
+
+        x = torch.empty(64, dtype=torch.float32)
+        state["v"] = 0
+        k0 = _with_key._fast_dispatch_key((x,))
+        state["v"] = 1
+        k1 = _with_key._fast_dispatch_key((x,))
+        self.assertNotEqual(k0, k1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1290,6 +1290,14 @@ class TestLauncher(TestCase):
         torch.accelerator.synchronize()
         torch.testing.assert_close(out, unaligned + unaligned)
 
+        # Interleave the two alignments: once both variants have been seen,
+        # repeat calls (which may each hit a cached fast path keyed on
+        # alignment) must keep dispatching to the right specialization.
+        for _ in range(3):
+            torch.testing.assert_close(add(aligned, aligned), aligned + aligned)
+            torch.testing.assert_close(add(unaligned, unaligned), unaligned + unaligned)
+        torch.accelerator.synchronize()
+
     def test_unaligned_writes_to_user_out_arg_land_on_original(self) -> None:
         """If the kernel writes to an unaligned user-supplied output
         buffer, those writes must land on the user's tensor (not on
@@ -1330,9 +1338,11 @@ class TestLauncher(TestCase):
         "exist in ref-eager mode"
     )
     def test_used_global_vals_mutation_raises(self) -> None:
-        """Mutating a tracked global (e.g. a ``_BLOCK_SIZE_*``
-        constexpr captured via ``used_global_vals``) between calls
-        must trigger ``RuntimeError`` from Triton's own guard."""
+        """Mutating or deleting a tracked global (e.g. a
+        ``_BLOCK_SIZE_*`` constexpr captured via ``used_global_vals``)
+        between calls must trigger ``RuntimeError`` from Triton's own
+        guard, and restoring the original value must return the kernel
+        to a working (and numerically correct) state."""
 
         @helion.kernel(
             static_shapes=True,
@@ -1360,13 +1370,81 @@ class TestLauncher(TestCase):
 
         (name, _gid), (val, gdict) = next(iter(ugv.items()))
         original = gdict[name]
-        gdict[name] = "MUTATED_NOPE"
         try:
+            gdict[name] = "MUTATED_NOPE"
+            with self.assertRaises(RuntimeError):
+                add(x, x)
+                torch.accelerator.synchronize()
+
+            del gdict[name]
             with self.assertRaises(RuntimeError):
                 add(x, x)
                 torch.accelerator.synchronize()
         finally:
             gdict[name] = original
+
+        # Restoring the original value must fully recover: repeated calls
+        # (which may hit a cached fast path) stay numerically correct.
+        for _ in range(2):
+            out = add(x, x)
+            torch.accelerator.synchronize()
+            torch.testing.assert_close(out, x + x)
+
+    @skipIfRefEager(
+        "Inspects the bound kernel's Triton JITFunction, which doesn't "
+        "exist in ref-eager mode"
+    )
+    def test_direct_launch_cache_engages(self) -> None:
+        """With ``triton_direct_launch`` on (the default), the first
+        launch must populate the direct-launch cache with one entry per
+        distinct specialization, so repeat calls skip
+        ``JITFunction.run``.  This is the perf half of the contract:
+        the other tests prove fallback correctness, this one proves the
+        fast path actually engages."""
+
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[1024], num_warps=4, num_stages=2),
+        )
+        def add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for i in hl.tile(out.size(0)):
+                out[i] = x[i] + y[i]
+            return out
+
+        n = 1024
+        base = torch.randn(n + 4, device=DEVICE, dtype=torch.float32)
+        aligned = base[:n]
+        unaligned = base[1 : n + 1]
+
+        add(aligned, aligned)
+        torch.accelerator.synchronize()
+
+        from triton.runtime.jit import JITFunction
+
+        bound = next(iter(add._bound_kernels.values()))  # type: ignore[attr-defined]
+        jit_fn = next(
+            v for v in bound._run.__globals__.values() if isinstance(v, JITFunction)
+        )
+        state = jit_fn.__dict__.get("_helion_direct_launch")
+        if state is None:
+            self.skipTest(
+                "Direct launch did not engage (disabled via setting/env, or "
+                "hooks/knobs active in this run)"
+            )
+        _make_key, cache = state
+        self.assertEqual(len(cache), 1)
+
+        # A repeat call with the same specialization must reuse the entry...
+        torch.testing.assert_close(add(aligned, aligned), aligned + aligned)
+        torch.accelerator.synchronize()
+        self.assertEqual(len(cache), 1)
+
+        # ...while a second specialization (unaligned pointers) gets its own
+        # entry after its slow-path prime, keyed apart by the alignment bit.
+        torch.testing.assert_close(add(unaligned, unaligned), unaligned + unaligned)
+        torch.accelerator.synchronize()
+        self.assertEqual(len(cache), 2)
 
     def test_correct_result_on_each_cuda_device(self) -> None:
         """The same kernel called on ``cuda:0`` then ``cuda:1`` must


### PR DESCRIPTION
Stacked PRs:
 * #3017
 * #3015
 * #3012
 * __->__#3010
 * #3009
 * #3008


--- --- ---

### Add triton_direct_launch setting for direct kernel launch


After a specialization compiles once through JITFunction.run, repeat
launches call the cached CompiledKernel handle directly, skipping option
parsing, argument re-specialization, cache-key stringification, hook
dispatch, and launch-metadata construction.

Exposed as a per-kernel boolean setting triton_direct_launch (default
True; opt out with @helion.kernel(triton_direct_launch=False) or
HELION_TRITON_DIRECT_LAUNCH=0). Triton-only: inert on other backends.
The fast-vs-slow choice is resolved once at codegen time
(TritonBackend.library_imports emits default_slow_launcher for opted-out
kernels), so the per-call path pays nothing for the setting.

The two launch hazards cannot be caught after the fact -- a misaligned
launch surfaces as an asynchronous CUDA error that poisons the context,
and a stale captured global silently computes wrong numerics -- so
instead of guarding the launch, every hazard is folded into the cache
key, making any deviation an ordinary cache miss that falls back to the
slow path (which re-validates and raises proper errors). The key
includes scalar values, per-tensor dtype and a 16-byte alignment bit,
the current value of every captured used_global_vals entry, and
device/num_warps/num_stages/launch_cooperative_grid. On first launch the
key builder is compiled per kernel with eval (as Triton's binder does),
baking the tensor/scalar split and globals lookups into one flat
expression -- no per-element type checks, no separate globals-guard loop.

Auto-fallback cases: unaligned pointers, mutated/deleted used_global_vals,
unseen dtype/scalar/device, extra launch kwargs, torch.compile tracing,
and Triton hooks/knobs active when the specialization is first cached.
The one intentional gap (documented, needs opt-out): hooks registered
after a kernel's first launch are not re-checked per call.
_clear_triton_jit_cache also drops the direct-launch cache so a
post-autotune recompile is never bypassed by an ephemeral binary.

Adds TestLauncher contract tests: unaligned-input correctness (including
interleaved aligned/unaligned), unaligned writes to user out args,
used_global_vals mutation/deletion raising and recovery, per-device
correctness, and that the direct-launch cache actually engages.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
