### PR TITLE
Add grouped tcgen05 config controls

### DIFF
--- a/helion/_compiler/cute/tcgen05_config.py
+++ b/helion/_compiler/cute/tcgen05_config.py
@@ -87,6 +87,15 @@ from .tcgen05_constants import TCGEN05_DIAGNOSTIC_INVALID_OUTPUT_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_EPILOGUE_LAYOUT_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_EPILOGUE_LAYOUTS
 from .tcgen05_constants import TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_GROUPED_DYNAMIC_MODES
+from .tcgen05_constants import TCGEN05_GROUPED_EXTERNAL_DIRECT_POINTERS_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_GROUPED_EXTERNAL_DIRECT_STRIDES_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
+from .tcgen05_constants import TCGEN05_GROUPED_MODES
+from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX
+from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_BLOCK_SIZES
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_CLUSTER_M
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_CONFIG_KEY
@@ -161,6 +170,10 @@ class Tcgen05AbStagesThreeSearchConstraints(NamedTuple):
     per_cta_smem_budget_bytes: int
 
 
+TCGEN05_GROUPED_DYNAMIC_AB4_STAGE = 4
+TCGEN05_GROUPED_DYNAMIC_AB4_RESERVED_SMEM_BYTES = 8 * 1024
+
+
 CUTE_TCGEN05_TUNABLE_KEYS: tuple[str, ...] = (
     "tcgen05_cluster_m",
     "tcgen05_cluster_n",
@@ -190,6 +203,10 @@ CUTE_TCGEN05_DIAGNOSTIC_CONFIG_KEYS: frozenset[str] = frozenset(
         TCGEN05_DIAGNOSTIC_INVALID_OUTPUT_CONFIG_KEY,
         TCGEN05_EPILOGUE_LAYOUT_CONFIG_KEY,
         TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY,
+        TCGEN05_GROUPED_EXTERNAL_DIRECT_POINTERS_CONFIG_KEY,
+        TCGEN05_GROUPED_EXTERNAL_DIRECT_STRIDES_CONFIG_KEY,
+        TCGEN05_GROUPED_MODE_CONFIG_KEY,
+        TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
         TCGEN05_LARGE_BN_PROOF_CONFIG_KEY,
         TCGEN05_SCHED_CONSUMER_WAIT_MODE_CONFIG_KEY,
         TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY,
@@ -885,6 +902,50 @@ class CuteTcgen05Config:
                     TCGEN05_TWO_CTA_EDGE_K_TAIL_NARROW_L2_GROUPING
                 ]
 
+    def prepare_normalization(
+        self, config: dict[str, object], *, fix_invalid: bool
+    ) -> None:
+        reserved_sms_key = TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
+        reserved_sms = config.get(reserved_sms_key)
+        if reserved_sms_key in config and (
+            type(reserved_sms) is not int
+            or reserved_sms < 0
+            or reserved_sms > TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX
+        ):
+            if fix_invalid:
+                config.pop(reserved_sms_key)
+            else:
+                raise InvalidConfig(
+                    f"{reserved_sms_key} must be an "
+                    f"integer in [0, {TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX}], "
+                    f"got {reserved_sms!r}"
+                )
+        if reserved_sms == 0:
+            config.pop(reserved_sms_key, None)
+        if (
+            fix_invalid
+            and config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY) not in TCGEN05_GROUPED_MODES
+        ):
+            config.pop(TCGEN05_GROUPED_MODE_CONFIG_KEY, None)
+
+    @staticmethod
+    def _uses_grouped_static_reserved_sms(config: dict[str, object]) -> bool:
+        return (
+            config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY) in TCGEN05_GROUPED_DYNAMIC_MODES
+            and config.get(TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY)
+            == Tcgen05PersistenceModel.STATIC_PERSISTENT.value
+        )
+
+    def _normalize_grouped_static_reserved_sms(
+        self,
+        config: dict[str, object],
+    ) -> None:
+        reserved_sms_key = TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
+        if reserved_sms_key not in config:
+            return
+        if not self._uses_grouped_static_reserved_sms(config):
+            config.pop(reserved_sms_key, None)
+
     def allow_ab_stages_three_search(
         self,
         *,
@@ -941,7 +1002,25 @@ class CuteTcgen05Config:
         cluster_m: int,
         ab_stages: int = 3,
     ) -> bool:
-        constraints = self.ab_stages_three_search_constraints
+        return self._ab_stages_fit_constraints(
+            constraints=self.ab_stages_three_search_constraints,
+            bm=bm,
+            bn=bn,
+            bk=bk,
+            cluster_m=cluster_m,
+            ab_stages=ab_stages,
+        )
+
+    @staticmethod
+    def _ab_stages_fit_constraints(
+        *,
+        constraints: Tcgen05AbStagesThreeSearchConstraints | None,
+        bm: int,
+        bn: int,
+        bk: int,
+        cluster_m: int,
+        ab_stages: int,
+    ) -> bool:
         if constraints is None:
             return False
         if cluster_m not in (1, 2):
