### PR TITLE
Add CuTe launcher support for grouped metadata

### DIFF
--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import collections
 import contextlib
+import contextvars
 import dataclasses
 import logging
 import sys
@@ -293,6 +294,13 @@ class CompileEnvironment:
         # TODO(jansel): check for guards in the shapeenv
         self.fake_mode = FakeTensorMode(shape_env=self.shape_env)
         self.input_sources: dict[torch.Tensor, Source] = {}
+        self._runtime_arg_values_by_name: contextvars.ContextVar[
+            dict[str, object] | None
+        ] = contextvars.ContextVar(
+            f"helion_runtime_arg_values_{id(self)}",
+            default=None,
+        )
+        self.cute_resolved_wrapper_plans: list[dict[str, object]] = []
         self.block_sizes: list[BlockSizeInfo] = []
         self.debug_shape_renames: dict[sympy.Basic, sympy.Basic] = {}
         try:
@@ -387,6 +395,20 @@ class CompileEnvironment:
 
         # TODO(hinriksnaer): tracing flag, not env config. move to CompilerState?
         self.has_barrier: bool = False
+
+    @property
+    def runtime_arg_values_by_name(self) -> dict[str, object]:
+        return self._runtime_arg_values_by_name.get() or {}
+
+    @contextlib.contextmanager
+    def use_runtime_arg_values(
+        self, values: dict[str, object]
+    ) -> typing.Iterator[None]:
+        token = self._runtime_arg_values_by_name.set(values)
+        try:
+            yield
+        finally:
+            self._runtime_arg_values_by_name.reset(token)
 
     def specialize_expr(self, expr: sympy.Expr) -> sympy.Expr:
         """Substitute any specialized vars with their concrete values."""

--- a/helion/_compiler/generate_ast.py
+++ b/helion/_compiler/generate_ast.py
@@ -154,6 +154,12 @@ class GenerateAST(NodeVisitor, CodegenInterface):
         self.grouped_fori_dma_resource_cache: dict[
             tuple[object, ...], tuple[str, str]
         ] = {}
