### PR TITLE
[TPU] Add TPU benchmark via the tritonbench bridge (artifact-only, gated)

### DIFF
--- a/.github/workflows/benchmark_dispatch.yml
+++ b/.github/workflows/benchmark_dispatch.yml
@@ -23,6 +23,15 @@ on:
         required: false
         type: boolean
         default: false
+      run_tpu_bridge:
+        # Transitional: kept separate (default off) so this PR can land without
+        # the bridge entering the nightly before its dashboard wiring exists. The
+        # dashboard follow-up folds this into `run_tpu` (both TPU jobs gated by
+        # one toggle) and removes this input.
+        description: 'Run TPU v7 benchmark via the tritonbench bridge (WIP; artifact-only until the dashboard follow-up lands). Independent of run_tpu; transitional, folded into run_tpu later.'
+        required: false
+        type: boolean
+        default: false
       run_b200_cute:
         description: 'Run benchmark on B200 with the Helion CuTe backend'
         required: false
@@ -55,6 +64,11 @@ on:
         required: false
         type: string
         default: "flash_attention,bmm,gemm,welford,softmax,layer_norm,rms_norm,rms_norm-bwd,cross_entropy,kl_div"
+      kernels_tpu_bridge:
+        description: 'Kernels benchmarked on TPU via the tritonbench bridge (benchmarks/run.py --device tpu). Currently produces artifacts only (manual, gated behind run_tpu_bridge); a follow-up wires these into the shared tpu dashboard column and moves them off kernels_tpu.'
+        required: false
+        type: string
+        default: "flash_attention,gemm,welford,softmax,layer_norm,rms_norm,rms_norm-bwd,kl_div"
       kernels_cute:
         description: 'Comma-separated list of kernels to benchmark on B200 with HELION_BACKEND=cute. Defaults to the CuTe-capable TritonBench subset.'
         required: false
@@ -230,9 +244,19 @@ jobs:
       kernels: ${{ github.event.inputs.kernels_linattn }}
       env-vars: ${{ github.event.inputs.env_vars }}
 
+  run-tpu-bridge:
+    if: ${{ github.event.inputs.run_tpu_bridge == 'true' }}
+    uses: ./.github/workflows/benchmark_tpu_bridge.yml
+    permissions:
+      contents: read
+    with:
+      alias: tpu_bridge
+      kernels: ${{ github.event.inputs.kernels_tpu_bridge }}
+      env-vars: ${{ github.event.inputs.env_vars }}
+
   trigger-docs-deploy:
     if: always()
