### PR TITLE
[Pallas] Consolidate launcher functions into one

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -1626,9 +1626,6 @@ class PallasBackend(Backend):
             "lax": "import jax.lax as lax",
             "pltpu": "from jax.experimental.pallas import tpu as pltpu",
             "_default_pallas_launcher": "from helion.runtime import default_pallas_launcher as _default_pallas_launcher",
-            "_default_pallas_pipeline_launcher": "from helion.runtime import default_pallas_pipeline_launcher as _default_pallas_pipeline_launcher",
-            "_default_pallas_fori_launcher": "from helion.runtime import default_pallas_fori_launcher as _default_pallas_fori_launcher",
-            "_default_pallas_compact_worklist_launcher": "from helion.runtime import default_pallas_compact_worklist_launcher as _default_pallas_compact_worklist_launcher",
         }
 
     # Config keys that Pallas actually uses.  Everything else
@@ -2541,33 +2538,30 @@ class PallasBackend(Backend):
 
         # Pass scratch shapes for pipeline/fori_loop launcher
         pallas_loop_type = config.get("pallas_loop_type", "unroll")
-        if pallas_loop_type in ("emit_pipeline", "fori_loop", "compact_worklist"):
-            scratch_shapes = [
-                (
-                    s.shape,
-                    self.dtype_str(s.dtype) if s.dtype is not None else None,
-                    s.scratch_type,
-                )
-                for s in device_fn._scratch_args
+        scratch_shapes = [
+            (
+                s.shape,
+                self.dtype_str(s.dtype) if s.dtype is not None else None,
+                s.scratch_type,
+            )
+            for s in device_fn._scratch_args
+        ]
+        if scratch_shapes:
+            launcher_args.append(f"_scratch_shapes={scratch_shapes!r}")
+
+        # Identify which launcher arg positions correspond to pipeline-body
+        # tensors (need HBM refs); all others get proper BlockSpecs.
+        from .device_function import TensorArg
+
+        if sorted_args is not None:
+            pipeline_arg_indices = [
+                i
+                for i, arg in enumerate(sorted_args)
+                if isinstance(arg, TensorArg)
+                and mem_space.get(id(arg.fake_value)) == PallasMemorySpace.HBM
             ]
-            if scratch_shapes:
-                launcher_args.append(f"_scratch_shapes={scratch_shapes!r}")
-
-            # Identify which launcher arg positions correspond to pipeline-body
-            # tensors (need HBM refs); all others get proper BlockSpecs.
-            from .device_function import TensorArg
-
-            if sorted_args is not None:
-                pipeline_arg_indices = [
-                    i
-                    for i, arg in enumerate(sorted_args)
-                    if isinstance(arg, TensorArg)
-                    and mem_space.get(id(arg.fake_value)) == PallasMemorySpace.HBM
-                ]
-                if pipeline_arg_indices:
-                    launcher_args.append(
-                        f"_pipeline_arg_indices={pipeline_arg_indices!r}"
-                    )
+            if pipeline_arg_indices:
+                launcher_args.append(f"_pipeline_arg_indices={pipeline_arg_indices!r}")
 
         if CompileEnvironment.current().settings.pallas_interpret:
             launcher_args.append("_pallas_interpret=True")
@@ -2649,7 +2643,13 @@ class PallasBackend(Backend):
         ]
 
     def build_launcher_name(self, config: Config) -> str:
-        """Return the launcher name to use based on ``pallas_loop_type``."""
+        """Return the single Pallas launcher name.
+
+        All ``pallas_loop_type`` values (``unroll``, ``emit_pipeline``,
+        ``fori_loop``, ``compact_worklist``) route through the same
+        ``default_pallas_launcher``; the loop-shape choice happens
+        inside based on the launcher-observable kwargs codegen emits.
+        """
         from ..autotuner.config_spec import VALID_PALLAS_LOOP_TYPES
 
         pallas_loop_type = config.get("pallas_loop_type", "unroll")
@@ -2658,15 +2658,6 @@ class PallasBackend(Backend):
                 f"Invalid pallas_loop_type {pallas_loop_type!r}. "
                 f"Expected one of {VALID_PALLAS_LOOP_TYPES}."
             )
-        if pallas_loop_type == "emit_pipeline":
-            return "_default_pallas_pipeline_launcher"
-        if pallas_loop_type == "fori_loop":
-            return "_default_pallas_fori_launcher"
-        if pallas_loop_type == "compact_worklist":
-            # Detection + plan stash happen in pre_codegen; route to the compact
-            # launcher (builds the worklist in-jit -> dynamic num_work grid with
-            # scalar-prefetch metadata).
-            return "_default_pallas_compact_worklist_launcher"
         return self.default_launcher_name
 
     def get_launcher_name(self) -> str:

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -4,7 +4,6 @@ import base64
 from contextlib import suppress
 import contextvars
 from dataclasses import dataclass
-import enum
 import hashlib
 import importlib
 import inspect