+        self._statements_by_owner_node_id: dict[
+            int, list[tuple[list[ast.AST], ast.AST]]
+        ] = {}
+        self._track_statement_owners = (
+            CompileEnvironment.current().backend.name == "cute"
+        )
 
         # Now create device function and initialize CodegenInterface
         self.device_function = DeviceFunction(
@@ -323,8 +329,21 @@ class GenerateAST(NodeVisitor, CodegenInterface):
         if isinstance(stmt, str):
             stmt = statement_from_string(stmt)
         self.statements_stack[-1].append(stmt)
+        owner_node = self._statement_owner_fx_node
+        if owner_node is not None and self._track_statement_owners:
+            self._statements_by_owner_node_id.setdefault(id(owner_node), []).append(
+                (self.statements_stack[-1], stmt)
+            )
         self._record_statement_thread_references([stmt])
         self._record_tcgen05_owned_statement(stmt)
+
+    def remove_statements_owned_by_nodes(self, nodes: tuple[Node, ...]) -> None:
+        """Remove statements emitted earlier for exactly these FX nodes."""
+        for node in nodes:
+            entries = self._statements_by_owner_node_id.pop(id(node), ())
+            for body, stmt in entries:
+                with contextlib.suppress(ValueError):
+                    body.remove(stmt)
 
     def _record_tcgen05_owned_statement(self, stmt: ast.AST) -> None:
         owner_node = self._statement_owner_fx_node
@@ -1232,11 +1251,15 @@ class GenerateAST(NodeVisitor, CodegenInterface):
         elif isinstance(type_info, SequenceType) and all(
             isinstance(x, TileIndexType) for x in type_info.unpack()
         ):
-            values = type_info.unpack()
+            values = [
+                value
+                for value in type_info.unpack()
+                if isinstance(value, TileIndexType)
+            ]
             return expr_from_string(
                 self.host_function.literal_expr(
                     [
-                        self.device_function.resolved_block_size(x.block_id)  # pyrefly: ignore[missing-attribute]
+                        self.device_function.resolved_block_size(x.block_id)
                         for x in values
                     ]
                 )
@@ -1367,6 +1390,8 @@ def generate_ast(
     extra_params: list[str] | None = None,
 ) -> ast.Module:
     with func:
+        env = CompileEnvironment.current()
+        env.cute_resolved_wrapper_plans = []
         if len(func.device_ir.phases) > 1:
             if not str(config.pid_type).startswith("persistent"):
                 raise exc.BarrierRequiresPersistent(config.pid_type)
@@ -1470,6 +1495,9 @@ def generate_ast(
                     *final_host_statements,
                 ]
             launcher_arg_positions: dict[str, int] | None = None
+            host_arg_positions = {
+                arg.arg: idx for idx, arg in enumerate(func.args.args)
+            }
 
             def resolve_cute_plan_arg_positions(
                 plans: list[dict[str, object]],
@@ -1508,32 +1536,44 @@ def generate_ast(
                         "bias_name",
                         "alibi_name",
                         "document_name",
+                        "layout_name",
+                        "n_sizes_name",
+                        "k_sizes_name",
+                        "direct_pointers_name",
+                        "direct_strides_name",
                     ):
                         if key in resolved:
+                            arg_name = str(resolved.pop(key))
                             resolved[key[:-5] + "_idx"] = launcher_arg_positions[
-                                str(resolved.pop(key))
+                                arg_name
                             ]
+                            if key in {"layout_name", "n_sizes_name"} and (
+                                arg_name in host_arg_positions
+                            ):
+                                resolved[key[:-5] + "_bind_idx"] = host_arg_positions[
+                                    arg_name
+                                ]
                     resolved_plans.append(resolved)
                 return resolved_plans
 
+            post_kernel_metadata_statements: list[ast.AST] = []
             resolved_wrapper_plans: list[dict[str, object]] = []
             if codegen.cute_wrapper_plans:
                 resolved_wrapper_plans = resolve_cute_plan_arg_positions(
                     codegen.cute_wrapper_plans
                 )
-                final_host_statements = [
+                env.cute_resolved_wrapper_plans = resolved_wrapper_plans
+                post_kernel_metadata_statements.append(
                     statement_from_string(
                         f"{codegen.device_function.name}._helion_cute_wrapper_plans = {resolved_wrapper_plans!r}"
-                    ),
-                    *final_host_statements,
-                ]
+                    )
+                )
             if codegen.device_function.cute_state.cluster_shape is not None:
-                final_host_statements = [
+                post_kernel_metadata_statements.append(
                     statement_from_string(
                         f"{codegen.device_function.name}._helion_cute_cluster_shape = {codegen.device_function.cute_state.cluster_shape!r}"
-                    ),
-                    *final_host_statements,
-                ]
+                    )
+                )
             # Assert sourceless prologue params were actually removed by DCE
             if codegen.device_function.sourceless_prologue_params:
                 remaining = codegen.device_function.sourceless_prologue_params & {
@@ -1555,15 +1595,19 @@ def generate_ast(
                 call_def = [func.codegen_call_function()]
                 main_def = [emit_main_def()]
 
-            module_body = [
+            module_body: list[ast.stmt] = []
+            for stmt in (
                 *func.codegen_imports(),
                 *codegen.module_statements,
                 *codegen.device_function.codegen_helper_functions(),
                 *kernel_def,
+                *post_kernel_metadata_statements,
                 host_def,
                 *call_def,
                 *main_def,
-            ]
+            ):
+                assert isinstance(stmt, ast.stmt)
+                module_body.append(stmt)
             result = ast.Module(module_body, [])
             existing_imports = {
                 ast.unparse(stmt)

--- a/helion/autotuner/benchmarking.py
+++ b/helion/autotuner/benchmarking.py
@@ -67,15 +67,16 @@ def _cudagraph_unavailable_reason() -> str | None:
 
 
 def _make_cudagraph_replay(fn: Callable[[], T]) -> Callable[[], T]:
+    from ..runtime import cute_cuda_graph
+
     stream = torch.cuda.Stream()
     with torch.cuda.stream(stream):
         fn()
     torch.cuda.current_stream().wait_stream(stream)
     torch.cuda.synchronize()
 
-    graph = torch.cuda.CUDAGraph()
     static_output: list[T] = []
-    with torch.cuda.graph(graph):
+    with cute_cuda_graph() as graph:
         static_output.append(fn())
     torch.cuda.synchronize()
 

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import base64
+from collections import OrderedDict
+from contextlib import contextmanager
 from contextlib import suppress
+import contextvars
+from dataclasses import dataclass
 import hashlib
 import importlib
 import inspect
@@ -10,8 +14,11 @@ import linecache
 import logging
 import os
 import sys
+from typing import TYPE_CHECKING
 from typing import Any
+from typing import Literal
 from typing import cast
+import weakref
 
 import torch
 
@@ -20,6 +27,12 @@ from .. import exc
 from .._compiler.cute.strategies import tcgen05_default_epilogue_tile_expr
 from .._compiler.cute.strategies import tcgen05_explicit_d_store_tile_expr
 from .._compiler.cute.strategies import tcgen05_smem_layout_expr
+from .._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
+)
+from .._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_MMA_M_TILE
+from .._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE
+from .._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_STORE_SHAPE
 from .config import Config as Config
 from .kernel import Kernel as Kernel
 from .kernel import OutputCodeOptions as OutputCodeOptions
@@ -30,6 +43,11 @@ from .triton.launcher import default_launcher as _triton_default_launcher
 from .triton.launcher import get_num_sm as _triton_get_num_sm
 from .triton.launcher import get_num_xcd as get_num_xcd
 from .triton.launcher import set_triton_allocator as set_triton_allocator
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from torch.cuda import _POOL_HANDLE
 
 log: logging.Logger = logging.getLogger(__name__)
 
@@ -225,6 +243,21 @@ def _cute_kernel_param_is_constexpr(cute_kernel: object) -> tuple[bool, ...]:
     return flags
 
 
+def _tcgen05_grouped_dynamic_ab_tensormap_rank(plan: dict[str, object]) -> int:
+    rank = plan.get("dynamic_ab_tensormap_rank", 3)
+    if (
+        not isinstance(rank, int)
+        or rank not in (2, 3)
+        or (rank == 2 and not bool(plan.get("dynamic_ab_tensormaps")))
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped dynamic A/B TensorMap rank must be 2 or 3, "
+            "and rank 2 requires dynamic A/B TensorMaps",
+        )
+    return rank
+
+
 def _append_cute_wrapper_plan(
     body: list[str],
     call_args: list[str],
@@ -278,8 +311,17 @@ def _append_cute_wrapper_plan(
         d_store_box_n: int | None = None,
         epi_tile_raw_expr: str | None = None,
         tensor_name: str | None = None,
+        rank3_mnl_tensor: bool = False,
+        orientation: str = "mn",
     ) -> None:
         assert len(kernel_args) == 2
+        assert orientation in ("mn", "nm")
+        worklist_nm_store = orientation == "nm"
+        d_store_layout = (
+            "cutlass.utils.layout.LayoutEnum.COL_MAJOR"
+            if worklist_nm_store
+            else "cutlass.utils.layout.LayoutEnum.ROW_MAJOR"
+        )
         tensor_expr = tensor_name if tensor_name is not None else f"arg{tensor_idx}"
         explicit_epi_tile = any(
             value is not None for value in (epi_tile_m, epi_tile_n, d_store_box_n)
@@ -305,12 +347,34 @@ def _append_cute_wrapper_plan(
                 bm,
                 bn,
                 dtype,
-                c_layout="cutlass.utils.layout.LayoutEnum.ROW_MAJOR",
+                c_layout=d_store_layout,
             )
         tma_atom, tma_tensor = kernel_args
         epi_tile = f"{tma_atom}_epi_tile"
         smem_layout = f"{tma_atom}_smem_layout"
         cta_v_layout = f"{tma_atom}_cta_v_layout"
+        gmem_tensor = (
+            f"{tma_atom}_d_nm"
+            if worklist_nm_store and rank3_mnl_tensor
+            else f"{tma_atom}_gmem_mnl"
+            if rank3_mnl_tensor
+            else tensor_expr
+        )
+        cta_tiler_expr = (
+            epi_tile
+            if rank3_mnl_tensor
+            else f"cute.composition(cute.make_identity_layout({gmem_tensor}.shape), {epi_tile})"
+        )
+        rank3_gmem_shape = (
+            f"(arg{tensor_idx}_shape1, arg{tensor_idx}_shape0, 1)"
+            if worklist_nm_store
+            else f"(arg{tensor_idx}_shape0, arg{tensor_idx}_shape1, 1)"
+        )
+        rank3_gmem_stride = (
+            f"(arg{tensor_idx}_stride1, arg{tensor_idx}_stride0, 0)"
+            if worklist_nm_store
+            else f"(arg{tensor_idx}_stride0, arg{tensor_idx}_stride1, 0)"
+        )
         # Keep these layout arguments in sync with the device-side
         # ``make_smem_layout_epi`` calls; the wrapper's TMA atom and the kernel's
         # SMEM staging must slice the same epilogue tile shape.
@@ -320,18 +384,28 @@ def _append_cute_wrapper_plan(
                 (
                     f"    {smem_layout} = cutlass.utils.blackwell_helpers."
                     "make_smem_layout_epi("
-                    f"{dtype}, cutlass.utils.layout.LayoutEnum.ROW_MAJOR, "
+                    f"{dtype}, {d_store_layout}, "
                     f"{epi_tile}, {stage_count})"
                 ),
-                (
-                    f"    {cta_v_layout} = cute.composition("
-                    f"cute.make_identity_layout({tensor_expr}.shape), {epi_tile})"
+                *(
+                    (
+                        (
+                            f"    {gmem_tensor} = cute.make_tensor("
+                            f"arg{tensor_idx}.iterator, "
+                            "layout=cute.make_layout("
+                            f"{rank3_gmem_shape}, stride={rank3_gmem_stride}))"
+                        ),
+                        f"    {gmem_tensor}.mark_layout_dynamic(leading_dim=1)",
+                    )
+                    if rank3_mnl_tensor
+                    else ()
                 ),
+                (f"    {cta_v_layout} = {cta_tiler_expr}"),
                 (
                     f"    {tma_atom}, {tma_tensor} = "
                     "cute.nvgpu.cpasync.make_tiled_tma_atom("
                     f"{copy_op}, "
-                    f"{tensor_expr}, cute.slice_({smem_layout}, (None, None, 0)), "
+                    f"{gmem_tensor}, cute.slice_({smem_layout}, (None, None, 0)), "
                     f"{cta_v_layout})"
                 ),
             )
@@ -621,6 +695,8 @@ def _append_cute_wrapper_plan(
             d_store_box_n=plan_optional_int("d_store_box_n"),
             epi_tile_raw_expr=plan_optional_str("epi_tile_raw_expr"),
             tensor_name=d_tensor_name,
+            rank3_mnl_tensor=bool(plan.get("rank3_mnl_tensor")),
+            orientation=_tcgen05_plan_orientation(plan),
         )
         return
     if kind == "tcgen05_aux_tma":
@@ -640,13 +716,42 @@ def _append_cute_wrapper_plan(
             copy_op="cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp()",
         )
         return
+    if kind == "tcgen05_grouped_static_persistent":
+        assert num_sm is not None and num_sm > 0
+        sched_params_arg = str(plan["sched_params_arg"])
+        total_clusters_arg = str(plan["total_clusters_arg"])
+        cluster_m = plan_int("cluster_m", 1)
+        cluster_n = plan_int("cluster_n", 1)
+        reserved_sms = plan_int(TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY, 0)
+        max_active_clusters = _tcgen05_grouped_static_active_clusters(
+            num_sm=num_sm,
+            cluster_m=max(1, cluster_m),
+            reserved_sms=reserved_sms,
+        )
+        body.extend(
+            (
+                (
+                    f"    {sched_params_arg} = cutlass.utils.PersistentTileSchedulerParams("
+                    f"({cluster_m}, {cluster_n}, {total_clusters_arg}), "
+                    f"({cluster_m}, {cluster_n}, 1))"
+                ),
+                (
+                    "    _tcgen05_grouped_grid = "
+                    "cutlass.utils.StaticPersistentGroupTileScheduler.get_grid_shape("
+                    f"{sched_params_arg}, cutlass.Int32({max_active_clusters}))"
+                ),
+                "    grid_x = _tcgen05_grouped_grid[0]",
+                "    grid_y = _tcgen05_grouped_grid[1]",
+                "    grid_z = _tcgen05_grouped_grid[2]",
+            )
+        )
+        call_args.append(sched_params_arg)
+        return
     if kind != "tcgen05_ab_tma":
         raise exc.BackendUnsupported("cute", f"wrapper plan kind: {kind}")
 
-    lhs_idx_key = "lhs_idx" if "lhs_idx" in plan else "lhsidx"
-    rhs_idx_key = "rhs_idx" if "rhs_idx" in plan else "rhsidx"
-    lhs_idx = plan_int(lhs_idx_key)
-    rhs_idx = plan_int(rhs_idx_key)
+    lhs_idx = plan_int("lhs_idx")
+    rhs_idx = plan_int("rhs_idx")
     bm = plan_int("bm")
     bn = plan_int("bn")
     bk = plan_int("bk")
@@ -673,6 +778,18 @@ def _append_cute_wrapper_plan(
     b_k_major = bool(plan.get("b_k_major"))
     lhs_leading_passthrough = bool(plan.get("lhs_leading_passthrough"))
     rhs_leading_passthrough = bool(plan.get("rhs_leading_passthrough"))
+    rhs_rank3_grouped_nt = bool(plan.get("rhs_rank3_grouped_nt"))
+    lhs_rank3_grouped_nt = bool(plan.get("lhs_rank3_grouped_nt"))
+    orientation = _tcgen05_plan_orientation(plan)
+    swapped_nm = orientation == "nm"
+    dynamic_ab_tensormaps = bool(plan.get("dynamic_ab_tensormaps"))
+    if swapped_nm and not dynamic_ab_tensormaps:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 N,M-oriented A/B TensorMaps without dynamic A/B "
+            "TensorMaps are unsupported",
+        )
+    dynamic_ab_tensormap_rank2 = _tcgen05_grouped_dynamic_ab_tensormap_rank(plan) == 2
     kernel_args = [str(arg) for arg in cast("list[object]", plan["kernel_args"])]
     assert len(kernel_args) == 4
     tma_atom_a, tma_tensor_a, tma_atom_b, tma_tensor_b = kernel_args
@@ -706,8 +823,107 @@ def _append_cute_wrapper_plan(
     smem_a_layout = f"{tma_atom_a}_smem_layout"
     smem_b_layout = f"{tma_atom_b}_smem_layout"
     lhs_tma = f"{tma_atom_a}_lhs_tma"
+    lhs_tma_arg = (
+        lhs_tma
+        if dynamic_ab_tensormaps or swapped_nm or lhs_leading_passthrough
+        else f"arg{lhs_idx}"
+    )
     rhs_tma = f"{tma_atom_b}_rhs_tma"
-    lhs_tma_operand = lhs_tma if lhs_leading_passthrough else f"arg{lhs_idx}"
+    if swapped_nm:
+        if not lhs_rank3_grouped_nt:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 N,M-oriented A/B TensorMaps require grouped rank-3 logical A",
+            )
+        if dynamic_ab_tensormap_rank2:
+            lhs_tma_layout = (
+                f"(arg{lhs_idx}_shape1, arg{lhs_idx}_shape2), "
+                f"stride=(arg{lhs_idx}_stride1, arg{lhs_idx}_stride2)"
+            )
+        else:
+            lhs_tma_layout = (
+                f"(arg{lhs_idx}_shape1, arg{lhs_idx}_shape2, "
+                f"arg{lhs_idx}_shape0), "
+                f"stride=(arg{lhs_idx}_stride1, arg{lhs_idx}_stride2, "
+                f"arg{lhs_idx}_stride0)"
+            )
+        if dynamic_ab_tensormap_rank2 or not dynamic_ab_tensormaps:
+            rhs_tma_layout = (
+                f"(arg{rhs_idx}_shape0, arg{rhs_idx}_shape1), "
+                f"stride=(arg{rhs_idx}_stride0, arg{rhs_idx}_stride1)"
+            )
+        else:
+            rhs_tma_layout = (
+                f"(arg{rhs_idx}_shape0, arg{rhs_idx}_shape1, 1), "
+                f"stride=(arg{rhs_idx}_stride0, arg{rhs_idx}_stride1, 0)"
+            )
+        lhs_tma_setup = (
+            (
+                f"    {lhs_tma} = cute.make_tensor("
+                f"arg{lhs_idx}.iterator, "
+                f"layout=cute.make_layout({lhs_tma_layout}))"
+            ),
+            f"    {lhs_tma}.mark_layout_dynamic(leading_dim=1)",
+        )
+        rhs_tma_setup = (
+            (
+                f"    {rhs_tma} = cute.make_tensor("
+                f"arg{rhs_idx}.iterator, "
+                f"layout=cute.make_layout({rhs_tma_layout}))"
+            ),
+            f"    {rhs_tma}.mark_layout_dynamic(leading_dim=1)",
+        )
+    else:
+        lhs_tma_setup = (
+            (
+                (
+                    f"    {lhs_tma} = cute.make_tensor("
+                    f"arg{lhs_idx}.iterator, "
+                    "layout=cute.make_layout("
+                    + (
+                        f"(arg{lhs_idx}_shape0, arg{lhs_idx}_shape1), "
+                        f"stride=(arg{lhs_idx}_stride0, arg{lhs_idx}_stride1)))"
+                        if dynamic_ab_tensormap_rank2
+                        else (
+                            f"(arg{lhs_idx}_shape0, arg{lhs_idx}_shape1, 1), "
+                            f"stride=(arg{lhs_idx}_stride0, "
+                            f"arg{lhs_idx}_stride1, 0)))"
+                        )
+                    )
+                ),
+                f"    {lhs_tma}.mark_layout_dynamic(leading_dim=1)",
+            )
+            if dynamic_ab_tensormaps
+            else ()
+        )
+        rhs_tma_setup = (
+            (
+                f"    {rhs_tma} = cute.make_tensor("
+                f"arg{rhs_idx}.iterator, "
+                "layout=cute.make_layout("
+                + (
+                    f"(arg{rhs_idx}_shape1, arg{rhs_idx}_shape2), "
+                    f"stride=(arg{rhs_idx}_stride1, arg{rhs_idx}_stride2)))"
+                    if dynamic_ab_tensormap_rank2
+                    else (
+                        f"(arg{rhs_idx}_shape1, arg{rhs_idx}_shape2, "
+                        f"arg{rhs_idx}_shape0), "
+                        f"stride=(arg{rhs_idx}_stride1, arg{rhs_idx}_stride2, "
+                        f"arg{rhs_idx}_stride0)))"
+                    )
+                )
+                if rhs_rank3_grouped_nt
+                else f"    {rhs_tma} = cute.make_tensor("
+                f"arg{rhs_idx}.iterator, "
+                "layout=cute.make_layout("
+                f"(arg{rhs_idx}_shape1, arg{rhs_idx}_shape0), "
+                f"stride=(arg{rhs_idx}_stride1, arg{rhs_idx}_stride0)))"
+            ),
+            (
+                f"    {rhs_tma}.mark_layout_dynamic(leading_dim="
+                f"{1 if dynamic_ab_tensormap_rank2 or rhs_rank3_grouped_nt else (1 if b_k_major else 0)})"
+            ),
+        )
     smem_a_layout_expr = tcgen05_smem_layout_expr(
         tiled_mma=tiled_mma,
         bm=bm,
@@ -733,48 +949,42 @@ def _append_cute_wrapper_plan(
         append_permuted_cute_tensor_view(lhs_tma, lhs_idx, (1, 2, 0))
     if rhs_leading_passthrough:
         append_permuted_cute_tensor_view(rhs_tma, rhs_idx, (2, 1, 0))
-    ab_tma_lines = [
+    lhs_tma_setup_lines = () if lhs_leading_passthrough else lhs_tma_setup
+    rhs_tma_setup_lines = (
+        (f"    {rhs_tma}.mark_layout_dynamic(leading_dim={1 if b_k_major else 0})",)
+        if rhs_leading_passthrough
+        else rhs_tma_setup
+    )
+    body.extend(
         (
-            f"    {tiled_mma} = cutlass.utils.blackwell_helpers.make_trivial_tiled_mma("
-            f"{input_dtype}, "
-            f"{input_dtype}, "
-            "cute.nvgpu.OperandMajorMode.K, "
-            + (
+            (
+                f"    {tiled_mma} = cutlass.utils.blackwell_helpers.make_trivial_tiled_mma("
+                f"{input_dtype}, "
+                f"{input_dtype}, "
                 "cute.nvgpu.OperandMajorMode.K, "
-                if b_k_major
-                else "cute.nvgpu.OperandMajorMode.MN, "
-            )
-            + f"{acc_dtype}, "
-            f"{cta_group}, "
-            f"({bm}, {bn}), "
-            "cute.nvgpu.tcgen05.OperandSource.SMEM)"
-        ),
-        (
-            f"    {cluster_layout_vmnk} = cute.tiled_divide("
-            f"cute.make_layout({cluster_shape}), ({tiled_mma}.thr_id.shape,))"
-        ),
-        f"    {smem_a_layout} = {smem_a_layout_expr}",
-        f"    {smem_b_layout} = {smem_b_layout_expr}",
-    ]
-    if not rhs_leading_passthrough:
-        ab_tma_lines.append(
-            f"    {rhs_tma} = cute.make_tensor("
-            f"arg{rhs_idx}.iterator, "
-            "layout=cute.make_layout("
-            f"(arg{rhs_idx}_shape1, arg{rhs_idx}_shape0), "
-            f"stride=(arg{rhs_idx}_stride1, arg{rhs_idx}_stride0)))"
-        )
-    ab_tma_lines.extend(
-        [
-            # B is viewed as (N, K). For row-major B (MN-major) the N axis
-            # (position 0) is contiguous; for column-major B (K-major, native
-            # fp8 layout) the K axis (position 1) is contiguous.
-            f"    {rhs_tma}.mark_layout_dynamic(leading_dim={1 if b_k_major else 0})",
+                + (
+                    "cute.nvgpu.OperandMajorMode.K, "
+                    if b_k_major
+                    else "cute.nvgpu.OperandMajorMode.MN, "
+                )
+                + f"{acc_dtype}, "
+                f"{cta_group}, "
+                f"({bm}, {bn}), "
+                "cute.nvgpu.tcgen05.OperandSource.SMEM)"
+            ),
+            (
+                f"    {cluster_layout_vmnk} = cute.tiled_divide("
+                f"cute.make_layout({cluster_shape}), ({tiled_mma}.thr_id.shape,))"
+            ),
+            f"    {smem_a_layout} = {smem_a_layout_expr}",
+            f"    {smem_b_layout} = {smem_b_layout_expr}",
+            *lhs_tma_setup_lines,
+            *rhs_tma_setup_lines,
             # ``make_tiled_tma_atom_A`` vs ``_B`` asymmetry:
             # - ``_B`` always passes ``cluster_layout_vmnk.shape`` as
             #   its trailing arg (CuTe's signature for B requires the
             #   cluster shape; the cluster_m=1 cluster_n=1 case still
-            #   passes the 1×1×1 shape harmlessly).
+            #   passes the 1x1x1 shape harmlessly).
             # - ``_A`` only adds the same trailing arg when
             #   ``cluster_n > 1``. For the validated cluster_n=1
             #   paths, A's atom is constructed without the cluster
@@ -787,7 +997,7 @@ def _append_cute_wrapper_plan(
                 f"    {tma_atom_a}, {tma_tensor_a} = cute.nvgpu.make_tiled_tma_atom_A("
                 "cutlass.utils.blackwell_helpers.cluster_shape_to_tma_atom_A("
                 f"{cluster_shape}, {tiled_mma}.thr_id), "
-                f"{lhs_tma_operand}, "
+                f"{lhs_tma_arg}, "
                 f"cute.slice_({smem_a_layout}, (None, None, None, 0)), "
                 f"({bm}, {bn}, {bk}), {tiled_mma}"
                 + (f", {cluster_layout_vmnk}.shape" if cluster_n > 1 else "")
@@ -804,9 +1014,8 @@ def _append_cute_wrapper_plan(
                 f"cute.slice_({smem_b_layout}, (None, None, None, 0)), "
                 f"({bm}, {bn}, {bk}), {tiled_mma}, {cluster_layout_vmnk}.shape)"
             ),
-        ]
+        )
     )
-    body.extend(ab_tma_lines)
     call_args.extend(kernel_args)
 
 
@@ -919,6 +1128,39 @@ def _create_cute_wrapper(
                 f"    arg{i} = cute.make_tensor({ptr_name}, layout=cute.make_layout({shape_tuple}, stride={stride_tuple}))"
             )
             call_args.append(f"arg{i}")
+            continue
+
+        if kind == "wrapper_tensor":
+            (_, name, _dtype, rank, sizes_t, strides_t) = entry
+            assert isinstance(name, str)
+            assert isinstance(rank, int)
+            assert isinstance(sizes_t, tuple) and len(sizes_t) == rank
+            assert isinstance(strides_t, tuple) and len(strides_t) == rank
+            ptr_name = f"{name}_ptr"
+            params.append(f"{ptr_name}: cute.Pointer")
+            shape_literals = [repr(int(s)) for s in sizes_t]
+            stride_literals = [repr(int(s)) for s in strides_t]
+            shape_tuple = (
+                f"({shape_literals[0]},)"
+                if rank == 1
+                else f"({', '.join(shape_literals)})"
+            )
+            stride_tuple = (
+                f"({stride_literals[0]},)"
+                if rank == 1
+                else f"({', '.join(stride_literals)})"
+            )
+            body.append(
+                f"    {name} = cute.make_tensor({ptr_name}, layout=cute.make_layout({shape_tuple}, stride={stride_tuple}))"
+            )
+            call_args.append(name)
+            continue
+
+        if kind == "wrapper_host_scalar":
+            (_, name, scalar_kind) = entry
+            assert isinstance(name, str)
+            assert isinstance(scalar_kind, str)
+            params.append(f"{name}: {_cute_scalar_annotation(scalar_kind)}")
             continue
 
         if kind == "scalar_constexpr":
@@ -1180,6 +1422,7 @@ class _CompiledCuteLauncher:
 
 
 _TVM_FFI_COMPILE_OPTION = "--enable-tvm-ffi"
+_CUTE_NUM_SM_CACHE: dict[tuple[str, int | None], int] = {}
 
 
 def _merge_tvm_ffi_compile_option(compile_options: str | None) -> str:
@@ -1200,6 +1443,40 @@ def _merge_tvm_ffi_compile_option(compile_options: str | None) -> str:
     return " ".join(tokens)
 
 
+def _cute_num_sm_from_arch_args(arch_args: tuple[object, ...] | None) -> int | None:
+    if arch_args is None:
+        return None
+    for arg in arch_args:
+        if isinstance(arg, torch.Tensor) and arg.device.type == "cuda":
+            cache_key = (arg.device.type, arg.device.index)
+            cached = _CUTE_NUM_SM_CACHE.get(cache_key)
+            if cached is None:
+                cached = get_num_sm(arg.device)
+                _CUTE_NUM_SM_CACHE[cache_key] = cached
+            return cached
+    return None
+
+
+def _cute_compiled_launcher_discriminator(
+    schema_key: tuple[tuple[object, ...], ...],
+    block: tuple[int, int, int],
+    compile_options: str | None,
+    arch_args: tuple[object, ...] | None,
+) -> tuple[tuple[object, ...], str, int | None]:
+    merged_compile_options = _merge_tvm_ffi_compile_option(compile_options)
+    num_sm = _cute_num_sm_from_arch_args(arch_args)
+    return (
+        (
+            schema_key,
+            block,
+            merged_compile_options,
+            num_sm,
+        ),
+        merged_compile_options,
+        num_sm,
+    )
+
+
 def _get_compiled_cute_launcher(
     cute_kernel: object,
     schema_key: tuple[tuple[object, ...], ...],
@@ -1214,7 +1491,12 @@ def _get_compiled_cute_launcher(
     # than replace because other flags (e.g. ``--generate-line-info`` when
     # ``tcgen05_cubin_lineinfo`` is True) can already be in
     # ``compile_options``.
-    compile_options = _merge_tvm_ffi_compile_option(compile_options)
+    cache_key, compile_options, num_sm = _cute_compiled_launcher_discriminator(
+        schema_key,
+        block,
+        compile_options,
+        arch_args,
+    )
     try:
         # pyrefly: ignore [missing-attribute]
         cache = cute_kernel._helion_cute_compiled_launchers
@@ -1222,36 +1504,19 @@ def _get_compiled_cute_launcher(
         cache = {}
         # pyrefly: ignore [missing-attribute]
         cute_kernel._helion_cute_compiled_launchers = cache
-    wrapper_plans = tuple(
-        repr(plan)
-        for plan in getattr(cast("Any", cute_kernel), "_helion_cute_wrapper_plans", [])
-    )
-    cluster_shape = getattr(
-        cast("Any", cute_kernel), "_helion_cute_cluster_shape", None
-    )
-    # Persistent flash kernels bake the device SM count into the wrapper grid
-    # clamp; resolve it from the first tensor arg's device so the cache key (and
-    # the baked literal) stay device-correct across GPUs.
-    num_sm: int | None = None
-    if arch_args is not None:
-        for arg in arch_args:
-            if isinstance(arg, torch.Tensor) and arg.device.type == "cuda":
-                num_sm = get_num_sm(arg.device)
-                break
-    cache_key = (
-        schema_key,
-        block,
-        wrapper_plans,
-        repr(cluster_shape),
-        compile_options,
-        num_sm,
-    )
     cached = cache.get(cache_key)
     if cached is not None:
         return cached
 
     if arch_args is not None:
         _ensure_cute_dsl_arch_env(arch_args)
+    wrapper_plans = tuple(
+        repr(plan)
+        for plan in getattr(cast("Any", cute_kernel), "_helion_cute_wrapper_plans", ())
+    )
+    cluster_shape = getattr(
+        cast("Any", cute_kernel), "_helion_cute_cluster_shape", None
+    )
     jit_func = _create_cute_wrapper(cute_kernel, schema_key, block, num_sm=num_sm)
     disk_cache_key = _cute_disk_cache_key(
         cute_kernel,
@@ -1381,6 +1646,288 @@ def _cute_current_stream() -> object:
 # Keep the per-kernel launch-argument cache small: production kernels normally
 # relaunch one or two stable tensor signatures, while autotune may probe many.
 _CUTE_LAUNCH_ARG_CACHE_LIMIT = 8
+_TCGEN05_GROUPED_STATIC_METADATA_CACHE_LIMIT = 8
+_TCGEN05_DYNAMIC_TENSORMAP_WORKSPACE_CACHE_LIMIT = 8
+
+_CuteGroupedLaunchContext = tuple[str, int | None, int, int | None]
+
+
+@dataclass
+class _CuteCudaGraphResources:
+    cache_entries: dict[tuple[int, str, object], tuple[object, str, object, object]]
+    tensors: dict[int, torch.Tensor]
+    devices: set[torch.device]
+    streams: set[torch.cuda.Stream]
+
+    def retain(
+        self,
+        owner: object,
+        attribute: str,
+        key: object,
+        value: object,
+        tensors: tuple[torch.Tensor, ...],
+    ) -> None:
+        self.cache_entries[(id(owner), attribute, key)] = (
+            owner,
+            attribute,
+            key,
+            value,
+        )
+        for tensor in tensors:
+            self.tensors[id(tensor)] = tensor
+            self.devices.add(tensor.device)
+            stream = torch.cuda.current_stream(tensor.device)
+            tensor.record_stream(stream)
+            self.streams.add(stream)
+
+    def record_replay_streams(self) -> None:
+        for device in self.devices:
+            stream = torch.cuda.current_stream(device)
+            if stream not in self.streams:
+                for tensor in self.tensors.values():
+                    if tensor.device == device:
+                        tensor.record_stream(stream)
+                self.streams.add(stream)
+
+    def release(self) -> None:
+        for owner, attribute, key, value in self.cache_entries.values():
+            cache = getattr(owner, attribute, None)
+            if isinstance(cache, dict) and cache.get(key) is value:
+                cache.pop(key)
+        self.cache_entries.clear()
+        self.tensors.clear()
+        self.devices.clear()
+        self.streams.clear()
+
+
+class _CuteCUDAGraph(torch.cuda.CUDAGraph):
+    def __init__(self) -> None:
+        super().__init__()
+        self._helion_resources = _CuteCudaGraphResources({}, {}, set(), set())
+        self._helion_resource_finalizer = weakref.finalize(
+            self, self._helion_resources.release
+        )
+
+    def replay(self) -> None:
+        self._helion_resources.record_replay_streams()
+        super().replay()
+
+
+_CUTE_ACTIVE_CUDA_GRAPH: contextvars.ContextVar[_CuteCUDAGraph | None] = (
+    contextvars.ContextVar("helion_cute_active_cuda_graph", default=None)
+)
+
+
+def _track_cute_cuda_graph_cache_entry(
+    owner: object,
+    attribute: str,
+    key: object,
+    value: object,
+    tensors: tuple[torch.Tensor, ...],
+) -> None:
+    graph = _CUTE_ACTIVE_CUDA_GRAPH.get()
+    if graph is None:
+        # Raw torch.cuda.graph callers are conservatively retained because the
+        # CUDA capture ID does not expose the owning Python CUDAGraph lifetime.
+        return
+    graph._helion_resources.retain(
+        owner,
+        attribute,
+        key,
+        value,
+        tensors,
+    )
+
+
+@contextmanager
+def cute_cuda_graph(
+    *,
+    pool: _POOL_HANDLE | None = None,
+    stream: torch.cuda.Stream | None = None,
+    capture_error_mode: str = "global",
+) -> Iterator[_CuteCUDAGraph]:
+    """Capture CuTe launches while tying raw-pointer owners to ``graph``.
+
+    Raw ``torch.cuda.graph`` captures cannot expose their Python graph owner to
+    the launcher, so their resources are conservatively retained without bound.
+    """
+    graph = _CuteCUDAGraph()
+    token = _CUTE_ACTIVE_CUDA_GRAPH.set(graph)
+    try:
+        with torch.cuda.graph(
+            graph,
+            pool=pool,
+            stream=stream,
+            capture_error_mode=capture_error_mode,
+        ):
+            yield graph
+    finally:
+        _CUTE_ACTIVE_CUDA_GRAPH.reset(token)
+
+
+@dataclass(frozen=True)
+class _Tcgen05GroupedStaticMetadataResult:
+    problem_sizes: torch.Tensor
+    starts: torch.Tensor
+    total_clusters: int
+    real_groups: torch.Tensor | None = None
+    direct_pointers: torch.Tensor | None = None
+    direct_strides: torch.Tensor | None = None
+
+    def tensors(self) -> tuple[torch.Tensor, ...]:
+        return (
+            self.problem_sizes,
+            self.starts,
+            *((self.real_groups,) if self.real_groups is not None else ()),
+            *((self.direct_pointers,) if self.direct_pointers is not None else ()),
+            *((self.direct_strides,) if self.direct_strides is not None else ()),
+        )
+
+
+@dataclass(frozen=True)
+class _Tcgen05GroupedStaticMetadataCacheEntry:
+    layout_ref: weakref.ReferenceType[torch.Tensor]
+    n_sizes_ref: weakref.ReferenceType[torch.Tensor] | None
+    k_sizes_ref: weakref.ReferenceType[torch.Tensor] | None
+    has_m_tail: bool
+    has_n_tail: bool
+    result: _Tcgen05GroupedStaticMetadataResult
+
+    def matches(
+        self,
+        layout: torch.Tensor,
+        n_sizes: torch.Tensor | None,
+        k_sizes: torch.Tensor | None,
+    ) -> bool:
+        if self.layout_ref() is not layout:
+            return False
+        if self.n_sizes_ref is None:
+            if n_sizes is not None:
+                return False
+        elif self.n_sizes_ref() is not n_sizes:
+            return False
+        if self.k_sizes_ref is None:
+            return k_sizes is None
+        return self.k_sizes_ref() is k_sizes
+
+
+@dataclass(frozen=True)
+class _CuteLaunchArgCacheEntry:
+    schema: tuple[tuple[object, ...], ...]
+    launch_args: tuple[object, ...]
+    grouped_static_metadata: tuple[_Tcgen05GroupedStaticMetadataCacheEntry, ...]
+    owned_tensors: tuple[torch.Tensor, ...]
+
+
+@dataclass(frozen=True)
+class _CuteLastLaunchCacheEntry:
+    arg_guard: _CuteLastLaunchArgGuard
+    compiled_discriminator: tuple[object, ...]
+    launch: _CuteLaunchArgCacheEntry
+    compiled: object
+
+
+@dataclass(frozen=True)
+class _CuteLastTensorArgGuard:
+    index: int
+    data_ptr: int
+    device_type: str
+    device_index: int | None
+    dtype: torch.dtype
+    ndim: int
+    shape: tuple[int, ...]
+    stride: tuple[int, ...]
+
+    def matches(self, args: tuple[object, ...]) -> bool:
+        if self.index >= len(args) or not isinstance(args[self.index], torch.Tensor):
+            return False
+        tensor = args[self.index]
+        assert isinstance(tensor, torch.Tensor)
+        return (
+            int(tensor.data_ptr()) == self.data_ptr
+            and tensor.device.type == self.device_type
+            and tensor.device.index == self.device_index
+            and tensor.dtype == self.dtype
+            and tensor.ndim == self.ndim
+            and tensor.size() == self.shape
+            and tensor.stride() == self.stride
+        )
+
+
+@dataclass(frozen=True)
+class _CuteLastScalarArgGuard:
+    index: int
+    is_constexpr: bool
+    scalar_kind: str
+    scalar_value: object
+
+    def matches(
+        self,
+        args: tuple[object, ...],
+        constexpr_flags: tuple[bool, ...],
+    ) -> bool:
+        if self.index >= len(args):
+            return False
+        arg = args[self.index]
+        if isinstance(arg, torch.Tensor):
+            return False
+        scalar_kind, scalar_value = _normalize_cute_scalar(arg)
+        is_constexpr = self.index < len(constexpr_flags) and constexpr_flags[self.index]
+        return (
+            is_constexpr == self.is_constexpr
+            and scalar_kind == self.scalar_kind
+            and _cute_scalar_cache_value(scalar_kind, scalar_value) == self.scalar_value
+        )
+
+
+@dataclass(frozen=True)
+class _CuteLastGroupedMutationGuard:
+    index: int
+    tensor_id: int
+    mutation_key: tuple[object, ...]
+
+    def matches(self, args: tuple[object, ...]) -> bool:
+        if self.index >= len(args) or not isinstance(args[self.index], torch.Tensor):
+            return False
+        tensor = args[self.index]
+        assert isinstance(tensor, torch.Tensor)
+        return (
+            id(tensor) == self.tensor_id
+            and _tcgen05_grouped_tensor_mutation_key(tensor) == self.mutation_key
+        )
+
+
+@dataclass(frozen=True)
+class _CuteLastLaunchArgGuard:
+    arg_count: int
+    grid: tuple[int, int, int]
+    bake_tensor_shapes: bool
+    arg_guards: tuple[_CuteLastTensorArgGuard | _CuteLastScalarArgGuard, ...]
+    grouped_mutation_guards: tuple[_CuteLastGroupedMutationGuard, ...]
+    grouped_launch_contexts: tuple[_CuteGroupedLaunchContext, ...]
+
+    def matches(
+        self,
+        cute_kernel: object,
+        args: tuple[object, ...],
+        grid: tuple[int, int, int],
+    ) -> bool:
+        if (
+            len(args) != self.arg_count
+            or grid != self.grid
+            or _cute_bake_tensor_shapes_guard(cute_kernel) != self.bake_tensor_shapes
+            or _cute_grouped_launch_contexts(cute_kernel, args)
+            != self.grouped_launch_contexts
+        ):
+            return False
+        constexpr_flags = _cute_kernel_param_is_constexpr(cute_kernel)
+        for guard in self.arg_guards:
+            if isinstance(guard, _CuteLastTensorArgGuard):
+                if not guard.matches(args):
+                    return False
+            elif not guard.matches(args, constexpr_flags):
+                return False
+        return all(guard.matches(args) for guard in self.grouped_mutation_guards)
 
 
 def _cute_scalar_cache_value(scalar_kind: str, scalar_value: object) -> object:
@@ -1394,13 +1941,1280 @@ def _validate_cute_launcher_tensor(arg: torch.Tensor) -> None:
         raise exc.BackendUnsupported("cute", "launcher requires tensor rank >= 1")
 
 
+def _validate_tcgen05_grouped_tensor_devices(
+    layout: torch.Tensor,
+    args: tuple[object, ...],
+) -> None:
+    mismatched_indices = [
+        index
+        for index, arg in enumerate(args)
+        if isinstance(arg, torch.Tensor) and arg.device != layout.device
+    ]
+    if mismatched_indices:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped scheduler requires every tensor argument to be on "
+            f"{layout.device}; mismatched argument indices: {mismatched_indices}",
+        )
+
+
+def _tcgen05_grouped_static_plans(cute_kernel: object) -> list[dict[str, object]]:
+    return [
+        cast("dict[str, object]", plan)
+        for plan in getattr(cast("Any", cute_kernel), "_helion_cute_wrapper_plans", [])
+        if cast("dict[str, object]", plan).get("kind")
+        == "tcgen05_grouped_static_persistent"
+    ]
+
+
+def _cute_grouped_static_metadata_matches(
+    grouped_static_metadata: tuple[_Tcgen05GroupedStaticMetadataCacheEntry, ...],
+    cute_kernel: object,
+    args: tuple[object, ...],
+) -> bool:
+    plans = _tcgen05_grouped_static_plans(cute_kernel)
+    if len(grouped_static_metadata) != len(plans):
+        return False
+    for plan, entry in zip(plans, grouped_static_metadata, strict=True):
+        layout = _tcgen05_grouped_static_layout_arg(plan, args)
+        n_sizes_arg = _tcgen05_grouped_static_size_arg(plan, args, "n_sizes")
+        k_sizes_arg = _tcgen05_grouped_static_size_arg(plan, args, "k_sizes")
+        if not entry.matches(layout, n_sizes_arg, k_sizes_arg):
+            return False
+        expected_has_m_tail = plan.get("grouped_static_has_m_tail")
+        if isinstance(expected_has_m_tail, bool) and (
+            entry.has_m_tail != expected_has_m_tail
+        ):
+            return False
+        expected_has_n_tail = plan.get("grouped_static_has_n_tail")
+        if isinstance(expected_has_n_tail, bool) and (
+            entry.has_n_tail != expected_has_n_tail
+        ):
+            return False
+    return True
+
+
+def _tcgen05_grouped_static_active_clusters(
+    *,
+    num_sm: int,
+    cluster_m: int,
+    reserved_sms: int,
+) -> int:
+    if num_sm <= 0:
+        raise ValueError("num_sm must be positive")
+    if cluster_m <= 0:
+        raise ValueError("cluster_m must be positive")
+    if reserved_sms < 0:
+        raise ValueError("reserved_sms must be non-negative")
+    active_sms = max(1, num_sm - reserved_sms)
+    return max(1, active_sms // cluster_m)
+
+
+def _plan_int_value(plan: dict[str, object], key: str) -> int:
+    value = plan[key]
+    assert isinstance(value, int)
+    return value
+
+
+def _plan_str_value(plan: dict[str, object], key: str) -> str:
+    value = plan[key]
+    assert isinstance(value, str)
+    return value
+
+
+def _tcgen05_plan_orientation(plan: dict[str, object]) -> str:
+    orientation = plan.get("orientation", "mn")
+    if orientation not in ("mn", "nm"):
+        raise exc.BackendUnsupported(
+            "cute", f"unsupported tcgen05 plan orientation {orientation!r}"
+        )
+    return cast("str", orientation)
+
+
+def _cuda_stream_capture_context(device: torch.device) -> tuple[int, int | None]:
+    """Return the current stream and its active capture ID, if any."""
+    cuda_runtime = importlib.import_module("cuda.bindings.runtime")
+    with torch.cuda.device(device):
+        stream_handle = int(torch.cuda.current_stream().cuda_stream)
+        capture_info = cuda_runtime.cudaStreamGetCaptureInfo(
+            cuda_runtime.cudaStream_t(stream_handle)
+        )
+    error = capture_info[0]
+    status = capture_info[1]
+    if error != cuda_runtime.cudaError_t.cudaSuccess:
+        raise exc.BackendUnsupported(
+            "cute",
+            f"failed to query the CUDA stream capture context: {error}",
+        )
+    if status == cuda_runtime.cudaStreamCaptureStatus.cudaStreamCaptureStatusNone:
+        return stream_handle, None
+    if status == cuda_runtime.cudaStreamCaptureStatus.cudaStreamCaptureStatusActive:
+        return stream_handle, int(capture_info[2])
+    raise exc.BackendUnsupported(
+        "cute", "the current CUDA stream capture has been invalidated"
+    )
+
+
+def _tcgen05_grouped_dynamic_tensormap_workspace(
+    cute_kernel: object,
+    *,
+    device: torch.device,
+    tensormap_count: int,
+) -> torch.Tensor:
+    num_sm = get_num_sm(device)
+    stream_handle, capture_id = _cuda_stream_capture_context(device)
+    cache_key = (
+        device.type,
+        device.index,
+        num_sm,
+        tensormap_count,
+        stream_handle,
+        capture_id,
+    )
+    # A captured graph embeds this raw pointer and can outlive the launch LRU.
+    # cute_cuda_graph ties tracked entries to graph lifetime; raw captures stay
+    # conservatively retained by this cache because their graph is unobservable.
+    try:
+        cache = cast(
+            "OrderedDict[tuple[object, ...], torch.Tensor]",
+            cast("Any", cute_kernel)._helion_tcgen05_dynamic_tensormap_workspace_cache,
+        )
+    except AttributeError:
+        cache = OrderedDict()
+        cast(
+            "Any", cute_kernel
+        )._helion_tcgen05_dynamic_tensormap_workspace_cache = cache
+    workspace = cache.get(cache_key)
+    if workspace is not None:
+        return workspace
+    workspace = torch.empty(
+        (num_sm, tensormap_count, 128 // 8),
+        dtype=torch.int64,
+        device=device,
+    )
+    cache[cache_key] = workspace
+    if capture_id is not None:
+        _track_cute_cuda_graph_cache_entry(
+            cute_kernel,
+            "_helion_tcgen05_dynamic_tensormap_workspace_cache",
+            cache_key,
+            workspace,
+            (workspace,),
+        )
+    else:
+        eager_keys = [key for key in cache if key[-1] is None]
+        while len(eager_keys) > _TCGEN05_DYNAMIC_TENSORMAP_WORKSPACE_CACHE_LIMIT:
+            cache.pop(eager_keys.pop(0))
+    return workspace
+
+
+def _tcgen05_grouped_static_layout_arg(
+    plan: dict[str, object],
+    args: tuple[object, ...],
+) -> torch.Tensor:
+    layout_idx = _plan_int_value(plan, "layout_idx")
+    if layout_idx >= len(args) or not isinstance(args[layout_idx], torch.Tensor):
+        raise exc.BackendUnsupported(
+            "cute", "tcgen05 grouped scheduler layout argument is not a tensor"
+        )
+    layout = args[layout_idx]
+    assert isinstance(layout, torch.Tensor)
+    if layout.device.type != "cuda":
+        raise exc.BackendUnsupported(
+            "cute", "tcgen05 grouped scheduler layout must be a CUDA tensor"
+        )
+    worklist_metadata = bool(plan.get("worklist_metadata"))
+    if worklist_metadata:
+        if layout.ndim != 2 or layout.size(1) != 4:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped worklist scheduler metadata must have shape [W, 4]",
+            )
+    elif layout.ndim != 1:
+        raise exc.BackendUnsupported(
+            "cute", "tcgen05 grouped scheduler layout must be rank 1"
+        )
+    if layout.dtype not in (torch.int32, torch.int64):
+        raise exc.BackendUnsupported(
+            "cute", "tcgen05 grouped scheduler layout must be int32 or int64"
+        )
+    return layout
+
+
+def _cute_dynamic_tensormap_contexts(
+    cute_kernel: object,
+    args: tuple[object, ...],
+) -> tuple[_CuteGroupedLaunchContext, ...]:
+    """Return stream/capture contexts that isolate mutable TensorMaps."""
+    contexts: list[_CuteGroupedLaunchContext] = []
+    for plan in _tcgen05_grouped_static_plans(cute_kernel):
+        if not (
+            bool(plan.get("dynamic_ab_tensormaps"))
+            or bool(plan.get("dynamic_d_tensormap"))
+        ):
+            continue
+        layout = _tcgen05_grouped_static_layout_arg(plan, args)
+        stream_handle, capture_id = _cuda_stream_capture_context(layout.device)
+        contexts.append(
+            (layout.device.type, layout.device.index, stream_handle, capture_id)
+        )
+    return tuple(contexts)
+
+
+def _cute_grouped_launch_contexts(
+    cute_kernel: object,
+    args: tuple[object, ...],
+    *,
+    dynamic_tensormap_contexts: tuple[_CuteGroupedLaunchContext, ...] | None = None,
+) -> tuple[_CuteGroupedLaunchContext, ...]:
+    """Return contexts that isolate mutable or capture-owned launch tensors."""
+    if dynamic_tensormap_contexts is None:
+        dynamic_tensormap_contexts = _cute_dynamic_tensormap_contexts(cute_kernel, args)
+    contexts = list(dynamic_tensormap_contexts)
+    contexts_by_device = {
+        (context[0], context[1]): context for context in dynamic_tensormap_contexts
+    }
+    for plan in _tcgen05_grouped_static_plans(cute_kernel):
+        if plan.get("dynamic_ab_tensormaps") or plan.get("dynamic_d_tensormap"):
+            continue
+        layout = _tcgen05_grouped_static_layout_arg(plan, args)
+        device_key = (layout.device.type, layout.device.index)
+        context = contexts_by_device.get(device_key)
+        if context is None:
+            stream_handle, capture_id = _cuda_stream_capture_context(layout.device)
+            context = (*device_key, stream_handle, capture_id)
+            contexts_by_device[device_key] = context
+        if context[3] is None:
+            # Static grouped metadata is read-only across eager streams, so
+            # keep the existing bounded shared cache on the eager hot path.
+            continue
+        if context not in contexts:
+            contexts.append(context)
+    return tuple(contexts)
+
+
+def _tcgen05_grouped_static_size_arg(
+    plan: dict[str, object],
+    args: tuple[object, ...],
+    name: Literal["n_sizes", "k_sizes"],
+) -> torch.Tensor | None:
+    index = plan.get(f"{name}_idx")
+    if index is None:
+        return None
+    assert isinstance(index, int)
+    if index >= len(args) or not isinstance(args[index], torch.Tensor):
+        raise exc.BackendUnsupported(
+            "cute", f"tcgen05 grouped scheduler {name} argument is not a tensor"
+        )
+    tensor = args[index]
+    assert isinstance(tensor, torch.Tensor)
+    if tensor.device.type != "cuda":
+        raise exc.BackendUnsupported(
+            "cute", f"tcgen05 grouped scheduler {name} must be a CUDA tensor"
+        )
+    if tensor.ndim != 1:
+        raise exc.BackendUnsupported(
+            "cute", f"tcgen05 grouped scheduler {name} must be rank 1"
+        )
+    if tensor.dtype not in (torch.int32, torch.int64):
+        raise exc.BackendUnsupported(
+            "cute", f"tcgen05 grouped scheduler {name} must be int32 or int64"
+        )
+    return tensor
+
+
+def _tcgen05_grouped_dynamic_ab_tensor_arg(
+    plan: dict[str, object],
+    args: tuple[object, ...],
+    key: str,
+    operand: str,
+) -> torch.Tensor:
+    idx = plan.get(key)
+    if (
+        not isinstance(idx, int)
+        or idx >= len(args)
+        or not isinstance(args[idx], torch.Tensor)
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            f"tcgen05 grouped dynamic A/B TensorMaps require tensor operand {operand}",
+        )
+    tensor = args[idx]
+    assert isinstance(tensor, torch.Tensor)
+    if tensor.device.type != "cuda":
+        raise exc.BackendUnsupported(
+            "cute",
+            f"tcgen05 grouped dynamic A/B TensorMap operand {operand} must be CUDA",
+        )
+    return tensor
+
+
+def _tcgen05_grouped_external_direct_tensor_arg(
+    plan: dict[str, object],
+    args: tuple[object, ...],
+    *,
+    key: str,
+    tensor_name: str,
+    dtype: torch.dtype,
+    ndim: int,
+) -> torch.Tensor:
+    idx = plan.get(key)
+    if (
+        not isinstance(idx, int)
+        or idx >= len(args)
+        or not isinstance(args[idx], torch.Tensor)
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            f"tcgen05 grouped external direct metadata requires {tensor_name} tensor",
+        )
+    tensor = args[idx]
+    assert isinstance(tensor, torch.Tensor)
+    if tensor.device.type != "cuda":
+        raise exc.BackendUnsupported(
+            "cute",
+            f"tcgen05 grouped external direct metadata {tensor_name} must be CUDA",
+        )
+    if tensor.dtype != dtype:
+        raise exc.BackendUnsupported(
+            "cute",
+            f"tcgen05 grouped external direct metadata {tensor_name} dtype must be "
+            f"{dtype}",
+        )
+    if tensor.ndim != ndim:
+        raise exc.BackendUnsupported(
+            "cute",
+            f"tcgen05 grouped external direct metadata {tensor_name} must be "
+            f"rank {ndim}",
+        )
+    return tensor
+
+
+def _tcgen05_grouped_external_direct_metadata_args(
+    plan: dict[str, object],
+    args: tuple[object, ...],
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    if not bool(plan.get("external_direct_pointer_metadata")):
+        return None
+    pointers = _tcgen05_grouped_external_direct_tensor_arg(
+        plan,
+        args,
+        key="direct_pointers_idx",
+        tensor_name="direct_pointers",
+        dtype=torch.int64,
+        ndim=2,
+    )
+    strides = _tcgen05_grouped_external_direct_tensor_arg(
+        plan,
+        args,
+        key="direct_strides_idx",
+        tensor_name="direct_strides",
+        dtype=torch.int32,
+        ndim=3,
+    )
+    if strides.device != pointers.device:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped external direct metadata pointers and strides "
+            "must be on the same CUDA device",
+        )
+    return pointers, strides
+
+
+def _tcgen05_grouped_external_direct_cache_key(
+    plan: dict[str, object],
+    args: tuple[object, ...] | None,
+) -> tuple[object, ...]:
+    if args is None or not bool(plan.get("external_direct_pointer_metadata")):
+        return ()
+    metadata_args = _tcgen05_grouped_external_direct_metadata_args(plan, args)
+    assert metadata_args is not None
+    pointers, strides = metadata_args
+    return (
+        *_tcgen05_grouped_tensor_cache_key(
+            "direct_pointers", pointers, include_version=True
+        ),
+        *_tcgen05_grouped_tensor_cache_key(
+            "direct_strides", strides, include_version=True
+        ),
+    )
+
+
+def _tcgen05_grouped_direct_d_idx(
+    cute_kernel: object,
+    _plan: dict[str, object],
+) -> int:
+    d_plans = [
+        cast("dict[str, object]", candidate)
+        for candidate in getattr(
+            cast("Any", cute_kernel), "_helion_cute_wrapper_plans", ()
+        )
+        if cast("dict[str, object]", candidate).get("kind") == "tcgen05_d_tma"
+        and bool(cast("dict[str, object]", candidate).get("rank3_mnl_tensor"))
+    ]
+    if len(d_plans) != 1:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped direct pointer metadata requires exactly one "
+            "rank-3 grouped D TensorMap wrapper plan",
+        )
+    d_idx = d_plans[0].get("d_idx")
+    if not isinstance(d_idx, int):
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped direct pointer metadata D TensorMap plan is missing "
+            "the output tensor index",
+        )
+    return d_idx
+
+
+def _tcgen05_grouped_direct_d_tensor_arg(
+    cute_kernel: object,
+    plan: dict[str, object],
+    args: tuple[object, ...],
+) -> torch.Tensor:
+    d_idx = _tcgen05_grouped_direct_d_idx(cute_kernel, plan)
+    if d_idx >= len(args) or not isinstance(args[d_idx], torch.Tensor):
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped direct pointer metadata requires tensor operand D",
+        )
+    tensor = args[d_idx]
+    assert isinstance(tensor, torch.Tensor)
+    if tensor.device.type != "cuda":
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped direct pointer metadata operand D must be CUDA",
+        )
+    return tensor
+
+
+def _tcgen05_grouped_tensor_cache_key(
+    label: str,
+    tensor: torch.Tensor,
+    *,
+    include_version: bool = False,
+) -> tuple[object, ...]:
+    return (
+        label,
+        id(tensor),
+        int(tensor.data_ptr()),
+        tuple(int(size) for size in tensor.shape),
+        tuple(int(stride) for stride in tensor.stride()),
+        int(tensor.storage_offset()),
+        tensor.device.type,
+        tensor.device.index,
+        str(tensor.dtype),
+        *(_tcgen05_grouped_tensor_mutation_key(tensor) if include_version else ()),
+    )
+
+
+def _tcgen05_grouped_tensor_mutation_key(
+    tensor: torch.Tensor,
+) -> tuple[object, ...]:
+    if not torch.is_inference(tensor):
+        return ("version", int(tensor._version))
+    if (
+        tensor.device.type == "cuda"
+        and _cuda_stream_capture_context(tensor.device)[1] is not None
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            "inference tensor grouped metadata is unsupported during CUDA graph "
+            "capture; use ordinary tensors with stable version counters",
+        )
+    return ("values", tuple(tensor.detach().reshape(-1).cpu().tolist()))
+
+
+def _validate_tcgen05_grouped_direct_d_tensormap(
+    tensor: torch.Tensor,
+) -> None:
+    if tensor.ndim != 2:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped direct pointer metadata requires rank-2 D",
+        )
+    if any(
+        int(stride) < 0 or int(stride) > torch.iinfo(torch.int32).max
+        for stride in tensor.stride()
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped direct pointer metadata requires non-negative "
+            "int32 D strides",
+        )
+    alignment = 16
+    if int(tensor.data_ptr()) % alignment != 0:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped direct pointer metadata requires 16-byte-aligned D",
+        )
+    if int(tensor.stride(0)) * tensor.element_size() % alignment != 0:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped direct pointer metadata requires 16-byte-aligned "
+            "D row starts",
+        )
+
+
+def _validate_tcgen05_grouped_dynamic_ab_tensormaps(
+    plan: dict[str, object],
+    args: tuple[object, ...],
+) -> None:
+    lhs = _tcgen05_grouped_dynamic_ab_tensor_arg(plan, args, "lhs_idx", "A")
+    rhs = _tcgen05_grouped_dynamic_ab_tensor_arg(plan, args, "rhs_idx", "B")
+    rank = _tcgen05_grouped_dynamic_ab_tensormap_rank(plan)
+    if lhs.ndim != 2:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped dynamic A/B TensorMaps require rank-2 A",
+        )
+    if rhs.ndim != 3:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped dynamic A/B TensorMaps require rank-3 grouped B",
+        )
+    if lhs.stride(1) != 1:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped dynamic A/B TensorMaps require K-contiguous A",
+        )
+    if rhs.stride(2) != 1:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped dynamic A/B TensorMaps require K-contiguous grouped B",
+        )
+    if rank == 2:
+        if lhs.stride(0) != lhs.size(1):
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped rank-2 dynamic A/B TensorMaps require "
+                "contiguous A[M,K] outer stride",
+            )
+        if rhs.stride(1) != rhs.size(2) or rhs.stride(0) != rhs.size(1) * rhs.size(2):
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped rank-2 dynamic A/B TensorMaps require "
+                "contiguous B[G,N,K] outer strides",
+            )
+    alignment = 16
+    lhs_stride0_bytes = int(lhs.stride(0)) * lhs.element_size()
+    rhs_stride0_bytes = int(rhs.stride(0)) * rhs.element_size()
+    rhs_stride1_bytes = int(rhs.stride(1)) * rhs.element_size()
+    if (
+        int(lhs.data_ptr()) % alignment != 0
+        or int(rhs.data_ptr()) % alignment != 0
+        or lhs_stride0_bytes % alignment != 0
+        or rhs_stride0_bytes % alignment != 0
+        or rhs_stride1_bytes % alignment != 0
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped dynamic A/B TensorMaps require 16-byte-aligned "
+            "A/B bases and outer strides",
+        )
+
+
+def _validate_tcgen05_grouped_worklist_nm(
+    plan: dict[str, object],
+    args: tuple[object, ...],
+    rows: list[list[int]],
+) -> None:
+    if _tcgen05_plan_orientation(plan) != "nm":
+        return
+    lhs = _tcgen05_grouped_dynamic_ab_tensor_arg(plan, args, "lhs_idx", "A")
+    rhs = _tcgen05_grouped_dynamic_ab_tensor_arg(plan, args, "rhs_idx", "B")
+    source_m_tile = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE
+    expected_store_end = 0
+    seen_groups: set[int] = set()
+    for row in rows:
+        real_group, start, actual_m, aligned_m = (int(value) for value in row)
+        if real_group < 0 or real_group >= int(rhs.size(0)):
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 N,M worklist real group id is outside B_grouped",
+            )
+        if real_group in seen_groups:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 N,M worklist requires unique real group ids",
+            )
+        seen_groups.add(real_group)
+        if start < 0 or start % source_m_tile != 0:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 N,M worklist requires group starts aligned "
+                f"to {source_m_tile} rows",
+            )
+        if start < expected_store_end:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 N,M worklist has overlapping A rows",
+            )
+        if start > expected_store_end:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 N,M worklist has row holes",
+            )
+        if actual_m <= 0 or actual_m > aligned_m:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 N,M worklist requires 0 < actual_m <= aligned_m",
+            )
+        if aligned_m <= 0 or aligned_m % source_m_tile != 0:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 N,M worklist requires aligned_m to be a "
+                f"positive multiple of {source_m_tile}",
+            )
+        if start + aligned_m > int(lhs.size(0)):
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 N,M worklist aligned extent exceeds A extent",
+            )
+        expected_store_end = start + aligned_m
+    if expected_store_end != int(lhs.size(0)):
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 N,M worklist aligned extents must cover A rows",
+        )
+    if seen_groups and seen_groups != set(range(len(seen_groups))):
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 N,M worklist requires dense real group ids",
+        )
+
+
+def _tcgen05_grouped_static_metadata_cache_key(
+    cute_kernel: object,
+    plan: dict[str, object],
+    layout: torch.Tensor,
+    n_sizes: torch.Tensor | None,
+    k_sizes: torch.Tensor | None,
+    args: tuple[object, ...],
+) -> tuple[object, ...]:
+    """Cache key for scheduler metadata copied from grouped-static tensors.
+
+    The hot path guards ordinary layout/n_sizes/k_sizes tensors by identity,
+    metadata, and ``_version``. Inference tensors have no version counter, so
+    their exact values form the mutation key instead. Inference metadata is
+    unsupported during CUDA graph capture because its current values cannot be
+    safely copied to the host there. Version-bypassing writes to ordinary tensors
+    remain unsupported; users must rewarm with the final metadata values.
+    During CUDA graph capture/replay these metadata tensors must match the exact
+    prewarmed values and remain immutable. Frozen wrapper plans supply the static
+    dependencies; source extents are included only when worklist validation reads
+    them, and full source tensor metadata only when generated pointer tables embed
+    it.
+    """
+    wrapper_plans = getattr(cast("Any", cute_kernel), "_helion_cute_wrapper_plans", ())
+    plan_index = next(
+        (index for index, candidate in enumerate(wrapper_plans) if candidate is plan),
+        None,
+    )
+    if plan_index is None:
+        raise exc.BackendUnsupported(
+            "cute", "grouped scheduler plan is not registered on the CuTe kernel"
+        )
+
+    worklist_source_extents: list[object] = []
+    if bool(plan.get("worklist_metadata")):
+        lhs = _tcgen05_grouped_dynamic_ab_tensor_arg(plan, args, "lhs_idx", "A")
+        rhs = _tcgen05_grouped_dynamic_ab_tensor_arg(plan, args, "rhs_idx", "B")
+        worklist_source_extents = [
+            "worklist_source_extents",
+            int(lhs.size(0)),
+            int(rhs.size(0)),
+        ]
+
+    return (
+        "tcgen05_grouped_static_metadata",
+        plan_index,
+        *_tcgen05_grouped_tensor_cache_key("layout", layout, include_version=True),
+        *worklist_source_extents,
+        *(
+            (
+                *_tcgen05_grouped_tensor_cache_key(
+                    "direct_lhs",
+                    _tcgen05_grouped_dynamic_ab_tensor_arg(plan, args, "lhs_idx", "A"),
+                ),
+                *_tcgen05_grouped_tensor_cache_key(
+                    "direct_rhs",
+                    _tcgen05_grouped_dynamic_ab_tensor_arg(plan, args, "rhs_idx", "B"),
+                ),
+                *_tcgen05_grouped_tensor_cache_key(
+                    "direct_d",
+                    _tcgen05_grouped_direct_d_tensor_arg(cute_kernel, plan, args),
+                ),
+            )
+            if bool(plan.get("direct_pointer_metadata"))
+            else ()
+        ),
+        *_tcgen05_grouped_external_direct_cache_key(plan, args),
+        *(
+            _tcgen05_grouped_tensor_cache_key("n_sizes", n_sizes, include_version=True)
+            if n_sizes is not None
+            else ()
+        ),
+        *(
+            _tcgen05_grouped_tensor_cache_key("k_sizes", k_sizes, include_version=True)
+            if k_sizes is not None
+            else ()
+        ),
+    )
+
+
+def _cute_bake_tensor_shapes_guard(cute_kernel: object) -> bool:
+    any_obj = cast("Any", cute_kernel)
+    wrapper_plans = getattr(any_obj, "_helion_cute_wrapper_plans", None)
+    wrapper_plans_disable_bake = bool(wrapper_plans) and any(
+        not _cute_wrapper_plan_bakes_tensor_shapes(plan) for plan in wrapper_plans
+    )
+    return not bool(
+        getattr(any_obj, "_helion_cute_disable_bake_tensor_shapes", False)
+        or wrapper_plans_disable_bake
+    )
+
+
+def _append_tcgen05_grouped_static_mutation_guards(
+    key: list[object],
+    cute_kernel: object,
+    args: tuple[object, ...],
+) -> None:
+    for plan in _tcgen05_grouped_static_plans(cute_kernel):
+        for label, index in (
+            ("layout", _plan_int_value(plan, "layout_idx")),
+            ("n_sizes", plan.get("n_sizes_idx")),
+            ("k_sizes", plan.get("k_sizes_idx")),
+        ):
+            if not (
+                isinstance(index, int)
+                and index < len(args)
+                and isinstance(args[index], torch.Tensor)
+            ):
+                continue
+            tensor = args[index]
+            assert isinstance(tensor, torch.Tensor)
+            key.append(
+                (
+                    f"tcgen05_grouped_static_{label}",
+                    index,
+                    id(tensor),
+                    *_tcgen05_grouped_tensor_mutation_key(tensor),
+                )
+            )
+
+
+def _tcgen05_grouped_static_metadata_cache(
+    cute_kernel: object,
+) -> OrderedDict[tuple[object, ...], _Tcgen05GroupedStaticMetadataCacheEntry] | None:
+    try:
+        return cast(
+            "OrderedDict[tuple[object, ...], _Tcgen05GroupedStaticMetadataCacheEntry]",
+            cast("Any", cute_kernel)._helion_tcgen05_grouped_static_metadata_cache,
+        )
+    except AttributeError:
+        return None
+
+
+def _tcgen05_grouped_static_metadata_cache_entry(
+    cute_kernel: object,
+    cache_key: tuple[object, ...],
+    layout: torch.Tensor,
+    n_sizes: torch.Tensor | None,
+    k_sizes: torch.Tensor | None = None,
+) -> _Tcgen05GroupedStaticMetadataCacheEntry | None:
+    cache = _tcgen05_grouped_static_metadata_cache(cute_kernel)
+    if cache is None:
+        return None
+    cached = cache.get(cache_key)
+    if cached is not None and cached.matches(layout, n_sizes, k_sizes):
+        cache.move_to_end(cache_key)
+        return cached
+    if cached is not None:
+        cache.pop(cache_key, None)
+    return None
+
+
+def _build_tcgen05_grouped_static_metadata(
+    cute_kernel: object,
+    plan: dict[str, object],
+    args: tuple[object, ...],
+) -> _Tcgen05GroupedStaticMetadataCacheEntry:
+    layout = _tcgen05_grouped_static_layout_arg(plan, args)
+    _validate_tcgen05_grouped_tensor_devices(layout, args)
+    n_sizes_arg = _tcgen05_grouped_static_size_arg(plan, args, "n_sizes")
+    k_sizes_arg = _tcgen05_grouped_static_size_arg(plan, args, "k_sizes")
+    cache_key = _tcgen05_grouped_static_metadata_cache_key(
+        cute_kernel,
+        plan,
+        layout,
+        n_sizes_arg,
+        k_sizes_arg,
+        args,
+    )
+    cache = _tcgen05_grouped_static_metadata_cache(cute_kernel)
+    if cache is None:
+        cache = OrderedDict()
+        cast("Any", cute_kernel)._helion_tcgen05_grouped_static_metadata_cache = cache
+    cached = _tcgen05_grouped_static_metadata_cache_entry(
+        cute_kernel,
+        cache_key,
+        layout,
+        n_sizes_arg,
+        k_sizes_arg,
+    )
+    if cached is not None:
+        return cached
+    if _cuda_stream_capture_context(layout.device)[1] is not None:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped scheduler metadata is not cached for this layout; "
+            "call the kernel once with the final grouped metadata values before "
+            "CUDA graph capture",
+        )
+
+    group_count = _plan_int_value(plan, "group_count")
+    bm = _plan_int_value(plan, "bm")
+    bn = _plan_int_value(plan, "bn")
+    bk = _plan_int_value(plan, "bk")
+    worklist_nm = _tcgen05_plan_orientation(plan) == "nm"
+    worklist_m_tile = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE if worklist_nm else bm
+    n_size = _plan_int_value(plan, "n_size")
+    k_total_size = _plan_int_value(plan, "k_total_size")
+    scheduler_bm = TCGEN05_GROUPED_WORKLIST_MMA_M_TILE if worklist_nm else bm
+    scheduler_bn = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE if worklist_nm else bn
+    dynamic_ab_tensormaps = bool(plan.get("dynamic_ab_tensormaps"))
+    dynamic_d_tensormap = bool(plan.get("dynamic_d_tensormap"))
+    direct_pointer_metadata = bool(plan.get("direct_pointer_metadata"))
+    external_direct_metadata = _tcgen05_grouped_external_direct_metadata_args(
+        plan,
+        args,
+    )
+    worklist_metadata = bool(plan.get("worklist_metadata"))
+    m_tail_preserve = bool(plan.get("m_tail_preserve"))
+    n_tail_preserve = bool(plan.get("n_tail_preserve"))
+    if worklist_nm and not worklist_metadata:
+        raise exc.BackendUnsupported(
+            "cute", "tcgen05 N,M orientation requires grouped worklist metadata"
+        )
+    if dynamic_ab_tensormaps and bk != 64:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped dynamic A/B TensorMaps are validated only for BK64",
+        )
+    direct_lhs: torch.Tensor | None = None
+    direct_rhs: torch.Tensor | None = None
+    direct_d: torch.Tensor | None = None
+    if direct_pointer_metadata:
+        if not dynamic_ab_tensormaps or not bool(plan.get("dynamic_d_tensormap")):
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped direct pointer metadata requires dynamic A/B "
+                "and D TensorMaps",
+            )
+        if worklist_nm:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped direct pointer metadata supports only the "
+                "default M,N TensorMap orientation",
+            )
+        _validate_tcgen05_grouped_dynamic_ab_tensormaps(plan, args)
+        direct_lhs = _tcgen05_grouped_dynamic_ab_tensor_arg(plan, args, "lhs_idx", "A")
+        direct_rhs = _tcgen05_grouped_dynamic_ab_tensor_arg(plan, args, "rhs_idx", "B")
+        direct_d = _tcgen05_grouped_direct_d_tensor_arg(cute_kernel, plan, args)
+        _validate_tcgen05_grouped_direct_d_tensormap(direct_d)
+    if worklist_nm:
+        if (
+            n_size <= 0
+            or n_size % TCGEN05_GROUPED_WORKLIST_STORE_SHAPE[2] != 0
+            or k_total_size % bk != 0
+        ):
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 N,M worklist scheduler requires output N "
+                "divisible by 32 and K divisible by the CTA K tile",
+            )
+    elif n_size % bn != 0 or k_total_size % bk != 0:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped scheduler requires common N/K dimensions divisible "
+            "by the CTA tile",
+        )
+    if worklist_nm and (
+        not dynamic_ab_tensormaps
+        or _tcgen05_grouped_dynamic_ab_tensormap_rank(plan) != 2
+        or not dynamic_d_tensormap
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 N,M worklist metadata requires rank-2 dynamic "
+            "A/B TensorMaps and a dynamic D TensorMap",
+        )
+    n_sizes_values: list[int] | None = None
+    if n_sizes_arg is not None:
+        if int(n_sizes_arg.numel()) != group_count:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped scheduler n_sizes length must match group count",
+            )
+        n_sizes_values = [int(value) for value in n_sizes_arg.detach().cpu().tolist()]
+    k_sizes_values: list[int] | None = None
+    if k_sizes_arg is not None:
+        if int(k_sizes_arg.numel()) != group_count:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped scheduler k_sizes length must match group count",
+            )
+        k_sizes_values = [int(value) for value in k_sizes_arg.detach().cpu().tolist()]
+    if dynamic_ab_tensormaps and k_sizes_values is None and not worklist_metadata:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped dynamic A/B TensorMaps require exact per-group k_sizes",
+        )
+
+    starts: list[int] = []
+    sizes: list[int] = []
+    has_m_tail = False
+    real_groups: list[int] | None = [] if worklist_metadata else None
+    if worklist_metadata:
+        if int(layout.size(0)) != group_count:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped worklist scheduler row count must match group count",
+            )
+        if n_sizes_values is not None or k_sizes_values is not None:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped worklist scheduler uses common N/K sizes",
+            )
+        lhs = _tcgen05_grouped_dynamic_ab_tensor_arg(plan, args, "lhs_idx", "A")
+        rhs = _tcgen05_grouped_dynamic_ab_tensor_arg(plan, args, "rhs_idx", "B")
+        rows = cast("list[list[int]]", layout.detach().cpu().tolist())
+        _validate_tcgen05_grouped_worklist_nm(plan, args, rows)
+        for row in rows:
+            real_group, start, valid_m, reserved_or_store_m = (
+                int(value) for value in row
+            )
+            if worklist_nm:
+                aligned_m = reserved_or_store_m
+                starts.append(start)
+                sizes.append(aligned_m)
+                assert real_groups is not None
+                real_groups.append(real_group)
+                continue
+            if reserved_or_store_m != 0:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "tcgen05 grouped worklist scheduler requires reserved "
+                    "metadata column to be zero",
+                )
+            if real_group < 0 or real_group >= int(rhs.size(0)):
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "tcgen05 grouped worklist scheduler real group id is "
+                    "outside B_grouped",
+                )
+            if start < 0 or valid_m <= 0 or valid_m > worklist_m_tile:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "tcgen05 grouped worklist scheduler requires each row to "
+                    "describe one CTA-M tile",
+                )
+            if start + valid_m > int(lhs.size(0)):
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "tcgen05 grouped worklist scheduler row exceeds A extent",
+                )
+            starts.append(start)
+            sizes.append(valid_m)
+            assert real_groups is not None
+            real_groups.append(real_group)
+    else:
+        layout_values = [int(value) for value in layout.detach().cpu().tolist()]
+        cursor = 0
+        for expected_group in range(group_count):
+            if m_tail_preserve and expected_group > 0:
+                next_m_boundary = ((cursor + bm - 1) // bm) * bm
+                while (
+                    cursor < len(layout_values)
+                    and cursor < next_m_boundary
+                    and layout_values[cursor] < 0
+                ):
+                    cursor += 1
+                if cursor != next_m_boundary or (
+                    cursor < len(layout_values) and layout_values[cursor] < 0
+                ):
+                    raise exc.BackendUnsupported(
+                        "cute",
+                        "tcgen05 grouped scheduler requires interior M-tail padding "
+                        "to end at the next CTA M tile boundary",
+                    )
+            if cursor >= len(layout_values) or layout_values[cursor] != expected_group:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "tcgen05 grouped scheduler requires ordered complete groups "
+                    "without row holes or skipped group indices",
+                )
+            start = cursor
+            while (
+                cursor < len(layout_values) and layout_values[cursor] == expected_group
+            ):
+                cursor += 1
+            actual_m = cursor - start
+            if start % bm != 0:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "tcgen05 grouped scheduler requires each group start to be "
+                    "divisible by the CTA M tile",
+                )
+            if actual_m % bm != 0 and not m_tail_preserve:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "tcgen05 grouped scheduler requires each group M size to be "
+                    "divisible by the CTA M tile unless the source store proves "
+                    "grouped M-tail preservation",
+                )
+            has_m_tail = has_m_tail or actual_m % bm != 0
+            starts.append(start)
+            sizes.append(actual_m)
+        if cursor != len(layout_values):
+            if m_tail_preserve and all(value < 0 for value in layout_values[cursor:]):
+                cursor = len(layout_values)
+        if cursor != len(layout_values):
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped scheduler requires layout rows to end after the "
+                "last ordered group",
+            )
+
+    problem_sizes = []
+    total_clusters = 0
+    has_n_tail = False
+    for group_idx, actual_m in enumerate(sizes):
+        group_n = n_size if n_sizes_values is None else n_sizes_values[group_idx]
+        group_k = k_total_size if k_sizes_values is None else k_sizes_values[group_idx]
+        if group_n <= 0 or group_n > n_size:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped scheduler requires each per-group N size to be "
+                "positive and within the output N extent",
+            )
+        if group_k <= 0 or group_k > k_total_size:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped scheduler requires each per-group K size to be "
+                "positive and within the padded K extent",
+            )
+        if worklist_nm:
+            if group_n % TCGEN05_GROUPED_WORKLIST_STORE_SHAPE[2] != 0:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "tcgen05 N,M worklist scheduler requires each "
+                    "per-group output N size to be divisible by 32",
+                )
+            has_n_tail = has_n_tail or group_n % scheduler_bm != 0
+        else:
+            if group_n % bn != 0 and not n_tail_preserve:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "tcgen05 grouped scheduler requires each per-group N size to be "
+                    "divisible by the CTA N tile unless the source store proves "
+                    "grouped N-tail preservation",
+                )
+            has_n_tail = has_n_tail or group_n % bn != 0
+        if group_k % bk != 0 and not (dynamic_ab_tensormaps and group_k % 16 == 0):
+            if dynamic_ab_tensormaps:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "tcgen05 grouped dynamic A/B TensorMaps require each "
+                    "per-group K size to be a multiple of 16",
+                )
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped scheduler requires each per-group K size to be "
+                "divisible by the CTA K tile",
+            )
+        if worklist_nm:
+            problem_sizes.append((group_n, actual_m, group_k, 1))
+            total_clusters += ((group_n + scheduler_bm - 1) // scheduler_bm) * (
+                (actual_m + scheduler_bn - 1) // scheduler_bn
+            )
+        else:
+            problem_sizes.append((actual_m, group_n, group_k, 1))
+            total_clusters += ((actual_m + bm - 1) // bm) * ((group_n + bn - 1) // bn)
+    if total_clusters <= 0:
+        raise exc.BackendUnsupported(
+            "cute", "tcgen05 grouped scheduler found zero work clusters"
+        )
+    expected_has_m_tail = plan.get("grouped_static_has_m_tail")
+    if isinstance(expected_has_m_tail, bool) and has_m_tail != expected_has_m_tail:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped M-tail specialization does not match the current "
+            "layout metadata; rebind and prewarm the grouped kernel with the "
+            "final metadata before launch or CUDA graph capture",
+        )
+    expected_has_n_tail = plan.get("grouped_static_has_n_tail")
+    if isinstance(expected_has_n_tail, bool) and has_n_tail != expected_has_n_tail:
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 grouped N-tail specialization does not match the current "
+            "n_sizes metadata; rebind and prewarm the grouped kernel with the "
+            "final metadata before launch or CUDA graph capture",
+        )
+
+    device = layout.device
+    direct_pointers_tensor: torch.Tensor | None = None
+    direct_strides_tensor: torch.Tensor | None = None
+    if direct_pointer_metadata:
+        assert direct_lhs is not None
+        assert direct_rhs is not None
+        assert direct_d is not None
+        if external_direct_metadata is not None:
+            direct_pointers_tensor, direct_strides_tensor = external_direct_metadata
+            if direct_pointers_tensor.device != device:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "tcgen05 grouped external direct metadata must be on the "
+                    "grouped scheduler metadata device",
+                )
+            if tuple(int(size) for size in direct_pointers_tensor.shape) != (
+                len(sizes),
+                3,
+            ):
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "tcgen05 grouped external direct pointer metadata must have "
+                    "shape [metadata_rows, 3]",
+                )
+            if tuple(int(size) for size in direct_strides_tensor.shape) != (
+                len(sizes),
+                3,
+                2,
+            ):
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "tcgen05 grouped external direct stride metadata must have "
+                    "shape [metadata_rows, 3, 2]",
+                )
+        else:
+            direct_pointer_rows: list[tuple[int, int, int]] = []
+            direct_stride_rows: list[
+                tuple[tuple[int, int], tuple[int, int], tuple[int, int]]
+            ] = []
+            for metadata_idx, (start, actual_m) in enumerate(
+                zip(starts, sizes, strict=True)
+            ):
+                real_group = (
+                    real_groups[metadata_idx]
+                    if real_groups is not None
+                    else metadata_idx
+                )
+                group_n = (
+                    n_size if n_sizes_values is None else n_sizes_values[metadata_idx]
+                )
+                group_k = (
+                    k_total_size
+                    if k_sizes_values is None
+                    else k_sizes_values[metadata_idx]
+                )
+                if start + actual_m > int(direct_lhs.size(0)):
+                    raise exc.BackendUnsupported(
+                        "cute",
+                        "tcgen05 grouped direct pointer metadata A segment exceeds "
+                        "the source extent",
+                    )
+                if start + actual_m > int(direct_d.size(0)) or group_n > int(
+                    direct_d.size(1)
+                ):
+                    raise exc.BackendUnsupported(
+                        "cute",
+                        "tcgen05 grouped direct pointer metadata D segment exceeds "
+                        "the output extent",
+                    )
+                if real_group < 0 or real_group >= int(direct_rhs.size(0)):
+                    raise exc.BackendUnsupported(
+                        "cute",
+                        "tcgen05 grouped direct pointer metadata B group is out "
+                        "of range",
+                    )
+                if group_n > int(direct_rhs.size(1)) or group_k > int(
+                    direct_rhs.size(2)
+                ):
+                    raise exc.BackendUnsupported(
+                        "cute",
+                        "tcgen05 grouped direct pointer metadata B segment exceeds "
+                        "the grouped B extent",
+                    )
+                direct_pointer_rows.append(
+                    (
+                        int(direct_lhs.data_ptr())
+                        + start * int(direct_lhs.stride(0)) * direct_lhs.element_size(),
+                        int(direct_rhs.data_ptr())
+                        + real_group
+                        * int(direct_rhs.stride(0))
+                        * direct_rhs.element_size(),
+                        int(direct_d.data_ptr())
+                        + start * int(direct_d.stride(0)) * direct_d.element_size(),
+                    )
+                )
+                direct_stride_rows.append(
+                    (
+                        (int(direct_lhs.stride(0)), int(direct_lhs.stride(1))),
+                        (int(direct_rhs.stride(1)), int(direct_rhs.stride(2))),
+                        (int(direct_d.stride(0)), int(direct_d.stride(1))),
+                    )
+                )
+            direct_pointers_tensor = torch.tensor(
+                direct_pointer_rows, dtype=torch.int64, device=device
+            )
+            direct_strides_tensor = torch.tensor(
+                direct_stride_rows, dtype=torch.int32, device=device
+            )
+    problem_tensor = torch.tensor(problem_sizes, dtype=torch.int32, device=device)
+    starts_tensor = torch.tensor(starts, dtype=torch.int32, device=device)
+    real_groups_tensor = (
+        torch.tensor(real_groups, dtype=torch.int32, device=device)
+        if real_groups is not None
+        else None
+    )
+    result = _Tcgen05GroupedStaticMetadataResult(
+        problem_sizes=problem_tensor,
+        starts=starts_tensor,
+        total_clusters=total_clusters,
+        real_groups=real_groups_tensor,
+        direct_pointers=direct_pointers_tensor,
+        direct_strides=direct_strides_tensor,
+    )
+    entry = _Tcgen05GroupedStaticMetadataCacheEntry(
+        layout_ref=weakref.ref(layout),
+        n_sizes_ref=weakref.ref(n_sizes_arg) if n_sizes_arg is not None else None,
+        k_sizes_ref=weakref.ref(k_sizes_arg) if k_sizes_arg is not None else None,
+        has_m_tail=has_m_tail,
+        has_n_tail=has_n_tail,
+        result=result,
+    )
+    cache[cache_key] = entry
+    cache.move_to_end(cache_key)
+    while len(cache) > _TCGEN05_GROUPED_STATIC_METADATA_CACHE_LIMIT:
+        cache.popitem(last=False)
+    return entry
+
+
 def _cute_launch_arg_cache_key(
     cute_kernel: object,
     args: tuple[object, ...],
     grid: tuple[int, int, int],
+    *,
+    dynamic_tensormap_contexts: tuple[_CuteGroupedLaunchContext, ...] | None = None,
 ) -> tuple[object, ...]:
     constexpr_flags = _cute_kernel_param_is_constexpr(cute_kernel)