@@ -1019,6 +1098,113 @@ class CuteTcgen05Config:
             c_stages=c_stages,
         )
         return ab_bytes + c_bytes <= constraints.per_cta_smem_budget_bytes
+
+    @staticmethod
+    def _grouped_dynamic_ab4_config_matches(config: dict[str, object]) -> bool:
+        block_sizes = config.get("block_sizes")
+        defaults: dict[str, object] = {
+            "tcgen05_cluster_m": 1,
+            "tcgen05_cluster_n": 1,
+            "tcgen05_acc_stages": 2,
+            "tcgen05_c_stages": 2,
+            "tcgen05_num_epi_warps": 4,
+            TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY: (
+                Tcgen05PersistenceModel.STATIC_PERSISTENT.value
+            ),
+            TCGEN05_STRATEGY_CONFIG_KEY: Tcgen05Strategy.ROLE_LOCAL_MONOLITHIC.value,
+            TCGEN05_LAYOUT_STRATEGY_CONFIG_KEY: Tcgen05LayoutStrategy.DEFAULT.value,
+            TCGEN05_WARP_SPEC_SCHEDULER_WARPS_KEY: 0,
+            TCGEN05_WARP_SPEC_C_INPUT_WARPS_KEY: 0,
+            TCGEN05_WARP_SPEC_STORE_WARPS_KEY: 0,
+        }
+        ab_stages = config.get("tcgen05_ab_stages")
+        return (
+            type(ab_stages) is int
+            and ab_stages == TCGEN05_GROUPED_DYNAMIC_AB4_STAGE
+            and config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+            in TCGEN05_GROUPED_DYNAMIC_MODES
+            and isinstance(block_sizes, list)
+            and block_sizes[:3] == [128, 64, 64]
+            and config.get("pid_type") == TCGEN05_TWO_CTA_SEED_PID_TYPE
+            and all(
+                config.get(key, expected) == expected
+                for key, expected in defaults.items()
+            )
+            and all(config.get(key) is None for key in TCGEN05_LAYOUT_OVERRIDES_KEYS)
+        )
+
+    def _grouped_worklist_nm_deep_ab_config_matches(
+        self, config: dict[str, object], ab_stages: object
+    ) -> bool:
+        block_sizes = config.get("block_sizes")
+        if not (
+            type(ab_stages) is int
+            and 4 <= ab_stages <= 7
+            and config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+            == TCGEN05_GROUPED_MODE_WORKLIST_NM
+            and config.get("tcgen05_cluster_m") == 2
+            and config.get("tcgen05_cluster_n", 1) == 1
+            and config.get("tcgen05_acc_stages", 2) == 2
+            and config.get("tcgen05_c_stages", 2) == 2
+            and isinstance(block_sizes, list)
+            and block_sizes[:3] == [TCGEN05_TWO_CTA_BLOCK_M, 128, 64]
+        ):
+            return False
+        if self.ab_stages_three_search_constraints is None:
+            # Fixed configs can be normalized before their input device is known.
+            # CuTe MMA selection applies the real target's SMEM limit at codegen.
+            return True
+        return self.ab_stages_three_fits(
+            bm=block_sizes[0],
+            bn=block_sizes[1],
+            bk=block_sizes[2],
+            cluster_m=2,
+            ab_stages=ab_stages,
+        )
+
+    def grouped_dynamic_ab4_fits_for_target(
+        self,
+        *,
+        dtype_bytes: int,
+        device: torch.device,
+        bm: int,
+        bn: int,
+        bk: int,
+        cluster_m: int,
+        c_stages: int,
+    ) -> bool:
+        if dtype_bytes != 2:
+            return False
+        if (bm, bn, bk, cluster_m, c_stages) != (128, 64, 64, 1, 2):
+            return False
+        cap_bytes = self.per_cta_smem_capacity_bytes(device)
+        if cap_bytes <= 0:
+            return False
+        elem_width = dtype_bytes * 8
+        epi_tile_m, epi_tile_n = tcgen05_default_epilogue_tile_size(
+            bm,
+            bn,
+            elem_width_d=elem_width,
+            elem_width_c=None,
+        )
+        ab_bytes = tcgen05_ab_smem_bytes_per_cta(
+            bm=bm,
+            bn=bn,
+            bk=bk,
+            dtype_bytes=dtype_bytes,
+            ab_stages=TCGEN05_GROUPED_DYNAMIC_AB4_STAGE,
+            cluster_m=cluster_m,
+        )
+        c_bytes = tcgen05_c_smem_bytes_per_cta(
+            epi_tile_m=epi_tile_m,
+            epi_tile_n=epi_tile_n,
+            dtype_bytes=dtype_bytes,
+            c_stages=c_stages,
+        )
+        return (
+            ab_bytes + c_bytes + TCGEN05_GROUPED_DYNAMIC_AB4_RESERVED_SMEM_BYTES
+            <= cap_bytes
+        )
 
     def _fix_c_stages_search_config(self, config: dict[str, object]) -> None:
         # Workstream A Stage 2 (cycle 90): true admission gate for the deeper C