-    needs: [run-b200, run-b200-cute, run-h100, run-mi350x, run-tpu, run-b200-linattn, run-h100-linattn]
+    needs: [run-b200, run-b200-cute, run-h100, run-mi350x, run-tpu, run-b200-linattn, run-h100-linattn, run-tpu-bridge]
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/benchmark_tpu_bridge.yml
+++ b/.github/workflows/benchmark_tpu_bridge.yml
@@ -1,0 +1,192 @@
+# Run TPU benchmarks through the *tritonbench bridge* (benchmarks/run.py
+# --device tpu), for kernels that have a tritonbench operator and run on TPU,
+# mirroring the GPU nightly (benchmark.yml). Reuses the TPU-aware
+# --list-impls-for-benchmark-ci for impl auto-discovery.
+#
+# run_tpu.py keeps: bmm (no tritonbench operator), cross_entropy (Helion Mosaic
+# holdout), Helion-only kernels, and the full sweep.
+name: Benchmark TPU (bridge)
+
+on:
+  workflow_call:
+    inputs:
+      alias:
+        required: true
+        type: string
+      kernels:
+        required: true
+        type: string
+        description: "Comma-separated tritonbench-backed kernels to run via the bridge on TPU."
+      env-vars:
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: benchmark-${{ inputs.alias }}-bridge
+
+    env:
+      HELION_BACKEND: pallas
+      HELION_AUTOTUNE_LOG_LEVEL: INFO
+      HELION_AUTOTUNE_EFFORT: full
+      HELION_BENCHMARK_KERNEL_TIMEOUT: "3600"
+
+    runs-on: linux.google.tpuv7x.1
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Create virtual environment
+        run: uv venv --python 3.12
+
+      - name: Install PyTorch (CPU nightly)
+        run: |
+          source .venv/bin/activate
+          uv pip install -U --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
+
+      - name: Install Helion
+        run: |
+          source .venv/bin/activate
+          uv pip install setuptools ninja
+          SETUPTOOLS_SCM_PRETEND_VERSION="0.0.0" uv pip install -e .'[dev]'
+          python -c "import helion; print(helion.__name__)"
+
+      # NOTE: identical to benchmark_tpu.yml's "Install TPU dependencies" step
+      # (jax/libtpu + bazel-build torch_tpu from the pin via GCP Secret Manager).
+      # TODO: factor this into a composite action shared with benchmark_tpu.yml.
+      - name: Install TPU dependencies (Pallas)
+        run: |
+          set -euxo pipefail
+          source .venv/bin/activate
+          uv pip install \
+            --extra-index-url https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/ \
+            --find-links https://storage.googleapis.com/jax-releases/libtpu_releases.html \
+            --pre \
+            'jax==0.10.1' 'jaxlib==0.10.1' 'libtpu==0.0.40' 'tpu-info==0.7.1' 'jaxtyping' 'frozendict'
+          if ! command -v bazel &> /dev/null; then
+            sudo curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.27.0/bazelisk-linux-amd64 -o /usr/local/bin/bazel
+            sudo chmod +x /usr/local/bin/bazel
+          fi
+          if ! command -v gcloud &> /dev/null; then
+            sudo apt-get install -y apt-transport-https ca-certificates gpg curl
+            curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+            echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
+            sudo apt-get update && sudo apt-get install -y google-cloud-cli
+          fi
+          TORCH_TPU_COMMIT=$(cat .github/ci_commit_pins/torch_tpu.txt)
+          set +x
+          gcloud secrets versions access latest --secret="torchtpu-read-key" \
+            --project="ml-velocity-actions-testing" > /tmp/torch_tpu_ssh_key
+          set -x
+          chmod 600 /tmp/torch_tpu_ssh_key
+          GIT_SSH_COMMAND="ssh -i /tmp/torch_tpu_ssh_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no" \
+            git clone git@github.com:google-pytorch/torch_tpu.git /tmp/torch_tpu
+          rm -f /tmp/torch_tpu_ssh_key
+          cd /tmp/torch_tpu
+          git checkout "${TORCH_TPU_COMMIT}"
+          export TORCH_SOURCE=$(python -c "import torch; import os; print(os.path.dirname(os.path.dirname(torch.__file__)))")
+          export SITE_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")
+          bazel build -c opt //ci/wheel:torch_tpu_wheel --config=helion_public_caching_readwrite --define WHEEL_VERSION=0.1.0 --define TORCH_SOURCE=local --action_env=PYTHONPATH=$TORCH_SOURCE:$SITE_PACKAGES --action_env=JAX_PLATFORMS=cpu
+          uv pip install bazel-bin/ci/wheel/*.whl
+          uv pip install libtpu==0.0.40
+          cd -
+          rm -rf /tmp/torch_tpu
+          python -c "import torch, sys; print('Success') if torch.tpu.is_available() else (print('(Torch)TPU not available'), sys.exit(1))"
+
+      # TPU-appropriate tritonbench install: base requirements + the dev-tpu
+      # dependency group (transformers/triton/tabulate). Deliberately SKIP the
+      # CUDA-only bits the GPU workflow does (quack-kernels, install.py --liger,
+      # mamba-ssm, flash-linear-attention).
+      # TODO: validate this recipe on the runner; requirements.txt may pull
+      # CUDA-only packages that need excluding.
+      - name: Install tritonbench (TPU)
+        run: |
+          set -x
+          source .venv/bin/activate
+          mkdir -p benchmarks/ && pushd benchmarks/
+          git clone https://github.com/meta-pytorch/tritonbench/
+          pushd tritonbench/
+          git checkout $(cat $GITHUB_WORKSPACE/.github/ci_commit_pins/tritonbench.txt)
+          git submodule update --init --recursive
+          uv pip install -r requirements.txt
+          # dev-tpu group deps needed by the bridged operators.
+          uv pip install "transformers==5.0.0rc3" triton tabulate
+          uv pip install -e . --no-deps
+          popd
+          popd
+
+      - name: Run TPU Benchmark (bridge)
+        run: |
+          rm -rf /tmp/torchinductor_*/ || true
+          source .venv/bin/activate
+          TEST_REPORTS_DIR=$(pwd)/test/test-reports
+          mkdir -p "$TEST_REPORTS_DIR"
+
+          KERNEL_LIST="${{ inputs.kernels }}"
+          for kernel in ${KERNEL_LIST//,/ }; do
+            echo "=== bridge TPU benchmark: $kernel ==="
+            # Requires --list-impls-for-benchmark-ci to be TPU-aware (return only
+            # TPU-runnable impls). See header note (2).
+            KERNEL_INFO=$(python benchmarks/run.py --list-impls-for-benchmark-ci --device tpu --op $kernel | grep "^$kernel:")
+            IMPLS=$(echo "$KERNEL_INFO" | sed -n 's/.*impls=\([^ ]*\).*/\1/p')
+            BASELINE=$(echo "$KERNEL_INFO" | sed -n 's/.*baseline=\([^ ]*\).*/\1/p')
+            if [[ -z "$IMPLS" || -z "$BASELINE" ]]; then
+              echo "Warning: no runnable impls/baseline for $kernel on TPU, skipping..."
+              continue
+            fi
+
+            # TPU differences vs GPU (benchmark.yml): --device tpu, --precision
+            # bf16 (match run_tpu), drop --cudagraph and
+            # --latency-measure-mode triton_do_bench (CUDA/Triton-only; TPU uses
+            # the wall-clock _do_bench_tpu path). Shapes are tritonbench's own,
+            # count-capped by --num-inputs; per-kernel shape args (e.g. embedding
+            # --B/--T/--D/--v-range) are supplied via inputs.env-vars / custom
+            # args where a default shape exceeds TPU vmem.
+            ${{ inputs.env-vars }} HELION_PRINT_OUTPUT_CODE=1 HELION_MEASURE_COMPILE_TIME=1 \
+              python benchmarks/run.py \
+                --op $kernel \
+                --device tpu \
+                --precision bf16 \
+                --helion-backend pallas \
+                --metrics speedup,accuracy,latency \
+                --measure-compile-time \
+                --num-inputs 2 \
+                --only $IMPLS \
+                --only-match-mode prefix-with-baseline \
+                --baseline $BASELINE \
+                --atol 1e-2 \
+                --rtol 1e-2 \
+                --output "$TEST_REPORTS_DIR/helionbench.json" \
+                --append-to-output \
+                --keep-going
+            echo "✅ $kernel"
+          done
+
+          if [[ ! -s "$TEST_REPORTS_DIR/helionbench.json" ]]; then
+            echo "❌ helionbench.json is missing or empty"
+            exit 1
+          fi
+          cat "$TEST_REPORTS_DIR/helionbench.json"
+
+      - name: Upload the benchmark results to GitHub
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-results-${{ inputs.alias }}
+          path: test/test-reports


### PR DESCRIPTION
Adds `benchmark_tpu_bridge.yml`: a reusable workflow that runs Helion's TPU benchmarks through the **tritonbench bridge** (`benchmarks/run.py --device tpu`), mirroring the GPU nightly (`benchmark.yml`). It reuses `benchmark_tpu.yml`'s TPU environment setup, installs tritonbench with a TPU-appropriate dep set (dev-tpu deps; skips the CUDA-only quack/liger/mamba path), and runs `run.py --device tpu --precision bf16` using the TPU-aware `--list-impls-for-benchmark-ci` (#3020) for impl auto-discovery.

**Status: artifact-only, gated, zero nightly/dashboard impact.** Wired into `benchmark_dispatch.yml` behind a `run_tpu_bridge` dispatch input (default **off**); the `run-tpu-bridge` job does **not** run in the nightly cron, and `kernels_tpu` (the run_tpu.py path feeding the current `tpu` dashboard column) is **unchanged**. Use it via manual `workflow_dispatch` to validate the tritonbench TPU install recipe on the runner.

The `run_tpu_bridge` toggle is **transitional**: it's kept separate here so this PR can land without the bridge entering the nightly before its dashboard wiring exists. The dashboard follow-up (#3030) folds it into `run_tpu` (both TPU jobs gated by one toggle) and removes this input.

The bridge job + install recipe were validated end-to-end on the real TPU runner (torch_tpu build, tritonbench dev-tpu install, gemm → `helionbench.json`).

`run_tpu.py` keeps: `bmm` (no tritonbench operator), `cross_entropy` (Helion Mosaic-codegen holdout), Helion-only kernels, and the full sweep.