-    key: list[object] = [grid]
+    key: list[object] = [len(args), grid, _cute_bake_tensor_shapes_guard(cute_kernel)]
+    if dynamic_tensormap_contexts is None:
+        dynamic_tensormap_contexts = _cute_dynamic_tensormap_contexts(cute_kernel, args)
+    if dynamic_tensormap_contexts:
+        key.append(("dynamic_tensormap_contexts", dynamic_tensormap_contexts))
     for i, arg in enumerate(args):
         if isinstance(arg, torch.Tensor):
             _validate_cute_launcher_tensor(arg)
@@ -1411,7 +3225,7 @@ def _cute_launch_arg_cache_key(
                     arg.device.index,
                     str(arg.dtype),
                     arg.ndim,
-                    arg.data_ptr(),
+                    int(arg.data_ptr()),
                     tuple(int(arg.size(d)) for d in range(arg.ndim)),
                     tuple(int(arg.stride(d)) for d in range(arg.ndim)),
                 )
@@ -1428,15 +3242,71 @@ def _cute_launch_arg_cache_key(
                 scalar_key_value,
             )
         )
+    _append_tcgen05_grouped_static_mutation_guards(key, cute_kernel, args)
     return tuple(key)
+
+
+def _retain_cute_capture_owned_launch_tensors(
+    cute_kernel: object,
+    *,
+    grouped_launch_contexts: tuple[_CuteGroupedLaunchContext, ...],
+    owned_tensors: tuple[torch.Tensor, ...],
+) -> None:
+    """Keep raw-pointer launch tensors alive for captured graph replays."""
+    capture_contexts = tuple(
+        context for context in grouped_launch_contexts if context[3] is not None
+    )
+    if not capture_contexts or not owned_tensors:
+        return
+    cache = cast(
+        "dict[tuple[_CuteGroupedLaunchContext, ...], dict[int, torch.Tensor]]",
+        cast("Any", cute_kernel).__dict__.setdefault(
+            "_helion_cute_capture_owned_launch_tensors", {}
+        ),
+    )
+    capture_tensors = cache.setdefault(capture_contexts, {})
+    for tensor in owned_tensors:
+        capture_tensors[id(tensor)] = tensor
+    _track_cute_cuda_graph_cache_entry(
+        cute_kernel,
+        "_helion_cute_capture_owned_launch_tensors",
+        capture_contexts,
+        capture_tensors,
+        owned_tensors,
+    )
+
+
+def _record_cute_owned_launch_tensors(
+    owned_tensors: tuple[torch.Tensor, ...],
+) -> None:
+    """Associate raw-pointer launch tensors with their current CUDA streams."""
+    streams: dict[tuple[str, int | None], torch.cuda.Stream] = {}
+    for tensor in owned_tensors:
+        device_key = (tensor.device.type, tensor.device.index)
+        stream = streams.get(device_key)
+        if stream is None:
+            stream = torch.cuda.current_stream(tensor.device)
+            streams[device_key] = stream
+        tensor.record_stream(stream)
 
 
 def _build_cached_cute_schema_and_args(
     cute_kernel: object,
     args: tuple[object, ...],
     grid: tuple[int, int, int],
-) -> tuple[tuple[tuple[object, ...], ...], tuple[object, ...]]:
-    cache_key = _cute_launch_arg_cache_key(cute_kernel, args, grid)
+) -> _CuteLaunchArgCacheEntry:
+    dynamic_tensormap_contexts = _cute_dynamic_tensormap_contexts(cute_kernel, args)
+    grouped_launch_contexts = _cute_grouped_launch_contexts(
+        cute_kernel,
+        args,
+        dynamic_tensormap_contexts=dynamic_tensormap_contexts,
+    )
+    cache_key = _cute_launch_arg_cache_key(
+        cute_kernel,
+        args,
+        grid,
+        dynamic_tensormap_contexts=dynamic_tensormap_contexts,
+    )
     try:
         # pyrefly: ignore [missing-attribute]
         cache = cute_kernel._helion_cute_launch_arg_cache
