### PR TITLE
[No Commit] Investigating B200 CI: add host-level probe workflow

### DIFF
--- a/.github/workflows/b200_host_probe.yml
+++ b/.github/workflows/b200_host_probe.yml
@@ -1,0 +1,89 @@
+name: B200 Host Probe (diagnostic)
+
+# Diagnostic-only workflow for investigating B200 CI infra failures.
+# Runs directly on the linux.dgx.b200 runner host (no container:) so we can
+# see host-level state that benchmark jobs cannot, e.g. Docker daemon state,
+# NVIDIA kernel modules, fabric-manager status. Optionally prunes leaked
+# Docker networks on the host that lands the job (Docker's default address
+# pools are per-daemon; a full pool = every subsequent `docker network create`
+# fails with "all predefined address pools have been fully subnetted", which
+# is what we saw take out `dgxb200-03` on 2026-07-08).
+
+on:
+  workflow_dispatch:
+    inputs:
+      prune_networks:
+        description: 'Prune leaked Docker networks (unfiltered `docker network prune -f`). Safe to leave off for pure inspection.'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  probe:
+    runs-on: linux.dgx.b200
+    permissions:
+      contents: read
+    steps:
+      - name: Runner identity
+        run: |
+          echo "runner name: ${RUNNER_NAME:-unknown}"
+          echo "hostname:    $(hostname)"
+          uname -a
+
+      - name: Docker daemon state
+        run: |
+          set +e
+          echo "== docker version =="
+          docker version 2>&1 || echo "docker version failed"
+          echo "== docker info (subnet-related fields) =="
+          docker info 2>&1 | grep -Ei 'server version|storage driver|default runtime|kernel version|operating system|architecture|cpus|total memory' || true
+          echo "== docker network ls =="
+          docker network ls 2>&1
+          echo "== count of user-defined networks (excludes bridge/host/none) =="
+          docker network ls --format '{{.Name}}' 2>&1 | grep -Ev '^(bridge|host|none)$' | wc -l
+          echo "== docker daemon config (if visible) =="
+          cat /etc/docker/daemon.json 2>/dev/null || echo "/etc/docker/daemon.json not readable"
+          echo "== docker network create smoke test =="
+          NETNAME="probe-$(date +%s)-$$"
+          if docker network create "$NETNAME" 2>&1; then
+            echo "smoke-create: OK"
+            docker network rm "$NETNAME" >/dev/null 2>&1 || true
+          else
+            echo "smoke-create: FAILED"
+          fi
+
+      - name: NVIDIA host state
+        run: |
+          set +e
+          echo "== nvidia-smi =="
+          nvidia-smi 2>&1 || echo "nvidia-smi not found on host"
+          echo "== /dev/nvidia* =="
+          ls -la /dev/nvidia* 2>&1
+          echo "== NVIDIA kernel modules =="
+          lsmod 2>/dev/null | grep -i nvidia || cat /proc/modules 2>/dev/null | grep -i nvidia || echo "module list unavailable"
+          echo "== fabric-manager (nv-fabricmanager) =="
+          pgrep -a nv-fabricmanager 2>&1 || echo "nv-fabricmanager not running"
+          systemctl status nvidia-fabricmanager 2>&1 | head -20 || true
+          echo "== persistenced =="
+          pgrep -a nvidia-persistenced 2>&1 || echo "nvidia-persistenced not running"
+          echo "== dmesg tail (nvidia/uvm) =="
+          dmesg 2>/dev/null | grep -iE 'nvidia|uvm' | tail -30 || echo "dmesg not accessible"
+
+      - name: Prune leaked Docker networks
+        if: ${{ github.event.inputs.prune_networks == 'true' }}
+        run: |
+          set +e
+          echo "== BEFORE: user-defined network count =="
+          docker network ls --format '{{.Name}}' | grep -Ev '^(bridge|host|none)$' | wc -l
+          echo "== docker network prune -f =="
+          docker network prune -f
+          echo "== AFTER: user-defined network count =="
+          docker network ls --format '{{.Name}}' | grep -Ev '^(bridge|host|none)$' | wc -l
+          echo "== post-prune smoke-create =="
+          NETNAME="probe-postprune-$(date +%s)-$$"
+          if docker network create "$NETNAME" 2>&1; then
+            echo "post-prune create: OK"
+            docker network rm "$NETNAME" >/dev/null 2>&1 || true
+          else
+            echo "post-prune create: STILL FAILING"
+          fi


### PR DESCRIPTION
## Summary
- On the 2026-07-08 nightly ([run 28930002457](https://github.com/pytorch/helion/actions/runs/28930002457)), 7 of the 18 failed B200 jobs died at `Initialize containers` with `Error response from daemon: all predefined address pools have been fully subnetted`. All 7 landed on the same physical host, `dgxb200-03`. The remaining 8 slots on that host got the CUDA bucket instead.
- Docker allocates the container network before any step of the job runs, so the `benchmark.yml` job can't see or fix this from inside its `container:`. This PR adds a separate diagnostic workflow that lands on `linux.dgx.b200` *without* a container, so it can look at the actual daemon state — and, behind an opt-in toggle, prune leaked networks and re-verify with a smoke create.
- Diagnostic-only, dispatch-only, no scheduled trigger. Also captures NVIDIA host state (kernel modules, `/dev/nvidia*`, fabric-manager, persistenced, dmesg) for the CUDA bucket investigation. The `[No Commit]` title is intentional; kept on `diag-b200-docker` until we have signal.

## What's in it
- New file `.github/workflows/b200_host_probe.yml` — `workflow_dispatch` only.
- Steps:
  - `Runner identity` — logs `RUNNER_NAME`, hostname, `uname -a`.
  - `Docker daemon state` — `docker version`/`info`, network ls, count of user-defined networks (bridge/host/none excluded), `/etc/docker/daemon.json`, and a live `docker network create` smoke test.
  - `NVIDIA host state` — nvidia-smi, `/dev/nvidia*`, `lsmod|grep nvidia`, fabric-manager/persistenced processes, recent dmesg lines mentioning nvidia/uvm.
  - `Prune leaked Docker networks` (only when `prune_networks=true`) — unfiltered `docker network prune -f`, then re-runs the smoke create.

## How to use
- To just look: run without arguments; the host you land on will dump state.
- To free a stuck host: keep re-dispatching until `RUNNER_NAME` prefix matches the host we want (visible in the previous nightly's failing logs). Then dispatch with `prune_networks=true`. That does an unfiltered prune — bystander networks belonging to *other* actively-running jobs on the same host could be removed. Only click when the pool is fully subnetted (i.e. every subsequent job would fail anyway).
- Long-term the real fix is a wider `default-address-pools` in `/etc/docker/daemon.json` on those hosts; the workflow's `daemon.json` dump gives us the evidence to ask for it.

## Test plan
- [ ] YAML parses (`yaml.safe_load`)
- [ ] `bash -n` on all four step scripts passes
- [ ] Dispatch on a healthy B200 runner and confirm all four steps print output; the smoke `docker network create` should succeed
- [ ] Confirm the `prune_networks` gate is off by default (the step should be `skipped` on a plain dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