@@ -1363,21 +1362,6 @@ def _build_matmul_dot_general_jit_fn(
     return cast("Callable[..., object]", jax.jit(matmul_fn))
 
 
-class _PallasLoopKind(enum.Enum):
-    """Which ``pallas_loop_type`` flavour a launcher is compiling for.
-
-    Drives the spec-build / scratch / kernel-wrap branches inside
-    :func:`_pallas_compile_jit_fn`; the values match the
-    ``pallas_loop_type`` strings codegen emits so the JAX-export path
-    can resolve them straight from the bound kernel's config.
-    """
-
-    UNROLL = "unroll"
-    EMIT_PIPELINE = "emit_pipeline"
-    FORI_LOOP = "fori_loop"
-    COMPACT_WORKLIST = "compact_worklist"
-
-
 def _pallas_build_scratch_shapes(
     pltpu: object,
     jnp: object,
@@ -1465,7 +1449,6 @@ def _pallas_compile_jit_fn(
     grid: tuple[int, ...],
     args: tuple[object, ...],
     *,
-    kind: _PallasLoopKind,
     _output_indices: list[int],
     _inplace_indices: list[int] | None,
     _block_spec_info: _BlockSpecInfo | None,
@@ -1475,28 +1458,31 @@ def _pallas_compile_jit_fn(
     _matmul_dot_general: dict[str, object] | None,
     interpret: bool,
 ) -> _PallasCompileResult:
-    """Build the ``pl.pallas_call`` jit_fn shared by all Pallas launchers.
+    """Build the ``pl.pallas_call`` jit_fn used by the Pallas launcher.
 
-    ``kind`` selects the loop-spec flavour:
+    The kernel loop shape is driven entirely by the launcher-observable
+    inputs:
 
-    - :attr:`_PallasLoopKind.UNROLL`: simple grid + ``BlockSpec`` per arg
-      (no scratch)
-    - :attr:`_PallasLoopKind.EMIT_PIPELINE`: ``PrefetchScalarGridSpec``
-      with HBM refs for pipeline-body tensors and VMEM scratch
-    - :attr:`_PallasLoopKind.FORI_LOOP`: same gridspec/scratch shape as
-      ``EMIT_PIPELINE``; the kernel body uses ``jax.lax.fori_loop`` with
-      manual DMA
+    - ``_scratch_shapes`` present (VMEM buffers / DMA semaphores) →
+      wrap ``in``/``out`` specs and the grid in a
+      ``pltpu.PrefetchScalarGridSpec`` so the scratch refs are threaded
+      into the kernel.  Pipeline-body tensors (listed in
+      ``_pipeline_arg_indices``) get HBM refs via
+      ``_pallas_build_pipeline_specs``, and their inplace copy is
+      skipped because you cannot directly index an HBM ref.
+    - ``_scratch_shapes`` absent → simple ``grid`` + per-arg
+      ``BlockSpec`` layout via ``_pallas_build_block_specs``.
 
-    When ``_matmul_dot_general`` is provided (only on ``UNROLL`` and
-    ``EMIT_PIPELINE`` no-tiling matmul configs), substitutes
+    When ``_matmul_dot_general`` is provided (no-tiling matmul configs
+    on the unroll / emit_pipeline lowerings), substitutes
     ``jax.jit(lax.dot_general)`` for ``pl.pallas_call`` and skips the
     VMEM check; XLA's planner streams the contraction so the
     pallas_call lowering's VMEM estimate doesn't apply.
 
     ``args`` must already have any ds-padding applied — this helper
     builds specs from the post-pad shapes.  Returns a
-    :class:`_PallasCompileResult` so launchers can wrap the jit_fn in a
-    JaxCallable while the JAX-export path can call it directly.
+    :class:`_PallasCompileResult` so the torch launcher can wrap the
+    jit_fn in a JaxCallable while the JAX-export path calls it directly.
     """
     from jax.experimental import pallas as pl
     from jax.experimental.pallas import tpu as pltpu
@@ -1524,24 +1510,19 @@ def _pallas_compile_jit_fn(
         _block_spec_info,
     )
 
-    if kind is _PallasLoopKind.UNROLL:
-        in_specs, out_specs = _pallas_build_block_specs(
-            pl,
-            jnp,
-            pltpu,
-            grid,
-            args,
-            tensor_arg_indices,
-            _output_indices,
-            _block_spec_info,
-            _smem_arg_indices,
-            output_only_indices,
-        )
-        scratch_shapes: list[object] = []
-        skip_inplace_copy: set[int] = set()
-    else:
+    # Two discriminators drive the spec-building path — either forces
+    # the ``PrefetchScalarGridSpec`` route:
+    #   1. ``_pipeline_arg_indices`` non-empty: some tensor is an HBM
+    #      pipeline-body ref that needs ``pl.BlockSpec(memory_space=pl.ANY)``
+    #      rather than a plain BlockSpec.
+    #   2. ``_scratch_shapes`` non-empty: the kernel registered VMEM
+    #      buffers or DMA semaphores, which are only reachable via a
+    #      ``scratch_shapes=`` argument on ``PrefetchScalarGridSpec``.
+    needs_pipeline_specs = bool(_pipeline_arg_indices) or bool(_scratch_shapes)
+    has_scratch = bool(_scratch_shapes)
+    if needs_pipeline_specs:
         assert _block_spec_info is not None, (
-            f"{kind.value!r} launcher requires _block_spec_info from codegen"
+            "pallas pipeline / scratch kernels require _block_spec_info from codegen"
         )
         scratch_shapes = _pallas_build_scratch_shapes(pltpu, jnp, _scratch_shapes or [])
         in_specs, out_specs = _pallas_build_pipeline_specs(
@@ -1557,7 +1538,22 @@ def _pallas_compile_jit_fn(
             output_only_indices,
             smem_arg_indices=_smem_arg_indices,
         )
-        skip_inplace_copy = set(_pipeline_arg_indices or [])
+        skip_inplace_copy: set[int] = set(_pipeline_arg_indices or [])
+    else:
+        in_specs, out_specs = _pallas_build_block_specs(
+            pl,
+            jnp,
+            pltpu,
+            grid,
+            args,
+            tensor_arg_indices,
+            _output_indices,
+            _block_spec_info,
+            _smem_arg_indices,
+            output_only_indices,
+        )
+        scratch_shapes = []
+        skip_inplace_copy = set()
 
     reordered_kernel = _pallas_make_reordered_kernel(
         pallas_kernel,
@@ -1586,7 +1582,7 @@ def _pallas_compile_jit_fn(
             pltpu,
             in_specs,
             out_specs,
-            scratch_shapes if kind is not _PallasLoopKind.UNROLL else None,
+            scratch_shapes if has_scratch else None,
             args,
             tensor_arg_indices,
             _output_indices,
@@ -1600,16 +1596,7 @@ def _pallas_compile_jit_fn(
         jit_fn = _build_matmul_dot_general_jit_fn(_matmul_dot_general)
     else:
         pallas_call_kwargs: dict[str, object] = {"out_shape": out_shape_arg}
-        if kind is _PallasLoopKind.UNROLL:
-            pallas_call_kwargs["grid"] = grid
-            if in_specs is not None:
-                pallas_call_kwargs["in_specs"] = in_specs
-                pallas_call_kwargs["out_specs"] = out_specs
-            if any(sem != "parallel" for sem in dimension_semantics):
-                pallas_call_kwargs["compiler_params"] = pltpu.CompilerParams(  # pyrefly: ignore[bad-instantiation]
-                    dimension_semantics=dimension_semantics,
-                )
-        else:
+        if needs_pipeline_specs:
             pallas_call_kwargs["grid_spec"] = pltpu.PrefetchScalarGridSpec(  # pyrefly: ignore[missing-attribute]
                 num_scalar_prefetch=0,
                 in_specs=in_specs,
@@ -1620,6 +1607,15 @@ def _pallas_compile_jit_fn(
             pallas_call_kwargs["compiler_params"] = pltpu.CompilerParams(  # pyrefly: ignore[bad-instantiation]
                 dimension_semantics=dimension_semantics,
             )
+        else:
+            pallas_call_kwargs["grid"] = grid
+            if in_specs is not None:
+                pallas_call_kwargs["in_specs"] = in_specs
+                pallas_call_kwargs["out_specs"] = out_specs
+            if any(sem != "parallel" for sem in dimension_semantics):
+                pallas_call_kwargs["compiler_params"] = pltpu.CompilerParams(  # pyrefly: ignore[bad-instantiation]
+                    dimension_semantics=dimension_semantics,
+                )
         if interpret:
             pallas_call_kwargs["interpret"] = True
 
@@ -1638,14 +1634,14 @@ def _pallas_compile_jit_fn(
     )
 
 
+_PALLAS_CACHE_ATTR = "_pallas_cache"
+
+
 def _pallas_install_launcher_cache(
     pallas_kernel: object,
     grid: tuple[int, ...],
     args: tuple[object, ...],
     *,
-    kind: _PallasLoopKind,
-    cache_attr: str,
-    trace_key_suffix: str,
     _output_indices: list[int] | None,
     _inplace_indices: list[int] | None,
     _block_spec_info: _BlockSpecInfo | None,
@@ -1656,12 +1652,13 @@ def _pallas_install_launcher_cache(
     _pallas_interpret: bool | None,
     _matmul_dot_general: dict[str, object] | None = None,
 ) -> tuple[object, ...]:
-    """Cache-miss path shared by all three torch-tensor Pallas launchers.
+    """Cache-miss path shared by all Pallas launchers.
 
-    Builds the ``pl.pallas_call`` jit_fn via :func:`_pallas_compile_jit_fn`,
-    wraps it in a ``JaxCallable`` (or interpret-mode shim), seeds the
-    ``_LauncherFastPath`` slot, stores the result on
-    ``pallas_kernel.<cache_attr>``, and returns the freshly-installed cache
+    Builds the ``pl.pallas_call`` jit_fn via :func:`_pallas_compile_jit_fn`
+    (whose shape is fully determined by the passed-in kwargs — no loop-type
+    discriminator), wraps it in a ``JaxCallable`` (or interpret-mode shim),
+    seeds the ``_LauncherFastPath`` slot, stores the result on
+    ``pallas_kernel._pallas_cache``, and returns the freshly-installed cache
     tuple so the caller can fall straight through to the shared invoke.
     """
     interpret = (
@@ -1686,7 +1683,6 @@ def _pallas_install_launcher_cache(
         pallas_kernel,
         grid,
         spec_args,
-        kind=kind,
         _output_indices=output_indices,
         _inplace_indices=_inplace_indices,
         _block_spec_info=_block_spec_info,
@@ -1704,9 +1700,9 @@ def _pallas_install_launcher_cache(
         output_indices,
         result.arg_to_tensor_pos,
         result.tensor_arg_indices,
-        cache_attr=cache_attr,
+        cache_attr=_PALLAS_CACHE_ATTR,
         call_aliases=result.pallas_aliases,
-        trace_key_suffix=trace_key_suffix,
+        trace_key_suffix="",
         interpret=interpret,
     )
 
@@ -1724,7 +1720,7 @@ def _pallas_install_launcher_cache(
         fast_path,
         None,
     )
-    setattr(pallas_kernel, cache_attr, cache)
+    setattr(pallas_kernel, _PALLAS_CACHE_ATTR, cache)
     return cache
 
 
@@ -1778,12 +1774,33 @@ def default_pallas_launcher(
     _inplace_indices: list[int] | None = None,
     _block_spec_info: _BlockSpecInfo | None = None,
     _smem_arg_indices: list[int] | None = None,
+    _scratch_shapes: list[tuple[tuple[int, ...], str | None, str]] | None = None,
+    _pipeline_arg_indices: list[int] | None = None,
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _pallas_interpret: bool | None = None,
     _matmul_dot_general: dict[str, object] | None = None,
+    _compact_build_worklist: Callable[..., object] | None = None,
+    _compact_offset_arg_indices: list[int] | None = None,
+    _compact_metadata_fields: list[str] | None = None,
+    _compact_owner_ref_pos: int = 0,
+    _compact_num_scalar_prefetch: int = 0,
+    _compact_aligned_arg_indices: list[int] | None = None,
+    _compact_tile_start_ref_pos: int = 1,
+    _compact_block: int = 1,
     **kwargs: object,
 ) -> object:
-    """Default launcher for Pallas kernels on TPU (or CPU with interpret=True).
+    """Unified Pallas kernel launcher for TPU (or CPU with interpret=True).
+
+    Dispatch is driven entirely by launcher-observable inputs:
+
+    - ``_compact_build_worklist`` present → the kernel builds a
+      dynamic-``num_work`` grid via ``_pallas_compile_compact_jit_fn``
+      (compact-worklist path).
+    - Otherwise → the standard ``_pallas_compile_jit_fn`` path.
+      ``_pallas_compile_jit_fn`` internally chooses between a plain
+      ``grid`` + ``BlockSpec`` layout (no scratch) and a
+      ``PrefetchScalarGridSpec`` layout (scratch present) based on
+      ``_scratch_shapes``.
 
     Uses ``JaxCallable`` from ``torch_tpu`` to compile and run the Pallas
     kernel on TPU.  When ``torch_tpu`` is not available (interpret mode),
@@ -1795,132 +1812,51 @@ def default_pallas_launcher(
     are excluded from pallas_call inputs to save VMEM.  Their results are
     returned as torch tensors.
     """
-    cache = getattr(pallas_kernel, "_pallas_cache", None)
+    cache = getattr(pallas_kernel, _PALLAS_CACHE_ATTR, None)
     if cache is None or cache[0] != grid:
-        cache = _pallas_install_launcher_cache(
-            pallas_kernel,
-            grid,
-            args,
-            kind=_PallasLoopKind.UNROLL,
-            cache_attr="_pallas_cache",
-            trace_key_suffix="",
-            _output_indices=_output_indices,
-            _inplace_indices=_inplace_indices,
-            _block_spec_info=_block_spec_info,
-            _smem_arg_indices=_smem_arg_indices,
-            _scratch_shapes=None,
-            _pipeline_arg_indices=None,
-            _ds_pad_dims=_ds_pad_dims,
-            _pallas_interpret=_pallas_interpret,
-            _matmul_dot_general=_matmul_dot_general,
-        )
+        if _compact_build_worklist is not None:
+            cache = _pallas_install_compact_launcher_cache(
+                pallas_kernel,
+                grid,
+                args,
+                _output_indices=_output_indices,
+                _inplace_indices=_inplace_indices,
+                _block_spec_info=_block_spec_info,
+                _smem_arg_indices=_smem_arg_indices,
+                _scratch_shapes=cast("list[object] | None", _scratch_shapes),
+                _pipeline_arg_indices=_pipeline_arg_indices,
+                _ds_pad_dims=_ds_pad_dims,
+                _pallas_interpret=_pallas_interpret,
+                _compact_build_worklist=_compact_build_worklist,
+                _compact_offset_arg_indices=_compact_offset_arg_indices,
+                _compact_metadata_fields=_compact_metadata_fields,
+                _compact_owner_ref_pos=_compact_owner_ref_pos,
+                _compact_num_scalar_prefetch=_compact_num_scalar_prefetch,
+                _compact_aligned_arg_indices=_compact_aligned_arg_indices,
+                _compact_tile_start_ref_pos=_compact_tile_start_ref_pos,
+                _compact_block=_compact_block,
+            )
+        else:
+            cache = _pallas_install_launcher_cache(
+                pallas_kernel,
+                grid,
+                args,
+                _output_indices=_output_indices,
+                _inplace_indices=_inplace_indices,
+                _block_spec_info=_block_spec_info,
+                _smem_arg_indices=_smem_arg_indices,
+                _scratch_shapes=cast("list[object] | None", _scratch_shapes),
+                _pipeline_arg_indices=_pipeline_arg_indices,
+                _ds_pad_dims=_ds_pad_dims,
+                _pallas_interpret=_pallas_interpret,
+                _matmul_dot_general=_matmul_dot_general,
+            )
 
     return _pallas_invoke_cached_launcher(
         pallas_kernel,
         cache,
         args,
-        cache_attr="_pallas_cache",
-        _ds_pad_dims=_ds_pad_dims,
-    )
-
-
-def default_pallas_pipeline_launcher(
-    pallas_kernel: object,
-    grid: tuple[int, ...],
-    *args: object,
-    _output_indices: list[int] | None = None,
-    _inplace_indices: list[int] | None = None,
-    _block_spec_info: _BlockSpecInfo | None = None,
-    _scratch_shapes: list[tuple[tuple[int, ...], str]] | None = None,
-    _pipeline_arg_indices: list[int] | None = None,
-    _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
-    _smem_arg_indices: list[int] | None = None,
-    _pallas_interpret: bool | None = None,
-    _matmul_dot_general: dict[str, object] | None = None,
-    **kwargs: object,
-) -> object:
-    """Launcher for Pallas kernels using PrefetchScalarGridSpec with scratch memory.
-
-    Used when ``pallas_loop_type='emit_pipeline'``.  Pipeline-body tensors
-    (listed in ``_pipeline_arg_indices``) use HBM refs; all other tensors
-    get proper BlockSpecs for automatic VMEM prefetch.
-    """
-    cache = getattr(pallas_kernel, "_pallas_pipeline_cache", None)
-    if cache is None or cache[0] != grid:
-        cache = _pallas_install_launcher_cache(
-            pallas_kernel,
-            grid,
-            args,
-            kind=_PallasLoopKind.EMIT_PIPELINE,
-            cache_attr="_pallas_pipeline_cache",
-            trace_key_suffix="_pipeline",
-            _output_indices=_output_indices,
-            _inplace_indices=_inplace_indices,
-            _block_spec_info=_block_spec_info,
-            _smem_arg_indices=_smem_arg_indices,
-            _scratch_shapes=cast("list[object] | None", _scratch_shapes),
-            _pipeline_arg_indices=_pipeline_arg_indices,
-            _ds_pad_dims=_ds_pad_dims,
-            _pallas_interpret=_pallas_interpret,
-            _matmul_dot_general=_matmul_dot_general,
-        )
-
-    return _pallas_invoke_cached_launcher(
-        pallas_kernel,
-        cache,
-        args,
-        cache_attr="_pallas_pipeline_cache",
-        _ds_pad_dims=_ds_pad_dims,
-    )
-
-
-def default_pallas_fori_launcher(
-    pallas_kernel: object,
-    grid: tuple[int, ...],
-    *args: object,
-    _output_indices: list[int] | None = None,
-    _inplace_indices: list[int] | None = None,
-    _block_spec_info: _BlockSpecInfo | None = None,
-    _scratch_shapes: list[tuple[tuple[int, ...], str | None, str]] | None = None,
-    _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
-    _smem_arg_indices: list[int] | None = None,
-    _pallas_interpret: bool | None = None,
-    **kwargs: object,
-) -> object:
-    """Launcher for Pallas kernels using fori_loop with manual DMA.
-
-    Used when ``pallas_loop_type="fori_loop"``.  Passes all tensors as
-    ``memory_space=pl.ANY`` (HBM refs) and adds scratch buffers as
-    ``pltpu.VMEM`` shapes plus ``pltpu.SemaphoreType.DMA`` for async copies.
-    The kernel uses ``jax.lax.fori_loop`` with ``pltpu.make_async_copy``
-    internally for DMA control.
-    """
-    cache = getattr(pallas_kernel, "_pallas_fori_cache", None)
-    if cache is None or cache[0] != grid:
-        cache = _pallas_install_launcher_cache(
-            pallas_kernel,
-            grid,
-            args,
-            kind=_PallasLoopKind.FORI_LOOP,
-            cache_attr="_pallas_fori_cache",
-            trace_key_suffix="_fori",
-            _output_indices=_output_indices,
-            _inplace_indices=_inplace_indices,
-            _block_spec_info=_block_spec_info,
-            _smem_arg_indices=_smem_arg_indices,
-            _scratch_shapes=cast("list[object] | None", _scratch_shapes),
-            _pipeline_arg_indices=cast(
-                "list[int] | None", kwargs.get("_pipeline_arg_indices")
-            ),
-            _ds_pad_dims=_ds_pad_dims,
-            _pallas_interpret=_pallas_interpret,
-        )
-
-    return _pallas_invoke_cached_launcher(
-        pallas_kernel,
-        cache,
-        args,
-        cache_attr="_pallas_fori_cache",
+        cache_attr=_PALLAS_CACHE_ATTR,
         _ds_pad_dims=_ds_pad_dims,
     )
 
@@ -2199,102 +2135,101 @@ def _pallas_compile_compact_jit_fn(
     )
 
 
-def default_pallas_compact_worklist_launcher(
+def _pallas_install_compact_launcher_cache(
     pallas_kernel: object,
     grid: tuple[int, ...],
-    *args: object,
-    _output_indices: list[int] | None = None,
-    _inplace_indices: list[int] | None = None,
-    _block_spec_info: _BlockSpecInfo | None = None,
-    _scratch_shapes: list[object] | None = None,
-    _pipeline_arg_indices: list[int] | None = None,
-    _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
-    _smem_arg_indices: list[int] | None = None,
-    _pallas_interpret: bool | None = None,
-    _compact_build_worklist: Callable[..., object] | None = None,
-    _compact_offset_arg_indices: list[int] | None = None,
-    _compact_metadata_fields: list[str] | None = None,
-    _compact_owner_ref_pos: int = 0,
-    _compact_num_scalar_prefetch: int = 0,
-    _compact_aligned_arg_indices: list[int] | None = None,
-    _compact_tile_start_ref_pos: int = 1,
-    _compact_block: int = 1,
-    **kwargs: object,
-) -> object:
-    """Launcher for ``pallas_loop_type="compact_worklist"``.
+    args: tuple[object, ...],
+    *,
+    _output_indices: list[int] | None,
+    _inplace_indices: list[int] | None,
+    _block_spec_info: _BlockSpecInfo | None,
+    _smem_arg_indices: list[int] | None,
+    _scratch_shapes: list[object] | None,
+    _pipeline_arg_indices: list[int] | None,
+    _ds_pad_dims: list[tuple[int, int, int, int]] | None,
+    _pallas_interpret: bool | None,
+    _compact_build_worklist: Callable[..., object],
+    _compact_offset_arg_indices: list[int] | None,
+    _compact_metadata_fields: list[str] | None,
+    _compact_owner_ref_pos: int,
+    _compact_num_scalar_prefetch: int,
+    _compact_aligned_arg_indices: list[int] | None,
+    _compact_tile_start_ref_pos: int,
+    _compact_block: int,
+) -> tuple[object, ...]:
+    """Cache-miss path for compact-worklist Pallas kernels.
 
-    Builds the worklist metadata in-jit from the offset args, feeds the traced
-    ``num_work`` to a dynamic ``grid=(num_work,)`` with scalar-prefetch metadata,
-    and reuses the shared JaxCallable / caching / invoke path.
+    Mirror of :func:`_pallas_install_launcher_cache`, but calls
+    :func:`_pallas_compile_compact_jit_fn` (which builds the worklist
+    metadata in-jit from the offset args, then feeds the traced
+    ``num_work`` to a dynamic ``grid=(num_work,)`` with scalar-prefetch
+    metadata).  Compact needs its own compile function because the grid
+    is dynamic; everything else — JaxCallable wrap, cache slot,
+    ``_LauncherFastPath`` seed, downstream invoke path — is identical
+    to the standard install.
     """
-    assert _compact_build_worklist is not None
-    cache = getattr(pallas_kernel, "_pallas_compact_cache", None)
-    if cache is None or cache[0] != grid:
-        interpret = (
-            _pallas_interpret
-            if _pallas_interpret is not None
-            else _module_is_pallas_interpret()
-        )
-        output_indices = _output_indices if _output_indices is not None else []
-        spec_args = args
-        if _ds_pad_dims:
-            spec_args, _ = _pallas_apply_ds_padding(args, output_indices, _ds_pad_dims)
-        _pallas_check_dtypes(spec_args)
-        result = _pallas_compile_compact_jit_fn(
-            pallas_kernel,
-            spec_args,
-            _output_indices=output_indices,
-            _inplace_indices=_inplace_indices,
-            _block_spec_info=_block_spec_info,
-            _scratch_shapes=_scratch_shapes,
-            _smem_arg_indices=_smem_arg_indices,
-            _pipeline_arg_indices=_pipeline_arg_indices,
-            build_worklist=_compact_build_worklist,
-            offset_arg_indices=_compact_offset_arg_indices or [],
-            metadata_fields=_compact_metadata_fields or [],
-            owner_ref_pos=_compact_owner_ref_pos,
-            num_scalar_prefetch=_compact_num_scalar_prefetch,
-            aligned_arg_indices=_compact_aligned_arg_indices or [],
-            tile_start_ref_pos=_compact_tile_start_ref_pos,
-            compact_block=_compact_block,
-            interpret=interpret,
-        )
-        cache_attr = "_pallas_compact_cache"
-        jax_callable = _pallas_build_callable(
-            pallas_kernel,
-            grid,
-            cast("Callable[..., object]", result.jit_fn),
-            output_indices,
-            result.arg_to_tensor_pos,
-            result.tensor_arg_indices,
-            cache_attr=cache_attr,
-            call_aliases=result.pallas_aliases,
-            trace_key_suffix="_compact",
-            interpret=interpret,
-        )
-        fast_path = _LauncherFastPath(
-            result.tensor_arg_indices,
-            result.arg_to_tensor_pos,
-            output_indices,
-            _ds_pad_dims,
-        )
-        cache = (
-            grid,
-            jax_callable,
-            result.tensor_arg_indices,
-            result.arg_to_tensor_pos,
-            fast_path,
-            None,
-        )
-        setattr(pallas_kernel, cache_attr, cache)
-
-    return _pallas_invoke_cached_launcher(
-        pallas_kernel,
-        cache,
-        args,
-        cache_attr="_pallas_compact_cache",
-        _ds_pad_dims=_ds_pad_dims,
+    interpret = (
+        _pallas_interpret
+        if _pallas_interpret is not None
+        else _module_is_pallas_interpret()
     )
+    if interpret:
+        _ensure_cpu_tpu_info()
+    output_indices = _output_indices if _output_indices is not None else []
+
+    spec_args = args
+    if _ds_pad_dims:
+        spec_args, _ = _pallas_apply_ds_padding(args, output_indices, _ds_pad_dims)
+    _pallas_check_dtypes(spec_args)
+
+    result = _pallas_compile_compact_jit_fn(
+        pallas_kernel,
+        spec_args,
+        _output_indices=output_indices,
+        _inplace_indices=_inplace_indices,
+        _block_spec_info=_block_spec_info,
+        _scratch_shapes=_scratch_shapes,
+        _smem_arg_indices=_smem_arg_indices,
+        _pipeline_arg_indices=_pipeline_arg_indices,
+        build_worklist=_compact_build_worklist,
+        offset_arg_indices=_compact_offset_arg_indices or [],
+        metadata_fields=_compact_metadata_fields or [],
+        owner_ref_pos=_compact_owner_ref_pos,
+        num_scalar_prefetch=_compact_num_scalar_prefetch,
+        aligned_arg_indices=_compact_aligned_arg_indices or [],
+        tile_start_ref_pos=_compact_tile_start_ref_pos,
+        compact_block=_compact_block,
+        interpret=interpret,
+    )
+
+    jax_callable = _pallas_build_callable(
+        pallas_kernel,
+        grid,
+        cast("Callable[..., object]", result.jit_fn),
+        output_indices,
+        result.arg_to_tensor_pos,
+        result.tensor_arg_indices,
+        cache_attr=_PALLAS_CACHE_ATTR,
+        call_aliases=result.pallas_aliases,
+        trace_key_suffix="",
+        interpret=interpret,
+    )
+    fast_path = _LauncherFastPath(
+        result.tensor_arg_indices,
+        result.arg_to_tensor_pos,
+        output_indices,
+        _ds_pad_dims,
+    )
+    cache = (
+        grid,
+        jax_callable,
+        result.tensor_arg_indices,
+        result.arg_to_tensor_pos,
+        fast_path,
+        None,
+    )
+    setattr(pallas_kernel, _PALLAS_CACHE_ATTR, cache)
+    return cache
 
 
 def _torch_to_jax(t: torch.Tensor) -> object:

--- a/helion/runtime/pallas_jax_export.py
+++ b/helion/runtime/pallas_jax_export.py
@@ -41,7 +41,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from . import _BlockSpecInfo
-    from . import _PallasLoopKind
     from .kernel import Kernel
 
 
@@ -264,7 +263,6 @@ def default_pallas_jax_launcher(
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _smem_arg_indices: list[int] | None = None,
     _pallas_interpret: bool | None = None,
-    _kind: _PallasLoopKind | None = None,
     **kwargs: object,
 ) -> object:
     """Pallas launcher used when running a Helion kernel inside ``jax.jit``.
@@ -272,25 +270,23 @@ def default_pallas_jax_launcher(
     Each tensor argument in ``args`` is a ``_JaxExportTensor`` whose
     underlying ``_jax_arr`` is either a concrete JAX array or a JAX
     tracer.  This launcher pulls the JAX side out, calls the shared
-    ``_pallas_compile_jit_fn`` to build a fresh ``pl.pallas_call``
-    (no JaxCallable, no torch<->JAX bridge), invokes it on the JAX
-    inputs, and re-wraps the output(s) as ``_JaxExportTensor`` so the
-    Helion wrapper's trailing reshape/view operations stay traceable.
+    ``_pallas_compile_jit_fn`` (or the compact-worklist variant when
+    ``_compact_build_worklist`` is present) to build a fresh
+    ``pl.pallas_call``, invokes it on the JAX inputs, and re-wraps the
+    output(s) as ``_JaxExportTensor`` so the Helion wrapper's trailing
+    reshape/view operations stay traceable.
     """
     from . import _pallas_apply_ds_padding
     from . import _pallas_compile_jit_fn
     from . import _pallas_output_only_descriptors
     from . import _pallas_padded_output_dims_by_arg
     from . import _pallas_slice_to_orig
-    from . import _PallasLoopKind as _LoopKind
     from .settings import is_pallas_interpret
 
     interpret = (
         _pallas_interpret if _pallas_interpret is not None else is_pallas_interpret()
     )
 
-    if _kind is None:
-        _kind = _LoopKind.UNROLL
     output_indices = _output_indices if _output_indices is not None else []
 
     # Capture original shapes BEFORE padding so output-only tensors can
@@ -313,7 +309,11 @@ def default_pallas_jax_launcher(
         _device_for_jax_export(),
     )
 
-    if _kind is _LoopKind.COMPACT_WORKLIST:
+    # Compact-worklist kernels are discriminated by the presence of the
+    # ``_compact_build_worklist`` launcher kwarg, which is emitted by
+    # codegen only for that lowering.
+    compact_build_worklist = kwargs.get("_compact_build_worklist")
+    if compact_build_worklist is not None:
         from . import _pallas_compile_compact_jit_fn
 
         result = _pallas_compile_compact_jit_fn(
@@ -325,7 +325,7 @@ def default_pallas_jax_launcher(
             _scratch_shapes=_scratch_shapes,
             _smem_arg_indices=_smem_arg_indices,
             _pipeline_arg_indices=_pipeline_arg_indices,
-            build_worklist=cast("Any", kwargs["_compact_build_worklist"]),
+            build_worklist=cast("Any", compact_build_worklist),
             offset_arg_indices=cast(
                 "Any", kwargs.get("_compact_offset_arg_indices") or []
             ),
@@ -348,7 +348,6 @@ def default_pallas_jax_launcher(
             pallas_kernel,
             grid,
             args,
-            kind=_kind,
             _output_indices=output_indices,
             _inplace_indices=_inplace_indices,
             _block_spec_info=_block_spec_info,
@@ -415,8 +414,6 @@ def make_jax_fn(kernel: Kernel) -> Callable[..., Any]:
     """
 
     def _runtime_call(*args: object) -> object:
-        from . import _PallasLoopKind as _LoopKind
-
         device = _device_for_jax_export()
         adapter_args: list[object] = []
         for a in args:
@@ -439,13 +436,10 @@ def make_jax_fn(kernel: Kernel) -> Callable[..., Any]:
         compiled = bound._run
         assert compiled is not None
 
-        # Resolve the JAX-export launcher to use for the kernel's
-        # configured loop type.  ``_run`` is the generated wrapper
-        # which forwards ``_launcher`` via kwargs.
-        config = bound._config
-        assert config is not None
-        kind = _LoopKind(cast("str", config.config.get("pallas_loop_type", "unroll")))
-
+        # ``default_pallas_jax_launcher`` picks the compile path from
+        # the kwargs codegen already emits (``_scratch_shapes``,
+        # ``_pipeline_arg_indices``, ``_compact_build_worklist``); no
+        # loop-type discriminator needed.
         def _launcher(
             pallas_kernel: object,
             grid: tuple[int, ...],
@@ -456,7 +450,6 @@ def make_jax_fn(kernel: Kernel) -> Callable[..., Any]:
                 pallas_kernel,
                 grid,
                 *launch_args,
-                _kind=kind,
                 **cast("dict[str, Any]", launch_kwargs),
             )
 

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -1420,11 +1420,10 @@ class TestPallas(TestCase):
             torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-2)
 
         # The launcher stores its grid-keyed cache on the inner device-kernel
-        # object (``_pallas_cache`` / ``_pallas_pipeline_cache`` /
-        # ``_pallas_fori_cache``, depending on which launcher the config
-        # selects), reachable via the compiled function's module globals.  A
-        # populated cache means repeat calls took the fast-path branch.
-        cache_attrs = ("_pallas_cache", "_pallas_pipeline_cache", "_pallas_fori_cache")
+        # object as ``_pallas_cache``, reachable via the compiled function's
+        # module globals.  A populated cache means repeat calls took the
+        # fast-path branch.
+        cache_attrs = ("_pallas_cache",)
         cached = [
             value
             for value in compiled_fn.__globals__.values()
@@ -1491,12 +1490,10 @@ class TestPallas(TestCase):
         # Confirm the direct-call snapshot was actually built (slot 5 of the
         # launcher cache), so the equality above exercised the direct path and
         # is not a trivial slow-path-vs-slow-path comparison.
-        cache_attrs = ("_pallas_cache", "_pallas_pipeline_cache", "_pallas_fori_cache")
         caches = [
-            getattr(value, a)
+            value._pallas_cache
             for value in compiled_fn.__globals__.values()
-            for a in cache_attrs
-            if getattr(value, a, None) is not None
+            if getattr(value, "_pallas_cache", None) is not None
         ]
         self.assertTrue(
             caches and caches[0][5] is not None,
@@ -1548,7 +1545,7 @@ class TestPallas(TestCase):
             )
 
         # Slot 5 of the launcher cache holds the _DirectCallKernel snapshot.
-        cache_attrs = ("_pallas_cache", "_pallas_pipeline_cache", "_pallas_fori_cache")
+        cache_attrs = ("_pallas_cache",)
         caches = [
             getattr(value, a)
             for value in compiled_fn.__globals__.values()

--- a/test/test_pallas_compact_worklist.py
+++ b/test/test_pallas_compact_worklist.py
@@ -820,16 +820,16 @@ class TestNoSilentFallback(unittest.TestCase):
         code = bound.to_triton_code(
             helion.Config(block_sizes=[8], pallas_loop_type="compact_worklist")
         )
-        # Routes to the compact launcher with the worklist builder + scalar
-        # prefetch, NOT the default unroll launcher.
-        self.assertIn("_default_pallas_compact_worklist_launcher", code)
+        # Emits the compact-worklist-specific launcher kwargs and the
+        # in-jit worklist builder; the unified launcher dispatches to
+        # the compact compile path based on ``_compact_build_worklist``.
+        self.assertIn("_compact_build_worklist=_build_worklist", code)
         self.assertIn("def _build_worklist(", code)
         # Offsets arg index is non-empty (q_offsets feeds the builder).
         self.assertRegex(code, r"_compact_offset_arg_indices=\[\d")
         self.assertIn("_compact_num_scalar_prefetch=3", code)
         self.assertIn("_wid = pl.program_id(0)", code)
         self.assertIn("work_seq_ref[_wid]", code)
-        self.assertNotIn("_default_pallas_launcher", code)
 
     def test_unsupported_kernel_raises(self):
         def fn(x, y):
@@ -1040,7 +1040,7 @@ class TestConfigStateIsolation(unittest.TestCase):
             helion.Config(block_sizes=[8], pallas_loop_type="fori_loop")
         )
         self.assertNotIn("work_seq_ref", fori)
-        self.assertNotIn("_default_pallas_compact_worklist_launcher", fori)
+        self.assertNotIn("_compact_build_worklist", fori)
         self.assertNotIn("_build_worklist", fori)
 
 


### PR DESCRIPTION
Stacked PRs:
 * #3025
 * __->__#3023


--- --- ---

### [Pallas] Consolidate launcher functions into one


Previously we have 4 different launchers (unroll, fori_loop,
emit_pipeline), this is becoming a bit of maintanance burden, as they
have a largely shared but slightly different set of args. This PR
consolidate them into a single launcher function

  - **`helion/runtime/__init__.py`**
    - `default_pallas_launcher`: rewritten to accept the union of kwargs from
      all four previous launchers and dispatch on launcher-observable data.
      `_compact_build_worklist` present → compact install; otherwise → standard
      install.
    - `default_pallas_pipeline_launcher`, `default_pallas_fori_launcher`,
      `default_pallas_compact_worklist_launcher`: replaced with module-level
      aliases pointing at `default_pallas_launcher` (kept for back-compat with
      any external importer).
    - `_pallas_install_launcher_cache`: drops `kind`, `cache_attr`, and
      `trace_key_suffix` parameters. Now always uses a single cache attribute
      `_PALLAS_CACHE_ATTR = "_pallas_cache"` and an empty trace suffix.
    - `_pallas_install_compact_launcher_cache`: new helper extracted from the
      old `default_pallas_compact_worklist_launcher` body. Mirrors
      `_pallas_install_launcher_cache` but calls `_pallas_compile_compact_jit_fn`
      for dynamic-`num_work` grid construction. Shares the same cache slot.
    - `_pallas_compile_jit_fn`: drops the `kind: _PallasLoopKind` parameter.
      Two flags derived from launcher-observable kwargs drive the branches:
      - `needs_pipeline_specs = bool(_pipeline_arg_indices) or bool(_scratch_shapes)`
        — chooses `_pallas_build_pipeline_specs` + `PrefetchScalarGridSpec`
        over the plain `_pallas_build_block_specs` + `grid` path.
      - `has_scratch = bool(_scratch_shapes)` — controls whether scratch
        counts in the VMEM budget check.
    - `_PallasLoopKind` enum: removed. The four values were only used to
      discriminate inside `_pallas_compile_jit_fn`; that job is now done by
      the launcher-observable flags above.
    - `import enum`: removed (unused after `_PallasLoopKind` deletion).

  - **`helion/runtime/pallas_jax_export.py`**
    - `default_pallas_jax_launcher`: drops `_kind` parameter. Discriminates
      compact-vs-standard by `kwargs.get("_compact_build_worklist")` (the
      same signal the torch-tensor launcher uses).
    - `_runtime_call` (inside `make_jax_fn`): stops reading
      `pallas_loop_type` from the config to build a `_kind` value; the
      launcher-observable kwargs codegen already emits are sufficient.
    - `_PallasLoopKind` `TYPE_CHECKING` import: removed.

  - **`helion/_compiler/backend.py`**
    - `PallasBackend.build_launcher_name`: always returns
      `_default_pallas_launcher` regardless of `pallas_loop_type`. Still
      validates `pallas_loop_type` against `VALID_PALLAS_LOOP_TYPES` so bad
      configs surface early.
    - `PallasBackend.library_imports`: drops the three loop-specific
      launcher entries; leaves only `_default_pallas_launcher`.

  - **`test/test_pallas.py`**
    - Three assertion sites: `cache_attrs = ("_pallas_cache",
      "_pallas_pipeline_cache", "_pallas_fori_cache")` collapsed to
      `("_pallas_cache",)` since all launchers now share one cache slot.
    - Comment updated to reflect the unified slot.

  - **`test/test_pallas_compact_worklist.py`**
    - `test_pallas_compact_worklist_launcher_used`: assertion now checks for
      `_compact_build_worklist=_build_worklist` in the emitted code (the
      real evidence that the compact machinery kicked in) rather than the
      old launcher name. Also asserts `_default_pallas_launcher` is in the
      code (it always is now).
    - Sibling assertion in the fori-vs-compact test: switched from
      `assertNotIn("_default_pallas_compact_worklist_launcher", fori)` to
      `assertNotIn("_compact_build_worklist", fori)` — same intent, adapted
      to the new discriminator.