@@ -1446,11 +3316,28 @@ def _build_cached_cute_schema_and_args(
         cute_kernel._helion_cute_launch_arg_cache = cache
     cached = cache.get(cache_key)
     if cached is not None:
-        cache[cache_key] = cache.pop(cache_key)
-        return cached
+        if isinstance(
+            cached, _CuteLaunchArgCacheEntry
+        ) and _cute_grouped_static_metadata_matches(
+            cached.grouped_static_metadata, cute_kernel, args
+        ):
+            cache[cache_key] = cache.pop(cache_key)
+            _retain_cute_capture_owned_launch_tensors(
+                cute_kernel,
+                grouped_launch_contexts=grouped_launch_contexts,
+                owned_tensors=cached.owned_tensors,
+            )
+            return cached
+        cache.pop(cache_key)
 
     built = _build_cute_schema_and_args(cute_kernel, args, grid)
     cache[cache_key] = built
+    if built.owned_tensors:
+        _retain_cute_capture_owned_launch_tensors(
+            cute_kernel,
+            grouped_launch_contexts=grouped_launch_contexts,
+            owned_tensors=built.owned_tensors,
+        )
     if len(cache) > _CUTE_LAUNCH_ARG_CACHE_LIMIT:
         cache.pop(next(iter(cache)))
     return built
@@ -1481,7 +3368,7 @@ def _build_cute_schema_and_args(
     args: tuple[object, ...],
     grid: tuple[int, int, int],
     bake_tensor_shapes: bool = True,
-) -> tuple[tuple[tuple[object, ...], ...], tuple[object, ...]]:
+) -> _CuteLaunchArgCacheEntry:
     # NOTE: the returned launch args deliberately EXCLUDE the CUDA stream. The
     # stream is the only launch arg that is not a pure function of
     # (grid, tensor metadata, scalars), so it must not be baked into the cached
