### PR TITLE
[Pallas] Rename pipeline_arg_indices -> hbm_arg_indices

### DIFF
--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -2554,14 +2554,14 @@ class PallasBackend(Backend):
         from .device_function import TensorArg
 
         if sorted_args is not None:
-            pipeline_arg_indices = [
+            hbm_arg_indices = [
                 i
                 for i, arg in enumerate(sorted_args)
                 if isinstance(arg, TensorArg)
                 and mem_space.get(id(arg.fake_value)) == PallasMemorySpace.HBM
             ]
-            if pipeline_arg_indices:
-                launcher_args.append(f"_pipeline_arg_indices={pipeline_arg_indices!r}")
+            if hbm_arg_indices:
+                launcher_args.append(f"_hbm_arg_indices={hbm_arg_indices!r}")
 
         if CompileEnvironment.current().settings.pallas_interpret:
             launcher_args.append("_pallas_interpret=True")

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -526,25 +526,28 @@ def _pallas_build_pipeline_specs(
     tensor_arg_indices: list[int],
     output_indices: list[int],
     block_spec_info: _BlockSpecInfo,
-    pipeline_arg_indices: list[int] | None,
+    hbm_arg_indices: list[int] | None,
     output_only_indices: list[int] | None = None,
     smem_arg_indices: list[int] | None = None,
 ) -> tuple[list[object], object]:
-    """Build in/out specs for pipeline launchers.
+    """Build in/out specs for the ``PrefetchScalarGridSpec`` path.
 
-    Pipeline-body tensors (listed in *pipeline_arg_indices*) get HBM refs.
-    All other tensors get proper BlockSpecs for automatic VMEM prefetch.
-    Tensors in *smem_arg_indices* (only ever accessed by scalar index, e.g.
-    group offset tables) are placed in SMEM so dynamic scalar reads don't
-    require 128-lane alignment proofs against a small VMEM ref.
+    Tensors listed in *hbm_arg_indices* get HBM refs (used by pipeline
+    launchers as the outer HBM ref that DMAs into VMEM, and by
+    distributed ops that address peer HBM directly).  All other
+    tensors get proper BlockSpecs for automatic VMEM prefetch.
+    Tensors in *smem_arg_indices* (only ever accessed by scalar index,
+    e.g. group offset tables) are placed in SMEM so dynamic scalar
+    reads don't require 128-lane alignment proofs against a small
+    VMEM ref.
     """
-    pipeline_set = set(pipeline_arg_indices or [])
+    hbm_set = set(hbm_arg_indices or [])
     smem_set = set(smem_arg_indices or [])
     all_positions = sorted(set(tensor_arg_indices) | set(output_only_indices or []))
     arg_to_tpos = {orig: tpos for tpos, orig in enumerate(all_positions)}
 
     def _spec_for(idx: int) -> object:
-        if idx in pipeline_set:
+        if idx in hbm_set:
             return pl.BlockSpec(memory_space=pltpu.HBM)  # type: ignore[union-attr]
         tpos = arg_to_tpos[idx]
         t = args[idx]
@@ -1123,9 +1126,9 @@ def _pallas_make_reordered_kernel(
     reordered args.
 
     *skip_inplace_copy* is a set of original-arg positions for which the
-    initial ``out_ref[...] = in_ref[...]`` copy should be skipped.  Used by
-    pipeline/fori launchers for pipeline-body tensors backed by HBM refs
-    where direct load/store is not allowed.
+    initial ``out_ref[...] = in_ref[...]`` copy should be skipped.  Used
+    for tensors backed by HBM refs (pipeline/fori-loop outer refs,
+    distributed-op targets) where direct load/store is not allowed.
     """
     _skip_copy = skip_inplace_copy or set()
     copy_guards = {
@@ -1454,7 +1457,7 @@ def _pallas_compile_jit_fn(
     _block_spec_info: _BlockSpecInfo | None,
     _smem_arg_indices: list[int] | None,
     _scratch_shapes: list[object] | None,
-    _pipeline_arg_indices: list[int] | None,
+    _hbm_arg_indices: list[int] | None,
     _matmul_dot_general: dict[str, object] | None,
     interpret: bool,
 ) -> _PallasCompileResult:
@@ -1466,10 +1469,9 @@ def _pallas_compile_jit_fn(
     - ``_scratch_shapes`` present (VMEM buffers / DMA semaphores) →
       wrap ``in``/``out`` specs and the grid in a
       ``pltpu.PrefetchScalarGridSpec`` so the scratch refs are threaded
-      into the kernel.  Pipeline-body tensors (listed in
-      ``_pipeline_arg_indices``) get HBM refs via
-      ``_pallas_build_pipeline_specs``, and their inplace copy is
-      skipped because you cannot directly index an HBM ref.
+      into the kernel.  Tensors listed in ``_hbm_arg_indices`` get HBM
+      refs via ``_pallas_build_pipeline_specs``, and their inplace copy
+      is skipped because you cannot directly index an HBM ref.
     - ``_scratch_shapes`` absent → simple ``grid`` + per-arg
       ``BlockSpec`` layout via ``_pallas_build_block_specs``.
 
@@ -1512,13 +1514,13 @@ def _pallas_compile_jit_fn(
 
     # Two discriminators drive the spec-building path — either forces
     # the ``PrefetchScalarGridSpec`` route:
-    #   1. ``_pipeline_arg_indices`` non-empty: some tensor is an HBM
-    #      pipeline-body ref that needs ``pl.BlockSpec(memory_space=pl.ANY)``
-    #      rather than a plain BlockSpec.
+    #   1. ``_hbm_arg_indices`` non-empty: some tensor needs an HBM
+    #      ref (``pl.BlockSpec(memory_space=pl.ANY)``) rather than a
+    #      plain BlockSpec.
     #   2. ``_scratch_shapes`` non-empty: the kernel registered VMEM
     #      buffers or DMA semaphores, which are only reachable via a
     #      ``scratch_shapes=`` argument on ``PrefetchScalarGridSpec``.
-    needs_pipeline_specs = bool(_pipeline_arg_indices) or bool(_scratch_shapes)
+    needs_pipeline_specs = bool(_hbm_arg_indices) or bool(_scratch_shapes)
     has_scratch = bool(_scratch_shapes)
     if needs_pipeline_specs:
         assert _block_spec_info is not None, (
@@ -1534,11 +1536,11 @@ def _pallas_compile_jit_fn(
             tensor_arg_indices,
             _output_indices,
             _block_spec_info,
-            _pipeline_arg_indices,
+            _hbm_arg_indices,
             output_only_indices,
             smem_arg_indices=_smem_arg_indices,
         )
-        skip_inplace_copy: set[int] = set(_pipeline_arg_indices or [])
+        skip_inplace_copy: set[int] = set(_hbm_arg_indices or [])
     else:
         in_specs, out_specs = _pallas_build_block_specs(
             pl,
@@ -1647,7 +1649,7 @@ def _pallas_install_launcher_cache(
     _block_spec_info: _BlockSpecInfo | None,
     _smem_arg_indices: list[int] | None,
     _scratch_shapes: list[object] | None,
-    _pipeline_arg_indices: list[int] | None,
+    _hbm_arg_indices: list[int] | None,
     _ds_pad_dims: list[tuple[int, int, int, int]] | None,
     _pallas_interpret: bool | None,
     _matmul_dot_general: dict[str, object] | None = None,
@@ -1688,7 +1690,7 @@ def _pallas_install_launcher_cache(
         _block_spec_info=_block_spec_info,
         _smem_arg_indices=_smem_arg_indices,
         _scratch_shapes=_scratch_shapes,
-        _pipeline_arg_indices=_pipeline_arg_indices,
+        _hbm_arg_indices=_hbm_arg_indices,
         _matmul_dot_general=_matmul_dot_general,
         interpret=interpret,
     )
@@ -1775,7 +1777,7 @@ def default_pallas_launcher(
     _block_spec_info: _BlockSpecInfo | None = None,
     _smem_arg_indices: list[int] | None = None,
     _scratch_shapes: list[tuple[tuple[int, ...], str | None, str]] | None = None,
-    _pipeline_arg_indices: list[int] | None = None,
+    _hbm_arg_indices: list[int] | None = None,
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _pallas_interpret: bool | None = None,
     _matmul_dot_general: dict[str, object] | None = None,
@@ -1824,7 +1826,7 @@ def default_pallas_launcher(
                 _block_spec_info=_block_spec_info,
                 _smem_arg_indices=_smem_arg_indices,
                 _scratch_shapes=cast("list[object] | None", _scratch_shapes),
-                _pipeline_arg_indices=_pipeline_arg_indices,
+                _hbm_arg_indices=_hbm_arg_indices,
                 _ds_pad_dims=_ds_pad_dims,
                 _pallas_interpret=_pallas_interpret,
                 _compact_build_worklist=_compact_build_worklist,
@@ -1846,7 +1848,7 @@ def default_pallas_launcher(
                 _block_spec_info=_block_spec_info,
                 _smem_arg_indices=_smem_arg_indices,
                 _scratch_shapes=cast("list[object] | None", _scratch_shapes),
-                _pipeline_arg_indices=_pipeline_arg_indices,
+                _hbm_arg_indices=_hbm_arg_indices,
                 _ds_pad_dims=_ds_pad_dims,
                 _pallas_interpret=_pallas_interpret,
                 _matmul_dot_general=_matmul_dot_general,
@@ -1870,7 +1872,7 @@ def _pallas_compact_in_out_specs(
     output_indices: list[int],
     block_spec_info: _BlockSpecInfo | None,
     smem_set: set[int],
-    pipeline_set: set[int],
+    hbm_set: set[int],
     owner_ref_pos: int,
     aligned_set: set[int] | None = None,
     tile_start_ref_pos: int = 1,
@@ -1891,7 +1893,7 @@ def _pallas_compact_in_out_specs(
     arg_to_tpos = {orig: tpos for tpos, orig in enumerate(all_positions)}
 
     def _spec_for(idx: int) -> object:
-        if idx in pipeline_set:
+        if idx in hbm_set:
             return pl.BlockSpec(memory_space=pltpu.HBM)  # type: ignore[union-attr]
         t = args[idx]
         assert isinstance(t, torch.Tensor)
@@ -2001,7 +2003,7 @@ def _pallas_compile_compact_jit_fn(
     _block_spec_info: _BlockSpecInfo | None,
     _scratch_shapes: list[object] | None,
     _smem_arg_indices: list[int] | None,
-    _pipeline_arg_indices: list[int] | None,
+    _hbm_arg_indices: list[int] | None,
     build_worklist: Callable[..., object],
     offset_arg_indices: list[int],
     metadata_fields: list[str],
@@ -2032,7 +2034,7 @@ def _pallas_compile_compact_jit_fn(
 
     scratch_shapes = _pallas_build_scratch_shapes(pltpu, jnp, _scratch_shapes or [])
     smem_set = set(_smem_arg_indices or [])
-    pipeline_set = set(_pipeline_arg_indices or [])
+    hbm_set = set(_hbm_arg_indices or [])
     in_specs, out_specs = _pallas_compact_in_out_specs(
         pl,
         jnp,
@@ -2042,7 +2044,7 @@ def _pallas_compile_compact_jit_fn(
         _output_indices,
         _block_spec_info,
         smem_set,
-        pipeline_set,
+        hbm_set,
         owner_ref_pos,
         set(aligned_arg_indices or []),
         tile_start_ref_pos,
@@ -2145,7 +2147,7 @@ def _pallas_install_compact_launcher_cache(
     _block_spec_info: _BlockSpecInfo | None,
     _smem_arg_indices: list[int] | None,
     _scratch_shapes: list[object] | None,
-    _pipeline_arg_indices: list[int] | None,
+    _hbm_arg_indices: list[int] | None,
     _ds_pad_dims: list[tuple[int, int, int, int]] | None,
     _pallas_interpret: bool | None,
     _compact_build_worklist: Callable[..., object],
@@ -2190,7 +2192,7 @@ def _pallas_install_compact_launcher_cache(
         _block_spec_info=_block_spec_info,
         _scratch_shapes=_scratch_shapes,
         _smem_arg_indices=_smem_arg_indices,
-        _pipeline_arg_indices=_pipeline_arg_indices,
+        _hbm_arg_indices=_hbm_arg_indices,
         build_worklist=_compact_build_worklist,
         offset_arg_indices=_compact_offset_arg_indices or [],
         metadata_fields=_compact_metadata_fields or [],

--- a/helion/runtime/pallas_jax_export.py
+++ b/helion/runtime/pallas_jax_export.py
@@ -259,7 +259,7 @@ def default_pallas_jax_launcher(
     _inplace_indices: list[int] | None = None,
     _block_spec_info: _BlockSpecInfo | None = None,
     _scratch_shapes: list[object] | None = None,
-    _pipeline_arg_indices: list[int] | None = None,
+    _hbm_arg_indices: list[int] | None = None,
     _ds_pad_dims: list[tuple[int, int, int, int]] | None = None,
     _smem_arg_indices: list[int] | None = None,
     _pallas_interpret: bool | None = None,
@@ -324,7 +324,7 @@ def default_pallas_jax_launcher(
             _block_spec_info=_block_spec_info,
             _scratch_shapes=_scratch_shapes,
             _smem_arg_indices=_smem_arg_indices,
-            _pipeline_arg_indices=_pipeline_arg_indices,
+            _hbm_arg_indices=_hbm_arg_indices,
             build_worklist=cast("Any", compact_build_worklist),
             offset_arg_indices=cast(
                 "Any", kwargs.get("_compact_offset_arg_indices") or []
@@ -353,7 +353,7 @@ def default_pallas_jax_launcher(
             _block_spec_info=_block_spec_info,
             _smem_arg_indices=_smem_arg_indices,
             _scratch_shapes=_scratch_shapes,
-            _pipeline_arg_indices=_pipeline_arg_indices,
+            _hbm_arg_indices=_hbm_arg_indices,
             _matmul_dot_general=None,
             interpret=interpret,
         )
@@ -438,7 +438,7 @@ def make_jax_fn(kernel: Kernel) -> Callable[..., Any]:
 
         # ``default_pallas_jax_launcher`` picks the compile path from
         # the kwargs codegen already emits (``_scratch_shapes``,
-        # ``_pipeline_arg_indices``, ``_compact_build_worklist``); no
+        # ``_hbm_arg_indices``, ``_compact_build_worklist``); no
         # loop-type discriminator needed.
         def _launcher(
             pallas_kernel: object,

--- a/test/test_pallas.py
+++ b/test/test_pallas.py
@@ -2318,7 +2318,7 @@ class TestPallas(TestCase):
             pallas_loop_type="emit_pipeline",
         )
         self.assertIn("pltpu.emit_pipeline", code)
-        self.assertIn("_pipeline_arg_indices=", code)
+        self.assertIn("_hbm_arg_indices=", code)
         torch.testing.assert_close(result, expected)
 
     def test_invalid_pallas_loop_type_raises(self) -> None:
@@ -3266,7 +3266,7 @@ class TestPallas(TestCase):
             pallas_loop_type="fori_loop",
         )
         self.assertNotIn("pltpu.make_async_copy", code)
-        self.assertNotIn("_pipeline_arg_indices=", code)
+        self.assertNotIn("_hbm_arg_indices=", code)
         torch.testing.assert_close(
             result, x.sum(dim=0, keepdim=True), rtol=1e-3, atol=1e-3
         )
@@ -3280,7 +3280,7 @@ class TestPallas(TestCase):
             block_sizes=[8],
             pallas_loop_type="fori_loop",
         )
-        self.assertIn("_pipeline_arg_indices=", code)
+        self.assertIn("_hbm_arg_indices=", code)
         self.assertIn("pltpu.make_async_copy(x.at", code)
         ref = torch.stack(
             [x[g, int(offsets[g]) : int(offsets[g + 1])].sum(dim=0) for g in range(2)]
@@ -3293,7 +3293,7 @@ class TestPallas(TestCase):
         self.assertIn("pltpu.emit_pipeline", code)
         self.assertIn("pl.BoundedSlice", code)
         self.assertIn("pipeline_mode=pl.Buffered", code)
-        self.assertIn("_pipeline_arg_indices=[1]", code)
+        self.assertIn("_hbm_arg_indices=[1]", code)
         self.assertNotIn("pltpu.make_async_copy", code)
 
         offsets = torch.tensor([3, 29], device=DEVICE, dtype=torch.int32)
@@ -3303,7 +3303,7 @@ class TestPallas(TestCase):
             block_sizes=[8],
             pallas_loop_type="fori_loop",
         )
-        self.assertIn("_pipeline_arg_indices=", code)
+        self.assertIn("_hbm_arg_indices=", code)
         self.assertIn("pltpu.make_async_copy(x.at", code)
         torch.testing.assert_close(
             result,
@@ -3319,7 +3319,7 @@ class TestPallas(TestCase):
         self.assertIn("pl.BlockSpec((1, pl.BoundedSlice", code)
         self.assertIn("lambda _j: (1, pl.ds(start + _j * _BLOCK_SIZE_1", code)
         self.assertIn("pipeline_mode=pl.Buffered", code)
-        self.assertIn("_pipeline_arg_indices=[1]", code)
+        self.assertIn("_hbm_arg_indices=[1]", code)
         self.assertNotIn("pltpu.make_async_copy", code)
 
     def test_tile_id_per_block_accumulator(self) -> None:
@@ -3450,7 +3450,7 @@ class TestPallas(TestCase):
                     pallas_loop_type=loop_type,
                 )
                 self.assertIn(loop_marker, code)
-                self.assertNotIn("_pipeline_arg_indices=[0", code)
+                self.assertNotIn("_hbm_arg_indices=[0", code)
                 torch.testing.assert_close(result, expected)
 
     def test_no_pipeline_outer_summary_read(self) -> None:
@@ -3493,7 +3493,7 @@ class TestPallas(TestCase):
         # T (arg index 0) must NOT be pipelined — its outer-scope load
         # would otherwise hit HBM after the BlockSpec is replaced.
         self.assertIn("pltpu.emit_pipeline", code)
-        self.assertNotIn("_pipeline_arg_indices=[0", code)
+        self.assertNotIn("_hbm_arg_indices=[0", code)
         torch.testing.assert_close(result, T * x, rtol=1e-3, atol=1e-3)
 
     def test_fori_loop_per_tensor_dma_mixed(self) -> None:
@@ -3513,7 +3513,7 @@ class TestPallas(TestCase):
         )
         self.assertIn("pltpu.make_async_copy", code)
         self.assertIn("pl.ds(", code)
-        self.assertIn("_pipeline_arg_indices=", code)
+        self.assertIn("_hbm_arg_indices=", code)
         torch.testing.assert_close(result, x * r)
 
     def test_pipeline_begin_aligned_skips_pad(self) -> None:

--- a/test/test_pallas_compact_worklist.py
+++ b/test/test_pallas_compact_worklist.py
@@ -866,8 +866,8 @@ class TestStreamingClassification(unittest.TestCase):
         )
 
         # Ordered K/V stream from HBM via a nested emit_pipeline with double
-        # buffering -- reusing _pipeline_arg_indices, no new launcher API.
-        self.assertIn("_pipeline_arg_indices=", code)
+        # buffering -- reusing _hbm_arg_indices, no new launcher API.
+        self.assertIn("_hbm_arg_indices=", code)
         self.assertIn("pltpu.emit_pipeline(", code)
         self.assertIn("pl.ds(kv_begin_ref[_wid]", code)
         self.assertIn("pl.BoundedSlice(", code)
@@ -893,7 +893,7 @@ class TestStreamingClassification(unittest.TestCase):
             helion.Config(block_sizes=[8], pallas_loop_type="compact_worklist")
         )
 
-        self.assertNotIn("_pipeline_arg_indices=", code)
+        self.assertNotIn("_hbm_arg_indices=", code)
         self.assertNotIn("pltpu.make_async_copy", code)
         # Dense-KV has no ordered axis, so no inner pipeline either.
         self.assertNotIn("pltpu.emit_pipeline", code)
@@ -915,7 +915,7 @@ class TestStreamingClassification(unittest.TestCase):
 
         # Here the ordered axis is the q-like loop, so q and dO stream via the
         # nested emit_pipeline; out is the compact exact-store and stays out.
-        self.assertIn("_pipeline_arg_indices=", code)
+        self.assertIn("_hbm_arg_indices=", code)
         self.assertIn("pltpu.emit_pipeline(", code)
         self.assertIn("pl.ds(q_begin_ref[_wid]", code)
         self.assertIn("pl.Buffered(buffer_count=2)", code)


### PR DESCRIPTION

The list identifies tensor args that need HBM refs
(``pl.BlockSpec(memory_space=pltpu.HBM)``).  Previously named
``pipeline_arg_indices`` because only the pipeline/fori-loop launchers
consumed it; after the launcher unification, distributed ops also
mark tensors as HBM, so the name should reflect the memory-space
semantic rather than the historic launcher-shaped origin.

Renamed:
- ``_pipeline_arg_indices`` (launcher kwarg) -> ``_hbm_arg_indices``
- ``pipeline_arg_indices`` (internal param) -> ``hbm_arg_indices``
- ``pipeline_set`` (local var) -> ``hbm_set``

Unrelated ``pipeline`` uses left alone: ``pltpu.emit_pipeline``,
``pipeline_in_args`` / ``pipeline_out_args`` in
``language/_tracing_ops.py``, and the CuTe TMA
``*_pipeline_setup`` / ``PipelineAsync`` machinery in
``memory_ops.py`` / ``cute/cute_mma.py``.

Test golden-string assertions updated (``_pipeline_arg_indices=`` ->
``_hbm_arg_indices=``).
