### PR TITLE
[testing][AMD] Strip xcd_remap from expected-journal comparisons

### DIFF
--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -79,6 +79,7 @@ def _strip_launcher_args(value: str) -> str:
         strip_pairs += [
             (r", waves_per_eu=\d+", ""),
             (r", matrix_instr_nonkdim=\d+", ""),
+            (r", xcd_remap=(?:True|False)", ""),
         ]
     if _get_backend() == "tileir":
         strip_pairs += [(r", num_ctas=\d+", ""), (r", occupancy=\d+", "")]


### PR DESCRIPTION
xcd_remap is an AMD-CDNA-gated Config key (same gate as matrix_instr_nonkdim / waves_per_eu), so it appears in the completed Config repr on multi-XCD AMD but is absent on NVIDIA. Add it to _strip_launcher_args so NVIDIA-generated .expected files still match on AMD, fixing test_print_repro_on_device_ir_lowering_error.