### PR TITLE
[TPU] Fold tritonbench-bridge results into the tpu dashboard column

### DIFF
--- a/.github/dashboard/build_dashboard_data.py
+++ b/.github/dashboard/build_dashboard_data.py
@@ -26,13 +26,16 @@ RETENTION_DAYS = 365
 # benchmark_dispatch input(s) whose `default` lists the kernels that platform
 # is expected to run on the nightly cron. Stable mapping; the kernel list(s)
 # are parsed from the workflow YAML so dashboard expectations track whatever's
-# currently in the workflow defaults without manual edits.
+# currently in the workflow defaults without manual edits. Platforms can draw
+# from multiple inputs: h100/b200 add `kernels_linattn`, and `tpu` unions
+# run_tpu.py (`kernels_tpu`) with the tritonbench bridge (`kernels_tpu_bridge`),
+# which cover disjoint kernels but share the one `tpu` dashboard column.
 _PLATFORM_KERNELS_INPUT = {
     "h100": ("kernels", "kernels_linattn"),
     "b200": ("kernels", "kernels_linattn"),
     "b200_cute": ("kernels_cute",),
     "mi350x": ("kernels",),
-    "tpu": ("kernels_tpu",),
+    "tpu": ("kernels_tpu", "kernels_tpu_bridge"),
 }
 
 
@@ -188,6 +191,11 @@ def parse_run(run_dir, active_platforms=None):
         dirname = os.path.basename(bench_dir)
         parts = dirname.replace("benchmark-results-", "").split("-", 1)
         platform_short = parts[0] if parts else "unknown"
+        # The tritonbench-bridge TPU job uploads under the `tpu_bridge` alias but
+        # benchmarks the same hardware as run_tpu.py's `tpu` job (on a disjoint
+        # set of kernels); fold it into the shared `tpu` platform column.
+        if platform_short == "tpu_bridge":
+            platform_short = "tpu"
 
         if active_platforms and platform_short not in active_platforms:
             continue
@@ -208,12 +216,18 @@ def parse_run(run_dir, active_platforms=None):
         extra_info = data[0].get("benchmark", {}).get("extra_info", {})
         backend = extra_info.get("backend")
         backend_label = "CuTe" if backend == "cute" else backend
-        if backend and backend != "triton" and not platform_short.endswith(f"_{backend}"):
+        # `pallas` is the TPU-native backend (like `triton` on GPU), not an
+        # alternative worth its own column, so it doesn't get a platform suffix.
+        if (
+            backend
+            and backend not in ("triton", "pallas")
+            and not platform_short.endswith(f"_{backend}")
+        ):
             platform_short = f"{platform_short}_{backend}"
             if active_platforms and platform_short not in active_platforms:
                 continue
         platform = extra_info.get("device", platform_short)
-        if backend and backend != "triton":
+        if backend and backend not in ("triton", "pallas"):
             platform = f"{platform} ({backend_label})"
         if platform == platform_short and platform in ("b200", "h100", "mi325x", "mi350x"):
             continue

--- a/.github/workflows/benchmark_dispatch.yml
+++ b/.github/workflows/benchmark_dispatch.yml
@@ -23,15 +23,6 @@ on:
         required: false
         type: boolean
         default: false
-      run_tpu_bridge:
-        # Transitional: kept separate (default off) so this PR can land without
-        # the bridge entering the nightly before its dashboard wiring exists. The
-        # dashboard follow-up folds this into `run_tpu` (both TPU jobs gated by
-        # one toggle) and removes this input.
-        description: 'Run TPU v7 benchmark via the tritonbench bridge (WIP; artifact-only until the dashboard follow-up lands). Independent of run_tpu; transitional, folded into run_tpu later.'
-        required: false
-        type: boolean
-        default: false
       run_b200_cute:
         description: 'Run benchmark on B200 with the Helion CuTe backend'
         required: false
@@ -60,12 +51,12 @@ on:
         # Triton bug is fixed. Forward `rope` stays in the list.
         default: "flash_attention,gdn_fwd_h,cross_entropy,grouped_gemm,gemm,welford,layer_norm-bwd,int4_gemm,softmax,layer_norm,mamba2_chunk_state,rms_norm-bwd,rope,jsd,mamba2_chunk_scan,kl_div,rms_norm"
       kernels_tpu:
-        description: 'Comma-separated list of kernels to benchmark on TPU (examples-based; disjoint from `kernels`). Default is the dashboard-tracked subset; pass an explicit list, or `all` to run every kernel registered in benchmarks/run_tpu.py::KERNEL_MAPPINGS.'
+        description: 'Kernels benchmarked on TPU via run_tpu.py: only the kernels the tritonbench bridge cannot handle — bmm (no tritonbench operator) and cross_entropy (Helion Mosaic-codegen holdout). Everything else runs via the bridge (kernels_tpu_bridge). `all` runs every kernel in benchmarks/run_tpu.py::KERNEL_MAPPINGS.'
         required: false
         type: string
-        default: "flash_attention,bmm,gemm,welford,softmax,layer_norm,rms_norm,rms_norm-bwd,cross_entropy,kl_div"
+        default: "bmm,cross_entropy"
       kernels_tpu_bridge:
-        description: 'Kernels benchmarked on TPU via the tritonbench bridge (benchmarks/run.py --device tpu). Currently produces artifacts only (manual, gated behind run_tpu_bridge); a follow-up wires these into the shared tpu dashboard column and moves them off kernels_tpu.'
+        description: 'Kernels benchmarked on TPU via the tritonbench bridge (benchmarks/run.py --device tpu). These land in the shared `tpu` dashboard column alongside kernels_tpu (disjoint sets).'
         required: false
         type: string
         default: "flash_attention,gemm,welford,softmax,layer_norm,rms_norm,rms_norm-bwd,kl_div"
@@ -244,8 +235,10 @@ jobs:
       kernels: ${{ github.event.inputs.kernels_linattn }}
       env-vars: ${{ github.event.inputs.env_vars }}
 
+  # Both TPU jobs (run_tpu.py for the holdouts, the bridge for everything else)
+  # share the single `run_tpu` toggle; together they cover the `tpu` dashboard.
   run-tpu-bridge:
-    if: ${{ github.event.inputs.run_tpu_bridge == 'true' }}
+    if: ${{ github.event.inputs.run_tpu == 'true' }}
     uses: ./.github/workflows/benchmark_tpu_bridge.yml
     permissions:
       contents: read

--- a/helion/_compat.py
+++ b/helion/_compat.py
@@ -402,6 +402,11 @@ def get_device_name(device: torch.device | None = None) -> str | None:
     if device is None:
         if torch.cuda.is_available():
             device = torch.device("cuda", torch.cuda.current_device())
+        elif getattr(torch, "tpu", None) is not None and torch.tpu.is_available():
+            # torch_tpu (PrivateUse1) exposes no per-chip name; report the
+            # generation so dashboard rows land on the "tpu" platform instead of
+            # "unknown" (matches benchmarks/run_tpu.py).
+            return "TPU v7"
         else:
             return None
 


### PR DESCRIPTION
Folds the tritonbench-bridge TPU results (from #3028) into the existing **`tpu` dashboard column**, and turns the bridge on in the nightly cron — so the TPU dashboard's bridgeable kernels are measured through tritonbench, in one column alongside the run_tpu.py holdouts.

- **`helion/_compat.py`** — `get_device_name()` returns `"TPU v7"` on TPU (was `None` → `"unknown"`), matching `run_tpu.py`, so bridge rows carry a real device label.
- **`build_dashboard_data.py`** — `parse_run` folds the `tpu_bridge` artifact into the `tpu` `platform_short`, and treats `pallas` as a native backend (no platform suffix, like `triton`) so pallas-on-tpu stays in the `tpu` column instead of a dropped `tpu_pallas`. The `tpu` platform's expected-kernels now unions `kernels_tpu` + `kernels_tpu_bridge`.
- **`benchmark_dispatch.yml`** — trims `kernels_tpu` to the bridge's holdouts (`bmm` — no tritonbench operator; `cross_entropy` — Helion Mosaic-codegen holdout); the other 8 kernels now come from the bridge, so nothing is double-reported (the two sets are disjoint). **Consolidates the toggles**: removes the transitional `run_tpu_bridge` input and gates *both* TPU jobs (`run-tpu` and `run-tpu-bridge`) on the single `run_tpu` input — so one switch runs all TPU benchmarks. No nightly change needed; the existing `run_tpu: 'true'` now triggers both.

Together with #3028, Helion's TPU nightly runs its 8 bridgeable kernels through tritonbench on the shared `tpu` dashboard column, with `bmm`/`cross_entropy` remaining on `run_tpu.py`. The bridge install recipe was validated end-to-end on the real TPU runner.