@@ -1495,15 +3382,7 @@ def _build_cute_schema_and_args(
     # Full-tile tcgen05 wrapper schemas are specialized by problem shape and
     # stride, while partial-tile paths still propagate runtime tensor layouts.
     if bake_tensor_shapes:
-        any_obj = cast("Any", cute_kernel)
-        wrapper_plans = getattr(any_obj, "_helion_cute_wrapper_plans", None)
-        non_bakeable_plan = bool(wrapper_plans) and any(
-            not _cute_wrapper_plan_bakes_tensor_shapes(plan) for plan in wrapper_plans
-        )
-        if (
-            getattr(any_obj, "_helion_cute_disable_bake_tensor_shapes", False)
-            or non_bakeable_plan
-        ):
+        if not _cute_bake_tensor_shapes_guard(cute_kernel):
             bake_tensor_shapes = False
     schema: list[tuple[object, ...]] = []
     launch_args: list[object] = []
@@ -1561,10 +3440,99 @@ def _build_cute_schema_and_args(
             schema.append(("scalar", scalar_kind))
             launch_args.append(scalar_value)
 
+    owned_tensors: list[torch.Tensor] = []
+    grouped_static_metadata: list[_Tcgen05GroupedStaticMetadataCacheEntry] = []
+
+    def append_wrapper_tensor(
+        name: str,
+        tensor: torch.Tensor,
+        *,
+        owned: bool = False,
+    ) -> None:
+        _validate_cute_launcher_tensor(tensor)
+        sizes = tuple(int(tensor.size(d)) for d in range(tensor.ndim))
+        strides = tuple(int(tensor.stride(d)) for d in range(tensor.ndim))
+        launch_args.append(
+            make_ptr(
+                cast("Any", _torch_dtype_to_cutlass(tensor.dtype)),
+                tensor.data_ptr(),
+                gmem_space,
+                assumed_align=16,
+            )
+        )
+        schema.append(
+            (
+                "wrapper_tensor",
+                name,
+                str(tensor.dtype),
+                tensor.ndim,
+                sizes,
+                strides,
+            )
+        )
+        if owned:
+            owned_tensors.append(tensor)
+
+    for plan in _tcgen05_grouped_static_plans(cute_kernel):
+        metadata_entry = _build_tcgen05_grouped_static_metadata(cute_kernel, plan, args)
+        metadata_result = metadata_entry.result
+        problem_tensor = metadata_result.problem_sizes
+        starts_tensor = metadata_result.starts
+        real_groups_tensor = metadata_result.real_groups
+        direct_pointers_tensor = metadata_result.direct_pointers
+        direct_strides_tensor = metadata_result.direct_strides
+        total_clusters = metadata_result.total_clusters
+        grouped_static_metadata.append(metadata_entry)
+        layout = _tcgen05_grouped_static_layout_arg(plan, args)
+        for name, tensor in (
+            (_plan_str_value(plan, "problem_sizes_arg"), problem_tensor),
+            (_plan_str_value(plan, "starts_arg"), starts_tensor),
+            *(
+                ((_plan_str_value(plan, "real_groups_arg"), real_groups_tensor),)
+                if real_groups_tensor is not None
+                else ()
+            ),
+        ):
+            append_wrapper_tensor(name, tensor)
+        workspace_name: str | None = None
+        tensormap_count = 0
+        if bool(plan.get("dynamic_ab_tensormaps")):
+            _validate_tcgen05_grouped_dynamic_ab_tensormaps(plan, args)
+            workspace_name = _plan_str_value(plan, "ab_tensormaps_arg")
+            tensormap_count = 3 if bool(plan.get("dynamic_d_tensormap")) else 2
+        elif bool(plan.get("dynamic_d_tensormap")):
+            workspace_name = _plan_str_value(plan, "d_tensormaps_arg")
+            tensormap_count = 1
+        if workspace_name is not None:
+            workspace = _tcgen05_grouped_dynamic_tensormap_workspace(
+                cute_kernel,
+                device=layout.device,
+                tensormap_count=tensormap_count,
+            )
+            append_wrapper_tensor(workspace_name, workspace, owned=True)
+        if direct_pointers_tensor is not None and direct_strides_tensor is not None:
+            append_wrapper_tensor(
+                _plan_str_value(plan, "direct_pointers_arg"),
+                direct_pointers_tensor,
+            )
+            append_wrapper_tensor(
+                _plan_str_value(plan, "direct_strides_arg"),
+                direct_strides_tensor,
+            )
+        total_name = _plan_str_value(plan, "total_clusters_arg")
+        schema.append(("wrapper_host_scalar", total_name, "int"))
+        launch_args.append(total_clusters)
+        owned_tensors.extend(metadata_result.tensors())
+
     launch_args.extend(grid)
     # The stream is intentionally NOT appended here; it is sampled fresh per
     # launch by the caller so CUDA graph capture sees the capture stream.
-    return tuple(schema), tuple(launch_args)
+    return _CuteLaunchArgCacheEntry(
+        schema=tuple(schema),
+        launch_args=tuple(launch_args),
+        grouped_static_metadata=tuple(grouped_static_metadata),
+        owned_tensors=tuple(owned_tensors),
+    )
 
 
 _CUTE_DSL_ARCH_CACHE: dict[int, str] = {}
@@ -1611,6 +3579,120 @@ def _ensure_cute_dsl_arch_env(args: tuple[object, ...]) -> None:
         os.environ["CUTE_DSL_ARCH"] = desired
 
 
+def _cute_last_launch_arg_guard(
+    cute_kernel: object,
+    args: tuple[object, ...],
+    grid: tuple[int, int, int],
+) -> _CuteLastLaunchArgGuard:
+    constexpr_flags = _cute_kernel_param_is_constexpr(cute_kernel)
+    arg_guards: list[_CuteLastTensorArgGuard | _CuteLastScalarArgGuard] = []
+    for index, arg in enumerate(args):
+        if isinstance(arg, torch.Tensor):
+            _validate_cute_launcher_tensor(arg)
+            arg_guards.append(
+                _CuteLastTensorArgGuard(
+                    index=index,
+                    data_ptr=int(arg.data_ptr()),
+                    device_type=arg.device.type,
+                    device_index=arg.device.index,
+                    dtype=arg.dtype,
+                    ndim=arg.ndim,
+                    shape=tuple(int(arg.size(dim)) for dim in range(arg.ndim)),
+                    stride=tuple(int(arg.stride(dim)) for dim in range(arg.ndim)),
+                )
+            )
+            continue
+        scalar_kind, scalar_value = _normalize_cute_scalar(arg)
+        arg_guards.append(
+            _CuteLastScalarArgGuard(
+                index=index,
+                is_constexpr=index < len(constexpr_flags) and constexpr_flags[index],
+                scalar_kind=scalar_kind,
+                scalar_value=_cute_scalar_cache_value(scalar_kind, scalar_value),
+            )
+        )
+    grouped_mutation_guards: list[_CuteLastGroupedMutationGuard] = []
+    for plan in _tcgen05_grouped_static_plans(cute_kernel):
+        for index in (
+            _plan_int_value(plan, "layout_idx"),
+            plan.get("n_sizes_idx"),
+            plan.get("k_sizes_idx"),
+        ):
+            if (
+                isinstance(index, int)
+                and index < len(args)
+                and isinstance(args[index], torch.Tensor)
+            ):
+                tensor = args[index]
+                assert isinstance(tensor, torch.Tensor)
+                grouped_mutation_guards.append(
+                    _CuteLastGroupedMutationGuard(
+                        index=index,
+                        tensor_id=id(tensor),
+                        mutation_key=_tcgen05_grouped_tensor_mutation_key(tensor),
+                    )
+                )
+    return _CuteLastLaunchArgGuard(
+        arg_count=len(args),
+        grid=grid,
+        bake_tensor_shapes=_cute_bake_tensor_shapes_guard(cute_kernel),
+        arg_guards=tuple(arg_guards),
+        grouped_mutation_guards=tuple(grouped_mutation_guards),
+        grouped_launch_contexts=_cute_grouped_launch_contexts(cute_kernel, args),
+    )
+
+
+def _cute_last_launch_cache_entry(
+    cute_kernel: object,
+    args: tuple[object, ...],
+    grid: tuple[int, int, int],
+    block: tuple[int, int, int],
+    compile_options: str | None,
+) -> _CuteLastLaunchCacheEntry | None:
+    entry = getattr(cast("Any", cute_kernel), "_helion_cute_last_launch_cache", None)
+    if not isinstance(entry, _CuteLastLaunchCacheEntry):
+        return None
+    if not entry.arg_guard.matches(cute_kernel, args, grid):
+        return None
+    discriminator = _cute_compiled_launcher_discriminator(
+        entry.launch.schema,
+        block,
+        compile_options,
+        args,
+    )[0]
+    if discriminator != entry.compiled_discriminator:
+        return None
+    if not _cute_grouped_static_metadata_matches(
+        entry.launch.grouped_static_metadata, cute_kernel, args
+    ):
+        return None
+    return entry
+
+
+def _set_cute_last_launch_cache_entry(
+    cute_kernel: object,
+    args: tuple[object, ...],
+    grid: tuple[int, int, int],
+    block: tuple[int, int, int],
+    compile_options: str | None,
+    launch: _CuteLaunchArgCacheEntry,
+    compiled: object,
+) -> None:
+    arg_guard = _cute_last_launch_arg_guard(cute_kernel, args, grid)
+    compiled_discriminator = _cute_compiled_launcher_discriminator(
+        launch.schema,
+        block,
+        compile_options,
+        args,
+    )[0]
+    cast("Any", cute_kernel)._helion_cute_last_launch_cache = _CuteLastLaunchCacheEntry(
+        arg_guard=arg_guard,
+        compiled_discriminator=compiled_discriminator,
+        launch=launch,
+        compiled=compiled,
+    )
+
+
 def default_cute_launcher(
     cute_kernel: object,
     grid: tuple[int, ...],
@@ -1643,20 +3725,43 @@ def default_cute_launcher(
         return None
 
     args_tuple = tuple(args)
-    schema_key, launch_args = _build_cached_cute_schema_and_args(
-        cute_kernel, args_tuple, grid_xyz
+    last_launch = _cute_last_launch_cache_entry(
+        cute_kernel,
+        args_tuple,
+        grid_xyz,
+        block_xyz,
+        cute_compile_options,
     )
+    if last_launch is not None:
+        _record_cute_owned_launch_tensors(last_launch.launch.owned_tensors)
+        return cast("Any", last_launch.compiled)(
+            *last_launch.launch.launch_args,
+            _cute_current_stream(),
+        )
+
+    launch = _build_cached_cute_schema_and_args(cute_kernel, args_tuple, grid_xyz)
     compiled = _get_compiled_cute_launcher(
         cute_kernel,
-        schema_key,
+        launch.schema,
         block_xyz,
         compile_options=cute_compile_options,
         arch_args=args_tuple,
     )
+    _record_cute_owned_launch_tensors(launch.owned_tensors)
     # Append the CUDA stream fresh on every launch (never cached): under CUDA
     # graph capture the current stream is the capture stream, so the kernel must
     # be issued there and not on a stale stream baked into the cached args.
-    return cast("Any", compiled)(*launch_args, _cute_current_stream())
+    result = cast("Any", compiled)(*launch.launch_args, _cute_current_stream())
+    _set_cute_last_launch_cache_entry(
+        cute_kernel,
+        args_tuple,
+        grid_xyz,
+        block_xyz,
+        cute_compile_options,
+        launch,
+        compiled,
+    )
+    return result
 
 
 def default_metal_launcher(

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -13,6 +13,7 @@ import os
 import re
 import sys
 import textwrap
+import threading
 import types
 from typing import TYPE_CHECKING
 from typing import Any
@@ -24,6 +25,7 @@ from typing import TypeVar
 from typing import cast
 from typing import overload
 from typing_extensions import Protocol
+import weakref
 
 import torch
 from torch._dynamo.source import GetItemSource
@@ -33,6 +35,7 @@ from torch._dynamo.source import TensorPropertySource
 from torch._inductor.codecache import PyCodeCache
 from torch._inductor.codecache import compiled_fx_graph_hash
 from torch._subclasses import FakeTensor
+from torch._subclasses.fake_tensor import unset_fake_temporarily
 import torch.distributed as dist
 from torch.utils._pytree import tree_map_only
 from torch.utils.weak import WeakIdKeyDictionary
@@ -67,6 +70,7 @@ from .ref_mode import is_ref_mode_enabled
 from .settings import Settings
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
     from collections.abc import Hashable
 
     from torch._guards import Source
@@ -259,6 +263,7 @@ class Kernel(Generic[_R]):
             Config(**config) if isinstance(config, dict) else config
             for config in configs or []
         ]
+        self._bind_lock = threading.RLock()
         self._bound_kernels: dict[BoundKernelInMemoryCacheKey, BoundKernel] = {}
         # Fast dispatch cache: maps a cheap, fine-grained argument key (exact
         # dtype/shape/stride/device per tensor) directly to a BoundKernel,
@@ -266,6 +271,10 @@ class Kernel(Generic[_R]):
         self._dispatch_cache: dict[Hashable, BoundKernel] = {}
         self._specialize_extra: dict[
             Hashable, list[Callable[[Sequence[object]], Hashable]]
+        ] = {}
+        self._has_specialization_extras = False
+        self._cute_grouped_static_tail_extra_descriptors: dict[
+            Hashable, set[Hashable]
         ] = {}
         if any(
             param.kind
@@ -342,8 +351,46 @@ class Kernel(Generic[_R]):
         from ..autotuner.base_cache import BoundKernelInMemoryCacheKey
 
         self._specialize_extra[signature] = extra_fns = bound_kernel._specialize_extra()
+        if extra_fns:
+            self._has_specialization_extras = True
         extra_results: tuple[Hashable, ...] = tuple([s(args) for s in extra_fns])
         return BoundKernelInMemoryCacheKey(signature, extra_results)
+
+    def _extend_bound_kernel_specializations(
+        self,
+        bound_kernel: BoundKernel,
+        signature: tuple[Hashable, ...],
+        extractors: list[Callable[[Sequence[object]], Hashable]],
+        args: Sequence[object],
+    ) -> None:
+        if not extractors:
+            return
+
+        from ..autotuner.base_cache import BoundKernelInMemoryCacheKey
+
+        with self._bind_lock:
+            existing_extractors = self._specialize_extra.setdefault(signature, [])
+            existing_extractors.extend(extractors)
+            self._has_specialization_extras = True
+            with unset_fake_temporarily():
+                current_results = tuple(
+                    extractor(args) for extractor in existing_extractors
+                )
+
+            stale_keys = [
+                key
+                for key in self._bound_kernels
+                if key.specialization_key == signature
+                and len(key.extra_results) < len(existing_extractors)
+            ]
+            for stale_key in stale_keys:
+                self._bound_kernels.pop(stale_key)
+            for fast_key, cached_bound in list(self._dispatch_cache.items()):
+                if cached_bound._base_spec_key == signature:
+                    self._dispatch_cache.pop(fast_key)
+            self._bound_kernels[
+                BoundKernelInMemoryCacheKey(signature, current_results)
+            ] = bound_kernel
 
     def _compute_is_distributed(self, args: Sequence[object]) -> bool:
         """Whether this call should compile as a distributed kernel.
@@ -370,6 +417,10 @@ class Kernel(Generic[_R]):
         different full keys also produce different fast keys.  That makes it
         safe to map a fast key directly to the BoundKernel that a full
         ``bind()`` resolved for the same arguments.
+
+        If a base signature has extra specialization extractors, their results
+        are appended to preserve the same no-collision invariant for
+        value-based specializations.
 
         Returns None when an argument type is not handled (tensor subclasses,
         containers, ...), or when there is no tensor argument to pin down the
@@ -403,8 +454,17 @@ class Kernel(Generic[_R]):
         if not has_tensor:
             return None
         key.append(self._compute_is_distributed(args))
+        signature = (
+            self._base_specialization_key(args)
+            if self._has_specialization_extras
+            else None
+        )
         if self._key_fn is not None:
-            key.append(self._key_fn(*args))
+            key.append(signature[-1] if signature is not None else self._key_fn(*args))
+        if signature is not None:
+            extra_fns = self._specialize_extra.get(signature)
+            if extra_fns is not None:
+                key.append(tuple(s(args) for s in extra_fns))
         return tuple(key)
 
     def bind(self, args: tuple[object, ...]) -> BoundKernel[_R]:
@@ -417,6 +477,14 @@ class Kernel(Generic[_R]):
         Returns:
             BoundKernel: A BoundKernel object with the given arguments bound.
         """
+        # Dynamo executes bind while capturing the call but cannot trace an RLock.
+        # Eager binds, including all cache mutations, remain serialized.
+        if torch.compiler.is_compiling():
+            return self._bind(args)
+        with self._bind_lock:
+            return self._bind(args)
+
+    def _bind(self, args: tuple[object, ...]) -> BoundKernel[_R]:
         with measure("Kernel.bind"):
             if not isinstance(args, tuple):
                 assert isinstance(args, list), "args must be a tuple or list"
@@ -858,6 +926,11 @@ class Kernel(Generic[_R]):
             return self.bind(args)(*args)
         bound = self.bind(args)
         result = bound(*args)
+        if self._has_specialization_extras:
+            # A concurrent first compile can discover a late specialization and
+            # make BoundKernel.__call__ rebind internally. Resolve it again so
+            # the fast-dispatch key never points at the pre-specialization bound.
+            bound = self.bind(args)
         if bound._run is not None:
             fast_key = self._fast_dispatch_key(args)
             if fast_key is not None:
@@ -924,6 +997,14 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         self._config: Config | None = None
         self._compile_cache: dict[Config, CompiledConfig] = {}
         self._cache_path_map: dict[Config, str | None] = {}
+        # Direct to_code() has no call arguments, so keep this bound kernel's
+        # construction-time tensor values as its stable weak fallback.
+        self._runtime_tensor_refs_by_name = {
+            name: weakref.ref(value)
+            for name, value in zip(self.kernel.signature.parameters, args, strict=False)
+            if isinstance(value, torch.Tensor)
+        }
+        self._first_compile_lock = threading.RLock()
         self._backward_compiled: (
             tuple[Kernel[object], str, BoundKernel[object]] | None
         ) = None
@@ -948,7 +1029,6 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             self._env.process_group_name = _find_process_group_name(
                 kernel.fn, args, is_distributed
             )
-
             assert len(args) == len(self.kernel.signature.parameters)
             self.fake_args: list[object] = []
             constexpr_args = {}
@@ -1097,6 +1177,12 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         # pyrefly: ignore [bad-argument-type]
         return Config(**config)
 
+    def _normalized_config_copy(self, config: ConfigLike) -> Config:
+        normalized = self._normalize_config(config)
+        normalized = Config(**normalized.config)  # pyrefly: ignore[bad-argument-type]
+        self.env.config_spec.normalize(normalized)
+        return normalized
+
     def format_kernel_decorator(self, config: Config, settings: Settings) -> str:
         """Return the @helion.kernel decorator snippet capturing configs and settings that influence Triton code generation."""
         parts = [
@@ -1133,17 +1219,16 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         if config is None:
             config = self._require_implicit_config()
         with self.env, measure("BoundKernel.to_code"):
-            config = self._normalize_config(config)
-            # Work on a copy so the caller's Config is not mutated with
-            # normalize defaults (e.g. indexing, load_eviction_policies)
-            # specific to this BoundKernel's config_spec.  Without this,
-            # reusing the same Config across compilations with different
-            # constexpr values carries stale entries from an earlier call.
-            config = Config(**config.config)  # pyrefly: ignore [bad-argument-type]
-            self.env.config_spec.normalize(config)
-            with measure("BoundKernel.generate_ast"):
+            # Work on a copy so the caller's Config is not mutated with defaults
+            # specific to this BoundKernel's config_spec.
+            config = self._normalized_config_copy(config)
+            with (
+                self._runtime_arg_values_for_codegen(),
+                measure("BoundKernel.generate_ast"),
+            ):
                 # pyrefly: ignore [bad-argument-type]
                 root = generate_ast(self.host_function, config, emit_repro_caller)
+                self._register_cute_grouped_static_tail_specializations()
             if output_origin_lines is None:
                 output_origin_lines = self.settings.output_origin_lines
             with measure("BoundKernel.unparse"):
@@ -1206,7 +1291,8 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         """
         if config is None:
             config = self._require_implicit_config()
-        config = self._normalize_config(config)
+        requested_config = self._normalize_config(config)
+        config = self._normalized_config_copy(requested_config)
         dist_check_config_consistancy(
             config, process_group_name=self._env.process_group_name
         )
@@ -1249,10 +1335,10 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         except Exception:
             log.warning(
                 "Helion compiler triton codegen error for %s",
-                self.format_kernel_decorator(config, self.settings),
+                self.format_kernel_decorator(requested_config, self.settings),
                 exc_info=True,
             )
-            self.maybe_log_repro(log.warning, self.fake_args, config=config)
+            self.maybe_log_repro(log.warning, self.fake_args, config=requested_config)
             raise
         if allow_print:
             log.info("Output code written to: %s", module.__file__)
@@ -1303,7 +1389,13 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         """
         if config is None:
             config = self._require_implicit_config()
-        config = self._normalize_config(config)
+        requested_config = self._normalize_config(config)
+        if requested_config in self._cache_path_map:
+            return self._cache_path_map[requested_config]
+        try:
+            config = self._normalized_config_copy(requested_config)
+        except exc.InvalidConfig:
+            return None
         return self._cache_path_map.get(config, None)
 
     def _debug_str(self) -> str:
@@ -1492,6 +1584,50 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
             extractors.append(td_layout_extractor)
         return extractors
 
+    @contextlib.contextmanager
+    def _runtime_arg_values_for_codegen(self) -> Generator[None, None, None]:
+        values: dict[str, object] = self.env.runtime_arg_values_by_name
+        if not values:
+            values = {
+                name: value
+                for name, ref in self._runtime_tensor_refs_by_name.items()
+                if (value := ref()) is not None
+            }
+        with self.env.use_runtime_arg_values(values):
+            yield
+
+    def _register_cute_grouped_static_tail_specializations(self) -> None:
+        if self.kernel.settings.backend != "cute":
+            return
+        signature = self._base_spec_key
+        descriptors = _cute_grouped_static_tail_extra_descriptors(
+            self.env.cute_resolved_wrapper_plans
+        )
+        if not descriptors:
+            return
+        seen = self.kernel._cute_grouped_static_tail_extra_descriptors.setdefault(
+            signature,
+            set(),
+        )
+        new_descriptors: list[Hashable] = []
+        new_extractors: list[Callable[[Sequence[object]], Hashable]] = []
+        for descriptor in descriptors:
+            if descriptor in seen:
+                continue
+            new_descriptors.append(descriptor)
+            new_extractors.append(_make_cute_grouped_static_tail_extractor(descriptor))
+        runtime_args = tuple(
+            self.env.runtime_arg_values_by_name.get(name)
+            for name in self.kernel.signature.parameters
+        )
+        self.kernel._extend_bound_kernel_specializations(
+            self,
+            signature,
+            new_extractors,
+            runtime_args,
+        )
+        seen.update(new_descriptors)
+
     def _fixed_config_for_td_layout_guards(self) -> Config | None:
         """Return the fixed config if TD layout guards can be filtered safely."""
         if self._config is not None:
@@ -1587,14 +1723,35 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         Returns:
             _R: The result of the kernel execution.
         """
+        if self.kernel._has_specialization_extras:
+            rebound = self.kernel.bind(args)
+            if rebound is not self:
+                return rebound(*args)
+
         if self._run is None:
-            if is_ref_mode_enabled(self.kernel.settings):
-                if (config := self._implicit_config()) is not None:
-                    self._config = config
-                return self.run_ref(*args)
-            self.ensure_config_exists(args)
-            assert self._run is not None
-            self.maybe_log_repro(log.warning, args)
+            with self._first_compile_lock:
+                # Another caller may have discovered a late specialization while
+                # this caller waited for the first compile.
+                if self.kernel._has_specialization_extras:
+                    rebound = self.kernel.bind(args)
+                    if rebound is not self:
+                        return rebound(*args)
+                if self._run is None:
+                    if is_ref_mode_enabled(self.kernel.settings):
+                        if (config := self._implicit_config()) is not None:
+                            self._config = config
+                        return self.run_ref(*args)
+                    runtime_args: dict[str, object] = {
+                        name: value
+                        for name, value in zip(
+                            self.kernel.signature.parameters, args, strict=False
+                        )
+                        if isinstance(value, torch.Tensor)
+                    }
+                    with self.env.use_runtime_arg_values(runtime_args):
+                        self.ensure_config_exists(args)
+                    assert self._run is not None
+                    self.maybe_log_repro(log.warning, args)
 
         return self._run(*args)
 
@@ -1617,7 +1774,7 @@ class BoundKernel(_AutotunableKernel, Generic[_R]):
         """
         if config is None:
             config = self._require_implicit_config()
-        config = self._normalize_config(config)
+        config = self._normalized_config_copy(config)
         compiled_fn = self._compile_cache.get(config)
         if compiled_fn is None:
             return None
@@ -1923,6 +2080,163 @@ def _function_key(fn: Kernel, obj: types.FunctionType) -> object:
         ]
         return (obj.__code__, *closures)
     return obj.__code__
+
+
+def _cute_grouped_layout_has_m_tail(
+    layout_values: tuple[int, ...],
+    *,
+    bm: int,
+    group_count: int,
+) -> bool | None:
+    cursor = 0
+    has_m_tail = False
+    for expected_group in range(group_count):
+        if expected_group > 0:
+            next_m_boundary = ((cursor + bm - 1) // bm) * bm
+            while (
+                cursor < len(layout_values)
+                and cursor < next_m_boundary
+                and layout_values[cursor] < 0
+            ):
+                cursor += 1
+            if cursor != next_m_boundary or (
+                cursor < len(layout_values) and layout_values[cursor] < 0
+            ):
+                return None
+        if cursor >= len(layout_values) or layout_values[cursor] != expected_group:
+            return None
+        start = cursor
+        while cursor < len(layout_values) and layout_values[cursor] == expected_group:
+            cursor += 1
+        actual_m = cursor - start
+        if start % bm != 0:
+            return None
+        has_m_tail = has_m_tail or actual_m % bm != 0
+    if cursor != len(layout_values):
+        if all(value < 0 for value in layout_values[cursor:]):
+            cursor = len(layout_values)
+    if cursor != len(layout_values):
+        return None
+    return has_m_tail
+
+
+def _cute_grouped_static_tail_extra_descriptors(
+    plans: Sequence[dict[str, object]],
+) -> tuple[Hashable, ...]:
+    descriptors: list[Hashable] = []
+    for plan in plans:
+        if plan.get("kind") != "tcgen05_grouped_static_persistent" or bool(
+            plan.get("worklist_metadata")
+        ):
+            continue
+        if not (
+            isinstance(plan.get("grouped_static_has_m_tail"), bool)
+            or isinstance(plan.get("grouped_static_has_n_tail"), bool)
+        ):
+            continue
+        layout_idx = plan.get("layout_bind_idx")
+        group_count = plan.get("group_count")
+        bm = plan.get("bm")
+        if not (
+            isinstance(layout_idx, int)
+            and isinstance(group_count, int)
+            and isinstance(bm, int)
+        ):
+            continue
+        n_sizes_idx = plan.get("n_sizes_bind_idx")
+        bn = plan.get("bn")
+        descriptors.append(
+            (
+                "cute_grouped_static_tail",
+                layout_idx,
+                group_count,
+                bm,
+                n_sizes_idx if isinstance(n_sizes_idx, int) else None,
+                bn if isinstance(bn, int) else None,
+            )
+        )
+    return tuple(sorted(descriptors, key=repr))
+
+
+def _cute_int_1d_tensor_values(
+    value: object,
+    cache: WeakIdKeyDictionary,
+) -> tuple[int, ...] | None:
+    if not (
+        isinstance(value, torch.Tensor)
+        and value.ndim == 1
+        and value.dtype in (torch.int32, torch.int64)
+    ):
+        return None
+    if torch.is_inference(value):
+        return tuple(int(v) for v in value.detach().cpu().tolist())
+    signature = (
+        int(value._version),
+        int(value.data_ptr()),
+        tuple(value.shape),
+        tuple(value.stride()),
+        value.dtype,
+    )
+    try:
+        cached_signature, cached_values = cache[value]
+    except KeyError:
+        pass
+    else:
+        if cached_signature == signature:
+            return cached_values
+    values = tuple(int(v) for v in value.detach().cpu().tolist())
+    cache[value] = (signature, values)
+    return values
+
+
+def _make_cute_grouped_static_tail_extractor(
+    descriptor: Hashable,
+) -> Callable[[Sequence[object]], Hashable]:
+    (
+        _label,
+        layout_idx,
+        group_count,
+        bm,
+        n_sizes_idx,
+        bn,
+    ) = cast("tuple[object, int, int, int, int | None, int | None]", descriptor)
+    tensor_values_cache: WeakIdKeyDictionary = WeakIdKeyDictionary()
+
+    def cute_grouped_static_tail_extractor(
+        args: Sequence[object],
+        *,
+        _descriptor: Hashable = descriptor,
+        _layout_idx: int = layout_idx,
+        _group_count: int = group_count,
+        _bm: int = bm,
+        _n_sizes_idx: int | None = n_sizes_idx,
+        _bn: int | None = bn,
+    ) -> Hashable:
+        layout_has_m_tail: bool | None = None
+        if _layout_idx < len(args):
+            layout_values = _cute_int_1d_tensor_values(
+                args[_layout_idx],
+                tensor_values_cache,
+            )
+            if layout_values is not None:
+                layout_has_m_tail = _cute_grouped_layout_has_m_tail(
+                    layout_values,
+                    bm=_bm,
+                    group_count=_group_count,
+                )
+        n_sizes_has_n_tail: bool | None = None
+        if _n_sizes_idx is not None and _bn is not None and _n_sizes_idx < len(args):
+            n_sizes_values = _cute_int_1d_tensor_values(
+                args[_n_sizes_idx],
+                tensor_values_cache,
+            )
+            if n_sizes_values is not None and len(n_sizes_values) == _group_count:
+                n_sizes_has_n_tail = any(
+                    group_n % _bn != 0 for group_n in n_sizes_values
+                )
+        return (_descriptor, layout_has_m_tail, n_sizes_has_n_tail)
+
+    return cute_grouped_static_tail_extractor
 
 
 def _graph_module_key(fn: Kernel, obj: torch.fx.GraphModule) -> Hashable:

--- a/test/test_benchmarking.py
+++ b/test/test_benchmarking.py
@@ -31,6 +31,17 @@ class _FakeGraphContext:
         return False
 
 
+class _FakeCuteGraphContext:
+    def __init__(self, cuda):
+        self.cuda = cuda
+
+    def __enter__(self):
+        return self.cuda.CUDAGraph()
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
 class _FakeGraph:
     def __init__(self):
         self.replay_count = 0
@@ -415,8 +426,15 @@ def test_cudagraph_defaults_off(monkeypatch):
 
 
 def test_cudagraph_replay_wraps_callable(monkeypatch):
+    import helion.runtime as helion_runtime
+
     fake_cuda = _FakeCuda()
     monkeypatch.setattr(benchmarking, "torch", _fake_torch(fake_cuda))
+    monkeypatch.setattr(
+        helion_runtime,
+        "cute_cuda_graph",
+        lambda: _FakeCuteGraphContext(fake_cuda),
+    )
     monkeypatch.setenv("HELION_BENCHMARK_CUDAGRAPH", "1")
     calls = []
 

--- a/test/test_cute_backend.py
+++ b/test/test_cute_backend.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 import ast
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+import gc
 import importlib
 import math
 import os
+import threading
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import cast
 from unittest.mock import patch
+import weakref
 
 import pytest
 import torch
@@ -24,7 +29,7 @@ from helion.exc import BackendUnsupported
 from helion.exc import CuteBackendUnavailable
 from helion.exc import InvalidConfig
 import helion.language as hl
-from helion.runtime import _build_cute_schema_and_args
+import helion.runtime as helion_runtime
 from helion.runtime import _cute_cluster_shape
 from helion.runtime import _cute_cluster_shape_from_wrapper_plans
 from helion.runtime import _ensure_cute_dsl_arch_env
@@ -32,6 +37,9 @@ from helion.runtime import _get_compiled_cute_launcher
 from helion.runtime import default_cute_launcher
 
 if TYPE_CHECKING:
+    from collections.abc import Hashable
+    from collections.abc import Sequence
+
     from helion.autotuner.config_spec import ConfigSpec
 
 cutlass = pytest.importorskip("cutlass")
@@ -2276,6 +2284,31 @@ def _attention_from_log2_scores(
 ) -> torch.Tensor:
     probs = torch.softmax(scores_log2.float() * math.log(2.0), dim=-1)
     return torch.matmul(probs.to(v.dtype), v)
+
+
+def _launch_entry(
+    schema: tuple[tuple[object, ...], ...],
+    launch_args: tuple[object, ...],
+    owned_tensors: tuple[torch.Tensor, ...] = (),
+) -> helion_runtime._CuteLaunchArgCacheEntry:
+    return helion_runtime._CuteLaunchArgCacheEntry(
+        schema, launch_args, (), owned_tensors
+    )
+
+
+def _runtime_identity_kernel() -> Any:
+    @helion.kernel(backend="cute")
+    def identity(x: torch.Tensor, layout: torch.Tensor) -> torch.Tensor:
+        out = torch.empty_like(x)
+        for tile in hl.tile(x.numel()):
+            out[tile] = x[tile]
+        return out
+
+    return identity
+
+
+def _runtime_layout(bound: Any) -> torch.Tensor:
+    return cast("torch.Tensor", bound.env.runtime_arg_values_by_name["layout"])
 
 
 @onlyBackends(["cute"])
@@ -6686,45 +6719,6 @@ class TestCuteBackend(TestCase):
             _ensure_cute_dsl_arch_env((tensor,))
             self.assertEqual(os.environ["CUTE_DSL_ARCH"], expected)
 
-    def test_cute_launcher_cache_key_includes_wrapper_plans(self) -> None:
-        cute_kernel = type("DummyCuteKernel", (), {})()
-        schema_key = (("tensor", 2, "float32"),)
-        block = (32, 1, 1)
-        created: list[str] = []
-
-        def make_wrapper(*_args: object, **_kwargs: object) -> str:
-            created.append("wrapper")
-            return f"wrapper-{len(created)}"
-
-        with patch("helion.runtime._create_cute_wrapper", side_effect=make_wrapper):
-            cute_kernel._helion_cute_wrapper_plans = [{"kind": "plan-a"}]
-            wrapper_a0 = _get_compiled_cute_launcher(cute_kernel, schema_key, block)
-            wrapper_a1 = _get_compiled_cute_launcher(cute_kernel, schema_key, block)
-            cute_kernel._helion_cute_wrapper_plans = [{"kind": "plan-b"}]
-            wrapper_b = _get_compiled_cute_launcher(cute_kernel, schema_key, block)
-
-        self.assertEqual(wrapper_a0, wrapper_a1)
-        self.assertNotEqual(wrapper_a0, wrapper_b)
-
-    def test_cute_launcher_cache_key_includes_cluster_shape(self) -> None:
-        cute_kernel = type("DummyCuteKernel", (), {})()
-        schema_key = (("tensor", 2, "float32"),)
-        block = (32, 1, 1)
-        created: list[str] = []
-
-        def make_wrapper(*_args: object, **_kwargs: object) -> str:
-            created.append("wrapper")
-            return f"wrapper-{len(created)}"
-
-        with patch("helion.runtime._create_cute_wrapper", side_effect=make_wrapper):
-            cute_kernel._helion_cute_wrapper_plans = [{"kind": "plan-a"}]
-            cute_kernel._helion_cute_cluster_shape = (1, 1, 1)
-            wrapper_a = _get_compiled_cute_launcher(cute_kernel, schema_key, block)
-            cute_kernel._helion_cute_cluster_shape = (2, 1, 1)
-            wrapper_b = _get_compiled_cute_launcher(cute_kernel, schema_key, block)
-
-        self.assertNotEqual(wrapper_a, wrapper_b)
-
     def test_cute_launcher_cache_key_includes_compile_options(self) -> None:
         cute_kernel = type("DummyCuteKernel", (), {})()
         schema_key = (("tensor", 2, "float32"),)
@@ -6841,9 +6835,9 @@ class TestCuteBackend(TestCase):
             _cute_kernel: object,
             args: tuple[object, ...],
             grid: tuple[int, int, int],
-        ) -> tuple[tuple[tuple[object, ...], ...], tuple[object, ...]]:
+        ) -> helion_runtime._CuteLaunchArgCacheEntry:
             build_calls.append((args, grid))
-            return (("scalar", "int"),), ("launch-arg", *args, *grid)
+            return _launch_entry((("scalar", "int"),), ("launch-arg", *args, *grid))
 
         with (
             patch("helion.runtime._build_cute_schema_and_args", side_effect=fake_build),
@@ -6883,6 +6877,7 @@ class TestCuteBackend(TestCase):
         build_calls: list[tuple[object, ...]] = []
         launched_args: list[tuple[object, ...]] = []
         streams = iter(["stream-A", "stream-B", "stream-C"])
+        owned_tensors = (torch.empty(1),)
 
         class FakeCompiled:
             def __call__(self, *args: object) -> tuple[str, tuple[object, ...]]:
@@ -6893,10 +6888,10 @@ class TestCuteBackend(TestCase):
             _cute_kernel: object,
             args: tuple[object, ...],
             _grid: tuple[int, int, int],
-        ) -> tuple[tuple[tuple[object, ...], ...], tuple[object, ...]]:
+        ) -> helion_runtime._CuteLaunchArgCacheEntry:
             build_calls.append(args)
             # Note: no stream baked into the returned launch args.
-            return (("scalar", "int"),), ("launch-arg",)
+            return _launch_entry((("scalar", "int"),), ("launch-arg",), owned_tensors)
 
         with (
             patch("helion.runtime._build_cute_schema_and_args", side_effect=fake_build),
@@ -6907,6 +6902,7 @@ class TestCuteBackend(TestCase):
                 "helion.runtime._get_compiled_cute_launcher",
                 return_value=FakeCompiled(),
             ),
+            patch("helion.runtime._record_cute_owned_launch_tensors") as record_owned,
         ):
             first = default_cute_launcher(cute_kernel, (1,), 7, block=(32, 1, 1))
             second = default_cute_launcher(cute_kernel, (1,), 7, block=(32, 1, 1))
@@ -6915,6 +6911,8 @@ class TestCuteBackend(TestCase):
         # Build (and thus the cached args) happens once; the stream is appended
         # fresh on each of the three launches.
         self.assertEqual(build_calls, [(7,)])
+        self.assertEqual(record_owned.call_count, 3)
+        record_owned.assert_called_with(owned_tensors)
         self.assertEqual(
             launched_args,
             [
@@ -6926,6 +6924,598 @@ class TestCuteBackend(TestCase):
         self.assertEqual(first, ("launched", ("launch-arg", "stream-A")))
         self.assertEqual(second, ("launched", ("launch-arg", "stream-B")))
         self.assertEqual(third, ("launched", ("launch-arg", "stream-C")))
+
+    def test_cute_owned_launch_tensor_survives_cross_stream_lru_eviction(
+        self,
+    ) -> None:
+        if DEVICE.type != "cuda":
+            self.skipTest("CuTe launch ownership test needs CUDA")
+        cuda_runtime = importlib.import_module("cuda.bindings.runtime")
+        producer_stream = torch.cuda.Stream(device=DEVICE)
+        launch_stream = torch.cuda.Stream(device=DEVICE)
+        tensor_size = 4 * 1024 * 1024
+
+        with torch.cuda.stream(producer_stream):
+            owned = torch.ones(tensor_size, dtype=torch.uint8, device=DEVICE)
+        producer_stream.synchronize()
+        owned_ref = weakref.ref(owned)
+        output = torch.empty_like(owned)
+        launch = _launch_entry((), (), (owned,))
+
+        with torch.cuda.stream(launch_stream):
+            # Keep the raw-pointer read pending while the launch-argument entry
+            # is evicted. Unlike a torch op, this memcpy does not retain or
+            # register the source tensor with the caching allocator.
+            torch.cuda._sleep(500_000_000)
+            copy_result = cuda_runtime.cudaMemcpyAsync(
+                output.data_ptr(),
+                owned.data_ptr(),
+                tensor_size,
+                cuda_runtime.cudaMemcpyKind.cudaMemcpyDeviceToDevice,
+                cuda_runtime.cudaStream_t(launch_stream.cuda_stream),
+            )
+            self.assertEqual(copy_result[0], cuda_runtime.cudaError_t.cudaSuccess)
+            helion_runtime._record_cute_owned_launch_tensors(launch.owned_tensors)
+
+        cache = {0: launch}
+        cache.update(
+            (index, _launch_entry((), ()))
+            for index in range(1, helion_runtime._CUTE_LAUNCH_ARG_CACHE_LIMIT + 1)
+        )
+        cache.pop(next(iter(cache)))
+        self.assertNotIn(0, cache)
+        del launch, owned
+        gc.collect()
+        self.assertIsNone(owned_ref())
+
+        with torch.cuda.stream(producer_stream):
+            replacement = torch.full(
+                (tensor_size,), 7, dtype=torch.uint8, device=DEVICE
+            )
+        producer_stream.synchronize()
+        launch_stream.synchronize()
+
+        self.assertTrue(torch.all(replacement == 7).item())
+        self.assertTrue(torch.all(output == 1).item())
+
+    def test_grouped_dynamic_tensormap_workspace_isolated_by_stream(self) -> None:
+        if not torch.cuda.is_available():
+            self.skipTest("dynamic TensorMap workspace test needs CUDA")
+        runtime_mod = importlib.import_module("helion.runtime")
+        cute_kernel = type("DummyCuteKernel", (), {})()
+        cute_kernel._helion_cute_wrapper_plans = [
+            {
+                "kind": "tcgen05_grouped_static_persistent",
+                "layout_idx": 0,
+                "dynamic_ab_tensormaps": True,
+            }
+        ]
+        layout = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+        streams = [
+            torch.cuda.Stream(device=DEVICE)
+            for _ in range(
+                runtime_mod._TCGEN05_DYNAMIC_TENSORMAP_WORKSPACE_CACHE_LIMIT + 1
+            )
+        ]
+        stream_a, stream_b = streams[:2]
+
+        with torch.cuda.stream(stream_a):
+            context_a = runtime_mod._cute_dynamic_tensormap_contexts(
+                cute_kernel, (layout,)
+            )
+            workspace_a = runtime_mod._tcgen05_grouped_dynamic_tensormap_workspace(
+                cute_kernel, device=layout.device, tensormap_count=2
+            )
+            workspace_a_again = (
+                runtime_mod._tcgen05_grouped_dynamic_tensormap_workspace(
+                    cute_kernel, device=layout.device, tensormap_count=2
+                )
+            )
+        with torch.cuda.stream(stream_b):
+            context_b = runtime_mod._cute_dynamic_tensormap_contexts(
+                cute_kernel, (layout,)
+            )
+            workspace_b = runtime_mod._tcgen05_grouped_dynamic_tensormap_workspace(
+                cute_kernel, device=layout.device, tensormap_count=2
+            )
+
+        self.assertIs(workspace_a_again, workspace_a)
+        self.assertIsNot(workspace_b, workspace_a)
+        self.assertNotEqual(workspace_b.data_ptr(), workspace_a.data_ptr())
+        self.assertNotEqual(context_a, context_b)
+        self.assertIsNone(context_a[0][3])
+        self.assertIsNone(context_b[0][3])
+
+        for stream in streams[2:]:
+            with torch.cuda.stream(stream):
+                runtime_mod._tcgen05_grouped_dynamic_tensormap_workspace(
+                    cute_kernel, device=layout.device, tensormap_count=2
+                )
+        cache = cute_kernel._helion_tcgen05_dynamic_tensormap_workspace_cache
+        self.assertEqual(
+            len(cache), runtime_mod._TCGEN05_DYNAMIC_TENSORMAP_WORKSPACE_CACHE_LIMIT
+        )
+        self.assertFalse(any(cached is workspace_a for cached in cache.values()))
+        self.assertTrue(any(cached is workspace_b for cached in cache.values()))
+
+    def test_grouped_static_capture_query_fails_closed(self) -> None:
+        if DEVICE.type != "cuda":
+            self.skipTest("grouped capture context test needs CUDA")
+        cute_kernel = type("DummyCuteKernel", (), {})()
+        cute_kernel._helion_cute_wrapper_plans = [
+            {"kind": "tcgen05_grouped_static_persistent", "layout_idx": 0}
+        ]
+        layout = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+
+        with (
+            patch(
+                "helion.runtime._cuda_stream_capture_context",
+                side_effect=BackendUnsupported("cute", "capture query failed"),
+            ),
+            self.assertRaisesRegex(BackendUnsupported, "capture query failed"),
+        ):
+            helion_runtime._cute_grouped_launch_contexts(cute_kernel, (layout,))
+
+    def test_grouped_dynamic_tensormap_workspace_retained_per_capture(self) -> None:
+        if not torch.cuda.is_available():
+            self.skipTest("dynamic TensorMap workspace test needs CUDA")
+        runtime_mod = importlib.import_module("helion.runtime")
+        cute_kernel = type("DummyCuteKernel", (), {})()
+        cute_kernel._helion_cute_wrapper_plans = [
+            {
+                "kind": "tcgen05_grouped_static_persistent",
+                "layout_idx": 0,
+                "dynamic_ab_tensormaps": True,
+            }
+        ]
+        layout = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+        args = (layout,)
+        grid = (1, 1, 1)
+        capture_stream = torch.cuda.Stream(device=DEVICE)
+        graphs: list[torch.cuda.CUDAGraph] = []
+        contexts: list[tuple[int, int | None]] = []
+        workspaces: list[torch.Tensor] = []
+        launch_keys: list[tuple[object, ...]] = []
+        guards: list[Any] = []
+        replay_aliases: list[Callable[[], None]] = []
+
+        runtime_mod.get_num_sm(DEVICE)
+        runtime_mod._cuda_stream_capture_context(DEVICE)
+        torch.empty(1, device=DEVICE).fill_(0)
+        torch.cuda.synchronize(DEVICE)
+        for value in range(1, 10):
+            with runtime_mod.cute_cuda_graph(stream=capture_stream) as graph:
+                replay_alias = graph.replay
+                context = runtime_mod._cuda_stream_capture_context(DEVICE)
+                launch_key = runtime_mod._cute_launch_arg_cache_key(
+                    cute_kernel, args, grid
+                )
+                if guards:
+                    self.assertFalse(guards[-1].matches(cute_kernel, args, grid))
+                guard = runtime_mod._cute_last_launch_arg_guard(cute_kernel, args, grid)
+                self.assertTrue(guard.matches(cute_kernel, args, grid))
+                workspace = runtime_mod._tcgen05_grouped_dynamic_tensormap_workspace(
+                    cute_kernel, device=DEVICE, tensormap_count=2
+                )
+                workspace.fill_(value)
+            graphs.append(graph)
+            contexts.append(context)
+            workspaces.append(workspace)
+            launch_keys.append(launch_key)
+            guards.append(guard)
+            replay_aliases.append(replay_alias)
+
+        self.assertEqual({context[0] for context in contexts}, {contexts[0][0]})
+        self.assertNotIn(None, {context[1] for context in contexts})
+        self.assertEqual(len({context[1] for context in contexts}), len(contexts))
+        self.assertEqual(len({workspace.data_ptr() for workspace in workspaces}), 9)
+        self.assertEqual(len(set(launch_keys)), 9)
+        cache = cute_kernel._helion_tcgen05_dynamic_tensormap_workspace_cache
+        self.assertEqual(len(cache), 9)
+        for workspace in workspaces:
+            self.assertTrue(any(cached is workspace for cached in cache.values()))
+
+        replay_aliases[0]()
+        replay_aliases[-1]()
+        torch.cuda.synchronize(DEVICE)
+        self.assertEqual(workspaces[0].flatten()[0].item(), 1)
+        self.assertEqual(workspaces[-1].flatten()[0].item(), 9)
+
+        replay_alias = replay_aliases.pop(0)
+        first_graph = graphs.pop(0)
+        graph_refs = [
+            weakref.ref(first_graph),
+            *(weakref.ref(graph) for graph in graphs),
+        ]
+        del first_graph
+        gc.collect()
+        self.assertIsNotNone(graph_refs[0]())
+        self.assertEqual(len(cache), 9)
+        replay_alias()
+        torch.cuda.synchronize(DEVICE)
+        self.assertEqual(workspaces[0].flatten()[0].item(), 1)
+
+        graphs.clear()
+        replay_aliases.clear()
+        del graph, replay_alias
+        gc.collect()
+        self.assertTrue(all(graph_ref() is None for graph_ref in graph_refs))
+        self.assertEqual(cache, {})
+
+    def test_grouped_dynamic_tensormap_context_guards_launcher_caches(
+        self,
+    ) -> None:
+        runtime_mod = importlib.import_module("helion.runtime")
+        cute_kernel = type("DummyCuteKernel", (), {})()
+        context_a = (("cuda", 0, 101, None),)
+        context_b = (("cuda", 0, 202, 7),)
+        current_context: list[tuple[tuple[str, int | None, int, int | None], ...]] = [
+            context_a
+        ]
+        build_calls: list[tuple[tuple[str, int | None, int, int | None], ...]] = []
+        launched_args: list[tuple[object, ...]] = []
+        streams = iter(["stream-A", "stream-B", "stream-C"])
+        generic_matcher = runtime_mod._cute_last_launch_cache_entry
+
+        class FakeCompiled:
+            def __call__(self, *args: object) -> tuple[str, tuple[object, ...]]:
+                launched_args.append(args)
+                return ("launched", args)
+
+        def fake_contexts(
+            _cute_kernel: object,
+            _args: tuple[object, ...],
+        ) -> tuple[tuple[str, int | None, int, int | None], ...]:
+            return current_context[0]
+
+        def fake_build(
+            _cute_kernel: object,
+            _args: tuple[object, ...],
+            _grid: tuple[int, int, int],
+        ) -> helion_runtime._CuteLaunchArgCacheEntry:
+            build_calls.append(current_context[0])
+            return _launch_entry((("scalar", "int"),), (current_context[0],))
+
+        with (
+            patch(
+                "helion.runtime._cute_dynamic_tensormap_contexts",
+                side_effect=fake_contexts,
+            ),
+            patch("helion.runtime._build_cute_schema_and_args", side_effect=fake_build),
+            patch(
+                "helion.runtime._cute_current_stream", side_effect=lambda: next(streams)
+            ),
+            patch(
+                "helion.runtime._get_compiled_cute_launcher",
+                return_value=FakeCompiled(),
+            ),
+            patch(
+                "helion.runtime._cute_last_launch_cache_entry",
+                wraps=generic_matcher,
+            ) as generic_match,
+        ):
+            first = default_cute_launcher(cute_kernel, (1,), 7)
+            current_context[0] = context_b
+            second = default_cute_launcher(cute_kernel, (1,), 7)
+            third = default_cute_launcher(cute_kernel, (1,), 7)
+
+        self.assertEqual(build_calls, [context_a, context_b])
+        self.assertEqual(generic_match.call_count, 3)
+        self.assertEqual(
+            launched_args,
+            [
+                (context_a, "stream-A"),
+                (context_b, "stream-B"),
+                (context_b, "stream-C"),
+            ],
+        )
+        self.assertEqual(first, ("launched", (context_a, "stream-A")))
+        self.assertEqual(second, ("launched", (context_b, "stream-B")))
+        self.assertEqual(third, ("launched", (context_b, "stream-C")))
+
+    def test_grouped_capture_retains_generated_tensors_beyond_launch_lru(
+        self,
+    ) -> None:
+        if not torch.cuda.is_available():
+            self.skipTest("grouped capture ownership test needs CUDA")
+        runtime_mod = importlib.import_module("helion.runtime")
+        cute_kernel = type("DummyCuteKernel", (), {})()
+        plan = {
+            "kind": "tcgen05_grouped_static_persistent",
+            "layout_idx": 0,
+            "n_sizes_idx": 1,
+            "group_count": 2,
+            "bm": 128,
+            "bn": 64,
+            "bk": 128,
+            "n_size": 256,
+            "k_total_size": 128,
+            "problem_sizes_arg": "tcgen05_grouped_problem_sizes_0",
+            "starts_arg": "tcgen05_grouped_starts_0",
+            "total_clusters_arg": "tcgen05_grouped_total_clusters_0",
+        }
+        cute_kernel._helion_cute_wrapper_plans = [plan]
+
+        def make_args(signature: int) -> tuple[torch.Tensor, torch.Tensor]:
+            first_group_size = 128 * (signature + 1)
+            layout = torch.cat(
+                (
+                    torch.zeros(first_group_size, dtype=torch.int32, device=DEVICE),
+                    torch.ones(128, dtype=torch.int32, device=DEVICE),
+                )
+            )
+            n_offset = 64 * (signature % 4)
+            n_sizes = torch.tensor(
+                (64 + n_offset, 256 - n_offset),
+                dtype=torch.int32,
+                device=DEVICE,
+            )
+            return layout, n_sizes
+
+        def fake_imports() -> tuple[object, object, object]:
+            def make_ptr(
+                _dtype: object,
+                data_ptr: int,
+                _space: object,
+                *,
+                assumed_align: int,
+            ) -> int:
+                self.assertEqual(assumed_align, 16)
+                return data_ptr
+
+            return object(), make_ptr, object()
+
+        first_args = make_args(0)
+        grid = (1, 1, 1)
+        # Metadata must be ready before capture, but leave the launch-argument
+        # cache cold so capture exercises the new-build ownership path.
+        runtime_mod._build_tcgen05_grouped_static_metadata(
+            cute_kernel, plan, first_args
+        )
+        runtime_mod._cuda_stream_capture_context(DEVICE)
+        torch.empty(1, device=DEVICE).fill_(0)
+        torch.cuda.synchronize(DEVICE)
+
+        capture_stream = torch.cuda.Stream(device=DEVICE)
+        with (
+            patch(
+                "helion.runtime._get_cute_launcher_imports", side_effect=fake_imports
+            ),
+            patch("helion.runtime._torch_dtype_to_cutlass", side_effect=str),
+        ):
+            with runtime_mod.cute_cuda_graph(stream=capture_stream) as graph:
+                runtime_mod._build_cached_cute_schema_and_args(
+                    cute_kernel, first_args, grid
+                )
+                capture_owned = cute_kernel._helion_cute_capture_owned_launch_tensors
+                self.assertEqual(len(capture_owned), 1)
+                capture_context = next(iter(capture_owned))
+                capture_tensors = capture_owned[capture_context]
+                problem_tensor = next(
+                    tensor for tensor in capture_tensors.values() if tensor.ndim == 2
+                )
+                problem_ref = weakref.ref(problem_tensor)
+                problem_ptr = problem_tensor.data_ptr()
+
+                # Drop one promoted tensor, then ensure the cache-hit path
+                # promotes it again from the bounded launch ownership cache.
+                capture_tensors.pop(id(problem_tensor))
+                runtime_mod._build_cached_cute_schema_and_args(
+                    cute_kernel, first_args, grid
+                )
+                self.assertIs(capture_tensors[id(problem_tensor)], problem_tensor)
+                problem_tensor.fill_(17)
+
+            torch.cuda.synchronize(DEVICE)
+            problem_tensor.zero_()
+            torch.cuda.synchronize(DEVICE)
+            del capture_owned, capture_tensors, problem_tensor
+
+            other_args = [make_args(signature) for signature in range(1, 9)]
+            for args in other_args:
+                runtime_mod._build_cached_cute_schema_and_args(cute_kernel, args, grid)
+
+        self.assertEqual(len(cute_kernel._helion_cute_launch_arg_cache), 8)
+        self.assertTrue(
+            all(
+                entry.owned_tensors
+                for entry in cute_kernel._helion_cute_launch_arg_cache.values()
+            )
+        )
+        self.assertEqual(
+            len(cute_kernel._helion_tcgen05_grouped_static_metadata_cache), 8
+        )
+        first_problem = problem_ref()
+        self.assertIsNotNone(first_problem)
+        assert first_problem is not None
+        self.assertFalse(
+            any(
+                tensor is first_problem
+                for entry in cute_kernel._helion_cute_launch_arg_cache.values()
+                for tensor in entry.owned_tensors
+            )
+        )
+        self.assertFalse(
+            any(
+                value is first_problem
+                for entry in cute_kernel._helion_tcgen05_grouped_static_metadata_cache.values()
+                for value in entry.result.tensors()
+            )
+        )
+        del first_problem
+
+        gc.collect()
+        allocator_churn = [
+            torch.empty((2, 4), dtype=torch.int32, device=DEVICE) for _ in range(32)
+        ]
+        graph.replay()
+        torch.cuda.synchronize(DEVICE)
+
+        retained_problem = problem_ref()
+        self.assertIsNotNone(retained_problem)
+        assert retained_problem is not None
+        self.assertEqual(retained_problem.data_ptr(), problem_ptr)
+        self.assertTrue(torch.all(retained_problem == 17).item())
+        self.assertEqual(len(allocator_churn), 32)
+
+        capture_owned = cute_kernel._helion_cute_capture_owned_launch_tensors
+        self.assertEqual(len(capture_owned), 1)
+        del retained_problem, graph
+        gc.collect()
+        self.assertEqual(capture_owned, {})
+        self.assertIsNone(problem_ref())
+
+    def test_grouped_worklist_metadata_cache_guards_source_extents(self) -> None:
+        if DEVICE.type != "cuda":
+            self.skipTest("grouped worklist metadata test needs CUDA")
+        runtime_mod = importlib.import_module("helion.runtime")
+        plan = {
+            "kind": "tcgen05_grouped_static_persistent",
+            "layout_idx": 2,
+            "lhs_idx": 0,
+            "rhs_idx": 1,
+            "group_count": 1,
+            "bm": 128,
+            "bn": 64,
+            "bk": 64,
+            "n_size": 64,
+            "k_total_size": 64,
+            "worklist_metadata": True,
+            "dynamic_ab_tensormaps": True,
+            "problem_sizes_arg": "problem_sizes",
+            "starts_arg": "starts",
+            "real_groups_arg": "real_groups",
+            "total_clusters_arg": "total_clusters",
+        }
+        cute_kernel = type("DummyCuteKernel", (), {})()
+        cute_kernel._helion_cute_wrapper_plans = [plan]
+        layout = torch.tensor(((0, 0, 128, 0),), dtype=torch.int32, device=DEVICE)
+        rhs = torch.empty((1, 64, 64), dtype=torch.bfloat16, device=DEVICE)
+
+        runtime_mod._build_tcgen05_grouped_static_metadata(
+            cute_kernel,
+            plan,
+            (torch.empty((128, 64), dtype=torch.bfloat16, device=DEVICE), rhs, layout),
+        )
+        with self.assertRaisesRegex(BackendUnsupported, "row exceeds A extent"):
+            runtime_mod._build_tcgen05_grouped_static_metadata(
+                cute_kernel,
+                plan,
+                (
+                    torch.empty((64, 64), dtype=torch.bfloat16, device=DEVICE),
+                    rhs,
+                    layout,
+                ),
+            )
+        with self.assertRaisesRegex(BackendUnsupported, "outside B_grouped"):
+            runtime_mod._build_tcgen05_grouped_static_metadata(
+                cute_kernel,
+                plan,
+                (
+                    torch.empty((128, 64), dtype=torch.bfloat16, device=DEVICE),
+                    torch.empty((0, 64, 64), dtype=torch.bfloat16, device=DEVICE),
+                    layout,
+                ),
+            )
+
+    def test_grouped_inference_metadata_tracks_value_mutation(self) -> None:
+        if DEVICE.type != "cuda":
+            self.skipTest("grouped inference metadata test needs CUDA")
+        runtime_mod = importlib.import_module("helion.runtime")
+        kernel_mod = importlib.import_module("helion.runtime.kernel")
+        plan = {
+            "kind": "tcgen05_grouped_static_persistent",
+            "layout_idx": 0,
+            "n_sizes_idx": 1,
+            "group_count": 2,
+            "bm": 128,
+            "bn": 64,
+            "bk": 128,
+            "n_size": 256,
+            "k_total_size": 128,
+            "problem_sizes_arg": "problem_sizes",
+            "starts_arg": "starts",
+            "total_clusters_arg": "total_clusters",
+        }
+        cute_kernel = type("DummyCuteKernel", (), {})()
+        cute_kernel._helion_cute_wrapper_plans = [plan]
+
+        with torch.inference_mode():
+            layout = torch.cat(
+                (
+                    torch.zeros(128, dtype=torch.int32, device=DEVICE),
+                    torch.ones(128, dtype=torch.int32, device=DEVICE),
+                )
+            )
+            n_sizes = torch.tensor((64, 256), dtype=torch.int32, device=DEVICE)
+            args = (layout, n_sizes)
+            self.assertTrue(torch.is_inference(layout))
+
+            first = runtime_mod._build_tcgen05_grouped_static_metadata(
+                cute_kernel, plan, args
+            )
+            self.assertIs(
+                runtime_mod._build_tcgen05_grouped_static_metadata(
+                    cute_kernel, plan, args
+                ),
+                first,
+            )
+            first_problem_sizes = first.result.problem_sizes.cpu().clone()
+            first_launch_key = runtime_mod._cute_launch_arg_cache_key(
+                cute_kernel, args, (1, 1, 1)
+            )
+            first_guard = runtime_mod._cute_last_launch_arg_guard(
+                cute_kernel, args, (1, 1, 1)
+            )
+            values_cache = kernel_mod.WeakIdKeyDictionary()
+            self.assertEqual(
+                kernel_mod._cute_int_1d_tensor_values(n_sizes, values_cache),
+                (64, 256),
+            )
+
+            n_sizes.copy_(torch.tensor((128, 192), dtype=torch.int32, device=DEVICE))
+
+            self.assertFalse(first_guard.matches(cute_kernel, args, (1, 1, 1)))
+            self.assertNotEqual(
+                runtime_mod._cute_launch_arg_cache_key(cute_kernel, args, (1, 1, 1)),
+                first_launch_key,
+            )
+            self.assertEqual(
+                kernel_mod._cute_int_1d_tensor_values(n_sizes, values_cache),
+                (128, 192),
+            )
+            updated = runtime_mod._build_tcgen05_grouped_static_metadata(
+                cute_kernel, plan, args
+            )
+
+        self.assertIsNot(updated, first)
+        self.assertFalse(
+            torch.equal(updated.result.problem_sizes.cpu(), first_problem_sizes)
+        )
+        with (
+            patch(
+                "helion.runtime._cuda_stream_capture_context",
+                return_value=(123, 456),
+            ),
+            self.assertRaisesRegex(BackendUnsupported, "inference tensor.*capture"),
+        ):
+            runtime_mod._tcgen05_grouped_tensor_mutation_key(n_sizes)
+
+    def test_grouped_metadata_rejects_mixed_cuda_devices(self) -> None:
+        if torch.cuda.device_count() < 2:
+            self.skipTest("mixed-device grouped metadata test needs two CUDA devices")
+        runtime_mod = importlib.import_module("helion.runtime")
+        device0 = torch.device(DEVICE.type, 0)
+        device1 = torch.device(DEVICE.type, 1)
+        layout = torch.zeros(128, dtype=torch.int32, device=device0)
+        other = torch.empty(1, device=device1)
+
+        with self.assertRaisesRegex(
+            BackendUnsupported, "every tensor argument.*mismatched argument indices"
+        ):
+            runtime_mod._build_tcgen05_grouped_static_metadata(
+                object(), {"layout_idx": 0}, (layout, other)
+            )
 
     def test_cute_build_schema_excludes_stream_from_cached_args(self) -> None:
         # The stream must never be part of the cached launch args produced by
@@ -6956,14 +7546,14 @@ class TestCuteBackend(TestCase):
                 "helion.runtime._cute_kernel_param_is_constexpr", return_value=(False,)
             ),
         ):
-            schema, launch_args = _build_cute_schema_and_args(
+            launch = helion_runtime._build_cute_schema_and_args(
                 cute_kernel, (7,), (2, 1, 1)
             )
 
         # Args end with the grid; the stream is not baked in.
-        self.assertEqual(launch_args, (7, 2, 1, 1))
-        self.assertNotIn(sentinel_stream, launch_args)
-        self.assertEqual(schema, (("scalar", "int"),))
+        self.assertEqual(launch.launch_args, (7, 2, 1, 1))
+        self.assertNotIn(sentinel_stream, launch.launch_args)
+        self.assertEqual(launch.schema, (("scalar", "int"),))
 
     def test_cute_launcher_launch_arg_cache_distinguishes_signed_zero(
         self,
@@ -6981,9 +7571,9 @@ class TestCuteBackend(TestCase):
             _cute_kernel: object,
             args: tuple[object, ...],
             _grid: tuple[int, int, int],
-        ) -> tuple[tuple[tuple[object, ...], ...], tuple[object, ...]]:
+        ) -> helion_runtime._CuteLaunchArgCacheEntry:
             build_calls.append(args)
-            return (("scalar", "float"),), (f"float-{len(build_calls)}",)
+            return _launch_entry((("scalar", "float"),), (f"float-{len(build_calls)}",))
 
         with (
             patch("helion.runtime._build_cute_schema_and_args", side_effect=fake_build),
@@ -7001,6 +7591,54 @@ class TestCuteBackend(TestCase):
         self.assertEqual(positive, ("launched", ("float-1", "stream")))
         self.assertEqual(negative, ("launched", ("float-2", "stream")))
 
+    def test_cute_launcher_last_launch_distinguishes_scalar_kinds(self) -> None:
+        cute_kernel = type("DummyCuteKernel", (), {})()
+        build_calls: list[tuple[object, ...]] = []
+        launched_args: list[tuple[object, ...]] = []
+
+        class FakeCompiled:
+            def __call__(self, *args: object) -> tuple[str, tuple[object, ...]]:
+                launched_args.append(args)
+                return ("launched", args)
+
+        def fake_build(
+            _cute_kernel: object,
+            args: tuple[object, ...],
+            _grid: tuple[int, int, int],
+        ) -> helion_runtime._CuteLaunchArgCacheEntry:
+            build_calls.append(args)
+            scalar_kind = type(args[0]).__name__
+            return _launch_entry(
+                (("scalar", scalar_kind),), (f"{scalar_kind}-{len(build_calls)}",)
+            )
+
+        with (
+            patch("helion.runtime._build_cute_schema_and_args", side_effect=fake_build),
+            patch("helion.runtime._cute_current_stream", return_value="stream"),
+            patch(
+                "helion.runtime._get_compiled_cute_launcher",
+                return_value=FakeCompiled(),
+            ),
+        ):
+            bool_launch = default_cute_launcher(cute_kernel, (1,), True)
+            bool_hit = default_cute_launcher(cute_kernel, (1,), True)
+            int_miss = default_cute_launcher(cute_kernel, (1,), 1)
+            float_miss = default_cute_launcher(cute_kernel, (1,), 1.0)
+
+        self.assertEqual(build_calls, [(True,), (1,), (1.0,)])
+        self.assertEqual(bool_launch, bool_hit)
+        self.assertEqual(int_miss, ("launched", ("int-2", "stream")))
+        self.assertEqual(float_miss, ("launched", ("float-3", "stream")))
+        self.assertEqual(
+            launched_args,
+            [
+                ("bool-1", "stream"),
+                ("bool-1", "stream"),
+                ("int-2", "stream"),
+                ("float-3", "stream"),
+            ],
+        )
+
     def test_cute_launcher_sets_arch_env_only_before_first_compile(self) -> None:
         cute_kernel = type("DummyCuteKernel", (), {})()
 
@@ -7011,7 +7649,7 @@ class TestCuteBackend(TestCase):
         with (
             patch(
                 "helion.runtime._build_cute_schema_and_args",
-                return_value=((("scalar", "int"),), ("launch-arg",)),
+                return_value=_launch_entry((("scalar", "int"),), ("launch-arg",)),
             ),
             patch("helion.runtime._cute_current_stream", return_value="stream"),
             patch("helion.runtime._create_cute_wrapper", return_value="jit-wrapper"),
@@ -7084,9 +7722,11 @@ class TestCuteBackend(TestCase):
             _cute_kernel: object,
             args: tuple[object, ...],
             _grid: tuple[int, int, int],
-        ) -> tuple[tuple[tuple[object, ...], ...], tuple[object, ...]]:
+        ) -> helion_runtime._CuteLaunchArgCacheEntry:
             build_calls.append(cast("torch.Tensor", args[0]).data_ptr())
-            return (("tensor", "torch.float32", 1),), (f"ptr-{len(build_calls)}",)
+            return _launch_entry(
+                (("tensor", "torch.float32", 1),), (f"ptr-{len(build_calls)}",)
+            )
 
         with (
             patch("helion.runtime._build_cute_schema_and_args", side_effect=fake_build),
@@ -7107,6 +7747,489 @@ class TestCuteBackend(TestCase):
         )
         self.assertEqual(first, second)
         self.assertEqual(third, ("launched", ("ptr-2", "stream")))
+
+    def test_cute_launcher_last_launch_guards_launch_parameters(self) -> None:
+        cute_kernel = type("DummyCuteKernel", (), {})()
+        build_calls: list[tuple[object, ...]] = []
+        compiled_calls: list[tuple[tuple[int, int, int], str | None]] = []
+        launched: list[tuple[int, tuple[object, ...]]] = []
+
+        class FakeCompiled:
+            def __init__(self, index: int) -> None:
+                self.index = index
+
+            def __call__(self, *args: object) -> tuple[int, tuple[object, ...]]:
+                launched.append((self.index, args))
+                return (self.index, args)
+
+        def fake_build(
+            _cute_kernel: object,
+            args: tuple[object, ...],
+            grid: tuple[int, int, int],
+        ) -> helion_runtime._CuteLaunchArgCacheEntry:
+            build_calls.append((*args, *grid))
+            return _launch_entry((("scalar", "int"),), ("launch", *args, *grid))
+
+        def fake_get(
+            _cute_kernel: object,
+            _schema_key: tuple[tuple[object, ...], ...],
+            block: tuple[int, int, int],
+            *,
+            compile_options: str | None = None,
+            arch_args: tuple[object, ...] | None = None,
+        ) -> FakeCompiled:
+            self.assertIsNotNone(arch_args)
+            compiled_calls.append((block, compile_options))
+            return FakeCompiled(len(compiled_calls))
+
+        with (
+            patch("helion.runtime._build_cute_schema_and_args", side_effect=fake_build),
+            patch("helion.runtime._cute_current_stream", return_value="stream"),
+            patch("helion.runtime._get_compiled_cute_launcher", side_effect=fake_get),
+        ):
+            first = default_cute_launcher(cute_kernel, (2,), 7, block=(32, 1, 1))
+            second = default_cute_launcher(cute_kernel, (2,), 7, block=(32, 1, 1))
+            options_miss = default_cute_launcher(
+                cute_kernel,
+                (2,),
+                7,
+                block=(32, 1, 1),
+                cute_compile_options="--generate-line-info",
+            )
+            block_miss = default_cute_launcher(
+                cute_kernel,
+                (2,),
+                7,
+                block=(64, 1, 1),
+                cute_compile_options="--generate-line-info",
+            )
+            grid_miss = default_cute_launcher(
+                cute_kernel,
+                (3,),
+                7,
+                block=(64, 1, 1),
+                cute_compile_options="--generate-line-info",
+            )
+
+        self.assertEqual(first[0], 1)
+        self.assertEqual(second[0], 1)
+        self.assertEqual(options_miss[0], 2)
+        self.assertEqual(block_miss[0], 3)
+        self.assertEqual(grid_miss[0], 4)
+        self.assertEqual(len(compiled_calls), 4)
+        self.assertEqual(
+            [entry[0] for entry in launched],
+            [1, 1, 2, 3, 4],
+        )
+        self.assertEqual(
+            build_calls,
+            [
+                (7, 2, 1, 1),
+                (7, 3, 1, 1),
+            ],
+        )
+
+    def test_cute_launcher_last_launch_guards_tensor_pointer_and_schema(
+        self,
+    ) -> None:
+        if DEVICE.type != "cuda":
+            self.skipTest("CuTe launcher tensor guard test needs CUDA")
+        cute_kernel = type("DummyCuteKernel", (), {})()
+        tensor = torch.empty(4, device=DEVICE)
+        same_storage_view = tensor.view_as(tensor)
+        self.assertEqual(tensor.data_ptr(), same_storage_view.data_ptr())
+        self.assertNotEqual(id(tensor), id(same_storage_view))
+        build_calls: list[tuple[int, bool]] = []
+        compiled_calls: list[int] = []
+
+        class FakeCompiled:
+            def __call__(self, *args: object) -> tuple[str, tuple[object, ...]]:
+                return ("launched", args)
+
+        def fake_build(
+            _cute_kernel: object,
+            args: tuple[object, ...],
+            _grid: tuple[int, int, int],
+        ) -> helion_runtime._CuteLaunchArgCacheEntry:
+            build_calls.append(
+                (
+                    id(args[0]),
+                    bool(
+                        getattr(
+                            _cute_kernel,
+                            "_helion_cute_disable_bake_tensor_shapes",
+                            False,
+                        )
+                    ),
+                )
+            )
+            return _launch_entry(
+                (("tensor", "torch.float32", 1),), (f"ptr-{len(build_calls)}",)
+            )
+
+        def fake_get(*_args: object, **_kwargs: object) -> FakeCompiled:
+            compiled_calls.append(len(compiled_calls) + 1)
+            return FakeCompiled()
+
+        with (
+            patch("helion.runtime._build_cute_schema_and_args", side_effect=fake_build),
+            patch("helion.runtime._cute_current_stream", return_value="stream"),
+            patch("helion.runtime._get_compiled_cute_launcher", side_effect=fake_get),
+        ):
+            first = default_cute_launcher(cute_kernel, (1,), tensor)
+            second = default_cute_launcher(cute_kernel, (1,), tensor)
+            view_hit = default_cute_launcher(cute_kernel, (1,), same_storage_view)
+            cute_kernel._helion_cute_disable_bake_tensor_shapes = True
+            schema_miss = default_cute_launcher(cute_kernel, (1,), same_storage_view)
+
+        self.assertEqual(first, ("launched", ("ptr-1", "stream")))
+        self.assertEqual(second, first)
+        self.assertEqual(view_hit, first)
+        self.assertEqual(schema_miss, ("launched", ("ptr-2", "stream")))
+        self.assertEqual(
+            build_calls,
+            [
+                (id(tensor), False),
+                (id(same_storage_view), True),
+            ],
+        )
+        self.assertEqual(len(compiled_calls), 2)
+
+    def test_cute_launcher_last_launch_misses_on_same_tensor_metadata_mutation(
+        self,
+    ) -> None:
+        if DEVICE.type != "cuda":
+            self.skipTest("CuTe launcher tensor guard test needs CUDA")
+        cute_kernel = type("DummyCuteKernel", (), {})()
+        base = torch.empty(32, device=DEVICE)
+        tensor = base.as_strided((4, 2), (2, 1), 0)
+        tensor_id = id(tensor)
+        build_calls: list[tuple[tuple[int, ...], tuple[int, ...], int, int]] = []
+
+        class FakeCompiled:
+            def __call__(self, *args: object) -> tuple[str, tuple[object, ...]]:
+                return ("launched", args)
+
+        def fake_build(
+            _cute_kernel: object,
+            args: tuple[object, ...],
+            _grid: tuple[int, int, int],
+        ) -> helion_runtime._CuteLaunchArgCacheEntry:
+            tensor_arg = cast("torch.Tensor", args[0])
+            build_calls.append(
+                (
+                    tuple(int(size) for size in tensor_arg.shape),
+                    tuple(int(stride) for stride in tensor_arg.stride()),
+                    int(tensor_arg.storage_offset()),
+                    int(tensor_arg.data_ptr()),
+                )
+            )
+            return _launch_entry(
+                (("tensor", "torch.float32", 2),), (f"ptr-{len(build_calls)}",)
+            )
+
+        with (
+            patch("helion.runtime._build_cute_schema_and_args", side_effect=fake_build),
+            patch("helion.runtime._cute_current_stream", return_value="stream"),
+            patch(
+                "helion.runtime._get_compiled_cute_launcher",
+                return_value=FakeCompiled(),
+            ),
+        ):
+            first = default_cute_launcher(cute_kernel, (1,), tensor)
+            second = default_cute_launcher(cute_kernel, (1,), tensor)
+            tensor.as_strided_((4, 2), (1, 4), 0)
+            stride_miss = default_cute_launcher(cute_kernel, (1,), tensor)
+            tensor.as_strided_((4, 2), (2, 1), 1)
+            offset_miss = default_cute_launcher(cute_kernel, (1,), tensor)
+
+        self.assertEqual(id(tensor), tensor_id)
+        self.assertEqual(first, second)
+        self.assertEqual(stride_miss, ("launched", ("ptr-2", "stream")))
+        self.assertEqual(offset_miss, ("launched", ("ptr-3", "stream")))
+        self.assertEqual(
+            [(shape, stride, offset) for shape, stride, offset, _ in build_calls],
+            [
+                ((4, 2), (2, 1), 0),
+                ((4, 2), (1, 4), 0),
+                ((4, 2), (2, 1), 1),
+            ],
+        )
+        self.assertEqual(build_calls[0][3], build_calls[1][3])
+        self.assertNotEqual(build_calls[1][3], build_calls[2][3])
+
+    def test_kernel_late_cute_specialization_rekeys_bound_kernel(self) -> None:
+        identity = _runtime_identity_kernel()
+        x = torch.empty(1)
+        layout = torch.zeros(128, dtype=torch.int64)
+        args = (x, layout)
+        bound = identity.bind(args)
+        signature = identity._base_specialization_key(args)
+        plan: dict[str, object] = {
+            "kind": "tcgen05_grouped_static_persistent",
+            "layout_bind_idx": 1,
+            "group_count": 1,
+            "bm": 128,
+        }
+        kernel_mod = importlib.import_module("helion.runtime.kernel")
+        self.assertEqual(
+            kernel_mod._cute_grouped_static_tail_extra_descriptors([plan]), ()
+        )
+        plan.update(
+            grouped_static_has_m_tail=True,
+            grouped_static_has_n_tail=False,
+        )
+        bound.env.cute_resolved_wrapper_plans = [plan]
+        self.assertEqual(bound._base_spec_key, signature)
+        with bound.env, bound._runtime_arg_values_for_codegen():
+            self.assertEqual(
+                bound.env.runtime_arg_values_by_name,
+                {"x": x, "layout": layout},
+            )
+            bound._register_cute_grouped_static_tail_specializations()
+
+        key0 = identity._fast_dispatch_key(args)
+        self.assertIs(identity.bind(args), bound)
+        layout[64:] = -1
+        key1 = identity._fast_dispatch_key(args)
+
+        self.assertNotEqual(key0, key1)
+        self.assertIsNot(identity.bind(args), bound)
+
+    def test_kernel_growing_late_specialization_evicts_all_stale_keys(self) -> None:
+        identity = _runtime_identity_kernel()
+        x = torch.empty(1)
+        layout_a = torch.tensor([0, 0], dtype=torch.int64)
+        args_a = (x, layout_a)
+        signature = identity._base_specialization_key(args_a)
+        bound_a = identity.bind(args_a)
+
+        def first(values: Sequence[object]) -> Hashable:
+            return int(cast("torch.Tensor", values[1])[0].item())
+
+        def last(values: Sequence[object]) -> Hashable:
+            return int(cast("torch.Tensor", values[1])[-1].item())
+
+        identity._extend_bound_kernel_specializations(
+            bound_a, signature, [first], args_a
+        )
+        args_b = (x, torch.tensor([1, 1], dtype=torch.int64))
+        bound_b = identity.bind(args_b)
+        self.assertIsNot(bound_b, bound_a)
+        identity._dispatch_cache.update(old_a=bound_a, old_b=bound_b)
+
+        identity._extend_bound_kernel_specializations(
+            bound_a, signature, [last], args_a
+        )
+
+        signature_entries = [
+            (key, cached_bound)
+            for key, cached_bound in identity._bound_kernels.items()
+            if key.specialization_key == signature
+        ]
+        self.assertEqual(len(signature_entries), 1)
+        self.assertEqual(signature_entries[0][0].extra_results, (0, 0))
+        self.assertIs(signature_entries[0][1], bound_a)
+        self.assertEqual(identity._dispatch_cache, {})
+
+    def test_bound_kernel_runtime_args_are_scoped_to_codegen(self) -> None:
+        @helion.kernel()
+        def identity(
+            x: torch.Tensor, layout: torch.Tensor, n_sizes: torch.Tensor
+        ) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.numel()):
+                out[tile] = x[tile]
+            return out
+
+        x = torch.empty(16, device=DEVICE)
+        layout = torch.tensor([0], device=DEVICE, dtype=torch.int64)
+        n_sizes = torch.tensor([128], device=DEVICE, dtype=torch.int64)
+        bound = identity.bind((x, layout, n_sizes))
+        layout_ref = weakref.ref(layout)
+
+        self.assertEqual(bound.env.runtime_arg_values_by_name, {})
+        with bound._runtime_arg_values_for_codegen():
+            self.assertEqual(
+                bound.env.runtime_arg_values_by_name,
+                {"x": x, "layout": layout, "n_sizes": n_sizes},
+            )
+        self.assertEqual(bound.env.runtime_arg_values_by_name, {})
+
+        del layout
+        gc.collect()
+        self.assertIsNone(layout_ref())
+
+    def test_bound_kernel_codegen_uses_stable_bind_and_current_call_args(self) -> None:
+        identity = _runtime_identity_kernel()
+        x = torch.empty(1)
+        layout_a = torch.zeros(1, dtype=torch.int64)
+        layout_b = torch.ones(1, dtype=torch.int64)
+        bound = identity.bind((x, layout_a))
+        self.assertIs(identity.bind((x, layout_b)), bound)
+        delayed_codegen_layouts: list[torch.Tensor] = []
+
+        def fake_generate_ast(*_args: object, **_kwargs: object) -> ast.Module:
+            delayed_codegen_layouts.append(_runtime_layout(bound))
+            return ast.parse("pass")
+
+        with patch("helion.runtime.kernel.generate_ast", side_effect=fake_generate_ast):
+            bound.to_code(helion.Config(block_sizes=[1]))
+
+        self.assertEqual(delayed_codegen_layouts, [layout_a])
+        call_codegen_layouts: list[torch.Tensor] = []
+
+        def fake_ensure(_args: tuple[object, ...]) -> None:
+            with bound._runtime_arg_values_for_codegen():
+                call_codegen_layouts.append(_runtime_layout(bound))
+            bound._run = lambda _x, layout: layout
+
+        with patch.object(bound, "ensure_config_exists", side_effect=fake_ensure):
+            result = bound(x, layout_b)
+
+        self.assertEqual(call_codegen_layouts, [layout_b])
+        self.assertIs(result, layout_b)
+
+    def test_concurrent_first_compile_uses_each_calls_runtime_args(self) -> None:
+        identity = _runtime_identity_kernel()
+        x = torch.empty(1)
+        layouts = {
+            "a": torch.zeros(1, dtype=torch.int64),
+            "b": torch.ones(1, dtype=torch.int64),
+        }
+        bind_lock = identity._bind_lock
+        both_binds_waiting = threading.Event()
+        bind_attempts: list[None] = []
+
+        class TrackingBindLock:
+            def __enter__(self) -> None:
+                bind_attempts.append(None)
+                if len(bind_attempts) == 2:
+                    both_binds_waiting.set()
+                bind_lock.acquire()
+
+            def __exit__(self, *_args: object) -> None:
+                bind_lock.release()
+
+        identity._bind_lock = TrackingBindLock()
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            bind_lock.acquire()
+            try:
+                bound_a = executor.submit(identity.bind, (x, layouts["a"]))
+                bound_b = executor.submit(identity.bind, (x, layouts["b"]))
+                self.assertTrue(both_binds_waiting.wait(timeout=5))
+            finally:
+                bind_lock.release()
+            bound = bound_a.result(timeout=5)
+            self.assertIs(bound_b.result(timeout=5), bound)
+        identity._bind_lock = bind_lock
+
+        first_compile_entered = threading.Event()
+        second_compile_waiting = threading.Event()
+        release_first_compile = threading.Event()
+        seen_layouts: list[torch.Tensor] = []
+        compile_lock = bound._first_compile_lock
+
+        class TrackingCompileLock:
+            def __enter__(self) -> None:
+                if first_compile_entered.is_set():
+                    second_compile_waiting.set()
+                compile_lock.acquire()
+
+            def __exit__(self, *_args: object) -> None:
+                compile_lock.release()
+
+        bound._first_compile_lock = cast("Any", TrackingCompileLock())
+
+        def layout_value(values: tuple[object, ...]) -> int:
+            return int(cast("torch.Tensor", values[1]).item())
+
+        def fake_ensure(current_bound: Any, call_args: tuple[object, ...]) -> None:
+            with current_bound._runtime_arg_values_for_codegen():
+                seen_layouts.append(_runtime_layout(current_bound))
+            if current_bound is bound:
+                first_compile_entered.set()
+                self.assertTrue(release_first_compile.wait(timeout=5))
+                identity._extend_bound_kernel_specializations(
+                    current_bound,
+                    current_bound._base_spec_key,
+                    [layout_value],
+                    call_args,
+                )
+            current_bound._run = lambda _x, layout: layout
+
+        with (
+            patch(
+                "helion.runtime.kernel.BoundKernel.ensure_config_exists",
+                new=fake_ensure,
+            ),
+            ThreadPoolExecutor(max_workers=2) as executor,
+        ):
+            future_a = executor.submit(identity, x, layouts["a"])
+            self.assertTrue(first_compile_entered.wait(timeout=5))
+            future_b = executor.submit(identity, x, layouts["b"])
+            try:
+                self.assertTrue(second_compile_waiting.wait(timeout=5))
+            finally:
+                release_first_compile.set()
+            output_a = future_a.result(timeout=5)
+            output_b = future_b.result(timeout=5)
+
+        self.assertEqual(seen_layouts, [layouts["a"], layouts["b"]])
+        self.assertIs(output_a, layouts["a"])
+        self.assertIs(output_b, layouts["b"])
+        rebound_b = identity.bind((x, layouts["b"]))
+        self.assertIsNot(rebound_b, bound)
+        fast_key_b = identity._fast_dispatch_key((x, layouts["b"]))
+        self.assertIsNotNone(fast_key_b)
+        assert fast_key_b is not None
+        self.assertIs(identity._dispatch_cache[fast_key_b], rebound_b)
+
+        def stale_run(*_args: object) -> torch.Tensor:
+            raise AssertionError("fast dispatch used the pre-specialization kernel")
+
+        bound._run = stale_run
+        self.assertIs(identity(x, layouts["b"]), layouts["b"])
+
+    def test_compile_cache_lookup_normalizes_config_copy(self) -> None:
+        identity = _runtime_identity_kernel()
+        bound = identity.bind((torch.empty(16), torch.empty(1)))
+        config = helion.Config(block_sizes=[16])
+        normalized = bound._normalized_config_copy(config)
+        self.assertNotEqual(config, normalized)
+        compiled = cast("Any", lambda x: x)
+        bound._compile_cache[normalized] = compiled
+
+        self.assertIs(bound.compile_config(config), compiled)
+        self.assertEqual(config, helion.Config(block_sizes=[16]))
+
+    def test_bound_kernel_ignores_non_tensor_runtime_args(self) -> None:
+        @dataclass(frozen=True)
+        class RuntimeMetadata:
+            layout: torch.Tensor
+            label: str
+
+        @helion.kernel()
+        def identity(x: torch.Tensor, metadata: RuntimeMetadata) -> torch.Tensor:
+            out = torch.empty_like(x)
+            for tile in hl.tile(x.numel()):
+                out[tile] = x[tile]
+            return out
+
+        x = torch.empty(16, device=DEVICE)
+        layout = torch.tensor([0], device=DEVICE, dtype=torch.int64)
+        metadata = RuntimeMetadata(layout=layout, label="grouped-layout")
+        metadata_ref = weakref.ref(metadata)
+        layout_ref = weakref.ref(layout)
+        bound = identity.bind((x, metadata))
+
+        with bound._runtime_arg_values_for_codegen():
+            self.assertEqual(bound.env.runtime_arg_values_by_name, {"x": x})
+
+        del metadata, layout
+        gc.collect()
+        self.assertIsNone(metadata_ref())
+        self.assertIsNone(layout_ref())
 
     def test_cute_launcher_tensor_shape_baking(self) -> None:
         tensor = torch.empty((2, 128, 64), device=DEVICE, dtype=torch.float16)
@@ -7131,12 +8254,12 @@ class TestCuteBackend(TestCase):
                 kernel = type("DummyCuteKernel", (), {})()
                 kernel._helion_cute_wrapper_plans = [plan]
                 kernel._helion_cute_disable_bake_tensor_shapes = disable_bake
-                schema, launch_args = _build_cute_schema_and_args(
+                launch = helion_runtime._build_cute_schema_and_args(
                     kernel, (tensor,), (128, 2, 1)
                 )
                 if expected_baked:
                     self.assertEqual(
-                        schema,
+                        launch.schema,
                         (
                             (
                                 "tensor",
@@ -7147,10 +8270,10 @@ class TestCuteBackend(TestCase):
                             ),
                         ),
                     )
-                    self.assertEqual(len(launch_args), 4)
+                    self.assertEqual(len(launch.launch_args), 4)
                 else:
-                    self.assertEqual(schema, (("tensor", "torch.float16", 3),))
-                    self.assertEqual(len(launch_args), 10)
+                    self.assertEqual(launch.schema, (("tensor", "torch.float16", 3),))
+                    self.assertEqual(len(launch.launch_args), 10)
 
     def test_cute_cluster_shape_from_wrapper_plans(self) -> None:
         self.assertIsNone(_cute_cluster_shape_from_wrapper_plans([]))

--- a/test/test_cute_device_state.py
+++ b/test/test_cute_device_state.py
@@ -133,6 +133,8 @@ class _StatementCaptureGenerateAST(GenerateAST):
         )
         self.statements_stack = [target]
         self._statement_owner_fx_node = None
+        self._statements_by_owner_node_id = {}
+        self._track_statement_owners = True
         self._device_loop = device_loop
 
     def _record_statement_thread_references(

--- a/test/test_fast_dispatch_key.py
+++ b/test/test_fast_dispatch_key.py
@@ -181,6 +181,31 @@ class TestFastDispatchKey(unittest.TestCase):
         k1 = _with_key._fast_dispatch_key((x,))
         self.assertNotEqual(k0, k1)
 
+    def test_key_fn_is_evaluated_once_with_specialization_extras(self) -> None:
+        calls = 0
+
+        def user_key(x: torch.Tensor) -> int:
+            nonlocal calls
+            calls += 1
+            return int(x.numel())
+
+        @helion.kernel(static_shapes=True, key=user_key)
+        def _with_key(x: torch.Tensor) -> torch.Tensor:
+            return x
+
+        args = (torch.empty(64),)
+        signature = _with_key._base_specialization_key(args)
+        _with_key._specialize_extra[signature] = [lambda values: len(values)]
+        _with_key._has_specialization_extras = True
+        calls = 0
+
+        key = _with_key._fast_dispatch_key(args)
+
+        self.assertIsNotNone(key)
+        self.assertEqual(calls, 1)
+        assert isinstance(key, tuple)
+        self.assertEqual(key[-2:], (64, (1,)))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Stacked PRs:
 * #3042
 * #3034
 * #3033
 * __->__#3032
 * #3031


--- --- ---

## Implementation

This stack layer implements the compiler-to-runtime contract required to launch grouped CuTe kernels.

- Resolves grouped layout, size, worklist, and direct pointer/stride metadata arguments back to original bindings, while holding codegen-only top-level tensors through weak references so compiling a kernel does not retain caller inputs.
- Builds scheduler metadata from ordered rank-1 layouts or compact `[W, 4]` worklists, including group order, source extents, tile alignment, M/N/K tails, and `[group, start, actual_m, aligned_m]` rows.
- Publishes each completed launch as an immutable cache entry containing its schema, launch arguments, grouped metadata, and owned tensors. Keys cover tensor identity and mutation, source extents, device, stream/capture context, schema, launch geometry, compile options, and SM count.
- Makes inference-tensor metadata mutation-safe by keying ordinary tensors on version counters and inference tensors on copied values; inference metadata is rejected during graph capture where a stable mutation key cannot be established.
- Introduces `_CuteCUDAGraph`, a `torch.cuda.CUDAGraph` subclass that owns captured workspaces, TensorMaps, pointer tables, cache entries, and metadata until graph destruction. Replay records those tensors on the current replay stream before dispatch.
- Keeps eager dynamic-TensorMap workspaces in a bounded cache keyed by device, SM count, descriptor count, stream, and capture ID. Entries captured through `cute_cuda_graph` are graph-owned; raw `torch.cuda.graph` captures are retained conservatively because their Python graph owner is not observable.
- Serializes eager binding and first compilation, rebinds after codegen discovers late specialization keys, and rekeys fast dispatch to the final bound kernel. Dynamo capture avoids tracing the lock while preserving static-index metadata in cache keys.

The measurements below use the complete stack rather than this launcher-only layer in isolation.

## Performance Results

Geometric-mean latency ratios are shown first. Ratios are Helion/reference, so values below `1.0` favor Helion.

| Reference | Repeat 1 geomean | Repeat 2 geomean | Result |
|---|---:|---:|---|
| CUTLASS CuTeDSL | **0.8928** | **0.8926** | Helion is 10.7% lower latency; 7/7 wins in both repeats |
| DeepGEMM | **0.9949** | **0.9948** | Helion is 0.5% lower latency; 6/8 wins in both repeats |

Both final repeats were collected from clean Helion commit `a9f735af2d8a78c0de49c45e99ca0a6503a40ca3` on an NVIDIA B200 (compute capability 10.0), using PyTorch `2.11.0+cu130` and CUDA `13.0`. The benchmark workers pin `HELION_CUTE_MMA_IMPL=tcgen05` to measure this path directly.

### CUTLASS CuTeDSL

Physical GPU 0. Each case uses common inputs, correctness checks, CUDA graph replay, and a fresh subprocess with fresh compiler caches. Each graph is prepared with `--compile-warmups 2`; both replays then receive five cache-warmup calls and one shared 10-second BF16 thermal warmup. Six paired `triton.testing.do_bench` rounds alternate Helion/CUTLASS and CUTLASS/Helion. Every round uses CUDA-event timing with `warmup=1000 ms` and `rep=500 ms`; the table reports the median of the six round means. The CUTLASS graph includes its pinned-host pointer-table upload.

Pinned reference: NVIDIA/cutlass `db1c288993354c88e551c40c19a8fb93a774a241`, `grouped_gemm.py` SHA256 `05b74a05682c024557d83284e32f973ed5be4f0d1a1a12c72fe7824c29f7e94f`, and `nvidia-cutlass-dsl==4.5.2`. Harness SHA256: `7e2efca8f381b431ab40ba3fd476378989308ef0d77766f62805a6b920039c75`.

| Case | Exact per-group `M x N x K` | R1 Helion us | R1 CUTLASS us | R1 H/C | R2 Helion us | R2 CUTLASS us | R2 H/C |
|---|---|---:|---:|---:|---:|---:|---:|
| `default_small_parity` | G3 [g0: 128x128x128, g1: 512x128x128, g2: 128x256x128] | 10.229 | 14.355 | 0.713 | 10.247 | 14.382 | 0.712 |
| `doc_no_mn_tail` | G4 [g0: 8192x1280x32, g1: 128x384x1536, g2: 640x1280x16, g3: 640x128x16] | 22.532 | 24.572 | 0.917 | 22.534 | 24.575 | 0.917 |
| `doc_no_mn_g3_192_extra_full` | G4 [g0: 8192x1280x32, g1: 128x384x1536, g2: 640x1280x16, g3: 640x192x16] | 22.921 | 24.583 | 0.932 | 22.897 | 24.611 | 0.930 |
| `doc_original` | G4 [g0: 8192x1280x32, g1: 16x384x1536, g2: 640x1280x16, g3: 640x160x16] | 22.958 | 24.622 | 0.932 | 22.909 | 24.582 | 0.932 |
| `doc_mtail_g1_g3_192_extra_full` | G4 [g0: 8192x1280x32, g1: 16x384x1536, g2: 640x1280x16, g3: 640x192x16] | 22.625 | 24.673 | 0.917 | 22.610 | 24.588 | 0.920 |
| `doc_mtail_g1_only` | G4 [g0: 8192x1280x32, g1: 16x384x1536, g2: 640x1280x16, g3: 640x128x16] | 22.580 | 24.590 | 0.918 | 22.573 | 24.578 | 0.918 |
| `doc_ntail_g3_160` | G4 [g0: 8192x1280x32, g1: 128x384x1536, g2: 640x1280x16, g3: 640x160x16] | 23.222 | 24.578 | 0.945 | 23.197 | 24.575 | 0.944 |

```bash
CUDA_VISIBLE_DEVICES=0 conda run --no-capture-output -n helion \
  python benchmarks/cute/compare_grouped_gemm_backends.py \
  --cutlass-source /tmp/cutlass-db1c2889-grouped-gemm.py \
  --out-dir <fresh-output-dir> --cuda-visible-devices 0 \
  --seed 0 --compile-warmups 2 --num-runs 6 \
  --warmup-ms 1000 --rep-ms 500 --cache-warmup-calls 5 \
  --thermal-warmup-ms 10000 --stream-subprocesses
```

### DeepGEMM

Physical GPU 3. Official shape is `(G, expected M/group, N, K)`; `actual M/group` is the exact seed-0 DeepGEMM-compatible M stream shared by both implementations. Each row uses `--compile-warmups 2`, five alternating graph warmups, and one 10-second BF16 thermal warmup. Ten paired samples alternate which implementation runs first; each sample averages 50 graph replays. An 8 GB L2 clear matching upstream DeepGEMM's `bench_kineto` default runs before every replay and outside its CUDA-event interval. The table reports the median of the ten sample means, and each repeat uses fresh compiler caches.

Pinned reference: DeepGEMM `559d79fb6994a58b8a15b4b93bf13ccc16edf247`, CUTLASS submodule `f3fde58372d33e9a5650ba7b80fc48b3b49d40c8`, and M alignment 224. The only untracked reference-checkout path was DeepGEMM's generated `deep_gemm/include/fmt` directory. Harness SHA256: `484741ae5259f8ce4f2f6216dc25c29def001dcb25b231e555b95998a667271e`.

| Row | Official `(G, M, N, K)` | Actual M/group | R1 Helion us | R1 DeepGEMM us | R1 H/D | R2 Helion us | R2 DeepGEMM us | R2 H/D |
|---:|---|---|---:|---:|---:|---:|---:|---:|
| 0 | `(4, 8192, 6144, 7168)` | `9884, 9459, 7801, 7007` | 2646.708 | 2518.028 | 1.051 | 2677.416 | 2562.513 | 1.045 |
| 1 | `(4, 8192, 7168, 3072)` | `8247, 7724, 9586, 7225` | 1070.407 | 1093.971 | 0.978 | 1081.872 | 1096.028 | 0.987 |
| 2 | `(4, 8192, 4096, 4096)` | `8076, 8601, 10197, 8215` | 872.093 | 877.294 | 0.994 | 873.244 | 880.124 | 0.992 |
| 3 | `(4, 8192, 4096, 2048)` | `7119, 9449, 8773, 6965` | 395.633 | 409.112 | 0.967 | 398.398 | 408.255 | 0.976 |
| 4 | `(8, 4096, 6144, 7168)` | `5102, 5282, 4858, 5084, 3629, 4660, 5076, 4548` | 3051.274 | 3021.418 | 1.010 | 3036.491 | 2995.513 | 1.014 |
| 5 | `(8, 4096, 7168, 3072)` | `4027, 3114, 3934, 4368, 5111, 5242, 4039, 4993` | 1168.279 | 1199.356 | 0.974 | 1166.589 | 1210.240 | 0.964 |
| 6 | `(8, 4096, 4096, 4096)` | `3507, 4845, 4215, 2901, 4635, 3847, 4894, 4509` | 835.664 | 836.549 | 0.999 | 837.359 | 838.471 | 0.999 |
| 7 | `(8, 4096, 4096, 2048)` | `2870, 4080, 4999, 3466, 3666, 5006, 3336, 4261` | 400.494 | 405.255 | 0.988 | 401.995 | 408.534 | 0.984 |

```bash
CUDA_VISIBLE_DEVICES=3 conda run --no-capture-output -n helion \
  python benchmarks/cute/deepgemm_selected_path.py \
  --rows all --compare-deepgemm \
  --deepgemm-root /tmp/DeepGEMM-559d79fb --device cuda \
  --samples 10 --iters 50 --warmups 5 --compile-warmups 2 \
  --thermal-warmup-ms 10000 --l2-flush-bytes 8000000000 \
  --m-alignment 224 --artifact-dir <fresh-output-dir> \
  --json-output <fresh-output-dir>/selected_results.json
```

All correctness checks passed in both final repeats.