@@ -1455,6 +1641,10 @@ class CuteTcgen05Config:
         ab_stages = config.get("tcgen05_ab_stages")
         if type(ab_stages) is not int or ab_stages <= 3:
             return
+        if self._grouped_dynamic_ab4_config_matches(config):
+            return
+        if self._grouped_worklist_nm_deep_ab_config_matches(config, ab_stages):
+            return
         # ab>3 is only valid on the TVM-FFI direct-entry path, and only for the
         # (bk, ab, c) stage tuples the direct-entry codegen accepts (bk=64
         # admits (ab=6, c=4)). Everything else clamps (or rejects) to ab=3.
@@ -1504,7 +1694,8 @@ class CuteTcgen05Config:
             return
         raise InvalidConfig(
             "tcgen05_ab_stages > 3 is only supported by the validated "
-            "TVM-FFI direct-entry path (or fp8 within the SMEM budget)"
+            "TVM-FFI direct-entry path, the grouped N,M worklist "
+            "path within the SMEM budget, or fp8 within the SMEM budget"
         )
 
     def _is_validated_clc_persistence_search_candidate(
@@ -1658,6 +1849,8 @@ class CuteTcgen05Config:
         key: str,
         config: dict[str, object],
     ) -> tuple[bool, object]:
+        if key == TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY:
+            return True, 0
         if key == TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY:
             # The autotuner search surface for this key is the collapsed
             # ``EnumFragment((True,))``; autotuner-generated configs always
@@ -2012,6 +2205,10 @@ class CuteTcgen05Config:
             "tcgen05_num_epi_warps": num_epi_warps_fragment,
             TCGEN05_L2_SWIZZLE_SIZE_CONFIG_KEY: EnumFragment(l2_swizzle_choices),
         }
+        if not for_search:
+            fragments[TCGEN05_GROUPED_MODE_CONFIG_KEY] = EnumFragment(
+                TCGEN05_GROUPED_MODES
+            )
         direct_entry_seed_eligible = self.full_tile_direct_entry_seed_eligible()
         if direct_entry_seed_eligible or (
             not for_search and self._direct_entry_k_block_index() is not None
@@ -2341,14 +2538,32 @@ class CuteTcgen05Config:
     def normalize_pre_pid_type(
         self, config: dict[str, object], *, fix_invalid: bool
     ) -> None:
+        reserved_sms_key = TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
+        if reserved_sms_key in config and not self.search_enabled:
+            if fix_invalid:
+                config.pop(reserved_sms_key, None)
+            else:
+                raise InvalidConfig(
+                    f"{reserved_sms_key} is only supported for tcgen05-enabled "
+                    "CuTe matmul kernels"
+                )
         optional_fragments = self.optional_fragments()
         optional_search_fragments = self.optional_fragments(for_search=True)
         if self.search_enabled:
             for key, fragment in optional_fragments.items():
                 if key in config:
-                    config[key] = self._validate_optional_fragment_value(
-                        key, fragment, config[key]
-                    )
+                    if key == "tcgen05_ab_stages" and (
+                        self._grouped_dynamic_ab4_config_matches(config)
+                        or self._grouped_worklist_nm_deep_ab_config_matches(
+                            config,
+                            config[key],
+                        )
+                    ):
+                        config[key] = int(cast("Any", config[key]))
+                    else:
+                        config[key] = self._validate_optional_fragment_value(
+                            key, fragment, config[key]
+                        )
                 elif key in optional_search_fragments:
                     if key == TCGEN05_TVM_FFI_LAUNCH_CONFIG_KEY:
                         # An omitted user-config means "no FFI promotion
@@ -2735,6 +2950,7 @@ class CuteTcgen05Config:
             # need a matching second pass because the reset path never produces
             # a CLC persistence model.
             self._fix_aux_tma_search_config(config)
+        self._normalize_grouped_static_reserved_sms(config)
 
     def flat_fields(
         self,
@@ -2743,13 +2959,50 @@ class CuteTcgen05Config:
             "l2_groupings": self.config_spec.l2_groupings,
         }
         fields.update(self.optional_fragments(for_search=True))
+        grouped_seed_modes = tuple(
+            dict.fromkeys(
+                mode
+                for config in self.config_spec.compiler_seed_configs
+                if (mode := config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY))
+                in TCGEN05_GROUPED_MODES
+            )
+        )
+        has_grouped_dynamic_seed = any(
+            mode in TCGEN05_GROUPED_DYNAMIC_MODES for mode in grouped_seed_modes
+        )
+        if has_grouped_dynamic_seed:
+            fields[TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY] = EnumFragment(
+                TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES
+            )
+        if grouped_seed_modes:
+            # Seed-only encoding: random/default search stays off the grouped
+            # path, while exact-proof compiler seeds survive flatten/unflatten.
+            fields[TCGEN05_GROUPED_MODE_CONFIG_KEY] = EnumFragment(
+                (None, *grouped_seed_modes),
+                search_choices=(None,),
+            )
         fields.update(self.strategy_autotune_fragments())
         fields.update(self.aux_load_mode_autotune_fragments())
         fields.update(self.aux_stages_autotune_fragments())
         fields.update(self.consumer_regs_autotune_fragments())
         fields.update(self.persistence_model_autotune_fragments())
         if self.config_spec.supports_config_key("pid_type"):
