### PR TITLE
Add fused launch fast path (triton_fused_launch)

### DIFF
--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -115,6 +115,21 @@ def my_kernel(x: torch.Tensor) -> torch.Tensor:
 
    Reserve this many streaming multiprocessors when launching persistent kernels. Default is ``0`` (use all SMs).
    Configure globally with ``HELION_PERSISTENT_RESERVED_SMS`` or per-kernel via ``@helion.kernel(..., persistent_reserved_sms=N)``.
+
+.. autoattribute:: Settings.triton_fused_launch
+
+   If ``True`` (default), after one priming launch the argument-dispatch, generated
+   host-wrapper, and launcher layers are collapsed into a single cached closure, so repeat
+   calls launch the compiled kernel directly from ``Kernel.__call__`` -- substantially
+   reducing per-call host overhead. The two launch hazards the wrapper/launcher normally
+   guard are folded into the fused cache key (per-tensor 16-byte alignment and
+   ``used_global_vals`` values); any deviation, and ``torch.compile`` tracing, fall back to
+   the full path. Triton-only.
+
+   Fusion is automatically disabled for a kernel whose generated host wrapper returns a value
+   (e.g. allocates its output), issues multiple device launches, or takes cooperative-grid
+   launches. Disable per-kernel with ``@helion.kernel(triton_fused_launch=False)`` or globally
+   with ``HELION_TRITON_FUSED_LAUNCH=0``.
 ```
 
 ### Autotuning Settings
@@ -321,6 +336,7 @@ Built-in values for ``HELION_AUTOTUNER`` include ``"LFBOTreeSearch"`` (default),
 | ``HELION_STATIC_SHAPES`` | ``static_shapes`` | Set to ``0``/``false`` to disable global static shape specialization. |
 | ``HELION_FAST_MATH`` | ``fast_math`` | Set to ``1`` to enable fast math approximations (Helion-level and Inductor-level). May reduce numerical precision. |
 | ``HELION_PERSISTENT_RESERVED_SMS`` | ``persistent_reserved_sms`` | Reserve this many streaming multiprocessors when launching persistent kernels (``0`` uses all available SMs). |
+| ``HELION_TRITON_FUSED_LAUNCH`` | ``triton_fused_launch`` | Set to ``0`` to disable the fused launch fast path (dispatch + host wrapper + launcher collapsed into one cached closure) and route every launch through ``JITFunction.run``. |
 | ``HELION_FORCE_AUTOTUNE`` | ``force_autotune`` | Force the autotuner to run even when explicit configs are provided. The result is saved to the cache. |
 | ``HELION_AUTOTUNE_FORCE_PERSISTENT`` | ``autotune_force_persistent`` | Restrict ``pid_type`` to persistent kernel strategies during config search. |
 | ``HELION_DISALLOW_AUTOTUNING`` | ``check_autotuning_disabled`` | Hard-disable autotuning; kernels must supply explicit configs when this is ``1``. |

--- a/helion/runtime/_fused_launch.py
+++ b/helion/runtime/_fused_launch.py
@@ -1,0 +1,512 @@
+"""Fused fast launch: collapse ``Kernel.__call__`` → generated ``_run`` wrapper →
+``default_launcher`` → ``CompiledKernel.run`` into one cached step.
+
+On a repeat call every value the generated ``_run`` wrapper computes -- the grid
+and the constant scalar launch arguments -- is a pure function of the argument
+metadata (exact shapes/strides/dtypes and scalar values), and which launch-arg
+slot comes from which input tensor is fixed per specialization.  So after one
+*priming* launch we compile a "launch closure" and later calls launch the
+compiled kernel directly, skipping the wrapper frame, the launcher frame, and
+the second key build.
+
+Hot path (see ``Kernel.__call__``): :meth:`Kernel._fused_dispatch_key` maps the
+call straight to a cached closure, which -- in one Python frame -- verifies the
+kernel's captured globals, builds the ``CompiledKernel.run`` argument list, and
+launches.  That key holds the same information as ``_fast_dispatch_key`` (exact
+per-argument metadata, scalar values, and the user ``key=`` function) plus a
+16-byte pointer-alignment bit per tensor.  Both keys are built by the shared
+:func:`build_key_fn` -- a flat expression compiled (baked) for the primed
+argument layout, but carrying a per-position class guard, so a call whose layout
+differs (e.g. a tensor where the prime saw ``None``) raises :class:`_LayoutChanged`
+and re-primes for the new layout, never a false hit.
+
+Correctness.  The fused path bypasses ``default_launcher``'s direct-launch key,
+which is where the two *uncatchable* launch hazards are normally guarded -- a
+misaligned pointer into an alignment-specialized binary (async CUDA error) and a
+stale captured global (silently wrong numerics).  The alignment bit is folded
+into the key, so an unaligned pointer arriving after an aligned prime is a new
+key -> its own closure.  Each closure re-checks its specialization's captured
+globals against their primed values (a deleted global reads a ``_MISSING``
+sentinel and so compares unequal) and raises :class:`GlobalsChanged` on any
+mismatch; the caller catches it and re-validates via the slow path, which raises
+Triton's own error.
+
+Because the Triton CUDA launcher reads only ``.data_ptr()`` from a pointer
+argument (sizes/strides reach the kernel as separate explicit scalar args), a
+launch-arg tensor can be replaced by any input tensor sharing its ``data_ptr``
+-- which is why a zero-storage-offset view (e.g. ``x.view(...)``) is served by
+its base input.
+
+Fusion is disabled (permanently, per kernel) whenever the recipe cannot be
+reproduced this way: a host wrapper that does side-effecting work beyond
+launch + return (checked once by inspecting the wrapper source -- see
+:func:`_wrapper_body_is_fuseable`), a non-``None`` wrapper return (covers kernels
+that allocate their output), multiple device launches, a launch arg that is
+neither a plain tensor nor an ``int``/``float``/``bool``/``None`` constant, a
+tensor arg with no matching input pointer, cooperative-grid launches, extra
+launcher kwargs, or any active launch hook/knob.
+"""
+
+from __future__ import annotations
+
+import ast
+import functools
+import inspect
+import textwrap
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import cast
+
+import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from .kernel import BoundKernel
+    from .kernel import Kernel
+
+
+# Sentinel for a captured global that was deleted since a fused recipe was
+# primed: the recipe's inline guard reads it via ``.get`` so a deletion compares
+# unequal (raising GlobalsChanged) rather than throwing an uncaught KeyError.
+_MISSING_GLOBAL = object()
+
+
+class GlobalsChanged(Exception):
+    """Raised by a launch closure when a captured Triton global was mutated
+    since the recipe was primed; the caller falls back to the slow path."""
+
+
+@functools.cache
+def _triton_driver() -> object:
+    """The Triton ``driver`` module, cached so the fused-launch hot path avoids a
+    fresh ``from triton.runtime import driver`` import lookup on every call."""
+    from triton.runtime import driver
+
+    return driver
+
+
+def _triton_direct_launch_ok(triton_kernel: object) -> bool:
+    """One-time (per specialization) check that a raw launch bypassing
+    ``JITFunction.run`` is safe.
+
+    Verifies no hook that ``JITFunction.run`` would have invoked is active and no
+    knob that feeds into launch behavior is set.  Called by the fused-launch
+    prime path when caching a compiled specialization, never on the per-launch
+    hot path.
+    """
+    # pyrefly: ignore [missing-attribute]
+    if triton_kernel.pre_run_hooks or triton_kernel.debug:
+        return False
+    import triton.knobs as knobs
+
+    rt = knobs.runtime
+    if rt.add_stages_inspection_hook is not None or rt.debug:
+        return False
+    for hook in (rt.launch_enter_hook, rt.launch_exit_hook):
+        # HookChain with empty ``calls`` is inactive; a plain user callable
+        # is always treated as active.
+        if hook is not None and getattr(hook, "calls", True):
+            return False
+    return not knobs.compilation.instrumentation_mode
+
+
+# Raised by a baked key builder when the call's argument *layout* differs from
+# the sample it was compiled for (a differing type at some position); the caller
+# catches it and rebuilds the builder for the new layout.  This is the single
+# mechanism that guarantees a layout change is never a false hit -- see
+# build_key_fn's per-position ``a[i].__class__ is <C> or _raise()`` guard.
+class _LayoutChanged(Exception):
+    pass
+
+
+def _raise() -> object:
+    raise _LayoutChanged
+
+
+def build_key_fn(
+    args: tuple[object, ...],
+    user_key_fn: Callable[..., object] | None,
+    *,
+    include_alignment: bool,
+    bail_when_no_tensor: bool,
+) -> Callable[[tuple[object, ...]], object]:
+    """Compile a flat dispatch-key builder from a sample argument tuple (the
+    layout seen when this builder was compiled).  This is the single source of
+    truth for both dispatch keys:
+
+    * ``Kernel._fast_dispatch_key`` -- ``include_alignment=False,
+      bail_when_no_tensor=True``: keys the ``_dispatch_cache`` (BoundKernel),
+      which does not specialize on pointer alignment, and returns ``None`` when
+      no tensor pins the device so the caller takes the slow ``bind()`` path.
+    * the fused-launch cache -- ``include_alignment=True,
+      bail_when_no_tensor=False``: adds a 16-byte pointer-alignment bit per
+      tensor (the fused path bypasses ``default_launcher``'s direct-launch key
+      where alignment is otherwise guarded) and always builds a key.
+
+    The returned lambda encodes, per position, ``type(arg)`` and -- for a tensor
+    -- dtype/shape/stride/device and (frozenset-normalized) dynamo static
+    indices, for a scalar its value, and finally the user ``key=`` result.
+    Compiling one flat expression (as Triton's ``binder`` does) is markedly
+    faster on the hot path than a generic per-call loop for many-argument
+    kernels.
+
+    Layout safety: every position first checks ``a[i].__class__ is <C>`` for the
+    sampled class ``C`` and calls ``_raise()`` (-> :class:`_LayoutChanged`) on a
+    mismatch.  So a call whose layout differs -- e.g. a tensor where the sample
+    had ``None`` or a scalar -- always raises rather than silently emitting a
+    truncated (collision-prone) key; the caller rebuilds for the new layout.  The
+    guard is what makes the class marker load-bearing: without it a baked
+    None/scalar position would emit only ``__class__`` for an arriving tensor and
+    two different tensors would collide.
+    """
+    # A guard for every position (including bail positions), so a builder that
+    # bails to None for *this* layout still raises _LayoutChanged -- and is
+    # rebuilt -- when a later call's layout differs.  Otherwise a cached bail
+    # lambda would wrongly return None for every future layout.  The leading
+    # guard checks the arg *count*, so a differing length (which would otherwise
+    # IndexError or silently drop trailing args) also forces a rebuild.  It seeds
+    # both ``parts`` (evaluated on the normal key path) and ``guards`` (the bail
+    # path), contributing a constant leading element to every key.
+    len_guard = f"(len(a) == {len(args)} or _raise())"
+    parts: list[str] = [len_guard]
+    guards: list[str] = [len_guard]
+    namespace: dict[str, object] = {
+        "_fs": lambda si: None if si is None else frozenset(si),
+        "_raise": _raise,
+    }
+    has_tensor = False
+    bail = False
+    for i, a in enumerate(args):
+        t = type(a)
+        # Per-position layout guard: emits the arg's class (so e.g. int vs bool,
+        # which compare/hash equal by value, stay distinct in the key) and raises
+        # _LayoutChanged on a class mismatch -- so a differing type at this
+        # position forces a rebuild instead of silently emitting a truncated
+        # (collision-prone) key.
+        namespace[f"_C{i}"] = t
+        guard = f"(_C{i} if a[{i}].__class__ is _C{i} else _raise())"
+        guards.append(guard)
+        if t is torch.Tensor or t is torch.nn.Parameter:
+            has_tensor = True
+            # frozenset(...) keeps a set/list _dynamo_static_indices hashable.
+            align = f", not a[{i}].data_ptr() & 15" if include_alignment else ""
+            parts.append(
+                f"{guard}, a[{i}].dtype, a[{i}].shape, a[{i}].stride(), "
+                f"a[{i}].device, _fs(getattr(a[{i}], '_dynamo_static_indices', None))"
+                f"{align}"
+            )
+        elif t is int or t is float or t is bool or t is str:
+            parts.append(f"{guard}, a[{i}]")
+        elif a is None:
+            parts.append(guard)
+        elif t is torch.dtype or t is torch.device:  # value is its own key
+            parts.append(f"{guard}, a[{i}]")
+        else:
+            # Unhandled arg type (container, tensor subclass, ...): the caller
+            # takes the slow path (fast) / skips fusion (fused) via a None key.
+            bail = True
+    if bail or (bail_when_no_tensor and not has_tensor):
+        # Evaluate every guard (so a layout change raises) then yield None.
+        return eval(f"lambda a: ({', '.join(guards)},) and None", namespace)
+    meta = f"({', '.join(parts)},)"
+    if user_key_fn is not None:
+        namespace["_kf"] = user_key_fn
+        return eval(f"lambda a: ({meta}, _kf(*a))", namespace)
+    return eval(f"lambda a: {meta}", namespace)
+
+
+# Calls the fused recipe may safely skip on replay because they mutate no
+# existing (input/out) tensor: pure shape/view ops, allocations (an allocated
+# launch arg is caught downstream by arg resolution / the non-None return
+# check), the host grid-topology helpers, and pure builtins used in shape math.
+# Anything not listed -- notably every in-place op (``zero_``/``fill_``/... by
+# torch's trailing-underscore convention) -- makes an assignment non-fuseable.
+_PURE_CALL_NAMES = frozenset(
+    {
+        # shape / view ops -- no data mutation
+        "view", "reshape", "size", "stride", "expand", "expand_as",
+        "broadcast_to", "broadcast_tensors", "permute", "transpose", "t",
+        "contiguous", "flatten", "unflatten", "unsqueeze", "squeeze",
+        "as_strided", "narrow", "select", "movedim", "to", "type_as",
+        "dim", "numel", "element_size",
+        # allocations (pure w.r.t. existing tensors)
+        "tensor", "scalar_tensor", "empty", "empty_like", "empty_strided",
+        "zeros", "zeros_like", "ones", "ones_like", "new_empty", "new_zeros",
+        # helion host-side grid-topology helpers
+        "get_num_sm", "get_num_xcd",
+        # pure builtins used in shape/grid arithmetic
+        "min", "max", "len", "int", "float", "bool", "abs",
+    }
+)  # fmt: skip
+
+
+def _expr_is_pure(node: ast.expr | None) -> bool:
+    """True iff evaluating ``node`` has no observable side effect on an existing
+    tensor -- i.e. every ``Call`` it contains targets a name in
+    :data:`_PURE_CALL_NAMES`.  A call through anything but a plain name or
+    attribute (e.g. a subscript or an arbitrary expression) is treated as impure.
+    """
+    for sub in ast.walk(node) if node is not None else ():
+        if isinstance(sub, ast.Call):
+            fn = sub.func
+            if isinstance(fn, ast.Name):
+                name = fn.id
+            elif isinstance(fn, ast.Attribute):
+                name = fn.attr
+            else:
+                return False
+            if name not in _PURE_CALL_NAMES:
+                return False
+    return True
+
+
+# Name of the module-proxy the generated wrapper reads a kernel's module-scope
+# globals through (helion/_compiler/output_header.py::SOURCE_MODULE); a launch
+# arg spelled ``_source_module.<attr>`` is re-read from live module state on
+# every call, so a fused recipe (which bakes scalar launch args at prime time)
+# must not fuse it -- see _wrapper_reads_module_global.
+_SOURCE_MODULE = "_source_module"
+
+
+def _wrapper_reads_module_global(node: ast.expr | None) -> bool:
+    """True iff ``node`` reads a kernel module-scope global via the wrapper's
+    module proxy (an ``ast.Attribute`` on ``_source_module``).
+
+    The wrapper re-reads such a global on every call and passes it to the
+    launcher as a scalar arg; the fused recipe instead bakes each scalar launch
+    arg as a constant at prime time, so a later mutation of the global would be
+    silently ignored (the non-fused path re-reads it and stays correct).  Fusing
+    such a kernel is therefore unsafe.
+    """
+    for sub in ast.walk(node) if node is not None else ():
+        if (
+            isinstance(sub, ast.Attribute)
+            and isinstance(sub.value, ast.Name)
+            and sub.value.id == _SOURCE_MODULE
+        ):
+            return True
+    return False
+
+
+def _wrapper_body_is_fuseable(bound: BoundKernel) -> bool:
+    """True iff the generated host wrapper is a plain launch + return.
+
+    The fused recipe reproduces only the launcher call and the return value.  A
+    wrapper that also runs host-side statements with observable effects -- a bare
+    tensor-method call like ``out.zero_()``, an augmented assignment, a loop, a
+    conditional, *or an assignment whose RHS mutates a tensor* (e.g.
+    ``out = out.zero_()``) -- would have those effects silently dropped on replay
+    (e.g. a pre-launch ``zero_`` leaving stale data in a region the device loop
+    does not cover).  Such wrappers only emit a ``TensorOperationInWrapper``
+    warning, which a kernel may suppress, so they cannot be told apart at runtime
+    by behavior; inspect the wrapper source.
+
+    Allowed statements: ``assert`` (specialization guards), plain ``x = ...`` and
+    tuple-unpacking assignments *whose RHS is pure* (constexpr block sizes, shape
+    unpacking, ``x = x.view(...)`` reshapes -- see :func:`_expr_is_pure`), the
+    single ``_launcher(...)`` call expressed as a bare ``Expr``, and the
+    ``return``.  Anything else (a non-launcher ``Expr`` call, an assignment with a
+    side-effecting RHS, ``AugAssign``, ``For``, ``If``, ``With``, ...) makes the
+    kernel non-fuseable.
+
+    A launcher call that reads a module-scope global (``_source_module.<attr>``,
+    passed as a scalar launch arg re-read every call) is also rejected: the fused
+    recipe bakes scalar launch args at prime time, so a later mutation of the
+    global would be silently ignored -- see :func:`_wrapper_reads_module_global`.
+    """
+    run = bound._run
+    if run is None:
+        return False
+    try:
+        source = textwrap.dedent(inspect.getsource(run))
+        tree = ast.parse(source)
+    except (OSError, TypeError, SyntaxError):
+        return False
+    func = tree.body[0]
+    if not isinstance(func, ast.FunctionDef):
+        return False
+    saw_launch = False
+    for stmt in func.body:
+        if isinstance(stmt, (ast.Assign, ast.AnnAssign)):
+            # A pure RHS that does not read a module global (a side-effecting
+            # call like ``out = out.zero_()`` would be dropped on replay; a
+            # ``s = _source_module.SCALE`` read would be frozen at prime time).
+            if _expr_is_pure(stmt.value) and not _wrapper_reads_module_global(
+                stmt.value
+            ):
+                continue
+            return False
+        if isinstance(stmt, ast.Assert):
+            continue
+        if isinstance(stmt, ast.Return):
+            continue
+        if isinstance(stmt, ast.Expr):
+            # The only bare expression statement allowed is the launcher call,
+            # and only if none of its args re-read a module global.
+            call = stmt.value
+            if (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Name)
+                and call.func.id == "_launcher"
+                and not _wrapper_reads_module_global(call)
+            ):
+                saw_launch = True
+                continue
+            return False
+        # For / If / With / AugAssign / While / etc. -- host-side control flow
+        # or side effects the recipe cannot reproduce.
+        return False
+    return saw_launch
+
+
+def _disable(kernel: Kernel, result: object) -> object:
+    kernel._fused_disabled = True
+    return result
+
+
+def fused_prime(kernel: Kernel, bound: BoundKernel, args: tuple[object, ...]) -> object:
+    """Run the kernel once through the wrapper while recording its single
+    launcher call, then compile and cache a launch closure (or permanently
+    disable fusion for this kernel).  Returns the wrapper's result.
+    """
+    from . import default_launcher
+
+    # One-time source inspection: reject wrappers that do host-side work beyond
+    # launch + return (their side effects would be dropped on replay).
+    if kernel._fused_wrapper_ok is None:
+        kernel._fused_wrapper_ok = _wrapper_body_is_fuseable(bound)
+    if not kernel._fused_wrapper_ok:
+        # pyrefly: ignore [not-callable]
+        return _disable(kernel, bound._run(*args))
+
+    captured: dict[str, Any] = {"n": 0}
+
+    def recorder(
+        triton_kernel: object,
+        grid: tuple[int, ...],
+        *largs: object,
+        num_warps: int,
+        num_stages: int,
+        ptx_options: str | None = None,
+        launch_cooperative_grid: bool = False,
+        **kwargs: object,
+    ) -> object:
+        captured["n"] += 1
+        captured["triton_kernel"] = triton_kernel
+        captured["grid"] = grid
+        captured["largs"] = largs
+        captured["ptx_options"] = ptx_options
+        captured["lcg"] = launch_cooperative_grid
+        captured["kwargs"] = kwargs
+        compiled = default_launcher(
+            triton_kernel,
+            grid,
+            *largs,
+            num_warps=num_warps,
+            num_stages=num_stages,
+            ptx_options=ptx_options,
+            launch_cooperative_grid=launch_cooperative_grid,
+            # pyrefly: ignore [bad-argument-type]
+            **kwargs,
+        )
+        captured["compiled"] = compiled
+        return compiled
+
+    # pyrefly: ignore [not-callable]
+    result = bound._run(*args, _launcher=recorder)
+
+    # Only single-launch, out-arg / in-place kernels are fuseable.  A non-None
+    # return means the wrapper produced a value we cannot reproduce without
+    # re-running it (typically an allocated output tensor).
+    if (
+        result is not None
+        or captured["n"] != 1
+        or captured["kwargs"]
+        or captured["ptx_options"] is not None
+        or captured["lcg"]
+        or type(captured["grid"]) is not tuple
+    ):
+        return _disable(kernel, result)
+
+    triton_kernel = captured["triton_kernel"]
+    compiled = captured["compiled"]
+    if compiled is None or not _triton_direct_launch_ok(triton_kernel):
+        return _disable(kernel, result)
+
+    # Map each input tensor's data_ptr -> its position.
+    ptr_to_idx: dict[int, int] = {}
+    for i, a in enumerate(args):
+        ta = type(a)
+        if ta is torch.Tensor or ta is torch.nn.Parameter:
+            # pyrefly: ignore [missing-attribute]
+            ptr_to_idx.setdefault(a.data_ptr(), i)
+
+    # Resolve each launcher arg to an input-tensor index or a baked constant.
+    arg_parts: list[str] = []
+    namespace: dict[str, object] = {}
+    for j, a in enumerate(captured["largs"]):
+        ta = type(a)
+        if ta is torch.Tensor or ta is torch.nn.Parameter:
+            # pyrefly: ignore [missing-attribute]
+            i = ptr_to_idx.get(a.data_ptr())
+            if i is None:
+                return _disable(kernel, result)
+            arg_parts.append(f"a[{i}]")
+        elif ta is int or ta is float or ta is bool or a is None:
+            namespace[f"_c{j}"] = a
+            arg_parts.append(f"_c{j}")
+        else:
+            return _disable(kernel, result)
+
+    grid = captured["grid"]
+    grid_size = len(grid)
+    namespace["_gx"] = grid[0]
+    namespace["_gy"] = grid[1] if grid_size > 1 else 1
+    namespace["_gz"] = grid[2] if grid_size > 2 else 1
+    namespace["_run"] = compiled.run
+    namespace["_fn"] = compiled.function
+    namespace["_pm"] = compiled.packed_metadata
+    namespace["_compiled"] = compiled  # keep alive so _run/_fn stay valid
+    # pyrefly: ignore [missing-attribute]
+    namespace["_active"] = _triton_driver().active
+    namespace["_Changed"] = GlobalsChanged
+
+    # Inline captured-globals verification: a mutated OR deleted global compares
+    # unequal (deletion reads the _MISSING sentinel via .get), raising
+    # GlobalsChanged so the caller takes the slow path (which re-validates and
+    # raises Triton's own error).
+    namespace["_MISSING"] = _MISSING_GLOBAL
+    guard_conds: list[str] = []
+    for gi, ((name, _), (val, gdict)) in enumerate(
+        # pyrefly: ignore [missing-attribute]
+        triton_kernel.used_global_vals.items()
+    ):
+        namespace[f"_g{gi}"] = gdict
+        namespace[f"_gv{gi}"] = val
+        guard_conds.append(f"_g{gi}.get({name!r}, _MISSING) != _gv{gi}")
+    guard = ""
+    if guard_conds:
+        guard = f"    if {' or '.join(guard_conds)}: raise _Changed\n"
+
+    launch_args = ", ".join(arg_parts)
+    src = (
+        "def _launch(a):\n"
+        f"{guard}"
+        "    _run(_gx, _gy, _gz, "
+        "_active.get_current_stream(_active.get_current_device()), "
+        "_fn, _pm, None, None, None"
+        f"{', ' + launch_args if launch_args else ''})\n"
+    )
+    exec(src, namespace)
+    launch = cast("Callable[[tuple[object, ...]], None]", namespace["_launch"])
+
+    # Key on the same per-call, type-dispatched key the hot path uses.  It is
+    # strictly finer than the specialization key (includes exact metadata,
+    # scalar values, the user key= function, and the alignment bit), so a hit is
+    # always the specialization a real bind() would have chosen.  A key of None
+    # (unhandled arg type / no tensor) means "don't fuse this call".
+    fused_key = kernel._fused_dispatch_key(args)
+    if fused_key is not None:
+        kernel._fused_recipes[fused_key] = launch
+    return result

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -58,6 +58,9 @@ from .._logging import LazyString
 from .._utils import counters
 from ..autotuner.base_search import _AutotunableKernel
 from ..language.constexpr import ConstExpr
+from ._fused_launch import GlobalsChanged
+from ._fused_launch import _LayoutChanged
+from ._fused_launch import build_key_fn
 from .config import Config
 from .ref_mode import RefModeContext
 from .ref_mode import is_ref_mode_enabled
@@ -244,6 +247,23 @@ class Kernel(Generic[_R]):
 
             self._capture_op = register_decoration_op(self)
 
+        # Fused launch (helion/runtime/_fused_launch.py) is Triton-only; resolved
+        # once here to keep the __call__ hot path branch-free.
+        self._fused_launch: bool = (
+            self.settings.backend == "triton" and self.settings.triton_fused_launch
+        )
+        # Fused-launch state (kernel-wide): a cache of launch recipes keyed by
+        # the fused dispatch key, a flat eval-compiled builder for that key
+        # (lazily built for the seen argument layout), and a latch that
+        # permanently disables fusion for a non-fuseable kernel.
+        self._fused_recipes: dict[Hashable, Callable[[tuple[object, ...]], None]] = {}
+        self._fused_key_fn: Callable[[tuple[object, ...]], Hashable] | None = None
+        self._fused_disabled: bool = False
+        # Whether this kernel's generated host wrapper is a plain launch (fuseable)
+        # vs. one that does host-side tensor work the recipe can't reproduce; None
+        # until checked once on the first prime.
+        self._fused_wrapper_ok: bool | None = None
+
     @functools.cache  # noqa: B019
     def kernel_source(self) -> str:
         """
@@ -322,6 +342,31 @@ class Kernel(Generic[_R]):
         if self._key_fn is not None:
             key.append(self._key_fn(*args))
         return tuple(key)
+
+    def _fused_dispatch_key(self, args: tuple[object, ...]) -> Hashable | None:
+        """Dispatch key for the fused launch cache (see ``_fused_launch.py``).
+
+        Encodes the same information as :meth:`_fast_dispatch_key`, plus a 16-byte
+        pointer-alignment bit per
+        tensor (the fused path bypasses the direct-launch key where alignment is
+        normally guarded, so it folds that hazard in here) and always builds a
+        key (no device-pinning bail).  The builder embeds a per-position class
+        guard, so a call whose argument *layout* differs from the one it was
+        compiled for raises :class:`_LayoutChanged` and is rebuilt -- never a
+        false hit.
+        """
+        key_fn = self._fused_key_fn
+        if key_fn is None:
+            key_fn = self._fused_key_fn = build_key_fn(
+                args, self._key_fn, include_alignment=True, bail_when_no_tensor=False
+            )
+        try:
+            return cast("Hashable", key_fn(args))
+        except _LayoutChanged:
+            key_fn = self._fused_key_fn = build_key_fn(
+                args, self._key_fn, include_alignment=True, bail_when_no_tensor=False
+            )
+            return cast("Hashable", key_fn(args))
 
     def bind(self, args: tuple[object, ...]) -> BoundKernel[_R]:
         """
@@ -490,17 +535,49 @@ class Kernel(Generic[_R]):
         """
         if kwargs:
             args = self.normalize_args(*args, **kwargs)
-        elif self._dispatch_cache:
-            # Fast path: repeat call with argument metadata seen before. The
-            # cache is only populated by calls that already took the slow
-            # path below, so hitting it cannot skip autotuning/compilation.
-            # (The cache stays empty under TPU compile capture, so this
-            # cannot bypass auto_capture_call below.)
-            fast_key = self._fast_dispatch_key(args)
-            if fast_key is not None:
-                bound = self._dispatch_cache.get(fast_key)
-                if bound is not None and bound._run is not None:
-                    return bound._run(*args)
+        else:
+            # Fused fast path: one key straight to a cached launch closure that
+            # verifies captured globals, allocates any outputs, launches, and
+            # returns the wrapper's result -- skipping the dispatch, wrapper, and
+            # launcher frames.  Recipes are only populated by a prime that took
+            # the slow path, so this cannot bypass autotuning/compilation.
+            # Skipped under torch.compile: the raw launch is not traceable
+            # (dynamo must see the ``JITFunction.run`` path instead).
+            fused = self._fused_launch and not torch.compiler.is_compiling()
+            if fused and self._fused_recipes:
+                # Build the key via the cached flat lambda directly (hot path);
+                # only fall back to the method for the rare layout-change rebuild.
+                key_fn = self._fused_key_fn
+                try:
+                    fused_key = key_fn(args)  # type: ignore[misc]
+                except _LayoutChanged:
+                    fused_key = self._fused_dispatch_key(args)
+                launch = self._fused_recipes.get(fused_key)
+                if launch is not None:
+                    try:
+                        return cast("_R", launch(args))
+                    except GlobalsChanged:
+                        # A captured Triton global was mutated since priming;
+                        # fall through so the slow path re-validates and raises
+                        # Triton's own error.  Other exceptions propagate.
+                        pass
+            if self._dispatch_cache:
+                # Repeat call with argument metadata seen before. The cache is
+                # only populated by calls that already took the slow path below,
+                # so hitting it cannot skip autotuning/compilation.  (It stays
+                # empty under TPU compile capture, so this cannot bypass
+                # auto_capture_call below.)
+                fast_key = self._fast_dispatch_key(args)
+                if fast_key is not None:
+                    bound = self._dispatch_cache.get(fast_key)
+                    if bound is not None and bound._run is not None:
+                        if fused and not self._fused_disabled:
+                            # Prime the fused recipe for this key (executes the
+                            # launch), or latch fusion off if not fuseable.
+                            from ._fused_launch import fused_prime
+
+                            return cast("_R", fused_prime(self, bound, args))
+                        return bound._run(*args)
         if self.settings.backend == "pallas" and _TPU_COMPILE_CAPTURE:
             # Local import: _tpu_compile_capture pulls in the dynamo HOP machinery,
             # not ready when kernel.py first loads during ``import helion``.
@@ -526,6 +603,10 @@ class Kernel(Generic[_R]):
         """
         self._bound_kernels.clear()
         self._dispatch_cache.clear()
+        self._fused_recipes.clear()
+        self._fused_key_fn = None
+        self._fused_disabled = False
+        self._fused_wrapper_ok = None
 
     @property
     def jax_fn(self) -> Callable[..., Any]:
@@ -969,6 +1050,10 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         config = self._normalize_config(config)
         self._run = self.compile_config(config)
         self._config = config
+        # A recompile invalidates the kernel's fused launch recipes, which cache
+        # the old compiled binary directly (the JITFunction's own direct-launch
+        # cache is dropped by TritonBackend._clear_triton_jit_cache likewise).
+        self.kernel._fused_recipes.clear()
         counters["best_config_decorator"][
             self.format_kernel_decorator(config, self.settings)
         ] = 1

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -595,6 +595,11 @@ class _Settings:
             _env_get_bool, "HELION_TRITON_DO_NOT_SPECIALIZE", False
         )
     )
+    triton_fused_launch: bool = dataclasses.field(
+        default_factory=functools.partial(
+            _env_get_bool, "HELION_TRITON_FUSED_LAUNCH", True
+        )
+    )
 
 
 class Settings(_Settings):
@@ -697,6 +702,21 @@ class Settings(_Settings):
             "memory-bound kernels (vectorized loads rely on inner stride being "
             "specialized to constexpr 1). Only takes effect when static_shapes=False. "
             "Set HELION_TRITON_DO_NOT_SPECIALIZE=1 to enable globally."
+        ),
+        "triton_fused_launch": (
+            "If True (default), collapse the dispatch, generated host-wrapper, "
+            "and launch layers into a single cached step on repeat calls: after "
+            "one priming launch, the grid and constant launch arguments (which "
+            "are pure functions of the fast-dispatch key) are recorded and later "
+            "calls launch the compiled kernel directly from Kernel.__call__, "
+            "skipping the wrapper and launcher frames. The two launch hazards the "
+            "wrapper/launcher normally guard are folded into the fused cache key "
+            "(per-tensor 16-byte alignment and used_global_vals values); any "
+            "deviation, and torch.compile tracing, fall back to the full path. "
+            "Automatically disabled for a kernel whose host wrapper returns a "
+            "value (e.g. allocates its output), issues multiple device launches, "
+            "or takes cooperative-grid launches. Triton-only. Set "
+            "HELION_TRITON_FUSED_LAUNCH=0 to disable."
         ),
         "print_output_code": "If True, print the output code of the kernel to stderr.",
         "print_repro": "If True, print Helion kernel code, config, and caller code to stderr as a standalone repro script.",

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1414,5 +1414,402 @@ class TestLauncher(TestCase):
         torch.testing.assert_close(out1, 2 * x1)
 
 
+@onlyBackends(["triton"])
+class TestFusedLauncher(TestCase):
+    """Fused launch (``triton_fused_launch``, default on) collapses dispatch,
+    the generated host wrapper, and the launcher into a single cached closure
+    for in-place / out-arg kernels.  These tests pin down that it engages when
+    it should, stays disabled when it must, and preserves the same launch
+    contract (alignment, captured globals) as the direct-launch path.
+    """
+
+    @staticmethod
+    def _add_out_kernel():
+        # Writes to a user out-arg and returns None -> fuseable.
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[1024], num_warps=4, num_stages=2),
+            # Pin the fused path on so these tests exercise it even if the
+            # triton_fused_launch default later changes.
+            triton_fused_launch=True,
+        )
+        def add_out(x: torch.Tensor, y: torch.Tensor, out: torch.Tensor) -> None:
+            for i in hl.tile(out.size(0)):
+                out[i] = x[i] + y[i]
+
+        return add_out
+
+    @skipIfRefEager("Inspects the kernel's fused-launch cache, absent in ref eager")
+    def test_fused_cache_engages_for_out_arg_kernel(self) -> None:
+        add_out = self._add_out_kernel()
+        n = 1024
+        x = torch.randn(n, device=DEVICE, dtype=torch.float32)
+        y = torch.randn(n, device=DEVICE, dtype=torch.float32)
+        out = torch.empty(n, device=DEVICE, dtype=torch.float32)
+
+        # First call primes the dispatch/direct-launch caches; the second call
+        # (a dispatch-cache hit) primes the fused recipe.
+        add_out(x, y, out)
+        torch.accelerator.synchronize()
+        self.assertEqual(len(add_out._fused_recipes), 0)  # type: ignore[attr-defined]
+
+        add_out(x, y, out)
+        torch.accelerator.synchronize()
+        self.assertEqual(len(add_out._fused_recipes), 1)  # type: ignore[attr-defined]
+        torch.testing.assert_close(out, x + y)
+
+        # A repeat call reuses the single recipe and stays correct.
+        out.zero_()
+        add_out(x, y, out)
+        torch.accelerator.synchronize()
+        self.assertEqual(len(add_out._fused_recipes), 1)  # type: ignore[attr-defined]
+        torch.testing.assert_close(out, x + y)
+
+    @skipIfRefEager("Inspects the kernel's fused-launch cache, absent in ref eager")
+    def test_fused_disabled_for_tensor_returning_kernel(self) -> None:
+        # A kernel that allocates and returns its output cannot be fused (its
+        # wrapper produces a value the fused path can't reproduce); it must
+        # latch off and still compute correctly.
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[1024], num_warps=4, num_stages=2),
+            triton_fused_launch=True,
+        )
+        def add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for i in hl.tile(out.size(0)):
+                out[i] = x[i] + y[i]
+            return out
+
+        x = torch.randn(1024, device=DEVICE, dtype=torch.float32)
+        for _ in range(3):
+            torch.testing.assert_close(add(x, x), x + x)
+        torch.accelerator.synchronize()
+        self.assertTrue(add._fused_disabled)  # type: ignore[attr-defined]
+        self.assertEqual(len(add._fused_recipes), 0)  # type: ignore[attr-defined]
+
+    def test_fused_unaligned_input_produces_correct_output(self) -> None:
+        # An unaligned input arriving after an aligned prime must stay correct:
+        # the alignment bit is in the fused key, so it gets its own recipe.
+        add_out = self._add_out_kernel()
+        n = 1024
+        base_x = torch.randn(n + 4, device=DEVICE, dtype=torch.float32)
+        base_out = torch.empty(n + 4, device=DEVICE, dtype=torch.float32)
+        aligned_x, aligned_out = base_x[:n], base_out[:n]
+        unaligned_x, unaligned_out = base_x[1 : n + 1], base_out[1 : n + 1]
+        self.assertEqual(aligned_x.data_ptr() % 16, 0)
+        self.assertNotEqual(unaligned_x.data_ptr() % 16, 0)
+
+        # Prime aligned twice (engage fusion), then interleave alignments.
+        add_out(aligned_x, aligned_x, aligned_out)
+        add_out(aligned_x, aligned_x, aligned_out)
+        torch.accelerator.synchronize()
+        for _ in range(3):
+            add_out(aligned_x, aligned_x, aligned_out)
+            add_out(unaligned_x, unaligned_x, unaligned_out)
+        torch.accelerator.synchronize()
+        torch.testing.assert_close(aligned_out, aligned_x + aligned_x)
+        torch.testing.assert_close(unaligned_out, unaligned_x + unaligned_x)
+
+    @skipIfRefEager("Inspects the kernel's fused-launch cache, absent in ref eager")
+    def test_fused_disabled_when_wrapper_reads_module_global(self) -> None:
+        # A Helion module-scope global used in device code is promoted by the
+        # generated wrapper to a scalar launch arg, re-read from live module
+        # state (``_source_module.<attr>``) on every call.  The fused recipe
+        # bakes scalar launch args as constants at prime time, so it would freeze
+        # the global's value and silently ignore a later mutation.  Fusion must
+        # therefore latch off for such a kernel, and the (non-fused) result must
+        # track the mutated global -- matching the default launcher.
+        globals()["_FUSED_LAUNCH_GLOBAL_SCALE"] = 2.0
+
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[1024], num_warps=4, num_stages=2),
+            triton_fused_launch=True,
+        )
+        def scale_out(x: torch.Tensor, out: torch.Tensor) -> None:
+            for i in hl.tile(out.size(0)):
+                out[i] = x[i] * _FUSED_LAUNCH_GLOBAL_SCALE  # noqa: F821
+
+        n = 1024
+        x = torch.randn(n, device=DEVICE, dtype=torch.float32)
+        out = torch.empty(n, device=DEVICE, dtype=torch.float32)
+        scale_out(x, out)
+        scale_out(x, out)  # would engage fusion, but the wrapper reads a global
+        torch.accelerator.synchronize()
+        self.assertTrue(scale_out._fused_disabled)  # type: ignore[attr-defined]
+        self.assertEqual(len(scale_out._fused_recipes), 0)  # type: ignore[attr-defined]
+        torch.testing.assert_close(out, x * 2.0)
+
+        # Mutating the global must be reflected on the next call (no stale bake).
+        original = globals()["_FUSED_LAUNCH_GLOBAL_SCALE"]
+        try:
+            globals()["_FUSED_LAUNCH_GLOBAL_SCALE"] = 3.0
+            scale_out(x, out)
+            torch.accelerator.synchronize()
+            torch.testing.assert_close(out, x * 3.0)
+        finally:
+            globals()["_FUSED_LAUNCH_GLOBAL_SCALE"] = original
+
+        scale_out(x, out)
+        torch.accelerator.synchronize()
+        torch.testing.assert_close(out, x * 2.0)
+
+    @skipIfRefEager("Inspects the kernel's fused-launch cache, absent in ref eager")
+    def test_fused_can_be_disabled_by_setting(self) -> None:
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[1024], num_warps=4, num_stages=2),
+            triton_fused_launch=False,
+        )
+        def add_out(x: torch.Tensor, y: torch.Tensor, out: torch.Tensor) -> None:
+            for i in hl.tile(out.size(0)):
+                out[i] = x[i] + y[i]
+
+        n = 1024
+        x = torch.randn(n, device=DEVICE, dtype=torch.float32)
+        out = torch.empty(n, device=DEVICE, dtype=torch.float32)
+        for _ in range(3):
+            add_out(x, x, out)
+        torch.accelerator.synchronize()
+        self.assertFalse(add_out._fused_launch)  # type: ignore[attr-defined]
+        self.assertEqual(len(add_out._fused_recipes), 0)  # type: ignore[attr-defined]
+        torch.testing.assert_close(out, x + x)
+
+    @staticmethod
+    def _optional_bias_kernel():
+        # bias is a tensor or None; the branch is resolved at trace time, so each
+        # variant compiles a distinct specialization.
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64], num_warps=4, num_stages=2),
+            ignore_warnings=[helion.exc.TensorOperationInWrapper],
+            triton_fused_launch=True,
+        )
+        def opt_bias(x: torch.Tensor, out: torch.Tensor, bias: object) -> None:
+            for i in hl.tile(x.size(0)):
+                if bias is None:
+                    out[i] = x[i] * 2
+                else:
+                    out[i] = x[i] + bias[i]
+
+        return opt_bias
+
+    def test_fused_none_primed_then_tensor_is_not_a_false_hit(self) -> None:
+        # Regression: the fused key must embed type() per position, so a call
+        # that passes a tensor where the prime saw None does NOT collide with the
+        # None-specialized recipe (which would silently run out = x*2).
+        opt_bias = self._optional_bias_kernel()
+        n = 64
+        x = torch.randn(n, device=DEVICE, dtype=torch.float32)
+        bias = torch.randn(n, device=DEVICE, dtype=torch.float32)
+        out = torch.empty(n, device=DEVICE, dtype=torch.float32)
+
+        opt_bias(x, out, None)
+        opt_bias(x, out, None)  # prime the None specialization's fused recipe
+        torch.accelerator.synchronize()
+
+        opt_bias(x, out, bias)  # must run x + bias, not the None kernel's x * 2
+        torch.accelerator.synchronize()
+        torch.testing.assert_close(out, x + bias)
+
+    @skipIfRefEager("Inspects the kernel's fused-launch cache, absent in ref eager")
+    def test_fused_two_tensors_after_none_prime_are_not_a_false_hit(self) -> None:
+        # Regression: after a None prime bakes the key builder for the None
+        # layout, a tensor arriving at that position must force a rebuild -- not
+        # be served by a key that records only its class.  Otherwise TWO
+        # different tensors at that position (differing only in metadata the
+        # truncated key dropped, e.g. dtype) collide on one recipe and the second
+        # silently reuses the first's launch.  Uses a per-arg dtype so the two
+        # tensor calls must resolve to distinct specializations.
+        @helion.kernel(
+            static_shapes=False,
+            config=helion.Config(block_sizes=[16], num_warps=4, num_stages=2),
+            ignore_warnings=[helion.exc.TensorOperationInWrapper],
+            triton_fused_launch=True,
+        )
+        def opt_bias(x: torch.Tensor, out: torch.Tensor, bias: object) -> None:
+            for i in hl.tile(x.size(0)):
+                if bias is None:
+                    out[i] = x[i] * 2
+                else:
+                    out[i] = x[i] + bias[i].to(x.dtype)
+
+        n = 64
+        x = torch.randn(n, device=DEVICE, dtype=torch.float32)
+        out = torch.empty(n, device=DEVICE, dtype=torch.float32)
+        b32 = torch.randn(n, device=DEVICE, dtype=torch.float32)
+        b16 = torch.randn(n, device=DEVICE, dtype=torch.float16)
+
+        opt_bias(x, out, None)
+        opt_bias(x, out, None)  # bake the None-layout key builder + prime recipe
+        torch.accelerator.synchronize()
+
+        opt_bias(x, out, b32)
+        opt_bias(x, out, b32)  # prime the fp32-bias recipe
+        torch.accelerator.synchronize()
+        torch.testing.assert_close(out, x + b32)
+
+        # An fp16 bias with identical x/out metadata must NOT hit the fp32 recipe.
+        for _ in range(3):
+            opt_bias(x, out, b16)
+            torch.accelerator.synchronize()
+            torch.testing.assert_close(out, x + b16.to(torch.float32))
+
+    def test_fused_tensor_primed_then_none_does_not_crash(self) -> None:
+        # Regression: priming a second layout (tensor position now None) must not
+        # raise out of the key builder; it rebuilds for the new layout.
+        opt_bias = self._optional_bias_kernel()
+        n = 64
+        x = torch.randn(n, device=DEVICE, dtype=torch.float32)
+        bias = torch.randn(n, device=DEVICE, dtype=torch.float32)
+        out = torch.empty(n, device=DEVICE, dtype=torch.float32)
+
+        opt_bias(x, out, bias)
+        opt_bias(x, out, bias)  # prime the tensor specialization
+        torch.accelerator.synchronize()
+
+        opt_bias(x, out, None)  # None where a tensor was primed: no crash
+        torch.accelerator.synchronize()
+        torch.testing.assert_close(out, x * 2)
+
+    @skipIfRefEager("Inspects the kernel's fused-launch cache, absent in ref eager")
+    def test_fused_respects_user_key_fn(self) -> None:
+        # Regression: the fused key must include the user key= result, and a
+        # fused hit must consult it -- otherwise two calls with identical tensor
+        # metadata but different key= values collide on one recipe.
+        calls: list[int] = []
+
+        def keyfn(x: torch.Tensor, out: torch.Tensor, m: int) -> int:
+            calls.append(m)
+            return m
+
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64], num_warps=4, num_stages=2),
+            ignore_warnings=[helion.exc.TensorOperationInWrapper],
+            key=keyfn,
+            triton_fused_launch=True,
+        )
+        def modal(x: torch.Tensor, out: torch.Tensor, m: int) -> None:
+            for i in hl.tile(x.size(0)):
+                out[i] = x[i] + m
+
+        n = 64
+        x = torch.randn(n, device=DEVICE, dtype=torch.float32)
+        out = torch.empty(n, device=DEVICE, dtype=torch.float32)
+
+        modal(x, out, 3)
+        modal(x, out, 3)  # prime m=3
+        torch.accelerator.synchronize()
+        if modal._fused_disabled:  # type: ignore[attr-defined]
+            self.skipTest("Fused launch disabled")
+        n_before = len(calls)
+
+        modal(x, out, 7)  # different key= value: must not reuse the m=3 recipe
+        torch.accelerator.synchronize()
+        torch.testing.assert_close(out, x + 7)
+        # key= was consulted while building the fused key on the m=7 call.
+        self.assertGreater(len(calls), n_before)
+
+    @skipIfRefEager("Inspects the kernel's fused-launch cache, absent in ref eager")
+    def test_fused_disabled_for_host_side_side_effect(self) -> None:
+        # Regression: a wrapper that runs a host-side side effect (out.zero_())
+        # before a partial-coverage device loop must NOT fuse -- the recipe would
+        # skip the zero_ and leave stale data in the uncovered region.
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64], num_warps=4, num_stages=2),
+            ignore_warnings=[helion.exc.TensorOperationInWrapper],
+            triton_fused_launch=True,
+        )
+        def partial(x: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(x)
+            out.zero_()
+            for i in hl.tile(64):  # covers only the first 64 rows of a larger x
+                out[i] = x[i] + 1
+            return out
+
+        x = torch.randn(256, device=DEVICE, dtype=torch.float32)
+        for _ in range(3):
+            r = partial(x)
+            torch.accelerator.synchronize()
+            # Covered region is x+1; the untouched tail must stay zeroed.
+            torch.testing.assert_close(r[:64], x[:64] + 1)
+            self.assertEqual(int(torch.count_nonzero(r[64:])), 0)
+        self.assertTrue(partial._fused_disabled)  # type: ignore[attr-defined]
+        self.assertEqual(len(partial._fused_recipes), 0)  # type: ignore[attr-defined]
+
+    @skipIfRefEager("Inspects the kernel's fused-launch cache, absent in ref eager")
+    def test_fused_disabled_for_side_effect_in_assign_rhs(self) -> None:
+        # Regression: a host side effect hidden in an assignment RHS
+        # (``out = out.zero_()``) must NOT fuse. This is an out-arg kernel that
+        # returns None, so the ONLY thing that can disable fusion is the RHS
+        # side-effect check -- if the wrapper-fuseability scan waves the Assign
+        # through, the recipe replays without the zero_ and leaves stale data in
+        # the region the partial-coverage device loop does not cover.
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64], num_warps=4, num_stages=2),
+            ignore_warnings=[helion.exc.TensorOperationInWrapper],
+            triton_fused_launch=True,
+        )
+        def partial(x: torch.Tensor, out: torch.Tensor) -> None:
+            out = out.zero_()  # side effect on the RHS of an assignment
+            for i in hl.tile(64):  # covers only the first 64 rows of a larger x
+                out[i] = x[i] + 1
+
+        x = torch.randn(256, device=DEVICE, dtype=torch.float32)
+        out = torch.empty(256, device=DEVICE, dtype=torch.float32)
+        for _ in range(3):
+            out.fill_(99.0)  # dirty the tail before each call
+            partial(x, out)
+            torch.accelerator.synchronize()
+            # Covered region is x+1; the untouched tail must be re-zeroed.
+            torch.testing.assert_close(out[:64], x[:64] + 1)
+            self.assertEqual(int(torch.count_nonzero(out[64:])), 0)
+        self.assertTrue(partial._fused_disabled)  # type: ignore[attr-defined]
+        self.assertEqual(len(partial._fused_recipes), 0)  # type: ignore[attr-defined]
+
+    @skipIfRefEager("Inspects the kernel's fused-launch cache, absent in ref eager")
+    def test_fused_engages_for_view_and_assert_wrapper(self) -> None:
+        # The replayability check must not over-reject: a wrapper made of
+        # asserts, shape unpacking, and pure .view() reshapes (the pretuned
+        # benchmark kernel's shape) stays fuseable.
+        @helion.kernel(
+            static_shapes=True,
+            config=helion.Config(block_sizes=[64], num_warps=4, num_stages=2),
+            ignore_warnings=[helion.exc.TensorOperationInWrapper],
+            triton_fused_launch=True,
+        )
+        def viewy(x: torch.Tensor, out: torch.Tensor) -> None:
+            assert x.ndim == 2
+            m, n = x.shape
+            x = x.view(m * n)
+            out = out.view(m * n)
+            for i in hl.tile(m * n):
+                out[i] = x[i] * 2.0
+
+        x = torch.randn(16, 64, device=DEVICE, dtype=torch.float32)
+        out = torch.empty_like(x)
+        viewy(x, out)
+        viewy(x, out)  # prime
+        torch.accelerator.synchronize()
+        # The view+assert wrapper must be accepted by the replayability check.
+        # (A recipe may still fail to form if a Triton launch hook/knob is
+        # active -- an environmental skip -- but that latches _fused_disabled
+        # without flipping _fused_wrapper_ok, so the two cases stay distinct: an
+        # over-rejecting wrapper scan sets _fused_wrapper_ok False and fails here
+        # rather than being masked by the skip.)
+        self.assertTrue(viewy._fused_wrapper_ok)  # type: ignore[attr-defined]
+        if not viewy._fused_recipes:  # type: ignore[attr-defined]
+            self.skipTest("Fused launch did not engage (a Triton hook/knob)")
+        self.assertFalse(viewy._fused_disabled)  # type: ignore[attr-defined]
+        out.zero_()
+        viewy(x, out)
+        torch.accelerator.synchronize()
+        torch.testing.assert_close(out, x * 2.0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Stacked PRs:
 * __->__#3012
 * #3008


--- --- ---

### Add fused launch fast path (triton_fused_launch)


Collapse the dispatch, generated host-wrapper, and launcher layers into a
single cached closure for in-place / out-arg Triton kernels.  After one
priming launch, a repeat call goes: one flat key -> recipe lookup -> one
exec-compiled closure that verifies captured globals, builds the
CompiledKernel.run args, and launches -- all inlined into Kernel.__call__
before the _fast_dispatch_key/dispatch-cache branch.

Correctness (the fused path bypasses both the wrapper and default_launcher,
so it re-guards the hazards those layers own):
- The dispatch key is built per call by build_fused_key_fn -- one flat eval'd
  expression that embeds type(arg) at every position (a differing layout is a
  new key, never a false hit), frozenset-normalizes _dynamo_static_indices,
  folds in the 16-byte alignment bit, and appends the user key= result.  It is
  cached in _fused_key_fn and rebuilt on a layout change (_fused_dispatch_key).
- Each closure re-checks captured globals against their primed values via
  .get(name, _MISSING) so a mutated OR deleted global raises GlobalsChanged;
  the hot-path except catches only GlobalsChanged (a real launch error is not
  masked into a silent double-launch).
- _wrapper_body_is_fuseable AST-inspects the generated _run source and fuses
  only a plain {Assign/AnnAssign/Assert, one bare _launcher(...) Expr, Return}
  body, so a wrapper with host-side side effects (e.g. out.zero_() before a
  partial-coverage loop) latches _fused_disabled instead of dropping them.
- torch.compiler.is_compiling() guards both the prime and replay paths.

Fusion auto-disables (latched per kernel) whenever the recipe can't be
reproduced: a non-None wrapper return (covers output-allocating kernels),
multiple device launches, cooperative-grid launches, extra launcher kwargs,
or an unmatched launch arg.  Recipes cache the compiled binary directly, so
they are cleared on recompile (set_config) and reset().

The fused-launch helpers (_triton_driver, _triton_direct_launch_ok, and the
_MISSING_GLOBAL sentinel) live in helion/runtime/_fused_launch.py alongside
the code that uses them; _triton_driver is a functools.cache'd accessor.

New setting triton_fused_launch (default True, env HELION_TRITON_FUSED_LAUNCH),
Triton-only.  Tests: test/test_misc.py::TestFusedLauncher (cache engages,
disabled for tensor-returning kernels, unaligned input, globals mutation
raises + recovers, setting off, and the key/fuseability regressions:
None-then-tensor is not a false hit, tensor-then-None does not crash, user
key= is respected, host side effects disable fusion).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
