### PR TITLE
Trying to get welford autotuning to pass on MI350

### DIFF
--- a/examples/welford.py
+++ b/examples/welford.py
@@ -42,12 +42,18 @@ def welford(
 
     out = torch.empty([m, n], dtype=x.dtype, device=x.device)
 
+    # Share one autotuned block size across both passes over n. This keeps the
+    # reduction config space one-dimensional (instead of tuning the two n-loops
+    # independently), which shrinks the search and avoids the fragile large-n
+    # configs that fail to autotune on AMD (gfx950) for wide reduction dims.
+    block_size_n = hl.register_block_size(n)
+
     for tile_m in hl.tile(m):
         acc_cnt = torch.zeros_like(x[tile_m, 0], dtype=torch.float32)
         acc_mean = torch.zeros_like(acc_cnt)
         acc_m2 = torch.zeros_like(acc_cnt)
 
-        for tile_n in hl.tile(n):
+        for tile_n in hl.tile(n, block_size=block_size_n):
             chunk = x[tile_m, tile_n]
             # Count of VALID columns (the divisor): use the true valid count, not the constexpr
             # tile width (over-counts last-tile padding). Cast the mask to int32 BEFORE summing —
@@ -69,7 +75,7 @@ def welford(
         mean_col = acc_mean[:, None]
         rstd_col = rstd_tile[:, None]
 
-        for tile_n in hl.tile(n):
+        for tile_n in hl.tile(n, block_size=block_size_n):
             xi_chuck = x[tile_m, tile_n]
             w_chuck = weight[tile_n][None, :]
             b_chuck = bias[tile_n][None, :]


### PR DESCRIPTION

welford is the only reduction example that tunes two *independent* block sizes for its two passes over the reduction dim n. On the benchmark dashboard it is also the sole AMD (gfx950 / MI350) kernel with run failures, and only at large reduction dims (N in {3072, 4096, 6144, 8192}); smaller N and every other platform (B200 / H100 / TPU) pass. Tuning the two n-loops independently doubles the reduction search space and lets autotuning explore/compile many wide-n variants, which is where the AMD failures cluster.

Register a single block size with hl.register_block_size(n) and use it for both hl.tile(n, ...) loops, so the reduction is tuned with one block-size dimension instead of two. This shrinks the search space and the number of distinct wide-n kernels that get compiled, without changing the algorithm.

Reproduction note: the failure reproduces only on gfx950 (MI350). On the MI300 (gfx942) available for development, welford already autotunes and runs correctly at all of the failing sizes, so the AMD-specific fault could not be directly reproduced/confirmed there. This change is validated on gfx942 for correctness and autotune convergence.

Test Plan:
Ran on an MI300 (gfx942) with the ROCm PyTorch nightly wheel + Triton.

- Correctness (default config), M=4096, N in {2048, 3072, 4096, 8192}: all allclose vs torch.nn.functional.layer_norm (max abs err ~2e-6).

- Autotuning still converges and the two n-loops now share one block: `HELION_AUTOTUNE_EFFORT=quick` autotune at N=8192 completed (62 configs) with best block_sizes=[256, 32] (was 3 entries) and a correct final run.

- Unit test: `python -m pytest test/test_examples.py::TestExamples::test_welford` -> passed.

Authored with assistance from Claude (Claude Code).