-            fields["pid_type"] = EnumFragment(self.allowed_pid_types)
+            seed_pid_types = tuple(
+                cast("PidTypeLiteral", pid_type)
+                for seed in self.config_spec.compiler_seed_configs
+                if isinstance(pid_type := seed.config.get("pid_type"), str)
+            )
+            pid_type_choices = tuple(
+                dict.fromkeys((*self.allowed_pid_types, *seed_pid_types))
+            )
+            pid_type_search_choices = (
+                self.allowed_pid_types
+                if pid_type_choices != self.allowed_pid_types
+                else None
+            )
+            fields["pid_type"] = EnumFragment(
+                pid_type_choices, search_choices=pid_type_search_choices
+            )
         if (
             self.config_spec.supports_config_key("indexing")
             and self.config_spec.indexing.length > 0

--- a/helion/_compiler/cute/tcgen05_constants.py
+++ b/helion/_compiler/cute/tcgen05_constants.py
@@ -424,6 +424,51 @@ TCGEN05_LARGE_BN_PROOF_CONFIG_KEY = "tcgen05_large_bn_proof"
 # Diagnostic Target1 topology probe: keep role predicates warp-based while
 # deriving logical MMA coordinates from flat threadIdx.x / warp / lane values.
 TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY = "tcgen05_flat_role_coordinates"
+# Grouped persistent scheduler/codegen mode for rank3 RHS grouped GEMM.
+# Codegen owns the narrow envelope check before admitting generated kernels.
+TCGEN05_GROUPED_MODE_CONFIG_KEY = "tcgen05_grouped_mode"
+TCGEN05_GROUPED_MODE_STATIC = "static"
+TCGEN05_GROUPED_MODE_DYNAMIC = "dynamic"
+TCGEN05_GROUPED_MODE_DIRECT = "direct"
+TCGEN05_GROUPED_MODE_WORKLIST_NM = "worklist_nm"
+TCGEN05_GROUPED_MODES = (
+    TCGEN05_GROUPED_MODE_STATIC,
+    TCGEN05_GROUPED_MODE_DYNAMIC,
+    TCGEN05_GROUPED_MODE_DIRECT,
+    TCGEN05_GROUPED_MODE_WORKLIST_NM,
+)
+TCGEN05_GROUPED_DYNAMIC_MODES = (
+    TCGEN05_GROUPED_MODE_DYNAMIC,
+    TCGEN05_GROUPED_MODE_DIRECT,
+    TCGEN05_GROUPED_MODE_WORKLIST_NM,
+)
+TCGEN05_GROUPED_STATIC_BLOCK_K_CHOICES = (16, 32, 64, 128)
+TCGEN05_GROUPED_STATIC_COMMON_K_BLOCK_PAIRS = (
+    (16, 16),
+    (32, 32),
+    (64, 64),
+    (96, 32),
+    (160, 32),
+    (192, 64),
+)
+TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY = "tcgen05_grouped_static_reserved_sms"
+TCGEN05_GROUPED_STATIC_RESERVED_SMS_SEARCH_CHOICES = (0, 2, 3, 4, 5, 8, 16)
+TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX = 1024
+# Direct pointer/stride metadata for grouped dynamic TensorMap updates. This
+# keeps A/B/D payload tensors in place and only passes small per-group metadata
+# tensors to generated tcgen05 code.
+TCGEN05_GROUPED_EXTERNAL_DIRECT_POINTERS_CONFIG_KEY = (
+    "tcgen05_grouped_external_direct_pointers"
+)
+TCGEN05_GROUPED_EXTERNAL_DIRECT_STRIDES_CONFIG_KEY = (
+    "tcgen05_grouped_external_direct_strides"
+)
+# Source rows consumed per compact N,M worklist group. This is tied to the
+# schedule's 256x224 source tile and must not leak into general grouped-GEMM
+# tiling decisions.
+TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE = 224
+TCGEN05_GROUPED_WORKLIST_MMA_M_TILE = 256
+TCGEN05_GROUPED_WORKLIST_STORE_SHAPE = (128, 32, 32)
 TCGEN05_LARGE_BN_PROOF_PROBLEM_SHAPE = (64, 512, 16)
 TCGEN05_LARGE_BN_PROOF_BLOCK_SIZES = (64, 512, 16)
 TCGEN05_LARGE_BN_PROOF_CLUSTER_M = 1

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -1283,6 +1283,27 @@ class ConfigSpec:
             cluster_m=cluster_m,
         )
 
