### PR TITLE
[No Commit] Investigating B200 CI: expand NVIDIA state dump and add CUDA-check retry

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -72,7 +72,17 @@ jobs:
         if: startsWith(inputs.image, 'nvidia')
         run: |
           echo "Detected NVIDIA image"
+          echo "== runner name: ${RUNNER_NAME:-unknown} =="
+          set +e
           nvidia-smi || echo "nvidia-smi not found"
+          echo "== /dev/nvidia* devices =="
+          ls -la /dev/nvidia* 2>&1
+          echo "== NVIDIA kernel modules =="
+          lsmod 2>/dev/null | grep -i nvidia || cat /proc/modules 2>/dev/null | grep -i nvidia || echo "module list unavailable"
+          echo "== NVIDIA/CUDA env =="
+          env | grep -E '^(NVIDIA|CUDA)_' | sort || true
+          echo "== fabric-manager socket (host mount, best-effort) =="
+          ls -la /var/run/nvidia-fabricmanager* 2>&1 || true
 
       - name: Run ROCm command
         if: startsWith(inputs.image, 'rocm')
@@ -125,22 +135,54 @@ jobs:
         if: startsWith(inputs.image, 'nvidia')
         run: |
           source .venv/bin/activate
-          python -c "
-          import torch, sys
+          # Retry once with a short sleep — CUDA init on B200 occasionally races
+          # with UVM device-node creation right after container start. On the
+          # second failure, dump environment/device state before failing.
+          check_cuda() {
+            python - <<'PY'
+          import os, sys, traceback
+          import torch
 
-          assert torch.cuda.is_available(), 'FATAL: CUDA not available'
+          try:
+              torch.cuda.init()
+          except Exception:
+              print("torch.cuda.init() raised:", file=sys.stderr)
+              traceback.print_exc()
+              print("CUDA_VISIBLE_DEVICES=", os.environ.get("CUDA_VISIBLE_DEVICES"), file=sys.stderr)
+              print("NVIDIA_VISIBLE_DEVICES=", os.environ.get("NVIDIA_VISIBLE_DEVICES"), file=sys.stderr)
+              sys.exit(1)
+
+          assert torch.cuda.is_available(), "FATAL: CUDA not available"
           n = torch.cuda.device_count()
-          assert n > 0, 'FATAL: No CUDA devices found'
-          print(f'CUDA devices: {n}')
+          assert n > 0, "FATAL: No CUDA devices found"
+          print(f"CUDA devices: {n}")
 
           for i in range(n):
-              dev = torch.device('cuda', i)
+              dev = torch.device("cuda", i)
               a = torch.randn(256, 256, device=dev)
-              b = (a @ a).sum().item()
-              print(f'  Device {i} ({torch.cuda.get_device_name(i)}): OK')
+              (a @ a).sum().item()
+              print(f"  Device {i} ({torch.cuda.get_device_name(i)}): OK")
 
-          print(f'All {n} devices healthy')
-          "
+          print(f"All {n} devices healthy")
+          PY
+          }
+
+          for attempt in 1 2; do
+            if check_cuda; then
+              exit 0
+            fi
+            echo "CUDA check attempt ${attempt} failed"
+            echo "== /dev/nvidia* =="
+            ls -la /dev/nvidia* 2>&1 || true
+            echo "== nvidia-smi (post-fail) =="
+            nvidia-smi 2>&1 || echo "nvidia-smi failed"
+            if [ "${attempt}" -eq 1 ]; then
+              echo "sleeping 15s before retry"
+              sleep 15
+            fi
+          done
+          echo "CUDA check failed on runner ${RUNNER_NAME:-unknown} after retry"
+          exit 1
 
       - name: Install Benchmark Requirements
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,17 @@ jobs:
         if: startsWith(matrix.image, 'nvidia')
         run: |
           echo "Detected NVIDIA image"
+          echo "== runner name: ${RUNNER_NAME:-unknown} =="
+          set +e
           nvidia-smi || echo "nvidia-smi not found"
+          echo "== /dev/nvidia* devices =="
+          ls -la /dev/nvidia* 2>&1
+          echo "== NVIDIA kernel modules =="
+          lsmod 2>/dev/null | grep -i nvidia || cat /proc/modules 2>/dev/null | grep -i nvidia || echo "module list unavailable"
+          echo "== NVIDIA/CUDA env =="
+          env | grep -E '^(NVIDIA|CUDA)_' | sort || true
+          echo "== fabric-manager socket (host mount, best-effort) =="
+          ls -la /var/run/nvidia-fabricmanager* 2>&1 || true
 
       - name: Run ROCm command
         if: startsWith(matrix.image, 'rocm')
