### PR TITLE
Support CuTe grouped GEMM lowering

### DIFF
--- a/helion/_compiler/autotuner_heuristics/__init__.py
+++ b/helion/_compiler/autotuner_heuristics/__init__.py
@@ -11,6 +11,8 @@ from .cute import CuteReductionTileHeuristic
 from .cute import CuteReductionWideChunkHeuristic
 from .cute import CuteTcgen05ClusterM2FfiHeuristic
 from .cute import CuteTcgen05ClusterM2Heuristic
+from .cute import CuteTcgen05GroupedDynamicBk64Heuristic
+from .cute import CuteTcgen05GroupedStaticCommonKHeuristic
 from .cute import CuteTileVecHeuristic
 from .cute import CuteTileVecWarpPerRowHeuristic
 from .cute import CuteTileVecWarpReduceHeuristic
@@ -42,6 +44,8 @@ HEURISTICS_BY_BACKEND: dict[str, tuple[AutotunerHeuristicType, ...]] = {
         CuteFlashAttentionCausalLptHeuristic,
         CuteTcgen05ClusterM2FfiHeuristic,
         CuteTcgen05ClusterM2Heuristic,
+        CuteTcgen05GroupedStaticCommonKHeuristic,
+        CuteTcgen05GroupedDynamicBk64Heuristic,
         CuteReductionTileHeuristic,
         CuteReductionWideChunkHeuristic,
         CuteTileVecHeuristic,

--- a/helion/_compiler/autotuner_heuristics/cute.py
+++ b/helion/_compiler/autotuner_heuristics/cute.py
@@ -9,6 +9,12 @@ import torch
 from ...runtime.config import Config
 from ..cute.strategies import TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY
 from ..cute.strategies import Tcgen05PersistenceModel
+from ..cute.tcgen05_config import TCGEN05_GROUPED_DYNAMIC_AB4_STAGE
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_MODE_DYNAMIC
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_MODE_STATIC
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_STATIC_COMMON_K_BLOCK_PAIRS
+from ..cute.tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_M
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
 from ..cute.tcgen05_constants import TCGEN05_TWO_CTA_EDGE_K_TAIL_BLOCK_K
@@ -22,6 +28,7 @@ from .registry import AutotunerHeuristic
 
 if TYPE_CHECKING:
     from ...autotuner.config_spec import ConfigSpec
+    from ...autotuner.config_spec import MatmulFact
     from ...autotuner.config_spec import ReductionLoopSpec
     from ..compile_environment import CompileEnvironment
     from ..device_ir import DeviceIR
@@ -483,6 +490,220 @@ class CuteReductionWideChunkHeuristic(AutotunerHeuristic):
         if vec > 1:
             seed["cute_vector_widths"] = [vec]
         return Config(**seed)
+
+
+def _block_size_value_reachable(
+    spec: ConfigSpec,
+    block_index: int,
+    value: int,
+) -> bool:
+    if block_index < 0 or block_index >= len(spec.block_sizes):
+        return False
+    fragment = cast("Any", spec.block_sizes[block_index])._fragment(spec)
+    low = getattr(fragment, "low", None)
+    high = getattr(fragment, "high", None)
+    return isinstance(low, int) and isinstance(high, int) and low <= value <= high
+
+
+def _tcgen05_grouped_fact(env: CompileEnvironment) -> MatmulFact | None:
+    spec = env.config_spec
+    if (
+        not spec.cute_tcgen05_search_enabled
+        or len(spec.matmul_facts) != 1
+        or len(spec.block_sizes) != 3
+    ):
+        return None
+    fact = spec.matmul_facts[0]
+    if fact.lhs_dtype is not fact.rhs_dtype or fact.lhs_dtype not in (
+        torch.float16,
+        torch.bfloat16,
+    ):
+        return None
+    if (
+        fact.m_block_id is None
+        or fact.n_block_id is None
+        or fact.k_block_id is None
+        or fact.static_m is None
+        or fact.static_n is None
+        or fact.static_k is None
+    ):
+        return None
+    try:
+        block_indices = (
+            spec.block_sizes.block_id_to_index(fact.m_block_id),
+            spec.block_sizes.block_id_to_index(fact.n_block_id),
+            spec.block_sizes.block_id_to_index(fact.k_block_id),
+        )
+    except KeyError:
+        return None
+    if block_indices != (0, 1, 2):
+        return None
+    if fact.static_m % 128 != 0 or fact.static_n % 64 != 0:
+        return None
+    return fact
+
+
+def _tcgen05_grouped_dynamic_bk64_fact(env: CompileEnvironment) -> MatmulFact | None:
+    fact = _tcgen05_grouped_fact(env)
+    if fact is None or cast("int", fact.static_k) % 64 != 0:
+        return None
+    spec = env.config_spec
+    if not (
+        _block_size_value_reachable(spec, 0, 128)
+        and _block_size_value_reachable(spec, 1, 64)
+        and _block_size_value_reachable(spec, 2, 64)
+    ):
+        return None
+    if not spec._tcgen05_grouped_dynamic_ab4_fits_for_target(
+        dtype_bytes=fact.lhs_dtype.itemsize,
+        device=env.device,
+        bm=128,
+        bn=64,
+        bk=64,
+        cluster_m=1,
+        c_stages=2,
+    ):
+        return None
+    return fact
+
+
+def _tcgen05_grouped_seed_grid_is_valid(device_ir: DeviceIR, fact: MatmulFact) -> bool:
+    return (
+        len(device_ir.root_ids) == 1
+        and len(device_ir.grid_block_ids) == 1
+        and device_ir.grid_block_ids[0] == [fact.m_block_id, fact.n_block_id]
+    )
+
+
+def _tcgen05_grouped_static_common_k_block_k(static_k: int) -> int | None:
+    return next(
+        (bk for k, bk in TCGEN05_GROUPED_STATIC_COMMON_K_BLOCK_PAIRS if static_k == k),
+        None,
+    )
+
+
+def _tcgen05_grouped_static_common_k_fact(env: CompileEnvironment) -> MatmulFact | None:
+    fact = _tcgen05_grouped_fact(env)
+    if fact is None:
+        return None
+    bk = _tcgen05_grouped_static_common_k_block_k(cast("int", fact.static_k))
+    if bk is None:
+        return None
+    spec = env.config_spec
+    if not (
+        _block_size_value_reachable(spec, 0, 128)
+        and _block_size_value_reachable(spec, 1, 64)
+        and _block_size_value_reachable(spec, 2, bk)
+    ):
+        return None
+    return fact
+
+
+def _tcgen05_grouped_seed_config(bk: int) -> Config:
+    config = Config(
+        block_sizes=[128, 64, bk],
+        l2_groupings=[1],
+        loop_orders=[[0, 1]],
+        num_stages=2,
+        num_warps=8,
+        pid_type=TCGEN05_TWO_CTA_SEED_PID_TYPE,
+        tcgen05_cluster_m=1,
+        tcgen05_cluster_n=1,
+        tcgen05_ab_stages=2,
+        tcgen05_acc_stages=2,
+        tcgen05_c_stages=2,
+        tcgen05_num_epi_warps=4,
+    )
+    config.config[TCGEN05_GROUPED_MODE_CONFIG_KEY] = TCGEN05_GROUPED_MODE_STATIC
+    config.config[TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY] = (
+        Tcgen05PersistenceModel.STATIC_PERSISTENT.value
+    )
+    return config
+
+
+class CuteTcgen05GroupedStaticCommonKHeuristic(AutotunerHeuristic):
+    """Seed grouped-static configs for common K tails without partial TMA."""
+
+    name = "cute_tcgen05_grouped_static_common_k"
+    backend = "cute"
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        from ..cute.cute_mma import tcgen05_grouped_static_seed_has_common_k_proof
+
+        fact = _tcgen05_grouped_static_common_k_fact(env)
+        return (
+            fact is not None
+            and _tcgen05_grouped_seed_grid_is_valid(device_ir, fact)
+            and tcgen05_grouped_static_seed_has_common_k_proof(env, device_ir, fact)
+        )
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        fact = _tcgen05_grouped_static_common_k_fact(env)
+        if fact is None:
+            return None
+        static_k = cast("int", fact.static_k)
+        bk = _tcgen05_grouped_static_common_k_block_k(static_k)
+        if bk is None:
+            return None
+        config = _tcgen05_grouped_seed_config(bk)
+        if (
+            static_k >= 3 * bk
+            and static_k % bk == 0
+            and env.config_spec._tcgen05_ab_stages_three_fits(
+                bm=128,
+                bn=64,
+                bk=bk,
+                cluster_m=1,
+            )
+        ):
+            config.config["tcgen05_ab_stages"] = 3
+        return config
+
+
+class CuteTcgen05GroupedDynamicBk64Heuristic(AutotunerHeuristic):
+    """Seed the proven BK64 dynamic TensorMap grouped-static config.
+
+    This is intentionally narrow: it only fires for one tcgen05 FP16/BF16
+    rank-3 RHS grouped-NT matmul whose graph proves the exact per-group
+    ``k_sizes[safe_group]`` mask on both A and grouped B operands. The dynamic
+    TensorMap flag stays seed-only and is not exposed as a broad random-search
+    knob.
+    """
+
+    name = "cute_tcgen05_grouped_dynamic_bk64"
+    backend = "cute"
+
+    @classmethod
+    def is_eligible(cls, env: CompileEnvironment, device_ir: DeviceIR) -> bool:
+        from ..cute.cute_mma import tcgen05_grouped_dynamic_bk64_seed_has_exact_k_proof
+
+        fact = _tcgen05_grouped_dynamic_bk64_fact(env)
+        return (
+            fact is not None
+            and _tcgen05_grouped_seed_grid_is_valid(device_ir, fact)
+            and tcgen05_grouped_dynamic_bk64_seed_has_exact_k_proof(
+                env,
+                device_ir,
+                fact,
+            )
+        )
+
+    @classmethod
+    def get_seed_config(
+        cls, env: CompileEnvironment, device_ir: DeviceIR
+    ) -> Config | None:
+        fact = _tcgen05_grouped_dynamic_bk64_fact(env)
+        if fact is None:
+            return None
+        config = _tcgen05_grouped_seed_config(64)
+        config.config[TCGEN05_GROUPED_MODE_CONFIG_KEY] = TCGEN05_GROUPED_MODE_DYNAMIC
+        config.config[TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY] = 3
+        config.config["tcgen05_ab_stages"] = TCGEN05_GROUPED_DYNAMIC_AB4_STAGE
+        return config
 
 
 class CuteFlashAttentionHeuristic(AutotunerHeuristic):

--- a/helion/_compiler/backend.py
+++ b/helion/_compiler/backend.py
@@ -41,11 +41,13 @@ if TYPE_CHECKING:
     from ..runtime.config import Config
     from ..runtime.kernel import BoundKernel
     from ..runtime.settings import DotPrecision
+    from .compile_environment import CompileEnvironment
     from .cute.cute_mma import _CuteMmaNode
     from .device_function import Argument
     from .device_function import DeviceFunction
     from .device_ir import DeviceIR
     from .device_ir import GraphInfo
+    from .generate_ast import GenerateAST
     from .host_function import HostFunction
     from .tile_dispatch import TileStrategyDispatch
     from .tile_strategy import TileStrategy
@@ -952,7 +954,8 @@ class Backend(abc.ABC):
 
         if block_size_infos[0].is_flattened(config):
             block_size = functools.reduce(  # pyrefly: ignore[incompatible-overload-residual]
-                operator.mul, [bs.from_config_assert(config) for bs in block_size_infos]
+                operator.mul,
+                [bs.from_config_assert(config) for bs in block_size_infos],
             )
             return FlattenedTileStrategy(
                 fn,
@@ -1056,6 +1059,72 @@ def _largest_divisor_at_most(size: int, limit: int) -> int:
         if size % divisor == 0:
             return divisor
     return 1
+
+
+def _cute_rank3_rhs_static_full_tiles(
+    env: CompileEnvironment,
+    *,
+    root_grid_ids: Sequence[int],
+    k_block_id: int,
+    bm: int,
+    bn: int,
+    bk: int,
+) -> bool:
+    for block_id, block_size in (
+        (root_grid_ids[0], bm),
+        (root_grid_ids[1], bn),
+        (k_block_id, bk),
+    ):
+        size = env.block_sizes[block_id].size
+        if not isinstance(size, (int, torch.SymInt)):
+            return False
+        extent = env.size_hint(size)
+        if not env.known_equal(size, extent) or extent % block_size != 0:
+            return False
+    return True
+
+
+def _rank3_rhs_grouped_nt_can_use_specialized_mma(
+    node: torch.fx.Node,
+    *,
+    env: CompileEnvironment,
+    cg: GenerateAST,
+    config: Config,
+    mn_root_grid_ids: Sequence[int],
+    segment_root_grid_id: int | None,
+    k_block_id: int,
+    bm: int,
+    bn: int,
+    bk: int,
+) -> bool:
+    from .cute.cute_mma import _GroupedMmaAxes
+    from .cute.cute_mma import _prove_rank3_rhs_grouped_mma
+    from .cute.cute_mma import _tcgen05_cluster_m
+
+    proof = _prove_rank3_rhs_grouped_mma(
+        cg,
+        node,
+        config=config,
+        axes=_GroupedMmaAxes(
+            m_block_id=mn_root_grid_ids[0],
+            n_block_id=mn_root_grid_ids[1],
+            k_block_id=k_block_id,
+            segment_block_id=segment_root_grid_id,
+        ),
+    )
+    if proof is None:
+        return False
+    return proof.is_worklist or (
+        _tcgen05_cluster_m(config) == 1
+        and _cute_rank3_rhs_static_full_tiles(
+            env,
+            root_grid_ids=mn_root_grid_ids,
+            k_block_id=k_block_id,
+            bm=bm,
+            bn=bn,
+            bk=bk,
+        )
+    )
 
 
 def _specialized_mma_root_mn_block_ids(
@@ -2737,15 +2806,122 @@ class _SpecializedMmaPlan(NamedTuple):
     n_block_id: int
 
 
+def _grouped_rank3_specialized_mma_plan(
+    node: torch.fx.Node,
+    *,
+    fn: DeviceFunction,
+    k_block_id: int,
+    bk: int,
+    config: Config,
+    env: CompileEnvironment,
+) -> _SpecializedMmaPlan | None:
+    from .cute.cute_mma import _choose_mma_impl
+    from .host_function import HostFunction
+
+    if node.target is not torch.ops.aten.addmm.default:
+        return None
+    device_ir = HostFunction.current().device_ir
+    if len(device_ir.grid_block_ids) != 1:
+        return None
+    root_grid_ids = device_ir.grid_block_ids[0]
+    if len(root_grid_ids) == 2:
+        segment_root_grid_id = None
+        mn_root_grid_ids = root_grid_ids
+    elif len(root_grid_ids) == 3:
+        segment_root_grid_id = root_grid_ids[0]
+        mn_root_grid_ids = root_grid_ids[1:]
+    else:
+        return None
+    if segment_root_grid_id is not None:
+        segment_block = env.block_sizes[segment_root_grid_id].from_config(config)
+        if segment_block != 1:
+            return None
+    bm = env.block_sizes[mn_root_grid_ids[0]].from_config(config)
+    bn = env.block_sizes[mn_root_grid_ids[1]].from_config(config)
+    if not isinstance(bm, int) or not isinstance(bn, int):
+        return None
+    if not _rank3_rhs_grouped_nt_can_use_specialized_mma(
+        node,
+        env=env,
+        cg=fn.codegen,
+        config=config,
+        mn_root_grid_ids=mn_root_grid_ids,
+        segment_root_grid_id=segment_root_grid_id,
+        k_block_id=k_block_id,
+        bm=bm,
+        bn=bn,
+        bk=bk,
+    ):
+        return None
+    lhs_node = node.args[1] if len(node.args) > 1 else None
+    if not isinstance(lhs_node, torch.fx.Node):
+        return None
+    lhs_val = lhs_node.meta.get("val")
+    if not isinstance(lhs_val, torch.Tensor):
+        return None
+    mma_impl = _choose_mma_impl(
+        lhs_val.dtype,
+        bm=bm,
+        bn=bn,
+        bk=bk,
+        config=config,
+        input_device=lhs_val.device,
+    )
+    if mma_impl != "tcgen05":
+        return None
+    return _SpecializedMmaPlan(mma_impl, *mn_root_grid_ids)
+
+
+def _analyzed_specialized_mma_plan(
+    node: torch.fx.Node,
+    *,
+    k_block_id: int,
+    bk: int,
+    config: Config,
+    env: CompileEnvironment,
+) -> _SpecializedMmaPlan | None:
+    from .cute.cute_mma import _choose_mma_impl
+    from .cute.cute_mma import _mma_tiles_are_static_full
+    from .cute.cute_mma import analyze_cute_mma_node
+
+    candidate = analyze_cute_mma_node(node)
+    if (
+        candidate is None
+        or candidate.requires_accumulator_seed
+        or candidate.operands.k_block_id != k_block_id
+    ):
+        return None
+    root_mn_block_ids = _specialized_mma_root_mn_block_ids(candidate, config)
+    if root_mn_block_ids is None:
+        return None
+    bm = env.block_sizes[root_mn_block_ids[0]].from_config(config)
+    bn = env.block_sizes[root_mn_block_ids[1]].from_config(config)
+    if not isinstance(bm, int) or not isinstance(bn, int):
+        return None
+    if candidate.operands.has_leading_passthrough and not _mma_tiles_are_static_full(
+        candidate.operands, bm=bm, bn=bn, bk=bk
+    ):
+        return None
+    lhs_val = candidate.operands.lhs.source_fake
+    mma_impl = _choose_mma_impl(
+        lhs_val.dtype,
+        bm=bm,
+        bn=bn,
+        bk=bk,
+        config=config,
+        input_device=lhs_val.device,
+    )
+    if mma_impl == "universal":
+        return None
+    return _SpecializedMmaPlan(mma_impl, *root_mn_block_ids)
+
+
 def _kernel_specialized_mma_plan(
     fn: DeviceFunction,
     *,
     config: Config,
 ) -> _SpecializedMmaPlan | None:
     from .compile_environment import CompileEnvironment
-    from .cute.cute_mma import _choose_mma_impl
-    from .cute.cute_mma import _mma_tiles_are_static_full
-    from .cute.cute_mma import analyze_cute_mma_node
     from .device_ir import ForLoopGraphInfo
     from .host_function import HostFunction
 
@@ -2768,38 +2944,25 @@ def _kernel_specialized_mma_plan(
             continue
         bk = block_sizes[0]
         for node in graph_info.graph.nodes:
-            candidate = analyze_cute_mma_node(node)
-            if (
-                candidate is None
-                or candidate.requires_accumulator_seed
-                or candidate.operands.k_block_id != block_ids[0]
-            ):
-                continue
-            root_mn_block_ids = _specialized_mma_root_mn_block_ids(candidate, config)
-            if root_mn_block_ids is None:
-                continue
-            bm = env.block_sizes[root_mn_block_ids[0]].from_config(config)
-            bn = env.block_sizes[root_mn_block_ids[1]].from_config(config)
-            if not isinstance(bm, int) or not isinstance(bn, int):
-                continue
-            if (
-                candidate.operands.has_leading_passthrough
-                and not _mma_tiles_are_static_full(
-                    candidate.operands, bm=bm, bn=bn, bk=bk
-                )
-            ):
-                continue
-            lhs_val = candidate.operands.lhs.source_fake
-            mma_impl = _choose_mma_impl(
-                lhs_val.dtype,
-                bm=bm,
-                bn=bn,
+            plan = _analyzed_specialized_mma_plan(
+                node,
+                k_block_id=block_ids[0],
                 bk=bk,
                 config=config,
-                input_device=lhs_val.device,
+                env=env,
             )
-            if mma_impl != "universal":
-                return _SpecializedMmaPlan(mma_impl, *root_mn_block_ids)
+            if plan is not None:
+                return plan
+            plan = _grouped_rank3_specialized_mma_plan(
+                node,
+                fn=fn,
+                k_block_id=block_ids[0],
+                bk=bk,
+                config=config,
+                env=env,
+            )
+            if plan is not None:
+                return plan
     return None
 
 

--- a/helion/_compiler/cute/backend.py
+++ b/helion/_compiler/cute/backend.py
@@ -26,6 +26,7 @@ from ..backend import _active_loop_block_ids
 from ..backend import _attention_flash_gate_enabled
 from ..backend import _attention_flash_supported
 from ..backend import _attention_softmax_pattern_head_dim
+from ..backend import _grouped_rank3_specialized_mma_plan
 from ..backend import _kernel_specialized_mma_impl
 from ..backend import _kernel_specialized_mma_plan
 from ..backend import _largest_divisor_at_most
@@ -119,7 +120,71 @@ def _detect_mma_loop(
     return False
 
 
-def _detect_specialized_mma_loop(
+def _specialized_mma_root_thread_layout(
+    root_block_ids: Sequence[int], config: Config
+) -> tuple[int, int, int, int] | None:
+    from ..compile_environment import CompileEnvironment
+
+    if len(root_block_ids) != 2:
+        return None
+    env = CompileEnvironment.current()
+    root_block_sizes: list[int] = []
+    root_thread_counts: list[int] = []
+    root_thread_auto: list[bool] = []
+    for block_id in root_block_ids:
+        block_size = env.block_sizes[block_id].from_config(config)
+        if not isinstance(block_size, int):
+            return None
+        root_block_sizes.append(block_size)
+        threads = env.config_spec.num_threads.config_get(
+            config.num_threads, block_id, 0
+        )
+        root_thread_counts.append(threads if threads > 0 else block_size)
+        root_thread_auto.append(threads == 0)
+    if functools.reduce(operator.mul, root_thread_counts, 1) > 1024:
+        for idx in (1, 0):
+            if not root_thread_auto[idx]:
+                continue
+            other_threads = root_thread_counts[1 - idx]
+            next_threads = _largest_divisor_at_most(
+                root_block_sizes[idx], max(1024 // max(other_threads, 1), 1)
+            )
+            root_thread_counts[idx] = next_threads
+            if functools.reduce(operator.mul, root_thread_counts, 1) <= 1024:
+                break
+    return (
+        root_block_sizes[0],
+        root_block_sizes[1],
+        root_thread_counts[0],
+        root_thread_counts[1],
+    )
+
+
+def _specialized_mma_root_threads_support_impl(
+    mma_impl: str,
+    *,
+    bm: int,
+    bn: int,
+    root_m_threads: int,
+    root_n_threads: int,
+) -> bool:
+    from .cute_mma import _mma_active_n_threads
+    from .cute_mma import _tcgen05_root_m_threads
+
+    if mma_impl == "tcgen05":
+        return (
+            _tcgen05_root_m_threads(bm, bn) <= root_m_threads <= bm
+            and bm % root_m_threads == 0
+            and _mma_active_n_threads("tcgen05") <= root_n_threads <= bn
+            and bn % root_n_threads == 0
+            and root_m_threads * root_n_threads <= 1024
+        )
+    return mma_impl in ("warp", "universal") and (
+        root_m_threads == bm and root_n_threads == bn
+    )
+
+
+def _detect_grouped_rank3_specialized_mma_loop(
     fn: DeviceFunction,
     block_ids: list[int],
     *,
@@ -128,11 +193,84 @@ def _detect_specialized_mma_loop(
 ) -> bool:
     from ..compile_environment import CompileEnvironment
     from ..host_function import HostFunction
+
+    device_ir = HostFunction.current().device_ir
+    if len(device_ir.grid_block_ids) != 1 or len(block_ids) != 1:
+        return False
+    root_grid_ids = device_ir.grid_block_ids[0]
+    if any(block_id in root_grid_ids for block_id in block_ids):
+        return False
+    if len(root_grid_ids) == 2:
+        segment_root_grid_id = None
+        mn_root_grid_ids = root_grid_ids
+    elif len(root_grid_ids) == 3:
+        segment_root_grid_id = root_grid_ids[0]
+        mn_root_grid_ids = root_grid_ids[1:]
+    else:
+        return False
+
+    env = CompileEnvironment.current()
+    if segment_root_grid_id is not None:
+        segment_block = env.block_sizes[segment_root_grid_id].from_config(config)
+        segment_threads = env.config_spec.num_threads.config_get(
+            config.num_threads, segment_root_grid_id, 0
+        )
+        if segment_block != 1 or segment_threads not in (0, 1):
+            return False
+    root_layout = _specialized_mma_root_thread_layout(mn_root_grid_ids, config)
+    if root_layout is None:
+        return False
+    bm, bn, root_m_threads, root_n_threads = root_layout
+    (bk,) = block_sizes
+    if not isinstance(bk, int):
+        return False
+    if not _specialized_mma_root_threads_support_impl(
+        "tcgen05",
+        bm=bm,
+        bn=bn,
+        root_m_threads=root_m_threads,
+        root_n_threads=root_n_threads,
+    ):
+        return False
+
+    for graph_info in fn.codegen.codegen_graphs:
+        if getattr(graph_info, "block_ids", None) != block_ids:
+            continue
+        for node in graph_info.graph.nodes:
+            if (
+                _grouped_rank3_specialized_mma_plan(
+                    node,
+                    fn=fn,
+                    k_block_id=block_ids[0],
+                    bk=bk,
+                    config=config,
+                    env=env,
+                )
+                is not None
+            ):
+                return True
+    return False
+
+
+def _detect_specialized_mma_loop(
+    fn: DeviceFunction,
+    block_ids: list[int],
+    *,
+    block_sizes: Sequence[int | torch.SymInt],
+    config: Config,
+) -> bool:
+    from ..host_function import HostFunction
     from .cute_mma import _choose_mma_impl
-    from .cute_mma import _mma_active_n_threads
     from .cute_mma import _mma_tiles_are_static_full
-    from .cute_mma import _tcgen05_root_m_threads
     from .cute_mma import analyze_cute_mma_node
+
+    if _detect_grouped_rank3_specialized_mma_loop(
+        fn,
+        block_ids,
+        block_sizes=block_sizes,
+        config=config,
+    ):
+        return True
 
     device_ir = HostFunction.current().device_ir
     if len(device_ir.grid_block_ids) != 1:
@@ -159,52 +297,13 @@ def _detect_specialized_mma_loop(
 
     root_mn_block_ids = _specialized_mma_root_mn_block_ids(candidates[0], config)
     assert root_mn_block_ids is not None
-
-    env = CompileEnvironment.current()
-    root_block_sizes: list[int] = []
-    root_thread_counts: list[int] = []
-    root_thread_auto: list[bool] = []
-    for block_id in root_mn_block_ids:
-        block_size = env.block_sizes[block_id].from_config(config)
-        if not isinstance(block_size, int):
-            return False
-        root_block_sizes.append(block_size)
-        threads = env.config_spec.num_threads.config_get(
-            config.num_threads, block_id, 0
-        )
-        resolved_threads = threads if threads > 0 else block_size
-        root_thread_counts.append(resolved_threads)
-        root_thread_auto.append(threads == 0)
-
-    if functools.reduce(operator.mul, root_thread_counts, 1) > 1024:
-        for idx in sorted(
-            (i for i, is_auto in enumerate(root_thread_auto) if is_auto),
-            reverse=True,
-        ):
-            other_threads = functools.reduce(
-                operator.mul,
-                (
-                    root_thread_counts[j]
-                    for j in range(len(root_thread_counts))
-                    if j != idx
-                ),
-                1,
-            )
-            if other_threads <= 0:
-                continue
-            thread_budget = max(1024 // other_threads, 1)
-            next_threads = _largest_divisor_at_most(
-                root_block_sizes[idx], thread_budget
-            )
-            root_thread_counts[idx] = next_threads
-            if functools.reduce(operator.mul, root_thread_counts, 1) <= 1024:
-                break
-
+    root_layout = _specialized_mma_root_thread_layout(root_mn_block_ids, config)
+    if root_layout is None:
+        return False
+    bm, bn, root_m_threads, root_n_threads = root_layout
     (bk,) = block_sizes
     if not isinstance(bk, int):
         return False
-    bm, bn = root_block_sizes
-    root_m_threads, root_n_threads = root_thread_counts
     candidates = [
         candidate
         for candidate in candidates
@@ -212,27 +311,6 @@ def _detect_specialized_mma_loop(
         or _mma_tiles_are_static_full(candidate.operands, bm=bm, bn=bn, bk=bk)
     ]
     if not candidates:
-        return False
-
-    def root_threads_support_impl(mma_impl: str) -> bool:
-        if mma_impl == "tcgen05":
-            mma_n_threads = _mma_active_n_threads("tcgen05")
-            min_root_m_threads = _tcgen05_root_m_threads(bm, bn)
-            if (
-                root_m_threads < min_root_m_threads
-                or root_m_threads > bm
-                or bm % root_m_threads != 0
-            ):
-                return False
-            if root_n_threads < mma_n_threads or root_n_threads > bn:
-                return False
-            if bn % root_n_threads != 0:
-                return False
-            return root_m_threads * root_n_threads <= 1024
-        if mma_impl == "warp":
-            return root_m_threads == bm and root_n_threads == bn
-        if mma_impl == "universal":
-            return root_m_threads == bm and root_n_threads == bn
         return False
 
     for candidate in candidates:
@@ -246,10 +324,22 @@ def _detect_specialized_mma_loop(
             input_device=lhs_val.device,
         )
         if candidate.requires_accumulator_seed:
-            if root_threads_support_impl("universal"):
+            if _specialized_mma_root_threads_support_impl(
+                "universal",
+                bm=bm,
+                bn=bn,
+                root_m_threads=root_m_threads,
+                root_n_threads=root_n_threads,
+            ):
                 return True
             continue
-        if mma_impl != "universal" and root_threads_support_impl(mma_impl):
+        if mma_impl != "universal" and _specialized_mma_root_threads_support_impl(
+            mma_impl,
+            bm=bm,
+            bn=bn,
+            root_m_threads=root_m_threads,
+            root_n_threads=root_n_threads,
+        ):
             return True
     return False
 
@@ -1687,14 +1777,15 @@ class CuteBackend(Backend):
                     root_grid_dims[axis] = max(root_grid_dims[axis], size)
         root_static_dims = tuple(root_grid_dims)
         root_static_threads = functools.reduce(operator.mul, root_static_dims, 1)
-        specialized_root_tcgen05 = (
+        recorded_tcgen05_block_shape = device_function.cute_state.block_shape
+        specialized_root_tcgen05 = recorded_tcgen05_block_shape is not None or (
             _kernel_specialized_mma_impl(device_function, config=device_function.config)
             == "tcgen05"
             and root_static_dims != (1, 1, 1)
             and root_static_threads <= MAX_THREADS_PER_BLOCK
         )
         tcgen05_compact_dims = (
-            device_function.cute_state.block_shape if specialized_root_tcgen05 else None
+            recorded_tcgen05_block_shape if specialized_root_tcgen05 else None
         )
         if referenced_dims != (1, 1, 1):
             dims = referenced_dims

--- a/helion/_compiler/cute/cute_epilogue.py
+++ b/helion/_compiler/cute/cute_epilogue.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 
 import dataclasses
 import math
+import operator
 from typing import TYPE_CHECKING
 
 import torch
@@ -58,9 +59,13 @@ from ...language._gelu_tanh_approx import epilogue_unary_step_template
 from ...language._gelu_tanh_approx import gelu_erf_epilogue_unary_step_template
 from .cute_fx_walk import aux_tensor_load_kind
 from .cute_fx_walk import build_inner_outputs_index
+from .cute_fx_walk import build_inner_outputs_index_from_graphs
 from .cute_fx_walk import walk_carrier_to_tcgen05_matmul
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from ..device_ir import GraphInfo
     from ..inductor_lowering import CodegenState
 
 
@@ -144,6 +149,19 @@ class _AuxiliaryTensorStep:
     op_template: str
     load_node: torch.fx.Node
     broadcast_axis: int | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class Tcgen05GroupedTailEpilogueMatch:
+    """Exact grouped preserve-output M/N tail source match."""
+
+    anchor: torch.fx.Node
+    store_node: torch.fx.Node
+    producer_nodes: tuple[torch.fx.Node, ...]
+    n_sizes_tensor: torch.Tensor | None
+    safe_group_node: torch.fx.Node
+    has_m_tail_mask: bool
+    has_n_tail_mask: bool
 
 
 # The cute DSL surface for whitelisted unary operations. Renderings are
@@ -368,6 +386,18 @@ def _is_helion_load_node(node: torch.fx.Node) -> bool:
     from ...language.memory_ops import load as helion_load
 
     return node.op == "call_function" and node.target is helion_load
+
+
+def _unmasked_helion_load_args(
+    node: torch.fx.Node,
+) -> tuple[object, object] | None:
+    if not _is_helion_load_node(node) or node.kwargs or len(node.args) < 2:
+        return None
+    if len(node.args) >= 3 and node.args[2] is not None:
+        return None
+    if len(node.args) >= 4 and node.args[3] is not None:
+        return None
+    return node.args[0], node.args[1]
 
 
 def _canonical_aux_load_operand(node: torch.fx.Node) -> tuple[torch.fx.Node, str]:
@@ -1125,3 +1155,596 @@ def analyze_tcgen05_unary_epilogue_chain(
         # actionable message.
         return None
     return None
+
+
+def _convert_input_and_dtype(
+    node: torch.fx.Node,
+) -> tuple[torch.fx.Node, torch.dtype] | None:
+    if (
+        node.op != "call_function"
+        or node.target is not torch.ops.prims.convert_element_type.default
+        or node.kwargs
+        or len(node.args) != 2
+        or not isinstance(node.args[0], torch.fx.Node)
+        or not isinstance(node.args[1], torch.dtype)
+    ):
+        return None
+    return node.args[0], node.args[1]
+
+
+def _mask_base_from_broadcast(
+    condition: torch.fx.Node,
+    *,
+    data_axis: int,
+) -> torch.fx.Node | None:
+    """Return the rank-1 mask broadcast along the other 2-D axis."""
+    from ...language import view_ops
+
+    if condition.op != "call_function" or condition.kwargs:
+        return None
+    if condition.target is view_ops.subscript:
+        if len(condition.args) != 2:
+            return None
+        base, index = condition.args
+        if (
+            isinstance(base, torch.fx.Node)
+            and isinstance(index, (list, tuple))
+            and len(index) == 2
+            and isinstance(index[data_axis], slice)
+            and index[data_axis] == slice(None)
+            and index[1 - data_axis] is None
+        ):
+            return base
+        return None
+    if condition.target is torch.ops.aten.unsqueeze.default:
+        if len(condition.args) != 2:
+            return None
+        base, dim = condition.args
+        if isinstance(base, torch.fx.Node) and dim in (
+            1 - data_axis,
+            -1 - data_axis,
+        ):
+            return base
+    return None
+
+
+def _rank1_mask_from_broadcast(
+    condition: torch.fx.Node,
+    *,
+    carrier_tile_shape: tuple[object, ...] | None,
+    data_axis: int,
+) -> tuple[torch.fx.Node, torch.Tensor] | None:
+    cond_val = condition.meta.get("val")
+    if (
+        not isinstance(cond_val, torch.Tensor)
+        or cond_val.dtype is not torch.bool
+        or cond_val.ndim != 2
+        or cond_val.shape[1 - data_axis] != 1
+    ):
+        return None
+    mask = _mask_base_from_broadcast(condition, data_axis=data_axis)
+    if mask is None:
+        return None
+    mask_val = mask.meta.get("val")
+    if (
+        not isinstance(mask_val, torch.Tensor)
+        or mask_val.dtype is not torch.bool
+        or mask_val.ndim != 1
+        or carrier_tile_shape is None
+        or len(carrier_tile_shape) != 2
+        or mask_val.shape[0] != carrier_tile_shape[data_axis]
+        or cond_val.shape[data_axis] != carrier_tile_shape[data_axis]
+    ):
+        return None
+    return mask, mask_val
+
+
+def _argument_sequence_matches_nodes(
+    candidate: object,
+    expected: tuple[torch.fx.Node, ...],
+) -> bool:
+    return (
+        isinstance(candidate, (list, tuple))
+        and len(candidate) == len(expected)
+        and all(candidate[index] is expected[index] for index in range(len(expected)))
+    )
+
+
+def _argument_sequence_indices_of(
+    candidate: object,
+    target: torch.fx.Node,
+) -> list[int] | None:
+    if not isinstance(candidate, (list, tuple)):
+        return None
+    return [index for index in range(len(candidate)) if candidate[index] is target]
+
+
+def _matches_grouped_n_col_mask(
+    condition: torch.fx.Node,
+    *,
+    carrier_tile_shape: tuple[object, ...] | None,
+    carrier_tile_index_nodes: tuple[torch.fx.Node, ...] | None,
+    safe_group_node: torch.fx.Node,
+) -> (
+    tuple[
+        torch.Tensor,
+        torch.fx.Node,
+        torch.fx.Node,
+        torch.fx.Node,
+        torch.fx.Node,
+    ]
+    | None
+):
+    """Return exact ``(n_sizes, n_load, col_mask, broadcast, tile_n.index)``."""
+
+    mask_info = _rank1_mask_from_broadcast(
+        condition,
+        carrier_tile_shape=carrier_tile_shape,
+        data_axis=1,
+    )
+    if mask_info is None:
+        return None
+    col_mask, col_mask_val = mask_info
+    if (
+        col_mask.op != "call_function"
+        or col_mask.target is not torch.ops.aten.lt.Tensor
+        or col_mask.kwargs
+        or len(col_mask.args) != 2
+        or not isinstance(col_mask.args[0], torch.fx.Node)
+        or not isinstance(col_mask.args[1], torch.fx.Node)
+    ):
+        return None
+    tile_index, n_load = col_mask.args
+    assert isinstance(tile_index, torch.fx.Node)
+    assert isinstance(n_load, torch.fx.Node)
+    tile_index_val = tile_index.meta.get("val")
+    if (
+        not isinstance(tile_index_val, torch.Tensor)
+        or tile_index_val.ndim != 1
+        or tuple(tile_index_val.shape) != tuple(col_mask_val.shape)
+    ):
+        return None
+    from ...language import tile_ops
+
+    if (
+        carrier_tile_index_nodes is None
+        or len(carrier_tile_index_nodes) != 2
+        or tile_index.op != "call_function"
+        or tile_index.target is not tile_ops.tile_index
+        or tile_index.kwargs
+        or len(tile_index.args) != 1
+        or tile_index.args[0] is not carrier_tile_index_nodes[1]
+    ):
+        return None
+    load_args = _unmasked_helion_load_args(n_load)
+    if load_args is None:
+        return None
+    tensor_node, index_list = load_args
+    if (
+        not isinstance(tensor_node, torch.fx.Node)
+        or not isinstance(index_list, (list, tuple))
+        or len(index_list) != 1
+        or not isinstance(index_list[0], torch.fx.Node)
+    ):
+        return None
+    if index_list[0] is not safe_group_node:
+        return None
+    n_sizes = tensor_node.meta.get("val")
+    loaded_n = n_load.meta.get("val")
+    if (
+        not isinstance(n_sizes, torch.Tensor)
+        or n_sizes.ndim != 1
+        or n_sizes.dtype not in (torch.int32, torch.int64)
+        or not isinstance(loaded_n, torch.Tensor)
+        or loaded_n.ndim != 0
+    ):
+        return None
+    return n_sizes, n_load, col_mask, condition, tile_index
+
+
+def _matches_grouped_m_row_mask(
+    condition: torch.fx.Node,
+    *,
+    carrier_tile_shape: tuple[object, ...] | None,
+    carrier_tile_index_nodes: tuple[torch.fx.Node, ...] | None,
+    safe_group_node: torch.fx.Node,
+    safe_group_layout_load_node: torch.fx.Node,
+) -> tuple[torch.fx.Node, torch.fx.Node, torch.fx.Node] | None:
+    """Return exact ``(row_load, row_eq, row_mask)`` metadata."""
+
+    mask_info = _rank1_mask_from_broadcast(
+        condition,
+        carrier_tile_shape=carrier_tile_shape,
+        data_axis=0,
+    )
+    if mask_info is None:
+        return None
+    row_mask, row_mask_val = mask_info
+    if (
+        row_mask.op != "call_function"
+        or row_mask.target is not torch.ops.aten.eq.Tensor
+        or row_mask.kwargs
+        or len(row_mask.args) != 2
+    ):
+        return None
+    lhs, rhs = row_mask.args
+    if lhs is safe_group_node and isinstance(rhs, torch.fx.Node):
+        row_load = rhs
+    elif rhs is safe_group_node and isinstance(lhs, torch.fx.Node):
+        row_load = lhs
+    else:
+        return None
+    load_args = _unmasked_helion_load_args(row_load)
+    if load_args is None:
+        return None
+    row_tensor_node, index_list = load_args
+    safe_tensor_node = (
+        safe_group_layout_load_node.args[0]
+        if safe_group_layout_load_node.args
+        else None
+    )
+    load_val = row_load.meta.get("val")
+    if (
+        row_tensor_node is not safe_tensor_node
+        or not isinstance(load_val, torch.Tensor)
+        or load_val.ndim != 1
+        or tuple(load_val.shape) != tuple(row_mask_val.shape)
+        or not isinstance(index_list, (list, tuple))
+        or len(index_list) != 1
+        or not isinstance(index_list[0], torch.fx.Node)
+    ):
+        return None
+    if carrier_tile_index_nodes is None or len(carrier_tile_index_nodes) != 2:
+        return None
+    if index_list[0] is not carrier_tile_index_nodes[0]:
+        return None
+    return row_load, row_mask, condition
+
+
+def _split_grouped_tail_condition(
+    condition: torch.fx.Node,
+    *,
+    carrier_tile_shape: tuple[object, ...] | None,
+    carrier_tile_index_nodes: tuple[torch.fx.Node, ...] | None,
+    safe_group_node: torch.fx.Node,
+    safe_group_layout_load_node: torch.fx.Node,
+) -> (
+    tuple[
+        tuple[torch.fx.Node, torch.fx.Node, torch.fx.Node] | None,
+        tuple[
+            torch.Tensor,
+            torch.fx.Node,
+            torch.fx.Node,
+            torch.fx.Node,
+            torch.fx.Node,
+        ]
+        | None,
+        tuple[torch.fx.Node, ...],
+    ]
+    | None
+):
+    """Classify row-only, column-only, or row-and-column preserve masks."""
+
+    row_info = _matches_grouped_m_row_mask(
+        condition,
+        carrier_tile_shape=carrier_tile_shape,
+        carrier_tile_index_nodes=carrier_tile_index_nodes,
+        safe_group_node=safe_group_node,
+        safe_group_layout_load_node=safe_group_layout_load_node,
+    )
+    if row_info is not None:
+        return row_info, None, ()
+    col_info = _matches_grouped_n_col_mask(
+        condition,
+        carrier_tile_shape=carrier_tile_shape,
+        carrier_tile_index_nodes=carrier_tile_index_nodes,
+        safe_group_node=safe_group_node,
+    )
+    if col_info is not None:
+        return None, col_info, ()
+    if (
+        condition.op != "call_function"
+        or condition.target
+        not in (
+            operator.and_,
+            torch.ops.aten.bitwise_and.Tensor,
+            torch.ops.aten.logical_and.default,
+        )
+        or condition.kwargs
+        or len(condition.args) != 2
+        or not isinstance(condition.args[0], torch.fx.Node)
+        or not isinstance(condition.args[1], torch.fx.Node)
+    ):
+        return None
+    cond_val = condition.meta.get("val")
+    if (
+        not isinstance(cond_val, torch.Tensor)
+        or cond_val.dtype is not torch.bool
+        or carrier_tile_shape is None
+        or tuple(cond_val.shape) != tuple(carrier_tile_shape)
+    ):
+        return None
+    left = condition.args[0]
+    right = condition.args[1]
+    assert isinstance(left, torch.fx.Node)
+    assert isinstance(right, torch.fx.Node)
+    left_row = _matches_grouped_m_row_mask(
+        left,
+        carrier_tile_shape=carrier_tile_shape,
+        carrier_tile_index_nodes=carrier_tile_index_nodes,
+        safe_group_node=safe_group_node,
+        safe_group_layout_load_node=safe_group_layout_load_node,
+    )
+    left_col = _matches_grouped_n_col_mask(
+        left,
+        carrier_tile_shape=carrier_tile_shape,
+        carrier_tile_index_nodes=carrier_tile_index_nodes,
+        safe_group_node=safe_group_node,
+    )
+    right_row = _matches_grouped_m_row_mask(
+        right,
+        carrier_tile_shape=carrier_tile_shape,
+        carrier_tile_index_nodes=carrier_tile_index_nodes,
+        safe_group_node=safe_group_node,
+        safe_group_layout_load_node=safe_group_layout_load_node,
+    )
+    right_col = _matches_grouped_n_col_mask(
+        right,
+        carrier_tile_shape=carrier_tile_shape,
+        carrier_tile_index_nodes=carrier_tile_index_nodes,
+        safe_group_node=safe_group_node,
+    )
+    if left_row is not None and right_col is not None:
+        return left_row, right_col, (condition,)
+    if left_col is not None and right_row is not None:
+        return right_row, left_col, (condition,)
+    return None
+
+
+def _matches_output_tile_load(
+    candidate: torch.fx.Node,
+    *,
+    store_node: torch.fx.Node,
+    output_dtype: torch.dtype,
+    carrier_tile_shape: tuple[object, ...] | None,
+    carrier_index_nodes: tuple[torch.fx.Node, ...] | None,
+) -> bool:
+    load_args = _unmasked_helion_load_args(candidate)
+    if load_args is None:
+        return False
+    false_tensor_node, false_index = load_args
+    if not isinstance(false_tensor_node, torch.fx.Node):
+        return False
+    store_tensor_node = store_node.args[0] if store_node.args else None
+    if not isinstance(store_tensor_node, torch.fx.Node):
+        return False
+    if false_tensor_node is not store_tensor_node:
+        return False
+    false_tensor = false_tensor_node.meta.get("val")
+    false_val = candidate.meta.get("val")
+    if (
+        not isinstance(false_tensor, torch.Tensor)
+        or not isinstance(false_val, torch.Tensor)
+        or carrier_tile_shape is None
+        or tuple(false_val.shape) != tuple(carrier_tile_shape)
+    ):
+        return False
+    if false_tensor.dtype is not output_dtype:
+        return False
+    return carrier_index_nodes is not None and _argument_sequence_matches_nodes(
+        false_index,
+        carrier_index_nodes,
+    )
+
+
+def analyze_tcgen05_grouped_tail_epilogue(
+    value_node: torch.fx.Node,
+    *,
+    safe_group_node: torch.fx.Node,
+    safe_group_layout_load_node: torch.fx.Node,
+    store_node: torch.fx.Node,
+    target_fx_node: torch.fx.Node,
+    inner_outputs_by_graph_id: dict[int, tuple[torch.fx.Node | None, ...]],
+) -> Tcgen05GroupedTailEpilogueMatch | None:
+    """Classify grouped M/N preserve-output tail stores."""
+
+    if (
+        value_node.op != "call_function"
+        or value_node.target is not torch.ops.aten.where.self
+        or value_node.kwargs
+        or len(value_node.args) != 3
+    ):
+        return None
+    condition, true_branch, false_branch = value_node.args
+    if not (
+        isinstance(condition, torch.fx.Node)
+        and isinstance(true_branch, torch.fx.Node)
+        and isinstance(false_branch, torch.fx.Node)
+    ):
+        return None
+
+    true_convert = _convert_input_and_dtype(true_branch)
+    if true_convert is None:
+        return None
+    carrier, true_dtype = true_convert
+    carrier_tile_shape = _carrier_tile_shape(carrier)
+    carrier_index_nodes = _carrier_tile_index_nodes(carrier)
+    grouped_tail_info = _split_grouped_tail_condition(
+        condition,
+        carrier_tile_shape=carrier_tile_shape,
+        carrier_tile_index_nodes=carrier_index_nodes,
+        safe_group_node=safe_group_node,
+        safe_group_layout_load_node=safe_group_layout_load_node,
+    )
+    if grouped_tail_info is None:
+        return None
+    row_info, grouped_n_info, and_nodes = grouped_tail_info
+    if not _matches_output_tile_load(
+        false_branch,
+        store_node=store_node,
+        output_dtype=true_dtype,
+        carrier_tile_shape=carrier_tile_shape,
+        carrier_index_nodes=carrier_index_nodes,
+    ):
+        return None
+    if carrier_index_nodes is None:
+        return None
+    store_index = store_node.args[1] if len(store_node.args) >= 2 else None
+    if not _argument_sequence_matches_nodes(store_index, carrier_index_nodes):
+        return None
+
+    anchor = walk_carrier_to_tcgen05_matmul(
+        carrier,
+        {target_fx_node},
+        inner_outputs_by_graph_id,
+    )
+    if anchor is None:
+        return None
+
+    expected_users: list[tuple[torch.fx.Node, set[torch.fx.Node]]] = []
+    producer_nodes: list[torch.fx.Node] = []
+    if row_info is not None:
+        row_load, row_mask, row_broadcast = row_info
+        row_mask_user = and_nodes[0] if and_nodes else value_node
+        expected_users.extend(
+            [
+                (row_load, {row_mask}),
+                (row_mask, {row_broadcast}),
+                (row_broadcast, {row_mask_user}),
+            ]
+        )
+        producer_nodes.extend([row_load, row_mask, row_broadcast])
+    n_sizes: torch.Tensor | None = None
+    n_load: torch.fx.Node | None = None
+    tile_index: torch.fx.Node | None = None
+    if grouped_n_info is not None:
+        n_sizes, n_load, col_mask, col_broadcast, tile_index = grouped_n_info
+        expected_users.extend(
+            [
+                (tile_index, {col_mask}),
+                (n_load, {col_mask}),
+                (col_mask, {col_broadcast}),
+                (
+                    col_broadcast,
+                    {and_nodes[0]} if and_nodes else {value_node},
+                ),
+            ]
+        )
+        producer_nodes.extend([tile_index, n_load, col_mask, col_broadcast])
+    if and_nodes:
+        expected_users.append((and_nodes[0], {value_node}))
+        producer_nodes.extend(and_nodes)
+    else:
+        expected_users.append((condition, {value_node}))
+        if condition not in producer_nodes:
+            producer_nodes.append(condition)
+    expected_users.extend(
+        [
+            (false_branch, {value_node}),
+            (value_node, {store_node}),
+        ]
+    )
+    for node, users in expected_users:
+        if set(node.users) != users:
+            return None
+    producer_nodes.extend([false_branch, value_node])
+    return Tcgen05GroupedTailEpilogueMatch(
+        anchor=anchor,
+        store_node=store_node,
+        producer_nodes=tuple(producer_nodes),
+        n_sizes_tensor=n_sizes,
+        safe_group_node=safe_group_node,
+        has_m_tail_mask=row_info is not None,
+        has_n_tail_mask=grouped_n_info is not None,
+    )
+
+
+def find_tcgen05_grouped_tail_epilogue_for_mma(
+    mma_node: torch.fx.Node,
+    graphs: Iterable[GraphInfo],
+    *,
+    safe_group_node: torch.fx.Node,
+    safe_group_layout_load_node: torch.fx.Node,
+) -> Tcgen05GroupedTailEpilogueMatch | None:
+    """Find the unique semantic grouped tail preserve-output store."""
+
+    from ...language import _tracing_ops
+    from ...language import memory_ops
+
+    graph_infos = list(graphs)
+    graph_id_of: dict[torch.fx.Graph, int] = {}
+    for_loop_calls_by_graph_id: dict[int, list[torch.fx.Node]] = {}
+    for graph_info in graph_infos:
+        graph_id_of[graph_info.graph] = graph_info.graph_id
+        for node in graph_info.graph.nodes:
+            if (
+                node.op == "call_function"
+                and _tracing_ops.is_for_loop_target(node.target)
+                and node.args
+                and isinstance(node.args[0], int)
+            ):
+                for_loop_calls_by_graph_id.setdefault(node.args[0], []).append(node)
+
+    inner_outputs_by_graph_id = build_inner_outputs_index_from_graphs(graph_infos)
+    found: list[Tcgen05GroupedTailEpilogueMatch] = []
+    visited: set[torch.fx.Node] = set()
+    stack: list[torch.fx.Node] = [mma_node]
+    while stack:
+        cur = stack.pop()
+        if cur in visited:
+            continue
+        visited.add(cur)
+        for user in cur.users:
+            if user.op == "output":
+                graph_id = graph_id_of.get(cur.graph)
+                if graph_id is None:
+                    return None
+                output_args = user.args[0] if user.args else None
+                out_indices = _argument_sequence_indices_of(output_args, cur)
+                if out_indices is None:
+                    return None
+                if not out_indices:
+                    return None
+                for outer_call in for_loop_calls_by_graph_id.get(graph_id, []):
+                    for outer_user in outer_call.users:
+                        if (
+                            outer_user.op == "call_function"
+                            and outer_user.target is operator.getitem
+                            and len(outer_user.args) >= 2
+                            and outer_user.args[1] in out_indices
+                            and outer_user not in visited
+                        ):
+                            stack.append(outer_user)
+                continue
+            if user.op != "call_function":
+                return None
+            if user.target is memory_ops.store:
+                value = user.args[2] if len(user.args) > 2 else None
+                if not isinstance(value, torch.fx.Node):
+                    return None
+                grouped_tail = analyze_tcgen05_grouped_tail_epilogue(
+                    value,
+                    safe_group_node=safe_group_node,
+                    safe_group_layout_load_node=safe_group_layout_load_node,
+                    store_node=user,
+                    target_fx_node=mma_node,
+                    inner_outputs_by_graph_id=inner_outputs_by_graph_id,
+                )
+                if grouped_tail is None:
+                    return None
+                found.append(grouped_tail)
+                continue
+            if user.target in (
+                _tracing_ops._phi,
+                _tracing_ops._new_var,
+                operator.getitem,
+                torch.ops.prims.convert_element_type.default,
+                torch.ops.aten.where.self,
+            ):
+                stack.append(user)
+                continue
+            return None
+
+    if len(found) != 1:
+        return None
+    return found[0]

--- a/helion/_compiler/cute/cute_mma.py
+++ b/helion/_compiler/cute/cute_mma.py
@@ -20,30 +20,40 @@ Features:
 from __future__ import annotations
 
 import ast
+from collections.abc import Mapping
+import contextlib
 from dataclasses import dataclass
+from dataclasses import replace
 import os
 import textwrap
 from typing import TYPE_CHECKING
-from typing import Protocol
+from typing import Any
 from typing import cast
 
 import torch
 from torch._subclasses.fake_tensor import FakeTensor
+from torch._subclasses.fake_tensor import unset_fake_temporarily
 from torch.fx.node import Node
 
 from ... import exc
 from ..ast_extension import expr_from_string
 from ..ast_extension import statement_from_string
 from ..dtype_utils import cast_ast
+from ..host_function import HostFunction
 from ..indexing_strategy import exact_tile_block_ids
 from ..matmul_utils import _needs_f32_accumulator
 from ..tile_strategy import DeviceLoopState
 from .aux_tensor import analyze_tcgen05_matmul_store_chains
 from .aux_tensor import discover_tcgen05_aux_tensor_descriptors
+from .cute_epilogue import Tcgen05GroupedTailEpilogueMatch
+from .cute_epilogue import find_tcgen05_grouped_tail_epilogue_for_mma
 from .cutedsl_compat import emit_pipeline_advance
 from .device_state import CuteDeviceFunctionState
+from .device_state import CuteTcgen05GroupedPlan
 from .device_state import CuteTcgen05MatmulPlan
 from .device_state import CuteTcgen05StoreValue
+from .device_state import Tcgen05GroupedDMode
+from .device_state import Tcgen05Orientation
 from .layout import MatmulExecutionKind
 from .layout import MatmulExecutionPlan
 from .matmul_utils import analyze_direct_grouped_n_loads
@@ -90,6 +100,20 @@ from .tcgen05_constants import TCGEN05_CONSUMER_REGS_CHOICES
 from .tcgen05_constants import TCGEN05_CONSUMER_REGS_CONFIG_KEY
 from .tcgen05_constants import TCGEN05_CONSUMER_REGS_DEFAULT
 from .tcgen05_constants import TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_GROUPED_EXTERNAL_DIRECT_POINTERS_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_GROUPED_EXTERNAL_DIRECT_STRIDES_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_GROUPED_MODE_DIRECT
+from .tcgen05_constants import TCGEN05_GROUPED_MODE_DYNAMIC
+from .tcgen05_constants import TCGEN05_GROUPED_MODE_STATIC
+from .tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
+from .tcgen05_constants import TCGEN05_GROUPED_MODES
+from .tcgen05_constants import TCGEN05_GROUPED_STATIC_BLOCK_K_CHOICES
+from .tcgen05_constants import TCGEN05_GROUPED_STATIC_COMMON_K_BLOCK_PAIRS
+from .tcgen05_constants import TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY
+from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_MMA_M_TILE
+from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE
+from .tcgen05_constants import TCGEN05_GROUPED_WORKLIST_STORE_SHAPE
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_BLOCK_SIZES
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_CLUSTER_M
 from .tcgen05_constants import TCGEN05_LARGE_BN_PROOF_CONFIG_KEY
@@ -104,8 +128,7 @@ from .tcgen05_lifecycle import Tcgen05LifecycleContext
 from .tcgen05_pure_matmul import Tcgen05PureMatmulObjectModel
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-
+    from ...autotuner.config_spec import MatmulFact
     from ..aten_lowering import LoweringContext
     from ..compile_environment import CompileEnvironment
     from ..device_function import DeviceFunction
@@ -114,6 +137,22 @@ if TYPE_CHECKING:
     from ..generate_ast import GenerateAST
     from ..inductor_lowering import CodegenState
     from .strategies import Tcgen05WarpSpec
+
+
+def _register_tensor_arg_by_host_name(df: DeviceFunction, arg_name: str) -> None:
+    for fake_value, origin in HostFunction.current().tensor_to_origin.items():
+        try:
+            host_name = origin.host_str()
+        except NotImplementedError:
+            continue
+        if host_name == arg_name:
+            df.tensor_arg(fake_value, prefer_name=arg_name)
+            return
+    raise exc.BackendUnsupported(
+        "cute",
+        f"external grouped direct pointer metadata argument {arg_name!r} "
+        "is not a tensor argument",
+    )
 
 
 _TRACE_THROUGH_TARGETS = {
@@ -214,6 +253,119 @@ class _Tcgen05LayoutPlan:
     acc_producer_state: str
     acc_consumer_state: str
     epilogue_rest_mode: str
+
+
+@dataclass(frozen=True)
+class _MmaOperandInfo:
+    load: Node
+    terminal: Node
+    source_fake: torch.Tensor
+    logical_fake: torch.Tensor
+    block_ids: tuple[int, ...] = ()
+    collective_dependency_nodes: tuple[Node, ...] = ()
+    grouped_k_mask: _Rank3RhsGroupedKMaskInfo | None = None
+    rhs_group_index: Node | None = None
+    rhs_safe_group: _Rank3RhsSafeGroupInfo | None = None
+    rhs_n_block_id: int | None = None
+    rhs_k_block_id: int | None = None
+    rhs_rank3_grouped_nt: bool = False
+    rhs_segment_group: _Rank3RhsSegmentGroupInfo | None = None
+
+    @property
+    def matrix_rows(self) -> int | torch.SymInt:
+        return self.logical_fake.size(-2)
+
+    @property
+    def matrix_cols(self) -> int | torch.SymInt:
+        return self.logical_fake.size(-1)
+
+    @property
+    def matrix_row_block_id(self) -> int:
+        return self.block_ids[-2]
+
+    @property
+    def matrix_col_block_id(self) -> int:
+        return self.block_ids[-1]
+
+    @property
+    def leading_passthrough_block_id(self) -> int | None:
+        leading_block_ids = self.block_ids[:-2]
+        return leading_block_ids[0] if leading_block_ids else None
+
+    @property
+    def is_leading_passthrough(self) -> bool:
+        return self.leading_passthrough_block_id is not None
+
+
+@dataclass(frozen=True)
+class _Rank3RhsGroupedKMaskInfo:
+    k_sizes_tensor: torch.Tensor
+    k_sizes_load: Node
+    k_sizes_value_nodes: tuple[Node, ...]
+    k_sizes_allowed_loop_users: tuple[Node, ...]
+    safe_group: Node
+    valid_k: Node
+    condition: Node
+    zero: Node
+    where: Node
+
+
+@dataclass(frozen=True)
+class _Rank3RhsSafeGroupInfo:
+    group_load: Node
+    condition: Node
+    safe_group: Node
+
+
+@dataclass(frozen=True)
+class _Rank3RhsSegmentGroupInfo:
+    metadata_tensor: torch.Tensor
+    segment_id: Node
+    segment_block_id: int
+    group_load: Node
+
+
+@dataclass(frozen=True)
+class _Rank3RhsSegmentLhsInfo:
+    segment_start_load: Node
+    actual_m_load: Node
+    row_index: Node
+    valid_m: Node
+    dependency_nodes: tuple[Node, ...]
+
+
+@dataclass(frozen=True)
+class _Rank3RhsSegmentStoreInfo:
+    store_node: Node
+    row_index: Node
+    valid_m: Node
+    extent_load: Node
+    uses_store_extent_metadata: bool = False
+
+
+@dataclass(frozen=True)
+class _GroupedMmaAxes:
+    m_block_id: int
+    n_block_id: int
+    k_block_id: int
+    segment_block_id: int | None = None
+
+
+@dataclass(frozen=True)
+class _Rank3RhsGroupedProof:
+    """Graph-local semantic proof for a rank-3 RHS grouped MMA."""
+
+    lhs: _MmaOperandInfo
+    rhs: _MmaOperandInfo
+    layout_tensor: torch.Tensor
+    k_mask: _Rank3RhsGroupedKMaskInfo | None
+    tail_epilogue: Tcgen05GroupedTailEpilogueMatch | None
+    segment_lhs: _Rank3RhsSegmentLhsInfo | None
+    segment_store: _Rank3RhsSegmentStoreInfo | None
+
+    @property
+    def is_worklist(self) -> bool:
+        return self.segment_lhs is not None
 
 
 @dataclass(frozen=True)
@@ -330,8 +482,12 @@ class _Tcgen05SchedPipelinePlan:
     clc_mbar_phase: str = ""
 
 
-class _ConfigLike(Protocol):
-    def get(self, key: str, default: object = ..., /) -> object: ...
+_ConfigLike = Mapping[str, object]
+
+
+def _tcgen05_grouped_mode(config: _ConfigLike) -> str | None:
+    mode = config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY)
+    return cast("str", mode) if mode in TCGEN05_GROUPED_MODES else None
 
 
 def _iter_node_inputs(arg: object) -> list[Node]:
@@ -345,6 +501,16 @@ def _iter_node_inputs(arg: object) -> list[Node]:
         for item in arg.values():
             nodes.extend(_iter_node_inputs(item))
     return nodes
+
+
+def _node_input_use_count(arg: object, needle: Node) -> int:
+    if arg is needle:
+        return 1
+    if isinstance(arg, (list, tuple)):
+        return sum(_node_input_use_count(item, needle) for item in arg)
+    if isinstance(arg, dict):
+        return sum(_node_input_use_count(item, needle) for item in arg.values())
+    return 0
 
 
 def _collect_node_dependencies(node: Node) -> set[Node]:
@@ -386,7 +552,9 @@ def _collective_load_dependency_nodes(
 
 
 def _register_collective_handled_loads(
-    cute_state: CuteDeviceFunctionState, *load_nodes: Node
+    cute_state: CuteDeviceFunctionState,
+    *load_nodes: Node,
+    extra_dependency_nodes: tuple[Node, ...] = (),
 ) -> None:
     # This is called both by the early lane-loop-suppression probe and by MMA
     # emission. Registration is set-based, so repeating it is idempotent and
@@ -394,6 +562,7 @@ def _register_collective_handled_loads(
     collective_dependency_nodes: set[Node] = set()
     for load_node in load_nodes:
         collective_dependency_nodes.update(_collect_node_dependencies(load_node))
+    collective_dependency_nodes.update(extra_dependency_nodes)
     terminal_load_nodes = set(load_nodes)
     for load_node in load_nodes:
         dependency_nodes = _collective_load_dependency_nodes(
@@ -403,6 +572,167 @@ def _register_collective_handled_loads(
             load_node.name,
             dependency_nodes=dependency_nodes,
         )
+
+
+def _sole_user_is(node: Node, expected_user: Node) -> bool:
+    return len(node.users) == 1 and next(iter(node.users)) is expected_user
+
+
+def _operand_load_path_exclusive(info: _MmaOperandInfo, fx_node: Node) -> bool:
+    if info.collective_dependency_nodes:
+        return False
+    if info.terminal is info.load:
+        return _sole_user_is(info.load, fx_node)
+    return _sole_user_is(info.load, info.terminal) and _sole_user_is(
+        info.terminal,
+        fx_node,
+    )
+
+
+def _is_tracing_for_loop_node(node: Node) -> bool:
+    from ...language import _tracing_ops
+
+    return node.op == "call_function" and node.target is _tracing_ops._for_loop
+
+
+def _grouped_k_allowed_loop_users(
+    cg: GenerateAST,
+    *,
+    k_sizes_load: Node,
+    k_sizes_value_nodes: tuple[Node, ...],
+) -> tuple[Node, ...]:
+    """Return the exact loop node that carried ``k_sizes_load`` into the mask."""
+    from ..device_ir import NodeArgsGraphInfo
+
+    def graph_info_for(graph: torch.fx.Graph) -> NodeArgsGraphInfo | None:
+        for graph_info in cg.codegen_graphs:
+            if graph_info.graph is graph and isinstance(graph_info, NodeArgsGraphInfo):
+                return graph_info
+        return None
+
+    allowed_loop_users: list[Node] = []
+    for value_node in k_sizes_value_nodes:
+        if value_node.op != "placeholder":
+            continue
+        graph_info = graph_info_for(value_node.graph)
+        if graph_info is None:
+            continue
+        placeholders = tuple(value_node.graph.find_nodes(op="placeholder"))
+        try:
+            placeholder_index = placeholders.index(value_node)
+        except ValueError:
+            continue
+        for user in k_sizes_load.users:
+            if (
+                not _is_tracing_for_loop_node(user)
+                or len(user.args) < 4
+                or user.args[0] != graph_info.graph_id
+            ):
+                continue
+            loop_args = user.args[3]
+            if not (
+                isinstance(loop_args, list | tuple)
+                and placeholder_index < len(loop_args)
+            ):
+                continue
+            loop_arg = loop_args[placeholder_index]
+            if (
+                isinstance(loop_arg, Node)
+                and _codegen_graph_node_for(cg, loop_arg) is k_sizes_load
+            ):
+                allowed_loop_users.append(user)
+    return tuple(dict.fromkeys(allowed_loop_users))
+
+
+def _operand_infos_exclusive_for_mma(
+    lhs_info: _MmaOperandInfo,
+    rhs_info: _MmaOperandInfo,
+    fx_node: Node,
+) -> bool:
+    if not (
+        lhs_info.collective_dependency_nodes or rhs_info.collective_dependency_nodes
+    ):
+        return _operand_load_path_exclusive(
+            lhs_info, fx_node
+        ) and _operand_load_path_exclusive(rhs_info, fx_node)
+
+    nodes: set[Node] = {
+        lhs_info.load,
+        lhs_info.terminal,
+        rhs_info.load,
+        rhs_info.terminal,
+        *lhs_info.collective_dependency_nodes,
+        *rhs_info.collective_dependency_nodes,
+    }
+    allowed_k_size_loop_users = {
+        (mask.k_sizes_load, loop_user)
+        for mask in (lhs_info.grouped_k_mask, rhs_info.grouped_k_mask)
+        if mask is not None
+        for loop_user in mask.k_sizes_allowed_loop_users
+    }
+    for node in nodes:
+        for user in node.users:
+            if user in nodes or user is fx_node:
+                continue
+            if (node, user) in allowed_k_size_loop_users:
+                continue
+            return False
+    return True
+
+
+def _same_grouped_k_mask(
+    lhs_info: _MmaOperandInfo,
+    rhs_info: _MmaOperandInfo,
+) -> _Rank3RhsGroupedKMaskInfo | None:
+    lhs_mask = lhs_info.grouped_k_mask
+    rhs_mask = rhs_info.grouped_k_mask
+    if lhs_mask is None or rhs_mask is None:
+        return None
+    if (
+        lhs_mask.k_sizes_tensor is rhs_mask.k_sizes_tensor
+        and lhs_mask.k_sizes_load is rhs_mask.k_sizes_load
+        and lhs_mask.safe_group is rhs_mask.safe_group
+        and lhs_mask.valid_k is rhs_mask.valid_k
+    ):
+        if (
+            not rhs_info.rhs_rank3_grouped_nt
+            or rhs_info.rhs_safe_group is None
+            or rhs_mask.safe_group is not rhs_info.rhs_safe_group.safe_group
+        ):
+            return None
+        return rhs_mask
+    return None
+
+
+def _rank3_rhs_safe_group_consumed_nodes_exclusive(
+    cg: GenerateAST,
+    info: _MmaOperandInfo,
+    *,
+    allowed_safe_group_users: tuple[Node, ...] = (),
+) -> bool:
+    if info.rhs_group_index is None or info.rhs_safe_group is None:
+        return False
+    group_load = info.rhs_safe_group.group_load
+    condition = info.rhs_safe_group.condition
+    safe_group = info.rhs_safe_group.safe_group
+    if _trace_to_outer_graph_arg(cg, info.rhs_group_index) is not safe_group:
+        return False
+    if set(group_load.users) != {condition, safe_group}:
+        return False
+    if set(condition.users) != {safe_group}:
+        return False
+    if not _sole_user_is(info.rhs_group_index, info.load):
+        return False
+    safe_group_users = set(safe_group.users)
+    safe_group_users.difference_update(allowed_safe_group_users)
+    if len(safe_group_users) != 1:
+        return False
+    (safe_group_user,) = tuple(safe_group_users)
+    return (
+        _node_input_use_count(safe_group_user.args, safe_group)
+        + _node_input_use_count(safe_group_user.kwargs, safe_group)
+        == 1
+    )
 
 
 def _mma_loop_is_exclusive(node: Node) -> bool:
@@ -435,6 +765,18 @@ def _trace_to_load(node: Node) -> Node | None:
     if cur.op != "call_function" or cur.target is not memory_ops.load:
         return None
     return cur
+
+
+def _is_unmasked_load(node: Node) -> bool:
+    """Return whether ``node`` is an ``hl.load`` without an extra mask."""
+    from ...language import memory_ops
+
+    return (
+        node.op == "call_function"
+        and node.target is memory_ops.load
+        and (len(node.args) < 3 or node.args[2] is None)
+        and node.kwargs.get("extra_mask") is None
+    )
 
 
 def _trace_to_load_tensor(node: Node) -> tuple[Node, str, torch.Tensor] | None:
@@ -478,44 +820,1038 @@ def _tcgen05_tma_matrix_major(tensor: torch.Tensor) -> str | None:
     return None
 
 
-@dataclass(frozen=True)
-class _MmaOperandInfo:
-    # ``matrix_rows``/``matrix_cols`` are the trailing two (matmul) axes of the
-    # operand. ``leading_passthrough_block_id`` is a *leading passthrough* grid
-    # axis that only offsets memory (the common case is a batch dim), derived
-    # from the load subscript structure -- not from op identity (mm/bmm/baddbmm/
-    # dot all route here) -- so the codegen is a general "matmul + leading grid
-    # axis", not a bmm special case. At most one leading axis is supported today
-    # (N leading axes is a possible future generalization).
-    load: Node
-    source_fake: torch.Tensor
-    block_ids: tuple[int, ...]
+def _rank3_rhs_index_block_id(index: Node, *, reduction: bool | None) -> int | None:
+    from ..compile_environment import CompileEnvironment
+    from ..compile_environment import _symint_expr
+    from ..host_function import HostFunction
+    from ..variable_origin import BlockSizeOrigin
 
-    @property
-    def matrix_rows(self) -> int | torch.SymInt:
-        return self.source_fake.size(-2)
+    val = index.meta.get("val")
+    if not isinstance(val, torch.SymInt):
+        return None
+    expr = _symint_expr(val)
+    if expr is None:
+        return None
+    env = CompileEnvironment.current()
+    origin_info = HostFunction.current().expr_to_origin.get(expr)
+    block_id = (
+        origin_info.origin.block_id
+        if origin_info is not None and isinstance(origin_info.origin, BlockSizeOrigin)
+        else env.resolve_block_id(val)
+    )
+    if block_id is None:
+        return None
+    canonical_block_id = env.canonical_block_id(block_id)
+    if (
+        reduction is not None
+        and bool(env.block_sizes[canonical_block_id].reduction) is not reduction
+    ):
+        return None
+    return canonical_block_id
 
-    @property
-    def matrix_cols(self) -> int | torch.SymInt:
-        return self.source_fake.size(-1)
 
-    @property
-    def matrix_row_block_id(self) -> int:
-        return self.block_ids[-2]
+def _rank3_rhs_safe_group_load(
+    cg: GenerateAST,
+    group_index: Node,
+    *,
+    m_block_id: int | None = None,
+) -> _Rank3RhsSafeGroupInfo | None:
+    """Return the admitted ``where(load(tile_m.begin) >= 0, load, 0)`` chain."""
+    import operator
 
-    @property
-    def matrix_col_block_id(self) -> int:
-        return self.block_ids[-1]
+    root = _trace_to_outer_graph_arg(cg, group_index)
+    if (
+        root.op != "call_function"
+        or root.target is not torch.ops.aten.where.self
+        or len(root.args) < 3
+    ):
+        return None
+    condition, true_value, false_value = root.args[:3]
+    if (
+        not isinstance(condition, Node)
+        or not isinstance(true_value, Node)
+        or not _is_zero_scalar_node(false_value)
+    ):
+        return None
+    if (
+        condition.op != "call_function"
+        or condition.target not in (operator.ge, torch.ops.aten.ge.Scalar)
+        or len(condition.args) < 2
+        or condition.args[0] is not true_value
+        or not _is_zero_scalar_node(condition.args[1])
+    ):
+        return None
+    if not _is_unmasked_load(true_value) or len(true_value.args) < 2:
+        return None
+    tensor_node = true_value.args[0]
+    index = true_value.args[1]
+    if (
+        not isinstance(tensor_node, Node)
+        or not isinstance(index, list)
+        or len(index) != 1
+        or not isinstance(index[0], Node)
+        or not _is_tile_begin(index[0], m_block_id=m_block_id)
+    ):
+        return None
+    tensor = tensor_node.meta.get("val")
+    loaded = true_value.meta.get("val")
+    if (
+        not isinstance(tensor, torch.Tensor)
+        or tensor.ndim != 1
+        or not isinstance(loaded, torch.Tensor)
+        or loaded.ndim != 0
+    ):
+        return None
+    return _Rank3RhsSafeGroupInfo(
+        group_load=true_value,
+        condition=condition,
+        safe_group=root,
+    )
 
-    @property
-    def leading_passthrough_block_id(self) -> int | None:
-        leading_block_ids = self.block_ids[:-2]
-        return leading_block_ids[0] if leading_block_ids else None
 
-    @property
-    def is_leading_passthrough(self) -> bool:
-        """True when this operand carries a leading passthrough grid axis."""
-        return self.leading_passthrough_block_id is not None
+def _tile_begin_block_id(node: Node) -> int | None:
+    from ..compile_environment import _symint_expr
+    from ..host_function import HostFunction
+    from ..variable_origin import TileBeginOrigin
+
+    val = node.meta.get("val")
+    if not isinstance(val, torch.SymInt):
+        return None
+    expr = _symint_expr(val)
+    if expr is None:
+        return None
+    origin_info = HostFunction.current().expr_to_origin.get(expr)
+    if origin_info is None or not isinstance(origin_info.origin, TileBeginOrigin):
+        return None
+    return origin_info.origin.block_id
+
+
+def _is_tile_index_for_block(
+    cg: GenerateAST,
+    node: Node,
+    *,
+    block_id: int,
+) -> bool:
+    from ...language import tile_ops
+    from ..compile_environment import CompileEnvironment
+
+    root = _trace_to_outer_graph_arg(cg, node)
+    if (
+        root.op != "call_function"
+        or root.target is not tile_ops.tile_index
+        or len(root.args) != 1
+        or not isinstance(root.args[0], Node)
+    ):
+        return False
+    root_block_id = _rank3_rhs_index_block_id(root.args[0], reduction=False)
+    if root_block_id is None:
+        return False
+    env = CompileEnvironment.current()
+    canonical_block_id = env.canonical_block_id
+    return canonical_block_id(root_block_id) == canonical_block_id(block_id)
+
+
+def _rank3_rhs_segment_metadata_load(
+    cg: GenerateAST,
+    node: Node,
+    *,
+    column: int,
+    expected_tensor: torch.Tensor | None = None,
+    expected_segment_id: Node | None = None,
+) -> tuple[torch.Tensor, Node, Node] | None:
+    root = _trace_to_outer_graph_arg(cg, node)
+    if not _is_unmasked_load(root) or len(root.args) < 2:
+        return None
+    tensor_node = root.args[0]
+    index = root.args[1]
+    if (
+        not isinstance(tensor_node, Node)
+        or not isinstance(index, list | tuple)
+        or len(index) != 2
+        or not isinstance(index[0], Node)
+        or index[1] != column
+    ):
+        return None
+    segment_id = _trace_to_outer_graph_arg(cg, index[0])
+    if expected_segment_id is not None and segment_id is not expected_segment_id:
+        return None
+    metadata = tensor_node.meta.get("val")
+    loaded = root.meta.get("val")
+    if (
+        not isinstance(metadata, torch.Tensor)
+        or metadata.ndim != 2
+        or metadata.dtype not in (torch.int32, torch.int64)
+        or metadata.shape[1] < 4
+        or (expected_tensor is not None and metadata is not expected_tensor)
+        or not isinstance(loaded, torch.Tensor)
+        or loaded.ndim != 0
+    ):
+        return None
+    return metadata, segment_id, root
+
+
+def _rank3_rhs_segment_group_load(
+    cg: GenerateAST,
+    group_index: Node,
+) -> _Rank3RhsSegmentGroupInfo | None:
+    loaded = _rank3_rhs_segment_metadata_load(cg, group_index, column=0)
+    if loaded is None:
+        return None
+    metadata, segment_id, group_load = loaded
+    segment_block_id = _tile_begin_block_id(segment_id)
+    if segment_block_id is None:
+        return None
+    return _Rank3RhsSegmentGroupInfo(
+        metadata_tensor=metadata,
+        segment_id=segment_id,
+        segment_block_id=segment_block_id,
+        group_load=group_load,
+    )
+
+
+def _rank3_rhs_broadcast_mask_base(
+    condition: Node, *, broadcast_dim: int
+) -> Node | None:
+    from ...language import view_ops
+
+    cond_val = condition.meta.get("val")
+    if (
+        not isinstance(cond_val, torch.Tensor)
+        or cond_val.dtype is not torch.bool
+        or cond_val.ndim != 2
+        or cond_val.shape[broadcast_dim] != 1
+        or condition.op != "call_function"
+        or condition.target is not view_ops.subscript
+        or len(condition.args) != 2
+        or not isinstance(condition.args[0], Node)
+        or not isinstance(condition.args[1], list | tuple)
+    ):
+        return None
+    index = condition.args[1]
+    if len(index) != 2:
+        return None
+    expected_index: list[object] = [slice(None), slice(None)]
+    expected_index[broadcast_dim] = None
+    if tuple(index) != tuple(expected_index):
+        return None
+    return condition.args[0]
+
+
+def _rank3_rhs_segment_lhs_info(
+    cg: GenerateAST,
+    lhs_info: _MmaOperandInfo,
+    rhs_info: _MmaOperandInfo,
+    *,
+    segment_block_id: int,
+    m_block_id: int,
+    k_block_id: int,
+) -> _Rank3RhsSegmentLhsInfo | None:
+    import operator
+
+    from ..compile_environment import CompileEnvironment
+
+    if rhs_info.rhs_segment_group is None:
+        return None
+    segment_group = rhs_info.rhs_segment_group
+    env = CompileEnvironment.current()
+    canonical_block_id = env.canonical_block_id
+    if canonical_block_id(segment_group.segment_block_id) != canonical_block_id(
+        segment_block_id
+    ) or canonical_block_id(segment_group.segment_block_id) in (
+        canonical_block_id(m_block_id),
+        canonical_block_id(k_block_id),
+    ):
+        return None
+    indices = lhs_info.load.args[1] if len(lhs_info.load.args) >= 2 else None
+    extra_mask = lhs_info.load.args[2] if len(lhs_info.load.args) >= 3 else None
+    if (
+        not isinstance(indices, list | tuple)
+        or len(indices) != 2
+        or not isinstance(indices[0], Node)
+        or not isinstance(indices[1], Node)
+        or not isinstance(extra_mask, Node)
+    ):
+        return None
+    lhs_k_block_id = _rank3_rhs_index_block_id(indices[1], reduction=None)
+    if lhs_k_block_id is None or canonical_block_id(
+        lhs_k_block_id
+    ) != canonical_block_id(k_block_id):
+        return None
+
+    row_index = _trace_to_outer_graph_arg(cg, indices[0])
+    if (
+        row_index.op != "call_function"
+        or row_index.target not in (operator.add, torch.ops.aten.add.Tensor)
+        or len(row_index.args) != 2
+        or not all(isinstance(arg, Node) for arg in row_index.args)
+    ):
+        return None
+    row_args = cast("tuple[Node, Node]", row_index.args)
+    segment_start_load = None
+    saw_local_m = False
+    for arg in row_args:
+        if _is_tile_index_for_block(cg, arg, block_id=m_block_id):
+            saw_local_m = True
+            continue
+        loaded = _rank3_rhs_segment_metadata_load(
+            cg,
+            arg,
+            column=1,
+            expected_tensor=segment_group.metadata_tensor,
+            expected_segment_id=segment_group.segment_id,
+        )
+        if loaded is not None:
+            _metadata, _segment_id, segment_start_load = loaded
+            continue
+        return None
+    if segment_start_load is None or not saw_local_m:
+        return None
+
+    mask = _trace_to_outer_graph_arg(cg, extra_mask)
+    valid_m = _rank3_rhs_broadcast_mask_base(mask, broadcast_dim=1)
+    if valid_m is not None:
+        valid_m = _trace_to_outer_graph_arg(cg, valid_m)
+    if (
+        valid_m is None
+        or valid_m.op != "call_function"
+        or valid_m.target not in (operator.lt, torch.ops.aten.lt.Tensor)
+        or len(valid_m.args) != 2
+        or not all(isinstance(arg, Node) for arg in valid_m.args)
+    ):
+        return None
+    valid_lhs, valid_rhs = cast("tuple[Node, Node]", valid_m.args)
+    if not _is_tile_index_for_block(cg, valid_lhs, block_id=m_block_id):
+        return None
+    loaded_actual_m = _rank3_rhs_segment_metadata_load(
+        cg,
+        valid_rhs,
+        column=2,
+        expected_tensor=segment_group.metadata_tensor,
+        expected_segment_id=segment_group.segment_id,
+    )
+    if loaded_actual_m is None:
+        return None
+    _metadata, _segment_id, actual_m_load = loaded_actual_m
+    return _Rank3RhsSegmentLhsInfo(
+        segment_start_load=segment_start_load,
+        actual_m_load=actual_m_load,
+        row_index=row_index,
+        valid_m=valid_m,
+        dependency_nodes=tuple(
+            dict.fromkeys(
+                (
+                    segment_group.group_load,
+                    segment_start_load,
+                    actual_m_load,
+                )
+            )
+        ),
+    )
+
+
+def _unwrap_zero_mask_to(node: Node) -> tuple[Node, Node | None]:
+    from ...language import _tracing_ops
+
+    if (
+        node.op == "call_function"
+        and node.target is _tracing_ops._mask_to
+        and len(node.args) == 2
+        and isinstance(node.args[0], Node)
+        and _is_zero_scalar_node(node.args[1])
+    ):
+        return node.args[0], node
+    return node, None
+
+
+def _is_zero_tensor_node(node: object, *, expected: torch.Tensor) -> bool:
+    if not isinstance(node, Node) or node.op != "call_function":
+        return False
+    val = node.meta.get("val")
+    if (
+        not isinstance(val, torch.Tensor)
+        or val.dtype is not expected.dtype
+        or tuple(val.shape) != tuple(expected.shape)
+    ):
+        return False
+    if node.target is torch.ops.aten.full.default and len(node.args) >= 2:
+        value = node.args[1]
+        return (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and value == 0
+        )
+    return node.target is torch.ops.aten.zeros_like.default
+
+
+def _rank3_rhs_grouped_k_mask(
+    cg: GenerateAST | None,
+    node: Node,
+    *,
+    load_node: Node,
+    k_index_node: Node,
+    expected_safe_group: Node | None = None,
+) -> _Rank3RhsGroupedKMaskInfo | None:
+    import operator
+
+    from ...language import tile_ops
+
+    if cg is None:
+        return None
+    if (
+        node.op != "call_function"
+        or node.target is not torch.ops.aten.where.self
+        or len(node.args) != 3
+        or not isinstance(node.args[0], Node)
+        or node.args[1] is not load_node
+    ):
+        return None
+    condition = node.args[0]
+    load_fake = load_node.meta.get("val")
+    if not isinstance(load_fake, torch.Tensor):
+        return None
+    if not _is_zero_tensor_node(node.args[2], expected=load_fake):
+        return None
+    zero_node = node.args[2]
+    assert isinstance(zero_node, Node)
+
+    valid_k = _rank3_rhs_broadcast_mask_base(condition, broadcast_dim=0)
+    if (
+        valid_k is None
+        or valid_k.op != "call_function"
+        or valid_k.target not in (operator.lt, torch.ops.aten.lt.Tensor)
+        or len(valid_k.args) != 2
+    ):
+        return None
+    tile_index = valid_k.args[0]
+    group_k = valid_k.args[1]
+    if not isinstance(tile_index, Node) or not isinstance(group_k, Node):
+        return None
+    if (
+        tile_index.op != "call_function"
+        or tile_index.target is not tile_ops.tile_index
+        or len(tile_index.args) != 1
+        or tile_index.args[0] is not k_index_node
+    ):
+        return None
+    group_k_root, group_k_value_nodes = _trace_to_outer_graph_arg_with_path(
+        cg,
+        group_k,
+    )
+    if not _is_unmasked_load(group_k_root) or len(group_k_root.args) < 2:
+        return None
+    tensor_node = group_k_root.args[0]
+    index = group_k_root.args[1]
+    if (
+        not isinstance(tensor_node, Node)
+        or not isinstance(index, list | tuple)
+        or len(index) != 1
+        or not isinstance(index[0], Node)
+    ):
+        return None
+    if expected_safe_group is not None and index[0] is not expected_safe_group:
+        return None
+    k_sizes = tensor_node.meta.get("val")
+    loaded_k = group_k_root.meta.get("val")
+    if (
+        not isinstance(k_sizes, torch.Tensor)
+        or k_sizes.ndim != 1
+        or k_sizes.dtype not in (torch.int32, torch.int64)
+        or not isinstance(loaded_k, torch.Tensor)
+        or loaded_k.ndim != 0
+    ):
+        return None
+    return _Rank3RhsGroupedKMaskInfo(
+        k_sizes_tensor=k_sizes,
+        k_sizes_load=group_k_root,
+        k_sizes_value_nodes=group_k_value_nodes,
+        k_sizes_allowed_loop_users=_grouped_k_allowed_loop_users(
+            cg,
+            k_sizes_load=group_k_root,
+            k_sizes_value_nodes=group_k_value_nodes,
+        ),
+        safe_group=index[0],
+        valid_k=valid_k,
+        condition=condition,
+        zero=zero_node,
+        where=node,
+    )
+
+
+def _trace_rank3_grouped_rhs_nt_operand(
+    cg: GenerateAST | None,
+    node: Node,
+    *,
+    m_block_id: int | None = None,
+    allow_grouped_k_mask: bool = False,
+) -> _MmaOperandInfo | None:
+    """Recognize ``B_grouped[group, tile_n, tile_k].T`` as logical ``[K, N]``.
+
+    This is intentionally narrower than tracing through arbitrary permutes:
+    the source must be a rank-3 tensor load, the first index must be the
+    safe-group expression ``where(load(tile_m.begin) >= 0, load, 0)``, and the
+    only data layout transform is the 2-D NT transpose.
+    """
+    if cg is None:
+        return None
+    original_node = node
+    node, mask_to_node = _unwrap_zero_mask_to(node)
+    if (
+        node.op != "call_function"
+        or node.target is not torch.ops.aten.permute.default
+        or len(node.args) < 2
+    ):
+        return None
+    dims = node.args[1]
+    if not isinstance(dims, list | tuple) or list(dims) != [1, 0]:
+        return None
+    permute_input = node.args[0]
+    if not isinstance(permute_input, Node):
+        return None
+    maybe_load_node = permute_input
+    if allow_grouped_k_mask:
+        maybe_load_node, _inner_mask_to = _unwrap_zero_mask_to(maybe_load_node)
+        if _inner_mask_to is not None:
+            return None
+        if (
+            maybe_load_node.op == "call_function"
+            and maybe_load_node.target is torch.ops.aten.where.self
+            and len(maybe_load_node.args) >= 2
+            and isinstance(maybe_load_node.args[1], Node)
+        ):
+            maybe_load_node = maybe_load_node.args[1]
+    load_node = maybe_load_node
+    if (
+        not isinstance(load_node, Node)
+        or not _is_unmasked_load(load_node)
+        or len(load_node.args) < 2
+    ):
+        return None
+    tensor_node = load_node.args[0]
+    indices = load_node.args[1]
+    if (
+        not isinstance(tensor_node, Node)
+        or not isinstance(indices, list)
+        or len(indices) != 3
+        or not isinstance(indices[0], Node)
+        or not isinstance(indices[1], Node)
+        or not isinstance(indices[2], Node)
+    ):
+        return None
+    source_fake = tensor_node.meta.get("val")
+    load_fake = load_node.meta.get("val")
+    node_fake = node.meta.get("val")
+    if (
+        not isinstance(source_fake, torch.Tensor)
+        or not isinstance(load_fake, torch.Tensor)
+        or not isinstance(node_fake, torch.Tensor)
+        or source_fake.ndim != 3
+        or load_fake.ndim != 2
+        or node_fake.ndim != 2
+    ):
+        return None
+    safe_group_info = _rank3_rhs_safe_group_load(
+        cg,
+        indices[0],
+        m_block_id=m_block_id,
+    )
+    segment_group_info = None
+    if safe_group_info is None:
+        segment_group_info = _rank3_rhs_segment_group_load(cg, indices[0])
+        if segment_group_info is None:
+            return None
+    rhs_n_block_id = _rank3_rhs_index_block_id(indices[1], reduction=False)
+    rhs_k_block_id = _rank3_rhs_index_block_id(indices[2], reduction=None)
+    if rhs_n_block_id is None or rhs_k_block_id is None:
+        return None
+    grouped_k_mask = None
+    collective_dependency_nodes: tuple[Node, ...] = ()
+    if permute_input is not load_node:
+        if safe_group_info is None:
+            return None
+        if not allow_grouped_k_mask:
+            return None
+        grouped_k_mask = _rank3_rhs_grouped_k_mask(
+            cg,
+            permute_input,
+            load_node=load_node,
+            k_index_node=indices[2],
+            expected_safe_group=safe_group_info.safe_group,
+        )
+        if grouped_k_mask is None:
+            return None
+        collective_dependency_nodes = (
+            *grouped_k_mask.k_sizes_value_nodes,
+            grouped_k_mask.k_sizes_load,
+            grouped_k_mask.valid_k,
+            grouped_k_mask.condition,
+            grouped_k_mask.zero,
+            grouped_k_mask.where,
+            node,
+            *(() if mask_to_node is None else (mask_to_node,)),
+        )
+    logical_fake = source_fake.as_strided(
+        (source_fake.shape[2], source_fake.shape[1]),
+        (source_fake.stride(2), source_fake.stride(1)),
+    )
+    if _tcgen05_tma_matrix_major(logical_fake) != "col":
+        return None
+    return _MmaOperandInfo(
+        load=load_node,
+        terminal=mask_to_node if mask_to_node is not None else original_node,
+        source_fake=source_fake,
+        logical_fake=logical_fake,
+        collective_dependency_nodes=collective_dependency_nodes,
+        grouped_k_mask=grouped_k_mask,
+        rhs_group_index=indices[0],
+        rhs_safe_group=safe_group_info,
+        rhs_n_block_id=rhs_n_block_id,
+        rhs_k_block_id=rhs_k_block_id,
+        rhs_rank3_grouped_nt=True,
+        rhs_segment_group=segment_group_info,
+    )
+
+
+def _trace_to_mma_operand(
+    node: Node,
+    *,
+    role: str,
+    allow_rank3_rhs_nt: bool = False,
+    cg: GenerateAST | None = None,
+    rank3_rhs_m_block_id: int | None = None,
+    allow_grouped_k_mask: bool = False,
+) -> _MmaOperandInfo | None:
+    if role == "rhs" and allow_rank3_rhs_nt:
+        rank3_rhs = _trace_rank3_grouped_rhs_nt_operand(
+            cg,
+            node,
+            m_block_id=rank3_rhs_m_block_id,
+            allow_grouped_k_mask=allow_grouped_k_mask,
+        )
+        if rank3_rhs is not None:
+            return rank3_rhs
+
+    original_node = node
+    unwrapped_node, mask_to_node = _unwrap_zero_mask_to(node)
+    grouped_k_mask = None
+    collective_dependency_nodes: tuple[Node, ...] = ()
+    if allow_grouped_k_mask and unwrapped_node is not node:
+        if (
+            unwrapped_node.op == "call_function"
+            and unwrapped_node.target is torch.ops.aten.where.self
+            and len(unwrapped_node.args) >= 2
+            and isinstance(unwrapped_node.args[1], Node)
+        ):
+            load_node = unwrapped_node.args[1]
+            traced = _trace_to_load_tensor(load_node)
+            if traced is not None:
+                load_node, _, source_fake = traced
+                indices = load_node.args[1] if len(load_node.args) >= 2 else None
+                if (
+                    isinstance(indices, list | tuple)
+                    and len(indices) == 2
+                    and isinstance(indices[1], Node)
+                ):
+                    grouped_k_mask = _rank3_rhs_grouped_k_mask(
+                        cg,
+                        unwrapped_node,
+                        load_node=load_node,
+                        k_index_node=indices[1],
+                    )
+                    if grouped_k_mask is not None:
+                        if mask_to_node is None:
+                            return None
+                        collective_dependency_nodes = (
+                            *grouped_k_mask.k_sizes_value_nodes,
+                            grouped_k_mask.k_sizes_load,
+                            grouped_k_mask.valid_k,
+                            grouped_k_mask.condition,
+                            grouped_k_mask.zero,
+                            grouped_k_mask.where,
+                            mask_to_node,
+                        )
+                        return _MmaOperandInfo(
+                            load=load_node,
+                            terminal=original_node,
+                            source_fake=source_fake,
+                            logical_fake=source_fake,
+                            collective_dependency_nodes=collective_dependency_nodes,
+                            grouped_k_mask=grouped_k_mask,
+                        )
+
+    traced = _trace_to_load_tensor(node)
+    if traced is None:
+        return None
+    load_node, _, source_fake = traced
+    if source_fake.ndim != 2:
+        return None
+    return _MmaOperandInfo(
+        load=load_node,
+        terminal=load_node,
+        source_fake=source_fake,
+        logical_fake=source_fake,
+    )
+
+
+def _same_fx_node_identity_in_graph(lhs: Node, rhs: Node) -> bool:
+    return lhs.name == rhs.name and lhs.op == rhs.op and lhs.target == rhs.target
+
+
+def _codegen_graph_node_for(cg: GenerateAST, node: Node) -> Node:
+    if any(graph_info.graph is node.graph for graph_info in cg.codegen_graphs):
+        return node
+
+    from ..host_function import HostFunction
+
+    graph_id = None
+    for graph_info in HostFunction.current().device_ir.graphs:
+        if graph_info.graph is node.graph:
+            graph_id = graph_info.graph_id
+            break
+    if graph_id is None or graph_id >= len(cg.codegen_graphs):
+        return node
+
+    for candidate in cg.codegen_graphs[graph_id].graph.nodes:
+        if _same_fx_node_identity_in_graph(candidate, node):
+            return candidate
+    return node
+
+
+def _trace_to_outer_graph_arg_with_path(
+    cg: GenerateAST,
+    node: Node,
+) -> tuple[Node, tuple[Node, ...]]:
+    """Follow loop placeholder copies back to the graph that produced *node*."""
+    from ...language import _tracing_ops
+    from ..device_ir import NodeArgsGraphInfo
+
+    def graph_info_for(graph: torch.fx.Graph) -> NodeArgsGraphInfo | None:
+        for graph_info in cg.codegen_graphs:
+            if graph_info.graph is graph and isinstance(graph_info, NodeArgsGraphInfo):
+                return graph_info
+        return None
+
+    current = node
+    seen: set[Node] = set()
+    path: list[Node] = []
+    while current not in seen:
+        seen.add(current)
+        if current.op == "call_function" and current.target is _tracing_ops._new_var:
+            if len(current.args) != 1 or not isinstance(current.args[0], Node):
+                return current, tuple(dict.fromkeys(path))
+            path.append(current)
+            current = current.args[0]
+            continue
+        if current.op == "placeholder":
+            graph_info = graph_info_for(current.graph)
+            if graph_info is None:
+                return current, tuple(dict.fromkeys(path))
+            outer = graph_info.placeholder_to_outer_arg(current)
+            if not isinstance(outer, Node):
+                return current, tuple(dict.fromkeys(path))
+            path.append(current)
+            current = _codegen_graph_node_for(cg, outer)
+            continue
+        return current, tuple(dict.fromkeys(path))
+    return current, tuple(dict.fromkeys(path))
+
+
+def _trace_to_outer_graph_arg(cg: GenerateAST, node: Node) -> Node:
+    return _trace_to_outer_graph_arg_with_path(cg, node)[0]
+
+
+def _is_zero_scalar_node(node: object) -> bool:
+    if isinstance(node, int) and not isinstance(node, bool):
+        return node == 0
+    if (
+        isinstance(node, Node)
+        and node.op == "call_function"
+        and node.target is torch.ops.aten.scalar_tensor.default
+        and len(node.args) >= 1
+    ):
+        value = node.args[0]
+        return isinstance(value, int) and not isinstance(value, bool) and value == 0
+    return False
+
+
+def _is_tile_begin(node: Node, *, m_block_id: int | None = None) -> bool:
+    from ..compile_environment import CompileEnvironment
+
+    block_id = _tile_begin_block_id(node)
+    if block_id is None:
+        return False
+    if m_block_id is None:
+        return True
+    env = CompileEnvironment.current()
+    canonical_block_id = env.canonical_block_id
+    return canonical_block_id(block_id) == canonical_block_id(m_block_id)
+
+
+def _tcgen05_rank3_rhs_group_tma_setup(
+    cg: GenerateAST,
+    group_index: Node,
+    *,
+    m_block_id: int,
+    m_offset_var: str,
+) -> tuple[str, list[str]] | None:
+    """Emit the role-local group-id expression for grouped rank-3 RHS TMA.
+
+    The K-loop RHS operand sees the group index through a placeholder copy.
+    For the TMA producer, recover the root ``where(load(tile_m.begin) >= 0,
+    load, 0)`` expression and materialize the same safe group value next to
+    ``gB_tma`` so extracted role-local code does not depend on shared-loop
+    locals.
+    """
+    from ..compile_environment import CompileEnvironment
+
+    safe_group_info = _rank3_rhs_safe_group_load(cg, group_index, m_block_id=m_block_id)
+    if safe_group_info is None:
+        return None
+    true_value = safe_group_info.group_load
+    tensor_node = true_value.args[0]
+    if not isinstance(tensor_node, Node):
+        return None
+    tensor = tensor_node.meta.get("val")
+    if not isinstance(tensor, torch.Tensor):
+        return None
+
+    df = cg.device_function
+    tensor_name = df.tensor_arg(tensor).name
+    group_var = df.new_var("tcgen05_rhs_group")
+    safe_group_var = df.new_var("tcgen05_rhs_safe_group")
+    index_dtype = CompileEnvironment.current().index_type()
+    load_expr = (
+        f"({tensor_name}.iterator + {index_dtype}({m_offset_var}) "
+        f"* {index_dtype}({tensor_name}.layout.stride[0])).load()"
+    )
+    return safe_group_var, [
+        f"{group_var} = {load_expr}",
+        (
+            f"{safe_group_var} = cutlass.Int32({group_var}) "
+            f"if {group_var} >= cutlass.Int32(0) else cutlass.Int32(0)"
+        ),
+    ]
+
+
+def _assignment_target_name(stmt: ast.AST) -> str | None:
+    if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+        return None
+    target = stmt.targets[0]
+    if not isinstance(target, ast.Name):
+        return None
+    return target.id
+
+
+def _rank3_rhs_safe_group_scalar_rewrite_plan(
+    cg: GenerateAST,
+    info: _MmaOperandInfo,
+    *,
+    m_offset_var: str,
+) -> tuple[ast.Assign, ast.expr, tuple[ast.AST, ...]] | None:
+    """Return the group-load assignment and unmasked load expression if safe."""
+    from ..compile_environment import CompileEnvironment
+
+    if info.rhs_group_index is None or info.rhs_safe_group is None:
+        return None
+    group_load = info.rhs_safe_group.group_load
+    condition = info.rhs_safe_group.condition
+    safe_group = info.rhs_safe_group.safe_group
+    entries_by_owner = cg._statements_by_owner_node_id
+    group_entries = list(entries_by_owner.get(id(group_load), ()))
+    condition_entries = list(entries_by_owner.get(id(condition), ()))
+    safe_group_entries = list(entries_by_owner.get(id(safe_group), ()))
+    if len(group_entries) != 1 or not condition_entries or len(safe_group_entries) != 1:
+        return None
+
+    body, group_stmt = group_entries[0]
+    owned_statements = [
+        stmt
+        for _owner_body, stmt in (
+            *group_entries,
+            *condition_entries,
+            *safe_group_entries,
+        )
+    ]
+    if len({id(stmt) for stmt in owned_statements}) != len(owned_statements):
+        return None
+    for owner_body, owned_stmt in (
+        *group_entries,
+        *condition_entries,
+        *safe_group_entries,
+    ):
+        if owner_body is not body or sum(stmt is owned_stmt for stmt in body) != 1:
+            return None
+    group_var = _assignment_target_name(group_stmt)
+    if group_var is None or not isinstance(group_stmt, ast.Assign):
+        return None
+
+    tensor_node = group_load.args[0] if group_load.args else None
+    if not isinstance(tensor_node, Node):
+        return None
+    tensor = tensor_node.meta.get("val")
+    if not isinstance(tensor, torch.Tensor) or tensor.ndim != 1:
+        return None
+
+    df = cg.device_function
+    tensor_name = df.tensor_arg(tensor).name
+    env = CompileEnvironment.current()
+    index_dtype = env.index_type()
+    load_expr = (
+        f"({tensor_name}.iterator + {index_dtype}({m_offset_var}) "
+        f"* {index_dtype}({tensor_name}.layout.stride[0])).load()"
+    )
+    return (
+        group_stmt,
+        cast("ast.expr", expr_from_string(load_expr)),
+        tuple(owned_statements),
+    )
+
+
+def _apply_rank3_rhs_safe_group_scalar_rewrite(
+    plan: tuple[ast.Assign, ast.expr, tuple[ast.AST, ...]],
+) -> None:
+    """Keep the safe-group scalar chain, but drop its tile-mask dependency."""
+    group_stmt, replacement, _owned_statements = plan
+    group_stmt.value = replacement
+    ast.fix_missing_locations(group_stmt)
+
+
+def _owned_scalar_statement_pass_rewrite_plan(
+    cg: GenerateAST,
+    required_nodes: tuple[Node, ...],
+    *,
+    optional_nodes: tuple[Node, ...] = (),
+) -> tuple[tuple[int, list[ast.AST], int, ast.AST], ...] | None:
+    replacement_plan: list[tuple[int, list[ast.AST], int, ast.AST]] = []
+    seen_node_ids: set[int] = set()
+    seen_stmt_ids: set[int] = set()
+    for index, node in enumerate((*required_nodes, *optional_nodes)):
+        required = index < len(required_nodes)
+        node_id = id(node)
+        if node_id in seen_node_ids:
+            return None
+        seen_node_ids.add(node_id)
+        entries = cg._statements_by_owner_node_id.get(node_id, ())
+        if required and len(entries) != 1:
+            return None
+        if not entries:
+            continue
+        for body, stmt in entries:
+            matching_indices = [
+                stmt_index
+                for stmt_index, existing in enumerate(body)
+                if existing is stmt
+            ]
+            if len(matching_indices) != 1 or id(stmt) in seen_stmt_ids:
+                return None
+            seen_stmt_ids.add(id(stmt))
+            replacement_plan.append((node_id, body, matching_indices[0], stmt))
+
+    return tuple(replacement_plan)
+
+
+def _apply_owned_scalar_statement_pass_rewrite(
+    cg: GenerateAST,
+    replacement_plan: tuple[tuple[int, list[ast.AST], int, ast.AST], ...],
+) -> None:
+    for node_id, body, index, stmt in replacement_plan:
+        assert body[index] is stmt
+        replacement = ast.Pass()
+        ast.fix_missing_locations(replacement)
+        body[index] = replacement
+        cg._statements_by_owner_node_id.pop(node_id, None)
+
+
+def _owned_scalar_statement_expr_rewrite_plan(
+    cg: GenerateAST,
+    replacements: dict[Node, str],
+) -> tuple[tuple[ast.Assign, ast.expr], ...] | None:
+    replacement_plan: list[tuple[ast.Assign, ast.expr]] = []
+    seen_stmt_ids: set[int] = set()
+    for node, expr in replacements.items():
+        entries = cg._statements_by_owner_node_id.get(id(node), ())
+        if not entries:
+            continue
+        if len(entries) != 1:
+            return None
+        body, stmt = entries[0]
+        if (
+            not isinstance(stmt, ast.Assign)
+            or _assignment_target_name(stmt) is None
+            or sum(existing is stmt for existing in body) != 1
+            or id(stmt) in seen_stmt_ids
+        ):
+            return None
+        seen_stmt_ids.add(id(stmt))
+        replacement_plan.append((stmt, cast("ast.expr", expr_from_string(expr))))
+    return tuple(replacement_plan)
+
+
+def _apply_owned_scalar_statement_expr_rewrite(
+    replacement_plan: tuple[tuple[ast.Assign, ast.expr], ...],
+) -> None:
+    for stmt, value in replacement_plan:
+        stmt.value = value
+        ast.fix_missing_locations(stmt)
+
+
+def _tcgen05_pid_initializes_epi_role_tile_counter(pid: object) -> bool:
+    from ..program_id import ForEachProgramID
+    from ..program_id import L2GroupingProgramIDs
+    from ..program_id import Tcgen05PersistentProgramIDs
+
+    if isinstance(pid, Tcgen05PersistentProgramIDs):
+        return True
+    if isinstance(pid, L2GroupingProgramIDs):
+        return (
+            pid.parent_strategy is not None
+            and _tcgen05_pid_initializes_epi_role_tile_counter(pid.parent_strategy)
+        )
+    if isinstance(pid, ForEachProgramID):
+        return any(
+            _tcgen05_pid_initializes_epi_role_tile_counter(case) for case in pid.cases
+        )
+    return False
+
+
+def _has_mma_operands(
+    lhs_node: Node,
+    rhs_node: Node,
+    *,
+    allow_rank3_rhs_nt: bool = False,
+    cg: GenerateAST | None = None,
+    rank3_rhs_m_block_id: int | None = None,
+    allow_grouped_k_mask: bool = False,
+) -> bool:
+    """Check if lhs/rhs come from loads with MMA-compatible dtypes."""
+    lhs_info = _trace_to_mma_operand(
+        lhs_node,
+        role="lhs",
+        cg=cg,
+        allow_grouped_k_mask=allow_grouped_k_mask,
+    )
+    rhs_info = _trace_to_mma_operand(
+        rhs_node,
+        role="rhs",
+        allow_rank3_rhs_nt=allow_rank3_rhs_nt,
+        cg=cg,
+        rank3_rhs_m_block_id=rank3_rhs_m_block_id,
+        allow_grouped_k_mask=allow_grouped_k_mask,
+    )
+    if lhs_info is None or rhs_info is None:
+        return False
+    if (
+        lhs_info.grouped_k_mask is not None or rhs_info.grouped_k_mask is not None
+    ) and _same_grouped_k_mask(lhs_info, rhs_info) is None:
+        return False
+    lhs_fake = lhs_info.logical_fake
+    rhs_fake = rhs_info.logical_fake
+    return (
+        lhs_fake.dtype in _MMA_SUPPORTED_DTYPES
+        and rhs_fake.dtype in _MMA_SUPPORTED_DTYPES
+        and lhs_fake.dtype == rhs_fake.dtype
+        and lhs_fake.ndim == 2
+        and rhs_fake.ndim == 2
+    )
 
 
 @dataclass(frozen=True)
@@ -554,6 +1890,11 @@ class _MmaOperandAnalysis:
         if self.leading_passthrough_block_id is None:
             return matrix_block_ids
         return (self.leading_passthrough_block_id, *matrix_block_ids)
+
+
+@dataclass(frozen=True)
+class _MmaSearchGraphView:
+    codegen_graphs: list[GraphInfo]
 
 
 @dataclass(frozen=True)
@@ -603,7 +1944,9 @@ def _analyze_mma_operand(
         return None
     return _MmaOperandInfo(
         load=load_node,
+        terminal=load_node,
         source_fake=source_fake,
+        logical_fake=source_fake,
         block_ids=block_ids,
     )
 
@@ -643,6 +1986,189 @@ def _analyze_mma_operands(
     ):
         return None
     return _MmaOperandAnalysis(lhs=lhs, rhs=rhs)
+
+
+def _analyze_rank3_rhs_grouped_search_operands(
+    lhs_node: Node,
+    rhs_node: Node,
+    env: CompileEnvironment,
+    device_ir: DeviceIR,
+) -> _MmaOperandAnalysis | None:
+    """Build the block-axis view needed by the early tcgen05 search gate.
+
+    Full grouped admission still runs later with ``GenerateAST`` so it can
+    prove the safe-group, segment metadata, and store chains across graphs.
+    The earlier DeviceIR search pass only needs the matrix axes and source
+    dtype; recover those from the canonical ``B[group, n, k].T`` load.
+    """
+    from ..device_ir import ForLoopGraphInfo
+
+    graph_view = cast("GenerateAST", _MmaSearchGraphView(device_ir.graphs))
+    lhs = _trace_to_mma_operand(
+        lhs_node,
+        role="lhs",
+        cg=graph_view,
+        allow_grouped_k_mask=True,
+    )
+    rhs = _trace_to_mma_operand(
+        rhs_node,
+        role="rhs",
+        allow_rank3_rhs_nt=True,
+        cg=graph_view,
+        allow_grouped_k_mask=True,
+    )
+    if (
+        lhs is None
+        or rhs is None
+        or not rhs.rhs_rank3_grouped_nt
+        or rhs.rhs_n_block_id is None
+        or rhs.rhs_k_block_id is None
+    ):
+        return None
+
+    canonical_block_id = env.canonical_block_id
+    n_block_id = canonical_block_id(rhs.rhs_n_block_id)
+    k_block_id = canonical_block_id(rhs.rhs_k_block_id)
+    if len(device_ir.grid_block_ids) != 1:
+        return None
+    root_grid_ids = device_ir.grid_block_ids[0]
+    segment_block_id = (
+        canonical_block_id(rhs.rhs_segment_group.segment_block_id)
+        if rhs.rhs_segment_group is not None
+        else None
+    )
+    n_root_ids = [
+        block_id
+        for block_id in root_grid_ids
+        if canonical_block_id(block_id) == n_block_id
+    ]
+    m_root_ids = [
+        block_id
+        for block_id in root_grid_ids
+        if canonical_block_id(block_id) != n_block_id
+        and (
+            segment_block_id is None or canonical_block_id(block_id) != segment_block_id
+        )
+    ]
+    if len(n_root_ids) != 1 or len(m_root_ids) != 1:
+        return None
+    m_block_id = m_root_ids[0]
+    n_block_id = n_root_ids[0]
+
+    k_loop_ids = [
+        block_id
+        for graph_info in device_ir.graphs
+        if isinstance(graph_info, ForLoopGraphInfo)
+        and graph_info.graph is rhs_node.graph
+        for block_id in graph_info.block_ids
+        if canonical_block_id(block_id) == k_block_id
+    ]
+    if len(k_loop_ids) != 1:
+        return None
+    k_block_id = k_loop_ids[0]
+    leading_block_ids = (
+        ()
+        if segment_block_id is None
+        else tuple(
+            block_id
+            for block_id in root_grid_ids
+            if canonical_block_id(block_id) == segment_block_id
+        )
+    )
+    if segment_block_id is not None and len(leading_block_ids) != 1:
+        return None
+    lhs = replace(
+        lhs,
+        block_ids=(*leading_block_ids, m_block_id, k_block_id),
+    )
+    rhs = replace(
+        rhs,
+        block_ids=(*leading_block_ids, k_block_id, n_block_id),
+    )
+    if lhs.source_fake.dtype != rhs.source_fake.dtype:
+        return None
+    if not env.known_equal(lhs.source_fake.size(-1), rhs.source_fake.size(-1)):
+        return None
+    return _MmaOperandAnalysis(lhs=lhs, rhs=rhs)
+
+
+def is_mma_compatible_aten(
+    node: Node,
+    with_acc: bool,
+    *,
+    allow_rank3_rhs_nt: bool = False,
+    cg: GenerateAST | None = None,
+    rank3_rhs_m_block_id: int | None = None,
+    allow_grouped_k_mask: bool = False,
+) -> bool:
+    """Check if an aten addmm/mm node can use MMA."""
+    args = node.args
+    if with_acc:
+        if len(args) < 3:
+            return False
+        acc_node = args[0]
+        lhs_node, rhs_node = args[1], args[2]
+        if isinstance(acc_node, Node):
+            acc_val = acc_node.meta.get("val")
+            if isinstance(acc_val, torch.Tensor) and acc_val.ndim != 2:
+                return False
+    else:
+        if len(args) < 2:
+            return False
+        lhs_node, rhs_node = args[0], args[1]
+    if not isinstance(lhs_node, Node) or not isinstance(rhs_node, Node):
+        return False
+    return _has_mma_operands(
+        lhs_node,
+        rhs_node,
+        allow_rank3_rhs_nt=allow_rank3_rhs_nt,
+        cg=cg,
+        rank3_rhs_m_block_id=rank3_rhs_m_block_id,
+        allow_grouped_k_mask=allow_grouped_k_mask,
+    )
+
+
+def is_mma_compatible_dot(node: Node) -> bool:
+    """Check if an hl.dot FX node can use MMA."""
+    if len(node.args) < 2:
+        return False
+    acc_node = node.args[2] if len(node.args) > 2 else None
+    lhs_node, rhs_node = node.args[0], node.args[1]
+    if not isinstance(lhs_node, Node) or not isinstance(rhs_node, Node):
+        return False
+    if isinstance(acc_node, Node):
+        acc_val = acc_node.meta.get("val")
+        if isinstance(acc_val, torch.Tensor) and acc_val.ndim != 2:
+            return False
+    return _has_mma_operands(lhs_node, rhs_node)
+
+
+def can_codegen_cute_mma_dot(node: Node) -> bool:
+    """Return True when hl.dot supports MMA and matches MMA dtype semantics."""
+    if not is_mma_compatible_dot(node):
+        return False
+    if not _mma_result_can_be_deferred(node) or not _mma_loop_is_exclusive(node):
+        return False
+
+    lhs_node = node.args[0]
+    rhs_node = node.args[1]
+    assert isinstance(lhs_node, Node) and isinstance(rhs_node, Node)
+    lhs_val = lhs_node.meta.get("val")
+    rhs_val = rhs_node.meta.get("val")
+    if not isinstance(lhs_val, torch.Tensor) or not isinstance(rhs_val, torch.Tensor):
+        return False
+    if not _needs_f32_accumulator(lhs_val.dtype, rhs_val.dtype):
+        return True
+
+    acc_dtype: torch.dtype | None = None
+    if len(node.args) > 2 and isinstance(node.args[2], Node):
+        acc_val = node.args[2].meta.get("val")
+        if isinstance(acc_val, torch.Tensor):
+            acc_dtype = acc_val.dtype
+    out_dtype = node.args[3] if len(node.args) > 3 else None
+    if out_dtype is not None and not isinstance(out_dtype, torch.dtype):
+        return False
+    return out_dtype in (None, torch.float32) and acc_dtype in (None, torch.float32)
 
 
 @dataclass(frozen=True)
@@ -748,6 +2274,29 @@ def _decode_cute_mma_target(
     )
 
 
+def can_codegen_cute_mma_aten(
+    node: Node,
+    with_acc: bool,
+    *,
+    allow_rank3_rhs_nt: bool = False,
+    cg: GenerateAST | None = None,
+    rank3_rhs_m_block_id: int | None = None,
+    allow_grouped_k_mask: bool = False,
+) -> bool:
+    return (
+        is_mma_compatible_aten(
+            node,
+            with_acc,
+            allow_rank3_rhs_nt=allow_rank3_rhs_nt,
+            cg=cg,
+            rank3_rhs_m_block_id=rank3_rhs_m_block_id,
+            allow_grouped_k_mask=allow_grouped_k_mask,
+        )
+        and _mma_result_can_be_deferred(node)
+        and _mma_loop_is_exclusive(node)
+    )
+
+
 def analyze_cute_mma_node(
     node: Node,
     *,
@@ -764,6 +2313,13 @@ def analyze_cute_mma_node(
         target.rhs,
         CompileEnvironment.current(),
     )
+    if operands is None and device_ir is not None:
+        operands = _analyze_rank3_rhs_grouped_search_operands(
+            target.lhs,
+            target.rhs,
+            CompileEnvironment.current(),
+            device_ir,
+        )
     if operands is None:
         return None
     if not _mma_result_can_be_deferred(node) or not _mma_loop_is_exclusive(node):
@@ -817,6 +2373,248 @@ def analyze_cute_mma_node(
         with_acc=target.with_acc,
         is_dot=target.is_dot,
         requires_accumulator_seed=target.requires_accumulator_seed,
+    )
+
+
+def _prove_rank3_rhs_grouped_mma(
+    cg: GenerateAST,
+    node: Node,
+    *,
+    config: _ConfigLike,
+    axes: _GroupedMmaAxes,
+) -> _Rank3RhsGroupedProof | None:
+    """Prove the graph semantics required by rank-3 RHS grouped lowering."""
+    from ..compile_environment import CompileEnvironment
+
+    # The grouped lowering is proven only for the rank-2 addmm form emitted by
+    # Helion's tiled reduction. Other Aten MMA forms remain supported by the
+    # ordinary collective path, but must not enter this grouped proof through
+    # only a subset of the compiler phases.
+    if node.target is not torch.ops.aten.addmm.default:
+        return None
+    with_acc = True
+    grouped_mode = _tcgen05_grouped_mode(config)
+    allow_grouped_k_mask = grouped_mode is not None
+    if not can_codegen_cute_mma_aten(
+        node,
+        with_acc,
+        allow_rank3_rhs_nt=True,
+        cg=cg,
+        rank3_rhs_m_block_id=axes.m_block_id,
+        allow_grouped_k_mask=allow_grouped_k_mask,
+    ):
+        return None
+    lhs_node = node.args[1] if with_acc else node.args[0]
+    rhs_node = node.args[2] if with_acc else node.args[1]
+    assert isinstance(lhs_node, Node) and isinstance(rhs_node, Node)
+    allow_segment_store_extent_metadata = (
+        grouped_mode == TCGEN05_GROUPED_MODE_WORKLIST_NM
+    )
+    lhs_info = _trace_to_mma_operand(
+        lhs_node,
+        role="lhs",
+        cg=cg,
+        allow_grouped_k_mask=allow_grouped_k_mask,
+    )
+    rhs_info = _trace_to_mma_operand(
+        rhs_node,
+        role="rhs",
+        allow_rank3_rhs_nt=True,
+        cg=cg,
+        rank3_rhs_m_block_id=axes.m_block_id,
+        allow_grouped_k_mask=allow_grouped_k_mask,
+    )
+    if lhs_info is None or rhs_info is None or not rhs_info.rhs_rank3_grouped_nt:
+        return None
+
+    lhs_fake = lhs_info.logical_fake
+    rhs_fake = rhs_info.logical_fake
+    env = CompileEnvironment.current()
+    canonical_block_id = env.canonical_block_id
+    k_mask = _same_grouped_k_mask(lhs_info, rhs_info)
+    if (
+        lhs_info.grouped_k_mask is not None or rhs_info.grouped_k_mask is not None
+    ) and k_mask is None:
+        return None
+    if not (
+        lhs_fake.dtype in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
+        and _tcgen05_tma_matrix_major(lhs_fake) == "row"
+        and _tcgen05_tma_matrix_major(rhs_fake) == "col"
+        and rhs_info.rhs_n_block_id == canonical_block_id(axes.n_block_id)
+        and rhs_info.rhs_k_block_id == canonical_block_id(axes.k_block_id)
+        and (
+            not with_acc
+            or (isinstance(node.args[0], Node) and _is_zero_init_acc_node(node.args[0]))
+        )
+    ):
+        return None
+
+    tail_epilogue = None
+    if (
+        allow_grouped_k_mask
+        and rhs_info.rhs_group_index is not None
+        and rhs_info.rhs_safe_group is not None
+    ):
+        tail_epilogue = find_tcgen05_grouped_tail_epilogue_for_mma(
+            node,
+            cg.codegen_graphs,
+            safe_group_node=rhs_info.rhs_safe_group.safe_group,
+            safe_group_layout_load_node=rhs_info.rhs_safe_group.group_load,
+        )
+    allowed_safe_group_users = (
+        tuple(
+            producer
+            for producer in tail_epilogue.producer_nodes
+            if producer in tail_epilogue.safe_group_node.users
+        )
+        if tail_epilogue is not None
+        else ()
+    )
+    allowed_safe_group_users = (
+        *allowed_safe_group_users,
+        *((k_mask.k_sizes_load,) if k_mask is not None else ()),
+    )
+
+    segment_group = rhs_info.rhs_segment_group
+    segment_lhs = None
+    segment_store = None
+    if segment_group is not None:
+        if axes.segment_block_id is None:
+            return None
+        segment_lhs = _rank3_rhs_segment_lhs_info(
+            cg,
+            lhs_info,
+            rhs_info,
+            segment_block_id=axes.segment_block_id,
+            m_block_id=axes.m_block_id,
+            k_block_id=axes.k_block_id,
+        )
+        if segment_lhs is None:
+            return None
+        segment_store = _rank3_rhs_segment_store_info(
+            cg,
+            node,
+            segment_lhs,
+            segment_group,
+            allow_store_extent_metadata=allow_segment_store_extent_metadata,
+        )
+        if segment_store is None:
+            return None
+        layout_tensor = segment_group.metadata_tensor
+    else:
+        if axes.segment_block_id is not None or not _is_unmasked_load(lhs_info.load):
+            return None
+        if not _rank3_rhs_safe_group_consumed_nodes_exclusive(
+            cg,
+            rhs_info,
+            allowed_safe_group_users=allowed_safe_group_users,
+        ):
+            return None
+        safe_group = rhs_info.rhs_safe_group
+        if rhs_info.rhs_group_index is None or safe_group is None:
+            return None
+        tensor_node = safe_group.group_load.args[0]
+        if not isinstance(tensor_node, Node):
+            return None
+        layout_tensor = tensor_node.meta.get("val")
+        if not isinstance(layout_tensor, torch.Tensor):
+            return None
+
+    return _Rank3RhsGroupedProof(
+        lhs=lhs_info,
+        rhs=rhs_info,
+        layout_tensor=layout_tensor,
+        k_mask=k_mask,
+        tail_epilogue=tail_epilogue,
+        segment_lhs=segment_lhs,
+        segment_store=segment_store,
+    )
+
+
+def _tcgen05_grouped_static_seed_has_proof(
+    env: CompileEnvironment,
+    device_ir: DeviceIR,
+    fact: MatmulFact,
+    *,
+    require_exact_k: bool,
+) -> bool:
+    from ..compile_environment import CompileEnvironment
+
+    host_function = device_ir.host_function
+    if (
+        host_function is None
+        or fact.m_block_id is None
+        or fact.n_block_id is None
+        or fact.k_block_id is None
+    ):
+        return False
+    axes = _GroupedMmaAxes(
+        m_block_id=fact.m_block_id,
+        n_block_id=fact.n_block_id,
+        k_block_id=fact.k_block_id,
+    )
+
+    probe_config = {
+        "block_sizes": [128, 64, 64 if require_exact_k else 16],
+        "pid_type": "persistent_interleaved",
+        "tcgen05_cluster_m": 1,
+        "tcgen05_cluster_n": 1,
+        TCGEN05_GROUPED_MODE_CONFIG_KEY: (
+            TCGEN05_GROUPED_MODE_DYNAMIC
+            if require_exact_k
+            else TCGEN05_GROUPED_MODE_STATIC
+        ),
+    }
+    graph_view = _MmaSearchGraphView(device_ir.graphs)
+    env_context = contextlib.nullcontext() if CompileEnvironment.has_current() else env
+    with env_context, host_function:
+        for graph_info in device_ir.graphs:
+            for node in graph_info.graph.nodes:
+                if node.op != "call_function":
+                    continue
+                if node.target is not torch.ops.aten.addmm.default:
+                    continue
+                proof = _prove_rank3_rhs_grouped_mma(
+                    cast("GenerateAST", graph_view),
+                    node,
+                    config=probe_config,
+                    axes=axes,
+                )
+                if proof is None:
+                    continue
+                proof_matches = (
+                    proof.k_mask is not None
+                    if require_exact_k
+                    else (
+                        proof.lhs.grouped_k_mask is None
+                        and proof.rhs.grouped_k_mask is None
+                        and not proof.is_worklist
+                    )
+                )
+                if proof_matches:
+                    return True
+    return False
+
+
+def tcgen05_grouped_dynamic_bk64_seed_has_exact_k_proof(
+    env: CompileEnvironment,
+    device_ir: DeviceIR,
+    fact: MatmulFact,
+) -> bool:
+    """Return whether a seed can rely on exact grouped K proof."""
+    return _tcgen05_grouped_static_seed_has_proof(
+        env, device_ir, fact, require_exact_k=True
+    )
+
+
+def tcgen05_grouped_static_seed_has_common_k_proof(
+    env: CompileEnvironment,
+    device_ir: DeviceIR,
+    fact: MatmulFact,
+) -> bool:
+    """Return whether a seed can use grouped-static common-K codegen."""
+    return _tcgen05_grouped_static_seed_has_proof(
+        env, device_ir, fact, require_exact_k=False
     )
 
 
@@ -1205,43 +3003,227 @@ def prepare_cute_collective_lane_loop_suppression(
     env = CompileEnvironment.current()
     if env.backend_name != "cute":
         return
-
+    allow_grouped_k_mask = _tcgen05_grouped_mode(cg.device_function.config) is not None
     for node in graph.nodes:
         candidate = analyze_cute_mma_node(node)
-        if candidate is None or candidate.requires_accumulator_seed:
+        if candidate is not None:
+            if candidate.requires_accumulator_seed:
+                continue
+            analysis = candidate.operands
+            if tuple(grid_state.block_ids) != analysis.output_block_ids:
+                continue
+            leading_block_id = analysis.leading_passthrough_block_id
+            if leading_block_id is not None and (
+                cg.device_function.resolved_block_size(leading_block_id) != 1
+            ):
+                continue
+            lhs_operand = analysis.lhs
+            rhs_operand = analysis.rhs
+            lhs_load = lhs_operand.load
+            rhs_load = rhs_operand.load
+            lhs_fake = lhs_operand.source_fake
+            rhs_fake = rhs_operand.source_fake
+            k_loop_info = _get_mma_k_loop_info(
+                cg,
+                env,
+                lhs_fake,
+                rhs_fake,
+                fx_node=node,
+                lhs_k_size=lhs_operand.matrix_cols,
+                rhs_k_size=rhs_operand.matrix_rows,
+            )
+            if k_loop_info is None or k_loop_info[1] != analysis.k_block_id:
+                continue
+            bm = cg.device_function.resolved_block_size(analysis.m_block_id)
+            bn = cg.device_function.resolved_block_size(analysis.n_block_id)
+            bk = k_loop_info[3]
+            if not isinstance(bm, int) or not isinstance(bn, int):
+                continue
+            if (
+                _choose_mma_impl(
+                    lhs_fake.dtype,
+                    bm=bm,
+                    bn=bn,
+                    bk=bk,
+                    config=cg.device_function.config,
+                    input_device=lhs_fake.device,
+                )
+                != "tcgen05"
+            ):
+                continue
+            if analysis.has_leading_passthrough and not _mma_tiles_are_static_full(
+                analysis, bm=bm, bn=bn, bk=bk
+            ):
+                continue
+            if (
+                len(lhs_load.users) != 1
+                or len(rhs_load.users) != 1
+                or next(iter(lhs_load.users)) is not node
+                or next(iter(rhs_load.users)) is not node
+            ):
+                continue
+            allowed_k_lane_loops: tuple[DeviceLoopState, ...] = (
+                (k_loop_info[0],)
+                if analysis.leading_passthrough_block_id is not None
+                else ()
+            )
+            if _has_non_root_lane_loops(cg, allowed_loop_states=allowed_k_lane_loops):
+                continue
+            cute_state = cg.device_function.cute_state
+            _register_collective_handled_loads(cute_state, lhs_load, rhs_load)
+            if grid_state.has_lane_loops():
+                cute_state.request_root_lane_loop_suppression()
             continue
-        analysis = candidate.operands
-        if tuple(grid_state.block_ids) != analysis.output_block_ids:
+
+        if node.target is torch.ops.aten.addmm.default:
+            with_acc = True
+            lhs_node = node.args[1]
+            rhs_node = node.args[2]
+            if not can_codegen_cute_mma_aten(
+                node,
+                with_acc,
+                allow_rank3_rhs_nt=True,
+                cg=cg,
+                allow_grouped_k_mask=allow_grouped_k_mask,
+            ):
+                continue
+        elif node.target is torch.ops.aten.mm.default:
+            with_acc = False
+            lhs_node = node.args[0]
+            rhs_node = node.args[1]
+            if not can_codegen_cute_mma_aten(
+                node,
+                with_acc,
+                allow_rank3_rhs_nt=True,
+                cg=cg,
+                allow_grouped_k_mask=allow_grouped_k_mask,
+            ):
+                continue
+        elif can_codegen_cute_mma_dot(node):
+            lhs_node = node.args[0]
+            rhs_node = node.args[1]
+        else:
             continue
-        leading_block_id = analysis.leading_passthrough_block_id
-        if leading_block_id is not None and (
-            cg.device_function.resolved_block_size(leading_block_id) != 1
+
+        if not isinstance(lhs_node, Node) or not isinstance(rhs_node, Node):
+            continue
+
+        lhs_info = _trace_to_mma_operand(
+            lhs_node,
+            role="lhs",
+            cg=cg,
+            allow_grouped_k_mask=allow_grouped_k_mask,
+        )
+        rhs_info = _trace_to_mma_operand(
+            rhs_node,
+            role="rhs",
+            allow_rank3_rhs_nt=True,
+            cg=cg,
+            allow_grouped_k_mask=allow_grouped_k_mask,
+        )
+        if lhs_info is None or rhs_info is None:
+            continue
+        lhs_fake = lhs_info.logical_fake
+        rhs_fake = rhs_info.logical_fake
+        if lhs_fake.ndim != 2 or rhs_fake.ndim != 2:
+            continue
+
+        if not (
+            isinstance(lhs_fake.shape[0], int)
+            and isinstance(rhs_fake.shape[1], int)
+            and isinstance(lhs_fake.shape[1], int)
         ):
             continue
-        lhs_operand = analysis.lhs
-        rhs_operand = analysis.rhs
-        lhs_load = lhs_operand.load
-        rhs_load = rhs_operand.load
-        lhs_fake = lhs_operand.source_fake
-        rhs_fake = rhs_operand.source_fake
-        lhs_k_size = lhs_operand.matrix_cols
-        rhs_k_size = rhs_operand.matrix_rows
-        k_loop_info = _get_mma_k_loop_info(
-            cg,
-            env,
-            lhs_fake,
-            rhs_fake,
-            fx_node=node,
-            lhs_k_size=lhs_k_size,
-            rhs_k_size=rhs_k_size,
-        )
-        if k_loop_info is None or k_loop_info[1] != analysis.k_block_id:
+        bm = bn = bk = None
+        m_block_id = n_block_id = None
+        candidate_block_ids = [*grid_state.block_ids]
+        if (
+            k_loop_info := _get_mma_k_loop_info(
+                cg, env, lhs_fake, rhs_fake, fx_node=node
+            )
+        ) is not None:
+            device_loop, k_block_id, _, k_block_size = k_loop_info
+            candidate_block_ids.append(k_block_id)
+            bk = int(k_block_size)
+        else:
+            device_loop = None
+            k_block_id = None
+        for bid in dict.fromkeys(candidate_block_ids):
+            size = env.block_sizes[bid].size
+            bs = cg.device_function.resolved_block_size(bid)
+            if not isinstance(bs, int):
+                continue
+            if isinstance(size, (int, torch.SymInt)):
+                if bm is None and env.known_equal(size, lhs_fake.shape[0]):
+                    bm = int(bs)
+                    m_block_id = bid
+                elif bn is None and env.known_equal(size, rhs_fake.shape[1]):
+                    bn = int(bs)
+                    n_block_id = bid
+                elif bk is None and env.known_equal(size, lhs_fake.shape[1]):
+                    bk = int(bs)
+        if bm is None or bn is None or bk is None:
             continue
-        bm = cg.device_function.resolved_block_size(analysis.m_block_id)
-        bn = cg.device_function.resolved_block_size(analysis.n_block_id)
-        bk = k_loop_info[3]
-        if not isinstance(bm, int) or not isinstance(bn, int):
-            continue
+        rhs_rank3_segment_lhs_info: _Rank3RhsSegmentLhsInfo | None = None
+        if rhs_info.rhs_rank3_grouped_nt:
+            if m_block_id is None or n_block_id is None or k_block_id is None:
+                continue
+            if device_loop is None:
+                continue
+            if _tcgen05_cluster_m(cg.device_function.config) != 1:
+                continue
+            canonical_block_id = env.canonical_block_id
+            segment_block_id = None
+            if rhs_info.rhs_segment_group is not None:
+                segment_block_ids = [
+                    bid
+                    for bid in grid_state.block_ids
+                    if canonical_block_id(bid)
+                    not in (
+                        canonical_block_id(m_block_id),
+                        canonical_block_id(n_block_id),
+                    )
+                ]
+                if len(segment_block_ids) != 1:
+                    continue
+                segment_block_id = segment_block_ids[0]
+                if cg.device_function.resolved_block_size(segment_block_id) != 1:
+                    continue
+            proof = _prove_rank3_rhs_grouped_mma(
+                cg,
+                node,
+                config=cg.device_function.config,
+                axes=_GroupedMmaAxes(
+                    m_block_id=m_block_id,
+                    n_block_id=n_block_id,
+                    k_block_id=k_block_id,
+                    segment_block_id=segment_block_id,
+                ),
+            )
+            if proof is None:
+                continue
+            lhs_info = proof.lhs
+            rhs_info = proof.rhs
+            lhs_fake = lhs_info.logical_fake
+            rhs_fake = rhs_info.logical_fake
+            rhs_rank3_segment_lhs_info = proof.segment_lhs
+            if not proof.is_worklist:
+                if (
+                    lhs_fake.shape[0] % bm != 0
+                    or rhs_fake.shape[1] % bn != 0
+                    or lhs_fake.shape[1] % bk != 0
+                ):
+                    continue
+                m_offset_var = grid_state.strategy.offset_var(m_block_id)
+                if (
+                    _rank3_rhs_safe_group_scalar_rewrite_plan(
+                        cg,
+                        rhs_info,
+                        m_offset_var=m_offset_var,
+                    )
+                    is None
+                ):
+                    continue
         if (
             _choose_mma_impl(
                 lhs_fake.dtype,
@@ -1254,16 +3236,7 @@ def prepare_cute_collective_lane_loop_suppression(
             != "tcgen05"
         ):
             continue
-        if analysis.has_leading_passthrough and not _mma_tiles_are_static_full(
-            analysis, bm=bm, bn=bn, bk=bk
-        ):
-            continue
-        if (
-            len(lhs_load.users) != 1
-            or len(rhs_load.users) != 1
-            or next(iter(lhs_load.users)) is not node
-            or next(iter(rhs_load.users)) is not node
-        ):
+        if not _operand_infos_exclusive_for_mma(lhs_info, rhs_info, node):
             continue
 
         # Mirror the real codegen bailout in ``_emit_mma_pipeline`` (it returns
@@ -1273,20 +3246,26 @@ def prepare_cute_collective_lane_loop_suppression(
         # takes the scalar fallback, requesting root lane-loop suppression would
         # drop the synthetic-lane index/mask definitions for the grid axis and
         # produce a ``NameError`` at runtime. Only register the loads / request
-        # suppression when the collective path will truly be taken. The K
-        # device-loop's lane loops are only tolerated for a *batched* matmul (it
-        # must exactly match the ``_emit_mma_pipeline`` guard); a non-batched
-        # config with device-loop lane loops takes the scalar fallback.
-        allowed_k_lane_loops: tuple[DeviceLoopState, ...] = (
-            (k_loop_info[0],)
-            if analysis.leading_passthrough_block_id is not None
-            else ()
-        )
-        if _has_non_root_lane_loops(cg, allowed_loop_states=allowed_k_lane_loops):
+        # suppression when the collective path will truly be taken.
+        allowed_loop_states = () if device_loop is None else (device_loop,)
+        if _has_non_root_lane_loops(cg, allowed_loop_states=allowed_loop_states):
             continue
 
         cute_state = cg.device_function.cute_state
-        _register_collective_handled_loads(cute_state, lhs_load, rhs_load)
+        _register_collective_handled_loads(
+            cute_state,
+            lhs_info.load,
+            rhs_info.load,
+            extra_dependency_nodes=(
+                *lhs_info.collective_dependency_nodes,
+                *rhs_info.collective_dependency_nodes,
+                *(
+                    ()
+                    if rhs_rank3_segment_lhs_info is None
+                    else rhs_rank3_segment_lhs_info.dependency_nodes
+                ),
+            ),
+        )
         if grid_state.has_lane_loops():
             cute_state.request_root_lane_loop_suppression()
 
@@ -1344,6 +3323,8 @@ class _PerKiterTmaArgs:
     # full-tile branch and scalar fallback. Non-pipelined/asymmetric or two-CTA
     # TMA paths must keep the guarded fallback path.
     static_full_tiles: bool = False
+    tma_desc_ptr_a: str | None = None
+    tma_desc_ptr_b: str | None = None
 
 
 def _kloop_tma_copy_a_src(args: _PerKiterTmaArgs, *, k_offset: str) -> str:
@@ -1355,11 +3336,12 @@ def _kloop_tma_copy_a_src(args: _PerKiterTmaArgs, *, k_offset: str) -> str:
     if not args.use_tma_a:
         return ""
     mcast = f", mcast_mask={args.tma_a_mcast_mask}" if args.is_two_cta else ""
+    desc = f", tma_desc_ptr={args.tma_desc_ptr_a}" if args.tma_desc_ptr_a else ""
     return (
         f"    cute.copy({args.tma_atom_a}, "
         f"{args.tma_gA}[None, {k_offset}], "
         f"{args.tma_sA}[None, {args.tma_producer_state}.index], "
-        f"tma_bar_ptr={args.tma_barrier_ptr}{mcast})\n"
+        f"tma_bar_ptr={args.tma_barrier_ptr}{mcast}{desc})\n"
     )
 
 
@@ -1367,17 +3349,18 @@ def _kloop_tma_copy_b_src(args: _PerKiterTmaArgs, *, k_offset: str) -> str:
     """Per-K-iter TMA copy source for B; ``""`` when B is not TMA-loaded.
 
     Callers pass a mask whenever the B TMA atom is multicast. The guarded
-    clustered CtaGroup.ONE bridge diagnostic uses a self-only mask so each CTA
-    duplicates local-B loads while satisfying CuTe's multicast-atom contract.
+    clustered CtaGroup.ONE bridge uses a self-only mask so each CTA duplicates
+    local-B loads while satisfying CuTe's multicast-atom contract.
     """
     if not args.use_tma_b:
         return ""
     mcast = f", mcast_mask={args.tma_b_mcast_mask}" if args.use_tma_b_mcast_mask else ""
+    desc = f", tma_desc_ptr={args.tma_desc_ptr_b}" if args.tma_desc_ptr_b else ""
     return (
         f"    cute.copy({args.tma_atom_b}, "
         f"{args.tma_gB}[None, {k_offset}], "
         f"{args.tma_sB}[None, {args.tma_producer_state}.index], "
-        f"tma_bar_ptr={args.tma_barrier_ptr}{mcast})\n"
+        f"tma_bar_ptr={args.tma_barrier_ptr}{mcast}{desc})\n"
     )
 
 
@@ -1420,7 +3403,10 @@ def _tcgen05_emit_optional_gate(src: str, predicate: str | None, *, indent: str)
 
 
 def _build_kloop_pipeline_producer_if(
-    args: _PerKiterTmaArgs, *, gate_tma_warp: bool = True
+    args: _PerKiterTmaArgs,
+    *,
+    gate_tma_warp: bool = True,
+    load_current_tile: bool = False,
 ) -> ast.stmt:
     """Per-K-iter TMA producer ``if`` for the pipelined branch.
 
@@ -1428,6 +3414,9 @@ def _build_kloop_pipeline_producer_if(
     loaded (``tcgen05_use_tma_pipeline = use_tma_a and use_tma_b``), so
     both ``cute.copy`` emissions must be present; assert that invariant
     rather than silently dropping a side.
+
+    Role-local grouped producers load the current tile because their loop
+    starts at tile 0; other producers issue lookahead copies after warmup.
     """
     assert args.use_tma_a and args.use_tma_b, (
         "pipelined branch requires both A and B to be TMA-loaded"
@@ -1435,13 +3424,22 @@ def _build_kloop_pipeline_producer_if(
     assert not (args.static_full_tiles and args.is_two_cta), (
         "static-full fast path is only valid for one-CTA pipelined TMA loops"
     )
-    k_offset = f"{args.tma_k_tile} + cutlass.Int32({args.ab_stage_count})"
+    if load_current_tile:
+        assert not args.static_full_tiles, (
+            "current-tile producer is only used by role-local pipelined TMA loops"
+        )
+    k_offset = (
+        args.tma_k_tile
+        if load_current_tile
+        else f"{args.tma_k_tile} + cutlass.Int32({args.ab_stage_count})"
+    )
     predicate_terms = []
     if not args.static_full_tiles:
         predicate_terms.append(args.tma_full_tile)
     if gate_tma_warp:
         predicate_terms.append(args.tma_warp)
-    predicate_terms.append(args.tma_next_full_tile)
+    if not load_current_tile:
+        predicate_terms.append(args.tma_next_full_tile)
     copy_src = _kloop_tma_copy_a_src(args, k_offset=k_offset) + _kloop_tma_copy_b_src(
         args, k_offset=k_offset
     )
@@ -1744,7 +3742,7 @@ def _build_kloop_non_pipeline_release_if(args: _PerKiterTmaArgs) -> ast.stmt:
     CTA-wide ``sync_threads()`` runs first so every warp sees the
     consumer wait completed; single-stage means both producer and
     consumer state normally advance here. The producer advance is omitted
-    only by the guarded invalid-output bridge diagnostic.
+    only when config explicitly requests skipping that edge.
     """
     assert not args.static_full_tiles, (
         "static-full fast path is only valid for pipelined all-TMA K loops"
@@ -1800,6 +3798,8 @@ class _InitialPrefetchTmaArgs:
     use_tma_b_mcast_mask: bool
     skip_producer_acquire: bool
     skip_producer_advance: bool
+    tma_desc_ptr_a: str | None = None
+    tma_desc_ptr_b: str | None = None
 
 
 def _initial_prefetch_copy_a_src(
@@ -1813,11 +3813,12 @@ def _initial_prefetch_copy_a_src(
     builders.
     """
     mcast = f", mcast_mask={args.tma_a_mcast_mask}" if args.is_two_cta else ""
+    desc = f", tma_desc_ptr={args.tma_desc_ptr_a}" if args.tma_desc_ptr_a else ""
     return (
         f"    cute.copy({args.tma_atom_a}, "
         f"{args.tma_gA}[None, {k_offset}], "
         f"{args.tma_sA}[None, {args.tma_producer_state}.index], "
-        f"tma_bar_ptr={args.tma_barrier_ptr}{mcast})\n"
+        f"tma_bar_ptr={args.tma_barrier_ptr}{mcast}{desc})\n"
     )
 
 
@@ -1827,15 +3828,16 @@ def _initial_prefetch_copy_b_src(
     """Initial-prefetch TMA copy source for B.
 
     Callers pass a mask whenever the B TMA atom is multicast. The guarded
-    clustered CtaGroup.ONE bridge diagnostic uses a self-only mask so each CTA
-    duplicates local-B loads while satisfying CuTe's multicast-atom contract.
+    clustered CtaGroup.ONE bridge uses a self-only mask so each CTA duplicates
+    local-B loads while satisfying CuTe's multicast-atom contract.
     """
     mcast = f", mcast_mask={args.tma_b_mcast_mask}" if args.use_tma_b_mcast_mask else ""
+    desc = f", tma_desc_ptr={args.tma_desc_ptr_b}" if args.tma_desc_ptr_b else ""
     return (
         f"    cute.copy({args.tma_atom_b}, "
         f"{args.tma_gB}[None, {k_offset}], "
         f"{args.tma_sB}[None, {args.tma_producer_state}.index], "
-        f"tma_bar_ptr={args.tma_barrier_ptr}{mcast})\n"
+        f"tma_bar_ptr={args.tma_barrier_ptr}{mcast}{desc})\n"
     )
 
 
@@ -1845,20 +3847,23 @@ def _build_initial_prefetch_if(
     full_tile_gates: list[str],
     k_offset: str,
     skip_producer_acquire: bool | None = None,
+    gate_tma_warp: bool = True,
 ) -> ast.stmt:
     """Initial-prefetch ``if`` block for stage ``k_offset``.
 
-    The predicate is ``<full_tile_gates joined with ' and '> and
-    {args.tma_warp}``: stage-0 callers pass
+    The predicate is ``<full_tile_gates joined with ' and '>`` plus
+    ``{args.tma_warp}`` when ``gate_tma_warp`` is true: stage-0 callers pass
     ``[tma_initial_full_tile]``; stage-(N-1) callers (only when
-    ``ab_stage_count > 1``) extend with ``tma_initial_next_full_tile``.
-    The body performs optional ``producer_acquire``, then
-    ``get_barrier / copy A / copy B / producer_commit`` and optional
-    producer-state ``advance``. The optional edges are omitted only by
-    guarded invalid-output bridge diagnostics. Caller passes a literal
-    ``cutlass.Int32(stage_idx)`` for ``k_offset``.
+    ``ab_stage_count > 1``) extend with ``tma_initial_next_full_tile``. The body
+    performs optional ``producer_acquire``, then ``get_barrier / copy A / copy B
+    / producer_commit`` and optional producer-state ``advance``. Optional edges
+    are omitted only when config explicitly requests skipping them. Caller
+    passes a literal ``cutlass.Int32(stage_idx)`` for ``k_offset``.
     """
-    predicate = " and ".join([*full_tile_gates, args.tma_warp])
+    predicate_terms = [*full_tile_gates]
+    if gate_tma_warp:
+        predicate_terms.append(args.tma_warp)
+    predicate = " and ".join(predicate_terms)
     if skip_producer_acquire is None:
         skip_producer_acquire = args.skip_producer_acquire
     producer_advance_src = (
@@ -1934,6 +3939,16 @@ def _tcgen05_k_loop_nounroll_iter_expr(device_loop: DeviceLoopState) -> ast.expr
     return iter_expr
 
 
+def _tcgen05_grouped_k_loop_iter_expr(*, problem_k: str, bk: int) -> ast.expr:
+    return cast(
+        "ast.expr",
+        expr_from_string(
+            f"cutlass.range(cutlass.Int32(0), {problem_k}, "
+            f"cutlass.Int32({bk}), unroll=1)"
+        ),
+    )
+
+
 def _wrap_stmt_in_if(stmt: ast.stmt, predicate_src: str) -> ast.If:
     return ast.copy_location(
         ast.If(
@@ -1988,7 +4003,8 @@ def _trace_mma_to_stores(
                 output_args = user.args[0] if user.args else None
                 if not isinstance(output_args, (list, tuple)):
                     return None
-                out_indices = [i for i, arg in enumerate(output_args) if arg is cur]
+                output_args_seq = cast("list[object] | tuple[object, ...]", output_args)
+                out_indices = [i for i, arg in enumerate(output_args_seq) if arg is cur]
                 if not out_indices:
                     return None
                 for outer_call in for_loop_calls_by_graph_id.get(graph_id, []):
@@ -2081,11 +4097,107 @@ def _analyze_mma_output_stores(
     )
 
 
+def _rank3_rhs_segment_store_info(
+    cg: GenerateAST,
+    mma_node: Node,
+    segment_lhs_info: _Rank3RhsSegmentLhsInfo,
+    segment_group: _Rank3RhsSegmentGroupInfo | None = None,
+    *,
+    allow_store_extent_metadata: bool = False,
+) -> _Rank3RhsSegmentStoreInfo | None:
+    import operator
+
+    from ...language import memory_ops
+
+    stores = _trace_mma_to_stores(mma_node, cg.codegen_graphs)
+    if stores is None or len(stores) != 1:
+        return None
+    store_node = stores[0]
+    if (
+        store_node.op != "call_function"
+        or store_node.target is not memory_ops.store
+        or len(store_node.args) < 4
+    ):
+        return None
+    index = store_node.args[1]
+    extra_mask = store_node.args[3]
+    if (
+        not isinstance(index, list | tuple)
+        or len(index) != 2
+        or not isinstance(index[0], Node)
+        or not isinstance(extra_mask, Node)
+    ):
+        return None
+    store_row = _trace_to_outer_graph_arg(cg, index[0])
+    if store_row is not segment_lhs_info.row_index:
+        return None
+    store_mask = _trace_to_outer_graph_arg(cg, extra_mask)
+    store_valid_m = _rank3_rhs_broadcast_mask_base(store_mask, broadcast_dim=1)
+    if store_valid_m is None:
+        return None
+    store_valid_m = _trace_to_outer_graph_arg(cg, store_valid_m)
+    store_extent_load = segment_lhs_info.actual_m_load
+    uses_store_extent_metadata = False
+    if store_valid_m is not segment_lhs_info.valid_m:
+        if not allow_store_extent_metadata or segment_group is None:
+            return None
+        if (
+            store_valid_m.op != "call_function"
+            or store_valid_m.target not in (operator.lt, torch.ops.aten.lt.Tensor)
+            or len(store_valid_m.args) != 2
+            or not all(isinstance(arg, Node) for arg in store_valid_m.args)
+        ):
+            return None
+        store_lhs, store_rhs = cast("tuple[Node, Node]", store_valid_m.args)
+        if (
+            segment_lhs_info.valid_m.op != "call_function"
+            or segment_lhs_info.valid_m.target
+            not in (operator.lt, torch.ops.aten.lt.Tensor)
+            or len(segment_lhs_info.valid_m.args) != 2
+            or not all(isinstance(arg, Node) for arg in segment_lhs_info.valid_m.args)
+        ):
+            return None
+        load_lhs, _load_rhs = cast("tuple[Node, Node]", segment_lhs_info.valid_m.args)
+        if _trace_to_outer_graph_arg(cg, store_lhs) is not _trace_to_outer_graph_arg(
+            cg, load_lhs
+        ):
+            return None
+        loaded_store_extent = _rank3_rhs_segment_metadata_load(
+            cg,
+            store_rhs,
+            column=3,
+            expected_tensor=segment_group.metadata_tensor,
+            expected_segment_id=segment_group.segment_id,
+        )
+        if loaded_store_extent is None:
+            return None
+        _metadata, _segment_id, store_extent_load = loaded_store_extent
+        uses_store_extent_metadata = True
+    return _Rank3RhsSegmentStoreInfo(
+        store_node=store_node,
+        row_index=store_row,
+        valid_m=store_valid_m,
+        extent_load=store_extent_load,
+        uses_store_extent_metadata=uses_store_extent_metadata,
+    )
+
+
+def _requested_tcgen05_grouped_schedule(
+    grouped_mode: str | None,
+) -> Tcgen05Orientation | None:
+    if grouped_mode != TCGEN05_GROUPED_MODE_WORKLIST_NM:
+        return None
+    return Tcgen05Orientation.NM
+
+
 def _emit_mma_pipeline(
     cg: GenerateAST,
-    candidate: _CuteMmaNode,
+    mma: _CuteMmaNode | Node,
+    rhs_node: Node | None = None,
     acc_expr: ast.AST | None = None,
     fx_node: Node | None = None,
+    lowering_ctx: LoweringContext | None = None,
+    grouped_mode: str | None = None,
 ) -> ast.AST | None:
     """Core MMA codegen shared by both aten and hl.dot paths.
 
@@ -2096,22 +4208,289 @@ def _emit_mma_pipeline(
     """
     from ..compile_environment import CompileEnvironment
 
+    candidate = mma if isinstance(mma, _CuteMmaNode) else None
+    lhs_node = candidate.lhs if candidate is not None else mma
+    rhs_node = candidate.rhs if candidate is not None else rhs_node
+    if not isinstance(lhs_node, Node) or not isinstance(rhs_node, Node):
+        return None
+
     env = CompileEnvironment.current()
-    analysis = candidate.operands
-    lhs_operand = analysis.lhs
-    rhs_operand = analysis.rhs
-    lhs_load = lhs_operand.load
-    rhs_load = rhs_operand.load
-    lhs_fake = lhs_operand.source_fake
-    rhs_fake = rhs_operand.source_fake
+    requested_schedule = _requested_tcgen05_grouped_schedule(grouped_mode)
+
+    def _unsupported_schedule(reason: str) -> None:
+        if requested_schedule is not None:
+            raise exc.BackendUnsupported(
+                "cute",
+                f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}="
+                f"{TCGEN05_GROUPED_MODE_WORKLIST_NM!r} requires the "
+                "generated N,M-oriented worklist tcgen05 schedule; " + reason,
+            )
+        return None
+
+    def _static_int(value: object) -> int | None:
+        with contextlib.suppress(TypeError, ValueError):
+            return int(cast("Any", value))
+        return None
+
+    def _is_contiguous_mk_source_fake(source_fake: torch.Tensor) -> bool:
+        if source_fake.ndim != 2:
+            return False
+        source_k = _static_int(source_fake.shape[1])
+        stride_m = _static_int(source_fake.stride(0))
+        return (
+            source_k is not None
+            and stride_m is not None
+            and _static_int(source_fake.stride(1)) == 1
+            and stride_m == source_k
+        )
+
+    def _is_contiguous_gnk_source_fake(source_fake: torch.Tensor) -> bool:
+        if source_fake.ndim != 3:
+            return False
+        source_n = _static_int(source_fake.shape[1])
+        source_k = _static_int(source_fake.shape[2])
+        stride_g = _static_int(source_fake.stride(0))
+        stride_n = _static_int(source_fake.stride(1))
+        return (
+            source_n is not None
+            and source_k is not None
+            and stride_g is not None
+            and stride_n is not None
+            and _static_int(source_fake.stride(2)) == 1
+            and stride_n == source_k
+            and stride_g == source_n * source_k
+        )
+
+    def _runtime_int_tensor_values(
+        arg_name: str,
+        *,
+        expected_numel: int,
+    ) -> list[int] | None:
+        value = CompileEnvironment.current().runtime_arg_values_by_name.get(arg_name)
+        if not (
+            isinstance(value, torch.Tensor)
+            and value.ndim == 1
+            and int(value.numel()) == expected_numel
+            and value.dtype in (torch.int32, torch.int64)
+        ):
+            return None
+        with unset_fake_temporarily():
+            return [int(item) for item in value.detach().cpu().tolist()]
+
+    def _runtime_ordered_group_m_tail(
+        layout_arg_name: str,
+        *,
+        group_count: int,
+        bm: int,
+        m_tail_preserve: bool,
+    ) -> bool | None:
+        layout_value = CompileEnvironment.current().runtime_arg_values_by_name.get(
+            layout_arg_name
+        )
+        if not (
+            isinstance(layout_value, torch.Tensor)
+            and layout_value.ndim == 1
+            and layout_value.dtype in (torch.int32, torch.int64)
+        ):
+            return None
+        with unset_fake_temporarily():
+            layout_values = [int(item) for item in layout_value.detach().cpu().tolist()]
+        cursor = 0
+        has_m_tail = False
+        for expected_group in range(group_count):
+            if m_tail_preserve and expected_group > 0:
+                next_m_boundary = ((cursor + bm - 1) // bm) * bm
+                while (
+                    cursor < len(layout_values)
+                    and cursor < next_m_boundary
+                    and layout_values[cursor] < 0
+                ):
+                    cursor += 1
+                if cursor != next_m_boundary or (
+                    cursor < len(layout_values) and layout_values[cursor] < 0
+                ):
+                    return None
+            if cursor >= len(layout_values) or layout_values[cursor] != expected_group:
+                return None
+            start = cursor
+            while (
+                cursor < len(layout_values) and layout_values[cursor] == expected_group
+            ):
+                cursor += 1
+            actual_m = cursor - start
+            if start % bm != 0:
+                return None
+            has_m_tail = has_m_tail or actual_m % bm != 0
+        if cursor != len(layout_values):
+            if m_tail_preserve and all(value < 0 for value in layout_values[cursor:]):
+                cursor = len(layout_values)
+        if cursor != len(layout_values):
+            return None
+        return has_m_tail
+
+    def _runtime_grouped_static_tail_facts(
+        *,
+        layout_arg_name: str,
+        n_sizes_arg_name: str | None,
+        group_count: int,
+        bm: int,
+        bn: int,
+        n_size: int,
+        m_tail_preserve: bool,
+    ) -> tuple[bool, bool] | None:
+        n_sizes_values = (
+            _runtime_int_tensor_values(
+                n_sizes_arg_name,
+                expected_numel=group_count,
+            )
+            if n_sizes_arg_name is not None
+            else [n_size] * group_count
+        )
+        if n_sizes_values is None or any(
+            group_n <= 0 or group_n > n_size for group_n in n_sizes_values
+        ):
+            return None
+        has_m_tail = _runtime_ordered_group_m_tail(
+            layout_arg_name,
+            group_count=group_count,
+            bm=bm,
+            m_tail_preserve=m_tail_preserve,
+        )
+        if has_m_tail is None:
+            return None
+        has_n_tail = any(group_n % bn != 0 for group_n in n_sizes_values)
+        return has_m_tail, has_n_tail
+
+    tcgen05_grouped_static_persistent_requested = grouped_mode is not None
+    tcgen05_grouped_dynamic_ab_tensormaps_requested = grouped_mode in (
+        TCGEN05_GROUPED_MODE_DYNAMIC,
+        TCGEN05_GROUPED_MODE_DIRECT,
+        TCGEN05_GROUPED_MODE_WORKLIST_NM,
+    )
+    tcgen05_grouped_direct_pointer_metadata_requested = (
+        grouped_mode == TCGEN05_GROUPED_MODE_DIRECT
+    )
+    allow_grouped_k_mask = tcgen05_grouped_static_persistent_requested
+    analysis = candidate.operands if candidate is not None else None
+    if analysis is None:
+        lhs_info = _trace_to_mma_operand(
+            lhs_node,
+            role="lhs",
+            cg=cg,
+            allow_grouped_k_mask=allow_grouped_k_mask,
+        )
+        rhs_info = _trace_to_mma_operand(
+            rhs_node,
+            role="rhs",
+            allow_rank3_rhs_nt=lowering_ctx is not None,
+            cg=cg,
+            allow_grouped_k_mask=allow_grouped_k_mask,
+        )
+        if lhs_info is None or rhs_info is None:
+            return _unsupported_schedule("MMA operand tracing failed")
+    else:
+        lhs_info = analysis.lhs
+        rhs_info = analysis.rhs
+    lhs_fake = lhs_info.logical_fake
+    rhs_fake = rhs_info.logical_fake
+    if analysis is None and (lhs_fake.ndim != 2 or rhs_fake.ndim != 2):
+        return _unsupported_schedule("MMA operands are not rank-2")
+    rhs_rank3_group_expr: str | None = None
+    rhs_rank3_group_index: Node | None = None
+    rhs_rank3_segment_metadata = rhs_info.rhs_segment_group is not None
+    rhs_rank3_segment_lhs_info: _Rank3RhsSegmentLhsInfo | None = None
+    rhs_rank3_segment_store_info: _Rank3RhsSegmentStoreInfo | None = None
+    rhs_rank3_grouped_proof: _Rank3RhsGroupedProof | None = None
+    tcgen05_grouped_external_direct_pointers_name = cg.device_function.config.get(
+        TCGEN05_GROUPED_EXTERNAL_DIRECT_POINTERS_CONFIG_KEY
+    )
+    tcgen05_grouped_external_direct_strides_name = cg.device_function.config.get(
+        TCGEN05_GROUPED_EXTERNAL_DIRECT_STRIDES_CONFIG_KEY
+    )
+    tcgen05_grouped_external_direct_pointers_arg_name: str | None = None
+    tcgen05_grouped_external_direct_strides_arg_name: str | None = None
+    tcgen05_grouped_static_reserved_sms = int(
+        cast(
+            "Any",
+            cg.device_function.config.get(
+                TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
+                0,
+            ),
+        )
+    )
+    tcgen05_use_grouped_static_single_tma_producer_loop = False
+    if requested_schedule is not None and not (
+        tcgen05_grouped_static_persistent_requested
+        and tcgen05_grouped_dynamic_ab_tensormaps_requested
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}="
+            f"{TCGEN05_GROUPED_MODE_WORKLIST_NM!r} requires the grouped "
+            "worklist path with dynamic A/B TensorMaps",
+        )
+    if (tcgen05_grouped_external_direct_pointers_name is None) != (
+        tcgen05_grouped_external_direct_strides_name is None
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            "external grouped direct pointer metadata requires both pointer "
+            "and stride tensor argument names",
+        )
+    if tcgen05_grouped_external_direct_pointers_name is not None:
+        if not tcgen05_grouped_direct_pointer_metadata_requested:
+            raise exc.BackendUnsupported(
+                "cute",
+                "external grouped direct pointer metadata requires "
+                f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}="
+                f"{TCGEN05_GROUPED_MODE_DIRECT!r}",
+            )
+        if not isinstance(tcgen05_grouped_external_direct_pointers_name, str):
+            raise exc.BackendUnsupported(
+                "cute",
+                "external grouped direct pointer metadata pointer argument "
+                "name must be a string",
+            )
+        if not isinstance(tcgen05_grouped_external_direct_strides_name, str):
+            raise exc.BackendUnsupported(
+                "cute",
+                "external grouped direct pointer metadata stride argument "
+                "name must be a string",
+            )
+        tcgen05_grouped_external_direct_pointers_arg_name = (
+            tcgen05_grouped_external_direct_pointers_name
+        )
+        tcgen05_grouped_external_direct_strides_arg_name = (
+            tcgen05_grouped_external_direct_strides_name
+        )
+    if rhs_info.rhs_rank3_grouped_nt:
+        if lowering_ctx is None or rhs_info.rhs_group_index is None:
+            return _unsupported_schedule(
+                "rank3 grouped RHS did not expose a lowering group index"
+            )
+        rhs_rank3_group_index = rhs_info.rhs_group_index
+        rhs_rank3_group_expr = (
+            rhs_info.rhs_segment_group.group_load.name
+            if rhs_info.rhs_segment_group is not None
+            else rhs_info.rhs_group_index.name
+        )
+
+    # Universal-MMA / tcgen05 MMA kernels rely on runtime tensor layouts
+    # for SMEM-load guards and TMA descriptors; baking literal shapes
+    # silently miscompiles those paths.  Mirror the flag set in
+    # ``_emit_cute_matmul`` so the host-side launcher disables the bake.
+    if analysis is None:
+        cg.cute_uses_matmul = True
+    lhs_operand = lhs_info
+    rhs_operand = rhs_info
     lhs_m_size = lhs_operand.matrix_rows
     lhs_k_size = lhs_operand.matrix_cols
     rhs_k_size = rhs_operand.matrix_rows
     rhs_n_size = rhs_operand.matrix_cols
 
     df = cg.device_function
-    lhs_arg = df.tensor_arg(lhs_fake)
-    rhs_arg = df.tensor_arg(rhs_fake)
+    lhs_arg = df.tensor_arg(lhs_info.source_fake)
+    rhs_arg = df.tensor_arg(rhs_info.source_fake)
     lhs_arg_name = lhs_arg.name
     rhs_arg_name = rhs_arg.name
 
@@ -2165,6 +4544,14 @@ def _emit_mma_pipeline(
     tcgen05_b_k_major = _rhs_major == "col"
     tcgen05_use_tma = tcgen05_use_tma_a or tcgen05_use_tma_b
     tcgen05_use_tma_pipeline = tcgen05_use_tma_a and tcgen05_use_tma_b
+    if rhs_rank3_segment_metadata and not (
+        tcgen05_grouped_static_persistent_requested
+        and tcgen05_grouped_dynamic_ab_tensormaps_requested
+    ):
+        tcgen05_use_tma_a = False
+        tcgen05_use_tma_b = False
+        tcgen05_use_tma = False
+        tcgen05_use_tma_pipeline = False
     tcgen05_requested_pure_matmul_role_lifecycle = is_pure_matmul_role_lifecycle_config(
         df.config
     )
@@ -2181,10 +4568,14 @@ def _emit_mma_pipeline(
         rhs_k_size=rhs_k_size,
     )
     if k_loop_info is None:
-        return None
+        return _unsupported_schedule("K loop analysis failed")
     device_loop, k_block_id, k_offset_var, bk = k_loop_info
-    if k_block_id != analysis.k_block_id:
+    if analysis is not None and k_block_id != analysis.k_block_id:
         return None
+    if analysis is None and _has_non_root_lane_loops(
+        cg, allowed_loop_states=(device_loop,)
+    ):
+        return _unsupported_schedule("unexpected nested lane loops")
     k_loop_begin_expr = _device_loop_begin_expr(device_loop)
 
     # Get M, N offsets and block sizes from grid state
@@ -2195,18 +4586,85 @@ def _emit_mma_pipeline(
     bm: int | None = None
     bn: int | None = None
     grid_state = cg.current_grid_state
-    if (
-        grid_state is not None
-        and tuple(grid_state.block_ids) == analysis.output_block_ids
-    ):
-        m_block_id = analysis.m_block_id
-        n_block_id = analysis.n_block_id
-        m_offset_var = grid_state.strategy.offset_var(m_block_id)
-        n_offset_var = grid_state.strategy.offset_var(n_block_id)
-        m_bs = df.resolved_block_size(m_block_id)
-        n_bs = df.resolved_block_size(n_block_id)
-        bm = int(m_bs) if isinstance(m_bs, int) else None
-        bn = int(n_bs) if isinstance(n_bs, int) else None
+    if analysis is not None:
+        if (
+            grid_state is not None
+            and tuple(grid_state.block_ids) == analysis.output_block_ids
+        ):
+            m_block_id = analysis.m_block_id
+            n_block_id = analysis.n_block_id
+            m_offset_var = grid_state.strategy.offset_var(m_block_id)
+            n_offset_var = grid_state.strategy.offset_var(n_block_id)
+            m_bs = df.resolved_block_size(m_block_id)
+            n_bs = df.resolved_block_size(n_block_id)
+            bm = int(m_bs) if isinstance(m_bs, int) else None
+            bn = int(n_bs) if isinstance(n_bs, int) else None
+    elif grid_state is not None:
+        if len(grid_state.block_ids) == 2:
+            m_block_id, n_block_id = grid_state.block_ids
+            m_offset_var = grid_state.strategy.offset_var(m_block_id)
+            n_offset_var = grid_state.strategy.offset_var(n_block_id)
+            m_bs = df.resolved_block_size(m_block_id)
+            n_bs = df.resolved_block_size(n_block_id)
+            bm = int(m_bs) if isinstance(m_bs, int) else None
+            bn = int(n_bs) if isinstance(n_bs, int) else None
+        else:
+            canonical_block_id = env.canonical_block_id
+            if (
+                rhs_rank3_segment_metadata
+                and rhs_info.rhs_segment_group is not None
+                and rhs_info.rhs_n_block_id is not None
+            ):
+                # Segment metadata already proves the work axis and RHS proves N;
+                # the remaining root axis is M, with exact LHS/store proof below.
+                segment_block_id = rhs_info.rhs_segment_group.segment_block_id
+                segment_canonical = canonical_block_id(segment_block_id)
+                n_canonical = canonical_block_id(rhs_info.rhs_n_block_id)
+                m_candidates = [
+                    bid
+                    for bid in grid_state.block_ids
+                    if canonical_block_id(bid)
+                    not in (
+                        segment_canonical,
+                        n_canonical,
+                    )
+                ]
+                if len(m_candidates) == 1:
+                    m_block_id = m_candidates[0]
+                    n_block_id = next(
+                        (
+                            bid
+                            for bid in grid_state.block_ids
+                            if canonical_block_id(bid) == n_canonical
+                        ),
+                        None,
+                    )
+                    if n_block_id is not None:
+                        m_offset_var = grid_state.strategy.offset_var(m_block_id)
+                        n_offset_var = grid_state.strategy.offset_var(n_block_id)
+                        m_bs = env.block_sizes[m_block_id].from_config(df.config)
+                        n_bs = env.block_sizes[n_block_id].from_config(df.config)
+                        bm = int(m_bs) if isinstance(m_bs, int) else None
+                        bn = int(n_bs) if isinstance(n_bs, int) else None
+            if m_block_id is None or n_block_id is None:
+                for bid in grid_state.block_ids:
+                    offset = grid_state.strategy.offset_var(bid)
+                    bs_info = env.block_sizes[bid]
+                    size = bs_info.size
+                    bs = bs_info.from_config(df.config)
+                    if isinstance(size, (int, torch.SymInt)):
+                        if m_offset_var is None and env.known_equal(
+                            size, lhs_fake.shape[0]
+                        ):
+                            m_offset_var = offset
+                            m_block_id = bid
+                            bm = int(bs) if isinstance(bs, int) else None
+                        elif n_offset_var is None and env.known_equal(
+                            size, rhs_fake.shape[1]
+                        ):
+                            n_offset_var = offset
+                            n_block_id = bid
+                            bn = int(bs) if isinstance(bs, int) else None
 
     if (
         bm is None
@@ -2216,7 +4674,64 @@ def _emit_mma_pipeline(
         or m_block_id is None
         or n_block_id is None
     ):
-        return None
+        return _unsupported_schedule("M/N tile axes were not resolved")
+    if rhs_info.rhs_rank3_grouped_nt:
+        if fx_node is None:
+            return _unsupported_schedule("MMA fx node was unavailable")
+        canonical_block_id = env.canonical_block_id
+        rhs_rank3_segment_metadata = rhs_info.rhs_segment_group is not None
+        segment_block_id = None
+        if rhs_rank3_segment_metadata:
+            assert grid_state is not None
+            segment_block_ids = [
+                bid
+                for bid in grid_state.block_ids
+                if canonical_block_id(bid)
+                not in (
+                    canonical_block_id(m_block_id),
+                    canonical_block_id(n_block_id),
+                )
+            ]
+            if len(segment_block_ids) != 1:
+                return _unsupported_schedule(
+                    "segment metadata work axis was not unique"
+                )
+            segment_block_id = segment_block_ids[0]
+            if df.resolved_block_size(segment_block_id) != 1:
+                return _unsupported_schedule(
+                    "segment metadata work axis block size was not 1"
+                )
+        rhs_rank3_grouped_proof = _prove_rank3_rhs_grouped_mma(
+            cg,
+            fx_node,
+            config=df.config,
+            axes=_GroupedMmaAxes(
+                m_block_id=m_block_id,
+                n_block_id=n_block_id,
+                k_block_id=k_block_id,
+                segment_block_id=segment_block_id,
+            ),
+        )
+        if rhs_rank3_grouped_proof is None:
+            return _unsupported_schedule("rank3 grouped semantic proof failed")
+        lhs_info = rhs_rank3_grouped_proof.lhs
+        rhs_info = rhs_rank3_grouped_proof.rhs
+        rhs_fake = rhs_info.logical_fake
+        rhs_rank3_segment_lhs_info = rhs_rank3_grouped_proof.segment_lhs
+        rhs_rank3_segment_store_info = rhs_rank3_grouped_proof.segment_store
+        if rhs_info.rhs_group_index is None:
+            return _unsupported_schedule("rank3 RHS group index was missing")
+        rhs_rank3_group_index = rhs_info.rhs_group_index
+        rhs_rank3_group_expr = (
+            rhs_info.rhs_segment_group.group_load.name
+            if rhs_info.rhs_segment_group is not None
+            else rhs_info.rhs_group_index.name
+        )
+    tcgen05_grouped_worklist_static_full_tiles = (
+        tcgen05_grouped_static_persistent_requested
+        and tcgen05_grouped_dynamic_ab_tensormaps_requested
+        and rhs_rank3_segment_lhs_info is not None
+    )
     # tcgen05 epilogues are emitted by `_codegen_cute_store_tcgen05_tile` in
     # `helion/language/memory_ops.py`. Static-full flat kernels and validated
     # role-local persistent kernels use the SMEM-staged TMA-store epilogue;
@@ -2226,7 +4741,9 @@ def _emit_mma_pipeline(
     m_index_var = cg.index_var(m_block_id)
     n_index_var = cg.index_var(n_block_id)
     leading_index_var: str | None = None
-    lp_block_id = analysis.leading_passthrough_block_id
+    lp_block_id = (
+        analysis.leading_passthrough_block_id if analysis is not None else None
+    )
     if lp_block_id is not None:
         if grid_state is None or lp_block_id not in grid_state.block_ids:
             return None
@@ -2264,10 +4781,26 @@ def _emit_mma_pipeline(
         return f"{lhs_arg_name}[{m_expr}, {k_expr}]"
 
     def _rhs_gmem_access(k_expr: str, n_expr: str) -> str:
+        if rhs_rank3_group_expr is not None:
+            return f"{rhs_arg_name}[{rhs_rank3_group_expr}, {n_expr}, {k_expr}]"
         if rhs_operand.is_leading_passthrough:
             assert leading_global is not None
             return f"{rhs_arg_name}[{leading_global}, {k_expr}, {n_expr}]"
         return f"{rhs_arg_name}[{k_expr}, {n_expr}]"
+
+    tcgen05_nm_orientation = requested_schedule is Tcgen05Orientation.NM
+    tcgen05_mma_bm = (
+        TCGEN05_GROUPED_WORKLIST_MMA_M_TILE if tcgen05_nm_orientation else bm
+    )
+    tcgen05_mma_bn = (
+        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE if tcgen05_nm_orientation else bn
+    )
+    tcgen05_source_bm = (
+        TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE if tcgen05_nm_orientation else bm
+    )
+    tcgen05_source_bn = (
+        TCGEN05_GROUPED_WORKLIST_MMA_M_TILE if tcgen05_nm_orientation else bn
+    )
 
     tcgen05_cluster_m = _tcgen05_cluster_m(df.config)
     tcgen05_large_bn_proof = _tcgen05_large_bn_proof_enabled(df.config)
@@ -2304,39 +4837,66 @@ def _emit_mma_pipeline(
         config=df.config,
         input_device=lhs_fake.device,
     )
-    mma_tiles_are_static_full = _mma_tiles_are_static_full(
-        analysis, bm=bm, bn=bn, bk=bk
+    mma_tiles_are_static_full = (
+        _mma_tiles_are_static_full(analysis, bm=bm, bn=bn, bk=bk)
+        if analysis is not None
+        else m_size % bm == 0 and n_size % bn == 0 and k_total_size % bk == 0
     )
-    if analysis.has_leading_passthrough and not mma_tiles_are_static_full:
+    if (
+        analysis is not None
+        and analysis.has_leading_passthrough
+        and not mma_tiles_are_static_full
+    ):
         return None
     # A leading-passthrough collective absorbs its serialized K loop. Other
     # non-root lane loops must already have been suppressed by MMA planning;
     # reusing one fragment across their logical iterations is wrong.
     allowed_k_lane_loops: tuple[DeviceLoopState, ...] = (
-        (device_loop,) if analysis.has_leading_passthrough else ()
+        (device_loop,) if analysis is None or analysis.has_leading_passthrough else ()
     )
     if _has_non_root_lane_loops(cg, allowed_loop_states=allowed_k_lane_loops):
         return None
     zero_acc_expr = acc_expr is not None and _is_zero_acc_expr(acc_expr)
+    if (
+        analysis is None
+        and not zero_acc_expr
+        and acc_expr is not None
+        and fx_node is not None
+        and fx_node.target is torch.ops.aten.addmm.default
+    ):
+        acc_node = fx_node.args[0] if fx_node.args else None
+        if isinstance(acc_node, Node) and _is_zero_init_acc_node(acc_node):
+            zero_acc_expr = True
     if acc_expr is not None and mma_impl != "universal" and not zero_acc_expr:
         mma_impl = "universal"
     if mma_impl != "universal" and zero_acc_expr:
         acc_expr = None
-    if mma_impl == "universal" and (
-        analysis.has_leading_passthrough
-        or _tcgen05_candidate_exceeds_smem(
-            input_dtype,
-            input_device=lhs_fake.device,
-            bm=bm,
-            bn=bn,
-            bk=bk,
-            config=df.config,
+    if analysis is None and mma_impl != "tcgen05" and _has_non_root_lane_loops(cg):
+        return _unsupported_schedule("non-tcgen05 MMA does not own nested lane loops")
+    if rhs_info.rhs_rank3_grouped_nt:
+        if mma_impl != "tcgen05":
+            return _unsupported_schedule("tcgen05 MMA was not selected")
+        if not rhs_rank3_segment_metadata and not tcgen05_use_tma_pipeline:
+            return _unsupported_schedule("rank3 RHS TMA pipeline was disabled")
+    if (
+        analysis is not None
+        and mma_impl == "universal"
+        and (
+            analysis.has_leading_passthrough
+            or _tcgen05_candidate_exceeds_smem(
+                input_dtype,
+                input_device=lhs_fake.device,
+                bm=bm,
+                bn=bn,
+                bk=bk,
+                config=df.config,
+            )
         )
     ):
         return None
     # Non-tcgen05 paths inspect runtime layouts. tcgen05 wrapper schemas are
     # specialized by shape and stride, so they can keep tensor layouts baked.
-    if mma_impl != "tcgen05":
+    if analysis is not None and mma_impl != "tcgen05":
         cg.cute_uses_matmul = True
     tcgen05_requested_flat_role_coordinates = bool(
         df.config.get(TCGEN05_FLAT_ROLE_COORDINATES_CONFIG_KEY, False)
@@ -2349,10 +4909,12 @@ def _emit_mma_pipeline(
         )
     tcgen05_pid_is_persistent = _is_persistent_pid_config(df.config)
     tcgen05_requested_two_cta = _tcgen05_use_2cta_instrs(
-        bm=bm,
+        bm=tcgen05_mma_bm,
         cluster_m=tcgen05_cluster_m,
         input_dtype=input_dtype,
     )
+    if tcgen05_nm_orientation and tcgen05_cluster_m == 2:
+        tcgen05_requested_two_cta = True
     tcgen05_cluster_n_requested = _tcgen05_cluster_n(df.config)
     # A leading-batch grid axis composes with the CtaGroup.TWO cluster (cluster_m,
     # cluster_n=1): the 2-CTA MMA/TMA-multicast operate within each (m, n) tile
@@ -2360,7 +4922,8 @@ def _emit_mma_pipeline(
     # (4-CTA) multicast does NOT yet compose with batch (produces wrong results),
     # so keep it on the scalar fallback for batched kernels.
     if (
-        analysis.has_leading_passthrough
+        analysis is not None
+        and analysis.has_leading_passthrough
         and mma_impl == "tcgen05"
         and tcgen05_cluster_n_requested != 1
     ):
@@ -2450,6 +5013,7 @@ def _emit_mma_pipeline(
     if (
         mma_impl == "tcgen05"
         and not tcgen05_static_full_tiles
+        and not tcgen05_grouped_worklist_static_full_tiles
         and not tcgen05_mixed_tma_scalar_fallback
         and not tcgen05_preserve_tma_for_two_cta_k_tail
         and not tcgen05_m_edge_only
@@ -2570,7 +5134,7 @@ def _emit_mma_pipeline(
     )
     # The exact CtaGroup.ONE bridge duplicates A/B TMA production locally and
     # remains runtime-guarded. Do not apply the CtaGroup.TWO deferred cluster
-    # pipeline protocol to that diagnostic shape.
+    # pipeline protocol to that shape.
     tcgen05_use_cluster_deferred_pipelines = (
         tcgen05_cluster_m > 1 and not tcgen05_cluster_m2_one_cta_role_local_bridge
     )
@@ -2581,6 +5145,7 @@ def _emit_mma_pipeline(
         and tcgen05_use_tma_pipeline
         and (
             tcgen05_static_full_tiles
+            or tcgen05_grouped_worklist_static_full_tiles
             or tcgen05_role_local_k_tail_tma
             or tcgen05_role_local_m_edge_tma
             or tcgen05_role_local_n_edge_tma
@@ -2759,6 +5324,9 @@ def _emit_mma_pipeline(
     tcgen05_ab_stage_count_value = _tcgen05_config_int(
         df.config, "tcgen05_ab_stages", _tcgen05_ab_stage_count(df.config.num_stages)
     )
+    tcgen05_c_stage_count_value = _tcgen05_config_int(
+        df.config, "tcgen05_c_stages", _tcgen05_c_stage_count(bn)
+    )
     tcgen05_output_edge_tma_store_fits_smem = (
         tcgen05_ab_stage_count_value <= TCGEN05_TWO_CTA_EDGE_TMA_STORE_MAX_AB_STAGES
     )
@@ -2780,6 +5348,7 @@ def _emit_mma_pipeline(
         and tcgen05_use_tma_pipeline
         and (
             tcgen05_static_full_tiles
+            or tcgen05_grouped_worklist_static_full_tiles
             or tcgen05_role_local_k_tail_tma
             or tcgen05_use_output_edge_tma_store_for_full_tiles
         )
@@ -2817,14 +5386,632 @@ def _emit_mma_pipeline(
         mma_impl == "tcgen05"
         and fx_node is not None
         and cg.current_grid_state is not None
-        and len(lhs_load.users) == 1
-        and len(rhs_load.users) == 1
-        and next(iter(lhs_load.users)) is fx_node
-        and next(iter(rhs_load.users)) is fx_node
+        and _operand_infos_exclusive_for_mma(lhs_info, rhs_info, fx_node)
     )
+    tcgen05_grouped_dynamic_ab_tensormap_rank: int | None = None
+    tcgen05_grouped_d_mode = Tcgen05GroupedDMode.NONE
+    tcgen05_grouped_worklist_persistent = False
+    tcgen05_grouped_layout_arg_name: str | None = None
+    tcgen05_grouped_n_sizes_arg_name: str | None = None
+    tcgen05_grouped_k_sizes_arg_name: str | None = None
+    tcgen05_grouped_ab_tensormaps: str | None = None
+    tcgen05_grouped_direct_pointers: str | None = None
+    tcgen05_grouped_direct_strides: str | None = None
+    tcgen05_grouped_d_tensormap: str | None = None
+    tcgen05_grouped_actual_has_m_tail: bool | None = None
+    tcgen05_grouped_actual_has_n_tail: bool | None = None
+    tcgen05_grouped_static_full_output_tiles_from_metadata = False
+    tcgen05_grouped_count: str | None = None
+    tcgen05_grouped_total_clusters: str | None = None
+    tcgen05_grouped_sched_params: str | None = None
+    tcgen05_grouped_problem_sizes: str | None = None
+    tcgen05_grouped_starts: str | None = None
+    tcgen05_grouped_real_groups: str | None = None
+    tcgen05_grouped_metadata_idx: str | None = None
+    tcgen05_grouped_group_idx: str | None = None
+    tcgen05_grouped_cta_tile_idx_m: str | None = None
+    tcgen05_grouped_cta_tile_idx_n: str | None = None
+    tcgen05_grouped_problem_m: str | None = None
+    tcgen05_grouped_problem_n: str | None = None
+    tcgen05_grouped_problem_k: str | None = None
+    tcgen05_grouped_global_m_start: str | None = None
+    tcgen05_grouped_valid_m: str | None = None
+    tcgen05_grouped_store_m: str | None = None
+    tcgen05_grouped_tail_proof = (
+        rhs_rank3_grouped_proof.tail_epilogue
+        if rhs_rank3_grouped_proof is not None
+        else None
+    )
+    tcgen05_grouped_k_mask = (
+        rhs_rank3_grouped_proof.k_mask if rhs_rank3_grouped_proof is not None else None
+    )
+    if requested_schedule is not None:
+        lhs_source_fake = lhs_info.source_fake
+        rhs_source_fake = rhs_info.source_fake
+        lhs_source_k = (
+            _static_int(lhs_source_fake.shape[1]) if lhs_source_fake.ndim == 2 else None
+        )
+        rhs_source_n = (
+            _static_int(rhs_source_fake.shape[1]) if rhs_source_fake.ndim == 3 else None
+        )
+        rhs_source_k = (
+            _static_int(rhs_source_fake.shape[2]) if rhs_source_fake.ndim == 3 else None
+        )
+        lhs_contiguous_mk = _is_contiguous_mk_source_fake(lhs_source_fake)
+        rhs_contiguous_gnk = _is_contiguous_gnk_source_fake(rhs_source_fake)
+        worklist_nm_static_checks = {
+            "bf16_operands": input_dtype == torch.bfloat16,
+            "bf16_store": epi_elem_dtype_str == "cutlass.BFloat16",
+            "tile_256x128x64": bm == 256 and bn == 128 and bk == 64,
+            "n_multiple_32": (
+                rhs_source_n is not None
+                and rhs_source_n > 0
+                and rhs_source_n % TCGEN05_GROUPED_WORKLIST_STORE_SHAPE[2] == 0
+            ),
+            "k_multiple_64": (
+                lhs_source_k is not None
+                and rhs_source_k is not None
+                and lhs_source_k % 64 == 0
+                and rhs_source_k % 64 == 0
+            ),
+            "common_k": (
+                lhs_source_k is not None
+                and rhs_source_k is not None
+                and lhs_source_k == rhs_source_k
+            ),
+            "contiguous_a_packed": lhs_contiguous_mk,
+            "contiguous_b_grouped": rhs_contiguous_gnk,
+            "zero_accumulator": zero_acc_expr or acc_expr is None,
+        }
+        failed_static_checks = [
+            name for name, passed in worklist_nm_static_checks.items() if not passed
+        ]
+        if failed_static_checks:
+            raise exc.BackendUnsupported(
+                "cute",
+                f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}="
+                f"{TCGEN05_GROUPED_MODE_WORKLIST_NM!r} is validated only for "
+                "generated BF16 NT contiguous "
+                "segment-worklist kernels: contiguous A_packed[M,K], "
+                "contiguous B_grouped[G,N,K], common K%64==0, "
+                "N%32==0, "
+                "CtaGroup.TWO 256x128x64, zero accumulator, and identity BF16 "
+                "store; failed checks: " + ", ".join(failed_static_checks),
+            )
+    if tcgen05_grouped_static_persistent_requested:
+        if rhs_rank3_grouped_proof is None:
+            raise exc.BackendUnsupported(
+                "cute",
+                f"{TCGEN05_GROUPED_MODE_CONFIG_KEY} requires the rank3 RHS "
+                "grouped-NT safe-group pattern layout[tile_m.begin]",
+            )
+        grouped_layout_tensor = rhs_rank3_grouped_proof.layout_tensor
+        tcgen05_grouped_worklist_persistent = (
+            rhs_rank3_grouped_proof.is_worklist
+            and tcgen05_grouped_dynamic_ab_tensormaps_requested
+        )
+        if tcgen05_grouped_worklist_persistent:
+            if grouped_layout_tensor.ndim != 2 or grouped_layout_tensor.shape[1] != 4:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "tcgen05 grouped worklist persistent path requires "
+                    "work_tile_metadata with shape [W, 4]",
+                )
+        if grouped_layout_tensor.dtype not in (torch.int32, torch.int64):
+            raise exc.BackendUnsupported(
+                "cute",
+                f"{TCGEN05_GROUPED_MODE_CONFIG_KEY} requires an int32/int64 "
+                "rank3 RHS group layout tensor",
+            )
+        grouped_warp_spec = (
+            warp_spec_from_config(df.config) if mma_impl == "tcgen05" else None
+        )
+        grouped_worklist_two_cta = (
+            tcgen05_grouped_worklist_persistent
+            and tcgen05_is_two_cta
+            and tcgen05_cluster_m == 2
+            and tcgen05_cluster_n == 1
+            and bm == TCGEN05_TWO_CTA_BLOCK_M
+            and bk == 64
+        )
+        grouped_common_k_pair_allowed = (
+            tcgen05_grouped_k_mask is not None
+            or tcgen05_grouped_worklist_persistent
+            or bk == 128
+            or (k_total_size, bk) in TCGEN05_GROUPED_STATIC_COMMON_K_BLOCK_PAIRS
+        )
+        grouped_envelope_checks = {
+            "rank3_rhs_grouped_nt": rhs_info.rhs_rank3_grouped_nt,
+            "common_k": k_total_size == int(rhs_fake.shape[0]),
+            "common_k_block_multiple": k_total_size % bk == 0,
+            "common_k_block_pair_allowlisted": grouped_common_k_pair_allowed,
+            "f16_or_bf16": input_dtype in (torch.float16, torch.bfloat16),
+            "tcgen05": mma_impl == "tcgen05",
+            "tma_pipeline": tcgen05_use_tma_pipeline,
+            "collective_operand_loads": tcgen05_collective_handles_operand_loads,
+            "static_full_tiles": (
+                tcgen05_static_full_tiles or tcgen05_grouped_worklist_persistent
+            ),
+            "persistent_pid": tcgen05_pid_is_persistent,
+            "cluster_m_1_or_worklist_2cta": (
+                tcgen05_cluster_m == 1 or grouped_worklist_two_cta
+            ),
+            "cluster_n_1": tcgen05_cluster_n == 1,
+            "cta_group_one_or_worklist_2cta": (
+                not tcgen05_is_two_cta or grouped_worklist_two_cta
+            ),
+            "role_local_body": tcgen05_use_role_local_persistent_body,
+            "tma_store_epilogue": tcgen05_use_tma_store_epilogue,
+            "zero_accumulator": zero_acc_expr or acc_expr is None,
+            "block_m_128_or_worklist_2cta": (bm == 128 or grouped_worklist_two_cta),
+            "block_n_64_or_128": bn in (64, 128),
+            "block_k_16_32_or_64_or_128": (
+                bk in TCGEN05_GROUPED_STATIC_BLOCK_K_CHOICES
+                or (
+                    tcgen05_grouped_dynamic_ab_tensormaps_requested
+                    and bk == 64
+                    and (
+                        tcgen05_grouped_k_mask is not None
+                        or tcgen05_grouped_worklist_persistent
+                    )
+                )
+            ),
+            "block_k_64_static_common_or_dynamic": (
+                bk != 64
+                or tcgen05_grouped_k_mask is None
+                or tcgen05_grouped_dynamic_ab_tensormaps_requested
+                or tcgen05_grouped_worklist_persistent
+            ),
+            "dynamic_ab_tensormaps_bk64_only": (
+                not tcgen05_grouped_dynamic_ab_tensormaps_requested or bk == 64
+            ),
+            "dynamic_ab_tensormaps_exact_k_sizes": (
+                not tcgen05_grouped_dynamic_ab_tensormaps_requested
+                or tcgen05_grouped_k_mask is not None
+                or tcgen05_grouped_worklist_persistent
+            ),
+            "worklist_dynamic_ab_only": (
+                not tcgen05_grouped_worklist_persistent
+                or (
+                    tcgen05_grouped_dynamic_ab_tensormaps_requested
+                    and (bm == 128 or grouped_worklist_two_cta)
+                    and bk == 64
+                )
+            ),
+            "no_scheduler_warp": (
+                grouped_warp_spec is not None and grouped_warp_spec.scheduler_warps == 0
+            ),
+            "no_c_input_warp": (
+                grouped_warp_spec is not None and grouped_warp_spec.c_input_warps == 0
+            ),
+            "no_store_warp": (
+                grouped_warp_spec is not None and grouped_warp_spec.store_warps == 0
+            ),
+        }
+        failed_grouped_checks = [
+            name for name, passed in grouped_envelope_checks.items() if not passed
+        ]
+        if failed_grouped_checks:
+            raise exc.BackendUnsupported(
+                "cute",
+                f"{TCGEN05_GROUPED_MODE_CONFIG_KEY} is currently validated "
+                "only for FP16/BF16 rank3 RHS grouped-NT CtaGroup.ONE "
+                "persistent_interleaved static-full 128x(64|128)x(16|32|64|128) "
+                "TMA-load + TMA-store kernels, or the generated segment "
+                "worklist BK64 dynamic-TensorMap variant (including the "
+                "CtaGroup.TWO 256x(64|128)x64 worklist shape), with no "
+                "scheduler/C-input/store warp variants; failed checks: "
+                + ", ".join(failed_grouped_checks),
+            )
+        grouped_count_value = (
+            int(grouped_layout_tensor.shape[0])
+            if tcgen05_grouped_worklist_persistent
+            else int(rhs_info.source_fake.shape[0])
+        )
+        if grouped_count_value <= 0:
+            raise exc.BackendUnsupported(
+                "cute",
+                f"{TCGEN05_GROUPED_MODE_CONFIG_KEY} requires at least one RHS group",
+            )
+        tcgen05_grouped_dynamic_ab_tensormap_rank = (
+            3 if tcgen05_grouped_dynamic_ab_tensormaps_requested and bk == 64 else None
+        )
+        tcgen05_grouped_layout_arg_name = df.tensor_arg(grouped_layout_tensor).name
+        if tcgen05_grouped_k_mask is not None:
+            tcgen05_grouped_k_sizes_arg_name = df.tensor_arg(
+                tcgen05_grouped_k_mask.k_sizes_tensor
+            ).name
+        if tcgen05_grouped_tail_proof is not None:
+            if tcgen05_grouped_tail_proof.n_sizes_tensor is not None:
+                tcgen05_grouped_n_sizes_arg_name = df.tensor_arg(
+                    tcgen05_grouped_tail_proof.n_sizes_tensor
+                ).name
+            tail_facts = _runtime_grouped_static_tail_facts(
+                layout_arg_name=tcgen05_grouped_layout_arg_name,
+                n_sizes_arg_name=tcgen05_grouped_n_sizes_arg_name or None,
+                group_count=grouped_count_value,
+                bm=bm,
+                bn=bn,
+                n_size=n_size,
+                m_tail_preserve=tcgen05_grouped_tail_proof.has_m_tail_mask,
+            )
+            if tail_facts is not None:
+                (
+                    tcgen05_grouped_actual_has_m_tail,
+                    tcgen05_grouped_actual_has_n_tail,
+                ) = tail_facts
+                tcgen05_grouped_static_full_output_tiles_from_metadata = (
+                    not tcgen05_grouped_actual_has_m_tail
+                    and not tcgen05_grouped_actual_has_n_tail
+                )
+            tcgen05_tma_store_full_tiles_only = True
+            grouped_static_d_tail_tensormap_n_only = (
+                (k_total_size, bk) in TCGEN05_GROUPED_STATIC_COMMON_K_BLOCK_PAIRS
+                and tcgen05_grouped_tail_proof.has_n_tail_mask
+                and tcgen05_grouped_actual_has_n_tail is True
+                and tcgen05_grouped_actual_has_m_tail is False
+            )
+            grouped_static_d_tail_tensormap_m_only = (
+                bk == 128
+                and tcgen05_grouped_tail_proof.has_m_tail_mask
+                and tcgen05_grouped_actual_has_m_tail is True
+                and tcgen05_grouped_actual_has_n_tail is False
+            )
+            grouped_static_d_tail_tensormap = (
+                tcgen05_grouped_dynamic_ab_tensormap_rank is None
+                and not tcgen05_grouped_worklist_persistent
+                and tcgen05_grouped_k_mask is None
+                and not tcgen05_is_two_cta
+                and tcgen05_cluster_m == 1
+                and tcgen05_cluster_n == 1
+                and n_size % bn == 0
+                and (
+                    grouped_static_d_tail_tensormap_n_only
+                    or grouped_static_d_tail_tensormap_m_only
+                )
+            )
+            if tcgen05_grouped_static_full_output_tiles_from_metadata:
+                tcgen05_tma_store_full_tiles_only = False
+            if tcgen05_grouped_dynamic_ab_tensormap_rank is not None:
+                tcgen05_grouped_d_mode = Tcgen05GroupedDMode.ALL_TILES
+                tcgen05_tma_store_full_tiles_only = False
+            elif grouped_static_d_tail_tensormap:
+                tcgen05_grouped_d_mode = Tcgen05GroupedDMode.EDGE_ONLY
+        if tcgen05_grouped_worklist_persistent:
+            tcgen05_grouped_d_mode = Tcgen05GroupedDMode.ALL_TILES
+            tcgen05_tma_store_full_tiles_only = False
+        if tcgen05_grouped_direct_pointer_metadata_requested:
+            if tcgen05_nm_orientation:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}="
+                    f"{TCGEN05_GROUPED_MODE_DIRECT!r} "
+                    "currently supports the default M,N grouped TensorMap "
+                    "orientation only",
+                )
+            if tcgen05_grouped_dynamic_ab_tensormap_rank is None:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}="
+                    f"{TCGEN05_GROUPED_MODE_DIRECT!r} "
+                    "requires dynamic grouped A/B TensorMaps",
+                )
+            if tcgen05_grouped_d_mode is Tcgen05GroupedDMode.NONE:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}="
+                    f"{TCGEN05_GROUPED_MODE_DIRECT!r} "
+                    "requires a dynamic grouped D TensorMap",
+                )
+        if requested_schedule is not None:
+            worklist_nm_envelope_checks = {
+                "rank3_segment_metadata": (
+                    rhs_rank3_segment_metadata
+                    and rhs_rank3_segment_lhs_info is not None
+                    and rhs_rank3_segment_store_info is not None
+                ),
+                "worklist_metadata": tcgen05_grouped_worklist_persistent,
+                "dynamic_ab_tensormaps": (
+                    tcgen05_grouped_dynamic_ab_tensormap_rank is not None
+                ),
+                "dynamic_d_tensormap": (
+                    tcgen05_grouped_d_mode is not Tcgen05GroupedDMode.NONE
+                ),
+                "cta_group_two": grouped_worklist_two_cta,
+                "no_grouped_k_mask": tcgen05_grouped_k_mask is None,
+                "no_tail_epilogue": tcgen05_grouped_tail_proof is None,
+            }
+            failed_worklist_nm_checks = [
+                name
+                for name, passed in worklist_nm_envelope_checks.items()
+                if not passed
+            ]
+            if failed_worklist_nm_checks:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}="
+                    f"{TCGEN05_GROUPED_MODE_WORKLIST_NM!r} is validated only "
+                    "for generated BF16 NT contiguous "
+                    "segment-worklist kernels: contiguous A_packed[M,K], "
+                    "contiguous B_grouped[G,N,K], common K%64==0, "
+                    "N%32==0, "
+                    "CtaGroup.TWO 256x128x64, dynamic A/B/D TensorMaps, "
+                    "zero accumulator, and identity BF16 store; failed checks: "
+                    + ", ".join(failed_worklist_nm_checks),
+                )
+            assert requested_schedule is not None
+        if (
+            tcgen05_grouped_dynamic_ab_tensormap_rank is not None
+            and not tcgen05_grouped_direct_pointer_metadata_requested
+            and _is_contiguous_mk_source_fake(lhs_info.source_fake)
+            and _is_contiguous_gnk_source_fake(rhs_info.source_fake)
+        ):
+            tcgen05_grouped_dynamic_ab_tensormap_rank = 2
+        nm_deep_ab = (
+            requested_schedule is not None
+            and 4 <= tcgen05_ab_stage_count_value <= 7
+            and tcgen05_c_stage_count_value == 2
+            and _tcgen05_config_int(
+                df.config,
+                "tcgen05_acc_stages",
+                _tcgen05_acc_stage_count(tcgen05_mma_bn),
+            )
+            == 2
+        )
+        if tcgen05_ab_stage_count_value > 3 and not (
+            nm_deep_ab
+            or (
+                tcgen05_ab_stage_count_value == 4
+                and tcgen05_grouped_dynamic_ab_tensormap_rank is not None
+                and tcgen05_grouped_d_mode is not Tcgen05GroupedDMode.NONE
+                and bm == 128
+                and bn == 64
+                and bk == 64
+                and tcgen05_cluster_m == 1
+                and tcgen05_cluster_n == 1
+                and not tcgen05_is_two_cta
+                and _tcgen05_config_int(
+                    df.config,
+                    "tcgen05_acc_stages",
+                    _tcgen05_acc_stage_count(tcgen05_mma_bn),
+                )
+                == 2
+                and tcgen05_c_stage_count_value == 2
+                and env.config_spec._tcgen05_grouped_dynamic_ab4_fits_for_target(
+                    dtype_bytes=input_dtype.itemsize,
+                    device=lhs_info.source_fake.device,
+                    bm=bm,
+                    bn=bn,
+                    bk=bk,
+                    cluster_m=tcgen05_cluster_m,
+                    c_stages=tcgen05_c_stage_count_value,
+                )
+            )
+        ):
+            raise exc.BackendUnsupported(
+                "cute",
+                f"{TCGEN05_GROUPED_MODE_CONFIG_KEY} admits explicit "
+                "tcgen05_ab_stages>3 only for the generated N,M-oriented "
+                "worklist schedule up to 7 stages within target-device SMEM "
+                "headroom, or tcgen05_ab_stages=4 for the FP16/BF16 rank3 "
+                "grouped-NT dynamic TensorMap BK64 128x64x64 CtaGroup.ONE "
+                "path with cluster_m=cluster_n=1, acc_stages=2, c_stages=2, "
+                "dynamic D TensorMap, and target-device SMEM headroom",
+            )
+        tcgen05_grouped_count = str(grouped_count_value)
+        tcgen05_grouped_total_clusters = df.new_var("tcgen05_grouped_total_clusters")
+        tcgen05_grouped_sched_params = df.new_var("tcgen05_grouped_tile_sched_params")
+        tcgen05_grouped_problem_sizes = df.new_var("tcgen05_grouped_problem_sizes")
+        tcgen05_grouped_starts = df.new_var("tcgen05_grouped_starts")
+        if tcgen05_grouped_worklist_persistent:
+            tcgen05_grouped_real_groups = df.new_var("tcgen05_grouped_real_groups")
+        tcgen05_grouped_metadata_idx = df.new_var("tcgen05_grouped_metadata_idx")
+        tcgen05_grouped_group_idx = df.new_var("tcgen05_grouped_group_idx")
+        tcgen05_grouped_cta_tile_idx_m = df.new_var("tcgen05_grouped_cta_tile_idx_m")
+        tcgen05_grouped_cta_tile_idx_n = df.new_var("tcgen05_grouped_cta_tile_idx_n")
+        tcgen05_grouped_problem_m = df.new_var("tcgen05_grouped_problem_m")
+        tcgen05_grouped_problem_n = df.new_var("tcgen05_grouped_problem_n")
+        tcgen05_grouped_problem_k = df.new_var("tcgen05_grouped_problem_k")
+        tcgen05_grouped_global_m_start = df.new_var("tcgen05_grouped_global_m_start")
+        if requested_schedule is not None:
+            tcgen05_grouped_valid_m = df.new_var("tcgen05_grouped_valid_m")
+            tcgen05_grouped_store_m = df.new_var("tcgen05_grouped_store_m")
+        if tcgen05_grouped_dynamic_ab_tensormap_rank is not None:
+            tcgen05_grouped_ab_tensormaps = df.new_var("tcgen05_grouped_ab_tensormaps")
+            if tcgen05_grouped_d_mode is not Tcgen05GroupedDMode.NONE:
+                tcgen05_grouped_d_tensormap = tcgen05_grouped_ab_tensormaps
+        elif tcgen05_grouped_d_mode is not Tcgen05GroupedDMode.NONE:
+            tcgen05_grouped_d_tensormap = df.new_var("tcgen05_grouped_d_tensormaps")
+        if tcgen05_grouped_direct_pointer_metadata_requested:
+            tcgen05_grouped_direct_pointers = df.new_var(
+                "tcgen05_grouped_direct_pointers"
+            )
+            tcgen05_grouped_direct_strides = df.new_var(
+                "tcgen05_grouped_direct_strides"
+            )
+    if (
+        tcgen05_grouped_direct_pointer_metadata_requested
+        and not tcgen05_grouped_direct_pointers
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}="
+            f"{TCGEN05_GROUPED_MODE_DIRECT!r} requires "
+            "the generated grouped static persistent dynamic TensorMap path",
+        )
+    tcgen05_grouped_plan: CuteTcgen05GroupedPlan | None = None
+    if tcgen05_grouped_static_persistent_requested:
+        tcgen05_grouped_plan = CuteTcgen05GroupedPlan(
+            orientation=requested_schedule or Tcgen05Orientation.MN,
+            layout=cast("str", tcgen05_grouped_layout_arg_name),
+            count=cast("str", tcgen05_grouped_count),
+            sched_params=cast("str", tcgen05_grouped_sched_params),
+            problem_sizes=cast("str", tcgen05_grouped_problem_sizes),
+            starts=cast("str", tcgen05_grouped_starts),
+            metadata_idx=cast("str", tcgen05_grouped_metadata_idx),
+            group_idx=cast("str", tcgen05_grouped_group_idx),
+            cta_tile_idx_m=cast("str", tcgen05_grouped_cta_tile_idx_m),
+            cta_tile_idx_n=cast("str", tcgen05_grouped_cta_tile_idx_n),
+            problem_m=cast("str", tcgen05_grouped_problem_m),
+            problem_n=cast("str", tcgen05_grouped_problem_n),
+            problem_k=cast("str", tcgen05_grouped_problem_k),
+            global_m_start=cast("str", tcgen05_grouped_global_m_start),
+            real_groups=tcgen05_grouped_real_groups,
+            valid_m=tcgen05_grouped_valid_m,
+            store_m=tcgen05_grouped_store_m,
+            direct_pointers=tcgen05_grouped_direct_pointers,
+            direct_strides=tcgen05_grouped_direct_strides,
+            d_mode=tcgen05_grouped_d_mode,
+            d_tensormap=tcgen05_grouped_d_tensormap,
+        )
+    if requested_schedule is not None and (
+        tcgen05_grouped_plan is None
+        or tcgen05_grouped_plan.real_groups is None
+        or tcgen05_grouped_plan.orientation is not requested_schedule
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}="
+            f"{TCGEN05_GROUPED_MODE_WORKLIST_NM!r} requires the "
+            "generated segment-worklist grouped tcgen05 path",
+        )
+    tcgen05_grouped_static_persistent = tcgen05_grouped_plan is not None
+    tcgen05_grouped_dynamic_ab_tensormaps = (
+        tcgen05_grouped_dynamic_ab_tensormap_rank is not None
+    )
+    tcgen05_grouped_direct_pointer_metadata = bool(
+        tcgen05_grouped_plan is not None
+        and tcgen05_grouped_plan.direct_pointers is not None
+    )
+    tcgen05_grouped_dynamic_d_tensormap = (
+        tcgen05_grouped_d_mode is not Tcgen05GroupedDMode.NONE
+    )
+    tcgen05_grouped_d_tensormap_tail_store = (
+        tcgen05_grouped_d_mode is Tcgen05GroupedDMode.EDGE_ONLY
+    )
+    nm_worklist = tcgen05_nm_orientation
+    rhs_rank3_tma_group_expr = rhs_rank3_group_expr
+    rhs_rank3_tma_group_setup: list[str] = []
+    if rhs_rank3_group_index is not None and not rhs_rank3_segment_metadata:
+        if (
+            mma_impl != "tcgen05"
+            or not tcgen05_use_tma_pipeline
+            or not tcgen05_static_full_tiles
+            or tcgen05_cluster_m != 1
+            or tcgen05_is_two_cta
+            or not tcgen05_collective_handles_operand_loads
+        ):
+            return _unsupported_schedule("rank3 grouped RHS TMA setup envelope failed")
+        if tcgen05_grouped_static_persistent:
+            rhs_rank3_tma_group_expr = tcgen05_grouped_group_idx
+            rhs_rank3_tma_group_setup = []
+        else:
+            rhs_rank3_tma_group_setup_info = _tcgen05_rank3_rhs_group_tma_setup(
+                cg,
+                rhs_rank3_group_index,
+                m_block_id=m_block_id,
+                m_offset_var=m_offset_var,
+            )
+            if rhs_rank3_tma_group_setup_info is None:
+                return _unsupported_schedule("rank3 RHS TMA setup failed")
+            rhs_rank3_tma_group_expr, rhs_rank3_tma_group_setup = (
+                rhs_rank3_tma_group_setup_info
+            )
+        safe_group_rewrite_plan = _rank3_rhs_safe_group_scalar_rewrite_plan(
+            cg,
+            rhs_info,
+            m_offset_var=m_offset_var,
+        )
+        if safe_group_rewrite_plan is None:
+            return _unsupported_schedule(
+                "rank3 RHS safe-group scalar rewrite was infeasible"
+            )
+        k_mask_dependency_nodes = tuple(
+            dict.fromkeys(
+                (
+                    *lhs_info.collective_dependency_nodes,
+                    *rhs_info.collective_dependency_nodes,
+                )
+            )
+        )
+        operand_pass_rewrite_plan = _owned_scalar_statement_pass_rewrite_plan(
+            cg,
+            (lhs_info.load, rhs_info.load),
+            optional_nodes=k_mask_dependency_nodes,
+        )
+        if operand_pass_rewrite_plan is None:
+            return _unsupported_schedule("owned scalar pass rewrite failed")
+        safe_group_stmt_ids = {id(stmt) for stmt in safe_group_rewrite_plan[2]}
+        if any(
+            id(stmt) in safe_group_stmt_ids
+            for _node_id, _body, _index, stmt in operand_pass_rewrite_plan
+        ):
+            return _unsupported_schedule(
+                "safe-group scalar rewrite statements overlapped"
+            )
+        _apply_rank3_rhs_safe_group_scalar_rewrite(safe_group_rewrite_plan)
+        _apply_owned_scalar_statement_pass_rewrite(
+            cg,
+            operand_pass_rewrite_plan,
+        )
+    if rhs_rank3_segment_lhs_info is not None:
+        operand_pass_rewrite_plan = _owned_scalar_statement_pass_rewrite_plan(
+            cg,
+            (lhs_info.load, rhs_info.load),
+        )
+        if operand_pass_rewrite_plan is None:
+            return _unsupported_schedule("segment operand scalar pass rewrite failed")
+        row_index_node = rhs_rank3_segment_lhs_info.row_index
+        valid_m_node = rhs_rank3_segment_lhs_info.valid_m
+        segment_scalar_replacements = {
+            row_index_node: "cutlass.Int32(0)",
+            valid_m_node: "cutlass.Boolean(0)",
+        }
+        if tcgen05_grouped_worklist_persistent:
+            assert rhs_info.rhs_segment_group is not None
+            segment_scalar_replacements.update(
+                {
+                    rhs_info.rhs_segment_group.group_load: "cutlass.Int32(0)",
+                    rhs_rank3_segment_lhs_info.segment_start_load: "cutlass.Int32(0)",
+                    rhs_rank3_segment_lhs_info.actual_m_load: "cutlass.Int32(0)",
+                }
+            )
+            if rhs_rank3_segment_store_info is not None:
+                segment_scalar_replacements.update(
+                    {
+                        rhs_rank3_segment_store_info.valid_m: "cutlass.Boolean(0)",
+                        rhs_rank3_segment_store_info.extent_load: "cutlass.Int32(0)",
+                    }
+                )
+        segment_expr_rewrite_plan = _owned_scalar_statement_expr_rewrite_plan(
+            cg,
+            segment_scalar_replacements,
+        )
+        if segment_expr_rewrite_plan is None:
+            return _unsupported_schedule("segment scalar scaffold replacement failed")
+        operand_stmt_ids = {
+            id(stmt) for _node_id, _body, _index, stmt in operand_pass_rewrite_plan
+        }
+        if any(
+            id(stmt) in operand_stmt_ids for stmt, _value in segment_expr_rewrite_plan
+        ):
+            return _unsupported_schedule("segment scalar rewrite statements overlapped")
+        _apply_owned_scalar_statement_pass_rewrite(
+            cg,
+            operand_pass_rewrite_plan,
+        )
+        _apply_owned_scalar_statement_expr_rewrite(segment_expr_rewrite_plan)
     if tcgen05_collective_handles_operand_loads:
         cute_state = df.cute_state
-        _register_collective_handled_loads(cute_state, lhs_load, rhs_load)
+        _register_collective_handled_loads(
+            cute_state,
+            lhs_info.load,
+            rhs_info.load,
+            extra_dependency_nodes=(
+                *lhs_info.collective_dependency_nodes,
+                *rhs_info.collective_dependency_nodes,
+            ),
+        )
         grid_state = cg.current_grid_state
         assert grid_state is not None
         if grid_state.has_lane_loops():
@@ -2901,7 +6088,6 @@ def _emit_mma_pipeline(
 
         assert not tcgen05_tmem_setup_emitted
         assert tcgen05_plan is not None
-        assert tcgen05_mma_owner_active is not None
         assert epi_active is not None
         tcgen05_tmem_setup_emitted = True
 
@@ -3008,14 +6194,18 @@ def _emit_mma_pipeline(
         # acquire stays in the work-tile body when the persistent loop
         # splitter runs.
         _emit_per_tile(
-            f"if {tcgen05_mma_owner_active}:\n"
-            f"    {tcgen05_plan.acc_pipeline}.producer_acquire("
-            f"{tcgen05_plan.acc_producer_state})",
+            _tcgen05_emit_optional_gate(
+                f"{tcgen05_plan.acc_pipeline}.producer_acquire("
+                f"{tcgen05_plan.acc_producer_state})",
+                tcgen05_mma_owner_active,
+                indent="",
+            ),
             mma_exec=tcgen05_use_role_local_mma_exec,
         )
         reset_accumulate_stmt = _build_tcgen05_mma_accumulate_reset_stmt(
             tcgen05_plan.exec_active,
             tiled_mma=tiled_mma,
+            gate_exec_warp=not tcgen05_use_role_local_mma_exec,
             is_two_cta=tcgen05_is_two_cta,
             cluster_n=tcgen05_cluster_n,
         )
@@ -3036,10 +6226,17 @@ def _emit_mma_pipeline(
     mma_phys_n = _mma_active_n_threads(mma_impl)
     mma_physical_m_threads = _grid_thread_extent(cg, m_block_id)
     tcgen05_cta_thread_count = _grid_cta_thread_count(cg)
+    if tcgen05_grouped_static_persistent and tcgen05_is_two_cta:
+        # Grouped CtaGroup.TWO uses the same physical role topology as the
+        # plain 2CTA path: one warp per role row. The grouped root tile can
+        # otherwise choose a narrower SIMT M axis, leaving role ids 4/5
+        # unlaunched while the generated predicates still depend on them.
+        mma_physical_m_threads = max(mma_physical_m_threads, 32)
+        tcgen05_cta_thread_count = max(tcgen05_cta_thread_count, 4 * 32)
     if mma_impl == "tcgen05" and tcgen05_cluster_m * tcgen05_cluster_n > 1:
         df.cute_state.cluster_shape = (tcgen05_cluster_m, tcgen05_cluster_n, 1)
     tcgen05_acc_stage_count_value = _tcgen05_config_int(
-        df.config, "tcgen05_acc_stages", _tcgen05_acc_stage_count(bn)
+        df.config, "tcgen05_acc_stages", _tcgen05_acc_stage_count(tcgen05_mma_bn)
     )
     # PipelineTmaUmma empty barriers are released by the leader CTA with the
     # pipeline's multicast mask. Peer CTAs still advance local consumer state,
@@ -3068,9 +6265,6 @@ def _emit_mma_pipeline(
         tcgen05_ab_consumer_arrive_count_value = num_mcast_ctas_a + num_mcast_ctas_b - 1
     else:
         tcgen05_ab_consumer_arrive_count_value = 1
-    tcgen05_c_stage_count_value = _tcgen05_config_int(
-        df.config, "tcgen05_c_stages", _tcgen05_c_stage_count(bn)
-    )
     tcgen05_defer_pipeline_sync_arg = (
         ", defer_sync=True" if tcgen05_use_cluster_deferred_pipelines else ""
     )
@@ -3094,25 +6288,58 @@ def _emit_mma_pipeline(
     tcgen05_explicit_epi_tile_m: int | None = None
     tcgen05_explicit_epi_tile_n: int | None = None
     tcgen05_explicit_d_store_box_n: int | None = None
+    tcgen05_d_store_layout = (
+        "cutlass.utils.layout.LayoutEnum.COL_MAJOR"
+        if nm_worklist
+        else "cutlass.utils.layout.LayoutEnum.ROW_MAJOR"
+    )
+    nm_explicit_store_wave = False
+    nm_scheduler_decode = False
     tcgen05_use_flat_role_coordinates = False
     if mma_impl == "tcgen05":
-        # Use ``warp_spec.ab_load_warps`` so the strategy data model
-        # stays the source of truth for warp role IDs; ``epi_warps``
-        # flows the same way via ``_tcgen05_epi_warp_count`` below.
         tcgen05_warp_spec = warp_spec_from_config(df.config)
-        # Pull swizzle overrides off the config and validate the
-        # bytes-per-row contract before constructing the matmul plan
-        # so a bad config raises ``BackendUnsupported`` here rather
-        # than silently inducing a CuTe ``ValueError`` at atom-build
-        # time. ``layout_overrides_from_config`` returns ``None`` for
-        # absent keys, which preserves the no-override byte-identity
-        # path.
+        # The public NM profile reserves its scheduler warp internally.
+        nm_scheduler_decode = (
+            nm_worklist
+            and tcgen05_nm_orientation
+            and tcgen05_grouped_static_persistent
+            and tcgen05_grouped_worklist_persistent
+            and tcgen05_grouped_dynamic_ab_tensormaps
+            and tcgen05_grouped_dynamic_d_tensormap
+            and tcgen05_cluster_m == 2
+            and tcgen05_cluster_n == 1
+            and tcgen05_warp_spec.scheduler_warps == 0
+            and tcgen05_warp_spec.c_input_warps == 0
+            and tcgen05_warp_spec.store_warps == 0
+        )
+        tcgen05_effective_scheduler_warps = (
+            1 if nm_scheduler_decode else tcgen05_warp_spec.scheduler_warps
+        )
+        # Validate overrides before CuTe constructs its layout atoms.
         _tcgen05_layout_overrides = layout_overrides_from_config(df.config)
         tcgen05_smem_swizzle_a = _tcgen05_layout_overrides.smem_swizzle_a
         tcgen05_smem_swizzle_b = _tcgen05_layout_overrides.smem_swizzle_b
         tcgen05_explicit_epi_tile_m = _tcgen05_layout_overrides.epi_tile_m
         tcgen05_explicit_epi_tile_n = _tcgen05_layout_overrides.epi_tile_n
         tcgen05_explicit_d_store_box_n = _tcgen05_layout_overrides.d_store_box_n
+        if tcgen05_nm_orientation:
+            nm_store_shape = (
+                tcgen05_explicit_epi_tile_m,
+                tcgen05_explicit_epi_tile_n,
+                tcgen05_explicit_d_store_box_n,
+            )
+            if all(value is None for value in nm_store_shape):
+                (
+                    tcgen05_explicit_epi_tile_m,
+                    tcgen05_explicit_epi_tile_n,
+                    tcgen05_explicit_d_store_box_n,
+                ) = TCGEN05_GROUPED_WORKLIST_STORE_SHAPE
+            elif nm_store_shape != TCGEN05_GROUPED_WORKLIST_STORE_SHAPE:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    "tcgen05 N,M store requires explicit epi_tile=(128, 32) "
+                    "and d_store_box_n=32",
+                )
         if tcgen05_edge_scalar_fallback_needs_inter_smem_a:
             # The mixed TMA/scalar edge path writes logical (_row, _col)
             # coordinates into the tcgen05 A SMEM view. With bk=128,
@@ -3132,8 +6359,8 @@ def _emit_mma_pipeline(
             _validate_tcgen05_smem_swizzle_override(
                 operand="a",
                 swizzle_bytes=tcgen05_smem_swizzle_a,
-                bm=bm,
-                bn=bn,
+                bm=tcgen05_mma_bm,
+                bn=tcgen05_mma_bn,
                 bk=bk,
                 input_dtype=input_dtype,
             )
@@ -3141,8 +6368,8 @@ def _emit_mma_pipeline(
             _validate_tcgen05_smem_swizzle_override(
                 operand="b",
                 swizzle_bytes=tcgen05_smem_swizzle_b,
-                bm=bm,
-                bn=bn,
+                bm=tcgen05_mma_bm,
+                bn=tcgen05_mma_bn,
                 bk=bk,
                 input_dtype=input_dtype,
             )
@@ -3169,7 +6396,7 @@ def _emit_mma_pipeline(
         # without overwriting a slower consumer's current tile.
         tcgen05_sched_stage_count_value = (
             cast("int", df.config.get(TCGEN05_SCHED_STAGE_COUNT_CONFIG_KEY, 1))
-            if tcgen05_warp_spec.scheduler_warps > 0
+            if tcgen05_effective_scheduler_warps > 0
             else 0
         )
         # Persistence model from the active config. Default
@@ -3269,6 +6496,14 @@ def _emit_mma_pipeline(
         tcgen05_tma_store_full_tiles_only = tcgen05_tma_store_full_tiles_only_for(
             tcgen05_partial_output_tma_store
         )
+        if tcgen05_grouped_tail_proof is not None:
+            if tcgen05_grouped_static_full_output_tiles_from_metadata:
+                tcgen05_tma_store_full_tiles_only = False
+            else:
+                tcgen05_tma_store_full_tiles_only = (
+                    not tcgen05_grouped_dynamic_d_tensormap
+                    or tcgen05_grouped_d_tensormap_tail_store
+                )
         explicit_epi_tile_requested = any(
             value is not None
             for value in (
@@ -3297,8 +6532,47 @@ def _emit_mma_pipeline(
         explicit_epi_tile_dtype_ok = (
             input_dtype == torch.bfloat16 and epi_elem_dtype_str == "cutlass.BFloat16"
         ) or (input_dtype == torch.float16 and epi_elem_dtype_str == "cutlass.Float16")
+        nm_explicit_store_wave = (
+            tcgen05_nm_orientation
+            and (
+                tcgen05_explicit_epi_tile_m,
+                tcgen05_explicit_epi_tile_n,
+                tcgen05_explicit_d_store_box_n,
+            )
+            == TCGEN05_GROUPED_WORKLIST_STORE_SHAPE
+        )
+        if nm_worklist:
+            nm_worklist_metadata_checks = {
+                "nm_explicit_store": nm_explicit_store_wave,
+                "dynamic_rank2_ab_tensormaps": (
+                    tcgen05_grouped_dynamic_ab_tensormap_rank == 2
+                ),
+            }
+            failed_nm_worklist_metadata_checks = [
+                name
+                for name, passed in nm_worklist_metadata_checks.items()
+                if not passed
+            ]
+            if failed_nm_worklist_metadata_checks:
+                raise exc.BackendUnsupported(
+                    "cute",
+                    f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}="
+                    f"{TCGEN05_GROUPED_MODE_WORKLIST_NM!r} is validated "
+                    "only for the BF16 N,M-oriented explicit-store "
+                    "worklist route with rank-2 dynamic A/B TensorMaps; "
+                    "failed checks: " + ", ".join(failed_nm_worklist_metadata_checks),
+                )
         if explicit_epi_tile_requested:
-            if not (
+            if nm_explicit_store_wave:
+                if aux_tensor_descriptors_value:
+                    raise exc.BackendUnsupported(
+                        "cute",
+                        "tcgen05 N,M-oriented explicit store is validated only "
+                        "for the BF16 grouped worklist TMA-store "
+                        "path with block_m=256, block_n=128, block_k=64, "
+                        "CtaGroup.TWO, and no auxiliary epilogue tensors",
+                    )
+            elif not (
                 tcgen05_static_full_tiles
                 and tcgen05_is_two_cta
                 and bm == TCGEN05_TWO_CTA_BLOCK_M
@@ -3314,10 +6588,14 @@ def _emit_mma_pipeline(
                     "envelope)",
                 )
             if (
-                tcgen05_explicit_epi_tile_m,
-                tcgen05_explicit_epi_tile_n,
-                tcgen05_explicit_d_store_box_n,
-            ) != _TCGEN05_EXPLICIT_EPI_TILE_VALIDATED_SHAPE:
+                not nm_explicit_store_wave
+                and (
+                    tcgen05_explicit_epi_tile_m,
+                    tcgen05_explicit_epi_tile_n,
+                    tcgen05_explicit_d_store_box_n,
+                )
+                != _TCGEN05_EXPLICIT_EPI_TILE_VALIDATED_SHAPE
+            ):
                 raise exc.BackendUnsupported(
                     "cute",
                     "explicit tcgen05 epilogue tile is currently validated only "
@@ -3359,12 +6637,12 @@ def _emit_mma_pipeline(
                     "CtaGroup.TWO 256x256 bk in {64,128} explicit-epilogue-tile "
                     "path",
                 )
-        tcgen05_scheduler_warp_count_for_plan = tcgen05_warp_spec.scheduler_warps
+        tcgen05_scheduler_warp_count_for_plan = tcgen05_effective_scheduler_warps
         tcgen05_sched_stage_count_for_plan = tcgen05_sched_stage_count_value
         tcgen05_persistence_model_for_plan = tcgen05_persistence_model_str
         tcgen05_matmul_plan = CuteTcgen05MatmulPlan(
-            bm=bm,
-            bn=bn,
+            bm=tcgen05_mma_bm,
+            bn=tcgen05_mma_bn,
             bk=bk,
             k_tile_count=(k_total_size + bk - 1) // bk,
             cluster_m=tcgen05_cluster_m,
@@ -3403,12 +6681,13 @@ def _emit_mma_pipeline(
             flat_role_launch_warp_count=8
             if tcgen05_use_flat_role_coordinates
             else None,
+            grouped=tcgen05_grouped_plan,
         )
         assert tcgen05_plan is not None
         tcgen05_mma_owner_active = _tcgen05_two_cta_owner_predicate(
             tcgen05_plan.exec_active,
             is_two_cta=tcgen05_is_two_cta,
-            gate_exec_warp=True,
+            gate_exec_warp=not tcgen05_use_role_local_mma_exec,
             cluster_n=tcgen05_cluster_n,
         )
         candidate_block_shape = tcgen05_matmul_plan.block_shape
@@ -3678,8 +6957,8 @@ def _emit_mma_pipeline(
                     mma_slice_linear,
                     input_dtype_str,
                     acc_dtype_str,
-                    bm,
-                    bn,
+                    tcgen05_mma_bm,
+                    tcgen05_mma_bn,
                     tcgen05_cluster_m=tcgen05_cluster_m,
                     b_k_major=tcgen05_b_k_major,
                     tcgen05_use_2cta_instrs=tcgen05_is_two_cta,
@@ -3706,7 +6985,6 @@ def _emit_mma_pipeline(
             )
     if mma_impl == "tcgen05":
         assert tcgen05_plan is not None
-        assert tcgen05_mma_owner_active is not None
         prefix.append(
             statement_from_string(
                 f"{tcgen05_cluster_layout_vmnk} = cute.tiled_divide("
@@ -3718,8 +6996,8 @@ def _emit_mma_pipeline(
             _make_tcgen05_layout_plan_setup(
                 tcgen05_plan,
                 tiled_mma,
-                bm=bm,
-                bn=bn,
+                bm=tcgen05_mma_bm,
+                bn=tcgen05_mma_bn,
                 bk=bk,
                 ab_stage_count=tcgen05_ab_stage_count_value,
                 is_two_cta=tcgen05_is_two_cta,
@@ -3730,13 +7008,16 @@ def _emit_mma_pipeline(
                 smem_swizzle_b=tcgen05_smem_swizzle_b,
                 explicit_epi_tile_m=tcgen05_explicit_epi_tile_m,
                 explicit_epi_tile_n=tcgen05_explicit_epi_tile_n,
+                nm_explicit_store_wave=nm_explicit_store_wave,
                 b_k_major=tcgen05_b_k_major,
+                c_layout=tcgen05_d_store_layout,
             )
         )
         prefix.append(
             statement_from_string(
                 f"{acc_frag_base} = {tiled_mma}.make_fragment_C("
-                f"cute.append({tiled_mma}.partition_shape_C(({bm}, {bn})), "
+                f"cute.append({tiled_mma}.partition_shape_C("
+                f"({tcgen05_mma_bm}, {tcgen05_mma_bn})), "
                 f"{tcgen05_acc_stage_count_value}))"
             )
         )
@@ -4207,10 +7488,20 @@ def _emit_mma_pipeline(
     tma_store_atom = (
         df.new_var("tcgen05_tma_store_atom") if tcgen05_use_tma_store_epilogue else ""
     )
+    tail_tma_store_atom = (
+        df.new_var("tcgen05_tail_tma_store_atom")
+        if tcgen05_use_tma_store_epilogue and tcgen05_grouped_d_tensormap_tail_store
+        else ""
+    )
     tma_tensor_a = df.new_var("tma_tensor_a")
     tma_tensor_b = df.new_var("tma_tensor_b")
     tma_store_tensor = (
         df.new_var("tcgen05_tma_store_tensor") if tcgen05_use_tma_store_epilogue else ""
+    )
+    tail_tma_store_tensor = (
+        df.new_var("tcgen05_tail_tma_store_tensor")
+        if tcgen05_use_tma_store_epilogue and tcgen05_grouped_d_tensormap_tail_store
+        else ""
     )
     tma_cta_layout = df.new_var("tma_cta_layout")
     tma_a_cta_layout = df.new_var("tma_a_cta_layout")
@@ -4227,7 +7518,20 @@ def _emit_mma_pipeline(
     tma_next_full_tile = df.new_var("tcgen05_tma_next_full_tile")
     tma_next_consumer_tile = df.new_var("tcgen05_tma_next_consumer_tile")
 
-    def _tcgen05_tma_output_tile_predicate() -> str:
+    def _tcgen05_tma_output_tile_predicate() -> str | None:
+        if tcgen05_grouped_dynamic_ab_tensormaps:
+            if tcgen05_grouped_static_full_output_tiles_from_metadata:
+                return None
+            predicate_m_tile = tcgen05_source_bm
+            predicate_n_tile = tcgen05_source_bn
+            return (
+                f"{tcgen05_grouped_cta_tile_idx_m} * "
+                f"cutlass.Int32({predicate_m_tile}) "
+                f"< {tcgen05_grouped_problem_m} "
+                f"and {tcgen05_grouped_cta_tile_idx_n} * "
+                f"cutlass.Int32({predicate_n_tile}) "
+                f"< {tcgen05_grouped_problem_n} "
+            )
         if tcgen05_role_local_double_edge_tma:
             # The role-local double-edge path lets TMA handle both partial AB
             # stripes while the SIMT epilogue predicates aux loads and stores.
@@ -4254,23 +7558,33 @@ def _emit_mma_pipeline(
             f"and {n_offset_var} + cutlass.Int32({bn}) <= cutlass.Int32({n_size}) "
         )
 
+    grouped_plan = tcgen05_grouped_plan
+    tcgen05_k_bound_expr: str = (
+        cast("str", tcgen05_grouped_problem_k)
+        if tcgen05_grouped_k_mask is not None
+        else f"cutlass.Int32({k_total_size})"
+    )
+
     def _tcgen05_tma_k_tile_predicate(
         *, k_tile_start_expr: str, full_tile_end_expr: str
     ) -> str:
-        if tcgen05_role_local_uses_k_tail_tma:
-            return f"{k_tile_start_expr} < cutlass.Int32({k_total_size})"
-        return f"{full_tile_end_expr} <= cutlass.Int32({k_total_size})"
+        if tcgen05_role_local_uses_k_tail_tma or tcgen05_grouped_dynamic_ab_tensormaps:
+            return f"{k_tile_start_expr} < {tcgen05_k_bound_expr}"
+        return f"{full_tile_end_expr} <= {tcgen05_k_bound_expr}"
 
     def _tcgen05_tma_tile_predicate(
         *, k_tile_start_expr: str, full_tile_end_expr: str
     ) -> str:
-        return (
-            _tcgen05_tma_output_tile_predicate()
-            + "and "
-            + _tcgen05_tma_k_tile_predicate(
-                k_tile_start_expr=k_tile_start_expr,
-                full_tile_end_expr=full_tile_end_expr,
+        return " and ".join(
+            predicate
+            for predicate in (
+                _tcgen05_tma_output_tile_predicate(),
+                _tcgen05_tma_k_tile_predicate(
+                    k_tile_start_expr=k_tile_start_expr,
+                    full_tile_end_expr=full_tile_end_expr,
+                ),
             )
+            if predicate
         )
 
     tma_k_tile = df.new_var("tcgen05_tma_k_tile")
@@ -4282,6 +7596,158 @@ def _emit_mma_pipeline(
     tma_a_mcast_mask = df.new_var("tcgen05_a_mcast_mask")
     tma_b_mcast_mask = df.new_var("tcgen05_b_mcast_mask")
     tcgen05_use_tma_b_mcast_mask = False
+    grouped_tensormap_manager = df.new_var("tcgen05_grouped_tensormap_manager")
+    grouped_tensormap_grid_dim = df.new_var("tcgen05_grouped_tensormap_grid_dim")
+    grouped_tensormap_workspace_idx = df.new_var(
+        "tcgen05_grouped_tensormap_workspace_idx"
+    )
+    grouped_tensormap_a_ptr = df.new_var("tcgen05_grouped_tensormap_a_ptr")
+    grouped_tensormap_b_ptr = df.new_var("tcgen05_grouped_tensormap_b_ptr")
+    grouped_tensormap_a_desc_ptr = df.new_var("tcgen05_grouped_tensormap_a_desc_ptr")
+    grouped_tensormap_b_desc_ptr = df.new_var("tcgen05_grouped_tensormap_b_desc_ptr")
+    grouped_tensormap_smem_ptr = df.new_var("tcgen05_grouped_tensormap_smem_ptr")
+    grouped_tensormap_a_smem_ptr = df.new_var("tcgen05_grouped_tensormap_a_smem_ptr")
+    grouped_tensormap_b_smem_ptr = df.new_var("tcgen05_grouped_tensormap_b_smem_ptr")
+    grouped_tensormap_init_done = df.new_var("tcgen05_grouped_tensormap_init_done")
+    grouped_tensormap_last_group = df.new_var("tcgen05_grouped_tensormap_last_group")
+    grouped_tensormap_group_changed = df.new_var(
+        "tcgen05_grouped_tensormap_group_changed"
+    )
+    grouped_tensormap_a_base = df.new_var("tcgen05_grouped_tensormap_a_base")
+    grouped_tensormap_b_base = df.new_var("tcgen05_grouped_tensormap_b_base")
+    grouped_tensormap_a_addr = df.new_var("tcgen05_grouped_tensormap_a_addr")
+    grouped_tensormap_b_addr = df.new_var("tcgen05_grouped_tensormap_b_addr")
+    grouped_tensormap_a_stride_m = df.new_var("tcgen05_grouped_tensormap_a_stride_m")
+    grouped_tensormap_a_stride_k = df.new_var("tcgen05_grouped_tensormap_a_stride_k")
+    grouped_tensormap_b_stride_n = df.new_var("tcgen05_grouped_tensormap_b_stride_n")
+    grouped_tensormap_b_stride_k = df.new_var("tcgen05_grouped_tensormap_b_stride_k")
+    grouped_tensormap_real_a = df.new_var("tcgen05_grouped_tensormap_real_a")
+    grouped_tensormap_real_b = df.new_var("tcgen05_grouped_tensormap_real_b")
+    grouped_tensormap_index_dtype = env.index_type()
+
+    def _grouped_dynamic_ab_shape_expr(outer_dim: str, k_dim: str) -> str:
+        if tcgen05_grouped_dynamic_ab_tensormap_rank == 2:
+            return f"({outer_dim}, {k_dim})"
+        return f"({outer_dim}, {k_dim}, cutlass.Int32(1))"
+
+    def _grouped_dynamic_ab_stride_expr(outer_stride: str, k_stride: str) -> str:
+        if tcgen05_grouped_dynamic_ab_tensormap_rank == 2:
+            return f"({outer_stride}, {k_stride})"
+        return f"({outer_stride}, {k_stride}, cutlass.Int32(0))"
+
+    def _grouped_direct_metadata_load(
+        tensor_name: str,
+        *indices: str | int,
+    ) -> str:
+        offset_terms = [
+            f"{grouped_tensormap_index_dtype}({index}) * "
+            f"{grouped_tensormap_index_dtype}({tensor_name}.layout.stride[{dim}])"
+            for dim, index in enumerate(indices)
+        ]
+        return f"({tensor_name}.iterator + {' + '.join(offset_terms)}).load()"
+
+    grouped_tensormap_a_base_expr = (
+        (
+            f"cute.make_ptr({input_dtype_str}, "
+            f"cutlass.Int64({grouped_tensormap_a_addr}), cute.AddressSpace.gmem)"
+        )
+        if tcgen05_grouped_direct_pointer_metadata
+        else (
+            f"{rhs_arg_name}.iterator + "
+            f"{grouped_tensormap_index_dtype}({tcgen05_grouped_group_idx}) * "
+            f"{grouped_tensormap_index_dtype}({rhs_arg_name}.layout.stride[0])"
+            if tcgen05_nm_orientation
+            else f"{lhs_arg_name}.iterator + "
+            f"{grouped_tensormap_index_dtype}({tcgen05_grouped_global_m_start}) * "
+            f"{grouped_tensormap_index_dtype}({lhs_arg_name}.layout.stride[0])"
+        )
+    )
+    grouped_tensormap_b_base_expr = (
+        (
+            f"cute.make_ptr({input_dtype_str}, "
+            f"cutlass.Int64({grouped_tensormap_b_addr}), cute.AddressSpace.gmem)"
+        )
+        if tcgen05_grouped_direct_pointer_metadata
+        else (
+            f"{lhs_arg_name}.iterator + "
+            f"{grouped_tensormap_index_dtype}({tcgen05_grouped_global_m_start}) * "
+            f"{grouped_tensormap_index_dtype}({lhs_arg_name}.layout.stride[0])"
+            if tcgen05_nm_orientation
+            else f"{rhs_arg_name}.iterator + "
+            f"{grouped_tensormap_index_dtype}({tcgen05_grouped_group_idx}) * "
+            f"{grouped_tensormap_index_dtype}({rhs_arg_name}.layout.stride[0])"
+        )
+    )
+    if grouped_plan is not None:
+        grouped_tensormap_real_a_shape_expr = _grouped_dynamic_ab_shape_expr(
+            grouped_plan.problem_n
+            if tcgen05_nm_orientation
+            else grouped_plan.problem_m,
+            grouped_plan.problem_k,
+        )
+        grouped_tensormap_real_b_shape_expr = _grouped_dynamic_ab_shape_expr(
+            grouped_plan.problem_m
+            if tcgen05_nm_orientation
+            else grouped_plan.problem_n,
+            grouped_plan.problem_k,
+        )
+        grouped_tensormap_real_a_stride_expr = (
+            _grouped_dynamic_ab_stride_expr(
+                grouped_tensormap_a_stride_m,
+                grouped_tensormap_a_stride_k,
+            )
+            if grouped_plan.direct_pointers is not None
+            else _grouped_dynamic_ab_stride_expr(
+                f"{rhs_arg_name}.layout.stride[1]"
+                if tcgen05_nm_orientation
+                else f"{lhs_arg_name}.layout.stride[0]",
+                f"{rhs_arg_name}.layout.stride[2]"
+                if tcgen05_nm_orientation
+                else f"{lhs_arg_name}.layout.stride[1]",
+            )
+        )
+        grouped_tensormap_real_b_stride_expr = (
+            _grouped_dynamic_ab_stride_expr(
+                grouped_tensormap_b_stride_n,
+                grouped_tensormap_b_stride_k,
+            )
+            if grouped_plan.direct_pointers is not None
+            else _grouped_dynamic_ab_stride_expr(
+                f"{lhs_arg_name}.layout.stride[0]"
+                if tcgen05_nm_orientation
+                else f"{rhs_arg_name}.layout.stride[1]",
+                f"{lhs_arg_name}.layout.stride[1]"
+                if tcgen05_nm_orientation
+                else f"{rhs_arg_name}.layout.stride[2]",
+            )
+        )
+        if (
+            grouped_plan.direct_pointers is not None
+            and grouped_plan.direct_strides is not None
+        ):
+            direct_idx = grouped_plan.metadata_idx or grouped_plan.group_idx
+            grouped_tensormap_direct_loads = (
+                f"    {grouped_tensormap_a_addr} = "
+                f"{_grouped_direct_metadata_load(grouped_plan.direct_pointers, direct_idx, 0)}\n"
+                f"    {grouped_tensormap_b_addr} = "
+                f"{_grouped_direct_metadata_load(grouped_plan.direct_pointers, direct_idx, 1)}\n"
+                f"    {grouped_tensormap_a_stride_m} = "
+                f"{_grouped_direct_metadata_load(grouped_plan.direct_strides, direct_idx, 0, 0)}\n"
+                f"    {grouped_tensormap_a_stride_k} = "
+                f"{_grouped_direct_metadata_load(grouped_plan.direct_strides, direct_idx, 0, 1)}\n"
+                f"    {grouped_tensormap_b_stride_n} = "
+                f"{_grouped_direct_metadata_load(grouped_plan.direct_strides, direct_idx, 1, 0)}\n"
+                f"    {grouped_tensormap_b_stride_k} = "
+                f"{_grouped_direct_metadata_load(grouped_plan.direct_strides, direct_idx, 1, 1)}\n"
+            )
+        else:
+            grouped_tensormap_direct_loads = ""
+    else:
+        grouped_tensormap_real_a_shape_expr = ""
+        grouped_tensormap_real_b_shape_expr = ""
+        grouped_tensormap_real_a_stride_expr = ""
+        grouped_tensormap_real_b_stride_expr = ""
+        grouped_tensormap_direct_loads = ""
     tma_pipeline_mbars = df.new_var("tcgen05_ab_pipeline_mbars")
     tma_pipeline_producer_group = df.new_var("tcgen05_ab_pipeline_producer_group")
     tma_pipeline_consumer_group = df.new_var("tcgen05_ab_pipeline_consumer_group")
@@ -4289,9 +7755,14 @@ def _emit_mma_pipeline(
     tma_pipeline = df.new_var("tcgen05_ab_pipeline")
     tma_producer_state = df.new_var("tcgen05_ab_producer_state")
     tma_consumer_state = df.new_var("tcgen05_ab_consumer_state")
+    tcgen05_use_tma_store_role_tile_counter = (
+        tcgen05_use_tma_store_epilogue
+        and tcgen05_use_role_local_tma_producer
+        and _tcgen05_pid_initializes_epi_role_tile_counter(df.pid)
+    )
     tma_store_role_tile_counter = (
         df.new_var("tcgen05_tma_store_role_tile")
-        if tcgen05_use_tma_store_epilogue and tcgen05_use_role_local_tma_producer
+        if tcgen05_use_tma_store_role_tile_counter
         else ""
     )
     tcgen05_frag_a = df.new_var("tcgen05_tCrA")
@@ -4311,32 +7782,192 @@ def _emit_mma_pipeline(
             # tensor arguments on the host even when device DCE sees no scalar
             # fallback references to those tensors.
             df.placeholder_args.update((lhs_arg_name, rhs_arg_name))
+            if grouped_plan is not None:
+                df.placeholder_args.add(grouped_plan.layout)
+                if tcgen05_grouped_n_sizes_arg_name:
+                    df.placeholder_args.add(tcgen05_grouped_n_sizes_arg_name)
+                if tcgen05_grouped_k_sizes_arg_name:
+                    df.placeholder_args.add(tcgen05_grouped_k_sizes_arg_name)
+                if (
+                    tcgen05_grouped_direct_pointer_metadata
+                    and tcgen05_grouped_external_direct_pointers_arg_name is not None
+                    and tcgen05_grouped_external_direct_strides_arg_name is not None
+                ):
+                    _register_tensor_arg_by_host_name(
+                        df,
+                        tcgen05_grouped_external_direct_pointers_arg_name,
+                    )
+                    _register_tensor_arg_by_host_name(
+                        df,
+                        tcgen05_grouped_external_direct_strides_arg_name,
+                    )
+                    df.placeholder_args.update(
+                        (
+                            tcgen05_grouped_external_direct_pointers_arg_name,
+                            tcgen05_grouped_external_direct_strides_arg_name,
+                        )
+                    )
+                grouped_wrapper_params: list[str] = [
+                    grouped_plan.problem_sizes,
+                    grouped_plan.starts,
+                ]
+                if grouped_plan.real_groups is not None:
+                    grouped_wrapper_params.append(grouped_plan.real_groups)
+                if tcgen05_grouped_ab_tensormaps is not None:
+                    grouped_wrapper_params.append(tcgen05_grouped_ab_tensormaps)
+                elif grouped_plan.d_tensormap is not None:
+                    grouped_wrapper_params.append(grouped_plan.d_tensormap)
+                if (
+                    grouped_plan.direct_pointers is not None
+                    and grouped_plan.direct_strides is not None
+                ):
+                    grouped_wrapper_params.extend(
+                        [
+                            grouped_plan.direct_pointers,
+                            grouped_plan.direct_strides,
+                        ]
+                    )
+                grouped_wrapper_params.append(grouped_plan.sched_params)
+                df.wrapper_only_params.extend(grouped_wrapper_params)
+                cg.cute_wrapper_plans.append(
+                    {
+                        "kind": "tcgen05_grouped_static_persistent",
+                        "layout_name": grouped_plan.layout,
+                        **(
+                            {"n_sizes_name": tcgen05_grouped_n_sizes_arg_name}
+                            if tcgen05_grouped_n_sizes_arg_name
+                            else {}
+                        ),
+                        **(
+                            {"k_sizes_name": tcgen05_grouped_k_sizes_arg_name}
+                            if tcgen05_grouped_k_sizes_arg_name
+                            else {}
+                        ),
+                        "m_tail_preserve": bool(
+                            tcgen05_grouped_tail_proof is not None
+                            and tcgen05_grouped_tail_proof.has_m_tail_mask
+                        ),
+                        "n_tail_preserve": bool(
+                            tcgen05_grouped_tail_proof is not None
+                            and tcgen05_grouped_tail_proof.has_n_tail_mask
+                        ),
+                        **(
+                            {
+                                "grouped_static_has_m_tail": (
+                                    tcgen05_grouped_actual_has_m_tail
+                                ),
+                                "grouped_static_has_n_tail": (
+                                    tcgen05_grouped_actual_has_n_tail
+                                ),
+                            }
+                            if tcgen05_grouped_actual_has_n_tail is not None
+                            else {}
+                        ),
+                        "group_count": int(grouped_plan.count),
+                        "bm": bm,
+                        "bn": bn,
+                        "bk": bk,
+                        "cluster_m": tcgen05_cluster_m,
+                        "cluster_n": tcgen05_cluster_n,
+                        **(
+                            {
+                                TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY: (
+                                    tcgen05_grouped_static_reserved_sms
+                                )
+                            }
+                            if tcgen05_grouped_static_reserved_sms
+                            else {}
+                        ),
+                        "n_size": n_size,
+                        "k_total_size": k_total_size,
+                        "problem_sizes_arg": grouped_plan.problem_sizes,
+                        "starts_arg": grouped_plan.starts,
+                        **(
+                            {"real_groups_arg": grouped_plan.real_groups}
+                            if grouped_plan.real_groups is not None
+                            else {}
+                        ),
+                        "sched_params_arg": grouped_plan.sched_params,
+                        "total_clusters_arg": tcgen05_grouped_total_clusters,
+                        **({"orientation": "nm"} if nm_worklist else {}),
+                        **(
+                            {"worklist_metadata": True}
+                            if tcgen05_grouped_worklist_persistent
+                            else {}
+                        ),
+                        **(
+                            {
+                                "dynamic_ab_tensormaps": True,
+                                "ab_tensormaps_arg": tcgen05_grouped_ab_tensormaps,
+                                "lhs_name": lhs_arg_name,
+                                "rhs_name": rhs_arg_name,
+                                **(
+                                    {"dynamic_ab_tensormap_rank": 2}
+                                    if tcgen05_grouped_dynamic_ab_tensormap_rank == 2
+                                    else {}
+                                ),
+                            }
+                            if tcgen05_grouped_dynamic_ab_tensormaps
+                            else {}
+                        ),
+                        **(
+                            {
+                                "direct_pointer_metadata": True,
+                                "direct_pointers_arg": grouped_plan.direct_pointers,
+                                "direct_strides_arg": grouped_plan.direct_strides,
+                                **(
+                                    {
+                                        "external_direct_pointer_metadata": True,
+                                        "direct_pointers_name": (
+                                            tcgen05_grouped_external_direct_pointers_arg_name
+                                        ),
+                                        "direct_strides_name": (
+                                            tcgen05_grouped_external_direct_strides_arg_name
+                                        ),
+                                    }
+                                    if tcgen05_grouped_external_direct_pointers_arg_name
+                                    is not None
+                                    and tcgen05_grouped_external_direct_strides_arg_name
+                                    is not None
+                                    else {}
+                                ),
+                            }
+                            if tcgen05_grouped_direct_pointer_metadata
+                            else {}
+                        ),
+                        **(
+                            {
+                                "dynamic_d_tensormap": True,
+                                "d_tensormaps_arg": grouped_plan.d_tensormap,
+                            }
+                            if tcgen05_grouped_dynamic_d_tensormap
+                            else {}
+                        ),
+                    }
+                )
             df.wrapper_only_params.extend(
                 [tma_atom_a, tma_tensor_a, tma_atom_b, tma_tensor_b]
             )
             ab_tma_plan: dict[str, object] = {
                 "kind": "tcgen05_ab_tma",
-                "lhs_name": lhs_arg_name,
-                "rhs_name": rhs_arg_name,
-                "bm": bm,
-                "bn": bn,
+                "lhs_name": (rhs_arg_name if tcgen05_nm_orientation else lhs_arg_name),
+                "rhs_name": (lhs_arg_name if tcgen05_nm_orientation else rhs_arg_name),
+                "bm": tcgen05_mma_bm,
+                "bn": tcgen05_mma_bn,
                 "bk": bk,
                 "cluster_m": tcgen05_cluster_m,
                 "cluster_n": tcgen05_cluster_n,
                 "ab_stage_count": tcgen05_ab_stage_count_value,
                 "input_dtype": input_dtype_str,
                 "acc_dtype": acc_dtype_str,
-                # B1 (cycle-3 review): plumb the validated problem
-                # shape onto the AB plan so the direct-entry plan can
-                # carry an envelope identity that the runtime
-                # validator dispatches on. T4 and T5 share ``bk=128``,
-                # so the bk-keyed shape-set alone cannot distinguish
-                # a T4 plan from a T5 plan when both are admitted.
+                # The direct-entry validator also keys on the problem shape.
                 "m_size": m_size,
                 "n_size": n_size,
                 "k_total_size": k_total_size,
                 "kernel_args": [tma_atom_a, tma_tensor_a, tma_atom_b, tma_tensor_b],
             }
+            if nm_worklist:
+                ab_tma_plan["orientation"] = "nm"
             # The bm=128 CtaGroup.TWO family cannot be derived from
             # ``bm == 256`` by the host wrapper, so record the resolved 2-CTA
             # decision on the plan. Only recorded for this family (where the
@@ -4344,13 +7975,20 @@ def _emit_mma_pipeline(
             # bm=256 path leaves the key absent so its golden wrapper-plan
             # literal stays byte-identical and the wrapper falls back to the
             # derivation. See ``_tcgen05_use_2cta_instrs``.
-            if tcgen05_is_two_cta and bm != TCGEN05_TWO_CTA_BLOCK_M:
+            if tcgen05_is_two_cta and tcgen05_mma_bm != TCGEN05_TWO_CTA_BLOCK_M:
                 ab_tma_plan["use_2cta_instrs"] = True
             # K-major (column-major / K-contiguous) B. Only recorded when True
             # so MN-major (row-major B) wrapper-plan literals stay byte-identical
             # to the golden.
             if tcgen05_b_k_major:
                 ab_tma_plan["b_k_major"] = True
+            if rhs_rank3_group_expr is not None:
+                grouped_operand = "lhs" if tcgen05_nm_orientation else "rhs"
+                ab_tma_plan[f"{grouped_operand}_rank3_grouped_nt"] = True
+            if tcgen05_grouped_dynamic_ab_tensormaps:
+                ab_tma_plan["dynamic_ab_tensormaps"] = True
+                if tcgen05_grouped_dynamic_ab_tensormap_rank == 2:
+                    ab_tma_plan["dynamic_ab_tensormap_rank"] = 2
             if lhs_operand.is_leading_passthrough:
                 ab_tma_plan["lhs_leading_passthrough"] = True
             if rhs_operand.is_leading_passthrough:
@@ -4381,6 +8019,32 @@ def _emit_mma_pipeline(
             if tcgen05_matmul_plan.is_clc_persistent:
                 ab_tma_plan["use_pdl"] = True
             cg.cute_wrapper_plans.append(ab_tma_plan)
+            if (
+                tcgen05_grouped_static_persistent
+                and tcgen05_grouped_dynamic_ab_tensormaps
+            ):
+                assert tma_warp is not None
+                assert warp_idx is not None
+                prefix.append(
+                    statement_from_string(
+                        f"if {tma_warp}:\n"
+                        f"    cute.nvgpu.cpasync.prefetch_descriptor({tma_atom_a})\n"
+                        f"    cute.nvgpu.cpasync.prefetch_descriptor({tma_atom_b})"
+                    )
+                )
+                if tcgen05_use_tma_store_epilogue:
+                    grouped_d_prefetch_atoms = [tma_store_atom]
+                    if tail_tma_store_atom:
+                        grouped_d_prefetch_atoms.append(tail_tma_store_atom)
+                    prefix.append(
+                        statement_from_string(
+                            f"if {warp_idx} == cutlass.Int32(0):\n"
+                            + "\n".join(
+                                f"    cute.nvgpu.cpasync.prefetch_descriptor({atom})"
+                                for atom in grouped_d_prefetch_atoms
+                            )
+                        )
+                    )
         prefix.append(
             statement_from_string(
                 f"{smem_a_ptr} = cute.arch.alloc_smem("
@@ -4438,36 +8102,187 @@ def _emit_mma_pipeline(
                     f"{tma_thr_mma} = {tiled_mma}.get_slice({tma_thr_mma_slice})"
                 )
             )
+            if tcgen05_grouped_dynamic_ab_tensormaps:
+                prefix.extend(
+                    [
+                        statement_from_string(
+                            f"{grouped_tensormap_manager} = "
+                            "cutlass.utils.TensorMapManager("
+                            "cutlass.utils.TensorMapUpdateMode.SMEM, 128)"
+                        ),
+                        statement_from_string(
+                            f"{grouped_tensormap_grid_dim} = cute.arch.grid_dim()"
+                        ),
+                        statement_from_string(
+                            f"{grouped_tensormap_workspace_idx} = ("
+                            f"cute.arch.block_idx()[2] * "
+                            f"{grouped_tensormap_grid_dim}[1] * "
+                            f"{grouped_tensormap_grid_dim}[0] + "
+                            f"cute.arch.block_idx()[1] * "
+                            f"{grouped_tensormap_grid_dim}[0] + "
+                            "cute.arch.block_idx()[0])"
+                        ),
+                        statement_from_string(
+                            f"{grouped_tensormap_a_ptr} = "
+                            f"{grouped_tensormap_manager}.get_tensormap_ptr("
+                            f"{tcgen05_grouped_ab_tensormaps}"
+                            f"[({grouped_tensormap_workspace_idx}, 0, None)].iterator)"
+                        ),
+                        statement_from_string(
+                            f"{grouped_tensormap_b_ptr} = "
+                            f"{grouped_tensormap_manager}.get_tensormap_ptr("
+                            f"{tcgen05_grouped_ab_tensormaps}"
+                            f"[({grouped_tensormap_workspace_idx}, 1, None)].iterator)"
+                        ),
+                        statement_from_string(
+                            f"{grouped_tensormap_a_desc_ptr} = "
+                            f"{grouped_tensormap_manager}.get_tensormap_ptr("
+                            f"{grouped_tensormap_a_ptr}, cute.AddressSpace.generic)"
+                        ),
+                        statement_from_string(
+                            f"{grouped_tensormap_b_desc_ptr} = "
+                            f"{grouped_tensormap_manager}.get_tensormap_ptr("
+                            f"{grouped_tensormap_b_ptr}, cute.AddressSpace.generic)"
+                        ),
+                        statement_from_string(
+                            f"{grouped_tensormap_smem_ptr} = "
+                            "cute.arch.alloc_smem(cutlass.Int64, "
+                            "cutlass.Int32(32), alignment=128)"
+                        ),
+                        statement_from_string(
+                            f"{grouped_tensormap_a_smem_ptr} = "
+                            f"{grouped_tensormap_smem_ptr}"
+                        ),
+                        statement_from_string(
+                            f"{grouped_tensormap_b_smem_ptr} = "
+                            f"{grouped_tensormap_a_smem_ptr} + 16"
+                        ),
+                        statement_from_string(
+                            f"{grouped_tensormap_init_done} = cutlass.Boolean(False)"
+                        ),
+                        statement_from_string(
+                            f"{grouped_tensormap_last_group} = cutlass.Int32(-1)"
+                        ),
+                    ]
+                )
             # gA, gB depend on per-tile (m_offset_var, n_offset_var). Their
             # downstream partitions and tma_partition outputs all inherit
             # that per-tile dependency, so all of these stay inside the
             # work-tile body when the persistent loop splitter runs.
+            for setup_stmt in rhs_rank3_tma_group_setup:
+                _emit_per_tile(
+                    setup_stmt,
+                    tma_load=tcgen05_use_role_local_tma_producer,
+                )
+            if tcgen05_grouped_dynamic_ab_tensormaps:
+                grouped_tensormap_update_idx = (
+                    tcgen05_grouped_metadata_idx or tcgen05_grouped_group_idx
+                )
+                _emit_per_tile(
+                    (
+                        f"{grouped_tensormap_group_changed} = "
+                        f"{grouped_tensormap_update_idx} != "
+                        f"{grouped_tensormap_last_group}"
+                    ),
+                    tma_load=tcgen05_use_role_local_tma_producer,
+                )
+                _emit_per_tile(
+                    (
+                        f"if {grouped_tensormap_group_changed}:\n"
+                        f"    if not {grouped_tensormap_init_done}:\n"
+                        f"        {grouped_tensormap_manager}.init_tensormap_from_atom("
+                        f"{tma_atom_a}, {grouped_tensormap_a_smem_ptr}, "
+                        f"{tcgen05_matmul_plan.tma_warp_id})\n"
+                        f"        {grouped_tensormap_manager}.init_tensormap_from_atom("
+                        f"{tma_atom_b}, {grouped_tensormap_b_smem_ptr}, "
+                        f"{tcgen05_matmul_plan.tma_warp_id})\n"
+                        f"        {grouped_tensormap_manager}.fence_tensormap_initialization()\n"
+                        f"        {grouped_tensormap_init_done} = cutlass.Boolean(True)\n"
+                        f"{grouped_tensormap_direct_loads}"
+                        f"    {grouped_tensormap_a_base} = "
+                        f"{grouped_tensormap_a_base_expr}\n"
+                        f"    {grouped_tensormap_b_base} = "
+                        f"{grouped_tensormap_b_base_expr}\n"
+                        f"    {grouped_tensormap_real_a} = cute.make_tensor("
+                        f"{grouped_tensormap_a_base}, "
+                        "cute.make_layout("
+                        f"{grouped_tensormap_real_a_shape_expr}, "
+                        f"stride={grouped_tensormap_real_a_stride_expr}))\n"
+                        f"    {grouped_tensormap_real_b} = cute.make_tensor("
+                        f"{grouped_tensormap_b_base}, "
+                        "cute.make_layout("
+                        f"{grouped_tensormap_real_b_shape_expr}, "
+                        f"stride={grouped_tensormap_real_b_stride_expr}))\n"
+                        f"    {grouped_tensormap_manager}.update_tensormap("
+                        f"({grouped_tensormap_real_a}, {grouped_tensormap_real_b}), "
+                        f"({tma_atom_a}, {tma_atom_b}), "
+                        f"({grouped_tensormap_a_ptr}, {grouped_tensormap_b_ptr}), "
+                        f"{tcgen05_matmul_plan.tma_warp_id}, "
+                        f"({grouped_tensormap_a_smem_ptr}, "
+                        f"{grouped_tensormap_b_smem_ptr}))\n"
+                        f"    {grouped_tensormap_manager}.fence_tensormap_update("
+                        f"{grouped_tensormap_a_ptr})\n"
+                        f"    {grouped_tensormap_manager}.fence_tensormap_update("
+                        f"{grouped_tensormap_b_ptr})\n"
+                        f"    {grouped_tensormap_last_group} = "
+                        f"{grouped_tensormap_update_idx}"
+                    ),
+                    tma_load=tcgen05_use_role_local_tma_producer,
+                )
+            dynamic_ab_tile_trailing_coord = (
+                "" if tcgen05_grouped_dynamic_ab_tensormap_rank == 2 else ", 0"
+            )
+            a_tile_coord = (
+                (
+                    f"({tcgen05_grouped_cta_tile_idx_n}, None"
+                    f"{dynamic_ab_tile_trailing_coord})"
+                    if tcgen05_nm_orientation
+                    else f"({tcgen05_grouped_cta_tile_idx_m}, None"
+                    f"{dynamic_ab_tile_trailing_coord})"
+                )
+                if tcgen05_grouped_dynamic_ab_tensormaps
+                else f"({m_offset_var} // cutlass.Int32({bm}), None)"
+            )
+            b_tile_coord = (
+                (
+                    f"({tcgen05_grouped_cta_tile_idx_m}, None"
+                    f"{dynamic_ab_tile_trailing_coord})"
+                    if tcgen05_nm_orientation
+                    else f"({tcgen05_grouped_cta_tile_idx_n}, None"
+                    f"{dynamic_ab_tile_trailing_coord})"
+                )
+                if tcgen05_grouped_dynamic_ab_tensormaps
+                else (
+                    f"({n_offset_var} // cutlass.Int32({bn}), None, "
+                    f"{rhs_rank3_tma_group_expr})"
+                    if rhs_rank3_tma_group_expr is not None
+                    else f"({n_offset_var} // cutlass.Int32({bn}), None)"
+                )
+            )
+            gmem_a_tma_tiler = f"({tcgen05_mma_bm}, {bk})"
+            gmem_b_tma_tiler = f"({tcgen05_mma_bn}, {bk})"
             if lhs_operand.is_leading_passthrough:
                 assert leading_global is not None
                 gmem_a_tma_tiler = f"({bm}, {bk}, 1)"
-                gmem_a_tma_coord = (
+                a_tile_coord = (
                     f"({m_offset_var} // cutlass.Int32({bm}), None, {leading_global})"
                 )
-            else:
-                gmem_a_tma_tiler = f"({bm}, {bk})"
-                gmem_a_tma_coord = f"({m_offset_var} // cutlass.Int32({bm}), None)"
             if rhs_operand.is_leading_passthrough:
                 assert leading_global is not None
                 gmem_b_tma_tiler = f"({bn}, {bk}, 1)"
-                gmem_b_tma_coord = (
+                b_tile_coord = (
                     f"({n_offset_var} // cutlass.Int32({bn}), None, {leading_global})"
                 )
-            else:
-                gmem_b_tma_tiler = f"({bn}, {bk})"
-                gmem_b_tma_coord = f"({n_offset_var} // cutlass.Int32({bn}), None)"
             _emit_per_tile(
                 f"{gmem_a_tma} = cute.local_tile("
-                f"{tma_tensor_a}, {gmem_a_tma_tiler}, {gmem_a_tma_coord})",
+                f"{tma_tensor_a}, {gmem_a_tma_tiler}, "
+                f"{a_tile_coord})",
                 tma_load=tcgen05_use_role_local_tma_producer,
             )
             _emit_per_tile(
                 f"{gmem_b_tma} = cute.local_tile("
-                f"{tma_tensor_b}, {gmem_b_tma_tiler}, {gmem_b_tma_coord})",
+                f"{tma_tensor_b}, {gmem_b_tma_tiler}, "
+                f"{b_tile_coord})",
                 tma_load=tcgen05_use_role_local_tma_producer,
             )
             _emit_per_tile(
@@ -4643,101 +8458,119 @@ def _emit_mma_pipeline(
             )
             _emit_tcgen05_tmem_setup()
             if tcgen05_use_tma_pipeline:
-                # Initial TMA prefetch warms stages 0..ab_stage_count-1 of the
-                # AB pipeline at the START of each tile. Both the boolean
-                # full-tile predicates and the TMA copies reference per-tile
-                # gA/gB tensors and m_offset/n_offset, so they must stay in
-                # the work-tile body.
-                #
-                # In the role-local producer path, the TMA-load warp needs
-                # its own per-tile tensor partitions and full-tile predicates
-                # because it no longer runs the shared work-tile loop. Tag
-                # those prerequisites together with the prefetch IFs so the
-                # partitioner extracts one self-contained TMA-load role body.
-                assert tma_warp is not None
-                prefetch_args = _InitialPrefetchTmaArgs(
-                    tma_pipeline=tma_pipeline,
-                    tma_producer_state=tma_producer_state,
-                    tma_barrier_ptr=tma_barrier_ptr,
-                    tma_warp=tma_warp,
-                    tma_atom_a=tma_atom_a,
-                    tma_atom_b=tma_atom_b,
-                    tma_gA=tma_gA,
-                    tma_gB=tma_gB,
-                    tma_sA=tma_sA,
-                    tma_sB=tma_sB,
-                    tma_a_mcast_mask=tma_a_mcast_mask,
-                    tma_b_mcast_mask=tma_b_mcast_mask,
-                    is_two_cta=tcgen05_is_two_cta,
-                    use_tma_b_mcast_mask=tcgen05_use_tma_b_mcast_mask,
-                    skip_producer_acquire=diagnose_skip_ab_producer_acquire,
-                    skip_producer_advance=diagnose_skip_ab_producer_advance,
+                tcgen05_use_grouped_static_single_tma_producer_loop = (
+                    tcgen05_grouped_static_persistent
+                    and tcgen05_use_role_local_tma_producer
                 )
-                _emit_per_tile(
-                    f"{tma_initial_full_tile} = "
-                    + _tcgen05_tma_tile_predicate(
-                        k_tile_start_expr="cutlass.Int32(0)",
-                        full_tile_end_expr=f"cutlass.Int32({bk})",
-                    ),
-                    tma_load=tcgen05_use_role_local_tma_producer,
-                )
-                stage0_prefetch = _build_initial_prefetch_if(
-                    prefetch_args,
-                    full_tile_gates=[tma_initial_full_tile],
-                    k_offset="cutlass.Int32(0)",
-                    skip_producer_acquire=(
-                        diagnose_skip_ab_producer_acquire
-                        or diagnose_skip_initial_ab_producer_acquire
-                    ),
-                )
-                prefix.append(stage0_prefetch)
-                per_tile_stmts.append(stage0_prefetch)
-                if tcgen05_use_role_local_tma_producer:
-                    tma_load_role_stmts.append(stage0_prefetch)
-                if tcgen05_ab_stage_count_value > 1:
-                    # Warm every stage 1..ab_stage_count-1; each gated by
-                    # an ``i+1``-k_tile fits-in-K predicate. The old
-                    # two-call pattern only covered stages 0 and N-1
-                    # (sufficient for ab=2 where they're the same set);
-                    # ab>=3 leaves intermediate stages unarmed and the
-                    # consumer ``consumer_wait`` deadlocks on stage 1
-                    # phase 0. See cute_plan.md §6.9.1.
+                if not tcgen05_use_grouped_static_single_tma_producer_loop:
+                    # Initial TMA prefetch warms stages 0..ab_stage_count-1 of
+                    # the AB pipeline at the START of each tile. Both the
+                    # boolean full-tile predicates and the TMA copies reference
+                    # per-tile gA/gB tensors and m_offset/n_offset, so they
+                    # must stay in the work-tile body.
+                    #
+                    # In the role-local producer path, the TMA-load warp needs
+                    # its own per-tile tensor partitions and full-tile
+                    # predicates because it no longer runs the shared work-tile
+                    # loop. Tag those prerequisites together with the prefetch
+                    # IFs so the partitioner extracts one self-contained
+                    # TMA-load role body.
+                    assert tma_warp is not None
+                    prefetch_args = _InitialPrefetchTmaArgs(
+                        tma_pipeline=tma_pipeline,
+                        tma_producer_state=tma_producer_state,
+                        tma_barrier_ptr=tma_barrier_ptr,
+                        tma_warp=tma_warp,
+                        tma_atom_a=tma_atom_a,
+                        tma_atom_b=tma_atom_b,
+                        tma_gA=tma_gA,
+                        tma_gB=tma_gB,
+                        tma_sA=tma_sA,
+                        tma_sB=tma_sB,
+                        tma_a_mcast_mask=tma_a_mcast_mask,
+                        tma_b_mcast_mask=tma_b_mcast_mask,
+                        is_two_cta=tcgen05_is_two_cta,
+                        use_tma_b_mcast_mask=tcgen05_use_tma_b_mcast_mask,
+                        skip_producer_acquire=diagnose_skip_ab_producer_acquire,
+                        skip_producer_advance=diagnose_skip_ab_producer_advance,
+                        tma_desc_ptr_a=(
+                            grouped_tensormap_a_desc_ptr
+                            if tcgen05_grouped_dynamic_ab_tensormaps
+                            else None
+                        ),
+                        tma_desc_ptr_b=(
+                            grouped_tensormap_b_desc_ptr
+                            if tcgen05_grouped_dynamic_ab_tensormaps
+                            else None
+                        ),
+                    )
                     _emit_per_tile(
-                        f"{tma_initial_next_full_tile} = "
+                        f"{tma_initial_full_tile} = "
                         + _tcgen05_tma_tile_predicate(
-                            k_tile_start_expr=f"cutlass.Int32({bk * (tcgen05_ab_stage_count_value - 1)})",
-                            full_tile_end_expr=f"cutlass.Int32({bk * tcgen05_ab_stage_count_value})",
+                            k_tile_start_expr="cutlass.Int32(0)",
+                            full_tile_end_expr=f"cutlass.Int32({bk})",
                         ),
                         tma_load=tcgen05_use_role_local_tma_producer,
                     )
-                    for stage_idx in range(1, tcgen05_ab_stage_count_value):
-                        if stage_idx == tcgen05_ab_stage_count_value - 1:
-                            stage_gates = [
-                                tma_initial_full_tile,
-                                tma_initial_next_full_tile,
-                            ]
-                        else:
-                            stage_gate_var = df.new_var(
-                                f"tcgen05_tma_initial_stage_{stage_idx}_full_tile"
-                            )
-                            _emit_per_tile(
-                                f"{stage_gate_var} = "
-                                + _tcgen05_tma_tile_predicate(
-                                    k_tile_start_expr=f"cutlass.Int32({bk * stage_idx})",
-                                    full_tile_end_expr=f"cutlass.Int32({bk * (stage_idx + 1)})",
-                                ),
-                                tma_load=tcgen05_use_role_local_tma_producer,
-                            )
-                            stage_gates = [tma_initial_full_tile, stage_gate_var]
-                        stage_prefetch = _build_initial_prefetch_if(
-                            prefetch_args,
-                            full_tile_gates=stage_gates,
-                            k_offset=f"cutlass.Int32({stage_idx})",
+                    stage0_prefetch = _build_initial_prefetch_if(
+                        prefetch_args,
+                        full_tile_gates=[tma_initial_full_tile],
+                        k_offset="cutlass.Int32(0)",
+                        skip_producer_acquire=(
+                            diagnose_skip_ab_producer_acquire
+                            or diagnose_skip_initial_ab_producer_acquire
+                        ),
+                        gate_tma_warp=not tcgen05_use_role_local_tma_producer,
+                    )
+                    prefix.append(stage0_prefetch)
+                    per_tile_stmts.append(stage0_prefetch)
+                    if tcgen05_use_role_local_tma_producer:
+                        tma_load_role_stmts.append(stage0_prefetch)
+                    if tcgen05_ab_stage_count_value > 1:
+                        # Warm every stage 1..ab_stage_count-1; each gated by
+                        # an ``i+1``-k_tile fits-in-K predicate. The old
+                        # two-call pattern only covered stages 0 and N-1
+                        # (sufficient for ab=2 where they're the same set);
+                        # ab>=3 leaves intermediate stages unarmed and the
+                        # consumer ``consumer_wait`` deadlocks on stage 1
+                        # phase 0. See cute_plan.md §6.9.1.
+                        _emit_per_tile(
+                            f"{tma_initial_next_full_tile} = "
+                            + _tcgen05_tma_tile_predicate(
+                                k_tile_start_expr=f"cutlass.Int32({bk * (tcgen05_ab_stage_count_value - 1)})",
+                                full_tile_end_expr=f"cutlass.Int32({bk * tcgen05_ab_stage_count_value})",
+                            ),
+                            tma_load=tcgen05_use_role_local_tma_producer,
                         )
-                        prefix.append(stage_prefetch)
-                        per_tile_stmts.append(stage_prefetch)
-                        if tcgen05_use_role_local_tma_producer:
-                            tma_load_role_stmts.append(stage_prefetch)
+                        for stage_idx in range(1, tcgen05_ab_stage_count_value):
+                            if stage_idx == tcgen05_ab_stage_count_value - 1:
+                                stage_gates = [
+                                    tma_initial_full_tile,
+                                    tma_initial_next_full_tile,
+                                ]
+                            else:
+                                stage_gate_var = df.new_var(
+                                    f"tcgen05_tma_initial_stage_{stage_idx}_full_tile"
+                                )
+                                _emit_per_tile(
+                                    f"{stage_gate_var} = "
+                                    + _tcgen05_tma_tile_predicate(
+                                        k_tile_start_expr=f"cutlass.Int32({bk * stage_idx})",
+                                        full_tile_end_expr=f"cutlass.Int32({bk * (stage_idx + 1)})",
+                                    ),
+                                    tma_load=tcgen05_use_role_local_tma_producer,
+                                )
+                                stage_gates = [tma_initial_full_tile, stage_gate_var]
+                            stage_prefetch = _build_initial_prefetch_if(
+                                prefetch_args,
+                                full_tile_gates=stage_gates,
+                                k_offset=f"cutlass.Int32({stage_idx})",
+                                gate_tma_warp=not tcgen05_use_role_local_tma_producer,
+                            )
+                            prefix.append(stage_prefetch)
+                            per_tile_stmts.append(stage_prefetch)
+                            if tcgen05_use_role_local_tma_producer:
+                                tma_load_role_stmts.append(stage_prefetch)
     else:
         prefix.append(
             statement_from_string(
@@ -4927,6 +8760,24 @@ def _emit_mma_pipeline(
         if mma_impl == "tcgen05":
             smem_a_store = f"{smem_a_mma}[((_row, _col),)]"
             smem_b_store = f"{smem_b_mma}[((_row, _col),)]"
+        if rhs_rank3_segment_lhs_info is None:
+            scalar_load_a_row_setup = f"            _gm = {m_offset_var} + _row\n"
+            scalar_load_a_guard = (
+                f"_gm < cutlass.Int32({m_size}) and _gk < cutlass.Int32({k_total_size})"
+            )
+        else:
+            segment_start_expr = rhs_rank3_segment_lhs_info.segment_start_load.name
+            actual_m_expr = rhs_rank3_segment_lhs_info.actual_m_load.name
+            scalar_load_a_row_setup = (
+                f"            _segment_m = {m_offset_var} + _row\n"
+                f"            _gm = cutlass.Int32({segment_start_expr}) + _segment_m\n"
+            )
+            scalar_load_a_guard = (
+                f"_segment_m < cutlass.Int32({actual_m_expr}) "
+                f"and cutlass.Int32(0) <= _gm "
+                f"and _gm < cutlass.Int32({m_size}) "
+                f"and _gk < cutlass.Int32({k_total_size})"
+            )
         scalar_load_a = statement_from_string(
             f"if {load_guard}:\n"
             f"    for _load_i in range(({bm * bk} + {load_thread_count} - 1) // {load_thread_count}):\n"
@@ -4934,12 +8785,11 @@ def _emit_mma_pipeline(
             f"        if _flat < cutlass.Int32({bm * bk}):\n"
             f"            _row = _flat // cutlass.Int32({bk})\n"
             f"            _col = _flat % cutlass.Int32({bk})\n"
-            f"            _gm = {m_offset_var} + _row\n"
+            f"{scalar_load_a_row_setup}"
             f"            _gk = {k_offset_var} + _col\n"
             f"            {smem_a_store} = ("
             f"{_lhs_gmem_access('_gm', '_gk')} "
-            f"if _gm < cutlass.Int32({m_size}) "
-            f"and _gk < cutlass.Int32({k_total_size}) "
+            f"if {scalar_load_a_guard} "
             f"else {input_dtype_str}(0.0))"
         )
         scalar_load_b = statement_from_string(
@@ -5011,8 +8861,35 @@ def _emit_mma_pipeline(
                 scalar_load_b=scalar_load_b,
                 cluster_n=tcgen05_cluster_n,
                 static_full_tiles=tcgen05_static_full_tma_fast_path,
+                tma_desc_ptr_a=(
+                    grouped_tensormap_a_desc_ptr
+                    if tcgen05_grouped_dynamic_ab_tensormaps
+                    else None
+                ),
+                tma_desc_ptr_b=(
+                    grouped_tensormap_b_desc_ptr
+                    if tcgen05_grouped_dynamic_ab_tensormaps
+                    else None
+                ),
             )
             if tcgen05_use_tma_pipeline:
+                grouped_k_loop_iter_expr = (
+                    _tcgen05_grouped_k_loop_iter_expr(
+                        problem_k=tcgen05_k_bound_expr,
+                        bk=bk,
+                    )
+                    if tcgen05_grouped_k_mask is not None
+                    else None
+                )
+                cloned_k_loop_iter_expr = (
+                    grouped_k_loop_iter_expr
+                    if grouped_k_loop_iter_expr is not None
+                    else (
+                        _tcgen05_k_loop_nounroll_iter_expr(device_loop)
+                        if tcgen05_use_nounroll_k_loop
+                        else None
+                    )
+                )
                 if tcgen05_use_separate_tma_producer:
                     producer_loop_body = [
                         statement_from_string(
@@ -5026,31 +8903,41 @@ def _emit_mma_pipeline(
                                 f"{tma_full_tile} = " + tma_full_tile_predicate_src
                             )
                         )
-                    producer_loop_body.extend(
-                        [
-                            statement_from_string(
-                                f"{tma_next_full_tile} = "
-                                + _tcgen05_tma_tile_predicate(
-                                    k_tile_start_expr=f"{k_offset_var} + cutlass.Int32({bk * tcgen05_ab_stage_count_value})",
-                                    full_tile_end_expr=f"{k_offset_var} + cutlass.Int32({bk * (tcgen05_ab_stage_count_value + 1)})",
-                                )
-                            ),
-                            statement_from_string(
-                                f"{tma_producer_try_token} = cutlass.Boolean(0)"
-                            ),
-                            _build_kloop_pipeline_producer_if(
-                                tma_kloop_args, gate_tma_warp=False
-                            ),
-                        ]
-                    )
+                    if tcgen05_use_grouped_static_single_tma_producer_loop:
+                        producer_loop_body.extend(
+                            [
+                                statement_from_string(
+                                    f"{tma_producer_try_token} = cutlass.Boolean(0)"
+                                ),
+                                _build_kloop_pipeline_producer_if(
+                                    tma_kloop_args,
+                                    gate_tma_warp=False,
+                                    load_current_tile=True,
+                                ),
+                            ]
+                        )
+                    else:
+                        producer_loop_body.extend(
+                            [
+                                statement_from_string(
+                                    f"{tma_next_full_tile} = "
+                                    + _tcgen05_tma_tile_predicate(
+                                        k_tile_start_expr=f"{k_offset_var} + cutlass.Int32({bk * tcgen05_ab_stage_count_value})",
+                                        full_tile_end_expr=f"{k_offset_var} + cutlass.Int32({bk * (tcgen05_ab_stage_count_value + 1)})",
+                                    )
+                                ),
+                                statement_from_string(
+                                    f"{tma_producer_try_token} = cutlass.Boolean(0)"
+                                ),
+                                _build_kloop_pipeline_producer_if(
+                                    tma_kloop_args, gate_tma_warp=False
+                                ),
+                            ]
+                        )
                     producer_loop = _clone_k_loop_with_body(
                         device_loop,
                         producer_loop_body,
-                        iter_expr=(
-                            _tcgen05_k_loop_nounroll_iter_expr(device_loop)
-                            if tcgen05_use_nounroll_k_loop
-                            else None
-                        ),
+                        iter_expr=cloned_k_loop_iter_expr,
                     )
                     producer_stmt: ast.stmt = producer_loop
                     if tcgen05_use_pure_matmul_role_lifecycle:
@@ -5142,11 +9029,7 @@ def _emit_mma_pipeline(
                     exec_loop = _clone_k_loop_with_body(
                         device_loop,
                         exec_loop_body,
-                        iter_expr=(
-                            _tcgen05_k_loop_nounroll_iter_expr(device_loop)
-                            if tcgen05_use_nounroll_k_loop
-                            else None
-                        ),
+                        iter_expr=cloned_k_loop_iter_expr,
                     )
                     exec_stmt: ast.stmt = exec_loop
                     if tcgen05_use_pure_matmul_role_lifecycle:
@@ -5365,7 +9248,6 @@ def _emit_mma_pipeline(
             suffix.append(statement_from_string("cute.arch.sync_threads()"))
         else:
             assert tcgen05_plan is not None
-            assert tcgen05_mma_owner_active is not None
             assert epi_active is not None
             assert epi_tidx is not None
             # The K-loop suffix's `acc_pipeline.producer_commit` +
@@ -5383,8 +9265,12 @@ def _emit_mma_pipeline(
             # ``_emit_per_tile_suffix`` so they stay inside the work-tile
             # loop.
             suffix_stmt = statement_from_string(
-                f"if {tcgen05_mma_owner_active}:\n"
-                f"    {tcgen05_plan.acc_pipeline}.producer_commit({tcgen05_plan.acc_producer_state})"
+                _tcgen05_emit_optional_gate(
+                    f"{tcgen05_plan.acc_pipeline}.producer_commit("
+                    f"{tcgen05_plan.acc_producer_state})",
+                    tcgen05_mma_owner_active,
+                    indent="",
+                )
             )
             suffix.append(suffix_stmt)
             per_tile_stmts.append(suffix_stmt)
@@ -5411,6 +9297,7 @@ def _emit_mma_pipeline(
 
     if mma_impl == "tcgen05":
         assert tcgen05_plan is not None
+        assert tcgen05_matmul_plan is not None
         assert epi_tidx is not None
         assert epi_active is not None
         assert tma_warp is not None
@@ -5442,14 +9329,46 @@ def _emit_mma_pipeline(
             if tcgen05_use_pure_matmul_role_lifecycle
             else None
         )
+        segment_store_m_offset = ""
+        segment_store_start = ""
+        segment_store_actual_m = ""
+        segment_store_valid_m_bound = ""
+        segment_store_node: Node | None = None
+        segment_store_row_index: Node | None = None
+        segment_store_valid_m: Node | None = None
+        if rhs_rank3_segment_store_info is not None:
+            assert rhs_rank3_segment_lhs_info is not None
+            segment_store_m_offset = m_offset_var
+            segment_store_start = rhs_rank3_segment_lhs_info.segment_start_load.name
+            segment_store_actual_m = (
+                tcgen05_grouped_store_m
+                if (
+                    nm_worklist
+                    and tcgen05_grouped_store_m
+                    and rhs_rank3_segment_store_info.uses_store_extent_metadata
+                )
+                else rhs_rank3_segment_store_info.extent_load.name
+            )
+            segment_store_valid_m_bound = (
+                tcgen05_grouped_valid_m
+                if nm_worklist and tcgen05_grouped_valid_m
+                else rhs_rank3_segment_lhs_info.actual_m_load.name
+            )
+            segment_store_node = rhs_rank3_segment_store_info.store_node
+            segment_store_row_index = rhs_rank3_segment_store_info.row_index
+            segment_store_valid_m = rhs_rank3_segment_store_info.valid_m
         df.cute_state.register_tcgen05_store_value(
             result_var,
             CuteTcgen05StoreValue(
                 lifecycle_context=tcgen05_lifecycle_context,
-                output_block_ids=analysis.output_block_ids,
+                output_block_ids=(
+                    analysis.output_block_ids
+                    if analysis is not None
+                    else tuple(grid_state.block_ids)
+                ),
                 pure_matmul_object=tcgen05_pure_matmul_object,
-                bm=bm,
-                bn=bn,
+                bm=tcgen05_mma_bm,
+                bn=tcgen05_mma_bn,
                 bk=bk,
                 thr_mma=thr_mma,
                 epi_warp_count=tcgen05_epi_warp_count_value,
@@ -5463,6 +9382,8 @@ def _emit_mma_pipeline(
                 epilogue_rest_mode=tcgen05_plan.epilogue_rest_mode,
                 tma_store_atom=tma_store_atom,
                 tma_store_tensor=tma_store_tensor,
+                tail_tma_store_atom=tail_tma_store_atom,
+                tail_tma_store_tensor=tail_tma_store_tensor,
                 role_local_tile_counter=tma_store_role_tile_counter,
                 use_role_local_epi=tcgen05_use_role_local_epi,
                 use_tma_store_epilogue=tcgen05_use_tma_store_epilogue,
@@ -5476,6 +9397,14 @@ def _emit_mma_pipeline(
                 explicit_epi_tile_m=tcgen05_explicit_epi_tile_m,
                 explicit_epi_tile_n=tcgen05_explicit_epi_tile_n,
                 explicit_d_store_box_n=tcgen05_explicit_d_store_box_n,
+                segment_store_m_offset=segment_store_m_offset,
+                segment_store_start=segment_store_start,
+                segment_store_actual_m=segment_store_actual_m,
+                segment_store_valid_m_bound=segment_store_valid_m_bound,
+                segment_store_node=segment_store_node,
+                segment_store_row_index=segment_store_row_index,
+                segment_store_valid_m=segment_store_valid_m,
+                orientation=tcgen05_matmul_plan.orientation,
             ),
         )
         if tcgen05_pure_matmul_object is not None:
@@ -5487,6 +9416,10 @@ def _emit_mma_pipeline(
             # walk from the user's store value through a whitelisted
             # unary chain to this matmul fx_node.
             df.cute_state.matmul_fx_node_result_vars[fx_node] = result_var
+        if tcgen05_grouped_tail_proof is not None:
+            df.cute_state.register_tcgen05_grouped_tail_proof(
+                tcgen05_grouped_tail_proof
+            )
     else:
         # Each thread reads its own (m, n) element from shared memory.
         suffix.append(
@@ -5614,8 +9547,8 @@ def _tcgen05_use_2cta_instrs(
     # validated for fp8 on the 512x6144x2048 scaled_mm shape, where it beats
     # both the bm=256 2-CTA and every 1-CTA config; it is fp8-gated because
     # the f16/bf16 bm=128 + cluster_m=2 config point is owned by the legacy
-    # clustered CTA-local CtaGroup.ONE family (guarded diagnostic bridge and
-    # multi-tile runtime guard).
+    # clustered CTA-local CtaGroup.ONE family (guarded bridge and multi-tile
+    # runtime guard).
     if cluster_m != 2:
         return False
     if bm == TCGEN05_TWO_CTA_BLOCK_M:
@@ -5980,7 +9913,9 @@ def _make_tcgen05_layout_plan_setup(
     smem_swizzle_b: int | None = None,
     explicit_epi_tile_m: int | None = None,
     explicit_epi_tile_n: int | None = None,
+    nm_explicit_store_wave: bool = False,
     b_k_major: bool = False,
+    c_layout: str = "cutlass.utils.layout.LayoutEnum.ROW_MAJOR",
 ) -> list[ast.AST]:
     # `compute_epilogue_tile_shape` must receive `elem_ty_d` and `elem_ty_c`
     # equal to the eventual D-output dtype so the helper takes the
@@ -6019,6 +9954,17 @@ def _make_tcgen05_layout_plan_setup(
         c_layout=plan.c_layout,
         explicit_expr=explicit_epi_tile_expr,
     )
+    tmem_load_atom_expr = (
+        "cute.make_copy_atom("
+        "cute.nvgpu.tcgen05.Ld16x256bOp(cute.nvgpu.tcgen05.Repetition.x4), "
+        f"{acc_dtype_str})"
+        if nm_explicit_store_wave
+        else (
+            "cutlass.utils.blackwell_helpers.get_tmem_load_op("
+            f"({epi_tile_m}, {bn}, {bk}), {plan.c_layout}, "
+            f"{acc_dtype_str}, {acc_dtype_str}, {plan.epi_tile}, {is_two_cta!s})"
+        )
+    )
     return [
         statement_from_string(
             f"{plan.smem_a_layout} = "
@@ -6028,15 +9974,9 @@ def _make_tcgen05_layout_plan_setup(
             f"{plan.smem_b_layout} = "
             f"{tcgen05_smem_layout_expr(tiled_mma=tiled_mma, bm=bm, bn=bn, bk=bk, dtype_str=input_dtype_str, num_stages=ab_stage_count, operand='b', swizzle_override=smem_swizzle_b, b_k_major=b_k_major)}"
         ),
-        statement_from_string(
-            f"{plan.c_layout} = cutlass.utils.layout.LayoutEnum.ROW_MAJOR"
-        ),
+        statement_from_string(f"{plan.c_layout} = {c_layout}"),
         statement_from_string(f"{plan.epi_tile} = {epi_tile_expr}"),
-        statement_from_string(
-            f"{plan.tmem_load_atom} = cutlass.utils.blackwell_helpers.get_tmem_load_op("
-            f"({epi_tile_m}, {bn}, {bk}), {plan.c_layout}, "
-            f"{acc_dtype_str}, {acc_dtype_str}, {plan.epi_tile}, {is_two_cta!s})"
-        ),
+        statement_from_string(f"{plan.tmem_load_atom} = {tmem_load_atom_expr}"),
         statement_from_string(
             f"{plan.epilogue_rest_mode} = cute.make_layout(1, stride=0)"
         ),
@@ -6270,12 +10210,17 @@ def _tcgen05_aux_pipeline_stage_count_from_config(config: object) -> int:
 
 def _tcgen05_consumer_regs_from_config(config: object) -> int:
     """Return the consumer-warp ``setmaxregister_increase`` ceiling for
-    ``config``, defaulting to ``TCGEN05_CONSUMER_REGS_DEFAULT`` (256)
-    when the knob is absent.
+    ``config``.
 
     Cycle 15 H2 (``cute_plan.md`` §6 Target 8). The default preserves
-    cycle-14 byte-identical emission; lower values force ``ptxas`` to
-    cap the consumer-warp per-thread register count. The validator
+    cycle-14 byte-identical emission outside the opt-in grouped static
+    scheduler path. The grouped static scheduler defaults to 240 to keep
+    the generated proof under the ptxas 255-register ceiling without
+    changing dense persistent kernels. Explicit ``tcgen05_consumer_regs``
+    configs still win.
+
+    Lower values force ``ptxas`` to cap the consumer-warp per-thread register
+    count. The validator
     (``_validate_int_enum_config`` in ``tcgen05_config.py``) is the
     single source of truth that rejects out-of-range values before
     they reach codegen; values seen here that are outside
@@ -6286,11 +10231,13 @@ def _tcgen05_consumer_regs_from_config(config: object) -> int:
     default-with-knob configuration emits the same code as the
     default-without-knob configuration.
     """
-    value = _tcgen05_config_int(
-        config, TCGEN05_CONSUMER_REGS_CONFIG_KEY, TCGEN05_CONSUMER_REGS_DEFAULT
-    )
+    grouped_static = _tcgen05_grouped_mode(cast("_ConfigLike", config)) is not None
+    default = 240 if grouped_static else TCGEN05_CONSUMER_REGS_DEFAULT
+    value = cast("_ConfigLike", config).get(TCGEN05_CONSUMER_REGS_CONFIG_KEY, default)
+    if not isinstance(value, int):
+        return default
     if value not in TCGEN05_CONSUMER_REGS_CHOICES:
-        return TCGEN05_CONSUMER_REGS_DEFAULT
+        return default
     return value
 
 
@@ -6595,29 +10542,78 @@ def codegen_cute_mma(
 
     if not isinstance(ctx.cg, GenerateAST):
         return None
+    grouped_mode = _tcgen05_grouped_mode(ctx.cg.device_function.config)
+    requested_schedule = _requested_tcgen05_grouped_schedule(grouped_mode)
+
+    def _unsupported_schedule(reason: str) -> None:
+        if requested_schedule is not None:
+            raise exc.BackendUnsupported(
+                "cute",
+                f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}="
+                f"{TCGEN05_GROUPED_MODE_WORKLIST_NM!r} requires the "
+                "generated N,M-oriented worklist tcgen05 schedule; " + reason,
+            )
+        return None
+
     if ctx.cg.current_grid_state is None:
-        return None
+        return _unsupported_schedule("MMA was not inside a grid tile")
     candidate = analyze_cute_mma_node(node)
-    if candidate is None or candidate.with_acc != with_acc or candidate.is_dot:
-        return None
+    if candidate is not None and (candidate.with_acc != with_acc or candidate.is_dot):
+        candidate = None
 
-    if with_acc:
-        acc_node = candidate.acc
-        assert acc_node is not None
-        acc_expr = (
-            ctx.to_ast(ctx.env[acc_node])
-            if candidate.requires_accumulator_seed
-            else None
+    rhs_node: Node | None
+    if candidate is None:
+        if node.target is not torch.ops.aten.addmm.default or not with_acc:
+            return _unsupported_schedule("MMA target was not grouped addmm")
+        if len(node.args) < 3:
+            return _unsupported_schedule("MMA operands were missing")
+        acc_node, lhs_arg, rhs_arg = node.args[:3]
+        if not all(isinstance(arg, Node) for arg in (acc_node, lhs_arg, rhs_arg)):
+            return _unsupported_schedule("MMA operands were not nodes")
+        assert isinstance(acc_node, Node)
+        assert isinstance(lhs_arg, Node)
+        assert isinstance(rhs_arg, Node)
+        allow_grouped_k_mask = grouped_mode is not None
+        rhs_info = _trace_to_mma_operand(
+            rhs_arg,
+            role="rhs",
+            allow_rank3_rhs_nt=True,
+            cg=ctx.cg,
+            allow_grouped_k_mask=allow_grouped_k_mask,
         )
+        if rhs_info is None or not rhs_info.rhs_rank3_grouped_nt:
+            return _unsupported_schedule("MMA RHS was not grouped rank-3")
+        acc_expr = (
+            None if _is_zero_init_acc_node(acc_node) else ctx.to_ast(ctx.env[acc_node])
+        )
+        mma: _CuteMmaNode | Node = lhs_arg
+        rhs_node = rhs_arg
     else:
-        acc_expr = None
+        mma = candidate
+        rhs_node = None
+        if with_acc:
+            acc_node = candidate.acc
+            assert acc_node is not None
+            acc_expr = (
+                ctx.to_ast(ctx.env[acc_node])
+                if candidate.requires_accumulator_seed
+                else None
+            )
+        else:
+            acc_expr = None
 
-    return _emit_mma_pipeline(
+    result = _emit_mma_pipeline(
         ctx.cg,
-        candidate,
+        mma,
+        rhs_node,
         acc_expr=acc_expr,
         fx_node=node,
+        lowering_ctx=ctx,
+        grouped_mode=grouped_mode,
     )
+    if result is None:
+        return _unsupported_schedule("MMA pipeline was not admitted")
+    return result
 
 
 def codegen_cute_mma_direct_mm(
@@ -6897,6 +10893,7 @@ def codegen_cute_mma_dot(state: CodegenState) -> object | None:
         candidate,
         acc_expr=acc_expr,
         fx_node=state.fx_node,
+        grouped_mode=_tcgen05_grouped_mode(state.device_function.config),
     )
     if result is None:
         if is_pure_matmul_role_lifecycle_config(state.device_function.config):

--- a/helion/_compiler/cute/device_state.py
+++ b/helion/_compiler/cute/device_state.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import ast
 import dataclasses
+import enum
 from typing import TYPE_CHECKING
+from typing import Protocol
+from typing import cast
 
 from ... import exc
 
@@ -16,14 +19,103 @@ if TYPE_CHECKING:
     from ..tile_strategy import DeviceLoopState
     from .attention_plan import AttentionScorePlan
     from .aux_tensor import Tcgen05AuxTensorDescriptor
+    from .cute_epilogue import Tcgen05GroupedTailEpilogueMatch
     from .cute_mma import _Tcgen05AuxPipelinePlan
     from .cute_mma import _Tcgen05SchedPipelinePlan
     from .tcgen05_lifecycle import Tcgen05LifecycleContext
     from .tcgen05_pure_matmul import Tcgen05PureMatmulObjectModel
 
 
+class Tcgen05Orientation(enum.Enum):
+    MN = enum.auto()
+    NM = enum.auto()
+
+
+class Tcgen05GroupedDMode(enum.Enum):
+    NONE = enum.auto()
+    ALL_TILES = enum.auto()
+    EDGE_ONLY = enum.auto()
+
+
 @dataclasses.dataclass(frozen=True)
-class CuteTcgen05StoreValue:
+class CuteTcgen05GroupedPlan:
+    orientation: Tcgen05Orientation
+    layout: str
+    count: str
+    sched_params: str
+    problem_sizes: str
+    starts: str
+    metadata_idx: str
+    group_idx: str
+    cta_tile_idx_m: str
+    cta_tile_idx_n: str
+    problem_m: str
+    problem_n: str
+    problem_k: str
+    global_m_start: str
+    real_groups: str | None = None
+    valid_m: str | None = None
+    store_m: str | None = None
+    direct_pointers: str | None = None
+    direct_strides: str | None = None
+    d_mode: Tcgen05GroupedDMode = Tcgen05GroupedDMode.NONE
+    d_tensormap: str | None = None
+
+    def __post_init__(self) -> None:
+        assert (self.valid_m is None) == (self.store_m is None)
+        assert (self.orientation is Tcgen05Orientation.NM) == (self.valid_m is not None)
+        assert (self.direct_pointers is None) == (self.direct_strides is None)
+        assert (self.d_mode is Tcgen05GroupedDMode.NONE) == (self.d_tensormap is None)
+
+
+class _CuteTcgen05Orientation(Protocol):
+    @property
+    def bm(self) -> int: ...
+
+    @property
+    def bn(self) -> int: ...
+
+    @property
+    def orientation(self) -> Tcgen05Orientation: ...
+
+
+class _CuteTcgen05OrientationMixin:
+    def _orientation(self) -> _CuteTcgen05Orientation:
+        return cast("_CuteTcgen05Orientation", self)
+
+    def _is_nm(self) -> bool:
+        return self._orientation().orientation is Tcgen05Orientation.NM
+
+    @property
+    def source_tile_m(self) -> int:
+        orientation = self._orientation()
+        return orientation.bn if self._is_nm() else orientation.bm
+
+    @property
+    def source_tile_n(self) -> int:
+        orientation = self._orientation()
+        return orientation.bm if self._is_nm() else orientation.bn
+
+    @property
+    def accumulator_view(self) -> str:
+        return "nm" if self._is_nm() else "mn"
+
+    @property
+    def output_view(self) -> str:
+        return self.accumulator_view
+
+    @property
+    def d_store_view(self) -> str:
+        return "nm_transposed" if self._is_nm() else "normal"
+
+    @property
+    def d_store_layout(self) -> str:
+        layout = "COL_MAJOR" if self._is_nm() else "ROW_MAJOR"
+        return f"cutlass.utils.layout.LayoutEnum.{layout}"
+
+
+@dataclasses.dataclass(frozen=True)
+class CuteTcgen05StoreValue(_CuteTcgen05OrientationMixin):
     lifecycle_context: Tcgen05LifecycleContext
     output_block_ids: tuple[int, ...]
     pure_matmul_object: Tcgen05PureMatmulObjectModel | None = None
@@ -42,6 +134,8 @@ class CuteTcgen05StoreValue:
     epilogue_rest_mode: str = ""
     tma_store_atom: str = ""
     tma_store_tensor: str = ""
+    tail_tma_store_atom: str = ""
+    tail_tma_store_tensor: str = ""
     role_local_tile_counter: str = ""
     use_role_local_epi: bool = False
     use_tma_store_epilogue: bool = False
@@ -53,6 +147,14 @@ class CuteTcgen05StoreValue:
     explicit_epi_tile_m: int | None = None
     explicit_epi_tile_n: int | None = None
     explicit_d_store_box_n: int | None = None
+    segment_store_m_offset: str = ""
+    segment_store_start: str = ""
+    segment_store_actual_m: str = ""
+    segment_store_valid_m_bound: str = ""
+    segment_store_node: Node | None = None
+    segment_store_row_index: Node | None = None
+    segment_store_valid_m: Node | None = None
+    orientation: Tcgen05Orientation = Tcgen05Orientation.MN
 
     def __post_init__(self) -> None:
         if self.pure_matmul_object is not None:
@@ -78,7 +180,7 @@ class CuteTcgen05StoreValue:
 
 
 @dataclasses.dataclass(frozen=True)
-class CuteTcgen05MatmulPlan:
+class CuteTcgen05MatmulPlan(_CuteTcgen05OrientationMixin):
     """Kernel-wide tcgen05 collective contract selected by CuTe matmul codegen.
 
     The warp-role order is part of the codegen contract: epilogue warps occupy
@@ -129,6 +231,7 @@ class CuteTcgen05MatmulPlan:
     l2_swizzle_size: int = 1
     tma_store_full_tiles_only: bool = False
     flat_role_launch_warp_count: int | None = None
+    grouped: CuteTcgen05GroupedPlan | None = None
     # Per-anchor auxiliary descriptors discovered by the forward FX walker. This
     # is store-fusion metadata, not a collective compatibility field:
     # two matmuls with identical collective parameters but different downstream
@@ -138,6 +241,10 @@ class CuteTcgen05MatmulPlan:
     aux_tensor_descriptors: tuple[Tcgen05AuxTensorDescriptor, ...] = dataclasses.field(
         default=(), compare=False
     )
+
+    @property
+    def orientation(self) -> Tcgen05Orientation:
+        return self.grouped.orientation if self.grouped else Tcgen05Orientation.MN
 
     @property
     def c_input_aux_tensor_descriptors(self) -> tuple[Tcgen05AuxTensorDescriptor, ...]:
@@ -271,6 +378,9 @@ class CuteDeviceFunctionState:
 
     def __init__(self) -> None:
         self._tcgen05_store_values: dict[str, CuteTcgen05StoreValue] = {}
+        self._tcgen05_grouped_tail_proofs: dict[
+            torch.fx.Node, Tcgen05GroupedTailEpilogueMatch
+        ] = {}
         self._tcgen05_consumed_store_value_ids: set[int] = set()
         # tcgen05 TMA-store atom/tensor kernel-arg names are allocated once per
         # matmul accumulator. When a single accumulator fans out to multiple
@@ -352,6 +462,21 @@ class CuteDeviceFunctionState:
         self, name: str, value: CuteTcgen05StoreValue
     ) -> None:
         self._tcgen05_store_values[name] = value
+
+    def register_tcgen05_grouped_tail_proof(
+        self, proof: Tcgen05GroupedTailEpilogueMatch
+    ) -> None:
+        if proof.store_node in self._tcgen05_grouped_tail_proofs:
+            raise exc.BackendUnsupported(
+                "cute",
+                "tcgen05 grouped tail proof must be unique per store node",
+            )
+        self._tcgen05_grouped_tail_proofs[proof.store_node] = proof
+
+    def grouped_tail_proof_for_store(
+        self, store_node: Node
+    ) -> Tcgen05GroupedTailEpilogueMatch | None:
+        return self._tcgen05_grouped_tail_proofs.get(store_node)
 
     def get_tcgen05_store_value(
         self,

--- a/helion/_compiler/cute/memory_ops.py
+++ b/helion/_compiler/cute/memory_ops.py
@@ -13,6 +13,8 @@ import contextlib
 import logging
 import operator
 from typing import TYPE_CHECKING
+from typing import Any
+from typing import cast
 
 import torch
 from torch.fx.node import map_arg
@@ -604,8 +606,9 @@ def _codegen_cute_affine_range_store(
             or len(source_subscript) != 1
         ):
             return None
+        source_subscript_args = tuple(cast("Any", source_subscript))
         ast_source_subscript = list(
-            map_arg(tuple(source_subscript), lambda arg: state.env[arg])
+            map_arg(source_subscript_args, lambda arg: state.env[arg])
         )
         (source_affine,) = ast_source_subscript
         if not isinstance(source_affine, CuteAffineRangeIndex):
@@ -977,7 +980,8 @@ def _codegen_cute_store_loaded_index_trailing_slices(
     indexer_value = indexer.meta.get("val")
     if not isinstance(indexer_value, torch.Tensor) or indexer_value.ndim == 0:
         return None
-    trailing_source = [*source_subscript[1:]]
+    source_subscript_args = tuple(cast("Any", source_subscript))
+    trailing_source = list(source_subscript_args[1:])
     if not trailing_source or not all(idx == slice(None) for idx in trailing_source):
         return None
     if len(subscript) != indexer_value.ndim + len(trailing_source):
@@ -987,7 +991,7 @@ def _codegen_cute_store_loaded_index_trailing_slices(
         return None
 
     ast_source_subscript = list(
-        map_arg(tuple(source_subscript), lambda arg: state.env[arg])
+        map_arg(source_subscript_args, lambda arg: state.env[arg])
     )
     index_exprs = _cute_index_exprs(
         state,
@@ -1191,7 +1195,10 @@ def _cute_unsqueeze_expand_load_source(
         if not isinstance(index_arg, (list, tuple)):
             return None
         # Exactly one ``None`` (the inserted broadcast dim) at ``broadcast_dim``.
-        none_positions = [pos for pos, entry in enumerate(index_arg) if entry is None]
+        index_arg_entries = tuple(cast("Any", index_arg))
+        none_positions = [
+            pos for pos, entry in enumerate(index_arg_entries) if entry is None
+        ]
         if none_positions != [broadcast_dim]:
             return None
         load_node = inner.args[0]
@@ -1288,11 +1295,12 @@ def _codegen_cute_store_expand_broadcast_tile(
         ):
             load_tensor = load_tensor_node.meta.get("val")
             if isinstance(load_tensor, torch.Tensor):
+                load_subscript_args = tuple(cast("Any", load_subscript))
                 load_subscript_proxy = tuple(
-                    map_arg([*load_subscript], lambda arg: arg.meta["val"])
+                    map_arg(load_subscript_args, lambda arg: arg.meta["val"])
                 )
                 load_subscript_ast = map_arg(
-                    [*load_subscript], lambda arg: state.env[arg]
+                    load_subscript_args, lambda arg: state.env[arg]
                 )
                 load_coords = _cute_index_exprs(
                     state,
@@ -1446,6 +1454,46 @@ def _try_splice_tcgen05_unary_epilogue(
     )
     if rewritten_stmt is None:
         return None
+    stmts = rewritten_stmt if isinstance(rewritten_stmt, list) else [rewritten_stmt]
+    for stmt in stmts:
+        state.add_statement(stmt)
+    return ast.Constant(value=None)
+
+
+def _try_splice_tcgen05_grouped_tail_epilogue(
+    state: CodegenState,
+    tensor: object,
+    subscript: list[object] | tuple[object, ...],
+    ast_subscript: list[object] | tuple[object, ...],
+    extra_mask: ast.AST | None,
+    value_node: torch.fx.Node | None,
+) -> ast.AST | None:
+    """Splice grouped preserve-output M/N tail stores into tcgen05."""
+    cute_state = state.device_function.cute_state
+    if not cute_state.matmul_fx_nodes:
+        return None
+    if value_node is None or state.fx_node is None:
+        return None
+    if not isinstance(tensor, torch.Tensor):
+        return None
+    grouped_tail = cute_state.grouped_tail_proof_for_store(state.fx_node)
+    if grouped_tail is None:
+        return None
+    anchor_result_var = cute_state.matmul_fx_node_result_vars.get(grouped_tail.anchor)
+    if anchor_result_var is None:
+        return None
+    rewritten_stmt = _codegen_cute_store_tcgen05_tile(
+        state,
+        tensor,
+        subscript,
+        ast_subscript,
+        extra_mask,
+        anchor_result_var,
+        grouped_tail_epilogue=grouped_tail,
+    )
+    if rewritten_stmt is None:
+        return None
+    state.codegen.remove_statements_owned_by_nodes(grouped_tail.producer_nodes)
     stmts = rewritten_stmt if isinstance(rewritten_stmt, list) else [rewritten_stmt]
     for stmt in stmts:
         state.add_statement(stmt)
@@ -1635,6 +1683,11 @@ def _(state: CodegenState) -> ast.AST:
     # splice off and fall through to the loud-failure backstop
     # below.
     spliced = _try_splice_tcgen05_unary_epilogue(
+        state, tensor, subscript, ast_subscript, extra_mask, value_node
+    )
+    if spliced is not None:
+        return spliced
+    spliced = _try_splice_tcgen05_grouped_tail_epilogue(
         state, tensor, subscript, ast_subscript, extra_mask, value_node
     )
     if spliced is not None:

--- a/helion/_compiler/program_id.py
+++ b/helion/_compiler/program_id.py
@@ -71,12 +71,16 @@ def _clone_stmt(stmt: ast.stmt) -> ast.stmt:
     return cast("ast.stmt", _clone_ast_value(stmt))
 
 
+_TCGEN05_WORK_TILE_MAILBOX_VALID = 3
+
+
 def _build_sched_pipeline_consumer_wait_block(
     *,
     sched_pipeline: str,
     sched_consumer_state: str,
     work_tile_smem: str,
     valid_var: str,
+    valid_slot_index: int = _TCGEN05_WORK_TILE_MAILBOX_VALID,
     work_tile_stage_index: str | None = None,
 ) -> list[ast.stmt]:
     """Emit the consumer-side wait block for the ``ROLE_LOCAL_WITH_SCHEDULER``
@@ -117,9 +121,12 @@ def _build_sched_pipeline_consumer_wait_block(
     except NoCurrentFunction:
         wait_mode = TCGEN05_SCHED_CONSUMER_WAIT_MODE_NORMAL
     valid_slot = (
-        f"{work_tile_smem}[cutlass.Int32(3)]"
+        f"{work_tile_smem}[cutlass.Int32({valid_slot_index})]"
         if work_tile_stage_index is None
-        else f"{work_tile_smem}[cutlass.Int32(3), {work_tile_stage_index}]"
+        else (
+            f"{work_tile_smem}[cutlass.Int32({valid_slot_index}), "
+            f"{work_tile_stage_index}]"
+        )
     )
     if wait_mode == TCGEN05_SCHED_CONSUMER_WAIT_MODE_WARP_LEADER:
         return [
@@ -180,6 +187,18 @@ def _build_sched_pipeline_consumer_release_block(
         statement_from_string(emit_pipeline_advance(sched_consumer_state)),
         statement_from_string("cute.arch.sync_warp()"),
     ]
+
+
+_TCGEN05_GROUPED_SELECTED_MAILBOX_CTA_M = 0
+_TCGEN05_GROUPED_SELECTED_MAILBOX_CTA_N = 1
+_TCGEN05_GROUPED_SELECTED_MAILBOX_VALID = 2
+_TCGEN05_GROUPED_SELECTED_MAILBOX_METADATA_IDX = 3
+_TCGEN05_GROUPED_SELECTED_MAILBOX_GROUP_IDX = 4
+_TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_M = 5
+_TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_N = 6
+_TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_K = 7
+_TCGEN05_GROUPED_SELECTED_MAILBOX_GLOBAL_M_START = 8
+_TCGEN05_GROUPED_SELECTED_MAILBOX_FIELD_COUNT = 9
 
 
 if TYPE_CHECKING:
@@ -1182,6 +1201,19 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         plan = self._tcgen05_plan()
         return plan is not None and plan.has_scheduler_warp
 
+    def _tcgen05_uses_grouped_static_persistent(self) -> bool:
+        plan = self._tcgen05_plan()
+        return bool(plan is not None and plan.grouped is not None)
+
+    def _tcgen05_uses_grouped_worklist_nm_scheduler_mailbox(self) -> bool:
+        plan = self._tcgen05_plan()
+        return bool(
+            plan is not None
+            and plan.accumulator_view == "nm"
+            and plan.has_scheduler_warp
+            and plan.uses_role_local_persistent_body
+        )
+
     def _tcgen05_sched_pipeline_plan(self) -> _Tcgen05SchedPipelinePlan | None:
         try:
             return DeviceFunction.current().cute_state.sched_pipeline_plan
@@ -1239,6 +1271,11 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         return (
             f"{layout.work_tile_smem}[None, {sched_plan.producer_state}.index].iterator"
         )
+
+    def _tcgen05_work_tile_mailbox_field_count(self) -> int:
+        if self._tcgen05_uses_grouped_worklist_nm_scheduler_mailbox():
+            return _TCGEN05_GROUPED_SELECTED_MAILBOX_FIELD_COUNT
+        return 4
 
     def _tcgen05_has_validated_role_local_two_cta_runtime(self) -> bool:
         plan = self._tcgen05_plan()
@@ -2080,7 +2117,11 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         omit_shared_loop = (
             full_role_local_body
             and not is_multi_root
-            and (layout.cluster_m > 1 or self._tcgen05_has_scheduler_warp())
+            and (
+                layout.cluster_m > 1
+                or self._tcgen05_has_scheduler_warp()
+                or self._tcgen05_uses_grouped_static_persistent()
+            )
         )
         if self._tcgen05_uses_staged_work_tile_mailbox() and not omit_shared_loop:
             raise exc.InvalidConfig(
@@ -2458,6 +2499,7 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         own helper that always runs when the work-tile mailbox is
         needed.
         """
+        field_count = self._tcgen05_work_tile_mailbox_field_count()
         if self._tcgen05_uses_staged_work_tile_mailbox():
             assert staged_ok, (
                 "staged work-tile mailbox requires omitted shared-loop "
@@ -2468,11 +2510,14 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                 "staged work-tile mailbox is only validated for clustered CLC"
             )
             stage_count = self._tcgen05_sched_stage_count()
-            alloc_extent = f"cutlass.Int32({4 * stage_count})"
-            layout_expr = f"cute.make_layout((4, {stage_count}), stride=(1, 4))"
+            alloc_extent = f"cutlass.Int32({field_count * stage_count})"
+            layout_expr = (
+                f"cute.make_layout(({field_count}, {stage_count}), "
+                f"stride=(1, {field_count}))"
+            )
         else:
-            alloc_extent = "4"
-            layout_expr = "cute.make_layout((4,), stride=(1,))"
+            alloc_extent = str(field_count)
+            layout_expr = f"cute.make_layout(({field_count},), stride=(1,))"
         return [
             statement_from_string(
                 f"{layout.work_tile_smem_ptr} = cute.arch.alloc_smem("
@@ -2734,6 +2779,17 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         # The per-role ``StaticPersistentTileScheduler.create`` is
         # *not* emitted in this mode — the scheduler warp owns the
         # only tile scheduler.
+        if self._tcgen05_uses_grouped_worklist_nm_scheduler_mailbox():
+            return self._build_grouped_static_role_local_while_with_scheduler(
+                device_function,
+                layout,
+                role_block,
+                scheduler_var_prefix=scheduler_var_prefix,
+                dependency_stmts=dependency_stmts,
+                role_prelude_stmts=role_prelude_stmts,
+                emit_pdl_wait=emit_pdl_wait,
+                initialize_tile_counter=initialize_tile_counter,
+            )
         if self._tcgen05_has_scheduler_warp():
             return self._build_role_local_while_with_scheduler(
                 device_function,
@@ -2746,6 +2802,15 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                 initialize_tile_counter=initialize_tile_counter,
                 store_aux_per_tile_stmts=store_aux_per_tile_stmts,
                 store_aux_predicate=store_aux_predicate,
+            )
+        if self._tcgen05_uses_grouped_static_persistent():
+            return self._build_grouped_static_role_local_while(
+                device_function,
+                role_block,
+                scheduler_var_prefix=scheduler_var_prefix,
+                dependency_stmts=dependency_stmts,
+                role_prelude_stmts=role_prelude_stmts,
+                initialize_tile_counter=initialize_tile_counter,
             )
         assert store_aux_per_tile_stmts is None, (
             "store-warp aux merge requires ROLE_LOCAL_WITH_SCHEDULER"
@@ -2786,22 +2851,15 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                 ),
             ]
         )
-        tile_counter_var = None
-        increment_tile_counter_per_tile = False
-        if (
-            role_block.role_predicate == self._tcgen05_epi_role_predicate()
-            and device_function.cute_state.epi_role_tile_counter_var is not None
-        ):
-            tile_counter_var = device_function.cute_state.epi_role_tile_counter_var
-            increment_tile_counter_per_tile = (
-                device_function.cute_state.epi_role_tile_counter_increment_per_tile
+        tile_counter_var, increment_tile_counter_per_tile = (
+            self._finish_role_local_prelude(
+                device_function,
+                role_block,
+                prelude,
+                role_prelude_stmts=role_prelude_stmts,
+                initialize_tile_counter=initialize_tile_counter,
             )
-            if initialize_tile_counter:
-                prelude.append(
-                    statement_from_string(f"{tile_counter_var} = cutlass.Int32(0)")
-                )
-        if role_prelude_stmts is not None:
-            prelude.extend(role_prelude_stmts)
+        )
 
         # Per-iteration refresh of role-local work-tile coordinates.
         # The role block's statements reference ``self.virtual_pid_var``
@@ -2846,6 +2904,367 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             )
         )
 
+        return create(
+            ast.If,
+            test=expr_from_string(role_block.role_predicate),
+            body=prelude,
+            orelse=[],
+        )
+
+    def _finish_role_local_prelude(
+        self,
+        device_function: DeviceFunction,
+        role_block: Tcgen05PersistentProgramIDs._PersistentRoleBlock,
+        prelude: list[ast.stmt],
+        *,
+        role_prelude_stmts: list[ast.stmt] | None,
+        initialize_tile_counter: bool,
+    ) -> tuple[str | None, bool]:
+        tile_counter_var = (
+            device_function.cute_state.epi_role_tile_counter_var
+            if role_block.role_predicate == self._tcgen05_epi_role_predicate()
+            else None
+        )
+        increment_tile_counter_per_tile = (
+            device_function.cute_state.epi_role_tile_counter_increment_per_tile
+            if tile_counter_var is not None
+            else False
+        )
+        if tile_counter_var is not None and initialize_tile_counter:
+            prelude.append(
+                statement_from_string(f"{tile_counter_var} = cutlass.Int32(0)")
+            )
+        prelude.extend(role_prelude_stmts or ())
+        return tile_counter_var, increment_tile_counter_per_tile
+
+    @staticmethod
+    def _grouped_static_dependency_stmts(
+        dependency_stmts: list[ast.stmt] | None,
+    ) -> list[ast.stmt]:
+        if dependency_stmts is None:
+            return []
+        grouped_coord_names = {
+            "virtual_pid",
+            "pid_0",
+            "pid_1",
+            "tile_offset_0",
+            "tile_offset_1",
+        }
+        filtered: list[ast.stmt] = []
+        for stmt in dependency_stmts:
+            _reads, writes = _stmt_name_uses(stmt)
+            if not (writes & grouped_coord_names):
+                filtered.append(stmt)
+                continue
+            if (
+                isinstance(stmt, ast.Assign)
+                and len(stmt.targets) == 1
+                and isinstance(stmt.targets[0], ast.Name)
+                and writes <= grouped_coord_names
+            ):
+                continue
+            raise AssertionError(
+                "tcgen05 grouped static scheduler cannot drop mixed coordinate "
+                "dependency statement: " + ast.unparse(stmt)
+            )
+        return filtered
+
+    def _grouped_worklist_nm_valid_store_m_stmts(
+        self,
+        device_function: DeviceFunction,
+    ) -> list[ast.stmt]:
+        plan = self._tcgen05_plan()
+        assert plan is not None and plan.accumulator_view == "nm"
+        grouped = plan.grouped
+        assert grouped is not None
+        assert grouped.valid_m is not None and grouped.store_m is not None
+        grouped_valid_m = grouped.valid_m
+        grouped_store_m = grouped.store_m
+        grouped_layout = grouped.layout
+        grouped_metadata_idx = grouped.metadata_idx
+        grouped_cta_tile_idx_m = grouped.cta_tile_idx_m
+
+        def metadata_load_expr(column: int) -> str:
+            return (
+                f"({grouped_layout}.iterator + "
+                f"{grouped_metadata_idx} * "
+                f"cutlass.Int32({grouped_layout}.layout.stride[0]) + "
+                f"cutlass.Int32({column}) * "
+                f"cutlass.Int32({grouped_layout}.layout.stride[1])).load()"
+            )
+
+        tile_start_var = device_function.new_var("tcgen05_grouped_selected_tile_start")
+        source_tile_m = plan.source_tile_m
+        return [
+            statement_from_string(
+                f"{tile_start_var} = {grouped_cta_tile_idx_m} * "
+                f"cutlass.Int32({source_tile_m})"
+            ),
+            statement_from_string(
+                f"{grouped_valid_m} = min(cutlass.Int32({source_tile_m}), "
+                f"max({metadata_load_expr(2)} - {tile_start_var}, cutlass.Int32(0)))"
+            ),
+            statement_from_string(
+                f"{grouped_store_m} = min(cutlass.Int32({source_tile_m}), "
+                f"{metadata_load_expr(3)} - {tile_start_var})"
+            ),
+        ]
+
+    def _build_grouped_static_role_local_while(
+        self,
+        device_function: DeviceFunction,
+        role_block: Tcgen05PersistentProgramIDs._PersistentRoleBlock,
+        *,
+        scheduler_var_prefix: str,
+        dependency_stmts: list[ast.stmt] | None,
+        role_prelude_stmts: list[ast.stmt] | None = None,
+        initialize_tile_counter: bool = True,
+    ) -> ast.stmt:
+        assert role_block.role_predicate is not None
+        plan = self._tcgen05_plan()
+        assert plan is not None and plan.grouped is not None
+        grouped = plan.grouped
+        assert plan.accumulator_view != "nm"
+
+        sched_var = device_function.new_var(f"{scheduler_var_prefix}_grouped_sched")
+        work_tile_var = device_function.new_var(f"{scheduler_var_prefix}_grouped_work")
+        group_info_var = device_function.new_var(
+            f"{scheduler_var_prefix}_group_search_result"
+        )
+
+        prelude: list[ast.stmt] = [
+            statement_from_string(
+                f"{sched_var} = cutlass.utils.StaticPersistentGroupTileScheduler.create("
+                f"{grouped.sched_params}, cute.arch.block_idx(), "
+                f"cute.arch.grid_dim(), ({plan.bm}, {plan.bn}, {plan.bk}), "
+                "cutlass.utils.create_initial_search_state(), "
+                f"{grouped.count}, {grouped.problem_sizes})"
+            ),
+            statement_from_string(
+                f"{work_tile_var} = {sched_var}.initial_work_tile_info()"
+            ),
+        ]
+
+        tile_counter_var, increment_tile_counter_per_tile = (
+            self._finish_role_local_prelude(
+                device_function,
+                role_block,
+                prelude,
+                role_prelude_stmts=role_prelude_stmts,
+                initialize_tile_counter=initialize_tile_counter,
+            )
+        )
+
+        grouped_cta_tile_idx_m = self._tcgen05_logical_m_coord_expr(
+            f"{group_info_var}.cta_tile_idx_m"
+        )
+        grouped_cta_tile_idx_n = f"{group_info_var}.cta_tile_idx_n"
+        grouped_metadata_stmts = [
+            statement_from_string(
+                f"{group_info_var} = {work_tile_var}.group_search_result"
+            ),
+            statement_from_string(
+                f"{grouped.metadata_idx} = {group_info_var}.group_idx"
+            ),
+            *(
+                [
+                    statement_from_string(
+                        f"{grouped.group_idx} = "
+                        f"({grouped.real_groups}.iterator + "
+                        f"{grouped.metadata_idx} * cutlass.Int32("
+                        f"{grouped.real_groups}.layout.stride[0])).load()"
+                    )
+                ]
+                if grouped.real_groups is not None
+                else [
+                    statement_from_string(
+                        f"{grouped.group_idx} = {grouped.metadata_idx}"
+                    )
+                ]
+            ),
+            statement_from_string(
+                f"{grouped.problem_m} = {group_info_var}.problem_shape_m"
+            ),
+            statement_from_string(
+                f"{grouped.problem_n} = {group_info_var}.problem_shape_n"
+            ),
+            statement_from_string(
+                f"{grouped.problem_k} = {group_info_var}.problem_shape_k"
+            ),
+            statement_from_string(
+                f"{grouped.cta_tile_idx_m} = {grouped_cta_tile_idx_m}"
+            ),
+            statement_from_string(
+                f"{grouped.cta_tile_idx_n} = {grouped_cta_tile_idx_n}"
+            ),
+            statement_from_string(
+                f"{grouped.global_m_start} = "
+                f"({grouped.starts}.iterator + {grouped.metadata_idx} "
+                f"* cutlass.Int32({grouped.starts}.layout.stride[0])).load()"
+            ),
+            statement_from_string(f"pid_0 = {grouped.cta_tile_idx_m}"),
+            statement_from_string(f"pid_1 = {grouped.cta_tile_idx_n}"),
+            statement_from_string(
+                f"tile_offset_0 = {grouped.global_m_start} + "
+                f"{grouped.cta_tile_idx_m} * "
+                f"cutlass.Int32({plan.source_tile_m})"
+            ),
+            statement_from_string(
+                f"tile_offset_1 = {grouped.cta_tile_idx_n} * "
+                f"cutlass.Int32({plan.source_tile_n})"
+            ),
+        ]
+        per_tile_body: list[ast.stmt] = grouped_metadata_stmts
+        per_tile_body.extend(self._grouped_static_dependency_stmts(dependency_stmts))
+        per_tile_body.extend(role_block.stmts)
+        if tile_counter_var is not None and increment_tile_counter_per_tile:
+            per_tile_body.append(
+                statement_from_string(
+                    f"{tile_counter_var} = {tile_counter_var} + cutlass.Int32(1)"
+                )
+            )
+        per_tile_body.extend(
+            [
+                statement_from_string(f"{sched_var}.advance_to_next_work()"),
+                statement_from_string(
+                    f"{work_tile_var} = {sched_var}.get_current_work()"
+                ),
+            ]
+        )
+        prelude.append(
+            create(
+                ast.While,
+                test=expr_from_string(f"{work_tile_var}.is_valid_tile"),
+                body=per_tile_body,
+                orelse=[],
+            )
+        )
+        return create(
+            ast.If,
+            test=expr_from_string(role_block.role_predicate),
+            body=prelude,
+            orelse=[],
+        )
+
+    def _build_grouped_static_role_local_while_with_scheduler(
+        self,
+        device_function: DeviceFunction,
+        layout: Tcgen05PersistentProgramIDs._Tcgen05PersistentLayout,
+        role_block: Tcgen05PersistentProgramIDs._PersistentRoleBlock,
+        *,
+        scheduler_var_prefix: str,
+        dependency_stmts: list[ast.stmt] | None,
+        role_prelude_stmts: list[ast.stmt] | None = None,
+        emit_pdl_wait: bool = True,
+        initialize_tile_counter: bool = True,
+    ) -> ast.stmt:
+        assert role_block.role_predicate is not None
+        assert self._tcgen05_uses_grouped_worklist_nm_scheduler_mailbox()
+        plan = self._tcgen05_plan()
+        assert plan is not None
+        grouped = plan.grouped
+        assert grouped is not None
+        sched_pipeline_plan = self._tcgen05_sched_pipeline_plan()
+        assert sched_pipeline_plan is not None
+
+        sched_pipeline = sched_pipeline_plan.pipeline
+        sched_consumer_state = sched_pipeline_plan.consumer_state
+        valid_var = device_function.new_var(f"{scheduler_var_prefix}_valid")
+
+        prelude: list[ast.stmt] = []
+        if (
+            emit_pdl_wait
+            and self._tcgen05_is_two_cta()
+            and role_block.role_predicate == self._tcgen05_tma_load_role_predicate()
+        ):
+            prelude.append(statement_from_string("cute.arch.griddepcontrol_wait()"))
+
+        tile_counter_var, increment_tile_counter_per_tile = (
+            self._finish_role_local_prelude(
+                device_function,
+                role_block,
+                prelude,
+                role_prelude_stmts=role_prelude_stmts,
+                initialize_tile_counter=initialize_tile_counter,
+            )
+        )
+
+        work_tile_stage_index = (
+            f"{sched_consumer_state}.index"
+            if self._tcgen05_uses_staged_work_tile_mailbox()
+            else None
+        )
+
+        def slot(i: int) -> str:
+            return self._tcgen05_work_tile_slot(layout, i)
+
+        def _consumer_wait_block() -> list[ast.stmt]:
+            return _build_sched_pipeline_consumer_wait_block(
+                sched_pipeline=sched_pipeline,
+                sched_consumer_state=sched_consumer_state,
+                work_tile_smem=layout.work_tile_smem,
+                valid_var=valid_var,
+                valid_slot_index=_TCGEN05_GROUPED_SELECTED_MAILBOX_VALID,
+                work_tile_stage_index=work_tile_stage_index,
+            )
+
+        def _consumer_release_block() -> list[ast.stmt]:
+            return _build_sched_pipeline_consumer_release_block(
+                sched_pipeline=sched_pipeline,
+                sched_consumer_state=sched_consumer_state,
+            )
+
+        grouped_valid_store_m_stmts = (
+            self._grouped_worklist_nm_valid_store_m_stmts(device_function)
+            if role_block.role_predicate == self._tcgen05_epi_role_predicate()
+            else []
+        )
+        mailbox_fields = (
+            (grouped.cta_tile_idx_m, _TCGEN05_GROUPED_SELECTED_MAILBOX_CTA_M),
+            (grouped.cta_tile_idx_n, _TCGEN05_GROUPED_SELECTED_MAILBOX_CTA_N),
+            (grouped.metadata_idx, _TCGEN05_GROUPED_SELECTED_MAILBOX_METADATA_IDX),
+            (grouped.group_idx, _TCGEN05_GROUPED_SELECTED_MAILBOX_GROUP_IDX),
+            (grouped.problem_m, _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_M),
+            (grouped.problem_n, _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_N),
+            (grouped.problem_k, _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_K),
+            (
+                grouped.global_m_start,
+                _TCGEN05_GROUPED_SELECTED_MAILBOX_GLOBAL_M_START,
+            ),
+        )
+        grouped_metadata_read_stmts = [
+            statement_from_string(f"{name} = {slot(field)}")
+            for name, field in mailbox_fields
+        ]
+        grouped_metadata_read_stmts.extend(grouped_valid_store_m_stmts)
+        grouped_metadata_read_stmts.extend(
+            [
+                statement_from_string(f"pid_0 = {grouped.cta_tile_idx_m}"),
+                statement_from_string(f"pid_1 = {grouped.cta_tile_idx_n}"),
+            ]
+        )
+
+        prelude.extend(_consumer_wait_block())
+        per_tile_body: list[ast.stmt] = grouped_metadata_read_stmts
+        per_tile_body.extend(_consumer_release_block())
+        per_tile_body.extend(self._grouped_static_dependency_stmts(dependency_stmts))
+        per_tile_body.extend(role_block.stmts)
+        if tile_counter_var is not None and increment_tile_counter_per_tile:
+            per_tile_body.append(
+                statement_from_string(
+                    f"{tile_counter_var} = {tile_counter_var} + cutlass.Int32(1)"
+                )
+            )
+        per_tile_body.extend(_consumer_wait_block())
+        prelude.append(
+            create(
+                ast.While,
+                test=expr_from_string(valid_var),
+                body=per_tile_body,
+                orelse=[],
+            )
+        )
+        prelude.extend(_consumer_release_block())
         return create(
             ast.If,
             test=expr_from_string(role_block.role_predicate),
@@ -2909,22 +3328,15 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             # Same PDL hand-off as the MONOLITHIC path.
             prelude.append(statement_from_string("cute.arch.griddepcontrol_wait()"))
 
-        tile_counter_var = None
-        increment_tile_counter_per_tile = False
-        if (
-            role_block.role_predicate == self._tcgen05_epi_role_predicate()
-            and device_function.cute_state.epi_role_tile_counter_var is not None
-        ):
-            tile_counter_var = device_function.cute_state.epi_role_tile_counter_var
-            increment_tile_counter_per_tile = (
-                device_function.cute_state.epi_role_tile_counter_increment_per_tile
+        tile_counter_var, increment_tile_counter_per_tile = (
+            self._finish_role_local_prelude(
+                device_function,
+                role_block,
+                prelude,
+                role_prelude_stmts=role_prelude_stmts,
+                initialize_tile_counter=initialize_tile_counter,
             )
-            if initialize_tile_counter:
-                prelude.append(
-                    statement_from_string(f"{tile_counter_var} = cutlass.Int32(0)")
-                )
-        if role_prelude_stmts is not None:
-            prelude.extend(role_prelude_stmts)
+        )
 
         work_tile_stage_index = (
             f"{sched_consumer_state}.index"
@@ -3029,6 +3441,232 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             orelse=[],
         )
 
+    def _build_grouped_worklist_nm_scheduler_warp_role_local_while(
+        self,
+        device_function: DeviceFunction,
+        layout: Tcgen05PersistentProgramIDs._Tcgen05PersistentLayout,
+    ) -> ast.stmt:
+        assert self._tcgen05_uses_grouped_worklist_nm_scheduler_mailbox()
+        plan = self._tcgen05_plan()
+        assert plan is not None and plan.grouped is not None
+        grouped = plan.grouped
+        assert grouped.real_groups is not None
+        source_tile_m = plan.source_tile_m
+        source_tile_n = plan.source_tile_n
+        grouped_starts = grouped.starts
+        grouped_real_groups = grouped.real_groups
+
+        sched_plan = self._tcgen05_sched_pipeline_plan()
+        assert sched_plan is not None
+        sched_pipeline = sched_plan.pipeline
+        sched_producer_state = sched_plan.producer_state
+
+        sched_var = device_function.new_var("tcgen05_grouped_selected_sched")
+        work_tile_var = device_function.new_var("tcgen05_grouped_selected_work_tile")
+        group_info_var = device_function.new_var(
+            "tcgen05_grouped_selected_group_search_result"
+        )
+        metadata_idx_var = device_function.new_var(
+            "tcgen05_grouped_selected_metadata_idx"
+        )
+        group_idx_var = device_function.new_var("tcgen05_grouped_selected_group_idx")
+        cta_tile_idx_m_var = device_function.new_var(
+            "tcgen05_grouped_selected_cta_tile_idx_m"
+        )
+        cta_tile_idx_n_var = device_function.new_var(
+            "tcgen05_grouped_selected_cta_tile_idx_n"
+        )
+        source_n_tiles_var = device_function.new_var(
+            "tcgen05_grouped_selected_source_n_tiles"
+        )
+        source_m_tiles_var = device_function.new_var(
+            "tcgen05_grouped_selected_source_m_tiles"
+        )
+        source_m_fast_linear_var = device_function.new_var(
+            "tcgen05_grouped_selected_source_m_fast_linear"
+        )
+
+        leader_predicate = "cute.arch.lane_idx() == cutlass.Int32(0)"
+
+        def slot(i: int) -> str:
+            return self._tcgen05_work_tile_producer_slot(layout, i)
+
+        mailbox_values = (
+            (_TCGEN05_GROUPED_SELECTED_MAILBOX_CTA_M, cta_tile_idx_m_var),
+            (_TCGEN05_GROUPED_SELECTED_MAILBOX_CTA_N, cta_tile_idx_n_var),
+            (_TCGEN05_GROUPED_SELECTED_MAILBOX_VALID, "cutlass.Int32(1)"),
+            (_TCGEN05_GROUPED_SELECTED_MAILBOX_METADATA_IDX, metadata_idx_var),
+            (_TCGEN05_GROUPED_SELECTED_MAILBOX_GROUP_IDX, group_idx_var),
+            (
+                _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_M,
+                f"{group_info_var}.problem_shape_n",
+            ),
+            (
+                _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_N,
+                f"{group_info_var}.problem_shape_m",
+            ),
+            (
+                _TCGEN05_GROUPED_SELECTED_MAILBOX_PROBLEM_K,
+                f"{group_info_var}.problem_shape_k",
+            ),
+            (
+                _TCGEN05_GROUPED_SELECTED_MAILBOX_GLOBAL_M_START,
+                (
+                    f"({grouped_starts}.iterator + {metadata_idx_var} * "
+                    f"cutlass.Int32({grouped_starts}.layout.stride[0])).load()"
+                ),
+            ),
+        )
+
+        def source_m_fast_raster_stmts() -> list[ast.stmt]:
+            source_n_tiles_expr = CompileEnvironment.current().backend.cdiv_expr(
+                f"{group_info_var}.problem_shape_m",
+                f"cutlass.Int32({source_tile_n})",
+                is_device=True,
+            )
+            return [
+                statement_from_string(f"{source_n_tiles_var} = {source_n_tiles_expr}"),
+                statement_from_string(
+                    f"{source_m_tiles_var} = {group_info_var}.problem_shape_n // "
+                    f"cutlass.Int32({source_tile_m})"
+                ),
+                create(
+                    ast.If,
+                    test=expr_from_string(
+                        f"{source_m_tiles_var} <= {source_n_tiles_var}"
+                    ),
+                    body=[
+                        # For wide compact rows, walk source-M fastest to keep
+                        # adjacent CTAs on nearby packed-A rows.
+                        statement_from_string(
+                            f"{source_m_fast_linear_var} = "
+                            f"{cta_tile_idx_m_var} * {source_n_tiles_var} + "
+                            f"{cta_tile_idx_n_var}"
+                        ),
+                        statement_from_string(
+                            f"{cta_tile_idx_m_var} = "
+                            f"{source_m_fast_linear_var} % {source_m_tiles_var}"
+                        ),
+                        statement_from_string(
+                            f"{cta_tile_idx_n_var} = "
+                            f"{source_m_fast_linear_var} // {source_m_tiles_var}"
+                        ),
+                    ],
+                    orelse=[],
+                ),
+            ]
+
+        def publish_current_tile_leader_stmts() -> list[ast.stmt]:
+            return [
+                statement_from_string(
+                    f"{sched_pipeline}.producer_acquire({sched_producer_state})"
+                ),
+                statement_from_string(
+                    f"{group_info_var} = {work_tile_var}.group_search_result"
+                ),
+                statement_from_string(
+                    f"{metadata_idx_var} = {group_info_var}.group_idx"
+                ),
+                *(
+                    [
+                        statement_from_string(
+                            f"{group_idx_var} = "
+                            f"({grouped_real_groups}.iterator + "
+                            f"{metadata_idx_var} * cutlass.Int32("
+                            f"{grouped_real_groups}.layout.stride[0])).load()"
+                        )
+                    ]
+                    if grouped_real_groups
+                    else [
+                        statement_from_string(f"{group_idx_var} = {metadata_idx_var}")
+                    ]
+                ),
+                statement_from_string(
+                    f"{cta_tile_idx_m_var} = {group_info_var}.cta_tile_idx_n"
+                ),
+                statement_from_string(
+                    f"{cta_tile_idx_n_var} = "
+                    f"{self._tcgen05_logical_m_coord_expr(f'{group_info_var}.cta_tile_idx_m')}"
+                ),
+                *source_m_fast_raster_stmts(),
+                *[
+                    statement_from_string(f"{slot(field)} = {value}")
+                    for field, value in mailbox_values
+                ],
+                statement_from_string(
+                    f"{sched_pipeline}.producer_commit({sched_producer_state})"
+                ),
+            ]
+
+        def publish_current_tile_stmts() -> list[ast.stmt]:
+            return [
+                create(
+                    ast.If,
+                    test=expr_from_string(leader_predicate),
+                    body=publish_current_tile_leader_stmts(),
+                    orelse=[],
+                ),
+                statement_from_string(emit_pipeline_advance(sched_producer_state)),
+                statement_from_string("cute.arch.sync_warp()"),
+            ]
+
+        def scheduler_advance_stmts() -> list[ast.stmt]:
+            return [
+                statement_from_string(f"{sched_var}.advance_to_next_work()"),
+                statement_from_string(
+                    f"{work_tile_var} = {sched_var}.get_current_work()"
+                ),
+            ]
+
+        prelude: list[ast.stmt] = [
+            statement_from_string(
+                f"{sched_var} = cutlass.utils.StaticPersistentGroupTileScheduler.create("
+                f"{grouped.sched_params}, cute.arch.block_idx(), "
+                f"cute.arch.grid_dim(), ({plan.bm}, {plan.bn}, {plan.bk}), "
+                "cutlass.utils.create_initial_search_state(), "
+                f"{grouped.count}, {grouped.problem_sizes})"
+            ),
+            statement_from_string(
+                f"{work_tile_var} = {sched_var}.initial_work_tile_info()"
+            ),
+            create(
+                ast.While,
+                test=expr_from_string(f"{work_tile_var}.is_valid_tile"),
+                body=[*publish_current_tile_stmts(), *scheduler_advance_stmts()],
+                orelse=[],
+            ),
+        ]
+
+        prelude.extend(
+            [
+                create(
+                    ast.If,
+                    test=expr_from_string(leader_predicate),
+                    body=[
+                        statement_from_string(
+                            f"{sched_pipeline}.producer_acquire({sched_producer_state})"
+                        ),
+                        statement_from_string(
+                            f"{slot(_TCGEN05_GROUPED_SELECTED_MAILBOX_VALID)} = "
+                            "cutlass.Int32(0)"
+                        ),
+                        statement_from_string(
+                            f"{sched_pipeline}.producer_commit({sched_producer_state})"
+                        ),
+                    ],
+                    orelse=[],
+                ),
+                statement_from_string(emit_pipeline_advance(sched_producer_state)),
+                statement_from_string("cute.arch.sync_warp()"),
+            ]
+        )
+        return create(
+            ast.If,
+            test=expr_from_string(self._tcgen05_scheduler_role_predicate()),
+            body=prelude,
+            orelse=[],
+        )
+
     def _build_scheduler_warp_role_local_while(
         self,
         device_function: DeviceFunction,
@@ -3061,6 +3699,10 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         """
         plan = self._tcgen05_plan()
         assert plan is not None and plan.has_scheduler_warp
+        if self._tcgen05_uses_grouped_worklist_nm_scheduler_mailbox():
+            return self._build_grouped_worklist_nm_scheduler_warp_role_local_while(
+                device_function, layout
+            )
         if plan.is_clc_persistent:
             return self._build_scheduler_warp_role_local_while_clc(
                 device_function, layout
@@ -4687,6 +5329,7 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             "cutlass.Float32",
             "cutlass.Float8E4M3FN",
             "cutlass.Int32",
+            "cutlass.Int64",
         }
     )
 
@@ -4768,6 +5411,90 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
             and not expr.keywords
         )
 
+    @staticmethod
+    def _tcgen05_single_name_assignment(
+        stmt: ast.stmt,
+    ) -> tuple[str, ast.expr] | None:
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+        ):
+            return stmt.targets[0].id, stmt.value
+        return None
+
+    @staticmethod
+    def _tcgen05_numbered_name(name: str, base: str) -> bool:
+        prefix = f"{base}_"
+        return name.startswith(prefix) and name[len(prefix) :].isdecimal()
+
+    @classmethod
+    def _tcgen05_grouped_stmt_safe_to_omit(
+        cls,
+        stmt: ast.stmt,
+        *,
+        allowed_coord_writes: set[str],
+        worklist_metadata: bool,
+    ) -> bool:
+        if isinstance(stmt, ast.Pass):
+            return True
+        if isinstance(stmt, ast.Expr):
+            return cls._tcgen05_is_bare_sync_threads_call(stmt.value)
+        assignment = cls._tcgen05_single_name_assignment(stmt)
+        if assignment is not None:
+            name, value = assignment
+            if name in allowed_coord_writes or name == "safe_group_id":
+                return cls._tcgen05_expr_safe_to_omit(value)
+            if name == "group_id":
+                return cls._tcgen05_expr_safe_to_omit(value) or (
+                    isinstance(value, ast.Call)
+                    and isinstance(value.func, ast.Attribute)
+                    and value.func.attr == "load"
+                    and not value.args
+                    and not value.keywords
+                    and cls._tcgen05_expr_safe_to_omit(value.func.value)
+                )
+            return (
+                isinstance(value, ast.Call)
+                and cls._tcgen05_call_path(value.func) == "operator.ge"
+                and len(value.args) == 2
+                and not value.keywords
+                and isinstance(value.args[0], ast.Name)
+                and value.args[0].id == "group_id"
+                and cls._tcgen05_expr_safe_to_omit(value.args[1])
+            )
+        if (
+            not isinstance(stmt, ast.For)
+            or not isinstance(stmt.target, ast.Name)
+            or not cls._tcgen05_numbered_name(stmt.target.id, "tile_offset")
+            or stmt.orelse
+            or not cls._tcgen05_expr_safe_to_omit(stmt.iter)
+        ):
+            return False
+        allowed_names = {"acc_copy", "safe_group_id_copy"}
+        allowed_bases = {"indices", "mask", *allowed_names}
+        if worklist_metadata:
+            allowed_names.update({"group_id_copy", "v_0_copy", "v_1_copy"})
+            allowed_bases.update(allowed_names)
+        for child in stmt.body:
+            if isinstance(child, ast.Pass):
+                continue
+            assignment = cls._tcgen05_single_name_assignment(child)
+            if assignment is None:
+                return False
+            name, value = assignment
+            if (
+                name != stmt.target.id
+                and name not in allowed_names
+                and not any(
+                    cls._tcgen05_numbered_name(name, base) for base in allowed_bases
+                )
+            ):
+                return False
+            if not cls._tcgen05_expr_safe_to_omit(value):
+                return False
+        return True
+
     @classmethod
     def _tcgen05_shared_stmt_safe_to_omit(cls, stmt: ast.stmt) -> bool:
         """Return whether a removed shared stmt is dependency-only setup.
@@ -4825,6 +5552,52 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
         ]
         assert not unsafe, (
             "tcgen05 fully role-local codegen would discard observable shared "
+            "statement(s) while omitting the residual shared loop: " + "; ".join(unsafe)
+        )
+
+    def _assert_tcgen05_grouped_omit_shared_loop_safe(
+        self, partition: Tcgen05PersistentProgramIDs._PartitionedRoleBody
+    ) -> None:
+        plan = self._tcgen05_plan()
+        worklist_metadata = bool(
+            plan is not None
+            and plan.grouped is not None
+            and plan.grouped.real_groups is not None
+        )
+        allowed_coord_writes = {
+            "virtual_pid",
+            "pid_0",
+            "pid_1",
+            "tile_offset_0",
+            "tile_offset_1",
+        }
+        if worklist_metadata:
+            # Generated segment worklists re-express the original
+            # parser-order work row as the grouped scheduler's pseudo-group.
+            # Once the scheduler metadata statements are injected, the old
+            # segment-loop coordinate and scalar scaffolding is dependency-only.
+            allowed_coord_writes.update(
+                {
+                    "pid_2",
+                    "tile_offset_2",
+                    "tile_offset_3",
+                    "indices_2",
+                    "indices_3",
+                    "mask_2",
+                    "mask_3",
+                }
+            )
+        unsafe = [
+            ast.unparse(stmt)
+            for stmt in partition.shared_body_extracted
+            if not self._tcgen05_grouped_stmt_safe_to_omit(
+                stmt,
+                allowed_coord_writes=allowed_coord_writes,
+                worklist_metadata=worklist_metadata,
+            )
+        ]
+        assert not unsafe, (
+            "tcgen05 grouped static scheduler would discard observable shared "
             "statement(s) while omitting the residual shared loop: " + "; ".join(unsafe)
         )
 
@@ -4890,7 +5663,10 @@ class Tcgen05PersistentProgramIDs(PersistentProgramIDs):
                 layout, shared_role_blocks
             )
         else:
-            self._assert_tcgen05_omit_shared_loop_safe(partition)
+            if self._tcgen05_uses_grouped_static_persistent():
+                self._assert_tcgen05_grouped_omit_shared_loop_safe(partition)
+            else:
+                self._assert_tcgen05_omit_shared_loop_safe(partition)
             shared_tile_body = []
         # Merge extracted blocks by ``role_predicate`` so each predicate
         # gets one role-local loop carrying all of its per-tile

--- a/helion/_testing.py
+++ b/helion/_testing.py
@@ -408,6 +408,21 @@ def skipIfCute(reason: str) -> Callable[[Callable], Callable]:
     return skipIfFn(lambda: _get_backend() == "cute", reason)
 
 
+def matchesBackends(backends: Sequence[str]) -> bool:
+    """Return whether `_get_backend() in backends`, matching onlyBackends."""
+    backend = _get_backend()
+    return backend in backends or (backend == "tileir" and "triton" in backends)
+
+
+def skipUnlessBackends(backends: Sequence[str]) -> pytest.MarkDecorator:
+    """Return a pytest mark that skips unless `_get_backend() in backends`."""
+    backend = _get_backend()
+    return pytest.mark.skipif(
+        not matchesBackends(backends),
+        reason=f"disabled for HELION_BACKEND={backend}",
+    )
+
+
 def default_cute_mma_support(
     *,
     supported_impls: tuple[str, ...] = ("universal", "warp", "tcgen05"),
@@ -483,7 +498,7 @@ def onlyBackends(
 
     def wrapper(cls: type[unittest.TestCase]) -> type[unittest.TestCase]:
         backend = _get_backend()
-        if backend in backends or (backend == "tileir" and "triton" in backends):
+        if matchesBackends(backends):
             return cls
         return unittest.skip(f"disabled for HELION_BACKEND={backend}")(cls)
 

--- a/helion/language/memory_ops.py
+++ b/helion/language/memory_ops.py
@@ -15,6 +15,8 @@ from .._compiler.ast_extension import statement_from_string
 from .._compiler.compile_environment import CompileEnvironment
 from .._compiler.compile_environment import _symint_expr
 from .._compiler.cute.cutedsl_compat import emit_pipeline_advance
+from .._compiler.cute.device_state import Tcgen05GroupedDMode
+from .._compiler.cute.device_state import Tcgen05Orientation
 from .._compiler.cute.strategies import tcgen05_explicit_d_store_tile_expr
 from .._compiler.cute.strategies import tcgen05_is_two_cta_m128
 from .._compiler.cute.strategies import tcgen05_resolve_epilogue_tile
@@ -45,6 +47,7 @@ from .._compiler.cute.tcgen05_constants import (
     TCGEN05_EPILOGUE_LAYOUT_SPLIT_ACC_T2R_STORE_TAIL,
 )
 from .._compiler.cute.tcgen05_constants import TCGEN05_EPILOGUE_LAYOUT_SPLIT_FIRST_T2R
+from .._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_WORKLIST_STORE_SHAPE
 from .._compiler.cute.tcgen05_constants import TCGEN05_TWO_CTA_BLOCK_N
 from .._compiler.cute.tcgen05_pure_matmul import Tcgen05TmaStoreBodyCoreParams
 from .._compiler.cute.tcgen05_pure_matmul import Tcgen05TmaStorePipelineParams
@@ -65,8 +68,10 @@ from . import _decorators
 from .stack_tensor import StackTensor
 
 if TYPE_CHECKING:
+    from .._compiler.cute.cute_epilogue import Tcgen05GroupedTailEpilogueMatch
     from .._compiler.cute.cute_epilogue import Tcgen05UnaryEpilogueChain
     from .._compiler.cute.cute_epilogue import _AuxiliaryTensorStep
+    from .._compiler.cute.device_state import CuteTcgen05StoreValue
     from .._compiler.inductor_lowering import CodegenState
     from .._compiler.tile_strategy import LoopDimInfo
 
@@ -1461,6 +1466,38 @@ def _cute_tile_begin_expr(state: CodegenState, idx: object) -> str:
     raise exc.BackendUnsupported("cute", f"unlowerable tile base index: {idx}")
 
 
+def _tcgen05_segment_store_matches_proof(
+    state: CodegenState,
+    tcgen05_value: CuteTcgen05StoreValue,
+) -> bool:
+    from .._compiler.cute.cute_mma import _rank3_rhs_broadcast_mask_base
+    from .._compiler.cute.cute_mma import _trace_to_outer_graph_arg
+
+    store_node = tcgen05_value.segment_store_node
+    if store_node is None or state.fx_node is not store_node:
+        return False
+    index = store_node.args[1] if len(store_node.args) > 1 else None
+    extra_mask = store_node.args[3] if len(store_node.args) > 3 else None
+    if (
+        not isinstance(index, (list, tuple))
+        or len(index) != 2
+        or not isinstance(index[0], torch.fx.Node)
+        or not isinstance(extra_mask, torch.fx.Node)
+        or tcgen05_value.segment_store_row_index is None
+        or tcgen05_value.segment_store_valid_m is None
+    ):
+        return False
+    store_row = _trace_to_outer_graph_arg(state.codegen, index[0])
+    if store_row is not tcgen05_value.segment_store_row_index:
+        return False
+    store_mask = _trace_to_outer_graph_arg(state.codegen, extra_mask)
+    store_valid_m = _rank3_rhs_broadcast_mask_base(store_mask, broadcast_dim=1)
+    if store_valid_m is None:
+        return False
+    store_valid_m = _trace_to_outer_graph_arg(state.codegen, store_valid_m)
+    return store_valid_m is tcgen05_value.segment_store_valid_m
+
+
 def _cute_leading_passthrough_view_2d(
     result_name: str,
     tensor_name: str,
@@ -1486,11 +1523,22 @@ def _codegen_cute_store_tcgen05_tile(
     extra_mask: ast.AST | None,
     value_name: str,
     epilogue_chain: Tcgen05UnaryEpilogueChain | None = None,
+    grouped_tail_epilogue: Tcgen05GroupedTailEpilogueMatch | None = None,
 ) -> list[ast.AST] | ast.AST | None:
     df = state.device_function
     candidate_names = df.variable_aliases(value_name)
     tcgen05_value = df.cute_state.get_tcgen05_store_value(candidate_names)
     if tcgen05_value is None:
+        return None
+    segment_store = bool(
+        tcgen05_value.segment_store_m_offset
+        and tcgen05_value.segment_store_start
+        and tcgen05_value.segment_store_actual_m
+    )
+    if segment_store and (
+        extra_mask is None
+        or not _tcgen05_segment_store_matches_proof(state, tcgen05_value)
+    ):
         return None
     if extra_mask is not None:
         if tcgen05_value.pure_matmul_role_lifecycle:
@@ -1498,7 +1546,8 @@ def _codegen_cute_store_tcgen05_tile(
                 "cute",
                 "tcgen05 pure role-lifecycle store cannot use an extra store mask",
             )
-        return None
+        if not segment_store:
+            return None
     if tcgen05_value.pure_matmul_role_lifecycle and tensor.ndim != 2:
         raise exc.BackendUnsupported(
             "cute",
@@ -1510,22 +1559,40 @@ def _codegen_cute_store_tcgen05_tile(
     env = CompileEnvironment.current()
     store_node = state.fx_node
     store_subscripts = store_node.args[1] if store_node is not None else None
-    actual_block_ids = (
-        exact_tile_block_ids(env, store_subscripts)
-        if isinstance(store_subscripts, (list, tuple))
-        else None
-    )
-    if actual_block_ids != tcgen05_value.output_block_ids:
+    actual_block_ids = None
+    if isinstance(store_subscripts, (list, tuple)):
+        if segment_store:
+            # The registered segment proof ties the dynamic row index to the
+            # work and M axes. The remaining N index must still be the exact
+            # zero-offset output tile, just as it is for ordinary stores.
+            actual_block_ids = exact_tile_block_ids(env, store_subscripts[1:])
+            expected_block_ids = tcgen05_value.output_block_ids[-1:]
+        else:
+            actual_block_ids = exact_tile_block_ids(env, store_subscripts)
+            expected_block_ids = tcgen05_value.output_block_ids
+    else:
+        expected_block_ids = tcgen05_value.output_block_ids
+    if actual_block_ids != expected_block_ids:
         raise exc.BackendUnsupported(
             "cute",
             "tcgen05 matmul store requires the exact zero-offset output tile axes",
         )
     if tcgen05_value.pure_matmul_role_lifecycle:
-        if epilogue_chain is not None:
+        if epilogue_chain is not None or grouped_tail_epilogue is not None:
             raise exc.BackendUnsupported(
                 "cute",
                 "tcgen05 pure role-lifecycle supports only identity pure-matmul stores",
             )
+    if tcgen05_value.orientation is Tcgen05Orientation.NM and (
+        epilogue_chain is not None or grouped_tail_epilogue is not None
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 N,M-oriented worklist path supports only an identity BF16 store",
+        )
+    assert (
+        sum(value is not None for value in (epilogue_chain, grouped_tail_epilogue)) <= 1
+    )
     # When one matmul accumulator fans out to multiple output stores (e.g.
     # aux = pre-activation and out = gelu(pre)), the per-matmul TMA-store
     # atom/tensor kernel-arg names allocated in cute_mma are shared by every
@@ -1622,20 +1689,64 @@ def _codegen_cute_store_tcgen05_tile(
             f"up with epi_elem_dtype_str={tcgen05_value.epi_elem_dtype_str!r} "
             f"but the store target tensor dtype is {target_dtype!r}.",
         )
-    base_indices = [_cute_tile_begin_expr(state, idx) for idx in subscript]
-    if len(base_indices) != (3 if leading_passthrough_output else 2):
+    if (
+        tcgen05_value.orientation is Tcgen05Orientation.NM
+        and target_dtype != "cutlass.BFloat16"
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 N,M-oriented worklist path requires a fixed BF16 store",
+        )
+    tcgen05_d_store_layout = tcgen05_value.d_store_layout
+    tcgen05_nm_store = tcgen05_value.orientation is Tcgen05Orientation.NM
+    if (
+        tcgen05_nm_store
+        and (
+            tcgen05_value.explicit_epi_tile_m,
+            tcgen05_value.explicit_epi_tile_n,
+            tcgen05_value.explicit_d_store_box_n,
+        )
+        != TCGEN05_GROUPED_WORKLIST_STORE_SHAPE
+    ):
+        raise exc.BackendUnsupported(
+            "cute",
+            "tcgen05 N,M-oriented store requires explicit "
+            "epi_tile=(128, 32) and d_store_box_n=32",
+        )
+    if len(subscript) != (3 if leading_passthrough_output else 2):
         if tcgen05_value.pure_matmul_role_lifecycle:
             raise exc.BackendUnsupported(
                 "cute",
                 "tcgen05 pure role-lifecycle store requires a rank-2 tile store",
             )
         return None
+    if segment_store:
+        base_indices = [
+            "",
+            _cute_tile_begin_expr(state, subscript[1]),
+        ]
+    else:
+        base_indices = [_cute_tile_begin_expr(state, idx) for idx in subscript]
     leading_index = base_indices[0] if leading_passthrough_output else None
     m_index, n_index = base_indices[-2:]
     m_size = _cute_tensor_dim_size_expr(state, tensor, tensor.ndim - 2)
     n_size = _cute_tensor_dim_size_expr(state, tensor, tensor.ndim - 1)
-    tile_coord_m = f"({m_index}) // cutlass.Int32({tcgen05_value.bm})"
-    tile_coord_n = f"({n_index}) // cutlass.Int32({tcgen05_value.bn})"
+    segment_store_local_m = tcgen05_value.segment_store_m_offset
+    segment_store_base_m = (
+        f"cutlass.Int32({tcgen05_value.segment_store_start}) + {segment_store_local_m}"
+        if segment_store
+        else ""
+    )
+    tcgen05_source_bm = tcgen05_value.source_tile_m
+    tcgen05_source_bn = tcgen05_value.source_tile_n
+    tile_coord_m = (
+        "cutlass.Int32(0)"
+        if segment_store
+        else f"({m_index}) // cutlass.Int32({tcgen05_source_bm})"
+    )
+    tile_coord_n = f"({n_index}) // cutlass.Int32({tcgen05_source_bn})"
+    static_tile_coord_m = tile_coord_m
+    static_tile_coord_n = tile_coord_n
     full_tile = df.new_var("tcgen05_full_tile")
 
     gmem_tile = df.new_var("tcgen05_gC")
@@ -1646,6 +1757,7 @@ def _codegen_cute_store_tcgen05_tile(
     tcgc_planned = df.new_var("tcgen05_tCgC_planned")
     tccc = df.new_var("tcgen05_tCcC")
     tacc = df.new_var("tcgen05_tAcc")
+    tacc_epi = df.new_var("tcgen05_tAcc_epi")
     epi_tile = df.new_var("tcgen05_store_epi_tile")
     tiled_copy_t2r = df.new_var("tcgen05_tiled_copy_t2r")
     thr_copy_t2r = df.new_var("tcgen05_thr_copy_t2r")
@@ -1660,9 +1772,14 @@ def _codegen_cute_store_tcgen05_tile(
     ttr_tacc = df.new_var("tcgen05_tTR_tAcc")
     ttr_gc_grouped = df.new_var("tcgen05_tTR_gC_grouped")
     ttr_cc_grouped = df.new_var("tcgen05_tTR_cC_grouped")
-    ttr_tacc_mn = df.new_var("tcgen05_tTR_tAcc_mn")
+    ttr_tacc_mn = df.new_var(
+        "tcgen05_tTR_tAcc_nm" if tcgen05_nm_store else "tcgen05_tTR_tAcc_mn"
+    )
     ttr_gc_subtile = df.new_var("tcgen05_tTR_gC_subtile")
     ttr_cc_subtile = df.new_var("tcgen05_tTR_cC_subtile")
+    trs_cc = df.new_var("tcgen05_tRS_cC")
+    trs_cc_grouped = df.new_var("tcgen05_tRS_cC_grouped")
+    trs_cc_subtile = df.new_var("tcgen05_tRS_cC_subtile")
     acc_vec = df.new_var("tcgen05_acc_vec")
     kernel_desc = df.new_var("tcgen05_kernel_desc")
     mcld = df.new_var("tcgen05_mcld")
@@ -1672,12 +1789,37 @@ def _codegen_cute_store_tcgen05_tile(
     smem_d_ptr = df.new_var("tcgen05_sD_ptr")
     smem_d = df.new_var("tcgen05_sD")
     tiled_copy_r2s = df.new_var("tcgen05_tiled_copy_r2s")
+    copy_atom_r2s = df.new_var("tcgen05_selected_nm_stsm_atom")
+    thr_copy_r2s = df.new_var("tcgen05_thr_copy_r2s")
     trs_rd = df.new_var("tcgen05_tRS_rD")
     trs_racc = df.new_var("tcgen05_tRS_rAcc")
     trs_sd = df.new_var("tcgen05_tRS_sD")
     bsg_sd = df.new_var("tcgen05_bSG_sD")
     bsg_gd_partitioned = df.new_var("tcgen05_bSG_gD_partitioned")
     bsg_gd = df.new_var("tcgen05_bSG_gD")
+    grouped_d_tensormap_manager = df.new_var("tcgen05_grouped_d_tensormap_manager")
+    grouped_d_tensormap_grid_dim = df.new_var("tcgen05_grouped_d_tensormap_grid_dim")
+    grouped_d_tensormap_workspace_idx = df.new_var(
+        "tcgen05_grouped_d_tensormap_workspace_idx"
+    )
+    grouped_d_tensormap_ptr = df.new_var("tcgen05_grouped_d_tensormap_ptr")
+    grouped_d_tensormap_desc_ptr = df.new_var("tcgen05_grouped_d_tensormap_desc_ptr")
+    grouped_d_tensormap_smem_ptr = df.new_var("tcgen05_grouped_d_tensormap_smem_ptr")
+    grouped_d_tensormap_last_group = df.new_var(
+        "tcgen05_grouped_d_tensormap_last_group"
+    )
+    grouped_d_tensormap_group_changed = df.new_var(
+        "tcgen05_grouped_d_tensormap_group_changed"
+    )
+    grouped_d_tensormap_base = df.new_var("tcgen05_grouped_d_tensormap_base")
+    grouped_d_tensormap_addr = df.new_var("tcgen05_grouped_d_tensormap_addr")
+    grouped_d_tensormap_stride_m = df.new_var("tcgen05_grouped_d_tensormap_stride_m")
+    grouped_d_tensormap_stride_n = df.new_var("tcgen05_grouped_d_tensormap_stride_n")
+    grouped_d_tensormap_real_d = df.new_var(
+        "tcgen05_grouped_d_tensormap_d_nm"
+        if tcgen05_nm_store
+        else "tcgen05_grouped_d_tensormap_real_d"
+    )
     c_buffer = df.new_var("tcgen05_c_buffer")
     epilog_sync_barrier = df.new_var("tcgen05_epilog_sync_barrier")
     c_pipeline_producer_group = df.new_var("tcgen05_c_pipeline_producer_group")
@@ -1816,6 +1958,10 @@ def _codegen_cute_store_tcgen05_tile(
     tcgen05_aux_epi_warp_count = tcgen05_value.epi_warp_count
     tcgen05_aux_epilogue_rest_mode = tcgen05_value.epilogue_rest_mode
     tcgen05_aux_use_tma_store_epilogue = tcgen05_value.use_tma_store_epilogue
+    tcgen05_aux_tmem_load_atom = tcgen05_value.tmem_load_atom
+    tcgen05_aux_tma_store_tensor = tcgen05_value.tma_store_tensor
+    tcgen05_aux_tail_tma_store_tensor = tcgen05_value.tail_tma_store_tensor
+    tcgen05_aux_segment_store_actual_m = tcgen05_value.segment_store_actual_m
     tcgen05_explicit_store_tile_expr: str | None = None
     if tcgen05_value.has_explicit_epilogue_tile:
         assert tcgen05_value.explicit_epi_tile_m is not None
@@ -2105,6 +2251,22 @@ def _codegen_cute_store_tcgen05_tile(
         return lines
 
     def _simt_edge_coord_subtile_source(indent: str) -> str:
+        if segment_store:
+            return (
+                f"{indent}{coord_tile} = cute.make_identity_tensor("
+                f"({tcgen05_aux_bm}, {tcgen05_aux_bn}))\n"
+                f"{indent}{tccc_base} = {tcgen05_aux_thr_mma}.partition_C("
+                f"{coord_tile})\n"
+                f"{indent}{tccc} = "
+                "cutlass.utils.gemm.sm100.transform_partitioned_tensor_layout("
+                f"{tccc_base})\n"
+                f"{indent}{tccc_epi} = cute.flat_divide({tccc}, {epi_tile})\n"
+                f"{indent}{ttr_cc} = {thr_copy_t2r}.partition_D({tccc_epi})\n"
+                f"{indent}{ttr_cc_grouped} = cute.group_modes("
+                f"{ttr_cc}, 3, cute.rank({ttr_cc}))\n"
+                f"{indent}{ttr_cc_subtile} = {ttr_cc_grouped}["
+                f"(None, None, None, cutlass.Int32(_tcgen05_subtile))]\n"
+            )
         return (
             f"{indent}{coord_tile} = cute.local_tile("
             f"cute.make_identity_tensor(({m_size}, {n_size})), "
@@ -2123,6 +2285,86 @@ def _codegen_cute_store_tcgen05_tile(
             f"cutlass.Int32(_tcgen05_subtile))]\n"
         )
 
+    def _tma_r2s_coord_subtile_source(indent: str) -> str:
+        if segment_store:
+            return (
+                f"{indent}{coord_tile} = cute.make_identity_tensor("
+                f"({tcgen05_aux_bm}, {tcgen05_aux_bn}))\n"
+                f"{indent}{tccc_base} = {tcgen05_aux_thr_mma}.partition_C("
+                f"{coord_tile})\n"
+                f"{indent}{tccc} = "
+                "cutlass.utils.gemm.sm100.transform_partitioned_tensor_layout("
+                f"{tccc_base})\n"
+                f"{indent}{tccc_epi} = cute.flat_divide({tccc}, {epi_tile})\n"
+                f"{indent}{ttr_cc} = {thr_copy_t2r}.partition_D({tccc_epi})\n"
+                f"{indent}{trs_cc} = {tiled_copy_r2s}.retile({ttr_cc})\n"
+                f"{indent}{trs_cc_grouped} = cute.group_modes("
+                f"{trs_cc}, 3, cute.rank({trs_cc}))\n"
+                f"{indent}{trs_cc_subtile} = {trs_cc_grouped}["
+                f"(None, None, None, cutlass.Int32(_tcgen05_subtile))]\n"
+            )
+        return (
+            f"{indent}{coord_tile} = cute.local_tile("
+            f"cute.make_identity_tensor(({m_size}, {n_size})), "
+            f"({tcgen05_aux_bm}, {tcgen05_aux_bn}), "
+            f"({tile_coord_m}, {tile_coord_n}))\n"
+            f"{indent}{tccc_base} = {tcgen05_aux_thr_mma}.partition_C("
+            f"{coord_tile})\n"
+            f"{indent}{tccc} = "
+            "cutlass.utils.gemm.sm100.transform_partitioned_tensor_layout("
+            f"{tccc_base})\n"
+            f"{indent}{tccc_epi} = cute.flat_divide({tccc}, {epi_tile})\n"
+            f"{indent}{ttr_cc} = {thr_copy_t2r}.partition_D({tccc_epi})\n"
+            f"{indent}{trs_cc} = {tiled_copy_r2s}.retile({ttr_cc})\n"
+            f"{indent}{trs_cc_grouped} = cute.group_modes({trs_cc}, 3, "
+            f"cute.rank({trs_cc}))\n"
+            f"{indent}{trs_cc_subtile} = {trs_cc_grouped}[(None, None, None, "
+            f"cutlass.Int32(_tcgen05_subtile))]\n"
+        )
+
+    def _coord_subtile_source(
+        indent: str, coord_layout: str, *, include_setup: bool
+    ) -> tuple[str, str]:
+        if coord_layout == "ttr":
+            return (
+                _simt_edge_coord_subtile_source(indent) if include_setup else "",
+                ttr_cc_subtile,
+            )
+        assert coord_layout == "trs"
+        return (
+            _tma_r2s_coord_subtile_source(indent) if include_setup else "",
+            trs_cc_subtile,
+        )
+
+    worklist_nm_segment_valid_m_bound = (
+        tcgen05_value.segment_store_valid_m_bound
+        if tcgen05_value.orientation is Tcgen05Orientation.NM and segment_store
+        else ""
+    )
+
+    def _worklist_nm_segment_valid_m_prelude_and_expr(
+        prelude_indent: str,
+        carrier_name: str,
+        coord_subtile_name: str,
+    ) -> tuple[str, str]:
+        valid_row_mask = df.new_var("tcgen05_selected_valid_row_mask")
+        valid_row_coord = df.new_var("tcgen05_selected_valid_row_coord")
+        if grouped_tail_store:
+            local_m = f"{valid_row_coord}[1]"
+        else:
+            local_m = f"({segment_store_local_m}) + {valid_row_coord}[1]"
+        prelude = (
+            f"{prelude_indent}{valid_row_mask} = cute.make_rmem_tensor("
+            f"cute.make_layout({carrier_name}.shape), cutlass.Boolean)\n"
+            f"{prelude_indent}for _selected_valid_i in range("
+            f"cute.size({valid_row_mask}.shape)):\n"
+            f"{prelude_indent}    {valid_row_coord} = "
+            f"{coord_subtile_name}[_selected_valid_i]\n"
+            f"{prelude_indent}    {valid_row_mask}[_selected_valid_i] = "
+            f"{local_m} < cutlass.Int32({worklist_nm_segment_valid_m_bound})\n"
+        )
+        return prelude, f"{valid_row_mask}.load()"
+
     def _simt_edge_scalar_copy_source(
         indent: str, src: str, dst: str, *, include_coord_setup: bool = True
     ) -> str:
@@ -2132,7 +2374,7 @@ def _codegen_cute_store_tcgen05_tile(
             (_simt_edge_coord_subtile_source(indent) if include_coord_setup else "")
             + f"{indent}for _edge_i in range(cute.size({src}.shape)):\n"
             f"{indent}    _coord = {ttr_cc_subtile}[_edge_i]\n"
-            f"{indent}    if cute.elem_less(_coord, ({m_size}, {n_size})):\n"
+            f"{indent}    if {_edge_predicate_expr('_coord')}:\n"
             f"{indent}        {dst}[_edge_i] = {src}[_edge_i]\n"
         )
 
@@ -2161,7 +2403,7 @@ def _codegen_cute_store_tcgen05_tile(
             f"{indent}{edge_pred} = cute.make_rmem_tensor((1, {edge_src}.shape[1]), cutlass.Boolean)\n"
             f"{indent}for _edge_i in range(cute.size({edge_src}.shape[1])):\n"
             f"{indent}    _coord = {edge_coord}[0, _edge_i]\n"
-            f"{indent}    {edge_pred}[0, _edge_i] = cute.elem_less(_coord, ({m_size}, {n_size}))\n"
+            f"{indent}    {edge_pred}[0, _edge_i] = {_edge_predicate_expr('_coord')}\n"
             f"{indent}cute.copy({copy_atom}, {edge_src}, {edge_dst}, pred={edge_pred})\n"
         )
 
@@ -2713,6 +2955,7 @@ def _codegen_cute_store_tcgen05_tile(
         *,
         force_simt_edge_aux: bool = False,
         safe_direct_aux_with_full_tile: bool = False,
+        coord_layout: str = "ttr",
     ) -> tuple[str, str, str]:
         """Return ``(early_aux_prelude, late_prelude, assignment_rhs)``.
 
@@ -2750,7 +2993,24 @@ def _codegen_cute_store_tcgen05_tile(
         """
         load_expr = f"{carrier_name}.load()"
         if epilogue_chain is None or not epilogue_chain.steps:
-            return ("", "", f"{load_expr}.to({target_dtype})")
+            rhs = load_expr
+            late_prelude = ""
+            if worklist_nm_segment_valid_m_bound:
+                coord_prelude, coord_subtile = _coord_subtile_source(
+                    prelude_indent,
+                    coord_layout,
+                    include_setup=True,
+                )
+                worklist_valid_prelude, worklist_valid_expr = (
+                    _worklist_nm_segment_valid_m_prelude_and_expr(
+                        prelude_indent,
+                        carrier_name,
+                        coord_subtile,
+                    )
+                )
+                rhs = f"cute.where({worklist_valid_expr}, {rhs}, 0.0)"
+                late_prelude = coord_prelude + worklist_valid_prelude
+            return "", late_prelude, f"({rhs}).to({target_dtype})"
         loaded = df.new_var("tcgen05_acc_loaded")
         prelude_load = f"{prelude_indent}{loaded} = {load_expr}\n"
         early_aux_prelude = _aux_subtile_load_source(
@@ -2772,10 +3032,39 @@ def _codegen_cute_store_tcgen05_tile(
             f"({final_expr}).to({target_dtype})",
         )
 
+    grouped_tma_plan = (
+        df.cute_state.matmul_plan if (grouped_tail_epilogue or segment_store) else None
+    )
+    grouped_tma = grouped_tma_plan.grouped if grouped_tma_plan is not None else None
+    d_tma_uses_rank3_mnl_tensor = (
+        grouped_tma is not None
+        and grouped_tma.d_mode is not Tcgen05GroupedDMode.NONE
+        and grouped_tma.d_tensormap is not None
+        and grouped_tma.d_mode is not Tcgen05GroupedDMode.EDGE_ONLY
+    )
+    d_tma_uses_tail_rank3_mnl_tensor = (
+        grouped_tma is not None
+        and grouped_tma.d_mode is not Tcgen05GroupedDMode.NONE
+        and grouped_tma.d_tensormap is not None
+        and grouped_tma.d_mode is Tcgen05GroupedDMode.EDGE_ONLY
+        and bool(tcgen05_value.tail_tma_store_atom)
+        and bool(tcgen05_value.tail_tma_store_tensor)
+    )
     if tcgen05_value.use_tma_store_epilogue:
         df.placeholder_args.add(tensor_name)
         df.wrapper_only_params.extend(
-            [tcgen05_value.tma_store_atom, tcgen05_value.tma_store_tensor]
+            [
+                tcgen05_value.tma_store_atom,
+                tcgen05_value.tma_store_tensor,
+                *(
+                    [
+                        tcgen05_value.tail_tma_store_atom,
+                        tcgen05_value.tail_tma_store_tensor,
+                    ]
+                    if d_tma_uses_tail_rank3_mnl_tensor
+                    else []
+                ),
+            ]
         )
         if tcgen05_value.use_role_local_epi and tcgen05_value.role_local_tile_counter:
             df.cute_state.register_tcgen05_epi_role_tile_counter(
@@ -2803,13 +3092,15 @@ def _codegen_cute_store_tcgen05_tile(
                 tcgen05_value.tma_store_atom,
                 tcgen05_value.tma_store_tensor,
             ],
+            **({"orientation": "nm"} if tcgen05_nm_store else {}),
+            **({"rank3_mnl_tensor": True} if d_tma_uses_rank3_mnl_tensor else {}),
             **(
                 {
                     "epi_tile_raw_expr": tcgen05_two_cta_m128_epilogue_tile_expr(
                         tcgen05_value.bm,
                         tcgen05_value.bn,
                         target_dtype,
-                        c_layout="cutlass.utils.layout.LayoutEnum.ROW_MAJOR",
+                        c_layout=tcgen05_d_store_layout,
                     )
                 }
                 if d_two_cta_m128 and not tcgen05_value.has_explicit_epilogue_tile
@@ -2828,6 +3119,16 @@ def _codegen_cute_store_tcgen05_tile(
         if leading_passthrough_output:
             d_tma_plan["d_leading_passthrough"] = True
         state.codegen.cute_wrapper_plans.append(d_tma_plan)
+        if d_tma_uses_tail_rank3_mnl_tensor:
+            tail_d_tma_plan = {
+                **d_tma_plan,
+                "kernel_args": [
+                    tcgen05_value.tail_tma_store_atom,
+                    tcgen05_value.tail_tma_store_tensor,
+                ],
+                "rank3_mnl_tensor": True,
+            }
+            state.codegen.cute_wrapper_plans.append(tail_d_tma_plan)
 
     tcgen05_bm = tcgen05_value.bm
     tcgen05_bn = tcgen05_value.bn
@@ -2847,23 +3148,154 @@ def _codegen_cute_store_tcgen05_tile(
         bn=tcgen05_bn,
         is_two_cta=tcgen05_is_two_cta,
         elem_dtype=target_dtype,
-        c_layout="cutlass.utils.layout.LayoutEnum.ROW_MAJOR",
+        c_layout=tcgen05_d_store_layout,
         explicit_expr=tcgen05_explicit_store_tile_expr,
     )
     full_tile_expr = (
-        f"({m_index}) + cutlass.Int32({tcgen05_bm}) <= {m_size} "
-        f"and ({n_index}) + cutlass.Int32({tcgen05_bn}) <= {n_size}"
+        (
+            f"{segment_store_local_m} + cutlass.Int32({tcgen05_source_bm}) "
+            f"<= cutlass.Int32({tcgen05_value.segment_store_actual_m}) "
+            f"and {segment_store_base_m} + cutlass.Int32({tcgen05_source_bm}) "
+            f"<= {m_size} "
+        )
+        if segment_store
+        else f"({m_index}) + cutlass.Int32({tcgen05_source_bm}) <= {m_size} "
+    ) + f"and ({n_index}) + cutlass.Int32({tcgen05_source_bn}) <= {n_size}"
+    grouped_tail_plan = (
+        df.cute_state.matmul_plan if (grouped_tail_epilogue or segment_store) else None
+    )
+    grouped_tail = grouped_tail_plan.grouped if grouped_tail_plan is not None else None
+    grouped_tail_store = (
+        grouped_tail is not None
+        and bool(grouped_tail.global_m_start)
+        and bool(grouped_tail.problem_m)
+        and bool(grouped_tail.problem_n)
+    )
+    grouped_tail_global_m_start = ""
+    grouped_tail_problem_m = ""
+    grouped_tail_problem_n = ""
+    grouped_dynamic_d_tensormap = False
+    grouped_tail_metadata_idx = ""
+    grouped_tail_cta_tile_idx_m = ""
+    grouped_tail_cta_tile_idx_n = ""
+    grouped_tail_d_tensormap = ""
+    grouped_tail_d_tensormap_slot = 0
+    grouped_direct_pointer_metadata = False
+    grouped_direct_pointers = ""
+    grouped_direct_strides = ""
+    grouped_dynamic_d_tensormap_edge_only = False
+    grouped_tail_store_problem_m = ""
+    grouped_tail_d_tensormap_problem_m = ""
+    if grouped_tail_store:
+        assert grouped_tail is not None
+        grouped_tail_global_m_start = grouped_tail.global_m_start
+        grouped_tail_problem_m = grouped_tail.problem_m
+        grouped_tail_problem_n = grouped_tail.problem_n
+        grouped_tail_store_problem_m = (
+            f"cutlass.Int32({tcgen05_value.segment_store_actual_m})"
+            if segment_store and tcgen05_value.orientation is Tcgen05Orientation.NM
+            else grouped_tail_problem_m
+        )
+        grouped_tail_d_tensormap_problem_m = (
+            grouped_tail_problem_m if tcgen05_nm_store else grouped_tail_store_problem_m
+        )
+        grouped_tail_metadata_idx = grouped_tail.metadata_idx
+        grouped_tail_cta_tile_idx_m = grouped_tail.cta_tile_idx_m
+        grouped_tail_cta_tile_idx_n = grouped_tail.cta_tile_idx_n
+        grouped_tail_d_tensormap = grouped_tail.d_tensormap or ""
+        grouped_tail_d_tensormap_slot = (
+            2 if grouped_tail.d_mode is Tcgen05GroupedDMode.ALL_TILES else 0
+        )
+        grouped_direct_pointer_metadata = grouped_tail.direct_pointers is not None
+        grouped_direct_pointers = grouped_tail.direct_pointers or ""
+        grouped_direct_strides = grouped_tail.direct_strides or ""
+        grouped_dynamic_d_tensormap = (
+            grouped_tail.d_mode is not Tcgen05GroupedDMode.NONE
+            and bool(grouped_tail_d_tensormap)
+        )
+        grouped_dynamic_d_tensormap_edge_only = (
+            grouped_dynamic_d_tensormap
+            and grouped_tail.d_mode is Tcgen05GroupedDMode.EDGE_ONLY
+            and tcgen05_value.tma_store_full_tiles_only
+        )
+        if segment_store:
+            segment_grouped_local_m = (
+                "cutlass.Int32(0)"
+                if tcgen05_nm_store
+                else f"(({segment_store_local_m}) - {grouped_tail_global_m_start})"
+            )
+            full_tile_expr = (
+                f"{segment_grouped_local_m} + cutlass.Int32({tcgen05_source_bm}) "
+                f"<= {grouped_tail_store_problem_m} "
+                f"and ({segment_store_base_m}) + cutlass.Int32({tcgen05_source_bm}) "
+                f"<= {m_size} "
+                f"and ({n_index}) + cutlass.Int32({tcgen05_source_bn}) "
+                f"<= {grouped_tail_problem_n} "
+                f"and ({n_index}) + cutlass.Int32({tcgen05_source_bn}) "
+                f"<= {n_size}"
+            )
+        else:
+            full_tile_expr = (
+                f"{full_tile_expr} and "
+                f"(({m_index}) - {grouped_tail_global_m_start}) "
+                f"+ cutlass.Int32({tcgen05_source_bm}) <= {grouped_tail_store_problem_m} "
+                f"and ({n_index}) + cutlass.Int32({tcgen05_source_bn}) "
+                f"<= {grouped_tail_problem_n}"
+            )
+    grouped_dynamic_d_tensormap_all_tiles = (
+        grouped_dynamic_d_tensormap and not grouped_dynamic_d_tensormap_edge_only
     )
 
+    def _edge_predicate_expr(coord: str) -> str:
+        if segment_store:
+            if grouped_tail_store:
+                local_m = (
+                    f"{coord}[0]"
+                    if tcgen05_nm_store
+                    else (
+                        f"(({segment_store_local_m}) - {grouped_tail_global_m_start}) "
+                        f"+ {coord}[0]"
+                    )
+                )
+                actual_m = grouped_tail_store_problem_m
+            else:
+                local_m = f"({segment_store_local_m}) + {coord}[0]"
+                actual_m = f"cutlass.Int32({tcgen05_aux_segment_store_actual_m})"
+            global_m = f"({segment_store_base_m}) + {coord}[0]"
+            global_n = f"({n_index}) + {coord}[1]"
+            return (
+                f"{local_m} < {actual_m} "
+                f"and cutlass.Int32(0) <= {global_m} "
+                f"and {global_m} < {m_size} "
+                f"and {global_n} < {n_size}"
+            )
+        global_pred = f"cute.elem_less({coord}, ({m_size}, {n_size}))"
+        if not grouped_tail_store:
+            return global_pred
+        return (
+            f"{global_pred} and "
+            f"({coord}[0] - {grouped_tail_global_m_start}) >= cutlass.Int32(0) "
+            f"and ({coord}[0] - {grouped_tail_global_m_start}) "
+            f"< {grouped_tail_store_problem_m} "
+            f"and {coord}[1] < {grouped_tail_problem_n}"
+        )
+
     def store_common_setup(
-        gmem_tensor: str, *, include_full_tile: bool, tma_store: bool = False
+        gmem_tensor: str,
+        *,
+        include_full_tile: bool,
+        tma_store: bool = False,
+        dynamic_d_tensormap: bool = False,
+        rank3_mnl_tensor: bool | None = None,
     ) -> tuple[list[str], list[str]]:
+        if rank3_mnl_tensor is None:
+            rank3_mnl_tensor = d_tma_uses_rank3_mnl_tensor
         epi_tile_expr = tcgen05_store_epi_tile_expr
         static_setup = [
             (
                 f"{kernel_desc} = type('Tcgen05KernelDesc', (), {{"
                 f"'cta_tile_shape_mnk': ({tcgen05_store_tile_m}, {tcgen05_bn}, {tcgen05_bk}), "
-                "'c_layout': cutlass.utils.layout.LayoutEnum.ROW_MAJOR, "
+                f"'c_layout': {tcgen05_d_store_layout}, "
                 f"'c_dtype': {target_dtype}, "
                 "'acc_dtype': cutlass.Float32, "
                 f"'epilog_sync_bar_id': cutlass.Int32({tcgen05_epilog_sync_barrier_id}), "
@@ -2911,19 +3343,67 @@ def _codegen_cute_store_tcgen05_tile(
                     leading_index,
                 )
             )
-        tile_setup.extend(
-            [
-                (
-                    f"{gmem_tile} = cute.local_tile("
-                    f"{local_gmem_tensor}, ({tcgen05_bm}, {tcgen05_bn}), "
-                    f"({tile_coord_m}, {tile_coord_n}))"
-                ),
-                f"{tcgc_base} = {tcgen05_thr_mma}.partition_C({gmem_tile})",
-            ]
-        )
+        if (
+            gmem_tensor
+            in (tcgen05_aux_tma_store_tensor, tcgen05_aux_tail_tma_store_tensor)
+            and rank3_mnl_tensor
+        ):
+            source_coord_m = (
+                grouped_tail_cta_tile_idx_m
+                if dynamic_d_tensormap
+                else static_tile_coord_m
+            )
+            source_coord_n = (
+                grouped_tail_cta_tile_idx_n
+                if dynamic_d_tensormap
+                else static_tile_coord_n
+            )
+            if tcgen05_nm_store:
+                coord_m = source_coord_n
+                coord_n = source_coord_m
+            else:
+                coord_m = source_coord_m
+                coord_n = source_coord_n
+            tile_coord = f"({coord_m}, {coord_n}, 0)"
+        else:
+            tile_coord = f"({static_tile_coord_m}, {static_tile_coord_n})"
+        if segment_store and gmem_tensor == tensor_name:
+            index_dtype = CompileEnvironment.current().index_type()
+            tile_setup.extend(
+                [
+                    (
+                        f"{gmem_tile} = cute.make_tensor("
+                        f"{gmem_tensor}.iterator + "
+                        f"{index_dtype}({segment_store_base_m}) * "
+                        f"{index_dtype}({gmem_tensor}.layout.stride[0]) + "
+                        f"{index_dtype}({n_index}) * "
+                        f"{index_dtype}({gmem_tensor}.layout.stride[1]), "
+                        "cute.make_layout("
+                        f"({tcgen05_bm}, {tcgen05_bn}), "
+                        f"stride=({gmem_tensor}.layout.stride[0], "
+                        f"{gmem_tensor}.layout.stride[1])))"
+                    ),
+                    f"{coord_tile} = cute.make_identity_tensor(({tcgen05_bm}, {tcgen05_bn}))",
+                    f"{tcgc_base} = {tcgen05_thr_mma}.partition_C({gmem_tile})",
+                ]
+            )
+        else:
+            tile_setup.extend(
+                [
+                    (
+                        f"{gmem_tile} = cute.local_tile("
+                        f"{local_gmem_tensor}, ({tcgen05_bm}, {tcgen05_bn}), "
+                        f"{tile_coord})"
+                    ),
+                    f"{tcgc_base} = {tcgen05_thr_mma}.partition_C({gmem_tile})",
+                ]
+            )
         return static_setup, tile_setup
 
-    simt_edge_only = tcgen05_value.tma_store_full_tiles_only
+    simt_edge_only = (
+        tcgen05_value.tma_store_full_tiles_only
+        and not grouped_dynamic_d_tensormap_edge_only
+    )
     simt_edge_aux_atoms: dict[int, str] = {}
     simt_edge_aux_atom_setup: list[str] = []
     if simt_edge_only:
@@ -2945,7 +3425,7 @@ def _codegen_cute_store_tcgen05_tile(
     simt_early_aux, simt_late_prelude, simt_acc_vec_rhs = _splice_acc_vec(
         ttr_racc,
         "        ",
-        force_simt_edge_aux=tcgen05_value.tma_store_full_tiles_only,
+        force_simt_edge_aux=simt_edge_only,
     )
     simt_acc_vec_prelude = simt_early_aux + simt_late_prelude
     if tcgen05_value.use_tma_store_epilogue:
@@ -2953,9 +3433,159 @@ def _codegen_cute_store_tcgen05_tile(
             tcgen05_value.tma_store_tensor,
             include_full_tile=partial_tma_needs_full_tile_guard,
             tma_store=True,
+            dynamic_d_tensormap=grouped_dynamic_d_tensormap_all_tiles,
+        )
+        dynamic_d_tma_tile_store_setup = (
+            store_common_setup(
+                tcgen05_value.tail_tma_store_tensor,
+                include_full_tile=False,
+                tma_store=True,
+                dynamic_d_tensormap=True,
+                rank3_mnl_tensor=True,
+            )[1]
+            if grouped_dynamic_d_tensormap_edge_only
+            else []
         )
     else:
         tma_static_store_setup, tma_tile_store_setup = [], []
+        dynamic_d_tma_tile_store_setup = []
+    grouped_d_tensormap_atom = (
+        tcgen05_value.tail_tma_store_atom
+        if grouped_dynamic_d_tensormap_edge_only
+        else tcgen05_value.tma_store_atom
+    )
+    grouped_d_tensormap_shape_expr = (
+        f"({grouped_tail_problem_n}, {grouped_tail_d_tensormap_problem_m}, cutlass.Int32(1))"
+        if tcgen05_nm_store
+        else f"({grouped_tail_d_tensormap_problem_m}, {grouped_tail_problem_n}, cutlass.Int32(1))"
+    )
+    grouped_d_tensormap_stride_expr = (
+        (
+            f"({grouped_d_tensormap_stride_n}, {grouped_d_tensormap_stride_m}, "
+            "cutlass.Int32(0))"
+        )
+        if grouped_direct_pointer_metadata and tcgen05_nm_store
+        else (
+            f"({grouped_d_tensormap_stride_m}, {grouped_d_tensormap_stride_n}, "
+            "cutlass.Int32(0))"
+        )
+        if grouped_direct_pointer_metadata
+        else (
+            f"({tensor_name}.layout.stride[1], {tensor_name}.layout.stride[0], "
+            "cutlass.Int32(0))"
+            if tcgen05_nm_store
+            else f"({tensor_name}.layout.stride[0], {tensor_name}.layout.stride[1], "
+            "cutlass.Int32(0))"
+        )
+    )
+    grouped_d_tensormap_setup: list[str] = []
+    grouped_d_tensormap_update: list[str] = []
+    if grouped_dynamic_d_tensormap:
+        index_dtype = CompileEnvironment.current().index_type()
+
+        def _grouped_direct_metadata_load(
+            tensor_name: str,
+            *indices: str | int,
+        ) -> str:
+            offset_terms = [
+                f"{index_dtype}({index}) * {index_dtype}("
+                f"{tensor_name}.layout.stride[{dim}])"
+                for dim, index in enumerate(indices)
+            ]
+            return f"({tensor_name}.iterator + {' + '.join(offset_terms)}).load()"
+
+        grouped_d_tensormap_base_expr = (
+            (
+                f"cute.make_ptr({target_dtype}, "
+                f"cutlass.Int64({grouped_d_tensormap_addr}), "
+                "cute.AddressSpace.gmem)"
+            )
+            if grouped_direct_pointer_metadata
+            else (
+                f"{tensor_name}.iterator + "
+                f"{index_dtype}({grouped_tail_global_m_start}) * "
+                f"{index_dtype}({tensor_name}.layout.stride[0])"
+            )
+        )
+        grouped_d_tensormap_direct_loads = (
+            (
+                f"    {grouped_d_tensormap_addr} = "
+                f"{_grouped_direct_metadata_load(grouped_direct_pointers, grouped_tail_metadata_idx, 2)}\n"
+                f"    {grouped_d_tensormap_stride_m} = "
+                f"{_grouped_direct_metadata_load(grouped_direct_strides, grouped_tail_metadata_idx, 2, 0)}\n"
+                f"    {grouped_d_tensormap_stride_n} = "
+                f"{_grouped_direct_metadata_load(grouped_direct_strides, grouped_tail_metadata_idx, 2, 1)}\n"
+            )
+            if grouped_direct_pointer_metadata
+            else ""
+        )
+        grouped_d_tensormap_setup = [
+            (
+                f"{grouped_d_tensormap_manager} = "
+                "cutlass.utils.TensorMapManager("
+                "cutlass.utils.TensorMapUpdateMode.SMEM, 128)"
+            ),
+            f"{grouped_d_tensormap_grid_dim} = cute.arch.grid_dim()",
+            (
+                f"{grouped_d_tensormap_workspace_idx} = ("
+                f"cute.arch.block_idx()[2] * "
+                f"{grouped_d_tensormap_grid_dim}[1] * "
+                f"{grouped_d_tensormap_grid_dim}[0] + "
+                f"cute.arch.block_idx()[1] * "
+                f"{grouped_d_tensormap_grid_dim}[0] + "
+                "cute.arch.block_idx()[0])"
+            ),
+            (
+                f"{grouped_d_tensormap_ptr} = "
+                f"{grouped_d_tensormap_manager}.get_tensormap_ptr("
+                f"{grouped_tail_d_tensormap}"
+                f"[({grouped_d_tensormap_workspace_idx}, "
+                f"{grouped_tail_d_tensormap_slot}, None)].iterator)"
+            ),
+            (
+                f"{grouped_d_tensormap_desc_ptr} = "
+                f"{grouped_d_tensormap_manager}.get_tensormap_ptr("
+                f"{grouped_d_tensormap_ptr}, cute.AddressSpace.generic)"
+            ),
+            (
+                f"{grouped_d_tensormap_smem_ptr} = "
+                "cute.arch.alloc_smem(cutlass.Int64, cutlass.Int32(16), "
+                "alignment=128)"
+            ),
+            (
+                f"{grouped_d_tensormap_manager}.init_tensormap_from_atom("
+                f"{grouped_d_tensormap_atom}, {grouped_d_tensormap_smem_ptr}, "
+                "0)"
+            ),
+            f"{grouped_d_tensormap_manager}.fence_tensormap_initialization()",
+            f"{grouped_d_tensormap_last_group} = cutlass.Int32(-1)",
+        ]
+        grouped_d_tensormap_update = [
+            (
+                f"{grouped_d_tensormap_group_changed} = "
+                f"{grouped_tail_metadata_idx} != {grouped_d_tensormap_last_group}"
+            ),
+            (
+                f"if {grouped_d_tensormap_group_changed}:\n"
+                f"{grouped_d_tensormap_direct_loads}"
+                f"    {grouped_d_tensormap_base} = "
+                f"{grouped_d_tensormap_base_expr}\n"
+                f"    {grouped_d_tensormap_real_d} = cute.make_tensor("
+                f"{grouped_d_tensormap_base}, "
+                "cute.make_layout("
+                f"{grouped_d_tensormap_shape_expr}, "
+                f"stride={grouped_d_tensormap_stride_expr}))\n"
+                f"    {grouped_d_tensormap_manager}.update_tensormap("
+                f"({grouped_d_tensormap_real_d},), "
+                f"({grouped_d_tensormap_atom},), "
+                f"({grouped_d_tensormap_ptr},), 0, "
+                f"({grouped_d_tensormap_smem_ptr},))\n"
+                f"    if {tcgen05_value.warp_idx} == cutlass.Int32(0):\n"
+                f"        {grouped_d_tensormap_manager}.fence_tensormap_update("
+                f"{grouped_d_tensormap_ptr})\n"
+                f"    {grouped_d_tensormap_last_group} = {grouped_tail_metadata_idx}"
+            ),
+        ]
     # Role-local TMA stores reuse one C pipeline across work tiles. Static-full
     # kernels increment this counter once per role-local tile; hybrid
     # output-edge kernels increment it only in the full-tile branch so SIMT
@@ -3224,6 +3854,14 @@ def _codegen_cute_store_tcgen05_tile(
         or diagnose_module_helper_acc_t2r
         or diagnose_module_helper_store_tail
     )
+    elide_role_local_epi_active = (
+        tcgen05_value.use_role_local_epi
+        and tcgen05_value.use_tma_store_epilogue
+        and tcgen05_pure_matmul_object is None
+        and not has_store_warp
+        and not diagnose_split_epilogue_layout
+        and not diagnose_skip_epilogue_store
+    )
     if tcgen05_pure_matmul_object is not None and diagnose_split_epilogue_layout:
         raise exc.BackendUnsupported(
             "cute",
@@ -3242,17 +3880,15 @@ def _codegen_cute_store_tcgen05_tile(
             "tcgen05_warp_spec_store_warps>0 (Workstream A Stage 4 wires the "
             "store-warp epilogue split into the non-pure WITH_SCHEDULER path)",
         )
-    # The diagnostic split / module-helper epilogue layouts route the
-    # per-subtile tail through helpers that emit ONLY the ``if epi_active``
-    # half under ``has_store_warp`` (and ``module_helper_store_tail`` keeps the
-    # OLD two-barrier warp-0 ``c_pipeline`` tail while the main path suppressed
-    # the matching acquires) — so the C-store edge would have no consumer and
-    # wedge once the ring wraps, or the ``c_pipeline`` commit/acquire counts
-    # mismatch. They are diagnostic-only source-boundary layouts; production
-    # uses the DEFAULT layout, so reject the combination loudly (same guard
-    # class as the pure-matmul tail above). ``split_first_t2r`` routes through
-    # ``tma_store_subtile_body`` and IS handled by the Stage-4 split, so it is
-    # intentionally excluded.
+    # The non-default split/helper epilogue layouts route the per-subtile tail
+    # through helpers that emit ONLY the ``if epi_active`` half under
+    # ``has_store_warp`` (and ``module_helper_store_tail`` keeps the OLD
+    # two-barrier warp-0 ``c_pipeline`` tail while the main path suppressed the
+    # matching acquires) — so the C-store edge would have no consumer and wedge
+    # once the ring wraps, or the ``c_pipeline`` commit/acquire counts mismatch.
+    # Reject the combination loudly (same guard class as the pure-matmul tail
+    # above). ``split_first_t2r`` routes through ``tma_store_subtile_body`` and
+    # IS handled by the Stage-4 split, so it is intentionally excluded.
     if has_store_warp and (
         diagnose_split_acc_t2r_store_tail
         or diagnose_module_helper_acc_t2r
@@ -3261,9 +3897,9 @@ def _codegen_cute_store_tcgen05_tile(
         raise exc.BackendUnsupported(
             "cute",
             f"{TCGEN05_EPILOGUE_LAYOUT_CONFIG_KEY}={epilogue_layout!r} does not "
-            "support tcgen05_warp_spec_store_warps>0 (the diagnostic split / "
-            "module-helper epilogue layouts do not emit the store-warp tail "
-            "half of the Workstream A Stage 4 split; use the default layout)",
+            "support tcgen05_warp_spec_store_warps>0 (the split/helper "
+            "epilogue layouts do not emit the store-warp tail half of the "
+            "Workstream A Stage 4 split; use the default layout)",
         )
     if tcgen05_pure_matmul_object is not None:
         pure_c_store_pipeline = Tcgen05TmaStorePipelineParams(
@@ -3321,8 +3957,12 @@ def _codegen_cute_store_tcgen05_tile(
             else f"{tcgen05_value.warp_idx} == cutlass.Int32(0)"
         )
         first_acquire_role_gate = (
-            f"{tcgen05_lifecycle.epi_active} and "
             f"{tcgen05_value.warp_idx} == cutlass.Int32(0)"
+            if elide_role_local_epi_active
+            else (
+                f"{tcgen05_lifecycle.epi_active} and "
+                f"{tcgen05_value.warp_idx} == cutlass.Int32(0)"
+            )
         )
         tma_store_pipeline_tail = (
             f"if {c_pipeline_owner_predicate}:\n    {c_pipeline}.producer_tail()"
@@ -3386,15 +4026,12 @@ def _codegen_cute_store_tcgen05_tile(
                 f"{TCGEN05_EPILOGUE_LAYOUT_CONFIG_KEY}={epilogue_layout!r} is only "
                 f"validated for CtaGroup.TWO block_n >= {TCGEN05_TWO_CTA_BLOCK_N}",
             )
-        # The diagnostic split-epilogue layouts emit the per-thread
-        # chain into separate ``@cute.jit`` helpers (module-helper
-        # layouts) or split source boundaries; the auxiliary-tensor
-        # splice site needs per-tile aux setup that is not currently
-        # plumbed into those helper signatures. Reject the
-        # combination loudly so a user does not silently get a
-        # kernel that drops the aux read. The diagnostic layouts
-        # are only used for source-boundary investigation and do not
-        # block any production path.
+        # The split/helper epilogue layouts emit the per-thread chain into
+        # separate ``@cute.jit`` helpers or split source boundaries; the
+        # auxiliary-tensor splice site needs per-tile aux setup that is not
+        # currently plumbed into those helper signatures. Reject the combination
+        # loudly so a user does not silently get a kernel that drops the aux
+        # read.
         if (
             diagnose_module_helper_acc_t2r
             or diagnose_module_helper_store_tail
@@ -3406,9 +4043,7 @@ def _codegen_cute_store_tcgen05_tile(
                 "auxiliary-tensor epilogue (e.g. "
                 "`out[tile] = (acc + residual[tile]).to(dtype)`) is "
                 f"not plumbed through {TCGEN05_EPILOGUE_LAYOUT_CONFIG_KEY}="
-                f"{epilogue_layout!r}. The diagnostic split-epilogue "
-                "layouts are only used for source-boundary "
-                "investigation; drop the layout config to use the "
+                f"{epilogue_layout!r}. Drop the layout config to use the "
                 "default production layout.",
             )
     tma_store_split_first_subtile_acquire = (
@@ -3468,9 +4103,18 @@ def _codegen_cute_store_tcgen05_tile(
     tcgen05_acc_consumer_state = tcgen05_lifecycle.acc_consumer_state
     tcgen05_warp_idx = tcgen05_value.warp_idx
     tcgen05_tma_store_atom = tcgen05_value.tma_store_atom
+    grouped_d_tensormap_desc_arg = (
+        f", tma_desc_ptr={grouped_d_tensormap_desc_ptr}"
+        if grouped_dynamic_d_tensormap
+        else ""
+    )
+    tma_store_desc_arg = (
+        grouped_d_tensormap_desc_arg if grouped_dynamic_d_tensormap_all_tiles else ""
+    )
     # Locals for the store-warp tail closure (Pyrefly drops the non-None
     # tcgen05_value narrowing inside nested source formatters; see above).
     tcgen05_role_local_tile_counter = tcgen05_value.role_local_tile_counter
+    tma_store_d_subtile_expr = "cutlass.Int32(_tcgen05_subtile)"
 
     def tma_store_acc_t2r_region_body(
         *, acc_wait: str, allow_aux_chain: bool = False
@@ -3486,9 +4130,9 @@ def _codegen_cute_store_tcgen05_tile(
         resulting local-memory spills.
         """
         assert allow_aux_chain or not aux_steps_in_chain, (
-            "diagnostic / module-helper layouts reject aux-tensor chains at "
-            "validate time; use allow_aux_chain=True only for the default TMA "
-            "store body that threads the aux LDG through the main T2R body."
+            "split/helper epilogue layouts reject aux-tensor chains at validate "
+            "time; use allow_aux_chain=True only for the default TMA store body "
+            "that threads the aux LDG through the main T2R body."
         )
         carrier = trs_racc
         store_target = trs_rd
@@ -3496,6 +4140,7 @@ def _codegen_cute_store_tcgen05_tile(
             carrier,
             "        ",
             safe_direct_aux_with_full_tile=partial_tma_needs_full_tile_guard,
+            coord_layout="trs",
         )
         # The secondary fan-out store reuses the still-live accumulator TMEM and
         # must not release it: the primary store already owns the accumulator
@@ -3541,7 +4186,16 @@ def _codegen_cute_store_tcgen05_tile(
             c_pipeline=c_pipeline,
         )
 
-    def tma_store_tail_region(*, late_later_subtile_acquire: str) -> str:
+    def tma_store_tail_region(
+        *,
+        late_later_subtile_acquire: str,
+        tma_desc_arg: str | None = None,
+        tma_store_atom: str | None = None,
+    ) -> str:
+        if tma_desc_arg is None:
+            tma_desc_arg = tma_store_desc_arg
+        if tma_store_atom is None:
+            tma_store_atom = tcgen05_tma_store_atom
         if tcgen05_pure_matmul_object is not None:
             return tcgen05_pure_matmul_object.render_tma_store_tail_region(
                 tma_store_tail_params(
@@ -3571,6 +4225,11 @@ def _codegen_cute_store_tcgen05_tile(
                 f"            {c_store_edge}.producer_commit({c_store_edge_producer_state})\n"
                 f"        {c_store_edge_producer_state}.advance()\n"
             )
+        tma_copy_line = (
+            f"            cute.copy({tma_store_atom}, "
+            f"{bsg_sd}[(None, {c_buffer})], "
+            f"{bsg_gd}[(None, {tma_store_d_subtile_expr})]{tma_desc_arg})\n"
+        )
         return (
             f"{late_later_subtile_acquire}"
             f"        {epilog_sync_barrier}.arrive_and_wait()\n"
@@ -3579,11 +4238,17 @@ def _codegen_cute_store_tcgen05_tile(
             f"        cute.arch.fence_view_async_shared()\n"
             f"        {epilog_sync_barrier}.arrive_and_wait()\n"
             f"        if {tcgen05_warp_idx} == cutlass.Int32(0):\n"
-            f"            cute.copy({tcgen05_tma_store_atom}, {bsg_sd}[(None, {c_buffer})], {bsg_gd}[(None, cutlass.Int32(_tcgen05_subtile))])\n"
+            f"{tma_copy_line}"
             f"            {c_pipeline}.producer_commit()\n"
         )
 
-    def tma_store_store_warp_tail_region() -> str:
+    def tma_store_store_warp_tail_region(
+        *, tma_desc_arg: str | None = None, tma_store_atom: str | None = None
+    ) -> str:
+        if tma_desc_arg is None:
+            tma_desc_arg = tma_store_desc_arg
+        if tma_store_atom is None:
+            tma_store_atom = tcgen05_tma_store_atom
         # Path B store-warp tail (inside ``if store_warp_predicate:``): consume
         # the C-store edge, issue the TMA-D, and recycle the C-ring SMEM stage
         # with a ``c_stages - 1`` lagged release so a stage is only freed for
@@ -3609,11 +4274,16 @@ def _codegen_cute_store_tcgen05_tile(
             if tcgen05_role_local_tile_counter
             else "cutlass.Int32(_tcgen05_subtile)"
         )
+        tma_copy_line = (
+            f"        cute.copy({tma_store_atom}, "
+            f"{bsg_sd}[(None, {c_buffer})], "
+            f"{bsg_gd}[(None, {tma_store_d_subtile_expr})]{tma_desc_arg})\n"
+        )
         return (
             f"        {c_store_edge}.consumer_wait({c_store_edge_consumer_state})\n"
             f"        {c_store_edge_consumer_state}.advance()\n"
             f"        {c_buffer} = ({tma_c_buffer_expr}) % cutlass.Int32({tcgen05_c_stage_count})\n"
-            f"        cute.copy({tcgen05_tma_store_atom}, {bsg_sd}[(None, {c_buffer})], {bsg_gd}[(None, cutlass.Int32(_tcgen05_subtile))])\n"
+            f"{tma_copy_line}"
             f"        {c_pipeline}.producer_commit()\n"
             f"        {c_pipeline}.producer_acquire()\n"
             f"        if {global_subtile} >= cutlass.Int32({lag}):\n"
@@ -3628,7 +4298,14 @@ def _codegen_cute_store_tcgen05_tile(
         later_subtile_acquire: str,
         acc_wait: str,
         late_later_subtile_acquire: str,
+        tma_desc_arg: str | None = None,
+        tma_store_atom: str | None = None,
+        gate_epi_active: bool = True,
     ) -> str:
+        if tma_desc_arg is None:
+            tma_desc_arg = tma_store_desc_arg
+        if tma_store_atom is None:
+            tma_store_atom = tcgen05_tma_store_atom
         # The aux LDG depends on ``_tcgen05_subtile`` and stays inside
         # the per-subtile T2R body. It intentionally runs after the
         # c_pipeline acquire and TMEM→register copy so the residual/bias
@@ -3648,17 +4325,19 @@ def _codegen_cute_store_tcgen05_tile(
             return (
                 f"    if {tcgen05_epi_active}:\n"
                 f"{t2r_body}"
-                f"{tma_store_tail_region(late_later_subtile_acquire='')}"
+                f"{tma_store_tail_region(late_later_subtile_acquire='', tma_desc_arg=tma_desc_arg, tma_store_atom=tma_store_atom)}"
                 f"    if {store_warp_predicate}:\n"
-                f"{tma_store_store_warp_tail_region()}"
+                f"{tma_store_store_warp_tail_region(tma_desc_arg=tma_desc_arg, tma_store_atom=tma_store_atom)}"
             )
-        return (
-            f"    if {tcgen05_epi_active}:\n"
+        epi_body = (
             f"{first_subtile_acquire}"
             f"{later_subtile_acquire}"
             f"{t2r_body}"
-            f"{tma_store_tail_region(late_later_subtile_acquire=late_later_subtile_acquire)}"
+            f"{tma_store_tail_region(late_later_subtile_acquire=late_later_subtile_acquire, tma_desc_arg=tma_desc_arg, tma_store_atom=tma_store_atom)}"
         )
+        if gate_epi_active:
+            return f"    if {tcgen05_epi_active}:\n{epi_body}"
+        return textwrap.indent(textwrap.dedent(epi_body), "    ")
 
     def indented_diagnostic_region(source: str) -> str:
         if not source:
@@ -3822,6 +4501,24 @@ def _codegen_cute_store_tcgen05_tile(
             f"{tma_store_module_tail_helper_call()}"
         )
 
+    def default_tma_store_subtile_loop(
+        tma_desc_arg: str | None = None,
+        tma_store_atom: str | None = None,
+    ) -> str:
+        tma_store_default_subtile_body = tma_store_subtile_body(
+            first_subtile_acquire=tma_store_loop_first_subtile_acquire,
+            later_subtile_acquire=tma_store_loop_later_subtile_acquire,
+            acc_wait=tma_store_loop_acc_wait,
+            late_later_subtile_acquire=tma_store_loop_late_later_subtile_acquire,
+            tma_desc_arg=tma_desc_arg,
+            tma_store_atom=tma_store_atom,
+            gate_epi_active=not elide_role_local_epi_active,
+        )
+        return (
+            f"for _tcgen05_subtile in cutlass.range({subtile_count}, unroll_full=True):\n"
+            f"{tma_store_default_subtile_body}"
+        )
+
     if diagnose_split_first_t2r:
         tma_store_split_first_subtile_body = tma_store_subtile_body(
             first_subtile_acquire=tma_store_split_first_subtile_acquire,
@@ -3910,22 +4607,21 @@ def _codegen_cute_store_tcgen05_tile(
             f"{tma_store_module_tail_body}"
         )
     else:
-        tma_store_default_subtile_body = tma_store_subtile_body(
-            first_subtile_acquire=tma_store_loop_first_subtile_acquire,
-            later_subtile_acquire=tma_store_loop_later_subtile_acquire,
-            acc_wait=tma_store_loop_acc_wait,
-            late_later_subtile_acquire=tma_store_loop_late_later_subtile_acquire,
+        tma_store_subtile_loop = default_tma_store_subtile_loop()
+    dynamic_d_tma_store_subtile_loop = (
+        default_tma_store_subtile_loop(
+            grouped_d_tensormap_desc_arg,
+            tcgen05_value.tail_tma_store_atom,
         )
-        tma_store_subtile_loop = (
-            f"for _tcgen05_subtile in cutlass.range({subtile_count}, unroll_full=True):\n"
-            f"{tma_store_default_subtile_body}"
-        )
+        if grouped_dynamic_d_tensormap_edge_only
+        else ""
+    )
     tma_store_smem_setup = [
         # Must match the wrapper-side `tcgen05_d_tma` TMA atom layout in
         # `helion/runtime/__init__.py`; both describe one D SMEM stage.
         (
             f"{smem_d_layout} = cutlass.utils.blackwell_helpers.make_smem_layout_epi("
-            f"{target_dtype}, cutlass.utils.layout.LayoutEnum.ROW_MAJOR, "
+            f"{target_dtype}, {tcgen05_d_store_layout}, "
             f"{epi_tile}, {tcgen05_value.c_stage_count})"
         ),
         (
@@ -4016,80 +4712,142 @@ def _codegen_cute_store_tcgen05_tile(
         and not split_hybrid_tma_store_role
         and not diagnose_skip_epilogue_store
     )
-    tma_store_body_setup_core = [
-        *(tma_static_store_setup if not hoist_tma_store_resources else []),
-        *(
-            tma_store_pipeline_setup
-            if not (hoist_tma_store_resources or hoist_hybrid_tma_store_pipeline)
-            else []
+
+    def worklist_nm_explicit_store_wave_setup_lines() -> list[str]:
+        return [
+            f"{tacc_epi} = cute.flat_divide({tacc}, {epi_tile})",
+            (
+                f"{tiled_copy_t2r} = cute.nvgpu.tcgen05.make_tmem_copy("
+                f"{tcgen05_aux_tmem_load_atom}, "
+                f"{tacc_epi}[(None, None, 0, 0, 0)])"
+            ),
+            f"{thr_copy_t2r} = {tiled_copy_t2r}.get_slice({tcgen05_aux_epi_tidx})",
+            f"{ttr_tacc_base} = {thr_copy_t2r}.partition_S({tacc_epi})",
+            f"{tcgc_epi} = cute.flat_divide({tcgc_planned}, {epi_tile})",
+            f"{ttr_gc} = {thr_copy_t2r}.partition_D({tcgc_epi})",
+            (
+                f"{ttr_racc} = cute.make_rmem_tensor("
+                f"{ttr_gc}[(None, None, None, 0, 0, 0, 0, 0)].shape, "
+                "cutlass.Float32)"
+            ),
+            f"{ttr_rd} = cute.make_rmem_tensor({ttr_racc}.shape, {target_dtype})",
+            (
+                f"{copy_atom_r2s} = cute.make_copy_atom("
+                "cute.nvgpu.warp.StMatrix8x8x16bOp("
+                "transpose=True, num_matrices=4), "
+                f"{target_dtype})"
+            ),
+            (
+                f"{tiled_copy_r2s} = cute.make_tiled_copy_D("
+                f"{copy_atom_r2s}, {tiled_copy_t2r})"
+            ),
+            f"{thr_copy_r2s} = {tiled_copy_r2s}.get_slice({tcgen05_aux_epi_tidx})",
+            f"{trs_sd} = {thr_copy_r2s}.partition_D({smem_d})",
+            f"{trs_rd} = {tiled_copy_r2s}.retile({ttr_rd})",
+            f"{trs_racc} = {tiled_copy_r2s}.retile({ttr_racc})",
+        ]
+
+    def default_store_wave_setup_lines() -> list[str]:
+        return [
+            (
+                f"{tiled_copy_t2r}, {ttr_tacc_base}, {ttr_racc} = "
+                "cutlass.utils.gemm.sm100.epilogue_tmem_copy_and_partition("
+                f"{kernel_desc}, {tcgen05_aux_epi_tidx}, {tacc}, "
+                f"{tcgc_planned}, {epi_tile}, {tcgen05_lifecycle.is_two_cta!s})"
+            ),
+            f"{ttr_rd} = cute.make_rmem_tensor({ttr_racc}.shape, {target_dtype})",
+            (
+                f"{tiled_copy_r2s}, {trs_rd}, {trs_sd} = "
+                "cutlass.utils.gemm.sm100.epilogue_smem_copy_and_partition("
+                f"{kernel_desc}, {tiled_copy_t2r}, {ttr_rd}, "
+                f"{tcgen05_aux_epi_tidx}, {smem_d})"
+            ),
+            f"{trs_racc} = {tiled_copy_r2s}.retile({ttr_racc})",
+            f"{tcgc_epi} = cute.flat_divide({tcgc_planned}, {epi_tile})",
+        ]
+
+    def build_tma_store_body_setup_core(
+        *,
+        tma_store_atom: str,
+        tile_store_setup: list[str],
+        dynamic_d_setup: list[str],
+        dynamic_d_update: list[str],
+    ) -> list[str]:
+        return [
+            *(tma_static_store_setup if not hoist_tma_store_resources else []),
+            *(
+                tma_store_pipeline_setup
+                if not (hoist_tma_store_resources or hoist_hybrid_tma_store_pipeline)
+                else []
+            ),
+            *(tma_store_smem_setup if not hoist_tma_store_resources else []),
+            *_rowvec_aux_copy_lines(),
+            *tma_store_first_subtile_acquire,
+            *dynamic_d_setup,
+            *dynamic_d_update,
+            *tile_store_setup,
+            (
+                f"{tcgc} = cutlass.utils.gemm.sm100.transform_partitioned_tensor_layout("
+                f"{tcgc_base})"
+            ),
+            (
+                f"{tcgc_planned} = cute.make_tensor("
+                f"{tcgc}.iterator, "
+                f"cute.append(cute.append(cute.append({tcgc}.layout, {tcgen05_aux_epilogue_rest_mode}), {tcgen05_aux_epilogue_rest_mode}), {tcgen05_aux_epilogue_rest_mode}))"
+            ),
+            *(tma_store_acc_layout_setup if not hoist_tma_store_resources else []),
+            *(
+                worklist_nm_explicit_store_wave_setup_lines()
+                if tcgen05_nm_store
+                else default_store_wave_setup_lines()
+            ),
+            # Per-aux-step partitioning lines (one chain per auxiliary tensor).
+            # No-op when the chain has no aux steps; the TMA path requires an
+            # explicit ``thr_copy_t2r`` slice because it consumes the partition
+            # through SMEM-staged stores rather than via partition_D.
+            *_aux_tile_setup_lines(
+                thr_copy_t2r_var=thr_copy_t2r,
+                define_thr_copy_t2r=not tcgen05_nm_store,
+                retile_for_r2s=True,
+            ),
+            (
+                f"{bsg_sd}, {bsg_gd_partitioned} = cute.nvgpu.cpasync.tma_partition("
+                f"{tma_store_atom}, 0, cute.make_layout(1), "
+                f"cute.group_modes({smem_d}, 0, 2), "
+                f"cute.group_modes({tcgc_epi}, 0, 2))"
+            ),
+            (
+                f"{bsg_gd} = {bsg_gd_partitioned}["
+                f"(None, None, None, cutlass.Int32(0), cutlass.Int32(0), cutlass.Int32(0))]"
+            ),
+            f"{bsg_gd} = cute.group_modes({bsg_gd}, 1, cute.rank({bsg_gd}))",
+            (
+                f"{ttr_tacc_stage} = {ttr_tacc_base}["
+                f"(None, None, None, None, None, {tcgen05_acc_stage_index_expr})]"
+            ),
+            f"{ttr_tacc} = cute.group_modes({ttr_tacc_stage}, 3, cute.rank({ttr_tacc_stage}))",
+            f"{subtile_count} = cutlass.const_expr(cute.size({ttr_tacc}.shape, mode=[3]))",
+            *tma_store_pre_loop_acc_wait,
+        ]
+
+    tma_store_body_setup_core = build_tma_store_body_setup_core(
+        tma_store_atom=tcgen05_value.tma_store_atom,
+        tile_store_setup=tma_tile_store_setup,
+        dynamic_d_setup=[],
+        dynamic_d_update=(
+            [] if grouped_dynamic_d_tensormap_edge_only else grouped_d_tensormap_update
         ),
-        *(tma_store_smem_setup if not hoist_tma_store_resources else []),
-        *_rowvec_aux_copy_lines(),
-        *tma_store_first_subtile_acquire,
-        *tma_tile_store_setup,
-        (
-            f"{tcgc} = cutlass.utils.gemm.sm100.transform_partitioned_tensor_layout("
-            f"{tcgc_base})"
-        ),
-        (
-            f"{tcgc_planned} = cute.make_tensor("
-            f"{tcgc}.iterator, "
-            f"cute.append(cute.append(cute.append({tcgc}.layout, {tcgen05_value.epilogue_rest_mode}), {tcgen05_value.epilogue_rest_mode}), {tcgen05_value.epilogue_rest_mode}))"
-        ),
-        *(tma_store_acc_layout_setup if not hoist_tma_store_resources else []),
-        (
-            f"{tiled_copy_t2r}, {ttr_tacc_base}, {ttr_racc} = "
-            "cutlass.utils.gemm.sm100.epilogue_tmem_copy_and_partition("
-            f"{kernel_desc}, {tcgen05_value.epi_tidx}, {tacc}, {tcgc_planned}, {epi_tile}, {tcgen05_lifecycle.is_two_cta!s})"
-        ),
-        (f"{ttr_rd} = cute.make_rmem_tensor({ttr_racc}.shape, {target_dtype})"),
-        (
-            f"{tiled_copy_r2s}, {trs_rd}, {trs_sd} = "
-            "cutlass.utils.gemm.sm100.epilogue_smem_copy_and_partition("
-            f"{kernel_desc}, {tiled_copy_t2r}, {ttr_rd}, "
-            f"{tcgen05_value.epi_tidx}, {smem_d})"
-        ),
-        f"{trs_racc} = {tiled_copy_r2s}.retile({ttr_racc})",
-        f"{tcgc_epi} = cute.flat_divide({tcgc_planned}, {epi_tile})",
-        # Per-aux-step partitioning lines (one chain per auxiliary
-        # tensor). No-op when the chain has no aux steps; the TMA
-        # path requires an explicit ``thr_copy_t2r`` slice because
-        # (unlike the SIMT path) the TMA path does not otherwise
-        # create one — the t2r partition is consumed directly by
-        # the SMEM-staged store, never via partition_D. The aux
-        # load needs partition_D to compute a per-thread GMEM read
-        # for the auxiliary tile so we create the slice here.
-        # When the C-input warp productive-body gate is open the
-        # source switches from per-tile GMEM to the per-subtile
-        # SMEM ring stage (see ``_aux_tile_setup_lines`` SMEM
-        # branch); the partition pipeline is layout-only and
-        # compiles unchanged, and the per-subtile ``consumer_wait``
-        # / lane-0-gated ``consumer_release`` are emitted by
-        # ``_aux_subtile_load_source`` inside the per-subtile loop.
-        *_aux_tile_setup_lines(
-            thr_copy_t2r_var=thr_copy_t2r,
-            define_thr_copy_t2r=True,
-            retile_for_r2s=True,
-        ),
-        (
-            f"{bsg_sd}, {bsg_gd_partitioned} = cute.nvgpu.cpasync.tma_partition("
-            f"{tcgen05_value.tma_store_atom}, 0, cute.make_layout(1), "
-            f"cute.group_modes({smem_d}, 0, 2), "
-            f"cute.group_modes({tcgc_epi}, 0, 2))"
-        ),
-        (
-            f"{bsg_gd} = {bsg_gd_partitioned}["
-            f"(None, None, None, cutlass.Int32(0), cutlass.Int32(0), cutlass.Int32(0))]"
-        ),
-        f"{bsg_gd} = cute.group_modes({bsg_gd}, 1, cute.rank({bsg_gd}))",
-        (
-            f"{ttr_tacc_stage} = {ttr_tacc_base}["
-            f"(None, None, None, None, None, {tcgen05_acc_stage_index_expr})]"
-        ),
-        f"{ttr_tacc} = cute.group_modes({ttr_tacc_stage}, 3, cute.rank({ttr_tacc_stage}))",
-        f"{subtile_count} = cutlass.const_expr(cute.size({ttr_tacc}.shape, mode=[3]))",
-        *tma_store_pre_loop_acc_wait,
-    ]
+    )
+    dynamic_d_tma_store_body_setup_core = (
+        build_tma_store_body_setup_core(
+            tma_store_atom=tcgen05_value.tail_tma_store_atom,
+            tile_store_setup=dynamic_d_tma_tile_store_setup,
+            dynamic_d_setup=grouped_d_tensormap_setup,
+            dynamic_d_update=grouped_d_tensormap_update,
+        )
+        if grouped_dynamic_d_tensormap_edge_only
+        else []
+    )
     # Warp 0 pre-acquires the first TMA-store SMEM stage before per-tile
     # C-store setup. The subtile loop acquires only later stages, so C-stage
     # waits can overlap setup, the first acc-pipeline wait, and the other epi
@@ -4125,6 +4883,7 @@ def _codegen_cute_store_tcgen05_tile(
         if not (hoist_tma_store_resources or hoist_hybrid_tma_store_pipeline)
         else []
     )
+    dynamic_d_tma_store_body_core: list[str] = []
     if tcgen05_pure_matmul_object is not None:
         tma_store_body_core = tcgen05_pure_matmul_object.build_tma_store_body_core(
             Tcgen05TmaStoreBodyCoreParams(
@@ -4166,6 +4925,12 @@ def _codegen_cute_store_tcgen05_tile(
             tma_store_subtile_loop + tma_store_acc_advance,
             *tma_store_pipeline_tail_lines,
         ]
+        if grouped_dynamic_d_tensormap_edge_only:
+            dynamic_d_tma_store_body_core = [
+                *dynamic_d_tma_store_body_setup_core,
+                dynamic_d_tma_store_subtile_loop + tma_store_acc_advance,
+                *tma_store_pipeline_tail_lines,
+            ]
     tma_store_full_tile_body_core = list(tma_store_body_core)
     if (
         tcgen05_value.tma_store_full_tiles_only
@@ -4175,15 +4940,25 @@ def _codegen_cute_store_tcgen05_tile(
             f"{tcgen05_value.role_local_tile_counter} = "
             f"{tcgen05_value.role_local_tile_counter} + cutlass.Int32(1)"
         )
+        if grouped_dynamic_d_tensormap_edge_only:
+            dynamic_d_tma_store_body_core.append(
+                f"{tcgen05_value.role_local_tile_counter} = "
+                f"{tcgen05_value.role_local_tile_counter} + cutlass.Int32(1)"
+            )
     tma_store_body_source = "\n".join(tma_store_full_tile_body_core)
     simt_store_body_source = "\n".join(simt_store_body_core)
+    edge_store_body_source = (
+        "\n".join(dynamic_d_tma_store_body_core)
+        if grouped_dynamic_d_tensormap_edge_only and dynamic_d_tma_store_body_core
+        else simt_store_body_source
+    )
     hybrid_tma_store_body_core = [
         f"{full_tile} = {full_tile_expr}",
         (
             f"if {full_tile}:\n"
             f"{textwrap.indent(tma_store_body_source, '    ')}\n"
             "else:\n"
-            f"{textwrap.indent(simt_store_body_source, '    ')}"
+            f"{textwrap.indent(edge_store_body_source, '    ')}"
         ),
     ]
     if diagnose_skip_epilogue_store:
@@ -4206,6 +4981,15 @@ def _codegen_cute_store_tcgen05_tile(
             if (hoist_tma_store_resources or hoist_hybrid_tma_store_pipeline)
             else []
         )
+        grouped_d_tensormap_hoisted_stmts = (
+            [statement_from_string(line) for line in grouped_d_tensormap_setup]
+            if grouped_d_tensormap_setup
+            and (
+                hoist_tma_store_resources
+                or tcgen05_value.orientation is Tcgen05Orientation.NM
+            )
+            else []
+        )
         tma_store_role_invariant_stmts = (
             [statement_from_string(line) for line in tma_store_role_invariant_setup]
             if hoist_tma_store_resources
@@ -4216,10 +5000,11 @@ def _codegen_cute_store_tcgen05_tile(
         elif hoist_tma_store_resources or hoist_hybrid_tma_store_pipeline:
             tma_store_hoisted_stmts = [
                 *tma_store_pipeline_hoisted_stmts,
+                *grouped_d_tensormap_hoisted_stmts,
                 *tma_store_role_invariant_stmts,
             ]
         else:
-            tma_store_hoisted_stmts = []
+            tma_store_hoisted_stmts = grouped_d_tensormap_hoisted_stmts
         if tcgen05_pure_matmul_object is not None:
             assert not split_hybrid_tma_store_role, (
                 "pure lifecycle is admitted only for static-full pure matmul"
@@ -4240,7 +5025,7 @@ def _codegen_cute_store_tcgen05_tile(
                 + textwrap.indent("\n".join(tma_store_full_tile_body_core), "    ")
             )
             edge_main_stmt = statement_from_string(
-                "if True:\n" + textwrap.indent("\n".join(simt_store_body_core), "    ")
+                "if True:\n" + textwrap.indent(edge_store_body_source, "    ")
             )
             df.cute_state.register_tcgen05_per_tile_stmts(
                 [sync_before_stmt, full_main_stmt, edge_main_stmt, sync_after_stmt]
@@ -4256,7 +5041,10 @@ def _codegen_cute_store_tcgen05_tile(
             # without making the shared-memory reservation data-dependent on
             # the runtime epi-warp predicate.
             df.cute_state.register_tcgen05_epi_role_prelude_stmts(
-                tma_store_role_invariant_stmts
+                [
+                    *grouped_d_tensormap_hoisted_stmts,
+                    *tma_store_role_invariant_stmts,
+                ]
             )
             main_stmts = [
                 *tcgen05_acc_stage_index_top_level_stmts,

--- a/test/test_cute_deepgemm_selected.py
+++ b/test/test_cute_deepgemm_selected.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import ast
+import os
+from unittest.mock import patch
+
+import pytest
+import torch
+
+import helion
+from helion._compat import requires_cuda_version
+from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
+from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_WORKLIST_NM
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE,
+)
+from helion._testing import DEVICE
+from helion._testing import matchesBackends
+from helion._testing import patch_cute_mma_support
+from helion._testing import skipUnlessBackends
+import helion.language as hl
+
+pytestmark = skipUnlessBackends(["cute"])
+if matchesBackends(["cute"]):
+    pytest.importorskip("cutlass")
+    pytest.importorskip("cutlass.cute")
+
+
+def _aligned_m(actual_m: int) -> int:
+    tile = TCGEN05_GROUPED_WORKLIST_SOURCE_M_TILE
+    return ((actual_m + tile - 1) // tile) * tile
+
+
+def _selected_config() -> helion.Config:
+    config = helion.Config(
+        block_sizes=[256, 128, 64],
+        l2_groupings=[1],
+        loop_orders=[[0, 1, 2]],
+        num_stages=7,
+        num_warps=8,
+        pid_type="persistent_interleaved",
+        tcgen05_cluster_m=2,
+        tcgen05_cluster_n=1,
+        tcgen05_ab_stages=7,
+        tcgen05_acc_stages=2,
+        tcgen05_c_stages=2,
+        tcgen05_num_epi_warps=4,
+    )
+    config.config[TCGEN05_GROUPED_MODE_CONFIG_KEY] = TCGEN05_GROUPED_MODE_WORKLIST_NM
+    return config
+
+
+@helion.kernel(backend="cute", static_shapes=False)
+def _selected_kernel(
+    a_packed: torch.Tensor,
+    b_grouped: torch.Tensor,
+    work_tile_metadata: torch.Tensor,
+) -> torch.Tensor:
+    m_total_aligned, k = a_packed.shape
+    _g, n, k2 = b_grouped.shape
+    assert k == k2
+    assert work_tile_metadata.size(1) == 4
+    block_m = hl.register_block_size(256)
+    block_n = hl.register_block_size(128)
+    block_k = hl.register_block_size(64)
+    out = torch.empty(
+        m_total_aligned,
+        n,
+        dtype=a_packed.dtype,
+        device=a_packed.device,
+    )
+    for work_tile, tile_m, tile_n in hl.tile(
+        [work_tile_metadata.size(0), 256, n],
+        block_size=[1, block_m, block_n],
+    ):
+        work_id = work_tile.begin
+        group_id = work_tile_metadata[work_id, 0]
+        global_m_start = work_tile_metadata[work_id, 1]
+        valid_m = work_tile_metadata[work_id, 2]
+        store_m = work_tile_metadata[work_id, 3]
+        local_m = tile_m.index
+        row_index = global_m_start + local_m
+        valid_rows = local_m < valid_m
+        store_rows = local_m < store_m
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k, block_size=block_k):
+            a_blk = hl.load(
+                a_packed,
+                [row_index, tile_k],
+                extra_mask=valid_rows[:, None],  # pyrefly: ignore[bad-index]
+            )
+            acc = torch.addmm(
+                acc,
+                a_blk,
+                b_grouped[group_id, tile_n, tile_k].T,
+            )
+        hl.store(
+            out,
+            [row_index, tile_n],
+            acc.to(out.dtype),
+            extra_mask=store_rows[:, None],  # pyrefly: ignore[bad-index]
+        )
+    return out
+
+
+def _make_args(
+    m_sizes: tuple[int, ...] = (17, 11),
+    *,
+    n: int = 128,
+    k: int = 64,
+    dtype: torch.dtype = torch.bfloat16,
+    dirty_padding: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    starts: list[int] = []
+    cursor = 0
+    for actual_m in m_sizes:
+        starts.append(cursor)
+        cursor += _aligned_m(actual_m)
+
+    a_packed = torch.zeros((cursor, k), device=DEVICE, dtype=dtype)
+    for start, actual_m in zip(starts, m_sizes, strict=True):
+        a_packed[start : start + actual_m].normal_()
+        if dirty_padding:
+            a_packed[start + actual_m : start + _aligned_m(actual_m)].normal_()
+    b_grouped = torch.randn((len(m_sizes), n, k), device=DEVICE, dtype=dtype)
+    work_tile_metadata = torch.tensor(
+        [
+            [group, start, actual_m, _aligned_m(actual_m)]
+            for group, (start, actual_m) in enumerate(zip(starts, m_sizes, strict=True))
+        ],
+        device=DEVICE,
+        dtype=torch.int32,
+    )
+    return a_packed, b_grouped, work_tile_metadata
+
+
+def _configured_bound(args: tuple[torch.Tensor, ...]):
+    _selected_kernel.reset()
+    bound = _selected_kernel.bind(args)
+    bound.env.config_spec.cute_tcgen05_search_enabled = True
+    bound.set_config(_selected_config())
+    return bound
+
+
+def _code_for(args: tuple[torch.Tensor, ...]) -> str:
+    _selected_kernel.reset()
+    bound = _selected_kernel.bind(args)
+    bound.env.config_spec.cute_tcgen05_search_enabled = True
+    with (
+        patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False),
+        patch_cute_mma_support(),
+    ):
+        return bound.to_triton_code(_selected_config())
+
+
+def _wrapper_plans(code: str) -> list[dict[str, object]]:
+    marker = "._helion_cute_wrapper_plans = "
+    payload = next(line for line in code.splitlines() if marker in line).split(
+        marker, 1
+    )[1]
+    return list(ast.literal_eval(payload))
+
+
+def _assert_output(
+    out: torch.Tensor,
+    args: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+) -> None:
+    a_packed, b_grouped, work_tile_metadata = args
+    for group, start, valid_m, store_m in work_tile_metadata.cpu().tolist():
+        expected = (
+            a_packed[start : start + valid_m].float() @ b_grouped[group].float().T
+        ).to(out.dtype)
+        torch.testing.assert_close(
+            out[start : start + valid_m],
+            expected,
+            rtol=3e-2,
+            atol=3e-2,
+        )
+        torch.testing.assert_close(
+            out[start + valid_m : start + store_m],
+            torch.zeros_like(out[start + valid_m : start + store_m]),
+            rtol=0,
+            atol=0,
+        )
+
+
+def _require_codegen_cuda() -> None:
+    if DEVICE.type != "cuda":
+        pytest.skip("tcgen05 selected-path codegen needs CUDA fake inputs")
+
+
+def _require_runtime_cuda13_sm100() -> None:
+    _require_codegen_cuda()
+    if not requires_cuda_version("13"):
+        pytest.skip("tcgen05 selected-path runtime needs CUDA >= 13")
+    from helion._compiler.cute.mma_support import get_cute_mma_support
+
+    with torch.cuda.device(DEVICE):
+        major, _minor = torch.cuda.get_device_capability(DEVICE)
+    if major < 10:
+        pytest.skip("tcgen05 requires SM100+")
+    if not get_cute_mma_support().tcgen05_f16bf16:
+        pytest.skip("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+
+def test_grouped_worklist_nm_codegen_and_wrapper_plan() -> None:
+    _require_codegen_cuda()
+
+    code = _code_for(_make_args((1, 127, 224, 256), n=224, k=64))
+
+    assert code.count("StaticPersistentGroupTileScheduler.create") == 1
+    assert "TensorMapManager" in code
+    assert "update_tensormap" in code
+    assert "cute.nvgpu.tcgen05.CtaGroup.TWO" in code
+    assert "(256, 224)" in code
+    assert "cute.local_tile(tma_tensor_a, (256, 64)" in code
+    assert "cute.local_tile(tma_tensor_b, (224, 64)" in code
+    assert "StMatrix8x8x16bOp(transpose=True, num_matrices=4)" in code
+    assert "cute.arch.alloc_smem(cutlass.Int32, 9" in code
+
+    plan = next(
+        plan
+        for plan in _wrapper_plans(code)
+        if plan["kind"] == "tcgen05_grouped_static_persistent"
+    )
+    assert {
+        "orientation": plan["orientation"],
+        "worklist_metadata": plan["worklist_metadata"],
+        "dynamic_ab_tensormaps": plan["dynamic_ab_tensormaps"],
+        "dynamic_d_tensormap": plan["dynamic_d_tensormap"],
+    } == {
+        "orientation": "nm",
+        "worklist_metadata": True,
+        "dynamic_ab_tensormaps": True,
+        "dynamic_d_tensormap": True,
+    }
+
+
+@pytest.mark.parametrize(
+    ("case", "match"),
+    (
+        ("fp16", "bf16_operands"),
+        ("k96", "k_multiple_64"),
+        ("n196", f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}|n_multiple_32"),
+        ("strided_b", f"{TCGEN05_GROUPED_MODE_CONFIG_KEY}|contiguous_b_grouped"),
+    ),
+)
+def test_grouped_worklist_nm_rejects_ineligible_inputs(case: str, match: str) -> None:
+    _require_codegen_cuda()
+    if case == "fp16":
+        args = _make_args(dtype=torch.float16)
+    elif case == "k96":
+        args = _make_args(k=96)
+    elif case == "n196":
+        args = _make_args(n=196)
+    else:
+        a_packed, b_grouped, work_tile_metadata = _make_args()
+        strided_b = torch.empty(
+            (b_grouped.size(0), b_grouped.size(2), b_grouped.size(1)),
+            device=DEVICE,
+            dtype=b_grouped.dtype,
+        ).transpose(1, 2)
+        strided_b.copy_(b_grouped)
+        args = (a_packed, strided_b, work_tile_metadata)
+
+    with pytest.raises(helion.exc.BackendUnsupported, match=match):
+        _code_for(args)
+
+
+def test_grouped_worklist_nm_runtime_and_graph_replay() -> None:
+    _require_runtime_cuda13_sm100()
+
+    args = _make_args((224, 449, 256), n=512, k=128, dirty_padding=True)
+    assert args[2].cpu().tolist() == [
+        [0, 0, 224, 224],
+        [1, 224, 449, 672],
+        [2, 896, 256, 448],
+    ]
+    with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
+        bound = _configured_bound(args)
+        warmup = bound(*args)
+        torch.cuda.synchronize()
+        _assert_output(warmup, args)
+
+        args[0].normal_()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            captured = bound(*args)
+        torch.cuda.synchronize()
+
+        captured.fill_(-7.0)
+        graph.replay()
+        torch.cuda.synchronize()
+
+    _assert_output(captured, args)

--- a/test/test_cute_lowerings.py
+++ b/test/test_cute_lowerings.py
@@ -8800,7 +8800,6 @@ class TestCuteLowerings(unittest.TestCase):
             if (
                 "tcgen05_tma_initial_full_tile" in test_src
                 and "tcgen05_tma_initial_next_full_tile" not in test_src
-                and "tcgen05_tma_warp" in test_src
             ):
                 stage0_blocks.append(node)
         self.assertEqual(len(stage0_blocks), 1, code)
@@ -14432,9 +14431,7 @@ class TestCuteLowerings(unittest.TestCase):
         self.assertIn(f"if {_TCGEN05_CLUSTER_LEADER_PREDICATE}:", code)
         self.assertIn("cute.copy(tma_atom_a", code)
         self.assertIn(
-            "if tcgen05_exec_active and "
-            "cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster()) "
-            "== cutlass.Int32(0):",
+            "if cute.arch.make_warp_uniform(cute.arch.warp_idx()) == cutlass.Int32(4):",
             code,
         )
         self.assertIn("'kind': 'tcgen05_d_tma'", code)

--- a/test/test_cute_rank3_rhs_b_tma.py
+++ b/test/test_cute_rank3_rhs_b_tma.py
@@ -1,0 +1,893 @@
+from __future__ import annotations
+
+import ast
+import os
+import re
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import torch
+
+import helion
+from helion._compiler.cute.strategies import TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY
+from helion._compiler.cute.strategies import Tcgen05PersistenceModel
+from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_CONFIG_KEY
+from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_DIRECT
+from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_DYNAMIC
+from helion._compiler.cute.tcgen05_constants import TCGEN05_GROUPED_MODE_STATIC
+from helion._compiler.cute.tcgen05_constants import (
+    TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY,
+)
+from helion._testing import DEVICE
+from helion._testing import matchesBackends
+from helion._testing import patch_cute_mma_support
+from helion._testing import skipUnlessBackends
+from helion.autotuner.config_generation import ConfigGeneration
+import helion.language as hl
+from helion.runtime import _append_cute_wrapper_plan
+
+pytestmark = skipUnlessBackends(["cute"])
+if matchesBackends(["cute"]):
+    pytest.importorskip("cutlass")
+    pytest.importorskip("cutlass.cute")
+
+
+def _require_cuda(reason: str) -> None:
+    if DEVICE.type != "cuda":
+        pytest.skip(reason)
+
+
+def _rank3_rhs_tma_config() -> helion.Config:
+    return helion.Config(
+        block_sizes=[128, 128, 128],
+        l2_groupings=[1],
+        loop_orders=[[0, 1]],
+        num_stages=2,
+        num_warps=8,
+        pid_type="persistent_interleaved",
+        tcgen05_cluster_m=1,
+        tcgen05_ab_stages=2,
+        tcgen05_acc_stages=2,
+        tcgen05_c_stages=2,
+        tcgen05_num_epi_warps=4,
+    )
+
+
+def _grouped_config(*, block_n: int = 128, block_k: int = 128) -> helion.Config:
+    config = _rank3_rhs_tma_config()
+    config.config["block_sizes"] = [128, block_n, block_k]
+    config.config[TCGEN05_GROUPED_MODE_CONFIG_KEY] = TCGEN05_GROUPED_MODE_STATIC
+    return config
+
+
+def _dynamic_bk64_config(*, direct: bool = False) -> helion.Config:
+    config = _grouped_config(block_n=64, block_k=64)
+    config.config[TCGEN05_GROUPED_MODE_CONFIG_KEY] = (
+        TCGEN05_GROUPED_MODE_DIRECT if direct else TCGEN05_GROUPED_MODE_DYNAMIC
+    )
+    return config
+
+
+@helion.kernel(backend="cute")
+def _rank3_rhs_grouped_nt(
+    a: torch.Tensor, b_grouped: torch.Tensor, layout: torch.Tensor
+) -> torch.Tensor:
+    m, k = a.size()
+    _g, n, _k = b_grouped.size()
+    out = torch.empty((m, n), dtype=a.dtype, device=a.device)
+    for tile_m, tile_n in hl.tile([m, n]):
+        group_id = layout[tile_m.begin]
+        safe_group_id = torch.where(group_id >= 0, group_id, 0)
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = torch.addmm(
+                acc,
+                a[tile_m, tile_k],
+                b_grouped[safe_group_id, tile_n, tile_k].T,
+            )
+        out[tile_m, tile_n] = acc.to(out.dtype)
+    return out
+
+
+@helion.kernel(backend="cute")
+def _rank3_rhs_grouped_nt_with_mn_tails(
+    a: torch.Tensor,
+    b_grouped: torch.Tensor,
+    layout: torch.Tensor,
+    n_sizes: torch.Tensor,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    m, k = a.size()
+    _g, max_n, _k = b_grouped.size()
+    for tile_m, tile_n in hl.tile([m, max_n]):
+        group_id = layout[tile_m.begin]
+        safe_group_id = torch.where(group_id >= 0, group_id, 0)
+        row_group_ids = layout[tile_m]
+        valid_rows = row_group_ids == safe_group_id
+        group_n = n_sizes[safe_group_id]
+        valid_cols = tile_n.index < group_n
+        valid = valid_rows[:, None] & valid_cols[None, :]  # pyrefly: ignore[bad-index]
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = torch.addmm(
+                acc,
+                a[tile_m, tile_k],
+                b_grouped[safe_group_id, tile_n, tile_k].T,
+            )
+        out[tile_m, tile_n] = torch.where(
+            valid,
+            acc.to(out.dtype),
+            out[tile_m, tile_n],
+        )
+    return out
+
+
+@helion.kernel(backend="cute")
+def _rank3_rhs_grouped_nt_with_mn_tails_and_k_sizes(
+    a: torch.Tensor,
+    b_grouped: torch.Tensor,
+    layout: torch.Tensor,
+    n_sizes: torch.Tensor,
+    k_sizes: torch.Tensor,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    m, max_k = a.size()
+    _g, max_n, _k = b_grouped.size()
+    for tile_m, tile_n in hl.tile([m, max_n]):
+        group_id = layout[tile_m.begin]
+        safe_group_id = torch.where(group_id >= 0, group_id, 0)
+        row_group_ids = layout[tile_m]
+        valid_rows = row_group_ids == safe_group_id
+        group_n = n_sizes[safe_group_id]
+        valid_cols = tile_n.index < group_n
+        valid = valid_rows[:, None] & valid_cols[None, :]  # pyrefly: ignore[bad-index]
+        group_k = k_sizes[safe_group_id]
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(max_k):
+            valid_k = tile_k.index < group_k
+            a_tile = a[tile_m, tile_k]
+            b_tile = b_grouped[safe_group_id, tile_n, tile_k]
+            masked_a = torch.where(valid_k[None, :], a_tile, torch.zeros_like(a_tile))
+            masked_b = torch.where(valid_k[None, :], b_tile, torch.zeros_like(b_tile))
+            acc = torch.addmm(acc, masked_a, masked_b.T)
+        out[tile_m, tile_n] = torch.where(
+            valid,
+            acc.to(out.dtype),
+            out[tile_m, tile_n],
+        )
+    return out
+
+
+@helion.kernel(backend="cute")
+def _bad_k_missing_b_mask(
+    a: torch.Tensor,
+    b_grouped: torch.Tensor,
+    layout: torch.Tensor,
+    k_sizes: torch.Tensor,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    m, max_k = a.size()
+    _g, n, _k = b_grouped.size()
+    for tile_m, tile_n in hl.tile([m, n]):
+        group_id = layout[tile_m.begin]
+        safe_group_id = torch.where(group_id >= 0, group_id, 0)
+        group_k = k_sizes[safe_group_id]
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(max_k):
+            valid_k = tile_k.index < group_k
+            a_tile = a[tile_m, tile_k]
+            masked_a = torch.where(valid_k[None, :], a_tile, torch.zeros_like(a_tile))
+            acc = torch.addmm(
+                acc,
+                masked_a,
+                b_grouped[safe_group_id, tile_n, tile_k].T,
+            )
+        out[tile_m, tile_n] = acc.to(out.dtype)
+    return out
+
+
+@helion.kernel(backend="cute")
+def _bad_k_arbitrary_mask(
+    a: torch.Tensor,
+    b_grouped: torch.Tensor,
+    layout: torch.Tensor,
+    k_sizes: torch.Tensor,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    m, max_k = a.size()
+    _g, n, _k = b_grouped.size()
+    for tile_m, tile_n in hl.tile([m, n]):
+        group_id = layout[tile_m.begin]
+        safe_group_id = torch.where(group_id >= 0, group_id, 0)
+        group_k = k_sizes[safe_group_id]
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(max_k):
+            valid_k = tile_k.index <= group_k
+            a_tile = a[tile_m, tile_k]
+            b_tile = b_grouped[safe_group_id, tile_n, tile_k]
+            masked_a = torch.where(valid_k[None, :], a_tile, torch.zeros_like(a_tile))
+            masked_b = torch.where(valid_k[None, :], b_tile, torch.zeros_like(b_tile))
+            acc = torch.addmm(acc, masked_a, masked_b.T)
+        out[tile_m, tile_n] = acc.to(out.dtype)
+    return out
+
+
+@helion.kernel(backend="cute")
+def _bad_k_without_source_proof(
+    a: torch.Tensor,
+    b_grouped: torch.Tensor,
+    layout: torch.Tensor,
+    k_sizes: torch.Tensor,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    m, max_k = a.size()
+    _g, n, _k = b_grouped.size()
+    for tile_m, tile_n in hl.tile([m, n]):
+        group_id = layout[tile_m.begin]
+        safe_group_id = torch.where(group_id >= 0, group_id, 0)
+        group_k = k_sizes[safe_group_id]
+        k_noop = (group_k - group_k).to(torch.float32)
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(max_k):
+            acc = torch.addmm(
+                acc,
+                a[tile_m, tile_k],
+                b_grouped[safe_group_id, tile_n, tile_k].T,
+            )
+        out[tile_m, tile_n] = (acc + k_noop).to(out.dtype)
+    return out
+
+
+@helion.kernel(backend="cute")
+def _bad_k_group_provenance(
+    a: torch.Tensor,
+    b_grouped: torch.Tensor,
+    layout: torch.Tensor,
+    k_layout: torch.Tensor,
+    k_sizes: torch.Tensor,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    m, max_k = a.size()
+    _g, n, _k = b_grouped.size()
+    for tile_m, tile_n in hl.tile([m, n]):
+        group_id = layout[tile_m.begin]
+        safe_group_id = torch.where(group_id >= 0, group_id, 0)
+        k_group_id = k_layout[tile_m.begin]
+        k_safe_group_id = torch.where(k_group_id >= 0, k_group_id, 0)
+        group_k = k_sizes[k_safe_group_id]
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(max_k):
+            valid_k = tile_k.index < group_k
+            a_tile = a[tile_m, tile_k]
+            b_tile = b_grouped[safe_group_id, tile_n, tile_k]
+            masked_a = torch.where(valid_k[None, :], a_tile, torch.zeros_like(a_tile))
+            masked_b = torch.where(valid_k[None, :], b_tile, torch.zeros_like(b_tile))
+            acc = torch.addmm(acc, masked_a, masked_b.T)
+        out[tile_m, tile_n] = acc.to(out.dtype)
+    return out
+
+
+@helion.kernel(backend="cute")
+def _bad_mn_tail_zero_store(
+    a: torch.Tensor,
+    b_grouped: torch.Tensor,
+    layout: torch.Tensor,
+    n_sizes: torch.Tensor,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    m, k = a.size()
+    _g, max_n, _k = b_grouped.size()
+    for tile_m, tile_n in hl.tile([m, max_n]):
+        group_id = layout[tile_m.begin]
+        safe_group_id = torch.where(group_id >= 0, group_id, 0)
+        valid_rows = layout[tile_m] == safe_group_id
+        group_n = n_sizes[safe_group_id]
+        valid_cols = tile_n.index < group_n
+        valid = valid_rows[:, None] & valid_cols[None, :]  # pyrefly: ignore[bad-index]
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            acc = torch.addmm(
+                acc,
+                a[tile_m, tile_k],
+                b_grouped[safe_group_id, tile_n, tile_k].T,
+            )
+        out[tile_m, tile_n] = torch.where(
+            valid,
+            acc.to(out.dtype),
+            torch.zeros_like(acc).to(out.dtype),
+        )
+    return out
+
+
+def _make_full_args(
+    *,
+    groups: int = 4,
+    m_per_group: int = 128,
+    n: int = 256,
+    k: int = 128,
+    dtype: torch.dtype = torch.bfloat16,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    m = groups * m_per_group
+    row_ids = torch.arange(m, device=DEVICE)
+    a = torch.zeros((m, k), device=DEVICE, dtype=dtype)
+    a[row_ids, row_ids % k] = 1
+    group = torch.arange(groups, device=DEVICE, dtype=torch.float32)[:, None, None]
+    col = torch.arange(n, device=DEVICE, dtype=torch.float32)[None, :, None]
+    kk = torch.arange(k, device=DEVICE, dtype=torch.float32)[None, None, :]
+    b_grouped = (group * 37.0 + (col % 17) * 1.25 + (kk % 13) * 0.125).to(dtype)
+    layout = torch.arange(groups, device=DEVICE, dtype=torch.int64).repeat_interleave(
+        m_per_group
+    )
+    return a, b_grouped, layout
+
+
+def _make_mn_tail_args(
+    *, k: int = 128, dtype: torch.dtype = torch.float16
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    padded_m = 256
+    max_n = 192
+    m_sizes = (128, 16)
+    a = torch.randn((padded_m, k), device=DEVICE, dtype=dtype)
+    b_grouped = torch.randn((2, max_n, k), device=DEVICE, dtype=dtype)
+    layout = torch.full((padded_m,), -1, device=DEVICE, dtype=torch.int32)
+    for group, m_size in enumerate(m_sizes):
+        start = group * 128
+        layout[start : start + m_size] = group
+    n_sizes = torch.tensor((192, 160), device=DEVICE, dtype=torch.int32)
+    out = torch.full((padded_m, max_n), -77.0, device=DEVICE, dtype=dtype)
+    return a, b_grouped, layout, n_sizes, out
+
+
+def _make_k_proof_args() -> tuple[torch.Tensor, ...]:
+    a, b_grouped, layout = _make_full_args(
+        groups=2,
+        n=128,
+        k=64,
+        dtype=torch.float16,
+    )
+    k_sizes = torch.tensor((32, 64), device=DEVICE, dtype=torch.int32)
+    out = torch.empty((256, 128), device=DEVICE, dtype=torch.float16)
+    return a, b_grouped, layout, k_sizes, out
+
+
+def _make_mismatched_k_group_args() -> tuple[torch.Tensor, ...]:
+    a, b_grouped, layout, k_sizes, out = _make_k_proof_args()
+    return a, b_grouped, layout, (1 - layout).contiguous(), k_sizes, out
+
+
+def _make_documented_mixed_k_args(
+    *, dtype: torch.dtype = torch.float16
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    k_values = (32, 1536, 16, 16)
+    m_values = (128, 16, 128, 16)
+    n_values = (64, 128, 64, 64)
+    groups = len(k_values)
+    padded_m = groups * 128
+    max_n = max(n_values)
+    max_k = max(k_values)
+    a_values = torch.arange(
+        padded_m * max_k, device=DEVICE, dtype=torch.float32
+    ).reshape(padded_m, max_k)
+    b_values = torch.arange(
+        groups * max_n * max_k, device=DEVICE, dtype=torch.float32
+    ).reshape(groups, max_n, max_k)
+    a = (((a_values % 23) - 11) / 257).to(dtype)
+    b_grouped = (((b_values % 29) - 14) / 257).to(dtype)
+    layout = torch.full((padded_m,), -1, device=DEVICE, dtype=torch.int32)
+    for group, (m_size, group_k) in enumerate(zip(m_values, k_values, strict=True)):
+        rows = slice(group * 128, group * 128 + m_size)
+        layout[rows] = group
+        if group_k < max_k:
+            a[rows, group_k:] = 3.0 + group
+            b_grouped[group, :, group_k:] = -2.0 - group
+    n_sizes = torch.tensor(n_values, device=DEVICE, dtype=torch.int32)
+    k_sizes = torch.tensor(k_values, device=DEVICE, dtype=torch.int32)
+    out = torch.full((padded_m, max_n), -77.0, device=DEVICE, dtype=dtype)
+    return a, b_grouped, layout, n_sizes, k_sizes, out
+
+
+def _make_mixed_non_row_major_args() -> tuple[torch.Tensor, ...]:
+    args = list(_make_documented_mixed_k_args())
+    a = args[0]
+    strided = torch.empty((a.size(1), a.size(0)), device=DEVICE, dtype=a.dtype).T
+    strided.copy_(a)
+    assert strided.stride(1) != 1
+    args[0] = strided
+    return tuple(args)
+
+
+def _make_non_k_contiguous_args() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    a, _b_grouped, layout = _make_full_args()
+    b_grouped = torch.empty(
+        (4, 128, 256), device=DEVICE, dtype=torch.bfloat16
+    ).transpose(1, 2)
+    assert b_grouped.stride(2) != 1
+    return a, b_grouped, layout
+
+
+def _assert_mixed_result(
+    out: torch.Tensor,
+    args: tuple[torch.Tensor, ...],
+    *,
+    tolerance: float = 4e-2,
+) -> None:
+    a, b_grouped, layout, n_sizes, k_sizes, _out = args
+    sentinel = torch.full_like(out, -77.0)
+    for group in range(b_grouped.size(0)):
+        rows = torch.nonzero(layout == group, as_tuple=False).flatten()
+        group_n = int(n_sizes[group].item())
+        group_k = int(k_sizes[group].item())
+        expected = (a[rows, :group_k] @ b_grouped[group, :group_n, :group_k].T).to(
+            out.dtype
+        )
+        torch.testing.assert_close(
+            out[rows, :group_n], expected, rtol=tolerance, atol=tolerance
+        )
+        torch.testing.assert_close(
+            out[rows, group_n:], sentinel[rows, group_n:], rtol=0, atol=0
+        )
+    invalid_rows = torch.nonzero(layout < 0, as_tuple=False).flatten()
+    torch.testing.assert_close(
+        out[invalid_rows], sentinel[invalid_rows], rtol=0, atol=0
+    )
+
+
+def _assert_grouped_result(
+    out: torch.Tensor,
+    args: tuple[torch.Tensor, ...],
+    *,
+    invalid_value: float | None = None,
+) -> None:
+    a, b_grouped, layout = args[:3]
+    expected = torch.empty_like(out)
+    if invalid_value is not None:
+        expected.fill_(invalid_value)
+    n_sizes = args[3] if len(args) > 3 else None
+    for group in range(b_grouped.size(0)):
+        rows = torch.nonzero(layout == group, as_tuple=False).flatten()
+        group_n = int(n_sizes[group]) if n_sizes is not None else out.size(1)
+        expected[rows, :group_n] = (
+            a[rows].float() @ b_grouped[group, :group_n].float().T
+        ).to(out.dtype)
+    torch.testing.assert_close(out, expected, rtol=4e-2, atol=4e-2)
+
+
+def _code_for(
+    kernel: Any,
+    args: tuple[Any, ...] | None = None,
+    config: helion.Config | None = None,
+) -> str:
+    if args is None:
+        args = _make_full_args()
+    if config is None:
+        config = _rank3_rhs_tma_config()
+    bound = kernel.bind(args)
+    bound.env.config_spec.cute_tcgen05_search_enabled = True
+    with (
+        patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False),
+        patch_cute_mma_support(),
+    ):
+        return bound.to_triton_code(config)
+
+
+def _wrapper_plans(code: str) -> list[dict[str, Any]]:
+    marker = "._helion_cute_wrapper_plans = "
+    line = next(line for line in code.splitlines() if marker in line)
+    payload = line.split(marker, 1)[1]
+    return list(ast.literal_eval(payload))
+
+
+def _wrapper_plan(code: str, kind: str) -> dict[str, Any]:
+    return next(plan for plan in _wrapper_plans(code) if plan["kind"] == kind)
+
+
+def _assert_group_scheduler(code: str) -> dict[str, Any]:
+    assert "StaticPersistentGroupTileScheduler.create" in code
+    assert "StaticPersistentTileScheduler.create" not in code
+    assert ".group_search_result" in code
+    assert "virtual_pid" not in code
+    assert "GroupedGemmKernel" not in code
+    assert "tcgen05_rhs_safe_group" not in code
+    return _wrapper_plan(code, "tcgen05_grouped_static_persistent")
+
+
+def _assert_regular_fallback(code: str) -> None:
+    assert "'rhs_rank3_grouped_nt': True" not in code
+    assert "tcgen05_rhs_safe_group" not in code
+    assert "tcgen05_grouped_static_persistent" not in code
+    assert "StaticPersistentGroupTileScheduler.create" not in code
+
+
+def _seed_configs(
+    kernel: Any,
+    args: tuple[torch.Tensor, ...],
+    mode: str,
+) -> tuple[Any, list[dict[str, Any]], list[dict[str, Any]]]:
+    with (
+        patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False),
+        patch_cute_mma_support(),
+    ):
+        bound = kernel.bind(args)
+    spec = bound.config_spec
+    raw = [
+        config.config
+        for config in spec.compiler_seed_configs
+        if config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY) == mode
+    ]
+    normalized = [
+        config.config
+        for _flat, config in ConfigGeneration(spec).seed_flat_config_pairs()
+        if config.config.get(TCGEN05_GROUPED_MODE_CONFIG_KEY) == mode
+    ]
+    return spec, raw, normalized
+
+
+def test_rank3_rhs_grouped_nt_codegen_uses_nkg_tma_view() -> None:
+    _require_cuda("rank3 RHS B TMA codegen test needs CUDA fake inputs")
+    code = _code_for(_rank3_rhs_grouped_nt)
+
+    assert "'rhs_rank3_grouped_nt': True" in code
+    assert "StaticPersistentTileScheduler.create" in code
+    assert "block=(32, 6, 1)" in code
+    assert "tcgen05_rhs_safe_group" in code
+    assert "tcgen05_rhs_group = (" in code
+    assert ".layout.stride[0])).load()" in code
+    assert "cute.slice_(tma_tensor_b" not in code
+    assert "tma_tensor_b[tcgen05_rhs_safe_group" not in code
+    assert any(
+        re.search(
+            r"cute\.local_tile\(tma_tensor_b, \(128, 128\), "
+            r"\([^,]+ // cutlass\.Int32\(128\), None, tcgen05_rhs_safe_group\)\)",
+            line.strip(),
+        )
+        for line in code.splitlines()
+        if "cute.local_tile(tma_tensor_b" in line
+    )
+
+    ab_plan = _wrapper_plan(code, "tcgen05_ab_tma")
+    assert ab_plan["rhs_rank3_grouped_nt"] is True
+    rhs_idx = int(ab_plan["rhs_idx"])
+    body: list[str] = []
+    call_args: list[str] = []
+    _append_cute_wrapper_plan(body, call_args, ab_plan)
+    wrapper = "\n".join(body)
+    assert f"(arg{rhs_idx}_shape1, arg{rhs_idx}_shape2, arg{rhs_idx}_shape0)" in wrapper
+    assert (
+        f"stride=(arg{rhs_idx}_stride1, arg{rhs_idx}_stride2, arg{rhs_idx}_stride0)"
+        in wrapper
+    )
+    assert ".mark_layout_dynamic(leading_dim=1)" in wrapper
+
+
+def test_rank3_rhs_grouped_static_codegen_uses_group_scheduler() -> None:
+    _require_cuda("rank3 RHS B TMA codegen test needs CUDA fake inputs")
+    code = _code_for(
+        _rank3_rhs_grouped_nt,
+        _make_full_args(),
+        _grouped_config(),
+    )
+
+    grouped_plan = _assert_group_scheduler(code)
+    assert "cutlass.utils.create_initial_search_state()" in code
+    assert ".group_idx" in code
+    assert ".cta_tile_idx_m" in code
+    assert ".cta_tile_idx_n" in code
+    assert ".problem_shape_m" in code
+    assert ".problem_shape_n" in code
+    assert ".problem_shape_k" in code
+    assert "tcgen05_grouped_global_m_start" in code
+    assert "tcgen05_grouped_group_idx" in code
+    assert ".layout.iterator" not in code
+    assert re.search(
+        r"cute\.local_tile\(tma_tensor_b, \(128, 128\), "
+        r"\([^,]+ // cutlass\.Int32\(128\), None, tcgen05_grouped_group_idx\)\)",
+        code,
+    )
+    assert grouped_plan["group_count"] == 4
+    assert grouped_plan["bm"] == 128
+    assert grouped_plan["bn"] == 128
+    assert grouped_plan["bk"] == 128
+    assert grouped_plan["n_size"] == 256
+    assert grouped_plan["k_total_size"] == 128
+    assert "layout_idx" in grouped_plan
+    ab_plan = _wrapper_plan(code, "tcgen05_ab_tma")
+    assert ab_plan["rhs_rank3_grouped_nt"] is True
+    assert ab_plan.get("dynamic_ab_tensormaps") is not True
+
+
+def test_rank3_rhs_grouped_static_dynamic_bk64_mixed_tail_direct_codegen() -> None:
+    _require_cuda("rank3 RHS B TMA codegen test needs CUDA fake inputs")
+    code = _code_for(
+        _rank3_rhs_grouped_nt_with_mn_tails_and_k_sizes,
+        _make_documented_mixed_k_args(),
+        _dynamic_bk64_config(direct=True),
+    )
+
+    grouped_plan = _assert_group_scheduler(code)
+    assert {
+        key: grouped_plan[key]
+        for key in (
+            "group_count",
+            "bn",
+            "bk",
+            "k_total_size",
+            "m_tail_preserve",
+            "n_tail_preserve",
+            "grouped_static_has_m_tail",
+            "grouped_static_has_n_tail",
+            "dynamic_ab_tensormaps",
+            "dynamic_d_tensormap",
+            "direct_pointer_metadata",
+        )
+    } == {
+        "group_count": 4,
+        "bn": 64,
+        "bk": 64,
+        "k_total_size": 1536,
+        "m_tail_preserve": True,
+        "n_tail_preserve": True,
+        "grouped_static_has_m_tail": True,
+        "grouped_static_has_n_tail": False,
+        "dynamic_ab_tensormaps": True,
+        "dynamic_d_tensormap": True,
+        "direct_pointer_metadata": True,
+    }
+    for marker in (
+        "cutlass.utils.TensorMapManager",
+        "update_tensormap",
+        "fence_tensormap_update",
+        "tma_desc_ptr=tcgen05_grouped_tensormap_a_desc_ptr",
+        "tma_desc_ptr=tcgen05_grouped_tensormap_b_desc_ptr",
+        "tma_desc_ptr=tcgen05_grouped_d_tensormap_desc_ptr",
+        "tcgen05_grouped_direct_pointers",
+        "tcgen05_grouped_direct_strides",
+        "tile_offset_2 < tcgen05_grouped_problem_k",
+    ):
+        assert marker in code
+    assert code.count("cute.nvgpu.cpasync.prefetch_descriptor(") == 3
+    assert "tcgen05_tiled_copy_r2g" not in code
+    assert "tcgen05_store_mask" not in code
+    assert _wrapper_plan(code, "tcgen05_ab_tma")["dynamic_ab_tensormaps"] is True
+    assert _wrapper_plan(code, "tcgen05_d_tma")["rank3_mnl_tensor"] is True
+
+
+@pytest.mark.parametrize(
+    ("k", "expected_bk", "expected_ab_stages"),
+    ((16, 16, 2), (96, 32, 3), (192, 64, 3)),
+)
+def test_rank3_rhs_grouped_static_mn_tail_seed_and_codegen(
+    k: int, expected_bk: int, expected_ab_stages: int
+) -> None:
+    _require_cuda("rank3 RHS B TMA compiler seed test needs CUDA fake inputs")
+    args = _make_mn_tail_args(k=k)
+    spec, raw, normalized = _seed_configs(
+        _rank3_rhs_grouped_nt_with_mn_tails,
+        args,
+        TCGEN05_GROUPED_MODE_STATIC,
+    )
+
+    assert "cute_tcgen05_grouped_static_common_k" in spec.autotuner_heuristics
+    assert "cute_tcgen05_grouped_dynamic_bk64" not in spec.autotuner_heuristics
+    assert len(raw) == len(normalized) == 1
+    for seed in (raw[0], normalized[0]):
+        assert seed["block_sizes"] == [128, 64, expected_bk]
+        assert seed[TCGEN05_GROUPED_MODE_CONFIG_KEY] == TCGEN05_GROUPED_MODE_STATIC
+        assert seed[TCGEN05_PERSISTENCE_MODEL_CONFIG_KEY] == (
+            Tcgen05PersistenceModel.STATIC_PERSISTENT.value
+        )
+        assert seed["tcgen05_ab_stages"] == expected_ab_stages
+
+    code = _code_for(
+        _rank3_rhs_grouped_nt_with_mn_tails,
+        args,
+        helion.Config.from_dict(normalized[0]),
+    )
+    grouped_plan = _assert_group_scheduler(code)
+    assert grouped_plan["bk"] == expected_bk
+    assert grouped_plan["k_total_size"] == k
+    assert grouped_plan["m_tail_preserve"] is True
+    assert grouped_plan["n_tail_preserve"] is True
+    assert grouped_plan["grouped_static_has_m_tail"] is True
+    assert grouped_plan["grouped_static_has_n_tail"] is True
+    assert grouped_plan.get("dynamic_ab_tensormaps") is not True
+    assert _wrapper_plan(code, "tcgen05_ab_tma")["ab_stage_count"] == (
+        expected_ab_stages
+    )
+
+
+def test_rank3_rhs_grouped_static_dynamic_bk64_compiler_seed() -> None:
+    _require_cuda("rank3 RHS B TMA compiler seed test needs CUDA fake inputs")
+    args = _make_documented_mixed_k_args()
+    spec, raw, normalized = _seed_configs(
+        _rank3_rhs_grouped_nt_with_mn_tails_and_k_sizes,
+        args,
+        TCGEN05_GROUPED_MODE_DYNAMIC,
+    )
+
+    assert "cute_tcgen05_grouped_static_common_k" not in spec.autotuner_heuristics
+    assert "cute_tcgen05_grouped_dynamic_bk64" in spec.autotuner_heuristics
+    assert len(raw) == len(normalized) == 1
+    for seed in (raw[0], normalized[0]):
+        assert seed["block_sizes"] == [128, 64, 64]
+        assert seed[TCGEN05_GROUPED_MODE_CONFIG_KEY] == TCGEN05_GROUPED_MODE_DYNAMIC
+        assert seed[TCGEN05_GROUPED_STATIC_RESERVED_SMS_CONFIG_KEY] == 3
+        assert seed["tcgen05_ab_stages"] == 4
+
+
+@pytest.mark.parametrize(
+    ("kernel", "args_fn"),
+    [
+        (_bad_k_missing_b_mask, _make_k_proof_args),
+        (_bad_k_arbitrary_mask, _make_k_proof_args),
+        (_bad_k_without_source_proof, _make_k_proof_args),
+        (_bad_k_group_provenance, _make_mismatched_k_group_args),
+        (
+            _rank3_rhs_grouped_nt_with_mn_tails_and_k_sizes,
+            _make_mixed_non_row_major_args,
+        ),
+    ],
+    ids=(
+        "one-sided-k-mask",
+        "arbitrary-k-mask",
+        "no-source-k-proof",
+        "mismatched-k-group",
+        "strided-a",
+    ),
+)
+def test_dynamic_bk64_seed_rejects_unsafe_proof(kernel: Any, args_fn: Any) -> None:
+    _require_cuda("rank3 RHS B TMA compiler seed test needs CUDA fake inputs")
+    spec, raw, normalized = _seed_configs(
+        kernel,
+        args_fn(),
+        TCGEN05_GROUPED_MODE_DYNAMIC,
+    )
+    assert "cute_tcgen05_grouped_dynamic_bk64" not in spec.autotuner_heuristics
+    assert raw == []
+    assert normalized == []
+
+
+@pytest.mark.parametrize(
+    "target",
+    (
+        torch.ops.aten.baddbmm.default,
+        torch.ops.aten.mm.default,
+        torch.ops.aten.bmm.default,
+        torch.ops.aten.bmm.dtype,
+    ),
+)
+def test_grouped_proof_rejects_unproven_aten_targets(target: Any) -> None:
+    from typing import cast
+
+    from helion._compiler.cute.cute_mma import _GroupedMmaAxes
+    from helion._compiler.cute.cute_mma import _prove_rank3_rhs_grouped_mma
+
+    graph = torch.fx.Graph()
+    node = graph.call_function(target)
+    assert (
+        _prove_rank3_rhs_grouped_mma(
+            cast("Any", None),
+            node,
+            config={},
+            axes=_GroupedMmaAxes(0, 1, 2),
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("kernel", "args_fn", "config_fn"),
+    [
+        (_rank3_rhs_grouped_nt, _make_non_k_contiguous_args, _rank3_rhs_tma_config),
+        (
+            _bad_mn_tail_zero_store,
+            _make_mn_tail_args,
+            lambda: _grouped_config(block_n=64, block_k=128),
+        ),
+    ],
+    ids=("strided-rhs", "non-preserving-tail-store"),
+)
+def test_rank3_rhs_unsafe_patterns_use_generic_fallback(
+    kernel: Any, args_fn: Any, config_fn: Any
+) -> None:
+    _require_cuda("rank3 RHS B TMA fallback test needs CUDA fake inputs")
+    code = _code_for(kernel, args_fn(), config_fn())
+    _assert_regular_fallback(code)
+    assert "virtual_pid" in code
+
+
+@pytest.mark.parametrize(
+    ("args_fn", "config_fn", "match"),
+    [
+        (
+            lambda: _make_mn_tail_args(k=64),
+            _dynamic_bk64_config,
+            "exact_k_sizes",
+        ),
+        (
+            lambda: _make_mn_tail_args(k=48),
+            lambda: _grouped_config(block_n=64, block_k=16),
+            "common_k_block_pair_allowlisted",
+        ),
+    ],
+    ids=("dynamic-without-k-sizes", "unsupported-common-k-pair"),
+)
+def test_grouped_static_rejects_unproven_k_contract(
+    args_fn: Any, config_fn: Any, match: str
+) -> None:
+    _require_cuda("rank3 RHS B TMA codegen test needs CUDA fake inputs")
+    with pytest.raises(helion.exc.BackendUnsupported, match=match):
+        _code_for(
+            _rank3_rhs_grouped_nt_with_mn_tails,
+            args_fn(),
+            config_fn(),
+        )
+
+
+def _require_tcgen05_runtime_test() -> None:
+    _require_cuda("rank3 RHS B TMA runtime test needs CUDA")
+    from helion._compiler.cute.mma_support import get_cute_mma_support
+
+    with torch.cuda.device(DEVICE):
+        major, _minor = torch.cuda.get_device_capability(DEVICE)
+    if major < 10:
+        pytest.skip("tcgen05 requires SM100+")
+    if not get_cute_mma_support().tcgen05_f16bf16:
+        pytest.skip("tcgen05 F16/BF16 MMA is not supported on this machine")
+
+
+def _run_configured(
+    kernel: Any, args: tuple[torch.Tensor, ...], config: helion.Config
+) -> torch.Tensor:
+    with patch.dict(os.environ, {"HELION_CUTE_MMA_IMPL": "tcgen05"}, clear=False):
+        bound = kernel.bind(args)
+        bound.env.config_spec.cute_tcgen05_search_enabled = True
+        bound.set_config(config)
+        out = bound(*args)
+        torch.cuda.synchronize()
+    return out
+
+
+def test_rank3_rhs_grouped_static_native_runtime() -> None:
+    _require_tcgen05_runtime_test()
+    args = _make_full_args()
+    out = _run_configured(_rank3_rhs_grouped_nt, args, _grouped_config())
+    _assert_grouped_result(out, args)
+
+
+def test_rank3_rhs_unsafe_store_fallback_runtime() -> None:
+    _require_tcgen05_runtime_test()
+    args = _make_mn_tail_args()
+    out = _run_configured(
+        _bad_mn_tail_zero_store,
+        args,
+        _grouped_config(block_n=64, block_k=128),
+    )
+    assert out is args[-1]
+    _assert_grouped_result(out, args, invalid_value=0)
+
+
+@pytest.mark.parametrize("direct", (False, True))
+def test_rank3_rhs_grouped_static_dynamic_bk64_runtime(direct: bool) -> None:
+    _require_tcgen05_runtime_test()
+    args = _make_documented_mixed_k_args()
+    out = _run_configured(
+        _rank3_rhs_grouped_nt_with_mn_tails_and_k_sizes,
+        args,
+        _dynamic_bk64_config(direct=direct),
+    )
+    assert out is args[-1]
+    _assert_mixed_result(out, args)


### PR DESCRIPTION
Stacked PRs:
 * #3042
 * #3034
 * __->__#3033
 * #3032
 * #3031


--- --- ---

## Implementation

This PR adds CuTe tcgen05 lowering for proven grouped BF16/FP16 NT `addmm` programs whose right-hand side is rank 3.

- Centralizes rank-3 RHS recognition and safety proofs in `_prove_rank3_rhs_grouped_mma`, shared by eligibility, configuration, and lowering so those stages use the same narrowed `addmm` contract.
- Uses the `tcgen05_grouped_mode` strings `static`, `dynamic`, `direct`, and `worklist_nm` for scheduler selection, while `Tcgen05GroupedDMode` separately describes edge-only versus all-tiles output handling.
- Recognizes packed or segmented `A[M,K] @ B[G,N,K].T` programs and derives group identity, valid-prefix M/N tails, and proven per-group K metadata from the FX graph.
- Implements static-common-K and dynamic-BK64 seeds, persistent grouped scheduling, dynamic A/B/D TensorMaps, direct pointer/stride metadata, compact N,M worklists, and grouped epilogues.
- Requires proofs for `addmm` structure, group identity, mask provenance, metadata loads, K bounds, and exclusive operand use before replacing program accesses. Rejected generic candidates use ordinary safe lowering; an explicitly requested `worklist_nm` configuration fails closed with `BackendUnsupported`.
- Plans scalar-expression and statement rewrites before mutating the AST, preventing a rejected specialization from leaving partial rewrites visible to fallback codegen.
- Adds focused coverage for static and dynamic grouping, direct metadata, worklists, row masks, M/N/K tails, configuration serialization, unsafe-proof rejection, runtime execution, and CUDA graph capture.

The measurements below exercise this lowering through the complete stack.

## Performance Results

Geometric-mean latency ratios are shown first. Ratios are Helion/reference, so values below `1.0` favor Helion.

| Reference | Repeat 1 geomean | Repeat 2 geomean | Result |
|---|---:|---:|---|
| CUTLASS CuTeDSL | **0.8928** | **0.8926** | Helion is 10.7% lower latency; 7/7 wins in both repeats |
| DeepGEMM | **0.9949** | **0.9948** | Helion is 0.5% lower latency; 6/8 wins in both repeats |

Both final repeats were collected from clean Helion commit `a9f735af2d8a78c0de49c45e99ca0a6503a40ca3` on an NVIDIA B200 (compute capability 10.0), using PyTorch `2.11.0+cu130` and CUDA `13.0`. The benchmark workers pin `HELION_CUTE_MMA_IMPL=tcgen05` to measure this path directly.

### CUTLASS CuTeDSL

Physical GPU 0. Each case uses common inputs, correctness checks, CUDA graph replay, and a fresh subprocess with fresh compiler caches. Each graph is prepared with `--compile-warmups 2`; both replays then receive five cache-warmup calls and one shared 10-second BF16 thermal warmup. Six paired `triton.testing.do_bench` rounds alternate Helion/CUTLASS and CUTLASS/Helion. Every round uses CUDA-event timing with `warmup=1000 ms` and `rep=500 ms`; the table reports the median of the six round means. The CUTLASS graph includes its pinned-host pointer-table upload.

Pinned reference: NVIDIA/cutlass `db1c288993354c88e551c40c19a8fb93a774a241`, `grouped_gemm.py` SHA256 `05b74a05682c024557d83284e32f973ed5be4f0d1a1a12c72fe7824c29f7e94f`, and `nvidia-cutlass-dsl==4.5.2`. Harness SHA256: `7e2efca8f381b431ab40ba3fd476378989308ef0d77766f62805a6b920039c75`.

| Case | Exact per-group `M x N x K` | R1 Helion us | R1 CUTLASS us | R1 H/C | R2 Helion us | R2 CUTLASS us | R2 H/C |
|---|---|---:|---:|---:|---:|---:|---:|
| `default_small_parity` | G3 [g0: 128x128x128, g1: 512x128x128, g2: 128x256x128] | 10.229 | 14.355 | 0.713 | 10.247 | 14.382 | 0.712 |
| `doc_no_mn_tail` | G4 [g0: 8192x1280x32, g1: 128x384x1536, g2: 640x1280x16, g3: 640x128x16] | 22.532 | 24.572 | 0.917 | 22.534 | 24.575 | 0.917 |
| `doc_no_mn_g3_192_extra_full` | G4 [g0: 8192x1280x32, g1: 128x384x1536, g2: 640x1280x16, g3: 640x192x16] | 22.921 | 24.583 | 0.932 | 22.897 | 24.611 | 0.930 |
| `doc_original` | G4 [g0: 8192x1280x32, g1: 16x384x1536, g2: 640x1280x16, g3: 640x160x16] | 22.958 | 24.622 | 0.932 | 22.909 | 24.582 | 0.932 |
| `doc_mtail_g1_g3_192_extra_full` | G4 [g0: 8192x1280x32, g1: 16x384x1536, g2: 640x1280x16, g3: 640x192x16] | 22.625 | 24.673 | 0.917 | 22.610 | 24.588 | 0.920 |
| `doc_mtail_g1_only` | G4 [g0: 8192x1280x32, g1: 16x384x1536, g2: 640x1280x16, g3: 640x128x16] | 22.580 | 24.590 | 0.918 | 22.573 | 24.578 | 0.918 |
| `doc_ntail_g3_160` | G4 [g0: 8192x1280x32, g1: 128x384x1536, g2: 640x1280x16, g3: 640x160x16] | 23.222 | 24.578 | 0.945 | 23.197 | 24.575 | 0.944 |

```bash
CUDA_VISIBLE_DEVICES=0 conda run --no-capture-output -n helion \
  python benchmarks/cute/compare_grouped_gemm_backends.py \
  --cutlass-source /tmp/cutlass-db1c2889-grouped-gemm.py \
  --out-dir <fresh-output-dir> --cuda-visible-devices 0 \
  --seed 0 --compile-warmups 2 --num-runs 6 \
  --warmup-ms 1000 --rep-ms 500 --cache-warmup-calls 5 \
  --thermal-warmup-ms 10000 --stream-subprocesses
```

### DeepGEMM

Physical GPU 3. Official shape is `(G, expected M/group, N, K)`; `actual M/group` is the exact seed-0 DeepGEMM-compatible M stream shared by both implementations. Each row uses `--compile-warmups 2`, five alternating graph warmups, and one 10-second BF16 thermal warmup. Ten paired samples alternate which implementation runs first; each sample averages 50 graph replays. An 8 GB L2 clear matching upstream DeepGEMM's `bench_kineto` default runs before every replay and outside its CUDA-event interval. The table reports the median of the ten sample means, and each repeat uses fresh compiler caches.

Pinned reference: DeepGEMM `559d79fb6994a58b8a15b4b93bf13ccc16edf247`, CUTLASS submodule `f3fde58372d33e9a5650ba7b80fc48b3b49d40c8`, and M alignment 224. The only untracked reference-checkout path was DeepGEMM's generated `deep_gemm/include/fmt` directory. Harness SHA256: `484741ae5259f8ce4f2f6216dc25c29def001dcb25b231e555b95998a667271e`.

| Row | Official `(G, M, N, K)` | Actual M/group | R1 Helion us | R1 DeepGEMM us | R1 H/D | R2 Helion us | R2 DeepGEMM us | R2 H/D |
|---:|---|---|---:|---:|---:|---:|---:|---:|
| 0 | `(4, 8192, 6144, 7168)` | `9884, 9459, 7801, 7007` | 2646.708 | 2518.028 | 1.051 | 2677.416 | 2562.513 | 1.045 |
| 1 | `(4, 8192, 7168, 3072)` | `8247, 7724, 9586, 7225` | 1070.407 | 1093.971 | 0.978 | 1081.872 | 1096.028 | 0.987 |
| 2 | `(4, 8192, 4096, 4096)` | `8076, 8601, 10197, 8215` | 872.093 | 877.294 | 0.994 | 873.244 | 880.124 | 0.992 |
| 3 | `(4, 8192, 4096, 2048)` | `7119, 9449, 8773, 6965` | 395.633 | 409.112 | 0.967 | 398.398 | 408.255 | 0.976 |
| 4 | `(8, 4096, 6144, 7168)` | `5102, 5282, 4858, 5084, 3629, 4660, 5076, 4548` | 3051.274 | 3021.418 | 1.010 | 3036.491 | 2995.513 | 1.014 |
| 5 | `(8, 4096, 7168, 3072)` | `4027, 3114, 3934, 4368, 5111, 5242, 4039, 4993` | 1168.279 | 1199.356 | 0.974 | 1166.589 | 1210.240 | 0.964 |
| 6 | `(8, 4096, 4096, 4096)` | `3507, 4845, 4215, 2901, 4635, 3847, 4894, 4509` | 835.664 | 836.549 | 0.999 | 837.359 | 838.471 | 0.999 |
| 7 | `(8, 4096, 4096, 2048)` | `2870, 4080, 4999, 3466, 3666, 5006, 3336, 4261` | 400.494 | 405.255 | 0.988 | 401.995 | 408.534 | 0.984 |

```bash
CUDA_VISIBLE_DEVICES=3 conda run --no-capture-output -n helion \
  python benchmarks/cute/deepgemm_selected_path.py \
  --rows all --compare-deepgemm \
  --deepgemm-root /tmp/DeepGEMM-559d79fb --device cuda \
  --samples 10 --iters 50 --warmups 5 --compile-warmups 2 \
  --thermal-warmup-ms 10000 --l2-flush-bytes 8000000000 \
  --m-alignment 224 --artifact-dir <fresh-output-dir> \
  --json-output <fresh-output-dir>/selected_results.json
```

All correctness checks passed in both final repeats.