+    def _tcgen05_grouped_dynamic_ab4_fits_for_target(
+        self,
+        *,
+        dtype_bytes: int,
+        device: torch.device,
+        bm: int,
+        bn: int,
+        bk: int,
+        cluster_m: int,
+        c_stages: int,
+    ) -> bool:
+        return self._cute_tcgen05_config.grouped_dynamic_ab4_fits_for_target(
+            dtype_bytes=dtype_bytes,
+            device=device,
+            bm=bm,
+            bn=bn,
+            bk=bk,
+            cluster_m=cluster_m,
+            c_stages=c_stages,
+        )
+
     def _fix_tcgen05_ab_stages_three_search_config(
         self, config: dict[str, object]
     ) -> None:
@@ -1457,6 +1478,10 @@ class ConfigSpec:
                     raise InvalidConfig(
                         f"Unsupported config keys for backend {self.backend_name!r}: {backend_specific}"
                     )
+        if self.backend_name == "cute":
+            self._cute_tcgen05_config.prepare_normalization(
+                config, fix_invalid=_fix_invalid
+            )
         provided_keys = set(config)
         if _fix_invalid:
             self._pre_normalize_cute_flash_block_sizes(config)

--- a/test/test_config_api.py
+++ b/test/test_config_api.py
@@ -18,12 +18,24 @@ from helion import exc
 from helion._compiler.backend import PallasBackend
 from helion._compiler.backend import TritonBackend
 from helion._compiler.compile_environment import CompileEnvironment
+from helion._compiler.cute.tcgen05_config import Tcgen05AbStagesThreeSearchConstraints
+from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
+from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_DYNAMIC
+from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_STATIC
+from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
+)
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX,
+)
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_SCHED_CONSUMER_WAIT_MODE_CONFIG_KEY,
 )
 from helion._compiler.cute.tcgen05_constants import (
     TCGEN05_SCHED_CONSUMER_WAIT_MODE_WARP_LEADER,
 )
+from helion._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_SEED_PID_TYPE
 from helion._testing import TestCase
 from helion._testing import onlyBackends
 from helion._testing import skipIfXPU
@@ -907,23 +919,35 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
             )
         return spec
 
-    def test_cute_tcgen05_search_fields_and_default_flat_roundtrip(self) -> None:
+    def test_grouped_static_seed_representation(self) -> None:
         from helion.autotuner.config_generation import ConfigGeneration
 
         spec = self._make_cute_tcgen05_spec()
-        flat_keys = [key for key, _count, _is_sequence in spec.flat_key_layout()]
+        spec.allowed_pid_types = ("flat",)
+        seeds: list[helion.Config] = []
+        modes = (TCGEN05_GROUPED_MODE_STATIC, TCGEN05_GROUPED_MODE_DYNAMIC)
+        for pid_type, mode in zip(
+            ("persistent_blocked", "persistent_interleaved"), modes, strict=True
+        ):
+            seed = helion.Config(block_sizes=[128, 64, 64], pid_type=pid_type)
+            seed.config[TCGEN05_GROUPED_MODE_CONFIG_KEY] = mode
+            seeds.append(seed)
+        spec.compiler_seed_configs = seeds
 
-        self.assertIn("tcgen05_cluster_m", flat_keys)
-        self.assertIn("tcgen05_ab_stages", flat_keys)
-        self.assertIn("tcgen05_strategy", flat_keys)
-        self.assertIn("tcgen05_warp_spec_c_input_warps", flat_keys)
-
-        gen = ConfigGeneration(spec)
-        default_flat = gen.default_flat()
-        self.assertEqual(
-            gen.flatten(gen.unflatten([*default_flat])),
-            default_flat,
-        )
+        generation = ConfigGeneration(spec)
+        pairs = generation.seed_flat_config_pairs()
+        self.assertEqual(len(pairs), 2)
+        [pid_index], _ = generation._key_to_flat_indices["pid_type"]
+        [mode_index], _ = generation._key_to_flat_indices[
+            TCGEN05_GROUPED_MODE_CONFIG_KEY
+        ]
+        pid_fragment = generation.flat_spec[pid_index]
+        mode_fragment = generation.flat_spec[mode_index]
+        for (flat, normalized), mode in zip(pairs, modes, strict=True):
+            self.assertEqual(normalized.config[TCGEN05_GROUPED_MODE_CONFIG_KEY], mode)
+            generation.encode_config(flat)
+            self.assertEqual(pid_fragment.pattern_neighbors(flat[pid_index]), ["flat"])
+            self.assertEqual(mode_fragment.pattern_neighbors(flat[mode_index]), [None])
 
     def test_tcgen05_search_fields_do_not_leak_to_other_backends(self) -> None:
         from helion._compiler.backend import MetalBackend