@@ -252,22 +262,54 @@ jobs:
         if: startsWith(matrix.image, 'nvidia')
         run: |
           source .venv/bin/activate
-          python -c "
-          import torch, sys
+          # Retry once with a short sleep — CUDA init on B200 occasionally races
+          # with UVM device-node creation right after container start. On the
+          # second failure, dump environment/device state before failing.
+          check_cuda() {
+            python - <<'PY'
+          import os, sys, traceback
+          import torch
 
-          assert torch.cuda.is_available(), 'FATAL: CUDA not available'
+          try:
+              torch.cuda.init()
+          except Exception:
+              print("torch.cuda.init() raised:", file=sys.stderr)
+              traceback.print_exc()
+              print("CUDA_VISIBLE_DEVICES=", os.environ.get("CUDA_VISIBLE_DEVICES"), file=sys.stderr)
+              print("NVIDIA_VISIBLE_DEVICES=", os.environ.get("NVIDIA_VISIBLE_DEVICES"), file=sys.stderr)
+              sys.exit(1)
+
+          assert torch.cuda.is_available(), "FATAL: CUDA not available"
           n = torch.cuda.device_count()
-          assert n > 0, 'FATAL: No CUDA devices found'
-          print(f'CUDA devices: {n}')
+          assert n > 0, "FATAL: No CUDA devices found"
+          print(f"CUDA devices: {n}")
 
           for i in range(n):
-              dev = torch.device('cuda', i)
+              dev = torch.device("cuda", i)
               a = torch.randn(256, 256, device=dev)
-              b = (a @ a).sum().item()
-              print(f'  Device {i} ({torch.cuda.get_device_name(i)}): OK')
+              (a @ a).sum().item()
+              print(f"  Device {i} ({torch.cuda.get_device_name(i)}): OK")
 
-          print(f'All {n} devices healthy')
-          "
+          print(f"All {n} devices healthy")
+          PY
+          }
+
+          for attempt in 1 2; do
+            if check_cuda; then
+              exit 0
+            fi
+            echo "CUDA check attempt ${attempt} failed"
+            echo "== /dev/nvidia* =="
+            ls -la /dev/nvidia* 2>&1 || true
+            echo "== nvidia-smi (post-fail) =="
+            nvidia-smi 2>&1 || echo "nvidia-smi failed"
+            if [ "${attempt}" -eq 1 ]; then
+              echo "sleeping 15s before retry"
+              sleep 15
+            fi
+          done
+          echo "CUDA check failed on runner ${RUNNER_NAME:-unknown} after retry"
+          exit 1
 
       - name: Inductor Worker Check
         if: startsWith(matrix.image, 'nvidia')


### PR DESCRIPTION
## Summary
- All 18 B200 jobs on the 2026-07-08 nightly ([run 28930002457](https://github.com/pytorch/helion/actions/runs/28930002457)) failed at infra steps: 11 at `CUDA Compute Check` with `CUDA unknown error`, 7 at `Initialize containers` with `all predefined address pools have been fully subnetted`. Docker-network failures are localized to a single host (`dgxb200-03`); the CUDA failures span `dgxb200-04` and `dgxb200-05`.
- The current CUDA-check log tells us only that `torch.cuda.is_available()` returned False. We cannot see whether UVM device nodes are missing, fabric-manager socket is down, `CUDA_VISIBLE_DEVICES` got clobbered, or something else. This PR expands the pre-check state dump and wraps the check with a retry + failure forensics so the next occurrence self-documents.
- Diagnostic-only — no behavior change on healthy runners. The `[No Commit]` title is intentional; this is meant to keep on `diag-b200-cuda` until we have signal from a nightly run.

## What changes
- `Run NVIDIA command`: dumps `/dev/nvidia*`, `nvidia` kernel modules, `NVIDIA_/CUDA_` env vars, and the fabric-manager socket next to `nvidia-smi`. Runs before the CUDA check so we get the state even when the check fails.
- `CUDA Compute Check`: calls `torch.cuda.init()` explicitly and prints the traceback (currently silenced as a `UserWarning`), retries once after 15s, and dumps `/dev/nvidia*` + `nvidia-smi` between/after attempts. The retry also covers the observed pattern where the *same runner host* succeeded on 2026-07-07 and failed on 2026-07-08 — a transient host-side race is a plausible cause.

## Test plan
- [ ] YAML parses (checked locally with `yaml.safe_load`)
- [ ] Bash `-n` syntax check on both step scripts passes (heredoc terminator lands at column 0 after YAML normalization)
- [ ] Wait for a nightly run to land; confirm we see the extra state dumped on any failing B200 job
- [ ] If runner infra is healed by then, kick a manual `benchmark_dispatch` on B200 to prove the diagnostic wiring executes cleanly on a healthy runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)