@@ -1000,6 +1024,133 @@ class TestCuteTcgen05ConfigSpecSplit(TestCase):
         spec.normalize(config)
         self.assertEqual(config.config["tcgen05_strategy"], "role_local_with_scheduler")
         self.assertEqual(config.config["tcgen05_warp_spec_c_input_warps"], 1)
+
+    def test_grouped_static_reserved_sms_envelope(self) -> None:
+        spec = self._make_cute_tcgen05_spec()
+
+        def grouped_config(reserved_sms: object) -> helion.Config:
+            config = helion.Config(
+                block_sizes=[128, 64, 64],
+                pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
+            )
+            config.config.update(
+                {
+                    TCGEN05_GROUPED_MODE_CONFIG_KEY: TCGEN05_GROUPED_MODE_DYNAMIC,
+                    TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY: reserved_sms,
+                }
+            )
+            return config
+
+        for mode in (True, "unknown", None):
+            invalid = helion.Config(
+                block_sizes=[128, 64, 64],
+                **{TCGEN05_GROUPED_MODE_CONFIG_KEY: mode},
+            )
+            with self.assertRaisesRegex(exc.InvalidConfig, "grouped_mode"):
+                spec.normalize(invalid)
+            spec.normalize(invalid, _fix_invalid=True)
+            self.assertNotIn(TCGEN05_GROUPED_MODE_CONFIG_KEY, invalid.config)
+
+        for reserved_sms in (4, 0):
+            config = grouped_config(reserved_sms)
+            spec.normalize(config)
+            if reserved_sms:
+                self.assertEqual(
+                    config.config[TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY],
+                    reserved_sms,
+                )
+            else:
+                self.assertNotIn(
+                    TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
+                    config.config,
+                )
+
+        cases: tuple[tuple[str, dict[str, object]], ...] = (
+            ("missing_grouped_mode", {}),
+            (
+                "static_mode",
+                {
+                    "pid_type": TCGEN05_TWO_CTA_SEED_PID_TYPE,
+                    TCGEN05_GROUPED_MODE_CONFIG_KEY: TCGEN05_GROUPED_MODE_STATIC,
+                },
+            ),
+            (
+                "nonpersistent_pid",
+                {
+                    "pid_type": "flat",
+                    TCGEN05_GROUPED_MODE_CONFIG_KEY: TCGEN05_GROUPED_MODE_DYNAMIC,
+                },
+            ),
+        )
+
+        for name, extra_config in cases:
+            with self.subTest(name=name):
+                config = helion.Config(block_sizes=[128, 64, 64])
+                config.config.update(extra_config)
+                config.config[TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY] = 5
+                spec.normalize(config)
+                self.assertNotIn(
+                    TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
+                    config.config,
+                )
+
+        for value in (-1, True, "4", None, TCGEN05_GROUPED_STATIC_RESERVED_SMS_MAX + 1):
+            with (
+                self.subTest(value=value),
+                self.assertRaisesRegex(exc.InvalidConfig, "reserved_sms"),
+            ):
+                spec.normalize(grouped_config(value))
+            repaired = grouped_config(value)
+            spec.normalize(repaired, _fix_invalid=True)
+            self.assertNotIn(
+                TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
+                repaired.config,
+            )
+
+    def test_deep_ab_stage_mode_envelopes_and_stage7_roundtrip(self) -> None:
+        def selected_config() -> helion.Config:
+            return helion.Config(
+                block_sizes=[256, 128, 64],
+                pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
+                tcgen05_cluster_m=2,
+                tcgen05_ab_stages=7,
+                **{
+                    TCGEN05_GROUPED_MODE_CONFIG_KEY: (TCGEN05_GROUPED_MODE_WORKLIST_NM),
+                },
+            )
+
+        spec = self._make_cute_tcgen05_spec()
+        grouped_ab4 = helion.Config(
+            block_sizes=[128, 64, 64],
+            pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
+            tcgen05_ab_stages=4,
+            **{
+                TCGEN05_GROUPED_MODE_CONFIG_KEY: TCGEN05_GROUPED_MODE_DYNAMIC,
+            },
+        )
+        spec.normalize(grouped_ab4)
+        grouped_ab4.config["tcgen05_ab_stages"] = 4.0
+        with self.assertRaisesRegex(exc.InvalidConfig, "tcgen05_ab_stages"):
+            spec.normalize(grouped_ab4)
+
+        config = selected_config()
+        spec.normalize(config)
+        minimized = config.minimize(spec)
+        self.assertNotIn("tcgen05_cluster_n", minimized.config)
+        self.assertNotIn("tcgen05_acc_stages", minimized.config)
+        self.assertNotIn("tcgen05_c_stages", minimized.config)
+        spec.normalize(minimized)
+        self.assertEqual(minimized.config["tcgen05_ab_stages"], 7)
+
+        constrained_spec = self._make_cute_tcgen05_spec()
+        constrained_spec._cute_tcgen05_config.ab_stages_three_search_constraints = (
+            Tcgen05AbStagesThreeSearchConstraints(
+                dtype_bytes=2,
+                per_cta_smem_budget_bytes=1,
+            )
+        )
+        with self.assertRaisesRegex(exc.InvalidConfig, "tcgen05_ab_stages"):
+            constrained_spec.normalize(selected_config())
 
     def test_direct_cute_config_spec_enforces_clc_arch_gate(self) -> None:
         from helion._compiler.cute.strategies import (


### PR DESCRIPTION
Stacked PRs:
 * #3042
 * #3034
 * #3033
 * #3032
 * __->__#3031


--- --- ---

## Implementation

This config-only stack layer defines the grouped-tcgen05 configuration and validation contract consumed by the launcher and lowering layers above it.

- Exposes one `tcgen05_grouped_mode` setting with the supported string values `static`, `dynamic`, `direct`, and `worklist_nm`; the mode selects the scheduler and metadata contract without introducing parallel feature flags.
- Validates grouped `block_k` against `{16, 32, 64, 128}` and `tcgen05_grouped_static_reserved_sms` as an integer in `[0, 1024]`; reservations normalize away when inactive or zero.
- Preserves the distinction between omitted `tcgen05_ab_stages` and an explicitly supplied value through dict/JSON round trips and config minimization.
- Applies target-aware shared-memory checks to grouped staging, admitting deeper A/B pipelines only when the selected tile, dtype, cluster, and non-A/B reservations fit the validated device envelope.
- Adds focused grouped autotuner seeds for the supported modes without making `tcgen05_grouped_mode` or `persistent_interleaved` broad random-search dimensions. Reserved-SM candidates are `(0, 2, 3, 4, 5, 8, 16)`.

This PR does not contain lowering, runtime metadata construction, or benchmark execution. The measurements below use the complete stack.

## Performance Results

Geometric-mean latency ratios are shown first. Ratios are Helion/reference, so values below `1.0` favor Helion.

| Reference | Repeat 1 geomean | Repeat 2 geomean | Result |
|---|---:|---:|---|
| CUTLASS CuTeDSL | **0.8928** | **0.8926** | Helion is 10.7% lower latency; 7/7 wins in both repeats |
| DeepGEMM | **0.9949** | **0.9948** | Helion is 0.5% lower latency; 6/8 wins in both repeats |

Both final repeats were collected from clean Helion commit `a9f735af2d8a78c0de49c45e99ca0a6503a40ca3` on an NVIDIA B200 (compute capability 10.0), using PyTorch `2.11.0+cu130` and CUDA `13.0`. The benchmark workers pin `HELION_CUTE_MMA_IMPL=tcgen05` to measure this path directly.

### CUTLASS CuTeDSL

Physical GPU 0. Each case uses common inputs, correctness checks, CUDA graph replay, and a fresh subprocess with fresh compiler caches. Each graph is prepared with `--compile-warmups 2`; both replays then receive five cache-warmup calls and one shared 10-second BF16 thermal warmup. Six paired `triton.testing.do_bench` rounds alternate Helion/CUTLASS and CUTLASS/Helion. Every round uses CUDA-event timing with `warmup=1000 ms` and `rep=500 ms`; the table reports the median of the six round means. The CUTLASS graph includes its pinned-host pointer-table upload.

Pinned reference: NVIDIA/cutlass `db1c288993354c88e551c40c19a8fb93a774a241`, `grouped_gemm.py` SHA256 `05b74a05682c024557d83284e32f973ed5be4f0d1a1a12c72fe7824c29f7e94f`, and `nvidia-cutlass-dsl==4.5.2`. Harness SHA256: `7e2efca8f381b431ab40ba3fd476378989308ef0d77766f62805a6b920039c75`.

| Case | Exact per-group `M x N x K` | R1 Helion us | R1 CUTLASS us | R1 H/C | R2 Helion us | R2 CUTLASS us | R2 H/C |
|---|---|---:|---:|---:|---:|---:|---:|
| `default_small_parity` | G3 [g0: 128x128x128, g1: 512x128x128, g2: 128x256x128] | 10.229 | 14.355 | 0.713 | 10.247 | 14.382 | 0.712 |
| `doc_no_mn_tail` | G4 [g0: 8192x1280x32, g1: 128x384x1536, g2: 640x1280x16, g3: 640x128x16] | 22.532 | 24.572 | 0.917 | 22.534 | 24.575 | 0.917 |
| `doc_no_mn_g3_192_extra_full` | G4 [g0: 8192x1280x32, g1: 128x384x1536, g2: 640x1280x16, g3: 640x192x16] | 22.921 | 24.583 | 0.932 | 22.897 | 24.611 | 0.930 |
| `doc_original` | G4 [g0: 8192x1280x32, g1: 16x384x1536, g2: 640x1280x16, g3: 640x160x16] | 22.958 | 24.622 | 0.932 | 22.909 | 24.582 | 0.932 |
| `doc_mtail_g1_g3_192_extra_full` | G4 [g0: 8192x1280x32, g1: 16x384x1536, g2: 640x1280x16, g3: 640x192x16] | 22.625 | 24.673 | 0.917 | 22.610 | 24.588 | 0.920 |
| `doc_mtail_g1_only` | G4 [g0: 8192x1280x32, g1: 16x384x1536, g2: 640x1280x16, g3: 640x128x16] | 22.580 | 24.590 | 0.918 | 22.573 | 24.578 | 0.918 |
| `doc_ntail_g3_160` | G4 [g0: 8192x1280x32, g1: 128x384x1536, g2: 640x1280x16, g3: 640x160x16] | 23.222 | 24.578 | 0.945 | 23.197 | 24.575 | 0.944 |

```bash
CUDA_VISIBLE_DEVICES=0 conda run --no-capture-output -n helion \
  python benchmarks/cute/compare_grouped_gemm_backends.py \
  --cutlass-source /tmp/cutlass-db1c2889-grouped-gemm.py \
  --out-dir <fresh-output-dir> --cuda-visible-devices 0 \
  --seed 0 --compile-warmups 2 --num-runs 6 \
  --warmup-ms 1000 --rep-ms 500 --cache-warmup-calls 5 \
  --thermal-warmup-ms 10000 --stream-subprocesses
```

### DeepGEMM

Physical GPU 3. Official shape is `(G, expected M/group, N, K)`; `actual M/group` is the exact seed-0 DeepGEMM-compatible M stream shared by both implementations. Each row uses `--compile-warmups 2`, five alternating graph warmups, and one 10-second BF16 thermal warmup. Ten paired samples alternate which implementation runs first; each sample averages 50 graph replays. An 8 GB L2 clear matching upstream DeepGEMM's `bench_kineto` default runs before every replay and outside its CUDA-event interval. The table reports the median of the ten sample means, and each repeat uses fresh compiler caches.

Pinned reference: DeepGEMM `559d79fb6994a58b8a15b4b93bf13ccc16edf247`, CUTLASS submodule `f3fde58372d33e9a5650ba7b80fc48b3b49d40c8`, and M alignment 224. The only untracked reference-checkout path was DeepGEMM's generated `deep_gemm/include/fmt` directory. Harness SHA256: `484741ae5259f8ce4f2f6216dc25c29def001dcb25b231e555b95998a667271e`.

| Row | Official `(G, M, N, K)` | Actual M/group | R1 Helion us | R1 DeepGEMM us | R1 H/D | R2 Helion us | R2 DeepGEMM us | R2 H/D |
|---:|---|---|---:|---:|---:|---:|---:|---:|
| 0 | `(4, 8192, 6144, 7168)` | `9884, 9459, 7801, 7007` | 2646.708 | 2518.028 | 1.051 | 2677.416 | 2562.513 | 1.045 |
| 1 | `(4, 8192, 7168, 3072)` | `8247, 7724, 9586, 7225` | 1070.407 | 1093.971 | 0.978 | 1081.872 | 1096.028 | 0.987 |
| 2 | `(4, 8192, 4096, 4096)` | `8076, 8601, 10197, 8215` | 872.093 | 877.294 | 0.994 | 873.244 | 880.124 | 0.992 |
| 3 | `(4, 8192, 4096, 2048)` | `7119, 9449, 8773, 6965` | 395.633 | 409.112 | 0.967 | 398.398 | 408.255 | 0.976 |
| 4 | `(8, 4096, 6144, 7168)` | `5102, 5282, 4858, 5084, 3629, 4660, 5076, 4548` | 3051.274 | 3021.418 | 1.010 | 3036.491 | 2995.513 | 1.014 |
| 5 | `(8, 4096, 7168, 3072)` | `4027, 3114, 3934, 4368, 5111, 5242, 4039, 4993` | 1168.279 | 1199.356 | 0.974 | 1166.589 | 1210.240 | 0.964 |
| 6 | `(8, 4096, 4096, 4096)` | `3507, 4845, 4215, 2901, 4635, 3847, 4894, 4509` | 835.664 | 836.549 | 0.999 | 837.359 | 838.471 | 0.999 |
| 7 | `(8, 4096, 4096, 2048)` | `2870, 4080, 4999, 3466, 3666, 5006, 3336, 4261` | 400.494 | 405.255 | 0.988 | 401.995 | 408.534 | 0.984 |

```bash
CUDA_VISIBLE_DEVICES=3 conda run --no-capture-output -n helion \
  python benchmarks/cute/deepgemm_selected_path.py \
  --rows all --compare-deepgemm \
  --deepgemm-root /tmp/DeepGEMM-559d79fb --device cuda \
  --samples 10 --iters 50 --warmups 5 --compile-warmups 2 \
  --thermal-warmup-ms 10000 --l2-flush-bytes 8000000000 \
  --m-alignment 224 --artifact-dir <fresh-output-dir> \
  --json-output <fresh-output-dir>/selected_results.json
```

All correctness checks passed in both final repeats.
